### PR TITLE
ci: validate exact head for #119819

### DIFF
--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -781,4 +781,39 @@ describe("dispatchAgentHook trust handling", () => {
       ),
     );
   });
+
+  it("targets requestHeartbeat to the hook's agentId, not globally (#119808)", async () => {
+    runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
+      status: "ok",
+      result: { summary: "done", text: "done" },
+    });
+
+    dispatchAgentHook({
+      ...buildAgentPayload("Targeted", "hooks"),
+      deliver: true,
+      delivery: { mode: "announce" as const },
+    });
+
+    await waitForFast(() =>
+      expect(requestHeartbeatMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: "hooks",
+        }),
+      ),
+    );
+  });
+
+  it("targets requestHeartbeat to the hook's agentId on error path (#119808)", async () => {
+    runCronIsolatedAgentTurnMock.mockRejectedValueOnce(new Error("agent exploded"));
+
+    dispatchAgentHook(buildAgentPayload("Targeted error", "hooks"));
+
+    await waitForFast(() =>
+      expect(requestHeartbeatMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: "hooks",
+        }),
+      ),
+    );
+  });
 });

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -46,8 +46,8 @@ vi.mock("../../channels/plugins/helpers.js", () => ({
 }));
 vi.mock("../../config/sessions.js", () => ({
   resolveMainSessionKeyFromConfig: resolveMainSessionKeyMock,
-  resolveMainSessionKey: vi.fn(
-    (cfg?: { session?: { mainKey?: string } }) => `agent:main:${cfg?.session?.mainKey ?? "main"}`,
+  resolveMainSessionKey: vi.fn((cfg?: { session?: { mainKey?: string; scope?: string } }) =>
+    cfg?.session?.scope === "global" ? "global" : `agent:main:${cfg?.session?.mainKey ?? "main"}`,
   ),
   resolveAgentMainSessionKey: vi.fn(
     (params: { cfg?: { session?: { mainKey?: string } }; agentId: string }) =>
@@ -824,5 +824,63 @@ describe("dispatchAgentHook trust handling", () => {
         }),
       ),
     );
+  });
+
+  it("keeps global-scope announcement events and wakes on the selected agent", async () => {
+    loadConfigMock.mockReturnValue({
+      agents: { entries: { main: { default: true }, hooks: {} } },
+      session: { scope: "global" },
+    });
+    runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
+      status: "ok",
+      summary: "done",
+      delivered: false,
+      deliveryAttempted: false,
+    });
+
+    dispatchAgentHook({
+      ...buildAgentPayload("Global announce", "hooks"),
+      deliver: true,
+      delivery: { mode: "announce" as const },
+    });
+
+    await waitForFast(() =>
+      expect(enqueueSystemEventMock).toHaveBeenCalledWith("Hook Global announce: done", {
+        sessionKey: "global",
+      }),
+    );
+    await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
+    expect(requestHeartbeatMock.mock.calls[0]?.[0]).toMatchObject({
+      source: "hook",
+      intent: "immediate",
+      reason: expect.stringMatching(/^hook:[0-9a-f-]+$/),
+      agentId: "hooks",
+    });
+    expect(requestHeartbeatMock.mock.calls[0]?.[0]?.sessionKey).toBeUndefined();
+  });
+
+  it("keeps global-scope error events and wakes on the selected agent", async () => {
+    loadConfigMock.mockReturnValue({
+      agents: { entries: { main: { default: true }, hooks: {} } },
+      session: { scope: "global" },
+    });
+    runCronIsolatedAgentTurnMock.mockRejectedValueOnce(new Error("agent exploded"));
+
+    dispatchAgentHook(buildAgentPayload("Global error", "hooks"));
+
+    await waitForFast(() =>
+      expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+        "Hook Global error (error): Error: agent exploded",
+        { sessionKey: "global" },
+      ),
+    );
+    await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
+    expect(requestHeartbeatMock.mock.calls[0]?.[0]).toMatchObject({
+      source: "hook",
+      intent: "immediate",
+      reason: expect.stringMatching(/^hook:[0-9a-f-]+:error$/),
+      agentId: "hooks",
+    });
+    expect(requestHeartbeatMock.mock.calls[0]?.[0]?.sessionKey).toBeUndefined();
   });
 });

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -483,7 +483,7 @@ describe("dispatchAgentHook trust handling", () => {
       throw new Error("config exploded");
     });
 
