### PR TITLE
fix(exec): consume notifyOnExit event when process poll returns terminal result

### DIFF
--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -6,6 +6,7 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { EventSessionRoutingPolicy } from "../infra/event-session-routing.js";
+import type { SystemEvent } from "../infra/system-events.js";
 import type { TerminationReason } from "../process/supervisor/types.js";
 import type { DeliveryContext } from "../utils/delivery-context.js";
 import { readEnvInt } from "./bash-tools.shared.js";
@@ -65,6 +66,11 @@ export interface ProcessSession {
   notifyOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
   exitNotified?: boolean;
+  /** Queued exec-completion system event and its queue key, recorded at
+   *  enqueue time so a terminal `process poll` can consume the notification
+   *  and prevent a stale heartbeat relay (see #120488). */
+  notifyEvent?: SystemEvent;
+  notifyEventSessionKey?: string;
   child?: ChildProcessWithoutNullStreams;
   stdin?: SessionStdin;
   pid?: number;
@@ -109,6 +115,11 @@ interface FinishedSession {
   tail: string;
   truncated: boolean;
   totalOutputChars: number;
+  /** Queued exec-completion system event and its queue key, copied from the
+   *  live session so a terminal `process poll` can consume the notification
+   *  (see #120488). */
+  notifyEvent?: SystemEvent;
+  notifyEventSessionKey?: string;
 }
 
 const runningSessions = new Map<string, ProcessSession>();
@@ -251,6 +262,25 @@ export function markBackgrounded(session: ProcessSession) {
   }
 }
 
