### PR TITLE
fix: cron updates recover Gemini dotted payload fields

### DIFF
--- a/src/agents/tools/cron-tool-canonicalize.ts
+++ b/src/agents/tools/cron-tool-canonicalize.ts
@@ -66,6 +66,8 @@ const CRON_RECOVERABLE_OBJECT_KEYS: ReadonlySet<string> = new Set([
   ...CRON_FLAT_PAYLOAD_KEYS,
   ...CRON_FLAT_SCHEDULE_KEYS,
 ]);
+const UNSAFE_NESTED_KEYS: ReadonlySet<string> = new Set(["__proto__", "constructor", "prototype"]);
+type CronDottedWrapper = "job" | "patch";
 
 function isCronScheduleKind(value: unknown): value is (typeof CRON_SCHEDULE_KINDS)[number] {
   return isStringOption(value, CRON_SCHEDULE_KINDS);
@@ -122,6 +124,71 @@ function repairConcatenatedCronToolKeys(value: Record<string, unknown>): void {
   delete value.namePayload;
   delete value.scheduleKind;
   delete value.sessionTargetName;
+}
+
+function recoverDottedCronField(
+  value: Record<string, unknown>,
+  rawKey: string,
+  rawValue: unknown,
+  wrapper: CronDottedWrapper,
+  requireWrapper: boolean,
+): boolean {
+  const key =
+    rawKey.length >= 2 &&
+    ((rawKey.startsWith('"') && rawKey.endsWith('"')) ||
+      (rawKey.startsWith("'") && rawKey.endsWith("'")))
+      ? rawKey.slice(1, -1)
+      : rawKey;
+  const path = key.split(".");
+  if (path[0] === "args") {
+    path.shift();
+  }
+  let foundWrapper = false;
+  if (path[0] === "job" || path[0] === "patch") {
+    if (path[0] !== wrapper) {
+      return false;
+    }
+    path.shift();
+    foundWrapper = true;
+  }
+  if (requireWrapper && !foundWrapper) {
+    return false;
+  }
+  const root = path[0];
+  if (
+    !root ||
+    !CRON_RECOVERABLE_OBJECT_KEYS.has(root) ||
+    path.some((segment) => !segment || UNSAFE_NESTED_KEYS.has(segment))
+  ) {
+    return false;
+  }
+
+  let target = value;
+  for (const segment of path.slice(0, -1)) {
+    const existing = target[segment];
+    if (existing !== undefined && !isRecord(existing)) {
+      return false;
+    }
+    const nested = isRecord(existing) ? existing : {};
+    target[segment] = nested;
+    target = nested;
+  }
+  const leaf = path.at(-1);
+  if (!leaf || target[leaf] !== undefined) {
+    return false;
+  }
+  target[leaf] = rawValue;
+  return true;
+}
+
+function cronRecoveryPathDepth(rawKey: string): number {
+  const key =
+    rawKey.length >= 2 &&
+    ((rawKey.startsWith('"') && rawKey.endsWith('"')) ||
+      (rawKey.startsWith("'") && rawKey.endsWith("'")))
+      ? rawKey.slice(1, -1)
+      : rawKey;
+  return key.split(".").length;
 }
 
 function setScheduleAtMs(schedule: Record<string, unknown>, value: unknown): void {
@@ -335,16 +402,61 @@ export function isEmptyRecoveredCronPatch(value: unknown): boolean {
 export function recoverCronObjectFromFlatParams(params: Record<string, unknown>): {
   found: boolean;
   value: Record<string, unknown>;
+};
+export function recoverCronObjectFromFlatParams(
+  params: Record<string, unknown>,
+  wrapper: CronDottedWrapper,
+  includeUnwrapped?: boolean,
+): {
+  found: boolean;
+  value: Record<string, unknown>;
+};
+export function recoverCronObjectFromFlatParams(
+  params: Record<string, unknown>,
+  wrapper: CronDottedWrapper = "job",
+  includeUnwrapped = true,
+): {
+  found: boolean;
+  value: Record<string, unknown>;
 } {
   const value: Record<string, unknown> = {};
   let found = false;
-  for (const key of Object.keys(params)) {
-    if (CRON_RECOVERABLE_OBJECT_KEYS.has(key) && params[key] !== undefined) {
+  const keys = Object.keys(params).toSorted(
+    (left, right) => cronRecoveryPathDepth(left) - cronRecoveryPathDepth(right),
+  );
+  for (const key of keys) {
+    if (includeUnwrapped && CRON_RECOVERABLE_OBJECT_KEYS.has(key) && params[key] !== undefined) {
       value[key] = params[key];
+      found = true;
+    } else if (
+      params[key] !== undefined &&
+      recoverDottedCronField(value, key, params[key], wrapper, !includeUnwrapped)
+    ) {
       found = true;
     }
   }
   return { found, value: canonicalizeCronToolObject(value) };
+}
+
+/** Merges recovered model fields under explicit structured input, which remains authoritative. */
+export function mergeRecoveredCronObject(
+  recovered: Record<string, unknown>,
+  explicit: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged = { ...recovered };
+  for (const [key, explicitValue] of Object.entries(explicit)) {
+    const recoveredValue = merged[key];
+    const value =
+      isRecord(recoveredValue) && isRecord(explicitValue)
+        ? mergeRecoveredCronObject(recoveredValue, explicitValue)
+        : explicitValue;
+    if (UNSAFE_NESTED_KEYS.has(key)) {
+      Object.defineProperty(merged, key, { configurable: true, enumerable: true, value });
+    } else {
+      merged[key] = value;
+    }
+  }
+  return merged;
 }
 
 /** Checks whether a recovered flat object has enough schedule/payload signal to create a job. */

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -2721,6 +2721,231 @@ describe("cron tool", () => {
     });
   });
 
+  it("recovers dotted cron update keys from model tool-call parsers", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createTestCronTool();
+    await tool.execute("call-update-dotted", {
+      action: "update",
+      jobId: "job-dotted",
+      "args.patch.payload.kind": "agentTurn",
+      "args.patch.payload.message": "Updated prompt.",
+      "args.patch.payload.timeoutSeconds": 300,
+      "args.patch.enabled": false,
+      "patch.deleteAfterRun": true,
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.update") as
+      | {
+          id?: string;
+          patch?: {
+            payload?: { kind?: string; message?: string; timeoutSeconds?: number };
+            enabled?: boolean;
+            deleteAfterRun?: boolean;
+          };
+        }
+      | undefined;
+    expect(params?.id).toBe("job-dotted");
+    expect(params?.patch).toEqual({
+      payload: { kind: "agentTurn", message: "Updated prompt.", timeoutSeconds: 300 },
+      enabled: false,
+      deleteAfterRun: true,
+    });
+  });
+
+  it("merges dotted cron update keys under explicit structured patch values", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createTestCronTool();
+    await tool.execute("call-update-dotted-mixed", {
+      action: "update",
+      jobId: "job-dotted-mixed",
+      patch: { enabled: true, payload: { kind: "agentTurn" } },
+      agentId: "unrelated-agent-filter",
+      sessionKey: "unrelated-wake-target",
+      text: "unrelated wake text",
+      "patch.enabled": false,
+      "patch.payload.kind": "script",
+      "patch.payload.message": "Updated prompt.",
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.update") as
+      | {
+          id?: string;
+          patch?: { enabled?: boolean; payload?: { kind?: string; message?: string } };
+        }
+      | undefined;
+    expect(params?.id).toBe("job-dotted-mixed");
+    expect(params?.patch).toEqual({
+      enabled: true,
+      payload: { kind: "agentTurn", message: "Updated prompt." },
+    });
+  });
+
+  it("keeps empty explicit patches isolated from unrelated action fields", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createTestCronTool();
+    await tool.execute("call-update-dotted-empty-explicit", {
+      action: "update",
+      jobId: "job-dotted-empty-explicit",
+      patch: {},
+      agentId: "unrelated-agent-filter",
+      sessionKey: "unrelated-wake-target",
+      text: "unrelated wake text",
+      "patch.payload.kind": "agentTurn",
+      "patch.payload.message": "Updated prompt.",
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.update") as
+      | {
+          patch?: {
+            agentId?: string;
+            payload?: { kind?: string; message?: string; text?: string };
+          };
+        }
+      | undefined;
+    expect(params?.patch).toEqual({
+      payload: { kind: "agentTurn", message: "Updated prompt." },
+    });
+  });
+
+  it.each([
+    {
+      name: "cron",
+      explicit: { kind: "cron", cron: "0 9 * * *" },
+      dotted: { "patch.schedule.expr": "0 8 * * *" },
+      expected: { kind: "cron", expr: "0 9 * * *" },
+    },
+    {
+      name: "every",
+      explicit: { kind: "every", every: 300_000 },
+      dotted: { "patch.schedule.everyMs": 60_000 },
+      expected: { kind: "every", everyMs: 300_000 },
+    },
+    {
+      name: "stagger",
+      explicit: { kind: "cron", cron: "0 9 * * *", stagger: 30_000 },
+      dotted: { "patch.schedule.staggerMs": 1_000 },
+      expected: { kind: "cron", expr: "0 9 * * *", staggerMs: 30_000 },
+    },
+  ])("prefers explicit $name schedule alias over recovered canonical fields", async (testCase) => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createTestCronTool();
+    await tool.execute("call-update-dotted-explicit-aliases", {
+      action: "update",
+      jobId: "job-dotted-explicit-aliases",
+      patch: { schedule: testCase.explicit },
+      ...testCase.dotted,
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.update") as
+      | {
+          patch?: { schedule?: Record<string, unknown> };
+        }
+      | undefined;
+    expect(params?.patch?.schedule).toEqual(testCase.expected);
+  });
+
+  it("recovers job wrappers but not patch wrappers when adding cron jobs", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createTestCronTool();
+    await tool.execute("call-add-dotted-wrapper", {
+      action: "add",
+      "args.job.name": "wrapped job",
+      "job.schedule.kind": "every",
+      "job.schedule.everyMs": 60_000,
+      "job.payload.kind": "agentTurn",
+      "job.payload.message": "run wrapped job",
+      "patch.enabled": false,
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.add") as
+      | { name?: string; enabled?: boolean; payload?: { message?: string } }
+      | undefined;
+    expect(params).toMatchObject({
+      name: "wrapped job",
+      payload: { message: "run wrapped job" },
+    });
+    expect(params?.enabled).toBe(true);
+  });
+
+  it("recovers quoted dotted cron keys emitted by Gemini", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createTestCronTool();
+    await tool.execute("call-update-dotted-quoted", {
+      action: "update",
+      jobId: "job-dotted-quoted",
+      '"patch.payload.kind"': "agentTurn",
+      '"patch.payload.message"': "Updated prompt.",
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.update") as
+      | { id?: string; patch?: { payload?: { kind?: string; message?: string } } }
+      | undefined;
+    expect(params).toMatchObject({
+      id: "job-dotted-quoted",
+      patch: { payload: { kind: "agentTurn", message: "Updated prompt." } },
+    });
+  });
+
+  it.each([
+    ["parent-first", ["patch.payload", "patch.payload.message"]],
+    ["child-first", ["patch.payload.message", "patch.payload"]],
+  ])("resolves dotted parent-child conflicts consistently (%s)", async (_name, keys) => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+    const dottedValues: Record<string, unknown> = {
+      "patch.payload": { kind: "agentTurn", message: "parent" },
+      "patch.payload.message": "child",
+    };
+    const dottedParams = Object.fromEntries(keys.map((key) => [key, dottedValues[key]]));
+
+    const tool = createTestCronTool();
+    await tool.execute("call-update-dotted-conflict", {
+      action: "update",
+      jobId: "job-dotted-conflict",
+      ...dottedParams,
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.update") as
+      | { patch?: { payload?: { kind?: string; message?: string } } }
+      | undefined;
+    expect(params?.patch?.payload).toEqual({ kind: "agentTurn", message: "parent" });
+  });
+
+  it("does not recover job wrappers or unsafe dotted paths into cron updates", async () => {
+    const tool = createTestCronTool();
+    await expect(
+      tool.execute("call-update-dotted-unsafe", {
+        action: "update",
+        jobId: "job-dotted-unsafe",
+        "job.payload.message": "wrong action wrapper",
+        "patch.payload.__proto__.polluted": true,
+      }),
+    ).rejects.toThrow("patch required");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("does not mutate prototypes while merging explicit cron patch JSON", async () => {
+    const tool = createTestCronTool();
+    const patch = JSON.parse('{"payload":{"kind":"agentTurn"},"__proto__":{"polluted":true}}');
+    await tool.execute("call-update-explicit-unsafe", {
+      action: "update",
+      jobId: "job-explicit-unsafe",
+      patch,
+      "patch.payload.message": "Updated prompt.",
+    });
+    const params = expectSingleGatewayCallMethod("cron.update") as
+      | { patch?: Record<string, unknown> }
+      | undefined;
+    expect(Object.hasOwn(params?.patch ?? {}, "__proto__")).toBe(true);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
   it("uses flat string scheduleKind without leaking it to cron update", async () => {
     callGatewayMock.mockResolvedValueOnce({ ok: true });
 

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -32,6 +32,7 @@ import {
   canonicalizeCronToolObject,
   hasCronCreateSignal,
   isEmptyRecoveredCronPatch,
+  mergeRecoveredCronObject,
   recoverCronObjectFromFlatParams,
 } from "./cron-tool-canonicalize.js";
 import {
@@ -427,7 +428,7 @@ Job wakeMode (main jobs): "now"(default)|"next-heartbeat". Restricted automation
             // a synthetic job object from any recognised top-level job fields.
             // See: https://github.com/openclaw/openclaw/issues/11310
             if (isMissingOrEmptyObject(params.job)) {
-              const synthetic = recoverCronObjectFromFlatParams(params);
+              const synthetic = recoverCronObjectFromFlatParams(params, "job");
               // Only use the synthetic job if at least one meaningful field is present
               // (schedule, payload, message, or text are the minimum signals that the
               // LLM intended to create a job).
@@ -569,14 +570,19 @@ Job wakeMode (main jobs): "now"(default)|"next-heartbeat". Restricted automation
               throw new Error("jobId required (id accepted for backward compatibility)");
             }
 
-            // Flat-params recovery for patch
+            // Recover flat/dotted patch fields even when the model also emitted a partial
+            // structured patch. Explicit structured values remain authoritative.
             let recoveredFlatPatch = false;
-            if (isMissingOrEmptyObject(params.patch)) {
-              const synthetic = recoverCronObjectFromFlatParams(params);
-              if (synthetic.found) {
-                params.patch = synthetic.value;
-                recoveredFlatPatch = true;
-              }
+            const explicitPatch = isRecord(params.patch)
+              ? canonicalizeCronToolObject(params.patch)
+              : undefined;
+            const hasExplicitPatch = explicitPatch !== undefined;
+            const synthetic = recoverCronObjectFromFlatParams(params, "patch", !hasExplicitPatch);
+            if (synthetic.found) {
+              params.patch = explicitPatch
+                ? mergeRecoveredCronObject(synthetic.value, explicitPatch)
+                : synthetic.value;
+              recoveredFlatPatch = true;
             }
 
             if (!params.patch || typeof params.patch !== "object") {


### PR DESCRIPTION
Closes #120616

## What Problem This Solves

Fixes an issue where users updating cron jobs through Gemini models could enter repeated failing tool-call loops when the provider emitted nested update fields as dotted or quoted-dotted parameter names instead of a structured `patch` object.

## Why This Change Was Made

Cron add/update inputs now recover an allowlisted set of flat, dotted, wrapped, and quoted-dotted job fields before normal validation. Recovery is action-aware, deterministic for parent/child conflicts, rejects unsafe path segments, and preserves explicit structured values (including shorthand aliases) as authoritative.

## User Impact

Gemini-backed agents can update cron schedule, payload, delivery, and related fields when provider serialization flattens the tool arguments. Unrelated arguments for other cron actions remain isolated, and malformed recovery cannot mutate object prototypes.

## Evidence

- Reproduced the original `patch required` failure with a disabled disposable cron using `github-copilot/gemini-3.1-pro-preview`.
- After the fix, the same model updated the disposable job payload from `before` to `after` in one tool call; the persisted cron state was verified and the disposable job was removed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-tools.config.ts src/agents/tools/cron-tool.test.ts src/agents/tools/cron-tool.flat-params.test.ts`
- Result: 2 test files passed, 210 tests passed.
- `git diff --check upstream/main` passed; editor diagnostics are clean.

## AI Assistance

This change was developed with GitHub Copilot assistance. The implementation, tests, live reproduction, persisted side effects, and final diff were reviewed and validated by the contributor.
