### PR TITLE
fix(agents): surface tool loop warnings to models

### DIFF
--- a/src/agents/agent-tool-definition-adapter.after-tool-call.fires-once.test.ts
+++ b/src/agents/agent-tool-definition-adapter.after-tool-call.fires-once.test.ts
@@ -99,7 +99,10 @@ async function loadFreshAfterToolCallModulesForTest() {
     emitAgentItemEvent: vi.fn(),
   }));
   vi.doMock("./agent-tools.before-tool-call.state.js", () => ({
+    appendLoopWarningToError: (error: unknown) => error,
+    appendLoopWarningToToolResult: (result: unknown) => result,
     consumeAdjustedParamsForToolCall: beforeToolCallMocks.consumeAdjustedParamsForToolCall,
+    consumeLoopWarningForToolCall: vi.fn(() => undefined),
     consumePreExecutionBlockedToolCall: vi.fn(() => false),
     consumeTrackedToolExecutionStarted: vi.fn(() => undefined),
     consumeStructuredReplaySafeToolCall: vi.fn(() => false),

--- a/src/agents/agent-tool-definition-adapter.after-tool-call.fires-once.test.ts
+++ b/src/agents/agent-tool-definition-adapter.after-tool-call.fires-once.test.ts
@@ -99,8 +99,8 @@ async function loadFreshAfterToolCallModulesForTest() {
     emitAgentItemEvent: vi.fn(),
   }));
   vi.doMock("./agent-tools.before-tool-call.state.js", () => ({
-    appendLoopWarningToError: (error: unknown) => error,
-    appendLoopWarningToToolResult: (result: unknown) => result,
+    carryLoopWarningToError: (error: unknown) => error,
+    carryLoopWarningToToolResult: (result: unknown) => result,
     consumeAdjustedParamsForToolCall: beforeToolCallMocks.consumeAdjustedParamsForToolCall,
     consumeLoopWarningForToolCall: vi.fn(() => undefined),
     consumePreExecutionBlockedToolCall: vi.fn(() => false),

--- a/src/agents/agent-tool-definition-adapter.after-tool-call.fires-once.test.ts
+++ b/src/agents/agent-tool-definition-adapter.after-tool-call.fires-once.test.ts
@@ -101,6 +101,7 @@ async function loadFreshAfterToolCallModulesForTest() {
   vi.doMock("./agent-tools.before-tool-call.state.js", () => ({
     carryLoopWarningToError: (error: unknown) => error,
     carryLoopWarningToToolResult: (result: unknown) => result,
+    resolveLoopWarningError: (error: unknown) => error,
     consumeAdjustedParamsForToolCall: beforeToolCallMocks.consumeAdjustedParamsForToolCall,
     consumeLoopWarningForToolCall: vi.fn(() => undefined),
     consumePreExecutionBlockedToolCall: vi.fn(() => false),
@@ -108,6 +109,7 @@ async function loadFreshAfterToolCallModulesForTest() {
     consumeStructuredReplaySafeToolCall: vi.fn(() => false),
     peekAdjustedParamsForToolCall: vi.fn(() => undefined),
     peekPreExecutionBlockedToolCall: vi.fn(() => false),
+    recordPreExecutionBlockedToolCall: vi.fn(),
   }));
   vi.doMock("./agent-tools.before-tool-call.js", () => ({
     BeforeToolCallBlockedError: beforeToolCallMocks.BeforeToolCallBlockedError,

--- a/src/agents/agent-tool-definition-adapter.test.ts
+++ b/src/agents/agent-tool-definition-adapter.test.ts
@@ -7,6 +7,8 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import type { AgentTool } from "openclaw/plugin-sdk/agent-core";
+import { runAgentLoop, type StreamFn } from "openclaw/plugin-sdk/agent-core";
+import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
 import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -402,6 +404,80 @@ describe("toClientToolDefinitions – param coercion", () => {
       type: "text",
       text: "Tool loop warning: Reassess before retrying.",
     });
+  });
+
+  it("preserves a client tool loop warning in the session transcript", async () => {
+    const runId = "run-transcript-warning";
+    const toolCallId = "call-transcript-warning";
+    const tools = toClientToolDefinitions([makeClientTool("update_plan")], undefined, { runId });
+    recordLoopWarningForToolCall(toolCallId, "Reassess before retrying.", runId);
+    const streamFn: StreamFn = () => {
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        stream.push({
+          type: "done",
+          reason: "toolUse",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: toolCallId,
+                name: "update_plan",
+                arguments: { query: "same plan" },
+              },
+            ],
+            api: "faux",
+            provider: "faux",
+            model: "faux-1",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: Date.now(),
+          },
+        });
+      });
+      return stream;
+    };
+
+    const messages = await runAgentLoop(
+      [{ role: "user", content: "update the plan", timestamp: Date.now() }],
+      { systemPrompt: "test", messages: [], tools },
+      {
+        model: {
+          id: "faux-1",
+          name: "Faux",
+          provider: "faux",
+          api: "faux",
+          baseUrl: "http://localhost:0",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 128_000,
+          maxTokens: 1024,
+        },
+        convertToLlm: (agentMessages) => agentMessages as never,
+      },
+      () => {},
+      undefined,
+      streamFn,
+    );
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        role: "toolResult",
+        toolCallId,
+        content: expect.arrayContaining([
+          { type: "text", text: "Tool loop warning: Reassess before retrying." },
+        ]),
+      }),
+    );
   });
 
   it("returns terminal pending results for each client tool in a batch", async () => {

--- a/src/agents/agent-tool-definition-adapter.test.ts
+++ b/src/agents/agent-tool-definition-adapter.test.ts
@@ -26,6 +26,71 @@ import type { ClientToolDefinition } from "./embedded-agent-runner/run/params.js
 type ToolExecute = ReturnType<typeof toToolDefinitions>[number]["execute"];
 const extensionContext = {} as Parameters<ToolExecute>[4];
 const CLIENT_TOOL_NAME_CONFLICT_PREFIX = "client tool name conflict:";
+const ZERO_USAGE = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+const FAUX_MODEL = {
+  id: "faux-1",
+  name: "Faux",
+  provider: "faux",
+  api: "faux",
+  baseUrl: "http://localhost:0",
+  reasoning: false,
+  input: ["text"] as const,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 1024,
+};
+
+async function runToolCallTranscript(params: {
+  tools: AgentTool[];
+  toolCall: { id: string; name: string; arguments: Record<string, unknown> };
+}) {
+  let streamCalls = 0;
+  const streamFn: StreamFn = () => {
+    const stream = createAssistantMessageEventStream();
+    queueMicrotask(() => {
+      streamCalls += 1;
+      const message =
+        streamCalls === 1
+          ? {
+              role: "assistant" as const,
+              content: [{ type: "toolCall" as const, ...params.toolCall }],
+              ...FAUX_MODEL,
+              usage: ZERO_USAGE,
+              stopReason: "toolUse" as const,
+              timestamp: Date.now(),
+            }
+          : {
+              role: "assistant" as const,
+              content: [{ type: "text" as const, text: "done" }],
+              ...FAUX_MODEL,
+              usage: ZERO_USAGE,
+              stopReason: "stop" as const,
+              timestamp: Date.now(),
+            };
+      stream.push({ type: "done", reason: message.stopReason, message });
+    });
+    return stream;
+  };
+
+  return await runAgentLoop(
+    [{ role: "user", content: "run the tool", timestamp: Date.now() }],
+    { systemPrompt: "test", messages: [], tools: params.tools },
+    {
+      model: FAUX_MODEL,
+      convertToLlm: (agentMessages) => agentMessages as never,
+    },
+    () => {},
+    undefined,
+    streamFn,
+  );
+}
 
 async function executeThrowingTool(name: string, callId: string) {
   const tool = {
@@ -87,6 +152,49 @@ describe("agent tool definition adapter", () => {
     expect(details?.tool).toBe("boom");
     expect(details?.error).toBe("nope");
     expect(JSON.stringify(result.details)).not.toContain("\n    at ");
+  });
+
+  it("surfaces and consumes a no-run loop warning when a tool throws", async () => {
+    recordLoopWarningForToolCall("call-warning-error", "Reassess before retrying.");
+
+    const warned = await executeThrowingTool("boom", "call-warning-error");
+    const next = await executeThrowingTool("boom", "call-warning-error");
+
+    expect(warned.content).toContainEqual({
+      type: "text",
+      text: "Tool loop warning: Reassess before retrying.",
+    });
+    expect(JSON.stringify(next)).not.toContain("Tool loop warning:");
+  });
+
+  it("clears a pending loop warning when an aborted tool has no result", async () => {
+    const controller = new AbortController();
+    const abortReason = new Error("cancelled");
+    const abortingTool = {
+      name: "abort_tool",
+      label: "Abort Tool",
+      description: "aborts",
+      parameters: Type.Object({}),
+      execute: async () => {
+        controller.abort(abortReason);
+        throw abortReason;
+      },
+    } satisfies AgentTool;
+    const [definition] = toToolDefinitions([abortingTool]);
+    recordLoopWarningForToolCall("call-warning-abort", "Reassess before retrying.");
+
+    await expect(
+      expectDefined(definition, "abort tool definition").execute(
+        "call-warning-abort",
+        {},
+        controller.signal,
+        undefined,
+        extensionContext,
+      ),
+    ).rejects.toBe(abortReason);
+
+    const next = await executeThrowingTool("boom", "call-warning-abort");
+    expect(JSON.stringify(next)).not.toContain("Tool loop warning:");
   });
 
   it("normalizes exec tool aliases in error results", async () => {
@@ -411,63 +519,14 @@ describe("toClientToolDefinitions – param coercion", () => {
     const toolCallId = "call-transcript-warning";
     const tools = toClientToolDefinitions([makeClientTool("update_plan")], undefined, { runId });
     recordLoopWarningForToolCall(toolCallId, "Reassess before retrying.", runId);
-    const streamFn: StreamFn = () => {
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        stream.push({
-          type: "done",
-          reason: "toolUse",
-          message: {
-            role: "assistant",
-            content: [
-              {
-                type: "toolCall",
-                id: toolCallId,
-                name: "update_plan",
-                arguments: { query: "same plan" },
-              },
-            ],
-            api: "faux",
-            provider: "faux",
-            model: "faux-1",
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
-            stopReason: "toolUse",
-            timestamp: Date.now(),
-          },
-        });
-      });
-      return stream;
-    };
-
-    const messages = await runAgentLoop(
-      [{ role: "user", content: "update the plan", timestamp: Date.now() }],
-      { systemPrompt: "test", messages: [], tools },
-      {
-        model: {
-          id: "faux-1",
-          name: "Faux",
-          provider: "faux",
-          api: "faux",
-          baseUrl: "http://localhost:0",
-          reasoning: false,
-          input: ["text"],
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 128_000,
-          maxTokens: 1024,
-        },
-        convertToLlm: (agentMessages) => agentMessages as never,
+    const messages = await runToolCallTranscript({
+      tools,
+      toolCall: {
+        id: toolCallId,
+        name: "update_plan",
+        arguments: { query: "same plan" },
       },
-      () => {},
-      undefined,
-      streamFn,
-    );
+    });
 
     expect(messages).toContainEqual(
       expect.objectContaining({
@@ -475,6 +534,43 @@ describe("toClientToolDefinitions – param coercion", () => {
         toolCallId,
         content: expect.arrayContaining([
           { type: "text", text: "Tool loop warning: Reassess before retrying." },
+        ]),
+      }),
+    );
+  });
+
+  it("preserves a thrown server tool loop warning in the session transcript", async () => {
+    const runId = "run-error-warning";
+    const toolCallId = "call-error-warning";
+    const tool = wrapToolWithBeforeToolCallHook(
+      {
+        name: "failing_tool",
+        label: "Failing Tool",
+        description: "fails",
+        parameters: Type.Object({}),
+        execute: async () => {
+          throw new Error("tool failed");
+        },
+      } satisfies AgentTool,
+      { runId },
+    );
+    recordLoopWarningForToolCall(toolCallId, "Reassess before retrying.", runId);
+
+    const messages = await runToolCallTranscript({
+      tools: [tool],
+      toolCall: { id: toolCallId, name: "failing_tool", arguments: {} },
+    });
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        role: "toolResult",
+        toolCallId,
+        isError: true,
+        content: expect.arrayContaining([
+          {
+            type: "text",
+            text: "tool failed\n\nTool loop warning: Reassess before retrying.",
+          },
         ]),
       }),
     );

--- a/src/agents/agent-tool-definition-adapter.test.ts
+++ b/src/agents/agent-tool-definition-adapter.test.ts
@@ -17,6 +17,7 @@ import {
   toToolDefinitions,
 } from "./agent-tool-definition-adapter.js";
 import { wrapToolWithBeforeToolCallHook } from "./agent-tools.before-tool-call.js";
+import { recordLoopWarningForToolCall } from "./agent-tools.before-tool-call.state.js";
 import { createExecTool } from "./bash-tools.exec-run.js";
 import type { ClientToolDefinition } from "./embedded-agent-runner/run/params.js";
 
@@ -380,6 +381,29 @@ async function executeClientTool(params: unknown): Promise<{
 }
 
 describe("toClientToolDefinitions – param coercion", () => {
+  it("includes a pending loop warning in the client tool result", async () => {
+    const [tool] = toClientToolDefinitions([makeClientTool("update_plan")], undefined, {
+      runId: "run-warning",
+    });
+    if (!tool) {
+      throw new Error("missing client tool definition");
+    }
+    recordLoopWarningForToolCall("call-warning", "Reassess before retrying.", "run-warning");
+
+    const result = await tool.execute(
+      "call-warning",
+      { query: "same plan" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(result.content).toContainEqual({
+      type: "text",
+      text: "Tool loop warning: Reassess before retrying.",
+    });
+  });
+
   it("returns terminal pending results for each client tool in a batch", async () => {
     const completed: Array<{ id: string; name: string; params: Record<string, unknown> }> = [];
     const defs = toClientToolDefinitions([makeClientTool("search"), makeClientTool("lookup")], {

--- a/src/agents/agent-tool-definition-adapter.test.ts
+++ b/src/agents/agent-tool-definition-adapter.test.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import type { AgentTool } from "openclaw/plugin-sdk/agent-core";
 import { runAgentLoop, type StreamFn } from "openclaw/plugin-sdk/agent-core";
-import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
+import { createAssistantMessageEventStream, type Model } from "openclaw/plugin-sdk/llm";
 import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -41,11 +41,11 @@ const FAUX_MODEL = {
   api: "faux",
   baseUrl: "http://localhost:0",
   reasoning: false,
-  input: ["text"] as const,
+  input: ["text"],
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
   contextWindow: 128_000,
   maxTokens: 1024,
-};
+} satisfies Model;
 
 async function runToolCallTranscript(params: {
   tools: AgentTool[];
@@ -62,6 +62,7 @@ async function runToolCallTranscript(params: {
               role: "assistant" as const,
               content: [{ type: "toolCall" as const, ...params.toolCall }],
               ...FAUX_MODEL,
+              model: FAUX_MODEL.id,
               usage: ZERO_USAGE,
               stopReason: "toolUse" as const,
               timestamp: Date.now(),
@@ -70,6 +71,7 @@ async function runToolCallTranscript(params: {
               role: "assistant" as const,
               content: [{ type: "text" as const, text: "done" }],
               ...FAUX_MODEL,
+              model: FAUX_MODEL.id,
               usage: ZERO_USAGE,
               stopReason: "stop" as const,
               timestamp: Date.now(),
@@ -517,7 +519,17 @@ describe("toClientToolDefinitions – param coercion", () => {
   it("preserves a client tool loop warning in the session transcript", async () => {
     const runId = "run-transcript-warning";
     const toolCallId = "call-transcript-warning";
-    const tools = toClientToolDefinitions([makeClientTool("update_plan")], undefined, { runId });
+    const clientTools = toClientToolDefinitions([makeClientTool("update_plan")], undefined, {
+      runId,
+    });
+    const tools: AgentTool[] = clientTools.map((tool) => ({
+      name: tool.name,
+      label: tool.label,
+      description: tool.description,
+      parameters: tool.parameters,
+      execute: async (callId, params, signal, onUpdate) =>
+        await tool.execute(callId, params, signal, onUpdate, extensionContext),
+    }));
     recordLoopWarningForToolCall(toolCallId, "Reassess before retrying.", runId);
     const messages = await runToolCallTranscript({
       tools,

--- a/src/agents/agent-tool-definition-adapter.test.ts
+++ b/src/agents/agent-tool-definition-adapter.test.ts
@@ -6,7 +6,7 @@
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import type { AgentTool } from "openclaw/plugin-sdk/agent-core";
+import type { Agent, AgentTool } from "openclaw/plugin-sdk/agent-core";
 import { runAgentLoop, type StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { createAssistantMessageEventStream, type Model } from "openclaw/plugin-sdk/llm";
 import { Type } from "typebox";
@@ -22,6 +22,7 @@ import { wrapToolWithBeforeToolCallHook } from "./agent-tools.before-tool-call.j
 import { recordLoopWarningForToolCall } from "./agent-tools.before-tool-call.state.js";
 import { createExecTool } from "./bash-tools.exec-run.js";
 import type { ClientToolDefinition } from "./embedded-agent-runner/run/params.js";
+import { installToolLoopWarningFinalizer } from "./embedded-agent-runner/run/tool-loop-recovery.js";
 
 type ToolExecute = ReturnType<typeof toToolDefinitions>[number]["execute"];
 const extensionContext = {} as Parameters<ToolExecute>[4];
@@ -50,6 +51,8 @@ const FAUX_MODEL = {
 async function runToolCallTranscript(params: {
   tools: AgentTool[];
   toolCall: { id: string; name: string; arguments: Record<string, unknown> };
+  afterToolCall?: Agent["afterToolCall"];
+  afterToolOutcome?: Agent["afterToolOutcome"];
 }) {
   let streamCalls = 0;
   const streamFn: StreamFn = () => {
@@ -87,6 +90,8 @@ async function runToolCallTranscript(params: {
     {
       model: FAUX_MODEL,
       convertToLlm: (agentMessages) => agentMessages as never,
+      ...(params.afterToolCall ? { afterToolCall: params.afterToolCall } : {}),
+      ...(params.afterToolOutcome ? { afterToolOutcome: params.afterToolOutcome } : {}),
     },
     () => {},
     undefined,
@@ -607,6 +612,91 @@ describe("toClientToolDefinitions – param coercion", () => {
             text: "tool failed\n\nTool loop warning: Reassess before retrying.",
           },
         ]),
+      }),
+    );
+  });
+
+  it("preserves a loop warning after afterToolCall replaces transcript content", async () => {
+    const runId = "run-after-call-replacement";
+    const toolCallId = "call-after-call-replacement";
+    const tool = wrapToolWithBeforeToolCallHook(
+      {
+        name: "read",
+        label: "Read",
+        description: "reads",
+        parameters: Type.Object({}),
+        execute: async () => ({
+          content: [{ type: "text", text: "tool output" }],
+          details: {},
+        }),
+      } satisfies AgentTool,
+      { runId },
+    );
+    const agent = {
+      afterToolCall: async () => ({
+        content: [{ type: "text" as const, text: "afterToolCall replacement" }],
+      }),
+    } as unknown as Agent;
+    installToolLoopWarningFinalizer({ agent, runId });
+    recordLoopWarningForToolCall(toolCallId, "Reassess before retrying.", runId);
+
+    const messages = await runToolCallTranscript({
+      tools: [tool],
+      toolCall: { id: toolCallId, name: "read", arguments: {} },
+      afterToolCall: agent.afterToolCall,
+      afterToolOutcome: agent.afterToolOutcome,
+    });
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        role: "toolResult",
+        toolCallId,
+        content: [
+          { type: "text", text: "afterToolCall replacement" },
+          { type: "text", text: "Tool loop warning: Reassess before retrying." },
+        ],
+      }),
+    );
+  });
+
+  it("preserves a loop warning after afterToolOutcome replaces transcript content", async () => {
+    const runId = "run-after-outcome-replacement";
+    const toolCallId = "call-after-outcome-replacement";
+    const tool = wrapToolWithBeforeToolCallHook(
+      {
+        name: "read",
+        label: "Read",
+        description: "reads",
+        parameters: Type.Object({}),
+        execute: async () => ({
+          content: [{ type: "text", text: "tool output" }],
+          details: {},
+        }),
+      } satisfies AgentTool,
+      { runId },
+    );
+    const agent = {
+      afterToolOutcome: async () => ({
+        content: [{ type: "text" as const, text: "afterToolOutcome replacement" }],
+      }),
+    } as unknown as Agent;
+    installToolLoopWarningFinalizer({ agent, runId });
+    recordLoopWarningForToolCall(toolCallId, "Reassess before retrying.", runId);
+
+    const messages = await runToolCallTranscript({
+      tools: [tool],
+      toolCall: { id: toolCallId, name: "read", arguments: {} },
+      afterToolOutcome: agent.afterToolOutcome,
+    });
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        role: "toolResult",
+        toolCallId,
+        content: [
+          { type: "text", text: "afterToolOutcome replacement" },
+          { type: "text", text: "Tool loop warning: Reassess before retrying." },
+        ],
       }),
     );
   });

--- a/src/agents/agent-tool-definition-adapter.test.ts
+++ b/src/agents/agent-tool-definition-adapter.test.ts
@@ -201,7 +201,8 @@ describe("agent tool definition adapter", () => {
 
   it("does not mask a frozen tool error while appending a loop warning", async () => {
     const toolCallId = "call-warning-frozen-error";
-    const frozenError = Object.freeze(new TypeError("immutable failure"));
+    const frozenError = new TypeError("immutable failure");
+    Object.freeze(frozenError);
     const tool = wrapToolWithBeforeToolCallHook({
       name: "frozen_error_tool",
       label: "Frozen Error Tool",

--- a/src/agents/agent-tool-definition-adapter.test.ts
+++ b/src/agents/agent-tool-definition-adapter.test.ts
@@ -199,6 +199,28 @@ describe("agent tool definition adapter", () => {
     expect(JSON.stringify(next)).not.toContain("Tool loop warning:");
   });
 
+  it("does not mask a frozen tool error while appending a loop warning", async () => {
+    const toolCallId = "call-warning-frozen-error";
+    const frozenError = Object.freeze(new TypeError("immutable failure"));
+    const tool = wrapToolWithBeforeToolCallHook({
+      name: "frozen_error_tool",
+      label: "Frozen Error Tool",
+      description: "throws an immutable error",
+      parameters: Type.Object({}),
+      execute: async () => {
+        throw frozenError;
+      },
+    } satisfies AgentTool);
+    recordLoopWarningForToolCall(toolCallId, "Reassess before retrying.");
+
+    const result = await executeTool(tool, toolCallId);
+
+    expect(result.details).toMatchObject({
+      status: "error",
+      error: "immutable failure\n\nTool loop warning: Reassess before retrying.",
+    });
+  });
+
   it("normalizes exec tool aliases in error results", async () => {
     const result = await executeThrowingTool("bash", "call2");
 

--- a/src/agents/agent-tool-definition-adapter.test.ts
+++ b/src/agents/agent-tool-definition-adapter.test.ts
@@ -6,8 +6,12 @@
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import type { Agent, AgentTool } from "openclaw/plugin-sdk/agent-core";
-import { runAgentLoop, type StreamFn } from "openclaw/plugin-sdk/agent-core";
+import {
+  type Agent,
+  type AgentTool,
+  runAgentLoop,
+  type StreamFn,
+} from "openclaw/plugin-sdk/agent-core";
 import { createAssistantMessageEventStream, type Model } from "openclaw/plugin-sdk/llm";
 import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -18,6 +18,11 @@ import {
 } from "./agent-tools.before-tool-call.js";
 import { consumeFinalClientVoiceToolConfirmation } from "./agent-tools.before-tool-call.policy.js";
 import {
+  appendLoopWarningToError,
+  appendLoopWarningToToolResult,
+  consumeLoopWarningForToolCall,
+} from "./agent-tools.before-tool-call.state.js";
+import {
   finalizeBeforeToolCallExecutionParams,
   prepareBeforeToolCallExecutionParams,
 } from "./agent-tools.before-tool-call.wrapper.js";
@@ -274,21 +279,30 @@ async function executeAdaptedToolOperation(params: {
   hookContext: HookContext | undefined;
 }): Promise<AgentToolResult<unknown>> {
   try {
-    return normalizeToolExecutionResult({
-      toolName: params.normalizedToolName,
-      result: await params.run(),
-    });
+    return appendLoopWarningToToolResult(
+      normalizeToolExecutionResult({
+        toolName: params.normalizedToolName,
+        result: await params.run(),
+      }),
+      params.toolCallId,
+      params.hookContext?.runId,
+    );
   } catch (err) {
     if (params.signal?.aborted) {
+      consumeLoopWarningForToolCall(params.toolCallId, params.hookContext?.runId);
       throw err;
     }
     if (isBeforeToolCallBlockedError(err)) {
       logDebug(`tools: ${params.normalizedToolName} blocked by before_tool_call: ${err.reason}`);
-      return buildBlockedToolResult({
-        reason: err.reason,
-        toolCallId: params.toolCallId,
-        runId: params.hookContext?.runId,
-      });
+      return appendLoopWarningToToolResult(
+        buildBlockedToolResult({
+          reason: err.reason,
+          toolCallId: params.toolCallId,
+          runId: params.hookContext?.runId,
+        }),
+        params.toolCallId,
+        params.hookContext?.runId,
+      );
     }
     const described = describeToolExecutionError(err);
     if (described.stack && described.stack !== described.message) {
@@ -300,10 +314,14 @@ async function executeAdaptedToolOperation(params: {
       effectiveParams: params.getEffectiveParams(),
     });
     logError(`[tools] ${params.normalizedToolName} failed: ${described.message} ${inputPreview}`);
-    return buildToolExecutionErrorResult({
-      toolName: params.normalizedToolName,
-      message: described.message,
-    });
+    return appendLoopWarningToToolResult(
+      buildToolExecutionErrorResult({
+        toolName: params.normalizedToolName,
+        message: described.message,
+      }),
+      params.toolCallId,
+      params.hookContext?.runId,
+    );
   }
 }
 
@@ -469,6 +487,7 @@ export function toToolDefinitions(
               });
               const decision = control ? await control.pause(executeParams) : undefined;
               if (decision && !decision.launch) {
+                consumeLoopWarningForToolCall(toolCallId, hookContext?.runId);
                 return { content: [], details: { status: "skipped" } };
               }
               // A voice grant binds the post-finalizer execution shape. Consuming it
@@ -641,12 +660,16 @@ export function toClientToolDefinitions(
               onClientToolCall.discard?.(toolCallId, func.name);
             }
             if (outcome.kind === "veto") {
-              return buildBlockedToolResult({
-                reason: outcome.reason,
-                deniedReason: outcome.deniedReason,
+              return appendLoopWarningToToolResult(
+                buildBlockedToolResult({
+                  reason: outcome.reason,
+                  deniedReason: outcome.deniedReason,
+                  toolCallId,
+                  runId: hookContext?.runId,
+                }),
                 toolCallId,
-                runId: hookContext?.runId,
-              });
+                hookContext?.runId,
+              );
             }
             throw new Error(outcome.reason);
           }
@@ -659,6 +682,7 @@ export function toClientToolDefinitions(
             if (onClientToolCall && typeof onClientToolCall !== "function") {
               onClientToolCall.discard?.(toolCallId, func.name);
             }
+            consumeLoopWarningForToolCall(toolCallId, hookContext?.runId);
             return { content: [], details: { status: "skipped" } };
           }
           const voiceConfirmation = consumeFinalClientVoiceToolConfirmation({
@@ -670,12 +694,16 @@ export function toClientToolDefinitions(
             if (onClientToolCall && typeof onClientToolCall !== "function") {
               onClientToolCall.discard?.(toolCallId, func.name);
             }
-            return buildBlockedToolResult({
-              reason: voiceConfirmation.reason,
-              deniedReason: "client-voice-confirmation",
+            return appendLoopWarningToToolResult(
+              buildBlockedToolResult({
+                reason: voiceConfirmation.reason,
+                deniedReason: "client-voice-confirmation",
+                toolCallId,
+                runId: hookContext?.runId,
+              }),
               toolCallId,
-              runId: hookContext?.runId,
-            });
+              hookContext?.runId,
+            );
           }
           decision?.start?.();
           // Notify handler that a client tool was called.
@@ -691,22 +719,34 @@ export function toClientToolDefinitions(
             onClientToolCall.discard?.(toolCallId, func.name);
           }
           if (err instanceof ToolInputError) {
-            return buildToolExecutionErrorResult({
-              toolName: func.name,
-              message: err.message,
-            });
+            return appendLoopWarningToToolResult(
+              buildToolExecutionErrorResult({
+                toolName: func.name,
+                message: err.message,
+              }),
+              toolCallId,
+              hookContext?.runId,
+            );
           }
-          throw err;
+          if (signal?.aborted) {
+            consumeLoopWarningForToolCall(toolCallId, hookContext?.runId);
+            throw err;
+          }
+          throw appendLoopWarningToError(err, toolCallId, hookContext?.runId);
         }
         // Return a terminal pending result; the client will execute the tool.
-        return {
-          ...jsonResult({
-            status: "pending",
-            tool: func.name,
-            message: "Tool execution delegated to client",
-          }),
-          terminate: true,
-        };
+        return appendLoopWarningToToolResult(
+          {
+            ...jsonResult({
+              status: "pending",
+              tool: func.name,
+              message: "Tool execution delegated to client",
+            }),
+            terminate: true,
+          },
+          toolCallId,
+          hookContext?.runId,
+        );
       },
     } satisfies ToolDefinition;
     return attachAdapterExecutionPreparer(definition);

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -18,8 +18,8 @@ import {
 } from "./agent-tools.before-tool-call.js";
 import { consumeFinalClientVoiceToolConfirmation } from "./agent-tools.before-tool-call.policy.js";
 import {
-  appendLoopWarningToError,
-  appendLoopWarningToToolResult,
+  carryLoopWarningToError,
+  carryLoopWarningToToolResult,
   consumeLoopWarningForToolCall,
 } from "./agent-tools.before-tool-call.state.js";
 import {
@@ -279,7 +279,7 @@ async function executeAdaptedToolOperation(params: {
   hookContext: HookContext | undefined;
 }): Promise<AgentToolResult<unknown>> {
   const withLoopWarning = (result: AgentToolResult<unknown>) =>
-    appendLoopWarningToToolResult(result, params.toolCallId, params.hookContext?.runId);
+    carryLoopWarningToToolResult(result, params.toolCallId, params.hookContext?.runId);
   try {
     return withLoopWarning(
       normalizeToolExecutionResult({
@@ -640,7 +640,7 @@ export function toClientToolDefinitions(
         const { toolCallId, params, signal } = splitToolExecuteArgs(args);
         const control = readInternalExecutionControl(args[4]);
         const withLoopWarning = (result: AgentToolResult<unknown>) =>
-          appendLoopWarningToToolResult(result, toolCallId, hookContext?.runId);
+          carryLoopWarningToToolResult(result, toolCallId, hookContext?.runId);
         if (onClientToolCall && typeof onClientToolCall !== "function") {
           onClientToolCall.reserve?.(toolCallId, func.name);
         }
@@ -724,7 +724,7 @@ export function toClientToolDefinitions(
             consumeLoopWarningForToolCall(toolCallId, hookContext?.runId);
             throw err;
           }
-          throw appendLoopWarningToError(err, toolCallId, hookContext?.runId);
+          throw carryLoopWarningToError(err, toolCallId, hookContext?.runId);
         }
         // Return a terminal pending result; the client will execute the tool.
         return withLoopWarning({

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -278,14 +278,14 @@ async function executeAdaptedToolOperation(params: {
   run: () => Promise<unknown>;
   hookContext: HookContext | undefined;
 }): Promise<AgentToolResult<unknown>> {
+  const withLoopWarning = (result: AgentToolResult<unknown>) =>
+    appendLoopWarningToToolResult(result, params.toolCallId, params.hookContext?.runId);
   try {
-    return appendLoopWarningToToolResult(
+    return withLoopWarning(
       normalizeToolExecutionResult({
         toolName: params.normalizedToolName,
         result: await params.run(),
       }),
-      params.toolCallId,
-      params.hookContext?.runId,
     );
   } catch (err) {
     if (params.signal?.aborted) {
@@ -294,14 +294,12 @@ async function executeAdaptedToolOperation(params: {
     }
     if (isBeforeToolCallBlockedError(err)) {
       logDebug(`tools: ${params.normalizedToolName} blocked by before_tool_call: ${err.reason}`);
-      return appendLoopWarningToToolResult(
+      return withLoopWarning(
         buildBlockedToolResult({
           reason: err.reason,
           toolCallId: params.toolCallId,
           runId: params.hookContext?.runId,
         }),
-        params.toolCallId,
-        params.hookContext?.runId,
       );
     }
     const described = describeToolExecutionError(err);
@@ -314,13 +312,11 @@ async function executeAdaptedToolOperation(params: {
       effectiveParams: params.getEffectiveParams(),
     });
     logError(`[tools] ${params.normalizedToolName} failed: ${described.message} ${inputPreview}`);
-    return appendLoopWarningToToolResult(
+    return withLoopWarning(
       buildToolExecutionErrorResult({
         toolName: params.normalizedToolName,
         message: described.message,
       }),
-      params.toolCallId,
-      params.hookContext?.runId,
     );
   }
 }
@@ -643,6 +639,8 @@ export function toClientToolDefinitions(
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params, signal } = splitToolExecuteArgs(args);
         const control = readInternalExecutionControl(args[4]);
+        const withLoopWarning = (result: AgentToolResult<unknown>) =>
+          appendLoopWarningToToolResult(result, toolCallId, hookContext?.runId);
         if (onClientToolCall && typeof onClientToolCall !== "function") {
           onClientToolCall.reserve?.(toolCallId, func.name);
         }
@@ -660,15 +658,13 @@ export function toClientToolDefinitions(
               onClientToolCall.discard?.(toolCallId, func.name);
             }
             if (outcome.kind === "veto") {
-              return appendLoopWarningToToolResult(
+              return withLoopWarning(
                 buildBlockedToolResult({
                   reason: outcome.reason,
                   deniedReason: outcome.deniedReason,
                   toolCallId,
                   runId: hookContext?.runId,
                 }),
-                toolCallId,
-                hookContext?.runId,
               );
             }
             throw new Error(outcome.reason);
@@ -694,15 +690,13 @@ export function toClientToolDefinitions(
             if (onClientToolCall && typeof onClientToolCall !== "function") {
               onClientToolCall.discard?.(toolCallId, func.name);
             }
-            return appendLoopWarningToToolResult(
+            return withLoopWarning(
               buildBlockedToolResult({
                 reason: voiceConfirmation.reason,
                 deniedReason: "client-voice-confirmation",
                 toolCallId,
                 runId: hookContext?.runId,
               }),
-              toolCallId,
-              hookContext?.runId,
             );
           }
           decision?.start?.();
@@ -719,13 +713,11 @@ export function toClientToolDefinitions(
             onClientToolCall.discard?.(toolCallId, func.name);
           }
           if (err instanceof ToolInputError) {
-            return appendLoopWarningToToolResult(
+            return withLoopWarning(
               buildToolExecutionErrorResult({
                 toolName: func.name,
                 message: err.message,
               }),
-              toolCallId,
-              hookContext?.runId,
             );
           }
           if (signal?.aborted) {
@@ -735,7 +727,7 @@ export function toClientToolDefinitions(
           throw appendLoopWarningToError(err, toolCallId, hookContext?.runId);
         }
         // Return a terminal pending result; the client will execute the tool.
-        return appendLoopWarningToToolResult(
+        return withLoopWarning(
           {
             ...jsonResult({
               status: "pending",
@@ -744,8 +736,6 @@ export function toClientToolDefinitions(
             }),
             terminate: true,
           },
-          toolCallId,
-          hookContext?.runId,
         );
       },
     } satisfies ToolDefinition;

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -727,16 +727,14 @@ export function toClientToolDefinitions(
           throw appendLoopWarningToError(err, toolCallId, hookContext?.runId);
         }
         // Return a terminal pending result; the client will execute the tool.
-        return withLoopWarning(
-          {
-            ...jsonResult({
-              status: "pending",
-              tool: func.name,
-              message: "Tool execution delegated to client",
-            }),
-            terminate: true,
-          },
-        );
+        return withLoopWarning({
+          ...jsonResult({
+            status: "pending",
+            tool: func.name,
+            message: "Tool execution delegated to client",
+          }),
+          terminate: true,
+        });
       },
     } satisfies ToolDefinition;
     return attachAdapterExecutionPreparer(definition);

--- a/src/agents/agent-tools.before-tool-call.blocked-result.ts
+++ b/src/agents/agent-tools.before-tool-call.blocked-result.ts
@@ -1,0 +1,30 @@
+import { recordPreExecutionBlockedToolCall } from "./agent-tools.before-tool-call.state.js";
+import type { HookBlockedReason } from "./agent-tools.before-tool-call.types.js";
+
+const preExecutionBlockedToolResults = new WeakSet<object>();
+
+export function isPreExecutionBlockedToolResult(result: unknown): boolean {
+  return (
+    result !== null && typeof result === "object" && preExecutionBlockedToolResults.has(result)
+  );
+}
+
+/** Build the standard terminal result for vetoed tool calls. */
+export function buildBlockedToolResult(params: {
+  reason: string;
+  deniedReason?: HookBlockedReason;
+  toolCallId?: string;
+  runId?: string;
+}) {
+  recordPreExecutionBlockedToolCall(params.toolCallId, params.runId);
+  const result = {
+    content: [{ type: "text" as const, text: params.reason }],
+    details: {
+      status: "blocked",
+      deniedReason: params.deniedReason ?? "plugin-before-tool-call",
+      reason: params.reason,
+    },
+  };
+  preExecutionBlockedToolResults.add(result);
+  return result;
+}

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -1000,9 +1000,19 @@ describe("before_tool_call loop detection behavior", () => {
       const { readTool, listTool } = createPingPongTools();
       await runPingPongSequence(readTool, listTool, 9);
 
-      await listTool.execute("list-9", { dir: "/workspace" }, undefined, undefined);
+      const warningResult = await listTool.execute(
+        "list-9",
+        { dir: "/workspace" },
+        undefined,
+        undefined,
+      );
       await readTool.execute("read-10", { path: "/a.txt" }, undefined, undefined);
       await listTool.execute("list-11", { dir: "/workspace" }, undefined, undefined);
+
+      expect(warningResult.content).toContainEqual({
+        type: "text",
+        text: expect.stringContaining("Tool loop warning:"),
+      });
 
       const pingPongWarns = emitted.filter(
         (evt) => evt.level === "warning" && evt.detector === "ping_pong",

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -2592,11 +2592,7 @@ describe("before_tool_call adapter and client tool integration", () => {
       undefined,
       {} as ExtensionContext,
     );
-    recordLoopWarningForToolCall(
-      "call-voice-client-2",
-      "Choose a different action.",
-      runId,
-    );
+    recordLoopWarningForToolCall("call-voice-client-2", "Choose a different action.", runId);
     const second = await definition.execute(
       "call-voice-client-2",
       toolParams,

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -53,6 +53,7 @@ import {
   adjustedParamsByToolCallId,
   buildAdjustedParamsKey,
   consumeTrackedToolExecutionStarted,
+  recordLoopWarningForToolCall,
   resetAdjustedParamsByToolCallIdForTests,
   structuredReplaySafeToolCallIds,
 } from "./agent-tools.before-tool-call.state.js";
@@ -322,11 +323,15 @@ describe("before_tool_call hook integration", () => {
     const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
     const tool = wrapToolWithBeforeToolCallHook(asAgentTool({ name: "exec", execute }));
     const extensionContext = {} as Parameters<typeof tool.execute>[3];
+    recordLoopWarningForToolCall("call-3", "Choose a different action.");
 
     await expect(
       tool.execute("call-3", { cmd: "rm -rf /" }, undefined, extensionContext),
     ).resolves.toEqual({
-      content: [{ type: "text", text: "blocked" }],
+      content: [
+        { type: "text", text: "blocked" },
+        { type: "text", text: "Tool loop warning: Choose a different action." },
+      ],
       details: {
         status: "blocked",
         deniedReason: "plugin-before-tool-call",
@@ -401,10 +406,14 @@ describe("before_tool_call hook integration", () => {
     const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
     const tool = wrapToolWithBeforeToolCallHook(asAgentTool({ name: "read", execute }));
     const extensionContext = {} as Parameters<typeof tool.execute>[3];
+    recordLoopWarningForToolCall("call-4", "Choose a different action.");
 
     await expect(
       tool.execute("call-4", { path: "/tmp/file" }, undefined, extensionContext),
-    ).rejects.toThrow("Tool call blocked because before_tool_call hook failed");
+    ).rejects.toThrow(
+      "Tool call blocked because before_tool_call hook failed\n\n" +
+        "Tool loop warning: Choose a different action.",
+    );
     expect(execute).not.toHaveBeenCalled();
   });
 
@@ -2084,6 +2093,49 @@ describe("before_tool_call adapter and client tool integration", () => {
     });
   });
 
+  it("surfaces a loop warning when a plugin vetoes a client-hosted tool", async () => {
+    installBeforeToolCallHook({
+      runBeforeToolCallImpl: async () => ({ block: true, blockReason: "blocked client call" }),
+    });
+    const runId = "run-client-veto-warning";
+    const toolCallId = "call-client-veto-warning";
+    const definition = expectDefined(
+      toClientToolDefinitions(
+        [
+          {
+            type: "function",
+            function: {
+              name: "client_tool",
+              description: "Client tool",
+              parameters: { type: "object", properties: {} },
+            },
+          },
+        ],
+        undefined,
+        { runId },
+      )[0],
+      "client tool definition",
+    );
+    recordLoopWarningForToolCall(toolCallId, "Choose a different action.", runId);
+
+    const result = await definition.execute(
+      toolCallId,
+      {},
+      undefined,
+      undefined,
+      {} as ExtensionContext,
+    );
+
+    expect(result.details).toMatchObject({
+      status: "blocked",
+      deniedReason: "plugin-before-tool-call",
+    });
+    expect(result.content).toContainEqual({
+      type: "text",
+      text: "Tool loop warning: Choose a different action.",
+    });
+  });
+
   it("preserves client tool source order when hooks resolve out of order", async () => {
     let releaseFirstHook: (() => void) | undefined;
     const firstHookGate = new Promise<void>((resolve) => {
@@ -2540,6 +2592,11 @@ describe("before_tool_call adapter and client tool integration", () => {
       undefined,
       {} as ExtensionContext,
     );
+    recordLoopWarningForToolCall(
+      "call-voice-client-2",
+      "Choose a different action.",
+      runId,
+    );
     const second = await definition.execute(
       "call-voice-client-2",
       toolParams,
@@ -2552,6 +2609,10 @@ describe("before_tool_call adapter and client tool integration", () => {
     expect(second.details).toMatchObject({
       status: "blocked",
       deniedReason: "client-voice-confirmation",
+    });
+    expect(second.content).toContainEqual({
+      type: "text",
+      text: "Tool loop warning: Choose a different action.",
     });
     expect(onClientToolCall).toHaveBeenCalledOnce();
     expect(onClientToolCall).toHaveBeenCalledWith("message", toolParams);

--- a/src/agents/agent-tools.before-tool-call.state.ts
+++ b/src/agents/agent-tools.before-tool-call.state.ts
@@ -3,12 +3,15 @@
  * The adapter and wrapper both consult this map so later execution can use the
  * normalized payload selected by hook processing.
  */
+import type { AgentToolResult } from "./runtime/index.js";
+
 export const adjustedParamsByToolCallId = new Map<string, unknown>();
 export const preExecutionBlockedToolCallIds = new Set<string>();
 export const structuredReplaySafeToolCallIds = new Set<string>();
 const startedToolCallIds = new Set<string>();
 const trackedToolCallIds = new Set<string>();
 const batchAdmittedToolCallIds = new Set<string>();
+const loopWarningsByToolCallId = new Map<string, string>();
 
 export function buildAdjustedParamsKey(params: { runId?: string; toolCallId: string }): string {
   if (params.runId && params.runId.trim()) {
@@ -102,13 +105,74 @@ export function consumeBatchAdmittedToolCall(toolCallId: string, runId?: string)
   return admitted;
 }
 
+/** Attach bounded loop guidance to the model-visible outcome of an admitted call. */
+export function recordLoopWarningForToolCall(
+  toolCallId: string,
+  warning: string,
+  runId?: string,
+): void {
+  loopWarningsByToolCallId.set(buildAdjustedParamsKey({ runId, toolCallId }), warning);
+}
+
+/** Consume pending guidance when no model-visible result can be emitted. */
+export function consumeLoopWarningForToolCall(
+  toolCallId: string,
+  runId?: string,
+): string | undefined {
+  const key = buildAdjustedParamsKey({ runId, toolCallId });
+  const warning = loopWarningsByToolCallId.get(key);
+  loopWarningsByToolCallId.delete(key);
+  return warning;
+}
+
+export function appendLoopWarningToToolResult(
+  result: AgentToolResult<unknown>,
+  toolCallId: string,
+  runId?: string,
+): AgentToolResult<unknown> {
+  const warning = consumeLoopWarningForToolCall(toolCallId, runId);
+  if (!warning) {
+    return result;
+  }
+  return {
+    ...result,
+    content: [...(result.content ?? []), { type: "text", text: `Tool loop warning: ${warning}` }],
+  };
+}
+
+/** Carry warning guidance through a failed call without masking immutable errors. */
+export function appendLoopWarningToError(
+  error: unknown,
+  toolCallId: string,
+  runId?: string,
+): unknown {
+  const warning = consumeLoopWarningForToolCall(toolCallId, runId);
+  if (!warning) {
+    return error;
+  }
+  const message = `${error instanceof Error ? error.message : String(error)}\n\nTool loop warning: ${warning}`;
+  if (error instanceof Error) {
+    try {
+      error.message = message;
+      return error;
+    } catch {
+      const wrapped = new Error(message, { cause: error });
+      wrapped.name = error.name;
+      return wrapped;
+    }
+  }
+  return new Error(message);
+}
+
 /** Release exact batch-admission markers for prepared calls suppressed by steering. */
 export function releaseBatchAdmittedToolCalls(
   toolCallIds: readonly string[],
   runId?: string,
 ): void {
   for (const toolCallId of toolCallIds) {
-    batchAdmittedToolCallIds.delete(buildAdjustedParamsKey({ runId, toolCallId }));
+    const key = buildAdjustedParamsKey({ runId, toolCallId });
+    batchAdmittedToolCallIds.delete(key);
+    loopWarningsByToolCallId.delete(key);
   }
 }
 
@@ -118,6 +182,11 @@ export function clearBatchAdmittedToolCallsForRun(runId: string): void {
   for (const key of batchAdmittedToolCallIds) {
     if (key.startsWith(prefix)) {
       batchAdmittedToolCallIds.delete(key);
+    }
+  }
+  for (const key of loopWarningsByToolCallId.keys()) {
+    if (key.startsWith(prefix)) {
+      loopWarningsByToolCallId.delete(key);
     }
   }
 }
@@ -130,4 +199,5 @@ export function resetAdjustedParamsByToolCallIdForTests(): void {
   startedToolCallIds.clear();
   structuredReplaySafeToolCallIds.clear();
   batchAdmittedToolCallIds.clear();
+  loopWarningsByToolCallId.clear();
 }

--- a/src/agents/agent-tools.before-tool-call.state.ts
+++ b/src/agents/agent-tools.before-tool-call.state.ts
@@ -7,7 +7,7 @@ import { pruneMapToMaxSize } from "../infra/map-size.js";
 import type { AgentToolResult } from "./runtime/index.js";
 
 export const adjustedParamsByToolCallId = new Map<string, unknown>();
-export const preExecutionBlockedToolCallIds = new Set<string>();
+const preExecutionBlockedToolCallIds = new Set<string>();
 export const structuredReplaySafeToolCallIds = new Set<string>();
 const startedToolCallIds = new Set<string>();
 const trackedToolCallIds = new Set<string>();

--- a/src/agents/agent-tools.before-tool-call.state.ts
+++ b/src/agents/agent-tools.before-tool-call.state.ts
@@ -13,6 +13,7 @@ const startedToolCallIds = new Set<string>();
 const trackedToolCallIds = new Set<string>();
 const batchAdmittedToolCallIds = new Set<string>();
 const loopWarningsByToolCallId = new Map<string, { warning: string; carried: boolean }>();
+const MAX_TRACKED_TOOL_CALLS = 1024;
 const MAX_PENDING_LOOP_WARNINGS = 1024;
 
 export function buildAdjustedParamsKey(params: { runId?: string; toolCallId: string }): string {
@@ -43,6 +44,20 @@ export function consumePreExecutionBlockedToolCall(toolCallId: string, runId?: s
   const blocked = preExecutionBlockedToolCallIds.has(key);
   preExecutionBlockedToolCallIds.delete(key);
   return blocked;
+}
+
+export function recordPreExecutionBlockedToolCall(toolCallId?: string, runId?: string): void {
+  if (!toolCallId) {
+    return;
+  }
+  preExecutionBlockedToolCallIds.add(buildAdjustedParamsKey({ runId, toolCallId }));
+  while (preExecutionBlockedToolCallIds.size > MAX_TRACKED_TOOL_CALLS) {
+    const oldest = preExecutionBlockedToolCallIds.values().next().value;
+    if (!oldest) {
+      break;
+    }
+    preExecutionBlockedToolCallIds.delete(oldest);
+  }
 }
 
 /** Snapshot whether policy prevented execution without stealing cleanup from the tool owner. */
@@ -203,6 +218,20 @@ export function carryLoopWarningToError(
 ): unknown {
   const warning = claimLoopWarningForTransport(toolCallId, runId);
   return warning ? appendWarningTextToError(error, warning) : error;
+}
+
+/** Carry warning guidance unless an aborted call cannot emit a model-visible result. */
+export function resolveLoopWarningError(
+  error: unknown,
+  toolCallId: string,
+  runId: string | undefined,
+  signal?: AbortSignal,
+): unknown {
+  if (signal?.aborted) {
+    consumeLoopWarningForToolCall(toolCallId, runId);
+    return error;
+  }
+  return carryLoopWarningToError(error, toolCallId, runId);
 }
 
 /** Release admission and warning state for prepared calls suppressed by steering. */

--- a/src/agents/agent-tools.before-tool-call.state.ts
+++ b/src/agents/agent-tools.before-tool-call.state.ts
@@ -12,7 +12,7 @@ export const structuredReplaySafeToolCallIds = new Set<string>();
 const startedToolCallIds = new Set<string>();
 const trackedToolCallIds = new Set<string>();
 const batchAdmittedToolCallIds = new Set<string>();
-const loopWarningsByToolCallId = new Map<string, string>();
+const loopWarningsByToolCallId = new Map<string, { warning: string; carried: boolean }>();
 const MAX_PENDING_LOOP_WARNINGS = 1024;
 
 export function buildAdjustedParamsKey(params: { runId?: string; toolCallId: string }): string {
@@ -113,7 +113,10 @@ export function recordLoopWarningForToolCall(
   warning: string,
   runId?: string,
 ): void {
-  loopWarningsByToolCallId.set(buildAdjustedParamsKey({ runId, toolCallId }), warning);
+  loopWarningsByToolCallId.set(buildAdjustedParamsKey({ runId, toolCallId }), {
+    warning,
+    carried: false,
+  });
   pruneMapToMaxSize(loopWarningsByToolCallId, MAX_PENDING_LOOP_WARNINGS);
 }
 
@@ -123,9 +126,45 @@ export function consumeLoopWarningForToolCall(
   runId?: string,
 ): string | undefined {
   const key = buildAdjustedParamsKey({ runId, toolCallId });
-  const warning = loopWarningsByToolCallId.get(key);
+  const warning = loopWarningsByToolCallId.get(key)?.warning;
   loopWarningsByToolCallId.delete(key);
   return warning;
+}
+
+function claimLoopWarningForTransport(toolCallId: string, runId?: string): string | undefined {
+  const pending = loopWarningsByToolCallId.get(buildAdjustedParamsKey({ runId, toolCallId }));
+  if (!pending || pending.carried) {
+    return undefined;
+  }
+  pending.carried = true;
+  return pending.warning;
+}
+
+function appendWarningTextToToolResult(
+  result: AgentToolResult<unknown>,
+  warning: string,
+): AgentToolResult<unknown> {
+  const text = `Tool loop warning: ${warning}`;
+  const alreadyPresent = result.content?.some(
+    (block) => block.type === "text" && block.text.includes(text),
+  );
+  if (alreadyPresent) {
+    return result;
+  }
+  return {
+    ...result,
+    content: [...(result.content ?? []), { type: "text", text }],
+  };
+}
+
+/** Carry guidance through tool execution while retaining it for final outcome hooks. */
+export function carryLoopWarningToToolResult(
+  result: AgentToolResult<unknown>,
+  toolCallId: string,
+  runId?: string,
+): AgentToolResult<unknown> {
+  const warning = claimLoopWarningForTransport(toolCallId, runId);
+  return warning ? appendWarningTextToToolResult(result, warning) : result;
 }
 
 export function appendLoopWarningToToolResult(
@@ -137,22 +176,10 @@ export function appendLoopWarningToToolResult(
   if (!warning) {
     return result;
   }
-  return {
-    ...result,
-    content: [...(result.content ?? []), { type: "text", text: `Tool loop warning: ${warning}` }],
-  };
+  return appendWarningTextToToolResult(result, warning);
 }
 
-/** Carry warning guidance through a failed call without masking immutable errors. */
-export function appendLoopWarningToError(
-  error: unknown,
-  toolCallId: string,
-  runId?: string,
-): unknown {
-  const warning = consumeLoopWarningForToolCall(toolCallId, runId);
-  if (!warning) {
-    return error;
-  }
+function appendWarningTextToError(error: unknown, warning: string): unknown {
   const originalMessage = error instanceof Error ? error.message : String(error);
   const message = `${originalMessage}\n\nTool loop warning: ${warning}`;
   if (error instanceof Error) {
@@ -166,6 +193,16 @@ export function appendLoopWarningToError(
     }
   }
   return new Error(message);
+}
+
+/** Carry guidance through a failed call while retaining it for final outcome hooks. */
+export function carryLoopWarningToError(
+  error: unknown,
+  toolCallId: string,
+  runId?: string,
+): unknown {
+  const warning = claimLoopWarningForTransport(toolCallId, runId);
+  return warning ? appendWarningTextToError(error, warning) : error;
 }
 
 /** Release admission and warning state for prepared calls suppressed by steering. */

--- a/src/agents/agent-tools.before-tool-call.state.ts
+++ b/src/agents/agent-tools.before-tool-call.state.ts
@@ -3,6 +3,7 @@
  * The adapter and wrapper both consult this map so later execution can use the
  * normalized payload selected by hook processing.
  */
+import { pruneMapToMaxSize } from "../infra/map-size.js";
 import type { AgentToolResult } from "./runtime/index.js";
 
 export const adjustedParamsByToolCallId = new Map<string, unknown>();
@@ -12,6 +13,7 @@ const startedToolCallIds = new Set<string>();
 const trackedToolCallIds = new Set<string>();
 const batchAdmittedToolCallIds = new Set<string>();
 const loopWarningsByToolCallId = new Map<string, string>();
+const MAX_PENDING_LOOP_WARNINGS = 1024;
 
 export function buildAdjustedParamsKey(params: { runId?: string; toolCallId: string }): string {
   if (params.runId && params.runId.trim()) {
@@ -112,6 +114,7 @@ export function recordLoopWarningForToolCall(
   runId?: string,
 ): void {
   loopWarningsByToolCallId.set(buildAdjustedParamsKey({ runId, toolCallId }), warning);
+  pruneMapToMaxSize(loopWarningsByToolCallId, MAX_PENDING_LOOP_WARNINGS);
 }
 
 /** Consume pending guidance when no model-visible result can be emitted. */
@@ -150,7 +153,8 @@ export function appendLoopWarningToError(
   if (!warning) {
     return error;
   }
-  const message = `${error instanceof Error ? error.message : String(error)}\n\nTool loop warning: ${warning}`;
+  const originalMessage = error instanceof Error ? error.message : String(error);
+  const message = `${originalMessage}\n\nTool loop warning: ${warning}`;
   if (error instanceof Error) {
     try {
       error.message = message;
@@ -164,7 +168,7 @@ export function appendLoopWarningToError(
   return new Error(message);
 }
 
-/** Release exact batch-admission markers for prepared calls suppressed by steering. */
+/** Release admission and warning state for prepared calls suppressed by steering. */
 export function releaseBatchAdmittedToolCalls(
   toolCallIds: readonly string[],
   runId?: string,
@@ -176,7 +180,7 @@ export function releaseBatchAdmittedToolCalls(
   }
 }
 
-/** Remove unused batch-admission markers when their embedded run ends. */
+/** Remove unused admission and warning state when an embedded run ends. */
 export function clearBatchAdmittedToolCallsForRun(runId: string): void {
   const prefix = `${runId}:`;
   for (const key of batchAdmittedToolCallIds) {

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -32,12 +32,14 @@ export {
   runBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.policy.js";
 export {
-  buildBlockedToolResult,
   getBeforeToolCallFailureDisposition,
   isBeforeToolCallBlockedError,
-  isPreExecutionBlockedToolResult,
   recordAdjustedParamsForToolCall,
   recordStructuredReplayTrustForToolCall,
   rewrapToolWithBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.wrapper.js";
+export {
+  buildBlockedToolResult,
+  isPreExecutionBlockedToolResult,
+} from "./agent-tools.before-tool-call.blocked-result.js";

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -38,10 +38,10 @@ import {
   runBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.policy.js";
 import {
-  appendLoopWarningToError,
-  appendLoopWarningToToolResult,
   adjustedParamsByToolCallId,
   buildAdjustedParamsKey,
+  carryLoopWarningToError,
+  carryLoopWarningToToolResult,
   clearTrackedToolExecution,
   consumeLoopWarningForToolCall,
   preExecutionBlockedToolCallIds,
@@ -325,7 +325,7 @@ export function wrapToolWithBeforeToolCallHook(
           consumeLoopWarningForToolCall(toolCallId, ctx?.runId);
           throw error;
         }
-        throw appendLoopWarningToError(error, toolCallId, ctx?.runId);
+        throw carryLoopWarningToError(error, toolCallId, ctx?.runId);
       };
       const trace =
         hookOptions.emitDiagnostics && ctx?.trace
@@ -424,7 +424,7 @@ export function wrapToolWithBeforeToolCallHook(
           result: blockedResult,
           toolCallOrdinal,
         });
-        return appendLoopWarningToToolResult(blockedResult, toolCallId, ctx?.runId);
+        return carryLoopWarningToToolResult(blockedResult, toolCallId, ctx?.runId);
       };
       let preparedParams: unknown;
       try {
@@ -621,7 +621,7 @@ export function wrapToolWithBeforeToolCallHook(
             }),
           );
         }
-        return appendLoopWarningToToolResult(result, toolCallId, ctx?.runId);
+        return carryLoopWarningToToolResult(result, toolCallId, ctx?.runId);
       } catch (err) {
         if (hookOptions.emitDiagnostics) {
           emitTrustedDiagnosticEventWithPrivateData(

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -437,7 +437,7 @@ export function wrapToolWithBeforeToolCallHook(
         });
       } catch (error) {
         recordPreExecutionError(error, params, "tool_preparation");
-        rethrowWithLoopWarning(tagBeforeToolCallFailure(error, signal));
+        return rethrowWithLoopWarning(tagBeforeToolCallFailure(error, signal));
       }
       const hookParams = normalizeCodeModeExecBeforeHookParams({ tool, params: preparedParams });
       const hookMetadata = getCodeModeExecBeforeHookMetadata({ tool, params: preparedParams });
@@ -454,7 +454,7 @@ export function wrapToolWithBeforeToolCallHook(
         });
       } catch (error) {
         recordPreExecutionError(error, hookParams, "before_tool_call");
-        rethrowWithLoopWarning(tagBeforeToolCallFailure(error, signal));
+        return rethrowWithLoopWarning(tagBeforeToolCallFailure(error, signal));
       }
       if (outcome.blocked) {
         if (outcome.kind !== "veto") {
@@ -464,7 +464,7 @@ export function wrapToolWithBeforeToolCallHook(
             outcome.deniedReason === "plugin-approval" ? "plugin_approval" : "before_tool_call",
             outcome.deniedReason,
           );
-          rethrowWithLoopWarning(
+          return rethrowWithLoopWarning(
             new BeforeToolCallFailureError(outcome.reason, outcome.disposition),
           );
         }
@@ -499,7 +499,7 @@ export function wrapToolWithBeforeToolCallHook(
         });
       } catch (error) {
         recordPreExecutionError(error, outcome.params ?? hookParams, "tool_preparation");
-        rethrowWithLoopWarning(tagBeforeToolCallFailure(error, signal));
+        return rethrowWithLoopWarning(tagBeforeToolCallFailure(error, signal));
       }
       let onImplementationStart: (() => void) | undefined;
       if (prepareControl) {
@@ -511,7 +511,7 @@ export function wrapToolWithBeforeToolCallHook(
           }
           onImplementationStart = decision.start;
         } catch (error) {
-          rethrowWithLoopWarning(error);
+          return rethrowWithLoopWarning(error);
         }
       }
       // A voice grant binds the post-finalizer execution shape. Consume it only
@@ -534,7 +534,7 @@ export function wrapToolWithBeforeToolCallHook(
         runAgentToolSourceExecutionGuard(tool);
         onImplementationStart?.();
       } catch (error) {
-        rethrowWithLoopWarning(error);
+        return rethrowWithLoopWarning(error);
       }
       recordAdjustedParamsForToolCall(toolCallId, executeParams, ctx?.runId);
       const eventBase = buildEventBase(executeParams);
@@ -649,7 +649,7 @@ export function wrapToolWithBeforeToolCallHook(
               : tool.resultContentSource,
           toolCallOrdinal,
         });
-        rethrowWithLoopWarning(err);
+        return rethrowWithLoopWarning(err);
       }
     },
   };

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -38,9 +38,12 @@ import {
   runBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.policy.js";
 import {
+  appendLoopWarningToError,
+  appendLoopWarningToToolResult,
   adjustedParamsByToolCallId,
   buildAdjustedParamsKey,
   clearTrackedToolExecution,
+  consumeLoopWarningForToolCall,
   preExecutionBlockedToolCallIds,
   recordStructuredReplaySafeToolCall,
   recordToolExecutionStarted,
@@ -414,7 +417,7 @@ export function wrapToolWithBeforeToolCallHook(
           result: blockedResult,
           toolCallOrdinal,
         });
-        return blockedResult;
+        return appendLoopWarningToToolResult(blockedResult, toolCallId, ctx?.runId);
       };
       let preparedParams: unknown;
       try {
@@ -493,6 +496,7 @@ export function wrapToolWithBeforeToolCallHook(
       if (prepareControl) {
         const decision = await prepareControl.pause(executeParams);
         if (!decision.launch) {
+          consumeLoopWarningForToolCall(toolCallId, ctx?.runId);
           return INTERNAL_DISPOSED_RESULT;
         }
         onImplementationStart = decision.start;
@@ -600,7 +604,7 @@ export function wrapToolWithBeforeToolCallHook(
             }),
           );
         }
-        return result;
+        return appendLoopWarningToToolResult(result, toolCallId, ctx?.runId);
       } catch (err) {
         if (hookOptions.emitDiagnostics) {
           emitTrustedDiagnosticEventWithPrivateData(
@@ -628,7 +632,11 @@ export function wrapToolWithBeforeToolCallHook(
               : tool.resultContentSource,
           toolCallOrdinal,
         });
-        throw err;
+        if (signal?.aborted) {
+          consumeLoopWarningForToolCall(toolCallId, ctx?.runId);
+          throw err;
+        }
+        throw appendLoopWarningToError(err, toolCallId, ctx?.runId);
       }
     },
   };

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -19,6 +19,7 @@ import {
   copyAgentToolSourceExecutionGuard,
   runAgentToolSourceExecutionGuard,
 } from "./agent-tool-source-execution-guard.js";
+import { buildBlockedToolResult } from "./agent-tools.before-tool-call.blocked-result.js";
 import {
   buildToolContentPrivateData,
   emitSkillUsedDiagnostic,
@@ -40,12 +41,12 @@ import {
 import {
   adjustedParamsByToolCallId,
   buildAdjustedParamsKey,
-  carryLoopWarningToError,
   carryLoopWarningToToolResult,
   clearTrackedToolExecution,
   consumeLoopWarningForToolCall,
-  preExecutionBlockedToolCallIds,
+  recordPreExecutionBlockedToolCall,
   recordStructuredReplaySafeToolCall,
+  resolveLoopWarningError,
   recordToolExecutionStarted,
   recordToolExecutionTracked,
   structuredReplaySafeToolCallIds,
@@ -255,34 +256,6 @@ export function isBeforeToolCallBlockedError(err: unknown): err is BeforeToolCal
   return err instanceof BeforeToolCallBlockedError;
 }
 
-const preExecutionBlockedToolResults = new WeakSet<object>();
-
-export function isPreExecutionBlockedToolResult(result: unknown): boolean {
-  return (
-    result !== null && typeof result === "object" && preExecutionBlockedToolResults.has(result)
-  );
-}
-
-/** Build the standard terminal result for vetoed tool calls. */
-export function buildBlockedToolResult(params: {
-  reason: string;
-  deniedReason?: HookBlockedReason;
-  toolCallId?: string;
-  runId?: string;
-}) {
-  recordPreExecutionBlockedToolCall(params.toolCallId, params.runId);
-  const result = {
-    content: [{ type: "text" as const, text: params.reason }],
-    details: {
-      status: "blocked",
-      deniedReason: params.deniedReason ?? "plugin-before-tool-call",
-      reason: params.reason,
-    },
-  };
-  preExecutionBlockedToolResults.add(result);
-  return result;
-}
-
 // Build the private (trusted-listener-only) tool content payload for a tool
 // execution diagnostic event. Raw args/results never ride the public event bus;
 // consumers (e.g. diagnostics-otel) bound and redact before export.
@@ -320,13 +293,6 @@ export function wrapToolWithBeforeToolCallHook(
       const toolCallOrdinal = ctx?.allocateToolOutcomeOrdinal?.(toolCallId);
       const preExecutionStartedAt = Date.now();
       const normalizedToolName = normalizeToolPolicyName(toolName || "tool");
-      const rethrowWithLoopWarning = (error: unknown): never => {
-        if (signal?.aborted) {
-          consumeLoopWarningForToolCall(toolCallId, ctx?.runId);
-          throw error;
-        }
-        throw carryLoopWarningToError(error, toolCallId, ctx?.runId);
-      };
       const trace =
         hookOptions.emitDiagnostics && ctx?.trace
           ? freezeDiagnosticTraceContext(createChildDiagnosticTraceContext(ctx.trace))
@@ -437,7 +403,12 @@ export function wrapToolWithBeforeToolCallHook(
         });
       } catch (error) {
         recordPreExecutionError(error, params, "tool_preparation");
-        return rethrowWithLoopWarning(tagBeforeToolCallFailure(error, signal));
+        throw resolveLoopWarningError(
+          tagBeforeToolCallFailure(error, signal),
+          toolCallId,
+          ctx?.runId,
+          signal,
+        );
       }
       const hookParams = normalizeCodeModeExecBeforeHookParams({ tool, params: preparedParams });
       const hookMetadata = getCodeModeExecBeforeHookMetadata({ tool, params: preparedParams });
@@ -454,7 +425,12 @@ export function wrapToolWithBeforeToolCallHook(
         });
       } catch (error) {
         recordPreExecutionError(error, hookParams, "before_tool_call");
-        return rethrowWithLoopWarning(tagBeforeToolCallFailure(error, signal));
+        throw resolveLoopWarningError(
+          tagBeforeToolCallFailure(error, signal),
+          toolCallId,
+          ctx?.runId,
+          signal,
+        );
       }
       if (outcome.blocked) {
         if (outcome.kind !== "veto") {
@@ -464,8 +440,11 @@ export function wrapToolWithBeforeToolCallHook(
             outcome.deniedReason === "plugin-approval" ? "plugin_approval" : "before_tool_call",
             outcome.deniedReason,
           );
-          return rethrowWithLoopWarning(
+          throw resolveLoopWarningError(
             new BeforeToolCallFailureError(outcome.reason, outcome.disposition),
+            toolCallId,
+            ctx?.runId,
+            signal,
           );
         }
         return await blockToolCall({
@@ -499,7 +478,12 @@ export function wrapToolWithBeforeToolCallHook(
         });
       } catch (error) {
         recordPreExecutionError(error, outcome.params ?? hookParams, "tool_preparation");
-        return rethrowWithLoopWarning(tagBeforeToolCallFailure(error, signal));
+        throw resolveLoopWarningError(
+          tagBeforeToolCallFailure(error, signal),
+          toolCallId,
+          ctx?.runId,
+          signal,
+        );
       }
       let onImplementationStart: (() => void) | undefined;
       if (prepareControl) {
@@ -511,7 +495,7 @@ export function wrapToolWithBeforeToolCallHook(
           }
           onImplementationStart = decision.start;
         } catch (error) {
-          return rethrowWithLoopWarning(error);
+          throw resolveLoopWarningError(error, toolCallId, ctx?.runId, signal);
         }
       }
       // A voice grant binds the post-finalizer execution shape. Consume it only
@@ -534,7 +518,7 @@ export function wrapToolWithBeforeToolCallHook(
         runAgentToolSourceExecutionGuard(tool);
         onImplementationStart?.();
       } catch (error) {
-        return rethrowWithLoopWarning(error);
+        throw resolveLoopWarningError(error, toolCallId, ctx?.runId, signal);
       }
       recordAdjustedParamsForToolCall(toolCallId, executeParams, ctx?.runId);
       const eventBase = buildEventBase(executeParams);
@@ -649,7 +633,7 @@ export function wrapToolWithBeforeToolCallHook(
               : tool.resultContentSource,
           toolCallOrdinal,
         });
-        return rethrowWithLoopWarning(err);
+        throw resolveLoopWarningError(err, toolCallId, ctx?.runId, signal);
       }
     },
   };
@@ -741,18 +725,4 @@ export function rewrapToolWithBeforeToolCallHook(
   copyToolTerminalPresentation(tool, rewrapSource);
   copyAgentToolSourceExecutionGuard(tool, rewrapSource);
   return wrapToolWithBeforeToolCallHook(rewrapSource, ctx ?? preservedContext, options);
-}
-
-function recordPreExecutionBlockedToolCall(toolCallId?: string, runId?: string): void {
-  if (!toolCallId) {
-    return;
-  }
-  preExecutionBlockedToolCallIds.add(buildAdjustedParamsKey({ runId, toolCallId }));
-  while (preExecutionBlockedToolCallIds.size > MAX_TRACKED_ADJUSTED_PARAMS) {
-    const oldest = preExecutionBlockedToolCallIds.values().next().value;
-    if (!oldest) {
-      break;
-    }
-    preExecutionBlockedToolCallIds.delete(oldest);
-  }
 }

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -320,6 +320,13 @@ export function wrapToolWithBeforeToolCallHook(
       const toolCallOrdinal = ctx?.allocateToolOutcomeOrdinal?.(toolCallId);
       const preExecutionStartedAt = Date.now();
       const normalizedToolName = normalizeToolPolicyName(toolName || "tool");
+      const rethrowWithLoopWarning = (error: unknown): never => {
+        if (signal?.aborted) {
+          consumeLoopWarningForToolCall(toolCallId, ctx?.runId);
+          throw error;
+        }
+        throw appendLoopWarningToError(error, toolCallId, ctx?.runId);
+      };
       const trace =
         hookOptions.emitDiagnostics && ctx?.trace
           ? freezeDiagnosticTraceContext(createChildDiagnosticTraceContext(ctx.trace))
@@ -430,7 +437,7 @@ export function wrapToolWithBeforeToolCallHook(
         });
       } catch (error) {
         recordPreExecutionError(error, params, "tool_preparation");
-        throw tagBeforeToolCallFailure(error, signal);
+        rethrowWithLoopWarning(tagBeforeToolCallFailure(error, signal));
       }
       const hookParams = normalizeCodeModeExecBeforeHookParams({ tool, params: preparedParams });
       const hookMetadata = getCodeModeExecBeforeHookMetadata({ tool, params: preparedParams });
@@ -447,7 +454,7 @@ export function wrapToolWithBeforeToolCallHook(
         });
       } catch (error) {
         recordPreExecutionError(error, hookParams, "before_tool_call");
-        throw tagBeforeToolCallFailure(error, signal);
+        rethrowWithLoopWarning(tagBeforeToolCallFailure(error, signal));
       }
       if (outcome.blocked) {
         if (outcome.kind !== "veto") {
@@ -457,7 +464,9 @@ export function wrapToolWithBeforeToolCallHook(
             outcome.deniedReason === "plugin-approval" ? "plugin_approval" : "before_tool_call",
             outcome.deniedReason,
           );
-          throw new BeforeToolCallFailureError(outcome.reason, outcome.disposition);
+          rethrowWithLoopWarning(
+            new BeforeToolCallFailureError(outcome.reason, outcome.disposition),
+          );
         }
         return await blockToolCall({
           reason: outcome.reason,
@@ -490,16 +499,20 @@ export function wrapToolWithBeforeToolCallHook(
         });
       } catch (error) {
         recordPreExecutionError(error, outcome.params ?? hookParams, "tool_preparation");
-        throw tagBeforeToolCallFailure(error, signal);
+        rethrowWithLoopWarning(tagBeforeToolCallFailure(error, signal));
       }
       let onImplementationStart: (() => void) | undefined;
       if (prepareControl) {
-        const decision = await prepareControl.pause(executeParams);
-        if (!decision.launch) {
-          consumeLoopWarningForToolCall(toolCallId, ctx?.runId);
-          return INTERNAL_DISPOSED_RESULT;
+        try {
+          const decision = await prepareControl.pause(executeParams);
+          if (!decision.launch) {
+            consumeLoopWarningForToolCall(toolCallId, ctx?.runId);
+            return INTERNAL_DISPOSED_RESULT;
+          }
+          onImplementationStart = decision.start;
+        } catch (error) {
+          rethrowWithLoopWarning(error);
         }
-        onImplementationStart = decision.start;
       }
       // A voice grant binds the post-finalizer execution shape. Consume it only
       // after steering can no longer suppress the prepared call.
@@ -515,10 +528,14 @@ export function wrapToolWithBeforeToolCallHook(
           toolParams: executeParams,
         });
       }
-      // Host capabilities can close while hooks, approval, validation, or
-      // steering awaits. Recheck at the final synchronous source boundary.
-      runAgentToolSourceExecutionGuard(tool);
-      onImplementationStart?.();
+      try {
+        // Host capabilities can close while hooks, approval, validation, or
+        // steering awaits. Recheck at the final synchronous source boundary.
+        runAgentToolSourceExecutionGuard(tool);
+        onImplementationStart?.();
+      } catch (error) {
+        rethrowWithLoopWarning(error);
+      }
       recordAdjustedParamsForToolCall(toolCallId, executeParams, ctx?.runId);
       const eventBase = buildEventBase(executeParams);
       recordToolExecutionStarted(toolCallId, ctx?.runId);
@@ -632,11 +649,7 @@ export function wrapToolWithBeforeToolCallHook(
               : tool.resultContentSource,
           toolCallOrdinal,
         });
-        if (signal?.aborted) {
-          consumeLoopWarningForToolCall(toolCallId, ctx?.runId);
-          throw err;
-        }
-        throw appendLoopWarningToError(err, toolCallId, ctx?.runId);
+        rethrowWithLoopWarning(err);
       }
     },
   };

--- a/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
@@ -57,6 +57,7 @@ import { notifyToolActivity } from "./tool-activity-heartbeat.js";
 import {
   createToolLoopBatchAdmission,
   installToolLoopRecoveryCleanup,
+  installToolLoopWarningFinalizer,
 } from "./tool-loop-recovery.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
@@ -233,6 +234,7 @@ export async function prepareEmbeddedAttemptAgentSession(input: {
   if (input.clientToolPreparation.codeModeControlsEnabledForRun) {
     installCodeModeRepairHook({ agent: activeSession.agent });
   }
+  installToolLoopWarningFinalizer({ agent: activeSession.agent, runId: attempt.runId });
   input.markStage("agent-session");
 
   return {

--- a/src/agents/embedded-agent-runner/run/tool-loop-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-loop-recovery.test.ts
@@ -1,8 +1,13 @@
 import type { InternalToolBatchCall } from "@openclaw/agent-core";
 import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
+import {
+  carryLoopWarningToToolResult,
+  consumeLoopWarningForToolCall,
+  recordLoopWarningForToolCall,
+} from "../../agent-tools.before-tool-call.state.js";
 import { markCodeModeControlTool } from "../../code-mode-control-tools.js";
-import type { AgentTool } from "../../runtime/index.js";
+import type { Agent, AgentTool, AgentToolResult } from "../../runtime/index.js";
 
 const mocks = vi.hoisted(() => ({
   attachedLifecycles: [] as Array<{
@@ -34,7 +39,10 @@ vi.mock("../../runtime/internal-hooks.js", () => ({
   },
 }));
 
-import { createToolLoopBatchAdmission } from "./tool-loop-recovery.js";
+import {
+  createToolLoopBatchAdmission,
+  installToolLoopWarningFinalizer,
+} from "./tool-loop-recovery.js";
 
 function codeModeExecTool(): AgentTool {
   return markCodeModeControlTool({
@@ -52,6 +60,18 @@ function batchCall(id: string, args: Record<string, unknown>): InternalToolBatch
     args,
     tool: codeModeExecTool(),
   };
+}
+
+function outcomeContext(toolCallId: string, result: AgentToolResult<unknown>) {
+  return {
+    assistantMessage: {},
+    toolCall: { type: "toolCall", id: toolCallId, name: "read", arguments: {} },
+    args: {},
+    result,
+    isError: false,
+    executionStarted: true,
+    context: { systemPrompt: "", messages: [] },
+  } as unknown as Parameters<NonNullable<Agent["afterToolOutcome"]>>[0];
 }
 
 describe("tool-loop recovery batch admission", () => {
@@ -133,5 +153,26 @@ describe("tool-loop recovery batch admission", () => {
     expect(second).toEqual({});
     expect(firstLifecycle?.commitReadyCalls).not.toBe(secondLifecycle?.commitReadyCalls);
     expect(mocks.attachedLifecycles).toHaveLength(2);
+  });
+});
+
+describe("tool-loop warning finalization", () => {
+  it("consumes already-carried guidance without duplicating it", async () => {
+    const runId = "run-preserved-warning";
+    const toolCallId = "call-preserved-warning";
+    recordLoopWarningForToolCall(toolCallId, "Choose a different action.", runId);
+    const carried = carryLoopWarningToToolResult(
+      { content: [{ type: "text", text: "tool output" }], details: {} },
+      toolCallId,
+      runId,
+    );
+    const agent = {} as Agent;
+    installToolLoopWarningFinalizer({ agent, runId });
+
+    const finalized = await agent.afterToolOutcome?.(outcomeContext(toolCallId, carried));
+
+    expect(finalized).toBeUndefined();
+    expect(JSON.stringify(carried).match(/Tool loop warning:/gu)).toHaveLength(1);
+    expect(consumeLoopWarningForToolCall(toolCallId, runId)).toBeUndefined();
   });
 });

--- a/src/agents/embedded-agent-runner/run/tool-loop-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/tool-loop-recovery.ts
@@ -1,7 +1,10 @@
-import { clearBatchAdmittedToolCallsForRun } from "../../agent-tools.before-tool-call.state.js";
+import {
+  appendLoopWarningToToolResult,
+  clearBatchAdmittedToolCallsForRun,
+} from "../../agent-tools.before-tool-call.state.js";
 import type { HookContext } from "../../agent-tools.before-tool-call.types.js";
 import { normalizeCodeModeExecBeforeHookParams } from "../../code-mode-control-tools.js";
-import type { Agent } from "../../runtime/index.js";
+import type { AfterToolCallResult, Agent } from "../../runtime/index.js";
 import {
   attachInternalToolBatchLifecycle,
   type InternalBeforeToolBatchHook,
@@ -60,4 +63,40 @@ export function installToolLoopRecoveryCleanup(params: { agent: Agent; runId: st
       clearBatchAdmittedToolCallsForRun(params.runId);
     }
   });
+}
+
+/** Attach pending guidance after every result-replacing outcome hook has settled. */
+export function installToolLoopWarningFinalizer(params: { agent: Agent; runId: string }): void {
+  const previousAfterToolOutcome = params.agent.afterToolOutcome?.bind(params.agent);
+  params.agent.afterToolOutcome = async (context, signal) => {
+    let prior: AfterToolCallResult | undefined;
+    try {
+      prior = await previousAfterToolOutcome?.(context, signal);
+    } catch (error) {
+      const result = appendLoopWarningToToolResult(
+        {
+          content: [{ type: "text", text: error instanceof Error ? error.message : String(error) }],
+          details: {},
+        },
+        context.toolCall.id,
+        params.runId,
+      );
+      return { content: result.content, details: result.details, isError: true };
+    }
+
+    const effectiveResult = prior
+      ? {
+          ...context.result,
+          content: prior.content ?? context.result.content,
+          details: prior.details ?? context.result.details,
+          terminate: prior.terminate ?? context.result.terminate,
+        }
+      : context.result;
+    const result = appendLoopWarningToToolResult(
+      effectiveResult,
+      context.toolCall.id,
+      params.runId,
+    );
+    return result === effectiveResult ? prior : { ...prior, content: result.content };
+  };
 }

--- a/src/agents/tool-loop-admission.test.ts
+++ b/src/agents/tool-loop-admission.test.ts
@@ -8,6 +8,8 @@ import { runBeforeToolCallHook } from "./agent-tools.before-tool-call.policy.js"
 import {
   clearBatchAdmittedToolCallsForRun,
   consumeBatchAdmittedToolCall,
+  consumeLoopWarningForToolCall,
+  recordLoopWarningForToolCall,
   resetAdjustedParamsByToolCallIdForTests,
 } from "./agent-tools.before-tool-call.state.js";
 import type { HookContext } from "./agent-tools.before-tool-call.types.js";
@@ -166,10 +168,12 @@ describe("whole-batch tool-loop admission", () => {
   it("cleans an admitted marker when a run ends before the wrapped tool consumes it", async () => {
     const admitted = call("blocked-later", "write", {});
     await admitToolCallBatch([admitted], ctx);
+    recordLoopWarningForToolCall(admitted.toolCall.id, "Choose a different action.", ctx.runId);
 
     clearBatchAdmittedToolCallsForRun(ctx.runId);
 
     expect(consumeBatchAdmittedToolCall(admitted.toolCall.id, ctx.runId)).toBe(false);
+    expect(consumeLoopWarningForToolCall(admitted.toolCall.id, ctx.runId)).toBeUndefined();
   });
 
   it("releases repeated skipped admissions without mutating bounded history", async () => {
@@ -223,6 +227,7 @@ describe("whole-batch tool-loop admission", () => {
       otherRun,
     );
     const admission = await admitToolCallBatch([first, skipped, last], ctx);
+    recordLoopWarningForToolCall(skipped.toolCall.id, "Choose a different action.", ctx.runId);
 
     admission.commitReadyCalls?.([
       { toolCallId: last.toolCall.id, args: last.args },
@@ -239,6 +244,7 @@ describe("whole-batch tool-loop admission", () => {
       last.toolCall.id,
     ]);
     expect(consumeBatchAdmittedToolCall(skipped.toolCall.id, ctx.runId)).toBe(false);
+    expect(consumeLoopWarningForToolCall(skipped.toolCall.id, ctx.runId)).toBeUndefined();
     expect(consumeBatchAdmittedToolCall(sharedId, otherRun.runId)).toBe(true);
     otherAdmission.releaseSkippedCalls?.([sharedId]);
   });

--- a/src/agents/tool-loop-admission.ts
+++ b/src/agents/tool-loop-admission.ts
@@ -11,6 +11,7 @@ import {
 } from "./agent-tools.before-tool-call.diagnostics.js";
 import {
   recordBatchAdmittedToolCall,
+  recordLoopWarningForToolCall,
   releaseBatchAdmittedToolCalls,
 } from "./agent-tools.before-tool-call.state.js";
 import type { HookContext } from "./agent-tools.before-tool-call.types.js";
@@ -28,13 +29,18 @@ type ToolLoopBatchAdmission = InternalBeforeToolBatchResult & {
   releaseSkippedCalls?: (toolCallIds: readonly string[]) => void;
 };
 
+type ToolLoopEvaluation = {
+  intervention?: ToolLoopIntervention;
+  warning?: string;
+};
+
 async function evaluateToolLoopCall(
   call: ToolLoopCall,
   ctx: HookContext,
   stateOverride?: SessionState,
-): Promise<ToolLoopIntervention | undefined> {
+): Promise<ToolLoopEvaluation> {
   if (!ctx.sessionKey || ctx.loopDetection?.enabled !== true) {
-    return undefined;
+    return {};
   }
   const toolName = normalizeToolPolicyName(call.toolName || "tool");
   const { getDiagnosticSessionState, logToolLoopAction, detectToolCallLoop } =
@@ -53,7 +59,7 @@ async function evaluateToolLoopCall(
     ctx.runId ? { runId: ctx.runId } : undefined,
   );
   if (!result.stuck) {
-    return undefined;
+    return {};
   }
   if (result.level === "critical") {
     log.error(`Blocking ${toolName} due to critical loop: ${result.message}`);
@@ -69,13 +75,15 @@ async function evaluateToolLoopCall(
       pairedToolName: result.pairedToolName,
     });
     return {
-      kind: "critical-tool-loop",
-      toolCallId: call.toolCallId ?? "",
-      toolName,
-      actionKey: hashToolCall(toolName, call.params),
-      detector: result.detector,
-      count: result.count,
-      reason: result.message,
+      intervention: {
+        kind: "critical-tool-loop",
+        toolCallId: call.toolCallId ?? "",
+        toolName,
+        actionKey: hashToolCall(toolName, call.params),
+        detector: result.detector,
+        count: result.count,
+        reason: result.message,
+      },
     };
   }
   const baseWarningKey = result.warningKey ?? `${result.detector}:${toolName}`;
@@ -93,8 +101,9 @@ async function evaluateToolLoopCall(
       message: result.message,
       pairedToolName: result.pairedToolName,
     });
+    return { warning: result.message };
   }
-  return undefined;
+  return {};
 }
 
 async function recordToolLoopCall(call: ToolLoopCall, ctx: HookContext): Promise<void> {
@@ -117,11 +126,14 @@ export async function admitSingleToolCallLoop(
   call: ToolLoopCall,
   ctx: HookContext,
 ): Promise<ToolLoopIntervention | undefined> {
-  const intervention = await evaluateToolLoopCall(call, ctx);
-  if (!intervention) {
+  const evaluation = await evaluateToolLoopCall(call, ctx);
+  if (!evaluation.intervention) {
+    if (evaluation.warning && call.toolCallId) {
+      recordLoopWarningForToolCall(call.toolCallId, evaluation.warning, ctx.runId);
+    }
     await recordToolLoopCall(call, ctx);
   }
-  return intervention;
+  return evaluation.intervention;
 }
 
 /**
@@ -181,9 +193,10 @@ export async function admitToolCallBatch(
       projectedState.toolCallHistory?.push(projectedCall);
     }
   };
+  const warnings: Array<{ toolCallId: string; message: string }> = [];
   for (const call of calls) {
     const toolName = normalizeToolPolicyName(call.toolCall.name || "tool");
-    const intervention = await evaluateToolLoopCall(
+    const evaluation = await evaluateToolLoopCall(
       {
         toolName,
         params: call.args,
@@ -192,7 +205,7 @@ export async function admitToolCallBatch(
       ctx,
       projectedState,
     );
-    if (intervention) {
+    if (evaluation.intervention) {
       // Preserve only denial evidence. No call in this batch executed, but a
       // recovery retry must still see same-action siblings that crossed the
       // threshold. Unrelated skipped actions remain valid recovery choices.
@@ -201,14 +214,20 @@ export async function admitToolCallBatch(
           normalizeToolPolicyName(rejectedCall.toolCall.name || "tool"),
           rejectedCall.args,
         );
-        if (rejectedActionKey === intervention.actionKey) {
+        if (rejectedActionKey === evaluation.intervention.actionKey) {
           recordLoopVeto(sessionState, rejectedCall);
         }
       }
-      return { intervention };
+      return { intervention: evaluation.intervention };
+    }
+    if (evaluation.warning) {
+      warnings.push({ toolCallId: call.toolCall.id, message: evaluation.warning });
     }
     // A later sibling must assume this candidate makes no progress.
     projectLoopVeto(call);
+  }
+  for (const warning of warnings) {
+    recordLoopWarningForToolCall(warning.toolCallId, warning.message, ctx.runId);
   }
   for (const call of calls) {
     recordBatchAdmittedToolCall(call.toolCall.id, ctx.runId);

--- a/src/agents/tool-terminal-outcome.test.ts
+++ b/src/agents/tool-terminal-outcome.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   adjustedParamsByToolCallId,
   buildAdjustedParamsKey,
-  preExecutionBlockedToolCallIds,
+  recordPreExecutionBlockedToolCall,
   recordToolExecutionStarted,
   recordToolExecutionTracked,
   resetAdjustedParamsByToolCallIdForTests,
@@ -97,7 +97,7 @@ describe("tool terminal outcome observer", () => {
   it("uses settled pre-execution evidence after active tracking is released", () => {
     const runId = "run-3";
     const toolCallId = "call-blocked";
-    preExecutionBlockedToolCallIds.add(buildAdjustedParamsKey({ runId, toolCallId }));
+    recordPreExecutionBlockedToolCall(toolCallId, runId);
 
     const resolution = createToolTerminalObserver(runId)({
       toolCallId,


### PR DESCRIPTION
Closes #120449

## What Problem This Solves

Warning-tier tool-loop detections were emitted through server-side diagnostics but were not included in the normal tool result returned to the model. This left the model without the existing recovery guidance until the loop reached the critical blocking tier.

## Changes

- attach each emitted warning to its admitted tool call
- carry the warning through successful and failed tool execution without consuming it early
- finalize and consume the warning once after result-replacing outcome hooks have settled
- restore the warning when `afterToolCall` or `afterToolOutcome` replaces tool-result content
- cover server-executed and client-executed tools
- preserve the warning when a tool throws and the failure becomes an error result
- clear pending warning state when an aborted call produces no result
- cover calls without a run ID and atomic batch rejection cleanup
- preserve existing diagnostics and critical-tier blocking behavior

Warning-tier calls continue to execute normally.

## Evidence

### Exact-head CI

- Head: `0a08a336377631bee153430c8b261a1c892fe708`
- CI: https://github.com/openclaw/openclaw/actions/runs/32574281911
- Result: 210 checks passed, 0 failed, and 38 non-applicable checks were skipped

### Focused Regression Validation

The current-head focused suites passed across agent-core, embedded-agent-run, and transcript paths:

```text
Test Files  13 passed
Tests       492 passed
```

The regression coverage includes:

- an actual `runAgentLoop` transcript regression where `afterToolCall` replaces the result content
- an actual `runAgentLoop` transcript regression where `afterToolOutcome` replaces the result content
- final warning restoration after either replacement hook
- one-time consumption without duplicate warning text when the original tool result retains the warning
- warning delivery for successful server and client tool results
- warning preservation when a tool failure becomes an error transcript result
- pending-warning cleanup when an aborted call produces no result

Also verified locally on the changed files:

- formatter check passed
- Oxlint passed with 0 warnings and 0 errors
- `git diff --check` passed

### Exact-head Live Runtime Proof

The exact PR head was built as an isolated Docker image:

```text
Image:    openclaw-pr120572:0a08a336377
Image ID: sha256:36630ffcd11ab280f7ed7065a569418b1f2dd1a265b47934fe642cd13e0243ec
Commit:   0a08a336377631bee153430c8b261a1c892fe708
```

Runtime conditions:

- model: `anthropic/claude-sonnet-4-6`
- read-only container root and proof workspace mount
- no host home directory or Docker socket mounted
- tool surface restricted to `read`
- one assistant batch containing exactly 11 parallel `read` calls
- every call used the same arguments: `{"path":"/work/proof.txt"}`

Observed transcript result:

```text
read calls:                   11
successful read results:     11
results containing payload:  11
results containing warning:  1
warning result ordinal:      11
tool failures:               0
final assistant response:    proof complete
```

The eleventh tool result retained the normal result and appended the guidance:

```text
proof payload

Tool loop warning: WARNING: You have called read 10 times with identical arguments. If this is not making progress, stop retrying and report the task as failed.
```

This confirms that warning-tier calls still execute, the model receives the warning through the committed tool-result transcript, and the warning is emitted and consumed exactly once.

The PR container received only a relay placeholder. A temporary relay held the provider credential, forwarded only `/v1/messages`, capped the proof at four requests, and was deleted afterward. Exact-key scans found 0 matches across 33,482 tracked files and 3 temporary proof files.
