### PR TITLE
fix(openai): explicit service tier overrides fast mode

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -111,9 +111,9 @@ Official provider plugins publish their own model catalog rows. These providers 
 - CLI: `openclaw onboard --auth-choice openai-api-key`
 - Default transport is `auto`; OpenClaw passes the transport choice to the shared model runtime.
 - Override per model via `agents.defaults.models["openai/<model>"].params.transport` (`"sse"`, `"websocket"`, or `"auto"`)
-- OpenAI API Fast mode (formerly Priority processing) can be requested on the embedded runtime via `agents.defaults.models["openai/<model>"].params.serviceTier`; OpenClaw currently sends `service_tier=priority`
-- `/fast` and valid `params.fastMode` / `params.fast_mode` values are shared agent-runtime controls; on direct embedded `openai/*` Responses requests they map to the same wire tier
-- Use `params.serviceTier` when you want an authored embedded-provider tier instead of the shared `/fast` control
+- Set an explicit OpenAI API service tier with `params.serviceTier` or `params.service_tier`; Fast mode (formerly Priority processing) uses `service_tier=priority`.
+- On native public OpenAI and ChatGPT/Codex Responses requests, precedence is payload/transport `service_tier`, then a valid explicit model param, then the fast-mode default.
+- `/fast` and valid `params.fastMode` / `params.fast_mode` values are shared agent-runtime controls; on direct embedded `openai/*` Responses requests they supply `service_tier=priority` only when no higher-precedence tier exists.
 - Hidden OpenClaw attribution headers (`originator`, `version`, `User-Agent`) apply only on native OpenAI traffic to `api.openai.com`, not generic OpenAI-compatible proxies
 - Native OpenAI routes also keep Responses `store`, prompt-cache hints, and OpenAI reasoning-compat payload shaping; proxy routes do not
 - `openai/gpt-5.3-codex-spark` is available only through ChatGPT/Codex OAuth; direct OpenAI API-key and Azure API-key routes reject it

--- a/src/plugin-sdk/provider-stream.test.ts
+++ b/src/plugin-sdk/provider-stream.test.ts
@@ -52,6 +52,66 @@ function requirePayload(payload: Record<string, unknown> | undefined): Record<st
   return payload;
 }
 
