### PR TITLE
fix: prevent LaunchAgent reinstall from leaving gateway down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS LaunchAgent cutover safety:** refuse in-band gateway install and uninstall mutations, keep staging non-disruptive, and restore prior service definitions and supervision when an external reinstall fails.
 - **Control UI dashboard index refresh:** keep an open Dashboards page current after session changes, agent-scope updates, and Gateway reconnects while preserving the last safe list until replacement hydration completes. Fixes #120602. Thanks @shakkernerd.
 - **Browser extension relay security:** require canonical 64-character relay secrets and safe WebSocket pairing URLs, and recheck OpenClaw tab-group consent at the extension edge before every authority-bearing existing-tab command.
 - **Control UI debug diagnostics:** keep last-good status, health, model, and heartbeat snapshots visible when refreshes fail, show the failure inside Snapshots, isolate it from Manual RPC state, and prevent older manual calls from overwriting newer ones. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS LaunchAgent cutover safety:** refuse in-band gateway install and uninstall mutations, keep staging non-disruptive, and restore prior service definitions and supervision when an external reinstall fails.
 - **Control UI dashboard index refresh:** keep an open Dashboards page current after session changes, agent-scope updates, and Gateway reconnects while preserving the last safe list until replacement hydration completes. Fixes #120602. Thanks @shakkernerd.
 - **Browser extension relay security:** require canonical 64-character relay secrets and safe WebSocket pairing URLs, and recheck OpenClaw tab-group consent at the extension edge before every authority-bearing existing-tab command.
 - **Control UI debug diagnostics:** keep last-good status, health, model, and heartbeat snapshots visible when refreshes fail, show the failure inside Snapshots, isolate it from Manual RPC state, and prevent older manual calls from overwriting newer ones. Thanks @shakkernerd.

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -11,7 +11,7 @@ import {
   LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS,
 } from "./launchd-plist.js";
 import {
-  installLaunchAgent,
+  installLaunchAgent as installLaunchAgentImpl,
   disableCurrentOpenClawUpdateLaunchdJob,
   disableOpenClawUpdateLaunchdJob,
   findStaleOpenClawUpdateLaunchdJobs,
@@ -52,6 +52,7 @@ const state = vi.hoisted(() => ({
   bootoutCode: 1,
   serviceLoaded: true,
   serviceRunning: true,
+  serviceStates: new Map<string, "running" | "stopped" | "not-loaded">(),
   stopLeavesRunning: false,
   dirs: new Set<string>(),
   dirModes: new Map<string, number>(),
@@ -136,6 +137,23 @@ function createDefaultLaunchdEnv(): Record<string, string | undefined> {
     HOME: "/Users/test",
     OPENCLAW_PROFILE: "default",
   };
+}
+
+async function installLaunchAgent(
+  args: Parameters<typeof installLaunchAgentImpl>[0],
+): ReturnType<typeof installLaunchAgentImpl> {
+  const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+  const serviceTarget = `${domain}/ai.openclaw.gateway`;
+  if (
+    !state.files.has(resolveLaunchAgentPlistPath(args.env)) &&
+    !state.serviceStates.has(serviceTarget)
+  ) {
+    // Most install cases model a genuinely fresh definition. Cached jobs with
+    // no plist must opt in explicitly because they have no rollback artifact.
+    state.serviceLoaded = false;
+    state.serviceRunning = false;
+  }
+  return await installLaunchAgentImpl(args);
 }
 
 function createTestLaunchAgentPlist(params: {
@@ -327,6 +345,16 @@ function executeLaunchctlMock(file: string, args: string[]) {
     if (state.printError && state.printFailuresRemaining > 0) {
       state.printFailuresRemaining -= 1;
       return { stdout: "", stderr: state.printError, code: state.printCode };
+    }
+    const serviceState = state.serviceStates.get(call[1] ?? "");
+    if (serviceState === "not-loaded") {
+      return { stdout: "", stderr: "Could not find service", code: 113 };
+    }
+    if (serviceState === "stopped") {
+      return { stdout: ["state = waiting", "pid = 0"].join("\n"), stderr: "", code: 0 };
+    }
+    if (serviceState === "running") {
+      return { stdout: ["state = running", "pid = 4242"].join("\n"), stderr: "", code: 0 };
     }
     if (!state.serviceLoaded) {
       return { stdout: "", stderr: "Could not find service", code: 113 };
@@ -579,6 +607,7 @@ beforeEach(() => {
   state.fileModes.clear();
   state.fileWrites.length = 0;
   state.cleanupProtectedPids.length = 0;
+  state.serviceStates.clear();
   launchdConstantsState.legacyGatewayLabels.length = 0;
   launchctlSpawnSync.mockReset();
   launchctlSpawnSync.mockImplementation((file: string, args: string[]) => {
@@ -1570,6 +1599,8 @@ describe("launchd install", () => {
     });
     launchdConstantsState.legacyGatewayLabels.push(legacyLabel);
     state.files.set(legacyPlistPath, previousLegacy);
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    state.serviceStates.set(`${domain}/${legacyLabel}`, "running");
     state.bootstrapError = "Operation not permitted";
     state.bootstrapTransient = true;
 
@@ -1586,6 +1617,7 @@ describe("launchd install", () => {
     expect(state.serviceLoaded).toBe(true);
     expect(state.serviceRunning).toBe(true);
     expect(launchctlCommandNames()).toEqual([
+      "print",
       "print",
       "bootout",
       "unload",
@@ -1645,6 +1677,25 @@ describe("launchd install", () => {
     expect(launchctlCommandNames()).toEqual(["print"]);
   });
 
+  it("aborts before mutation when launchd has the only copy of the prior definition", async () => {
+    const env = createDefaultLaunchdEnv();
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    state.serviceStates.set(`${domain}/ai.openclaw.gateway`, "running");
+
+    await expect(
+      installLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+        programArguments: defaultProgramArguments,
+      }),
+    ).rejects.toThrow("is loaded but its plist is missing");
+
+    expect(state.serviceLoaded).toBe(true);
+    expect(state.serviceRunning).toBe(true);
+    expect(state.fileWrites).toEqual([]);
+    expect(launchctlCommandNames()).toEqual(["print"]);
+  });
+
   it("keeps a previously unloaded LaunchAgent unloaded after failed reinstall", async () => {
     const env = createDefaultLaunchdEnv();
     const plistPath = resolveLaunchAgentPlistPath(env);
@@ -1684,6 +1735,8 @@ describe("launchd install", () => {
     const plistPath = resolveLaunchAgentPlistPath(env);
     const envFilePath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway.env";
     const wrapperPath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh";
+    state.serviceLoaded = false;
+    state.serviceRunning = false;
     state.bootstrapError = "Operation not permitted";
     state.bootstrapTransient = true;
 
@@ -1724,6 +1777,8 @@ describe("launchd install", () => {
     state.files.set(wrapperPath, previousWrapper);
     state.fileModes.set(envFilePath, 0o600);
     state.fileModes.set(wrapperPath, 0o700);
+    state.serviceLoaded = true;
+    state.serviceRunning = true;
     state.bootstrapError = "Operation not permitted";
     state.bootstrapTransient = true;
 
@@ -1770,7 +1825,7 @@ describe("launchd install", () => {
     await expect(stageLaunchAgent(args)).rejects.toThrow("system ownership blocked: loaded");
 
     expect(state.fileWrites).toEqual([]);
-    expect(state.launchctlCalls).toEqual([]);
+    expect(launchctlCommandNames()).toEqual(["print"]);
   });
 
   it("rolls back a post-publication ownership race before activation", async () => {
@@ -1790,7 +1845,7 @@ describe("launchd install", () => {
 
     expect(launchdSystemState.assertNoSystemLaunchDaemonOwnership).toHaveBeenCalledTimes(3);
     expect(state.files.has(resolveLaunchAgentPlistPath(env))).toBe(false);
-    expect(state.launchctlCalls).toEqual([]);
+    expect(launchctlCommandNames()).toEqual(["print"]);
   });
 
   it("restores the previous plist when staged publication loses ownership", async () => {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -68,6 +68,9 @@ const launchdRestartHandoffState = vi.hoisted(() => ({
     (_params: unknown) => { ok: true; value: Promise<boolean> } | { ok: false; error: string }
   >(() => ({ ok: true, value: Promise.resolve(true) })),
 }));
+const launchdConstantsState = vi.hoisted(() => ({
+  legacyGatewayLabels: [] as string[],
+}));
 const launchdSystemState = vi.hoisted(() => ({
   assertNoSystemLaunchDaemonOwnership: vi.fn<(label: string) => Promise<void>>(async () => {}),
   inspectSystemLaunchDaemonOwnership: vi.fn<
@@ -409,6 +412,14 @@ vi.mock("./launchd-restart-handoff.js", () => ({
     launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff(params),
 }));
 
+vi.mock("./constants.js", async () => {
+  const actual = await vi.importActual<typeof import("./constants.js")>("./constants.js");
+  return {
+    ...actual,
+    resolveLegacyGatewayLaunchAgentLabels: () => [...launchdConstantsState.legacyGatewayLabels],
+  };
+});
+
 vi.mock("./launchd-system.js", () => ({
   assertNoSystemLaunchDaemonOwnership: (label: string) =>
     launchdSystemState.assertNoSystemLaunchDaemonOwnership(label),
@@ -568,6 +579,7 @@ beforeEach(() => {
   state.fileModes.clear();
   state.fileWrites.length = 0;
   state.cleanupProtectedPids.length = 0;
+  launchdConstantsState.legacyGatewayLabels.length = 0;
   launchctlSpawnSync.mockReset();
   launchctlSpawnSync.mockImplementation((file: string, args: string[]) => {
     const result = executeLaunchctlMock(file, args);
@@ -1404,6 +1416,22 @@ describe("launchd bootstrap repair", () => {
 });
 
 describe("launchd uninstall", () => {
+  it("refuses an in-band uninstall before bootout or plist removal", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    const previous = "RunAtLoad=true";
+    state.files.set(plistPath, previous);
+
+    await withProcessEnv({ XPC_SERVICE_NAME: "ai.openclaw.gateway" }, async () => {
+      await expect(uninstallLaunchAgent({ env, stdout: new PassThrough() })).rejects.toThrow(
+        "Refusing to uninstall LaunchAgent ai.openclaw.gateway from inside ai.openclaw.gateway",
+      );
+    });
+
+    expect(state.files.get(plistPath)).toBe(previous);
+    expect(state.launchctlCalls).toEqual([]);
+  });
+
   it("reports a surviving LaunchAgent when moving its plist to Trash is denied", async () => {
     const env = createDefaultLaunchdEnv();
     const plistPath = resolveLaunchAgentPlistPath(env);
@@ -1485,6 +1513,250 @@ describe("launchd uninstall", () => {
 });
 
 describe("launchd install", () => {
+  it("refuses an in-band reinstall before booting out its own LaunchAgent", async () => {
+    const env = createDefaultLaunchdEnv();
+
+    await withProcessEnv({ XPC_SERVICE_NAME: "ai.openclaw.gateway" }, async () => {
+      await expect(
+        installLaunchAgent({
+          env,
+          stdout: new PassThrough(),
+          programArguments: defaultProgramArguments,
+        }),
+      ).rejects.toThrow(
+        "Refusing to install LaunchAgent ai.openclaw.gateway from inside ai.openclaw.gateway",
+      );
+    });
+
+    expect(state.fileWrites).toEqual([]);
+    expect(state.launchctlCalls).toEqual([]);
+  });
+
+  it("refuses an in-band label migration before mutating either LaunchAgent", async () => {
+    const env = createDefaultLaunchdEnv();
+
+    await withProcessEnv(
+      {
+        XPC_SERVICE_NAME: "0",
+        OPENCLAW_SERVICE_MARKER: GATEWAY_SERVICE_MARKER,
+        OPENCLAW_SERVICE_KIND: GATEWAY_SERVICE_KIND,
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.legacy-gateway",
+      },
+      async () => {
+        await expect(
+          installLaunchAgent({
+            env,
+            stdout: new PassThrough(),
+            programArguments: defaultProgramArguments,
+          }),
+        ).rejects.toThrow(
+          "Refusing to install LaunchAgent ai.openclaw.gateway from inside ai.openclaw.legacy-gateway",
+        );
+      },
+    );
+
+    expect(state.fileWrites).toEqual([]);
+    expect(state.launchctlCalls).toEqual([]);
+  });
+
+  it("restores an external legacy-label owner when canonical bootstrap fails", async () => {
+    const env = createDefaultLaunchdEnv();
+    const legacyLabel = "ai.openclaw.legacy-gateway";
+    const legacyPlistPath = `${env.HOME}/Library/LaunchAgents/${legacyLabel}.plist`;
+    const targetPlistPath = resolveLaunchAgentPlistPath(env);
+    const previousLegacy = createTestLaunchAgentPlist({
+      label: legacyLabel,
+      programArguments: ["/legacy/node", "/legacy/openclaw.mjs", "gateway"],
+    });
+    launchdConstantsState.legacyGatewayLabels.push(legacyLabel);
+    state.files.set(legacyPlistPath, previousLegacy);
+    state.bootstrapError = "Operation not permitted";
+    state.bootstrapTransient = true;
+
+    await expect(
+      installLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+        programArguments: defaultProgramArguments,
+      }),
+    ).rejects.toThrow("launchctl bootstrap failed: Operation not permitted");
+
+    expect(state.files.get(legacyPlistPath)).toBe(previousLegacy);
+    expect(state.files.has(targetPlistPath)).toBe(false);
+    expect(state.serviceLoaded).toBe(true);
+    expect(state.serviceRunning).toBe(true);
+    expect(launchctlCommandNames()).toEqual([
+      "print",
+      "bootout",
+      "unload",
+      "bootout",
+      "unload",
+      "enable",
+      "bootstrap",
+      "bootout",
+      "enable",
+      "bootstrap",
+    ]);
+  });
+
+  it("stages a canonical plist without retiring a legacy LaunchAgent", async () => {
+    const env = createDefaultLaunchdEnv();
+    const legacyLabel = "ai.openclaw.legacy-gateway";
+    const legacyPlistPath = `${env.HOME}/Library/LaunchAgents/${legacyLabel}.plist`;
+    const previousLegacy = createTestLaunchAgentPlist({
+      label: legacyLabel,
+      programArguments: ["/legacy/node", "/legacy/openclaw.mjs", "gateway"],
+    });
+    launchdConstantsState.legacyGatewayLabels.push(legacyLabel);
+    state.files.set(legacyPlistPath, previousLegacy);
+
+    await stageLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: defaultProgramArguments,
+    });
+
+    expect(state.files.get(legacyPlistPath)).toBe(previousLegacy);
+    expect(state.files.has(resolveLaunchAgentPlistPath(env))).toBe(true);
+    expect(state.launchctlCalls).toEqual([]);
+  });
+
+  it("aborts before mutation when prior LaunchAgent supervision is ambiguous", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    const previous = createTestLaunchAgentPlist({
+      label: "ai.openclaw.gateway",
+      programArguments: ["/previous/node", "/previous/openclaw.mjs", "gateway"],
+    });
+    state.files.set(plistPath, previous);
+    state.printError = "launchctl print permission denied";
+    state.printFailuresRemaining = 1;
+
+    await expect(
+      installLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+        programArguments: defaultProgramArguments,
+      }),
+    ).rejects.toThrow("could not determine whether");
+
+    expect(state.files.get(plistPath)).toBe(previous);
+    expect(state.fileWrites).toEqual([]);
+    expect(launchctlCommandNames()).toEqual(["print"]);
+  });
+
+  it("keeps a previously unloaded LaunchAgent unloaded after failed reinstall", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    const previous = createTestLaunchAgentPlist({
+      label: "ai.openclaw.gateway",
+      programArguments: ["/previous/node", "/previous/openclaw.mjs", "gateway"],
+    });
+    state.files.set(plistPath, previous);
+    state.serviceLoaded = false;
+    state.serviceRunning = false;
+    state.bootstrapError = "Operation not permitted";
+    state.bootstrapTransient = true;
+
+    await expect(
+      installLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+        programArguments: defaultProgramArguments,
+      }),
+    ).rejects.toThrow("launchctl bootstrap failed: Operation not permitted");
+
+    expect(state.files.get(plistPath)).toBe(previous);
+    expect(state.serviceLoaded).toBe(false);
+    expect(state.serviceRunning).toBe(false);
+    expect(launchctlCommandNames()).toEqual([
+      "print",
+      "bootout",
+      "unload",
+      "enable",
+      "bootstrap",
+      "bootout",
+    ]);
+  });
+
+  it("removes generated artifacts after a failed fresh install", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    const envFilePath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway.env";
+    const wrapperPath =
+      "/Users/test/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh";
+    state.bootstrapError = "Operation not permitted";
+    state.bootstrapTransient = true;
+
+    await expect(
+      installLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+        programArguments: defaultProgramArguments,
+        environment: { OPENCLAW_GATEWAY_PORT: "19000" },
+      }),
+    ).rejects.toThrow("launchctl bootstrap failed: Operation not permitted");
+
+    expect(state.files.has(plistPath)).toBe(false);
+    expect(state.files.has(envFilePath)).toBe(false);
+    expect(state.files.has(wrapperPath)).toBe(false);
+  });
+
+  it("restores the exact prior plist and supervision after external bootstrap failure", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    const envFilePath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway.env";
+    const wrapperPath =
+      "/Users/test/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh";
+    const previousEnv = "export OPENCLAW_GATEWAY_PORT='18789'\n";
+    const previousWrapper = "#!/bin/sh\n. \"$1\"\nshift\nexec \"$@\"\n";
+    const previous = createTestLaunchAgentPlist({
+      label: "ai.openclaw.gateway",
+      programArguments: [
+        "/bin/sh",
+        wrapperPath,
+        envFilePath,
+        "/previous/node",
+        "/previous/openclaw.mjs",
+        "gateway",
+      ],
+    });
+    state.files.set(plistPath, previous);
+    state.files.set(envFilePath, previousEnv);
+    state.files.set(wrapperPath, previousWrapper);
+    state.fileModes.set(envFilePath, 0o600);
+    state.fileModes.set(wrapperPath, 0o700);
+    state.bootstrapError = "Operation not permitted";
+    state.bootstrapTransient = true;
+
+    await expect(
+      installLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+        programArguments: defaultProgramArguments,
+        environment: { OPENCLAW_GATEWAY_PORT: "19000" },
+      }),
+    ).rejects.toThrow("launchctl bootstrap failed: Operation not permitted");
+
+    expect(state.files.get(plistPath)).toBe(previous);
+    expect(state.files.get(envFilePath)).toBe(previousEnv);
+    expect(state.files.get(wrapperPath)).toBe(previousWrapper);
+    expect(state.fileModes.get(envFilePath)).toBe(0o600);
+    expect(state.fileModes.get(wrapperPath)).toBe(0o700);
+    expect(state.serviceLoaded).toBe(true);
+    expect(state.serviceRunning).toBe(true);
+    expect(launchctlCommandNames()).toEqual([
+      "print",
+      "bootout",
+      "unload",
+      "enable",
+      "bootstrap",
+      "bootout",
+      "enable",
+      "bootstrap",
+    ]);
+  });
+
   it("refuses install and stage before any user LaunchAgent mutation", async () => {
     const env = createDefaultLaunchdEnv();
     launchdSystemState.assertNoSystemLaunchDaemonOwnership.mockRejectedValue(

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1683,8 +1683,7 @@ describe("launchd install", () => {
     const env = createDefaultLaunchdEnv();
     const plistPath = resolveLaunchAgentPlistPath(env);
     const envFilePath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway.env";
-    const wrapperPath =
-      "/Users/test/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh";
+    const wrapperPath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh";
     state.bootstrapError = "Operation not permitted";
     state.bootstrapTransient = true;
 
@@ -1706,10 +1705,9 @@ describe("launchd install", () => {
     const env = createDefaultLaunchdEnv();
     const plistPath = resolveLaunchAgentPlistPath(env);
     const envFilePath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway.env";
-    const wrapperPath =
-      "/Users/test/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh";
+    const wrapperPath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh";
     const previousEnv = "export OPENCLAW_GATEWAY_PORT='18789'\n";
-    const previousWrapper = "#!/bin/sh\n. \"$1\"\nshift\nexec \"$@\"\n";
+    const previousWrapper = '#!/bin/sh\n. "$1"\nshift\nexec "$@"\n';
     const previous = createTestLaunchAgentPlist({
       label: "ai.openclaw.gateway",
       programArguments: [

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1390,16 +1390,21 @@ async function snapshotLaunchAgentLoadedState(
   plistContents: Buffer | null,
   serviceTarget: string,
 ): Promise<boolean> {
-  if (plistContents === null) {
-    return false;
-  }
   const probe = await probeLaunchAgentState(serviceTarget);
   if (probe.state === "unknown") {
     throw new Error(
       `launchctl print could not determine whether ${serviceTarget} is loaded: ${probe.detail ?? "unknown error"}`,
     );
   }
-  return probe.state !== "not-loaded";
+  const loaded = probe.state !== "not-loaded";
+  if (loaded && plistContents === null) {
+    // launchd can retain a definition after its plist is deleted. Booting that
+    // job out would destroy the only copy, so no exact rollback is possible.
+    throw new Error(
+      `LaunchAgent ${serviceTarget} is loaded but its plist is missing; refusing an install that cannot restore the current definition if activation fails.`,
+    );
+  }
+  return loaded;
 }
 
 async function restoreLaunchAgentOwnedFile(params: {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -970,6 +970,7 @@ export async function uninstallLaunchAgent({
   env,
   stdout,
 }: GatewayServiceManageArgs): Promise<void> {
+  assertExternalLaunchAgentMutation(env, "uninstall");
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel(env);
   const plistPath = resolveLaunchAgentPlistPath(env);
@@ -1298,18 +1299,6 @@ async function writeLaunchAgentPlist({
   const { logDir, stdoutPath } = resolveGatewaySupervisorLogPaths(env, { platform: "darwin" });
   await ensureSecureDirectory(logDir);
 
-  const domain = resolveGuiDomain();
-  for (const legacyLabel of resolveLegacyGatewayLaunchAgentLabels(env.OPENCLAW_PROFILE)) {
-    const legacyPlistPath = resolveLaunchAgentPlistPathForLabel(env, legacyLabel);
-    await execLaunchctl(["bootout", domain, legacyPlistPath]);
-    await execLaunchctl(["unload", legacyPlistPath]);
-    try {
-      await fs.unlink(legacyPlistPath);
-    } catch {
-      // ignore
-    }
-  }
-
   const plistPath = resolveLaunchAgentPlistPathForLabel(env, label);
   const home = toPosixPath(resolveHomeDir(env));
   const libraryDir = path.posix.join(home, "Library");
@@ -1340,6 +1329,34 @@ async function writeLaunchAgentPlist({
   return { plistPath, stdoutPath };
 }
 
+function currentGatewayLaunchAgentLabel(
+  targetEnv: Record<string, string | undefined>,
+): string | undefined {
+  const configuredCurrentLabel = process.env.OPENCLAW_LAUNCHD_LABEL?.trim();
+  const candidates = new Set([
+    resolveLaunchAgentLabel(targetEnv),
+    ...(configuredCurrentLabel ? [assertValidLaunchAgentLabel(configuredCurrentLabel)] : []),
+  ]);
+  return [...candidates].find((label) =>
+    isCurrentProcessLaunchdServiceLabel(label, process.env, {
+      allowConfiguredLabelFallback: false,
+    }),
+  );
+}
+
+function assertExternalLaunchAgentMutation(
+  env: Record<string, string | undefined>,
+  action: "install" | "uninstall",
+): void {
+  const currentLabel = currentGatewayLaunchAgentLabel(env);
+  if (!currentLabel) {
+    return;
+  }
+  throw new Error(
+    `Refusing to ${action} LaunchAgent ${resolveLaunchAgentLabel(env)} from inside ${currentLabel}; run this command from an external shell.`,
+  );
+}
+
 export async function stageLaunchAgent({
   stdout,
   ...args
@@ -1356,29 +1373,261 @@ export async function stageLaunchAgent({
   return { plistPath };
 }
 
-async function activateLaunchAgent(params: { env: GatewayServiceEnv; plistPath: string }) {
+type LaunchAgentInstallSnapshot = {
+  plistContents: Buffer | null;
+  envFileContents: Buffer | null;
+  wrapperContents: Buffer | null;
+  legacy: Array<{
+    label: string;
+    plistPath: string;
+    contents: Buffer | null;
+    loaded: boolean;
+  }>;
+  loaded: boolean;
+};
+
+async function snapshotLaunchAgentLoadedState(
+  plistContents: Buffer | null,
+  serviceTarget: string,
+): Promise<boolean> {
+  if (plistContents === null) {
+    return false;
+  }
+  const probe = await probeLaunchAgentState(serviceTarget);
+  if (probe.state === "unknown") {
+    throw new Error(
+      `launchctl print could not determine whether ${serviceTarget} is loaded: ${probe.detail ?? "unknown error"}`,
+    );
+  }
+  return probe.state !== "not-loaded";
+}
+
+async function restoreLaunchAgentOwnedFile(params: {
+  path: string;
+  contents: Buffer | null;
+  mode: number;
+}): Promise<void> {
+  if (params.contents === null) {
+    await fs.unlink(params.path).catch((error: unknown) => {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    });
+    return;
+  }
+  const temporaryPath = `${params.path}.openclaw-${randomUUID()}.rollback`;
+  try {
+    await fs.writeFile(temporaryPath, params.contents.toString("utf8"), {
+      flag: "wx",
+      mode: params.mode,
+    });
+    await fs.rename(temporaryPath, params.path);
+    await fs.chmod(params.path, params.mode).catch(() => undefined);
+  } finally {
+    await fs.unlink(temporaryPath).catch(() => undefined);
+  }
+}
+
+async function restoreLaunchAgentInstallArtifacts(params: {
+  env: GatewayServiceEnv;
+  label: string;
+  plistPath: string;
+  snapshot: LaunchAgentInstallSnapshot;
+}): Promise<void> {
+  await restoreLaunchAgentOwnedFile({
+    path: resolveLaunchAgentEnvFilePath(params.env, params.label),
+    contents: params.snapshot.envFileContents,
+    mode: LAUNCH_AGENT_ENV_FILE_MODE,
+  });
+  await restoreLaunchAgentOwnedFile({
+    path: resolveLaunchAgentEnvWrapperPath(params.env, params.label),
+    contents: params.snapshot.wrapperContents,
+    mode: LAUNCH_AGENT_ENV_WRAPPER_MODE,
+  });
+  for (const legacy of params.snapshot.legacy) {
+    await restoreLaunchAgentOwnedFile({
+      path: legacy.plistPath,
+      contents: legacy.contents,
+      mode: LAUNCH_AGENT_PLIST_MODE,
+    });
+  }
+  if (params.snapshot.plistContents === null) {
+    await fs.unlink(params.plistPath).catch((error: unknown) => {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    });
+    return;
+  }
+  await publishLaunchAgentPlist({
+    label: params.label,
+    plistPath: params.plistPath,
+    contents: params.snapshot.plistContents.toString("utf8"),
+  });
+}
+
+async function restoreLaunchAgentInstall(params: {
+  domain: string;
+  env: GatewayServiceEnv;
+  label: string;
+  plistPath: string;
+  snapshot: LaunchAgentInstallSnapshot;
+}): Promise<void> {
+  const serviceTarget = `${params.domain}/${params.label}`;
+  const bootout = await execLaunchctl(["bootout", serviceTarget]);
+  if (bootout.code !== 0 && !isLaunchctlNotLoaded(bootout)) {
+    throw new Error(`launchctl bootout failed: ${formatLaunchctlResultDetail(bootout)}`);
+  }
+  await restoreLaunchAgentInstallArtifacts({
+    env: params.env,
+    label: params.label,
+    plistPath: params.plistPath,
+    snapshot: params.snapshot,
+  });
+  if (params.snapshot.loaded && params.snapshot.plistContents !== null) {
+    await bootstrapLaunchAgentOrThrow({
+      domain: params.domain,
+      serviceTarget,
+      plistPath: params.plistPath,
+      actionHint: "openclaw gateway start",
+      retryPendingTeardown: true,
+    });
+  }
+  for (const legacy of params.snapshot.legacy) {
+    if (!legacy.loaded || legacy.contents === null) {
+      continue;
+    }
+    await bootstrapLaunchAgentOrThrow({
+      domain: params.domain,
+      serviceTarget: `${params.domain}/${legacy.label}`,
+      plistPath: legacy.plistPath,
+      actionHint: "openclaw gateway start",
+      retryPendingTeardown: true,
+    });
+  }
+}
+
+async function deactivateLaunchAgentDefinition(domain: string, plistPath: string): Promise<void> {
+  for (const args of [
+    ["bootout", domain, plistPath],
+    ["unload", plistPath],
+  ]) {
+    const result = await execLaunchctl(args);
+    if (result.code !== 0 && !isLaunchctlNotLoaded(result)) {
+      throw new Error(
+        `launchctl ${args[0]} failed during LaunchAgent install: ${formatLaunchctlResultDetail(result)}`,
+      );
+    }
+  }
+}
+
+async function activateLaunchAgent(params: {
+  env: GatewayServiceEnv;
+  plistPath: string;
+  snapshot: LaunchAgentInstallSnapshot;
+}) {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel(params.env);
-  // Recheck immediately before activation so a system daemon installed after
-  // the plist write cannot race us into two KeepAlive managers.
-  await assertNoSystemLaunchDaemonOwnership(label);
-
-  await execLaunchctl(["bootout", domain, params.plistPath]);
-  await execLaunchctl(["unload", params.plistPath]);
-  // launchd can persist "disabled" state even after bootout + plist removal; clear it before bootstrap.
-  await bootstrapLaunchAgentOrThrow({
-    domain,
-    serviceTarget: `${domain}/${label}`,
-    plistPath: params.plistPath,
-    actionHint: "openclaw gateway install --force",
-  });
+  try {
+    // Recheck immediately before activation so a system daemon installed after
+    // the plist write cannot race us into two KeepAlive managers.
+    await assertNoSystemLaunchDaemonOwnership(label);
+    for (const legacy of params.snapshot.legacy) {
+      await deactivateLaunchAgentDefinition(domain, legacy.plistPath);
+    }
+    await deactivateLaunchAgentDefinition(domain, params.plistPath);
+    // launchd can persist "disabled" state even after bootout + plist removal; clear it before bootstrap.
+    await bootstrapLaunchAgentOrThrow({
+      domain,
+      serviceTarget: `${domain}/${label}`,
+      plistPath: params.plistPath,
+      actionHint: "openclaw gateway install --force",
+      retryPendingTeardown: true,
+    });
+    for (const legacy of params.snapshot.legacy) {
+      await fs.unlink(legacy.plistPath).catch((error: unknown) => {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
+      });
+    }
+  } catch (error) {
+    try {
+      await restoreLaunchAgentInstall({
+        domain,
+        env: params.env,
+        label,
+        plistPath: params.plistPath,
+        snapshot: params.snapshot,
+      });
+    } catch (rollbackError) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`${detail}\nThe previous LaunchAgent supervision could not be restored.`, {
+        cause: rollbackError,
+      });
+    }
+    throw error;
+  }
 }
 
 export async function installLaunchAgent(
   args: GatewayServiceInstallArgs,
 ): Promise<{ plistPath: string }> {
-  const { plistPath, stdoutPath } = await writeLaunchAgentPlist(args);
-  await activateLaunchAgent({ env: args.env, plistPath });
+  assertExternalLaunchAgentMutation(args.env, "install");
+  const targetPlistPath = resolveLaunchAgentPlistPath(args.env);
+  const previousContents = await readExistingLaunchAgentPlist(targetPlistPath);
+  const label = resolveLaunchAgentLabel(args.env);
+  const domain = resolveGuiDomain();
+  // Plist, generated environment files, and launchd registration form one cutover.
+  // Capture every prior owner before publication so any later failure can restore it.
+  const legacy = await Promise.all(
+    resolveLegacyGatewayLaunchAgentLabels(args.env.OPENCLAW_PROFILE).map(async (legacyLabel) => {
+      const plistPath = resolveLaunchAgentPlistPathForLabel(args.env, legacyLabel);
+      const contents = await readExistingLaunchAgentPlist(plistPath);
+      return {
+        label: legacyLabel,
+        plistPath,
+        contents,
+        loaded: await snapshotLaunchAgentLoadedState(contents, `${domain}/${legacyLabel}`),
+      };
+    }),
+  );
+  const snapshot: LaunchAgentInstallSnapshot = {
+    plistContents: previousContents,
+    envFileContents: await readExistingLaunchAgentPlist(
+      resolveLaunchAgentEnvFilePath(args.env, label),
+    ),
+    wrapperContents: await readExistingLaunchAgentPlist(
+      resolveLaunchAgentEnvWrapperPath(args.env, label),
+    ),
+    legacy,
+    loaded: await snapshotLaunchAgentLoadedState(previousContents, `${domain}/${label}`),
+  };
+  let plistPath: string;
+  let stdoutPath: string;
+  try {
+    ({ plistPath, stdoutPath } = await writeLaunchAgentPlist(args));
+  } catch (error) {
+    try {
+      await restoreLaunchAgentInstallArtifacts({
+        env: args.env,
+        label,
+        plistPath: targetPlistPath,
+        snapshot,
+      });
+    } catch (rollbackError) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`${detail}\nThe previous LaunchAgent files could not be restored.`, {
+        cause: rollbackError,
+      });
+    }
+    throw error;
+  }
+  await activateLaunchAgent({
+    env: args.env,
+    plistPath,
+    snapshot,
+  });
   // `bootstrap` already loads RunAtLoad agents. Avoid `kickstart -k` here:
   // on slow macOS guests it SIGTERMs the freshly booted gateway and pushes the
   // real listener startup past setup's health deadline.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS Gateway service installation could leave the Gateway unsupervised when `gateway install --force` was invoked from inside that same LaunchAgent, or when external activation failed after the existing job was booted out.

Related operational evidence came from a clawstudio ownership incident, although that incident's direct outage path was the separate built-in mutable-update handoff. Review of the sibling LaunchAgent lifecycle exposed this independently reproducible defect.

## Why This Change Was Made

LaunchAgent install now refuses install or uninstall from its own launchd ancestry before any filesystem or launchctl mutation. External install treats the plist, generated environment file, generated wrapper, legacy definitions, and their loaded states as one transaction: it snapshots them before publication, activates the candidate, and restores the exact previous artifacts and supervision if any mutation fails. Staging remains definition-only and does not retire a live legacy job.

The activation owner now rejects ambiguous `launchctl print` state and checks real bootout/unload failures instead of proceeding with an unprovable prior state.

Production LOC: +276/-27 (net +249) | Tests: +272/-0

The production growth implements the missing lifecycle ownership transaction and removes the service-loss class across canonical and legacy LaunchAgent paths.

Provenance: the inline activation path was introduced by commit `5c9e4cd30a1ee9189f5f7d9d6dfa75b9a3a98ad8` on 2026-03-23 by Peter Steinberger; no associated PR is recorded by GitHub.

## User Impact

Operators can no longer accidentally self-terminate the Gateway by reinstalling or uninstalling its LaunchAgent from an in-band agent/tool command. Failed external reinstalls restore the prior runnable service instead of leaving launchd with no job to respawn.

## Evidence

- Exact rebased head: `f500a7e7ae1135240ce60df775532d9aa46c21fc`
- Blacksmith Testbox `tbx_01kzhhjg7xbpnbgd4v8f9perwy` (`swift-barnacle`), [run 31277382157](https://github.com/openclaw/openclaw/actions/runs/31277382157)
  - `pnpm test src/daemon/launchd.test.ts`
  - 121 passed, 24 macOS/platform skips, 0 failed
- Pre-rebase independent Testbox confirmation: `tbx_01kzhg1sy73gdajptc0gyzehtk`, [run 31276315535](https://github.com/openclaw/openclaw/actions/runs/31276315535), same 121/24 result
- `git diff --check origin/main...HEAD`
- Autoreview after rebase: clean, no accepted/actionable findings, confidence 0.96

Regression coverage includes canonical and configured-old-label in-band refusal, in-band uninstall refusal, stage non-mutation, ambiguous launchd state, loaded and unloaded rollback, fresh-install artifact cleanup, generated env/wrapper restoration, and legacy supervision restoration.

ClawSweeper was explicitly waived for this repair.
