### PR TITLE
fix(ci): reject malformed hosted-gate PR numbers

### DIFF
--- a/scripts/verify-pr-hosted-gates.mts
+++ b/scripts/verify-pr-hosted-gates.mts
@@ -5,7 +5,12 @@ import path from "node:path";
 import { isRecord, readStringField } from "@openclaw/normalization-core/record-coerce";
 import { minimatch } from "minimatch";
 import { parse } from "yaml";
-import { booleanFlag, parseFlagArgs, stringFlag } from "./lib/arg-utils.mts";
+import {
+  booleanFlag,
+  classifyBoundedUnsignedDecimal,
+  parseFlagArgs,
+  stringFlag,
+} from "./lib/arg-utils.mts";
 import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import { execGhApiRead, plainGhEnv } from "./lib/plain-gh.mjs";
 
@@ -167,11 +172,11 @@ export function parseArgs(argv: readonly string[]) {
         missingValueMessage: "Expected --pr <value>.",
         rejectShortOptions: true,
         transform(value: string) {
-          const parsed = Number(value);
-          if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+          const result = classifyBoundedUnsignedDecimal(value, 1, Number.MAX_SAFE_INTEGER);
+          if (result.kind !== "value") {
             throw new Error("Expected --pr <positive-integer>.");
           }
-          return parsed;
+          return result.value;
         },
       }),
       booleanFlag("--changelog-only", "changelogOnly"),

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -1561,11 +1561,46 @@ describe("verify-pr-hosted-gates", () => {
     expect(() => parseArgs(["--repo", "openclaw/openclaw"])).toThrow("Usage:");
     expect(() => parseArgs(requiredCliArgs.with(1, "-h"))).toThrow("Expected --repo <value>.");
     expect(() => parseArgs(requiredCliArgs.with(3, "-h"))).toThrow("Expected --sha <value>.");
-    expect(() => parseArgs(requiredCliArgs.with(5, "zero"))).toThrow(
-      "Expected --pr <positive-integer>.",
-    );
+    expect(() => parseArgs(requiredCliArgs.with(5, "-h"))).toThrow("Expected --pr <value>.");
+    for (const [value, expected] of [
+      ["1", 1],
+      ["001", 1],
+      [String(Number.MAX_SAFE_INTEGER), Number.MAX_SAFE_INTEGER],
+    ] as const) {
+      expect(parseArgs(requiredCliArgs.with(5, value)).pr).toBe(expected);
+    }
+    for (const value of [
+      "zero",
+      "0",
+      String(Number.MAX_SAFE_INTEGER + 1),
+      "1e3",
+      "0x10",
+      "0b10",
+      "1.5",
+      "+1",
+      " 1 ",
+    ]) {
+      expect(() => parseArgs(requiredCliArgs.with(5, value))).toThrow(
+        "Expected --pr <positive-integer>.",
+      );
+    }
     expect(() => parseArgs(requiredCliArgs.with(7, "-h"))).toThrow("Expected --output <value>.");
     expect(() => parseArgs(requiredCliArgs.with(9, "origin/main"))).toThrow("Usage:");
+  });
+
+  it("rejects malformed PR numbers before invoking GitHub", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(process.cwd(), "scripts/verify-pr-hosted-gates.mjs"),
+        ...requiredCliArgs.with(5, "1e3"),
+      ],
+      { encoding: "utf8", env: { ...process.env, PATH: "" } },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Expected --pr <positive-integer>.");
+    expect(result.stderr).not.toContain("spawnSync gh");
   });
 
   it("rejects duplicate hosted gate verifier CLI arguments", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running hosted-gate verification could pass JavaScript numeric syntax such as `1e3` or `0x10` to `--pr`, causing the verifier to silently target a different pull request.

## Why This Change Was Made

The `--pr` parser now reuses the repository's canonical bounded unsigned-decimal classifier with inclusive bounds from `1` through `Number.MAX_SAFE_INTEGER`. This keeps the existing validation messages while rejecting exponent, hexadecimal, binary, fractional, signed, whitespace-padded, zero, and above-safe-integer inputs.

Leading-zero decimal input remains supported (`001` becomes `1`). The rewrite was built independently from trusted current `main`; the contributor branch's unrelated positional assertion was intentionally omitted. Contributor credit is preserved with the public noreply identity.

## User Impact

Malformed PR numbers now fail before any GitHub request instead of being coerced into another PR number. Existing valid decimal usage, including leading zeros and the safe-integer upper boundary, continues to work.

## Evidence

- Trusted-main reproduction before the fix:
  - `1e3` parsed as `1000`
  - `0x10` parsed as `16`
  - `0b10` parsed as `2`
  - `+1` and whitespace-padded `1` parsed as `1`
  - the real `.mjs` entrypoint attempted `gh api repos/openclaw/openclaw/pulls/1000`
- After the fix, every malformed form exits with `Expected --pr <positive-integer>.` before `gh`; `1`, `001`, and `Number.MAX_SAFE_INTEGER` pass.
- Focused tests: 162 passed (`test/scripts/arg-utils.test.ts` and `test/scripts/verify-pr-hosted-gates.test.ts`).
- Process-boundary regression runs the real `.mjs` CLI with `gh` unavailable and proves parser failure occurs first.
- Production formatting and Oxlint passed; Docker E2E boundaries, raw HTTP/2 guard, script erasability, coercion-helper guard, dependency pins, patch guard, and focused diff checks passed.
- Full sparse-worktree typechecking remains unavailable because the profile omits unrelated UI, Android, and QA files and the shared install has an unchanged `pako` declaration mismatch. Exact-head CI remains authoritative for those gates.
- Mandatory autoreview: clean, no actionable findings, correctness `0.99`.
- Independent verification: pass, no findings.
- Production LOC: `+9/-4`, net `+5`.
- Tests: `+38/-3`, net `+35`.
