### PR TITLE
fix(ui): bulk session archive no longer stalls per thread

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -508,6 +508,7 @@ enum class GatewayMethod(
   TasksRetry("tasks.retry"),
   TasksDismiss("tasks.dismiss"),
   AuditRunInspect("audit.run.inspect"),
+  SessionsArchiveMany("sessions.archiveMany"),
 }
 
 enum class GatewayEvent(

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -7790,6 +7790,38 @@ public struct SessionsPatchParams: Codable, Sendable {
     }
 }
 
+public struct SessionsArchiveManyParams: Codable, Sendable {
+    public let targets: [[String: AnyCodable]]
+    public let archived: Bool
+
+    public init(
+        targets: [[String: AnyCodable]],
+        archived: Bool)
+    {
+        self.targets = targets
+        self.archived = archived
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case targets
+        case archived
+    }
+}
+
+public struct SessionsArchiveManyResult: Codable, Sendable {
+    public let outcomes: [AnyCodable]
+
+    public init(
+        outcomes: [AnyCodable])
+    {
+        self.outcomes = outcomes
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case outcomes
+    }
+}
+
 public struct SessionsPluginPatchParams: Codable, Sendable {
     public let key: String
     public let pluginid: String

--- a/packages/gateway-protocol/src/index.test.ts
+++ b/packages/gateway-protocol/src/index.test.ts
@@ -21,6 +21,7 @@ import {
   validateSessionsCompanionStateParams,
   validateSessionsCreateParams,
   validateSessionsObserverVisibilityParams,
+  validateSessionsArchiveManyParams,
   validateSessionsPatchParams,
   validateSessionsSearchParams,
   validateSessionsSendParams,
@@ -195,6 +196,40 @@ describe("lazy protocol validators", () => {
     expectRejected(validateSessionsPatchParams, [
       sessionPatch({ key: "agent:main:self-archive", expectedSessionId: "" }),
       sessionPatch({ key: "agent:main:self-archive", expectedLifecycleRevision: "" }),
+    ]);
+  });
+
+  it("validates bounded closed bulk session archive requests", () => {
+    const target = {
+      key: "agent:main:archive-me",
+      agentId: "main",
+      expectedSessionId: "session-archive-me",
+      expectedLifecycleRevision: "revision-archive-me",
+    };
+    expectAccepted(validateSessionsArchiveManyParams, [
+      { targets: [target], archived: true },
+      {
+        targets: Array.from({ length: 100 }, (_, index) => ({
+          key: `agent:main:archive-${index}`,
+        })),
+        archived: false,
+      },
+    ]);
+    expectRejected(validateSessionsArchiveManyParams, [
+      { targets: [], archived: true },
+      {
+        targets: Array.from({ length: 101 }, (_, index) => ({
+          key: `agent:main:archive-${index}`,
+        })),
+        archived: true,
+      },
+      { targets: [{ key: "" }], archived: true },
+      { targets: [{ key: target.key, agentId: "" }], archived: true },
+      { targets: [{ key: target.key, expectedSessionId: "" }], archived: true },
+      { targets: [{ key: target.key, expectedLifecycleRevision: "" }], archived: true },
+      { targets: [{ key: target.key, extra: true }], archived: true },
+      { targets: [target], archived: "yes" },
+      { targets: [target], archived: true, extra: true },
     ]);
   });
 

--- a/packages/gateway-protocol/src/schema-export-registry.ts
+++ b/packages/gateway-protocol/src/schema-export-registry.ts
@@ -226,6 +226,8 @@ export {
   SessionsSendParamsSchema,
   SessionsAbortParamsSchema,
   SessionsPatchParamsSchema,
+  SessionsArchiveManyParamsSchema,
+  SessionsArchiveManyResultSchema,
   SessionsPluginPatchParamsSchema,
   SessionsResetParamsSchema,
   SessionsDeleteParamsSchema,

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-sessions-lifecycle.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-sessions-lifecycle.ts
@@ -47,6 +47,8 @@ export const SessionLifecycleProtocolSchemas = {
   SessionsViewerPresenceSetResult: viewerPresence.SessionsViewerPresenceSetResultSchema,
   SessionsAbortParams: sessions.SessionsAbortParamsSchema,
   SessionsPatchParams: sessions.SessionsPatchParamsSchema,
+  SessionsArchiveManyParams: sessions.SessionsArchiveManyParamsSchema,
+  SessionsArchiveManyResult: sessions.SessionsArchiveManyResultSchema,
   SessionsPluginPatchParams: sessions.SessionsPluginPatchParamsSchema,
   SessionsPluginPatchResult: sessions.SessionsPluginPatchResultSchema,
   SessionsResetParams: sessions.SessionsResetParamsSchema,

--- a/packages/gateway-protocol/src/schema/sessions-archive-many.ts
+++ b/packages/gateway-protocol/src/schema/sessions-archive-many.ts
@@ -1,0 +1,41 @@
+import type { Static } from "typebox";
+import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
+import { ErrorShapeSchema } from "./frames.js";
+import { NonEmptyString } from "./primitives.js";
+
+export const SessionsArchiveManyTargetSchema = closedObject({
+  key: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  expectedSessionId: Type.Optional(NonEmptyString),
+  expectedLifecycleRevision: Type.Optional(NonEmptyString),
+});
+
+export const SessionsArchiveManyParamsSchema = closedObject({
+  targets: Type.Array(SessionsArchiveManyTargetSchema, { minItems: 1, maxItems: 100 }),
+  archived: Type.Boolean(),
+});
+
+const SessionsArchiveManyOutcomeIdentitySchema = {
+  key: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+};
+
+export const SessionsArchiveManyResultSchema = closedObject({
+  outcomes: Type.Array(
+    Type.Union([
+      closedObject({
+        ok: Type.Literal(true),
+        ...SessionsArchiveManyOutcomeIdentitySchema,
+      }),
+      closedObject({
+        ok: Type.Literal(false),
+        ...SessionsArchiveManyOutcomeIdentitySchema,
+        error: ErrorShapeSchema,
+      }),
+    ]),
+  ),
+});
+
+export type SessionsArchiveManyParams = Static<typeof SessionsArchiveManyParamsSchema>;
+export type SessionsArchiveManyResult = Static<typeof SessionsArchiveManyResultSchema>;

--- a/packages/gateway-protocol/src/schema/sessions-archive-many.ts
+++ b/packages/gateway-protocol/src/schema/sessions-archive-many.ts
@@ -4,6 +4,8 @@ import { closedObject } from "./closed-object.js";
 import { ErrorShapeSchema } from "./frames.js";
 import { NonEmptyString } from "./primitives.js";
 
+export const SESSIONS_ARCHIVE_MANY_MAX_TARGETS = 100;
+
 export const SessionsArchiveManyTargetSchema = closedObject({
   key: NonEmptyString,
   agentId: Type.Optional(NonEmptyString),
@@ -12,7 +14,10 @@ export const SessionsArchiveManyTargetSchema = closedObject({
 });
 
 export const SessionsArchiveManyParamsSchema = closedObject({
-  targets: Type.Array(SessionsArchiveManyTargetSchema, { minItems: 1, maxItems: 100 }),
+  targets: Type.Array(SessionsArchiveManyTargetSchema, {
+    minItems: 1,
+    maxItems: SESSIONS_ARCHIVE_MANY_MAX_TARGETS,
+  }),
   archived: Type.Boolean(),
 });
 

--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -12,6 +12,7 @@ import { SessionToolOverridesSchema } from "./sessions-row.js";
 
 export { SessionsCreateParamsSchema };
 export {
+  SESSIONS_ARCHIVE_MANY_MAX_TARGETS,
   SessionsArchiveManyParamsSchema,
   SessionsArchiveManyResultSchema,
   SessionsArchiveManyTargetSchema,

--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -551,6 +551,38 @@ export const SessionsPatchParamsSchema = closedObject({
 });
 export type SessionsPatchParams = Static<typeof SessionsPatchParamsSchema>;
 
+export const SessionsArchiveManyTargetSchema = closedObject({
+  key: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+  expectedSessionId: Type.Optional(NonEmptyString),
+  expectedLifecycleRevision: Type.Optional(NonEmptyString),
+});
+export const SessionsArchiveManyParamsSchema = closedObject({
+  targets: Type.Array(SessionsArchiveManyTargetSchema, { minItems: 1, maxItems: 100 }),
+  archived: Type.Boolean(),
+});
+export type SessionsArchiveManyParams = Static<typeof SessionsArchiveManyParamsSchema>;
+const SessionsArchiveManyOutcomeIdentitySchema = {
+  key: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
+};
+export const SessionsArchiveManyResultSchema = closedObject({
+  outcomes: Type.Array(
+    Type.Union([
+      closedObject({
+        ok: Type.Literal(true),
+        ...SessionsArchiveManyOutcomeIdentitySchema,
+      }),
+      closedObject({
+        ok: Type.Literal(false),
+        ...SessionsArchiveManyOutcomeIdentitySchema,
+        error: ErrorShapeSchema,
+      }),
+    ]),
+  ),
+});
+export type SessionsArchiveManyResult = Static<typeof SessionsArchiveManyResultSchema>;
+
 /** Updates or clears one plugin namespace value on a session record. */
 export const SessionsPluginPatchParamsSchema = closedObject({
   key: NonEmptyString,

--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -12,6 +12,13 @@ import { SessionToolOverridesSchema } from "./sessions-row.js";
 
 export { SessionsCreateParamsSchema };
 export {
+  SessionsArchiveManyParamsSchema,
+  SessionsArchiveManyResultSchema,
+  SessionsArchiveManyTargetSchema,
+  type SessionsArchiveManyParams,
+  type SessionsArchiveManyResult,
+} from "./sessions-archive-many.js";
+export {
   SessionCreatedActorSchema,
   SessionRowSchema,
   SessionToolOverridesSchema,
@@ -550,38 +557,6 @@ export const SessionsPatchParamsSchema = closedObject({
   ),
 });
 export type SessionsPatchParams = Static<typeof SessionsPatchParamsSchema>;
-
-export const SessionsArchiveManyTargetSchema = closedObject({
-  key: NonEmptyString,
-  agentId: Type.Optional(NonEmptyString),
-  expectedSessionId: Type.Optional(NonEmptyString),
-  expectedLifecycleRevision: Type.Optional(NonEmptyString),
-});
-export const SessionsArchiveManyParamsSchema = closedObject({
-  targets: Type.Array(SessionsArchiveManyTargetSchema, { minItems: 1, maxItems: 100 }),
-  archived: Type.Boolean(),
-});
-export type SessionsArchiveManyParams = Static<typeof SessionsArchiveManyParamsSchema>;
-const SessionsArchiveManyOutcomeIdentitySchema = {
-  key: NonEmptyString,
-  agentId: Type.Optional(NonEmptyString),
-};
-export const SessionsArchiveManyResultSchema = closedObject({
-  outcomes: Type.Array(
-    Type.Union([
-      closedObject({
-        ok: Type.Literal(true),
-        ...SessionsArchiveManyOutcomeIdentitySchema,
-      }),
-      closedObject({
-        ok: Type.Literal(false),
-        ...SessionsArchiveManyOutcomeIdentitySchema,
-        error: ErrorShapeSchema,
-      }),
-    ]),
-  ),
-});
-export type SessionsArchiveManyResult = Static<typeof SessionsArchiveManyResultSchema>;
 
 /** Updates or clears one plugin namespace value on a session record. */
 export const SessionsPluginPatchParamsSchema = closedObject({

--- a/packages/gateway-protocol/src/validator-registry.ts
+++ b/packages/gateway-protocol/src/validator-registry.ts
@@ -214,6 +214,7 @@ export const validateSessionsViewerPresenceSetParams = compile(
 );
 export const validateSessionsAbortParams = compile(S.SessionsAbortParamsSchema);
 export const validateSessionsPatchParams = compile(S.SessionsPatchParamsSchema);
+export const validateSessionsArchiveManyParams = compile(S.SessionsArchiveManyParamsSchema);
 export const validateSessionsPluginPatchParams = compile(S.SessionsPluginPatchParamsSchema);
 export const validateSessionsResetParams = compile(S.SessionsResetParamsSchema);
 export const validateSessionsDeleteParams = compile(S.SessionsDeleteParamsSchema);

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -61,6 +61,7 @@ describe("method scope resolution", () => {
     ["sessions.reclaim", ["operator.admin"]],
     ["sessions.send", ["operator.write"]],
     ["sessions.abort", ["operator.write"]],
+    ["sessions.archiveMany", ["operator.write"]],
     ["tasks.cancel", ["operator.write"]],
     ["tasks.retry", ["operator.write"]],
     ["tasks.dismiss", ["operator.write"]],

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -486,6 +486,7 @@ const CORE_GATEWAY_METHOD_SPECS = [
   ["tasks.dismiss", "tasks", "operator.write", "2026.7"],
   // Additive audit inspection appends so older advertised method indices stay stable.
   ["audit.run.inspect", "audit", "operator.read", "2026.7"],
+  ["sessions.archiveMany", "sessions-mutations", "operator.write", "2026.8"],
 ] as const satisfies readonly CoreGatewayMethodSpecRow[];
 
 export type CoreGatewayHandlerFamily = Exclude<(typeof CORE_GATEWAY_METHOD_SPECS)[number][1], null>;

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -66,7 +66,7 @@ describe("listGatewayMethods", () => {
   });
 
   it("appends new methods after model probing without shifting older method indices", () => {
-    expect(listGatewayMethods().slice(-31)).toEqual([
+    expect(listGatewayMethods().slice(-32)).toEqual([
       "models.probe",
       "migrations.memory.plan",
       "migrations.memory.apply",
@@ -98,6 +98,7 @@ describe("listGatewayMethods", () => {
       "tasks.retry",
       "tasks.dismiss",
       "audit.run.inspect",
+      "sessions.archiveMany",
     ]);
     const methods = listGatewayMethods();
     expect(methods.indexOf("node.pluginSurface.refresh")).toBe(
@@ -165,7 +166,7 @@ describe("listGatewayMethods", () => {
       "exec.approval.get",
     ]);
     expect(methods).toContain("tts.speak");
-    expect(coreMethods.slice(-38)).toEqual([
+    expect(coreMethods.slice(-39)).toEqual([
       "sessions.catalog.continue",
       "sessions.catalog.archive",
       "approval.get",
@@ -204,10 +205,12 @@ describe("listGatewayMethods", () => {
       "tasks.retry",
       "tasks.dismiss",
       "audit.run.inspect",
+      "sessions.archiveMany",
     ]);
     expect(methods.indexOf("approval.get")).toBeGreaterThan(methods.indexOf("tts.speak"));
     expect(methods.indexOf("approval.resolve")).toBe(methods.indexOf("approval.get") + 1);
     expect(methods.indexOf("audit.run.inspect")).toBe(methods.indexOf("tasks.dismiss") + 1);
+    expect(methods.indexOf("sessions.archiveMany")).toBe(methods.indexOf("audit.run.inspect") + 1);
   });
 
   it("advertises the versioned Talk session RPCs", () => {

--- a/src/gateway/server-methods.authorization.test.ts
+++ b/src/gateway/server-methods.authorization.test.ts
@@ -339,10 +339,21 @@ describe("gateway method authorization", () => {
   });
 });
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
 describe("sessions.archiveMany orchestration", () => {
   it("starts canonical patches concurrently and preserves target order", async () => {
     const originalPatch = sessionMutationHandlers["sessions.patch"];
-    const releases = Array.from({ length: 3 }, () => Promise.withResolvers<void>());
+    if (!originalPatch) {
+      throw new Error("sessions.patch handler is not registered");
+    }
+    const releases = Array.from({ length: 3 }, () => deferred<void>());
     const patch = vi.fn<GatewayRequestHandler>(async ({ params, respond }) => {
       const index = Number(String(params.key).at(-1));
       await releases[index]?.promise;
@@ -391,6 +402,9 @@ describe("sessions.archiveMany orchestration", () => {
 
   it("rejects logical aliases before dispatch", async () => {
     const originalPatch = sessionMutationHandlers["sessions.patch"];
+    if (!originalPatch) {
+      throw new Error("sessions.patch handler is not registered");
+    }
     const patch = vi.fn<GatewayRequestHandler>();
     sessionMutationHandlers["sessions.patch"] = patch;
     const respond = vi.fn();

--- a/src/gateway/server-methods.authorization.test.ts
+++ b/src/gateway/server-methods.authorization.test.ts
@@ -338,3 +338,79 @@ describe("gateway method authorization", () => {
     });
   });
 });
+
+describe("sessions.archiveMany orchestration", () => {
+  it("starts canonical patches concurrently and preserves target order", async () => {
+    const originalPatch = sessionMutationHandlers["sessions.patch"];
+    const releases = Array.from({ length: 3 }, () => Promise.withResolvers<void>());
+    const patch = vi.fn<GatewayRequestHandler>(async ({ params, respond }) => {
+      const index = Number(String(params.key).at(-1));
+      await releases[index]?.promise;
+      if (index === 1) {
+        respond(false, undefined, { code: "INVALID_REQUEST", message: "active run" });
+      } else {
+        respond(true, { ok: true });
+      }
+    });
+    sessionMutationHandlers["sessions.patch"] = patch;
+    const respond = vi.fn();
+    try {
+      const request = sessionMutationHandlers["sessions.archiveMany"]!({
+        params: {
+          targets: [0, 1, 2].map((index) => ({ key: `agent:main:batch-${index}` })),
+          archived: true,
+        },
+        respond,
+        context: { getRuntimeConfig: () => ({}) },
+      } as never);
+      await vi.waitFor(() => expect(patch).toHaveBeenCalledTimes(3));
+      releases[2]!.resolve();
+      releases[1]!.resolve();
+      releases[0]!.resolve();
+      await request;
+
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        {
+          outcomes: [
+            { ok: true, key: "agent:main:batch-0" },
+            {
+              ok: false,
+              key: "agent:main:batch-1",
+              error: { code: "INVALID_REQUEST", message: "active run" },
+            },
+            { ok: true, key: "agent:main:batch-2" },
+          ],
+        },
+        undefined,
+      );
+    } finally {
+      sessionMutationHandlers["sessions.patch"] = originalPatch;
+    }
+  });
+
+  it("rejects logical aliases before dispatch", async () => {
+    const originalPatch = sessionMutationHandlers["sessions.patch"];
+    const patch = vi.fn<GatewayRequestHandler>();
+    sessionMutationHandlers["sessions.patch"] = patch;
+    const respond = vi.fn();
+    try {
+      await sessionMutationHandlers["sessions.archiveMany"]!({
+        params: {
+          targets: [{ key: "agent:main:duplicate" }, { key: "duplicate" }],
+          archived: true,
+        },
+        respond,
+        context: { getRuntimeConfig: () => ({}) },
+      } as never);
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({ message: "Duplicate target." }),
+      );
+      expect(patch).not.toHaveBeenCalled();
+    } finally {
+      sessionMutationHandlers["sessions.patch"] = originalPatch;
+    }
+  });
+});

--- a/src/gateway/server-methods/sessions-mutations.ts
+++ b/src/gateway/server-methods/sessions-mutations.ts
@@ -3,6 +3,8 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import {
   ErrorCodes,
   errorShape,
+  type SessionsArchiveManyResult,
+  validateSessionsArchiveManyParams,
   validateSessionsPatchParams,
   validateSessionsPluginPatchParams,
   validateSessionsResetParams,
@@ -30,6 +32,7 @@ import { ADMIN_SCOPE } from "../operator-scopes.js";
 import { ensureSessionGroupRegistered } from "../session-groups.js";
 import { triggerSessionPatchHook } from "../session-patch-hooks.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-request-agent.js";
+import { SessionMutationAuthorizationChangedError } from "../session-sharing.js";
 import {
   loadSessionEntry,
   resolveCanonicalGatewaySessionStoreKey,
@@ -57,6 +60,56 @@ import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 export const sessionMutationHandlers: GatewayRequestHandlers = {
+  "sessions.archiveMany": async (options) => {
+    const { params, respond, context } = options;
+    if (
+      !assertValidParams(params, validateSessionsArchiveManyParams, "sessions.archiveMany", respond)
+    ) {
+      return;
+    }
+    const cfg = context.getRuntimeConfig();
+    const logicalTargets = new Set<string>();
+    for (const target of params.targets) {
+      const resolved = resolveGatewaySessionTargetFromKey(target.key.trim(), cfg, {
+        agentId: target.agentId,
+      });
+      const logicalId = `${resolved.storePath}\0${resolved.target.canonicalKey ?? target.key}`;
+      if (logicalTargets.has(logicalId)) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "Duplicate target."));
+        return;
+      }
+      logicalTargets.add(logicalId);
+    }
+    const patchHandler = sessionMutationHandlers["sessions.patch"];
+    if (!patchHandler) {
+      throw new Error("sessions.patch handler is not registered");
+    }
+    const outcomes = await Promise.all(
+      params.targets.map(async (target) => {
+        const identity = {
+          key: target.key,
+          ...(target.agentId ? { agentId: target.agentId } : {}),
+        };
+        let outcome: SessionsArchiveManyResult["outcomes"][number] | undefined;
+        try {
+          await patchHandler({
+            ...options,
+            params: { ...target, archived: params.archived },
+            respond: (ok, _payload, error) => {
+              outcome = ok ? { ok: true, ...identity } : { ok: false, ...identity, error: error! };
+            },
+          });
+        } catch (error) {
+          if (!(error instanceof SessionMutationAuthorizationChangedError)) {
+            throw error;
+          }
+          outcome = { ok: false, ...identity, error: error.error };
+        }
+        return outcome!;
+      }),
+    );
+    respond(true, { outcomes } satisfies SessionsArchiveManyResult, undefined);
+  },
   "sessions.patch": async ({ params, respond, context, client, sessionMutationAuthorization }) => {
     if (!assertValidParams(params, validateSessionsPatchParams, "sessions.patch", respond)) {
       return;

--- a/src/gateway/server.sessions.store-rpc.test.ts
+++ b/src/gateway/server.sessions.store-rpc.test.ts
@@ -127,6 +127,7 @@ test("lists and patches session store via sessions.* RPC", async () => {
   expect(methods).toContain("sessions.preview");
   expect(methods).toContain("sessions.cleanup");
   expect(methods).toContain("sessions.patch");
+  expect(methods).toContain("sessions.archiveMany");
   expect(methods).toContain("sessions.reset");
   expect(methods).toContain("sessions.delete");
   expect(methods).toContain("sessions.compact");

--- a/src/gateway/session-sharing-store-cache.test.ts
+++ b/src/gateway/session-sharing-store-cache.test.ts
@@ -39,6 +39,23 @@ function identifiedClient(userId: string): GatewayClient {
 }
 
 describe("session mutation authorization store caches", () => {
+  it("fails an archiveMany request when a nested target is incognito", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const sessionKey = "agent:main:dashboard:incognito-archive-many";
+      await sessionAccessor.upsertSessionEntry(
+        { agentId: "main", sessionKey },
+        { sessionId: "session-incognito", updatedAt: 1, incognito: true },
+      );
+      const result = resolveSessionMutationAuthorization({
+        client: identifiedClient("viewer@example.com"),
+        method: "sessions.archiveMany",
+        requestParams: { targets: [{ key: sessionKey, agentId: "main" }], archived: true },
+        context: { chatAbortControllers: new Map(), getRuntimeConfig: () => ({}) } as never,
+      });
+      expect(result.error).toMatchObject({ code: "INVALID_REQUEST" });
+    });
+  });
+
   it("materializes and discovers each store once when one request resolves multiple targets", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       for (const [sessionKey, sessionId] of [

--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -412,6 +412,16 @@ function resolveSessionMutationTargets(params: {
   context: GatewayRequestContext;
   getCfg: () => OpenClawConfig;
 }): SessionMutationTarget[] | undefined {
+  if (params.method === "sessions.archiveMany") {
+    const targets = (params.requestParams as { targets?: unknown } | null)?.targets;
+    return Array.isArray(targets)
+      ? targets.slice(0, 101).flatMap((target): SessionMutationTarget[] => {
+          const sessionKey = readStringParam(target, "key");
+          const agentId = readStringParam(target, "agentId");
+          return sessionKey ? [{ sessionKey, ...(agentId ? { agentId } : {}) }] : [];
+        })
+      : undefined;
+  }
   if (params.method === "sessions.groups.rename" || params.method === "sessions.groups.delete") {
     return resolveSessionGroupMutationTargets({
       getCfg: params.getCfg,
@@ -532,7 +542,15 @@ export function resolveSessionMutationAuthorization(params: {
       agentId: targetRef.agentId,
       ...lookupCaches,
     });
-    const error = target ? authorizeSessionSharingTarget({ client: params.client, target }) : null;
+    const error =
+      (params.method === "sessions.archiveMany"
+        ? authorizeIncognitoSessionTarget({
+            client: params.client,
+            sessionKey: targetRef.sessionKey,
+            target,
+          })
+        : null) ??
+      (target ? authorizeSessionSharingTarget({ client: params.client, target }) : null);
     if (error) {
       return { error };
     }

--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -53,6 +53,7 @@ const PLUGIN_GATEWAY_SESSION_MUTATION_METHODS = new Set([
   "sessions.fork",
   "sessions.create",
   "sessions.delete",
+  "sessions.archiveMany",
   "sessions.patch",
   "sessions.pluginPatch",
   "sessions.reset",

--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeOptionalAgentRuntimeId } from "../agents/agent-runtime-id.js";
 import { createChannelIngressDrain } from "../channels/message/ingress-drain.js";
@@ -473,6 +474,19 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
         return;
       }
       const request = params ?? {};
+      if (method === "sessions.archiveMany" && Array.isArray(request.targets)) {
+        for (const target of request.targets) {
+          if (!isRecord(target)) {
+            continue;
+          }
+          assertSessionIdentitiesOwned({
+            action: `request gateway method "${method}" for`,
+            agentId: target.agentId,
+            sessionKeys: [target.key],
+          });
+        }
+        return;
+      }
       const sessionKeys = [request.sessionKey, request.key, request.parentSessionKey];
       const sessionIds = [request.sessionId];
       assertSessionIdentitiesOwned({

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -719,6 +719,12 @@ describe("plugin registry runtime config scope", () => {
       }),
     ).rejects.toThrow('owned by plugin "codex-owner"');
     await expect(
+      otherApi.runtime.gateway.request("sessions.archiveMany", {
+        targets: [{ key: ordinaryKey }, { key: reservedKey }],
+        archived: true,
+      }),
+    ).rejects.toThrow('owned by plugin "codex-owner"');
+    await expect(
       otherApi.runtime.gateway.request("agent", {
         sessionId: reservedEntry.sessionId,
         message: "continue",

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -30,3 +30,4 @@ import "../test-helpers/app-sidebar-cases/sessions.ts";
 import "../test-helpers/app-sidebar-cases/session-ownership.ts";
 import "../test-helpers/app-sidebar-cases/session-list-sections.ts";
 import "../test-helpers/app-sidebar-cases/sidebar-zone.ts";
+import "../test-helpers/app-sidebar-cases/transient-menus.ts";

--- a/ui/src/components/session-organizer-batch-mutations.test.ts
+++ b/ui/src/components/session-organizer-batch-mutations.test.ts
@@ -3,7 +3,7 @@ import type {
   SessionsArchiveManyParams,
   SessionsArchiveManyResult,
 } from "../../../packages/gateway-protocol/src/schema/sessions-archive-many.js";
-import type { GatewayBrowserClient } from "../api/gateway.ts";
+import { GatewayRequestError, type GatewayBrowserClient } from "../api/gateway.ts";
 import type { ApplicationGatewaySnapshot } from "../app/gateway.ts";
 import type { SessionCapability } from "../lib/sessions/index.ts";
 import type {
@@ -22,16 +22,22 @@ function sessionRow(index: number): SidebarRecentSession {
 
 function createHarness(
   params: {
-    methods?: string[];
+    methods?: string[] | null;
     scopes?: string[];
     current?: boolean;
     staleAfterRequest?: number;
+    requestFailure?: { at: number; error: unknown };
   } = {},
 ) {
   let current = params.current ?? true;
   let requestCount = 0;
   const request = vi.fn(async (_method: string, rawParams?: unknown) => {
     const archiveParams = rawParams as SessionsArchiveManyParams;
+    const requestFailure = params.requestFailure;
+    requestCount += 1;
+    if (requestFailure && requestCount === requestFailure.at) {
+      throw requestFailure.error;
+    }
     const result = {
       outcomes: archiveParams.targets.map((target) => {
         if (target.agentId) {
@@ -40,7 +46,6 @@ function createHarness(
         return { ok: true as const, key: target.key };
       }),
     } satisfies SessionsArchiveManyResult;
-    requestCount += 1;
     if (requestCount === params.staleAfterRequest) {
       current = false;
     }
@@ -51,7 +56,8 @@ function createHarness(
     client,
     phase: "connected",
     hello: {
-      features: { methods: params.methods ?? ["sessions.archiveMany"] },
+      features:
+        params.methods === null ? {} : { methods: params.methods ?? ["sessions.archiveMany"] },
       auth: { role: "operator", scopes: params.scopes ?? ["operator.write"] },
     },
   } as ApplicationGatewaySnapshot;
@@ -145,6 +151,76 @@ describe("archiveSessionRows", () => {
     expect(harness.request).not.toHaveBeenCalled();
     expect(harness.refreshReplacement).not.toHaveBeenCalled();
     expect(harness.publishSessionMutationError).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])(
+    "uses the supplied fallback for a metadata-less legacy rejection with archived=%s",
+    async (archived) => {
+      const rejection = new GatewayRequestError({
+        code: "INVALID_REQUEST",
+        message: "unknown method: sessions.archiveMany",
+      });
+      const harness = createHarness({
+        methods: null,
+        requestFailure: { at: 1, error: rejection },
+      });
+      const rows = [sessionRow(0)];
+      const fallbackRows = [sessionRow(1)];
+      const fallback = vi.fn(async () => fallbackRows);
+
+      await expect(
+        archiveSessionRows(harness.host, rows, archived, harness.scope, { fallback }),
+      ).resolves.toBe(fallbackRows);
+
+      expect(harness.request).toHaveBeenCalledOnce();
+      expect(harness.request).toHaveBeenCalledWith("sessions.archiveMany", {
+        targets: [{ key: rows[0]!.key, agentId: "main" }],
+        archived,
+      });
+      expect(fallback).toHaveBeenCalledOnce();
+      expect(harness.refreshReplacement).not.toHaveBeenCalled();
+      expect(harness.publishSessionMutationError).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not fallback for an unrelated INVALID_REQUEST", async () => {
+    const rejection = new GatewayRequestError({
+      code: "INVALID_REQUEST",
+      message: "invalid archive request",
+    });
+    const harness = createHarness({
+      methods: null,
+      requestFailure: { at: 1, error: rejection },
+    });
+    const fallback = vi.fn(async () => [sessionRow(1)]);
+
+    await expect(
+      archiveSessionRows(harness.host, [sessionRow(0)], true, harness.scope, { fallback }),
+    ).resolves.toBeNull();
+
+    expect(harness.request).toHaveBeenCalledOnce();
+    expect(fallback).not.toHaveBeenCalled();
+    expect(harness.refreshReplacement).not.toHaveBeenCalled();
+    expect(harness.publishSessionMutationError).toHaveBeenCalledWith(harness.scope, rejection);
+  });
+
+  it("does not fallback after an earlier chunk succeeds", async () => {
+    const rejection = new GatewayRequestError({
+      code: "INVALID_REQUEST",
+      message: "unknown method: sessions.archiveMany",
+    });
+    const harness = createHarness({ requestFailure: { at: 2, error: rejection } });
+    const rows = Array.from({ length: 101 }, (_, index) => sessionRow(index));
+    const fallback = vi.fn(async () => [sessionRow(1)]);
+
+    await expect(
+      archiveSessionRows(harness.host, rows, true, harness.scope, { fallback }),
+    ).resolves.toEqual(rows.slice(0, 100));
+
+    expect(harness.request).toHaveBeenCalledTimes(2);
+    expect(fallback).not.toHaveBeenCalled();
+    expect(harness.refreshReplacement).toHaveBeenCalledOnce();
+    expect(harness.publishSessionMutationError).toHaveBeenCalledWith(harness.scope, rejection);
   });
 
   it("does not fallback when operator.write is missing", async () => {

--- a/ui/src/components/session-organizer-batch-mutations.test.ts
+++ b/ui/src/components/session-organizer-batch-mutations.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  SessionsArchiveManyParams,
+  SessionsArchiveManyResult,
+} from "../../../packages/gateway-protocol/src/schema/sessions-archive-many.js";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import type { ApplicationGatewaySnapshot } from "../app/gateway.ts";
+import type { SessionCapability } from "../lib/sessions/index.ts";
+import type {
+  SidebarRecentSession,
+  SidebarSessionMutationScope,
+} from "./app-sidebar-session-types.ts";
+import { archiveSessionRows } from "./session-organizer-batch-mutations.ts";
+import type { SessionOrganizerControllerHost } from "./session-organizer-controller.ts";
+
+function sessionRow(index: number): SidebarRecentSession {
+  return {
+    key: `agent:main:batch-${index}`,
+    pinned: index === 0 || index === 100,
+  } as SidebarRecentSession;
+}
+
+function createHarness(
+  params: {
+    methods?: string[];
+    scopes?: string[];
+    current?: boolean;
+    staleAfterRequest?: number;
+  } = {},
+) {
+  let current = params.current ?? true;
+  let requestCount = 0;
+  const request = vi.fn(async (_method: string, rawParams?: unknown) => {
+    const archiveParams = rawParams as SessionsArchiveManyParams;
+    const result = {
+      outcomes: archiveParams.targets.map((target) => ({
+        ok: true,
+        key: target.key,
+        ...(target.agentId ? { agentId: target.agentId } : {}),
+      })),
+    } satisfies SessionsArchiveManyResult;
+    requestCount += 1;
+    if (requestCount === params.staleAfterRequest) {
+      current = false;
+    }
+    return result;
+  });
+  const client = { request } as unknown as GatewayBrowserClient;
+  const snapshot = {
+    client,
+    phase: "connected",
+    hello: {
+      features: { methods: params.methods ?? ["sessions.archiveMany"] },
+      auth: { role: "operator", scopes: params.scopes ?? ["operator.write"] },
+    },
+  } as ApplicationGatewaySnapshot;
+  const refreshReplacement = vi.fn(async () => undefined);
+  const scope = {
+    epoch: 1,
+    context: {},
+    gateway: { snapshot },
+    sessions: { refreshReplacement } as unknown as SessionCapability,
+    client,
+    selectedAgentId: "main",
+  } as SidebarSessionMutationScope;
+  const publishSessionMutationError = vi.fn();
+  const pruneSidebarSessionEntry = vi.fn();
+  const host = {
+    sessionData: {
+      isSessionMutationScopeCurrent: vi.fn(() => current),
+      publishSessionMutationError,
+      refreshSidebarSessions: vi.fn(),
+    },
+    sidebarSessionStatusFilter: () => "active",
+    pruneSidebarSessionEntry,
+  } as unknown as SessionOrganizerControllerHost;
+  return {
+    host,
+    pruneSidebarSessionEntry,
+    publishSessionMutationError,
+    refreshReplacement,
+    request,
+    scope,
+  };
+}
+
+describe("archiveSessionRows", () => {
+  it("dispatches 101 rows as ordered protocol-sized chunks and refreshes once", async () => {
+    const rows = Array.from({ length: 101 }, (_, index) => sessionRow(index));
+    const harness = createHarness();
+
+    const archived = await archiveSessionRows(harness.host, rows, true, harness.scope);
+
+    expect(harness.request).toHaveBeenCalledTimes(2);
+    expect(harness.request.mock.calls.map(([, params]) => params)).toEqual([
+      {
+        targets: rows.slice(0, 100).map((row) => ({ key: row.key, agentId: "main" })),
+        archived: true,
+      },
+      {
+        targets: [{ key: rows[100]!.key, agentId: "main" }],
+        archived: true,
+      },
+    ]);
+    expect(archived).toEqual(rows);
+    expect(harness.pruneSidebarSessionEntry.mock.calls.map(([key]) => key)).toEqual([
+      rows[0]!.key,
+      rows[100]!.key,
+    ]);
+    expect(harness.refreshReplacement).toHaveBeenCalledOnce();
+  });
+
+  it("sends no requests or refresh when the mutation scope is already stale", async () => {
+    const harness = createHarness({ current: false });
+
+    await expect(
+      archiveSessionRows(harness.host, [sessionRow(0)], true, harness.scope),
+    ).resolves.toBeNull();
+
+    expect(harness.request).not.toHaveBeenCalled();
+    expect(harness.refreshReplacement).not.toHaveBeenCalled();
+  });
+
+  it("stops before a later chunk when the mutation scope becomes stale", async () => {
+    const harness = createHarness({ staleAfterRequest: 1 });
+    const rows = Array.from({ length: 101 }, (_, index) => sessionRow(index));
+
+    await expect(archiveSessionRows(harness.host, rows, true, harness.scope)).resolves.toBeNull();
+
+    expect(harness.request).toHaveBeenCalledOnce();
+    expect(harness.refreshReplacement).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "the method is unavailable",
+      harness: () => createHarness({ methods: [] }),
+      reason: "This Gateway does not support this thread action.",
+    },
+    {
+      name: "operator.write is missing",
+      harness: () => createHarness({ scopes: ["operator.read"] }),
+      reason: "This action requires operator.write access.",
+    },
+  ])("sends no requests and surfaces the access error when $name", async ({ harness, reason }) => {
+    const testHarness = harness();
+
+    await expect(
+      archiveSessionRows(testHarness.host, [sessionRow(0)], true, testHarness.scope),
+    ).resolves.toBeNull();
+
+    expect(testHarness.request).not.toHaveBeenCalled();
+    expect(testHarness.refreshReplacement).not.toHaveBeenCalled();
+    expect(testHarness.publishSessionMutationError).toHaveBeenCalledWith(testHarness.scope, reason);
+  });
+});

--- a/ui/src/components/session-organizer-batch-mutations.test.ts
+++ b/ui/src/components/session-organizer-batch-mutations.test.ts
@@ -132,26 +132,35 @@ describe("archiveSessionRows", () => {
     expect(harness.refreshReplacement).not.toHaveBeenCalled();
   });
 
-  it.each([
-    {
-      name: "the method is unavailable",
-      harness: () => createHarness({ methods: [] }),
-      reason: "This Gateway does not support this thread action.",
-    },
-    {
-      name: "operator.write is missing",
-      harness: () => createHarness({ scopes: ["operator.read"] }),
-      reason: "This action requires operator.write access.",
-    },
-  ])("sends no requests and surfaces the access error when $name", async ({ harness, reason }) => {
-    const testHarness = harness();
+  it("uses the supplied fallback when the method is unavailable", async () => {
+    const harness = createHarness({ methods: [] });
+    const fallbackRows = [sessionRow(1)];
+    const fallback = vi.fn(async () => fallbackRows);
 
     await expect(
-      archiveSessionRows(testHarness.host, [sessionRow(0)], true, testHarness.scope),
+      archiveSessionRows(harness.host, [sessionRow(0)], true, harness.scope, { fallback }),
+    ).resolves.toBe(fallbackRows);
+
+    expect(fallback).toHaveBeenCalledOnce();
+    expect(harness.request).not.toHaveBeenCalled();
+    expect(harness.refreshReplacement).not.toHaveBeenCalled();
+    expect(harness.publishSessionMutationError).not.toHaveBeenCalled();
+  });
+
+  it("does not fallback when operator.write is missing", async () => {
+    const harness = createHarness({ scopes: ["operator.read"] });
+    const fallback = vi.fn(async () => [sessionRow(1)]);
+
+    await expect(
+      archiveSessionRows(harness.host, [sessionRow(0)], true, harness.scope, { fallback }),
     ).resolves.toBeNull();
 
-    expect(testHarness.request).not.toHaveBeenCalled();
-    expect(testHarness.refreshReplacement).not.toHaveBeenCalled();
-    expect(testHarness.publishSessionMutationError).toHaveBeenCalledWith(testHarness.scope, reason);
+    expect(fallback).not.toHaveBeenCalled();
+    expect(harness.request).not.toHaveBeenCalled();
+    expect(harness.refreshReplacement).not.toHaveBeenCalled();
+    expect(harness.publishSessionMutationError).toHaveBeenCalledWith(
+      harness.scope,
+      "This action requires operator.write access.",
+    );
   });
 });

--- a/ui/src/components/session-organizer-batch-mutations.test.ts
+++ b/ui/src/components/session-organizer-batch-mutations.test.ts
@@ -33,11 +33,12 @@ function createHarness(
   const request = vi.fn(async (_method: string, rawParams?: unknown) => {
     const archiveParams = rawParams as SessionsArchiveManyParams;
     const result = {
-      outcomes: archiveParams.targets.map((target) => ({
-        ok: true,
-        key: target.key,
-        ...(target.agentId ? { agentId: target.agentId } : {}),
-      })),
+      outcomes: archiveParams.targets.map((target) => {
+        if (target.agentId) {
+          return { ok: true as const, key: target.key, agentId: target.agentId };
+        }
+        return { ok: true as const, key: target.key };
+      }),
     } satisfies SessionsArchiveManyResult;
     requestCount += 1;
     if (requestCount === params.staleAfterRequest) {

--- a/ui/src/components/session-organizer-batch-mutations.ts
+++ b/ui/src/components/session-organizer-batch-mutations.ts
@@ -3,6 +3,7 @@ import {
   type SessionsArchiveManyParams,
   type SessionsArchiveManyResult,
 } from "../../../packages/gateway-protocol/src/schema/sessions-archive-many.js";
+import { GatewayRequestError } from "../api/gateway.ts";
 import { formatUiError } from "../lib/format-error.ts";
 import { readSessionMethodAccess } from "../lib/session-method-access.ts";
 import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
@@ -12,6 +13,14 @@ import type {
   SidebarSessionMutationScope,
 } from "./app-sidebar-session-types.ts";
 import type { SessionOrganizerControllerHost } from "./session-organizer-controller.ts";
+
+function isLegacyArchiveManyMethodRejection(error: unknown): boolean {
+  return (
+    error instanceof GatewayRequestError &&
+    error.gatewayCode === "INVALID_REQUEST" &&
+    error.message.includes("unknown method: sessions.archiveMany")
+  );
+}
 
 export function sessionRowAgentId(
   session: SidebarRecentSession,
@@ -104,6 +113,15 @@ export async function archiveSessionRows(
       }
       dispatched.push({ rows: chunkRows, result });
     } catch (error) {
+      // Metadata-less legacy Gateways allow the optimistic request, then identify
+      // this one unsupported method through the canonical Gateway error contract.
+      if (
+        dispatched.length === 0 &&
+        options.fallback &&
+        isLegacyArchiveManyMethodRejection(error)
+      ) {
+        return options.fallback();
+      }
       terminalError = error;
       host.sessionData.publishSessionMutationError(scope, error);
       break;

--- a/ui/src/components/session-organizer-batch-mutations.ts
+++ b/ui/src/components/session-organizer-batch-mutations.ts
@@ -59,7 +59,10 @@ export async function archiveSessionRows(
   rows: readonly SidebarRecentSession[],
   archived: boolean,
   scope: SidebarSessionMutationScope,
-  deferListRefresh = false,
+  options: {
+    deferListRefresh?: boolean;
+    fallback?: () => Promise<SidebarRecentSession[] | null>;
+  } = {},
 ): Promise<SidebarRecentSession[] | null> {
   const dispatched: Array<{
     rows: readonly SidebarRecentSession[];
@@ -84,6 +87,9 @@ export async function archiveSessionRows(
       requiredScope: "operator.write",
     });
     if (!access.allowed) {
+      if (access.cause === "method-unavailable" && options.fallback) {
+        return options.fallback();
+      }
       terminalError = access.reason;
       host.sessionData.publishSessionMutationError(scope, access.reason);
       break;
@@ -106,7 +112,7 @@ export async function archiveSessionRows(
   if (dispatched.length === 0) {
     return null;
   }
-  if (!deferListRefresh) {
+  if (!options.deferListRefresh) {
     const refreshResult = await refreshSessionsAfterBatch(host, scope, rows);
     if (refreshResult === "stale") {
       return null;

--- a/ui/src/components/session-organizer-batch-mutations.ts
+++ b/ui/src/components/session-organizer-batch-mutations.ts
@@ -1,4 +1,9 @@
-import type { SessionsArchiveManyResult } from "../../../packages/gateway-protocol/src/schema/sessions-archive-many.js";
+import {
+  SESSIONS_ARCHIVE_MANY_MAX_TARGETS,
+  type SessionsArchiveManyParams,
+  type SessionsArchiveManyResult,
+} from "../../../packages/gateway-protocol/src/schema/sessions-archive-many.js";
+import { readSessionMethodAccess } from "../lib/session-method-access.ts";
 import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
 import type {
   SidebarRecentSession,
@@ -55,42 +60,78 @@ export async function archiveSessionRows(
   scope: SidebarSessionMutationScope,
   deferListRefresh = false,
 ): Promise<SidebarRecentSession[] | null> {
-  const targets = rows.map((row) => ({ key: row.key, agentId: sessionRowAgentId(row, scope) }));
-  let result;
-  try {
-    result = await scope.client.request<SessionsArchiveManyResult>("sessions.archiveMany", {
-      targets,
-      archived,
-    });
+  const dispatched: Array<{
+    rows: readonly SidebarRecentSession[];
+    result: SessionsArchiveManyResult;
+  }> = [];
+  let terminalError: unknown = null;
+  for (let offset = 0; offset < rows.length; offset += SESSIONS_ARCHIVE_MANY_MAX_TARGETS) {
     if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
       return null;
     }
-    if (!deferListRefresh) {
-      const refreshResult = await refreshSessionsAfterBatch(host, scope, rows);
-      if (refreshResult === "stale") {
+    const chunkRows = rows.slice(offset, offset + SESSIONS_ARCHIVE_MANY_MAX_TARGETS);
+    const params: SessionsArchiveManyParams = {
+      targets: chunkRows.map((row) => ({
+        key: row.key,
+        agentId: sessionRowAgentId(row, scope),
+      })),
+      archived,
+    };
+    const access = readSessionMethodAccess(scope.gateway.snapshot, {
+      method: "sessions.archiveMany",
+      params,
+      requiredScope: "operator.write",
+    });
+    if (!access.allowed) {
+      terminalError = access.reason;
+      host.sessionData.publishSessionMutationError(scope, access.reason);
+      break;
+    }
+    try {
+      const result = await scope.client.request<SessionsArchiveManyResult>(
+        "sessions.archiveMany",
+        params,
+      );
+      if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
         return null;
       }
+      dispatched.push({ rows: chunkRows, result });
+    } catch (error) {
+      terminalError = error;
+      host.sessionData.publishSessionMutationError(scope, error);
+      break;
     }
-  } catch (error) {
-    host.sessionData.publishSessionMutationError(scope, error);
+  }
+  if (dispatched.length === 0) {
     return null;
+  }
+  if (!deferListRefresh) {
+    const refreshResult = await refreshSessionsAfterBatch(host, scope, rows);
+    if (refreshResult === "stale") {
+      return null;
+    }
   }
   if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
     return null;
   }
   const errors: string[] = [];
-  const successful = result.outcomes.flatMap((outcome, index) => {
-    if (!outcome.ok) {
-      errors.push(`${outcome.key}: ${outcome.error.message}`);
-      return [];
-    }
-    const row = rows[index];
-    if (row?.pinned && archived) {
-      host.pruneSidebarSessionEntry(row.key);
-    }
-    return row ? [row] : [];
-  });
+  const successful = dispatched.flatMap(({ rows: chunkRows, result }) =>
+    result.outcomes.flatMap((outcome, index) => {
+      if (!outcome.ok) {
+        errors.push(`${outcome.key}: ${outcome.error.message}`);
+        return [];
+      }
+      const row = chunkRows[index];
+      if (row?.pinned && archived) {
+        host.pruneSidebarSessionEntry(row.key);
+      }
+      return row ? [row] : [];
+    }),
+  );
   if (errors.length > 0) {
+    if (terminalError !== null) {
+      errors.push(String(terminalError));
+    }
     host.sessionData.publishSessionMutationError(scope, errors.join("; "));
   }
   return successful;

--- a/ui/src/components/session-organizer-batch-mutations.ts
+++ b/ui/src/components/session-organizer-batch-mutations.ts
@@ -1,0 +1,97 @@
+import type { SessionsArchiveManyResult } from "../../../packages/gateway-protocol/src/schema/sessions-archive-many.js";
+import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
+import type {
+  SidebarRecentSession,
+  SidebarSessionMutationResult,
+  SidebarSessionMutationScope,
+} from "./app-sidebar-session-types.ts";
+import type { SessionOrganizerControllerHost } from "./session-organizer-controller.ts";
+
+export function sessionRowAgentId(
+  session: SidebarRecentSession,
+  scope: SidebarSessionMutationScope,
+): string {
+  return parseAgentSessionKey(session.key)?.agentId ?? scope.selectedAgentId;
+}
+
+/**
+ * One list refresh per owning agent, replacing the per-row refreshes a batch
+ * defers; each deferred row skipped a full `sessions.list` round trip and rode
+ * pushed `sessions.changed` events instead. Agents come from the rows, not the
+ * scope, because `patchSession` routes every mutation by its own key. The
+ * result carries the stale/failed reporting the per-row refresh owed its caller.
+ */
+export async function refreshSessionsAfterBatch(
+  host: SessionOrganizerControllerHost,
+  scope: SidebarSessionMutationScope,
+  rows: readonly SidebarRecentSession[],
+): Promise<SidebarSessionMutationResult> {
+  const agentIds = [...new Set(rows.map((row) => sessionRowAgentId(row, scope)))];
+  const refreshSidebar = host.sidebarSessionStatusFilter() !== "active";
+  for (const agentId of agentIds) {
+    if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
+      return "stale";
+    }
+    try {
+      await scope.sessions.refreshReplacement(agentId);
+      if (refreshSidebar && host.sessionData.isSessionMutationScopeCurrent(scope)) {
+        await host.sessionData.refreshSidebarSessions(agentId);
+      }
+    } catch (error) {
+      if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
+        return "stale";
+      }
+      host.sessionData.publishSessionMutationError(scope, error);
+      return "failed";
+    }
+  }
+  return host.sessionData.isSessionMutationScopeCurrent(scope) ? "completed" : "stale";
+}
+
+export async function archiveSessionRows(
+  host: SessionOrganizerControllerHost,
+  rows: readonly SidebarRecentSession[],
+  archived: boolean,
+  scope: SidebarSessionMutationScope,
+  deferListRefresh = false,
+): Promise<SidebarRecentSession[] | null> {
+  const targets = rows.map((row) => ({ key: row.key, agentId: sessionRowAgentId(row, scope) }));
+  let result;
+  try {
+    result = await scope.client.request<SessionsArchiveManyResult>("sessions.archiveMany", {
+      targets,
+      archived,
+    });
+    if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
+      return null;
+    }
+    if (!deferListRefresh) {
+      const refreshResult = await refreshSessionsAfterBatch(host, scope, rows);
+      if (refreshResult === "stale") {
+        return null;
+      }
+    }
+  } catch (error) {
+    host.sessionData.publishSessionMutationError(scope, error);
+    return null;
+  }
+  if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
+    return null;
+  }
+  const errors: string[] = [];
+  const successful = result.outcomes.flatMap((outcome, index) => {
+    if (!outcome.ok) {
+      errors.push(`${outcome.key}: ${outcome.error.message}`);
+      return [];
+    }
+    const row = rows[index];
+    if (row?.pinned && archived) {
+      host.pruneSidebarSessionEntry(row.key);
+    }
+    return row ? [row] : [];
+  });
+  if (errors.length > 0) {
+    host.sessionData.publishSessionMutationError(scope, errors.join("; "));
+  }
+  return successful;
+}

--- a/ui/src/components/session-organizer-batch-mutations.ts
+++ b/ui/src/components/session-organizer-batch-mutations.ts
@@ -3,6 +3,7 @@ import {
   type SessionsArchiveManyParams,
   type SessionsArchiveManyResult,
 } from "../../../packages/gateway-protocol/src/schema/sessions-archive-many.js";
+import { formatUiError } from "../lib/format-error.ts";
 import { readSessionMethodAccess } from "../lib/session-method-access.ts";
 import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
 import type {
@@ -129,8 +130,9 @@ export async function archiveSessionRows(
     }),
   );
   if (errors.length > 0) {
-    if (terminalError !== null) {
-      errors.push(String(terminalError));
+    const terminalErrorMessage = terminalError === null ? "" : formatUiError(terminalError);
+    if (terminalErrorMessage) {
+      errors.push(terminalErrorMessage);
     }
     host.sessionData.publishSessionMutationError(scope, errors.join("; "));
   }

--- a/ui/src/components/session-organizer-controller.ts
+++ b/ui/src/components/session-organizer-controller.ts
@@ -1,4 +1,4 @@
-import type { ReactiveController } from "lit";
+import type { ReactiveController, ReactiveControllerHost } from "lit";
 import {
   parseSidebarEntry,
   SIDEBAR_NAV_ROUTES,
@@ -29,10 +29,35 @@ import {
   type SidebarSessionPatch,
   type SidebarSessionStatusFilter,
 } from "./app-sidebar-session-types.ts";
+import type { SessionDataController } from "./session-data-controller.ts";
 import type { SessionMenuAction } from "./session-menu.ts";
-import type { SessionOrganizerControllerHost } from "./session-organizer-operations.runtime.ts";
 
 type SessionOrganizerOperations = typeof import("./session-organizer-operations.runtime.ts");
+
+export interface SessionOrganizerControllerHost extends ReactiveControllerHost {
+  readonly sessionData: Pick<
+    SessionDataController,
+    | "beginSessionMutation"
+    | "isSessionMutationScopeCurrent"
+    | "publishSessionMutationError"
+    | "refreshSidebarSessions"
+    | "resetForStatusFilter"
+  >;
+  readonly onUpdateSidebarEntries?: (entries: string[]) => void;
+  sessionsGrouping: SidebarSessionsGrouping;
+  sessionsShowCron: boolean;
+  sessionsStatusFilter: SidebarSessionStatusFilter;
+  clearSessionSelection(): void;
+  findSidebarSessionByKey(sessionKey: string): SidebarRecentSession | undefined;
+  knownSessionGroups(): string[];
+  knownSessionCatalogIds(): string[];
+  knownSectionOrder(): string[];
+  pruneSidebarSessionEntry(key: string): void;
+  reconciledSidebarZone(): { sidebarEntries: readonly string[] };
+  replaceCurrentSession(sessionKey: string): void;
+  selectSession(sessionKey: string): void;
+  sidebarSessionStatusFilter(): SidebarSessionStatusFilter;
+}
 
 /** Custom session groups, collapse state, and drag-and-drop assignment. */
 export class SessionOrganizerController implements ReactiveController {

--- a/ui/src/components/session-organizer-operations.runtime.ts
+++ b/ui/src/components/session-organizer-operations.runtime.ts
@@ -125,6 +125,32 @@ export async function patchSessions(
   return refreshed === "completed" ? result : refreshed;
 }
 
+async function archiveSessionRowsSerial(
+  host: SessionOrganizerControllerHost,
+  rows: readonly SidebarRecentSession[],
+  archived: boolean,
+  scope: SidebarSessionMutationScope,
+  options: { deferListRefresh?: boolean } = {},
+): Promise<SidebarRecentSession[] | null> {
+  const completed: SidebarRecentSession[] = [];
+  for (const row of rows) {
+    const result = await patchSession(host, row, { archived }, scope, { deferListRefresh: true });
+    if (result === "stale") {
+      return null;
+    }
+    if (result === "completed") {
+      completed.push(row);
+    }
+  }
+  if (!options.deferListRefresh) {
+    const refreshed = await refreshSessionsAfterBatch(host, scope, rows);
+    if (refreshed === "stale") {
+      return null;
+    }
+  }
+  return completed;
+}
+
 export async function archiveSessionWithUndo(
   host: SessionOrganizerControllerHost,
   session: SidebarRecentSession,
@@ -151,7 +177,9 @@ async function archiveSessionsWithUndo(
   if (rows.length === 0) {
     return;
   }
-  const archivedRows = await archiveSessionRows(host, rows, true, scope);
+  const archivedRows = await archiveSessionRows(host, rows, true, scope, {
+    fallback: () => archiveSessionRowsSerial(host, rows, true, scope),
+  });
   if (!archivedRows || archivedRows.length === 0) {
     return;
   }
@@ -171,13 +199,11 @@ async function restoreArchivedSessions(
   archived: readonly { session: SidebarRecentSession; pinned: boolean }[],
   scope: SidebarSessionMutationScope,
 ) {
-  const restored = await archiveSessionRows(
-    host,
-    archived.map((entry) => entry.session),
-    false,
-    scope,
-    true,
-  );
+  const rows = archived.map((entry) => entry.session);
+  const restored = await archiveSessionRows(host, rows, false, scope, {
+    deferListRefresh: true,
+    fallback: () => archiveSessionRowsSerial(host, rows, false, scope, { deferListRefresh: true }),
+  });
   if (!restored) {
     return;
   }
@@ -195,11 +221,7 @@ async function restoreArchivedSessions(
   if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
     return;
   }
-  await refreshSessionsAfterBatch(
-    host,
-    scope,
-    archived.map((entry) => entry.session),
-  );
+  await refreshSessionsAfterBatch(host, scope, rows);
 }
 
 /** One confirm and one preserved-worktrees alert for the whole selection. */
@@ -291,7 +313,9 @@ export async function runBatchSessionAction(
       break;
     case "toggle-archived":
       if (rows.every((row) => row.archived === true)) {
-        await archiveSessionRows(host, rows, false, scope);
+        await archiveSessionRows(host, rows, false, scope, {
+          fallback: () => archiveSessionRowsSerial(host, rows, false, scope),
+        });
       } else {
         await archiveSessionsWithUndo(
           host,

--- a/ui/src/components/session-organizer-operations.runtime.ts
+++ b/ui/src/components/session-organizer-operations.runtime.ts
@@ -1,12 +1,6 @@
-import type { ReactiveControllerHost } from "lit";
-import type { SessionsArchiveManyResult } from "../../../packages/gateway-protocol/src/schema/sessions.js";
 import { t } from "../i18n/index.ts";
 import { readSessionMethodAccess } from "../lib/session-method-access.ts";
-import {
-  moveSessionSection,
-  normalizeSessionSectionOrder,
-  type SidebarSessionsGrouping,
-} from "../lib/sessions/grouping.ts";
+import { moveSessionSection, normalizeSessionSectionOrder } from "../lib/sessions/grouping.ts";
 import {
   buildAgentMainSessionKey,
   parseAgentSessionKey,
@@ -19,35 +13,14 @@ import type {
   SidebarSessionMutationResult,
   SidebarSessionMutationScope,
   SidebarSessionPatch,
-  SidebarSessionStatusFilter,
 } from "./app-sidebar-session-types.ts";
-import type { SessionDataController } from "./session-data-controller.ts";
 import type { SessionMenuAction } from "./session-menu.ts";
-
-export interface SessionOrganizerControllerHost extends ReactiveControllerHost {
-  readonly sessionData: Pick<
-    SessionDataController,
-    | "beginSessionMutation"
-    | "isSessionMutationScopeCurrent"
-    | "publishSessionMutationError"
-    | "refreshSidebarSessions"
-    | "resetForStatusFilter"
-  >;
-  readonly onUpdateSidebarEntries?: (entries: string[]) => void;
-  sessionsGrouping: SidebarSessionsGrouping;
-  sessionsShowCron: boolean;
-  sessionsStatusFilter: SidebarSessionStatusFilter;
-  clearSessionSelection(): void;
-  findSidebarSessionByKey(sessionKey: string): SidebarRecentSession | undefined;
-  knownSessionGroups(): string[];
-  knownSessionCatalogIds(): string[];
-  knownSectionOrder(): string[];
-  pruneSidebarSessionEntry(key: string): void;
-  reconciledSidebarZone(): { sidebarEntries: readonly string[] };
-  replaceCurrentSession(sessionKey: string): void;
-  selectSession(sessionKey: string): void;
-  sidebarSessionStatusFilter(): SidebarSessionStatusFilter;
-}
+import {
+  archiveSessionRows,
+  refreshSessionsAfterBatch,
+  sessionRowAgentId,
+} from "./session-organizer-batch-mutations.ts";
+import type { SessionOrganizerControllerHost } from "./session-organizer-controller.ts";
 
 function requireSessionMutationAccess(
   host: SessionOrganizerControllerHost,
@@ -122,47 +95,6 @@ export async function patchSession(
     host.sessionData.publishSessionMutationError(scope, error);
     return "failed";
   }
-}
-
-function sessionRowAgentId(
-  session: SidebarRecentSession,
-  scope: SidebarSessionMutationScope,
-): string {
-  return parseAgentSessionKey(session.key)?.agentId ?? scope.selectedAgentId;
-}
-
-/**
- * One list refresh per owning agent, replacing the per-row refreshes a batch
- * defers; each deferred row skipped a full `sessions.list` round trip and rode
- * pushed `sessions.changed` events instead. Agents come from the rows, not the
- * scope, because `patchSession` routes every mutation by its own key. The
- * result carries the stale/failed reporting the per-row refresh owed its caller.
- */
-async function refreshSessionsAfterBatch(
-  host: SessionOrganizerControllerHost,
-  scope: SidebarSessionMutationScope,
-  rows: readonly SidebarRecentSession[],
-): Promise<SidebarSessionMutationResult> {
-  const agentIds = [...new Set(rows.map((row) => sessionRowAgentId(row, scope)))];
-  const refreshSidebar = host.sidebarSessionStatusFilter() !== "active";
-  for (const agentId of agentIds) {
-    if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
-      return "stale";
-    }
-    try {
-      await scope.sessions.refreshReplacement(agentId);
-      if (refreshSidebar && host.sessionData.isSessionMutationScopeCurrent(scope)) {
-        await host.sessionData.refreshSidebarSessions(agentId);
-      }
-    } catch (error) {
-      if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
-        return "stale";
-      }
-      host.sessionData.publishSessionMutationError(scope, error);
-      return "failed";
-    }
-  }
-  return host.sessionData.isSessionMutationScopeCurrent(scope) ? "completed" : "stale";
 }
 
 export async function patchSessions(
@@ -268,54 +200,6 @@ async function restoreArchivedSessions(
     scope,
     archived.map((entry) => entry.session),
   );
-}
-
-async function archiveSessionRows(
-  host: SessionOrganizerControllerHost,
-  rows: readonly SidebarRecentSession[],
-  archived: boolean,
-  scope: SidebarSessionMutationScope,
-  deferListRefresh = false,
-): Promise<SidebarRecentSession[] | null> {
-  const targets = rows.map((row) => ({ key: row.key, agentId: sessionRowAgentId(row, scope) }));
-  let result;
-  try {
-    result = await scope.client.request<SessionsArchiveManyResult>("sessions.archiveMany", {
-      targets,
-      archived,
-    });
-    if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
-      return null;
-    }
-    if (!deferListRefresh) {
-      const refreshResult = await refreshSessionsAfterBatch(host, scope, rows);
-      if (refreshResult === "stale") {
-        return null;
-      }
-    }
-  } catch (error) {
-    host.sessionData.publishSessionMutationError(scope, error);
-    return null;
-  }
-  if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
-    return null;
-  }
-  const errors: string[] = [];
-  const successful = result.outcomes.flatMap((outcome, index) => {
-    if (!outcome.ok) {
-      errors.push(`${outcome.key}: ${outcome.error.message}`);
-      return [];
-    }
-    const row = rows[index];
-    if (row?.pinned && archived) {
-      host.pruneSidebarSessionEntry(row.key);
-    }
-    return row ? [row] : [];
-  });
-  if (errors.length > 0) {
-    host.sessionData.publishSessionMutationError(scope, errors.join("; "));
-  }
-  return successful;
 }
 
 /** One confirm and one preserved-worktrees alert for the whole selection. */

--- a/ui/src/components/session-organizer-operations.runtime.ts
+++ b/ui/src/components/session-organizer-operations.runtime.ts
@@ -1,4 +1,5 @@
 import type { ReactiveControllerHost } from "lit";
+import type { SessionsArchiveManyResult } from "../../../packages/gateway-protocol/src/schema/sessions.js";
 import { t } from "../i18n/index.ts";
 import { readSessionMethodAccess } from "../lib/session-method-access.ts";
 import {
@@ -218,22 +219,11 @@ async function archiveSessionsWithUndo(
   if (rows.length === 0) {
     return;
   }
-  const archived: Array<{ session: SidebarRecentSession; pinned: boolean }> = [];
-  for (const session of rows) {
-    const result = await patchSession(host, session, { archived: true }, scope, {
-      deferListRefresh: true,
-    });
-    if (result === "stale") {
-      return;
-    }
-    if (result === "completed") {
-      archived.push({ session, pinned: session.pinned });
-    }
-  }
-  const refreshed = await refreshSessionsAfterBatch(host, scope, rows);
-  if (archived.length === 0 || refreshed === "stale") {
+  const archivedRows = await archiveSessionRows(host, rows, true, scope);
+  if (!archivedRows || archivedRows.length === 0) {
     return;
   }
+  const archived = archivedRows.map((session) => ({ session, pinned: session.pinned }));
   showToast({
     message:
       archived.length === 1
@@ -249,26 +239,83 @@ async function restoreArchivedSessions(
   archived: readonly { session: SidebarRecentSession; pinned: boolean }[],
   scope: SidebarSessionMutationScope,
 ) {
-  if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
+  const restored = await archiveSessionRows(
+    host,
+    archived.map((entry) => entry.session),
+    false,
+    scope,
+    true,
+  );
+  if (!restored) {
     return;
   }
   for (const { session, pinned } of archived) {
-    const result = await patchSession(
-      host,
-      session,
-      { archived: false, ...(pinned ? { pinned: true } : {}) },
-      scope,
-      { deferListRefresh: true },
-    );
+    if (!pinned || !restored.includes(session)) {
+      continue;
+    }
+    const result = await patchSession(host, session, { pinned: true }, scope, {
+      deferListRefresh: true,
+    });
     if (result === "stale") {
       return;
     }
+  }
+  if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
+    return;
   }
   await refreshSessionsAfterBatch(
     host,
     scope,
     archived.map((entry) => entry.session),
   );
+}
+
+async function archiveSessionRows(
+  host: SessionOrganizerControllerHost,
+  rows: readonly SidebarRecentSession[],
+  archived: boolean,
+  scope: SidebarSessionMutationScope,
+  deferListRefresh = false,
+): Promise<SidebarRecentSession[] | null> {
+  const targets = rows.map((row) => ({ key: row.key, agentId: sessionRowAgentId(row, scope) }));
+  let result;
+  try {
+    result = await scope.client.request<SessionsArchiveManyResult>("sessions.archiveMany", {
+      targets,
+      archived,
+    });
+    if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
+      return null;
+    }
+    if (!deferListRefresh) {
+      const refreshResult = await refreshSessionsAfterBatch(host, scope, rows);
+      if (refreshResult === "stale") {
+        return null;
+      }
+    }
+  } catch (error) {
+    host.sessionData.publishSessionMutationError(scope, error);
+    return null;
+  }
+  if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
+    return null;
+  }
+  const errors: string[] = [];
+  const successful = result.outcomes.flatMap((outcome, index) => {
+    if (!outcome.ok) {
+      errors.push(`${outcome.key}: ${outcome.error.message}`);
+      return [];
+    }
+    const row = rows[index];
+    if (row?.pinned && archived) {
+      host.pruneSidebarSessionEntry(row.key);
+    }
+    return row ? [row] : [];
+  });
+  if (errors.length > 0) {
+    host.sessionData.publishSessionMutationError(scope, errors.join("; "));
+  }
+  return successful;
 }
 
 /** One confirm and one preserved-worktrees alert for the whole selection. */
@@ -360,7 +407,7 @@ export async function runBatchSessionAction(
       break;
     case "toggle-archived":
       if (rows.every((row) => row.archived === true)) {
-        await patchSessions(host, rows, { archived: false }, scope);
+        await archiveSessionRows(host, rows, false, scope);
       } else {
         await archiveSessionsWithUndo(
           host,

--- a/ui/src/components/sidebar-menus-controller.ts
+++ b/ui/src/components/sidebar-menus-controller.ts
@@ -31,8 +31,10 @@ import type { SidebarWorkboardBoard, SidebarWorkboardRenderers } from "./app-sid
 import type { SessionDataController } from "./session-data-controller.ts";
 import { fetchSessionMenuWork } from "./session-menu-work.ts";
 import type { SessionMenuWork } from "./session-menu.ts";
-import type { SessionOrganizerController } from "./session-organizer-controller.ts";
-import type { SessionOrganizerControllerHost } from "./session-organizer-operations.runtime.ts";
+import type {
+  SessionOrganizerController,
+  SessionOrganizerControllerHost,
+} from "./session-organizer-controller.ts";
 import type { SessionCreatorOption } from "./session-owner-chip.ts";
 
 type SidebarMenuAgent = {

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -45,8 +45,18 @@ function sessionMenuActionDisabledReasons(
     method: "sessions.patch",
     params: { key: session.key, label: null },
   });
-  const archiveReason = batchRows
-    ? reason({ method: "sessions.archiveMany", requiredScope: "operator.write" })
+  const archiveManyAccess = batchRows
+    ? readSessionMethodAccess(snapshot, {
+        method: "sessions.archiveMany",
+        requiredScope: "operator.write",
+      })
+    : null;
+  const archiveReason = archiveManyAccess
+    ? archiveManyAccess.allowed
+      ? undefined
+      : archiveManyAccess.cause === "method-unavailable"
+        ? patchReason
+        : archiveManyAccess.reason
     : patchReason;
   const groupReason = reason({
     method: "sessions.groups.put",

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -45,6 +45,9 @@ function sessionMenuActionDisabledReasons(
     method: "sessions.patch",
     params: { key: session.key, label: null },
   });
+  const archiveReason = batchRows
+    ? reason({ method: "sessions.archiveMany", requiredScope: "operator.write" })
+    : patchReason;
   const groupReason = reason({
     method: "sessions.groups.put",
     requiredScope: "operator.write",
@@ -66,9 +69,9 @@ function sessionMenuActionDisabledReasons(
           "toggle-unread": patchReason,
           rename: patchReason,
           "move-to-group": patchReason,
-          "toggle-archived": patchReason,
         }
       : {}),
+    ...(archiveReason ? { "toggle-archived": archiveReason } : {}),
     ...(groupReason || patchReason ? { "new-group": groupReason ?? patchReason } : {}),
     ...(deleteReason ? { delete: deleteReason } : {}),
     ...(batchRows

--- a/ui/src/e2e/session-management.archive.e2e.test.ts
+++ b/ui/src/e2e/session-management.archive.e2e.test.ts
@@ -193,11 +193,10 @@ suite.define(() => {
     }
   });
 
-  // Batch archiving used to force one canonical sessions.list per row, which is
-  // what made a multi-select stall. The whole selection must archive on one
-  // refresh and leave the sidebar settled with the rows gone.
+  // Batch archiving used to serialize one sessions.patch transaction per row.
+  // The whole selection now crosses the Gateway once and settles from one list.
 
-  it("archives a sidebar multi-select with one canonical list refresh", async () => {
+  it("archives a sidebar multi-select in one RPC and surfaces ordered partial failures", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -214,8 +213,20 @@ suite.define(() => {
           sessionRow(batchKeys[1], "Batch B", baseTime - 2_000),
           sessionRow(batchKeys[2], "Batch C", baseTime - 3_000),
         ]),
-        "sessions.patch": {},
+        "sessions.archiveMany": {
+          outcomes: [
+            { ok: true, key: batchKeys[0], agentId: "main" },
+            {
+              ok: false,
+              key: batchKeys[1],
+              agentId: "main",
+              error: { code: "INVALID_REQUEST", message: "active run" },
+            },
+            { ok: true, key: batchKeys[2], agentId: "main" },
+          ],
+        },
       },
+      sessionArchiveFiltering: true,
       sessionKey: "agent:main:main",
     });
 
@@ -240,18 +251,26 @@ suite.define(() => {
       await captureUiProof(page, "sidebar-multi-select-archive-menu.png");
       await activateMenuItem(archiveItem);
 
-      for (const key of batchKeys) {
-        await waitForPatch(gateway, (params) => params.key === key && params.archived === true);
-      }
-
-      const patches = await gateway.getRequests("sessions.patch");
-      expect(patches.map((request) => requireRecord(request.params).key)).toEqual([...batchKeys]);
-      // The whole selection costs one canonical refresh, not one per archived row.
+      const archive = await gateway.waitForRequest("sessions.archiveMany");
+      const archiveParams = requireRecord(archive.params);
+      expect(archiveParams.archived).toBe(true);
+      expect((archiveParams.targets as Array<{ key: string }>).map((target) => target.key)).toEqual(
+        [...batchKeys],
+      );
+      expect(await gateway.getRequests("sessions.patch")).toEqual([]);
       await expect
         .poll(async () => (await gateway.getRequests("sessions.list")).length, { timeout: 10_000 })
         .toBe(listCountBeforeBatch + 1);
+      await rowFor(batchKeys[0]).waitFor({ state: "detached" });
+      await rowFor(batchKeys[2]).waitFor({ state: "detached" });
+      await rowFor(batchKeys[1]).waitFor({ state: "visible" });
+      const error = page.locator("[data-sidebar-session-error]");
+      await error.waitFor({ state: "visible" });
+      await expect.poll(() => error.textContent()).toContain(`${batchKeys[1]}: active run`);
+      await expect
+        .poll(() => page.locator(".app-toast").textContent())
+        .toContain("Archived 2 threads");
       await captureUiProof(page, "sidebar-multi-select-archive-settled.png");
-      // Hold past the batch so a late per-row refresh would still be caught.
       await page.waitForTimeout(500);
       expect((await gateway.getRequests("sessions.list")).length).toBe(listCountBeforeBatch + 1);
     } finally {
@@ -282,6 +301,9 @@ suite.define(() => {
           sessionRow("agent:main:main", "Main", baseTime),
           ...sessionRows,
         ]),
+        "sessions.archiveMany": {
+          outcomes: batchRows.map((row) => ({ ok: true, key: row.key, agentId: "main" })),
+        },
         "sessions.patch": {},
       },
       sessionArchiveFiltering: true,
@@ -317,8 +339,8 @@ suite.define(() => {
       await activateMenuItem(
         batchMenu.getByRole("menuitem", { name: `Archive ${batchRows.length}` }),
       );
+      await gateway.waitForRequest("sessions.archiveMany");
       for (const row of batchRows) {
-        await waitForPatch(gateway, (params) => params.key === row.key && params.archived === true);
         await gateway.emitGatewayEvent("sessions.changed", {
           ...row,
           archived: true,

--- a/ui/src/test-helpers/app-sidebar-cases/interactions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/interactions.ts
@@ -3,7 +3,7 @@ import type {
   SessionCatalog,
   SessionsCatalogListResult,
 } from "../../../../packages/gateway-protocol/src/index.ts";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
 import {
   loadStoredHiddenSessionCatalogIds,
@@ -87,11 +87,14 @@ describe("AppSidebar multi-select", () => {
     return menu;
   }
 
-  async function mountMultiSelect(methods?: string[]) {
+  async function mountMultiSelect(methods?: string[] | null, archiveManyError?: Error) {
     const harness = createSessionsHarness("main", KEYS);
     const request = vi.fn((method: string, params?: unknown) => {
       if (method !== "sessions.archiveMany") {
         return Promise.reject(new Error(`unexpected request: ${method}`));
+      }
+      if (archiveManyError) {
+        return Promise.reject(archiveManyError);
       }
       const archiveParams = params as {
         targets: Array<{ key: string; agentId?: string }>;
@@ -104,11 +107,11 @@ describe("AppSidebar multi-select", () => {
         return request(method, params);
       },
     } as GatewayBrowserClient);
-    if (methods) {
+    if (methods !== undefined) {
       gateway.publish({
         phase: "connected",
         hello: {
-          features: { methods },
+          features: methods === null ? {} : { methods },
           auth: { role: "operator", scopes: ["operator.write"] },
         } as ApplicationGatewaySnapshot["hello"],
       });
@@ -243,6 +246,45 @@ describe("AppSidebar multi-select", () => {
     expect(harness.refreshReplacement).toHaveBeenCalledWith("main");
   });
 
+  it("archives serially when an older Gateway omits method metadata and rejects archiveMany", async () => {
+    const rejection = new GatewayRequestError({
+      code: "INVALID_REQUEST",
+      message: "unknown method: sessions.archiveMany",
+    });
+    const { sidebar, harness, request } = await mountMultiSelect(null, rejection);
+
+    click(rowLink(sidebar, "agent:main:a"), { metaKey: true });
+    click(rowLink(sidebar, "agent:main:b"), { metaKey: true });
+    await sidebar.updateComplete;
+    openContextMenu(sidebar, "agent:main:a");
+    await sidebar.updateComplete;
+
+    const menu = await sessionMenu(sidebar);
+    const archive = menu.querySelector<HTMLButtonElement>('[data-shortcut="a"]');
+    expect(archive?.disabled).toBe(false);
+    archive?.click();
+
+    await waitForFast(() => expect(harness.patch).toHaveBeenCalledTimes(2));
+    expect(harness.patch).toHaveBeenNthCalledWith(
+      1,
+      "agent:main:a",
+      { archived: true },
+      { agentId: "main", deferListRefresh: true },
+    );
+    expect(harness.patch).toHaveBeenNthCalledWith(
+      2,
+      "agent:main:b",
+      { archived: true },
+      { agentId: "main", deferListRefresh: true },
+    );
+    expect(request.mock.calls.filter(([method]) => method === "sessions.archiveMany")).toHaveLength(
+      1,
+    );
+    expect(harness.archiveMany).not.toHaveBeenCalled();
+    await waitForFast(() => expect(harness.refreshReplacement).toHaveBeenCalledOnce());
+    expect(harness.refreshReplacement).toHaveBeenCalledWith("main");
+  });
+
   it("deletes the selection in one batch after a single confirm", async () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     try {
@@ -282,155 +324,6 @@ describe("AppSidebar multi-select", () => {
     const menu = await sessionMenu(sidebar);
     expect(menu.selectionCount).toBe(1);
     expect(menu.querySelector('[data-shortcut="r"]')).not.toBeNull();
-  });
-});
-
-describe("AppSidebar transient menus", () => {
-  // Regression: the nav column is a stacking context (z-index 10) painted
-  // below the sidebar resizer (z-index 20), so transient menus must render
-  // through the top-layer surface host instead of plain fixed divs.
-  it("hosts the session sort menu in the top-layer menu surface", async () => {
-    const gateway = createGateway({} as GatewayBrowserClient);
-    const { sidebar } = await mountSidebar(
-      gateway,
-      createSessions("main", ["agent:main:main", "agent:main:task"]),
-    );
-
-    const trigger = sidebar.querySelector<HTMLButtonElement>(".sidebar-session-sort");
-    if (!trigger) {
-      throw new Error("expected sort menu trigger");
-    }
-    trigger.click();
-    await sidebar.updateComplete;
-
-    const menu = sidebar.querySelector(".sidebar-session-sort-menu");
-    expect(menu).not.toBeNull();
-    expect(menu?.closest("openclaw-menu-surface")).not.toBeNull();
-  });
-
-  it("ignores a stale sort-menu hide after opening its replacement", async () => {
-    const gateway = createGateway({} as GatewayBrowserClient);
-    const { sidebar } = await mountSidebar(
-      gateway,
-      createSessions("main", ["agent:main:main", "agent:main:task"]),
-    );
-    const trigger = sidebar.querySelector<HTMLButtonElement>(".sidebar-session-sort");
-    if (!trigger) {
-      throw new Error("expected sort menu trigger");
-    }
-
-    trigger.click();
-    await sidebar.updateComplete;
-    const firstMenu = sidebar.querySelector<HTMLElement>(".sidebar-session-sort-menu");
-    expect(firstMenu).not.toBeNull();
-    firstMenu?.dispatchEvent(
-      new CustomEvent("wa-select", {
-        bubbles: true,
-        detail: { item: { value: "sort:created" } },
-      }),
-    );
-    await sidebar.updateComplete;
-
-    trigger.click();
-    await sidebar.updateComplete;
-    const replacement = sidebar.querySelector<HTMLElement>(".sidebar-session-sort-menu");
-    expect(replacement).not.toBe(firstMenu);
-
-    firstMenu?.dispatchEvent(new CustomEvent("wa-after-hide", { bubbles: true, composed: true }));
-    await sidebar.updateComplete;
-    expect(sidebar.querySelector(".sidebar-session-sort-menu")).toBe(replacement);
-  });
-
-  it("ignores a stale agent-menu hide after opening its replacement", async () => {
-    const gateway = createGateway({} as GatewayBrowserClient);
-    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
-    const trigger = sidebar.querySelector<HTMLButtonElement>(".sidebar-agent-card__main");
-    if (!trigger) {
-      throw new Error("expected agent menu trigger");
-    }
-
-    trigger.click();
-    await sidebar.updateComplete;
-    const firstMenu = sidebar.querySelector<HTMLElement>(".sidebar-agent-menu");
-    const settingsItem = firstMenu?.querySelector<HTMLElement>(
-      'wa-dropdown-item[value="command:agent-settings"]',
-    );
-    expect(firstMenu).not.toBeNull();
-    expect(settingsItem).not.toBeNull();
-    firstMenu?.dispatchEvent(
-      new CustomEvent("wa-select", {
-        bubbles: true,
-        detail: { item: settingsItem },
-      }),
-    );
-    await sidebar.updateComplete;
-
-    trigger.click();
-    await sidebar.updateComplete;
-    const replacement = sidebar.querySelector<HTMLElement>(".sidebar-agent-menu");
-    expect(replacement).not.toBe(firstMenu);
-
-    firstMenu?.dispatchEvent(new CustomEvent("wa-after-hide", { bubbles: true, composed: true }));
-    await sidebar.updateComplete;
-    expect(sidebar.querySelector(".sidebar-agent-menu")).toBe(replacement);
-  });
-
-  it("ignores a stale More-menu hide after opening its replacement", async () => {
-    const gateway = createGateway({} as GatewayBrowserClient);
-    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
-    const trigger = sidebar.querySelector<HTMLButtonElement>(".sidebar-nav__head-action");
-    if (!trigger) {
-      throw new Error("expected Pages menu trigger");
-    }
-
-    trigger.click();
-    await sidebar.updateComplete;
-    const firstMenu = sidebar.querySelector<HTMLElement>(".sidebar-more-menu");
-    expect(firstMenu).not.toBeNull();
-    trigger.click();
-    await sidebar.updateComplete;
-    trigger.click();
-    await sidebar.updateComplete;
-    const replacement = sidebar.querySelector<HTMLElement>(".sidebar-more-menu");
-    expect(replacement).not.toBe(firstMenu);
-
-    firstMenu?.dispatchEvent(new CustomEvent("wa-after-hide", { bubbles: true, composed: true }));
-    await sidebar.updateComplete;
-    expect(sidebar.querySelector(".sidebar-more-menu")).toBe(replacement);
-  });
-
-  it("ignores a stale Customize-menu hide after opening its replacement", async () => {
-    const gateway = createGateway({} as GatewayBrowserClient);
-    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
-    const nav = sidebar.querySelector<HTMLElement>(".sidebar-nav");
-    if (!nav) {
-      throw new Error("expected sidebar navigation");
-    }
-
-    nav.dispatchEvent(
-      new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 20, clientY: 20 }),
-    );
-    await sidebar.updateComplete;
-    const firstMenu = sidebar.querySelector<HTMLElement>(".sidebar-customize-menu");
-    expect(firstMenu).not.toBeNull();
-    firstMenu?.dispatchEvent(
-      new CustomEvent("wa-select", {
-        bubbles: true,
-        detail: { item: { value: "reset" } },
-      }),
-    );
-    await sidebar.updateComplete;
-
-    nav.dispatchEvent(
-      new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 24, clientY: 24 }),
-    );
-    await sidebar.updateComplete;
-    const replacement = sidebar.querySelector<HTMLElement>(".sidebar-customize-menu");
-    expect(replacement).not.toBe(firstMenu);
-
-    firstMenu?.dispatchEvent(new CustomEvent("wa-after-hide", { bubbles: true, composed: true }));
-    await sidebar.updateComplete;
-    expect(sidebar.querySelector(".sidebar-customize-menu")).toBe(replacement);
   });
 });
 

--- a/ui/src/test-helpers/app-sidebar-cases/interactions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/interactions.ts
@@ -88,8 +88,19 @@ describe("AppSidebar multi-select", () => {
   }
 
   async function mountMultiSelect() {
-    const gateway = createGateway({} as GatewayBrowserClient);
     const harness = createSessionsHarness("main", KEYS);
+    const gateway = createGateway({
+      request: (method, params) => {
+        if (method !== "sessions.archiveMany") {
+          return Promise.reject(new Error(`unexpected request: ${method}`));
+        }
+        const request = params as {
+          targets: Array<{ key: string; agentId?: string }>;
+          archived: boolean;
+        };
+        return harness.archiveMany(request.targets, request.archived);
+      },
+    } as GatewayBrowserClient);
     const { sidebar } = await mountSidebar(gateway, harness.sessions);
     sidebar.connected = true;
     await sidebar.updateComplete;
@@ -174,21 +185,15 @@ describe("AppSidebar multi-select", () => {
     expect(menu.querySelector('[data-shortcut="r"]')).toBeNull();
     menu.querySelector<HTMLButtonElement>('[data-shortcut="a"]')?.click();
 
-    await waitForFast(() => expect(harness.patch).toHaveBeenCalledTimes(2));
-    // Each row defers its canonical list refresh; the batch pays one refresh at
-    // the end instead of a full sessions.list round trip per archived row.
-    expect(harness.patch).toHaveBeenNthCalledWith(
-      1,
-      "agent:main:a",
-      { archived: true },
-      { agentId: "main", deferListRefresh: true },
+    await waitForFast(() => expect(harness.archiveMany).toHaveBeenCalledOnce());
+    expect(harness.archiveMany).toHaveBeenCalledWith(
+      [
+        { key: "agent:main:a", agentId: "main" },
+        { key: "agent:main:b", agentId: "main" },
+      ],
+      true,
     );
-    expect(harness.patch).toHaveBeenNthCalledWith(
-      2,
-      "agent:main:b",
-      { archived: true },
-      { agentId: "main", deferListRefresh: true },
-    );
+    expect(harness.patch).not.toHaveBeenCalled();
     await waitForFast(() => expect(harness.refreshReplacement).toHaveBeenCalledTimes(1));
     expect(harness.refreshReplacement).toHaveBeenCalledWith("main");
   });

--- a/ui/src/test-helpers/app-sidebar-cases/interactions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/interactions.ts
@@ -87,24 +87,36 @@ describe("AppSidebar multi-select", () => {
     return menu;
   }
 
-  async function mountMultiSelect() {
+  async function mountMultiSelect(methods?: string[]) {
     const harness = createSessionsHarness("main", KEYS);
-    const gateway = createGateway({
+    const request = vi.fn((method: string, params?: unknown) => {
+      if (method !== "sessions.archiveMany") {
+        return Promise.reject(new Error(`unexpected request: ${method}`));
+      }
+      const archiveParams = params as {
+        targets: Array<{ key: string; agentId?: string }>;
+        archived: boolean;
+      };
+      return harness.archiveMany(archiveParams.targets, archiveParams.archived);
+    });
+    const gateway = createGatewayHarness({
       request: (method, params) => {
-        if (method !== "sessions.archiveMany") {
-          return Promise.reject(new Error(`unexpected request: ${method}`));
-        }
-        const request = params as {
-          targets: Array<{ key: string; agentId?: string }>;
-          archived: boolean;
-        };
-        return harness.archiveMany(request.targets, request.archived);
+        return request(method, params);
       },
     } as GatewayBrowserClient);
-    const { sidebar } = await mountSidebar(gateway, harness.sessions);
+    if (methods) {
+      gateway.publish({
+        phase: "connected",
+        hello: {
+          features: { methods },
+          auth: { role: "operator", scopes: ["operator.write"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+    }
+    const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
     sidebar.connected = true;
     await sidebar.updateComplete;
-    return { sidebar, harness };
+    return { sidebar, harness, request };
   }
 
   it("names each session's pin and menu buttons after their owning session", async () => {
@@ -195,6 +207,39 @@ describe("AppSidebar multi-select", () => {
     );
     expect(harness.patch).not.toHaveBeenCalled();
     await waitForFast(() => expect(harness.refreshReplacement).toHaveBeenCalledTimes(1));
+    expect(harness.refreshReplacement).toHaveBeenCalledWith("main");
+  });
+
+  it("archives serially when an older Gateway does not advertise archiveMany", async () => {
+    const { sidebar, harness, request } = await mountMultiSelect(["sessions.patch"]);
+
+    click(rowLink(sidebar, "agent:main:a"), { metaKey: true });
+    click(rowLink(sidebar, "agent:main:b"), { metaKey: true });
+    await sidebar.updateComplete;
+    openContextMenu(sidebar, "agent:main:a");
+    await sidebar.updateComplete;
+
+    const menu = await sessionMenu(sidebar);
+    const archive = menu.querySelector<HTMLButtonElement>('[data-shortcut="a"]');
+    expect(archive?.disabled).toBe(false);
+    archive?.click();
+
+    await waitForFast(() => expect(harness.patch).toHaveBeenCalledTimes(2));
+    expect(harness.patch).toHaveBeenNthCalledWith(
+      1,
+      "agent:main:a",
+      { archived: true },
+      { agentId: "main", deferListRefresh: true },
+    );
+    expect(harness.patch).toHaveBeenNthCalledWith(
+      2,
+      "agent:main:b",
+      { archived: true },
+      { agentId: "main", deferListRefresh: true },
+    );
+    expect(harness.archiveMany).not.toHaveBeenCalled();
+    expect(request.mock.calls.filter(([method]) => method === "sessions.archiveMany")).toEqual([]);
+    await waitForFast(() => expect(harness.refreshReplacement).toHaveBeenCalledOnce());
     expect(harness.refreshReplacement).toHaveBeenCalledWith("main");
   });
 

--- a/ui/src/test-helpers/app-sidebar-cases/sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sessions.ts
@@ -351,22 +351,25 @@ describe("AppSidebar session mutation feedback", () => {
       "agent:main:a",
       "agent:main:b",
     ]);
-    const originalRequest = client.request?.bind(client);
-    const gateway = createGatewayHarness({
-      ...client,
-      request: (method, params, options) => {
-        if (method === "sessions.archiveMany") {
-          const request = params as {
-            targets: Array<{ key: string; agentId?: string }>;
-            archived: boolean;
-          };
-          return harness.archiveMany(request.targets, request.archived);
-        }
-        return originalRequest
-          ? originalRequest(method, params, options)
-          : Promise.reject(new Error(`unexpected request: ${method}`));
-      },
-    } as GatewayBrowserClient);
+    const originalRequest = client.request?.bind(client) as
+      | GatewayBrowserClient["request"]
+      | undefined;
+    client.request = <T = unknown>(
+      ...args: Parameters<GatewayBrowserClient["request"]>
+    ): Promise<T> => {
+      const [method, params] = args;
+      if (method === "sessions.archiveMany") {
+        const request = params as {
+          targets: Array<{ key: string; agentId?: string }>;
+          archived: boolean;
+        };
+        return harness.archiveMany(request.targets, request.archived).then((result) => result as T);
+      }
+      return originalRequest
+        ? originalRequest<T>(...args)
+        : Promise.reject(new Error(`unexpected request: ${method}`));
+    };
+    const gateway = createGatewayHarness(client);
     const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
     sidebar.connected = true;
     await sidebar.updateComplete;

--- a/ui/src/test-helpers/app-sidebar-cases/sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sessions.ts
@@ -346,12 +346,27 @@ describe("AppSidebar session navigation", () => {
 
 describe("AppSidebar session mutation feedback", () => {
   async function mountMutationHarness(client: GatewayBrowserClient = {} as GatewayBrowserClient) {
-    const gateway = createGatewayHarness(client);
     const harness = createSessionsHarness("main", [
       "agent:main:main",
       "agent:main:a",
       "agent:main:b",
     ]);
+    const originalRequest = client.request?.bind(client);
+    const gateway = createGatewayHarness({
+      ...client,
+      request: (method, params, options) => {
+        if (method === "sessions.archiveMany") {
+          const request = params as {
+            targets: Array<{ key: string; agentId?: string }>;
+            archived: boolean;
+          };
+          return harness.archiveMany(request.targets, request.archived);
+        }
+        return originalRequest
+          ? originalRequest(method, params, options)
+          : Promise.reject(new Error(`unexpected request: ${method}`));
+      },
+    } as GatewayBrowserClient);
     const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
     sidebar.connected = true;
     await sidebar.updateComplete;
@@ -426,13 +441,20 @@ describe("AppSidebar session mutation feedback", () => {
     toast.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
 
     await vi.waitFor(() => expect(harness.patch).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(harness.archiveMany).toHaveBeenCalledOnce());
     expect(setSessionKey).not.toHaveBeenCalled();
-    // Undo restores through the batch helper, which refreshes once at the end.
+    expect(harness.archiveMany).toHaveBeenCalledWith(
+      [{ key: archivedRow.key, agentId: "main" }],
+      false,
+    );
+    // Archive restore owns the canonical refresh; the non-archive patch only
+    // restores the pin that archive projection intentionally removed.
     expect(harness.patch).toHaveBeenLastCalledWith(
       archivedRow.key,
-      { archived: false, pinned: true },
+      { pinned: true },
       { agentId: "main", deferListRefresh: true },
     );
+    expect(harness.refreshReplacement).toHaveBeenCalledOnce();
     expect(navigate).not.toHaveBeenCalled();
   });
 
@@ -551,6 +573,41 @@ describe("AppSidebar session mutation feedback", () => {
     }
   });
 
+  it("surfaces ordered partial batch-archive errors", async () => {
+    const { harness, sidebar } = await mountMutationHarness();
+    harness.archiveMany.mockImplementationOnce(async (targets) => {
+      return {
+        outcomes: [
+          { ok: true, key: targets[0]!.key, agentId: targets[0]!.agentId },
+          {
+            ok: false,
+            key: targets[1]!.key,
+            agentId: targets[1]!.agentId,
+            error: { code: "INVALID_REQUEST", message: "active run" },
+          },
+        ],
+      };
+    });
+    selectSession(sidebar, "agent:main:a");
+    selectSession(sidebar, "agent:main:b");
+    await sidebar.updateComplete;
+    const row = sidebar.querySelector('[data-session-key="agent:main:b"]');
+    row?.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    await sidebar.updateComplete;
+    const menu = sidebar.querySelector<TestSessionMenu>("openclaw-session-menu");
+    await menu?.updateComplete;
+    menu?.querySelector<HTMLButtonElement>('[data-shortcut="a"]')?.click();
+
+    await waitForFast(() => {
+      expect(sidebar.querySelector("[data-sidebar-session-error]")?.textContent).toContain(
+        "agent:main:b: active run",
+      );
+    });
+    expect(harness.archiveMany).toHaveBeenCalledOnce();
+    expect(harness.patch).not.toHaveBeenCalled();
+    expect(harness.refreshReplacement).toHaveBeenCalledOnce();
+  });
+
   it("suppresses a late rejection after a same-client reconnect", async () => {
     const { gateway, harness, sidebar } = await mountMutationHarness();
     const pending = deferred<ReturnType<typeof successfulSessionPatch>>();
@@ -569,10 +626,10 @@ describe("AppSidebar session mutation feedback", () => {
     expect(sidebar.querySelector("[data-sidebar-session-error]")).toBeNull();
   });
 
-  it("does not continue a batch patch on a reconnected Gateway", async () => {
+  it("suppresses a late batch archive result after a reconnect", async () => {
     const { gateway, harness, sidebar } = await mountMutationHarness();
-    const pending = deferred<ReturnType<typeof successfulSessionPatch>>();
-    harness.patch.mockImplementationOnce(() => pending.promise);
+    const pending = deferred<Awaited<ReturnType<typeof harness.archiveMany>>>();
+    harness.archiveMany.mockImplementationOnce(() => pending.promise);
     selectSession(sidebar, "agent:main:a");
     selectSession(sidebar, "agent:main:b");
     await sidebar.updateComplete;
@@ -582,23 +639,29 @@ describe("AppSidebar session mutation feedback", () => {
     const menu = sidebar.querySelector<TestSessionMenu>("openclaw-session-menu");
     await menu?.updateComplete;
     menu?.querySelector<HTMLButtonElement>('[data-shortcut="a"]')?.click();
-    await waitForFast(() => expect(harness.patch).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(harness.archiveMany).toHaveBeenCalledOnce());
 
     gateway.publish({ phase: "reconnecting" });
     gateway.publish({ phase: "connected" });
-    pending.resolve(successfulSessionPatch("agent:main:a"));
+    pending.resolve({
+      outcomes: [
+        { ok: true, key: "agent:main:a" },
+        { ok: true, key: "agent:main:b" },
+      ],
+    });
     await pending.promise;
     await new Promise<void>((resolve) => {
       globalThis.setTimeout(resolve, 0);
     });
 
-    expect(harness.patch).toHaveBeenCalledOnce();
+    expect(harness.archiveMany).toHaveBeenCalledOnce();
+    expect(harness.patch).not.toHaveBeenCalled();
   });
 
   it("does not truncate a pending batch when another mutation starts", async () => {
     const { harness, sidebar } = await mountMutationHarness();
-    const firstPatch = deferred<ReturnType<typeof successfulSessionPatch>>();
-    harness.patch.mockImplementationOnce(() => firstPatch.promise);
+    const archive = deferred<Awaited<ReturnType<typeof harness.archiveMany>>>();
+    harness.archiveMany.mockImplementationOnce(() => archive.promise);
     selectSession(sidebar, "agent:main:a");
     selectSession(sidebar, "agent:main:b");
     await sidebar.updateComplete;
@@ -609,24 +672,26 @@ describe("AppSidebar session mutation feedback", () => {
     let menu = sidebar.querySelector<TestSessionMenu>("openclaw-session-menu");
     await menu?.updateComplete;
     menu?.querySelector<HTMLButtonElement>('[data-shortcut="a"]')?.click();
-    await waitForFast(() => expect(harness.patch).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(harness.archiveMany).toHaveBeenCalledOnce());
 
     row?.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
     await sidebar.updateComplete;
     menu = sidebar.querySelector<TestSessionMenu>("openclaw-session-menu");
     await menu?.updateComplete;
     menu?.querySelector<HTMLButtonElement>('[data-shortcut="u"]')?.click();
-    await waitForFast(() => expect(harness.patch).toHaveBeenCalledTimes(3));
+    await waitForFast(() => expect(harness.patch).toHaveBeenCalledTimes(2));
 
-    firstPatch.resolve(successfulSessionPatch("agent:main:a"));
-    await waitForFast(() => expect(harness.patch).toHaveBeenCalledTimes(4));
+    archive.resolve({
+      outcomes: [
+        { ok: true, key: "agent:main:a" },
+        { ok: true, key: "agent:main:b" },
+      ],
+    });
+    await archive.promise;
+    expect(harness.archiveMany).toHaveBeenCalledOnce();
+    expect(harness.patch).toHaveBeenCalledTimes(2);
     expect(harness.patch.mock.calls.map(([, patch]) => patch)).toEqual(
-      expect.arrayContaining([
-        { archived: true },
-        { archived: true },
-        { unread: true },
-        { unread: true },
-      ]),
+      expect.arrayContaining([{ unread: true }, { unread: true }]),
     );
   });
 

--- a/ui/src/test-helpers/app-sidebar-cases/transient-menus.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/transient-menus.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { createGateway, createSessions, mountSidebar } from "../app-sidebar.ts";
+import "../../components/app-sidebar.ts";
+
+describe("AppSidebar transient menus", () => {
+  // Regression: the nav column is a stacking context (z-index 10) painted
+  // below the sidebar resizer (z-index 20), so transient menus must render
+  // through the top-layer surface host instead of plain fixed divs.
+  it("hosts the session sort menu in the top-layer menu surface", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(
+      gateway,
+      createSessions("main", ["agent:main:main", "agent:main:task"]),
+    );
+
+    const trigger = sidebar.querySelector<HTMLButtonElement>(".sidebar-session-sort");
+    if (!trigger) {
+      throw new Error("expected sort menu trigger");
+    }
+    trigger.click();
+    await sidebar.updateComplete;
+
+    const menu = sidebar.querySelector(".sidebar-session-sort-menu");
+    expect(menu).not.toBeNull();
+    expect(menu?.closest("openclaw-menu-surface")).not.toBeNull();
+  });
+
+  it("ignores a stale sort-menu hide after opening its replacement", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(
+      gateway,
+      createSessions("main", ["agent:main:main", "agent:main:task"]),
+    );
+    const trigger = sidebar.querySelector<HTMLButtonElement>(".sidebar-session-sort");
+    if (!trigger) {
+      throw new Error("expected sort menu trigger");
+    }
+
+    trigger.click();
+    await sidebar.updateComplete;
+    const firstMenu = sidebar.querySelector<HTMLElement>(".sidebar-session-sort-menu");
+    expect(firstMenu).not.toBeNull();
+    firstMenu?.dispatchEvent(
+      new CustomEvent("wa-select", {
+        bubbles: true,
+        detail: { item: { value: "sort:created" } },
+      }),
+    );
+    await sidebar.updateComplete;
+
+    trigger.click();
+    await sidebar.updateComplete;
+    const replacement = sidebar.querySelector<HTMLElement>(".sidebar-session-sort-menu");
+    expect(replacement).not.toBe(firstMenu);
+
+    firstMenu?.dispatchEvent(new CustomEvent("wa-after-hide", { bubbles: true, composed: true }));
+    await sidebar.updateComplete;
+    expect(sidebar.querySelector(".sidebar-session-sort-menu")).toBe(replacement);
+  });
+
+  it("ignores a stale agent-menu hide after opening its replacement", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
+    const trigger = sidebar.querySelector<HTMLButtonElement>(".sidebar-agent-card__main");
+    if (!trigger) {
+      throw new Error("expected agent menu trigger");
+    }
+
+    trigger.click();
+    await sidebar.updateComplete;
+    const firstMenu = sidebar.querySelector<HTMLElement>(".sidebar-agent-menu");
+    const settingsItem = firstMenu?.querySelector<HTMLElement>(
+      'wa-dropdown-item[value="command:agent-settings"]',
+    );
+    expect(firstMenu).not.toBeNull();
+    expect(settingsItem).not.toBeNull();
+    firstMenu?.dispatchEvent(
+      new CustomEvent("wa-select", {
+        bubbles: true,
+        detail: { item: settingsItem },
+      }),
+    );
+    await sidebar.updateComplete;
+
+    trigger.click();
+    await sidebar.updateComplete;
+    const replacement = sidebar.querySelector<HTMLElement>(".sidebar-agent-menu");
+    expect(replacement).not.toBe(firstMenu);
+
+    firstMenu?.dispatchEvent(new CustomEvent("wa-after-hide", { bubbles: true, composed: true }));
+    await sidebar.updateComplete;
+    expect(sidebar.querySelector(".sidebar-agent-menu")).toBe(replacement);
+  });
+
+  it("ignores a stale More-menu hide after opening its replacement", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
+    const trigger = sidebar.querySelector<HTMLButtonElement>(".sidebar-nav__head-action");
+    if (!trigger) {
+      throw new Error("expected Pages menu trigger");
+    }
+
+    trigger.click();
+    await sidebar.updateComplete;
+    const firstMenu = sidebar.querySelector<HTMLElement>(".sidebar-more-menu");
+    expect(firstMenu).not.toBeNull();
+    trigger.click();
+    await sidebar.updateComplete;
+    trigger.click();
+    await sidebar.updateComplete;
+    const replacement = sidebar.querySelector<HTMLElement>(".sidebar-more-menu");
+    expect(replacement).not.toBe(firstMenu);
+
+    firstMenu?.dispatchEvent(new CustomEvent("wa-after-hide", { bubbles: true, composed: true }));
+    await sidebar.updateComplete;
+    expect(sidebar.querySelector(".sidebar-more-menu")).toBe(replacement);
+  });
+
+  it("ignores a stale Customize-menu hide after opening its replacement", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
+    const nav = sidebar.querySelector<HTMLElement>(".sidebar-nav");
+    if (!nav) {
+      throw new Error("expected sidebar navigation");
+    }
+
+    nav.dispatchEvent(
+      new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 20, clientY: 20 }),
+    );
+    await sidebar.updateComplete;
+    const firstMenu = sidebar.querySelector<HTMLElement>(".sidebar-customize-menu");
+    expect(firstMenu).not.toBeNull();
+    firstMenu?.dispatchEvent(
+      new CustomEvent("wa-select", {
+        bubbles: true,
+        detail: { item: { value: "reset" } },
+      }),
+    );
+    await sidebar.updateComplete;
+
+    nav.dispatchEvent(
+      new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 24, clientY: 24 }),
+    );
+    await sidebar.updateComplete;
+    const replacement = sidebar.querySelector<HTMLElement>(".sidebar-customize-menu");
+    expect(replacement).not.toBe(firstMenu);
+
+    firstMenu?.dispatchEvent(new CustomEvent("wa-after-hide", { bubbles: true, composed: true }));
+    await sidebar.updateComplete;
+    expect(sidebar.querySelector(".sidebar-customize-menu")).toBe(replacement);
+  });
+});

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, vi } from "vitest";
 import type {
   SessionCatalogPullRequestSummary,
+  SessionsArchiveManyParams,
+  SessionsArchiveManyResult,
   SessionsCatalogListResult,
 } from "../../../packages/gateway-protocol/src/index.ts";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
@@ -243,6 +245,18 @@ export function createSessionsHarness(agentId: string, keys: string[]) {
     Promise.resolve(),
   );
   const refreshReplacement = vi.fn(() => Promise.resolve());
+  const archiveMany = vi.fn(
+    async (
+      targets: SessionsArchiveManyParams["targets"],
+      _archived: boolean,
+    ): Promise<SessionsArchiveManyResult> => ({
+      outcomes: targets.map((target) => ({
+        ok: true,
+        key: target.key,
+        ...(target.agentId ? { agentId: target.agentId } : {}),
+      })),
+    }),
+  );
   const setCreatorFilter = vi.fn(() => Promise.resolve());
   const subscribeMessages = vi.fn((key: string, options?: { agentId?: string | null }) =>
     Promise.resolve({ key, agentId: options?.agentId ?? null }),
@@ -295,6 +309,7 @@ export function createSessionsHarness(agentId: string, keys: string[]) {
     groupsDelete,
     create,
     patch,
+    archiveMany,
     delete: deleteSession,
     deleteMany,
     list,
@@ -349,6 +364,10 @@ export function createSessionsHarness(agentId: string, keys: string[]) {
           if (method === "sessions.subscribe") {
             return { subscribed: true } as T;
           }
+          if (method === "sessions.archiveMany") {
+            const { targets, archived } = params as SessionsArchiveManyParams;
+            return (await archiveMany(targets, archived)) as T;
+          }
           if (method !== "sessions.list") {
             return client.request<T>(method, params);
           }
@@ -392,6 +411,7 @@ export function createSessionsHarness(agentId: string, keys: string[]) {
     groupsDelete,
     create,
     patch,
+    archiveMany,
     deleteSession,
     deleteMany,
     list,

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -1553,13 +1553,13 @@ function installControlUiMockGateway(
       case "sessions.archiveMany": {
         const targets = isRecord(params) && Array.isArray(params.targets) ? params.targets : [];
         const result = {
-          outcomes: targets.map((target) => ({
-            ok: true,
-            key: isRecord(target) && typeof target.key === "string" ? target.key : "unknown",
-            ...(isRecord(target) && typeof target.agentId === "string"
-              ? { agentId: target.agentId }
-              : {}),
-          })),
+          outcomes: targets.map((target) => {
+            const key = isRecord(target) && typeof target.key === "string" ? target.key : "unknown";
+            if (isRecord(target) && typeof target.agentId === "string") {
+              return { ok: true, key, agentId: target.agentId };
+            }
+            return { ok: true, key };
+          }),
         };
         recordSessionsArchiveMany(params, result);
         return result;

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -159,6 +159,7 @@ const defaultControlUiFeatureMethods = [
   "session.members.remove",
   "session.visibility.set",
   "sessions.abort",
+  "sessions.archiveMany",
   "sessions.branches.switch",
   "sessions.compact",
   "sessions.compaction.branch",
@@ -1083,6 +1084,21 @@ function installControlUiMockGateway(
     sessionPatches.set(params.key, patch);
   }
 
+  function recordSessionsArchiveMany(params: unknown, response: unknown): void {
+    if (!scenario.sessionArchiveFiltering || !isRecord(params) || !Array.isArray(params.targets)) {
+      return;
+    }
+    const outcomes =
+      isRecord(response) && Array.isArray(response.outcomes) ? response.outcomes : [];
+    for (const [index, target] of params.targets.entries()) {
+      const outcome = outcomes[index];
+      if (!isRecord(target) || !isRecord(outcome) || outcome.ok !== true) {
+        continue;
+      }
+      recordSessionPatch({ key: target.key, archived: params.archived });
+    }
+  }
+
   function recordMaterializedSession(params: unknown, response: unknown): void {
     if (!isRecord(response)) {
       return;
@@ -1356,6 +1372,9 @@ function installControlUiMockGateway(
       if (method === "sessions.create" || method === "sessions.catalog.continue") {
         recordMaterializedSession(params, configuredValue);
       }
+      if (method === "sessions.archiveMany") {
+        recordSessionsArchiveMany(params, configuredValue);
+      }
       return method === "sessions.list"
         ? applySessionPatches(configuredValue, params)
         : configuredValue;
@@ -1531,6 +1550,20 @@ function installControlUiMockGateway(
           },
           params,
         );
+      case "sessions.archiveMany": {
+        const targets = isRecord(params) && Array.isArray(params.targets) ? params.targets : [];
+        const result = {
+          outcomes: targets.map((target) => ({
+            ok: true,
+            key: isRecord(target) && typeof target.key === "string" ? target.key : "unknown",
+            ...(isRecord(target) && typeof target.agentId === "string"
+              ? { agentId: target.agentId }
+              : {}),
+          })),
+        };
+        recordSessionsArchiveMany(params, result);
+        return result;
+      }
       case "sessions.groups.list":
         return groupsPayload();
       case "sessions.groups.put": {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who multi-selected several sidebar sessions and archived them would wait for each session to finish a separate gateway round trip before the next one started. In an isolated dev gateway, archiving 10 sessions took more than 15 seconds and still had 3 rows visible at the 15-second mark.

## Why This Change Was Made

The Control UI now sends one bounded `sessions.archiveMany` request and performs one authoritative list refresh. The gateway runs the existing canonical `sessions.patch` path concurrently for each target, so active-run checks, sharing authorization, archive attribution, audit notes, hooks, cron handling, and partial failures remain single-sourced rather than being reimplemented in a second mutation path.

This PR is AI-assisted; I reviewed the implementation, behavior, and test coverage.

## User Impact

Bulk archive now feels immediate instead of scaling by seconds per selected thread. Against the rebuilt isolated gateway, the same 10-session operation completed in 307 ms with 10/10 successful outcomes (roughly 50× faster than the original user-path baseline).

## Evidence

- Before: real Control UI against an isolated dev gateway; 10 selected sessions took >15 seconds, with 3 still visible at 15.0 seconds.
- After: rebuilt gateway measured through the repository gateway client; 10 selected sessions archived in 307 ms, 10/10 successful.
- `node scripts/run-vitest.mjs packages/gateway-protocol/src/index.test.ts src/gateway/method-scopes.test.ts src/gateway/server-methods-list.test.ts src/gateway/server-methods.authorization.test.ts src/gateway/server.sessions.store-rpc.test.ts src/gateway/session-sharing-store-cache.test.ts` — 251 passed.
- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — 238 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-management.archive.e2e.test.ts -t 'archives a sidebar multi-select in one RPC'` — 1 passed, 7 skipped.
- `pnpm build` — passed.
- `autoreview --mode uncommitted` — clean, no accepted/actionable findings.
- Local changed-surface fallback passed formatting, API surface, plugin boundaries, dead-code, and i18n checks. The final core typecheck retry was blocked by sustained cross-worktree heavy-check lock contention; exact-head CI is the remaining full type/lint proof.
