### PR TITLE
fix(ci): prevent scheduled work from skewing performance probes

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -826,10 +826,7 @@ jobs:
             },
             "plugins": {
               "enabled": true,
-              "entries": {
-                "browser": { "enabled": false },
-                "memory-core": { "config": { "dreaming": { "enabled": false } } }
-              }
+              "entries": { "browser": { "enabled": false } }
             }
           }
           EOF
@@ -843,7 +840,7 @@ jobs:
             rm -rf "$gateway_home" "$gateway_readiness_home"
           }
           trap cleanup_gateway EXIT
-          OPENCLAW_HOME="$gateway_home" OPENCLAW_STATE_DIR="$gateway_state" OPENCLAW_CONFIG_PATH="$gateway_config" OPENCLAW_GATEWAY_PORT="$gateway_port" OPENCLAW_SKIP_CHANNELS=1 \
+          OPENCLAW_HOME="$gateway_home" OPENCLAW_STATE_DIR="$gateway_state" OPENCLAW_CONFIG_PATH="$gateway_config" OPENCLAW_GATEWAY_PORT="$gateway_port" OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_SKIP_CRON=1 \
             node dist/entry.js gateway run --bind loopback --port "$gateway_port" --auth none --allow-unconfigured --force \
             >"$gateway_log" 2>&1 &
           gateway_pid="$!"

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -47,6 +47,7 @@ type WorkflowJob = {
 };
 
 type Workflow = {
+  env?: Record<string, string>;
   jobs?: Record<string, WorkflowJob>;
 };
 
@@ -404,22 +405,23 @@ describe("OpenClaw performance workflow", () => {
     expect(run).toContain("--case gatewayHealthJsonFirstDevice \\");
   });
 
-  it("keeps the source performance gateway fixture network-hermetic", () => {
-    const run = findStep("Run OpenClaw source performance probes", "source_performance").run ?? "";
+  it("isolates the source performance gateway from network and scheduled work", () => {
+    const step = findStep("Run OpenClaw source performance probes", "source_performance");
+    const run = step.run ?? "";
 
     expect(run).toContain("catalog_refresh_config");
     expect(run).toContain("rg -q 'catalogRefresh:' src/config/zod-schema.core.ts");
     expect(run).toContain(
       'catalog_refresh_config=\'    "models": { "catalogRefresh": { "enabled": false } },\'',
     );
-    expect(run).toContain('"agents": { "defaults": { "heartbeat": { "every": "0m" } } },');
     expect(run).toContain('"update": { "checkOnStart": false },');
-    expect(run).toContain('"browser": { "enabled": false },');
-    expect(run).toContain('"memory-core": { "config": { "dreaming": { "enabled": false } } }');
-    expect(run).toContain('cp "$gateway_config" "$gateway_readiness_config"');
-    expect(run.indexOf('"agents":')).toBeLessThan(
-      run.indexOf('cp "$gateway_config" "$gateway_readiness_config"'),
+    expect(run).toContain('"agents": { "defaults": { "heartbeat": { "every": "0m" } } },');
+    expect(run).toContain(
+      'OPENCLAW_GATEWAY_PORT="$gateway_port" OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_SKIP_CRON=1 \\',
     );
+    expect(readWorkflow().env?.OPENCLAW_SKIP_CRON).toBeUndefined();
+    expect(readWorkflow().jobs?.source_performance?.env?.OPENCLAW_SKIP_CRON).toBeUndefined();
+    expect(step.env?.OPENCLAW_SKIP_CRON).toBeUndefined();
   });
 
   it("isolates required publication in a fresh artifact-consuming job", () => {


### PR DESCRIPTION
Related: #120620

## What Problem This Solves

Resolves an issue where the source-performance gateway's first strict connected-health sample could time out when fixture-local scheduled work began immediately after gateway readiness. Later samples recovered, but the overlapping work made the first result unreliable.

## Why This Change Was Made

The landed initial repair in #120620 correctly disabled the fixture heartbeat, but it also disabled Memory Core dreaming even though the artifact shows dreaming was not the 15:31 trigger. This focused follow-up keeps `agents.defaults.heartbeat.every = "0m"`, removes that unrelated dreaming override, and sets `OPENCLAW_SKIP_CRON=1` only on the direct source-performance gateway child beside `OPENCLAW_SKIP_CHANNELS=1`. The existing 120-second shared health deadline, probe caps, retry pacing, benchmark behavior, frozen install inputs, and production runtime are unchanged.

The artifact timeline identifies the cause:

- gateway ready: 15:31:39.138Z
- default heartbeat: 15:31:40.045Z
- first connected-health completion: 15:31:42.907Z
- strict sample timeout: 15:31:54.336Z
- overlapping embedded turn: 33.2 seconds
- later connected-health samples recovered

Memory dreaming was only registered at 15:31:41.955Z and did not execute, so preserving its suppression would encode the wrong rationale. Disabling cron on this one child also removes the same class of fixture-local scheduled work without leaking the control into the workflow, job, step, preceding probes, or later benchmark processes.

## User Impact

No shipped product or production runtime behavior changes. Maintainers get a more deterministic source-performance fixture while normal heartbeat, cron, Memory Core dreaming, CLI startup behavior, lockfiles, release metadata, and version surfaces remain unchanged.

## Evidence

- Source artifact: https://github.com/openclaw/openclaw/actions/runs/31264355829/artifacts/9023790487
- `node scripts/run-vitest.mjs test/scripts/openclaw-performance-workflow.test.ts test/scripts/bench-cli-startup.test.ts test/scripts/cli-startup-bench-spawner.test.ts` — 3 files passed, 65 tests passed
- `node scripts/check-workflows.mjs` — passed zizmor and composite-action interpolation checks
- `git diff --check` — passed
- Codex-backed autoreview — clean, no accepted/actionable findings
- Exact head: `495deecfa483bc6a01a233a6dd3512c0e041e80c`
- LOC: workflow +2/-5; workflow test +10/-8; total +12/-13; production runtime +0/-0

Known proof gaps at draft creation: exact-head pull-request CI and the hosted Blacksmith Testbox changed gate have not completed yet. The full performance workflow was not rerun locally; its source artifact is the root-cause evidence, while exact-head hosted workflow and changed-gate validation follow on this PR.

Human credit: Vincent Koc authored the landed initial repair, and the implementation commit preserves `Co-authored-by: Vincent Koc <vincentkoc@ieee.org>`. This follow-up was AI-assisted and reviewed; the implementation and evidence have been checked directly.
