### PR TITLE
fix(release): keep prerelease companions exact in cross-OS checks

### DIFF
--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -545,11 +545,11 @@ jobs:
       - name: Verify provided prerelease plugin registry upload
         if: steps.provided_registry.outputs.json != ''
         env:
-          ARTIFACT_DIGEST: ${{ fromJSON(steps.provided_registry.outputs.json).prepublishPluginRegistryArtifactDigest }}
-          ARTIFACT_ID: ${{ fromJSON(steps.provided_registry.outputs.json).prepublishPluginRegistryArtifactId }}
-          ARTIFACT_NAME: ${{ fromJSON(steps.provided_registry.outputs.json).prepublishPluginRegistryArtifactName }}
-          ARTIFACT_RUN_ATTEMPT: ${{ fromJSON(steps.provided_registry.outputs.json).prepublishPluginRegistryArtifactRunAttempt }}
-          ARTIFACT_RUN_ID: ${{ fromJSON(steps.provided_registry.outputs.json).prepublishPluginRegistryArtifactRunId }}
+          ARTIFACT_DIGEST: ${{ fromJSON(steps.provided_registry.outputs.json || '{}').prepublishPluginRegistryArtifactDigest || '' }}
+          ARTIFACT_ID: ${{ fromJSON(steps.provided_registry.outputs.json || '{}').prepublishPluginRegistryArtifactId || '' }}
+          ARTIFACT_NAME: ${{ fromJSON(steps.provided_registry.outputs.json || '{}').prepublishPluginRegistryArtifactName || '' }}
+          ARTIFACT_RUN_ATTEMPT: ${{ fromJSON(steps.provided_registry.outputs.json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}
+          ARTIFACT_RUN_ID: ${{ fromJSON(steps.provided_registry.outputs.json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
           GH_TOKEN: ${{ github.token }}
         run: |
           bash workflow/scripts/docker/shared-image-artifact.sh \
@@ -953,18 +953,18 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          artifact-ids: ${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json).prepublishPluginRegistryArtifactId }}
+          artifact-ids: ${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactId || '' }}
           path: ${{ runner.temp }}/openclaw-cross-os-release-checks/plugins
-          run-id: ${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json).prepublishPluginRegistryArtifactRunId }}
+          run-id: ${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
           github-token: ${{ github.token }}
 
       - name: Retry prerelease plugin registry artifact download
         if: needs.prepare.outputs.prepublish_plugin_registry_json != '' && steps.download_prepublish_plugin_registry.outcome == 'failure'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          artifact-ids: ${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json).prepublishPluginRegistryArtifactId }}
+          artifact-ids: ${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactId || '' }}
           path: ${{ runner.temp }}/openclaw-cross-os-release-checks/plugins
-          run-id: ${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json).prepublishPluginRegistryArtifactRunId }}
+          run-id: ${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
           github-token: ${{ github.token }}
 
       - name: Verify release-check inputs

--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -210,33 +210,8 @@ on:
         required: false
         default: ""
         type: string
-      prepublish_plugin_registry_artifact_name:
-        description: Optional immutable prerelease plugin registry artifact name
-        required: false
-        default: ""
-        type: string
-      prepublish_plugin_registry_artifact_id:
-        description: Immutable prerelease plugin registry artifact id
-        required: false
-        default: ""
-        type: string
-      prepublish_plugin_registry_artifact_digest:
-        description: Exact upload-artifact SHA-256 digest for the plugin registry
-        required: false
-        default: ""
-        type: string
-      prepublish_plugin_registry_artifact_run_id:
-        description: Exact workflow run id that produced the plugin registry
-        required: false
-        default: ""
-        type: string
-      prepublish_plugin_registry_artifact_run_attempt:
-        description: Exact workflow run attempt that produced the plugin registry
-        required: false
-        default: ""
-        type: string
-      prepublish_plugin_registry_manifest_sha256:
-        description: Exact SHA-256 of prepublish-plugin-registry.json
+      prepublish_plugin_registry_json:
+        description: Optional immutable prerelease plugin registry tuple
         required: false
         default: ""
         type: string
@@ -291,12 +266,7 @@ jobs:
       candidate_sha256: ${{ steps.candidate_metadata.outputs.sha256 }}
       candidate_version: ${{ steps.candidate_metadata.outputs.version }}
       matrix: ${{ steps.matrix.outputs.value }}
-      prepublish_plugin_registry_artifact_digest: ${{ steps.upload_prepublish_plugin_registry.outputs.artifact-digest || inputs.prepublish_plugin_registry_artifact_digest || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactDigest || '' }}
-      prepublish_plugin_registry_artifact_id: ${{ steps.upload_prepublish_plugin_registry.outputs.artifact-id || inputs.prepublish_plugin_registry_artifact_id || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactId || '' }}
-      prepublish_plugin_registry_artifact_name: ${{ steps.upload_prepublish_plugin_registry.outputs.artifact-id && format('openclaw-cross-os-prepublish-plugin-registry-{0}-{1}', github.run_id, github.run_attempt) || inputs.prepublish_plugin_registry_artifact_name || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactName || '' }}
-      prepublish_plugin_registry_artifact_run_attempt: ${{ steps.upload_prepublish_plugin_registry.outputs.artifact-id && github.run_attempt || inputs.prepublish_plugin_registry_artifact_run_attempt || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactRunAttempt || '' }}
-      prepublish_plugin_registry_artifact_run_id: ${{ steps.upload_prepublish_plugin_registry.outputs.artifact-id && github.run_id || inputs.prepublish_plugin_registry_artifact_run_id || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactRunId || '' }}
-      prepublish_plugin_registry_manifest_sha256: ${{ steps.source_prepublish_plugin_registry.outputs.manifest_sha256 || inputs.prepublish_plugin_registry_manifest_sha256 || fromJSON(inputs.prepublish_plugin_registry_json || '{}').manifestSha256 || '' }}
+      prepublish_plugin_registry_json: ${{ steps.registry_identity.outputs.json }}
       required_companion_packages_json: ${{ steps.provider_requirements.outputs.json }}
       source_sha: ${{ steps.candidate_metadata.outputs.source_sha }}
       workflow_ref: ${{ steps.workflow_ref.outputs.value }}
@@ -468,36 +438,10 @@ jobs:
             echo "Candidate package source SHA does not match the selected exact ref." >&2
             exit 1
           fi
-
-          artifact_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}")"
-          jq -e \
-            --arg digest "sha256:${ARTIFACT_DIGEST}" \
-            --arg id "$ARTIFACT_ID" \
-            --arg name "$ARTIFACT_NAME" \
-            --arg run_id "$ARTIFACT_RUN_ID" \
-            '
-              (.id | tostring) == $id and
-              .name == $name and
-              .expired == false and
-              .digest == $digest and
-              (.workflow_run.id | tostring) == $run_id
-            ' <<< "$artifact_json" >/dev/null || {
-              echo "Candidate artifact identity does not match the requested immutable tuple." >&2
-              exit 1
-            }
-
-          attempt_json="$(
-            gh api \
-              "repos/${GITHUB_REPOSITORY}/actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}"
-          )"
-          jq -e \
-            --arg attempt "$ARTIFACT_RUN_ATTEMPT" \
-            --arg run_id "$ARTIFACT_RUN_ID" \
-            '(.id | tostring) == $run_id and (.run_attempt | tostring) == $attempt' \
-            <<< "$attempt_json" >/dev/null || {
-              echo "Candidate artifact producer run attempt does not match the requested tuple." >&2
-              exit 1
-            }
+          bash workflow/scripts/docker/shared-image-artifact.sh \
+            verify-upload "Candidate" \
+            "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
 
       - name: Checkout public source ref
         if: inputs.candidate_artifact_name == ''
@@ -538,50 +482,80 @@ jobs:
           jq -e 'type == "array" and all(.[]; type == "string")' <<< "$packages_json" >/dev/null
           echo "json=$packages_json" >> "$GITHUB_OUTPUT"
 
-      - name: Validate companion registry contract
+      - name: Normalize companion registry contract
+        id: provided_registry
         env:
           CANDIDATE_ARTIFACT_NAME: ${{ inputs.candidate_artifact_name }}
-          PLUGIN_ARTIFACT_DIGEST: ${{ inputs.prepublish_plugin_registry_artifact_digest || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactDigest || '' }}
-          PLUGIN_ARTIFACT_ID: ${{ inputs.prepublish_plugin_registry_artifact_id || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactId || '' }}
-          PLUGIN_ARTIFACT_NAME: ${{ inputs.prepublish_plugin_registry_artifact_name || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactName || '' }}
-          PLUGIN_ARTIFACT_RUN_ATTEMPT: ${{ inputs.prepublish_plugin_registry_artifact_run_attempt || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactRunAttempt || '' }}
-          PLUGIN_ARTIFACT_RUN_ID: ${{ inputs.prepublish_plugin_registry_artifact_run_id || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactRunId || '' }}
-          PLUGIN_MANIFEST_SHA256: ${{ inputs.prepublish_plugin_registry_manifest_sha256 || fromJSON(inputs.prepublish_plugin_registry_json || '{}').manifestSha256 || '' }}
           PREPUBLISH_PLUGIN_REGISTRY_JSON: ${{ inputs.prepublish_plugin_registry_json }}
           REQUIRED_COMPANION_PACKAGES_JSON: ${{ steps.provider_requirements.outputs.json }}
         shell: bash
         run: |
           set -euo pipefail
-          if [[ -n "${PREPUBLISH_PLUGIN_REGISTRY_JSON// }" ]]; then
-            jq -e 'has("requiredPackages") | not' <<< "$PREPUBLISH_PLUGIN_REGISTRY_JSON" >/dev/null || {
-              echo "Provider-owned companion requirements cannot be overridden by dispatch input." >&2
-              exit 1
-            }
-          fi
-          tuple_count=0
-          for value in \
-            "$PLUGIN_ARTIFACT_DIGEST" \
-            "$PLUGIN_ARTIFACT_ID" \
-            "$PLUGIN_ARTIFACT_NAME" \
-            "$PLUGIN_ARTIFACT_RUN_ATTEMPT" \
-            "$PLUGIN_ARTIFACT_RUN_ID" \
-            "$PLUGIN_MANIFEST_SHA256"; do
-            [[ -n "${value// }" ]] && tuple_count=$((tuple_count + 1))
-          done
-          [[ "$tuple_count" == "0" || "$tuple_count" == "6" ]] || {
-            echo "Prerelease companion registry selection must provide the complete immutable tuple." >&2
-            exit 1
-          }
           required_count="$(jq -er 'length' <<< "$REQUIRED_COMPANION_PACKAGES_JSON")"
           if [[ -z "${CANDIDATE_ARTIFACT_NAME// }" ]]; then
-            [[ "$tuple_count" == "0" ]] || {
+            [[ -z "${PREPUBLISH_PLUGIN_REGISTRY_JSON// }" ]] || {
               echo "Source-built candidates produce their own companion registry and reject a second tuple." >&2
               exit 1
             }
-          elif [[ "$required_count" -gt 0 && "$tuple_count" != "6" ]]; then
+            echo "json=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ -z "${PREPUBLISH_PLUGIN_REGISTRY_JSON// }" ]]; then
+            if [[ "$required_count" -gt 0 ]]; then
+              echo "The selected provider requires a complete immutable companion registry tuple." >&2
+              exit 1
+            fi
+            echo "json=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          normalized="$(
+            jq -ce '
+              def digits: test("^[1-9][0-9]*$");
+              def hex64: test("^[a-f0-9]{64}$");
+              . as $value |
+              (keys | sort) == ([
+                "prepublishPluginRegistryArtifactDigest",
+                "prepublishPluginRegistryArtifactId",
+                "prepublishPluginRegistryArtifactName",
+                "prepublishPluginRegistryArtifactRunAttempt",
+                "prepublishPluginRegistryArtifactRunId",
+                "prepublishPluginRegistryManifestSha256"
+              ] | sort) and
+              all(.[]; type == "string") and
+              (.prepublishPluginRegistryArtifactDigest | hex64) and
+              (.prepublishPluginRegistryArtifactId | digits) and
+              (.prepublishPluginRegistryArtifactRunAttempt | digits) and
+              (.prepublishPluginRegistryArtifactRunId | digits) and
+              (.prepublishPluginRegistryManifestSha256 | hex64) and
+              (.prepublishPluginRegistryArtifactName |
+                endswith("-" + $value.prepublishPluginRegistryArtifactRunId + "-" +
+                  $value.prepublishPluginRegistryArtifactRunAttempt)) |
+              if . then $value else error("invalid prerelease plugin registry tuple") end
+            ' <<< "$PREPUBLISH_PLUGIN_REGISTRY_JSON"
+          )" || {
+            echo "Prerelease companion registry must be one closed immutable JSON tuple." >&2
+            exit 1
+          }
+          if [[ "$required_count" -gt 0 && -z "${normalized// }" ]]; then
             echo "The selected provider requires a complete immutable companion registry tuple." >&2
             exit 1
           fi
+          echo "json=$normalized" >> "$GITHUB_OUTPUT"
+
+      - name: Verify provided prerelease plugin registry upload
+        if: steps.provided_registry.outputs.json != ''
+        env:
+          ARTIFACT_DIGEST: ${{ fromJSON(steps.provided_registry.outputs.json).prepublishPluginRegistryArtifactDigest }}
+          ARTIFACT_ID: ${{ fromJSON(steps.provided_registry.outputs.json).prepublishPluginRegistryArtifactId }}
+          ARTIFACT_NAME: ${{ fromJSON(steps.provided_registry.outputs.json).prepublishPluginRegistryArtifactName }}
+          ARTIFACT_RUN_ATTEMPT: ${{ fromJSON(steps.provided_registry.outputs.json).prepublishPluginRegistryArtifactRunAttempt }}
+          ARTIFACT_RUN_ID: ${{ fromJSON(steps.provided_registry.outputs.json).prepublishPluginRegistryArtifactRunId }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          bash workflow/scripts/docker/shared-image-artifact.sh \
+            verify-upload "Prerelease plugin registry" \
+            "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
 
       - name: Ensure pnpm store cache directory exists
         run: mkdir -p "$(pnpm store path --silent)"
@@ -817,6 +791,68 @@ jobs:
           path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/baseline/${{ steps.baseline_metadata.outputs.file_name }}
           if-no-files-found: error
 
+      - name: Prepare prerelease plugin registry identity
+        id: registry_identity
+        env:
+          ARTIFACT_DIGEST: ${{ steps.upload_prepublish_plugin_registry.outputs.artifact-digest }}
+          ARTIFACT_ID: ${{ steps.upload_prepublish_plugin_registry.outputs.artifact-id }}
+          MANIFEST_SHA256: ${{ steps.source_prepublish_plugin_registry.outputs.manifest_sha256 }}
+          PROVIDED_JSON: ${{ steps.provided_registry.outputs.json }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$ARTIFACT_ID" ]]; then
+            echo "json=$PROVIDED_JSON" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          jq -cnr \
+            --arg digest "$ARTIFACT_DIGEST" \
+            --arg id "$ARTIFACT_ID" \
+            --arg manifest "$MANIFEST_SHA256" \
+            --arg name "openclaw-cross-os-prepublish-plugin-registry-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            --arg attempt "$GITHUB_RUN_ATTEMPT" \
+            --arg run "$GITHUB_RUN_ID" \
+            '{
+              prepublishPluginRegistryArtifactName: $name,
+              prepublishPluginRegistryArtifactId: $id,
+              prepublishPluginRegistryArtifactDigest: $digest,
+              prepublishPluginRegistryArtifactRunId: $run,
+              prepublishPluginRegistryArtifactRunAttempt: $attempt,
+              prepublishPluginRegistryManifestSha256: $manifest
+            } | "json=\(.)"' >> "$GITHUB_OUTPUT"
+
+      - name: Verify prepared artifact uploads
+        env:
+          CANDIDATE_DIGEST: ${{ steps.upload_candidate.outputs.artifact-digest }}
+          CANDIDATE_ID: ${{ steps.upload_candidate.outputs.artifact-id }}
+          BASELINE_DIGEST: ${{ steps.upload_baseline.outputs.artifact-digest }}
+          BASELINE_ID: ${{ steps.upload_baseline.outputs.artifact-id }}
+          GENERATED_REGISTRY: ${{ steps.upload_prepublish_plugin_registry.outputs.artifact-id != '' }}
+          GH_TOKEN: ${{ github.token }}
+          REGISTRY_JSON: ${{ steps.registry_identity.outputs.json }}
+        run: |
+          set -euo pipefail
+          bash workflow/scripts/docker/shared-image-artifact.sh \
+            verify-upload "Candidate" \
+            "$CANDIDATE_ID" \
+            "openclaw-cross-os-release-checks-candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            "$CANDIDATE_DIGEST" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT"
+          if [[ -n "$BASELINE_ID" ]]; then
+            bash workflow/scripts/docker/shared-image-artifact.sh \
+              verify-upload "Baseline" \
+              "$BASELINE_ID" \
+              "openclaw-cross-os-release-checks-baseline-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+              "$BASELINE_DIGEST" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT"
+          fi
+          if [[ "$GENERATED_REGISTRY" == "true" ]]; then
+            bash workflow/scripts/docker/shared-image-artifact.sh \
+              verify-upload "Prerelease plugin registry" \
+              "$(jq -r '.prepublishPluginRegistryArtifactId' <<< "$REGISTRY_JSON")" \
+              "$(jq -r '.prepublishPluginRegistryArtifactName' <<< "$REGISTRY_JSON")" \
+              "$(jq -r '.prepublishPluginRegistryArtifactDigest' <<< "$REGISTRY_JSON")" \
+              "$(jq -r '.prepublishPluginRegistryArtifactRunId' <<< "$REGISTRY_JSON")" \
+              "$(jq -r '.prepublishPluginRegistryArtifactRunAttempt' <<< "$REGISTRY_JSON")"
+          fi
+
       - name: Resolve runner matrix
         id: matrix
         env:
@@ -872,173 +908,6 @@ jobs:
           lockfile-path: workflow/pnpm-lock.yaml
           use-actions-cache: "false"
 
-      - name: Validate prepared candidate artifact binding
-        env:
-          ARTIFACT_DIGEST: ${{ needs.prepare.outputs.candidate_artifact_digest }}
-          ARTIFACT_ID: ${{ needs.prepare.outputs.candidate_artifact_id }}
-          ARTIFACT_NAME: ${{ format('openclaw-cross-os-release-checks-candidate-{0}-{1}', needs.prepare.outputs.candidate_artifact_run_id, needs.prepare.outputs.candidate_artifact_run_attempt) }}
-          ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare.outputs.candidate_artifact_run_attempt }}
-          ARTIFACT_RUN_ID: ${{ needs.prepare.outputs.candidate_artifact_run_id }}
-          BASELINE_ARTIFACT_DIGEST: ${{ needs.prepare.outputs.baseline_artifact_digest }}
-          BASELINE_ARTIFACT_ID: ${{ needs.prepare.outputs.baseline_artifact_id }}
-          BASELINE_ARTIFACT_NAME: ${{ format('openclaw-cross-os-release-checks-baseline-{0}-{1}', needs.prepare.outputs.baseline_artifact_run_id, needs.prepare.outputs.baseline_artifact_run_attempt) }}
-          BASELINE_ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare.outputs.baseline_artifact_run_attempt }}
-          BASELINE_ARTIFACT_RUN_ID: ${{ needs.prepare.outputs.baseline_artifact_run_id }}
-          BASELINE_SHA256: ${{ needs.prepare.outputs.baseline_sha256 }}
-          CANDIDATE_SHA256: ${{ needs.prepare.outputs.candidate_sha256 }}
-          CANDIDATE_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
-          CANDIDATE_VERSION: ${{ needs.prepare.outputs.candidate_version }}
-          GH_TOKEN: ${{ github.token }}
-          PLUGIN_ARTIFACT_DIGEST: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_digest }}
-          PLUGIN_ARTIFACT_ID: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_id }}
-          PLUGIN_ARTIFACT_NAME: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_name }}
-          PLUGIN_ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_run_attempt }}
-          PLUGIN_ARTIFACT_RUN_ID: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_run_id }}
-          PLUGIN_MANIFEST_SHA256: ${{ needs.prepare.outputs.prepublish_plugin_registry_manifest_sha256 }}
-          REQUIRED_COMPANION_PACKAGES_JSON: ${{ needs.prepare.outputs.required_companion_packages_json }}
-          SUITE: ${{ matrix.suite }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ &&
-            "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ &&
-            -n "${ARTIFACT_NAME// }" &&
-            "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ &&
-            "$ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
-            echo "Prepared candidate artifact binding is incomplete." >&2
-            exit 1
-          }
-          [[ "$CANDIDATE_SHA256" =~ ^[a-f0-9]{64}$ &&
-            "$CANDIDATE_SOURCE_SHA" =~ ^[a-f0-9]{40}$ &&
-            -n "${CANDIDATE_VERSION// }" ]] || {
-            echo "Prepared candidate package identity is incomplete." >&2
-            exit 1
-          }
-          if [[ "$SUITE" == "packaged-upgrade" ]]; then
-            [[ "$BASELINE_ARTIFACT_ID" =~ ^[1-9][0-9]*$ &&
-              "$BASELINE_ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ &&
-              -n "${BASELINE_ARTIFACT_NAME// }" &&
-              "$BASELINE_ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ &&
-              "$BASELINE_ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ &&
-              "$BASELINE_SHA256" =~ ^[a-f0-9]{64}$ ]] || {
-              echo "Prepared baseline artifact binding is incomplete." >&2
-              exit 1
-            }
-          fi
-          plugin_tuple_present=false
-          for value in \
-            "$PLUGIN_ARTIFACT_DIGEST" \
-            "$PLUGIN_ARTIFACT_ID" \
-            "$PLUGIN_ARTIFACT_NAME" \
-            "$PLUGIN_ARTIFACT_RUN_ATTEMPT" \
-            "$PLUGIN_ARTIFACT_RUN_ID" \
-            "$PLUGIN_MANIFEST_SHA256"; do
-            if [[ -n "${value// }" ]]; then
-              plugin_tuple_present=true
-            fi
-          done
-          if [[ "$plugin_tuple_present" == "true" ]]; then
-            [[ "$PLUGIN_ARTIFACT_ID" =~ ^[1-9][0-9]*$ &&
-              "$PLUGIN_ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ &&
-              -n "${PLUGIN_ARTIFACT_NAME// }" &&
-              "$PLUGIN_ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ &&
-              "$PLUGIN_ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ &&
-              "$PLUGIN_MANIFEST_SHA256" =~ ^[a-f0-9]{64}$ ]] || {
-              echo "Prepared prerelease plugin registry binding is incomplete." >&2
-              exit 1
-            }
-          fi
-          required_companion_count="$(
-            jq -er 'if type == "array" and all(.[]; type == "string") then length else error("invalid") end' \
-              <<< "$REQUIRED_COMPANION_PACKAGES_JSON"
-          )" || {
-              echo "Required companion packages must be a JSON string array." >&2
-              exit 1
-            }
-          if [[ "$required_companion_count" -gt 0 && "$plugin_tuple_present" != "true" ]]; then
-            echo "Required companion packages need the immutable plugin registry tuple." >&2
-            exit 1
-          fi
-          node <<'NODE'
-          const apiUrl = process.env.GITHUB_API_URL || "https://api.github.com";
-          const repository = process.env.GITHUB_REPOSITORY;
-          const token = process.env.GH_TOKEN;
-          const suite = process.env.SUITE;
-          const tuples = [
-            {
-              digest: process.env.ARTIFACT_DIGEST,
-              id: process.env.ARTIFACT_ID,
-              label: "candidate",
-              name: process.env.ARTIFACT_NAME,
-              runAttempt: process.env.ARTIFACT_RUN_ATTEMPT,
-              runId: process.env.ARTIFACT_RUN_ID,
-            },
-          ];
-          if (suite === "packaged-upgrade") {
-            tuples.push({
-              digest: process.env.BASELINE_ARTIFACT_DIGEST,
-              id: process.env.BASELINE_ARTIFACT_ID,
-              label: "baseline",
-              name: process.env.BASELINE_ARTIFACT_NAME,
-              runAttempt: process.env.BASELINE_ARTIFACT_RUN_ATTEMPT,
-              runId: process.env.BASELINE_ARTIFACT_RUN_ID,
-            });
-          }
-          if (process.env.PLUGIN_ARTIFACT_ID) {
-            tuples.push({
-              digest: process.env.PLUGIN_ARTIFACT_DIGEST,
-              id: process.env.PLUGIN_ARTIFACT_ID,
-              label: "prerelease plugin registry",
-              name: process.env.PLUGIN_ARTIFACT_NAME,
-              runAttempt: process.env.PLUGIN_ARTIFACT_RUN_ATTEMPT,
-              runId: process.env.PLUGIN_ARTIFACT_RUN_ID,
-            });
-          }
-
-          const request = async (path) => {
-            const response = await fetch(`${apiUrl}/repos/${repository}/${path}`, {
-              headers: {
-                Accept: "application/vnd.github+json",
-                Authorization: `Bearer ${token}`,
-                "X-GitHub-Api-Version": "2022-11-28",
-              },
-            });
-            if (!response.ok) {
-              throw new Error(`GitHub artifact API ${path} returned ${response.status}.`);
-            }
-            return response.json();
-          };
-
-          async function main() {
-            for (const tuple of tuples) {
-              const artifact = await request(`actions/artifacts/${tuple.id}`);
-              if (
-                String(artifact.id) !== tuple.id ||
-                artifact.name !== tuple.name ||
-                artifact.expired !== false ||
-                artifact.digest !== `sha256:${tuple.digest}` ||
-                String(artifact.workflow_run?.id) !== tuple.runId
-              ) {
-                throw new Error(`Prepared ${tuple.label} artifact identity does not match.`);
-              }
-              const attempt = await request(
-                `actions/runs/${tuple.runId}/attempts/${tuple.runAttempt}`,
-              );
-              if (
-                String(attempt.id) !== tuple.runId ||
-                String(attempt.run_attempt) !== tuple.runAttempt
-              ) {
-                throw new Error(`Prepared ${tuple.label} artifact run attempt does not match.`);
-              }
-            }
-          }
-
-          main().catch((error) => {
-            console.error(error instanceof Error ? error.message : String(error));
-            process.exitCode = 1;
-          });
-          NODE
-
       - name: Download candidate artifact
         id: download_candidate
         continue-on-error: true
