### PR TITLE
fix(agents): carry complete tool args from content_block_start input

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -3492,5 +3492,113 @@ describe("createCliJsonlStreamingParser", () => {
 
     expect(commentaryTexts).toEqual(expectedCommentary);
   });
+
+  it("carries complete tool args from content_block_start input without input_json_delta chunks", () => {
+    // Regression: backends that deliver the whole tool input on the start block
+    // (instead of streaming input_json_delta parts) used to emit a start delta
+    // with empty args, dropping the resolved command/args from the Discord
+    // progress draft (name-only rows). See #120306.
+    const starts: CliToolUseStartDelta[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onToolUseStart: (delta) => starts.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-input-on-start" }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: {
+              type: "tool_use",
+              id: "toolu_1",
+              name: "Bash",
+              input: { command: "ls -la", cwd: "/tmp" },
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(starts).toEqual([
+      {
+        toolCallId: "toolu_1",
+        name: "Bash",
+        kind: "tool_use",
+        args: { command: "ls -la", cwd: "/tmp" },
+      },
+    ]);
+  });
+
+  it("keeps streaming input_json_delta accumulation when the start block input is empty", () => {
+    // The streaming placeholder (input: {}) must not seed parts, otherwise the
+    // delta chunks concatenated after it would corrupt the JSON fragment.
+    const starts: CliToolUseStartDelta[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onToolUseStart: (delta) => starts.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-input-deltas" }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "tool_use", id: "toolu_1", name: "Bash", input: {} },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "input_json_delta", partial_json: '{"command": "ls' },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "input_json_delta", partial_json: ' -la"}' },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(starts).toEqual([
+      { toolCallId: "toolu_1", name: "Bash", kind: "tool_use", args: { command: "ls -la" } },
+    ]);
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -937,11 +937,17 @@ function dispatchClaudeCliStreamingToolEvent(params: {
         const toolCallId = typeof block.id === "string" ? block.id.trim() : "";
         const name = typeof block.name === "string" ? block.name.trim() : "";
         if (toolCallId && name) {
+          // Some backends deliver the complete tool input on the start block
+          // instead of streaming it as input_json_delta chunks; seed the parts
+          // so the stop event emits a start delta with real args. An empty
+          // input object is the streaming placeholder, so only seed non-empty
+          // inputs to avoid corrupting subsequent delta concatenation.
+          const completeInput = isRecord(block.input) && Object.keys(block.input).length > 0;
           tracker.pendingByIndex.set(event.index, {
             toolCallId,
             name,
             kind: block.type,
-            inputJsonParts: [],
+            inputJsonParts: completeInput ? [JSON.stringify(block.input)] : [],
           });
         }
       } else if (isClaudeAssistantToolResultBlockType(block.type)) {


### PR DESCRIPTION
## What Problem

Backends that deliver the whole tool input on the `content_block_start` event (instead of streaming `input_json_delta` chunks) produced a tool-start delta with empty args: the start block only recorded id/name, args were assembled solely from delta parts, and the complete copy in the later `assistant` record was dropped by the `startedIds` dedup. Completed tool rows in the Discord progress draft then rendered name-only (`Bash`, `Agent`) with the resolved command/args missing, while TUI and web rendered the same calls correctly (reported in #120306, re-filed after #113631 was closed `not_planned`).

## Why

The fault is in the CLI live-output path: `dispatchClaudeCliStreamingToolEvent` never read `block.input` on the start block, so a backend that supplies the complete input up front produced `{}` args, and no later event could repair the row (the streaming merge guard only carries `detail` forward for `kind === "command-output"`). The root cause is the dropped start-block input, not the renderer.

## User Impact

Discord users in raw progress mode see completed tool rows as icon + name only — no command/args — for backends that do not chunk the input. After this change the draft shows the resolved command/args, matching TUI and web.

## Evidence

- `src/agents/cli-output.ts`: seed `inputJsonParts` from a non-empty `block.input` at `content_block_start` (an empty input object is the streaming placeholder, so only non-empty inputs are seeded to avoid corrupting delta concatenation). 8 production lines.
- `src/agents/cli-output.test.ts`: 108 lines of new coverage — start-block input is carried through to the stop event, empty-input streaming placeholders still assemble args from `input_json_delta` chunks, and the previously-dropped complete copy no longer regresses the emitted args.
- `node scripts/run-vitest.mjs run src/agents/cli-output.test.ts`: 129 tests pass (was 125 before this change; new cases cover the start-block-input and delta-concatenation paths).

[AI-assisted]