### PR TITLE
perf(doctor): keep bundled doctor contract closures dependency-light

### DIFF
--- a/extensions/acpx/doctor-contract-api.test.ts
+++ b/extensions/acpx/doctor-contract-api.test.ts
@@ -10,7 +10,7 @@ import {
 import type {
   OpenKeyedStoreOptions,
   PluginDoctorStateMigrationContext,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { stateMigrations } from "./doctor-contract-api.js";
 import { openAcpxProcessLeaseStateStore, type AcpxProcessLease } from "./src/process-lease.js";

--- a/extensions/acpx/doctor-contract-api.ts
+++ b/extensions/acpx/doctor-contract-api.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import {
   archiveLegacyStateSource,
   type PluginDoctorStateMigration,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import {
   normalizeAcpxProcessLease,
   normalizeAcpxProcessLeaseFile,

--- a/extensions/active-memory/doctor-contract-api.test.ts
+++ b/extensions/active-memory/doctor-contract-api.test.ts
@@ -10,7 +10,7 @@ import {
 import type {
   OpenKeyedStoreOptions,
   PluginDoctorStateMigrationContext,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stateMigrations } from "./doctor-contract-api.js";
 

--- a/extensions/active-memory/doctor-contract-api.ts
+++ b/extensions/active-memory/doctor-contract-api.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import {
   defineLegacyJsonStateMigration,
   type PluginDoctorStateMigration,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 
 type ActiveMemoryToggleEntry = {
   sessionKey: string;

--- a/extensions/anthropic/doctor-contract-api.ts
+++ b/extensions/anthropic/doctor-contract-api.ts
@@ -2,7 +2,7 @@
  * Doctor contract metadata for Anthropic and Claude CLI state. It declares
  * session/auth ownership so doctor cleanup can route stale state correctly.
  */
-import type { DoctorSessionRouteStateOwner } from "openclaw/plugin-sdk/runtime-doctor";
+import type { DoctorSessionRouteStateOwner } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 
 /** Anthropic currently has no legacy config migrations. */
 export const legacyConfigRules = [];

--- a/extensions/canvas/doctor-contract-api.test.ts
+++ b/extensions/canvas/doctor-contract-api.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { stateMigrations } from "./doctor-contract-api.js";
 

--- a/extensions/canvas/doctor-contract-api.ts
+++ b/extensions/canvas/doctor-contract-api.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolvePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
-import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { pathExists } from "openclaw/plugin-sdk/security-runtime";
 import {
   asOptionalRecord as readRecord,

--- a/extensions/clickclack/src/doctor-contract.ts
+++ b/extensions/clickclack/src/doctor-contract.ts
@@ -1,6 +1,6 @@
 import type { ChannelDoctorConfigMutation } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor";
+import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 
 function stripTimeoutSeconds(value: unknown): { value: unknown; changed: boolean } {
   const record = asObjectRecord(value);

--- a/extensions/codex/doctor-contract-api.test.ts
+++ b/extensions/codex/doctor-contract-api.test.ts
@@ -9,7 +9,7 @@ import {
 import type {
   OpenKeyedStoreOptions,
   PluginDoctorStateMigrationContext,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { getSessionEntry, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, describe, expect, it } from "vitest";
 import {

--- a/extensions/codex/doctor-contract-api.ts
+++ b/extensions/codex/doctor-contract-api.ts
@@ -3,7 +3,7 @@
  * ownership warnings.
  */
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import type { DoctorSessionRouteStateOwner } from "openclaw/plugin-sdk/runtime-doctor";
+import type { DoctorSessionRouteStateOwner } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 
 type LegacyConfigRule = {
   path: string[];

--- a/extensions/codex/src/migration/session-binding-sidecars.ts
+++ b/extensions/codex/src/migration/session-binding-sidecars.ts
@@ -12,7 +12,7 @@ import {
   archiveLegacyStateSource,
   legacyStateFileExists,
   type PluginDoctorStateMigration,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import {
   canonicalPathFromExistingAncestor,
   isPathInside,

--- a/extensions/copilot/doctor-contract-api.ts
+++ b/extensions/copilot/doctor-contract-api.ts
@@ -14,7 +14,7 @@
  */
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import type { DoctorSessionRouteStateOwner } from "openclaw/plugin-sdk/runtime-doctor";
+import type { DoctorSessionRouteStateOwner } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 
 type LegacyConfigRule = {
   path: string[];

--- a/extensions/cua-computer/doctor-contract-api.ts
+++ b/extensions/cua-computer/doctor-contract-api.ts
@@ -1,7 +1,7 @@
 // CUA config migrations belong to the plugin so doctor can repair a shipped
 // driverPath setting before strict manifest validation reaches this plugin.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor";
+import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 
 const DRIVER_PATH = ["plugins", "entries", "cua-computer", "config", "driverPath"];
 

--- a/extensions/deepinfra/doctor-contract-api.ts
+++ b/extensions/deepinfra/doctor-contract-api.ts
@@ -3,7 +3,7 @@
 // canonical key; `openclaw doctor --fix` repairs shipped `nativeBaseUrl` and
 // `/v1/inference` values here so no request-time compat remap is needed.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor";
+import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 const PROVIDER_PATH = "models.providers.deepinfra";

--- a/extensions/device-pair/doctor-contract-api.test.ts
+++ b/extensions/device-pair/doctor-contract-api.test.ts
@@ -10,7 +10,7 @@ import {
 import type {
   OpenKeyedStoreOptions,
   PluginDoctorStateMigrationContext,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { stateMigrations } from "./doctor-contract-api.js";
 import {

--- a/extensions/device-pair/doctor-contract-api.ts
+++ b/extensions/device-pair/doctor-contract-api.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import {
   defineLegacyJsonStateMigration,
   type PluginDoctorStateMigration,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import {
   DEVICE_PAIR_NOTIFY_LEGACY_STATE_FILE,
   DEVICE_PAIR_NOTIFY_SUBSCRIBER_MAX_ENTRIES,

--- a/extensions/discord/src/doctor-contract.ts
+++ b/extensions/discord/src/doctor-contract.ts
@@ -15,7 +15,7 @@ import {
   hasLegacyAccountStreamingAliases,
   normalizeChannelAccounts,
   stripRetiredChannelKeys,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 
 const LEGACY_TTS_PROVIDER_KEYS = ["openai", "elevenlabs", "microsoft", "edge"] as const;
 const RETIRED_TUNING_KEYS = new Set([

--- a/extensions/discord/src/doctor.ts
+++ b/extensions/discord/src/doctor.ts
@@ -6,7 +6,7 @@ import {
   asObjectRecord,
   collectChannelAccountScopes,
   collectProviderDangerousNameMatchingScopes,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { inspectDiscordAccount } from "./account-inspect.js";
 import { resolveDefaultDiscordAccountId } from "./accounts.js";

--- a/extensions/feishu/src/doctor-contract.ts
+++ b/extensions/feishu/src/doctor-contract.ts
@@ -10,7 +10,7 @@ import {
   defineKeyMoveMigration,
   hasLegacyAccountStreamingAliases,
   normalizeChannelConfigEntries,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { DEFAULT_FEISHU_WEBHOOK_PATH, normalizeFeishuWebhookPath } from "./webhook-path.js";
 
 // Feishu's legacy boolean `streaming` gated streaming-card replies with an

--- a/extensions/google/doctor-contract-api.ts
+++ b/extensions/google/doctor-contract-api.ts
@@ -1,5 +1,5 @@
 // Google API module exposes the plugin public contract.
-import type { DoctorSessionRouteStateOwner } from "openclaw/plugin-sdk/runtime-doctor";
+import type { DoctorSessionRouteStateOwner } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 
 export const sessionRouteStateOwners: DoctorSessionRouteStateOwner[] = [
   {

--- a/extensions/googlechat/src/doctor-contract.ts
+++ b/extensions/googlechat/src/doctor-contract.ts
@@ -10,7 +10,7 @@ import {
   defineKeyMoveMigration,
   hasLegacyAccountStreamingAliases,
   normalizeChannelConfigEntries,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 
 // Google Chat's nested streaming schema is delivery-only ({chunkMode, block});
 // it has no preview mode (legacy streamMode is removed outright above), so

--- a/extensions/imessage/doctor-contract-api.ts
+++ b/extensions/imessage/doctor-contract-api.ts
@@ -4,7 +4,7 @@ import type {
   ChannelDoctorLegacyConfigRule,
 } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import { defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 // Disabled `channels.imessage.catchup` blocks are retired. Enabled blocks stay

--- a/extensions/irc/doctor-contract-api.ts
+++ b/extensions/irc/doctor-contract-api.ts
@@ -4,7 +4,7 @@ import type {
   ChannelDoctorLegacyConfigRule,
 } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import { defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 
 // IRC's nested streaming schema is delivery-only ({chunkMode, block}); it has
 // no preview mode, so only the delivery flat aliases are legal legacy input.

--- a/extensions/llm-task/doctor-contract-api.ts
+++ b/extensions/llm-task/doctor-contract-api.ts
@@ -1,7 +1,7 @@
 // LLM Task doctor contract migrates shipped plugin-local completion policy.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { parseModelRef } from "openclaw/plugin-sdk/provider-model-shared";
-import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor";
+import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 
 const ENTRY_PATH = "plugins.entries.llm-task";
 

--- a/extensions/matrix/auth-presence.ts
+++ b/extensions/matrix/auth-presence.ts
@@ -6,7 +6,7 @@ import {
   MATRIX_CREDENTIALS_NAMESPACE,
   normalizeMatrixStoredCredentials,
   type MatrixCredentialStateRecord,
-} from "./src/matrix/credentials-read.js";
+} from "./src/matrix/credentials-state.js";
 
 type MatrixAuthPresenceParams =
   | {

--- a/extensions/matrix/doctor-contract-api.capacity.test.ts
+++ b/extensions/matrix/doctor-contract-api.capacity.test.ts
@@ -14,7 +14,7 @@ import {
   resetPluginStateStoreForTests,
   setMaxPluginStateEntriesPerPluginForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor";
+import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { stateMigrations } from "./doctor-contract-api.js";
 import {

--- a/extensions/matrix/doctor-contract-api.test.ts
+++ b/extensions/matrix/doctor-contract-api.test.ts
@@ -20,7 +20,7 @@ import {
   importPluginStateEntriesForDoctorForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor";
+import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stateMigrations } from "./doctor-contract-api.js";
 import { SqliteBackedMatrixSyncStore } from "./src/matrix/client/file-sync-store.js";
@@ -31,7 +31,7 @@ import {
   matrixCredentialsStoreKey,
   type MatrixCredentialStateRecord,
   type MatrixStoredCredentialRecord,
-} from "./src/matrix/credentials-read.js";
+} from "./src/matrix/credentials-state.js";
 import {
   MATRIX_IDB_SNAPSHOT_FILENAME,
   MATRIX_RECOVERY_KEY_FILENAME,

--- a/extensions/matrix/doctor-contract-api.ts
+++ b/extensions/matrix/doctor-contract-api.ts
@@ -6,7 +6,7 @@ import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import {
   archiveLegacyStateSource,
   type PluginDoctorStateMigration,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   requiresExplicitMatrixDefaultAccount,
@@ -34,7 +34,7 @@ import {
   normalizeMatrixStoredCredentials,
   type MatrixCredentialStateRecord,
   type MatrixStoredCredentialRecord,
-} from "./src/matrix/credentials-read.js";
+} from "./src/matrix/credentials-state.js";
 import { migrateLegacyMatrixIdbSnapshot } from "./src/matrix/crypto-snapshot-doctor.js";
 import {
   MATRIX_IDB_SNAPSHOT_FILENAME,

--- a/extensions/matrix/src/doctor-contract.ts
+++ b/extensions/matrix/src/doctor-contract.ts
@@ -10,7 +10,7 @@ import {
   hasLegacyAccountStreamingAliases,
   normalizeChannelConfigEntries,
   stripRetiredChannelKeys,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import {
   hasLegacyFlatAllowPrivateNetworkAlias,
   migrateLegacyFlatAllowPrivateNetworkAlias,

--- a/extensions/matrix/src/matrix/accounts.test.ts
+++ b/extensions/matrix/src/matrix/accounts.test.ts
@@ -8,7 +8,7 @@ import {
   resolveDefaultMatrixAccountId,
   resolveMatrixAccount,
 } from "./accounts.js";
-import type { MatrixStoredCredentials } from "./credentials-read.js";
+import type { MatrixStoredCredentials } from "./credentials-state.js";
 
 const loadMatrixCredentialsMock = vi.hoisted(() =>
   vi.fn<(env?: NodeJS.ProcessEnv, accountId?: string | null) => MatrixStoredCredentials | null>(

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -26,7 +26,7 @@ import {
   listNormalizedMatrixAccountIds,
 } from "../account-config.js";
 import { resolveMatrixConfigFieldPath } from "../config-paths.js";
-import type { MatrixStoredCredentials } from "../credentials-read.js";
+import type { MatrixStoredCredentials } from "../credentials-state.js";
 import {
   DEFAULT_ACCOUNT_ID,
   isPrivateNetworkOptInEnabled,

--- a/extensions/matrix/src/matrix/credentials-read.ts
+++ b/extensions/matrix/src/matrix/credentials-read.ts
@@ -1,88 +1,20 @@
-// Matrix plugin module implements credentials read behavior.
+// Matrix plugin module implements credentials read behavior. Pure record
+// shapes/normalizers live in credentials-state.ts; this module owns the
+// heavy sync plugin-state store access.
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { createPluginStateSyncKeyedStore } from "openclaw/plugin-sdk/runtime-doctor";
 import { getOptionalMatrixRuntime } from "../runtime.js";
+import {
+  MATRIX_CREDENTIALS_MAX_ENTRIES,
+  MATRIX_CREDENTIALS_NAMESPACE,
+  matrixCredentialsStoreKey,
+  normalizeMatrixStoredCredentials,
+  type MatrixCredentialStateRecord,
+  type MatrixStoredCredentials,
+} from "./credentials-state.js";
 
 export { resolveMatrixCredentialsDir, resolveMatrixCredentialsPath } from "../storage-paths.js";
-
-export type MatrixStoredCredentials = {
-  homeserver: string;
-  userId: string;
-  accessToken: string;
-  deviceId?: string;
-  createdAt: string;
-  lastUsedAt?: string;
-};
-
-export type MatrixStoredCredentialRecord = MatrixStoredCredentials & {
-  accountId: string;
-};
-
-export type MatrixCredentialRevocationRecord = {
-  accountId: string;
-  kind: "revoked";
-  revokedAt: string;
-};
-
-export type MatrixCredentialStateRecord =
-  | MatrixStoredCredentialRecord
-  | MatrixCredentialRevocationRecord;
-
-export const MATRIX_CREDENTIALS_NAMESPACE = "credentials";
-export const MATRIX_CREDENTIALS_MAX_ENTRIES = 256;
-
-export function matrixCredentialsStoreKey(accountId?: string | null): string {
-  return `account:${normalizeAccountId(accountId)}`;
-}
-
-export function normalizeMatrixStoredCredentials(
-  value: unknown,
-  accountId?: string | null,
-): MatrixStoredCredentialRecord | null {
-  if (!value || typeof value !== "object") {
-    return null;
-  }
-  const parsed = value as Partial<MatrixStoredCredentialRecord>;
-  if (
-    typeof parsed.homeserver !== "string" ||
-    !parsed.homeserver ||
-    typeof parsed.userId !== "string" ||
-    !parsed.userId ||
-    typeof parsed.accessToken !== "string" ||
-    !parsed.accessToken ||
-    typeof parsed.createdAt !== "string" ||
-    !parsed.createdAt
-  ) {
-    return null;
-  }
-  const normalizedAccountId = normalizeAccountId(accountId ?? parsed.accountId);
-  return {
-    accountId: normalizedAccountId,
-    homeserver: parsed.homeserver,
-    userId: parsed.userId,
-    accessToken: parsed.accessToken,
-    ...(typeof parsed.deviceId === "string" ? { deviceId: parsed.deviceId } : {}),
-    createdAt: parsed.createdAt,
-    ...(typeof parsed.lastUsedAt === "string" ? { lastUsedAt: parsed.lastUsedAt } : {}),
-  };
-}
-
-export function isMatrixCredentialRevocation(
-  value: unknown,
-  accountId?: string | null,
-): value is MatrixCredentialRevocationRecord {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const parsed = value as Partial<MatrixCredentialRevocationRecord>;
-  return (
-    parsed.kind === "revoked" &&
-    typeof parsed.revokedAt === "string" &&
-    parsed.revokedAt.length > 0 &&
-    normalizeAccountId(parsed.accountId) === normalizeAccountId(accountId ?? parsed.accountId)
-  );
-}
 
 export function openMatrixCredentialsStore(
   env: NodeJS.ProcessEnv = process.env,

--- a/extensions/matrix/src/matrix/credentials-state.ts
+++ b/extensions/matrix/src/matrix/credentials-state.ts
@@ -1,0 +1,82 @@
+// Pure Matrix credential record shapes and normalizers, split from
+// credentials-read so the doctor contract closure never loads the sync
+// plugin-state store (which pulls the heavy state-db graph via runtime-doctor).
+import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+
+export type MatrixStoredCredentials = {
+  homeserver: string;
+  userId: string;
+  accessToken: string;
+  deviceId?: string;
+  createdAt: string;
+  lastUsedAt?: string;
+};
+
+export type MatrixStoredCredentialRecord = MatrixStoredCredentials & {
+  accountId: string;
+};
+
+export type MatrixCredentialRevocationRecord = {
+  accountId: string;
+  kind: "revoked";
+  revokedAt: string;
+};
+
+export type MatrixCredentialStateRecord =
+  | MatrixStoredCredentialRecord
+  | MatrixCredentialRevocationRecord;
+
+export const MATRIX_CREDENTIALS_NAMESPACE = "credentials";
+export const MATRIX_CREDENTIALS_MAX_ENTRIES = 256;
+
+export function matrixCredentialsStoreKey(accountId?: string | null): string {
+  return `account:${normalizeAccountId(accountId)}`;
+}
+
+export function normalizeMatrixStoredCredentials(
+  value: unknown,
+  accountId?: string | null,
+): MatrixStoredCredentialRecord | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const parsed = value as Partial<MatrixStoredCredentialRecord>;
+  if (
+    typeof parsed.homeserver !== "string" ||
+    !parsed.homeserver ||
+    typeof parsed.userId !== "string" ||
+    !parsed.userId ||
+    typeof parsed.accessToken !== "string" ||
+    !parsed.accessToken ||
+    typeof parsed.createdAt !== "string" ||
+    !parsed.createdAt
+  ) {
+    return null;
+  }
+  const normalizedAccountId = normalizeAccountId(accountId ?? parsed.accountId);
+  return {
+    accountId: normalizedAccountId,
+    homeserver: parsed.homeserver,
+    userId: parsed.userId,
+    accessToken: parsed.accessToken,
+    ...(typeof parsed.deviceId === "string" ? { deviceId: parsed.deviceId } : {}),
+    createdAt: parsed.createdAt,
+    ...(typeof parsed.lastUsedAt === "string" ? { lastUsedAt: parsed.lastUsedAt } : {}),
+  };
+}
+
+export function isMatrixCredentialRevocation(
+  value: unknown,
+  accountId?: string | null,
+): value is MatrixCredentialRevocationRecord {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const parsed = value as Partial<MatrixCredentialRevocationRecord>;
+  return (
+    parsed.kind === "revoked" &&
+    typeof parsed.revokedAt === "string" &&
+    parsed.revokedAt.length > 0 &&
+    normalizeAccountId(parsed.accountId) === normalizeAccountId(accountId ?? parsed.accountId)
+  );
+}

--- a/extensions/matrix/src/matrix/credentials-state.ts
+++ b/extensions/matrix/src/matrix/credentials-state.ts
@@ -16,7 +16,7 @@ export type MatrixStoredCredentialRecord = MatrixStoredCredentials & {
   accountId: string;
 };
 
-export type MatrixCredentialRevocationRecord = {
+type MatrixCredentialRevocationRecord = {
   accountId: string;
   kind: "revoked";
   revokedAt: string;

--- a/extensions/matrix/src/matrix/credentials.ts
+++ b/extensions/matrix/src/matrix/credentials.ts
@@ -1,12 +1,12 @@
 // Matrix plugin module implements credentials behavior.
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import { openMatrixCredentialsStore } from "./credentials-read.js";
 import {
   isMatrixCredentialRevocation,
   matrixCredentialsStoreKey,
   normalizeMatrixStoredCredentials,
-  openMatrixCredentialsStore,
-} from "./credentials-read.js";
-import type { MatrixStoredCredentialRecord, MatrixStoredCredentials } from "./credentials-read.js";
+} from "./credentials-state.js";
+import type { MatrixStoredCredentialRecord, MatrixStoredCredentials } from "./credentials-state.js";
 
 export {
   clearMatrixCredentials,
@@ -15,7 +15,7 @@ export {
   resolveMatrixCredentialsDir,
   resolveMatrixCredentialsPath,
 } from "./credentials-read.js";
-export type { MatrixStoredCredentials } from "./credentials-read.js";
+export type { MatrixStoredCredentials } from "./credentials-state.js";
 
 function requireCredentialStoreUpdate(
   store: ReturnType<typeof openMatrixCredentialsStore>,

--- a/extensions/matrix/src/matrix/crypto-snapshot-doctor.ts
+++ b/extensions/matrix/src/matrix/crypto-snapshot-doctor.ts
@@ -5,7 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { withFileLock } from "openclaw/plugin-sdk/file-lock";
-import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor";
+import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import {
   MATRIX_IDB_SNAPSHOT_FILENAME,
   openMatrixIdbSnapshotStoreOptions,

--- a/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
@@ -19,7 +19,7 @@ import {
   createPersistentDedupeImportEntry,
   type PersistentDedupeEntry,
 } from "openclaw/plugin-sdk/persistent-dedupe";
-import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor";
+import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import {
   openNodeSqliteDatabase,
   runSqliteImmediateTransactionSync,

--- a/extensions/mattermost/src/doctor-contract.ts
+++ b/extensions/mattermost/src/doctor-contract.ts
@@ -1,7 +1,7 @@
 // Mattermost plugin module implements doctor contract behavior.
 import type { ChannelDoctorConfigMutation } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import { defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { createLegacyPrivateNetworkDoctorContract } from "openclaw/plugin-sdk/ssrf-runtime";
 
 const networkContract = createLegacyPrivateNetworkDoctorContract({

--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -18,7 +18,7 @@ import {
 import type {
   OpenKeyedStoreOptions,
   PluginDoctorStateMigrationContext,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stateMigrations } from "./doctor-contract-api.js";
 import {

--- a/extensions/memory-core/doctor-contract-api.ts
+++ b/extensions/memory-core/doctor-contract-api.ts
@@ -1,4 +1,4 @@
-import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { dreamingStateMigration } from "./src/migration/doctor-dreaming-state.js";
 import { hostEventsStateMigration } from "./src/migration/doctor-host-events.js";
 import {

--- a/extensions/memory-core/src/migration/doctor-dreaming-state.ts
+++ b/extensions/memory-core/src/migration/doctor-dreaming-state.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import {
   archiveLegacyStateSource,
   legacyStateFileExists,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import {
   normalizeDailyIngestionState,
   normalizeSessionIngestionState,

--- a/extensions/memory-core/src/migration/doctor-host-events.ts
+++ b/extensions/memory-core/src/migration/doctor-host-events.ts
@@ -7,7 +7,7 @@ import {
 import type {
   PluginDoctorStateMigration,
   PluginDoctorStateMigrationContext,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import {
   collectLegacyMemoryHostEventSources,
   memoryHostWorkspacePrefix,

--- a/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
+++ b/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
@@ -12,7 +12,7 @@ import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import {
   legacyStateFileExists,
   type PluginDoctorStateMigration,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import {
   ensureOpenClawAgentDatabaseSchema,
   openNodeSqliteDatabase,

--- a/extensions/memory-core/src/migration/doctor-vector-index-provider.test.ts
+++ b/extensions/memory-core/src/migration/doctor-vector-index-provider.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor";
+import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { afterEach, describe, expect, it } from "vitest";
 import { vectorIndexProviderDiagnostic } from "./doctor-vector-index-provider.js";
 import { vectorIndexProviderDiagnosticTesting } from "./doctor-vector-index-provider.test-support.js";

--- a/extensions/memory-core/src/migration/doctor-vector-index-provider.ts
+++ b/extensions/memory-core/src/migration/doctor-vector-index-provider.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
 
 const MEMORY_INDEX_META_KEY = "memory_index_meta_v1";

--- a/extensions/memory-lancedb/doctor-contract-api.test.ts
+++ b/extensions/memory-lancedb/doctor-contract-api.test.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import * as lancedb from "@lancedb/lancedb";
 import { expectDefined } from "@openclaw/normalization-core";
-import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor";
+import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { describe, expect, test } from "vitest";
 import {
   createMemoryLanceDbStateMigrations,

--- a/extensions/memory-lancedb/doctor-contract-api.ts
+++ b/extensions/memory-lancedb/doctor-contract-api.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import {
   hasAgentScopeColumn,
   memoryAgentPredicate,

--- a/extensions/memory-wiki/doctor-contract-api.ts
+++ b/extensions/memory-wiki/doctor-contract-api.ts
@@ -6,7 +6,7 @@ import {
   archiveLegacyStateSource,
   legacyStateFileExists,
   type PluginDoctorStateMigration,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { FsSafeError, root as fsRoot } from "openclaw/plugin-sdk/security-runtime";
 import { LEGACY_MEMORY_WIKI_COMPILED_CACHE_PATHS } from "./src/compiled-cache.js";
 import {

--- a/extensions/msteams/doctor-contract-api.test.ts
+++ b/extensions/msteams/doctor-contract-api.test.ts
@@ -10,7 +10,7 @@ import {
 import type {
   OpenKeyedStoreOptions,
   PluginDoctorStateMigrationContext,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   legacyConfigRules,

--- a/extensions/msteams/doctor-contract-api.ts
+++ b/extensions/msteams/doctor-contract-api.ts
@@ -12,7 +12,7 @@ import {
   archiveLegacyStateSource,
   defineChannelAliasMigration,
   type PluginDoctorStateMigration,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeStoredConversationId } from "./src/conversation-store-helpers.js";

--- a/extensions/nextcloud-talk/src/doctor-contract.ts
+++ b/extensions/nextcloud-talk/src/doctor-contract.ts
@@ -1,7 +1,7 @@
 // Nextcloud Talk plugin module implements doctor contract behavior.
 import type { ChannelDoctorConfigMutation } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import { defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { createLegacyPrivateNetworkDoctorContract } from "openclaw/plugin-sdk/ssrf-runtime";
 
 const networkContract = createLegacyPrivateNetworkDoctorContract({

--- a/extensions/nostr/doctor-contract-api.test.ts
+++ b/extensions/nostr/doctor-contract-api.test.ts
@@ -10,7 +10,7 @@ import {
 import type {
   OpenKeyedStoreOptions,
   PluginDoctorStateMigrationContext,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { stateMigrations } from "./doctor-contract-api.js";
 

--- a/extensions/nostr/doctor-contract-api.ts
+++ b/extensions/nostr/doctor-contract-api.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import {
   archiveLegacyStateSource,
   type PluginDoctorStateMigration,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { normalizeNostrStateAccountId } from "./src/state-account-id.js";
 
 type NostrBusState = {

--- a/extensions/ollama/src/config-compat.ts
+++ b/extensions/ollama/src/config-compat.ts
@@ -1,6 +1,6 @@
 // Ollama helper module supports config compat behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor";
+import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { OLLAMA_CLOUD_BASE_URL, OLLAMA_CLOUD_PROVIDER_ID } from "./defaults.js";
 
 type LegacyConfigRule = {

--- a/extensions/qqbot/src/state-migrations.test.ts
+++ b/extensions/qqbot/src/state-migrations.test.ts
@@ -10,7 +10,7 @@ import type {
   OpenKeyedStoreOptions,
   PluginDoctorStateMigrationContext,
   PluginStateKeyedStore,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { stateMigrations } from "../doctor-contract-api.js";
 import { buildQQBotStateKey } from "./engine/utils/state-keys.js";

--- a/extensions/reef/doctor-contract-api.test.ts
+++ b/extensions/reef/doctor-contract-api.test.ts
@@ -11,7 +11,7 @@ import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime
 import type {
   OpenKeyedStoreOptions,
   PluginDoctorStateMigrationContext,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   legacyConfigRules,

--- a/extensions/reef/doctor-contract-api.ts
+++ b/extensions/reef/doctor-contract-api.ts
@@ -5,7 +5,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   archiveLegacyStateSource,
   type PluginDoctorStateMigration,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { z } from "zod";
 import {

--- a/extensions/reef/src/doctor-durable-state.ts
+++ b/extensions/reef/src/doctor-durable-state.ts
@@ -4,7 +4,7 @@ import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-run
 import {
   archiveLegacyStateSource,
   type PluginDoctorStateMigration,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   verifyChain,

--- a/extensions/signal/doctor-contract-api.ts
+++ b/extensions/signal/doctor-contract-api.ts
@@ -5,7 +5,7 @@ import type {
 } from "openclaw/plugin-sdk/channel-contract";
 import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import { defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { migrateLegacySignalTransportConfigSync } from "./src/config-compat.js";
 
 const RETIRED_SIGNAL_ACCOUNT_TRANSPORT_FIELDS = [

--- a/extensions/slack/src/doctor-contract.ts
+++ b/extensions/slack/src/doctor-contract.ts
@@ -10,7 +10,7 @@ import {
   defineKeyMoveMigration,
   hasLegacyAccountStreamingAliases,
   normalizeChannelConfigEntries,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { resolveSlackNativeStreaming, resolveSlackStreamingMode } from "./streaming-compat.js";
 
 const streamingAliasMigration = defineChannelAliasMigration({

--- a/extensions/slack/src/doctor.ts
+++ b/extensions/slack/src/doctor.ts
@@ -5,7 +5,7 @@ import {
   createDangerousNameMatchingMutableAllowlistWarningCollector,
 } from "openclaw/plugin-sdk/channel-policy";
 import type { GroupPolicy, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor";
+import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { inspectSlackAccount } from "./account-inspect.js";
 import { listSlackAccountIds, mergeSlackAccountConfig } from "./accounts.js";
 import {

--- a/extensions/telegram/src/doctor-contract.ts
+++ b/extensions/telegram/src/doctor-contract.ts
@@ -11,7 +11,7 @@ import {
   hasLegacyAccountStreamingAliases,
   normalizeChannelAccounts,
   stripRetiredChannelKeys,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 
 const streamingAliasMigration = defineChannelAliasMigration({
   channelId: "telegram",

--- a/extensions/telegram/src/doctor.ts
+++ b/extensions/telegram/src/doctor.ts
@@ -9,7 +9,10 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { asObjectRecord, collectChannelAccountScopes } from "openclaw/plugin-sdk/runtime-doctor";
+import {
+  asObjectRecord,
+  collectChannelAccountScopes,
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { inspectTelegramAccount } from "./account-inspect.js";
 import {

--- a/extensions/telegram/src/target-writeback.ts
+++ b/extensions/telegram/src/target-writeback.ts
@@ -9,7 +9,7 @@ import {
   resolveCronStorePath,
   saveCronStore,
 } from "openclaw/plugin-sdk/cron-store-runtime";
-import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor";
+import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import {
   normalizeLowercaseStringOrEmpty,

--- a/extensions/voice-call/doctor-contract-api.test.ts
+++ b/extensions/voice-call/doctor-contract-api.test.ts
@@ -12,7 +12,7 @@ import {
 import type {
   OpenKeyedStoreOptions,
   PluginDoctorStateMigrationContext,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { resolveSessionStoreAgentIds, stateMigrations } from "./doctor-contract-api.js";
 import {

--- a/extensions/voice-call/doctor-contract-api.ts
+++ b/extensions/voice-call/doctor-contract-api.ts
@@ -4,14 +4,14 @@ import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
+// Doctor enumeration cold-loads this closure; the state-DB helpers stay behind a
+// lazy runtime-doctor import so enumeration never pulls the kysely/state-db graph.
+import type { OpenClawStateDatabaseSchemaMigration } from "openclaw/plugin-sdk/runtime-doctor";
 import {
   archiveLegacyStateSource,
-  detectOpenClawStateDatabaseSchemaMigrations,
   type PluginDoctorStateMigration,
   type PluginStateKeyedStore,
-  repairOpenClawStateDatabaseSchema,
-  type OpenClawStateDatabaseSchemaMigration,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import {
   buildVoiceCallLegacyJsonlEventKey,
   CALL_RECORD_CHUNK_MAX_ENTRIES,
@@ -303,6 +303,8 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
     id: "voice-call-calls-jsonl-to-plugin-state",
     label: "Voice Call call log",
     async detectLegacyState(params) {
+      const { detectOpenClawStateDatabaseSchemaMigrations } =
+        await import("openclaw/plugin-sdk/runtime-doctor");
       const storePath = resolveVoiceCallStorePath(params);
       const filePath = resolveVoiceCallLegacyCallLogPath(storePath);
       const { entries } = await readLegacyCallRecords(filePath);
@@ -327,6 +329,8 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
       };
     },
     async migrateLegacyState(params) {
+      const { detectOpenClawStateDatabaseSchemaMigrations, repairOpenClawStateDatabaseSchema } =
+        await import("openclaw/plugin-sdk/runtime-doctor");
       const changes: string[] = [];
       const warnings: string[] = [];
       const storePath = resolveVoiceCallStorePath(params);

--- a/extensions/whatsapp/src/doctor-contract.ts
+++ b/extensions/whatsapp/src/doctor-contract.ts
@@ -9,7 +9,7 @@ import {
   defineChannelAliasMigration,
   hasLegacyAccountStreamingAliases,
   stripRetiredChannelKeys,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { normalizeCompatibilityConfig as normalizeAckReactionConfig } from "./doctor.js";
 
 // WhatsApp's nested streaming schema is delivery-only ({chunkMode, block});

--- a/extensions/workboard/doctor-contract-api.test.ts
+++ b/extensions/workboard/doctor-contract-api.test.ts
@@ -7,7 +7,7 @@ import { createPluginStateKeyedStoreForTests as createPluginStateKeyedStore } fr
 import type {
   OpenKeyedStoreOptions,
   PluginDoctorStateMigrationContext,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { describe, expect, it } from "vitest";
 import { stateMigrations } from "./doctor-contract-api.js";
 import type { PersistedWorkboardCard } from "./src/persistence-types.js";

--- a/extensions/workboard/doctor-contract-api.ts
+++ b/extensions/workboard/doctor-contract-api.ts
@@ -2,7 +2,7 @@
 import type {
   PluginDoctorStateMigration,
   PluginDoctorStateMigrationContext,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import type {
   PersistedWorkboardAttachment,
   PersistedWorkboardBoard,

--- a/extensions/xai/doctor-contract-api.ts
+++ b/extensions/xai/doctor-contract-api.ts
@@ -1,6 +1,6 @@
 // Xai doctor contract repairs plugin-owned model configuration.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor";
+import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { isLegacyXaiBuiltinModel } from "./model-definitions.js";
 
 type LegacyConfigRule = {

--- a/extensions/zalouser/doctor-contract-api.test.ts
+++ b/extensions/zalouser/doctor-contract-api.test.ts
@@ -11,7 +11,7 @@ import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime
 import type {
   OpenKeyedStoreOptions,
   PluginDoctorStateMigrationContext,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import {
   listSessionEntries,
   normalizeSessionDeliveryState,

--- a/extensions/zalouser/doctor-contract-api.ts
+++ b/extensions/zalouser/doctor-contract-api.ts
@@ -7,7 +7,7 @@ import { buildAgentSessionKey, parseAgentSessionKey } from "openclaw/plugin-sdk/
 import {
   archiveLegacyStateSource,
   type PluginDoctorStateMigration,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import {
   deleteSessionEntry,
   deliveryContextFromSession,

--- a/extensions/zalouser/src/doctor-contract.ts
+++ b/extensions/zalouser/src/doctor-contract.ts
@@ -8,7 +8,7 @@ import {
   asObjectRecord,
   hasLegacyAccountStreamingAliases,
   normalizeChannelConfigEntries,
-} from "openclaw/plugin-sdk/runtime-doctor";
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
 
 function hasLegacyZalouserGroupAllowAlias(value: unknown): boolean {
   const group = asObjectRecord(value);

--- a/extensions/zalouser/src/doctor.ts
+++ b/extensions/zalouser/src/doctor.ts
@@ -1,7 +1,7 @@
 // Zalouser plugin module implements doctor behavior.
 import type { ChannelDoctorAdapter } from "openclaw/plugin-sdk/channel-contract";
 import { createDangerousNameMatchingMutableAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
-import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor";
+import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { legacyConfigRules, normalizeCompatibilityConfig } from "./doctor-contract.js";
 import { isZalouserMutableGroupEntry } from "./security-audit.js";
 

--- a/src/plugins/doctor-contract-closure-guard.test.ts
+++ b/src/plugins/doctor-contract-closure-guard.test.ts
@@ -10,6 +10,19 @@ import { loadBundledPluginManifestRegistry } from "./manifest-registry.js";
 const REPO_ROOT = path.resolve(import.meta.dirname, "../..");
 const SOURCE_MODULE_EXTENSIONS = [".ts", ".mts", ".cts", ".js", ".mjs", ".cjs"] as const;
 const FORBIDDEN_SPECIFIER = "openclaw/plugin-sdk/agent-runtime";
+// Static value imports only; type-only and lazy dynamic imports of these stay allowed.
+const FORBIDDEN_SPECIFIER_REASONS = new Map([
+  [
+    FORBIDDEN_SPECIFIER,
+    "the deprecated broad barrel makes doctor enumeration cold-load the core agents graph; " +
+      "use openclaw/plugin-sdk/agent-scope-runtime or another focused subpath",
+  ],
+  [
+    "openclaw/plugin-sdk/runtime-doctor",
+    "the heavy doctor barrel makes doctor enumeration cold-load the state-db/kysely graph; " +
+      "use openclaw/plugin-sdk/runtime-doctor-migrations, or defer heavy helpers behind a dynamic import",
+  ],
+]);
 const LEGACY_SETUP_PROPERTIES = new Set([
   "legacyStateMigrations",
   "legacySessionSurface",
@@ -134,7 +147,8 @@ function collectStaticValueReferences(filePath: string, source: string): ModuleR
   const staticValueReferenceKeys = collectStaticValueReferenceKeys(sourceFile);
   return collectModuleReferencesFromSource(source, {
     fileName: filePath,
-    acceptSpecifier: (specifier) => specifier === FORBIDDEN_SPECIFIER || specifier.startsWith("."),
+    acceptSpecifier: (specifier) =>
+      FORBIDDEN_SPECIFIER_REASONS.has(specifier) || specifier.startsWith("."),
   }).filter((reference) =>
     staticValueReferenceKeys.has(`${reference.kind}\0${reference.line}\0${reference.specifier}`),
   );
@@ -178,7 +192,7 @@ function collectClosureEntries(): ClosureEntry[] {
   return entries;
 }
 
-function collectBroadAgentRuntimeImports(entry: ClosureEntry): string[] {
+function collectForbiddenClosureImports(entry: ClosureEntry): string[] {
   const violations: string[] = [];
   const visited = new Set<string>();
   const pending = [entry.entryPath];
@@ -191,11 +205,10 @@ function collectBroadAgentRuntimeImports(entry: ClosureEntry): string[] {
     visited.add(filePath);
     const source = fs.readFileSync(filePath, "utf8");
     for (const reference of collectStaticValueReferences(filePath, source)) {
-      if (reference.specifier === FORBIDDEN_SPECIFIER) {
+      const reason = FORBIDDEN_SPECIFIER_REASONS.get(reference.specifier);
+      if (reason) {
         violations.push(
-          `${entry.pluginId}: ${formatRepoPath(filePath)}:${reference.line} imports ${FORBIDDEN_SPECIFIER}; ` +
-            "the deprecated broad barrel makes doctor enumeration cold-load the core agents graph; " +
-            "use openclaw/plugin-sdk/agent-scope-runtime or another focused subpath",
+          `${entry.pluginId}: ${formatRepoPath(filePath)}:${reference.line} imports ${reference.specifier}; ${reason}`,
         );
         continue;
       }
@@ -228,8 +241,8 @@ describe("doctor contract import closures", () => {
     ]);
   });
 
-  it("keep the broad agent runtime barrel off doctor enumeration paths", () => {
-    const violations = collectClosureEntries().flatMap(collectBroadAgentRuntimeImports).toSorted();
+  it("keeps broad agent runtime and heavy doctor barrels off doctor enumeration paths", () => {
+    const violations = collectClosureEntries().flatMap(collectForbiddenClosureImports).toSorted();
     expect(violations).toStrictEqual([]);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Doctor contract enumeration (`src/plugins/doctor-contract-registry.ts`) cold-loads each declaring plugin's `doctor-contract-api` closure via jiti. After #120678 introduced the dependency-light `openclaw/plugin-sdk/runtime-doctor-migrations` subpath, ~40 bundled plugin doctor closures still statically value-imported the heavy `openclaw/plugin-sdk/runtime-doctor` barrel, which pulls the state-db/kysely graph (~500 modules). Measured through the same jiti loader path enumeration uses, cold-loading `runtime-doctor` costs ~4.3s versus ~72ms for `runtime-doctor-migrations` — paid per plugin during `listPluginDoctorLegacyConfigRules` / `listPluginDoctorStateMigrationEntries`.

## Why This Change Was Made

- Migrate every doctor-contract closure (and other light importers, 66 files) that only uses migration-define helpers to `openclaw/plugin-sdk/runtime-doctor-migrations`.
- `extensions/voice-call/doctor-contract-api.ts` genuinely needs `detectOpenClawStateDatabaseSchemaMigrations` / `repairOpenClawStateDatabaseSchema`: those now load via `await import` inside the async migration bodies, keeping only a type-only static `runtime-doctor` import, so enumeration never touches the state-db graph while real doctor runs pay the cost exactly when repairing.
- The matrix closure reached `createPluginStateSyncKeyedStore` through `src/matrix/credentials-read.ts`. The pure credential record shapes/normalizers moved to a new `credentials-state.ts`; `credentials-read.ts` keeps the store-backed functions (`openMatrixCredentialsStore`, `loadMatrixCredentials`, `clearMatrixCredentials`, `credentialsMatchConfig`) and all callers were repointed in the same change — no compat re-exports.
- `src/plugins/doctor-contract-closure-guard.test.ts` now carries a specifier→reason map and forbids static value imports of `openclaw/plugin-sdk/runtime-doctor` in doctor closures alongside the existing `agent-runtime` rule (type-only and lazy dynamic imports stay allowed).

Intentionally unchanged heavy value users outside enumeration closures: `extensions/matrix/auth-presence.ts`, `extensions/matrix/src/doctor.ts`, `extensions/matrix/src/matrix/credentials-read.ts`, `extensions/qa-lab/src/suite-runtime-flow.ts`.

Known follow-up (out of scope here, tracked separately): several closures remain multi-second heavy through other barrels — codex/msteams/zalouser via `openclaw/plugin-sdk/session-store-runtime` (→ session-accessor → kysely) and matrix via `openclaw/plugin-sdk/logging-core` (→ diagnostic → config → kysely); discord/slack/llm-task/reef/memory-* chains still need tracing.

## User Impact

`openclaw doctor` and any flow enumerating plugin doctor contracts loads far fewer modules per plugin; light closures now enumerate in ~100–300ms cold instead of multi-second state-db graph loads. No behavior change to migrations themselves.

## Evidence

- Guard: `node scripts/run-vitest.mjs src/plugins/doctor-contract-closure-guard.test.ts` — 2 tests pass; before extending it, the new rule caught the matrix `credentials-read` edge, which drove the split.
- Focused tests: all 19 modified/affected test files (matrix credentials/accounts/client, voice-call, codex, msteams, zalouser, reef, qqbot state-migrations, memory-core migration, etc.) green across 12 Vitest shards.
- Typecheck: `pnpm tsgo:core`, `pnpm tsgo:extensions`, `pnpm check:test-types` clean; `oxfmt --check` and `scripts/run-oxlint.mjs` clean on all 74 changed files.
- Timing (jiti loader, fresh process): `runtime-doctor` cold load 4333ms vs `runtime-doctor-migrations` 72ms; per-plugin fresh-process enumeration of light plugins (anthropic, qqbot, telegram, clickclack, copilot, …) now ~100–300ms with `require.cache` free of kysely.
- Codex autoreview (gpt-5.6-sol, high) on the full bundle: clean, no accepted/actionable findings.
