### PR TITLE
fix(qa): keep one Docker candidate across evidence producers

### DIFF
--- a/extensions/qa-lab/src/test-file-scenario-docker-batch.ts
+++ b/extensions/qa-lab/src/test-file-scenario-docker-batch.ts
@@ -65,7 +65,7 @@ export async function runDockerE2eBatch(params: {
   repoRoot: string;
   runCommand: (command: QaScenarioCommandExecution) => Promise<QaScenarioCommandResult>;
   scenarios: readonly QaDockerScenario[];
-}): Promise<QaDockerBatchResult[]> {
+}): Promise<{ packageTgz?: string; results: QaDockerBatchResult[] }> {
   const selected = params.scenarios.map((scenario) => ({
     lane: dockerE2eLaneName(scenario)!,
     scenario,
@@ -76,7 +76,16 @@ export async function runDockerE2eBatch(params: {
   const logPath = path.join(params.outputDir, `docker-e2e-batch-${batchId}.log`);
   await fs.mkdir(dockerOutputDir, { recursive: true });
   const summaryPath = path.join(dockerOutputDir, "summary.json");
+  const generatedPackageTgz = path.join(
+    dockerOutputDir,
+    "openclaw-package",
+    "openclaw-current.tgz",
+  );
+  const inheritedPackageTgz = params.env.OPENCLAW_CURRENT_PACKAGE_TGZ?.trim();
   await fs.rm(summaryPath, { force: true });
+  if (!inheritedPackageTgz) {
+    await fs.rm(generatedPackageTgz, { force: true });
+  }
   let commandResult: QaScenarioCommandResult;
   try {
     commandResult = await params.runCommand({
@@ -90,6 +99,7 @@ export async function runDockerE2eBatch(params: {
         OPENCLAW_DOCKER_ALL_LANES: laneNames.join(","),
         OPENCLAW_DOCKER_ALL_LANE_TIMEOUT_MS: String(params.commandTimeoutMs),
         OPENCLAW_DOCKER_ALL_LOG_DIR: dockerOutputDir,
+        OPENCLAW_DOCKER_ALL_PREPARE_PREPUBLISH_PLUGIN_REGISTRY: "1",
         OPENCLAW_DOCKER_ALL_PROFILE: "all",
         OPENCLAW_DOCKER_ALL_TIMINGS_FILE: path.join(dockerOutputDir, "lane-timings.json"),
       },
@@ -132,7 +142,7 @@ export async function runDockerE2eBatch(params: {
         (failure) =>
           !laneNames.some((laneName) => laneMatches(laneName, failure.name, resolvedLaneNames)),
       ));
-  return selected.map(({ lane, scenario }) => {
+  const results = selected.map(({ lane, scenario }) => {
     const matchingLanes = lanes.filter((result) =>
       laneMatches(lane, result.name, resolvedLaneNames),
     );
@@ -158,4 +168,12 @@ export async function runDockerE2eBatch(params: {
     }
     return result;
   });
+  const packageTgz = inheritedPackageTgz
+    ? path.resolve(params.repoRoot, inheritedPackageTgz)
+    : generatedPackageTgz;
+  const packageExists = await fs
+    .access(packageTgz)
+    .then(() => true)
+    .catch(() => false);
+  return { ...(packageExists ? { packageTgz } : {}), results };
 }

--- a/extensions/qa-lab/src/test-file-scenario-runner.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.test.ts
@@ -799,16 +799,41 @@ describe("qa test file scenario runner", () => {
 
   it("preserves individual Docker lane success without generic producer evidence", async () => {
     const repoRoot = await makeTempRepo("qa-script-docker-individual-no-producer-evidence-");
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "docker-individual");
+    const commands: QaScenarioCommandExecution[] = [];
     const result = await runQaTestFileScenarios({
       repoRoot,
-      outputDir: path.join(repoRoot, ".artifacts", "qa-e2e", "docker-individual"),
+      outputDir,
       providerMode: "mock-openai",
       primaryModel: "mock-openai/gpt-5.6-luna",
       failFast: true,
       scenarios: [makeDockerE2eScenario("docker-gateway-network", "gateway-network")],
-      runCommand: async () => ({ exitCode: 0, stdout: "Docker lane passed\n", stderr: "" }),
+      runCommand: async (command) => {
+        commands.push(command);
+        const logDir = command.env.OPENCLAW_DOCKER_ALL_LOG_DIR;
+        if (!logDir) {
+          throw new Error("missing Docker scheduler log dir");
+        }
+        await fs.writeFile(
+          path.join(logDir, "summary.json"),
+          `${JSON.stringify({
+            failures: [],
+            lanes: [{ elapsedSeconds: 1, name: "gateway-network", status: 0 }],
+            selectedLanes: ["gateway-network"],
+          })}\n`,
+          "utf8",
+        );
+        return { exitCode: 0, stdout: "Docker lane passed\n", stderr: "" };
+      },
     });
 
+    expect(commands[0]).toMatchObject({
+      args: ["scripts/test-docker-all.mjs"],
+      env: {
+        OPENCLAW_DOCKER_ALL_LANES: "gateway-network",
+        OPENCLAW_DOCKER_ALL_PREPARE_PREPUBLISH_PLUGIN_REGISTRY: "1",
+      },
+    });
     expect(result.results[0]).toMatchObject({
       scenario: { id: "docker-gateway-network" },
       status: "pass",
@@ -1010,6 +1035,7 @@ describe("qa test file scenario runner", () => {
         OPENCLAW_DOCKER_ALL_LANES:
           "openai-chat-tools,bundled-plugin-install-uninstall,gateway,gateway-network",
         OPENCLAW_DOCKER_ALL_LANE_TIMEOUT_MS: "1800000",
+        OPENCLAW_DOCKER_ALL_PREPARE_PREPUBLISH_PLUGIN_REGISTRY: "1",
       },
     });
     expect(result.results).toMatchObject([
@@ -1020,6 +1046,74 @@ describe("qa test file scenario runner", () => {
     ]);
     expect(result.results[3]?.failureMessage).toBe("gateway-network exited with 1");
   });
+
+  it.each([{ failFast: false }, { failFast: true }])(
+    "reuses the Docker batch package for later script producers (failFast=$failFast)",
+    async ({ failFast }) => {
+      const repoRoot = await makeTempRepo("qa-script-docker-package-reuse-");
+      const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "docker-package-reuse");
+      const packageTgz = path.join(
+        outputDir,
+        "docker-e2e-1800000ms",
+        "openclaw-package",
+        "openclaw-current.tgz",
+      );
+      await fs.mkdir(path.dirname(packageTgz), { recursive: true });
+      await fs.writeFile(packageTgz, "stale package", "utf8");
+      const commands: QaScenarioCommandExecution[] = [];
+      await runQaTestFileScenarios({
+        repoRoot,
+        outputDir,
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        failFast,
+        scenarios: [
+          makeDockerE2eScenario("docker-lane", "gateway"),
+          makeTestFileScenario("script", "scripts/evidence-producer.ts"),
+        ],
+        runCommand: async (command) => {
+          commands.push(command);
+          if (command.args[0] === "scripts/test-docker-all.mjs") {
+            const exists = await fs.access(packageTgz).then(
+              () => true,
+              () => false,
+            );
+            expect(exists).toBe(false);
+            const logDir = command.env.OPENCLAW_DOCKER_ALL_LOG_DIR;
+            if (!logDir) {
+              throw new Error("missing Docker scheduler log dir");
+            }
+            const producedPackageTgz = path.join(
+              logDir,
+              "openclaw-package",
+              "openclaw-current.tgz",
+            );
+            await fs.mkdir(path.dirname(producedPackageTgz), { recursive: true });
+            await fs.writeFile(producedPackageTgz, "package fixture", "utf8");
+            await fs.writeFile(
+              path.join(logDir, "summary.json"),
+              `${JSON.stringify({
+                failures: [],
+                lanes: [{ elapsedSeconds: 1, name: "gateway", status: 0 }],
+                selectedLanes: ["gateway"],
+              })}\n`,
+              "utf8",
+            );
+          } else {
+            await writeScriptProducerEvidence({ outputDir, status: "pass" });
+          }
+          return { exitCode: 0, stdout: "", stderr: "" };
+        },
+      });
+
+      expect(commands).toHaveLength(2);
+      expect(commands[1]?.env).toMatchObject({
+        OPENCLAW_BUNDLED_CHANNEL_HOST_BUILD: "0",
+        OPENCLAW_CURRENT_PACKAGE_TGZ: packageTgz,
+        OPENCLAW_NPM_ONBOARD_HOST_BUILD: "0",
+      });
+    },
+  );
 
   it("uses script scenario timeout overrides when running producer commands", async () => {
     const repoRoot = await makeTempRepo("qa-script-scenario-timeout-");

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -556,6 +556,17 @@ async function writeTestFileEvidenceFile(params: {
   return { evidencePath };
 }
 
+function adoptDockerBatchPackage(env: NodeJS.ProcessEnv, packageTgz: string | undefined) {
+  if (!packageTgz) {
+    return;
+  }
+  // The scheduler package is authoritative for every later producer, regardless
+  // of whether the caller batches all lanes or preserves fail-fast ordering.
+  env.OPENCLAW_CURRENT_PACKAGE_TGZ = packageTgz;
+  env.OPENCLAW_BUNDLED_CHANNEL_HOST_BUILD = "0";
+  env.OPENCLAW_NPM_ONBOARD_HOST_BUILD = "0";
+}
+
 export async function runQaTestFileScenarios(
   params: QaTestFileScenarioRunParams,
 ): Promise<QaTestFileScenarioRunResult> {
@@ -575,10 +586,9 @@ export async function runQaTestFileScenarios(
     ...params.env,
   };
   const results: QaTestFileScenarioResult[] = [];
-  const dockerBatchScenarios =
-    kind === "script" && !params.failFast ? scenarios.filter(isDockerE2eScenario) : [];
+  const dockerBatchScenarios = kind === "script" ? scenarios.filter(isDockerE2eScenario) : [];
   const dockerBatchGroups = new Map<number, typeof dockerBatchScenarios>();
-  for (const scenario of dockerBatchScenarios) {
+  for (const scenario of params.failFast ? [] : dockerBatchScenarios) {
     const scenarioTimeoutMs = resolvePositiveTimerTimeoutMs(
       scenario.execution.timeoutMs,
       commandTimeoutMs,
@@ -590,20 +600,42 @@ export async function runQaTestFileScenarios(
   for (const [scenarioTimeoutMs, group] of dockerBatchGroups) {
     // A scheduler invocation shares one fallback lane timeout, so timeout overrides
     // stay in separate batches instead of borrowing another scenario's budget.
-    results.push(
-      ...(await runDockerE2eBatch({
-        commandTimeoutMs: scenarioTimeoutMs,
+    const batch = await runDockerE2eBatch({
+      commandTimeoutMs: scenarioTimeoutMs,
+      env,
+      outputDir: params.outputDir,
+      repoRoot: params.repoRoot,
+      runCommand,
+      scenarios: group,
+    });
+    results.push(...batch.results);
+    adoptDockerBatchPackage(env, batch.packageTgz);
+  }
+  const dockerBatchScenarioIds = new Set(dockerBatchScenarios.map((scenario) => scenario.id));
+  for (const scenario of scenarios) {
+    if (!params.failFast && dockerBatchScenarioIds.has(scenario.id)) {
+      continue;
+    }
+    if (params.failFast && isDockerE2eScenario(scenario)) {
+      const batch = await runDockerE2eBatch({
+        commandTimeoutMs: resolvePositiveTimerTimeoutMs(
+          scenario.execution.timeoutMs,
+          commandTimeoutMs,
+        ),
         env,
         outputDir: params.outputDir,
         repoRoot: params.repoRoot,
         runCommand,
-        scenarios: group,
-      })),
-    );
-  }
-  const dockerBatchScenarioIds = new Set(dockerBatchScenarios.map((scenario) => scenario.id));
-  for (const scenario of scenarios) {
-    if (dockerBatchScenarioIds.has(scenario.id)) {
+        scenarios: [scenario],
+      });
+      adoptDockerBatchPackage(env, batch.packageTgz);
+      const [result] = batch.results;
+      if (result) {
+        results.push(result);
+      }
+      if (result?.status !== "pass") {
+        break;
+      }
       continue;
     }
     const result = await runQaTestFileScenario({

--- a/scripts/test-docker-all.d.mts
+++ b/scripts/test-docker-all.d.mts
@@ -2,6 +2,26 @@ export function parseDockerAllCliArgs(argv: unknown): {
   help: boolean;
   planJson: boolean;
 };
+export function prepareLocalPrepublishPluginRegistry(params: {
+  baseEnv: NodeJS.ProcessEnv;
+  createArtifact?: (params: {
+    candidateVersion: string;
+    outputDir: string;
+    repoRoot: string;
+    requiredPackages: string[];
+    sourceSha: string;
+  }) => { manifestSha256: string };
+  enabled: boolean;
+  logDir: string;
+  plan: {
+    needs: { prepublishPluginRegistry: boolean };
+    requiredPrepublishPluginPackages: string[];
+  };
+  readFileSync?: (path: string, encoding: "utf8") => string;
+  repoRoot: string;
+  resolveGitHead?: (params: { cwd: string }) => string | undefined;
+  rmSync?: (path: string, options: { force: boolean; recursive: boolean }) => void;
+}): void;
 export function describeDockerSchedulerLimits(parallelism: unknown, options: unknown): string;
 export function canStartSchedulerLane(
   candidate: unknown,

--- a/scripts/test-docker-all.mjs
+++ b/scripts/test-docker-all.mjs
@@ -1,7 +1,7 @@
 // Docker E2E aggregate scheduler.
 // Builds shared Docker images, prepares one OpenClaw npm tarball, assigns lanes
 // to bare/functional images, and runs lanes through weighted resource pools.
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import { mkdir, open, readFile } from "node:fs/promises";
 import path from "node:path";
@@ -28,7 +28,10 @@ import {
   resolveDockerE2ePlan,
 } from "./lib/docker-e2e-plan.mjs";
 import { sleep } from "./lib/sleep.mjs";
-import { validatePrepublishPluginRegistryArtifact } from "./prepublish-plugin-registry-artifact.mjs";
+import {
+  createPrepublishPluginRegistryArtifact,
+  validatePrepublishPluginRegistryArtifact,
+} from "./prepublish-plugin-registry-artifact.mjs";
 
 const SCRIPT_ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ROOT_DIR = path.resolve(process.env.OPENCLAW_DOCKER_E2E_REPO_ROOT || SCRIPT_ROOT_DIR);
@@ -267,6 +270,51 @@ function commandEnv(extra = {}) {
     .filter(Boolean);
   env.PATH = [...new Set(pathEntries)].join(path.delimiter);
   return env;
+}
+
+function resolveDockerRepositoryHead(params) {
+  const result = (params.spawnSync ?? spawnSync)("git", ["rev-parse", "HEAD"], {
+    cwd: params.cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  return result.status === 0 ? result.stdout?.trim() || undefined : undefined;
+}
+
+export function prepareLocalPrepublishPluginRegistry(params) {
+  if (
+    !params.enabled ||
+    !params.plan.needs.prepublishPluginRegistry ||
+    params.baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR
+  ) {
+    return;
+  }
+  const sourceSha = (params.resolveGitHead ?? resolveDockerRepositoryHead)({
+    cwd: params.repoRoot,
+  });
+  if (!sourceSha) {
+    throw new Error("cannot resolve repository HEAD for the local prepublish plugin registry");
+  }
+  const packageJson = JSON.parse(
+    (params.readFileSync ?? fs.readFileSync)(path.join(params.repoRoot, "package.json"), "utf8"),
+  );
+  const candidateVersion = packageJson?.version;
+  if (typeof candidateVersion !== "string" || !candidateVersion.trim()) {
+    throw new Error("root package.json must declare a candidate version");
+  }
+  const outputDir = path.join(params.logDir, "prepublish-plugin-registry");
+  (params.rmSync ?? fs.rmSync)(outputDir, { force: true, recursive: true });
+  const artifact = (params.createArtifact ?? createPrepublishPluginRegistryArtifact)({
+    candidateVersion,
+    outputDir,
+    repoRoot: params.repoRoot,
+    requiredPackages: params.plan.requiredPrepublishPluginPackages,
+    sourceSha,
+  });
+  params.baseEnv.OPENCLAW_DOCKER_E2E_SELECTED_SHA = sourceSha;
+  params.baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION = candidateVersion;
+  params.baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR = outputDir;
+  params.baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256 = artifact.manifestSha256;
 }
 
 function shellQuote(value) {
@@ -1469,6 +1517,10 @@ async function main() {
   const preflightCleanup = parseBool(process.env.OPENCLAW_DOCKER_ALL_PREFLIGHT_CLEANUP, true);
   const timingsEnabled = parseBool(process.env.OPENCLAW_DOCKER_ALL_TIMINGS, true);
   const buildEnabled = parseBool(process.env.OPENCLAW_DOCKER_ALL_BUILD, true);
+  const preparePrepublishPluginRegistry = parseBool(
+    process.env.OPENCLAW_DOCKER_ALL_PREPARE_PREPUBLISH_PLUGIN_REGISTRY,
+    false,
+  );
   const allowFrozenTargetScenarioOmissions = parseBool(
     process.env.OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS,
     false,
@@ -1542,15 +1594,15 @@ async function main() {
       allowFrozenTargetScenarioOmissions,
       candidatePackageRoot: ROOT_DIR,
     });
-  if (plan.needs.prepublishPluginRegistry && process.env.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR) {
+  if (plan.needs.prepublishPluginRegistry && baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR) {
     baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR = path.resolve(
-      process.env.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR,
+      baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR,
     );
     validatePrepublishPluginRegistryArtifact({
       artifactDir: baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR,
-      expectedCandidateVersion: process.env.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION,
-      expectedManifestSha256: process.env.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256,
-      expectedSourceSha: process.env.OPENCLAW_DOCKER_E2E_SELECTED_SHA,
+      expectedCandidateVersion: baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION,
+      expectedManifestSha256: baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256,
+      expectedSourceSha: baseEnv.OPENCLAW_DOCKER_E2E_SELECTED_SHA,
       requiredPackages: plan.requiredPrepublishPluginPackages,
     });
   } else {
@@ -1651,6 +1703,14 @@ async function main() {
       `resolved zero runnable Docker lanes; frozen target does not support: ${omittedUnsupportedLanes.join(", ")}`,
     );
   }
+
+  prepareLocalPrepublishPluginRegistry({
+    baseEnv,
+    enabled: preparePrepublishPluginRegistry,
+    logDir,
+    plan,
+    repoRoot: ROOT_DIR,
+  });
 
   await runPhase(
     phases,

--- a/test/scripts/docker-all-scheduler.test.ts
+++ b/test/scripts/docker-all-scheduler.test.ts
@@ -26,6 +26,7 @@ import {
   githubWorkflowRerunCommand,
   LOG_TAIL_MAX_BYTES,
   parseDockerAllCliArgs,
+  prepareLocalPrepublishPluginRegistry,
   resolveDockerPreflightPlatform,
   runCleanupSmokePhase,
   runShellCaptureCommand,
@@ -162,6 +163,51 @@ describe("scripts/test-docker-all scheduler", () => {
     expect(result.stderr).toContain("unknown argument: --bogus");
     expect(result.stderr).toContain("Usage: node scripts/test-docker-all.mjs [--plan-json]");
     expect(result.stderr).not.toContain("at ");
+  });
+
+  it("prepares a plan-scoped local prerelease plugin registry when explicitly enabled", () => {
+    const baseEnv: NodeJS.ProcessEnv = {};
+    const removed: Array<{ options: { force: boolean; recursive: boolean }; path: string }> = [];
+    const created: unknown[] = [];
+    prepareLocalPrepublishPluginRegistry({
+      baseEnv,
+      createArtifact: (params) => {
+        created.push(params);
+        return { manifestSha256: "a".repeat(64) };
+      },
+      enabled: true,
+      logDir: "/artifacts/docker",
+      plan: {
+        needs: { prepublishPluginRegistry: true },
+        requiredPrepublishPluginPackages: ["@openclaw/codex", "@openclaw/discord"],
+      },
+      readFileSync: () => JSON.stringify({ version: "2026.8.1" }),
+      repoRoot: "/repo",
+      resolveGitHead: () => "b".repeat(40),
+      rmSync: (file, options) => removed.push({ options, path: file }),
+    });
+
+    expect(removed).toEqual([
+      {
+        options: { force: true, recursive: true },
+        path: "/artifacts/docker/prepublish-plugin-registry",
+      },
+    ]);
+    expect(created).toEqual([
+      {
+        candidateVersion: "2026.8.1",
+        outputDir: "/artifacts/docker/prepublish-plugin-registry",
+        repoRoot: "/repo",
+        requiredPackages: ["@openclaw/codex", "@openclaw/discord"],
+        sourceSha: "b".repeat(40),
+      },
+    ]);
+    expect(baseEnv).toMatchObject({
+      OPENCLAW_DOCKER_E2E_SELECTED_SHA: "b".repeat(40),
+      OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION: "2026.8.1",
+      OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR: "/artifacts/docker/prepublish-plugin-registry",
+      OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256: "a".repeat(64),
+    });
   });
 
   it("plans from an isolated release harness without installed dependencies", () => {


### PR DESCRIPTION
## Summary

- make the QA Lab Docker scheduler prepare the exact candidate companion-plugin registry required by its selected plan
- return the scheduler-owned OpenClaw tarball from Docker batches and reuse that same artifact in every later script producer
- route fail-fast Docker scenarios through the canonical scheduler path and preserve the same package handoff

## Root cause and architectural owner

QA Lab invoked `scripts/test-docker-all.mjs` without the candidate companion-plugin registry used by release E2E. Prerelease survivor lanes could therefore resolve older public `@openclaw/codex` or `@openclaw/discord` packages that could not converge with the core candidate. The scheduler also produced an authoritative checkout tarball, but the fail-fast runner path did not carry it into later producers, allowing a second build to replace that identity.

Ownership is split across one canonical flow:

1. `scripts/test-docker-all.mjs` owns the resolved Docker plan and prepares an exact, plan-scoped local companion registry only when QA Lab explicitly requests it. The existing external artifact validation path remains unchanged.
2. `extensions/qa-lab/src/test-file-scenario-docker-batch.ts` invokes that scheduler, rejects stale summaries/packages, and returns either the inherited or newly generated checkout tarball.
3. `extensions/qa-lab/src/test-file-scenario-runner.ts` adopts the returned tarball after every Docker batch and disables later host rebuilds for both aggregate and fail-fast execution.

## ClawSweeper P1

The prior review correctly found that only the aggregate path adopted `batch.packageTgz`. This head centralizes that transition in `adoptDockerBatchPackage`, calls it from both aggregate and fail-fast paths, and covers the original Docker-pass-then-script sequence in both modes. The later producer now receives:

- `OPENCLAW_CURRENT_PACKAGE_TGZ=<scheduler artifact>`
- `OPENCLAW_BUNDLED_CHANNEL_HOST_BUILD=0`
- `OPENCLAW_NPM_ONBOARD_HOST_BUILD=0`

## Proof

- exact head: `910e912c92ac8b5f168c9d9ba318487351060e9f`
- focused exact-patch proof: `test-file-scenario-runner.test.ts` and `docker-all-scheduler.test.ts`, 84/84 tests passed after the final rebase
- Blacksmith Testbox static proof: https://github.com/openclaw/openclaw/actions/runs/31304180559 — 255 script declaration contracts, extension production/test types, script/root-test types, and the Docker E2E boundary lint passed
- candidate companion Docker proof: https://github.com/openclaw/openclaw/actions/runs/31256940309 — `update-restart-auth` completed doctor, automatic restart, health, readiness, and status against exact candidate Codex and Discord packages
- targeted `oxfmt`, `oxlint`, and `git diff --check`: passed

## Scope and risk

- Production/QA harness: `+152/-22` (net `+130`). Tests: `+142/-2` (net `+140`). Total: `+294/-24`.
- Positive harness growth establishes one artifact-identity boundary: plan-derived companion registry creation, the scheduler/batch result contract, canonical post-batch adoption, and the required script declaration.
- Local registry creation is explicit, clean-HEAD-only, exact-versioned, plan-scoped, and skipped for plan/dry-run modes. An externally supplied immutable registry is still validated and preferred.
- The scheduler-local Git resolver remains self-contained because the isolated release harness intentionally copies only its curated scheduler dependencies.
- Complete all-profile maturity evidence still depends on #120710 for the trusted protocol comparison base and #120816 for aggregate suite/cache isolation.

## Rerun and acceptance

After #120710, #120816, and this PR land, resolve the exact target `main` SHA and run:

```bash
gh workflow run qa-profile-evidence.yml \
  --repo openclaw/openclaw \
  --ref main \
  -f ref=<exact-main-sha> \
  -f expected_sha=<exact-main-sha> \
  -f qa_profile=all \
  -f allow_failures=true
```

Accept the `allow_failures` result only when every non-pass entry is a WhatsApp credential-acquisition failure and every other scenario passes. Any other failure remains actionable and should be repaired before treating the maturity run as complete.

## Split out

The unrelated repairs formerly carried by this PR now have their own owner-scoped reviews:

- #121006 — Matrix durable delivery identity across payload fanout
- #121007 — fresh Matrix readiness after destructive restart
- #121008 — Slack MPIM marker correlation
- #121009 — Slack progress commentary draft routing
- #121010 — explicit Telegram plugin activation in isolated startup proof
- #121011 — structured SSH blocked evidence outside Testbox

The live-frontier alternate-model repair is #120998. The explicit Matrix quiet-streaming `blockStreaming: false` override was dropped because the Matrix QA substrate already defaults and writes that value.
