### PR TITLE
fix(release): keep upgrade survivor validation runnable

### DIFF
--- a/scripts/e2e/lib/clawhub-fixture-server.cjs
+++ b/scripts/e2e/lib/clawhub-fixture-server.cjs
@@ -16,6 +16,31 @@ const tar = requireFromApp("tar");
 const packageName = "@openclaw/kitchen-sink";
 const pluginId = "openclaw-kitchen-sink-fixture";
 
+async function assertPrepublishRequests(baseUrl, requestedPackage, version) {
+  if (!baseUrl || !requestedPackage || !version) {
+    throw new Error("assert-prepublish-requests requires <base-url> <package-name> <version>");
+  }
+  const response = await fetch(new URL("/__fixture__/requests", baseUrl));
+  if (!response.ok) {
+    throw new Error(`ClawHub fixture request ledger returned HTTP ${response.status}`);
+  }
+  const payload = await response.json();
+  if (!Array.isArray(payload?.requests)) {
+    throw new Error("ClawHub fixture request ledger must contain a requests array");
+  }
+  const packagePath = `/api/v1/packages/${encodeURIComponent(requestedPackage)}`;
+  const versionPath = `${packagePath}/versions/${encodeURIComponent(version)}`;
+  const expected = [
+    `GET ${packagePath}`,
+    `GET ${versionPath}/artifact`,
+    `GET ${versionPath}/security`,
+    `GET ${versionPath}/artifact/download`,
+  ];
+  if (JSON.stringify(payload.requests) !== JSON.stringify(expected)) {
+    throw new Error(`unexpected ClawHub fixture requests: ${JSON.stringify(payload.requests)}`);
+  }
+}
+
 function startPrepublishArtifactServer() {
   const manifest = JSON.parse(fs.readFileSync(artifactManifestFile, "utf8"));
   if (!Array.isArray(manifest.packages) || manifest.packages.length === 0) {
@@ -576,6 +601,16 @@ profiles["catalog-search"] = {
     ],
   },
 };
