### PR TITLE
refactor(acp): make reply projector single-dispatch

### DIFF
--- a/src/auto-reply/reply/acp-projector.test.ts
+++ b/src/auto-reply/reply/acp-projector.test.ts
@@ -112,13 +112,6 @@ function emitTool(projector: Projector, event: Omit<EventOf<"tool_call">, "type"
   return projector.onEvent({ type: "tool_call", ...event });
 }
 
-function finishTurn(
-  projector: Projector,
-  event: EventOf<"done"> | EventOf<"error"> = { type: "done" },
-) {
-  return projector.onEvent(event);
-}
-
 async function runHiddenBoundaryCase(params: {
   streamOverrides?: Record<string, unknown>;
   toolCallId: string;
@@ -230,7 +223,7 @@ describe("createAcpReplyProjector", () => {
     await emitText(projector, "done");
     allowToolSummaries = false;
 
-    await finishTurn(projector);
+    await projector.flush(true);
 
     expect(deliveries).toEqual([{ kind: "final", text: "done" }]);
   });
@@ -258,23 +251,9 @@ describe("createAcpReplyProjector", () => {
     await emitText(projector, "I don't");
     allowToolSummaries = false;
 
-    await finishTurn(projector);
+    await projector.flush(true);
 
     expect(deliveries).toEqual([{ kind: "final", text: "fallback.\n\nI don't" }]);
-  });
-
-  it("does not suppress identical short text across terminal turn boundaries", async () => {
-    const { deliveries, projector } = createStreamHarness("live");
-
-    await emitText(projector, "A");
-    await finishTurn(projector, { type: "done", stopReason: "end_turn" });
-    await emitText(projector, "A");
-    await finishTurn(projector, { type: "done", stopReason: "end_turn" });
-
-    expect(blockDeliveries(deliveries)).toEqual([
-      { kind: "block", text: "A" },
-      { kind: "block", text: "A" },
-    ]);
   });
 
   it("flushes staggered live text deltas after idle gaps", async () => {
@@ -343,7 +322,7 @@ describe("createAcpReplyProjector", () => {
     await emitText(projector, " now?");
     expect(deliveries).toStrictEqual([]);
 
-    await finishTurn(projector);
+    await projector.flush(true);
     expect(deliveries).toHaveLength(3);
     expect(deliveries[0]).toEqual({
       kind: "tool",
@@ -366,7 +345,7 @@ describe("createAcpReplyProjector", () => {
     });
     expect(deliveries).toStrictEqual([]);
 
-    await finishTurn(projector, { type: "error", message: "turn failed" });
+    await projector.flush(true);
     expect(deliveries).toHaveLength(2);
     expect(deliveries[0]).toEqual({
       kind: "tool",

--- a/src/auto-reply/reply/acp-projector.ts
+++ b/src/auto-reply/reply/acp-projector.ts
@@ -187,15 +187,13 @@ export function createAcpReplyProjector(params: {
     accountId: params.accountId,
     deliveryMode: settings.deliveryMode,
   });
-  const createTurnBlockReplyPipeline = () =>
-    createBlockReplyPipeline({
-      onBlockReply: async (payload) => {
-        await params.deliver("block", payload);
-      },
-      timeoutMs: ACP_BLOCK_REPLY_TIMEOUT_MS,
-      coalescing: settings.deliveryMode === "live" ? undefined : streaming.coalescing,
-    });
-  let blockReplyPipeline = createTurnBlockReplyPipeline();
+  const blockReplyPipeline = createBlockReplyPipeline({
+    onBlockReply: async (payload) => {
+      await params.deliver("block", payload);
+    },
+    timeoutMs: ACP_BLOCK_REPLY_TIMEOUT_MS,
+    coalescing: settings.deliveryMode === "live" ? undefined : streaming.coalescing,
+  });
   const chunker = new EmbeddedBlockChunker(streaming.chunking);
   const liveIdleFlushMs = Math.max(streaming.coalescing.idleMs, ACP_LIVE_IDLE_FLUSH_FLOOR_MS);
 
@@ -265,23 +263,6 @@ export function createAcpReplyProjector(params: {
         scheduleLiveIdleFlush();
       }
     }, liveIdleFlushMs);
-  };
-
-  const resetTurnState = () => {
-    clearLiveIdleTimer();
-    blockReplyPipeline.stop();
-    blockReplyPipeline = createTurnBlockReplyPipeline();
-    emittedOutputChars = 0;
-    truncationNoticeEmitted = false;
-    lastStatusHash = undefined;
-    lastToolHash = undefined;
-    lastUsageTuple = undefined;
-    lastVisibleOutputTail = undefined;
-    pendingHiddenBoundary = false;
-    liveBufferText = "";
-    finalOnlyOutputText = "";
-    pendingToolDeliveries.length = 0;
-    toolLifecycleById.clear();
   };
 
   const flushBufferedToolDeliveries = async (force: boolean) => {
@@ -434,6 +415,7 @@ export function createAcpReplyProjector(params: {
     );
   };
 
+  // One projector serves one dispatch; terminal settlement belongs to tryDispatchAcpReply.
   const onEvent = async (event: AcpRuntimeEvent): Promise<void> => {
     params.onProgress?.();
     if (event.type === "text_delta") {
@@ -514,12 +496,6 @@ export function createAcpReplyProjector(params: {
         return;
       }
       await emitToolSummary(event);
-      return;
-    }
-
-    if (event.type === "done" || event.type === "error") {
-      await flush(true);
-      resetTurnState();
     }
   };
 


### PR DESCRIPTION
## What Problem This Solves

OpenClaw’s ACP reply projector still modeled reuse across multiple turns even though production creates one projector per logical dispatch and the outer dispatcher already settles output on success and failure. That duplicated lifecycle ownership let terminal events recreate streaming state inside the projector and kept an unsupported multi-turn test as policy.

This is an ownership cleanup with one narrow observable retry-status change. It does not claim to fix #92199, supersede the retained-text behavior discussion in #119589, or harden malformed third-party terminal streams.

## Why This Change Was Made

The projector now owns one block-reply pipeline for its single dispatch lifetime. Projector-local terminal flushing, turn-state reset, pipeline recreation, and the artificial reused-projector test are removed; `tryDispatchAcpReply` remains the canonical success/error force-flush owner.

A forced flush already clears the projector idle timer, drains the coalescer timer and buffers, and awaits ordered delivery. Modern ACPX separates live events from terminal results, while legacy terminal normalization and recoverable backend attempts remain manager-owned.

Rejected alternatives:

- Keeping terminal flush but only deleting reset would preserve duplicate settlement ownership.
- Restoring attempt-local reset would reintroduce the lifecycle this task removes. Recoverable attempts are internal to one logical dispatch, and text/tool output already disables retry.
- Adding malformed-stream or typed retry-boundary policy in the projector would put producer/attempt policy below the manager boundary.
- Claiming #92199 would overstate the evidence; that report and #119589 concern retained-text behavior, not projector lifetime.

## User Impact

Normal reply text and tool delivery are unchanged. During the supported recoverable pre-output retry path, visible status projection now follows the logical dispatch instead of each backend attempt:

- Live delivery emits the first status immediately, suppresses an identical retry status, preserves distinct retry statuses, then emits the final reply.
- Final-only delivery keeps statuses buffered until overall dispatch settlement, suppresses an identical retry status, preserves distinct retry statuses, then emits one final reply.

The previous implementation already delivered the losing attempt’s status before resetting; this change removes duplicate/early status delivery rather than newly retaining hidden reply content.

- Config/default surfaces changed: 0
- Production LOC: +8 / -32, net -24
- Test LOC: +4 / -25, net -21
- Exact head: `b14a6861fd98e956b24e892f06be899b40e4a943`
- AI-assisted: yes

## Maintainer Decision

Dispatch-scoped retry statuses are the intended contract for this cleanup. Recoverable backend attempts are internal to one logical OpenClaw dispatch; identical visible statuses dedupe across attempts, distinct statuses remain ordered, and outer settlement produces one final reply.

A committed manager retry-contract test is intentionally not added here. Task #18 is the frozen two-file projector lifecycle cleanup with the requested test delta; the separate repair-sweep task #17 owns retry-boundary contract coverage. Adding that third owner surface here would collapse the task boundary the sweep explicitly reserved.

Direct current Codex-source inspection was completed at `3aae5d885bac39c1262491aa3fd100dfd8b3919f`: core emits `TurnComplete` only after turn completion and final-message collection ([tasks/mod.rs](https://github.com/openai/codex/blob/3aae5d885bac39c1262491aa3fd100dfd8b3919f/codex-rs/core/src/tasks/mod.rs#L778-L811)); app-server handles that terminal event and publishes `turn/completed` ([bespoke_event_handling.rs](https://github.com/openai/codex/blob/3aae5d885bac39c1262491aa3fd100dfd8b3919f/codex-rs/app-server/src/bespoke_event_handling.rs#L187-L201), [completion builder](https://github.com/openai/codex/blob/3aae5d885bac39c1262491aa3fd100dfd8b3919f/codex-rs/app-server/src/bespoke_event_handling.rs#L1277-L1302)). No supported producer needs projector reuse across separate logical turns.

## Evidence

Focused lifecycle and boundary suite:

```sh
node scripts/run-vitest.mjs \
  src/auto-reply/reply/acp-projector.test.ts \
  src/auto-reply/reply/dispatch-acp.test.ts \
  src/auto-reply/reply/dispatch-from-config.test.ts \
  src/acp/control-plane/manager.turn-results.test.ts \
  extensions/acpx/src/runtime-turn.test.ts \
  extensions/acpx/index.test.ts
```

Result: 6 files passed across 3 routed shards; 485 tests passed.

Boundary proof through the real `dispatchReplyFromConfig` → ACP hook → dispatch/projector → channel dispatcher seam:

```sh
node scripts/run-vitest.mjs \
  src/auto-reply/reply/dispatch-from-config.test.ts \
  -t "coalesces tiny ACP token deltas into normal Discord text spacing"
```

Result: passed. The production route consumed multiple deltas plus the terminal event and emitted one correctly coalesced reply after outer settlement.

Recoverable-retry proof used a temporary, uncommitted Vitest harness wiring the real `AcpSessionManager` to the production projector, then removed the file before publication:

```sh
node scripts/run-vitest.mjs src/acp/control-plane/task18-retry-boundary.proof.test.ts
```

Result: 2 tests passed, one for each delivery mode. Both observed two backend attempts and the forwarded sequence `status → error → status → status → text_delta → done`. The first and identical retry status produced one visible status, the distinct status remained ordered, the transient error was not delivered, and outer `flush(true)` produced exactly one final reply.

Additional proof:

```sh
./node_modules/.bin/oxfmt --check \
  src/auto-reply/reply/acp-projector.ts \
  src/auto-reply/reply/acp-projector.test.ts
git diff --check
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs --timed
```

Result: formatting, whitespace, typechecks, changed-file lint, dead-export scans, plugin boundaries, database-first guards, and runtime cycle checks passed. Remote proof backends were unavailable, so the trusted-source local fallback ran per repository policy; no credentialed external ACP smoke is claimed.

Review:

- Autoreview: clean, no accepted/actionable findings.
- Independent exact-head read-only review: clean; best-fix verdict confirmed, with no correctness or regression findings.
- ClawSweeper retry-boundary finding: mechanism confirmed, severity disputed. The updated proof demonstrates dispatch-scoped status semantics; restoring projector reset would be the wrong owner boundary. If losing-attempt statuses should be discarded entirely, that is a separate typed manager policy decision.
