### PR TITLE
fix(agents): transfer requester wake ownership across yield and deflake survivor registry setup

### DIFF
--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -760,18 +760,31 @@ describe("shared Codex app-server client", () => {
   );
 
   it("closes and clears a shared app-server when initialize times out", async () => {
+    vi.useFakeTimers();
     const first = createClientHarness();
     const second = createClientHarness();
     const startSpy = vi
       .spyOn(CodexAppServerClient, "start")
       .mockReturnValueOnce(first.client)
       .mockReturnValueOnce(second.client);
+    let markFirstStarted: () => void = () => undefined;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
 
-    await expect(listCodexAppServerModels({ timeoutMs: 5 })).rejects.toThrow(
+    const firstAcquire = getSharedCodexAppServerClient({
+      timeoutMs: 5,
+      onStartedClient: markFirstStarted,
+    });
+    const firstRejection = expect(firstAcquire).rejects.toThrow(
       "codex app-server initialize timed out",
     );
+    await firstStarted;
+    await vi.advanceTimersByTimeAsync(5);
+    await firstRejection;
     expect(first.process.stdin.destroyed).toBe(true);
 
+    vi.useRealTimers();
     const secondList = listCodexAppServerModels({ timeoutMs: 1000 });
     await sendInitializeResult(second, "openclaw/0.146.1 (macOS; test)");
     await sendEmptyModelList(second);
@@ -870,12 +883,22 @@ describe("shared Codex app-server client", () => {
   });
 
   it("does not wait for isolated initialize after a timeout closes the client", async () => {
+    vi.useFakeTimers();
     const harness = createClientHarness();
     vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
+    let markStarted: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
 
-    await expect(createIsolatedCodexAppServerClient({ timeoutMs: 5 })).rejects.toThrow(
-      "codex app-server initialize timed out",
-    );
+    const client = createIsolatedCodexAppServerClient({
+      timeoutMs: 5,
+      onStartedClient: markStarted,
+    });
+    const rejection = expect(client).rejects.toThrow("codex app-server initialize timed out");
+    await started;
+    await vi.advanceTimersByTimeAsync(5);
+    await rejection;
     expect(harness.process.stdin.destroyed).toBe(true);
   });
 

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -406,8 +406,8 @@ for (const entry of manifest.packages) {
 }
 NODE
     )"
-    while IFS=$'\t' read -r package_name package_version package_tarball; do
-      registry_args+=("$package_name" "$package_version" "$package_tarball")
+    while IFS=$'\t' read -r plugin_package_name plugin_package_version plugin_package_tarball; do
+      registry_args+=("$plugin_package_name" "$plugin_package_version" "$plugin_package_tarball")
     done <<<"$registry_rows"
   fi
 

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -314,8 +314,8 @@ for (const entry of manifest.packages) {
 }
 NODE
     )"
-    while IFS=$'"'"'\t'"'"' read -r package_name package_version package_tarball; do
-      registry_args+=("$package_name" "$package_version" "$package_tarball")
+    while IFS=$'"'"'\t'"'"' read -r plugin_package_name plugin_package_version plugin_package_tarball; do
+      registry_args+=("$plugin_package_name" "$plugin_package_version" "$plugin_package_tarball")
     done <<<"$registry_rows"
   fi
 

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -128,7 +128,7 @@ type QueueEmbeddedAgentMessageWithOutcome = (
   sessionId: string,
   message: string,
   options?: EmbeddedAgentQueueMessageOptions,
-) => EmbeddedAgentQueueMessageOutcome;
+) => EmbeddedAgentQueueMessageOutcome | Promise<EmbeddedAgentQueueMessageOutcome>;
 
 function createQueueOutcomeMock(
   queued: boolean,
@@ -1158,6 +1158,53 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       expect(callGateway).not.toHaveBeenCalled();
     },
   );
