### PR TITLE
release(2026.8.1): carry wake-ownership and Codex test fixes onto beta.1 candidate

### DIFF
--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -760,18 +760,31 @@ describe("shared Codex app-server client", () => {
   );
 
   it("closes and clears a shared app-server when initialize times out", async () => {
+    vi.useFakeTimers();
     const first = createClientHarness();
     const second = createClientHarness();
     const startSpy = vi
       .spyOn(CodexAppServerClient, "start")
       .mockReturnValueOnce(first.client)
       .mockReturnValueOnce(second.client);
+    let markFirstStarted: () => void = () => undefined;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
 
-    await expect(listCodexAppServerModels({ timeoutMs: 5 })).rejects.toThrow(
+    const firstAcquire = getSharedCodexAppServerClient({
+      timeoutMs: 5,
+      onStartedClient: markFirstStarted,
+    });
+    const firstRejection = expect(firstAcquire).rejects.toThrow(
       "codex app-server initialize timed out",
     );
+    await firstStarted;
+    await vi.advanceTimersByTimeAsync(5);
+    await firstRejection;
     expect(first.process.stdin.destroyed).toBe(true);
 
+    vi.useRealTimers();
     const secondList = listCodexAppServerModels({ timeoutMs: 1000 });
     await sendInitializeResult(second, "openclaw/0.146.1 (macOS; test)");
     await sendEmptyModelList(second);
@@ -870,12 +883,22 @@ describe("shared Codex app-server client", () => {
   });
 
   it("does not wait for isolated initialize after a timeout closes the client", async () => {
+    vi.useFakeTimers();
     const harness = createClientHarness();
     vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
+    let markStarted: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
 
-    await expect(createIsolatedCodexAppServerClient({ timeoutMs: 5 })).rejects.toThrow(
-      "codex app-server initialize timed out",
-    );
+    const client = createIsolatedCodexAppServerClient({
+      timeoutMs: 5,
+      onStartedClient: markStarted,
+    });
+    const rejection = expect(client).rejects.toThrow("codex app-server initialize timed out");
+    await started;
+    await vi.advanceTimersByTimeAsync(5);
+    await rejection;
     expect(harness.process.stdin.destroyed).toBe(true);
   });
 

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -128,7 +128,7 @@ type QueueEmbeddedAgentMessageWithOutcome = (
   sessionId: string,
   message: string,
   options?: EmbeddedAgentQueueMessageOptions,
-) => EmbeddedAgentQueueMessageOutcome;
+) => EmbeddedAgentQueueMessageOutcome | Promise<EmbeddedAgentQueueMessageOutcome>;
 
 function createQueueOutcomeMock(
   queued: boolean,
@@ -1158,6 +1158,53 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       expect(callGateway).not.toHaveBeenCalled();
     },
   );
+
+  it("fences an active completion delivery when sessions_yield takes ownership mid-wait", async () => {
+    let requesterYielded = false;
+    let markWakeStarted: () => void = () => undefined;
+    const wakeStarted = new Promise<void>((resolve) => {
+      markWakeStarted = resolve;
+    });
+    let releaseWake: () => void = () => undefined;
+    const wakeGate = new Promise<void>((resolve) => {
+      releaseWake = resolve;
+    });
+    const queueEmbeddedAgentMessageWithOutcome = vi.fn(async (sessionId: string) => {
+      markWakeStarted();
+      await wakeGate;
+      return {
+        queued: true as const,
+        sessionId,
+        target: "embedded_run" as const,
+        gatewayHealth: "live" as const,
+        enqueuedAtMs: 4_100,
+        deliveredAtMs: 4_200,
+      };
+    });
+    const callGateway = createGatewayMock();
+
+    const delivery = deliverSlackThreadAnnouncement({
+      callGateway,
+      sessionId: "requester-session-1",
+      isActive: true,
+      directIdempotencyKey: "announce-yield-owned-mid-wait",
+      queueEmbeddedAgentMessageWithOutcome,
+      isCompletionOwnedByRequesterYield: () => requesterYielded,
+    });
+    await wakeStarted;
+    requesterYielded = true;
+    releaseWake();
+
+    await expect(delivery).resolves.toMatchObject({
+      delivered: false,
+      path: "none",
+      reason: "source_owner_changed",
+      terminal: true,
+      disposition: "intentional_non_delivery",
+    });
+    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledOnce();
+    expect(callGateway).not.toHaveBeenCalled();
+  });
 
   it("keeps direct external delivery for dormant completion requesters", async () => {
     const callGateway = createGatewayMock();

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -224,7 +224,7 @@ async function resolveActiveWakeWithRetries(
   message: string,
   wakeOptions: EmbeddedAgentQueueMessageOptions,
   signal?: AbortSignal,
-  isSourceSessionEffectsAllowed?: () => boolean,
+  isAttemptAllowed?: () => boolean,
 ): Promise<EmbeddedAgentQueueMessageOutcome | typeof SOURCE_OWNER_CHANGED> {
   // Bound the whole active wake by the caller's delivery window. Each retry
   // passes only the remaining window into transcript-commit waiting so a
@@ -247,10 +247,13 @@ async function resolveActiveWakeWithRetries(
       deliveryTimeoutMs: remainingDeliveryTimeoutMs,
     };
   };
-  const attemptWake = (options: EmbeddedAgentQueueMessageOptions) =>
-    isSourceSessionEffectsAllowed?.() === false
-      ? SOURCE_OWNER_CHANGED
-      : resolveQueueEmbeddedAgentMessageOutcome(sessionId, message, options);
+  const attemptWake = async (options: EmbeddedAgentQueueMessageOptions) => {
+    if (isAttemptAllowed?.() === false) {
+      return SOURCE_OWNER_CHANGED;
+    }
+    const result = await resolveQueueEmbeddedAgentMessageOutcome(sessionId, message, options);
+    return isAttemptAllowed?.() === false ? SOURCE_OWNER_CHANGED : result;
+  };
   let outcome = await attemptWake(currentOptions);
   const compactionRetryDelaysMs = resolveCompactionSteerRetryDelaysMs();
   let compactionRetryIndex = 0;
@@ -261,7 +264,7 @@ async function resolveActiveWakeWithRetries(
     if (outcome.queued || signal?.aborted) {
       break;
     }
-    if (isSourceSessionEffectsAllowed?.() === false) {
+    if (isAttemptAllowed?.() === false) {
       outcome = SOURCE_OWNER_CHANGED;
       break;
     }
@@ -958,7 +961,10 @@ async function sendSubagentAnnounceDirectly(params: {
         error: "requester session abandoned after timeout",
       };
     }
-    if (params.expectsCompletionMessage && params.isCompletionOwnedByRequesterYield?.()) {
+    const isCompletionDeliveryAllowed = () =>
+      params.isSourceSessionEffectsAllowed?.() !== false &&
+      !(params.expectsCompletionMessage && params.isCompletionOwnedByRequesterYield?.());
+    if (!isCompletionDeliveryAllowed()) {
       // sessions_yield owns the post-turn synthesis. Starting or steering a
       // requester turn here would replay the original fanout during handoff.
       return {
@@ -977,7 +983,7 @@ async function sendSubagentAnnounceDirectly(params: {
         deliveryTarget,
         internalEvents: params.internalEvents,
         onDeliveryResult: params.onDeliveryResult,
-        isSourceSessionEffectsAllowed: params.isSourceSessionEffectsAllowed,
+        isSourceSessionEffectsAllowed: isCompletionDeliveryAllowed,
       });
     const completionSourceReplyDeliveryMode = requiresMessageToolDelivery
       ? "message_tool_only"
@@ -1014,7 +1020,7 @@ async function sendSubagentAnnounceDirectly(params: {
         params.triggerMessage,
         wakeOptions,
         params.signal,
-        params.isSourceSessionEffectsAllowed,
+        isCompletionDeliveryAllowed,
       );
       if (wakeOutcome === SOURCE_OWNER_CHANGED) {
         return sourceOwnerChangedResult();
@@ -1092,9 +1098,9 @@ async function sendSubagentAnnounceDirectly(params: {
           ? "completion direct announce agent call"
           : "direct announce agent call",
         signal: params.signal,
-        isAttemptAllowed: params.isSourceSessionEffectsAllowed,
+        isAttemptAllowed: isCompletionDeliveryAllowed,
         run: async () => {
-          if (params.isSourceSessionEffectsAllowed?.() === false) {
+          if (!isCompletionDeliveryAllowed()) {
             throw new SourceOwnerChangedError();
           }
           return await runAnnounceAgentCall({
@@ -1120,6 +1126,9 @@ async function sendSubagentAnnounceDirectly(params: {
           });
         },
       });
+      if (!isCompletionDeliveryAllowed()) {
+        return sourceOwnerChangedResult();
+      }
     } catch (err) {
       if (err instanceof SourceOwnerChangedError) {
         return sourceOwnerChangedResult();

--- a/src/agents/subagent-registry-requester-yield.test.ts
+++ b/src/agents/subagent-registry-requester-yield.test.ts
@@ -166,10 +166,11 @@ describe("settleRequesterTurnAfterSessionSpawns", () => {
       requesterYieldBatch: true,
       afterRequesterYield: true,
     });
-    expect(schedule).not.toHaveBeenCalled();
+    expect(entry.delivery?.disposition).toBe("intentional_non_delivery");
+    expect(schedule).toHaveBeenCalledExactlyOnceWith(entry.runId, entry);
   });
 
-  it("persists a mixed delivered and in-progress yielded batch without scheduling", () => {
+  it("persists a mixed delivered and in-progress yielded batch before scheduling", () => {
     const alpha = makeRun("run-alpha");
     const beta = makeRun("run-beta");
     beta.delivery = { status: "in_progress" };
@@ -204,8 +205,9 @@ describe("settleRequesterTurnAfterSessionSpawns", () => {
     expect(beta.requesterSettleWake).toEqual(frozenState);
     expect(alpha.requesterTurnRunId).toBeUndefined();
     expect(beta.requesterTurnRunId).toBeUndefined();
-    expect(calls).toEqual(["persist"]);
-    expect(schedule).not.toHaveBeenCalled();
+    expect(beta.delivery?.disposition).toBe("intentional_non_delivery");
+    expect(calls).toEqual(["persist", "schedule"]);
+    expect(schedule).toHaveBeenCalledExactlyOnceWith(alpha.runId, alpha);
   });
 
   it.each([true, false])(

--- a/src/agents/subagent-registry-requester-yield.ts
+++ b/src/agents/subagent-registry-requester-yield.ts
@@ -81,6 +81,7 @@ export function settleRequesterTurnAfterSessionSpawns(params: {
   }
   const batchRunIds = entries.map((entry) => entry.runId).toSorted();
   const previousStates = entries.map((entry) => ({
+    delivery: structuredClone(entry.delivery),
     requesterSettleWake: structuredClone(entry.requesterSettleWake),
     requesterTurnRunId: entry.requesterTurnRunId,
     requesterTurnYielded: entry.requesterTurnYielded,
@@ -92,11 +93,18 @@ export function settleRequesterTurnAfterSessionSpawns(params: {
       Math.max(0, ...entries.map((entry) => entry.requesterSettleWake?.rearmGeneration ?? 0)) + 1;
     for (const entry of entries) {
       const existing = entry.requesterSettleWake;
+      const completionEnded = typeof entry.execution.endedAt === "number";
       // An in-progress delivery may already target the requester run being aborted.
       // Re-arm it like a delivered result so that completion cannot die with that turn.
-      const completionMayBeAttachedToYieldedTurn =
-        typeof entry.execution.endedAt === "number" &&
-        (entry.delivery?.status === "delivered" || entry.delivery?.status === "in_progress");
+      const completionMayBeAttachedToYieldedTurn = completionEnded;
+      if (completionEnded && entry.delivery?.status !== "delivered") {
+        // The persisted yielded batch now owns terminal delivery. Mark the old
+        // per-child attempt terminal so it cannot keep the batch unsettled.
+        entry.delivery = {
+          ...(entry.delivery ?? { status: "pending" }),
+          disposition: "intentional_non_delivery",
+        };
+      }
       entry.requesterSettleWake = {
         status: "pending",
         attemptCount: 0,
@@ -132,6 +140,7 @@ export function settleRequesterTurnAfterSessionSpawns(params: {
     entries.forEach((entry, index) => {
       const previous = previousStates[index];
       params.runs.set(entry.runId, entry);
+      entry.delivery = previous?.delivery;
       entry.requesterSettleWake = previous?.requesterSettleWake;
       entry.requesterTurnRunId = previous?.requesterTurnRunId;
       entry.requesterTurnYielded = previous?.requesterTurnYielded;
@@ -142,12 +151,9 @@ export function settleRequesterTurnAfterSessionSpawns(params: {
 
   if (
     rearmGeneration !== undefined &&
-    entries.every(
-      (entry) =>
-        typeof entry.execution.endedAt === "number" && entry.delivery?.status === "delivered",
-    )
+    entries.every((entry) => typeof entry.execution.endedAt === "number")
   ) {
-    // Active children keep the frozen batch but let their normal cleanup owner schedule it.
+    // Active children keep the frozen batch; their normal completion owner schedules it.
     params.schedule(firstEntry.runId, firstEntry);
   }
   return true;

--- a/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -383,7 +383,7 @@ describe("subagent registry lifecycle error grace", () => {
       });
   }
 
-  it("lets the delivered cleanup own a yielded batch after a stale wake loses generation", async () => {
+  it("lets requester settlement own a yielded batch while child delivery is in progress", async () => {
     const requesterTurnRunId = "run-requester-yield-race";
     const alphaSessionKey = "agent:main:subagent:yield-alpha";
     const betaSessionKey = "agent:main:subagent:yield-beta";
@@ -456,6 +456,7 @@ describe("subagent registry lifecycle error grace", () => {
       yieldedBatch.map((run) => ({
         runId: run.runId,
         delivery: run.delivery?.status,
+        disposition: run.delivery?.disposition,
         nextAttemptAt: run.requesterSettleWake?.nextAttemptAt,
         rearmGeneration: run.requesterSettleWake?.rearmGeneration,
       })),
@@ -463,14 +464,16 @@ describe("subagent registry lifecycle error grace", () => {
       {
         runId: "run-yield-alpha",
         delivery: "delivered",
+        disposition: "delivered",
         nextAttemptAt: undefined,
-        rearmGeneration: 1,
+        rearmGeneration: undefined,
       },
       {
         runId: "run-yield-beta",
         delivery: "in_progress",
+        disposition: "intentional_non_delivery",
         nextAttemptAt: undefined,
-        rearmGeneration: 1,
+        rearmGeneration: undefined,
       },
     ]);
     const requesterWakeCalls = () =>
@@ -482,11 +485,11 @@ describe("subagent registry lifecycle error grace", () => {
           idempotencyKey.startsWith("announce:requester-settle:")
         );
       });
-    expect(requesterWakeCalls()).toHaveLength(0);
+    await waitForAgentCallCount(3);
+    expect(requesterWakeCalls()).toHaveLength(1);
 
     agentCallGates.delete(betaSessionKey);
     releaseBetaDelivery?.();
-    await waitForAgentCallCount(3);
     await waitForDeliveredCleanup("run-yield-alpha");
     await waitForDeliveredCleanup("run-yield-beta");
 


### PR DESCRIPTION
## What Problem This Solves

Carries two attempt-3 validation fixes onto the 2026.8.1-beta.1 candidate (partial cherry-pick of main d9080cfff86c; harness-script parts intentionally excluded — they run from the trusted main snapshot):

1. The requester wake-ownership race: a yielded parent could hang forever when its child completed during the yield window (QA Lab parity lane failure; real user-facing product bug).
2. The Codex shared-client test flake fix (deterministic fake-timer seam) — the candidate runs these test bytes in plugin-prerelease.

## Evidence

Focused suites green on this branch (shared-client + requester-yield + announce-delivery, 2 shards). Main-side landing (PR #120538) carried 415 tests, tsgo, deadcode, determinism 12×, autoreview clean (0.94), and sibling `../codex` contract citations.
