### PR TITLE
fix(telegram): reuse saved media for quoted replies

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
@@ -98,6 +98,7 @@ export function createTelegramInboundMediaGroupRuntime(
   } = params;
   const {
     resolveMediaRuntime,
+    recordMessageResolvedMedia,
     promptContextBoundaryOptions,
     latestPromptContextMinTimestampMs,
     latestPromptContextAmbientWatermark,
@@ -347,6 +348,7 @@ export function createTelegramInboundMediaGroupRuntime(
           continue;
         }
         if (media) {
+          await recordMessageResolvedMedia({ msg, media, botUserId: ctx.me?.id });
           allMedia.push({
             path: media.path,
             contentType: media.contentType,

--- a/extensions/telegram/src/bot-handlers.inbound.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound.runtime.ts
@@ -58,6 +58,7 @@ export function createTelegramHandlerInboundRuntime(
 ) {
   const {
     resolveMediaRuntime,
+    recordMessageResolvedMedia,
     promptContextBoundaryOptions,
     releaseDispatchDedupeClaims,
     createSpooledReplayParticipantForBufferedWork,
@@ -233,6 +234,9 @@ export function createTelegramHandlerInboundRuntime(
         maxBytes: mediaMaxBytes,
         ...mediaRuntime,
       });
+      if (media) {
+        await recordMessageResolvedMedia({ msg, media, botUserId: ctx.me?.id });
+      }
     } catch (mediaErr) {
       const replayingSpooledUpdate = isTelegramSpooledReplayUpdate(ctx.update);
       const warningThreadParams = buildTelegramThreadParams(

--- a/extensions/telegram/src/bot-handlers.message-context.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-context.runtime.ts
@@ -109,6 +109,29 @@ export function createTelegramMessageContextRuntime({
       ...(params.botUserId !== undefined ? { botUserId: params.botUserId } : {}),
     });
 
+  const recordReplyMessageResolvedMedia = async (params: {
+    chatId: string | number;
+    messageId: string;
+    media: TelegramResolvedMedia;
+    botUserId?: number;
+  }) => {
+    const cachedNode = await messageCache.get({
+      accountId,
+      chatId: params.chatId,
+      messageId: params.messageId,
+    });
+    if (!cachedNode) {
+      return;
+    }
+    await messageCache.recordResolvedMedia({
+      accountId,
+      chatId: params.chatId,
+      messageId: params.messageId,
+      media: params.media,
+      ...(params.botUserId !== undefined ? { botUserId: params.botUserId } : {}),
+    });
+  };
+
   // `MessageReactionUpdated` carries no `message_thread_id`, so the reaction handler
   // recovers the originating topic from the same bounded cache that records inbound
   // and outbound messages. `undefined` means "thread unknown", never "General": the
@@ -290,6 +313,7 @@ export function createTelegramMessageContextRuntime({
   return {
     recordMessageForReplyChain,
     recordMessageResolvedMedia,
+    recordReplyMessageResolvedMedia,
     resolveCachedMessageThreadId,
     buildReplyChainForMessage,
     toReplyChainEntry,

--- a/extensions/telegram/src/bot-handlers.message-context.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-context.runtime.ts
@@ -17,7 +17,10 @@ import {
   isTelegramHistoryEntryAfterAmbientWatermark,
   isTelegramSelfSenderName,
 } from "./group-history-window.js";
-import { resolveTelegramMessageCacheScope } from "./message-cache-persistence.js";
+import {
+  resolveTelegramMessageCacheScope,
+  type TelegramResolvedMedia,
+} from "./message-cache-persistence.js";
 import {
   buildTelegramConversationContext,
   buildTelegramReplyChain,
@@ -91,6 +94,19 @@ export function createTelegramMessageContextRuntime({
       ...(botUserId !== undefined ? { botUserId } : {}),
       ...(threadId != null ? { providerObservedThreadId: threadId } : {}),
       ...(threadId != null ? { threadId } : {}),
+    });
+
+  const recordMessageResolvedMedia = (params: {
+    msg: Message;
+    media: TelegramResolvedMedia;
+    botUserId?: number;
+  }) =>
+    messageCache.recordResolvedMedia({
+      accountId,
+      chatId: params.msg.chat.id,
+      messageId: String(params.msg.message_id),
+      media: params.media,
+      ...(params.botUserId !== undefined ? { botUserId: params.botUserId } : {}),
     });
 
   // `MessageReactionUpdated` carries no `message_thread_id`, so the reaction handler
@@ -272,6 +288,7 @@ export function createTelegramMessageContextRuntime({
 
   return {
     recordMessageForReplyChain,
+    recordMessageResolvedMedia,
     resolveCachedMessageThreadId,
     buildReplyChainForMessage,
     toReplyChainEntry,

--- a/extensions/telegram/src/bot-handlers.message-context.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-context.runtime.ts
@@ -135,6 +135,7 @@ export function createTelegramMessageContextRuntime({
   ): TelegramReplyChainEntry => {
     const {
       sourceMessage: _sourceMessage,
+      resolvedMedia: _resolvedMedia,
       promptContextProjectionMarker: _promptContextProjectionMarker,
       threadBinding: _threadBinding,
       ...entry

--- a/extensions/telegram/src/bot-handlers.message.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message.runtime.ts
@@ -30,9 +30,40 @@ import { resolveMedia } from "./bot/delivery.resolve-media.js";
 import { resolveTelegramMessageThreadSpec } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import { resolveTelegramScopedGroupConfig } from "./group-config-helpers.js";
+import type { TelegramResolvedMedia } from "./message-cache-persistence.js";
 import type { TelegramCachedMessageNode, TelegramReplyChainEntry } from "./message-cache.js";
 import type { TelegramMessageDispatchReplayClaim } from "./message-dispatch-dedupe.js";
-import { resolveTelegramPromptMediaPath } from "./prompt-media-path.js";
+import {
+  resolveTelegramInboundMediaUri,
+  resolveTelegramPromptMediaPath,
+} from "./prompt-media-path.js";
+
+const HOUR_MS = 60 * 60_000;
+
+function resolveRetainedTelegramMedia(params: {
+  media?: TelegramResolvedMedia;
+  maxBytes: number;
+  ttlHours?: number;
+}): TelegramMediaRef | undefined {
+  const media = params.media;
+  if (!media || media.size > params.maxBytes) {
+    return undefined;
+  }
+  // The gateway's configured retention sweep owns file expiry. Mirror that
+  // deadline here so reply hydration never polls the filesystem for freshness.
+  if (params.ttlHours !== undefined && media.savedAt + params.ttlHours * HOUR_MS <= Date.now()) {
+    return undefined;
+  }
+  const path = resolveTelegramInboundMediaUri(media.id);
+  return path
+    ? {
+        path,
+        kind: media.kind,
+        ...(media.contentType ? { contentType: media.contentType } : {}),
+        ...(media.stickerMetadata ? { stickerMetadata: media.stickerMetadata } : {}),
+      }
+    : undefined;
+}
 
 export function createTelegramHandlerMessageRuntime({
   cfg,
@@ -77,6 +108,7 @@ export function createTelegramHandlerMessageRuntime({
   const { resolveTelegramSessionState, resolvePromptContextAmbientWatermark } = sessionRuntime;
   const {
     recordMessageForReplyChain,
+    recordMessageResolvedMedia,
     resolveCachedMessageThreadId,
     buildReplyChainForMessage,
     toReplyChainEntry,
@@ -126,23 +158,36 @@ export function createTelegramHandlerMessageRuntime({
         (await shouldHydrateMedia(node, index))
       ) {
         try {
-          const media = await resolveMedia({
-            ctx: {
-              message: node.sourceMessage,
-              me: ctx.me,
-              getFile: async (signal) => await bot.api.getFile(replyFileId, signal),
-            },
+          mediaRuntime.abortSignal?.throwIfAborted();
+          mediaRef = resolveRetainedTelegramMedia({
+            media: node.resolvedMedia,
             maxBytes: mediaMaxBytes,
-            ...mediaRuntime,
+            ttlHours: cfg.attachments?.ttlHours,
           });
-          mediaRef = media
-            ? {
+          if (!mediaRef) {
+            const media = await resolveMedia({
+              ctx: {
+                message: node.sourceMessage,
+                me: ctx.me,
+                getFile: async (signal) => await bot.api.getFile(replyFileId, signal),
+              },
+              maxBytes: mediaMaxBytes,
+              ...mediaRuntime,
+            });
+            if (media) {
+              await recordMessageResolvedMedia({
+                msg: node.sourceMessage,
+                media,
+                botUserId: ctx.me?.id,
+              });
+              mediaRef = {
                 path: media.path,
                 kind: media.kind,
                 ...(media.contentType ? { contentType: media.contentType } : {}),
                 ...(media.stickerMetadata ? { stickerMetadata: media.stickerMetadata } : {}),
-              }
-            : undefined;
+              };
+            }
+          }
         } catch (err) {
           // Only durable ingress can replay a reply-media abort. Live polling must
           // preserve the current text instead of acknowledging it without dispatch.
@@ -430,6 +475,7 @@ export function createTelegramHandlerMessageRuntime({
     resolveTelegramSessionState,
     resolvePromptContextAmbientWatermark,
     recordMessageForReplyChain,
+    recordMessageResolvedMedia,
     resolveCachedMessageThreadId,
     processMessageWithReplyChain,
   };

--- a/extensions/telegram/src/bot-handlers.message.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message.runtime.ts
@@ -109,6 +109,7 @@ export function createTelegramHandlerMessageRuntime({
   const {
     recordMessageForReplyChain,
     recordMessageResolvedMedia,
+    recordReplyMessageResolvedMedia,
     resolveCachedMessageThreadId,
     buildReplyChainForMessage,
     toReplyChainEntry,
@@ -175,17 +176,18 @@ export function createTelegramHandlerMessageRuntime({
               ...mediaRuntime,
             });
             if (media) {
-              await recordMessageResolvedMedia({
-                msg: node.sourceMessage,
-                media,
-                botUserId: ctx.me?.id,
-              });
               mediaRef = {
                 path: media.path,
                 kind: media.kind,
                 ...(media.contentType ? { contentType: media.contentType } : {}),
                 ...(media.stickerMetadata ? { stickerMetadata: media.stickerMetadata } : {}),
               };
+              await recordReplyMessageResolvedMedia({
+                chatId: ctx.message.chat.id,
+                messageId: node.messageId,
+                media,
+                botUserId: ctx.me?.id,
+              });
             }
           }
         } catch (err) {

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -5066,6 +5066,59 @@ describe("createTelegramBot", () => {
     expect((payload as Record<string, unknown>).ReplyToIsExternal).toBe(true);
   });
 
+  it("keeps fetched media for uncached external replies", async () => {
+    const mediaFetch = vi.fn(
+      async () =>
+        new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+    );
+    const ssrfMock = mockPinnedHostnameResolution();
+
+    try {
+      createTelegramBot({
+        token: "tok",
+        telegramTransport: makeTelegramTransport(mediaFetch as typeof fetch),
+      });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+      await handler({
+        message: {
+          chat: { id: 7, type: "private" },
+          text: "What is in this image?",
+          date: 1736380800,
+          external_reply: {
+            origin: {
+              type: "user",
+              sender_user: { id: 22, is_bot: false, first_name: "Ada" },
+              date: 1736380700,
+            },
+            chat: { id: -10022, type: "supergroup", title: "Source" },
+            message_id: 9003,
+            photo: [{ file_id: "external-photo-1" }],
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: getEmptyTelegramFile,
+      });
+    } finally {
+      ssrfMock.mockRestore();
+    }
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = mockMsgContextArg(
+      replySpy as unknown as MockCallSource,
+      0,
+      0,
+      "replySpy call",
+    ) as { ReplyChain?: Array<{ messageId?: string; mediaPath?: string }> };
+    expect(payload.ReplyChain?.[0]).toMatchObject({ messageId: "9003" });
+    expect(payload.ReplyChain?.[0]?.mediaPath).toBeTypeOf("string");
+    expect(getFileSpy).toHaveBeenCalledWith("external-photo-1", expect.any(AbortSignal));
+    expect(mediaFetch).toHaveBeenCalledTimes(1);
+  });
+
   it("propagates forwarded origin from external_reply targets", async () => {
     onSpy.mockReset();
     sendMessageSpy.mockReset();

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -4394,6 +4394,7 @@ describe("createTelegramBot", () => {
     expect(payload.ReplyChain?.[1]?.mediaPath).toBeTypeOf("string");
     expect(payload.ReplyChain?.[1]?.mediaPath).toMatch(/^media:\/\/inbound\//);
     expect(payload.ReplyChain?.[1]?.mediaRef).toBeUndefined();
+    expect(payload.ReplyChain?.[1]).not.toHaveProperty("resolvedMedia");
     const [conversationContext] = requireArray(
       payload.ChannelStructuredContext,
       "structured context",

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -4300,7 +4300,7 @@ describe("createTelegramBot", () => {
     expect(replySpy).not.toHaveBeenCalled();
   });
 
-  it("hydrates reply chains from cached Telegram messages", async () => {
+  it("reuses resolved media when hydrating cached Telegram reply chains", async () => {
     const mediaFetch = vi.fn(
       async () =>
         new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
@@ -4323,7 +4323,7 @@ describe("createTelegramBot", () => {
           message_id: 9000,
           date: 1736380700,
           from: { id: 1, first_name: "Kesava" },
-          photo: [{ file_id: "root-photo-1" }],
+          photo: [{ file_id: "root-photo-1", file_unique_id: "root-photo-unique-1" }],
         },
         me: { username: "openclaw_bot" },
         getFile: async () => ({ file_path: "media/root.jpg" }),
@@ -4338,7 +4338,7 @@ describe("createTelegramBot", () => {
           from: { id: 2, first_name: "Ada" },
           reply_to_message: {
             message_id: 9000,
-            photo: [{ file_id: "root-photo-1" }],
+            photo: [{ file_id: "root-photo-1", file_unique_id: "root-photo-unique-1" }],
             from: { id: 1, first_name: "Kesava" },
           },
         },
@@ -4392,7 +4392,7 @@ describe("createTelegramBot", () => {
     expect(payload.ReplyChain?.[0]?.replyToId).toBe("9000");
     expect(payload.ReplyChain?.[1]?.messageId).toBe("9000");
     expect(payload.ReplyChain?.[1]?.mediaPath).toBeTypeOf("string");
-    expect(payload.ReplyChain?.[1]?.mediaPath).toContain("/media/inbound/");
+    expect(payload.ReplyChain?.[1]?.mediaPath).toMatch(/^media:\/\/inbound\//);
     expect(payload.ReplyChain?.[1]?.mediaRef).toBeUndefined();
     const [conversationContext] = requireArray(
       payload.ChannelStructuredContext,
@@ -4408,10 +4408,10 @@ describe("createTelegramBot", () => {
       sender: "Kesava",
     });
     expect(messagesById.get("9000")?.media_path).toMatch(/^media:\/\/inbound\//);
-    expect(messagesById.get("9000")?.media_path).not.toBe(payload.ReplyChain?.[1]?.mediaPath);
+    expect(messagesById.get("9000")?.media_path).toBe(payload.ReplyChain?.[1]?.mediaPath);
     expect(messagesById.get("9000")?.media_ref).toBeUndefined();
-    expect(getFileSpy).toHaveBeenCalledWith("root-photo-1", expect.any(AbortSignal));
-    expect(mediaFetch).toHaveBeenCalledTimes(1);
+    expect(getFileSpy).not.toHaveBeenCalled();
+    expect(mediaFetch).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -4470,6 +4470,9 @@ describe("createTelegramBot", () => {
         },
       });
 
+      expect(getFileSpy).toHaveBeenCalledWith("generated-photo-1", expect.any(AbortSignal));
+      expect(mediaFetch).toHaveBeenCalledTimes(1);
+
       replySpy.mockClear();
       getFileSpy.mockClear();
       mediaFetch.mockClear();
@@ -4518,7 +4521,7 @@ describe("createTelegramBot", () => {
     });
     if (expectHydrated) {
       expect(payload.ReplyChain?.[1]?.mediaPath).toBeTypeOf("string");
-      expect(payload.ReplyChain?.[1]?.mediaPath).toContain("/media/inbound/");
+      expect(payload.ReplyChain?.[1]?.mediaPath).toMatch(/^media:\/\/inbound\//);
       expect(payload.ReplyChain?.[1]?.mediaRef).toBeUndefined();
     } else {
       expect(payload.ReplyChain?.[1]?.mediaPath).toBeUndefined();
@@ -4552,13 +4555,8 @@ describe("createTelegramBot", () => {
       reply_to_id: "101",
       is_reply_target: true,
     });
-    if (expectHydrated) {
-      expect(getFileSpy).toHaveBeenCalledWith("generated-photo-1", expect.any(AbortSignal));
-      expect(mediaFetch).toHaveBeenCalledTimes(1);
-    } else {
-      expect(getFileSpy).not.toHaveBeenCalled();
-      expect(mediaFetch).not.toHaveBeenCalled();
-    }
+    expect(getFileSpy).not.toHaveBeenCalled();
+    expect(mediaFetch).not.toHaveBeenCalled();
   });
 
   it("does not hydrate reply media denied by General forum topic visibility", async () => {

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -4,6 +4,7 @@ import { GrammyError } from "grammy";
 import { root as fsRoot } from "openclaw/plugin-sdk/file-access-runtime";
 import { TelegramBotApiFileTooLargeError } from "../bot-handlers.media.js";
 import type { TelegramTransport } from "../fetch.js";
+import type { TelegramResolvedMedia } from "../message-cache-persistence.js";
 import { isRetryableTelegramApiError, readTelegramRetryAfterMs } from "../network-errors.js";
 import { cacheSticker, getCachedSticker } from "../sticker-cache.js";
 import {
@@ -16,8 +17,8 @@ import {
   shouldRetryTelegramTransportFallback,
   sleepWithAbort,
 } from "./delivery.resolve-media.runtime.js";
-import { resolveTelegramPrimaryMedia, type TelegramMediaKind } from "./helpers.js";
-import type { StickerMetadata, TelegramContext } from "./types.js";
+import { resolveTelegramPrimaryMedia } from "./helpers.js";
+import type { TelegramContext } from "./types.js";
 
 const FILE_TOO_BIG_RE = /file is too big/i;
 const TELEGRAM_GET_FILE_RETRY_DEADLINE_MS = 20 * 60_000;
@@ -375,16 +376,7 @@ async function resolveStickerMedia(params: {
   trustedLocalFileRoots?: readonly string[];
   dangerouslyAllowPrivateNetwork?: boolean;
   abortSignal?: AbortSignal;
-}): Promise<
-  | {
-      path: string;
-      contentType?: string;
-      kind: TelegramMediaKind;
-      stickerMetadata?: StickerMetadata;
-    }
-  | null
-  | undefined
-> {
+}): Promise<(TelegramResolvedMedia & { path: string }) | null | undefined> {
   const { msg, ctx, maxBytes, token, transport, abortSignal } = params;
   if (!msg.sticker) {
     return undefined;
@@ -431,9 +423,13 @@ async function resolveStickerMedia(params: {
       });
     }
     return {
+      id: saved.id,
       path: saved.path,
+      size: saved.size,
       contentType: saved.contentType,
       kind: "sticker",
+      fileUniqueId: sticker.file_unique_id,
+      savedAt: Date.now(),
       stickerMetadata: {
         emoji,
         setName,
@@ -446,9 +442,13 @@ async function resolveStickerMedia(params: {
 
   // Cache miss - return metadata for vision processing
   return {
+    id: saved.id,
     path: saved.path,
+    size: saved.size,
     contentType: saved.contentType,
     kind: "sticker",
+    fileUniqueId: sticker.file_unique_id,
+    savedAt: Date.now(),
     stickerMetadata: {
       emoji: sticker.emoji ?? undefined,
       setName: sticker.set_name ?? undefined,
@@ -467,12 +467,7 @@ export async function resolveMedia(params: {
   trustedLocalFileRoots?: readonly string[];
   dangerouslyAllowPrivateNetwork?: boolean;
   abortSignal?: AbortSignal;
-}): Promise<{
-  path: string;
-  contentType?: string;
-  kind: TelegramMediaKind;
-  stickerMetadata?: StickerMetadata;
-} | null> {
+}): Promise<(TelegramResolvedMedia & { path: string }) | null> {
   const {
     ctx,
     maxBytes,
@@ -528,5 +523,13 @@ export async function resolveMedia(params: {
       : saved.contentType?.startsWith("audio/")
         ? "audio"
         : nativeKind;
-  return { path: saved.path, contentType: saved.contentType, kind };
+  return {
+    id: saved.id,
+    path: saved.path,
+    size: saved.size,
+    contentType: saved.contentType,
+    kind,
+    fileUniqueId: m.file_unique_id,
+    savedAt: Date.now(),
+  };
 }

--- a/extensions/telegram/src/message-cache-persistence.ts
+++ b/extensions/telegram/src/message-cache-persistence.ts
@@ -2,6 +2,8 @@
 import { createHash } from "node:crypto";
 import type { Message } from "grammy/types";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { TelegramMediaKind } from "./bot/body-helpers.js";
+import type { StickerMetadata } from "./bot/types.js";
 import type {
   TelegramPromptContextProjection,
   TelegramPromptContextSource,
@@ -18,14 +20,77 @@ export type TelegramMessageThreadBinding = {
   threadId: string;
 };
 
+export type TelegramResolvedMedia = {
+  id: string;
+  fileUniqueId: string;
+  size: number;
+  savedAt: number;
+  kind: TelegramMediaKind;
+  contentType?: string;
+  stickerMetadata?: StickerMetadata;
+};
+
 export type PersistedTelegramMessageCacheValue = {
   version: typeof TELEGRAM_MESSAGE_CACHE_PERSISTED_VERSION;
   sourceMessage: Message;
   botUserId?: number;
   promptContextProjection?: TelegramPromptContextProjection | TelegramPromptContextSource;
+  resolvedMedia?: TelegramResolvedMedia;
   threadBinding?: TelegramMessageThreadBinding;
   threadId?: string;
 };
+
+const TELEGRAM_MEDIA_KINDS = new Set<string>(["audio", "document", "image", "sticker", "video"]);
+
+function isTelegramMediaKind(value: unknown): value is TelegramMediaKind {
+  return typeof value === "string" && TELEGRAM_MEDIA_KINDS.has(value);
+}
+
+function parseStickerMetadata(value: unknown): StickerMetadata | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  return {
+    ...(typeof value.emoji === "string" ? { emoji: value.emoji } : {}),
+    ...(typeof value.setName === "string" ? { setName: value.setName } : {}),
+    ...(typeof value.fileId === "string" ? { fileId: value.fileId } : {}),
+    ...(typeof value.fileUniqueId === "string" ? { fileUniqueId: value.fileUniqueId } : {}),
+    ...(typeof value.cachedDescription === "string"
+      ? { cachedDescription: value.cachedDescription }
+      : {}),
+  };
+}
+
+export function parseTelegramResolvedMedia(value: unknown): TelegramResolvedMedia | undefined {
+  if (
+    !isRecord(value) ||
+    typeof value.id !== "string" ||
+    !value.id ||
+    value.id.includes("/") ||
+    value.id.includes("\\") ||
+    value.id.includes("\0") ||
+    typeof value.fileUniqueId !== "string" ||
+    !value.fileUniqueId ||
+    typeof value.size !== "number" ||
+    !Number.isFinite(value.size) ||
+    value.size < 0 ||
+    typeof value.savedAt !== "number" ||
+    !Number.isFinite(value.savedAt) ||
+    !isTelegramMediaKind(value.kind)
+  ) {
+    return undefined;
+  }
+  const stickerMetadata = parseStickerMetadata(value.stickerMetadata);
+  return {
+    id: value.id,
+    fileUniqueId: value.fileUniqueId,
+    size: value.size,
+    savedAt: value.savedAt,
+    kind: value.kind,
+    ...(typeof value.contentType === "string" ? { contentType: value.contentType } : {}),
+    ...(stickerMetadata ? { stickerMetadata } : {}),
+  };
+}
 
 export function resolveTelegramMessageCachePath(storePath: string): string {
   return `${storePath}.telegram-messages.json`;

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   resolveTelegramMessageCachePersistentScopeKey,
   TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
+  type TelegramResolvedMedia,
 } from "./message-cache-persistence.js";
 import {
   buildTelegramConversationContext,
@@ -23,6 +24,7 @@ type PersistedValue = {
   sourceMessage: Message;
   botUserId?: number;
   promptContextProjection?: unknown;
+  resolvedMedia?: TelegramResolvedMedia;
   threadBinding?: { kind: "provider-observed-v1"; threadId: string };
   threadId?: string;
 };
@@ -141,6 +143,37 @@ const projection = (transcriptMessageId: string) => ({
 });
 
 describe("telegram message cache", () => {
+  it("persists resolved media with its source message and drops it when the media changes", async () => {
+    const { bucketKey, entries, store } = createMemoryStore();
+    const cache = cacheFor(bucketKey, store);
+    await record(cache, message(9000, "Kesava", { photo: photo("photo-1") }));
+    await cache.recordResolvedMedia({
+      accountId: "default",
+      chatId: 7,
+      messageId: "9000",
+      media: {
+        id: "saved-photo.png",
+        fileUniqueId: "photo-1-unique",
+        size: 4,
+        savedAt: 1_736_380_700_000,
+        kind: "image",
+        contentType: "image/png",
+      },
+    });
+
+    expect(onlyEntry(entries)[1].resolvedMedia?.id).toBe("saved-photo.png");
+    const reloaded = await reloadGet(bucketKey, store, "9000");
+    expect(reloaded?.resolvedMedia).toMatchObject({
+      id: "saved-photo.png",
+      fileUniqueId: "photo-1-unique",
+      kind: "image",
+    });
+
+    const reloadedCache = cacheFor(bucketKey, store);
+    await record(reloadedCache, message(9000, "Kesava", { photo: photo("photo-2") }));
+    expect((await get(reloadedCache, "9000"))?.resolvedMedia).toBeUndefined();
+  });
+
   it("persists provider-observed topic bindings for messages and same-topic replies", async () => {
     const { bucketKey, entries, store } = createMemoryStore();
     const forum = { id: -1001, type: "supergroup", title: "QA", is_forum: true };

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -18,7 +18,9 @@ import {
 } from "./bot/helpers.js";
 import {
   isTelegramMessageCacheSourceMessage,
+  parseTelegramResolvedMedia,
   type PersistedTelegramMessageCacheValue,
+  type TelegramResolvedMedia,
   resolveTelegramMessageCachePersistentScopeKey,
   TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
   TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE,
@@ -39,6 +41,7 @@ export type TelegramReplyChainEntry = NonNullable<MsgContext["ReplyChain"]>[numb
 
 export type TelegramCachedMessageNode = Omit<TelegramReplyChainEntry, "messageId"> & {
   messageId: string;
+  resolvedMedia?: TelegramResolvedMedia;
   sourceMessage: Message;
   promptContextProjectionMarker?: TelegramPromptContextProjectionMarker;
   threadBinding?: TelegramMessageThreadBinding;
@@ -60,6 +63,13 @@ type TelegramMessageCache = {
     providerObservedThreadId?: number;
     threadId?: number;
   }) => Promise<TelegramCachedMessageNode>;
+  recordResolvedMedia: (params: {
+    accountId: string;
+    botUserId?: number;
+    chatId: string | number;
+    messageId: string;
+    media: TelegramResolvedMedia;
+  }) => Promise<void>;
   get: (params: {
     accountId: string;
     chatId: string | number;
@@ -195,6 +205,7 @@ function normalizeMessageNode(
   params: {
     threadId?: number;
     promptContextProjectionMarker?: TelegramPromptContextProjectionMarker;
+    resolvedMedia?: TelegramResolvedMedia;
     threadBinding?: TelegramMessageThreadBinding;
   },
 ): TelegramCachedMessageNode {
@@ -225,6 +236,7 @@ function normalizeMessageNode(
     ...(params.promptContextProjectionMarker
       ? { promptContextProjectionMarker: params.promptContextProjectionMarker }
       : {}),
+    ...(params.resolvedMedia ? { resolvedMedia: params.resolvedMedia } : {}),
     ...(threadBinding ? { threadBinding } : {}),
   };
 }
@@ -272,6 +284,7 @@ function normalizeMessageNodes(
   params: {
     threadId?: number;
     promptContextProjectionMarker?: TelegramPromptContextProjectionMarker;
+    resolvedMedia?: TelegramResolvedMedia;
     threadBinding?: TelegramMessageThreadBinding;
   },
 ): TelegramCachedMessageObservation[] {
@@ -285,6 +298,7 @@ function normalizeMessageNodes(
     mode: TelegramMessageObservationMode,
     promptContextProjectionMarker?: TelegramPromptContextProjectionMarker,
     threadBinding?: TelegramMessageThreadBinding,
+    resolvedMedia?: TelegramResolvedMedia,
   ) => {
     const embeddedThreadId = parseTelegramMessageThreadId(
       (message as { message_thread_id?: unknown }).message_thread_id,
@@ -296,6 +310,7 @@ function normalizeMessageNodes(
           ? (inheritedThread ?? embeddedThreadId)
           : (embeddedThreadId ?? inheritedThread),
       ...(promptContextProjectionMarker ? { promptContextProjectionMarker } : {}),
+      ...(resolvedMedia ? { resolvedMedia } : {}),
       ...(threadBinding ? { threadBinding } : {}),
     });
     if (visited.has(node.messageId)) {
@@ -310,6 +325,7 @@ function normalizeMessageNodes(
         "partial",
         undefined,
         node.threadBinding,
+        undefined,
       );
     }
     observations.push({ node, mode });
@@ -320,6 +336,7 @@ function normalizeMessageNodes(
     "authoritative",
     params.promptContextProjectionMarker,
     params.threadBinding,
+    params.resolvedMedia,
   );
   return observations;
 }
@@ -350,10 +367,12 @@ function parsePersistedCacheValue(key: string, value: unknown) {
     value.version === TELEGRAM_MESSAGE_CACHE_PERSISTED_VERSION
       ? normalizeTelegramMessageThreadBinding(value.threadBinding, threadId)
       : undefined;
+  const resolvedMedia = parseTelegramResolvedMedia(value.resolvedMedia);
   return normalizeMessageNodes(value.sourceMessage, {
     ...(threadId !== undefined ? { threadId } : {}),
     ...(promptContextProjectionMarker ? { promptContextProjectionMarker } : {}),
     ...(threadBinding ? { threadBinding } : {}),
+    ...(resolvedMedia ? { resolvedMedia } : {}),
   }).map(({ node, mode }) => ({
     key: `${key.slice(0, separatorIndex + 1)}${node.messageId}`,
     node,
@@ -422,10 +441,16 @@ function mergeCachedMessageNode(
   const threadBinding =
     normalizeTelegramMessageThreadBinding(incoming.threadBinding, threadId) ??
     normalizeTelegramMessageThreadBinding(existing.threadBinding, threadId);
+  const primaryMedia = resolveTelegramPrimaryMedia(sourceMessage);
+  const resolvedMedia =
+    existing.resolvedMedia?.fileUniqueId === primaryMedia?.fileRef.file_unique_id
+      ? existing.resolvedMedia
+      : undefined;
   return normalizeMessageNode(sourceMessage, {
     ...(threadId !== undefined ? { threadId } : {}),
     ...(promptContextProjectionMarker ? { promptContextProjectionMarker } : {}),
     ...(threadBinding ? { threadBinding } : {}),
+    ...(resolvedMedia ? { resolvedMedia } : {}),
   });
 }
 
@@ -548,6 +573,7 @@ async function persistCachedNode(params: {
       sourceMessage: params.node.sourceMessage,
       ...(params.botUserId !== undefined ? { botUserId: params.botUserId } : {}),
       ...(promptContextProjection ? { promptContextProjection } : {}),
+      ...(params.node.resolvedMedia ? { resolvedMedia: params.node.resolvedMedia } : {}),
       ...(params.node.threadBinding ? { threadBinding: params.node.threadBinding } : {}),
       ...(params.node.threadId ? { threadId: params.node.threadId } : {}),
     });
@@ -668,6 +694,27 @@ export function createTelegramMessageCache(params?: {
         });
       }
       return recordedEntry;
+    },
+    recordResolvedMedia: async ({ accountId, botUserId, chatId, messageId, media }) => {
+      await hydrateMessageCacheBucket(bucket, maxMessages, scopeKey);
+      const key = telegramMessageCacheKey({ scopeKey, accountId, chatId, messageId });
+      const node = messages.get(key);
+      if (!node) {
+        throw new Error(`Telegram message ${messageId} was not recorded before media resolution`);
+      }
+      const fileUniqueId = resolveTelegramPrimaryMedia(node.sourceMessage)?.fileRef.file_unique_id;
+      if (fileUniqueId !== media.fileUniqueId) {
+        throw new Error(`Telegram message ${messageId} media changed during resolution`);
+      }
+      const resolvedNode = { ...node, resolvedMedia: media };
+      messages.delete(key);
+      messages.set(key, resolvedNode);
+      await persistCachedNode({
+        bucket,
+        key,
+        node: resolvedNode,
+        ...(botUserId !== undefined ? { botUserId } : {}),
+      });
     },
     get,
     recentBefore: async ({ accountId, chatId, messageId, threadId, limit }) => {

--- a/extensions/telegram/src/prompt-media-path.ts
+++ b/extensions/telegram/src/prompt-media-path.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-function toInboundMediaPath(id: string): string | undefined {
+export function resolveTelegramInboundMediaUri(id: string): string | undefined {
   if (
     !id ||
     id === "." ||
@@ -26,11 +26,11 @@ export function resolveTelegramPromptMediaPath(mediaPath: string): string | unde
   const canonicalMatch = /^media:\/\/inbound\/([^/\\]+)$/i.exec(mediaPath);
   if (canonicalMatch?.[1]) {
     const id = decodeInboundMediaId(canonicalMatch[1]);
-    return id ? toInboundMediaPath(id) : undefined;
+    return id ? resolveTelegramInboundMediaUri(id) : undefined;
   }
   const normalized = mediaPath.replace(/\\/g, "/");
   if (!normalized.includes("/media/inbound/")) {
     return undefined;
   }
-  return toInboundMediaPath(path.posix.basename(normalized));
+  return resolveTelegramInboundMediaUri(path.posix.basename(normalized));
 }


### PR DESCRIPTION
Related: #120425

## What Problem This Solves

Fixes an issue where Telegram users replying to the same photo repeatedly caused OpenClaw to call `getFile` and download the photo again for every turn. Those redundant transfers could delay the answer long enough to show a misleading no-reply placeholder before the real response arrived.

## Why This Change Was Made

The observed Telegram message now owns the authoritative reference to media already saved in OpenClaw's inbound media store. Initial inbound resolution records that fact; quoted-reply hydration reuses it while it remains inside the existing size and retention contracts. If the artifact was reclaimed, the canonical Telegram fetch path restores it and refreshes the same message node.

This keeps one message-cache lifecycle instead of adding a second cache, namespace, TTL, timer, or config surface. Restart persistence comes from the existing Telegram message cache. Stickers retain their media semantics and metadata. Telegram `external_reply` snapshots remain uncached: fetched media stays available to the active turn without being written under the current chat.

Product contract: a user can quote an already observed photo and receive a normal answer without paying another Telegram transfer for the same stored bytes. Reclaimed media still resolves through the existing fetch path. No config, schema, or default changes.

Production LOC: +246/-35 (net +211) | Tests: +100/-15 (net +85). The production growth records the missing owner-boundary fact, validates it once at persistence, and carries it through the existing inbound, album, edit, restart, quote-refresh, and uncached external-reply paths.

## User Impact

Repeated replies to the same Telegram photo reuse the saved attachment across turns and gateway restarts. This removes repeated Telegram downloads and the associated reply latency. The first observation still saves the file once; retention and size limits remain unchanged.

## Evidence

- Focused Telegram/message-cache suites: 160/160 passed on final branch code.
- Relevant exact-branch static lanes passed on Blacksmith Testbox: extension Oxlint, production tsgo, and extension-test tsgo (Actions run 31333120282). The full changed classifier stopped earlier on the unchanged `origin/main` `ui/package.json` range for `@novnc/novnc`; this branch has no UI diff.
- Exact-branch Autoreview: no findings; correctness confidence 0.93; secret scan clean.
- Redacted local real-user Telegram proof on the final code tree (rebased head `4983aad25d0`): a native quote to an existing photo refreshed one retention-expired 4,698-byte inbound artifact and delivered `FINAL_HEAD_QUOTE_OK`. An immediate second native quote to the same photo delivered the same result without creating or changing another artifact. Both turns supplied one JPEG to image understanding. Provider requests contained no `resolvedMedia`, `savedAt`, `fileUniqueId`, or `stickerMetadata` cache fields.
- External-reply fallback boundary: the TDLib user driver can create native replies but cannot synthesize Telegram Bot API `external_reply` updates. The focused transport regression therefore supplies a contract-valid external reply with `origin`, optional source `chat`, and photo; it proves the fetched image remains on the active reply chain while the absent current-chat cache record is not persisted.
- Live-proof boundary: the deterministic seed photo was sent outbound by the candidate gateway, so the live run proves fallback refresh followed by reuse. The focused regression proves the initial-inbound path records the media fact before the first quoted reply; outbound delivery does not traverse that producer.

Co-authored-by: Ayaan Gazali <ayaangazali.work@gmail.com>
