### PR TITLE
fix(agents): validate MCP App resource blob encoding before rendering

### DIFF
--- a/src/agents/mcp-ui-resource.test.ts
+++ b/src/agents/mcp-ui-resource.test.ts
@@ -147,6 +147,83 @@ describe("MCP App UI resources", () => {
     }
   });
 
+  it("rejects blob content that is not valid base64", async () => {
+    for (const blob of ["<p>hello mcp app</p>", "!!!!", "SGVsbG==", "SGVsb"]) {
+      const result = await fetchMcpAppView({
+        runtime: runtime(async () => ({
+          contents: [{ uri: "ui://demo/app", mimeType: MCP_APP_RESOURCE_MIME_TYPE, blob }],
+        })),
+        serverName: "demo",
+        toolName: "show",
+        uiResourceUri: "ui://demo/app",
+        toolInput: {},
+        toolResult: { content: [] },
+      });
+      expect(result).toBeUndefined();
+    }
+  });
+
+  it("preserves valid empty base64 blobs", async () => {
+    const sessionRuntime = runtime(async () => ({
+      contents: [{ uri: "ui://demo/app", mimeType: MCP_APP_RESOURCE_MIME_TYPE, blob: "" }],
+    }));
+    const result = await fetchMcpAppView({
+      runtime: sessionRuntime,
+      serverName: "demo",
+      toolName: "show",
+      uiResourceUri: "ui://demo/app",
+      toolInput: {},
+      toolResult: { content: [] },
+    });
+    expect(result?.viewId).toMatch(/^mcp-app-/u);
+    expect(getMcpAppViewLease(result?.viewId ?? "", sessionRuntime)?.html).toBe("");
+  });
+
+  it("rejects blob content that is not valid UTF-8", async () => {
+    const result = await fetchMcpAppView({
+      runtime: runtime(async () => ({
+        contents: [
+          {
+            uri: "ui://demo/app",
+            mimeType: MCP_APP_RESOURCE_MIME_TYPE,
+            blob: Buffer.from([0xff, 0xfe, 0xfd, 0x80]).toString("base64"),
+          },
+        ],
+      })),
+      serverName: "demo",
+      toolName: "show",
+      uiResourceUri: "ui://demo/app",
+      toolInput: {},
+      toolResult: { content: [] },
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("decodes valid base64 blob content, including unpadded input", async () => {
+    const html = "<html>blob demo</html>";
+    const blobs = [
+      Buffer.from(html, "utf8").toString("base64"),
+      // Same payload in unpadded form (padding stripped), which the shared
+      // canonicalizer accepts.
+      Buffer.from(html, "utf8").toString("base64").replace(/=+$/, ""),
+    ];
+    for (const blob of blobs) {
+      const sessionRuntime = runtime(async () => ({
+        contents: [{ uri: "ui://demo/app", mimeType: MCP_APP_RESOURCE_MIME_TYPE, blob }],
+      }));
+      const result = await fetchMcpAppView({
+        runtime: sessionRuntime,
+        serverName: "demo",
+        toolName: "show",
+        uiResourceUri: "ui://demo/app",
+        toolInput: {},
+        toolResult: { content: [] },
+      });
+      expect(result?.viewId).toMatch(/^mcp-app-/u);
+      expect(getMcpAppViewLease(result?.viewId ?? "", sessionRuntime)?.html).toBe(html);
+    }
+  });
+
   it("bounds concurrent app bridge requests", () => {
     const view = {
       requestWindowStartedAtMs: 0,

--- a/src/agents/mcp-ui-resource.ts
+++ b/src/agents/mcp-ui-resource.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { canonicalizeBase64 } from "@openclaw/media-core/base64";
 import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { formatErrorMessage } from "../infra/errors.js";
 import { logWarn } from "../logger.js";
@@ -178,11 +179,25 @@ function decodeResourceHtml(content: Record<string, unknown>): string {
   if (content.blob.length > maxEncodedBytes) {
     throw new Error(`MCP App resource exceeds ${MCP_APP_RESOURCE_MAX_BYTES} bytes`);
   }
-  const decoded = Buffer.from(content.blob, "base64");
+  // Node's lenient decoders would render garbled HTML with no error; validate
+  // strictly before the view is cached. Empty blobs stay valid (zero bytes),
+  // matching the lenient decode and the empty-text path.
+  if (content.blob.trim() === "") {
+    return "";
+  }
+  const normalizedBlob = canonicalizeBase64(content.blob);
+  if (normalizedBlob === undefined) {
+    throw new Error("MCP App resource blob is not valid base64");
+  }
+  const decoded = Buffer.from(normalizedBlob, "base64");
   if (decoded.byteLength > MCP_APP_RESOURCE_MAX_BYTES) {
     throw new Error(`MCP App resource exceeds ${MCP_APP_RESOURCE_MAX_BYTES} bytes`);
   }
-  return decoded.toString("utf8");
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(decoded);
+  } catch {
+    throw new Error("MCP App resource blob is not valid UTF-8");
+  }
 }
 
 async function resolveListingUiMeta(


### PR DESCRIPTION
## Summary

`fix(agents): validate MCP App resource blob as strict base64 and decode it as fatal UTF-8 so malformed payloads are rejected instead of silently rendered`

## What Problem This Solves

When an MCP tool result references a UI resource (`ui://...`), `fetchMcpAppView` reads the resource from the external MCP server and caches the HTML into the in-memory view store for rendering in the sandboxed iframe. For `blob` content (base64, per the MCP spec), the decode path uses Node's **lenient** base64 decoder and a **non-fatal** UTF-8 conversion: invalid base64 characters are silently dropped, and invalid UTF-8 sequences silently become `` replacement characters. The text path, the missing-content path, and both size caps all fail loudly; only the blob's actual encoding is never checked.

The directly reachable case on the real stdio transport: an MCP server returns `blob` that **is** valid base64 (so it passes the MCP SDK's own schema gate) but decodes to bytes that are not valid UTF-8 — a server-side encoding bug, a binary payload mislabeled as HTML, or truncation. Those bytes are converted with U+FFFD replacements and cached as a legitimate app view with **no error anywhere**; the user sees a garbled or blank app and there is nothing to act on. (On the stdio SDK transport, blobs that are not base64 at all are already rejected by the SDK schema — shown in the Evidence trace — so the strict-base64 half of this fix is defense in depth for that boundary; the fatal-UTF-8 half is the reachable repair.)

**Code evidence**: in `src/agents/mcp-ui-resource.ts` (main, before this fix):

- `src/agents/mcp-ui-resource.ts:181` — `Buffer.from(content.blob, "base64")` — Node's decoder ignores invalid characters instead of rejecting them.
- `src/agents/mcp-ui-resource.ts:185` — `decoded.toString("utf8")` — non-fatal conversion turns invalid sequences into U+FFFD with no signal.
- Compare `packages/media-core/src/base64.ts` — `canonicalizeBase64` is the repo's shared validating canonicalizer (alphabet, padding, pad bits), already used for camera/media payloads.

Minimal reproduction: serve `blob: <base64 of 0xFF 0xFE 0xFD 0x80>` from a real stdio MCP server and run the real `fetchMcpAppView` over the real session MCP runtime — the view is accepted and the cached `html` is `""`. See the Evidence section below.

## Root Cause

- The lenient decode predates the current history root (the file arrives unchanged at the boundary).
- Violated invariant: untrusted external input entering the persistence/rendering pipeline must be validated for encoding validity, not just for size. `Buffer.from(x, "base64")` and `buf.toString("utf8")` are lossy, non-validating APIs — the two existing size caps bound *how much* data comes in but say nothing about *whether* it is what it claims to be.
- Trigger condition: any MCP server returning `mimeType: "text/html;profile=mcp-app"` with a `blob` whose decoded bytes are not valid UTF-8 (reachable today), or — on runtimes without the SDK schema gate — content that is not well-formed base64 at all.

## Why This Fix

- Option A (chosen): validate with the repo's shared `canonicalizeBase64` (whitespace-tolerant, accepts valid **unpadded** input, checks pad bits — no custom regex to drift) and decode with `new TextDecoder("utf-8", { fatal: true })`. On failure, throw inside `decodeResourceHtml`, which `fetchMcpAppView` already converts into a logged warning plus a rejected view (`undefined`) — the same failure mode as oversized/mistyped resources. Empty blobs (`blob: ""`) remain valid (zero bytes), exactly as on main and as in the adjacent empty-`text` path.
- Option B: keep the lenient decode but validate the result heuristically (e.g. "must contain `<`") — rejected: content sniffing is guesswork; the encoding itself is the contract and can be checked exactly.
- Option C: hand-rolled strict base64 regex (padded-only) — rejected during review: it rejects valid unpadded input that the shared canonicalizer accepts, and duplicates logic the repo already maintains in `media-core`.

## User Impact

- Affected scenario: MCP App servers that return malformed `blob` resource content (server bugs, mislabeled binary payloads, proxies, hand-rolled servers).
- Before: base64 of non-UTF-8 bytes is cached as U+FFFD-mangled HTML and rendered in the sandboxed iframe with zero diagnostics.
- After: view preparation fails with a clear logged warning (`MCP App resource blob is not valid base64` / `not valid UTF-8`) and no view is rendered.
- Behavior change: none for well-formed servers — padded, unpadded, and empty valid blobs behave exactly as before (all three covered by controls in tests and in the transport proof).

## Evidence

No mocked modules and no structural stand-ins: the proof spawns a **real raw-JSON-RPC stdio MCP server** process and connects through the repository's **real session MCP runtime** (`getOrCreateSessionMcpRuntime` → stdio transport → `runtime.readResource`), then calls the real `fetchMcpAppView`. The server logs every inbound JSON-RPC message, producing the stdio resource-read trace shown inline. Scenarios: S1 raw-HTML `blob` (not base64 at all), S2 base64 of invalid-UTF-8 bytes (the reachable bug), S3 empty-`blob` control, S4 padded valid control, S5 unpadded valid control. `mcp-ui-resource.ts` is byte-identical between the main checkout used below and the current PR base.

### Before (on main)

```bash
$ node --import tsx proof-mcp-app-blob-transport.mjs   # main: lenient base64 + non-fatal utf8
S1 raw-HTML blob (malformed base64): view REJECTED -> OK      # rejected upstream by the MCP SDK schema gate
   stdio trace: recv resources/read uri=ui://proof/app
S2 invalid-UTF-8 blob: view ACCEPTED html="" -> BAD   # passes the SDK gate, silently mangled by main's decoder
   stdio trace: recv resources/read uri=ui://proof/app | recv resources/list
S3 empty blob control: view ACCEPTED html="" -> OK
   stdio trace: recv resources/read uri=ui://proof/app | recv resources/list
S4 padded valid control: view ACCEPTED html="<html>blob demo</html>" -> OK
   stdio trace: recv resources/read uri=ui://proof/app | recv resources/list
S5 unpadded valid control: view ACCEPTED html="<html>blob demo</html>" -> OK
   stdio trace: recv resources/read uri=ui://proof/app | recv resources/list
BEHAVIOR: FAIL - malformed MCP App blobs are accepted and/or valid blobs break
exit=1
```

### After (with fix)

```bash
$ node --import tsx proof-mcp-app-blob-transport.mjs   # HEAD: canonicalizeBase64 + fatal UTF-8 decode
S1 raw-HTML blob (malformed base64): view REJECTED -> OK
   stdio trace: recv resources/read uri=ui://proof/app
[mcp-app] failed to prepare ui://proof/app from "proof": MCP App resource blob is not valid UTF-8
S2 invalid-UTF-8 blob: view REJECTED -> OK
   stdio trace: recv resources/read uri=ui://proof/app
S3 empty blob control: view ACCEPTED html="" -> OK
   stdio trace: recv resources/read uri=ui://proof/app | recv resources/list
S4 padded valid control: view ACCEPTED html="<html>blob demo</html>" -> OK
   stdio trace: recv resources/read uri=ui://proof/app | recv resources/list
S5 unpadded valid control: view ACCEPTED html="<html>blob demo</html>" -> OK
   stdio trace: recv resources/read uri=ui://proof/app | recv resources/list
BEHAVIOR: PASS - malformed blobs rejected over real stdio MCP transport; empty/unpadded/padded valid blobs unchanged
exit=0
```

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run src/agents/mcp-ui-resource.test.ts` -- 28/28 tests passed, including the regression tests `rejects blob content that is not valid base64` (raw HTML, `!!!!`, bad pad bits, `%4==1` length), `rejects blob content that is not valid UTF-8`, `preserves valid empty base64 blobs`, and `decodes valid base64 blob content, including unpadded input`, alongside the existing view-store suite.
- `pnpm exec oxfmt --check src/agents/mcp-ui-resource.ts src/agents/mcp-ui-resource.test.ts` passed; `git diff --check` passed.
- Manual verification (the proof above):
  1. On main, base64 of invalid-UTF-8 bytes passes the SDK schema gate and is silently cached as `` with no error -- FAIL.
  2. With the fix, the same payload is rejected with a logged warning, while empty, padded-valid, and unpadded-valid blobs are byte-identical to main -- PASS.

Note: proof and tests were run with Node 24.19.0; the stdio MCP server is a ~70-line raw JSON-RPC process written into a temp dir by the proof itself, and its trace log is printed inline above.
