### PR TITLE
fix(test): keep fork E2E setup builds observable

### DIFF
--- a/test/scripts/vitest-e2e-global-setup.test.ts
+++ b/test/scripts/vitest-e2e-global-setup.test.ts
@@ -13,7 +13,7 @@ import {
   waitForDead,
   waitForPidFile,
 } from "../helpers/process-wait.js";
-import { runE2eGlobalSetup } from "./vitest.e2e.global-setup.js";
+import { runE2eGlobalSetup } from "../vitest/vitest.e2e.global-setup.js";
 
 type SetupCommandRunner = NonNullable<Parameters<typeof runE2eGlobalSetup>[0]>;
 
@@ -22,15 +22,18 @@ const PROCESS_TIMEOUT_MS = process.env.CI ? 15_000 : 5_000;
 
 describe("vitest E2E global setup", () => {
   it("runs both build commands sequentially with their exact environments", async () => {
-    const firstCommand = Promise.withResolvers<number>();
+    let resolveFirstCommand!: (status: number) => void;
+    const firstCommand = new Promise<number>((resolve) => {
+      resolveFirstCommand = resolve;
+    });
     const runCommand = vi
       .fn<SetupCommandRunner>()
-      .mockImplementationOnce(() => firstCommand.promise)
+      .mockImplementationOnce(() => firstCommand)
       .mockResolvedValueOnce(0);
 
     const setupPromise = runE2eGlobalSetup(runCommand);
     await vi.waitFor(() => expect(runCommand).toHaveBeenCalledTimes(1));
-    firstCommand.resolve(0);
+    resolveFirstCommand(0);
     await setupPromise;
     expect(runCommand.mock.calls).toEqual([
       [
@@ -74,7 +77,7 @@ process.stdin.once("data", () => {
 process.stdin.resume();
 `,
     );
-    const setupUrl = new URL("./vitest.e2e.global-setup.ts", import.meta.url).href;
+    const setupUrl = new URL("../vitest/vitest.e2e.global-setup.ts", import.meta.url).href;
     const runnerScript = `import { runE2eSetupCommand } from ${JSON.stringify(setupUrl)};
 await runE2eSetupCommand([${JSON.stringify(fixturePath)}], process.env);`;
     const runner = spawn(

--- a/test/vitest/vitest.e2e.global-setup.test.ts
+++ b/test/vitest/vitest.e2e.global-setup.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { runE2eGlobalSetup } from "./vitest.e2e.global-setup.js";
+
+type ManagedCommandRunner = NonNullable<Parameters<typeof runE2eGlobalSetup>[0]>;
+
+describe("vitest E2E global setup", () => {
+  it("streams both sequential build commands without a local timeout", async () => {
+    let finishFirst: (status: number) => void = () => {};
+    const firstCommand = new Promise<number>((resolve) => {
+      finishFirst = resolve;
+    });
+    const runCommand = vi
+      .fn<ManagedCommandRunner>()
+      .mockImplementationOnce(() => firstCommand)
+      .mockResolvedValueOnce(0);
+
+    const setupPromise = runE2eGlobalSetup(runCommand);
+    await vi.waitFor(() => expect(runCommand).toHaveBeenCalledTimes(1));
+
+    const firstOptions = runCommand.mock.calls[0]?.[0];
+    expect(firstOptions).toEqual({
+      args: ["scripts/run-node.mjs", "--version"],
+      bin: process.execPath,
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        OPENCLAW_BUILD_PRIVATE_QA: "1",
+        OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "0",
+      },
+      stdio: "inherit",
+    });
+    expect(firstOptions).not.toHaveProperty("timeoutMs");
+    expect(runCommand).toHaveBeenCalledTimes(1);
+
+    finishFirst(0);
+    await setupPromise;
+
+    const secondOptions = runCommand.mock.calls[1]?.[0];
+    expect(secondOptions).toEqual({
+      args: ["scripts/tsdown-build.mjs", "--config", "tsdown.ai.config.ts"],
+      bin: process.execPath,
+      cwd: process.cwd(),
+      env: process.env,
+      stdio: "inherit",
+    });
+    expect(secondOptions).not.toHaveProperty("timeoutMs");
+  });
+
+  it.each([
+    {
+      calls: 1,
+      statuses: [17],
+      command: "scripts/run-node.mjs --version",
+    },
+    {
+      calls: 2,
+      statuses: [0, 23],
+      command: "scripts/tsdown-build.mjs --config tsdown.ai.config.ts",
+    },
+  ])("propagates a nonzero status from $command", async ({ calls, statuses, command }) => {
+    const runCommand = vi.fn<ManagedCommandRunner>();
+    for (const status of statuses) {
+      runCommand.mockResolvedValueOnce(status);
+    }
+
+    await expect(runE2eGlobalSetup(runCommand)).rejects.toThrow(
+      `E2E setup command failed with exit code ${statuses.at(-1)}: ${command}`,
+    );
+    expect(runCommand).toHaveBeenCalledTimes(calls);
+  });
+});

--- a/test/vitest/vitest.e2e.global-setup.test.ts
+++ b/test/vitest/vitest.e2e.global-setup.test.ts
@@ -1,49 +1,77 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
+import { spawnWatchedVitestProcess } from "../../scripts/run-vitest.mjs";
+import { forceKillVitestProcessGroup } from "../../scripts/vitest-process-group.mjs";
 import { runE2eGlobalSetup } from "./vitest.e2e.global-setup.js";
 
-type ManagedCommandRunner = NonNullable<Parameters<typeof runE2eGlobalSetup>[0]>;
+type SetupCommandRunner = NonNullable<Parameters<typeof runE2eGlobalSetup>[0]>;
+
+const posixIt = process.platform === "win32" ? it.skip : it;
+const PROCESS_TIMEOUT_MS = process.env.CI ? 15_000 : 5_000;
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function waitFor(condition: () => boolean, message: string): Promise<void> {
+  const deadline = Date.now() + PROCESS_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (condition()) {
+      return;
+    }
+    await delay(25);
+  }
+  throw new Error(message);
+}
+
+function forceKillProcess(pid: number): void {
+  if (!pid || !isProcessAlive(pid)) {
+    return;
+  }
+  process.kill(pid, "SIGKILL");
+}
 
 describe("vitest E2E global setup", () => {
-  it("streams both sequential build commands without a local timeout", async () => {
+  it("runs both build commands sequentially with their exact environments", async () => {
     let finishFirst: (status: number) => void = () => {};
     const firstCommand = new Promise<number>((resolve) => {
       finishFirst = resolve;
     });
     const runCommand = vi
-      .fn<ManagedCommandRunner>()
+      .fn<SetupCommandRunner>()
       .mockImplementationOnce(() => firstCommand)
       .mockResolvedValueOnce(0);
 
     const setupPromise = runE2eGlobalSetup(runCommand);
     await vi.waitFor(() => expect(runCommand).toHaveBeenCalledTimes(1));
 
-    const firstOptions = runCommand.mock.calls[0]?.[0];
-    expect(firstOptions).toEqual({
-      args: ["scripts/run-node.mjs", "--version"],
-      bin: process.execPath,
-      cwd: process.cwd(),
-      env: {
-        ...process.env,
-        OPENCLAW_BUILD_PRIVATE_QA: "1",
-        OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "0",
-      },
-      stdio: "inherit",
+    expect(runCommand.mock.calls[0]?.[0]).toEqual(["scripts/run-node.mjs", "--version"]);
+    expect(runCommand.mock.calls[0]?.[1]).toEqual({
+      ...process.env,
+      OPENCLAW_BUILD_PRIVATE_QA: "1",
+      OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "0",
     });
-    expect(firstOptions).not.toHaveProperty("timeoutMs");
     expect(runCommand).toHaveBeenCalledTimes(1);
 
     finishFirst(0);
     await setupPromise;
 
-    const secondOptions = runCommand.mock.calls[1]?.[0];
-    expect(secondOptions).toEqual({
-      args: ["scripts/tsdown-build.mjs", "--config", "tsdown.ai.config.ts"],
-      bin: process.execPath,
-      cwd: process.cwd(),
-      env: process.env,
-      stdio: "inherit",
-    });
-    expect(secondOptions).not.toHaveProperty("timeoutMs");
+    expect(runCommand.mock.calls[1]).toEqual([
+      ["scripts/tsdown-build.mjs", "--config", "tsdown.ai.config.ts"],
+      process.env,
+    ]);
   });
 
   it.each([
@@ -58,7 +86,7 @@ describe("vitest E2E global setup", () => {
       command: "scripts/tsdown-build.mjs --config tsdown.ai.config.ts",
     },
   ])("propagates a nonzero status from $command", async ({ calls, statuses, command }) => {
-    const runCommand = vi.fn<ManagedCommandRunner>();
+    const runCommand = vi.fn<SetupCommandRunner>();
     for (const status of statuses) {
       runCommand.mockResolvedValueOnce(status);
     }
@@ -68,4 +96,104 @@ describe("vitest E2E global setup", () => {
     );
     expect(runCommand).toHaveBeenCalledTimes(calls);
   });
+
+  posixIt(
+    "streams real child output and leaves no descendants after the runner group is killed",
+    async () => {
+      const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-e2e-setup-group-"));
+      const fixturePath = path.join(fixtureDir, "build-fixture.mjs");
+      const childPidPath = path.join(fixtureDir, "child.pid");
+      const descendantPidPath = path.join(fixtureDir, "descendant.pid");
+      const activityMarker = "e2e-setup-build-active\n";
+      const setupModuleUrl = pathToFileURL(
+        path.resolve("test/vitest/vitest.e2e.global-setup.ts"),
+      ).href;
+      let childPid = 0;
+      let descendantPid = 0;
+
+      fs.writeFileSync(
+        fixturePath,
+        [
+          'import { spawn } from "node:child_process";',
+          'import fs from "node:fs";',
+          'const descendant = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });',
+          'if (!descendant.pid) throw new Error("descendant pid unavailable");',
+          `fs.writeFileSync(${JSON.stringify(childPidPath)}, String(process.pid));`,
+          `fs.writeFileSync(${JSON.stringify(descendantPidPath)}, String(descendant.pid));`,
+          `process.stdout.write(${JSON.stringify(activityMarker)});`,
+          "setInterval(() => {}, 1000);",
+          "",
+        ].join("\n"),
+      );
+
+      const runnerScript = [
+        `import { runE2eSetupCommand } from ${JSON.stringify(setupModuleUrl)};`,
+        `await runE2eSetupCommand([${JSON.stringify(fixturePath)}], process.env);`,
+      ].join("\n");
+      const watchedEnv = {
+        ...process.env,
+        OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: String(PROCESS_TIMEOUT_MS),
+      };
+      const watched = spawnWatchedVitestProcess({
+        pnpmArgs: [
+          "exec",
+          "node",
+          "--import",
+          "tsx",
+          "--input-type=module",
+          "--eval",
+          runnerScript,
+        ],
+        spawnParams: {
+          detached: true,
+          env: watchedEnv,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+        env: watchedEnv,
+        label: "E2E global setup process-group regression",
+      });
+      let output = "";
+      watched.child.stdout?.setEncoding("utf8");
+      watched.child.stdout?.on("data", (chunk) => {
+        output += chunk;
+      });
+      const completion = watched.completion.then(
+        (result) => ({ result }),
+        (error: unknown) => ({ error }),
+      );
+
+      try {
+        await waitFor(
+          () =>
+            fs.existsSync(childPidPath) &&
+            fs.existsSync(descendantPidPath) &&
+            output.includes(activityMarker),
+          "timed out waiting for streamed setup activity and descendant pids",
+        );
+        childPid = Number(fs.readFileSync(childPidPath, "utf8"));
+        descendantPid = Number(fs.readFileSync(descendantPidPath, "utf8"));
+        expect(isProcessAlive(childPid)).toBe(true);
+        expect(isProcessAlive(descendantPid)).toBe(true);
+        expect(output).toContain(activityMarker);
+
+        expect(forceKillVitestProcessGroup(watched.child)).toBe(true);
+        const outcome = await completion;
+        if ("error" in outcome) {
+          throw outcome.error;
+        }
+        expect(outcome.result).toEqual({ code: null, signal: "SIGKILL" });
+        await waitFor(
+          () => !isProcessAlive(childPid) && !isProcessAlive(descendantPid),
+          "setup child processes remained alive after the runner group was killed",
+        );
+      } finally {
+        watched.teardown();
+        forceKillVitestProcessGroup(watched.child);
+        await completion;
+        forceKillProcess(childPid);
+        forceKillProcess(descendantPid);
+        fs.rmSync(fixtureDir, { force: true, recursive: true });
+      }
+    },
+  );
 });

--- a/test/vitest/vitest.e2e.global-setup.test.ts
+++ b/test/vitest/vitest.e2e.global-setup.test.ts
@@ -1,11 +1,18 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { setTimeout as delay } from "node:timers/promises";
-import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
-import { spawnWatchedVitestProcess } from "../../scripts/run-vitest.mjs";
-import { forceKillVitestProcessGroup } from "../../scripts/vitest-process-group.mjs";
+import {
+  forceKillVitestProcessGroup,
+  forwardSignalToVitestProcessGroup,
+} from "../../scripts/vitest-process-group.mjs";
+import {
+  isProcessAlive,
+  waitForChildClose,
+  waitForDead,
+  waitForPidFile,
+} from "../helpers/process-wait.js";
 import { runE2eGlobalSetup } from "./vitest.e2e.global-setup.js";
 
 type SetupCommandRunner = NonNullable<Parameters<typeof runE2eGlobalSetup>[0]>;
@@ -13,187 +20,101 @@ type SetupCommandRunner = NonNullable<Parameters<typeof runE2eGlobalSetup>[0]>;
 const posixIt = process.platform === "win32" ? it.skip : it;
 const PROCESS_TIMEOUT_MS = process.env.CI ? 15_000 : 5_000;
 
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ESRCH") {
-      return false;
-    }
-    throw error;
-  }
-}
-
-async function waitFor(condition: () => boolean, message: string): Promise<void> {
-  const deadline = Date.now() + PROCESS_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    if (condition()) {
-      return;
-    }
-    await delay(25);
-  }
-  throw new Error(message);
-}
-
-function forceKillProcess(pid: number): void {
-  if (!pid || !isProcessAlive(pid)) {
-    return;
-  }
-  process.kill(pid, "SIGKILL");
-}
-
 describe("vitest E2E global setup", () => {
   it("runs both build commands sequentially with their exact environments", async () => {
-    let finishFirst: (status: number) => void = () => {};
-    const firstCommand = new Promise<number>((resolve) => {
-      finishFirst = resolve;
-    });
+    const firstCommand = Promise.withResolvers<number>();
     const runCommand = vi
       .fn<SetupCommandRunner>()
-      .mockImplementationOnce(() => firstCommand)
+      .mockImplementationOnce(() => firstCommand.promise)
       .mockResolvedValueOnce(0);
 
     const setupPromise = runE2eGlobalSetup(runCommand);
     await vi.waitFor(() => expect(runCommand).toHaveBeenCalledTimes(1));
-
-    expect(runCommand.mock.calls[0]?.[0]).toEqual(["scripts/run-node.mjs", "--version"]);
-    expect(runCommand.mock.calls[0]?.[1]).toEqual({
-      ...process.env,
-      OPENCLAW_BUILD_PRIVATE_QA: "1",
-      OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "0",
-    });
-    expect(runCommand).toHaveBeenCalledTimes(1);
-
-    finishFirst(0);
+    firstCommand.resolve(0);
     await setupPromise;
-
-    expect(runCommand.mock.calls[1]).toEqual([
-      ["scripts/tsdown-build.mjs", "--config", "tsdown.ai.config.ts"],
-      process.env,
+    expect(runCommand.mock.calls).toEqual([
+      [
+        ["scripts/run-node.mjs", "--version"],
+        {
+          ...process.env,
+          OPENCLAW_BUILD_PRIVATE_QA: "1",
+          OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "0",
+        },
+      ],
+      [["scripts/tsdown-build.mjs", "--config", "tsdown.ai.config.ts"], process.env],
     ]);
   });
 
-  it.each([
-    {
-      calls: 1,
-      statuses: [17],
-      command: "scripts/run-node.mjs --version",
-    },
-    {
-      calls: 2,
-      statuses: [0, 23],
-      command: "scripts/tsdown-build.mjs --config tsdown.ai.config.ts",
-    },
-  ])("propagates a nonzero status from $command", async ({ calls, statuses, command }) => {
-    const runCommand = vi.fn<SetupCommandRunner>();
-    for (const status of statuses) {
-      runCommand.mockResolvedValueOnce(status);
-    }
-
+  it("propagates a nonzero command status", async () => {
+    const runCommand = vi
+      .fn<SetupCommandRunner>()
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(23);
     await expect(runE2eGlobalSetup(runCommand)).rejects.toThrow(
-      `E2E setup command failed with exit code ${statuses.at(-1)}: ${command}`,
+      "E2E setup command failed with exit code 23: scripts/tsdown-build.mjs --config tsdown.ai.config.ts",
     );
-    expect(runCommand).toHaveBeenCalledTimes(calls);
   });
 
-  posixIt(
-    "streams real child output and leaves no descendants after the runner group is killed",
-    async () => {
-      const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-e2e-setup-group-"));
-      const fixturePath = path.join(fixtureDir, "build-fixture.mjs");
-      const childPidPath = path.join(fixtureDir, "child.pid");
-      const descendantPidPath = path.join(fixtureDir, "descendant.pid");
-      const activityMarker = "e2e-setup-build-active\n";
-      const setupModuleUrl = pathToFileURL(
-        path.resolve("test/vitest/vitest.e2e.global-setup.ts"),
-      ).href;
-      let childPid = 0;
-      let descendantPid = 0;
+  posixIt("forwards output and SIGTERM through the runner process group", async () => {
+    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-e2e-setup-group-"));
+    const fixturePath = path.join(fixtureDir, "build-fixture.mjs");
+    const pidPaths = ["child.pid", "descendant.pid"].map((name) => path.join(fixtureDir, name));
+    fs.writeFileSync(
+      fixturePath,
+      `import { spawn } from "node:child_process";
+import fs from "node:fs";
+process.stdin.once("data", () => {
+  const descendant = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+  fs.writeFileSync(${JSON.stringify(pidPaths[0])}, String(process.pid));
+  fs.writeFileSync(${JSON.stringify(pidPaths[1])}, String(descendant.pid));
+  process.stdout.write("setup-stdout\\n");
+  process.stderr.write("setup-stderr\\n");
+  setInterval(() => {}, 1000);
+});
+process.stdin.resume();
+`,
+    );
+    const setupUrl = new URL("./vitest.e2e.global-setup.ts", import.meta.url).href;
+    const runnerScript = `import { runE2eSetupCommand } from ${JSON.stringify(setupUrl)};
+await runE2eSetupCommand([${JSON.stringify(fixturePath)}], process.env);`;
+    const runner = spawn(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "--eval", runnerScript],
+      { detached: true, stdio: ["pipe", "pipe", "pipe"] },
+    );
+    const pids: number[] = [];
+    let stdout = "";
+    let stderr = "";
+    runner.stdout.setEncoding("utf8").on("data", (chunk) => (stdout += chunk));
+    runner.stderr.setEncoding("utf8").on("data", (chunk) => (stderr += chunk));
 
-      fs.writeFileSync(
-        fixturePath,
-        [
-          'import { spawn } from "node:child_process";',
-          'import fs from "node:fs";',
-          'const descendant = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });',
-          'if (!descendant.pid) throw new Error("descendant pid unavailable");',
-          `fs.writeFileSync(${JSON.stringify(childPidPath)}, String(process.pid));`,
-          `fs.writeFileSync(${JSON.stringify(descendantPidPath)}, String(descendant.pid));`,
-          `process.stdout.write(${JSON.stringify(activityMarker)});`,
-          "setInterval(() => {}, 1000);",
-          "",
-        ].join("\n"),
+    try {
+      runner.stdin.write("start\n");
+      pids.push(
+        ...(await Promise.all(pidPaths.map((file) => waitForPidFile(file, PROCESS_TIMEOUT_MS)))),
       );
-
-      const runnerScript = [
-        `import { runE2eSetupCommand } from ${JSON.stringify(setupModuleUrl)};`,
-        `await runE2eSetupCommand([${JSON.stringify(fixturePath)}], process.env);`,
-      ].join("\n");
-      const watchedEnv = {
-        ...process.env,
-        OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: String(PROCESS_TIMEOUT_MS),
-      };
-      const watched = spawnWatchedVitestProcess({
-        pnpmArgs: [
-          "exec",
-          "node",
-          "--import",
-          "tsx",
-          "--input-type=module",
-          "--eval",
-          runnerScript,
-        ],
-        spawnParams: {
-          detached: true,
-          env: watchedEnv,
-          stdio: ["ignore", "pipe", "pipe"],
-        },
-        env: watchedEnv,
-        label: "E2E global setup process-group regression",
+      await vi.waitFor(() => {
+        expect(stdout).toContain("setup-stdout");
+        expect(stderr).toContain("setup-stderr");
       });
-      let output = "";
-      watched.child.stdout?.setEncoding("utf8");
-      watched.child.stdout?.on("data", (chunk) => {
-        output += chunk;
-      });
-      const completion = watched.completion.then(
-        (result) => ({ result }),
-        (error: unknown) => ({ error }),
-      );
-
-      try {
-        await waitFor(
-          () =>
-            fs.existsSync(childPidPath) &&
-            fs.existsSync(descendantPidPath) &&
-            output.includes(activityMarker),
-          "timed out waiting for streamed setup activity and descendant pids",
-        );
-        childPid = Number(fs.readFileSync(childPidPath, "utf8"));
-        descendantPid = Number(fs.readFileSync(descendantPidPath, "utf8"));
-        expect(isProcessAlive(childPid)).toBe(true);
-        expect(isProcessAlive(descendantPid)).toBe(true);
-        expect(output).toContain(activityMarker);
-
-        expect(forceKillVitestProcessGroup(watched.child)).toBe(true);
-        const outcome = await completion;
-        if ("error" in outcome) {
-          throw outcome.error;
+      const closed = waitForChildClose(runner, PROCESS_TIMEOUT_MS);
+      expect(
+        forwardSignalToVitestProcessGroup({
+          child: runner,
+          kill: process.kill.bind(process),
+          signal: "SIGTERM",
+        }),
+      ).toBe(true);
+      await expect(closed).resolves.toEqual({ code: null, signal: "SIGTERM" });
+      await Promise.all(pids.map((pid) => waitForDead(pid, PROCESS_TIMEOUT_MS)));
+    } finally {
+      forceKillVitestProcessGroup(runner);
+      for (const pid of pids) {
+        if (isProcessAlive(pid)) {
+          process.kill(pid, "SIGKILL");
         }
-        expect(outcome.result).toEqual({ code: null, signal: "SIGKILL" });
-        await waitFor(
-          () => !isProcessAlive(childPid) && !isProcessAlive(descendantPid),
-          "setup child processes remained alive after the runner group was killed",
-        );
-      } finally {
-        watched.teardown();
-        forceKillVitestProcessGroup(watched.child);
-        await completion;
-        forceKillProcess(childPid);
-        forceKillProcess(descendantPid);
-        fs.rmSync(fixtureDir, { force: true, recursive: true });
       }
-    },
-  );
+      fs.rmSync(fixtureDir, { force: true, recursive: true });
+    }
+  });
 });

--- a/test/vitest/vitest.e2e.global-setup.ts
+++ b/test/vitest/vitest.e2e.global-setup.ts
@@ -1,29 +1,42 @@
 // Builds the shared CLI/package artifacts once before parallel E2E workers
 // start long-lived Gateway processes that import those artifacts lazily.
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
+import { runManagedCommand } from "../../scripts/lib/managed-child-process.mjs";
 
-const execFileAsync = promisify(execFile);
+type ManagedCommandRunner = typeof runManagedCommand;
+
+async function runSetupCommand(
+  runCommand: ManagedCommandRunner,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  const status = await runCommand({
+    bin: process.execPath,
+    args,
+    cwd: process.cwd(),
+    env,
+    stdio: "inherit",
+  });
+
+  if (status !== 0) {
+    throw new Error(`E2E setup command failed with exit code ${status}: ${args.join(" ")}`);
+  }
+}
+
+export async function runE2eGlobalSetup(
+  runCommand: ManagedCommandRunner = runManagedCommand,
+): Promise<void> {
+  await runSetupCommand(runCommand, ["scripts/run-node.mjs", "--version"], {
+    ...process.env,
+    OPENCLAW_BUILD_PRIVATE_QA: "1",
+    OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "0",
+  });
+  await runSetupCommand(
+    runCommand,
+    ["scripts/tsdown-build.mjs", "--config", "tsdown.ai.config.ts"],
+    process.env,
+  );
+}
 
 export default async function setup() {
-  await execFileAsync(process.execPath, ["scripts/run-node.mjs", "--version"], {
-    cwd: process.cwd(),
-    env: {
-      ...process.env,
-      OPENCLAW_BUILD_PRIVATE_QA: "1",
-      OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "0",
-    },
-    maxBuffer: 8 * 1024 * 1024,
-    timeout: 300_000,
-  });
-  await execFileAsync(
-    process.execPath,
-    ["scripts/tsdown-build.mjs", "--config", "tsdown.ai.config.ts"],
-    {
-      cwd: process.cwd(),
-      env: process.env,
-      maxBuffer: 8 * 1024 * 1024,
-      timeout: 300_000,
-    },
-  );
+  await runE2eGlobalSetup();
 }

--- a/test/vitest/vitest.e2e.global-setup.ts
+++ b/test/vitest/vitest.e2e.global-setup.ts
@@ -1,29 +1,43 @@
 // Builds the shared CLI/package artifacts once before parallel E2E workers
 // start long-lived Gateway processes that import those artifacts lazily.
-import { runManagedCommand } from "../../scripts/lib/managed-child-process.mjs";
+import { spawn } from "node:child_process";
 
-type ManagedCommandRunner = typeof runManagedCommand;
+type SetupCommandRunner = (args: string[], env: NodeJS.ProcessEnv) => Promise<number>;
 
 async function runSetupCommand(
-  runCommand: ManagedCommandRunner,
+  runCommand: SetupCommandRunner,
   args: string[],
   env: NodeJS.ProcessEnv,
 ): Promise<void> {
-  const status = await runCommand({
-    bin: process.execPath,
-    args,
-    cwd: process.cwd(),
-    env,
-    stdio: "inherit",
-  });
+  const status = await runCommand(args, env);
 
   if (status !== 0) {
     throw new Error(`E2E setup command failed with exit code ${status}: ${args.join(" ")}`);
   }
 }
 
+export function runE2eSetupCommand(args: string[], env: NodeJS.ProcessEnv): Promise<number> {
+  const child = spawn(process.execPath, args, {
+    cwd: process.cwd(),
+    detached: false,
+    env,
+    stdio: "inherit",
+  });
+
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (status, signal) => {
+      if (signal) {
+        reject(new Error(`E2E setup command terminated by ${signal}: ${args.join(" ")}`));
+        return;
+      }
+      resolve(status ?? 1);
+    });
+  });
+}
+
 export async function runE2eGlobalSetup(
-  runCommand: ManagedCommandRunner = runManagedCommand,
+  runCommand: SetupCommandRunner = runE2eSetupCommand,
 ): Promise<void> {
   await runSetupCommand(runCommand, ["scripts/run-node.mjs", "--version"], {
     ...process.env,

--- a/test/vitest/vitest.e2e.global-setup.ts
+++ b/test/vitest/vitest.e2e.global-setup.ts
@@ -4,25 +4,15 @@ import { spawn } from "node:child_process";
 
 type SetupCommandRunner = (args: string[], env: NodeJS.ProcessEnv) => Promise<number>;
 
-async function runSetupCommand(
-  runCommand: SetupCommandRunner,
-  args: string[],
-  env: NodeJS.ProcessEnv,
-): Promise<void> {
-  const status = await runCommand(args, env);
-
-  if (status !== 0) {
-    throw new Error(`E2E setup command failed with exit code ${status}: ${args.join(" ")}`);
-  }
-}
-
 export function runE2eSetupCommand(args: string[], env: NodeJS.ProcessEnv): Promise<number> {
   const child = spawn(process.execPath, args, {
     cwd: process.cwd(),
     detached: false,
     env,
-    stdio: "inherit",
+    stdio: ["inherit", "pipe", "pipe"],
   });
+  child.stdout.pipe(process.stdout, { end: false });
+  child.stderr.pipe(process.stderr, { end: false });
 
   return new Promise((resolve, reject) => {
     child.once("error", reject);
@@ -39,16 +29,26 @@ export function runE2eSetupCommand(args: string[], env: NodeJS.ProcessEnv): Prom
 export async function runE2eGlobalSetup(
   runCommand: SetupCommandRunner = runE2eSetupCommand,
 ): Promise<void> {
-  await runSetupCommand(runCommand, ["scripts/run-node.mjs", "--version"], {
-    ...process.env,
-    OPENCLAW_BUILD_PRIVATE_QA: "1",
-    OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "0",
-  });
-  await runSetupCommand(
-    runCommand,
-    ["scripts/tsdown-build.mjs", "--config", "tsdown.ai.config.ts"],
-    process.env,
-  );
+  const commands = [
+    {
+      args: ["scripts/run-node.mjs", "--version"],
+      env: {
+        ...process.env,
+        OPENCLAW_BUILD_PRIVATE_QA: "1",
+        OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "0",
+      },
+    },
+    {
+      args: ["scripts/tsdown-build.mjs", "--config", "tsdown.ai.config.ts"],
+      env: process.env,
+    },
+  ];
+  for (const { args, env } of commands) {
+    const status = await runCommand(args, env);
+    if (status !== 0) {
+      throw new Error(`E2E setup command failed with exit code ${status}: ${args.join(" ")}`);
+    }
+  }
 }
 
 export default async function setup() {


### PR DESCRIPTION
Related: #119267

## What Problem This Solves

Fixes an issue where fork pull-request E2E jobs could time out after five minutes even while their setup builds were still making progress.

## Why This Change Was Made

The E2E global setup now forwards build output through owned pipes and keeps build processes in Vitest's process group. The existing outer inactivity watchdog remains the single timeout owner, and setup failures still propagate immediately.

## User Impact

There is no product-runtime change. Contributors get reliable GitHub-hosted fork CI, and cancelled jobs clean up the setup build and its descendants.

## Evidence

- 158 focused setup, watchdog, process-group, and tsdown tests passed.
- 71 focused run-node tests passed.
- The real descendant-cleanup regression passed three consecutive runs.
- Targeted oxlint, oxfmt, `git diff --check`, TruffleHog, and autoreview passed.
- Independent owner review found no remaining P0-P3 findings.
- This targets the repeated 300-second setup stalls seen in #119267 and unrelated fork PR runs.
