### PR TITLE
feat(ui): show agent runtime distinction in model picker rows

### DIFF
--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5196,6 +5196,40 @@ describe("chat model controls", () => {
     expect(modelOption?.closest("openclaw-tooltip")).toBeNull();
   });
 
+  it("distinguishes model rows that use different agent runtimes", () => {
+    const { state } = createChatHeaderState({
+      model: "gpt-5.6",
+      modelProvider: "openai",
+      models: [
+        {
+          id: "gpt-5.6",
+          name: "GPT-5.6",
+          provider: "openai",
+          contextWindow: 1_000_000,
+          agentRuntime: { id: "openclaw", source: "model" },
+        },
+        {
+          id: "gpt-5.6-sol",
+          name: "GPT-5.6 Sol",
+          provider: "openai",
+          contextWindow: 1_000_000,
+          agentRuntime: { id: "codex", source: "model" },
+        },
+      ],
+    });
+    const container = renderModelControls(state);
+    const openClawMeta = container.querySelector(
+      '[data-chat-model-option="openai/gpt-5.6"] .chat-controls__model-option-meta',
+    );
+    const codexMeta = container.querySelector(
+      '[data-chat-model-option="openai/gpt-5.6-sol"] .chat-controls__model-option-meta',
+    );
+
+    expect(openClawMeta?.textContent).toBe("1M · OpenClaw");
+    expect(openClawMeta?.textContent).not.toContain("Codex");
+    expect(codexMeta?.textContent).toBe("1M · Codex");
+  });
+
   it("marks chat-only models in the active control and picker", () => {
     const { state } = createChatHeaderState({
       model: "qwen3-8b",

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5215,19 +5215,34 @@ describe("chat model controls", () => {
           contextWindow: 1_000_000,
           agentRuntime: { id: "codex", source: "model" },
         },
+        {
+          id: "claude-opus-4-5",
+          name: "Claude Opus 4.5",
+          provider: "anthropic",
+          contextWindow: 200_000,
+          agentRuntime: { id: "claude-cli", source: "model" },
+        },
+        {
+          id: "gemini-3-pro",
+          name: "Gemini 3 Pro",
+          provider: "google",
+          contextWindow: 1_000_000,
+          agentRuntime: { id: "google-gemini-cli", source: "model" },
+        },
       ],
     });
     const container = renderModelControls(state);
-    const openClawMeta = container.querySelector(
-      '[data-chat-model-option="openai/gpt-5.6"] .chat-controls__model-option-meta',
-    );
-    const codexMeta = container.querySelector(
-      '[data-chat-model-option="openai/gpt-5.6-sol"] .chat-controls__model-option-meta',
-    );
+    const metaFor = (value: string) =>
+      container.querySelector(
+        `[data-chat-model-option="${value}"] .chat-controls__model-option-meta`,
+      )?.textContent;
 
-    expect(openClawMeta?.textContent).toBe("1M · OpenClaw");
-    expect(openClawMeta?.textContent).not.toContain("Codex");
-    expect(codexMeta?.textContent).toBe("1M · Codex");
+    expect(metaFor("openai/gpt-5.6")).toBe("1M · OpenClaw");
+    expect(metaFor("openai/gpt-5.6")).not.toContain("Codex");
+    expect(metaFor("openai/gpt-5.6-sol")).toBe("1M · Codex");
+    // Known CLI runtime ids map to their product labels, not capitalized ids.
+    expect(metaFor("anthropic/claude-opus-4-5")).toBe("200k · Claude CLI");
+    expect(metaFor("google/gemini-3-pro")).toBe("1M · Gemini CLI");
   });
 
   it("marks chat-only models in the active control and picker", () => {

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -200,8 +200,10 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     const isDefault =
       defaultSelectable && option.value.trim().toLowerCase() === normalizedDefaultModel;
     const catalogEntry = resolveChatModelCatalogEntry(option.value, props.modelCatalog);
+    const agentRuntimeId = catalogEntry?.agentRuntime?.id.trim();
     return {
       commitValue: isDefault ? "" : option.value,
+      ...(agentRuntimeId ? { agentRuntimeId } : {}),
       ...(catalogEntry?.contextWindow ? { contextWindow: catalogEntry.contextWindow } : {}),
       ...(typeof catalogEntry?.supportsTools === "boolean"
         ? { supportsTools: catalogEntry.supportsTools }

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -17,6 +17,7 @@ export type ChatModelCatalogState = {
 };
 
 export type ChatModelPickerOption = {
+  agentRuntimeId?: string;
   commitValue: string;
   contextWindow?: number;
   isDefault: boolean;
@@ -25,6 +26,19 @@ export type ChatModelPickerOption = {
   supportsTools?: boolean;
   value: string;
 };
+
+const AGENT_RUNTIME_LABELS: Readonly<Record<string, string>> = {
+  codex: "Codex",
+  openclaw: "OpenClaw",
+};
+
+function formatAgentRuntimeLabel(id: string): string {
+  const normalized = id.trim().toLowerCase();
+  return (
+    AGENT_RUNTIME_LABELS[normalized] ??
+    `${normalized.charAt(0).toUpperCase()}${normalized.slice(1)}`
+  );
+}
 
 type ChatModelPickerParams = {
   defaultModelLabel: string;
@@ -470,6 +484,9 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
                                     : "",
                                   entry.supportsTools === false
                                     ? t("chat.modelControls.chatOnly")
+                                    : "",
+                                  entry.agentRuntimeId
+                                    ? formatAgentRuntimeLabel(entry.agentRuntimeId)
                                     : "",
                                 ]
                                   .filter(Boolean)

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -27,8 +27,13 @@ export type ChatModelPickerOption = {
   value: string;
 };
 
+// Known models.list runtime ids; mirrors src/status/agent-runtime-label.ts,
+// which cannot be imported here (it drags terminal sanitizers into the bundle).
 const AGENT_RUNTIME_LABELS: Readonly<Record<string, string>> = {
+  "claude-cli": "Claude CLI",
   codex: "Codex",
+  "codex-cli": "Codex",
+  "google-gemini-cli": "Gemini CLI",
   openclaw: "OpenClaw",
 };
 

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -10,6 +10,7 @@ import type { Locator, Page } from "playwright";
 import type { InlineConfig, Plugin, PreviewServer, ViteDevServer } from "vite";
 import { PROTOCOL_VERSION } from "../../../packages/gateway-protocol/src/version.js";
 import { CONTROL_UI_BOOTSTRAP_CONFIG_PATH } from "../../../src/gateway/control-ui-contract.js";
+import type { ModelCatalogEntry } from "../api/types.ts";
 import type { ControlUiBuildInfo } from "../build-info.ts";
 
 export function controlUiSessionPath(sessionKey: string, basePath = ""): string {
@@ -245,14 +246,7 @@ export type ControlUiMockGatewayScenario = {
   sessionInfo?: Record<string, unknown> | null;
   /** Partition sessions.list fixtures by archived state after applying patches. */
   sessionArchiveFiltering?: boolean;
-  models?: Array<{
-    id: string;
-    name: string;
-    provider: string;
-    available?: boolean;
-    contextWindow?: number;
-    supportsTools?: boolean;
-  }>;
+  models?: ModelCatalogEntry[];
   /** Operator scopes returned by the mocked connect handshake. */
   operatorScopes?: string[];
   sessionKey?: string;


### PR DESCRIPTION
## What Problem This Solves

An operator can configure the same logical model under two different agent runtimes — e.g. `openai/gpt-5.6` pinned to the OpenClaw runtime and `openai/gpt-5.6-sol` pinned to the native Codex runtime. The model picker then shows two visually identical rows ("GPT-5.6 1M" / "GPT-5.6 Sol 1M") with nothing explaining why both exist, which reads as a configuration bug even when the setup is intentional.

## Why This Change Was Made

The gateway already records the fact: `models.list` returns `agentRuntime: {id, source}` per entry (`src/gateway/server-methods/models-list-result.ts`), and the UI catalog type declares the field — the picker just dropped it. Per the "record facts where they happen; read them where they are needed" doctrine, the fix is to render the existing fact, not to infer anything client-side: rows whose catalog entry carries an explicit runtime now append it to the meta line ("1M · OpenClaw" / "1M · Codex"), after the existing context/chat-only meta so no current strings shift. Runtime ids map through a tiny label table (codex → Codex, openclaw → OpenClaw) with a capitalize fallback; entries without an explicit runtime (`auto` resolution) show nothing, unchanged.

The e2e mock-gateway helper's inline `models` type was replaced with the real `ModelCatalogEntry` type so fixtures can carry `agentRuntime` (net −8 lines).

## User Impact

Duplicate-looking rows from multi-runtime configurations are now self-explanatory in the picker. No behavior changes — selection, search, shortcuts, and all existing meta stay as they are.

## Evidence

Screenshot in first comment: the two rows rendering "1M · OpenClaw" vs "1M · Codex" via the mock-gateway harness.

- `chat-view.test.ts` — 230 passed, incl. new regression asserting per-row runtime meta
- `chat-only-model.e2e.test.ts` — passes (meta join order preserved; runtime appends last)
- Autoreview (Codex `gpt-5.6-sol`, high): clean, no actionable findings
- LOC: production +19, tests/helpers +36/−8
