### PR TITLE
 fix(cli): keep targeted config writes out of state migration

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -766,6 +766,8 @@ describe("argv helpers", () => {
     { argv: ["node", "openclaw", "--log-level=debug", "models", "list"], expected: true },
     { argv: ["node", "openclaw", "config", "get", "update"], expected: false },
     { argv: ["node", "openclaw", "config", "unset", "update"], expected: false },
+    { argv: ["node", "openclaw", "config", "set", "update.channel", "beta"], expected: false },
+    { argv: ["node", "openclaw", "config", "patch", "update", "{}"], expected: false },
     { argv: ["node", "openclaw", "models", "list"], expected: true },
     { argv: ["node", "openclaw", "models", "status"], expected: true },
     { argv: ["node", "openclaw", "update", "status", "--json"], expected: false },

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -625,7 +625,7 @@ export function shouldMigrateStateFromPath(path: string[]): boolean {
   if (primary === "update" && secondary === "status") {
     return false;
   }
-  if (primary === "config" && (secondary === "get" || secondary === "unset")) {
+  if (primary === "config") {
     return false;
   }
   return true;

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -180,6 +180,16 @@ describe("ensureConfigReady", () => {
       expectedDoctorCalls: 0,
     },
     {
+      name: "skips doctor flow for config set",
+      commandPath: ["config", "set"],
+      expectedDoctorCalls: 0,
+    },
+    {
+      name: "skips doctor flow for config patch",
+      commandPath: ["config", "patch"],
+      expectedDoctorCalls: 0,
+    },
+    {
       name: "skips doctor flow for agent without legacy state",
       commandPath: ["agent"],
       expectedDoctorCalls: 0,


### PR DESCRIPTION
Closes #120413

## What Problem This Solves

Fixes an issue where `openclaw config set` and `openclaw config patch --stdin` could run the startup Doctor/state-migration path before applying a targeted config change. That implicit whole-state repair could rewrite unrelated legacy cron data, including per-job model routing, during an otherwise narrow config update.

## Why This Change Was Made

All `config` commands now opt out of startup state migration. Targeted writers still pass through the config guard and the existing full candidate/schema/plugin validation before writing; only unrelated state repair is removed from their startup envelope. Persistent migration remains owned by explicit `openclaw doctor --fix` and gateway startup.

This is the canonical owner-boundary fix rather than a cron-specific guard, a new flag, or a writer-side compatibility path. It also protects future targeted config subcommands from inheriting the same implicit-repair bug.

## User Impact

`config set` and `config patch` now apply only the requested validated config change. They no longer emit Doctor/state-migration output or mutate legacy cron storage as a side effect. Operators who need legacy-state repair continue to use `openclaw doctor --fix` or normal gateway startup.

No config key, default, schema, protocol, flag, or output shape changes.

## Evidence

Exact head: `9a50ce20ae6f2f16853a6ea4af376cdf0228be30`

Sanitized AWS Crabbox proof used a fresh public-network lease with no instance profile, no Tailscale, no hydration, isolated `HOME`, pinned Node/pnpm, and exact-head verification.

- [Focused CLI tests](https://crabbox.openclaw.ai/portal/runs/run_243543232d95): 447 tests passed across `src/cli/argv.test.ts`, `src/cli/program/config-guard.test.ts`, `src/cli/program/preaction.test.ts`, and `src/cli/config-cli.test.ts`.
- [Real CLI behavior](https://crabbox.openclaw.ai/portal/runs/run_af09993c1130): built the exact head, created an isolated config plus legacy `cron/jobs.json`, then ran both targeted writers. The cron file remained byte-identical after `config patch --stdin` and `config set`; neither command emitted Doctor/migration output. A subsequent `doctor --fix --non-interactive` migrated and archived the same legacy cron store.

```json
{"head":"9a50ce20ae6f2f16853a6ea4af376cdf0228be30","patchCronHashPreserved":true,"setCronHashPreserved":true,"patchMigrationOutput":false,"setMigrationOutput":false,"doctorMigratedLegacyCron":true}
```

- [Gateway/Doctor sibling tests](https://crabbox.openclaw.ai/portal/runs/run_a844f343ca99): 12 gateway startup recovery tests and 62 Doctor cron migration tests passed.
- Structured autoreview: clean, no actionable findings.
- Independent exact-head read-only review: no findings; judged the whole-`config` predicate the best fix and confirmed validation and migration-owner paths remain intact.
- [Hosted exact-head CI](https://github.com/openclaw/openclaw/actions/runs/31247778098): affected CLI/config tests, build, types, guards, protocol, and dependency checks are green. The aggregate gate is red only from untouched base files: existing context/session expectation failures, two max-lines violations, and a worktree-migration timeout; the same failure cluster was present on the prior head.

### Review metrics

- Production: `+1/-1` (net 0)
- Tests: `+12/-0`
- Config keys/defaults/schemas: `0 added / 0 changed / 0 removed`
- Gateway protocol surfaces: `0 changed`
- Observable migration-routing behavior: `2 commands changed` (`config set`, `config patch`)
- Generated/unrelated files: none

### Compatibility note

This intentionally removes undocumented incidental migration from targeted config writes. Migration is deferred to its documented owners (`doctor --fix` and gateway startup), not deleted.

Human contributor credit is preserved in the commit for @SunnyShu0925; issue report by @jerabinovich.
