### PR TITLE
fix(process): report output discarded by retention caps

### DIFF
--- a/docs/gateway/background-process.md
+++ b/docs/gateway/background-process.md
@@ -27,11 +27,11 @@ Parameters:
 
 Behavior:
 
-- Foreground runs return output directly.
+- Foreground runs return retained output directly and disclose when earlier output exceeded the aggregate cap.
 - When backgrounded (explicit or via `yieldMs` timeout), the tool returns `status: "running"` + `sessionId` and a short output tail.
 - Backgrounded and `yieldMs` runs inherit `tools.exec.timeoutSeconds` unless the call passes an explicit `timeout`.
-- Output stays in memory until the session is polled or cleared.
-- Finished sessions expire after their configured TTL. The registry also retains at most 50 finished sessions and 2,000,000 total output characters, evicting the oldest records first. The newest completed session retains its full output even if it exceeds the aggregate limit.
+- Output stays in memory up to the per-session aggregate cap until the session is polled or cleared.
+- Finished sessions expire after their configured TTL. The registry also retains at most 50 finished sessions and 2,000,000 total retained output characters, evicting the oldest records first. The newest completed session retains its capped per-session aggregate even when that record alone exceeds the global limit.
 - If the `process` tool is disallowed, `exec` runs synchronously and ignores `yieldMs`/`background`.
 - Spawned exec commands receive `OPENCLAW_SHELL=exec` for context-aware shell/profile rules.
 - For long-running work that starts now: start it once and rely on automatic completion wake (when enabled) once the command emits output or fails.
@@ -43,8 +43,8 @@ Behavior:
 | Variable                                 | Effect                                                                                                           |
 | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `OPENCLAW_BASH_YIELD_MS`                 | Default yield before backgrounding (ms). Default 10000, clamped 10-120000.                                       |
-| `OPENCLAW_BASH_MAX_OUTPUT_CHARS`         | In-memory output cap (chars).                                                                                    |
-| `OPENCLAW_BASH_PENDING_MAX_OUTPUT_CHARS` | Pending stdout/stderr cap per stream (chars).                                                                    |
+| `OPENCLAW_BASH_MAX_OUTPUT_CHARS`         | In-memory aggregate cap in characters. Default 200000, clamped 1000-200000.                                      |
+| `OPENCLAW_BASH_PENDING_MAX_OUTPUT_CHARS` | Pending stdout/stderr cap per stream. Default 30000, clamped 1000-200000 and limited by the aggregate cap.       |
 | `OPENCLAW_BASH_JOB_TTL_MS`               | TTL for finished sessions (ms), bounded to 1m-3h.                                                                |
 | `OPENCLAW_PROCESS_INPUT_WAIT_IDLE_MS`    | Idle-output threshold before writable background sessions are marked as likely waiting for input. Default 15000. |
 
@@ -93,7 +93,7 @@ Notes:
 - `process list` includes a derived `name` (command verb + target) for quick scans.
 - `process list`, `poll`, and `log` report `waitingForInput` only when the session still has writable stdin and has been idle longer than the input-wait threshold (default 15000 ms, `OPENCLAW_PROCESS_INPUT_WAIT_IDLE_MS`).
 - `process log` uses line-based `offset`/`limit`. When both are omitted, it returns the last 200 lines with a paging hint. When `offset` is set and `limit` isn't, it returns from `offset` to the end (not capped to 200).
-- `process poll` marks omitted output when a pending burst exceeds its display buffer or a completed session returns only its retained tail. Use `process log` with `offset` and `limit` to inspect the retained output.
+- `process poll` and `process log` distinguish output discarded at the aggregate retention cap from output merely omitted by the pending buffer or retained tail. Discarded output cannot be recovered; paged logs can inspect only the retained portion.
 - `poll`'s `timeout` waits up to that many milliseconds before returning; values above 30000 are clamped to 30000.
 - Polling is for on-demand status, not wait-loop scheduling. If the work should happen later, use cron.
 

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -634,6 +634,8 @@ export function createExecTool(
                 outcome: settledOutcome,
                 cwd: run.session.cwd,
                 warningText: getWarningText(),
+                aggregateOutputDropped:
+                  run.session.totalOutputChars > run.session.aggregated.length,
               }),
             );
             return;
