### PR TITLE
fix(gateway): resolve restart-recovery state only on lifecycle events

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2858,6 +2858,38 @@ describe("agent event handler", () => {
     ).toBe(false);
   });
 
+  it("skips the session entry read for non-lifecycle events and resolves restart recovery only on lifecycle events", () => {
+    const { broadcast, chatRunState, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-recovery-lazy",
+    });
+    registerChatRun(chatRunState, "run-lazy", "session-recovery-lazy", "client-lazy");
+    vi.mocked(loadSessionEntry).mockClear();
+
+    // High-volume chat delta events must not touch the session store:
+    // restart-recovery state is consumed only by lifecycle-phase handling.
+    for (let seq = 1; seq <= 5; seq++) {
+      emitAgentEvent(
+        handler,
+        "run-lazy",
+        "assistant",
+        { text: `message ${seq}` },
+        { seq, ts: Date.now() + seq * 200 },
+      );
+    }
+    expect(loadSessionEntry).not.toHaveBeenCalled();
+    expect(chatBroadcastCalls(broadcast).length).toBeGreaterThanOrEqual(1);
+
+    // Lifecycle events still resolve restart-recovery state through the store.
+    emitAgentEvent(
+      handler,
+      "run-lazy",
+      "lifecycle",
+      { phase: "end", endedAt: Date.now() },
+      { seq: 6, sessionKey: "session-recovery-lazy" },
+    );
+    expect(loadSessionEntry).toHaveBeenCalled();
+  });
+
   it("clears tracked active runs before terminal sessions.changed broadcasts", async () => {
     vi.mocked(loadGatewaySessionRow).mockReturnValue({
       key: "session-finished",

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1326,9 +1326,18 @@ export function createAgentEventHandler({
       isChatAbortMarkerCurrent(chatRunState.runs.get(clientRunId)?.abortMarker, chatLink) ||
       isChatAbortMarkerCurrent(chatRunState.runs.get(evt.runId)?.abortMarker, chatLink);
 
-    const restartRecoveryState = restartRecoverySessionKey
-      ? resolveRestartRecoveryLifecycleState(restartRecoverySessionKey, restartRecoveryAgentId, evt)
-      : undefined;
+    // Restart-recovery state is consumed only by lifecycle-phase handling
+    // (suppression and terminal projection). Resolving it on every event runs
+    // a session-store read per stream delta; short-circuit non-lifecycle
+    // events the same way resolveSpawnedBy does above.
+    const restartRecoveryState =
+      lifecyclePhase !== null && restartRecoverySessionKey
+        ? resolveRestartRecoveryLifecycleState(
+            restartRecoverySessionKey,
+            restartRecoveryAgentId,
+            evt,
+          )
+        : undefined;
     const suppressRestartRecoveryLifecycle =
       lifecyclePhase !== null &&
       (Boolean(


### PR DESCRIPTION
## What Problem

#120378: the gateway's `handleEvent` resolved `restartRecoveryState` on **every** agent runtime event. `resolveRestartRecoveryLifecycleState` runs a session-store read, so post-turn cost scaled with answer length: a 10k-token answer streamed as hundreds of deltas triggered hundreds of redundant session-entry reads, each also paying the store's discovery overhead per stream event.

## Why

Restart-recovery state is consumed only by lifecycle-phase handling — suppression of lifecycle projection and terminal `sessions.changed` projection (see `server-chat.ts` around `suppressRestartRecoveryLifecycle` and the `lifecyclePhase === "end"/"error"` branches). Non-lifecycle events (delta/flush/final/agent/seq-gap) never read it, yet paid for the lookup anyway. The function above, `resolveSpawnedBy`, already short-circuits the same way — the restart-recovery path was the remaining per-delta store touch.

## User Impact

- High-churn sessions no longer do one session-store read per stream delta; post-turn cost is proportional to turn work, not answer length.
- Reduces hot-path latency and store contention for long answers, subagents, and cron/memory-flush turns (the same class of amplification as #120521).
- No behavior change: lifecycle events still resolve restart-recovery state exactly as before.

## Evidence

- `src/gateway/server-chat.ts`: `restartRecoveryState` resolution is now gated on `lifecyclePhase !== null && restartRecoverySessionKey`, mirroring the existing `resolveSpawnedBy` short-circuit directly above it.
- New test in `src/gateway/server-chat.agent-events.test.ts`: emits 5 chat delta events and asserts `loadSessionEntry` is **not** called (before the fix it was called once per event); then emits a lifecycle event and asserts the store read still happens.

[AI-assisted]
