### PR TITLE
fix: keep open dashboards current after session changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI dashboard index refresh:** keep an open Dashboards page current after session changes, agent-scope updates, and Gateway reconnects while preserving the last safe list until replacement hydration completes. Fixes #120602. Thanks @shakkernerd.
 - **Browser extension relay security:** require canonical 64-character relay secrets and safe WebSocket pairing URLs, and recheck OpenClaw tab-group consent at the extension edge before every authority-bearing existing-tab command.
 - **Control UI debug diagnostics:** keep last-good status, health, model, and heartbeat snapshots visible when refreshes fail, show the failure inside Snapshots, isolate it from Manual RPC state, and prevent older manual calls from overwriting newer ones. Thanks @shakkernerd.
 - **Control UI read-only preferences:** keep personal preference edits browser-local without attempting unauthorized config writes or claiming server sync, preserve offline intent for a later authorized reconnect, and restore the current server value on local reset. Thanks @shakkernerd.

--- a/docs/web/dashboards.md
+++ b/docs/web/dashboards.md
@@ -21,7 +21,9 @@ core feature, owned by the thread, stored with the agent, and they survive
 
 Open `/dashboards` to see every thread whose preferred face is Dashboard, with
 the most recently updated thread first. Open any row to go directly to that
-thread's `/dashboard/<agent>/<sessionRef>` URL.
+thread's `/dashboard/<agent>/<sessionRef>` URL. An open Dashboards page updates
+as threads are renamed, archived, deleted, or switched between Chat and
+Dashboard, including after a Gateway reconnect.
 
 The Chat or Dashboard face preference is stored server-side per thread. It
 therefore follows you when you connect to the same gateway from another device.

--- a/ui/src/lib/sessions/index-list.test.ts
+++ b/ui/src/lib/sessions/index-list.test.ts
@@ -90,6 +90,20 @@ describe("session list requests", () => {
     sessions.dispose();
   });
 