@@ -672,6 +674,8 @@ export function createExecTool(
                 outcome,
                 cwd: run.session.cwd,
                 warningText: getWarningText(),
+                aggregateOutputDropped:
+                  run.session.totalOutputChars > run.session.aggregated.length,
               }),
             );
           })

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -56,7 +56,6 @@ let listRunningSessions: typeof import("./bash-process-registry.js").listRunning
 let resetProcessRegistryForTests: typeof import("./bash-process-registry.test-support.js").resetProcessRegistryForTests;
 let resolveExecTarget: typeof import("./bash-tools.exec-runtime.js").resolveExecTarget;
 let runExecProcess: typeof import("./bash-tools.exec-runtime.js").runExecProcess;
-let buildExecForegroundResult: typeof import("./bash-tools.exec-support.js").buildExecForegroundResult;
 let prepareGatewaySuspend: typeof import("../infra/gateway-suspend-coordinator.js").prepareGatewaySuspend;
 let resetGatewaySuspendCoordinatorForLifecycleRestart: typeof import("../infra/gateway-suspend-coordinator.js").resetGatewaySuspendCoordinatorForLifecycleRestart;
 let resumeGatewaySuspend: typeof import("../infra/gateway-suspend-coordinator.js").resumeGatewaySuspend;
@@ -66,7 +65,6 @@ beforeAll(async () => {
     await import("./bash-process-registry.js"));
   ({ resetProcessRegistryForTests } = await import("./bash-process-registry.test-support.js"));
   ({ resolveExecTarget, runExecProcess } = await import("./bash-tools.exec-runtime.js"));
-  ({ buildExecForegroundResult } = await import("./bash-tools.exec-support.js"));
   ({
     prepareGatewaySuspend,
     resetGatewaySuspendCoordinatorForLifecycleRestart,
@@ -85,28 +83,6 @@ beforeEach(() => {
 
 afterEach(() => {
   resetProcessRegistryForTests();
-});
-
-describe("exec foreground retention", () => {
-  it("discloses output discarded at the aggregate cap", () => {
-    const result = buildExecForegroundResult({
-      outcome: {
-        status: "completed",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 1,
-        aggregated: "retained output",
-        timedOut: false,
-      },
-      aggregateOutputDropped: true,
-    });
-
-    expect(result.content[0]).toMatchObject({
-      type: "text",
-      text: expect.stringContaining("discarded at the retention cap and cannot be recovered"),
-    });
-    expect((result.details as { aggregated?: string }).aggregated).toBe("retained output");
-  });
 });
 
 function createDeferred<T>() {

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -56,6 +56,7 @@ let listRunningSessions: typeof import("./bash-process-registry.js").listRunning
 let resetProcessRegistryForTests: typeof import("./bash-process-registry.test-support.js").resetProcessRegistryForTests;
 let resolveExecTarget: typeof import("./bash-tools.exec-runtime.js").resolveExecTarget;
 let runExecProcess: typeof import("./bash-tools.exec-runtime.js").runExecProcess;
+let buildExecForegroundResult: typeof import("./bash-tools.exec-support.js").buildExecForegroundResult;
 let prepareGatewaySuspend: typeof import("../infra/gateway-suspend-coordinator.js").prepareGatewaySuspend;
 let resetGatewaySuspendCoordinatorForLifecycleRestart: typeof import("../infra/gateway-suspend-coordinator.js").resetGatewaySuspendCoordinatorForLifecycleRestart;
 let resumeGatewaySuspend: typeof import("../infra/gateway-suspend-coordinator.js").resumeGatewaySuspend;
@@ -65,6 +66,7 @@ beforeAll(async () => {
     await import("./bash-process-registry.js"));
   ({ resetProcessRegistryForTests } = await import("./bash-process-registry.test-support.js"));
   ({ resolveExecTarget, runExecProcess } = await import("./bash-tools.exec-runtime.js"));
+  ({ buildExecForegroundResult } = await import("./bash-tools.exec-support.js"));
   ({
     prepareGatewaySuspend,
     resetGatewaySuspendCoordinatorForLifecycleRestart,
@@ -83,6 +85,28 @@ beforeEach(() => {
 
 afterEach(() => {
   resetProcessRegistryForTests();
+});
+
+describe("exec foreground retention", () => {
+  it("discloses output discarded at the aggregate cap", () => {
+    const result = buildExecForegroundResult({
+      outcome: {
+        status: "completed",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 1,
+        aggregated: "retained output",
+        timedOut: false,
+      },
+      aggregateOutputDropped: true,
+    });
+
+    expect(result.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("discarded at the retention cap and cannot be recovered"),
+    });
+    expect((result.details as { aggregated?: string }).aggregated).toBe("retained output");
+  });
 });
 
 function createDeferred<T>() {

--- a/src/agents/bash-tools.exec-support.test.ts
+++ b/src/agents/bash-tools.exec-support.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { buildExecForegroundResult } from "./bash-tools.exec-support.js";
+
+describe("exec foreground retention", () => {
+  it("discloses output discarded at the aggregate cap", () => {
+    const result = buildExecForegroundResult({
+      outcome: {
+        status: "completed",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 1,
+        aggregated: "retained output",
+        timedOut: false,
+      },
+      aggregateOutputDropped: true,
+    });
+
+    expect(result.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("discarded at the retention cap and cannot be recovered"),
+    });
+    expect((result.details as { aggregated?: string }).aggregated).toBe("retained output");
+  });
+});

--- a/src/agents/bash-tools.exec-support.ts
+++ b/src/agents/bash-tools.exec-support.ts
@@ -13,8 +13,12 @@ export function buildExecForegroundResult(params: {
   outcome: ExecProcessOutcome;
   cwd?: string;
   warningText?: string;
+  aggregateOutputDropped?: boolean;
 }): AgentToolResult<ExecToolDetails> {
   const warningText = params.warningText?.trim() ? `${params.warningText}\n\n` : "";
+  const retentionCapNote = params.aggregateOutputDropped
+    ? "\n\n[earlier output was discarded at the retention cap and cannot be recovered]"
+    : "";
   if (params.outcome.status === "failed") {
     const linuxOomGuidance =
       params.outcome.failureKind === "signal" &&
@@ -25,7 +29,8 @@ export function buildExecForegroundResult(params: {
           "SIGKILL alone does not identify whether the Linux OOM killer, an operator, or another process sent it. " +
           "Check cgroup memory events or kernel logs. If they show memory pressure, narrow the command or adjust memory, concurrency, or resource limits."
         : "";
-    return failedTextResult(`${warningText}${params.outcome.reason}${linuxOomGuidance}`, {
+    const outputText = `${warningText}${params.outcome.reason}${linuxOomGuidance}${retentionCapNote}`;
+    return failedTextResult(outputText, {
       status: "failed",
       exitCode: params.outcome.exitCode ?? null,
       exitSignal: params.outcome.exitSignal,
@@ -38,7 +43,8 @@ export function buildExecForegroundResult(params: {
       cwd: params.cwd,
     });
   }
-  return textResult(`${warningText}${renderExecOutputText(params.outcome.aggregated)}`, {
+  const outputText = `${warningText}${renderExecOutputText(params.outcome.aggregated)}${retentionCapNote}`;
+  return textResult(outputText, {
     status: "completed",
     exitCode: params.outcome.exitCode,
     exitSignal: params.outcome.exitSignal,

--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -288,6 +288,7 @@ test.each([
       action: "log",
       sessionId,
     });
+    const runningPoll = await pollSession(processTool, "toolcall-running-aggregate-cap", sessionId);
     markExited(session, 0, null, "completed");
 
     const poll = await pollSession(processTool, "toolcall-aggregate-cap", sessionId);
@@ -297,6 +298,8 @@ test.each([
     });
     const text = poll.content[0]?.type === "text" ? poll.content[0].text : "";
     const runningLogText = runningLog.content[0]?.type === "text" ? runningLog.content[0].text : "";
+    const runningPollText =
+      runningPoll.content[0]?.type === "text" ? runningPoll.content[0].text : "";
     const finishedLogText =
       finishedLog.content[0]?.type === "text" ? finishedLog.content[0].text : "";
     const details = poll.details as { aggregated?: string };
@@ -306,6 +309,7 @@ test.each([
     expect(text).toContain(latestMarker);
     expect(text).toContain("discarded at the retention cap and cannot be recovered");
     expect(runningLogText).toContain("discarded at the retention cap and cannot be recovered");
+    expect(runningPollText).toContain("discarded at the retention cap and cannot be recovered");
     expect(finishedLogText).toContain("discarded at the retention cap and cannot be recovered");
     if (aggregateCap > 2_000) {
       expect(text).toContain("earlier retained output is omitted");

--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -264,6 +264,55 @@ test.each([
       expect(text).toContain(earlierMarker);
       expect(text).not.toContain("earlier retained output is omitted");
     }
+    expect(text).not.toContain("discarded at the retention cap");
+  },
+);
+
+test.each([
+  { name: "below the retained tail", outputLength: 1_500, aggregateCap: 1_000 },
+  { name: "above the retained tail", outputLength: 3_500, aggregateCap: 3_000 },
+])(
+  "process poll distinguishes discarded aggregate output $name",
+  async ({ outputLength, aggregateCap }) => {
+    const sessionId = `sess-aggregate-cap-${aggregateCap}`;
+    const { processTool, session } = createProcessSessionHarness(sessionId);
+    const earlierMarker = "[discarded-output]";
+    const latestMarker = "[latest-retained-output]";
+    const output = `${earlierMarker}${"x".repeat(
+      outputLength - earlierMarker.length - latestMarker.length,
+    )}${latestMarker}`;
+    session.maxOutputChars = aggregateCap;
+
+    appendOutput(session, "stdout", output);
+    const runningLog = await processTool.execute("toolcall-running-aggregate-cap", {
+      action: "log",
+      sessionId,
+    });
+    markExited(session, 0, null, "completed");
+
+    const poll = await pollSession(processTool, "toolcall-aggregate-cap", sessionId);
+    const finishedLog = await processTool.execute("toolcall-finished-aggregate-cap", {
+      action: "log",
+      sessionId,
+    });
+    const text = poll.content[0]?.type === "text" ? poll.content[0].text : "";
+    const runningLogText = runningLog.content[0]?.type === "text" ? runningLog.content[0].text : "";
+    const finishedLogText =
+      finishedLog.content[0]?.type === "text" ? finishedLog.content[0].text : "";
+    const details = poll.details as { aggregated?: string };
+
+    expect(details.aggregated).toHaveLength(aggregateCap);
+    expect(text).not.toContain(earlierMarker);
+    expect(text).toContain(latestMarker);
+    expect(text).toContain("discarded at the retention cap and cannot be recovered");
+    expect(runningLogText).toContain("discarded at the retention cap and cannot be recovered");
+    expect(finishedLogText).toContain("discarded at the retention cap and cannot be recovered");
+    if (aggregateCap > 2_000) {
+      expect(text).toContain("earlier retained output is omitted");
+      expect(text).toContain("action=log with offset and limit");
+    } else {
+      expect(text).not.toContain("action=log with offset and limit");
+    }
   },
 );
 

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -74,6 +74,12 @@ function defaultTailNote(totalLines: number, usingDefaultTail: boolean) {
   return `\n\n[showing last ${DEFAULT_LOG_TAIL_LINES} of ${totalLines} lines; pass offset/limit to page]`;
 }
 
+function retentionCapNote(session: Pick<ProcessSession, "totalOutputChars" | "aggregated">) {
+  return session.totalOutputChars > session.aggregated.length
+    ? "\n\n[earlier output was discarded at the retention cap and cannot be recovered]"
+    : "";
+}
+
 const MAX_POLL_WAIT_MS = 30_000;
 
 type RunningSessionRuntime = {
@@ -394,8 +400,8 @@ export function createProcessTool(
             if (scopedFinished) {
               resetPollRetrySuggestion(params.sessionId);
               acknowledgeNotifyOnExit(scopedFinished);
-              // Finished polls render a bounded tail; disclose retained content so the
-              // model can recover it through paged logs instead of treating it as complete.
+              // Aggregate-cap loss is permanent; tail omission remains pageable.
+              const aggregateOutputNote = retentionCapNote(scopedFinished);
               const retainedOutputNote =
                 scopedFinished.tail.length < scopedFinished.aggregated.length
                   ? "\n\n[earlier retained output is omitted; use action=log with offset and limit to page]"
@@ -409,6 +415,7 @@ export function createProcessTool(
                         `(no output recorded${
                           scopedFinished.truncated ? " — truncated to cap" : ""
                         })`) +
+                        aggregateOutputNote +
                         retainedOutputNote +
                         `\n\nProcess exited with ${
                           scopedFinished.exitSignal
@@ -478,6 +485,7 @@ export function createProcessTool(
               : "failed"
             : "running";
           const output = [stdout.trimEnd(), stderr.trimEnd()].filter(Boolean).join("\n").trim();
+          const aggregateOutputNote = exited ? retentionCapNote(scopedSession) : "";
           const retainedOutputNote = outputDropped
             ? "\n\n[earlier output is omitted from this poll; use action=log with offset and limit to inspect retained output]"
             : "";
@@ -495,6 +503,7 @@ export function createProcessTool(
                 type: "text",
                 text: appendExecTimeoutRetryGuidance(
                   (output || "(no new output)") +
+                    aggregateOutputNote +
                     retainedOutputNote +
                     (exited
                       ? `\n\nProcess exited with ${
@@ -557,7 +566,10 @@ export function createProcessTool(
                 {
                   type: "text",
                   text:
-                    (slice || "(no output yet)") + logDefaultTailNote + buildInputWaitHint(runtime),
+                    (slice || "(no output yet)") +
+                    logDefaultTailNote +
+                    retentionCapNote(scopedSession) +
+                    buildInputWaitHint(runtime),
                 },
               ],
               details: {
@@ -583,7 +595,13 @@ export function createProcessTool(
             const logDefaultTailNote = defaultTailNote(totalLines, window.usingDefaultTail);
             return {
               content: [
-                { type: "text", text: (slice || "(no output recorded)") + logDefaultTailNote },
+                {
+                  type: "text",
+                  text:
+                    (slice || "(no output recorded)") +
+                    logDefaultTailNote +
+                    retentionCapNote(scopedFinished),
+                },
               ],
               details: {
                 status,

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -485,7 +485,7 @@ export function createProcessTool(
               : "failed"
             : "running";
           const output = [stdout.trimEnd(), stderr.trimEnd()].filter(Boolean).join("\n").trim();
-          const aggregateOutputNote = exited ? retentionCapNote(scopedSession) : "";
+          const aggregateOutputNote = retentionCapNote(scopedSession);
           const retainedOutputNote = outputDropped
             ? "\n\n[earlier output is omitted from this poll; use action=log with offset and limit to inspect retained output]"
             : "";


### PR DESCRIPTION
Related: #120567
Follow-up to #120583 and its late exact-head review: https://github.com/openclaw/openclaw/pull/120583#issuecomment-5226389829

## What Problem This Solves

Fixes an issue where foreground and background process results could present retained output as complete after earlier bytes had been permanently discarded by the per-session aggregate cap. This remained possible after #120583 when the configured aggregate cap was smaller than the fixed poll tail, because `tail.length === aggregated.length` hid the unrecoverable loss.

## Why This Change Was Made

Use the producer-recorded `totalOutputChars > aggregated.length` fact to distinguish permanent aggregate-cap loss from pageable pending-buffer or retained-tail omission. Polls and logs append the permanent-loss warning independently from existing paging guidance; foreground exec results receive the same fact from their owning process session.

Two compact notification surfaces remain intentionally unchanged: automatic completion wake is explicitly a 180-character summary rather than a complete output projection, and the gateway approval follow-up outcome does not carry the authoritative total count. Expanding either contract speculatively would add state without fixing a projection that claims completeness.

## User Impact

Agents now know when earlier command output is gone and cannot be recovered. When output is merely outside the visible poll tail, the result still points to paged `process log`; when both cases occur, both facts are shown. Running and finished logs also disclose aggregate-cap loss instead of looking complete. Defaults, aggregate retention, process lifecycle, and log paging are unchanged.

## Evidence

- Focused Vitest: 76 tests passed across `bash-tools.process.poll-timeout.test.ts`, `bash-process-registry.test.ts`, and `bash-tools.exec-runtime.test.ts`.
- Aggregate-cap regressions cover a 1,000-character cap below the 2,000-character tail and a 3,000-character cap where discarded output and pageable retained-tail omission coexist. Running and finished logs prove only retained output remains inspectable.
- `oxfmt` and `git diff --check` passed.
- Changed-surface conflict, environment, max-lines, attribution, dependency, formatting, SDK, deprecation, plugin-boundary, patch, dead-code, and temp-directory guards passed. The local fallback later hit the known stale installed `string-width` type in untouched terminal code; current hosted `main` CI proves that lane green.
- Codex autoreview: clean, no accepted/actionable findings (`patch is correct`, confidence 0.98).
- Rebase onto current `origin/main` was patch-identical (`git patch-id --stable` unchanged).
- Production delta: +34/-6 (net +28), justified by the owner-boundary completeness signal across poll, log, exit-during-poll, and foreground projections. Tests +73/-0; docs +6/-6.

[AI-assisted]
