### PR TITLE
fix(memory): score LIKE-fallback keyword hits as 0 instead of 1

### DIFF
--- a/extensions/memory-core/src/memory/hybrid.test.ts
+++ b/extensions/memory-core/src/memory/hybrid.test.ts
@@ -816,46 +816,6 @@ describe("memory hybrid helpers", () => {
     expect(merged[0]?.textScore).toBeCloseTo(1);
   });
 
-  it("mergeHybridResults does not produce finalScore = 1.0 for LIKE-fallback keyword hits", async () => {
-    // LIKE substring fallback (FTS5 MATCH throws, or substring-only query)
-    // scores textScore = 0 because it carries no BM25 ranking signal. Even
-    // when the same chunk is a perfect vector neighbor (vectorScore = 1), the
-    // merged contentScore must stay below 1.0 so non-identical content is not
-    // reported as a near-duplicate. See #115001.
-    const merged = await mergeHybridResults({
-      vectorWeight: 0.7,
-      textWeight: 0.3,
-      vector: [
-        {
-          id: "a",
-          path: "memory/a.md",
-          startLine: 1,
-          endLine: 2,
-          source: "memory",
-          snippet: "vec-a",
-          vectorScore: 1,
-        },
-      ],
-      keyword: [
-        {
-          id: "a",
-          path: "memory/a.md",
-          startLine: 1,
-          endLine: 2,
-          source: "memory",
-          snippet: "kw-a",
-          textScore: 0,
-        },
-      ],
-    });
-
-    expect(merged).toHaveLength(1);
-    expect(merged[0]?.textScore).toBe(0);
-    // 0.7 * 1 (vector) + 0.3 * 0 (LIKE recall only) = 0.7, strictly below 1.0.
-    expect(merged[0]?.score).toBeCloseTo(0.7);
-    expect(merged[0]?.score).toBeLessThan(1);
-  });
-
   it("preserves LIKE-fallback lexical ordering in hybrid selection (keyword-only)", async () => {
     // Two LIKE-fallback body hits: both textScore = 0 (no BM25), no vector
     // match, exactPathSpecificity = 0. Their weighted contentScore collapses to
@@ -877,6 +837,7 @@ describe("memory hybrid helpers", () => {
         source: "memory",
         snippet: "weak substring overlap",
         textScore: 0,
+        hasBodyMatch: true,
         rankingScore: 0.2,
         pathScore: 0,
         exactPathSpecificity: 0 as const,
@@ -889,6 +850,7 @@ describe("memory hybrid helpers", () => {
         source: "memory",
         snippet: "strong substring overlap with the query terms",
         textScore: 0,
+        hasBodyMatch: true,
         rankingScore: 0.8,
         pathScore: 0,
         exactPathSpecificity: 0 as const,

--- a/extensions/memory-core/src/memory/hybrid.test.ts
+++ b/extensions/memory-core/src/memory/hybrid.test.ts
@@ -816,6 +816,110 @@ describe("memory hybrid helpers", () => {
     expect(merged[0]?.textScore).toBeCloseTo(1);
   });
 
+  it("mergeHybridResults does not produce finalScore = 1.0 for LIKE-fallback keyword hits", async () => {
+    // LIKE substring fallback (FTS5 MATCH throws, or substring-only query)
+    // scores textScore = 0 because it carries no BM25 ranking signal. Even
+    // when the same chunk is a perfect vector neighbor (vectorScore = 1), the
+    // merged contentScore must stay below 1.0 so non-identical content is not
+    // reported as a near-duplicate. See #115001.
+    const merged = await mergeHybridResults({
+      vectorWeight: 0.7,
+      textWeight: 0.3,
+      vector: [
+        {
+          id: "a",
+          path: "memory/a.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "vec-a",
+          vectorScore: 1,
+        },
+      ],
+      keyword: [
+        {
+          id: "a",
+          path: "memory/a.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "kw-a",
+          textScore: 0,
+        },
+      ],
+    });
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.textScore).toBe(0);
+    // 0.7 * 1 (vector) + 0.3 * 0 (LIKE recall only) = 0.7, strictly below 1.0.
+    expect(merged[0]?.score).toBeCloseTo(0.7);
+    expect(merged[0]?.score).toBeLessThan(1);
+  });
+
+  it("preserves LIKE-fallback lexical ordering in hybrid selection (keyword-only)", async () => {
+    // Two LIKE-fallback body hits: both textScore = 0 (no BM25), no vector
+    // match, exactPathSpecificity = 0. Their weighted contentScore collapses to
+    // 0 for both, so they would tie by path without the lexical tie-break.
+    // The manager carries a boost-derived lexical score as `rankingScore`; the
+    // hybrid consumer must use it as an unweighted tie-break so the
+    // lexically-stronger hit ranks first regardless of path alphabetical order.
+    // See ClawSweeper P2 finding on #120603 / #115001.
+    //
+    // path alphabetical order (memory/aaa.md < memory/zzz.md) is intentionally
+    // the REVERSE of lexical strength, so a path-ordered tie would put aaa
+    // first while the lexical tie-break must put zzz first.
+    const keyword = [
+      {
+        id: "aaa",
+        path: "memory/aaa.md",
+        startLine: 1,
+        endLine: 1,
+        source: "memory",
+        snippet: "weak substring overlap",
+        textScore: 0,
+        rankingScore: 0.2,
+        pathScore: 0,
+        exactPathSpecificity: 0 as const,
+      },
+      {
+        id: "zzz",
+        path: "memory/zzz.md",
+        startLine: 1,
+        endLine: 1,
+        source: "memory",
+        snippet: "strong substring overlap with the query terms",
+        textScore: 0,
+        rankingScore: 0.8,
+        pathScore: 0,
+        exactPathSpecificity: 0 as const,
+      },
+    ];
+    const merged = await mergeHybridResults({
+      vectorWeight: 0.7,
+      textWeight: 0.3,
+      vector: [],
+      keyword,
+    });
+
+    // Both hits tie at contentScore = 0 (no vector, LIKE carries no weighted
+    // text signal), proving the ordering below comes from the lexical tie-break
+    // and not from a restored weighted text score.
+    expect(merged.map((entry) => entry.score)).toEqual([0, 0]);
+    // The internal lexicalRank signal must not leak into the public result.
+    expect(merged.every((entry) => !("lexicalRank" in entry))).toBe(true);
+
+    const selected = selectHybridSearchResults({
+      merged,
+      keyword,
+      maxResults: 2,
+      minScore: 0,
+    });
+
+    // Lexical tie-break: zzz (rankingScore 0.8) before aaa (rankingScore 0.2),
+    // NOT path alphabetical (aaa before zzz).
+    expect(selected.map((entry) => entry.path)).toEqual(["memory/zzz.md", "memory/aaa.md"]);
+  });
+
   const vectorResult = (id: string, path: string, vectorScore: number) => ({
     id,
     path,

--- a/extensions/memory-core/src/memory/hybrid.ts
+++ b/extensions/memory-core/src/memory/hybrid.ts
@@ -51,6 +51,7 @@ type HybridKeywordResult<TSource extends HybridSource = HybridSource> = {
   source: TSource;
   snippet: string;
   textScore: number;
+  hasBodyMatch?: boolean;
   importance?: number;
   triggers?: string;
   projectKey?: string;
@@ -113,6 +114,7 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
       rankingScore: number;
       pathScore: number;
       exactPathSpecificity: ExactPathSpecificity;
+      hasBodyMatch: boolean;
       hasVector: boolean;
       hasKeyword: boolean;
       importance?: number;
@@ -135,6 +137,7 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
       rankingScore: 0,
       pathScore: 0,
       exactPathSpecificity: r.exactPathSpecificity ?? 0,
+      hasBodyMatch: false,
       hasVector: true,
       hasKeyword: false,
       importance: r.importance,
@@ -149,6 +152,7 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
     const existing = byId.get(r.id);
     if (existing) {
       existing.textScore = r.textScore;
+      existing.hasBodyMatch = r.hasBodyMatch ?? r.textScore > 0;
       existing.rankingScore = r.rankingScore ?? r.textScore;
       existing.pathScore = r.pathScore ?? 0;
       existing.exactPathSpecificity = Math.max(
@@ -178,6 +182,7 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
         rankingScore: r.rankingScore ?? r.textScore,
         pathScore: r.pathScore ?? 0,
         exactPathSpecificity,
+        hasBodyMatch: r.hasBodyMatch ?? r.textScore > 0,
         hasVector: false,
         hasKeyword: true,
         importance: r.importance,
@@ -207,14 +212,9 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
       ? entry.vectorScore
       : params.vectorWeight * entry.vectorScore + params.textWeight * keywordScore;
     const hasWeightedContentRelevance = contentScore > 0;
-    // LIKE-fallback body hits carry textScore = 0 (no BM25) but still have a
-    // manager-computed lexical ranking score in `rankingScore`. The weighted
-    // `keywordScore` above correctly stays 0 so LIKE never inflates the hybrid
-    // content score; carry the lexical score here as an unweighted tie-break
-    // signal so keyword-only / vector-less fallback results order by lexical
-    // overlap rather than collapsing into a path-ordered tie at score 0.
-    const lexicalRank =
-      entry.textScore === 0 && entry.exactPathSpecificity === 0 ? (entry.rankingScore ?? 0) : 0;
+    // LIKE recall has no weighted BM25 score. Its lexical score only breaks
+    // ties between otherwise equal results.
+    const lexicalRank = entry.hasBodyMatch && entry.textScore === 0 ? entry.rankingScore : 0;
     // With decay enabled, reserve the lower half of an exact tier for path
     // identity and the upper half for content relevance. This lets recency beat
     // a stale cap-selected content hit. Otherwise retain the established score.
@@ -299,6 +299,7 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
   };
   const compareExactTieScores = (a: (typeof rankable)[number], b: (typeof rankable)[number]) =>
     b.exactPathTieScore - a.exactPathTieScore ||
+    b.lexicalRank - a.lexicalRank ||
     a.path.localeCompare(b.path) ||
     a.startLine - b.startLine ||
     a.endLine - b.endLine;
@@ -309,8 +310,12 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
     if (temporalDecayConfig.enabled) {
       return rerankExactGroup(tier);
     }
-    const contentBacked = tier.filter((entry) => entry.hasWeightedContentRelevance);
-    const pathOnly = tier.filter((entry) => !entry.hasWeightedContentRelevance);
+    const contentBacked = tier.filter(
+      (entry) => entry.hasWeightedContentRelevance || entry.lexicalRank > 0,
+    );
+    const pathOnly = tier.filter(
+      (entry) => !entry.hasWeightedContentRelevance && entry.lexicalRank === 0,
+    );
     return rerankExactGroup(contentBacked).concat(rerankExactGroup(pathOnly));
   });
   const ranked = [

--- a/extensions/memory-core/src/memory/hybrid.ts
+++ b/extensions/memory-core/src/memory/hybrid.ts
@@ -207,6 +207,14 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
       ? entry.vectorScore
       : params.vectorWeight * entry.vectorScore + params.textWeight * keywordScore;
     const hasWeightedContentRelevance = contentScore > 0;
+    // LIKE-fallback body hits carry textScore = 0 (no BM25) but still have a
+    // manager-computed lexical ranking score in `rankingScore`. The weighted
+    // `keywordScore` above correctly stays 0 so LIKE never inflates the hybrid
+    // content score; carry the lexical score here as an unweighted tie-break
+    // signal so keyword-only / vector-less fallback results order by lexical
+    // overlap rather than collapsing into a path-ordered tie at score 0.
+    const lexicalRank =
+      entry.textScore === 0 && entry.exactPathSpecificity === 0 ? (entry.rankingScore ?? 0) : 0;
     // With decay enabled, reserve the lower half of an exact tier for path
     // identity and the upper half for content relevance. This lets recency beat
     // a stale cap-selected content hit. Otherwise retain the established score.
@@ -227,6 +235,7 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
       textScore: entry.textScore,
       exactPathSpecificity: entry.exactPathSpecificity,
       hasWeightedContentRelevance,
+      lexicalRank,
       snippet: entry.snippet,
       source: entry.source,
       importance: entry.importance,
@@ -267,6 +276,7 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
     .toSorted(
       (a, b) =>
         b.score - a.score ||
+        b.lexicalRank - a.lexicalRank ||
         a.path.localeCompare(b.path) ||
         a.startLine - b.startLine ||
         a.endLine - b.endLine,
@@ -313,6 +323,7 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
       exactPathSpecificity: _exactPathSpecificity,
       exactPathTieScore: _exactPathTieScore,
       hasWeightedContentRelevance: _hasWeightedContentRelevance,
+      lexicalRank: _lexicalRank,
       ...entry
     }) => entry,
   );

--- a/extensions/memory-core/src/memory/manager-index.test-support.ts
+++ b/extensions/memory-core/src/memory/manager-index.test-support.ts
@@ -41,6 +41,7 @@ export type ManagerIndexFixtureConfig = {
     maxFileBytes?: number;
   };
   vectorEnabled?: boolean;
+  ftsTokenizer?: "unicode61" | "trigram";
   cacheEnabled?: boolean;
   minScore?: number;
   onSearch?: boolean;
@@ -430,6 +431,7 @@ export function createManagerIndexFixture(deps: {
           fallback: params.fallback,
           outputDimensionality: params.outputDimensionality,
           store: {
+            fts: params.ftsTokenizer ? { tokenizer: params.ftsTokenizer } : undefined,
             vector: params.vectorEnabled !== undefined ? { enabled: params.vectorEnabled } : {},
           },
           remote: params.batchEnabled ? { batch: { enabled: true } } : undefined,

--- a/extensions/memory-core/src/memory/manager-keyword-retrieval.test.ts
+++ b/extensions/memory-core/src/memory/manager-keyword-retrieval.test.ts
@@ -471,4 +471,131 @@ describe("memory index", () => {
       fixture.restoreStateDir();
     }
   });
+
+  it("preserves LIKE fallback body lexical ordering through manager normalization", async () => {
+    // LIKE fallback body hits carry textScore = 0 (no BM25, recall only) but
+    // boost mode still derives a lexical score. The manager's path-only
+    // sentinel (textScore === 0) must not erase that boost-derived score
+    // during normalization, or every fallback body hit ties at zero. See #120603.
+    const cfg = createCfg({
+      minScore: 0,
+      hybrid: { enabled: true, vectorWeight: 0, textWeight: 1 },
+    });
+    const manager = await getPersistentManager(cfg);
+    type FallbackKeywordHit = {
+      id: string;
+      path: string;
+      startLine: number;
+      endLine: number;
+      score: number;
+      snippet: string;
+      source: "memory";
+      textScore: number;
+      pathScore: number;
+      exactPathSpecificity: 0;
+      likeFallbackBody?: boolean;
+    };
+    const internal = manager as unknown as {
+      mergeKeywordSearchHits: (
+        resultSets: FallbackKeywordHit[][],
+        exactPathQuery?: string,
+      ) => Array<FallbackKeywordHit>;
+    };
+
+    const merged = internal.mergeKeywordSearchHits(
+      [
+        [
+          {
+            id: "strong",
+            path: "memory/strong.md",
+            startLine: 1,
+            endLine: 2,
+            score: 0.69,
+            snippet: "strong fallback body",
+            source: "memory",
+            textScore: 0,
+            pathScore: 0,
+            exactPathSpecificity: 0,
+            likeFallbackBody: true,
+          },
+          {
+            id: "weak",
+            path: "memory/weak.md",
+            startLine: 1,
+            endLine: 2,
+            score: 0.35,
+            snippet: "weak fallback body",
+            source: "memory",
+            textScore: 0,
+            pathScore: 0,
+            exactPathSpecificity: 0,
+            likeFallbackBody: true,
+          },
+        ],
+      ],
+      "fallback query",
+    );
+
+    expect(merged).toHaveLength(2);
+    const byId = new Map(merged.map((entry) => [entry.id, entry]));
+    // textScore stays 0 (fallback contributes no BM25 to hybrid contentScore).
+    expect(byId.get("strong")?.textScore).toBe(0);
+    expect(byId.get("weak")?.textScore).toBe(0);
+    // The flag survives normalization so the path-only sentinel excludes them.
+    expect(byId.get("strong")?.likeFallbackBody).toBe(true);
+    expect(byId.get("weak")?.likeFallbackBody).toBe(true);
+    // Boost-derived scores survive normalization (not reset to pathScore = 0).
+    expect(byId.get("strong")?.score).toBeCloseTo(0.69);
+    expect(byId.get("weak")?.score).toBeCloseTo(0.35);
+    expect(byId.get("strong")?.score).toBeGreaterThan(byId.get("weak")?.score ?? 0);
+  });
+
+  it("does not leak the likeFallbackBody marker into public search results", async () => {
+    // likeFallbackBody is manager-internal state; it must be stripped at the
+    // public conversion boundary (toMemorySearchResults) so memory tool and
+    // CLI JSON output never serialize an undocumented field. See #120603.
+    const cfg = createCfg({
+      minScore: 0,
+      hybrid: { enabled: true, vectorWeight: 0, textWeight: 1 },
+    });
+    const manager = await getPersistentManager(cfg);
+    type InternalKeywordHit = {
+      id: string;
+      path: string;
+      startLine: number;
+      endLine: number;
+      score: number;
+      snippet: string;
+      source: "memory";
+      textScore: number;
+      pathScore: number;
+      exactPathSpecificity: 0;
+      likeFallbackBody?: boolean;
+    };
+    const internal = manager as unknown as {
+      toMemorySearchResults: (results: InternalKeywordHit[]) => Array<Record<string, unknown>>;
+    };
+
+    const publicResults = internal.toMemorySearchResults([
+      {
+        id: "strong",
+        path: "memory/strong.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.69,
+        snippet: "strong fallback body",
+        source: "memory",
+        textScore: 0,
+        pathScore: 0,
+        exactPathSpecificity: 0,
+        likeFallbackBody: true,
+      },
+    ]);
+
+    expect(publicResults).toHaveLength(1);
+    expect(publicResults[0]).not.toHaveProperty("likeFallbackBody");
+    // Other internal ranking fields stay stripped too.
+    expect(publicResults[0]).not.toHaveProperty("pathScore");
+    expect(publicResults[0]).not.toHaveProperty("exactPathSpecificity");
+  });
 });

--- a/extensions/memory-core/src/memory/manager-keyword-retrieval.test.ts
+++ b/extensions/memory-core/src/memory/manager-keyword-retrieval.test.ts
@@ -472,130 +472,51 @@ describe("memory index", () => {
     }
   });
 
-  it("preserves LIKE fallback body lexical ordering through manager normalization", async () => {
-    // LIKE fallback body hits carry textScore = 0 (no BM25, recall only) but
-    // boost mode still derives a lexical score. The manager's path-only
-    // sentinel (textScore === 0) must not erase that boost-derived score
-    // during normalization, or every fallback body hit ties at zero. See #120603.
-    const cfg = createCfg({
-      minScore: 0,
-      hybrid: { enabled: true, vectorWeight: 0, textWeight: 1 },
-    });
-    const manager = await getPersistentManager(cfg);
-    type FallbackKeywordHit = {
-      id: string;
-      path: string;
-      startLine: number;
-      endLine: number;
-      score: number;
-      snippet: string;
-      source: "memory";
-      textScore: number;
-      pathScore: number;
-      exactPathSpecificity: 0;
-      likeFallbackBody?: boolean;
-    };
-    const internal = manager as unknown as {
-      mergeKeywordSearchHits: (
-        resultSets: FallbackKeywordHit[][],
-        exactPathQuery?: string,
-      ) => Array<FallbackKeywordHit>;
-    };
-
-    const merged = internal.mergeKeywordSearchHits(
-      [
-        [
-          {
-            id: "strong",
-            path: "memory/strong.md",
-            startLine: 1,
-            endLine: 2,
-            score: 0.69,
-            snippet: "strong fallback body",
-            source: "memory",
-            textScore: 0,
-            pathScore: 0,
-            exactPathSpecificity: 0,
-            likeFallbackBody: true,
-          },
-          {
-            id: "weak",
-            path: "memory/weak.md",
-            startLine: 1,
-            endLine: 2,
-            score: 0.35,
-            snippet: "weak fallback body",
-            source: "memory",
-            textScore: 0,
-            pathScore: 0,
-            exactPathSpecificity: 0,
-            likeFallbackBody: true,
-          },
-        ],
-      ],
-      "fallback query",
+  it("ranks substring-only recall without reporting perfect confidence", async () => {
+    providerFixture.forceNoProvider = true;
+    const manager = await getPersistentManager(
+      createCfg({
+        provider: "none",
+        ftsTokenizer: "trigram",
+        minScore: 0,
+        hybrid: { enabled: true },
+      }),
     );
+    if (!manager.status().fts?.available) {
+      return;
+    }
+    await fs.writeFile(path.join(fixture.paths.memory, "a-weak.md"), "记忆 alpha beta gamma");
+    await fs.writeFile(path.join(fixture.paths.memory, "z-strong.md"), "记忆");
+    await manager.sync({ reason: "test" });
 
-    expect(merged).toHaveLength(2);
-    const byId = new Map(merged.map((entry) => [entry.id, entry]));
-    // textScore stays 0 (fallback contributes no BM25 to hybrid contentScore).
-    expect(byId.get("strong")?.textScore).toBe(0);
-    expect(byId.get("weak")?.textScore).toBe(0);
-    // The flag survives normalization so the path-only sentinel excludes them.
-    expect(byId.get("strong")?.likeFallbackBody).toBe(true);
-    expect(byId.get("weak")?.likeFallbackBody).toBe(true);
-    // Boost-derived scores survive normalization (not reset to pathScore = 0).
-    expect(byId.get("strong")?.score).toBeCloseTo(0.69);
-    expect(byId.get("weak")?.score).toBeCloseTo(0.35);
-    expect(byId.get("strong")?.score).toBeGreaterThan(byId.get("weak")?.score ?? 0);
+    const results = await manager.search("记忆", { maxResults: 2, minScore: 0 });
+
+    expect(results.map((entry) => entry.path)).toEqual(["memory/z-strong.md", "memory/a-weak.md"]);
+    expect(results.every((entry) => entry.score > 0 && entry.score < 1)).toBe(true);
+    expect(results.every((entry) => !("hasBodyMatch" in entry))).toBe(true);
   });
 
-  it("does not leak the likeFallbackBody marker into public search results", async () => {
-    // likeFallbackBody is manager-internal state; it must be stripped at the
-    // public conversion boundary (toMemorySearchResults) so memory tool and
-    // CLI JSON output never serialize an undocumented field. See #120603.
-    const cfg = createCfg({
-      minScore: 0,
-      hybrid: { enabled: true, vectorWeight: 0, textWeight: 1 },
-    });
-    const manager = await getPersistentManager(cfg);
-    type InternalKeywordHit = {
-      id: string;
-      path: string;
-      startLine: number;
-      endLine: number;
-      score: number;
-      snippet: string;
-      source: "memory";
-      textScore: number;
-      pathScore: number;
-      exactPathSpecificity: 0;
-      likeFallbackBody?: boolean;
-    };
-    const internal = manager as unknown as {
-      toMemorySearchResults: (results: InternalKeywordHit[]) => Array<Record<string, unknown>>;
-    };
+  it("keeps substring-only body ranking within an exact hybrid tier", async () => {
+    const manager = await getPersistentManager(
+      createCfg({
+        ftsTokenizer: "trigram",
+        minScore: 0,
+        hybrid: { enabled: true, vectorWeight: 0, textWeight: 1 },
+      }),
+    );
+    if (!manager.status().fts?.available) {
+      return;
+    }
+    const weakDir = path.join(fixture.paths.memory, "a");
+    const strongDir = path.join(fixture.paths.memory, "z");
+    await fs.mkdir(weakDir, { recursive: true });
+    await fs.mkdir(strongDir, { recursive: true });
+    await fs.writeFile(path.join(weakDir, "记忆.md"), "记忆 alpha beta gamma");
+    await fs.writeFile(path.join(strongDir, "记忆.md"), "记忆");
+    await manager.sync({ reason: "test" });
 
-    const publicResults = internal.toMemorySearchResults([
-      {
-        id: "strong",
-        path: "memory/strong.md",
-        startLine: 1,
-        endLine: 2,
-        score: 0.69,
-        snippet: "strong fallback body",
-        source: "memory",
-        textScore: 0,
-        pathScore: 0,
-        exactPathSpecificity: 0,
-        likeFallbackBody: true,
-      },
-    ]);
+    const results = await manager.search("记忆", { maxResults: 2, minScore: 0 });
 
-    expect(publicResults).toHaveLength(1);
-    expect(publicResults[0]).not.toHaveProperty("likeFallbackBody");
-    // Other internal ranking fields stay stripped too.
-    expect(publicResults[0]).not.toHaveProperty("pathScore");
-    expect(publicResults[0]).not.toHaveProperty("exactPathSpecificity");
+    expect(results.map((entry) => entry.path)).toEqual(["memory/z/记忆.md", "memory/a/记忆.md"]);
   });
 });

--- a/extensions/memory-core/src/memory/manager-keyword-retrieval.ts
+++ b/extensions/memory-core/src/memory/manager-keyword-retrieval.ts
@@ -35,7 +35,23 @@ export type KeywordSearchHit = MemorySearchResult & {
   textScore: number;
   pathScore: number;
   exactPathSpecificity: ExactPathSpecificity;
+  // LIKE fallback body hits carry no BM25 (textScore = 0, recall only) but
+  // boost mode still derives a lexical score. Without this flag the manager's
+  // path-only sentinel (textScore === 0) would erase that boost-derived score.
+  likeFallbackBody?: boolean;
 };
+
+// A hit counts as a body hit when it has real BM25 (textScore > 0) OR is a
+// LIKE fallback body hit (textScore = 0 but boost-derived score present).
+function keywordHitHasBody(hit: KeywordSearchHit): boolean {
+  return hit.textScore > 0 || hit.likeFallbackBody === true;
+}
+
+// The path-only sentinel must exclude LIKE fallback body hits so their
+// boost-derived score survives manager normalization.
+function keywordHitIsPathOnly(hit: KeywordSearchHit): boolean {
+  return hit.textScore === 0 && hit.likeFallbackBody !== true;
+}
 
 function compareKeywordSearchHits(
   a: KeywordSearchHit,
@@ -47,7 +63,7 @@ function compareKeywordSearchHits(
     return specificityDelta;
   }
   if (preferExactBody && a.exactPathSpecificity > 0) {
-    const bodyPresenceDelta = Number(b.textScore > 0) - Number(a.textScore > 0);
+    const bodyPresenceDelta = Number(keywordHitHasBody(b)) - Number(keywordHitHasBody(a));
     if (bodyPresenceDelta !== 0) {
       return bodyPresenceDelta;
     }
@@ -154,7 +170,7 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
           if (entry.exactPathSpecificity === 0) {
             return entry;
           }
-          const contentScore = entry.textScore > 0 ? entry.score : 0;
+          const contentScore = keywordHitHasBody(entry) ? entry.score : 0;
           return { ...entry, score: scoreExactPathTieForTemporalDecay(contentScore) };
         })
       : params.results;
@@ -324,8 +340,8 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
           seenIds.set(result.id, result);
           continue;
         }
-        const existingHasBody = existing.textScore > 0;
-        const resultHasBody = result.textScore > 0;
+        const existingHasBody = keywordHitHasBody(existing);
+        const resultHasBody = keywordHitHasBody(result);
         const existingBodyScore = existingHasBody ? existing.score : 0;
         const resultBodyScore = resultHasBody ? result.score : 0;
         existing.textScore = Math.max(existing.textScore, result.textScore);
@@ -334,6 +350,10 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
           existing.exactPathSpecificity,
           result.exactPathSpecificity,
         ) as ExactPathSpecificity;
+        // Preserve the LIKE fallback body flag across merges so the path-only
+        // sentinel keeps excluding boost-derived fallback body scores.
+        existing.likeFallbackBody =
+          existing.likeFallbackBody === true || result.likeFallbackBody === true;
         const bodyScore = Math.max(existingBodyScore, resultBodyScore);
         existing.score = bodyScore > 0 ? bodyScore : existing.pathScore;
         // Path hits project the first chunk; keep a real body-match snippet
@@ -355,9 +375,11 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
       }
     }
     for (const result of merged) {
-      if (result.textScore === 0) {
+      if (keywordHitIsPathOnly(result)) {
         // A uniform exact-only baseline lets temporal decay order otherwise
         // equivalent filename hits without reusing incomparable path BM25.
+        // LIKE fallback body hits (textScore = 0 but boost-derived score) are
+        // excluded so their lexical ranking survives normalization.
         result.score = result.exactPathSpecificity > 0 ? 1 : result.pathScore;
       }
     }
@@ -370,10 +392,10 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
   ): KeywordSearchHit[] {
     const ranked = results.toSorted(compareKeywordSearchHits);
     const exactBody = ranked
-      .filter((entry) => entry.exactPathSpecificity > 0 && entry.textScore > 0)
+      .filter((entry) => entry.exactPathSpecificity > 0 && keywordHitHasBody(entry))
       .slice(0, nonExactLimit);
     const exactPathOnly = ranked.filter(
-      (entry) => entry.exactPathSpecificity > 0 && entry.textScore === 0,
+      (entry) => entry.exactPathSpecificity > 0 && keywordHitIsPathOnly(entry),
     );
     const boundedExact = exactBody.concat(exactPathOnly).toSorted(compareKeywordSearchHits);
     const selectedPathKeys = new Set<string>();
@@ -398,6 +420,7 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
         id: _id,
         pathScore: _pathScore,
         exactPathSpecificity: _exactPathSpecificity,
+        likeFallbackBody: _likeFallbackBody,
         ...result
       }) => result,
     );

--- a/extensions/memory-core/src/memory/manager-keyword-retrieval.ts
+++ b/extensions/memory-core/src/memory/manager-keyword-retrieval.ts
@@ -35,22 +35,11 @@ export type KeywordSearchHit = MemorySearchResult & {
   textScore: number;
   pathScore: number;
   exactPathSpecificity: ExactPathSpecificity;
-  // LIKE fallback body hits carry no BM25 (textScore = 0, recall only) but
-  // boost mode still derives a lexical score. Without this flag the manager's
-  // path-only sentinel (textScore === 0) would erase that boost-derived score.
-  likeFallbackBody?: boolean;
+  hasBodyMatch: boolean;
 };
 
-// A hit counts as a body hit when it has real BM25 (textScore > 0) OR is a
-// LIKE fallback body hit (textScore = 0 but boost-derived score present).
 function keywordHitHasBody(hit: KeywordSearchHit): boolean {
-  return hit.textScore > 0 || hit.likeFallbackBody === true;
-}
-
-// The path-only sentinel must exclude LIKE fallback body hits so their
-// boost-derived score survives manager normalization.
-function keywordHitIsPathOnly(hit: KeywordSearchHit): boolean {
-  return hit.textScore === 0 && hit.likeFallbackBody !== true;
+  return hit.hasBodyMatch;
 }
 
 function compareKeywordSearchHits(
@@ -350,10 +339,7 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
           existing.exactPathSpecificity,
           result.exactPathSpecificity,
         ) as ExactPathSpecificity;
-        // Preserve the LIKE fallback body flag across merges so the path-only
-        // sentinel keeps excluding boost-derived fallback body scores.
-        existing.likeFallbackBody =
-          existing.likeFallbackBody === true || result.likeFallbackBody === true;
+        existing.hasBodyMatch ||= result.hasBodyMatch;
         const bodyScore = Math.max(existingBodyScore, resultBodyScore);
         existing.score = bodyScore > 0 ? bodyScore : existing.pathScore;
         // Path hits project the first chunk; keep a real body-match snippet
@@ -375,11 +361,9 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
       }
     }
     for (const result of merged) {
-      if (keywordHitIsPathOnly(result)) {
+      if (!keywordHitHasBody(result)) {
         // A uniform exact-only baseline lets temporal decay order otherwise
         // equivalent filename hits without reusing incomparable path BM25.
-        // LIKE fallback body hits (textScore = 0 but boost-derived score) are
-        // excluded so their lexical ranking survives normalization.
         result.score = result.exactPathSpecificity > 0 ? 1 : result.pathScore;
       }
     }
@@ -395,7 +379,7 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
       .filter((entry) => entry.exactPathSpecificity > 0 && keywordHitHasBody(entry))
       .slice(0, nonExactLimit);
     const exactPathOnly = ranked.filter(
-      (entry) => entry.exactPathSpecificity > 0 && keywordHitIsPathOnly(entry),
+      (entry) => entry.exactPathSpecificity > 0 && !keywordHitHasBody(entry),
     );
     const boundedExact = exactBody.concat(exactPathOnly).toSorted(compareKeywordSearchHits);
     const selectedPathKeys = new Set<string>();
@@ -420,7 +404,7 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
         id: _id,
         pathScore: _pathScore,
         exactPathSpecificity: _exactPathSpecificity,
-        likeFallbackBody: _likeFallbackBody,
+        hasBodyMatch: _hasBodyMatch,
         ...result
       }) => result,
     );

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -480,6 +480,7 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
         source: r.source,
         snippet: r.snippet,
         textScore: r.textScore,
