### PR TITLE
docs: simplify Release & CI navigation

### DIFF
--- a/docs/.i18n/zh-Hans-navigation.json
+++ b/docs/.i18n/zh-Hans-navigation.json
@@ -508,8 +508,28 @@
       "tab": "发布与 CI",
       "groups": [
         {
-          "group": "发布策略",
-          "pages": ["zh-CN/reference/RELEASING", "zh-CN/reference/test"]
+          "group": "发布说明",
+          "pages": [
+            "zh-CN/releases/index",
+            "zh-CN/releases/2026.7.1",
+            "zh-CN/releases/2026.6.11"
+          ]
+        },
+        {
+          "group": "成熟度",
+          "pages": ["zh-CN/maturity/scorecard", "zh-CN/maturity/taxonomy"]
+        },
+        {
+          "group": "发布流程",
+          "pages": [
+            "zh-CN/reference/RELEASING",
+            "zh-CN/reference/full-release-validation",
+            "zh-CN/reference/release-performance-sweep"
+          ]
+        },
+        {
+          "group": "测试与 CI",
+          "pages": ["zh-CN/reference/test", "zh-CN/ci", "zh-CN/help/scripts"]
         }
       ]
     },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2014,21 +2014,31 @@
             "tab": "Release & CI",
             "groups": [
               {
-                "group": "Release and CI",
+                "group": "Release notes",
                 "pages": [
-                  {
-                    "group": "Release notes",
-                    "pages": [
-                      "releases/index",
-                      "releases/2026.7.1",
-                      "releases/2026.6.11"
-                    ]
-                  },
+                  "releases/index",
+                  "releases/2026.7.1",
+                  "releases/2026.6.11"
+                ]
+              },
+              {
+                "group": "Maturity",
+                "pages": [
                   "maturity/scorecard",
-                  "maturity/taxonomy",
+                  "maturity/taxonomy"
+                ]
+              },
+              {
+                "group": "Release process",
+                "pages": [
                   "reference/RELEASING",
                   "reference/full-release-validation",
-                  "reference/release-performance-sweep",
+                  "reference/release-performance-sweep"
+                ]
+              },
+              {
+                "group": "Testing and CI",
+                "pages": [
                   "reference/test",
                   "ci",
                   "help/scripts"

--- a/test/scripts/docs-sync-publish.test.ts
+++ b/test/scripts/docs-sync-publish.test.ts
@@ -153,7 +153,19 @@ describe("docs-sync-publish", () => {
       "help/scripts",
     ];
     const releaseTab = english!.tabs.find((tab) => tab.tab === "Release & CI");
+    expect(releaseTab?.groups?.map((group) => group.group)).toEqual([
+      "Release notes",
+      "Maturity",
+      "Release process",
+      "Testing and CI",
+    ]);
+    expect(releaseTab?.groups?.[0]?.pages).toEqual([
+      "releases/index",
+      "releases/2026.7.1",
+      "releases/2026.6.11",
+    ]);
     expect(collectPages(releaseTab)).toEqual(releaseRoutes);
+    expect(new Set(collectPages(releaseTab))).toHaveLength(releaseRoutes.length);
 
     const englishWithoutClawHub = {
       ...english,
@@ -168,13 +180,36 @@ describe("docs-sync-publish", () => {
     const simplifiedChineseReleaseTab = simplifiedChinese!.tabs.find(
       (tab) => tab.tab === "发布与 CI",
     );
-    expect(simplifiedChineseReleaseTab?.groups?.[0]?.group).toBe("发布策略");
+    expect(simplifiedChineseReleaseTab?.groups?.map((group) => group.group)).toEqual([
+      "发布说明",
+      "成熟度",
+      "发布流程",
+      "测试与 CI",
+    ]);
+    expect(simplifiedChineseReleaseTab?.groups?.[0]?.pages).toEqual([
+      "zh-CN/releases/index",
+      "zh-CN/releases/2026.7.1",
+      "zh-CN/releases/2026.6.11",
+    ]);
     expect(collectPages(simplifiedChineseReleaseTab)).toEqual(
       releaseRoutes.map((page) => `zh-CN/${page}`),
     );
+    expect(new Set(collectPages(simplifiedChineseReleaseTab))).toHaveLength(releaseRoutes.length);
 
     expect(collectPages(german)).toHaveLength(collectPages(englishWithoutClawHub).length);
     expect(german!.tabs[0]?.tab).toBe("Loslegen");
     expect(german!.tabs[0]?.groups?.[0]?.group).toBe("Überblick");
+
+    for (const locale of config.navigation.languages.filter(
+      (entry) => entry.language !== "en" && entry.language !== "zh-Hans",
+    )) {
+      const localeDir = collectPages(locale)[0]?.split("/")[0];
+      const localizedRoutes = releaseRoutes.map((page) => `${localeDir}/${page}`);
+      const localizedReleaseTab = locale.tabs.find((tab) =>
+        collectPages(tab).includes(`${localeDir}/releases/index`),
+      );
+      expect(collectPages(localizedReleaseTab)).toEqual(localizedRoutes);
+      expect(new Set(collectPages(localizedReleaseTab))).toHaveLength(localizedRoutes.length);
+    }
   });
 });


### PR DESCRIPTION
Closes #120672

## What Problem This Solves

The Release & CI tab currently wraps all pages in a redundant **Release and CI** group. That extra layer flattens unrelated pages into one section and produces the index breadcrumb **Release & CI / Release and CI / Release notes**. Production also serves a stale version-page shell that selects **Reference** instead of **Release & CI**.

## Why This Change Was Made

This PR uses the navigation shape already used throughout the repository: four direct `group` entries with `pages`, with the release index first in **Release notes**. It preserves all 11 routes and their order, adds the same four groups to the zh-Hans overlay, and leaves the sync implementation unchanged because its existing pages-first path already prefixes and matches every localized route.

The source-only scope intentionally does not claim a clickable group heading or removal of the index child row. The current `openclaw/docs` renderer renders group headings as text and builds breadcrumbs from the tab, group, and page. Supporting a clickable heading with a two-part index breadcrumb would be separate renderer work.

## User Impact

Fresh renders would show four useful Release & CI sections — **Release notes**, **Maturity**, **Release process**, and **Testing and CI** — on desktop and mobile. Version pages would render under the Release & CI tab with **Release & CI / Release notes / v…** breadcrumbs. The release index would no longer include the redundant **Release and CI** level, while retaining the renderer's existing **Release notes** child row and three-part index breadcrumb.

## Evidence

**Before — current production (2026-08-08): redundant outer group and breadcrumb**

<img width="1293" height="788" alt="Before — current production shows the redundant Release and CI group and breadcrumb" src="https://github.com/user-attachments/assets/b64a97d7-0fd2-4a9f-8394-c4cc30e6563d" />

**Validated before merge — prepared head `3c6a890`: English desktop index with all four groups and all 11 routes**

<img width="1425" height="990" alt="Validated before merge — English desktop release index with four direct groups" src="https://github.com/user-attachments/assets/a92cec7a-b9da-4b6b-8073-4cc77268fd98" />

**Validated before merge — prepared head `3c6a890`: English version page with `Release & CI / Release notes / v2026.7.1`**

<img width="1425" height="990" alt="Validated before merge — English release version breadcrumb" src="https://github.com/user-attachments/assets/b70b606f-50e5-4df3-a48c-1e47981d191a" />

**Validated before merge — prepared head `3c6a890`: mobile drawer with the complete four-group sidebar**

<img width="390" height="980" alt="Validated before merge — mobile Release and CI drawer without clipping" src="https://github.com/user-attachments/assets/b507a08a-7841-4bdc-8e3a-2c3eaaf3c96c" />

**Validated before merge — prepared head `3c6a890`: zh-CN index with localized group labels and routes**

<img width="1425" height="990" alt="Validated before merge — localized Chinese Release and CI navigation" src="https://github.com/user-attachments/assets/41533469-8955-4888-a42e-a4fa193a7379" />

The screenshots were generated through the current `openclaw/docs` renderer from an ephemeral mirror synced from this exact head. Measurements found no horizontal overflow; the complete desktop sidebar fits its 701 px viewport, and the last mobile route ends at 731 px in a 980 px drawer.

Validation:

- Red proof: the focused test fails against the previous single-group navigation (`expected` four direct groups, `received` `Release and CI`).
- `node scripts/run-vitest.mjs test/scripts/docs-sync-publish.test.ts` — 5 tests passed.
- `pnpm check:docs` — formatting, Markdown lint, 769 MDX files, glossary, and 6,404 internal links passed; 0 broken links.
- `git diff --check` and targeted `oxfmt --check` passed.
- Ephemeral renderer builds passed for English (578 pages) and zh-CN (547 pages).

Mintlify CLI validation was not run because the CLI is not installed in the existing workspace; no dependency installation was needed for this docs-only change.