+type OpenAIResponsesTestModel = {
+  api: "openai-responses" | "openai-chatgpt-responses";
+  provider: "openai";
+  baseUrl: string;
+  id: string;
+};
+
+const openAIResponsesServiceTierEndpoints = [
+  {
+    name: "public OpenAI Responses",
+    model: {
+      api: "openai-responses",
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      id: "gpt-5.6-luna",
+    },
+    fastParams: { fastMode: true },
+    payloadServiceTier: "default",
+    configuredServiceTier: "flex",
+  },
+  {
+    name: "ChatGPT Responses",
+    model: {
+      api: "openai-chatgpt-responses",
+      provider: "openai",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+      id: "gpt-5.6-sol",
+    },
+    fastParams: { fast_mode: true },
+    payloadServiceTier: "flex",
+    configuredServiceTier: "default",
+  },
+] as const;
+
+async function captureOpenAIResponsesFamilyPayload(params: {
+  model: OpenAIResponsesTestModel;
+  extraParams: Record<string, unknown>;
+  initialServiceTier?: string;
+}): Promise<Record<string, unknown>> {
+  let capturedPayload: Record<string, unknown> | undefined;
+  const baseStreamFn: StreamFn = (model, _context, options) => {
+    const payload: Record<string, unknown> = { model: model.id };
+    if (params.initialServiceTier !== undefined) {
+      payload.service_tier = params.initialServiceTier;
+    }
+    options?.onPayload?.(payload as never, model as never);
+    capturedPayload = payload;
+    return {} as never;
+  };
+  const wrapStreamFn = requireWrapStreamFn(
+    buildProviderStreamFamilyHooks("openai-responses-defaults").wrapStreamFn,
+  );
+  const streamFn = requireStreamFn(
+    wrapStreamFn({ streamFn: baseStreamFn, extraParams: params.extraParams } as never),
+  );
+
+  await streamFn(params.model as never, {} as never, {});
+  return requirePayload(capturedPayload);
+}
+
 function expectDefaultThinkingBudget(payload: Record<string, unknown>) {
   const config = requireRecord(payload.config, "payload.config");
   const thinkingConfig = requireRecord(config.thinkingConfig, "payload.config.thinkingConfig");
@@ -195,6 +255,49 @@ describe("composeProviderStreamWrappers", () => {
 });
 
 describe("buildProviderStreamFamilyHooks", () => {
+  it.each(
+    openAIResponsesServiceTierEndpoints.flatMap(
+      ({ name, model, fastParams, payloadServiceTier, configuredServiceTier }) => [
+        {
+          name: `${name}: configured flex beats fast mode`,
+          model,
+          extraParams: { ...fastParams, serviceTier: "flex" },
+          initialServiceTier: undefined,
+          expectedServiceTier: "flex",
+        },
+        {
+          name: `${name}: configured default beats fast mode`,
+          model,
+          extraParams: { ...fastParams, service_tier: "default" },
+          initialServiceTier: undefined,
+          expectedServiceTier: "default",
+        },
+        {
+          name: `${name}: payload ${payloadServiceTier} beats configured ${configuredServiceTier} and fast mode`,
+          model,
+          extraParams: { ...fastParams, serviceTier: configuredServiceTier },
+          initialServiceTier: payloadServiceTier,
+          expectedServiceTier: payloadServiceTier,
+        },
+        {
+          name: `${name}: fast mode defaults to priority`,
+          model,
+          extraParams: fastParams,
+          initialServiceTier: undefined,
+          expectedServiceTier: "priority",
+        },
+      ],
+    ),
+  )("$name", async ({ model, extraParams, initialServiceTier, expectedServiceTier }) => {
+    const payload = await captureOpenAIResponsesFamilyPayload({
+      model,
+      extraParams,
+      initialServiceTier,
+    });
+
+    expect(payload.service_tier).toBe(expectedServiceTier);
+  });
+
   it("covers the stream family matrix", async () => {
     let capturedPayload: Record<string, unknown> | undefined;
     let capturedModelId: string | undefined;

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -130,13 +130,15 @@ export function buildProviderStreamFamilyHooks(
           // before payload-shape and context-management compatibility rewrites.
           let nextStreamFn = createOpenAIAttributionHeadersWrapper(ctx.streamFn);
 
-          if (hasFastModeParam(ctx.extraParams)) {
+          const serviceTier = resolveOpenAIServiceTier(ctx.extraParams);
+          // Payload/transport tier stays authoritative, then an explicit tier, then fast's default.
+          // Skip fast for valid config so its payload hook cannot install priority first.
+          if (!serviceTier && hasFastModeParam(ctx.extraParams)) {
             nextStreamFn = createOpenAIFastModeWrapper(nextStreamFn, () =>
               resolveOpenAIFastMode(ctx.extraParams),
             );
           }
 
-          const serviceTier = resolveOpenAIServiceTier(ctx.extraParams);
           if (serviceTier) {
             nextStreamFn = createOpenAIServiceTierWrapper(nextStreamFn, serviceTier);
           }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenAI users configuring both fast mode and an explicit `serviceTier` would silently send `service_tier=priority` even when they selected `flex` or `default`.

## Why This Change Was Made

The production wrapper family now treats fast mode as a default only when no valid explicit service tier is configured. Existing write-if-absent behavior remains intact, preserving caller- and transport-provided payload tiers. Regression coverage invokes the real production wrapper composition for native public OpenAI and ChatGPT/Codex Responses endpoints.

This change was AI-assisted and reviewed with the repository autoreview workflow.

## User Impact

Operators can combine shared fast-mode configuration with per-model tier settings without the fast default overriding their explicit choice. Canonical precedence is now payload/transport tier, then explicit model configuration, then fast-mode priority.

## Evidence

- `node scripts/run-vitest.mjs src/plugin-sdk/provider-stream.test.ts` — 19 tests passed
- `pnpm format:check -- src/plugin-sdk/provider-stream.ts src/plugin-sdk/provider-stream.test.ts docs/concepts/model-providers.md` — passed
- `node scripts/run-oxlint.mjs --tsconfig tsconfig.json src/plugin-sdk/provider-stream.ts src/plugin-sdk/provider-stream.test.ts` — passed
- `pnpm plugin-sdk:surface:check` — passed
- `git diff --check` — passed
- Codex autoreview — clean; no accepted/actionable findings

The broader changed-file gate could not acquire the repository-wide local heavy-check lock after remote Testbox/Crabbox routing was unavailable. The directly affected lanes above were run independently.
