### PR TITLE
fix(protocol): preserve Swift checkpoint token version casing

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4818,7 +4818,7 @@ public struct SessionCompactionCheckpoint: Codable, Sendable {
     public let reason: AnyCodable
     public let tokensbefore: Int?
     public let tokensafter: Int?
-    public let tokensversion: Double?
+    public let tokensVersion: Double?
     public let summary: String?
     public let firstkeptentryid: String?
     public let precompaction: [String: AnyCodable]
@@ -4832,7 +4832,7 @@ public struct SessionCompactionCheckpoint: Codable, Sendable {
         reason: AnyCodable,
         tokensbefore: Int? = nil,
         tokensafter: Int? = nil,
-        tokensversion: Double? = nil,
+        tokensVersion: Double? = nil,
         summary: String? = nil,
         firstkeptentryid: String? = nil,
         precompaction: [String: AnyCodable],
@@ -4845,7 +4845,7 @@ public struct SessionCompactionCheckpoint: Codable, Sendable {
         self.reason = reason
         self.tokensbefore = tokensbefore
         self.tokensafter = tokensafter
-        self.tokensversion = tokensversion
+        self.tokensVersion = tokensVersion
         self.summary = summary
         self.firstkeptentryid = firstkeptentryid
         self.precompaction = precompaction
@@ -4860,7 +4860,7 @@ public struct SessionCompactionCheckpoint: Codable, Sendable {
         case reason
         case tokensbefore = "tokensBefore"
         case tokensafter = "tokensAfter"
-        case tokensversion = "tokensVersion"
+        case tokensVersion
         case summary
         case firstkeptentryid = "firstKeptEntryId"
         case precompaction = "preCompaction"

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
@@ -77,6 +77,34 @@ struct GatewayModelsCompatibilityTests {
     }
 
     @Test
+    func `session compaction checkpoint preserves canonical token version casing`() throws {
+        let checkpoint = SessionCompactionCheckpoint(
+            checkpointid: "checkpoint-1",
+            sessionkey: "main",
+            sessionid: "session-1",
+            createdat: 1,
+            reason: AnyCodable("manual"),
+            tokensVersion: 1,
+            precompaction: [:],
+            postcompaction: [:])
+
+        #expect(checkpoint.tokensVersion == 1)
+
+        let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(checkpoint))
+        let encodedJSON = try #require(encoded as? [String: Any])
+        #expect(encodedJSON.keys.contains("tokensVersion"))
+        #expect(!encodedJSON.keys.contains("tokensversion"))
+
+        let decoded = try JSONDecoder().decode(
+            SessionCompactionCheckpoint.self,
+            from: Data(
+                #"{"checkpointId":"checkpoint-2","sessionKey":"main","sessionId":"session-2","createdAt":2,"reason":"manual","tokensVersion":1,"preCompaction":{},"postCompaction":{}}"#
+                    .utf8))
+
+        #expect(decoded.tokensVersion == 1)
+    }
+
+    @Test
     func `request frames round trip current payloads`() throws {
         let frame = try self.roundTripGatewayFrame(
             #"{"type":"req","id":"req-1","method":"sessions.list","params":{"limit":20}}"#)

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -114,6 +114,9 @@ function safeName(name: string) {
 // Canonical initializer labels must match stored properties; compatibility initializers
 // declare legacy labels separately.
 function swiftStoredPropertyName(structName: string, key: string): string {
+  if (structName === "SessionCompactionCheckpoint" && key === "tokensVersion") {
+    return "tokensVersion";
+  }
   if (structName === "WizardStartParams" && key === "installDaemon") {
     return "installDaemon";
   }


### PR DESCRIPTION
Related: #120504
Related: #120548

## What Problem This Solves

Fixes an issue where Swift clients consuming session compaction checkpoints exposed the canonical `tokensVersion` field as `tokensversion`, producing an incorrect source-level property name even though the JSON key remained canonical.

## Why This Change Was Made

The Swift protocol generator now preserves `tokensVersion` for `SessionCompactionCheckpoint`, and the generated model uses that spelling for the stored property, initializer label, and coding key. A focused compatibility test covers source access, canonical encoding, rejection of the lowercased key, and decoding independently written canonical JSON.

Peter Steinberger authored source commit `1b9ad9280d4b363f789059b1a518689207cf6f09`. This PR is the maintainer-selected canonical split because https://github.com/openclaw/openclaw/pull/120509 is author-owned/uneditable and mixes retry behavior with the Swift protocol repair.

No schema, Kotlin, protocol-version, compatibility alias, changelog, or global recasing changes are included.

## User Impact

Swift callers can construct and read checkpoint token versions through `tokensVersion`, while encoded and decoded payloads continue using the canonical `tokensVersion` JSON key.

## Evidence

- Frozen base: `205753eef707f665773e46441eb9570d7d8a317d`
- Exact head: `a6b733342b7819399820840046dc4e64666bca0d`
- Source patch stable patch-id matches `1b9ad9280d4b363f789059b1a518689207cf6f09`: `f390a9c9d18ab0dbe3277c6ca804fc92b474bd94`
- `fnm exec --using 24.15.0 -- pnpm protocol:gen:swift`
- `fnm exec --using 24.15.0 -- pnpm protocol:check:swift`
- `fnm exec --using 24.15.0 -- pnpm protocol:check`
- `swift test --package-path apps/shared/OpenClawKit --filter GatewayModelsCompatibilityTests` (12 tests passed)
- Targeted TypeScript and Swift test formatting checks passed; generated Swift remains governed by the generator check and repository exclusion policy
- `git diff --check 205753eef707f665773e46441eb9570d7d8a317d...HEAD`
- Exact-diff autoreview: clean, no accepted/actionable findings, overall `0.99`
- Scope assertion: exactly the generator, generated Swift model, and focused Swift compatibility test changed

## AI-Assisted Disclosure

- [x] AI-assisted implementation and validation
- [x] The changes and generated output were reviewed and understood
- [x] Exact-diff autoreview completed with no actionable findings

<!-- Punchcard-Receipt: pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaR0hBTUJEOTVGMDRCRkFNMDE3MTk1OQB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pGWE42TVBWRDRBMzM2VlZDWVdHUDQ1AGFtYmVyLXdvcmtzaG9wLXdvcmtzaG9wLTM2AG9wZW5jbGF3L29wZW5jbGF3AAAxMjA1NjgAMzBkZmIyYWUzOWEzOWYxZDBlMDZkMGUwMmQ1ZjllMDFjODk4NjA1MzM2OGZlOGM4NTE4YWRmNWE1ZjA3MmM3ZQBzaWduaW5nLXYxAGEydGRvMDMtNHExREJLamE1TDZQdUNsazBFQm0yYzVmNFMxOGZxNEVSOU0zMGJuWU9jT2xVTGtHcVYwS01HbWh2cVRUZTZrNWxpSHVHN2ZUQkxBQUFnADIwMjYtMDgtMDhUMTE6MTQ6NTguNTQxWgA.AZE4H4nJRlu7xnpLr71KHkMfm5EFUCOvd2pL2vI-kvfcDDcZmwpREO4ZUK0zaykmacGt3PY2NaEsHAAaOUY1BA -->

Co-authored-by: Peter Steinberger <steipete@gmail.com>
