### PR TITLE
fix(release): dispatch validation through a client-pushed target ref

### DIFF
--- a/scripts/full-release-validation-at-sha.mjs
+++ b/scripts/full-release-validation-at-sha.mjs
@@ -34,11 +34,12 @@ const DEFAULT_INPUTS = {
 function usage() {
   console.error(`Usage: node scripts/full-release-validation-at-sha.mjs [--sha <target-sha>] [--target-ref <canonical-release-branch-or-tag>] [--workflow-sha <trusted-main-ref>] [--keep-branch] [--dry-run] [-- -f key=value ...]
 
-Creates a temporary remote branch pinned to trusted main release tooling,
-dispatches Full Release Validation with the target commit as its ref input,
+Creates temporary remote branches pinned to trusted main release tooling and
+the exact target commit, dispatches Full Release Validation with the target
+branch as its ref input,
 watches the parent run, verifies all child workflow head SHAs match the trusted
-workflow lineage through the release evidence manifest, then deletes the
-temporary branch by default. Exact-target and changelog-only Release SHA
+workflow lineage through the release evidence manifest, then deletes both
+temporary branches by default. --keep-branch retains both branches. Exact-target and changelog-only Release SHA
 evidence reuse stay enabled; pass -f reuse_evidence=false to force a fresh
 run. Child workflows collect independent failures by default; pass
 -f fail_fast=true to cancel each child after its first failed job. The release
@@ -217,6 +218,35 @@ function verifyTargetRef(targetRef, targetSha) {
 function resolveSha(requestedSha) {
   const rev = requestedSha || "HEAD";
   return run("git", ["rev-parse", "--verify", `${rev}^{commit}`], { dryRun: false });
+}
+
+function fetchTargetRef(targetRef) {
+  if (!targetRef) {
+    return;
+  }
+  const sourceRef = RELEASE_BRANCH_PATTERN.test(targetRef)
+    ? `refs/heads/${targetRef}`
+    : `refs/tags/${targetRef}`;
+  run("git", ["fetch", "--no-tags", "origin", sourceRef], {
+    stdio: "inherit",
+  });
+}
+
+function resolveTargetSha(requestedSha, targetRef) {
+  fetchTargetRef(targetRef);
+  const revision = requestedSha || "HEAD";
+  const resolved = runStatus("git", ["rev-parse", "--verify", `${revision}^{commit}`], {
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  const resolvedSha = typeof resolved.stdout === "string" ? resolved.stdout.trim() : "";
+  if (resolved.status !== 0 || !resolvedSha) {
+    throw new Error(
+      targetRef
+        ? `Target SHA ${revision} is not available locally after fetching ${targetRef}`
+        : `Target SHA ${revision} is not available locally; pass --target-ref so it can be fetched by name`,
+    );
+  }
+  return resolvedSha;
 }
 
 export function releaseProfileForTarget(
@@ -408,7 +438,7 @@ function verifyReleaseEvidence(parentRunId, workflowSha) {
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
-  const targetSha = resolveSha(args.sha);
+  const targetSha = resolveTargetSha(args.sha, args.targetRef);
   args.inputs.release_profile ??= releaseProfileForTarget(targetSha);
   args.inputs.allow_unreleased_changelog ??= args.targetRef ? "false" : "true";
   const targetContextRef = verifyTargetRef(args.targetRef, targetSha);
@@ -417,25 +447,32 @@ function main() {
   const shortSha = workflowSha.slice(0, 12);
   const branch = `release-ci/${shortSha}-${Date.now()}`;
   const remoteBranchRef = `refs/heads/${branch}`;
+  const targetBranch = `validation/target-${targetSha.slice(0, 12)}-${Date.now()}`;
+  const remoteTargetBranchRef = `refs/heads/${targetBranch}`;
   const dispatchInputs = {
-    ref: targetSha,
+    ref: targetBranch,
     ...(targetContextRef !== targetSha ? { target_context_ref: targetContextRef } : {}),
     ...args.inputs,
   };
 
   console.log(`Target SHA: ${targetSha}`);
   console.log(`Trusted workflow SHA: ${workflowSha}`);
+  console.log(`Temporary target ref: ${targetBranch}`);
   console.log(`Temporary workflow ref: ${branch}`);
-
-  run("git", ["push", "origin", `${workflowSha}:${remoteBranchRef}`], {
-    dryRun: args.dryRun,
-    stdio: "inherit",
-  });
 
   let parentRunId;
   let parentConclusion = "";
   let evidenceVerified = false;
   try {
+    run("git", ["push", "origin", `${targetSha}:${remoteTargetBranchRef}`], {
+      dryRun: args.dryRun,
+      stdio: "inherit",
+    });
+    run("git", ["push", "origin", `${workflowSha}:${remoteBranchRef}`], {
+      dryRun: args.dryRun,
+      stdio: "inherit",
+    });
+
     const dispatchArgs = ["workflow", "run", WORKFLOW, "--ref", branch];
     for (const [key, value] of Object.entries(dispatchInputs)) {
       dispatchArgs.push("-f", `${key}=${value}`);
@@ -481,15 +518,16 @@ function main() {
         evidenceVerified,
       })
     ) {
-      run("git", ["push", "origin", `:${remoteBranchRef}`], {
+      run("git", ["push", "origin", `:${remoteBranchRef}`, `:${remoteTargetBranchRef}`], {
         dryRun: args.dryRun,
         stdio: "inherit",
       });
     } else {
+      const keptRefs = `${remoteBranchRef} and ${remoteTargetBranchRef}`;
       console.warn(
         args.keepBranch
-          ? `Kept ${remoteBranchRef}`
-          : `Kept ${remoteBranchRef}: ${
+          ? `Kept ${keptRefs}`
+          : `Kept ${keptRefs}: ${
               parentConclusion === "success"
                 ? "release evidence was not verified"
                 : `parent concluded ${parentConclusion || "without a conclusion"}`
@@ -503,7 +541,10 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   try {
     main();
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exit(1);
+    console.error(
+      `[full-release-validation] FAILED: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    console.error("[full-release-validation] FAILED (exit 1)");
+    process.exitCode = 1;
   }
 }

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -1,6 +1,7 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   assertTrustedWorkflowHarness,
@@ -11,6 +12,131 @@ import {
   resolveRemoteTargetRefSha,
   shouldDeleteTemporaryWorkflowRef,
 } from "../../scripts/full-release-validation-at-sha.mjs";
+
+const SCRIPT_PATH = resolve("scripts/full-release-validation-at-sha.mjs");
+
+function runGit(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+}
+
+function createDispatchFixture() {
+  const root = mkdtempSync(join(tmpdir(), "openclaw-release-dispatch-"));
+  const origin = join(root, "origin.git");
+  const checkout = join(root, "checkout");
+  const binDir = join(root, "bin");
+  const gitCallsPath = join(root, "git-calls.jsonl");
+  const ghCallsPath = join(root, "gh-calls.jsonl");
+  const releaseRef = "release/2026.8.1";
+  mkdirSync(checkout);
+  mkdirSync(binDir);
+  writeFileSync(gitCallsPath, "");
+  writeFileSync(ghCallsPath, "");
+
+  execFileSync("git", ["init", "--bare", origin], { stdio: "ignore" });
+  execFileSync("git", ["init", "-b", "main"], { cwd: checkout, stdio: "ignore" });
+  runGit(checkout, ["config", "user.email", "release-test@openclaw.invalid"]);
+  runGit(checkout, ["config", "user.name", "OpenClaw Release Test"]);
+  mkdirSync(join(checkout, ".github", "workflows"), { recursive: true });
+  mkdirSync(join(checkout, "scripts"), { recursive: true });
+  writeFileSync(join(checkout, "package.json"), '{"version":"2026.8.1"}\n');
+  writeFileSync(
+    join(checkout, ".github", "workflows", "full-release-validation.yml"),
+    "name: Full Release Validation\n",
+  );
+  writeFileSync(
+    join(checkout, "scripts", "release-ci-summary.mjs"),
+    'console.log(JSON.stringify({ valid: true, current: { runId: "123" }, root: { runId: "123" }, evidenceReuse: false }));\n',
+  );
+  runGit(checkout, ["add", "."]);
+  runGit(checkout, ["commit", "-m", "test: trusted workflow"]);
+  const workflowSha = runGit(checkout, ["rev-parse", "HEAD"]);
+  runGit(checkout, ["remote", "add", "origin", origin]);
+  runGit(checkout, ["push", "-u", "origin", "main"]);
+  runGit(checkout, ["checkout", "-b", releaseRef]);
+  writeFileSync(join(checkout, "target.txt"), "release target\n");
+  runGit(checkout, ["add", "target.txt"]);
+  runGit(checkout, ["commit", "-m", "test: release target"]);
+  const targetSha = runGit(checkout, ["rev-parse", "HEAD"]);
+  runGit(checkout, ["push", "-u", "origin", releaseRef]);
+  runGit(checkout, ["checkout", "main"]);
+
+  const gitPath = join(binDir, "git");
+  writeFileSync(
+    gitPath,
+    `#!${process.execPath}
+const fs = require("node:fs");
+const { spawnSync } = require("node:child_process");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.MOCK_GIT_CALLS, JSON.stringify(args) + "\\n");
+const result = spawnSync("git", args, {
+  env: { ...process.env, PATH: process.env.MOCK_REAL_PATH },
+  stdio: "inherit",
+});
+process.exit(result.status ?? 1);
+`,
+  );
+  chmodSync(gitPath, 0o755);
+
+  const ghPath = join(binDir, "gh");
+  writeFileSync(
+    ghPath,
+    `#!${process.execPath}
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.MOCK_GH_CALLS, JSON.stringify(args) + "\\n");
+if (args[0] === "workflow" && args[1] === "run") {
+  console.log("https://github.com/openclaw/openclaw/actions/runs/123");
+} else if (args[0] === "api" && args.at(-1).endsWith("/actions/runs/123")) {
+  console.log(JSON.stringify({ status: "completed", conclusion: "success", head_sha: process.env.MOCK_WORKFLOW_SHA }));
+} else {
+  console.error("unexpected gh call: " + args.join(" "));
+  process.exit(2);
+}
+`,
+  );
+  chmodSync(ghPath, 0o755);
+
+  const run = (extraArgs: string[] = []) =>
+    spawnSync(
+      process.execPath,
+      [SCRIPT_PATH, "--sha", targetSha, "--target-ref", releaseRef, ...extraArgs],
+      {
+        cwd: checkout,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          MOCK_GH_CALLS: ghCallsPath,
+          MOCK_GIT_CALLS: gitCallsPath,
+          MOCK_REAL_PATH: process.env.PATH,
+          MOCK_WORKFLOW_SHA: workflowSha,
+          PATH: `${binDir}:${process.env.PATH}`,
+        },
+      },
+    );
+  const readCalls = (path: string): string[][] =>
+    readFileSync(path, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+
+  return {
+    checkout,
+    cleanup: () => rmSync(root, { force: true, recursive: true }),
+    ghCallsPath,
+    gitCallsPath,
+    origin,
+    readCalls,
+    releaseRef,
+    run,
+    targetSha,
+    workflowSha,
+  };
+}
 
 describe("full-release-validation-at-sha", () => {
   it("parses release validation dispatch args", () => {
@@ -66,7 +192,7 @@ describe("full-release-validation-at-sha", () => {
 
   it("keeps release context separate from the exact target SHA", () => {
     const source = readFileSync("scripts/full-release-validation-at-sha.mjs", "utf8");
-    expect(source).toContain("ref: targetSha");
+    expect(source).toContain("ref: targetBranch");
     expect(source).toContain("target_context_ref: targetContextRef");
     expect(source).toContain(
       'args.inputs.allow_unreleased_changelog ??= args.targetRef ? "false" : "true"',
@@ -223,6 +349,130 @@ describe("full-release-validation-at-sha", () => {
         parentConclusion: "success",
       }),
     ).toBe(false);
+  });
+
+  it("pushes an exact target ref, dispatches it, prints the run URL, and cleans both refs", () => {
+    const fixture = createDispatchFixture();
+    try {
+      const result = fixture.run();
+      expect(result.status, result.stderr).toBe(0);
+      const gitCalls = fixture.readCalls(fixture.gitCallsPath);
+      const ghCalls = fixture.readCalls(fixture.ghCallsPath);
+      const targetPush = gitCalls.find(
+        (args) => args[0] === "push" && args[2]?.includes(":refs/heads/validation/target-"),
+      );
+      expect(targetPush?.[2]).toMatch(
+        new RegExp(
+          `^${fixture.targetSha}:refs/heads/validation/target-${fixture.targetSha.slice(0, 12)}-[0-9]+$`,
+          "u",
+        ),
+      );
+      const targetBranch = targetPush?.[2]?.split(":refs/heads/")[1];
+      const workflowPush = gitCalls.find(
+        (args) => args[0] === "push" && args[2]?.includes(":refs/heads/release-ci/"),
+      );
+      const workflowBranch = workflowPush?.[2]?.split(":refs/heads/")[1];
+      expect(workflowPush?.[2]).toMatch(
+        new RegExp(
+          `^${fixture.workflowSha}:refs/heads/release-ci/${fixture.workflowSha.slice(0, 12)}-[0-9]+$`,
+          "u",
+        ),
+      );
+      const dispatch = ghCalls.find((args) => args[0] === "workflow" && args[1] === "run");
+      expect(dispatch).toEqual(
+        expect.arrayContaining([
+          "--ref",
+          workflowBranch,
+          "-f",
+          `ref=${targetBranch}`,
+          "-f",
+          `target_context_ref=${fixture.releaseRef}`,
+        ]),
+      );
+      expect(result.stdout).toContain(
+        "Parent run: https://github.com/openclaw/openclaw/actions/runs/123",
+      );
+      expect(result.stdout.indexOf("Parent run:")).toBeLessThan(
+        result.stdout.indexOf("Parent run status:"),
+      );
+      expect(gitCalls).toContainEqual([
+        "push",
+        "origin",
+        `:refs/heads/${workflowBranch}`,
+        `:refs/heads/${targetBranch}`,
+      ]);
+      expect(runGit(fixture.origin, ["for-each-ref", "--format=%(refname)", "refs/heads"])).toBe(
+        "refs/heads/main\nrefs/heads/release/2026.8.1",
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("keeps both temporary refs with --keep-branch", () => {
+    const fixture = createDispatchFixture();
+    try {
+      const result = fixture.run(["--keep-branch"]);
+      expect(result.status, result.stderr).toBe(0);
+      const gitCalls = fixture.readCalls(fixture.gitCallsPath);
+      expect(
+        gitCalls.some(
+          (args) => args[0] === "push" && args.slice(2).some((value) => value.startsWith(":")),
+        ),
+      ).toBe(false);
+      const remoteRefs = runGit(fixture.origin, [
+        "for-each-ref",
+        "--format=%(refname)",
+        "refs/heads/release-ci",
+        "refs/heads/validation",
+      ]).split("\n");
+      expect(remoteRefs).toHaveLength(2);
+      expect(remoteRefs).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^refs\/heads\/release-ci\//u),
+          expect.stringMatching(/^refs\/heads\/validation\/target-/u),
+        ]),
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("fails clearly before dispatch when the target SHA is absent after the named fetch", () => {
+    const fixture = createDispatchFixture();
+    try {
+      const missingSha = "f".repeat(40);
+      const result = spawnSync(
+        process.execPath,
+        [SCRIPT_PATH, "--sha", missingSha, "--target-ref", fixture.releaseRef],
+        {
+          cwd: fixture.checkout,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            MOCK_GH_CALLS: fixture.ghCallsPath,
+            MOCK_GIT_CALLS: fixture.gitCallsPath,
+            MOCK_REAL_PATH: process.env.PATH,
+            MOCK_WORKFLOW_SHA: fixture.workflowSha,
+            PATH: `${join(fixture.checkout, "..", "bin")}:${process.env.PATH}`,
+          },
+        },
+      );
+      expect(result.status).toBe(1);
+      const failedReasons = result.stderr
+        .trim()
+        .split("\n")
+        .filter((line) => line.startsWith("[full-release-validation] FAILED:"));
+      expect(failedReasons).toEqual([
+        `[full-release-validation] FAILED: Target SHA ${missingSha} is not available locally after fetching ${fixture.releaseRef}`,
+      ]);
+      expect(result.stderr.trim().split("\n").at(-1)).toBe(
+        "[full-release-validation] FAILED (exit 1)",
+      );
+      expect(readFileSync(fixture.ghCallsPath, "utf8")).toBe("");
+    } finally {
+      fixture.cleanup();
+    }
   });
 
   it("supports current and legacy verifier locations in trusted workflow checkouts", () => {


### PR DESCRIPTION
## What Problem This Solves

`scripts/full-release-validation-at-sha.mjs` fails when `--sha` targets a GitHub-API-created squash-merge commit on a release branch: both the script's local git preflight and every `actions/checkout ref=<sha>` in the workflow die with `upload-pack: not our ref <sha>` — persistently, even when the SHA is the advertised branch tip. Client-pushed SHAs fetch fine; API-created squash commits (8ff1724, 0cd3075, 06ceff10) consistently refuse. This silently consumed three dispatch attempts during the 2026.8.1-beta.1 push (runner-side failures: run 31256980937); ref-name dispatch (run 31257301355) went fully green and proved the mechanism.

## Why This Change Was Made

The script now pushes the exact target SHA to a script-owned temporary ref (`validation/target-<sha12>-<ts>`) and dispatches that ref name, preserving the canonical `target_context_ref`. Exact-SHA pinning is kept (the temp ref is immutable and script-owned) and the workflow's seven internal bare-SHA checkouts become safe because the client-pushed ref advertises that exact object for the run's lifetime. Both temporary refs (workflow branch + target ref) share the existing cleanup and `--keep-branch` semantics; refs are retained after failed runs for rerun/diagnosis. Ergonomics hardened per the script-wrapper rule: the parent run URL prints to stdout before any waiting, and every fatal path ends with a single reason-bearing `FAILED (exit 1)` stderr trailer.

Sibling audit: `scripts/release-candidate-checklist.mjs:1566` is a separate bare-SHA dispatcher with the same latent exposure — flagged as follow-up, not changed here.

## User Impact

Release operators can dispatch validation for any candidate SHA — including squash-merged release-branch tips — without silent fetch failures.

## Evidence

- Mocked dispatch-harness tests: 19/19 green covering temp-ref shape/push args, ref-name dispatch args, cleanup + `--keep-branch`, loud-failure trailer, and stdout run URL.
- `pnpm tsgo:core` + `tsgo:core:test`, dead-export scans, script-declaration contracts (254 matched), formatting, `git diff --check`: all green.
- Codex autoreview (`gpt-5.6-sol`, high): clean (0.98).
- Production +56/−15; tests +253/−3. Real-world mechanism proof: green run 31257301355.
