### PR TITLE
fix(cloud-workers): prevent teardown from racing slow provider setup

### DIFF
--- a/src/gateway/worker-environments/service.test.ts
+++ b/src/gateway/worker-environments/service.test.ts
@@ -1260,7 +1260,13 @@ describe("worker environment service", () => {
   });
 
   it("bounds worker identity resolution as a provider operation", async () => {
-    bootstrapWorker = vi.fn(async ({ installation, resolveIdentity }) => {
+    const events: string[] = [];
+    let finishIdentity: (() => void) | undefined;
+    const identityPending = new Promise<void>((resolve) => {
+      finishIdentity = resolve;
+    });
+    bootstrapWorker = vi.fn(async ({ installation, resolveIdentity, signal }) => {
+      signal.addEventListener("abort", () => void events.push("abort"), { once: true });
       await resolveIdentity(SSH_ENDPOINT.keyRef);
       return {
         bundleHash: installation.bundleHash,
@@ -1268,18 +1274,34 @@ describe("worker environment service", () => {
         protocolFeatures: [...installation.protocolFeatures],
       };
     });
-    const destroy = vi.fn(async () => {});
+    const destroy = vi.fn(async () => {
+      events.push("destroy");
+    });
     const workerService = createService(createProvider({ destroy }), {
       providerCallTimeoutMs: 5,
-      resolveSshIdentity: async () => await new Promise<never>(() => {}),
+      resolveSshIdentity: async () => {
+        events.push("identity:start");
+        await identityPending;
+        events.push("identity:end");
+        return { kind: "path", path: "/keys/worker" };
+      },
     });
 
-    await expect(
-      workerService.create("development", "request-identity-timeout"),
-    ).rejects.toMatchObject({
+    const creation = workerService.create("development", "request-identity-timeout");
+    const creationResult = expect(creation).rejects.toMatchObject({
       code: "bootstrap_failure",
     } satisfies Partial<WorkerEnvironmentServiceError>);
+    try {
+      await waitForFast(() => expect(store.list()[0]).toMatchObject({ state: "destroying" }));
+      expect(events).toEqual(["identity:start", "abort"]);
+      expect(destroy).not.toHaveBeenCalled();
+    } finally {
+      finishIdentity?.();
+    }
+
+    await creationResult;
     expect(destroy).toHaveBeenCalledOnce();
+    expect(events).toEqual(["identity:start", "abort", "identity:end", "destroy"]);
     expect(store.list()[0]).toMatchObject({ state: "failed", leaseId: null });
   });
 
@@ -1351,6 +1373,83 @@ describe("worker environment service", () => {
     });
     expect(calls).toHaveLength(2);
     expect(new Set(calls).size).toBe(1);
+  });
+
+  it("serializes destroy and provision replay behind a timed-out provider operation", async () => {
+    const events: string[] = [];
+    const operationIds: string[] = [];
+    let active = 0;
+    let maxActive = 0;
+    let originalProvisionCalls = 0;
+    let finishFirstProvision: (() => void) | undefined;
+    const firstProvisionPending = new Promise<void>((resolve) => {
+      finishFirstProvision = resolve;
+    });
+    const destroy = vi.fn(async () => {
+      events.push("destroy:start");
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      active -= 1;
+      events.push("destroy:end");
+    });
+    const provider = createProvider({
+      provision: async (_profile, operationId) => {
+        originalProvisionCalls += 1;
+        const call = originalProvisionCalls;
+        operationIds.push(operationId);
+        events.push(`provision:${call}:start`);
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        if (call === 1) {
+          await firstProvisionPending;
+        }
+        active -= 1;
+        events.push(`provision:${call}:end`);
+        return { leaseId: "lease-timeout-replay", ssh: SSH_ENDPOINT };
+      },
+      destroy,
+    });
+    const workerService = createService(provider, { providerCallTimeoutMs: 20 });
+    const creation = workerService.create("development", "request-provider-timeout-race");
+    const creationResult = expect(creation).rejects.toMatchObject({
+      code: "provider_failure",
+    } satisfies Partial<WorkerEnvironmentServiceError>);
+    let environmentId: string | undefined;
+    let teardownResult: Promise<void> | undefined;
+    try {
+      await waitForFast(() => expect(events).toEqual(["provision:1:start"]));
+      const queuedEnvironmentId = expectDefined(
+        store.list()[0],
+        "timed-out provision row",
+      ).environmentId;
+      environmentId = queuedEnvironmentId;
+      const teardown = workerService.destroy(queuedEnvironmentId);
+      teardownResult = expect(teardown).resolves.toMatchObject({ state: "destroyed" });
+      await creationResult;
+      await waitForFast(() =>
+        expect(store.get(queuedEnvironmentId)?.destroyRequestedAtMs).not.toBeNull(),
+      );
+      expect(originalProvisionCalls).toBe(1);
+      expect(destroy).not.toHaveBeenCalled();
+      expect(maxActive).toBe(1);
+    } finally {
+      finishFirstProvision?.();
+    }
+
+    await teardownResult;
+    const finalEnvironmentId = expectDefined(environmentId, "timed-out provision environment id");
+    expect(operationIds).toHaveLength(2);
+    expect(new Set(operationIds).size).toBe(1);
+    expect(maxActive).toBe(1);
+    expect(events).toEqual([
+      "provision:1:start",
+      "provision:1:end",
+      "provision:2:start",
+      "provision:2:end",
+      "destroy:start",
+      "destroy:end",
+    ]);
+    expect(store.get(finalEnvironmentId)).toMatchObject({ state: "destroyed" });
   });
 
   it("adopts an indeterminate allocation before a replay preparation failure", async () => {
@@ -2184,6 +2283,47 @@ describe("worker environment service", () => {
     expect(new Set(inspected.map(({ leaseId }) => leaseId))).toEqual(
       new Set(["lease:worker-concurrent-a", "lease:worker-concurrent-b"]),
     );
+  });
+
+  it("waits for timed-out provider work during shutdown", async () => {
+    let finishProvision: (() => void) | undefined;
+    const provisionPending = new Promise<void>((resolve) => {
+      finishProvision = resolve;
+    });
+    const provision = vi.fn(async () => {
+      await provisionPending;
+      return { leaseId: "lease-stop-timeout", ssh: SSH_ENDPOINT };
+    });
+    const stopAll = vi.fn(async () => {});
+    const tunnelManager = {
+      stopAll,
+    } as unknown as WorkerTunnelManager;
+    const workerService = createService(createProvider({ provision }), {
+      providerCallTimeoutMs: 5,
+      tunnelManager,
+    });
+    const creation = workerService.create("development", "request-stop-provider-timeout");
+    const creationResult = expect(creation).rejects.toMatchObject({
+      code: "provider_failure",
+    } satisfies Partial<WorkerEnvironmentServiceError>);
+    let stopped = false;
+    let stopping: Promise<void> | undefined;
+
+    try {
+      await waitForFast(() => expect(provision).toHaveBeenCalledOnce());
+      await creationResult;
+      stopping = workerService.stop().then(() => {
+        stopped = true;
+      });
+      await waitForFast(() => expect(stopAll).toHaveBeenCalledOnce());
+      await Promise.resolve();
+      expect(stopped).toBe(false);
+    } finally {
+      finishProvision?.();
+    }
+
+    await stopping;
+    expect(stopped).toBe(true);
   });
 
   it("owns and clears one periodic reconciliation timer", async () => {

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -218,6 +218,7 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
   const tunnels = options.tunnelManager;
   const warn = (message: string) => options.logger?.warn(message);
   const operations = new KeyedAsyncQueue();
+  const providerOperations = new KeyedAsyncQueue();
   const activeOperations = new Set<Promise<unknown>>();
   const pendingCredentials = new Map<string, MintedWorkerCredential>();
   const observedAckCursors = new Map<string, WorkerTerminalTurnFence>();
@@ -351,20 +352,34 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
 
   const inState = (r: WorkerEnvironmentRecord, ...states: WorkerEnvironmentState[]) =>
     states.includes(r.state);
-  const withLock = <T>(environmentId: string, task: () => Promise<T>) => {
-    const operation = operations.enqueue(environmentId, task);
+  const trackOperation = <T>(operation: Promise<T>) => {
     activeOperations.add(operation);
     const release = () => activeOperations.delete(operation);
     void operation.then(release, release);
     return operation;
   };
+  const withLock = <T>(environmentId: string, task: () => Promise<T>) =>
+    trackOperation(operations.enqueue(environmentId, task));
 
-  const callProvider = <T>(run: () => Promise<T>) =>
-    withTimeout(
-      Promise.resolve().then(run),
+  const callProvider = async <T>(environmentId: string, run: () => Promise<T>): Promise<T> => {
+    let signalStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      signalStarted = resolve;
+    });
+    const operation = trackOperation(
+      providerOperations.enqueue(environmentId, async () => {
+        signalStarted();
+        return await run();
+      }),
+    );
+    await started;
+    // Timeout completion must not release provider ownership or permit replay/destroy overlap.
+    return await withTimeout(
+      operation,
       options.providerCallTimeoutMs ?? 300_000,
       "Worker provider operation",
     );
+  };
 
   const callBootstrap = async <T>(run: (signal: AbortSignal) => Promise<T>): Promise<T> => {
     const controller = new AbortController();
@@ -401,7 +416,9 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
       if (!resolveSshIdentity) {
         throw new Error("Worker SSH identity resolution is unavailable");
       }
-      return await callProvider(() => resolveSshIdentity({ provider, leaseId, profile, keyRef }));
+      return await callProvider(record.environmentId, () =>
+        resolveSshIdentity({ provider, leaseId, profile, keyRef }),
+      );
     };
   };
 
@@ -518,7 +535,9 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     await tunnels?.stop(record.environmentId);
     const destroying = move(draining, "destroying", { lastError: detail });
     try {
-      await callProvider(() => provider.destroy(lifecycleLease(record, leaseId)));
+      await callProvider(record.environmentId, () =>
+        provider.destroy(lifecycleLease(record, leaseId)),
+      );
     } catch (cleanupError) {
       // An indeterminate destroy must remain retryable; never hide a possibly-live paid lease
       // behind terminal failed state.
@@ -585,7 +604,9 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     try {
       const profile = requireWorkerProfile(record.profileSnapshot.settings);
       lease = requireWorkerLease(
-        await callProvider(() => provider.provision(profile, record.provisionOperationId)),
+        await callProvider(record.environmentId, () =>
+          provider.provision(profile, record.provisionOperationId),
+        ),
       );
     } catch (error) {
       if (
@@ -670,7 +691,7 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     const owningProvider = provider ?? providerFor(r.providerId);
     const destroying = beginDestroy(draining);
     try {
-      await callProvider(() => owningProvider.destroy(lifecycleLease(r, leaseId)));
+      await callProvider(r.environmentId, () => owningProvider.destroy(lifecycleLease(r, leaseId)));
     } catch (error) {
       saveError(destroying, error);
       throw serviceError("provider_failure", "Worker provider operation failed");
@@ -753,7 +774,9 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
       }
       return;
     }
-    const status = await callProvider(() => provider.inspect(lifecycleLease(record, leaseId)))
+    const status = await callProvider(record.environmentId, () =>
+      provider.inspect(lifecycleLease(record, leaseId)),
+    )
       .then(inspectionStatus)
       .catch((error: unknown) => {
         saveError(record, error);


### PR DESCRIPTION
Closes #120651

AI-assisted: yes. I reviewed the implementation and understand the lifecycle changes.

## What Problem This Solves

Fixes an issue where cloud worker provisioning or setup that outlived the gateway's 300-second provider timeout could continue running after lifecycle ownership was released. Reconciliation or teardown could then replay setup and destroy the same environment concurrently with the original provider operation.

Crabbox makes this reachable in normal operation because provisioning and optional setup have separate budgets that can legitimately exceed the gateway wrapper timeout.

## Why This Change Was Made

The worker-environment service now owns a separate per-environment queue for the raw provider promises. Caller-visible timeouts remain bounded observers, but replay, inspection, identity resolution, destroy, and shutdown join the actual in-flight provider operation before starting another provider call for that environment.

This keeps the fix at the gateway lifecycle owner and avoids a Crabbox-specific timeout exception or a new public WorkerProvider cancellation contract. Cancellation was intentionally not used because stopping the local Crabbox process cannot authoritatively prove that remote allocation or setup has stopped.

Production delta: `+33/-10` (net `+23`), justified by the new provider-operation ownership boundary. Tests: `+146/-6`.

## User Impact

Operators can still receive a bounded timeout when a provider operation runs long, but OpenClaw will no longer overlap a replay or teardown with that still-running setup. Service shutdown also waits for timed-out provider work to settle instead of leaving it active in the background.

No configuration, storage schema, protocol, Plugin SDK, or documentation surface changes.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/worker-environments/service.test.ts`
  - 1 test file passed
  - 67/67 tests passed after rebasing onto current `origin/main`
- Added deterministic regression coverage proving:
  - a timed-out provision remains the sole active provider operation;
  - destroy intent can be recorded, but provision replay and provider destroy wait for the original promise to settle;
  - replay reuses the same durable operation ID;
  - nested identity timeout cleanup waits before provider teardown;
  - service shutdown joins raw timed-out provider work.
- `./node_modules/.bin/oxfmt --check src/gateway/worker-environments/service.ts src/gateway/worker-environments/service.test.ts` — passed.
- `node scripts/run-oxlint.mjs src/gateway/worker-environments/service.ts src/gateway/worker-environments/service.test.ts` — passed.
- `pnpm tsgo:core` — passed.
- `pnpm tsgo:core:test` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Codex autoreview (`--mode uncommitted`, high reasoning) — clean, no accepted/actionable findings.

The normal changed-surface gate first could not acquire a ready Crabbox/Testbox provider. Its trusted-source local fallback then stopped on an unrelated current-`main` max-lines baseline failure for `src/agents/provider-local-service.ts`; the touched-surface test, format, lint, and typecheck proof above all passed. A live Crabbox lease was not used because the backend was unavailable; the overlap and repair are covered through the SQLite-backed lifecycle service with controlled provider promises.
