### PR TITLE
fix(openai): prevent OAuth login crashes on invalid token responses

### DIFF
--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
@@ -411,6 +411,50 @@ async function closeServer(server: Server): Promise<void> {
 }
 
 describe("OpenAI Codex OAuth bounded token response reads", () => {
+  it.each([
+    { operation: "exchange", envelope: "null", value: null },
+    { operation: "exchange", envelope: "array", value: [] },
+    { operation: "refresh", envelope: "null", value: null },
+    { operation: "refresh", envelope: "array", value: [] },
+  ] as const)(
+    "rejects $envelope $operation token responses from a real loopback HTTP server",
+    async ({ operation, value }) => {
+      const server = createServer((_req, res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(value));
+      });
+      const port = await listenLoopbackServer(server);
+      const release = vi.fn(async () => undefined);
+
+      try {
+        ssrfMocks.fetchWithSsrFGuard.mockImplementation(async ({ init, signal }) => {
+          const response = await globalThis.fetch(`http://127.0.0.1:${port}`, {
+            ...init,
+            signal,
+          });
+          return { response, release };
+        });
+
+        const result =
+          operation === "exchange"
+            ? await exchangeOpenAIAuthorizationCode(
+                "code-loopback",
+                "verifier-loopback",
+                "http://localhost:1455/auth/callback",
+              )
+            : await refreshOpenAIAccessToken("refresh-token-loopback");
+
+        expect(result).toEqual({
+          type: "failed",
+          message: `OpenAI Codex token ${operation} failed: expected JSON object response`,
+        });
+        expect(release).toHaveBeenCalledOnce();
+      } finally {
+        await closeServer(server);
+      }
+    },
+  );
+
   it("reads under-cap token exchange responses from a real loopback HTTP server", async () => {
     const validPayload = {
       access_token: "access-token-loopback",

--- a/extensions/openai/openai-chatgpt-oauth-token.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-token.runtime.ts
@@ -5,6 +5,7 @@ import {
 } from "openclaw/plugin-sdk/provider-oauth-runtime";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const TOKEN_URL = "https://auth.openai.com/oauth/token";
@@ -112,6 +113,12 @@ async function readOpenAITokenResponse(
     };
   }
   const json = (await response.json()) as TokenResponseJson;
+  if (!isRecord(json)) {
+    return {
+      type: "failed",
+      message: `OpenAI Codex token ${operation} failed: expected JSON object response`,
+    };
+  }
   const expires = resolveOAuthTokenExpiresAt(json.expires_in);
   if (!json.access_token || !json.refresh_token || expires === undefined) {
     return {


### PR DESCRIPTION
Related: #120174

## What Problem This Solves

Fixes an issue where users signing in with OpenAI OAuth or refreshing an existing credential could receive an uncaught exception or an unhelpful failure when the token endpoint returned HTTP 200 with JSON `null` or an array instead of a token object.

## Why This Change Was Made

Validate the decoded response once in the OpenAI plugin's shared token-response reader, which owns both authorization-code exchange and token refresh. The existing Plugin SDK record guard rejects invalid envelopes before any property access, so both flows return the same actionable failure without duplicate checks or new compatibility paths.

The original contributor PR #120174 is currently merge-conflicting and includes a temporary standalone proof script. This clean replacement preserves the contributor's authorship, applies the fix to the current shared owner, and keeps regression proof in the existing runtime test suite.

The public upstream OAuth implementation likewise deserializes successful exchange and refresh responses into object-shaped records: `codex-rs/login/src/server.rs:794`, `codex-rs/login/src/server.rs:853`, `codex-rs/login/src/auth/manager.rs:1356`, and `codex-rs/login/src/auth/manager.rs:1440`.

## User Impact

Malformed OAuth token responses now fail cleanly with an explicit `expected JSON object response` message for both initial login and token refresh. Valid login and refresh behavior remain unchanged.

## Evidence

- Four new regression cases failed against the unfixed owner and pass with this change: JSON `null` and JSON array responses on both authorization-code exchange and refresh.
- The regression cases exercise both production entry points through real loopback HTTP servers and native HTTP fetch, including response-resource release.
- The focused runtime suite passes all 22 tests; the complete changed-code validation gate also passed remotely.
- Independent review found no actionable issues, and `git diff --check` passes.
- Production: +7/-0 lines; tests: +44/-0 lines. The production growth is the single provider-boundary envelope validation required by the upstream response contract.

Original report and contribution by @Monkey-wusky; the replacement commit retains the original author's `Co-authored-by` credit.