@@ -1079,23 +948,23 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Download prerelease plugin registry artifact
-        if: needs.prepare.outputs.prepublish_plugin_registry_artifact_id != ''
+        if: needs.prepare.outputs.prepublish_plugin_registry_json != ''
         id: download_prepublish_plugin_registry
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          artifact-ids: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_id }}
+          artifact-ids: ${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json).prepublishPluginRegistryArtifactId }}
           path: ${{ runner.temp }}/openclaw-cross-os-release-checks/plugins
-          run-id: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_run_id }}
+          run-id: ${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json).prepublishPluginRegistryArtifactRunId }}
           github-token: ${{ github.token }}
 
       - name: Retry prerelease plugin registry artifact download
-        if: needs.prepare.outputs.prepublish_plugin_registry_artifact_id != '' && steps.download_prepublish_plugin_registry.outcome == 'failure'
+        if: needs.prepare.outputs.prepublish_plugin_registry_json != '' && steps.download_prepublish_plugin_registry.outcome == 'failure'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          artifact-ids: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_id }}
+          artifact-ids: ${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json).prepublishPluginRegistryArtifactId }}
           path: ${{ runner.temp }}/openclaw-cross-os-release-checks/plugins
-          run-id: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_run_id }}
+          run-id: ${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json).prepublishPluginRegistryArtifactRunId }}
           github-token: ${{ github.token }}
 
       - name: Verify release-check inputs
@@ -1169,16 +1038,16 @@ jobs:
           SUITE: ${{ matrix.suite }}
           REF: ${{ inputs.ref }}
           OUTPUT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/${{ matrix.artifact_name }}-${{ matrix.suite }}
-          PLUGIN_REGISTRY_ARTIFACT_ID: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_id }}
+          PLUGIN_REGISTRY_JSON: ${{ needs.prepare.outputs.prepublish_plugin_registry_json }}
           PLUGIN_REGISTRY_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/plugins
-          PLUGIN_REGISTRY_MANIFEST_SHA256: ${{ needs.prepare.outputs.prepublish_plugin_registry_manifest_sha256 }}
           REQUIRED_COMPANION_PACKAGES_JSON: ${{ needs.prepare.outputs.required_companion_packages_json }}
         run: |
           PLUGIN_ARGS=()
-          if [[ -n "$PLUGIN_REGISTRY_ARTIFACT_ID" ]]; then
+          if [[ -n "$PLUGIN_REGISTRY_JSON" ]]; then
             PLUGIN_ARGS+=(
               --plugin-registry-dir "$PLUGIN_REGISTRY_DIR"
-              --plugin-registry-manifest-sha256 "$PLUGIN_REGISTRY_MANIFEST_SHA256"
+              --plugin-registry-manifest-sha256 \
+                "$(jq -r '.prepublishPluginRegistryManifestSha256' <<< "$PLUGIN_REGISTRY_JSON")"
             )
           fi
           DISCORD_ARGS=()

--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -101,8 +101,8 @@ on:
         required: false
         default: ""
         type: string
-      candidate_artifact_json:
-        description: Optional immutable full-release candidate tuple with companion plugins
+      prepublish_plugin_registry_json:
+        description: Optional immutable prerelease plugin registry tuple for manual dispatch
         required: false
         default: ""
         type: string
@@ -210,10 +210,40 @@ on:
         required: false
         default: ""
         type: string
-      candidate_artifact_json:
-        description: Optional immutable full-release candidate tuple with companion plugins
+      prepublish_plugin_registry_artifact_name:
+        description: Optional immutable prerelease plugin registry artifact name
         required: false
         default: ""
+        type: string
+      prepublish_plugin_registry_artifact_id:
+        description: Immutable prerelease plugin registry artifact id
+        required: false
+        default: ""
+        type: string
+      prepublish_plugin_registry_artifact_digest:
+        description: Exact upload-artifact SHA-256 digest for the plugin registry
+        required: false
+        default: ""
+        type: string
+      prepublish_plugin_registry_artifact_run_id:
+        description: Exact workflow run id that produced the plugin registry
+        required: false
+        default: ""
+        type: string
+      prepublish_plugin_registry_artifact_run_attempt:
+        description: Exact workflow run attempt that produced the plugin registry
+        required: false
+        default: ""
+        type: string
+      prepublish_plugin_registry_manifest_sha256:
+        description: Exact SHA-256 of prepublish-plugin-registry.json
+        required: false
+        default: ""
+        type: string
+      required_companion_packages_json:
+        description: JSON array of prerelease companion packages required by these lanes
+        required: false
+        default: "[]"
         type: string
       openai_model:
         description: OpenAI model for release cross-OS agent-turn smoke
@@ -265,15 +295,14 @@ jobs:
       candidate_file_name: ${{ steps.candidate_metadata.outputs.file_name }}
       candidate_sha256: ${{ steps.candidate_metadata.outputs.sha256 }}
       candidate_version: ${{ steps.candidate_metadata.outputs.version }}
-      codex_plugin_file_name: ${{ steps.codex_plugin_metadata.outputs.file_name }}
-      codex_plugin_sha256: ${{ steps.codex_plugin_metadata.outputs.sha256 }}
       matrix: ${{ steps.matrix.outputs.value }}
-      prepublish_plugin_registry_artifact_digest: ${{ steps.upload_generated_plugin_registry.outputs.artifact-digest || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}
-      prepublish_plugin_registry_artifact_id: ${{ steps.upload_generated_plugin_registry.outputs.artifact-id || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}
-      prepublish_plugin_registry_artifact_name: ${{ steps.upload_generated_plugin_registry.outputs.artifact-id && format('openclaw-cross-os-release-checks-plugins-{0}-{1}', github.run_id, github.run_attempt) || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactName || '' }}
-      prepublish_plugin_registry_artifact_run_attempt: ${{ steps.upload_generated_plugin_registry.outputs.artifact-id && github.run_attempt || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}
-      prepublish_plugin_registry_artifact_run_id: ${{ steps.upload_generated_plugin_registry.outputs.artifact-id && github.run_id || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
-      prepublish_plugin_registry_manifest_sha256: ${{ steps.create_codex_plugin_registry.outputs.manifest_sha256 || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
+      prepublish_plugin_registry_artifact_digest: ${{ inputs.prepublish_plugin_registry_artifact_digest || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactDigest || '' }}
+      prepublish_plugin_registry_artifact_id: ${{ inputs.prepublish_plugin_registry_artifact_id || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactId || '' }}
+      prepublish_plugin_registry_artifact_name: ${{ inputs.prepublish_plugin_registry_artifact_name || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactName || '' }}
+      prepublish_plugin_registry_artifact_run_attempt: ${{ inputs.prepublish_plugin_registry_artifact_run_attempt || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactRunAttempt || '' }}
+      prepublish_plugin_registry_artifact_run_id: ${{ inputs.prepublish_plugin_registry_artifact_run_id || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactRunId || '' }}
+      prepublish_plugin_registry_manifest_sha256: ${{ inputs.prepublish_plugin_registry_manifest_sha256 || fromJSON(inputs.prepublish_plugin_registry_json || '{}').manifestSha256 || '' }}
+      required_companion_packages_json: ${{ inputs.required_companion_packages_json || toJSON(fromJSON(inputs.prepublish_plugin_registry_json || '{}').requiredPackages || fromJSON('[]')) }}
       source_sha: ${{ steps.candidate_metadata.outputs.source_sha }}
       workflow_ref: ${{ steps.workflow_ref.outputs.value }}
     steps:
@@ -475,34 +504,12 @@ jobs:
               exit 1
             }
 
-      - name: Validate prerelease plugin registry artifact binding
-        if: fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId != ''
-        env:
-          ARTIFACT_DIGEST: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}
-          ARTIFACT_ID: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}
-          ARTIFACT_NAME: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactName || '' }}
-          ARTIFACT_RUN_ATTEMPT: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}
-          ARTIFACT_RUN_ID: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
-          GH_TOKEN: ${{ github.token }}
-          MANIFEST_SHA256: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          [[ "$MANIFEST_SHA256" =~ ^[a-f0-9]{64}$ ]] || {
-            echo "Prerelease plugin registry manifest SHA-256 is missing or invalid." >&2
-            exit 1
-          }
-          bash workflow/scripts/docker/shared-image-artifact.sh \
-            verify-upload "Prerelease plugin registry" \
-            "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
-            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
-
       - name: Checkout public source ref
-        if: inputs.candidate_artifact_name == '' || (inputs.provider == 'openai' && fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId == '')
+        if: inputs.candidate_artifact_name == ''
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ env.OPENCLAW_REPOSITORY }}
-          ref: ${{ inputs.candidate_artifact_name != '' && inputs.candidate_source_sha || inputs.ref }}
+          ref: ${{ inputs.ref }}
           path: source
           fetch-depth: 0
           filter: blob:none
@@ -532,13 +539,6 @@ jobs:
           CI: "true"
         run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
 
-      - name: Install companion plugin build dependencies
-        if: inputs.candidate_artifact_name != '' && inputs.provider == 'openai' && fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId == ''
-        working-directory: source
-        env:
-          CI: "true"
-        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
-
       - name: Build candidate artifact once
         if: inputs.candidate_artifact_name == ''
         env:
@@ -556,26 +556,6 @@ jobs:
           artifact-ids: ${{ inputs.candidate_artifact_id }}
           path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/input
           run-id: ${{ inputs.candidate_artifact_run_id }}
-          github-token: ${{ github.token }}
-
-      - name: Download prerelease plugin registry artifact
-        if: fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId != ''
-        id: download_prepublish_plugin_registry
-        continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          artifact-ids: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}
-          path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/plugins
-          run-id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
-          github-token: ${{ github.token }}
-
-      - name: Retry prerelease plugin registry artifact download
-        if: fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId != '' && steps.download_prepublish_plugin_registry.outcome == 'failure'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          artifact-ids: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}
-          path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/plugins
-          run-id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
           github-token: ${{ github.token }}
 
       - name: Resolve provided candidate package
@@ -702,80 +682,6 @@ jobs:
           process.stdout.write(`source_sha=${sourceSha}\n`);
           NODE
 
-      - name: Pack exact Codex companion plugin
-        id: create_codex_plugin_registry
-        if: inputs.provider == 'openai' && fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId == ''
-        env:
-          ARTIFACT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/plugins
-          CANDIDATE_VERSION: ${{ steps.candidate_metadata.outputs.version }}
-          SOURCE_SHA: ${{ steps.candidate_metadata.outputs.source_sha }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p "$ARTIFACT_DIR"
-          result="$(
-            node workflow/scripts/prepublish-plugin-registry-artifact.mjs create \
-              --repo-root source \
-              --artifact-dir "$ARTIFACT_DIR" \
-              --source-sha "$SOURCE_SHA" \
-              --candidate-version "$CANDIDATE_VERSION" \
-              --required-packages-json '["@openclaw/codex"]'
-          )"
-          manifest_sha256="$(jq -er '.manifestSha256' <<< "$result")"
-          echo "manifest_sha256=$manifest_sha256" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve exact Codex companion plugin
-        id: codex_plugin_metadata
-        if: inputs.provider == 'openai'
-        env:
-          ARTIFACT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/plugins
-          CANDIDATE_VERSION: ${{ steps.candidate_metadata.outputs.version }}
-          EXPECTED_MANIFEST_SHA256: ${{ steps.create_codex_plugin_registry.outputs.manifest_sha256 || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
-          SOURCE_SHA: ${{ steps.candidate_metadata.outputs.source_sha }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          manifest="$ARTIFACT_DIR/prepublish-plugin-registry.json"
-          required_packages="$(jq -c '[.packages[].name]' "$manifest")"
-          jq -e '.packages | any(.name == "@openclaw/codex")' "$manifest" >/dev/null || {
-            echo "Prerelease plugin registry does not contain @openclaw/codex." >&2
-            exit 1
-          }
-          node workflow/scripts/prepublish-plugin-registry-artifact.mjs verify \
-            --artifact-dir "$ARTIFACT_DIR" \
-            --source-sha "$SOURCE_SHA" \
-            --candidate-version "$CANDIDATE_VERSION" \
-            --manifest-sha256 "$EXPECTED_MANIFEST_SHA256" \
-            --required-packages-json "$required_packages"
-          node <<'NODE' >>"$GITHUB_OUTPUT"
-          const fs = require("node:fs");
-          const path = require("node:path");
-          const manifest = JSON.parse(
-            fs.readFileSync(path.join(process.env.ARTIFACT_DIR, "prepublish-plugin-registry.json"), "utf8"),
-          );
-          const entry = manifest.packages.find((candidate) => candidate.name === "@openclaw/codex");
-          if (
-            typeof entry?.tarball !== "string" ||
-            !entry.tarball.endsWith(".tgz") ||
-            entry.tarball !== path.basename(entry.tarball) ||
-            entry.tarball !== path.win32.basename(entry.tarball) ||
-            !/^[a-f0-9]{64}$/u.test(entry.sha256 ?? "")
-          ) {
-            throw new Error("Codex companion plugin manifest entry is invalid.");
-          }
-          process.stdout.write(`file_name=${entry.tarball}\n`);
-          process.stdout.write(`sha256=${entry.sha256}\n`);
-          NODE
-
-      - name: Upload generated prerelease plugin registry artifact
-        id: upload_generated_plugin_registry
-        if: inputs.provider == 'openai' && steps.create_codex_plugin_registry.outputs.manifest_sha256 != ''
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: openclaw-cross-os-release-checks-plugins-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/plugins/
-          if-no-files-found: error
-
       - name: Capture baseline metadata
         if: ${{ inputs.mode != 'fresh' }}
         id: baseline_metadata
@@ -899,13 +805,14 @@ jobs:
           CANDIDATE_SHA256: ${{ needs.prepare.outputs.candidate_sha256 }}
           CANDIDATE_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
           CANDIDATE_VERSION: ${{ needs.prepare.outputs.candidate_version }}
-          CODEX_PLUGIN_FILE_NAME: ${{ needs.prepare.outputs.codex_plugin_file_name }}
           GH_TOKEN: ${{ github.token }}
           PLUGIN_ARTIFACT_DIGEST: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_digest }}
           PLUGIN_ARTIFACT_ID: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_id }}
           PLUGIN_ARTIFACT_NAME: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_name }}
           PLUGIN_ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_run_attempt }}
           PLUGIN_ARTIFACT_RUN_ID: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_run_id }}
+          PLUGIN_MANIFEST_SHA256: ${{ needs.prepare.outputs.prepublish_plugin_registry_manifest_sha256 }}
+          REQUIRED_COMPANION_PACKAGES_JSON: ${{ needs.prepare.outputs.required_companion_packages_json }}
           SUITE: ${{ matrix.suite }}
         shell: bash
         run: |
@@ -935,6 +842,40 @@ jobs:
               exit 1
             }
           fi
+          plugin_tuple_present=false
+          for value in \
+            "$PLUGIN_ARTIFACT_DIGEST" \
+            "$PLUGIN_ARTIFACT_ID" \
+            "$PLUGIN_ARTIFACT_NAME" \
+            "$PLUGIN_ARTIFACT_RUN_ATTEMPT" \
+            "$PLUGIN_ARTIFACT_RUN_ID" \
+            "$PLUGIN_MANIFEST_SHA256"; do
+            if [[ -n "${value// }" ]]; then
+              plugin_tuple_present=true
+            fi
+          done
+          if [[ "$plugin_tuple_present" == "true" ]]; then
+            [[ "$PLUGIN_ARTIFACT_ID" =~ ^[1-9][0-9]*$ &&
+              "$PLUGIN_ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ &&
+              -n "${PLUGIN_ARTIFACT_NAME// }" &&
+              "$PLUGIN_ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ &&
+              "$PLUGIN_ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ &&
+              "$PLUGIN_MANIFEST_SHA256" =~ ^[a-f0-9]{64}$ ]] || {
+              echo "Prepared prerelease plugin registry binding is incomplete." >&2
+              exit 1
+            }
+          fi
+          required_companion_count="$(
+            jq -er 'if type == "array" and all(.[]; type == "string") then length else error("invalid") end' \
+              <<< "$REQUIRED_COMPANION_PACKAGES_JSON"
+          )" || {
+              echo "Required companion packages must be a JSON string array." >&2
+              exit 1
+            }
+          if [[ "$required_companion_count" -gt 0 && "$plugin_tuple_present" != "true" ]]; then
+            echo "Required companion packages need the immutable plugin registry tuple." >&2
+            exit 1
+          fi
           node <<'NODE'
           const apiUrl = process.env.GITHUB_API_URL || "https://api.github.com";
           const repository = process.env.GITHUB_REPOSITORY;
@@ -960,7 +901,7 @@ jobs:
               runId: process.env.BASELINE_ARTIFACT_RUN_ID,
             });
           }
-          if (process.env.CODEX_PLUGIN_FILE_NAME) {
+          if (process.env.PLUGIN_ARTIFACT_ID) {
             tuples.push({
               digest: process.env.PLUGIN_ARTIFACT_DIGEST,
               id: process.env.PLUGIN_ARTIFACT_ID,
@@ -1055,7 +996,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Download prerelease plugin registry artifact
-        if: needs.prepare.outputs.codex_plugin_file_name != ''
+        if: needs.prepare.outputs.prepublish_plugin_registry_artifact_id != ''
         id: download_prepublish_plugin_registry
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -1066,7 +1007,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Retry prerelease plugin registry artifact download
-        if: needs.prepare.outputs.codex_plugin_file_name != '' && steps.download_prepublish_plugin_registry.outcome == 'failure'
+        if: needs.prepare.outputs.prepublish_plugin_registry_artifact_id != '' && steps.download_prepublish_plugin_registry.outcome == 'failure'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           artifact-ids: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_id }}
@@ -1081,8 +1022,6 @@ jobs:
           EXPECTED_CANDIDATE_SHA256: ${{ needs.prepare.outputs.candidate_sha256 }}
           BASELINE_TGZ: ${{ runner.temp }}/openclaw-cross-os-release-checks/baseline/${{ needs.prepare.outputs.baseline_file_name }}
           EXPECTED_BASELINE_SHA256: ${{ needs.prepare.outputs.baseline_sha256 }}
-          CODEX_PLUGIN_TGZ: ${{ runner.temp }}/openclaw-cross-os-release-checks/plugins/${{ needs.prepare.outputs.codex_plugin_file_name }}
-          EXPECTED_CODEX_PLUGIN_SHA256: ${{ needs.prepare.outputs.codex_plugin_sha256 }}
           OUTPUT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/${{ matrix.artifact_name }}-${{ matrix.suite }}
           SUITE: ${{ matrix.suite }}
         run: |
@@ -1125,27 +1064,6 @@ jobs:
               exit 1
             fi
           fi
-          if [[ -n "$EXPECTED_CODEX_PLUGIN_SHA256" ]]; then
-            [[ -f "$CODEX_PLUGIN_TGZ" ]] || {
-              echo "::error::Codex companion plugin artifact missing: ${CODEX_PLUGIN_TGZ}"
-              exit 1
-            }
-            actual_codex_sha256="$(
-              node -e '
-                const crypto = require("node:crypto");
-                const fs = require("node:fs");
-                process.stdout.write(
-                  crypto.createHash("sha256").update(fs.readFileSync(process.env.CODEX_PLUGIN_TGZ)).digest("hex"),
-                );
-              '
-            )"
-            if [[ ! "$EXPECTED_CODEX_PLUGIN_SHA256" =~ ^[a-f0-9]{64}$ ||
-                  "$actual_codex_sha256" != "$EXPECTED_CODEX_PLUGIN_SHA256" ]]; then
-              echo "::error::Codex companion plugin SHA-256 does not match the prepared identity"
-              exit 1
-            fi
-          fi
-
       - name: Run cross-OS release checks
         shell: bash
         env:
@@ -1168,14 +1086,18 @@ jobs:
           SUITE: ${{ matrix.suite }}
           REF: ${{ inputs.ref }}
           OUTPUT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/${{ matrix.artifact_name }}-${{ matrix.suite }}
-          CODEX_PLUGIN_FILE_NAME: ${{ needs.prepare.outputs.codex_plugin_file_name }}
-          CODEX_PLUGIN_TGZ: ${{ runner.temp }}/openclaw-cross-os-release-checks/plugins/${{ needs.prepare.outputs.codex_plugin_file_name }}
+          PLUGIN_REGISTRY_ARTIFACT_ID: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_id }}
+          PLUGIN_REGISTRY_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/plugins
+          PLUGIN_REGISTRY_MANIFEST_SHA256: ${{ needs.prepare.outputs.prepublish_plugin_registry_manifest_sha256 }}
+          REQUIRED_COMPANION_PACKAGES_JSON: ${{ needs.prepare.outputs.required_companion_packages_json }}
         run: |
