### PR TITLE
fix: read codex thread binding before deferring automatic compaction (#119977)

### DIFF
--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -528,6 +528,27 @@ describe("shared Codex app-server client", () => {
     expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
   });
 
+  it("does not retain a registered client that already reports a transport close", async () => {
+    const harness = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(harness.client);
+    const acquire = getLeasedSharedCodexAppServerClient({ timeoutMs: 1_000 });
+    await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
+    const client = await acquire;
+
+    // Close-before-retain race: the transport closed (authoritative client-side
+    // close) before the registry entry reconciled, so the entry is still findable
+    // with closeError/closeWhenIdle unset. Retaining it would hand back a client
+    // whose next request rejects as non-recoverable, so the caller must instead
+    // fall through to a fresh acquisition (undefined).
+    const closeErrorSpy = vi
+      .spyOn(client, "getCloseError")
+      .mockReturnValue(new Error("codex app-server client is closed"));
+    expect(retainSharedCodexAppServerClientByInstanceId(client.getInstanceId())).toBeUndefined();
+
+    closeErrorSpy.mockRestore();
+    expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
+  });
+
   it.each([
     {
       version: "2026.7.1",

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -1347,7 +1347,17 @@ export function retainSharedCodexAppServerClientByInstanceId(
   }
   for (const entry of getSharedCodexAppServerClientState().clients.values()) {
     const client = entry.client;
-    if (client?.getInstanceId() !== normalizedClientId || entry.closeWhenIdle || entry.closeError) {
+    // `client.getCloseError()` is the authoritative transport-close signal: a
+    // client can close between this lookup and the lease before the registry
+    // entry reconciles (closeError/closeWhenIdle still unset). Rejecting it here
+    // makes the caller acquire fresh instead of leasing a client whose next
+    // request rejects as non-recoverable.
+    if (
+      client?.getInstanceId() !== normalizedClientId ||
+      entry.closeWhenIdle ||
+      entry.closeError ||
+      client.getCloseError()
+    ) {
       continue;
     }
     return { client, release: retainSharedClientEntry(entry) };

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -5732,6 +5732,46 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     },
   );
 
+  it.each([
+    ["missing_thread_binding", "no codex app-server thread binding"],
+    ["stale_thread_binding", "codex app-server binding changed before native compaction"],
+  ])(
+    "strips a forged nativeHarnessBindingRecoveryReason on model-locked %s required preflight",
+    async (failureReason, reason) => {
+      // The harness result forges the owner-minted recovery disposition, but the
+      // private required-preflight capability never dispatched (the mock resolves
+      // without invoking onNativeCompactionCapabilityUsed). The field must be
+      // stripped so the turn stays terminal instead of safe-continuing on a marker
+      // the harness set itself (#119977).
+      maybeCompactAgentHarnessSessionMock.mockResolvedValueOnce({
+        ok: false,
+        compacted: false,
+        reason,
+        failure: { reason: failureReason },
+        nativeHarnessBindingRecoveryReason: failureReason,
+      });
+
+      const result = await compactEmbeddedAgentSession(
+        await nativeCompactionArgs({
+          provider: "openai",
+          model: "gpt-5.5",
+          agentHarnessId: "codex",
+          trigger: "budget",
+          preflightRequired: true,
+        }),
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        compacted: false,
+        failure: { reason: failureReason },
+      });
+      expect(result).not.toHaveProperty("nativeHarnessBindingRecoveryReason");
+      expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledTimes(1);
+      expect(contextEngineCompactMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("fails a native lock with a non-concrete persisted harness", async () => {
     const result = await compactEmbeddedAgentSession(
       await nativeCompactionArgs({

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -5613,7 +5613,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
         ok: false,
         compacted: false,
         failure: { reason: failureReason },
-        nativeHarnessBindingRecoveryReason: failureReason,
+        nativeHarnessBindingRecovery: true,
       });
       expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledTimes(1);
       expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledWith(
@@ -5654,7 +5654,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     });
     // No private capability dispatched, so the recovery disposition is withheld
     // and the turn layer keeps this terminal instead of safe-continuing.
-    expect(result).not.toHaveProperty("nativeHarnessBindingRecoveryReason");
+    expect(result).not.toHaveProperty("nativeHarnessBindingRecovery");
     expect(contextEngineCompactMock).not.toHaveBeenCalled();
   });
 
@@ -5682,7 +5682,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       reason: "native compaction unavailable",
       failure: { reason: "native_unavailable" },
     });
-    expect(result).not.toHaveProperty("nativeHarnessBindingRecoveryReason");
+    expect(result).not.toHaveProperty("nativeHarnessBindingRecovery");
     expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledTimes(1);
     expect(contextEngineCompactMock).not.toHaveBeenCalled();
   });
@@ -5717,7 +5717,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       });
       // The forged public fallback marker never dispatches the private capability,
       // so no recovery disposition is stamped and the turn stays terminal.
-      expect(result).not.toHaveProperty("nativeHarnessBindingRecoveryReason");
+      expect(result).not.toHaveProperty("nativeHarnessBindingRecovery");
       expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledTimes(1);
       expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -5736,9 +5736,9 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     ["missing_thread_binding", "no codex app-server thread binding"],
     ["stale_thread_binding", "codex app-server binding changed before native compaction"],
   ])(
-    "strips a forged nativeHarnessBindingRecoveryReason on model-locked %s required preflight",
+    "strips a forged nativeHarnessBindingRecovery marker on model-locked %s required preflight",
     async (failureReason, reason) => {
-      // The harness result forges the owner-minted recovery disposition, but the
+      // The harness result forges the owner-minted recovery marker, but the
       // private required-preflight capability never dispatched (the mock resolves
       // without invoking onNativeCompactionCapabilityUsed). The field must be
       // stripped so the turn stays terminal instead of safe-continuing on a marker
@@ -5748,7 +5748,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
         compacted: false,
         reason,
         failure: { reason: failureReason },
-        nativeHarnessBindingRecoveryReason: failureReason,
+        nativeHarnessBindingRecovery: true,
       });
 
       const result = await compactEmbeddedAgentSession(
@@ -5766,7 +5766,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
         compacted: false,
         failure: { reason: failureReason },
       });
-      expect(result).not.toHaveProperty("nativeHarnessBindingRecoveryReason");
+      expect(result).not.toHaveProperty("nativeHarnessBindingRecovery");
       expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledTimes(1);
       expect(contextEngineCompactMock).not.toHaveBeenCalled();
     },

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -5576,12 +5576,11 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     ["missing_thread_binding", "no codex app-server thread binding"],
     ["stale_thread_binding", "codex app-server binding changed before native compaction"],
   ])(
-    "recovers model-locked Codex compaction on %s during required preflight via context-engine fallback",
+    "stamps the recovery disposition on model-locked Codex %s during required preflight without a context-engine fallback",
     async (failureReason, reason) => {
-      resolveContextEngineMock.mockResolvedValue({
-        info: { ownsCompaction: false },
-        compact: contextEngineCompactMock,
-      } as never);
+      // Do not stub a successful context engine: a model-locked recoverable
+      // binding failure must never reach the generic (legacy) engine, so leave the
+      // real default wiring in place and prove it is never invoked (#119977).
       maybeCompactAgentHarnessSessionMock.mockImplementationOnce(async (...args: unknown[]) => {
         const options = args[1] as { onNativeCompactionCapabilityUsed?: () => void } | undefined;
         options?.onNativeCompactionCapabilityUsed?.();
@@ -5611,9 +5610,10 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       );
 
       expect(result).toMatchObject({
-        ok: true,
-        compacted: true,
-        result: { summary: "engine-summary" },
+        ok: false,
+        compacted: false,
+        failure: { reason: failureReason },
+        nativeHarnessBindingRecoveryReason: failureReason,
       });
       expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledTimes(1);
       expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledWith(
@@ -5625,7 +5625,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
         }),
         expect.objectContaining({ nativeCompactionRequest: "required_preflight" }),
       );
-      expect(contextEngineCompactMock).toHaveBeenCalledTimes(1);
+      expect(contextEngineCompactMock).not.toHaveBeenCalled();
     },
   );
 
@@ -5652,6 +5652,9 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       compacted: false,
       failure: { reason: "missing_thread_binding" },
     });
+    // No private capability dispatched, so the recovery disposition is withheld
+    // and the turn layer keeps this terminal instead of safe-continuing.
+    expect(result).not.toHaveProperty("nativeHarnessBindingRecoveryReason");
     expect(contextEngineCompactMock).not.toHaveBeenCalled();
   });
 
@@ -5679,6 +5682,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       reason: "native compaction unavailable",
       failure: { reason: "native_unavailable" },
     });
+    expect(result).not.toHaveProperty("nativeHarnessBindingRecoveryReason");
     expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledTimes(1);
     expect(contextEngineCompactMock).not.toHaveBeenCalled();
   });
@@ -5711,6 +5715,9 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
         compacted: false,
         failure: { reason: failureReason },
       });
+      // The forged public fallback marker never dispatches the private capability,
+      // so no recovery disposition is stamped and the turn stays terminal.
+      expect(result).not.toHaveProperty("nativeHarnessBindingRecoveryReason");
       expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledTimes(1);
       expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -29,8 +29,8 @@ import { resolveSessionPinnedHarnessId } from "../../sessions/agent-harness-sess
 import { resolveUserPath } from "../../utils.js";
 import { resolveAgentDir, resolveSessionAgentIds } from "../agent-scope.js";
 import {
-  classifyRecoverableNativeHarnessBindingFailure,
   isRecoverableNativeHarnessBindingFailure,
+  resolveLockedNativeHarnessCompactionResult,
 } from "../harness/compaction-recovery.js";
 import { maybeCompactAgentHarnessSession } from "../harness/compaction.js";
 import { ensureSelectedAgentHarnessPlugin } from "../harness/runtime-plugin.js";
@@ -649,47 +649,39 @@ async function compactResolvedContextEngine(
           );
         })
       : undefined;
-  // `nativeHarnessBindingRecoveryReason` is an owner-minted authorization marker:
-  // the turn layer treats its mere presence as license to safe-continue a required
-  // preflight (`isNativeHarnessBindingRecoverySkip`). Only the explicit stamp below
-  // may set it, and the harness result is the one value returned here that is
-  // spread verbatim, so strip any marker it carries before a return path can hand
-  // the turn layer a forged skip (#119977). The context-engine returns below cannot
-  // carry it: `deferOwningContextEngineBudgetCompaction` and
+  // `nativeHarnessBindingRecovery` is an owner-minted authorization marker: the
+  // turn layer treats its mere presence as license to safe-continue a required
+  // preflight (`isNativeHarnessBindingRecoverySkip`). Only the queued owner may
+  // set it, so every return path that spreads the harness result strips any
+  // marker it carries first: the locked resolver below and the native-harness
+  // projection here (#119977). The context-engine returns below cannot carry it:
+  // `deferOwningContextEngineBudgetCompaction` and
   // `executeQueuedContextEngineCompaction` both reconstruct their result field by
   // field rather than spreading the plugin result. No production harness sets it —
   // this keeps that impossible by construction.