+
+if (profile === "assert-prepublish-requests") {
+  assertPrepublishRequests(portFile, artifactManifestFile, process.argv[5]).catch(
+    /** @param {unknown} error */ (error) => {
+      console.error(error);
+      process.exit(1);
+    },
+  );
+  return;
+}
 
 const fixture = profiles[profile];
 if (!fixture || !portFile) {

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -1479,8 +1479,11 @@ phase prepare-update-restart-probe prepare_update_restart_probe
 phase configure-clawhub-fixture configure_clawhub_fixture
 phase configure-plugin-registry configure_plugin_registry
 phase update-candidate update_candidate
-[ -z "${OPENCLAW_CLAWHUB_URL:-}" ] || CLAWHUB_EXPECTED_VERSION="$candidate_version" \
-  node -e 'const n="@openclaw/whatsapp",v=encodeURIComponent(process.env.CLAWHUB_EXPECTED_VERSION),p=`/api/v1/packages/${encodeURIComponent(n)}`,expected=[`GET ${p}`,`GET ${p}/versions/${v}/artifact`,`GET ${p}/versions/${v}/security`,`GET ${p}/versions/${v}/artifact/download`];fetch(`${process.env.OPENCLAW_CLAWHUB_URL}/__fixture__/requests`).then((response)=>response.json()).then(({requests})=>{if(JSON.stringify(requests)!==JSON.stringify(expected))throw new Error(`unexpected ClawHub fixture requests: ${JSON.stringify(requests)}`)})'
+if [ -n "${OPENCLAW_CLAWHUB_URL:-}" ]; then
+  phase assert-prepublish-requests node \
+    "${OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER:-scripts/e2e/lib/clawhub-fixture-server.cjs}" \
+    assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "@openclaw/whatsapp" "$candidate_version"
+fi
 phase root-managed-vps-cli-usable assert_root_managed_vps_cli_usable
 phase assert-legacy-plugin-dependency-debris-before-doctor assert_legacy_plugin_dependency_debris_before_doctor
 phase doctor run_doctor

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -461,8 +461,10 @@ if [ "$update_status" -ne 0 ]; then
   openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-update.json >&2
   exit "$update_status"
 fi
-[ -z "${OPENCLAW_CLAWHUB_URL:-}" ] || CLAWHUB_EXPECTED_VERSION="$package_version" \
-  node -e 'const n="@openclaw/whatsapp",v=encodeURIComponent(process.env.CLAWHUB_EXPECTED_VERSION),p=`/api/v1/packages/${encodeURIComponent(n)}`,expected=[`GET ${p}`,`GET ${p}/versions/${v}/artifact`,`GET ${p}/versions/${v}/security`,`GET ${p}/versions/${v}/artifact/download`];fetch(`${process.env.OPENCLAW_CLAWHUB_URL}/__fixture__/requests`).then((response)=>response.json()).then(({requests})=>{if(JSON.stringify(requests)!==JSON.stringify(expected))throw new Error(`unexpected ClawHub fixture requests: ${JSON.stringify(requests)}`)})'
+if [ -n "${OPENCLAW_CLAWHUB_URL:-}" ]; then
+  node "$OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER" \
+    assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "@openclaw/whatsapp" "$package_version"
+fi
 
 if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
   echo "Skipping doctor repair until after restart proof."

--- a/test/scripts/clawhub-fixture-server.test.ts
+++ b/test/scripts/clawhub-fixture-server.test.ts
@@ -80,6 +80,14 @@ async function fetchJson(baseUrl: string, requestPath: string) {
   return response.json();
 }
 
+function runPrepublishAssertion(baseUrl?: string, packageName?: string, version?: string) {
+  return spawnSync(
+    process.execPath,
+    [SCRIPT_PATH, "assert-prepublish-requests", baseUrl ?? "", packageName ?? "", version ?? ""],
+    { cwd: process.cwd(), encoding: "utf8", env: { ...process.env } },
+  );
+}
+
 describe("ClawHub fixture server", () => {
   it("serves package metadata and npm-pack artifacts for kitchen-sink fixtures", async () => {
     const { baseUrl } = await startFixtureServer("kitchen-sink-plugin");
@@ -124,6 +132,11 @@ describe("ClawHub fixture server", () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
       "usage: clawhub-fixture-server.cjs <catalog-search|kitchen-sink-plugin|plugins|prepublish-artifacts> <port-file> [manifest-file]",
+    );
+    const assertion = runPrepublishAssertion();
+    expect(assertion.status).toBe(1);
+    expect(assertion.stderr).toContain(
+      "assert-prepublish-requests requires <base-url> <package-name> <version>",
     );
   });
 
@@ -177,7 +190,11 @@ describe("ClawHub fixture server", () => {
       `GET ${whatsappPath}/versions/${version}/security`,
       `GET ${whatsappPath}/versions/${version}/artifact/download`,
     ]);
+    expect(runPrepublishAssertion(baseUrl, "@openclaw/whatsapp", version).status).toBe(0);
     expect((await fetch(`${baseUrl}${whatsappPath}/versions/0.0.0/artifact`)).status).toBe(404);
+    const mismatch = runPrepublishAssertion(baseUrl, "@openclaw/whatsapp", version);
+    expect(mismatch.status).toBe(1);
+    expect(mismatch.stderr).toContain("unexpected ClawHub fixture requests");
   });
 
   it("serves separate plugin-family and skill search fixtures", async () => {

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -115,6 +115,16 @@ const CENTRALIZED_BUILD_SCRIPTS = [
   "scripts/test-install-sh-e2e-docker.sh",
   "scripts/test-live-build-docker.sh",
 ] as const;
+
+function extractUpgradeSurvivorPayload(script: string) {
+  const marker = " bash -lc ";
+  const start = script.indexOf(marker);
+  const quoted = script.slice(start + marker.length).trimEnd();
+  if (start < 0 || !quoted.startsWith("'") || !quoted.endsWith("'")) {
+    throw new Error("upgrade survivor bash -lc payload not found");
+  }
+  return quoted.slice(1, -1).replaceAll(`'"'"'`, "'");
+}
 const BOUNDED_CLIENT_LOG_DOCKER_E2E_SCRIPTS = [
   "scripts/e2e/cron-mcp-cleanup-docker.sh",
   "scripts/e2e/mcp-channels-docker.sh",
@@ -2305,11 +2315,21 @@ docker_e2e_docker_run_cmd run demo
       publishedRunner.indexOf("phase configure-clawhub-fixture configure_clawhub_fixture"),
     ).toBeLessThan(publishedRunner.indexOf("phase update-candidate update_candidate"));
     expect(publishedRunner.indexOf("phase update-candidate update_candidate")).toBeLessThan(
-      publishedRunner.indexOf('CLAWHUB_EXPECTED_VERSION="$candidate_version"'),
+      publishedRunner.indexOf("phase assert-prepublish-requests node"),
     );
-    expect(runner.indexOf("openclaw_e2e_maybe_timeout")).toBeLessThan(
-      runner.indexOf('CLAWHUB_EXPECTED_VERSION="$package_version"'),
+    expect(publishedRunner.indexOf("phase assert-prepublish-requests node")).toBeLessThan(
+      publishedRunner.indexOf("phase doctor run_doctor"),
     );
+    expect(runner.indexOf('openclaw "${update_args[@]}"')).toBeLessThan(
+      runner.indexOf(
+        'assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "@openclaw/whatsapp" "$package_version"',
+      ),
+    );
+    expect(
+      runner.indexOf(
+        'assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "@openclaw/whatsapp" "$package_version"',
+      ),
+    ).toBeLessThan(runner.indexOf("openclaw doctor --fix --non-interactive"));
     expect(runner).toContain(
       'if [ "${OPENCLAW_UPGRADE_SURVIVOR_SCENARIO:-base}" = "feishu-channel" ]; then',
     );
@@ -2329,9 +2349,10 @@ docker_e2e_docker_run_cmd run demo
         "unset OPENCLAW_CLAWHUB_URL CLAWHUB_URL",
         'export OPENCLAW_CLAWHUB_URL="http://127.0.0.1:$(cat "$port_file")"',
         'openclaw_e2e_stop_process "${clawhub_fixture_pid:-}"',
-        "/__fixture__/requests",
-        "@openclaw/whatsapp",
+        "assert-prepublish-requests",
       ]);
+      expect(script).not.toContain("CLAWHUB_EXPECTED_VERSION");
+      expect(script).not.toContain("/__fixture__/requests");
       expect(script).not.toContain("https://clawhub.ai");
       const emptyRegistryGuardIndex = script.indexOf('if [ "${#registry_args[@]}" -eq 0 ]; then');
       const fixtureDirectoryIndex = script.indexOf(
@@ -2364,6 +2385,19 @@ docker_e2e_docker_run_cmd run demo
         /-e OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER=\/tmp\/openclaw-clawhub-fixture-server\.cjs/gu,
       ),
     ).toHaveLength(2);
+  });
+
+  it("keeps upgrade survivor wrappers and the embedded payload valid bash", () => {
+    for (const path of [UPGRADE_SURVIVOR_DOCKER_E2E_PATH, UPGRADE_SURVIVOR_RUN_SCRIPT]) {
+      const result = spawnSync("bash", ["-n", path], { encoding: "utf8" });
+      expect(result.status, result.stderr).toBe(0);
+    }
+    const wrapper = readFileSync(UPGRADE_SURVIVOR_DOCKER_E2E_PATH, "utf8");
+    const inner = spawnSync("bash", ["-n"], {
+      input: extractUpgradeSurvivorPayload(wrapper),
+      encoding: "utf8",
+    });
+    expect(inner.status, inner.stderr).toBe(0);
   });
 
   it("wraps package-backed scenario OpenClaw CLI calls with the shared timeout helper", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the beta upgrade-survivor Docker wrapper failed shell parsing before validation when the prepublish ClawHub request-ledger assertion was present.

## Why This Change Was Made

The ledger check embedded single-quoted JavaScript inside an already single-quoted `bash -lc` payload. This moves the exact ordered-request assertion into the trusted, container-mounted ClawHub fixture CLI and has both survivor runners call it with argv-only inputs after update and before doctor.

The fixture server owns the request ledger. The canonical assertion is fail-closed for missing inputs, fetch failures, non-2xx responses, malformed ledgers, and reordered, missing, or extra requests. The duplicate inline JavaScript paths are removed. Harness delta: +40 net lines; tests: +51 net lines.

## User Impact

Release operators can run the beta upgrade-survivor validation again without the wrapper aborting on a shell syntax error. No runtime product behavior, package publication, tag, or release branch changes are included.

## Evidence

- Before: `bash -n scripts/e2e/upgrade-survivor-docker.sh` failed at the inline `node -e` assertion.
- After: `node --check` for the fixture CLI; `bash -n` for both runners; separately decoded embedded `bash -lc` payload passes `bash -n`.
- `test/scripts/clawhub-fixture-server.test.ts`: 4/4 passed.
- Targeted `test/scripts/docker-build-helper.test.ts`: 2/2 passed.
- Exact branch autoreview: clean, no accepted/actionable findings.
- Exact-head ClawSweeper attempt: infrastructure-throttled before review at head `a84507a513badcb5623a3fa5c98ea1f1d69c7dbe`; no findings or rank-up moves were produced. Maintainer release contingency approved instead of waiting for the future `2026-08-08 20:12:26 UTC` retry.
- Scoped `check-changed`: passed on Blacksmith Testbox receipt `tbx_01kzhefx8edt70pp4vq1z6mkwp`.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/31275182296
