### PR TITLE
fix: recover gateway startup state migrations

### DIFF
--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -8,6 +8,7 @@ import { gunzipSync, gzipSync } from "node:zlib";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions/types.js";
+import { acquireGatewayLock } from "../infra/gateway-lock.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { readChannelPairingStateSnapshot } from "../pairing/pairing-store-sqlite.test-helpers.js";
 import {
@@ -23,6 +24,12 @@ import {
   writePersistedInstalledPluginIndex,
 } from "../plugins/installed-plugin-index-store.js";
 import type { InstalledPluginInstallRecordInfo } from "../plugins/installed-plugin-index.js";
+import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  listOpenClawRegisteredAgentDatabases,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -224,6 +231,7 @@ afterEach(async () => {
   resetAutoMigrateLegacyStateDirForTest();
   resetAutoMigrateLegacyTaskStateSidecarsForTest();
   closeOpenClawStateDatabaseForTest();
+  closeOpenClawAgentDatabasesForTest();
   setMaxPluginStateEntriesPerPluginForTests();
   resetPluginStateStoreForTests();
   mockedChannelMigrationPlans.plans = [];
@@ -795,6 +803,29 @@ function writeLegacyAgentFiles(root: string, files: Record<string, string>) {
   return legacyAgentDir;
 }
 
+function writeAgentDatabase(pathname: string, agentId: string): void {
+  fs.mkdirSync(path.dirname(pathname), { recursive: true });
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(pathname);
+  try {
+    database.exec(`
+      CREATE TABLE schema_meta (
+        meta_key TEXT PRIMARY KEY,
+        role TEXT NOT NULL,
+        schema_version INTEGER NOT NULL,
+        agent_id TEXT NOT NULL
+      );
+    `);
+    database
+      .prepare(
+        "INSERT INTO schema_meta (meta_key, role, schema_version, agent_id) VALUES (?, ?, ?, ?)",
+      )
+      .run("primary", "agent", 1, agentId);
+  } finally {
+    database.close();
+  }
+}
+
 function ensureCredentialsDir(root: string) {
   const oauthDir = path.join(root, "credentials");
   fs.mkdirSync(oauthDir, { recursive: true });
@@ -1331,6 +1362,386 @@ describe("doctor legacy state migrations", () => {
     expect(fs.readFileSync(path.join(targetAgentDir, "baz.txt"), "utf-8")).toBe("legacy2");
     const backupDir = path.join(root, "agents", "main", "agent.legacy-123");
     expect(fs.existsSync(path.join(backupDir, "foo.txt"))).toBe(true);
+  });
+
+  it("routes a legacy root database and sessions to its durable owner", async () => {
+    const { root, cfg } = await makeRootWithEmptyCfg();
+    const legacyAgentDir = writeLegacyAgentFiles(root, { "auth.json": "{}" });
+    const sourcePath = path.join(legacyAgentDir, "openclaw-agent.sqlite");
+    const env = { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv;
+    writeAgentDatabase(sourcePath, "openclaw");
+    registerOpenClawAgentDatabase({ agentId: "main", path: sourcePath, env });
+    writeLegacySessionsFixture({
+      root,
+      sessions: { legacy: { sessionId: "legacy-session", updatedAt: 10 } },
+    });
+
+    const targetAgentDir = path.join(root, "agents", "openclaw", "agent");
+    const rename = vi.spyOn(fs, "renameSync");
+    try {
+      const detected = await detectLegacyStateMigrations({
+        cfg,
+        env,
+      });
+      await runLegacyStateMigrations({ detected, env });
+      expect(rename).toHaveBeenCalledWith(legacyAgentDir, targetAgentDir);
+    } finally {
+      rename.mockRestore();
+    }
+
+    expect(fs.existsSync(path.join(targetAgentDir, "openclaw-agent.sqlite"))).toBe(true);
+    expect(fs.existsSync(path.join(targetAgentDir, "auth.json"))).toBe(true);
+    expect(
+      readSessionsStore(path.join(root, "agents", "openclaw", "sessions"))["agent:openclaw:legacy"]
+        ?.sessionId,
+    ).toBe("legacy-session");
+    expect(fs.existsSync(path.join(root, "agents", "main", "sessions", "sessions.json"))).toBe(
+      false,
+    );
+    expect(
+      listOpenClawRegisteredAgentDatabases({ env }).map((entry) => ({
+        agentId: entry.agentId,
+        path: entry.path,
+      })),
+    ).toEqual([
+      {
+        agentId: "openclaw",
+        path: path.join(targetAgentDir, "openclaw-agent.sqlite"),
+      },
+    ]);
+  });
+
+  it("retains a root agent database when its session migration warns", async () => {
+    const { root, cfg } = await makeRootWithEmptyCfg();
+    const legacyAgentDir = writeLegacyAgentFiles(root, { "auth.json": "{}" });
+    writeAgentDatabase(path.join(legacyAgentDir, "openclaw-agent.sqlite"), "openclaw");
+    writeLegacySessionsFixture({
+      root,
+      sessions: { legacy: { sessionId: "legacy-session", updatedAt: 10 } },
+    });
+    const targetStorePath = path.join(root, "agents", "openclaw", "sessions", "sessions.json");
+    fs.mkdirSync(path.dirname(targetStorePath), { recursive: true });
+    fs.writeFileSync(targetStorePath, "{ invalid", "utf-8");
+
+    const detected = await detectLegacyStateMigrations({
+      cfg,
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.warnings).toContain(
+      `Target sessions store unreadable; left untouched to avoid overwriting at ${targetStorePath}. Run openclaw doctor --fix to archive it and retry the legacy merge.`,
+    );
+    expect(fs.existsSync(legacyAgentDir)).toBe(true);
+    expect(fs.existsSync(path.join(root, "agents", "openclaw", "agent"))).toBe(false);
+  });
+
+  it("does not relocate agent state while SQLite maintenance owns the state directory", async () => {
+    const { root, cfg } = await makeRootWithEmptyCfg();
+    const legacyAgentDir = writeLegacyAgentFiles(root, { "auth.json": "{}" });
+    writeAgentDatabase(path.join(legacyAgentDir, "openclaw-agent.sqlite"), "openclaw");
+    const targetAgentDir = path.join(root, "agents", "openclaw", "agent");
+    const env = { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv;
+    const lock = await acquireGatewayLock({
+      allowInTests: true,
+      env,
+      pollIntervalMs: 10,
+      role: "sqlite-maintenance",
+      timeoutMs: 100,
+    });
+    if (!lock) {
+      throw new Error("expected SQLite maintenance lock");
+    }
+
+    try {
+      const detected = await detectLegacyStateMigrations({ cfg, env });
+      const result = await runLegacyStateMigrations({ detected, env });
+
+      expect(result.warnings).toEqual([
+        expect.stringContaining(
+          "Failed migrating legacy agent relocation: the Gateway or another SQLite maintenance command owns this state directory",
+        ),
+      ]);
+      expect(fs.existsSync(legacyAgentDir)).toBe(true);
+      expect(fs.existsSync(targetAgentDir)).toBe(false);
+    } finally {
+      await lock.release();
+    }
+  });
+
+  it("relocates a bare registered default-agent database to its durable owner", async () => {
+    const { root, cfg } = await makeRootWithEmptyCfg();
+    const sourcePath = path.join(root, "agents", "main", "agent", "openclaw-agent.sqlite");
+    const targetPath = path.join(root, "agents", "openclaw", "agent", "openclaw-agent.sqlite");
+    const env = { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv;
+    writeAgentDatabase(sourcePath, "openclaw");
+    writeLegacyAgentFiles(root, { "auth.json": "{}" });
+    writeLegacySessionsFixture({
+      root,
+      sessions: { legacy: { sessionId: "legacy-session", updatedAt: 10 } },
+    });
+    registerOpenClawAgentDatabase({ agentId: "main", path: sourcePath, env });
+
+    const detected = await detectLegacyStateMigrations({
+      cfg,
+      env,
+    });
+    expect(detected.preview).toContain(`- Agent relocation: ${sourcePath} → ${targetPath}`);
+    fs.writeFileSync(`${sourcePath}-wal`, "");
+    fs.writeFileSync(`${sourcePath}-shm`, "wal-index");
+    const result = await runLegacyStateMigrations({ detected, env });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(fs.existsSync(sourcePath)).toBe(false);
+    expect(fs.existsSync(targetPath)).toBe(true);
+    expect(fs.existsSync(`${sourcePath}-wal`)).toBe(false);
+    expect(fs.existsSync(`${sourcePath}-shm`)).toBe(false);
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(targetPath, { readOnly: true });
+    try {
+      expect(
+        database.prepare("SELECT agent_id FROM schema_meta WHERE meta_key = ?").get("primary"),
+      ).toEqual({ agent_id: "openclaw" });
+    } finally {
+      database.close();
+    }
+    expect(
+      listOpenClawRegisteredAgentDatabases({ env }).map((entry) => ({
+        agentId: entry.agentId,
+        path: entry.path,
+      })),
+    ).toEqual([{ agentId: "openclaw", path: targetPath }]);
+    expect(fs.existsSync(path.join(root, "agents", "main", "agent", "auth.json"))).toBe(true);
+    expect(
+      readSessionsStore(path.join(root, "agents", "main", "sessions"))["agent:main:legacy"]
+        ?.sessionId,
+    ).toBe("legacy-session");
+  });
+
+  it("resumes a relocation with a prewritten durable registry intent", async () => {
+    const { root, cfg } = await makeRootWithEmptyCfg();
+    const sourcePath = path.join(root, "agents", "main", "agent", "openclaw-agent.sqlite");
+    const targetPath = path.join(root, "agents", "openclaw", "agent", "openclaw-agent.sqlite");
+    const env = { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv;
+    writeAgentDatabase(sourcePath, "openclaw");
+    registerOpenClawAgentDatabase({ agentId: "openclaw", path: targetPath, env });
+
+    const detected = await detectLegacyStateMigrations({ cfg, env });
+    const result = await runLegacyStateMigrations({ detected, env });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(fs.existsSync(sourcePath)).toBe(false);
+    expect(fs.existsSync(targetPath)).toBe(true);
+    expect(
+      listOpenClawRegisteredAgentDatabases({ env }).map((entry) => ({
+        agentId: entry.agentId,
+        path: entry.path,
+      })),
+    ).toEqual([{ agentId: "openclaw", path: targetPath }]);
+  });
+
+  it("transitions a source registry row stored through a state-root symlink", async () => {
+    const { root, cfg } = await makeRootWithEmptyCfg();
+    const sourcePath = path.join(root, "agents", "main", "agent", "openclaw-agent.sqlite");
+    const targetPath = path.join(root, "agents", "openclaw", "agent", "openclaw-agent.sqlite");
+    const stateRootAlias = `${root}-alias`;
+    const sourceAliasPath = path.join(
+      stateRootAlias,
+      "agents",
+      "main",
+      "agent",
+      "openclaw-agent.sqlite",
+    );
+    const env = { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv;
+    writeAgentDatabase(sourcePath, "openclaw");
+    fs.symlinkSync(root, stateRootAlias);
+    try {
+      registerOpenClawAgentDatabase({ agentId: "main", path: sourceAliasPath, env });
+
+      const detected = await detectLegacyStateMigrations({ cfg, env });
+      const result = await runLegacyStateMigrations({ detected, env });
+
+      expect(result.warnings).toStrictEqual([]);
+      expect(fs.existsSync(sourcePath)).toBe(false);
+      expect(fs.existsSync(targetPath)).toBe(true);
+      expect(
+        listOpenClawRegisteredAgentDatabases({ env }).map((entry) => ({
+          agentId: entry.agentId,
+          path: entry.path,
+        })),
+      ).toEqual([{ agentId: "openclaw", path: targetPath }]);
+    } finally {
+      fs.unlinkSync(stateRootAlias);
+    }
+  });
+
+  it("does not move the database when a foreign registry target blocks preparation", async () => {
+    const { root, cfg } = await makeRootWithEmptyCfg();
+    const sourcePath = path.join(root, "agents", "main", "agent", "openclaw-agent.sqlite");
+    const targetPath = path.join(root, "agents", "openclaw", "agent", "openclaw-agent.sqlite");
+    const env = { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv;
+    writeAgentDatabase(sourcePath, "openclaw");
+    registerOpenClawAgentDatabase({ agentId: "main", path: sourcePath, env });
+    registerOpenClawAgentDatabase({ agentId: "other", path: targetPath, env });
+
+    const detected = await detectLegacyStateMigrations({ cfg, env });
+    fs.writeFileSync(`${sourcePath}-wal`, "");
+    fs.writeFileSync(`${sourcePath}-shm`, "wal-index");
+    const rename = vi.spyOn(fs, "renameSync");
+    let result: Awaited<ReturnType<typeof runLegacyStateMigrations>>;
+    try {
+      result = await runLegacyStateMigrations({ detected, env });
+      expect(rename).not.toHaveBeenCalledWith(sourcePath, targetPath);
+    } finally {
+      rename.mockRestore();
+    }
+
+    expect(result.changes).not.toContain(
+      `Relocated agent database → ${path.relative(root, targetPath)}`,
+    );
+    expect(result.warnings).toEqual([
+      expect.stringContaining(
+        `Agent database registry target ${targetPath} is already registered to other.`,
+      ),
+    ]);
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    expect(fs.existsSync(targetPath)).toBe(false);
+    expect(fs.existsSync(`${sourcePath}-wal`)).toBe(true);
+    expect(fs.existsSync(`${sourcePath}-shm`)).toBe(true);
+    expect(
+      listOpenClawRegisteredAgentDatabases({ env }).map((entry) => ({
+        agentId: entry.agentId,
+        path: entry.path,
+      })),
+    ).toEqual([
+      { agentId: "main", path: sourcePath },
+      { agentId: "other", path: targetPath },
+    ]);
+  });
+
+  it("leaves relocation state untouched when the source database changes type", async () => {
+    const { root, cfg } = await makeRootWithEmptyCfg();
+    const legacyAgentDir = writeLegacyAgentFiles(root, { "auth.json": "{}" });
+    const sourcePath = path.join(legacyAgentDir, "openclaw-agent.sqlite");
+    writeAgentDatabase(sourcePath, "openclaw");
+    writeLegacySessionsFixture({
+      root,
+      sessions: { legacy: { sessionId: "legacy-session", updatedAt: 10 } },
+    });
+
+    const detected = await detectLegacyStateMigrations({
+      cfg,
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    fs.unlinkSync(sourcePath);
+    fs.mkdirSync(sourcePath);
+
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.warnings).toEqual([
+      `Refused relocating legacy agent directory because ${legacyAgentDir} no longer contains a regular agent database.`,
+    ]);
+    expect(fs.existsSync(path.join(root, "sessions", "sessions.json"))).toBe(true);
+    expect(fs.lstatSync(sourcePath).isDirectory()).toBe(true);
+  });
+
+  it("leaves relocation sessions untouched when its target appears after detection", async () => {
+    const { root, cfg } = await makeRootWithEmptyCfg();
+    const legacyAgentDir = writeLegacyAgentFiles(root, { "auth.json": "{}" });
+    writeAgentDatabase(path.join(legacyAgentDir, "openclaw-agent.sqlite"), "openclaw");
+    writeLegacySessionsFixture({
+      root,
+      sessions: { legacy: { sessionId: "legacy-session", updatedAt: 10 } },
+    });
+
+    const targetAgentDir = path.join(root, "agents", "openclaw", "agent");
+    const detected = await detectLegacyStateMigrations({
+      cfg,
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    fs.mkdirSync(path.dirname(targetAgentDir), { recursive: true });
+    fs.writeFileSync(targetAgentDir, "collision", "utf-8");
+
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.warnings).toEqual([
+      `Refused relocating legacy agent directory because destination already exists at ${targetAgentDir}; left source files untouched.`,
+    ]);
+    expect(fs.existsSync(path.join(root, "sessions", "sessions.json"))).toBe(true);
+    expect(fs.existsSync(legacyAgentDir)).toBe(true);
+  });
+
+  it("reports a dangling relocation target as blocked during detection", async () => {
+    const { root, cfg } = await makeRootWithEmptyCfg();
+    const legacyAgentDir = writeLegacyAgentFiles(root, { "auth.json": "{}" });
+    writeAgentDatabase(path.join(legacyAgentDir, "openclaw-agent.sqlite"), "openclaw");
+    writeLegacySessionsFixture({
+      root,
+      sessions: { legacy: { sessionId: "legacy-session", updatedAt: 10 } },
+    });
+
+    const targetAgentDir = path.join(root, "agents", "openclaw", "agent");
+    fs.mkdirSync(path.dirname(targetAgentDir), { recursive: true });
+    fs.symlinkSync("missing-agent-dir", targetAgentDir);
+
+    const detected = await detectLegacyStateMigrations({
+      cfg,
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    const warning = `Refused relocating legacy agent directory because destination already exists at ${targetAgentDir}; left source files untouched.`;
+    expect(detected.agentDir.migrationBlockedReason).toBe(warning);
+    expect(detected.preview).toContain(`- Agent relocation blocked: ${warning}`);
+
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.warnings).toEqual([warning]);
+    expect(fs.existsSync(path.join(root, "sessions", "sessions.json"))).toBe(true);
+    expect(fs.existsSync(legacyAgentDir)).toBe(true);
+  });
+
+  it("retains an open source agent database without moving sessions", async () => {
+    const { root, cfg } = await makeRootWithEmptyCfg();
+    const sourcePath = path.join(root, "agent", "openclaw-agent.sqlite");
+    const env = { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv;
+    openOpenClawAgentDatabase({ agentId: "openclaw", env, path: sourcePath });
+    writeLegacySessionsFixture({
+      root,
+      sessions: { legacy: { sessionId: "legacy-session", updatedAt: 10 } },
+    });
+
+    try {
+      const detected = await detectLegacyStateMigrations({ cfg, env });
+      const result = await runLegacyStateMigrations({ detected, env });
+
+      expect(result.warnings).toEqual([
+        `Skipped legacy agent relocation because source agent database is open in this process at ${sourcePath}; left sessions and agent state untouched.`,
+      ]);
+      expect(fs.existsSync(path.join(root, "sessions", "sessions.json"))).toBe(true);
+      expect(fs.existsSync(sourcePath)).toBe(true);
+    } finally {
+      closeOpenClawAgentDatabasesForTest();
+    }
+  });
+
+  it("refuses an ambiguous root SQLite sidecar without moving agent state", async () => {
+    const { root, cfg } = await makeRootWithEmptyCfg();
+    const sourcePath = path.join(root, "agents", "main", "agent", "openclaw-agent.sqlite");
+    const targetPath = path.join(root, "agents", "openclaw", "agent", "openclaw-agent.sqlite");
+    writeAgentDatabase(sourcePath, "openclaw");
+    writeLegacyAgentFiles(root, { "openclaw-agent.sqlite-wal": "residual" });
+
+    const detected = await detectLegacyStateMigrations({
+      cfg,
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.warnings).toEqual([
+      "Refused relocating misplaced agent database because SQLite sidecars are present or ambiguous; left source files untouched.",
+    ]);
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    expect(fs.existsSync(targetPath)).toBe(false);
+    expect(fs.existsSync(path.join(root, "agent", "openclaw-agent.sqlite-wal"))).toBe(true);
   });
 
   it("auto-migrates legacy agent dir on startup", async () => {

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -1,3 +1,4 @@
+import { statSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -34,6 +35,9 @@ import {
   LEGACY_IMPLICIT_AGENT_ID,
   normalizeAgentId,
 } from "../routing/session-key.js";
+import { relocateOpenClawAgentDatabaseRegistry } from "../state/openclaw-agent-db-registry.js";
+import { readExistingAgentSchemaMeta } from "../state/openclaw-agent-db-schema-helpers.js";
+import { isOpenClawAgentDatabaseOpen } from "../state/openclaw-agent-db.js";
 import {
   detectOpenClawStateDatabaseSchemaMigrations,
   repairOpenClawStateDatabaseSchema,
@@ -42,6 +46,8 @@ import {
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { acquireGatewayLock } from "./gateway-lock.js";
+import { openNodeSqliteDatabase } from "./node-sqlite.js";
+import { resolveSqliteDatabaseFilePaths } from "./sqlite-files.js";
 import {
   detectLegacyAcpReplayLedger,
   migrateLegacyAcpReplayLedger,
@@ -80,9 +86,12 @@ import {
   safeReadDir,
 } from "./state-migrations.fs.js";
 import {
+  clearTransientAgentDatabaseSidecars,
+  getLegacyAgentRelocationBlocker,
   migrateLegacyAgentDir,
   migrateLegacySessions,
 } from "./state-migrations.legacy-sessions.js";
+import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import {
   detectLegacyManagedOutgoingImages,
   migrateLegacyManagedOutgoingImages,
@@ -276,6 +285,31 @@ function resolveDoctorStateMigrationAgentId(cfg: OpenClawConfig): string {
   }
 }
 
+function readAgentDatabaseOwner(pathname: string): string {
+  const database = openNodeSqliteDatabase(pathname, { readOnly: true });
+  try {
+    const metadata = readExistingAgentSchemaMeta(database);
+    if (!metadata || metadata.role !== "agent" || !metadata.agentId) {
+      throw new Error("missing valid agent schema ownership metadata");
+    }
+    return normalizeAgentId(metadata.agentId);
+  } finally {
+    database.close();
+  }
+}
+
+function resolveAgentDatabasePath(stateDir: string, agentId: string): string {
+  return path.join(stateDir, "agents", agentId, "agent", "openclaw-agent.sqlite");
+}
+
+function hasSqliteDataSidecars(pathname: string): boolean {
+  const [, walPath, , journalPath] = resolveSqliteDatabaseFilePaths(pathname);
+  return [walPath, journalPath].some(
+    (sidecarPath) =>
+      sidecarPath !== undefined && fileExists(sidecarPath) && statSync(sidecarPath).size > 0,
+  );
+}
+
 function resolveConcreteBindingAccountId(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
@@ -349,13 +383,64 @@ export async function detectLegacyStateMigrations(params: {
   const stateDir = resolveStateDir(env, homedir);
   const oauthDir = resolveOAuthDir(env, stateDir);
 
-  const targetAgentId = resolveDoctorStateMigrationAgentId(params.cfg);
+  const configuredAgentId = resolveDoctorStateMigrationAgentId(params.cfg);
+  let targetAgentId = configuredAgentId;
   const rawMainKey = params.cfg.session?.mainKey;
   const targetMainKey =
     typeof rawMainKey === "string" && rawMainKey.trim().length > 0
       ? rawMainKey.trim()
       : DEFAULT_MAIN_KEY;
   const targetScope = params.cfg.session?.scope;
+
+  const legacyAgentDir = path.join(stateDir, "agent");
+  const legacyAgentDatabasePath = path.join(legacyAgentDir, "openclaw-agent.sqlite");
+  const configuredAgentDatabasePath = resolveAgentDatabasePath(stateDir, configuredAgentId);
+  const legacyAgentDatabaseHasDataSidecars = hasSqliteDataSidecars(legacyAgentDatabasePath);
+  const configuredAgentDatabaseHasDataSidecars = hasSqliteDataSidecars(configuredAgentDatabasePath);
+  let agentDirRelocation: LegacyStateDetection["agentDir"]["relocation"];
+  let migrationBlockedReason: string | undefined;
+  const resolveDatabaseOwner = (pathname: string): string | undefined => {
+    try {
+      return readAgentDatabaseOwner(pathname);
+    } catch (err) {
+      migrationBlockedReason = `Cannot read agent database ownership from ${pathname}; left related legacy agent state in place. ${String(err)}`;
+      return undefined;
+    }
+  };
+  const legacyDatabaseOwner = fileExists(legacyAgentDatabasePath)
+    ? resolveDatabaseOwner(legacyAgentDatabasePath)
+    : undefined;
+  if (legacyDatabaseOwner) {
+    targetAgentId = legacyDatabaseOwner;
+    const targetDir = path.dirname(resolveAgentDatabasePath(stateDir, targetAgentId));
+    const relocation = {
+      kind: "directory" as const,
+      ownerAgentId: legacyDatabaseOwner,
+      sourcePath: legacyAgentDir,
+      targetPath: targetDir,
+    };
+    migrationBlockedReason = getLegacyAgentRelocationBlocker(relocation);
+    if (!migrationBlockedReason) {
+      agentDirRelocation = relocation;
+    }
+  } else if (!migrationBlockedReason && fileExists(configuredAgentDatabasePath)) {
+    const databaseOwner = resolveDatabaseOwner(configuredAgentDatabasePath);
+    if (databaseOwner && databaseOwner !== configuredAgentId) {
+      const targetPath = resolveAgentDatabasePath(stateDir, databaseOwner);
+      const relocation = {
+        kind: "database" as const,
+        ownerAgentId: databaseOwner,
+        sourcePath: configuredAgentDatabasePath,
+        targetPath,
+        sourceHasDataSidecars:
+          configuredAgentDatabaseHasDataSidecars || legacyAgentDatabaseHasDataSidecars,
+      };
+      migrationBlockedReason = getLegacyAgentRelocationBlocker(relocation);
+      if (!migrationBlockedReason) {
+        agentDirRelocation = relocation;
+      }
+    }
+  }
 
   const sessionsLegacyDir = path.join(stateDir, "sessions");
   const sessionsLegacyStorePath = path.join(sessionsLegacyDir, "sessions.json");
@@ -378,15 +463,20 @@ export async function detectLegacyStateMigrations(params: {
   });
   const sessionStoreOwnership: SessionStoreOwnership = {
     preserveAmbiguousKeys:
-      params.sessionStoreOwnership?.preserveAmbiguousKeys === true ||
+      (targetAgentId === configuredAgentId &&
+        params.sessionStoreOwnership?.preserveAmbiguousKeys === true) ||
       currentSessionStoreOwnership.preserveAmbiguousKeys,
     preserveForeignMainAliases:
-      params.sessionStoreOwnership?.preserveForeignMainAliases === true ||
+      (targetAgentId === configuredAgentId &&
+        params.sessionStoreOwnership?.preserveForeignMainAliases === true) ||
       currentSessionStoreOwnership.preserveForeignMainAliases,
-    targetStoreAliases: mergeSessionStoreAliasPlans(
-      params.sessionStoreOwnership?.targetStoreAliases,
-      currentSessionStoreOwnership.targetStoreAliases,
-    ),
+    targetStoreAliases:
+      targetAgentId === configuredAgentId
+        ? mergeSessionStoreAliasPlans(
+            params.sessionStoreOwnership?.targetStoreAliases,
+            currentSessionStoreOwnership.targetStoreAliases,
+          )
+        : currentSessionStoreOwnership.targetStoreAliases,
   };
   const { preserveForeignMainAliases } = sessionStoreOwnership;
   const legacySessionEntries = safeReadDir(sessionsLegacyDir);
@@ -419,7 +509,6 @@ export async function detectLegacyStateMigrations(params: {
       ),
     );
 
-  const legacyAgentDir = path.join(stateDir, "agent");
   const targetAgentDir = path.join(stateDir, "agents", targetAgentId, "agent");
   const hasLegacyAgentDir = existsDir(legacyAgentDir);
   const pluginStateSidecarPath = resolveLegacyPluginStateSidecarPath(stateDir);
@@ -561,7 +650,7 @@ export async function detectLegacyStateMigrations(params: {
       configuredChannels.flatMap(([channelId, value]) => {
         const boundAccountId = params.cfg.bindings?.find(
           (binding) =>
-            normalizeAgentId(binding.agentId) === targetAgentId &&
+            normalizeAgentId(binding.agentId) === configuredAgentId &&
             binding.match?.channel === channelId &&
             resolveConcreteBindingAccountId(binding.match.accountId) !== undefined,
         )?.match.accountId;
@@ -609,7 +698,13 @@ export async function detectLegacyStateMigrations(params: {
   if (hasStaleSessionFiles) {
     preview.push(`- Sessions: repair migrated transcript paths in ${sessionsTargetStorePath}`);
   }
-  if (hasLegacyAgentDir) {
+  if (agentDirRelocation) {
+    preview.push(
+      `- Agent relocation: ${agentDirRelocation.sourcePath} → ${agentDirRelocation.targetPath}`,
+    );
+  } else if (migrationBlockedReason) {
+    preview.push(`- Agent relocation blocked: ${migrationBlockedReason}`);
+  } else if (hasLegacyAgentDir) {
     preview.push(`- Agent dir: ${legacyAgentDir} → ${targetAgentDir}`);
   }
   if (hasPluginStateSidecar) {
@@ -738,7 +833,12 @@ export async function detectLegacyStateMigrations(params: {
     agentDir: {
       legacyDir: legacyAgentDir,
       targetDir: targetAgentDir,
-      hasLegacy: hasLegacyAgentDir,
+      hasLegacy:
+        hasLegacyAgentDir ||
+        agentDirRelocation !== undefined ||
+        migrationBlockedReason !== undefined,
+      ...(migrationBlockedReason ? { migrationBlockedReason } : {}),
+      ...(agentDirRelocation ? { relocation: agentDirRelocation } : {}),
     },
     pluginPlans: {
       hasLegacy: pluginPlans.length > 0,
@@ -982,6 +1082,88 @@ function migrateLegacyStateSchema(
   });
 }
 
+async function migrateRelocatedLegacyAgentState(params: {
+  detected: LegacyStateDetection;
+  env: NodeJS.ProcessEnv;
+  now: () => number;
+  recoverCorruptTargetStore?: boolean;
+}): Promise<MigrationMessages> {
+  const relocation = params.detected.agentDir.relocation;
+  if (!relocation) {
+    return { changes: [], warnings: [] };
+  }
+
+  return await withLegacyMigrationStateLock({
+    stateDir: params.detected.stateDir,
+    env: params.env,
+    label: "legacy agent relocation",
+    releaseLabel: "Legacy agent relocation",
+    retryGuidance:
+      "Stop the Gateway and run `openclaw doctor --fix` again; sessions and agent state were left untouched.",
+    run: async (stateEnv) => {
+      const sourceDatabasePath =
+        relocation.kind === "directory"
+          ? path.join(relocation.sourcePath, "openclaw-agent.sqlite")
+          : relocation.sourcePath;
+      const result: MigrationMessages = { changes: [], warnings: [] };
+      if (isOpenClawAgentDatabaseOpen(sourceDatabasePath)) {
+        result.warnings.push(
+          `Skipped legacy agent relocation because source agent database is open in this process at ${sourceDatabasePath}; left sessions and agent state untouched.`,
+        );
+        return result;
+      }
+
+      const relocationBlocker = getLegacyAgentRelocationBlocker(relocation);
+      if (relocationBlocker) {
+        result.warnings.push(relocationBlocker);
+        return result;
+      }
+
+      const registrySourcePath =
+        relocation.kind === "directory"
+          ? path.join(relocation.sourcePath, "openclaw-agent.sqlite")
+          : relocation.sourcePath;
+      const registryTargetPath =
+        relocation.kind === "directory"
+          ? path.join(relocation.targetPath, "openclaw-agent.sqlite")
+          : relocation.targetPath;
+      try {
+        relocateOpenClawAgentDatabaseRegistry({
+          agentId: relocation.ownerAgentId,
+          sourcePath: registrySourcePath,
+          targetPath: registryTargetPath,
+          env: stateEnv,
+        });
+      } catch (error) {
+        result.warnings.push(
+          `Failed preparing the agent database registry relocation from ${registrySourcePath}; left sessions and agent state untouched: ${String(error)}`,
+        );
+        return result;
+      }
+
+      const transientSidecarWarning = clearTransientAgentDatabaseSidecars(relocation);
+      if (transientSidecarWarning) {
+        result.warnings.push(transientSidecarWarning);
+        return result;
+      }
+
+      const sessions = await migrateLegacySessions(params.detected, params.now, {
+        recoverCorruptTargetStore: params.recoverCorruptTargetStore,
+      });
+      result.changes.push(...sessions.changes);
+      result.warnings.push(...sessions.warnings);
+      if (relocation.kind === "directory" && sessions.warnings.length > 0) {
+        return result;
+      }
+
+      const agentDir = await migrateLegacyAgentDir(params.detected, params.now);
+      result.changes.push(...agentDir.changes);
+      result.warnings.push(...agentDir.warnings);
+      return result;
+    },
+  });
+}
+
 type LegacyStateMigrationStep = {
   phase: "shared" | "final";
   kind?: "acp-session-metadata";
@@ -1125,7 +1307,19 @@ function buildLegacyStateMigrationSteps(
       ]
     : [];
 
+  const relocatedAgentStateStep =
+    !params.skipAgentScopedMigrations && detected.agentDir.relocation
+      ? finalStep(() =>
+          migrateRelocatedLegacyAgentState({
+            detected,
+            env,
+            now,
+            recoverCorruptTargetStore: params.recoverCorruptTargetStore,
+          }),
+        )
+      : undefined;
   const finalSteps: LegacyStateMigrationStep[] = [
+    ...(relocatedAgentStateStep ? [relocatedAgentStateStep] : []),
     ownerStep(detected.restartSentinel, migrateLegacyRestartSentinel),
     ...doctorFinalSteps,
     finalStep(() =>
@@ -1146,25 +1340,29 @@ function buildLegacyStateMigrationSteps(
   if (!params.skipAgentScopedMigrations) {
     // ACP metadata must run once after sessions are canonicalized; otherwise
     // existing rows and newly imported rows generate conflicting repeat warnings.
-    finalSteps.push(
-      finalStep(() =>
-        migrateLegacySessions(detected, now, {
-          recoverCorruptTargetStore: params.recoverCorruptTargetStore,
+    const migrateAcpSessionMetadataStep = {
+      ...finalStep(() =>
+        migrateLegacyAcpSessionMetadata({
+          cfg: params.sessionConfig ?? params.config,
+          env: isDoctor ? { ...env, OPENCLAW_STATE_DIR: stateDir } : env,
+          now,
+          ...(isDoctor ? {} : { pluginSessionStoreAgentIds: params.pluginSessionStoreAgentIds }),
         }),
       ),
-      {
-        ...finalStep(() =>
-          migrateLegacyAcpSessionMetadata({
-            cfg: params.sessionConfig ?? params.config,
-            env: isDoctor ? { ...env, OPENCLAW_STATE_DIR: stateDir } : env,
-            now,
-            ...(isDoctor ? {} : { pluginSessionStoreAgentIds: params.pluginSessionStoreAgentIds }),
-          }),
-        ),
-        kind: "acp-session-metadata",
-      },
-      finalStep(() => migrateLegacyAgentDir(detected, now)),
-    );
+      kind: "acp-session-metadata" as const,
+    };
+    const agentStateSteps = relocatedAgentStateStep
+      ? [migrateAcpSessionMetadataStep]
+      : [
+          finalStep(() =>
+            migrateLegacySessions(detected, now, {
+              recoverCorruptTargetStore: params.recoverCorruptTargetStore,
+            }),
+          ),
+          migrateAcpSessionMetadataStep,
+          finalStep(() => migrateLegacyAgentDir(detected, now)),
+        ];
+    finalSteps.push(...agentStateSteps);
   }
 
   return [...managedWorktreePrelude, ...sharedSteps, ...doctorStateSteps, ...finalSteps];
@@ -1296,22 +1494,6 @@ export async function autoMigrateLegacyState(params: {
       ...(stateDirResult.notices?.length ? { notices: stateDirResult.notices } : {}),
     };
   }
-  const mediaPersistence =
-    params.doctorOnlyStateMigrations === true
-      ? migrateLegacyMediaPersistence({ env: { ...env, OPENCLAW_STATE_DIR: stateDir } })
-      : { changes: [], warnings: [] };
-  if (mediaPersistence.warnings.length > 0) {
-    return {
-      migrated:
-        stateDirResult.migrated ||
-        stateSchema.changes.length > 0 ||
-        mediaPersistence.changes.length > 0,
-      skipped: false,
-      changes: [...stateDirResult.changes, ...stateSchema.changes, ...mediaPersistence.changes],
-      warnings: [...stateDirResult.warnings, ...stateSchema.warnings, ...mediaPersistence.warnings],
-      ...(stateDirResult.notices?.length ? { notices: stateDirResult.notices } : {}),
-    };
-  }
   const pluginDoctorConfig = params.pluginDoctorConfig ?? params.cfg;
   const configMachineState = migrateLegacyConfigMachineState({
     config: pluginDoctorConfig,
@@ -1397,13 +1579,7 @@ export async function autoMigrateLegacyState(params: {
     recoverCorruptTargetStore: params.recoverCorruptTargetStore,
     skipAgentScopedMigrations: Boolean(hasCustomAgentDir),
   });
-  const initialMigrationSources = [
-    stateDirResult,
-    stateSchema,
-    mediaPersistence,
-    configMachineState,
-    orphanKeys,
-  ];
+  const initialMigrationSources = [stateDirResult, stateSchema, configMachineState, orphanKeys];
   const initialMigrationWarnings = [
     ...initialMigrationSources.slice(0, -1).flatMap((source) => source.warnings),
     ...detected.warnings,
@@ -1438,9 +1614,14 @@ export async function autoMigrateLegacyState(params: {
     const acpSessionMetadata = acpSessionMetadataStep
       ? await acpSessionMetadataStep.run()
       : { changes: [], warnings: [] };
+    const mediaPersistence =
+      params.doctorOnlyStateMigrations === true
+        ? migrateLegacyMediaPersistence({ env: { ...env, OPENCLAW_STATE_DIR: stateDir } })
+        : { changes: [], warnings: [] };
     const completedSources = [
       ...initialMigrationSources,
       acpSessionMetadata,
+      mediaPersistence,
       deviceAuth,
       deviceIdentity,
       meetingTranscripts,
@@ -1448,9 +1629,13 @@ export async function autoMigrateLegacyState(params: {
     const changes = completedSources.flatMap((source) => source.changes);
     const warnings = [
       ...initialMigrationWarnings,
-      ...[acpSessionMetadata, deviceAuth, deviceIdentity, meetingTranscripts].flatMap(
-        (source) => source.warnings,
-      ),
+      ...[
+        acpSessionMetadata,
+        mediaPersistence,
+        deviceAuth,
+        deviceIdentity,
+        meetingTranscripts,
+      ].flatMap((source) => source.warnings),
     ];
     const notices = mergeNotices([stateDirResult, detected, deviceAuth, deviceIdentity]);
     logMigrationResults(changes, warnings, notices);
@@ -1464,6 +1649,11 @@ export async function autoMigrateLegacyState(params: {
   }
 
   const migrations = await runLegacyStateMigrationSteps(migrationSteps);
+  const mediaPersistence =
+    params.doctorOnlyStateMigrations === true &&
+    migrations.sources.every((source) => source.warnings.length === 0)
+      ? migrateLegacyMediaPersistence({ env: { ...env, OPENCLAW_STATE_DIR: stateDir } })
+      : { changes: [], warnings: [] };
   const completedSources = [
     ...initialMigrationSources,
     ...migrations.sharedSources,
@@ -1471,6 +1661,7 @@ export async function autoMigrateLegacyState(params: {
     deviceIdentity,
     ...(hasCustomAgentDir ? [] : [meetingTranscripts]),
     ...migrations.finalSources,
+    mediaPersistence,
   ];
   const changes = completedSources.flatMap((source) => source.changes);
   const warnings = [
@@ -1480,6 +1671,7 @@ export async function autoMigrateLegacyState(params: {
     ...deviceIdentity.warnings,
     ...(hasCustomAgentDir ? [] : meetingTranscripts.warnings),
     ...migrations.finalSources.flatMap((source) => source.warnings),
+    ...mediaPersistence.warnings,
   ];
   const notices = mergeNotices([
     stateDirResult,

--- a/src/infra/state-migrations.legacy-sessions.ts
+++ b/src/infra/state-migrations.legacy-sessions.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { SessionEntry } from "../config/sessions.js";
 import { buildAgentMainSessionKey } from "../routing/session-key.js";
+import { resolveSqliteDatabaseFilePaths } from "./sqlite-files.js";
 import {
   ensureMigrationDir,
   fileExists,
@@ -25,6 +26,105 @@ import {
   unresolvedSessionStoreIdentityWarning,
 } from "./state-migrations.session-store.js";
 import type { LegacyStateDetection } from "./state-migrations.types.js";
+
+type LegacyAgentRelocation = NonNullable<LegacyStateDetection["agentDir"]["relocation"]>;
+
+function pathEntryExists(pathname: string): boolean {
+  try {
+    fs.lstatSync(pathname);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return false;
+    }
+    if (code === "ENOTDIR") {
+      return true;
+    }
+    throw error;
+  }
+}
+
+function sourceRelocationBlocker(relocation: LegacyAgentRelocation): string | undefined {
+  try {
+    const source = fs.lstatSync(relocation.sourcePath);
+    if (relocation.kind === "database") {
+      return source.isFile()
+        ? undefined
+        : `Refused relocating agent database because source ${relocation.sourcePath} is no longer a regular file.`;
+    }
+    if (!source.isDirectory()) {
+      return `Refused relocating legacy agent directory because source ${relocation.sourcePath} is no longer a directory.`;
+    }
+    const database = fs.lstatSync(path.join(relocation.sourcePath, "openclaw-agent.sqlite"));
+    return database.isFile()
+      ? undefined
+      : `Refused relocating legacy agent directory because ${relocation.sourcePath} no longer contains a regular agent database.`;
+  } catch (error) {
+    return `Refused relocating agent database because source ${relocation.sourcePath} is unavailable: ${String(error)}.`;
+  }
+}
+
+/**
+ * Reject partial SQLite moves and any destination that would turn a rename
+ * into a merge. The migration lock serializes OpenClaw writers, not outside
+ * filesystem changes, so callers check this before dependent session moves.
+ */
+export function getLegacyAgentRelocationBlocker(
+  relocation: LegacyAgentRelocation,
+): string | undefined {
+  const sourceBlocker = sourceRelocationBlocker(relocation);
+  if (sourceBlocker) {
+    return sourceBlocker;
+  }
+  if (relocation.kind === "directory") {
+    // One same-filesystem directory rename keeps the primary, WAL, SHM, and
+    // rollback journal together as one SQLite generation.
+    return pathEntryExists(relocation.targetPath)
+      ? `Refused relocating legacy agent directory because destination already exists at ${relocation.targetPath}; left source files untouched.`
+      : undefined;
+  }
+
+  if (relocation.sourceHasDataSidecars) {
+    return "Refused relocating misplaced agent database because SQLite sidecars are present or ambiguous; left source files untouched.";
+  }
+  return resolveSqliteDatabaseFilePaths(relocation.targetPath).some((pathname) =>
+    pathEntryExists(pathname),
+  )
+    ? "Refused relocating misplaced agent database because a canonical destination or SQLite sidecar already exists; left source files untouched."
+    : undefined;
+}
+
+export function clearTransientAgentDatabaseSidecars(
+  relocation: LegacyAgentRelocation,
+): string | undefined {
+  if (relocation.kind === "directory") {
+    return undefined;
+  }
+
+  const [, walPath, shmPath, journalPath] = resolveSqliteDatabaseFilePaths(relocation.sourcePath);
+  for (const [pathname, containsRecoveryData] of [
+    [walPath, true],
+    [shmPath, false],
+    [journalPath, true],
+  ] as const) {
+    if (!pathname) {
+      continue;
+    }
+    try {
+      const stat = fs.lstatSync(pathname);
+      if (!stat.isFile() || (containsRecoveryData && stat.size > 0)) {
+        return "Refused relocating misplaced agent database because SQLite sidecars appeared after detection; left source files untouched.";
+      }
+      fs.unlinkSync(pathname);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        return `Failed clearing transient SQLite sidecar ${pathname}: ${String(error)}`;
+      }
+    }
+  }
+  return undefined;
+}
 
 function normalizeMergedSessionStore(
   merged: Record<string, SessionEntryLike>,
@@ -55,9 +155,10 @@ export async function migrateLegacySessions(
 ): Promise<{ changes: string[]; warnings: string[] }> {
   const changes: string[] = [];
   const warnings: string[] = [];
-  if (!detected.sessions.hasLegacy) {
+  if (!detected.sessions.hasLegacy || detected.agentDir.migrationBlockedReason) {
     return { changes, warnings };
   }
+  const targetAgentId = detected.targetAgentId;
 
   ensureMigrationDir(detected.sessions.targetDir);
 
@@ -113,7 +214,7 @@ export async function migrateLegacySessions(
 
   const canonicalizedTarget = canonicalizeSessionStore({
     store: targetStore,
-    agentId: detected.targetAgentId,
+    agentId: targetAgentId,
     mainKey: detected.targetMainKey,
     scope: detected.targetScope,
     skipCrossAgentRemap: detected.sessions.preserveAmbiguousKeys,
@@ -123,7 +224,7 @@ export async function migrateLegacySessions(
   });
   const canonicalizedLegacy = canonicalizeSessionStore({
     store: legacyStore,
-    agentId: detected.targetAgentId,
+    agentId: targetAgentId,
     mainKey: detected.targetMainKey,
     scope: detected.targetScope,
     preserveCanonicalAgentOwner: true,
@@ -162,7 +263,7 @@ export async function migrateLegacySessions(
   }
 
   const mainKey = buildAgentMainSessionKey({
-    agentId: detected.targetAgentId,
+    agentId: targetAgentId,
     mainKey: detected.targetMainKey,
   });
   let migratedDirectChatKey: string | undefined;
@@ -251,7 +352,7 @@ export async function migrateLegacySessions(
     }
     try {
       fs.renameSync(from, to);
-      changes.push(`Moved ${entry.name} → agents/${detected.targetAgentId}/sessions`);
+      changes.push(`Moved ${entry.name} → agents/${targetAgentId}/sessions`);
     } catch (err) {
       warnings.push(`Failed moving ${from}: ${String(err)}`);
     }
@@ -291,6 +392,48 @@ export async function migrateLegacyAgentDir(
   if (!detected.agentDir.hasLegacy) {
     return { changes, warnings };
   }
+  const targetAgentId = detected.targetAgentId;
+  if (detected.agentDir.migrationBlockedReason) {
+    return { changes, warnings: [detected.agentDir.migrationBlockedReason] };
+  }
+  if (detected.agentDir.relocation) {
+    const { relocation } = detected.agentDir;
+    const relocationBlocker = getLegacyAgentRelocationBlocker(relocation);
+    if (relocationBlocker) {
+      return {
+        changes,
+        warnings: [relocationBlocker],
+      };
+    }
+    const transientSidecarWarning = clearTransientAgentDatabaseSidecars(relocation);
+    if (transientSidecarWarning) {
+      return {
+        changes,
+        warnings: [transientSidecarWarning],
+      };
+    }
+    try {
+      ensureMigrationDir(path.dirname(relocation.targetPath));
+      try {
+        fs.renameSync(relocation.sourcePath, relocation.targetPath);
+      } catch (error) {
+        warnings.push(
+          `Failed relocating agent database from ${relocation.sourcePath} to ${relocation.targetPath}; the registry relocation intent remains prepared. Rerun openclaw doctor --fix: ${String(error)}`,
+        );
+        return { changes, warnings };
+      }
+      changes.push(
+        relocation.kind === "directory"
+          ? `Moved agent dir → agents/${targetAgentId}/agent`
+          : `Relocated agent database → ${path.relative(detected.stateDir, relocation.targetPath)}`,
+      );
+    } catch (err) {
+      warnings.push(`Failed relocating agent database: ${String(err)}`);
+    }
+    if (relocation.kind === "directory" || warnings.length > 0) {
+      return { changes, warnings };
+    }
+  }
 
   ensureMigrationDir(detected.agentDir.targetDir);
 
@@ -303,7 +446,7 @@ export async function migrateLegacyAgentDir(
     }
     try {
       fs.renameSync(from, to);
-      changes.push(`Moved agent file ${entry.name} → agents/${detected.targetAgentId}/agent`);
+      changes.push(`Moved agent file ${entry.name} → agents/${targetAgentId}/agent`);
     } catch (err) {
       warnings.push(`Failed moving ${from}: ${String(err)}`);
     }
@@ -314,7 +457,7 @@ export async function migrateLegacyAgentDir(
     const backupDir = path.join(
       detected.stateDir,
       "agents",
-      detected.targetAgentId,
+      targetAgentId,
       `agent.legacy-${now()}`,
     );
     try {

--- a/src/infra/state-migrations.types.ts
+++ b/src/infra/state-migrations.types.ts
@@ -42,6 +42,16 @@ export type LegacyStateDetection = {
     legacyDir: string;
     targetDir: string;
     hasLegacy: boolean;
+    migrationBlockedReason?: string;
+    relocation?:
+      | { kind: "directory"; ownerAgentId: string; sourcePath: string; targetPath: string }
+      | {
+          kind: "database";
+          ownerAgentId: string;
+          sourcePath: string;
+          targetPath: string;
+          sourceHasDataSidecars: boolean;
+        };
   };
   pluginPlans?: {
     hasLegacy: boolean;

--- a/src/plugins/manifest-registry-installed.test.ts
+++ b/src/plugins/manifest-registry-installed.test.ts
@@ -198,6 +198,273 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
     expect(second).not.toBe(first);
   });
 
+  it("canonicalizes installed-index collection order without masking semantic changes", () => {
+    const rootDir = makeTempDir();
+    const baseIndex = createIndex(rootDir);
+    const contracts = {
+      "\u00e9": ["composed"],
+      "e\u0301": ["decomposed"],
+      alpha: ["alpha-one", "alpha-two"],
+    } satisfies NonNullable<InstalledPluginIndex["plugins"][number]["contributions"]>["contracts"];
+    const installed = {
+      ...expectDefined(baseIndex.plugins[0], "index.plugins[0] test invariant"),
+      contributions: {
+        channels: [],
+        channelConfigs: [],
+        providers: [],
+        modelCatalogProviders: [],
+        modelSupportPrefixes: [],
+        modelSupportPatterns: [],
+        autoEnableProviderIds: [],
+        commandAliases: [],
+        contracts,
+      },
+      packageChannel: {
+        id: "installed",
+        commands: {
+          nativeSkillsAutoEnabled: false,
+          nativeCommandsAutoEnabled: true,
+        },
+      },
+    };
+    const secondary = {
+      ...installed,
+      pluginId: "secondary",
+      manifestPath: path.join(rootDir, "secondary", "openclaw.plugin.json"),
+      manifestHash: "secondary-manifest-hash",
+      source: path.join(rootDir, "secondary", "index.ts"),
+      rootDir: path.join(rootDir, "secondary"),
+    };
+    const installRecords = {
+      installed: { source: "npm", spec: "installed" },
+      secondary: { source: "path", sourcePath: secondary.rootDir },
+    } satisfies InstalledPluginIndex["installRecords"];
+    const diagnostics = [
+      {
+        pluginId: "installed",
+        source: installed.manifestPath,
+        code: "plugin-verification",
+        level: "warn",
+        message: "installed diagnostic",
+      },
+      {
+        pluginId: "secondary",
+        source: secondary.manifestPath,
+        code: "plugin-verification",
+        level: "error",
+        message: "secondary diagnostic",
+      },
+    ] satisfies InstalledPluginIndex["diagnostics"];
+    const index: InstalledPluginIndex = {
+      ...baseIndex,
+      installRecords,
+      plugins: [secondary, installed],
+      diagnostics,
+    };
+    const reorderedIndex: InstalledPluginIndex = {
+      ...index,
+      installRecords: {
+        secondary: installRecords.secondary,
+        installed: installRecords.installed,
+      },
+      plugins: [installed, secondary].map((record) => ({
+        ...record,
+        contributions: {
+          ...expectDefined(record.contributions, "index.contributions test invariant"),
+          contracts: {
+            alpha: ["alpha-one", "alpha-two"],
+            "e\u0301": ["decomposed"],
+            "\u00e9": ["composed"],
+          },
+        },
+        packageChannel: {
+          ...expectDefined(record.packageChannel, "index.packageChannel test invariant"),
+          commands: {
+            nativeCommandsAutoEnabled: true,
+            nativeSkillsAutoEnabled: false,
+          },
+        },
+      })),
+      diagnostics: [...diagnostics].reverse(),
+    };
+    const changedIndex: InstalledPluginIndex = {
+      ...reorderedIndex,
+      plugins: reorderedIndex.plugins.map((record) =>
+        record.pluginId === "installed"
+          ? {
+              ...record,
+              contributions: {
+                ...expectDefined(record.contributions, "index.contributions test invariant"),
+                contracts: {
+                  ...expectDefined(record.contributions, "index.contributions test invariant")
+                    .contracts,
+                  alpha: ["alpha-two", "alpha-one"],
+                },
+              },
+            }
+          : record,
+      ),
+    };
+
+    const fingerprint = resolveInstalledManifestRegistryIndexFingerprint(index);
+    expect(resolveInstalledManifestRegistryIndexFingerprint(reorderedIndex)).toBe(fingerprint);
+    expect(resolveInstalledManifestRegistryIndexFingerprint(changedIndex)).not.toBe(fingerprint);
+
+    const unicodeDiagnostics = [
+      {
+        pluginId: "unicode",
+        source: "unicode-source",
+        code: "plugin-verification",
+        level: "warn",
+        message: "\u00e9",
+      },
+      {
+        pluginId: "unicode",
+        source: "unicode-source",
+        code: "plugin-verification",
+        level: "warn",
+        message: "e\u0301",
+      },
+    ] satisfies InstalledPluginIndex["diagnostics"];
+    const unicodeIndex: InstalledPluginIndex = { ...index, diagnostics: unicodeDiagnostics };
+    expect(
+      resolveInstalledManifestRegistryIndexFingerprint({
+        ...unicodeIndex,
+        diagnostics: [...unicodeDiagnostics].reverse(),
+      }),
+    ).toBe(resolveInstalledManifestRegistryIndexFingerprint(unicodeIndex));
+  });
+
+  it("fingerprints only the persisted package-build field", () => {
+    const rootDir = makeTempDir();
+    const index = createIndex(rootDir);
+    const plugin = expectDefined(index.plugins[0], "index.plugins[0] test invariant");
+    const initialIndex: InstalledPluginIndex = {
+      ...index,
+      plugins: [
+        {
+          ...plugin,
+          packageBuild: Object.assign(
+            { bundledDist: true },
+            {
+              openclawVersion: "2026.8.8",
+              staticAssets: ["assets/logo.svg"],
+              runtimeFormat: "esm",
+            },
+          ),
+        },
+      ],
+    };
+    const convergedIndex: InstalledPluginIndex = {
+      ...initialIndex,
+      plugins: [{ ...plugin, packageBuild: { bundledDist: true } }],
+    };
+    const volatileOnlyIndex: InstalledPluginIndex = {
+      ...initialIndex,
+      plugins: [
+        {
+          ...plugin,
+          packageBuild: Object.assign(
+            {},
+            {
+              openclawVersion: "2026.8.8",
+              staticAssets: ["assets/logo.svg"],
+              runtimeFormat: "esm",
+            },
+          ),
+        },
+      ],
+    };
+    const changedBundledDistIndex: InstalledPluginIndex = {
+      ...convergedIndex,
+      plugins: [{ ...plugin, packageBuild: { bundledDist: false } }],
+    };
+
+    const fingerprint = resolveInstalledManifestRegistryIndexFingerprint(initialIndex);
+    expect(resolveInstalledManifestRegistryIndexFingerprint(convergedIndex)).toBe(fingerprint);
+    expect(resolveInstalledManifestRegistryIndexFingerprint(volatileOnlyIndex)).toBe(
+      resolveInstalledManifestRegistryIndexFingerprint(index),
+    );
+    expect(resolveInstalledManifestRegistryIndexFingerprint(changedBundledDistIndex)).not.toBe(
+      fingerprint,
+    );
+  });
+
+  it("ignores retimed file signatures while retaining plugin artifact identities", () => {
+    const rootDir = makeTempDir();
+    writePlugin(rootDir, "installed", "installed-");
+    const index = createIndexWithPackageJson(rootDir);
+    const plugin = expectDefined(index.plugins[0], "index.plugins[0] test invariant");
+    const packageJson = expectDefined(plugin.packageJson, "index.packageJson test invariant");
+    const manifestFile = expectDefined(plugin.manifestFile, "index.manifestFile test invariant");
+    const packageJsonFile = expectDefined(
+      packageJson.fileSignature,
+      "index.packageJson.fileSignature test invariant",
+    );
+    const manifestFileCtimeMs = expectDefined(
+      manifestFile.ctimeMs,
+      "index.manifestFile.ctimeMs test invariant",
+    );
+    const packageJsonFileCtimeMs = expectDefined(
+      packageJsonFile.ctimeMs,
+      "index.packageJson.fileSignature.ctimeMs test invariant",
+    );
+    const initialIndex: InstalledPluginIndex = {
+      ...index,
+      plugins: [{ ...plugin, doctorContractHash: "doctor-contract-hash" }],
+    };
+    const initialFingerprint = resolveInstalledManifestRegistryIndexFingerprint(initialIndex);
+    const retimedIndex: InstalledPluginIndex = {
+      ...initialIndex,
+      plugins: [
+        {
+          ...expectDefined(initialIndex.plugins[0], "index.plugins[0] test invariant"),
+          manifestFile: {
+            ...manifestFile,
+            mtimeMs: manifestFile.mtimeMs + 1,
+            ctimeMs: manifestFileCtimeMs + 1,
+          },
+          packageJson: {
+            ...packageJson,
+            fileSignature: {
+              ...packageJsonFile,
+              mtimeMs: packageJsonFile.mtimeMs + 1,
+              ctimeMs: packageJsonFileCtimeMs + 1,
+            },
+          },
+        },
+      ],
+    };
+
+    expect(resolveInstalledManifestRegistryIndexFingerprint(retimedIndex)).toBe(initialFingerprint);
+
+    for (const changedPlugin of [
+      {
+        ...plugin,
+        doctorContractHash: "doctor-contract-hash",
+        manifestHash: "changed-manifest-hash",
+      },
+      { ...plugin, doctorContractHash: "changed-doctor-contract-hash" },
+      {
+        ...plugin,
+        doctorContractHash: "doctor-contract-hash",
+        packageJson: { ...packageJson, path: "nested/package.json" },
+      },
+      {
+        ...plugin,
+        doctorContractHash: "doctor-contract-hash",
+        packageJson: { ...packageJson, hash: "changed-package-json-hash" },
+      },
+    ]) {
+      expect(
+        resolveInstalledManifestRegistryIndexFingerprint({
+          ...initialIndex,
+          plugins: [changedPlugin],
+        }),
+      ).not.toBe(initialFingerprint);
+    }
+  });
+
   it("fingerprints immutable inventory without inspecting plugin files", () => {
     const rootDir = makeTempDir();
     writePlugin(rootDir, "installed", "installed-");

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -123,6 +123,96 @@ function buildInstalledPackageMetadataCacheKey(
   });
 }
 
+function compareInstalledManifestRegistryFingerprintFields(
+  left: readonly (string | undefined)[],
+  right: readonly (string | undefined)[],
+): number {
+  for (let index = 0; index < left.length; index += 1) {
+    const leftValue = left[index];
+    const rightValue = right[index];
+    if (leftValue === rightValue) {
+      continue;
+    }
+    if (leftValue === undefined) {
+      return -1;
+    }
+    if (rightValue === undefined) {
+      return 1;
+    }
+    const comparison = compareInstalledManifestRegistryFingerprintKeys(leftValue, rightValue);
+    if (comparison !== 0) {
+      return comparison;
+    }
+  }
+  return 0;
+}
+
+function compareInstalledManifestRegistryFingerprintKeys(left: string, right: string): number {
+  if (left < right) {
+    return -1;
+  }
+  return left > right ? 1 : 0;
+}
+
+function canonicalizeInstalledManifestRegistryFingerprintJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalizeInstalledManifestRegistryFingerprintJson);
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort(compareInstalledManifestRegistryFingerprintKeys)
+      .map((key) => [key, canonicalizeInstalledManifestRegistryFingerprintJson(value[key])]),
+  );
+}
+
+function buildInstalledManifestRegistryIndexFingerprintPayload(index: InstalledPluginIndex) {
+  return {
+    version: index.version,
+    hostContractVersion: index.hostContractVersion,
+    compatRegistryVersion: index.compatRegistryVersion,
+    migrationVersion: index.migrationVersion,
+    policyHash: index.policyHash,
+    installRecords: Object.fromEntries(
+      Object.entries(index.installRecords).sort(([leftPluginId], [rightPluginId]) =>
+        compareInstalledManifestRegistryFingerprintFields([leftPluginId], [rightPluginId]),
+      ),
+    ),
+    diagnostics: [...index.diagnostics].sort((left, right) =>
+      compareInstalledManifestRegistryFingerprintFields(
+        [left.pluginId, left.source, left.code, left.level, left.message],
+        [right.pluginId, right.source, right.code, right.level, right.message],
+      ),
+    ),
+    plugins: [...index.plugins]
+      .sort((left, right) =>
+        compareInstalledManifestRegistryFingerprintFields(
+          [left.pluginId, left.rootDir, left.manifestPath],
+          [right.pluginId, right.rootDir, right.manifestPath],
+        ),
+      )
+      .map(
+        ({
+          doctorContractFile: _doctorContractFile,
+          manifestFile: _manifestFile,
+          packageBuild,
+          packageJson,
+          ...plugin
+        }) => ({
+          ...plugin,
+          ...(packageJson
+            ? { packageJson: { path: packageJson.path, hash: packageJson.hash } }
+            : {}),
+          ...(packageBuild?.bundledDist === undefined
+            ? {}
+            : { packageBuild: { bundledDist: packageBuild.bundledDist } }),
+        }),
+      ),
+  };
+}
+
 export function resolveInstalledManifestRegistryIndexFingerprint(
   index: InstalledPluginIndex,
 ): string {
@@ -132,16 +222,12 @@ export function resolveInstalledManifestRegistryIndexFingerprint(
   }
   // The immutable installed inventory owns freshness; lifecycle clears publish
   // a replacement instead of polling manifests or package paths on hot reads.
-  const fingerprint = hashJson({
-    version: index.version,
-    hostContractVersion: index.hostContractVersion,
-    compatRegistryVersion: index.compatRegistryVersion,
-    migrationVersion: index.migrationVersion,
-    policyHash: index.policyHash,
-    installRecords: index.installRecords,
-    diagnostics: index.diagnostics,
-    plugins: index.plugins.map(({ doctorContractFile: _doctorContractFile, ...plugin }) => plugin),
-  });
+  // Only this checkpoint payload is canonicalized; other hashJson callers remain byte-sensitive.
+  const fingerprint = hashJson(
+    canonicalizeInstalledManifestRegistryFingerprintJson(
+      buildInstalledManifestRegistryIndexFingerprintPayload(index),
+    ),
+  );
   if (isDeepFrozenJsonLike(index)) {
     installedManifestRegistryIndexFingerprintCache.set(index, fingerprint);
   }

--- a/src/state/openclaw-agent-db-registry.ts
+++ b/src/state/openclaw-agent-db-registry.ts
@@ -1,9 +1,18 @@
 import { randomBytes } from "node:crypto";
-import { lstatSync, mkdirSync, readlinkSync, realpathSync, rmdirSync, statSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readlinkSync,
+  realpathSync,
+  rmdirSync,
+  statSync,
+} from "node:fs";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { isPathInside } from "../infra/path-guards.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import {
   assertAgentDeletionPathFence,
   prepareAgentDeletionPathFence,
@@ -12,6 +21,7 @@ import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
 import { invalidateRegisteredAgentDatabasesMemo } from "./openclaw-agent-db-registry-listing.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "./openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
 export { listOpenClawRegisteredAgentDatabases } from "./openclaw-agent-db-registry-listing.js";
 
@@ -640,6 +650,98 @@ export function registerOpenClawAgentDatabase(params: {
     { env: params.env },
   );
   invalidateRegisteredAgentDatabasesMemo({ env: params.env });
+}
+
+type AgentDatabaseRegistryPathRow = {
+  agent_id: string;
+  path: string;
+};
+
+function describeAgentDatabaseRegistryOwners(
+  rows: readonly AgentDatabaseRegistryPathRow[],
+): string {
+  return rows
+    .map((row) => row.agent_id)
+    .toSorted()
+    .join(", ");
+}
+
+/** Record a durable registry intent before moving an owned database file. */
+export function relocateOpenClawAgentDatabaseRegistry(params: {
+  agentId: string;
+  sourcePath: string;
+  targetPath: string;
+  env?: NodeJS.ProcessEnv;
+}): boolean {
+  const agentId = normalizeAgentId(params.agentId);
+  const sourcePath = params.sourcePath;
+  const targetPath = params.targetPath;
+  const env = params.env ?? process.env;
+  if (!existsSync(resolveOpenClawStateSqlitePath(env))) {
+    return false;
+  }
+  let relocated = false;
+  runOpenClawStateWriteTransaction(
+    (database) => {
+      const db = getNodeSqliteKysely<OpenClawAgentRegistryDatabase>(database.db);
+      const rows = executeSqliteQuerySync(
+        database.db,
+        db.selectFrom("agent_databases").select(["agent_id", "path"]),
+      ).rows;
+      const sourceRows = rows.filter((row) =>
+        isSameOpenClawAgentDatabasePath(row.path, sourcePath),
+      );
+      const targetRows = rows.filter((row) =>
+        isSameOpenClawAgentDatabasePath(row.path, targetPath),
+      );
+
+      if (sourceRows.length === 0) {
+        if (targetRows.length === 0) {
+          return;
+        }
+        if (targetRows.length === 1 && normalizeAgentId(targetRows[0]!.agent_id) === agentId) {
+          return;
+        }
+        const owners = describeAgentDatabaseRegistryOwners(targetRows);
+        throw new Error(
+          `Agent database registry target ${targetPath} is already registered${owners ? ` to ${owners}` : ""}.`,
+        );
+      }
+      if (sourceRows.length !== 1) {
+        const owners = describeAgentDatabaseRegistryOwners(sourceRows);
+        throw new Error(
+          `Agent database registry source ${sourcePath} is not uniquely registered${owners ? ` (registered owners: ${owners})` : ""}.`,
+        );
+      }
+      if (targetRows.length > 0) {
+        const owners = describeAgentDatabaseRegistryOwners(targetRows);
+        throw new Error(
+          `Agent database registry target ${targetPath} is already registered${owners ? ` to ${owners}` : ""}.`,
+        );
+      }
+
+      const sourceRow = sourceRows[0]!;
+      const update = executeSqliteQuerySync(
+        database.db,
+        db
+          .updateTable("agent_databases")
+          .set({ agent_id: agentId, path: targetPath })
+          .where("agent_id", "=", sourceRow.agent_id)
+          .where("path", "=", sourceRow.path),
+      );
+      if (update.numAffectedRows !== 1n) {
+        throw new Error(
+          `Agent database registry source ${sourcePath} changed before relocation could complete.`,
+        );
+      }
+      relocated = true;
+    },
+    { env },
+  );
+  if (relocated) {
+    invalidateRegisteredAgentDatabasesMemo({ env });
+  }
+  return relocated;
 }
 
 function canonicalPathForRegistryBoundary(pathname: string): string {

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -31,6 +31,7 @@ import { withOpenClawAgentDatabaseReadOnly } from "./openclaw-agent-db-readonly.
 import {
   createOpenClawAgentDatabasePathMatcher,
   isSameOpenClawAgentDatabasePath,
+  relocateOpenClawAgentDatabaseRegistry,
   registerOpenClawAgentDatabase,
   unregisterOpenClawAgentDatabase,
 } from "./openclaw-agent-db-registry.js";
@@ -1090,6 +1091,74 @@ describe("openclaw agent database", () => {
     registerOpenClawAgentDatabase({ agentId: "worker-1", path: databasePath, env });
     expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([
       expect.objectContaining({ agentId: "worker-1", path: databasePath }),
+    ]);
+  });
+
+  it("prepares registered database metadata before the filesystem move", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const sourcePath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    const targetPath = path.join(stateDir, "agents", "worker-1", "agent", "openclaw-agent.sqlite");
+    registerOpenClawAgentDatabase({ agentId: "main", path: sourcePath, env });
+
+    expect(
+      relocateOpenClawAgentDatabaseRegistry({
+        agentId: "worker-1",
+        sourcePath,
+        targetPath,
+        env,
+      }),
+    ).toBe(true);
+    expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([
+      expect.objectContaining({ agentId: "worker-1", path: targetPath }),
+    ]);
+    expect(
+      relocateOpenClawAgentDatabaseRegistry({
+        agentId: "worker-1",
+        sourcePath,
+        targetPath,
+        env,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects duplicate source or occupied target registry paths", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const foreignSourcePath = path.join(stateDir, "agents", "foreign", "agent", "source.sqlite");
+    const sourcePath = path.join(stateDir, "agents", "worker-1", "agent", "source.sqlite");
+    const targetPath = path.join(stateDir, "agents", "worker-1", "agent", "target.sqlite");
+    registerOpenClawAgentDatabase({ agentId: "foreign", path: foreignSourcePath, env });
+    registerOpenClawAgentDatabase({ agentId: "worker-1", path: foreignSourcePath, env });
+    registerOpenClawAgentDatabase({ agentId: "worker-1", path: sourcePath, env });
+    registerOpenClawAgentDatabase({ agentId: "other", path: targetPath, env });
+
+    expect(() =>
+      relocateOpenClawAgentDatabaseRegistry({
+        agentId: "worker-1",
+        sourcePath: foreignSourcePath,
+        targetPath,
+        env,
+      }),
+    ).toThrow("not uniquely registered");
+    expect(() =>
+      relocateOpenClawAgentDatabaseRegistry({
+        agentId: "worker-1",
+        sourcePath,
+        targetPath,
+        env,
+      }),
+    ).toThrow("already registered to other");
+    expect(
+      listOpenClawRegisteredAgentDatabases({ env }).map((entry) => ({
+        agentId: entry.agentId,
+        path: entry.path,
+      })),
+    ).toEqual([
+      { agentId: "foreign", path: foreignSourcePath },
+      { agentId: "other", path: targetPath },
+      { agentId: "worker-1", path: foreignSourcePath },
+      { agentId: "worker-1", path: sourcePath },
     ]);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where gateway startup could repeatedly refuse readiness after bundled-plugin rebuild or persistence convergence, reporting: `OpenClaw plugin migration inputs changed during startup convergence; refusing to report the gateway ready.` It also recovers legacy agent database relocation without changing the durable database owner or registry intent.

## Why This Change Was Made

The migration fingerprint included non-semantic, runtime-generated plugin inventory fields that can change across bundled-plugin rebuild and persistence convergence: collection and nested ordering, package-build metadata, and file timestamps. The repair fingerprints the semantic persisted inventory contract, while relocation preserves durable database ownership and registry intent.

## User Impact

Operators can run `openclaw doctor --fix` to recover the affected legacy agent database placement, and subsequent gateway launches converge normally instead of repeatedly refusing readiness after generated plugin inventory changes.

## Evidence

- Sanitized session behavior: `openclaw doctor --fix` relocated the mismatch to `agents/openclaw/agent/openclaw-agent.sqlite`.
- After the semantic fingerprint repair, two consecutive `pnpm openclaw gateway run` launches reached `ready`.
- Focused migration tests and manifest registry/preflight tests passed.
- Remote Blacksmith Testbox `pnpm check:test-types` passed at `tbx_01kzhax5rvz5x0njrmnw3cqk0r`; [GitHub Actions run 31272571006](https://github.com/openclaw/openclaw/actions/runs/31272571006).
- Autoreview: clean.

This is local behavioral and CI proof; no live provider or channel proof is claimed.
