### PR TITLE
fix(e2e): keep shared artifacts stable across parallel tests [AI]

### DIFF
--- a/packages/ai/src/package.e2e.test.ts
+++ b/packages/ai/src/package.e2e.test.ts
@@ -271,11 +271,8 @@ describe("@openclaw/ai packed package", () => {
     }
     const tempDir = tempDirs.make("openclaw-ai-consumer-");
 
-    await runCommand(
-      process.execPath,
-      ["scripts/tsdown-build.mjs", "--config", "tsdown.ai.config.ts"],
-      { cwd: repoRoot },
-    );
+    // The E2E global setup owns the exact-head build. Rebuilding this shared
+    // package here can delete modules beneath concurrently running Gateways.
     const pack = await runNpmCommand(
       ["pack", "--ignore-scripts", "--json", "--pack-destination", tempDir],
       packageRoot,

--- a/test/vitest/vitest.e2e.config.ts
+++ b/test/vitest/vitest.e2e.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
     ...baseTest,
     maxWorkers: e2eWorkers,
     silent: !verboseE2E,
+    globalSetup: [resolveRepoRootPath("test/vitest/vitest.e2e.global-setup.ts")],
     setupFiles: [
       ...new Set(
         [...(baseTest.setupFiles ?? []), "test/setup-openclaw-runtime.ts"].map(resolveRepoRootPath),

--- a/test/vitest/vitest.e2e.global-setup.ts
+++ b/test/vitest/vitest.e2e.global-setup.ts
@@ -1,0 +1,29 @@
+// Builds the shared CLI/package artifacts once before parallel E2E workers
+// start long-lived Gateway processes that import those artifacts lazily.
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export default async function setup() {
+  await execFileAsync(process.execPath, ["scripts/run-node.mjs", "--version"], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      OPENCLAW_BUILD_PRIVATE_QA: "1",
+      OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "0",
+    },
+    maxBuffer: 8 * 1024 * 1024,
+    timeout: 300_000,
+  });
+  await execFileAsync(
+    process.execPath,
+    ["scripts/tsdown-build.mjs", "--config", "tsdown.ai.config.ts"],
+    {
+      cwd: process.cwd(),
+      env: process.env,
+      maxBuffer: 8 * 1024 * 1024,
+      timeout: 300_000,
+    },
+  );
+}


### PR DESCRIPTION
Closes #120624

## What Problem This Solves

Fixes an issue where parallel E2E workers could rebuild shared `dist` and `packages/ai/dist` artifacts after other workers had already started long-lived Gateway processes. Those Gateways then failed later lazy imports with missing root chunks, a missing `dist/index.js`, or a missing `@openclaw/ai` transport module.

## Why This Change Was Made

The existing build lock serializes writers but cannot protect a running reader after the lock is released. The E2E config now owns one exact-head private-QA build and one `@openclaw/ai` build in global setup, before file workers start. The packed AI-package test consumes that prepared artifact instead of cleaning and rebuilding it beneath concurrent Gateways.

This is the narrow owner boundary: artifact production happens once before worker admission, while individual tests remain consumers. No production code or operator state changes.

## User Impact

Maintainers and CI can run parallel Gateway/package E2E stress without unrelated tests failing because another worker replaced their build tree. This makes real Gateway regressions easier to distinguish from test-infrastructure corruption.

## Evidence

Pre-fix reproduction on `1e004151c618d876881740ff1fd35353a547e7c6`:

- `CI=1 OPENCLAW_E2E_WORKERS=6 pnpm test:e2e:gateway`
- Testbox `tbx_01kzgxj59ax71gw0tydvbz2drh`
- https://github.com/openclaw/openclaw/actions/runs/31262884714
- 13 failed / 1,421 passed / 23 skipped, including missing hashed root chunks, `dist/index.js`, and `@openclaw/ai/dist/transports.mjs`

Focused exact-candidate stress:

- `CI=1 OPENCLAW_E2E_WORKERS=4 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts packages/ai/src/package.e2e.test.ts test/gateway-steer-fifo.e2e.test.ts test/clawrouter-managed-gateway.e2e.test.ts extensions/diagnostics-prometheus/src/install-runtime.e2e.test.ts`
- Testbox `tbx_01kzh1qrs7mdsdtja2znyrptxh`
- https://github.com/openclaw/openclaw/actions/runs/31265941863
- 4 files passed / 6 tests passed in 218.34s; no missing-artifact failures

Additional proof:

- AutoReview: clean, no accepted/actionable findings
- Production LOC: +0/-0; test infrastructure: +32/-5
- Public model identifier gate: PASS; no model-bearing code or artifacts changed

The six-worker broad rerun eliminated all 13 original failures. Four separate load-sensitive cases remained; each passed immediately in isolation and is not masked or modified by this PR.

## AI Assistance

AI-assisted. The implementation, failure classification, exact commands, and resulting diff were reviewed directly before publication.
