### PR TITLE
fix(llm-core): settle result() when a stream ends without a terminal event

### DIFF
--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -597,37 +597,30 @@ async function streamAssistantResponse(
         break;
 
       case "done":
-      case "error": {
-        const finalMessage = withAssistantTurnTaint(
-          ensureToolTurnIdentity(removeNonExecutableToolCalls(await response.result())),
-          turnTainted,
-        );
-        if (addedPartial) {
-          context.messages[context.messages.length - 1] = finalMessage;
-        } else {
-          context.messages.push(finalMessage);
-        }
-        if (!addedPartial) {
-          await emit({ type: "message_start", message: { ...finalMessage } });
-        }
-        await emit({ type: "message_end", message: finalMessage });
-        return finalMessage;
-      }
+      case "error":
+        return await finalizeAssistantMessage();
     }
   }
 
-  const finalMessage = withAssistantTurnTaint(
-    ensureToolTurnIdentity(removeNonExecutableToolCalls(await response.result())),
-    turnTainted,
-  );
-  if (addedPartial) {
-    context.messages[context.messages.length - 1] = finalMessage;
-  } else {
-    context.messages.push(finalMessage);
-    await emit({ type: "message_start", message: { ...finalMessage } });
+  // Stream ended without a terminal event: result() either carries an explicit
+  // end(result) value or rejects with the EventStream terminal-contract error,
+  // so a contract-violating producer surfaces loudly instead of hanging here.
+  return await finalizeAssistantMessage();
+
+  async function finalizeAssistantMessage(): Promise<AssistantMessage> {
+    const finalMessage = withAssistantTurnTaint(
+      ensureToolTurnIdentity(removeNonExecutableToolCalls(await response.result())),
+      turnTainted,
+    );
+    if (addedPartial) {
+      context.messages[context.messages.length - 1] = finalMessage;
+    } else {
+      context.messages.push(finalMessage);
+      await emit({ type: "message_start", message: { ...finalMessage } });
+    }
+    await emit({ type: "message_end", message: finalMessage });
+    return finalMessage;
   }
-  await emit({ type: "message_end", message: finalMessage });
-  return finalMessage;
 }
 
 /**

--- a/packages/llm-core/src/utils/event-stream.test.ts
+++ b/packages/llm-core/src/utils/event-stream.test.ts
@@ -49,4 +49,56 @@ describe("EventStream", () => {
     }
     expect(await iterator.next()).toEqual({ value: undefined, done: true });
   });
+
+  it("resolves result() from a terminal event and from an explicit end(result)", async () => {
+    const terminal = createNumberStream();
+    terminal.push(-1);
+    terminal.end();
+    await expect(terminal.result()).resolves.toBe(-1);
+
+    const explicit = createNumberStream();
+    explicit.push(7);
+    explicit.end(42);
+    await expect(explicit.result()).resolves.toBe(42);
+  });
+
+  it("rejects result() when the stream ends without a terminal event or explicit result", async () => {
+    const stream = createNumberStream();
+    stream.push(1);
+    stream.end();
+    // result() awaiters previously hung forever on this producer bug; the
+    // contract now surfaces it loudly.
+    await expect(stream.result()).rejects.toThrow(
+      "event stream ended without a terminal event or final result",
+    );
+    // Iterate-only consumption of the same stream still completes normally.
+    const events: number[] = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+    expect(events).toEqual([1]);
+  });
+
+  it("keeps iterate-only consumers free of unhandled rejections on bare end()", async () => {
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => {
+      rejections.push(reason);
+    };
+    process.on("unhandledRejection", onRejection);
+    try {
+      const stream = createNumberStream();
+      stream.push(1);
+      stream.end();
+      const iterator = stream[Symbol.asyncIterator]();
+      expect(await iterator.next()).toEqual({ value: 1, done: false });
+      expect(await iterator.next()).toEqual({ value: undefined, done: true });
+      // Give the microtask queue a chance to surface any unhandled rejection.
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(rejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onRejection);
+    }
+  });
 });

--- a/packages/llm-core/src/utils/event-stream.ts
+++ b/packages/llm-core/src/utils/event-stream.ts
@@ -11,8 +11,10 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
   private queueHead = 0;
   private waiting: ((value: IteratorResult<T>) => void)[] = [];
   private done = false;
+  private resultSettled = false;
   private finalResultPromise: Promise<R>;
   private resolveFinalResult: (result: R) => void;
+  private rejectFinalResult: (error: Error) => void;
   private isComplete: (event: T) => boolean;
   private extractResult: (event: T) => R;
 
@@ -20,14 +22,18 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
     this.isComplete = isComplete;
     this.extractResult = extractResult;
     const resolvers: Array<(result: R) => void> = [];
-    this.finalResultPromise = new Promise((resolve) => {
+    const rejecters: Array<(error: Error) => void> = [];
+    this.finalResultPromise = new Promise((resolve, reject) => {
       resolvers.push(resolve);
+      rejecters.push(reject);
     });
     const resolveFinalResult = resolvers.at(0);
-    if (!resolveFinalResult) {
+    const rejectFinalResult = rejecters.at(0);
+    if (!resolveFinalResult || !rejectFinalResult) {
       throw new Error("event stream result promise did not initialize its resolver");
     }
     this.resolveFinalResult = resolveFinalResult;
+    this.rejectFinalResult = rejectFinalResult;
   }
 
   push(event: T): void {
@@ -37,6 +43,7 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 
     if (this.isComplete(event)) {
       this.done = true;
+      this.resultSettled = true;
       this.resolveFinalResult(this.extractResult(event));
     }
 
@@ -51,7 +58,19 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
   end(result?: R): void {
     this.done = true;
     if (result !== undefined) {
+      this.resultSettled = true;
       this.resolveFinalResult(result);
+    } else if (!this.resultSettled) {
+      // A producer that ends without a terminal event or explicit result would
+      // otherwise leave result() pending forever; awaiting consumers dead-end
+      // silently for the whole run budget. Reject loudly instead. The
+      // pre-attached catch keeps iterate-only consumers (which legitimately
+      // never call result()) free of unhandled rejections.
+      this.resultSettled = true;
+      this.finalResultPromise.catch(() => {});
+      this.rejectFinalResult(
+        new Error("event stream ended without a terminal event or final result"),
+      );
     }
     while (this.waiting.length > 0) {
       const waiter = this.waiting.shift();

--- a/packages/llm-core/src/utils/event-stream.ts
+++ b/packages/llm-core/src/utils/event-stream.ts
@@ -67,7 +67,7 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
       // pre-attached catch keeps iterate-only consumers (which legitimately
       // never call result()) free of unhandled rejections.
       this.resultSettled = true;
-      this.finalResultPromise.catch(() => {});
+      void this.finalResultPromise.catch(() => {});
       this.rejectFinalResult(
         new Error("event stream ended without a terminal event or final result"),
       );


### PR DESCRIPTION
## What Problem This Solves

`EventStream.end()` called with no argument and no prior terminal event leaves the final result promise pending forever. Any consumer awaiting `result()` — most importantly the agent loop's fall-through in `streamAssistantResponse`, which runs exactly when a stream ends without a terminal `done`/`error` event — dead-ends silently for the entire run budget (48h by default). This is the same silent-no-outcome bug class as #120426 and was identified during that investigation as a latent liveness hole.

## Why This Change Was Made

The owner of the result contract is `EventStream` itself. `end()` without a settled result now rejects `result()` with a named contract error (`event stream ended without a terminal event or final result`). Every in-repo pump was audited (all provider transports, the proxy stream — which already throws "Proxy stream ended before terminal event" — and the agent loop's own `end(messages)`): all comply, so the rejection only fires on producer contract violations that previously hung forever. A pre-attached no-op catch keeps iterate-only consumers (including existing tests that call bare `end()` and never touch `result()`) free of unhandled rejections.

Opportunistic cleanup in the same neighborhood: `streamAssistantResponse` carried two byte-identical final-message blocks (terminal-event case and fall-through); they are now one `finalizeAssistantMessage` helper, with a comment explaining why the fall-through is safe to await. Net production delta is negative.

## User Impact

A provider/plugin stream that violates the terminal contract now fails the turn loudly with a clear error instead of freezing the agent until the run budget or a gateway restart. No behavior change for compliant streams.

## Evidence

- New tests in `packages/llm-core/src/utils/event-stream.test.ts`: terminal-event and `end(result)` resolution; bare-`end()` rejection with the contract message while iterate-only consumption still completes; explicit unhandled-rejection guard around bare `end()`.
- Regression suites green: full `packages/agent-core` (137 tests incl. agent-loop), `llm-idle-timeout` + `attempt-stream-finalize` (26), `provider-transport-stream` + `simple-completion-transport` (129).
- tsgo core lane clean; oxlint clean. Codex autoreview (`gpt-5.6-sol`, high): no actionable findings.

## ClawSweeper status at landing

The 08:37Z review (head `0822218ec64`) raised one P1 — "mark the intentional rejection handler with void" — which is **applied** in `435ad977ff2` (carried through the rebase as `7b9fcf7a825`); no other actionable findings were reported. An exact-head re-review was requested and acknowledged, but ClawSweeper did not produce a durable review across multiple worker attempts (the same wedge seen on #120426). Landing on green exact-head CI, validated review artifacts, and clean Codex autoreviews, with this status recorded per the never-merge-past-moves-silently policy.
