### PR TITLE
refactor(pr): remove unreachable fork push retry

### DIFF
--- a/scripts/pr-lib/push.sh
+++ b/scripts/pr-lib/push.sh
@@ -208,10 +208,8 @@ resolve_prhead_remote_sha() {
   local remote_sha
   remote_sha=$(git ls-remote "$PRHEAD_REMOTE_URL" "refs/heads/$pr_head" 2>/dev/null | awk '{print $1}' || true)
   if [ -z "$remote_sha" ]; then
-    if [ -z "$remote_sha" ]; then
-      echo "Remote branch refs/heads/$pr_head not found on prhead" >&2
-      exit 1
-    fi
+    echo "Remote branch refs/heads/$pr_head not found on prhead" >&2
+    exit 1
   fi
 
   PRHEAD_REMOTE_SHA="$remote_sha"

--- a/scripts/pr-lib/push.sh
+++ b/scripts/pr-lib/push.sh
@@ -175,26 +175,6 @@ GRAPHQL
   printf '%s\n' "$new_oid"
 }
 
-resolve_head_push_url_https() {
-  # shellcheck disable=SC1091
-  source .local/pr-meta.env
-
-  if [ -n "${PR_HEAD_OWNER:-}" ] && [ -n "${PR_HEAD_REPO_NAME:-}" ]; then
-    printf 'https://github.com/%s/%s.git\n' "$PR_HEAD_OWNER" "$PR_HEAD_REPO_NAME"
-    return 0
-  fi
-
-  if [ -n "${PR_HEAD_REPO_URL:-}" ] && [ "$PR_HEAD_REPO_URL" != "null" ]; then
-    case "$PR_HEAD_REPO_URL" in
-      *.git) printf '%s\n' "$PR_HEAD_REPO_URL" ;;
-      *) printf '%s.git\n' "$PR_HEAD_REPO_URL" ;;
-    esac
-    return 0
-  fi
-
-  return 1
-}
-
 verify_pr_head_branch_matches_expected() {
   local pr="$1"
   local expected_head="$2"
@@ -228,13 +208,6 @@ resolve_prhead_remote_sha() {
   local remote_sha
   remote_sha=$(git ls-remote "$PRHEAD_REMOTE_URL" "refs/heads/$pr_head" 2>/dev/null | awk '{print $1}' || true)
   if [ -z "$remote_sha" ]; then
-    local https_url
-    https_url=$(resolve_head_push_url_https 2>/dev/null) || true
-    if [ -n "$https_url" ] && [ "$https_url" != "$PRHEAD_REMOTE_URL" ]; then
-      echo "SSH remote failed; falling back to HTTPS..." >&2
-      PRHEAD_REMOTE_URL="$https_url"
-      remote_sha=$(git ls-remote "$PRHEAD_REMOTE_URL" "refs/heads/$pr_head" 2>/dev/null | awk '{print $1}' || true)
-    fi
     if [ -z "$remote_sha" ]; then
       echo "Remote branch refs/heads/$pr_head not found on prhead" >&2
       exit 1

--- a/test/scripts/pr-prepare-gates.test.ts
+++ b/test/scripts/pr-prepare-gates.test.ts
@@ -792,7 +792,7 @@ describe("GraphQL fork publication", () => {
 });
 
 describe("fork publication transport", () => {
-  it("keeps the PR push URL process-local", () => {
+  it("keeps the PR push URL process-local and reports a missing branch", () => {
     const { repoDir } = makeRetryRepo();
     const result = runGatesBash(
       [
@@ -800,24 +800,9 @@ describe("fork publication transport", () => {
         "git() { touch .local/git-called; return 99; }",
         "setup_prhead_remote",
         'test "$PRHEAD_REMOTE_URL" = https://github.com/contributor/repo.git',
-        "test ! -e .local/git-called",
-      ].join("\n"),
-      { cwd: repoDir, sourcePush: true },
-    );
-
-    expect(result.status, result.stderr).toBe(0);
-  });
-
-  it("preserves an HTTPS fallback for the later push", () => {
-    const { repoDir } = makeRetryRepo();
-    const result = runGatesBash(
-      [
-        "PRHEAD_REMOTE_URL=ssh://git@example.test/contributor/repo.git",
-        "resolve_head_push_url_https() { printf '%s\\n' https://github.com/contributor/repo.git; }",
-        'git() { if [ "$1" = ls-remote ] && [ "$2" = https://github.com/contributor/repo.git ]; then printf \'hosted\\trefs/heads/topic\\n\'; fi; }',
-        "resolve_prhead_remote_sha topic",
-        'test "$PRHEAD_REMOTE_URL" = https://github.com/contributor/repo.git',
-        'test "$PRHEAD_REMOTE_SHA" = hosted',
+        "if remote_error=$(resolve_prhead_remote_sha topic 2>&1); then exit 97; fi",
+        'test "$remote_error" = "Remote branch refs/heads/topic not found on prhead"',
+        "test -e .local/git-called",
       ].join("\n"),
       { cwd: repoDir, sourcePush: true },
     );

--- a/test/scripts/pr-prepare-gates.test.ts
+++ b/test/scripts/pr-prepare-gates.test.ts
@@ -800,6 +800,7 @@ describe("fork publication transport", () => {
         "git() { touch .local/git-called; return 99; }",
         "setup_prhead_remote",
         'test "$PRHEAD_REMOTE_URL" = https://github.com/contributor/repo.git',
+        "test ! -e .local/git-called",
         "if remote_error=$(resolve_prhead_remote_sha topic 2>&1); then exit 97; fi",
         'test "$remote_error" = "Remote branch refs/heads/topic not found on prhead"',
         "test -e .local/git-called",


### PR DESCRIPTION
AI-assisted: yes

## What Problem This Solves

scripts/pr publication had two identical HTTPS resolvers plus an SSH-to-HTTPS retry that production setup could never reach; the fabricated test made the dead state look supported.

## Why This Change Was Made

This keeps one canonical HTTPS resolver, removes the duplicate and unreachable retry, and preserves signed Git publication plus the real Git 403 to `graphql_push_to_fork` fallback. Restoring SSH-first behavior or adding a parallel fallback is explicitly out of scope because neither matches the reachable production setup.

## User Impact

There is no user-facing product change. Maintainer takeover and publication code now matches reachable behavior while keeping the real permissions fallback.

## Evidence

- Exact head: `667ea6f288ac49760b4afc4b8565d48054d29b2f`.
- The prior ClawSweeper P1 was resolved by rebasing onto current main and preserving `gh_plain` for mutating GraphQL fork publication and the focused test doubles; the unreachable retry cleanup is unchanged.
- Focused test: `node scripts/run-vitest.mjs test/scripts/pr-prepare-gates.test.ts` passed 41/41.
- Changed guards through script declarations are clean.
- The local test-root typecheck is blocked only by unrelated unchanged `packages/terminal-core/src/ansi.ts`.
- `git diff --check` is clean.
- Remote changed gate run `run_9511761536e0` passed testRoot/tooling before the final behavior-neutral cleanup: https://crabbox.openclaw.ai/portal/runs/run_9511761536e0. Lease `cbx_ee895bcacc95` was released.
- Final autoreview was clean. An independent exact-head review reported READY with no findings.
- There is no existing real end-to-end takeover transport harness; the stages are covered by focused Git and GraphQL tests.
- **LOC:** production +2/-31, net -29; tests +4/-18, net -14.
- **Risks:** there is no fully green exact-head changed gate because the remote Testbox CLI was unavailable, the raw AWS Git seed failed once, broker authentication then expired, and the local fallback exposed an unrelated unchanged dependency typecheck. Exact-head CI is the remaining broad proof.
- **Open overlap checked:** #103983 is a stale/conflicting partial overlap; #120525 is orthogonal same-line work. There is no competing complete fix.
