### PR TITLE
ci: extend watchdog for cold migration proofs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1196,7 +1196,9 @@ jobs:
       - name: Verify built Doctor plugin index persistence
         run: |
           if [[ -f test/scripts/doctor-config-preflight-plugin-index.built-cli.e2e.test.ts ]]; then
-            node scripts/run-vitest.mjs run \
+            # Cold hosted runners can spend over five minutes in E2E setup before
+            # this proof's own bounded test can report a result.
+            env OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=660000 node scripts/run-vitest.mjs run \
               --config test/vitest/vitest.e2e.config.ts \
               test/scripts/doctor-config-preflight-plugin-index.built-cli.e2e.test.ts
           else
@@ -2611,7 +2613,9 @@ jobs:
               if [ ! -f test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts ]; then
                 echo "[skip] SQLite sessions/transcripts flip proof is not present in this checkout"
               else
-                run_check "sqlite sessions/transcripts flip proof" node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts
+                # This lane owns a 420-second E2E case plus cold hosted-runner setup;
+                # keep the global watchdog strict and scope compatibility headroom here.
+                run_check "sqlite sessions/transcripts flip proof" env OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=660000 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts
               fi
               ;;
             extension-package-boundary)

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -5174,8 +5174,25 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(proofStep.run).toContain(
       "test/scripts/doctor-config-preflight-plugin-index.built-cli.e2e.test.ts",
     );
+    expect(proofStep.run).toContain(
+      "env OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=660000 node scripts/run-vitest.mjs run",
+    );
     expect(proofStep.run).toContain("--config test/vitest/vitest.e2e.config.ts");
     expect(proofStep.run).toContain("Selected target predates");
+  });
+
+  it("scopes cold-runner watchdog headroom to the SQLite flip proof", () => {
+    const workflow = readCiWorkflow();
+    const additionalJob = workflow.jobs["check-additional-shard"];
+    const runStep = additionalJob.steps.find(
+      (step: WorkflowStep) => step.name === "Run additional check shard",
+    );
+
+    expect(runStep.run).toContain("sqlite-session-flip-proof)");
+    expect(runStep.run).toContain(
+      'run_check "sqlite sessions/transcripts flip proof" env OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=660000 node scripts/run-vitest.mjs run',
+    );
+    expect(runStep.env.OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS).toBeUndefined();
   });
 
   it("restores the dist build cache before building and saves only cache misses", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI problem where cold GitHub-hosted fork runners could terminate the SQLite session migration proof or built Doctor plugin-index migration proof after 300 seconds of quiet E2E setup, even though the bounded proof still had legitimate work and later passed unchanged on faster runners.

## Why This Change Was Made

The two affected invocations now use the existing 660-second compatibility watchdog budget. The override stays at the workflow call sites: global Vitest watchdog defaults, test-case timeouts, product code, SQLite behavior, and unrelated E2E lanes are unchanged.

## User Impact

There is no product behavior change. Contributor PRs should no longer get false exit-143 failures from these two cold migration-proof lanes, while genuinely silent tests elsewhere retain the strict default watchdog.

## Evidence

- Before: #119511 run 31269509452 and #119520 run 31271225251 each showed 30-second no-output heartbeats followed by SIGTERM at exactly 300,000 ms in the SQLite proof; their reruns reproduced it.
- Sibling before: both reruns also killed `Verify built Doctor plugin index persistence` at exactly 300,000 ms before a test result.
- Unchanged proof: current-main runs 31275486675 and 31275569164 passed the SQLite case in 89.69s and 96.05s after cold setup, confirming the failure was runner-speed-sensitive rather than a SQLite assertion.
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts`: 108 passed, 2 skipped.
- Changed gate fallback completed conflict, attribution, dependency, formatting, patch, declaration, test-root typecheck, and script-lint lanes. Remote Testbox was unavailable because the Blacksmith CLI is not installed; direct AWS Crabbox was unavailable because no broker login is configured.
- `pnpm check:workflows` reached the pinned workflow hook but this Mac's Python 3.9.6 is below the hook's Python 3.10 minimum; exact-head CI is the authoritative workflow check.
- Fresh Codex autoreview: clean, no actionable findings; TruffleHog clean.

The unrelated Bun launcher rerun is intentionally not covered: it was not terminated with exit 143 and instead completed setup before reporting that no test files were found.
