### PR TITLE
refactor(qa): reuse canonical string normalization

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1012,7 +1012,6 @@ extensions/qa-lab/src/cron-run-wait.ts	1
 extensions/qa-lab/src/discovery-eval.ts	1
 extensions/qa-lab/src/docker-up.runtime.ts	1
 extensions/qa-lab/src/evidence-gallery.ts	2
-extensions/qa-lab/src/evidence-summary.ts	1
 extensions/qa-lab/src/execution-identity-storage-inspection.ts	1
 extensions/qa-lab/src/fixture-utils.ts	10
 extensions/qa-lab/src/gateway-child-artifacts.ts	1
@@ -1095,7 +1094,6 @@ extensions/qa-lab/src/runtime-tool-fixture.ts	2
 extensions/qa-lab/src/runtime-tool-metadata.ts	5
 extensions/qa-lab/src/scenario-catalog.ts	1
 extensions/qa-lab/src/scenario-flow-runner.ts	5
-extensions/qa-lab/src/scorecard-evidence.ts	1
 extensions/qa-lab/src/self-check-scenario.ts	2
 extensions/qa-lab/src/suite-launch.runtime.ts	2
 extensions/qa-lab/src/suite-planning.ts	2

--- a/extensions/qa-lab/src/evidence-summary.ts
+++ b/extensions/qa-lab/src/evidence-summary.ts
@@ -1,4 +1,5 @@
 // QA Lab plugin module implements QA evidence summary behavior.
+import { normalizeSortedUniqueTrimmedStringList } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { z } from "zod";
 import { qaCoverageIdSchema } from "./coverage-id.js";
 import { resolveQaEvidenceEnvironment } from "./evidence-environment.js";
@@ -276,10 +277,10 @@ function buildQaEvidenceCoverage(params: {
     role,
   });
   return [
-    ...uniqueSortedStrings(params.primaryCoverageIds ?? []).map((id) =>
+    ...normalizeSortedUniqueTrimmedStringList(params.primaryCoverageIds ?? []).map((id) =>
       buildCoverage(id, "primary"),
     ),
-    ...uniqueSortedStrings(params.secondaryCoverageIds ?? []).map((id) =>
+    ...normalizeSortedUniqueTrimmedStringList(params.secondaryCoverageIds ?? []).map((id) =>
       buildCoverage(id, "secondary"),
     ),
   ];
@@ -291,12 +292,6 @@ function buildQaEvidenceArtifacts(paths: readonly QaEvidenceArtifactInput[], sou
     path: artifact.path,
     source,
   }));
