### PR TITLE
fix(ui): keep session text stable on hover

### DIFF
--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -3,6 +3,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { normalizeChatType } from "../../../channels/chat-type.js";
 import { logMessageQueuedWithBacklogPolicy } from "../../../logging/diagnostic-runtime.js";
 import { channelRouteDedupeKey } from "../../../plugin-sdk/channel-route.js";
+import { createDeferred } from "../../../shared/deferred.js";
 import {
   applyQueueDropPolicy,
   countPendingQueueItems,
@@ -158,10 +159,7 @@ export function enqueueFollowupRun(
     if (!markFollowupRunEnqueued(run)) {
       return false;
     }
-    let settle = (_accepted: boolean) => {};
-    const acceptance = new Promise<boolean>((resolve) => {
-      settle = resolve;
-    });
+    const { promise: acceptance, resolve: settle } = createDeferred<boolean>();
     run.steerPending = { predecessor: queue.steerAcceptanceTail, settle };
     queue.steerAcceptanceTail = acceptance;
     appendQueueItem({
@@ -364,10 +362,10 @@ function consumeParkedFollowupRun(key: string, run: FollowupRun): boolean {
 }
 
 type ParkedSteerReservation = {
-  admit(): Promise<"steer" | "fallback" | "cancelled">;
+  admit: () => Promise<"steer" | "fallback" | "cancelled">;
   accepted: (accepted: boolean) => void;
-  fallback(): void;
-  consume(): void;
+  fallback: () => void;
+  consume: () => void;
 };
 
 export function parkSteerCandidate(

--- a/src/auto-reply/reply/reply-admission-ticket.ts
+++ b/src/auto-reply/reply/reply-admission-ticket.ts
@@ -1,4 +1,5 @@
 import { normalizeStringifiedEntries } from "@openclaw/normalization-core/string-coerce";
+import { createDeferred } from "../../shared/deferred.js";
 import { resolveGlobalMap } from "../../shared/global-singleton.js";
 
 export const REPLY_ADMISSION_TICKET = Symbol("openclaw.replyAdmissionTicket");
@@ -20,10 +21,7 @@ export function reserveReplyAdmissionTicket(
   if (keys.length === 0) {
     return undefined;
   }
-  let finish = () => {};
-  const completed = new Promise<void>((resolve) => {
-    finish = resolve;
-  });
+  const { promise: completed, resolve: finish } = createDeferred();
   const predecessors = keys.map((key) => tails.get(key) ?? Promise.resolve());
   const owned = keys.map((key, index) => {
     const tail = predecessors[index]!.then(() => completed);

--- a/ui/src/e2e/session-management.trailing-state.e2e.test.ts
+++ b/ui/src/e2e/session-management.trailing-state.e2e.test.ts
@@ -13,7 +13,7 @@ import {
 const suite = createSessionManagementE2eSuite();
 
 suite.define(() => {
-  it("swaps an active turn spinner for hover and focus management actions", async () => {
+  it("keeps action-only text widest at rest and swaps active state for actions", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -24,6 +24,11 @@ suite.define(() => {
       methodResponses: {
         "sessions.list": sessionsListResponse([
           sessionRow("agent:main:main", "Main", Date.now()),
+          sessionRow(
+            "agent:main:hover-actions",
+            "A deliberately long action-only sidebar title",
+            Date.now() - 1,
+          ),
           sessionRow("agent:main:hover-active", "Hover active", Date.now() - 1, {
             hasActiveRun: true,
             status: "running",
@@ -35,6 +40,36 @@ suite.define(() => {
 
     try {
       await page.goto(`${suite.server.baseUrl}chat`);
+      const actionOnlyRow = page.locator('[data-session-key="agent:main:hover-actions"]');
+      await actionOnlyRow.waitFor({ state: "visible", timeout: 10_000 });
+      const actionOnlyText = actionOnlyRow.locator(".sidebar-recent-session__text");
+      const actionOnlyLink = actionOnlyRow.locator(".sidebar-recent-session__link");
+      const actionOnlyPin = actionOnlyRow.getByRole("button", { name: "Pin thread" });
+      await expect
+        .poll(() => actionOnlyLink.evaluate((element) => getComputedStyle(element).paddingRight))
+        .toBe("4px");
+      const restingTextBounds = await actionOnlyText.boundingBox();
+
+      await actionOnlyRow.hover();
+      await expect.poll(() => actionOpacity(actionOnlyPin)).toBe("1");
+      await expect
+        .poll(() => actionOnlyLink.evaluate((element) => getComputedStyle(element).paddingRight))
+        .toBe("52px");
+      const hoveredTextBounds = await actionOnlyText.boundingBox();
+
+      await page.mouse.move(0, 0);
+      await actionOnlyPin.focus();
+      await expect.poll(() => actionOpacity(actionOnlyPin)).toBe("1");
+      await expect
+        .poll(() => actionOnlyLink.evaluate((element) => getComputedStyle(element).paddingRight))
+        .toBe("52px");
+      const focusedTextBounds = await actionOnlyText.boundingBox();
+      if (!restingTextBounds || !hoveredTextBounds || !focusedTextBounds) {
+        throw new Error("Expected visible action-only text geometry");
+      }
+      expect(restingTextBounds.width).toBeGreaterThanOrEqual(hoveredTextBounds.width);
+      expect(restingTextBounds.width).toBeGreaterThanOrEqual(focusedTextBounds.width);
+
       const row = page.locator('[data-session-key="agent:main:hover-active"]');
       await row.waitFor({ state: "visible", timeout: 10_000 });
       const state = row.locator(".session-row-state");
@@ -177,7 +212,7 @@ suite.define(() => {
     }
   });
 
-  it("reserves only the visible desktop trailing surface for a long active row", async () => {
+  it("does not widen desktop session text when hover actions replace trailing state", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -268,43 +303,42 @@ suite.define(() => {
         .poll(() => link.evaluate((element) => getComputedStyle(element).paddingRight))
         .toBe("68px");
 
-      const [restingNameBounds, restingStateBounds, restingPinBounds, restingMenuBounds] =
+      const [restingTextBounds, restingStateBounds, restingPinBounds, restingMenuBounds] =
         await Promise.all([
-          row.locator(".sidebar-recent-session__name").boundingBox(),
+          row.locator(".sidebar-recent-session__text").boundingBox(),
           state.boundingBox(),
           pin.boundingBox(),
           menu.boundingBox(),
         ]);
-      if (!restingNameBounds || !restingStateBounds || !restingPinBounds || !restingMenuBounds) {
+      if (!restingTextBounds || !restingStateBounds || !restingPinBounds || !restingMenuBounds) {
         throw new Error("Expected visible resting session state geometry");
       }
       const actionSurfaceWidth = restingMenuBounds.x + restingMenuBounds.width - restingPinBounds.x;
-      expect(restingNameBounds.x + restingNameBounds.width).toBeLessThanOrEqual(
+      expect(restingTextBounds.x + restingTextBounds.width).toBeLessThanOrEqual(
         restingStateBounds.x,
       );
-      expect(restingNameBounds.x + restingNameBounds.width).toBeGreaterThan(
+      expect(restingTextBounds.x + restingTextBounds.width).toBeGreaterThan(
         restingStateBounds.x - actionSurfaceWidth,
       );
-
       await row.hover();
       await expect.poll(() => actionOpacity(state)).toBe("0");
       await expect.poll(() => actionOpacity(pin)).toBe("1");
       await expect.poll(() => actionOpacity(menu)).toBe("1");
       await expect
         .poll(() => link.evaluate((element) => getComputedStyle(element).paddingRight))
-        .toBe("52px");
+        .toBe("68px");
 
-      const [nameBounds, pinBounds, menuBounds] = await Promise.all([
-        row.locator(".sidebar-recent-session__name").boundingBox(),
+      const [textBounds, pinBounds, menuBounds] = await Promise.all([
+        row.locator(".sidebar-recent-session__text").boundingBox(),
         pin.boundingBox(),
         menu.boundingBox(),
       ]);
-      if (!nameBounds || !pinBounds || !menuBounds) {
+      if (!textBounds || !pinBounds || !menuBounds) {
         throw new Error("Expected visible combined session action geometry");
       }
-      expect(nameBounds.x + nameBounds.width).toBeLessThanOrEqual(pinBounds.x);
+      expect(restingTextBounds.width).toBeGreaterThanOrEqual(textBounds.width);
+      expect(textBounds.x + textBounds.width).toBeLessThanOrEqual(pinBounds.x);
       expect(pinBounds.x + pinBounds.width).toBeLessThanOrEqual(menuBounds.x);
-
       await page.mouse.move(0, 0);
       await pin.focus();
       await expect.poll(() => actionOpacity(state)).toBe("0");
@@ -312,17 +346,18 @@ suite.define(() => {
       await expect.poll(() => actionOpacity(menu)).toBe("1");
       await expect
         .poll(() => link.evaluate((element) => getComputedStyle(element).paddingRight))
-        .toBe("52px");
+        .toBe("68px");
 
-      const [focusedNameBounds, focusedPinBounds, focusedMenuBounds] = await Promise.all([
-        row.locator(".sidebar-recent-session__name").boundingBox(),
+      const [focusedTextBounds, focusedPinBounds, focusedMenuBounds] = await Promise.all([
+        row.locator(".sidebar-recent-session__text").boundingBox(),
         pin.boundingBox(),
         menu.boundingBox(),
       ]);
-      if (!focusedNameBounds || !focusedPinBounds || !focusedMenuBounds) {
+      if (!focusedTextBounds || !focusedPinBounds || !focusedMenuBounds) {
         throw new Error("Expected visible focused session action geometry");
       }
-      expect(focusedNameBounds.x + focusedNameBounds.width).toBeLessThanOrEqual(focusedPinBounds.x);
+      expect(restingTextBounds.width).toBeGreaterThanOrEqual(focusedTextBounds.width);
+      expect(focusedTextBounds.x + focusedTextBounds.width).toBeLessThanOrEqual(focusedPinBounds.x);
       expect(focusedPinBounds.x + focusedPinBounds.width).toBeLessThanOrEqual(focusedMenuBounds.x);
     } finally {
       await context.close();

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2159,11 +2159,10 @@ html.openclaw-native-macos
   padding-right: 2px;
 }
 
-/* Resting rows give the title the full sidebar width: the trailing aside
-   overlays the row instead of reserving button width in-flow. It must not
-   intercept clicks on the link tail beneath it — the buttons re-enable
-   their own pointer-events on hover/focus. Child rows keep the in-flow
-   aside because their runtime trail is resting content, not a hover swap. */
+/* The trailing aside overlays the row so action-only rows retain the full
+   resting link width. It must not intercept clicks on the link beneath it —
+   the buttons re-enable their own pointer-events on hover/focus. Child rows
+   keep the in-flow aside because their runtime trail is resting content. */
 .sidebar-recent-session:not(.sidebar-recent-session--child) > .sidebar-recent-session__aside {
   position: absolute;
   top: 50%;
@@ -2180,8 +2179,8 @@ html.openclaw-native-macos
   right: 35px;
 }
 
-/* Resting semantic state remains visible, so reserve its overlay slot before
-   the title. Action-only rows still get the full resting width. */
+/* State-bearing rows reserve the larger state/action maximum throughout the
+   swap, while action-only rows reserve controls only when they appear. */
 .sidebar-recent-session:not(.sidebar-recent-session--child):where(
     :has(> .sidebar-recent-session__aside > .session-row-state)
   )
@@ -2189,9 +2188,9 @@ html.openclaw-native-macos
   padding-right: 68px;
 }
 
-/* Desktop hover/focus swaps resting state for actions, so reserve only the
-   action surface while it is visible. */
-.sidebar-recent-session:not(.sidebar-recent-session--child):is(:hover, :focus-within)
+.sidebar-recent-session:not(.sidebar-recent-session--child):not(
+    :has(> .sidebar-recent-session__aside > .session-row-state)
+  ):is(:hover, :focus-within)
   > .sidebar-recent-session__link {
   padding-right: 52px;
 }


### PR DESCRIPTION
AI-assisted: yes

## What Problem This Solves

Fixes an issue where users hovering or keyboard-focusing a state-bearing session row in the Control UI sidebar would see its title and subtitle widen while the trailing state indicator was replaced by pin and menu actions.

## Why This Change Was Made

State-bearing rows reserved 68px at rest, but a generic hover/focus rule reduced that reservation to 52px exactly when the trailing controls appeared. The sidebar row now owns a stable reservation by row kind: action-only rows retain maximum width at rest and reserve 52px when controls appear, while rows with `.session-row-state` keep the larger 68px reservation throughout the state-to-actions swap. Child-row and touch behavior are unchanged.

### Red main repair

Exact-head PR CI and base-main CI shared unrelated lint and test-type failures, and repository policy forbids landing onto red `main`. This PR therefore includes the smallest correct repair: shared mutable model fixtures now carry the authoritative type; deferred promises, sorting, braces, callback properties, and OAuth executors follow canonical typed patterns; the active-steer state machine now lives in its existing steering owner while preserving ticket release, predecessor admission, fallback/consume symmetry, typing refresh, and cleanup; and the MCP subprocess fixture is extracted into a concept-named test-support module instead of suppressing the file-size gate.

Before the conflict-required rebase, the repair was an ownership-boundary extraction: production +251/-184 (net +67), tests/fixtures +75/-64 (net +11). Current `main` independently absorbed most of that repair; the final retained red-main delta is production +7/-11 (net -4) with no test-file delta. The original UI change is production +9/-10 (net -1), tests +54/-19 (net +35).

## User Impact

Session titles and subtitles no longer shift or reflow when users reveal row actions with a pointer or keyboard. Action-only rows still use the available resting width, and existing child and touch behavior remains intact. The inherited red-main repair is behavior-preserving and restores the lint and test-type gates needed to land safely.

## Evidence

- MCP CLI/OAuth focused tests: 37/37 passed.
- Auto-reply runner/media focused tests: 12/12 passed.
- Gateway steering E2E: 3/3 passed.
- Sidebar hover E2E: 4/4 passed.
- Root test tsgo check passed.
- Targeted oxlint passed.
- Oxfmt check passed on all touched files.
- `git diff --check` passed.
- Fresh structured review of the red-main repair was clean, with no accepted/actionable findings; the UI fix review was already clean.
- Deployed-row reproduction: 77px text width at rest to 93px on hover while right padding changed from 68px to 52px. Fixed deterministic mock: 156px to 156px with padding stable at 68px.
- Sanitized deterministic-mock Before/After images were prepared locally, but Crabbox artifact publication returned HTTP 401 `unauthorized`. No images were committed and no alternate public image host was used, so there is no manifest URL.

### ClawSweeper rank-up reconciliation

- Exact-head CI [run 31239864241](https://github.com/openclaw/openclaw/actions/runs/31239864241) completed successfully on `adb90f8d0c6775a86d9699d58ee3bf47c8ee3386`: 62 successful jobs, 11 intentional skips, and no failures.
- Fresh exact-head structured autoreview completed cleanly with no accepted/actionable findings.
- The latest exact-head ClawSweeper review reported no findings. Its optional rank-up moves were to wait for exact-head CI and reconcile the latest note plus fresh autoreview; both are complete. The artifact-publication 401 remains an explicitly documented proof gap, with deterministic geometry proof retained above.

No changelog change: normal PR release-note context is captured here, and release generation owns `CHANGELOG.md`.
