### PR TITLE
fix(memory): support stable Gemini Embedding 2

### DIFF
--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -153,7 +153,7 @@ different daily notes.
 
 ## Multimodal memory
 
-With `gemini-embedding-2-preview`, you can index images and audio alongside
+With `gemini-embedding-2`, you can index images and audio alongside
 Markdown. This only applies to files under `memory.search.extraPaths`; default
 memory roots (`MEMORY.md`, `memory/*.md`) stay Markdown-only. Search queries
 remain text, but they match against visual and audio content. See

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -227,6 +227,13 @@ Use `provider: "openai-compatible"` for a generic OpenAI-compatible
     <Warning>
     Changing model or `outputDimensionality` changes the index identity. OpenClaw
     pauses vector search until you explicitly rebuild the memory index.
+
+    Upgrading an existing configuration that already uses `gemini-embedding-2`
+    can trigger the same pause even when you do not edit the configuration. This
+    release resolves the model's previously unknown default dimensionality to
+    3072 and includes that value in the index identity. Check the affected agent
+    with `openclaw memory status --index --agent <id>`, then rebuild when ready
+    with `openclaw memory index --force --agent <id>`.
     </Warning>
 
   </Accordion>

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -228,12 +228,15 @@ Use `provider: "openai-compatible"` for a generic OpenAI-compatible
     Changing model or `outputDimensionality` changes the index identity. OpenClaw
     pauses vector search until you explicitly rebuild the memory index.
 
-    Upgrading an existing configuration that already uses `gemini-embedding-2`
-    can trigger the same pause even when you do not edit the configuration. This
-    release resolves the model's previously unknown default dimensionality to
-    3072 and includes that value in the index identity. Check the affected agent
-    with `openclaw memory status --index --agent <id>`, then rebuild when ready
-    with `openclaw memory index --force --agent <id>`.
+    Upgrading any existing configuration that already uses
+    `gemini-embedding-2` can trigger the same pause even when you do not edit the
+    configuration. Before this release, the stable model's dimension was
+    omitted from index identity whether `outputDimensionality` was absent or
+    explicitly set. After upgrade, an absent setting resolves to 3072, while an
+    explicit 768, 1536, or 3072 setting becomes part of the identity. For either
+    path, check the affected agent with
+    `openclaw memory status --index --agent <id>`, then rebuild when ready with
+    `openclaw memory index --force --agent <id>`.
     </Warning>
 
   </Accordion>

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -218,8 +218,11 @@ Use `provider: "openai-compatible"` for a generic OpenAI-compatible
   <Accordion title="Gemini">
     | Key                    | Type     | Default                | Description                                |
     | ---------------------- | -------- | ---------------------- | ------------------------------------------- |
-    | `model`                | `string` | `gemini-embedding-001` | Also supports `gemini-embedding-2-preview` |
+    | `model`                | `string` | `gemini-embedding-001` | Also supports `gemini-embedding-2`         |
     | `outputDimensionality` | `number` | `3072`                 | For Embedding 2: 768, 1536, or 3072        |
+
+    The legacy `gemini-embedding-2-preview` identifier remains accepted during
+    migration to the stable model.
 
     <Warning>
     Changing model or `outputDimensionality` changes the index identity. OpenClaw
@@ -422,7 +425,7 @@ Index images and audio alongside Markdown using Gemini Embedding 2:
 | `multimodal.maxFileBytes` | `number`   | `10485760` | Max file size for indexing (10 MiB)    |
 
 <Note>
-Only applies to files in `extraPaths`. Default memory roots stay Markdown-only. Requires `gemini-embedding-2-preview`. `fallback` must be `"none"`.
+Only applies to files in `extraPaths`. Default memory roots stay Markdown-only. Requires `gemini-embedding-2` (the legacy preview identifier is also accepted). `fallback` must be `"none"`.
 </Note>
 
 Supported formats: `.jpg`, `.jpeg`, `.png`, `.webp`, `.gif`, `.heic`, `.heif` (images); `.mp3`, `.wav`, `.ogg`, `.opus`, `.m4a`, `.aac`, `.flac` (audio).

