### PR TITLE
fix(scripts): keep dependency pin timeout test deterministic

### DIFF
--- a/test/scripts/check-dependency-pins.test.ts
+++ b/test/scripts/check-dependency-pins.test.ts
@@ -8,6 +8,7 @@ import { cleanupTempDirs, makeTempRepoRoot } from "../helpers/temp-repo.js";
 
 const tempDirs: string[] = [];
 const itUnix = process.platform === "win32" ? it.skip : it;
+const hangingGitTimeoutMs = 1_000;
 
 const nestedGitEnvKeys = [
   "GIT_ALTERNATE_OBJECT_DIRECTORIES",
@@ -45,15 +46,15 @@ function writeJson(filePath: string, value: unknown) {
 function stubHangingGit(cwd: string, stalledSubcommand: "ls-files" | "show") {
   const binDir = path.join(cwd, "fake-git-bin");
   mkdirSync(binDir);
-  const fixture = `#!${process.execPath}
-if (process.argv[2] === ${JSON.stringify(stalledSubcommand)}) {
-  process.on("SIGTERM", () => {});
-  setInterval(() => {}, 1_000);
-} else if (process.argv[2] === "ls-files") {
-  process.stdout.write("package.json\\0");
-} else {
-  process.exitCode = 1;
-}
+  const fixture = `#!/bin/sh
+if [ "$1" = ${JSON.stringify(stalledSubcommand)} ]; then
+  trap '' TERM
+  exec sleep 60
+elif [ "$1" = "ls-files" ]; then
+  printf 'package.json\\000'
+else
+  exit 1
+fi
 `;
   writeFileSync(path.join(binDir, "git"), fixture, { mode: 0o755 });
   vi.stubEnv("PATH", `${binDir}${path.delimiter}${process.env.PATH ?? ""}`);
@@ -184,8 +185,10 @@ packageExtensions:
     const dir = makeTempRepoRoot(tempDirs, "openclaw-dependency-pins-ls-files-timeout-");
     stubHangingGit(dir, "ls-files");
 
-    expect(() => collectDependencyPinViolations(dir, { gitTimeoutMs: 200 })).toThrow(
-      "dependency pin guard: git ls-files -z -- *package.json timed out after 200ms.",
+    expect(() =>
+      collectDependencyPinViolations(dir, { gitTimeoutMs: hangingGitTimeoutMs }),
+    ).toThrow(
+      `dependency pin guard: git ls-files -z -- *package.json timed out after ${hangingGitTimeoutMs}ms.`,
     );
   });
 
@@ -198,8 +201,10 @@ packageExtensions:
       rmSync(path.join(dir, "package.json"));
       stubHangingGit(dir, "show");
 
-      expect(() => collectDependencyPinViolations(dir, { gitTimeoutMs: 200 })).toThrow(
-        "dependency pin guard: git show :package.json timed out after 200ms.",
+      expect(() =>
+        collectDependencyPinViolations(dir, { gitTimeoutMs: hangingGitTimeoutMs }),
+      ).toThrow(
+        `dependency pin guard: git show :package.json timed out after ${hangingGitTimeoutMs}ms.`,
       );
     },
   );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the dependency-pin timeout regression test could fail on a loaded runner before reaching the `git show` command it intended to verify.

## Why This Change Was Made

The Unix-only fake Git fixture now uses a lightweight shell fast path for prerequisite `ls-files` output and keeps the selected command resistant to `SIGTERM`. The focused timeout is one second, preserving exact command-specific timeout assertions without changing production behavior.

## User Impact

No user-visible runtime impact. Maintainers get deterministic dependency-pin timeout coverage during validation.

## Evidence

- Before: a bounded focused loop failed on run 2 because prerequisite `git ls-files` exceeded the old 200 ms fixture deadline; the `git show` branch was never reached.
- After: `node scripts/run-vitest.mjs test/scripts/check-dependency-pins.test.ts` passed 10/10 consecutive runs on the same loaded host.
- Final focused run: 6 tests passed.
- `pnpm format:check --no-error-on-unmatched-pattern -- test/scripts/check-dependency-pins.test.ts`
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings.

AI-assisted: yes.
