### PR TITLE
fix(release): keep beta survivor plugin repair hermetic

### DIFF
--- a/scripts/e2e/lib/clawhub-fixture-server.cjs
+++ b/scripts/e2e/lib/clawhub-fixture-server.cjs
@@ -1,4 +1,5 @@
 // CommonJS fixture server for ClawHub package/install E2E scenarios.
+const { execFileSync } = require("node:child_process");
 const crypto = require("node:crypto");
 const fs = require("node:fs");
 const http = require("node:http");
@@ -8,11 +9,149 @@ const { createRequire } = require("node:module");
 
 const profile = process.argv[2];
 const portFile = process.argv[3];
+const artifactManifestFile = process.argv[4];
 const requireFromApp = createRequire(path.join(process.cwd(), "package.json"));
 const JSZip = requireFromApp("jszip");
 const tar = requireFromApp("tar");
 const packageName = "@openclaw/kitchen-sink";
 const pluginId = "openclaw-kitchen-sink-fixture";
+
+function startPrepublishArtifactServer() {
+  const manifest = JSON.parse(fs.readFileSync(artifactManifestFile, "utf8"));
+  if (!Array.isArray(manifest.packages) || manifest.packages.length === 0) {
+    throw new Error("prepublish artifact manifest must contain packages");
+  }
+  const artifacts = new Map(
+    manifest.packages.map((entry) => {
+      if (
+        typeof entry.name !== "string" ||
+        typeof entry.version !== "string" ||
+        typeof entry.tarball !== "string" ||
+        path.basename(entry.tarball) !== entry.tarball
+      ) {
+        throw new Error("invalid prepublish artifact manifest entry");
+      }
+      const tarballPath = path.join(path.dirname(artifactManifestFile), entry.tarball);
+      const archive = fs.readFileSync(tarballPath);
+      const sha256 = crypto.createHash("sha256").update(archive).digest("hex");
+      const packedPackage = JSON.parse(
+        execFileSync("tar", ["-xOf", tarballPath, "package/package.json"], {
+          encoding: "utf8",
+        }),
+      );
+      const packedPlugin = JSON.parse(
+        execFileSync("tar", ["-xOf", tarballPath, "package/openclaw.plugin.json"], {
+          encoding: "utf8",
+        }),
+      );
+      if (
+        sha256 !== entry.sha256 ||
+        packedPackage.name !== entry.name ||
+        packedPackage.version !== entry.version ||
+        typeof packedPlugin.id !== "string" ||
+        packedPlugin.id.length === 0
+      ) {
+        throw new Error(`prepublish artifact metadata mismatch for ${entry.name}`);
+      }
+      return [
+        entry.name,
+        {
+          ...entry,
+          archive,
+          runtimeId: packedPlugin.id,
+          npmIntegrity: `sha512-${crypto.createHash("sha512").update(archive).digest("base64")}`,
+          npmShasum: crypto.createHash("sha1").update(archive).digest("hex"),
+        },
+      ];
+    }),
+  );
+  const requestLog = [];
+  const json = (response, value, status = 200) => {
+    response.writeHead(status, { "content-type": "application/json" });
+    response.end(`${JSON.stringify(value)}\n`);
+  };
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url, "http://127.0.0.1");
+    if (url.pathname === "/__fixture__/requests") {
+      json(response, { requests: requestLog });
+      return;
+    }
+    requestLog.push(`${request.method} ${url.pathname}${url.search}`);
+    const match =
+      /^\/api\/v1\/packages\/([^/]+)(?:\/versions\/([^/]+)(?:\/(artifact(?:\/download)?|security))?)?$/u.exec(
+        url.pathname,
+      );
+    const entry = match ? artifacts.get(decodeURIComponent(match[1])) : undefined;
+    if (request.method !== "GET" || !entry) {
+      response.writeHead(request.method === "GET" ? 404 : 405);
+      response.end(request.method === "GET" ? "not found" : "method not allowed");
+      return;
+    }
+    const version = match[2] ? decodeURIComponent(match[2]) : undefined;
+    if (version && version !== entry.version) {
+      json(response, { error: "version not found" }, 404);
+      return;
+    }
+    const packageRecord = {
+      name: entry.name,
+      family: "code-plugin",
+      runtimeId: entry.runtimeId,
+    };
+    const artifact = {
+      kind: "npm-pack",
+      sha256: entry.sha256,
+      npmIntegrity: entry.npmIntegrity,
+      npmShasum: entry.npmShasum,
+    };
+    const versionRecord = {
+      version: entry.version,
+      artifact,
+    };
+    if (!version) {
+      json(response, {
+        package: {
+          ...packageRecord,
+          channel: "official",
+          isOfficial: true,
+          latestVersion: entry.version,
+          tags: { latest: entry.version, beta: entry.version },
+        },
+      });
+    } else if (!match[3]) {
+      json(response, { package: packageRecord, version: versionRecord });
+    } else if (match[3] === "security") {
+      json(response, {
+        trust: {
+          blockedFromDownload: false,
+          reasons: [],
+          pending: false,
+          stale: false,
+        },
+      });
+    } else if (match[3] === "artifact") {
+      json(response, {
+        version: versionRecord,
+        artifact: {
+          artifactKind: "npm-pack",
+          artifactSha256: entry.sha256,
+          npmIntegrity: entry.npmIntegrity,
+        },
+      });
+    } else {
+      response.writeHead(200, {
+        "content-type": "application/octet-stream",
+        "X-ClawHub-Artifact-Sha256": entry.sha256,
+        "X-ClawHub-Npm-Integrity": entry.npmIntegrity,
+        "X-ClawHub-Npm-Shasum": entry.npmShasum,
+        "X-ClawHub-Npm-Tarball-Name": entry.tarball,
+      });
+      response.end(entry.archive);
+    }
+  });
+  server.listen(0, "127.0.0.1", () => {
+    fs.writeFileSync(portFile, String(server.address().port));
+  });
+}
 
 const buildArtifactSummary = ({
   clawpackSha256,
@@ -440,8 +579,12 @@ profiles["catalog-search"] = {
 
 const fixture = profiles[profile];
 if (!fixture || !portFile) {
+  if (profile === "prepublish-artifacts" && portFile && artifactManifestFile) {
+    startPrepublishArtifactServer();
+    return;
+  }
   console.error(
-    "usage: clawhub-fixture-server.cjs <catalog-search|kitchen-sink-plugin|plugins> <port-file>",
+    "usage: clawhub-fixture-server.cjs <catalog-search|kitchen-sink-plugin|plugins|prepublish-artifacts> <port-file> [manifest-file]",
   );
   process.exit(1);
 }

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -57,6 +57,7 @@ FAILURE_PHASE=""
 FAILURE_MESSAGE=""
 gateway_pid=""
 plugin_registry_pid=""
+clawhub_fixture_pid=""
 baseline_spec=""
 baseline_version=""
 baseline_version_expected="0"
@@ -229,9 +230,6 @@ NODE
 }
 
 cleanup() {
-  if [ -n "${plugin_registry_pid:-}" ]; then
-    kill "$plugin_registry_pid" >/dev/null 2>&1 || true
-  fi
   if [ -s "$SYSTEMCTL_SHIM_PID_FILE" ]; then
     systemctl --user stop openclaw-gateway.service >/dev/null 2>&1 || true
   fi
@@ -243,6 +241,8 @@ cleanup() {
       openclaw_e2e_terminate_gateways "$shim_pid"
     fi
   fi
+  openclaw_e2e_stop_process "${plugin_registry_pid:-}"
+  openclaw_e2e_stop_process "${clawhub_fixture_pid:-}"
 }
 
 on_error() {
@@ -373,6 +373,33 @@ TS
   echo "Seeded source-only plugin shadow: $shadow_root"
 }
 
+wait_for_fixture_port() {
+  local pid="$1" port_file="$2" log_file="$3" label="$4"
+  for _ in $(seq 1 100); do
+    [ -s "$port_file" ] && return 0
+    openclaw_e2e_process_alive "$pid" || break
+    sleep 0.1
+  done
+  openclaw_e2e_print_log "$log_file" >&2
+  echo "Timed out waiting for upgrade survivor $label." >&2
+  return 1
+}
+
+configure_clawhub_fixture() {
+  unset OPENCLAW_CLAWHUB_URL CLAWHUB_URL
+  [ -z "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ] && return 0
+  local fixture_root="$ARTIFACT_ROOT/clawhub-fixture" port_file log_file
+  port_file="$fixture_root/port"
+  log_file="$fixture_root/server.log"
+  mkdir -p "$fixture_root"
+  node "${OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER:-scripts/e2e/lib/clawhub-fixture-server.cjs}" \
+    prepublish-artifacts "$port_file" \
+    "$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR/prepublish-plugin-registry.json" >"$log_file" 2>&1 &
+  clawhub_fixture_pid="$!"
+  wait_for_fixture_port "$clawhub_fixture_pid" "$port_file" "$log_file" "ClawHub fixture"
+  export OPENCLAW_CLAWHUB_URL="http://127.0.0.1:$(cat "$port_file")"
+}
+
 configure_plugin_registry() {
   local fixture_root="$ARTIFACT_ROOT/plugin-registry"
   local package_dir="$fixture_root/package"
@@ -482,22 +509,9 @@ NODE
     >"$log_file" 2>&1 &
   plugin_registry_pid="$!"
 
-  for _ in $(seq 1 100); do
-    if [ -s "$port_file" ]; then
-      export NPM_CONFIG_REGISTRY="http://127.0.0.1:$(cat "$port_file")"
-      export npm_config_registry="$NPM_CONFIG_REGISTRY"
-      return 0
-    fi
-    if ! kill -0 "$plugin_registry_pid" 2>/dev/null; then
-      openclaw_e2e_print_log "$log_file" >&2
-      return 1
-    fi
-    sleep 0.1
-  done
-
-  openclaw_e2e_print_log "$log_file" >&2
-  echo "Timed out waiting for upgrade survivor npm registry." >&2
-  return 1
+  wait_for_fixture_port "$plugin_registry_pid" "$port_file" "$log_file" "npm registry"
+  export NPM_CONFIG_REGISTRY="http://127.0.0.1:$(cat "$port_file")"
+  export npm_config_registry="$NPM_CONFIG_REGISTRY"
 }
 
 legacy_plugin_dependency_probe_paths() {
@@ -1462,8 +1476,11 @@ phase assert-baseline assert_baseline_state
 phase seed-legacy-runtime-deps-symlink seed_legacy_runtime_deps_symlink
 phase resolve-candidate resolve_candidate_version
 phase prepare-update-restart-probe prepare_update_restart_probe
+phase configure-clawhub-fixture configure_clawhub_fixture
 phase configure-plugin-registry configure_plugin_registry
 phase update-candidate update_candidate
+[ -z "${OPENCLAW_CLAWHUB_URL:-}" ] || CLAWHUB_EXPECTED_VERSION="$candidate_version" \
+  node -e 'const n="@openclaw/whatsapp",v=encodeURIComponent(process.env.CLAWHUB_EXPECTED_VERSION),p=`/api/v1/packages/${encodeURIComponent(n)}`,expected=[`GET ${p}`,`GET ${p}/versions/${v}/artifact`,`GET ${p}/versions/${v}/security`,`GET ${p}/versions/${v}/artifact/download`];fetch(`${process.env.OPENCLAW_CLAWHUB_URL}/__fixture__/requests`).then((response)=>response.json()).then(({requests})=>{if(JSON.stringify(requests)!==JSON.stringify(expected))throw new Error(`unexpected ClawHub fixture requests: ${JSON.stringify(requests)}`)})'
 phase root-managed-vps-cli-usable assert_root_managed_vps_cli_usable
 phase assert-legacy-plugin-dependency-debris-before-doctor assert_legacy_plugin_dependency_debris_before_doctor
 phase doctor run_doctor

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -176,8 +176,10 @@ if [ "${OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE:-0}" = "1" ]; then
     -e OPENCLAW_UPGRADE_SURVIVOR_SUMMARY_JSON=/tmp/openclaw-upgrade-survivor-artifacts/summary.json \
     -e OPENCLAW_UPGRADE_SURVIVOR_START_BUDGET_SECONDS="$START_BUDGET_SECONDS" \
     -e OPENCLAW_UPGRADE_SURVIVOR_STATUS_BUDGET_SECONDS="$STATUS_BUDGET_SECONDS" \
+    -e OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER=/tmp/openclaw-clawhub-fixture-server.cjs \
     "${PROBE_ENV_ARGS[@]}" \
     -v "$ARTIFACT_DIR:/tmp/openclaw-upgrade-survivor-artifacts" \
+    -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/clawhub-fixture-server.cjs:/tmp/openclaw-clawhub-fixture-server.cjs:ro" \
     -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/run.sh:/tmp/openclaw-upgrade-survivor-run.sh:ro" \
     "${PREPUBLISH_PLUGIN_REGISTRY_ARGS[@]}" \
     "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
@@ -206,8 +208,10 @@ docker_e2e_run_with_harness \
   -e OPENCLAW_UPGRADE_SURVIVOR_COMMAND_TIMEOUT="$COMMAND_TIMEOUT" \
   -e OPENCLAW_UPGRADE_SURVIVOR_START_BUDGET_SECONDS="$START_BUDGET_SECONDS" \
   -e OPENCLAW_UPGRADE_SURVIVOR_STATUS_BUDGET_SECONDS="$STATUS_BUDGET_SECONDS" \
+  -e OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER=/tmp/openclaw-clawhub-fixture-server.cjs \
   "${PROBE_ENV_ARGS[@]}" \
   -v "$ARTIFACT_DIR:/tmp/openclaw-upgrade-survivor-artifacts" \
+  -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/clawhub-fixture-server.cjs:/tmp/openclaw-clawhub-fixture-server.cjs:ro" \
   "${PREPUBLISH_PLUGIN_REGISTRY_ARGS[@]}" \
   "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
   "${DOCKER_RUN_USER_ARGS[@]}" \
@@ -265,10 +269,8 @@ export OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_ERR="$BASELINE_SERVICE
 
 gateway_pid=""
 plugin_registry_pid=""
+clawhub_fixture_pid=""
 cleanup() {
-  if [ -n "${plugin_registry_pid:-}" ]; then
-    kill "$plugin_registry_pid" >/dev/null 2>&1 || true
-  fi
   if [ -s "$SYSTEMCTL_SHIM_PID_FILE" ]; then
     systemctl --user stop openclaw-gateway.service >/dev/null 2>&1 || true
   fi
@@ -276,8 +278,37 @@ cleanup() {
   if [ -s "$SYSTEMCTL_SHIM_PID_FILE" ]; then
     openclaw_e2e_terminate_gateways "$(cat "$SYSTEMCTL_SHIM_PID_FILE" 2>/dev/null || true)"
   fi
+  openclaw_e2e_stop_process "${plugin_registry_pid:-}"
+  openclaw_e2e_stop_process "${clawhub_fixture_pid:-}"
 }
 trap cleanup EXIT
+
+wait_for_fixture_port() {
+  local pid="$1" port_file="$2" log_file="$3" label="$4"
+  for _ in $(seq 1 100); do
+    [ -s "$port_file" ] && return 0
+    openclaw_e2e_process_alive "$pid" || break
+    sleep 0.1
+  done
+  openclaw_e2e_print_log "$log_file" >&2
+  echo "Timed out waiting for upgrade survivor $label." >&2
+  return 1
+}
+
+configure_clawhub_fixture() {
+  unset OPENCLAW_CLAWHUB_URL CLAWHUB_URL
+  [ -z "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ] && return 0
+  local fixture_root="$OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT/clawhub-fixture" port_file log_file
+  port_file="$fixture_root/port"
+  log_file="$fixture_root/server.log"
+  mkdir -p "$fixture_root"
+  node "$OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER" \
+    prepublish-artifacts "$port_file" \
+    "$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR/prepublish-plugin-registry.json" >"$log_file" 2>&1 &
+  clawhub_fixture_pid="$!"
+  wait_for_fixture_port "$clawhub_fixture_pid" "$port_file" "$log_file" "ClawHub fixture"
+  export OPENCLAW_CLAWHUB_URL="http://127.0.0.1:$(cat "$port_file")"
+}
 
 configure_plugin_registry() {
   local fixture_root="$OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT/plugin-registry"
@@ -388,22 +419,9 @@ NODE
     >"$log_file" 2>&1 &
   plugin_registry_pid="$!"
 
-  for _ in $(seq 1 100); do
-    if [ -s "$port_file" ]; then
-      export NPM_CONFIG_REGISTRY="http://127.0.0.1:$(cat "$port_file")"
-      export npm_config_registry="$NPM_CONFIG_REGISTRY"
-      return 0
-    fi
-    if ! kill -0 "$plugin_registry_pid" 2>/dev/null; then
-      openclaw_e2e_print_log "$log_file" >&2
-      return 1
-    fi
-    sleep 0.1
-  done
-
-  openclaw_e2e_print_log "$log_file" >&2
-  echo "Timed out waiting for upgrade survivor npm registry." >&2
-  return 1
+  wait_for_fixture_port "$plugin_registry_pid" "$port_file" "$log_file" "npm registry"
+  export NPM_CONFIG_REGISTRY="http://127.0.0.1:$(cat "$port_file")"
+  export npm_config_registry="$NPM_CONFIG_REGISTRY"
 }
 
 openclaw_e2e_eval_test_state_from_b64 "${OPENCLAW_TEST_STATE_SCRIPT_B64:?missing OPENCLAW_TEST_STATE_SCRIPT_B64}"
@@ -426,6 +444,7 @@ if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
   prepare_update_restart_probe_current_install "$PORT" "$GATEWAY_LOG"
 fi
 
+configure_clawhub_fixture
 configure_plugin_registry
 echo "Running package update against the mounted tarball..."
 update_args=(update --tag "${OPENCLAW_CURRENT_PACKAGE_TGZ:?missing OPENCLAW_CURRENT_PACKAGE_TGZ}" --yes --json)
@@ -442,6 +461,8 @@ if [ "$update_status" -ne 0 ]; then
   openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-update.json >&2
   exit "$update_status"
 fi
+[ -z "${OPENCLAW_CLAWHUB_URL:-}" ] || CLAWHUB_EXPECTED_VERSION="$package_version" \
+  node -e 'const n="@openclaw/whatsapp",v=encodeURIComponent(process.env.CLAWHUB_EXPECTED_VERSION),p=`/api/v1/packages/${encodeURIComponent(n)}`,expected=[`GET ${p}`,`GET ${p}/versions/${v}/artifact`,`GET ${p}/versions/${v}/security`,`GET ${p}/versions/${v}/artifact/download`];fetch(`${process.env.OPENCLAW_CLAWHUB_URL}/__fixture__/requests`).then((response)=>response.json()).then(({requests})=>{if(JSON.stringify(requests)!==JSON.stringify(expected))throw new Error(`unexpected ClawHub fixture requests: ${JSON.stringify(requests)}`)})'
 
 if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
   echo "Skipping doctor repair until after restart proof."

--- a/scripts/lib/docker-e2e-plan.mjs
+++ b/scripts/lib/docker-e2e-plan.mjs
@@ -698,7 +698,6 @@ export function requiredPrepublishPluginPackagesForLanes(poolLanes) {
       return (
         typeof entry.name === "string" &&
         configuredChannelIds.has(channelId) &&
-        install?.defaultChoice === "npm" &&
         install?.npmSpec === entry.name
       );
     })

--- a/test/scripts/clawhub-fixture-server.test.ts
+++ b/test/scripts/clawhub-fixture-server.test.ts
@@ -1,6 +1,7 @@
 // ClawHub Fixture Server tests cover the local package fixture HTTP contract.
-import { spawn, spawnSync, type ChildProcessByStdio } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { execFileSync, spawn, spawnSync, type ChildProcessByStdio } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { Readable } from "node:stream";
 import { setTimeout as delay } from "node:timers/promises";
@@ -44,10 +45,10 @@ async function stopServer(child: FixtureServerChild) {
   }
 }
 
-async function startFixtureServer(profile: string) {
+async function startFixtureServer(profile: string, args: string[] = []) {
   const root = makeTempDir(tempDirs, "openclaw-clawhub-fixture-server-");
   const portFile = path.join(root, "port");
-  const child = spawn(process.execPath, [SCRIPT_PATH, profile, portFile], {
+  const child = spawn(process.execPath, [SCRIPT_PATH, profile, portFile, ...args], {
     cwd: process.cwd(),
     env: { ...process.env },
     stdio: ["ignore", "pipe", "pipe"],
@@ -122,8 +123,61 @@ describe("ClawHub fixture server", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
-      "usage: clawhub-fixture-server.cjs <catalog-search|kitchen-sink-plugin|plugins> <port-file>",
+      "usage: clawhub-fixture-server.cjs <catalog-search|kitchen-sink-plugin|plugins|prepublish-artifacts> <port-file> [manifest-file]",
     );
+  });
+
+  it("serves exact prepublish tarballs through the ClawHub artifact contract", async () => {
+    const root = makeTempDir(tempDirs, "openclaw-clawhub-prepublish-");
+    const packageDir = path.join(root, "package");
+    const tarball = "openclaw-whatsapp-2026.8.1-beta.1.tgz";
+    const tarballPath = path.join(root, tarball);
+    const version = "2026.8.1-beta.1";
+    mkdirSync(packageDir);
+    writeFileSync(
+      path.join(packageDir, "package.json"),
+      `${JSON.stringify({ name: "@openclaw/whatsapp", version })}\n`,
+    );
+    writeFileSync(
+      path.join(packageDir, "openclaw.plugin.json"),
+      `${JSON.stringify({ id: "whatsapp", configSchema: { type: "object" } })}\n`,
+    );
+    execFileSync("tar", ["-czf", tarballPath, "-C", root, "package"]);
+    const archive = readFileSync(tarballPath);
+    const sha256 = createHash("sha256").update(archive).digest("hex");
+    const manifestPath = path.join(root, "prepublish-plugin-registry.json");
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify({
+        packages: [{ name: "@openclaw/whatsapp", version, tarball, sha256 }],
+      })}\n`,
+    );
+
+    const { baseUrl } = await startFixtureServer("prepublish-artifacts", [manifestPath]);
+    const whatsappPath = `/api/v1/packages/${encodeURIComponent("@openclaw/whatsapp")}`;
+    const detail = await fetchJson(baseUrl, whatsappPath);
+    expect(detail.package).toMatchObject({
+      latestVersion: version,
+      runtimeId: "whatsapp",
+      tags: { beta: version, latest: version },
+    });
+    const artifact = await fetchJson(baseUrl, `${whatsappPath}/versions/${version}/artifact`);
+    expect(artifact.artifact).toMatchObject({
+      artifactKind: "npm-pack",
+      artifactSha256: sha256,
+    });
+    const security = await fetchJson(baseUrl, `${whatsappPath}/versions/${version}/security`);
+    expect(security.trust).toMatchObject({ blockedFromDownload: false, pending: false });
+    const download = await fetch(`${baseUrl}${whatsappPath}/versions/${version}/artifact/download`);
+    expect(download.headers.get("x-clawhub-artifact-sha256")).toBe(sha256);
+    expect(Buffer.from(await download.arrayBuffer())).toEqual(archive);
+    expect((await fetchJson(baseUrl, "/__fixture__/requests")).requests).toEqual([
+      `GET ${whatsappPath}`,
+      `GET ${whatsappPath}/versions/${version}/artifact`,
+      `GET ${whatsappPath}/versions/${version}/security`,
+      `GET ${whatsappPath}/versions/${version}/artifact/download`,
+    ]);
+    expect((await fetch(`${baseUrl}${whatsappPath}/versions/0.0.0/artifact`)).status).toBe(404);
   });
 
   it("serves separate plugin-family and skill search fixtures", async () => {

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2298,6 +2298,18 @@ docker_e2e_docker_run_cmd run demo
     expect(
       publishedRunner.indexOf("phase configure-plugin-registry configure_plugin_registry"),
     ).toBeLessThan(publishedRunner.indexOf("phase update-candidate update_candidate"));
+    expect(runner.indexOf("\nconfigure_clawhub_fixture\n")).toBeLessThan(
+      runner.indexOf('\necho "Running package update against the mounted tarball..."\n'),
+    );
+    expect(
+      publishedRunner.indexOf("phase configure-clawhub-fixture configure_clawhub_fixture"),
+    ).toBeLessThan(publishedRunner.indexOf("phase update-candidate update_candidate"));
+    expect(publishedRunner.indexOf("phase update-candidate update_candidate")).toBeLessThan(
+      publishedRunner.indexOf('CLAWHUB_EXPECTED_VERSION="$candidate_version"'),
+    );
+    expect(runner.indexOf("openclaw_e2e_maybe_timeout")).toBeLessThan(
+      runner.indexOf('CLAWHUB_EXPECTED_VERSION="$package_version"'),
+    );
     expect(runner).toContain(
       'if [ "${OPENCLAW_UPGRADE_SURVIVOR_SCENARIO:-base}" = "feishu-channel" ]; then',
     );
@@ -2311,8 +2323,21 @@ docker_e2e_docker_run_cmd run demo
       ].join("\n"),
     );
     for (const script of [runner, publishedRunner]) {
+      expectTextToIncludeAll(script, [
+        "prepublish-artifacts",
+        "prepublish-plugin-registry.json",
+        "unset OPENCLAW_CLAWHUB_URL CLAWHUB_URL",
+        'export OPENCLAW_CLAWHUB_URL="http://127.0.0.1:$(cat "$port_file")"',
+        'openclaw_e2e_stop_process "${clawhub_fixture_pid:-}"',
+        "/__fixture__/requests",
+        "@openclaw/whatsapp",
+      ]);
+      expect(script).not.toContain("https://clawhub.ai");
       const emptyRegistryGuardIndex = script.indexOf('if [ "${#registry_args[@]}" -eq 0 ]; then');
-      const fixtureDirectoryIndex = script.indexOf('mkdir -p "$fixture_root"');
+      const fixtureDirectoryIndex = script.indexOf(
+        'mkdir -p "$fixture_root"',
+        emptyRegistryGuardIndex,
+      );
       const registryServerIndex = script.indexOf(
         "OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org",
       );
@@ -2329,6 +2354,16 @@ docker_e2e_docker_run_cmd run demo
     expect(publishedRunner).not.toContain(
       '\nexport BRAVE_API_KEY="BSA_upgrade_survivor_brave_key"\n',
     );
+    expect(
+      runner.match(
+        /-v "\$HARNESS_ROOT_DIR\/scripts\/e2e\/lib\/clawhub-fixture-server\.cjs:\/tmp\/openclaw-clawhub-fixture-server\.cjs:ro"/gu,
+      ),
+    ).toHaveLength(2);
+    expect(
+      runner.match(
+        /-e OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER=\/tmp\/openclaw-clawhub-fixture-server\.cjs/gu,
+      ),
+    ).toHaveLength(2);
   });
 
   it("wraps package-backed scenario OpenClaw CLI calls with the shared timeout helper", () => {

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -1664,6 +1664,7 @@ describe("scripts/lib/docker-e2e-plan", () => {
       expect(plan.requiredPrepublishPluginPackages).toEqual([
         "@openclaw/codex",
         "@openclaw/discord",
+        "@openclaw/whatsapp",
       ]);
       expect(plan.needs.prepublishPluginRegistry).toBe(true);
     }
@@ -1677,6 +1678,7 @@ describe("scripts/lib/docker-e2e-plan", () => {
       "@openclaw/codex",
       "@openclaw/discord",
       "@openclaw/feishu",
+      "@openclaw/whatsapp",
     ]);
     const legacyFeishuPlan = planFor({
       selectedLaneNames: ["published-upgrade-survivor"],
@@ -1686,6 +1688,7 @@ describe("scripts/lib/docker-e2e-plan", () => {
     expect(legacyFeishuPlan.requiredPrepublishPluginPackages).toEqual([
       "@openclaw/codex",
       "@openclaw/discord",
+      "@openclaw/whatsapp",
     ]);
     const selfUpgradeLane = findLaneByName("update-run-package-self-upgrade");
     expect(selfUpgradeLane).toBeDefined();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where beta upgrade-survivor validation could reach public ClawHub while repairing a configured WhatsApp plugin from an unpublished release candidate.

## Why This Change Was Made

The release planner now includes every configured official external channel whose exact package name is publishable, rather than only channels whose default install choice is npm. Both survivor runners start a local ClawHub fixture from the immutable prepublish tarballs before update/doctor, validate the packed package and plugin identity, and fail unless WhatsApp uses the ordered package -> artifact -> security -> download route sequence.

The fixture is release-harness-only. This does not change runtime code, public config, scenarios, or survivor assertions. Shared fixture readiness also replaces the duplicated npm-registry polling and raw process cleanup.

## User Impact

Release CI can validate WhatsApp plugin repair from exact beta candidate bytes without publishing packages or depending on live ClawHub. npm fallback can no longer mask a missing ClawHub path.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/docker-e2e-plan.test.ts`: 57 passed
- `node scripts/run-vitest.mjs test/scripts/clawhub-fixture-server.test.ts`: 4 passed
- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts -t "starts the upgrade survivor plugin registry before updates with scenario-owned config"`: 1 passed, 186 skipped
- `node --check scripts/e2e/lib/clawhub-fixture-server.cjs`
- `bash -n scripts/e2e/lib/upgrade-survivor/run.sh scripts/e2e/upgrade-survivor-docker.sh`
- `git diff --check`
- Changed-surface Testbox: https://github.com/openclaw/openclaw/actions/runs/31274345022, exit 0
- Harness delta: +220/-40, net +180. Tests: +98/-6, net +92.
- Independent release-scope audit: GO after adding the real-runner ordered ledger assertion.

Long Docker E2E and Parallels are intentionally deferred until after the beta, per the release plan. No npm publish, release tag, or release branch mutation is included.
