### PR TITLE
fix(qa): recover Crabbox proofs on fallback SSH ports

### DIFF
--- a/extensions/qa-lab/src/mantis/crabbox-runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/crabbox-runtime.test.ts
@@ -1,6 +1,6 @@
 // Qa Lab tests cover Crabbox runtime behavior.
 import { describe, expect, it } from "vitest";
-import { defaultCommandRunner } from "./crabbox-runtime.js";
+import { type CommandRunner, defaultCommandRunner, sshCommand } from "./crabbox-runtime.js";
 
 describe("Crabbox command runner", () => {
   it("preserves UTF-8 split across child-process pipe chunks", async () => {
@@ -17,5 +17,94 @@ describe("Crabbox command runner", () => {
       stdout: "😀",
       stderr: "测",
     });
+  });
+
+  it("keeps captured stderr in command failures", async () => {
+    await expect(
+      defaultCommandRunner(
+        process.execPath,
+        ["-e", 'process.stderr.write("Permission denied (publickey)\\n"); process.exit(255)'],
+        {},
+      ),
+    ).rejects.toThrow("Permission denied (publickey)");
+  });
+
+  it.each([
+    {
+      host: "ssh.proof.example",
+      inspect: {
+        sshFallbackPorts: ["22", "2222", " 2200 ", "22"],
+        sshHost: "ssh.proof.example",
+        sshPort: "2222",
+      },
+      ports: ["2222", "22", "2200"],
+    },
+    {
+      host: "proof.example",
+      inspect: { sshFallbackPorts: ["2200", "22", "2200"] },
+      ports: ["22", "2200"],
+    },
+    { host: "proof.example", inspect: {}, ports: ["22"] },
+  ])("selects ordered, deduplicated SSH candidates: $ports", async ({ host, inspect, ports }) => {
+    const calls: Array<{ args: readonly string[]; command: string }> = [];
+    const runner: CommandRunner = async (command, args) => {
+      calls.push({ args, command });
+      if (command === "ssh" && !args.includes(ports.at(-1) ?? "22")) {
+        throw new Error("Connection refused");
+      }
+      return { stderr: "", stdout: "" };
+    };
+    const transport = await sshCommand({
+      cwd: "/repo",
+      env: {},
+      inspect: {
+        host: "proof.example",
+        ...inspect,
+        sshKey: "/tmp/key",
+        sshUser: "proof",
+      },
+      runner,
+    });
+
+    await runner("rsync", ["-e", transport.sshArgs], {});
+
+    const expectedProbes = ports.length === 1 ? [] : ports;
+    expect(calls.filter((call) => call.command === "ssh").map((call) => call.args[3])).toEqual(
+      expectedProbes,
+    );
+    expect(calls.filter((call) => call.command === "ssh").map((call) => call.args[12])).toEqual(
+      expectedProbes.map(() => `proof@${host}`),
+    );
+    expect(transport.host).toBe(host);
+    expect(calls.filter((call) => call.command === "rsync")).toEqual([
+      { args: ["-e", expect.stringContaining(`-p ${ports.at(-1)}`)], command: "rsync" },
+    ]);
+  });
+
+  it("does not try a fallback after an SSH authentication failure", async () => {
+    const probes: string[] = [];
+    const runner: CommandRunner = async (command, args) => {
+      if (command === "ssh") {
+        probes.push(args[3] ?? "");
+        throw new Error("Permission denied (publickey)");
+      }
+      return { stderr: "", stdout: "" };
+    };
+
+    await expect(
+      sshCommand({
+        cwd: "/repo",
+        env: {},
+        inspect: {
+          host: "proof.example",
+          sshFallbackPorts: ["22"],
+          sshKey: "/tmp/key",
+          sshPort: "2222",
+          sshUser: "proof",
+        },
+        runner,
+      }),
+    ).rejects.toThrow("Permission denied");
+    expect(probes).toEqual(["2222"]);
   });
 });