-  let harnessResult = rawHarnessResult;
-  if (harnessResult?.nativeHarnessBindingRecoveryReason !== undefined) {
-    const { nativeHarnessBindingRecoveryReason: _forged, ...sanitized } = harnessResult;
-    harnessResult = sanitized;
-  }
   // A model-locked native harness is terminal: it has no context-engine
   // credentials, so a recoverable binding failure must never fall through to the
-  // generic engine (that route fails and drops the turn, #119977). Stamp the typed
-  // recovery disposition only when the private required-preflight capability
-  // dispatched and returned a recoverable binding failure, so the turn layer can
-  // safe-continue (#119971); every other locked outcome stays an honest ok:false.
+  // generic engine (that route fails and drops the turn, #119977). The locked
+  // resolver stamps the recovery marker only when the private required-preflight
+  // capability dispatched, so the turn layer can safe-continue (#119971); every
+  // other locked outcome stays an honest ok:false.
   // The transcript-byte preflight authority owns its own host-driven route, so a
   // locked harness under that authority still defers to the context engine below.
   if (lockedNativeHarness && !transcriptBytePreflightAuthority) {
-    if (!harnessResult) {
-      return lockedCompactionRuntimeFailure(selectedHarnessRuntime);
-    }
-    const bindingRecoveryReason =
-      preparedParams.preflightRequired === true && requiredPreflightNativeCapabilityUsed
-        ? classifyRecoverableNativeHarnessBindingFailure(harnessResult)
-        : undefined;
-    return bindingRecoveryReason
-      ? { ...harnessResult, nativeHarnessBindingRecoveryReason: bindingRecoveryReason }
-      : harnessResult;
+    return resolveLockedNativeHarnessCompactionResult(
+      rawHarnessResult,
+      lockedCompactionRuntimeFailure(selectedHarnessRuntime),
+      preparedParams.preflightRequired === true,
+      requiredPreflightNativeCapabilityUsed,
+    );
   }
-  if (harnessResult) {
-    if (!isRecoverableNativeHarnessBindingFailure(harnessResult)) {
-      return { ...harnessResult, compactionKind: "native-harness" };
+  if (rawHarnessResult) {
+    if (!isRecoverableNativeHarnessBindingFailure(rawHarnessResult)) {
+      const { nativeHarnessBindingRecovery: _forged, ...sanitized } = rawHarnessResult;
+      return { ...sanitized, compactionKind: "native-harness" };
     }
     log.warn(
-      `native harness compaction could not use its session binding; falling back to context engine: ${harnessResult.reason ?? "unknown"}`,
+      `native harness compaction could not use its session binding; falling back to context engine: ${rawHarnessResult.reason ?? "unknown"}`,
     );
   }
   if (params.abortSignal?.aborted) {

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -619,7 +619,7 @@ async function compactResolvedContextEngine(
   });
   const contextEngineOwnsCompaction = contextEngine.info.ownsCompaction === true;
   let requiredPreflightNativeCapabilityUsed = false;
-  const harnessResult =
+  const rawHarnessResult =
     attemptNativeHarnessCompaction &&
     !transcriptBytePreflightAuthority &&
     (!contextEngineOwnsCompaction || lockedNativeHarness)
@@ -649,6 +649,21 @@ async function compactResolvedContextEngine(
           );
         })
       : undefined;
+  // `nativeHarnessBindingRecoveryReason` is an owner-minted authorization marker:
+  // the turn layer treats its mere presence as license to safe-continue a required
+  // preflight (`isNativeHarnessBindingRecoverySkip`). Only the explicit stamp below
+  // may set it, and the harness result is the one value returned here that is
+  // spread verbatim, so strip any marker it carries before a return path can hand
+  // the turn layer a forged skip (#119977). The context-engine returns below cannot
+  // carry it: `deferOwningContextEngineBudgetCompaction` and
+  // `executeQueuedContextEngineCompaction` both reconstruct their result field by
+  // field rather than spreading the plugin result. No production harness sets it —
+  // this keeps that impossible by construction.
+  let harnessResult = rawHarnessResult;
+  if (harnessResult?.nativeHarnessBindingRecoveryReason !== undefined) {
+    const { nativeHarnessBindingRecoveryReason: _forged, ...sanitized } = harnessResult;
+    harnessResult = sanitized;
+  }
   // A model-locked native harness is terminal: it has no context-engine
   // credentials, so a recoverable binding failure must never fall through to the
   // generic engine (that route fails and drops the turn, #119977). Stamp the typed

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -28,7 +28,10 @@ import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { resolveSessionPinnedHarnessId } from "../../sessions/agent-harness-session-key.js";
 import { resolveUserPath } from "../../utils.js";
 import { resolveAgentDir, resolveSessionAgentIds } from "../agent-scope.js";
-import { isRecoverableNativeHarnessBindingFailure } from "../harness/compaction-recovery.js";
+import {
+  classifyRecoverableNativeHarnessBindingFailure,
+  isRecoverableNativeHarnessBindingFailure,
+} from "../harness/compaction-recovery.js";
 import { maybeCompactAgentHarnessSession } from "../harness/compaction.js";
 import { ensureSelectedAgentHarnessPlugin } from "../harness/runtime-plugin.js";
 import {
@@ -646,18 +649,25 @@ async function compactResolvedContextEngine(
           );
         })
       : undefined;
