### PR TITLE
refactor(cli): inline state migration policy

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -17,7 +17,6 @@ import {
   normalizeRootHelpTargetArgv,
   normalizeRootLogLevelArgv,
   normalizeRootNoColorArgv,
-  shouldMigrateStateFromPath,
 } from "./argv.js";
 
 describe("argv helpers", () => {
@@ -755,48 +754,5 @@ describe("argv helpers", () => {
   ] as const)("builds parse argv from raw args: $name", ({ rawArgs, expected }) => {
     const parsed = buildParseArgv([...rawArgs]);
     expect(parsed).toEqual([...expected]);
-  });
-
-  it.each([
-    { argv: ["node", "openclaw", "status"], expected: true },
-    { argv: ["node", "openclaw", "logs", "--plain"], expected: false },
-    { argv: ["node", "openclaw", "health"], expected: false },
-    { argv: ["node", "openclaw", "sessions"], expected: false },
-    { argv: ["node", "openclaw", "--profile", "work", "status"], expected: true },
-    { argv: ["node", "openclaw", "--log-level=debug", "models", "list"], expected: true },
-    { argv: ["node", "openclaw", "config", "get", "update"], expected: false },
-    { argv: ["node", "openclaw", "config", "unset", "update"], expected: false },
-    { argv: ["node", "openclaw", "config", "set", "update.channel", "beta"], expected: false },
-    { argv: ["node", "openclaw", "config", "patch", "update", "{}"], expected: false },
-    { argv: ["node", "openclaw", "models", "list"], expected: true },
-    { argv: ["node", "openclaw", "models", "status"], expected: true },
-    { argv: ["node", "openclaw", "update", "status", "--json"], expected: false },
-    { argv: ["node", "openclaw", "gateway", "call", "health", "--json"], expected: false },
-    {
-      argv: ["node", "openclaw", "--profile", "remote", "gateway", "call", "status"],
-      expected: false,
-    },
-    { argv: ["node", "openclaw", "gateway", "status"], expected: true },
-    { argv: ["node", "openclaw", "agent", "--message", "hi"], expected: true },
-    { argv: ["node", "openclaw", "agents", "list"], expected: true },
-    { argv: ["node", "openclaw", "message", "send"], expected: true },
-  ] as const)("decides when to migrate state: $argv", ({ argv, expected }) => {
-    const commandPath = getCommandPathWithRootOptions([...argv], 2);
-    expect(shouldMigrateStateFromPath(commandPath)).toBe(expected);
-  });
-
-  it.each([
-    { path: ["status"], expected: true },
-    { path: ["logs"], expected: false },
-    { path: ["update", "status"], expected: false },
-    { path: ["gateway", "call"], expected: false },
-    { path: ["gateway", "health"], expected: true },
-    { path: ["gateway", "status"], expected: true },
-    { path: ["config", "get"], expected: false },
-    { path: ["agent"], expected: true },
-    { path: ["models", "status"], expected: true },
-    { path: ["agents", "list"], expected: true },
-  ])("reuses command path for migrate state decisions: $path", ({ path, expected }) => {
-    expect(shouldMigrateStateFromPath(path)).toBe(expected);
   });
 });

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -609,24 +609,3 @@ export function buildParseArgv(rawArgs: string[], programName = "openclaw"): str
   }
   return ["node", programName, ...normalizedArgv];
 }
