### PR TITLE
fix(ui): remove model picker chevrons

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -285,7 +285,6 @@ function composerControlsHtml() {
           <details class="chat-controls__inline-select chat-controls__model-picker">
           <summary class="chat-controls__inline-select-trigger" data-chat-composer-model="true" aria-label="Chat model">
             <span class="chat-controls__inline-select-label">GPT-5.6</span>
-            <span class="chat-controls__inline-select-icon">${iconSvg()}</span>
           </summary>
           <div class="chat-controls__inline-select-menu chat-controls__model-menu">
             <div class="chat-controls__model-search-wrap"><input class="chat-controls__model-search" placeholder="Search models" /></div>
@@ -299,7 +298,6 @@ function composerControlsHtml() {
           <details class="chat-controls__inline-select chat-controls__effort-picker">
           <summary class="chat-controls__inline-select-trigger" data-chat-composer-effort="true" aria-label="Effort">
             <span class="chat-controls__inline-select-label">High</span>
-            <span class="chat-controls__inline-select-icon">${iconSvg()}</span>
           </summary>
           <div class="chat-controls__inline-select-menu chat-controls__effort-menu">
             <div class="chat-controls__reasoning-panel">Effort</div>

--- a/ui/src/pages/chat/components/chat-effort-picker.ts
+++ b/ui/src/pages/chat/components/chat-effort-picker.ts
@@ -162,9 +162,6 @@ export function renderChatEffortPicker(params: ChatEffortPickerParams) {
           ? html`<span class="chat-controls__effort-zap" aria-hidden="true">${icons.zap}</span>`
           : nothing}
         <span class="chat-controls__inline-select-label">${triggerLabel}</span>
-        <span class="chat-controls__inline-select-icon" aria-hidden="true">
-          ${icons.chevronDown}
-        </span>
       </summary>
       <div
         class="chat-controls__inline-select-menu chat-controls__effort-menu"

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -406,9 +406,6 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
         ${params.triggerStatusLabel || !triggerMeta
           ? nothing
           : html`<span class="chat-controls__trigger-meta">${triggerMeta}</span>`}
-        <span class="chat-controls__inline-select-icon" aria-hidden="true">
-          ${icons.chevronDown}
-        </span>
       </summary>
       <div
         class="chat-controls__inline-select-menu chat-controls__model-menu"

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -4347,26 +4347,11 @@ openclaw-chat-video-player {
   height: 12px;
 }
 
-/* Keep the chevron pinned right when the mobile trigger stretches. */
-.chat-controls__inline-select-icon {
-  display: inline-flex;
-  width: 14px;
-  height: 14px;
-  margin-left: auto;
-  color: var(--muted);
-  flex: 0 0 auto;
-}
-
-.chat-controls__inline-select-icon svg,
 .chat-controls__inline-select-check svg {
   width: 100%;
   height: 100%;
   stroke: currentColor;
   fill: none;
-}
-
-.chat-controls__inline-select[open] .chat-controls__inline-select-icon {
-  transform: rotate(180deg);
 }
 
 .chat-controls__inline-select-menu {


### PR DESCRIPTION
## What Problem This Solves

The chat composer’s model and effort controls showed small chevron arrows that added visual noise without adding interaction or state information beyond the native expandable controls.

## Why This Change Was Made

Remove the decorative chevrons from both triggers and delete their now-unused styling. The existing details/summary controls continue to own click, keyboard, focus, disabled, and expanded behavior.

## User Impact

The composer footer is cleaner and more compact while model selection, effort selection, context metadata, and accessibility behavior remain unchanged.

AI-assisted: yes.

## Evidence

### Before

<img width="298" height="66" alt="Model picker before" src="https://github.com/user-attachments/assets/da8faa7b-d912-4a73-8ec0-4e9387809011" />

### After

<img width="258" height="66" alt="Model picker after" src="https://github.com/user-attachments/assets/a4dff323-2cf9-42fc-9c77-a421df9682a9" />
- Source-blind mock-gateway Chromium validation: model and effort labels remain visible; both triggers focus and open via Enter; no chevrons render; the context ring remains visible; footer controls remain aligned.
- Focused tests: 76 responsive browser tests and 6 composer E2E tests passed via `node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts ui/src/e2e/chat-composer-redesign.e2e.test.ts`
- `oxfmt --check` on all four changed files
- `stylelint` on all four changed files
- Codex autoreview: clean, no accepted/actionable findings
