### PR TITLE
fix(codex): render dynamic tool images in chat

### DIFF
--- a/extensions/codex/src/app-server/event-projector-tool-progress.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-progress.ts
@@ -67,6 +67,7 @@ export type ToolTranscriptResultInput = {
   id: string;
   name: string;
   text?: string;
+  images?: Array<{ url: string }>;
   isError: boolean;
   details?: unknown;
   resultContentSource?: "network";

--- a/extensions/codex/src/app-server/event-projector-tool-transcript.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-transcript.ts
@@ -35,6 +35,7 @@ import {
   type ToolTranscriptCallInput,
   type ToolTranscriptResultInput,
 } from "./event-projector-tool-progress.js";
+import { invalidInlineImageText, sanitizeInlineImageDataUrl } from "./image-payload-sanitizer.js";
 import { resolveCodexLocalRuntimeAttribution } from "./local-runtime-attribution.js";
 import type {
   CodexDynamicToolCallOutputContentItem,
@@ -167,10 +168,28 @@ export class CodexToolTranscriptProjection {
     },
     resultContentSource?: "network",
   ): void {
+    const contentItems = params.contentItems.map((item) => {
+      if (item.type !== "inputImage") {
+        return item;
+      }
+      const imageUrl =
+        typeof item.imageUrl === "string" ? sanitizeInlineImageDataUrl(item.imageUrl) : undefined;
+      return imageUrl
+        ? { type: "inputImage" as const, imageUrl }
+        : {
+            type: "inputText" as const,
+            text: invalidInlineImageText("codex dynamic tool transcript"),
+          };
+    });
     this.recordToolResult({
       id: params.callId,
       name: params.tool,
-      text: collectDynamicToolContentText(params.contentItems),
+      text: collectDynamicToolContentText(contentItems),
+      images: contentItems.flatMap((item) =>
+        item.type === "inputImage" && typeof item.imageUrl === "string"
+          ? [{ url: item.imageUrl }]
+          : [],
+      ),
       isError: !params.success,
       details: params.details,
       ...(resultContentSource ? { resultContentSource } : {}),
@@ -618,6 +637,7 @@ export class CodexToolTranscriptProjection {
           content: text,
           text,
         },
+        ...(params.images ?? []).map((image) => ({ type: "image", url: image.url })),
       ],
       ...(params.details !== undefined ? { details: params.details } : {}),
       ...(params.resultContentSource

--- a/extensions/codex/src/app-server/event-projector.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/event-projector.dynamic-tools.test.ts
@@ -17,6 +17,9 @@ import {
 
 registerCodexEventProjectorTestLifecycle();
 
+const PNG_1X1 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+
 describe("CodexAppServerEventProjector dynamic tool projection", () => {
   it("records dynamic OpenClaw tool calls in mirrored transcript snapshots", async () => {
     const projector = await createProjector(undefined, {
@@ -76,6 +79,63 @@ describe("CodexAppServerEventProjector dynamic tool projection", () => {
     ).toMatchObject({
       turnTainted: true,
     });
+  });
+
+  it("preserves validated dynamic tool images in mirrored transcript snapshots", async () => {
+    const projector = await createProjector();
+    const imageUrl = `data:image/png;base64,${PNG_1X1}`;
+
+    projector.recordDynamicToolCall({
+      callId: "call-computer-screenshot",
+      tool: "computer",
+      arguments: { action: "screenshot" },
+    });
+    projector.recordDynamicToolResult({
+      callId: "call-computer-screenshot",
+      tool: "computer",
+      success: true,
+      contentItems: [
+        { type: "inputText", text: "screenshot 1x1" },
+        { type: "inputImage", imageUrl },
+      ],
+    });
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    const toolResultMessage = requireRecord(
+      result.messagesSnapshot.find((message) => message.role === "toolResult"),
+      "tool result message",
+    );
+    expect(requireArray(toolResultMessage.content, "tool result content")).toEqual([
+      expect.objectContaining({
+        type: "toolResult",
+        toolCallId: "call-computer-screenshot",
+        text: "screenshot 1x1",
+      }),
+      { type: "image", url: imageUrl },
+    ]);
+  });
+
+  it("replaces invalid dynamic tool transcript images with safe text", async () => {
+    const projector = await createProjector();
+
+    projector.recordDynamicToolResult({
+      callId: "call-invalid-image",
+      tool: "computer",
+      success: true,
+      contentItems: [{ type: "inputImage", imageUrl: "data:image/png;base64,not base64!" }],
+    });
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    const toolResultMessage = requireRecord(
+      result.messagesSnapshot.find((message) => message.role === "toolResult"),
+      "tool result message",
+    );
+    const content = requireArray(toolResultMessage.content, "tool result content");
+    expect(content).toHaveLength(1);
+    expect(requireRecord(content[0], "tool result content item").text).toContain(
+      "invalid inline image data",
+    );
+    expect(JSON.stringify(content)).not.toContain("not base64!");
   });
 
   it("retains MCP App preview details in mirrored dynamic tool results", async () => {

--- a/src/gateway/server-methods/chat-history-budget.test.ts
+++ b/src/gateway/server-methods/chat-history-budget.test.ts
@@ -1,7 +1,10 @@
 // Covers the chat.history final byte-budget fallback, including the sentinel
 // that prevents an empty (blank) transcript from being returned to the dashboard.
 import { describe, expect, it } from "vitest";
-import { enforceChatHistoryFinalBudget } from "./chat-history-budget.js";
+import {
+  enforceChatHistoryFinalBudget,
+  replaceOversizedChatHistoryMessages,
+} from "./chat-history-budget.js";
 
 type DisplayMessage = {
   role?: string;
@@ -73,5 +76,41 @@ describe("enforceChatHistoryFinalBudget", () => {
     expect(firstText(result.messages)).toContain("chat.history unavailable");
     // The sentinel does not carry the oversized source metadata.
     expect((result.messages[0] as Record<string, unknown>)["__openclaw"]).toBeUndefined();
+  });
+});
+
+describe("replaceOversizedChatHistoryMessages", () => {
+  it("preserves bounded image output above the ordinary message cap", () => {
+    const message = {
+      role: "toolResult",
+      content: [
+        { type: "toolResult", text: "screenshot" },
+        { type: "image", url: `data:image/jpeg;base64,${"a".repeat(2_000)}` },
+      ],
+    };
+
+    const result = replaceOversizedChatHistoryMessages({
+      messages: [message],
+      maxSingleMessageBytes: 1_000,
+      maxImageMessageBytes: 4_000,
+    });
+
+    expect(result).toEqual({ messages: [message], replacedCount: 0 });
+  });
+
+  it("still replaces image output above the image-specific cap", () => {
+    const result = replaceOversizedChatHistoryMessages({
+      messages: [
+        {
+          role: "toolResult",
+          content: [{ type: "image", url: `data:image/jpeg;base64,${"a".repeat(4_000)}` }],
+        },
+      ],
+      maxSingleMessageBytes: 1_000,
+      maxImageMessageBytes: 2_000,
+    });
+
+    expect(result.replacedCount).toBe(1);
+    expect(firstText(result.messages)).toContain("chat.history omitted: message too large");
   });
 });

--- a/src/gateway/server-methods/chat-history-budget.ts
+++ b/src/gateway/server-methods/chat-history-budget.ts
@@ -2,6 +2,7 @@ import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { logLargePayload } from "../../logging/diagnostic-payload.js";
 
 export const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
+export const CHAT_HISTORY_MAX_IMAGE_MESSAGE_BYTES = 1024 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
 const CHAT_HISTORY_UNAVAILABLE_SENTINEL =
   "[chat.history unavailable: transcript too large to display; the full history is preserved on disk]";
@@ -59,6 +60,7 @@ function buildOversizedHistoryPlaceholder(message?: unknown): Record<string, unk
 export function replaceOversizedChatHistoryMessages(params: {
   messages: unknown[];
   maxSingleMessageBytes: number;
+  maxImageMessageBytes?: number;
 }): { messages: unknown[]; replacedCount: number } {
   const { messages, maxSingleMessageBytes } = params;
   if (messages.length === 0) {
@@ -66,7 +68,26 @@ export function replaceOversizedChatHistoryMessages(params: {
   }
   let replacedCount = 0;
   const next = messages.map((message) => {
-    if (jsonUtf8Bytes(message) <= maxSingleMessageBytes) {
+    const content =
+      message && typeof message === "object"
+        ? (message as { content?: unknown }).content
+        : undefined;
+    const hasImage =
+      Array.isArray(content) &&
+      content.some((block) => {
+        const type =
+          block && typeof block === "object" ? (block as { type?: unknown }).type : undefined;
+        return (
+          type === "image" ||
+          type === "image_url" ||
+          type === "input_image" ||
+          type === "openclaw_pairing_qr"
+        );
+      });
+    const messageLimit = hasImage
+      ? Math.max(maxSingleMessageBytes, params.maxImageMessageBytes ?? maxSingleMessageBytes)
+      : maxSingleMessageBytes;
+    if (jsonUtf8Bytes(message) <= messageLimit) {
       return message;
     }
     replacedCount += 1;

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -44,6 +44,7 @@ import {
 import { scheduleChatHistoryManagedMediaCleanup } from "./chat-assistant-content.js";
 import {
   CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
+  CHAT_HISTORY_MAX_IMAGE_MESSAGE_BYTES,
   enforceChatHistoryFinalBudget,
   replaceOversizedChatHistoryMessages,
   reportOmittedChatHistory,
@@ -328,6 +329,7 @@ async function handleChatHistoryRequest({
   const replaced = replaceOversizedChatHistoryMessages({
     messages: normalized,
     maxSingleMessageBytes: perMessageHardCap,
+    maxImageMessageBytes: Math.min(CHAT_HISTORY_MAX_IMAGE_MESSAGE_BYTES, maxHistoryBytes),
   });
   scheduleChatHistoryManagedMediaCleanup({
     sessionKey,

--- a/ui/src/pages/chat/chat-message-visible-content.ts
+++ b/ui/src/pages/chat/chat-message-visible-content.ts
@@ -1,0 +1,19 @@
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
+
+/** Media output remains visible even when the user hides tool-call chrome. */
+export function messageHasVisibleImage(message: unknown): boolean {
+  const content = asRecord(message)?.content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some((block) => {
+    const type = normalizeLowercaseStringOrEmpty(asRecord(block)?.type);
+    return (
+      type === "image" ||
+      type === "image_url" ||
+      type === "input_image" ||
+      type === "openclaw_pairing_qr"
+    );
+  });
+}

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -20,6 +20,7 @@ import { extractTextCached } from "../../lib/chat/message-extract.ts";
 import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { normalizeOptionalString } from "../../lib/string-coerce.ts";
+import { messageHasVisibleImage } from "./chat-message-visible-content.ts";
 import {
   buildCompactionDividerItem,
   clearWorkingProgress,
@@ -256,7 +257,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       });
     }
 
-    if (!props.showToolCalls && isToolResult) {
+    if (!props.showToolCalls && isToolResult && !messageHasVisibleImage(msg)) {
       continue;
     }
 
@@ -475,7 +476,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       }
     }
     const tool = toolItems[i];
-    if (tool && props.showToolCalls) {
+    if (tool && (props.showToolCalls || messageHasVisibleImage(tool.message))) {
       const toolItem: ChatItem = {
         kind: "message",
         key: tool.key,

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -9,6 +9,7 @@ import { normalizeMessage, normalizeRoleForGrouping } from "../../lib/chat/messa
 import { senderIdentityKey } from "../../lib/chat/sender-label.ts";
 import { extractToolCardsCached, isToolCardError } from "../../lib/chat/tool-cards.ts";
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
+import { messageHasVisibleImage } from "./chat-message-visible-content.ts";
 import {
   resolveMessageToolUseId,
   resolveToolBlockId,
@@ -554,7 +555,14 @@ function isCollapsibleWorkGroup(item: TurnRenderItem): item is MessageGroup {
     return false;
   }
   const role = item.role.toLowerCase();
-  return role === "tool" || (role === "assistant" && !assistantGroupIsForwardedBoundary(item));
+  return (
+    (role === "tool" && !toolGroupHasVisibleImage(item)) ||
+    (role === "assistant" && !assistantGroupIsForwardedBoundary(item))
+  );
+}
+
+function toolGroupHasVisibleImage(group: MessageGroup): boolean {
+  return group.messages.some(({ message }) => messageHasVisibleImage(message));
 }
 
 // Attachment/canvas/media-only replies carry no text but are still the turn's
@@ -741,7 +749,11 @@ export function coalesceActivityRuns(
     groups = [];
   };
   for (const item of items) {
-    if (item.kind === "group" && item.role.toLowerCase() === "tool") {
+    if (
+      item.kind === "group" &&
+      item.role.toLowerCase() === "tool" &&
+      !toolGroupHasVisibleImage(item)
+    ) {
       groups.push(item);
       continue;
     }

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -701,6 +701,87 @@ describe("collapseCompletedTurnWork", () => {
     expect(requireGroup(items[2]).role).toBe("assistant");
   });
 
+  it("keeps image-bearing tool results outside completed-work and activity rollups", () => {
+    const items = collapsedItems({
+      messages: [
+        userMessage("capture it", 1_000),
+        toolResultMessage(
+          "call-screenshot",
+          "computer",
+          [
+            {
+              type: "toolResult",
+              id: "call-screenshot",
+              name: "computer",
+              text: "screenshot 1x1",
+            },
+            { type: "image", url: "data:image/png;base64,cG5n" },
+          ],
+          2_000,
+        ),
+        assistantMessage("Captured.", 3_000),
+      ],
+    });
+
+    expect(items.map((item) => item.kind)).toEqual(["group", "group", "group"]);
+    expect(requireGroup(items[1]).role).toBe("tool");
+    expect(coalesceActivityRuns(items).map((item) => item.kind)).toEqual([
+      "group",
+      "group",
+      "group",
+    ]);
+  });
+
+  it("keeps persisted image output when tool calls are hidden", () => {
+    const groups = messageGroups({
+      messages: [
+        userMessage("capture it", 1_000),
+        toolResultMessage(
+          "call-screenshot",
+          "computer",
+          [
+            {
+              type: "toolResult",
+              id: "call-screenshot",
+              name: "computer",
+              text: "screenshot 1x1",
+            },
+            { type: "image", url: "data:image/png;base64,cG5n" },
+          ],
+          2_000,
+        ),
+      ],
+      showToolCalls: false,
+    });
+
+    expect(groups.map((group) => group.role)).toEqual(["user", "tool"]);
+    expect(firstMessageContent(groupAt(groups, 1))).toContainEqual({
+      type: "image",
+      url: "data:image/png;base64,cG5n",
+    });
+  });
+
+  it("keeps live image output when tool calls are hidden", () => {
+    const groups = messageGroups({
+      toolMessages: [
+        toolResultMessage(
+          "call-live-screenshot",
+          "computer",
+          [{ type: "image", url: "data:image/png;base64,cG5n" }],
+          2_000,
+        ),
+      ],
+      showToolCalls: false,
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groupAt(groups, 0).role).toBe("tool");
+    expect(firstMessageContent(groupAt(groups, 0))).toContainEqual({
+      type: "image",
+      url: "data:image/png;base64,cG5n",
+    });
+  });
+
   it("keeps search matches visible instead of folding them into a rollup", () => {
     const items = collapseCompletedTurnWork(
       coalesceStreamRuns(

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -413,11 +413,11 @@ export function renderGroupedMessage(
                     ? html`<span class="chat-tool-msg-summary__preview">${toolPreview}</span>`
                     : nothing}
               </button>
+              ${renderMessageImages(images, imageRenderOptions)}
               ${toolMessageExpanded
                 ? html`
                     <div class="chat-tool-msg-body">
                       ${renderPairingQrExpiryNotices(pairingQrExpiryNotices)}
-                      ${renderMessageImages(images, imageRenderOptions)}
                       ${renderAssistantAttachments(
                         visibleAttachments,
                         opts.localMediaPreviewRoots ?? [],

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -13,6 +13,7 @@ import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
 import { fnv1aUtf16 } from "../../../lib/fnv1a.ts";
 import { resolveIdentityHue } from "../../../lib/identity-avatar.ts";
 import { renderChatAvatar } from "../chat-avatar.ts";
+import { messageHasVisibleImage } from "../chat-message-visible-content.ts";
 import type { TurnRecap } from "../chat-progress.ts";
 import {
   isPendingSendMessage,
@@ -331,6 +332,7 @@ export function renderActivityGroup(
 
 export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroupOptions) {
   const normalizedRole = normalizeRoleForGrouping(group.role);
+  const hasVisibleImage = group.messages.some((item) => messageHasVisibleImage(item.message));
   const isWorkspaceConflict = group.messages.every((item) =>
     Boolean(workspaceResultConflictFromTranscript(item.message)),
   );
@@ -370,7 +372,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
   // Aggregate usage/cost/model across all messages in the group
   const meta = extractGroupMeta(group, opts.contextWindow ?? null);
 
-  if (normalizedRole === "tool" && opts.showToolCalls === false) {
+  if (normalizedRole === "tool" && opts.showToolCalls === false && !hasVisibleImage) {
     return nothing;
   }
 
@@ -379,7 +381,11 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
       ? group.messages.flatMap((item) => extractToolCardsCached(item.message, item.key))
       : [];
 
-  if (normalizedRole === "tool" && (group.messages.length > 1 || groupedToolCards.length > 1)) {
+  if (
+    normalizedRole === "tool" &&
+    !hasVisibleImage &&
+    (group.messages.length > 1 || groupedToolCards.length > 1)
+  ) {
     return renderActivityGroup([group], opts);
   }
 

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -2148,6 +2148,35 @@ describe("grouped chat rendering", () => {
     expect(container.querySelector(".chat-tool-msg-body")).toBeNull();
   });
 
+  it("renders tool result images while their detail disclosure is collapsed", () => {
+    const container = document.createElement("div");
+    const imageUrl = "data:image/png;base64,cG5n";
+    const group = createToolGroup("tool-image-group", [
+      createMessageEntry(
+        "tool-image-message",
+        createToolResultMessage("call-screenshot", "computer", [
+          createToolResultBlock("call-screenshot", "computer", "screenshot 1x1"),
+          createMediaBlock({ url: imageUrl, alt: "Computer screenshot" }),
+        ]),
+      ),
+    ]);
+
+    renderMessageGroups(container, [group], {
+      showToolCalls: false,
+      isToolMessageExpanded: () => false,
+    });
+
+    expect(
+      expectElement(container, ".chat-message-image", HTMLImageElement).getAttribute("src"),
+    ).toBe(imageUrl);
+    expect(container.querySelector(".chat-tool-msg-body")).toBeNull();
+    expect(
+      expectElement(container, ".chat-tool-msg-summary", HTMLButtonElement).getAttribute(
+        "aria-expanded",
+      ),
+    ).toBe("false");
+  });
+
   it("collapses paired parallel tool cards from one message into an activity group", () => {
     const container = document.createElement("div");
     const group = createToolGroup("parallel-tool-group", [


### PR DESCRIPTION
## What Problem This Solves

Codex dynamic tools can return image content successfully, but the durable transcript projection flattened those images to text. Control UI then hid or rolled up the surviving tool result, and chat-history budgeting replaced a typical screenshot-sized message with a message-too-large placeholder. The result was a successful computer screenshot that never rendered in chat.

## What Changed

- Preserve validated dynamic-tool image outputs as top-level transcript image blocks.
- Replace invalid inline image payloads with safe explanatory text.
- Keep image-bearing tool results outside completed-work and activity rollups.
- Render tool-result images even when tool details are collapsed or tool calls are hidden.
- Give image-bearing history messages a bounded 1 MiB per-message allowance while preserving the 128 KiB ordinary-message cap and existing total-history cap.

## Evidence

- Seven focused Codex projector, chat grouping/rendering, and history-budget suites: 387 tests passed.
- Changed-file Oxlint: passed.
- Changed-file Oxfmt check: passed.
- Full pnpm build, including Control UI compressed assets and performance checks: passed.
- Live pinned CUA Driver 0.19.0 gateway replay: the stored screenshot survives chat.history as toolResult + image with a 418,067-character data URL and no omitted-message placeholder.
- Live Control UI verification: the Linux XFCE screenshot visibly renders inline with the Computer screenshot tool result.

## Impact

Computer screenshots and other dynamic-tool images survive transcript persistence, history transport, grouping, and rendering, so they appear inline in Control UI chat without requiring users to expand tool details.