### PR TITLE
fix(gateway): reconcile live terminal session persistence

### DIFF
--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -59,6 +59,11 @@ export type ChatAbortControllerEntry = {
   projectSessionTerminalPending?: boolean;
   /** Store timestamp expected from the observed terminal lifecycle event. */
   projectSessionTerminalObservedAt?: number;
+  /**
+   * Retained terminal lifecycle event until durable session persistence succeeds.
+   * Live reconciliation and lazy-dispatch recovery replay this exact event.
+   */
+  projectSessionTerminalEvent?: AgentEventPayload;
   /** In-flight terminal session-store update used by restart shutdown. */
   projectSessionTerminalPersistence?: Promise<void>;
   /** Caller completion requested cleanup before terminal lifecycle persistence settled. */
@@ -84,6 +89,8 @@ export type RestartRecoveryCandidate = {
   sessionKey: string;
   sessionId: string;
   observedAt?: number;
+  /** Retained terminal event for live persistence reconciliation while Gateway stays up. */
+  event?: AgentEventPayload;
 };
 
 type InFlightRunSnapshot = {

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2658,9 +2658,9 @@ describe("agent event handler", () => {
       startedAt: 1_000,
       abortedLastRun: false,
     });
-    persistGatewaySessionLifecycleEventMock.mockRejectedValueOnce(
-      new Error("disk full sk-abcdefghijklmnopqrstuvwxyz123456"),
-    );
+    persistGatewaySessionLifecycleEventMock
+      .mockRejectedValueOnce(new Error("disk full sk-abcdefghijklmnopqrstuvwxyz123456"))
+      .mockRejectedValueOnce(new Error("disk full sk-abcdefghijklmnopqrstuvwxyz123456"));
     const markTrackedRunTerminalPersisted = vi.fn();
     const { broadcastToConnIds, handler, sessionEventSubscribers } = createHarness({
       resolveSessionKeyForRun: () => "session-failed-write",
@@ -2690,11 +2690,68 @@ describe("agent event handler", () => {
       updatedAt: 2_100,
       abortedLastRun: false,
     });
+    expect(persistGatewaySessionLifecycleEventMock).toHaveBeenCalledTimes(2);
     expect(logErrorMock).toHaveBeenCalledTimes(1);
     expect(logErrorMock).toHaveBeenCalledWith(
       "gateway: terminal session persistence failed session=session-failed-write run=run-failed-write error=Error: disk full sk-abc…3456",
     );
     expect(markTrackedRunTerminalPersisted).not.toHaveBeenCalled();
+  });
+
+  it("retries terminal persistence once and marks persisted without duplicate delivery", async () => {
+    vi.mocked(loadGatewaySessionRow).mockReturnValue({
+      key: "session-persist-retry",
+      kind: "direct",
+      sessionId: "session-persist-retry",
+      updatedAt: 2_000,
+      status: "running",
+      startedAt: 1_000,
+      abortedLastRun: false,
+    });
+    persistGatewaySessionLifecycleEventMock
+      .mockRejectedValueOnce(new Error("transient disk full"))
+      .mockResolvedValueOnce(undefined);
+    const markTrackedRunTerminalPersisted = vi.fn();
+    const trackTrackedRunTerminalPersistence = vi.fn();
+    const { broadcastToConnIds, handler, sessionEventSubscribers } = createHarness({
+      resolveSessionKeyForRun: () => "session-persist-retry",
+      lifecycleErrorRetryGraceMs: 0,
+      markTrackedRunTerminalPersisted,
+      trackTrackedRunTerminalPersistence,
+    });
+    sessionEventSubscribers.subscribe("conn-session");
+
+    emitAgentEvent(
+      handler,
+      "run-persist-retry",
+      "lifecycle",
+      {
+        phase: "end",
+        endedAt: 2_100,
+        aborted: true,
+        stopReason: "timeout",
+      },
+      {
+        seq: 2,
+        sessionKey: "session-persist-retry",
+        sessionId: "session-persist-retry",
+        ts: 2_100,
+      },
+    );
+
+    await waitForFast(() => {
+      expect(markTrackedRunTerminalPersisted).toHaveBeenCalledTimes(1);
+    });
+    expect(persistGatewaySessionLifecycleEventMock).toHaveBeenCalledTimes(2);
+    expect(markTrackedRunTerminalPersisted).toHaveBeenCalledWith({
+      runId: "run-persist-retry",
+      clientRunId: "run-persist-retry",
+      sessionKey: "session-persist-retry",
+    });
+    expect(trackTrackedRunTerminalPersistence).toHaveBeenCalledTimes(1);
+    expect(
+      broadcastToConnIds.mock.calls.filter(([event]) => event === "sessions.changed"),
+    ).toHaveLength(1);
   });
 
   it("does not clear a same-id retry when an old restart terminal arrives", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -808,11 +808,24 @@ export function createAgentEventHandler({
     if (sessionKey) {
       clearTrackedActiveRun?.({ runId: evt.runId, clientRunId, sessionKey });
       if (!suppressRestartRecoveryProjection && projectSessionLifecycle) {
-        const persistence = persistGatewaySessionLifecycleEvent({
-          sessionKey,
-          agentId: sessionAgentId,
-          event: evt,
-        });
+        const persistTerminal = async () => {
+          try {
+            await persistGatewaySessionLifecycleEvent({
+              sessionKey,
+              agentId: sessionAgentId,
+              event: evt,
+            });
+          } catch {
+            // One bounded retry keeps the canonical writer as the owner while
+            // transient store failures cannot strand durable status on running.
+            await persistGatewaySessionLifecycleEvent({
+              sessionKey,
+              agentId: sessionAgentId,
+              event: evt,
+            });
+          }
+        };
+        const persistence = persistTerminal();
         trackTrackedRunTerminalPersistence?.({
           runId: evt.runId,
           clientRunId,

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -927,6 +927,111 @@ describe("startGatewayMaintenanceTimers", () => {
     await stopMaintenanceTimers(timers);
   });
 
+  it("live-reconciles expired stalled terminal persistence instead of shutdown-only recovery", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-22T00:00:00Z"));
+    const sessionLifecycleState = await import("./session-lifecycle-state.js");
+    const persistSpy = vi
+      .spyOn(sessionLifecycleState, "persistGatewaySessionLifecycleEvent")
+      .mockResolvedValue(undefined);
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+    const deps = createMaintenanceTimerDeps();
+    const runId = "run-terminal-live-reconcile";
+    const terminalEvent = {
+      runId,
+      seq: 2,
+      stream: "lifecycle" as const,
+      ts: Date.now() - 500,
+      sessionKey: "main",
+      sessionId: "sess-1",
+      lifecycleGeneration: "generation-live-1",
+      data: {
+        phase: "end",
+        aborted: true,
+        stopReason: "timeout",
+        startedAt: Date.now() - 5_000,
+        endedAt: Date.now() - 500,
+      },
+    };
+    const terminalRun = createActiveRun("main");
+    terminalRun.expiresAtMs = Date.now() - 1;
+    terminalRun.projectSessionActive = false;
+    terminalRun.lifecycleGeneration = "generation-live-1";
+    terminalRun.projectSessionTerminalObservedAt = Date.now() - 500;
+    Object.assign(terminalRun, { projectSessionTerminalEvent: terminalEvent });
+    terminalRun.projectSessionTerminalPersistence = new Promise<void>(() => {});
+    deps.chatAbortControllers.set(runId, terminalRun);
+
+    const timers = startGatewayMaintenanceTimers(deps);
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.waitFor(() => {
+      expect(persistSpy).toHaveBeenCalledTimes(1);
+    });
+
+    expect(persistSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "main",
+        event: expect.objectContaining({
+          runId,
+          data: expect.objectContaining({ stopReason: "timeout" }),
+        }),
+      }),
+    );
+    expect(terminalRun.projectSessionTerminalPersisted).toBe(true);
+    expect(deps.chatAbortControllers.has(runId)).toBe(false);
+    expect(deps.restartRecoveryCandidates.has(runId)).toBe(false);
+    stopMaintenanceTimers(timers);
+    persistSpy.mockRestore();
+  });
+
+  it("live-reconciles expired pending terminal observations without an in-flight promise", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-22T00:00:00Z"));
+    const sessionLifecycleState = await import("./session-lifecycle-state.js");
+    const persistSpy = vi
+      .spyOn(sessionLifecycleState, "persistGatewaySessionLifecycleEvent")
+      .mockResolvedValue(undefined);
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+    const deps = createMaintenanceTimerDeps();
+    const runId = "run-terminal-pending-expired";
+    const terminalEvent = {
+      runId,
+      seq: 3,
+      stream: "lifecycle" as const,
+      ts: Date.now() - 500,
+      sessionKey: "main",
+      sessionId: "sess-1",
+      lifecycleGeneration: "generation-pending-1",
+      data: {
+        phase: "end",
+        aborted: true,
+        stopReason: "timeout",
+        startedAt: Date.now() - 5_000,
+        endedAt: Date.now() - 500,
+      },
+    };
+    const terminalRun = createActiveRun("main");
+    terminalRun.expiresAtMs = Date.now() - 1;
+    terminalRun.projectSessionActive = false;
+    terminalRun.lifecycleGeneration = "generation-pending-1";
+    terminalRun.projectSessionTerminalPending = true;
+    terminalRun.projectSessionTerminalObservedAt = Date.now() - 500;
+    Object.assign(terminalRun, { projectSessionTerminalEvent: terminalEvent });
+    deps.chatAbortControllers.set(runId, terminalRun);
+
+    const timers = startGatewayMaintenanceTimers(deps);
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.waitFor(() => {
+      expect(persistSpy).toHaveBeenCalledTimes(1);
+    });
+
+    expect(terminalRun.projectSessionTerminalPending).not.toBe(true);
+    expect(terminalRun.projectSessionTerminalPersisted).toBe(true);
+    expect(deps.chatAbortControllers.has(runId)).toBe(false);
+    stopMaintenanceTimers(timers);
+    persistSpy.mockRestore();
+  });
+
   it("reaps expired inactive registrations without emitting a timeout abort", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-22T00:00:00Z"));

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -43,6 +43,7 @@ import { hasRegisteredChatRunForSessionKey } from "./server-methods/session-acti
 import { PENDING_CHAT_SEND_DEDUPE_PREFIX, type DedupeEntry } from "./server-shared.js";
 import { formatError } from "./server-utils.js";
 import { setBroadcastHealthUpdate } from "./server/health-state.js";
+import { persistGatewaySessionLifecycleEvent } from "./session-lifecycle-state.js";
 
 // Hourly sweep plus a one-day grace bounds orphan storage without racing the
 // stage-before-row-commit window.
@@ -252,11 +253,75 @@ export function startGatewayMaintenanceTimers(params: {
 
     pruneMapToMaxSize(params.agentRunSeq, AGENT_RUN_SEQ_MAX);
 
+    const reconcileLiveTerminalPersistence = (paramsForRun: {
+      runId: string;
+      entry: ChatAbortControllerEntry;
+      event: NonNullable<ChatAbortControllerEntry["projectSessionTerminalEvent"]>;
+    }) => {
+      const { runId, entry, event } = paramsForRun;
+      entry.projectSessionTerminalPending = false;
+      const persistence = persistGatewaySessionLifecycleEvent({
+        sessionKey: entry.sessionKey,
+        agentId: entry.agentId,
+        event,
+      });
+      entry.projectSessionTerminalPersistence = persistence;
+      void persistence
+        .then(() => {
+          if (params.chatAbortControllers.get(runId) !== entry) {
+            return;
+          }
+          entry.projectSessionTerminalPersisted = true;
+          entry.projectSessionTerminalPersistence = undefined;
+          entry.projectSessionTerminalEvent = undefined;
+          params.restartRecoveryCandidates.delete(runId);
+          removeChatAbortControllerEntry(params.chatAbortControllers, runId, entry);
+        })
+        .catch(() => {
+          if (params.chatAbortControllers.get(runId) !== entry) {
+            return;
+          }
+          entry.projectSessionTerminalPersistence = undefined;
+          const lifecycleGeneration = entry.lifecycleGeneration?.trim();
+          const sessionKey = entry.sessionKey.trim();
+          const sessionId = entry.sessionId.trim();
+          if (entry.controlUiVisible !== false && lifecycleGeneration && sessionKey && sessionId) {
+            params.restartRecoveryCandidates.set(runId, {
+              runId,
+              lifecycleGeneration,
+              sessionKey,
+              sessionId,
+              observedAt: entry.projectSessionTerminalObservedAt,
+              event,
+            });
+          }
+          removeChatAbortControllerEntry(params.chatAbortControllers, runId, entry);
+        });
+    };
+
     for (const [runId, entry] of params.chatAbortControllers) {
+      const expired = !isFutureDateTimestampMs(entry.expiresAtMs, { nowMs: now });
+      const retainedTerminalEvent = entry.projectSessionTerminalEvent;
+      // Expired terminal observations must reconcile live while Gateway stays up.
+      // Pending-without-promise and stalled persistence both keep the retained event.
+      if (
+        expired &&
+        retainedTerminalEvent &&
+        entry.projectSessionTerminalPersisted !== true &&
+        (entry.projectSessionTerminalPending === true ||
+          entry.projectSessionTerminalPersistence !== undefined)
+      ) {
+        reconcileLiveTerminalPersistence({
+          runId,
+          entry,
+          event: retainedTerminalEvent,
+        });
+        continue;
+      }
       if (entry.projectSessionTerminalPending === true) {
         continue;
       }
-      if (isFutureDateTimestampMs(entry.expiresAtMs, { nowMs: now })) {
+      if (!expired) {
         continue;
       }
       if (entry.projectSessionTerminalPersistence) {
@@ -270,6 +335,7 @@ export function startGatewayMaintenanceTimers(params: {
             sessionKey,
             sessionId,
             observedAt: entry.projectSessionTerminalObservedAt,
+            ...(retainedTerminalEvent ? { event: retainedTerminalEvent } : {}),
           });
         }
         removeChatAbortControllerEntry(params.chatAbortControllers, runId, entry);
@@ -284,6 +350,23 @@ export function startGatewayMaintenanceTimers(params: {
         sessionKey: entry.sessionKey,
         stopReason: "timeout",
       });
+    }
+
+    for (const [runId, candidate] of params.restartRecoveryCandidates) {
+      if (!candidate.event || params.chatAbortControllers.has(runId)) {
+        continue;
+      }
+      const event = candidate.event;
+      void persistGatewaySessionLifecycleEvent({
+        sessionKey: candidate.sessionKey,
+        event,
+      })
+        .then(() => {
+          params.restartRecoveryCandidates.delete(runId);
+        })
+        .catch(() => {
+          // Keep the candidate for shutdown recovery when live write still fails.
+        });
     }
 
     const ABORTED_RUN_TTL_MS = 60 * 60_000;

--- a/src/gateway/server-runtime-subscriptions.test.ts
+++ b/src/gateway/server-runtime-subscriptions.test.ts
@@ -242,6 +242,64 @@ describe("startGatewayEventSubscriptions", () => {
     );
   });
 
+  it("clears stuck terminal pending and retains live reconciliation after lazy handler failure", async () => {
+    const { getAgentEventLifecycleGeneration } = await import("../infra/agent-events.js");
+    const params = createParams();
+    const runId = "run-terminal-lazy-fail";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const entry = {
+      controller: new AbortController(),
+      sessionId: "sess-terminal-lazy",
+      sessionKey: "agent:main:main",
+      startedAtMs: 1_000,
+      expiresAtMs: Date.now() + 60_000,
+      lifecycleGeneration,
+      projectSessionActive: true,
+    };
+    params.chatAbortControllers.set(runId, entry);
+    unsubs = startGatewayEventSubscriptions(params);
+
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      sessionKey: "agent:main:main",
+      sessionId: "sess-terminal-lazy",
+      data: {
+        phase: "end",
+        status: "cancelled",
+        aborted: true,
+        stopReason: "timeout",
+        startedAt: 1_000,
+        endedAt: 2_000,
+      },
+    });
+
+    await waitForFast(() => expect(warn).toHaveBeenCalledTimes(1));
+    expect(warn).toHaveBeenCalledWith(
+      "Agent event dispatch failed",
+      expect.objectContaining({ runId, stream: "lifecycle" }),
+    );
+    // Lazy failure must not immortalize pending; keep a live recoverable attempt.
+    expect(entry.projectSessionTerminalPending).not.toBe(true);
+    expect(params.restartRecoveryCandidates.get(runId)).toEqual(
+      expect.objectContaining({
+        runId,
+        lifecycleGeneration,
+        sessionKey: "agent:main:main",
+        sessionId: "sess-terminal-lazy",
+      }),
+    );
+    expect(
+      (entry as { projectSessionTerminalEvent?: unknown }).projectSessionTerminalEvent,
+    ).toEqual(
+      expect.objectContaining({
+        runId,
+        stream: "lifecycle",
+        data: expect.objectContaining({ stopReason: "timeout" }),
+      }),
+    );
+  });
+
   it("disposes a loaded agent event handler on unsubscribe", async () => {
     const dispose = vi.fn();
     const handler = Object.assign(vi.fn(), { dispose });

--- a/src/gateway/server-runtime-subscriptions.test.ts
+++ b/src/gateway/server-runtime-subscriptions.test.ts
@@ -173,6 +173,7 @@ describe("startGatewayEventSubscriptions", () => {
     resetAgentEventsForTest();
     resetTaskRegistryForTests({ persist: false });
     configureExecutionIdentityAdmissionSink(() => false)();
+    vi.useRealTimers();
   });
 
   it("records audit events by default and stops the recorder on unsubscribe", async () => {
@@ -298,6 +299,170 @@ describe("startGatewayEventSubscriptions", () => {
         data: expect.objectContaining({ stopReason: "timeout" }),
       }),
     );
+  });
+
+  it("retains the terminal event through double persist rejection for maintenance replay", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-22T00:00:00Z"));
+    const sessionLifecycleState = await import("./session-lifecycle-state.js");
+    const persistSpy = vi
+      .spyOn(sessionLifecycleState, "persistGatewaySessionLifecycleEvent")
+      .mockRejectedValueOnce(new Error("terminal write failed"))
+      .mockRejectedValueOnce(new Error("terminal write retry failed"))
+      .mockResolvedValueOnce(undefined);
+    const { getAgentEventLifecycleGeneration } = await import("../infra/agent-events.js");
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+    const params = createParams();
+    const runId = "run-double-persist-reject";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const entry = {
+      controller: new AbortController(),
+      sessionId: "sess-double-reject",
+      sessionKey: "agent:main:main",
+      startedAtMs: 1_000,
+      expiresAtMs: Date.now() + 120_000,
+      lifecycleGeneration,
+      projectSessionActive: true,
+      controlUiVisible: true as const,
+    };
+    params.chatAbortControllers.set(runId, entry);
+
+    // Mirror finalizeLifecycleEvent ownership: clear active, then track a bounded
+    // double-reject persist through the production subscription callbacks.
+    agentEventHandlerMocks.create.mockImplementation((options: unknown) => {
+      const opts = options as {
+        clearTrackedActiveRun?: (params: {
+          runId: string;
+          clientRunId: string;
+          sessionKey: string;
+        }) => void;
+        trackTrackedRunTerminalPersistence?: (params: {
+          runId: string;
+          clientRunId: string;
+          sessionKey: string;
+          sessionId?: string;
+          observedAt: number;
+          persistence: Promise<void>;
+        }) => void;
+      };
+      return (evt: {
+        runId: string;
+        sessionKey?: string;
+        sessionId?: string;
+        ts: number;
+        stream: string;
+        data?: { phase?: unknown };
+      }) => {
+        if (evt.stream !== "lifecycle") {
+          return;
+        }
+        const phase = typeof evt.data?.phase === "string" ? evt.data.phase : "";
+        if (phase !== "end" && phase !== "error") {
+          return;
+        }
+        const sessionKey = evt.sessionKey ?? "agent:main:main";
+        opts.clearTrackedActiveRun?.({
+          runId: evt.runId,
+          clientRunId: evt.runId,
+          sessionKey,
+        });
+        const persistence = (async () => {
+          try {
+            await sessionLifecycleState.persistGatewaySessionLifecycleEvent({
+              sessionKey,
+              event: evt,
+            });
+          } catch {
+            await sessionLifecycleState.persistGatewaySessionLifecycleEvent({
+              sessionKey,
+              event: evt,
+            });
+          }
+        })();
+        opts.trackTrackedRunTerminalPersistence?.({
+          runId: evt.runId,
+          clientRunId: evt.runId,
+          sessionKey,
+          sessionId: evt.sessionId,
+          observedAt: evt.ts,
+          persistence,
+        });
+        void persistence.catch(() => undefined);
+      };
+    });
+
+    unsubs = startGatewayEventSubscriptions(params);
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      sessionKey: "agent:main:main",
+      sessionId: "sess-double-reject",
+      data: {
+        phase: "end",
+        status: "cancelled",
+        aborted: true,
+        stopReason: "timeout",
+        startedAt: 1_000,
+        endedAt: 2_000,
+      },
+    });
+
+    await waitForFast(() => expect(persistSpy).toHaveBeenCalledTimes(2));
+    // Authoritative event must survive clearTrackedActiveRun + both write rejects.
+    expect(entry.projectSessionTerminalEvent).toEqual(
+      expect.objectContaining({
+        runId,
+        stream: "lifecycle",
+        data: expect.objectContaining({ stopReason: "timeout" }),
+      }),
+    );
+    expect(params.restartRecoveryCandidates.get(runId)).toEqual(
+      expect.objectContaining({
+        runId,
+        event: expect.objectContaining({
+          runId,
+          data: expect.objectContaining({ stopReason: "timeout" }),
+        }),
+      }),
+    );
+
+    entry.expiresAtMs = Date.now() - 1;
+    const timers = startGatewayMaintenanceTimers({
+      ...params,
+      nodeSendToAllSubscribed: vi.fn(),
+      getPresenceVersion: () => 1,
+      getHealthVersion: () => 1,
+      refreshGatewayHealthSnapshot: async () => ({ ok: true }),
+      logHealth: { error: vi.fn() },
+      dedupe: new Map(),
+      chatQueuedTurns: new Map(),
+      removeChatRun: () => undefined,
+      getRuntimeConfig: () => ({}),
+      runDeliveryQueueMediaGc: async () => undefined,
+    });
+    await vi.advanceTimersByTimeAsync(60_000);
+    await waitForFast(() => expect(persistSpy).toHaveBeenCalledTimes(3));
+    expect(persistSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        event: expect.objectContaining({
+          runId,
+          data: expect.objectContaining({ stopReason: "timeout" }),
+        }),
+      }),
+    );
+    expect(entry.projectSessionTerminalPersisted).toBe(true);
+    expect(params.chatAbortControllers.has(runId)).toBe(false);
+    expect(params.restartRecoveryCandidates.has(runId)).toBe(false);
+
+    clearInterval(timers.tickInterval);
+    clearInterval(timers.healthInterval);
+    clearInterval(timers.dedupeCleanup);
+    clearInterval(timers.worktreeCleanup);
+    await timers.stopMediaCleanup();
+    timers.skillCuratorCleanup();
+    persistSpy.mockRestore();
+    vi.useRealTimers();
   });
 
   it("disposes a loaded agent event handler on unsubscribe", async () => {

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -180,7 +180,9 @@ export function startGatewayEventSubscriptions(params: {
                   entry.projectSessionActive = false;
                   entry.projectSessionTerminalPending = false;
                   entry.projectSessionTerminalPersisted = false;
-                  entry.projectSessionTerminalEvent = undefined;
+                  // Keep projectSessionTerminalEvent until markTrackedRunTerminalPersisted
+                  // or live maintenance reconciliation succeeds; clearing here strands
+                  // replay after both bounded persist attempts reject.
                   queueMicrotask(() => {
                     const current = params.chatAbortControllers.get(candidateRunId);
                     if (

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -5,7 +5,11 @@ import { createAuditEventRecorder } from "../audit/audit-recorder.js";
 import { configureExecutionIdentityAdmissionSink } from "../audit/execution-identity-admission.js";
 import { onTrustedMessageAuditEvent } from "../audit/message-audit-events.js";
 import { getRuntimeConfig } from "../config/io.js";
-import { onAgentAuditEvent, onAgentRuntimeEvent } from "../infra/agent-events.js";
+import {
+  onAgentAuditEvent,
+  onAgentRuntimeEvent,
+  type AgentEventRuntimePayload,
+} from "../infra/agent-events.js";
 import { clearAgentRunContext } from "../infra/agent-run-registry.js";
 import { onTrustedToolExecutionEvent } from "../infra/diagnostic-events.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
@@ -36,13 +40,60 @@ function dispatchEventHandler<TEvent>(params: {
   log: SubsystemLogger;
   failureMessage: string;
   context: Record<string, unknown>;
+  onFailure?: (error: unknown) => void;
 }) {
   void params
     .loadHandler()
     .then((handler) => handler(params.event))
     .catch((error: unknown) => {
       params.log.warn(params.failureMessage, { ...params.context, error });
+      params.onFailure?.(error);
     });
+}
+
+function retainLiveTerminalReconciliationCandidate(params: {
+  chatAbortControllers: Map<string, ChatAbortControllerEntry>;
+  restartRecoveryCandidates: Map<string, RestartRecoveryCandidate>;
+  runId: string;
+  clientRunId: string;
+  event: AgentEventRuntimePayload;
+}) {
+  const candidateRunIds =
+    params.runId === params.clientRunId ? [params.runId] : [params.runId, params.clientRunId];
+  const eventLifecycleGeneration = params.event.lifecycleGeneration?.trim();
+  for (const candidateRunId of candidateRunIds) {
+    const entry = params.chatAbortControllers.get(candidateRunId);
+    if (!entry) {
+      continue;
+    }
+    if (
+      eventLifecycleGeneration &&
+      entry.lifecycleGeneration &&
+      entry.lifecycleGeneration !== eventLifecycleGeneration
+    ) {
+      continue;
+    }
+    // Lazy dispatch lost the handler path; clear immortal pending and keep the
+    // exact terminal event for live maintenance reconciliation.
+    entry.projectSessionTerminalPending = false;
+    entry.projectSessionTerminalEvent = params.event;
+    entry.projectSessionActive = false;
+    const lifecycleGeneration = entry.lifecycleGeneration?.trim() || eventLifecycleGeneration;
+    const sessionKey = entry.sessionKey.trim() || params.event.sessionKey?.trim() || "";
+    const sessionId =
+      entry.sessionId.trim() ||
+      (typeof params.event.sessionId === "string" ? params.event.sessionId.trim() : "");
+    if (lifecycleGeneration && sessionKey && sessionId && entry.controlUiVisible !== false) {
+      params.restartRecoveryCandidates.set(candidateRunId, {
+        runId: candidateRunId,
+        lifecycleGeneration,
+        sessionKey,
+        sessionId,
+        observedAt: entry.projectSessionTerminalObservedAt,
+        event: params.event,
+      });
+    }
+  }
 }
 
 /** Register gateway runtime event subscriptions and return unsubscribe handles. */
@@ -129,6 +180,7 @@ export function startGatewayEventSubscriptions(params: {
                   entry.projectSessionActive = false;
                   entry.projectSessionTerminalPending = false;
                   entry.projectSessionTerminalPersisted = false;
+                  entry.projectSessionTerminalEvent = undefined;
                   queueMicrotask(() => {
                     const current = params.chatAbortControllers.get(candidateRunId);
                     if (
@@ -155,6 +207,7 @@ export function startGatewayEventSubscriptions(params: {
                   entry.projectSessionTerminalPending = false;
                   entry.projectSessionTerminalPersisted = true;
                   entry.projectSessionTerminalPersistence = undefined;
+                  entry.projectSessionTerminalEvent = undefined;
                 }
               }
             },
@@ -200,6 +253,9 @@ export function startGatewayEventSubscriptions(params: {
                         sessionKey,
                         sessionId,
                         observedAt,
+                        ...(entry.projectSessionTerminalEvent
+                          ? { event: entry.projectSessionTerminalEvent }
+                          : {}),
                       });
                     });
                   }
@@ -285,12 +341,30 @@ export function startGatewayEventSubscriptions(params: {
             entry.lifecycleGeneration === eventLifecycleGeneration)
         ) {
           entry.projectSessionTerminalPending = true;
+          entry.projectSessionTerminalEvent = evt;
           entry.projectSessionTerminalObservedAt =
             typeof evt.data.endedAt === "number" && Number.isFinite(evt.data.endedAt)
               ? evt.data.endedAt
               : evt.ts;
         }
       }
+      dispatchEventHandler({
+        loadHandler: getAgentEventHandler,
+        event: evt,
+        log: params.log,
+        failureMessage: "Agent event dispatch failed",
+        context: { runId: evt.runId, stream: evt.stream },
+        onFailure: () => {
+          retainLiveTerminalReconciliationCandidate({
+            chatAbortControllers: params.chatAbortControllers,
+            restartRecoveryCandidates: params.restartRecoveryCandidates,
+            runId: evt.runId,
+            clientRunId,
+            event: evt,
+          });
+        },
+      });
+      return;
     } else if (lifecyclePhase === "start") {
       const chatLink = evt.contextClaimId
         ? undefined
@@ -308,6 +382,7 @@ export function startGatewayEventSubscriptions(params: {
         ) {
           entry.projectSessionTerminalPending = false;
           entry.projectSessionTerminalObservedAt = undefined;
+          entry.projectSessionTerminalEvent = undefined;
         }
       }
     }

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -2636,5 +2636,90 @@ describe("gateway server chat", () => {
       testState.sessionStorePath = undefined;
     }
   });
+
+  test("maintenance-shaped timeout lifecycle moves seeded running session to timeout once", async () => {
+    await withMainSessionStore(async (dir) => {
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-timeout-reconcile",
+            sessionFile: path.join(dir, "sess-timeout-reconcile.jsonl"),
+            updatedAt: 1_000,
+            status: "running",
+            startedAt: 900,
+          },
+        },
+      });
+
+      const runId = "run-maintenance-timeout";
+      await sessionLifecycleState.persistGatewaySessionLifecycleEvent({
+        sessionKey: "main",
+        event: {
+          runId,
+          ts: 2_000,
+          sessionId: "sess-timeout-reconcile",
+          data: {
+            phase: "end",
+            status: "cancelled",
+            aborted: true,
+            stopReason: "timeout",
+            startedAt: 900,
+            endedAt: 2_000,
+          },
+        },
+      });
+
+      const stored = loadSessionEntry({
+        sessionKey: "main",
+        storePath: testState.sessionStorePath,
+      });
+      expect(stored).toMatchObject({
+        status: "timeout",
+        startedAt: 900,
+        endedAt: 2_000,
+      });
+
+      const { waitForAgentJob } = await import("./server-methods/agent-job.js");
+      vi.useFakeTimers();
+      try {
+        const waitPromise = waitForAgentJob({ runId, timeoutMs: 5_000 });
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: { phase: "start", startedAt: 900 },
+        });
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: {
+            phase: "end",
+            aborted: true,
+            stopReason: "timeout",
+            timeoutPhase: "provider",
+            providerStarted: true,
+            startedAt: 900,
+            endedAt: 2_000,
+          },
+        });
+        await vi.advanceTimersByTimeAsync(6_000);
+        const waitRes = await waitPromise;
+        expect(waitRes).toMatchObject({
+          status: "timeout",
+          stopReason: "timeout",
+        });
+
+        // Publish the deferred hard-timeout snapshot, then prove idempotent wait.
+        await vi.advanceTimersByTimeAsync(15_000);
+        const waitAgain = await waitForAgentJob({ runId, timeoutMs: 0 });
+        expect(waitAgain).toMatchObject({
+          status: "timeout",
+          stopReason: "timeout",
+        });
+        expect(waitAgain).toEqual(waitRes);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

A lazy terminal-handler failure or failed session-row writes can leave a completed or timed-out Gateway run permanently marked `running` while the Gateway remains live. The existing shutdown recovery is too late for a healthy long-running Gateway, and the original draft also cleared the only replayable terminal event before persistence tracking completed.

This change retains the authoritative terminal event until persistence succeeds, clears stuck pending state after lazy dispatch failure, retries one failed canonical persistence attempt, and lets maintenance reconcile retained terminal events while live.

## Review Finding Resolved

ClawSweeper correctly found that the first revision cleared `projectSessionTerminalEvent` before terminal persistence was tracked. If both bounded writes rejected, maintenance had no event to replay.

The branch is now rebased onto current `main`. Commit `9d6772960e4` preserves the terminal event through the full subscription -> double persistence rejection -> live maintenance reconciliation path, and clears it only after canonical persistence succeeds.

## Evidence

The integrated regression `retains the terminal event through double persist rejection for maintenance replay` exercises the real Gateway owner callbacks in sequence:

1. A terminal timeout lifecycle event enters the Gateway subscription.
2. Both bounded canonical persistence attempts reject.
3. The tracked run retains the authoritative timeout event and recovery candidate.
4. Live maintenance retries the same event.
5. The third canonical persistence attempt succeeds exactly once.
6. The tracked run and recovery candidate are cleared.

Before the fix, the test fails because `projectSessionTerminalEvent` is `undefined` after `clearTrackedActiveRun`, leaving maintenance nothing to replay. After the fix, the test passes.

Validation:

- 189/189 tests passed across runtime subscriptions, agent events, and maintenance.
- Maintenance-shaped timeout boundary test passed.
- New full subscription-to-maintenance double-write-failure regression passed.
- Touched-file `oxfmt` and `oxlint` passed.
- `git diff --check` passed.
- Full repository type-generation currently fails on unrelated `rejectSymlinks` errors already present on the rebased `main`; none are in this PR's touched files.

No live Gateway was restarted or mutated for this proof. The downstream operator requires separate human approval before any installed-runtime restart. The deterministic proof uses the production Gateway subscription, handler ownership callbacks, maintenance timer, and canonical session lifecycle writer under injected write failures.

Related downstream repair: stevenjhammond/Marvin-Claw#264.

No Gateway restart, install, or live-state mutation was performed.
