### PR TITLE
fix(daemon): stop stale service version warnings after upgrades

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
@@ -680,7 +680,7 @@ struct GatewayProcessManagerTests {
                   "loaded":true,
                   "runtime":{"status":"running","pid":4242},
                   "command":{"programArguments":["openclaw","gateway","--port","\(port)"]},
-                  "configAudit":{"ok":false,"issues":[{"code":"gateway-service-version-mismatch"}]}
+                  "configAudit":{"ok":false,"issues":[{"code":"gateway-entrypoint-mismatch"}]}
                 }}
                 """,
             ]

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -205,7 +205,7 @@ Write a unit by hand only for a custom setup. Minimal user-unit example
 
 ```ini
 [Unit]
-Description=OpenClaw Gateway (profile: <profile>, v<version>)
+Description=OpenClaw Gateway (profile: <profile>)
 After=network-online.target
 Wants=network-online.target
 StartLimitBurst=5

--- a/extensions/xai/src/xai-user-agent.test.ts
+++ b/extensions/xai/src/xai-user-agent.test.ts
@@ -12,18 +12,6 @@ describe("xaiUserAgent", () => {
     expect(xaiUserAgent()).toBe("openclaw/2026.3.22");
   });
 
-  it("falls back to OPENCLAW_SERVICE_VERSION when OPENCLAW_VERSION is unset", () => {
-    vi.stubEnv("OPENCLAW_VERSION", "");
-    vi.stubEnv("OPENCLAW_SERVICE_VERSION", "2026.3.99");
-    // OPENCLAW_VERSION from the SDK is the bundled VERSION constant. In a dev
-    // checkout it resolves to a real semver, so we cannot deterministically
-    // assert "unknown" here. We just lock the prefix to ensure the env-first
-    // contract holds whenever the bundle resolves to 0.0.0/empty.
-    const result = xaiUserAgent();
-    expect(result.startsWith("openclaw/")).toBe(true);
-    expect(result).not.toBe("openclaw/");
-  });
-
   it("returns the openclaw/<version> shape", () => {
     vi.stubEnv("OPENCLAW_VERSION", "2026.5.16");
     expect(xaiUserAgent()).toMatch(/^openclaw\/\d+\.\d+\.\d+$/u);

--- a/extensions/xai/src/xai-user-agent.ts
+++ b/extensions/xai/src/xai-user-agent.ts
@@ -21,11 +21,7 @@ function resolveXaiUserAgentVersion(): string {
   if (packageVersion && packageVersion !== UNUSABLE_PACKAGE_VERSION) {
     return packageVersion;
   }
-  return (
-    trimToUndefined(process.env.OPENCLAW_SERVICE_VERSION) ??
-    trimToUndefined(process.env.npm_package_version) ??
-    FALLBACK_VERSION
-  );
+  return trimToUndefined(process.env.npm_package_version) ?? FALLBACK_VERSION;
 }
 
 export function xaiUserAgent(): string {

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -652,17 +652,16 @@ describe("runServiceRestart token drift", () => {
   it("warns in json when an already-running gateway definition needs repair", async () => {
     service.readRuntime.mockResolvedValue({ status: "running", pid: 4242 });
     service.readCommand.mockResolvedValue({
-      programArguments: ["openclaw", "gateway", "run"],
-      environment: { OPENCLAW_SERVICE_VERSION: "2026.4.24" },
+      programArguments: ["openclaw", "gateway", "--port", "18789"],
     });
 
-    await runServiceStart(createServiceRunArgs());
+    await runServiceStart({ ...createServiceRunArgs(), expectedPort: 19_001 });
 
     const payload = readJsonLog<{ result?: string; warnings?: string[] }>();
     expect(payload.result).toBe("already-running");
     expect(payload.warnings).toEqual([
       expect.stringMatching(
-        /^Gateway service already running, but its installed service definition needs repair: service was installed by OpenClaw 2026\.4\.24, current CLI is .+; run `openclaw gateway restart` to apply\.$/,
+        /^Gateway service already running, but its installed service definition needs repair: service port 18789 does not match current gateway config port 19001; run `openclaw gateway restart` to apply\.$/,
       ),
     ]);
     expect(service.start).not.toHaveBeenCalled();
@@ -671,14 +670,14 @@ describe("runServiceRestart token drift", () => {
   it("prints one warning line when an already-running gateway definition needs repair", async () => {
     service.readRuntime.mockResolvedValue({ status: "running", pid: 4242 });
     service.readCommand.mockResolvedValue({
-      programArguments: ["openclaw", "gateway", "run"],
-      environment: { OPENCLAW_SERVICE_VERSION: "2026.4.24" },
+      programArguments: ["openclaw", "gateway", "--port", "18789"],
     });
 
     await runServiceStart({
       serviceNoun: "Gateway",
       service,
       renderStartHints: () => [],
+      expectedPort: 19_001,
     });
 
     const repairWarnings = runtimeLogs.filter((line) =>
@@ -762,10 +761,9 @@ describe("runServiceRestart token drift", () => {
     );
   });
 
-  it("repairs stale loaded services during start before reporting success", async () => {
+  it("repairs loaded services with port drift during start before reporting success", async () => {
     service.readCommand.mockResolvedValue({
-      programArguments: ["openclaw", "gateway"],
-      environment: { OPENCLAW_SERVICE_VERSION: "2026.4.24" },
+      programArguments: ["openclaw", "gateway", "--port", "18789"],
     });
     type RepairLoadedService = NonNullable<
       Parameters<typeof runServiceStart>[0]["repairLoadedService"]
@@ -777,7 +775,7 @@ describe("runServiceRestart token drift", () => {
       return {
         result: "started" as const,
         message: "Gateway service definition repaired and started.",
-        warnings: ["service was installed by OpenClaw 2026.4.24, current CLI is 2026.5.2"],
+        warnings: ["service port 18789 does not match current gateway config port 19001"],
         loaded: true,
       };
     });
@@ -788,6 +786,7 @@ describe("runServiceRestart token drift", () => {
       renderStartHints: () => [],
       opts: { json: true },
       repairLoadedService,
+      expectedPort: 19_001,
     });
 
     expect(repairLoadedService).toHaveBeenCalledTimes(1);
@@ -802,20 +801,21 @@ describe("runServiceRestart token drift", () => {
     expect(payload.message).toBe("Gateway service definition repaired and started.");
     expect(payload.warnings).toEqual(
       expect.arrayContaining([
-        expect.stringContaining("service was installed by OpenClaw"),
+        expect.stringContaining("service port 18789"),
         expect.stringContaining("custom behavior and will be overwritten"),
       ]),
     );
     expect(payload.service?.loaded).toBe(true);
   });
 
-  it("fails start with an install hint when a stale loaded service has no repair callback", async () => {
+  it("fails start with an install hint when port drift has no repair callback", async () => {
     service.readCommand.mockResolvedValue({
-      programArguments: ["openclaw", "gateway"],
-      environment: { OPENCLAW_SERVICE_VERSION: "2026.4.24" },
+      programArguments: ["openclaw", "gateway", "--port", "18789"],
     });
 
-    await expect(runServiceStart(createServiceRunArgs())).rejects.toThrow("__exit__:1");
+    await expect(
+      runServiceStart({ ...createServiceRunArgs(), expectedPort: 19_001 }),
+    ).rejects.toThrow("__exit__:1");
 
     const payload = readJsonLog<{ ok?: boolean; error?: string; hints?: string[] }>();
     expect(payload.ok).toBe(false);

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -434,7 +434,7 @@ describe("runDaemonRestart health checks", () => {
         json: true,
         stdout: process.stdout,
         state: {},
-        issues: [{ code: "version-mismatch", message: "old service" }],
+        issues: [{ code: "port-mismatch", message: "service port is stale" }],
       });
       await params.postRestartCheck?.({
         json: true,
@@ -513,7 +513,7 @@ describe("runDaemonRestart health checks", () => {
     expect(runServiceRestart).not.toHaveBeenCalled();
   });
 
-  it("repairs stale loaded service definitions from gateway start", async () => {
+  it("repairs loaded service definitions with port drift from gateway start", async () => {
     repairLoadedGatewayServiceForStart.mockResolvedValue({
       result: "started",
       message: "Gateway service definition repaired and started.",
@@ -531,8 +531,8 @@ describe("runDaemonRestart health checks", () => {
         await params.repairLoadedService?.({
           json: true,
           stdout: process.stdout,
-          state: { command: { environment: { OPENCLAW_SERVICE_VERSION: "2026.4.24" } } },
-          issues: [{ code: "version-mismatch", message: "old service" }],
+          state: { command: { environment: { OPENCLAW_GATEWAY_PORT: "18789" } } },
+          issues: [{ code: "port-mismatch", message: "service port is stale" }],
         });
       },
     );
@@ -551,10 +551,10 @@ describe("runDaemonRestart health checks", () => {
     expect(repairParams.service).toBe(service);
     expect(repairParams.json).toBe(true);
     expect(repairParams.state?.command?.environment).toEqual({
-      OPENCLAW_SERVICE_VERSION: "2026.4.24",
+      OPENCLAW_GATEWAY_PORT: "18789",
     });
     expect(repairParams.issues).toHaveLength(1);
-    expect(repairParams.issues?.[0]?.code).toBe("version-mismatch");
+    expect(repairParams.issues?.[0]?.code).toBe("port-mismatch");
   });
 
   it("kills stale gateway pids and retries restart", async () => {

--- a/src/cli/daemon-cli/start-repair.test.ts
+++ b/src/cli/daemon-cli/start-repair.test.ts
@@ -129,7 +129,7 @@ describe("repairLoadedGatewayServiceForStart", () => {
     });
     resolveOpenClawWrapperPathMock.mockResolvedValue("/usr/bin/openclaw");
     formatGatewayServiceStartRepairIssuesMock.mockReturnValue(
-      "service was installed by an older version",
+      "service port does not match current gateway config",
     );
   });
 
@@ -137,7 +137,7 @@ describe("repairLoadedGatewayServiceForStart", () => {
     vi.unstubAllEnvs();
   });
 
-  it("forwards existing env value-source metadata when repairing stale service definitions", async () => {
+  it("drops legacy version metadata when repairing genuine service drift", async () => {
     const installMock = vi.fn(async () => {});
     const isLoadedMock = vi.fn(async () => true);
     const service = {
@@ -168,7 +168,7 @@ describe("repairLoadedGatewayServiceForStart", () => {
     await repairLoadedGatewayServiceForStart({
       service,
       state,
-      issues: [{ code: "version-mismatch", message: "old service" }],
+      issues: [{ code: "port-mismatch", message: "old port" }],
       json: true,
       stdout: process.stdout,
     });
@@ -295,7 +295,7 @@ describe("repairLoadedGatewayServiceForStart", () => {
       repairLoadedGatewayServiceForStart({
         service,
         state,
-        issues: [{ code: "version-mismatch", message: "old service" }],
+        issues: [{ code: "port-mismatch", message: "old port" }],
         json: true,
         stdout: process.stdout,
       }),
@@ -329,7 +329,7 @@ describe("repairLoadedGatewayServiceForStart", () => {
       repairLoadedGatewayServiceForStart({
         service,
         state,
-        issues: [{ code: "version-mismatch", message: "old service" }],
+        issues: [{ code: "port-mismatch", message: "old port" }],
         json: true,
         stdout: process.stdout,
       }),
@@ -361,7 +361,7 @@ describe("repairLoadedGatewayServiceForStart", () => {
       repairLoadedGatewayServiceForStart({
         service,
         state,
-        issues: [{ code: "version-mismatch", message: "old service" }],
+        issues: [{ code: "missing-program", message: "missing program" }],
         json: true,
         stdout: process.stdout,
       }),

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -2212,6 +2212,11 @@ describe("collectPreservedExistingServiceEnvVars — operator opt-in allowlist",
     expect(result.OPENCLAW_FOO).toBeUndefined();
   });
 
+  it("drops legacy install-time version metadata from canonical rewrites", async () => {
+    const result = await buildEnvironment({ OPENCLAW_SERVICE_VERSION: "2026.4.24" });
+    expect(result.OPENCLAW_SERVICE_VERSION).toBeUndefined();
+  });
+
   it("preserves container opt-ins while dropping unrelated OPENCLAW_* keys", async () => {
     const result = await buildEnvironment({
       OPENCLAW_CLI_CONTAINER_BYPASS: "1",

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -1131,7 +1131,6 @@ describe("maybeRepairGatewayServiceConfig", () => {
     mocks.readCommand.mockResolvedValue({
       programArguments: gatewayProgramArguments,
       environment: {
-        OPENCLAW_SERVICE_VERSION: "2026.5.25",
         OPENCLAW_WINDOWS_TASK_NAME: "OpenClaw Gateway Work",
       },
     });
@@ -1139,8 +1138,8 @@ describe("maybeRepairGatewayServiceConfig", () => {
       ok: false,
       issues: [
         {
-          code: "gateway-service-version-mismatch",
-          message: "Gateway service was installed by an older OpenClaw version.",
+          code: "gateway-entrypoint-mismatch",
+          message: "Gateway service entrypoint differs from the current install.",
           level: "recommended",
         },
       ],
@@ -1148,16 +1147,14 @@ describe("maybeRepairGatewayServiceConfig", () => {
     mocks.buildGatewayInstallPlan.mockResolvedValue({
       programArguments: gatewayProgramArguments,
       workingDirectory: "/tmp",
-      environment: {
-        OPENCLAW_SERVICE_VERSION: "2026.5.26",
-      },
+      environment: {},
     });
     mocks.readRuntime.mockResolvedValue({ status: "running" });
 
     await runNonInteractiveRepair({ updateInProgress: true });
 
     expectNoteContaining(
-      "Gateway service was installed by an older OpenClaw version.",
+      "Gateway service entrypoint differs from the current install.",
       "Gateway service config",
     );
     expect(mocks.stage).not.toHaveBeenCalled();
@@ -1178,16 +1175,14 @@ describe("maybeRepairGatewayServiceConfig", () => {
     process.env.OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION = "0";
     mocks.readCommand.mockResolvedValue({
       programArguments: gatewayProgramArguments,
-      environment: {
-        OPENCLAW_SERVICE_VERSION: "2026.5.25",
-      },
+      environment: { OPENCLAW_GATEWAY_PORT: "18789" },
     });
     mocks.auditGatewayServiceConfig.mockResolvedValue({
       ok: false,
       issues: [
         {
-          code: "gateway-service-version-mismatch",
-          message: "Gateway service was installed by an older OpenClaw version.",
+          code: "gateway-entrypoint-mismatch",
+          message: "Gateway service entrypoint differs from the current install.",
           level: "recommended",
         },
       ],
@@ -1195,9 +1190,7 @@ describe("maybeRepairGatewayServiceConfig", () => {
     mocks.buildGatewayInstallPlan.mockResolvedValue({
       programArguments: gatewayProgramArguments,
       workingDirectory: "/tmp",
-      environment: {
-        OPENCLAW_SERVICE_VERSION: "2026.5.26",
-      },
+      environment: {},
     });
     mocks.readRuntime.mockResolvedValue({ status: "running" });
 
@@ -1217,15 +1210,14 @@ describe("maybeRepairGatewayServiceConfig", () => {
       programArguments: gatewayProgramArguments,
       environment: {
         OPENCLAW_GATEWAY_TOKEN: "stale-token",
-        OPENCLAW_SERVICE_VERSION: "2026.5.25",
       },
     });
     mocks.auditGatewayServiceConfig.mockResolvedValue({
       ok: false,
       issues: [
         {
-          code: "gateway-service-version-mismatch",
-          message: "Gateway service was installed by an older OpenClaw version.",
+          code: "gateway-entrypoint-mismatch",
+          message: "Gateway service entrypoint differs from the current install.",
           level: "recommended",
         },
       ],
@@ -1275,14 +1267,14 @@ describe("maybeRepairGatewayServiceConfig", () => {
     mocks.readWindowsProcessArgsSync.mockReturnValue(args);
     mocks.readCommand.mockResolvedValue({
       programArguments: gatewayProgramArguments,
-      environment: { OPENCLAW_SERVICE_VERSION: "2026.5.25" },
+      environment: { OPENCLAW_GATEWAY_PORT: "18789" },
     });
     mocks.auditGatewayServiceConfig.mockResolvedValue({
       ok: false,
       issues: [
         {
-          code: "gateway-service-version-mismatch",
-          message: "Gateway service was installed by an older OpenClaw version.",
+          code: "gateway-entrypoint-mismatch",
+          message: "Gateway service entrypoint differs from the current install.",
           level: "recommended",
         },
       ],
@@ -1290,7 +1282,7 @@ describe("maybeRepairGatewayServiceConfig", () => {
     mocks.buildGatewayInstallPlan.mockResolvedValue({
       programArguments: gatewayProgramArguments,
       workingDirectory: "/tmp",
-      environment: { OPENCLAW_SERVICE_VERSION: "2026.5.26" },
+      environment: {},
     });
     mocks.readRuntime.mockResolvedValue({ status: "running" });
 
@@ -1324,7 +1316,6 @@ describe("maybeRepairGatewayServiceConfig", () => {
           programArguments: gatewayProgramArguments,
           environment: {
             OPENCLAW_GATEWAY_TOKEN: "stale-token",
-            OPENCLAW_SERVICE_VERSION: "2026.5.25",
           },
         });
         mocks.auditGatewayServiceConfig.mockResolvedValue({
@@ -1340,9 +1331,7 @@ describe("maybeRepairGatewayServiceConfig", () => {
         mocks.buildGatewayInstallPlan.mockResolvedValue({
           programArguments: gatewayProgramArguments,
           workingDirectory: "/tmp",
-          environment: {
-            OPENCLAW_SERVICE_VERSION: "2026.5.26",
-          },
+          environment: {},
         });
         mocks.readRuntime.mockResolvedValue({ status: "running" });
         mocks.readWindowsStartupFallbackRuntimeForUpdate.mockResolvedValue({
@@ -1423,7 +1412,6 @@ describe("maybeRepairGatewayServiceConfig", () => {
           programArguments: gatewayProgramArguments,
           environment: {
             OPENCLAW_GATEWAY_TOKEN: "stale-token",
-            OPENCLAW_SERVICE_VERSION: "2026.5.25",
           },
         });
         mocks.auditGatewayServiceConfig.mockResolvedValue({
@@ -1439,9 +1427,7 @@ describe("maybeRepairGatewayServiceConfig", () => {
         mocks.buildGatewayInstallPlan.mockResolvedValue({
           programArguments: gatewayProgramArguments,
           workingDirectory: "/tmp",
-          environment: {
-            OPENCLAW_SERVICE_VERSION: "2026.5.26",
-          },
+          environment: {},
         });
         mocks.readRuntime.mockResolvedValue({ status: "running" });
 
@@ -1469,16 +1455,14 @@ describe("maybeRepairGatewayServiceConfig", () => {
     process.env.OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION = "1";
     mocks.readCommand.mockResolvedValue({
       programArguments: gatewayProgramArguments,
-      environment: {
-        OPENCLAW_SERVICE_VERSION: "2026.5.25",
-      },
+      environment: { OPENCLAW_GATEWAY_PORT: "18789" },
     });
     mocks.auditGatewayServiceConfig.mockResolvedValue({
       ok: false,
       issues: [
         {
-          code: "gateway-service-version-mismatch",
-          message: "Gateway service was installed by an older OpenClaw version.",
+          code: "gateway-entrypoint-mismatch",
+          message: "Gateway service entrypoint differs from the current install.",
           level: "recommended",
         },
       ],
@@ -1486,9 +1470,7 @@ describe("maybeRepairGatewayServiceConfig", () => {
     mocks.buildGatewayInstallPlan.mockResolvedValue({
       programArguments: gatewayProgramArguments,
       workingDirectory: "/tmp",
-      environment: {
-        OPENCLAW_SERVICE_VERSION: "2026.5.26",
-      },
+      environment: {},
     });
     mocks.readRuntime.mockResolvedValue({ status: "stopped" });
 

--- a/src/commands/node-daemon-install-helpers.test.ts
+++ b/src/commands/node-daemon-install-helpers.test.ts
@@ -42,7 +42,7 @@ describe("buildNodeInstallPlan", () => {
     });
     mocks.renderSystemNodeWarning.mockReturnValue(undefined);
     mocks.buildNodeServiceEnvironment.mockReturnValue({
-      OPENCLAW_SERVICE_VERSION: "2026.3.22",
+      OPENCLAW_SERVICE_MARKER: "openclaw",
     });
 
     const plan = await buildNodeInstallPlan({
@@ -54,7 +54,7 @@ describe("buildNodeInstallPlan", () => {
     });
 
     expect(plan.environment).toEqual({
-      OPENCLAW_SERVICE_VERSION: "2026.3.22",
+      OPENCLAW_SERVICE_MARKER: "openclaw",
     });
     expect(plan.environmentValueSources).toEqual({
       OPENCLAW_GATEWAY_TOKEN: "file",
@@ -79,7 +79,7 @@ describe("buildNodeInstallPlan", () => {
     });
     mocks.renderSystemNodeWarning.mockReturnValue(undefined);
     mocks.buildNodeServiceEnvironment.mockReturnValue({
-      OPENCLAW_SERVICE_VERSION: "2026.3.22",
+      OPENCLAW_SERVICE_MARKER: "openclaw",
     });
 
     await buildNodeInstallPlan({
@@ -110,7 +110,7 @@ describe("buildNodeInstallPlan", () => {
     mocks.buildNodeServiceEnvironment.mockReturnValue({
       OPENCLAW_GATEWAY_TOKEN: "node-token",
       OPENCLAW_GATEWAY_PASSWORD: "node-password",
-      OPENCLAW_SERVICE_VERSION: "2026.3.22",
+      OPENCLAW_SERVICE_MARKER: "openclaw",
     });
 
     const plan = await buildNodeInstallPlan({
@@ -125,6 +125,7 @@ describe("buildNodeInstallPlan", () => {
 
     expect(plan.environment.OPENCLAW_GATEWAY_TOKEN).toBe("node-token");
     expect(plan.environment.OPENCLAW_GATEWAY_PASSWORD).toBe("node-password");
+    expect(plan.description).toBe("OpenClaw Node Host");
     expect(plan.environmentValueSources).toEqual({
       OPENCLAW_GATEWAY_TOKEN: "file",
       OPENCLAW_GATEWAY_PASSWORD: "file", // pragma: allowlist secret

--- a/src/commands/node-daemon-install-helpers.ts
+++ b/src/commands/node-daemon-install-helpers.ts
@@ -1,5 +1,4 @@
 /** Node-based daemon install plan builder for managed gateway services. */
-import { formatNodeServiceDescription } from "../daemon/constants.js";
 import { resolveNodeProgramArguments } from "../daemon/program-args.js";
 import { buildNodeServiceEnvironment } from "../daemon/service-env.js";
 import type { GatewayServiceEnvironmentValueSource } from "../daemon/service-types.js";
@@ -79,15 +78,11 @@ export async function buildNodeInstallPlan(params: {
     // node toolchain on PATH for sibling binaries like npm/pnpm when needed.
     extraPathDirs: resolveDaemonNodeBinDir(nodePath),
   });
-  const description = formatNodeServiceDescription({
-    version: environment.OPENCLAW_SERVICE_VERSION,
-  });
-
   return {
     programArguments,
     workingDirectory,
     environment,
     environmentValueSources: buildNodeInstallEnvironmentValueSources(),
-    description,
+    description: "OpenClaw Node Host",
   };
 }

--- a/src/daemon/constants.test.ts
+++ b/src/daemon/constants.test.ts
@@ -110,7 +110,7 @@ describe("resolveGatewayProfileSuffix", () => {
 });
 
 describe("resolveGatewayServiceDescription", () => {
-  it("returns default description when no profile/version", () => {
+  it("returns default description when no profile", () => {
     expect(resolveGatewayServiceDescription({ env: {} })).toBe("OpenClaw Gateway");
   });
 
@@ -120,35 +120,19 @@ describe("resolveGatewayServiceDescription", () => {
     );
   });
 
-  it("includes version when set", () => {
+  it("ignores legacy install-time version metadata", () => {
     expect(
       resolveGatewayServiceDescription({ env: { OPENCLAW_SERVICE_VERSION: "2026.1.10" } }),
-    ).toBe("OpenClaw Gateway (v2026.1.10)");
+    ).toBe("OpenClaw Gateway");
   });
 
-  it("includes profile and version when set", () => {
-    expect(
-      resolveGatewayServiceDescription({
-        env: { OPENCLAW_PROFILE: "dev", OPENCLAW_SERVICE_VERSION: "1.2.3" },
-      }),
-    ).toBe("OpenClaw Gateway (profile: dev, v1.2.3)");
-  });
   it("prefers explicit description override", () => {
     expect(
       resolveGatewayServiceDescription({
-        env: { OPENCLAW_PROFILE: "work", OPENCLAW_SERVICE_VERSION: "1.0.0" },
+        env: { OPENCLAW_PROFILE: "work" },
         description: "Custom",
       }),
     ).toBe("Custom");
-  });
-
-  it("resolves version from explicit environment map", () => {
-    expect(
-      resolveGatewayServiceDescription({
-        env: { OPENCLAW_PROFILE: "work", OPENCLAW_SERVICE_VERSION: "local" },
-        environment: { OPENCLAW_SERVICE_VERSION: "remote" },
-      }),
-    ).toBe("OpenClaw Gateway (profile: work, vremote)");
   });
 });
 

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -95,34 +95,19 @@ export function resolveGatewayNativeServiceIdentityConflict(
   return null;
 }
 
-function formatGatewayServiceDescription(params?: { profile?: string; version?: string }): string {
-  const profile = normalizeGatewayProfile(params?.profile);
-  const version = params?.version?.trim();
-  const parts: string[] = [];
-  if (profile) {
-    parts.push(`profile: ${profile}`);
-  }
-  if (version) {
-    parts.push(`v${version}`);
-  }
-  if (parts.length === 0) {
+function formatGatewayServiceDescription(profile?: string): string {
+  const normalized = normalizeGatewayProfile(profile);
+  if (!normalized) {
     return "OpenClaw Gateway";
   }
-  return `OpenClaw Gateway (${parts.join(", ")})`;
+  return `OpenClaw Gateway (profile: ${normalized})`;
 }
 
 export function resolveGatewayServiceDescription(params: {
   env: Record<string, string | undefined>;
-  environment?: Record<string, string | undefined>;
   description?: string;
 }): string {
-  return (
-    params.description ??
-    formatGatewayServiceDescription({
-      profile: params.env.OPENCLAW_PROFILE,
-      version: params.environment?.OPENCLAW_SERVICE_VERSION ?? params.env.OPENCLAW_SERVICE_VERSION,
-    })
-  );
+  return params.description ?? formatGatewayServiceDescription(params.env.OPENCLAW_PROFILE);
 }
 
 export function resolveNodeLaunchAgentLabel(): string {
@@ -148,12 +133,4 @@ export function resolveNodeServiceIdentityEnvironment(): Record<string, string> 
     OPENCLAW_SERVICE_MARKER: NODE_SERVICE_MARKER,
     OPENCLAW_SERVICE_KIND: NODE_SERVICE_KIND,
   };
-}
-
-export function formatNodeServiceDescription(params?: { version?: string }): string {
-  const version = params?.version?.trim();
-  if (!version) {
-    return "OpenClaw Node Host";
-  }
-  return `OpenClaw Node Host (v${version})`;
 }

--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -20,7 +20,7 @@ vi.mock("./schtasks-exec.js", () => ({
 // Real content from the openclaw-gateway.service unit file (the canonical gateway unit).
 const GATEWAY_SERVICE_CONTENTS = `\
 [Unit]
-Description=OpenClaw Gateway (v2026.3.8)
+Description=OpenClaw Gateway
 After=network-online.target
 Wants=network-online.target
 
@@ -29,7 +29,6 @@ ExecStart=/usr/bin/node /home/openclaw/.npm-global/lib/node_modules/openclaw/dis
 Restart=always
 Environment=OPENCLAW_SERVICE_MARKER=openclaw
 Environment=OPENCLAW_SERVICE_KIND=gateway
-Environment=OPENCLAW_SERVICE_VERSION=2026.3.8
 
 [Install]
 WantedBy=default.target

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1553,11 +1553,31 @@ describe("launchd install", () => {
       programArguments: defaultProgramArguments,
     });
 
+    const plist = state.files.get(resolveLaunchAgentPlistPath(env)) ?? "";
+    expect(plist).toContain("<key>Comment</key>\n    <string>OpenClaw Gateway</string>");
+    expect(plist).not.toContain("OPENCLAW_SERVICE_VERSION");
     const { serviceId } = expectLaunchctlEnableBootstrapOrder(env);
     const installKickstartIndex = state.launchctlCalls.findIndex(
       (c) => c[0] === "kickstart" && c[2] === serviceId,
     );
     expect(installKickstartIndex).toBe(-1);
+  });
+
+  it("writes a version-free node service description", async () => {
+    const env = {
+      HOME: "/Users/test",
+      OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.node",
+    };
+    await installLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: ["node", "node-host.js"],
+      description: "OpenClaw Node Host",
+    });
+
+    const plist = state.files.get(resolveLaunchAgentPlistPath(env)) ?? "";
+    expect(plist).toContain("<key>Comment</key>\n    <string>OpenClaw Node Host</string>");
+    expect(plist).not.toContain("OPENCLAW_SERVICE_VERSION");
   });
 
   it("writes LaunchAgent environment to an owner-only env file when provided", async () => {
@@ -1880,6 +1900,11 @@ describe("launchd install", () => {
         "      <string>node</string>",
         "      <string>gateway.js</string>",
         "    </array>",
+        "    <key>EnvironmentVariables</key>",
+        "    <dict>",
+        "      <key>OPENCLAW_SERVICE_VERSION</key>",
+        "      <string>2026.4.24</string>",
+        "    </dict>",
         "  </dict>",
         "</plist>",
       ].join("\n"),
@@ -1898,6 +1923,7 @@ describe("launchd install", () => {
     expect(plist).toContain("<string>/dev/null</string>");
     expect(plist).toContain("<key>KeepAlive</key>");
     expect(plist).toContain("<string>node</string>");
+    expect(plist).not.toContain("OPENCLAW_SERVICE_VERSION");
     const rewriteIndex = state.fileWrites.findIndex((write) => write.path === plistPath);
     const bootstrapIndex = state.launchctlCalls.findIndex((call) => call[0] === "bootstrap");
     expect(rewriteIndex).toBeGreaterThanOrEqual(0);

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1326,7 +1326,7 @@ async function writeLaunchAgentPlist({
     warn,
   });
 
-  const serviceDescription = resolveGatewayServiceDescription({ env, environment, description });
+  const serviceDescription = resolveGatewayServiceDescription({ env, description });
   const plist = buildLaunchAgentPlist({
     label,
     comment: serviceDescription,
@@ -1419,13 +1419,18 @@ async function rewriteLaunchAgentPlistForRestart({
 
   const serviceDescription = resolveGatewayServiceDescription({
     env,
-    environment: existing.environment,
   });
+  // Restart rewrites must retire install provenance from legacy plists instead
+  // of copying it into the next canonical definition.
+  const canonicalEnvironment = {
+    ...existing.environment,
+    OPENCLAW_SERVICE_VERSION: undefined,
+  };
   const prepared = await prepareLaunchAgentProgramArguments({
     env,
     label,
     programArguments: existing.programArguments,
-    environment: existing.environment,
+    environment: canonicalEnvironment,
     stdout,
     warn,
   });

--- a/src/daemon/schtasks-install.ts
+++ b/src/daemon/schtasks-install.ts
@@ -130,7 +130,6 @@ async function writeScheduledTaskScript({
   await fs.mkdir(path.dirname(scriptPath), { recursive: true });
   const taskDescription = resolveGatewayServiceDescription({
     env: taskEnv,
-    environment,
     description,
   });
   const script = buildTaskScript({

--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -106,6 +106,40 @@ describe("installScheduledTask", () => {
     expect(schtasksCalls[index]).toEqual(["/Run", "/TN", taskName]);
   }
 
+  it("writes version-free gateway and node descriptions", async () => {
+    await withUserProfileDir(async (_tmpDir, env) => {
+      const gateway = await installDefaultGatewayTask(env);
+      const gatewayScript = decodeWindowsLauncherScript({
+        buffer: await fs.readFile(gateway.scriptPath),
+      });
+      expect(gatewayScript).toContain("rem OpenClaw Gateway");
+      expect(gatewayScript).not.toContain("OPENCLAW_SERVICE_VERSION");
+      expect(xmlPayloadCaptures.at(-1)?.xml).toContain(
+        "<Description>OpenClaw Gateway</Description>",
+      );
+
+      const node = await installScheduledTask({
+        env: {
+          ...env,
+          OPENCLAW_WINDOWS_TASK_NAME: "OpenClaw Node",
+          OPENCLAW_TASK_SCRIPT_NAME: "node.cmd",
+        },
+        stdout: new PassThrough(),
+        programArguments: ["node", "node-host.js"],
+        description: "OpenClaw Node Host",
+        environment: {},
+      });
+      const nodeScript = decodeWindowsLauncherScript({
+        buffer: await fs.readFile(node.scriptPath),
+      });
+      expect(nodeScript).toContain("rem OpenClaw Node Host");
+      expect(nodeScript).not.toContain("OPENCLAW_SERVICE_VERSION");
+      expect(xmlPayloadCaptures.at(-1)?.xml).toContain(
+        "<Description>OpenClaw Node Host</Description>",
+      );
+    });
+  });
+
   it("writes quoted set assignments and escapes metacharacters", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
       const { scriptPath } = await installScheduledTask({

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -3,7 +3,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { VERSION } from "../version.js";
 import {
   auditGatewayServiceConfig,
   checkTokenDrift,
@@ -791,39 +790,13 @@ describe("checkTokenDrift", () => {
   });
 });
 
-describe("gateway service version mismatch detection", () => {
-  it("flags stale gateway service version metadata", async () => {
-    const audit = await createGatewayAudit({
+describe("legacy gateway service version metadata", () => {
+  it("does not treat install-time version metadata as runtime truth", async () => {
+    const legacyAudit = await createGatewayAudit({
       extraEnvironment: { OPENCLAW_SERVICE_VERSION: "2026.4.15-beta.1" },
     });
+    const canonicalAudit = await createGatewayAudit();
 
-    const issue = audit.issues.find(
-      (entry) => entry.code === SERVICE_AUDIT_CODES.gatewayServiceVersionMismatch,
-    );
-    expect(issue).toBeDefined();
-    expect(issue?.message).toContain("2026.4.15-beta.1");
-    expect(issue?.message).toContain(VERSION);
-    expect(issue?.level).toBe("recommended");
-  });
-
-  it("accepts current gateway service version metadata", async () => {
-    const audit = await createGatewayAudit({
-      extraEnvironment: { OPENCLAW_SERVICE_VERSION: VERSION },
-    });
-
-    expect(
-      audit.issues.some(
-        (entry) => entry.code === SERVICE_AUDIT_CODES.gatewayServiceVersionMismatch,
-      ),
-    ).toBe(false);
-  });
-
-  it("does not flag missing gateway service version metadata", async () => {
-    const audit = await createGatewayAudit();
-    expect(
-      audit.issues.some(
-        (entry) => entry.code === SERVICE_AUDIT_CODES.gatewayServiceVersionMismatch,
-      ),
-    ).toBe(false);
+    expect(legacyAudit).toEqual(canonicalAudit);
   });
 });

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -9,7 +9,6 @@ import { normalizeStringEntries } from "@openclaw/normalization-core/string-norm
 import { resolveInlineCommandMatch } from "../infra/shell-inline-command.js";
 import { POSIX_SHELL_WRAPPERS } from "../infra/shell-wrapper-resolution.js";
 import { parseTcpPort } from "../infra/tcp-port.js";
-import { VERSION } from "../version.js";
 import { resolveLaunchAgentPlistPath } from "./launchd.js";
 import { isBunRuntime, isNodeRuntime } from "./runtime-binary.js";
 import {
@@ -61,7 +60,6 @@ export const SERVICE_AUDIT_CODES = {
   gatewayRuntimeNodeVersionManager: "gateway-runtime-node-version-manager",
   gatewayRuntimeNodeSystemMissing: "gateway-runtime-node-system-missing",
   gatewayTokenDrift: "gateway-token-drift",
-  gatewayServiceVersionMismatch: "gateway-service-version-mismatch",
   launchdKeepAlive: "launchd-keep-alive",
   launchdRunAtLoad: "launchd-run-at-load",
   systemdAfterNetworkOnline: "systemd-after-network-online",
@@ -577,20 +575,6 @@ export function checkTokenDrift(params: {
   return null;
 }
 
-function auditGatewayServiceVersion(command: GatewayServiceCommand, issues: ServiceConfigIssue[]) {
-  const serviceVersion = command?.environment?.OPENCLAW_SERVICE_VERSION?.trim();
-  if (!serviceVersion || serviceVersion === VERSION) {
-    return;
-  }
-
-  issues.push({
-    code: SERVICE_AUDIT_CODES.gatewayServiceVersionMismatch,
-    message: `Gateway service was installed by OpenClaw ${serviceVersion}; current CLI is ${VERSION}.`,
-    detail: command?.sourcePath,
-    level: "recommended",
-  });
-}
-
 export async function auditGatewayServiceConfig(params: {
   env: Record<string, string | undefined>;
   command: GatewayServiceCommand;
@@ -612,7 +596,6 @@ export async function auditGatewayServiceConfig(params: {
   auditManagedServiceEnvironment(params.command, issues, params.expectedManagedServiceEnvKeys);
   auditProxyServiceEnvironment(params.command, issues);
   auditGatewayToken(params.command, issues, params.expectedGatewayToken);
-  auditGatewayServiceVersion(params.command, issues);
   auditGatewayServicePath(params.command, issues, params.env, platform, params.expectedServicePath);
   await auditGatewayRuntime(params.env, params.command, issues, platform);
 

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -528,7 +528,7 @@ describe("buildServiceEnvironment", () => {
     expect(env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
     expect(env.OPENCLAW_SERVICE_MARKER).toBe("openclaw");
     expect(env.OPENCLAW_SERVICE_KIND).toBe("gateway");
-    expect(typeof env.OPENCLAW_SERVICE_VERSION).toBe("string");
+    expect(env).not.toHaveProperty("OPENCLAW_SERVICE_VERSION");
     expect(env.OPENCLAW_SYSTEMD_UNIT).toBe("openclaw-gateway.service");
     expect(env.OPENCLAW_WINDOWS_TASK_NAME).toBe("OpenClaw Gateway");
     expect(env.OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER).toBe("1");
@@ -772,6 +772,7 @@ describe("buildNodeServiceEnvironment", () => {
       env: { HOME: "/home/user" },
     });
     expect(env.HOME).toBe("/home/user");
+    expect(env).not.toHaveProperty("OPENCLAW_SERVICE_VERSION");
   });
 
   it("sets the OpenClaw-owned launchd marker for macOS node services", () => {

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -4,7 +4,6 @@ import os from "node:os";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveNodeStartupTlsEnvironment } from "../bootstrap/node-startup-env.js";
-import { VERSION } from "../version.js";
 import {
   GATEWAY_SERVICE_KIND,
   GATEWAY_SERVICE_MARKER,
@@ -364,7 +363,6 @@ export function buildServiceEnvironment(params: {
     OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "1",
     OPENCLAW_SERVICE_MARKER: GATEWAY_SERVICE_MARKER,
     OPENCLAW_SERVICE_KIND: GATEWAY_SERVICE_KIND,
-    OPENCLAW_SERVICE_VERSION: VERSION,
   };
 }
 
@@ -391,7 +389,6 @@ export function buildNodeServiceEnvironment(params: {
     OPENCLAW_GATEWAY_PASSWORD: gatewayPassword,
     OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: allowInsecurePrivateWs,
     ...resolveNodeServiceIdentityEnvironment(),
-    OPENCLAW_SERVICE_VERSION: VERSION,
   };
 }
 

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -105,7 +105,7 @@ export type GatewayServiceState = {
 };
 
 export type GatewayServiceStartRepairIssue = {
-  code: "missing-program" | "port-mismatch" | "temporary-program" | "version-mismatch";
+  code: "missing-program" | "port-mismatch" | "temporary-program";
   message: string;
 };
 

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -9,7 +9,6 @@ import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
 import type { GatewayService } from "./service.js";
 import {
   describeGatewayServiceRestart,
-  formatGatewayServiceStartRepairIssues,
   readGatewayServiceState,
   resolveGatewayService,
   startGatewayService,
@@ -358,7 +357,7 @@ describe("startGatewayService", () => {
     expect(service.start).not.toHaveBeenCalled();
   });
 
-  it("returns repair drift with an already-running service", async () => {
+  it("ignores legacy version metadata on an already-running service", async () => {
     const service = createService({
       readCommand: vi.fn(async () => ({
         programArguments: ["openclaw", "gateway", "run"],
@@ -375,12 +374,12 @@ describe("startGatewayService", () => {
 
     expect(result.outcome).toBe("already-running");
     if (result.outcome === "already-running") {
-      expect(result.issues).toEqual([expect.objectContaining({ code: "version-mismatch" })]);
+      expect(result.issues).toEqual([]);
     }
     expect(service.start).not.toHaveBeenCalled();
   });
 
-  it("requests repair before start when the loaded service version is stale", async () => {
+  it("starts a stopped service despite legacy version metadata", async () => {
     const service = createService({
       readCommand: vi.fn(async () => ({
         programArguments: ["openclaw", "gateway", "run"],
@@ -395,13 +394,8 @@ describe("startGatewayService", () => {
       stdout: process.stdout,
     });
 
-    expect(result.outcome).toBe("repair-required");
-    if (result.outcome === "repair-required") {
-      expect(formatGatewayServiceStartRepairIssues(result.issues)).toContain(
-        "service was installed by OpenClaw 2026.4.24",
-      );
-    }
-    expect(service.start).not.toHaveBeenCalled();
+    expect(result.outcome).toBe("started");
+    expect(service.start).toHaveBeenCalledOnce();
   });
 
   it("requests repair before start when the managed port differs from config", async () => {

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { assertGatewayServiceMutationAllowed } from "../infra/gateway-supervision.js";
 import { parseTcpPort, parseTcpPortFromArgs } from "../infra/tcp-port.js";
-import { VERSION } from "../version.js";
 import { assertFutureConfigActionAllowed } from "./future-config-guard.js";
 import {
   installLaunchAgent,
@@ -126,15 +125,6 @@ function collectGatewayServiceStartRepairIssues(
     return [];
   }
   const issues: GatewayServiceStartRepairIssue[] = [];
-  const serviceVersion = command.environment?.OPENCLAW_SERVICE_VERSION?.trim();
-  if (serviceVersion && serviceVersion !== VERSION) {
-    // Version drift often means the service points at old package paths; require
-    // reinstall/repair before pretending restart succeeded.
-    issues.push({
-      code: "version-mismatch",
-      message: `service was installed by OpenClaw ${serviceVersion}, current CLI is ${VERSION}`,
-    });
-  }
   const servicePort =
     parseTcpPortFromArgs(command.programArguments) ??
     parseTcpPort(command.environment?.OPENCLAW_GATEWAY_PORT ?? "");

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1726,6 +1726,8 @@ describe("stageSystemdService", () => {
 
       const unit = await fs.readFile(unitPath, "utf8");
 
+      expect(unit).toContain("Description=OpenClaw Gateway");
+      expect(unit).not.toContain("OPENCLAW_SERVICE_VERSION");
       expect(unit).not.toContain("EnvironmentFile=");
       expect(unit).toContain("Environment=OPENCLAW_GATEWAY_PORT=18789");
       expect(unit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=dotenv-token");
@@ -2377,6 +2379,7 @@ describe("systemd service install and uninstall", () => {
         stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
         programArguments: ["/usr/bin/openclaw", "node", "run"],
         workingDirectory: "/tmp",
+        description: "OpenClaw Node Host",
         environment: {
           OPENCLAW_SYSTEMD_UNIT: "openclaw-node",
         },
@@ -2384,7 +2387,9 @@ describe("systemd service install and uninstall", () => {
 
       const unit = await fs.readFile(unitPath, "utf8");
       expect(unitPath).toMatch(/openclaw-node\.service$/);
+      expect(unit).toContain("Description=OpenClaw Node Host");
       expect(unit).toContain("openclaw node run");
+      expect(unit).not.toContain("OPENCLAW_SERVICE_VERSION");
       expect(execFileMock).toHaveBeenCalledTimes(4);
     });
   });

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -1177,7 +1177,7 @@ async function writeSystemdUnit({
     // File does not exist yet — nothing to back up.
   }
 
-  const serviceDescription = resolveGatewayServiceDescription({ env, environment, description });
+  const serviceDescription = resolveGatewayServiceDescription({ env, description });
   const stateDir = resolveStateDir(env as NodeJS.ProcessEnv);
   const { entries: stateDirDotEnvEntries, skippedShellReferenceKeys } =
     readStateDirDotEnvFromStateDir(stateDir);

--- a/src/gateway/server.auth.default-token.suite.ts
+++ b/src/gateway/server.auth.default-token.suite.ts
@@ -216,7 +216,6 @@ export function registerDefaultAuthTokenSuite(): void {
         {
           env: {
             OPENCLAW_VERSION: " ",
-            OPENCLAW_SERVICE_VERSION: "2.4.6-service",
             npm_package_version: "1.0.0-package",
           },
           expectedVersion: VERSION,
@@ -224,7 +223,6 @@ export function registerDefaultAuthTokenSuite(): void {
         {
           env: {
             OPENCLAW_VERSION: "9.9.9-cli",
-            OPENCLAW_SERVICE_VERSION: "2.4.6-service",
             npm_package_version: "1.0.0-package",
           },
           expectedVersion: "9.9.9-cli",
@@ -232,7 +230,6 @@ export function registerDefaultAuthTokenSuite(): void {
         {
           env: {
             OPENCLAW_VERSION: " ",
-            OPENCLAW_SERVICE_VERSION: "\t",
             npm_package_version: "1.0.0-package",
           },
           expectedVersion: VERSION,

--- a/src/infra/system-presence.version.test.ts
+++ b/src/infra/system-presence.version.test.ts
@@ -23,7 +23,6 @@ async function withPresenceModule<T>(
   return withEnvAsync(
     {
       OPENCLAW_VERSION: undefined,
-      OPENCLAW_SERVICE_VERSION: undefined,
       npm_package_version: undefined,
       ...env,
     },
@@ -66,7 +65,7 @@ describe("system-presence version fallback", () => {
     });
   }
 
-  it("uses runtime VERSION when OPENCLAW_VERSION is not set", async () => {
+  it("ignores legacy service metadata and uses runtime VERSION", async () => {
     await expectSelfVersion(
       {
         OPENCLAW_SERVICE_VERSION: "2.4.6-service",
@@ -80,29 +79,16 @@ describe("system-presence version fallback", () => {
     await expectSelfVersion(
       {
         OPENCLAW_VERSION: "9.9.9-cli",
-        OPENCLAW_SERVICE_VERSION: "2.4.6-service",
         npm_package_version: "1.0.0-package",
       },
       "9.9.9-cli",
     );
   });
 
-  it("still prefers runtime VERSION over OPENCLAW_SERVICE_VERSION when OPENCLAW_VERSION is blank", async () => {
+  it("uses runtime VERSION when OPENCLAW_VERSION is blank despite npm_package_version", async () => {
     await expectSelfVersion(
       {
         OPENCLAW_VERSION: " ",
-        OPENCLAW_SERVICE_VERSION: "2.4.6-service",
-        npm_package_version: "1.0.0-package",
-      },
-      runtimeVersion,
-    );
-  });
-
-  it("uses runtime VERSION when service markers are blank despite npm_package_version", async () => {
-    await expectSelfVersion(
-      {
-        OPENCLAW_VERSION: " ",
-        OPENCLAW_SERVICE_VERSION: "\t",
         npm_package_version: "1.0.0-package",
       },
       runtimeVersion,

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -148,11 +148,10 @@ describe("version resolution", () => {
     });
   });
 
-  it("prefers OPENCLAW_VERSION over service and package versions", () => {
+  it("prefers OPENCLAW_VERSION over package versions", () => {
     expect(
       resolveRuntimeServiceVersion({
         OPENCLAW_VERSION: "9.9.9",
-        OPENCLAW_SERVICE_VERSION: "2.2.2",
         npm_package_version: "1.1.1",
       }),
     ).toBe("9.9.9");
@@ -169,18 +168,15 @@ describe("version resolution", () => {
   it("prefers runtime VERSION over stale OPENCLAW_VERSION for compatibility checks", () => {
     const previousCompatibility = process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
     const previous = process.env.OPENCLAW_VERSION;
-    const previousService = process.env.OPENCLAW_SERVICE_VERSION;
     const previousPackage = process.env.npm_package_version;
     try {
       delete process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
       process.env.OPENCLAW_VERSION = "2026.3.25";
-      process.env.OPENCLAW_SERVICE_VERSION = "2026.3.25-service";
       process.env.npm_package_version = "2026.3.25-package";
       expect(resolveCompatibilityHostVersion()).toBe(VERSION);
     } finally {
       restoreEnvValue("OPENCLAW_COMPATIBILITY_HOST_VERSION", previousCompatibility);
       restoreEnvValue("OPENCLAW_VERSION", previous);
-      restoreEnvValue("OPENCLAW_SERVICE_VERSION", previousService);
       restoreEnvValue("npm_package_version", previousPackage);
     }
   });
@@ -189,7 +185,6 @@ describe("version resolution", () => {
     expect(
       resolveCompatibilityHostVersion({
         OPENCLAW_VERSION: "2026.3.99",
-        OPENCLAW_SERVICE_VERSION: "2026.3.98",
         npm_package_version: "2026.3.97",
       }),
     ).toBe("2026.3.99");
@@ -200,7 +195,6 @@ describe("version resolution", () => {
       resolveCompatibilityHostVersion({
         OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.4.8",
         OPENCLAW_VERSION: "2026.3.99",
-        OPENCLAW_SERVICE_VERSION: "2026.3.98",
         npm_package_version: "2026.3.97",
       }),
     ).toBe("2026.4.8");
@@ -216,11 +210,10 @@ describe("version resolution", () => {
     expect(resolveUsableRuntimeVersion(" 2026.3.2 ")).toBe("2026.3.2");
   });
 
-  it("prefers runtime VERSION over service/package markers and ignores unusable env values", () => {
+  it("prefers runtime VERSION over package markers and ignores unusable env values", () => {
     expect(
       resolveRuntimeServiceVersion({
         OPENCLAW_VERSION: "   ",
-        OPENCLAW_SERVICE_VERSION: "  2.0.0  ",
         npm_package_version: "1.0.0",
       }),
     ).toBe(VERSION);
@@ -228,7 +221,6 @@ describe("version resolution", () => {
     expect(
       resolveRuntimeServiceVersion({
         OPENCLAW_VERSION: " ",
-        OPENCLAW_SERVICE_VERSION: "\t",
         npm_package_version: " 1.0.0-package ",
       }),
     ).toBe(VERSION);
@@ -237,7 +229,6 @@ describe("version resolution", () => {
       resolveRuntimeServiceVersion(
         {
           OPENCLAW_VERSION: "",
-          OPENCLAW_SERVICE_VERSION: " ",
           npm_package_version: "",
         },
         "fallback",
@@ -247,7 +238,6 @@ describe("version resolution", () => {
     expect(
       resolveRuntimeServiceVersion({
         OPENCLAW_VERSION: "undefined",
-        OPENCLAW_SERVICE_VERSION: "null",
         npm_package_version: "1.0.0-package",
       }),
     ).toBe(VERSION);

--- a/src/version.ts
+++ b/src/version.ts
@@ -103,7 +103,7 @@ type RuntimeVersionPreference = "env-first" | "runtime-first";
 export function resolveUsableRuntimeVersion(version: string | undefined): string | undefined {
   const trimmed = normalizeOptionalString(version);
   // "0.0.0" is the resolver's hard fallback when module metadata cannot be read.
-  // Prefer explicit service/package markers in that edge case.
+  // Prefer explicit runtime/package markers in that edge case.
   if (!trimmed || trimmed === "0.0.0") {
     return undefined;
   }
@@ -121,11 +121,7 @@ function resolveVersionFromRuntimeSources(params: {
       ? [params.env["OPENCLAW_VERSION"], params.runtimeVersion]
       : [params.runtimeVersion, params.env["OPENCLAW_VERSION"]];
   return (
-    firstNonEmpty(
-      ...preferredCandidates,
-      params.env["OPENCLAW_SERVICE_VERSION"],
-      params.env["npm_package_version"],
-    ) ?? params.fallback
+    firstNonEmpty(...preferredCandidates, params.env["npm_package_version"]) ?? params.fallback
   );
 }
 

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -1487,7 +1487,7 @@ describe("finalizeSetupWizard", () => {
       state: { installed: true, loaded: true, running: false },
       issues: [
         { code: "port-mismatch", message: "service is configured for another port" },
-        { code: "version-mismatch", message: "service was installed by an older version" },
+        { code: "missing-program", message: "service command points at a missing path" },
       ],
     });
 
@@ -1503,7 +1503,7 @@ describe("finalizeSetupWizard", () => {
 
     expect(result.gateway).toEqual({
       status: "failed",
-      error: "service is configured for another port; service was installed by an older version",
+      error: "service is configured for another port; service command points at a missing path",
     });
     expect(
       vi


### PR DESCRIPTION
Closes #120701

## What Problem This Solves

Managed gateway and node services embed their install-time OpenClaw version. After a package upgrade, that historical stamp makes a healthy service look stale and triggers unnecessary repair work.

## Why This Change Was Made

Remove install provenance from gateway and node service definitions across systemd, launchd, and Windows Task Scheduler, and delete the audit and startup-repair consumers that compared it. Live gateway RPC plus real entrypoint, port, runtime, and token checks remain authoritative. Legacy version metadata is ignored when inspecting existing definitions and is scrubbed the next time OpenClaw performs a canonical service rewrite.

## User Impact

Upgrades no longer report healthy managed services as stale or rewrite them solely because they carry an old version stamp.

## Evidence

- Independent focused proof: 16 Vitest files, 761 tests passed.
- Source proof: the broader focused suites plus TypeScript, lint, daemon-boundary, and ratchet checks passed. The local changed gate reached SwiftLint but could not complete because SwiftLint crashed while loading `sourcekitdInProc.framework`.
- Pre-commit automated review completed with no actionable findings.
- Live systemd proof on an existing user service: removing the legacy version metadata and running `daemon-reload` left the gateway PID and restart count unchanged; gateway RPC and audit remained healthy.
- Blacksmith Testbox was unavailable because the local executable was missing, and AWS Crabbox was unavailable because no broker login was present. Exact-head hosted CI is therefore the macOS/Swift proof for this PR.
- AI-assisted implementation and verification. No transcript or session logs are included.
