### PR TITLE
fix(ci): restore gateway steer FIFO lint gate

### DIFF
--- a/test/gateway-steer-fifo.e2e.test.ts
+++ b/test/gateway-steer-fifo.e2e.test.ts
@@ -182,7 +182,7 @@ function writeToolResponse(res: ServerResponse): void {
 
 async function startMockModelServer(): Promise<MockModelServer> {
   const requests: ModelRequest[] = [];
-  const firstResponse = createDeferred<void>();
+  const firstResponse = createDeferred();
   let firstResponseKind: FirstResponseKind = "final";
   const server = createServer((req, res) => {
     void (async () => {
@@ -579,7 +579,9 @@ describe("Gateway steer FIFO", () => {
           ),
         ).toBe(true);
       }, WAIT_OPTS);
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
 
       const currentA = currentUserInput(fixture.modelServer.requests[1]);
       const currentB = currentUserInput(fixture.modelServer.requests[2]);
@@ -625,7 +627,9 @@ describe("Gateway steer FIFO", () => {
           ),
         ).toBe(true);
       }, WAIT_OPTS);
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(fixture.modelServer.requests).toHaveLength(2);
     },
     TEST_TIMEOUT_MS,


### PR DESCRIPTION
Related: #120429

## What Problem This Solves

Restores the gateway steer FIFO test's lint gate on current `main`. The broader repair in #120429 conflicts with current `main`, while only three test-only lint corrections remain necessary.

## Why This Change Was Made

This extracts exactly those three corrections: remove the redundant `createDeferred<void>()` type argument and brace two `Promise` executors. It does not copy the conflicting production, queue, admission, fixture, baseline, suppression, or changelog changes from #120429.

Credit: Peter Steinberger (@steipete). The signed commit retains his public `Co-authored-by` trailer.

## User Impact

No runtime or user-visible behavior changes. This only restores the CI lint gate for the existing gateway steer FIFO coverage.

## Evidence

- Exact signed head: `c9f52a35eb7d02a040fb95cbafe83f7de025ff8c`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs test/gateway-steer-fifo.e2e.test.ts` - passed
- `node scripts/check-max-lines-ratchet.mjs --base origin/main` - passed
- `git diff --check origin/main...HEAD` - passed
- `node scripts/run-vitest.mjs src/auto-reply/reply/reply-turn-admission.test.ts src/auto-reply/reply/agent-runner.media-paths.test.ts` - 56/56 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts test/gateway-steer-fifo.e2e.test.ts` - 145/145 passed
- Independent exact-head autoreview - clean, no accepted/actionable findings, correctness confidence 0.99
- Commit attestation: `att_01KZFTDP0J0SWWDBW0G4HC93CN`

- PR attestation: `att_01KZFV557GP45Z3KEAD86TY37K`

<!-- punchcard-receipt: pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaRlY1NTdHUDQ1WjNLRUFEODZUWTM3SwB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pETTlQMDdINzVBOTlWSENSN1pOUzg0AGdvbGRlbi12YWxsZXktd29ya3Nob3AtYnIAb3BlbmNsYXcvb3BlbmNsYXcAADEyMDQ3MQA1NGIxYzc0Y2VlNGM1YTU3NzcyZGUyZTAwYTFiYTZmNjljY2IxYjNlMWQ4MWM0ZjgzYjcwNGE3ZDg0ZjRiYmE3AHNpZ25pbmctdjEANTF5VXhVajNWRnRSbV9mc3RlcWp1bEJFNlJkMDkzNmxwOWpqQlJLSlFsb2hlVGppMEh3VVJ6NW5wTzZHSEZ0anFXaEFfeGVKNEhhdHZMNHY1MnAwQ2cAMjAyNi0wOC0wOFQwNDo0NzozMC41NDRaAA.fwP5G0c6TS8LodOevAeKZRyX33d7392EPdP2Aw1PVHZ1SbTpcJuDPop8UgRbrkLNq0_Og5GInP1_-es_BH0yBw -->
