### PR TITLE
fix(qa): restore process runner line budget [AI]

### DIFF
--- a/extensions/qa-lab/src/suite-runtime-agent-process.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.ts
@@ -6,7 +6,6 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   appendQaChildOutput,
   appendQaChildOutputTail,
@@ -22,6 +21,7 @@ import { resolveQaNodeExecPath } from "./node-exec.js";
 import { createQaPosixCommandSettlement } from "./posix-command-settlement.js";
 import { liveTurnTimeoutMs } from "./suite-runtime-agent-common.js";
 import { readSessionTranscriptSummary } from "./suite-runtime-agent-session.js";
+import { parseQaCliJsonOutput } from "./suite-runtime-cli-json.js";
 import { waitForGatewayHealthy, waitForTransportReady } from "./suite-runtime-gateway.js";
 import type { QaDreamingStatus, QaSuiteRuntimeEnv } from "./suite-runtime-types.js";
 import { resolveQaGatewayTimeoutWithGraceMs } from "./timer-timeouts.js";
@@ -62,7 +62,6 @@ type QaAgentWaitResult = {
   terminalReply?: QaAgentTerminalReply;
 };
 
-const ANSI_ESCAPE_PATTERN = new RegExp(String.raw`\x1B\[[0-?]*[ -/]*[@-~]`, "g");
 const MANAGED_DREAMING_CRON_MARKER = "[managed-by=memory-core.short-term-promotion]";
 const MANAGED_DREAMING_CRON_NAME = "Memory Dreaming Promotion";
 const MANAGED_DREAMING_PROMPT = "__openclaw_memory_core_short_term_promotion_dream__";
@@ -71,169 +70,6 @@ const QA_HISTORY_RETRY_MIN_MS = 100;
 const QA_HISTORY_RETRY_MAX_MS = 5_000;
 const QA_TRANSCRIPT_EVIDENCE_TIMEOUT_MS = 5_000;
 const QA_TRANSCRIPT_EVIDENCE_POLL_MS = 50;