-
-export function shouldMigrateStateFromPath(path: string[]): boolean {
-  if (path.length === 0) {
-    return true;
-  }
-  const [primary, secondary] = path;
-  if (primary === "health" || primary === "logs" || primary === "sessions") {
-    return false;
-  }
-  // Remote RPC clients must not migrate state owned by the running gateway.
-  if (primary === "gateway" && secondary === "call") {
-    return false;
-  }
-  if (primary === "update" && secondary === "status") {
-    return false;
-  }
-  if (primary === "config") {
-    return false;
-  }
-  return true;
-}

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -170,8 +170,18 @@ describe("ensureConfigReady", () => {
       expectedDoctorCalls: 0,
     },
     {
+      name: "skips doctor flow for health",
+      commandPath: ["health"],
+      expectedDoctorCalls: 0,
+    },
+    {
       name: "skips doctor flow for logs",
       commandPath: ["logs"],
+      expectedDoctorCalls: 0,
+    },
+    {
+      name: "skips doctor flow for sessions",
+      commandPath: ["sessions"],
       expectedDoctorCalls: 0,
     },
     {
@@ -190,6 +200,16 @@ describe("ensureConfigReady", () => {
       expectedDoctorCalls: 0,
     },
     {
+      name: "skips doctor flow for config get",
+      commandPath: ["config", "get"],
+      expectedDoctorCalls: 0,
+    },
+    {
+      name: "skips doctor flow for config unset",
+      commandPath: ["config", "unset"],
+      expectedDoctorCalls: 0,
+    },
+    {
       name: "skips doctor flow for agent without legacy state",
       commandPath: ["agent"],
       expectedDoctorCalls: 0,
@@ -202,6 +222,16 @@ describe("ensureConfigReady", () => {
     {
       name: "runs doctor flow for commands that may mutate state without legacy state",
       commandPath: ["message"],
+      expectedDoctorCalls: 1,
+    },
+    {
+      name: "runs doctor flow for unknown commands",
+      commandPath: ["unknown-command"],
+      expectedDoctorCalls: 1,
+    },
+    {
+      name: "runs doctor flow when the command path is empty",
+      commandPath: [],
       expectedDoctorCalls: 1,
     },
   ])("$name", async ({ commandPath, expectedDoctorCalls }) => {

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -237,6 +237,7 @@ export async function ensureConfigReady(
     commandName !== "health" &&
     commandName !== "logs" &&
     commandName !== "sessions" &&
+    // Remote RPC clients must not migrate state owned by the running gateway.
     !(commandName === "gateway" && subcommandName === "call") &&
     !(commandName === "update" && subcommandName === "status");
   const requiresLegacyStateInput = shouldRunStateMigrationOnlyWithLegacyInputs(commandPath);

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -16,7 +16,6 @@ import type { ConfigFileSnapshot } from "../../config/types.js";
 import { resolveExecApprovalsPath } from "../../infra/exec-approvals-config.js";
 import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
 import { ExitError, type RuntimeEnv } from "../../runtime.js";
-import { shouldMigrateStateFromPath } from "../argv.js";
 import type { InvalidConfigRecoveryDeps } from "../invalid-config-recovery.js";
 
 const ALLOWED_INVALID_COMMANDS = new Set(["audit", "doctor", "logs", "health", "help", "status"]);
@@ -233,7 +232,13 @@ export async function ensureConfigReady(
   const commandName = commandPath[0];
   const subcommandName = commandPath[1];
   let preflightSnapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>> | null = null;
-  const shouldConsiderStateMigration = shouldMigrateStateFromPath(commandPath);
+  const shouldConsiderStateMigration =
+    commandName !== "config" &&
+    commandName !== "health" &&
+    commandName !== "logs" &&
+    commandName !== "sessions" &&
+    !(commandName === "gateway" && subcommandName === "call") &&
+    !(commandName === "update" && subcommandName === "status");
   const requiresLegacyStateInput = shouldRunStateMigrationOnlyWithLegacyInputs(commandPath);
   const runStateMigrationPreflight = async () => {
     didRunDoctorConfigFlow = true;

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -3,7 +3,6 @@ import { Command } from "commander";
 import { repoInstallSpec } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { loggingState } from "../../logging/state.js";
-import { shouldMigrateStateFromPath } from "../argv.js";
 import { isConfigSetJsonParseOnly } from "../config-output-mode.js";
 import { setCommandJsonMode } from "./json-mode.js";
 import { applyParentDefaultHelpAction } from "./parent-default-help.js";
@@ -976,7 +975,6 @@ describe("registerPreActionHooks", () => {
       commandPath: ["gateway", "call"],
       suppressDoctorStdout: true,
     });
-    expect(shouldMigrateStateFromPath(bootstrap?.commandPath ?? [])).toBe(false);
   });
 
   it("uses the shared skip policy for gateway health on the Commander path", async () => {


### PR DESCRIPTION
## What Problem This Solves

Merged PR #120451 fixed the state-migration policy, but the follow-up structure still left that policy exposed as a single-use argv helper and duplicated its coverage across argv, preaction, and lifecycle tests. This separate owner-boundary follow-up removes the extra surface without changing the behavior delivered by #120451.

## Why This Change Was Made

The migration decision now lives directly in `ensureConfigReady`, the lifecycle owner that invokes the Doctor migration flow. The redundant exported helper and its argv/preaction assertions are removed, while the existing `ensureConfigReady` table becomes the canonical behavior matrix.

The preserved matrix skips migration consideration for every top-level `config` command, plus `health`, `logs`, `sessions`, `gateway call`, and `update status`. Empty, unknown, and state-mutating command paths still consider migration, while the existing `status`, `agent`, and plugin legacy-input semantics remain unchanged. Doctor remains the migration owner, and gateway startup ownership/checkpoint code is untouched.

## User Impact

No user-visible behavior changes. This is the net-negative owner-boundary cleanup that follows #120451: operators retain the same migration and skip behavior with less exported policy and one lifecycle-owned test matrix.

No changelog entry is included because release generation owns `CHANGELOG.md`.

## Evidence

- `node scripts/run-vitest.mjs src/cli/argv.test.ts src/cli/program/config-guard.test.ts src/cli/program/preaction.test.ts` — 3 test files and 239 tests passed across 2 Vitest shards in 7.50s.
- `git diff --check origin/main...HEAD` — clean.
- LOC: production `+8/-23` (net `-15`); tests `+30/-46` (net `-16`).
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, with no accepted or actionable findings before the second commit.
- Exact reviewed head: `68d3a9173f57335566af0e42f4ca3c8ff507592d`.
