### PR TITLE
fix: allow consecutive compaction preparation

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -357,6 +357,38 @@ describe("session-entry compaction budgeting", () => {
     expect(result.value.messagesToSummarize.length).toBeGreaterThan(0);
   });
 
+  it("can prepare another pass after a compaction entry when retained context is still too large", () => {
+    const entries: SessionTreeEntry[] = [
+      createMessageEntry({ role: "user", content: "first", timestamp: 1 }, 0),
+      createMessageEntry(createAssistant("answer ".repeat(1_000), createUsage(20_000), 2), 1),
+      createMessageEntry({ role: "user", content: "second", timestamp: 3 }, 2),
+      createMessageEntry(createAssistant("answer ".repeat(1_000), createUsage(20_000), 4), 3),
+      {
+        type: "compaction",
+        id: "entry-4",
+        parentId: "entry-3",
+        timestamp: new Date(5).toISOString(),
+        summary: "first pass summary",
+        firstKeptEntryId: "entry-2",
+        tokensBefore: 40_000,
+      },
+    ];
+
+    const result = prepareCompaction(entries, {
+      enabled: true,
+      reserveTokens: 16_384,
+      keepRecentTokens: 1,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok || !result.value) {
+      throw new Error("expected second compaction pass to be prepared");
+    }
+    expect(result.value.previousSummary).toBe("first pass summary");
+    expect(result.value.firstKeptEntryId).toBe("entry-3");
+    expect(result.value.turnPrefixMessages.map((message) => message.role)).toEqual(["user"]);
+  });
+
   it("keeps reset-filtered tool rows out of later compaction input", () => {
     const entries: SessionTreeEntry[] = [
       createMessageEntry({ role: "user", content: "discarded", timestamp: 1 }, 0),

--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -669,10 +669,7 @@ describe("split-turn compaction", () => {
         tokensBefore: result.value.tokensBefore,
         details: result.value.details,
       },
-      createMessageEntry(
-        { role: "assistant", content: [{ type: "text", text: "kept suffix" }], timestamp: 4 },
-        3,
-      ),
+      createMessageEntry(createAssistant("kept suffix", createUsage(10), 4), 3),
     ]);
     expect(replayContext.messages[0]).toMatchObject({
       role: "compactionSummary",

--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createAssistantMessageEventStream } from "../../llm.js";
 import type { AssistantMessage, Model, StreamFn, Usage } from "../../llm.js";
 import type { AgentMessage } from "../../types.js";
+import { buildSessionContext } from "../session/session.js";
 import type { SessionTreeEntry } from "../types.js";
 import {
   calculateContextTokens,
@@ -595,6 +596,90 @@ describe("generateSummary thinking options", () => {
 });
 
 describe("split-turn compaction", () => {
+  it("preserves previous summaries for prefix-only second passes", async () => {
+    const model: Model = {
+      id: "summary-model",
+      name: "Summary Model",
+      api: "test-api",
+      provider: "test-provider",
+      baseUrl: "https://example.test",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 100_000,
+      maxTokens: 8_000,
+    };
+    const streamFn = vi.fn<StreamFn>(() => {
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message: AssistantMessage = {
+          role: "assistant",
+          content: [{ type: "text", text: "prefix summary" }],
+          api: model.api,
+          provider: model.provider,
+          model: model.id,
+          usage: createUsage(0),
+          stopReason: "stop",
+          timestamp: 1,
+        };
+        stream.push({ type: "done", reason: "stop", message });
+        stream.end();
+      });
+      return stream;
+    });
+
+    const result = await compact(
+      {
+        firstKeptEntryId: "kept-entry",
+        messagesToSummarize: [],
+        turnPrefixMessages: [{ role: "user", content: "prefix", timestamp: 2 }],
+        isSplitTurn: true,
+        tokensBefore: 100,
+        previousSummary: "previous compacted history",
+        fileOps: createFileOps(),
+        settings: { enabled: true, reserveTokens: 1_000, keepRecentTokens: 100 },
+      },
+      model,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      streamFn,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected compaction to succeed");
+    }
+    expect(result.value.summary).toContain("previous compacted history");
+    expect(result.value.summary).not.toContain("No prior history.");
+    expect(streamFn).toHaveBeenCalledOnce();
+
+    const replayContext = buildSessionContext([
+      createMessageEntry({ role: "user", content: "old", timestamp: 1 }, 0),
+      createMessageEntry(createAssistant("old answer", createUsage(20), 2), 1),
+      {
+        type: "compaction",
+        id: "entry-2",
+        parentId: "entry-1",
+        timestamp: new Date(3).toISOString(),
+        summary: result.value.summary,
+        firstKeptEntryId: result.value.firstKeptEntryId,
+        tokensBefore: result.value.tokensBefore,
+        details: result.value.details,
+      },
+      createMessageEntry(
+        { role: "assistant", content: [{ type: "text", text: "kept suffix" }], timestamp: 4 },
+        3,
+      ),
+    ]);
+    expect(replayContext.messages[0]).toMatchObject({
+      role: "compactionSummary",
+      summary: expect.stringContaining("previous compacted history"),
+    });
+  });
+
   it("serializes history and turn-prefix summaries", async () => {
     const model: Model = {
       id: "summary-model",

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -851,7 +851,7 @@ export async function compact(
           streamFn,
           runtime,
         )
-      : ok<string, CompactionError>("No prior history.");
+      : ok<string, CompactionError>(previousSummary ?? "No prior history.");
   if (!historyResult.ok) {
     return err(historyResult.error);
   }

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -661,11 +661,7 @@ export function prepareCompaction(
   pathEntries: SessionTreeEntry[],
   settings: CompactionSettings,
 ): Result<CompactionPreparation | undefined, CompactionError> {
-  if (
-    pathEntries.at(-1)?.type === "compaction" ||
-    pathEntries.at(-1)?.type === "reset" ||
-    pathEntries.length === 0
-  ) {
+  if (pathEntries.at(-1)?.type === "reset" || pathEntries.length === 0) {
     return ok(undefined);
   }
 

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -903,6 +903,91 @@ describe("SessionManager.open", () => {
     expect(sessionManager.getAppendParentId()).toBe(appendParentBeforeRejectedAppends);
   });
 
+  it("replays a persisted double compaction after reopening the SQLite session", async () => {
+    const dir = await makeTempDir();
+    const storePath = path.join(dir, "sessions.json");
+    const sessionId = "sqlite-double-compaction-replay";
+    const sessionKey = "agent:main:dashboard:sqlite-double-compaction-replay";
+    const marker = formatSqliteSessionFileMarker({
+      agentId: "main",
+      sessionId,
+      storePath,
+    });
+    const scope = { agentId: "main", sessionId, sessionKey, storePath };
+    await upsertSessionEntry(scope, { sessionFile: marker, sessionId, updatedAt: 1 });
+
+    const firstUser = await appendTranscriptMessage(scope, {
+      cwd: dir,
+      eventId: "first-user",
+      message: { role: "user", content: "question before first compaction" },
+      parentId: null,
+    });
+    const firstAssistant = await appendTranscriptMessage(scope, {
+      cwd: dir,
+      eventId: "first-assistant",
+      message: buildAssistantMessage("answer before first compaction"),
+      parentId: firstUser.messageId,
+    });
+
+    const firstPass = openMarker(marker, sessionKey, dir);
+    const firstCompactionId = firstPass.appendCompaction(
+      "first persisted summary",
+      firstAssistant.messageId,
+      1_000,
+    );
+    firstPass.appendMessage({
+      role: "user",
+      content: "prefix before second compaction",
+      timestamp: 2,
+    });
+
+    const secondPass = openMarker(marker, sessionKey, dir);
+    const secondCompactionId = secondPass.appendCompaction(
+      "first persisted summary\n\nsecond prefix summary",
+      firstCompactionId,
+      1_500,
+    );
+    secondPass.appendMessage(buildAssistantMessage("answer after second compaction"));
+
+    const reopened = openMarker(marker, sessionKey, dir);
+    const context = reopened.buildSessionContext().messages;
+    expect(context).toEqual([
+      expect.objectContaining({
+        role: "compactionSummary",
+        summary: "first persisted summary\n\nsecond prefix summary",
+        tokensBefore: 1_500,
+      }),
+      expect.objectContaining({
+        content: "prefix before second compaction",
+        role: "user",
+      }),
+      expect.objectContaining({
+        content: [{ type: "text", text: "answer after second compaction" }],
+        role: "assistant",
+      }),
+    ]);
+    expect(context).not.toContainEqual(
+      expect.objectContaining({ summary: "first persisted summary", role: "compactionSummary" }),
+    );
+
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          firstKeptEntryId: firstAssistant.messageId,
+          id: firstCompactionId,
+          summary: "first persisted summary",
+          type: "compaction",
+        }),
+        expect.objectContaining({
+          firstKeptEntryId: firstCompactionId,
+          id: secondCompactionId,
+          summary: "first persisted summary\n\nsecond prefix summary",
+          type: "compaction",
+        }),
+      ]),
+    );
+  });
+
   it("reloads SQLite markers through setSessionFile without switching to file paths", async () => {
     const dir = await makeTempDir();
     const storePath = path.join(dir, "sessions.json");


### PR DESCRIPTION
## What Problem This Solves
- Consecutive compaction can be needed when the retained tail is still too large after a first compaction pass.
- A second split-turn pass whose only new summarized input is the current turn prefix must not replace the already-compacted history summary with a placeholder.
- This keeps the existing summary available while still adding the split-turn prefix context needed by the retained suffix.

## Summary
- allow `prepareCompaction()` to run when the latest session entry is a previous compaction boundary
- keep reset-ending branches as no-ops
- preserve the previous compaction summary when a split-turn second pass only has prefix messages to summarize
- add regression coverage for both preparing a second compaction pass and preserving prior summary text during prefix-only compaction
- extend the prefix-only regression through `buildSessionContext()` so the persisted compaction boundary is replayed through the session-context projection path

Fixes #120455.

## Evidence
- `node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/compaction.test.ts` — passed locally on 2026-08-09 after the follow-up commit (`27 passed`). This includes prep → compact → replay proof for the prefix-only second pass preserving `previousSummary` through the compaction boundary projected by `buildSessionContext()`.
- `node scripts/run-vitest.mjs src/agents/sessions/agent-session-loop-correctness.test.ts src/agents/agent-hooks/compaction-safeguard.test.ts` — passed locally on 2026-08-09 (`144 passed`).
- Earlier validation from the first commit: `corepack pnpm tsgo:test:packages` — passed.
- Earlier validation from the first commit: `corepack pnpm tsgo:test:src` — passed.

## Notes
- `pnpm install --frozen-lockfile --prefer-offline` was needed in the fresh follow-up worktree before running the targeted Vitest commands.
- `corepack pnpm install --frozen-lockfile` was needed in the initial worktree before the earlier type checks.
- `corepack pnpm test:changed -- --help` was attempted as a discovery command; it failed because the UI e2e preflight could not find the expected Playwright Chromium binary path after installation. The targeted test and type checks above passed.