-
-function stripAnsiCodes(text: string) {
-  return text.replace(ANSI_ESCAPE_PATTERN, "");
-}
-
-function findBalancedJsonEnd(text: string, startIndex: number) {
-  const opening = text[startIndex];
-  const firstClosing = opening === "{" ? "}" : opening === "[" ? "]" : "";
-  if (!firstClosing) {
-    return -1;
-  }
-
-  const stack = [firstClosing];
-  let inString = false;
-  let escaping = false;
-  for (let index = startIndex + 1; index < text.length; index += 1) {
-    const char = text[index];
-    if (inString) {
-      if (escaping) {
-        escaping = false;
-      } else if (char === "\\") {
-        escaping = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (char === '"') {
-      inString = true;
-    } else if (char === "{" || char === "[") {
-      stack.push(char === "{" ? "}" : "]");
-    } else if (char === "}" || char === "]") {
-      if (stack.at(-1) !== char) {
-        return -1;
-      }
-      stack.pop();
-      if (stack.length === 0) {
-        return index;
-      }
-    }
-  }
-  return -1;
-}
-
-function parseBalancedJsonPayloadStart(text: string) {
-  const trimmedStart = text.search(/\S/u);
-  if (trimmedStart < 0) {
-    return undefined;
-  }
-  const char = text[trimmedStart];
-  if (char !== "{" && char !== "[") {
-    return undefined;
-  }
-  const end = findBalancedJsonEnd(text, trimmedStart);
-  if (end <= trimmedStart) {
-    return undefined;
-  }
-  try {
-    return JSON.parse(text.slice(trimmedStart, end + 1)) as unknown;
-  } catch {
-    return undefined;
-  }
-}
-
-function isJsonRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
-}
-
-function isStructuredDiagnosticJson(value: unknown) {
-  if (!isJsonRecord(value)) {
-    return false;
-  }
-  const level = value.level ?? value.logLevel ?? value.severity;
-  if (typeof level !== "string") {
-    return false;
-  }
-  return (
-    typeof value.message === "string" ||
-    typeof value.msg === "string" ||
-    typeof value.time === "string" ||
-    typeof value.timestamp === "string"
-  );
-}
-
-function isMemorySearchJsonPayload(value: unknown) {
-  return isJsonRecord(value) && Array.isArray(value.results);
-}
-
-function isMemoryStatusJsonPayload(value: unknown) {
-  if (Array.isArray(value)) {
-    return true;
-  }
-  return isJsonRecord(value) && value.command === "memory" && value.subcommand === "status";
-}
-
-function resolveQaCliJsonPayloadMatcher(args: readonly string[]) {
-  if (!args.includes("--json")) {
-    return undefined;
-  }
-  if (args[0] === "memory" && args[1] === "search") {
-    return isMemorySearchJsonPayload;
-  }
-  if (args[0] === "memory" && args[1] === "status") {
-    return isMemoryStatusJsonPayload;
-  }
-  return undefined;
-}
-
-function parseQaCliJsonOutput(text: string, args: readonly string[]) {
-  const cleaned = stripAnsiCodes(text).trim();
-  if (!cleaned) {
-    return {};
-  }
-  const matchesExpectedPayload = resolveQaCliJsonPayloadMatcher(args);
-  try {
-    return JSON.parse(cleaned) as unknown;
-  } catch {
-    // Some startup repair logs are emitted on stdout before command JSON.
-    const lines = cleaned.split(/\r?\n/);
-    const candidates: unknown[] = [];
-    for (const [index, line] of lines.entries()) {
-      const candidate = line.trimStart();
-      if (candidate !== line || (!candidate.startsWith("{") && !candidate.startsWith("["))) {
-        continue;
-      }
-      const jsonTail = lines.slice(index).join("\n");
-      try {
-        candidates.push(JSON.parse(jsonTail) as unknown);
-      } catch {
-        const balanced = parseBalancedJsonPayloadStart(jsonTail);
-        if (balanced !== undefined) {
-          candidates.push(balanced);
-        }
-      }
-    }
-    const expectedPayload = candidates.find((value) => matchesExpectedPayload?.(value) === true);
-    if (expectedPayload !== undefined) {
-      return expectedPayload;
-    }
-    const payload = candidates.toReversed().find((value) => !isStructuredDiagnosticJson(value));
-    if (payload !== undefined) {
-      return payload;
-    }
-    const diagnosticOnly = candidates.at(-1);
-    if (diagnosticOnly !== undefined) {
-      return diagnosticOnly;
-    }
-
-    // Keep a line-oriented fallback for compact payloads followed by diagnostics.
-    for (const line of lines.toReversed()) {
-      const candidate = line.trim();
-      if (!candidate.startsWith("{") && !candidate.startsWith("[")) {
-        continue;
-      }
-      try {
-        return JSON.parse(candidate) as unknown;
-      } catch {
-        // Keep looking for the actual payload line.
-      }
-    }
-    throw new Error(`qa cli returned non-JSON stdout: ${truncateUtf16Safe(cleaned, 240)}`);
-  }
-}
 
 function killQaCliWindowsProcessTree(child: Pick<ChildProcessWithoutNullStreams, "kill" | "pid">) {
   if (child.pid) {

--- a/extensions/qa-lab/src/suite-runtime-cli-json.ts
+++ b/extensions/qa-lab/src/suite-runtime-cli-json.ts
@@ -1,0 +1,166 @@
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+
+const ANSI_ESCAPE_PATTERN = new RegExp(String.raw`\x1B\[[0-?]*[ -/]*[@-~]`, "g");
+
+function stripAnsiCodes(text: string) {
+  return text.replace(ANSI_ESCAPE_PATTERN, "");
+}
+
+function findBalancedJsonEnd(text: string, startIndex: number) {
+  const opening = text[startIndex];
+  const firstClosing = opening === "{" ? "}" : opening === "[" ? "]" : "";
+  if (!firstClosing) {
+    return -1;
+  }
+
+  const stack = [firstClosing];
+  let inString = false;
+  let escaping = false;
+  for (let index = startIndex + 1; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      if (escaping) {
+        escaping = false;
+      } else if (char === "\\") {
+        escaping = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+    } else if (char === "{" || char === "[") {
+      stack.push(char === "{" ? "}" : "]");
+    } else if (char === "}" || char === "]") {
+      if (stack.at(-1) !== char) {
+        return -1;
+      }
+      stack.pop();
+      if (stack.length === 0) {
+        return index;
+      }
+    }
+  }
+  return -1;
+}
+
+function parseBalancedJsonPayloadStart(text: string) {
+  const trimmedStart = text.search(/\S/u);
+  if (trimmedStart < 0) {
+    return undefined;
+  }
+  const char = text[trimmedStart];
+  if (char !== "{" && char !== "[") {
+    return undefined;
+  }
+  const end = findBalancedJsonEnd(text, trimmedStart);
+  if (end <= trimmedStart) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text.slice(trimmedStart, end + 1)) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function isStructuredDiagnosticJson(value: unknown) {
+  if (!isJsonRecord(value)) {
+    return false;
+  }
+  const level = value.level ?? value.logLevel ?? value.severity;
+  if (typeof level !== "string") {
+    return false;
+  }
+  return (
+    typeof value.message === "string" ||
+    typeof value.msg === "string" ||
+    typeof value.time === "string" ||
+    typeof value.timestamp === "string"
+  );
+}
+
+function isMemorySearchJsonPayload(value: unknown) {
+  return isJsonRecord(value) && Array.isArray(value.results);
+}
+
+function isMemoryStatusJsonPayload(value: unknown) {
+  if (Array.isArray(value)) {
+    return true;
+  }
+  return isJsonRecord(value) && value.command === "memory" && value.subcommand === "status";
+}
+
+function resolveQaCliJsonPayloadMatcher(args: readonly string[]) {
+  if (!args.includes("--json")) {
+    return undefined;
+  }
+  if (args[0] === "memory" && args[1] === "search") {
+    return isMemorySearchJsonPayload;
+  }
+  if (args[0] === "memory" && args[1] === "status") {
+    return isMemoryStatusJsonPayload;
+  }
+  return undefined;
+}
+
+export function parseQaCliJsonOutput(text: string, args: readonly string[]) {
+  const cleaned = stripAnsiCodes(text).trim();
+  if (!cleaned) {
+    return {};
+  }
+  const matchesExpectedPayload = resolveQaCliJsonPayloadMatcher(args);
+  try {
+    return JSON.parse(cleaned) as unknown;
+  } catch {
+    // Some startup repair logs are emitted on stdout before command JSON.
+    const lines = cleaned.split(/\r?\n/);
+    const candidates: unknown[] = [];
+    for (const [index, line] of lines.entries()) {
+      const candidate = line.trimStart();
+      if (candidate !== line || (!candidate.startsWith("{") && !candidate.startsWith("["))) {
+        continue;
+      }
+      const jsonTail = lines.slice(index).join("\n");
+      try {
+        candidates.push(JSON.parse(jsonTail) as unknown);
+      } catch {
+        const balanced = parseBalancedJsonPayloadStart(jsonTail);
+        if (balanced !== undefined) {
+          candidates.push(balanced);
+        }
+      }
+    }
+    const expectedPayload = candidates.find((value) => matchesExpectedPayload?.(value) === true);
+    if (expectedPayload !== undefined) {
+      return expectedPayload;
+    }
+    const payload = candidates.toReversed().find((value) => !isStructuredDiagnosticJson(value));
+    if (payload !== undefined) {
+      return payload;
+    }
+    const diagnosticOnly = candidates.at(-1);
+    if (diagnosticOnly !== undefined) {
+      return diagnosticOnly;
+    }
+
+    // Keep a line-oriented fallback for compact payloads followed by diagnostics.
+    for (const line of lines.toReversed()) {
+      const candidate = line.trim();
+      if (!candidate.startsWith("{") && !candidate.startsWith("[")) {
+        continue;
+      }
+      try {
+        return JSON.parse(candidate) as unknown;
+      } catch {
+        // Keep looking for the actual payload line.
+      }
+    }
+    throw new Error(`qa cli returned non-JSON stdout: ${truncateUtf16Safe(cleaned, 240)}`);
+  }
+}


### PR DESCRIPTION
Closes #120516

## What Problem This Solves

Fixes an issue where current `main` cannot pass `check-lint` because the QA process runner grew to 707 counted lines after the Unix command-settlement refactor.

## Why This Change Was Made

The runner contained a self-contained CLI JSON parsing subsystem: ANSI cleanup, balanced JSON extraction, diagnostic filtering, command-specific payload selection, and bounded invalid-output reporting. That logic now lives in `suite-runtime-cli-json.ts`, while the process runner imports the same parser through one call.

This is a real ownership split rather than line-count gaming: process lifecycle/settlement remains in the runner, and output parsing owns its own module. No suppression, timeout, fallback, or behavior change was added.

Production LOC: +167/-165 (net +2) | Tests: +0/-0

## User Impact

Maintainers regain a green lint gate for pull requests based on current `main`. QA CLI process execution and JSON output parsing behave exactly as before.

## Evidence

- Before: `suite-runtime-agent-process.ts` was 748 physical / 707 counted lines and failed `eslint(max-lines)` in https://github.com/openclaw/openclaw/actions/runs/31246019142.
- After: the runner is 584 physical lines; the parser module is 166 lines.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/suite-runtime-agent-process.test.ts` — 36/36 passed, including colored startup logs, pretty/multiline payloads, diagnostic JSON filtering, truncation, timeout, and process-settlement cases.
- Targeted oxfmt, oxlint, and `git diff --check` passed.
- Fresh P2 AutoReview: clean, no accepted/actionable P0-P2 findings (0.99).
- Public model identifier audit: PASS; this diff has no model-bearing code or artifacts.

No screenshots are included because this is a nonvisual internal QA runtime refactor required by lint.

AI-assisted: yes. I reproduced the exact `main` failure, selected the existing parser owner boundary, and verified the complete process-runner test file after extraction.
