### PR TITLE
refactor(github-copilot): narrow runtime facade

### DIFF
--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -22,7 +22,6 @@ import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { runGitHubCopilotDeviceFlow } from "./login.js";
 
 const mocks = vi.hoisted(() => ({
-  githubCopilotLoginCommand: vi.fn(),
   fetchWithSsrFGuard: vi.fn<typeof fetchWithSsrFGuard>(async (params) => ({
     response: await fetch(params.url, params.init),
     finalUrl: params.url,
@@ -50,7 +49,6 @@ vi.mock("./register.runtime.js", () => ({
   DEFAULT_COPILOT_API_BASE_URL: "https://api.githubcopilot.test",
   resolveCopilotRuntimeAuth: mocks.resolveCopilotRuntimeAuth,
   resolveCopilotStarterModel: mocks.resolveCopilotStarterModel,
-  githubCopilotLoginCommand: mocks.githubCopilotLoginCommand,
   fetchCopilotUsage: vi.fn(),
 }));
 
@@ -663,7 +661,6 @@ describe("github-copilot plugin", () => {
       message: "GitHub Copilot auth already exists. Re-run login?",
       initialValue: false,
     });
-    expect(mocks.githubCopilotLoginCommand).not.toHaveBeenCalled();
     expect(result).toEqual({
       profiles: [
         {
@@ -1012,7 +1009,6 @@ describe("github-copilot plugin", () => {
         message: "GitHub Copilot auth already exists. Re-run login?",
         initialValue: false,
       });
-      expect(mocks.githubCopilotLoginCommand).not.toHaveBeenCalled();
       if (!result) {
         throw new Error("Expected GitHub Copilot auth result");
       }
@@ -1287,7 +1283,6 @@ describe("github-copilot plugin", () => {
       message: "GitHub Copilot auth already exists. Re-run login?",
       initialValue: false,
     });
-    expect(mocks.githubCopilotLoginCommand).not.toHaveBeenCalled();
     expect(result.profiles[0]?.credential).toEqual({
       type: "token",
       provider: "github-copilot",

--- a/extensions/github-copilot/register.runtime.ts
+++ b/extensions/github-copilot/register.runtime.ts
@@ -1,7 +1,6 @@
 // Github Copilot plugin module implements register behavior.
-export {
-  DEFAULT_COPILOT_API_BASE_URL,
-  resolveCopilotRuntimeAuth,
-} from "./runtime-auth.js";
+export { DEFAULT_COPILOT_API_BASE_URL } from "./runtime-auth.js";
+export { resolveCopilotRuntimeAuth } from "./runtime-auth.js";
+
 export { resolveCopilotStarterModel } from "./starter-model.js";
 export { fetchCopilotUsage } from "./usage.js";

--- a/extensions/github-copilot/register.runtime.ts
+++ b/extensions/github-copilot/register.runtime.ts
@@ -1,27 +1,7 @@
 // Github Copilot plugin module implements register behavior.
-import {
-  coerceSecretRef,
-  ensureAuthProfileStore,
-  listProfilesForProvider,
-} from "openclaw/plugin-sdk/provider-auth";
-import { githubCopilotLoginCommand } from "./login.js";
-import { PROVIDER_ID, resolveCopilotForwardCompatModel } from "./models.js";
-import { DEFAULT_COPILOT_API_BASE_URL, resolveCopilotRuntimeAuth } from "./runtime-auth.js";
-import { resolveCopilotStarterModel } from "./starter-model.js";
-import { wrapCopilotAnthropicStream, wrapCopilotProviderStream } from "./stream.js";
-import { fetchCopilotUsage } from "./usage.js";
-
 export {
-  coerceSecretRef,
   DEFAULT_COPILOT_API_BASE_URL,
-  ensureAuthProfileStore,
-  fetchCopilotUsage,
-  githubCopilotLoginCommand,
-  listProfilesForProvider,
-  PROVIDER_ID,
   resolveCopilotRuntimeAuth,
-  resolveCopilotStarterModel,
-  resolveCopilotForwardCompatModel,
-  wrapCopilotAnthropicStream,
-  wrapCopilotProviderStream,
-};
+} from "./runtime-auth.js";
+export { resolveCopilotStarterModel } from "./starter-model.js";
+export { fetchCopilotUsage } from "./usage.js";


### PR DESCRIPTION
## What Problem This Solves

Resolves an internal maintenance problem where the GitHub Copilot plugin's lazy runtime facade exposed eight symbols that no production consumer loads through that boundary. The broad barrel also made unrelated auth, login, model, and stream ownership look coupled, while tests mocked and asserted a login command that the plugin entrypoint never imported from the runtime facade.

## Why This Change Was Made

The runtime facade now directly exports only the four symbols loaded by `index.ts` and `dynamic-models.ts`: the default API base URL, runtime auth resolver, starter-model resolver, and usage fetcher. The eight unused re-exports and their static imports are removed, along with five stale login-command mock/assertion lines. The deprecated login facade remains owned by `api.ts`; removing that separate compatibility surface was explicitly rejected as out of scope.

This is an AI-assisted change from authorized repair sweep task #8.

## User Impact

No user-visible behavior changes. The plugin keeps the same auth, discovery, usage, and stream behavior with a smaller, more accurate lazy runtime boundary.

Production LOC: +4/-25, net -21. Test LOC: +0/-5, net -5.

## Evidence

- Full-tree consumer/export scan confirmed production destructures only the four retained runtime symbols; removed symbols continue through their direct owner modules.
- Private package and SDK-facade inspection confirmed the legacy login command loads `api.js`, not `register.runtime.js`.
- Open-PR overlap check found no PR touching `register.runtime.ts`; three PRs touching `index.test.ts` modify unrelated thinking/replay cases.
- `node scripts/run-vitest.mjs extensions/github-copilot/index.test.ts extensions/github-copilot/provider-discovery.contract.test.ts extensions/github-copilot/stream.test.ts` — 3 files, 60 tests passed on the corrected checkout.
- `git diff --check` — passed.
- Remote repository-wide `pnpm format:check` and `pnpm build` — AWS Crabbox run `run_b2dda8e91f77`, exit 0.
- Mandatory complete-branch autoreview — no accepted/actionable findings.
- Separate read-only exact-head review — no actionable findings; judged the owner-boundary cleanup behavior-neutral and best-fit.
- Exact reviewed head: `b4dd9596a3f386bec06ac163098990923cc4f892`.

Exact-head CI and ClawSweeper state will be verified before landing.
