### PR TITLE
docs(release): reconcile stable maturity issue signals

### DIFF
--- a/.agents/skills/release-openclaw-maintainer/references/backport-discovery.md
+++ b/.agents/skills/release-openclaw-maintainer/references/backport-discovery.md
@@ -30,6 +30,33 @@ evidence must remain opaque; retain private identifiers only in the approved
 security record. The next accepted audit uses this ledger's `scan_end` as its
 cursor.
 
+## Reconcile Stable-Maturity Issues
+
+At the pinned `origin/main` SHA, snapshot all OpenClaw issues carrying
+`maturity:stable` and record the query time with the audit bounds. This is a
+secondary completeness and priority check over the commit inventory, not a
+replacement for it. The label means the current issue review matched broken
+existing behavior to a primary M4/M5 scorecard surface; it does not prove the
+issue, identify a complete fix, approve a backport, or block a release by
+itself.
+
+For each closed labelled issue whose fixing PR or commit intersects the scan
+range, link that fix to its commit-ledger row and require an ordinary
+`backport`, `already-covered`, `not-affected`, `blocked`, or `skip` decision.
+Do not omit a commit merely because its linked issue was closed, and do not add
+one merely because the issue has this label. For each open P0/P1 labelled
+issue, add a release-readiness disposition: fixed by the candidate, not
+affected on the release baseline, explicitly deferred by a maintainer, or
+blocked because no proven fix exists. Open issues without a merged fix are not
+backport candidates.
+
+Read the current review rationale before relying on the signal. If the issue is
+a feature proposal, new config or policy request, docs/support work, or is
+primarily owned by a below-M4 surface, record `label-drift` in the audit and do
+not treat it as a maturity candidate. Release discovery reports drift but does
+not mutate issue labels. Keep the underlying commit and security inventory
+complete even when label data is missing, stale, or wrong.
+
 ## Find Reliability and Security Candidates
 
 Do not use commit subjects, labels, or PR visibility as an inclusion gate.

--- a/.agents/skills/release-openclaw-maintainer/references/backport-discovery.md
+++ b/.agents/skills/release-openclaw-maintainer/references/backport-discovery.md
@@ -40,13 +40,13 @@ existing behavior to a primary M4/M5 scorecard surface; it does not prove the
 issue, identify a complete fix, approve a backport, or block a release by
 itself.
 
-For each closed labelled issue whose fixing PR or commit intersects the scan
-range, link that fix to its commit-ledger row and require an ordinary
-`backport`, `already-covered`, `not-affected`, `blocked`, or `skip` decision.
-Do not omit a commit merely because its linked issue was closed, and do not add
-one merely because the issue has this label. For each open P0/P1 labelled
-issue, add a release-readiness disposition: fixed by the candidate, not
-affected on the release baseline, explicitly deferred by a maintainer, or
+For each labelled issue, whether open or closed, whose fixing PR or commit
+actually landed in the scan range, link that fix to its commit-ledger row and
+require an ordinary `backport`, `already-covered`, `not-affected`, `blocked`,
+or `skip` decision. Do not omit a commit based on its linked issue's state, and
+do not add one merely because the issue has this label. For each open P0/P1
+labelled issue, add a release-readiness disposition: fixed by the candidate,
+not affected on the release baseline, explicitly deferred by a maintainer, or
 blocked because no proven fix exists. Open issues without a merged fix are not
 backport candidates.
 

--- a/.agents/skills/release-openclaw-nightly/SKILL.md
+++ b/.agents/skills/release-openclaw-nightly/SKILL.md
@@ -42,6 +42,15 @@ baseline worktree and record whether it is clean, conflicted,
 empty/already-covered, or failed. A clean patch is triage evidence, not an
 automatic backport.
 
+Also snapshot OpenClaw issues carrying `maturity:stable` at the pinned source
+SHA. Reconcile every closed labelled issue whose fixing PR or commit intersects
+the scan range with a commit-ledger decision, and give every open P0/P1
+labelled issue an explicit fixed, not-affected, maintainer-deferred, or blocked
+release disposition. Treat the label only as a completeness and priority
+signal: validate its review rationale, record feature/docs/lower-maturity
+matches as `label-drift`, and never infer a fix, backport approval, or release
+blocker from the label alone.
+
 For every proposed item, inspect the complete change, baseline behavior,
 callers, callees, siblings, tests, dependency contracts, security impact, and
 publication surface. Collapse overlapping or dependent commits to the smallest

--- a/.agents/skills/release-openclaw-nightly/SKILL.md
+++ b/.agents/skills/release-openclaw-nightly/SKILL.md
@@ -44,13 +44,14 @@ automatic backport.
 
 Also snapshot OpenClaw issues carrying `maturity:stable` at the pinned source
 SHA and record the label query time with the audit bounds. Reconcile every
