### PR TITLE
fix(claws): restore bootstrap export tests on macOS

### DIFF
--- a/src/claws/export.test.ts
+++ b/src/claws/export.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -124,7 +124,7 @@ async function installedFixture(
       ? {
           packageBootstrap: {
             sourcePath: "BOOTSTRAP.md",
-            realPath: packageBootstrapPath,
+            realPath: await realpath(packageBootstrapPath),
             byteLength: packageBootstrapContent.byteLength,
             digest: `sha256:${createHash("sha256").update(packageBootstrapContent).digest("hex")}`,
           },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Claw export test fixture created a non-canonical package bootstrap snapshot on macOS, causing four pending-bootstrap export tests to fail after bootstrap seeding correctly rejected the `/var` versus `/private/var` path mismatch.

## Why This Change Was Made

The production reader records `ClawWorkspaceSourceSnapshot.realPath` as a canonical filesystem path. The export fixture now does the same instead of fabricating the snapshot from the logical temp-directory spelling. This preserves the production `install_incomplete` guard and tests the real reader contract.

## User Impact

No runtime behavior changes. The pending package-bootstrap export coverage is reliable on macOS again.

## Evidence

- Before: `node scripts/run-vitest.mjs src/claws/export.test.ts` failed 4 of 19 tests with `install_incomplete`; tracing the add result showed `bootstrap_source_escape` from the `/var` and `/private/var` alias mismatch.
- After: `node scripts/run-vitest.mjs src/claws/export.test.ts` passed 19 of 19 tests.
- Sibling lifecycle proof: `node scripts/run-vitest.mjs src/claws/bootstrap.test.ts` passed 14 of 14 tests.
- `pnpm format src/claws/export.test.ts`
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings, correctness 0.99.
