### PR TITLE
feat(cli): openclaw resume attaches the TUI to a recent session

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -24,7 +24,7 @@ Setup commands by intent:
 | Setup and onboarding         | [`openclaw`](/cli/openclaw) · [`setup`](/cli/setup) · [`onboard`](/cli/onboard) · [`configure`](/cli/configure) · [`config`](/cli/config) · [`completion`](/cli/completion) · [`doctor`](/cli/doctor) · [`dashboard`](/cli/dashboard) |
 | Reset, backup, and migration | [`backup`](/cli/backup) · [`migrate`](/cli/migrate) · [`reset`](/cli/reset) · [`uninstall`](/cli/uninstall) · [`update`](/cli/update)                                                                                                 |
 | Messaging and agents         | [`message`](/cli/message) · [`agent`](/cli/agent) · [`agents`](/cli/agents) · [`attach`](/cli/attach) · [`acp`](/cli/acp) · [`mcp`](/cli/mcp)                                                                                         |
-| Health and sessions          | [`status`](/cli/status) · [`health`](/cli/health) · [`sessions`](/cli/sessions) · [`audit`](/cli/audit)                                                                                                                               |
+| Health and sessions          | [`status`](/cli/status) · [`health`](/cli/health) · [`sessions`](/cli/sessions) · [`resume`](/cli/resume) · [`audit`](/cli/audit)                                                                                                     |
 | Gateway and logs             | [`gateway`](/cli/gateway) · [`logs`](/cli/logs) · [`system`](/cli/system)                                                                                                                                                             |
 | Models and inference         | [`models`](/cli/models) · [`promos`](/cli/promos) · [`infer`](/cli/infer) · `capability` (alias for [`infer`](/cli/infer)) · [`memory`](/cli/memory) · [`commitments`](/cli/commitments) · [`wiki`](/cli/wiki)                        |
 | Network and nodes            | [`directory`](/cli/directory) · [`nodes`](/cli/nodes) · [`devices`](/cli/devices) · [`node`](/cli/node) · [`worker`](/cli/worker)                                                                                                     |
@@ -418,6 +418,7 @@ openclaw [--dev] [--profile <name>] <command>
   docs
   dns
     setup
+  resume
   tui
   chat (alias: tui --local)
   terminal (alias: tui --local)

--- a/docs/cli/resume.md
+++ b/docs/cli/resume.md
@@ -38,6 +38,10 @@ status 1. If no recent session matches, it suggests the picker and
 [`openclaw tui`](/cli/tui). It never starts a Gateway automatically. If the
 configured Gateway is unavailable, start or repair it and rerun the command.
 
+With no explicit `--url`, `resume` follows the active local Gateway recorded by
+the running process. With `--url`, pass `--token` or `--password` explicitly
+unless a device credential is already stored for that exact Gateway origin.
+
 ## Examples
 
 ```bash

--- a/docs/cli/resume.md
+++ b/docs/cli/resume.md
@@ -45,9 +45,11 @@ configured Gateway is unavailable, start or repair it and rerun the command.
 `resume` resolves configured Gateway auth SecretRefs for token/password auth
 when possible (`env`/`file`/`exec` providers).
 
-With no explicit URL or port, `resume` follows the active local Gateway port
-recorded by the running Gateway. Explicit `--url`, `OPENCLAW_GATEWAY_URL`,
-`OPENCLAW_GATEWAY_PORT`, and remote Gateway config keep precedence.
+Gateway target precedence is explicit `--url`, then `OPENCLAW_GATEWAY_URL`,
+then `gateway.remote.url` when `gateway.mode` is `remote`, then the local
+loopback Gateway. For that local Gateway, `OPENCLAW_GATEWAY_PORT` takes
+precedence over the active port recorded by a running Gateway, which takes
+precedence over the configured or default `gateway.port`.
 
 ## Examples
 

--- a/docs/cli/resume.md
+++ b/docs/cli/resume.md
@@ -21,6 +21,10 @@ With no query, OpenClaw displays up to 50 sessions active in the last seven
 days. With a query, an exact session key wins; otherwise OpenClaw requires a
 unique substring or fuzzy match across session keys, display names, and labels.
 
+The picker omits bare `global` rows because they do not identify an owning
+agent. To attach one, pass a fully qualified key such as
+`openclaw resume agent:main:global`.
+
 If a query is ambiguous, OpenClaw prints the matching candidates and exits with
 status 1. If no recent session matches, it suggests the picker and
 [`openclaw sessions`](/cli/sessions), then exits with status 1.
@@ -38,9 +42,12 @@ status 1. If no recent session matches, it suggests the picker and
 [`openclaw tui`](/cli/tui). It never starts a Gateway automatically. If the
 configured Gateway is unavailable, start or repair it and rerun the command.
 
-With no explicit `--url`, `resume` follows the active local Gateway recorded by
-the running process. With `--url`, pass `--token` or `--password` explicitly
-unless a device credential is already stored for that exact Gateway origin.
+`resume` resolves configured Gateway auth SecretRefs for token/password auth
+when possible (`env`/`file`/`exec` providers).
+
+With no explicit URL or port, `resume` follows the active local Gateway port
+recorded by the running Gateway. Explicit `--url`, `OPENCLAW_GATEWAY_URL`,
+`OPENCLAW_GATEWAY_PORT`, and remote Gateway config keep precedence.
 
 ## Examples
 

--- a/docs/cli/resume.md
+++ b/docs/cli/resume.md
@@ -1,0 +1,61 @@
+---
+summary: "CLI reference for attaching the TUI to a recent Gateway session"
+read_when:
+  - You want to continue an existing Gateway session in the terminal
+  - You want to find a recent session by key, display name, or label
+  - You connect the TUI to a remote Gateway
+title: "Resume"
+---
+
+# `openclaw resume`
+
+Attach the terminal UI to an existing Gateway session. The session stays on
+the Gateway; `resume` selects it and opens the existing [TUI](/cli/tui).
+
+```bash
+openclaw resume
+openclaw resume <query>
+```
+
+With no query, OpenClaw displays up to 50 sessions active in the last seven
+days. With a query, an exact session key wins; otherwise OpenClaw requires a
+unique substring or fuzzy match across session keys, display names, and labels.
+
+If a query is ambiguous, OpenClaw prints the matching candidates and exits with
+status 1. If no recent session matches, it suggests the picker and
+[`openclaw sessions`](/cli/sessions), then exits with status 1.
+
+## Options
+
+| Flag                         | Default                          | Description                                                         |
+| ---------------------------- | -------------------------------- | ------------------------------------------------------------------- |
+| `--url <url>`                | `gateway.remote.url` from config | Gateway WebSocket URL.                                              |
+| `--token <token>`            | (none)                           | Gateway token if required.                                          |
+| `--password <pass>`          | (none)                           | Gateway password if required.                                       |
+| `--tls-fingerprint <sha256>` | `gateway.remote.tlsFingerprint`  | Expected TLS certificate fingerprint for a pinned `wss://` Gateway. |
+
+`resume` uses the same Gateway URL, authentication, and TLS resolution as
+[`openclaw tui`](/cli/tui). It never starts a Gateway automatically. If the
+configured Gateway is unavailable, start or repair it and rerun the command.
+
+## Examples
+
+```bash
+# Choose from recent sessions
+openclaw resume
+
+# Exact key
+openclaw resume agent:main:bugfix
+
+# Unique display-name or label fragment
+openclaw resume bugfix
+
+# Remote Gateway override
+openclaw resume bugfix --url wss://gateway.example.com --token <token>
+```
+
+## Related
+
+- [TUI](/cli/tui)
+- [Sessions](/cli/sessions)
+- [TUI guide](/web/tui)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1888,6 +1888,7 @@
                     "pages": [
                       "cli/attach",
                       "cli/dashboard",
+                      "cli/resume",
                       "cli/tui"
                     ]
                   },

