### PR TITLE
fix(slack): guard directory cursor pagination against repeated cursors

### DIFF
--- a/extensions/slack/src/directory-live.test.ts
+++ b/extensions/slack/src/directory-live.test.ts
@@ -1,0 +1,67 @@
+// Slack tests cover directory live behavior.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listSlackDirectoryGroupsLive, listSlackDirectoryPeersLive } from "./directory-live.js";
+
+const slackClientMocks = vi.hoisted(() => ({
+  createSlackLookupClient: vi.fn(),
+  usersList: vi.fn(),
+  conversationsList: vi.fn(),
+}));
+
+vi.mock("./client.js", () => ({
+  createSlackLookupClient: slackClientMocks.createSlackLookupClient,
+}));
+
+const params = { cfg: { channels: { slack: { botToken: "xoxb-test" } } } };
+
+describe("slack directory live cursor pagination", () => {
+  beforeEach(() => {
+    slackClientMocks.usersList.mockReset();
+    slackClientMocks.conversationsList.mockReset();
+    slackClientMocks.createSlackLookupClient.mockReset().mockReturnValue({
+      users: { list: slackClientMocks.usersList },
+      conversations: { list: slackClientMocks.conversationsList },
+    });
+  });
+
+  it("lists peers across advancing cursors", async () => {
+    slackClientMocks.usersList
+      .mockResolvedValueOnce({
+        members: [{ id: "U1", name: "one" }],
+        response_metadata: { next_cursor: "cursor-1" },
+      })
+      .mockResolvedValueOnce({
+        members: [{ id: "U2", name: "two" }],
+        response_metadata: { next_cursor: "" },
+      });
+
+    const rows = await listSlackDirectoryPeersLive(params);
+
+    expect(rows.map((row) => row.id)).toEqual(["user:U1", "user:U2"]);
+    expect(slackClientMocks.usersList).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a repeated users.list cursor instead of paginating forever", async () => {
+    slackClientMocks.usersList.mockResolvedValue({
+      members: [],
+      response_metadata: { next_cursor: "cursor-loop" },
+    });
+
+    await expect(listSlackDirectoryPeersLive(params)).rejects.toThrow(
+      "Slack cursor pagination repeated a cursor",
+    );
+    expect(slackClientMocks.usersList).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a repeated conversations.list cursor instead of paginating forever", async () => {
+    slackClientMocks.conversationsList.mockResolvedValue({
+      channels: [],
+      response_metadata: { next_cursor: "cursor-loop" },
+    });
+
+    await expect(listSlackDirectoryGroupsLive(params)).rejects.toThrow(
+      "Slack cursor pagination repeated a cursor",
+    );
+    expect(slackClientMocks.conversationsList).toHaveBeenCalledTimes(2);
+  });
+});

--- a/extensions/slack/src/directory-live.ts
+++ b/extensions/slack/src/directory-live.ts
@@ -11,6 +11,7 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveSlackAccount } from "./accounts.js";
 import { createSlackLookupClient } from "./client.js";
+import { collectSlackCursorPages } from "./cursor-pages.js";
 
 type SlackUser = NonNullable<UsersListResponse["members"]>[number];
 type SlackChannel = NonNullable<ConversationsListResponse["channels"]>[number];
@@ -95,20 +96,12 @@ export async function listSlackDirectoryPeersLive(
     return [];
   }
   const query = normalizeQuery(params.query);