-}
-
-function uniqueSortedStrings(values: readonly (string | undefined)[]) {
-  return [...new Set(values.map((value) => value?.trim()).filter(Boolean) as string[])].toSorted(
-    (left, right) => left.localeCompare(right),
-  );
 }
 
 export function resolveQaEvidenceProfile(params: {
@@ -526,8 +521,10 @@ export function buildQaSuiteEvidenceSummary(
   const channelDriver = params.channelDriver?.trim() || undefined;
   const entries = params.scenarioResults.map((result, index): QaEvidenceSummaryEntry => {
     const scenario = params.scenarioDefinitions[index];
-    const primaryCoverageIds = uniqueSortedStrings(scenario?.coverage?.primary ?? []);
-    const coverageIds = uniqueSortedStrings([
+    const primaryCoverageIds = normalizeSortedUniqueTrimmedStringList(
+      scenario?.coverage?.primary ?? [],
+    );
+    const coverageIds = normalizeSortedUniqueTrimmedStringList([
       ...(scenario?.coverage?.primary ?? []),
       ...(scenario?.coverage?.secondary ?? []),
     ]);

--- a/extensions/qa-lab/src/qa-cli-process.ts
+++ b/extensions/qa-lab/src/qa-cli-process.ts
@@ -2,6 +2,7 @@
 import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
 import path from "node:path";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   appendQaChildOutput,
@@ -83,12 +84,8 @@ function parseBalancedJsonPayloadStart(text: string) {
   }
 }
 
-function isJsonRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
-}
-
 function isStructuredDiagnosticJson(value: unknown) {
-  if (!isJsonRecord(value)) {
+  if (!isRecord(value)) {
     return false;
   }
   const level = value.level ?? value.logLevel ?? value.severity;
@@ -104,14 +101,14 @@ function isStructuredDiagnosticJson(value: unknown) {
 }
 
 function isMemorySearchJsonPayload(value: unknown) {
-  return isJsonRecord(value) && Array.isArray(value.results);
+  return isRecord(value) && Array.isArray(value.results);
 }
 
 function isMemoryStatusJsonPayload(value: unknown) {
   if (Array.isArray(value)) {
     return true;
   }
-  return isJsonRecord(value) && value.command === "memory" && value.subcommand === "status";
+  return isRecord(value) && value.command === "memory" && value.subcommand === "status";
 }
 
 function resolveQaCliJsonPayloadMatcher(args: readonly string[]) {

--- a/extensions/qa-lab/src/scorecard-evidence.ts
+++ b/extensions/qa-lab/src/scorecard-evidence.ts
@@ -1,5 +1,6 @@
 // QA Lab plugin module embeds profile scorecard context into QA evidence.
 import fs from "node:fs/promises";
+import { normalizeSortedUniqueTrimmedStringList } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   attachQaEvidenceScorecard,
   validateQaEvidenceSummaryJson,
@@ -19,12 +20,6 @@ type QaProfileScorecardFilters = {
 };
 
 type EvidenceCoverageRole = QaEvidenceSummaryEntry["coverage"][number]["role"];
-
-function uniqueSortedStrings(values: Iterable<string | undefined>) {
-  return [
-    ...new Set([...values].map((value) => value?.trim()).filter(Boolean) as string[]),
-  ].toSorted((left, right) => left.localeCompare(right));
-}
 
 function percent(part: number, total: number) {
   return total === 0 ? 0 : Number(((part / total) * 100).toFixed(1));
@@ -64,7 +59,7 @@ function featureCounts(
   let partial = 0;
   let missing = 0;
   for (const feature of features) {
-    const coverageIds = uniqueSortedStrings(feature.coverageIds);
+    const coverageIds = normalizeSortedUniqueTrimmedStringList(feature.coverageIds);
     const fulfilledCoverageIds = coverageIds.filter((coverageId) =>
       primaryCoverageIds.has(coverageId),
     ).length;
@@ -97,7 +92,7 @@ function buildQaProfileScorecardEvidence(params: {
   const categoryInputs = params.categories.map((category) => ({
     category,
     features: category.features,
-    coverageIds: uniqueSortedStrings(category.coverageIds),
+    coverageIds: normalizeSortedUniqueTrimmedStringList(category.coverageIds),
   }));
   const categoryReports = categoryInputs.map(({ category, features, coverageIds }) => {
     const fulfilledCoverageIdCount = coverageIds.filter((coverageId) =>
@@ -106,7 +101,7 @@ function buildQaProfileScorecardEvidence(params: {
     const secondaryOnlyCoverageIdCount = coverageIds.filter(
       (coverageId) => !primaryCoverageIds.has(coverageId) && secondaryCoverageIds.has(coverageId),
     ).length;
-    const missingCoverageIds = uniqueSortedStrings(
+    const missingCoverageIds = normalizeSortedUniqueTrimmedStringList(
       coverageIds.filter((coverageId) => !primaryCoverageIds.has(coverageId)),
     );
     const missingCoverageIdCount = coverageIds.length - fulfilledCoverageIdCount;
@@ -129,7 +124,7 @@ function buildQaProfileScorecardEvidence(params: {
       missingCoverageIds,
     };
   });
-  const profileCoverageIds = uniqueSortedStrings(
+  const profileCoverageIds = normalizeSortedUniqueTrimmedStringList(
     categoryInputs.flatMap((input) => input.coverageIds),
   );
   const coverageIdCount = profileCoverageIds.length;


### PR DESCRIPTION
## What Problem This Solves

QA Lab independently implemented the same trim, empty filtering, deduplication, and sorting policy in two evidence modules even though the exact normalization owner already exists in the public Plugin SDK facade.

The previous diff on this PR became obsolete after the record-guard consolidation landed independently in #122299. This rewrite keeps the QA Lab cleanup on the existing PR instead of opening another maintainer PR.

## Why This Change Was Made

- Reuse `normalizeSortedUniqueTrimmedStringList` from `openclaw/plugin-sdk/string-coerce-runtime`.
- Remove both local `uniqueSortedStrings` implementations.
- Shrink the assertion-safety baseline after removing the two local casts.
- Leave `scorecard-taxonomy.ts` unchanged because its generic iterable helper intentionally does not trim values.

For valid lowercase ASCII coverage IDs, the new helper preserves the existing trim, empty filtering, and deduplication behavior while using the repository's deterministic ASCII ordering instead of locale-sensitive `localeCompare`.

No new SDK seam, config, schema, dependency, docs, tests, or user-visible capability.

## User Impact

No intended user-visible change. QA evidence and scorecard coverage IDs continue to normalize deterministically, with one less duplicated policy to drift.

## Evidence

Exact head: `c873f35541663d92eb0502846d0144a62d5ae4c6`

- Full QA Lab extension suite locally: 204 files / 2,830 tests passed.
- The current-main Vitest ownership audit passes at this head: 23/23.
- `pnpm check:coercion-helpers`: passed.
- `git diff --check`: passed.
- Autoreview, Codex `gpt-5.6-sol` high, P0 scope: clean, confidence 0.99.
- Blacksmith Testbox `tbx_01m0x9mqwcq5tzvpetv0n4hvd2`: `CI=1 pnpm test:extension qa-lab`, 204 files / 2,830 tests passed.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/32895341862
- Production LOC: +12/-20, net -8. Test LOC: +0/-0. Tooling baseline: +0/-2.

AI-assisted: yes.
