### PR TITLE
fix(agents): mark Shre Router AUM chat-only

### DIFF
--- a/src/agents/embedded-agent-runner/model.inline-provider.test.ts
+++ b/src/agents/embedded-agent-runner/model.inline-provider.test.ts
@@ -307,6 +307,23 @@ describe("buildInlineProviderModels", () => {
       "X-Static": "tenant-a",
     });
   });
+
+  it("marks shre-router aum/70b inline config as chat-only by default", () => {
+    const providers: Parameters<typeof buildInlineProviderModels>[0] = {
+      "shre-router": {
+        baseUrl: "http://127.0.0.1:5497/v1",
+        api: "openai-completions",
+        models: [makeModel("aum/70b")],
+      },
+    };
+
+    const result = buildInlineProviderModels(providers);
+
+    expect(result).toHaveLength(1);
+    expect(expectDefined(result[0], "result[0] test invariant").compat).toEqual({
+      supportsTools: false,
+    });
+  });
 });
 
 describe("resolveProviderModelInput", () => {

--- a/src/agents/embedded-agent-runner/model.inline-provider.ts
+++ b/src/agents/embedded-agent-runner/model.inline-provider.ts
@@ -106,6 +106,21 @@ function isLegacyFoundryVisionModelCandidate(params: {
   );
 }
 
+function resolveInlineProviderModelCompat(params: {
+  provider: string;
+  model: ModelDefinitionConfig;
+}): ModelDefinitionConfig["compat"] {
+  const configuredCompat = params.model.compat;
+  if (
+    normalizeOptionalLowercaseString(params.provider) === "shre-router" &&
+    normalizeOptionalLowercaseString(params.model.id) === "aum/70b" &&
+    configuredCompat?.supportsTools === undefined
+  ) {
+    return { ...configuredCompat, supportsTools: false };
+  }
+  return configuredCompat;
+}
+
 /** Resolves model input modalities with Foundry legacy vision-model compatibility. */
 export function resolveProviderModelInput(params: {
   provider?: string;
@@ -162,6 +177,7 @@ export function buildInlineProviderModels(
       const modelHeaders = sanitizeModelHeaders((model as InlineModelEntry).headers, {
         stripSecretRefMarkers: true,
       });
+      const compat = resolveInlineProviderModelCompat({ provider: trimmed, model });
       const requestConfig = resolveProviderRequestConfig({
         provider: trimmed,
         api: transport.api ?? model.api,
@@ -190,6 +206,7 @@ export function buildInlineProviderModels(
                 modelName: model.name,
                 input: model.input,
               }),
+              ...(compat ? { compat } : {}),
               provider: trimmed,
               baseUrl: requestConfig.baseUrl ?? transport.baseUrl,
               api: requestConfig.api ?? model.api,


### PR DESCRIPTION
## Summary
- Default inline shre-router aum/70b model config to compat.supportsTools=false.
- Add a regression test for the chat-only default so Hermes/MyClaw flows do not send tools to AUM by default.

## Verification
- RED: node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model.inline-provider.test.ts failed before the implementation with compat undefined.
- GREEN: node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model.inline-provider.test.ts passed, 15 tests.
- git diff --check passed.
- OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- src/agents/embedded-agent-runner/model.inline-provider.ts src/agents/embedded-agent-runner/model.inline-provider.test.ts passed locally.

## Notes
- Direct push/merge to openclaw/openclaw is blocked for the current GitHub account (viewerPermission READ), so this PR is opened from the writable fork.