### PR TITLE
fix(agents): prevent requester settle while child is still running

### DIFF
--- a/src/agents/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagent-announce.requester-settle-wake.test.ts
@@ -437,6 +437,69 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
     expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1);
   });
 
+  it.each([
+    ["is running without an end timestamp", { status: "running", startedAt: 2_000 }],
+    [
+      "is still marked running with an end timestamp",
+      { status: "running", startedAt: 2_000, endedAt: 3_000 },
+    ],
+    ["has no end timestamp", { status: "terminal", startedAt: 2_000 }],
+  ] as const)(
+    "does not wake a yielded requester while its only frozen child %s",
+    async (_description, execution) => {
+      const activeChild = makeSettledChild({
+        runId: "run-b",
+        execution,
+        delivery: { status: "pending" },
+        requesterSettleWake: {
+          status: "pending",
+          attemptCount: 0,
+          batchRunIds: ["run-b"],
+          requesterYieldBatch: true,
+          rearmGeneration: 1,
+        },
+      });
+      registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([activeChild]);
+
+      const woke = await maybeWakeRequesterAfterAllChildrenSettled(
+        wakeParams({ settledEntry: activeChild }),
+      );
+
+      expect(woke).toBe(false);
+      expect(deliverSpy).not.toHaveBeenCalled();
+      expect(completeBatchSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it("revalidates the frozen child registry row before declaring the yielded batch settled", async () => {
+    const settledChild = makeSettledChild({
+      runId: "run-b",
+      requesterSettleWake: {
+        status: "pending",
+        attemptCount: 0,
+        batchRunIds: ["run-b"],
+        requesterYieldBatch: true,
+        rearmGeneration: 1,
+      },
+    });
+    const currentRunningChild = {
+      ...settledChild,
+      execution: { status: "running" as const, startedAt: 2_000 },
+    };
+    registryRuntimeMock.listSubagentRunsForRequester
+      .mockReturnValueOnce([settledChild])
+      .mockReturnValue([currentRunningChild]);
+
+    const woke = await maybeWakeRequesterAfterAllChildrenSettled(
+      wakeParams({ settledEntry: settledChild }),
+    );
+
+    expect(woke).toBe(false);
+    expect(registryRuntimeMock.listSubagentRunsForRequester).toHaveBeenCalledTimes(2);
+    expect(deliverSpy).not.toHaveBeenCalled();
+    expect(completeBatchSpy).not.toHaveBeenCalled();
+  });
+
   it("wakes after a requester yields with one already-delivered completion", async () => {
     const child = makeSettledChild({
       runId: "run-b",

--- a/src/agents/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagent-announce.requester-settle-wake.test.ts
@@ -471,33 +471,27 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
     },
   );
 
-  it("revalidates the frozen child registry row before declaring the yielded batch settled", async () => {
-    const settledChild = makeSettledChild({
-      runId: "run-b",
+  it("wakes after a retired frozen member disappears from the registry", async () => {
+    const remainingChild = makeSettledChild({
+      runId: "run-a",
+      delivery: { status: "delivered" },
       requesterSettleWake: {
         status: "pending",
         attemptCount: 0,
-        batchRunIds: ["run-b"],
+        batchRunIds: ["run-a", "run-b"],
         requesterYieldBatch: true,
         rearmGeneration: 1,
       },
     });
-    const currentRunningChild = {
-      ...settledChild,
-      execution: { status: "running" as const, startedAt: 2_000 },
-    };
-    registryRuntimeMock.listSubagentRunsForRequester
-      .mockReturnValueOnce([settledChild])
-      .mockReturnValue([currentRunningChild]);
+    registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([remainingChild]);
 
     const woke = await maybeWakeRequesterAfterAllChildrenSettled(
-      wakeParams({ settledEntry: settledChild }),
+      wakeParams({ settledEntry: remainingChild }),
     );
 
-    expect(woke).toBe(false);
-    expect(registryRuntimeMock.listSubagentRunsForRequester).toHaveBeenCalledTimes(2);
-    expect(deliverSpy).not.toHaveBeenCalled();
-    expect(completeBatchSpy).not.toHaveBeenCalled();
+    expect(woke).toBe(true);
+    expect(deliverSpy).toHaveBeenCalledOnce();
+    expect(completeBatchSpy).toHaveBeenCalledWith(["run-a"], 1);
   });
 
   it("wakes after a requester yields with one already-delivered completion", async () => {

--- a/src/agents/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagent-announce.requester-settle-wake.ts
@@ -254,16 +254,23 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
   let settledBatch: SubagentRunRecord[];
   if (frozenBatchRunIds && frozenBatchRunIds.length > 0) {
     const runsById = new Map(requesterRuns.map((entry) => [entry.runId, entry]));
-    settledBatch = frozenBatchRunIds
-      .map((runId) => runsById.get(runId))
-      .filter(
-        (entry): entry is SubagentRunRecord =>
-          Boolean(entry?.requesterSettleWake) &&
-          entry?.requesterSettleWake?.rearmGeneration === currentRearmGeneration,
-      );
+    const frozenBatch = frozenBatchRunIds.map((runId) => runsById.get(runId));
+    if (
+      frozenBatch.some(
+        (entry) => !entry || entry.requesterSettleWake?.rearmGeneration !== currentRearmGeneration,
+      )
+    ) {
+      return false;
+    }
+    settledBatch = frozenBatch as SubagentRunRecord[];
   } else {
     settledBatch = buildConnectedSettledWave(
-      requesterRuns.filter((entry) => entry.requesterSettleWake && hasSubagentRunEnded(entry)),
+      requesterRuns.filter(
+        (entry) =>
+          entry.requesterSettleWake &&
+          entry.execution.status !== "running" &&
+          hasSubagentRunEnded(entry),
+      ),
       currentSettledEntry,
     );
   }
@@ -272,6 +279,26 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
   }
 
   const batchRunIds = settledBatch.map((entry) => entry.runId).toSorted();
+  const currentRunsById = new Map(
+    registryRuntime
+      .listSubagentRunsForRequester(requesterSessionKey)
+      .map((entry) => [entry.runId, entry]),
+  );
+  const revalidatedBatch = batchRunIds.map((runId) => currentRunsById.get(runId));
+  // Frozen membership is not terminal proof. Re-read every durable execution
+  // fact so a live child cannot become an unknown completion.
+  if (
+    revalidatedBatch.some(
+      (entry) =>
+        !entry ||
+        entry.requesterSettleWake?.rearmGeneration !== currentRearmGeneration ||
+        entry.execution.status === "running" ||
+        !hasSubagentRunEnded(entry),
+    )
+  ) {
+    return false;
+  }
+  settledBatch = revalidatedBatch as SubagentRunRecord[];
   const selectedState = readSharedBatchState(settledBatch);
   if (hasUnsettledDescendants) {
     if (frozenBatchRunIds && frozenBatchRunIds.length > 0) {

--- a/src/agents/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagent-announce.requester-settle-wake.ts
@@ -254,15 +254,22 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
   let settledBatch: SubagentRunRecord[];
   if (frozenBatchRunIds && frozenBatchRunIds.length > 0) {
     const runsById = new Map(requesterRuns.map((entry) => [entry.runId, entry]));
-    const frozenBatch = frozenBatchRunIds.map((runId) => runsById.get(runId));
+    // Retired rows no longer own completion, but every surviving frozen member
+    // must be terminal before this batch can wake its requester.
+    settledBatch = frozenBatchRunIds
+      .map((runId) => runsById.get(runId))
+      .filter(
+        (entry): entry is SubagentRunRecord =>
+          Boolean(entry?.requesterSettleWake) &&
+          entry?.requesterSettleWake?.rearmGeneration === currentRearmGeneration,
+      );
     if (
-      frozenBatch.some(
-        (entry) => !entry || entry.requesterSettleWake?.rearmGeneration !== currentRearmGeneration,
+      settledBatch.some(
+        (entry) => entry.execution.status === "running" || !hasSubagentRunEnded(entry),
       )
     ) {
       return false;
     }
-    settledBatch = frozenBatch as SubagentRunRecord[];
   } else {
     settledBatch = buildConnectedSettledWave(
       requesterRuns.filter(
@@ -279,26 +286,6 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
   }
 
   const batchRunIds = settledBatch.map((entry) => entry.runId).toSorted();
-  const currentRunsById = new Map(
-    registryRuntime
-      .listSubagentRunsForRequester(requesterSessionKey)
-      .map((entry) => [entry.runId, entry]),
-  );
-  const revalidatedBatch = batchRunIds.map((runId) => currentRunsById.get(runId));
-  // Frozen membership is not terminal proof. Re-read every durable execution
-  // fact so a live child cannot become an unknown completion.
-  if (
-    revalidatedBatch.some(
-      (entry) =>
-        !entry ||
-        entry.requesterSettleWake?.rearmGeneration !== currentRearmGeneration ||
-        entry.execution.status === "running" ||
-        !hasSubagentRunEnded(entry),
-    )
-  ) {
-    return false;
-  }
-  settledBatch = revalidatedBatch as SubagentRunRecord[];
   const selectedState = readSharedBatchState(settledBatch);
   if (hasUnsettledDescendants) {
     if (frozenBatchRunIds && frozenBatchRunIds.length > 0) {

--- a/src/agents/subagent-registry-lifecycle-requester-wake.ts
+++ b/src/agents/subagent-registry-lifecycle-requester-wake.ts
@@ -6,6 +6,7 @@ import type {
   SubagentRegistryLifecycleState,
 } from "./subagent-registry-lifecycle-contracts.js";
 import type { RequesterSettleWakeState, SubagentRunRecord } from "./subagent-registry.types.js";
+import { hasSubagentRunEnded } from "./subagent-run-liveness.js";
 
 type RequesterSettleWakeBatchState =
   import("./subagent-announce.requester-settle-wake.js").RequesterSettleWakeBatchState;
@@ -207,8 +208,12 @@ export function createSubagentRegistryLifecycleRequesterWake(
 
   function scheduleRequesterSettleWake(runId: string, entry: SubagentRunRecord): void {
     const requesterSessionKey = entry.requesterSessionKey?.trim();
+    // A replayed lifecycle start can retain an older endedAt; require both
+    // terminal status and end evidence so a live child never wakes its requester.
     if (
       entry.collect ||
+      entry.execution.status === "running" ||
+      !hasSubagentRunEnded(entry) ||
       !requesterSessionKey ||
       (entry.requesterTurnRunId && entry.requesterTurnYielded === true) ||
       scheduledRequesterSettleWakeRuns.has(runId) ||

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -4121,6 +4121,26 @@ describe("requester settle wake trigger", () => {
     expect(later.requesterSettleWake).toEqual({ status: "pending", attemptCount: 0 });
   });
 
+  it("does not resume a persisted settle wake until its registry row is terminal", async () => {
+    const entry = createRunEntry({
+      requesterSettleWake: { status: "pending", attemptCount: 0 },
+    });
+    const settleWake = vi.fn(async () => false);
+    const controller = createLifecycleController({
+      entry,
+      maybeWakeRequesterAfterAllChildrenSettled: settleWake,
+    });
+
+    controller.resumeRequesterSettleWake(entry.runId, entry);
+    await Promise.resolve();
+    expect(settleWake).not.toHaveBeenCalled();
+
+    entry.execution = { ...entry.execution, status: "terminal", endedAt: 4_000 };
+    controller.resumeRequesterSettleWake(entry.runId, entry);
+
+    await waitForLifecycleState(() => expect(settleWake).toHaveBeenCalledOnce());
+  });
+
   it("keeps a yielded completion parked until its requester turn settles", async () => {
     const entry = createRunEntry({
       requesterTurnRunId: "run-requester",

--- a/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -4,7 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { testing as subagentAnnounceDeliveryTesting } from "./subagent-announce-delivery.test-support.js";
 import { testing as subagentAnnounceOutputTesting } from "./subagent-announce-output.test-support.js";
 import { testing as subagentAnnounceTesting } from "./subagent-announce.js";
-import { testing as settleWakeTesting } from "./subagent-announce.requester-settle-wake.js";
+import {
+  maybeWakeRequesterAfterAllChildrenSettled,
+  testing as settleWakeTesting,
+} from "./subagent-announce.requester-settle-wake.js";
 import * as announceRead from "./subagent-registry-announce-read.js";
 import * as mod from "./subagent-registry.test-helpers.js";
 
@@ -363,6 +366,17 @@ describe("subagent registry lifecycle error grace", () => {
       .filter((request): request is GatewayRequest => request.method === "agent");
   }
 
+  function getRequesterWakeCalls() {
+    return getAgentCalls().filter((request) => {
+      const idempotencyKey = (request.params as Record<string, unknown> | undefined)
+        ?.idempotencyKey;
+      return (
+        typeof idempotencyKey === "string" &&
+        idempotencyKey.startsWith("announce:requester-settle:")
+      );
+    });
+  }
+
   function getAgentResultsForChildSession(childSessionKey: string): string[] {
     return getAgentCalls()
       .filter((request) => {
@@ -479,25 +493,16 @@ describe("subagent registry lifecycle error grace", () => {
         rearmGeneration: undefined,
       },
     ]);
-    const requesterWakeCalls = () =>
-      getAgentCalls().filter((request) => {
-        const idempotencyKey = (request.params as Record<string, unknown> | undefined)
-          ?.idempotencyKey;
-        return (
-          typeof idempotencyKey === "string" &&
-          idempotencyKey.startsWith("announce:requester-settle:")
-        );
-      });
     await waitForAgentCallCount(3);
-    expect(requesterWakeCalls()).toHaveLength(1);
+    expect(getRequesterWakeCalls()).toHaveLength(1);
 
     agentCallGates.delete(betaSessionKey);
     releaseBetaDelivery?.();
     await waitForDeliveredCleanup("run-yield-alpha");
     await waitForDeliveredCleanup("run-yield-beta");
 
-    expect(requesterWakeCalls()).toHaveLength(1);
-    const requesterWakeParams = requesterWakeCalls()[0]?.params as
+    expect(getRequesterWakeCalls()).toHaveLength(1);
+    const requesterWakeParams = getRequesterWakeCalls()[0]?.params as
       | Record<string, unknown>
       | undefined;
     expect(requesterWakeParams?.idempotencyKey).toContain(":yield-1");
@@ -511,7 +516,66 @@ describe("subagent registry lifecycle error grace", () => {
 
     await vi.advanceTimersByTimeAsync(30_000);
     await flushAsync();
-    expect(requesterWakeCalls()).toHaveLength(1);
+    expect(getRequesterWakeCalls()).toHaveLength(1);
+  });
+
+  it("keeps a frozen live child asleep until its real registry row becomes terminal", async () => {
+    const requesterTurnRunId = "run-requester-live-child";
+    const liveChildSessionKey = "agent:main:subagent:frozen-live-child";
+    registerCompletionRun(
+      "run-frozen-live-child",
+      "frozen-live-child",
+      "live child",
+      requesterTurnRunId,
+    );
+    setAssistantOutput(liveChildSessionKey, "live child complete");
+
+    expect(
+      mod.markRequesterTurnYielded({
+        requesterSessionKey: MAIN_REQUESTER_SESSION_KEY,
+        requesterTurnRunId,
+      }),
+    ).toBe(1);
+    expect(
+      mod.settleRequesterAfterSessionSpawns({
+        requesterSessionKey: MAIN_REQUESTER_SESSION_KEY,
+        requesterTurnRunId,
+        requesterYielded: true,
+        acceptedSessionSpawns: [
+          { runId: "run-frozen-live-child", childSessionKey: liveChildSessionKey },
+        ],
+      }),
+    ).toBe(true);
+
+    const liveChild = mod
+      .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
+      .find((run) => run.runId === "run-frozen-live-child");
+    if (!liveChild) {
+      throw new Error("expected frozen live child");
+    }
+    expect(
+      await maybeWakeRequesterAfterAllChildrenSettled({
+        requesterSessionKey: MAIN_REQUESTER_SESSION_KEY,
+        settledEntry: liveChild,
+        transitionBatch: noop,
+        completeBatch: noop,
+      }),
+    ).toBe(false);
+    await flushAsync();
+
+    expect(getRequesterWakeCalls()).toHaveLength(0);
+    expect(liveChild.execution.status).toBe("running");
+
+    emitLifecycleEvent("run-frozen-live-child", { phase: "end", endedAt: Date.now() + 1 });
+    await waitForAgentCallCount(1);
+    await waitForDeliveredCleanup("run-frozen-live-child");
+
+    expect(
+      mod
+        .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
+        .find((run) => run.runId === "run-frozen-live-child")?.execution,
+    ).toMatchObject({ status: "terminal", endedAt: expect.any(Number) });
+    expect(getRequesterWakeCalls()).toHaveLength(1);
   });
 
   it("ignores transient lifecycle errors when run retries and then ends successfully", async () => {


### PR DESCRIPTION
## Summary

### High Level TLDR

`sessions_yield` could wake a requester while a frozen child was still running. This refresh moves the primary terminality gate to requester-wake scheduling, keeps a matching admission backstop, and preserves the existing behavior where retired batch rows do not strand surviving siblings.

## What Problem This Solves

A yielded requester could receive an "all subagents settled" continuation while its only frozen child still had `execution.status: "running"` and no finite `execution.endedAt`. The triggering run is intentionally excluded from the descendant-drain query, and the lifecycle rearm loop could schedule any armed row without checking whether that row had ended.

The earlier revision also introduced a silent-failure regression: if a sweeper retired one frozen member before delivery, admission aborted the entire batch instead of dropping the vanished row and settling the surviving members.

## Why This Change Was Made

### Root Cause

Frozen `batchRunIds` own membership, not liveness. The wake path treated membership as terminal proof, while `hasDescendantRunAwaitingSettle` excluded the triggering run. Separately, `completeRequesterSettleWakeBatch` re-dispatched remaining armed rows through `scheduleRequesterSettleWake` without a terminality gate.

The canonical lifecycle owner now refuses to schedule a row whose status is still `running` or whose finite end timestamp is absent. Frozen-batch admission applies the same rule to every surviving row in its single current registry snapshot. Missing or generation-mismatched rows are filtered, preserving the pre-existing retire-and-continue behavior.

Both status and `endedAt` are required intentionally. A replayed lifecycle `start` event in `src/agents/subagent-registry-listener.ts` preserves the existing execution object while restoring `status: "running"`, so a real reordered state can contain an older `endedAt` while the run is live.

The redundant second registry listing was removed: no `await` separated it from the first listing, so production could not change between the two snapshots. The former test only made the mock return different arrays synchronously and did not prove runtime behavior.

Scope remains inside requester-settle scheduling and admission. There are no config, protocol, persistence-schema, delivery-retry, channel, or stale-run-policy changes.

## User Impact

Yielded requesters remain parked while any surviving frozen child is live. After the child reaches its real terminal lifecycle state, the requester is woken exactly once. If a frozen sibling was legitimately retired meanwhile, the remaining terminal siblings still complete the batch instead of leaving the requester silently stranded.

## Evidence

The closest feasible production-owner proof uses the real in-memory subagent registry and lifecycle controller with the existing mocked Gateway RPC delivery seam. It creates a yielded frozen row, injects the previously faulty wake attempt while that real row is live, emits the production lifecycle terminal event, and observes delivery at the Gateway boundary.

```json
{
  "harness": "production registry and lifecycle with mocked Gateway RPC delivery",
  "running": {
    "executionStatus": "running",
    "requesterWakeCalls": 0
  },
  "terminal": {
    "executionStatus": "terminal",
    "requesterWakeCalls": 1
  },
  "verdict": "PASS"
}
```

The focused regression command and copied result were:

```text
$ node scripts/run-vitest.mjs src/agents/subagent-announce.requester-settle-wake.test.ts src/agents/subagent-registry-lifecycle.test.ts src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts src/agents/subagent-registry-requester-yield.test.ts src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts
Test Files  5 passed (5)
Tests       204 passed (204)
[test] passed 3 Vitest shards
```

The real-registry trace is asserted by `keeps a frozen live child asleep until its real registry row becomes terminal`. The scheduler-owner unit test independently proves a persisted wake is not resumed before the row becomes terminal. Unit coverage also proves running-with-end and terminal-without-end rejection plus successful completion when a frozen sibling has been retired.

### Verification

- `git diff --check` passed.
- The five focused files above passed: 204 tests across unit-fast, agents-core, and E2E shards.
- Final isolated boundary rerun passed: 1 selected E2E test, 10 skipped.
- `node scripts/check-changed.mjs -- <five touched files>` attempted the required Testbox route, but no configured provider was ready. The documented trusted-source local fallback passed conflict markers, env/max-lines ratchets, attribution, re-export, duplication, dependency, formatting, Plugin SDK, deprecated-API, plugin-boundary, patch, dead-export, and test-temp gates. It then stopped at the unrelated existing `packages/terminal-core/src/ansi.ts:194` type error; this PR does not change that file or its dependency surface.
- Final autoreview was clean with no accepted/actionable findings; secret scan was clean.

Performance was sampled on Linux with Node 25.9.0 using the same focused terminal-wake test, one warmup, and five whole-process samples. Prior head `4bed0b45ae98` measured 5.38, 5.29, 5.20, 5.23, and 5.07 seconds (mean 5.23, median 5.23). The refreshed code measured 5.26, 6.17, 5.43, 6.31, and 5.25 seconds (mean 5.68, median 5.43). This import-dominated benchmark ran while the shared host carried unrelated heavy checks, so the 0.20-second median difference is within observed host noise; it does not support an isolated latency claim. The production refresh itself is net -8 lines versus the prior PR head.

Production LOC for the complete PR is +20/-1 (net +19): scheduler ownership plus admission backstop. Tests are +155/-14. Relative to the prior PR head, production is +16/-24 (net -8) and tests are +108/-30.

## What was not tested

- No authenticated live channel or operator Gateway was touched. The registry/lifecycle failure is deterministic, and this proof stops at the mocked Gateway RPC delivery seam.
- No private operational identifiers, chat context, or live artifacts were copied into this public PR.
- The full changed gate could not finish because Testbox/broker capacity was unavailable and the trusted local fallback encountered the unrelated terminal-core type error above. Exact-head GitHub CI remains the merge-ref proof for the lanes after that point.



## Exact-head real Gateway proof

Exact head `098581226c26a06abdb78a2e59aff44f3fcd6bcb` also passed an ephemeral real-Gateway QA scenario with a mock provider and mock channel: [Crabbox run `run_d0b4ebc99754`](https://crabbox.openclaw.ai/portal/runs/run_d0b4ebc99754).

```json
{
  "whileChildRunning": {
    "requesterWakeCount": 0,
    "requesterOutboundCount": 0
  },
  "terminalBoundary": {
    "gatewayEvent": "agent",
    "stream": "lifecycle",
    "phase": "end"
  },
  "afterTerminal": {
    "requesterWakeCount": 1,
    "requesterOutboundCount": 1
  },
  "afterQuietWindow": {
    "windowMs": 3000,
    "requesterWakeCount": 1,
    "requesterOutboundCount": 1
  },
  "verdict": "PASS"
}
```

The scenario exercised the actual Gateway, in-memory task ledger, subagent lifecycle controller, requester wake path, and outbound channel delivery. The controlled mock provider kept the child request in flight until release; no requester wake or outbound message occurred while the child was running. A real Gateway `agent` lifecycle `end` event was then observed before the single wake and single outbound response, and both counts remained exactly one through the quiet window.