--- a/extensions/google/embedding-batch.test.ts
+++ b/extensions/google/embedding-batch.test.ts
@@ -80,6 +80,18 @@ function makeGeminiClient(
   };
 }
 
+function makeGeminiEmbedding2Client(
+  outputDimensionality: number,
+  baseUrl = "https://generativelanguage.googleapis.com/v1beta",
+): GeminiEmbeddingClient {
+  return {
+    ...makeGeminiClient(baseUrl),
+    model: "gemini-embedding-2",
+    modelPath: "models/gemini-embedding-2",
+    outputDimensionality,
+  };
+}
+
 type GeminiBatchRequest = Parameters<typeof runGeminiEmbeddingBatches>[0]["requests"][number];
 
 function batchRequest(customId: string, text: string): GeminiBatchRequest {
@@ -207,6 +219,22 @@ function makeOversizedResponse(status = 200): {
 }
 
 describe("Google embedding-batch bounded JSON reads", () => {
+  it("rejects async batch embeddings that do not match the requested dimensions", async () => {
+    stubBatchFetch((stage) => {
+      if (stage !== "download") {
+        return undefined;
+      }
+      return new Response(
+        JSON.stringify({ key: "r0", response: { embedding: { values: [1, 0, 0] } } }),
+        { status: 200 },
+      );
+    });
+
+    await expect(runBatch(singleRequest(), makeGeminiEmbedding2Client(768))).rejects.toThrow(
+      "gemini embeddings failed: expected 768 dimensions, received 3",
+    );
+  });
+
   it("stops before polling status after the batch timeout expires", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);

--- a/extensions/google/embedding-batch.ts
+++ b/extensions/google/embedding-batch.ts
@@ -9,7 +9,6 @@ import {
   formatBatchErrorDetail,
   normalizeBatchBaseUrl,
   readEmbeddingBatchJsonl,
-  sanitizeAndNormalizeEmbedding,
   withRemoteHttpResponse,
   type EmbeddingBatchExecutionParams,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
@@ -21,7 +20,11 @@ import {
   resolveProviderOperationTimeoutMs,
   waitProviderOperationPollInterval,
 } from "openclaw/plugin-sdk/provider-http";
-import type { GeminiEmbeddingClient, GeminiTextEmbeddingRequest } from "./embedding-provider.js";
+import {
+  sanitizeGeminiEmbedding,
+  type GeminiEmbeddingClient,
+  type GeminiTextEmbeddingRequest,
+} from "./embedding-provider.js";
 import { parseGeminiAuth } from "./gemini-auth.js";
 
 type GeminiBatchRequest = {
@@ -290,6 +293,7 @@ function applyGeminiBatchOutputLine(params: {
   remaining: Set<string>;
   errors: string[];
   byCustomId: Map<string, number[]>;
+  expectedDimensions?: number;
 }): void {
   const customId = params.line.key ?? params.line.custom_id ?? params.line.request_id;
   // Only the first response for a submitted id may mutate results.
@@ -301,8 +305,9 @@ function applyGeminiBatchOutputLine(params: {
     params.errors.push(`${customId}: ${error}`);
     return;
   }
-  const embedding = sanitizeAndNormalizeEmbedding(
+  const embedding = sanitizeGeminiEmbedding(
     params.line.embedding?.values ?? params.line.response?.embedding?.values ?? [],
+    params.expectedDimensions,
   );
   if (embedding.length === 0) {
     params.errors.push(`${customId}: empty embedding`);
@@ -338,6 +343,7 @@ async function fetchGeminiBatchOutput(params: {
             remaining: params.remaining,
             errors: params.errors,
             byCustomId: params.byCustomId,
+            expectedDimensions: params.gemini.outputDimensionality,
           });
           return params.errors.length === 0 && params.remaining.size > 0;
         },

--- a/extensions/google/embedding-provider.test.ts
+++ b/extensions/google/embedding-provider.test.ts
@@ -54,23 +54,30 @@ function requireFirstFetchInput(fetchMock: ReturnType<typeof vi.fn>): RequestInf
   return call[0] as RequestInfo | URL;
 }
 
+function axisVector(length: number, index = 0, value = 1): number[] {
+  return Array.from({ length }, (_, offset) => (offset === index ? value : 0));
+}
+
 describe("Gemini embedding provider", () => {
   it.each(["models/", "gemini/", "google/"])(
     "normalizes the %s model prefix through the provider request",
     async (prefix) => {
-      const fetchMock = installFetchMock(() => ({ embedding: { values: [1, 0] } }));
+      const fetchMock = installFetchMock(() => ({
+        embedding: { values: axisVector(768) },
+      }));
       const { provider } = await createGeminiEmbeddingProvider({
         config: {} as never,
         provider: "gemini",
         remote: { apiKey: "placeholder" },
-        model: `${prefix}gemini-embedding-2-preview`,
+        model: `${prefix}gemini-embedding-2`,
+        outputDimensionality: 768,
         fallback: "none",
       });
 
       await provider.embedQuery("query");
 
       expect(requireFirstFetchInput(fetchMock)).toBe(
-        "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:embedContent",
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2:embedContent",
       );
     },
   );
@@ -81,7 +88,7 @@ describe("Gemini embedding provider", () => {
         config: {} as never,
         provider: "gemini",
         remote: { apiKey: "placeholder" },
-        model: "gemini-embedding-2-preview",
+        model: "gemini-embedding-2",
         outputDimensionality: 1024,
         fallback: "none",
       }),
@@ -94,17 +101,23 @@ describe("Gemini embedding provider", () => {
       return url.endsWith(":batchEmbedContents")
         ? {
             embeddings: Array.from({ length: 2 }, () => ({
-              values: [0, 0, 5],
+              values: axisVector(768, 2, 5),
             })),
           }
-        : { embedding: { values: [3, 4, 0] } };
+        : {
+            embedding: {
+              values: Array.from({ length: 768 }, (_, index) =>
+                index === 0 ? 3 : index === 1 ? 4 : 0,
+              ),
+            },
+          };
     });
 
     const { provider } = await createGeminiEmbeddingProvider({
       config: {} as never,
       provider: "gemini",
       remote: { apiKey: "test-key" },
-      model: "gemini-embedding-2-preview",
+      model: "gemini-embedding-2",
       outputDimensionality: 768,
       taskType: "SEMANTIC_SIMILARITY",
       fallback: "none",
@@ -112,7 +125,9 @@ describe("Gemini embedding provider", () => {
 
     await expect(provider.embedQuery("   ")).resolves.toStrictEqual([]);
     await expect(provider.embedBatch([])).resolves.toStrictEqual([]);
-    await expect(provider.embedQuery("test query")).resolves.toEqual([0.6, 0.8, 0]);
+    const queryEmbedding = await provider.embedQuery("test query");
+    expect(queryEmbedding).toHaveLength(768);
+    expect(queryEmbedding.slice(0, 3)).toEqual([0.6, 0.8, 0]);
 
     const structuredBatch = await provider.embedBatchInputs?.([
       {
@@ -130,13 +145,13 @@ describe("Gemini embedding provider", () => {
         ],
       },
     ]);
-    expect(structuredBatch).toEqual([
-      [0, 0, 1],
-      [0, 0, 1],
-    ]);
+    expect(structuredBatch).toHaveLength(2);
+    expect(structuredBatch?.[0]).toHaveLength(768);
+    expect(structuredBatch?.[0]?.slice(0, 4)).toEqual([0, 0, 1, 0]);
+    expect(structuredBatch?.[1]).toEqual(structuredBatch?.[0]);
 
     expect(requireFirstFetchInput(fetchMock)).toBe(
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:embedContent",
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2:embedContent",
     );
     expect(fetchJsonBody(fetchMock, 0)).toEqual({
       outputDimensionality: 768,
@@ -146,7 +161,7 @@ describe("Gemini embedding provider", () => {
     expect(fetchJsonBody(fetchMock, 1)).toEqual({
       requests: [
         {
-          model: "models/gemini-embedding-2-preview",
+          model: "models/gemini-embedding-2",
           content: {
             parts: [
               { text: "Image file: diagram.png" },
@@ -157,7 +172,7 @@ describe("Gemini embedding provider", () => {
           outputDimensionality: 768,
         },
         {
-          model: "models/gemini-embedding-2-preview",
+          model: "models/gemini-embedding-2",
           content: {
             parts: [
               { text: "Audio file: note.wav" },
@@ -216,6 +231,49 @@ describe("Gemini embedding provider", () => {
 
     await expect(provider.embedBatch(["one", "two"])).rejects.toThrow(
       "gemini embeddings failed: malformed JSON response",
+    );
+  });
+
+  it("keeps the preview identifier compatible during migration", async () => {
+    const fetchMock = installFetchMock(() => ({
+      embedding: { values: axisVector(768) },
+    }));
+    const { provider } = await createGeminiEmbeddingProvider({
+      config: {} as never,
+      provider: "gemini",
+      remote: { apiKey: "test-key" },
+      model: "gemini-embedding-2-preview",
+      outputDimensionality: 768,
+      fallback: "none",
+    });
+
+    await expect(provider.embedQuery("test query")).resolves.toHaveLength(768);
+    expect(requireFirstFetchInput(fetchMock)).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:embedContent",
+    );
+  });
+
+  it("rejects Gemini 2 responses that drift from the requested dimensions", async () => {
+    installFetchMock((input) => {
+      const url = input instanceof URL ? input.href : typeof input === "string" ? input : input.url;
+      return url.endsWith(":batchEmbedContents")
+        ? { embeddings: [{ values: axisVector(3072) }] }
+        : { embedding: { values: axisVector(3072) } };
+    });
+    const { provider } = await createGeminiEmbeddingProvider({
+      config: {} as never,
+      provider: "gemini",
+      remote: { apiKey: "test-key" },
+      model: "gemini-embedding-2",
+      outputDimensionality: 768,
+      fallback: "none",
+    });
+
+    await expect(provider.embedQuery("test query")).rejects.toThrow(
+      "gemini embeddings failed: expected 768 dimensions, received 3072",
+    );
+    await expect(provider.embedBatch(["test document"])).rejects.toThrow(
+      "gemini embeddings failed: expected 768 dimensions, received 3072",
     );
   });
 });

--- a/extensions/google/embedding-provider.ts
+++ b/extensions/google/embedding-provider.ts
@@ -211,7 +211,7 @@ function normalizeGeminiModel(model: string): string {
   return withoutPrefix;
 }
 
-function sanitizeGeminiEmbedding(values: number[], expectedDimensions?: number): number[] {
+export function sanitizeGeminiEmbedding(values: number[], expectedDimensions?: number): number[] {
   if (expectedDimensions != null && values.length !== expectedDimensions) {
     throw unexpectedGeminiEmbeddingDimensions(expectedDimensions, values.length);
   }

--- a/extensions/google/embedding-provider.ts
+++ b/extensions/google/embedding-provider.ts
@@ -42,17 +42,15 @@ export const DEFAULT_GEMINI_EMBEDDING_MODEL = "gemini-embedding-001";
 const DEFAULT_GOOGLE_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
 const GEMINI_MAX_INPUT_TOKENS: Record<string, number> = {
   "gemini-embedding-001": 2048,
+  "gemini-embedding-2": 8192,
   "gemini-embedding-2-preview": 8192,
 };
 
 type GeminiTaskType = NonNullable<MemoryEmbeddingProviderCreateOptions["taskType"]>;
 
-// --- gemini-embedding-2-preview support ---
+// --- Gemini Embedding 2 support ---
 
-const GEMINI_EMBEDDING_2_MODELS = new Set([
-  "gemini-embedding-2-preview",
-  // Add the GA model name here once released.
-]);
+const GEMINI_EMBEDDING_2_MODELS = new Set(["gemini-embedding-2", "gemini-embedding-2-preview"]);
 
 const GEMINI_EMBEDDING_2_DEFAULT_DIMENSIONS = 3072;
 const GEMINI_EMBEDDING_2_VALID_DIMENSIONS = [768, 1536, 3072] as const;
@@ -73,6 +71,10 @@ export type GeminiTextEmbeddingRequest = GeminiEmbeddingRequest;
 
 function malformedGeminiEmbeddingResponse(): Error {
   return new Error("gemini embeddings failed: malformed JSON response");
+}
+
+function unexpectedGeminiEmbeddingDimensions(expected: number, actual: number): Error {
+  return new Error(`gemini embeddings failed: expected ${expected} dimensions, received ${actual}`);
 }
 
 function readGeminiEmbeddingValues(value: unknown): number[] {
@@ -157,8 +159,8 @@ export function buildGeminiEmbeddingRequest(params: {
  * Returns true if the given model name is a gemini-embedding-2 variant that
  * supports `outputDimensionality` and extended task types.
  */
-function isGeminiEmbedding2Model(model: string): boolean {
-  return GEMINI_EMBEDDING_2_MODELS.has(model);
+export function isGeminiEmbedding2Model(model: string): boolean {
+  return GEMINI_EMBEDDING_2_MODELS.has(normalizeGeminiModel(model));
 }
 
 /**
@@ -207,6 +209,13 @@ function normalizeGeminiModel(model: string): string {
     return withoutPrefix.slice("google/".length);
   }
   return withoutPrefix;
+}
+
+function sanitizeGeminiEmbedding(values: number[], expectedDimensions?: number): number[] {
+  if (expectedDimensions != null && values.length !== expectedDimensions) {
+    throw unexpectedGeminiEmbeddingDimensions(expectedDimensions, values.length);
+  }
+  return sanitizeAndNormalizeEmbedding(values);
 }
 
 async function fetchGeminiEmbeddingPayload(params: {
@@ -306,7 +315,10 @@ export async function createGeminiEmbeddingProvider(
       }),
       signal: callOptions?.signal,
     });
-    return sanitizeAndNormalizeEmbedding(readGeminiSingleEmbedding(payload));
+    return sanitizeGeminiEmbedding(
+      readGeminiSingleEmbedding(payload),
+      isV2 ? outputDimensionality : undefined,
+    );
   };
 
   const embedBatchInputs = async (
@@ -332,7 +344,9 @@ export async function createGeminiEmbeddingProvider(
       signal: callOptions?.signal,
     });
     const embeddings = readGeminiBatchEmbeddings(payload, inputs.length);
-    return embeddings.map((values) => sanitizeAndNormalizeEmbedding(values));
+    return embeddings.map((values) =>
+      sanitizeGeminiEmbedding(values, isV2 ? outputDimensionality : undefined),
+    );
   };
 
   const embedBatch = async (

--- a/extensions/google/memory-embedding-adapter.test.ts
+++ b/extensions/google/memory-embedding-adapter.test.ts
@@ -10,11 +10,14 @@ const mocks = vi.hoisted(() => ({
   runGeminiEmbeddingBatches: vi.fn(async () => new Map([["0", [1, 0]]])),
 }));
 
-vi.mock("./embedding-provider.js", () => ({
-  DEFAULT_GEMINI_EMBEDDING_MODEL: "gemini-embedding-001",
-  createGeminiEmbeddingProvider: mocks.createGeminiEmbeddingProvider,
-  buildGeminiEmbeddingRequest: vi.fn(),
-}));
+vi.mock("./embedding-provider.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./embedding-provider.js")>();
+  return {
+    ...actual,
+    createGeminiEmbeddingProvider: mocks.createGeminiEmbeddingProvider,
+    buildGeminiEmbeddingRequest: vi.fn(),
+  };
+});
 
 vi.mock("./embedding-batch.js", () => ({
   runGeminiEmbeddingBatches: mocks.runGeminiEmbeddingBatches,
@@ -24,15 +27,15 @@ import { geminiMemoryEmbeddingProviderAdapter } from "./memory-embedding-adapter
 
 const provider: MemoryEmbeddingProvider = {
   id: "gemini",
-  model: "gemini-embedding-2-preview",
+  model: "gemini-embedding-2",
   embedQuery: async () => [1, 0],
   embedBatch: async (texts) => texts.map(() => [1, 0]),
 };
 
 const clientBase = {
   baseUrl: "https://generativelanguage.googleapis.com/v1beta",
-  model: "gemini-embedding-2-preview",
-  modelPath: "models/gemini-embedding-2-preview",
+  model: "gemini-embedding-2",
+  modelPath: "models/gemini-embedding-2",
   outputDimensionality: 768,
 };
 
@@ -44,7 +47,7 @@ async function createAdapterWithHeaders(headers: Record<string, string>) {
   return await geminiMemoryEmbeddingProviderAdapter.create({
     config: {} as never,
     provider: "gemini",
-    model: "gemini-embedding-2-preview",
+    model: "gemini-embedding-2",
     fallback: "none",
   });
 }
@@ -53,6 +56,26 @@ describe("Gemini memory embedding adapter", () => {
   beforeEach(() => {
     mocks.createGeminiEmbeddingProvider.mockReset();
     mocks.runGeminiEmbeddingBatches.mockClear();
+  });
+
+  it.each([
+    "gemini-embedding-2",
+    "gemini-embedding-2-preview",
+    "models/gemini-embedding-2",
+    "gemini/gemini-embedding-2",
+    "google/gemini-embedding-2",
+  ])("accepts multimodal memory for %s", (model) => {
+    expect(geminiMemoryEmbeddingProviderAdapter.supportsMultimodalEmbeddings?.({ model })).toBe(
+      true,
+    );
+  });
+
+  it("keeps legacy Gemini embeddings text-only", () => {
+    expect(
+      geminiMemoryEmbeddingProviderAdapter.supportsMultimodalEmbeddings?.({
+        model: "gemini-embedding-001",
+      }),
+    ).toBe(false);
   });
 
   it("keeps durable identity stable across generated client-version changes", async () => {

--- a/extensions/google/memory-embedding-adapter.ts
+++ b/extensions/google/memory-embedding-adapter.ts
@@ -11,15 +11,8 @@ import {
   buildGeminiEmbeddingRequest,
   createGeminiEmbeddingProvider,
   DEFAULT_GEMINI_EMBEDDING_MODEL,
+  isGeminiEmbedding2Model,
 } from "./embedding-provider.js";
-
-function supportsGeminiMultimodalEmbeddings(model: string): boolean {
-  const normalized = model
-    .trim()
-    .replace(/^models\//, "")
-    .replace(/^(gemini|google)\//, "");
-  return normalized === "gemini-embedding-2-preview";
-}
 
 export const geminiMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapter = {
   id: "gemini",
@@ -28,7 +21,7 @@ export const geminiMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapte
   authProviderId: "google",
   autoSelectPriority: 30,
   allowExplicitWhenConfiguredAuto: true,
-  supportsMultimodalEmbeddings: ({ model }) => supportsGeminiMultimodalEmbeddings(model),
+  supportsMultimodalEmbeddings: ({ model }) => isGeminiEmbedding2Model(model),
   shouldContinueAutoSelection: isMissingEmbeddingApiKeyError,
   create: async (options) => {
     const { provider, client } = await createGeminiEmbeddingProvider({


### PR DESCRIPTION
## Summary

- recognize Google's stable `gemini-embedding-2` identifier across Gemini memory requests, token limits, and multimodal capability validation
- keep `gemini-embedding-2-preview` compatible during migration
- fail closed when Gemini returns a vector length different from the requested `outputDimensionality` on direct, synchronous-batch, and asynchronous-batch paths
- update memory documentation to recommend the stable model

Closes #120662.

## What problem this solves

Google released `gemini-embedding-2` as GA and lists it as the replacement for the preview model. Current OpenClaw `main` contains an explicit placeholder to add the GA name but only recognizes the preview identifier.

Without this change, a stable-model configuration omits `outputDimensionality`, loses the 8,192-token capability, and fails multimodal-provider validation. Before the review correction, asynchronous batch downloads could also bypass the new dimension invariant and cache an incompatible vector.

## Evidence

Exact PR-head provider code was bundled from `36fb217f86303a2e55d7f8bab480d906fb748ec1`, hash-verified, and loaded temporarily against the deployed OpenClaw SDK. It made one query-only stable-model request through the isolated memory credential lane. The credential, endpoint, vector, host, and image identities were not printed.

```json
{
  "result": "passed",
  "exactHead": "36fb217f86303a2e55d7f8bab480d906fb748ec1",
  "provider": "gemini",
  "model": "gemini-embedding-2",
  "taskType": "RETRIEVAL_QUERY",
  "requestedDimensions": 768,
  "receivedDimensions": 768,
  "maxInputTokens": 8192,
  "finiteValues": true,
  "responseVectorRedacted": true,
  "credentialRedacted": true
}
```

```json
{
  "exactHeadProviderCanary": "passed",
  "productionUnchanged": true,
  "temporaryArtifactsRemoved": true,
  "temporaryOsAdminRemoved": true
}
```

A separate live `openclaw memory search` used the deployed stable-model/768 lane against an existing index. It returned three semantic results while before/after database hash and stat checks remained identical. No result content was printed.

```json
{
  "memorySearch": "passed",
  "resultCount": 3,
  "provider": "gemini",
  "model": "gemini-embedding-2",
  "dimensions": 768,
  "indexDatabaseUnchanged": true,
  "shadowCreated": false,
  "indexingStarted": false,
  "productionUnchanged": true,
  "temporaryOsAdminRemoved": true
}
```

Neither canary reindexed, rebuilt, mutated an index, exposed memory content, restarted a service, or changed production configuration.

## Repository validation

- Exact tested head: `36fb217f86303a2e55d7f8bab480d906fb748ec1`.
- Rebased directly onto current `upstream/main` at `b7add0b5603`.
- Google embedding batch/provider/memory-adapter suites: 39/39 tests passed, including the real loopback batch lifecycle.
- Downloaded asynchronous batch vectors pass through the same model-dimension validator before they can enter the memory cache or index.
- The async regression configures stable Gemini Embedding 2 for 768 dimensions, returns a three-value result, and proves fail-closed rejection with the expected/received dimension error.
- Plugin SDK API baseline, max-lines ratchet, targeted lint, formatting, and `git diff --check` passed.
- Exact-head CI [run 31292922122](https://github.com/openclaw/openclaw/actions/runs/31292922122) is terminal with **52 successful**, **13 skipped**, and one underlying failure plus the aggregate gate. [`checks-node-compact-small-5`](https://github.com/openclaw/openclaw/actions/runs/31292922122/job/93193184918) timed out after 120 seconds in `src/config/io.observe-recovery.test.ts`; the other 221 files and 3,133 tests in that shard passed.
- The timed-out test's blob is exactly identical (`8d2976d81541e2d85f141b17004d7728f64eccc2`) on the PR CI merge `7a656a8d290d0433b130f03d0cf74431bc4d296d` and its exact main base `c1217886119c16a92ad7b0f080272af24fcb0bf7`. This Google/docs-only PR does not touch the config recovery path, so the timeout is recorded as unrelated rather than green; no branch edit or blind rerun was made.

## Compatibility

- default `gemini-embedding-001` behavior is unchanged
- preview configurations remain accepted
- supported configured dimensions remain 768, 1536, and 3072
- index identity continues to include the resolved model and requested dimension
- asynchronous batch output now fails closed before incompatible vectors can be cached

## AI assistance

AI-assisted investigation, implementation, tests, documentation, canary preparation, and PR maintenance. Live outputs above are redacted aggregates from the executed canaries.
