### PR TITLE
fix(ci): isolate performance gateway fixture

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -812,6 +812,7 @@ jobs:
           fi
           cat > "$gateway_config" <<EOF
           {
+            "agents": { "defaults": { "heartbeat": { "every": "0m" } } },
             "browser": { "enabled": false },
           ${catalog_refresh_config}
             "update": { "checkOnStart": false },
@@ -825,7 +826,10 @@ jobs:
             },
             "plugins": {
               "enabled": true,
-              "entries": { "browser": { "enabled": false } }
+              "entries": {
+                "browser": { "enabled": false },
+                "memory-core": { "config": { "dreaming": { "enabled": false } } }
+              }
             }
           }
           EOF

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -412,7 +412,14 @@ describe("OpenClaw performance workflow", () => {
     expect(run).toContain(
       'catalog_refresh_config=\'    "models": { "catalogRefresh": { "enabled": false } },\'',
     );
+    expect(run).toContain('"agents": { "defaults": { "heartbeat": { "every": "0m" } } },');
     expect(run).toContain('"update": { "checkOnStart": false },');
+    expect(run).toContain('"browser": { "enabled": false },');
+    expect(run).toContain('"memory-core": { "config": { "dreaming": { "enabled": false } } }');
+    expect(run).toContain('cp "$gateway_config" "$gateway_readiness_config"');
+    expect(run.indexOf('"agents":')).toBeLessThan(
+      run.indexOf('cp "$gateway_config" "$gateway_readiness_config"'),
+    );
   });
 
   it("isolates required publication in a fresh artifact-consuming job", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation problem where the source performance gateway fixture could start background heartbeat and memory dreaming work while measuring CLI startup. That made the fixture non-hermetic and could consume provider/network resources unrelated to the benchmark.

## Why This Change Was Made

The fixture now disables heartbeat cadence and memory-core dreaming in its generated config while keeping plugins enabled and preserving the explicit browser plugin coverage. The readiness client still receives an exact copy of the benchmark config, so both gateway identities run under the same isolated policy.

Root cause: the performance fixture disabled update, model catalog refresh, and browser networking, but inherited newly active background producers from normal product defaults.

Provenance: the fixture originated in `25ca5cc8dfcd`; the missing isolation became observable after dreaming was enabled by default in `28630a9a650` (#114819).

## User Impact

No product runtime behavior changes. Maintainers get more reliable source performance and beta-release validation without unrelated heartbeat or dreaming activity.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/openclaw-performance-workflow.test.ts` (36 passed)
- `node scripts/check-changed.mjs -- .github/workflows/openclaw-performance.yml test/scripts/openclaw-performance-workflow.test.ts` (passed on Blacksmith Testbox)
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings
- Changed-file proof: https://github.com/openclaw/openclaw/actions/runs/31265252489

No changelog entry: this is release-validation fixture isolation with no shipped product behavior change.
