### PR TITLE
fix(release): keep base upgrade validation hermetic

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -21,8 +21,10 @@ export TELEGRAM_BOT_TOKEN="123456:upgrade-survivor-telegram-token"
 if [ "$SCENARIO" = "feishu-channel" ]; then
   export FEISHU_APP_SECRET="upgrade-survivor-feishu-secret"
 fi
-export MATRIX_ACCESS_TOKEN="upgrade-survivor-matrix-token"
-export BRAVE_API_KEY="BSA_upgrade_survivor_brave_key"
+if [ "$SCENARIO" = "configured-plugin-installs" ]; then
+  export MATRIX_ACCESS_TOKEN="upgrade-survivor-matrix-token"
+  export BRAVE_API_KEY="BSA_upgrade_survivor_brave_key"
+fi
 
 ARTIFACT_ROOT="$(dirname "${OPENCLAW_UPGRADE_SURVIVOR_SUMMARY_JSON:-/tmp/openclaw-upgrade-survivor-artifacts/summary.json}")"
 export OPENCLAW_UPGRADE_SURVIVOR_RUNTIME_ROOT="${OPENCLAW_UPGRADE_SURVIVOR_RUNTIME_ROOT:-/tmp/openclaw-upgrade-survivor-runtime}"

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2288,7 +2288,7 @@ docker_e2e_docker_run_cmd run demo
     expect(publishedRunner).toContain('OPENCLAW_NPM_REGISTRY_DIST_TAGS="beta=$candidate_version"');
   });
 
-  it("starts the upgrade survivor plugin registry before updates without ambient Feishu config", () => {
+  it("starts the upgrade survivor plugin registry before updates with scenario-owned config", () => {
     const runner = readFileSync(UPGRADE_SURVIVOR_DOCKER_E2E_PATH, "utf8");
     const publishedRunner = readFileSync(UPGRADE_SURVIVOR_RUN_SCRIPT, "utf8");
 
@@ -2302,6 +2302,14 @@ docker_e2e_docker_run_cmd run demo
       'if [ "${OPENCLAW_UPGRADE_SURVIVOR_SCENARIO:-base}" = "feishu-channel" ]; then',
     );
     expect(publishedRunner).toContain('if [ "$SCENARIO" = "feishu-channel" ]; then');
+    expect(publishedRunner).toContain(
+      [
+        'if [ "$SCENARIO" = "configured-plugin-installs" ]; then',
+        '  export MATRIX_ACCESS_TOKEN="upgrade-survivor-matrix-token"',
+        '  export BRAVE_API_KEY="BSA_upgrade_survivor_brave_key"',
+        "fi",
+      ].join("\n"),
+    );
     for (const script of [runner, publishedRunner]) {
       const emptyRegistryGuardIndex = script.indexOf('if [ "${#registry_args[@]}" -eq 0 ]; then');
       const fixtureDirectoryIndex = script.indexOf('mkdir -p "$fixture_root"');
@@ -2315,6 +2323,12 @@ docker_e2e_docker_run_cmd run demo
       expect(fixtureDirectoryIndex).toBeLessThan(registryServerIndex);
       expect(script).not.toContain('\nexport FEISHU_APP_SECRET="upgrade-survivor-feishu-secret"\n');
     }
+    expect(publishedRunner).not.toContain(
+      '\nexport MATRIX_ACCESS_TOKEN="upgrade-survivor-matrix-token"\n',
+    );
+    expect(publishedRunner).not.toContain(
+      '\nexport BRAVE_API_KEY="BSA_upgrade_survivor_brave_key"\n',
+    );
   });
 
   it("wraps package-backed scenario OpenClaw CLI calls with the shared timeout helper", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the base `update-restart-auth` release validation could discover Matrix and Brave configuration before the candidate update, making a hermetic upgrade lane depend on live ClawHub availability.

## Why This Change Was Made

The upgrade-survivor harness now exports Matrix and Brave fixture credentials only for the `configured-plugin-installs` scenario, matching the existing Feishu scenario ownership. Registry setup and ordering are unchanged.

## User Impact

Release operators get deterministic base upgrade validation without accidental plugin discovery or network dependency. Product runtime behavior is unchanged.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts` (187 passed)
- focused regression: 1 passed, 186 skipped
- `bash -n scripts/e2e/lib/upgrade-survivor/run.sh`
- targeted `oxfmt --check`
- `git diff --check`
- `node scripts/check-changed.mjs -- scripts/e2e/lib/upgrade-survivor/run.sh test/scripts/docker-build-helper.test.ts` via Blacksmith Testbox: passed
- local autoreview: clean, no accepted/actionable findings

AI-assisted: yes. The patch and validation were reviewed by the maintainer running this release.
