### PR TITLE
fix(agents): preserve retry usage chronology

### DIFF
--- a/src/agents/embedded-agent-runner/run.attempt-normalization.direct.test.ts
+++ b/src/agents/embedded-agent-runner/run.attempt-normalization.direct.test.ts
@@ -27,6 +27,19 @@ function makeAttempt(
   };
 }
 
+function makeCliUsageAssistant(stopReason: "error" | "stop", text = "legacy reply") {
+  return {
+    role: "assistant",
+    api: "cli",
+    provider: "openai",
+    model: "gpt-5.6-luna",
+    content: [{ type: "text", text }],
+    usage: { input: 128_814, output: 3_000, cacheRead: 992_953, totalTokens: 1_124_767 },
+    stopReason,
+    timestamp: 1,
+  };
+}
+
 function makePromptState(options: { waitForPersistence?: () => Promise<void> } = {}) {
   const activePrompt = { persisted: false, internal: false };
   const state = {
@@ -243,16 +256,7 @@ describe("normalizeEmbeddedRunAttempt", () => {
 
   it("does not promote historical CLI usage without context provenance", async () => {
     const state = makePromptState();
-    const legacyAssistant = {
-      role: "assistant",
-      api: "cli",
-      provider: "openai",
-      model: "gpt-5.6-luna",
-      content: [{ type: "text", text: "legacy reply" }],
-      usage: { input: 128_814, output: 3_000, cacheRead: 992_953, totalTokens: 1_124_767 },
-      stopReason: "error",
-      timestamp: 1,
-    };
+    const legacyAssistant = makeCliUsageAssistant("error");
     const attempt = makeAttempt();
     attempt.messagesSnapshot = [legacyAssistant] as never;
     attempt.lastAssistant = legacyAssistant as never;
@@ -268,16 +272,7 @@ describe("normalizeEmbeddedRunAttempt", () => {
 
   it("keeps the unavailable sentinel across a retry instead of reviving prior usage", async () => {
     const state = makePromptState();
-    const legacyAssistant = {
-      role: "assistant",
-      api: "cli",
-      provider: "openai",
-      model: "gpt-5.6-luna",
-      content: [{ type: "text", text: "legacy reply" }],
-      usage: { input: 128_814, output: 3_000, cacheRead: 992_953, totalTokens: 1_124_767 },
-      stopReason: "stop",
-      timestamp: 1,
-    };
+    const legacyAssistant = makeCliUsageAssistant("stop");
     const attempt = makeAttempt({
       route: "compact_only",
       handled: true,
@@ -285,6 +280,7 @@ describe("normalizeEmbeddedRunAttempt", () => {
     });
     attempt.messagesSnapshot = [legacyAssistant] as never;
     attempt.lastAssistant = legacyAssistant as never;
+    attempt.currentAttemptAssistant = legacyAssistant as never;
     const input = makeNormalizationInput(attempt, state);
     input.lastRunPromptUsage = { input: 42_000, output: 1_000, total: 43_000 };
 
@@ -295,5 +291,31 @@ describe("normalizeEmbeddedRunAttempt", () => {
       throw new Error(`expected retry, got ${result.action}`);
     }
     expect(result.lastRunPromptUsage).toEqual({ contextUsage: { state: "unavailable" } });
+  });
+
+  it("keeps newer carried usage over an older transcript fallback", async () => {
+    const state = makePromptState();
+    const historicalAssistant = makeCliUsageAssistant("stop", "historical reply");
+    const attempt = makeAttempt({
+      route: "compact_only",
+      handled: true,
+      truncatedCount: 0,
+    });
+    attempt.messagesSnapshot = [historicalAssistant] as never;
+    attempt.lastAssistant = historicalAssistant as never;
+    const input = makeNormalizationInput(attempt, state);
+    input.lastRunPromptUsage = { input: 42_000, output: 1_000, total: 43_000 };
+
+    const result = await normalizeEmbeddedRunAttempt(input);
+
+    expect(result.action).toBe("retry");
+    if (result.action !== "retry") {
+      throw new Error(`expected retry, got ${result.action}`);
+    }
+    expect(result.lastRunPromptUsage).toEqual({
+      input: 42_000,
+      output: 1_000,
+      total: 43_000,
+    });
   });
 });

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -20,6 +20,7 @@ import {
   runIncompleteTurnOwnerHarness,
 } from "./run.incomplete-turn.test-support.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import { buildEmbeddedRunRecoveryErrorAgentMeta } from "./run/attempt-recovery.js";
 import {
   buildAttemptReplayMetadata,
   DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT,
@@ -38,6 +39,7 @@ import {
 } from "./run/incomplete-turn.js";
 import { normalizeEmbeddedRunAttemptResult } from "./run/run-attempt-result.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
+import { createUsageAccumulator } from "./usage-accumulator.js";
 
 const REASONING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn recorded reasoning but did not produce a user-visible answer. Continue from that partial turn and produce the visible answer now. Do not restate the reasoning or restart from scratch.";
@@ -56,6 +58,7 @@ type LastAssistantFixture = Omit<LastAssistant, "content" | "stopReason" | "usag
   stopReason: LastAssistant["stopReason"] | "end_turn";
   usage: Partial<LastAssistant["usage"]> & { total?: number };
 };
+const CARRIED_RETRY_USAGE = { input: 42_000, output: 1_000, total: 43_000 };
 
 function makeLastAssistant(overrides: Partial<LastAssistantFixture> = {}): LastAssistant {
   return {
@@ -263,6 +266,38 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
     expect(result.meta?.livenessState).toBe("blocked");
   });
+
+  it.each(["overflow", "hook block", "prompt error"])(
+    "keeps carried usage ahead of transcript history on %s exits",
+    () => {
+      const historicalAssistant = makeLastAssistant({
+        api: "cli",
+        usage: {
+          input: 128_814,
+          output: 3_000,
+          cacheRead: 992_953,
+          totalTokens: 1_124_767,
+        },
+      });
+      const normalizedAttempt = {
+        sessionIdUsed: "test-session",
+        currentAttemptAssistant: undefined,
+        attemptAssistant: historicalAssistant,
+      } as never;
+
+      const agentMeta = buildEmbeddedRunRecoveryErrorAgentMeta({
+        normalizedAttempt,
+        sessionFile: "/tmp/session.jsonl",
+        provider: "openai",
+        model: "gpt-5.5",
+        outerContextTokenMeta: {},
+        usageAccumulator: createUsageAccumulator(),
+        lastRunPromptUsage: CARRIED_RETRY_USAGE,
+      });
+
+      expect(agentMeta.lastCallUsage).toEqual(CARRIED_RETRY_USAGE);
+    },
+  );
 
   it("warns before retrying when an incomplete turn already sent a message", async () => {
     // Delivery evidence means retrying could duplicate user-visible output, so

--- a/src/agents/embedded-agent-runner/run.terminal-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run.terminal-timeout.test.ts
@@ -13,6 +13,7 @@ function makeTimedOutAttempt(
     assistantTexts: [],
     toolMetas: [],
     lastAssistant: undefined,
+    currentAttemptAssistant: undefined,
     didSendViaMessagingTool: false,
     messagingToolSentTexts: [],
     messagingToolSentMediaUrls: [],
@@ -38,7 +39,7 @@ function makeTimeoutInput(
     payloadsWithToolMedia: undefined,
     terminalState: resolveEmbeddedRunAttemptTerminalState({
       attempt,
-      assistant: attempt.lastAssistant,
+      assistant: attempt.currentAttemptAssistant,
     }),
     resolveReplayInvalid: vi.fn(() => false),
     setTerminalLifecycleMeta: vi.fn(),
@@ -61,6 +62,44 @@ describe("resolveEmbeddedRunTerminalTimeout", () => {
     expect(result?.payloads).toEqual([
       { text: expect.stringContaining("timed out"), isError: true },
     ]);
+  });
+
+  it("keeps stale transcript usage out of a no-response timeout", () => {
+    const carriedUsage = { input: 42_000, output: 1_000, total: 43_000 };
+    const attempt = makeTimedOutAttempt({
+      lastAssistant: {
+        role: "assistant",
+        api: "cli",
+        provider: "openai",
+        model: "gpt-5.6-luna",
+        content: [{ type: "text", text: "stale reply" }],
+        usage: {
+          input: 128_814,
+          output: 3_000,
+          cacheRead: 992_953,
+          totalTokens: 1_124_767,
+        },
+        stopReason: "stop",
+        timestamp: 1,
+      } as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>,
+      currentAttemptAssistant: undefined,
+    });
+
+    const result = resolveEmbeddedRunTerminalTimeout(
+      makeTimeoutInput(attempt, {
+        agentMeta: {
+          sessionId: "session-1",
+          provider: "openai",
+          model: "gpt-5.6-luna",
+          lastCallUsage: carriedUsage,
+        },
+      }),
+    );
+
+    expect(result?.payloads).toEqual([
+      { text: expect.stringContaining("timed out"), isError: true },
+    ]);
+    expect(result?.meta.agentMeta?.lastCallUsage).toEqual(carriedUsage);
   });
 
   it("prefers harness timeout metadata while retaining terminal attribution", () => {

--- a/src/agents/embedded-agent-runner/run/attempt-normalization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-normalization.ts
@@ -162,11 +162,12 @@ export async function normalizeEmbeddedRunAttempt(input: {
   const lastAssistantUsage = normalizeAssistantUsageForContext(sessionLastAssistant);
   const currentAttemptAssistantUsage = normalizeAssistantUsageForContext(currentAttemptAssistant);
   const promptCacheLastCallUsage = normalizeUsage(attempt.promptCache?.lastCallUsage as UsageLike);
+  // Current-attempt evidence is newest. The session assistant is only a transcript fallback
+  // and can predate a carried attempt snapshot after transcript rewrites or compaction.
   const callUsage = resolveLatestCallUsage({
     currentAttemptCandidates: [currentAttemptAssistantUsage, promptCacheLastCallUsage],
-    // The latest assistant sentinel must invalidate stale carried usage; reversing this order
-    // would resurrect a prior exact value after the runtime reports context as unavailable.
-    carriedCandidates: [lastAssistantUsage, input.lastRunPromptUsage],
+    carriedUsage: input.lastRunPromptUsage,
+    transcriptFallback: lastAssistantUsage,
   });
   const attemptUsage = attempt.attemptUsage ?? callUsage.currentAttempt;
   mergeUsageIntoAccumulator(input.usageAccumulator, attemptUsage);

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.ts
@@ -7,7 +7,7 @@ import { shouldSwitchToLiveModel, clearLiveModelSwitchPending } from "../../live
 import type { normalizeUsage } from "../../usage.js";
 import { log } from "../logger.js";
 import { getEmbeddedSessionPromptState } from "../session-prompt-state.js";
-import type { EmbeddedAgentRunResult, TraceAttempt } from "../types.js";
+import type { EmbeddedAgentMeta, EmbeddedAgentRunResult, TraceAttempt } from "../types.js";
 import type { createUsageAccumulator } from "../usage-accumulator.js";
 import type { prepareAndDispatchEmbeddedRunAttempt } from "./attempt-dispatch-preparation.js";
 import type { normalizeEmbeddedRunAttempt } from "./attempt-normalization.js";
@@ -35,6 +35,29 @@ type Dispatch = Awaited<ReturnType<typeof prepareAndDispatchEmbeddedRunAttempt>>
 type SessionPromptState = ReturnType<typeof createEmbeddedRunSessionPromptState>;
 type FailoverRetryController = ReturnType<typeof createEmbeddedRunFailoverRetryController>;
 type CompactionRuntime = ReturnType<typeof createEmbeddedRunCompactionRuntime>;
+
+// Error exits must not infer current usage from a transcript fallback. When no
+// current response exists, the carried snapshot remains the newest known fact.
+export function buildEmbeddedRunRecoveryErrorAgentMeta(input: {
+  normalizedAttempt: Pick<NormalizedAttempt, "currentAttemptAssistant" | "sessionIdUsed">;
+  sessionFile?: string;
+  provider: string;
+  model: string;
+  outerContextTokenMeta: { contextTokens?: number };
+  usageAccumulator: ReturnType<typeof createUsageAccumulator>;
+  lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
+}): EmbeddedAgentMeta {
+  return buildErrorAgentMeta({
+    sessionId: input.normalizedAttempt.sessionIdUsed,
+    sessionFile: input.sessionFile,
+    provider: input.provider,
+    model: input.model,
+    ...input.outerContextTokenMeta,
+    usageAccumulator: input.usageAccumulator,
+    lastRunPromptUsage: input.lastRunPromptUsage,
+    currentAttemptAssistant: input.normalizedAttempt.currentAttemptAssistant,
+  });
+}
 
 export async function recoverEmbeddedRunAttempt(input: {
   runInput: PreparedEmbeddedRunInput;
@@ -198,6 +221,16 @@ export async function recoverEmbeddedRunAttempt(input: {
     }),
     armPostCompactionGuard: input.armPostCompactionGuard,
   };
+  const buildRecoveryErrorAgentMeta = () =>
+    buildEmbeddedRunRecoveryErrorAgentMeta({
+      normalizedAttempt,
+      sessionFile: sessionPromptState.sessionFile,
+      provider: preparedRuntime.provider,
+      model: preparedRuntime.model.id,
+      outerContextTokenMeta: runtime.outerContextTokenMeta,
+      usageAccumulator: input.usageAccumulator,
+      lastRunPromptUsage: input.lastRunPromptUsage,
+    });
   if (
     await recoverEmbeddedRunTimeout({
       ...commonRecoveryInput,
@@ -235,16 +268,7 @@ export async function recoverEmbeddedRunAttempt(input: {
         errorKind: overflowRecovery.kind,
         errorMessage: overflowRecovery.errorText,
         durationMs: Date.now() - runInput.startedAtMs,
-        agentMeta: buildErrorAgentMeta({
-          sessionId: sessionIdUsed,
-          sessionFile: sessionPromptState.sessionFile,
-          provider: preparedRuntime.provider,
-          model: preparedRuntime.model.id,
-          ...runtime.outerContextTokenMeta,
-          usageAccumulator: input.usageAccumulator,
-          lastRunPromptUsage: input.lastRunPromptUsage,
-          lastAssistant: attemptAssistant,
-        }),
+        agentMeta: buildRecoveryErrorAgentMeta(),
         attempt,
         replayInvalid,
         finalPromptText: attempt.finalPromptText,
@@ -262,16 +286,7 @@ export async function recoverEmbeddedRunAttempt(input: {
         errorKind: "hook_block",
         errorMessage: errorText,
         durationMs: Date.now() - runInput.startedAtMs,
-        agentMeta: buildErrorAgentMeta({
-          sessionId: sessionIdUsed,
-          sessionFile: sessionPromptState.sessionFile,
-          provider: preparedRuntime.provider,
-          model: preparedRuntime.model.id,
-          ...runtime.outerContextTokenMeta,
-          usageAccumulator: input.usageAccumulator,
-          lastRunPromptUsage: input.lastRunPromptUsage,
-          lastAssistant: attemptAssistant,
-        }),
+        agentMeta: buildRecoveryErrorAgentMeta(),
         attempt,
         replayInvalid,
       }),
@@ -332,17 +347,7 @@ export async function recoverEmbeddedRunAttempt(input: {
       suspendForFailure: runInput.suspendForFailure,
       resolveReplayInvalid: resolveReplayInvalidForAttempt,
       setTerminalLifecycleMeta,
-      buildErrorAgentMeta: () =>
-        buildErrorAgentMeta({
-          sessionId: sessionIdUsed,
-          sessionFile: sessionPromptState.sessionFile,
-          provider: preparedRuntime.provider,
-          model: preparedRuntime.model.id,
-          ...runtime.outerContextTokenMeta,
-          usageAccumulator: input.usageAccumulator,
-          lastRunPromptUsage: input.lastRunPromptUsage,
-          lastAssistant: attemptAssistant,
-        }),
+      buildErrorAgentMeta: buildRecoveryErrorAgentMeta,
       startedAtMs: runInput.startedAtMs,
       fallbackConfigured: runInput.fallbackConfigured,
       aborted,

--- a/src/agents/embedded-agent-runner/run/helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.test.ts
@@ -193,7 +193,8 @@ describe("resolveLatestCallUsage", () => {
     expect(
       resolveLatestCallUsage({
         currentAttemptCandidates: [{ input: 0, output: 0, total: 0 }, undefined],
-        carriedCandidates: [previous],
+        carriedUsage: previous,
+        transcriptFallback: undefined,
       }),
     ).toEqual({
       currentAttempt: undefined,
@@ -207,17 +208,33 @@ describe("resolveLatestCallUsage", () => {
     expect(
       resolveLatestCallUsage({
         currentAttemptCandidates: [{ input: 0, output: 0, total: 0 }, latest],
-        carriedCandidates: [{ input: 12, output: 3, total: 15 }],
+        carriedUsage: { input: 12, output: 3, total: 15 },
+        transcriptFallback: undefined,
       }),
     ).toEqual({
       currentAttempt: latest,
       latest,
     });
   });
+
+  it("keeps carried attempt usage ahead of an older transcript fallback", () => {
+    const carried = { input: 20, output: 4, total: 24 };
+
+    expect(
+      resolveLatestCallUsage({
+        currentAttemptCandidates: [],
+        carriedUsage: carried,
+        transcriptFallback: { contextUsage: { state: "unavailable" } },
+      }),
+    ).toEqual({
+      currentAttempt: undefined,
+      latest: carried,
+    });
+  });
 });
 
 describe("buildUsageAgentMetaFields", () => {
-  it("selects unavailable over older prompt usage", () => {
+  it("selects unavailable current-attempt usage over older prompt usage", () => {
     const fields = buildUsageAgentMetaFields({
       usageAccumulator: createUsageAccumulator(),
       lastAssistantUsage: { contextUsage: { state: "unavailable" } },
@@ -336,14 +353,14 @@ describe("buildUsageAgentMetaFields", () => {
 });
 
 describe("buildErrorAgentMeta", () => {
-  it("does not promote historical CLI usage without context provenance", () => {
+  it("does not promote current CLI usage without context provenance", () => {
     const fields = buildErrorAgentMeta({
       sessionId: "session-error",
       provider: "openai",
       model: "gpt-5.6-luna",
       usageAccumulator: createUsageAccumulator(),
       lastRunPromptUsage: { input: 42_000, output: 1_000, total: 43_000 },
-      lastAssistant: {
+      currentAttemptAssistant: {
         api: "cli",
         usage: { input: 128_814, output: 3_000, cacheRead: 992_953, totalTokens: 1_124_767 },
       },
@@ -374,7 +391,7 @@ describe("buildErrorAgentMeta", () => {
       model: "claude-opus-4-6",
       usageAccumulator,
       lastRunPromptUsage: latestCallUsage,
-      lastAssistant: { usage: latestCallUsage },
+      currentAttemptAssistant: { usage: latestCallUsage },
     });
 
     expect(fields.usage).toMatchObject({

--- a/src/agents/embedded-agent-runner/run/helpers.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.ts
@@ -189,15 +189,20 @@ export function resolveReportedModelRef(params: {
 
 export function resolveLatestCallUsage(params: {
   currentAttemptCandidates: readonly (NormalizedUsage | undefined)[];
-  carriedCandidates: readonly (NormalizedUsage | undefined)[];
+  carriedUsage: NormalizedUsage | undefined;
+  transcriptFallback: NormalizedUsage | undefined;
 }): {
   currentAttempt: NormalizedUsage | undefined;
   latest: NormalizedUsage | undefined;
 } {
   const currentAttempt = params.currentAttemptCandidates.find(hasNonzeroUsage);
+  const carriedUsage = hasNonzeroUsage(params.carriedUsage) ? params.carriedUsage : undefined;
+  const transcriptFallback = hasNonzeroUsage(params.transcriptFallback)
+    ? params.transcriptFallback
+    : undefined;
   return {
     currentAttempt,
-    latest: currentAttempt ?? params.carriedCandidates.find(hasNonzeroUsage),
+    latest: currentAttempt ?? carriedUsage ?? transcriptFallback,
   };
 }
 
@@ -252,11 +257,11 @@ export function buildErrorAgentMeta(params: {
   contextTokens?: number;
   usageAccumulator: UsageAccumulator;
   lastRunPromptUsage: UsageSnapshot | undefined;
-  lastAssistant?: { api?: string; usage?: unknown } | null;
+  currentAttemptAssistant?: { api?: string; usage?: unknown } | null;
 }): EmbeddedAgentMeta {
   const usageMeta = buildUsageAgentMetaFields({
     usageAccumulator: params.usageAccumulator,
-    lastAssistantUsage: normalizeAssistantUsageForContext(params.lastAssistant),
+    lastAssistantUsage: normalizeAssistantUsageForContext(params.currentAttemptAssistant),
     lastRunPromptUsage: params.lastRunPromptUsage,
   });
   return {

--- a/src/agents/harness/lifecycle.test.ts
+++ b/src/agents/harness/lifecycle.test.ts
@@ -86,6 +86,7 @@ function createAttemptResult(): EmbeddedRunAttemptResult {
     assistantTexts: ["ok"],
     toolMetas: [],
     lastAssistant: undefined,
+    currentAttemptAssistant: undefined,
     didSendViaMessagingTool: false,
     messagingToolSentTexts: [],
     messagingToolSentMediaUrls: [],
@@ -172,6 +173,39 @@ describe("AgentHarness lifecycle runner", () => {
 
     expect(attemptResult).toEqual({ ...result, agentHarnessId: "codex" });
     expect(runAttempt).toHaveBeenCalledWith(params);
+  });
+
+  it("backfills the current attempt assistant for legacy harness results", async () => {
+    const result = createAttemptResult();
+    const assistant = createFinalAssistant();
+    result.lastAssistant = assistant;
+    delete result.currentAttemptAssistant;
+    const harness: AgentHarness = {
+      id: "codex",
+      label: "Codex",
+      supports: () => ({ supported: true }),
+      runAttempt: async () => result,
+    };
+
+    const attemptResult = await runAgentHarnessLifecycleAttempt(harness, createAttemptParams());
+
+    expect(attemptResult.currentAttemptAssistant).toBe(assistant);
+  });
+
+  it("preserves explicit evidence that the current attempt produced no assistant", async () => {
+    const result = createAttemptResult();
+    result.lastAssistant = createFinalAssistant();
+    result.currentAttemptAssistant = undefined;
+    const harness: AgentHarness = {
+      id: "codex",
+      label: "Codex",
+      supports: () => ({ supported: true }),
+      runAttempt: async () => result,
+    };
+
+    const attemptResult = await runAgentHarnessLifecycleAttempt(harness, createAttemptParams());
+
+    expect(attemptResult.currentAttemptAssistant).toBeUndefined();
   });
 
   it("records the selected harness for harness-scoped preflight failures", async () => {

--- a/src/agents/harness/lifecycle.ts
+++ b/src/agents/harness/lifecycle.ts
@@ -110,8 +110,13 @@ function normalizeAgentHarnessAttemptResult(
     timedOutDuringToolExecution,
     ...canonical
   } = result;
-  if ("terminal" in canonical) {
-    return canonical;
+  // Older harnesses use lastAssistant for the current response. An explicit
+  // undefined currentAttemptAssistant proves this attempt produced no response.
+  const normalized = Object.hasOwn(canonical, "currentAttemptAssistant")
+    ? canonical
+    : { ...canonical, currentAttemptAssistant: canonical.lastAssistant };
+  if ("terminal" in normalized) {
+    return normalized;
   }
   const terminal = normalizeAgentRunAttemptTerminal({
     aborted,
@@ -124,7 +129,7 @@ function normalizeAgentHarnessAttemptResult(
     timedOutDuringCompaction,
     timedOutDuringToolExecution,
   });
-  return { ...canonical, terminal };
+  return { ...normalized, terminal };
 }
 
 function agentHarnessRunOutcome(

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -1,5 +1,6 @@
 // Status summary tests cover aggregate status text for channels, sessions, tasks, and audit findings.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { SESSION_TOTAL_TOKENS_VERSION } from "../config/sessions/types.js";
 import { setActiveDegradedPlugins } from "../plugins/runtime-degraded-state.js";
 import { setActiveDegradedSecretOwners } from "../secrets/runtime-degraded-state.js";
 import type { TaskAuditFinding } from "../tasks/task-registry.audit.js";
@@ -555,14 +556,62 @@ describe("getStatusSummary", () => {
     ).toBe(false);
   });
 
-  it("keeps stale totals visible without deriving context utilization", async () => {
+  it.each([
+    {
+      name: "fresh v1",
+      checkpoint: {
+        totalTokensFresh: true,
+        totalTokensVersion: SESSION_TOTAL_TOKENS_VERSION,
+      },
+      expected: {
+        totalTokensFresh: true,
+        remainingTokens: 150_000,
+        percentUsed: 25,
+      },
+    },
+    {
+      name: "stale v1",
+      checkpoint: {
+        totalTokensFresh: false,
+        totalTokensVersion: SESSION_TOTAL_TOKENS_VERSION,
+      },
+      expected: {
+        totalTokensFresh: false,
+        remainingTokens: null,
+        percentUsed: null,
+      },
+    },
+    {
+      name: "fresh unversioned",
+      checkpoint: {
+        totalTokensFresh: true,
+      },
+      expected: {
+        totalTokensFresh: false,
+        remainingTokens: null,
+        percentUsed: null,
+      },
+    },
+    {
+      name: "wrong-version",
+      checkpoint: {
+        totalTokensFresh: true,
+        totalTokensVersion: SESSION_TOTAL_TOKENS_VERSION + 1,
+      },
+      expected: {
+        totalTokensFresh: false,
+        remainingTokens: null,
+        percentUsed: null,
+      },
+    },
+  ])("handles $name checkpoint usage provenance", async ({ checkpoint, expected }) => {
     statusSummaryMocks.listSessionEntries.mockReturnValue(
       toSessionEntrySummaries({
         "agent:main:main": {
-          sessionId: "stale-total",
+          sessionId: "checkpoint-total",
           updatedAt: Date.now(),
           totalTokens: 50_000,
-          totalTokensFresh: false,
+          ...checkpoint,
         },
       }),
     );
@@ -571,9 +620,7 @@ describe("getStatusSummary", () => {
 
     expect(summary.sessions.recent[0]).toMatchObject({
       totalTokens: 50_000,
-      totalTokensFresh: false,
-      remainingTokens: null,
-      percentUsed: null,
+      ...expected,
     });
   });
 


### PR DESCRIPTION
Related:

- https://github.com/openclaw/openclaw/issues/120504
- https://github.com/openclaw/openclaw/pull/120509
- https://github.com/openclaw/openclaw/pull/120535

## What Problem This Solves

Fixes an issue where an embedded-agent retry could let historical transcript usage outrank the exact usage from the current attempt or the canonical usage carried from the preceding attempt. That stale chronology could reach retry error metadata, compaction decisions, and status reporting.

## Why This Change Was Made

The runtime now enforces one usage chronology:

1. exact current-attempt prompt usage
2. carried canonical usage from `lastRunPromptUsage`
3. historical transcript assistant usage only as a fallback

The root cause crossed the retry lifecycle boundary: attempt recovery could pass the broader historical `attemptAssistant` into error metadata, while lifecycle adaptation could not distinguish an omitted `currentAttemptAssistant` property from an explicit `currentAttemptAssistant: undefined`. Recovery now passes only current-attempt evidence, and the harness backfills from `lastAssistant` only when the property is omitted. Explicit `undefined` remains evidence that the current attempt produced no assistant response.

This is the canonical owner-boundary repair across attempt normalization, recovery, helpers, and harness lifecycle. It intentionally retains no changes to `terminal-preparation.ts` or `worker-turn-payload.ts`.

## User Impact

Overflow, hook-block, prompt-error, and terminal-timeout failures preserve the newest trustworthy usage fact. Status summaries trust checkpoint totals only when freshness and provenance agree.

## Exact Revision

- Head: `35d3bdf7ec65b0d1743e3030a2c19890022b4c13`
- Frozen implementation base and merge base: `c5d00cb47ddb7236980de8e0fbc938b23fdeaae0`
- Head tree: `0022d335b29579e988cec6b06d509eda2ed192a4`
- Remote `main` at publication: `c9331450887cf159ea3acf4d0dca7c3da2a78d7d`
- Clean current-main merge tree: `fd0622ef249d533c266793884d233121117bd1b0`

Remote main has no owned-file overlap. Its only provenance-adjacent delta is a compatible test fixture that omits a version marker when totals are stale; the merge tree remains clean, so this branch was not rebased for unrelated drift.

## Authorship

- `872793fb3c9421e18b46fdbbdff9a936fe07367d` `fix(agents): preserve retry usage chronology`
  - Author: Peter Steinberger `<steipete@gmail.com>`
  - Committer and signer: Vincent Koc `<vincentkoc@ieee.org>`
  - Good Git signature
  - `Co-authored-by: Vincent Koc <vincentkoc@ieee.org>`
  - `Punchcard-Session: amber-workshop-workshop-36`
- `35d3bdf7ec65b0d1743e3030a2c19890022b4c13` `test(status): cover checkpoint usage provenance`
  - Author, committer, and signer: Vincent Koc `<vincentkoc@ieee.org>`
  - Good Git signature
  - `Punchcard-Session: amber-workshop-workshop-36`

Peter's retry repair ancestry from #120509 is preserved explicitly in the runtime commit. Vincent's co-authorship records the material lifecycle, recovery, and regression-test adaptation; the status provenance commit is Vincent-authored.

## Codex Contract

Direct sibling Codex inspection at `bb1af235ea2822d7a40f75ef52e4d6a2cde84da2` confirmed:

- `codex-rs/protocol/src/protocol.rs:2055-2110` distinguishes cumulative total usage from exact last-response usage and appends the latter.
- `codex-rs/core/src/session/turn.rs:2501-2524` records token usage from the completed upstream response.
- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:1502-1537` carries both total and last usage fields.
- `codex-rs/app-server/src/request_processors/token_usage_replay.rs:29-91` treats restored usage as historical lifecycle replay rather than a current model event.

## Evidence

- Focused trusted proof, once across the six approved test files: `263/263` passed across five Vitest shards in 33.39s.
- Command: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.attempt-normalization.direct.test.ts src/agents/embedded-agent-runner/run/helpers.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/embedded-agent-runner/run.terminal-timeout.test.ts src/agents/harness/lifecycle.test.ts src/commands/status.summary.test.ts`
- Direct precedence coverage proves current-attempt usage over carried canonical usage over transcript fallback.
- Incomplete-turn coverage proves overflow, hook-block, and prompt-error chronology; terminal timeout remains a separate regression.
- Status coverage proves fresh v1, stale v1, fresh unversioned, and wrong-version checkpoint behavior.
- Targeted formatting and format checks passed for all ten changed files.
- `git diff --check` passed.
- `node scripts/check-changed.mjs --dry-run -- <changed files>` classified `core, coreTests`; no heavy or hosted proof was dispatched.

## Diff Surface

Production LOC: `+58/-42` (net `+16`) across four runtime files. The positive delta records the current-attempt lifecycle fact at its owner boundary and preserves omitted-versus-explicit-undefined semantics.

Tests: `+227/-33` (net `+194`) across six focused test files.

No changelog: this repairs unreleased retry chronology and adds regression coverage; it does not add a new user-facing feature or configuration surface.

## Direct-Land Rationale

#120509 remains open at `f2223c32c052fc963fdcd81c33271d95ac3cccef` with `maintainerCanModify=false` and mixes retry repair with broader protocol, generated, and session changes. The landed diff must materially differ: this draft selectively preserves Peter's retry contribution and rebuilds the canonical lifecycle/recovery repair plus bounded status coverage from the frozen base. The mixed contributor branch cannot be edited into this owner-scoped series.

#120504 tracks six CI rows and remains open; this PR does not claim to close it. #120535 is closed and remains historical context only.

Punchcard-Session: amber-workshop-workshop-36
Punchcard PR attestation: att_01KZGDGZHE4QH7DNT690R6JAH6
