### PR TITLE
refactor(gateway): centralize channel health projection

### DIFF
--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -407,7 +407,14 @@ describe("resolveChannelHealthState", () => {
     const evaluation = evaluateHealth(snapshot);
 
     expect(evaluation).toEqual({ healthy: false, reason: "terminal-disconnect" });
-    expect(resolveChannelHealthState(snapshot, evaluation)).toBe("conflict");
+    expect(
+      resolveChannelHealthState(snapshot, {
+        channelId: "discord",
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      }),
+    ).toBe("conflict");
   });
 });
 

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -53,8 +53,9 @@ export type ChannelHealthPolicy = {
 /** Keep channel-authored terminal detail above the shared unhealthy projection. */
 export function resolveChannelHealthState(
   snapshot: ChannelHealthSnapshot,
-  evaluation: ChannelHealthEvaluation,
+  policy: ChannelHealthPolicy,
 ): string | undefined {
+  const evaluation = evaluateChannelHealth(snapshot, policy);
   return !evaluation.healthy && !(snapshot.lifecycle === "blocked" && snapshot.healthState)
     ? evaluation.reason
     : snapshot.healthState;

--- a/src/gateway/health/collector.ts
+++ b/src/gateway/health/collector.ts
@@ -24,7 +24,6 @@ import { normalizeAgentId } from "../../routing/session-key.js";
 import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
   DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
-  evaluateChannelHealth,
   resolveChannelHealthState,
 } from "../channel-health-policy.js";
 import type { GatewayHotReloadStatus } from "../config-reload-status.types.js";
@@ -331,13 +330,12 @@ export async function collectGatewayHealthSnapshot(params: {
       if (lastProbeAt) {
         snapshot.lastProbeAt = lastProbeAt;
       }
-      const health = evaluateChannelHealth(snapshot, {
+      const healthState = resolveChannelHealthState(snapshot, {
         channelId: plugin.id,
         now: Date.now(),
         staleEventThresholdMs: DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
         channelConnectGraceMs: DEFAULT_CHANNEL_CONNECT_GRACE_MS,
       });
-      const healthState = resolveChannelHealthState(snapshot, health);
       if (healthState !== undefined) {
         snapshot.healthState = healthState;
       }

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -29,7 +29,6 @@ import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
 import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
   DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
-  evaluateChannelHealth,
   resolveChannelHealthState,
 } from "../channel-health-policy.js";
 import { resolveGatewayPluginConfig } from "../runtime-plugin-config.js";
@@ -476,13 +475,12 @@ export const channelsHandlers: GatewayRequestHandlers = {
       if (snapshot.lastOutboundAt == null) {
         snapshot.lastOutboundAt = activity.outboundAt;
       }
-      const health = evaluateChannelHealth(snapshot, {
+      const healthState = resolveChannelHealthState(snapshot, {
         channelId,
         now: Date.now(),
         staleEventThresholdMs: DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
         channelConnectGraceMs: DEFAULT_CHANNEL_CONNECT_GRACE_MS,
       });
-      const healthState = resolveChannelHealthState(snapshot, health);
       if (healthState !== undefined) {
         snapshot.healthState = healthState;
       }


### PR DESCRIPTION
## What Problem This Solves

Resolves a maintenance defect where gateway health snapshots and `channels.status` each repeated the same channel-health evaluation immediately before projecting `healthState`. Keeping evaluation and projection split across reporting callers made the shared policy vulnerable to drift as lifecycle reasons evolved.

## Why This Change Was Made

`resolveChannelHealthState` now owns evaluation from a caller-supplied `ChannelHealthPolicy`. The two projection-only callers pass the same default policy values they used before, while readiness, the health monitor, and status diagnostics continue consuming the full evaluation reason for restart, suppression, and operator-message decisions.

This preserves channel-authored blocked-state detail over inferred unhealthy reasons, including terminal disconnect and unavailable ingress. Retaining caller-side evaluation or adding a compatibility overload would keep duplicate policy or unnecessary internal API surface.

Overlap was checked against #119296 and #80805. #119296 changes disabled account-state projection only; #80805 predates this resolver and only exports the busy threshold in this policy, so neither implements these semantics.

## User Impact

No intended user-visible behavior change. Gateway health and channel-status projections keep the existing healthy, stopped, blocked, disconnected, and stale-socket behavior, but the policy now has one canonical owner.

## Evidence

Exact head: `be96c9bcaa8947be8d4137814e3e57f6eb4032e3`

- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/31250415337 completed successfully for this SHA; required `openclaw/ci-gate` passed.
- Focused remote proof: https://crabbox.openclaw.ai/portal/runs/run_b74e0a72591a
  - `src/gateway/channel-health-policy.test.ts`
  - `src/gateway/server-methods/channels.status.test.ts`
  - `src/commands/health.snapshot.test.ts`
  - 3 files / 71 tests passed.
- The exact-head test-only signature correction was independently reviewed after that run. A post-fix remote retry was blocked because the owned lease had already ended asynchronously.
- `git diff --check origin/main...HEAD` passed.
- `check:changed` reached and passed conflict-marker, env-count, max-lines, attribution, wildcard-export, duplicate coverage, dependency-pin, formatting, Plugin SDK manifest, deprecated-API, plugin-boundary, and package-patch checks on https://crabbox.openclaw.ai/portal/runs/run_6a087217eb9f. The remaining install failure was independently investigated and ruled out as a PR or current-main lockfile defect; a clean no-hydrate/full-resync AWS run with a fresh HOME/store passed (https://crabbox.openclaw.ai/portal/runs/run_42254f465a60, lease cbx_427937adb3c7, Ubuntu 26.04, Node 24.18.1, pnpm 11.15.1, exit 0). The original failure came from stale/mixed remote install state.
- Final autoreview: clean, no accepted/actionable findings.
- Independent exact-head review: PASS, no actionable findings; the earlier stale test-signature finding was fixed.
- Production LOC: +4 / -7 (net -3).
- Test LOC: +8 / -1 (net +7). The task packet expected neutral tests, but the existing resolver unit test required a policy argument to remain type-correct.

AI-assisted change. I reviewed the implementation, history, callers, tests, proof, and final committed diff. No agent transcript is attached for this autonomous repair-sweep run.