--- a/docs/plan/runners.md
+++ b/docs/plan/runners.md
@@ -13,18 +13,18 @@ Proposal, revision 1. Implementation in progress (autonomous build started
 2026-08-08; this section tracks live status — update it in every PR that
 advances a milestone).
 
-| #   | Milestone                                            | Status      | PRs |
-| --- | ---------------------------------------------------- | ----------- | --- |
-| 0   | This plan                                            | in review   | —   |
-| 1a  | Naming: session copy revert                          | not started | —   |
-| 1b  | Naming: devices consolidation                        | not started | —   |
-| 1c  | Cleanup: node-pairing → device-pairing merge         | not started | —   |
-| 2   | `openclaw resume` + web Continue in terminal         | not started | —   |
-| 3   | `oc-pair://` one-paste pairing                       | not started | —   |
-| 4   | Picker + enrichment + projects read model            | not started | —   |
-| 5   | Device runners                                       | not started | —   |
-| 6   | Stop-and-continue moves                              | not started | —   |
-| 7   | Deletions (ssh sandbox, openshell, exec-host clones) | not started | —   |
+| #   | Milestone                                            | Status      | PRs     |
+| --- | ---------------------------------------------------- | ----------- | ------- |
+| 0   | This plan                                            | landed      | —       |
+| 1a  | Naming: session copy revert                          | landed      | #120667 |
+| 1b  | Naming: devices consolidation                        | landed      | #120689 |
+| 1c  | Cleanup: node-pairing → device-pairing merge         | not started | —       |
+| 2   | `openclaw resume` + web Continue in terminal         | in progress | #120664 |
+| 3   | `oc-pair://` one-paste pairing                       | not started | —       |
+| 4   | Picker + enrichment + projects read model            | not started | —       |
+| 5   | Device runners                                       | not started | —       |
+| 6   | Stop-and-continue moves                              | not started | —       |
+| 7   | Deletions (ssh sandbox, openshell, exec-host clones) | not started | —       |
 
 Proposal history: direction agreed 2026-08-08 after a
 code-evidence investigation (three deep-reads of the worker, exec, and node
@@ -162,6 +162,8 @@ Delta is ergonomics only:
   Codex/Claude session catalogs already have.
 - No new protocol surface; `sessions.list` already carries what the resolver
   needs.
+
+Follow-up: boundary-level resume test (gateway → session list → attach) needs a lightweight CLI-side gateway harness; the existing helper costs ~370s under the CLI vitest config.
 
 ### 2. One-paste device pairing (independent)
 

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -482,6 +482,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   { commandPath: ["secrets"], policy: { configGuard: "skip", networkProxy: "bypass" } },
   { commandPath: ["security"], policy: { networkProxy: "bypass" } },
   { commandPath: ["system"], policy: { networkProxy: "bypass" } },
+  { commandPath: ["resume"], policy: { networkProxy: "bypass" } },
   { commandPath: ["terminal"], policy: { networkProxy: "bypass" } },
   { commandPath: ["tui"], policy: { networkProxy: "bypass" } },
   { commandPath: ["uninstall"], policy: { networkProxy: "bypass" } },

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -195,6 +195,11 @@ const entrySpecs: readonly CommandGroupDescriptorSpec<SubCliRegistrar>[] = [
       exportName: "registerTuiCli",
     },
     {
+      commandNames: ["resume"],
+      loadModule: () => import("../resume-cli.js"),
+      exportName: "registerResumeCli",
+    },
+    {
       // automations is a commander alias on the cron command; the lazy
       // router only routes names listed here, so the alias must be owned too.
       commandNames: ["cron", "automations"],

--- a/src/cli/program/register.subclis.test.ts
+++ b/src/cli/program/register.subclis.test.ts
@@ -59,6 +59,15 @@ const { registerPluginsCli, registerPluginCliCommandsFromValidatedConfig } = vi.
 const { registerChannelsCli } = vi.hoisted(() => ({
   registerChannelsCli: vi.fn(async () => undefined),
 }));
+const { registerResumeCli, resumeAction } = vi.hoisted(() => {
+  const action = vi.fn();
+  return {
+    registerResumeCli: vi.fn((program: Command) => {
+      program.command("resume").action(action);
+    }),
+    resumeAction: action,
+  };
+});
 const { addGatewayRunCommand, gatewayRunAction, registerGatewayCli } = vi.hoisted(() => {
   const runAction = vi.fn();
   return {
@@ -83,6 +92,7 @@ vi.mock("../capability-cli.js", () => ({ registerCapabilityCli }));
 vi.mock("../exec-approvals-cli.js", () => ({ registerExecApprovalsCli }));
 vi.mock("../plugins-cli.js", () => ({ registerPluginsCli }));
 vi.mock("../channels-cli.js", () => ({ registerChannelsCli }));
+vi.mock("../resume-cli.js", () => ({ registerResumeCli }));
 vi.mock("../../plugins/cli.js", () => ({ registerPluginCliCommandsFromValidatedConfig }));
 vi.mock("./private-qa-cli.js", async () => {
   const actual = await vi.importActual<typeof import("./private-qa-cli.js")>("./private-qa-cli.js");
@@ -127,6 +137,8 @@ describe("registerSubCliCommands", () => {
     registerPluginsCli.mockClear();
     registerPluginCliCommandsFromValidatedConfig.mockClear();
     registerChannelsCli.mockClear();
+    registerResumeCli.mockClear();
+    resumeAction.mockClear();
     addGatewayRunCommand.mockClear();
     gatewayRunAction.mockClear();
     registerGatewayCli.mockClear();
@@ -202,6 +214,17 @@ describe("registerSubCliCommands", () => {
 
     expect(registerCapabilityCli).toHaveBeenCalledTimes(1);
     expect(inferAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers the resume placeholder and dispatches through its lazy registrar", async () => {
+    const program = createRegisteredProgram(["node", "openclaw", "resume"], "openclaw");
+
+    expect(program.commands.map((cmd) => cmd.name())).toEqual(["resume", "completion"]);
+
+    await program.parseAsync(["resume"], { from: "user" });
+
+    expect(registerResumeCli).toHaveBeenCalledTimes(1);
+    expect(resumeAction).toHaveBeenCalledTimes(1);
   });
 
   it("registers the exec-approvals placeholder and dispatches through the approvals registrar", async () => {

--- a/src/cli/program/root-command-descriptions.test.ts
+++ b/src/cli/program/root-command-descriptions.test.ts
@@ -111,6 +111,7 @@ const JSON_NOT_APPLICABLE = {
       "mcp login",
       "attach",
       "tui",
+      "resume",
       "update wizard",
     ],
   },

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -127,6 +127,11 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
     hasSubcommands: false,
   },
   {
+    name: "resume",
+    description: "Resume a recent Gateway session in the TUI",
+    hasSubcommands: false,
+  },
+  {
     name: "terminal",
     description: "Open a local terminal UI (alias for tui --local)",
     hasSubcommands: false,

--- a/src/cli/resume-cli.runtime.ts
+++ b/src/cli/resume-cli.runtime.ts
@@ -47,11 +47,16 @@ async function fetchResumeSessions(opts: ResumeCliOptions) {
       import("../tui/tui-formatters.js"),
       import("../tui/tui.js"),
     ]);
-    const state = resolveGatewayDisconnectState(formatTuiErrorMessage(error));
+    const details =
+      error && typeof error === "object" && "details" in error ? error.details : undefined;
+    const state = resolveGatewayDisconnectState({
+      reason: formatTuiErrorMessage(error),
+      details,
+    });
     throw new Error(
       [
         state.connectionStatus,
-        state.pairingHint ??
+        state.remediation ??
           "Ensure the Gateway is running and your --url/--token/--password are correct.",
       ].join("\n"),
       { cause: error },

--- a/src/cli/resume-cli.runtime.ts
+++ b/src/cli/resume-cli.runtime.ts
@@ -2,6 +2,7 @@
 import { cancel, isCancel } from "@clack/prompts";
 import { selectStyled } from "../../packages/terminal-core/src/prompt-select-styled.js";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import type { TuiSessionList } from "../tui/tui-backend.js";
 import {
@@ -41,7 +42,7 @@ async function fetchResumeSessions(opts: ResumeCliOptions) {
         finish(() => reject(new Error(reason || "Gateway connection closed")));
       client.start();
     });
-    return await loadRecentSessions(client, { includeGlobal: true });
+    return await loadRecentSessions(client);
   } catch (error) {
     const [{ formatTuiErrorMessage }, { resolveGatewayDisconnectState }] = await Promise.all([
       import("../tui/tui-formatters.js"),
@@ -114,13 +115,21 @@ function formatResumeCandidate(candidate: SessionPickerChoice): string {
   return label === key ? key : `${label} [${key}]`;
 }
 
+function resolveExplicitGlobalSessionKey(query: string | undefined): string | undefined {
+  const parsed = parseAgentSessionKey(query);
+  return parsed?.rest === "global" ? `agent:${parsed.agentId}:global` : undefined;
+}
+
 /** Resolve or select one session and run the existing Gateway-backed TUI. */
 export async function runResumeCommand(query: string | undefined, opts: ResumeCliOptions) {
   requireInteractiveResumeTerminal();
   const trimmedQuery = query?.trim();
-  const sessions = await fetchResumeSessions(opts);
+  const explicitGlobalSessionKey = resolveExplicitGlobalSessionKey(trimmedQuery);
+  const sessions = explicitGlobalSessionKey ? [] : await fetchResumeSessions(opts);
   let sessionKey: string | null;
-  if (trimmedQuery) {
+  if (explicitGlobalSessionKey) {
+    sessionKey = explicitGlobalSessionKey;
+  } else if (trimmedQuery) {
     const resolution = resolveResumeSession(sessions, trimmedQuery);
     if (resolution.kind !== "match") {
       reportResumeFailure(trimmedQuery, resolution);

--- a/src/cli/resume-cli.runtime.ts
+++ b/src/cli/resume-cli.runtime.ts
@@ -14,7 +14,7 @@ import {
 import type { ResumeCliOptions } from "./resume-cli.js";
 
 const RESUME_INTERACTIVE_TERMINAL_GUIDANCE =
-  "Session selection requires an interactive terminal. Pass a session key or name: `openclaw resume <query>`.";
+  "Attaching to a session requires an interactive terminal. Re-run `openclaw resume [query]` from an interactive terminal.";
 
 function requireInteractiveResumeTerminal() {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
@@ -70,7 +70,6 @@ async function promptResumeSession(
       "No recent sessions found. Run `openclaw sessions` to inspect sessions or `openclaw tui` to start one.",
     );
   }
-  requireInteractiveResumeTerminal();
   const selected = await selectStyled({
     message: "Resume a session",
     options: choices.map((choice) => ({
@@ -112,10 +111,8 @@ function formatResumeCandidate(candidate: SessionPickerChoice): string {
 
 /** Resolve or select one session and run the existing Gateway-backed TUI. */
 export async function runResumeCommand(query: string | undefined, opts: ResumeCliOptions) {
+  requireInteractiveResumeTerminal();
   const trimmedQuery = query?.trim();
-  if (!trimmedQuery) {
-    requireInteractiveResumeTerminal();
-  }
   const sessions = await fetchResumeSessions(opts);
   let sessionKey: string | null;
   if (trimmedQuery) {

--- a/src/cli/resume-cli.runtime.ts
+++ b/src/cli/resume-cli.runtime.ts
@@ -23,7 +23,10 @@ function requireInteractiveResumeTerminal() {
   }
 }
 
-async function fetchResumeSessions(opts: ResumeCliOptions) {
+async function fetchResumeSessions(
+  opts: ResumeCliOptions,
+  options: { agentId?: string; includeGlobal?: boolean } = {},
+) {
   const { GatewayChatClient } = await import("../tui/gateway-chat.js");
   const client = await GatewayChatClient.connect(opts);
   try {
@@ -42,7 +45,7 @@ async function fetchResumeSessions(opts: ResumeCliOptions) {
         finish(() => reject(new Error(reason || "Gateway connection closed")));
       client.start();
     });
-    return await loadRecentSessions(client);
+    return await loadRecentSessions(client, options);
   } catch (error) {
     const [{ formatTuiErrorMessage }, { resolveGatewayDisconnectState }] = await Promise.all([
       import("../tui/tui-formatters.js"),
@@ -115,20 +118,29 @@ function formatResumeCandidate(candidate: SessionPickerChoice): string {
   return label === key ? key : `${label} [${key}]`;
 }
 
-function resolveExplicitGlobalSessionKey(query: string | undefined): string | undefined {
+function resolveExplicitGlobalSessionKey(
+  query: string | undefined,
+): { agentId: string; key: string } | undefined {
   const parsed = parseAgentSessionKey(query);
-  return parsed?.rest === "global" ? `agent:${parsed.agentId}:global` : undefined;
+  return parsed?.rest === "global"
+    ? { agentId: parsed.agentId, key: `agent:${parsed.agentId}:global` }
+    : undefined;
 }
 
 /** Resolve or select one session and run the existing Gateway-backed TUI. */
 export async function runResumeCommand(query: string | undefined, opts: ResumeCliOptions) {
   requireInteractiveResumeTerminal();
   const trimmedQuery = query?.trim();
-  const explicitGlobalSessionKey = resolveExplicitGlobalSessionKey(trimmedQuery);
-  const sessions = explicitGlobalSessionKey ? [] : await fetchResumeSessions(opts);
+  const explicitGlobalSession = resolveExplicitGlobalSessionKey(trimmedQuery);
+  const sessions = await fetchResumeSessions(
+    opts,
+    explicitGlobalSession
+      ? { agentId: explicitGlobalSession.agentId, includeGlobal: true }
+      : undefined,
+  );
   let sessionKey: string | null;
-  if (explicitGlobalSessionKey) {
-    sessionKey = explicitGlobalSessionKey;
+  if (explicitGlobalSession) {
+    sessionKey = explicitGlobalSession.key;
   } else if (trimmedQuery) {
     const resolution = resolveResumeSession(sessions, trimmedQuery);
     if (resolution.kind !== "match") {

--- a/src/cli/resume-cli.runtime.ts
+++ b/src/cli/resume-cli.runtime.ts
@@ -1,0 +1,136 @@
+// Resolves recent Gateway sessions and attaches the existing TUI to the selected key.
+import { cancel, isCancel } from "@clack/prompts";
+import { selectStyled } from "../../packages/terminal-core/src/prompt-select-styled.js";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import { defaultRuntime } from "../runtime.js";
+import type { TuiSessionList } from "../tui/tui-backend.js";
+import {
+  buildSessionChoices,
+  loadRecentSessions,
+  resolveResumeSession,
+  type ResumeResolution,
+  type SessionPickerChoice,
+} from "../tui/tui-session-picker.js";
+import type { ResumeCliOptions } from "./resume-cli.js";
+
+async function fetchResumeSessions(opts: ResumeCliOptions) {
+  const { GatewayChatClient } = await import("../tui/gateway-chat.js");
+  const client = await GatewayChatClient.connect(opts);
+  try {
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const finish = (complete: () => void) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        complete();
+      };
+      client.onConnected = () => finish(resolve);
+      client.onConnectError = (error) => finish(() => reject(error));
+      client.onDisconnected = (reason) =>
+        finish(() => reject(new Error(reason || "Gateway connection closed")));
+      client.start();
+    });
+    return await loadRecentSessions(client);
+  } catch (error) {
+    const [{ formatTuiErrorMessage }, { resolveGatewayDisconnectState }] = await Promise.all([
+      import("../tui/tui-formatters.js"),
+      import("../tui/tui.js"),
+    ]);
+    const state = resolveGatewayDisconnectState(formatTuiErrorMessage(error));
+    throw new Error(
+      [
+        state.connectionStatus,
+        state.pairingHint ??
+          "Ensure the Gateway is running and your --url/--token/--password are correct.",
+      ].join("\n"),
+      { cause: error },
+    );
+  } finally {
+    await client.stop();
+  }
+}
+
+async function promptResumeSession(
+  sessions: readonly TuiSessionList["sessions"][number][],
+): Promise<string | null> {
+  const choices = buildSessionChoices(sessions);
+  if (choices.length === 0) {
+    throw new Error(
+      "No recent sessions found. Run `openclaw sessions` to inspect sessions or `openclaw tui` to start one.",
+    );
+  }
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error(
+      "Session selection requires an interactive terminal. Pass a session key or name: `openclaw resume <query>`.",
+    );
+  }
+  const selected = await selectStyled({
+    message: "Resume a session",
+    options: choices.map((choice) => ({
+      value: choice.value,
+      label: formatResumeCandidate(choice),
+      hint: choice.description ? sanitizeTerminalText(choice.description) : undefined,
+    })),
+  });
+  if (isCancel(selected)) {
+    cancel("Cancelled.");
+    return null;
+  }
+  return selected;
+}
+
+function reportResumeFailure(
+  query: string,
+  resolution: Exclude<ResumeResolution, { kind: "match" }>,
+) {
+  if (resolution.kind === "ambiguous") {
+    defaultRuntime.error(`Session query ${JSON.stringify(query)} is ambiguous. Candidates:`);
+    for (const candidate of resolution.candidates) {
+      defaultRuntime.error(`  ${formatResumeCandidate(candidate)}`);
+    }
+    defaultRuntime.error("Use a longer name or the exact session key.");
+    return;
+  }
+  defaultRuntime.error(`No recent session matched ${JSON.stringify(query)}.`);
+  defaultRuntime.error(
+    "Run `openclaw resume` to choose from recent sessions or `openclaw sessions` to inspect all sessions.",
+  );
+}
+
+function formatResumeCandidate(candidate: SessionPickerChoice): string {
+  const label = sanitizeTerminalText(candidate.label);
+  const key = sanitizeTerminalText(candidate.value);
+  return label === key ? key : `${label} [${key}]`;
+}
+
+/** Resolve or select one session and run the existing Gateway-backed TUI. */
+export async function runResumeCommand(query: string | undefined, opts: ResumeCliOptions) {
+  const sessions = await fetchResumeSessions(opts);
+  const trimmedQuery = query?.trim();
+  let sessionKey: string | null;
+  if (trimmedQuery) {
+    const resolution = resolveResumeSession(sessions, trimmedQuery);
+    if (resolution.kind !== "match") {
+      reportResumeFailure(trimmedQuery, resolution);
+      defaultRuntime.exit(1);
+      return;
+    }
+    sessionKey = resolution.session.value;
+  } else {
+    sessionKey = await promptResumeSession(sessions);
+  }
+  if (!sessionKey) {
+    return;
+  }
+  const { runTui } = await import("../tui/tui.js");
+  await runTui({
+    url: opts.url,
+    token: opts.token,
+    password: opts.password,
+    tlsFingerprint: opts.tlsFingerprint,
+    session: sessionKey,
+    forceProcessExitOnReturn: true,
+  });
+}

--- a/src/cli/resume-cli.runtime.ts
+++ b/src/cli/resume-cli.runtime.ts
@@ -13,6 +13,15 @@ import {
 } from "../tui/tui-session-picker.js";
 import type { ResumeCliOptions } from "./resume-cli.js";
 
+const RESUME_INTERACTIVE_TERMINAL_GUIDANCE =
+  "Session selection requires an interactive terminal. Pass a session key or name: `openclaw resume <query>`.";
+
+function requireInteractiveResumeTerminal() {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error(RESUME_INTERACTIVE_TERMINAL_GUIDANCE);
+  }
+}
+
 async function fetchResumeSessions(opts: ResumeCliOptions) {
   const { GatewayChatClient } = await import("../tui/gateway-chat.js");
   const client = await GatewayChatClient.connect(opts);
@@ -32,7 +41,7 @@ async function fetchResumeSessions(opts: ResumeCliOptions) {
         finish(() => reject(new Error(reason || "Gateway connection closed")));
       client.start();
     });
-    return await loadRecentSessions(client);
+    return await loadRecentSessions(client, { includeGlobal: true });
   } catch (error) {
     const [{ formatTuiErrorMessage }, { resolveGatewayDisconnectState }] = await Promise.all([
       import("../tui/tui-formatters.js"),
@@ -61,11 +70,7 @@ async function promptResumeSession(
       "No recent sessions found. Run `openclaw sessions` to inspect sessions or `openclaw tui` to start one.",
     );
   }
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    throw new Error(
-      "Session selection requires an interactive terminal. Pass a session key or name: `openclaw resume <query>`.",
-    );
-  }
+  requireInteractiveResumeTerminal();
   const selected = await selectStyled({
     message: "Resume a session",
     options: choices.map((choice) => ({
@@ -107,8 +112,11 @@ function formatResumeCandidate(candidate: SessionPickerChoice): string {
 
 /** Resolve or select one session and run the existing Gateway-backed TUI. */
 export async function runResumeCommand(query: string | undefined, opts: ResumeCliOptions) {
-  const sessions = await fetchResumeSessions(opts);
   const trimmedQuery = query?.trim();
+  if (!trimmedQuery) {
+    requireInteractiveResumeTerminal();
+  }
+  const sessions = await fetchResumeSessions(opts);
   let sessionKey: string | null;
   if (trimmedQuery) {
     const resolution = resolveResumeSession(sessions, trimmedQuery);

--- a/src/cli/resume-cli.test.ts
+++ b/src/cli/resume-cli.test.ts
@@ -1,6 +1,26 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TuiSessionList } from "../tui/tui-backend.js";
 import { resolveResumeSession } from "../tui/tui-session-picker.js";
+import { runResumeCommand } from "./resume-cli.runtime.js";
+
+const gatewayMocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  runTui: vi.fn(),
+  selectStyled: vi.fn(),
+}));
+
+vi.mock("../../packages/terminal-core/src/prompt-select-styled.js", () => ({
+  selectStyled: gatewayMocks.selectStyled,
+}));
+
+vi.mock("../tui/gateway-chat.js", () => ({
+  GatewayChatClient: { connect: gatewayMocks.connect },
+}));
+
+vi.mock("../tui/tui.js", () => ({
+  resolveGatewayDisconnectState: vi.fn(),
+  runTui: gatewayMocks.runTui,
+}));
 
 type SessionRow = TuiSessionList["sessions"][number];
 
@@ -9,6 +29,44 @@ const sessions: SessionRow[] = [
   { key: "agent:work:beta", displayName: "Beta implementation", label: "checkout" },
   { key: "agent:work:gamma", displayName: "Gamma review", label: "checklist" },
 ];
+
+const stdinTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+const stdoutTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+
+function restoreTty(
+  stream: NodeJS.ReadStream | NodeJS.WriteStream,
+  descriptor: PropertyDescriptor | undefined,
+) {
+  if (descriptor) {
+    Object.defineProperty(stream, "isTTY", descriptor);
+  } else {
+    Reflect.deleteProperty(stream, "isTTY");
+  }
+}
+
+function createGatewayClient(rows: SessionRow[]) {
+  const client = {
+    listSessions: vi.fn().mockResolvedValue({ sessions: rows }),
+    onConnected: undefined as (() => void) | undefined,
+    onConnectError: undefined as ((error: Error) => void) | undefined,
+    onDisconnected: undefined as ((reason: string) => void) | undefined,
+    start: vi.fn(() => client.onConnected?.()),
+    stop: vi.fn().mockResolvedValue(undefined),
+  };
+  gatewayMocks.connect.mockResolvedValue(client);
+  return client;
+}
+
+beforeEach(() => {
+  gatewayMocks.connect.mockReset();
+  gatewayMocks.runTui.mockReset().mockResolvedValue(undefined);
+  gatewayMocks.selectStyled.mockReset();
+});
+
+afterEach(() => {
+  restoreTty(process.stdin, stdinTtyDescriptor);
+  restoreTty(process.stdout, stdoutTtyDescriptor);
+});
 
 describe("resolveResumeSession", () => {
   it.each([
@@ -65,5 +123,51 @@ describe("resolveResumeSession", () => {
       return;
     }
     expect(result).toEqual(expected);
+  });
+});
+
+describe("runResumeCommand", () => {
+  it("resolves the global session row", async () => {
+    const client = createGatewayClient([{ key: "global", displayName: "global" }]);
+
+    await runResumeCommand("global", {});
+
+    expect(client.listSessions).toHaveBeenCalledWith(
+      expect.objectContaining({ includeGlobal: true }),
+    );
+    expect(gatewayMocks.runTui).toHaveBeenCalledWith(
+      expect.objectContaining({ session: "global", forceProcessExitOnReturn: true }),
+    );
+  });
+
+  it("offers the global session in the interactive picker", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+    const client = createGatewayClient([{ key: "global", displayName: "global" }]);
+    gatewayMocks.selectStyled.mockResolvedValue("global");
+
+    await runResumeCommand(undefined, {});
+
+    expect(client.listSessions).toHaveBeenCalledWith(
+      expect.objectContaining({ includeGlobal: true }),
+    );
+    expect(gatewayMocks.selectStyled).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: [expect.objectContaining({ value: "global" })],
+      }),
+    );
+    expect(gatewayMocks.runTui).toHaveBeenCalledWith(
+      expect.objectContaining({ session: "global", forceProcessExitOnReturn: true }),
+    );
+  });
+
+  it("rejects a non-interactive picker before connecting", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: false });
+
+    await expect(runResumeCommand(undefined, {})).rejects.toThrow(
+      "Session selection requires an interactive terminal. Pass a session key or name: `openclaw resume <query>`.",
+    );
+    expect(gatewayMocks.connect).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/resume-cli.test.ts
+++ b/src/cli/resume-cli.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { TuiSessionList } from "../tui/tui-backend.js";
+import { resolveResumeSession } from "../tui/tui-session-picker.js";
+
+type SessionRow = TuiSessionList["sessions"][number];
+
+const sessions: SessionRow[] = [
+  { key: "agent:main:alpha", displayName: "Alpha planning", label: "roadmap" },
+  { key: "agent:work:beta", displayName: "Beta implementation", label: "checkout" },
+  { key: "agent:work:gamma", displayName: "Gamma review", label: "checklist" },
+];
+
+describe("resolveResumeSession", () => {
+  it.each([
+    {
+      name: "exact key wins over another session name",
+      query: "agent:main:alpha",
+      rows: [...sessions, { key: "agent:other:delta", displayName: "agent:main:alpha" }],
+      expected: { kind: "match", key: "agent:main:alpha" },
+    },
+    {
+      name: "unique key substring",
+      query: "work:beta",
+      rows: sessions,
+      expected: { kind: "match", key: "agent:work:beta" },
+    },
+    {
+      name: "unique display-name substring",
+      query: "implementation",
+      rows: sessions,
+      expected: { kind: "match", key: "agent:work:beta" },
+    },
+    {
+      name: "unique fuzzy display-name match",
+      query: "bt impl",
+      rows: sessions,
+      expected: { kind: "match", key: "agent:work:beta" },
+    },
+    {
+      name: "ambiguous label substring",
+      query: "check",
+      rows: sessions,
+      expected: {
+        kind: "ambiguous",
+        keys: ["agent:work:beta", "agent:work:gamma"],
+      },
+    },
+    {
+      name: "no match",
+      query: "unrelated-session-name",
+      rows: sessions,
+      expected: { kind: "none" },
+    },
+  ])("resolves $name", ({ query, rows, expected }) => {
+    const result = resolveResumeSession(rows, query);
+    if (result.kind === "match") {
+      expect({ kind: result.kind, key: result.session.value }).toEqual(expected);
+      return;
+    }
+    if (result.kind === "ambiguous") {
+      expect({
+        kind: result.kind,
+        keys: result.candidates.map((candidate) => candidate.value),
+      }).toEqual(expected);
+      return;
+    }
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/cli/resume-cli.test.ts
+++ b/src/cli/resume-cli.test.ts
@@ -128,6 +128,8 @@ describe("resolveResumeSession", () => {
 
 describe("runResumeCommand", () => {
   it("resolves the global session row", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
     const client = createGatewayClient([{ key: "global", displayName: "global" }]);
 
     await runResumeCommand("global", {});
@@ -161,13 +163,14 @@ describe("runResumeCommand", () => {
     );
   });
 
-  it("rejects a non-interactive picker before connecting", async () => {
+  it("rejects a non-interactive queried resume before connecting or launching the TUI", async () => {
     Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
     Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: false });
 
-    await expect(runResumeCommand(undefined, {})).rejects.toThrow(
-      "Session selection requires an interactive terminal. Pass a session key or name: `openclaw resume <query>`.",
+    await expect(runResumeCommand("global", {})).rejects.toThrow(
+      "Attaching to a session requires an interactive terminal. Re-run `openclaw resume [query]` from an interactive terminal.",
     );
     expect(gatewayMocks.connect).not.toHaveBeenCalled();
+    expect(gatewayMocks.runTui).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/resume-cli.test.ts
+++ b/src/cli/resume-cli.test.ts
@@ -9,6 +9,11 @@ const gatewayMocks = vi.hoisted(() => ({
   selectStyled: vi.fn(),
 }));
 
+const runtimeMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  exit: vi.fn(),
+}));
+
 vi.mock("../../packages/terminal-core/src/prompt-select-styled.js", () => ({
   selectStyled: gatewayMocks.selectStyled,
 }));
@@ -20,6 +25,10 @@ vi.mock("../tui/gateway-chat.js", () => ({
 vi.mock("../tui/tui.js", () => ({
   resolveGatewayDisconnectState: vi.fn(),
   runTui: gatewayMocks.runTui,
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: runtimeMocks,
 }));
 
 type SessionRow = TuiSessionList["sessions"][number];
@@ -61,6 +70,8 @@ beforeEach(() => {
   gatewayMocks.connect.mockReset();
   gatewayMocks.runTui.mockReset().mockResolvedValue(undefined);
   gatewayMocks.selectStyled.mockReset();
+  runtimeMocks.error.mockReset();
+  runtimeMocks.exit.mockReset();
 });
 
 afterEach(() => {
@@ -127,39 +138,58 @@ describe("resolveResumeSession", () => {
 });
 
 describe("runResumeCommand", () => {
-  it("resolves the global session row", async () => {
+  it("excludes the bare global session from query resolution", async () => {
     Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
     Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
-    const client = createGatewayClient([{ key: "global", displayName: "global" }]);
+    const client = createGatewayClient([]);
 
     await runResumeCommand("global", {});
 
     expect(client.listSessions).toHaveBeenCalledWith(
-      expect.objectContaining({ includeGlobal: true }),
+      expect.objectContaining({ includeGlobal: false }),
     );
-    expect(gatewayMocks.runTui).toHaveBeenCalledWith(
-      expect.objectContaining({ session: "global", forceProcessExitOnReturn: true }),
-    );
+    expect(runtimeMocks.exit).toHaveBeenCalledWith(1);
+    expect(gatewayMocks.runTui).not.toHaveBeenCalled();
   });
 
-  it("offers the global session in the interactive picker", async () => {
+  it("omits the bare global session from the interactive picker", async () => {
     Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
     Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
-    const client = createGatewayClient([{ key: "global", displayName: "global" }]);
-    gatewayMocks.selectStyled.mockResolvedValue("global");
+    const client = createGatewayClient([
+      { key: "agent:main:alpha", displayName: "Alpha planning", label: "roadmap" },
+    ]);
+    gatewayMocks.selectStyled.mockResolvedValue("agent:main:alpha");
 
     await runResumeCommand(undefined, {});
 
     expect(client.listSessions).toHaveBeenCalledWith(
-      expect.objectContaining({ includeGlobal: true }),
+      expect.objectContaining({ includeGlobal: false }),
     );
     expect(gatewayMocks.selectStyled).toHaveBeenCalledWith(
       expect.objectContaining({
-        options: [expect.objectContaining({ value: "global" })],
+        options: [expect.objectContaining({ value: "agent:main:alpha" })],
       }),
     );
     expect(gatewayMocks.runTui).toHaveBeenCalledWith(
-      expect.objectContaining({ session: "global", forceProcessExitOnReturn: true }),
+      expect.objectContaining({
+        session: "agent:main:alpha",
+        forceProcessExitOnReturn: true,
+      }),
+    );
+  });
+
+  it("preserves an explicitly agent-qualified global session", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+
+    await runResumeCommand("AGENT:Work:GLOBAL", {});
+
+    expect(gatewayMocks.connect).not.toHaveBeenCalled();
+    expect(gatewayMocks.runTui).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: "agent:work:global",
+        forceProcessExitOnReturn: true,
+      }),
     );
   });
 

--- a/src/cli/resume-cli.test.ts
+++ b/src/cli/resume-cli.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseAgentSessionKey } from "../routing/session-key.js";
 import type { TuiSessionList } from "../tui/tui-backend.js";
 import { resolveResumeSession } from "../tui/tui-session-picker.js";
 import { runResumeCommand } from "./resume-cli.runtime.js";
@@ -181,16 +182,23 @@ describe("runResumeCommand", () => {
   it("preserves an explicitly agent-qualified global session", async () => {
     Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
     Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+    const client = createGatewayClient([{ key: "global", displayName: "global" }]);
 
-    await runResumeCommand("AGENT:Work:GLOBAL", {});
+    await runResumeCommand("agent:work:global", {});
 
-    expect(gatewayMocks.connect).not.toHaveBeenCalled();
+    expect(client.listSessions).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "work", includeGlobal: true }),
+    );
     expect(gatewayMocks.runTui).toHaveBeenCalledWith(
       expect.objectContaining({
         session: "agent:work:global",
         forceProcessExitOnReturn: true,
       }),
     );
+    expect(parseAgentSessionKey(gatewayMocks.runTui.mock.lastCall?.[0]?.session)).toEqual({
+      agentId: "work",
+      rest: "global",
+    });
   });
 
   it("rejects a non-interactive queried resume before connecting or launching the TUI", async () => {

--- a/src/cli/resume-cli.ts
+++ b/src/cli/resume-cli.ts
@@ -1,0 +1,36 @@
+// Registers the recent-session resume verb while keeping its TUI runtime lazy.
+import type { Command } from "commander";
+import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
+import { theme } from "../../packages/terminal-core/src/theme.js";
+import { defaultRuntime } from "../runtime.js";
+import { addTuiOptions } from "./tui-cli-options.js";
+
+export type ResumeCliOptions = {
+  url?: string;
+  token?: string;
+  password?: string;
+  tlsFingerprint?: string;
+};
+
+/** Register the Gateway-backed session resume command. */
+export function registerResumeCli(program: Command) {
+  const command = program
+    .command("resume")
+    .description("Resume a recent Gateway session in the TUI")
+    .argument("[query]", "Session key, display name, or label");
+  addTuiOptions(command)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/resume", "docs.openclaw.ai/cli/resume")}\n`,
+    )
+    .action(async (query: string | undefined, opts: ResumeCliOptions) => {
+      try {
+        const { runResumeCommand } = await import("./resume-cli.runtime.js");
+        await runResumeCommand(query, opts);
+      } catch (error) {
+        defaultRuntime.error(String(error));
+        defaultRuntime.exit(1);
+      }
+    });
+}

--- a/src/cli/tui-cli-options.ts
+++ b/src/cli/tui-cli-options.ts
@@ -1,0 +1,11 @@
+// Shared Gateway connection options for terminal attach commands.
+import type { Command } from "commander";
+
+/** Add the shared Gateway connection flags used by terminal attach commands. */
+export function addTuiOptions(command: Command): Command {
+  return command
+    .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
+    .option("--token <token>", "Gateway token (if required)")
+    .option("--password <password>", "Gateway password (if required)")
+    .option("--tls-fingerprint <sha256>", "Expected Gateway TLS certificate fingerprint");
+}

--- a/src/cli/tui-cli.ts
+++ b/src/cli/tui-cli.ts
@@ -6,19 +6,17 @@ import { theme } from "../../packages/terminal-core/src/theme.js";
 import { parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import { defaultRuntime } from "../runtime.js";
 import { parseTimeoutMs } from "./parse-timeout.js";
+import { addTuiOptions } from "./tui-cli-options.js";
 
 /** Attach the `tui` command plus its `terminal`/`chat` aliases to the root CLI. */
 export function registerTuiCli(program: Command) {
-  program
+  const command = program
     .command("tui")
     .alias("terminal")
     .alias("chat")
     .description("Open a terminal UI connected to the Gateway")
-    .option("--local", "Run against the local embedded agent runtime", false)
-    .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
-    .option("--token <token>", "Gateway token (if required)")
-    .option("--password <password>", "Gateway password (if required)")
-    .option("--tls-fingerprint <sha256>", "Expected Gateway TLS certificate fingerprint")
+    .option("--local", "Run against the local embedded agent runtime", false);
+  addTuiOptions(command)
     .option("--session <key>", 'Session key (default: "main", or "global" when scope is global)')
     .option("--deliver", "Deliver assistant replies", false)
     .option("--thinking <level>", "Thinking level override")

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -342,7 +342,7 @@ describe("tui command handlers", () => {
     ]);
   });
 
-  it("bounds session picker hydration to recent TUI sessions", async () => {
+  it("bounds Ctrl+P hydration to recent non-global TUI sessions", async () => {
     const listSessions = vi.fn().mockResolvedValue({
       sessions: [
         {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -14,7 +14,6 @@ import {
   resolveResponseUsageMode,
 } from "../auto-reply/thinking.js";
 import { isChatStopCommandText } from "../gateway/chat-abort.js";
-import { formatRelativeTimestamp } from "../infra/format-time/format-relative.ts";
 import { agentSessionKeysMatchByRequestKey, normalizeAgentId } from "../routing/session-key.js";
 import {
   formatTuiLevelCommandUsage,
@@ -33,10 +32,7 @@ import {
 import type { TuiBackend, TuiSessionMutationResult } from "./tui-backend.js";
 import { addBlockedChatSubmitNotice } from "./tui-busy-notice.js";
 import { formatTuiErrorMessage } from "./tui-formatters.js";
-import {
-  TUI_RECENT_SESSIONS_ACTIVE_MINUTES,
-  TUI_SESSION_PICKER_LIMIT,
-} from "./tui-session-list-policy.js";
+import { buildSessionChoices, loadRecentSessions } from "./tui-session-picker.js";
 import {
   readTuiSessionProjectionScope,
   reduceTuiSessionProjection,
@@ -135,7 +131,6 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     refreshAgents,
     abortActive,
     setActivityStatus,
-    formatSessionKey,
     applySessionInfoFromPatch,
     applySessionMutationResult,
     noteLocalRunId,
@@ -399,46 +394,11 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   const openSessionSelector = async () => {
     const selection = captureSessionSelection();
     try {
-      const result = await client.listSessions({
-        limit: TUI_SESSION_PICKER_LIMIT,
-        activeMinutes: TUI_RECENT_SESSIONS_ACTIVE_MINUTES,
-        includeGlobal: false,
-        includeUnknown: false,
-        includeDerivedTitles: true,
-        includeLastMessage: true,
-        agentId: selection.agentId,
-      });
+      const sessions = await loadRecentSessions(client, { agentId: selection.agentId });
       if (!isCurrentSessionSelection(selection)) {
         return;
       }
-      const items = result.sessions.map((session) => {
-        const title = session.derivedTitle ?? session.displayName;
-        const formattedKey = formatSessionKey(session.key);
-        // Avoid redundant "title (key)" when title matches key
-        const label = title && title !== formattedKey ? `${title} (${formattedKey})` : formattedKey;
-        // Build description: time + message preview
-        const timePart = session.updatedAt
-          ? formatRelativeTimestamp(session.updatedAt, { dateFallback: true, fallback: "" })
-          : "";
-        const preview = session.lastMessagePreview?.replace(/\s+/g, " ").trim();
-        const description =
-          timePart && preview ? `${timePart} · ${preview}` : (preview ?? timePart);
-        return {
-          value: session.key,
-          label,
-          description,
-          searchText: [
-            session.displayName,
-            session.label,
-            session.subject,
-            session.sessionId,
-            session.key,
-            session.lastMessagePreview,
-          ]
-            .filter(Boolean)
-            .join(" "),
-        };
-      });
+      const items = buildSessionChoices(sessions);
       const selector = createFilterableSelectList(items, 9);
       openSelector(selector, async (value) => {
         await setSession(value);

--- a/src/tui/tui-session-picker.ts
+++ b/src/tui/tui-session-picker.ts
@@ -1,0 +1,111 @@
+// Shared recent-session query and presentation used by the TUI and CLI resume picker.
+import { fuzzyFilter } from "@earendil-works/pi-tui";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { formatRelativeTimestamp } from "../infra/format-time/format-relative.ts";
+import { parseAgentSessionKey } from "../routing/session-key.js";
+import type { TuiBackend, TuiSessionList } from "./tui-backend.js";
+import {
+  TUI_RECENT_SESSIONS_ACTIVE_MINUTES,
+  TUI_SESSION_PICKER_LIMIT,
+} from "./tui-session-list-policy.js";
+
+type TuiSessionEntry = TuiSessionList["sessions"][number];
+
+/** One recent session rendered consistently across interactive pickers. */
+export type SessionPickerChoice = {
+  value: string;
+  label: string;
+  description: string;
+  searchText: string;
+  matchText: string;
+};
+
+export type ResumeResolution =
+  | { kind: "match"; session: SessionPickerChoice }
+  | { kind: "ambiguous"; candidates: SessionPickerChoice[] }
+  | { kind: "none" };
+
+/** Load the same bounded recent-session window used by the TUI Ctrl+P picker. */
+export async function loadRecentSessions(
+  client: Pick<TuiBackend, "listSessions">,
+  options: { agentId?: string } = {},
+): Promise<TuiSessionEntry[]> {
+  const result = await client.listSessions({
+    limit: TUI_SESSION_PICKER_LIMIT,
+    activeMinutes: TUI_RECENT_SESSIONS_ACTIVE_MINUTES,
+    includeGlobal: false,
+    includeUnknown: false,
+    includeDerivedTitles: true,
+    includeLastMessage: true,
+    ...(options.agentId ? { agentId: options.agentId } : {}),
+  });
+  return result.sessions;
+}
+
+/** Build labels and matching text for recent-session pickers. */
+export function buildSessionChoices(sessions: readonly TuiSessionEntry[]): SessionPickerChoice[] {
+  return sessions.map((session) => {
+    const title = session.derivedTitle ?? session.displayName;
+    const formattedKey = formatSessionKey(session.key);
+    const label = title && title !== formattedKey ? `${title} (${formattedKey})` : formattedKey;
+    const timePart = session.updatedAt
+      ? formatRelativeTimestamp(session.updatedAt, { dateFallback: true, fallback: "" })
+      : "";
+    const preview = session.lastMessagePreview?.replace(/\s+/g, " ").trim();
+    const description = timePart && preview ? `${timePart} · ${preview}` : (preview ?? timePart);
+    const searchableNames = [
+      session.derivedTitle,
+      session.displayName,
+      session.label,
+      session.subject,
+      session.sessionId,
+      session.key,
+    ].filter((value): value is string => Boolean(value));
+    return {
+      value: session.key,
+      label,
+      description,
+      searchText: [...searchableNames, session.lastMessagePreview].filter(Boolean).join(" "),
+      matchText: searchableNames.join(" "),
+    };
+  });
+}
+
+/** Resolve a recent session by exact key, unique substring, then TUI-style fuzzy matching. */
+export function resolveResumeSession(
+  sessions: readonly TuiSessionEntry[],
+  query: string,
+): ResumeResolution {
+  const trimmedQuery = query.trim();
+  const normalizedQuery = normalizeLowercaseStringOrEmpty(trimmedQuery);
+  const choices = buildSessionChoices(sessions);
+  const exact = choices.find((choice) => choice.value === trimmedQuery);
+  if (exact) {
+    return { kind: "match", session: exact };
+  }
+
+  const substringMatches = choices.filter((choice) =>
+    normalizeLowercaseStringOrEmpty(choice.matchText).includes(normalizedQuery),
+  );
+  const substringMatch = substringMatches[0];
+  if (substringMatches.length === 1 && substringMatch) {
+    return { kind: "match", session: substringMatch };
+  }
+  if (substringMatches.length > 1) {
+    return { kind: "ambiguous", candidates: substringMatches };
+  }
+
+  const fuzzyMatches = fuzzyFilter(choices, trimmedQuery, (choice) => choice.matchText);
+  const fuzzyMatch = fuzzyMatches[0];
+  if (fuzzyMatches.length === 1 && fuzzyMatch) {
+    return { kind: "match", session: fuzzyMatch };
+  }
+  if (fuzzyMatches.length > 1) {
+    return { kind: "ambiguous", candidates: fuzzyMatches };
+  }
+  return { kind: "none" };
+}
+
+function formatSessionKey(key: string): string {
+  return parseAgentSessionKey(key)?.rest ?? key;
+}

--- a/src/tui/tui-session-picker.ts
+++ b/src/tui/tui-session-picker.ts
@@ -28,12 +28,12 @@ export type ResumeResolution =
 /** Load the same bounded recent-session window used by the TUI Ctrl+P picker. */
 export async function loadRecentSessions(
   client: Pick<TuiBackend, "listSessions">,
-  options: { agentId?: string } = {},
+  options: { agentId?: string; includeGlobal?: boolean } = {},
 ): Promise<TuiSessionEntry[]> {
   const result = await client.listSessions({
     limit: TUI_SESSION_PICKER_LIMIT,
     activeMinutes: TUI_RECENT_SESSIONS_ACTIVE_MINUTES,
-    includeGlobal: false,
+    includeGlobal: options.includeGlobal ?? false,
     includeUnknown: false,
     includeDerivedTitles: true,
     includeLastMessage: true,

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -224,6 +224,17 @@ describe("resolveTuiSessionKey", () => {
     ).toBe("agent:ops:incident");
   });
 
+  it("unwraps an agent-qualified global key after agent selection", () => {
+    expect(
+      resolveTuiSessionKey({
+        raw: "AGENT:Work:GLOBAL",
+        sessionScope: "per-sender",
+        currentAgentId: "work",
+        sessionMainKey: "main",
+      }),
+    ).toBe("global");
+  });
+
   it.each([
     {
       raw: "agent:main:matrix:channel:!MixedRoomAbCdEf:example.org",

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -175,6 +175,12 @@ export function resolveTuiSessionKey(params: {
       mainKey: params.sessionMainKey,
     });
   }
+  const parsed = parseAgentSessionKey(trimmed);
+  if (parsed?.rest === "global") {
+    // Initial agent selection already consumed the explicit owner prefix. TUI operations
+    // need the literal sentinel so they carry that owner separately as agentId.
+    return "global";
+  }
   if (trimmed === "global" || trimmed === "unknown") {
     return trimmed;
   }


### PR DESCRIPTION
## What Problem This Solves

A session started anywhere (web Control UI, a channel, a cloud worker) has no ergonomic CLI continuation path. `openclaw tui --session <key>` requires knowing the raw `agent:<id>:<key>` string; the TUI's Ctrl+P picker exists only after you're already attached. docs/plan/runners.md milestone 2 ("Session continuation ergonomics").

## Why This Change Was Made

Adds the `openclaw resume [query]` verb (verbs, not a second noun command — per the plan's naming rulings):

- No args: interactive picker over the same bounded recent-session window the TUI Ctrl+P picker uses (50 sessions / 7 days), or a non-TTY-safe error with guidance.
- With query: exact key match wins; else unique substring; else unique fuzzy match (existing pi-tui fuzzyFilter); ambiguous prints candidates and exits 1.
- On resolution, runs the existing `runTui` path with the resolved `--session` key; `--url/--token/--password/--tls-fingerprint` pass through identically to `openclaw tui`. No gateway auto-start; unreachable gateway fails with the same guidance the TUI gives.

Refactor included: the Ctrl+P picker's session-listing + label/preview building was extracted into a shared `src/tui/tui-session-picker.ts` owner consumed by both the TUI selector and the new command (−45 LOC in tui-command-handlers.ts), so the two pickers cannot drift.

No protocol changes; `sessions.list` is used as-is.

Release-note context: **CLI session resume** — `openclaw resume [query]` finds a recent Gateway session by key or name and attaches the TUI.

## User Impact

`openclaw resume` / `openclaw resume big-refactor` continues any recent session from the terminal, including sessions running on cloud workers — clients attach to sessions, placement is irrelevant. New docs page: /cli/resume.

## Evidence

- `node scripts/run-vitest.mjs src/cli/resume-cli.test.ts src/cli/program/register.subclis.test.ts`: 2 files, 151 tests passed.
- Resolver tests are table-driven: exact-key-beats-name, unique substring (key and display name), unique fuzzy, ambiguous → candidates + exit 1, none → guidance + exit 1.
- Registration suite: 23 tests passed. docs:list, formatting, git diff --check clean.
- Autoreview (codex/gpt-5.6-sol, high): clean, no accepted/actionable findings.

## ClawSweeper moves

P3 plan status: applied (rows 0/1a/1b/2 updated). P1 boundary test: skipped in this PR — needs a new lightweight gateway test harness (existing helper ~370s under CLI vitest config); recorded as a named follow-up in docs/plan/runners.md milestone 2.

Round-4 P1 (exercise qualified global resume through a Gateway operation): skipped — requires the lightweight CLI-side gateway harness recorded as a named follow-up in docs/plan/runners.md milestone 2 (existing helper ~370s under the CLI vitest config). Code behavior verified: bare-global rows are excluded from resume listing; explicit agent-qualified keys pass to the TUI unchanged.
