### PR TITLE
fix(build): avoid false CLI help timeouts during fallback

### DIFF
--- a/scripts/write-cli-startup-metadata.ts
+++ b/scripts/write-cli-startup-metadata.ts
@@ -665,9 +665,9 @@ export async function renderBundledRootHelpText(
   });
 }
 
-function renderSourceRootHelpText(renderContext?: RootHelpRenderContext): string {
+async function renderSourceRootHelpText(renderContext?: RootHelpRenderContext): Promise<string> {
   if (!renderContext) {
-    return withIsolatedRootHelpRenderContext(extensionsDir, renderSourceRootHelpText);
+    return await withIsolatedRootHelpRenderContext(extensionsDir, renderSourceRootHelpText);
   }
   const moduleUrl = pathToFileURL(path.join(rootDir, "src/cli/program/root-help.ts")).href;
   const renderOptions = {
@@ -684,28 +684,12 @@ function renderSourceRootHelpText(renderContext?: RootHelpRenderContext): string
     "process.stdout.write(output);",
     "process.exit(0);",
   ].join("\n");
-  const result = spawnSync(
-    process.execPath,
-    ["--import", "tsx", "--input-type=module", "--eval", inlineModule],
-    {
-      cwd: rootDir,
-      encoding: "utf8",
-      env: renderContext.env,
-      killSignal: "SIGKILL",
-      timeout: ROOT_HELP_RENDER_TIMEOUT_MS,
-    },
-  );
-  if (result.error) {
-    throw result.error;
-  }
-  if (result.status !== 0) {
-    const stderr = result.stderr?.trim();
-    throw new Error(
-      "Failed to render source root help" +
-        (stderr ? `: ${stderr}` : result.signal ? `: terminated by ${result.signal}` : ""),
-    );
-  }
-  return result.stdout ?? "";
+  return await spawnText(["--import", "tsx", "--input-type=module", "--eval", inlineModule], {
+    cwd: rootDir,
+    env: renderContext.env ?? process.env,
+    failureMessage: "Failed to render source root help",
+    timeoutMs: ROOT_HELP_RENDER_TIMEOUT_MS,
+  });
 }
 
 async function renderSourceBrowserHelpText(renderContext: RootHelpRenderContext): Promise<string> {
@@ -777,7 +761,7 @@ export async function writeCliStartupMetadata(options?: {
   extensionsDir?: string;
   sourceRootDir?: string;
   renderBundledRootHelpText?: typeof renderBundledRootHelpText;
-  renderSourceRootHelpText?: typeof renderSourceRootHelpText;
+  renderSourceRootHelpText?: (renderContext: RootHelpRenderContext) => Awaitable<string>;
   renderSourceBrowserHelpText?: (renderContext: RootHelpRenderContext) => Awaitable<string>;
   renderSourceSecretsHelpText?: (renderContext: RootHelpRenderContext) => Awaitable<string>;
   renderSourceNodesHelpText?: (renderContext: RootHelpRenderContext) => Awaitable<string>;
@@ -877,10 +861,11 @@ export async function writeCliStartupMetadata(options?: {
             renderContext,
           );
         } catch {
-          // The spawnSync source fallback blocks the event loop; that is fine for
-          // this rare recovery path (missing/broken bundle) and only delays
-          // draining sibling render output, not its correctness.
-          return (options?.renderSourceRootHelpText ?? renderSourceRootHelpText)(renderContext);
+          // Keep the fallback asynchronous: sibling help renders share this
+          // event loop, so blocking here can turn completed children into false timeouts.
+          return await (options?.renderSourceRootHelpText ?? renderSourceRootHelpText)(
+            renderContext,
+          );
         }
       })();
   const hasCustomCommandRenderer =

--- a/test/scripts/write-cli-startup-metadata.test.ts
+++ b/test/scripts/write-cli-startup-metadata.test.ts
@@ -1,5 +1,5 @@
 // Write Cli Startup Metadata tests cover write cli startup metadata script behavior.
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import fs, { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
@@ -12,7 +12,7 @@ import { createScriptTestHarness } from "./test-helpers.js";
 
 vi.mock("node:child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:child_process")>();
-  return { ...actual, spawnSync: vi.fn(actual.spawnSync) };
+  return { ...actual, spawn: vi.fn(actual.spawn) };
 });
 
 // These subprocess tests use explicit ready/close signals; timeout only catches broken fixtures.
@@ -119,25 +119,38 @@ async function waitForChildClose(
 describe("write-cli-startup-metadata", () => {
   const { createTempDir } = createScriptTestHarness();
 
-  it("hard-kills synchronous source root help after its timeout", () => {
-    const spawnSyncMock = vi.mocked(spawnSync);
-    const successfulRender = {
-      error: undefined,
-      output: [null, "Usage: openclaw\n", ""],
-      pid: 123,
-      signal: null,
-      status: 0,
-      stderr: "",
-      stdout: "Usage: openclaw\n",
-    };
-    spawnSyncMock.mockReturnValueOnce(successfulRender);
+  it("renders source root help without blocking sibling child events", async () => {
+    const child = createSpawnTextChild();
+    const spawnMock = vi.mocked(spawn);
+    spawnMock.mockImplementationOnce(() => child as unknown as ReturnType<typeof spawn>);
+    let siblingEventObserved = false;
+    const siblingEvent = new Promise<void>((resolve) => {
+      setImmediate(() => {
+        siblingEventObserved = true;
+        resolve();
+      });
+    });
 
-    expect(__testing.renderSourceRootHelpText()).toBe("Usage: openclaw\n");
+    const render = __testing.renderSourceRootHelpText();
+    child.stdout.write("Usage: openclaw\n");
+    setImmediate(() => {
+      child.emit("close", 0, null);
+    });
 
-    expect(spawnSyncMock).toHaveBeenCalledOnce();
-    expect(spawnSyncMock.mock.calls[0]?.[2]).toMatchObject({
-      killSignal: "SIGKILL",
-      timeout: 120_000,
+    await siblingEvent;
+    expect(siblingEventObserved).toBe(true);
+    await expect(render).resolves.toBe("Usage: openclaw\n");
+    expect(spawnMock).toHaveBeenCalledOnce();
+    expect(spawnMock.mock.calls[0]?.[1]).toEqual([
+      "--import",
+      "tsx",
+      "--input-type=module",
+      "--eval",
+      expect.any(String),
+    ]);
+    expect(spawnMock.mock.calls[0]?.[2]).toMatchObject({
+      detached: process.platform !== "win32",
+      stdio: ["ignore", "pipe", "pipe"],
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where source builds could fail during `write-cli-startup-metadata` when the bundled root-help renderer timed out under host contention. The observed clawstudio build at `1f15bc92f90353bd6a7327e149cb5dddf0a17bd1` ran this phase for 4m 1.2s, then reported a misleading `nodes` help timeout and deleted the pre-canary candidate.

## Why This Change Was Made

The bundled root-help renderer and command-help renderers run concurrently, but the source root-help fallback still used `spawnSync`. After the bundled renderer's 120-second timeout, that fallback blocked the parent event loop for almost another 120 seconds. Completed command children could not deliver their `close` events, so their timeout callbacks ran first once the event loop resumed.

The source fallback now uses the existing asynchronous, output-bounded, process-tree-safe `spawnText` owner used by the other renderers. The 120-second deadline is unchanged; there is no retry or weakened build proof. This also removes the remaining split subprocess lifecycle from the generator.

## User Impact

Operators building OpenClaw on a busy host no longer get a false command-help timeout solely because the root-help fallback starved sibling child events. Genuine stalled renderers still fail at the same deadline and retain graceful process-tree termination followed by force-kill.

## Evidence

- Incident evidence: clawstudio Node 26.7.0, source SHA `1f15bc92f90353bd6a7327e149cb5dddf0a17bd1`, `write-cli-startup-metadata` failed after 4m 1.2s; the preceding unified build was also contention-slow at 16m 37.9s.
- Timing signature: approximately one bundled-render timeout plus one synchronous fallback timeout before the queued command timeout surfaced.
- Focused regression: `node scripts/run-vitest.mjs test/scripts/write-cli-startup-metadata.test.ts --reporter=verbose` — 16/16 passed, including event-loop yielding, output bounds, process-tree timeout cleanup, signal relay, fallback, caching, and state cleanup.
- Exact frozen-SHA informational CI: build-artifacts passed in [run 31235764532](https://github.com/openclaw/openclaw/actions/runs/31235764532); unrelated type/lint lanes made the overall run red.
- `git diff --check` and changed-file formatting passed.
- Structured Codex autoreview: clean, no accepted/actionable findings, correctness confidence 0.99.
- Independent verification: a controlled Node reproduction observed timeout-before-close ordering in 5/5 runs with a completed async child during `spawnSync`. AWS Crabbox lease `cbx_301e86b54fb0`, run `run_31cfde73d37e`, passed 16/16 focused tests and a full `pnpm build`; startup metadata completed in 12.3s and the lease was stopped.

Provenance: the synchronous fallback predates concurrent rendering; the hazardous overlap was introduced by #109628 and carried forward by the startup-metadata cache refactor. #109417 previously bounded the synchronous child with SIGKILL, but did not address event-loop starvation of concurrent siblings.
