### PR TITLE
fix(scripts): detect growth in existing dist-runtime files

### DIFF
--- a/scripts/check-gateway-watch-regression.mts
+++ b/scripts/check-gateway-watch-regression.mts
@@ -982,6 +982,10 @@ export function writeBuildAndRuntimePostBuildStamps(params: { cwd?: string } = {
   writeRuntimePostBuildStamp({ cwd });
 }
 
+export function calculateDistRuntimeByteGrowth(pre, post) {
+  return post.distRuntime.apparentBytes - pre.distRuntime.apparentBytes;
+}
+
 /**
  * Collects pass/fail findings for the bounded gateway watch regression run.
  */
@@ -1150,10 +1154,7 @@ async function main() {
     entry.startsWith("dist-runtime/"),
   ).length;
   const distRuntimeFileGrowth = distRuntimeAddedPaths;
-  const distRuntimeByteGrowth =
-    distRuntimeAddedPaths === 0
-      ? 0
-      : post.distRuntime.apparentBytes - pre.distRuntime.apparentBytes;
+  const distRuntimeByteGrowth = calculateDistRuntimeByteGrowth(pre, post);
   const totalCpuMs = Math.round(
     (watchResult.timing.userSeconds + watchResult.timing.sysSeconds) * 1000,
   );

--- a/test/scripts/check-gateway-watch-regression.test.ts
+++ b/test/scripts/check-gateway-watch-regression.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   appendBoundedWatchLog,
   buildTimedWatchCommand,
+  calculateDistRuntimeByteGrowth,
   collectGatewayWatchFindings,
   hasGatewayReadyLog,
   parseArgs,
@@ -93,6 +94,38 @@ describe("check-gateway-watch-regression", () => {
       true,
     );
     expect(hasGatewayReadyLog("[gateway] starting HTTP server...")).toBe(false);
+  });
+
+  it("detects byte growth in existing dist-runtime paths", () => {
+    const distRuntimeByteGrowth = calculateDistRuntimeByteGrowth(
+      { distRuntime: { apparentBytes: 100 } },
+      { distRuntime: { apparentBytes: 2_097_253 } },
+    );
+    const findings = collectGatewayWatchFindings({
+      cpuMs: 0,
+      distRuntimeByteGrowth,
+      distRuntimeFileGrowth: 0,
+      options: {
+        cpuFailMs: 8000,
+        cpuWarnMs: 1000,
+        distRuntimeByteGrowthMax: 2 * 1024 * 1024,
+        distRuntimeFileGrowthMax: 200,
+        windowMs: 10_000,
+      },
+      watchBuildReason: null,
+      watchResult: {
+        idleCpuMs: 0,
+        readyBeforeWindow: true,
+        spawnError: null,
+        timingFileMissing: false,
+      },
+      watchTriggeredBuild: false,
+    });
+
+    expect(distRuntimeByteGrowth).toBe(2_097_153);
+    expect(findings.failures).toContain(
+      "dist-runtime apparent byte growth 2097153 exceeded max 2097152",
+    );
   });
 
   it("bounds in-memory watch output capture while keeping the newest logs", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the gateway watch regression check would report zero `dist-runtime` byte growth when an existing runtime file grew during the watch window without adding a new path. That could let an oversized runtime artifact change pass the byte-growth threshold.

## Why This Change Was Made

The check now always compares the before/after `dist-runtime` apparent-byte totals, independently of added-path count. The calculation remains in the script's existing snapshot/findings path, with no change to file-growth counting or threshold configuration.

## User Impact

Operators and CI checks now receive the configured byte-growth failure for oversized changes to existing `dist-runtime` files, as well as for newly added files.

## Evidence

- Final production-entry-point proof at head `de43ec8487b8b096ecbf49d2611c801f7a4fb4a9`:

  ```text
  productionScriptExit=1
  distRuntimeAddedPaths=0
  distRuntimeByteGrowth=2097153
  addedPaths=0
  threshold=0
  FAIL: dist-runtime apparent byte growth 2097153 exceeded max 0
  ```

  This output comes from `node scripts/check-gateway-watch-regression.mjs --skip-build`; the existing runtime file was enlarged after the pre-watch snapshot, so the production snapshot, path diff, growth calculation, and threshold findings path all ran with zero added paths.
- Supporting checks at the same head: focused `check-gateway-watch-regression` coverage passed 19 tests; script declaration validation matched 254 contracts; targeted formatting and `git diff --check` passed.
- Proof boundary: the production script's snapshot/diff/findings behavior is directly exercised. Gateway readiness and CPU timing are Linux CI concerns and are not claimed by this Windows proof.
- Exact head: `de43ec8487b8b096ecbf49d2611c801f7a4fb4a9`.