-closed labelled issue whose fixing PR or commit intersects the scan range with
-a commit-ledger decision, and give every open P0/P1 labelled issue an explicit
-fixed, not-affected, maintainer-deferred, or blocked release disposition. Treat
-the label only as a completeness and priority signal: validate its review
-rationale, record feature, new configuration or policy, docs/support, and
-lower-maturity matches as `label-drift`, and never infer a fix, backport
-approval, or release blocker from the label alone.
+labelled issue, whether open or closed, whose fixing PR or commit actually
+landed in the scan range with a commit-ledger decision, and give every open
+P0/P1 labelled issue an explicit fixed, not-affected, maintainer-deferred, or
+blocked release disposition. Treat the label only as a completeness and
+priority signal: validate its review rationale, record feature, new
+configuration or policy, docs/support, and lower-maturity matches as
+`label-drift`, and never infer a fix, backport approval, or release blocker from
+the label alone.
 
 For every proposed item, inspect the complete change, baseline behavior,
 callers, callees, siblings, tests, dependency contracts, security impact, and

--- a/.agents/skills/release-openclaw-nightly/SKILL.md
+++ b/.agents/skills/release-openclaw-nightly/SKILL.md
@@ -43,13 +43,14 @@ empty/already-covered, or failed. A clean patch is triage evidence, not an
 automatic backport.
 
 Also snapshot OpenClaw issues carrying `maturity:stable` at the pinned source
-SHA. Reconcile every closed labelled issue whose fixing PR or commit intersects
-the scan range with a commit-ledger decision, and give every open P0/P1
-labelled issue an explicit fixed, not-affected, maintainer-deferred, or blocked
-release disposition. Treat the label only as a completeness and priority
-signal: validate its review rationale, record feature/docs/lower-maturity
-matches as `label-drift`, and never infer a fix, backport approval, or release
-blocker from the label alone.
+SHA and record the label query time with the audit bounds. Reconcile every
+closed labelled issue whose fixing PR or commit intersects the scan range with
+a commit-ledger decision, and give every open P0/P1 labelled issue an explicit
+fixed, not-affected, maintainer-deferred, or blocked release disposition. Treat
+the label only as a completeness and priority signal: validate its review
+rationale, record feature, new configuration or policy, docs/support, and
+lower-maturity matches as `label-drift`, and never infer a fix, backport
+approval, or release blocker from the label alone.
 
 For every proposed item, inspect the complete change, baseline behavior,
 callers, callees, siblings, tests, dependency contracts, security impact, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,14 @@ Skills own workflows; root owns hard policy and routing. Product direction and m
 - Verify the premise before fixing: restrictions and missing links are sometimes intentional design, and removed code often had a reason. Check history (`git log -p -S <symbol>`) and name the exact line where the reported bug manifests before treating a gap as unfinished work.
 - Won't-implement and out-of-scope closes are maintainer product judgment. Automated review may recommend with evidence but never executes that close on its own; when design intent is plausible, escalate instead of closing.
 - Doctrine-class findings are first-class: an action path that can end with no visible outcome and no recorded reason; a default-path regression; prompt/tool-description text that contradicts shipped behavior; multi-signal inference where a recorded fact belongs; a new default-off capability with no named enablement path.
+- `maturity:stable` is an issue-only attention signal for broken existing
+  behavior whose primary owner is an M4/M5 scorecard surface. Do not apply it
+  to feature requests, new configuration or policy choices, docs/support work,
+  or lower-maturity owners that merely pass through Gateway, CLI, hosting,
+  diagnostics, or another stable implementation surface. The review must name
+  the primary scorecard surface and matching category. The label raises triage
+  and release-audit visibility; it is not proof that a fix exists, approval to
+  backport, or a release blocker by itself.
 - Before landing any PR: read the latest ClawSweeper comment and its `Rank-up moves:` list. Apply each move, or state in the PR why it is skipped; never merge past them silently. A ClawSweeper review from the last 12 hours covers the PR even when the head moved afterward, provided every actionable finding from that review is addressed (or its skip stated in the PR) and exact-head CI is green. Request `@clawsweeper re-review` only when the latest review is older than 12 hours, still has unaddressed actionable findings, or the post-review pushes changed behavior beyond addressing findings and mechanical refreshes (rebase, format, merge-ref). A queued or late-publishing re-review refreshes the rating; never block landing on the review publisher.
 - Changelog findings: see Docs / Changelog.
 - Public ClawSweeper comments prefer `https://docs.openclaw.ai/...` when a public docs page exists; structured evidence still cites repo files, lines, SHAs.


### PR DESCRIPTION
## What Problem This Solves

Release backport audits currently ignore `maturity:stable`, while the label itself has no repository-level contract separating broken mature behavior from feature, docs, or lower-maturity work. That makes the issue signal noisy and leaves stable-surface fixes outside the release reconciliation checklist.

## Why This Change Was Made

Define `maturity:stable` as an attention signal for broken existing behavior primarily owned by an M4/M5 surface, with explicit exclusions and non-goals. Extend shared and nightly backport discovery so closed labelled fixes are reconciled with the commit ledger and open P0/P1 labelled issues receive a release disposition. The complete commit/security inventory remains canonical; the label never approves a backport or blocks a release by itself.

## User Impact

No direct runtime impact. Maintainers get a clearer stable-issue contract and release audits are less likely to miss a mature-surface reliability fix or over-trust a stale label.

## Evidence

- `git diff --check`
- `oxfmt --check AGENTS.md .agents/skills/release-openclaw-maintainer/references/backport-discovery.md .agents/skills/release-openclaw-nightly/SKILL.md`
- Reviewed the shared regular/extended-stable discovery flow and the self-contained nightly audit flow.

AI-assisted: yes. The requested policy and release-skill changes were implemented and reviewed with Codex.