### PR TITLE
fix(protocol): refresh Swift gateway models

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4818,6 +4818,7 @@ public struct SessionCompactionCheckpoint: Codable, Sendable {
     public let reason: AnyCodable
     public let tokensbefore: Int?
     public let tokensafter: Int?
+    public let tokensversion: Double?
     public let summary: String?
     public let firstkeptentryid: String?
     public let precompaction: [String: AnyCodable]
@@ -4831,6 +4832,7 @@ public struct SessionCompactionCheckpoint: Codable, Sendable {
         reason: AnyCodable,
         tokensbefore: Int? = nil,
         tokensafter: Int? = nil,
+        tokensversion: Double? = nil,
         summary: String? = nil,
         firstkeptentryid: String? = nil,
         precompaction: [String: AnyCodable],
@@ -4843,6 +4845,7 @@ public struct SessionCompactionCheckpoint: Codable, Sendable {
         self.reason = reason
         self.tokensbefore = tokensbefore
         self.tokensafter = tokensafter
+        self.tokensversion = tokensversion
         self.summary = summary
         self.firstkeptentryid = firstkeptentryid
         self.precompaction = precompaction
@@ -4857,6 +4860,7 @@ public struct SessionCompactionCheckpoint: Codable, Sendable {
         case reason
         case tokensbefore = "tokensBefore"
         case tokensafter = "tokensAfter"
+        case tokensversion = "tokensVersion"
         case summary
         case firstkeptentryid = "firstKeptEntryId"
         case precompaction = "preCompaction"


### PR DESCRIPTION
## What Problem This Solves

`main` fails `checks-fast-bundled-protocol` because `GatewayModels.swift` is stale. Commit `fa0fcef9f624f156e723ce10eeaf06fbfa3a7231` added optional `tokensVersion` provenance to `SessionCompactionCheckpointSchema` without committing the generator-owned Swift binding.

This leaves every PR merge tree inheriting the same baseline failure even when the PR does not touch the protocol.

## Root Cause and Fix

The canonical gateway schema is the owner. `scripts/protocol-gen-swift.ts` projects `ProtocolSchemas` into `apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift`; schema and generated native bindings must land together.

This PR commits the exact current generator output: the optional `tokensVersion` property, initializer parameter, assignment, and coding key on `SessionCompactionCheckpoint`. No generator, schema, runtime, config, storage, or compatibility behavior changes are introduced.

This is the best fix because it repairs the stale owner-generated artifact directly. JSON and Kotlin sibling outputs already regenerate without tracked changes.

## Evidence

- Reproduced on the base commit with `pnpm protocol:check:swift`: stale `GatewayModels.swift`, exit 1.
- `pnpm test:bundled`: 2 files, 205 tests passed.
- `pnpm protocol:check`: registry, JSON, Swift, Kotlin, protocol-since guard, and generated-output diff all passed on the committed head.
- Focused native/schema proof: `node scripts/run-vitest.mjs packages/gateway-protocol/src/native-protocol-levels.guard.test.ts packages/gateway-protocol/src/schema/sessions-checkpoint.test.ts`: 2 files, 6 tests passed.
- `git diff --check origin/main...HEAD`: passed.
- Autoreview: clean, no actionable findings, correctness confidence 0.99.
- Failing main evidence: https://github.com/openclaw/openclaw/actions/runs/31244410920/job/93070584758

## Review Surface

- Changed surface: generated Swift gateway model.
- Entry point: `protocol:check` / `protocol:check:swift`.
- Owner boundary: `ProtocolSchemas` -> `scripts/protocol-gen-swift.ts`.
- Caller/callee: package script invokes generator; generator writes `GatewayModels.swift` through the shared generated-output helper.
- Siblings: JSON and Kotlin protocol generation checked and unchanged.
- LOC: generated production +4/-0; handwritten production +0/-0; tests +0/-0.

No changelog entry: this is generated-artifact drift repair with no new user-visible behavior.
