### PR TITLE
fix(plugins): add fail-closed foreign session ID check (#120215 follow-up)

### DIFF
--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -473,11 +473,21 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
         }
         return ownerPluginId;
       }
+      // Fail-closed: reject keyed runs whose session ID does not match the
+      // keyed entry. The SQLite accessor cannot scan cross-agent stores, so
+      // an unscoped lookup would throw rather than reject cleanly. Also
+      // covers keys with no persisted entry. Keyless runs are preserved.
+      const resolvedSessionId = normalizeOptionalString(target?.sessionId ?? params.sessionId);
+      if (sessionKey && resolvedSessionId && (!entry || resolvedSessionId !== entry.sessionId)) {
+        throw new Error(
+          `Plugin "${pluginId}" may execute session "${resolvedSessionId}" only through its own session key "${sessionKey}".`,
+        );
+      }
       assertSessionIdentitiesOwned({
         action: "run",
         agentId: ownershipAgentId,
         sessionFiles: [params.sessionFile],
-        sessionIds: [target?.sessionId ?? params.sessionId],
+        sessionIds: [resolvedSessionId],
         sessionKeys: [target?.sessionKey ?? params.sessionKey],
         storePath: ownershipStorePath,
       });

--- a/src/plugins/registry.runtime-config.sqlite.test.ts
+++ b/src/plugins/registry.runtime-config.sqlite.test.ts
@@ -94,8 +94,86 @@ describe("plugin registry SQLite session ownership", () => {
             ...runParams,
             sessionId: lockedSessionId,
           }),
-        ).rejects.toThrow('owned by plugin "harness-owner"');
+        ).rejects.toThrow(/may execute session.*only through its own session key/);
         expect(runEmbeddedAgent).toHaveBeenCalledOnce();
+      } finally {
+        closeOpenClawAgentDatabasesForTest();
+      }
+    });
+  });
+
+  it("rejects a foreign locked session ID from a different agent store", async () => {
+    await withTempHome(async (home) => {
+      const ownKey = "agent:main:own-session";
+      const ownSessionId = "own-session-id";
+      const foreignKey = "agent:researcher:dashboard:foreign-locked";
+      const foreignSessionId = "foreign-locked-session-id";
+      try {
+        // Seed own session in agent main's store
+        await replaceSessionEntry(
+          { agentId: "main", sessionKey: ownKey },
+          { sessionId: ownSessionId, updatedAt: 1 },
+        );
+        // Seed foreign locked session in a different agent's store
+        await replaceSessionEntry(
+          { agentId: "researcher", sessionKey: foreignKey },
+          {
+            sessionId: foreignSessionId,
+            updatedAt: 2,
+            agentHarnessId: "test-harness",
+            modelSelectionLocked: true,
+          },
+        );
+
+        const runtime = createPluginRuntime();
+        const runEmbeddedAgent = vi.fn(async () => ({ ok: true })) as unknown as ReturnType<
+          typeof createPluginRuntime
+        >["agent"]["runEmbeddedAgent"];
+        Object.defineProperty(runtime.agent, "runEmbeddedAgent", {
+          configurable: true,
+          value: runEmbeddedAgent,
+        });
+        const pluginRegistry = createTestRegistry(runtime);
+        const ownerRecord = createPluginRecord({
+          id: "harness-owner",
+          source: "/plugins/harness-owner/index.js",
+          origin: "bundled",
+          enabled: true,
+          configSchema: false,
+        });
+        const callerRecord = createPluginRecord({
+          id: "extractor-plugin",
+          source: "/plugins/extractor-plugin/index.js",
+          origin: "bundled",
+          enabled: true,
+          configSchema: false,
+        });
+        const ownerApi = pluginRegistry.createApi(ownerRecord, { config: {} as OpenClawConfig });
+        const callerApi = pluginRegistry.createApi(callerRecord, {
+          config: {} as OpenClawConfig,
+        });
+        ownerApi.registerAgentHarness({
+          id: "test-harness",
+          label: "Test Harness",
+          supports: () => ({ supported: true }),
+          runAttempt: async () => {
+            throw new Error("unused");
+          },
+        });
+
+        // Plugin uses its own key + a foreign locked session ID from a different agent.
+        // The pre-scan guard rejects this before any SQLite store listing.
+        await expect(
+          callerApi.runtime.agent.runEmbeddedAgent({
+            sessionId: foreignSessionId,
+            sessionKey: ownKey,
+            workspaceDir: path.join(home, "workspace"),
+            prompt: "continue",
+            timeoutMs: 1,
+            runId: "run-cross-store",
+          } as Parameters<PluginRuntime["agent"]["runEmbeddedAgent"]>[0]),
+        ).rejects.toThrow(/may execute session.*only through its own session key/);
+        expect(runEmbeddedAgent).not.toHaveBeenCalled();
       } finally {
         closeOpenClawAgentDatabasesForTest();
       }


### PR DESCRIPTION
## What Problem This Solves

PR #120215 (merged) derived the agent scope and incognito store path from the session key, fixing the original `Cannot resolve SQLite session scope without an agent id` error. However, it does not validate that a supplied session ID belongs to the keyed entry before narrowing the SQLite store scan. A plugin can supply its own session key plus a foreign locked session ID and bypass the ownership check.

## Changes

Add a fail-closed rejection **for keyed runs only** (where a sessionKey is provided): when the caller supplies a session ID that does not match the keyed entry (or the key has no persisted entry at all), reject immediately before the SQLite store scan. The SQLite accessor cannot perform a cross-agent global scan, so an unscoped lookup would throw rather than reject cleanly.

**Keyless runs (no sessionKey) are preserved** — with no key there is no keyed entry to validate against, so the ownership scan proceeds as before.

## Evidence

### Real behavior proof (from local production plugin invocation)

L1 extraction with the fix applied (120s timeout, no longer timing out):
```
2026-08-09T18:32:15 L1 >>> model=laguna-xs-2.1, timeout=120000ms, userLen=7141
2026-08-09T18:32:46 L1 <<< 30681ms, output=566 chars
2026-08-09T18:33:37 L1 >>> model=laguna-xs-2.1, timeout=120000ms, userLen=12049
2026-08-09T18:35:09 L1 <<< 91994ms, output=1225 chars
```

### Real SQLite regression (`registry.runtime-config.sqlite.test.ts`)
- Same-agent store: own key + own sessionId → resolves
- Same-agent store: own key + foreign locked sessionId → rejects `may execute session...only through its own session key` (pre-scan guard)
- **Cross-agent store**: own key + foreign locked sessionId from a different agent's store → rejects `may execute session...only through its own session key` (pre-scan guard, before SQLite listing)
- Cross-agent agentId → rejects `does not match session key agent`

### Mock regression (`registry.runtime-config.test.ts`)
Same scenarios with mock accessor, plus gateway request carrying foreign locked session ID + own key still rejects (shared path unchanged).

## Verification

```bash
node scripts/run-vitest.mjs src/plugins/registry.runtime-config.test.ts src/plugins/registry.runtime-config.sqlite.test.ts
```

## Release Note

Embedded-agent foreign session ID is rejected fail-closed for keyed runs, preventing a P1 security boundary bypass. Keyless runs are preserved.