### PR TITLE
refactor(ui): unify the visible board dock union into board settings

### DIFF
--- a/ui/src/lib/board/settings.ts
+++ b/ui/src/lib/board/settings.ts
@@ -1,9 +1,10 @@
 import type { SessionBoardFace } from "../../../../src/shared/session-types.js";
+import type { BoardTab } from "./types.ts";
 
 export type BoardFace = SessionBoardFace;
-// Persisted-settings union; the render-layer equivalent is VisibleBoardDock
-// (chat-pane-shared.ts), derived from the protocol BoardTab shape.
-type BoardVisibleChatDock = "bottom" | "left" | "right";
+// Canonical visible-dock union, derived from the protocol BoardTab shape so
+// persisted settings and render code can never drift from the wire contract.
+export type BoardVisibleChatDock = Exclude<BoardTab["chatDock"], "hidden">;
 
 export type BoardSessionView = {
   activeTabId?: string;

--- a/ui/src/pages/chat/board-session-surface.ts
+++ b/ui/src/pages/chat/board-session-surface.ts
@@ -5,14 +5,13 @@ import { icons } from "../../components/icons.ts";
 import { renderSettingsSegmented } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { isMockBoardEnabled, type BoardViewCallbacks } from "../../lib/board/provider.ts";
-import type { BoardFace } from "../../lib/board/settings.ts";
+import type { BoardFace, BoardVisibleChatDock } from "../../lib/board/settings.ts";
 import type { BoardTab } from "../../lib/board/types.ts";
 import type {
   BoardObserverContext,
   BoardViewSnapshot,
   BoardWidgetFrameUrl,
 } from "../../lib/board/view-types.ts";
-import type { VisibleBoardDock } from "./chat-pane-shared.ts";
 
 export type BoardChatDockSize = {
   height: number;
@@ -61,7 +60,7 @@ export async function ensureBoardViewElement(): Promise<boolean> {
 
 type BoardViewMode = "chat" | "split" | "dashboard";
 
-function dockLabel(dock: VisibleBoardDock): string {
+function dockLabel(dock: BoardVisibleChatDock): string {
   if (dock === "left") {
     return t("chat.board.dockLeft");
   }
@@ -77,7 +76,7 @@ export function renderBoardViewSwitch(props: {
   dock: BoardTab["chatDock"];
   canChangeDock: boolean;
   onSelectMode: (mode: BoardViewMode) => void;
-  onDockSideChange: (dock: VisibleBoardDock) => void;
+  onDockSideChange: (dock: BoardVisibleChatDock) => void;
 }) {
   if (!props.hasBoard) {
     return nothing;

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -29,7 +29,7 @@ import type {
   BoardProvider,
   BoardProviderLease,
 } from "../../lib/board/provider.ts";
-import type { BoardFace } from "../../lib/board/settings.ts";
+import type { BoardFace, BoardVisibleChatDock } from "../../lib/board/settings.ts";
 import type { BoardSnapshot, BoardTab } from "../../lib/board/types.ts";
 import type { BoardViewSnapshot } from "../../lib/board/view-types.ts";
 import { ObserverDigestHistory } from "../../lib/observer-digest.ts";
@@ -47,7 +47,6 @@ import {
   boardChatDockLayout,
   type ChatPageContext,
   type PaneSessionChangeOptions,
-  type VisibleBoardDock,
 } from "./chat-pane-shared.ts";
 import { SessionParticipationTracker } from "./chat-pane-state.ts";
 import {
@@ -254,7 +253,7 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
         resolve: (confirmed: boolean) => void;
       }
     | undefined;
-  protected readonly lastVisibleBoardDock = new Map<string, VisibleBoardDock>();
+  protected readonly lastVisibleBoardDock = new Map<string, BoardVisibleChatDock>();
   protected readonly observerDigestHistory = new ObserverDigestHistory();
   protected builtinBoardSnapshot: BoardViewSnapshot | null = null;
   protected builtinBoardSnapshotBase: BoardSnapshot | null = null;

--- a/ui/src/pages/chat/chat-pane-board.ts
+++ b/ui/src/pages/chat/chat-pane-board.ts
@@ -12,7 +12,11 @@ import {
   type BoardCommandEvent,
   type BoardProvider,
 } from "../../lib/board/provider.ts";
-import { updateBoardSessionView, type BoardSessionView } from "../../lib/board/settings.ts";
+import {
+  updateBoardSessionView,
+  type BoardSessionView,
+  type BoardVisibleChatDock,
+} from "../../lib/board/settings.ts";
 import type { BoardTab } from "../../lib/board/types.ts";
 import type { BoardViewSnapshot } from "../../lib/board/view-types.ts";
 import {
@@ -30,11 +34,7 @@ import {
 } from "../../lib/sessions/session-key.ts";
 import type { WorkboardCardChipProps } from "./board-session-surface.ts";
 import { ChatPaneHistory } from "./chat-pane-history.ts";
-import {
-  boardChatDockLayout,
-  type ResolvedBoardView,
-  type VisibleBoardDock,
-} from "./chat-pane-shared.ts";
+import { boardChatDockLayout, type ResolvedBoardView } from "./chat-pane-shared.ts";
 import { renderChatResizableDivider } from "./components/chat-resizable-divider.ts";
 import {
   SIDEBAR_NARROW_BREAKPOINT_PX,
@@ -423,7 +423,7 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
     this.requestUpdate();
   }
 
-  protected persistBoardReopenDock(board: ResolvedBoardView, dock: VisibleBoardDock): void {
+  protected persistBoardReopenDock(board: ResolvedBoardView, dock: BoardVisibleChatDock): void {
     if (!board.activeTabId) {
       return;
     }
@@ -489,7 +489,7 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
       .catch((error: unknown) => this.publishHeaderError(error));
   }
 
-  protected renderBoardDivider(dock: VisibleBoardDock) {
+  protected renderBoardDivider(dock: BoardVisibleChatDock) {
     return renderChatResizableDivider({
       className: "board-session-surface__divider",
       orientation: dock === "bottom" ? "horizontal" : "vertical",
@@ -518,7 +518,7 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
   }
 
   protected handleBoardDockResize(
-    dock: VisibleBoardDock,
+    dock: BoardVisibleChatDock,
     event: CustomEvent<{ splitRatio: number }>,
   ): void {
     if (dock !== "bottom") {

--- a/ui/src/pages/chat/chat-pane-shared.ts
+++ b/ui/src/pages/chat/chat-pane-shared.ts
@@ -5,7 +5,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { createDockPanelLayout } from "../../components/dock-panel-layout.ts";
 import type { BoardProvider } from "../../lib/board/provider.ts";
-import type { BoardFace } from "../../lib/board/settings.ts";
+import type { BoardFace, BoardVisibleChatDock } from "../../lib/board/settings.ts";
 import type { BoardTab } from "../../lib/board/types.ts";
 import type { BoardViewSnapshot } from "../../lib/board/view-types.ts";
 import { clampText } from "../../lib/format.ts";
@@ -13,7 +13,6 @@ import type { ChatPageHost } from "./chat-state-host.ts";
 
 export type ChatPageContext = ApplicationContext;
 export type PaneSessionChangeOptions = { replace?: boolean };
-export type VisibleBoardDock = Exclude<BoardTab["chatDock"], "hidden">;
 export type ResolvedBoardView = {
   provider: BoardProvider;
   snapshot: BoardViewSnapshot;
@@ -22,7 +21,7 @@ export type ResolvedBoardView = {
   activeTabId: string;
   activeTabReadOnly: boolean;
   dock: BoardTab["chatDock"];
-  reopenDock: VisibleBoardDock;
+  reopenDock: BoardVisibleChatDock;
 };
 
 export const boardChatDockLayout = createDockPanelLayout({


### PR DESCRIPTION
Related: #120487

## What Problem This Solves

The Control UI carried two definitions of the same "visible chat dock side" concept: `BoardVisibleChatDock`, a hand-written `"bottom" | "left" | "right"` literal union in `ui/src/lib/board/settings.ts` (persistence layer), and `VisibleBoardDock`, derived from the protocol `BoardTab["chatDock"]` shape in `ui/src/pages/chat/chat-pane-shared.ts` (render layer). Two spellings of one concept invite drift: if the protocol ever gained or renamed a dock side, the hand-written settings union would silently diverge from what the render layer accepts.

## Why This Change Was Made

Named follow-up from [#120487](https://github.com/openclaw/openclaw/pull/120487), where the duplication was noted in review artifacts. One canonical exported type now lives in `ui/src/lib/board/settings.ts`, derived from `BoardTab` (`Exclude<BoardTab["chatDock"], "hidden">`) so the persisted-settings validator and every render-layer consumer share the wire contract by construction. All five consumer files migrate to it; the render-layer alias is deleted.

## User Impact

None — type-only refactor, no runtime behavior change. Net −5 LOC, one concept, one spelling (repo rule: "One spelling per concept repo-wide").

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/chat ui/src/lib/board` — 125 files, 2697 tests passed
- `pnpm tsgo:ui` — clean (exit 0, 0 errors)
- `pnpm check:import-cycles` — 0 runtime value cycles (settings→types import is type-only re-export)
- `pnpm deadcode:exports` — 0 entries (the export now has cross-module consumers)
- Codex autoreview (`gpt-5.6-sol`, high) — clean, no actionable findings
