### PR TITLE
chore(codex): align completed tool metadata expectation

### DIFF
--- a/extensions/codex/src/app-server/event-projector.reasoning.test.ts
+++ b/extensions/codex/src/app-server/event-projector.reasoning.test.ts
@@ -178,7 +178,7 @@ describe("CodexAppServerEventProjector reasoning and guardian projection", () =>
         completed: true,
       },
     );
-    expect(result.toolMetas).toEqual([{ toolName: "sessions_send" }]);
+    expect(result.toolMetas).toEqual([{ toolName: "sessions_send", isError: false }]);
     expect(result.messagesSnapshot.map((message) => message.role)).toEqual([
       "user",
       "assistant",


### PR DESCRIPTION
## What Problem This Solves

Plugin Prerelease validation expected the older completed-tool metadata shape, so the current-main CI job failed after the projector began recording explicit successful completion metadata.

Failed job: https://github.com/openclaw/openclaw/actions/runs/31264039947/job/93119256057

## Why This Change Was Made

Update only the stale test expectation to the canonical completed-tool shape, including `isError: false`. There is no runtime change. Upstream Codex defines dynamic-tool responses with a required `success` boolean and maps successful responses to completed items:

- https://github.com/openai/codex/blob/e1895710addb863acf335ef18b4c43b128439567/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L1546-L1552
- https://github.com/openai/codex/blob/e1895710addb863acf335ef18b4c43b128439567/codex-rs/app-server-protocol/src/protocol/event_mapping.rs#L38-L76

AI-assisted maintainer repair; the final diff was reviewed against the upstream contract.

## User Impact

No runtime or user-visible behavior changes. This restores Plugin Prerelease validation by aligning the assertion with the metadata OpenClaw already emits for a successful completed tool call.

## Evidence

- 158 focused tests passed on the reviewed change.
- Targeted lint, formatting, and `git diff --check` passed.
- Fresh autoreview on the exact staged diff: clean, no accepted/actionable findings.
- Independent exact-head review: PASS.
- Exact head: https://github.com/openclaw/openclaw/commit/571cd8ee0f791807e95e87e287a0b9d5e612ddb1
- Production LOC delta: 0.
- Test LOC delta: +1/-1.
