### PR TITLE
refactor(trajectory): use findLast in export scans

### DIFF
--- a/src/trajectory/export.ts
+++ b/src/trajectory/export.ts
@@ -919,10 +919,7 @@ function redactEventForExport(
 }
 
 function resolveRuntimeContext(runtimeEvents: TrajectoryEvent[]): RuntimeTrajectoryContext {
-  const latestContext = runtimeEvents
-    .slice()
-    .toReversed()
-    .find((event) => event.type === "context.compiled");
+  const latestContext = runtimeEvents.findLast((event) => event.type === "context.compiled");
   const runtimeData = latestContext?.data;
   const toolsValue = Array.isArray(runtimeData?.tools)
     ? (runtimeData.tools as TrajectoryToolDefinition[])
@@ -938,10 +935,7 @@ function resolveLatestRuntimeEventData(
   runtimeEvents: TrajectoryEvent[],
   type: string,
 ): JsonRecord | undefined {
-  const event = runtimeEvents
-    .slice()
-    .toReversed()
-    .find((candidate) => candidate.type === type);
+  const event = runtimeEvents.findLast((candidate) => candidate.type === type);
   return event?.data;
 }
 
@@ -1041,10 +1035,9 @@ function buildMetadataCapture(params: {
     return undefined;
   }
   const modelFallback = (() => {
-    const latest = params.runtimeEvents
-      .slice()
-      .toReversed()
-      .find((event) => event.provider || event.modelId || event.modelApi);
+    const latest = params.runtimeEvents.findLast(
+      (event) => event.provider || event.modelId || event.modelApi,
+    );
     if (!latest?.provider && !latest?.modelId && !latest?.modelApi) {
       return undefined;
     }


### PR DESCRIPTION
## What Problem This Solves

Trajectory export used three reverse-copy scans to select the last matching runtime event. Those scans were correct but allocated reversed array copies solely to perform last-match lookup.

## Why This Change Was Made

Use `Array.prototype.findLast` for the same three last-match queries. The predicates and resulting behavior are unchanged, while the temporary reverse-copy allocations and seven net production lines are removed.

This change is independent of #118685 and does not modify that PR or its branch. No changelog entry is needed for this behavior-neutral refactor.

## User Impact

There is no user-visible behavior change. Trajectory export performs the same last-match selection with simpler code and without allocating reversed copies of the runtime event array.

## Evidence

- `node scripts/run-vitest.mjs src/trajectory/export.test.ts` — 42/42 tests passed on the rebased source diff.
- Changed-surface validation passed: formatting, core and core-test typechecks, targeted core lint, dead-export scan, plugin/API guards, import cycles, and selected core guards. This completed locally after no remote provider was ready.
- `git diff --check` passed before commit on the rebased diff.
- Production LOC: +5/-12 (net -7); tests: +0/-0.
- Codex-backed autoreview on the rebased uncommitted diff exited cleanly with no accepted/actionable findings.
