### PR TITLE
fix(qa): prevent stale evidence after failed suite cleanup

### DIFF
--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -356,10 +356,10 @@ jobs:
           timeout_outcome="none"
           if [[ "$qa_exit_code" -eq 137 ]] && grep -Eq "^timeout: sending signal KILL to command '[A-Za-z0-9_./+-]+'$" "$timeout_supervisor_log"; then
             timeout_outcome="kill"
-            echo "::warning::QA profile '${QA_PROFILE}' timed out after 110 minutes and required SIGKILL after the 30-second grace period; partial evidence will still be uploaded."
+            echo "::warning::QA profile '${QA_PROFILE}' timed out after 110 minutes and required SIGKILL after the 30-second grace period; canonical qa-evidence.json was not published, but diagnostic artifacts will still be uploaded."
           elif [[ "$qa_exit_code" -eq 124 ]] && grep -Eq "^timeout: sending signal TERM to command '[A-Za-z0-9_./+-]+'$" "$timeout_supervisor_log"; then
             timeout_outcome="term"
-            echo "::warning::QA profile '${QA_PROFILE}' timed out after 110 minutes and was terminated; partial evidence will still be uploaded."
+            echo "::warning::QA profile '${QA_PROFILE}' timed out after 110 minutes and was terminated; canonical qa-evidence.json was not published, but diagnostic artifacts will still be uploaded."
           fi
 
           QA_EXIT_CODE="$qa_exit_code" TIMEOUT_OUTCOME="$timeout_outcome" OUTPUT_DIR="$output_dir" \

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -43,6 +43,30 @@ vi.mock("./suite-launch.runtime.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./suite-launch.runtime.js")>()),
   runQaFlowSuiteFromRuntime,
   runQaSuite,
