### PR TITLE
fix(update): log campaign lifecycle for debugging

### DIFF
--- a/src/gateway/server-methods/update-hold.test.ts
+++ b/src/gateway/server-methods/update-hold.test.ts
@@ -4,14 +4,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type UpdateScheduleState =
   import("../../../packages/gateway-protocol/src/index.js").UpdateScheduleState;
+type UpdateCampaignState = NonNullable<UpdateScheduleState["campaign"]>;
 
 const holdUpdateCampaignMock = vi.hoisted(() => vi.fn(() => false));
+const getUpdateCampaignStateMock = vi.hoisted(() =>
+  vi.fn<() => UpdateCampaignState | undefined>(() => undefined),
+);
 const getUpdateScheduleMock = vi.hoisted(() => vi.fn<() => UpdateScheduleState | null>(() => null));
 const validateUpdateHoldResultMock = vi.hoisted(() => vi.fn(() => true));
 
 vi.mock("../../infra/update-campaign.js", () => ({
   gatewayUpdateCampaign: {
     adopt: () => undefined,
+    getState: getUpdateCampaignStateMock,
     hold: holdUpdateCampaignMock,
   },
 }));
@@ -36,17 +41,31 @@ vi.mock("./validation.js", () => ({
 beforeEach(() => {
   holdUpdateCampaignMock.mockReset();
   holdUpdateCampaignMock.mockReturnValue(false);
+  getUpdateCampaignStateMock.mockReset();
+  getUpdateCampaignStateMock.mockReturnValue(undefined);
   getUpdateScheduleMock.mockReset();
   getUpdateScheduleMock.mockReturnValue(null);
   validateUpdateHoldResultMock.mockClear();
 });
 
-async function invokeUpdateHold(respond: ReturnType<typeof vi.fn>) {
+async function invokeUpdateHold(
+  respond: ReturnType<typeof vi.fn>,
+  logInfo = vi.fn(),
+): Promise<void> {
   const { updateHandlers } = await import("./update.js");
   await expectDefined(
     updateHandlers["update.hold"],
     'updateHandlers["update.hold"] test invariant',
-  )({ params: {}, respond } as never);
+  )({
+    params: {},
+    respond,
+    client: {
+      connId: "conn-1",
+      clientIp: "127.0.0.1",
+      connect: { client: { id: "control-ui" }, device: { id: "device-1" } },
+    },
+    context: { logGateway: { info: logInfo } },
+  } as never);
 }
 
 describe("update.hold", () => {
@@ -64,9 +83,26 @@ describe("update.hold", () => {
         updatedAtMs: 1,
       },
     });
+    getUpdateCampaignStateMock
+      .mockReturnValueOnce({
+        id: "campaign-1",
+        state: "waiting-for-idle",
+        announcedAtMs: 1,
+        forceAtMs: 900_001,
+        updatedAtMs: 1,
+      })
+      .mockReturnValueOnce({
+        id: "campaign-1",
+        state: "waiting-for-idle",
+        announcedAtMs: 1,
+        holdUntilMs: 3_600_001,
+        forceAtMs: 4_500_001,
+        updatedAtMs: 1,
+      });
     const respond = vi.fn();
+    const logInfo = vi.fn();
 
-    await invokeUpdateHold(respond);
+    await invokeUpdateHold(respond, logInfo);
 
     const result = {
       ok: true,
@@ -77,14 +113,60 @@ describe("update.hold", () => {
     expect(holdUpdateCampaignMock).toHaveBeenCalledOnce();
     expect(validateUpdateHoldResultMock).toHaveBeenCalledWith(result);
     expect(respond).toHaveBeenCalledWith(true, result);
+    expect(logInfo).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /^update\.hold granted actor=control-ui .*holdUntilMs=3600001 forceAtMs=4500001$/,
+      ),
+    );
   });
 
   it("returns ok=false when there is no active campaign", async () => {
     const respond = vi.fn();
+    const logInfo = vi.fn();
 
-    await invokeUpdateHold(respond);
+    await invokeUpdateHold(respond, logInfo);
 
     expect(holdUpdateCampaignMock).toHaveBeenCalledOnce();
     expect(respond).toHaveBeenCalledWith(true, { ok: false });
+    expect(logInfo).toHaveBeenCalledWith(
+      expect.stringMatching(/^update\.hold refused actor=control-ui /),
+      { reason: "no campaign" },
+    );
+  });
+
+  it.each([
+    {
+      name: "an applying campaign",
+      campaign: {
+        id: "campaign-1",
+        state: "applying" as const,
+        announcedAtMs: 1,
+        forceAtMs: 900_001,
+        updatedAtMs: 1,
+      },
+      reason: "applying",
+    },
+    {
+      name: "an already-held campaign",
+      campaign: {
+        id: "campaign-1",
+        state: "waiting-for-idle" as const,
+        announcedAtMs: 1,
+        holdUntilMs: 3_600_001,
+        forceAtMs: 4_500_001,
+        updatedAtMs: 1,
+      },
+      reason: "already held",
+    },
+  ])("logs why $name cannot be held", async ({ campaign, reason }) => {
+    getUpdateCampaignStateMock.mockReturnValueOnce(campaign);
+    const logInfo = vi.fn();
+
+    await invokeUpdateHold(vi.fn(), logInfo);
+
+    expect(logInfo).toHaveBeenCalledWith(
+      expect.stringMatching(/^update\.hold refused actor=control-ui /),
+      { reason },
+    );
   });
 });

--- a/src/gateway/server-methods/update-run-campaign.test.ts
+++ b/src/gateway/server-methods/update-run-campaign.test.ts
@@ -45,6 +45,7 @@ const startManagedServiceUpdateHandoffMock = vi.fn(async () => ({
   handoffId: "handoff-1",
 }));
 const scheduleGatewaySigusr1RestartMock = vi.fn(() => ({ scheduled: true }));
+const logGatewayInfoMock = vi.fn();
 
 vi.mock("../../../packages/gateway-protocol/src/index.js", () => ({
   validateUpdateRunParams: () => true,
@@ -176,6 +177,7 @@ beforeEach(() => {
   detectRespawnSupervisorMock.mockReturnValue(null);
   startManagedServiceUpdateHandoffMock.mockClear();
   scheduleGatewaySigusr1RestartMock.mockClear();
+  logGatewayInfoMock.mockClear();
 });
 
 function setDevCampaignSchedule(upstreamSha = "frozen-upstream-sha"): void {
@@ -217,7 +219,15 @@ async function invokeUpdateRun(): Promise<void> {
   )({
     params: {},
     respond: () => undefined,
-    context: { getRuntimeConfig: () => ({ update: {} }) as OpenClawConfig },
+    client: {
+      connId: "conn-1",
+      clientIp: "127.0.0.1",
+      connect: { client: { id: "control-ui" }, device: { id: "device-1" } },
+    },
+    context: {
+      getRuntimeConfig: () => ({ update: {} }) as OpenClawConfig,
+      logGateway: { info: logGatewayInfoMock },
+    },
   } as never);
 }
 
@@ -235,6 +245,10 @@ describe("update.run campaign ownership", () => {
 
     expect(runGatewayUpdateMock).toHaveBeenCalledWith(
       expect.objectContaining({ channel: "beta", tag: "2.0.0" }),
+    );
+    expect(logGatewayInfoMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^update\.run adopted campaign campaign-1 actor=control-ui /),
+      { target: { kind: "package", version: "2.0.0" } },
     );
   });
 
@@ -329,6 +343,9 @@ describe("update.run campaign ownership", () => {
 
     expect(adoptCampaignMock).toHaveBeenCalledOnce();
     expect(clearCampaignMock).toHaveBeenCalledOnce();
+    expect(logGatewayInfoMock).toHaveBeenCalledWith("update.run failed; adopted campaign cleared", {
+      campaignId: "campaign-1",
+    });
   });
 
   it("does not clear a campaign that update.run did not adopt", async () => {
@@ -360,6 +377,10 @@ describe("update.run campaign ownership", () => {
 
     expect(getCampaignStateMock).toHaveBeenCalledOnce();
     expect(clearCampaignMock).not.toHaveBeenCalled();
+    expect(logGatewayInfoMock).not.toHaveBeenCalledWith(
+      "update.run failed; adopted campaign cleared",
+      expect.anything(),
+    );
   });
 
   it("keeps the adopted campaign while a successful update restarts", async () => {

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -159,12 +159,29 @@ export const updateHandlers: GatewayRequestHandlers = {
     }
     respond(true, result);
   },
-  "update.hold": ({ params, respond }) => {
+  "update.hold": ({ params, respond, client, context }) => {
     if (!assertValidParams(params, validateUpdateHoldParams, "update.hold", respond)) {
       return;
     }
+    const actor = resolveControlPlaneActor(client);
+    const campaignBeforeHold = gatewayUpdateCampaign.getState();
     const ok = gatewayUpdateCampaign.hold();
     const schedule = getUpdateSchedule();
+    if (ok) {
+      const heldCampaign = gatewayUpdateCampaign.getState();
+      context?.logGateway?.info(
+        `update.hold granted ${formatControlPlaneActor(actor)} holdUntilMs=${heldCampaign?.holdUntilMs} forceAtMs=${heldCampaign?.forceAtMs}`,
+      );
+    } else {
+      const reason = !campaignBeforeHold
+        ? "no campaign"
+        : campaignBeforeHold.state === "applying"
+          ? "applying"
+          : "already held";
+      context?.logGateway?.info(`update.hold refused ${formatControlPlaneActor(actor)}`, {
+        reason,
+      });
+    }
     const result = {
       ok,
       ...(schedule ? { schedule } : {}),
@@ -193,6 +210,12 @@ export const updateHandlers: GatewayRequestHandlers = {
         ? adoptedCampaign.target.version.trim() || undefined
         : undefined;
     const actor = resolveControlPlaneActor(client);
+    if (adoptedCampaign) {
+      context?.logGateway?.info(
+        `update.run adopted campaign ${adoptedCampaign.campaignId} ${formatControlPlaneActor(actor)}`,
+        { target: adoptedCampaign.target },
+      );
+    }
     const {
       sessionKey,
       deliveryContext: requestedDeliveryContext,
@@ -473,6 +496,9 @@ export const updateHandlers: GatewayRequestHandlers = {
       gatewayUpdateCampaign.getState()?.id === adoptedCampaignId
     ) {
       gatewayUpdateCampaign.clear();
+      context?.logGateway?.info("update.run failed; adopted campaign cleared", {
+        campaignId: adoptedCampaignId,
+      });
     }
 
     const payload: RestartSentinelPayload = buildUpdateRestartSentinelPayload({

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -1137,11 +1137,12 @@ describe("update-startup", () => {
   it("resets a busy dev campaign and forces it at the deadline", async () => {
     mockDevGitStatus();
     let busy = 1;
+    const log = { info: vi.fn() };
     const runAutoUpdate = createAutoUpdateSuccessMock();
 
     await runGatewayUpdateCheck({
       cfg: { update: { channel: "dev", auto: { enabled: true } } },
-      log: { info: vi.fn() },
+      log,
       isNixMode: false,
       allowInTests: true,
       activeWorkInspectors: {
@@ -1151,9 +1152,28 @@ describe("update-startup", () => {
       runAutoUpdate,
     });
     expect(getUpdateSchedule()?.campaign).toMatchObject({ state: "waiting-for-idle" });
+    expect(log.info).toHaveBeenCalledWith(
+      "update campaign waiting-for-idle",
+      expect.objectContaining({
+        campaignId: expect.any(String),
+        state: "waiting-for-idle",
+        channel: "dev",
+        target: { upstreamSha: "upstream-sha", commitsBehind: 2 },
+        forceAtMs: expect.any(Number),
+      }),
+    );
     busy = 0;
     await vi.advanceTimersByTimeAsync(5_000);
     expect(getUpdateSchedule()?.campaign).toMatchObject({ state: "countdown" });
+    expect(log.info).toHaveBeenCalledWith(
+      "update campaign countdown",
+      expect.objectContaining({
+        campaignId: expect.any(String),
+        state: "countdown",
+        channel: "dev",
+        applyAtMs: expect.any(Number),
+      }),
+    );
     busy = 1;
     await vi.advanceTimersByTimeAsync(5_000);
     expect(getUpdateSchedule()?.campaign).toMatchObject({ state: "waiting-for-idle" });
@@ -1162,6 +1182,14 @@ describe("update-startup", () => {
     await vi.advanceTimersByTimeAsync(14 * 60_000 + 50_000);
     expect(getUpdateSchedule()?.campaign?.state).toBe("applying");
     expect(runAutoUpdate).toHaveBeenCalledOnce();
+    expect(log.info).toHaveBeenCalledWith(
+      "auto-update applied",
+      expect.objectContaining({
+        channel: "dev",
+        version: "upstream-sha",
+        forced: true,
+      }),
+    );
   });
 
   it("supersedes and clears dev git campaigns from fresh git facts", async () => {
@@ -1451,10 +1479,19 @@ describe("update-startup", () => {
       skipCooldown: true,
       skipDeferral: true,
     });
+    expect(log.info).toHaveBeenCalledWith(
+      "update campaign waiting-for-idle",
+      expect.objectContaining({
+        campaignId: expect.any(String),
+        channel: "beta",
+        target: "2.0.0-beta.1",
+      }),
+    );
     expect(log.info).toHaveBeenCalledWith("auto-update handoff started", {
       channel: "beta",
       version: "2.0.0-beta.1",
       tag: "beta",
+      forced: false,
       command: "openclaw update --yes --channel beta --tag 2.0.0-beta.1 --timeout 2700",
       logPath: "/tmp/openclaw-handoff.log",
     });
@@ -1484,8 +1521,16 @@ describe("update-startup", () => {
       channel: "beta",
       version: "2.0.0-beta.1",
       tag: "beta",
+      forced: false,
       reason: "Error: spawn ENOENT",
     });
+    expect(log.info).toHaveBeenCalledWith(
+      "update campaign ended",
+      expect.objectContaining({
+        campaignId: expect.any(String),
+        channel: "beta",
+      }),
+    );
     expect(getUpdateSchedule()?.campaign).toBeUndefined();
   });
 

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -646,6 +646,7 @@ async function runCampaignUpdate(params: {
   channel: "stable" | "beta" | "dev";
   version: string;
   tag: string;
+  forced: boolean;
   root?: string;
   devTargetSha?: string;
   log: { info: (msg: string, meta?: Record<string, unknown>) => void };
@@ -670,6 +671,7 @@ async function runCampaignUpdate(params: {
       channel: params.channel,
       version: params.version,
       tag: params.tag,
+      forced: params.forced,
       ...(outcome.command ? { command: outcome.command } : {}),
       ...(outcome.logPath ? { logPath: outcome.logPath } : {}),
     });
@@ -684,6 +686,7 @@ async function runCampaignUpdate(params: {
       channel: params.channel,
       version: params.version,
       tag: params.tag,
+      forced: params.forced,
     });
     return "applied";
   }
@@ -691,6 +694,7 @@ async function runCampaignUpdate(params: {
     channel: params.channel,
     version: params.version,
     tag: params.tag,
+    forced: params.forced,
     reason: outcome.reason ?? `exit:${outcome.code}`,
   });
   return "failed";
@@ -754,6 +758,32 @@ export async function runGatewayUpdateCheck(params: {
     const current = updateScheduleCache;
     if (!current || current.channel !== configuredChannel) {
       return;
+    }
+    const target =
+      current.target?.kind === "package"
+        ? current.target.version
+        : current.target?.kind === "git"
+          ? {
+              upstreamSha: current.target.upstreamSha,
+              commitsBehind: current.target.commitsBehind,
+            }
+          : undefined;
+    if (campaign) {
+      params.log.info(`update campaign ${campaign.state}`, {
+        campaignId: campaign.id,
+        state: campaign.state,
+        channel: configuredChannel,
+        ...(target === undefined ? {} : { target }),
+        ...(campaign.applyAtMs === undefined ? {} : { applyAtMs: campaign.applyAtMs }),
+        ...(campaign.holdUntilMs === undefined ? {} : { holdUntilMs: campaign.holdUntilMs }),
+        forceAtMs: campaign.forceAtMs,
+      });
+    } else {
+      params.log.info("update campaign ended", {
+        ...(current.campaign?.id ? { campaignId: current.campaign.id } : {}),
+        channel: configuredChannel,
+        ...(target === undefined ? {} : { target }),
+      });
     }
     setUpdateScheduleCache({
       next: campaign ? { ...current, campaign } : withoutCampaign(current),
@@ -964,12 +994,13 @@ export async function runGatewayUpdateCheck(params: {
           target,
           inspect: params.activeWorkInspectors,
           onChange: onCampaignChange,
-          apply: async () =>
+          apply: async ({ forced }) =>
             await runCampaignUpdate({
               identity: upstreamSha,
               channel: "dev",
               version: upstreamSha,
               tag: "dev",
+              forced,
               root: root ?? status.root ?? undefined,
               devTargetSha: target.upstreamSha,
               log: params.log,
@@ -1116,12 +1147,13 @@ export async function runGatewayUpdateCheck(params: {
           target,
           inspect: params.activeWorkInspectors,
           onChange: onCampaignChange,
-          apply: async () =>
+          apply: async ({ forced }) =>
             await runCampaignUpdate({
               identity: resolvedVersion,
               channel,
               version: resolvedVersion,
               tag,
+              forced,
               root: root ?? status.root ?? undefined,
               log: params.log,
               runAuto,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators debugging scheduled updates could see final apply outcomes but not the campaign transitions, holds, or manual adoption that led to them.

## Why This Change Was Made

Campaign lifecycle decisions now log at their owning boundaries: the scheduler records each deduplicated transition and end, apply outcomes record whether the deadline forced them, and Gateway RPC handlers record hold decisions plus manual campaign adoption and failure release. This is logging-only; it adds no protocol, schema, or configuration surface.

## User Impact

Operators can reconstruct an update campaign from announcement through countdown, hold, apply, adoption, failure, or clear using Gateway logs, including the campaign target and actor where relevant.

## Evidence

- `node scripts/run-vitest.mjs src/infra/update-startup.test.ts src/infra/update-campaign.test.ts src/gateway/server-methods/update-hold.test.ts src/gateway/server-methods/update-run-campaign.test.ts src/gateway/server-methods/update.test.ts` — 5 files, 119 tests passed.
- `pnpm tsgo:core` and `pnpm tsgo:core:test` — passed.
- Touched-file `oxfmt` and `oxlint` — passed.
- `git diff --check` — passed.
- Uncommitted autoreview — clean, no accepted/actionable findings.

## ClawSweeper rank-up moves

The suggested typed terminal/supersession event and broader disable/target-replacement tests are intentionally skipped for this focused logging PR:

- Replacing a target is represented by the new campaign transition; the controller does not emit `onCampaignChange(undefined)` for the displaced campaign.
- Disable paths can intentionally remove the cached campaign before clear, and this design requires the prior campaign ID only when it is available.
- Adding typed terminal or supersession events would change the controller's internal event contract beyond this logging-only change.
