### PR TITLE
fix(qa): defer testing skill model policy

### DIFF
--- a/.agents/skills/openclaw-qa-testing/SKILL.md
+++ b/.agents/skills/openclaw-qa-testing/SKILL.md
@@ -19,12 +19,13 @@ Use this skill for `qa-lab` / `qa-channel` work. Repo-local QA only.
 
 ## Model policy
 
-- Live OpenAI lane: `openai/gpt-5.4`
-- Fast mode: on
-- Do not use:
-  - `openai/gpt-5.4-pro`
-  - `openai/gpt-5.4-mini`
-- Only change model policy if the user explicitly asks.
+- Normal live suite runs rely on QA Lab source- and auth-aware defaults.
+- Do not pass `--model`, `--alt-model`, or `--fast` by default. Omitted
+  `--fast` does not mean fast is disabled; fast behavior is source-owned.
+- For scenario-specific runs, the complete `execution.summary` is authoritative
+  and overrides generic default guidance, including when it requires other
+  flags. Add explicit provider/model pins only when
+  `execution.config.requiredProvider` or `requiredModel` requires them.
 
 ## Default workflow
 
@@ -32,14 +33,11 @@ Use this skill for `qa-lab` / `qa-channel` work. Repo-local QA only.
 2. Decide lane:
    - mock/dev: `mock-openai`
    - real validation: `live-frontier`
-3. For live OpenAI, use:
+3. For a normal live suite, use:
 
 ```bash
-OPENCLAW_LIVE_OPENAI_KEY="${OPENAI_API_KEY}" \
 pnpm openclaw qa suite \
   --provider-mode live-frontier \
-  --model openai/gpt-5.4 \
-  --alt-model openai/gpt-5.4 \
   --output-dir .artifacts/qa-e2e/run-all-live-frontier-<tag>
 ```
 
@@ -156,28 +154,15 @@ Use `qa character-eval` for style/persona/vibe checks across multiple live model
 
 ```bash
 pnpm openclaw qa character-eval \
-  --model openai/gpt-5.4,thinking=xhigh \
-  --model openai/gpt-5.2,thinking=xhigh \
-  --model openai/gpt-5,thinking=xhigh \
-  --model anthropic/claude-opus-4-6,thinking=high \
-  --model anthropic/claude-sonnet-4-6,thinking=high \
-  --model zai/glm-5.1,thinking=high \
-  --model moonshot/kimi-k2.5,thinking=high \
-  --model google/gemini-3.1-pro-preview,thinking=high \
-  --judge-model openai/gpt-5.4,thinking=xhigh,fast \
-  --judge-model anthropic/claude-opus-4-6,thinking=high \
-  --concurrency 16 \
-  --judge-concurrency 16 \
   --output-dir .artifacts/qa-e2e/character-eval-<tag>
 ```
 
 - Runs local QA gateway child processes, not Docker.
-- Preferred model spec syntax is `provider/model,thinking=<level>[,fast|,no-fast|,fast=<bool>]` for both `--model` and `--judge-model`.
+- With no model flags, character eval uses its current source-defined candidate,
+  judge, thinking, and fast defaults.
+- Repeat `--model provider/model,thinking=<level>[,fast|,no-fast|,fast=<bool>]`
+  or `--judge-model ...` only to replace the corresponding inventory explicitly.
 - Do not add new examples with separate `--model-thinking`; keep that flag as legacy compatibility only.
-- Defaults to candidate models `openai/gpt-5.4`, `openai/gpt-5.2`, `openai/gpt-5`, `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6`, `zai/glm-5.1`, `moonshot/kimi-k2.5`, and `google/gemini-3.1-pro-preview` when no `--model` is passed.
-- Candidate thinking defaults to `high`, with `xhigh` for OpenAI models that support it. Prefer inline `--model provider/model,thinking=<level>`; `--thinking <level>` and `--model-thinking <provider/model=level>` remain compatibility shims.
-- OpenAI candidate refs default to fast mode so priority processing is used where supported. Use inline `,fast`, `,no-fast`, or `,fast=false` for one model; use `--fast` only to force fast mode for every candidate.
-- Judges default to `openai/gpt-5.4,thinking=xhigh,fast` and `anthropic/claude-opus-4-6,thinking=high`.
 - Report includes judge ranking, run stats, durations, and full transcripts; do not include raw judge replies. Duration is benchmark context, not a grading signal.
 - Candidate and judge concurrency default to 16. Use `--concurrency <n>` and `--judge-concurrency <n>` to override when local gateways or provider limits need a gentler lane.
 - Scenario source is YAML-only under `qa/scenarios/`: use `index.yaml` and