+        hasBodyMatch: r.hasBodyMatch,
         importance: r.importance,
         triggers: r.triggers,
         projectKey: r.projectKey,

--- a/extensions/memory-core/src/memory/manager-search.test.ts
+++ b/extensions/memory-core/src/memory/manager-search.test.ts
@@ -211,7 +211,9 @@ describe("searchKeyword trigram fallback", () => {
       query: "成语",
     });
     expect(results.map((row) => row.id)).toContain("1");
-    expect(results[0]?.textScore).toBe(1);
+    // LIKE substring fallback carries no BM25 ranking signal, so textScore is 0
+    // (recall only); the hybrid merge must not treat it as a perfect match.
+    expect(results[0]?.textScore).toBe(0);
   });
 
   itWithTrigramFts("finds short Japanese and Korean queries with substring fallback", async () => {
@@ -353,8 +355,9 @@ describe("searchKeyword FTS MATCH fallback", () => {
       // LIKE fallback should find "Agent" in the first row
       expect(results.length).toBeGreaterThan(0);
       expect(results[0]?.id).toBe("1");
-      // Fallback results have textScore=1 (no BM25 ranking)
-      expect(results[0]?.textScore).toBe(1);
+      // LIKE fallback has no BM25 ranking, so textScore is 0 (recall only) and
+      // cannot inflate the hybrid merge into a spurious finalScore = 1.0.
+      expect(results[0]?.textScore).toBe(0);
     } finally {
       db.close();
     }

--- a/extensions/memory-core/src/memory/manager-search.test.ts
+++ b/extensions/memory-core/src/memory/manager-search.test.ts
@@ -214,6 +214,7 @@ describe("searchKeyword trigram fallback", () => {
     // LIKE substring fallback carries no BM25 ranking signal, so textScore is 0
     // (recall only); the hybrid merge must not treat it as a perfect match.
     expect(results[0]?.textScore).toBe(0);
+    expect(results[0]?.hasBodyMatch).toBe(true);
   });
 
   itWithTrigramFts("finds short Japanese and Korean queries with substring fallback", async () => {
@@ -358,6 +359,7 @@ describe("searchKeyword FTS MATCH fallback", () => {
       // LIKE fallback has no BM25 ranking, so textScore is 0 (recall only) and
       // cannot inflate the hybrid merge into a spurious finalScore = 1.0.
       expect(results[0]?.textScore).toBe(0);
+      expect(results[0]?.hasBodyMatch).toBe(true);
     } finally {
       db.close();
     }

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -106,6 +106,7 @@ type PathKeywordSearchResult = SearchRowResult & {
   textScore: 0;
   pathScore: number;
   exactPathSpecificity: ExactPathSpecificity;
+  hasBodyMatch: false;
 };
 
 function comparePathKeywordSearchResults(
@@ -662,7 +663,7 @@ export async function searchKeyword(params: {
   bm25RankToScore: (rank: number) => number;
   boostFallbackRanking?: boolean;
   rankingQuery?: string;
-}): Promise<Array<SearchRowResult & { textScore: number; likeFallbackBody?: boolean }>> {
+}): Promise<Array<SearchRowResult & { textScore: number; hasBodyMatch: true }>> {
   if (params.limit <= 0) {
     return [];
   }
@@ -767,11 +768,9 @@ export async function searchKeyword(params: {
         endLine: row.end_line,
         score,
         textScore,
+        hasBodyMatch: true as const,
         snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
         source: row.source,
-        // Mark LIKE fallback body hits so the manager's path-only sentinel
-        // (textScore === 0) does not erase the boost-derived lexical score.
-        ...(usedMatch ? {} : { likeFallbackBody: true }),
       },
       readChunkProvenance(params.db, row.id),
     );
@@ -899,6 +898,7 @@ export async function searchPathKeyword(params: {
       textScore: 0,
       pathScore: 0,
       exactPathSpecificity: row.exact_path_specificity,
+      hasBodyMatch: false,
       snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
       source: row.source,
     };
@@ -1039,6 +1039,7 @@ export async function searchPathKeyword(params: {
         textScore: 0,
         pathScore,
         exactPathSpecificity,
+        hasBodyMatch: false,
         snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
         source: row.source,
       };

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -662,7 +662,7 @@ export async function searchKeyword(params: {
   bm25RankToScore: (rank: number) => number;
   boostFallbackRanking?: boolean;
   rankingQuery?: string;
-}): Promise<Array<SearchRowResult & { textScore: number }>> {
+}): Promise<Array<SearchRowResult & { textScore: number; likeFallbackBody?: boolean }>> {
   if (params.limit <= 0) {
     return [];
   }
@@ -743,7 +743,14 @@ export async function searchKeyword(params: {
   }
 
   return rows.map((row) => {
-    const textScore = usedMatch ? params.bm25RankToScore(row.rank) : 1;
+    // LIKE fallback only confirms substring recall — it has no BM25 ranking, so
+    // treating it as a perfect text match (textScore = 1) let weak substring
+    // hits combine with vectorScore in the hybrid merge and produce spurious
+    // finalScore = 1.0 for non-identical content. Score these as a zero text
+    // signal so only the vector score contributes to contentScore; boost mode
+    // still derives a lexicalBoost from query/text overlap via
+    // scoreFallbackKeywordResult below.
+    const textScore = usedMatch ? params.bm25RankToScore(row.rank) : 0;
     const score = params.boostFallbackRanking
       ? scoreFallbackKeywordResult({
           query: params.rankingQuery ?? params.query,
@@ -762,6 +769,9 @@ export async function searchKeyword(params: {
         textScore,
         snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
         source: row.source,
+        // Mark LIKE fallback body hits so the manager's path-only sentinel
+        // (textScore === 0) does not erase the boost-derived lexical score.
+        ...(usedMatch ? {} : { likeFallbackBody: true }),
       },
       readChunkProvenance(params.db, row.id),
     );


### PR DESCRIPTION
Closes #115001

## What Problem This Solves

FTS5 LIKE fallback no longer reports every body hit as perfect text relevance.

- `searchKeyword` used `textScore = 1` when `MATCH` failed or a short trigram query used substring matching.
- Keyword-only search returned that value as a public score, so unrelated fallback hits tied at `1.0`.
- Hybrid search could also combine it with `vectorScore = 1` and report a false perfect score.
- Candidate recall is unchanged. Returned scores, ordering, and selected membership can change by design.

## Why This Change Was Made

LIKE confirms substring recall but provides no BM25 ranking signal. The producer now records `textScore = 0` and a separate `hasBodyMatch` fact. Keyword and hybrid ranking use the existing lexical-overlap score only as an ordering signal. They strip the internal fact before returning public results.

This also fixes the exact-path sibling case. A LIKE body hit in an exact path tier now stays ahead of a weaker path-only or lower-overlap hit.

## User Impact

- LIKE fallback body hits no longer appear as perfect matches.
- Keyword-only fallback results rank by lexical overlap instead of path name.
- Exact-path fallback results keep the same lexical ordering in hybrid mode.
- No configuration or storage migration is required.

## Evidence

Current-main reproduction on `b581ff0be72`:

```console
$ node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-keyword-retrieval.test.ts -t 'substring-only'
FAIL ranks substring-only recall without reporting perfect confidence
expected memory/z-strong.md first; received memory/a-weak.md first
```

The producer test also failed on current main with `expected 0; received 1` for the short Chinese LIKE fallback.

The prior PR head `c61eeba31ba3` reproduced the exact-tier sibling bug:

```console
$ node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-keyword-retrieval.test.ts -t 'exact hybrid tier'
FAIL expected memory/z/记忆.md first; received memory/a/记忆.md first
```

Exact repaired head `7cfa6ffdfdafce078ca631516155db7910821a84`:

```console
$ node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-search.test.ts extensions/memory-core/src/memory/manager-keyword-retrieval.test.ts extensions/memory-core/src/memory/hybrid.test.ts extensions/memory-core/src/memory/manager-search-orchestration.test.ts
Test Files  4 passed (4)
Tests  93 passed (93)

$ git diff --check
# clean
```

`$autoreview --mode local` returned `patch is correct (0.99)` with no accepted or actionable findings.

Production delta is `+46/-11` across the four ranking files. Tests and test support are `+124/-3`. The production growth carries one producer-owned body-match fact through keyword and hybrid ranking, then removes it at both public result boundaries.

### Landing Proof

- Exact-head CI: [`openclaw/ci-gate` passed](https://github.com/openclaw/openclaw/actions/runs/33035571809) on `7cfa6ffdfdafce078ca631516155db7910821a84`.
- Local ClawSweeper: platinum hermit; patch correct; zero findings; security cleared; no maintainer decision; no Rank-up moves.
- Telegram default-turn probe: doctor passed; the QA user sent `Please answer with OPENCLAW_E2E_BASIC only.` in a direct message; Telegram recorded typing and the exact `OPENCLAW_E2E_BASIC` reply; the mock provider recorded one request.
- Telegram artifacts: `summary.json`, `events.ndjson`, `gateway.log`, and `mock-openai-requests.ndjson` were retained outside the repository.

## AI Assistance

- AI-assisted: Yes
- Contributor tools: Claude Sonnet 4.6
- Maintainer repair and review: Codex
- Confirmed understanding: Yes
