### PR TITLE
fix(gateway): resolve restart-recovery state only on lifecycle events

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2858,6 +2858,38 @@ describe("agent event handler", () => {
     ).toBe(false);
   });
 
+  it("skips the session entry read for non-lifecycle events and resolves restart recovery only on lifecycle events", () => {
+    const { broadcast, chatRunState, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-recovery-lazy",
+    });
+    registerChatRun(chatRunState, "run-lazy", "session-recovery-lazy", "client-lazy");
+    vi.mocked(loadSessionEntry).mockClear();
+
+    // High-volume chat delta events must not touch the session store:
+    // restart-recovery state is consumed only by lifecycle-phase handling.
+    for (let seq = 1; seq <= 5; seq++) {
+      emitAgentEvent(
+        handler,
+        "run-lazy",
+        "assistant",
+        { text: `message ${seq}` },
+        { seq, ts: Date.now() + seq * 200 },
+      );
+    }
+    expect(loadSessionEntry).not.toHaveBeenCalled();
+    expect(chatBroadcastCalls(broadcast).length).toBeGreaterThanOrEqual(1);
+
+    // Lifecycle events still resolve restart-recovery state through the store.
+    emitAgentEvent(
+      handler,
+      "run-lazy",
+      "lifecycle",
+      { phase: "end", endedAt: Date.now() },
+      { seq: 6, sessionKey: "session-recovery-lazy" },
+    );
+    expect(loadSessionEntry).toHaveBeenCalled();
+  });
+
   it("clears tracked active runs before terminal sessions.changed broadcasts", async () => {
     vi.mocked(loadGatewaySessionRow).mockReturnValue({
       key: "session-finished",

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1326,9 +1326,18 @@ export function createAgentEventHandler({
       isChatAbortMarkerCurrent(chatRunState.runs.get(clientRunId)?.abortMarker, chatLink) ||
       isChatAbortMarkerCurrent(chatRunState.runs.get(evt.runId)?.abortMarker, chatLink);
 
-    const restartRecoveryState = restartRecoverySessionKey
-      ? resolveRestartRecoveryLifecycleState(restartRecoverySessionKey, restartRecoveryAgentId, evt)
-      : undefined;
+    // Restart-recovery state is consumed only by lifecycle-phase handling
+    // (suppression and terminal projection). Resolving it on every event runs
+    // a session-store read per stream delta; short-circuit non-lifecycle
+    // events the same way resolveSpawnedBy does above.
+    const restartRecoveryState =
+      lifecyclePhase !== null && restartRecoverySessionKey
+        ? resolveRestartRecoveryLifecycleState(
+            restartRecoverySessionKey,
+            restartRecoveryAgentId,
+            evt,
+          )
+        : undefined;
     const suppressRestartRecoveryLifecycle =
       lifecyclePhase !== null &&
       (Boolean(


### PR DESCRIPTION
## What Problem

`handleEvent` resolved `restartRecoveryState` on **every** agent runtime event via `resolveRestartRecoveryLifecycleState`, which runs a session-store read. That state is consumed only by lifecycle-phase handling (suppression and terminal projection), so on delta/flush/final/agent/seq-gap events the value was computed and discarded. Post-turn cost scaled with answer length (one full session-store read per stream delta), stalling the event loop after long model responses.

## Why

The issue (#120378) documents a measured slope of ~1.00 full discovery per extra stream delta and suggests, as the cheapest option, short-circuiting non-lifecycle events — the same move already made for `resolveSpawnedBy` twelve lines above (memoized, short-circuits non-lineage keys). `restartRecoveryState` is read at exactly four sites (`suppressRestartRecoveryLifecycle`, and the `lifecyclePhase === "error"` / `"end"` terminal branches), all unreachable when `lifecyclePhase === null`, so guarding the resolution is behavior-preserving.

## User Impact

Multi-agent gateways see shorter post-turn stalls on long, tool-light answers and less synchronous event-loop contention (one agent finalizing a long turn no longer blocks other agents/channels/Control UI for a fleet enumeration per event). No behavioral change for restart-recovery suppression on lifecycle events.

## Evidence

- `src/gateway/server-chat.ts`: `restartRecoveryState` now resolves only when `lifecyclePhase !== null` (and a session key exists). 5 production lines.
- New regression test in `src/gateway/server-chat.agent-events.test.ts`: five `assistant` delta events do **not** touch `loadSessionEntry` (the mocked session-store read behind `resolveRestartRecoveryLifecycleState`), and a following `lifecycle` `end` event still does. Verified the test fails without the fix (reverted `server-chat.ts` → `expect(loadSessionEntry).not.toHaveBeenCalled()` fails) and passes with it.
- `node scripts/run-vitest.mjs run src/gateway/server-chat.agent-events.test.ts`: 140 tests pass (139 prior + 1 new).
- `tsc --noEmit -p tsconfig.core.json`: clean for touched files.

[AI-assisted]