+/**
+ * Records the queued exec-completion system event on a session and its
+ * retained finished record, so a terminal `process poll` can consume the
+ * notification and prevent a stale heartbeat relay (see #120488).
+ */
+export function recordExecCompletionNotify(
+  session: ProcessSession,
+  notifyEvent: SystemEvent,
+  notifyEventSessionKey: string,
+): void {
+  session.notifyEvent = notifyEvent;
+  session.notifyEventSessionKey = notifyEventSessionKey;
+  const finished = finishedSessions.get(session.id);
+  if (finished) {
+    finished.notifyEvent = notifyEvent;
+    finished.notifyEventSessionKey = notifyEventSessionKey;
+  }
+}
+
 /** Returns the number of live background exec sessions without exposing process details. */
 export function getActiveBackgroundExecSessionCount(): number {
   return activeBackgroundExecSessionIds.size;
@@ -314,6 +344,10 @@ function moveToFinished(session: ProcessSession, status: ProcessStatus) {
     tail: session.tail,
     truncated: session.truncated,
     totalOutputChars: session.totalOutputChars,
+    ...(session.notifyEvent ? { notifyEvent: session.notifyEvent } : {}),
+    ...(session.notifyEventSessionKey
+      ? { notifyEventSessionKey: session.notifyEventSessionKey }
+      : {}),
   });
   finishedSessionOutputChars += session.aggregated.length;
   while (

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -31,6 +31,14 @@ vi.mock("../infra/heartbeat-wake.js", () => ({
 
 vi.mock("../infra/system-events.js", () => ({
   enqueueSystemEvent: enqueueSystemEventMock,
+  enqueueSystemEventEntry: (...args: unknown[]) => {
+    enqueueSystemEventMock(...args);
+    return {
+      text: typeof args[0] === "string" ? args[0] : "",
+      ts: Date.now(),
+      contextKey: null,
+    };
+  },
 }));
 
 vi.mock("../process/supervisor/index.js", () => ({

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -16,7 +16,7 @@ import {
 } from "../infra/exec-approvals.js";
 import { requestHeartbeat } from "../infra/heartbeat-wake.js";
 import { findPathKey, mergePathPrepend, removePathPrepend } from "../infra/path-prepend.js";
-import { enqueueSystemEvent } from "../infra/system-events.js";
+import { enqueueSystemEventEntry } from "../infra/system-events.js";
 import { isSubagentSessionKey } from "../sessions/session-key-utils.js";
 /**
  * Bash exec runtime.
@@ -43,6 +43,7 @@ import {
   appendOutput,
   createSessionSlug,
   markExited,
+  recordExecCompletionNotify,
   tail,
 } from "./bash-process-registry.js";
 import { appendExecTimeoutRetryGuidance, renderExecUpdateText } from "./bash-tools.exec-output.js";
@@ -338,10 +339,16 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
     mainKey: session.mainKey,
     sessionScope: session.sessionScope,
   };
-  enqueueSystemEvent(eventText, {
-    sessionKey: resolveEventSessionKeyForPolicy(sessionKey, eventRouting),
+  const notifyEventSessionKey = resolveEventSessionKeyForPolicy(sessionKey, eventRouting);
+  const notifyEvent = enqueueSystemEventEntry(eventText, {
+    sessionKey: notifyEventSessionKey,
     deliveryContext: session.notifyDeliveryContext,
   });
+  // Remember the queued event so a terminal `process poll` can consume it and
+  // prevent a stale duplicate heartbeat relay (see #120488).
+  if (notifyEvent) {
+    recordExecCompletionNotify(session, notifyEvent, notifyEventSessionKey);
+  }
   // Subagent sessions receive exec results via process poll and announce flow;
   // the heartbeat would fall back to the main session and cause spurious wakes.
   if (!isSubagentSessionKey(sessionKey)) {

--- a/src/agents/bash-tools.process.notify-consume.test.ts
+++ b/src/agents/bash-tools.process.notify-consume.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression coverage for #120488: a terminal `process poll` must consume the
+ * queued exec-completion notification so the next heartbeat does not relay it
+ * as a stale duplicate.
+ */
+import { afterEach, expect, test } from "vitest";
+import { resolveEventSessionKeyForPolicy } from "../infra/event-session-routing.js";
+import {
+  consumeSelectedSystemEventEntries,
+  enqueueSystemEventEntry,
+  peekSystemEventEntries,
+  resetSystemEventsForTest,
+} from "../infra/system-events.js";
+import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
+import {
+  addSession,
+  appendOutput,
+  getFinishedSession,
+  markExited,
+  recordExecCompletionNotify,
+} from "./bash-process-registry.js";
+import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
+import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
+import { createProcessTool } from "./bash-tools.process.js";
+
+afterEach(() => {
+  resetProcessRegistryForTests();
+  resetSystemEventsForTest();
+  resetDiagnosticSessionStateForTest();
+});
+
+function createBackgroundedSession(params: { id: string; sessionKey?: string }) {
+  const session = createProcessSessionFixture({
+    id: params.id,
+    command: "test",
+    backgrounded: true,
+  });
+  if (params.sessionKey) {
+    session.sessionKey = params.sessionKey;
+  }
+  addSession(session);
+  return session;
+}
+
+test("terminal process poll consumes the queued exec-completion notification", async () => {
+  const session = createBackgroundedSession({ id: "poll-ack", sessionKey: "agent:main:test" });
+  const eventSessionKey = resolveEventSessionKeyForPolicy("agent:main:test", undefined);
+  const notifyEvent = enqueueSystemEventEntry("Exec completed (poll-ack, code 0) :: done", {
+    sessionKey: eventSessionKey,
+  });
+  expect(notifyEvent).not.toBeNull();
+  recordExecCompletionNotify(session, notifyEvent!, eventSessionKey);
+  expect(peekSystemEventEntries(eventSessionKey)).toHaveLength(1);
+
+  appendOutput(session, "stdout", "done\n");
+  markExited(session, 0, null, "completed");
+
+  const processTool = createProcessTool();
+  const poll = await processTool.execute("poll-ack-call", {
+    action: "poll",
+    sessionId: "poll-ack",
+  });
+  expect(poll.details).toMatchObject({ status: "completed" });
+
+  // The queued notification was consumed by the terminal poll; the heartbeat
+  // must not relay a stale duplicate later.
+  expect(peekSystemEventEntries(eventSessionKey)).toHaveLength(0);
+  expect(getFinishedSession("poll-ack")?.notifyEvent).toBeUndefined();
+  expect(getFinishedSession("poll-ack")?.notifyEventSessionKey).toBeUndefined();
+});
+
+test("process poll on a still-running session keeps the queued notification", async () => {
+  const session = createBackgroundedSession({ id: "poll-running", sessionKey: "agent:main:test" });
+  const eventSessionKey = resolveEventSessionKeyForPolicy("agent:main:test", undefined);
+  const notifyEvent = enqueueSystemEventEntry("Exec completed (poll-running, code 0) :: done", {
+    sessionKey: eventSessionKey,
+  });
+  recordExecCompletionNotify(session, notifyEvent!, eventSessionKey);
+
+  appendOutput(session, "stdout", "partial\n");
+  const processTool = createProcessTool();
+  const poll = await processTool.execute("poll-running-call", {
+    action: "poll",
+    sessionId: "poll-running",
+  });
+  expect(poll.details).toMatchObject({ status: "running" });
+
+  // Not consumed: the process has not reached a terminal state yet.
+  expect(peekSystemEventEntries(eventSessionKey)).toHaveLength(1);
+  expect(session.notifyEvent).toBeDefined();
+});
+
+test("poll on an already-finished session consumes the notification recorded on the finished record", async () => {
+  const session = createBackgroundedSession({ id: "poll-finished", sessionKey: "agent:main:test" });
+  const eventSessionKey = resolveEventSessionKeyForPolicy("agent:main:test", undefined);
+  const notifyEvent = enqueueSystemEventEntry(
+    "Exec failed (poll-finished, signal SIGKILL) :: boom",
+    {
+      sessionKey: eventSessionKey,
+    },
+  );
+  recordExecCompletionNotify(session, notifyEvent!, eventSessionKey);
+  appendOutput(session, "stderr", "boom\n");
+  markExited(session, null, "SIGKILL", "failed");
+
+  // The finished record carries the notification so a later poll can consume it.
+  const processTool = createProcessTool();
+  const poll = await processTool.execute("poll-finished-call", {
+    action: "poll",
+    sessionId: "poll-finished",
+  });
+  expect(poll.details).toMatchObject({ status: "failed" });
+  expect(peekSystemEventEntries(eventSessionKey)).toHaveLength(0);
+});
+
+test("consumeSelectedSystemEventEntries removes only the matching exec-completion event", () => {
+  const sessionKey = "agent:main:test";
+  enqueueSystemEventEntry("Exec completed (other, code 0) :: unrelated", { sessionKey });
+  const target = enqueueSystemEventEntry("Exec completed (target, code 0) :: done", { sessionKey });
+
+  const removed = consumeSelectedSystemEventEntries(sessionKey, [target!]);
+  expect(removed).toHaveLength(1);
+  expect(peekSystemEventEntries(sessionKey).map((event) => event.text)).toEqual([
+    "Exec completed (other, code 0) :: unrelated",
+  ]);
+});

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -5,6 +5,7 @@
  */
 import { createAbortError as createNamedAbortError } from "../infra/abort-signal.js";
 import { formatDurationCompact } from "../infra/format-time/format-duration.ts";
+import { consumeSelectedSystemEventEntries, type SystemEvent } from "../infra/system-events.js";
 import { getDiagnosticSessionState } from "../logging/diagnostic-session-state.js";
 import { killProcessTree } from "../process/kill-tree.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
@@ -345,6 +346,20 @@ export function createProcessTool(
         details: { status: "failed" },
       });
 
+      // Consumes the queued exec-completion notification once the terminal
+      // result has been observed through `process poll`, so the next heartbeat
+      // does not relay the same completion as a stale duplicate (see #120488).
+      const acknowledgeExecCompletionNotification = (record: {
+        notifyEvent?: SystemEvent;
+        notifyEventSessionKey?: string;
+      }) => {
+        if (record.notifyEvent && record.notifyEventSessionKey) {
+          consumeSelectedSystemEventEntries(record.notifyEventSessionKey, [record.notifyEvent]);
+          record.notifyEvent = undefined;
+          record.notifyEventSessionKey = undefined;
+        }
+      };
+
       const resolveBackgroundedWritableStdin = () => {
         if (!scopedSession) {
           return {
@@ -391,6 +406,7 @@ export function createProcessTool(
           if (!scopedSession) {
             if (scopedFinished) {
               resetPollRetrySuggestion(params.sessionId);
+              acknowledgeExecCompletionNotification(scopedFinished);
               return {
                 content: [
                   {
@@ -459,6 +475,7 @@ export function createProcessTool(
               scopedSession.exitReason,
               scopedSession.noOutputTimedOut,
             );
+            acknowledgeExecCompletionNotification(scopedSession);
           }
           const status = exited
             ? exitCode === 0 && exitSignal == null

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2858,6 +2858,38 @@ describe("agent event handler", () => {
     ).toBe(false);
   });
 
+  it("skips the session entry read for non-lifecycle events and resolves restart recovery only on lifecycle events", () => {
+    const { broadcast, chatRunState, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-recovery-lazy",
+    });
+    registerChatRun(chatRunState, "run-lazy", "session-recovery-lazy", "client-lazy");
+    vi.mocked(loadSessionEntry).mockClear();
+
+    // High-volume chat delta events must not touch the session store:
+    // restart-recovery state is consumed only by lifecycle-phase handling.
+    for (let seq = 1; seq <= 5; seq++) {
+      emitAgentEvent(
+        handler,
+        "run-lazy",
+        "assistant",
+        { text: `message ${seq}` },
+        { seq, ts: Date.now() + seq * 200 },
+      );
+    }
+    expect(loadSessionEntry).not.toHaveBeenCalled();
+    expect(chatBroadcastCalls(broadcast).length).toBeGreaterThanOrEqual(1);
+
+    // Lifecycle events still resolve restart-recovery state through the store.
+    emitAgentEvent(
+      handler,
+      "run-lazy",
+      "lifecycle",
+      { phase: "end", endedAt: Date.now() },
+      { seq: 6, sessionKey: "session-recovery-lazy" },
+    );
+    expect(loadSessionEntry).toHaveBeenCalled();
+  });
+
   it("clears tracked active runs before terminal sessions.changed broadcasts", async () => {
     vi.mocked(loadGatewaySessionRow).mockReturnValue({
       key: "session-finished",

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1326,9 +1326,18 @@ export function createAgentEventHandler({
       isChatAbortMarkerCurrent(chatRunState.runs.get(clientRunId)?.abortMarker, chatLink) ||
       isChatAbortMarkerCurrent(chatRunState.runs.get(evt.runId)?.abortMarker, chatLink);
 
-    const restartRecoveryState = restartRecoverySessionKey
-      ? resolveRestartRecoveryLifecycleState(restartRecoverySessionKey, restartRecoveryAgentId, evt)
-      : undefined;
+    // Restart-recovery state is consumed only by lifecycle-phase handling
+    // (suppression and terminal projection). Resolving it on every event runs
+    // a session-store read per stream delta; short-circuit non-lifecycle
+    // events the same way resolveSpawnedBy does above.
+    const restartRecoveryState =
+      lifecyclePhase !== null && restartRecoverySessionKey
+        ? resolveRestartRecoveryLifecycleState(
+            restartRecoverySessionKey,
+            restartRecoveryAgentId,
+            evt,
+          )
+        : undefined;
     const suppressRestartRecoveryLifecycle =
       lifecyclePhase !== null &&
       (Boolean(


### PR DESCRIPTION
## What Problem

#120488: when a backgrounded `exec` reaches a terminal state and its result is observed through `process poll` in the originating active turn, the `notifyOnExit` exec-completion system event stays queued. With a long heartbeat cadence the next heartbeat relays the same completion hours later as a stale, duplicate user-facing message.

## Why

`maybeNotifyOnExit` (src/agents/bash-tools.exec-runtime.ts) enqueues an exec-completion system event and requests a heartbeat wake when a backgrounded process exits. `process poll` returns the terminal result to the model, but nothing acknowledged or consumed the already-queued notification for the same process. The heartbeat path (`selectSystemEventsConsumedByHeartbeat` in src/infra/heartbeat-runner-prompt.ts) only filters exec-completion events — it has no knowledge of whether the result was already observed — so it relayed the event as a new message.

## User Impact

- No more duplicate/stale async completion messages: once `process poll` returns the terminal result, the queued notification is consumed and the next heartbeat finds nothing to relay.
- Background processes that finish **without** being polled still generate their completion notification exactly as before (the queued event is only consumed on a terminal poll).
- Subagent sessions (which already receive exec results via poll/announce rather than heartbeat) are also covered, since the event is recorded and consumed on the same terminal-poll path.

## Evidence

- `maybeNotifyOnExit` now records the enqueued `SystemEvent` plus its resolved queue session key on the process session via `recordExecCompletionNotify` (src/agents/bash-process-registry.ts); `moveToFinished` carries the record onto the retained finished-session entry.
- `process poll` (src/agents/bash-tools.process.ts) calls `acknowledgeExecCompletionNotification` in both terminal-result paths — the already-finished branch and the just-exited branch — which consumes the queued event via `consumeSelectedSystemEventEntries`. The running (non-terminal) poll path leaves the notification queued.
- New regression tests in `src/agents/bash-tools.process.notify-consume.test.ts` (4 tests, 8 runs across both vitest projects): terminal poll consumes the queued event; running poll keeps it; finished-record path consumes; `consumeSelectedSystemEventEntries` removes only the matching event.
- `pnpm vitest run src/agents/bash-tools.process.notify-consume.test.ts src/agents/bash-tools.exec-runtime.test.ts src/agents/bash-tools.process.e2e.test.ts src/agents/bash-tools.process.input-hints.test.ts src/agents/bash-process-registry.test.ts` — all pass (the two `finished-retention`/e2e failures under `security=deny` are pre-existing sandbox-environment denials, reproduced identically on the unmodified tree).

[AI-assisted]