+
+  it("fences an active completion delivery when sessions_yield takes ownership mid-wait", async () => {
+    let requesterYielded = false;
+    let markWakeStarted: () => void = () => undefined;
+    const wakeStarted = new Promise<void>((resolve) => {
+      markWakeStarted = resolve;
+    });
+    let releaseWake: () => void = () => undefined;
+    const wakeGate = new Promise<void>((resolve) => {
+      releaseWake = resolve;
+    });
+    const queueEmbeddedAgentMessageWithOutcome = vi.fn(async (sessionId: string) => {
+      markWakeStarted();
+      await wakeGate;
+      return {
+        queued: true as const,
+        sessionId,
+        target: "embedded_run" as const,
+        gatewayHealth: "live" as const,
+        enqueuedAtMs: 4_100,
+        deliveredAtMs: 4_200,
+      };
+    });
+    const callGateway = createGatewayMock();
+
+    const delivery = deliverSlackThreadAnnouncement({
+      callGateway,
+      sessionId: "requester-session-1",
+      isActive: true,
+      directIdempotencyKey: "announce-yield-owned-mid-wait",
+      queueEmbeddedAgentMessageWithOutcome,
+      isCompletionOwnedByRequesterYield: () => requesterYielded,
+    });
+    await wakeStarted;
+    requesterYielded = true;
+    releaseWake();
+
+    await expect(delivery).resolves.toMatchObject({
+      delivered: false,
+      path: "none",
+      reason: "source_owner_changed",
+      terminal: true,
+      disposition: "intentional_non_delivery",
+    });
+    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledOnce();
+    expect(callGateway).not.toHaveBeenCalled();
+  });
 
   it("keeps direct external delivery for dormant completion requesters", async () => {
     const callGateway = createGatewayMock();

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -224,7 +224,7 @@ async function resolveActiveWakeWithRetries(
   message: string,
   wakeOptions: EmbeddedAgentQueueMessageOptions,
   signal?: AbortSignal,
-  isSourceSessionEffectsAllowed?: () => boolean,
+  isAttemptAllowed?: () => boolean,
 ): Promise<EmbeddedAgentQueueMessageOutcome | typeof SOURCE_OWNER_CHANGED> {
   // Bound the whole active wake by the caller's delivery window. Each retry
   // passes only the remaining window into transcript-commit waiting so a
@@ -247,10 +247,13 @@ async function resolveActiveWakeWithRetries(
       deliveryTimeoutMs: remainingDeliveryTimeoutMs,
     };
   };
-  const attemptWake = (options: EmbeddedAgentQueueMessageOptions) =>
-    isSourceSessionEffectsAllowed?.() === false
-      ? SOURCE_OWNER_CHANGED
-      : resolveQueueEmbeddedAgentMessageOutcome(sessionId, message, options);
+  const attemptWake = async (options: EmbeddedAgentQueueMessageOptions) => {
+    if (isAttemptAllowed?.() === false) {
+      return SOURCE_OWNER_CHANGED;
+    }
+    const result = await resolveQueueEmbeddedAgentMessageOutcome(sessionId, message, options);
+    return isAttemptAllowed?.() === false ? SOURCE_OWNER_CHANGED : result;
+  };
   let outcome = await attemptWake(currentOptions);
   const compactionRetryDelaysMs = resolveCompactionSteerRetryDelaysMs();
   let compactionRetryIndex = 0;
@@ -261,7 +264,7 @@ async function resolveActiveWakeWithRetries(
     if (outcome.queued || signal?.aborted) {
       break;
     }
-    if (isSourceSessionEffectsAllowed?.() === false) {
+    if (isAttemptAllowed?.() === false) {
       outcome = SOURCE_OWNER_CHANGED;
       break;
     }
@@ -958,7 +961,10 @@ async function sendSubagentAnnounceDirectly(params: {
         error: "requester session abandoned after timeout",
       };
     }
-    if (params.expectsCompletionMessage && params.isCompletionOwnedByRequesterYield?.()) {
+    const isCompletionDeliveryAllowed = () =>
+      params.isSourceSessionEffectsAllowed?.() !== false &&
+      !(params.expectsCompletionMessage && params.isCompletionOwnedByRequesterYield?.());
+    if (!isCompletionDeliveryAllowed()) {
       // sessions_yield owns the post-turn synthesis. Starting or steering a
       // requester turn here would replay the original fanout during handoff.
       return {
@@ -977,7 +983,7 @@ async function sendSubagentAnnounceDirectly(params: {
         deliveryTarget,
         internalEvents: params.internalEvents,
         onDeliveryResult: params.onDeliveryResult,
-        isSourceSessionEffectsAllowed: params.isSourceSessionEffectsAllowed,
+        isSourceSessionEffectsAllowed: isCompletionDeliveryAllowed,
       });
     const completionSourceReplyDeliveryMode = requiresMessageToolDelivery
       ? "message_tool_only"
@@ -1014,7 +1020,7 @@ async function sendSubagentAnnounceDirectly(params: {
         params.triggerMessage,
         wakeOptions,
         params.signal,
-        params.isSourceSessionEffectsAllowed,
+        isCompletionDeliveryAllowed,
       );
       if (wakeOutcome === SOURCE_OWNER_CHANGED) {
         return sourceOwnerChangedResult();
@@ -1092,9 +1098,9 @@ async function sendSubagentAnnounceDirectly(params: {
           ? "completion direct announce agent call"
           : "direct announce agent call",
         signal: params.signal,
-        isAttemptAllowed: params.isSourceSessionEffectsAllowed,
+        isAttemptAllowed: isCompletionDeliveryAllowed,
         run: async () => {
-          if (params.isSourceSessionEffectsAllowed?.() === false) {
+          if (!isCompletionDeliveryAllowed()) {
             throw new SourceOwnerChangedError();
           }
           return await runAnnounceAgentCall({
@@ -1120,6 +1126,9 @@ async function sendSubagentAnnounceDirectly(params: {
           });
         },
       });
+      if (!isCompletionDeliveryAllowed()) {
+        return sourceOwnerChangedResult();
+      }
     } catch (err) {
       if (err instanceof SourceOwnerChangedError) {
         return sourceOwnerChangedResult();

--- a/src/agents/subagent-registry-requester-yield.test.ts
+++ b/src/agents/subagent-registry-requester-yield.test.ts
@@ -166,10 +166,11 @@ describe("settleRequesterTurnAfterSessionSpawns", () => {
       requesterYieldBatch: true,
       afterRequesterYield: true,
     });
-    expect(schedule).not.toHaveBeenCalled();
+    expect(entry.delivery?.disposition).toBe("intentional_non_delivery");
+    expect(schedule).toHaveBeenCalledExactlyOnceWith(entry.runId, entry);
   });
 
-  it("persists a mixed delivered and in-progress yielded batch without scheduling", () => {
+  it("persists a mixed delivered and in-progress yielded batch before scheduling", () => {
     const alpha = makeRun("run-alpha");
     const beta = makeRun("run-beta");
     beta.delivery = { status: "in_progress" };
@@ -204,8 +205,9 @@ describe("settleRequesterTurnAfterSessionSpawns", () => {
     expect(beta.requesterSettleWake).toEqual(frozenState);
     expect(alpha.requesterTurnRunId).toBeUndefined();
     expect(beta.requesterTurnRunId).toBeUndefined();
-    expect(calls).toEqual(["persist"]);
-    expect(schedule).not.toHaveBeenCalled();
+    expect(beta.delivery?.disposition).toBe("intentional_non_delivery");
+    expect(calls).toEqual(["persist", "schedule"]);
+    expect(schedule).toHaveBeenCalledExactlyOnceWith(alpha.runId, alpha);
   });
 
   it.each([true, false])(

--- a/src/agents/subagent-registry-requester-yield.ts
+++ b/src/agents/subagent-registry-requester-yield.ts
@@ -81,6 +81,7 @@ export function settleRequesterTurnAfterSessionSpawns(params: {
   }
   const batchRunIds = entries.map((entry) => entry.runId).toSorted();
   const previousStates = entries.map((entry) => ({
+    delivery: structuredClone(entry.delivery),
     requesterSettleWake: structuredClone(entry.requesterSettleWake),
     requesterTurnRunId: entry.requesterTurnRunId,
     requesterTurnYielded: entry.requesterTurnYielded,
@@ -92,11 +93,18 @@ export function settleRequesterTurnAfterSessionSpawns(params: {
       Math.max(0, ...entries.map((entry) => entry.requesterSettleWake?.rearmGeneration ?? 0)) + 1;
     for (const entry of entries) {
       const existing = entry.requesterSettleWake;
+      const completionEnded = typeof entry.execution.endedAt === "number";
       // An in-progress delivery may already target the requester run being aborted.
       // Re-arm it like a delivered result so that completion cannot die with that turn.
-      const completionMayBeAttachedToYieldedTurn =
-        typeof entry.execution.endedAt === "number" &&
-        (entry.delivery?.status === "delivered" || entry.delivery?.status === "in_progress");
+      const completionMayBeAttachedToYieldedTurn = completionEnded;
+      if (completionEnded && entry.delivery?.status !== "delivered") {
+        // The persisted yielded batch now owns terminal delivery. Mark the old
+        // per-child attempt terminal so it cannot keep the batch unsettled.
+        entry.delivery = {
+          ...(entry.delivery ?? { status: "pending" }),
+          disposition: "intentional_non_delivery",
+        };
+      }
       entry.requesterSettleWake = {
         status: "pending",
         attemptCount: 0,
@@ -132,6 +140,7 @@ export function settleRequesterTurnAfterSessionSpawns(params: {
     entries.forEach((entry, index) => {
       const previous = previousStates[index];
       params.runs.set(entry.runId, entry);
+      entry.delivery = previous?.delivery;
       entry.requesterSettleWake = previous?.requesterSettleWake;
       entry.requesterTurnRunId = previous?.requesterTurnRunId;
       entry.requesterTurnYielded = previous?.requesterTurnYielded;
@@ -142,12 +151,9 @@ export function settleRequesterTurnAfterSessionSpawns(params: {
 
   if (
     rearmGeneration !== undefined &&
-    entries.every(
-      (entry) =>
-        typeof entry.execution.endedAt === "number" && entry.delivery?.status === "delivered",
-    )
+    entries.every((entry) => typeof entry.execution.endedAt === "number")
   ) {
-    // Active children keep the frozen batch but let their normal cleanup owner schedule it.
+    // Active children keep the frozen batch; their normal completion owner schedules it.
     params.schedule(firstEntry.runId, firstEntry);
   }
   return true;

--- a/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -386,7 +386,7 @@ describe("subagent registry lifecycle error grace", () => {
       });
   }
 
-  it("lets the delivered cleanup own a yielded batch after a stale wake loses generation", async () => {
+  it("lets requester settlement own a yielded batch while child delivery is in progress", async () => {
     const requesterTurnRunId = "run-requester-yield-race";
     const alphaSessionKey = "agent:main:subagent:yield-alpha";
     const betaSessionKey = "agent:main:subagent:yield-beta";
@@ -459,6 +459,7 @@ describe("subagent registry lifecycle error grace", () => {
       yieldedBatch.map((run) => ({
         runId: run.runId,
         delivery: run.delivery?.status,
+        disposition: run.delivery?.disposition,
         nextAttemptAt: run.requesterSettleWake?.nextAttemptAt,
         rearmGeneration: run.requesterSettleWake?.rearmGeneration,
       })),
@@ -466,14 +467,16 @@ describe("subagent registry lifecycle error grace", () => {
       {
         runId: "run-yield-alpha",
         delivery: "delivered",
+        disposition: "delivered",
         nextAttemptAt: undefined,
-        rearmGeneration: 1,
+        rearmGeneration: undefined,
       },
       {
         runId: "run-yield-beta",
         delivery: "in_progress",
+        disposition: "intentional_non_delivery",
         nextAttemptAt: undefined,
-        rearmGeneration: 1,
+        rearmGeneration: undefined,
       },
     ]);
     const requesterWakeCalls = () =>
@@ -485,11 +488,11 @@ describe("subagent registry lifecycle error grace", () => {
           idempotencyKey.startsWith("announce:requester-settle:")
         );
       });
-    expect(requesterWakeCalls()).toHaveLength(0);
+    await waitForAgentCallCount(3);
+    expect(requesterWakeCalls()).toHaveLength(1);
 
     agentCallGates.delete(betaSessionKey);
     releaseBetaDelivery?.();
-    await waitForAgentCallCount(3);
     await waitForDeliveredCleanup("run-yield-alpha");
     await waitForDeliveredCleanup("run-yield-beta");
 

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2279,6 +2279,10 @@ docker_e2e_docker_run_cmd run demo
     for (const script of [runner, publishedRunner]) {
       expect(script).toContain("OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org");
       expect(script).toContain("node scripts/e2e/lib/plugins/npm-registry-server.mjs");
+      expect(script).toContain(
+        "read -r plugin_package_name plugin_package_version plugin_package_tarball",
+      );
+      expect(script).not.toContain("read -r package_name package_version package_tarball");
     }
     expect(runner).toContain('OPENCLAW_NPM_REGISTRY_DIST_TAGS="beta=$package_version"');
     expect(publishedRunner).toContain('OPENCLAW_NPM_REGISTRY_DIST_TAGS="beta=$candidate_version"');


### PR DESCRIPTION
## What Problem This Solves

Three failures from 2026.8.1-beta.1 validation attempt 3 (run 31244729306):

1. **QA Lab parity lane — real product bug**: a yielded parent agent never resumed even though both children completed (`ALPHA-OK`/`BETA-OK`, 11/12 scenarios green). Requester settlement rearmed terminal in-progress deliveries but only scheduled the consolidated wake when every delivery was already marked delivered — a stale per-child delivery waiting across yield left no wake owner. Fix: atomically transfer terminal delivery ownership and schedule the wake (`subagent-registry-requester-yield.ts`), and fence stale completion delivery across its async transcript wait (`subagent-announce-delivery.ts`). The parity-report failure was purely downstream of this.
2. **Codex shared-client timing flake** (blocked plugin-prerelease): the test's 5ms wall-clock deadline could expire during pre-spawn context resolution, so no client existed to close. Both affected tests now await the real `onStartedClient` seam and advance fake timers deterministically. Codex 0.146.1 contract verified against sibling source (`../codex/codex-rs/app-server/README.md:76`, `app-server-protocol/src/protocol/common.rs:481`, `request_processors/initialize_processor.rs:44`, `app-server-transport/src/transport/stdio.rs:43`, `app-server/src/lib.rs:990`). Determinism: 12 consecutive full-suite runs, 672 test executions, all green.
3. **upgrade-survivor lane residual**: 733512b introduced a Bash variable collision — the manifest loop reused `package_version`, cleared on the loop's final EOF read, so the registry launcher passed `beta=` and the registry correctly rejected it. Both survivor runners now use distinct `plugin_package_*` loop variables.

## User Impact

The QA-parity fix is user-facing beyond CI: any yielded requester whose child completed during the yield window could hang forever awaiting a wake that had no owner.

## Evidence

- Focused suites 415 tests green across four shards (re-verified after review); exact lifecycle-order regression for the wake race; flake determinism 12×56 green.
- `pnpm tsgo:core` + `tsgo:core:test`, deadcode scans, shell syntax, `git diff --check`: all green.
- Codex autoreview (`gpt-5.6-sol`, high): clean (0.94).
- Production +34/−19 (the ownership-transfer boundary); harness +4/−4; tests +93/−14.
