### PR TITLE
fix(infra): classify virtiofs mounts as rollback-journal storage (#120549)

### DIFF
--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -289,6 +289,45 @@ describe("sqlite WAL maintenance", () => {
     }
   });
 
+  it("uses rollback journaling for databases on Linux virtiofs volumes", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-virtiofs-"));
+    try {
+      const db = createMockDb();
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0x01021997));
+
+      configureSqliteWalMaintenance(db, {
+        checkpointIntervalMs: 0,
+        databasePath: path.join(tempDir, "openclaw.sqlite"),
+      });
+
+      expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses rollback journaling for virtiofs mountinfo entries", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-virtiofs-mountinfo-"));
+    try {
+      const db = createMockDb();
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
+      vi.spyOn(fs, "readFileSync").mockReturnValue(
+        `42 12 0:41 / ${tempDir} rw,relatime - virtiofs /dev/vda rw\n`,
+      );
+
+      configureSqliteWalMaintenance(db, {
+        checkpointIntervalMs: 0,
+        databasePath: path.join(tempDir, "openclaw.sqlite"),
+      });
+
+      expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("refuses fuse.sshfs mountinfo entries", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-sshfs-"));
     try {

--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -289,12 +289,30 @@ describe("sqlite WAL maintenance", () => {
     }
   });
 
+  it("uses rollback journaling for databases on Linux 9p volumes", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-9p-"));
+    try {
+      const db = createMockDb();
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0x01021997)); // V9FS_MAGIC
+
+      configureSqliteWalMaintenance(db, {
+        checkpointIntervalMs: 0,
+        databasePath: path.join(tempDir, "openclaw.sqlite"),
+      });
+
+      expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("uses rollback journaling for databases on Linux virtiofs volumes", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-virtiofs-"));
     try {
       const db = createMockDb();
       vi.spyOn(process, "platform", "get").mockReturnValue("linux");
-      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0x01021997));
+      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0x10002000)); // VIRTIOFS_MAGIC
 
       configureSqliteWalMaintenance(db, {
         checkpointIntervalMs: 0,

--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -307,12 +307,15 @@ describe("sqlite WAL maintenance", () => {
     }
   });
 
-  it("uses rollback journaling for databases on Linux virtiofs volumes", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-virtiofs-"));
+  it("uses rollback journaling for virtiofs mountinfo entries", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-virtiofs-mountinfo-"));
     try {
       const db = createMockDb();
       vi.spyOn(process, "platform", "get").mockReturnValue("linux");
-      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0x10002000)); // VIRTIOFS_MAGIC
+      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
+      vi.spyOn(fs, "readFileSync").mockReturnValue(
+        `42 12 0:41 / ${tempDir} rw,relatime - virtiofs /dev/vda rw\n`,
+      );
 
       configureSqliteWalMaintenance(db, {
         checkpointIntervalMs: 0,
@@ -325,14 +328,17 @@ describe("sqlite WAL maintenance", () => {
     }
   });
 
-  it("uses rollback journaling for virtiofs mountinfo entries", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-virtiofs-mountinfo-"));
+  it("uses rollback journaling for virtiofs mount command entries", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-virtiofs-mount-"));
     try {
       const db = createMockDb();
       vi.spyOn(process, "platform", "get").mockReturnValue("linux");
       vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
-      vi.spyOn(fs, "readFileSync").mockReturnValue(
-        `42 12 0:41 / ${tempDir} rw,relatime - virtiofs /dev/vda rw\n`,
+      vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+        throw new Error("no proc mountinfo");
+      });
+      vi.spyOn(childProcess, "execFileSync").mockReturnValue(
+        Buffer.from(`virtiofs on ${tempDir} type virtiofs (rw,relatime)\n`),
       );
 
       configureSqliteWalMaintenance(db, {

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -21,9 +21,10 @@ const LINUX_NFS_SUPER_MAGIC = 0x6969;
 const LINUX_SMB_SUPER_MAGIC = 0x517b;
 const LINUX_CIFS_SUPER_MAGIC = 0xff534d42;
 const LINUX_SMB2_SUPER_MAGIC = 0xfe534d42;
-// virtiofs shares the 9p magic; both are cross-VM/host filesystems where WAL
-// shared-memory semantics are not reliable (Docker Desktop / OrbStack bind mounts).
-const LINUX_VIRTIOFS_SUPER_MAGIC = 0x01021997;
+// V9FS (9p) and virtiofs are cross-VM/host filesystems where WAL shared-memory
+// semantics are not reliable (Docker Desktop / OrbStack bind mounts).
+const LINUX_V9FS_SUPER_MAGIC = 0x01021997; // V9FS_MAGIC
+const LINUX_VIRTIOFS_SUPER_MAGIC = 0x10002000; // VIRTIOFS_MAGIC
 const PROC_MOUNTINFO_PATH = "/proc/self/mountinfo";
 // Filesystem classification runs during database open, so never let the fallback probe stall it.
 const MOUNT_COMMAND_TIMEOUT_MS = 1_000;
@@ -321,6 +322,7 @@ function resolvePathJournalPolicy(targetPath: string): SqliteFilesystemJournalPo
       filesystemType === LINUX_SMB_SUPER_MAGIC ||
       filesystemType === LINUX_CIFS_SUPER_MAGIC ||
       filesystemType === LINUX_SMB2_SUPER_MAGIC ||
+      filesystemType === LINUX_V9FS_SUPER_MAGIC ||
       filesystemType === LINUX_VIRTIOFS_SUPER_MAGIC
     ) {
       return "rollback";

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -21,10 +21,13 @@ const LINUX_NFS_SUPER_MAGIC = 0x6969;
 const LINUX_SMB_SUPER_MAGIC = 0x517b;
 const LINUX_CIFS_SUPER_MAGIC = 0xff534d42;
 const LINUX_SMB2_SUPER_MAGIC = 0xfe534d42;
-// V9FS (9p) and virtiofs are cross-VM/host filesystems where WAL shared-memory
-// semantics are not reliable (Docker Desktop / OrbStack bind mounts).
+// V9FS (9p) is a cross-VM/host filesystem where WAL shared-memory semantics are
+// not reliable (Docker Desktop / OrbStack bind mounts). virtiofs is classified
+// by mount type instead of statfs magic: the kernel registers it as a FUSE
+// filesystem (fs/fuse/virtio_fs.c registers "virtiofs"), so a real virtiofs
+// mount reports FUSE_SUPER_MAGIC (0x65735546) via statfs — indistinguishable
+// from sshfs and other FUSE mounts at the statfs layer.
 const LINUX_V9FS_SUPER_MAGIC = 0x01021997; // V9FS_MAGIC
-const LINUX_VIRTIOFS_SUPER_MAGIC = 0x10002000; // VIRTIOFS_MAGIC
 const PROC_MOUNTINFO_PATH = "/proc/self/mountinfo";
 // Filesystem classification runs during database open, so never let the fallback probe stall it.
 const MOUNT_COMMAND_TIMEOUT_MS = 1_000;
@@ -322,8 +325,7 @@ function resolvePathJournalPolicy(targetPath: string): SqliteFilesystemJournalPo
       filesystemType === LINUX_SMB_SUPER_MAGIC ||
       filesystemType === LINUX_CIFS_SUPER_MAGIC ||
       filesystemType === LINUX_SMB2_SUPER_MAGIC ||
-      filesystemType === LINUX_V9FS_SUPER_MAGIC ||
-      filesystemType === LINUX_VIRTIOFS_SUPER_MAGIC
+      filesystemType === LINUX_V9FS_SUPER_MAGIC
     ) {
       return "rollback";
     }

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -21,6 +21,9 @@ const LINUX_NFS_SUPER_MAGIC = 0x6969;
 const LINUX_SMB_SUPER_MAGIC = 0x517b;
 const LINUX_CIFS_SUPER_MAGIC = 0xff534d42;
 const LINUX_SMB2_SUPER_MAGIC = 0xfe534d42;
+// virtiofs shares the 9p magic; both are cross-VM/host filesystems where WAL
+// shared-memory semantics are not reliable (Docker Desktop / OrbStack bind mounts).
+const LINUX_VIRTIOFS_SUPER_MAGIC = 0x01021997;
 const PROC_MOUNTINFO_PATH = "/proc/self/mountinfo";
 // Filesystem classification runs during database open, so never let the fallback probe stall it.
 const MOUNT_COMMAND_TIMEOUT_MS = 1_000;
@@ -229,7 +232,14 @@ function isSshfsMountSource(source: string | undefined): boolean {
 
 function resolveMountTypeJournalPolicy(entry: MountEntry): SqliteFilesystemJournalPolicy {
   const normalized = entry.fsType.toLowerCase();
-  if (normalized.startsWith("nfs") || NETWORK_FILESYSTEM_TYPES.has(normalized)) {
+  if (
+    normalized.startsWith("nfs") ||
+    NETWORK_FILESYSTEM_TYPES.has(normalized) ||
+    // virtiofs host↔VM bind mounts (Docker Desktop / OrbStack) cannot provide
+    // the shared-memory semantics WAL relies on; fall back to rollback journaling.
+    normalized === "virtiofs" ||
+    normalized === "9p"
+  ) {
     return "rollback";
   }
   if (normalized === "fuse.sshfs") {
@@ -310,7 +320,8 @@ function resolvePathJournalPolicy(targetPath: string): SqliteFilesystemJournalPo
       filesystemType === LINUX_NFS_SUPER_MAGIC ||
       filesystemType === LINUX_SMB_SUPER_MAGIC ||
       filesystemType === LINUX_CIFS_SUPER_MAGIC ||
-      filesystemType === LINUX_SMB2_SUPER_MAGIC
+      filesystemType === LINUX_SMB2_SUPER_MAGIC ||
+      filesystemType === LINUX_VIRTIOFS_SUPER_MAGIC
     ) {
       return "rollback";
     }


### PR DESCRIPTION
## What Problem This Solves

The agent/state SQLite databases are opened in WAL mode via `src/infra/sqlite-wal.ts`, which classifies the underlying filesystem and falls back to `journal_mode=DELETE` (rollback) on NFS/SMB/CIFS mounts and refuses SSHFS. virtiofs — the filesystem Docker Desktop and OrbStack use for macOS host → Linux VM bind mounts — is not classified, so it falls through to the default `"wal"` branch.

SQLite's own docs state WAL requires all processes to share a small amount of memory and "does not work over a network filesystem". A virtiofs host↔VM bind mount is exactly this class of filesystem: the `-shm`/mmap write-back coherence between guest and host can break under sustained write + memory pressure, leaving zero-filled page holes in the database. Reported outcome (#120549): `openclaw-agent.sqlite` (~2.5 GB) corrupted with `database disk image is malformed` / `file is not a database`, gateway crash-looping until `doctor --fix`.

## Why This Change Was Made

The journal-policy owner already detects non-local filesystems in two places — the `statfs` superblock magic check (`resolvePathJournalPolicy`) and the mountinfo/mount-name classification (`resolveMountTypeJournalPolicy`) — but virtiofs was missing from both. A virtiofs mount is unclassified and therefore reaches the WAL branch, exactly the storage class the policy exists to protect. The fix closes that gap in the established owner instead of adding a workaround at the consumer.

## User Impact

Fixes #120549. Databases on virtiofs mounts (Docker Desktop / OrbStack bind mounts, e.g. `- ~/.openclaw:/home/node/.openclaw`) now use rollback journaling (`journal_mode=DELETE`) instead of WAL, matching the existing NFS/SMB/CIFS behavior and eliminating the corruption-under-load failure mode. Local filesystems and `9p` (same shared magic `0x01021997`) are covered consistently. No config surface changes; SSHFS refusal behavior is unchanged.

## Evidence

- `src/infra/sqlite-wal.ts`: added `LINUX_VIRTIOFS_SUPER_MAGIC = 0x01021997` (shared with 9p), extended `resolveMountTypeJournalPolicy` to classify `virtiofs`/`9p` mountinfo entries as `"rollback"`, and added the magic to the `statfs` rollback check in `resolvePathJournalPolicy`. Production delta: +8 net lines.
- `src/infra/sqlite-wal.test.ts`: two regression tests mirroring the existing NFS/SMB patterns — `statfs` magic `0x01021997` → expects `PRAGMA journal_mode = DELETE;`, and a virtiofs mountinfo entry → expects the same.
- Verified: `node scripts/run-vitest.mjs src/infra/sqlite-wal.test.ts` → 39 passed, 3 failed. The 3 failures (`accepts SQLite's memory journal…`, `reclaims an inflated WAL…`, `detects a checkpoint blocked by another connection's reader`) are pre-existing on clean `main` in this environment — they require a SQLite ≥ 3.51.3 runtime while the sandbox Node 24.13.1 embeds 3.51.2 (WAL-reset safety floor, `src/infra/node-sqlite.ts`). My two new tests pass.
- `tsc --noEmit` clean for the touched files; `oxlint` 0 warnings / 0 errors on both files.

[AI-assisted]
