### PR TITLE
fix(qa): keep diagnostics package identity current [AI]

### DIFF
--- a/test/e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.ts
@@ -14,7 +14,6 @@ import { startLocalOtlpReceiver } from "./otel-test-support.js";
 
 const execFileAsync = promisify(execFile);
 const PACKAGE_NAME = "@openclaw/diagnostics-otel";
-const PACKAGE_VERSION = "2026.7.2";
 
 type MutableConfig = {
   diagnostics?: unknown;
@@ -163,20 +162,23 @@ async function packPlugin(repoRoot: string, scratch: string) {
   if (!tarballName) {
     throw new Error("diagnostics-otel pack did not produce a tarball");
   }
-  return path.join(outputDir, tarballName);
+  const manifest = JSON.parse(await readFile(path.join(stagingDir, "package.json"), "utf8")) as {
+    version?: unknown;
+  };
+  if (typeof manifest.version !== "string" || !manifest.version.trim()) {
+    throw new Error("diagnostics-otel package version is missing");
+  }
+  return {
+    tarball: path.join(outputDir, tarballName),
+    version: manifest.version.trim(),
+  };
 }
 
-async function startRegistry(repoRoot: string, scratch: string, tarball: string) {
+async function startRegistry(repoRoot: string, scratch: string, tarball: string, version: string) {
   const portFile = path.join(scratch, "registry-port");
   const child = spawn(
     process.execPath,
-    [
-      "scripts/e2e/lib/plugins/npm-registry-server.mjs",
-      portFile,
-      PACKAGE_NAME,
-      PACKAGE_VERSION,
-      tarball,
-    ],
+    ["scripts/e2e/lib/plugins/npm-registry-server.mjs", portFile, PACKAGE_NAME, version, tarball],
     {
       cwd: repoRoot,
       env: {
@@ -259,6 +261,7 @@ async function installAndConfigure(params: {
   envTraceEndpoint: string;
   mockBaseUrl: string;
   nodeOptions?: string;
+  packageVersion: string;
   registryBaseUrl: string;
   repoRoot: string;
   sampleRate?: number;
@@ -289,7 +292,7 @@ async function installAndConfigure(params: {
       ...(params.nodeOptions ? { OPENCLAW_OTEL_PRELOADED: "1" } : {}),
     },
   });
-  const spec = `npm:${PACKAGE_NAME}@${PACKAGE_VERSION}`;
+  const spec = `npm:${PACKAGE_NAME}@${params.packageVersion}`;
   await gateway.runCli(["plugins", "install", spec, "--force"]);
   const stateDir = gateway.runtimeEnv.OPENCLAW_STATE_DIR;
   if (!stateDir) {
@@ -301,10 +304,10 @@ async function installAndConfigure(params: {
   });
   expect(records["diagnostics-otel"]).toMatchObject({
     source: "npm",
-    spec: `${PACKAGE_NAME}@${PACKAGE_VERSION}`,
-    version: PACKAGE_VERSION,
+    spec: `${PACKAGE_NAME}@${params.packageVersion}`,
+    version: params.packageVersion,
     resolvedName: PACKAGE_NAME,
-    resolvedVersion: PACKAGE_VERSION,
+    resolvedVersion: params.packageVersion,
   });
   expect(records["diagnostics-otel"]?.installPath).toContain("diagnostics-otel");
   expect(records["diagnostics-otel"]?.integrity).toMatch(/^sha512-/u);
@@ -342,13 +345,14 @@ describe("managed diagnostics-otel install runtime", () => {
     let mock: Awaited<ReturnType<typeof startQaMockOpenAiServer>> | undefined;
     let gateway: Awaited<ReturnType<typeof startQaGatewayChild>> | undefined;
     try {
-      const tarball = await packPlugin(repoRoot, scratch);
-      registry = await startRegistry(repoRoot, scratch, tarball);
+      const packed = await packPlugin(repoRoot, scratch);
+      registry = await startRegistry(repoRoot, scratch, packed.tarball, packed.version);
       mock = await startQaMockOpenAiServer();
       gateway = await installAndConfigure({
         configTraceEndpoint: configured.baseUrl,
         envTraceEndpoint: envOnly.baseUrl,
         mockBaseUrl: mock.baseUrl,
+        packageVersion: packed.version,
         registryBaseUrl: registry.baseUrl,
         repoRoot,
         sampleRate: 0,
@@ -427,8 +431,8 @@ describe("managed diagnostics-otel install runtime", () => {
     let mock: Awaited<ReturnType<typeof startQaMockOpenAiServer>> | undefined;
     let gateway: Awaited<ReturnType<typeof startQaGatewayChild>> | undefined;
     try {
-      const tarball = await packPlugin(repoRoot, scratch);
-      registry = await startRegistry(repoRoot, scratch, tarball);
+      const packed = await packPlugin(repoRoot, scratch);
+      registry = await startRegistry(repoRoot, scratch, packed.tarball, packed.version);
       mock = await startQaMockOpenAiServer();
       const preloadRoot = path.join(scratch, `otel-preload-${randomUUID()}`);
       const preloadModules = path.join(preloadRoot, "node_modules", "@opentelemetry");
@@ -458,6 +462,7 @@ describe("managed diagnostics-otel install runtime", () => {
         envTraceEndpoint: receiver.baseUrl,
         mockBaseUrl: mock.baseUrl,
         nodeOptions: `--import=${pathToFileURL(preloadPath).href}`,
+        packageVersion: packed.version,
         registryBaseUrl: registry.baseUrl,
         repoRoot,
       });


### PR DESCRIPTION
Closes #120635

## What Problem This Solves

Fixes an issue where the managed diagnostics-otel install E2E published the current source tarball as the stale hard-coded version `2026.7.2`. The packed package manifest was already `2026.8.1`, so the persisted install record correctly disagreed with the fixture registry and both runtime tests failed before reaching telemetry behavior.

## Why This Change Was Made

The packed artifact is the authoritative identity. `packPlugin()` now reads the staged package manifest once and returns its version alongside the tarball. That exact value is threaded through the local registry, requested npm spec, and persisted install-record assertions.

This matches the adjacent diagnostics-prometheus install fixture and removes the duplicate version owner. Production plugin install semantics are unchanged.

## User Impact

Plugin version bumps no longer make the managed OpenTelemetry install/runtime proof fail on an artificial registry/package mismatch. The E2E test can reach and verify configuration precedence, sampling, flushing, and preloaded-SDK behavior again.

## Evidence

Pre-fix isolated behavior:

- 1 file failed / 2 tests failed
- Registry `spec` and `resolvedVersion`: `2026.7.2`
- Installed package `version`: `2026.8.1`

Exact candidate:

- `CI=1 pnpm test test/e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.ts`
- Testbox `tbx_01kzh2zgbstbs2jzz12hkka8s9`
- https://github.com/openclaw/openclaw/actions/runs/31266833019
- 1 file passed / 2 tests passed in 235.96s (cold exact-artifact setup included)

Additional proof:

- AutoReview: clean, no accepted/actionable findings
- Production LOC: +0/-0; tests: +23/-18
- Public model identifier gate: PASS; no model-bearing code or artifacts changed

## AI Assistance

AI-assisted. The failing install record, source package manifest, registry fixture, sibling diagnostics fixture, and final diff were reviewed directly before publication.