--- a/.agents/skills/openclaw-qa-testing/agents/openai.yaml
+++ b/.agents/skills/openclaw-qa-testing/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "QA Test OpenClaw"
   short_description: "Run and debug qa-lab and qa-channel scenarios"
-  default_prompt: "Use $openclaw-qa-testing to run or extend the OpenClaw QA suite with qa-lab and qa-channel, using regular openai/gpt-5.4 in fast mode for live OpenAI runs."
+  default_prompt: "Use $openclaw-qa-testing to run or extend the OpenClaw QA suite with qa-lab and qa-channel. Start with QA Lab source- and auth-aware defaults. For a selected scenario, its complete execution.summary overrides generic guidance and may require other flags; pin provider/model only when execution.config.requiredProvider or execution.config.requiredModel requires it."


### PR DESCRIPTION
Related: #120206

## What Problem This Solves

Fixes an issue where the QA testing skill forced stale concrete model and fast-mode choices for normal live and character-evaluation runs, bypassing QA Lab's current source- and authentication-aware defaults.

## Why This Change Was Made

The skill and its OpenAI agent prompt now defer normal live selection to QA Lab. Explicit provider/model selection is reserved for scenarios whose `execution.config.requiredProvider` or `execution.config.requiredModel` contract pins it, with the scenario's complete `execution.summary` remaining authoritative.

This partially supersedes #120206 only for the QA testing skill and agent-prompt policy. It does not adopt that proposal's workflow/runtime changes, does not close #120206, and leaves repair B as a prerequisite for closing the issue.

## User Impact

Maintainers invoking `$openclaw-qa-testing` no longer force a duplicated model inventory or default `--model`, `--alt-model`, or `--fast` flags. Character evaluation likewise uses its maintained source-defined candidate, judge, thinking, and fast defaults unless an operator explicitly replaces them.

## Evidence

- Candidate SHA: `3e216994fe8ad25029d332d61d0c0507585b1ed0`
- Scope: exactly `.agents/skills/openclaw-qa-testing/SKILL.md` and `.agents/skills/openclaw-qa-testing/agents/openai.yaml`
- LOC: docs/config `+13/-28` (net `-15`); production `+0/-0`; tests `+0/-0`
- YAML parse: passed
- `git diff --check`: passed
- Focused QA Lab tests: 28 passed across `model-selection.runtime.test.ts` and `character-eval.test.ts`
- Changed-file formatting and static guards: passed
- Autoreview: clean, no accepted/actionable findings
- The changed-file wrapper's remote sync failed, then its unknown-agent-YAML fail-safe expanded to all lanes. That expanded local typecheck failed on unrelated missing UI/QA/Android modules and an existing terminal-core signature error; no failure referenced either changed file.
- QA Profile Evidence is not dispatched pre-merge: its trust policy accepts selected revisions only when they are reachable from current `main`, a release tag, or the exact release-branch head. This unmerged candidate SHA is therefore ineligible, and the workflow exposes no model-selection inputs.

Punchcard attestation:

`Punchcard-Session: amber-workshop-workshop-36`

`pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaR1BZMllBV1RWTlBSQjU3MlZBMlpENwB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pGWE42TVBWRDRBMzM2VlZDWVdHUDQ1AGFtYmVyLXdvcmtzaG9wLXdvcmtzaG9wLTM2AG9wZW5jbGF3L29wZW5jbGF3AAAxMjA1OTAAYTJhNDRkMjMxNDY1ZGFkMTFlNWEyNWEwMWUwMzBmYTE5YzBhYTk3ODk1MmYwYzUwMTgxOGI3MzNkYTIyMGQ1YwBzaWduaW5nLXYxADZzVXVGZGluMmprYkpUSDhiZU8wb2FFWGtRejh3Ry1OYjdUOGU3R3pNWmJucEkwN0NZZ2djUE9EaFVzVGpvUV9RSFY2bzZMZ0FlOU1Bek1id004QkRRADIwMjYtMDgtMDhUMTI6NTI6NTguOTU0WgA.TDsnNE2EqFCZKLUMa2Mz2bHx8qneEf1wwkjAC2jFbtHOO_LJ9ygQ7R5GdXpJ3Yr1dHP8o4CVWlcu9QlS7yhyDw`
