### PR TITLE
fix: uninstall removes unloaded gateway service definitions

### DIFF
--- a/src/commands/uninstall.test.ts
+++ b/src/commands/uninstall.test.ts
@@ -1,5 +1,5 @@
 // Uninstall command tests cover cleanup flow, prompts, and runtime messages.
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   cleanupCommandLogMessages,
   createCleanupCommandRuntime,
@@ -11,6 +11,19 @@ import {
   silenceCleanupCommandRuntime,
 } from "./cleanup-command.test-support.js";
 
+const gatewayService = vi.hoisted(() => ({
+  label: "LaunchAgent",
+  loadedText: "loaded",
+  notLoadedText: "not loaded",
+  isLoaded: vi.fn(async () => false),
+  stop: vi.fn(async () => {}),
+  uninstall: vi.fn(async () => {}),
+}));
+
+vi.mock("../daemon/service.js", () => ({
+  resolveGatewayService: () => gatewayService,
+}));
+
 const { uninstallCommand } = await import("./uninstall.js");
 
 describe("uninstallCommand", () => {
@@ -19,7 +32,39 @@ describe("uninstallCommand", () => {
   beforeEach(() => {
     resetCleanupCommandMocks();
     silenceCleanupCommandRuntime(runtime);
+    gatewayService.isLoaded.mockResolvedValue(false);
+    gatewayService.stop.mockResolvedValue(undefined);
+    gatewayService.uninstall.mockResolvedValue(undefined);
   });
+
+  it.each([
+    { loadProbe: true, expectedStops: 1 },
+    { loadProbe: false, expectedStops: 0 },
+    { loadProbe: new Error("launchctl unavailable"), expectedStops: 0 },
+  ])(
+    "uninstalls the service definition when the load probe returns $loadProbe",
+    async ({ loadProbe, expectedStops }) => {
+      if (loadProbe instanceof Error) {
+        gatewayService.isLoaded.mockRejectedValueOnce(loadProbe);
+      } else {
+        gatewayService.isLoaded.mockResolvedValueOnce(loadProbe);
+      }
+
+      await uninstallCommand(runtime, {
+        service: true,
+        yes: true,
+        nonInteractive: true,
+      });
+
+      expect(gatewayService.stop).toHaveBeenCalledTimes(expectedStops);
+      expect(gatewayService.uninstall).toHaveBeenCalledOnce();
+      if (loadProbe instanceof Error) {
+        expect(runtime.error).toHaveBeenCalledWith(
+          expect.stringContaining("continuing with uninstall"),
+        );
+      }
+    },
+  );
 
   it("recommends creating a backup before removing state or workspaces", async () => {
     await uninstallCommand(runtime, {

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -58,43 +58,41 @@ function buildScopeSelection(opts: UninstallOptions): {
   return { scopes, hadExplicit };
 }
 
-async function stopAndUninstallService(runtime: RuntimeEnv): Promise<boolean> {
+async function stopAndUninstallService(runtime: RuntimeEnv): Promise<void> {
   if (isNixMode) {
     // Nix owns service lifecycle in Nix mode; uninstalling via launchd/systemd would fight the profile.
     runtime.error(
       `Nix mode detected; service uninstall is disabled. Manage the service through your Nix profile instead, then run ${formatCliCommand("openclaw status")} to verify.`,
     );
-    return false;
+    return;
   }
   const service = resolveGatewayService();
-  let loaded;
+  let loaded: boolean | undefined;
   try {
     loaded = await service.isLoaded({ env: process.env });
   } catch (err) {
     runtime.error(
-      `Gateway service check failed: ${formatErrorMessage(err)}. Run ${formatCliCommand("openclaw gateway status --deep")} for service diagnostics.`,
+      `Gateway service check failed: ${formatErrorMessage(err)}; continuing with uninstall. Run ${formatCliCommand("openclaw gateway status --deep")} if removal does not complete.`,
     );
-    return false;
   }
-  if (!loaded) {
+  if (loaded === false) {
     runtime.log(`Gateway service ${service.notLoadedText}.`);
-    return true;
   }
-  try {
-    await service.stop({ env: process.env, stdout: process.stdout });
-  } catch (err) {
-    runtime.error(
-      `Gateway stop failed: ${formatErrorMessage(err)}. Run ${formatCliCommand("openclaw gateway status --deep")} before retrying uninstall.`,
-    );
+  if (loaded) {
+    try {
+      await service.stop({ env: process.env, stdout: process.stdout });
+    } catch (err) {
+      runtime.error(
+        `Gateway stop failed: ${formatErrorMessage(err)}. Run ${formatCliCommand("openclaw gateway status --deep")} before retrying uninstall.`,
+      );
+    }
   }
   try {
     await service.uninstall({ env: process.env, stdout: process.stdout });
-    return true;
   } catch (err) {
     runtime.error(
       `Gateway uninstall failed: ${formatErrorMessage(err)}. Run ${formatCliCommand("openclaw gateway status --deep")} for the service state.`,
     );
-    return false;
   }
 }
 


### PR DESCRIPTION
Closes #120574

## What Problem This Solves

Fixes an issue where users uninstalling the gateway service would be told it was not loaded while an unloaded service definition remained installed. On macOS, the leftover LaunchAgent plist could be loaded again at a later login even though `openclaw uninstall --service` had completed.

## Why This Change Was Made

The command now uses the load probe only to decide whether a separate stop step is needed. It always delegates removal to the platform's idempotent uninstall implementation, including when the service is not loaded or the load probe fails.

This deliberately does not add system-level LaunchDaemon management; that broader product decision remains in #14251.

## User Impact

Operators can now remove disabled, unloaded, or otherwise unprobeable gateway service definitions with the normal uninstall command. Loaded services are still stopped before removal, while unloaded services no longer leave autostart definitions behind.

## Evidence

- `node scripts/run-vitest.mjs src/commands/uninstall.test.ts` — 11 tests passed.
- Regression coverage proves that loaded, unloaded, and failed-probe states all invoke platform uninstall, while only the loaded state invokes stop.
- `node scripts/run-oxlint.mjs src/commands/uninstall.ts src/commands/uninstall.test.ts` — passed.
- `node_modules/.bin/oxfmt --check --threads=1 src/commands/uninstall.ts src/commands/uninstall.test.ts` — passed.
- `pnpm tsgo:core` and `pnpm tsgo:core:test` — passed on the final diff.
- `pnpm check:test-types` — passed before the final message/assertion-only refinement.
- `git diff --check` — passed.
- Production delta: 13 additions, 15 deletions (net -2); tests: 46 additions, 1 deletion.

AI-assisted: yes. The implementation and tests were produced with Codex and manually reviewed against the command entry point, all three platform uninstall implementations, sibling reset/configure flows, current `main`, and relevant file history. The repository's `$autoreview` skill was not available in this Codex session; no subagent review was run.

## Release note

CLI: ensure gateway service uninstall removes definitions even when the service is unloaded or its load-state probe fails.
