### PR TITLE
fix(deps): register missing ownership metadata

### DIFF
--- a/scripts/lib/dependency-ownership.json
+++ b/scripts/lib/dependency-ownership.json
@@ -83,6 +83,17 @@
       "activation": ["agent.tool.read.image.bmp"],
       "risk": ["wasm", "parser", "untrusted-files"]
     },
+    "@trycua/cua-driver": {
+      "owner": "plugin:cua-computer",
+      "class": "plugin-runtime",
+      "activation": ["plugins.entries.cua-computer.enabled"],
+      "risk": ["native", "computer-control"]
+    },
+    "acorn": {
+      "owner": "core:code-mode-and-release-verification",
+      "class": "core-runtime",
+      "risk": ["parser", "untrusted-javascript"]
+    },
     "chalk": {
       "owner": "core:cli",
       "class": "core-runtime",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the root dependency ownership gate reported `acorn` and `@trycua/cua-driver` as unclassified release dependencies.

## Why This Change Was Made

Adds the two missing canonical ownership records. `acorn` is owned by core code mode and release verification; `@trycua/cua-driver` is owned by the opt-in CUA computer plugin.

## User Impact

No runtime behavior changes. Release and dependency audits can now account for every root dependency without waiving ownership metadata.

## Evidence

- `node scripts/dependency-ownership-surface-report.mjs --check`
- `node scripts/dependency-ownership-surface-report.mjs --json /tmp/dependency-ownership-canonical-report.json`
  - 65 root dependencies
  - 65 ownership records
  - 0 ownership gaps
  - 0 stale records
- `node scripts/root-dependency-ownership-audit.mjs --check`
- `oxfmt` stdin comparison: clean
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings

The report still shows the pre-existing `linkedom` ownership warning; this patch does not alter that separate surface.