--- a/extensions/qa-lab/src/mantis/crabbox-runtime.ts
+++ b/extensions/qa-lab/src/mantis/crabbox-runtime.ts
@@ -21,6 +21,8 @@ export type CrabboxInspect = {
   provider?: string;
   ready?: boolean;
   slug?: string;
+  sshFallbackPorts?: string[];
+  sshHost?: string;
   sshKey?: string;
   sshPort?: string;
   sshUser?: string;
@@ -60,7 +62,11 @@ export async function defaultCommandRunner(
         return;
       }
       const detail = signal ? `signal ${signal}` : `exit code ${code ?? "unknown"}`;
-      reject(new Error(`${command} ${args.join(" ")} failed with ${detail}`));
+      reject(
+        new Error(
+          `${command} ${args.join(" ")} failed with ${detail}${stderr ? `\n${stderr.trimEnd()}` : ""}`,
+        ),
+      );
     });
   });
 }
@@ -181,28 +187,72 @@ export async function stopCrabbox(params: {
   });
 }
 
-export function sshCommand(params: { inspect: CrabboxInspect }) {
-  const { host, sshKey, sshPort, sshUser } = params.inspect;
+function crabboxSshPortCandidates(inspect: Pick<CrabboxInspect, "sshFallbackPorts" | "sshPort">) {
+  const ports = [inspect.sshPort?.trim() || "22", ...(inspect.sshFallbackPorts ?? [])];
+  return [...new Set(ports.map((port) => port.trim()).filter(Boolean))] as [string, ...string[]];
+}
+
+function isSshConnectionFailure(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return /Connection (?:closed|refused|reset|timed out)|Operation timed out|Network is unreachable|No route to host/u.test(
+    message,
+  );
+}
+
+function sshCommandForPort(inspect: CrabboxInspect, sshPort: string) {
+  const host = inspect.sshHost || inspect.host;
+  const { sshKey, sshUser } = inspect;
   if (!host || !sshKey || !sshUser) {
     throw new Error("Crabbox inspect output is missing SSH copy details.");
   }
+  const options = [
+    "-p",
+    sshPort,
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    "ConnectTimeout=15",
+    "-o",
+    "StrictHostKeyChecking=no",
+    "-o",
+    "UserKnownHostsFile=/dev/null",
+  ];
   return {
-    host,
-    sshArgs: [
-      "ssh",
-      "-i",
-      shellQuote(sshKey),
-      "-p",
-      sshPort ?? "22",
-      "-o",
-      "BatchMode=yes",
-      "-o",
-      "ConnectTimeout=15",
-      "-o",
-      "StrictHostKeyChecking=no",
-      "-o",
-      "UserKnownHostsFile=/dev/null",
-    ].join(" "),
-    sshUser,
+    probeArgs: ["-i", sshKey, ...options, `${sshUser}@${host}`, "exit 0"],
+    value: { host, sshArgs: ["ssh", "-i", shellQuote(sshKey), ...options].join(" "), sshUser },
   };
+}
+
+export async function sshCommand(params: {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  inspect: CrabboxInspect;
+  runner: CommandRunner;
+}) {
+  const candidates = crabboxSshPortCandidates(params.inspect);
+  if (candidates.length === 1) {
+    return sshCommandForPort(params.inspect, candidates[0]).value;
+  }
+
+  let lastError: unknown;
+  // Select the transport before rsync so a copy failure never replays the operation on another port.
+  for (const port of candidates) {
+    const command = sshCommandForPort(params.inspect, port);
+    try {
+      await runCommand({
+        args: command.probeArgs,
+        command: "ssh",
+        cwd: params.cwd,
+        env: params.env,
+        runner: params.runner,
+      });
+      return command.value;
+    } catch (error) {
+      if (!isSshConnectionFailure(error)) {
+        throw error;
+      }
+      lastError = error;
+    }
+  }
+  throw lastError;
 }

--- a/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.ts
+++ b/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.ts
@@ -290,7 +290,7 @@ async function copyRemoteArtifacts(params: {
   remoteOutputDir: string;
   runner: CommandRunner;
 }) {
-  const { host, sshArgs, sshUser } = sshCommand({ inspect: params.inspect });
+  const { host, sshArgs, sshUser } = await sshCommand(params);
   await runCommand({
     command: "rsync",
     args: [

--- a/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
+++ b/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
@@ -1244,7 +1244,7 @@ async function copyRemoteArtifacts(params: {
   remoteOutputDir: string;
   runner: CommandRunner;
 }) {
-  const { host, sshArgs, sshUser } = sshCommand({ inspect: params.inspect });
+  const { host, sshArgs, sshUser } = await sshCommand(params);
   await fs.mkdir(path.join(params.outputDir, "slack-qa"), { recursive: true });
   await runCommand({
     command: "rsync",

--- a/extensions/qa-lab/src/mantis/telegram-desktop-builder.runtime.ts
+++ b/extensions/qa-lab/src/mantis/telegram-desktop-builder.runtime.ts
@@ -547,7 +547,7 @@ async function copyRemoteArtifacts(params: {
   remoteOutputDir: string;
   runner: CommandRunner;
 }) {
-  const { host, sshArgs, sshUser } = sshCommand({ inspect: params.inspect });
+  const { host, sshArgs, sshUser } = await sshCommand(params);
   await runCommand({
     command: "rsync",
     args: [

--- a/scripts/e2e/telegram-user-crabbox-proof.ts
+++ b/scripts/e2e/telegram-user-crabbox-proof.ts
@@ -39,6 +39,7 @@ type CrabboxInspect = {
   id?: string;
   slug?: string;
   sshHost?: string;
+  sshFallbackPorts?: string[];
   sshKey?: string;
   sshPort?: string;
   sshUser?: string;
@@ -2035,7 +2036,12 @@ async function inspectCrabbox(opts: Options, root: string, leaseId: string) {
   return JSON.parse(result.stdout) as CrabboxInspect;
 }
 
-function sshArgs(inspect: CrabboxInspect) {
+function crabboxSshPortCandidates(inspect: Pick<CrabboxInspect, "sshFallbackPorts" | "sshPort">) {
+  const ports = [inspect.sshPort?.trim() || "22", ...(inspect.sshFallbackPorts ?? [])];
+  return [...new Set(ports.map((port) => port.trim()).filter(Boolean))];
+}
+
+function sshArgs(inspect: CrabboxInspect, sshPort = inspect.sshPort?.trim() || "22") {
   const sshHost = inspect.sshHost || inspect.host;
   if (!sshHost || !inspect.sshKey || !inspect.sshUser) {
     throw new Error("Crabbox inspect output is missing SSH details.");
@@ -2045,7 +2051,7 @@ function sshArgs(inspect: CrabboxInspect) {
       "-i",
       inspect.sshKey,
       "-p",
-      inspect.sshPort ?? "22",
+      sshPort,
       "-o",
       "IdentitiesOnly=yes",
       "-o",
@@ -2059,7 +2065,7 @@ function sshArgs(inspect: CrabboxInspect) {
       "-i",
       inspect.sshKey,
       "-P",
-      inspect.sshPort ?? "22",
+      sshPort,
       "-o",
       "IdentitiesOnly=yes",
       "-o",
@@ -2069,6 +2075,7 @@ function sshArgs(inspect: CrabboxInspect) {
       "-o",
       "ConnectTimeout=15",
     ],
+    sshPort,
     target: `${inspect.sshUser}@${sshHost}`,
   };
 }
@@ -2076,6 +2083,35 @@ function sshArgs(inspect: CrabboxInspect) {
 function isTransientSshFailure(error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
   return /Connection (?:closed|reset)|Operation timed out|Connection timed out/u.test(message);
+}
+
+function isSshConnectionFailure(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = error && typeof error === "object" && "code" in error ? error.code : undefined;
+  return (
+    code === "ETIMEDOUT" ||
+    isTransientSshFailure(error) ||
+    /Connection refused|Network is unreachable|No route to host/u.test(message)
+  );
+}
+
+export async function selectCrabboxSshPort(params: {
+  inspect: Pick<CrabboxInspect, "sshFallbackPorts" | "sshPort">;
+  probe: (port: string) => Promise<void>;
+}) {
+  let lastError: unknown;
+  for (const port of crabboxSshPortCandidates(params.inspect)) {
+    try {
+      await params.probe(port);
+      return port;
+    } catch (error) {
+      if (!isSshConnectionFailure(error)) {
+        throw error;
+      }
+      lastError = error;
+    }
+  }
+  throw lastError;
 }
 
 async function runRemoteCommand(params: {
@@ -2103,8 +2139,30 @@ async function runRemoteCommand(params: {
   throw lastError;
 }
 
+const selectedSshPorts = new WeakMap<CrabboxInspect, string>();
+
+async function selectedSshArgs(root: string, inspect: CrabboxInspect) {
+  let sshPort = selectedSshPorts.get(inspect);
+  if (!sshPort) {
+    // Probe with a no-op so fallback selection cannot replay a remote command or file transfer.
+    sshPort = await selectCrabboxSshPort({
+      inspect,
+      probe: async (port) => {
+        const ssh = sshArgs(inspect, port);
+        await runCommand({
+          args: [...ssh.base, ssh.target, "exit 0"],
+          command: "ssh",
+          cwd: root,
+        });
+      },
+    });
+    selectedSshPorts.set(inspect, sshPort);
+  }
+  return sshArgs(inspect, sshPort);
+}
+
 async function scpToRemote(root: string, inspect: CrabboxInspect, local: string, remote: string) {
-  const ssh = sshArgs(inspect);
+  const ssh = await selectedSshArgs(root, inspect);
   await runRemoteCommand({
     command: "scp",
     args: [...ssh.scpBase, local, `${ssh.target}:${remote}`],
@@ -2114,7 +2172,7 @@ async function scpToRemote(root: string, inspect: CrabboxInspect, local: string,
 }
 
 async function scpFromRemote(root: string, inspect: CrabboxInspect, remote: string, local: string) {
-  const ssh = sshArgs(inspect);
+  const ssh = await selectedSshArgs(root, inspect);
   await runRemoteCommand({
     command: "scp",
     args: [...ssh.scpBase, `${ssh.target}:${remote}`, local],
@@ -2129,7 +2187,7 @@ async function sshRun(
   remoteCommand: string,
   options: { outputFile?: string; timeoutMs?: number } = {},
 ) {
-  const ssh = sshArgs(inspect);
+  const ssh = await selectedSshArgs(root, inspect);
   return await runRemoteCommand({
     command: "ssh",
     args: [...ssh.base, ssh.target, remoteCommand],
@@ -2176,12 +2234,15 @@ async function startTailscaleFunnelBridge(params: {
   // Keep the SUT local while letting its real Gateway lifecycle own Funnel on
   // the Tailscale-enabled desktop lease; no Tailscale credential leaves Crabbox.
   const proxyPath = path.join(params.localRoot, "tailscale");
+  const ssh = await selectedSshArgs(params.localRoot, params.inspect);
   await writeExecutable(
     proxyPath,
-    renderTailscaleSshProxy({ gatewayPort: params.gatewayPort, inspect: params.inspect }),
+    renderTailscaleSshProxy({
+      gatewayPort: params.gatewayPort,
+      inspect: { ...params.inspect, sshPort: ssh.sshPort },
+    }),
   );
   const tunnelLog = path.join(params.localRoot, "gateway-funnel-tunnel.log");
-  const ssh = sshArgs(params.inspect);
   const tunnelPid = spawnDaemon({
     args: [
       ...ssh.base,

--- a/test/scripts/telegram-user-crabbox-proof.test.ts
+++ b/test/scripts/telegram-user-crabbox-proof.test.ts
@@ -28,6 +28,7 @@ import {
   renderTailscaleSshProxy,
   runCommand,
   runSutContainerAction,
+  selectCrabboxSshPort,
   signalCommandTree,
   stageFullSessionArtifacts,
   startLocalSut,
@@ -267,6 +268,48 @@ describe("telegram user Crabbox proof log polling", () => {
   it("allows cold remote setup to outlive ordinary command timeouts", () => {
     expect(REMOTE_SETUP_COMMAND_TIMEOUT_MS).toBeGreaterThan(COMMAND_TIMEOUT_MS);
     expect(REMOTE_SETUP_COMMAND_TIMEOUT_MS).toBeGreaterThanOrEqual(90 * 60 * 1000);
+  });
+
+  it.each([
+    {
+      inspect: { sshFallbackPorts: ["22", "2222", " 2200 ", "22"], sshPort: "2222" },
+      ports: ["2222", "22", "2200"],
+    },
+    {
+      inspect: { sshFallbackPorts: ["2200", "22", "2200"] },
+      ports: ["22", "2200"],
+    },
+    { inspect: {}, ports: ["22"] },
+  ])("selects ordered, deduplicated SSH candidates: $ports", async ({ inspect, ports }) => {
+    const probes: string[] = [];
+
+    await expect(
+      selectCrabboxSshPort({
+        inspect,
+        probe: async (port) => {
+          probes.push(port);
+          if (port !== ports.at(-1)) {
+            throw new Error("Connection refused");
+          }
+        },
+      }),
+    ).resolves.toBe(ports.at(-1));
+    expect(probes).toEqual(ports);
+  });
+
+  it("does not try a fallback after a non-connection failure", async () => {
+    const probes: string[] = [];
+
+    await expect(
+      selectCrabboxSshPort({
+        inspect: { sshFallbackPorts: ["22"], sshPort: "2222" },
+        probe: async (port) => {
+          probes.push(port);
+          throw new Error("Permission denied (publickey)");
+        },
+      }),
+    ).rejects.toThrow("Permission denied");
+    expect(probes).toEqual(["2222"]);
   });
 
   it("rejects loose numeric log tail limits instead of parsing prefixes", () => {
@@ -532,11 +575,29 @@ describe("telegram user Crabbox proof log polling", () => {
     expect(rejected.stderr).toContain("unsupported proof Tailscale command");
   });
 
-  posixIt("prefers the inspect SSH host over the public host", () => {
+  posixIt("keeps the inspect SSH host when selecting a fallback port", async () => {
     const root = makeTempDir();
     const sshPath = path.join(root, "ssh");
     const argvPath = path.join(root, "ssh-argv.json");
     const proxyPath = path.join(root, "tailscale");
+    const inspect = {
+      host: "public.example",
+      sshFallbackPorts: ["22"],
+      sshHost: "ssh.example",
+      sshKey: "/tmp/proof-key",
+      sshPort: "2222",
+      sshUser: "proof",
+    };
+    const probes: string[] = [];
+    const sshPort = await selectCrabboxSshPort({
+      inspect,
+      probe: async (port) => {
+        probes.push(port);
+        if (port === "2222") {
+          throw new Error("Connection refused");
+        }
+      },
+    });
     writeExecutable(
       sshPath,
       `#!/usr/bin/env node\nimport fs from "node:fs";\nfs.writeFileSync(process.env.ARGV_PATH, JSON.stringify(process.argv.slice(2)));\n`,
@@ -545,13 +606,7 @@ describe("telegram user Crabbox proof log polling", () => {
       proxyPath,
       renderTailscaleSshProxy({
         gatewayPort: 19042,
-        inspect: {
-          host: "public.example",
-          sshHost: "ssh.example",
-          sshKey: "/tmp/proof-key",
-          sshPort: "2222",
-          sshUser: "proof",
-        },
+        inspect: { ...inspect, sshPort },
       }),
     );
 
@@ -566,8 +621,11 @@ describe("telegram user Crabbox proof log polling", () => {
 
     expect(result.status).toBe(0);
     const argv = JSON.parse(fs.readFileSync(argvPath, "utf8"));
+    expect(probes).toEqual(["2222", "22"]);
     expect(argv).toContain("proof@ssh.example");
     expect(argv).not.toContain("proof@public.example");
+    const portFlagIndex = argv.indexOf("-p");
+    expect(argv.slice(portFlagIndex, portFlagIndex + 2)).toEqual(["-p", "22"]);
   });
 
   it("reads only the requested log tail", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenClaw’s non-production Crabbox QA consumers would keep using only the primary `sshPort` from `crabbox inspect --json`, causing remote proof setup or artifact collection to fail when that port was unavailable even though Crabbox advertised a working `sshFallbackPorts` endpoint.

## Why This Change Was Made

Each owner now consumes the public Crabbox inspect contract through a narrow local transport seam. QA Lab selects an ordered reachable SSH candidate before rsync, while the Telegram user proof selects and reuses a working port before SSH/SCP operations. Fallback advances only for connection-level failures, so authentication or command failures are not masked. Both seams preserve `sshHost || host` endpoint precedence. The change does not deep-import the bundled Crabbox plugin or add a cross-owner core abstraction.

## User Impact

Maintainers running Mantis desktop QA or Telegram real-user Crabbox proofs can complete remote setup and artifact collection when the configured primary SSH port is blocked but an advertised fallback port is reachable. Production runtime behavior, configuration, and public OpenClaw APIs are unchanged.

## Evidence

- Final exact head: `eb4c775b4d6466910ce35ecf0bd79d9745fa3e96`, one focused commit and the original 7-file scope.
- Preserved the same-owner #120611 `sshHost || host` precedence together with ordered fallback-port probing in the Telegram seam. Its combined regression proves an unreachable primary selects port 22 while retaining the resolved SSH host.
- Applied the same resolved-endpoint contract in the QA Lab seam. Its fallback regression uses a distinct `sshHost`, proves every connection probe targets it, and proves the returned rsync transport keeps it.
- Inspected the public `sshPort` / `sshFallbackPorts` contract directly in `openclaw/crabbox` at `ce9487f552054326d9209d3ba9606d01a36f5666`: `internal/cli/inspect.go` serializes `StatusView`; `internal/cli/status.go` exposes string `sshPort` plus optional string-array `sshFallbackPorts`; `internal/cli/ssh.go` tries ordered unique primary-plus-fallback candidates.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/mantis/crabbox-runtime.test.ts test/scripts/telegram-user-crabbox-proof.test.ts` — 2 shards passed, 55 tests on the final tree.
- `./node_modules/.bin/oxfmt --check ...` — all 7 touched files formatted.
- `node scripts/run-oxlint.mjs` with `config/tsconfig/oxlint.extensions.json` and `config/tsconfig/oxlint.scripts.json` — passed for the changed extension and script surfaces.
- `git diff --check origin/main...HEAD` — passed.
- `/Users/steipete/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — TruffleHog clean and no accepted/actionable findings on the final committed branch; correctness 0.99.
- The explicit maintainer land decision accepts the deterministic exact-head fallback tests plus direct dependency-contract inspection instead of a newly leased live Crabbox recovery scenario. This is a consciously accepted live/rank-up proof gap; no live recovery is claimed.

AI-assisted: yes. I reviewed the implementation, ownership boundaries, upstream contract, tests, and final diff.