+  runQaSuiteCore: async (
+    params: QaSuiteRunParams,
+    target: { canonicalPath: string; stagedPath: string },
+  ) => {
+    const result = await runQaSuite(params);
+    const evidencePath = result?.result.evidencePath;
+    await fs.mkdir(path.dirname(target.stagedPath), { recursive: true });
+    if (evidencePath) {
+      try {
+        if (evidencePath === target.canonicalPath) {
+          await fs.rename(evidencePath, target.stagedPath);
+        } else {
+          await fs.copyFile(evidencePath, target.stagedPath);
+        }
+        return result;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
+      }
+    }
+    await fs.writeFile(target.stagedPath, `${JSON.stringify(makeQaEvidence(), null, 2)}\n`, "utf8");
+    return result;
+  },
 }));
 
 vi.mock("./character-eval.js", () => ({
@@ -248,6 +272,8 @@ function executionCellsForSuiteParams(params?: QaSuiteRunParams) {
 describe("qa cli runtime", () => {
   let stdoutWrite: ReturnType<typeof vi.spyOn>;
   let stderrWrite: ReturnType<typeof vi.spyOn>;
+  let profileArtifactsDir: string;
+  let profileEvidencePath: string;
   let suiteArtifactsDir: string;
   let suiteEvidencePath: string;
   let suiteReportPath: string;
@@ -260,6 +286,10 @@ describe("qa cli runtime", () => {
     suiteEvidencePath = path.join(suiteArtifactsDir, "qa-evidence.json");
     suiteReportPath = path.join(suiteArtifactsDir, "qa-suite-report.md");
     suiteSummaryPath = path.join(suiteArtifactsDir, "qa-suite-summary.json");
+    profileArtifactsDir = path.join(suiteArtifactsDir, "profile");
+    profileEvidencePath = path.join(profileArtifactsDir, QA_EVIDENCE_FILENAME);
+    await fs.mkdir(profileArtifactsDir, { recursive: true });
+    await fs.writeFile(profileEvidencePath, "stale profile evidence\n", "utf8");
     telegramArtifactsDir = await fs.mkdtemp(path.join(os.tmpdir(), "qa-telegram-runtime-"));
     telegramSummaryPath = path.join(telegramArtifactsDir, QA_EVIDENCE_FILENAME);
     await fs.writeFile(suiteReportPath, "# QA Suite Report\n", "utf8");
@@ -731,8 +761,8 @@ describe("qa cli runtime", () => {
       });
 
       await runQaProfileCommand({
-        repoRoot: "/tmp/openclaw-repo",
-        outputDir: ".artifacts/qa-e2e/smoke-ci",
+        repoRoot: suiteArtifactsDir,
+        outputDir: "profile",
         profile: "smoke-ci",
         surface: "telegram",
         category: "telegram.native-controls-and-approvals",
@@ -745,8 +775,8 @@ describe("qa cli runtime", () => {
 
       const suiteArgs = mockFirstObjectArg(runQaSuite);
       expectFields(suiteArgs, {
-        repoRoot: path.resolve("/tmp/openclaw-repo"),
-        outputDir: path.resolve("/tmp/openclaw-repo", ".artifacts/qa-e2e/smoke-ci"),
+        repoRoot: suiteArtifactsDir,
+        outputDir: profileArtifactsDir,
         transportId: "qa-channel",
         channelDriver: "crabline",
         providerMode: "mock-openai",
@@ -759,7 +789,7 @@ describe("qa cli runtime", () => {
       });
       expect(suiteArgs.scenarioIds).toEqual(["telegram-commands-command"]);
       expect(process.env.OPENCLAW_QA_PROFILE).toBe("release");
-      const evidence = JSON.parse(await fs.readFile(suiteEvidencePath, "utf8")) as {
+      const evidence = JSON.parse(await fs.readFile(profileEvidencePath, "utf8")) as {
         evidenceMode?: unknown;
         entries?: unknown[];
         profile?: unknown;
@@ -803,7 +833,7 @@ describe("qa cli runtime", () => {
       expect(evidence.entries?.[0]).not.toHaveProperty("execution");
       expect(JSON.stringify(evidence.scorecard)).not.toContain("telegram-commands-command");
       expectWriteContains(stdoutWrite, "QA run profile: smoke-ci; categories: 1; scenarios:");
-      expectWriteContains(stdoutWrite, `QA profile scorecard: ${suiteEvidencePath}`);
+      expectWriteContains(stdoutWrite, `QA profile scorecard: ${profileEvidencePath}`);
     } finally {
       if (previousProfile === undefined) {
         delete process.env.OPENCLAW_QA_PROFILE;
@@ -815,7 +845,8 @@ describe("qa cli runtime", () => {
 
   it("passes non-Crabline profile channel drivers as declarative suite metadata", async () => {
     await runQaProfileCommand({
-      repoRoot: "/tmp/openclaw-repo",
+      repoRoot: suiteArtifactsDir,
+      outputDir: "profile",
       profile: "release",
       surface: "agent-runtime",
       category: "agent-runtime.agent-turn-execution",
@@ -829,7 +860,8 @@ describe("qa cli runtime", () => {
 
   it("keeps portable channel scenarios in driver-selected profile runs", async () => {
     await runQaProfileCommand({
-      repoRoot: "/tmp/openclaw-repo",
+      repoRoot: suiteArtifactsDir,
+      outputDir: "profile",
       profile: "release",
       surface: "channels",
       providerMode: "mock-openai",
@@ -847,7 +879,8 @@ describe("qa cli runtime", () => {
 
   it("runs the all profile through the live taxonomy profile path", async () => {
     await runQaProfileCommand({
-      repoRoot: "/tmp/openclaw-repo",
+      repoRoot: suiteArtifactsDir,
+      outputDir: "profile",
       profile: "all",
       surface: "agent-runtime",
       category: "agent-runtime.agent-turn-execution",
@@ -906,7 +939,8 @@ describe("qa cli runtime", () => {
 
       try {
         await runQaProfileCommand({
-          repoRoot: "/tmp/openclaw-repo",
+          repoRoot: suiteArtifactsDir,
+          outputDir: "profile",
           profile: "all",
           surface: "media",
           category: "media.media-generation",
@@ -935,7 +969,8 @@ describe("qa cli runtime", () => {
     });
 
     await runQaProfileCommand({
-      repoRoot: "/tmp/openclaw-repo",
+      repoRoot: suiteArtifactsDir,
+      outputDir: "profile",
       profile: "smoke-ci",
     });
 
@@ -960,7 +995,8 @@ describe("qa cli runtime", () => {
   it("rejects explicit profile selections incompatible with the profile channel", async () => {
     await expect(
       runQaProfileCommand({
-        repoRoot: "/tmp/openclaw-repo",
+        repoRoot: suiteArtifactsDir,
+        outputDir: "profile",
         profile: "smoke-ci",
         scenarioIds: ["control-ui-qa-channel-image-roundtrip"],
       }),
@@ -973,7 +1009,8 @@ describe("qa cli runtime", () => {
 
   it("dispatches the Matrix restart scenario through the Crabline smoke profile", async () => {
     await runQaProfileCommand({
-      repoRoot: "/tmp/openclaw-repo",
+      repoRoot: suiteArtifactsDir,
+      outputDir: "profile",
       profile: "smoke-ci",
       scenarioIds: ["matrix-restart-resume"],
     });
@@ -989,7 +1026,8 @@ describe("qa cli runtime", () => {
   it("rejects qa profile runs that do not match taxonomy categories", async () => {
     await expect(
       runQaProfileCommand({
-        repoRoot: "/tmp/openclaw-repo",
+        repoRoot: suiteArtifactsDir,
+        outputDir: "profile",
         profile: "smoke-ci",
         surface: "unknown-surface",
       }),
@@ -1002,7 +1040,8 @@ describe("qa cli runtime", () => {
   it("rejects qa profile scenario filters outside the selected taxonomy categories", async () => {
     await expect(
       runQaProfileCommand({
-        repoRoot: "/tmp/openclaw-repo",
+        repoRoot: suiteArtifactsDir,
+        outputDir: "profile",
         profile: "smoke-ci",
         category: "channels.outbound-delivery-and-reply-pipeline",
         scenarioIds: ["not-a-real-scenario"],
@@ -1016,13 +1055,57 @@ describe("qa cli runtime", () => {
   it("rejects qa profile runs whose profile is not declared in taxonomy.yaml", async () => {
     await expect(
       runQaProfileCommand({
-        repoRoot: "/tmp/openclaw-repo",
+        repoRoot: suiteArtifactsDir,
+        outputDir: "profile",
         profile: "nightly",
       }),
     ).rejects.toThrow(
       '--qa-profile must be one of smoke-ci, personal-agent, observability, release, all, got "nightly".',
     );
     expect(runQaSuite).not.toHaveBeenCalled();
+  });
+
+  it("invalidates stale profile evidence before planning fails", async () => {
+    const planningError = new Error("profile planning failed");
+    readQaScenarioPack.mockImplementationOnce(() => {
+      throw planningError;
+    });
+
+    await expect(
+      runQaProfileCommand({
+        repoRoot: suiteArtifactsDir,
+        outputDir: "profile",
+        profile: "smoke-ci",
+      }),
+    ).rejects.toBe(planningError);
+    await expect(fs.access(profileEvidencePath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(runQaSuite).not.toHaveBeenCalled();
+  });
+
+  it("does not restore stale profile evidence when scorecard attachment fails", async () => {
+    runQaSuite.mockImplementationOnce(async (params) => {
+      await fs.writeFile(suiteEvidencePath, "not-json\n", "utf8");
+      return flowSuiteRuntimeResult({
+        observedCells: executionCellsForSuiteParams(params),
+        reportPath: suiteReportPath,
+        summaryPath: suiteSummaryPath,
+      });
+    });
+
+    await expect(
+      runQaProfileCommand({
+        repoRoot: suiteArtifactsDir,
+        outputDir: "profile",
+        profile: "release",
+        surface: "agent-runtime",
+        category: "agent-runtime.agent-turn-execution",
+        providerMode: "mock-openai",
+      }),
+    ).rejects.toBeInstanceOf(SyntaxError);
+    await expect(fs.access(profileEvidencePath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(
+      (await fs.readdir(profileArtifactsDir)).filter((entry) => entry.endsWith(".staged")),
+    ).toEqual([]);
   });
 
   it("resolves suite repo-root-relative paths before dispatching", async () => {

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -43,29 +43,20 @@ vi.mock("./suite-launch.runtime.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./suite-launch.runtime.js")>()),
   runQaFlowSuiteFromRuntime,
   runQaSuite,
-  runQaSuiteCore: async (
-    params: QaSuiteRunParams,
-    target: { canonicalPath: string; stagedPath: string },
-  ) => {
+  runQaSuiteCore: async (params: QaSuiteRunParams) => {
     const result = await runQaSuite(params);
     const evidencePath = result?.result.evidencePath;
-    await fs.mkdir(path.dirname(target.stagedPath), { recursive: true });
+    let evidence = makeQaEvidence();
     if (evidencePath) {
       try {
-        if (evidencePath === target.canonicalPath) {
-          await fs.rename(evidencePath, target.stagedPath);
-        } else {
-          await fs.copyFile(evidencePath, target.stagedPath);
-        }
-        return result;
+        evidence = JSON.parse(await fs.readFile(evidencePath, "utf8"));
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
           throw error;
         }
       }
     }
-    await fs.writeFile(target.stagedPath, `${JSON.stringify(makeQaEvidence(), null, 2)}\n`, "utf8");
-    return result;
+    return Object.freeze({ result, evidence, complete: vi.fn() });
   },
 }));
 
@@ -1106,6 +1097,8 @@ describe("qa cli runtime", () => {
     expect(
       (await fs.readdir(profileArtifactsDir)).filter((entry) => entry.endsWith(".staged")),
     ).toEqual([]);
+    expect(stdoutWrite.mock.calls.flat().join("")).not.toContain("QA profile scorecard:");
+    expect(stdoutWrite.mock.calls.flat().join("")).not.toContain("QA suite evidence:");
   });
 
   it("resolves suite repo-root-relative paths before dispatching", async () => {

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -97,9 +97,11 @@ import {
   type QaScorecardEvidenceMode,
 } from "./scorecard-taxonomy.js";
 import { isQaSelfCheckSuccessful } from "./self-check.js";
+import { runQaSuiteEvidenceLifecycle } from "./suite-evidence-lifecycle.js";
 import {
   runQaFlowSuiteFromRuntime,
   runQaSuite,
+  runQaSuiteCore,
   runQaSuiteWithInfraRetry,
 } from "./suite-launch.runtime.js";
 import { resolveQaSuiteScenarioChannel, resolveQaSuiteScenarioChannels } from "./suite-planning.js";
@@ -626,144 +628,146 @@ export async function runQaLabSelfCheckCommand(opts: QaLabSelfCheckCommandOption
 }
 
 export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
-  const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
-  const scenarioPack = readQaScenarioPack();
-  const scorecardReport = readQaScorecardTaxonomyReport(scenarioPack.scenarios);
-  const profile = normalizeQaRunProfile(
-    opts.profile,
-    scorecardReport.profiles.map((entry) => entry.id),
-  );
-  const profileReport = scorecardReport.profiles.find((entry) => entry.id === profile);
-  if (!profileReport) {
-    throw new Error(`taxonomy.yaml does not define QA run profile ${profile}.`);
-  }
-  const membership = resolveQaRunProfileMembership(
-    {
-      profile,
-      surface: opts.surface,
-      category: opts.category,
-      scenarioIds: opts.scenarioIds,
-    },
-    { scenarios: scenarioPack.scenarios, scorecardReport },
-  );
-  const categories = membership.categories;
-  if (categories.length === 0) {
-    throw new Error(formatQaRunProfileNoMatchMessage(opts));
-  }
+  const evidencePath = await runQaSuiteEvidenceLifecycle(opts, async (resolved) => {
+    const { repoRoot, outputDir, target } = resolved;
+    const scenarioPack = readQaScenarioPack();
+    const scorecardReport = readQaScorecardTaxonomyReport(scenarioPack.scenarios);
+    const profile = normalizeQaRunProfile(
+      opts.profile,
+      scorecardReport.profiles.map((entry) => entry.id),
+    );
+    const profileReport = scorecardReport.profiles.find((entry) => entry.id === profile);
+    if (!profileReport) {
+      throw new Error(`taxonomy.yaml does not define QA run profile ${profile}.`);
+    }
+    const membership = resolveQaRunProfileMembership(
+      {
+        profile,
+        surface: opts.surface,
+        category: opts.category,
+        scenarioIds: opts.scenarioIds,
+      },
+      { scenarios: scenarioPack.scenarios, scorecardReport },
+    );
+    const categories = membership.categories;
+    if (categories.length === 0) {
+      throw new Error(formatQaRunProfileNoMatchMessage(opts));
+    }
 
-  const requestedScenarioIds = uniqueStrings(
-    (opts.scenarioIds ?? []).map((scenarioId) => scenarioId.trim()).filter(Boolean),
-  );
-  const taxonomyScenarios = membership.selectedScenarios;
-  const missingScenarioIds = membership.excludedScenarioIds;
-  const providerMode = opts.providerMode ?? defaultQaRunProfileProviderMode(profile);
-  const normalizedProviderMode = normalizeQaProviderMode(providerMode);
-  const primaryModel = opts.primaryModel?.trim() || defaultQaModelForMode(normalizedProviderMode);
-  const missingScenarioIdSet = new Set(missingScenarioIds);
-  const executionScenarios =
-    missingScenarioIds.length > 0
-      ? [
-          ...taxonomyScenarios,
-          ...scenarioPack.scenarios.filter((scenario) => missingScenarioIdSet.has(scenario.id)),
-        ]
-      : taxonomyScenarios;
-  const liveAdapterFactories =
-    profileReport.channelDriver === "live" ? listLiveTransportQaAdapterFactories() : undefined;
-  const executionSelection = resolveQaRunProfileExecutionSelection({
-    scenarios: executionScenarios,
-    providerMode: normalizedProviderMode,
-    primaryModel,
-    channelDriver: profileReport.channelDriver,
-    defaultChannel:
-      profileReport.channelDriver === "crabline" ? OPENCLAW_CRABLINE_DEFAULT_CHANNEL : undefined,
-    supportsChannel:
-      profileReport.channelDriver === "crabline" ? isCrablineServerChannel : undefined,
-    resolveModuleFlowSupport:
-      profileReport.channelDriver === "live"
-        ? (channel) =>
-            channel
-              ? qaTransportSupportsModuleFlows(liveAdapterFactories, {
-                  channelId: channel,
-                  driver: "live",
-                })
-              : false
-        : undefined,
-  });
-  if (requestedScenarioIds.length > 0 && executionSelection.excludedScenarios.length > 0) {
-    const exclusions = executionSelection.excludedScenarios
-      .map(({ scenario, reasons }) => `${scenario.id} (${reasons.join(", ")})`)
-      .join(", ");
-    throw new Error(
-      `qa run --qa-profile ${profile} cannot run explicitly selected scenario(s): ${exclusions}.`,
+    const requestedScenarioIds = uniqueStrings(
+      (opts.scenarioIds ?? []).map((scenarioId) => scenarioId.trim()).filter(Boolean),
     );
-  }
-  if (requestedScenarioIds.length > 0 && taxonomyScenarios.length === 0) {
-    throw new Error(
-      `qa run did not find taxonomy scenarios for ${formatQaRunProfileFilterList(opts)} --scenario ${requestedScenarioIds.join(",")}.`,
-    );
-  }
-  if (missingScenarioIds.length > 0) {
-    throw new Error(
-      `qa run did not find taxonomy scenarios for ${formatQaRunProfileFilterList(opts)} --scenario ${missingScenarioIds.join(",")}.`,
-    );
-  }
-  const scenarios = executionSelection.selectedScenarios;
-  if (scenarios.length === 0) {
-    throw new Error(
-      `qa run --qa-profile ${profile} did not resolve any executable QA scenarios for provider mode ${normalizedProviderMode}.`,
-    );
-  }
-
-  process.stdout.write(
-    `QA run profile: ${profile}; categories: ${categories.length}; scenarios: ${scenarios.length}\n`,
-  );
-  let evidencePath: string | undefined;
-  let expectedCells: QaProfileEvidencePlan["expectedCells"] = [];
-  let observedCells: QaProfileEvidencePlan["observedCells"] = [];
-  await withTemporaryQaProfileEnv(profile, async () => {
-    const suiteResult = await runQaSuiteCommand({
-      repoRoot,
-      outputDir: opts.outputDir,
-      evidenceMode: opts.evidenceMode,
-      transportId: opts.transportId,
-      providerMode,
-      primaryModel: opts.primaryModel,
-      alternateModel: opts.alternateModel,
-      fastMode: opts.fastMode,
-      failFast: opts.failFast,
-      scenarioIds: scenarios.map((scenario) => scenario.id),
-      explicitScenarioSelection: requestedScenarioIds.length > 0,
-      concurrency: opts.concurrency,
-      allowFailures: opts.allowFailures,
+    const taxonomyScenarios = membership.selectedScenarios;
+    const missingScenarioIds = membership.excludedScenarioIds;
+    const providerMode = opts.providerMode ?? defaultQaRunProfileProviderMode(profile);
+    const normalizedProviderMode = normalizeQaProviderMode(providerMode);
+    const primaryModel = opts.primaryModel?.trim() || defaultQaModelForMode(normalizedProviderMode);
+    const missingScenarioIdSet = new Set(missingScenarioIds);
+    const executionScenarios =
+      missingScenarioIds.length > 0
+        ? [
+            ...taxonomyScenarios,
+            ...scenarioPack.scenarios.filter((scenario) => missingScenarioIdSet.has(scenario.id)),
+          ]
+        : taxonomyScenarios;
+    const liveAdapterFactories =
+      profileReport.channelDriver === "live" ? listLiveTransportQaAdapterFactories() : undefined;
+    const executionSelection = resolveQaRunProfileExecutionSelection({
+      scenarios: executionScenarios,
+      providerMode: normalizedProviderMode,
+      primaryModel,
       channelDriver: profileReport.channelDriver,
-      expandScenarioChannels: true,
+      defaultChannel:
+        profileReport.channelDriver === "crabline" ? OPENCLAW_CRABLINE_DEFAULT_CHANNEL : undefined,
+      supportsChannel:
+        profileReport.channelDriver === "crabline" ? isCrablineServerChannel : undefined,
+      resolveModuleFlowSupport:
+        profileReport.channelDriver === "live"
+          ? (channel) =>
+              channel
+                ? qaTransportSupportsModuleFlows(liveAdapterFactories, {
+                    channelId: channel,
+                    driver: "live",
+                  })
+                : false
+          : undefined,
     });
-    evidencePath =
-      suiteResult && "evidencePath" in suiteResult ? suiteResult.evidencePath : undefined;
-    expectedCells = suiteResult && "expectedCells" in suiteResult ? suiteResult.expectedCells : [];
-    observedCells = suiteResult && "observedCells" in suiteResult ? suiteResult.observedCells : [];
-  });
-  if (!evidencePath) {
-    throw new Error("qa run --qa-profile did not produce qa-evidence.json.");
-  }
-  const profilePlan = qaProfileEvidencePlan.build({
-    profile,
-    membershipScenarios: taxonomyScenarios,
-    selectedScenarios: scenarios,
-    excludedScenarios: executionSelection.excludedScenarios,
-    expectedCells,
-    observedCells,
-  });
-  await attachQaProfileScorecardEvidenceToFile({
-    evidencePath,
-    evidenceMode: opts.evidenceMode,
-    profile,
-    profilePlan,
-    filters: {
-      surface: opts.surface,
-      category: opts.category,
-    },
-    categories,
+    if (requestedScenarioIds.length > 0 && executionSelection.excludedScenarios.length > 0) {
+      const exclusions = executionSelection.excludedScenarios
+        .map(({ scenario, reasons }) => `${scenario.id} (${reasons.join(", ")})`)
+        .join(", ");
+      throw new Error(
+        `qa run --qa-profile ${profile} cannot run explicitly selected scenario(s): ${exclusions}.`,
+      );
+    }
+    if (requestedScenarioIds.length > 0 && taxonomyScenarios.length === 0) {
+      throw new Error(
+        `qa run did not find taxonomy scenarios for ${formatQaRunProfileFilterList(opts)} --scenario ${requestedScenarioIds.join(",")}.`,
+      );
+    }
+    if (missingScenarioIds.length > 0) {
+      throw new Error(
+        `qa run did not find taxonomy scenarios for ${formatQaRunProfileFilterList(opts)} --scenario ${missingScenarioIds.join(",")}.`,
+      );
+    }
+    const scenarios = executionSelection.selectedScenarios;
+    if (scenarios.length === 0) {
+      throw new Error(
+        `qa run --qa-profile ${profile} did not resolve any executable QA scenarios for provider mode ${normalizedProviderMode}.`,
+      );
+    }
+
+    process.stdout.write(
+      `QA run profile: ${profile}; categories: ${categories.length}; scenarios: ${scenarios.length}\n`,
+    );
+    let expectedCells: QaProfileEvidencePlan["expectedCells"] = [];
+    let observedCells: QaProfileEvidencePlan["observedCells"] = [];
+    await withTemporaryQaProfileEnv(profile, async () => {
+      const suiteResult = await runQaSuiteCommandCore(
+        {
+          repoRoot,
+          outputDir: opts.outputDir,
+          evidenceMode: opts.evidenceMode,
+          transportId: opts.transportId,
+          providerMode,
+          primaryModel: opts.primaryModel,
+          alternateModel: opts.alternateModel,
+          fastMode: opts.fastMode,
+          failFast: opts.failFast,
+          scenarioIds: scenarios.map((scenario) => scenario.id),
+          explicitScenarioSelection: requestedScenarioIds.length > 0,
+          concurrency: opts.concurrency,
+          allowFailures: opts.allowFailures,
+          channelDriver: profileReport.channelDriver,
+          expandScenarioChannels: true,
+        },
+        (params) => runQaSuiteCore({ ...params, outputDir }, target),
+      );
+      expectedCells =
+        suiteResult && "expectedCells" in suiteResult ? suiteResult.expectedCells : [];
+      observedCells =
+        suiteResult && "observedCells" in suiteResult ? suiteResult.observedCells : [];
+    });
+    const profilePlan = qaProfileEvidencePlan.build({
+      profile,
+      membershipScenarios: taxonomyScenarios,
+      selectedScenarios: scenarios,
+      excludedScenarios: executionSelection.excludedScenarios,
+      expectedCells,
+      observedCells,
+    });
+    await attachQaProfileScorecardEvidenceToFile({
+      evidencePath: target.stagedPath,
+      evidenceMode: opts.evidenceMode,
+      profile,
+      profilePlan,
+      filters: {
+        surface: opts.surface,
+        category: opts.category,
+      },
+      categories,
+    });
+    return target.canonicalPath;
   });
   process.stdout.write(`QA profile scorecard: ${evidencePath}\n`);
 }
@@ -854,7 +858,12 @@ function resolveQaReportOnlyOptionalScenarioNames(params: {
   return resolveQaReportOnlyOptionalScenarioNamesFromCatalog(readQaScenarioPack().scenarios);
 }
 
-export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
+async function runQaSuiteCommandCore(
+  opts: QaSuiteCommandOptions,
+  runSuite: (
+    params: NonNullable<Parameters<typeof runQaSuite>[0]>,
+  ) => ReturnType<typeof runQaSuite>,
+) {
   const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
   const transportId = normalizeQaTransportId(opts.transportId);
   const runner = (opts.runner ?? "host").trim().toLowerCase();
@@ -1038,7 +1047,7 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
     return undefined;
   }
   const thinkingDefault = parseQaThinkingLevel("--thinking", opts.thinking);
-  const runtimeResult = await runQaSuite({
+  const runtimeResult = await runSuite({
     repoRoot,
     outputDir: resolveRepoRelativeOutputDir(repoRoot, opts.outputDir),
     evidenceMode: opts.evidenceMode,
@@ -1129,6 +1138,10 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
     }
   }
   return undefined;
+}
+
+export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
+  return await runQaSuiteCommandCore(opts, runQaSuite);
 }
 
 export async function runQaParityReportCommand(opts: {

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -628,8 +628,7 @@ export async function runQaLabSelfCheckCommand(opts: QaLabSelfCheckCommandOption
 }
 
 export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
-  const evidencePath = await runQaSuiteEvidenceLifecycle(opts, async (resolved) => {
-    const { repoRoot, outputDir, target } = resolved;
+  await runQaSuiteEvidenceLifecycle(opts, async ({ repoRoot, outputDir }) => {
     const scenarioPack = readQaScenarioPack();
     const scorecardReport = readQaScorecardTaxonomyReport(scenarioPack.scenarios);
     const profile = normalizeQaRunProfile(
@@ -720,10 +719,10 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
     process.stdout.write(
       `QA run profile: ${profile}; categories: ${categories.length}; scenarios: ${scenarios.length}\n`,
     );
-    let expectedCells: QaProfileEvidencePlan["expectedCells"] = [];
-    let observedCells: QaProfileEvidencePlan["observedCells"] = [];
-    await withTemporaryQaProfileEnv(profile, async () => {
-      const suiteResult = await runQaSuiteCommandCore(
+    let suiteCompletion: Awaited<ReturnType<typeof runQaSuiteCore>> | undefined;
+    let commandCompletion: (() => Promise<void>) | undefined;
+    const suiteResult = await withTemporaryQaProfileEnv(profile, async () =>
+      runQaSuiteCommandCore(
         {
           repoRoot,
           outputDir: opts.outputDir,
@@ -741,35 +740,50 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
           channelDriver: profileReport.channelDriver,
           expandScenarioChannels: true,
         },
-        (params) => runQaSuiteCore({ ...params, outputDir }, target),
-      );
-      expectedCells =
-        suiteResult && "expectedCells" in suiteResult ? suiteResult.expectedCells : [];
-      observedCells =
-        suiteResult && "observedCells" in suiteResult ? suiteResult.observedCells : [];
-    });
+        async (params) => {
+          suiteCompletion = await runQaSuiteCore({ ...params, repoRoot, outputDir });
+          return suiteCompletion.result;
+        },
+        (complete) => {
+          commandCompletion = complete;
+        },
+      ),
+    );
     const profilePlan = qaProfileEvidencePlan.build({
       profile,
       membershipScenarios: taxonomyScenarios,
       selectedScenarios: scenarios,
       excludedScenarios: executionSelection.excludedScenarios,
-      expectedCells,
-      observedCells,
+      expectedCells: suiteResult?.expectedCells ?? [],
+      observedCells: suiteResult?.observedCells ?? [],
     });
-    await attachQaProfileScorecardEvidenceToFile({
-      evidencePath: target.stagedPath,
-      evidenceMode: opts.evidenceMode,
-      profile,
-      profilePlan,
-      filters: {
-        surface: opts.surface,
-        category: opts.category,
+    const completion = suiteCompletion;
+    const completeCommand = commandCompletion;
+    if (!completion || !completeCommand) {
+      throw new Error("QA profile suite completed without deferred publication state");
+    }
+    return Object.freeze({
+      evidence: completion.evidence,
+      result: undefined,
+      transformStagedEvidence: (stagedPath) =>
+        attachQaProfileScorecardEvidenceToFile({
+          evidencePath: stagedPath,
+          evidenceMode: opts.evidenceMode,
+          profile,
+          profilePlan,
+          filters: {
+            surface: opts.surface,
+            category: opts.category,
+          },
+          categories,
+        }),
+      complete: async () => {
+        await completion.complete();
+        await completeCommand();
+        process.stdout.write(`QA profile scorecard: ${path.join(outputDir, "qa-evidence.json")}\n`);
       },
-      categories,
     });
-    return target.canonicalPath;
   });
-  process.stdout.write(`QA profile scorecard: ${evidencePath}\n`);
 }
 
 function selectQaScenarioDefinitionsForChannelResolution(params: {
@@ -863,6 +877,7 @@ async function runQaSuiteCommandCore(
   runSuite: (
     params: NonNullable<Parameters<typeof runQaSuite>[0]>,
   ) => ReturnType<typeof runQaSuite>,
+  deferCompletion?: (complete: () => Promise<void>) => void,
 ) {
   const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
   const transportId = normalizeQaTransportId(opts.transportId);
@@ -1086,58 +1101,38 @@ async function runQaSuiteCommandCore(
         : {}),
     ...(runtimePair ? { runtimePair } : {}),
   });
-  switch (runtimeResult.executionKind) {
-    case "suite": {
-      const result = runtimeResult.result;
-      process.stdout.write(`QA suite report: ${result.reportPath}\n`);
-      process.stdout.write(`QA suite evidence: ${result.evidencePath}\n`);
-      process.stdout.write(`QA suite summary: ${result.summaryPath}\n`);
-      const blockingScenarioCount = await readQaSuiteFailedOrSkippedScenarioCountFromFile(
-        result.summaryPath,
-        {
-          optionalScenarioNames: resolveQaReportOnlyOptionalScenarioNames({
-            scenarioIds,
-            explicitScenarioSelection: opts.explicitScenarioSelection,
-          }),
-          requireExecutedScenario: allowFailures,
-        },
-      );
-      if (!allowFailures && blockingScenarioCount > 0) {
-        process.exitCode = 1;
-      }
-      return {
-        ...result,
-        expectedCells: runtimeResult.expectedCells,
-        observedCells: runtimeResult.observedCells,
-      };
+  const result = runtimeResult.result;
+  const complete = async () => {
+    if (runtimeResult.executionKind === "flow") {
+      process.stdout.write(`QA suite watch: ${runtimeResult.result.watchUrl}\n`);
     }
-    case "flow": {
-      const result = runtimeResult.result;
-      process.stdout.write(`QA suite watch: ${result.watchUrl}\n`);
-      process.stdout.write(`QA suite report: ${result.reportPath}\n`);
-      process.stdout.write(`QA suite evidence: ${result.evidencePath}\n`);
-      process.stdout.write(`QA suite summary: ${result.summaryPath}\n`);
-      const blockingScenarioCount = await readQaSuiteFailedOrSkippedScenarioCountFromFile(
-        result.summaryPath,
-        {
-          optionalScenarioNames: resolveQaReportOnlyOptionalScenarioNames({
-            scenarioIds,
-            explicitScenarioSelection: opts.explicitScenarioSelection,
-          }),
-          requireExecutedScenario: allowFailures,
-        },
-      );
-      if (!allowFailures && blockingScenarioCount > 0) {
-        process.exitCode = 1;
-      }
-      return {
-        ...result,
-        expectedCells: runtimeResult.expectedCells,
-        observedCells: runtimeResult.observedCells,
-      };
+    process.stdout.write(`QA suite report: ${result.reportPath}\n`);
+    process.stdout.write(`QA suite evidence: ${result.evidencePath}\n`);
+    process.stdout.write(`QA suite summary: ${result.summaryPath}\n`);
+    const blockingScenarioCount = await readQaSuiteFailedOrSkippedScenarioCountFromFile(
+      result.summaryPath,
+      {
+        optionalScenarioNames: resolveQaReportOnlyOptionalScenarioNames({
+          scenarioIds,
+          explicitScenarioSelection: opts.explicitScenarioSelection,
+        }),
+        requireExecutedScenario: allowFailures,
+      },
+    );
+    if (!allowFailures && blockingScenarioCount > 0) {
+      process.exitCode = 1;
     }
+  };
+  if (deferCompletion) {
+    deferCompletion(complete);
+  } else {
+    await complete();
   }
-  return undefined;
+  return {
+    ...result,
+    expectedCells: runtimeResult.expectedCells,
+    observedCells: runtimeResult.observedCells,
+  };
 }
 
 export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {

--- a/extensions/qa-lab/src/suite-artifacts.ts
+++ b/extensions/qa-lab/src/suite-artifacts.ts
@@ -15,6 +15,7 @@ import { renderQaMarkdownReport, type QaReportScenario } from "./report.js";
 import type { RuntimeId } from "./runtime-parity.js";
 import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 import type { QaScorecardEvidenceMode } from "./scorecard-taxonomy.js";
+import type { QaSuiteEvidenceTarget } from "./suite-evidence-lifecycle.js";
 import { splitModelRef } from "./suite-planning.js";
 import { countQaSuiteFailedScenarios, type QaSuiteSummaryJson } from "./suite-summary.js";
 import { createQaSuiteReportNotes } from "./suite-support.js";
@@ -133,13 +134,15 @@ export async function writeQaSuiteArtifacts(params: {
   scenarioIds?: readonly string[];
   runtimePair?: [RuntimeId, RuntimeId];
   writeEvidenceFile?: boolean;
+  evidenceTarget?: QaSuiteEvidenceTarget;
   runCrablineChannelDriverSmoke?: (
     params: Parameters<QaCrablineRuntime["runOpenClawCrablineChannelDriverSmoke"]>[0],
   ) => Promise<QaCrablineChannelDriverSmokeResult>;
 }) {
   const reportPath = path.join(params.outputDir, "qa-suite-report.md");
   const summaryPath = path.join(params.outputDir, "qa-suite-summary.json");
-  const evidencePath = path.join(params.outputDir, QA_EVIDENCE_FILENAME);
+  const evidencePath =
+    params.evidenceTarget?.canonicalPath ?? path.join(params.outputDir, QA_EVIDENCE_FILENAME);
   const crablineChannelDriverSelection = params.channelDriverSelection;
   // Non-Crabline package acceptance mounts this source without plugin-local
   // dependencies. Keep the owner runtime outside every unrelated live path.
@@ -266,7 +269,11 @@ export async function writeQaSuiteArtifacts(params: {
   const writeEvidenceFile = params.writeEvidenceFile ?? true;
   await fs.writeFile(reportPath, report, "utf8");
   if (evidence && writeEvidenceFile) {
-    await fs.writeFile(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
+    await fs.writeFile(
+      params.evidenceTarget?.stagedPath ?? evidencePath,
+      `${JSON.stringify(evidence, null, 2)}\n`,
+      "utf8",
+    );
   }
   await fs.writeFile(
     summaryPath,
@@ -283,7 +290,10 @@ export async function writeQaSuiteArtifacts(params: {
   await assertQaSuiteArtifactWritten("report", reportPath);
   await assertQaSuiteArtifactWritten("summary", summaryPath);
   if (evidence && writeEvidenceFile) {
-    await assertQaSuiteArtifactWritten("evidence", evidencePath);
+    await assertQaSuiteArtifactWritten(
+      "evidence",
+      params.evidenceTarget?.stagedPath ?? evidencePath,
+    );
   }
   return { evidence, evidencePath, report, reportPath, summaryPath };
 }

--- a/extensions/qa-lab/src/suite-artifacts.ts
+++ b/extensions/qa-lab/src/suite-artifacts.ts
@@ -15,7 +15,6 @@ import { renderQaMarkdownReport, type QaReportScenario } from "./report.js";
 import type { RuntimeId } from "./runtime-parity.js";
 import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 import type { QaScorecardEvidenceMode } from "./scorecard-taxonomy.js";
-import type { QaSuiteEvidenceTarget } from "./suite-evidence-lifecycle.js";
 import { splitModelRef } from "./suite-planning.js";
 import { countQaSuiteFailedScenarios, type QaSuiteSummaryJson } from "./suite-summary.js";
 import { createQaSuiteReportNotes } from "./suite-support.js";
@@ -134,15 +133,13 @@ export async function writeQaSuiteArtifacts(params: {
   scenarioIds?: readonly string[];
   runtimePair?: [RuntimeId, RuntimeId];
   writeEvidenceFile?: boolean;
-  evidenceTarget?: QaSuiteEvidenceTarget;
   runCrablineChannelDriverSmoke?: (
     params: Parameters<QaCrablineRuntime["runOpenClawCrablineChannelDriverSmoke"]>[0],
   ) => Promise<QaCrablineChannelDriverSmokeResult>;
 }) {
   const reportPath = path.join(params.outputDir, "qa-suite-report.md");
   const summaryPath = path.join(params.outputDir, "qa-suite-summary.json");
-  const evidencePath =
-    params.evidenceTarget?.canonicalPath ?? path.join(params.outputDir, QA_EVIDENCE_FILENAME);
+  const evidencePath = path.join(params.outputDir, QA_EVIDENCE_FILENAME);
   const crablineChannelDriverSelection = params.channelDriverSelection;
   // Non-Crabline package acceptance mounts this source without plugin-local
   // dependencies. Keep the owner runtime outside every unrelated live path.
@@ -269,11 +266,7 @@ export async function writeQaSuiteArtifacts(params: {
   const writeEvidenceFile = params.writeEvidenceFile ?? true;
   await fs.writeFile(reportPath, report, "utf8");
   if (evidence && writeEvidenceFile) {
-    await fs.writeFile(
-      params.evidenceTarget?.stagedPath ?? evidencePath,
-      `${JSON.stringify(evidence, null, 2)}\n`,
-      "utf8",
-    );
+    await fs.writeFile(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
   }
   await fs.writeFile(
     summaryPath,
@@ -290,10 +283,7 @@ export async function writeQaSuiteArtifacts(params: {
   await assertQaSuiteArtifactWritten("report", reportPath);
   await assertQaSuiteArtifactWritten("summary", summaryPath);
   if (evidence && writeEvidenceFile) {
-    await assertQaSuiteArtifactWritten(
-      "evidence",
-      params.evidenceTarget?.stagedPath ?? evidencePath,
-    );
+    await assertQaSuiteArtifactWritten("evidence", evidencePath);
   }
   return { evidence, evidencePath, report, reportPath, summaryPath };
 }

--- a/extensions/qa-lab/src/suite-evidence-lifecycle.process-fixture.ts
+++ b/extensions/qa-lab/src/suite-evidence-lifecycle.process-fixture.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  QA_EVIDENCE_SUMMARY_KIND,
+  QA_EVIDENCE_SUMMARY_SCHEMA_VERSION,
+  type QaEvidenceSummaryJson,
+} from "./evidence-summary.js";
+import { runQaSuiteEvidenceLifecycle } from "./suite-evidence-lifecycle.js";
+
+const [outputDir, mode, markerPath] = process.argv.slice(2);
+if (!outputDir || !mode || !markerPath || !process.send) {
+  throw new Error("expected outputDir, mode, markerPath, and IPC");
+}
+
+const send = (message: object) => process.send?.(message);
+const finish = (message: object) =>
+  new Promise<void>((resolve) => {
+    process.send?.(message, () => {
+      process.disconnect();
+      resolve();
+    });
+  });
+const evidence: QaEvidenceSummaryJson = {
+  kind: QA_EVIDENCE_SUMMARY_KIND,
+  schemaVersion: QA_EVIDENCE_SUMMARY_SCHEMA_VERSION,
+  generatedAt: "2026-08-08T00:00:00.000Z",
+  evidenceMode: "full",
+  entries: [],
+  profile: mode,
+};
+
+const waitForRelease = () =>
+  new Promise<void>((resolve) => {
+    process.on("message", (message) => {
+      if (message === "release") {
+        resolve();
+      }
+    });
+  });
+
+try {
+  const result = await runQaSuiteEvidenceLifecycle(
+    { repoRoot: path.dirname(outputDir), outputDir },
+    async () => {
+      send({ type: "entered" });
+      if (mode === "hold" || mode === "crash") {
+        await waitForRelease();
+      }
+      return Object.freeze({
+        evidence,
+        result: mode,
+        complete: async () => {
+          await fs.writeFile(markerPath, `${mode}\n`, "utf8");
+          send({ type: "completed" });
+        },
+      });
+    },
+  );
+  await finish({ type: "result", result });
+} catch (error) {
+  await finish({
+    type: "error",
+    code: error && typeof error === "object" && "code" in error ? String(error.code) : undefined,
+    lockPath:
+      error && typeof error === "object" && "lockPath" in error
+        ? String(error.lockPath)
+        : undefined,
+    message: error instanceof Error ? error.message : String(error),
+  });
+}

--- a/extensions/qa-lab/src/suite-evidence-lifecycle.process.test.ts
+++ b/extensions/qa-lab/src/suite-evidence-lifecycle.process.test.ts
@@ -1,0 +1,146 @@
+import { fork, type ChildProcess } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+type ChildMessage = {
+  code?: string;
+  lockPath?: string;
+  message?: string;
+  result?: string;
+  type: "completed" | "entered" | "error" | "result";
+};
+
+const fixturePath = fileURLToPath(
+  new URL("./suite-evidence-lifecycle.process-fixture.ts", import.meta.url),
+);
+const tempRoots: string[] = [];
+const children = new Set<ChildProcess>();
+
+async function makeOutputDir(label: string) {
+  const repoRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), label)));
+  const outputDir = path.join(repoRoot, "output");
+  tempRoots.push(repoRoot);
+  await fs.mkdir(outputDir, { recursive: true });
+  return { outputDir, repoRoot };
+}
+
+function spawnFixture(outputDir: string, mode: string, markerPath: string) {
+  const child = fork(fixturePath, [outputDir, mode, markerPath], {
+    execArgv: ["--import", "tsx"],
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+  });
+  children.add(child);
+  const messages: ChildMessage[] = [];
+  let stderr = "";
+  child.on("message", (message) => messages.push(message as ChildMessage));
+  child.stderr?.on("data", (chunk) => {
+    stderr += String(chunk);
+  });
+  child.once("exit", () => children.delete(child));
+  return {
+    child,
+    messages,
+    waitForMessage: (type: ChildMessage["type"], timeoutMs = 5_000) =>
+      new Promise<ChildMessage>((resolve, reject) => {
+        const existing = messages.find((message) => message.type === type);
+        if (existing) {
+          resolve(existing);
+          return;
+        }
+        const timer = setTimeout(
+          () => reject(new Error(`timed out waiting for ${type}; stderr=${stderr}`)),
+          timeoutMs,
+        );
+        const onMessage = (message: unknown) => {
+          const typed = message as ChildMessage;
+          if (typed.type !== type) {
+            return;
+          }
+          clearTimeout(timer);
+          child.off("message", onMessage);
+          resolve(typed);
+        };
+        child.on("message", onMessage);
+      }),
+    waitForExit: (timeoutMs = 5_000) =>
+      new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          resolve({ code: child.exitCode, signal: child.signalCode });
+          return;
+        }
+        const timer = setTimeout(
+          () => reject(new Error(`timed out waiting for child exit; stderr=${stderr}`)),
+          timeoutMs,
+        );
+        child.once("exit", (code, signal) => {
+          clearTimeout(timer);
+          resolve({ code, signal });
+        });
+      }),
+  };
+}
+
+afterEach(async () => {
+  for (const child of children) {
+    child.kill("SIGKILL");
+  }
+  children.clear();
+  await Promise.all(
+    tempRoots.splice(0).map((repoRoot) => fs.rm(repoRoot, { recursive: true, force: true })),
+  );
+});
+
+describe("QA suite evidence lifecycle process locking", () => {
+  it("fails a same-output loser before callback entry and preserves winner artifacts", async () => {
+    const { outputDir } = await makeOutputDir("qa-evidence-process-contention-");
+    const canonicalPath = path.join(outputDir, "qa-evidence.json");
+    const lockPath = `${outputDir}.lock`;
+    const winnerMarker = path.join(outputDir, "winner.marker");
+    const loserMarker = path.join(outputDir, "loser.marker");
+    const winner = spawnFixture(outputDir, "hold", winnerMarker);
+    await winner.waitForMessage("entered");
+    await expect(fs.access(lockPath)).resolves.toBeUndefined();
+
+    const loser = spawnFixture(outputDir, "loser", loserMarker);
+    const loserError = await loser.waitForMessage("error");
+    expect(loserError.code).toBe("file_lock_timeout");
+    expect(loserError.lockPath).toBe(lockPath);
+    expect(loser.messages.some((message) => message.type === "entered")).toBe(false);
+    await expect(fs.access(canonicalPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await loser.waitForExit();
+
+    winner.child.send("release");
+    await winner.waitForMessage("completed");
+    await winner.waitForExit();
+    await expect(fs.access(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(JSON.parse(await fs.readFile(canonicalPath, "utf8"))).toMatchObject({ profile: "hold" });
+    await expect(fs.readFile(winnerMarker, "utf8")).resolves.toBe("hold\n");
+    await expect(fs.access(loserMarker)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("recovers a dead owner after SIGKILL without reviving stale canonical evidence", async () => {
+    const { outputDir } = await makeOutputDir("qa-evidence-process-recovery-");
+    const canonicalPath = path.join(outputDir, "qa-evidence.json");
+    await fs.writeFile(canonicalPath, "stale\n", "utf8");
+    const crashed = spawnFixture(outputDir, "crash", path.join(outputDir, "crash.marker"));
+    await crashed.waitForMessage("entered");
+    await expect(fs.access(canonicalPath)).rejects.toMatchObject({ code: "ENOENT" });
+
+    crashed.child.kill("SIGKILL");
+    await expect(crashed.waitForExit()).resolves.toMatchObject({ signal: "SIGKILL" });
+
+    const recoveryMarker = path.join(outputDir, "recovery.marker");
+    const recovery = spawnFixture(outputDir, "recovery", recoveryMarker);
+    await recovery.waitForMessage("entered");
+    await recovery.waitForMessage("completed");
+    await recovery.waitForExit();
+
+    expect(JSON.parse(await fs.readFile(canonicalPath, "utf8"))).toMatchObject({
+      profile: "recovery",
+    });
+    await expect(fs.readFile(recoveryMarker, "utf8")).resolves.toBe("recovery\n");
+  });
+});

--- a/extensions/qa-lab/src/suite-evidence-lifecycle.test.ts
+++ b/extensions/qa-lab/src/suite-evidence-lifecycle.test.ts
@@ -17,28 +17,32 @@ vi.mock("openclaw/plugin-sdk/file-lock", async (importOriginal) => {
 });
 
 import { drainFileLockStateForTest } from "openclaw/plugin-sdk/file-lock";
+import {
+  QA_EVIDENCE_SUMMARY_KIND,
+  QA_EVIDENCE_SUMMARY_SCHEMA_VERSION,
+  type QaEvidenceSummaryJson,
+} from "./evidence-summary.js";
 import { runQaSuiteEvidenceLifecycle } from "./suite-evidence-lifecycle.js";
 
 const tempRoots: string[] = [];
 
-async function makeTempRepo(label: string) {
-  const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), label));
+async function makeOutputDir(label: string) {
+  const repoRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), label)));
+  const outputDir = path.join(repoRoot, "output");
   tempRoots.push(repoRoot);
-  return repoRoot;
-}
-
-async function makeOutputDir(repoRoot: string, name = "output") {
-  const outputDir = path.join(repoRoot, name);
   await fs.mkdir(outputDir, { recursive: true });
-  return outputDir;
+  return { outputDir, repoRoot };
 }
 
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
+function makeEvidence(profile: string): QaEvidenceSummaryJson {
+  return {
+    kind: QA_EVIDENCE_SUMMARY_KIND,
+    schemaVersion: QA_EVIDENCE_SUMMARY_SCHEMA_VERSION,
+    generatedAt: "2026-08-08T00:00:00.000Z",
+    evidenceMode: "full",
+    entries: [],
+    profile,
+  };
 }
 
 beforeEach(() => {
@@ -58,79 +62,11 @@ afterEach(async () => {
 });
 
 describe("QA suite evidence lifecycle", () => {
-  it("rejects a same-output loser before its callback can mutate evidence", async () => {
-    const repoRoot = await makeTempRepo("qa-evidence-lock-same-");
-    const outputDir = await makeOutputDir(repoRoot);
-    const firstEntered = deferred();
-    const releaseFirst = deferred();
-    const loserRun = vi.fn();
-    const firstRun = runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, async ({ target }) => {
-      await fs.writeFile(target.stagedPath, "first\n", "utf8");
-      firstEntered.resolve();
-      await releaseFirst.promise;
-      return target.canonicalPath;
-    });
-    await firstEntered.promise;
-
-    await expect(
-      runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, loserRun),
-    ).rejects.toMatchObject({ code: "file_lock_timeout" });
-    expect(loserRun).not.toHaveBeenCalled();
-
-    releaseFirst.resolve();
-    await expect(firstRun).resolves.toBe(path.join(outputDir, "qa-evidence.json"));
-    await expect(fs.readFile(path.join(outputDir, "qa-evidence.json"), "utf8")).resolves.toBe(
-      "first\n",
-    );
-  });
-
-  it("allows different output directories to stage concurrently", async () => {
-    const repoRoot = await makeTempRepo("qa-evidence-lock-different-");
-    const outputDirs = await Promise.all([
-      makeOutputDir(repoRoot, "one"),
-      makeOutputDir(repoRoot, "two"),
-    ]);
-    const bothEntered = deferred();
-    let entered = 0;
-    const run = (outputDir: string, value: string) =>
-      runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, async ({ target }) => {
-        await fs.writeFile(target.stagedPath, value, "utf8");
-        entered += 1;
-        if (entered === 2) {
-          bothEntered.resolve();
-        }
-        await bothEntered.promise;
-      });
-
-    await Promise.all([run(outputDirs[0]!, "one"), run(outputDirs[1]!, "two")]);
-    await expect(fs.readFile(path.join(outputDirs[0]!, "qa-evidence.json"), "utf8")).resolves.toBe(
-      "one",
-    );
-    await expect(fs.readFile(path.join(outputDirs[1]!, "qa-evidence.json"), "utf8")).resolves.toBe(
-      "two",
-    );
-  });
-
-  it("invalidates stale canonical evidence before planning", async () => {
-    const repoRoot = await makeTempRepo("qa-evidence-stale-");
-    const outputDir = await makeOutputDir(repoRoot);
+  it("holds one canonical lock through publication and completes after release", async () => {
+    const { outputDir, repoRoot } = await makeOutputDir("qa-evidence-publish-");
     const canonicalPath = path.join(outputDir, "qa-evidence.json");
-    await fs.writeFile(canonicalPath, "stale\n", "utf8");
-    const planningError = new Error("planning failed");
-
-    await expect(
-      runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, async () => {
-        await expect(fs.access(canonicalPath)).rejects.toMatchObject({ code: "ENOENT" });
-        throw planningError;
-      }),
-    ).rejects.toBe(planningError);
-    await expect(fs.access(canonicalPath)).rejects.toMatchObject({ code: "ENOENT" });
-  });
-
-  it("publishes staged evidence before releasing the lifecycle lock", async () => {
-    const repoRoot = await makeTempRepo("qa-evidence-publish-");
-    const outputDir = await makeOutputDir(repoRoot);
     const events: string[] = [];
+    await fs.writeFile(canonicalPath, "stale\n", "utf8");
     const rename = fs.rename.bind(fs);
     vi.spyOn(fs, "rename").mockImplementation(async (...args) => {
       events.push("publish");
@@ -138,7 +74,16 @@ describe("QA suite evidence lifecycle", () => {
     });
     const actualAcquire = fileLockMocks.actualAcquire!;
     fileLockMocks.acquire.mockImplementationOnce(async (...args) => {
+      events.push("acquire");
+      expect(args[0]).toBe(outputDir);
+      expect(args[1]?.retries).toEqual({
+        retries: 0,
+        factor: 1,
+        minTimeout: 1,
+        maxTimeout: 1,
+      });
       const lock = await actualAcquire(...args);
+      expect(lock.lockPath).toBe(`${outputDir}.lock`);
       return {
         ...lock,
         release: async () => {
@@ -148,17 +93,27 @@ describe("QA suite evidence lifecycle", () => {
       };
     });
 
-    await runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, async ({ target }) => {
-      events.push("stage");
-      await fs.writeFile(target.stagedPath, "candidate\n", "utf8");
+    const result = await runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, async () => {
+      events.push("run");
+      await expect(fs.access(`${outputDir}.lock`)).resolves.toBeUndefined();
+      await expect(fs.access(canonicalPath)).rejects.toMatchObject({ code: "ENOENT" });
+      return Object.freeze({
+        evidence: makeEvidence("winner"),
+        result: "result",
+        complete: () => events.push("complete"),
+      });
     });
 
-    expect(events).toEqual(["stage", "publish", "release"]);
+    expect(result).toBe("result");
+    expect(events).toEqual(["acquire", "run", "publish", "release", "complete"]);
+    await expect(fs.access(`${outputDir}.lock`)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(JSON.parse(await fs.readFile(canonicalPath, "utf8"))).toMatchObject({
+      profile: "winner",
+    });
   });
 
   it("keeps the run failure primary when discard and release also fail", async () => {
-    const repoRoot = await makeTempRepo("qa-evidence-errors-");
-    const outputDir = await makeOutputDir(repoRoot);
+    const { outputDir, repoRoot } = await makeOutputDir("qa-evidence-errors-");
     const runError = new Error("run failed");
     const discardError = new Error("discard failed");
     const releaseError = new Error("release failed");
@@ -181,13 +136,9 @@ describe("QA suite evidence lifecycle", () => {
       };
     });
 
-    const thrown = await runQaSuiteEvidenceLifecycle(
-      { repoRoot, outputDir },
-      async ({ target }) => {
-        await fs.writeFile(target.stagedPath, "candidate\n", "utf8");
-        throw runError;
-      },
-    ).catch((error: unknown) => error);
+    const thrown = await runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, async () => {
+      throw runError;
+    }).catch((error: unknown) => error);
 
     expect(thrown).toMatchObject({
       cause: runError,
@@ -195,12 +146,37 @@ describe("QA suite evidence lifecycle", () => {
     });
   });
 
-  it("discards after publish failure and releases last", async () => {
-    const repoRoot = await makeTempRepo("qa-evidence-publish-failure-");
-    const outputDir = await makeOutputDir(repoRoot);
+  it("suppresses completion when the staged profile transform fails", async () => {
+    const { outputDir, repoRoot } = await makeOutputDir("qa-evidence-transform-");
+    const canonicalPath = path.join(outputDir, "qa-evidence.json");
+    const diagnosticPath = path.join(outputDir, "qa-suite-report.md");
+    const transformError = new Error("profile transform failed");
+    const complete = vi.fn();
+
+    await expect(
+      runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, async () => {
+        await fs.writeFile(diagnosticPath, "diagnostic\n", "utf8");
+        return Object.freeze({
+          evidence: makeEvidence("profile"),
+          result: undefined,
+          complete,
+          transformStagedEvidence: async () => {
+            throw transformError;
+          },
+        });
+      }),
+    ).rejects.toBe(transformError);
+
+    expect(complete).not.toHaveBeenCalled();
+    await expect(fs.access(canonicalPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readFile(diagnosticPath, "utf8")).resolves.toBe("diagnostic\n");
+  });
+
+  it("discards after rename failure, releases last, and emits no completion", async () => {
+    const { outputDir, repoRoot } = await makeOutputDir("qa-evidence-rename-");
     const publishError = new Error("publish failed");
-    const releaseError = new Error("release failed");
     const events: string[] = [];
+    const complete = vi.fn();
     vi.spyOn(fs, "rename").mockImplementation(async () => {
       events.push("publish");
       throw publishError;
@@ -220,23 +196,25 @@ describe("QA suite evidence lifecycle", () => {
         release: async () => {
           events.push("release");
           await lock.release();
-          throw releaseError;
         },
       };
     });
 
-    const thrown = await runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, async ({ target }) =>
-      fs.writeFile(target.stagedPath, "candidate\n", "utf8"),
-    ).catch((error: unknown) => error);
+    await expect(
+      runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, async () =>
+        Object.freeze({ evidence: makeEvidence("rename"), result: undefined, complete }),
+      ),
+    ).rejects.toBe(publishError);
 
     expect(events).toEqual(["publish", "discard", "release"]);
-    expect(thrown).toMatchObject({ cause: publishError, errors: [publishError, releaseError] });
+    expect(complete).not.toHaveBeenCalled();
   });
 
-  it("keeps published canonical evidence when post-publish release fails", async () => {
-    const repoRoot = await makeTempRepo("qa-evidence-release-failure-");
-    const outputDir = await makeOutputDir(repoRoot);
+  it("keeps published canonical evidence and emits no completion when release fails", async () => {
+    const { outputDir, repoRoot } = await makeOutputDir("qa-evidence-release-");
+    const canonicalPath = path.join(outputDir, "qa-evidence.json");
     const releaseError = new Error("release failed after publish");
+    const complete = vi.fn();
     const actualAcquire = fileLockMocks.actualAcquire!;
     fileLockMocks.acquire.mockImplementationOnce(async (...args) => {
       const lock = await actualAcquire(...args);
@@ -250,12 +228,14 @@ describe("QA suite evidence lifecycle", () => {
     });
 
     await expect(
-      runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, async ({ target }) => {
-        await fs.writeFile(target.stagedPath, "published\n", "utf8");
-      }),
+      runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, async () =>
+        Object.freeze({ evidence: makeEvidence("published"), result: undefined, complete }),
+      ),
     ).rejects.toBe(releaseError);
-    await expect(fs.readFile(path.join(outputDir, "qa-evidence.json"), "utf8")).resolves.toBe(
-      "published\n",
-    );
+
+    expect(complete).not.toHaveBeenCalled();
+    expect(JSON.parse(await fs.readFile(canonicalPath, "utf8"))).toMatchObject({
+      profile: "published",
+    });
   });
 });

--- a/extensions/qa-lab/src/suite-evidence-lifecycle.test.ts
+++ b/extensions/qa-lab/src/suite-evidence-lifecycle.test.ts
@@ -1,0 +1,261 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fileLockMocks = vi.hoisted(() => ({
+  acquire: vi.fn(),
+  actualAcquire: undefined as
+    | typeof import("openclaw/plugin-sdk/file-lock").acquireFileLock
+    | undefined,
+}));
+
+vi.mock("openclaw/plugin-sdk/file-lock", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/file-lock")>();
+  fileLockMocks.actualAcquire = actual.acquireFileLock;
+  return { ...actual, acquireFileLock: fileLockMocks.acquire };
+});
+
+import { drainFileLockStateForTest } from "openclaw/plugin-sdk/file-lock";
+import { runQaSuiteEvidenceLifecycle } from "./suite-evidence-lifecycle.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRepo(label: string) {
+  const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), label));
+  tempRoots.push(repoRoot);
+  return repoRoot;
+}
+
+async function makeOutputDir(repoRoot: string, name = "output") {
+  const outputDir = path.join(repoRoot, name);
+  await fs.mkdir(outputDir, { recursive: true });
+  return outputDir;
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  const actualAcquire = fileLockMocks.actualAcquire;
+  if (!actualAcquire) {
+    throw new Error("expected the real file-lock implementation");
+  }
+  fileLockMocks.acquire.mockReset().mockImplementation(actualAcquire);
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await drainFileLockStateForTest();
+  await Promise.all(
+    tempRoots.splice(0).map((repoRoot) => fs.rm(repoRoot, { recursive: true, force: true })),
+  );
+});
+
+describe("QA suite evidence lifecycle", () => {
+  it("rejects a same-output loser before its callback can mutate evidence", async () => {
+    const repoRoot = await makeTempRepo("qa-evidence-lock-same-");
+    const outputDir = await makeOutputDir(repoRoot);
+    const firstEntered = deferred();
+    const releaseFirst = deferred();
+    const loserRun = vi.fn();
+    const firstRun = runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, async ({ target }) => {
+      await fs.writeFile(target.stagedPath, "first\n", "utf8");
+      firstEntered.resolve();
+      await releaseFirst.promise;
+      return target.canonicalPath;
+    });
+    await firstEntered.promise;
+
+    await expect(
+      runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, loserRun),
+    ).rejects.toMatchObject({ code: "file_lock_timeout" });
+    expect(loserRun).not.toHaveBeenCalled();
+
+    releaseFirst.resolve();
+    await expect(firstRun).resolves.toBe(path.join(outputDir, "qa-evidence.json"));
+    await expect(fs.readFile(path.join(outputDir, "qa-evidence.json"), "utf8")).resolves.toBe(
+      "first\n",
+    );
+  });
+
+  it("allows different output directories to stage concurrently", async () => {
+    const repoRoot = await makeTempRepo("qa-evidence-lock-different-");
+    const outputDirs = await Promise.all([
+      makeOutputDir(repoRoot, "one"),
+      makeOutputDir(repoRoot, "two"),
+    ]);
+    const bothEntered = deferred();
+    let entered = 0;
+    const run = (outputDir: string, value: string) =>
+      runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, async ({ target }) => {
+        await fs.writeFile(target.stagedPath, value, "utf8");
+        entered += 1;
+        if (entered === 2) {
+          bothEntered.resolve();
+        }
+        await bothEntered.promise;
+      });
+
+    await Promise.all([run(outputDirs[0]!, "one"), run(outputDirs[1]!, "two")]);
+    await expect(fs.readFile(path.join(outputDirs[0]!, "qa-evidence.json"), "utf8")).resolves.toBe(
+      "one",
+    );
+    await expect(fs.readFile(path.join(outputDirs[1]!, "qa-evidence.json"), "utf8")).resolves.toBe(
+      "two",
+    );
+  });
+
+  it("invalidates stale canonical evidence before planning", async () => {
+    const repoRoot = await makeTempRepo("qa-evidence-stale-");
+    const outputDir = await makeOutputDir(repoRoot);
+    const canonicalPath = path.join(outputDir, "qa-evidence.json");
+    await fs.writeFile(canonicalPath, "stale\n", "utf8");
+    const planningError = new Error("planning failed");
+
+    await expect(
+      runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, async () => {
+        await expect(fs.access(canonicalPath)).rejects.toMatchObject({ code: "ENOENT" });
+        throw planningError;
+      }),
+    ).rejects.toBe(planningError);
+    await expect(fs.access(canonicalPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("publishes staged evidence before releasing the lifecycle lock", async () => {
+    const repoRoot = await makeTempRepo("qa-evidence-publish-");
+    const outputDir = await makeOutputDir(repoRoot);
+    const events: string[] = [];
+    const rename = fs.rename.bind(fs);
+    vi.spyOn(fs, "rename").mockImplementation(async (...args) => {
+      events.push("publish");
+      return await rename(...args);
+    });
+    const actualAcquire = fileLockMocks.actualAcquire!;
+    fileLockMocks.acquire.mockImplementationOnce(async (...args) => {
+      const lock = await actualAcquire(...args);
+      return {
+        ...lock,
+        release: async () => {
+          events.push("release");
+          await lock.release();
+        },
+      };
+    });
+
+    await runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, async ({ target }) => {
+      events.push("stage");
+      await fs.writeFile(target.stagedPath, "candidate\n", "utf8");
+    });
+
+    expect(events).toEqual(["stage", "publish", "release"]);
+  });
+
+  it("keeps the run failure primary when discard and release also fail", async () => {
+    const repoRoot = await makeTempRepo("qa-evidence-errors-");
+    const outputDir = await makeOutputDir(repoRoot);
+    const runError = new Error("run failed");
+    const discardError = new Error("discard failed");
+    const releaseError = new Error("release failed");
+    const rm = fs.rm.bind(fs);
+    vi.spyOn(fs, "rm").mockImplementation(async (targetPath, options) => {
+      if (String(targetPath).endsWith(".staged")) {
+        throw discardError;
+      }
+      return await rm(targetPath, options);
+    });
+    const actualAcquire = fileLockMocks.actualAcquire!;
+    fileLockMocks.acquire.mockImplementationOnce(async (...args) => {
+      const lock = await actualAcquire(...args);
+      return {
+        ...lock,
+        release: async () => {
+          await lock.release();
+          throw releaseError;
+        },
+      };
+    });
+
+    const thrown = await runQaSuiteEvidenceLifecycle(
+      { repoRoot, outputDir },
+      async ({ target }) => {
+        await fs.writeFile(target.stagedPath, "candidate\n", "utf8");
+        throw runError;
+      },
+    ).catch((error: unknown) => error);
+
+    expect(thrown).toMatchObject({
+      cause: runError,
+      errors: [runError, discardError, releaseError],
+    });
+  });
+
+  it("discards after publish failure and releases last", async () => {
+    const repoRoot = await makeTempRepo("qa-evidence-publish-failure-");
+    const outputDir = await makeOutputDir(repoRoot);
+    const publishError = new Error("publish failed");
+    const releaseError = new Error("release failed");
+    const events: string[] = [];
+    vi.spyOn(fs, "rename").mockImplementation(async () => {
+      events.push("publish");
+      throw publishError;
+    });
+    const rm = fs.rm.bind(fs);
+    vi.spyOn(fs, "rm").mockImplementation(async (targetPath, options) => {
+      if (String(targetPath).endsWith(".staged")) {
+        events.push("discard");
+      }
+      return await rm(targetPath, options);
+    });
+    const actualAcquire = fileLockMocks.actualAcquire!;
+    fileLockMocks.acquire.mockImplementationOnce(async (...args) => {
+      const lock = await actualAcquire(...args);
+      return {
+        ...lock,
+        release: async () => {
+          events.push("release");
+          await lock.release();
+          throw releaseError;
+        },
+      };
+    });
+
+    const thrown = await runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, async ({ target }) =>
+      fs.writeFile(target.stagedPath, "candidate\n", "utf8"),
+    ).catch((error: unknown) => error);
+
+    expect(events).toEqual(["publish", "discard", "release"]);
+    expect(thrown).toMatchObject({ cause: publishError, errors: [publishError, releaseError] });
+  });
+
+  it("keeps published canonical evidence when post-publish release fails", async () => {
+    const repoRoot = await makeTempRepo("qa-evidence-release-failure-");
+    const outputDir = await makeOutputDir(repoRoot);
+    const releaseError = new Error("release failed after publish");
+    const actualAcquire = fileLockMocks.actualAcquire!;
+    fileLockMocks.acquire.mockImplementationOnce(async (...args) => {
+      const lock = await actualAcquire(...args);
+      return {
+        ...lock,
+        release: async () => {
+          await lock.release();
+          throw releaseError;
+        },
+      };
+    });
+
+    await expect(
+      runQaSuiteEvidenceLifecycle({ repoRoot, outputDir }, async ({ target }) => {
+        await fs.writeFile(target.stagedPath, "published\n", "utf8");
+      }),
+    ).rejects.toBe(releaseError);
+    await expect(fs.readFile(path.join(outputDir, "qa-evidence.json"), "utf8")).resolves.toBe(
+      "published\n",
+    );
+  });
+});

--- a/extensions/qa-lab/src/suite-evidence-lifecycle.ts
+++ b/extensions/qa-lab/src/suite-evidence-lifecycle.ts
@@ -2,39 +2,52 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { acquireFileLock } from "openclaw/plugin-sdk/file-lock";
-import { QA_EVIDENCE_FILENAME } from "./evidence-summary.js";
+import { QA_EVIDENCE_FILENAME, type QaEvidenceSummaryJson } from "./evidence-summary.js";
 import { resolveQaSuiteOutputDir } from "./suite-planning.js";
 
-export type QaSuiteEvidenceTarget = { canonicalPath: string; stagedPath: string };
+export type QaSuiteDeferredCompletion<Result> = Readonly<{
+  result: Result;
+  evidence: QaEvidenceSummaryJson;
+  complete: () => void | Promise<void>;
+  transformStagedEvidence?: (stagedPath: string) => Promise<void>;
+}>;
+
+export async function completeQaSuiteWithoutEvidence<Result>(
+  run: () => Promise<QaSuiteDeferredCompletion<Result>>,
+): Promise<Result> {
+  const completion = await run();
+  await completion.complete();
+  return completion.result;
+}
+
 export async function runQaSuiteEvidenceLifecycle<Result>(
   params: { repoRoot?: string; outputDir?: string } | undefined,
   run: (resolved: {
     repoRoot: string;
     outputDir: string;
-    target: QaSuiteEvidenceTarget;
-  }) => Result | Promise<Result>,
+  }) => QaSuiteDeferredCompletion<Result> | Promise<QaSuiteDeferredCompletion<Result>>,
 ): Promise<Result> {
   const repoRoot = path.resolve(params?.repoRoot ?? process.cwd());
   const outputDir = await resolveQaSuiteOutputDir(repoRoot, params?.outputDir);
-  const target = {
-    canonicalPath: path.join(outputDir, QA_EVIDENCE_FILENAME),
-    stagedPath: path.join(outputDir, `.${QA_EVIDENCE_FILENAME}.${randomUUID()}.staged`),
-  } satisfies QaSuiteEvidenceTarget;
+  const canonicalPath = path.join(outputDir, QA_EVIDENCE_FILENAME);
+  const stagedPath = path.join(outputDir, `.${QA_EVIDENCE_FILENAME}.${randomUUID()}.staged`);
   const lock = await acquireFileLock(outputDir, {
     retries: { retries: 0, factor: 1, minTimeout: 1, maxTimeout: 1 },
     stale: 5 * 60_000,
     staleRecovery: "remove-if-unchanged",
   });
-  let result: Result | undefined;
+  let completion!: QaSuiteDeferredCompletion<Result>;
   const errors: unknown[] = [];
   try {
-    await fs.rm(target.canonicalPath, { force: true });
-    result = await run({ repoRoot, outputDir, target });
-    await fs.rename(target.stagedPath, target.canonicalPath);
+    await fs.rm(canonicalPath, { force: true });
+    completion = await run({ repoRoot, outputDir });
+    await fs.writeFile(stagedPath, `${JSON.stringify(completion.evidence, null, 2)}\n`, "utf8");
+    await completion.transformStagedEvidence?.(stagedPath);
+    await fs.rename(stagedPath, canonicalPath);
   } catch (error) {
     errors.push(error);
     await fs
-      .rm(target.stagedPath, { force: true })
+      .rm(stagedPath, { force: true })
       .catch((discardError: unknown) => errors.push(discardError));
   }
   await lock.release().catch((error) => errors.push(error));
@@ -44,5 +57,6 @@ export async function runQaSuiteEvidenceLifecycle<Result>(
   if (errors.length > 1) {
     throw new AggregateError(errors, "QA suite evidence lifecycle failed", { cause: errors[0] });
   }
-  return result as Result;
+  await completion.complete();
+  return completion.result;
 }

--- a/extensions/qa-lab/src/suite-evidence-lifecycle.ts
+++ b/extensions/qa-lab/src/suite-evidence-lifecycle.ts
@@ -1,0 +1,48 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { acquireFileLock } from "openclaw/plugin-sdk/file-lock";
+import { QA_EVIDENCE_FILENAME } from "./evidence-summary.js";
+import { resolveQaSuiteOutputDir } from "./suite-planning.js";
+
+export type QaSuiteEvidenceTarget = { canonicalPath: string; stagedPath: string };
+export async function runQaSuiteEvidenceLifecycle<Result>(
+  params: { repoRoot?: string; outputDir?: string } | undefined,
+  run: (resolved: {
+    repoRoot: string;
+    outputDir: string;
+    target: QaSuiteEvidenceTarget;
+  }) => Result | Promise<Result>,
+): Promise<Result> {
+  const repoRoot = path.resolve(params?.repoRoot ?? process.cwd());
+  const outputDir = await resolveQaSuiteOutputDir(repoRoot, params?.outputDir);
+  const target = {
+    canonicalPath: path.join(outputDir, QA_EVIDENCE_FILENAME),
+    stagedPath: path.join(outputDir, `.${QA_EVIDENCE_FILENAME}.${randomUUID()}.staged`),
+  } satisfies QaSuiteEvidenceTarget;
+  const lock = await acquireFileLock(outputDir, {
+    retries: { retries: 0, factor: 1, minTimeout: 1, maxTimeout: 1 },
+    stale: 5 * 60_000,
+    staleRecovery: "remove-if-unchanged",
+  });
+  let result: Result | undefined;
+  const errors: unknown[] = [];
+  try {
+    await fs.rm(target.canonicalPath, { force: true });
+    result = await run({ repoRoot, outputDir, target });
+    await fs.rename(target.stagedPath, target.canonicalPath);
+  } catch (error) {
+    errors.push(error);
+    await fs
+      .rm(target.stagedPath, { force: true })
+      .catch((discardError: unknown) => errors.push(discardError));
+  }
+  await lock.release().catch((error) => errors.push(error));
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "QA suite evidence lifecycle failed", { cause: errors[0] });
+  }
+  return result as Result;
+}

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { acquireFileLock } from "openclaw/plugin-sdk/file-lock";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QaSuiteInfraError } from "./errors.js";
 import type { QaLabServerHandle } from "./lab-server.types.js";
@@ -11,19 +12,13 @@ import type {
   QaTestFileScenarioRunResult,
 } from "./test-file-scenario-runner.js";
 
-const {
-  crablineRuntimeLoads,
-  evidenceTargets,
-  generatedOutputDirs,
-  runQaFlowSuite,
-  runQaTestFileScenarios,
-} = vi.hoisted(() => ({
-  crablineRuntimeLoads: vi.fn(),
-  evidenceTargets: new WeakMap<object, { stagedPath: string }>(),
-  generatedOutputDirs: new Set<string>(),
-  runQaFlowSuite: vi.fn(),
-  runQaTestFileScenarios: vi.fn(),
-}));
+const { crablineRuntimeLoads, generatedOutputDirs, runQaFlowSuite, runQaTestFileScenarios } =
+  vi.hoisted(() => ({
+    crablineRuntimeLoads: vi.fn(),
+    generatedOutputDirs: new Set<string>(),
+    runQaFlowSuite: vi.fn(),
+    runQaTestFileScenarios: vi.fn(),
+  }));
 
 vi.mock("@openclaw/crabline", async (importOriginal) => {
   crablineRuntimeLoads();
@@ -31,21 +26,9 @@ vi.mock("@openclaw/crabline", async (importOriginal) => {
 });
 
 vi.mock("./suite-run.runtime.js", () => ({
-  runQaFlowSuiteFromRuntimeCore: async (
-    params: object | undefined,
-    target?: { canonicalPath: string; stagedPath: string },
-  ) => {
-    if (params && target) {
-      evidenceTargets.set(params, target);
-      generatedOutputDirs.add(path.dirname(target.canonicalPath));
-    }
-    try {
-      return await runQaFlowSuite(params);
-    } finally {
-      if (params) {
-        evidenceTargets.delete(params);
-      }
-    }
+  runQaFlowSuiteFromRuntimeCore: async (params: object | undefined) => {
+    const result = await runQaFlowSuite(params);
+    return Object.freeze({ result, evidence: result.evidence, complete: vi.fn() });
   },
 }));
 
@@ -135,11 +118,7 @@ describe("qa suite runtime launcher", () => {
       ) => {
         const outputDir = params?.outputDir ?? "/tmp/qa-flow";
         const evidencePath = path.join(outputDir, "qa-evidence.json");
-        const target = params ? evidenceTargets.get(params) : undefined;
-        const evidence = await writeEvidence(
-          target?.stagedPath ?? evidencePath,
-          params?.writeEvidenceFile,
-        );
+        const evidence = await writeEvidence(evidencePath, params?.writeEvidenceFile);
         const scenarioIds = params?.scenarioIds ?? ["channel-chat-baseline"];
         return {
           evidence,
@@ -259,29 +238,41 @@ describe("qa suite runtime launcher", () => {
   });
 
   it("retries a flow-only suite once for retryable infrastructure failures", async () => {
-    const attempts = mockFlowPartitionFailures(
-      new Map([
-        [
-          "channel-chat-baseline",
-          [new QaSuiteInfraError("agent_wait_failed", "agent.wait failed")],
-        ],
-      ]),
-    );
+    const repoRoot = await makeTempRepo("qa-suite-retry-lock-");
+    const outputDir = path.join(repoRoot, "output");
+    const defaultFlowImplementation = runQaFlowSuite.getMockImplementation()!;
+    let attempts = 0;
+    runQaFlowSuite.mockImplementation(async (params) => {
+      attempts += 1;
+      await expect(
+        acquireFileLock(outputDir, {
+          retries: { retries: 0, factor: 1, minTimeout: 1, maxTimeout: 1 },
+        }),
+      ).rejects.toMatchObject({ code: "file_lock_timeout" });
+      if (attempts === 1) {
+        throw new QaSuiteInfraError("agent_wait_failed", "agent.wait failed");
+      }
+      return await defaultFlowImplementation(params);
+    });
+    const rename = vi.spyOn(fs, "rename");
     const stderrWrite = vi.spyOn(process.stderr, "write").mockReturnValue(true);
 
     try {
       const result = await runQaSuite({
-        repoRoot: process.cwd(),
+        repoRoot,
+        outputDir,
         providerMode: "mock-openai",
         scenarioIds: ["channel-chat-baseline"],
       });
 
       expect(result.executionKind).toBe("flow");
-      expect(attempts.get("channel-chat-baseline")).toBe(2);
+      expect(attempts).toBe(2);
+      expect(rename).toHaveBeenCalledOnce();
       expect(stderrWrite.mock.calls.flat().join("")).toContain(
         "[qa-suite] infra retry 1/1: agent.wait failed",
       );
     } finally {
+      rename.mockRestore();
       stderrWrite.mockRestore();
     }
   });
@@ -1285,6 +1276,29 @@ describe("qa suite runtime launcher", () => {
     expect(summary.scenarios?.[1]?.details).toContain(
       "log=.artifacts/qa-e2e/mixed/playwright/control-ui-chat-flow-playwright.log",
     );
+  });
+
+  it("leaves unified publication state untouched when evidence writing is disabled", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-unified-no-evidence-");
+    const outputDir = path.join(repoRoot, "output");
+    const canonicalPath = path.join(outputDir, "qa-evidence.json");
+    const lockPath = `${canonicalPath}.lock`;
+    const stagedPath = path.join(outputDir, ".qa-evidence.json.preseed.staged");
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.writeFile(canonicalPath, "canonical\n", "utf8");
+    await fs.writeFile(lockPath, "lock\n", "utf8");
+    await fs.writeFile(stagedPath, "staged\n", "utf8");
+
+    await runQaSuite({
+      repoRoot,
+      outputDir,
+      writeEvidenceFile: false,
+      scenarioIds: ["channel-chat-baseline", "control-ui-chat-flow-playwright"],
+    });
+
+    await expect(fs.readFile(canonicalPath, "utf8")).resolves.toBe("canonical\n");
+    await expect(fs.readFile(lockPath, "utf8")).resolves.toBe("lock\n");
+    await expect(fs.readFile(stagedPath, "utf8")).resolves.toBe("staged\n");
   });
 
   it("aggregates mixed-kind progress through the parent lab", async () => {

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -11,8 +11,16 @@ import type {
   QaTestFileScenarioRunResult,
 } from "./test-file-scenario-runner.js";
 
-const { crablineRuntimeLoads, runQaFlowSuite, runQaTestFileScenarios } = vi.hoisted(() => ({
+const {
+  crablineRuntimeLoads,
+  evidenceTargets,
+  generatedOutputDirs,
+  runQaFlowSuite,
+  runQaTestFileScenarios,
+} = vi.hoisted(() => ({
   crablineRuntimeLoads: vi.fn(),
+  evidenceTargets: new WeakMap<object, { stagedPath: string }>(),
+  generatedOutputDirs: new Set<string>(),
   runQaFlowSuite: vi.fn(),
   runQaTestFileScenarios: vi.fn(),
 }));
@@ -22,9 +30,23 @@ vi.mock("@openclaw/crabline", async (importOriginal) => {
   return await importOriginal<typeof import("@openclaw/crabline")>();
 });
 
-vi.mock("./suite.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./suite.js")>()),
-  runQaFlowSuite,
+vi.mock("./suite-run.runtime.js", () => ({
+  runQaFlowSuiteFromRuntimeCore: async (
+    params: object | undefined,
+    target?: { canonicalPath: string; stagedPath: string },
+  ) => {
+    if (params && target) {
+      evidenceTargets.set(params, target);
+      generatedOutputDirs.add(path.dirname(target.canonicalPath));
+    }
+    try {
+      return await runQaFlowSuite(params);
+    } finally {
+      if (params) {
+        evidenceTargets.delete(params);
+      }
+    }
+  },
 }));
 
 vi.mock("./test-file-scenario-runner.js", async (importOriginal) => ({
@@ -113,7 +135,11 @@ describe("qa suite runtime launcher", () => {
       ) => {
         const outputDir = params?.outputDir ?? "/tmp/qa-flow";
         const evidencePath = path.join(outputDir, "qa-evidence.json");
-        const evidence = await writeEvidence(evidencePath, params?.writeEvidenceFile);
+        const target = params ? evidenceTargets.get(params) : undefined;
+        const evidence = await writeEvidence(
+          target?.stagedPath ?? evidencePath,
+          params?.writeEvidenceFile,
+        );
         const scenarioIds = params?.scenarioIds ?? ["channel-chat-baseline"];
         return {
           evidence,
@@ -163,8 +189,11 @@ describe("qa suite runtime launcher", () => {
   afterEach(async () => {
     vi.unstubAllEnvs();
     await Promise.all(
-      tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+      [...tempRoots.splice(0), ...generatedOutputDirs].map((root) =>
+        fs.rm(root, { recursive: true, force: true }),
+      ),
     );
+    generatedOutputDirs.clear();
   });
 
   it("keeps Crabline out of unrelated live transport startup", async () => {
@@ -182,22 +211,26 @@ describe("qa suite runtime launcher", () => {
   });
 
   it("routes selected flow scenarios to the flow suite engine", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-flow-route-");
     const result = await runQaSuite({
-      repoRoot: process.cwd(),
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/flow-route",
       providerMode: "mock-openai",
       scenarioIds: ["channel-chat-baseline"],
     });
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "flow-route");
 
     expect(result).toMatchObject({
       executionKind: "flow",
       result: {
-        summaryPath: "/tmp/qa-flow/qa-suite-summary.json",
+        summaryPath: path.join(outputDir, "qa-suite-summary.json"),
       },
     });
     expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
     expect(runQaFlowSuite).toHaveBeenCalledWith(
       expect.objectContaining({
-        repoRoot: process.cwd(),
+        repoRoot,
+        outputDir,
         providerMode: "mock-openai",
         scenarioIds: ["channel-chat-baseline"],
       }),
@@ -279,6 +312,37 @@ describe("qa suite runtime launcher", () => {
     } finally {
       stderrWrite.mockRestore();
     }
+  });
+
+  it("does not publish stale or staged evidence when flow cleanup fails", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-cleanup-publication-");
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "cleanup-publication");
+    const evidencePath = path.join(outputDir, "qa-evidence.json");
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.writeFile(evidencePath, "stale\n", "utf8");
+    const cleanupError = new Error("agent harness cleanup failed");
+    let cleanupFailure: unknown;
+    try {
+      throwQaSuiteCleanupErrors({
+        cleanupFailures: [{ phase: "agent harnesses", error: cleanupError }],
+        runFailed: false,
+        runError: undefined,
+      });
+    } catch (error) {
+      cleanupFailure = error;
+    }
+    runQaFlowSuite.mockRejectedValueOnce(cleanupFailure);
+
+    await expect(
+      runQaSuite({
+        repoRoot,
+        outputDir,
+        providerMode: "mock-openai",
+        scenarioIds: ["channel-chat-baseline"],
+      }),
+    ).rejects.toBe(cleanupFailure);
+    await expect(fs.access(evidencePath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect((await fs.readdir(outputDir)).filter((entry) => entry.endsWith(".staged"))).toEqual([]);
   });
 
   it("partitions flow-only suites that request isolated workers", async () => {
@@ -1145,13 +1209,29 @@ describe("qa suite runtime launcher", () => {
 
   it("runs mixed flow and Vitest/Playwright scenarios as one suite", async () => {
     const repoRoot = await makeTempRepo("qa-suite-mixed-");
-    const result = await runQaSuite({
-      repoRoot,
-      outputDir: ".artifacts/qa-e2e/mixed",
-      scenarioIds: ["channel-chat-baseline", "control-ui-chat-flow-playwright"],
-    });
-
     const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "mixed");
+    const evidencePath = path.join(outputDir, "qa-evidence.json");
+    const rename = fs.rename.bind(fs);
+    const publications: Array<{ source: string; destination: string }> = [];
+    const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async (source, destination) => {
+      if (String(destination) === evidencePath) {
+        publications.push({ source: String(source), destination: String(destination) });
+        expect(path.basename(String(source))).toMatch(/^\.qa-evidence\.json\..+\.staged$/);
+        await expect(fs.access(evidencePath)).rejects.toMatchObject({ code: "ENOENT" });
+      }
+      return await rename(source, destination);
+    });
+    let result: Awaited<ReturnType<typeof runQaSuite>>;
+    try {
+      result = await runQaSuite({
+        repoRoot,
+        outputDir: ".artifacts/qa-e2e/mixed",
+        scenarioIds: ["channel-chat-baseline", "control-ui-chat-flow-playwright"],
+      });
+    } finally {
+      renameSpy.mockRestore();
+    }
+
     expect(result).toMatchObject({
       executionKind: "suite",
       result: {
@@ -1173,7 +1253,10 @@ describe("qa suite runtime launcher", () => {
       }),
     );
     await expect(fs.access(path.join(outputDir, "qa-suite-summary.json"))).resolves.toBeUndefined();
-    await expect(fs.access(path.join(outputDir, "qa-evidence.json"))).resolves.toBeUndefined();
+    expect(publications).toEqual([
+      { source: expect.any(String), destination: path.join(outputDir, "qa-evidence.json") },
+    ]);
+    await expect(fs.access(evidencePath)).resolves.toBeUndefined();
     await expect(fs.access(path.join(outputDir, "flow", "qa-evidence.json"))).rejects.toMatchObject(
       {
         code: "ENOENT",

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -5,7 +5,6 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { isRepoRootRelativeRef, toRepoRelativePath } from "./cli-paths.js";
 import { QaSuiteArtifactError, QaSuiteInfraError } from "./errors.js";
 import {
-  QA_EVIDENCE_FILENAME,
   QA_EVIDENCE_SUMMARY_KIND,
   QA_EVIDENCE_SUMMARY_SCHEMA_VERSION,
   buildQaSuiteEvidenceSummary,
@@ -27,6 +26,10 @@ import {
   type QaSeedScenarioWithSource,
 } from "./scenario-catalog.js";
 import { expandQaScenarioExecutionCells, type QaScenarioExecutionCell } from "./scenario-lane.js";
+import {
+  runQaSuiteEvidenceLifecycle,
+  type QaSuiteEvidenceTarget,
+} from "./suite-evidence-lifecycle.js";
 import {
   mapQaSuiteWithConcurrency,
   normalizeQaSuiteConcurrency,
@@ -214,15 +217,18 @@ async function loadQaLabServerRuntime() {
 }
 
 async function loadQaFlowSuiteRuntime() {
-  const [{ runQaFlowSuite }, startLab] = await Promise.all([
-    import("./suite.js"),
+  const [{ runQaFlowSuiteFromRuntimeCore }, startLab] = await Promise.all([
+    import("./suite-run.runtime.js"),
     loadQaLabServerRuntime(),
   ]);
-  return async (params: QaSuiteRunParams | undefined) =>
-    await runQaFlowSuite({
-      ...params,
-      startLab: params?.startLab ?? startLab,
-    });
+  return async (params: QaSuiteRunParams | undefined, target?: QaSuiteEvidenceTarget) =>
+    await runQaFlowSuiteFromRuntimeCore(
+      {
+        ...params,
+        startLab: params?.startLab ?? startLab,
+      },
+      target,
+    );
 }
 
 function resolveRequestedScenarios(params: {
@@ -697,9 +703,10 @@ async function writeUnifiedQaSuiteArtifacts(params: {
   scenarioIds: readonly string[];
   scenarios: readonly QaSuiteScenarioResult[];
   startedAt: Date;
+  target: QaSuiteEvidenceTarget;
 }) {
   await fs.mkdir(params.outputDir, { recursive: true });
-  const evidencePath = path.join(params.outputDir, QA_EVIDENCE_FILENAME);
+  const evidencePath = params.target.canonicalPath;
   const reportPath = path.join(params.outputDir, "qa-suite-report.md");
   const summaryPath = path.join(params.outputDir, "qa-suite-summary.json");
   const report = renderUnifiedQaSuiteReport({
@@ -722,7 +729,11 @@ async function writeUnifiedQaSuiteArtifacts(params: {
     scenarios: [...params.scenarios],
     startedAt: params.startedAt,
   }) satisfies QaSuiteSummaryJson;
-  await fs.writeFile(evidencePath, `${JSON.stringify(params.evidence, null, 2)}\n`, "utf8");
+  await fs.writeFile(
+    params.target.stagedPath,
+    `${JSON.stringify(params.evidence, null, 2)}\n`,
+    "utf8",
+  );
   await fs.writeFile(reportPath, report, "utf8");
   await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
   return {
@@ -738,13 +749,14 @@ async function writeUnifiedQaSuiteArtifacts(params: {
 async function runUnifiedQaSuite(params: {
   plan: Extract<QaSuiteExecutionPlan, { kind: "unified" }>;
   runParams: QaSuiteRunParams | undefined;
+  target: QaSuiteEvidenceTarget;
 }): Promise<QaUnifiedSuiteResult & { observedCells: QaScenarioExecutionCell[] }> {
   if (params.plan.testFileScenariosByKind.size > 0) {
     rejectFlowOnlySuiteOptionsForUnifiedRun(params.runParams);
   }
   const startedAt = new Date();
-  const repoRoot = path.resolve(params.runParams?.repoRoot ?? process.cwd());
-  const outputDir = await resolveQaSuiteOutputDir(repoRoot, params.runParams?.outputDir);
+  const repoRoot = params.runParams!.repoRoot!;
+  const outputDir = params.runParams!.outputDir!;
   // Only an explicitly selected single flow may replace the unified suite's mock default.
   const [selectedScenario] = params.plan.scenarios;
   const selectedProviderMode =
@@ -1356,6 +1368,7 @@ async function runUnifiedQaSuite(params: {
     scenarioIds: params.plan.scenarios.map((scenario) => scenario.id),
     scenarios,
     startedAt,
+    target: params.target,
   });
   const progressResults = params.plan.scenarios.flatMap((scenario) => {
     const results = scenarioResultsById.get(scenario.id);
@@ -1408,12 +1421,21 @@ async function runUnifiedQaSuite(params: {
 }
 
 export async function runQaSuite(...args: [QaSuiteRunParams?]): Promise<QaSuiteRuntimeResult> {
-  const runParams = args[0];
+  return await runQaSuiteEvidenceLifecycle(args[0], ({ repoRoot, outputDir, target }) =>
+    runQaSuiteCore({ ...args[0], repoRoot, outputDir }, target),
+  );
+}
+
+export async function runQaSuiteCore(
+  runParams: QaSuiteRunParams,
+  target: QaSuiteEvidenceTarget,
+): Promise<QaSuiteRuntimeResult> {
   const plan = await resolveSuiteExecutionPlan(runParams);
   if (plan.kind === "unified") {
     const { observedCells, ...result } = await runUnifiedQaSuite({
       runParams,
       plan,
+      target,
     });
     return {
       executionKind: "suite",
@@ -1422,7 +1444,8 @@ export async function runQaSuite(...args: [QaSuiteRunParams?]): Promise<QaSuiteR
       result,
     };
   }
-  const result = await runQaSuiteWithInfraRetry(() => runQaFlowSuiteFromRuntime(...args));
+  const runQaFlowSuite = await loadQaFlowSuiteRuntime();
+  const result = await runQaSuiteWithInfraRetry(() => runQaFlowSuite(runParams, target));
   const startedScenarioIds = new Set(result.startedScenarioIds);
   return {
     executionKind: "flow",
@@ -1435,8 +1458,9 @@ export async function runQaSuite(...args: [QaSuiteRunParams?]): Promise<QaSuiteR
 export async function runQaFlowSuiteFromRuntime(
   ...args: [QaSuiteRunParams?]
 ): Promise<QaSuiteResult> {
-  return await (
-    await loadQaFlowSuiteRuntime()
-  )(args[0]);
+  const runQaFlowSuite = await loadQaFlowSuiteRuntime();
+  return await runQaSuiteEvidenceLifecycle(args[0], ({ repoRoot, outputDir, target }) =>
+    runQaFlowSuite({ ...args[0], repoRoot, outputDir }, target),
+  );
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -5,6 +5,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { isRepoRootRelativeRef, toRepoRelativePath } from "./cli-paths.js";
 import { QaSuiteArtifactError, QaSuiteInfraError } from "./errors.js";
 import {
+  QA_EVIDENCE_FILENAME,
   QA_EVIDENCE_SUMMARY_KIND,
   QA_EVIDENCE_SUMMARY_SCHEMA_VERSION,
   buildQaSuiteEvidenceSummary,
@@ -27,8 +28,9 @@ import {
 } from "./scenario-catalog.js";
 import { expandQaScenarioExecutionCells, type QaScenarioExecutionCell } from "./scenario-lane.js";
 import {
+  completeQaSuiteWithoutEvidence,
   runQaSuiteEvidenceLifecycle,
-  type QaSuiteEvidenceTarget,
+  type QaSuiteDeferredCompletion,
 } from "./suite-evidence-lifecycle.js";
 import {
   mapQaSuiteWithConcurrency,
@@ -221,14 +223,11 @@ async function loadQaFlowSuiteRuntime() {
     import("./suite-run.runtime.js"),
     loadQaLabServerRuntime(),
   ]);
-  return async (params: QaSuiteRunParams | undefined, target?: QaSuiteEvidenceTarget) =>
-    await runQaFlowSuiteFromRuntimeCore(
-      {
-        ...params,
-        startLab: params?.startLab ?? startLab,
-      },
-      target,
-    );
+  return async (params: QaSuiteRunParams | undefined) =>
+    await runQaFlowSuiteFromRuntimeCore({
+      ...params,
+      startLab: params?.startLab ?? startLab,
+    });
 }
 
 function resolveRequestedScenarios(params: {
@@ -703,10 +702,9 @@ async function writeUnifiedQaSuiteArtifacts(params: {
   scenarioIds: readonly string[];
   scenarios: readonly QaSuiteScenarioResult[];
   startedAt: Date;
-  target: QaSuiteEvidenceTarget;
 }) {
   await fs.mkdir(params.outputDir, { recursive: true });
-  const evidencePath = params.target.canonicalPath;
+  const evidencePath = path.join(params.outputDir, QA_EVIDENCE_FILENAME);
   const reportPath = path.join(params.outputDir, "qa-suite-report.md");
   const summaryPath = path.join(params.outputDir, "qa-suite-summary.json");
   const report = renderUnifiedQaSuiteReport({
@@ -729,11 +727,6 @@ async function writeUnifiedQaSuiteArtifacts(params: {
     scenarios: [...params.scenarios],
     startedAt: params.startedAt,
   }) satisfies QaSuiteSummaryJson;
-  await fs.writeFile(
-    params.target.stagedPath,
-    `${JSON.stringify(params.evidence, null, 2)}\n`,
-    "utf8",
-  );
   await fs.writeFile(reportPath, report, "utf8");
   await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
   return {
@@ -749,14 +742,13 @@ async function writeUnifiedQaSuiteArtifacts(params: {
 async function runUnifiedQaSuite(params: {
   plan: Extract<QaSuiteExecutionPlan, { kind: "unified" }>;
   runParams: QaSuiteRunParams | undefined;
-  target: QaSuiteEvidenceTarget;
-}): Promise<QaUnifiedSuiteResult & { observedCells: QaScenarioExecutionCell[] }> {
+}) {
   if (params.plan.testFileScenariosByKind.size > 0) {
     rejectFlowOnlySuiteOptionsForUnifiedRun(params.runParams);
   }
   const startedAt = new Date();
-  const repoRoot = params.runParams!.repoRoot!;
-  const outputDir = params.runParams!.outputDir!;
+  const repoRoot = path.resolve(params.runParams?.repoRoot ?? process.cwd());
+  const outputDir = await resolveQaSuiteOutputDir(repoRoot, params.runParams?.outputDir);
   // Only an explicitly selected single flow may replace the unified suite's mock default.
   const [selectedScenario] = params.plan.scenarios;
   const selectedProviderMode =
@@ -799,6 +791,7 @@ async function runUnifiedQaSuite(params: {
         defaultConcurrency,
       );
   const evidenceSummaries: QaEvidenceSummaryJson[] = [];
+  const childCompletions: QaSuiteDeferredCompletion<unknown>["complete"][] = [];
   const scenarioResultsById = new Map<string, QaSuiteScenarioResult[]>();
   const observedCellsByKey = new Map<string, QaScenarioExecutionCell>();
   const recordObservedScenarios = (
@@ -971,7 +964,7 @@ async function runUnifiedQaSuite(params: {
             if (unavailableDetails) {
               return buildCredentialUnavailableResult(unavailableDetails);
             }
-            const result = await runFlowSuite({
+            const child = await runFlowSuite({
               ...params.runParams,
               ...(progress
                 ? {
@@ -1017,9 +1010,11 @@ async function runUnifiedQaSuite(params: {
               }
               return buildCredentialUnavailableResult(details);
             });
-            if ("evidenceSummaries" in result) {
-              return result;
+            if ("evidenceSummaries" in child) {
+              return child;
             }
+            childCompletions.push(child.complete);
+            const result = child.result;
             const startedScenarioIdSet = new Set(result.startedScenarioIds);
             recordObservedScenarios(
               partition.scenarios.filter((scenario) => startedScenarioIdSet.has(scenario.id)),
@@ -1368,7 +1363,6 @@ async function runUnifiedQaSuite(params: {
     scenarioIds: params.plan.scenarios.map((scenario) => scenario.id),
     scenarios,
     startedAt,
-    target: params.target,
   });
   const progressResults = params.plan.scenarios.flatMap((scenario) => {
     const results = scenarioResultsById.get(scenario.id);
@@ -1406,61 +1400,76 @@ async function runUnifiedQaSuite(params: {
       },
     ];
   });
-  progress?.complete(progressResults, finishedAt.toISOString());
-  params.runParams?.lab?.setLatestReport({
-    outputPath: unifiedResult.reportPath,
-    markdown: unifiedResult.report,
-    generatedAt: finishedAt.toISOString(),
+  return Object.freeze({
+    evidence,
+    result: {
+      ...unifiedResult,
+      observedCells: [...observedCellsByKey.values()].toSorted((left, right) =>
+        JSON.stringify(left).localeCompare(JSON.stringify(right)),
+      ),
+    },
+    complete: async () => {
+      await Promise.all(childCompletions.map((run) => run()));
+      progress?.complete(progressResults, finishedAt.toISOString());
+      params.runParams?.lab?.setLatestReport({
+        outputPath: unifiedResult.reportPath,
+        markdown: unifiedResult.report,
+        generatedAt: finishedAt.toISOString(),
+      });
+    },
   });
-  return {
-    ...unifiedResult,
-    observedCells: [...observedCellsByKey.values()].toSorted((left, right) =>
-      JSON.stringify(left).localeCompare(JSON.stringify(right)),
-    ),
-  };
 }
 
 export async function runQaSuite(...args: [QaSuiteRunParams?]): Promise<QaSuiteRuntimeResult> {
-  return await runQaSuiteEvidenceLifecycle(args[0], ({ repoRoot, outputDir, target }) =>
-    runQaSuiteCore({ ...args[0], repoRoot, outputDir }, target),
-  );
+  return args[0]?.writeEvidenceFile === false
+    ? await completeQaSuiteWithoutEvidence(() => runQaSuiteCore(args[0]))
+    : await runQaSuiteEvidenceLifecycle(args[0], ({ repoRoot, outputDir }) =>
+        runQaSuiteCore({ ...args[0], repoRoot, outputDir }),
+      );
 }
 
 export async function runQaSuiteCore(
-  runParams: QaSuiteRunParams,
-  target: QaSuiteEvidenceTarget,
-): Promise<QaSuiteRuntimeResult> {
+  runParams: QaSuiteRunParams | undefined,
+): Promise<QaSuiteDeferredCompletion<QaSuiteRuntimeResult>> {
   const plan = await resolveSuiteExecutionPlan(runParams);
   if (plan.kind === "unified") {
-    const { observedCells, ...result } = await runUnifiedQaSuite({
+    const completion = await runUnifiedQaSuite({
       runParams,
       plan,
-      target,
     });
-    return {
-      executionKind: "suite",
-      expectedCells: plan.expectedCells,
-      observedCells,
-      result,
-    };
+    const { observedCells, ...result } = completion.result;
+    return Object.freeze({
+      ...completion,
+      result: {
+        executionKind: "suite",
+        expectedCells: plan.expectedCells,
+        observedCells,
+        result,
+      },
+    });
   }
   const runQaFlowSuite = await loadQaFlowSuiteRuntime();
-  const result = await runQaSuiteWithInfraRetry(() => runQaFlowSuite(runParams, target));
-  const startedScenarioIds = new Set(result.startedScenarioIds);
-  return {
-    executionKind: "flow",
-    expectedCells: plan.expectedCells,
-    observedCells: plan.expectedCells.filter((cell) => startedScenarioIds.has(cell.scenarioId)),
-    result,
-  };
+  const completion = await runQaSuiteWithInfraRetry(() => runQaFlowSuite(runParams));
+  const startedScenarioIds = new Set(completion.result.startedScenarioIds);
+  return Object.freeze({
+    ...completion,
+    result: {
+      executionKind: "flow",
+      expectedCells: plan.expectedCells,
+      observedCells: plan.expectedCells.filter((cell) => startedScenarioIds.has(cell.scenarioId)),
+      result: completion.result,
+    },
+  });
 }
 
 export async function runQaFlowSuiteFromRuntime(
   ...args: [QaSuiteRunParams?]
 ): Promise<QaSuiteResult> {
   const runQaFlowSuite = await loadQaFlowSuiteRuntime();
-  return await runQaSuiteEvidenceLifecycle(args[0], ({ repoRoot, outputDir, target }) =>
-    runQaFlowSuite({ ...args[0], repoRoot, outputDir }, target),
-  );
+  return args[0]?.writeEvidenceFile === false
+    ? await completeQaSuiteWithoutEvidence(() => runQaFlowSuite(args[0]))
+    : await runQaSuiteEvidenceLifecycle(args[0], ({ repoRoot, outputDir }) =>
+        runQaFlowSuite({ ...args[0], repoRoot, outputDir }),
+      );
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
@@ -1,15 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createQaBusState } from "./bus-state.js";
 import type { QaLabServerHandle } from "./lab-server.types.js";
 import type { QaTransportAdapterFactory } from "./qa-transport-registry.js";
 import { runQaFlowSuiteIsolated } from "./suite-run-isolated.js";
 import { runQaFlowSuiteStandard } from "./suite-run-standard.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
-import type {
-  QaSuiteResolvedRunContext,
-  QaSuiteRunner,
-  QaSuiteScenarioRunner,
-} from "./suite-types.js";
+import type { QaSuiteResolvedRunContext, QaSuiteScenarioRunner } from "./suite-types.js";
 
 const mocks = vi.hoisted(() => ({
   disposeRegisteredAgentHarnesses: vi.fn(async () => {}),
@@ -26,13 +25,14 @@ const mocks = vi.hoisted(() => ({
     stop: vi.fn(async () => {}),
   })),
   writeQaSuiteArtifacts: vi.fn(async () => ({
-    evidence: undefined,
+    evidence: { kind: "test" },
     evidencePath: "/qa-output/qa-evidence.json",
     report: "",
     reportPath: "/qa-output/qa-suite-report.md",
     summaryPath: "/qa-output/qa-suite-summary.json",
   })),
 }));
+const tempRoots: string[] = [];
 
 vi.mock("openclaw/plugin-sdk/agent-harness", () => ({
   disposeRegisteredAgentHarnesses: mocks.disposeRegisteredAgentHarnesses,
@@ -91,6 +91,12 @@ function createCleanupTestContext(): QaSuiteResolvedRunContext {
   };
 }
 
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((repoRoot) => fs.rm(repoRoot, { recursive: true, force: true })),
+  );
+});
+
 describe("isolated QA suite transport cleanup", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -128,16 +134,23 @@ describe("isolated QA suite transport cleanup", () => {
     const cleanupError = new Error("agent harness disposal failed");
     mocks.disposeRegisteredAgentHarnesses.mockRejectedValueOnce(cleanupError);
     const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    const runChild = vi.fn<QaSuiteRunner>().mockResolvedValue({
-      outputDir: "/qa-child",
-      evidencePath: "/qa-child/qa-evidence.json",
-      reportPath: "/qa-child/qa-suite-report.md",
-      summaryPath: "/qa-child/qa-suite-summary.json",
-      report: "",
-      scenarios: [{ name: "leased-channel-scenario", status: "pass", steps: [] }],
-      startedScenarioIds: ["leased-channel-scenario"],
-      watchUrl: lab.baseUrl,
-    });
+    const runChild = vi.fn().mockResolvedValue(
+      Object.freeze({
+        evidence: { kind: "test" },
+        complete: vi.fn(),
+        result: {
+          outputDir: "/qa-child",
+          evidence: { kind: "test" },
+          evidencePath: "/qa-child/qa-evidence.json",
+          reportPath: "/qa-child/qa-suite-report.md",
+          summaryPath: "/qa-child/qa-suite-summary.json",
+          report: "",
+          scenarios: [{ name: "leased-channel-scenario", status: "pass", steps: [] }],
+          startedScenarioIds: ["leased-channel-scenario"],
+          watchUrl: lab.baseUrl,
+        },
+      }),
+    );
     const context = createCleanupTestContext();
     context.progressEnabled = true;
 
@@ -157,6 +170,9 @@ describe("isolated QA suite transport cleanup", () => {
     expect(lab.stop).toHaveBeenCalledOnce();
     expect(lab.setLatestReport).toHaveBeenCalledWith(
       expect.objectContaining({ outputPath: "/qa-output/qa-suite-report.md" }),
+    );
+    expect(lab.setScenarioRun).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: "completed" }),
     );
     expect((thrown as Error).message.split("\n")[0]).toBe(
       "QA scenarios passed, but cleanup failed",
@@ -186,7 +202,7 @@ describe("isolated QA suite transport cleanup", () => {
     const runScenario = vi
       .fn<QaSuiteScenarioRunner>()
       .mockResolvedValue({ name: "leased-channel-scenario", status: "pass", steps: [] });
-    const runChild: QaSuiteRunner = async (childParams) => {
+    const runChild = async (childParams: Parameters<typeof runQaFlowSuiteStandard>[0]) => {
       if (!childParams) {
         throw new Error("expected nested standard run params");
       }
@@ -204,7 +220,8 @@ describe("isolated QA suite transport cleanup", () => {
     const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
     try {
-      await runQaFlowSuiteIsolated({ startLab }, context, runChild);
+      const completion = await runQaFlowSuiteIsolated({ startLab }, context, runChild);
+      await completion.complete();
 
       const completionLines = stderrWrite.mock.calls
         .flat()
@@ -218,6 +235,52 @@ describe("isolated QA suite transport cleanup", () => {
     } finally {
       stderrWrite.mockRestore();
     }
+  });
+
+  it("leaves isolated publication state untouched when evidence writing is disabled", async () => {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-isolated-no-evidence-"));
+    tempRoots.push(repoRoot);
+    const outputDir = path.join(repoRoot, "output");
+    const canonicalPath = path.join(outputDir, "qa-evidence.json");
+    const lockPath = `${canonicalPath}.lock`;
+    const stagedPath = path.join(outputDir, ".qa-evidence.json.preseed.staged");
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.writeFile(canonicalPath, "canonical\n", "utf8");
+    await fs.writeFile(lockPath, "lock\n", "utf8");
+    await fs.writeFile(stagedPath, "staged\n", "utf8");
+    const lab = createCleanupTestLab();
+    const context = createCleanupTestContext();
+    context.repoRoot = repoRoot;
+    context.outputDir = outputDir;
+    context.channelDriver = undefined;
+    const runChild = vi.fn().mockResolvedValue(
+      Object.freeze({
+        evidence: { kind: "test" },
+        complete: vi.fn(),
+        result: {
+          outputDir: path.join(outputDir, "child"),
+          evidence: { kind: "test" },
+          evidencePath: path.join(outputDir, "child", "qa-evidence.json"),
+          reportPath: path.join(outputDir, "child", "qa-suite-report.md"),
+          summaryPath: path.join(outputDir, "child", "qa-suite-summary.json"),
+          report: "",
+          scenarios: [{ name: "leased-channel-scenario", status: "pass", steps: [] }],
+          startedScenarioIds: ["leased-channel-scenario"],
+          watchUrl: lab.baseUrl,
+        },
+      }),
+    );
+
+    const completion = await runQaFlowSuiteIsolated(
+      { startLab: async () => lab, writeEvidenceFile: false },
+      context,
+      runChild,
+    );
+    await completion.complete();
+
+    await expect(fs.readFile(canonicalPath, "utf8")).resolves.toBe("canonical\n");
+    await expect(fs.readFile(lockPath, "utf8")).resolves.toBe("lock\n");
+    await expect(fs.readFile(stagedPath, "utf8")).resolves.toBe("staged\n");
   });
 
   it.each(["cleanup", "cleanupAfterGatewayStop"] as const)(
@@ -254,7 +317,7 @@ describe("isolated QA suite transport cleanup", () => {
           };
         },
       };
-      const runChild = vi.fn<QaSuiteRunner>();
+      const runChild = vi.fn();
 
       await expect(
         runQaFlowSuiteIsolated(

--- a/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
@@ -167,6 +167,7 @@ describe("isolated QA suite transport cleanup", () => {
     expect((thrown as Error).message).toContain(
       "retained artifacts: output=/qa-output report=/qa-output/qa-suite-report.md summary=/qa-output/qa-suite-summary.json",
     );
+    expect((thrown as Error).message).not.toContain(" evidence=");
     expect((thrown as Error).cause).toBe(cleanupError);
     expect(stderrWrite.mock.calls.flat().join("")).not.toContain("run complete");
     stderrWrite.mockRestore();

--- a/extensions/qa-lab/src/suite-run-isolated.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.ts
@@ -4,13 +4,12 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { QaLabLatestReport, QaLabScenarioOutcome } from "./lab-server.types.js";
 import { sanitizeQaProgressValue as sanitizeQaSuiteProgressValue } from "./progress-format.js";
 import { writeQaSuiteArtifacts } from "./suite-artifacts.js";
-import type { QaSuiteEvidenceTarget } from "./suite-evidence-lifecycle.js";
+import type { QaSuiteDeferredCompletion } from "./suite-evidence-lifecycle.js";
 import { mapQaSuiteWithConcurrency, resolveQaSuiteWorkerStartStaggerMs } from "./suite-planning.js";
 import { buildQaIsolatedScenarioWorkerParams } from "./suite-support.js";
 import type {
   QaSuiteResolvedRunContext,
   QaSuiteResult,
-  QaSuiteRunner,
   QaSuiteRunParams,
   QaSuiteScenarioResult,
 } from "./suite-types.js";
@@ -26,9 +25,8 @@ import {
 export async function runQaFlowSuiteIsolated(
   params: QaSuiteRunParams | undefined,
   context: QaSuiteResolvedRunContext,
-  runQaFlowSuite: QaSuiteRunner,
-  evidenceTarget?: QaSuiteEvidenceTarget,
-): Promise<QaSuiteResult> {
+  runQaFlowSuite: (params?: QaSuiteRunParams) => Promise<QaSuiteDeferredCompletion<QaSuiteResult>>,
+): Promise<QaSuiteDeferredCompletion<QaSuiteResult>> {
   const {
     startedAt,
     repoRoot,
@@ -141,7 +139,8 @@ export async function runQaFlowSuiteIsolated(
   let isolatedRunError: unknown;
   let parentTransportCleaned = false;
   let result: QaSuiteResult | undefined;
-  let completionProgress: string | undefined;
+  let complete: (() => void | Promise<void>) | undefined;
+  const childCompletions: QaSuiteDeferredCompletion<QaSuiteResult>["complete"][] = [];
   try {
     if (params?.channelDriver === "live") {
       // The parent only renders aggregate artifacts. Release its live credentials
@@ -171,7 +170,7 @@ export async function runQaFlowSuiteIsolated(
         updateScenarioRun();
         try {
           const scenarioOutputDir = path.join(outputDir, "scenarios", scenario.id);
-          const childSuiteResult: QaSuiteResult = await runQaFlowSuite(
+          const childCompletion = await runQaFlowSuite(
             markQaSuiteNestedRun({
               ...buildQaIsolatedScenarioWorkerParams({
                 repoRoot,
@@ -190,6 +189,8 @@ export async function runQaFlowSuiteIsolated(
               writeEvidenceFile: false,
             }),
           );
+          childCompletions.push(childCompletion.complete);
+          const childSuiteResult = childCompletion.result;
           for (const scenarioId of childSuiteResult.startedScenarioIds) {
             startedScenarioIds.add(scenarioId);
           }
@@ -265,13 +266,6 @@ export async function runQaFlowSuiteIsolated(
     );
     await artifactWriteQueue;
     const finishedAt = new Date();
-    lab.setScenarioRun({
-      kind: "suite",
-      status: "completed",
-      startedAt: startedAt.toISOString(),
-      finishedAt: finishedAt.toISOString(),
-      scenarios: [...liveScenarioOutcomes],
-    });
     const { evidence, evidencePath, report, reportPath, summaryPath } = await writeQaSuiteArtifacts(
       {
         repoRoot,
@@ -291,8 +285,7 @@ export async function runQaFlowSuiteIsolated(
         channelDriver: transportFactoryResult.driver,
         channelDriverSelection: params?.channelDriverSelection,
         isolatedWorkers: true,
-        writeEvidenceFile: evidenceTarget !== undefined,
-        evidenceTarget,
+        writeEvidenceFile: false,
         // When the caller supplied an explicit non-empty --scenario filter,
         // record the executed (post-selectQaFlowSuiteScenarios-normalized) ids
         // so the summary matches what actually ran. When the caller passed
@@ -305,12 +298,22 @@ export async function runQaFlowSuiteIsolated(
             : undefined,
       },
     );
-    lab.setLatestReport({
-      outputPath: reportPath,
-      markdown: report,
-      generatedAt: finishedAt.toISOString(),
-    } satisfies QaLabLatestReport);
-    completionProgress = "run complete";
+    complete = async () => {
+      await Promise.all(childCompletions.map((run) => run()));
+      lab.setScenarioRun({
+        kind: "suite",
+        status: "completed",
+        startedAt: startedAt.toISOString(),
+        finishedAt: finishedAt.toISOString(),
+        scenarios: [...liveScenarioOutcomes],
+      });
+      lab.setLatestReport({
+        outputPath: reportPath,
+        markdown: report,
+        generatedAt: finishedAt.toISOString(),
+      } satisfies QaLabLatestReport);
+      writeQaSuiteProgress(progressEnabled, "run complete");
+    };
     result = {
       outputDir,
       evidence,
@@ -344,9 +347,12 @@ export async function runQaFlowSuiteIsolated(
       result,
     });
   }
-  if (!result || !completionProgress) {
+  if (!result?.evidence || !complete) {
     throw new Error("QA suite completed without terminal result metadata");
   }
-  writeQaSuiteProgress(progressEnabled, completionProgress);
-  return result;
+  return Object.freeze({
+    evidence: result.evidence,
+    result,
+    complete,
+  });
 }

--- a/extensions/qa-lab/src/suite-run-isolated.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.ts
@@ -4,6 +4,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { QaLabLatestReport, QaLabScenarioOutcome } from "./lab-server.types.js";
 import { sanitizeQaProgressValue as sanitizeQaSuiteProgressValue } from "./progress-format.js";
 import { writeQaSuiteArtifacts } from "./suite-artifacts.js";
+import type { QaSuiteEvidenceTarget } from "./suite-evidence-lifecycle.js";
 import { mapQaSuiteWithConcurrency, resolveQaSuiteWorkerStartStaggerMs } from "./suite-planning.js";
 import { buildQaIsolatedScenarioWorkerParams } from "./suite-support.js";
 import type {
@@ -26,6 +27,7 @@ export async function runQaFlowSuiteIsolated(
   params: QaSuiteRunParams | undefined,
   context: QaSuiteResolvedRunContext,
   runQaFlowSuite: QaSuiteRunner,
+  evidenceTarget?: QaSuiteEvidenceTarget,
 ): Promise<QaSuiteResult> {
   const {
     startedAt,
@@ -115,7 +117,7 @@ export async function runQaFlowSuiteIsolated(
           channelDriver: transportFactoryResult.driver,
           channelDriverSelection: params?.channelDriverSelection,
           isolatedWorkers: true,
-          writeEvidenceFile: params?.writeEvidenceFile,
+          writeEvidenceFile: false,
           scenarioIds:
             params?.scenarioIds && params.scenarioIds.length > 0
               ? selectedScenarios.map((scenario) => scenario.id)
@@ -140,7 +142,6 @@ export async function runQaFlowSuiteIsolated(
   let parentTransportCleaned = false;
   let result: QaSuiteResult | undefined;
   let completionProgress: string | undefined;
-  let evidenceWritten = false;
   try {
     if (params?.channelDriver === "live") {
       // The parent only renders aggregate artifacts. Release its live credentials
@@ -171,8 +172,8 @@ export async function runQaFlowSuiteIsolated(
         try {
           const scenarioOutputDir = path.join(outputDir, "scenarios", scenario.id);
           const childSuiteResult: QaSuiteResult = await runQaFlowSuite(
-            markQaSuiteNestedRun(
-              buildQaIsolatedScenarioWorkerParams({
+            markQaSuiteNestedRun({
+              ...buildQaIsolatedScenarioWorkerParams({
                 repoRoot,
                 outputDir: scenarioOutputDir,
                 providerMode,
@@ -186,7 +187,8 @@ export async function runQaFlowSuiteIsolated(
                 scenario,
                 input: params,
               }),
-            ),
+              writeEvidenceFile: false,
+            }),
           );
           for (const scenarioId of childSuiteResult.startedScenarioIds) {
             startedScenarioIds.add(scenarioId);
@@ -289,7 +291,8 @@ export async function runQaFlowSuiteIsolated(
         channelDriver: transportFactoryResult.driver,
         channelDriverSelection: params?.channelDriverSelection,
         isolatedWorkers: true,
-        writeEvidenceFile: params?.writeEvidenceFile,
+        writeEvidenceFile: evidenceTarget !== undefined,
+        evidenceTarget,
         // When the caller supplied an explicit non-empty --scenario filter,
         // record the executed (post-selectQaFlowSuiteScenarios-normalized) ids
         // so the summary matches what actually ran. When the caller passed
@@ -308,7 +311,6 @@ export async function runQaFlowSuiteIsolated(
       generatedAt: finishedAt.toISOString(),
     } satisfies QaLabLatestReport);
     completionProgress = "run complete";
-    evidenceWritten = evidence !== undefined && (params?.writeEvidenceFile ?? true);
     result = {
       outputDir,
       evidence,
@@ -340,7 +342,6 @@ export async function runQaFlowSuiteIsolated(
       runFailed: isolatedRunFailed,
       runError: isolatedRunError,
       result,
-      evidenceWritten,
     });
   }
   if (!result || !completionProgress) {

--- a/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
+++ b/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
@@ -1,6 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { QaLabServerHandle } from "./lab-server.types.js";
 import { runQaFlowSuiteStandard } from "./suite-run-standard.js";
+import { runQaFlowSuiteFromRuntime } from "./suite-run.runtime.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
 import type {
   QaSuiteResolvedRunContext,
@@ -46,6 +50,11 @@ const mocks = vi.hoisted(() => ({
   waitForGatewayHealthy: vi.fn(async () => {}),
   waitForTransportReady: vi.fn(async () => {}),
   runQaFlowSuiteCleanupPlan: vi.fn<typeof runQaFlowSuiteCleanupPlan>(async () => []),
+  runQaSuiteScenarioDefinitionForRuntime: vi.fn(async () => ({
+    name: "runtime-soak-100-turn",
+    status: "pass" as const,
+    steps: [],
+  })),
   writeQaSuiteProgress: vi.fn(),
 }));
 
@@ -80,6 +89,7 @@ vi.mock("./suite.js", async (importOriginal) => ({
   requireQaSuiteStartLab: vi.fn(),
   resolveQaSuiteTransportReadyTimeoutMs: vi.fn(() => 1_000),
   runQaFlowSuiteCleanupPlan: mocks.runQaFlowSuiteCleanupPlan,
+  runQaSuiteScenarioDefinitionForRuntime: mocks.runQaSuiteScenarioDefinitionForRuntime,
   waitForQaLabReadyOrStopOwned: vi.fn(async () => {}),
   writeQaSuiteProgress: mocks.writeQaSuiteProgress,
 }));
@@ -132,6 +142,14 @@ function makeRetryTestResult(status: "pass" | "fail"): QaSuiteScenarioResult {
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.runQaFlowSuiteCleanupPlan.mockResolvedValue([]);
+});
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((repoRoot) => fs.rm(repoRoot, { recursive: true, force: true })),
+  );
 });
 
 describe("QA suite Control UI ownership", () => {
@@ -237,6 +255,48 @@ describe("QA runtime parity scenario retry isolation", () => {
         String(message).startsWith("run complete"),
       ),
     ).toHaveLength(0);
+  });
+
+  it("discards staged evidence when direct runtime cleanup fails", async () => {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-direct-runtime-cleanup-"));
+    tempRoots.push(repoRoot);
+    const outputDir = path.join(repoRoot, "output");
+    const evidencePath = path.join(outputDir, "qa-evidence.json");
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.writeFile(evidencePath, "stale\n", "utf8");
+    const cleanupError = new Error("direct runtime cleanup failed");
+    mocks.runQaFlowSuiteCleanupPlan.mockResolvedValueOnce([
+      { phase: "agent harnesses", error: cleanupError },
+    ]);
+    mocks.writeQaSuiteArtifacts.mockImplementationOnce(
+      async (params: { evidenceTarget?: { stagedPath: string }; outputDir: string }) => {
+        const stagedPath = params.evidenceTarget?.stagedPath;
+        if (!stagedPath) {
+          throw new Error("expected direct runtime evidence target");
+        }
+        await fs.writeFile(stagedPath, "candidate\n", "utf8");
+        return {
+          evidence: { kind: "test" },
+          evidencePath,
+          report: "",
+          reportPath: path.join(params.outputDir, "qa-suite-report.md"),
+          summaryPath: path.join(params.outputDir, "qa-suite-summary.json"),
+        };
+      },
+    );
+
+    const thrown = await runQaFlowSuiteFromRuntime({
+      repoRoot,
+      outputDir,
+      lab: makeRetryTestLab(),
+      providerMode: "live-frontier",
+      scenarioIds: ["runtime-soak-100-turn"],
+    }).catch((error: unknown) => error);
+
+    expect((thrown as Error).message).toContain("direct runtime cleanup failed");
+    expect(mocks.runQaSuiteScenarioDefinitionForRuntime).toHaveBeenCalledOnce();
+    await expect(fs.access(evidencePath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect((await fs.readdir(outputDir)).filter((entry) => entry.endsWith(".staged"))).toEqual([]);
   });
 
   it.each([

--- a/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
+++ b/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
@@ -41,7 +41,7 @@ const mocks = vi.hoisted(() => ({
     stop: vi.fn(async () => {}),
   })),
   writeQaSuiteArtifacts: vi.fn(async () => ({
-    evidence: undefined,
+    evidence: { kind: "test" },
     evidencePath: "/qa-output/qa-evidence.json",
     report: "",
     reportPath: "/qa-output/qa-suite-report.md",
@@ -67,7 +67,8 @@ vi.mock("./gateway-child.js", () => ({
 vi.mock("./providers/server-runtime.js", () => ({
   startQaProviderServer: vi.fn(async () => undefined),
 }));
-vi.mock("./runtime-parity.js", () => ({
+vi.mock("./runtime-parity.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./runtime-parity.js")>()),
   captureRuntimeParityCell: mocks.captureRuntimeParityCell,
 }));
 vi.mock("./suite-artifacts.js", () => ({
@@ -85,8 +86,9 @@ vi.mock("./suite.js", async (importOriginal) => ({
     adapter: { id: "qa-channel" },
     cleanupBeforeGatewayStop: vi.fn(async () => {}),
     cleanupAfterGatewayStop: vi.fn(async () => {}),
+    cleanupWithoutGateway: vi.fn(async () => {}),
   })),
-  requireQaSuiteStartLab: vi.fn(),
+  requireQaSuiteStartLab: vi.fn((startLab) => startLab),
   resolveQaSuiteTransportReadyTimeoutMs: vi.fn(() => 1_000),
   runQaFlowSuiteCleanupPlan: mocks.runQaFlowSuiteCleanupPlan,
   runQaSuiteScenarioDefinitionForRuntime: mocks.runQaSuiteScenarioDefinitionForRuntime,
@@ -194,7 +196,7 @@ describe("QA suite Control UI ownership", () => {
       .fn<QaSuiteScenarioRunner>()
       .mockResolvedValue(makeRetryTestResult("pass"));
 
-    await runQaFlowSuiteStandard(
+    const completion = await runQaFlowSuiteStandard(
       {
         lab,
         ...(testCase.explicit === undefined ? {} : { controlUiEnabled: testCase.explicit }),
@@ -202,6 +204,7 @@ describe("QA suite Control UI ownership", () => {
       context,
       runScenario,
     );
+    await completion.complete();
 
     expect(mocks.startQaGatewayChild).toHaveBeenCalledWith(
       expect.objectContaining({ controlUiEnabled: testCase.enabled }),
@@ -247,9 +250,7 @@ describe("QA runtime parity scenario retry isolation", () => {
       "retained artifacts: output=/qa-output report=/qa-output/qa-suite-report.md summary=/qa-output/qa-suite-summary.json",
     );
     expect((thrown as Error).cause).toBe(cleanupError);
-    expect(lab.setLatestReport).toHaveBeenCalledWith(
-      expect.objectContaining({ outputPath: "/qa-output/qa-suite-report.md" }),
-    );
+    expect(lab.setLatestReport).not.toHaveBeenCalled();
     expect(
       mocks.writeQaSuiteProgress.mock.calls.filter(([, message]) =>
         String(message).startsWith("run complete"),
@@ -268,22 +269,15 @@ describe("QA runtime parity scenario retry isolation", () => {
     mocks.runQaFlowSuiteCleanupPlan.mockResolvedValueOnce([
       { phase: "agent harnesses", error: cleanupError },
     ]);
-    mocks.writeQaSuiteArtifacts.mockImplementationOnce(
-      async (params: { evidenceTarget?: { stagedPath: string }; outputDir: string }) => {
-        const stagedPath = params.evidenceTarget?.stagedPath;
-        if (!stagedPath) {
-          throw new Error("expected direct runtime evidence target");
-        }
-        await fs.writeFile(stagedPath, "candidate\n", "utf8");
-        return {
-          evidence: { kind: "test" },
-          evidencePath,
-          report: "",
-          reportPath: path.join(params.outputDir, "qa-suite-report.md"),
-          summaryPath: path.join(params.outputDir, "qa-suite-summary.json"),
-        };
-      },
-    );
+    mocks.writeQaSuiteArtifacts.mockImplementationOnce(async (params: { outputDir: string }) => {
+      return {
+        evidence: { kind: "test" },
+        evidencePath,
+        report: "",
+        reportPath: path.join(params.outputDir, "qa-suite-report.md"),
+        summaryPath: path.join(params.outputDir, "qa-suite-summary.json"),
+      };
+    });
 
     const thrown = await runQaFlowSuiteFromRuntime({
       repoRoot,
@@ -299,6 +293,60 @@ describe("QA runtime parity scenario retry isolation", () => {
     expect((await fs.readdir(outputDir)).filter((entry) => entry.endsWith(".staged"))).toEqual([]);
   });
 
+  it("leaves standard direct-runtime publication state untouched when disabled", async () => {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-direct-runtime-no-evidence-"));
+    tempRoots.push(repoRoot);
+    const outputDir = path.join(repoRoot, "output");
+    const canonicalPath = path.join(outputDir, "qa-evidence.json");
+    const lockPath = `${canonicalPath}.lock`;
+    const stagedPath = path.join(outputDir, ".qa-evidence.json.preseed.staged");
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.writeFile(canonicalPath, "canonical\n", "utf8");
+    await fs.writeFile(lockPath, "lock\n", "utf8");
+    await fs.writeFile(stagedPath, "staged\n", "utf8");
+
+    await runQaFlowSuiteFromRuntime({
+      repoRoot,
+      outputDir,
+      lab: makeRetryTestLab(),
+      providerMode: "live-frontier",
+      scenarioIds: ["runtime-soak-100-turn"],
+      writeEvidenceFile: false,
+    });
+
+    await expect(fs.readFile(canonicalPath, "utf8")).resolves.toBe("canonical\n");
+    await expect(fs.readFile(lockPath, "utf8")).resolves.toBe("lock\n");
+    await expect(fs.readFile(stagedPath, "utf8")).resolves.toBe("staged\n");
+  });
+
+  it("leaves parity direct-runtime publication state untouched when disabled", async () => {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-parity-no-evidence-"));
+    tempRoots.push(repoRoot);
+    const outputDir = path.join(repoRoot, "output");
+    const canonicalPath = path.join(outputDir, "qa-evidence.json");
+    const lockPath = `${canonicalPath}.lock`;
+    const stagedPath = path.join(outputDir, ".qa-evidence.json.preseed.staged");
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.writeFile(canonicalPath, "canonical\n", "utf8");
+    await fs.writeFile(lockPath, "lock\n", "utf8");
+    await fs.writeFile(stagedPath, "staged\n", "utf8");
+
+    await runQaFlowSuiteFromRuntime({
+      repoRoot,
+      outputDir,
+      lab: makeRetryTestLab(),
+      startLab: async () => makeRetryTestLab(),
+      providerMode: "live-frontier",
+      runtimePair: ["openclaw", "codex"],
+      scenarioIds: ["runtime-soak-100-turn"],
+      writeEvidenceFile: false,
+    });
+
+    await expect(fs.readFile(canonicalPath, "utf8")).resolves.toBe("canonical\n");
+    await expect(fs.readFile(lockPath, "utf8")).resolves.toBe("lock\n");
+    await expect(fs.readFile(stagedPath, "utf8")).resolves.toBe("staged\n");
+  });
+
   it.each([
     { forcedRuntime: undefined, expectedRuntime: "openclaw" },
     { forcedRuntime: "codex" as const, expectedRuntime: "codex" },
@@ -310,11 +358,12 @@ describe("QA runtime parity scenario retry isolation", () => {
         return makeRetryTestResult("pass");
       });
 
-      await runQaFlowSuiteStandard(
+      const completion = await runQaFlowSuiteStandard(
         { lab: makeRetryTestLab(), ...(forcedRuntime ? { forcedRuntime } : {}) },
         makeRetryTestContext(),
         runScenario,
       );
+      await completion.complete();
 
       expect(runScenario).toHaveBeenCalledOnce();
     },
@@ -327,7 +376,12 @@ describe("QA runtime parity scenario retry isolation", () => {
       .fn<QaSuiteScenarioRunner>()
       .mockResolvedValue(makeRetryTestResult("pass"));
 
-    await runQaFlowSuiteStandard({ lab: makeRetryTestLab() }, context, runScenario);
+    const completion = await runQaFlowSuiteStandard(
+      { lab: makeRetryTestLab() },
+      context,
+      runScenario,
+    );
+    await completion.complete();
 
     expect(mocks.startQaGatewayChild).toHaveBeenCalledWith(
       expect.objectContaining({ allowUnhealthyStartup: true }),
@@ -343,11 +397,13 @@ describe("QA runtime parity scenario retry isolation", () => {
       .mockResolvedValueOnce(makeRetryTestResult("fail"))
       .mockResolvedValueOnce(makeRetryTestResult("pass"));
 
-    const result = await runQaFlowSuiteStandard(
+    const completion = await runQaFlowSuiteStandard(
       { lab: makeRetryTestLab(), forcedRuntime: "codex", captureRuntimeParityCell: true },
       makeRetryTestContext(),
       runScenario,
     );
+    await completion.complete();
+    const result = completion.result;
 
     expect(runScenario).toHaveBeenCalledOnce();
     expect(result.scenarios[0]).toMatchObject({ status: "fail" });
@@ -372,11 +428,13 @@ describe("QA runtime parity scenario retry isolation", () => {
       .mockResolvedValueOnce(makeRetryTestResult("fail"))
       .mockResolvedValueOnce(makeRetryTestResult("pass"));
 
-    const result = await runQaFlowSuiteStandard(
+    const completion = await runQaFlowSuiteStandard(
       { lab: makeRetryTestLab() },
       makeRetryTestContext(),
       runScenario,
     );
+    await completion.complete();
+    const result = completion.result;
 
     expect(runScenario).toHaveBeenCalledTimes(2);
     expect(result.scenarios[0]).toMatchObject({ status: "pass" });

--- a/extensions/qa-lab/src/suite-run-standard.ts
+++ b/extensions/qa-lab/src/suite-run-standard.ts
@@ -15,7 +15,7 @@ import {
   type QaSuiteGatewayRssSample,
   writeQaSuiteArtifacts,
 } from "./suite-artifacts.js";
-import type { QaSuiteEvidenceTarget } from "./suite-evidence-lifecycle.js";
+import type { QaSuiteDeferredCompletion } from "./suite-evidence-lifecycle.js";
 import {
   applyQaMergePatch,
   collectQaSuiteTransportPolicy,
@@ -54,8 +54,7 @@ export async function runQaFlowSuiteStandard(
   params: QaSuiteRunParams | undefined,
   context: QaSuiteResolvedRunContext,
   runScenarioDefinition: QaSuiteScenarioRunner,
-  evidenceTarget?: QaSuiteEvidenceTarget,
-): Promise<QaSuiteResult> {
+): Promise<QaSuiteDeferredCompletion<QaSuiteResult>> {
   const {
     startedAt,
     repoRoot,
@@ -111,7 +110,7 @@ export async function runQaFlowSuiteStandard(
   let runFailed = false;
   let runError: unknown;
   let result: QaSuiteResult | undefined;
-  let completionProgress: string | undefined;
+  let complete: (() => void) | undefined;
   const startedScenarioIds: string[] = [];
   try {
     writeQaSuiteProgress(progressEnabled, `provider start: ${providerMode}`);
@@ -373,13 +372,6 @@ export async function runQaFlowSuiteStandard(
     ) {
       preserveGatewayRuntimeDir = path.join(outputDir, "artifacts", "gateway-runtime");
     }
-    lab.setScenarioRun({
-      kind: "suite",
-      status: "completed",
-      startedAt: startedAt.toISOString(),
-      finishedAt: finishedAt.toISOString(),
-      scenarios: [...liveScenarioOutcomes],
-    });
     const { evidence, evidencePath, report, reportPath, summaryPath } = await writeQaSuiteArtifacts(
       {
         repoRoot,
@@ -400,8 +392,7 @@ export async function runQaFlowSuiteStandard(
         channelDriver: transportFactoryResult.driver,
         channelDriverSelection: params?.channelDriverSelection,
         isolatedWorkers: false,
-        writeEvidenceFile: evidenceTarget !== undefined,
-        evidenceTarget,
+        writeEvidenceFile: false,
         // Same "filtered → executed list, unfiltered → null" convention as
         // the concurrent-path writeQaSuiteArtifacts call above.
         scenarioIds:
@@ -410,13 +401,26 @@ export async function runQaFlowSuiteStandard(
             : undefined,
       },
     );
-    const latestReport = {
-      outputPath: reportPath,
-      markdown: report,
-      generatedAt: finishedAt.toISOString(),
-    } satisfies QaLabLatestReport;
-    lab.setLatestReport(latestReport);
-    completionProgress = `run complete: passed=${scenarios.length - failedCount - skippedCount} failed=${failedCount} skipped=${skippedCount} total=${scenarios.length}`;
+    complete = () => {
+      lab.setScenarioRun({
+        kind: "suite",
+        status: "completed",
+        startedAt: startedAt.toISOString(),
+        finishedAt: finishedAt.toISOString(),
+        scenarios: [...liveScenarioOutcomes],
+      });
+      lab.setLatestReport({
+        outputPath: reportPath,
+        markdown: report,
+        generatedAt: finishedAt.toISOString(),
+      } satisfies QaLabLatestReport);
+      if (!params?.captureRuntimeParityCell && !isQaSuiteNestedRun(params)) {
+        writeQaSuiteProgress(
+          progressEnabled,
+          `run complete: passed=${scenarios.length - failedCount - skippedCount} failed=${failedCount} skipped=${skippedCount} total=${scenarios.length}`,
+        );
+      }
+    };
     result = {
       outputDir,
       evidence,
@@ -465,11 +469,12 @@ export async function runQaFlowSuiteStandard(
     });
     throwQaSuiteCleanupErrors({ cleanupFailures, runFailed, runError, result });
   }
-  if (!result || !completionProgress) {
+  if (!result?.evidence || !complete) {
     throw new Error("QA suite completed without terminal result metadata");
   }
-  if (!params?.captureRuntimeParityCell && !isQaSuiteNestedRun(params)) {
-    writeQaSuiteProgress(progressEnabled, completionProgress);
-  }
-  return result;
+  return Object.freeze({
+    evidence: result.evidence,
+    result,
+    complete,
+  });
 }

--- a/extensions/qa-lab/src/suite-run-standard.ts
+++ b/extensions/qa-lab/src/suite-run-standard.ts
@@ -15,6 +15,7 @@ import {
   type QaSuiteGatewayRssSample,
   writeQaSuiteArtifacts,
 } from "./suite-artifacts.js";
+import type { QaSuiteEvidenceTarget } from "./suite-evidence-lifecycle.js";
 import {
   applyQaMergePatch,
   collectQaSuiteTransportPolicy,
@@ -53,6 +54,7 @@ export async function runQaFlowSuiteStandard(
   params: QaSuiteRunParams | undefined,
   context: QaSuiteResolvedRunContext,
   runScenarioDefinition: QaSuiteScenarioRunner,
+  evidenceTarget?: QaSuiteEvidenceTarget,
 ): Promise<QaSuiteResult> {
   const {
     startedAt,
@@ -110,7 +112,6 @@ export async function runQaFlowSuiteStandard(
   let runError: unknown;
   let result: QaSuiteResult | undefined;
   let completionProgress: string | undefined;
-  let evidenceWritten = false;
   const startedScenarioIds: string[] = [];
   try {
     writeQaSuiteProgress(progressEnabled, `provider start: ${providerMode}`);
@@ -399,7 +400,8 @@ export async function runQaFlowSuiteStandard(
         channelDriver: transportFactoryResult.driver,
         channelDriverSelection: params?.channelDriverSelection,
         isolatedWorkers: false,
-        writeEvidenceFile: params?.writeEvidenceFile,
+        writeEvidenceFile: evidenceTarget !== undefined,
+        evidenceTarget,
         // Same "filtered → executed list, unfiltered → null" convention as
         // the concurrent-path writeQaSuiteArtifacts call above.
         scenarioIds:
@@ -415,7 +417,6 @@ export async function runQaFlowSuiteStandard(
     } satisfies QaLabLatestReport;
     lab.setLatestReport(latestReport);
     completionProgress = `run complete: passed=${scenarios.length - failedCount - skippedCount} failed=${failedCount} skipped=${skippedCount} total=${scenarios.length}`;
-    evidenceWritten = evidence !== undefined && (params?.writeEvidenceFile ?? true);
     result = {
       outputDir,
       evidence,
@@ -462,7 +463,7 @@ export async function runQaFlowSuiteStandard(
             }
           },
     });
-    throwQaSuiteCleanupErrors({ cleanupFailures, runFailed, runError, result, evidenceWritten });
+    throwQaSuiteCleanupErrors({ cleanupFailures, runFailed, runError, result });
   }
   if (!result || !completionProgress) {
     throw new Error("QA suite completed without terminal result metadata");

--- a/extensions/qa-lab/src/suite-run.runtime.ts
+++ b/extensions/qa-lab/src/suite-run.runtime.ts
@@ -6,8 +6,9 @@ import {
 } from "./qa-transport-registry.js";
 import { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
 import {
+  completeQaSuiteWithoutEvidence,
   runQaSuiteEvidenceLifecycle,
-  type QaSuiteEvidenceTarget,
+  type QaSuiteDeferredCompletion,
 } from "./suite-evidence-lifecycle.js";
 import { resolveRequestedQaSuiteModels } from "./suite-model-selection.js";
 import {
@@ -32,28 +33,25 @@ import {
 } from "./suite.js";
 
 export async function runQaFlowSuiteFromRuntime(params?: QaSuiteRunParams): Promise<QaSuiteResult> {
-  return await runQaSuiteEvidenceLifecycle(params, ({ repoRoot, outputDir, target }) =>
-    runQaFlowSuiteFromRuntimeCore({ ...params, repoRoot, outputDir }, target),
-  );
+  return params?.writeEvidenceFile === false
+    ? await completeQaSuiteWithoutEvidence(() => runQaFlowSuiteFromRuntimeCore(params))
+    : await runQaSuiteEvidenceLifecycle(params, ({ repoRoot, outputDir }) =>
+        runQaFlowSuiteFromRuntimeCore({ ...params, repoRoot, outputDir }),
+      );
 }
 
 export async function runQaFlowSuiteFromRuntimeCore(
   params?: QaSuiteRunParams,
-  evidenceTarget?: QaSuiteEvidenceTarget,
-): Promise<QaSuiteResult> {
+): Promise<QaSuiteDeferredCompletion<QaSuiteResult>> {
   const startedAt = new Date();
-  const repoRoot = evidenceTarget
-    ? params!.repoRoot!
-    : path.resolve(params?.repoRoot ?? process.cwd());
+  const repoRoot = path.resolve(params?.repoRoot ?? process.cwd());
   const catalog = readQaBootstrapScenarioCatalog();
   const requestedModels = resolveRequestedQaSuiteModels({
     ...params,
     scenarios: catalog.scenarios,
   });
   const transportId = normalizeQaTransportId(params?.transportId);
-  const outputDir = evidenceTarget
-    ? params!.outputDir!
-    : await resolveQaSuiteOutputDir(repoRoot, params?.outputDir);
+  const outputDir = await resolveQaSuiteOutputDir(repoRoot, params?.outputDir);
   const channelDriver = params?.channelDriver ?? params?.channelDriverSelection?.channelDriver;
   const selectedScenarios = selectQaFlowSuiteScenarios({
     scenarios: catalog.scenarios,
@@ -171,10 +169,9 @@ export async function runQaFlowSuiteFromRuntimeCore(
       progressEnabled,
       scenarioIds: params.scenarioIds,
       runtimePair: params.runtimePair,
-      evidenceTarget,
     });
   }
   return useIsolatedScenarioWorkers
-    ? await runQaFlowSuiteIsolated(params, context, runQaFlowSuiteFromRuntimeCore, evidenceTarget)
-    : await runQaFlowSuiteStandard(params, context, runScenario, evidenceTarget);
+    ? await runQaFlowSuiteIsolated(params, context, runQaFlowSuiteFromRuntimeCore)
+    : await runQaFlowSuiteStandard(params, context, runScenario);
 }

--- a/extensions/qa-lab/src/suite-run.runtime.ts
+++ b/extensions/qa-lab/src/suite-run.runtime.ts
@@ -5,6 +5,10 @@ import {
   qaTransportSupportsModuleFlows,
 } from "./qa-transport-registry.js";
 import { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
+import {
+  runQaSuiteEvidenceLifecycle,
+  type QaSuiteEvidenceTarget,
+} from "./suite-evidence-lifecycle.js";
 import { resolveRequestedQaSuiteModels } from "./suite-model-selection.js";
 import {
   collectQaSuiteGatewayConfigPatch,
@@ -21,22 +25,35 @@ import { shouldCaptureGatewayHeapCheckpoints } from "./suite-support.js";
 import type { QaSuiteResolvedRunContext, QaSuiteResult, QaSuiteRunParams } from "./suite-types.js";
 import {
   formatQaSuiteRunStartProgress,
-  runQaSuiteScenarioDefinitionForRuntime,
+  runQaSuiteScenarioDefinitionForRuntime as runScenario,
   shouldLogQaSuiteProgress,
   shouldRunQaSuiteWithIsolatedScenarioWorkers,
   writeQaSuiteProgress,
 } from "./suite.js";
 
 export async function runQaFlowSuiteFromRuntime(params?: QaSuiteRunParams): Promise<QaSuiteResult> {
+  return await runQaSuiteEvidenceLifecycle(params, ({ repoRoot, outputDir, target }) =>
+    runQaFlowSuiteFromRuntimeCore({ ...params, repoRoot, outputDir }, target),
+  );
+}
+
+export async function runQaFlowSuiteFromRuntimeCore(
+  params?: QaSuiteRunParams,
+  evidenceTarget?: QaSuiteEvidenceTarget,
+): Promise<QaSuiteResult> {
   const startedAt = new Date();
-  const repoRoot = path.resolve(params?.repoRoot ?? process.cwd());
+  const repoRoot = evidenceTarget
+    ? params!.repoRoot!
+    : path.resolve(params?.repoRoot ?? process.cwd());
   const catalog = readQaBootstrapScenarioCatalog();
   const requestedModels = resolveRequestedQaSuiteModels({
     ...params,
     scenarios: catalog.scenarios,
   });
   const transportId = normalizeQaTransportId(params?.transportId);
-  const outputDir = await resolveQaSuiteOutputDir(repoRoot, params?.outputDir);
+  const outputDir = evidenceTarget
+    ? params!.outputDir!
+    : await resolveQaSuiteOutputDir(repoRoot, params?.outputDir);
   const channelDriver = params?.channelDriver ?? params?.channelDriverSelection?.channelDriver;
   const selectedScenarios = selectQaFlowSuiteScenarios({
     scenarios: catalog.scenarios,
@@ -128,7 +145,7 @@ export async function runQaFlowSuiteFromRuntime(params?: QaSuiteRunParams): Prom
   });
   if (params?.runtimePair) {
     return await runQaRuntimeParitySuite({
-      runQaFlowSuite: runQaFlowSuiteFromRuntime,
+      runQaFlowSuite: runQaFlowSuiteFromRuntimeCore,
       adapterFactories: params.adapterFactories,
       channelId: params.channelId,
       adapterOptions: params.adapterOptions,
@@ -154,10 +171,10 @@ export async function runQaFlowSuiteFromRuntime(params?: QaSuiteRunParams): Prom
       progressEnabled,
       scenarioIds: params.scenarioIds,
       runtimePair: params.runtimePair,
-      writeEvidenceFile: params.writeEvidenceFile,
+      evidenceTarget,
     });
   }
   return useIsolatedScenarioWorkers
-    ? await runQaFlowSuiteIsolated(params, context, runQaFlowSuiteFromRuntime)
-    : await runQaFlowSuiteStandard(params, context, runQaSuiteScenarioDefinitionForRuntime);
+    ? await runQaFlowSuiteIsolated(params, context, runQaFlowSuiteFromRuntimeCore, evidenceTarget)
+    : await runQaFlowSuiteStandard(params, context, runScenario, evidenceTarget);
 }

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
@@ -5,14 +5,28 @@ import {
   createQaTransportAdapter,
   type QaTransportAdapterFactory,
 } from "./qa-transport-registry.js";
+import type { QaSuiteDeferredCompletion } from "./suite-evidence-lifecycle.js";
 import { runQaFlowSuiteStandard } from "./suite-run-standard.js";
 import { runQaRuntimeParitySuite } from "./suite-runtime-parity-runner.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
 import type {
   QaSuiteResolvedRunContext,
-  QaSuiteRunner,
+  QaSuiteResult,
+  QaSuiteRunParams,
   QaSuiteScenarioRunner,
 } from "./suite-types.js";
+
+type DeferredQaSuiteRunner = (
+  params?: QaSuiteRunParams,
+) => Promise<QaSuiteDeferredCompletion<QaSuiteResult>>;
+
+function deferResult(result: QaSuiteResult): QaSuiteDeferredCompletion<QaSuiteResult> {
+  return Object.freeze({
+    evidence: result.evidence!,
+    result,
+    complete: vi.fn(),
+  });
+}
 
 const mocks = vi.hoisted(() => ({
   captureRuntimeParityCell: vi.fn(
@@ -138,7 +152,7 @@ function runCleanupTestSuite(params: {
   factory: QaTransportAdapterFactory;
   lab: QaLabServerHandle;
   progressEnabled?: boolean;
-  runChild: QaSuiteRunner;
+  runChild: DeferredQaSuiteRunner;
 }) {
   return runQaRuntimeParitySuite({
     runQaFlowSuite: params.runChild,
@@ -176,25 +190,28 @@ describe("runtime parity suite transport cleanup", () => {
     const cleanup = vi.fn(async () => {});
     const factory = createCleanupTestFactory(lab, () => ({ cleanup }));
     const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    const runChild = vi.fn<QaSuiteRunner>().mockImplementation(async (params) => ({
-      outputDir: "/qa-child",
-      evidencePath: "/qa-child/qa-evidence.json",
-      reportPath: "/qa-child/qa-suite-report.md",
-      summaryPath: "/qa-child/qa-suite-summary.json",
-      report: "",
-      scenarios: [{ name: "runtime-cleanup", status: "pass", steps: [] }],
-      startedScenarioIds: ["runtime-cleanup"],
-      watchUrl: lab.baseUrl,
-      runtimeParityCell: {
-        runtime: params?.forcedRuntime ?? "openclaw",
-        transcriptBytes: "",
-        toolCalls: [],
-        finalText: "ok",
-        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        wallClockMs: 1,
-        bootStateLines: [],
-      },
-    }));
+    const runChild = vi.fn<DeferredQaSuiteRunner>().mockImplementation(async (params) =>
+      deferResult({
+        outputDir: "/qa-child",
+        evidence: { kind: "test" } as QaSuiteResult["evidence"],
+        evidencePath: "/qa-child/qa-evidence.json",
+        reportPath: "/qa-child/qa-suite-report.md",
+        summaryPath: "/qa-child/qa-suite-summary.json",
+        report: "",
+        scenarios: [{ name: "runtime-cleanup", status: "pass", steps: [] }],
+        startedScenarioIds: ["runtime-cleanup"],
+        watchUrl: lab.baseUrl,
+        runtimeParityCell: {
+          runtime: params?.forcedRuntime ?? "openclaw",
+          transcriptBytes: "",
+          toolCalls: [],
+          finalText: "ok",
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          wallClockMs: 1,
+          bootStateLines: [],
+        },
+      }),
+    );
 
     try {
       const thrown = await runCleanupTestSuite({
@@ -205,12 +222,7 @@ describe("runtime parity suite transport cleanup", () => {
       }).catch((error: unknown) => error);
 
       expect(cleanup).toHaveBeenCalledOnce();
-      expect(setLatestReport).toHaveBeenCalledWith(
-        expect.objectContaining({ outputPath: "/qa-output/qa-suite-report.md" }),
-      );
-      expect(setLatestReport.mock.invocationCallOrder[0]).toBeLessThan(
-        stopLab.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
-      );
+      expect(setLatestReport).not.toHaveBeenCalled();
       expect((thrown as Error).message.split("\n")[0]).toBe(
         "QA scenarios passed, but cleanup failed",
       );
@@ -232,27 +244,32 @@ describe("runtime parity suite transport cleanup", () => {
     const lab = createCleanupTestLab();
     const cleanup = vi.fn(async () => {});
     const factory = createCleanupTestFactory(lab, () => ({ cleanup }));
-    const runChild = vi.fn<QaSuiteRunner>().mockImplementation(async (params) => ({
-      outputDir: "/qa-child",
-      evidencePath: "/qa-child/qa-evidence.json",
-      reportPath: "/qa-child/qa-suite-report.md",
-      summaryPath: "/qa-child/qa-suite-summary.json",
-      report: "",
-      scenarios: [{ name: "runtime-cleanup", status: "pass", steps: [] }],
-      startedScenarioIds: [],
-      watchUrl: lab.baseUrl,
-      runtimeParityCell: {
-        runtime: params?.forcedRuntime ?? "openclaw",
-        transcriptBytes: "",
-        toolCalls: [],
-        finalText: "ok",
-        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        wallClockMs: 1,
-        bootStateLines: [],
-      },
-    }));
+    const runChild = vi.fn<DeferredQaSuiteRunner>().mockImplementation(async (params) =>
+      deferResult({
+        outputDir: "/qa-child",
+        evidence: { kind: "test" } as QaSuiteResult["evidence"],
+        evidencePath: "/qa-child/qa-evidence.json",
+        reportPath: "/qa-child/qa-suite-report.md",
+        summaryPath: "/qa-child/qa-suite-summary.json",
+        report: "",
+        scenarios: [{ name: "runtime-cleanup", status: "pass", steps: [] }],
+        startedScenarioIds: [],
+        watchUrl: lab.baseUrl,
+        runtimeParityCell: {
+          runtime: params?.forcedRuntime ?? "openclaw",
+          transcriptBytes: "",
+          toolCalls: [],
+          finalText: "ok",
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          wallClockMs: 1,
+          bootStateLines: [],
+        },
+      }),
+    );
 
-    const result = await runCleanupTestSuite({ factory, lab, runChild });
+    const completion = await runCleanupTestSuite({ factory, lab, runChild });
+    await completion.complete();
+    const result = completion.result;
 
     expect(result.startedScenarioIds).toEqual([]);
     expect(runChild).toHaveBeenCalledTimes(2);
@@ -271,7 +288,7 @@ describe("runtime parity suite transport cleanup", () => {
     const runScenario = vi
       .fn<QaSuiteScenarioRunner>()
       .mockResolvedValue({ name: scenario.title, status: "pass", steps: [] });
-    const runChild: QaSuiteRunner = async (childParams) => {
+    const runChild: DeferredQaSuiteRunner = async (childParams) => {
       if (!childParams) {
         throw new Error("expected nested standard run params");
       }
@@ -298,7 +315,7 @@ describe("runtime parity suite transport cleanup", () => {
     const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
     try {
-      await runQaRuntimeParitySuite({
+      const completion = await runQaRuntimeParitySuite({
         runQaFlowSuite: runChild,
         repoRoot: "/qa-repo",
         outputDir: "/qa-output",
@@ -314,6 +331,7 @@ describe("runtime parity suite transport cleanup", () => {
         progressEnabled: true,
         runtimePair: ["openclaw", "codex"],
       });
+      await completion.complete();
 
       const completionLines = stderrWrite.mock.calls
         .flat()
@@ -339,7 +357,7 @@ describe("runtime parity suite transport cleanup", () => {
     });
     const cleanup = vi.fn(async () => {});
     const factory = createCleanupTestFactory(lab, () => ({ cleanup }));
-    const runChild = vi.fn<QaSuiteRunner>().mockRejectedValueOnce(scenarioError);
+    const runChild = vi.fn<DeferredQaSuiteRunner>().mockRejectedValueOnce(scenarioError);
 
     await expect(runCleanupTestSuite({ factory, lab, runChild })).rejects.toMatchObject({
       message: expect.stringContaining(
@@ -380,7 +398,7 @@ describe("runtime parity suite transport cleanup", () => {
         },
       };
     });
-    const runChild = vi.fn<QaSuiteRunner>().mockImplementation(async () => {
+    const runChild = vi.fn<DeferredQaSuiteRunner>().mockImplementation(async () => {
       const childTransport = await createQaTransportAdapter(
         {
           channelId: "leased",
@@ -419,7 +437,7 @@ describe("runtime parity suite transport cleanup", () => {
         .mockRejectedValueOnce(cleanupError)
         .mockResolvedValueOnce(undefined);
       const factory = createCleanupTestFactory(lab, () => ({ [cleanupPhase]: cleanup }));
-      const runChild = vi.fn<QaSuiteRunner>();
+      const runChild = vi.fn<DeferredQaSuiteRunner>();
 
       await expect(runCleanupTestSuite({ factory, lab, runChild })).rejects.toBe(cleanupError);
 

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
@@ -218,8 +218,9 @@ describe("runtime parity suite transport cleanup", () => {
         "failed cleanup phases: lab stop: owned lab shutdown reset",
       );
       expect((thrown as Error).message).toContain(
-        "retained artifacts: output=/qa-output report=/qa-output/qa-suite-report.md summary=/qa-output/qa-suite-summary.json evidence=/qa-output/qa-evidence.json",
+        "retained artifacts: output=/qa-output report=/qa-output/qa-suite-report.md summary=/qa-output/qa-suite-summary.json",
       );
+      expect((thrown as Error).message).not.toContain(" evidence=");
       expect((thrown as Error).cause).toBe(cleanupError);
       expect(stderrWrite.mock.calls.flat().join("")).not.toContain("run complete");
     } finally {

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.ts
@@ -18,6 +18,7 @@ import {
 import { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
 import type { QaScorecardChannelDriver, QaScorecardEvidenceMode } from "./scorecard-taxonomy.js";
 import { writeQaSuiteArtifacts } from "./suite-artifacts.js";
+import type { QaSuiteEvidenceTarget } from "./suite-evidence-lifecycle.js";
 import {
   collectQaSuiteTransportPolicy,
   mapQaSuiteWithConcurrency,
@@ -68,7 +69,7 @@ export async function runQaRuntimeParitySuite(params: {
   progressEnabled: boolean;
   scenarioIds?: readonly string[];
   runtimePair: [RuntimeId, RuntimeId];
-  writeEvidenceFile?: boolean;
+  evidenceTarget?: QaSuiteEvidenceTarget;
 }) {
   const ownsLab = !params.lab;
   const startLab = requireQaSuiteStartLab(params.startLab);
@@ -109,7 +110,6 @@ export async function runQaRuntimeParitySuite(params: {
   let runError: unknown;
   let parentTransportCleaned = false;
   let result: QaSuiteResult | undefined;
-  let evidenceWritten = false;
   const startedScenarioIds = new Set<string>();
   try {
     if (params.channelDriver === "live") {
@@ -182,7 +182,7 @@ export async function runQaRuntimeParitySuite(params: {
               controlUiEnabled: params.controlUiEnabled ?? scenarioRequiresControlUi(scenario),
               forcedRuntime: runtime,
               captureRuntimeParityCell: true,
-              writeEvidenceFile: params.writeEvidenceFile,
+              writeEvidenceFile: false,
             });
             for (const startedScenarioId of cellResult.startedScenarioIds) {
               startedScenarioIds.add(startedScenarioId);
@@ -277,7 +277,8 @@ export async function runQaRuntimeParitySuite(params: {
             ? params.selectedScenarios.map((scenario) => scenario.id)
             : undefined,
         runtimePair: params.runtimePair,
-        writeEvidenceFile: params.writeEvidenceFile,
+        writeEvidenceFile: params.evidenceTarget !== undefined,
+        evidenceTarget: params.evidenceTarget,
       },
     );
     lab.setLatestReport({
@@ -292,7 +293,6 @@ export async function runQaRuntimeParitySuite(params: {
       finishedAt: finishedAt.toISOString(),
       scenarios: [...liveScenarioOutcomes],
     });
-    evidenceWritten = evidence !== undefined && (params.writeEvidenceFile ?? true);
     result = {
       outputDir: params.outputDir,
       evidence,
@@ -317,7 +317,7 @@ export async function runQaRuntimeParitySuite(params: {
         : []),
       ...(ownsLab ? [{ phase: "lab stop", run: () => lab.stop() }] : []),
     ]);
-    throwQaSuiteCleanupErrors({ cleanupFailures, runFailed, runError, result, evidenceWritten });
+    throwQaSuiteCleanupErrors({ cleanupFailures, runFailed, runError, result });
   }
   if (!result) {
     throw new Error("QA runtime parity suite completed without a result");

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.ts
@@ -18,7 +18,7 @@ import {
 import { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
 import type { QaScorecardChannelDriver, QaScorecardEvidenceMode } from "./scorecard-taxonomy.js";
 import { writeQaSuiteArtifacts } from "./suite-artifacts.js";
-import type { QaSuiteEvidenceTarget } from "./suite-evidence-lifecycle.js";
+import type { QaSuiteDeferredCompletion } from "./suite-evidence-lifecycle.js";
 import {
   collectQaSuiteTransportPolicy,
   mapQaSuiteWithConcurrency,
@@ -29,7 +29,6 @@ import { buildRuntimeParityScenarioResult } from "./suite-runtime-parity-result.
 import { remapModelRefForForcedRuntime } from "./suite-support.js";
 import type {
   QaSuiteRunParams,
-  QaSuiteRunner,
   QaSuiteScenarioResult,
   QaSuiteStartLabFn,
   QaSuiteResult,
@@ -43,7 +42,7 @@ import {
 } from "./suite.js";
 
 export async function runQaRuntimeParitySuite(params: {
-  runQaFlowSuite: QaSuiteRunner;
+  runQaFlowSuite: (params?: QaSuiteRunParams) => Promise<QaSuiteDeferredCompletion<QaSuiteResult>>;
   adapterOptions?: QaSuiteRunParams["adapterOptions"];
   adapterFactories?: readonly QaTransportAdapterFactory[];
   channelId?: string;
@@ -69,8 +68,7 @@ export async function runQaRuntimeParitySuite(params: {
   progressEnabled: boolean;
   scenarioIds?: readonly string[];
   runtimePair: [RuntimeId, RuntimeId];
-  evidenceTarget?: QaSuiteEvidenceTarget;
-}) {
+}): Promise<QaSuiteDeferredCompletion<QaSuiteResult>> {
   const ownsLab = !params.lab;
   const startLab = requireQaSuiteStartLab(params.startLab);
   const lab =
@@ -110,6 +108,8 @@ export async function runQaRuntimeParitySuite(params: {
   let runError: unknown;
   let parentTransportCleaned = false;
   let result: QaSuiteResult | undefined;
+  let complete: (() => void | Promise<void>) | undefined;
+  const childCompletions: QaSuiteDeferredCompletion<QaSuiteResult>["complete"][] = [];
   const startedScenarioIds = new Set<string>();
   try {
     if (params.channelDriver === "live") {
@@ -152,7 +152,7 @@ export async function runQaRuntimeParitySuite(params: {
               runtime,
             );
             const cellStartedAt = Date.now();
-            const cellResult = await params.runQaFlowSuite({
+            const cellCompletion = await params.runQaFlowSuite({
               adapterFactories: params.adapterFactories,
               channelId: params.channelId,
               adapterOptions: params.adapterOptions,
@@ -184,6 +184,8 @@ export async function runQaRuntimeParitySuite(params: {
               captureRuntimeParityCell: true,
               writeEvidenceFile: false,
             });
+            childCompletions.push(cellCompletion.complete);
+            const cellResult = cellCompletion.result;
             for (const startedScenarioId of cellResult.startedScenarioIds) {
               startedScenarioIds.add(startedScenarioId);
             }
@@ -277,22 +279,25 @@ export async function runQaRuntimeParitySuite(params: {
             ? params.selectedScenarios.map((scenario) => scenario.id)
             : undefined,
         runtimePair: params.runtimePair,
-        writeEvidenceFile: params.evidenceTarget !== undefined,
-        evidenceTarget: params.evidenceTarget,
+        writeEvidenceFile: false,
       },
     );
-    lab.setLatestReport({
-      outputPath: reportPath,
-      markdown: report,
-      generatedAt: finishedAt.toISOString(),
-    } satisfies QaLabLatestReport);
-    lab.setScenarioRun({
-      kind: "suite",
-      status: "completed",
-      startedAt: params.startedAt.toISOString(),
-      finishedAt: finishedAt.toISOString(),
-      scenarios: [...liveScenarioOutcomes],
-    });
+    complete = async () => {
+      await Promise.all(childCompletions.map((run) => run()));
+      lab.setLatestReport({
+        outputPath: reportPath,
+        markdown: report,
+        generatedAt: finishedAt.toISOString(),
+      } satisfies QaLabLatestReport);
+      lab.setScenarioRun({
+        kind: "suite",
+        status: "completed",
+        startedAt: params.startedAt.toISOString(),
+        finishedAt: finishedAt.toISOString(),
+        scenarios: [...liveScenarioOutcomes],
+      });
+      writeQaSuiteProgress(params.progressEnabled, "run complete");
+    };
     result = {
       outputDir: params.outputDir,
       evidence,
@@ -319,9 +324,12 @@ export async function runQaRuntimeParitySuite(params: {
     ]);
     throwQaSuiteCleanupErrors({ cleanupFailures, runFailed, runError, result });
   }
-  if (!result) {
+  if (!result?.evidence || !complete) {
     throw new Error("QA runtime parity suite completed without a result");
   }
-  writeQaSuiteProgress(params.progressEnabled, "run complete");
-  return result;
+  return Object.freeze({
+    evidence: result.evidence,
+    result,
+    complete,
+  });
 }

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -5537,11 +5537,11 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
         }
         if (scenario.timeoutOutcome === "term") {
           expect(result.stdout).toContain(
-            "::warning::QA profile 'all' timed out after 1 second and was terminated",
+            "::warning::QA profile 'all' timed out after 1 second and was terminated; canonical qa-evidence.json was not published, but diagnostic artifacts will still be uploaded.",
           );
         } else if (scenario.timeoutOutcome === "kill") {
           expect(result.stdout).toContain(
-            "::warning::QA profile 'all' timed out after 1 second and required SIGKILL after the 0.5-second grace period",
+            "::warning::QA profile 'all' timed out after 1 second and required SIGKILL after the 0.5-second grace period; canonical qa-evidence.json was not published, but diagnostic artifacts will still be uploaded.",
           );
         } else {
           expect(result.stdout).not.toContain("::warning::QA profile");


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where QA suite runs could leave stale or prematurely published `qa-evidence.json` after planning, execution, profile scorecard finalization, or runner cleanup failed. Concurrent runs targeting the same output directory could also overwrite one another's evidence.

This is a clean replacement for the earlier draft. It does not cherry-pick or derive from the stale implementation, and the earlier draft remains open until this replacement eventually lands.

## Why This Change Was Made

QA evidence publication now has one internal lifecycle owner. It acquires a fail-fast lock keyed by the resolved output directory, invalidates stale canonical evidence, gives runners an invocation-unique staged target, holds ownership through retries and cleanup, attaches profile scorecards before publication, atomically renames staged evidence into place, and applies explicit discard/publish/release error precedence.

Reports and summaries remain direct diagnostic writes. Only canonical evidence is transactional, and no lifecycle controls were added to `QaSuiteRunParams` or public API barrels.

## User Impact

Operators can trust canonical QA evidence to represent a fully successful suite lifecycle. Failed planning, execution, cleanup, or profile finalization leaves canonical evidence absent; successful runs publish once after cleanup; same-output contention fails before mutation while different output directories remain concurrent.

## Evidence

- Exact branch base: `7ecdef6e2ed4c5d8007ac9a65c952b3af4eb0798`
- Exact signed head: `7b25193235756dd01b5e4e0700c2394489b99cef`
- Current `origin/main`: `e6353d85ef3ac52ed33b1ed454c4c7f9ce88cc73`
- Current-main overlap: none in the owned QA evidence lifecycle paths; no rebase performed for unrelated drift
- Merge-tree: clean, tree `bfd58873f07251600b998fbe30e1ead53a7772f0`
- Checkpointed broader evidence before the final correction: 224 focused tests passed; workflow guards 107 passed / 2 skipped
- Final required three-file run: 56 tests collected, 54 passed, 2 failed only because macOS canonicalized `/var` to `/private/var` in lock-path assertions
- Targeted rerun after canonicalizing the two test temp roots: 7/7 passed; all three requested focused files are green
- Targeted formatting and `git diff --check`: passed
- Independent Sol autoreview (`gpt-5.6-sol`, high): clean, no actionable findings, correctness confidence 0.96
- Follow-up commit LOC: production `+274/-250` (net `+24`); tests `+615/-273` (net `+342`); workflow `+2/-2`
- Full PR LOC: production `+445/-307` (net `+138`); tests `+962/-131` (net `+831`); workflow `+2/-2`
- Commit attestation: `att_01KZHKR0YS93604CQRXSGWAETB`
- PR attestation: `att_01KZHKT4PRNBG3RQRRY58Y8ND7`

No hosted CI, heavy QA profile, merge, issue close, or Punchcard finish was run for this checkpoint.

## Provenance

- https://github.com/openclaw/openclaw/pull/120012
- https://github.com/openclaw/openclaw/pull/119868
- https://github.com/openclaw/openclaw/pull/119957
- https://github.com/openclaw/openclaw/pull/119572
- https://github.com/openclaw/openclaw/pull/119761
- https://github.com/openclaw/openclaw/pull/91587
- https://github.com/openclaw/openclaw/pull/93109

PR #120012 is intentionally not closed by this draft and should remain open until a replacement lands.

Punchcard-Session: amber-workshop-workshop-36