-          if [[ -n "$CODEX_PLUGIN_FILE_NAME" ]]; then
-            export OPENCLAW_ALLOW_PLUGIN_INSTALL_OVERRIDES=1
-            export OPENCLAW_PLUGIN_INSTALL_OVERRIDES="$(
-              node -e 'process.stdout.write(JSON.stringify({ codex: `npm-pack:${process.env.CODEX_PLUGIN_TGZ}` }))'
-            )"
+          PLUGIN_ARGS=()
+          if [[ -n "$PLUGIN_REGISTRY_ARTIFACT_ID" ]]; then
+            PLUGIN_ARGS+=(
+              --plugin-registry-dir "$PLUGIN_REGISTRY_DIR"
+              --plugin-registry-manifest-sha256 "$PLUGIN_REGISTRY_MANIFEST_SHA256"
+              --required-companion-packages-json "$REQUIRED_COMPANION_PACKAGES_JSON"
+            )
           fi
           DISCORD_ARGS=()
           if [[ -n "${OPENCLAW_DISCORD_SMOKE_BOT_TOKEN}" ]] && [[ -n "${OPENCLAW_DISCORD_SMOKE_GUILD_ID}" ]] && [[ -n "${OPENCLAW_DISCORD_SMOKE_CHANNEL_ID}" ]]; then
@@ -1193,6 +1115,7 @@ jobs:
               --mode "${MODE}" \
               --suite "${SUITE}" \
               --ref "${REF}" \
+              "${PLUGIN_ARGS[@]}" \
               "${DISCORD_ARGS[@]}" \
               --output-dir "${OUTPUT_DIR}"
           }

--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -240,11 +240,6 @@ on:
         required: false
         default: ""
         type: string
-      required_companion_packages_json:
-        description: JSON array of prerelease companion packages required by these lanes
-        required: false
-        default: "[]"
-        type: string
       openai_model:
         description: OpenAI model for release cross-OS agent-turn smoke
         required: false
@@ -296,13 +291,13 @@ jobs:
       candidate_sha256: ${{ steps.candidate_metadata.outputs.sha256 }}
       candidate_version: ${{ steps.candidate_metadata.outputs.version }}
       matrix: ${{ steps.matrix.outputs.value }}
-      prepublish_plugin_registry_artifact_digest: ${{ inputs.prepublish_plugin_registry_artifact_digest || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactDigest || '' }}
-      prepublish_plugin_registry_artifact_id: ${{ inputs.prepublish_plugin_registry_artifact_id || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactId || '' }}
-      prepublish_plugin_registry_artifact_name: ${{ inputs.prepublish_plugin_registry_artifact_name || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactName || '' }}
-      prepublish_plugin_registry_artifact_run_attempt: ${{ inputs.prepublish_plugin_registry_artifact_run_attempt || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactRunAttempt || '' }}
-      prepublish_plugin_registry_artifact_run_id: ${{ inputs.prepublish_plugin_registry_artifact_run_id || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactRunId || '' }}
-      prepublish_plugin_registry_manifest_sha256: ${{ inputs.prepublish_plugin_registry_manifest_sha256 || fromJSON(inputs.prepublish_plugin_registry_json || '{}').manifestSha256 || '' }}
-      required_companion_packages_json: ${{ inputs.required_companion_packages_json || toJSON(fromJSON(inputs.prepublish_plugin_registry_json || '{}').requiredPackages || fromJSON('[]')) }}
+      prepublish_plugin_registry_artifact_digest: ${{ steps.upload_prepublish_plugin_registry.outputs.artifact-digest || inputs.prepublish_plugin_registry_artifact_digest || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactDigest || '' }}
+      prepublish_plugin_registry_artifact_id: ${{ steps.upload_prepublish_plugin_registry.outputs.artifact-id || inputs.prepublish_plugin_registry_artifact_id || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactId || '' }}
+      prepublish_plugin_registry_artifact_name: ${{ steps.upload_prepublish_plugin_registry.outputs.artifact-id && format('openclaw-cross-os-prepublish-plugin-registry-{0}-{1}', github.run_id, github.run_attempt) || inputs.prepublish_plugin_registry_artifact_name || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactName || '' }}
+      prepublish_plugin_registry_artifact_run_attempt: ${{ steps.upload_prepublish_plugin_registry.outputs.artifact-id && github.run_attempt || inputs.prepublish_plugin_registry_artifact_run_attempt || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactRunAttempt || '' }}
+      prepublish_plugin_registry_artifact_run_id: ${{ steps.upload_prepublish_plugin_registry.outputs.artifact-id && github.run_id || inputs.prepublish_plugin_registry_artifact_run_id || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactRunId || '' }}
+      prepublish_plugin_registry_manifest_sha256: ${{ steps.source_prepublish_plugin_registry.outputs.manifest_sha256 || inputs.prepublish_plugin_registry_manifest_sha256 || fromJSON(inputs.prepublish_plugin_registry_json || '{}').manifestSha256 || '' }}
+      required_companion_packages_json: ${{ steps.provider_requirements.outputs.json }}
       source_sha: ${{ steps.candidate_metadata.outputs.source_sha }}
       workflow_ref: ${{ steps.workflow_ref.outputs.value }}
     steps:
@@ -529,6 +524,65 @@ jobs:
           lockfile-path: ${{ inputs.candidate_artifact_name == '' && 'source/pnpm-lock.yaml' || 'workflow/pnpm-lock.yaml' }}
           use-actions-cache: ${{ inputs.candidate_artifact_name == '' && 'true' || 'false' }}
 
+      - name: Resolve provider-owned companion requirements
+        id: provider_requirements
+        env:
+          PROVIDER: ${{ inputs.provider }}
+        run: |
+          set -euo pipefail
+          packages_json="$(
+            bash workflow/scripts/github/run-openclaw-cross-os-release-checks.sh \
+              --resolve-provider-required-companion-packages \
+              --provider "$PROVIDER"
+          )"
+          jq -e 'type == "array" and all(.[]; type == "string")' <<< "$packages_json" >/dev/null
+          echo "json=$packages_json" >> "$GITHUB_OUTPUT"
+
+      - name: Validate companion registry contract
+        env:
+          CANDIDATE_ARTIFACT_NAME: ${{ inputs.candidate_artifact_name }}
+          PLUGIN_ARTIFACT_DIGEST: ${{ inputs.prepublish_plugin_registry_artifact_digest || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactDigest || '' }}
+          PLUGIN_ARTIFACT_ID: ${{ inputs.prepublish_plugin_registry_artifact_id || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactId || '' }}
+          PLUGIN_ARTIFACT_NAME: ${{ inputs.prepublish_plugin_registry_artifact_name || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactName || '' }}
+          PLUGIN_ARTIFACT_RUN_ATTEMPT: ${{ inputs.prepublish_plugin_registry_artifact_run_attempt || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactRunAttempt || '' }}
+          PLUGIN_ARTIFACT_RUN_ID: ${{ inputs.prepublish_plugin_registry_artifact_run_id || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactRunId || '' }}
+          PLUGIN_MANIFEST_SHA256: ${{ inputs.prepublish_plugin_registry_manifest_sha256 || fromJSON(inputs.prepublish_plugin_registry_json || '{}').manifestSha256 || '' }}
+          PREPUBLISH_PLUGIN_REGISTRY_JSON: ${{ inputs.prepublish_plugin_registry_json }}
+          REQUIRED_COMPANION_PACKAGES_JSON: ${{ steps.provider_requirements.outputs.json }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${PREPUBLISH_PLUGIN_REGISTRY_JSON// }" ]]; then
+            jq -e 'has("requiredPackages") | not' <<< "$PREPUBLISH_PLUGIN_REGISTRY_JSON" >/dev/null || {
+              echo "Provider-owned companion requirements cannot be overridden by dispatch input." >&2
+              exit 1
+            }
+          fi
+          tuple_count=0
+          for value in \
+            "$PLUGIN_ARTIFACT_DIGEST" \
+            "$PLUGIN_ARTIFACT_ID" \
+            "$PLUGIN_ARTIFACT_NAME" \
+            "$PLUGIN_ARTIFACT_RUN_ATTEMPT" \
+            "$PLUGIN_ARTIFACT_RUN_ID" \
+            "$PLUGIN_MANIFEST_SHA256"; do
+            [[ -n "${value// }" ]] && tuple_count=$((tuple_count + 1))
+          done
+          [[ "$tuple_count" == "0" || "$tuple_count" == "6" ]] || {
+            echo "Prerelease companion registry selection must provide the complete immutable tuple." >&2
+            exit 1
+          }
+          required_count="$(jq -er 'length' <<< "$REQUIRED_COMPANION_PACKAGES_JSON")"
+          if [[ -z "${CANDIDATE_ARTIFACT_NAME// }" ]]; then
+            [[ "$tuple_count" == "0" ]] || {
+              echo "Source-built candidates produce their own companion registry and reject a second tuple." >&2
+              exit 1
+            }
+          elif [[ "$required_count" -gt 0 && "$tuple_count" != "6" ]]; then
+            echo "The selected provider requires a complete immutable companion registry tuple." >&2
+            exit 1
+          fi
+
       - name: Ensure pnpm store cache directory exists
         run: mkdir -p "$(pnpm store path --silent)"
 
@@ -543,11 +597,31 @@ jobs:
         if: inputs.candidate_artifact_name == ''
         env:
           OUTPUT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare
+          PROVIDER: ${{ inputs.provider }}
         run: |
           bash workflow/scripts/github/run-openclaw-cross-os-release-checks.sh \
             --prepare-only \
+            --provider "$PROVIDER" \
             --source-dir source \
             --output-dir "${OUTPUT_DIR}"
+
+      - name: Pack source-built prerelease companion registry
+        id: source_prepublish_plugin_registry
+        if: inputs.candidate_artifact_name == '' && steps.provider_requirements.outputs.json != '[]'
+        env:
+          OUTPUT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare
+          REQUIRED_PACKAGES_JSON: ${{ steps.provider_requirements.outputs.json }}
+        run: |
+          set -euo pipefail
+          result="$(
+            node workflow/scripts/prepublish-plugin-registry-artifact.mjs create \
+              --repo-root source \
+              --artifact-dir "$OUTPUT_DIR/plugins" \
+              --source-sha "$(git -C source rev-parse HEAD)" \
+              --candidate-version "$(node -p "require('./source/package.json').version")" \
+              --required-packages-json "$REQUIRED_PACKAGES_JSON"
+          )"
+          echo "manifest_sha256=$(jq -er '.manifestSha256' <<< "$result")" >> "$GITHUB_OUTPUT"
 
       - name: Download provided candidate artifact
         if: inputs.candidate_artifact_name != ''
@@ -723,6 +797,15 @@ jobs:
         with:
           name: openclaw-cross-os-release-checks-candidate-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/package/${{ steps.candidate_metadata.outputs.file_name }}
+          if-no-files-found: error
+
+      - name: Upload source-built prerelease companion registry
+        id: upload_prepublish_plugin_registry
+        if: inputs.candidate_artifact_name == '' && steps.provider_requirements.outputs.json != '[]'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: openclaw-cross-os-prepublish-plugin-registry-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/plugins/
           if-no-files-found: error
 
       - name: Upload baseline artifact
@@ -1096,7 +1179,6 @@ jobs:
             PLUGIN_ARGS+=(
               --plugin-registry-dir "$PLUGIN_REGISTRY_DIR"
               --plugin-registry-manifest-sha256 "$PLUGIN_REGISTRY_MANIFEST_SHA256"
-              --required-companion-packages-json "$REQUIRED_COMPANION_PACKAGES_JSON"
             )
           fi
           DISCORD_ARGS=()

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -610,12 +610,12 @@ jobs:
       package_file_name: ${{ steps.artifact.outputs.file_name || fromJSON(inputs.candidate_artifact_json || '{}').packageFileName }}
       package_sha256: ${{ steps.package.outputs.sha256 || fromJSON(inputs.candidate_artifact_json || '{}').packageSha256 }}
       package_version: ${{ steps.package.outputs.package_version || fromJSON(inputs.candidate_artifact_json || '{}').packageVersion }}
-      prepublish_plugin_registry_artifact_digest: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}
-      prepublish_plugin_registry_artifact_id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}
-      prepublish_plugin_registry_artifact_name: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactName || '' }}
-      prepublish_plugin_registry_artifact_run_attempt: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}
-      prepublish_plugin_registry_artifact_run_id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
-      prepublish_plugin_registry_manifest_sha256: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
+      prepublish_plugin_registry_artifact_digest: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-digest || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}
+      prepublish_plugin_registry_artifact_id: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}
+      prepublish_plugin_registry_artifact_name: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id && format('docker-e2e-prepublish-plugin-registry-{0}-{1}', github.run_id, github.run_attempt) || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactName || '' }}
+      prepublish_plugin_registry_artifact_run_attempt: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id && github.run_attempt || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}
+      prepublish_plugin_registry_artifact_run_id: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id && github.run_id || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
+      prepublish_plugin_registry_manifest_sha256: ${{ steps.package.outputs.plugin_registry_manifest_sha256 || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
       source_sha: ${{ steps.package.outputs.source_sha || fromJSON(inputs.candidate_artifact_json || '{}').packageSourceSha }}
     steps:
       - name: Checkout trusted workflow ref
@@ -655,13 +655,37 @@ jobs:
         run: |
           set -euo pipefail
           source_args=(--source ref --package-ref "$PACKAGE_REF")
+          registry_args=()
           package_label="ref:${PACKAGE_REF}"
           if [[ -n "${RELEASE_PACKAGE_SPEC// }" ]]; then
             source_args=(--source npm --package-spec "$RELEASE_PACKAGE_SPEC")
             package_label="$RELEASE_PACKAGE_SPEC"
+          else
+            provider_packages="$(
+              OPENCLAW_RELEASE_CHECKS_SCRIPT=scripts/openclaw-cross-os-release-checks.ts \
+                bash scripts/github/run-openclaw-cross-os-release-checks.sh \
+                --resolve-provider-required-companion-packages \
+                --provider "${{ needs.resolve_target.outputs.provider }}"
+            )"
+            export OPENCLAW_DOCKER_ALL_PROFILE=release-path
+            export OPENCLAW_DOCKER_ALL_PLAN_RELEASE_ALL=1
+            export OPENCLAW_DOCKER_ALL_INCLUDE_OPENWEBUI="${{ needs.resolve_target.outputs.release_profile != 'beta' }}"
+            export OPENCLAW_DOCKER_ALL_RELEASE_PROFILE="${{ needs.resolve_target.outputs.release_profile }}"
+            docker_plan="$(node scripts/test-docker-all.mjs --plan-json)"
+            required_packages="$(
+              jq -cn \
+                --argjson provider "$provider_packages" \
+                --argjson docker "$(jq -c '.requiredPrepublishPluginPackages' <<< "$docker_plan")" \
+                '$provider + $docker | unique | sort'
+            )"
+            registry_args=(
+              --plugin-registry-output-dir .artifacts/prepublish-plugin-registry
+              --required-plugin-packages-json "$required_packages"
+            )
           fi
           node scripts/resolve-openclaw-package-candidate.mjs \
             "${source_args[@]}" \
+            "${registry_args[@]}" \
             --output-dir .artifacts/docker-e2e-package \
             --output-name openclaw-current.tgz \
             --metadata .artifacts/docker-e2e-package/package-candidate.json \
@@ -669,11 +693,13 @@ jobs:
           digest="$(node -p "JSON.parse(require('fs').readFileSync('.artifacts/docker-e2e-package/package-candidate.json', 'utf8')).sha256")"
           version="$(node -p "JSON.parse(require('fs').readFileSync('.artifacts/docker-e2e-package/package-candidate.json', 'utf8')).version")"
           source_sha="$(node -p "JSON.parse(require('fs').readFileSync('.artifacts/docker-e2e-package/package-candidate.json', 'utf8')).packageSourceSha")"
+          plugin_registry_manifest_sha256="$(node -p "JSON.parse(require('fs').readFileSync('.artifacts/docker-e2e-package/package-candidate.json', 'utf8')).pluginRegistryManifestSha256 || ''")"
           if [[ "$source_sha" != "$PACKAGE_REF" ]]; then
             echo "Release package source SHA differs from the selected release SHA: expected $PACKAGE_REF, found ${source_sha:-<missing>}." >&2
             exit 1
           fi
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "plugin_registry_manifest_sha256=$plugin_registry_manifest_sha256" >> "$GITHUB_OUTPUT"
           {
             echo "## Release package artifact"
             echo
@@ -693,6 +719,16 @@ jobs:
           path: |
             .artifacts/docker-e2e-package/${{ steps.artifact.outputs.file_name }}
             .artifacts/docker-e2e-package/package-candidate.json
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Upload shared prerelease plugin registry artifact
+        id: prepublish_plugin_registry_upload
+        if: inputs.candidate_artifact_json == '' && steps.package.outputs.plugin_registry_manifest_sha256 != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: docker-e2e-prepublish-plugin-registry-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/prepublish-plugin-registry/
           retention-days: 14
           if-no-files-found: error
 
@@ -732,6 +768,21 @@ jobs:
             "$PACKAGE_SOURCE_SHA" =~ ^[a-f0-9]{40}$ &&
             -n "${PACKAGE_VERSION// }" ]] || {
             echo "Release package identity is incomplete." >&2
+            exit 1
+          }
+
+      - name: Validate shared prerelease plugin registry binding
+        if: inputs.candidate_artifact_json == '' && steps.package.outputs.plugin_registry_manifest_sha256 != ''
+        env:
+          ARTIFACT_DIGEST: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-digest }}
+          ARTIFACT_ID: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id }}
+          MANIFEST_SHA256: ${{ steps.package.outputs.plugin_registry_manifest_sha256 }}
+        run: |
+          set -euo pipefail
+          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ &&
+            "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ &&
+            "$MANIFEST_SHA256" =~ ^[a-f0-9]{64}$ ]] || {
+            echo "Shared prerelease plugin registry identity is incomplete." >&2
             exit 1
           }
 
@@ -826,7 +877,6 @@ jobs:
       prepublish_plugin_registry_artifact_run_attempt: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_run_attempt }}
       prepublish_plugin_registry_artifact_run_id: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_run_id }}
       prepublish_plugin_registry_manifest_sha256: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_manifest_sha256 }}
-      required_companion_packages_json: ${{ needs.resolve_target.outputs.provider == 'openai' && '["@openclaw/codex"]' || '[]' }}
       openai_model: openai/gpt-5.6-luna
       ubuntu_runner: ubuntu-24.04
       windows_runner: windows-2025

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -154,6 +154,8 @@ jobs:
       release_package_spec: ${{ steps.inputs.outputs.release_package_spec }}
       package_acceptance_package_spec: ${{ steps.inputs.outputs.package_acceptance_package_spec }}
       codex_plugin_spec: ${{ steps.inputs.outputs.codex_plugin_spec }}
+      cross_os_scheduled: ${{ steps.inputs.outputs.cross_os_scheduled }}
+      docker_release_scheduled: ${{ steps.inputs.outputs.docker_release_scheduled }}
     steps:
       - name: Require trusted workflow ref for release checks
         env:
@@ -506,6 +508,17 @@ jobs:
             fi
           fi
 
+          cross_os_scheduled=false
+          if [[ "$RELEASE_RERUN_GROUP_INPUT" == "all" || "$RELEASE_RERUN_GROUP_INPUT" == "cross-os" ]]; then
+            cross_os_scheduled=true
+          fi
+          docker_release_scheduled=false
+          if { [[ "$RELEASE_RERUN_GROUP_INPUT" == "live-e2e" ]] ||
+              { [[ "$RELEASE_RERUN_GROUP_INPUT" == "all" ]] && [[ "$run_release_soak" == "true" ]]; }; } &&
+            [[ -z "${repo_live_suite_filter// }" ]]; then
+            docker_release_scheduled=true
+          fi
+
           {
             printf 'ref=%s\n' "$RELEASE_REF_INPUT"
             printf 'provider=%s\n' "$RELEASE_PROVIDER_INPUT"
@@ -528,6 +541,8 @@ jobs:
             printf 'release_package_spec=%s\n' "$RELEASE_PACKAGE_SPEC_INPUT"
             printf 'package_acceptance_package_spec=%s\n' "$RELEASE_PACKAGE_ACCEPTANCE_PACKAGE_SPEC_INPUT"
             printf 'codex_plugin_spec=%s\n' "$codex_plugin_spec"
+            printf 'cross_os_scheduled=%s\n' "$cross_os_scheduled"
+            printf 'docker_release_scheduled=%s\n' "$docker_release_scheduled"
           } >> "$GITHUB_OUTPUT"
 
       - name: Summarize validated ref
@@ -595,10 +610,11 @@ jobs:
   prepare_release_package:
     name: Prepare release package artifact
     needs: [resolve_target]
-    if: contains(fromJSON('["all","cross-os","package"]'), needs.resolve_target.outputs.rerun_group) || (needs.resolve_target.outputs.rerun_group == 'live-e2e' && needs.resolve_target.outputs.repo_live_suite_filter == '')
+    if: needs.resolve_target.outputs.cross_os_scheduled == 'true' || needs.resolve_target.outputs.docker_release_scheduled == 'true' || needs.resolve_target.outputs.rerun_group == 'package'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
+      actions: read
       contents: read
       packages: read
     outputs:
@@ -610,12 +626,7 @@ jobs:
       package_file_name: ${{ steps.artifact.outputs.file_name || fromJSON(inputs.candidate_artifact_json || '{}').packageFileName }}
       package_sha256: ${{ steps.package.outputs.sha256 || fromJSON(inputs.candidate_artifact_json || '{}').packageSha256 }}
       package_version: ${{ steps.package.outputs.package_version || fromJSON(inputs.candidate_artifact_json || '{}').packageVersion }}
-      prepublish_plugin_registry_artifact_digest: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-digest || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}
-      prepublish_plugin_registry_artifact_id: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}
-      prepublish_plugin_registry_artifact_name: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id && format('docker-e2e-prepublish-plugin-registry-{0}-{1}', github.run_id, github.run_attempt) || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactName || '' }}
-      prepublish_plugin_registry_artifact_run_attempt: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id && github.run_attempt || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}
-      prepublish_plugin_registry_artifact_run_id: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id && github.run_id || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
-      prepublish_plugin_registry_manifest_sha256: ${{ steps.package.outputs.plugin_registry_manifest_sha256 || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
+      prepublish_plugin_registry_json: ${{ steps.registry_identity.outputs.json }}
       source_sha: ${{ steps.package.outputs.source_sha || fromJSON(inputs.candidate_artifact_json || '{}').packageSourceSha }}
     steps:
       - name: Checkout trusted workflow ref
@@ -650,8 +661,12 @@ jobs:
         if: inputs.candidate_artifact_json == ''
         shell: bash
         env:
+          CROSS_OS_SCHEDULED: ${{ needs.resolve_target.outputs.cross_os_scheduled }}
+          DOCKER_RELEASE_SCHEDULED: ${{ needs.resolve_target.outputs.docker_release_scheduled }}
           PACKAGE_REF: ${{ needs.resolve_target.outputs.revision }}
+          PROVIDER: ${{ needs.resolve_target.outputs.provider }}
           RELEASE_PACKAGE_SPEC: ${{ needs.resolve_target.outputs.release_package_spec }}
+          RELEASE_PROFILE: ${{ needs.resolve_target.outputs.release_profile }}
         run: |
           set -euo pipefail
           source_args=(--source ref --package-ref "$PACKAGE_REF")
@@ -660,27 +675,42 @@ jobs:
             source_args=(--source npm --package-spec "$RELEASE_PACKAGE_SPEC" --package-ref "$PACKAGE_REF")
             package_label="$RELEASE_PACKAGE_SPEC"
           fi
-          provider_packages="$(
-            OPENCLAW_RELEASE_CHECKS_SCRIPT=scripts/openclaw-cross-os-release-checks.ts \
-              bash scripts/github/run-openclaw-cross-os-release-checks.sh \
-              --resolve-provider-required-companion-packages \
-              --provider "${{ needs.resolve_target.outputs.provider }}"
-          )"
-          export OPENCLAW_DOCKER_ALL_PROFILE=release-path
-          export OPENCLAW_DOCKER_ALL_PLAN_RELEASE_ALL=1
-          export OPENCLAW_DOCKER_ALL_INCLUDE_OPENWEBUI="${{ needs.resolve_target.outputs.release_profile != 'beta' }}"
-          export OPENCLAW_DOCKER_ALL_RELEASE_PROFILE="${{ needs.resolve_target.outputs.release_profile }}"
-          docker_plan="$(node scripts/test-docker-all.mjs --plan-json)"
+          provider_packages='[]'
+          if [[ "$CROSS_OS_SCHEDULED" == "true" ]]; then
+            provider_packages="$(
+              OPENCLAW_RELEASE_CHECKS_SCRIPT=scripts/openclaw-cross-os-release-checks.ts \
+                bash scripts/github/run-openclaw-cross-os-release-checks.sh \
+                --resolve-provider-required-companion-packages \
+                --provider "$PROVIDER"
+            )"
+          fi
+          docker_packages='[]'
+          if [[ "$DOCKER_RELEASE_SCHEDULED" == "true" && -z "${RELEASE_PACKAGE_SPEC// }" ]]; then
+            export OPENCLAW_DOCKER_ALL_PROFILE=release-path
+            export OPENCLAW_DOCKER_ALL_PLAN_RELEASE_ALL=1
+            export OPENCLAW_DOCKER_ALL_INCLUDE_OPENWEBUI="${{ needs.resolve_target.outputs.release_profile != 'beta' }}"
+            export OPENCLAW_DOCKER_ALL_RELEASE_PROFILE="$RELEASE_PROFILE"
+            docker_packages="$(
+              node scripts/test-docker-all.mjs --plan-json |
+                jq -c '.requiredPrepublishPluginPackages'
+            )"
+          fi
           required_packages="$(
