### PR TITLE
fix(identity): prevent cross-runtime device identity races

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
@@ -34,24 +34,29 @@ enum DeviceIdentitySQLiteStore {
     }
 
     private final class IdentityCoordinator {
-        private var database: OpaquePointer?
+        private var databases: [OpaquePointer]
 
-        init(database: OpaquePointer) {
-            self.database = database
+        init(databases: [OpaquePointer]) {
+            self.databases = databases
         }
 
         func release() throws {
-            guard let database else { return }
-            self.database = nil
-            var releaseError: NSError?
-            if sqlite3_exec(database, "ROLLBACK", nil, nil, nil) != SQLITE_OK {
-                releaseError = DeviceIdentityStore.storageError(
-                    "Could not release device identity coordinator: \(String(cString: sqlite3_errmsg(database)))")
+            let databases = self.databases
+            self.databases = []
+            var releaseErrors: [String] = []
+            for database in databases.reversed() {
+                if sqlite3_exec(database, "ROLLBACK", nil, nil, nil) != SQLITE_OK {
+                    releaseErrors.append(String(cString: sqlite3_errmsg(database)))
+                }
+                if sqlite3_close(database) != SQLITE_OK {
+                    releaseErrors.append("could not close coordinator database")
+                }
             }
-            if sqlite3_close(database) != SQLITE_OK, releaseError == nil {
-                releaseError = DeviceIdentityStore.storageError("Could not close device identity coordinator")
+            if !releaseErrors.isEmpty {
+                throw DeviceIdentityStore.storageError(
+                    "Could not release device identity coordinator: " +
+                        releaseErrors.joined(separator: "; "))
             }
-            if let releaseError { throw releaseError }
         }
     }
 
@@ -64,7 +69,11 @@ enum DeviceIdentitySQLiteStore {
         afterLegacyCommit: (() throws -> Void)? = nil) throws
         -> DeviceIdentity
     {
-        let coordinator = try self.acquireIdentityCoordinator(databaseURL: databaseURL)
+        try self.secureDirectory(destinationStateDirURL)
+        try self.secureDirectory(databaseURL.deletingLastPathComponent())
+        let coordinator = try self.acquireIdentityCoordinator(
+            databaseURL: databaseURL,
+            destinationStateDirURL: destinationStateDirURL)
         do {
             let identity = try self.loadOrCreateOwned(
                 databaseURL: databaseURL,
@@ -128,8 +137,6 @@ enum DeviceIdentitySQLiteStore {
         beforeLegacyClaim: ((DeviceIdentityPaths.LegacyIdentitySource) throws -> Void)?,
         afterLegacyCommit: (() throws -> Void)?) throws -> DeviceIdentity
     {
-        try self.secureDirectory(destinationStateDirURL)
-        try self.secureDirectory(databaseURL.deletingLastPathComponent())
         // SQLite owns an existing profile; leave any downgrade-recreated legacy source for Doctor.
         if self.pathMayExist(databaseURL),
            let existing = try self.loadExisting(databaseURL: databaseURL, profile: profile)
@@ -229,17 +236,67 @@ enum DeviceIdentitySQLiteStore {
         return authoritative.identity
     }
 
-    private static func acquireIdentityCoordinator(databaseURL: URL) throws -> IdentityCoordinator {
-        let canonicalPath = self.canonicalDatabasePath(databaseURL)
-        let digest = SHA256.hash(data: Data(canonicalPath.utf8))
+    static func resolveDeviceIdentityCoordinatorURLs(
+        databaseURL: URL,
+        destinationStateDirURL: URL,
+        temporaryDirectory: URL,
+        uid: uid_t) -> [URL]
+    {
+        let canonicalDatabasePath = self.canonicalExistingAncestorPath(databaseURL)
+        let digest = SHA256.hash(data: Data(canonicalDatabasePath.utf8))
         let pathHash = digest.prefix(4).map { String(format: "%02x", $0) }.joined()
-        let lockDirectoryURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("openclaw-\(getuid())", isDirectory: true)
-        try self.secureCoordinatorDirectory(lockDirectoryURL)
-        let coordinatorURL = lockDirectoryURL.appendingPathComponent(
-            "device-identity.\(pathHash).lock.sqlite",
-            isDirectory: false)
+        let filename = "device-identity.\(pathHash).lock.sqlite"
+        let suffix = "openclaw-\(uid)"
+        let canonicalStateDirURL = URL(
+            fileURLWithPath: self.canonicalExistingAncestorPath(destinationStateDirURL),
+            isDirectory: true)
+        let orderedURLs = [
+            temporaryDirectory.standardizedFileURL
+                .appendingPathComponent(suffix, isDirectory: true)
+                .appendingPathComponent(filename, isDirectory: false),
+            canonicalStateDirURL
+                .appendingPathComponent("tmp", isDirectory: true)
+                .appendingPathComponent(suffix, isDirectory: true)
+                .appendingPathComponent(filename, isDirectory: false),
+        ]
+        var seen: Set<String> = []
+        return orderedURLs.filter { seen.insert(self.canonicalExistingAncestorPath($0)).inserted }
+    }
 
+    private static func acquireIdentityCoordinator(
+        databaseURL: URL,
+        destinationStateDirURL: URL) throws -> IdentityCoordinator
+    {
+        let coordinatorURLs = self.resolveDeviceIdentityCoordinatorURLs(
+            databaseURL: databaseURL,
+            destinationStateDirURL: destinationStateDirURL,
+            temporaryDirectory: FileManager.default.temporaryDirectory,
+            uid: getuid())
+        for coordinatorURL in coordinatorURLs {
+            try self.secureCoordinatorDirectory(coordinatorURL.deletingLastPathComponent())
+        }
+        var databases: [OpaquePointer] = []
+        do {
+            // v2026.7.2-beta.4 through beta.7 use process temp. Keep it first until
+            // those builds are no longer rolling-upgrade peers.
+            for coordinatorURL in coordinatorURLs {
+                try databases.append(self.acquireIdentityCoordinator(at: coordinatorURL))
+            }
+            return IdentityCoordinator(databases: databases)
+        } catch let acquisitionError {
+            do {
+                try IdentityCoordinator(databases: databases).release()
+            } catch let cleanupError {
+                throw DeviceIdentityStore.storageError(
+                    "Could not acquire every device identity coordinator: " +
+                        "\(acquisitionError.localizedDescription); cleanup failed: " +
+                        cleanupError.localizedDescription)
+            }
+            throw acquisitionError
+        }
+    }
+
+    private static func acquireIdentityCoordinator(at coordinatorURL: URL) throws -> OpaquePointer {
         var database: OpaquePointer?
         let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX
         let openResult = sqlite3_open_v2(coordinatorURL.path, &database, flags, nil)
@@ -254,6 +311,7 @@ enum DeviceIdentitySQLiteStore {
                     "Could not configure device identity coordinator timeout: " +
                         String(cString: sqlite3_errmsg(database)))
             }
+            try self.secureFile(coordinatorURL)
             var errorMessage: UnsafeMutablePointer<CChar>?
             guard sqlite3_exec(database, "BEGIN EXCLUSIVE", nil, nil, &errorMessage) == SQLITE_OK else {
                 let detail = errorMessage.map { String(cString: $0) }
@@ -261,9 +319,9 @@ enum DeviceIdentitySQLiteStore {
                 sqlite3_free(errorMessage)
                 throw DeviceIdentityStore.storageError("Could not acquire device identity coordinator: \(detail)")
             }
-            try self.secureFile(coordinatorURL)
-            return IdentityCoordinator(database: database)
+            return database
         } catch {
+            sqlite3_exec(database, "ROLLBACK", nil, nil, nil)
             sqlite3_close(database)
             throw error
         }
@@ -276,9 +334,10 @@ enum DeviceIdentitySQLiteStore {
             guard inspectError == ENOENT else {
                 throw POSIXError(POSIXErrorCode(rawValue: inspectError) ?? .EIO)
             }
-            if mkdir(url.path, mode_t(0o700)) != 0, errno != EEXIST {
-                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-            }
+            try FileManager.default.createDirectory(
+                at: url,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700])
             guard lstat(url.path, &info) == 0 else {
                 throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
             }
@@ -302,19 +361,19 @@ enum DeviceIdentitySQLiteStore {
         }
     }
 
-    private static func canonicalDatabasePath(_ databaseURL: URL) -> String {
+    private static func canonicalExistingAncestorPath(_ url: URL) -> String {
         let fileManager = FileManager.default
-        let resolved = databaseURL.standardizedFileURL
+        let resolved = url.standardizedFileURL
         var current = resolved
         var missingSegments: [String] = []
         while !fileManager.fileExists(atPath: current.path) {
             let parent = current.deletingLastPathComponent()
             guard parent.path != current.path else { return resolved.path }
-            missingSegments.insert(current.lastPathComponent, at: 0)
+            missingSegments.append(current.lastPathComponent)
             current = parent
         }
         var canonical = current.resolvingSymlinksInPath().standardizedFileURL
-        for segment in missingSegments {
+        for segment in missingSegments.reversed() {
             canonical.appendPathComponent(segment)
         }
         return canonical.standardizedFileURL.path

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityCoordinatorContractTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityCoordinatorContractTests.swift
@@ -1,0 +1,47 @@
+import Darwin
+import Foundation
+import Testing
+@testable import OpenClawKit
+
+private struct DeviceIdentityCoordinatorContractFixture: Decodable {
+    let databasePath: String
+    let stateDirectory: String
+    let temporaryDirectory: String
+    let uid: UInt32
+    let orderedExpectedPaths: [String]
+}
+
+private enum DeviceIdentityCoordinatorContractFixtureLoader {
+    static func load() throws -> DeviceIdentityCoordinatorContractFixture {
+        let fixtureURL = try self.findFixtureURL(startingAt: URL(fileURLWithPath: #filePath))
+        return try JSONDecoder().decode(
+            DeviceIdentityCoordinatorContractFixture.self,
+            from: Data(contentsOf: fixtureURL))
+    }
+
+    private static func findFixtureURL(startingAt fileURL: URL) throws -> URL {
+        var directory = fileURL.deletingLastPathComponent()
+        while directory.path != "/" {
+            let candidate = directory.appendingPathComponent(
+                "test/fixtures/device-identity-coordinator-contract.json")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+            directory.deleteLastPathComponent()
+        }
+        throw NSError(domain: "DeviceIdentityCoordinatorContractFixtureLoader", code: 1)
+    }
+}
+
+struct DeviceIdentityCoordinatorContractTests {
+    @Test func `matches shared ordered path vector`() throws {
+        let fixture = try DeviceIdentityCoordinatorContractFixtureLoader.load()
+        let resolved = DeviceIdentitySQLiteStore.resolveDeviceIdentityCoordinatorURLs(
+            databaseURL: URL(fileURLWithPath: fixture.databasePath),
+            destinationStateDirURL: URL(fileURLWithPath: fixture.stateDirectory, isDirectory: true),
+            temporaryDirectory: URL(fileURLWithPath: fixture.temporaryDirectory, isDirectory: true),
+            uid: uid_t(fixture.uid))
+
+        #expect(resolved.map(\.path) == fixture.orderedExpectedPaths)
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
@@ -1,4 +1,5 @@
 import CryptoKit
+import Darwin
 import Foundation
 import SQLite3
 import Testing
@@ -442,6 +443,22 @@ struct DeviceIdentityStoreTests {
             FileManager.default.attributesOfItem(atPath: fixture.databaseURL.path)[.posixPermissions] as? NSNumber)
         #expect(directoryMode.intValue & 0o777 == 0o700)
         #expect(databaseMode.intValue & 0o777 == 0o600)
+
+        let coordinatorURLs = DeviceIdentitySQLiteStore.resolveDeviceIdentityCoordinatorURLs(
+            databaseURL: fixture.databaseURL,
+            destinationStateDirURL: fixture.destination,
+            temporaryDirectory: FileManager.default.temporaryDirectory,
+            uid: getuid())
+        #expect(coordinatorURLs.count == 2)
+        for coordinatorURL in coordinatorURLs {
+            let coordinatorDirectoryMode = try #require(
+                FileManager.default.attributesOfItem(
+                    atPath: coordinatorURL.deletingLastPathComponent().path)[.posixPermissions] as? NSNumber)
+            let coordinatorFileMode = try #require(
+                FileManager.default.attributesOfItem(atPath: coordinatorURL.path)[.posixPermissions] as? NSNumber)
+            #expect(coordinatorDirectoryMode.intValue & 0o777 == 0o700)
+            #expect(coordinatorFileMode.intValue & 0o777 == 0o600)
+        }
     }
 
     @Test

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -39,6 +39,8 @@ const SKILLS_PYTHON_SCOPE_RE = /^(skills\/|skills\/pyproject\.toml$)/;
 const INSTALL_SMOKE_WORKFLOW_SCOPE_RE = /^\.github\/workflows\/install-smoke\.yml$/;
 const NATIVE_PROTOCOL_GEN_RE = /^apps\/shared\/OpenClawKit\/Sources\/OpenClawProtocol\//;
 const APPLE_SWIFT_CONFIG_RE = /^config\/(?:swiftformat|swiftlint\.yml)$/;
+const APPLE_SHARED_CONTRACT_FIXTURE_RE =
+  /^test\/fixtures\/(?:device-identity-coordinator|talk-config)-contract\.json$/;
 const MACOS_NATIVE_RE =
   /^(apps\/macos\/|apps\/macos-mlx-tts\/|apps\/ios\/|apps\/shared\/|apps\/swabble\/|Swabble\/)/;
 const MACOS_SCRIPT_SCOPE_RE =
@@ -138,7 +140,10 @@ export function detectChangedScope(changedPaths) {
 
     if (
       !NATIVE_PROTOCOL_GEN_RE.test(path) &&
-      (MACOS_NATIVE_RE.test(path) || MACOS_SCRIPT_SCOPE_RE.test(path) || isAppleSwiftConfig)
+      (MACOS_NATIVE_RE.test(path) ||
+        MACOS_SCRIPT_SCOPE_RE.test(path) ||
+        APPLE_SHARED_CONTRACT_FIXTURE_RE.test(path) ||
+        isAppleSwiftConfig)
     ) {
       runMacos = true;
     }

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -1830,6 +1830,7 @@ const releaseCheck = "test/release-check.test.ts";
 const installDocker = "test-install-sh-docker";
 const changedScope = "src/scripts/ci-changed-scope.test.ts";
 const changedScopeTests = [
+  "src/scripts/ci-changed-scope.contract-fixtures.test.ts",
   "src/scripts/ci-changed-scope.control-ui.test.ts",
   "src/scripts/ci-changed-scope.native-i18n.test.ts",
   changedScope,

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -405,8 +405,10 @@ export const DEFAULT_GATEWAY_PORT = 18789;
  * Gateway lock directory inside the selected state tree.
  * Default: $OPENCLAW_STATE_DIR/tmp/openclaw-<uid> (uid suffix when available).
  */
-export function resolveGatewayLockDir(stateDir: string = resolveStateDir()): string {
-  const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
+export function resolveGatewayLockDir(
+  stateDir: string = resolveStateDir(),
+  uid: number | undefined = typeof process.getuid === "function" ? process.getuid() : undefined,
+): string {
   const suffix = uid != null ? `openclaw-${uid}` : "openclaw";
   // Clean break: older binaries still use process temp and do not exclude a
   // state-local binary during a mixed-version upgrade.

--- a/src/infra/device-identity-coordinator-paths.ts
+++ b/src/infra/device-identity-coordinator-paths.ts
@@ -1,0 +1,41 @@
+import path from "node:path";
+import { resolveGatewayLockDir } from "../config/paths.js";
+import { resolvePathViaExistingAncestorSync } from "./boundary-path.js";
+import { sha256HexPrefix } from "./crypto-digest.js";
+
+function resolveDeviceIdentityCoordinatorFilename(databasePath: string): string {
+  const canonicalPath = resolvePathViaExistingAncestorSync(databasePath);
+  const databaseHash = sha256HexPrefix(canonicalPath, 8);
+  return `device-identity.${databaseHash}.lock.sqlite`;
+}
+
+export function resolveDeviceIdentityCoordinatorPath(
+  databasePath: string,
+  lockDir: string,
+): string {
+  return path.join(lockDir, resolveDeviceIdentityCoordinatorFilename(databasePath));
+}
+
+export function resolveDeviceIdentityCoordinatorPaths(params: {
+  databasePath: string;
+  stateDir: string;
+  temporaryDirectory: string;
+  uid: number | undefined;
+}): string[] {
+  const suffix = params.uid === undefined ? "openclaw" : `openclaw-${params.uid}`;
+  const filename = resolveDeviceIdentityCoordinatorFilename(params.databasePath);
+  const canonicalStateDir = resolvePathViaExistingAncestorSync(params.stateDir);
+  const orderedPaths = [
+    path.join(path.resolve(params.temporaryDirectory), suffix, filename),
+    path.join(resolveGatewayLockDir(canonicalStateDir, params.uid), filename),
+  ];
+  const seen = new Set<string>();
+  return orderedPaths.filter((coordinatorPath) => {
+    const canonicalPath = resolvePathViaExistingAncestorSync(coordinatorPath);
+    if (seen.has(canonicalPath)) {
+      return false;
+    }
+    seen.add(canonicalPath);
+    return true;
+  });
+}

--- a/src/infra/device-identity-coordinator.contract.test.ts
+++ b/src/infra/device-identity-coordinator.contract.test.ts
@@ -1,0 +1,75 @@
+// Verifies the shared Node/Swift device identity coordinator path contract.
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempDir } from "../test-utils/temp-dir.js";
+import { resolveDeviceIdentityCoordinatorPaths } from "./device-identity-coordinator-paths.js";
+
+type ContractFixture = {
+  databasePath: string;
+  stateDirectory: string;
+  temporaryDirectory: string;
+  uid: number;
+  orderedExpectedPaths: string[];
+};
+
+const fixture = JSON.parse(
+  fs.readFileSync(
+    new URL("../../test/fixtures/device-identity-coordinator-contract.json", import.meta.url),
+    "utf8",
+  ),
+) as ContractFixture;
+
+describe.skipIf(process.platform === "win32")("device identity coordinator contract", () => {
+  it("matches the shared ordered path vector", () => {
+    expect(
+      resolveDeviceIdentityCoordinatorPaths({
+        databasePath: fixture.databasePath,
+        stateDir: fixture.stateDirectory,
+        temporaryDirectory: fixture.temporaryDirectory,
+        uid: fixture.uid,
+      }),
+    ).toEqual(fixture.orderedExpectedPaths);
+  });
+
+  it("deduplicates coincident process-temp and state-local paths", () => {
+    const stateLocalPath = fixture.orderedExpectedPaths[1];
+    if (!stateLocalPath) {
+      throw new Error("state-local fixture path is unavailable");
+    }
+    expect(
+      resolveDeviceIdentityCoordinatorPaths({
+        databasePath: fixture.databasePath,
+        stateDir: fixture.stateDirectory,
+        temporaryDirectory: path.join(fixture.stateDirectory, "tmp"),
+        uid: fixture.uid,
+      }),
+    ).toEqual([stateLocalPath]);
+  });
+
+  it("canonicalizes database and state paths through existing symlink ancestors", async () => {
+    await withTempDir("openclaw-device-identity-path-contract-", async (rawRootDir) => {
+      const rootDir = fs.realpathSync.native(rawRootDir);
+      const canonicalStateDir = path.join(rootDir, "canonical-state");
+      const aliasedStateDir = path.join(rootDir, "aliased-state");
+      const temporaryDirectory = path.join(rootDir, "process-temp");
+      fs.mkdirSync(canonicalStateDir);
+      fs.symlinkSync(canonicalStateDir, aliasedStateDir);
+
+      const common = { temporaryDirectory, uid: fixture.uid };
+      expect(
+        resolveDeviceIdentityCoordinatorPaths({
+          ...common,
+          databasePath: path.join(aliasedStateDir, "state", "openclaw.sqlite"),
+          stateDir: aliasedStateDir,
+        }),
+      ).toEqual(
+        resolveDeviceIdentityCoordinatorPaths({
+          ...common,
+          databasePath: path.join(canonicalStateDir, "state", "openclaw.sqlite"),
+          stateDir: canonicalStateDir,
+        }),
+      );
+    });
+  });
+});

--- a/src/infra/device-identity-coordinator.ts
+++ b/src/infra/device-identity-coordinator.ts
@@ -1,7 +1,10 @@
-import crypto from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import { resolveGatewayLockDir, resolveStateDir } from "../config/paths.js";
+import {
+  resolveDeviceIdentityCoordinatorPath,
+  resolveDeviceIdentityCoordinatorPaths,
+} from "./device-identity-coordinator-paths.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
 
 const DEFAULT_BUSY_TIMEOUT_MS = 5000;
@@ -14,35 +17,6 @@ class DeviceIdentityCoordinatorError extends Error {
     super(message);
     this.name = "DeviceIdentityCoordinatorError";
   }
-}
-
-function canonicalizeDatabasePath(databasePath: string): string {
-  const resolved = path.resolve(databasePath);
-  try {
-    return fs.realpathSync.native(resolved);
-  } catch {
-    const missingSegments: string[] = [];
-    let current = resolved;
-    while (true) {
-      const parent = path.dirname(current);
-      if (parent === current) {
-        return resolved;
-      }
-      missingSegments.push(path.basename(current));
-      current = parent;
-      try {
-        return path.join(fs.realpathSync.native(current), ...missingSegments.toReversed());
-      } catch {
-        // Existing ancestors can still contain aliases even when the database is absent.
-      }
-    }
-  }
-}
-
-function resolveDeviceIdentityCoordinatorPath(databasePath: string, lockDir: string): string {
-  const canonicalPath = canonicalizeDatabasePath(databasePath);
-  const databaseHash = crypto.createHash("sha256").update(canonicalPath).digest("hex").slice(0, 8);
-  return path.join(lockDir, `device-identity.${databaseHash}.lock.sqlite`);
 }
 
 function ensurePrivateCoordinatorDirectory(lockDir: string): void {
@@ -84,20 +58,18 @@ function ensurePrivateCoordinatorDirectory(lockDir: string): void {
   }
 }
 
-export function acquireDeviceIdentityCoordinator(params: {
+type DeviceIdentityCoordinatorParams = {
   databasePath: string;
   busyTimeoutMs?: number;
-  env?: NodeJS.ProcessEnv;
-  lockDir?: string;
-}): { release: () => void } {
-  const lockDir =
-    params.lockDir ?? resolveGatewayLockDir(resolveStateDir(params.env ?? process.env));
-  const coordinatorPath = resolveDeviceIdentityCoordinatorPath(params.databasePath, lockDir);
-  ensurePrivateCoordinatorDirectory(path.dirname(coordinatorPath));
+} & ({ stateDir: string; lockDir?: never } | { lockDir: string; stateDir?: never });
+
+function acquireCoordinatorDatabase(
+  coordinatorPath: string,
+  busyTimeoutMs: number,
+): ReturnType<typeof openNodeSqliteDatabase> {
   const database = openNodeSqliteDatabase(coordinatorPath);
   try {
-    const timeout = Math.max(0, Math.trunc(params.busyTimeoutMs ?? DEFAULT_BUSY_TIMEOUT_MS));
-    database.exec(`PRAGMA busy_timeout = ${timeout}; BEGIN EXCLUSIVE;`);
+    database.exec(`PRAGMA busy_timeout = ${busyTimeoutMs}; BEGIN EXCLUSIVE;`);
   } catch (error) {
     try {
       database.close();
@@ -105,6 +77,63 @@ export function acquireDeviceIdentityCoordinator(params: {
     throw new DeviceIdentityCoordinatorError(
       "device identity migration or creation already owns this state database",
       error,
+    );
+  }
+  return database;
+}
+
+function releaseCoordinatorDatabase(
+  database: ReturnType<typeof openNodeSqliteDatabase>,
+): unknown[] {
+  const releaseErrors: unknown[] = [];
+  try {
+    database.exec("ROLLBACK");
+  } catch (error) {
+    releaseErrors.push(error);
+  }
+  try {
+    database.close();
+  } catch (error) {
+    releaseErrors.push(error);
+  }
+  return releaseErrors;
+}
+
+export function acquireDeviceIdentityCoordinator(params: DeviceIdentityCoordinatorParams): {
+  release: () => void;
+} {
+  const timeout = Math.max(0, Math.trunc(params.busyTimeoutMs ?? DEFAULT_BUSY_TIMEOUT_MS));
+  const coordinatorPaths =
+    params.lockDir !== undefined
+      ? [resolveDeviceIdentityCoordinatorPath(params.databasePath, params.lockDir)]
+      : resolveDeviceIdentityCoordinatorPaths({
+          databasePath: params.databasePath,
+          stateDir: params.stateDir,
+          temporaryDirectory: os.tmpdir(),
+          uid: typeof process.getuid === "function" ? process.getuid() : undefined,
+        });
+  for (const coordinatorPath of coordinatorPaths) {
+    ensurePrivateCoordinatorDirectory(path.dirname(coordinatorPath));
+  }
+  const databases: Array<ReturnType<typeof openNodeSqliteDatabase>> = [];
+  try {
+    // v2026.7.2-beta.4 through beta.7 use process temp. Keep it first until
+    // those builds are no longer rolling-upgrade peers.
+    for (const coordinatorPath of coordinatorPaths) {
+      databases.push(acquireCoordinatorDatabase(coordinatorPath, timeout));
+    }
+  } catch (error) {
+    const cleanupErrors = databases.toReversed().flatMap(releaseCoordinatorDatabase);
+    if (cleanupErrors.length === 0) {
+      throw error;
+    }
+    const message =
+      error instanceof DeviceIdentityCoordinatorError
+        ? `${error.message}; failed to clean up a partially acquired coordinator`
+        : "failed to acquire and clean up device identity coordinators";
+    throw new DeviceIdentityCoordinatorError(
+      message,
+      new AggregateError([error, ...cleanupErrors]),
     );
   }
 
@@ -115,21 +144,11 @@ export function acquireDeviceIdentityCoordinator(params: {
         return;
       }
       released = true;
-      let releaseError: unknown;
-      try {
-        database.exec("ROLLBACK");
-      } catch (error) {
-        releaseError = error;
-      }
-      try {
-        database.close();
-      } catch (error) {
-        releaseError ??= error;
-      }
-      if (releaseError) {
+      const releaseErrors = databases.toReversed().flatMap(releaseCoordinatorDatabase);
+      if (releaseErrors.length > 0) {
         throw new DeviceIdentityCoordinatorError(
           "failed to release device identity coordinator",
-          releaseError,
+          releaseErrors.length === 1 ? releaseErrors[0] : new AggregateError(releaseErrors),
         );
       }
     },

--- a/src/infra/device-identity.state-dir.test.ts
+++ b/src/infra/device-identity.state-dir.test.ts
@@ -7,6 +7,7 @@ import { resolveGatewayLockDir } from "../config/paths.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
+import { resolveDeviceIdentityCoordinatorPaths } from "./device-identity-coordinator-paths.js";
 import { loadDeviceIdentityIfPresent, loadOrCreateDeviceIdentity } from "./device-identity.js";
 
 afterEach(() => {
@@ -57,10 +58,21 @@ describe("device identity state dir defaults", () => {
 
       loadOrCreateDeviceIdentity({ env });
 
-      expect(fs.readdirSync(resolveGatewayLockDir(stateDir))).toContainEqual(
-        expect.stringMatching(/^device-identity\.[0-9a-f]{8}\.lock\.sqlite$/u),
-      );
-      expect(fs.readdirSync(legacyTmpDir)).toEqual([]);
+      const coordinatorPaths = resolveDeviceIdentityCoordinatorPaths({
+        databasePath: path.join(stateDir, "state", "openclaw.sqlite"),
+        stateDir,
+        temporaryDirectory: legacyTmpDir,
+        uid: typeof process.getuid === "function" ? process.getuid() : undefined,
+      });
+      const processTempPath = coordinatorPaths[0];
+      const stateLocalPath = coordinatorPaths[1];
+      if (!processTempPath || !stateLocalPath) {
+        throw new Error("coordinator bridge paths are unavailable");
+      }
+      const stateCoordinators = fs.readdirSync(path.dirname(stateLocalPath));
+      const processTempCoordinators = fs.readdirSync(path.dirname(processTempPath));
+      expect(stateCoordinators).toHaveLength(1);
+      expect(processTempCoordinators).toEqual(stateCoordinators);
       expect(fs.existsSync(path.join(fakeHome, ".openclaw"))).toBe(false);
     });
   });

--- a/src/infra/device-identity.test.ts
+++ b/src/infra/device-identity.test.ts
@@ -2,13 +2,15 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   closeOpenClawStateDatabaseForTest,
   OPENCLAW_STATE_SCHEMA_VERSION,
 } from "../state/openclaw-state-db.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
+import { resolveDeviceIdentityCoordinatorPaths } from "./device-identity-coordinator-paths.js";
 import { acquireDeviceIdentityCoordinator } from "./device-identity-coordinator.js";
 import { normalizeLegacyDeviceIdentity } from "./device-identity-legacy.js";
 import type { DeviceIdentityStoreOptions } from "./device-identity-store.js";
@@ -31,6 +33,7 @@ const MISMATCHED_SWIFT_RAW_PRIVATE_KEY = "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ
 
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
 });
 
 function storeOptions(rootDir: string, identityKey?: string): DeviceIdentityStoreOptions {
@@ -177,6 +180,84 @@ describe("device identity SQLite store", () => {
           busyTimeoutMs: 0,
         }),
       ).toThrow(/real directory/);
+    });
+  });
+
+  it("bridges process-temp and state-local coordinator owners", async () => {
+    await withTempDir("openclaw-device-identity-bridge-", async (rawRootDir) => {
+      const rootDir = fs.realpathSync.native(rawRootDir);
+      const databasePath = path.join(rootDir, "selected-state", "state", "openclaw.sqlite");
+      const stateDir = path.join(rootDir, "selected-state");
+      const temporaryDirectory = path.join(rootDir, "process-temp");
+      fs.mkdirSync(temporaryDirectory, { recursive: true });
+      vi.spyOn(os, "tmpdir").mockReturnValue(temporaryDirectory);
+
+      const paths = resolveDeviceIdentityCoordinatorPaths({
+        databasePath,
+        stateDir,
+        temporaryDirectory,
+        uid: typeof process.getuid === "function" ? process.getuid() : undefined,
+      });
+      expect(paths).toHaveLength(2);
+      const processTempPath = paths[0];
+      const stateLocalPath = paths[1];
+      if (!processTempPath || !stateLocalPath) {
+        throw new Error("coordinator bridge paths are unavailable");
+      }
+      const processTempLockDir = path.dirname(processTempPath);
+      const stateLockDir = path.dirname(stateLocalPath);
+
+      const stateOnly = acquireDeviceIdentityCoordinator({
+        databasePath,
+        lockDir: stateLockDir,
+        busyTimeoutMs: 0,
+      });
+      try {
+        expect(() =>
+          acquireDeviceIdentityCoordinator({ databasePath, stateDir, busyTimeoutMs: 0 }),
+        ).toThrow(/migration or creation already owns this state database/);
+        const oldAfterPartialFailure = acquireDeviceIdentityCoordinator({
+          databasePath,
+          lockDir: processTempLockDir,
+          busyTimeoutMs: 0,
+        });
+        oldAfterPartialFailure.release();
+      } finally {
+        stateOnly.release();
+      }
+
+      const dual = acquireDeviceIdentityCoordinator({ databasePath, stateDir, busyTimeoutMs: 0 });
+      try {
+        expect(() =>
+          acquireDeviceIdentityCoordinator({
+            databasePath,
+            lockDir: processTempLockDir,
+            busyTimeoutMs: 0,
+          }),
+        ).toThrow(/migration or creation already owns this state database/);
+        expect(() =>
+          acquireDeviceIdentityCoordinator({
+            databasePath,
+            lockDir: stateLockDir,
+            busyTimeoutMs: 0,
+          }),
+        ).toThrow(/migration or creation already owns this state database/);
+      } finally {
+        dual.release();
+      }
+
+      const oldRuntime = acquireDeviceIdentityCoordinator({
+        databasePath,
+        lockDir: processTempLockDir,
+        busyTimeoutMs: 0,
+      });
+      const transitionalRuntime = acquireDeviceIdentityCoordinator({
+        databasePath,
+        lockDir: stateLockDir,
+        busyTimeoutMs: 0,
+      });
+      transitionalRuntime.release();
+      oldRuntime.release();
     });
   });
 

--- a/src/infra/device-identity.ts
+++ b/src/infra/device-identity.ts
@@ -2,7 +2,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { resolveStateDir } from "../config/paths.js";
 import { acquireDeviceIdentityCoordinator } from "./device-identity-coordinator.js";
 import {
   generateStoredDeviceIdentity,
@@ -55,20 +54,18 @@ function pathMayExist(filePath: string): boolean {
   }
 }
 
-function resolveLegacyStateDir(options: DeviceIdentityStoreOptions): string {
-  if (options.env?.OPENCLAW_STATE_DIR?.trim()) {
-    return resolveStateDir(options.env);
-  }
-  if (options.path) {
-    const databaseDir = path.dirname(path.resolve(options.path));
-    return path.basename(databaseDir) === "state" ? path.dirname(databaseDir) : databaseDir;
-  }
-  return resolveStateDir(options.env ?? process.env);
+function resolveDeviceIdentityStateDir(databasePath: string): string {
+  const databaseDir = path.dirname(databasePath);
+  return path.basename(databaseDir) === "state" ? path.dirname(databaseDir) : databaseDir;
 }
 
 /** Exact retired file owned by Doctor migration code. */
 function resolveLegacyDeviceIdentityPath(options: DeviceIdentityStoreOptions = {}): string {
-  return path.join(resolveLegacyStateDir(options), LEGACY_DEVICE_IDENTITY_RELATIVE_PATH);
+  const { databasePath } = resolveDeviceIdentityStore(options);
+  return path.join(
+    resolveDeviceIdentityStateDir(databasePath),
+    LEGACY_DEVICE_IDENTITY_RELATIVE_PATH,
+  );
 }
 
 function assertNoPendingLegacyIdentity(options: DeviceIdentityStoreOptions): void {
@@ -102,7 +99,7 @@ function withDeviceIdentityCoordinator<T>(
   };
   const coordinator = acquireDeviceIdentityCoordinator({
     databasePath: resolved.databasePath,
-    env: options.env,
+    stateDir: resolveDeviceIdentityStateDir(resolved.databasePath),
   });
   let result: T;
   try {

--- a/src/infra/state-migrations.device-identity.ts
+++ b/src/infra/state-migrations.device-identity.ts
@@ -535,7 +535,7 @@ export async function migrateLegacyDeviceIdentity(params: {
       try {
         identityCoordinator = acquireDeviceIdentityCoordinator({
           databasePath: resolveDeviceIdentityStore({ env, identityKey: IDENTITY_KEY }).databasePath,
-          env,
+          stateDir: params.stateDir,
         });
       } catch (error) {
         return {

--- a/src/scripts/ci-changed-scope.contract-fixtures.test.ts
+++ b/src/scripts/ci-changed-scope.contract-fixtures.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { detectChangedScope } from "../../scripts/ci-changed-scope.mjs";
+
+describe("shared Apple contract fixture CI scope", () => {
+  it.each([
+    "test/fixtures/device-identity-coordinator-contract.json",
+    "test/fixtures/talk-config-contract.json",
+  ])("runs macOS contract tests for %s", (fixturePath) => {
+    expect(detectChangedScope([fixturePath])).toEqual({
+      runNode: true,
+      runMacos: true,
+      runIosBuild: false,
+      runAndroid: false,
+      runWindows: false,
+      runSkillsPython: false,
+      runChangedSmoke: false,
+      runControlUiI18n: false,
+      runUiTests: false,
+    });
+  });
+});

--- a/test/fixtures/device-identity-coordinator-contract.json
+++ b/test/fixtures/device-identity-coordinator-contract.json
@@ -1,0 +1,10 @@
+{
+  "databasePath": "/openclaw-device-identity-contract/state/openclaw.sqlite",
+  "stateDirectory": "/openclaw-device-identity-contract",
+  "temporaryDirectory": "/openclaw-device-identity-contract-temp",
+  "uid": 501,
+  "orderedExpectedPaths": [
+    "/openclaw-device-identity-contract-temp/openclaw-501/device-identity.e5c82e32.lock.sqlite",
+    "/openclaw-device-identity-contract/tmp/openclaw-501/device-identity.e5c82e32.lock.sqlite"
+  ]
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running the TypeScript and Swift runtimes against the same selected state tree could have each runtime coordinate device identity SQLite ownership through a different lock database. During mixed-version upgrades or alternate state-directory use, that split ownership could allow overlapping initialization and produce mismatched device identities.

## Why This Change Was Made

The selected state tree now owns the canonical coordinator under `tmp/openclaw-<uid>`. For rolling upgrades, both runtimes first acquire the shipped process-temporary coordinator and then the state-local coordinator, release them in reverse order, and unwind every acquired coordinator if a later acquisition fails. A shared ordered JSON fixture pins the full cross-language path and hash contract, and CI routes fixture-only changes through both Node and OpenClawKit coverage. The bridge preserves interoperability with the shipped process-temporary owner without migrating or deleting coordinator files, and it does not change the SQLite schema or schema version. This change was AI-assisted and reviewed before publication.

## User Impact

Users can run mixed TypeScript/Swift deployments and rolling upgrades without the two runtimes independently claiming the same device identity database. Existing installations require no configuration change or migration, and the device identity remains stable across the upgrade boundary.

## Evidence

- `node scripts/run-vitest.mjs src/infra/device-identity-coordinator.contract.test.ts src/infra/device-identity.test.ts src/infra/device-identity.state-dir.test.ts src/infra/state-migrations.device-identity.test.ts src/infra/gateway-lock.state-dir.test.ts src/scripts/ci-changed-scope.test.ts src/scripts/ci-changed-scope.contract-fixtures.test.ts` — 55 infrastructure tests and 38 tooling tests passed.
- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts --testNamePattern 'keeps CI, dependency, and docs tooling edits on owner tests'` — the exact CI routing assertion passed after registering the new fixture suite with its tooling owner.
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/shared/OpenClawKit --filter DeviceIdentityCoordinatorContractTests` — 1 test passed.
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/shared/OpenClawKit --filter DeviceIdentityStoreTests` — 37 tests passed.
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, `pnpm tsgo:scripts`, targeted Oxlint/oxfmt, SwiftFormat, and `git diff --check` passed.
- Fresh branch review of the coordinator repair and fresh uncommitted review of the CI owner-routing follow-up both reported no actionable findings.
- Exact-head CI run https://github.com/openclaw/openclaw/actions/runs/31268419751 exposed the missing owner-test registration in `checks-node-compact-small-2`; commit `add86a3e6de8623fed90060fa7c83570c7c20871` fixes that deterministic PR-owned failure. A new exact-head hosted run is required before landing.
- The earlier `node scripts/check-changed.mjs` delegation could not acquire a Crabbox/Testbox provider; its prescribed trusted-source local fallback passed.
- No live channel proof was run; this repair is a deterministic local SQLite/path ownership contract and does not change a channel or external API path.
