### PR TITLE
fix(ui): label only operator-pinned runtimes in model picker rows

### DIFF
--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5229,6 +5229,13 @@ describe("chat model controls", () => {
           contextWindow: 1_000_000,
           agentRuntime: { id: "google-gemini-cli", source: "model" },
         },
+        {
+          id: "gpt-5.6-terra",
+          name: "GPT-5.6 Terra",
+          provider: "openai",
+          contextWindow: 1_000_000,
+          agentRuntime: { id: "openclaw", source: "implicit" },
+        },
       ],
     });
     const container = renderModelControls(state);
@@ -5243,6 +5250,9 @@ describe("chat model controls", () => {
     // Known CLI runtime ids map to their product labels, not capitalized ids.
     expect(metaFor("anthropic/claude-opus-4-5")).toBe("200k · Claude CLI");
     expect(metaFor("google/gemini-3-pro")).toBe("1M · Gemini CLI");
+    // Implicitly resolved runtimes stay unlabeled; only operator-pinned
+    // (source model/provider) rows carry the runtime meta.
+    expect(metaFor("openai/gpt-5.6-terra")).toBe("1M");
   });
 
   it("marks chat-only models in the active control and picker", () => {

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -200,7 +200,13 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     const isDefault =
       defaultSelectable && option.value.trim().toLowerCase() === normalizedDefaultModel;
     const catalogEntry = resolveChatModelCatalogEntry(option.value, props.modelCatalog);
-    const agentRuntimeId = catalogEntry?.agentRuntime?.id.trim();
+    // Runtime meta labels only operator-pinned runtimes (models/provider config);
+    // implicit/default resolution stays unlabeled so ordinary rows stay clean.
+    const agentRuntime = catalogEntry?.agentRuntime;
+    const agentRuntimeId =
+      agentRuntime && (agentRuntime.source === "model" || agentRuntime.source === "provider")
+        ? agentRuntime.id.trim()
+        : undefined;
     return {
       commitValue: isDefault ? "" : option.value,
       ...(agentRuntimeId ? { agentRuntimeId } : {}),


### PR DESCRIPTION
## What Problem This Solves

#120617 rendered the resolved agent runtime on every model row that carries one. But the gateway resolves a runtime for many rows implicitly (harness policy defaults, OpenAI implicit routing), so ordinary rows could pick up repetitive "· OpenClaw" meta that conveys no operator decision.

## Why This Change Was Made

Maintainer decision after landing #120617: the label should mark operator intent, not resolution mechanics. The runtime meta now renders only when `agentRuntime.source` is `model` or `provider` — i.e. an operator pinned that runtime in config. Implicit/default/env/session resolutions stay unlabeled, so a dual-runtime setup like `gpt-5.6` (OpenClaw) vs `gpt-5.6-sol` (Codex) stays distinguished while the rest of the list stays clean.

## User Impact

Runtime labels appear exactly where a configuration choice created lookalike rows, and nowhere else. No other picker behavior changes.

## Evidence

- `chat-view.test.ts` — 230 passed; regression extended with an implicit-source row asserting bare "1M" meta
- Autoreview (Codex `gpt-5.6-sol`, high): clean
- LOC: production +5, tests +12