+  it("discards a list rejection from a retired same-client connection", async () => {
+    let rejectStale!: (error: Error) => void;
+    const staleRequest = new Promise<SessionsListResult>((_resolve, reject) => {
+      rejectStale = reject;
+    });
+    const request = vi.fn(async () => staleRequest);
+    const { sessions, reconnect } = sessionHarness(request);
+    const retiredRequest = sessions.list({ boardFace: "dashboard" });
+    reconnect();
+    rejectStale(new Error("retired connection"));
+    await expect(retiredRequest).resolves.toBeNull();
+    sessions.dispose();
+  });
+
   it("keeps filtered pages scoped without replacing the canonical active roster", async () => {
     const request = vi.fn(async (_method: string, params?: ListParams) => {
       const filter = params?.archived === true ? "archived" : params?.archived || "active";

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -181,8 +181,15 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     if (!scope) {
       return null;
     }
-    const result = await requestSessionList(scope.client, options);
-    return host.connection.isCurrent(scope) ? host.decorate(result ?? null) : null;
+    try {
+      const result = await requestSessionList(scope.client, options);
+      return host.connection.isCurrent(scope) ? host.decorate(result ?? null) : null;
+    } catch (error) {
+      if (!host.connection.isCurrent(scope)) {
+        return null;
+      }
+      throw error;
+    }
   };
 
   const load = async (options: SessionRefreshOptions) => {

--- a/ui/src/pages/dashboards/dashboards-page.test.ts
+++ b/ui/src/pages/dashboards/dashboards-page.test.ts
@@ -1,0 +1,139 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import { i18n } from "../../i18n/index.ts";
+import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
+import { page as dashboardsRoute } from "./route.ts";
+import type { DashboardsRouteData } from "./view.ts";
+import "./dashboards-page.ts";
+
+type DashboardsPageElement = HTMLElement & {
+  routeData?: DashboardsRouteData;
+  updateComplete: Promise<boolean>;
+};
+
+async function loadDashboards(
+  context: ApplicationContext,
+  options: Parameters<NonNullable<typeof dashboardsRoute.loader>>[1],
+): Promise<DashboardsRouteData> {
+  return (await Promise.resolve(dashboardsRoute.loader!(context, options))) as DashboardsRouteData;
+}
+
+function result(sessionRow: GatewaySessionRow): SessionsListResult {
+  return {
+    ts: 1,
+    path: "(multiple)",
+    count: 1,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions: [sessionRow],
+  };
+}
+
+function row(key: string, displayName: string): GatewaySessionRow {
+  return {
+    key,
+    kind: "direct",
+    boardFace: "dashboard",
+    displayName,
+    updatedAt: 1,
+  };
+}
+
+describe("DashboardsPage", () => {
+  beforeEach(async () => {
+    await i18n.setLocale("en");
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it("reloads rendered rows once per canonical revision or agent scope change", async () => {
+    const sessionListeners = new Set<() => void>();
+    const selectionListeners = new Set<() => void>();
+    let canonicalListRevision = 1;
+    const selectionState = { selectedId: "main", scopeId: null as string | null };
+    let element: DashboardsPageElement;
+    const list = vi
+      .fn<() => Promise<SessionsListResult | null>>()
+      .mockResolvedValueOnce(result(row("agent:main:before", "Before")))
+      .mockResolvedValueOnce(result(row("agent:main:after", "After")))
+      .mockResolvedValueOnce(result(row("agent:writer:scoped", "Writer dashboard")));
+    const context = {
+      basePath: "",
+      gateway: { snapshot: { client: {}, phase: "connected", hello: null } },
+      sessions: {
+        get canonicalListRevision() {
+          return canonicalListRevision;
+        },
+        list,
+        subscribe(listener: () => void) {
+          sessionListeners.add(listener);
+          return () => sessionListeners.delete(listener);
+        },
+      },
+      agentSelection: {
+        state: selectionState,
+        subscribe(listener: () => void) {
+          selectionListeners.add(listener);
+          return () => selectionListeners.delete(listener);
+        },
+      },
+      agents: { state: { agentsList: null } },
+      revalidate: vi.fn(async () => {
+        element.routeData = await loadDashboards(context, {
+          ...loaderOptions,
+          revalidating: true,
+          cause: "revalidate",
+        });
+        await element.updateComplete;
+      }),
+    } as unknown as ApplicationContext;
+    if (!dashboardsRoute.loader) {
+      throw new Error("dashboards route has no loader");
+    }
+    const loaderOptions = {
+      signal: new AbortController().signal,
+      shouldRun: () => true,
+      revalidating: false,
+      location: { pathname: "/dashboards", search: "", hash: "" },
+      deps: "",
+      cause: "navigation" as const,
+    };
+    element = document.createElement("openclaw-dashboards-page") as DashboardsPageElement;
+    element.routeData = await loadDashboards(context, loaderOptions);
+    const provider = createApplicationContextProvider(context);
+    provider.append(element);
+    document.body.append(provider);
+    await element.updateComplete;
+
+    expect(list).toHaveBeenCalledTimes(1);
+    expect(context.revalidate).not.toHaveBeenCalled();
+    expect(element.textContent).toContain("Before");
+
+    canonicalListRevision += 1;
+    sessionListeners.forEach((listener) => listener());
+    await vi.waitFor(() => expect(element.textContent).toContain("After"));
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(context.revalidate).toHaveBeenCalledTimes(1);
+
+    sessionListeners.forEach((listener) => listener());
+    await Promise.resolve();
+    expect(context.revalidate).toHaveBeenCalledTimes(1);
+
+    selectionState.scopeId = "writer";
+    selectionListeners.forEach((listener) => listener());
+    await vi.waitFor(() => expect(element.textContent).toContain("Writer dashboard"));
+    expect(list).toHaveBeenCalledTimes(3);
+    expect(context.revalidate).toHaveBeenCalledTimes(2);
+    expect(list).toHaveBeenLastCalledWith({
+      limit: 50,
+      boardFace: "dashboard",
+      archivedFilter: "all",
+      agentId: "writer",
+    });
+  });
+});

--- a/ui/src/pages/dashboards/dashboards-page.test.ts
+++ b/ui/src/pages/dashboards/dashboards-page.test.ts
@@ -56,7 +56,8 @@ describe("DashboardsPage", () => {
     const selectionListeners = new Set<() => void>();
     let canonicalListRevision = 1;
     const selectionState = { selectedId: "main", scopeId: null as string | null };
-    let element: DashboardsPageElement;
+    const client = {};
+    const gateway = { snapshot: { client, phase: "connected", hello: null } };
     const list = vi
       .fn<() => Promise<SessionsListResult | null>>()
       .mockResolvedValueOnce(result(row("agent:main:before", "Before")))
@@ -64,7 +65,7 @@ describe("DashboardsPage", () => {
       .mockResolvedValueOnce(result(row("agent:writer:scoped", "Writer dashboard")));
     const context = {
       basePath: "",
-      gateway: { snapshot: { client: {}, phase: "connected", hello: null } },
+      gateway,
       sessions: {
         get canonicalListRevision() {
           return canonicalListRevision;
@@ -83,14 +84,6 @@ describe("DashboardsPage", () => {
         },
       },
       agents: { state: { agentsList: null } },
-      revalidate: vi.fn(async () => {
-        element.routeData = await loadDashboards(context, {
-          ...loaderOptions,
-          revalidating: true,
-          cause: "revalidate",
-        });
-        await element.updateComplete;
-      }),
     } as unknown as ApplicationContext;
     if (!dashboardsRoute.loader) {
       throw new Error("dashboards route has no loader");
@@ -103,7 +96,7 @@ describe("DashboardsPage", () => {
       deps: "",
       cause: "navigation" as const,
     };
-    element = document.createElement("openclaw-dashboards-page") as DashboardsPageElement;
+    const element = document.createElement("openclaw-dashboards-page") as DashboardsPageElement;
     element.routeData = await loadDashboards(context, loaderOptions);
     const provider = createApplicationContextProvider(context);
     provider.append(element);
@@ -111,29 +104,87 @@ describe("DashboardsPage", () => {
     await element.updateComplete;
 
     expect(list).toHaveBeenCalledTimes(1);
-    expect(context.revalidate).not.toHaveBeenCalled();
     expect(element.textContent).toContain("Before");
 
     canonicalListRevision += 1;
     sessionListeners.forEach((listener) => listener());
     await vi.waitFor(() => expect(element.textContent).toContain("After"));
     expect(list).toHaveBeenCalledTimes(2);
-    expect(context.revalidate).toHaveBeenCalledTimes(1);
 
     sessionListeners.forEach((listener) => listener());
     await Promise.resolve();
-    expect(context.revalidate).toHaveBeenCalledTimes(1);
+    expect(list).toHaveBeenCalledTimes(2);
 
     selectionState.scopeId = "writer";
     selectionListeners.forEach((listener) => listener());
     await vi.waitFor(() => expect(element.textContent).toContain("Writer dashboard"));
     expect(list).toHaveBeenCalledTimes(3);
-    expect(context.revalidate).toHaveBeenCalledTimes(2);
     expect(list).toHaveBeenLastCalledWith({
       limit: 50,
       boardFace: "dashboard",
       archivedFilter: "all",
       agentId: "writer",
     });
+  });
+
+  it("ignores a retired refresh after the replacement connection renders", async () => {
+    const sessionListeners = new Set<() => void>();
+    let canonicalListRevision = 1;
+    const clientA = {};
+    const clientB = {};
+    const gateway = { snapshot: { client: clientA, phase: "connected", hello: null } };
+    let resolveRetired!: (value: SessionsListResult | null) => void;
+    const retiredResult = new Promise<SessionsListResult | null>((resolve) => {
+      resolveRetired = resolve;
+    });
+    const list = vi
+      .fn<() => Promise<SessionsListResult | null>>()
+      .mockImplementationOnce(() => retiredResult)
+      .mockResolvedValueOnce(result(row("agent:main:current", "Current")));
+    const context = {
+      basePath: "",
+      gateway,
+      sessions: {
+        get canonicalListRevision() {
+          return canonicalListRevision;
+        },
+        list,
+        subscribe(listener: () => void) {
+          sessionListeners.add(listener);
+          return () => sessionListeners.delete(listener);
+        },
+      },
+      agentSelection: {
+        state: { selectedId: "main", scopeId: null },
+        subscribe: () => () => undefined,
+      },
+      agents: { state: { agentsList: null } },
+    } as unknown as ApplicationContext;
+    const element = document.createElement("openclaw-dashboards-page") as DashboardsPageElement;
+    element.routeData = {
+      result: result(row("agent:main:before", "Before")),
+      error: null,
+      basePath: "",
+      fallbackAgentId: "main",
+      mainKey: "main",
+    };
+    const provider = createApplicationContextProvider(context);
+    provider.append(element);
+    document.body.append(provider);
+    await element.updateComplete;
+
+    canonicalListRevision = 2;
+    sessionListeners.forEach((listener) => listener());
+    await vi.waitFor(() => expect(list).toHaveBeenCalledTimes(1));
+    gateway.snapshot = { client: clientB, phase: "connected", hello: null };
+    canonicalListRevision = 3;
+    sessionListeners.forEach((listener) => listener());
+    await vi.waitFor(() => expect(element.textContent).toContain("Current"));
+
+    resolveRetired(result(row("agent:main:retired", "Retired")));
+    await Promise.resolve();
+    await element.updateComplete;
+    expect(element.textContent).toContain("Current");
+    expect(element.textContent).not.toContain("Retired");
   });
 });

--- a/ui/src/pages/dashboards/dashboards-page.ts
+++ b/ui/src/pages/dashboards/dashboards-page.ts
@@ -1,0 +1,76 @@
+import { consume } from "@lit/context";
+import { property } from "lit/decorators.js";
+import { applicationContext, type ApplicationContext } from "../../app/context.ts";
+import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
+import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
+import { renderDashboards, type DashboardsRouteData } from "./view.ts";
+
+class DashboardsPage extends OpenClawLightDomElement {
+  @consume({ context: applicationContext, subscribe: true })
+  private context?: ApplicationContext;
+
+  @property({ attribute: false }) routeData?: DashboardsRouteData;
+
+  private observedSessions?: ApplicationContext["sessions"];
+  private observedAgentSelection?: ApplicationContext["agentSelection"];
+  private observedDependencies = "";
+  private dependenciesInitialized = false;
+  private readonly subscriptions = new SubscriptionsController(this)
+    .effect(
+      () => this.context?.sessions,
+      (sessions) => {
+        this.synchronizeDependencies();
+        return sessions.subscribe(() => this.synchronizeDependencies());
+      },
+    )
+    .effect(
+      () => this.context?.agentSelection,
+      (agentSelection) => {
+        this.synchronizeDependencies();
+        return agentSelection.subscribe(() => this.synchronizeDependencies());
+      },
+    );
+
+  override disconnectedCallback() {
+    this.subscriptions.clear();
+    super.disconnectedCallback();
+  }
+
+  private synchronizeDependencies(): void {
+    const context = this.context;
+    if (!context) {
+      return;
+    }
+    const sessions = context.sessions;
+    const agentSelection = context.agentSelection;
+    const dependencies = `${agentSelection.state.scopeId ?? "all"}\u0000${
+      sessions.canonicalListRevision
+    }`;
+    const sourceChanged =
+      sessions !== this.observedSessions || agentSelection !== this.observedAgentSelection;
+    if (
+      this.dependenciesInitialized &&
+      !sourceChanged &&
+      dependencies === this.observedDependencies
+    ) {
+      return;
+    }
+    const shouldRevalidate =
+      this.dependenciesInitialized && context.gateway.snapshot.phase === "connected";
+    this.dependenciesInitialized = true;
+    this.observedSessions = sessions;
+    this.observedAgentSelection = agentSelection;
+    this.observedDependencies = dependencies;
+    if (shouldRevalidate) {
+      void context.revalidate("dashboards").catch(() => undefined);
+    }
+  }
+
+  override render() {
+    return renderDashboards(this.routeData);
+  }
+}
+
+if (!customElements.get("openclaw-dashboards-page")) {
+  customElements.define("openclaw-dashboards-page", DashboardsPage);
+}

--- a/ui/src/pages/dashboards/dashboards-page.ts
+++ b/ui/src/pages/dashboards/dashboards-page.ts
@@ -1,8 +1,10 @@
 import { consume } from "@lit/context";
+import type { PropertyValues } from "lit";
 import { property } from "lit/decorators.js";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
+import { loadDashboardsRoute } from "./route.ts";
 import { renderDashboards, type DashboardsRouteData } from "./view.ts";
 
 class DashboardsPage extends OpenClawLightDomElement {
@@ -15,6 +17,8 @@ class DashboardsPage extends OpenClawLightDomElement {
   private observedAgentSelection?: ApplicationContext["agentSelection"];
   private observedDependencies = "";
   private dependenciesInitialized = false;
+  private refreshGeneration = 0;
+  private data?: DashboardsRouteData;
   private readonly subscriptions = new SubscriptionsController(this)
     .effect(
       () => this.context?.sessions,
@@ -32,8 +36,15 @@ class DashboardsPage extends OpenClawLightDomElement {
     );
 
   override disconnectedCallback() {
+    this.refreshGeneration += 1;
     this.subscriptions.clear();
     super.disconnectedCallback();
+  }
+
+  override willUpdate(changed: PropertyValues<this>) {
+    if (changed.has("routeData")) {
+      this.data = this.routeData;
+    }
   }
 
   private synchronizeDependencies(): void {
@@ -55,19 +66,51 @@ class DashboardsPage extends OpenClawLightDomElement {
     ) {
       return;
     }
-    const shouldRevalidate =
-      this.dependenciesInitialized && context.gateway.snapshot.phase === "connected";
+    const shouldRefresh =
+      context.gateway.snapshot.phase === "connected" &&
+      (this.dependenciesInitialized ||
+        (this.routeData?.result === null && this.routeData.error === null));
     this.dependenciesInitialized = true;
     this.observedSessions = sessions;
     this.observedAgentSelection = agentSelection;
     this.observedDependencies = dependencies;
-    if (shouldRevalidate) {
-      void context.revalidate("dashboards").catch(() => undefined);
+    if (shouldRefresh) {
+      void this.refresh(context, sessions, agentSelection, dependencies);
     }
   }
 
+  private async refresh(
+    context: ApplicationContext,
+    sessions: ApplicationContext["sessions"],
+    agentSelection: ApplicationContext["agentSelection"],
+    dependencies: string,
+  ): Promise<void> {
+    const gateway = context.gateway;
+    const client = gateway.snapshot.phase === "connected" ? gateway.snapshot.client : null;
+    if (!client) {
+      return;
+    }
+    const generation = ++this.refreshGeneration;
+    const data = await loadDashboardsRoute(context);
+    if (
+      generation !== this.refreshGeneration ||
+      this.context !== context ||
+      context.sessions !== sessions ||
+      context.agentSelection !== agentSelection ||
+      this.observedDependencies !== dependencies ||
+      context.gateway !== gateway ||
+      gateway.snapshot.phase !== "connected" ||
+      gateway.snapshot.client !== client ||
+      (data.result === null && data.error === null)
+    ) {
+      return;
+    }
+    this.data = data;
+    this.requestUpdate();
+  }
+
   override render() {
-    return renderDashboards(this.routeData);
+    return renderDashboards(this.data);
   }
 }
 

--- a/ui/src/pages/dashboards/route.test.ts
+++ b/ui/src/pages/dashboards/route.test.ts
@@ -2,8 +2,11 @@
 
 import type { RouteLoaderOptions } from "@openclaw/uirouter";
 import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SessionsListResult } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { page } from "./route.ts";
+import type { DashboardsRouteData } from "./view.ts";
 
 const loaderOptions: RouteLoaderOptions = {
   signal: new AbortController().signal,
@@ -13,6 +16,23 @@ const loaderOptions: RouteLoaderOptions = {
   deps: "",
   cause: "navigation",
 };
+
+function sessionsResult(key: string): SessionsListResult {
+  return {
+    ts: 1,
+    path: "(multiple)",
+    count: 1,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions: [{ key, kind: "direct", boardFace: "dashboard", updatedAt: 1 }],
+  };
+}
+
+async function loadDashboards(
+  context: ApplicationContext,
+  options: RouteLoaderOptions,
+): Promise<Awaited<ReturnType<NonNullable<typeof page.loader>>>> {
+  return await Promise.resolve(page.loader!(context, options));
+}
 
 describe("dashboards route", () => {
   it("requests the dashboard face from the server before pagination", async () => {
@@ -28,12 +48,70 @@ describe("dashboards route", () => {
       throw new Error("dashboards route has no loader");
     }
 
-    await page.loader(context, loaderOptions);
+    await loadDashboards(context, loaderOptions);
 
     expect(list).toHaveBeenCalledWith({
       limit: 50,
       boardFace: "dashboard",
       archivedFilter: "all",
     });
+  });
+
+  it("does not publish a retired connection result while replacement hydration is pending", async () => {
+    let resolveRetired!: (value: SessionsListResult | null) => void;
+    const retiredResult = new Promise<SessionsListResult | null>((resolve) => {
+      resolveRetired = resolve;
+    });
+    const clientA = {} as GatewayBrowserClient;
+    const clientB = {} as GatewayBrowserClient;
+    let canonicalListRevision = 1;
+    let gatewaySnapshot = { client: clientA, phase: "connected", hello: null };
+    const gateway = {
+      get snapshot() {
+        return gatewaySnapshot;
+      },
+    } as unknown as ApplicationContext["gateway"];
+    const list = vi
+      .fn<() => Promise<SessionsListResult | null>>()
+      .mockImplementationOnce(() => retiredResult)
+      .mockResolvedValueOnce(sessionsResult("agent:main:current"));
+    const context = {
+      basePath: "",
+      sessions: {
+        list,
+        get canonicalListRevision() {
+          return canonicalListRevision;
+        },
+      },
+      agentSelection: { state: { selectedId: "main", scopeId: null } },
+      agents: { state: { agentsList: null } },
+      gateway,
+    } as unknown as ApplicationContext;
+    if (!page.loader) {
+      throw new Error("dashboards route has no loader");
+    }
+
+    const retiredAbort = new AbortController();
+    let retiredSettled = false;
+    const retiredLoad = loadDashboards(context, {
+      ...loaderOptions,
+      signal: retiredAbort.signal,
+      revalidating: true,
+    }).finally(() => {
+      retiredSettled = true;
+    });
+    gatewaySnapshot = { client: clientA, phase: "reconnecting", hello: null };
+    resolveRetired(null);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(retiredSettled).toBe(false);
+
+    gatewaySnapshot = { client: clientB, phase: "connected", hello: null };
+    canonicalListRevision = 2;
+    retiredAbort.abort();
+    await expect(retiredLoad).rejects.toMatchObject({ name: "AbortError" });
+
+    const current = (await loadDashboards(context, loaderOptions)) as DashboardsRouteData;
+    expect(current.result?.sessions[0]?.key).toBe("agent:main:current");
   });
 });

--- a/ui/src/pages/dashboards/route.test.ts
+++ b/ui/src/pages/dashboards/route.test.ts
@@ -2,11 +2,8 @@
 
 import type { RouteLoaderOptions } from "@openclaw/uirouter";
 import { describe, expect, it, vi } from "vitest";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { SessionsListResult } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { page } from "./route.ts";
-import type { DashboardsRouteData } from "./view.ts";
 
 const loaderOptions: RouteLoaderOptions = {
   signal: new AbortController().signal,
@@ -16,16 +13,6 @@ const loaderOptions: RouteLoaderOptions = {
   deps: "",
   cause: "navigation",
 };
-
-function sessionsResult(key: string): SessionsListResult {
-  return {
-    ts: 1,
-    path: "(multiple)",
-    count: 1,
-    defaults: { modelProvider: null, model: null, contextTokens: null },
-    sessions: [{ key, kind: "direct", boardFace: "dashboard", updatedAt: 1 }],
-  };
-}
 
 async function loadDashboards(
   context: ApplicationContext,
@@ -55,63 +42,5 @@ describe("dashboards route", () => {
       boardFace: "dashboard",
       archivedFilter: "all",
     });
-  });
-
-  it("does not publish a retired connection result while replacement hydration is pending", async () => {
-    let resolveRetired!: (value: SessionsListResult | null) => void;
-    const retiredResult = new Promise<SessionsListResult | null>((resolve) => {
-      resolveRetired = resolve;
-    });
-    const clientA = {} as GatewayBrowserClient;
-    const clientB = {} as GatewayBrowserClient;
-    let canonicalListRevision = 1;
-    let gatewaySnapshot = { client: clientA, phase: "connected", hello: null };
-    const gateway = {
-      get snapshot() {
-        return gatewaySnapshot;
-      },
-    } as unknown as ApplicationContext["gateway"];
-    const list = vi
-      .fn<() => Promise<SessionsListResult | null>>()
-      .mockImplementationOnce(() => retiredResult)
-      .mockResolvedValueOnce(sessionsResult("agent:main:current"));
-    const context = {
-      basePath: "",
-      sessions: {
-        list,
-        get canonicalListRevision() {
-          return canonicalListRevision;
-        },
-      },
-      agentSelection: { state: { selectedId: "main", scopeId: null } },
-      agents: { state: { agentsList: null } },
-      gateway,
-    } as unknown as ApplicationContext;
-    if (!page.loader) {
-      throw new Error("dashboards route has no loader");
-    }
-
-    const retiredAbort = new AbortController();
-    let retiredSettled = false;
-    const retiredLoad = loadDashboards(context, {
-      ...loaderOptions,
-      signal: retiredAbort.signal,
-      revalidating: true,
-    }).finally(() => {
-      retiredSettled = true;
-    });
-    gatewaySnapshot = { client: clientA, phase: "reconnecting", hello: null };
-    resolveRetired(null);
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(retiredSettled).toBe(false);
-
-    gatewaySnapshot = { client: clientB, phase: "connected", hello: null };
-    canonicalListRevision = 2;
-    retiredAbort.abort();
-    await expect(retiredLoad).rejects.toMatchObject({ name: "AbortError" });
-
-    const current = (await loadDashboards(context, loaderOptions)) as DashboardsRouteData;
-    expect(current.result?.sessions[0]?.key).toBe("agent:main:current");
   });
 });

--- a/ui/src/pages/dashboards/route.ts
+++ b/ui/src/pages/dashboards/route.ts
@@ -7,23 +7,53 @@ import { resolveSessionNavigationAgentId } from "../../lib/sessions/route-naviga
 import { resolveUiConfiguredMainKey } from "../../lib/sessions/session-key.ts";
 import type { DashboardsRouteData } from "./view.ts";
 
-async function loadDashboardsRoute(context: ApplicationContext): Promise<DashboardsRouteData> {
-  const result = await context.sessions
-    .list({
+function waitForSupersedingNavigation(signal: AbortSignal): Promise<never> {
+  const abortError = () =>
+    signal.reason instanceof Error
+      ? signal.reason
+      : new DOMException("Dashboard route load superseded", "AbortError");
+  if (signal.aborted) {
+    return Promise.reject(abortError());
+  }
+  return new Promise((_, reject) => {
+    signal.addEventListener("abort", () => reject(abortError()), { once: true });
+  });
+}
+
+async function loadDashboardsRoute(
+  context: ApplicationContext,
+  signal: AbortSignal,
+): Promise<DashboardsRouteData> {
+  const gateway = context.gateway;
+  const client = gateway.snapshot.phase === "connected" ? gateway.snapshot.client : null;
+  let value = null;
+  let error: string | null = null;
+  try {
+    value = await context.sessions.list({
       ...DEFAULT_SESSION_LIST_QUERY,
       boardFace: "dashboard",
       archivedFilter: "all",
       ...(context.agentSelection.state.scopeId
         ? { agentId: context.agentSelection.state.scopeId }
         : {}),
-    })
-    .then(
-      (value) => ({ value, error: null }),
-      (error: unknown) => ({ value: null, error: String(error) }),
-    );
+    });
+  } catch (cause) {
+    error = String(cause);
+  }
+  if (
+    client &&
+    (gateway !== context.gateway ||
+      gateway.snapshot.phase !== "connected" ||
+      gateway.snapshot.client !== client ||
+      (error === null && value === null))
+  ) {
+    // Keep the last successful match visible until reconnect hydration starts
+    // a current-connection load and the router aborts this retired request.
+    return waitForSupersedingNavigation(signal);
+  }
   return {
-    result: result.value,
-    error: result.error,
+    result: value,
+    error,
     basePath: context.basePath,
     fallbackAgentId: resolveSessionNavigationAgentId(context),
     mainKey: resolveUiConfiguredMainKey({
@@ -37,10 +67,11 @@ export const page = definePage({
   ...routePageSpec("dashboards"),
   loaderDeps: (context: ApplicationContext) =>
     `${context.agentSelection.state.scopeId ?? "all"}\u0000${context.sessions.canonicalListRevision}`,
-  loader: (context: ApplicationContext) => loadDashboardsRoute(context),
+  loader: (context: ApplicationContext, { signal }) => loadDashboardsRoute(context, signal),
   component: () =>
-    import("./view.ts").then(({ renderDashboards }) => ({
+    import("./dashboards-page.ts").then(() => ({
       header: true,
-      render: (data: DashboardsRouteData | undefined) => html`${renderDashboards(data)}`,
+      render: (data: DashboardsRouteData | undefined) =>
+        html`<openclaw-dashboards-page .routeData=${data}></openclaw-dashboards-page>`,
     })),
 });

--- a/ui/src/pages/dashboards/route.ts
+++ b/ui/src/pages/dashboards/route.ts
@@ -7,25 +7,9 @@ import { resolveSessionNavigationAgentId } from "../../lib/sessions/route-naviga
 import { resolveUiConfiguredMainKey } from "../../lib/sessions/session-key.ts";
 import type { DashboardsRouteData } from "./view.ts";
 
-function waitForSupersedingNavigation(signal: AbortSignal): Promise<never> {
-  const abortError = () =>
-    signal.reason instanceof Error
-      ? signal.reason
-      : new DOMException("Dashboard route load superseded", "AbortError");
-  if (signal.aborted) {
-    return Promise.reject(abortError());
-  }
-  return new Promise((_, reject) => {
-    signal.addEventListener("abort", () => reject(abortError()), { once: true });
-  });
-}
-
-async function loadDashboardsRoute(
+export async function loadDashboardsRoute(
   context: ApplicationContext,
-  signal: AbortSignal,
 ): Promise<DashboardsRouteData> {
-  const gateway = context.gateway;
-  const client = gateway.snapshot.phase === "connected" ? gateway.snapshot.client : null;
   let value = null;
   let error: string | null = null;
   try {
@@ -39,17 +23,6 @@ async function loadDashboardsRoute(
     });
   } catch (cause) {
     error = String(cause);
-  }
-  if (
-    client &&
-    (gateway !== context.gateway ||
-      gateway.snapshot.phase !== "connected" ||
-      gateway.snapshot.client !== client ||
-      (error === null && value === null))
-  ) {
-    // Keep the last successful match visible until reconnect hydration starts
-    // a current-connection load and the router aborts this retired request.
-    return waitForSupersedingNavigation(signal);
   }
   return {
     result: value,
@@ -65,9 +38,7 @@ async function loadDashboardsRoute(
 
 export const page = definePage({
   ...routePageSpec("dashboards"),
-  loaderDeps: (context: ApplicationContext) =>
-    `${context.agentSelection.state.scopeId ?? "all"}\u0000${context.sessions.canonicalListRevision}`,
-  loader: (context: ApplicationContext, { signal }) => loadDashboardsRoute(context, signal),
+  loader: loadDashboardsRoute,
   component: () =>
     import("./dashboards-page.ts").then(() => ({
       header: true,


### PR DESCRIPTION
Closes #120602

## What Problem This Solves

Fixes an issue where users who left `/dashboards` open would continue seeing stale rows after dashboard sessions were created, renamed, reordered, archived, deleted, switched between Chat and Dashboard, or refreshed after a Gateway reconnect.

## Why This Change Was Made

The Dashboards page now observes canonical session-list revisions and the selected agent scope, then reloads the existing server-filtered dashboard query when either changes.

The page retains its last safe data while reconnecting and rejects results from retired connections. The shared session-list owner also treats errors from retired requests as stale results while preserving errors from the active connection.

Generic router behavior and the server-side `boardFace: "dashboard"` filtering contract remain unchanged.

## User Impact

An open Dashboards page now converges automatically to the current Gateway state without requiring navigation or a manual reload.

Existing dashboard links, ordering, empty states, error states, and agent-scoped filtering remain intact.

## Evidence

- Live OCM and Chromium verification:
  - created dashboard sessions from a second client
  - renamed and reordered dashboard rows
  - archived and deleted sessions
  - retained the last safe list while the Gateway was offline
  - reconnected without navigation
  - observed a post-reconnect rename update in place
- Content-bound AWS beast validation verified every changed file before running:
  - 11 focused dashboard and session lifecycle tests
  - `pnpm tsgo:ui`
  - `pnpm tsgo:test:ui`
- Added regression coverage for:
  - duplicate initial-request prevention
  - canonical revision and agent-scope refresh counts
  - replacement-connection stale-result rejection
  - retired same-client request errors
  - existing server-side dashboard filtering and rendering
