### PR TITLE
fix(codex): support app-server 0.147.0

### DIFF
--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -244,10 +244,10 @@ reconciliation so OpenClaw does not override that selection.
 
 ## Remote marketplaces
 
-Codex 0.146.1 can read and install Computer Use plugins from discovered remote
-marketplaces. OpenClaw passes the opaque remote plugin ID returned by Codex to
-`plugin/read` and `plugin/install`; a human-readable plugin name is not a valid
-substitute.
+Remote marketplace support was introduced in Codex 0.146.1 and remains
+available in OpenClaw's pinned Codex 0.147.0. OpenClaw passes the opaque remote
+plugin ID returned by Codex to `plugin/read` and `plugin/install`; a
+human-readable plugin name is not a valid substitute.
 
 `/codex computer-use install` can explicitly install or re-enable a discovered
 remote plugin. Turn-start `autoInstall` can also use an already discovered local

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -131,7 +131,7 @@ flags, and plugin allow/deny references into this block. Explicit canonical
 ## App-server transport
 
 For ordinary harness turns, OpenClaw starts the managed Codex binary shipped
-with the official plugin (currently `@openai/codex` `0.146.1`):
+with the official plugin (currently `@openai/codex` `0.147.0`):
 
 ```bash
 codex app-server --listen stdio://
@@ -253,7 +253,7 @@ If the normal app-server runtime would be `danger-full-access`, enabling
 permission profile instead. Codex-managed network enforcement is sandboxed
 networking, so a full-access profile would not protect outbound traffic.
 
-The plugin accepts exactly stable Codex app-server `0.146.1`. Older or newer
+The plugin accepts exactly stable Codex app-server `0.147.0`. Older or newer
 versions, prereleases, build-suffixed versions, and unversioned app-server
 handshakes are rejected. The same exact-version requirement applies to explicit
 custom executables, remote app-servers, and macOS desktop binaries.
@@ -304,7 +304,7 @@ configured plugin's details to reserve the denied app IDs. It does not scan
 unrelated marketplaces or install, enable, or authenticate the disabled plugin;
 missing ownership fails closed.
 
-Only connect OpenClaw to a `0.146.1` remote app-server trusted to accept
+Only connect OpenClaw to a `0.147.0` remote app-server trusted to accept
 configured marketplace plugin installs and inventory refreshes. Missing modern
 inventory methods and server, authentication, or transport failures fail closed.
 
@@ -380,7 +380,7 @@ The stable default is fail-closed: active OpenClaw sandboxing disables native
 Codex execution surfaces that would otherwise run from the Codex app-server
 host. Use `appServer.experimental.sandboxExecServer: true` only when you want
 to try Codex's remote environment support with OpenClaw's sandbox backend.
-This preview path uses the pinned Codex `0.146.1` app-server.
+This preview path uses the pinned Codex `0.147.0` app-server.
 
 ```json5
 {
@@ -663,17 +663,21 @@ response remains authoritative even if it contains no visible models; HTTP
 `401` and `403` return an empty catalog rather than exposing fallback models.
 
 <Note>
-The current bundled harness is `@openai/codex` `0.146.1`. A live `model/list`
-probe against the official `0.146.1` app-server returned these public picker
+The current bundled harness is `@openai/codex` `0.147.0`. A live `model/list`
+probe against the official `0.147.0` app-server returned these public picker
 rows:
 
-| Model id        | Input modalities | Reasoning efforts                    |
-| --------------- | ---------------- | ------------------------------------ |
-| `gpt-5.6-sol`   | text, image      | low, medium, high, xhigh, max, ultra |
-| `gpt-5.6-terra` | text, image      | low, medium, high, xhigh, max, ultra |
-| `gpt-5.6-luna`  | text, image      | low, medium, high, xhigh, max        |
-| `gpt-5.5`       | text, image      | low, medium, high, xhigh             |
-| `gpt-5.2`       | text, image      | low, medium, high, xhigh             |
+| Model id        | Input modalities | Reasoning efforts               |
+| --------------- | ---------------- | ------------------------------- |
+| `gpt-5.5`       | text, image      | low, medium, high, xhigh        |
+| `gpt-5.6`       | text, image      | low, medium, high, xhigh, ultra |
+| `gpt-5.6-luna`  | text, image      | low, medium, high, xhigh, ultra |
+| `gpt-5.6-terra` | text, image      | low, medium, high, xhigh, ultra |
+| `gpt-5.6-sol`   | text, image      | low, medium, high, xhigh, ultra |
+| `gpt-5.4`       | text, image      | low, medium, high, xhigh        |
+| `gpt-5.4-mini`  | text, image      | low, medium, high, xhigh        |
+| `gpt-5.3-codex` | text, image      | low, medium, high, xhigh        |
+| `gpt-5.2`       | text, image      | low, medium, high, xhigh        |
 
 Available model IDs, input modalities, and reasoning efforts remain
 account-scoped. Run `/codex models` after starting or upgrading the gateway to

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -66,10 +66,10 @@ channel is the communication surface.
 
 - The official `@openclaw/codex` plugin installed. Include `codex` in
   `plugins.allow` if your config uses an allowlist.
-- Codex app-server `0.146.1`. The plugin ships and manages `@openai/codex`
-  `0.146.1` by default, so a `codex` command on `PATH` does not affect normal
+- Codex app-server `0.147.0`. The plugin ships and manages `@openai/codex`
+  `0.147.0` by default, so a `codex` command on `PATH` does not affect normal
   startup. Explicit custom, remote, and macOS desktop-owned app-servers must
-  report the same exact stable `0.146.1` version.
+  report the same exact stable `0.147.0` version.
 - Node.js on the remote Codex app-server host when `remoteWorkspaceRoot` is set
   and cross-machine workspace attachments must be transferred.
 - Codex auth through `openclaw models auth login --provider openai`, an
@@ -1181,7 +1181,7 @@ instead of a plain OpenAI API-key failure.
 Doctor rewrites legacy model refs to `openai/*`, removes stale session and
 whole-agent runtime pins, and preserves existing auth-profile overrides.
 
-**The app-server is rejected:** use exactly stable Codex `0.146.1`. Older or
+**The app-server is rejected:** use exactly stable Codex `0.147.0`. Older or
 newer versions, prereleases, build-suffixed versions, and unversioned servers
 are rejected because OpenClaw validates generated schemas and runtime contracts
 against the Codex version it ships. Update or remove custom, remote, or desktop

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -22,8 +22,8 @@ working.
 - The agent runtime must be the native Codex harness.
 - `plugins.entries.codex.enabled` is `true`.
 - `plugins.entries.codex.config.codexPlugins.enabled` is `true`.
-- Codex app-server reports exactly stable `0.146.1`. The official plugin ships
-  `@openai/codex` `0.146.1`; custom, remote, and macOS desktop-owned binaries
+- Codex app-server reports exactly stable `0.147.0`. The official plugin ships
+  `@openai/codex` `0.147.0`; custom, remote, and macOS desktop-owned binaries
   must use the same exact version.
 - The target Codex app-server can see the expected marketplace, plugin, and
   app inventory.

--- a/extensions/codex/media-understanding-provider.test.ts
+++ b/extensions/codex/media-understanding-provider.test.ts
@@ -47,7 +47,7 @@ function threadStartResult() {
       status: { type: "idle" },
       path: null,
       cwd: "/tmp/openclaw-agent",
-      cliVersion: "0.146.1",
+      cliVersion: "0.147.0",
       source: "unknown",
       agentNickname: null,
       agentRole: null,

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@openai/codex": "0.146.1",
+    "@openai/codex": "0.147.0",
     "smol-toml": "1.7.1",
     "typebox": "1.3.6",
     "ws": "8.21.1",

--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -177,7 +177,7 @@ async function captureExpectedRuntimeArtifact(
     before,
     startOptions: appServer.start,
     spawnIdentity,
-    runtimeIdentity: { serverVersion: "0.146.1", userAgent: "openclaw/0.146.1 (macOS; test)" },
+    runtimeIdentity: { serverVersion: "0.147.0", userAgent: "openclaw/0.147.0 (macOS; test)" },
   });
 }
 
@@ -187,7 +187,7 @@ async function answerInitialize(harness: ClientHarness): Promise<void> {
     timeout: HARNESS_REQUEST_TIMEOUT_MS,
   });
   const initialize = JSON.parse(harness.writes[0] ?? "{}") as { id?: number };
