### PR TITLE
fix(ui): reveal question prompts without scroll overlap

### DIFF
--- a/ui/src/e2e/question-flow.e2e.test.ts
+++ b/ui/src/e2e/question-flow.e2e.test.ts
@@ -5,11 +5,13 @@ import type { QuestionResolveResult } from "@openclaw/gateway-protocol";
 import type { BrowserContext, Page } from "playwright";
 import { afterEach, expect, it } from "vitest";
 import type { SessionsListResult } from "../api/types.ts";
+import { CHAT_TRANSCRIPT_END_THRESHOLD_PX } from "../pages/chat/scroll.ts";
 import {
   controlUiSessionUrl,
   installMockGateway,
   type MockGatewayControls,
 } from "../test-helpers/control-ui-e2e.ts";
+import { chatThreadDistanceFromBottom, waitForChatScrollIdle } from "./chat-flow.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -156,10 +158,95 @@ async function emitRequested(
   await gateway.emitGatewayEvent("question.requested", record);
 }
 
+function scrollRegressionQuestion(id: string, prompt: string) {
+  return questionRecord(id, [
+    {
+      questionId: "release_strategy",
+      header: "Strategy",
+      question: prompt,
+      options: Array.from({ length: 4 }, (_, index) => ({
+        label: `Release strategy ${index + 1}`,
+        description: `Deterministic option ${index + 1} makes the rendered panel exceed the near-bottom threshold after layout, proving resize reconciliation follows explicit user intent instead of stale geometry.`,
+      })),
+      isOther: true,
+    },
+  ]);
+}
+
 suite.define(() => {
   afterEach(async () => {
     await context?.close().catch(() => {});
     context = undefined;
+  });
+
+  it("settles a live-edge transcript after a question enters footer flow", async () => {
+    const { gateway, page } = await openQuestionPage();
+    await waitForChatScrollIdle(page);
+    await expect
+      .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
+      .toBeLessThanOrEqual(CHAT_TRANSCRIPT_END_THRESHOLD_PX);
+
+    const prompt = "Which detailed release strategy should I use?";
+    await emitRequested(gateway, scrollRegressionQuestion("question-live-edge-scroll", prompt));
+    const panel = panelFor(page, prompt);
+    await panel.waitFor();
+    await waitForChatScrollIdle(page);
+
+    await expect
+      .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
+      .toBeLessThanOrEqual(CHAT_TRANSCRIPT_END_THRESHOLD_PX);
+    await expect
+      .poll(async () => {
+        const panelBox = await panel.boundingBox();
+        const conversationBox = await page.locator(".chat-main__conversation").boundingBox();
+        return Boolean(
+          panelBox &&
+          conversationBox &&
+          panelBox.y >= conversationBox.y - 1 &&
+          panelBox.y + panelBox.height <= conversationBox.y + conversationBox.height + 1,
+        );
+      })
+      .toBe(true);
+    await expect.poll(() => page.getByRole("button", { name: "Scroll to latest" }).count()).toBe(0);
+    await screenshot(page, "05-question-live-edge-scroll.png");
+  });
+
+  it("preserves explicit backscroll and keeps the latest arrow above the question", async () => {
+    const { gateway, page } = await openQuestionPage();
+    await waitForChatScrollIdle(page);
+    const thread = page.locator(".chat-thread");
+    await thread.hover();
+    await page.mouse.wheel(0, -600);
+    await expect
+      .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
+      .toBeGreaterThan(CHAT_TRANSCRIPT_END_THRESHOLD_PX);
+    const scrollToLatest = page.getByRole("button", { name: "Scroll to latest" });
+    await scrollToLatest.waitFor({ state: "visible", timeout: 10_000 });
+    await waitForChatScrollIdle(page);
+    const readingScrollTop = await thread.evaluate((element) => element.scrollTop);
+
+    const prompt = "Which detailed release strategy should stay below my reading position?";
+    await emitRequested(gateway, scrollRegressionQuestion("question-backscroll-position", prompt));
+    const panel = panelFor(page, prompt);
+    await panel.waitFor();
+    await waitForChatScrollIdle(page);
+
+    await expect
+      .poll(
+        async () =>
+          Math.abs((await thread.evaluate((element) => element.scrollTop)) - readingScrollTop),
+        { timeout: 10_000 },
+      )
+      .toBeLessThanOrEqual(2);
+    await scrollToLatest.waitFor({ state: "visible", timeout: 10_000 });
+    await expect
+      .poll(async () => {
+        const arrowBox = await scrollToLatest.boundingBox();
+        const panelBox = await panel.boundingBox();
+        return Boolean(arrowBox && panelBox && arrowBox.y + arrowBox.height <= panelBox.y);
+      })
+      .toBe(true);
+    await screenshot(page, "06-question-backscroll-arrow.png");
   });
 
   it("restores the composer and its draft from an authoritative answer without a resolution event", async () => {
@@ -217,15 +304,6 @@ suite.define(() => {
         };
       })
       .toEqual({ left: 0, width: 0 });
-    await expect
-      .poll(async () => {
-        const panelHeight = (await panel.boundingBox())?.height ?? 0;
-        const padding = await page
-          .locator(".chat-thread")
-          .evaluate((element) => Number.parseFloat(getComputedStyle(element).paddingBottom));
-        return padding >= panelHeight;
-      })
-      .toBe(true);
     await screenshot(page, "01-question-pending.png");
 
     await panel.locator(".chat-question-panel__collapse").click();

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1554,17 +1554,37 @@ describe("chat goal status", () => {
 });
 
 describe("chat scroll-to-bottom affordance", () => {
-  it("renders a centered icon button above the composer when the transcript is away from latest", () => {
+  it("anchors immediately after the transcript and above every rendered footer surface", () => {
     const onScrollToBottom = vi.fn();
-    const container = renderChatView({ showNewMessages: true, onScrollToBottom });
+    const container = renderChatView({
+      showNewMessages: true,
+      onScrollToBottom,
+      inlineApproval: {
+        id: "approval-below-scroll-anchor",
+        kind: "exec",
+        request: {
+          command: "pnpm test",
+          agentId: "main",
+          sessionKey: "agent:main:current",
+          commandSpans: [],
+        },
+        createdAtMs: 1,
+        expiresAtMs: 61_000,
+      },
+      onApprovalDecision: vi.fn(),
+      queue: [{ id: "queued-below-scroll-anchor", text: "queued message", createdAt: 1 }],
+    });
 
     const button = container.querySelector<HTMLButtonElement>(".chat-scroll-to-bottom");
     const wrapper = button?.closest(".chat-scroll-to-bottom-wrap");
     expect(button?.getAttribute("aria-label")).toBe("Scroll to latest");
     expect(wrapper?.previousElementSibling?.classList.contains("chat-thread")).toBe(true);
-    expect(wrapper?.nextElementSibling?.classList.contains("agent-chat__composer-shell")).toBe(
-      true,
-    );
+    expect(wrapper?.nextElementSibling?.classList.contains("chat-inline-approval")).toBe(true);
+    for (const surface of container.querySelectorAll(
+      ".chat-inline-approval, .chat-queue, .agent-chat__composer-shell",
+    )) {
+      expect(wrapper?.compareDocumentPosition(surface) ?? 0).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    }
     expect(button?.textContent?.trim()).toBe("");
     expect(container.querySelector(".chat-new-messages")).toBeNull();
 

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -627,7 +627,7 @@ export function renderChat(props: ChatProps) {
                 : ""}"
             >
               <div class="chat-main__conversation">
-                ${thread}
+                ${thread} ${scrollToBottomButton}
                 ${props.inlineApproval && props.onApprovalDecision
                   ? html`<div class="chat-inline-approval">
                       ${renderExecApprovalCard({
@@ -665,7 +665,6 @@ export function renderChat(props: ChatProps) {
                   onResolve: (suggestion, resolution) =>
                     props.onResolveSessionSuggestion?.(suggestion, resolution),
                 })}
-                ${scrollToBottomButton}
                 ${renderChatSwarmProgress({
                   sessions: props.swarmSessions ?? [],
                   sessionKey: props.sessionKey,

--- a/ui/src/pages/chat/components/chat-composer-dom.ts
+++ b/ui/src/pages/chat/components/chat-composer-dom.ts
@@ -21,7 +21,6 @@ const composerTextareaResizeObservers = new WeakMap<
   HTMLTextAreaElement,
   ComposerTextareaResizeObserverState
 >();
-const questionDockResizeObservers = new WeakMap<HTMLElement, ResizeObserver>();
 
 function updateTextareaOverflow(el: HTMLTextAreaElement) {
   el.style.overflowY = el.scrollHeight > el.clientHeight ? "auto" : "hidden";
@@ -77,29 +76,6 @@ export function disconnectTextareaOverflowObserver(el: HTMLTextAreaElement) {
   if (state.adjustmentFrame !== null) {
     cancelAnimationFrame(state.adjustmentFrame);
   }
-}
-
-function syncQuestionDockHeight(el: HTMLElement): void {
-  el.closest<HTMLElement>(".chat")?.style.setProperty(
-    "--chat-question-dock-height",
-    `${el.offsetHeight}px`,
-  );
-}
-
-export function observeQuestionDock(el: HTMLElement): void {
-  syncQuestionDockHeight(el);
-  if (typeof ResizeObserver !== "function" || questionDockResizeObservers.has(el)) {
-    return;
-  }
-  const observer = new ResizeObserver(() => syncQuestionDockHeight(el));
-  observer.observe(el);
-  questionDockResizeObservers.set(el, observer);
-}
-
-export function disconnectQuestionDock(el: HTMLElement): void {
-  questionDockResizeObservers.get(el)?.disconnect();
-  questionDockResizeObservers.delete(el);
-  el.closest<HTMLElement>(".chat")?.style.removeProperty("--chat-question-dock-height");
 }
 
 export function scheduleTextareaHeightAdjustment(el: HTMLTextAreaElement) {

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -18,11 +18,7 @@ import {
 } from "./chat-attachments.ts";
 import type { ChatRunControlsProps } from "./chat-composer-controls.ts";
 import { renderChatPrimaryActions } from "./chat-composer-controls.ts";
-import {
-  disconnectQuestionDock,
-  focusComposerFromChrome,
-  observeQuestionDock,
-} from "./chat-composer-dom.ts";
+import { focusComposerFromChrome } from "./chat-composer-dom.ts";
 import { renderChatGoal } from "./chat-composer-goal.ts";
 import { renderChatComposerPlusMenu } from "./chat-composer-plus-menu.ts";
 import { renderChatQueue } from "./chat-composer-queue.ts";
@@ -108,7 +104,6 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
     slashMenuAnnouncementId,
     composerRunStatus,
   } = context;
-  let questionDock: HTMLElement | null = null;
   const disabledBanner = props.disabledBanner
     ? html`
         <div class="agent-chat__disabled-banner callout info callout--action" role="status">
@@ -157,19 +152,7 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
     <div class="agent-chat__composer-shell">
       ${questionPanelProps
         ? html`
-            <div
-              class="agent-chat__question-dock"
-              ${ref((element) => {
-                const nextDock = element instanceof HTMLElement ? element : null;
-                if (questionDock && questionDock !== nextDock) {
-                  disconnectQuestionDock(questionDock);
-                }
-                questionDock = nextDock;
-                if (questionDock) {
-                  observeQuestionDock(questionDock);
-                }
-              })}
-            >
+            <div class="agent-chat__question-dock">
               <openclaw-chat-question-panel
                 .props=${questionPanelProps}
               ></openclaw-chat-question-panel>

--- a/ui/src/pages/chat/scroll.test.ts
+++ b/ui/src/pages/chat/scroll.test.ts
@@ -265,6 +265,7 @@ describe("scheduleChatScroll", () => {
     });
     // distanceFromBottom = 2000 - 500 - 400 = 1100 → not near bottom
     host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
     const originalScrollTop = container.scrollTop;
 
     scheduleChatScroll(host);
@@ -279,8 +280,9 @@ describe("scheduleChatScroll", () => {
       scrollTop: 500,
       clientHeight: 400,
     });
-    // User has scrolled up — chatUserNearBottom is false
+    // User has scrolled up, so the authoritative follow lock is set.
     host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
     host.chatHasAutoScrolled = true; // Already past initial load
     const originalScrollTop = container.scrollTop;
 
@@ -396,6 +398,7 @@ describe("scheduleChatScroll", () => {
       clientHeight: 400,
     });
     host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
     host.chatHasAutoScrolled = true;
     host.chatNewMessagesBelow = false;
 
@@ -405,19 +408,43 @@ describe("scheduleChatScroll", () => {
     expect(host.chatNewMessagesBelow).toBe(true);
   });
 
-  it("does not show new messages for a resize when the thread height did not grow", async () => {
-    const { host } = createScrollHost({
+  it("re-sticks an unlocked resize even when layout moves beyond the near-bottom threshold", async () => {
+    const { host, container } = createScrollHost({
       scrollHeight: 2000,
-      scrollTop: 500,
-      clientHeight: 400,
+      scrollTop: 1100,
+      clientHeight: 900,
     });
-    host.chatUserNearBottom = false;
     host.chatHasAutoScrolled = true;
+    host.chatUserNearBottom = false;
     host.chatLastScrollHeight = 2000;
+    container.clientHeight = 400;
 
     scheduleChatScroll(host, false, false, { source: "resize" });
     await host.updateComplete;
 
+    expect(container.scrollTop).toBe(container.scrollHeight);
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatNewMessagesBelow).toBe(false);
+  });
+
+  it("preserves a locked viewport across the same resize", async () => {
+    const { host, container } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1100,
+      clientHeight: 900,
+    });
+    host.chatHasAutoScrolled = true;
+    host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
+    host.chatLastScrollHeight = 2000;
+    container.clientHeight = 400;
+
+    scheduleChatScroll(host, false, false, { source: "resize" });
+    await host.updateComplete;
+
+    expect(container.scrollTop).toBe(1100);
+    expect(host.chatFollowLocked).toBe(true);
     expect(host.chatNewMessagesBelow).toBe(false);
   });
 
@@ -428,6 +455,7 @@ describe("scheduleChatScroll", () => {
       clientHeight: 400,
     });
     host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
     host.chatHasAutoScrolled = true;
     host.chatLastScrollHeight = 2000;
 
@@ -502,6 +530,7 @@ describe("scheduleChatScroll", () => {
       clientHeight: 400,
     });
     host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
     host.chatHasAutoScrolled = true;
 
     scheduleChatScroll(host, true, false, { source: "manual" });
@@ -553,6 +582,7 @@ describe("streaming scroll behavior", () => {
       clientHeight: 400,
     });
     host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
     host.chatHasAutoScrolled = true;
     const originalScrollTop = container.scrollTop;
 

--- a/ui/src/pages/chat/scroll.ts
+++ b/ui/src/pages/chat/scroll.ts
@@ -201,7 +201,9 @@ export function scheduleCommittedChatScroll(
       manualScroll ||
       effectiveForce ||
       (!host.chatFollowLocked &&
-        (host.chatUserNearBottom || distanceFromBottom < NEAR_BOTTOM_THRESHOLD));
+        (options.source === "resize" ||
+          host.chatUserNearBottom ||
+          distanceFromBottom < NEAR_BOTTOM_THRESHOLD));
 
     if (!shouldStick) {
       if (contentChanged || (options.source === "resize" && contentGrew)) {

--- a/ui/src/styles/chat/question-card.css
+++ b/ui/src/styles/chat/question-card.css
@@ -1,17 +1,5 @@
-.chat:has(.agent-chat__question-dock) .chat-thread {
-  padding-bottom: calc(6px + var(--chat-question-dock-height, 0px));
-  scroll-padding-bottom: var(--chat-question-dock-height, 0px);
-}
-
-.agent-chat__composer-shell:has(.agent-chat__question-dock) {
-  position: relative;
-  z-index: 8;
-  margin-top: calc(8px - var(--chat-question-dock-height, 0px));
-}
-
 .agent-chat__question-dock {
   position: relative;
-  z-index: 1;
   min-width: 0;
 }
 


### PR DESCRIPTION
AI-assisted: yes

## What Problem This Solves

Fixes an issue where Control UI users could receive a structured question below the visible chat edge, while the Scroll to latest affordance overlapped the question panel.

## Why This Change Was Made

The question panel now participates in the normal footer layout instead of using measured padding and a negative-margin overlay. Resize reconciliation follows the explicit user backscroll lock, and the latest-message affordance is anchored directly after the transcript so it stays above every footer surface.

## User Impact

Questions automatically open fully visible when the reader is following the live conversation. If the reader intentionally scrolled up, their position remains stable and the navigation arrow stays above the question instead of covering it.

## Evidence

- 271 focused chat scroll/view unit tests passed.
- 11 mocked-Gateway rendered question-flow browser tests passed.
- Source-blind behavior validation passed all 3 clauses (live-edge reveal, preserved backscroll, usable panel).
- Targeted oxfmt, oxlint, stylelint, and `git diff --check` passed.
- Production delta: +6/-58 (net -52); tests: +147/-19.
- [Synthetic before/after and live-edge screenshots](https://github.com/openclaw/openclaw/pull/120695#issuecomment-5228046367).
