### PR TITLE
fix(ui): prevent clipped transcript focus outline

### DIFF
--- a/ui/src/e2e/app-chrome-interaction.e2e.test.ts
+++ b/ui/src/e2e/app-chrome-interaction.e2e.test.ts
@@ -35,6 +35,25 @@ async function dragAcross(page: Page, locator: Locator): Promise<string> {
   return page.evaluate(() => globalThis.getSelection()?.toString() ?? "");
 }
 
+async function readFocusOutline(locator: Locator) {
+  return locator.evaluate((element) => {
+    const styles = getComputedStyle(element);
+    const colorProbe = document.createElement("span");
+    colorProbe.style.color = "var(--muted-strong)";
+    document.body.append(colorProbe);
+    const mutedStrongColor = getComputedStyle(colorProbe).color;
+    colorProbe.remove();
+    return {
+      focusVisible: element.matches(":focus-visible"),
+      mutedStrongColor,
+      outlineColor: styles.outlineColor,
+      outlineOffset: styles.outlineOffset,
+      outlineStyle: styles.outlineStyle,
+      outlineWidth: styles.outlineWidth,
+    };
+  });
+}
+
 async function captureUiProof(page: Page, fileName: string) {
   if (!captureUiProofEnabled) {
     return;
@@ -94,7 +113,35 @@ suite.define(() => {
           sidebarScrollbar: "6px",
         });
         expect(await dragAcross(page, transcript)).toContain("Selectable transcript");
+        const thread = page.locator(".chat-thread");
+        expect(await readFocusOutline(thread)).toMatchObject({
+          focusVisible: false,
+          outlineStyle: "none",
+        });
         await captureUiProof(page, "01-chat-selectable-transcript.png");
+
+        await thread.focus();
+        await page.keyboard.press("Tab");
+        await expect
+          .poll(() => thread.evaluate((element) => element !== document.activeElement))
+          .toBe(true);
+        await page.keyboard.press("Shift+Tab");
+        await expect
+          .poll(() =>
+            thread.evaluate(
+              (element) => element === document.activeElement && element.matches(":focus-visible"),
+            ),
+          )
+          .toBe(true);
+        const focusedOutline = await readFocusOutline(thread);
+        expect(focusedOutline).toMatchObject({
+          focusVisible: true,
+          outlineOffset: "-2px",
+          outlineStyle: "solid",
+          outlineWidth: "2px",
+        });
+        expect(focusedOutline.outlineColor).toBe(focusedOutline.mutedStrongColor);
+        await captureUiProof(page, "02-chat-thread-keyboard-focus.png");
 
         await page.setViewportSize({ height: 650, width: 1440 });
         // Appearance renders schema-independent theme/UI sections that overflow
@@ -148,7 +195,7 @@ suite.define(() => {
         await content.evaluate((element) => {
           element.scrollTop = Math.min(160, element.scrollHeight - element.clientHeight);
         });
-        await captureUiProof(page, "02-settings-contextual-scrollbars.png");
+        await captureUiProof(page, "03-settings-contextual-scrollbars.png");
       },
     );
   });

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -316,6 +316,12 @@ openclaw-chat-page {
   background: transparent;
 }
 
+/* The oversized clipped transcript owns its focus ring, so it stays inward to keep every edge visible. */
+.chat-thread:focus-visible {
+  outline: 2px solid var(--muted-strong);
+  outline-offset: -2px;
+}
+
 :root .chat-thread::-webkit-scrollbar-thumb {
   background: var(--muted-strong);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting transcript text or navigating the chat by keyboard could see a clipped orange/red line along the bottom of the conversation viewport. The partial outline looked like an unexplained message-selection state.

## Why This Change Was Made

The transcript remains keyboard-focusable, but its oversized scrollport now owns a complete inward neutral focus indicator instead of inheriting the global outward accent ring that clipped against its parent containers. Message styling and split-pane active-state behavior are unchanged.

This change is AI-assisted and has been reviewed against the rendered behavior and the source diff.

## User Impact

Pointer text selection no longer produces a stray orange/red edge. Keyboard users still get a visible, accessible focus indicator, now contained within the full transcript viewport.

## Evidence

### Before — clipped accent focus outline

![Clipped coral focus outline along the transcript bottom edge](https://github.com/user-attachments/assets/bc8979c9-e147-4a4a-ac61-a9515f40198b)

### After — contained neutral keyboard focus ring

![Complete inward neutral focus ring around the transcript viewport](https://github.com/user-attachments/assets/99b5c12c-5734-4fd7-9493-cc19e6db07c2)
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs ui/src/e2e/app-chrome-interaction.e2e.test.ts` — passed (1 file, 1 test).
- Black-box behavior validation — 3/3 clauses passed: pointer selection, keyboard focus, and adjacent popup/composer visibility.
- `pnpm format:check --no-error-on-unmatched-pattern -- ui/src/e2e/app-chrome-interaction.e2e.test.ts ui/src/styles/chat/layout.css` — passed.
- `pnpm lint:ui:styles` — passed.
- `git diff --check` — passed.
- Codex autoreview — clean; no accepted/actionable findings.
- The broader local `check:changed`/oxlint lanes could not acquire the shared heavy-check lock, and configured remote backends were unavailable (Blacksmith CLI missing; AWS broker not authenticated). Exact-head PR CI is required before merge and will cover those lanes.
