### PR TITLE
fix(feishu): attribute plain group replies to bound agent

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -6,7 +6,7 @@ import type {
   resolveConfiguredBindingRoute,
 } from "openclaw/plugin-sdk/conversation-runtime";
 import { createRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
-import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
+import { resolveAgentIdFromSessionKey, type ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveGroupSessionKey } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
@@ -129,6 +129,21 @@ function createConfiguredFeishuRoute(): NonNullable<ConfiguredBindingRoute> {
 
 function createConfiguredBindingReadiness(ok: boolean, error?: string): BindingReadiness {
   return (ok ? { ok: true } : { ok: false, error: error ?? "unknown error" }) as BindingReadiness;
+}
+
+function createPlainGroupBoundConversation(): NonNullable<BoundConversation> {
+  return {
+    bindingId: "default:oc_group_chat",
+    targetSessionKey: "agent:review:acp:binding:feishu:default:plain-group",
+    targetKind: "session",
+    conversation: {
+      channel: "feishu",
+      accountId: "default",
+      conversationId: "oc_group_chat",
+    },
+    status: "active",
+    boundAt: 0,
+  };
 }
 
 function createBoundConversation(): NonNullable<BoundConversation> {
@@ -442,13 +457,15 @@ vi.mock("openclaw/plugin-sdk/conversation-runtime", async () => {
         return { bindingRecord: null, route: params.route };
       }
       mockTouchBinding(bindingRecord.bindingId);
+      const boundAgentId = resolveAgentIdFromSessionKey(boundSessionKey) || params.route.agentId;
       return {
         bindingRecord,
         boundSessionKey,
-        boundAgentId: params.route.agentId,
+        boundAgentId,
         route: {
           ...params.route,
           sessionKey: boundSessionKey,
+          agentId: boundAgentId,
           lastRoutePolicy: boundSessionKey === params.route.mainSessionKey ? "main" : "session",
           matchedBy: "binding.channel",
         },
@@ -658,6 +675,48 @@ describe("handleFeishuMessage ACP routing", () => {
     expect(conversationRef.channel).toBe("feishu");
     expect(conversationRef.conversationId).toBe("oc_group_chat:topic:om_topic_root");
     expect(mockTouchBinding).toHaveBeenCalledWith("default:oc_group_chat:topic:om_topic_root");
+  });
+
+  it("keeps plain group session ownership while attributing bound agents in reply footers", async () => {
+    mockResolveBoundConversation.mockReturnValue(createPlainGroupBoundConversation());
+    mockResolveAgentRoute.mockReturnValue(
+      createFeishuTestRoute({
+        agentId: "main",
+        sessionKey: "agent:main:feishu:group:oc_group_chat",
+        matchedBy: "default",
+      }),
+    );
+
+    await dispatchMessage({
+      cfg: createFeishuTestConfig({
+        groups: {
+          oc_group_chat: {
+            requireMention: false,
+            groupSessionScope: "group",
+          },
+        },
+      }),
+      event: createFeishuTestEvent({
+        messageId: "msg-plain-bound",
+        senderOpenId: "ou_sender_1",
+        chatId: "oc_group_chat",
+        chatType: "group",
+        text: "hello plain group",
+      }),
+    });
+
+    expect(mockResolveBoundConversation).toHaveBeenCalledWith({
+      channel: "feishu",
+      accountId: "default",
+      conversationId: "oc_group_chat",
+      parentConversationId: "oc_group_chat",
+    });
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "review",
+        sessionKey: "agent:main:feishu:group:oc_group_chat",
+      }),
+    );
   });
 
   it("records Feishu DM last-route updates on the resolved session", async () => {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -447,6 +447,7 @@ vi.mock("openclaw/plugin-sdk/conversation-runtime", async () => {
       mockResolveConfiguredBindingRoute(params as { route: ResolvedAgentRoute }),
     resolveRuntimeConversationBindingRoute: (params: {
       route: ResolvedAgentRoute;
+      touch?: boolean;
       conversation: Parameters<
         ReturnType<typeof actual.getSessionBindingService>["resolveByConversation"]
       >[0];
@@ -456,7 +457,9 @@ vi.mock("openclaw/plugin-sdk/conversation-runtime", async () => {
       if (!bindingRecord || !boundSessionKey) {
         return { bindingRecord: null, route: params.route };
       }
-      mockTouchBinding(bindingRecord.bindingId);
+      if (params.touch !== false) {
+        mockTouchBinding(bindingRecord.bindingId);
+      }
       const boundAgentId = resolveAgentIdFromSessionKey(boundSessionKey) || params.route.agentId;
       return {
         bindingRecord,
@@ -717,6 +720,50 @@ describe("handleFeishuMessage ACP routing", () => {
         sessionKey: "agent:main:feishu:group:oc_group_chat",
       }),
     );
+    // Footer attribution is a read-only lookup; it must not touch binding activity.
+    expect(mockTouchBinding).not.toHaveBeenCalled();
+  });
+
+  it("keeps main in plain group reply footer when the bound target is not an ACP session", async () => {
+    mockResolveBoundConversation.mockReturnValue({
+      ...createPlainGroupBoundConversation(),
+      targetSessionKey: "agent:review:feishu:group:oc_group_chat",
+    });
+    mockResolveAgentRoute.mockReturnValue(
+      createFeishuTestRoute({
+        agentId: "main",
+        sessionKey: "agent:main:feishu:group:oc_group_chat",
+        matchedBy: "default",
+      }),
+    );
+
+    await dispatchMessage({
+      cfg: createFeishuTestConfig({
+        groups: {
+          oc_group_chat: {
+            requireMention: false,
+            groupSessionScope: "group",
+          },
+        },
+      }),
+      event: createFeishuTestEvent({
+        messageId: "msg-plain-subagent",
+        senderOpenId: "ou_sender_1",
+        chatId: "oc_group_chat",
+        chatType: "group",
+        text: "hello plain group subagent",
+      }),
+    });
+
+    // A non-ACP (subagent) target is not dispatched through by core, so the footer must
+    // keep main instead of naming an agent that did not handle the reply.
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "main",
+        sessionKey: "agent:main:feishu:group:oc_group_chat",
+      }),
+    );
+    expect(mockTouchBinding).not.toHaveBeenCalled();
   });
 
   it("records Feishu DM last-route updates on the resolved session", async () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -22,7 +22,7 @@ import {
   createChannelHistoryWindow,
   type HistoryEntry,
 } from "openclaw/plugin-sdk/reply-history";
-import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
+import { isAcpSessionKey, resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import {
   resolveDefaultGroupPolicy,
   resolveOpenProviderRuntimeGroupPolicy,
@@ -929,9 +929,13 @@ export async function handleFeishuMessage(params: {
     let outboundAgentId = route.agentId;
     if (isGroup && !feishuAcpConversationSupported) {
       // Plain groups keep session ownership on the default route; core may still dispatch via
-      // a runtime conversation binding. Resolve attribution without rewriting route.sessionKey.
+      // a runtime conversation binding. Resolve footer attribution with a read-only binding
+      // lookup (touch: false, so binding idle expiry is not prolonged) and only when core
+      // would actually dispatch through the bound ACP session target. Non-ACP (subagent)
+      // targets keep main as the executing agent, so the footer must not name them.
       const attributionRoute = resolveRuntimeConversationBindingRoute({
         route,
+        touch: false,
         conversation: {
           channel: "feishu",
           accountId: account.accountId,
@@ -939,7 +943,9 @@ export async function handleFeishuMessage(params: {
           ...(parentConversationId ? { parentConversationId } : {}),
         },
       });
-      outboundAgentId = attributionRoute.boundAgentId ?? route.agentId;
+      if (attributionRoute.boundSessionKey && isAcpSessionKey(attributionRoute.boundSessionKey)) {
+        outboundAgentId = attributionRoute.boundAgentId ?? route.agentId;
+      }
     }
 
     if (configuredBinding) {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -926,6 +926,22 @@ export async function handleFeishuMessage(params: {
       }
     }
 
+    let outboundAgentId = route.agentId;
+    if (isGroup && !feishuAcpConversationSupported) {
+      // Plain groups keep session ownership on the default route; core may still dispatch via
+      // a runtime conversation binding. Resolve attribution without rewriting route.sessionKey.
+      const attributionRoute = resolveRuntimeConversationBindingRoute({
+        route,
+        conversation: {
+          channel: "feishu",
+          accountId: account.accountId,
+          conversationId: currentConversationId,
+          ...(parentConversationId ? { parentConversationId } : {}),
+        },
+      });
+      outboundAgentId = attributionRoute.boundAgentId ?? route.agentId;
+    }
+
     if (configuredBinding) {
       const ensured = await ensureConfiguredBindingRouteReady({
         cfg: effectiveCfg,
@@ -1804,7 +1820,7 @@ export async function handleFeishuMessage(params: {
         ctx.mentionedBot,
       );
 
-      const identity = resolveAgentOutboundIdentity(effectiveCfg, route.agentId);
+      const identity = resolveAgentOutboundIdentity(effectiveCfg, outboundAgentId);
       const storePath = resolveStorePath(effectiveCfg.session?.store, {
         agentId: route.agentId,
       });
@@ -1817,7 +1833,7 @@ export async function handleFeishuMessage(params: {
       const { dispatcherOptions, delivery, replyOptions, ensureNoVisibleReplyFallback } =
         createFeishuReplyDispatcher({
           cfg: effectiveCfg,
-          agentId: route.agentId,
+          agentId: outboundAgentId,
           runtime: runtime as RuntimeEnv,
           chatId: ctx.chatId,
           sendTarget: feishuReplyTarget,

--- a/src/channels/plugins/binding-routing.ts
+++ b/src/channels/plugins/binding-routing.ts
@@ -132,6 +132,12 @@ export function resolveConfiguredBindingRoute(
 export function resolveRuntimeConversationBindingRoute(
   params: {
     route: ResolvedAgentRoute;
+    /**
+     * When `false`, skip the binding-activity touch so read-only lookups (e.g. footer
+     * attribution) do not prolong binding idle expiry. Defaults to `true` to preserve
+     * the existing routing behavior.
+     */
+    touch?: boolean;
   } & ConfiguredBindingRouteConversationInput,
 ): RuntimeConversationBindingRouteResult {
   const bindingRecord = getSessionBindingService().resolveByConversation(
@@ -156,7 +162,9 @@ export function resolveRuntimeConversationBindingRoute(
     };
   }
 
-  getSessionBindingService().touch(bindingRecord.bindingId);
+  if (params.touch !== false) {
+    getSessionBindingService().touch(bindingRecord.bindingId);
+  }
   if (isPluginOwnedRuntimeBindingRecord(bindingRecord)) {
     // Plugin-owned binding records are observed but not route-rewritten by core; the owning
     // plugin is responsible for its runtime target handoff.


### PR DESCRIPTION
Closes #120547

## What Problem This Solves

Fixes an issue where users bind a non-default agent in a plain Feishu group chat (`groupSessionScope: "group"`) would see replies signed as `agent: main` in the card footer even though the bound agent handled the message.

## Why This Change Was Made

Plain groups intentionally skip `feishuAcpConversationSupported`, so the Feishu plugin never resolved runtime conversation bindings for route attribution. Core still dispatches through the bound session independently, which produced correct reply content with the wrong footer.

This change resolves the runtime binding a second time for outbound attribution only, without rewriting `route.sessionKey` or changing session ownership.

## User Impact

Feishu group reply footers now name the bound ACP agent in plain groups, matching topic-mode groups and direct chats. Execution/session behavior is unchanged.

## Changes (addressing ClawSweeper P1 + P2 findings)

- **P1 — ACP-only attribution gate:** The footer override now checks `isAcpSessionKey(boundSessionKey)` before using the bound agent ID. Non-ACP bindings (subagent targets) keep the route agent in the footer, matching core dispatch behavior which only re-targets ACP sessions.
- **P2 — Read-only lookup:** The binding resolver now accepts an optional `touch: false` parameter. Footer attribution passes `touch: false` so the binding idle expiry is not prolonged by attribution-only lookups.
- Both the attribution resolver in `extensions/feishu/src/bot.ts` and the shared `resolveRuntimeConversationBindingRoute` in `src/channels/plugins/binding-routing.ts` were updated.

## Evidence

All 100 feishu bot tests pass (including the two new regression cases):

```bash
PATH="/usr/bin:$PATH" node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts
# Test Files  1 passed (1)
# Tests  100 passed (100)

PATH="/usr/bin:$PATH" node scripts/run-vitest.mjs src/channels/plugins/binding-routing.test.ts
# Test Files  1 passed (1)
# Tests  4 passed (4)
```

New test cases verify:
1. ACP-bound plain groups: footer uses bound agent ID, `mockTouchBinding` not called
2. Non-ACP (subagent) bound plain groups: footer keeps route agent (main), `mockTouchBinding` not called

Note: real Feishu behavior proof requires a live Feishu testbed which is not available in this environment. The mocked regression coverage validates the correct branching behavior for both ACP and non-ACP targets.