-            jq -cn \
+            jq -cnr \
               --argjson provider "$provider_packages" \
-              --argjson docker "$(jq -c '.requiredPrepublishPluginPackages' <<< "$docker_plan")" \
+              --argjson docker "$docker_packages" \
               '$provider + $docker | unique | sort'
           )"
+          registry_args=()
+          if [[ "$required_packages" != '[]' ]]; then
+            registry_args=(
+              --plugin-registry-output-dir .artifacts/prepublish-plugin-registry
+              --required-plugin-packages-json "$required_packages"
+            )
+          fi
           node scripts/resolve-openclaw-package-candidate.mjs \
             "${source_args[@]}" \
-            --plugin-registry-output-dir .artifacts/prepublish-plugin-registry \
-            --required-plugin-packages-json "$required_packages" \
+            "${registry_args[@]}" \
             --output-dir .artifacts/docker-e2e-package \
             --output-name openclaw-current.tgz \
             --metadata .artifacts/docker-e2e-package/package-candidate.json \
@@ -735,28 +765,15 @@ jobs:
           ARTIFACT_NAME: ${{ steps.artifact.outputs.name }}
           ARTIFACT_RUN_ATTEMPT: ${{ steps.artifact.outputs.run_attempt }}
           ARTIFACT_RUN_ID: ${{ steps.artifact.outputs.run_id }}
+          GH_TOKEN: ${{ github.token }}
           PACKAGE_FILE_NAME: ${{ steps.artifact.outputs.file_name }}
           PACKAGE_SHA256: ${{ steps.package.outputs.sha256 }}
           PACKAGE_SOURCE_SHA: ${{ steps.package.outputs.source_sha }}
           PACKAGE_VERSION: ${{ steps.package.outputs.package_version }}
         run: |
           set -euo pipefail
-          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || {
-            echo "Release package artifact ID is missing or invalid." >&2
-            exit 1
-          }
-          [[ "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ ]] || {
-            echo "Release package artifact digest is missing or invalid." >&2
-            exit 1
-          }
-          [[ "$ARTIFACT_RUN_ID" == "$GITHUB_RUN_ID" &&
-            "$ARTIFACT_RUN_ATTEMPT" == "$GITHUB_RUN_ATTEMPT" ]] || {
-            echo "Release package artifact run binding is invalid." >&2
-            exit 1
-          }
-          [[ "$ARTIFACT_NAME" == "release-package-under-test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" &&
-            "$PACKAGE_FILE_NAME" == "openclaw-current.tgz" ]] || {
-            echo "Release package artifact name or tarball filename is invalid." >&2
+          [[ "$PACKAGE_FILE_NAME" == "openclaw-current.tgz" ]] || {
+            echo "Release package tarball filename is invalid." >&2
             exit 1
           }
           [[ "$PACKAGE_SHA256" =~ ^[a-f0-9]{64}$ &&
@@ -765,26 +782,37 @@ jobs:
             echo "Release package identity is incomplete." >&2
             exit 1
           }
+          bash scripts/docker/shared-image-artifact.sh \
+            verify-upload "Release package" \
+            "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
 
       - name: Validate shared prerelease plugin registry binding
         if: inputs.candidate_artifact_json == '' && steps.package.outputs.plugin_registry_manifest_sha256 != ''
         env:
           ARTIFACT_DIGEST: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-digest }}
           ARTIFACT_ID: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id }}
+          ARTIFACT_NAME: docker-e2e-prepublish-plugin-registry-${{ github.run_id }}-${{ github.run_attempt }}
+          ARTIFACT_RUN_ATTEMPT: ${{ github.run_attempt }}
+          ARTIFACT_RUN_ID: ${{ github.run_id }}
+          GH_TOKEN: ${{ github.token }}
           MANIFEST_SHA256: ${{ steps.package.outputs.plugin_registry_manifest_sha256 }}
         run: |
           set -euo pipefail
-          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ &&
-            "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ &&
-            "$MANIFEST_SHA256" =~ ^[a-f0-9]{64}$ ]] || {
-            echo "Shared prerelease plugin registry identity is incomplete." >&2
+          [[ "$MANIFEST_SHA256" =~ ^[a-f0-9]{64}$ ]] || {
+            echo "Shared prerelease plugin registry manifest identity is incomplete." >&2
             exit 1
           }
+          bash scripts/docker/shared-image-artifact.sh \
+            verify-upload "Prerelease plugin registry" \
+            "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
 
       - name: Validate shared release candidate identity
         if: inputs.candidate_artifact_json != ''
         env:
           CANDIDATE_ARTIFACT_JSON: ${{ inputs.candidate_artifact_json }}
+          GH_TOKEN: ${{ github.token }}
           SELECTED_SHA: ${{ needs.resolve_target.outputs.revision }}
         run: |
           set -euo pipefail
@@ -820,10 +848,10 @@ jobs:
                ) or
                (
                  (.prepublishPluginRegistryArtifactName | type == "string" and length > 0) and
-                 (.prepublishPluginRegistryArtifactId | tostring | digits) and
+                 (.prepublishPluginRegistryArtifactId | type == "string" and digits) and
                  (.prepublishPluginRegistryArtifactDigest | hex64) and
-                 (.prepublishPluginRegistryArtifactRunId | tostring | digits) and
-                 (.prepublishPluginRegistryArtifactRunAttempt | tostring | digits) and
+                 (.prepublishPluginRegistryArtifactRunId | type == "string" and digits) and
+                 (.prepublishPluginRegistryArtifactRunAttempt | type == "string" and digits) and
                  (.prepublishPluginRegistryManifestSha256 | hex64) and
                  .prepublishPluginRegistryArtifactName ==
                    ("docker-e2e-prepublish-plugin-registry-" +
@@ -832,6 +860,65 @@ jobs:
                )
              )' \
             <<< "$CANDIDATE_ARTIFACT_JSON" >/dev/null
+          bash scripts/docker/shared-image-artifact.sh \
+            verify-upload "Release package" \
+            "$(jq -r '.packageArtifactId' <<< "$CANDIDATE_ARTIFACT_JSON")" \
+            "$(jq -r '.packageArtifactName' <<< "$CANDIDATE_ARTIFACT_JSON")" \
+            "$(jq -r '.packageArtifactDigest' <<< "$CANDIDATE_ARTIFACT_JSON")" \
+            "$(jq -r '.packageArtifactRunId' <<< "$CANDIDATE_ARTIFACT_JSON")" \
+            "$(jq -r '.packageArtifactRunAttempt' <<< "$CANDIDATE_ARTIFACT_JSON")"
+          if jq -e 'has("prepublishPluginRegistryArtifactId")' \
+            <<< "$CANDIDATE_ARTIFACT_JSON" >/dev/null; then
+            bash scripts/docker/shared-image-artifact.sh \
+              verify-upload "Prerelease plugin registry" \
+              "$(jq -r '.prepublishPluginRegistryArtifactId' <<< "$CANDIDATE_ARTIFACT_JSON")" \
+              "$(jq -r '.prepublishPluginRegistryArtifactName' <<< "$CANDIDATE_ARTIFACT_JSON")" \
+              "$(jq -r '.prepublishPluginRegistryArtifactDigest' <<< "$CANDIDATE_ARTIFACT_JSON")" \
+              "$(jq -r '.prepublishPluginRegistryArtifactRunId' <<< "$CANDIDATE_ARTIFACT_JSON")" \
+              "$(jq -r '.prepublishPluginRegistryArtifactRunAttempt' <<< "$CANDIDATE_ARTIFACT_JSON")"
+          fi
+
+      - name: Prepare prerelease plugin registry identity
+        id: registry_identity
+        env:
+          CANDIDATE_ARTIFACT_JSON: ${{ inputs.candidate_artifact_json }}
+          GENERATED_ARTIFACT_DIGEST: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-digest }}
+          GENERATED_ARTIFACT_ID: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id }}
+          GENERATED_MANIFEST_SHA256: ${{ steps.package.outputs.plugin_registry_manifest_sha256 }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$GENERATED_ARTIFACT_ID" ]]; then
+            jq -cnr \
+              --arg digest "$GENERATED_ARTIFACT_DIGEST" \
+              --arg id "$GENERATED_ARTIFACT_ID" \
+              --arg manifest "$GENERATED_MANIFEST_SHA256" \
+              --arg name "docker-e2e-prepublish-plugin-registry-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+              --arg attempt "$GITHUB_RUN_ATTEMPT" \
+              --arg run "$GITHUB_RUN_ID" \
+              '{
+                prepublishPluginRegistryArtifactName: $name,
+                prepublishPluginRegistryArtifactId: $id,
+                prepublishPluginRegistryArtifactDigest: $digest,
+                prepublishPluginRegistryArtifactRunId: $run,
+                prepublishPluginRegistryArtifactRunAttempt: $attempt,
+                prepublishPluginRegistryManifestSha256: $manifest
+              } | "json=\(.)"' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ -n "$CANDIDATE_ARTIFACT_JSON" ]] &&
+            jq -e 'has("prepublishPluginRegistryArtifactId")' \
+              <<< "$CANDIDATE_ARTIFACT_JSON" >/dev/null; then
+            jq -cr '{
+              prepublishPluginRegistryArtifactName,
+              prepublishPluginRegistryArtifactId,
+              prepublishPluginRegistryArtifactDigest,
+              prepublishPluginRegistryArtifactRunId,
+              prepublishPluginRegistryArtifactRunAttempt,
+              prepublishPluginRegistryManifestSha256
+            } | "json=\(.)"' <<< "$CANDIDATE_ARTIFACT_JSON" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "json=" >> "$GITHUB_OUTPUT"
 
   install_smoke_release_checks:
     needs: [resolve_target]
@@ -848,7 +935,7 @@ jobs:
 
   cross_os_release_checks:
     needs: [resolve_target, prepare_release_package]
-    if: contains(fromJSON('["all","cross-os"]'), needs.resolve_target.outputs.rerun_group)
+    if: needs.resolve_target.outputs.cross_os_scheduled == 'true'
     permissions: read-all
     uses: ./.github/workflows/openclaw-cross-os-release-checks-reusable.yml
     with:
@@ -866,12 +953,7 @@ jobs:
       candidate_sha256: ${{ needs.prepare_release_package.outputs.package_sha256 }}
       candidate_version: ${{ needs.prepare_release_package.outputs.package_version }}
       candidate_source_sha: ${{ needs.prepare_release_package.outputs.source_sha }}
-      prepublish_plugin_registry_artifact_digest: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_digest }}
-      prepublish_plugin_registry_artifact_id: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_id }}
-      prepublish_plugin_registry_artifact_name: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_name }}
-      prepublish_plugin_registry_artifact_run_attempt: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_run_attempt }}
-      prepublish_plugin_registry_artifact_run_id: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_run_id }}
-      prepublish_plugin_registry_manifest_sha256: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_manifest_sha256 }}
+      prepublish_plugin_registry_json: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_json }}
       openai_model: openai/gpt-5.6-luna
       ubuntu_runner: ubuntu-24.04
       windows_runner: windows-2025
@@ -962,7 +1044,7 @@ jobs:
   docker_e2e_release_checks:
     name: Run Docker release-path validation
     needs: [resolve_target, prepare_release_package]
-    if: (needs.resolve_target.outputs.rerun_group == 'live-e2e' || (needs.resolve_target.outputs.rerun_group == 'all' && needs.resolve_target.outputs.run_release_soak == 'true')) && needs.resolve_target.outputs.repo_live_suite_filter == ''
+    if: needs.resolve_target.outputs.docker_release_scheduled == 'true'
     permissions:
       actions: read
       contents: read
@@ -989,12 +1071,12 @@ jobs:
       package_source_sha: ${{ needs.prepare_release_package.outputs.source_sha }}
       package_version: ${{ needs.prepare_release_package.outputs.package_version }}
       enable_prepublish_plugin_registry: ${{ needs.resolve_target.outputs.release_package_spec == '' }}
-      prepublish_plugin_registry_artifact_name: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_name }}
-      prepublish_plugin_registry_artifact_id: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_id }}
-      prepublish_plugin_registry_artifact_digest: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_digest }}
-      prepublish_plugin_registry_artifact_run_id: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_run_id }}
-      prepublish_plugin_registry_artifact_run_attempt: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_run_attempt }}
-      prepublish_plugin_registry_manifest_sha256: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_manifest_sha256 }}
+      prepublish_plugin_registry_artifact_name: ${{ fromJSON(needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactName || '' }}
+      prepublish_plugin_registry_artifact_id: ${{ fromJSON(needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactId || '' }}
+      prepublish_plugin_registry_artifact_digest: ${{ fromJSON(needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}
+      prepublish_plugin_registry_artifact_run_id: ${{ fromJSON(needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
+      prepublish_plugin_registry_artifact_run_attempt: ${{ fromJSON(needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}
+      prepublish_plugin_registry_manifest_sha256: ${{ fromJSON(needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
       codex_plugin_spec: ${{ needs.resolve_target.outputs.codex_plugin_spec }}
       shared_image_artifact_namespace: release-docker
       shared_image_artifact_name: ${{ fromJSON(inputs.candidate_artifact_json || '{}').imageArtifactName || '' }}

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -610,6 +610,12 @@ jobs:
       package_file_name: ${{ steps.artifact.outputs.file_name || fromJSON(inputs.candidate_artifact_json || '{}').packageFileName }}
       package_sha256: ${{ steps.package.outputs.sha256 || fromJSON(inputs.candidate_artifact_json || '{}').packageSha256 }}
       package_version: ${{ steps.package.outputs.package_version || fromJSON(inputs.candidate_artifact_json || '{}').packageVersion }}
+      prepublish_plugin_registry_artifact_digest: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}
+      prepublish_plugin_registry_artifact_id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}
+      prepublish_plugin_registry_artifact_name: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactName || '' }}
+      prepublish_plugin_registry_artifact_run_attempt: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}
+      prepublish_plugin_registry_artifact_run_id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
+      prepublish_plugin_registry_manifest_sha256: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
       source_sha: ${{ steps.package.outputs.source_sha || fromJSON(inputs.candidate_artifact_json || '{}').packageSourceSha }}
     steps:
       - name: Checkout trusted workflow ref
@@ -814,7 +820,13 @@ jobs:
       candidate_sha256: ${{ needs.prepare_release_package.outputs.package_sha256 }}
       candidate_version: ${{ needs.prepare_release_package.outputs.package_version }}
       candidate_source_sha: ${{ needs.prepare_release_package.outputs.source_sha }}
-      candidate_artifact_json: ${{ inputs.candidate_artifact_json }}
+      prepublish_plugin_registry_artifact_digest: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_digest }}
+      prepublish_plugin_registry_artifact_id: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_id }}
+      prepublish_plugin_registry_artifact_name: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_name }}
+      prepublish_plugin_registry_artifact_run_attempt: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_run_attempt }}
+      prepublish_plugin_registry_artifact_run_id: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_run_id }}
+      prepublish_plugin_registry_manifest_sha256: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_manifest_sha256 }}
+      required_companion_packages_json: ${{ needs.resolve_target.outputs.provider == 'openai' && '["@openclaw/codex"]' || '[]' }}
       openai_model: openai/gpt-5.6-luna
       ubuntu_runner: ubuntu-24.04
       windows_runner: windows-2025
@@ -932,12 +944,12 @@ jobs:
       package_source_sha: ${{ needs.prepare_release_package.outputs.source_sha }}
       package_version: ${{ needs.prepare_release_package.outputs.package_version }}
       enable_prepublish_plugin_registry: ${{ needs.resolve_target.outputs.release_package_spec == '' }}
-      prepublish_plugin_registry_artifact_name: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactName || '' }}
-      prepublish_plugin_registry_artifact_id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}
-      prepublish_plugin_registry_artifact_digest: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}
-      prepublish_plugin_registry_artifact_run_id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
-      prepublish_plugin_registry_artifact_run_attempt: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}
-      prepublish_plugin_registry_manifest_sha256: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
+      prepublish_plugin_registry_artifact_name: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_name }}
+      prepublish_plugin_registry_artifact_id: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_id }}
+      prepublish_plugin_registry_artifact_digest: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_digest }}
+      prepublish_plugin_registry_artifact_run_id: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_run_id }}
+      prepublish_plugin_registry_artifact_run_attempt: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_run_attempt }}
+      prepublish_plugin_registry_manifest_sha256: ${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_manifest_sha256 }}
       codex_plugin_spec: ${{ needs.resolve_target.outputs.codex_plugin_spec }}
       shared_image_artifact_namespace: release-docker
       shared_image_artifact_name: ${{ fromJSON(inputs.candidate_artifact_json || '{}').imageArtifactName || '' }}

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -655,37 +655,32 @@ jobs:
         run: |
           set -euo pipefail
           source_args=(--source ref --package-ref "$PACKAGE_REF")
-          registry_args=()
           package_label="ref:${PACKAGE_REF}"
           if [[ -n "${RELEASE_PACKAGE_SPEC// }" ]]; then
-            source_args=(--source npm --package-spec "$RELEASE_PACKAGE_SPEC")
+            source_args=(--source npm --package-spec "$RELEASE_PACKAGE_SPEC" --package-ref "$PACKAGE_REF")
             package_label="$RELEASE_PACKAGE_SPEC"
-          else
-            provider_packages="$(
-              OPENCLAW_RELEASE_CHECKS_SCRIPT=scripts/openclaw-cross-os-release-checks.ts \
-                bash scripts/github/run-openclaw-cross-os-release-checks.sh \
-                --resolve-provider-required-companion-packages \
-                --provider "${{ needs.resolve_target.outputs.provider }}"
-            )"
-            export OPENCLAW_DOCKER_ALL_PROFILE=release-path
-            export OPENCLAW_DOCKER_ALL_PLAN_RELEASE_ALL=1
-            export OPENCLAW_DOCKER_ALL_INCLUDE_OPENWEBUI="${{ needs.resolve_target.outputs.release_profile != 'beta' }}"
-            export OPENCLAW_DOCKER_ALL_RELEASE_PROFILE="${{ needs.resolve_target.outputs.release_profile }}"
-            docker_plan="$(node scripts/test-docker-all.mjs --plan-json)"
-            required_packages="$(
-              jq -cn \
-                --argjson provider "$provider_packages" \
-                --argjson docker "$(jq -c '.requiredPrepublishPluginPackages' <<< "$docker_plan")" \
-                '$provider + $docker | unique | sort'
-            )"
-            registry_args=(
-              --plugin-registry-output-dir .artifacts/prepublish-plugin-registry
-              --required-plugin-packages-json "$required_packages"
-            )
           fi
+          provider_packages="$(
+            OPENCLAW_RELEASE_CHECKS_SCRIPT=scripts/openclaw-cross-os-release-checks.ts \
+              bash scripts/github/run-openclaw-cross-os-release-checks.sh \
+              --resolve-provider-required-companion-packages \
+              --provider "${{ needs.resolve_target.outputs.provider }}"
+          )"
+          export OPENCLAW_DOCKER_ALL_PROFILE=release-path
+          export OPENCLAW_DOCKER_ALL_PLAN_RELEASE_ALL=1
+          export OPENCLAW_DOCKER_ALL_INCLUDE_OPENWEBUI="${{ needs.resolve_target.outputs.release_profile != 'beta' }}"
+          export OPENCLAW_DOCKER_ALL_RELEASE_PROFILE="${{ needs.resolve_target.outputs.release_profile }}"
+          docker_plan="$(node scripts/test-docker-all.mjs --plan-json)"
+          required_packages="$(
+            jq -cn \
+              --argjson provider "$provider_packages" \
+              --argjson docker "$(jq -c '.requiredPrepublishPluginPackages' <<< "$docker_plan")" \
+              '$provider + $docker | unique | sort'
+          )"
           node scripts/resolve-openclaw-package-candidate.mjs \
             "${source_args[@]}" \
-            "${registry_args[@]}" \
+            --plugin-registry-output-dir .artifacts/prepublish-plugin-registry \
+            --required-plugin-packages-json "$required_packages" \
             --output-dir .artifacts/docker-e2e-package \
             --output-name openclaw-current.tgz \
             --metadata .artifacts/docker-e2e-package/package-candidate.json \

--- a/scripts/lib/cross-os-release-checks/companions.ts
+++ b/scripts/lib/cross-os-release-checks/companions.ts
@@ -1,0 +1,35 @@
+import { resolve } from "node:path";
+import { validatePrepublishPluginRegistryArtifact } from "../../prepublish-plugin-registry-artifact.mjs";
+
+export type CrossOsCompanionPackage = {
+  name: string;
+  tarballPath: string;
+};
+
+export function resolveCrossOsCompanionPackages(params: {
+  artifactDir: string;
+  candidateVersion: string;
+  manifestSha256: string;
+  requiredPackages: string[];
+  sourceSha: string;
+}): CrossOsCompanionPackage[] {
+  const artifactDir = resolve(params.artifactDir);
+  const { manifest } = validatePrepublishPluginRegistryArtifact({
+    artifactDir,
+    expectedCandidateVersion: params.candidateVersion,
+    expectedManifestSha256: params.manifestSha256,
+    expectedSourceSha: params.sourceSha,
+    requiredPackages: params.requiredPackages,
+  });
+  const requiredPackages = new Set(params.requiredPackages);
+  return manifest.packages
+    .filter((entry) => requiredPackages.has(entry.name))
+    .map((entry) => ({
+      name: entry.name,
+      tarballPath: resolve(artifactDir, entry.tarball),
+    }));
+}
+
+export function buildCrossOsCompanionInstallArgs(companion: CrossOsCompanionPackage): string[] {
+  return ["plugins", "install", `npm-pack:${companion.tarballPath}`, "--force"];
+}

--- a/scripts/lib/cross-os-release-checks/companions.ts
+++ b/scripts/lib/cross-os-release-checks/companions.ts
@@ -29,7 +29,3 @@ export function resolveCrossOsCompanionPackages(params: {
       tarballPath: resolve(artifactDir, entry.tarball),
     }));
 }
-
-export function buildCrossOsCompanionInstallArgs(companion: CrossOsCompanionPackage): string[] {
-  return ["plugins", "install", `npm-pack:${companion.tarballPath}`, "--force"];
-}

--- a/scripts/lib/cross-os-release-checks/companions.ts
+++ b/scripts/lib/cross-os-release-checks/companions.ts
@@ -1,7 +1,7 @@
 import { resolve } from "node:path";
 import { validatePrepublishPluginRegistryArtifact } from "../../prepublish-plugin-registry-artifact.mjs";
 
