### PR TITLE
fix(e2e): expose beta companions in survivor registries and unbind ReDoS timing from shell startup

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -472,6 +472,7 @@ NODE
   fi
 
   mkdir -p "$fixture_root"
+  OPENCLAW_NPM_REGISTRY_DIST_TAGS="beta=$candidate_version" \
   OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org \
     node scripts/e2e/lib/plugins/npm-registry-server.mjs \
     "$port_file" \

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -380,6 +380,7 @@ NODE
   fi
 
   mkdir -p "$fixture_root"
+  OPENCLAW_NPM_REGISTRY_DIST_TAGS="beta=$package_version" \
   OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org \
     node scripts/e2e/lib/plugins/npm-registry-server.mjs \
     "$port_file" \

--- a/scripts/lib/docker-e2e-plan.mjs
+++ b/scripts/lib/docker-e2e-plan.mjs
@@ -99,6 +99,10 @@ const UPGRADE_SURVIVOR_SCENARIO_ALIASES = new Map([
   ["far-reaching", UPGRADE_SURVIVOR_SCENARIOS],
 ]);
 
+// Upgrade recipes select an OpenAI model whose runtime is supplied by the
+// version-matched Codex companion after the candidate replaces the baseline.
+const UPGRADE_SURVIVOR_RUNTIME_COMPANION_PACKAGES = ["@openclaw/codex"];
+
 // Pre-protocol catalogs are content-addressed. Unknown legacy blocks fail
 // closed instead of requiring a dependency or reimplementing a JavaScript parser.
 const LEGACY_UPGRADE_SURVIVOR_SCENARIO_CATALOGS = new Map([
@@ -676,12 +680,12 @@ export function requiredPrepublishPluginPackagesForLanes(poolLanes) {
   const configuredChannelIds = new Set();
   const requiredPackages = new Set();
   for (const poolLane of poolLanes) {
-    for (const packageName of poolLane.prepublishPluginPackages ?? []) {
-      requiredPackages.add(packageName);
-    }
     const scenario = upgradeSurvivorScenarioForLane(poolLane);
     if (!scenario) {
       continue;
+    }
+    for (const packageName of UPGRADE_SURVIVOR_RUNTIME_COMPANION_PACKAGES) {
+      requiredPackages.add(packageName);
     }
     for (const channelId of configuredChannelIdsForLane(poolLane, scenario)) {
       configuredChannelIds.add(channelId);

--- a/scripts/lib/docker-e2e-scenarios.d.mts
+++ b/scripts/lib/docker-e2e-scenarios.d.mts
@@ -11,7 +11,6 @@ export type DockerE2eLane = {
   name: string;
   needsLiveImage?: boolean;
   noOutputTimeoutMs?: number;
-  prepublishPluginPackages?: string[];
   resources: string[];
   retries: number;
   retryPatterns: RegExp[];

--- a/scripts/lib/docker-e2e-scenarios.mjs
+++ b/scripts/lib/docker-e2e-scenarios.mjs
@@ -82,9 +82,6 @@ function lane(name, command, options = {}) {
     timeoutMs: options.timeoutMs,
     upgradeSurvivorScenario: options.upgradeSurvivorScenario,
     weight: options.weight ?? 1,
-    ...(options.prepublishPluginPackages
-      ? { prepublishPluginPackages: options.prepublishPluginPackages }
-      : {}),
   };
 }
 
@@ -201,8 +198,6 @@ function createPackageUpdateMaintenanceLanes() {
       weight: 3,
     }),
     npmLane("update-restart-auth", updateRestartAuthCommand, {
-      // Credential hydration auto-enables the candidate's Codex runtime during restart.
-      prepublishPluginPackages: ["@openclaw/codex"],
       stateScenario: "upgrade-survivor",
       timeoutMs: 25 * 60 * 1000,
       upgradeSurvivorScenario: "base",

--- a/src/agents/bash-tools.exec.script-preflight.test.ts
+++ b/src/agents/bash-tools.exec.script-preflight.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { detectUnsafeExecControlShellCommand } from "../infra/exec-control-command-guard.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import { createExecTool } from "./bash-tools.exec-run.js";
+import { validateScriptFileForShellBleed } from "./bash-tools.exec-script-preflight.js";
 
 vi.mock("./bash-tools.exec-host-gateway.js", () => ({
   processGatewayAllowlist: async () => ({ allowWithoutEnforcedCommand: true }),
@@ -573,12 +574,11 @@ describeWin("exec script preflight on windows path syntax", () => {
 
 describe("exec interpreter heuristics ReDoS guard", () => {
   it("does not hang on long commands with VAR=value assignments and whitespace-heavy text", async () => {
-    // Keep the workload side-effect free while exercising the full exec path.
     const htmlBlock = '<section style="padding: 30px 20px; font-family: Arial;">'.repeat(50);
     const command = `ACCESS_TOKEN=$(__openclaw_missing_redos_guard__)\nprintf '%s' '${htmlBlock}' >/dev/null`;
 
     const start = Date.now();
-    await runExecPreflight({ command, workdir: process.cwd() });
+    await validateScriptFileForShellBleed({ command, workdir: process.cwd() });
     const elapsed = Date.now() - start;
     expect(elapsed).toBeLessThan(5000);
   });

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2280,6 +2280,8 @@ docker_e2e_docker_run_cmd run demo
       expect(script).toContain("OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org");
       expect(script).toContain("node scripts/e2e/lib/plugins/npm-registry-server.mjs");
     }
+    expect(runner).toContain('OPENCLAW_NPM_REGISTRY_DIST_TAGS="beta=$package_version"');
+    expect(publishedRunner).toContain('OPENCLAW_NPM_REGISTRY_DIST_TAGS="beta=$candidate_version"');
   });
 
   it("starts the upgrade survivor plugin registry before updates without ambient Feishu config", () => {

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -1653,9 +1653,20 @@ describe("scripts/lib/docker-e2e-plan", () => {
   });
 
   it("derives prerelease npm companions from selected survivor recipes", () => {
-    const basePlan = planFor({ selectedLaneNames: ["published-upgrade-survivor"] });
-    expect(basePlan.requiredPrepublishPluginPackages).toEqual(["@openclaw/discord"]);
-    expect(basePlan.needs.prepublishPluginRegistry).toBe(true);
+    for (const laneName of [
+      "upgrade-survivor",
+      "published-upgrade-survivor",
+      "root-managed-vps-upgrade",
+      "update-restart-auth",
+      "update-migration",
+    ]) {
+      const plan = planFor({ selectedLaneNames: [laneName] });
+      expect(plan.requiredPrepublishPluginPackages).toEqual([
+        "@openclaw/codex",
+        "@openclaw/discord",
+      ]);
+      expect(plan.needs.prepublishPluginRegistry).toBe(true);
+    }
 
     const feishuPlan = planFor({
       selectedLaneNames: ["published-upgrade-survivor"],
@@ -1663,27 +1674,19 @@ describe("scripts/lib/docker-e2e-plan", () => {
       upgradeSurvivorScenarios: "base feishu-channel",
     });
     expect(feishuPlan.requiredPrepublishPluginPackages).toEqual([
-      "@openclaw/discord",
-      "@openclaw/feishu",
-    ]);
-    expect(
-      planFor({ selectedLaneNames: ["root-managed-vps-upgrade"] }).requiredPrepublishPluginPackages,
-    ).toEqual(["@openclaw/discord"]);
-    expect(
-      planFor({ selectedLaneNames: ["update-migration"] }).requiredPrepublishPluginPackages,
-    ).toEqual(["@openclaw/discord"]);
-    const updateRestartLane = findLaneByName("update-restart-auth");
-    expect(updateRestartLane?.prepublishPluginPackages).toEqual(["@openclaw/codex"]);
-    expect(requiredPrepublishPluginPackagesForLanes([updateRestartLane!])).toEqual([
       "@openclaw/codex",
       "@openclaw/discord",
+      "@openclaw/feishu",
     ]);
     const legacyFeishuPlan = planFor({
       selectedLaneNames: ["published-upgrade-survivor"],
       upgradeSurvivorBaselines: "2026.3.13",
       upgradeSurvivorScenarios: "feishu-channel",
     });
-    expect(legacyFeishuPlan.requiredPrepublishPluginPackages).toEqual(["@openclaw/discord"]);
+    expect(legacyFeishuPlan.requiredPrepublishPluginPackages).toEqual([
+      "@openclaw/codex",
+      "@openclaw/discord",
+    ]);
     const selfUpgradeLane = findLaneByName("update-run-package-self-upgrade");
     expect(selfUpgradeLane).toBeDefined();
     expect(requiredPrepublishPluginPackagesForLanes([selfUpgradeLane!])).toEqual([]);


### PR DESCRIPTION
## What Problem This Solves

Two main-owned harness defects failing 2026.8.1-beta.1 validation lanes (run 31236823378):

1. **Docker upgrade-survivor lanes** (`upgrade-survivor`, `published-upgrade-survivor`, `root-managed-vps-upgrade`): every phase passed — update, doctor, config/state survival, migration — until gateway startup, because a beta core correctly requests `@openclaw/codex@beta` and the lanes' local npm registry exposed the exact candidate companions only under `latest` (provenance: a0deb8edae1a). The registry launchers now publish the `beta` dist-tag, and the Docker E2E planner derives the Codex companion for every standalone survivor lane instead of the one-off `update-restart-auth` metadata seam.
2. **`checks-windows-node-test`**: the ReDoS boundary test measured full Git Bash process startup (6163ms against a 5000ms threshold) instead of the regex it guards (introduced by dc61172e519c9). It now calls the canonical `validateScriptFileForShellBleed` directly — timing-immune, same invariant.

## Why This Change Was Made

Same defect class as the fixed cross-OS lanes: validation must exercise the exact candidate artifacts, including their dist-tag identity. The ReDoS fix removes a platform-speed dependency from a security-invariant test.

## User Impact

Release validation lanes measure the product, not the harness. The ReDoS test fix must also ride the release candidate (CI executes candidate test sources) — cherry-picked separately.

## Evidence

- Lane logs analyzed per job (93051081084, 93053012050/69/73): all product phases green before the identified harness failures; v14/v15 migration interplay explicitly excluded (doctor + survival phases passed).
- Focused Vitest 301 passed (4 platform-skipped); `pnpm tsgo:core` + `tsgo:core:test`; deadcode 0; `git diff --check` clean.
- Codex autoreview (`gpt-5.6-sol`, high): clean (0.99).
- Net release-harness production LOC: 0; tests +7.
