### PR TITLE
release(2026.8.1): retain work admission across hosted wizard steps

### DIFF
--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -1,6 +1,12 @@
 // Wizard server-method tests cover stable lifecycle errors for process-local sessions.
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
+import { createSafeGatewayRestartPreflight } from "../../infra/restart-coordinator.js";
+import {
+  getActiveGatewayRootWorkCount,
+  resetGatewayWorkAdmission,
+  runWithGatewayIndependentRootWorkAdmission,
+} from "../../process/gateway-work-admission.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { createDeferred } from "../../shared/deferred.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
@@ -138,6 +144,44 @@ describe("hosted wizard runtime isolation", () => {
 });
 
 describe("wizard setup ownership", () => {
+  it("retains gateway work admission between requests until the wizard settles", async () => {
+    resetGatewayWorkAdmission();
+    const runnerSettled = createDeferred();
+    const tracker = createWizardSessionTracker();
+    const context = {
+      ...tracker,
+      wizardRunner: async (_opts: unknown, _runtime: RuntimeEnv, prompter: WizardPrompter) => {
+        prompter.progress("working");
+        await runnerSettled.promise;
+      },
+    };
+
+    try {
+      await runWithGatewayIndependentRootWorkAdmission(async () => {
+        const respond = vi.fn();
+        await expectDefined(
+          wizardHandlers["wizard.start"],
+          "wizard.start test invariant",
+        )({ params: { mode: "local" }, respond, context } as never);
+        expect(respond.mock.calls[0]?.[1]).toMatchObject({ status: "running" });
+      });
+
+      expect(getActiveGatewayRootWorkCount()).toBe(1);
+      expect(createSafeGatewayRestartPreflight()).toMatchObject({
+        safe: false,
+        blockers: [expect.objectContaining({ kind: "root-request", count: 1 })],
+      });
+      runnerSettled.resolve();
+      await vi.waitFor(() => {
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
+      });
+      expect(createSafeGatewayRestartPreflight().safe).toBe(true);
+    } finally {
+      runnerSettled.resolve();
+      resetGatewayWorkAdmission();
+    }
+  });
+
   it("blocks a replacement wizard until the cancelled runner settles", async () => {
     const runnerSettled = createDeferred();
     const tracker = createWizardSessionTracker();

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -12,6 +12,7 @@ import {
   validateWizardStatusParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { OnboardOptions } from "../../commands/onboard-types.js";
+import { retainGatewayRootWorkAdmissionContinuation } from "../../process/gateway-work-admission.js";
 import { createNonExitingRuntime, ExitError, type RuntimeEnv } from "../../runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import {
@@ -71,6 +72,15 @@ function readWizardStatus(session: WizardSession) {
 
 function sanitizeWizardResultForClient<T extends { step?: WizardStep }>(result: T): T {
   return result.step ? { ...result, step: sanitizeWizardStepForClient(result.step) } : result;
+}
+
+function retainGatewayWorkUntilSettled(session: WizardSession): void {
+  // Hosted wizard state spans RPC requests. Keep restart/suspend admission
+  // active between steps or a config reload can erase the process-local session.
+  const release = retainGatewayRootWorkAdmissionContinuation();
+  if (release) {
+    void session.whenSettled().then(release);
+  }
 }
 
 /** Resolves a live wizard session or sends the public not-found error. */
@@ -136,6 +146,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
               ),
             ),
           );
+    retainGatewayWorkUntilSettled(session);
     context.wizardSessions.set(sessionId, session);
     const result = await session.next();
     if (result.done) {


### PR DESCRIPTION
## What Problem This Solves

Carries the hosted-wizard work-admission fix (main e5d4fe02a46a, PR #120582) onto the 2026.8.1-beta.1 candidate — the last red validation lanes (Windows-node prerelease/stable E2E) die with `wizard.next unavailable during gateway restart` because a config reload can restart the gateway between wizard RPC steps. Candidate package bytes are immutable, so the runtime fix must be on the branch.

## Evidence

Clean cherry-pick (+11 production/+44 tests); wizard suite green on this branch; main landing carried full gates and clean autoreview (0.97).
