### PR TITLE
fix(gateway): resolve restart-recovery state only on lifecycle events

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2858,6 +2858,38 @@ describe("agent event handler", () => {
     ).toBe(false);
   });
 
+  it("skips the session entry read for non-lifecycle events and resolves restart recovery only on lifecycle events", () => {
+    const { broadcast, chatRunState, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-recovery-lazy",
+    });
+    registerChatRun(chatRunState, "run-lazy", "session-recovery-lazy", "client-lazy");
+    vi.mocked(loadSessionEntry).mockClear();
+
+    // High-volume chat delta events must not touch the session store:
+    // restart-recovery state is consumed only by lifecycle-phase handling.
+    for (let seq = 1; seq <= 5; seq++) {
+      emitAgentEvent(
+        handler,
+        "run-lazy",
+        "assistant",
+        { text: `message ${seq}` },
+        { seq, ts: Date.now() + seq * 200 },
+      );
+    }
+    expect(loadSessionEntry).not.toHaveBeenCalled();
+    expect(chatBroadcastCalls(broadcast).length).toBeGreaterThanOrEqual(1);
+
+    // Lifecycle events still resolve restart-recovery state through the store.
+    emitAgentEvent(
+      handler,
+      "run-lazy",
+      "lifecycle",
+      { phase: "end", endedAt: Date.now() },
+      { seq: 6, sessionKey: "session-recovery-lazy" },
+    );
+    expect(loadSessionEntry).toHaveBeenCalled();
+  });
+
   it("clears tracked active runs before terminal sessions.changed broadcasts", async () => {
     vi.mocked(loadGatewaySessionRow).mockReturnValue({
       key: "session-finished",

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2879,13 +2879,29 @@ describe("agent event handler", () => {
     expect(loadSessionEntry).not.toHaveBeenCalled();
     expect(chatBroadcastCalls(broadcast).length).toBeGreaterThanOrEqual(1);
 
-    // Lifecycle events still resolve restart-recovery state through the store.
+    // Unrelated lifecycle notifications (e.g. fallback) are not recovery
+    // phases, so they must stay off the session store as well.
+    emitAgentEvent(
+      handler,
+      "run-lazy",
+      "lifecycle",
+      {
+        phase: "fallback",
+        selectedProvider: "fireworks",
+        selectedModel: "fireworks/accounts/fireworks/routers/kimi-k2p5-turbo",
+      },
+      { seq: 6, sessionKey: "session-recovery-lazy" },
+    );
+    expect(loadSessionEntry).not.toHaveBeenCalled();
+
+    // Recovery lifecycle events still resolve restart-recovery state through
+    // the store.
     emitAgentEvent(
       handler,
       "run-lazy",
       "lifecycle",
       { phase: "end", endedAt: Date.now() },
-      { seq: 6, sessionKey: "session-recovery-lazy" },
+      { seq: 7, sessionKey: "session-recovery-lazy" },
     );
     expect(loadSessionEntry).toHaveBeenCalled();
   });

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1326,9 +1326,18 @@ export function createAgentEventHandler({
       isChatAbortMarkerCurrent(chatRunState.runs.get(clientRunId)?.abortMarker, chatLink) ||
       isChatAbortMarkerCurrent(chatRunState.runs.get(evt.runId)?.abortMarker, chatLink);
 
-    const restartRecoveryState = restartRecoverySessionKey
-      ? resolveRestartRecoveryLifecycleState(restartRecoverySessionKey, restartRecoveryAgentId, evt)
-      : undefined;
+    // Restart-recovery state is consumed only by lifecycle-phase handling
+    // (suppression and terminal projection). Resolving it on every event runs
+    // a session-store read per stream delta; short-circuit non-lifecycle
+    // events the same way resolveSpawnedBy does above.
+    const restartRecoveryState =
+      lifecyclePhase !== null && restartRecoverySessionKey
+        ? resolveRestartRecoveryLifecycleState(
+            restartRecoverySessionKey,
+            restartRecoveryAgentId,
+            evt,
+          )
+        : undefined;
     const suppressRestartRecoveryLifecycle =
       lifecyclePhase !== null &&
       (Boolean(

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1326,13 +1326,10 @@ export function createAgentEventHandler({
       isChatAbortMarkerCurrent(chatRunState.runs.get(clientRunId)?.abortMarker, chatLink) ||
       isChatAbortMarkerCurrent(chatRunState.runs.get(evt.runId)?.abortMarker, chatLink);
 
-    // Restart-recovery state is consumed only by lifecycle-phase handling
-    // (suppression and terminal projection). Resolving it on every event runs
-    // a session-store read per stream delta; short-circuit non-lifecycle
-    // events the same way resolveSpawnedBy does above, and restrict the
-    // lookup to the phases restart recovery actually recognizes
-    // (start/end/error) so unrelated lifecycle notifications (e.g. fallback)
-    // stay off the session store.
+    // Restart-recovery state is consumed only for the lifecycle phases
+    // restart recovery recognizes (start/end/error); short-circuit other
+    // events so unrelated notifications (e.g. fallback) stay off the
+    // session store.
     const restartRecoveryState =
       (lifecyclePhase === "start" || lifecyclePhase === "end" || lifecyclePhase === "error") &&
       restartRecoverySessionKey

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1329,9 +1329,13 @@ export function createAgentEventHandler({
     // Restart-recovery state is consumed only by lifecycle-phase handling
     // (suppression and terminal projection). Resolving it on every event runs
     // a session-store read per stream delta; short-circuit non-lifecycle
-    // events the same way resolveSpawnedBy does above.
+    // events the same way resolveSpawnedBy does above, and restrict the
+    // lookup to the phases restart recovery actually recognizes
+    // (start/end/error) so unrelated lifecycle notifications (e.g. fallback)
+    // stay off the session store.
     const restartRecoveryState =
-      lifecyclePhase !== null && restartRecoverySessionKey
+      (lifecyclePhase === "start" || lifecyclePhase === "end" || lifecyclePhase === "error") &&
+      restartRecoverySessionKey
         ? resolveRestartRecoveryLifecycleState(
             restartRecoverySessionKey,
             restartRecoveryAgentId,


### PR DESCRIPTION
## What Problem This Solves

`handleEvent` resolved `restartRecoveryState` on **every** agent runtime event via `resolveRestartRecoveryLifecycleState`, which runs a session-store read. That state is consumed only by lifecycle-phase handling (suppression and terminal projection), so on delta/flush/final/agent/seq-gap events it ran a full session-store lookup per stream delta. Post-turn cost therefore scaled with answer length instead of turn work — the exact issue reported in #120378 (session-store discovery once per stream event).

## Why This Change Was Made

The `restartRecoveryState` value is only meaningful during lifecycle-phase handling. The code path already short-circuits `resolveSpawnedBy` above it for the same reason; restart recovery should follow the same rule. Resolving it eagerly on every event violates the invariant "resolve lifecycle state only where lifecycle handling consumes it" and makes per-delta cost proportional to output size.

## User Impact

Fixes #120378. Long agent turns no longer pay an extra session-store read per stream delta, so post-turn gateway cost stays bounded by turn work (session creation, tool calls, terminal projection) instead of scaling with answer length. No behavior change for restart recovery itself — suppression and terminal projection still see the same resolved state on the lifecycle events that consume it.

## Evidence

- `src/gateway/server-chat.ts`: `handleEvent` now computes `restartRecoveryState` only for lifecycle-phase events (`phase` transitions / terminal states), mirroring the existing `resolveSpawnedBy` short-circuit above it; non-lifecycle events skip the session-store read entirely.
- `src/gateway/server-chat.agent-events.test.ts`: added regression coverage asserting non-lifecycle delta/final/agent events do not touch restart-recovery resolution, while lifecycle events still resolve it (restart suppression and terminal projection behavior unchanged).
- Verified: `pnpm vitest run src/gateway/server-chat.agent-events.test.ts` — 139/139 tests pass after the change.

[AI-assisted]


## ClawSweeper P3 repair (head `35349ee7a1e`)

P3 "Condense the hot-path comment" fixed: the restart-recovery comment in `src/gateway/server-chat.ts` is condensed (7 lines - 4). No behavior change.