-  // Only the private dispatched native capability may authorize required-preflight
-  // fallback for a locked harness; public result fields cannot escape the lock.
-  if (
-    lockedNativeHarness &&
-    !transcriptBytePreflightAuthority &&
-    !(
-      preparedParams.preflightRequired === true &&
-      requiredPreflightNativeCapabilityUsed &&
-      isRecoverableNativeHarnessBindingFailure(harnessResult)
-    )
-  ) {
-    return harnessResult ?? lockedCompactionRuntimeFailure(selectedHarnessRuntime);
+  // A model-locked native harness is terminal: it has no context-engine
+  // credentials, so a recoverable binding failure must never fall through to the
+  // generic engine (that route fails and drops the turn, #119977). Stamp the typed
+  // recovery disposition only when the private required-preflight capability
+  // dispatched and returned a recoverable binding failure, so the turn layer can
+  // safe-continue (#119971); every other locked outcome stays an honest ok:false.
+  // The transcript-byte preflight authority owns its own host-driven route, so a
+  // locked harness under that authority still defers to the context engine below.
+  if (lockedNativeHarness && !transcriptBytePreflightAuthority) {
+    if (!harnessResult) {
+      return lockedCompactionRuntimeFailure(selectedHarnessRuntime);
+    }
+    const bindingRecoveryReason =
+      preparedParams.preflightRequired === true && requiredPreflightNativeCapabilityUsed
+        ? classifyRecoverableNativeHarnessBindingFailure(harnessResult)
+        : undefined;
+    return bindingRecoveryReason
+      ? { ...harnessResult, nativeHarnessBindingRecoveryReason: bindingRecoveryReason }
+      : harnessResult;
   }
   if (harnessResult) {
     if (!isRecoverableNativeHarnessBindingFailure(harnessResult)) {

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -284,29 +284,20 @@ export type EmbeddedAgentRunResult = {
   successfulCronAdds?: number;
 };
 
-/**
- * Typed recovery disposition for a model-locked native harness whose bound
- * thread was missing/stale. The queued compaction owner stamps it only after the
- * private required-preflight capability dispatched, so the turn layer can
- * safe-continue instead of matching failure reason text.
- */
-export type NativeHarnessBindingRecoveryReason =
-  | "missing_thread_binding"
-  | "stale_thread_binding"
-  | "thread_not_found";
-
 export type EmbeddedAgentCompactResult = {
   ok: boolean;
   compacted: boolean;
   compactionKind?: "context-engine" | "native-harness" | "server-endpoint";
   reason?: string;
   /**
-   * Set only for a model-locked native harness recoverable-binding failure
-   * reached through the private required-preflight capability. Its presence
-   * authorizes the turn layer to safe-continue the preflight instead of dropping
-   * the turn; a locked session has no context-engine fallback (#119971/#119977).
+   * @internal Host-only authenticated marker. Plugin-supplied values are stripped
+   * by the queued-compaction owner before every return path; only that owner
+   * stamps it, after the private required-preflight capability dispatched for a
+   * model-locked native harness recoverable-binding failure. Its presence
+   * authorizes a benign required-preflight skip (safe-continue) in the turn layer;
+   * a locked session has no context-engine fallback (#119971/#119977).
    */
-  nativeHarnessBindingRecoveryReason?: NativeHarnessBindingRecoveryReason;
+  nativeHarnessBindingRecovery?: true;
   /** Structured failure metadata used by model fallback classification. */
   failure?: {
     reason?: string;

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -284,11 +284,29 @@ export type EmbeddedAgentRunResult = {
   successfulCronAdds?: number;
 };
 
+/**
+ * Typed recovery disposition for a model-locked native harness whose bound
+ * thread was missing/stale. The queued compaction owner stamps it only after the
+ * private required-preflight capability dispatched, so the turn layer can
+ * safe-continue instead of matching failure reason text.
+ */
+export type NativeHarnessBindingRecoveryReason =
+  | "missing_thread_binding"
+  | "stale_thread_binding"
+  | "thread_not_found";
+
 export type EmbeddedAgentCompactResult = {
   ok: boolean;
   compacted: boolean;
   compactionKind?: "context-engine" | "native-harness" | "server-endpoint";
   reason?: string;
+  /**
+   * Set only for a model-locked native harness recoverable-binding failure
+   * reached through the private required-preflight capability. Its presence
+   * authorizes the turn layer to safe-continue the preflight instead of dropping
+   * the turn; a locked session has no context-engine fallback (#119971/#119977).
+   */
+  nativeHarnessBindingRecoveryReason?: NativeHarnessBindingRecoveryReason;
   /** Structured failure metadata used by model fallback classification. */
   failure?: {
     reason?: string;

--- a/src/agents/harness/compaction-recovery.test.ts
+++ b/src/agents/harness/compaction-recovery.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { EmbeddedAgentCompactResult } from "../embedded-agent-runner/types.js";
 import {
-  classifyRecoverableNativeHarnessBindingFailure,
   isNativeHarnessBindingRecoverySkip,
   isRecoverableNativeHarnessBindingFailure,
 } from "./compaction-recovery.js";
@@ -10,25 +9,17 @@ function failure(overrides: Partial<EmbeddedAgentCompactResult>): EmbeddedAgentC
   return { ok: false, compacted: false, ...overrides };
 }
 
-describe("classifyRecoverableNativeHarnessBindingFailure", () => {
+describe("isRecoverableNativeHarnessBindingFailure", () => {
   it.each([
-    [{ failure: { reason: "missing_thread_binding" } }, "missing_thread_binding"],
-    [{ failure: { reason: "stale_thread_binding" } }, "stale_thread_binding"],
-    [{ reason: "thread not found: <id>" }, "thread_not_found"],
-    [{ reason: "no thread binding for session" }, "missing_thread_binding"],
-    [{ reason: "STALE_THREAD_BINDING" }, "stale_thread_binding"],
-  ] as const)("maps %o to %s", (overrides, expected) => {
-    const result = failure(overrides);
-    expect(classifyRecoverableNativeHarnessBindingFailure(result)).toBe(expected);
+    failure({ failure: { reason: "missing_thread_binding" } }),
+    failure({ failure: { reason: "stale_thread_binding" } }),
+    failure({ reason: "thread not found: <id>" }),
+    failure({ reason: "no thread binding for session" }),
+    failure({ reason: "STALE_THREAD_BINDING" }),
+    // Structured failure reason is recognized even when the display reason is not.
+    failure({ reason: "auth profile mismatch", failure: { reason: "stale_thread_binding" } }),
+  ])("recognizes recoverable binding failure %#", (result) => {
     expect(isRecoverableNativeHarnessBindingFailure(result)).toBe(true);
-  });
-
-  it("prefers the structured failure reason over the display reason", () => {
-    const result = failure({
-      reason: "thread not found",
-      failure: { reason: "stale_thread_binding" },
-    });
-    expect(classifyRecoverableNativeHarnessBindingFailure(result)).toBe("stale_thread_binding");
   });
 
   it.each([
@@ -37,18 +28,15 @@ describe("classifyRecoverableNativeHarnessBindingFailure", () => {
     failure({}),
     { ok: true, compacted: false, reason: "thread not found" } as EmbeddedAgentCompactResult,
     undefined,
-  ])("does not classify non-recoverable result %#", (result) => {
-    expect(classifyRecoverableNativeHarnessBindingFailure(result)).toBeUndefined();
+  ])("does not recognize non-recoverable result %#", (result) => {
     expect(isRecoverableNativeHarnessBindingFailure(result)).toBe(false);
   });
 });
 
 describe("isNativeHarnessBindingRecoverySkip", () => {
-  it("is true only when the typed disposition is present", () => {
+  it("is true only when the authenticated marker is present", () => {
     expect(
-      isNativeHarnessBindingRecoverySkip(
-        failure({ nativeHarnessBindingRecoveryReason: "stale_thread_binding" }),
-      ),
+      isNativeHarnessBindingRecoverySkip(failure({ nativeHarnessBindingRecovery: true })),
     ).toBe(true);
     expect(
       isNativeHarnessBindingRecoverySkip(failure({ failure: { reason: "stale_thread_binding" } })),

--- a/src/agents/harness/compaction-recovery.test.ts
+++ b/src/agents/harness/compaction-recovery.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { EmbeddedAgentCompactResult } from "../embedded-agent-runner/types.js";
+import {
+  classifyRecoverableNativeHarnessBindingFailure,
+  isNativeHarnessBindingRecoverySkip,
+  isRecoverableNativeHarnessBindingFailure,
+} from "./compaction-recovery.js";
+
+function failure(overrides: Partial<EmbeddedAgentCompactResult>): EmbeddedAgentCompactResult {
+  return { ok: false, compacted: false, ...overrides };
+}
+
+describe("classifyRecoverableNativeHarnessBindingFailure", () => {
+  it.each([
+    [{ failure: { reason: "missing_thread_binding" } }, "missing_thread_binding"],
+    [{ failure: { reason: "stale_thread_binding" } }, "stale_thread_binding"],
+    [{ reason: "thread not found: <id>" }, "thread_not_found"],
+    [{ reason: "no thread binding for session" }, "missing_thread_binding"],
+    [{ reason: "STALE_THREAD_BINDING" }, "stale_thread_binding"],
+  ] as const)("maps %o to %s", (overrides, expected) => {
+    const result = failure(overrides);
+    expect(classifyRecoverableNativeHarnessBindingFailure(result)).toBe(expected);
+    expect(isRecoverableNativeHarnessBindingFailure(result)).toBe(true);
+  });
+
+  it("prefers the structured failure reason over the display reason", () => {
+    const result = failure({
+      reason: "thread not found",
+      failure: { reason: "stale_thread_binding" },
+    });
+    expect(classifyRecoverableNativeHarnessBindingFailure(result)).toBe("stale_thread_binding");
+  });
+
+  it.each([
+    failure({ reason: "native compaction unavailable", failure: { reason: "native_unavailable" } }),
+    failure({ reason: "auth profile mismatch" }),
+    failure({}),
+    { ok: true, compacted: false, reason: "thread not found" } as EmbeddedAgentCompactResult,
+    undefined,
+  ])("does not classify non-recoverable result %#", (result) => {
+    expect(classifyRecoverableNativeHarnessBindingFailure(result)).toBeUndefined();
+    expect(isRecoverableNativeHarnessBindingFailure(result)).toBe(false);
+  });
+});
+
+describe("isNativeHarnessBindingRecoverySkip", () => {
+  it("is true only when the typed disposition is present", () => {
+    expect(
+      isNativeHarnessBindingRecoverySkip(
+        failure({ nativeHarnessBindingRecoveryReason: "stale_thread_binding" }),
+      ),
+    ).toBe(true);
+    expect(
+      isNativeHarnessBindingRecoverySkip(failure({ failure: { reason: "stale_thread_binding" } })),
+    ).toBe(false);
+    expect(isNativeHarnessBindingRecoverySkip(undefined)).toBe(false);
+  });
+});

--- a/src/agents/harness/compaction-recovery.ts
+++ b/src/agents/harness/compaction-recovery.ts
@@ -3,20 +3,49 @@
  *
  * CLI compaction uses these guards to recognize thread-binding failures that can
  * fall back to context-engine compaction after clearing stale session bindings.
+ * A model-locked native harness cannot reach the context engine, so it carries a
+ * typed recovery disposition (classified here) that lets the turn layer
+ * safe-continue instead of string-sniffing the failure reason.
  */
-import type { EmbeddedAgentCompactResult } from "../embedded-agent-runner/types.js";
+import type {
+  EmbeddedAgentCompactResult,
+  NativeHarnessBindingRecoveryReason,
+} from "../embedded-agent-runner/types.js";
 
-/** Returns whether a native harness failure reason indicates a recoverable binding issue. */
-function isRecoverableNativeHarnessBindingReason(reason: unknown): boolean {
+/** Classify a native harness failure reason into a typed recovery reason, if recoverable. */
+function classifyNativeHarnessBindingReason(
+  reason: unknown,
+): NativeHarnessBindingRecoveryReason | undefined {
   if (typeof reason !== "string") {
-    return false;
+    return undefined;
   }
   const normalized = reason.trim().toLowerCase();
+  // "no thread binding" is the free-text spelling of a missing binding.
+  if (normalized === "missing_thread_binding" || normalized.includes("no thread binding")) {
+    return "missing_thread_binding";
+  }
+  if (normalized === "stale_thread_binding") {
+    return "stale_thread_binding";
+  }
+  if (normalized.includes("thread not found")) {
+    return "thread_not_found";
+  }
+  return undefined;
+}
+
+/**
+ * Returns the typed recovery reason for a recoverable native binding failure, or
+ * undefined. Prefers the structured failure reason over the display reason.
+ */
+export function classifyRecoverableNativeHarnessBindingFailure(
+  result: EmbeddedAgentCompactResult | undefined,
+): NativeHarnessBindingRecoveryReason | undefined {
+  if (result?.ok !== false) {
+    return undefined;
+  }
   return (
-    normalized === "missing_thread_binding" ||
-    normalized === "stale_thread_binding" ||
-    normalized.includes("thread not found") ||
-    normalized.includes("no thread binding")
+    classifyNativeHarnessBindingReason(result.failure?.reason) ??
+    classifyNativeHarnessBindingReason(result.reason)
   );
 }
 
@@ -24,9 +53,17 @@ function isRecoverableNativeHarnessBindingReason(reason: unknown): boolean {
 export function isRecoverableNativeHarnessBindingFailure(
   result: EmbeddedAgentCompactResult | undefined,
 ): boolean {
-  return (
-    result?.ok === false &&
-    (isRecoverableNativeHarnessBindingReason(result.failure?.reason) ||
-      isRecoverableNativeHarnessBindingReason(result.reason))
-  );
+  return classifyRecoverableNativeHarnessBindingFailure(result) !== undefined;
+}
+
+/**
+ * Returns whether a compaction result carries the authenticated locked-harness
+ * binding-recovery disposition. Only the queued compaction owner stamps it, and
+ * only after the private required-preflight capability dispatched, so the turn
+ * layer can safe-continue without re-deriving lock state or matching reason text.
+ */
+export function isNativeHarnessBindingRecoverySkip(
+  result: EmbeddedAgentCompactResult | undefined,
+): boolean {
+  return result?.nativeHarnessBindingRecoveryReason !== undefined;
 }

--- a/src/agents/harness/compaction-recovery.ts
+++ b/src/agents/harness/compaction-recovery.ts
@@ -3,67 +3,83 @@
  *
  * CLI compaction uses these guards to recognize thread-binding failures that can
  * fall back to context-engine compaction after clearing stale session bindings.
- * A model-locked native harness cannot reach the context engine, so it carries a
- * typed recovery disposition (classified here) that lets the turn layer
- * safe-continue instead of string-sniffing the failure reason.
+ * A model-locked native harness cannot reach the context engine, so the queued
+ * owner stamps a boolean recovery marker that lets the turn layer safe-continue
+ * instead of string-sniffing the failure reason.
  */
-import type {
-  EmbeddedAgentCompactResult,
-  NativeHarnessBindingRecoveryReason,
-} from "../embedded-agent-runner/types.js";
+import type { EmbeddedAgentCompactResult } from "../embedded-agent-runner/types.js";
 
-/** Classify a native harness failure reason into a typed recovery reason, if recoverable. */
-function classifyNativeHarnessBindingReason(
-  reason: unknown,
-): NativeHarnessBindingRecoveryReason | undefined {
+/** Recognizes a recoverable native binding failure reason (structured or free-text). */
+function isRecoverableNativeHarnessBindingReason(reason: unknown): boolean {
   if (typeof reason !== "string") {
-    return undefined;
+    return false;
   }
   const normalized = reason.trim().toLowerCase();
-  // "no thread binding" is the free-text spelling of a missing binding.
-  if (normalized === "missing_thread_binding" || normalized.includes("no thread binding")) {
-    return "missing_thread_binding";
-  }
-  if (normalized === "stale_thread_binding") {
-    return "stale_thread_binding";
-  }
-  if (normalized.includes("thread not found")) {
-    return "thread_not_found";
-  }
-  return undefined;
-}
-
-/**
- * Returns the typed recovery reason for a recoverable native binding failure, or
- * undefined. Prefers the structured failure reason over the display reason.
- */
-export function classifyRecoverableNativeHarnessBindingFailure(
-  result: EmbeddedAgentCompactResult | undefined,
-): NativeHarnessBindingRecoveryReason | undefined {
-  if (result?.ok !== false) {
-    return undefined;
-  }
+  // Structured markers plus their provider free-text spellings: "no thread
+  // binding" is a missing binding and "thread not found" is a gone binding;
+  // both are recoverable by clearing the stale binding and rotating.
   return (
-    classifyNativeHarnessBindingReason(result.failure?.reason) ??
-    classifyNativeHarnessBindingReason(result.reason)
+    normalized === "missing_thread_binding" ||
+    normalized === "stale_thread_binding" ||
+    normalized.includes("no thread binding") ||
+    normalized.includes("thread not found")
   );
 }
 
-/** Returns whether a compact result failed due to a recoverable native binding issue. */
+/**
+ * Returns whether a compact result failed due to a recoverable native binding
+ * issue. Prefers the structured failure reason over the display reason.
+ */
 export function isRecoverableNativeHarnessBindingFailure(
   result: EmbeddedAgentCompactResult | undefined,
 ): boolean {
-  return classifyRecoverableNativeHarnessBindingFailure(result) !== undefined;
+  if (result?.ok !== false) {
+    return false;
+  }
+  return (
+    isRecoverableNativeHarnessBindingReason(result.failure?.reason) ||
+    isRecoverableNativeHarnessBindingReason(result.reason)
+  );
+}
+
+/**
+ * Resolves the model-locked native harness compaction outcome. A model-locked
+ * harness has no context-engine credentials, so a recoverable binding failure
+ * must never fall through to the generic engine (that route fails and drops the
+ * turn, #119977). The result is sanitized against a forged owner-minted marker
+ * first; the recovery marker is stamped only when the private required-preflight
+ * capability dispatched, so the turn layer can safe-continue (#119971); every
+ * other locked outcome stays an honest ok:false.
+ */
+export function resolveLockedNativeHarnessCompactionResult(
+  result: EmbeddedAgentCompactResult | undefined,
+  lockedFailure: EmbeddedAgentCompactResult,
+  preflightRequired: boolean,
+  requiredPreflightNativeCapabilityUsed: boolean,
+): EmbeddedAgentCompactResult {
+  let sanitized = result;
+  if (sanitized?.nativeHarnessBindingRecovery !== undefined) {
+    const { nativeHarnessBindingRecovery: _forged, ...rest } = sanitized;
+    sanitized = rest;
+  }
+  if (sanitized === undefined) {
+    return lockedFailure;
+  }
+  return preflightRequired &&
+    requiredPreflightNativeCapabilityUsed &&
+    isRecoverableNativeHarnessBindingFailure(sanitized)
+    ? { ...sanitized, nativeHarnessBindingRecovery: true }
+    : sanitized;
 }
 
 /**
  * Returns whether a compaction result carries the authenticated locked-harness
- * binding-recovery disposition. Only the queued compaction owner stamps it, and
- * only after the private required-preflight capability dispatched, so the turn
- * layer can safe-continue without re-deriving lock state or matching reason text.
+ * binding-recovery marker. Only the queued compaction owner stamps it, and only
+ * after the private required-preflight capability dispatched, so the turn layer
+ * can safe-continue without re-deriving lock state or matching reason text.
  */
 export function isNativeHarnessBindingRecoverySkip(
   result: EmbeddedAgentCompactResult | undefined,
 ): boolean {
-  return result?.nativeHarnessBindingRecoveryReason !== undefined;
+  return result?.nativeHarnessBindingRecovery === true;
 }

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -1,6 +1,7 @@
 // Covers agent harness selection, fallback behavior, and compaction routing.
 import path from "node:path";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import type { AgentHarnessCompactResult } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
@@ -87,11 +88,7 @@ import {
   resolveAgentHarnessPreparedAuthSupport,
   resolveAgentHarnessPreparedRouteSupport,
 } from "./support.js";
-import type {
-  AgentHarness,
-  AgentHarnessCompactParams,
-  AgentHarnessCompactResult,
-} from "./types.js";
+import type { AgentHarness, AgentHarnessCompactParams } from "./types.js";
 
 type TestNativeCompactionParams = AgentHarnessCompactParams & {
   nativeCompactionRequest: "required_preflight" | "after_context_engine";

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -284,7 +284,7 @@ export type AgentHarnessSideQuestionResult = {
 };
 export type AgentHarnessCompactParams =
   import("../embedded-agent-runner/compact.types.js").CompactEmbeddedAgentSessionParams;
-export type AgentHarnessCompactResult =
+type AgentHarnessCompactResult =
   import("../embedded-agent-runner/types.js").EmbeddedAgentCompactResult;
 export type AgentHarnessNativeCompactionRequest = "after_context_engine" | "required_preflight";
 export type AgentHarnessNativeCompactionParams = AgentHarnessCompactParams & {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2120,6 +2120,71 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(incrementCompactionCountMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["stale_thread_binding", "codex app-server binding changed before native compaction"],
+    ["missing_thread_binding", "no codex app-server thread binding"],
+  ] as const)(
+    "safe-continues required preflight on a model-locked %s recovery disposition",
+    async (recoveryReason, reason) => {
+      const sessionFile = path.join(rootDir, "session.jsonl");
+      await fs.writeFile(
+        sessionFile,
+        `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+        "utf8",
+      );
+      registerMemoryFlushPlanResolverForTest(() => ({
+        softThresholdTokens: 1,
+        forceFlushTranscriptBytes: 1_000_000_000,
+        reserveTokensFloor: 0,
+        prompt: "Pre-compaction memory flush.\nNO_REPLY",
+        systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+        relativePath: "memory/2023-11-14.md",
+      }));
+      // A model-locked native harness cannot fall back to context-engine
+      // compaction; the queued owner returns an honest ok:false carrying the
+      // authenticated recovery disposition, so preflight must continue the turn
+      // instead of dropping it (#119971/#119977).
+      compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
+        ok: false,
+        compacted: false,
+        reason,
+        failure: { reason: recoveryReason },
+        nativeHarnessBindingRecoveryReason: recoveryReason,
+      });
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        totalTokens: 120,
+        totalTokensFresh: true,
+        totalTokensVersion: 1,
+        agentHarnessId: "openclaw",
+        modelSelectionLocked: true,
+      };
+      const sessionStore = { "agent:main:telegram:group:redacted": sessionEntry };
+
+      const result = await runSessionCompactionIfNeeded({
+        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+        followupRun: createTestFollowupRun({
+          sessionId: "session",
+          sessionFile,
+          sessionKey: "agent:main:telegram:group:redacted",
+        }),
+        defaultModel: "anthropic/claude-opus-4-6",
+        modelContextTokens: 100,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:telegram:group:redacted",
+        storePath: path.join(rootDir, "sessions.json"),
+        isHeartbeat: false,
+        ...createCompactionLifecycle(createReplyOperation()),
+      });
+
+      expect(result).toMatchObject({ sessionId: "session", modelSelectionLocked: true });
+      expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+      expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("still fails preflight compaction for non-binding native harness failures", async () => {
     const sessionFile = path.join(rootDir, "session.jsonl");
     await fs.writeFile(

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2149,7 +2149,7 @@ describe("runMemoryFlushIfNeeded", () => {
         compacted: false,
         reason,
         failure: { reason: recoveryReason },
-        nativeHarnessBindingRecoveryReason: recoveryReason,
+        nativeHarnessBindingRecovery: true,
       });
       const sessionEntry: SessionEntry = {
         sessionId: "session",

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -19,6 +19,7 @@ import { runEmbeddedAgentEntry } from "../../agents/embedded-agent-runner/run-en
 import { createDeferredEmbeddedRunLifecycleManager } from "../../agents/embedded-agent-runner/run/deferred-lifecycle-owner.js";
 import type { RunEmbeddedAgentInternalParams } from "../../agents/embedded-agent-runner/run/internal-params.js";
 import { createToolResultPromptProjectionState } from "../../agents/embedded-agent-runner/session-prompt-state.js";
+import { isNativeHarnessBindingRecoverySkip } from "../../agents/harness/compaction-recovery.js";
 import { isCliRuntimeAliasForProvider } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { resolveContextConfigProviderForRuntime } from "../../agents/openai-routing.js";
@@ -1123,7 +1124,14 @@ export async function runSessionCompactionIfNeeded(params: {
     if (!result?.ok) {
       assertActive();
       const reason = result?.reason ?? "not_compacted";
-      if (result && isBenignCompactionSkipResult(result)) {
+      // A model-locked native harness has no context-engine fallback; its
+      // recoverable binding failure carries the authenticated recovery
+      // disposition, so continue the turn instead of dropping it
+      // (#119971/#119977). Unknown or non-recoverable failures stay fatal.
+      if (
+        result &&
+        (isBenignCompactionSkipResult(result) || isNativeHarnessBindingRecoverySkip(result))
+      ) {
         await notifyTerminalCompaction("skipped");
         logVerbose(`preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`);
         return entry ?? params.sessionEntry;

--- a/src/plugin-sdk/agent-harness-runtime.test.ts
+++ b/src/plugin-sdk/agent-harness-runtime.test.ts
@@ -17,11 +17,13 @@ import {
   type AgentHarnessQuestionGatewayCall,
   type AgentHarnessAttemptParams,
   type AgentHarnessAttemptParamsV2,
+  type AgentHarnessCompactResult,
   type AgentHarnessSideQuestionParams,
   type AgentHarnessSideQuestionParamsV2,
   type AgentHarnessSupportContext,
   type AgentHarnessTerminalOutcomeClassification,
   type AgentHarnessV2,
+  type EmbeddedAgentCompactResult,
   type EmbeddedRunAttemptParams,
   type EmbeddedRunAttemptParamsV2,
 } from "./agent-harness-runtime.js";
@@ -230,6 +232,25 @@ describe("agent harness runtime SDK facade", () => {
       "run" | "source-bound"
     >();
     expectTypeOf<Parameters<GuardedInjection["queueMessage"]>["length"]>().toEqualTypeOf<4>();
+  });
+
+  it("keeps the native binding-recovery marker out of the SDK compact-result contract", () => {
+    // The internal runtime type carries a host-only `nativeHarnessBindingRecovery`
+    // authorization marker (stamped/stripped solely by the queued-compaction owner).
+    // It must not be part of the plugin SDK contract, so the exported result type
+    // omits it and the harness alias resolves to the same narrowed shape.
+    expectTypeOf<
+      "nativeHarnessBindingRecovery" extends keyof EmbeddedAgentCompactResult ? true : false
+    >().toEqualTypeOf<false>();
+    expectTypeOf<
+      "nativeHarnessBindingRecovery" extends keyof AgentHarnessCompactResult ? true : false
+    >().toEqualTypeOf<false>();
+    expectTypeOf<AgentHarnessCompactResult>().toEqualTypeOf<EmbeddedAgentCompactResult>();
+    // The rest of the compaction result contract is preserved for SDK consumers.
+    expectTypeOf<EmbeddedAgentCompactResult>().toMatchTypeOf<{
+      ok: boolean;
+      compacted: boolean;
+    }>();
   });
 
   it("keeps legacy question callbacks and requires explicit guarded dispatch authority", () => {

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -27,6 +27,7 @@ import {
   type AbortAndDrainEmbeddedAgentRunResult,
   type EmbeddedAgentQueueMessageOptions,
 } from "../agents/embedded-agent-runner/runs.js";
+import type { EmbeddedAgentCompactResult as InternalEmbeddedAgentCompactResult } from "../agents/embedded-agent-runner/types.js";
 import { runStructuredInput } from "../agents/harness/structured-input-execution.js";
 import {
   compileStructuredInputForm,
@@ -87,7 +88,6 @@ export type {
   AgentHarnessAttemptParamsV2,
   AgentHarnessAttemptResult,
   AgentHarnessCompactParams,
-  AgentHarnessCompactResult,
   AgentHarnessNativeCompaction,
   AgentHarnessNativeCompactionParams,
   AgentHarnessNativeCompactionRequest,
@@ -156,6 +156,22 @@ export type EmbeddedRunAttemptParamsV2 = EmbeddedRunAttemptParamsBase & {
   hostCapabilities: import("../agents/harness/host-capability-types.js").AgentHarnessHostCapabilities;
 };
 export type { EmbeddedRunAttemptResult };
+/**
+ * SDK-facing compaction result contract.
+ *
+ * The internal runtime type carries a host-only `nativeHarnessBindingRecovery`
+ * authorization marker that is stamped and stripped exclusively by the
+ * queued-compaction owner; plugin-supplied values are ignored by sanitization.
+ * That marker is intentionally kept out of the plugin SDK contract, so the
+ * exported result type omits it. Internal runtime types and sanitization are
+ * unchanged — this narrowing applies only at the SDK boundary.
+ */
+export type EmbeddedAgentCompactResult = Omit<
+  InternalEmbeddedAgentCompactResult,
+  "nativeHarnessBindingRecovery"
+>;
+/** SDK-facing alias of the narrowed compaction result contract. */
+export type AgentHarnessCompactResult = EmbeddedAgentCompactResult;
 export type {
   ContextEngine as HarnessContextEngine,
   ContextEngineHostCapability,
@@ -163,7 +179,6 @@ export type {
   ContextEngineProjection,
 } from "../context-engine/types.js";
 export type { CompactEmbeddedAgentSessionParams } from "../agents/embedded-agent-runner/compact.js";
-export type { EmbeddedAgentCompactResult } from "../agents/embedded-agent-runner/types.js";
 export type { AnyAgentTool } from "../agents/tools/common.js";
 export type {
   MessagingToolSend,


### PR DESCRIPTION
Fixes #119977 (and the compounding dropped-turn symptom in #119971).

## What Problem This Solves

Two gaps that still exist on current `main` cause a model-locked Codex (native-harness) session to silently drop a turn when its bound app-server thread has gone missing or stale.

**1. A recoverable binding failure on a model-locked harness falls through to the context-engine fallback and drops the turn.** A persisted Codex app-server thread binding (durable SQLite state) outlives the app-server client that owned the in-memory thread. Thread liveness lives only in app-server process memory (`thread_manager.get_thread` reads a per-process map), so once the owning client retires the stored `threadId` is non-empty but the thread is dead. When a required preflight compaction hits this on a session whose model selection is **locked** (OAuth-only Codex), `main` routes the recoverable binding failure into the shared context-engine fallback — a route a locked session cannot use, because context-engine compaction fails a locked session with "No API key found". The preflight compaction therefore fails and the turn is dropped with no visible outcome. That is the #119977 / #119971 symptom.

**2. A closed bound client can be retained and immediately reject.** `retainSharedCodexAppServerClientByInstanceId` gated only on the registry-side flags (`entry.closeWhenIdle`, `entry.closeError`). A client whose transport closes between the registry lookup and the lease still has those flags unset, so the closed client is retained and handed back; its next request rejects immediately as non-recoverable — the close-before-retain race.

## Why This Change Was Made

Thread liveness is owned by codex-rs and exists only in app-server process memory; the only way to learn it is to issue the native request at compaction time. `thread/compact/start` loads the thread and a retired thread maps to `invalid_request(format!("thread not found: {thread_id}"))`, i.e. JSON-RPC `-32600`. The queued compaction owner discriminates recoverable binding failures — `missing_thread_binding`, `stale_thread_binding`, and the free-text `"thread not found"` / `"no thread binding"` spellings — through the private required-preflight native capability it actually dispatched, never a public result field. The full structured `-32600` + `"thread not found"` pair is the codex-rs contract cited below.

The re-scoped fix has three parts, plus a follow-up refactor:

- **F1 — keep model-locked native compaction off the context-engine fallback.** For a locked native harness, `compactResolvedContextEngine` now always returns terminally; it never falls through to the generic engine. The locked gate (`src/agents/embedded-agent-runner/compact.queued.ts:670`) delegates to `resolveLockedNativeHarnessCompactionResult` (`src/agents/harness/compaction-recovery.ts:54`): when the private required-preflight capability dispatched and returned a recoverable binding failure, that resolver stamps a host-only boolean marker `nativeHarnessBindingRecovery: true` on the result (`compaction-recovery.ts:71`; the field is declared `@internal` at `src/agents/embedded-agent-runner/types.ts:300`). The turn-layer consumer (`runSessionCompactionIfNeeded`) recognizes that authenticated marker by presence (`isNativeHarnessBindingRecoverySkip` → `result.nativeHarnessBindingRecovery === true`, consumed at `src/auto-reply/reply/agent-runner-memory.ts:1127`) as a benign preflight skip and safe-continues the turn — with no failure-reason text matching at the consumer. Every other locked outcome stays an honest `ok:false`. The recognizer is the existing `isRecoverableNativeHarnessBindingFailure` (structured `missing_thread_binding`/`stale_thread_binding` plus the free-text spellings); no reason-string sniffing is introduced downstream.

- **F2-min — reject closed bound clients before retaining them.** The `retainSharedCodexAppServerClientByInstanceId` gate (`extensions/codex/src/app-server/shared-client.ts:1341`) now also rejects a client that reports `client.getCloseError()` (`:1359`), the authoritative client-side transport-close signal, alongside the existing registry flags (`entry.closeWhenIdle || entry.closeError`). This closes the close-before-retain race so the caller acquires fresh instead of leasing a client whose next request rejects. The sibling client-currency gate `captureSharedClientRegistration` (`:1328`) already carried this conjunct; the retain gate did not.

- **Hardening — strip forged binding-recovery markers.** `nativeHarnessBindingRecovery` is an owner-minted authorization marker: the turn layer treats its mere presence as license to safe-continue. Because the harness result is the one value returned from `compactResolvedContextEngine` that is spread verbatim, any incoming `nativeHarnessBindingRecovery` is stripped before every return path that spreads it — inside the locked resolver (`compaction-recovery.ts:60`) and at the native-harness projection return (`compact.queued.ts:680`) — so only the owner's explicit authenticated stamp can set it. The two context-engine return points cannot carry the marker: both reconstruct their result object field by field rather than spreading the plugin result. No production harness sets the field today; this keeps it impossible by construction.

- **Option B — collapse the recovery disposition to a boolean marker.** An earlier iteration carried a three-value `NativeHarnessBindingRecoveryReason` union (plus a `classifyRecoverableNativeHarnessBindingFailure` classifier). Since the turn layer only needs presence, that was collapsed to a single host-only boolean `nativeHarnessBindingRecovery?: true` (`@internal`); the named union type and the classifier layer are deleted — neither `NativeHarnessBindingRecoveryReason` nor `classifyRecoverableNativeHarnessBindingFailure` appears anywhere in `compact.queued.ts`, `compaction-recovery.ts`, or `types.ts` (0 occurrences) — and the single boolean predicate `isRecoverableNativeHarnessBindingFailure` retains all recognition logic. All F1 invariants are behaviorally preserved: owner-only stamp, presence-only consumer check, unknown-stays-fatal, locked-harness never falls through.

- **SDK isolation — keep the recovery marker out of the plugin-SDK exported compact-result contract.** The compaction result type is re-exported to plugins from `src/plugin-sdk/agent-harness-runtime.ts`, which previously re-exported the internal type verbatim and so leaked the new host-only `nativeHarnessBindingRecovery` marker into the plugin-facing TypeScript contract. The SDK re-exports of `EmbeddedAgentCompactResult` (and its `AgentHarnessCompactResult` alias) are now narrowed to `Omit<…, "nativeHarnessBindingRecovery">`, importing the internal type under an alias. SDK consumers therefore see the narrowed type with the marker removed, while the internal runtime types and the existing sanitization stay exactly as-is (zero behavior change; all internal consumers keep compiling unchanged). A compile-time contract test locks the marker out of the exported type.

### Re-scope disclosure

Earlier iterations of this PR carried a broader Codex-owner recovery design (retain-first client acquisition, dead-binding clear under lease, and next-turn rebind in the codex extension). While this PR was open, upstream `main` independently landed its own #119977 recovery built on the `isRecoverableNativeHarnessBindingFailure` recognizer plus a required-preflight fallback gate. That upstream design closes part of the problem but still routes a locked-harness recoverable failure into the context-engine fallback — which a locked session cannot use — so the turn is still dropped. Rather than duplicate or conflict with upstream's implementation, this PR was re-scoped to the two gaps that **still exist** on current `main` (verified read-only against current base `2d948bf8e8`):

- The locked fall-through path — `src/agents/embedded-agent-runner/compact.queued.ts:649-669`: the locked gate (`:651-661`) excludes the required-preflight recoverable-binding-failure case (`:654-658`), so when that case fires the gate does not early-return and execution falls through into the warn-and-context-engine path (`:662-669`, `log.warn("… falling back to context engine …")`), dropping the turn on a locked session. (Upstream's `!transcriptBytePreflightAuthority` term only diverts a separate host-byte-preflight route; it does not change the locked recoverable fall-through.)
- The retain gate missing the `getCloseError()` conjunct — `extensions/codex/src/app-server/shared-client.ts:1350`: the retain gate checks only `entry.closeWhenIdle || entry.closeError`, lacking the authoritative `client.getCloseError()` term that the sibling client-currency gate `captureSharedClientRegistration` (base line 1328) already carries.

This PR reuses upstream's recognizer and adds no broad codex-owner recovery machinery. It introduces **no new public plugin-SDK surface**: the only plugin-SDK file it touches (`src/plugin-sdk/agent-harness-runtime.ts`) is edited solely to *narrow* the exported compact-result contract — removing the host-only `nativeHarnessBindingRecovery` marker from the plugin-facing type via `Omit` while keeping the exported names stable. The host-only boolean marker is core-internal (`@internal`), and no named union type or classifier is exported.

**Rebase note (drift).** This branch was rebased onto current `main` (`2d948bf8e8`). The rebase ran in two clean stages. First, `git rebase --onto 8214179fe2` (the tip at the start of the run, 204 commits past the prior base): a clean replay with zero conflicts whose `git range-diff` reported three commits identical (`=`) and one `!` that was contextual-only — the F2-min commit's hunk context shifted by an unrelated upstream test edit, with its added/removed lines byte-identical. Upstream then advanced to `2d948bf8e8` during the run, so a bounded nested retry rebased `--onto 2d948bf8e8`; the only intersecting file was `compact.hooks.test.ts` (upstream #139564 moved classification tests out of it, disjoint from this PR's additions), and that replay was clean with `range-diff` reporting all four commits `=`. Across the run the fix's own locked-recovery and retain-gate logic is byte-identical; the only internal reshaping was a behavior-identical restructure that moved the strip/stamp into `resolveLockedNativeHarnessCompactionResult` in `compaction-recovery.ts` to keep `compact.queued.ts` under the oxlint `max-lines` cap (700). The full local gate chain — focused verification, the discriminating red-on-base/green-on-head regression proof, an exact-tree review, and the full test-type/typecheck/lint/format checks — was re-run green on the final tree. The branch was subsequently rebased once more onto `b75423c2fc` during the CI-fix cycle (a single bounded push-time retry after upstream touched three intersecting files; clean replay of all six commits with the fix diff byte-identical; gates re-run green — see Evidence (e)).

### Codex-rs contract (verbatim, pinned `rust-v0.153.4` @ `3d2ee51ca`)

`extensions/codex/package.json` at this head declares `"@openai/codex": "0.153.4"`, and the contract citations below were re-verified verbatim against the `rust-v0.153.4` tag (`3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`) — the tracked re-read follow-up from the previous `rust-v0.151.0 @ 78c290807` pin is complete. The structured `-32600` + `"thread not found"` pair the recovery recognizer depends on is unchanged between the two tags; only line anchors moved (remapped below). The runtime proof in Evidence (c) executed against the vendored `0.153.4` binary (`serverVersion=0.153.4`, `userAgent openclaw/0.153.4`).

**1. `thread/compact/start` loads the thread through the per-process in-memory map** — `codex-rs/app-server/src/request_processors/thread_processor.rs:951-966` (`thread_compact_start` at `:749-757` delegates to `thread_compact_start_inner` at `:2347-2360`, which calls `load_thread` before `submit_core_op(Op::Compact)`):

```rust
async fn load_thread(
    &self,
    thread_id: &str,
) -> Result<(ThreadId, Arc<CodexThread>), JSONRPCErrorError> {
    // Resolve the core conversation handle from a v2 thread id string.
    let thread_id = ThreadId::from_string(thread_id)
        .map_err(|err| invalid_request(format!("invalid thread id: {err}")))?;

    let thread = self
        .thread_manager
        .get_thread(thread_id)
        .await
        .map_err(|_| invalid_request(format!("thread not found: {thread_id}")))?;

    Ok((thread_id, thread))
}
```

**2. The `-32600` definition** — `codex-rs/app-server/src/error_code.rs:3` and the `:10-12` helper:

```rust
pub(crate) const INVALID_REQUEST_ERROR_CODE: i64 = -32600;

pub(crate) fn invalid_request(message: impl Into<String>) -> JSONRPCErrorError {
    error(INVALID_REQUEST_ERROR_CODE, message)
}
```

**3. Thread knowledge is per-process** — `codex-rs/core/src/thread_manager.rs:343-350` (`ThreadManagerState` holding the `threads: Arc<RwLock<HashMap<ThreadId, Arc<CodexThread>>>>` map at `:344`) and `:1475-1481` (`get_thread` reads only that in-memory map; a missing/retired or internal-source thread yields `CodexErr::ThreadNotFound`):

```rust
/// Fetch a thread by ID or return ThreadNotFound.
pub(crate) async fn get_thread(&self, thread_id: ThreadId) -> CodexResult<Arc<CodexThread>> {
    let threads = self.threads.read().await;
    match threads.get(&thread_id) {
        Some(thread) if !thread.session_source.is_internal() => Ok(thread.clone()),
        Some(_) | None => Err(CodexErr::ThreadNotFound(thread_id)),
    }
}
```

**4. The app-server suite's own dual assertion for a retired thread** — `codex-rs/app-server/tests/suite/v2/compaction.rs:404` and `:434-435` (constant at `:50`):

```rust
assert_eq!(error.error.code, INVALID_REQUEST_ERROR_CODE);
assert!(error.error.message.contains("thread not found"));
```

A new app-server process starts with an empty thread map, so a compact request for the old binding's thread returns `ThreadNotFound` → `-32600 "thread not found"`. This is exactly the structured pair the recovery recognizer discriminates on.

**5. Resume requires an existing rollout** — `codex-rs/core/src/thread_manager.rs:1031-1047`: `resume_thread_from_rollout` loads the rollout first (`initial_history_from_rollout_path`), so a killed owner whose thread was in-memory-only surfaces at the resume stage as `"no rollout found"` — a genuinely different failure that the recovery gate deliberately does not recognize (see the honest note in Evidence (c)).

## User Impact

Compaction behavior for a Codex/OpenAI session, by state:

- **Model-locked required preflight, recoverable binding (missing / stale / thread-not-found)** — the queued owner stamps the host-only boolean `nativeHarnessBindingRecovery: true`; the turn layer safe-continues the preflight instead of dropping the turn. Authorization comes from the private required-preflight capability that actually dispatched, never a public result field. This is the #119977 / #119971 fix.
- **Model-locked, any other outcome** — returns an honest `ok:false`; the locked path never reaches the context engine.
- **Unlocked sessions** — behavior is unchanged: a recoverable native binding failure still falls back to context-engine compaction.
- **Bound client that closed between registry lookup and lease** — no longer retained; the caller acquires a fresh client instead of leasing one whose next request would reject.
- **Forged recovery marker on a harness result** — stripped before any return path, so a harness result can never mint the marker the turn layer trusts.

Net production change is small (**+97 production lines net**, `+124 / −27` across the 5 production files, offset by deleting the union type and classifier layer): the fix reshapes the locked return path, collapses the disposition to a single host-only boolean marker, and adds the retain-gate conjunct, rather than bolting broad recovery machinery onto the codex owner.

## Evidence

**(a) Discriminating regression proof (red on base, green on head).** Method: detach to bare base `2d948bf8e8` (no fixes), overlay the branch's own regression suites, run them (RED), restore the branch head `f76627905d`, re-run (GREEN).

Base `2d948bf8e8` (no fix) — **5 behavior-level assertion failures**:
- `src/agents/embedded-agent-runner/compact.hooks.test.ts` — 4 failed / 178 passed (182):
  1. stamps the recovery disposition on model-locked Codex `missing_thread_binding` during required preflight without a context-engine fallback
  2. stamps the recovery disposition on model-locked Codex `stale_thread_binding` during required preflight without a context-engine fallback
  3. strips a forged `nativeHarnessBindingRecovery` marker on model-locked `missing_thread_binding` required preflight
  4. strips a forged `nativeHarnessBindingRecovery` marker on model-locked `stale_thread_binding` required preflight
- `extensions/codex/src/app-server/shared-client.test.ts` — 1 failed / 115 passed (116):
  5. does not retain a registered client that already reports a transport close (base returns the closed client instead of skipping)

Branch head `f76627905d` (with fix) — **symmetric green**: `compact.hooks.test.ts` 182/182, `shared-client.test.ts` 116/116. The exact 4 + 1 tests that fail on base pass on head; the regression tests fail pre-fix for the intended reason. All five failures are behavior-level assertions with zero compile/import errors. (`compact.hooks.test.ts` totals 182 on this base, down from 185 on the earlier base: upstream #139564 moved 3 classification tests out of the file; RED and GREEN were both measured on the same 182-test file.)

**(b) Focused validation on the exact head `f76627905d`.** All green:
- Vitest, 7 suites: `src/agents/embedded-agent-runner/compact.hooks.test.ts` (182), `src/agents/harness/compaction-recovery.test.ts` (12), `src/auto-reply/reply/agent-runner-memory.test.ts` (117), `extensions/codex/src/app-server/shared-client.test.ts` (116), plus the adjacent compaction suites `compact.test.ts` (59), `cli-compaction.test.ts` (32), and `compact.native-cli.test.ts` (3).
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, `pnpm tsgo:extensions`, `pnpm tsgo:extensions:test` — all exit 0.
- `oxlint` on the 9 changed files — clean (exit 0); `oxfmt` formatting is enforced by the pre-commit hook (which reformatted the tree during the `max-lines` restructure).

**(c) Exact-head runtime proof — CAPTURED at `9737873b18` (2026-09-06).** A real runtime batch (no vitest, no mocked clients, no injected compaction results for the headline traces) ran the production entry points against a real Codex app-server subprocess spawned from the vendored `@openai/codex` 0.153.4 binary, with the dist built at this exact head (`build-info` commit-matched; HEAD verified unchanged before and after the run). Results:

- **Reachable queued-preflight continuation (the P1 merge-risk item).** The full production entry `maybeCompactAgentHarnessSession(params, {nativeCompactionRequest: "required_preflight", onNativeCompactionCapabilityUsed})` dispatched the registry-owned private native capability for real (`onNativeCompactionCapabilityUsed` fired ⇒ `requiredPreflightNativeCapabilityUsed=true`). **STALE** (the canonical #119977 shape: a live owner holds an OpenClaw live-thread subscription for a thread the app-server does not have): real `-32600 "thread not found"` → `failure.reason="stale_thread_binding"` → `resolveLockedNativeHarnessCompactionResult` stamped `nativeHarnessBindingRecovery=true` → `isNativeHarnessBindingRecoverySkip=true` → consumer decision **CONTINUE** (reply pipeline proceeds; no context-engine fallback, no defer-forever, no throw; owner reused, no new spawn). **MISSING** (absent binding): real `missing_thread_binding` → same stamp → **CONTINUE**. Dual trigger: missing ✓ stale ✓.
- **Negative controls.** Forged marker without native-capability dispatch → stripped, THROW; forged marker with a non-recoverable failure → stripped, THROW; real recoverable failure without native-capability dispatch (the transcript-byte-preflight analog, which bypasses native dispatch) → no marker, THROW — the marker is unreachable off the required-preflight native route.
- **Ownership adjudication at resume-after-safe-continue.** `resolveSessionRuntimeOwnership` → `undefined` in both post-continue states ⇒ `expectedSessionRuntimeOwnership` **unset** ⇒ the Codex ownership fence (`assertCodexSessionRuntimeOwnership` / `assertCodexBindingMayBeReplaced`) stays dormant and the rotation chain proceeds on the next turn.
- **Physical closed-client rejection (the second pending item).** Healthy client: keyed retain GRANTED. After a real production `client.close()` — which latches `getCloseError()` synchronously (`markClosed`) without touching the registry retire flags — the same keyed retain was REJECTED before retention with only `getCloseError()` changed (no retire, stable instanceId), attributable to the `:1359` conjunct; the process exited and the post-exit retain still rejected (a closed client is never handed out).

Honest notes for this batch: (i) the turn-layer consumer branch (`agent-runner-memory.ts:1131-1141`) was exercised directly against the real stamped result — the full reply pipeline requires a live gateway session, so the branch and both of its arms were reproduced verbatim against production values; (ii) standalone runs supply an infrastructure-only prepared-runtime stub (empty auth/model registry) for the entry's auth/model-metadata prelude, which emitted a benign `modelIdNormalizationPolicies` warning while the native dispatch still fired and produced the real app-server result; (iii) the literal killed-owner variant whose thread was in-memory-only surfaces `"no rollout found"` at the resume stage (contract item 5 above), which the recovery gate deliberately does not recognize — the `-32600` contract is proven by the live-owner stale case, the faithful model of #119977.

The complete, untruncated redacted captures follow.

Every relied-upon snapshot below is inlined in FULL, untruncated. Redaction applied: `/Users/<user>` → `$HOME`. No API-key value, IP,
private endpoint, or phone number appears in any capture (verified by scan). Ephemeral
PIDs / instanceIds / threadIds are retained as permitted. `/Volumes/MacDataXY/...` paths
are retained because they are the workdir and the 0.153.4 vendor-binary paths (evidence),
not credentials or PII.

Sources of truth (unredacted originals also on disk): `run-A.log`, `run-B.log`,
`ps-snapshots.log`.

---

## 1. Vendored Codex binary + runtime identity (Phase B, `processIdentity`)

The `processIdentity` line proves the executed binary is the vendored 0.153.4, resolved
from the Codex plugin's `node_modules` — the native command is the
`aarch64-apple-darwin` vendor binary — and `serverVersion`/`userAgent` are `0.153.4`
(NOT the PATH CLI 0.144.5):

```
   client: pid=91245 instanceId=352832b1-d9a3-4a9c-b7be-0edef5b34842 serverVersion=0.153.4
   processIdentity={"clientId":"352832b1-d9a3-4a9c-b7be-0edef5b34842","command":"/Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js","argsFingerprint":"2b55a93772528206b0974e048ad60708f3200ce757bf7315204312c3cf790f03","commandSource":"resolved-managed","managedCommandOrder":"desktop-first","nativeCommand":"/Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4-darwin-arm64/node_modules/@openai/codex/vendor/aarch64-apple-darwin/bin/codex","serverVersion":"0.153.4","userAgent":"openclaw/0.153.4 (Mac OS 15.3.1; arm64) unknown (openclaw; 2026.9.2)"}
```

---

## 2. Phase A — full text of `run-A.redacted.log`

Reply-preflight → queued-owner native dispatch → recovery marker → continuation, for
both the STALE (real `-32600`) and MISSING triggers, plus negative controls. The full
production entry `maybeCompactAgentHarnessSession(required_preflight)` dispatched and the
real `onNativeCompactionCapabilityUsed` callback fired.

```
HEAD=9737873b185fe9f6f65e884f990f2cf3369f65ad
node=v26.5.0
connection start.command=codex args=["app-server","--listen","stdio://"] source=managed
isolated CODEX_HOME=$HOME/.openclaw/tmp/proof120443v3-A-ct0OGo/codex-home

================================================================
== A0 — boot real plugin registry + register REAL codex harness
================================================================
   registered harness id=codex authBootstrap=harness
   resolveCodexAgentHarnessNativeCompaction(registered codex) => FUNCTION (registry-owned private capability)
   resolveCodexAgentHarnessNativeCompaction({id:'not-codex'}) => undefined (non-owner rejected)

================================================================
== A1 — real codex app-server owner + real thread (live owner)
================================================================
[agent/embedded] codex app-server stderr: WARNING: proceeding, even though we could not create PATH aliases: Refusing to create helper binaries under temporary dir "$HOME/.openclaw/tmp" (codex_home: AbsolutePathBuf("$HOME/.openclaw/tmp/proof120443v3-A-ct0OGo/codex-home"))
   owner O: pid=90066 instanceId=9cefcb9d-1108-4ea1-8895-f9c1d01bee5a serverVersion=0.153.4
[ps] A1 owner acquired: pid=90066(alive)
   started real thread T=01a076ff-1e3a-7cd2-936f-b12d5e4aecf4 (owned by O's in-memory thread map)

================================================================
== A2 — STALE case (#119977 canonical): live owner holds a subscription for a thread the app-server does not have -> real -32600 'thread not found'
================================================================
   retainCodexAppServerLiveThread(O, ghost=5b88b996-41c3-4c32-baa5-d0bb64eadc95) => true (OpenClaw now holds a live-thread subscription for a thread O never created)
   stale binding stored: threadId=5b88b996-41c3-4c32-baa5-d0bb64eadc95 clientId=9cefcb9d-1108-4ea1-8895-f9c1d01bee5a (clientId===O.instanceId: true)
[agents/harness-compaction] native compaction model resolution failed for codex/gpt-5.5: Cannot read properties of undefined (reading 'modelIdNormalizationPolicies')
[agent/embedded] codex app-server compaction could not use thread binding
   [STALE] via maybeCompactAgentHarnessSession (full entry); capabilityUsed=true
   codex app-server pids before=[90066,90079] after=[90066,90079] (owner O reused, no new spawn: true)
   native dispatch path: maybeCompactAgentHarnessSession (full openclaw native dispatch)
   >> RAW harness result: {"ok":false,"compacted":false,"reason":"thread not found: 5b88b996-41c3-4c32-baa5-d0bb64eadc95","failure":{"reason":"stale_thread_binding","rawError":"thread not found: 5b88b996-41c3-4c32-baa5-d0bb64eadc95"}}
   >> onNativeCompactionCapabilityUsed fired (requiredPreflightNativeCapabilityUsed): true
   >> isRecoverableNativeHarnessBindingFailure(raw): true
   >> raw failure.reason="stale_thread_binding" raw.reason="thread not found: 5b88b996-41c3-4c32-baa5-d0bb64eadc95"
   >> resolveLockedNativeHarnessCompactionResult (compact.queued.ts:670-677) -> nativeHarnessBindingRecovery=true
   >> isNativeHarnessBindingRecoverySkip(stamped) [compaction-recovery.ts:84]: true
   >> CONSUMER DECISION [agent-runner-memory.ts:1131-1141]: CONTINUE
   >> continuation: reply pipeline PROCEEDS (safe-continue; notifyTerminalCompaction('skipped'); return entry) — NO context-engine fallback, NO defer-forever, NO throw
   >> Angie(i) STALE resolveSessionRuntimeOwnership => undefined => expectedSessionRuntimeOwnership UNSET (Codex fence dormant; rotation chain proceeds on the next turn)
[ps] A2 after stale dispatch (owner alive): pid=90066(alive)

================================================================
== A2b — killed-owner variant (task step 3 literal): kill owner -> observe resume-stage outcome (honest)
================================================================
[ps] A2b before kill: pid=90066(alive)
[ps] A2b after kill (owner GONE): pid=90066(gone)
   owner O alive after SIGKILL? false
[agents/harness-compaction] native compaction model resolution failed for codex/gpt-5.5: Cannot read properties of undefined (reading 'modelIdNormalizationPolicies')
[agent/embedded] codex app-server stderr: WARNING: proceeding, even though we could not create PATH aliases: Refusing to create helper binaries under temporary dir "$HOME/.openclaw/tmp" (codex_home: AbsolutePathBuf("$HOME/.openclaw/tmp/proof120443v3-A-ct0OGo/codex-home"))
[agent/embedded] codex app-server compaction failed
   [KILLED-OWNER] via maybeCompactAgentHarnessSession (full entry); capabilityUsed=true
   >> RAW result: {"ok":false,"compacted":false,"reason":"no rollout found for thread id 5b88b996-41c3-4c32-baa5-d0bb64eadc95"}
   >> isRecoverableNativeHarnessBindingFailure(raw): false
   >> NOTE: a killed owner whose thread was in-memory-only surfaces at the RESUME stage ('no rollout found'), which is NOT one of the recovery gate's recognized reasons; the -32600 'thread not found' contract is exercised by the live-owner stale case A2 above.

================================================================
== A3 — MISSING case: absent binding -> missing_thread_binding -> continuation
================================================================
[agents/harness-compaction] native compaction model resolution failed for codex/gpt-5.5: Cannot read properties of undefined (reading 'modelIdNormalizationPolicies')
[agent/embedded] codex app-server compaction could not use thread binding
   [MISSING] via maybeCompactAgentHarnessSession (full entry); capabilityUsed=true
   native dispatch path: maybeCompactAgentHarnessSession (full openclaw native dispatch)
   >> RAW harness result: {"ok":false,"compacted":false,"reason":"no codex app-server thread binding","failure":{"reason":"missing_thread_binding","rawError":"no codex app-server thread binding"}}
   >> onNativeCompactionCapabilityUsed fired (requiredPreflightNativeCapabilityUsed): true
   >> isRecoverableNativeHarnessBindingFailure(raw): true
   >> raw failure.reason="missing_thread_binding" raw.reason="no codex app-server thread binding"
   >> resolveLockedNativeHarnessCompactionResult (compact.queued.ts:670-677) -> nativeHarnessBindingRecovery=true
   >> isNativeHarnessBindingRecoverySkip(stamped) [compaction-recovery.ts:84]: true
   >> CONSUMER DECISION [agent-runner-memory.ts:1131-1141]: CONTINUE
   >> continuation: reply pipeline PROCEEDS (safe-continue; notifyTerminalCompaction('skipped'); return entry) — NO context-engine fallback, NO defer-forever, NO throw
   >> Angie(i) MISSING resolveSessionRuntimeOwnership => undefined => expectedSessionRuntimeOwnership UNSET (Codex fence dormant; rotation chain proceeds on the next turn)

================================================================
== A4 — NEGATIVE CONTROLS
================================================================
   NC1 forged marker + native capability NOT used: input.nativeHarnessBindingRecovery=true -> output=undefined (STRIPPED @compaction-recovery.ts:61-64, not re-stamped) isSkip=false decision=THROW (expect THROW)
   NC2 forged marker + non-recoverable failure: output=undefined (stripped, not re-stamped: !recoverable) isSkip=false decision=THROW (expect THROW)
   NC3 real recoverable failure but native capability NOT used (transcript-byte preflight bypasses native dispatch + marker): marker=undefined isSkip=false decision=THROW (expect THROW)

================================================================
== A — SUMMARY
================================================================
STALE(-32600): path=maybeCompactAgentHarnessSession capabilityUsed=true rawFailure="stale_thread_binding" reason="thread not found: 5b88b996-41c3-4c32-baa5-d0bb64eadc95" marker=true decision=continue ownership=unset
MISSING: path=maybeCompactAgentHarnessSession capabilityUsed=true rawFailure="missing_thread_binding" marker=true decision=continue ownership=unset
DUAL TRIGGER: missing=OK ✓ stale=OK ✓
driverA finished; cleaned up only driver-spawned codex app-servers
```

Annotations:
- `A0`: registry-owned private capability confirmed (`resolveCodexAgentHarnessNativeCompaction` returns a function for the registered codex harness, `undefined` for a non-owner) — this is the ownership authority the recovery marker keys on (registry.ts:100-115).
- `A2` STALE: the RAW result carries the genuine codex `-32600` message `"thread not found: <id>"` and `failure.reason="stale_thread_binding"`; the production resolver then stamps `nativeHarnessBindingRecovery=true`; the production predicate returns `true`; the consumer branch decides CONTINUE. `owner O reused, no new spawn: true` shows the dispatch used the same live app-server.
- `A3` MISSING: genuine `missing_thread_binding` from the absent-binding short-circuit → same marker → CONTINUE.
- `A4` NC1/NC2 prove forged markers are stripped; NC3 proves that without the native-capability dispatch (transcript-byte preflight analog) no marker is produced and the turn would THROW — i.e. the marker cannot be reached off the required-preflight native route.
- `Angie(i)`: `resolveSessionRuntimeOwnership` → `undefined` for both post-continue states ⇒ `expectedSessionRuntimeOwnership` UNSET ⇒ the Codex ownership fence stays dormant and the rotation chain proceeds.

---

## 3. Phase B — full text of `run-B.redacted.log`

Physical closed-client rejection at the retain gate.

```
HEAD=9737873b185fe9f6f65e884f990f2cf3369f65ad
node=v26.5.0

================================================================
== B1 — acquire a REAL shared codex app-server client via the production pool
================================================================
[agent/embedded] codex app-server stderr: WARNING: proceeding, even though we could not create PATH aliases: Refusing to create helper binaries under temporary dir "$HOME/.openclaw/tmp" (codex_home: AbsolutePathBuf("$HOME/.openclaw/tmp/proof120443v3-B-mUo3Qy/codex-home"))
   client: pid=91245 instanceId=352832b1-d9a3-4a9c-b7be-0edef5b34842 serverVersion=0.153.4
   processIdentity={"clientId":"352832b1-d9a3-4a9c-b7be-0edef5b34842","command":"/Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js","argsFingerprint":"2b55a93772528206b0974e048ad60708f3200ce757bf7315204312c3cf790f03","commandSource":"resolved-managed","managedCommandOrder":"desktop-first","nativeCommand":"/Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4-darwin-arm64/node_modules/@openai/codex/vendor/aarch64-apple-darwin/bin/codex","serverVersion":"0.153.4","userAgent":"openclaw/0.153.4 (Mac OS 15.3.1; arm64) unknown (openclaw; 2026.9.2)"}
[ps] B1 client acquired (alive): pid=91245(alive)

================================================================
== B2 — POSITIVE CONTROL: healthy client -> retain GRANTS a lease
================================================================
   client.getCloseError() (healthy) => undefined
   retainSharedCodexAppServerClientByInstanceId(idC) [healthy] => GRANTED (entry present, keyed by instanceId, registry flags unset, getCloseError undefined)
     leased client is the same process: true instanceId match: true
   (lease released; NO retire called — registry closeWhenIdle/closeError remain unset)

================================================================
== B3 — PHYSICALLY close the client via the production close() API (real transport close)
================================================================
   getCloseError() before close() => undefined
   client.close() called (production close path).
   getCloseError() after close() => "codex app-server client is closed" (REAL transport-close error, latched synchronously by markClosed @client.ts:1043-1051)

================================================================
== B4 — retain the SAME closed client -> retain gate REJECTS before retention (:1359 getCloseError conjunct)
================================================================
   retainSharedCodexAppServerClientByInstanceId(idC) [closed] => undefined (REJECTED before retention)
   ATTRIBUTION: between B2 (GRANTED) and B4 (REJECTED) the ONLY changed state is
     client.getCloseError(): undefined -> REAL error.
     No retire was called, so entry.closeWhenIdle and entry.closeError are unchanged (unset).
     getInstanceId() is stable (true), so the id-match conjunct is unchanged.
     => the rejecting conjunct is the F2-added `client.getCloseError()` at shared-client.ts:1359.
[ps] B4 after close (process gone/closing): pid=91245(gone)
   client process alive after close()? false
   retainSharedCodexAppServerClientByInstanceId(idC) [post-exit] => undefined (still REJECTED; closed client never handed out)

================================================================
== B — CONTRAST with the acquire gate + SUMMARY
================================================================
   Acquire/registration capture gate captureSharedClientRegistration (shared-client.ts:1318-1330)
   already carried `!entry.closeError && !client.getCloseError()` at :1327-1328; the F2 fix
   (99383b361b) added the same authoritative `client.getCloseError()` check to the KEYED retain
   gate retainSharedCodexAppServerClientByInstanceId at :1359, so a client that closes between
   the keyed lookup and the lease (registry flags not yet reconciled) is skipped and the caller
   acquires fresh instead of leasing a client whose next request rejects as non-recoverable.
   RESULT: healthy retain GRANTED; physically-closed retain REJECTED via :1359 getCloseError() conjunct; closed client never handed out.
driverB finished; cleaned up only driver-spawned codex app-servers
```

Annotations:
- `B2` vs `B4` is a clean before/after: the healthy client is leasable; after a real
  `client.close()` (which latches `getCloseError()` synchronously but does not touch the
  registry entry's close flags — those are set only by retire), the same keyed retain
  returns `undefined`. Since the only changed state is `getCloseError()`, the rejection is
  attributable to the `:1359` conjunct.
- ps confirms the process is gone after `close()`; the post-exit retain still rejects, so a
  physically closed client is never handed back to a caller.

---

## 4. Process snapshots — full text of `ps-snapshots.redacted.log`

Codex process identity before/after each heavy step (owner acquisition, kill, close). Each
`app-server --listen stdio://` process is the vendored 0.153.4 launcher (`bin/codex.js`)
plus its native `vendor/aarch64-apple-darwin/bin/codex` child.

```
### 2026-09-06T13:35:45.407Z [phaseA] A1 owner acquired
  PID  PPID STAT    RSS COMMAND
79915 79852 Ss    47632 node /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js app-server --listen stdio://
-- pgrep 'app-server' --
79915 node /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js app-server --listen stdio://
79940 /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4-darwin-arm64/node_modules/@openai/codex/vendor/aarch64-apple-darwin/bin/codex app-server --listen stdio://

### 2026-09-06T13:35:45.500Z [phaseA] A2 before kill
  PID  PPID STAT    RSS COMMAND
79915 79852 Ss    47632 node /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js app-server --listen stdio://
-- pgrep 'app-server' --
79915 node /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js app-server --listen stdio://
79940 /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4-darwin-arm64/node_modules/@openai/codex/vendor/aarch64-apple-darwin/bin/codex app-server --listen stdio://

### 2026-09-06T13:35:45.749Z [phaseA] A2 after kill (owner GONE)
pid 79915: (not running)
-- pgrep 'app-server' --

### 2026-09-06T13:48:09.844Z [phaseA] A1 owner acquired
  PID  PPID STAT    RSS COMMAND
86897 86705 Ss    47504 node /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js app-server --listen stdio://
-- pgrep 'app-server --listen' --
86897 node /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js app-server --listen stdio://
86912 /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4-darwin-arm64/node_modules/@openai/codex/vendor/aarch64-apple-darwin/bin/codex app-server --listen stdio://

### 2026-09-06T13:48:10.471Z [phaseA] A2 after stale dispatch (owner alive)
  PID  PPID STAT    RSS COMMAND
86897 86705 Ss    37408 node /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js app-server --listen stdio://
-- pgrep 'app-server --listen' --
86897 node /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js app-server --listen stdio://
86912 /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4-darwin-arm64/node_modules/@openai/codex/vendor/aarch64-apple-darwin/bin/codex app-server --listen stdio://

### 2026-09-06T13:48:10.493Z [phaseA] A2b before kill
  PID  PPID STAT    RSS COMMAND
86897 86705 Ss    37408 node /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js app-server --listen stdio://
-- pgrep 'app-server --listen' --
86897 node /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js app-server --listen stdio://
86912 /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4-darwin-arm64/node_modules/@openai/codex/vendor/aarch64-apple-darwin/bin/codex app-server --listen stdio://

### 2026-09-06T13:48:10.723Z [phaseA] A2b after kill (owner GONE)
pid 86897: (not running)
-- pgrep 'app-server --listen' --

### 2026-09-06T13:53:45.993Z [phaseA] A1 owner acquired
  PID  PPID STAT    RSS COMMAND
90066 89948 Ss    48480 node /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js app-server --listen stdio://
-- pgrep 'app-server --listen' --
90066 node /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js app-server --listen stdio://
90079 /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4-darwin-arm64/node_modules/@openai/codex/vendor/aarch64-apple-darwin/bin/codex app-server --listen stdio://

### 2026-09-06T13:53:46.632Z [phaseA] A2 after stale dispatch (owner alive)
  PID  PPID STAT    RSS COMMAND
90066 89948 Ss    40752 node /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js app-server --listen stdio://
-- pgrep 'app-server --listen' --
90066 node /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js app-server --listen stdio://
90079 /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4-darwin-arm64/node_modules/@openai/codex/vendor/aarch64-apple-darwin/bin/codex app-server --listen stdio://

### 2026-09-06T13:53:46.654Z [phaseA] A2b before kill
  PID  PPID STAT    RSS COMMAND
90066 89948 Ss    40752 node /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js app-server --listen stdio://
-- pgrep 'app-server --listen' --
90066 node /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js app-server --listen stdio://
90079 /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4-darwin-arm64/node_modules/@openai/codex/vendor/aarch64-apple-darwin/bin/codex app-server --listen stdio://

### 2026-09-06T13:53:46.882Z [phaseA] A2b after kill (owner GONE)
pid 90066: (not running)
-- pgrep 'app-server --listen' --

### 2026-09-06T13:55:39.638Z [phaseB] B1 client acquired (alive)
  PID  PPID STAT    RSS COMMAND
91245 91130 Ss    47088 node /Volumes/MacDataXY/data/tmp/thomas/openclaw-pr-workdirs/pr-120443/node_modules/.pnpm/@openai+codex@0.153.4/node_modules/@openai/codex/bin/codex.js app-server --listen stdio://

### 2026-09-06T13:55:39.844Z [phaseB] B4 after close (process gone/closing)
pid 91245: (not running)
```

(The log accumulated across the driverA iterations while the trace was being brought up
to the exact `-32600` contract; the final, clean Phase A run is owner pid `90066`,
ghost thread `5b88b996-…`, matching `run-A.redacted.log`. Phase B is pid `91245`,
matching `run-B.redacted.log`.)

---

## 5. Build / dist provenance

```
dist/build-info.json:
{
  "version": "2026.9.2",
  "commit": "9737873b185fe9f6f65e884f990f2cf3369f65ad",
  "builtAt": "2026-09-06T13:20:21.670Z",
  "buildId": "2026.9.2-9737873b185f-2026-09-06T13-20-21.670Z"
}

git rev-parse HEAD (before and after): 9737873b185fe9f6f65e884f990f2cf3369f65ad
git status --short: " M pnpm-lock.yaml"   (pre-existing residue; no tracked source modified)
```


**(d) Model-completion limitation, disclosed.** The (c) batch deliberately ran without completing a model turn: the app-servers were spawned into an isolated throwaway `CODEX_HOME` with api-key auth and no real turn was run, so terminal states that require a completed turn (a *successful* native compaction commit, post-compaction token accounting) were not captured. Every behavior this fix changes — trigger reachability, native-capability dispatch, marker stamping and stripping, the consumer safe-continue decision, and the retain-gate close rejection — is independent of turn completion. The failure results used in (c) are the genuine `-32600` / absent-binding failures produced by real production code, not injected values. Earlier credential-free batches at prior heads carried the same limitation (placeholder api-key → 401 model turn); it is stated here rather than hidden.

**(e) SDK-isolation commit, CI-fix commit, and final head `9737873b18`.** The 5th commit narrowed the plugin-SDK exported compact-result contract (see the SDK-isolation bullet above), after which the whole chain was cleanly rebased onto current upstream `main`; a 6th commit then removed the orphaned `AgentHarnessCompactResult` export in `src/agents/harness/types.ts` (dropping only the `export` keyword — the alias remains for internal use) and repointed one test import to the SDK-narrowed type, fixing the `check-dependencies` Knip unused-export scan that the narrowing had orphaned. Final head: `9737873b18` (6-commit chain on base `b75423c2fc`). That commit is a type-only plugin-SDK change (no runtime code path is altered) and was verified on the final rebased tree: `pnpm tsgo:core`, `tsgo:core:test`, `tsgo:extensions`, `tsgo:extensions:test` all exit 0; `oxlint` on the changed files is clean; a compile-time contract test locks the marker out of the exported type (discriminative — it fails typecheck when the marker is present and passes when it is omitted); and the focused suites re-run green (`compact.hooks.test.ts` 182, `compaction-recovery.test.ts` 12, `agent-runner-memory.test.ts` 117, `compact.native-cli.test.ts` 3, `shared-client.test.ts` + `compact.test.ts` 175, plugin-SDK `agent-harness-runtime.test.ts` + `api-baseline.test.ts` 46, plugin-SDK contract guardrails 44). Gates were re-run green on this final tree: deadcode export + unused-file scans exit 0; `oxlint` on the changed files exit 0; `pnpm tsgo:core` and `tsgo:core:test` exit 0; focused vitest suites (serial) 9 files / 213 tests / 0 failures, including `selection.test.ts` (145) and the plugin-SDK suites (46 + 44 contract guardrails). The exact-head runtime/production-path proof of (c) is now **captured at this final head**.


