### PR TITLE
fix(ui): streamline live token counter in the chat working row

### DIFF
--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -521,7 +521,7 @@ suite.define(() => {
         .poll(async () =>
           (await page.locator(".chat-working-indicator__tokens").textContent())?.trim(),
         )
-        .toBe("2.4k output tokens");
+        .toBe("2.4k tokens");
 
       const response = "The streamed response is now visible.";
       await gateway.emitGatewayEvent("chat", {
@@ -542,7 +542,7 @@ suite.define(() => {
         (row, visibleResponse) => ({
           connected: row.isConnected,
           hasResponse: row.textContent?.includes(visibleResponse) ?? false,
-          hasTokens: row.textContent?.includes("2.4k output tokens") ?? false,
+          hasTokens: row.textContent?.includes("2.4k tokens") ?? false,
           key: row.getAttribute("data-virtual-row-key"),
         }),
         response,

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4348,7 +4348,6 @@ export const en: TranslationMap = {
       preparingContext: "Preparing this turn…",
       startingModel: "Waiting for a response…",
     },
-    outputTokens: "{count} output tokens",
     archivedSessionDisabled: "This session is archived. Unarchive it to continue the conversation.",
     sessionRoute: {
       chooseTitle: "Choose a session",

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1670,8 +1670,10 @@ describe("grouped chat rendering", () => {
 
     expect(container.querySelector(".chat-working-indicator__elapsed")).not.toBeNull();
     expect(container.querySelector(".chat-working-indicator__tokens")?.textContent?.trim()).toBe(
-      "5.5k output tokens",
+      "5.5k tokens",
     );
+    // Streaming tokens replace the whimsical phrase: one liveness signal at a time.
+    expect(container.querySelector("openclaw-working-phrase")).toBeNull();
   });
 
   it("relabels the working indicator while the run waits for approval", () => {

--- a/ui/src/pages/chat/components/chat-working-indicator.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.ts
@@ -51,15 +51,20 @@ function formatTurnRecapDuration(ms: number): string {
   return new Intl.ListFormat(locale, { style: "long", type: "unit" }).format(parts);
 }
 
+// 0 is a valid count (command-only turns); only null/undefined means "unknown".
+function outputTokensLabel(outputTokens: number): string {
+  return outputTokens === 1
+    ? t("chat.turnRecap.tokensOne")
+    : t("chat.turnRecap.tokens", { count: formatCompactTokenCount(outputTokens) });
+}
+
 function renderLiveOutputTokens(outputTokens: number | null | undefined) {
   if (outputTokens === null || outputTokens === undefined) {
     return nothing;
   }
   return html`
     <span aria-hidden="true">·</span>
-    <span class="chat-working-indicator__tokens">
-      ${t("chat.outputTokens", { count: formatCompactTokenCount(outputTokens) })}
-    </span>
+    <span class="chat-working-indicator__tokens">${outputTokensLabel(outputTokens)}</span>
   `;
 }
 
@@ -74,6 +79,9 @@ export function renderChatWorkingIndicator(
 ) {
   const waitingApproval = options.waitingApproval === true;
   const continuation = options.presentation === "continuation";
+  // Streaming tokens are the real liveness signal; the whimsical phrase only
+  // covers the stretch before any usage data exists.
+  const hasTokens = options.outputTokens !== null && options.outputTokens !== undefined;
   // The animated claw stays decorative; the text status exposes progress without
   // announcing every elapsed-time tick to screen readers.
   return html`
@@ -114,12 +122,15 @@ export function renderChatWorkingIndicator(
                   class="chat-working-indicator__elapsed"
                   .startMs=${part.startedAt}
                 ></openclaw-elapsed-time>
-                <openclaw-working-phrase
-                  aria-hidden="true"
-                  .startMs=${part.startedAt}
-                  .seed=${part.key}
-                ></openclaw-working-phrase>
-                ${renderLiveOutputTokens(options.outputTokens)}
+                ${hasTokens
+                  ? renderLiveOutputTokens(options.outputTokens)
+                  : html`
+                      <openclaw-working-phrase
+                        aria-hidden="true"
+                        .startMs=${part.startedAt}
+                        .seed=${part.key}
+                      ></openclaw-working-phrase>
+                    `}
               `}
       </span>
     </div>
@@ -136,13 +147,8 @@ export function renderTurnRecapRow(
   const continuation = options.presentation === "continuation";
   // Sub-second turns still read as one second; terminal recaps favor full words.
   const duration = formatTurnRecapDuration(recap.runtimeMs);
-  // 0 is a valid count (command-only turns); only null means "unknown".
   const tokens =
-    typeof recap.outputTokens === "number"
-      ? recap.outputTokens === 1
-        ? t("chat.turnRecap.tokensOne")
-        : t("chat.turnRecap.tokens", { count: formatCompactTokenCount(recap.outputTokens) })
-      : null;
+    typeof recap.outputTokens === "number" ? outputTokensLabel(recap.outputTokens) : null;
   return html`
     <div
       class="chat-tasks-status chat-turn-recap ${continuation


### PR DESCRIPTION
## What Problem This Solves

The live chat working row showed two liveness signals at once — the whimsical progress phrase ("Sifting…") and the streaming token counter — and its token label ("592 output tokens") diverged from the post-turn recap wording ("592 tokens"). The whimsical phrase exists specifically to keep long quiet runs feeling alive "without claiming progress data the UI does not have"; once tokens are streaming, we do have that data, so the phrase is redundant noise.

## Why This Change Was Made

Operator feedback on the working row: drop the "output" word and show the cute phrase only while there is no token count yet. The change tightens the row to one liveness signal at a time:

- Before usage data arrives: `🦞 3m 10s · Sifting…` (phrase keeps its 30s grace period)
- Once tokens stream: `🦞 3m 10s · 592 tokens`

The live indicator now reuses the shared `chat.turnRecap.tokens`/`tokensOne` labels (matching the recap row and its singular form), and the now-unused `chat.outputTokens` key is removed. Known tradeoff, accepted deliberately: once tokens exist the phrase never returns for that run, even during long tool-call stalls — the per-second elapsed timer keeps the row visibly alive.

## User Impact

Cleaner live status row in the Control UI chat: no "output" jargon, no duplicated whimsy next to a real progress number, and consistent token wording between the live row and the turn recap.

## Evidence

- Focused tests: `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-working-indicator.test.ts ui/src/pages/chat/components/chat-message.test.ts` — 168 passed, including a new assertion that the whimsical phrase is absent once tokens render.
- `node scripts/check-changed.mjs` (lanes coreTests, ui) run locally with the remote broker unavailable (Crabbox/Blacksmith auth down; local fallback per repo policy): format, i18n verify (`keys=4597`, baseline regenerated), `tsgo:core:test`, `tsgo:ui`, oxlint, deadcode — all green.
- Autoreview (Codex `gpt-5.6-sol`, high): clean, no accepted/actionable findings.
- E2E string assertions in `ui/src/e2e/chat-flow.streaming.e2e.test.ts` updated to the new label; hosted CI covers the streaming e2e lane.
