### PR TITLE
fix(protocol): restore generated gateway model parity

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4818,6 +4818,7 @@ public struct SessionCompactionCheckpoint: Codable, Sendable {
     public let reason: AnyCodable
     public let tokensbefore: Int?
     public let tokensafter: Int?
+    public let tokensversion: Double?
     public let summary: String?
     public let firstkeptentryid: String?
     public let precompaction: [String: AnyCodable]
@@ -4831,6 +4832,7 @@ public struct SessionCompactionCheckpoint: Codable, Sendable {
         reason: AnyCodable,
         tokensbefore: Int? = nil,
         tokensafter: Int? = nil,
+        tokensversion: Double? = nil,
         summary: String? = nil,
         firstkeptentryid: String? = nil,
         precompaction: [String: AnyCodable],
@@ -4843,6 +4845,7 @@ public struct SessionCompactionCheckpoint: Codable, Sendable {
         self.reason = reason
         self.tokensbefore = tokensbefore
         self.tokensafter = tokensafter
+        self.tokensversion = tokensversion
         self.summary = summary
         self.firstkeptentryid = firstkeptentryid
         self.precompaction = precompaction
@@ -4857,6 +4860,7 @@ public struct SessionCompactionCheckpoint: Codable, Sendable {
         case reason
         case tokensbefore = "tokensBefore"
         case tokensafter = "tokensAfter"
+        case tokensversion = "tokensVersion"
         case summary
         case firstkeptentryid = "firstKeptEntryId"
         case precompaction = "preCompaction"


### PR DESCRIPTION
Related: #120497

## What Problem This Solves

Resolves a problem where main CI fails `checks-fast-bundled-protocol` and `check-lint` because #120497 changed the gateway session schema without refreshing its derived Swift protocol model.

## Why This Change Was Made

Regenerates the gateway protocol artifacts from the current schema with the repository-owned generator. The resulting tracked diff is limited to the Swift `SessionCompactionCheckpoint` model, which now exposes the optional `tokensVersion` field already added to the source schema by #120497.

## User Impact

Restores generated gateway-model parity and unblocks main CI. There is no new behavior beyond making the committed Swift protocol projection match the canonical schema.

## Evidence

- Main failure: CI run 31245057256, including `checks-fast-bundled-protocol` and `check-lint`.
- Before regeneration: `pnpm protocol:check:swift` reported stale generated output at `apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift`.
- After regeneration: `pnpm protocol-registry:check`, `pnpm protocol:gen`, `pnpm protocol:check:swift`, `pnpm protocol:gen:kotlin`, `node scripts/check-protocol-since.mjs`, and the four-path generated-artifact diff guard all pass.
- `pnpm plugin-sdk:surface:check` passes on clean main without changing the checked-in SDK API baseline.
- Autoreview: clean, no accepted/actionable findings.