-export type CrossOsCompanionPackage = {
+type CrossOsCompanionPackage = {
   name: string;
   tarballPath: string;
 };

--- a/scripts/lib/cross-os-release-checks/config.ts
+++ b/scripts/lib/cross-os-release-checks/config.ts
@@ -64,7 +64,9 @@ export type CommandInvocation = {
 };
 export type Cleanup = () => Promise<void> | void;
 export type LaneBaseParams = {
-  companions: readonly import("./companions.ts").CrossOsCompanionPackage[];
+  companions: Readonly<
+    ReturnType<typeof import("./companions.ts").resolveCrossOsCompanionPackages>
+  >;
   logsDir: string;
   providerConfig: ProviderConfig;
   providerSecretValue: string;

--- a/scripts/lib/cross-os-release-checks/config.ts
+++ b/scripts/lib/cross-os-release-checks/config.ts
@@ -64,6 +64,7 @@ export type CommandInvocation = {
 };
 export type Cleanup = () => Promise<void> | void;
 export type LaneBaseParams = {
+  companions: readonly import("./companions.ts").CrossOsCompanionPackage[];
   logsDir: string;
   providerConfig: ProviderConfig;
   providerSecretValue: string;

--- a/scripts/lib/cross-os-release-checks/config.ts
+++ b/scripts/lib/cross-os-release-checks/config.ts
@@ -11,6 +11,7 @@ export type ProviderConfig = {
   secretEnv: string;
   authChoice: string;
   model: string;
+  requiredCompanionPackages: readonly string[];
   baseUrl?: string;
   timeoutSeconds?: number;
 };
@@ -131,6 +132,7 @@ const providerConfig = {
     secretEnv: "OPENAI_API_KEY",
     authChoice: "openai-api-key",
     model: "openai/gpt-5.6-luna",
+    requiredCompanionPackages: ["@openclaw/codex"],
     baseUrl: "https://api.openai.com/v1",
     timeoutSeconds: CROSS_OS_AGENT_TURN_TIMEOUT_SECONDS,
   },
@@ -139,12 +141,14 @@ const providerConfig = {
     secretEnv: "ANTHROPIC_API_KEY",
     authChoice: "apiKey",
     model: "anthropic/claude-sonnet-4-6",
+    requiredCompanionPackages: [],
   },
   minimax: {
     extensionId: "minimax",
     secretEnv: "MINIMAX_API_KEY",
     authChoice: "minimax-global-api",
     model: "minimax/MiniMax-M2.7",
+    requiredCompanionPackages: [],
   },
 } satisfies Record<ProviderId, ProviderConfig>;
 
@@ -156,6 +160,16 @@ export function resolveProviderConfig(provider: string, env = process.env): Prov
   const providerEnvKey = `OPENCLAW_CROSS_OS_${provider.toUpperCase().replace(/[^A-Z0-9]+/gu, "_")}_MODEL`;
   const model = env[providerEnvKey]?.trim() || env.OPENCLAW_CROSS_OS_MODEL?.trim() || config.model;
   return { ...config, model };
+}
+
+export function assertCrossOsCompanionRegistryAvailable(
+  provider: string,
+  requiredPackages: readonly string[],
+  available: boolean,
+) {
+  if (requiredPackages.length > 0 && !available) {
+    throw new Error(`Provider "${provider}" requires an immutable prerelease companion registry.`);
+  }
 }
 
 const RELEASE_SMOKE_PLUGIN_ALLOWLIST_BASE = [

--- a/scripts/lib/cross-os-release-checks/config.ts
+++ b/scripts/lib/cross-os-release-checks/config.ts
@@ -162,16 +162,6 @@ export function resolveProviderConfig(provider: string, env = process.env): Prov
   return { ...config, model };
 }
 
-export function assertCrossOsCompanionRegistryAvailable(
-  provider: string,
-  requiredPackages: readonly string[],
-  available: boolean,
-) {
-  if (requiredPackages.length > 0 && !available) {
-    throw new Error(`Provider "${provider}" requires an immutable prerelease companion registry.`);
-  }
-}
-
 const RELEASE_SMOKE_PLUGIN_ALLOWLIST_BASE = [
   "acpx",
   "bonjour",

--- a/scripts/lib/cross-os-release-checks/index.ts
+++ b/scripts/lib/cross-os-release-checks/index.ts
@@ -1,5 +1,6 @@
 export * from "./agent.ts";
 export * from "./config.ts";
+export * from "./companions.ts";
 export * from "./install.ts";
 export * from "./installed.ts";
 export * from "./lanes.ts";

--- a/scripts/lib/cross-os-release-checks/index.ts
+++ b/scripts/lib/cross-os-release-checks/index.ts
@@ -1,6 +1,5 @@
 export * from "./agent.ts";
 export * from "./config.ts";
-export * from "./companions.ts";
 export * from "./install.ts";
 export * from "./installed.ts";
 export * from "./lanes.ts";

--- a/scripts/lib/cross-os-release-checks/lanes.ts
+++ b/scripts/lib/cross-os-release-checks/lanes.ts
@@ -1,7 +1,6 @@
 import { appendFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir, userInfo } from "node:os";
 import { join } from "node:path";
-import { buildCrossOsCompanionInstallArgs } from "./companions.ts";
 import type {
   CandidateBuild,
   Cleanup,
@@ -96,7 +95,7 @@ async function installLaneCompanions(
         params.logsDir,
         `companion-${companion.name.replace(/[^a-z0-9]+/giu, "-")}.log`,
       );
-      const args = buildCrossOsCompanionInstallArgs(companion);
+      const args = ["plugins", "install", `npm-pack:${companion.tarballPath}`, "--force"];
       if (params.cliPath) {
         await runInstalledCli({
           cliPath: params.cliPath,

--- a/scripts/lib/cross-os-release-checks/lanes.ts
+++ b/scripts/lib/cross-os-release-checks/lanes.ts
@@ -1,6 +1,7 @@
 import { appendFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir, userInfo } from "node:os";
 import { join } from "node:path";
+import { buildCrossOsCompanionInstallArgs } from "./companions.ts";
 import type {
   CandidateBuild,
   Cleanup,
@@ -79,6 +80,45 @@ import {
 } from "./runtime.ts";
 import { formatError, trimForSummary } from "./shared.ts";
 
+async function installLaneCompanions(
+  params: LaneBaseParams & {
+    lane: LaneState;
+    env: NodeJS.ProcessEnv;
+    cliPath?: string;
+  },
+) {
+  if (params.companions.length === 0) {
+    return;
+  }
+  await runTimedLanePhase(params.lane, "install-companions", async () => {
+    for (const companion of params.companions) {
+      const logPath = join(
+        params.logsDir,
+        `companion-${companion.name.replace(/[^a-z0-9]+/giu, "-")}.log`,
+      );
+      const args = buildCrossOsCompanionInstallArgs(companion);
+      if (params.cliPath) {
+        await runInstalledCli({
+          cliPath: params.cliPath,
+          args,
+          env: params.env,
+          cwd: params.lane.homeDir,
+          logPath,
+          timeoutMs: 10 * 60 * 1000,
+        });
+        continue;
+      }
+      await runOpenClaw({
+        lane: params.lane,
+        args,
+        env: params.env,
+        logPath,
+        timeoutMs: 10 * 60 * 1000,
+      });
+    }
+  });
+}
+
 export async function runFreshLane(params: LaneBaseParams & { build: CandidateBuild }) {
   const lane = createLaneState("fresh");
   const cleanup: Cleanup[] = [];
@@ -118,6 +158,8 @@ export async function runFreshLane(params: LaneBaseParams & { build: CandidateBu
           }),
       );
     }
+
+    await installLaneCompanions({ ...params, lane, env });
 
     await runTimedLanePhase(lane, "onboard", async () => {
       await runOnboard({
@@ -328,6 +370,8 @@ export async function runUpgradeLane(
     const installed = readInstalledMetadata(lane.prefixDir);
     verifyInstalledCandidate(installed, params.build);
 
+    await installLaneCompanions({ ...params, lane, env });
+
     await runTimedLanePhase(lane, "onboard", async () => {
       await runOnboard({
         lane,
@@ -484,6 +528,8 @@ export async function runInstallerFreshSuite(
       managedHostEnv = env;
       managedHostCliPath = freshShell.cliPath;
     }
+
+    await installLaneCompanions({ ...params, lane, env, cliPath: freshShell.cliPath });
 
     // Hold the configured port through onboarding and model setup so another runner process
     // cannot claim it before the manual gateway starts. Release immediately before spawn.
@@ -765,6 +811,8 @@ export async function runDevUpdateSuite(
         logPath: join(params.logsDir, "dev-update-windows-toolchain.log"),
       });
     }
+
+    await installLaneCompanions({ ...params, lane, env, cliPath: verifiedShell.cliPath });
 
     logLanePhase(lane, "onboard");
     await runOnboardWithInstalledCli({

--- a/scripts/openclaw-cross-os-release-checks.ts
+++ b/scripts/openclaw-cross-os-release-checks.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import { resolveCrossOsCompanionPackages } from "./lib/cross-os-release-checks/companions.ts";
 import type { CandidateBuild, LaneResult } from "./lib/cross-os-release-checks/config.ts";
 import {
+  assertCrossOsCompanionRegistryAvailable,
   isSupportedCrossOsSuite,
   parseArgs,
   readRunnerOverrideEnv,
@@ -71,6 +72,16 @@ async function main(argv: string[]) {
     return;
   }
 
+  if (args["resolve-provider-required-companion-packages"] === "true") {
+    const provider = args["provider"]?.trim() || "";
+    const selectedProvider = resolveProviderConfig(provider);
+    if (!selectedProvider) {
+      throw new Error(`Unsupported provider "${provider}".`);
+    }
+    process.stdout.write(`${JSON.stringify(selectedProvider.requiredCompanionPackages)}\n`);
+    return;
+  }
+
   const outputDir = resolve(requireArg(args, "output-dir"));
   const prepareOnly = args["prepare-only"] === "true";
   const sourceDir = args["source-dir"]?.trim() ? resolve(args["source-dir"].trim()) : "";
@@ -94,17 +105,13 @@ async function main(argv: string[]) {
     ? resolve(args["plugin-registry-dir"].trim())
     : "";
   const pluginRegistryManifestSha256 = args["plugin-registry-manifest-sha256"]?.trim() || "";
-  const parsedRequiredCompanionPackages: unknown = JSON.parse(
-    args["required-companion-packages-json"] ?? "[]",
-  );
-  if (
-    !Array.isArray(parsedRequiredCompanionPackages) ||
-    parsedRequiredCompanionPackages.some((entry) => typeof entry !== "string")
-  ) {
-    throw new Error("--required-companion-packages-json must be a JSON string array.");
-  }
-  const requiredCompanionPackages = parsedRequiredCompanionPackages as string[];
   const runDiscordRoundtrip = args["run-discord-roundtrip"] === "true";
+
+  const selectedProvider = resolveProviderConfig(provider);
+  if (!selectedProvider) {
+    throw new Error(`Unsupported provider "${provider}".`);
+  }
+  const requiredCompanionPackages = [...selectedProvider.requiredCompanionPackages];
 
   mkdirSync(outputDir, { recursive: true });
   const logsDir = join(outputDir, "logs");
@@ -127,10 +134,6 @@ async function main(argv: string[]) {
     throw new Error(`Unsupported suite "${suite}".`);
   }
 
-  const selectedProvider = resolveProviderConfig(provider);
-  if (!selectedProvider) {
-    throw new Error(`Unsupported provider "${provider}".`);
-  }
   const providerSecretValue = process.env[selectedProvider.secretEnv]?.trim();
   if (!providerSecretValue) {
     throw new Error(`Missing ${selectedProvider.secretEnv}.`);
@@ -177,6 +180,11 @@ async function main(argv: string[]) {
         "--plugin-registry-dir and --plugin-registry-manifest-sha256 must be provided together.",
       );
     }
+    assertCrossOsCompanionRegistryAvailable(
+      provider,
+      requiredCompanionPackages,
+      Boolean(pluginRegistryDir),
+    );
     const companions = pluginRegistryDir
       ? resolveCrossOsCompanionPackages({
           artifactDir: pluginRegistryDir,

--- a/scripts/openclaw-cross-os-release-checks.ts
+++ b/scripts/openclaw-cross-os-release-checks.ts
@@ -5,6 +5,7 @@
 import { mkdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveCrossOsCompanionPackages } from "./lib/cross-os-release-checks/companions.ts";
 import type { CandidateBuild, LaneResult } from "./lib/cross-os-release-checks/config.ts";
 import {
   isSupportedCrossOsSuite,
@@ -89,6 +90,20 @@ async function main(argv: string[]) {
     : "";
   const providedCandidateVersion = args["candidate-version"]?.trim() || "";
   const providedSourceSha = args["source-sha"]?.trim() || "";
+  const pluginRegistryDir = args["plugin-registry-dir"]?.trim()
+    ? resolve(args["plugin-registry-dir"].trim())
+    : "";
+  const pluginRegistryManifestSha256 = args["plugin-registry-manifest-sha256"]?.trim() || "";
+  const parsedRequiredCompanionPackages: unknown = JSON.parse(
+    args["required-companion-packages-json"] ?? "[]",
+  );
+  if (
+    !Array.isArray(parsedRequiredCompanionPackages) ||
+    parsedRequiredCompanionPackages.some((entry) => typeof entry !== "string")
+  ) {
+    throw new Error("--required-companion-packages-json must be a JSON string array.");
+  }
+  const requiredCompanionPackages = parsedRequiredCompanionPackages as string[];
   const runDiscordRoundtrip = args["run-discord-roundtrip"] === "true";
 
   mkdirSync(outputDir, { recursive: true });
@@ -157,10 +172,25 @@ async function main(argv: string[]) {
     summary.sourceSha = build.sourceSha;
     summary.candidateVersion = build.candidateVersion;
     summary.candidateTgz = build.candidateTgz;
+    if (Boolean(pluginRegistryDir) !== Boolean(pluginRegistryManifestSha256)) {
+      throw new Error(
+        "--plugin-registry-dir and --plugin-registry-manifest-sha256 must be provided together.",
+      );
+    }
+    const companions = pluginRegistryDir
+      ? resolveCrossOsCompanionPackages({
+          artifactDir: pluginRegistryDir,
+          candidateVersion: build.candidateVersion,
+          manifestSha256: pluginRegistryManifestSha256,
+          requiredPackages: requiredCompanionPackages,
+          sourceSha: build.sourceSha,
+        })
+      : [];
 
     if (suite === "packaged-fresh") {
       summary.result = await runFreshLane({
         build,
+        companions,
         logsDir,
         providerConfig: selectedProvider,
         providerSecretValue,
@@ -175,6 +205,7 @@ async function main(argv: string[]) {
           baselineSpec,
           baselineTgz: providedBaselineTgz,
           build,
+          companions,
           candidateUrl: tgzServer.url,
           logsDir,
           providerConfig: selectedProvider,
@@ -186,6 +217,7 @@ async function main(argv: string[]) {
     } else if (suite === "installer-fresh") {
       summary.result = await runInstallerFreshSuite({
         build,
+        companions,
         logsDir,
         providerConfig: selectedProvider,
         providerSecretValue,
@@ -194,6 +226,7 @@ async function main(argv: string[]) {
     } else {
       summary.result = await runDevUpdateSuite({
         baselineSpec,
+        companions,
         logsDir,
         providerConfig: selectedProvider,
         providerSecretValue,

--- a/scripts/openclaw-cross-os-release-checks.ts
+++ b/scripts/openclaw-cross-os-release-checks.ts
@@ -8,7 +8,6 @@ import { fileURLToPath } from "node:url";
 import { resolveCrossOsCompanionPackages } from "./lib/cross-os-release-checks/companions.ts";
 import type { CandidateBuild, LaneResult } from "./lib/cross-os-release-checks/config.ts";
 import {
-  assertCrossOsCompanionRegistryAvailable,
   isSupportedCrossOsSuite,
   parseArgs,
   readRunnerOverrideEnv,
@@ -101,10 +100,17 @@ async function main(argv: string[]) {
     : "";
   const providedCandidateVersion = args["candidate-version"]?.trim() || "";
   const providedSourceSha = args["source-sha"]?.trim() || "";
-  const pluginRegistryDir = args["plugin-registry-dir"]?.trim()
-    ? resolve(args["plugin-registry-dir"].trim())
-    : "";
-  const pluginRegistryManifestSha256 = args["plugin-registry-manifest-sha256"]?.trim() || "";
+  const pluginRegistryDir = args["plugin-registry-dir"]?.trim();
+  const pluginRegistryManifestSha256 = args["plugin-registry-manifest-sha256"]?.trim();
+  if (Boolean(pluginRegistryDir) !== Boolean(pluginRegistryManifestSha256)) {
+    throw new Error(
+      "--plugin-registry-dir and --plugin-registry-manifest-sha256 must be provided together.",
+    );
+  }
+  const pluginRegistry =
+    pluginRegistryDir && pluginRegistryManifestSha256
+      ? { dir: resolve(pluginRegistryDir), manifestSha256: pluginRegistryManifestSha256 }
+      : undefined;
   const runDiscordRoundtrip = args["run-discord-roundtrip"] === "true";
 
   const selectedProvider = resolveProviderConfig(provider);
@@ -175,21 +181,16 @@ async function main(argv: string[]) {
     summary.sourceSha = build.sourceSha;
     summary.candidateVersion = build.candidateVersion;
     summary.candidateTgz = build.candidateTgz;
-    if (Boolean(pluginRegistryDir) !== Boolean(pluginRegistryManifestSha256)) {
+    if (requiredCompanionPackages.length > 0 && !pluginRegistry) {
       throw new Error(
-        "--plugin-registry-dir and --plugin-registry-manifest-sha256 must be provided together.",
+        `Provider "${provider}" requires an immutable prerelease companion registry.`,
       );
     }
-    assertCrossOsCompanionRegistryAvailable(
-      provider,
-      requiredCompanionPackages,
-      Boolean(pluginRegistryDir),
-    );
-    const companions = pluginRegistryDir
+    const companions = pluginRegistry
       ? resolveCrossOsCompanionPackages({
-          artifactDir: pluginRegistryDir,
+          artifactDir: pluginRegistry.dir,
           candidateVersion: build.candidateVersion,
-          manifestSha256: pluginRegistryManifestSha256,
+          manifestSha256: pluginRegistry.manifestSha256,
           requiredPackages: requiredCompanionPackages,
           sourceSha: build.sourceSha,
         })

--- a/scripts/resolve-openclaw-package-candidate.d.mts
+++ b/scripts/resolve-openclaw-package-candidate.d.mts
@@ -9,6 +9,8 @@ export function parseArgs(argv: unknown): {
   packageSha256: string;
   packageSpec: string;
   packageUrl: string;
+  pluginRegistryOutputDir: string;
+  requiredPluginPackagesJson: string;
   source: string;
   trustedSourceId: string;
   trustedSourcePolicy: string;

--- a/scripts/resolve-openclaw-package-candidate.mjs
+++ b/scripts/resolve-openclaw-package-candidate.mjs
@@ -18,6 +18,7 @@ import { resolveNpmJsonEntries } from "./lib/npm-json-output.mjs";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
 import { resolveNpmRunner } from "./npm-runner.mjs";
+import { createPrepublishPluginRegistryArtifact } from "./prepublish-plugin-registry-artifact.mjs";
 
 const ROOT_DIR = resolveRepoRoot(import.meta.url);
 const DEFAULT_OUTPUT_NAME = "openclaw-current.tgz";
@@ -82,6 +83,10 @@ Options:
   --artifact-dir <dir>        Directory containing exactly one .tgz for source=artifact.
   --output-name <name>        Output tarball filename. Default: ${DEFAULT_OUTPUT_NAME}
   --metadata <file>           Write package metadata JSON.
+  --plugin-registry-output-dir <dir>
+                              Build an immutable registry for source=ref before cleanup.
+  --required-plugin-packages-json <json>
+                              Scoped package names to include in that registry.
   --github-output <file>      Append tarball, sha256, package name/version outputs.`;
 }
 
@@ -96,6 +101,8 @@ export function parseArgs(argv) {
     packageSha256: "",
     packageSpec: "",
     packageUrl: "",
+    pluginRegistryOutputDir: "",
+    requiredPluginPackagesJson: "[]",
     source: "",
     trustedSourceId: "",
     trustedSourcePolicy: TRUSTED_PACKAGE_SOURCE_POLICY,
@@ -110,6 +117,8 @@ export function parseArgs(argv) {
         ["--metadata", "metadata"],
         ["--output-dir", "outputDir"],
         ["--output-name", "outputName"],
+        ["--plugin-registry-output-dir", "pluginRegistryOutputDir"],
+        ["--required-plugin-packages-json", "requiredPluginPackagesJson"],
         ["--source", "source"],
         ["--trusted-source-policy", "trustedSourcePolicy"],
       ].map(([flag, key]) =>
@@ -1465,6 +1474,7 @@ async function resolveCandidate(options) {
   let packageTrustedSourceId = "";
   let packageWorktreeDir = "";
   let artifactMetadata = {};
+  let pluginRegistryManifestSha256 = "";
   let resolveError;
 
   try {
@@ -1485,6 +1495,20 @@ async function resolveCandidate(options) {
         "--output-name",
         options.outputName || DEFAULT_OUTPUT_NAME,
       ]);
+      if (options.pluginRegistryOutputDir) {
+        const requiredPackages = JSON.parse(options.requiredPluginPackagesJson);
+        const rootPackage = JSON.parse(
+          await fs.readFile(path.join(packageSource.sourceDir, "package.json"), "utf8"),
+        );
+        const registry = createPrepublishPluginRegistryArtifact({
+          repoRoot: packageSource.sourceDir,
+          outputDir: path.resolve(ROOT_DIR, options.pluginRegistryOutputDir),
+          sourceSha: packageSource.selectedSha,
+          candidateVersion: rootPackage.version,
+          requiredPackages,
+        });
+        pluginRegistryManifestSha256 = registry.manifestSha256;
+      }
     } else if (options.source === "npm") {
       const npmPackRunner = resolveNpmPackageCandidatePackRunner(options.packageSpec, outputDir, {
         env: process.env,
@@ -1544,6 +1568,9 @@ async function resolveCandidate(options) {
         `source must be one of: ref, npm, url, trusted-url, artifact. Got: ${options.source}`,
       );
     }
+    if (options.source !== "ref" && options.pluginRegistryOutputDir) {
+      throw new Error("--plugin-registry-output-dir is only supported with source=ref");
+    }
   } catch (error) {
     resolveError = error;
     throw error;
@@ -1576,6 +1603,7 @@ async function resolveCandidate(options) {
     packageSpec: options.packageSpec || "",
     packageSourceSha,
     packageTrustedReason,
+    pluginRegistryManifestSha256,
     trustedSourceId: packageTrustedSourceId,
     sha256: digest,
     source: options.source,
@@ -1601,6 +1629,7 @@ async function resolveCandidate(options) {
     package_name: pkg.name,
     package_source_sha: packageSourceSha,
     package_version: pkg.version,
+    plugin_registry_manifest_sha256: pluginRegistryManifestSha256,
     sha256: digest,
     tarball: metadata.tarball,
   });

--- a/scripts/resolve-openclaw-package-candidate.mjs
+++ b/scripts/resolve-openclaw-package-candidate.mjs
@@ -74,7 +74,7 @@ function usage() {
 
 Options:
   --package-spec <spec>       Published npm spec for source=npm.
-  --package-ref <ref>         Trusted repo ref for source=ref.
+  --package-ref <ref>         Trusted repo ref for source=ref or npm companion packaging.
   --package-url <url>         HTTPS tarball URL for source=url or source=trusted-url.
   --package-sha256 <sha256>   Expected tarball SHA-256 for source=url, source=trusted-url, or source=artifact.
   --trusted-source-id <id>    Named trusted URL policy for source=trusted-url.
@@ -1473,6 +1473,9 @@ async function resolveCandidate(options) {
   let packageTrustedReason = "";
   let packageTrustedSourceId = "";
   let packageWorktreeDir = "";
+  let pluginRegistrySource;
+  let pluginRegistryCandidateVersion = "";
+  let pluginRegistrySourceSha = "";
   let artifactMetadata = {};
   let pluginRegistryManifestSha256 = "";
   let resolveError;
@@ -1482,6 +1485,9 @@ async function resolveCandidate(options) {
       packageRef = options.packageRef || "main";
       const packageSource = await preparePackageSourceWorktree(packageRef);
       packageWorktreeDir = packageSource.sourceDir;
+      if (options.pluginRegistryOutputDir) {
+        pluginRegistrySource = packageSource;
+      }
       packageSourceSha = packageSource.selectedSha;
       packageTrustedReason = packageSource.trustedReason;
       await installPackageSourceDeps(packageSource.sourceDir);
@@ -1495,20 +1501,6 @@ async function resolveCandidate(options) {
         "--output-name",
         options.outputName || DEFAULT_OUTPUT_NAME,
       ]);
-      if (options.pluginRegistryOutputDir) {
-        const requiredPackages = JSON.parse(options.requiredPluginPackagesJson);
-        const rootPackage = JSON.parse(
-          await fs.readFile(path.join(packageSource.sourceDir, "package.json"), "utf8"),
-        );
-        const registry = createPrepublishPluginRegistryArtifact({
-          repoRoot: packageSource.sourceDir,
-          outputDir: path.resolve(ROOT_DIR, options.pluginRegistryOutputDir),
-          sourceSha: packageSource.selectedSha,
-          candidateVersion: rootPackage.version,
-          requiredPackages,
-        });
-        pluginRegistryManifestSha256 = registry.manifestSha256;
-      }
     } else if (options.source === "npm") {
       const npmPackRunner = resolveNpmPackageCandidatePackRunner(options.packageSpec, outputDir, {
         env: process.env,
@@ -1525,6 +1517,12 @@ async function resolveCandidate(options) {
         packOutput,
         options.outputName || DEFAULT_OUTPUT_NAME,
       );
+      if (options.pluginRegistryOutputDir) {
+        pluginRegistrySource = await preparePackageSourceWorktree(options.packageRef);
+        packageWorktreeDir = pluginRegistrySource.sourceDir;
+        packageRef = options.packageRef;
+        await installPackageSourceDeps(pluginRegistrySource.sourceDir);
+      }
     } else if (options.source === "url" || options.source === "trusted-url") {
       if (!options.packageUrl) {
         throw new Error(`${options.source} requires --package-url`);
@@ -1568,8 +1566,26 @@ async function resolveCandidate(options) {
         `source must be one of: ref, npm, url, trusted-url, artifact. Got: ${options.source}`,
       );
     }
-    if (options.source !== "ref" && options.pluginRegistryOutputDir) {
-      throw new Error("--plugin-registry-output-dir is only supported with source=ref");
+    if (options.pluginRegistryOutputDir && !pluginRegistrySource) {
+      throw new Error(
+        "--plugin-registry-output-dir is only supported with source=ref or source=npm",
+      );
+    }
+    if (options.pluginRegistryOutputDir && pluginRegistrySource) {
+      const requiredPackages = JSON.parse(options.requiredPluginPackagesJson);
+      const rootPackage = JSON.parse(
+        await fs.readFile(path.join(pluginRegistrySource.sourceDir, "package.json"), "utf8"),
+      );
+      const registry = createPrepublishPluginRegistryArtifact({
+        repoRoot: pluginRegistrySource.sourceDir,
+        outputDir: path.resolve(ROOT_DIR, options.pluginRegistryOutputDir),
+        sourceSha: pluginRegistrySource.selectedSha,
+        candidateVersion: rootPackage.version,
+        requiredPackages,
+      });
+      pluginRegistryCandidateVersion = rootPackage.version;
+      pluginRegistrySourceSha = pluginRegistrySource.selectedSha;
+      pluginRegistryManifestSha256 = registry.manifestSha256;
     }
   } catch (error) {
     resolveError = error;
@@ -1596,6 +1612,14 @@ async function resolveCandidate(options) {
     if (packageSourceSha && !packageTrustedReason) {
       packageTrustedReason = "package-build-info";
     }
+  }
+  if (
+    pluginRegistryManifestSha256 &&
+    (pluginRegistryCandidateVersion !== pkg.version || pluginRegistrySourceSha !== packageSourceSha)
+  ) {
+    throw new Error(
+      "prepublish plugin registry source SHA/version differs from the package candidate",
+    );
   }
   const metadata = {
     name: pkg.name,

--- a/scripts/resolve-openclaw-package-candidate.mjs
+++ b/scripts/resolve-openclaw-package-candidate.mjs
@@ -1474,10 +1474,8 @@ async function resolveCandidate(options) {
   let packageTrustedSourceId = "";
   let packageWorktreeDir = "";
   let pluginRegistrySource;
-  let pluginRegistryCandidateVersion = "";
-  let pluginRegistrySourceSha = "";
   let artifactMetadata = {};
-  let pluginRegistryManifestSha256 = "";
+  let pluginRegistryIdentity;
   let resolveError;
 
   try {
@@ -1583,9 +1581,11 @@ async function resolveCandidate(options) {
         candidateVersion: rootPackage.version,
         requiredPackages,
       });
-      pluginRegistryCandidateVersion = rootPackage.version;
-      pluginRegistrySourceSha = pluginRegistrySource.selectedSha;
-      pluginRegistryManifestSha256 = registry.manifestSha256;
+      pluginRegistryIdentity = {
+        candidateVersion: rootPackage.version,
+        manifestSha256: registry.manifestSha256,
+        sourceSha: pluginRegistrySource.selectedSha,
+      };
     }
   } catch (error) {
     resolveError = error;
@@ -1614,8 +1614,9 @@ async function resolveCandidate(options) {
     }
   }
   if (
-    pluginRegistryManifestSha256 &&
-    (pluginRegistryCandidateVersion !== pkg.version || pluginRegistrySourceSha !== packageSourceSha)
+    pluginRegistryIdentity &&
+    (pluginRegistryIdentity.candidateVersion !== pkg.version ||
+      pluginRegistryIdentity.sourceSha !== packageSourceSha)
   ) {
     throw new Error(
       "prepublish plugin registry source SHA/version differs from the package candidate",
@@ -1627,7 +1628,7 @@ async function resolveCandidate(options) {
     packageSpec: options.packageSpec || "",
     packageSourceSha,
     packageTrustedReason,
-    pluginRegistryManifestSha256,
+    pluginRegistryManifestSha256: pluginRegistryIdentity?.manifestSha256 ?? "",
     trustedSourceId: packageTrustedSourceId,
     sha256: digest,
     source: options.source,
@@ -1653,7 +1654,7 @@ async function resolveCandidate(options) {
     package_name: pkg.name,
     package_source_sha: packageSourceSha,
     package_version: pkg.version,
-    plugin_registry_manifest_sha256: pluginRegistryManifestSha256,
+    plugin_registry_manifest_sha256: pluginRegistryIdentity?.manifestSha256 ?? "",
     sha256: digest,
     tarball: metadata.tarball,
   });

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -25,6 +25,7 @@ import {
   buildCrossOsReleaseAgentSessionId,
   buildCrossOsReleaseSmokePluginAllowlist,
   buildCrossOsReleaseSmokeMemorySlotConfigArgs,
+  buildCrossOsCompanionInstallArgs,
   buildDiscordFetchInit,
   buildPackagedUpgradeUpdateArgs,
   buildReleaseOnboardArgs,
@@ -790,6 +791,46 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     expect(freshLaneSource).toContain('runTimedLanePhase(lane, "install-candidate"');
     expect(freshLaneSource).toContain('runTimedLanePhase(lane, "agent-turn"');
     expect(freshLaneSource).toContain("phaseTimings: lane.phaseTimings");
+  });
+
+  it("builds managed installs for validated companion tarballs", () => {
+    const companions = [
+      {
+        name: "@openclaw/codex",
+        tarballPath: "/tmp/openclaw-codex-2026.8.1-beta.1.tgz",
+      },
+      {
+        name: "@openclaw/discord",
+        tarballPath: "/tmp/openclaw-discord-2026.8.1-beta.1.tgz",
+      },
+    ];
+
+    expect(companions.map(buildCrossOsCompanionInstallArgs)).toEqual(
+      companions.map((companion) => [
+        "plugins",
+        "install",
+        `npm-pack:${companion.tarballPath}`,
+        "--force",
+      ]),
+    );
+  });
+
+  it.each([
+    ["Linux packaged fresh", "runFreshLane", "runUpgradeLane", false],
+    ["macOS packaged upgrade", "runUpgradeLane", "runInstallerFreshSuite", false],
+    ["Windows installer fresh", "runInstallerFreshSuite", "runDevUpdateSuite", true],
+  ])("installs companions before onboarding for %s", (_label, start, end, usesCliPath) => {
+    const source = readFileSync("scripts/lib/cross-os-release-checks/lanes.ts", "utf8");
+    const laneSource = source.slice(
+      source.indexOf(`function ${start}`),
+      source.indexOf(`function ${end}`),
+    );
+    const installIndex = laneSource.indexOf("installLaneCompanions(");
+    const onboardIndex = laneSource.indexOf('"onboard"');
+
+    expect(installIndex).toBeGreaterThanOrEqual(0);
+    expect(onboardIndex).toBeGreaterThan(installIndex);
+    expect(laneSource.includes("cliPath: freshShell.cliPath")).toBe(usesCliPath);
   });
 
   it("accepts OK agent output from the captured log when stdout is empty", () => {

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -21,12 +21,10 @@ import { describe, expect, it } from "vitest";
 import {
   agentOutputHasExpectedOkMarker,
   acquireManagedGatewayInstallerHostLease,
-  assertCrossOsCompanionRegistryAvailable,
   buildCrossOsDiscordRoundtripNonces,
   buildCrossOsReleaseAgentSessionId,
   buildCrossOsReleaseSmokePluginAllowlist,
   buildCrossOsReleaseSmokeMemorySlotConfigArgs,
-  buildCrossOsCompanionInstallArgs,
   buildDiscordFetchInit,
   buildPackagedUpgradeUpdateArgs,
   buildReleaseOnboardArgs,
@@ -794,46 +792,6 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     expect(freshLaneSource).toContain("phaseTimings: lane.phaseTimings");
   });
 
-  it("builds managed installs for validated companion tarballs", () => {
-    const companions = [
-      {
-        name: "@openclaw/codex",
-        tarballPath: "/tmp/openclaw-codex-2026.8.1-beta.1.tgz",
-      },
-      {
-        name: "@openclaw/discord",
-        tarballPath: "/tmp/openclaw-discord-2026.8.1-beta.1.tgz",
-      },
-    ];
-
-    expect(companions.map(buildCrossOsCompanionInstallArgs)).toEqual(
-      companions.map((companion) => [
-        "plugins",
-        "install",
-        `npm-pack:${companion.tarballPath}`,
-        "--force",
-      ]),
-    );
-  });
-
-  it.each([
-    ["Linux packaged fresh", "runFreshLane", "runUpgradeLane", false],
-    ["macOS packaged upgrade", "runUpgradeLane", "runInstallerFreshSuite", false],
-    ["Windows installer fresh", "runInstallerFreshSuite", "runDevUpdateSuite", true],
-  ])("installs companions before onboarding for %s", (_label, start, end, usesCliPath) => {
-    const source = readFileSync("scripts/lib/cross-os-release-checks/lanes.ts", "utf8");
-    const laneSource = source.slice(
-      source.indexOf(`function ${start}`),
-      source.indexOf(`function ${end}`),
-    );
-    const installIndex = laneSource.indexOf("installLaneCompanions(");
-    const onboardIndex = laneSource.indexOf('"onboard"');
-
-    expect(installIndex).toBeGreaterThanOrEqual(0);
-    expect(onboardIndex).toBeGreaterThan(installIndex);
-    expect(laneSource.includes("cliPath: freshShell.cliPath")).toBe(usesCliPath);
-  });
-
   it("accepts OK agent output from the captured log when stdout is empty", () => {
     withTempDir("openclaw-cross-os-agent-output-", (dir) => {
       const logPath = join(dir, "agent.log");
@@ -1013,17 +971,6 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     ]);
     expect(resolveProviderConfig("anthropic", {})?.requiredCompanionPackages).toEqual([]);
     expect(resolveProviderConfig("minimax", {})?.requiredCompanionPackages).toEqual([]);
-  });
-
-  it("requires immutable companions only for providers that own them", () => {
-    expect(() =>
-      assertCrossOsCompanionRegistryAvailable("openai", ["@openclaw/codex"], false),
-    ).toThrow('Provider "openai" requires an immutable prerelease companion registry.');
-    expect(() =>
-      assertCrossOsCompanionRegistryAvailable("openai", ["@openclaw/codex"], true),
-    ).not.toThrow();
-    expect(() => assertCrossOsCompanionRegistryAvailable("anthropic", [], false)).not.toThrow();
-    expect(() => assertCrossOsCompanionRegistryAvailable("minimax", [], false)).not.toThrow();
   });
 
   it("keeps release cross-OS OpenAI smoke on GPT-5.6 Luna", () => {
@@ -1372,30 +1319,6 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       suite: "packaged-fresh",
       suite_label: "packaged fresh",
     });
-  });
-
-  it("keeps the immutable release matrix at three suites across three operating systems", () => {
-    const matrix = resolveRunnerMatrix({
-      mode: "both",
-      ref: "08753a1d793c040b101c8a26c43445dbbab14995",
-      ubuntuRunner: "ubuntu-24.04",
-      windowsRunner: "windows-2025",
-      macosRunner: "macos-26",
-      varUbuntuRunner: "",
-      varWindowsRunner: "",
-      varMacosRunner: "",
-    });
-
-    expect(matrix.include).toHaveLength(9);
-    expect(matrix.include.map(({ os_id, suite }) => `${os_id}/${suite}`).toSorted()).toEqual(
-      ["ubuntu", "windows", "macos"]
-        .flatMap((os) =>
-          ["packaged-fresh", "packaged-upgrade", "installer-fresh"].map(
-            (suite) => `${os}/${suite}`,
-          ),
-        )
-        .toSorted(),
-    );
   });
 
   it("keeps matrix resolution independent of package dependency imports", () => {

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -21,6 +21,7 @@ import { describe, expect, it } from "vitest";
 import {
   agentOutputHasExpectedOkMarker,
   acquireManagedGatewayInstallerHostLease,
+  assertCrossOsCompanionRegistryAvailable,
   buildCrossOsDiscordRoundtripNonces,
   buildCrossOsReleaseAgentSessionId,
   buildCrossOsReleaseSmokePluginAllowlist,
@@ -1007,6 +1008,22 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       })?.model,
     ).toBe("openai/gpt-5.4-nano");
     expect(resolveProviderConfig("openai", {})?.model).toBe("openai/gpt-5.6-luna");
+    expect(resolveProviderConfig("openai", {})?.requiredCompanionPackages).toEqual([
+      "@openclaw/codex",
+    ]);
+    expect(resolveProviderConfig("anthropic", {})?.requiredCompanionPackages).toEqual([]);
+    expect(resolveProviderConfig("minimax", {})?.requiredCompanionPackages).toEqual([]);
+  });
+
+  it("requires immutable companions only for providers that own them", () => {
+    expect(() =>
+      assertCrossOsCompanionRegistryAvailable("openai", ["@openclaw/codex"], false),
+    ).toThrow('Provider "openai" requires an immutable prerelease companion registry.');
+    expect(() =>
+      assertCrossOsCompanionRegistryAvailable("openai", ["@openclaw/codex"], true),
+    ).not.toThrow();
+    expect(() => assertCrossOsCompanionRegistryAvailable("anthropic", [], false)).not.toThrow();
+    expect(() => assertCrossOsCompanionRegistryAvailable("minimax", [], false)).not.toThrow();
   });
 
   it("keeps release cross-OS OpenAI smoke on GPT-5.6 Luna", () => {
@@ -1355,6 +1372,30 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       suite: "packaged-fresh",
       suite_label: "packaged fresh",
     });
+  });
+
+  it("keeps the immutable release matrix at three suites across three operating systems", () => {
+    const matrix = resolveRunnerMatrix({
+      mode: "both",
+      ref: "08753a1d793c040b101c8a26c43445dbbab14995",
+      ubuntuRunner: "ubuntu-24.04",
+      windowsRunner: "windows-2025",
+      macosRunner: "macos-26",
+      varUbuntuRunner: "",
+      varWindowsRunner: "",
+      varMacosRunner: "",
+    });
+
+    expect(matrix.include).toHaveLength(9);
+    expect(matrix.include.map(({ os_id, suite }) => `${os_id}/${suite}`).toSorted()).toEqual(
+      ["ubuntu", "windows", "macos"]
+        .flatMap((os) =>
+          ["packaged-fresh", "packaged-upgrade", "installer-fresh"].map(
+            (suite) => `${os}/${suite}`,
+          ),
+        )
+        .toSorted(),
+    );
   });
 
   it("keeps matrix resolution independent of package dependency imports", () => {

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -450,9 +450,9 @@ describe("cross-OS release checks workflow", () => {
     const download = step(consumer, "Download prerelease plugin registry artifact");
     expect(download.with).toMatchObject({
       "artifact-ids":
-        "${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json).prepublishPluginRegistryArtifactId }}",
+        "${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactId || '' }}",
       "run-id":
-        "${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json).prepublishPluginRegistryArtifactRunId }}",
+        "${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}",
     });
 
     const run = step(consumer, "Run cross-OS release checks");
@@ -491,6 +491,14 @@ describe("cross-OS release checks workflow", () => {
     );
     expect(step(prepare, "Verify provided prerelease plugin registry upload").run).toContain(
       'verify-upload "Prerelease plugin registry"',
+    );
+    const workflowSource = readFileSync(WORKFLOW_PATH, "utf8");
+    const optionalJsonParses =
+      workflowSource.match(/fromJSON\([^)]+ \|\| '\{\}'\)\.[A-Za-z]+ \|\| ''/gu) ?? [];
+    expect(optionalJsonParses).toHaveLength(9);
+    expect(workflowSource).not.toContain("fromJSON(steps.provided_registry.outputs.json).");
+    expect(workflowSource).not.toContain(
+      "fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json).",
     );
   });
 

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -164,6 +164,9 @@ describe("cross-OS release checks workflow", () => {
     expect(resolve.run).toContain("'$provider + $docker | unique | sort'");
     expect(resolve.run).toContain("--plugin-registry-output-dir");
     expect(resolve.run).toContain("--required-plugin-packages-json");
+    expect(resolve.run).toContain(
+      'source_args=(--source npm --package-spec "$RELEASE_PACKAGE_SPEC" --package-ref "$PACKAGE_REF")',
+    );
 
     const registryUpload = step(producer, "Upload shared prerelease plugin registry artifact");
     expect(registryUpload.with?.name).toBe(

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -23,6 +23,7 @@ type WorkflowStep = {
 };
 
 type WorkflowJob = {
+  if?: string;
   outputs?: Record<string, unknown>;
   steps?: WorkflowStep[];
   with?: Record<string, unknown>;
@@ -124,18 +125,7 @@ describe("cross-OS release checks workflow", () => {
         "${{ steps.package.outputs.sha256 || fromJSON(inputs.candidate_artifact_json || '{}').packageSha256 }}",
       package_version:
         "${{ steps.package.outputs.package_version || fromJSON(inputs.candidate_artifact_json || '{}').packageVersion }}",
-      prepublish_plugin_registry_artifact_digest:
-        "${{ steps.prepublish_plugin_registry_upload.outputs.artifact-digest || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}",
-      prepublish_plugin_registry_artifact_id:
-        "${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}",
-      prepublish_plugin_registry_artifact_name:
-        "${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id && format('docker-e2e-prepublish-plugin-registry-{0}-{1}', github.run_id, github.run_attempt) || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactName || '' }}",
-      prepublish_plugin_registry_artifact_run_attempt:
-        "${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id && github.run_attempt || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}",
-      prepublish_plugin_registry_artifact_run_id:
-        "${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id && github.run_id || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}",
-      prepublish_plugin_registry_manifest_sha256:
-        "${{ steps.package.outputs.plugin_registry_manifest_sha256 || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}",
+      prepublish_plugin_registry_json: "${{ steps.registry_identity.outputs.json }}",
       source_sha:
         "${{ steps.package.outputs.source_sha || fromJSON(inputs.candidate_artifact_json || '{}').packageSourceSha }}",
     });
@@ -183,9 +173,7 @@ describe("cross-OS release checks workflow", () => {
       PACKAGE_SOURCE_SHA: "${{ steps.package.outputs.source_sha }}",
       PACKAGE_VERSION: "${{ steps.package.outputs.package_version }}",
     });
-    expect(binding.run).toContain('[[ "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ ]]');
-    expect(binding.run).toContain('"$ARTIFACT_RUN_ID" == "$GITHUB_RUN_ID"');
-    expect(binding.run).toContain('"$ARTIFACT_RUN_ATTEMPT" == "$GITHUB_RUN_ATTEMPT"');
+    expect(binding.run).toContain('verify-upload "Release package"');
     expect(binding.run).toContain('"$PACKAGE_SHA256" =~ ^[a-f0-9]{64}$');
     expect(binding.run).toContain('"$PACKAGE_SOURCE_SHA" =~ ^[a-f0-9]{40}$');
 
@@ -201,18 +189,8 @@ describe("cross-OS release checks workflow", () => {
       candidate_sha256: "${{ needs.prepare_release_package.outputs.package_sha256 }}",
       candidate_source_sha: "${{ needs.prepare_release_package.outputs.source_sha }}",
       candidate_version: "${{ needs.prepare_release_package.outputs.package_version }}",
-      prepublish_plugin_registry_artifact_digest:
-        "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_digest }}",
-      prepublish_plugin_registry_artifact_id:
-        "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_id }}",
-      prepublish_plugin_registry_artifact_name:
-        "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_name }}",
-      prepublish_plugin_registry_artifact_run_attempt:
-        "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_run_attempt }}",
-      prepublish_plugin_registry_artifact_run_id:
-        "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_run_id }}",
-      prepublish_plugin_registry_manifest_sha256:
-        "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_manifest_sha256 }}",
+      prepublish_plugin_registry_json:
+        "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_json }}",
     });
     expect(crossOs.with?.required_companion_packages_json).toBeUndefined();
 
@@ -228,9 +206,9 @@ describe("cross-OS release checks workflow", () => {
       package_source_sha: "${{ needs.prepare_release_package.outputs.source_sha }}",
       package_version: "${{ needs.prepare_release_package.outputs.package_version }}",
       prepublish_plugin_registry_artifact_id:
-        "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_id }}",
+        "${{ fromJSON(needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactId || '' }}",
       prepublish_plugin_registry_manifest_sha256:
-        "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_manifest_sha256 }}",
+        "${{ fromJSON(needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}",
     });
     expect(job(release, "package_acceptance_release_checks").with).toMatchObject({
       artifact_digest: "${{ needs.prepare_release_package.outputs.artifact_digest }}",
@@ -243,6 +221,39 @@ describe("cross-OS release checks workflow", () => {
       package_version: "${{ needs.prepare_release_package.outputs.package_version }}",
       workflow_ref: "${{ github.sha }}",
     });
+  });
+
+  it("builds companion registries only for scheduled cross-OS or Docker consumers", () => {
+    const workflow = readWorkflow(RELEASE_CHECKS_PATH);
+    const resolveTarget = job(workflow, "resolve_target");
+    expect(resolveTarget.outputs).toMatchObject({
+      cross_os_scheduled: "${{ steps.inputs.outputs.cross_os_scheduled }}",
+      docker_release_scheduled: "${{ steps.inputs.outputs.docker_release_scheduled }}",
+    });
+    const capture = step(resolveTarget, "Capture selected inputs");
+    expect(capture.run).toContain("cross_os_scheduled=false");
+    expect(capture.run).toContain("docker_release_scheduled=false");
+    expect(capture.run).toContain('"$RELEASE_RERUN_GROUP_INPUT" == "cross-os"');
+    expect(capture.run).toContain('[[ -z "${repo_live_suite_filter// }" ]]');
+
+    const producer = job(workflow, "prepare_release_package");
+    expect(producer.if).toContain("needs.resolve_target.outputs.cross_os_scheduled == 'true'");
+    expect(producer.if).toContain(
+      "needs.resolve_target.outputs.docker_release_scheduled == 'true'",
+    );
+    const resolvePackage = step(producer, "Resolve release package artifact");
+    expect(resolvePackage.run).toContain('if [[ "$CROSS_OS_SCHEDULED" == "true" ]]');
+    expect(resolvePackage.run).toContain(
+      'if [[ "$DOCKER_RELEASE_SCHEDULED" == "true" && -z "${RELEASE_PACKAGE_SPEC// }" ]]',
+    );
+    expect(resolvePackage.run).toContain("registry_args=()");
+    expect(resolvePackage.run).toContain("if [[ \"$required_packages\" != '[]' ]]");
+    expect(job(workflow, "cross_os_release_checks").if).toBe(
+      "needs.resolve_target.outputs.cross_os_scheduled == 'true'",
+    );
+    expect(job(workflow, "docker_e2e_release_checks").if).toBe(
+      "needs.resolve_target.outputs.docker_release_scheduled == 'true'",
+    );
   });
 
   it("downloads and re-exports exact candidate artifacts only by immutable id", () => {
@@ -271,6 +282,10 @@ describe("cross-OS release checks workflow", () => {
       default: "",
       type: "string",
     });
+    expect(workflow.on?.workflow_call?.inputs?.prepublish_plugin_registry_json).toMatchObject({
+      default: "",
+      type: "string",
+    });
     for (const inputName of [
       "prepublish_plugin_registry_artifact_digest",
       "prepublish_plugin_registry_artifact_id",
@@ -280,10 +295,7 @@ describe("cross-OS release checks workflow", () => {
       "prepublish_plugin_registry_manifest_sha256",
     ]) {
       expect(workflow.on?.workflow_dispatch?.inputs?.[inputName], inputName).toBeUndefined();
-      expect(workflow.on?.workflow_call?.inputs?.[inputName], inputName).toMatchObject({
-        default: "",
-        type: "string",
-      });
+      expect(workflow.on?.workflow_call?.inputs?.[inputName], inputName).toBeUndefined();
     }
     expect(workflow.on?.workflow_call?.inputs?.required_companion_packages_json).toBeUndefined();
 
@@ -300,10 +312,7 @@ describe("cross-OS release checks workflow", () => {
       candidate_artifact_run_id: "${{ github.run_id }}",
       candidate_sha256: "${{ steps.candidate_metadata.outputs.sha256 }}",
       candidate_version: "${{ steps.candidate_metadata.outputs.version }}",
-      prepublish_plugin_registry_artifact_id:
-        "${{ steps.upload_prepublish_plugin_registry.outputs.artifact-id || inputs.prepublish_plugin_registry_artifact_id || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactId || '' }}",
-      prepublish_plugin_registry_manifest_sha256:
-        "${{ steps.source_prepublish_plugin_registry.outputs.manifest_sha256 || inputs.prepublish_plugin_registry_manifest_sha256 || fromJSON(inputs.prepublish_plugin_registry_json || '{}').manifestSha256 || '' }}",
+      prepublish_plugin_registry_json: "${{ steps.registry_identity.outputs.json }}",
       required_companion_packages_json: "${{ steps.provider_requirements.outputs.json }}",
       source_sha: "${{ steps.candidate_metadata.outputs.source_sha }}",
     });
@@ -330,10 +339,7 @@ describe("cross-OS release checks workflow", () => {
     expect(inputBinding.run).toContain(
       '[[ "$ARTIFACT_NAME" == *"-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}" ]]',
     );
-    expect(inputBinding.run).toContain('--arg digest "sha256:${ARTIFACT_DIGEST}"');
-    expect(inputBinding.run).toContain(
-      "actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}",
-    );
+    expect(inputBinding.run).toContain('verify-upload "Candidate"');
     expect(inputBinding.run).toContain('"$CANDIDATE_SOURCE_SHA" != "$INPUT_REF"');
 
     const inputDownload = step(prepare, "Download provided candidate artifact");
@@ -383,35 +389,14 @@ describe("cross-OS release checks workflow", () => {
     expect(sourceRegistry.run).toContain("--repo-root source");
     expect(sourceRegistry.run).toContain('--required-packages-json "$REQUIRED_PACKAGES_JSON"');
 
+    const preparedUploadVerification = step(prepare, "Verify prepared artifact uploads");
+    expect(preparedUploadVerification.run).toContain('verify-upload "Candidate"');
+    expect(preparedUploadVerification.run).toContain('verify-upload "Baseline"');
+    expect(preparedUploadVerification.run).toContain('verify-upload "Prerelease plugin registry"');
     const consumer = job(workflow, "cross_os_release_checks");
-    const binding = step(consumer, "Validate prepared candidate artifact binding");
-    expect(binding.env).toMatchObject({
-      ARTIFACT_DIGEST: "${{ needs.prepare.outputs.candidate_artifact_digest }}",
-      ARTIFACT_ID: "${{ needs.prepare.outputs.candidate_artifact_id }}",
-      ARTIFACT_NAME:
-        "${{ format('openclaw-cross-os-release-checks-candidate-{0}-{1}', needs.prepare.outputs.candidate_artifact_run_id, needs.prepare.outputs.candidate_artifact_run_attempt) }}",
-      ARTIFACT_RUN_ATTEMPT: "${{ needs.prepare.outputs.candidate_artifact_run_attempt }}",
-      ARTIFACT_RUN_ID: "${{ needs.prepare.outputs.candidate_artifact_run_id }}",
-      BASELINE_ARTIFACT_DIGEST: "${{ needs.prepare.outputs.baseline_artifact_digest }}",
-      BASELINE_ARTIFACT_ID: "${{ needs.prepare.outputs.baseline_artifact_id }}",
-      BASELINE_ARTIFACT_NAME:
-        "${{ format('openclaw-cross-os-release-checks-baseline-{0}-{1}', needs.prepare.outputs.baseline_artifact_run_id, needs.prepare.outputs.baseline_artifact_run_attempt) }}",
-      BASELINE_ARTIFACT_RUN_ATTEMPT: "${{ needs.prepare.outputs.baseline_artifact_run_attempt }}",
-      BASELINE_ARTIFACT_RUN_ID: "${{ needs.prepare.outputs.baseline_artifact_run_id }}",
-      BASELINE_SHA256: "${{ needs.prepare.outputs.baseline_sha256 }}",
-      CANDIDATE_SHA256: "${{ needs.prepare.outputs.candidate_sha256 }}",
-      CANDIDATE_SOURCE_SHA: "${{ needs.prepare.outputs.source_sha }}",
-      CANDIDATE_VERSION: "${{ needs.prepare.outputs.candidate_version }}",
-      GH_TOKEN: "${{ github.token }}",
-    });
-    expect(binding.run).not.toContain('"$ARTIFACT_RUN_ATTEMPT" == "$GITHUB_RUN_ATTEMPT"');
-    expect(binding.run).not.toContain('"$BASELINE_ARTIFACT_RUN_ATTEMPT" == "$GITHUB_RUN_ATTEMPT"');
-    expect(binding.run).toContain("actions/artifacts/${tuple.id}");
-    expect(binding.run).toContain("artifact.expired !== false");
-    expect(binding.run).toContain("artifact.digest !== `sha256:${tuple.digest}`");
-    expect(binding.run).toContain("String(artifact.workflow_run?.id) !== tuple.runId");
-    expect(binding.run).toContain("actions/runs/${tuple.runId}/attempts/${tuple.runAttempt}");
-    expect(binding.run).toContain("String(attempt.run_attempt) !== tuple.runAttempt");
+    expect(consumer.steps?.map((candidate) => candidate.name)).not.toContain(
+      "Validate prepared candidate artifact binding",
+    );
 
     for (const name of ["Download candidate artifact", "Retry candidate artifact download"]) {
       const download = step(consumer, name);
@@ -462,44 +447,23 @@ describe("cross-OS release checks workflow", () => {
     );
 
     const consumer = job(workflow, "cross_os_release_checks");
-    const binding = step(consumer, "Validate prepared candidate artifact binding");
-    expect(binding.env).toMatchObject({
-      PLUGIN_ARTIFACT_DIGEST:
-        "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_digest }}",
-      PLUGIN_ARTIFACT_ID: "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_id }}",
-      PLUGIN_ARTIFACT_NAME: "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_name }}",
-      PLUGIN_ARTIFACT_RUN_ATTEMPT:
-        "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_run_attempt }}",
-      PLUGIN_ARTIFACT_RUN_ID:
-        "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_run_id }}",
-      PLUGIN_MANIFEST_SHA256:
-        "${{ needs.prepare.outputs.prepublish_plugin_registry_manifest_sha256 }}",
-      REQUIRED_COMPANION_PACKAGES_JSON:
-        "${{ needs.prepare.outputs.required_companion_packages_json }}",
-    });
-    expect(binding.run).toContain("Prepared prerelease plugin registry binding is incomplete.");
-    expect(binding.run).toContain(
-      "Required companion packages need the immutable plugin registry tuple.",
-    );
-    expect(binding.run).toContain("actions/artifacts/${tuple.id}");
     const download = step(consumer, "Download prerelease plugin registry artifact");
     expect(download.with).toMatchObject({
-      "artifact-ids": "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_id }}",
-      "run-id": "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_run_id }}",
+      "artifact-ids":
+        "${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json).prepublishPluginRegistryArtifactId }}",
+      "run-id":
+        "${{ fromJSON(needs.prepare.outputs.prepublish_plugin_registry_json).prepublishPluginRegistryArtifactRunId }}",
     });
 
     const run = step(consumer, "Run cross-OS release checks");
     expect(run.env).toMatchObject({
-      PLUGIN_REGISTRY_ARTIFACT_ID:
-        "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_id }}",
-      PLUGIN_REGISTRY_MANIFEST_SHA256:
-        "${{ needs.prepare.outputs.prepublish_plugin_registry_manifest_sha256 }}",
+      PLUGIN_REGISTRY_JSON: "${{ needs.prepare.outputs.prepublish_plugin_registry_json }}",
       REQUIRED_COMPANION_PACKAGES_JSON:
         "${{ needs.prepare.outputs.required_companion_packages_json }}",
     });
     expect(run.run).toContain('--plugin-registry-dir "$PLUGIN_REGISTRY_DIR"');
     expect(run.run).toContain(
-      '--plugin-registry-manifest-sha256 "$PLUGIN_REGISTRY_MANIFEST_SHA256"',
+      '"$(jq -r \'.prepublishPluginRegistryManifestSha256\' <<< "$PLUGIN_REGISTRY_JSON")"',
     );
     expect(run.run).not.toContain("--required-companion-packages-json");
     expect(run.run).not.toContain("OPENCLAW_PLUGIN_INSTALL_OVERRIDES");
@@ -513,18 +477,20 @@ describe("cross-OS release checks workflow", () => {
     expect(requirements.run).toContain("--resolve-provider-required-companion-packages");
     expect(requirements.run).toContain('--provider "$PROVIDER"');
 
-    const contract = step(prepare, "Validate companion registry contract");
+    const contract = step(prepare, "Normalize companion registry contract");
+    expect(contract.run).toContain("(keys | sort) == ([");
+    expect(contract.run).toContain('all(.[]; type == "string")');
     expect(contract.run).toContain(
-      "Provider-owned companion requirements cannot be overridden by dispatch input.",
-    );
-    expect(contract.run).toContain(
-      "Prerelease companion registry selection must provide the complete immutable tuple.",
+      "Prerelease companion registry must be one closed immutable JSON tuple.",
     );
     expect(contract.run).toContain(
       "The selected provider requires a complete immutable companion registry tuple.",
     );
     expect(contract.run).toContain(
       "Source-built candidates produce their own companion registry and reject a second tuple.",
+    );
+    expect(step(prepare, "Verify provided prerelease plugin registry upload").run).toContain(
+      'verify-upload "Prerelease plugin registry"',
     );
   });
 

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -125,17 +125,17 @@ describe("cross-OS release checks workflow", () => {
       package_version:
         "${{ steps.package.outputs.package_version || fromJSON(inputs.candidate_artifact_json || '{}').packageVersion }}",
       prepublish_plugin_registry_artifact_digest:
-        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}",
+        "${{ steps.prepublish_plugin_registry_upload.outputs.artifact-digest || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}",
       prepublish_plugin_registry_artifact_id:
-        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}",
+        "${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}",
       prepublish_plugin_registry_artifact_name:
-        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactName || '' }}",
+        "${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id && format('docker-e2e-prepublish-plugin-registry-{0}-{1}', github.run_id, github.run_attempt) || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactName || '' }}",
       prepublish_plugin_registry_artifact_run_attempt:
-        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}",
+        "${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id && github.run_attempt || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}",
       prepublish_plugin_registry_artifact_run_id:
-        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}",
+        "${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id && github.run_id || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}",
       prepublish_plugin_registry_manifest_sha256:
-        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}",
+        "${{ steps.package.outputs.plugin_registry_manifest_sha256 || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}",
       source_sha:
         "${{ steps.package.outputs.source_sha || fromJSON(inputs.candidate_artifact_json || '{}').packageSourceSha }}",
     });
@@ -158,6 +158,17 @@ describe("cross-OS release checks workflow", () => {
       name: "${{ steps.artifact.outputs.name }}",
       "if-no-files-found": "error",
     });
+    const resolve = step(producer, "Resolve release package artifact");
+    expect(resolve.run).toContain("--resolve-provider-required-companion-packages");
+    expect(resolve.run).toContain(".requiredPrepublishPluginPackages");
+    expect(resolve.run).toContain("'$provider + $docker | unique | sort'");
+    expect(resolve.run).toContain("--plugin-registry-output-dir");
+    expect(resolve.run).toContain("--required-plugin-packages-json");
+
+    const registryUpload = step(producer, "Upload shared prerelease plugin registry artifact");
+    expect(registryUpload.with?.name).toBe(
+      "docker-e2e-prepublish-plugin-registry-${{ github.run_id }}-${{ github.run_attempt }}",
+    );
 
     const binding = step(producer, "Validate release package artifact binding");
     expect(binding.env).toMatchObject({
@@ -199,9 +210,8 @@ describe("cross-OS release checks workflow", () => {
         "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_run_id }}",
       prepublish_plugin_registry_manifest_sha256:
         "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_manifest_sha256 }}",
-      required_companion_packages_json:
-        "${{ needs.resolve_target.outputs.provider == 'openai' && '[\"@openclaw/codex\"]' || '[]' }}",
     });
+    expect(crossOs.with?.required_companion_packages_json).toBeUndefined();
 
     expect(job(release, "docker_e2e_release_checks").with).toMatchObject({
       package_artifact_digest: "${{ needs.prepare_release_package.outputs.artifact_digest }}",
@@ -272,10 +282,7 @@ describe("cross-OS release checks workflow", () => {
         type: "string",
       });
     }
-    expect(workflow.on?.workflow_call?.inputs?.required_companion_packages_json).toMatchObject({
-      default: "[]",
-      type: "string",
-    });
+    expect(workflow.on?.workflow_call?.inputs?.required_companion_packages_json).toBeUndefined();
 
     const prepare = job(workflow, "prepare");
     expect(prepare.outputs).toMatchObject({
@@ -291,11 +298,10 @@ describe("cross-OS release checks workflow", () => {
       candidate_sha256: "${{ steps.candidate_metadata.outputs.sha256 }}",
       candidate_version: "${{ steps.candidate_metadata.outputs.version }}",
       prepublish_plugin_registry_artifact_id:
-        "${{ inputs.prepublish_plugin_registry_artifact_id || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactId || '' }}",
+        "${{ steps.upload_prepublish_plugin_registry.outputs.artifact-id || inputs.prepublish_plugin_registry_artifact_id || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactId || '' }}",
       prepublish_plugin_registry_manifest_sha256:
-        "${{ inputs.prepublish_plugin_registry_manifest_sha256 || fromJSON(inputs.prepublish_plugin_registry_json || '{}').manifestSha256 || '' }}",
-      required_companion_packages_json:
-        "${{ inputs.required_companion_packages_json || toJSON(fromJSON(inputs.prepublish_plugin_registry_json || '{}').requiredPackages || fromJSON('[]')) }}",
+        "${{ steps.source_prepublish_plugin_registry.outputs.manifest_sha256 || inputs.prepublish_plugin_registry_manifest_sha256 || fromJSON(inputs.prepublish_plugin_registry_json || '{}').manifestSha256 || '' }}",
+      required_companion_packages_json: "${{ steps.provider_requirements.outputs.json }}",
       source_sha: "${{ steps.candidate_metadata.outputs.source_sha }}",
     });
     for (const [jobName, workflowJob] of Object.entries(workflow.jobs)) {
@@ -365,6 +371,14 @@ describe("cross-OS release checks workflow", () => {
     expect(baselineUpload.with?.name).toBe(
       "openclaw-cross-os-release-checks-baseline-${{ github.run_id }}-${{ github.run_attempt }}",
     );
+    const registryUpload = step(prepare, "Upload source-built prerelease companion registry");
+    expect(registryUpload.if).toBe(
+      "inputs.candidate_artifact_name == '' && steps.provider_requirements.outputs.json != '[]'",
+    );
+    const sourceRegistry = step(prepare, "Pack source-built prerelease companion registry");
+    expect(sourceRegistry.run).toContain("prepublish-plugin-registry-artifact.mjs create");
+    expect(sourceRegistry.run).toContain("--repo-root source");
+    expect(sourceRegistry.run).toContain('--required-packages-json "$REQUIRED_PACKAGES_JSON"');
 
     const consumer = job(workflow, "cross_os_release_checks");
     const binding = step(consumer, "Validate prepared candidate artifact binding");
@@ -484,11 +498,50 @@ describe("cross-OS release checks workflow", () => {
     expect(run.run).toContain(
       '--plugin-registry-manifest-sha256 "$PLUGIN_REGISTRY_MANIFEST_SHA256"',
     );
-    expect(run.run).toContain(
-      '--required-companion-packages-json "$REQUIRED_COMPANION_PACKAGES_JSON"',
-    );
+    expect(run.run).not.toContain("--required-companion-packages-json");
     expect(run.run).not.toContain("OPENCLAW_PLUGIN_INSTALL_OVERRIDES");
     expect(JSON.stringify(workflow)).not.toContain("@openclaw/codex");
+  });
+
+  it("owns provider companion requirements and fails closed for direct candidates", () => {
+    const workflow = readWorkflow(WORKFLOW_PATH);
+    const prepare = job(workflow, "prepare");
+    const requirements = step(prepare, "Resolve provider-owned companion requirements");
+    expect(requirements.run).toContain("--resolve-provider-required-companion-packages");
+    expect(requirements.run).toContain('--provider "$PROVIDER"');
+
+    const contract = step(prepare, "Validate companion registry contract");
+    expect(contract.run).toContain(
+      "Provider-owned companion requirements cannot be overridden by dispatch input.",
+    );
+    expect(contract.run).toContain(
+      "Prerelease companion registry selection must provide the complete immutable tuple.",
+    );
+    expect(contract.run).toContain(
+      "The selected provider requires a complete immutable companion registry tuple.",
+    );
+    expect(contract.run).toContain(
+      "Source-built candidates produce their own companion registry and reject a second tuple.",
+    );
+  });
+
+  it.each([
+    ["openai", ["@openclaw/codex"]],
+    ["anthropic", []],
+    ["minimax", []],
+  ])("resolves provider-owned companions for %s", (provider, expected) => {
+    const result = spawnSync(
+      BASH_BIN,
+      [WRAPPER_PATH, "--resolve-provider-required-companion-packages", "--provider", provider],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, OPENCLAW_RELEASE_CHECKS_SCRIPT: SCRIPT_PATH },
+      },
+    );
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual(expected);
   });
 
   it("executes the release harness directly with Node", () => {

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -124,6 +124,18 @@ describe("cross-OS release checks workflow", () => {
         "${{ steps.package.outputs.sha256 || fromJSON(inputs.candidate_artifact_json || '{}').packageSha256 }}",
       package_version:
         "${{ steps.package.outputs.package_version || fromJSON(inputs.candidate_artifact_json || '{}').packageVersion }}",
+      prepublish_plugin_registry_artifact_digest:
+        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}",
+      prepublish_plugin_registry_artifact_id:
+        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}",
+      prepublish_plugin_registry_artifact_name:
+        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactName || '' }}",
+      prepublish_plugin_registry_artifact_run_attempt:
+        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}",
+      prepublish_plugin_registry_artifact_run_id:
+        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}",
+      prepublish_plugin_registry_manifest_sha256:
+        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}",
       source_sha:
         "${{ steps.package.outputs.source_sha || fromJSON(inputs.candidate_artifact_json || '{}').packageSourceSha }}",
     });
@@ -175,7 +187,20 @@ describe("cross-OS release checks workflow", () => {
       candidate_sha256: "${{ needs.prepare_release_package.outputs.package_sha256 }}",
       candidate_source_sha: "${{ needs.prepare_release_package.outputs.source_sha }}",
       candidate_version: "${{ needs.prepare_release_package.outputs.package_version }}",
-      candidate_artifact_json: "${{ inputs.candidate_artifact_json }}",
+      prepublish_plugin_registry_artifact_digest:
+        "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_digest }}",
+      prepublish_plugin_registry_artifact_id:
+        "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_id }}",
+      prepublish_plugin_registry_artifact_name:
+        "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_name }}",
+      prepublish_plugin_registry_artifact_run_attempt:
+        "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_run_attempt }}",
+      prepublish_plugin_registry_artifact_run_id:
+        "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_run_id }}",
+      prepublish_plugin_registry_manifest_sha256:
+        "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_manifest_sha256 }}",
+      required_companion_packages_json:
+        "${{ needs.resolve_target.outputs.provider == 'openai' && '[\"@openclaw/codex\"]' || '[]' }}",
     });
 
     expect(job(release, "docker_e2e_release_checks").with).toMatchObject({
@@ -189,6 +214,10 @@ describe("cross-OS release checks workflow", () => {
       package_sha256: "${{ needs.prepare_release_package.outputs.package_sha256 }}",
       package_source_sha: "${{ needs.prepare_release_package.outputs.source_sha }}",
       package_version: "${{ needs.prepare_release_package.outputs.package_version }}",
+      prepublish_plugin_registry_artifact_id:
+        "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_artifact_id }}",
+      prepublish_plugin_registry_manifest_sha256:
+        "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_manifest_sha256 }}",
     });
     expect(job(release, "package_acceptance_release_checks").with).toMatchObject({
       artifact_digest: "${{ needs.prepare_release_package.outputs.artifact_digest }}",
@@ -215,7 +244,6 @@ describe("cross-OS release checks workflow", () => {
       "candidate_sha256",
       "candidate_source_sha",
       "candidate_version",
-      "candidate_artifact_json",
     ]) {
       expect(workflow.on?.workflow_dispatch?.inputs?.[inputName], inputName).toMatchObject({
         default: "",
@@ -226,6 +254,28 @@ describe("cross-OS release checks workflow", () => {
         type: "string",
       });
     }
+    expect(workflow.on?.workflow_dispatch?.inputs?.prepublish_plugin_registry_json).toMatchObject({
+      default: "",
+      type: "string",
+    });
+    for (const inputName of [
+      "prepublish_plugin_registry_artifact_digest",
+      "prepublish_plugin_registry_artifact_id",
+      "prepublish_plugin_registry_artifact_name",
+      "prepublish_plugin_registry_artifact_run_attempt",
+      "prepublish_plugin_registry_artifact_run_id",
+      "prepublish_plugin_registry_manifest_sha256",
+    ]) {
+      expect(workflow.on?.workflow_dispatch?.inputs?.[inputName], inputName).toBeUndefined();
+      expect(workflow.on?.workflow_call?.inputs?.[inputName], inputName).toMatchObject({
+        default: "",
+        type: "string",
+      });
+    }
+    expect(workflow.on?.workflow_call?.inputs?.required_companion_packages_json).toMatchObject({
+      default: "[]",
+      type: "string",
+    });
 
     const prepare = job(workflow, "prepare");
     expect(prepare.outputs).toMatchObject({
@@ -240,14 +290,12 @@ describe("cross-OS release checks workflow", () => {
       candidate_artifact_run_id: "${{ github.run_id }}",
       candidate_sha256: "${{ steps.candidate_metadata.outputs.sha256 }}",
       candidate_version: "${{ steps.candidate_metadata.outputs.version }}",
-      codex_plugin_file_name: "${{ steps.codex_plugin_metadata.outputs.file_name }}",
-      codex_plugin_sha256: "${{ steps.codex_plugin_metadata.outputs.sha256 }}",
       prepublish_plugin_registry_artifact_id:
-        "${{ steps.upload_generated_plugin_registry.outputs.artifact-id || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}",
-      prepublish_plugin_registry_artifact_run_attempt:
-        "${{ steps.upload_generated_plugin_registry.outputs.artifact-id && github.run_attempt || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}",
-      prepublish_plugin_registry_artifact_run_id:
-        "${{ steps.upload_generated_plugin_registry.outputs.artifact-id && github.run_id || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}",
+        "${{ inputs.prepublish_plugin_registry_artifact_id || fromJSON(inputs.prepublish_plugin_registry_json || '{}').artifactId || '' }}",
+      prepublish_plugin_registry_manifest_sha256:
+        "${{ inputs.prepublish_plugin_registry_manifest_sha256 || fromJSON(inputs.prepublish_plugin_registry_json || '{}').manifestSha256 || '' }}",
+      required_companion_packages_json:
+        "${{ inputs.required_companion_packages_json || toJSON(fromJSON(inputs.prepublish_plugin_registry_json || '{}').requiredPackages || fromJSON('[]')) }}",
       source_sha: "${{ steps.candidate_metadata.outputs.source_sha }}",
     });
     for (const [jobName, workflowJob] of Object.entries(workflow.jobs)) {
@@ -381,63 +429,66 @@ describe("cross-OS release checks workflow", () => {
     expect(verify.run).toContain('"$actual_baseline_sha256" != "$EXPECTED_BASELINE_SHA256"');
   });
 
-  it("binds OpenAI onboarding to the exact prerelease Codex companion", () => {
+  it("passes and consumes the immutable prerelease companion registry generically", () => {
     const workflow = readWorkflow(WORKFLOW_PATH);
     const prepare = job(workflow, "prepare");
-    const binding = step(prepare, "Validate prerelease plugin registry artifact binding");
-    expect(binding.run).toContain('verify-upload "Prerelease plugin registry"');
-    expect(binding.env).toMatchObject({
-      ARTIFACT_ID:
-        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}",
-      ARTIFACT_RUN_ID:
-        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}",
-      MANIFEST_SHA256:
-        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}",
-    });
-
     const sourceCheckout = step(prepare, "Checkout public source ref");
-    expect(sourceCheckout.if).toContain("inputs.provider == 'openai'");
-    expect(sourceCheckout.with?.ref).toBe(
-      "${{ inputs.candidate_artifact_name != '' && inputs.candidate_source_sha || inputs.ref }}",
+    expect(sourceCheckout.if).toBe("inputs.candidate_artifact_name == ''");
+    expect(sourceCheckout.with?.ref).toBe("${{ inputs.ref }}");
+    expect(prepare.steps?.map((candidate) => candidate.name)).not.toEqual(
+      expect.arrayContaining([
+        "Install companion plugin build dependencies",
+        "Pack exact Codex companion plugin",
+        "Resolve exact Codex companion plugin",
+        "Upload generated prerelease plugin registry artifact",
+      ]),
     );
-    expect(step(prepare, "Install companion plugin build dependencies").run).toBe(
-      "pnpm install --frozen-lockfile --prefer-offline --ignore-scripts",
-    );
-    const pack = step(prepare, "Pack exact Codex companion plugin");
-    expect(pack.run).toContain("prepublish-plugin-registry-artifact.mjs create");
-    expect(pack.run).toContain("--repo-root source");
-    expect(pack.run).toContain(`--required-packages-json '["@openclaw/codex"]'`);
-
-    const metadata = step(prepare, "Resolve exact Codex companion plugin");
-    expect(metadata.run).toContain('any(.name == "@openclaw/codex")');
-    expect(metadata.run).toContain("prepublish-plugin-registry-artifact.mjs verify");
-    expect(metadata.run).toContain('--source-sha "$SOURCE_SHA"');
-    expect(metadata.run).toContain('--candidate-version "$CANDIDATE_VERSION"');
-    expect(metadata.run).toContain("entry.tarball !== path.win32.basename(entry.tarball)");
-    expect(
-      step(prepare, "Upload generated prerelease plugin registry artifact").with,
-    ).toMatchObject({
-      name: "openclaw-cross-os-release-checks-plugins-${{ github.run_id }}-${{ github.run_attempt }}",
-      "if-no-files-found": "error",
-    });
 
     const consumer = job(workflow, "cross_os_release_checks");
+    const binding = step(consumer, "Validate prepared candidate artifact binding");
+    expect(binding.env).toMatchObject({
+      PLUGIN_ARTIFACT_DIGEST:
+        "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_digest }}",
+      PLUGIN_ARTIFACT_ID: "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_id }}",
+      PLUGIN_ARTIFACT_NAME: "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_name }}",
+      PLUGIN_ARTIFACT_RUN_ATTEMPT:
+        "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_run_attempt }}",
+      PLUGIN_ARTIFACT_RUN_ID:
+        "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_run_id }}",
+      PLUGIN_MANIFEST_SHA256:
+        "${{ needs.prepare.outputs.prepublish_plugin_registry_manifest_sha256 }}",
+      REQUIRED_COMPANION_PACKAGES_JSON:
+        "${{ needs.prepare.outputs.required_companion_packages_json }}",
+    });
+    expect(binding.run).toContain("Prepared prerelease plugin registry binding is incomplete.");
+    expect(binding.run).toContain(
+      "Required companion packages need the immutable plugin registry tuple.",
+    );
+    expect(binding.run).toContain("actions/artifacts/${tuple.id}");
     const download = step(consumer, "Download prerelease plugin registry artifact");
     expect(download.with).toMatchObject({
       "artifact-ids": "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_id }}",
       "run-id": "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_run_id }}",
     });
-    const verify = step(consumer, "Verify release-check inputs");
-    expect(verify.run).toContain('"$actual_codex_sha256" != "$EXPECTED_CODEX_PLUGIN_SHA256"');
 
     const run = step(consumer, "Run cross-OS release checks");
-    expect(run.env?.CODEX_PLUGIN_FILE_NAME).toBe(
-      "${{ needs.prepare.outputs.codex_plugin_file_name }}",
-    );
-    expect(run.run).toContain("OPENCLAW_ALLOW_PLUGIN_INSTALL_OVERRIDES=1");
+    expect(run.env).toMatchObject({
+      PLUGIN_REGISTRY_ARTIFACT_ID:
+        "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_id }}",
+      PLUGIN_REGISTRY_MANIFEST_SHA256:
+        "${{ needs.prepare.outputs.prepublish_plugin_registry_manifest_sha256 }}",
+      REQUIRED_COMPANION_PACKAGES_JSON:
+        "${{ needs.prepare.outputs.required_companion_packages_json }}",
+    });
+    expect(run.run).toContain('--plugin-registry-dir "$PLUGIN_REGISTRY_DIR"');
     expect(run.run).toContain(
-      "JSON.stringify({ codex: `npm-pack:${process.env.CODEX_PLUGIN_TGZ}` })",
+      '--plugin-registry-manifest-sha256 "$PLUGIN_REGISTRY_MANIFEST_SHA256"',
     );
+    expect(run.run).toContain(
+      '--required-companion-packages-json "$REQUIRED_COMPANION_PACKAGES_JSON"',
+    );
+    expect(run.run).not.toContain("OPENCLAW_PLUGIN_INSTALL_OVERRIDES");
+    expect(JSON.stringify(workflow)).not.toContain("@openclaw/codex");
   });
 
   it("executes the release harness directly with Node", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3410,10 +3410,10 @@ describe("package artifact reuse", () => {
       "live_suite_filter: ${{ needs.resolve_target.outputs.repo_live_suite_filter }}",
     );
     expect(workflow).toContain(
-      "contains(fromJSON('[\"all\",\"cross-os\",\"package\"]'), needs.resolve_target.outputs.rerun_group) || (needs.resolve_target.outputs.rerun_group == 'live-e2e' && needs.resolve_target.outputs.repo_live_suite_filter == '')",
+      "if: needs.resolve_target.outputs.cross_os_scheduled == 'true' || needs.resolve_target.outputs.docker_release_scheduled == 'true' || needs.resolve_target.outputs.rerun_group == 'package'",
     );
     expect(workflow).toContain(
-      "(needs.resolve_target.outputs.rerun_group == 'live-e2e' || (needs.resolve_target.outputs.rerun_group == 'all' && needs.resolve_target.outputs.run_release_soak == 'true')) && needs.resolve_target.outputs.repo_live_suite_filter == ''",
+      "if: needs.resolve_target.outputs.docker_release_scheduled == 'true'",
     );
     expect(workflow).toContain(
       'if [[ "$release_profile" == "stable" || "$release_profile" == "full" ]]; then\n            run_release_soak=true',
@@ -5676,7 +5676,7 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
   it("executes shared release candidate identity validation with its JSON input", () => {
     const selectedSha = "a".repeat(40);
     const candidate = {
-      packageArtifactName: "docker-e2e-package-123-1",
+      packageArtifactName: "docker-e2e-package-456-1",
       packageArtifactId: "123",
       packageArtifactDigest: "b".repeat(64),
       packageArtifactRunId: "456",
@@ -5697,13 +5697,40 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       "Validate shared release candidate identity",
     ).run;
     expect(validation).toBeDefined();
+    const binDir = resolve(tempDirs.make("release-candidate-validation-"), "bin");
+    mkdirSync(binDir, { recursive: true });
+    const ghPath = resolve(binDir, "gh");
+    writeFileSync(
+      ghPath,
+      `#!/bin/sh
+case "$2" in
+  */actions/artifacts/123)
+    printf '%s\n' '{"id":123,"name":"docker-e2e-package-456-1","expired":false,"digest":"sha256:${"b".repeat(64)}","workflow_run":{"id":456}}'
+    ;;
+  */actions/artifacts/790)
+    printf '%s\n' '{"id":790,"name":"docker-e2e-prepublish-plugin-registry-456-1","expired":false,"digest":"sha256:${"f".repeat(64)}","workflow_run":{"id":456}}'
+    ;;
+  */actions/runs/456/attempts/1)
+    printf '%s\n' '{"id":456,"run_attempt":1}'
+    ;;
+  *) exit 1 ;;
+esac
+`,
+    );
+    chmodSync(ghPath, 0o755);
+    const validationEnv = {
+      ...process.env,
+      GH_TOKEN: "test-token",
+      GITHUB_REPOSITORY: "openclaw/openclaw",
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      SELECTED_SHA: selectedSha,
+    };
 
     const valid = spawnSync("bash", ["-c", validation ?? ""], {
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...validationEnv,
         CANDIDATE_ARTIFACT_JSON: JSON.stringify(candidate),
-        SELECTED_SHA: selectedSha,
       },
     });
     expect(valid.status, valid.stderr).toBe(0);
@@ -5720,9 +5747,8 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     const validRegistry = spawnSync("bash", ["-c", validation ?? ""], {
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...validationEnv,
         CANDIDATE_ARTIFACT_JSON: JSON.stringify(registryCandidate),
-        SELECTED_SHA: selectedSha,
       },
     });
     expect(validRegistry.status, validRegistry.stderr).toBe(0);
@@ -5730,12 +5756,11 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     const partialRegistry = spawnSync("bash", ["-c", validation ?? ""], {
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...validationEnv,
         CANDIDATE_ARTIFACT_JSON: JSON.stringify({
           ...candidate,
           prepublishPluginRegistryArtifactId: "790",
         }),
-        SELECTED_SHA: selectedSha,
       },
     });
     expect(partialRegistry.status).not.toBe(0);
@@ -5743,12 +5768,11 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     const mismatchedRegistryName = spawnSync("bash", ["-c", validation ?? ""], {
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...validationEnv,
         CANDIDATE_ARTIFACT_JSON: JSON.stringify({
           ...registryCandidate,
           prepublishPluginRegistryArtifactName: "docker-e2e-prepublish-plugin-registry-999-1",
         }),
-        SELECTED_SHA: selectedSha,
       },
     });
     expect(mismatchedRegistryName.status).not.toBe(0);
@@ -5756,7 +5780,7 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     const mismatched = spawnSync("bash", ["-c", validation ?? ""], {
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...validationEnv,
         CANDIDATE_ARTIFACT_JSON: JSON.stringify(candidate),
         SELECTED_SHA: "f".repeat(40),
       },

--- a/test/scripts/prepublish-plugin-registry-artifact.test.ts
+++ b/test/scripts/prepublish-plugin-registry-artifact.test.ts
@@ -4,6 +4,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { resolveCrossOsCompanionPackages } from "../../scripts/lib/cross-os-release-checks/companions.ts";
 import {
   PREPUBLISH_PLUGIN_REGISTRY_MANIFEST,
   createPrepublishPluginRegistryArtifact,
@@ -190,6 +191,50 @@ describe("prepublish plugin registry artifact", () => {
       "@openclaw/discord",
       "@openclaw/feishu",
     ]);
+  });
+
+  it("extracts only required cross-OS companions from the validated registry", () => {
+    const paths = fixture();
+    addCompanionPackage(paths);
+
+    expect(
+      resolveCrossOsCompanionPackages({
+        artifactDir: paths.artifactDir,
+        candidateVersion: VERSION,
+        manifestSha256: sha256(paths.manifestPath),
+        requiredPackages: ["@openclaw/feishu"],
+        sourceSha: SOURCE_SHA,
+      }),
+    ).toEqual([
+      {
+        name: "@openclaw/feishu",
+        tarballPath: path.join(paths.artifactDir, "openclaw-feishu-2026.8.1-beta.1.tgz"),
+      },
+    ]);
+  });
+
+  it("rejects mismatched cross-OS companion registry identities", () => {
+    const paths = fixture();
+    const common = {
+      artifactDir: paths.artifactDir,
+      candidateVersion: VERSION,
+      manifestSha256: sha256(paths.manifestPath),
+      requiredPackages: [PACKAGE_NAME],
+      sourceSha: SOURCE_SHA,
+    };
+
+    expect(() => resolveCrossOsCompanionPackages({ ...common, sourceSha: "b".repeat(40) })).toThrow(
+      "source SHA differs",
+    );
+    expect(() =>
+      resolveCrossOsCompanionPackages({ ...common, candidateVersion: "2026.8.1-beta.2" }),
+    ).toThrow("version differs");
+    expect(() =>
+      resolveCrossOsCompanionPackages({ ...common, manifestSha256: "c".repeat(64) }),
+    ).toThrow("manifest SHA-256 differs");
+
+    writeFileSync(paths.tarballPath, "tampered");
+    expect(() => resolveCrossOsCompanionPackages(common)).toThrow("tarball SHA-256 mismatch");
   });
 
   it("refuses to create an artifact from tracked changes under the same HEAD", () => {

--- a/test/scripts/resolve-openclaw-package-candidate.test.ts
+++ b/test/scripts/resolve-openclaw-package-candidate.test.ts
@@ -196,6 +196,11 @@ describe("resolve-openclaw-package-candidate", () => {
     expect(createIndex).toBeLessThan(cleanupIndex);
     expect(script).toContain("requiredPackages,");
     expect(script).toContain("plugin_registry_manifest_sha256: pluginRegistryManifestSha256");
+    expect(script).toContain('options.source === "npm"');
+    expect(script).toContain("pluginRegistrySource = await preparePackageSourceWorktree(");
+    expect(script).toContain(
+      "prepublish plugin registry source SHA/version differs from the package candidate",
+    );
   });
 
   it("rejects option-shaped package candidate option values", () => {

--- a/test/scripts/resolve-openclaw-package-candidate.test.ts
+++ b/test/scripts/resolve-openclaw-package-candidate.test.ts
@@ -187,22 +187,6 @@ describe("resolve-openclaw-package-candidate", () => {
     });
   });
 
-  it("creates a source-built companion registry before removing the trusted worktree", () => {
-    const script = readFileSync("scripts/resolve-openclaw-package-candidate.mjs", "utf8");
-    const createIndex = script.indexOf("createPrepublishPluginRegistryArtifact({");
-    const cleanupIndex = script.indexOf("cleanupPackageSourceWorktree(packageWorktreeDir");
-
-    expect(createIndex).toBeGreaterThan(0);
-    expect(createIndex).toBeLessThan(cleanupIndex);
-    expect(script).toContain("requiredPackages,");
-    expect(script).toContain("plugin_registry_manifest_sha256: pluginRegistryManifestSha256");
-    expect(script).toContain('options.source === "npm"');
-    expect(script).toContain("pluginRegistrySource = await preparePackageSourceWorktree(");
-    expect(script).toContain(
-      "prepublish plugin registry source SHA/version differs from the package candidate",
-    );
-  });
-
   it("rejects option-shaped package candidate option values", () => {
     for (const flag of [
       "--artifact-dir",

--- a/test/scripts/resolve-openclaw-package-candidate.test.ts
+++ b/test/scripts/resolve-openclaw-package-candidate.test.ts
@@ -179,10 +179,23 @@ describe("resolve-openclaw-package-candidate", () => {
       packageRef: "release/2026.4.27",
       packageSpec: "openclaw@beta",
       packageUrl: "",
+      pluginRegistryOutputDir: "",
+      requiredPluginPackagesJson: "[]",
       source: "npm",
       trustedSourceId: "",
       trustedSourcePolicy: ".github/package-trusted-sources.json",
     });
+  });
+
+  it("creates a source-built companion registry before removing the trusted worktree", () => {
+    const script = readFileSync("scripts/resolve-openclaw-package-candidate.mjs", "utf8");
+    const createIndex = script.indexOf("createPrepublishPluginRegistryArtifact({");
+    const cleanupIndex = script.indexOf("cleanupPackageSourceWorktree(packageWorktreeDir");
+
+    expect(createIndex).toBeGreaterThan(0);
+    expect(createIndex).toBeLessThan(cleanupIndex);
+    expect(script).toContain("requiredPackages,");
+    expect(script).toContain("plugin_registry_manifest_sha256: pluginRegistryManifestSha256");
   });
 
   it("rejects option-shaped package candidate option values", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes the release-path ownership gap that made all nine native cross-OS checks install the correct OpenClaw `2026.8.1-beta.1` core candidate but resolve required version-bound companions from the moving npm `beta` tag.

Full Release child [31229165502](https://github.com/openclaw/openclaw/actions/runs/31229165502) installed candidate core `2026.8.1-beta.1`, while onboarding resolved `@openclaw/codex@beta` to `2026.7.2-beta.7`. Startup correctly refreshed the stale version-bound runtime and refused readiness. Linux, macOS, and Windows each failed packaged fresh, packaged upgrade, and installer fresh. Parent artifact `9013102058` already contained the exact candidate-version companion bound to source SHA `272b3098c71af4143882e68e13193437ef605dd9`; the release-check child dropped that prepared fact at the cross-OS boundary.

Follow-up review also found that source-built release checks had lost the registry producer, direct OpenAI cross-OS dispatch made the tuple optional, and the documented published-package path skipped companion production.

## Architecture

Provider metadata remains the narrow owner of generic required companions: OpenAI currently requires `@openclaw/codex`, while Anthropic and MiniMax require none. Candidate preparation unions that owned set with scheduled Docker-plan requirements and calls the existing immutable prepublish registry producer while the trusted source worktree is available. Package-only and filtered live reruns no longer build unused companion registries; Docker planning only runs when the Docker consumer is actually scheduled and the core package is not already published.

Registry identity now crosses release and cross-OS boundaries as one optional closed `prepublish_plugin_registry_json` object using the established `prepublishPluginRegistryArtifact*` and `prepublishPluginRegistryManifestSha256` fields. It is normalized once, rejects extra/partial/non-string values, invalid ids/digests, and a producer-name suffix mismatch, then is unpacked only at upload verification, download, the CLI manifest-SHA boundary, and the existing six-field Docker reusable-workflow API.

The candidate, baseline, and registry artifact uploads are verified once in preparation through `scripts/docker/shared-image-artifact.sh verify-upload`; the duplicated per-matrix GitHub API verifier is gone. Each OS lane still checks downloaded candidate/baseline bytes and delegates source SHA, candidate version, manifest digest, required package, tarball digest, and packed package identity checks to the canonical registry validator. Exact companions install via managed `npm-pack:` before onboarding/startup in all nine lanes.

Direct OpenAI dispatch now requires either trusted source preparation or a complete verified registry object. Non-OpenAI providers with no version-bound companions remain valid without one. No Codex-specific repack, install override, or fallback stack was restored.

Codex dependency inspection confirmed the platform package selection and binary resolution contract in `../codex/codex-cli/bin/codex.js:16-110` and the CLI package surface in `../codex/codex-cli/package.json:1-21`.

## Expected Fixed Lanes

- Linux: packaged fresh, packaged upgrade, installer fresh
- macOS: packaged fresh, packaged upgrade, installer fresh
- Windows: packaged fresh, packaged upgrade, installer fresh

## Evidence

Failure evidence:

- Full Release child: https://github.com/openclaw/openclaw/actions/runs/31229165502
- Candidate package: `2026.8.1-beta.1`
- Immutable companion artifact: `9013102058`
- Failed jobs: `93029615151`, `93029615152`, `93029615160`, `93029615165`, `93029615173`, `93029615187`, `93029615195`, `93029615222`, `93029615231`

Focused proof on head `d056cf2c7ac91e9d56aa7818f5c639ebd084aa79`:

- 431 focused workflow, Package Acceptance, cross-OS harness, Windows installer, resolver, immutable registry, shared upload verifier, and Docker-plan tests passed; one platform-gated test skipped.
- `pnpm check:workflows` and direct `actionlint` passed.
- `pnpm check:script-declarations` passed: 254 contracts match.
- `pnpm tsgo:scripts` and `pnpm check:test-types` passed.
- `pnpm lint:scripts` plus targeted test lint passed.
- Knip production/full-tree dependency and unused-export scans passed with zero entries.
- Targeted formatting and `git diff --check` passed.
- Exact-head canonical CI is green: https://github.com/openclaw/openclaw/actions/runs/31255790929

Blacksmith CLI is unavailable on this host, so trusted-source checks used the documented local fallback. Exact-head PR CI supplies hosted proof.

Production delta before simplification: `+443/-184` (net `+259`). Current production delta: `+563/-367` (net `+196`), a 63-line net reduction. Current test delta: `+251/-102` (net `+149`).

## Deliberately Deferred

- Registry bytes remain a separate immutable artifact; folding them into the candidate artifact is intentionally outside this release pass.
- The existing provider metadata requirement remains in place. Moving the Codex requirement into a new scenario or product API would introduce a new contract rather than a mechanical cleanup, so that is a follow-up after the active release.

This changes release validation tooling only. It does not touch the release branch, tags, or published packages.
