### PR TITLE
test(infra): isolate worktree migration plugin discovery

### DIFF
--- a/src/infra/state-migrations.worktree-paths.test.ts
+++ b/src/infra/state-migrations.worktree-paths.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { getRegistryWorktree, insertRegistryWorktree } from "../agents/worktrees/registry.js";
 import { ManagedWorktreeService } from "../agents/worktrees/service.js";
@@ -14,6 +14,10 @@ import {
 import { detectLegacyStateMigrations, runLegacyStateMigrations } from "./state-migrations.js";
 
 describe("managed worktree path state migrations", () => {
+  beforeEach(() => {
+    vi.stubEnv("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+  });
+
   const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
     afterEach(() => {
       closeOpenClawStateDatabaseForTest();
@@ -21,7 +25,7 @@ describe("managed worktree path state migrations", () => {
     });
   });
 
-  it("does not create the worktrees directory during detection", { timeout: 240_000 }, async () => {
+  it("does not create the worktrees directory during detection", async () => {
     const root = tempDirs.make("openclaw-worktree-path-detection-");
     const stateDir = path.join(root, "state");
     const worktreesDir = path.join(stateDir, "worktrees");
@@ -40,7 +44,6 @@ describe("managed worktree path state migrations", () => {
 
   it.skipIf(process.platform === "win32")(
     "canonicalizes persisted paths from symlinked state directories",
-    { timeout: 240_000 },
     async () => {
       const root = tempDirs.make(
         "openclaw-worktree-path-migration-",


### PR DESCRIPTION
Related: #120362

## What Problem This Solves

Resolves a release-check failure where the managed-worktree state migration test spent 296.410s in unrelated bundled plugin and channel discovery, exceeding its 240s timeout.

Failure: https://github.com/openclaw/openclaw/actions/runs/31251209017/job/93087808770

## Why This Change Was Made

The worktree-path suite now disables bundled plugin discovery through `process.env` before each test. The suite exercises only core managed-worktree detection and application; bundled plugin and channel migration behavior remains covered by `src/infra/state-migrations.test.ts`.

The two explicit 240s test timeout overrides are removed because the isolated tests complete in seconds under the default timeout.

## User Impact

No user-visible runtime change. Release validation no longer lets unrelated plugin discovery dominate this focused migration suite.

## Evidence

- Before: 296.410s against a 240s limit.
- `node scripts/run-vitest.mjs src/infra/state-migrations.worktree-paths.test.ts`, three fresh processes:
  - pass 1: 2/2 passed, 6.16s wall time
  - pass 2: 2/2 passed, 3.84s wall time
  - pass 3: 2/2 passed, 3.03s wall time
- `node scripts/run-vitest.mjs src/infra/state-migrations.test.ts`: 80/80 passed, 25.50s wall time.
- `pnpm format:check src/infra/state-migrations.worktree-paths.test.ts`: passed.
- `git diff --check`: passed.
- Exact-diff autoreview: clean, no actionable findings.
- Production LOC: 0.
- Test LOC: +6/-3.
- Changelog: not required; test-only isolation repair with no shipped behavior change.

## Punchcard

- Session: `amber-workshop-workshop-36`
- Commit attestation: `att_01KZGFHZ0E8KJ248250JKGDTA7`
- Commit receipt: `pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaR0ZIWjBFOEtKMjQ4MjUwSktHRFRBNwB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pGWE42TVBWRDRBMzM2VlZDWVdHUDQ1AGFtYmVyLXdvcmtzaG9wLXdvcmtzaG9wLTM2AG9wZW5jbGF3L29wZW5jbGF3ADRiMGE4N2JlNjRjZTc4MmRkMThlZjNjN2NkYWRhNzYwZDJkYTZmZTYAADdmN2VlYmQ0MzVlZWRhNDUyY2E1NTgyNGQ2ZGMzOTIwYmRkYjk2MmU4YWRmNDIzZjhjNWQwYjc0NzE0MGQwZjUAc2lnbmluZy12MQBxSjh5S0txdzg0RkZtdTZiQ2NZdFM4aTR5eXdyb2RTSTkwMzhaT2VJX3ZiMFJrVXZzTVA1OVdhMHpUN2tycUJpZV94dTRPY0pSaEhTbXpNd2k4aFZCQQAyMDI2LTA4LTA4VDEwOjQ0OjAxLjY3OFoA.9K-1NWH5it3DV86TYYxSTAXVAhl5Cl0RaOTy6uKHYoSCK31UAI1uuxnJWfo_Fvs45fYRvDjBB7DhWTJ_fEERDQ`
- PR attestation: `att_01KZGFMM72XD65Z4ENG3A001DR`
- PR receipt: `pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaR0ZNTTcyWEQ2NVo0RU5HM0EwMDFEUgB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pGWE42TVBWRDRBMzM2VlZDWVdHUDQ1AGFtYmVyLXdvcmtzaG9wLXdvcmtzaG9wLTM2AG9wZW5jbGF3L29wZW5jbGF3AAAxMjA1NjQAODZjMWYxNGI5NzA1YzA4NmE1Njk1N2FkNTBlN2E4YTc4YTQyNGJhNmJkOTMwYjA0ZGU4NzFlNWY1YzIxYTFhMwBzaWduaW5nLXYxAC1xdmN2OHlvZXZKMVpVQXdjTFU3dHZGTl90ckF1ellDcklMU3FiNnJrVlo0MzZreG9UZjZseHdHc3FzdTdaTktaR1BYc0FsSEwzMVJmVXFTWkJVMEJRADIwMjYtMDgtMDhUMTA6NDU6MjguOTMwWgA.JJOlDPwe3Ssmp3duuhE7gZxVB-zeoa8GuET1zUZibG8QNYxXDELGgGRSHF90KMG1w20NP9I2gHZh3g0dzQIlDg`
