### PR TITLE
fix(agents): preserve terminal context usage provenance

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1814,7 +1814,7 @@ src/agents/embedded-agent-runner/run/session-bootstrap.ts	2
 src/agents/embedded-agent-runner/run/session-prompt-state.ts	1
 src/agents/embedded-agent-runner/run/setup.ts	2
 src/agents/embedded-agent-runner/run/stream-wrapper.ts	1
-src/agents/embedded-agent-runner/run/terminal-preparation.ts	2
+src/agents/embedded-agent-runner/run/terminal-preparation.ts	1
 src/agents/embedded-agent-runner/run/terminal-resolution.ts	1
 src/agents/embedded-agent-runner/run/tool-activity-heartbeat.ts	2
 src/agents/embedded-agent-runner/runs.ts	2

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
@@ -108,6 +108,57 @@ describe("prepareEmbeddedRunTerminal", () => {
       expect(prepared.finalAssistantRawText).toBeUndefined();
     },
   );
+
+  it("keeps legacy CLI aggregates while marking latest context usage unavailable", async () => {
+    const { prepareEmbeddedRunTerminal } = await import("./terminal-preparation.js");
+    const assistant = {
+      ...assistantMessage("stop"),
+      api: "cli",
+      usage: {
+        input: 128_814,
+        output: 3_000,
+        cacheRead: 992_953,
+        totalTokens: 1_124_767,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+    } satisfies AssistantMessage;
+    const aggregate = {
+      input: 128_814,
+      output: 3_000,
+      cacheRead: 992_953,
+      total: 1_124_767,
+    };
+    const usageAccumulator = Object.assign(createUsageAccumulator(), aggregate);
+    const prepared = prepareEmbeddedRunTerminal({
+      runParams: {
+        sessionId: "session-1",
+        runId: "run-1",
+        workspaceDir: "/tmp/openclaw-test",
+        prompt: "hi",
+        trigger: "user",
+        timeoutMs: 60_000,
+      },
+      attempt: attemptResult(),
+      currentAttemptCompletedAssistant: assistant,
+      provider: "openai",
+      model: "gpt-5.4",
+      activeErrorContext: { provider: "openai", model: "gpt-5.4" },
+      authProfileStore: { version: 1, profiles: {} },
+      sessionIdUsed: "session-1",
+      outerContextTokenMeta: {},
+      usageAccumulator,
+      lastRunPromptUsage: { input: 42_000, output: 1_000, total: 43_000 },
+      contextRecoveryState: createEmbeddedRunContextRecoveryState(),
+      resolvedToolResultFormat: "markdown",
+      terminalState: {
+        outcome: { reason: "completed", status: "ok", stopReason: "stop" },
+        signalOwnedInterruption: false,
+      },
+    });
+    expect(prepared.agentMeta.usage).toEqual(aggregate);
+    expect(prepared.agentMeta.lastCallUsage).toEqual({ contextUsage: { state: "unavailable" } });
+    expect(prepared.agentMeta.promptTokens).toBeUndefined();
+  });
 });
 
 describe("prepareEmbeddedRunTerminal run stats", () => {

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
@@ -118,6 +118,7 @@ describe("prepareEmbeddedRunTerminal", () => {
         input: 128_814,
         output: 3_000,
         cacheRead: 992_953,
+        cacheWrite: 0,
         totalTokens: 1_124_767,
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
       },

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
@@ -328,6 +328,66 @@ describe("prepareEmbeddedRunTerminal", () => {
     },
   );
 
+  it("keeps legacy CLI aggregates while marking latest context usage unavailable", async () => {
+    const { prepareEmbeddedRunTerminal } = await import("./terminal-preparation.js");
+    const assistant = {
+      ...assistantMessage("stop"),
+      api: "cli",
+      usage: {
+        input: 128_814,
+        output: 3_000,
+        cacheRead: 992_953,
+        cacheWrite: 0,
+        totalTokens: 1_124_767,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+    } satisfies AssistantMessage;
+    const aggregate = {
+      input: 128_814,
+      output: 3_000,
+      cacheRead: 992_953,
+      total: 1_124_767,
+    };
+    const usageAccumulator = Object.assign(createUsageAccumulator(), aggregate);
+    const prepared = prepareEmbeddedRunTerminal({
+      runParams: {
+        admittedRunContext: createTestAdmittedRunContext("run-cli-usage"),
+        sessionId: "session-cli-usage",
+        runId: "run-cli-usage",
+        workspaceDir: "/tmp/openclaw-test",
+        prompt: "hi",
+        trigger: "user",
+        timeoutMs: 60_000,
+      },
+      attempt: attemptResult({
+        lastAssistant: assistant,
+        currentAttemptAssistant: assistant,
+        currentAttemptCompletedAssistant: assistant,
+      }),
+      currentAttemptCompletedAssistant: assistant,
+      provider: "openai",
+      model: "gpt-5.4",
+      activeErrorContext: { provider: "openai", model: "gpt-5.4" },
+      authProfileStore: { version: 1, profiles: {} },
+      sessionIdUsed: "session-cli-usage",
+      outerContextTokenMeta: {},
+      usageAccumulator,
+      lastRunPromptUsage: { input: 42_000, output: 1_000, total: 43_000 },
+      contextRecoveryState: createEmbeddedRunContextRecoveryState(),
+      resolvedToolResultFormat: "markdown",
+      terminalState: {
+        outcome: { reason: "completed", status: "ok", stopReason: "stop" },
+        signalOwnedInterruption: false,
+      },
+    });
+
+    expect(prepared.agentMeta.usage).toEqual(aggregate);
+    expect(prepared.agentMeta.lastCallUsage).toEqual({
+      contextUsage: { state: "unavailable" },
+    });
+    expect(prepared.agentMeta.promptTokens).toBeUndefined();
+  });
+
   it("projects a Code Mode cron tool failure into terminal metadata", async () => {
     const { prepareEmbeddedRunTerminal } = await import("./terminal-preparation.js");
     const assistant = assistantMessage("stop");

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -4,13 +4,14 @@ import { estimateUsageCost, resolveModelCostConfig } from "../../../utils/usage-
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
 import type { AgentRunTerminalReceipt } from "../../agent-run-terminal-receipt.js";
 import type { AuthProfileStore } from "../../auth-profiles.js";
-import type { NormalizedUsage, UsageLike } from "../../usage.js";
+import type { NormalizedUsage } from "../../usage.js";
 import { resolveEmbeddedRunFailureSignal } from "../failure-signal.js";
 import type { EmbeddedAgentMeta, EmbeddedAgentRunResult } from "../types.js";
 import type { UsageAccumulator } from "../usage-accumulator.js";
 import type { EmbeddedRunContextRecoveryState } from "./context-recovery-state.js";
 import {
   buildUsageAgentMetaFields,
+  normalizeAssistantUsageForContext,
   resolveFinalAssistantRawText,
   resolveFinalAssistantVisibleText,
   resolveReportedModelRef,
@@ -70,7 +71,7 @@ export function prepareEmbeddedRunTerminal(input: {
   const terminalAssistant = input.currentAttemptCompletedAssistant;
   const usageMeta = buildUsageAgentMetaFields({
     usageAccumulator: input.usageAccumulator,
-    latestUsage: terminalAssistant?.usage as UsageLike | undefined,
+    latestUsage: normalizeAssistantUsageForContext(terminalAssistant),
     lastRunPromptUsage: input.lastRunPromptUsage,
   });
   const resolvedModelRef = resolveReportedModelRef({

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -6,7 +6,7 @@ import type { AgentRunTerminalReceipt } from "../../agent-run-terminal-receipt.j
 import type { AuthProfileStore } from "../../auth-profiles.js";
 import type { PreparedProviderFailoverOwner } from "../../failover/provider-patterns.js";
 import { getCoreTtsAttemptResultMediaUrls } from "../../tools/tts-tool-result-provenance.js";
-import type { NormalizedUsage, UsageLike } from "../../usage.js";
+import type { NormalizedUsage } from "../../usage.js";
 import { hasMessagingToolDeliveryEvidence } from "../delivery-evidence.js";
 import { resolveEmbeddedRunFailureSignal } from "../failure-signal.js";
 import { resolveEmbeddedRunTerminalToolFailure } from "../terminal-tool-failure.js";
@@ -16,6 +16,7 @@ import type { EmbeddedRunAttemptWithReceiptEvidence } from "./attempt-result.js"
 import type { EmbeddedRunContextRecoveryState } from "./context-recovery-state.js";
 import {
   buildUsageAgentMetaFields,
+  normalizeAssistantUsageForContext,
   resolveFinalAssistantRawText,
   resolveFinalAssistantVisibleText,
   resolveReportedModelRef,
@@ -78,7 +79,7 @@ export function prepareEmbeddedRunTerminal(input: {
   const terminalAssistant = input.currentAttemptCompletedAssistant;
   const usageMeta = buildUsageAgentMetaFields({
     usageAccumulator: input.usageAccumulator,
-    latestUsage: terminalAssistant?.usage as UsageLike | undefined,
+    latestUsage: normalizeAssistantUsageForContext(terminalAssistant),
     lastRunPromptUsage: input.lastRunPromptUsage,
   });
   // A runtime can observe its model without emitting message_end. That scoped


### PR DESCRIPTION
Related: #120536

Replaces the conflicting generated candidate #120550 with the current-main owner repair. Thanks @Yuxin-Qiao for reporting the regression and providing the source reproduction.

## What Problem This Solves

A completed legacy CLI assistant could expose cumulative billing usage as if it were trustworthy latest-context usage. That could revive stale numeric context metadata even though the latest assistant did not provide context provenance.

## Fix

Terminal metadata production now routes the completed assistant through the existing context-usage normalizer. Aggregate run usage remains separately available in `agentMeta.usage`; `lastCallUsage` records the unavailable-context sentinel and `promptTokens` remains unset.

The assertion-safety baseline is reduced from 2 to 1 for `terminal-preparation.ts`, exactly recording removal of the obsolete raw usage cast.

## User Impact

Legacy CLI runs retain aggregate token and billing totals without presenting those totals as active context usage.

## Evidence

- Published head: `4a845b38ce09dcd79afb15fbf88ac1112fbbdaf5`
- Validated rebase parent: `245c5bac43653208bde0991496638b9048b147b1`
- Publication-time current main: `245c5bac43653208bde0991496638b9048b147b1`
- Current merge base: `245c5bac43653208bde0991496638b9048b147b1`
- Clean synthetic merge tree against publication-time main: `2048fb797cd2b763a3a533e41df339c68d2d0320`
- Production LOC: `+3/-2` (net `+1`)
- Regression tests: `+60/-0`
- Assertion baseline: `+1/-1`, shrink-only `2 -> 1`

### Regression and validation

- Pre-fix regression failed because terminal metadata received raw cumulative CLI usage instead of `{ contextUsage: { state: "unavailable" } }`.
- Focused current-main matrix: 449 tests passed. This includes the verifier-requested 387-test coverage and 62 additional parameterized CLI/session cases now present on current main.
- `tsgo:core`: passed.
- `tsgo:core:test`: passed.
- Assertion-safety ratchet: passed, 12,401 grandfathered assertions.
- Targeted `oxfmt`, type-aware `oxlint`, and `git diff --check`: passed.
- Independent code review: no actionable P0-P2 findings; patch judged correct.
- ClawSweeper's PR-metadata finding was addressed by changing the broader issue reference from closing to non-closing.

### Owner and sibling coverage

- Terminal metadata production and regression: `src/agents/embedded-agent-runner/run/terminal-preparation.ts`, `src/agents/embedded-agent-runner/run/terminal-preparation.test.ts`
- Retry normalization: `src/agents/embedded-agent-runner/run.attempt-normalization.direct.test.ts`
- Shared metadata helpers: `src/agents/embedded-agent-runner/run/helpers.test.ts`
- Settled terminal finalization: `src/agents/embedded-agent-runner/run/settled-turn-finalization*.test.ts`
- Session persistence: `src/agents/command/session-store.test.ts`
- CLI attempt execution: `src/agents/command/attempt-execution.cli.test.ts`
- Usage derivation and status display: `src/agents/usage.test.ts`, `src/auto-reply/reply/commands-status.test.ts`

### Codex dependency contract

Directly inspected `openai/codex` at exact SHA `3c837e568c24e4281bba4abdf3bc3c398f3fff13`:

- `codex-rs/protocol/src/protocol.rs:2251-2288` keeps cumulative `total_token_usage` separate from `last_token_usage`.
- `codex-rs/core/src/context_manager/history.rs:586-617` derives active context from latest-response usage plus local tail items, not cumulative billing totals.
- `codex-rs/exec/src/event_processor_with_jsonl_output.rs:117-127,502-527` exposes cumulative totals in legacy exec completion output.

This contract requires preserving aggregate reporting while marking legacy CLI latest-context provenance unavailable.

### Conflict resolution

Both historical PR conflicts were resolved by reconstructing the owner fix on current main, retaining current terminal timeout, delivery, settled-finalization, and session behavior. The final rebase was conflict-free; the synthetic merge against publication-time main is also clean.

Co-authored-by: clawsweeper <274271284+clawsweeper[bot]@users.noreply.github.com>
