### PR TITLE
fix(macos): recover node startup after legacy identity recreation

### DIFF
--- a/apps/macos/Sources/OpenClaw/CommandResolver.swift
+++ b/apps/macos/Sources/OpenClaw/CommandResolver.swift
@@ -254,6 +254,27 @@ enum CommandResolver {
         #endif
     }
 
+    static func projectNodeHostWorkerLaunch(
+        projectRoot: URL? = nil,
+        searchPaths: [String]? = nil) async throws -> MacNodeHostWorkerLaunch?
+    {
+        #if DEBUG
+        let root = projectRoot ?? self.projectRoot()
+        let sourceRunner = root.appendingPathComponent("scripts/run-node.mjs")
+        guard FileManager().isReadableFile(atPath: sourceRunner.path) else { return nil }
+        switch await self.runtimeResolution(searchPaths: searchPaths) {
+        case let .success(runtime):
+            return MacNodeHostWorkerLaunch(
+                command: [runtime.path, sourceRunner.path, "node", "worker"],
+                currentDirectoryURL: root)
+        case let .failure(error):
+            throw error
+        }
+        #else
+        return nil
+        #endif
+    }
+
     static func openclawNodeCommand(
         subcommand: String,
         extraArgs: [String] = [],

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
@@ -16,8 +16,18 @@ struct MacNodeHostManifest: Equatable, Sendable {
     let pathEnv: String
 }
 
+struct MacNodeHostWorkerLaunch: Equatable, Sendable {
+    let command: [String]
+    let currentDirectoryURL: URL?
+
+    init(command: [String], currentDirectoryURL: URL? = nil) {
+        self.command = command
+        self.currentDirectoryURL = currentDirectoryURL
+    }
+}
+
 protocol MacNodeHostWorking: Sendable {
-    func start(command: [String]) async throws -> MacNodeHostManifest
+    func start(launch: MacNodeHostWorkerLaunch) async throws -> MacNodeHostManifest
     func supports(_ command: String) async -> Bool
     func invoke(_ request: BridgeInvokeRequest) async -> BridgeInvokeResponse
     func handleInput(invokeId: String, seq: Int, payloadJSON: String) async
@@ -63,7 +73,7 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
     private var stdoutSource: DispatchSourceRead?
     private var stderrSource: DispatchSourceRead?
     private var processGeneration: UUID?
-    private var launchedCommand: [String]?
+    private var launchedWorker: MacNodeHostWorkerLaunch?
     private var stdoutBuffer = Data()
     private var manifest: MacNodeHostManifest?
     private var inventoryData: Data?
@@ -89,12 +99,12 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         self.onUnexpectedExit = onUnexpectedExit
     }
 
-    func start(command: [String]) async throws -> MacNodeHostManifest {
+    func start(launch: MacNodeHostWorkerLaunch) async throws -> MacNodeHostManifest {
         try await withCheckedThrowingContinuation { continuation in
             self.queue.async {
                 if let manifest = self.manifest,
                    self.process?.isRunning == true,
-                   self.launchedCommand == command
+                   self.launchedWorker == launch
                 {
                     continuation.resume(returning: manifest)
                     return
@@ -104,7 +114,7 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
                     return
                 }
                 self.startContinuation = continuation
-                self.startLocked(command: command)
+                self.startLocked(launch: launch)
             }
         }
     }
@@ -285,7 +295,8 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         }
     }
 
