### PR TITLE
fix(clawrouter): honor advertised reasoning efforts

### DIFF
--- a/extensions/clawrouter/index.test.ts
+++ b/extensions/clawrouter/index.test.ts
@@ -57,6 +57,7 @@ describe("ClawRouter plugin", () => {
       prepareDynamicModel: expect.any(Function),
       preferRuntimeResolvedModel: expect.any(Function),
       resolveDynamicModel: expect.any(Function),
+      resolveThinkingProfile: expect.any(Function),
       resolveUsageAuth: expect.any(Function),
       sanitizeReplayHistory: expect.any(Function),
       wrapSimpleCompletionStreamFn: expect.any(Function),
@@ -68,6 +69,73 @@ describe("ClawRouter plugin", () => {
       kind: "api_key",
     });
     expect(provider?.wrapSimpleCompletionStreamFn).toBe(provider?.wrapStreamFn);
+  });
+
+  it("resolves authoritative catalog thinking profiles without inventing minimal", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const compat = {
+      supportedReasoningEfforts: ["none", "low", "medium", "high", "xhigh", "max"],
+    };
+    const resolveLevels = (agentRuntime: string | undefined) =>
+      provider
+        ?.resolveThinkingProfile?.({
+          provider: "clawrouter",
+          modelId: "opaque-route-id",
+          agentRuntime,
+          compat,
+        } as never)
+        ?.levels.map((level) => level.id);
+
+    expect(resolveLevels("openclaw")).toEqual([
+      "off",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+      "ultra",
+    ]);
+    expect(resolveLevels("auto")).toEqual([
+      "off",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+      "ultra",
+    ]);
+    expect(resolveLevels("codex")).toEqual(["off", "low", "medium", "high", "xhigh", "max"]);
+    expect(resolveLevels(undefined)).toEqual(["off", "low", "medium", "high", "xhigh", "max"]);
+    expect(
+      provider?.resolveThinkingProfile?.({
+        provider: "clawrouter",
+        modelId: "opaque-route-id",
+      } as never),
+    ).toBeUndefined();
+  });
+
+  it("bounds configured thinking metadata at the provider hook", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    expect(
+      provider
+        ?.resolveThinkingProfile?.({
+          provider: "clawrouter",
+          modelId: "opaque-route-id",
+          agentRuntime: "openclaw",
+          compat: {
+            supportedReasoningEfforts: ["ultra", "custom", "none", "none", "max"],
+          },
+        } as never)
+        ?.levels.map((level) => level.id),
+    ).toEqual(["off", "max", "ultra"]);
+    expect(
+      provider?.resolveThinkingProfile?.({
+        provider: "clawrouter",
+        modelId: "opaque-route-id",
+        compat: { supportedReasoningEfforts: ["ultra", "custom"] },
+      } as never),
+    ).toBeUndefined();
   });
 
   it("attaches the proxy key and native upstream id only at request dispatch", async () => {

--- a/extensions/clawrouter/index.ts
+++ b/extensions/clawrouter/index.ts
@@ -1,7 +1,9 @@
 // ClawRouter plugin entrypoint registers credential-scoped model routing and quota reporting.
 import type {
+  ProviderDefaultThinkingPolicyContext,
   ProviderResolveDynamicModelContext,
   ProviderRuntimeModel,
+  ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
@@ -9,7 +11,9 @@ import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 import {
   buildClawRouterProviderConfig,
+  CLAWROUTER_REASONING_EFFORT_LEVELS,
   normalizeClawRouterApiBaseUrl,
+  normalizeClawRouterReasoningEfforts,
   normalizeClawRouterRootUrl,
   normalizeClawRouterResolvedModel,
 } from "./provider-catalog.js";
@@ -35,6 +39,28 @@ const perplexityTools = {
   normalizeToolSchemas: normalizePerplexityToolSchemas,
   inspectToolSchemas: inspectPerplexityToolSchemas,
 };
+
+function resolveClawRouterThinkingProfile(
+  ctx: ProviderDefaultThinkingPolicyContext,
+): ProviderThinkingProfile | undefined {
+  const efforts = normalizeClawRouterReasoningEfforts(ctx.compat?.supportedReasoningEfforts);
+  if (!efforts) {
+    return undefined;
+  }
+  const supported = new Set(efforts);
+  const levels: Array<ProviderThinkingProfile["levels"][number]> =
+    CLAWROUTER_REASONING_EFFORT_LEVELS.filter(([effort]) => supported.has(effort)).map(
+      ([, id]) => ({ id }),
+    );
+  const runtime = ctx.agentRuntime?.trim().toLowerCase();
+  if (
+    levels.some((level) => level.id === "max") &&
+    (runtime === "openclaw" || runtime === "auto")
+  ) {
+    levels.push({ id: "ultra" });
+  }
+  return { levels };
+}
 
 function configuredBaseUrl(
   config: { models?: { providers?: Record<string, { baseUrl?: unknown }> } } | null | undefined,
@@ -213,6 +239,7 @@ export default defineSingleProviderPluginEntry({
         ctx.modelApi === "google-generative-ai"
           ? googleReplay.resolveReasoningOutputMode?.(ctx)
           : undefined,
+      resolveThinkingProfile: resolveClawRouterThinkingProfile,
       normalizeToolSchemas: (ctx) => resolveToolFamily(ctx.modelId ?? "").normalizeToolSchemas(ctx),
       inspectToolSchemas: (ctx) => resolveToolFamily(ctx.modelId ?? "").inspectToolSchemas(ctx),
       isModernModelRef: () => true,

--- a/extensions/clawrouter/provider-catalog.test.ts
+++ b/extensions/clawrouter/provider-catalog.test.ts
@@ -37,9 +37,10 @@ const CATALOG = {
       ],
       models: [
         {
-          id: "openai/gpt-5.5",
-          upstream: "gpt-5.5",
+          id: "openai/gpt-5.6",
+          upstream: "gpt-5.6",
           capabilities: ["llm.responses", "llm.chat"],
+          supportedReasoningEfforts: ["none", "low", "medium", "high", "xhigh", "max"],
           pricing: PRICING,
         },
       ],
@@ -157,9 +158,10 @@ describe("ClawRouter provider catalog", () => {
       "anthropic/claude-sonnet-4-6",
       "deepseek/deepseek-v4-flash",
       "google/gemini-3.5-flash",
-      "openai/gpt-5.5",
+      "openai/gpt-5.6",
     ]);
-    expect(provider.models.find((model) => model.id === "openai/gpt-5.5")).toMatchObject({
+    const openai = provider.models.find((model) => model.id === "openai/gpt-5.6");
+    expect(openai).toMatchObject({
       api: "openai-responses",
       baseUrl: "https://clawrouter.example/v1",
       reasoning: true,
@@ -168,9 +170,23 @@ describe("ClawRouter provider catalog", () => {
       contextWindow: 1_000_000,
       maxTokens: 64_000,
     });
-    expect(
-      provider.models.find((model) => model.id === "deepseek/deepseek-v4-flash"),
-    ).toMatchObject({ api: "openai-completions" });
+    expect(openai?.thinkingLevelMap).toEqual({
+      off: "none",
+      minimal: null,
+      low: "low",
+      medium: "medium",
+      high: "high",
+      xhigh: "xhigh",
+      max: "max",
+    });
+    expect(openai?.compat).toEqual({
+      supportsReasoningEffort: true,
+      supportedReasoningEfforts: ["none", "low", "medium", "high", "xhigh", "max"],
+    });
+    const deepseek = provider.models.find((model) => model.id === "deepseek/deepseek-v4-flash");
+    expect(deepseek).toMatchObject({ api: "openai-completions" });
+    expect(deepseek?.compat).toBeUndefined();
+    expect(deepseek?.thinkingLevelMap).toBeUndefined();
     expect(
       provider.models.find((model) => model.id === "anthropic/claude-sonnet-4-6"),
     ).toMatchObject({
@@ -206,15 +222,69 @@ describe("ClawRouter provider catalog", () => {
       params: undefined,
     });
 
-    const openai = provider.models.find((model) => model.id === "openai/gpt-5.5");
+    const openaiModel = provider.models.find((model) => model.id === "openai/gpt-5.6");
     const normalizedOpenAi = normalizeClawRouterResolvedModel({
-      ...openai,
+      ...openaiModel,
       baseUrl: provider.baseUrl,
       provider: "clawrouter",
     } as ProviderRuntimeModel);
     expect(prepareClawRouterRequestModel(normalizedOpenAi as ProviderRuntimeModel).id).toBe(
-      "openai/gpt-5.5",
+      "openai/gpt-5.6",
     );
+  });
+
+  it("bounds reasoning effort metadata to exact canonical wire values", async () => {
+    const catalog = structuredClone(CATALOG);
+    const model = expectDefined(catalog.providers[0]?.models[0], "OpenAI ClawRouter model");
+    (model as unknown as Record<string, unknown>).supportedReasoningEfforts = [
+      "max",
+      "none",
+      "ultra",
+      "low",
+      "low",
+      null,
+      "xhigh",
+    ];
+    const provider = await buildClawRouterProviderConfig({
+      apiKey: "clawrouter-test-key",
+      fetchGuard: buildFetchGuard(catalog).fetchGuard,
+    });
+    const bounded = provider.models.find((entry) => entry.id === "openai/gpt-5.6");
+
+    expect(bounded?.compat?.supportedReasoningEfforts).toEqual(["none", "low", "xhigh", "max"]);
+    expect(bounded?.thinkingLevelMap).toEqual({
+      off: "none",
+      minimal: null,
+      low: "low",
+      medium: null,
+      high: null,
+      xhigh: "xhigh",
+      max: "max",
+    });
+
+    const malformedCatalog = structuredClone(CATALOG);
+    const malformed = expectDefined(
+      malformedCatalog.providers[0]?.models[0],
+      "OpenAI ClawRouter model",
+    );
+    (malformed as unknown as Record<string, unknown>).supportedReasoningEfforts = [
+      "none",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+      "ultra",
+    ];
+    clearLiveCatalogCacheForTests();
+    const rejected = await buildClawRouterProviderConfig({
+      apiKey: "clawrouter-test-key",
+      fetchGuard: buildFetchGuard(malformedCatalog).fetchGuard,
+    });
+    const rejectedModel = rejected.models.find((entry) => entry.id === "openai/gpt-5.6");
+    expect(rejectedModel?.compat).toBeUndefined();
+    expect(rejectedModel?.thinkingLevelMap).toBeUndefined();
   });
 
   it("caches catalog rows per credential scope", async () => {

--- a/extensions/clawrouter/provider-catalog.ts
+++ b/extensions/clawrouter/provider-catalog.ts
@@ -23,6 +23,17 @@ const DEFAULT_COST = {
   cacheWrite: 0,
 };
 
+export const CLAWROUTER_REASONING_EFFORT_LEVELS = [
+  ["none", "off"],
+  ["minimal", "minimal"],
+  ["low", "low"],
+  ["medium", "medium"],
+  ["high", "high"],
+  ["xhigh", "xhigh"],
+  ["max", "max"],
+] as const;
+type CatalogReasoningEffort = (typeof CLAWROUTER_REASONING_EFFORT_LEVELS)[number][0];
+
 type CatalogRoute = {
   path: string;
   requestFormat: string;
@@ -43,6 +54,7 @@ type CatalogModel = {
   id: string;
   upstream: string;
   capabilities: string[];
+  supportedReasoningEfforts?: CatalogReasoningEffort[];
   pricing?: CatalogPricing;
 };
 
@@ -75,6 +87,19 @@ function readStringArray(value: unknown): string[] {
   return Array.isArray(value)
     ? value.map(readString).filter((entry): entry is string => Boolean(entry))
     : [];
+}
+
+export function normalizeClawRouterReasoningEfforts(
+  value: unknown,
+): CatalogReasoningEffort[] | undefined {
+  if (!Array.isArray(value) || value.length > CLAWROUTER_REASONING_EFFORT_LEVELS.length) {
+    return undefined;
+  }
+  const advertised = new Set(value);
+  const efforts = CLAWROUTER_REASONING_EFFORT_LEVELS.filter(([effort]) =>
+    advertised.has(effort),
+  ).map(([effort]) => effort);
+  return efforts.length > 0 ? efforts : undefined;
 }
 
 function readNonNegativeNumber(value: unknown): number | undefined {
@@ -134,6 +159,7 @@ function parseCatalogModel(value: unknown): CatalogModel | undefined {
     id,
     upstream,
     capabilities: readStringArray(row?.capabilities),
+    supportedReasoningEfforts: normalizeClawRouterReasoningEfforts(row?.supportedReasoningEfforts),
     pricing: parseCatalogPricing(row?.pricing),
   };
 }
@@ -221,6 +247,17 @@ function modelCost(pricing: CatalogPricing | undefined): ModelDefinitionConfig["
   };
 }
 
+function buildThinkingLevelMap(
+  efforts: readonly CatalogReasoningEffort[],
+): NonNullable<ModelDefinitionConfig["thinkingLevelMap"]> {
+  const supported = new Set(efforts);
+  const levelMap: NonNullable<ModelDefinitionConfig["thinkingLevelMap"]> = {};
+  for (const [effort, level] of CLAWROUTER_REASONING_EFFORT_LEVELS) {
+    levelMap[level] = supported.has(effort) ? effort : null;
+  }
+  return levelMap;
+}
+
 function buildRoutedModel(
   rootUrl: string,
   provider: CatalogProvider,
@@ -268,7 +305,17 @@ function buildRoutedModel(
     name: `${provider.displayName} · ${model.id}`,
     api,
     baseUrl,
-    reasoning: inferReasoning(provider.id, model.id),
+    reasoning:
+      model.supportedReasoningEfforts !== undefined || inferReasoning(provider.id, model.id),
+    ...(model.supportedReasoningEfforts
+      ? {
+          thinkingLevelMap: buildThinkingLevelMap(model.supportedReasoningEfforts),
+          compat: {
+            supportsReasoningEffort: true,
+            supportedReasoningEfforts: model.supportedReasoningEfforts,
+          },
+        }
+      : {}),
     input: inferInput(provider.id, model.id),
     cost: modelCost(model.pricing),
     contextWindow: model.pricing?.maxInputTokens ?? DEFAULT_CONTEXT_WINDOW,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Claw Router users selecting reasoning effort for GPT-5.6 would see OpenClaw's generic `off`/`minimal`/`low`/`medium`/`high` fallback because the router catalog previously omitted model-specific effort metadata. That list stopped at `high` and could include an unsupported `minimal` choice.

Paired producer change: https://github.com/openclaw/clawrouter/pull/110, merged as https://github.com/openclaw/clawrouter/commit/ca27bc44227f3e0179539bcc1fd2f30da9051c52.

## Why This Change Was Made

The Claw Router plugin now consumes the producer's bounded `supportedReasoningEfforts` catalog field, projects it into the existing model compatibility contract, and resolves the exact advertised OpenClaw effort profile. The paired producer and consumer fixes make the authoritative list `off`/`low`/`medium`/`high`/`xhigh`/`max`, plus the intentional logical OpenClaw `ultra` tier where `max` is available. Rows without metadata retain the existing generic fallback.

The implementation is metadata-driven: it adds no model-name regex and changes neither core reasoning semantics nor the Control UI. This change was AI-assisted and reviewed before publication.

## User Impact

Claw Router users get effort choices that match the selected model's advertised capabilities. Unsupported values are filtered at the catalog boundary, `minimal` is no longer offered when the router does not advertise it, and advanced `xhigh`, `max`, and logical OpenClaw `ultra` choices remain available. Catalogs without the new metadata behave exactly as before.

## Evidence

- Exact head: `a3304ed79b10131c4a783ac0d67d739a696c225c`; CI run https://github.com/openclaw/openclaw/actions/runs/31266728685 completed successfully, including `openclaw/ci-gate`.
- Producer contract: Claw Router PR https://github.com/openclaw/clawrouter/pull/110 is merged at https://github.com/openclaw/clawrouter/commit/ca27bc44227f3e0179539bcc1fd2f30da9051c52. Its authenticated local Wrangler Worker proof returned HTTP 200 from `/v1/catalog`, advertised GPT-5.6 efforts `none`/`low`/`medium`/`high`/`xhigh`/`max`, and omitted the field for GPT-5.5. Direct inspection confirmed omitted metadata remains omitted, empty/duplicate/unsupported lists are rejected at compilation, and valid partial lists pass through exactly.
- Codex contract: directly inspected openai/codex revision https://github.com/openai/codex/commit/2e3a1702c2e7adea5f2ae9ea2799c625024b4fda. `codex-rs/models-manager/models.json` advertises GPT-5.6 reasoning levels, `codex-rs/app-server-protocol/src/protocol/v2/model.rs` exposes `supported_reasoning_efforts`, and `codex-rs/core/src/client.rs` maps logical `Ultra` to provider `Max`.
- Public identifiers: PASS against official OpenAI documentation at https://developers.openai.com/api/docs/guides/latest-model and the Codex source above.
- Fresh focused Vitest: `node scripts/run-vitest.mjs extensions/clawrouter/provider-catalog.test.ts extensions/clawrouter/index.test.ts` passed 21 tests across 2 files.
- `git diff --check origin/main...HEAD` passed.
- Fresh changed gate: the normal `node scripts/check-changed.mjs -- ...` route could not start its remote backend because Blacksmith/Testbox and managed Crabbox broker authentication were unavailable. The trusted-source local fallback completed successfully with extension typechecks, lint, formatting, plugin boundaries, guards, dead-code checks, the database-first guard, and import-cycle checks.
- Fresh Codex autoreview on the committed branch reported no accepted or actionable findings.
- Existing source-blind public CLI proof against a disposable catalog rejected `minimal` with allowed choices `off`/`low`/`medium`/`high`/`xhigh`/`max`/`ultra`; confirmed `xhigh`, `max`, and `ultra` reached provider dispatch; confirmed absent metadata retained the generic `minimal` fallback; and bounded malformed metadata to valid choices only.
- Fresh cross-repository attempt: the merged Claw Router local Worker completed its full smoke, and the exact OpenClaw candidate consumed its authenticated local catalog. A generated local credential returned an executable OpenAI catalog with the exact GPT-5.6 effort field and no GPT-5.5 field. The agent-dispatch half did not complete: `agent exec` stopped before thinking validation with `prepared model runtime publication timed out`. No fresh `minimal` rejection or `xhigh`/`max` dispatch is claimed from that attempt; the prior source-blind CLI proof remains the behavior evidence for those cases.
- Owner decision: the maintainer explicitly authorized landing both paired PRs. The exact-head ClawSweeper review found no actionable code defect; its producer, sibling Codex, latest-move, and protected-owner evidence items are addressed above. Because the reviewed head is unchanged, no rating-only re-review was requested.
- Deployment status: not deployed. No release or deployment is part of this PR.
