### PR TITLE
fix(gateway): retain work admission across hosted wizard steps

### DIFF
--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -1,6 +1,12 @@
 // Wizard server-method tests cover stable lifecycle errors for process-local sessions.
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
+import { createSafeGatewayRestartPreflight } from "../../infra/restart-coordinator.js";
+import {
+  getActiveGatewayRootWorkCount,
+  resetGatewayWorkAdmission,
+  runWithGatewayIndependentRootWorkAdmission,
+} from "../../process/gateway-work-admission.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { createDeferred } from "../../shared/deferred.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
@@ -138,6 +144,44 @@ describe("hosted wizard runtime isolation", () => {
 });
 
 describe("wizard setup ownership", () => {
+  it("retains gateway work admission between requests until the wizard settles", async () => {
+    resetGatewayWorkAdmission();
+    const runnerSettled = createDeferred();
+    const tracker = createWizardSessionTracker();
+    const context = {
+      ...tracker,
+      wizardRunner: async (_opts: unknown, _runtime: RuntimeEnv, prompter: WizardPrompter) => {
+        prompter.progress("working");
+        await runnerSettled.promise;
+      },
+    };
+
+    try {
+      await runWithGatewayIndependentRootWorkAdmission(async () => {
+        const respond = vi.fn();
+        await expectDefined(
+          wizardHandlers["wizard.start"],
+          "wizard.start test invariant",
+        )({ params: { mode: "local" }, respond, context } as never);
+        expect(respond.mock.calls[0]?.[1]).toMatchObject({ status: "running" });
+      });
+
+      expect(getActiveGatewayRootWorkCount()).toBe(1);
+      expect(createSafeGatewayRestartPreflight()).toMatchObject({
+        safe: false,
+        blockers: [expect.objectContaining({ kind: "root-request", count: 1 })],
+      });
+      runnerSettled.resolve();
+      await vi.waitFor(() => {
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
+      });
+      expect(createSafeGatewayRestartPreflight().safe).toBe(true);
+    } finally {
+      runnerSettled.resolve();
+      resetGatewayWorkAdmission();
+    }
+  });
+
   it("blocks a replacement wizard until the cancelled runner settles", async () => {
     const runnerSettled = createDeferred();
     const tracker = createWizardSessionTracker();

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -12,6 +12,7 @@ import {
   validateWizardStatusParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { OnboardOptions } from "../../commands/onboard-types.js";
+import { retainGatewayRootWorkAdmissionContinuation } from "../../process/gateway-work-admission.js";
 import { createNonExitingRuntime, ExitError, type RuntimeEnv } from "../../runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import {
@@ -71,6 +72,15 @@ function readWizardStatus(session: WizardSession) {
 
 function sanitizeWizardResultForClient<T extends { step?: WizardStep }>(result: T): T {
   return result.step ? { ...result, step: sanitizeWizardStepForClient(result.step) } : result;
+}
+
+function retainGatewayWorkUntilSettled(session: WizardSession): void {
+  // Hosted wizard state spans RPC requests. Keep restart/suspend admission
+  // active between steps or a config reload can erase the process-local session.
+  const release = retainGatewayRootWorkAdmissionContinuation();
+  if (release) {
+    void session.whenSettled().then(release);
+  }
 }
 
 /** Resolves a live wizard session or sends the public not-found error. */
@@ -136,6 +146,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
               ),
             ),
           );
+    retainGatewayWorkUntilSettled(session);
     context.wizardSessions.set(sessionId, session);
     const result = await session.next();
     if (result.done) {


### PR DESCRIPTION
## What Problem This Solves

Both Windows-node release E2E lanes (the last red lanes for 2026.8.1-beta.1, release-checks run 31254782847) fail in the hosted setup wizard: `wizard.next unavailable during gateway restart`. Root cause is a real product bug, not a lane issue: `WizardSession` is process-local and spans multiple RPCs, but gateway work admission ended after each request — so a hybrid config reload could restart the gateway *between wizard steps* and erase the live session. Any operator whose config reloads mid-onboarding hits the same dead wizard.

## Why This Change Was Made

The wizard handler now retains root-work admission for the session's lifetime (`retainGatewayRootWorkAdmissionContinuation`, released on `whenSettled()`), so restart deferral sees the hosted wizard as active across RPC gaps. The admission primitive (1bcc4c5) and settlement ownership (8915f9c) both existed — they were never joined. System-agent wizard siblings already hold command-queue admission; setup and channel wizards share this repaired path.

Provenance: newly *reached*, not newly broken — the Windows-node lanes were added by 08579c5/31e056e and made mandatory by 79ea4d0; earlier validation runs never executed them. Legacy-node metadata work is unrelated.

## User Impact

Onboarding/setup wizards survive gateway config reloads instead of dying mid-flow with an unavailable error. Unblocks the final red lanes for the beta.1 candidate (cherry-pick follows — candidate package bytes are immutable).

## Evidence

- Lane logs + diagnostics artifact: install, gateway start, operator pairing, node pairing, verify-e2e all green before the wizard abort; both stable and prerelease variants identical.
- Regression: restart preflight remains blocked until wizard settlement (`wizard.test.ts`); focused suite 14/14.
- `pnpm tsgo:core` + `tsgo:core:test`, deadcode scans, `git diff --check`: green.
- Codex autoreview (`gpt-5.6-sol`, high): clean (0.97).
- Production +11; tests +44.
