### PR TITLE
fix(telegram): restore account-scoped reply mode

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -90,6 +90,7 @@ import {
   createTelegramPluginBase,
   findTelegramTokenOwnerAccountId,
   formatDuplicateTelegramTokenReason,
+  resolveTelegramConfigAccessorAccount,
   telegramConfigAdapter,
 } from "./shared.js";
 import { withTelegramStartupProbeSlot } from "./startup-probe-limiter.js";
@@ -1246,11 +1247,8 @@ export const telegramPlugin = createChatChannelPlugin({
   },
   security: telegramSecurityAdapter,
   threading: {
-    scopedAccountReplyToMode: {
-      resolveAccount: (cfg, accountId) => resolveTelegramAccount({ cfg, accountId }),
-      resolveReplyToMode: (account) => account.config.replyToMode,
-      fallback: "off",
-    },
+    resolveReplyToMode: ({ cfg, accountId }) =>
+      resolveTelegramConfigAccessorAccount({ cfg, accountId }).config.replyToMode ?? "off",
     buildToolContext: (params) => buildTelegramThreadingToolContext(params),
     resolveAutoThreadId: ({ to, toolContext }) => resolveTelegramAutoThreadId({ to, toolContext }),
     resolveCurrentChannelId: ({ to, threadId }) => {

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -1246,7 +1246,11 @@ export const telegramPlugin = createChatChannelPlugin({
   },
   security: telegramSecurityAdapter,
   threading: {
-    topLevelReplyToMode: "telegram",
+    scopedAccountReplyToMode: {
+      resolveAccount: (cfg, accountId) => resolveTelegramAccount({ cfg, accountId }),
+      resolveReplyToMode: (account) => account.config.replyToMode,
+      fallback: "off",
+    },
     buildToolContext: (params) => buildTelegramThreadingToolContext(params),
     resolveAutoThreadId: ({ to, toolContext }) => resolveTelegramAutoThreadId({ to, toolContext }),
     resolveCurrentChannelId: ({ to, threadId }) => {

--- a/extensions/telegram/src/shared.ts
+++ b/extensions/telegram/src/shared.ts
@@ -104,7 +104,7 @@ function isBlockedByMultiBotGuard(cfg: OpenClawConfig, accountId: string): boole
   return !resolveNormalizedAccountEntry(accounts, accountId, normalizeAccountId);
 }
 
-function resolveTelegramConfigAccessorAccount(params: {
+export function resolveTelegramConfigAccessorAccount(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
 }): TelegramConfigAccessorAccount {

--- a/extensions/telegram/src/threading-tool-context.test.ts
+++ b/extensions/telegram/src/threading-tool-context.test.ts
@@ -1,45 +1,64 @@
 // Telegram tests cover threading tool context plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { telegramPlugin } from "./channel.js";
 import { buildTelegramThreadingToolContext } from "./threading-tool-context.js";
+
+const tryReadSecretFileSyncMock = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error("reply mode must not read Telegram credentials");
+  }),
+);
+
+vi.mock("openclaw/plugin-sdk/secret-file-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/secret-file-runtime")>()),
+  tryReadSecretFileSync: tryReadSecretFileSyncMock,
+}));
 
 describe("telegramPlugin reply threading", () => {
   it.each([
     {
       name: "uses an account override",
       telegram: {
-        botToken: "token-default",
-        accounts: { sut: { botToken: "token-sut", replyToMode: "first" as const } },
+        accounts: {
+          sut: {
+            tokenFile: "/tmp/openclaw-telegram-reply-mode-must-not-read",
+            replyToMode: "first" as const,
+          },
+        },
       },
       expected: "first",
     },
     {
       name: "inherits the top-level mode",
       telegram: {
-        botToken: "token-default",
         replyToMode: "all" as const,
-        accounts: { sut: { botToken: "token-sut" } },
+        accounts: {
+          sut: {
+            botToken: { source: "file", provider: "telegram_token", id: "value" },
+          },
+        },
       },
       expected: "all",
     },
     {
       name: "allows an account to disable replies",
       telegram: {
-        botToken: "token-default",
         replyToMode: "all" as const,
-        accounts: { sut: { botToken: "token-sut", replyToMode: "off" as const } },
+        accounts: { sut: { replyToMode: "off" as const } },
       },
       expected: "off",
     },
   ])("$name", ({ telegram, expected }) => {
+    tryReadSecretFileSyncMock.mockClear();
     const resolveReplyToMode = telegramPlugin.threading?.resolveReplyToMode;
     if (!resolveReplyToMode) {
       throw new Error("Telegram reply mode resolver is unavailable");
     }
 
-    const cfg = { channels: { telegram } } as OpenClawConfig;
+    const cfg = { channels: { telegram } } as unknown as OpenClawConfig;
     expect(resolveReplyToMode({ cfg, accountId: "sut" })).toBe(expected);
+    expect(tryReadSecretFileSyncMock).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/telegram/src/threading-tool-context.test.ts
+++ b/extensions/telegram/src/threading-tool-context.test.ts
@@ -1,7 +1,47 @@
 // Telegram tests cover threading tool context plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it } from "vitest";
+import { telegramPlugin } from "./channel.js";
 import { buildTelegramThreadingToolContext } from "./threading-tool-context.js";
+
+describe("telegramPlugin reply threading", () => {
+  it.each([
+    {
+      name: "uses an account override",
+      telegram: {
+        botToken: "token-default",
+        accounts: { sut: { botToken: "token-sut", replyToMode: "first" as const } },
+      },
+      expected: "first",
+    },
+    {
+      name: "inherits the top-level mode",
+      telegram: {
+        botToken: "token-default",
+        replyToMode: "all" as const,
+        accounts: { sut: { botToken: "token-sut" } },
+      },
+      expected: "all",
+    },
+    {
+      name: "allows an account to disable replies",
+      telegram: {
+        botToken: "token-default",
+        replyToMode: "all" as const,
+        accounts: { sut: { botToken: "token-sut", replyToMode: "off" as const } },
+      },
+      expected: "off",
+    },
+  ])("$name", ({ telegram, expected }) => {
+    const resolveReplyToMode = telegramPlugin.threading?.resolveReplyToMode;
+    if (!resolveReplyToMode) {
+      throw new Error("Telegram reply mode resolver is unavailable");
+    }
+
+    const cfg = { channels: { telegram } } as OpenClawConfig;
+    expect(resolveReplyToMode({ cfg, accountId: "sut" })).toBe(expected);
+  });
+});
 
 describe("buildTelegramThreadingToolContext", () => {
   it("keeps topic thread state in plugin-owned tool context", () => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators using an account-scoped Telegram `replyToMode` override could receive non-reply messages even when that account was configured with `replyToMode: "first"`.

The 2026.8.1 package candidate exposed this in the Telegram channel canary: both outbound payloads omitted `replyToMessageId`, so the scenario failed while the other 18 package scenarios passed.

It also fixes the P1 follow-up identified on the first exact head: resolving reply policy through the full Telegram account resolver read credential sources even though reply policy only needs merged config. A configured `tokenFile` was opened, and an unresolved token `SecretRef` could throw while computing reply mode.

## Why This Change Was Made

The Telegram channel's threading producer had regressed from resolving the selected account to resolving reply mode from top-level Telegram config only. The first repair restored account-scoped inheritance. The follow-up now resolves reply mode directly through Telegram's existing private config-accessor account projection, which merges top-level and per-account config without reading token files or resolving credential references.

This keeps reply policy at its owning configuration boundary. There is no new config or public API, and no canary-specific workaround, peer-bot fallback, downstream send-path branch, or credential-resolution side effect.

Provenance: commit `ab96520b` replaced the account-scoped resolution used by `a3541a1cce717` with a top-level resolver. This restores the earlier account ownership boundary and preserves Tak Hoffman's contribution credit in the first commit trailer.

## User Impact

Telegram accounts now honor their configured `replyToMode` (`first`, `all`, or `off`) independently, while accounts without an override continue to inherit the top-level Telegram setting. In particular, `first` once again attaches the triggering message ID to the first outbound reply.

Reply-mode checks no longer touch Telegram credentials, so a token file or unresolved token `SecretRef` cannot block this config-only policy decision. No operator migration or config change is required.

## Evidence

### Release-blocking package evidence

- Candidate: OpenClaw 2026.8.1.
- Package Telegram run: https://github.com/openclaw/openclaw/actions/runs/31243345426
- Immutable artifact: https://github.com/openclaw/openclaw/actions/runs/31243345426/artifacts/9017828276
- Result: 18 scenarios passed; the channel canary failed because both send payloads omitted `replyToMessageId` despite `channels.telegram.accounts.sut.replyToMode: "first"`.

### Account-scope repair and main refresh

The first commit was rebased without conflicts onto the repaired main baseline `e5d4fe02a46a29ecc23470eb03527393dfea19da` as head `df7d10353ac6cc505789b995948f8769b5a0d4e9`.

- Hosted CI: https://github.com/openclaw/openclaw/actions/runs/31257191588 — green on `df7d10353ac6cc505789b995948f8769b5a0d4e9`.
- Focused reply-mode regression — 1 file / 5 tests pass; wrapper time 9.80s.
- Channel contracts — 4 shards / 50 files / 482 tests pass; wrapper time 54.16s.
- Stable patch-id before and after rebase: `9188c146e025ecb551048a06c29519eb319faf8d`.
- `git range-diff` reports the first commit as patch-equivalent (`7d0f261ad0cee = df7d10353ac6c`).

The focused regression covers account override `first`, inherited top-level behavior, account override `off`, and the existing default behavior without duplicating the outbound funnel tests.

### Credential-safety P1 follow-up

The exact-head P1 review traced the remaining problem to the full account resolver: it resolves credential-bearing token fields as part of account construction even though threading policy only consumes `account.config.replyToMode`. Telegram already had a private `resolveTelegramConfigAccessorAccount` projection for config-only access; the follow-up exports that local helper and calls it directly from the threading resolver.

Red proof on `df7d10353ac6cc505789b995948f8769b5a0d4e9`:

- An account with `tokenFile` invoked the secret-file reader while resolving reply mode.
- An account with an unresolved token `SecretRef` threw during the same config-only policy lookup.

Green proof after the follow-up:

- Focused Telegram config/reply suites — 2 files / 85 tests pass.
- `corepack pnpm test:contracts:channels` — 4 shards / 50 files / 482 tests pass.
- `corepack pnpm tsgo:extensions` — pass.
- `corepack pnpm tsgo:extensions:test` — pass.
- Targeted oxlint for `extensions/telegram/src/channel.ts`, `extensions/telegram/src/shared.ts`, and `extensions/telegram/src/threading-tool-context.test.ts` — pass.
- Targeted oxfmt for the same three files — pass.
- `git diff --check` — pass.

Blacksmith Testbox was unavailable before a lease could be provisioned, so trusted-source focused proof fell back to the prepared local checkout. Per user direction, no live Telegram run was performed.

### Prior wider-suite context

The earlier broad Telegram run reported 3,393 pass / 5 fail, with the same five failures reproducing when the new regression test was excluded. Those failures were current-main test debt outside this patch and are covered by the main repair included in the rebase; the rebased focused regression, channel contracts, and hosted CI above are green.

### Scope and exact-head status

- Current head: `f5b934598a9b90a241c6bac427ebfbb8be590c49`.
- Exact-head hosted CI for the credential-safety follow-up: pending.
- Full PR production LOC: +4/-2 (net +2); tests: +60/-1 (net +59).
- Credential-safety follow-up production LOC: +4/-6 (net -2); tests: +27/-8 (net +19).
- No config or public API surface changed.
- No live Telegram proof was run, per user direction. The immutable package run above remains the original release-blocking symptom evidence, not passing exact-head live proof.

AI-assisted implementation; the code path, history, focused regression, sibling policy, credential boundary, and current-main failures were independently inspected.
