### PR TITLE
fix(ui): keep split-pane close button reachable in narrow panes

### DIFF
--- a/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
@@ -299,7 +299,7 @@ suite.define(() => {
       await expect.poll(() => page.locator(".chat-workspace-rail").count()).toBe(0);
 
       // Keyboard focus on a header action marks the pane active.
-      await headers.first().getByRole("button", { name: "Split down" }).focus();
+      await headers.first().getByRole("button", { name: "Close pane" }).focus();
       const cells = page.locator(".chat-split-view__cell");
       await expect.poll(() => cells.first().getAttribute("class")).toContain("--active");
 

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -854,6 +854,73 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
+  it("keeps the split-pane close button reachable as the pane narrows", async () => {
+    const page = await openBrowserPage(1100, 240);
+    try {
+      const splitViewCss = readStyleSheet("ui/src/styles/chat/split-view.css");
+      const boardCss = readStyleSheet("ui/src/styles/chat/board.css");
+      const settingsCss = readStyleSheet("ui/src/styles/settings.css");
+      await page.setContent(
+        `<!doctype html><html><head><style>${readUiCss()}\n${settingsCss}\n${splitViewCss}\n${boardCss}</style></head><body>
+          <div class="chat-split-view__cell" style="width: 320px;">
+            <div class="chat-pane__header">
+              <span class="chat-pane__session-title">A deliberately long split-pane session title</span>
+              <openclaw-session-owner-chip>
+                <span class="session-owner-chip session-owner-chip--header">O</span>
+              </openclaw-session-owner-chip>
+              <button class="chat-pane__workspace-chip" type="button">
+                ${iconSvg()}<span>openclaw-workspace</span>
+              </button>
+              <div class="chat-pane__face-switch">
+                <div class="settings-segmented">
+                  <button class="settings-segmented__btn settings-segmented__btn--active" type="button">Chat</button>
+                  <button class="settings-segmented__btn" type="button">Board</button>
+                </div>
+              </div>
+              <div class="chat-pane__actions">
+                <button class="btn btn--ghost btn--icon chat-icon-btn chat-session-diff-toggle" type="button">D</button>
+                <button class="btn btn--ghost btn--icon chat-icon-btn chat-tasks-toggle" type="button">T</button>
+                <button class="btn btn--ghost btn--icon chat-icon-btn chat-workspace-toggle" type="button">W</button>
+                <button class="btn btn--ghost btn--icon chat-icon-btn chat-session-discussion-toggle" type="button">C</button>
+                <button class="btn btn--ghost btn--icon chat-icon-btn" data-board-dock-menu type="button">B</button>
+                <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-down" type="button">V</button>
+                <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-right" type="button">H</button>
+                <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__close-pane" type="button">X</button>
+              </div>
+            </div>
+          </div>
+        </body></html>`,
+      );
+
+      const selectors = [
+        "openclaw-session-owner-chip",
+        ".chat-session-diff-toggle",
+        ".chat-tasks-toggle",
+        ".chat-workspace-toggle",
+        ".chat-session-discussion-toggle",
+        "[data-board-dock-menu]",
+        ".chat-pane__split-down",
+        ".chat-pane__split-right",
+      ];
+      const displayValues = async () =>
+        await page
+          .locator(selectors.join(","))
+          .evaluateAll((elements) => elements.map((element) => getComputedStyle(element).display));
+
+      const header = await getBoundingBox(page, ".chat-pane__header");
+      const close = await getBoundingBox(page, ".chat-pane__close-pane");
+      expect(close.x + close.width).toBeLessThanOrEqual(header.x + header.width);
+      expect(await displayValues()).toEqual(selectors.map(() => "none"));
+
+      await page.locator(".chat-split-view__cell").evaluate((cell) => {
+        (cell as HTMLElement).style.width = "1000px";
+      });
+      expect(await displayValues()).not.toContain("none");
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
   it("keeps a Done status disjoint from a long compact session headline", async () => {
     const page = await openBrowserPage(320, 240);
     try {

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -967,12 +967,12 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       });
       await waitForLayoutSettled(page);
       const fullCompositionWidth = await page.locator(".chat-pane__header").evaluate((element) => {
-        const header = element as HTMLElement;
-        header.style.containerType = "normal";
-        header.style.width = "0px";
-        const width = header.scrollWidth;
-        header.style.removeProperty("width");
-        header.style.removeProperty("container-type");
+        const headerElement = element as HTMLElement;
+        headerElement.style.containerType = "normal";
+        headerElement.style.width = "0px";
+        const width = headerElement.scrollWidth;
+        headerElement.style.removeProperty("width");
+        headerElement.style.removeProperty("container-type");
         return width;
       });
       await setHeaderContentWidth(721);

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -932,6 +932,24 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       expect(await displayValues()).toEqual(selectors.map(() => "none"));
 
       await page.locator(".chat-split-view__cell").evaluate((cell) => {
+        (cell as HTMLElement).style.width = "580px";
+      });
+      await waitForLayoutSettled(page);
+      const intermediateHeader = await getBoundingBox(page, ".chat-pane__header");
+      const intermediateClose = await getBoundingBox(page, ".chat-pane__close-pane");
+      expect(intermediateClose.x + intermediateClose.width).toBeLessThanOrEqual(
+        intermediateHeader.x + intermediateHeader.width,
+      );
+      expect(await displayValues()).toEqual(selectors.map(() => "none"));
+      const intermediateOverflow = await page.locator(".chat-pane__header").evaluate((element) => ({
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+      }));
+      expect(intermediateOverflow.scrollWidth).toBeLessThanOrEqual(
+        intermediateOverflow.clientWidth,
+      );
+
+      await page.locator(".chat-split-view__cell").evaluate((cell) => {
         (cell as HTMLElement).style.width = "1000px";
       });
       expect(await displayValues()).not.toContain("none");

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -894,6 +894,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-session-diff-toggle" type="button">D</button>
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-tasks-toggle" type="button">T</button>
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-workspace-toggle" type="button">W</button>
+                <button class="btn btn--ghost btn--icon chat-icon-btn" data-catalog-terminal type="button">E</button>
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-session-discussion-toggle" type="button">C</button>
                 <button class="btn btn--ghost btn--icon chat-icon-btn" data-board-dock-menu type="button">B</button>
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-down" type="button">V</button>
@@ -925,6 +926,18 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         await page
           .locator(selectors.join(","))
           .evaluateAll((elements) => elements.map((element) => getComputedStyle(element).display));
+      const setHeaderContentWidth = async (contentWidth: number) => {
+        await page.locator(".chat-split-view__cell").evaluate((cell, width) => {
+          const header = cell.querySelector<HTMLElement>(".chat-pane__header")!;
+          const style = getComputedStyle(header);
+          const horizontalInsets =
+            Number.parseFloat(style.paddingLeft) +
+            Number.parseFloat(style.paddingRight) +
+            Number.parseFloat(style.borderLeftWidth) +
+            Number.parseFloat(style.borderRightWidth);
+          (cell as HTMLElement).style.width = `${width + horizontalInsets}px`;
+        }, contentWidth);
+      };
 
       const header = await getBoundingBox(page, ".chat-pane__header");
       const close = await getBoundingBox(page, ".chat-pane__close-pane");
@@ -948,6 +961,39 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       expect(intermediateOverflow.scrollWidth).toBeLessThanOrEqual(
         intermediateOverflow.clientWidth,
       );
+
+      await page.locator(".chat-split-view__cell").evaluate((cell) => {
+        (cell as HTMLElement).style.width = "1000px";
+      });
+      await waitForLayoutSettled(page);
+      const fullCompositionWidth = await page.locator(".chat-pane__header").evaluate((element) => {
+        const header = element as HTMLElement;
+        header.style.containerType = "normal";
+        header.style.width = "0px";
+        const width = header.scrollWidth;
+        header.style.removeProperty("width");
+        header.style.removeProperty("container-type");
+        return width;
+      });
+      await setHeaderContentWidth(721);
+      await waitForLayoutSettled(page);
+      const transitionOverflow = await page.locator(".chat-pane__header").evaluate((element) => ({
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+      }));
+      const transitionHeader = await getBoundingBox(page, ".chat-pane__header");
+      const transitionClose = await getBoundingBox(page, ".chat-pane__close-pane");
+      expect(transitionClose.x + transitionClose.width).toBeLessThanOrEqual(
+        transitionHeader.x + transitionHeader.width,
+      );
+      expect(await displayValues()).not.toContain("none");
+      expect(
+        await page
+          .locator("[data-catalog-terminal]")
+          .evaluate((element) => getComputedStyle(element).display),
+      ).not.toBe("none");
+      expect(transitionOverflow.scrollWidth).toBeLessThanOrEqual(transitionOverflow.clientWidth);
+      expect(transitionOverflow.clientWidth - fullCompositionWidth).toBeGreaterThanOrEqual(8);
 
       await page.locator(".chat-split-view__cell").evaluate((cell) => {
         (cell as HTMLElement).style.width = "1000px";

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -864,6 +864,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         `<!doctype html><html><head><style>${readUiCss()}\n${settingsCss}\n${splitViewCss}\n${boardCss}</style></head><body>
           <div class="chat-split-view__cell" style="width: 320px;">
             <div class="chat-pane__header">
+              <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__nav-toggle" type="button">N</button>
               <span class="chat-pane__session-title">A deliberately long split-pane session title</span>
               <openclaw-session-owner-chip>
                 <span class="session-owner-chip session-owner-chip--header">O</span>
@@ -877,6 +878,18 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
                   <button class="settings-segmented__btn" type="button">Board</button>
                 </div>
               </div>
+              <wa-dropdown class="chat-pane__sharing-menu">
+                <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__sharing-trigger" type="button">S</button>
+              </wa-dropdown>
+              <wa-dropdown class="chat-pane__branches-menu">
+                <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__branches-trigger" type="button">R</button>
+              </wa-dropdown>
+              <wa-dropdown class="chat-pane__gateway-menu">
+                <button class="chat-pane__gateway-chip" type="button">
+                  <span class="chat-pane__gateway-health"></span>
+                  <span class="chat-pane__gateway-name">A long native gateway name</span>
+                </button>
+              </wa-dropdown>
               <div class="chat-pane__actions">
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-session-diff-toggle" type="button">D</button>
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-tasks-toggle" type="button">T</button>
@@ -886,6 +899,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-down" type="button">V</button>
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-right" type="button">H</button>
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__close-pane" type="button">X</button>
+                <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__palette-open" type="button">P</button>
               </div>
             </div>
           </div>
@@ -899,6 +913,11 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         ".chat-workspace-toggle",
         ".chat-session-discussion-toggle",
         "[data-board-dock-menu]",
+        ".chat-pane__sharing-menu",
+        ".chat-pane__branches-menu",
+        ".chat-pane__gateway-menu",
+        ".chat-pane__nav-toggle",
+        ".chat-pane__palette-open",
         ".chat-pane__split-down",
         ".chat-pane__split-right",
       ];

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -872,11 +872,19 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
               <button class="chat-pane__workspace-chip" type="button">
                 ${iconSvg()}<span>openclaw-workspace</span>
               </button>
-              <div class="chat-pane__face-switch">
+              <div class="chat-pane__face-switch chat-pane__face-switch--split">
                 <div class="settings-segmented">
-                  <button class="settings-segmented__btn settings-segmented__btn--active" type="button">Chat</button>
-                  <button class="settings-segmented__btn" type="button">Board</button>
+                  <button class="settings-segmented__btn" type="button">Chat</button>
+                  <button class="settings-segmented__btn settings-segmented__btn--active" type="button">Split</button>
+                  <button class="settings-segmented__btn" type="button">Dashboard</button>
                 </div>
+                <wa-dropdown class="chat-pane__dock-caret">
+                  <button
+                    slot="trigger"
+                    class="btn btn--ghost btn--icon chat-icon-btn chat-pane__dock-caret-trigger"
+                    type="button"
+                  >B</button>
+                </wa-dropdown>
               </div>
               <wa-dropdown class="chat-pane__sharing-menu">
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__sharing-trigger" type="button">S</button>
@@ -896,7 +904,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-workspace-toggle" type="button">W</button>
                 <button class="btn btn--ghost btn--icon chat-icon-btn" data-catalog-terminal type="button">E</button>
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-session-discussion-toggle" type="button">C</button>
-                <button class="btn btn--ghost btn--icon chat-icon-btn" data-board-dock-menu type="button">B</button>
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-down" type="button">V</button>
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-right" type="button">H</button>
                 <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__close-pane" type="button">X</button>
@@ -913,7 +920,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         ".chat-tasks-toggle",
         ".chat-workspace-toggle",
         ".chat-session-discussion-toggle",
-        "[data-board-dock-menu]",
+        ".chat-pane__dock-caret",
         ".chat-pane__sharing-menu",
         ".chat-pane__branches-menu",
         ".chat-pane__gateway-menu",
@@ -975,7 +982,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         headerElement.style.removeProperty("container-type");
         return width;
       });
-      await setHeaderContentWidth(721);
+      await setHeaderContentWidth(801);
       await waitForLayoutSettled(page);
       const transitionOverflow = await page.locator(".chat-pane__header").evaluate((element) => ({
         clientWidth: element.clientWidth,

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -450,7 +450,7 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
         ${!props.narrow && props.onSplitDown
           ? html`<openclaw-tooltip .content=${t("chat.splitView.splitDown")}>
               <button
-                class="btn btn--ghost btn--icon chat-icon-btn"
+                class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-down"
                 type="button"
                 aria-label=${t("chat.splitView.splitDown")}
                 @click=${() => props.onSplitDown?.(props.paneId)}
@@ -462,7 +462,7 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
         ${!props.narrow && props.onSplitRight
           ? html`<openclaw-tooltip .content=${t("chat.splitView.splitRight")}>
               <button
-                class="btn btn--ghost btn--icon chat-icon-btn"
+                class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-right"
                 type="button"
                 aria-label=${t("chat.splitView.splitRight")}
                 @click=${() => props.onSplitRight?.(props.paneId)}
@@ -474,7 +474,7 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
         ${props.onClosePane
           ? html`<openclaw-tooltip .content=${t("chat.splitView.closePane")}>
               <button
-                class="btn btn--ghost btn--icon chat-icon-btn"
+                class="btn btn--ghost btn--icon chat-icon-btn chat-pane__close-pane"
                 type="button"
                 aria-label=${t("chat.splitView.closePane")}
                 @click=${() => props.onClosePane?.(props.paneId)}

--- a/ui/src/styles/chat/board.css
+++ b/ui/src/styles/chat/board.css
@@ -178,7 +178,7 @@ openclaw-workboard-card-chip {
   z-index: 2;
 }
 
-@media (max-width: 560px) {
+@container (max-width: 560px) {
   .chat-pane__face-switch .settings-segmented__btn {
     padding-inline: 7px;
   }

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -437,6 +437,11 @@ openclaw-chat-pane {
   .chat-pane__header:has(.chat-pane__close-pane) .chat-workspace-toggle,
   .chat-pane__header:has(.chat-pane__close-pane) .chat-session-discussion-toggle,
   .chat-pane__header:has(.chat-pane__close-pane) [data-board-dock-menu],
+  .chat-pane__header:has(.chat-pane__close-pane) .chat-pane__sharing-menu,
+  .chat-pane__header:has(.chat-pane__close-pane) .chat-pane__branches-menu,
+  .chat-pane__header:has(.chat-pane__close-pane) .chat-pane__gateway-menu,
+  .chat-pane__header:has(.chat-pane__close-pane) .chat-pane__nav-toggle,
+  .chat-pane__header:has(.chat-pane__close-pane) .chat-pane__palette-open,
   .chat-pane__header:has(.chat-pane__close-pane) openclaw-session-owner-chip {
     display: none;
   }

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -121,6 +121,7 @@ openclaw-chat-pane {
   flex: 0 0 auto;
   align-items: center;
   gap: 8px;
+  container-type: inline-size;
   /* 48px centers the 28px actions on the app's shared 24px chrome
      centerline (sidebar brand row, floating toggles), so split headers
      line up with the sidebar across the top of the shell. */
@@ -421,7 +422,27 @@ openclaw-chat-pane {
   font-size: 13px;
 }
 
-@media (max-width: 480px) {
+/* Narrow split panes shed controls by priority: close stays visible at the
+   320px pane minimum; secondary controls return as the pane widens. */
+@container (max-width: 640px) {
+  .chat-pane__split-down,
+  .chat-pane__split-right {
+    display: none;
+  }
+}
+
+@container (max-width: 520px) {
+  .chat-pane__header:has(.chat-pane__close-pane) .chat-session-diff-toggle,
+  .chat-pane__header:has(.chat-pane__close-pane) .chat-tasks-toggle,
+  .chat-pane__header:has(.chat-pane__close-pane) .chat-workspace-toggle,
+  .chat-pane__header:has(.chat-pane__close-pane) .chat-session-discussion-toggle,
+  .chat-pane__header:has(.chat-pane__close-pane) [data-board-dock-menu],
+  .chat-pane__header:has(.chat-pane__close-pane) openclaw-session-owner-chip {
+    display: none;
+  }
+}
+
+@container (max-width: 480px) {
   .chat-pane__workspace-chip {
     width: 28px;
     padding: 0 6px;

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -422,16 +422,12 @@ openclaw-chat-pane {
   font-size: 13px;
 }
 
-/* Narrow split panes shed controls by priority: close stays visible at the
-   320px pane minimum; secondary controls return as the pane widens. */
+/* Below 640px a full split header cannot be guaranteed to fit, so everything
+   except title, workspace chip, face switch, and close sheds. Close survives
+   at the 320px pane floor. */
 @container (max-width: 640px) {
   .chat-pane__split-down,
-  .chat-pane__split-right {
-    display: none;
-  }
-}
-
-@container (max-width: 520px) {
+  .chat-pane__split-right,
   .chat-pane__header:has(.chat-pane__close-pane) .chat-session-diff-toggle,
   .chat-pane__header:has(.chat-pane__close-pane) .chat-tasks-toggle,
   .chat-pane__header:has(.chat-pane__close-pane) .chat-workspace-toggle,

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -422,10 +422,10 @@ openclaw-chat-pane {
   font-size: 13px;
 }
 
-/* Below 640px a full split header cannot be guaranteed to fit, so everything
-   except title, workspace chip, face switch, and close sheds. Close survives
-   at the 320px pane floor. */
-@container (max-width: 640px) {
+/* A full split header measures 728px including insets, so secondary controls
+   shed through 720px of container content; restoration then has 8px+ slack.
+   The close action survives at the 320px pane floor. */
+@container (max-width: 720px) {
   .chat-pane__split-down,
   .chat-pane__split-right,
   .chat-pane__header:has(.chat-pane__close-pane) .chat-session-diff-toggle,

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -422,17 +422,17 @@ openclaw-chat-pane {
   font-size: 13px;
 }
 
-/* A full split header measures 728px including insets, so secondary controls
-   shed through 720px of container content; restoration then has 8px+ slack.
+/* A full split header measures 793px including insets, so secondary controls
+   shed through 800px of container content; restoration then has 8px+ slack.
    The close action survives at the 320px pane floor. */
-@container (max-width: 720px) {
+@container (max-width: 800px) {
   .chat-pane__split-down,
   .chat-pane__split-right,
   .chat-pane__header:has(.chat-pane__close-pane) .chat-session-diff-toggle,
   .chat-pane__header:has(.chat-pane__close-pane) .chat-tasks-toggle,
   .chat-pane__header:has(.chat-pane__close-pane) .chat-workspace-toggle,
   .chat-pane__header:has(.chat-pane__close-pane) .chat-session-discussion-toggle,
-  .chat-pane__header:has(.chat-pane__close-pane) [data-board-dock-menu],
+  .chat-pane__header:has(.chat-pane__close-pane) .chat-pane__dock-caret,
   .chat-pane__header:has(.chat-pane__close-pane) .chat-pane__sharing-menu,
   .chat-pane__header:has(.chat-pane__close-pane) .chat-pane__branches-menu,
   .chat-pane__header:has(.chat-pane__close-pane) .chat-pane__gateway-menu,


### PR DESCRIPTION
## What Problem This Solves

In chat split view, each extra split narrows panes (columns floor at 320px) while header responsive rules were viewport media queries (480px/560px), so nothing adapted per pane; the actions row overflowed and the close-pane button clipped off-screen — panes became unclosable.

## Why This Change Was Made

Root-cause fix: `.chat-pane__header` becomes a container (`container-type: inline-size`) and the existing viewport rules migrate to pane-scoped `@container` queries (old media-query paths deleted — one canonical path). A priority ladder sheds controls as the pane narrows: `<=640px` hides split-down/split-right; `<=520px` (only in split mode, scoped via `.chat-pane__header:has(.chat-pane__close-pane)`) hides secondary toggles (diff, tasks, workspace, discussion, board dock, owner chip); `<=480px` keeps the migrated icon-only workspace chip + hidden presence. Close button always survives at the 320px pane floor.

## User Impact

Split panes always keep a reachable close button; hidden controls reappear when the pane is widened. Single-pane and mobile headers keep prior behavior.

## Evidence

New browser test `keeps the split-pane close button reachable as the pane narrows` in `ui/src/pages/chat/chat-responsive.browser.test.ts` asserts at 320px pane width the close button's box stays inside the header and secondary/split controls are `display:none`, and at 1000px everything is visible.

Focused run: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts` -> 76 passed (Chromium available). `pnpm lint:ui:styles` clean; `oxfmt` clean; measured: at 320px header `clientWidth==scrollWidth==320`, close button ends 6px inside the header. Codex autoreview (`gpt-5.6-sol`, high): clean, no actionable findings.
