### PR TITLE
fix(matrix): non-positive mediaMaxMb blocks every outbound media send

### DIFF
--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -997,6 +997,25 @@ describe("sendMessageMatrix media", () => {
     expect(resolveTextChunkLimitMock).toHaveBeenCalledWith(explicitCfg, "matrix", "ops");
   });
 
+  it.each([{ mediaMaxMb: 0 }, { mediaMaxMb: -5 }])(
+    "leaves outbound media uncapped when mediaMaxMb is $mediaMaxMb",
+    async ({ mediaMaxMb }) => {
+      const { client } = makeClient();
+
+      await sendMessageMatrix("room:!room:example", "caption", {
+        client,
+        cfg: { channels: { matrix: { mediaMaxMb } } },
+        mediaUrl: "file:///tmp/photo.png",
+      });
+
+      const mediaOptions = requireRecord(
+        mockCallArg(loadWebMediaMock, "loadWebMedia", 1),
+        "media options",
+      );
+      expect(mediaOptions.maxBytes).toBeUndefined();
+    },
+  );
+
   it("passes caller mediaLocalRoots to media loading", async () => {
     const { client } = makeClient();
 

--- a/extensions/matrix/src/matrix/send/client.ts
+++ b/extensions/matrix/src/matrix/send/client.ts
@@ -18,11 +18,11 @@ export function resolveMediaMaxBytes(
   }
   const resolvedCfg = requireRuntimeConfig(cfg, "Matrix media limits") as CoreConfig;
   const matrixCfg = resolveMatrixAccountConfig({ cfg: resolvedCfg, accountId });
-  const mediaMaxMb = typeof matrixCfg.mediaMaxMb === "number" ? matrixCfg.mediaMaxMb : undefined;
-  if (typeof mediaMaxMb === "number") {
-    return mediaMaxMb * 1024 * 1024;
-  }
-  return undefined;
+  const mediaMaxMb = matrixCfg.mediaMaxMb;
+  // Only a positive value is a cap, matching CommonMediaMaxMbSchema. `0` or a negative
+  // number would become a literal 0-byte limit that rejects every outbound media send;
+  // fall through to the unset path instead. Inbound floors the same field (monitor/index.ts).
+  return typeof mediaMaxMb === "number" && mediaMaxMb > 0 ? mediaMaxMb * 1024 * 1024 : undefined;
 }
 
 export async function withResolvedMatrixSendClient<T>(


### PR DESCRIPTION
**Prompt request:** Make the Matrix outbound media path treat a non-positive `mediaMaxMb` the
same way it treats an unset one, without changing how a positive cap is resolved or enforced.

**Proof target:** Show that an attachment configured with a non-positive `mediaMaxMb` loads
successfully instead of throwing before upload, and that a `mediaMaxMb: 1` cap still rejects an
oversized attachment.

This PR does not close an issue.

## What Problem This Solves

Fixes an issue where a Matrix operator who sets `channels.matrix.mediaMaxMb` to `0` — at the
channel level or on an individual account — has their agent's media replies fail before upload,
while inbound attachments on the same account keep working normally. A negative value fails the
same way.

The value is accepted at config load with no warning, and the failures name an internal limit
rather than the setting that caused them. Both attachment kinds exercised below fail:

- an image fails with `maxBytes must be a positive integer` — the loader's image path forwards the
  cap as an encode byte budget, and the encoder rejects a non-positive one;
- a non-image attachment fails with `Media exceeds 0MB limit (got 0.00MB)`.

The inbound side of the same channel already floors this value
(`Math.max(1, mediaMaxMb)` in `extensions/matrix/src/matrix/monitor/index.ts`), so the two
directions of one channel disagree about what a non-positive value means.

The config is accepted because `matrix` hand-rolls the field as `z.number().optional()` in
`extensions/matrix/src/config-schema.ts`, instead of reusing the shared
`CommonMediaMaxMbSchema = z.number().positive()`
(`src/config/zod-schema.channel-messaging-common.ts`) that most bundled channels use. That is a
reading of the two schema declarations, not something the capture below demonstrates; the capture
starts from resolved config.

## Why This Change Was Made

**Root cause:** `resolveMediaMaxBytes` accepted any `number` as an explicit cap, so a value that
cannot be a cap was multiplied into a byte limit and handed to the shared media loader. Between the
two, `resolveMatrixAccountConfig` returns the configured value as-is and
`buildOutboundMediaLoadOptions` (`src/media/load-options.ts`) forwards it on `!== undefined` rather
than on truthiness, so nothing downstream absorbs a non-positive value — and the shared loader is
right to trust a cap a channel states explicitly. That makes the resolver the place to fix it.

**Fix:** this PR changes `resolveMediaMaxBytes` to treat only a positive value as an explicit cap,
which is the predicate the shared `CommonMediaMaxMbSchema` already applies for the channels that
use it. Anything else falls through to the existing "no explicit cap" result, which is not
unlimited: the shared loader then applies its per-kind ceilings (`maxBytesForKind` in
`packages/media-core/src/constants.ts`), the same ones that already apply to every Matrix operator
who leaves the field unset. The `mediaMaxMb * 1024 * 1024` expression is unchanged in the diff, and
config loading is untouched too — this change edits no schema — so the set of configs that load is
unchanged and a positive cap still resolves through that same expression. "Behaves as unset" means
one specific thing throughout this PR: the loader's per-kind ceilings decide, instead of a
channel-supplied cap.

**Tests:** a table-driven regression case in `extensions/matrix/src/matrix/send.test.ts`, next to
the existing `mediaMaxMb: 1` case that pins the positive path at `1048576` bytes, asserts that `0`
and a negative value both reach the media loader as no explicit cap. Reverting the resolver guard
fails both.

**Non-scope:** this change is limited to the Matrix outbound resolver, and the alternatives below
are out of scope here. Tightening the plugin schema to `.positive()` would be the other candidate
fix, but it rejects configs that load today, and `matrix` accepts per-account overrides as
`z.unknown()`, so it would not close the account-level path anyway. The inbound path already floors
this value and is untouched. `line` and `zalo` declare the same field without a range constraint
but consume it on different paths, so each would need its own change.

**Limitations:** the proof covers the outbound media load, which is the step where the failure this
fixes occurs. Upload and delivery to a live homeserver are later steps and stay outside the capture.

## User Impact

A Matrix account configured with a non-positive `mediaMaxMb` no longer fails every media send on an
invalid cap. Such an account takes the same code path as one that leaves the field unset, so the
shared loader's per-kind ceilings decide the outcome and an attachment over those ceilings is still
rejected. That rejection is produced by unchanged code, so it is expected to read like every other
over-size rejection rather than the `0MB` one; the capture below does not exercise it.

Operators using a positive cap see no change: the resolved byte value comes out of the same
unchanged expression, and oversized attachments are still rejected. The capture below pins that at
`mediaMaxMb: 1`; the wider claim rests on the expression being untouched in the diff.

## Change size

Counting tests separately: production is +5/-5 (net zero), and the test file adds 19 lines.

## Evidence

### Real behavior proof

Behavior addressed: a Matrix outbound media send configured with `channels.matrix.mediaMaxMb: 0` at
the channel level, the same at the account level, and `-5` at the channel level, for an image and
for a non-image attachment. Channel-level and account-level values converge into one
`resolveMatrixAccountConfig` result before the guard sees them, so the account-level case is there
to show the account path reaches the same predicate, not to re-test each value on both levels.
The `-5` case is captured for an image; the non-image sink is captured at `0`. In the output below,
`cap=undefined` and the structured capture's `"capBytes": null` are the same state — no explicit
cap — spelled differently because the structured form is JSON.

The command below is the reproducible one: it runs the script at whichever checkout you are in, so
running it once on this branch and once on the merge base gives the two outputs shown. The collapsed
structured block that follows is corroboration from a separate automated before/after run of an
equivalent harness at those same two commits; it is included as evidence, not as something a
reviewer needs to re-run.

This is not an end-to-end send. The script below reproduces the two calls
`extensions/matrix/src/matrix/send.ts` makes when it has media to send —
`resolveMediaMaxBytes(accountId, cfg)`, then `loadOutboundMediaFromUrl(mediaUrl, { maxBytes })` —
because that is where the failure occurs. That second call is the one that runs
`buildOutboundMediaLoadOptions` internally, so the forwarding step named above is exercised rather
than bypassed. No homeserver is involved.

Real environment tested: Linux x86_64, node v24.18.0. Captured at `e8766606529e` (this PR's head)
and at `8b8058a68b6a` (its merge base).

Exact steps or command run after this patch: save the script below at the repo root and run it with
`node --import tsx <script>`.

```js
import fs from "node:fs/promises";
import os from "node:os";
import path from "node:path";
import { pathToFileURL } from "node:url";

const { resolveMediaMaxBytes } = await import("./extensions/matrix/src/matrix/send/client.ts");
const { loadOutboundMediaFromUrl } = await import("./src/plugin-sdk/outbound-media.ts");

const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "matrix-media-")));
await fs.writeFile(
  path.join(dir, "photo.png"),
  Buffer.from(
    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
    "base64",
  ),
);
await fs.writeFile(path.join(dir, "notes.txt"), Buffer.alloc(1024, 0x41));
await fs.writeFile(path.join(dir, "report.txt"), Buffer.alloc(2 * 1024 * 1024, 0x41));

// The two calls extensions/matrix/src/matrix/send.ts makes for an outbound media send.
for (const [label, cfg, accountId, file] of [
  ["mediaMaxMb: 0, image", { channels: { matrix: { mediaMaxMb: 0 } } }, undefined, "photo.png"],
  [
    "mediaMaxMb: 0 on account 'ops', image",
    { channels: { matrix: { accounts: { ops: { mediaMaxMb: 0 } } } } },
    "ops",
    "photo.png",
  ],
  ["mediaMaxMb: -5, image", { channels: { matrix: { mediaMaxMb: -5 } } }, undefined, "photo.png"],
  ["mediaMaxMb: 0, document", { channels: { matrix: { mediaMaxMb: 0 } } }, undefined, "notes.txt"],
  ["unset, image", { channels: { matrix: {} } }, undefined, "photo.png"],
  ["mediaMaxMb: 1, image", { channels: { matrix: { mediaMaxMb: 1 } } }, undefined, "photo.png"],
  ["mediaMaxMb: 1, 2MB document", { channels: { matrix: { mediaMaxMb: 1 } } }, undefined, "report.txt"],
]) {
  const maxBytes = resolveMediaMaxBytes(accountId, cfg);
  try {
    const media = await loadOutboundMediaFromUrl(pathToFileURL(path.join(dir, file)).href, {
      maxBytes,
      mediaLocalRoots: [dir],
    });
    console.log(`${label} -> cap=${maxBytes} LOADED ${media.buffer.length}B ${media.contentType}`);
  } catch (err) {
    console.log(`${label} -> cap=${maxBytes} FAILED ${err.message}`);
  }
}
await fs.rm(dir, { recursive: true, force: true });
```

Its output at `8b8058a68b6a` (pre-fix):

```text
mediaMaxMb: 0, image -> cap=0 FAILED maxBytes must be a positive integer
mediaMaxMb: 0 on account 'ops', image -> cap=0 FAILED maxBytes must be a positive integer
mediaMaxMb: -5, image -> cap=-5242880 FAILED maxBytes must be a positive integer
mediaMaxMb: 0, document -> cap=0 FAILED Media exceeds 0MB limit (got 0.00MB)
unset, image -> cap=undefined LOADED 70B image/png
mediaMaxMb: 1, image -> cap=1048576 LOADED 70B image/png
mediaMaxMb: 1, 2MB document -> cap=1048576 FAILED Media exceeds 1MB limit (got 2.00MB)
```

Its output at `e8766606529e` (this PR):

```text
mediaMaxMb: 0, image -> cap=undefined LOADED 70B image/png
mediaMaxMb: 0 on account 'ops', image -> cap=undefined LOADED 70B image/png
mediaMaxMb: -5, image -> cap=undefined LOADED 70B image/png
mediaMaxMb: 0, document -> cap=undefined LOADED 1024B text/plain
unset, image -> cap=undefined LOADED 70B image/png
mediaMaxMb: 1, image -> cap=1048576 LOADED 70B image/png
mediaMaxMb: 1, 2MB document -> cap=1048576 FAILED Media exceeds 1MB limit (got 2.00MB)
```

<details>
<summary>The same seven cases captured as structured output by an automated before/after run at the same two commits</summary>

Before (pre-fix):

```text
===== BEFORE (baseline 8b8058a68b6a, unfixed source) =====
--- harness.stderr ---
[harness: importing [REDACTED:path]/before/extensions/matrix/src/matrix/send/client.ts]
[harness: importing [REDACTED:path]/before/src/plugin-sdk/outbound-media.ts]
[harness: running channel-level mediaMaxMb: 0, small png]
[harness: running account-level mediaMaxMb: 0, small png]
[harness: running channel-level mediaMaxMb: -5, small png]
[harness: running channel-level mediaMaxMb: 0, small document]
[harness: running control: mediaMaxMb unset, small png]
[harness: running control: mediaMaxMb: 1, small png stays allowed]
[harness: running control: mediaMaxMb: 1 still rejects a 2MB document]
--- harness.stdout ---
{
  "clientModule": "extensions/matrix/src/matrix/send/client.ts",
  "mediaModule": "src/plugin-sdk/outbound-media.ts",
  "results": [
    {
      "case": "channel-level mediaMaxMb: 0, small png",
      "sourceBytes": 70,
      "capBytes": 0,
      "mediaLoaded": false,
      "media": null,
      "error": "maxBytes must be a positive integer"
    },
    {
      "case": "account-level mediaMaxMb: 0, small png",
      "sourceBytes": 70,
      "capBytes": 0,
      "mediaLoaded": false,
      "media": null,
      "error": "maxBytes must be a positive integer"
    },
    {
      "case": "channel-level mediaMaxMb: -5, small png",
      "sourceBytes": 70,
      "capBytes": -5242880,
      "mediaLoaded": false,
      "media": null,
      "error": "maxBytes must be a positive integer"
    },
    {
      "case": "channel-level mediaMaxMb: 0, small document",
      "sourceBytes": 1024,
      "capBytes": 0,
      "mediaLoaded": false,
      "media": null,
      "error": "Media exceeds 0MB limit (got 0.00MB)"
    },
    {
      "case": "control: mediaMaxMb unset, small png",
      "sourceBytes": 70,
      "capBytes": null,
      "mediaLoaded": true,
      "media": {
        "byteLength": 70,
        "contentType": "image/png",
        "fileName": "photo.png",
        "kind": "image"
      },
      "error": null
    },
    {
      "case": "control: mediaMaxMb: 1, small png stays allowed",
      "sourceBytes": 70,
      "capBytes": 1048576,
      "mediaLoaded": true,
      "media": {
        "byteLength": 70,
        "contentType": "image/png",
        "fileName": "photo.png",
        "kind": "image"
      },
      "error": null
    },
    {
      "case": "control: mediaMaxMb: 1 still rejects a 2MB document",
      "sourceBytes": 2097152,
      "capBytes": 1048576,
      "mediaLoaded": false,
      "media": null,
      "error": "Media exceeds 1MB limit (got 2.00MB)"
    }
  ]
}

```

Evidence after fix:

```text
===== AFTER (candidate e8766606529e, fix applied) =====
--- harness.stderr ---
[harness: importing [REDACTED:path]/after/extensions/matrix/src/matrix/send/client.ts]
[harness: importing [REDACTED:path]/after/src/plugin-sdk/outbound-media.ts]
[harness: running channel-level mediaMaxMb: 0, small png]
[harness: running account-level mediaMaxMb: 0, small png]
[harness: running channel-level mediaMaxMb: -5, small png]
[harness: running channel-level mediaMaxMb: 0, small document]
[harness: running control: mediaMaxMb unset, small png]
[harness: running control: mediaMaxMb: 1, small png stays allowed]
[harness: running control: mediaMaxMb: 1 still rejects a 2MB document]
--- harness.stdout ---
{
  "clientModule": "extensions/matrix/src/matrix/send/client.ts",
  "mediaModule": "src/plugin-sdk/outbound-media.ts",
  "results": [
    {
      "case": "channel-level mediaMaxMb: 0, small png",
      "sourceBytes": 70,
      "capBytes": null,
      "mediaLoaded": true,
      "media": {
        "byteLength": 70,
        "contentType": "image/png",
        "fileName": "photo.png",
        "kind": "image"
      },
      "error": null
    },
    {
      "case": "account-level mediaMaxMb: 0, small png",
      "sourceBytes": 70,
      "capBytes": null,
      "mediaLoaded": true,
      "media": {
        "byteLength": 70,
        "contentType": "image/png",
        "fileName": "photo.png",
        "kind": "image"
      },
      "error": null
    },
    {
      "case": "channel-level mediaMaxMb: -5, small png",
      "sourceBytes": 70,
      "capBytes": null,
      "mediaLoaded": true,
      "media": {
        "byteLength": 70,
        "contentType": "image/png",
        "fileName": "photo.png",
        "kind": "image"
      },
      "error": null
    },
    {
      "case": "channel-level mediaMaxMb: 0, small document",
      "sourceBytes": 1024,
      "capBytes": null,
      "mediaLoaded": true,
      "media": {
        "byteLength": 1024,
        "contentType": "text/plain",
        "fileName": "notes.txt",
        "kind": "document"
      },
      "error": null
    },
    {
      "case": "control: mediaMaxMb unset, small png",
      "sourceBytes": 70,
      "capBytes": null,
      "mediaLoaded": true,
      "media": {
        "byteLength": 70,
        "contentType": "image/png",
        "fileName": "photo.png",
        "kind": "image"
      },
      "error": null
    },
    {
      "case": "control: mediaMaxMb: 1, small png stays allowed",
      "sourceBytes": 70,
      "capBytes": 1048576,
      "mediaLoaded": true,
      "media": {
        "byteLength": 70,
        "contentType": "image/png",
        "fileName": "photo.png",
        "kind": "image"
      },
      "error": null
    },
    {
      "case": "control: mediaMaxMb: 1 still rejects a 2MB document",
      "sourceBytes": 2097152,
      "capBytes": 1048576,
      "mediaLoaded": false,
      "media": null,
      "error": "Media exceeds 1MB limit (got 2.00MB)"
    }
  ]
}
```

</details>

Observed result after fix: the four non-positive cases go from a throw to a completed load, and the
resolved cap moves from a non-positive byte value to no explicit cap. The three control cases are
identical before and after — an unset cap still loads, `mediaMaxMb: 1` still resolves to `1048576`,
and it still rejects a 2MB attachment with `Media exceeds 1MB limit (got 2.00MB)`.
What was not tested: upload and delivery to a live homeserver, and the inbound download path,
which already floors this value and is unchanged here.

The regression case alone:
`node scripts/run-vitest.mjs extensions/matrix/src/matrix/send.test.ts -t "leaves outbound media uncapped"`.
The whole plugin suite (`node scripts/run-vitest.mjs extensions/matrix`): 122 files, 1924 tests
passing.
