### PR TITLE
fix: prevent embedded agent test-order SQLite failures

### DIFF
--- a/src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts
+++ b/src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   createReplyOperation,
   isReplyRunActiveForSessionId,
@@ -9,6 +8,10 @@ import {
 import { testing as replyRunTesting } from "../../auto-reply/reply/reply-run-registry.test-support.js";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/io.js";
 import { loadSessionEntry, upsertSessionEntry } from "../../config/sessions/session-accessor.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
 import {
   abortAndDrainEmbeddedAgentRun,
   clearActiveEmbeddedRun,
@@ -34,19 +37,28 @@ function createRunHandle(
 }
 
 describe("force-clear terminal state persistence", () => {
-  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  let testState: OpenClawTestState | undefined;
   let storePath: string;
 
-  beforeEach(() => {
-    const tempDir = tempDirs.make("openclaw-forceclear-");
-    storePath = path.join(tempDir, "sessions.json");
+  beforeEach(async () => {
+    testState = await createOpenClawTestState({
+      layout: "state-only",
+      prefix: "openclaw-forceclear-",
+    });
+    storePath = path.join(testState.sessionsDir(), "sessions.json");
     setRuntimeConfigSnapshot({ session: { store: storePath } });
   });
 
-  afterEach(() => {
-    clearRuntimeConfigSnapshot();
-    testing.resetActiveEmbeddedRuns();
-    replyRunTesting.resetReplyRunRegistry();
+  afterEach(async () => {
+    const state = testState;
+    testState = undefined;
+    try {
+      clearRuntimeConfigSnapshot();
+      testing.resetActiveEmbeddedRuns();
+      replyRunTesting.resetReplyRunRegistry();
+    } finally {
+      await state?.cleanup();
+    }
   });
 
   it("delays stale-owner followups until the old reply owner settles", async () => {

--- a/src/agents/embedded-agent-runner/runs.persistence.test.ts
+++ b/src/agents/embedded-agent-runner/runs.persistence.test.ts
@@ -1,9 +1,8 @@
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { InternalSessionEntry } from "../../config/sessions/types.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { testing } from "./runs.test-support.js";
 
 describe("embedded-agent runner persistence", () => {
@@ -12,31 +11,31 @@ describe("embedded-agent runner persistence", () => {
   });
 
   it("clears lifecycle ownership when a forced run clear persists killed state", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-force-clear-"));
-    const storePath = path.join(root, "sessions.json");
-    const sessionKey = "agent:main:main";
-    const entry: InternalSessionEntry = {
-      lifecycleRunId: "stuck-run",
-      sessionId: "session-stuck",
-      startedAt: 10,
-      status: "running",
-      updatedAt: 20,
-    };
-    try {
-      await replaceSessionEntry({ storePath, sessionKey }, entry);
-      await testing.persistForceClearedEmbeddedRunTerminalState({
-        sessionId: entry.sessionId,
-        sessionKey,
-        startedAt: entry.startedAt,
-        storePath,
-        updatedAt: entry.updatedAt,
-      });
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-force-clear-" },
+      async (state) => {
+        const storePath = path.join(state.sessionsDir(), "sessions.json");
+        const sessionKey = "agent:main:main";
+        const entry: InternalSessionEntry = {
+          lifecycleRunId: "stuck-run",
+          sessionId: "session-stuck",
+          startedAt: 10,
+          status: "running",
+          updatedAt: 20,
+        };
+        await replaceSessionEntry({ storePath, sessionKey }, entry);
+        await testing.persistForceClearedEmbeddedRunTerminalState({
+          sessionId: entry.sessionId,
+          sessionKey,
+          startedAt: entry.startedAt,
+          storePath,
+          updatedAt: entry.updatedAt,
+        });
 
-      const persisted = loadSessionEntry({ storePath, sessionKey }) as InternalSessionEntry;
-      expect(persisted.status).toBe("killed");
-      expect(persisted.lifecycleRunId).toBeUndefined();
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+        const persisted = loadSessionEntry({ storePath, sessionKey }) as InternalSessionEntry;
+        expect(persisted.status).toBe("killed");
+        expect(persisted.lifecycleRunId).toBeUndefined();
+      },
+    );
   });
 });

--- a/test/non-isolated-runner.test.ts
+++ b/test/non-isolated-runner.test.ts
@@ -280,3 +280,89 @@ it("clears session suspension state between files", async () => {
     await fs.rm(root, { recursive: true, force: true });
   }
 });
+
+it("disposes embedded-agent SQLite state before running the next file", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sqlite-lifecycle-runner-"));
+  const orderLogPath = path.join(root, "order.log");
+  const forceClearPath = path.join(
+    repoRoot,
+    "src",
+    "agents",
+    "embedded-agent-runner",
+    "runs.force-clear-terminal.test.ts",
+  );
+  const persistencePath = path.join(
+    repoRoot,
+    "src",
+    "agents",
+    "embedded-agent-runner",
+    "runs.persistence.test.ts",
+  );
+  try {
+    const embeddedConfigPath = JSON.stringify(
+      path.join(repoRoot, "test", "vitest", "vitest.agents-embedded-agent.config.ts"),
+    );
+    await fs.symlink(
+      path.join(repoRoot, "node_modules"),
+      path.join(root, "node_modules"),
+      "junction",
+    );
+    await fs.writeFile(
+      path.join(root, "vitest.config.ts"),
+      [
+        `import { createAgentsEmbeddedVitestConfig } from ${embeddedConfigPath};`,
+        'import { BaseSequencer } from "vitest/node";',
+        "class AlphabeticalSequencer extends BaseSequencer {",
+        '  override async sort(files: Parameters<BaseSequencer["sort"]>[0]) {',
+        "    return [...files].sort((a, b) => a.moduleId.localeCompare(b.moduleId));",
+        "  }",
+        "}",
+        "const base = createAgentsEmbeddedVitestConfig();",
+        "export default {",
+        "  ...base,",
+        `  cacheDir: ${JSON.stringify(path.join(root, ".vite"))},`,
+        "  test: {",
+        "    ...base.test,",
+        "    exclude: [],",
+        "    isolate: false,",
+        "    fileParallelism: false,",
+        "    maxWorkers: 1,",
+        "    sequence: { ...base.test?.sequence, sequencer: AlphabeticalSequencer },",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const vitestEntry = path.join(repoRoot, "node_modules", "vitest", "vitest.mjs");
+    const result = await execFileAsync(
+      process.execPath,
+      [
+        vitestEntry,
+        "run",
+        "src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts",
+        "src/agents/embedded-agent-runner/runs.persistence.test.ts",
+        "--config",
+        path.join(root, "vitest.config.ts"),
+      ],
+      {
+        cwd: repoRoot,
+        env: { ...childEnv(), OPENCLAW_VITEST_FILE_ORDER_LOG: orderLogPath },
+        maxBuffer: 16 * 1024 * 1024,
+      },
+    );
+    expect(`${result.stdout}\n${result.stderr}`).toMatch(/Test Files\s+2 passed \(2\)/u);
+    await expect(fs.readFile(orderLogPath, "utf8")).resolves.toBe(
+      [
+        `START ${forceClearPath}`,
+        `END ${forceClearPath}`,
+        `START ${persistencePath}`,
+        `END ${persistencePath}`,
+        "",
+      ].join("\n"),
+    );
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What Problem This Solves

The force-clear suite could leave agent/shared SQLite handles and schema-validation state alive across non-isolated Vitest module resets. A later persistence test could then report noncanonical `claw_package_refs`, making the result depend on test execution order.

## Why This Change Was Made

This uses the canonical `OpenClawTestState` fixture cleanup so the suite releases the SQLite state it owns, and adds a deterministic same-worker order regression covering the force-clear-to-persistence sequence.

## User Impact

There is no user-visible runtime change. The affected embedded-agent tests are isolated from prior same-worker SQLite state and remain deterministic across non-isolated module resets.

## Evidence

- Affected suites: 13/13 passing.
- Tooling regression: 4/4 passing, including the exact shared-worker ordered pair.
- `oxfmt` clean.
- `git diff --check` clean.
- Codex-backed autoreview clean.
- TruffleHog clean.

AI-assisted: Yes.
