### PR TITLE
fix(process): announce retained tail slice on poll of exited sessions

### DIFF
--- a/src/agents/bash-tools.process.finished-tail-note.test.ts
+++ b/src/agents/bash-tools.process.finished-tail-note.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Regression coverage for process poll on already-exited sessions.
+ *
+ * Polling a finished background session returns the retained 2000-char tail;
+ * when the full aggregated output is longer, the response must announce the
+ * slice (mirroring action=log) so callers never mistake a partial tail for the
+ * complete output.
+ */
+import { afterEach, expect, test } from "vitest";
+import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
+import { addSession, appendOutput, markExited } from "./bash-process-registry.js";
+import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
+import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
+import { createProcessTool } from "./bash-tools.process.js";
+
+afterEach(() => {
+  resetProcessRegistryForTests();
+  resetDiagnosticSessionStateForTest();
+});
+
+function finishedPollHarness(sessionId: string, output: string) {
+  const processTool = createProcessTool();
+  const session = createProcessSessionFixture({
+    id: sessionId,
+    command: "test",
+    backgrounded: true,
+  });
+  addSession(session);
+  appendOutput(session, "stdout", output);
+  markExited(session, 0, null, "completed");
+  return processTool;
+}
+
+test("process poll on an exited session announces the retained tail slice", async () => {
+  const processTool = finishedPollHarness("sess-truncated", "x".repeat(6410));
+
+  const poll = await processTool.execute("toolcall", {
+    action: "poll",
+    sessionId: "sess-truncated",
+  });
+
+  expect(poll.details).toMatchObject({ status: "completed" });
+  const text = poll.content[0]?.type === "text" ? poll.content[0].text : "";
+  expect(text).toContain("[showing last 2000 of 6410 chars");
+  expect(text).toContain("pass offset/limit to action=log to page the full output");
+  // The full output must still be available to the caller through details.
+  expect((poll.details as { aggregated?: string }).aggregated).toHaveLength(6410);
+});
+
+test("process poll on an exited session stays quiet when the tail is complete", async () => {
+  const processTool = finishedPollHarness("sess-complete", "x".repeat(512));
+
+  const poll = await processTool.execute("toolcall", {
+    action: "poll",
+    sessionId: "sess-complete",
+  });
+
+  expect(poll.details).toMatchObject({ status: "completed" });
+  const text = poll.content[0]?.type === "text" ? poll.content[0].text : "";
+  expect(text).toContain("x".repeat(512));
+  expect(text).not.toContain("showing last");
+  expect((poll.details as { aggregated?: string }).aggregated).toHaveLength(512);
+});

--- a/src/agents/bash-tools.process.finished-tail-note.test.ts
+++ b/src/agents/bash-tools.process.finished-tail-note.test.ts
@@ -42,7 +42,7 @@ test("process poll on an exited session announces the retained tail slice", asyn
   expect(poll.details).toMatchObject({ status: "completed" });
   const text = poll.content[0]?.type === "text" ? poll.content[0].text : "";
   expect(text).toContain("[showing last 2000 of 6410 chars");
-  expect(text).toContain("pass offset/limit to action=log to page the full output");
+  expect(text).toContain("pass offset/limit to action=log to page the retained output");
   // The full output must still be available to the caller through details.
   expect((poll.details as { aggregated?: string }).aggregated).toHaveLength(6410);
 });

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -72,6 +72,14 @@ function defaultTailNote(totalLines: number, usingDefaultTail: boolean) {
   return `\n\n[showing last ${DEFAULT_LOG_TAIL_LINES} of ${totalLines} lines; pass offset/limit to page]`;
 }
 
+/** Poll on an already-exited session returns the retained 2000-char tail; say so when it is a slice. */
+function finishedTailNote(tailText: string, aggregated: string) {
+  if (tailText.length >= aggregated.length) {
+    return "";
+  }
+  return `\n\n[showing last ${tailText.length} of ${aggregated.length} chars; pass offset/limit to action=log to page the full output]`;
+}
+
 const MAX_POLL_WAIT_MS = 30_000;
 
 type RunningSessionRuntime = {
@@ -400,6 +408,7 @@ export function createProcessTool(
                         `(no output recorded${
                           scopedFinished.truncated ? " — truncated to cap" : ""
                         })`) +
+                        finishedTailNote(scopedFinished.tail, scopedFinished.aggregated) +
                         `\n\nProcess exited with ${
                           scopedFinished.exitSignal
                             ? `signal ${scopedFinished.exitSignal}`

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -77,7 +77,7 @@ function finishedTailNote(tailText: string, aggregated: string) {
   if (tailText.length >= aggregated.length) {
     return "";
   }
-  return `\n\n[showing last ${tailText.length} of ${aggregated.length} chars; pass offset/limit to action=log to page the full output]`;
+  return `\n\n[showing last ${tailText.length} of ${aggregated.length} chars; pass offset/limit to action=log to page the retained output]`;
 }
 
 const MAX_POLL_WAIT_MS = 30_000;


### PR DESCRIPTION
## What Problem This Solves

`process poll` on an already-exited background session returns only the retained 2000-char `tail` with no indication that anything was dropped. The caller cannot distinguish a partial tail from the complete output: `action=log` appends `[showing last 200 of N lines; pass offset/limit to page]`, and polling a *running* session drains the incremental buffer, but poll-on-finished silently loses the head of the output.

## Why This Change Was Made

The failure is invisible to the caller, so the agent proceeds confidently on partial data. Reported case: a scheduled check produced a 6410-character report; the agent backgrounded the command, polled after exit, and received a 2025-character tail plus the exit line — then acted on that fragment as if it were the whole report (13 items listed, agent reported 4). The truncated text is an exact suffix of the full output, and the cut is character-based, so it reads as odd phrasing rather than an obvious error. This is a tool-layer truncation, not a comprehension failure.

## User Impact

Fixes #120567. Polling an exited session now announces the slice (`[showing last 2000 of 6410 chars; pass offset/limit to action=log to page the retained output]`) whenever the retained tail is shorter than the aggregated output, mirroring the existing `action=log` note. `details.aggregated` already carries the full output, so callers keep a complete-data path; under-the-tail outputs stay quiet (no noise for normal-sized results).

## Evidence

- `src/agents/bash-tools.process.ts`: added `finishedTailNote(tailText, aggregated)` next to the existing `defaultTailNote`, and wired it into the poll-finished branch so the note is appended only when `tail.length < aggregated.length`. The note says `page the retained output` (not `full output`) because `details.aggregated` is itself bounded by the process capture cap (ClawSweeper P2).
- `src/agents/bash-tools.process.finished-tail-note.test.ts`: two regression tests — output over the tail size announces the truncation and still exposes `details.aggregated` (length 6410); output under the tail size stays quiet (no `showing last` note, full 512 chars present).
- Verified: `vitest run` on `bash-tools.process.finished-tail-note.test.ts` + `poll-timeout` + `finished-retention` + `e2e` + `input-hints` + `supervisor` — 48/48 tests pass (22 + 26), including the new regression tests.

[AI-assisted]
