### PR TITLE
ci(release): retry child-run adoption through read-after-write lag

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -486,19 +486,23 @@ jobs:
               echo "::error::Refusing to adopt invalid ${workflow} run ID ${candidate_run_id}." >&2
               return 1
             fi
-            # GitHub evaluates run-name asynchronously: a run adopted from the dispatch
-            # response can briefly report its default display_title. Identity fields are
-            # immediate-refuse; a lone title mismatch retries until the template lands.
+            # GitHub materializes a dispatched run asynchronously: the API can 404 the
+            # fresh run id (read-after-write lag) and can briefly report the default
+            # display_title before run-name evaluates. Both are retryable; a REAL run
+            # object with mismatched identity fields still refuses immediately.
             for attempt in $(seq 1 12); do
-              candidate_run_json="$(
+              if ! candidate_run_json="$(
                 gh_with_retry api "repos/${GITHUB_REPOSITORY}/actions/runs/${candidate_run_id}"
-              )"
+              )" || ! jq -e --argjson id "$candidate_run_id" '.id == $id' \
+                <<< "$candidate_run_json" >/dev/null 2>&1; then
+                echo "Waiting for ${workflow} run ${candidate_run_id} to become readable (attempt ${attempt})." >&2
+                sleep 5
+                continue
+              fi
               if ! jq -e \
-                --argjson id "$candidate_run_id" \
                 --argjson workflow_id "$expected_workflow_id" \
                 --arg branch "$CHILD_WORKFLOW_REF" \
-                '(.id == $id)
-                  and (.workflow_id == $workflow_id)
+                '(.workflow_id == $workflow_id)
                   and (.head_branch == $branch)
                   and (.event == "workflow_dispatch")' \
                 <<< "$candidate_run_json" >/dev/null; then
@@ -515,9 +519,9 @@ jobs:
               echo "Waiting for ${workflow} run ${candidate_run_id} display title (attempt ${attempt})." >&2
               sleep 5
             done
-            echo "::error::Refusing to adopt ${workflow} run ${candidate_run_id}: display title never matched ${dispatch_run_name}." >&2
+            echo "::error::Refusing to adopt ${workflow} run ${candidate_run_id}: run never became readable with display title ${dispatch_run_name}." >&2
             jq '{id, workflow_id, path, display_title, head_branch, head_sha, event, html_url}' \
-              <<< "$candidate_run_json" >&2
+              <<< "$candidate_run_json" >&2 || printf '%s\n' "$candidate_run_json" >&2
             return 1
           }
 

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1978,7 +1978,7 @@ describe("package acceptance workflow", () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
       label === "title"
-        ? "Refusing to adopt ci.yml run 101: display title never matched"
+        ? "Refusing to adopt ci.yml run 101: run never became readable with display title"
         : "Refusing to adopt unvalidated ci.yml run 101",
     );
     expect(


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation run 31236823378 lost its plugin-prerelease child to a second adoption race: `gh workflow run` returned the new run's URL, the immediate `GET /actions/runs/<id>` answered **HTTP 404** (GitHub materializes dispatched runs asynchronously), and the error payload failed the identity check → hard "Refusing to adopt unvalidated" refusal. The first fix (#120427) only covered the display-title race, not run-visibility lag.

## Why This Change Was Made

The adoption loop now distinguishes three states: fetch failed or payload isn't the requested run object (no matching `.id`) → retryable, bounded by the same 12×5s loop; a **readable** run whose workflow_id/head_branch/event mismatch → immediate refusal, unchanged; title not yet templated → retry as before. The exhaustion diagnostic covers both lag classes and dumps whatever payload was last seen.

## User Impact

Release validation no longer dies on GitHub's read-after-write lag; wrong-identity runs are still rejected instantly.

## Evidence

- All 168 dispatch-workflow tests pass (`test/scripts/package-acceptance-workflow.test.ts`), including the wrong-title refusal path updated for the new exhaustion wording.
- `node scripts/check-workflows.mjs` (zizmor) passes; all five extracted job scripts pass `bash -n`; `git diff --check` clean.
- Codex autoreview (`gpt-5.6-sol`, high): clean (0.98) — "retries transient read-after-write failures … while continuing to reject readable runs whose identity does not match".
- Harness-only: `.github/workflows/full-release-validation.yml` + one test-string update.