-  harness.send({ id: initialize.id, result: { userAgent: "openclaw/0.146.1 (macOS; test)" } });
+  harness.send({ id: initialize.id, result: { userAgent: "openclaw/0.147.0 (macOS; test)" } });
 }
 
 async function waitForRequest(

--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -331,7 +331,7 @@ describe("CodexAppServerClient", () => {
     const { harness, initializing, outbound } = startInitialize();
     harness.send({
       id: outbound.id,
-      result: { userAgent: "openclaw/0.146.1 (macOS; test)" },
+      result: { userAgent: "openclaw/0.147.0 (macOS; test)" },
     });
 
     await expect(initializing).resolves.toBeUndefined();
@@ -383,11 +383,11 @@ describe("CodexAppServerClient", () => {
     const { harness, initializing, outbound } = startInitialize();
     harness.send({
       id: outbound.id,
-      result: { userAgent: "openclaw/0.146.1-alpha.2 (macOS; test)" },
+      result: { userAgent: "openclaw/0.147.0-alpha.2 (macOS; test)" },
     });
 
     await expect(initializing).rejects.toThrow(
-      `Codex app-server ${CODEX_APP_SERVER_VERSION} is required, but detected 0.146.1-alpha.2`,
+      `Codex app-server ${CODEX_APP_SERVER_VERSION} is required, but detected 0.147.0-alpha.2`,
     );
     expect(harness.writes).toHaveLength(1);
   });
@@ -396,11 +396,11 @@ describe("CodexAppServerClient", () => {
     const { harness, initializing, outbound } = startInitialize();
     harness.send({
       id: outbound.id,
-      result: { userAgent: "openclaw/0.146.1+alpha.2 (macOS; test)" },
+      result: { userAgent: "openclaw/0.147.0+alpha.2 (macOS; test)" },
     });
 
     await expect(initializing).rejects.toThrow(
-      `Codex app-server ${CODEX_APP_SERVER_VERSION} is required, but detected 0.146.1+alpha.2`,
+      `Codex app-server ${CODEX_APP_SERVER_VERSION} is required, but detected 0.147.0+alpha.2`,
     );
     expect(harness.writes).toHaveLength(1);
   });

--- a/extensions/codex/src/app-server/codex-app-server.test-fixtures.ts
+++ b/extensions/codex/src/app-server/codex-app-server.test-fixtures.ts
@@ -33,7 +33,7 @@ export function threadStartResult(threadId = "thread-1", cwd = "/tmp/openclaw-co
       status: { type: "idle" },
       path: null,
       cwd,
-      cliVersion: "0.146.1",
+      cliVersion: "0.147.0",
       source: "unknown",
       agentNickname: null,
       agentRole: null,

--- a/extensions/codex/src/app-server/models.test.ts
+++ b/extensions/codex/src/app-server/models.test.ts
@@ -149,7 +149,7 @@ describe("listCodexAppServerModels", () => {
     const initialize = JSON.parse(harness.writes[0] ?? "{}") as { id?: number };
     harness.send({
       id: initialize.id,
-      result: { userAgent: "openclaw/0.146.1 (macOS; test)" },
+      result: { userAgent: "openclaw/0.147.0 (macOS; test)" },
     });
     await vi.waitFor(() => expect(harness.writes.length).toBeGreaterThanOrEqual(3));
     const list = JSON.parse(harness.writes[2] ?? "{}") as { id?: number; method?: string };
@@ -170,7 +170,7 @@ describe("listCodexAppServerModels", () => {
     const initialize = JSON.parse(harness.writes[0] ?? "{}") as { id?: number };
     harness.send({
       id: initialize.id,
-      result: { userAgent: "openclaw/0.146.1 (macOS; test)" },
+      result: { userAgent: "openclaw/0.147.0 (macOS; test)" },
     });
     await vi.waitFor(() => expect(harness.writes.length).toBeGreaterThanOrEqual(3));
     const list = JSON.parse(harness.writes[2] ?? "{}") as { id?: number; method?: string };
@@ -232,7 +232,7 @@ describe("listCodexAppServerModels", () => {
     const initialize = JSON.parse(harness.writes[0] ?? "{}") as { id?: number };
     harness.send({
       id: initialize.id,
-      result: { userAgent: "openclaw/0.146.1 (macOS; test)" },
+      result: { userAgent: "openclaw/0.147.0 (macOS; test)" },
     });
     await vi.waitFor(() => expect(harness.writes.length).toBeGreaterThanOrEqual(3));
     const firstList = JSON.parse(harness.writes[2] ?? "{}") as {
@@ -312,7 +312,7 @@ describe("listCodexAppServerModels", () => {
     const initialize = JSON.parse(harness.writes[0] ?? "{}") as { id?: number };
     harness.send({
       id: initialize.id,
-      result: { userAgent: "openclaw/0.146.1 (macOS; test)" },
+      result: { userAgent: "openclaw/0.147.0 (macOS; test)" },
     });
     await vi.waitFor(() => expect(harness.writes.length).toBeGreaterThanOrEqual(3));
     const firstList = JSON.parse(harness.writes[2] ?? "{}") as { id?: number };

--- a/extensions/codex/src/app-server/protocol-generated/json/v2/CodexAppServerProtocolDefinitions.json
+++ b/extensions/codex/src/app-server/protocol-generated/json/v2/CodexAppServerProtocolDefinitions.json
@@ -368,7 +368,7 @@
               "type": "string"
             },
             "path": {
-              "$ref": "#/definitions/AbsolutePathBuf"
+              "$ref": "#/definitions/LegacyAppPathString"
             },
             "type": {
               "enum": [
@@ -1072,9 +1072,11 @@
         "pro",
         "prolite",
         "team",
+        "self_serve_business_prolite",
         "self_serve_business_usage_based",
         "business",
         "ent26",
+        "enterprise_cbp_automation",
         "enterprise_cbp_usage_based",
         "enterprise",
         "edu",
@@ -1434,11 +1436,6 @@
           "description": "Identifier for this thread. Codex-generated thread IDs are UUIDv7.",
           "type": "string"
         },
-        "isPinned": {
-          "default": false,
-          "description": "Whether the thread has been pinned by the user.",
-          "type": "boolean"
-        },
         "modelProvider": {
           "description": "Model provider used for this thread (for example, 'openai').",
           "type": "string"
@@ -1470,6 +1467,27 @@
         },
         "recencyAt": {
           "description": "Unix timestamp (in seconds) used for thread recency ordering.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "section": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadSection"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The independently persisted section selected for this thread, if any."
+        },
+        "sectionEnteredAt": {
+          "default": null,
+          "description": "Unix timestamp in seconds when the thread entered its current section.",
           "format": "int64",
           "type": [
             "integer",
@@ -1902,6 +1920,12 @@
                 "null"
               ]
             },
+            "readOnlyHint": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "result": {
               "anyOf": [
                 {
@@ -2237,6 +2261,13 @@
             "status": {
               "type": "string"
             },
+            "transparentBackground": {
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"
@@ -2323,6 +2354,24 @@
           "type": "object"
         }
       ]
+    },
+    "ThreadSection": {
+      "description": "An independently persisted, user-visible thread section.",
+      "properties": {
+        "id": {
+          "description": "Opaque UUIDv7 identity that remains stable when the section is renamed.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The current user-visible section name.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name"
+      ],
+      "type": "object"
     },
     "ThreadSource": {
       "type": "string"

--- a/extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts
@@ -76,7 +76,7 @@ function threadStartResult(threadId = "thread-1", serviceTier: string | null = n
       status: { type: "idle" },
       path: null,
       cwd: tempDir,
-      cliVersion: "0.146.1",
+      cliVersion: "0.147.0",
       source: "unknown",
       agentNickname: null,
       agentRole: null,

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -326,7 +326,7 @@ describe("shared Codex app-server client", () => {
     const options = { config, startOptions, timeoutMs: 1_000 };
 
     const firstAcquire = getLeasedSharedCodexAppServerClient(options);
-    await sendInitializeResult(first, "openclaw/0.146.1 (Linux; test)");
+    await sendInitializeResult(first, "openclaw/0.147.0 (Linux; test)");
     await expect(firstAcquire).resolves.toBe(first.client);
     expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
     expect(mocks.resolveCodexAppServerAuthProfileStore).toHaveBeenCalledOnce();
@@ -346,7 +346,7 @@ describe("shared Codex app-server client", () => {
 
     expect(clearSharedCodexAppServerClientIfCurrent(first.client)).toBe(true);
     const replacementAcquire = getLeasedSharedCodexAppServerClient(options);
-    await sendInitializeResult(replacement, "openclaw/0.146.1 (Linux; test)");
+    await sendInitializeResult(replacement, "openclaw/0.147.0 (Linux; test)");
     await expect(replacementAcquire).resolves.toBe(replacement.client);
     expect(releaseLeasedSharedCodexAppServerClient(replacement.client)).toBe(true);
     expect(mocks.resolveCodexAppServerAuthProfileStore).toHaveBeenCalledTimes(3);
@@ -397,7 +397,7 @@ describe("shared Codex app-server client", () => {
     await expect(first).rejects.toThrow("codex app-server initialize aborted");
     expect(harness.stdinDestroyed).toBe(false);
 
-    await sendInitializeResult(harness, "openclaw/0.146.1 (Linux; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (Linux; test)");
     await expect(second).resolves.toBe(harness.client);
     expect(releaseLeasedSharedCodexAppServerClient(harness.client)).toBe(true);
   });
@@ -406,7 +406,7 @@ describe("shared Codex app-server client", () => {
     const harness = createClientHarness();
     vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
     const acquire = getLeasedSharedCodexAppServerClient({ timeoutMs: 1_000 });
-    await sendInitializeResult(harness, "openclaw/0.146.1 (Linux; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (Linux; test)");
     const client = await acquire;
 
     const retained = retainSharedCodexAppServerClientByInstanceId(client.getInstanceId());
@@ -420,7 +420,7 @@ describe("shared Codex app-server client", () => {
     vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
     const options = { timeoutMs: 1_000 };
     const firstLease = getLeasedSharedCodexAppServerClient(options);
-    await sendInitializeResult(harness, "openclaw/0.146.1 (Linux; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (Linux; test)");
     const client = await firstLease;
     await expect(getLeasedSharedCodexAppServerClient(options)).resolves.toBe(client);
     const ownedLease = { client };
@@ -464,7 +464,7 @@ describe("shared Codex app-server client", () => {
 
     const listPromise = listCodexAppServerModels({ timeoutMs: 1000 });
     await sendInitializeResult(desktop, "openclaw/0.124.9 (macOS; test)");
-    await sendInitializeResult(pluginLocal, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(pluginLocal, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(pluginLocal);
 
     await expect(listPromise).resolves.toEqual({ models: [] });
@@ -502,13 +502,13 @@ describe("shared Codex app-server client", () => {
       };
 
       const normalPromise = getLeasedSharedCodexAppServerClient({ startOptions });
-      await sendInitializeResult(normal, "openclaw/0.146.1 (Linux; test)");
+      await sendInitializeResult(normal, "openclaw/0.147.0 (Linux; test)");
       const normalClient = await normalPromise;
       const capturedPromise = getLeasedSharedCodexAppServerClient({
         startOptions,
         runtimeArtifactMode: "capture",
       });
-      await sendInitializeResult(captured, "openclaw/0.146.1 (Linux; test)");
+      await sendInitializeResult(captured, "openclaw/0.147.0 (Linux; test)");
       const capturedClient = await capturedPromise;
 
       expect(capturedClient).not.toBe(normalClient);
@@ -560,7 +560,7 @@ describe("shared Codex app-server client", () => {
         runtimeArtifactMode: "capture",
       });
       await sendInitializeResult(desktop, "openclaw/0.124.9 (macOS; test)");
-      await sendInitializeResult(fallback, "openclaw/0.146.1 (macOS; test)");
+      await sendInitializeResult(fallback, "openclaw/0.147.0 (macOS; test)");
       const client = await acquire;
       const { readCodexAppServerClientRuntimeArtifact, validateCodexAppServerRuntimeArtifact } =
         await import("./runtime-artifact.js");
@@ -623,7 +623,7 @@ describe("shared Codex app-server client", () => {
         startOptions,
         agentDir,
       });
-      await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+      await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
       const client = await clientPromise;
 
       expect(readCodexAppServerClientProcessIdentity(client)).toEqual({
@@ -632,8 +632,8 @@ describe("shared Codex app-server client", () => {
         argsFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
         commandSource: "resolved-managed",
         nativeCommand: "/cache/openclaw/codex.native",
-        serverVersion: "0.146.1",
-        userAgent: "openclaw/0.146.1 (macOS; test)",
+        serverVersion: "0.147.0",
+        userAgent: "openclaw/0.147.0 (macOS; test)",
       });
 
       expect(() =>
@@ -717,7 +717,7 @@ describe("shared Codex app-server client", () => {
         };
 
         const clientPromise = createIsolatedCodexAppServerClient({ startOptions, agentDir });
-        await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+        await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
         const client = await clientPromise;
         const fenceKey = resolveCodexNativeConfigFenceKey({ client });
         expect(fenceKey).toBeTypeOf("string");
@@ -786,7 +786,7 @@ describe("shared Codex app-server client", () => {
 
     vi.useRealTimers();
     const secondList = listCodexAppServerModels({ timeoutMs: 1000 });
-    await sendInitializeResult(second, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(second, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(second);
 
     await expect(secondList).resolves.toEqual({ models: [] });
@@ -819,7 +819,7 @@ describe("shared Codex app-server client", () => {
     await expect(shortAcquire).rejects.toThrow("codex app-server initialize timed out");
     expect(harness.process.stdin.destroyed).toBe(false);
 
-    await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
 
     await expect(longAcquire).resolves.toBe(harness.client);
     expect(startSpy).toHaveBeenCalledTimes(1);
@@ -832,7 +832,7 @@ describe("shared Codex app-server client", () => {
     const releaseAuth = deferNextAuthProfileApplication();
 
     const acquire = getSharedCodexAppServerClient({ timeoutMs: 100 });
-    await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
 
     await expect(acquire).rejects.toThrow("codex app-server authentication timed out");
     expect(harness.process.stdin.destroyed).toBe(true);
@@ -846,7 +846,7 @@ describe("shared Codex app-server client", () => {
 
     const shortAcquire = getSharedCodexAppServerClient({ timeoutMs: 100 });
     const longAcquire = getSharedCodexAppServerClient({ timeoutMs: 1000 });
-    await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
 
     await expect(shortAcquire).rejects.toThrow("codex app-server authentication timed out");
     expect(harness.process.stdin.destroyed).toBe(false);
@@ -875,7 +875,7 @@ describe("shared Codex app-server client", () => {
     abandonController.abort();
     expect(harness.process.stdin.destroyed).toBe(false);
 
-    await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
 
     await abandonedRejection;
     await expect(activeAcquire).resolves.toBe(harness.client);
@@ -931,7 +931,7 @@ describe("shared Codex app-server client", () => {
     const rejection = expect(clientPromise).rejects.toThrow(
       "codex app-server initialize timed out",
     );
-    await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
 
     await rejection;
     expect(harness.process.stdin.destroyed).toBe(true);
@@ -947,7 +947,7 @@ describe("shared Codex app-server client", () => {
     const clientPromise = createIsolatedCodexAppServerClient({ timeoutMs: 100 });
     await vi.waitFor(() => expect(harness.writes.length).toBeGreaterThanOrEqual(1));
     now = 101;
-    await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
 
     await expect(clientPromise).rejects.toThrow("codex app-server initialize timed out");
     expect(mocks.applyCodexAppServerAuthProfile).not.toHaveBeenCalled();
@@ -962,7 +962,7 @@ describe("shared Codex app-server client", () => {
       timeoutMs: 1000,
       authProfileId: "openai:work",
     });
-    await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(harness);
 
     await expect(listPromise).resolves.toEqual({ models: [] });
@@ -989,7 +989,7 @@ describe("shared Codex app-server client", () => {
       timeoutMs: 1000,
       authProfileStore,
     });
-    await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
 
     await expect(clientPromise).resolves.toBe(harness.client);
     expect(mocks.resolveCodexAppServerAuthProfileStore).toHaveBeenCalledWith({
@@ -1048,7 +1048,7 @@ describe("shared Codex app-server client", () => {
         store: authProfileStore,
       },
     });
-    await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
 
     await expect(clientPromise).resolves.toBe(harness.client);
     expect(mocks.resolveCodexAppServerAuthProfileStore).not.toHaveBeenCalled();
@@ -1142,7 +1142,7 @@ describe("shared Codex app-server client", () => {
       timeoutMs: 1000,
       preparedAuth: { kind: "profile", profileId: "openai:scoped", store: firstStore },
     });
-    await sendInitializeResult(firstHarness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(firstHarness, "openclaw/0.147.0 (macOS; test)");
     await expect(firstPromise).resolves.toBe(firstHarness.client);
 
     const secondPromise = getSharedCodexAppServerClient({
@@ -1150,7 +1150,7 @@ describe("shared Codex app-server client", () => {
       preparedAuth: { kind: "profile", profileId: "openai:scoped", store: secondStore },
     });
     await vi.waitFor(() => expect(startSpy).toHaveBeenCalledTimes(2));
-    await sendInitializeResult(secondHarness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(secondHarness, "openclaw/0.147.0 (macOS; test)");
     await expect(secondPromise).resolves.toBe(secondHarness.client);
 
     expect(resolvedCacheKeys).toEqual(["account:sha256:first", "account:sha256:second"]);
@@ -1186,7 +1186,7 @@ describe("shared Codex app-server client", () => {
       timeoutMs: 1000,
       preparedAuth: { kind: "api-key", apiKey: "platform-key" },
     });
-    await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
 
     await expect(clientPromise).resolves.toBe(harness.client);
     expect(mocks.resolveCodexAppServerAuthProfileStore).not.toHaveBeenCalled();
@@ -1235,7 +1235,7 @@ describe("shared Codex app-server client", () => {
       timeoutMs: 1000,
       preparedAuth: { kind: "api-key", apiKey: "first-platform-key" },
     });
-    await sendInitializeResult(firstHarness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(firstHarness, "openclaw/0.147.0 (macOS; test)");
     await expect(firstPromise).resolves.toBe(firstHarness.client);
 
     const secondPromise = getSharedCodexAppServerClient({
@@ -1243,7 +1243,7 @@ describe("shared Codex app-server client", () => {
       preparedAuth: { kind: "api-key", apiKey: "second-platform-key" },
     });
     await vi.waitFor(() => expect(startSpy).toHaveBeenCalledTimes(2));
-    await sendInitializeResult(secondHarness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(secondHarness, "openclaw/0.147.0 (macOS; test)");
     await expect(secondPromise).resolves.toBe(secondHarness.client);
 
     expect(cacheKeys).toEqual(["api_key:sha256:first", "api_key:sha256:second"]);
@@ -1271,7 +1271,7 @@ describe("shared Codex app-server client", () => {
       authProfileId: "openai:persisted",
       agentDir: "/tmp/openclaw-persisted-agent",
     });
-    await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
 
     await expect(clientPromise).resolves.toBe(harness.client);
     const priorWriteCount = harness.writes.length;
@@ -1309,7 +1309,7 @@ describe("shared Codex app-server client", () => {
       agentId: "research",
       config,
     });
-    await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
 
     await expect(clientPromise).resolves.toBe(harness.client);
     expect(mocks.resolveCodexAppServerAuthProfileIdForAgent).not.toHaveBeenCalled();
@@ -1339,7 +1339,7 @@ describe("shared Codex app-server client", () => {
         headers: {},
       },
     });
-    await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
 
     await expect(clientPromise).resolves.toBe(harness.client);
     expect(mocks.resolveCodexAppServerAuthProfileIdForAgent).not.toHaveBeenCalled();
@@ -1357,7 +1357,7 @@ describe("shared Codex app-server client", () => {
       timeoutMs: 1000,
       config,
     });
-    await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(harness);
 
     await expect(listPromise).resolves.toEqual({ models: [] });
@@ -1384,7 +1384,7 @@ describe("shared Codex app-server client", () => {
       authProfileId: "openai:work",
       agentDir: "/tmp/openclaw-agent-nova",
     });
-    await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(harness);
 
     await expect(listPromise).resolves.toEqual({ models: [] });
@@ -1408,7 +1408,7 @@ describe("shared Codex app-server client", () => {
       timeoutMs: 1000,
       agentDir: "/tmp/openclaw-agent-one",
     });
-    await sendInitializeResult(first, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(first, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(first);
     await expect(firstList).resolves.toEqual({ models: [] });
 
@@ -1416,7 +1416,7 @@ describe("shared Codex app-server client", () => {
       timeoutMs: 1000,
       agentDir: "/tmp/openclaw-agent-two",
     });
-    await sendInitializeResult(second, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(second, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(second);
     await expect(secondList).resolves.toEqual({ models: [] });
 
@@ -1435,7 +1435,7 @@ describe("shared Codex app-server client", () => {
     }));
 
     const listPromise = listCodexAppServerModels({ timeoutMs: 1000 });
-    await sendInitializeResult(harness, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(harness);
 
     await expect(listPromise).resolves.toEqual({ models: [] });
@@ -1500,7 +1500,7 @@ describe("shared Codex app-server client", () => {
         headers: {},
       },
     });
-    await sendInitializeResult(first, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(first, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(first);
     await expect(firstList).resolves.toEqual({ models: [] });
 
@@ -1515,7 +1515,7 @@ describe("shared Codex app-server client", () => {
         headers: {},
       },
     });
-    await sendInitializeResult(second, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(second, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(second);
     await expect(secondList).resolves.toEqual({ models: [] });
 
@@ -1538,7 +1538,7 @@ describe("shared Codex app-server client", () => {
       timeoutMs: 1000,
       authRequirement: "api-key",
     });
-    await sendInitializeResult(first, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(first, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(first);
     await expect(firstList).resolves.toEqual({ models: [] });
 
@@ -1546,7 +1546,7 @@ describe("shared Codex app-server client", () => {
       timeoutMs: 1000,
       authRequirement: "api-key",
     });
-    await sendInitializeResult(second, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(second, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(second);
     await expect(secondList).resolves.toEqual({ models: [] });
 
@@ -1568,7 +1568,7 @@ describe("shared Codex app-server client", () => {
       authProfileId: "openai:work",
       authRequirement: "api-key",
     });
-    await sendInitializeResult(first, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(first, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(first);
     await expect(firstList).resolves.toEqual({ models: [] });
 
@@ -1577,7 +1577,7 @@ describe("shared Codex app-server client", () => {
       authProfileId: "openai:work",
       authRequirement: "subscription",
     });
-    await sendInitializeResult(second, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(second, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(second);
     await expect(secondList).resolves.toEqual({ models: [] });
 
@@ -1632,7 +1632,7 @@ describe("shared Codex app-server client", () => {
     });
     await vi.waitFor(() => expect(second.writes.length).toBeGreaterThanOrEqual(1));
 
-    await sendInitializeResult(second, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(second, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(second);
     await expect(secondList).resolves.toEqual({ models: [] });
 
@@ -1650,7 +1650,7 @@ describe("shared Codex app-server client", () => {
       .mockReturnValueOnce(second.client);
 
     const firstList = listCodexAppServerModels({ timeoutMs: 1000 });
-    await sendInitializeResult(first, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(first, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(first);
     await expect(firstList).resolves.toEqual({ models: [] });
 
@@ -1658,7 +1658,7 @@ describe("shared Codex app-server client", () => {
     expect(first.process.stdin.destroyed).toBe(true);
 
     const secondList = listCodexAppServerModels({ timeoutMs: 1000 });
-    await sendInitializeResult(second, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(second, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(second);
     await expect(secondList).resolves.toEqual({ models: [] });
 
@@ -1676,7 +1676,7 @@ describe("shared Codex app-server client", () => {
       .mockReturnValueOnce(second.client);
 
     const firstList = listCodexAppServerModels({ timeoutMs: 1000 });
-    await sendInitializeResult(first, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(first, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(first);
     await expect(firstList).resolves.toEqual({ models: [] });
 
@@ -1695,7 +1695,7 @@ describe("shared Codex app-server client", () => {
     await expect(activeRequest).rejects.toThrow("codex app-server client is closed");
 
     const secondList = listCodexAppServerModels({ timeoutMs: 1000 });
-    await sendInitializeResult(second, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(second, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(second);
     await expect(secondList).resolves.toEqual({ models: [] });
 
@@ -1715,7 +1715,7 @@ describe("shared Codex app-server client", () => {
     vi.spyOn(CodexAppServerClient, "start").mockReturnValueOnce(harness.client);
 
     const clientPromise = getLeasedSharedCodexAppServerClient({ timeoutMs: 1000 });
-    await sendInitializeResult(harness, "openclaw/0.146.1 (Linux; test)");
+    await sendInitializeResult(harness, "openclaw/0.147.0 (Linux; test)");
     const client = await clientPromise;
     const deliverCompletion = vi.fn(async () => ({ delivered: true, path: "direct" as const }));
     const taskRuntime = {
@@ -1810,7 +1810,7 @@ describe("shared Codex app-server client", () => {
 
     const firstLease = getLeasedSharedCodexAppServerClient({ timeoutMs: 1000 });
     const secondLease = getLeasedSharedCodexAppServerClient({ timeoutMs: 1000 });
-    await sendInitializeResult(first, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(first, "openclaw/0.147.0 (macOS; test)");
     await expect(firstLease).resolves.toBe(first.client);
     await expect(secondLease).resolves.toBe(first.client);
 
@@ -1844,7 +1844,7 @@ describe("shared Codex app-server client", () => {
 
     const completedRunLease = getLeasedSharedCodexAppServerClient({ timeoutMs: 1000 });
     const siblingRunLease = getLeasedSharedCodexAppServerClient({ timeoutMs: 1000 });
-    await sendInitializeResult(first, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(first, "openclaw/0.147.0 (macOS; test)");
     await expect(completedRunLease).resolves.toBe(first.client);
     await expect(siblingRunLease).resolves.toBe(first.client);
 
@@ -1893,7 +1893,7 @@ describe("shared Codex app-server client", () => {
     await expect(pendingLease).rejects.toThrow("codex app-server client is closed");
 
     const freshLease = getLeasedSharedCodexAppServerClient({ timeoutMs: 1000 });
-    await sendInitializeResult(second, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(second, "openclaw/0.147.0 (macOS; test)");
     await expect(freshLease).resolves.toBe(second.client);
     expect(second.process.stdin.destroyed).toBe(false);
   });
@@ -1903,7 +1903,7 @@ describe("shared Codex app-server client", () => {
     vi.spyOn(CodexAppServerClient, "start").mockReturnValueOnce(first.client);
 
     const lease = getLeasedSharedCodexAppServerClient({ timeoutMs: 1000 });
-    await sendInitializeResult(first, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(first, "openclaw/0.147.0 (macOS; test)");
     await expect(lease).resolves.toBe(first.client);
 
     // Routine cleanup detaches gracefully; a later terminal-idle kill must
@@ -1929,7 +1929,7 @@ describe("shared Codex app-server client", () => {
     vi.spyOn(CodexAppServerClient, "start").mockReturnValueOnce(first.client);
 
     const lease = getLeasedSharedCodexAppServerClient({ timeoutMs: 1000 });
-    await sendInitializeResult(first, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(first, "openclaw/0.147.0 (macOS; test)");
     await expect(lease).resolves.toBe(first.client);
 
     // Routine cleanup (e.g. one-shot bundle-MCP) must not yank a healthy
@@ -1957,7 +1957,7 @@ describe("shared Codex app-server client", () => {
       timeoutMs: 1000,
       agentDir: "/tmp/openclaw-agent-one",
     });
-    await sendInitializeResult(first, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(first, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(first);
     await expect(firstList).resolves.toEqual({ models: [] });
 
@@ -1965,7 +1965,7 @@ describe("shared Codex app-server client", () => {
       timeoutMs: 1000,
       agentDir: "/tmp/openclaw-agent-two",
     });
-    await sendInitializeResult(second, "openclaw/0.146.1 (macOS; test)");
+    await sendInitializeResult(second, "openclaw/0.147.0 (macOS; test)");
     await sendEmptyModelList(second);
     await expect(secondList).resolves.toEqual({ models: [] });
 
@@ -1991,7 +1991,7 @@ describe("shared Codex app-server client", () => {
         const message = JSON.parse(rawDataToText(data)) as { id?: number; method?: string };
         if (message.method === "initialize") {
           socket.send(
-            JSON.stringify({ id: message.id, result: { userAgent: "openclaw/0.146.1" } }),
+            JSON.stringify({ id: message.id, result: { userAgent: "openclaw/0.147.0" } }),
           );
           return;
         }

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -245,7 +245,7 @@ function threadResult(threadId: string) {
       status: { type: "idle" },
       path: null,
       cwd: "/tmp/workspace",
-      cliVersion: "0.146.1",
+      cliVersion: "0.147.0",
       source: "unknown",
       agentNickname: null,
       agentRole: null,

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -549,7 +549,7 @@ function threadStartResult(threadId = "thread-1") {
       status: { type: "idle" },
       path: null,
       cwd: tempDir,
-      cliVersion: "0.146.1",
+      cliVersion: "0.147.0",
       source: "unknown",
       agentNickname: null,
       agentRole: null,

--- a/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
@@ -36,7 +36,7 @@ function threadStartResult(threadId = "thread-1"): Record<string, unknown> {
       status: { type: "idle" },
       path: null,
       cwd: "/tmp",
-      cliVersion: "0.146.1",
+      cliVersion: "0.147.0",
       source: "unknown",
       agentNickname: null,
       agentRole: null,

--- a/extensions/codex/src/app-server/transport-websocket.test.ts
+++ b/extensions/codex/src/app-server/transport-websocket.test.ts
@@ -55,7 +55,7 @@ describe("Codex app-server websocket transport", () => {
         const message = JSON.parse(rawDataToText(data)) as { id?: number; method?: string };
         if (message.method === "initialize") {
           socket.send(
-            JSON.stringify({ id: message.id, result: { userAgent: "openclaw/0.146.1" } }),
+            JSON.stringify({ id: message.id, result: { userAgent: "openclaw/0.147.0" } }),
           );
           return;
         }

--- a/extensions/codex/src/app-server/upstream-session-fork.test.ts
+++ b/extensions/codex/src/app-server/upstream-session-fork.test.ts
@@ -79,7 +79,7 @@ function forkResponse(threadId = "thread-forked") {
     thread: {
       id: threadId,
       sessionId: "session-forked",
-      cliVersion: "0.146.1",
+      cliVersion: "0.147.0",
       createdAt: 1715299200,
       updatedAt: 1715299200,
       cwd: "/tmp",

--- a/extensions/codex/src/app-server/user-input-bridge.test.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.test.ts
@@ -4,10 +4,14 @@ import {
   type AgentHarnessQuestionGatewayCall,
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createCodexUserInputBridge } from "./user-input-bridge.js";
 
 type GatewayCallRecord = { method: string; opts: unknown; params: unknown };
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 function createParams(signal?: AbortSignal): EmbeddedRunAttemptParams {
   return {
@@ -222,7 +226,7 @@ describe("Codex app-server user input bridge", () => {
     );
   });
 
-  it("passes Codex autoResolutionMs and option-less free text through", async () => {
+  it("keeps legacy requests blocking and ignores deprecated autoResolutionMs", async () => {
     const params = createParams();
     const gateway = createGatewayStub();
     const bridge = createCodexUserInputBridge({
@@ -249,12 +253,98 @@ describe("Codex app-server user input bridge", () => {
     });
     await vi.waitFor(() => expect(params.onBlockReply).toHaveBeenCalledOnce());
     expect(gateway.calls[0]?.params).toMatchObject({
-      timeoutMs: 60_000,
+      timeoutMs: 90_000,
       questions: [expect.objectContaining({ questionId: "notes", options: [] })],
     });
     await claimPendingAgentQuestionAnswer({ sessionKey: params.sessionKey, text: "Refactor it" });
     await expect(response).resolves.toEqual({
       answers: { notes: { answers: ["Refactor it"] } },
     });
+  });
+
+  it("auto-resolves nonblocking gateway questions after exactly 120 seconds", async () => {
+    vi.useFakeTimers();
+    const params = createParams();
+    const calls: GatewayCallRecord[] = [];
+    const gatewayCall: AgentHarnessQuestionGatewayCall = async (method, opts, rawParams) => {
+      calls.push({ method, opts, params: rawParams });
+      if (method === "question.request") {
+        return { id: (rawParams as { id: string }).id };
+      }
+      if (method === "question.waitAnswer") {
+        return await new Promise((resolve) => {
+          setTimeout(() => resolve({ status: "pending" }), 120_000);
+        });
+      }
+      if (method === "question.resolve") {
+        return { status: "cancelled" };
+      }
+      throw new Error(`unexpected gateway method: ${method}`);
+    };
+    const bridge = createCodexUserInputBridge({
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      gatewayCall,
+    });
+
+    const response = bridge.handleRequest({
+      id: "input-nonblocking",
+      params: requestParams({ isBlocking: false, autoResolutionMs: 60_000 }),
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(calls.find((entry) => entry.method === "question.request")?.params).toMatchObject({
+      timeoutMs: 120_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(119_999);
+    let settled = false;
+    void response.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(response).resolves.toEqual({ answers: {} });
+  });
+
+  it("auto-resolves nonblocking secret prompts after exactly 120 seconds", async () => {
+    vi.useFakeTimers();
+    const params = createParams();
+    const bridge = createCodexUserInputBridge({
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    const response = bridge.handleRequest({
+      id: "input-secret-nonblocking",
+      params: requestParams({
+        isBlocking: false,
+        autoResolutionMs: 60_000,
+        questions: [
+          {
+            id: "token",
+            header: "Secret",
+            question: "Enter token",
+            isOther: true,
+            isSecret: true,
+            options: null,
+          },
+        ],
+      }),
+    });
+
+    await vi.advanceTimersByTimeAsync(119_999);
+    let settled = false;
+    void response.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(response).resolves.toEqual({ answers: {} });
+    expect(bridge.claimPendingRequest()).toBeUndefined();
   });
 });

--- a/extensions/codex/src/app-server/user-input-bridge.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.ts
@@ -20,6 +20,8 @@ import {
 } from "./protocol.js";
 
 const DEFAULT_USER_INPUT_TIMEOUT_MS = 15 * 60_000;
+// Codex omits a deadline for nonblocking requests, so bound gateway and secret paths alike.
+const NONBLOCKING_USER_INPUT_TIMEOUT_MS = 120_000;
 
 type PendingSecretUserInput = {
   requestId: number | string;
@@ -104,7 +106,19 @@ export function createCodexUserInputBridge(params: {
       if (requestParams.questions.some((question) => question.isSecret)) {
         return new Promise<JsonValue>((resolve) => {
           const abortListener = () => resolveSecret(emptyUserInputResponse());
-          const cleanup = () => params.signal?.removeEventListener("abort", abortListener);
+          const timeout = requestParams.isBlocking
+            ? undefined
+            : setTimeout(
+                () => resolveSecret(emptyUserInputResponse()),
+                NONBLOCKING_USER_INPUT_TIMEOUT_MS,
+              );
+          timeout?.unref?.();
+          const cleanup = () => {
+            params.signal?.removeEventListener("abort", abortListener);
+            if (timeout) {
+              clearTimeout(timeout);
+            }
+          };
           const current: PendingSecretUserInput = {
             requestId: request.id,
             threadId: requestParams.threadId,
@@ -141,10 +155,9 @@ export function createCodexUserInputBridge(params: {
           sessionKey: params.paramsForRun.sessionKey ?? params.paramsForRun.sessionId,
           agentId: params.paramsForRun.agentId,
           runId: params.paramsForRun.runId,
-          timeoutMs:
-            requestParams.autoResolutionMs ??
-            params.paramsForRun.timeoutMs ??
-            DEFAULT_USER_INPUT_TIMEOUT_MS,
+          timeoutMs: requestParams.isBlocking
+            ? (params.paramsForRun.timeoutMs ?? DEFAULT_USER_INPUT_TIMEOUT_MS)
+            : NONBLOCKING_USER_INPUT_TIMEOUT_MS,
           gatewayCall,
           delivery: params.paramsForRun,
           promptOptions: {
@@ -217,7 +230,7 @@ function readUserInputParams(value: JsonValue | undefined):
       turnId: string;
       itemId: string;
       questions: AgentHarnessUserInputQuestion[];
-      autoResolutionMs?: number;
+      isBlocking: boolean;
     }
   | undefined {
   if (!isJsonObject(value)) {
@@ -239,11 +252,7 @@ function readUserInputParams(value: JsonValue | undefined):
       return question;
     })
     .filter((question): question is AgentHarnessUserInputQuestion => Boolean(question));
-  const autoResolutionMs =
-    typeof value.autoResolutionMs === "number" && value.autoResolutionMs > 0
-      ? value.autoResolutionMs
-      : undefined;
-  return { threadId, turnId, itemId, questions, autoResolutionMs };
+  return { threadId, turnId, itemId, questions, isBlocking: value.isBlocking !== false };
 }
 
 function readQuestion(value: JsonValue): AgentHarnessUserInputQuestion | undefined {

--- a/extensions/codex/src/app-server/version.ts
+++ b/extensions/codex/src/app-server/version.ts
@@ -2,6 +2,6 @@
  * Version and package pins for the managed Codex app-server runtime.
  */
 /** Exact Codex app-server version shipped and supported by the OpenClaw Codex bridge. */
-export const CODEX_APP_SERVER_VERSION = "0.146.1";
+export const CODEX_APP_SERVER_VERSION = "0.147.0";
 /** npm package name for the managed Codex app-server binary. */
 export const MANAGED_CODEX_APP_SERVER_PACKAGE = "@openai/codex";

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -242,7 +242,7 @@ function conversationThreadStartResult(threadId: string) {
       status: { type: "idle" },
       path: null,
       cwd: tempDir,
-      cliVersion: "0.146.1",
+      cliVersion: "0.147.0",
       source: "unknown",
       agentNickname: null,
       agentRole: null,

--- a/extensions/codex/src/web-search-provider.test.ts
+++ b/extensions/codex/src/web-search-provider.test.ts
@@ -48,7 +48,7 @@ function threadStartResult() {
       status: { type: "idle" },
       path: null,
       cwd: "/tmp/openclaw-agent",
-      cliVersion: "0.146.1",
+      cliVersion: "0.147.0",
       source: "unknown",
       agentNickname: null,
       agentRole: null,

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -84,7 +84,7 @@ function classifyOpenAiFailoverCode(code: string | undefined) {
 const OPENAI_MODELS_ENDPOINT = "https://api.openai.com/v1/models";
 // Keep synchronized with extensions/codex's exact @openai/codex dependency;
 // the provider contract test fails when that managed-runtime pin changes.
-const OPENAI_CODEX_CLIENT_VERSION = "0.146.1";
+const OPENAI_CODEX_CLIENT_VERSION = "0.147.0";
 const OPENAI_CODEX_MODELS_ENDPOINT = `${OPENAI_CODEX_RESPONSES_BASE_URL}/models?client_version=${OPENAI_CODEX_CLIENT_VERSION}`;
 const OPENAI_MODELS_CACHE_TTL_MS = 60_000;
 const OPENAI_CODEX_MODELS_CACHE_TTL_MS = 60_000;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@agentclientprotocol/codex-acp@1.1.7>@openai/codex': 0.146.1
+  '@agentclientprotocol/codex-acp@1.1.7>@openai/codex': 0.147.0
   '@anthropic-ai/sdk': 0.115.0
   '@opentelemetry/core': 2.10.0
   '@opentelemetry/propagator-jaeger': 2.10.0
@@ -640,8 +640,8 @@ importers:
   extensions/codex:
     dependencies:
       '@openai/codex':
-        specifier: 0.146.1
-        version: 0.146.1
+        specifier: 0.147.0
+        version: 0.147.0
       smol-toml:
         specifier: 1.7.1
         version: 1.7.1
@@ -4085,43 +4085,43 @@ packages:
     resolution: {integrity: sha512-3zcN5Q3yEmeyxXBzqB6fXPQFzYa2ROsGFSr69W0ArXIAGJqxl/aFECOVPD2kbkYPm0U/EHxFKgclK3UA9WQg5A==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
-  '@openai/codex@0.146.1':
-    resolution: {integrity: sha512-f51R56E/G15soLhf5l5pWUiM+mGHK0NdLozOtzjRoAa+bA20hgWrkyxE/fpwCnuGQM6XNdktHYtK9xQ7bPIbTA==}
+  '@openai/codex@0.147.0':
+    resolution: {integrity: sha512-EQLEXecAG2ptxI7UpBMo2TR/ga5596/c/OsYF/0LoUDh5JANZ7IoGqlzBEWbuEVQ76JePIbtTW/ihCkp1a7Z3w==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.146.1-darwin-arm64':
-    resolution: {integrity: sha512-zvXxiGRuKCOoFQyh7lRC2SHwomM2VNzHralyeP+i6fxLjQ5grpmnfJpnLs54+GkK7K5nEpkj7chqjlKbMELgZw==}
+  '@openai/codex@0.147.0-darwin-arm64':
+    resolution: {integrity: sha512-BEUVkiOW7kLcRyrMLfAr/h9wF8sRVJyZDy6OHtVn6QGDXiv3BvAZVTY1Pu9xF7KdIdkYXbp4uayN0aDQQaAUJw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.146.1-darwin-x64':
-    resolution: {integrity: sha512-XQbemMBWH37hVL2vkoP+t//QyUmMjDRksf8YHmhAzHmt2oTTo8xyzH76LLFqMPCNpTdG755T8ZCbkpM0X2NJwA==}
+  '@openai/codex@0.147.0-darwin-x64':
+    resolution: {integrity: sha512-Tb8McE5SvJIH0Vs5R6sq7u+quiC931yan2KOOl6km1OdZ82+Wi7eF5XrSFPs5CF7xCgoIK4Vs+byMbT5hN+ZUw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.146.1-linux-arm64':
-    resolution: {integrity: sha512-2LhK2axFZKe6BbhlzGXCpVkSva1TikFYJIq6x7+xu0AdfmY855EV5lQ7lwFpjJfM5gAJqxcycttvE1ODoSoLaA==}
+  '@openai/codex@0.147.0-linux-arm64':
+    resolution: {integrity: sha512-SLC1JXw2TYfr/c3HhrJubyyLelq7vTOLWVmiThFA+z0+WgzCPmaseJ/kzDD3Gge/TO7fCnnj7UcPmC0d2c8XAg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.146.1-linux-x64':
-    resolution: {integrity: sha512-XPWpWzJgGK1ygsUBMXgskEkr+uTVj/XOnnCP2UE9tQUXTWYRYElz7QW1YS3bxkN6Kev4CJQKbdJopVwh+0E/TQ==}
+  '@openai/codex@0.147.0-linux-x64':
+    resolution: {integrity: sha512-0W9MBxPpWW0cSkNqrTDN2jR7rzzT7oNMhQY5446lT2Lw5cz5yhDTck4Va9rjkQEm+HlFzP/dmEMSZbXfJsINmw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.146.1-win32-arm64':
-    resolution: {integrity: sha512-3UJf8sKefCbUgPPcgQRiCaKn9AsItuPl0ZL6erHWzT6UIemrdjt2WHiTNOw/7tVJRnUsG4A1LUrK2to9/SkwXA==}
+  '@openai/codex@0.147.0-win32-arm64':
+    resolution: {integrity: sha512-e2ZstJ8zT8Rm1nvR7CUVO+Gr3cTChE41+VfOzGhynzDXEoW0wfbjUQbc2bWbh1arG94LMm4y3dqBtUIbSrfeGA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.146.1-win32-x64':
-    resolution: {integrity: sha512-FfiNJysKpHkJ08Kn+571r701dgoZVZjqNUxrEZ/JJyu5hIzNTs4XBllAX6ynHkF8G9NebPEtaJz72zxbol/JPg==}
+  '@openai/codex@0.147.0-win32-x64':
+    resolution: {integrity: sha512-oT7Ss5fAPf2fiWE9QNURqZcQGAAawSVxmIUdgPzckq4KFZAM+pRz9JbM4Rr498CjtbNgTOjWvDJ+DXvIBSfOPA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -9517,7 +9517,7 @@ snapshots:
   '@agentclientprotocol/codex-acp@1.1.7':
     dependencies:
       '@agentclientprotocol/sdk': 1.3.0(zod@4.4.3)
-      '@openai/codex': 0.146.1
+      '@openai/codex': 0.147.0
       diff: 9.0.0
       open: 11.0.0
       vscode-jsonrpc: 9.0.1
@@ -11381,31 +11381,31 @@ snapshots:
 
   '@npmcli/redact@5.0.0': {}
 
-  '@openai/codex@0.146.1':
+  '@openai/codex@0.147.0':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.146.1-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.146.1-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.146.1-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.146.1-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.146.1-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.146.1-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.147.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.147.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.147.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.147.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.147.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.147.0-win32-x64'
 
-  '@openai/codex@0.146.1-darwin-arm64':
+  '@openai/codex@0.147.0-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.146.1-darwin-x64':
+  '@openai/codex@0.147.0-darwin-x64':
     optional: true
 
-  '@openai/codex@0.146.1-linux-arm64':
+  '@openai/codex@0.147.0-linux-arm64':
     optional: true
 
-  '@openai/codex@0.146.1-linux-x64':
+  '@openai/codex@0.147.0-linux-x64':
     optional: true
 
-  '@openai/codex@0.146.1-win32-arm64':
+  '@openai/codex@0.147.0-win32-arm64':
     optional: true
 
-  '@openai/codex@0.146.1-win32-x64':
+  '@openai/codex@0.147.0-win32-x64':
     optional: true
 
   '@openclaw/crabline@0.1.11':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -120,7 +120,7 @@ verifyDepsBeforeRun: false
 blockExoticSubdeps: true
 
 overrides:
-  "@agentclientprotocol/codex-acp@1.1.7>@openai/codex": 0.146.1
+  "@agentclientprotocol/codex-acp@1.1.7>@openai/codex": 0.147.0
   "@anthropic-ai/sdk": 0.115.0
   "@opentelemetry/core": 2.10.0
   "@opentelemetry/propagator-jaeger": 2.10.0

--- a/scripts/lib/codex-app-server-protocol-source.ts
+++ b/scripts/lib/codex-app-server-protocol-source.ts
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { zstdDecompressSync } from "node:zlib";
 import { expectDefined } from "../../packages/normalization-core/src/expect.js";
 import { resolvePnpmRunner } from "../pnpm-runner.mjs";
 import { stageCodexAppServerProtocolArtifacts } from "./codex-app-server-protocol-artifacts.js";
@@ -40,6 +41,11 @@ type PnpmCommand = {
   windowsVerbatimArguments?: boolean;
 };
 
+type CargoProtocolFixtureCommand = {
+  args: string[];
+  env: NodeJS.ProcessEnv;
+};
+
 type ResolvePnpmCommandOptions = {
   comSpec?: string;
   env?: NodeJS.ProcessEnv;
@@ -69,20 +75,30 @@ export function resolveCodexProtocolPnpmCommand(
   return command;
 }
 
-export function buildCodexProtocolExportArgs(manifestPath: string, outDir: string): string[] {
-  return [
-    "run",
-    "--manifest-path",
-    manifestPath,
-    "-p",
-    "codex-app-server-protocol",
-    "--bin",
-    "export",
-    "--",
-    "--out",
-    outDir,
-    "--experimental",
-  ];
+export function buildCodexProtocolFixtureCommand(
+  manifestPath: string,
+  outDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+): CargoProtocolFixtureCommand {
+  return {
+    args: [
+      "test",
+      "--manifest-path",
+      manifestPath,
+      "-p",
+      "codex-app-server-protocol",
+      "--lib",
+      "schema_fixtures_tests::write_schema_fixtures_from_env",
+      "--",
+      "--exact",
+      "--ignored",
+    ],
+    env: {
+      ...env,
+      CODEX_APP_SERVER_SCHEMA_ROOT: outDir,
+      CODEX_APP_SERVER_SCHEMA_EXPERIMENTAL: "1",
+    },
+  };
 }
 
 export function resolveCodexProtocolMinFreeBytes(env: NodeJS.ProcessEnv = process.env): number {
@@ -165,7 +181,7 @@ export async function generateExperimentalCodexAppServerProtocolSource(
 ): Promise<GeneratedCodexAppServerProtocolSource> {
   const { codexRepo } = await resolveCodexAppServerProtocolSource(repoRoot);
   await validateCodexProtocolSourceVersion({ codexRepo, repoRoot });
-  const root = await fs.mkdtemp(path.join(repoRoot, ".tmp-codex-app-server-protocol-"));
+  const root = await fs.mkdtemp(path.join(repoRoot, "codex-protocol-tmp-"));
   const generatedRoot = path.join(root, "generated");
   const typescriptRoot = path.join(root, "typescript");
   const jsonRoot = path.join(root, "json");
@@ -175,8 +191,12 @@ export async function generateExperimentalCodexAppServerProtocolSource(
   };
 
   try {
-    await assertCodexProtocolGenerationHeadroom({ codexRepo, repoRoot });
-    runCargoProtocolGenerator(codexRepo, buildCodexProtocolExportArgs(manifestPath, generatedRoot));
+    await assertCodexProtocolGenerationHeadroom({ codexRepo, repoRoot: root });
+    runCargoProtocolGenerator(
+      codexRepo,
+      buildCodexProtocolFixtureCommand(manifestPath, generatedRoot),
+    );
+    await materializeCodexProtocolPrecomputedExports(generatedRoot);
     await stageCodexAppServerProtocolArtifacts(generatedRoot, { jsonRoot, typescriptRoot });
     formatGeneratedTypeScript(repoRoot, typescriptRoot);
   } catch (error) {
@@ -191,6 +211,44 @@ export async function generateExperimentalCodexAppServerProtocolSource(
     jsonRoot,
     cleanup,
   };
+}
+
+export async function materializeCodexProtocolPrecomputedExports(root: string): Promise<void> {
+  const archivePath = path.join(root, "precomputed/app-server-exports-experimental.json.zst");
+  const decoded = JSON.parse(
+    zstdDecompressSync(await fs.readFile(archivePath)).toString("utf8"),
+  ) as unknown;
+  if (!isPlainObject(decoded)) {
+    throw new Error("Codex experimental protocol export must be an object");
+  }
+  const artifacts = [
+    ...readCodexProtocolArtifactMap(decoded.typescript, "typescript"),
+    ...readCodexProtocolArtifactMap(decoded.json_schema, "json_schema"),
+  ];
+  await fs.rm(root, { recursive: true, force: true });
+  await Promise.all(
+    artifacts.map(async ([relativePath, content]) => {
+      const targetPath = path.resolve(root, relativePath);
+      const rootPrefix = `${path.resolve(root)}${path.sep}`;
+      if (!targetPath.startsWith(rootPrefix)) {
+        throw new Error(`Codex protocol export path escapes output root: ${relativePath}`);
+      }
+      await fs.mkdir(path.dirname(targetPath), { recursive: true });
+      await fs.writeFile(targetPath, content);
+    }),
+  );
+}
+
+function readCodexProtocolArtifactMap(value: unknown, label: string): Array<[string, string]> {
+  if (!isPlainObject(value)) {
+    throw new Error(`Codex experimental protocol ${label} export must be an object`);
+  }
+  return Object.entries(value).map(([relativePath, content]) => {
+    if (typeof content !== "string") {
+      throw new Error(`Codex experimental protocol ${label} export ${relativePath} must be text`);
+    }
+    return [relativePath, content];
+  });
 }
 
 export function readCargoWorkspacePackageVersion(manifest: string): string | undefined {
@@ -321,16 +379,19 @@ async function resolveExistingStatfsPath(targetPath: string): Promise<string> {
   }
 }
 
-function runCargoProtocolGenerator(codexRepo: string, args: string[]): void {
-  const result = spawnSync("cargo", args, {
+function runCargoProtocolGenerator(codexRepo: string, command: CargoProtocolFixtureCommand): void {
+  const result = spawnSync("cargo", command.args, {
     cwd: codexRepo,
+    env: command.env,
     stdio: "inherit",
   });
   if (result.error) {
     throw new Error(`Failed to start cargo: ${result.error.message}`, { cause: result.error });
   }
   if (result.status !== 0) {
-    throw new Error(`cargo ${args.join(" ")} failed with exit code ${result.status ?? "unknown"}`);
+    throw new Error(
+      `cargo ${command.args.join(" ")} failed with exit code ${result.status ?? "unknown"}`,
+    );
   }
 }
 

--- a/test/scripts/codex-app-server-protocol-source.test.ts
+++ b/test/scripts/codex-app-server-protocol-source.test.ts
@@ -1,15 +1,17 @@
 // Codex App Server Protocol Source tests cover codex app server protocol source script behavior.
 import fs from "node:fs";
 import path from "node:path";
+import { zstdCompressSync } from "node:zlib";
 import { afterEach, describe, expect, it } from "vitest";
 import { stageCodexAppServerProtocolArtifacts } from "../../scripts/lib/codex-app-server-protocol-artifacts.js";
 import {
-  buildCodexProtocolExportArgs,
+  buildCodexProtocolFixtureCommand,
   canonicalizeCodexAppServerProtocolJson,
   codexAppServerSharedDefinitionsSchema,
   compactCodexAppServerProtocolJsonSchemas,
   expandCodexAppServerProtocolJsonSchema,
   formatCodexAppServerProtocolJsonText,
+  materializeCodexProtocolPrecomputedExports,
   readCargoWorkspacePackageVersion,
   resolveCodexAppServerProtocolSource,
   resolveCodexProtocolCargoTargetDir,
@@ -72,6 +74,30 @@ describe("Codex app-server generated artifact staging", () => {
     expect(fs.existsSync(path.join(jsonRoot, "README.md"))).toBe(false);
     expect(fs.readFileSync(path.join(sourceRoot, "index.ts"), "utf8")).toBe(rootTypeScript);
   });
+
+  it("materializes the upstream experimental precomputed export tree", async () => {
+    const root = createTempDir("openclaw-protocol-precomputed-");
+    const archivePath = path.join(root, "precomputed/app-server-exports-experimental.json.zst");
+    fs.mkdirSync(path.dirname(archivePath), { recursive: true });
+    fs.writeFileSync(
+      archivePath,
+      zstdCompressSync(
+        JSON.stringify({
+          typescript: { "v2/Thing.ts": "export type Thing = string;\n" },
+          json_schema: { "v2/Thing.json": '{"type":"string"}\n' },
+          internal_json_schema: {},
+        }),
+      ),
+    );
+
+    await materializeCodexProtocolPrecomputedExports(root);
+
+    expect(fs.readFileSync(path.join(root, "v2/Thing.ts"), "utf8")).toBe(
+      "export type Thing = string;\n",
+    );
+    expect(fs.readFileSync(path.join(root, "v2/Thing.json"), "utf8")).toBe('{"type":"string"}\n');
+    expect(fs.existsSync(archivePath)).toBe(false);
+  });
 });
 
 describe("codex app-server protocol source resolver", () => {
@@ -113,20 +139,30 @@ version = "9.9.9"
     );
   });
 
-  it("uses the app-server protocol export binary instead of compiling the full codex cli", () => {
-    expect(buildCodexProtocolExportArgs("/codex/codex-rs/Cargo.toml", "/tmp/protocol")).toEqual([
-      "run",
-      "--manifest-path",
-      "/codex/codex-rs/Cargo.toml",
-      "-p",
-      "codex-app-server-protocol",
-      "--bin",
-      "export",
-      "--",
-      "--out",
-      "/tmp/protocol",
-      "--experimental",
-    ]);
+  it("uses the upstream ignored fixture test with explicit schema env", () => {
+    expect(
+      buildCodexProtocolFixtureCommand("/codex/codex-rs/Cargo.toml", "/tmp/protocol", {
+        CARGO_TARGET_DIR: "/cache/codex-target",
+      }),
+    ).toEqual({
+      args: [
+        "test",
+        "--manifest-path",
+        "/codex/codex-rs/Cargo.toml",
+        "-p",
+        "codex-app-server-protocol",
+        "--lib",
+        "schema_fixtures_tests::write_schema_fixtures_from_env",
+        "--",
+        "--exact",
+        "--ignored",
+      ],
+      env: {
+        CARGO_TARGET_DIR: "/cache/codex-target",
+        CODEX_APP_SERVER_SCHEMA_ROOT: "/tmp/protocol",
+        CODEX_APP_SERVER_SCHEMA_EXPERIMENTAL: "1",
+      },
+    });
   });
 
   it("fails before cargo protocol generation when local disk headroom is too low", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the 2026.8.1 release candidate could not pass Codex plugin validation after the managed app-server moved to `0.147.0`. The upstream release also removed the old protocol export binary and changed `request_user_input` timeout semantics.

## Why This Change Was Made

Pins the managed Codex, ACP override, OpenAI client identity, docs, tests, and lockfile to exact stable `0.147.0`. Protocol sync now invokes the upstream ignored schema-fixture test and materializes its compressed export, while the user-input bridge treats missing `isBlocking` as blocking, ignores deprecated `autoResolutionMs`, and bounds nonblocking gateway and secret prompts at 120 seconds.

The obsolete `cargo --bin export` path and runtime use of `autoResolutionMs` are removed. Blocking prompt behavior remains unchanged. No release tag, changelog, npm publish, or release-branch mutation is included.

## User Impact

Operators can package the 2026.8.1 beta with the current managed Codex app-server. Nonblocking Codex input requests now resolve predictably after 120 seconds instead of waiting indefinitely or honoring the deprecated upstream deadline field.

## Evidence

- Exact source base: `295c8dfe6eb7522eb905e31114362d24bf2392b5`
- Upstream contract inspected at Codex `rust-v0.147.0` commit `be6e8eac029b183056b7e4402879f15d2c85f61b`
- Exact upstream files personally inspected:
  - `codex-rs/app-server-protocol/src/protocol/v2/item.rs:1643-1673`
  - `codex-rs/app-server-protocol/src/protocol/v2/tests.rs:4772-4808`
  - `codex-rs/app-server-protocol/src/schema_fixtures_tests.rs:99-110`
  - `codex-rs/app-server-protocol/src/precomputed_exports.rs:18`
  - `codex-rs/app-server/tests/suite/v2/request_user_input.rs:53-140`
- Protocol sync and protocol check passed against that exact upstream checkout
- Live `0.147.0` app-server `initialize` plus `model/list` probe returned 9 visible text/image models; the docs snapshot matches that response
- Focused tests passed: 8 user-input bridge tests, 20 protocol-source tests, and 118 client/provider/manifest contract tests
- Dependency pin guard passed across 617 direct specs
- All 95 npm package locks validated
- Publishable plugin metadata check passed, including `@openclaw/codex@2026.8.1`
- Changed-file formatting passed
- Auxiliary delegated `check:changed` proof was cancelled/inconclusive and is not counted as terminal green evidence
- Independent implementation review of `e1dbb93aeeaa3e334cbb1be47f9ec6a2b0882e5f`: clean and judged the owner-boundary change the best fix
- Initial autoreview: clean, no accepted/actionable findings
- Docs follow-up autoreview: clean at 0.99, no accepted/actionable findings
- Exact-head CI run `31261179611` passed, including terminal `openclaw/ci-gate`
- Exact-head ClawSweeper re-review: pending
