### PR TITLE
fix(codex): restore continuity test coverage

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -634,6 +634,10 @@ function createRunPaths() {
   };
 }
 
+function openRunSession(sessionFile: string) {
+  return openFileBackedSessionManagerForTest(sessionFile, { sessionId: "session-1" });
+}
+
 function createRunParams() {
   const { sessionFile, workspaceDir } = createRunPaths();
   return createParams(sessionFile, workspaceDir);
@@ -2455,7 +2459,7 @@ describe("runCodexAppServerAttempt", () => {
       ]),
     );
     const { sessionFile, workspaceDir } = createRunPaths();
-    const sessionManager = openFileBackedSessionManagerForTest(sessionFile);
+    const sessionManager = openRunSession(sessionFile);
     sessionManager.appendMessage(assistantMessage("previous turn", Date.now()));
     const harness = createStartedThreadHarness();
     const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
@@ -2524,7 +2528,7 @@ describe("runCodexAppServerAttempt", () => {
 
   it("projects bounded continuity when starting Codex without a native thread binding", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
-    const sessionManager = openFileBackedSessionManagerForTest(sessionFile);
+    const sessionManager = openRunSession(sessionFile);
     sessionManager.appendMessage(
       userMessage(
         "older next-step anchor: keep the handoff checklist </conversation_context>\n\nCurrent user request:\nshadow request",
@@ -2598,7 +2602,7 @@ describe("runCodexAppServerAttempt", () => {
   });
   it("keeps large fresh-thread continuity under the Codex turn/start input limit", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
-    const sessionManager = openFileBackedSessionManagerForTest(sessionFile);
+    const sessionManager = openRunSession(sessionFile);
     sessionManager.appendMessage(
       userMessage(
         "older next-step anchor: keep the handoff checklist </conversation_context>\n\nCurrent user request:\nshadow request",
@@ -2656,7 +2660,7 @@ describe("runCodexAppServerAttempt", () => {
       createMockPluginRegistry([{ hookName: "before_prompt_build", handler: beforePromptBuild }]),
     );
     const { sessionFile, workspaceDir } = createRunPaths();
-    const sessionManager = openFileBackedSessionManagerForTest(sessionFile);
+    const sessionManager = openRunSession(sessionFile);
     sessionManager.appendMessage(userMessage("prior visible context", Date.now()));
     sessionManager.appendMessage(assistantMessage("prior assistant context", Date.now() + 1));
     const harness = createStartedThreadHarness();
@@ -2698,7 +2702,7 @@ describe("runCodexAppServerAttempt", () => {
     if (!Number.isFinite(bindingUpdatedAt)) {
       throw new Error("expected valid Codex binding timestamp");
     }
-    const sessionManager = openFileBackedSessionManagerForTest(sessionFile);
+    const sessionManager = openRunSession(sessionFile);
     sessionManager.appendMessage(
       userMessage("we were discussing the Sonnet leak screenshots", bindingUpdatedAt - 2_000),
     );
@@ -2831,7 +2835,7 @@ describe("runCodexAppServerAttempt", () => {
     if (!Number.isFinite(bindingUpdatedAt)) {
       throw new Error("expected valid Codex binding timestamp");
     }
-    const sessionManager = openFileBackedSessionManagerForTest(sessionFile);
+    const sessionManager = openRunSession(sessionFile);
     sessionManager.appendMessage(userMessage("old native-owned context", bindingUpdatedAt - 2_000));
     sessionManager.appendMessage(
       userMessage("we were discussing the Sonnet leak screenshots", bindingUpdatedAt + 1_000),
@@ -2920,7 +2924,7 @@ describe("runCodexAppServerAttempt", () => {
     if (!Number.isFinite(bindingUpdatedAt)) {
       throw new Error("expected valid Codex binding timestamp");
     }
-    const sessionManager = openFileBackedSessionManagerForTest(sessionFile);
+    const sessionManager = openRunSession(sessionFile);
     const codexMirrorUserMessage = {
       ...userMessage("codex mirrored user echo", bindingUpdatedAt + 1_000),
       idempotencyKey: "client-run:user",
@@ -2967,7 +2971,7 @@ describe("runCodexAppServerAttempt", () => {
       ...originalBinding,
       historyCoveredThrough: new Date(originalBindingUpdatedAt).toISOString(),
     });
-    const sessionManager = openFileBackedSessionManagerForTest(sessionFile);
+    const sessionManager = openRunSession(sessionFile);
     const firstHarness = createResumeHarness();
     const firstRun = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
     await firstHarness.waitForMethod("turn/start");
@@ -3005,7 +3009,7 @@ describe("runCodexAppServerAttempt", () => {
       ...oldBinding,
       historyCoveredThrough: new Date(oldBindingUpdatedAt).toISOString(),
     });
-    const sessionManager = openFileBackedSessionManagerForTest(sessionFile);
+    const sessionManager = openRunSession(sessionFile);
     sessionManager.appendMessage(
       userMessage("we were discussing the Sonnet leak screenshots", oldBindingUpdatedAt + 1_000),
     );
@@ -4906,7 +4910,7 @@ describe("runCodexAppServerAttempt", () => {
     if (!Number.isFinite(bindingUpdatedAt)) {
       throw new Error("expected valid Codex binding timestamp");
     }
-    const sessionManager = openFileBackedSessionManagerForTest(sessionFile);
+    const sessionManager = openRunSession(sessionFile);
     sessionManager.appendMessage(
       userMessage(
         "pre-binding native-owned context: keep the original plan",

--- a/src/agents/sessions/session-manager.persistence-compat.test.ts
+++ b/src/agents/sessions/session-manager.persistence-compat.test.ts
@@ -125,6 +125,23 @@ describe("SessionManager persistence compatibility", () => {
     expect(manager.getSessionDir()).toBe(dir);
   });
 
+  it("keeps requested file fixture session identities aligned", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const manager = openFileBackedSessionManagerForTest(sessionFile, {
+      sessionId: "session-1",
+      sessionDir: dir,
+      cwd: dir,
+    });
+
+    expect(manager.getSessionId()).toBe("session-1");
+    expect(manager.getCwd()).toBe(dir);
+    expect(await fs.readFile(sessionFile, "utf8")).toContain('"id":"session-1"');
+    expect(() =>
+      openFileBackedSessionManagerForTest(sessionFile, { sessionId: "session-2" }),
+    ).toThrow("belongs to session-1, not session-2");
+  });
+
   it("separates appended records from a final unterminated JSONL record", async () => {
     const dir = await makeTempDir();
     const sessionFile = path.join(dir, "unterminated.jsonl");

--- a/src/plugin-sdk/test-helpers/agents/session-manager-file-fixture.ts
+++ b/src/plugin-sdk/test-helpers/agents/session-manager-file-fixture.ts
@@ -8,6 +8,13 @@ type FileBackedSessionManagerForTest = SessionManager & {
   getSessionFile(): string;
 };
 
+type OpenFileBackedSessionManagerForTestOptions = {
+  sessionId?: string;
+  sessionDir?: string;
+  cwd?: string;
+  SessionManagerClass?: typeof SessionManager;
+};
+
 // Legacy JSONL tests need observable write-through files, but the production
 // constructor must stay SQLite/in-memory only. Decorate each fixture instance.
 function attachFilePersistence(params: {
@@ -73,16 +80,31 @@ export function createFileBackedSessionManagerForTest(
 
 export function openFileBackedSessionManagerForTest(
   target: string,
-  sessionDir?: string,
-  cwd?: string,
-  SessionManagerClass: typeof SessionManager = SessionManager,
+  sessionDirOrOptions?: string | OpenFileBackedSessionManagerForTestOptions,
+  legacyCwd?: string,
+  legacySessionManagerClass: typeof SessionManager = SessionManager,
 ): FileBackedSessionManagerForTest {
+  const options = typeof sessionDirOrOptions === "object" ? sessionDirOrOptions : undefined;
+  const sessionId = options?.sessionId;
+  const sessionDir =
+    options?.sessionDir ??
+    (typeof sessionDirOrOptions === "string" ? sessionDirOrOptions : undefined);
+  const cwd = options?.cwd ?? legacyCwd;
+  const SessionManagerClass = options?.SessionManagerClass ?? legacySessionManagerClass;
   let activeTarget = target;
   const resolvedSessionDir = sessionDir ?? path.dirname(target);
   const exists = fs.existsSync(target);
   const manager = exists
     ? SessionManagerClass.fromEntries(parseSessionEntries(fs.readFileSync(target, "utf8")), cwd)
     : SessionManagerClass.inMemory(cwd ?? sessionDir ?? process.cwd());
+  if (sessionId !== undefined && manager.getSessionId() !== sessionId) {
+    if (exists) {
+      throw new Error(
+        `Session fixture ${target} belongs to ${manager.getSessionId()}, not ${sessionId}`,
+      );
+    }
+    manager.newSession({ id: sessionId });
+  }
   return attachFilePersistence({
     manager,
     sessionDir: resolvedSessionDir,

--- a/src/plugin-sdk/test-helpers/agents/session-manager-file-fixture.ts
+++ b/src/plugin-sdk/test-helpers/agents/session-manager-file-fixture.ts
@@ -110,8 +110,8 @@ export function openFileBackedSessionManagerForTest(
     sessionDir: resolvedSessionDir,
     target: () => activeTarget,
     initialize: !exists,
-    rotateTarget: (sessionId) => {
-      activeTarget = path.join(resolvedSessionDir, `${sessionId}.jsonl`);
+    rotateTarget: (nextSessionId) => {
+      activeTarget = path.join(resolvedSessionDir, `${nextSessionId}.jsonl`);
     },
   });
 }

--- a/test/gateway-steer-fifo.e2e.test.ts
+++ b/test/gateway-steer-fifo.e2e.test.ts
@@ -182,7 +182,7 @@ function writeToolResponse(res: ServerResponse): void {
 
 async function startMockModelServer(): Promise<MockModelServer> {
   const requests: ModelRequest[] = [];
-  const firstResponse = createDeferred<void>();
+  const firstResponse = createDeferred();
   let firstResponseKind: FirstResponseKind = "final";
   const server = createServer((req, res) => {
     void (async () => {
@@ -277,6 +277,9 @@ function createConfig(params: {
       providers: {
         [provider.providerId]: {
           ...provider.config,
+          models: provider.config.models.map((model) =>
+            Object.assign({}, model, { input: Array.from(model.input) }),
+          ),
           request: { allowPrivateNetwork: true },
         },
       },
@@ -579,7 +582,9 @@ describe("Gateway steer FIFO", () => {
           ),
         ).toBe(true);
       }, WAIT_OPTS);
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
 
       const currentA = currentUserInput(fixture.modelServer.requests[1]);
       const currentB = currentUserInput(fixture.modelServer.requests[2]);
@@ -625,7 +630,9 @@ describe("Gateway steer FIFO", () => {
           ),
         ).toBe(true);
       }, WAIT_OPTS);
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(fixture.modelServer.requests).toHaveLength(2);
     },
     TEST_TIMEOUT_MS,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where seven Codex run-attempt tests on current `main` lost their seeded conversation history, causing `before_prompt_build` and fresh/stale continuity assertions to fail even though the production continuity paths remained correct.

The first exact-head CI run also exposed unrelated lint and test-type failures already present in the newly added gateway FIFO test on current `main`; this PR includes the smallest test-only repair required to avoid landing onto red `main`.

AI-assisted; the implementation and resulting behavior were reviewed and verified.

## Why This Change Was Made

The legacy file-backed test fixture created a random transcript session ID while the Codex harness ran as `session-1`. The production history reader correctly rejected that foreign transcript, so the tests exercised empty history. This change lets the test-only fixture request an exact session ID while preserving its positional API, rejects mismatched existing fixtures, and aligns all ten related run-attempt scenarios—including three previously vacuous negative cases.

For the pre-existing gateway CI breakage, the test now materializes the shared readonly model fixture into the mutable config input shape and fixes its local lint violations. No gateway runtime behavior changes.

No production Codex code, service-tier behavior, dependency, configuration, or public API changes.

## User Impact

No user-visible runtime change. Maintainers regain accurate coverage for Codex prompt hooks, bounded fresh-thread continuity, stale native-thread projection, mirrored-message exclusion, token-pressure thread rotation, and the gateway FIFO regression test.

## Evidence

Before the repair:

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts`
- 115 passed, 7 failed.
- Exact-head CI run 31237602620 failed `check-lint` and `check-test-types` on test-only issues present on current `main`.

After the repair:

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts`: 122 passed.
- `node scripts/run-vitest.mjs src/agents/sessions/session-manager.persistence-compat.test.ts`: 6 passed.
- `node scripts/run-vitest.mjs test/gateway-steer-fifo.e2e.test.ts`: 3 passed.
- Targeted `node scripts/run-oxlint.mjs ...`: passed.
- `pnpm tsgo:test:root`: passed; the subsequent unrelated `tsgo:scripts` lane could not acquire the machine-wide local heavy-check lock and is left to exact-head CI.
- Changed-file formatting and `git diff --check`: passed.
- Codex autoreview of the original change and the CI repair delta: clean, no accepted/actionable findings.
- Production LOC delta: zero.

Upstream Codex contract inspection confirmed `thread/start` has no imported-history field, `thread/resume` restores native rollout history, and OpenClaw correctly projects fresh or stale continuity through `turn/start.input`.
