### PR TITLE
fix(slack): prevent bot message authorization from hanging on repeated cursors

### DIFF
--- a/extensions/slack/src/monitor/auth.test.ts
+++ b/extensions/slack/src/monitor/auth.test.ts
@@ -221,6 +221,59 @@ describe("authorizeSlackSystemEventSender", () => {
     expect(conversationsMembers).toHaveBeenCalledTimes(1);
   });
 
+  it("authorizes an owner found on a later channel member page", async () => {
+    type MembersResponse = {
+      members: string[];
+      response_metadata: { next_cursor?: string };
+    };
+    const conversationsMembers = vi
+      .fn<() => Promise<MembersResponse>>()
+      .mockResolvedValueOnce({
+        members: ["UOTHER"],
+        response_metadata: { next_cursor: "cursor-next" },
+      })
+      .mockResolvedValueOnce({ members: ["UOWNER"], response_metadata: {} });
+    const { authorize } = makeChannelMemberAuth(conversationsMembers);
+
+    await expect(authorize()).resolves.toBe(true);
+    expect(conversationsMembers.mock.calls).toEqual([
+      [{ token: "xoxb-test", channel: "C1", limit: 999 }],
+      [{ token: "xoxb-test", channel: "C1", limit: 999, cursor: "cursor-next" }],
+    ]);
+  });
+
+  it.each([
+    ["a repeated cursor", ["cursor-a", "cursor-a"]],
+    ["a cursor cycle", ["cursor-a", "cursor-b", "cursor-a"]],
+  ] as const)(
+    "denies channel bot authorization on %s and retries cleanly",
+    async (_name, cursors) => {
+      type MembersResponse = {
+        members: string[];
+        response_metadata: { next_cursor?: string };
+      };
+      const remainingCursors = [...cursors];
+      const conversationsMembers = vi.fn(async (): Promise<MembersResponse> => {
+        const nextCursor = remainingCursors.shift();
+        if (!nextCursor) {
+          throw new Error("channel member pagination escaped the cursor guard");
+        }
+        return { members: ["UOWNER"], response_metadata: { next_cursor: nextCursor } };
+      });
+      const { authorize } = makeChannelMemberAuth(conversationsMembers);
+
+      await expect(authorize()).resolves.toBe(false);
+      expect(conversationsMembers).toHaveBeenCalledTimes(cursors.length);
+
+      conversationsMembers.mockResolvedValueOnce({
+        members: ["UOWNER"],
+        response_metadata: {},
+      });
+      await expect(authorize()).resolves.toBe(true);
+      expect(conversationsMembers).toHaveBeenCalledTimes(cursors.length + 1);
+    },
+  );
+
   it.each([
     {
       name: "keeps non-interactive channel senders open when only global allowFrom is configured",

--- a/extensions/slack/src/monitor/auth.ts
+++ b/extensions/slack/src/monitor/auth.ts
@@ -15,6 +15,7 @@ import {
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { collectSlackCursorPages } from "../cursor-pages.js";
 import {
   allowListMatches,
   normalizeAllowList,
@@ -208,22 +209,17 @@ async function fetchSlackChannelMemberIds(
   channelId: string,
   eventScope?: SlackEventScope,
 ): Promise<Set<string>> {
-  const members = new Set<string>();
-  let cursor: string | undefined;
-  do {
-    const response = await (eventScope?.client ?? ctx.app.client).conversations.members({
-      token: ctx.botToken,
-      channel: channelId,
-      limit: 999,
-      ...(cursor ? { cursor } : {}),
-    });
-    for (const member of normalizeAllowListLower(response.members)) {
-      members.add(member);
-    }
-    const nextCursor = response.response_metadata?.next_cursor?.trim();
-    cursor = nextCursor ? nextCursor : undefined;
-  } while (cursor);
-  return members;
+  const members = await collectSlackCursorPages({
+    fetchPage: (cursor) =>
+      (eventScope?.client ?? ctx.app.client).conversations.members({
+        token: ctx.botToken,
+        channel: channelId,
+        limit: 999,
+        ...(cursor ? { cursor } : {}),
+      }),
+    collectPageItems: (response) => normalizeAllowListLower(response.members),
+  });
+  return new Set(members);
 }
 
 async function resolveSlackChannelMemberIds(


### PR DESCRIPTION
Related: #120445 (separate Slack directory pagination owner; this change covers channel-member authorization).

## What Problem This Solves

Fixes an issue where Slack channel bot messages could stall indefinitely when the channel-member lookup received a repeated or cyclic pagination cursor. The stuck lookup also prevented a later authorization attempt from starting cleanly.

## Why This Change Was Made

The Slack plugin already has a canonical cursor paginator that detects repeated cursors, bounds pagination, and is shared by its user and channel resolution flows. Route the channel-member authorization lookup through that same owner-local helper instead of maintaining another unbounded pagination loop. Normal multi-page owner discovery remains supported; failed lookups deny authorization and release their pending cache entry so the next attempt can retry.

## User Impact

Slack operators retain normal bot-message authorization across multiple member pages, while malformed pagination can no longer hang message processing indefinitely or poison subsequent authorization attempts.

## Evidence

- Before the fix, the repeated-cursor and cyclic-cursor authorization regressions failed; after the fix, both terminate, deny safely, and allow a clean successful retry.
- Remote focused Slack authorization and shared-paginator tests: **45 passed**.
- Remote changed-file verification: **passed**.
- Independent automated review: **clean**.
- Production delta: **-4 lines**; regression coverage: **+53 lines**.
- AI-assisted; independently reviewed.
