### PR TITLE
release(2026.8.1): unbind ReDoS boundary test from shell startup time

### DIFF
--- a/src/agents/bash-tools.exec.script-preflight.test.ts
+++ b/src/agents/bash-tools.exec.script-preflight.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { detectUnsafeExecControlShellCommand } from "../infra/exec-control-command-guard.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import { createExecTool } from "./bash-tools.exec-run.js";
+import { validateScriptFileForShellBleed } from "./bash-tools.exec-script-preflight.js";
 
 vi.mock("./bash-tools.exec-host-gateway.js", () => ({
   processGatewayAllowlist: async () => ({ allowWithoutEnforcedCommand: true }),
@@ -573,12 +574,11 @@ describeWin("exec script preflight on windows path syntax", () => {
 
 describe("exec interpreter heuristics ReDoS guard", () => {
   it("does not hang on long commands with VAR=value assignments and whitespace-heavy text", async () => {
-    // Keep the workload side-effect free while exercising the full exec path.
     const htmlBlock = '<section style="padding: 30px 20px; font-family: Arial;">'.repeat(50);
     const command = `ACCESS_TOKEN=$(__openclaw_missing_redos_guard__)\nprintf '%s' '${htmlBlock}' >/dev/null`;
 
     const start = Date.now();
-    await runExecPreflight({ command, workdir: process.cwd() });
+    await validateScriptFileForShellBleed({ command, workdir: process.cwd() });
     const elapsed = Date.now() - start;
     expect(elapsed).toBeLessThan(5000);
   });


### PR DESCRIPTION
## What Problem This Solves

`checks-windows-node-test` fails 2026.8.1-beta.1 validation because the ReDoS boundary test measures full Git Bash process startup (6163ms vs 5000ms threshold) instead of the regex it guards. CI executes candidate test sources, so the candidate needs the fix (cherry-picked from main 733512b612e5, where it landed with full gates).

Squash-merging this PR also gives the candidate a GitHub-signed head — the QA Lab Telegram provenance preflight correctly fail-closed on the previous locally-signed head (`UNKNOWN_KEY`).

## Why This Change Was Made

Release-scoped: the candidate diff is exactly the two-line test change; the timing-immune test calls the canonical `validateScriptFileForShellBleed` directly, preserving the same security invariant.

## User Impact

Unblocks the Windows CI lane and the Telegram provenance gate for the next validation dispatch.

## Evidence

Test passes on this branch (focused run); main-side landing carried 301 focused tests, tsgo, deadcode, and clean autoreview (PR #120479).
