### PR TITLE
fix(ui): quiet tool-activity rows with one hover treatment

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -746,7 +746,8 @@ img.chat-avatar.chat-avatar--logo {
   outline-offset: 2px;
 }
 
-.chat-bubble:hover {
+/* Tool rows own their hover treatment; an accent border reads as an error. */
+.chat-bubble:not(:where(.chat-bubble--tool-shell)):hover {
   border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
 }
 

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -19,7 +19,7 @@
    the row's 8px inline inset bleeds left into the avatar gutter (never right,
    which could overflow the thread on narrow panes) so the hover pill keeps
    its inset without indenting the icon/label. Child combinator keeps shells
-   nested in .chat-activity-group__body on the boxed 12px inset. */
+   nested in .chat-activity-group__body on the group's indented rail. */
 .chat-group-messages > .chat-bubble--tool-shell .chat-tool-msg-summary {
   width: calc(100% + 8px);
   margin-left: -8px;
@@ -1078,33 +1078,15 @@
   flex-shrink: 0;
 }
 
-/* Rows live in one bordered card with hairline separators. */
+/* Rows form a flat indented list below the summary. The rail marks the group
+   extent while shared row hover pills remain free of per-row chrome. */
 .chat-activity-group__body {
   display: flex;
   flex-direction: column;
-  gap: 0;
-  margin: 4px 0 0 2px;
-  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
-  border-radius: var(--radius-md, 10px);
-  background: color-mix(in srgb, var(--card, var(--bg)) 55%, transparent);
-  overflow: hidden;
-}
-
-.chat-activity-group__body > .chat-bubble {
-  border-top: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
-}
-
-.chat-activity-group__body > .chat-bubble:first-child {
-  border-top: 0;
-}
-
-.chat-activity-group__body .chat-tool-msg-summary {
-  padding: 7px 12px;
-  border-radius: 0;
-}
-
-.chat-activity-group__body .chat-tool-msg-body {
-  padding: 0 12px 10px 12px;
+  gap: 2px;
+  margin: 4px 0 0 10px;
+  padding-left: 10px;
+  border-left: 2px solid color-mix(in srgb, var(--border) 82%, transparent);
 }
 
 /* Completed-turn work rollup: slim "Worked for X" disclosure standing in for


### PR DESCRIPTION
## What Problem This Solves
The chat tool-activity UI stacked four layers of chrome: a bordered card around expanded tool groups, a background tint, 1px hairline separators between rows, and per-row radius flattening. Hovering a row inside a group showed a square highlight while rows outside groups showed a 6px rounded pill — a visible corner mismatch. Worse, the generic `.chat-bubble:hover` accent-border rule tinted the group's hairline separators red (`--accent` #ff5c5c) on hover, which read as an error state on perfectly healthy rows.

## Why This Change Was Made
Tool rows are declared chrome-free by design (comment at the top of `ui/src/styles/chat/tool-cards.css`); the bordered group card reintroduced chrome on top of that and created three competing corner radii (6px pill, 0 in-card, 10px clipped container). This change restores one enclosure (a single 2px left rail marking group extent) and one hover treatment (the shared 6px pill) everywhere, and scopes the accent hover rule away from tool-shell bubbles so the red-hairline bug class is removed rather than patched per-row.

## User Impact
Calmer transcript: expanded tool groups render as a flat indented list under the summary instead of a bordered card with separators. Hover looks identical on every tool row, and the spurious red hover line is gone. CSS-only; net −17 LOC.

## Evidence
- Verified live in the mock Control UI dev server (`pnpm dev:ui:mock`, mock gateway + seeded tool turn): before, the group body computed `border: 1px`, `border-radius: 10px`, `background` tint, row `border-radius: 0`; after, body computes a `2px` left rail only, `border-radius: 0`, transparent background, rows `border-radius: 6px`, bubble `border-top: 0` (accent hover leak no longer has a border to tint). Row label indent (30px) matches the group header label edge.
- Focused e2e: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts` — 4/4 passed.
- `pnpm lint:ui:styles` clean; `git diff --check` clean.
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings.
