### PR TITLE
fix(ui): prevent Git metadata stalls from blocking Control UI builds [AI]

### DIFF
--- a/ui/src/app/vite-config.node.test.ts
+++ b/ui/src/app/vite-config.node.test.ts
@@ -13,6 +13,14 @@ import {
   resolveTsconfigPathAliasesForVite,
 } from "../../vite.config.ts";
 
+const childProcessMocks = vi.hoisted(() => ({ execFileSync: vi.fn() }));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  childProcessMocks.execFileSync.mockImplementation(actual.execFileSync);
+  return { ...actual, execFileSync: childProcessMocks.execFileSync };
+});
+
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 type ResolveIdHandler = (
   this: never,
@@ -91,6 +99,49 @@ describe("Control UI Vite config", () => {
       release: false,
       buildId: "aaaaaaaaaaaa-2026-07-10T13-14-15.000Z",
     });
+  });
+
+  it("hard-kills every advisory Git read after its deadline", async () => {
+    await childProcessMocks.execFileSync.withImplementation(
+      ((_file: string, args?: readonly string[]) => {
+        const commandArgs = args ?? [];
+        if (commandArgs.includes("--format=%ct")) {
+          return "0\n";
+        }
+        if (commandArgs.includes("--abbrev-ref")) {
+          return "main\n";
+        }
+        if (commandArgs.includes("--porcelain")) {
+          return "";
+        }
+        return `${"a".repeat(40)}\n`;
+      }) as typeof import("node:child_process").execFileSync,
+      async () => {
+        childProcessMocks.execFileSync.mockClear();
+
+        expect(
+          resolveControlUiBuildInfo({
+            env: {},
+            readPackageVersion: () => null,
+          }),
+        ).toMatchObject({
+          commit: "a".repeat(40),
+          commitAt: "1970-01-01T00:00:00.000Z",
+          branch: "main",
+          dirty: false,
+        });
+        expect(childProcessMocks.execFileSync).toHaveBeenCalledTimes(4);
+        for (const call of childProcessMocks.execFileSync.mock.calls) {
+          const args = call[1];
+          const options = call[2];
+          expect(args).toContain("--no-optional-locks");
+          expect(options).toMatchObject({
+            killSignal: "SIGKILL",
+            timeout: 2_000,
+          });
+        }
+      },
+    );
   });
 
   it("records release packaging as an explicit artifact fact", () => {

--- a/ui/src/app/vite-config.node.test.ts
+++ b/ui/src/app/vite-config.node.test.ts
@@ -134,8 +134,8 @@ describe("Control UI Vite config", () => {
         now: () => new Date("2026-07-10T13:14:15.000Z"),
         readGitCommit,
         readPackageVersion: () => null,
-      }).commit,
-    ).toBe("c".repeat(40));
+      }),
+    ).toMatchObject({ commit: "c".repeat(40), commitAt: null });
     expect(readGitCommit).toHaveBeenCalledOnce();
     expect(
       resolveControlUiBuildInfo({

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -101,13 +101,19 @@ function readPackageVersion(): string | null {
   }
 }
 
+function readGit(args: string[]): string {
+  return execFileSync("git", ["--no-optional-locks", "-C", repoRoot, ...args], {
+    encoding: "utf8",
+    // Metadata reads need no index lock; disabling it makes the hard startup deadline safe.
+    killSignal: "SIGKILL",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: CONTROL_UI_GIT_READ_TIMEOUT_MS,
+  });
+}
+
 function readGitCommit(): string | null {
   try {
-    const raw = execFileSync("git", ["-C", repoRoot, "rev-parse", "HEAD"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-      timeout: CONTROL_UI_GIT_READ_TIMEOUT_MS,
-    });
+    const raw = readGit(["rev-parse", "HEAD"]);
     return raw.trim() || null;
   } catch {
     return null;
@@ -116,11 +122,7 @@ function readGitCommit(): string | null {
 
 function readGitBranch(): string | null {
   try {
-    const raw = execFileSync("git", ["-C", repoRoot, "rev-parse", "--abbrev-ref", "HEAD"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-      timeout: CONTROL_UI_GIT_READ_TIMEOUT_MS,
-    });
+    const raw = readGit(["rev-parse", "--abbrev-ref", "HEAD"]);
     return raw.trim() || null;
   } catch {
     return null;
@@ -129,11 +131,7 @@ function readGitBranch(): string | null {
 
 function readGitCommitTimestamp(commit: string): string | null {
   try {
-    const raw = execFileSync("git", ["-C", repoRoot, "show", "-s", "--format=%ct", commit], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-      timeout: CONTROL_UI_GIT_READ_TIMEOUT_MS,
-    });
+    const raw = readGit(["show", "-s", "--format=%ct", commit]);
     const seconds = Number.parseInt(raw.trim(), 10);
     const date = new Date(seconds * 1000);
     return Number.isNaN(date.getTime()) ? null : date.toISOString();
@@ -144,11 +142,7 @@ function readGitCommitTimestamp(commit: string): string | null {
 
 function readGitDirty(): boolean | null {
   try {
-    const raw = execFileSync("git", ["-C", repoRoot, "status", "--porcelain"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-      timeout: CONTROL_UI_GIT_READ_TIMEOUT_MS,
-    });
+    const raw = readGit(["status", "--porcelain"]);
     return Boolean(raw.trim());
   } catch {
     return null;

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -14,6 +14,7 @@ import type { ControlUiBuildInfo } from "./src/build-info.ts";
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "..");
 const outDir = path.resolve(here, "../dist/control-ui");
+const CONTROL_UI_GIT_READ_TIMEOUT_MS = 2_000;
 const require = createRequire(import.meta.url);
 const json5EsmPath = require.resolve("json5/dist/index.mjs");
 type ControlUiViteAlias = {
@@ -105,6 +106,7 @@ function readGitCommit(): string | null {
     const raw = execFileSync("git", ["-C", repoRoot, "rev-parse", "HEAD"], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
+      timeout: CONTROL_UI_GIT_READ_TIMEOUT_MS,
     });
     return raw.trim() || null;
   } catch {
@@ -117,6 +119,7 @@ function readGitBranch(): string | null {
     const raw = execFileSync("git", ["-C", repoRoot, "rev-parse", "--abbrev-ref", "HEAD"], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
+      timeout: CONTROL_UI_GIT_READ_TIMEOUT_MS,
     });
     return raw.trim() || null;
   } catch {
@@ -129,6 +132,7 @@ function readGitCommitTimestamp(commit: string): string | null {
     const raw = execFileSync("git", ["-C", repoRoot, "show", "-s", "--format=%ct", commit], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
+      timeout: CONTROL_UI_GIT_READ_TIMEOUT_MS,
     });
     const seconds = Number.parseInt(raw.trim(), 10);
     const date = new Date(seconds * 1000);
@@ -143,6 +147,7 @@ function readGitDirty(): boolean | null {
     const raw = execFileSync("git", ["-C", repoRoot, "status", "--porcelain"], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
+      timeout: CONTROL_UI_GIT_READ_TIMEOUT_MS,
     });
     return Boolean(raw.trim());
   } catch {
@@ -206,9 +211,14 @@ export function resolveControlUiBuildInfo(
   // Commit time is advisory identity like branch/dirty: read from the local
   // object store for the exact embedded commit, null when no checkout has it
   // (e.g. GITHUB_SHA-only builds). It must never block a build.
+  const readCommitTimestamp =
+    sources.readGitCommitTimestamp ??
+    // A caller-provided commit reader can return synthetic or remote identity.
+    // Do not combine it with a filesystem-bound reader from this checkout.
+    (sources.readGitCommit ? () => null : readGitCommitTimestamp);
   const commitAt = commit
     ? normalizeControlUiBuildInfo({
-        commitAt: (sources.readGitCommitTimestamp ?? readGitCommitTimestamp)(commit),
+        commitAt: readCommitTimestamp(commit),
       }).commitAt
     : null;
   const builtAt = normalizeBuildTimestamp(


### PR DESCRIPTION
Closes #120489

## What Problem This Solves

Fixes an issue where Control UI tests and builds could hang indefinitely while evaluating Vite configuration when advisory Git metadata was unavailable or a Git subprocess stalled.

The deterministic reproduction used a syntactically valid commit SHA that did not exist in the checkout. The synchronous `git show` child consumed a CPU core for more than five minutes, so the test/build never reached an actionable failure.

## Why This Change Was Made

All four advisory Git readers now use one owner helper with a two-second deadline, `SIGKILL`, and Git's native `--no-optional-locks` mode. The hard signal guarantees a child that ignores `SIGTERM` cannot hold synchronous Vite startup; suppressing optional locks guarantees that hard termination cannot strand an index lock. Every reader preserves its existing `null` fallback.

The build-info resolver also keeps injected commit identity and timestamp sources paired: a caller-provided commit reader can no longer fall through to a timestamp query against an unrelated local checkout.

This is the owner-boundary fix because `controlUiViteConfig()` resolves build identity synchronously before Vite starts. The final branch deliberately drops the stale generated Plugin SDK digest and weaker Doctor test refactor from the earlier candidate because current `main` already owns the canonical versions.

Provenance: the commit timestamp path was introduced by https://github.com/openclaw/openclaw/pull/111495. The pre-existing branch and dirty-state readers shared the same unbounded subprocess pattern.

Production LOC: +21/-17 (net +4) | Tests: +53/-2

## User Impact

Developers, CI jobs, and release automation now get a bounded Control UI build even when the checkout has incomplete or unhealthy Git state. Available metadata is still embedded; unavailable advisory fields become `null` instead of blocking the build or leaving a stale Git index lock.

## Evidence

- Exact head: `7333fdb21b95524d9c69db3e06bfaf45c386c98a`.
- Focused Control UI Vite config suite: 21/21 passed. The regression drives all four private Git readers through the public build-info resolver and verifies `--no-optional-locks`, `SIGKILL`, and the 2,000 ms deadline on every call.
- Git 2.55.0 directly advertises and accepts `--no-optional-locks`; repository precedent uses `SIGKILL` for bounded Git reads.
- Patch-identical pre-rebase UI fix: full Control UI suite passed 561 files, 8,379 tests, with 1 skipped; 10 fresh-process missing-commit probes returned `commitAt: null` with a 3,167 ms maximum including TypeScript/Vite startup.
- Targeted oxfmt, format check, core oxlint, `git diff --check`, and changed-lane classification passed.
- Blacksmith Testbox `tbx_01kzgvd9emzbe33dckw7addc2t` never executed the changed gate because delegated sync timed out after targeted and full-sync attempts; the lease stopped cleanly. Infrastructure run: https://github.com/openclaw/openclaw/actions/runs/31261331301. Trusted-source proof therefore fell back to the existing local dependency install, focused behavior proof, and hosted exact-head CI.
- Final P2 AutoReview accepted the index-lock safety finding; after `--no-optional-locks` and regression coverage were added, the rerun was clean with no accepted/actionable P0-P2 findings at 0.95 confidence.
- Exact-head hosted CI passed the full selected graph, Control UI E2E, and `openclaw/ci-gate`: https://github.com/openclaw/openclaw/actions/runs/31261690397.
- ClawSweeper https://github.com/openclaw/clawsweeper/actions/runs/31262048013 was rate-limited before review context acquisition; its shard artifact records `completed: 0`. No exact-head bot approval or rank-up move is claimed. Both concrete findings from the prior review are directly repaired and covered.
- Public model identifier audit: PASS; the diff and proof contain no model-bearing code or artifacts.
- Current-main merge tree is clean; no current-main commit after the rewritten base changed either owned file.

Repo-native review artifacts validate with `READY FOR /prepare-pr` and zero findings. `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 120490` passed on the unchanged head.

No screenshots are included because this changes build metadata failure handling and has no visual output change.

AI-assisted: yes. I reviewed the full Vite build-info path, its tests, current `main`, Node's synchronous child-process timeout contract, Git's optional-lock contract, related bounded Git helpers, and regression provenance.