-    private func startLocked(command: [String]) {
+    private func startLocked(launch: MacNodeHostWorkerLaunch) {
+        let command = launch.command
         guard let executable = command.first, !executable.isEmpty else {
             self.finishStartLocked(.failure(WorkerError.unavailable("node-host worker command missing")))
             return
@@ -303,6 +314,7 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         }
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = Array(command.dropFirst())
+        process.currentDirectoryURL = launch.currentDirectoryURL
         var environment = ProcessInfo.processInfo.environment
         environment["PATH"] = CommandResolver.preferredPaths().joined(separator: ":")
         environment["OPENCLAW_NODE_EXEC_HOST"] = "app"
@@ -312,7 +324,7 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
         self.process = process
-        self.launchedCommand = command
+        self.launchedWorker = launch
         self.stdinPipe = stdinPipe
         self.stdoutPipe = stdoutPipe
         self.stderrPipe = stderrPipe
@@ -646,7 +658,7 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
             self.process?.terminate()
         }
         self.process = nil
-        self.launchedCommand = nil
+        self.launchedWorker = nil
         self.stdinPipe = nil
         self.stdoutPipe = nil
         self.stderrPipe = nil

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorkerRetryPolicy.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorkerRetryPolicy.swift
@@ -2,7 +2,7 @@ import Foundation
 
 struct MacNodeHostWorkerRetryPolicy: Sendable {
     struct Input: Equatable, Sendable {
-        let command: [String]
+        let launch: MacNodeHostWorkerLaunch
         let configurationGeneration: UInt64
     }
 

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -753,7 +753,7 @@ final class MacNodeModeCoordinator: NSObject {
             throw MacNodeHostWorkerRetryPolicy.RetryBackoffPending()
         }
         let input = MacNodeHostWorkerRetryPolicy.Input(
-            command: command,
+            launch: MacNodeHostWorkerLaunch(command: command),
             configurationGeneration: self.nodeHostWorkerConfigurationGeneration)
         try self.nodeHostWorkerRetryPolicy.prepareForStart(input)
         self.activeNodeHostWorkerInput = input
@@ -823,23 +823,27 @@ final class MacNodeModeCoordinator: NSObject {
         guard self.nodeHostWorkerRetryTask == nil else {
             throw MacNodeHostWorkerRetryPolicy.RetryBackoffPending()
         }
-        let executable: String
-        if let projectExecutable = CommandResolver.projectOpenClawExecutable() {
-            executable = projectExecutable
-        } else {
-            switch await CLIInstaller.status() {
-            case let .ready(location, _): executable = location
-            case let status:
-                throw MacNodeHostWorker.WorkerError.unavailable(status.message)
+        let launch: MacNodeHostWorkerLaunch
+        do {
+            if let projectLaunch = try await CommandResolver.projectNodeHostWorkerLaunch() {
+                launch = projectLaunch
+            } else {
+                switch await CLIInstaller.status() {
+                case let .ready(location, _):
+                    launch = MacNodeHostWorkerLaunch(command: [location, "node", "worker"])
+                case let status:
+                    throw MacNodeHostWorker.WorkerError.unavailable(status.message)
+                }
             }
+        } catch let error as RuntimeResolutionError {
+            throw MacNodeHostWorker.WorkerError.unavailable(RuntimeLocator.describeFailure(error))
         }
-        let command = [executable, "node", "worker"]
         let input = MacNodeHostWorkerRetryPolicy.Input(
-            command: command,
+            launch: launch,
             configurationGeneration: self.nodeHostWorkerConfigurationGeneration)
         try self.nodeHostWorkerRetryPolicy.prepareForStart(input)
         self.activeNodeHostWorkerInput = input
-        return try await nodeHostWorker.start(command: command)
+        return try await nodeHostWorker.start(launch: launch)
     }
 
     private func handleNodeHostWorkerFailure() {

--- a/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
@@ -40,23 +40,34 @@ import Testing
         #expect(cmd.prefix(2).elementsEqual([openclawPath.path, "gateway"]))
     }
 
-    @Test func `source checkout entrypoint wins when package bin link is absent`() async throws {
-        let defaults = self.makeLocalDefaults()
+    @Test func `source checkout worker uses the freshness aware runner`() async throws {
         let tmp = try makeTempDirForTests()
+        let runner = tmp.appendingPathComponent("scripts/run-node.mjs")
         let sourceEntrypoint = tmp.appendingPathComponent("openclaw.mjs")
-        let staleGlobalBin = tmp.appendingPathComponent("global/bin")
+        let distEntrypoint = tmp.appendingPathComponent("dist/entry.js")
+        let projectExecutable = tmp.appendingPathComponent("node_modules/.bin/openclaw")
+        let runtimeBin = tmp.appendingPathComponent("runtime/bin")
+        let node = runtimeBin.appendingPathComponent("node")
+        try FileManager().createDirectory(
+            at: runner.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        try "// source runner\n".write(to: runner, atomically: true, encoding: .utf8)
         try makeExecutableForTests(at: sourceEntrypoint)
-        try makeExecutableForTests(at: staleGlobalBin.appendingPathComponent("openclaw"))
+        try makeExecutableForTests(at: distEntrypoint)
+        try makeExecutableForTests(at: projectExecutable)
+        try makeExecutableForTests(at: node)
+        try "#!/bin/sh\necho v22.22.3\n".write(to: node, atomically: true, encoding: .utf8)
+        try FileManager().setAttributes([.posixPermissions: 0o755], ofItemAtPath: node.path)
 
-        let cmd = await CommandResolver.openclawCommand(
-            subcommand: "node",
-            extraArgs: ["worker"],
-            defaults: defaults,
-            configRoot: [:],
-            searchPaths: [staleGlobalBin.path],
-            projectRoot: tmp)
+        let launch = try #require(try await CommandResolver.projectNodeHostWorkerLaunch(
+            projectRoot: tmp,
+            searchPaths: [runtimeBin.path]))
 
-        #expect(cmd == [sourceEntrypoint.path, "node", "worker"])
+        #expect(launch.command == [node.path, runner.path, "node", "worker"])
+        #expect(launch.currentDirectoryURL == tmp)
+        #expect(!launch.command.contains(sourceEntrypoint.path))
+        #expect(!launch.command.contains(distEntrypoint.path))
+        #expect(!launch.command.contains(projectExecutable.path))
     }
 
     @Test func `falls back to node and script`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerPipeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerPipeTests.swift
@@ -12,7 +12,8 @@ struct MacNodeHostWorkerPipeTests {
         printf '%s\\n' '{"type":"ready","version":"test","manifest":{"caps":[],"commands":[],"pathEnv":"/bin"}}'
         sleep 1
         """
-        _ = try await worker.start(command: ["/bin/sh", "-c", script])
+        _ = try await worker.start(launch: MacNodeHostWorkerLaunch(
+            command: ["/bin/sh", "-c", script]))
 
         let response = await worker.invoke(BridgeInvokeRequest(
             id: "closed",

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import OpenClawKit
 import Testing
@@ -17,7 +18,7 @@ private actor StubMacNodeHostWorker: MacNodeHostWorking {
             pathEnv: "/usr/bin:/bin")
     }
 
-    func start(command _: [String]) async throws -> MacNodeHostManifest { self.manifest }
+    func start(launch _: MacNodeHostWorkerLaunch) async throws -> MacNodeHostManifest { self.manifest }
     func supports(_ command: String) async -> Bool { self.manifest.commands.contains(command) }
 
     func invoke(_ request: BridgeInvokeRequest) async -> BridgeInvokeResponse {
@@ -38,7 +39,8 @@ private actor StubMacNodeHostWorker: MacNodeHostWorking {
 struct MacNodeHostWorkerTests {
     @Test func `worker crash retry budget is bounded and exponentially delayed`() throws {
         let input = MacNodeHostWorkerRetryPolicy.Input(
-            command: ["/usr/local/bin/openclaw", "node", "worker"],
+            launch: MacNodeHostWorkerLaunch(
+                command: ["/usr/local/bin/openclaw", "node", "worker"]),
             configurationGeneration: 4)
         var policy = MacNodeHostWorkerRetryPolicy(maximumRetryCount: 5)
 
@@ -62,10 +64,11 @@ struct MacNodeHostWorkerTests {
 
     @Test func `new worker input resets an exhausted crash retry budget`() throws {
         let original = MacNodeHostWorkerRetryPolicy.Input(
-            command: ["/usr/local/bin/openclaw", "node", "worker"],
+            launch: MacNodeHostWorkerLaunch(
+                command: ["/usr/local/bin/openclaw", "node", "worker"]),
             configurationGeneration: 4)
         let updated = MacNodeHostWorkerRetryPolicy.Input(
-            command: original.command,
+            launch: original.launch,
             configurationGeneration: 5)
         var policy = MacNodeHostWorkerRetryPolicy(maximumRetryCount: 1)
 
@@ -89,8 +92,28 @@ struct MacNodeHostWorkerTests {
         while IFS= read -r line; do :; done
         """
 
-        let manifest = try await worker.start(command: ["/bin/sh", "-c", script])
+        let manifest = try await worker.start(launch: MacNodeHostWorkerLaunch(
+            command: ["/bin/sh", "-c", script]))
         #expect(manifest.version == "test")
+        await worker.stop()
+    }
+
+    @Test func `worker launches in the selected checkout`() async throws {
+        let checkout = try makeTempDirForTests().resolvingSymlinksInPath()
+        let worker = MacNodeHostWorker(session: GatewayNodeSession(), startupTimeout: 1)
+        let script = """
+        printf '{"type":"ready","version":"test","manifest":{"caps":[],"commands":[],"pathEnv":"%s"}}\\n' \
+          "$(/bin/pwd -P)"
+        while IFS= read -r line; do :; done
+        """
+
+        let manifest = try await worker.start(launch: MacNodeHostWorkerLaunch(
+            command: ["/bin/sh", "-c", script],
+            currentDirectoryURL: checkout))
+
+        let expectedCurrentDirectory = try #require(realpath(checkout.path, nil))
+        defer { free(expectedCurrentDirectory) }
+        #expect(manifest.pathEnv == String(cString: expectedCurrentDirectory))
         await worker.stop()
     }
 
@@ -227,7 +250,8 @@ struct MacNodeHostWorkerTests {
         done
         """
 
-        let manifest = try await worker.start(command: ["/bin/sh", "-c", script])
+        let manifest = try await worker.start(launch: MacNodeHostWorkerLaunch(
+            command: ["/bin/sh", "-c", script]))
         #expect(manifest.commands == ["system.run"])
         let response = await worker.invoke(BridgeInvokeRequest(
             id: "worker-run",
@@ -255,7 +279,8 @@ struct MacNodeHostWorkerTests {
         while IFS= read -r line; do :; done
         """
 
-        _ = try await worker.start(command: ["/bin/sh", "-c", script])
+        _ = try await worker.start(launch: MacNodeHostWorkerLaunch(
+            command: ["/bin/sh", "-c", script]))
         await worker.handleInput(invokeId: "terminal-1", seq: 7, payloadJSON: #"{"data":"x"}"#)
         await worker.cancel(invokeId: "terminal-1")
         let response = await worker.invoke(BridgeInvokeRequest(
@@ -277,7 +302,8 @@ struct MacNodeHostWorkerTests {
             exit 7
             """
 
-            _ = try await worker.start(command: ["/bin/sh", "-c", script])
+            _ = try await worker.start(launch: MacNodeHostWorkerLaunch(
+                command: ["/bin/sh", "-c", script]))
             try? await Task.sleep(for: .milliseconds(200))
         }
     }
@@ -293,8 +319,10 @@ struct MacNodeHostWorkerTests {
         while IFS= read -r line; do :; done
         """
 
-        let first = try await worker.start(command: ["/bin/sh", "-c", firstScript])
-        let second = try await worker.start(command: ["/bin/sh", "-c", secondScript])
+        let first = try await worker.start(launch: MacNodeHostWorkerLaunch(
+            command: ["/bin/sh", "-c", firstScript]))
+        let second = try await worker.start(launch: MacNodeHostWorkerLaunch(
+            command: ["/bin/sh", "-c", secondScript]))
 
         #expect(first.version == "first")
         #expect(second.version == "second")
@@ -312,7 +340,8 @@ struct MacNodeHostWorkerTests {
         IFS= read -r second
         printf '%s\\n' '{"type":"invoke-result","result":{"id":"second","ok":true,"payload":{"done":true}}}'
         """
-        _ = try await worker.start(command: ["/bin/sh", "-c", script])
+        _ = try await worker.start(launch: MacNodeHostWorkerLaunch(
+            command: ["/bin/sh", "-c", script]))
 
         let first = Task {
             await worker.invoke(BridgeInvokeRequest(

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
@@ -103,7 +103,7 @@ private actor CoordinatorDrainSnapshotProbe {
 private actor CoordinatorNodeHostWorkerProbe: MacNodeHostWorking {
     private var stopCount = 0
 
-    func start(command _: [String]) async throws -> MacNodeHostManifest {
+    func start(launch _: MacNodeHostWorkerLaunch) async throws -> MacNodeHostManifest {
         MacNodeHostManifest(version: "test", caps: [], commands: [], pathEnv: "/usr/bin:/bin")
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
@@ -130,6 +130,12 @@ enum DeviceIdentitySQLiteStore {
     {
         try self.secureDirectory(destinationStateDirURL)
         try self.secureDirectory(databaseURL.deletingLastPathComponent())
+        // SQLite owns an existing profile; leave any downgrade-recreated legacy source for Doctor.
+        if self.pathMayExist(databaseURL),
+           let existing = try self.loadExisting(databaseURL: databaseURL, profile: profile)
+        {
+            return existing
+        }
         var claims: [LegacyClaim] = []
         do {
             for source in legacySources {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
@@ -498,17 +498,20 @@ struct DeviceIdentityStoreTests {
     @Test
     func `same key migration preserves the authoritative SQLite timestamp`() throws {
         let fixture = DeviceIdentityMigrationFixture()
-        try Self.seedCanonicalSchema(fixture.databaseURL, nodeOwned: true)
-        try Self.execute(fixture.databaseURL, """
-        INSERT INTO device_identities (
-          identity_key, device_id, public_key_pem, private_key_pem, created_at_ms, updated_at_ms
-        ) VALUES (
-          'primary', '\(Self.fixtureDeviceID)', '\(Self.sql(Self.fixturePublicKeyPEM))',
-          '\(Self.sql(Self.fixturePrivateKeyPEM))', 1700000000000, 1700000000123
-        )
-        """)
         let source = try fixture.source()
-        let identity = try fixture.load(sources: [source])
+        let identity = try fixture.load(
+            sources: [source],
+            beforeLegacyClaim: { _ in
+                try Self.seedCanonicalSchema(fixture.databaseURL, nodeOwned: true)
+                try Self.execute(fixture.databaseURL, """
+                INSERT INTO device_identities (
+                  identity_key, device_id, public_key_pem, private_key_pem, created_at_ms, updated_at_ms
+                ) VALUES (
+                  'primary', '\(Self.fixtureDeviceID)', '\(Self.sql(Self.fixturePublicKeyPEM))',
+                  '\(Self.sql(Self.fixturePrivateKeyPEM))', 1700000000000, 1700000000123
+                )
+                """)
+            })
 
         #expect(identity.deviceId == Self.fixtureDeviceID)
         #expect(identity.createdAtMs == 1_700_000_000_000)
@@ -516,6 +519,38 @@ struct DeviceIdentityStoreTests {
             fixture.databaseURL,
             "SELECT updated_at_ms FROM device_identities WHERE identity_key = 'primary'") == 1_700_000_000_123)
         #expect(!FileManager.default.fileExists(atPath: source.identityURL.path))
+    }
+
+    @Test(arguments: [GatewayDeviceIdentityProfile.primary, .node])
+    func `canonical SQLite identity ignores a recreated retired file`(
+        profile: GatewayDeviceIdentityProfile) throws
+    {
+        let fixture = DeviceIdentityMigrationFixture()
+        let canonical = try fixture.load(profile: profile)
+        let createdAt = try Self.scalarInt(
+            fixture.databaseURL,
+            "SELECT created_at_ms FROM device_identities WHERE identity_key = '\(profile.rawValue)'")
+        let updatedAt = try Self.scalarInt(
+            fixture.databaseURL,
+            "SELECT updated_at_ms FROM device_identities WHERE identity_key = '\(profile.rawValue)'")
+        let source = try fixture.source(profile: profile)
+        let legacyBytes = try Data(contentsOf: source.identityURL)
+
+        let loaded = try fixture.load(
+            profile: profile,
+            sources: [source],
+            beforeLegacyClaim: { _ in Issue.record("canonical identity inspected a retired source") })
+
+        #expect(loaded == canonical)
+        #expect(canonical.deviceId != Self.fixtureDeviceID)
+        #expect(try Self.scalarInt(
+            fixture.databaseURL,
+            "SELECT created_at_ms FROM device_identities WHERE identity_key = '\(profile.rawValue)'") == createdAt)
+        #expect(try Self.scalarInt(
+            fixture.databaseURL,
+            "SELECT updated_at_ms FROM device_identities WHERE identity_key = '\(profile.rawValue)'") == updatedAt)
+        #expect(try Data(contentsOf: source.identityURL) == legacyBytes)
+        #expect(!FileManager.default.fileExists(atPath: fixture.claimURL(for: source).path))
     }
 
     @Test
@@ -755,19 +790,6 @@ struct DeviceIdentityStoreTests {
         }
         #expect(FileManager.default.fileExists(atPath: real.identityURL.path))
         #expect(FileManager.default.fileExists(atPath: hard.identityURL.path))
-    }
-
-    @Test
-    func `conflicting SQLite identity preserves the legacy source`() throws {
-        let fixture = DeviceIdentityMigrationFixture()
-        let existing = try fixture.load()
-        let source = try fixture.source("shared")
-
-        #expect(throws: NSError.self) {
-            try fixture.load(sources: [source])
-        }
-        #expect(FileManager.default.fileExists(atPath: source.identityURL.path))
-        #expect(try fixture.load().deviceId == existing.deviceId)
     }
 
     @Test

--- a/src/infra/device-identity.test.ts
+++ b/src/infra/device-identity.test.ts
@@ -41,6 +41,19 @@ function storeOptions(rootDir: string, identityKey?: string): DeviceIdentityStor
   };
 }
 
+function writeRetiredIdentity(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    `${JSON.stringify({
+      deviceId: SWIFT_RAW_DEVICE_ID,
+      publicKey: SWIFT_RAW_PUBLIC_KEY,
+      privateKey: SWIFT_RAW_PRIVATE_KEY,
+      createdAtMs: 1_700_000_000_000,
+    })}\n`,
+  );
+}
+
 function waitForChild(child: ChildProcess): Promise<DeviceIdentity> {
   let stdout = "";
   let stderr = "";
@@ -263,11 +276,30 @@ describe("device identity SQLite store", () => {
       expect(secondary.deviceId).not.toBe(primary.deviceId);
 
       const claimPath = path.join(rootDir, "identity", "device.json.doctor-importing");
-      fs.mkdirSync(path.dirname(claimPath), { recursive: true });
-      fs.writeFileSync(claimPath, "{}\n");
-      expect(() => loadOrCreateProcessDeviceIdentity(primaryOptions)).toThrow(/doctor --fix/);
+      writeRetiredIdentity(claimPath);
+      expect(loadOrCreateProcessDeviceIdentity(primaryOptions)).toBe(primary);
+      expect(fs.existsSync(claimPath)).toBe(true);
     });
   });
+
+  it.each(["device.json", "device.json.doctor-importing", "device.json.native-importing"])(
+    "keeps canonical SQLite authoritative when retired %s reappears",
+    async (legacyName) => {
+      await withTempDir("openclaw-device-identity-canonical-", async (rootDir) => {
+        const options = storeOptions(rootDir);
+        const canonical = loadOrCreateDeviceIdentity(options);
+        expect(canonical.deviceId).not.toBe(SWIFT_RAW_DEVICE_ID);
+        closeOpenClawStateDatabaseForTest();
+
+        const legacyPath = path.join(rootDir, "identity", legacyName);
+        writeRetiredIdentity(legacyPath);
+
+        expect(loadDeviceIdentityIfPresent(options)).toEqual(canonical);
+        expect(loadOrCreateDeviceIdentity(options)).toEqual(canonical);
+        expect(fs.existsSync(legacyPath)).toBe(true);
+      });
+    },
+  );
 
   it("returns one authoritative winner to concurrent creators", async () => {
     await withTempDir("openclaw-device-identity-concurrent-", async (rootDir) => {

--- a/src/infra/device-identity.ts
+++ b/src/infra/device-identity.ts
@@ -125,11 +125,14 @@ function withDeviceIdentityCoordinator<T>(
 }
 
 function loadOrCreateDeviceIdentityOwned(options: DeviceIdentityStoreOptions): DeviceIdentity {
-  assertNoPendingLegacyIdentity(options);
-  const existing = readStoredDeviceIdentity(options);
+  const { databasePath } = resolveDeviceIdentityStore(options);
+  // A downgrade can recreate retired JSON after SQLite migration. Once this profile has
+  // a canonical row, keep it authoritative and leave the retired source for Doctor.
+  const existing = pathMayExist(databasePath) ? readStoredDeviceIdentity(options) : null;
   if (existing) {
     return toDeviceIdentity(existing);
   }
+  assertNoPendingLegacyIdentity(options);
 
   // Generate outside the write transaction. The transaction rereads the row
   // before inserting so concurrent runtimes converge on one authoritative key.
@@ -154,7 +157,6 @@ export function loadOrCreateProcessDeviceIdentity(
   options: DeviceIdentityStoreOptions = {},
 ): DeviceIdentity {
   return withDeviceIdentityCoordinator(options, (resolved, resolvedOptions) => {
-    assertNoPendingLegacyIdentity(resolvedOptions);
     const cacheKey = `${resolved.databasePath}\0${resolved.identityKey}`;
     const cached = processDeviceIdentities.get(cacheKey);
     if (cached) {
@@ -172,9 +174,12 @@ export function loadDeviceIdentityIfPresent(
   options: DeviceIdentityStoreOptions = {},
 ): DeviceIdentity | null {
   return withDeviceIdentityCoordinator(options, (_resolved, resolvedOptions) => {
-    assertNoPendingLegacyIdentity(resolvedOptions);
     const stored = readStoredDeviceIdentityReadOnly(resolvedOptions);
-    return stored ? toDeviceIdentity(stored) : null;
+    if (stored) {
+      return toDeviceIdentity(stored);
+    }
+    assertNoPendingLegacyIdentity(resolvedOptions);
+    return null;
   });
 }
 


### PR DESCRIPTION
Closes #120608

## What Problem This Solves

Fixes an issue where macOS app users could lose native node startup after an older app build recreated retired device identity JSON files alongside valid canonical SQLite identities. The app would repeatedly report `Could not access the persisted device identity`, leaving node capabilities such as camera control unavailable.

## Why This Change Was Made

Canonical SQLite rows now win before retired identity files are examined in both the native and TypeScript identity paths. Divergent retired files remain untouched for explicit Doctor handling, while missing canonical rows still use the existing migration flow.

Debug Mac node workers now launch the selected checkout through the freshness-aware `scripts/run-node.mjs` runner with an explicit checkout working directory, rather than invoking a bare launcher against potentially partial shared `dist/` output. Installed/release CLI behavior is unchanged.

AI-assisted implementation and review; the behavior and ownership boundaries were independently verified against copied state.

## User Impact

Affected macOS nodes recover their existing canonical identity and can connect again without rotating keys, deleting retired files, or changing the SQLite schema. Developers also get deterministic worker startup from the intended checkout and its validated build artifacts.

## Evidence

Before the repair, a throwaway Swift probe against a copied state directory returned:

```text
primary=false
node=false
```

After the repair, the same copied state returned:

```text
primary=true
node=true
copied_db_and_legacy_identity_bytes_unchanged=true
```

Focused validation:

- `DeviceIdentityStoreTests`: 37 passed
- `src/infra/device-identity.test.ts`: 20 passed
- `CommandResolverTests`: 26 passed
- `MacNodeHostWorkerTests`: 15 passed
- `pnpm lint:swift` under the Xcode toolchain: 0 violations
- core and core-test typechecks: passed
- full core lint matrix: passed
- native state schema version guard: passed at v6
- dependency, plugin-boundary, dead-export, formatting, conflict-marker, and max-lines guards: passed
- `git diff --check origin/main...HEAD`: passed
- Codex autoreview: clean, no accepted/actionable findings

The remote fast-CI backend was unavailable during local preflight, so trusted-source validation followed the documented local fallback. Hosted exact-head CI remains the landing gate.