-    const result = await dispatchAgentHook(buildAgentPayload("Config"));
+    const result = await dispatchAgentHook(buildAgentPayload("Config", "hooks"));
 
     expect(result).toMatchObject({
       ok: false,
@@ -497,6 +497,15 @@ describe("dispatchAgentHook trust handling", () => {
         { sessionKey: "main-session" },
       ),
     );
+    await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
+    const wake = requestHeartbeatMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(wake).toMatchObject({
+      source: "hook",
+      intent: "immediate",
+      reason: expect.stringMatching(/^hook:[0-9a-f-]+:error$/),
+      sessionKey: "main-session",
+    });
+    expect(wake.agentId).toBeUndefined();
     await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
   });
 

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -314,6 +314,8 @@ export function createGatewayHooksRequestHandler(params: {
           source: "hook",
           intent: "immediate",
           reason: `hook:${jobId}:error`,
+          agentId: value.agentId,
+          sessionKey: hookEventSessionKey,
         });
       }
     };
@@ -471,7 +473,13 @@ export function createGatewayHooksRequestHandler(params: {
               sessionKey: eventSessionKey,
             });
             if (value.wakeMode === "now") {
-              requestHeartbeat({ source: "hook", intent: "immediate", reason: `hook:${jobId}` });
+              requestHeartbeat({
+                source: "hook",
+                intent: "immediate",
+                reason: `hook:${jobId}`,
+                agentId: value.agentId,
+                sessionKey: hookEventSessionKey,
+              });
             }
           } else if (result.status === "ok" && !value.deliver) {
             logHooks.info("hook agent run completed without announcement", {

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -53,10 +53,45 @@ const HOOK_AGENT_SESSION_CONFLICT_ERROR =
   "hook agent run was rejected because the target session changed";
 const HOOK_AGENT_PREPARATION_ERROR = "hook agent run failed before entering the agent runner";
 
-function resolveHookEventSessionKey(params: { cfg: OpenClawConfig; agentId?: string }): string {
-  return params.agentId
-    ? resolveAgentMainSessionKey({ cfg: params.cfg, agentId: params.agentId })
-    : resolveMainSessionKey(params.cfg);
+type HookEventTarget = {
+  eventSessionKey: string;
+  heartbeatTarget: { agentId?: string; sessionKey?: string };
+};
+
+function resolveHookEventTarget(params: {
+  cfg: OpenClawConfig;
+  resolvedAgentId: string;
+  explicitAgentId?: string;
+  sessionKey?: string;
+}): HookEventTarget {
+  if (params.cfg.session?.scope === "global") {
+    // Each agent owns a literal `global` row in its store. Target the agent,
+    // but never force an agent-qualified session key that the runner ignores.
+    return {
+      eventSessionKey: "global",
+      heartbeatTarget: { agentId: params.resolvedAgentId },
+    };
+  }
+  const eventSessionKey = params.sessionKey
+    ? canonicalizeMainSessionAlias({
+        cfg: params.cfg,
+        agentId: params.resolvedAgentId,
+        sessionKey: toAgentStoreSessionKey({
+          agentId: params.resolvedAgentId,
+          requestKey: params.sessionKey,
+          mainKey: params.cfg.session?.mainKey,
+        }),
+      })
+    : params.explicitAgentId
+      ? resolveAgentMainSessionKey({ cfg: params.cfg, agentId: params.explicitAgentId })
+      : resolveMainSessionKey(params.cfg);
+  return {
+    eventSessionKey,
+    heartbeatTarget: {
+      ...(params.explicitAgentId ? { agentId: params.explicitAgentId } : {}),
+      sessionKey: eventSessionKey,
+    },
+  };
 }
 
 function shouldAnnounceHookRunResult(params: {
@@ -233,27 +268,12 @@ export function createGatewayHooksRequestHandler(params: {
       ? (() => {
           const cfg = getRuntimeConfig();
           const agentId = value.agentId ?? resolveDefaultAgentId(cfg);
-          if (cfg.session?.scope === "global") {
-            return {
-              eventSessionKey: "global",
-              heartbeatTarget: { agentId },
-            };
-          }
-          const eventSessionKey = canonicalizeMainSessionAlias({
+          return resolveHookEventTarget({
             cfg,
-            agentId,
-            sessionKey: value.sessionKey
-              ? toAgentStoreSessionKey({
-                  agentId,
-                  requestKey: value.sessionKey,
-                  mainKey: cfg.session?.mainKey,
-                })
-              : resolveAgentMainSessionKey({ cfg, agentId }),
+            resolvedAgentId: agentId,
+            explicitAgentId: value.agentId,
+            sessionKey: value.sessionKey,
           });
-          return {
-            eventSessionKey,
-            heartbeatTarget: { agentId, sessionKey: eventSessionKey },
-          };
         })()
       : undefined;
     const sessionKey = target?.eventSessionKey ?? resolveMainSessionKeyFromConfig();
@@ -303,10 +323,10 @@ export function createGatewayHooksRequestHandler(params: {
       delivery: value.delivery,
       state: { nextRunAtMs: nowMs },
     };
-    let hookEventSessionKey: string | undefined;
+    let hookEventTarget: HookEventTarget | undefined;
     const reportHookFailure = (err: unknown) => {
       logHooks.warn(`hook agent failed: ${String(err)}`);
-      const eventSessionKey = hookEventSessionKey ?? resolveMainSessionKeyFromConfig();
+      const eventSessionKey = hookEventTarget?.eventSessionKey ?? resolveMainSessionKeyFromConfig();
       enqueueSystemEvent(`Hook ${safeName} (error): ${String(err)}`, {
         sessionKey: eventSessionKey,
       });
@@ -317,8 +337,7 @@ export function createGatewayHooksRequestHandler(params: {
           source: "hook",
           intent: "immediate",
           reason: `hook:${jobId}:error`,
-          ...(hookEventSessionKey ? { agentId: value.agentId } : {}),
-          sessionKey: eventSessionKey,
+          ...(hookEventTarget?.heartbeatTarget ?? { sessionKey: eventSessionKey }),
         });
       }
     };
@@ -403,9 +422,10 @@ export function createGatewayHooksRequestHandler(params: {
           }
           // Keep an omitted agent omitted for event routing so global session scope
           // stays global; runner identity is frozen separately via accepted agentId.
-          hookEventSessionKey = resolveHookEventSessionKey({
+          hookEventTarget = resolveHookEventTarget({
             cfg,
-            agentId: acceptedValue.agentId,
+            resolvedAgentId: agentId,
+            explicitAgentId: acceptedValue.agentId,
           });
           const { runCronIsolatedAgentTurn } = await loadIsolatedAgentModule();
           // Lazy module loading is the last Gateway-owned async boundary before
@@ -471,7 +491,8 @@ export function createGatewayHooksRequestHandler(params: {
             });
           }
           if (shouldAnnounce) {
-            const eventSessionKey = hookEventSessionKey ?? resolveMainSessionKeyFromConfig();
+            const eventSessionKey =
+              hookEventTarget?.eventSessionKey ?? resolveMainSessionKeyFromConfig();
             enqueueSystemEvent(`${prefix}: ${summary}`.trim(), {
               sessionKey: eventSessionKey,
             });
@@ -480,8 +501,7 @@ export function createGatewayHooksRequestHandler(params: {
                 source: "hook",
                 intent: "immediate",
                 reason: `hook:${jobId}`,
-                agentId: value.agentId,
-                sessionKey: hookEventSessionKey,
+                ...(hookEventTarget?.heartbeatTarget ?? { sessionKey: eventSessionKey }),
               });
             }
           } else if (result.status === "ok" && !value.deliver) {

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -306,16 +306,19 @@ export function createGatewayHooksRequestHandler(params: {
     let hookEventSessionKey: string | undefined;
     const reportHookFailure = (err: unknown) => {
       logHooks.warn(`hook agent failed: ${String(err)}`);
+      const eventSessionKey = hookEventSessionKey ?? resolveMainSessionKeyFromConfig();
       enqueueSystemEvent(`Hook ${safeName} (error): ${String(err)}`, {
-        sessionKey: hookEventSessionKey ?? resolveMainSessionKeyFromConfig(),
+        sessionKey: eventSessionKey,
       });
       if (value.wakeMode === "now") {
+        // Before config resolves, the error belongs to the fallback main session.
+        // Wake that exact session; the requested hook agent may not own it.
         requestHeartbeat({
           source: "hook",
           intent: "immediate",
           reason: `hook:${jobId}:error`,
-          agentId: value.agentId,
-          sessionKey: hookEventSessionKey,
+          ...(hookEventSessionKey ? { agentId: value.agentId } : {}),
+          sessionKey: eventSessionKey,
         });
       }
     };


### PR DESCRIPTION
## What Problem This Solves

Provides same-repository CI execution for the exact reviewed head of #119819 after the fork's GitHub-hosted lanes repeatedly hit resource watchdogs unrelated to the two-file Gateway patch.

## Why This Change Was Made

The branch points at the identical commit used by #119819. This temporary PR exists only to obtain authoritative Blacksmith pull-request CI for that exact SHA; it is not a replacement implementation and must not be merged.

## User Impact

None. No additional code is introduced beyond #119819.

## Evidence

- Original PR: #119819
- Exact head: `a2bac96472bb82a3e44f763ced918ecbb515d78a`
- Focused Gateway tests: 23/23 passed.
- Fresh autoreview: clean, no actionable findings.
