### PR TITLE
fix(release): make tar extraction portable on Windows

### DIFF
--- a/scripts/prepublish-plugin-registry-artifact.mjs
+++ b/scripts/prepublish-plugin-registry-artifact.mjs
@@ -41,7 +41,8 @@ function normalizeRequiredPackages(value) {
 function readTarballPackageJson(tarball) {
   try {
     return JSON.parse(
-      execFileSync("tar", ["-xOf", tarball, "package/package.json"], {
+      execFileSync("tar", ["-xOf", path.basename(tarball), "package/package.json"], {
+        cwd: path.dirname(tarball),
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
       }),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows release validation could not inspect prerelease plugin tarballs when the artifact path was absolute.

## Why This Change Was Made

Runs `tar` from the tarball directory and passes only the archive basename. This avoids Windows drive-letter paths being parsed as remote archive syntax while preserving the absolute tarball path in error diagnostics.

## User Impact

Windows packaged fresh, packaged upgrade, and installer-fresh release checks can validate prerelease plugin companions instead of failing before package acceptance.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/prepublish-plugin-registry-artifact.test.ts` (10 tests passed)
- `pnpm check:script-declarations` (254 contracts matched)
- `pnpm format scripts/prepublish-plugin-registry-artifact.mjs`
- `git diff --check`
- project autoreview: clean, no actionable findings

Targeted script lint preparation also exposed an unrelated existing type error in `packages/terminal-core/src/ansi.ts`; exact-head CI remains the authoritative lint result for this branch.
