### PR TITLE
fix(scripts): preserve UTF-8 across incremental log reads

### DIFF
--- a/scripts/e2e/lib/incremental-line-reader.mjs
+++ b/scripts/e2e/lib/incremental-line-reader.mjs
@@ -1,20 +1,7 @@
 // Incremental line reader for streaming E2E logs.
 import { createHash } from "node:crypto";
 import fs from "node:fs";
-
-function readSlice(filePath, start, length) {
-  if (length <= 0) {
-    return "";
-  }
-  const fd = fs.openSync(filePath, "r");
-  try {
-    const buffer = Buffer.alloc(length);
-    const bytesRead = fs.readSync(fd, buffer, 0, length, start);
-    return buffer.subarray(0, bytesRead).toString("utf8");
-  } finally {
-    fs.closeSync(fd);
-  }
-}
+import { StringDecoder } from "node:string_decoder";
 
 function readBufferSlice(filePath, start, length) {
   if (length <= 0) {
@@ -55,6 +42,7 @@ export function createIncrementalLineReader(filePath, options = {}) {
   let contentFingerprint;
   let offset = 0;
   let pending = "";
+  let decoder = new StringDecoder("utf8");
 
   return {
     readLines() {
@@ -76,6 +64,7 @@ export function createIncrementalLineReader(filePath, options = {}) {
       ) {
         offset = 0;
         pending = "";
+        decoder = new StringDecoder("utf8");
         reset = true;
       }
       fileIdentity = nextFileIdentity;
@@ -85,6 +74,7 @@ export function createIncrementalLineReader(filePath, options = {}) {
         if (contentFingerprint !== nextContentFingerprint) {
           offset = 0;
           pending = "";
+          decoder = new StringDecoder("utf8");
           reset = true;
         } else {
           contentFingerprint = nextContentFingerprint;
@@ -95,6 +85,7 @@ export function createIncrementalLineReader(filePath, options = {}) {
       if (stats.size < offset) {
         offset = 0;
         pending = "";
+        decoder = new StringDecoder("utf8");
         reset = true;
       }
       if (stats.size === offset) {
@@ -107,28 +98,31 @@ export function createIncrementalLineReader(filePath, options = {}) {
       if (start === 0 && stats.size > maxReadBytes) {
         start = stats.size - maxReadBytes;
         pending = "";
+        decoder = new StringDecoder("utf8");
         clamped = true;
       } else if (stats.size - start > maxReadBytes) {
         start = stats.size - maxReadBytes;
         pending = "";
+        decoder = new StringDecoder("utf8");
         clamped = true;
       }
       if (clamped && start > 0) {
-        discardFirstLine = readSlice(filePath, start - 1, 1) !== "\n";
+        discardFirstLine = readBufferSlice(filePath, start - 1, 1)[0] !== 0x0a;
       }
 
-      const text = readSlice(filePath, start, stats.size - start);
+      const buffer = readBufferSlice(filePath, start, stats.size - start);
       offset = stats.size;
       contentFingerprint = readTailFingerprint(filePath, stats, maxReadBytes);
-      if (!text) {
+      if (buffer.byteLength === 0) {
         return { lines: [], reset };
       }
 
-      let chunk = pending + text;
+      let chunk = pending + decoder.write(buffer);
       if (discardFirstLine) {
         const newlineIndex = chunk.indexOf("\n");
         if (newlineIndex === -1) {
           pending = "";
+          decoder = new StringDecoder("utf8");
           return { lines: [], reset };
         }
         chunk = chunk.slice(newlineIndex + 1);

--- a/test/scripts/incremental-line-reader.test.ts
+++ b/test/scripts/incremental-line-reader.test.ts
@@ -32,6 +32,19 @@ describe("scripts/e2e/lib/incremental-line-reader.mjs", () => {
     });
   });
 
+  it("preserves UTF-8 characters split across polls", () => {
+    withTempLog((logPath) => {
+      const reader = createIncrementalLineReader(logPath);
+      const encoded = Buffer.from("😀\n", "utf8");
+
+      writeFileSync(logPath, encoded.subarray(0, 2));
+      expect(reader.readLines()).toEqual({ lines: [], reset: false });
+
+      appendFileSync(logPath, encoded.subarray(2));
+      expect(reader.readLines()).toEqual({ lines: ["😀"], reset: false });
+    });
+  });
+
   it("resets when an existing log is rewritten without changing size", () => {
     withTempLog((logPath) => {
       writeFileSync(logPath, "first\n", "utf8");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where streaming E2E log readers could corrupt a UTF-8 character when a log writer split that character between polling reads. The affected JSONL and gateway-log assertions could then receive replacement characters instead of the original text.

## Why This Change Was Made

The incremental reader advances its file position in bytes, so it now keeps a `StringDecoder` across polls and resets it whenever the reader state is reset or the bounded tail skips bytes. Existing line buffering and bounded-tail behavior remain unchanged.

## User Impact

Streaming E2E log and JSONL assertions preserve non-ASCII text even when writes arrive in partial UTF-8 byte sequences.

## Evidence

- Before the fix, a real temporary-file reproduction that split one emoji across polls returned three `U+FFFD` replacement characters.
- Final runtime proof through the config-reload log scanner returned one line with UTF-8 base64 `Y29uZmlnIPCfmIA=` and code point `128512` (`U+1F600`).
- Focused Vitest: `node scripts/run-vitest.mjs test/scripts/incremental-line-reader.test.ts` — 1 file, 4 tests passed.
- Supporting checks: targeted `oxfmt`, targeted `oxlint`, and `git diff --check` passed.
- Autoreview completed cleanly with no accepted/actionable findings; TruffleHog was clean.
- Proof boundary: local temporary-file runtime proof; no external account, provider, or message delivery was involved.
- Exact head: `ef4765534710d9b258d4cab537936309e474a967`.

AI-assisted contribution.
