### PR TITLE
fix(scripts): preserve quoted git paths in changed-lanes

### DIFF
--- a/scripts/changed-lanes.mts
+++ b/scripts/changed-lanes.mts
@@ -77,6 +77,7 @@ export type ChangedLaneResult = {
 
 type DetectChangedLanesOptions = {
   packageJsonChangeKind?: "liveDockerTooling" | "tooling" | null;
+  pathsAreRawGitTokens?: boolean;
 };
 
 type PackageJsonGitParams = {
@@ -121,7 +122,10 @@ export function detectChangedLanes(
   changedPaths: string[],
   options: DetectChangedLanesOptions = {},
 ): ChangedLaneResult {
-  const paths = [...new Set(changedPaths.map(normalizeChangedPath).filter(Boolean))]
+  const pathNormalizer = options.pathsAreRawGitTokens
+    ? (changedPath: string) => changedPath
+    : normalizeChangedPath;
+  const paths = [...new Set(changedPaths.map(pathNormalizer).filter(Boolean))]
     .toSorted((left, right) => left.localeCompare(right))
     .filter((changedPath) => changedPath !== "--");
   const lanes = createEmptyChangedLanes();
@@ -145,7 +149,11 @@ export function detectChangedLanes(
     paths.every((changedPath) => RELEASE_METADATA_PATHS.has(changedPath))
   ) {
     lanes.releaseMetadata = true;
-    lanes.docs = paths.some((changedPath) => getChangedPathFacts(changedPath).surface === "docs");
+    lanes.docs = paths.some(
+      (changedPath) =>
+        getChangedPathFacts(changedPath, { preserveRawPath: options.pathsAreRawGitTokens === true })
+          .surface === "docs",
+    );
     for (const changedPath of paths) {
       reasons.push(`${changedPath}: release metadata`);
     }
@@ -153,7 +161,9 @@ export function detectChangedLanes(
   }
 
   for (const changedPath of paths) {
-    const facts = getChangedPathFacts(changedPath);
+    const facts = getChangedPathFacts(changedPath, {
+      preserveRawPath: options.pathsAreRawGitTokens === true,
+    });
     if (BUNDLED_CHANNEL_CONFIG_METADATA_PATH_RE.test(changedPath)) {
       lanes.bundledChannelConfigMetadata = true;
       reasons.push(`${changedPath}: bundled channel config metadata input`);
@@ -291,6 +301,7 @@ export function detectChangedLanesForPaths(params: {
   head?: string;
   staged?: boolean;
   mergeHeadFirstParent?: boolean;
+  pathsAreRawGitTokens?: boolean;
 }): ChangedLaneResult {
   const resolvedBase = params.staged
     ? params.base
@@ -308,7 +319,10 @@ export function detectChangedLanesForPaths(params: {
         staged: params.staged,
       })
     : null;
-  return detectChangedLanes(params.paths, { packageJsonChangeKind });
+  return detectChangedLanes(params.paths, {
+    packageJsonChangeKind,
+    pathsAreRawGitTokens: params.pathsAreRawGitTokens === true,
+  });
 }
 
 /**
@@ -320,6 +334,7 @@ export function listChangedPathsFromGit(params: {
   includeWorktree?: boolean;
   cwd?: string;
   mergeHeadFirstParent?: boolean;
+  preserveRawGitTokens?: boolean;
 }): string[] {
   const head = params.head ?? "HEAD";
   const cwd = params.cwd ?? process.cwd();
@@ -331,27 +346,28 @@ export function listChangedPathsFromGit(params: {
     preferFirstParent: params.mergeHeadFirstParent === true,
   });
   const base = typeof resolvedBase === "string" ? resolvedBase : "";
+  const preserveRawGitTokens = params.preserveRawGitTokens === true;
   if (!base) {
     return [];
   }
   let rangePaths: string[];
   let noMergeBase = false;
   try {
-    rangePaths = runGitNameOnlyDiff([`${base}...${head}`], cwd);
+    rangePaths = runGitNameOnlyDiff([`${base}...${head}`], cwd, preserveRawGitTokens);
   } catch (error) {
     if (!isGitNoMergeBaseError(error)) {
       throw error;
     }
     noMergeBase = true;
-    rangePaths = runGitNameOnlyDiff([`${base}..${head}`], cwd);
+    rangePaths = runGitNameOnlyDiff([`${base}..${head}`], cwd, preserveRawGitTokens);
   }
   if (params.includeWorktree === false) {
     return rangePaths;
   }
   const worktreePaths = [
-    ...runGitNameOnlyDiff(["--cached", "--diff-filter=ACMRD"], cwd),
-    ...runGitNameOnlyDiff(["--diff-filter=ACMRD"], cwd),
-    ...runGitLsFiles(["--others", "--exclude-standard"], cwd),
+    ...runGitNameOnlyDiff(["--cached", "--diff-filter=ACMRD"], cwd, preserveRawGitTokens),
+    ...runGitNameOnlyDiff(["--diff-filter=ACMRD"], cwd, preserveRawGitTokens),
+    ...runGitLsFiles(["--others", "--exclude-standard"], cwd, preserveRawGitTokens),
   ];
   // Raw Crabbox syncs can have unrelated synthetic refs; prefer the synced
   // worktree delta instead of turning that into an accidental whole-repo gate.
@@ -368,14 +384,23 @@ export function listChangedPathsFromGit(params: {
   );
 }
 
-function runGitNameOnlyDiff(extraArgs: string[], cwd = process.cwd()): string[] {
-  const output = execFileSync("git", ["diff", "--name-only", ...extraArgs], {
+function runGitNameOnlyDiff(
+  extraArgs: string[],
+  cwd = process.cwd(),
+  preserveRawGitTokens = false,
+): string[] {
+  const output = execFileSync("git", ["diff", "--name-only", "-z", ...extraArgs], {
     cwd,
     stdio: ["ignore", "pipe", "pipe"],
     encoding: "utf8",
     maxBuffer: GIT_OUTPUT_MAX_BUFFER,
   });
-  return output.split("\n").map(normalizeChangedPath).filter(Boolean);
+  return parseGitPathOutput(output, preserveRawGitTokens);
+}
+
+function parseGitPathOutput(output: string, preserveRawGitTokens: boolean): string[] {
+  const paths = output.split("\0").filter((changedPath) => changedPath.length > 0);
+  return preserveRawGitTokens ? paths : paths.map(normalizeChangedPath).filter(Boolean);
 }
 
 function gitOutputText(value: unknown) {
@@ -395,27 +420,38 @@ function isGitNoMergeBaseError(error: unknown) {
   return text.includes("no merge base");
 }
 
-function runGitLsFiles(extraArgs: string[], cwd = process.cwd()): string[] {
-  const output = execFileSync("git", ["ls-files", ...extraArgs], {
+function runGitLsFiles(
+  extraArgs: string[],
+  cwd = process.cwd(),
+  preserveRawGitTokens = false,
+): string[] {
+  const output = execFileSync("git", ["ls-files", "-z", ...extraArgs], {
     cwd,
     stdio: ["ignore", "pipe", "pipe"],
     encoding: "utf8",
     maxBuffer: GIT_OUTPUT_MAX_BUFFER,
   });
-  return output.split("\n").map(normalizeChangedPath).filter(Boolean);
+  return parseGitPathOutput(output, preserveRawGitTokens);
 }
 
 /**
  * Lists staged changed paths for pre-commit checks.
  */
-export function listStagedChangedPaths(cwd = process.cwd()) {
-  const output = execFileSync("git", ["diff", "--cached", "--name-only", "--diff-filter=ACMRD"], {
-    cwd,
-    stdio: ["ignore", "pipe", "pipe"],
-    encoding: "utf8",
-    maxBuffer: GIT_OUTPUT_MAX_BUFFER,
-  });
-  return output.split("\n").map(normalizeChangedPath).filter(Boolean);
+export function listStagedChangedPaths(
+  cwd = process.cwd(),
+  options: { preserveRawGitTokens?: boolean } = {},
+) {
+  const output = execFileSync(
+    "git",
+    ["diff", "--cached", "--name-only", "-z", "--diff-filter=ACMRD"],
+    {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf8",
+      maxBuffer: GIT_OUTPUT_MAX_BUFFER,
+    },
+  );
+  return parseGitPathOutput(output, options.preserveRawGitTokens === true);
 }
 
 /**
@@ -670,11 +706,12 @@ if (isDirectRun()) {
     args.paths.length > 0
       ? args.paths
       : args.staged
-        ? listStagedChangedPaths()
+        ? listStagedChangedPaths(undefined, { preserveRawGitTokens: true })
         : listChangedPathsFromGit({
             base: args.base,
             head: args.head,
             mergeHeadFirstParent: args.mergeHeadFirstParent,
+            preserveRawGitTokens: true,
           });
   const result = detectChangedLanesForPaths({
     paths,
@@ -682,6 +719,7 @@ if (isDirectRun()) {
     head: args.head,
     staged: args.staged,
     mergeHeadFirstParent: args.mergeHeadFirstParent,
+    pathsAreRawGitTokens: args.paths.length === 0,
   });
   if (args.githubOutput) {
     writeChangedLaneGitHubOutput(result);

--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -310,12 +310,21 @@ function buildDelegatedChangedCheckArgv(argv: string[], options: { cwd?: string 
   if (!args.staged || args.paths.length > 0) {
     return argv;
   }
-  const stagedPaths = listStagedChangedPaths(options.cwd);
+  const stagedPaths = listStagedChangedPaths(options.cwd, { preserveRawGitTokens: true });
   const timedArgs = args.timed ? ["--timed"] : [];
   if (stagedPaths.length === 0) {
     return [...timedArgs, "--no-changes"];
   }
-  return [...timedArgs, "--base", "HEAD", "--head", "HEAD", "--", ...stagedPaths];
+  return [
+    ...timedArgs,
+    "--paths-are-raw-git-tokens",
+    "--base",
+    "HEAD",
+    "--head",
+    "HEAD",
+    "--",
+    ...stagedPaths,
+  ];
 }
 
 export function shouldRunNpmLockGuard(paths: string[]) {
@@ -1130,8 +1139,7 @@ function printSummary(timings: ChangedCheckTiming[], options: ChangedCheckRunOpt
 function parseArgs(argv: string[]) {
   const separatorIndex = argv.indexOf("--");
   const flagArgv = separatorIndex === -1 ? argv : argv.slice(0, separatorIndex);
-  const explicitPaths =
-    separatorIndex === -1 ? [] : argv.slice(separatorIndex + 1).map(normalizeChangedPath);
+  const explicitPaths = separatorIndex === -1 ? [] : argv.slice(separatorIndex + 1);
   const args = {
     base: "origin/main",
     head: "HEAD",
@@ -1139,6 +1147,7 @@ function parseArgs(argv: string[]) {
     dryRun: false,
     timed: false,
     noChanges: false,
+    pathsAreRawGitTokens: false,
     help: false,
     paths: new Array<string>(),
   };
@@ -1152,6 +1161,7 @@ function parseArgs(argv: string[]) {
       booleanFlag("--dry-run", "dryRun"),
       booleanFlag("--timed", "timed"),
       booleanFlag("--no-changes", "noChanges"),
+      booleanFlag("--paths-are-raw-git-tokens", "pathsAreRawGitTokens"),
       booleanFlag("--help", "help"),
       booleanFlag("-h", "help"),
     ],
@@ -1160,12 +1170,15 @@ function parseArgs(argv: string[]) {
         if (arg.startsWith("-")) {
           throw new Error(`Unknown option: ${arg}`);
         }
-        target.paths.push(normalizeChangedPath(arg));
+        target.paths.push(arg);
         return "handled";
       },
     },
   );
   parsed.paths.push(...explicitPaths);
+  if (!parsed.pathsAreRawGitTokens) {
+    parsed.paths = parsed.paths.map(normalizeChangedPath);
+  }
   return parsed;
 }
 
@@ -1212,8 +1225,12 @@ async function main() {
         : args.paths.length > 0
           ? args.paths
           : args.staged
-            ? listStagedChangedPaths()
-            : listChangedPathsFromGit({ base: args.base, head: args.head });
+            ? listStagedChangedPaths(undefined, { preserveRawGitTokens: true })
+            : listChangedPathsFromGit({
+                base: args.base,
+                head: args.head,
+                preserveRawGitTokens: true,
+              });
     } catch (error) {
       // A sparse/fresh checkout may not have the requested base ref yet. The remote
       // workflow fetches it, so preserve explicit/default delegation instead of dying locally.
@@ -1234,6 +1251,7 @@ async function main() {
         base: args.base,
         head: args.head,
         staged: args.staged,
+        pathsAreRawGitTokens: args.pathsAreRawGitTokens || args.paths.length === 0,
       });
       if (
         shouldDelegateChangedCheckToCrabbox(argv, process.env, {

--- a/scripts/lib/changed-path-facts.mjs
+++ b/scripts/lib/changed-path-facts.mjs
@@ -44,10 +44,12 @@ export function normalizeChangedPath(inputPath) {
 /**
  * Returns shared path facts without imposing a caller's lane-selection policy.
  * @param {unknown} inputPath
+ * @param {{ preserveRawPath?: boolean }} [options]
  * @returns {{ path: string; surface: ChangedPathSurface; isChangedLaneTest: boolean; isTestOnly: boolean; isNativeOnly: boolean }}
  */
-export function getChangedPathFacts(inputPath) {
-  const path = typeof inputPath === "string" ? inputPath.trim() : "";
+export function getChangedPathFacts(inputPath, options = {}) {
+  const path =
+    typeof inputPath === "string" ? (options.preserveRawPath ? inputPath : inputPath.trim()) : "";
   const surface = SURFACE_PATTERNS.find(([, pattern]) => pattern.test(path))?.[0] ?? "unknown";
 
   return {

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -417,6 +417,64 @@ describe("scripts/changed-lanes", () => {
     expectLanes(result.lanes, { tooling: true });
   });
 
+  it("preserves Git-quoted paths across the active CLI producer", () => {
+    const dir = makeTempRepoRoot(tempDirs, "openclaw-changed-lanes-quoted-paths-");
+    const quotedPath = "scripts/中文.ts";
+    git(dir, ["init", "-q", "--initial-branch=main"]);
+    writeRepoFile(dir, "README.md", "initial\n");
+    commitAll(dir, "initial");
+
+    writeRepoFile(dir, quotedPath, "export const value = 1;\n");
+    const result = runChangedLanesCli(dir, ["--json", "--base", "HEAD"]);
+
+    expect(result.paths).toEqual([quotedPath]);
+    expectLanes(result.lanes, { scripts: true, tooling: true });
+  });
+
+  it("preserves raw Git tokens from diff, staged, and untracked producers", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempRepoRoot(tempDirs, "openclaw-changed-lanes-raw-producers-");
+    const rawPaths = [
+      " scripts/generated.ts",
+      String.raw`scripts\generated.ts`,
+      "scripts/trailing.ts ",
+    ];
+    git(dir, ["init", "-q", "--initial-branch=main"]);
+    writeRepoFile(dir, "README.md", "initial\n");
+    commitAll(dir, "initial");
+
+    for (const rawPath of rawPaths) {
+      writeRepoFile(dir, rawPath, "export const value = 1;\n");
+    }
+    expect(listChangedPathsFromGit({ base: "HEAD", cwd: dir, preserveRawGitTokens: true })).toEqual(
+      [...rawPaths].toSorted((left, right) => left.localeCompare(right)),
+    );
+
+    git(dir, ["add", "--", ...rawPaths]);
+    expect(listStagedChangedPaths(dir, { preserveRawGitTokens: true })).toEqual(
+      [...rawPaths].toSorted((left, right) => left.localeCompare(right)),
+    );
+  });
+
+  it("keeps raw Git path tokens separate from explicit path normalization", () => {
+    const rawPaths = [
+      " scripts/generated.ts",
+      String.raw`scripts\generated.ts`,
+      "scripts/trailing.ts ",
+    ];
+
+    expect(detectChangedLanes(rawPaths, { pathsAreRawGitTokens: true })).toMatchObject({
+      paths: [...rawPaths].toSorted((left, right) => left.localeCompare(right)),
+      lanes: { all: true },
+    });
+    expect(detectChangedLanes(rawPaths).paths).toEqual([
+      "scripts/generated.ts",
+      "scripts/trailing.ts",
+    ]);
+  });
+
   it("falls back to a two-dot diff when a delegated checkout has no merge base", () => {
     const dir = makeTempRepoRoot(tempDirs, "openclaw-changed-lanes-no-merge-base-");
     git(dir, ["init", "-q", "--initial-branch=main"]);
@@ -1201,6 +1259,7 @@ describe("scripts/changed-lanes", () => {
     const args = buildChangedCheckCrabboxArgs(["--staged", "--timed"], { cwd: dir });
     expect(args.slice(args.indexOf("check:changed") + 1)).toEqual([
       "--timed",
+      "--paths-are-raw-git-tokens",
       "--base",
       "HEAD",
       "--head",


### PR DESCRIPTION
## What Problem This Solves

Fixes an operational issue where changed-file checks misclassify files with non-ASCII or other Git-quoted names, causing `scripts/check-changed` to target a nonexistent path or select the wrong lane.

## Why This Change Was Made

Git path-list commands now use NUL-delimited output and parsing for committed, staged, and untracked paths. Lane classification itself is unchanged; the patch only preserves Git's exact path boundaries.

## User Impact

Changed-file checks now preserve valid filenames and classify their actual repository surface, instead of passing escaped C-style path text downstream.

## Evidence

- Final head: `1b6a24b440cb428987e3cdb169034a67039c0213`.
- Production CLI proof against a real temporary Git repository with an untracked Unicode filename returned `paths=["scripts/中文.ts"]`, `scripts=true`, `tooling=true`, and `all=false`.- Observed CLI output:
  ```text
  paths=["scripts/中文.ts"]
  scripts=true
  tooling=true
  all=false
  ```
- Raw-token regression: `node scripts/run-vitest.mjs test/scripts/changed-lanes.test.ts -t "preserves Git-quoted paths|raw Git tokens|staged changed gates as explicit remote paths|includes untracked worktree files|keeps raw Git path tokens separate"` — 5 passed. This covers the active TypeScript owner, diff/staged/untracked Git producers, literal backslashes, boundary whitespace, and explicit-path normalization.
- Supporting checks passed: `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/changed-lanes.mts scripts/check-changed.mts scripts/lib/changed-path-facts.mjs`, targeted `oxfmt --check`, `node --check scripts/changed-lanes.mjs`, `node --check scripts/check-changed.mjs`, and `git diff --check`.

Proof boundary: the behavior proof uses the production CLI and a real local Git repository; the regression covers raw-token boundaries in the active owner and staged delegation. It does not claim external CI or live service behavior.