### PR TITLE
fix: Telegram Crabbox proof uses resolved SSH target

### DIFF
--- a/scripts/e2e/telegram-user-crabbox-proof.ts
+++ b/scripts/e2e/telegram-user-crabbox-proof.ts
@@ -38,6 +38,7 @@ type CrabboxInspect = {
   host?: string;
   id?: string;
   slug?: string;
+  sshHost?: string;
   sshKey?: string;
   sshPort?: string;
   sshUser?: string;
@@ -2035,7 +2036,8 @@ async function inspectCrabbox(opts: Options, root: string, leaseId: string) {
 }
 
 function sshArgs(inspect: CrabboxInspect) {
-  if (!inspect.host || !inspect.sshKey || !inspect.sshUser) {
+  const sshHost = inspect.sshHost || inspect.host;
+  if (!sshHost || !inspect.sshKey || !inspect.sshUser) {
     throw new Error("Crabbox inspect output is missing SSH details.");
   }
   return {
@@ -2067,7 +2069,7 @@ function sshArgs(inspect: CrabboxInspect) {
       "-o",
       "ConnectTimeout=15",
     ],
-    target: `${inspect.sshUser}@${inspect.host}`,
+    target: `${inspect.sshUser}@${sshHost}`,
   };
 }
 

--- a/test/scripts/telegram-user-crabbox-proof.test.ts
+++ b/test/scripts/telegram-user-crabbox-proof.test.ts
@@ -502,6 +502,7 @@ describe("telegram user Crabbox proof log polling", () => {
         gatewayPort: 19042,
         inspect: {
           host: "proof.example",
+          sshHost: "",
           sshKey: "/tmp/proof-key",
           sshPort: "2222",
           sshUser: "proof",
@@ -519,9 +520,9 @@ describe("telegram user Crabbox proof log polling", () => {
       env,
     });
     expect(allowed.status).toBe(0);
-    expect(JSON.parse(fs.readFileSync(argvPath, "utf8"))).toContain(
-      "'tailscale' 'funnel' '--bg' '--yes' '19042'",
-    );
+    const fallbackArgv = JSON.parse(fs.readFileSync(argvPath, "utf8"));
+    expect(fallbackArgv).toContain("proof@proof.example");
+    expect(fallbackArgv).toContain("'tailscale' 'funnel' '--bg' '--yes' '19042'");
 
     const rejected = spawnSync(proxyPath, ["serve", "--bg", "19042"], {
       encoding: "utf8",
@@ -529,6 +530,44 @@ describe("telegram user Crabbox proof log polling", () => {
     });
     expect(rejected.status).toBe(64);
     expect(rejected.stderr).toContain("unsupported proof Tailscale command");
+  });
+
+  posixIt("prefers the inspect SSH host over the public host", () => {
+    const root = makeTempDir();
+    const sshPath = path.join(root, "ssh");
+    const argvPath = path.join(root, "ssh-argv.json");
+    const proxyPath = path.join(root, "tailscale");
+    writeExecutable(
+      sshPath,
+      `#!/usr/bin/env node\nimport fs from "node:fs";\nfs.writeFileSync(process.env.ARGV_PATH, JSON.stringify(process.argv.slice(2)));\n`,
+    );
+    writeExecutable(
+      proxyPath,
+      renderTailscaleSshProxy({
+        gatewayPort: 19042,
+        inspect: {
+          host: "public.example",
+          sshHost: "ssh.example",
+          sshKey: "/tmp/proof-key",
+          sshPort: "2222",
+          sshUser: "proof",
+        },
+      }),
+    );
+
+    const result = spawnSync(proxyPath, ["status", "--json"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ARGV_PATH: argvPath,
+        PATH: `${root}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    const argv = JSON.parse(fs.readFileSync(argvPath, "utf8"));
+    expect(argv).toContain("proof@ssh.example");
+    expect(argv).not.toContain("proof@public.example");
   });
 
   it("reads only the requested log tail", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Telegram user Crabbox proof could connect to Crabbox's provider/public `host` instead of the resolved SSH endpoint when `inspect --json` returned a distinct `sshHost`.

## Why This Change Was Made

The proof script now follows Crabbox's public `StatusView` contract: it prefers `sshHost` for SSH and SCP targets, while retaining `host` as the fallback when the SSH-specific field is empty or unavailable. The parsing stays owner-local in the proof script and does not import Crabbox plugin internals.

## User Impact

Operators running the Telegram user Crabbox proof now connect through the endpoint Crabbox resolved for SSH, including non-public or routed targets, without breaking older or incomplete inspect payloads that only provide `host`.

AI-assisted: yes.

## Evidence

Upstream contract inspected directly at Crabbox SHA `ce9487f552054326d9209d3ba9606d01a36f5666`:

- `internal/cli/status.go`: `StatusView` publishes separate `host` and `sshHost` fields.
- `internal/cli/inspect.go`: `inspect --json` encodes that `StatusView`.

Focused proof:

- `node scripts/run-vitest.mjs test/scripts/telegram-user-crabbox-proof.test.ts` — 45 tests passed.
- `./node_modules/.bin/oxfmt --check scripts/e2e/telegram-user-crabbox-proof.ts test/scripts/telegram-user-crabbox-proof.test.ts` — passed.
- `git diff --check` — passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- scripts/e2e/telegram-user-crabbox-proof.ts test/scripts/telegram-user-crabbox-proof.test.ts` — all classified scripts, test-root, and tooling checks passed locally. Testbox/managed Crabbox was unavailable before the local fallback, so no remote run summary was produced.
- Codex autoreview (`--mode uncommitted`) — clean; no accepted/actionable findings.