-  const members: SlackUser[] = [];
-  let cursor: string | undefined;
-
-  do {
-    const res = await client.users.list({
-      limit: 200,
-      cursor,
-    });
-    if (Array.isArray(res.members)) {
-      members.push(...res.members);
-    }
-    const next = res.response_metadata?.next_cursor?.trim();
-    cursor = next ? next : undefined;
-  } while (cursor);
+  // Route through the shared cursor guard: a repeated or endless next_cursor
+  // (buggy proxy or Slack edge case) must fail instead of paginating forever.
+  const members = await collectSlackCursorPages({
+    fetchPage: (cursor) => client.users.list({ limit: 200, cursor }),
+    collectPageItems: (res) => (Array.isArray(res.members) ? res.members : []),
+  });
 
   const filtered = members.filter((member) => {
     const name = member.profile?.display_name || member.profile?.real_name || member.real_name;
@@ -141,22 +134,16 @@ export async function listSlackDirectoryGroupsLive(
     return [];
   }
   const query = normalizeQuery(params.query);
-  const channels: SlackChannel[] = [];
-  let cursor: string | undefined;
-
-  do {
-    const res = await client.conversations.list({
-      types: "public_channel,private_channel",
-      exclude_archived: false,
-      limit: 1000,
-      cursor,
-    });
-    if (Array.isArray(res.channels)) {
-      channels.push(...res.channels);
-    }
-    const next = res.response_metadata?.next_cursor?.trim();
-    cursor = next ? next : undefined;
-  } while (cursor);
+  const channels = await collectSlackCursorPages({
+    fetchPage: (cursor) =>
+      client.conversations.list({
+        types: "public_channel,private_channel",
+        exclude_archived: false,
+        limit: 1000,
+        cursor,
+      }),
+    collectPageItems: (res) => (Array.isArray(res.channels) ? res.channels : []),
+  });
 
   const filtered = channels.filter((channel) => {
     const name = normalizeOptionalLowercaseString(channel.name);


### PR DESCRIPTION
## Summary

`fix(slack): route directory users.list/conversations.list pagination through the shared repeated-cursor guard so a looping next_cursor cannot hang directory queries`

## What Problem This Solves

Slack directory queries (`listSlackDirectoryPeersLive`, `listSlackDirectoryGroupsLive` — used by directory lookup and channel self-checks) paginate the Slack Web API with a hand-rolled `do/while` that follows `response_metadata.next_cursor` until it comes back empty. Slack documents an empty cursor as the only normal termination signal, but nothing guards the abnormal ones: if the API (or an intermediate proxy, gateway, or SDK edge) keeps returning the **same non-empty cursor** — or endless distinct cursors — the loop never exits, and the `members`/`channels` arrays grow without bound. The directory request hangs forever while memory climbs.

This is not hypothetical hardening of an unreachable path: the repository already treats unbounded cursor pagination as a real failure mode. `extensions/slack/src/cursor-pages.ts` (`collectSlackCursorPages`) exists precisely for this invariant — it throws on a repeated cursor and caps total pages — and it is already used for the **same two endpoints** in `resolve-users.ts` and `resolve-channels.ts`. `directory-live.ts` is the only consumer of these endpoints that still hand-rolls the loop.

**Code evidence**: in `extensions/slack/src/directory-live.ts` (main, before this fix):

- `extensions/slack/src/directory-live.ts:101-111` — `do { users.list(...) } while (cursor)` with no repeated-cursor detection and no page cap.
- `extensions/slack/src/directory-live.ts:147-159` — the identical pattern for `conversations.list`.
- Compare `extensions/slack/src/cursor-pages.ts:20-38` — `collectSlackCursorPages` keeps a `seenCursors` set (throw on repeat) and enforces `SLACK_CURSOR_PAGE_LIMIT`.

Minimal reproduction: stub only the network wire to return `{ ok: true, members: [], response_metadata: { next_cursor: "SAME_CURSOR_FOREVER" } }` for every `users.list` call — the real `listSlackDirectoryPeersLive` keeps issuing requests indefinitely (the proof below stops it at 501 calls with a harness cap). See the Evidence section below.

## Root Cause

- The unguarded loops predate the current history root (the file arrives unchanged at the boundary).
- Violated invariant: every cursor pagination loop over external API data must terminate even when the cursor stream is pathological — repeated cursors are a protocol violation and must fail fast; endless distinct cursors must hit a page bound. The shared helper encodes exactly this contract, but these two call sites were never migrated to it.
- Trigger condition: a Slack workspace (or a proxy between gateway and Slack) whose `users.list`/`conversations.list` responses repeat a non-empty `next_cursor`, then any directory query.

## Why This Fix

- Option A (chosen): replace both hand-rolled loops with `collectSlackCursorPages` — the guard the repo already built and tested for this exact invariant, already used on the same endpoints elsewhere. The change deletes code and aligns all consumers on one behavior; item collection, filtering, ranking, and `params.limit` slicing are untouched.
- Option B: add a local repeated-cursor set and page cap inside `directory-live.ts` — rejected: it forks the guard into a second implementation that can drift (the repo's own comment in `cursor-pages.ts` calls this backstop "deliberately" shared).
- Option C: leave the loops and document that directory queries can hang — rejected: an unbounded await inside a user-facing lookup is a liveness bug, not a doc issue.

## User Impact

- Affected scenario: Slack directory queries against a workspace/proxy that returns repeating or endless `next_cursor` values.
- Before: the query paginates forever (in the proof, 501 sequential API calls with no end until the harness cap), memory grows with the accumulated arrays, and the caller never gets an answer.
- After: the query fails fast with `Slack cursor pagination repeated a cursor after 2 pages`, surfacing the upstream misbehavior instead of hiding it.
- Behavior change: none for healthy workspaces — the honest multi-page control in the proof resolves with identical results before and after.

## Evidence

No mocked modules: the proof runs the real `listSlackDirectoryPeersLive`/`listSlackDirectoryGroupsLive` with the real Slack lookup client (`createSlackLookupClient` → `@slack/web-api`); only the network wire (`globalThis.fetch`, the exact boundary where Slack/proxy data enters) is stubbed. The stub repeats one non-empty cursor but stops offering it after 500 calls (a proof-harness cap, not a code path) so the run terminates; S3 is an honest two-page directory control. `directory-live.ts` and `cursor-pages.ts` are byte-identical between the main checkout used below and the current PR base.

### Before (on main)

```bash
$ node --import tsx proof-slack-directory-pagination.mjs   # main: bare do/while, no cursor guard
S1 peers, repeated next_cursor: RESOLVED after 501 API call(s)
BAD  S1: loop only ended because the proof cap stopped the cursor at 500
S2 groups, repeated next_cursor: RESOLVED after 501 API call(s)
BAD  S2: loop only ended because the proof cap stopped the cursor at 500
S3 control, honest two-page users.list: RESOLVED after 2 API call(s)
   entries: ["user:U1","user:U2"]
BEHAVIOR: FAIL - directory pagination spins on a repeated Slack cursor
exit=1
```

### After (with fix)

```bash
$ node --import tsx proof-slack-directory-pagination.mjs   # HEAD: collectSlackCursorPages guards both loops
S1 peers, repeated next_cursor: REJECTED after 2 API call(s)
   error: Slack cursor pagination repeated a cursor after 2 pages
S2 groups, repeated next_cursor: REJECTED after 2 API call(s)
   error: Slack cursor pagination repeated a cursor after 2 pages
S3 control, honest two-page users.list: RESOLVED after 2 API call(s)
   entries: ["user:U1","user:U2"]
BEHAVIOR: PASS - repeated cursors fail fast; honest paginated directories still resolve
exit=0
```

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run extensions/slack/src/directory-live.test.ts extensions/slack/src/cursor-pages.test.ts` -- 9/9 tests passed, including the new regression tests `rejects a repeated users.list cursor instead of paginating forever` and `rejects a repeated conversations.list cursor instead of paginating forever` (both fail fast after exactly 2 API calls) plus the advancing-cursor control.
- `pnpm exec oxfmt --check extensions/slack/src/directory-live.ts extensions/slack/src/directory-live.test.ts` passed; `git diff --check` passed.
- Manual verification (the proof above):
  1. On main, both loops only stop because the proof harness cuts the cursor off at 500 pages -- FAIL.
  2. With the fix, both fail fast at 2 calls with the shared guard's repeated-cursor error, and the honest two-page control is unchanged -- PASS.

Note: proof and tests were run with Node 24.19.0.
