### PR TITLE
fix(telegram): unblock chats after media claim timeout

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
@@ -97,7 +97,7 @@ export function createTelegramInboundMediaGroupRuntime(
     resolveGroupRequireMention,
   } = params;
   const {
-    mediaRuntimeWithAbort,
+    resolveMediaRuntime,
     promptContextBoundaryOptions,
     latestPromptContextMinTimestampMs,
     latestPromptContextAmbientWatermark,
@@ -318,6 +318,9 @@ export function createTelegramInboundMediaGroupRuntime(
       }
       const allMedia: TelegramMediaRef[] = [];
       const selection = new Map<string, "include" | "exclude">();
+      const mediaRuntime = resolveMediaRuntime(
+        ...entry.spooledReplayParticipants.map((participant) => participant.abortSignal),
+      );
       let materializedCount = 0;
       let skippedCount = 0;
       for (const { ctx, msg } of entry.messages) {
@@ -325,12 +328,11 @@ export function createTelegramInboundMediaGroupRuntime(
         const nativeKind = resolveTelegramPrimaryMedia(msg)?.kind ?? "document";
         let media;
         try {
-          media = await resolveMedia({ ctx, maxBytes: mediaMaxBytes, ...mediaRuntimeWithAbort });
+          media = await resolveMedia({ ctx, maxBytes: mediaMaxBytes, ...mediaRuntime });
         } catch (error) {
           if (
             entry.spooledReplayParticipants.length > 0 &&
-            (mediaRuntimeWithAbort.abortSignal?.aborted ||
-              isDurablyRetryableInboundMediaError(error))
+            (mediaRuntime.abortSignal?.aborted || isDurablyRetryableInboundMediaError(error))
           ) {
             throw error;
           }

--- a/extensions/telegram/src/bot-handlers.inbound.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound.runtime.ts
@@ -57,7 +57,7 @@ export function createTelegramHandlerInboundRuntime(
   messageRuntime: TelegramHandlerMessageRuntime,
 ) {
   const {
-    mediaRuntimeWithAbort,
+    resolveMediaRuntime,
     promptContextBoundaryOptions,
     releaseDispatchDedupeClaims,
     createSpooledReplayParticipantForBufferedWork,
@@ -225,12 +225,13 @@ export function createTelegramHandlerInboundRuntime(
     }
 
     const nativeMedia = resolveTelegramPrimaryMedia(msg);
+    const mediaRuntime = resolveMediaRuntime();
     let media: Awaited<ReturnType<typeof resolveMedia>> = null;
     try {
       media = await resolveMedia({
         ctx,
         maxBytes: mediaMaxBytes,
-        ...mediaRuntimeWithAbort,
+        ...mediaRuntime,
       });
     } catch (mediaErr) {
       const replayingSpooledUpdate = isTelegramSpooledReplayUpdate(ctx.update);
@@ -241,10 +242,7 @@ export function createTelegramHandlerInboundRuntime(
           messageThreadId: resolvedThreadId ?? dmThreadId,
         }),
       );
-      if (
-        mediaRuntimeWithAbort.abortSignal?.aborted &&
-        isDurablyRetryableInboundMediaError(mediaErr)
-      ) {
+      if (mediaRuntime.abortSignal?.aborted && isDurablyRetryableInboundMediaError(mediaErr)) {
         // Abort mid-media-resolution must stay retryable for live updates too;
         // a clean claim release would settle the update as handled and silently
         // drop the message during shutdown or deadline cancellation.

--- a/extensions/telegram/src/bot-handlers.message.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message.runtime.ts
@@ -20,6 +20,7 @@ import {
   createTelegramSpooledReplayDeferredParticipant,
   createTelegramSpooledReplayParticipant,
   getTelegramSpooledReplayDeferredParticipant,
+  getTelegramSpooledReplayLifecycle,
   isTelegramSpooledReplayUpdate,
   recordTelegramMessageProcessingResult,
   type TelegramMessageProcessingResult,
@@ -54,13 +55,19 @@ export function createTelegramHandlerMessageRuntime({
     token,
     transport: telegramTransport,
   });
-  const mediaAbortSignal =
-    opts.mediaAbortSignal && opts.fetchAbortSignal
-      ? AbortSignal.any([opts.mediaAbortSignal, opts.fetchAbortSignal])
-      : (opts.mediaAbortSignal ?? opts.fetchAbortSignal);
-  const mediaRuntimeWithAbort = {
-    ...mediaRuntimeOptions,
-    abortSignal: mediaAbortSignal,
+  // Resolve the ALS owner at operation time; buffered callers retain ownership
+  // after that frame ends by passing their participant signals explicitly.
+  const resolveMediaRuntime = (...explicitSignals: AbortSignal[]) => {
+    const abortSignals = [
+      opts.mediaAbortSignal,
+      opts.fetchAbortSignal,
+      getTelegramSpooledReplayLifecycle()?.abortSignal,
+      ...explicitSignals,
+    ].filter((signal): signal is AbortSignal => signal !== undefined);
+    return {
+      ...mediaRuntimeOptions,
+      abortSignal: abortSignals.length > 1 ? AbortSignal.any(abortSignals) : abortSignals[0],
+    };
   };
   const sessionRuntime = createTelegramMessageSessionRuntime({
     accountId,
@@ -105,7 +112,9 @@ export function createTelegramHandlerMessageRuntime({
     chain: TelegramCachedMessageNode[],
     shouldHydrateMedia: (node: TelegramCachedMessageNode, index: number) => Promise<boolean>,
     durableMediaReplay: boolean,
+    ...participantSignals: AbortSignal[]
   ): Promise<{ replyMedia: TelegramMediaRef[]; replyChain: TelegramReplyChainEntry[] }> => {
+    const mediaRuntime = resolveMediaRuntime(...participantSignals);
     const replyMedia: TelegramMediaRef[] = [];
     const replyChain: TelegramReplyChainEntry[] = [];
     for (const [index, node] of chain.entries()) {
@@ -124,7 +133,7 @@ export function createTelegramHandlerMessageRuntime({
               getFile: async (signal) => await bot.api.getFile(replyFileId, signal),
             },
             maxBytes: mediaMaxBytes,
-            ...mediaRuntimeWithAbort,
+            ...mediaRuntime,
           });
           mediaRef = media
             ? {
@@ -137,7 +146,7 @@ export function createTelegramHandlerMessageRuntime({
         } catch (err) {
           // Only durable ingress can replay a reply-media abort. Live polling must
           // preserve the current text instead of acknowledging it without dispatch.
-          if (mediaRuntimeWithAbort.abortSignal?.aborted && durableMediaReplay) {
+          if (mediaRuntime.abortSignal?.aborted && durableMediaReplay) {
             recordTelegramMessageProcessingResult({ kind: "failed-retryable", error: err });
             throw err;
           }
@@ -319,6 +328,8 @@ export function createTelegramHandlerMessageRuntime({
         replyChainNodes,
         shouldHydrateReplyMedia,
         durableMediaReplay,
+        ...spooledReplayParticipants.map((participant) => participant.abortSignal),
+        ...(params.spooledReplayAbortSignal ? [params.spooledReplayAbortSignal] : []),
       );
       const promptContextMediaByMessageId = new Map<string, TelegramMediaRef>();
       const currentMessageId =
@@ -407,7 +418,7 @@ export function createTelegramHandlerMessageRuntime({
   };
 
   return {
-    mediaRuntimeWithAbort,
+    resolveMediaRuntime,
     normalizePromptContextMinTimestampMs,
     promptContextBoundaryOptions,
     latestPromptContextMinTimestampMs,

--- a/extensions/telegram/src/bot-processing-outcome.ts
+++ b/extensions/telegram/src/bot-processing-outcome.ts
@@ -94,6 +94,9 @@ export function createTelegramSpooledReplayParticipant(
 ): TelegramSpooledReplayDeferredParticipant {
   const abortController = new AbortController();
   const ownerAbortSignal = telegramSpooledReplayFrames.getStore()?.lifecycle?.abortSignal;
+  const abortSignal = ownerAbortSignal
+    ? AbortSignal.any([abortController.signal, ownerAbortSignal])
+    : abortController.signal;
   let settled = false;
   let ownerAbortedWhilePending = ownerAbortSignal?.aborted === true;
   let settlementHeld = false;
@@ -121,7 +124,9 @@ export function createTelegramSpooledReplayParticipant(
   };
   return {
     key,
-    abortSignal: abortController.signal,
+    // Buffered work outlives the ALS frame, so its signal must retain the
+    // claim owner's pre-adoption cancellation boundary.
+    abortSignal,
     task,
     isSettled: () => settled,
     wasOwnerAbortedWhilePending: () => ownerAbortedWhilePending,

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -4263,37 +4263,41 @@ describe("createTelegramBot", () => {
     expect(payload.Body).toContain("continue after polling restart");
   });
 
-  it("durably retries a spooled reply when shutdown aborts reply media", async () => {
-    const botShutdown = new AbortController();
-    const mediaAbort = new AbortController();
-    getFileSpy.mockImplementationOnce(async () => {
-      botShutdown.abort();
+  it("durably retries a spooled reply when its claim owner aborts reply media", async () => {
+    const claimOwner = new AbortController();
+    getFileSpy.mockImplementationOnce(async (_fileId, signal) => {
+      claimOwner.abort(new Error("claim adoption stalled"));
+      expect((signal as AbortSignal | undefined)?.aborted).toBe(true);
       throw new Error("Bad Request: file is too big");
     });
 
-    createTelegramBot({
-      token: "tok",
-      fetchAbortSignal: botShutdown.signal,
-      mediaAbortSignal: mediaAbort.signal,
-    });
+    createTelegramBot({ token: "tok" });
     const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
     const update = { update_id: 98081, message: createReplyPhotoMessage("keep the old image") };
 
     const { result } = await runWithTelegramUpdateProcessingFrame(() =>
-      withTelegramSpooledReplayUpdate(update, () =>
-        handler({
-          update,
-          message: update.message,
-          me: { username: "openclaw_bot" },
-          getFile: async () => ({}),
-        }),
+      runWithTelegramSpooledReplayUpdate(
+        update,
+        () =>
+          handler({
+            update,
+            message: update.message,
+            me: { username: "openclaw_bot" },
+            getFile: async () => ({}),
+          }),
+        {
+          abortSignal: claimOwner.signal,
+          onAdopted: vi.fn(),
+          onDeferred: vi.fn(),
+          onAdoptionFinalizing: vi.fn(),
+          onAbandoned: vi.fn(),
+        },
       ),
     );
 
     expect(result).toEqual({ kind: "failed-retryable", error: expect.any(Error) });
     expect(getFileSpy).toHaveBeenCalledWith("reply-photo-1", expect.any(AbortSignal));
     expect(replySpy).not.toHaveBeenCalled();
-    expect(mediaAbort.signal.aborted).toBe(false);
   });
 
   it("hydrates reply chains from cached Telegram messages", async () => {

--- a/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
+++ b/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
@@ -114,6 +114,25 @@ function photoUpdate(params: { updateId: number; messageId: number; caption?: st
   };
 }
 
+function singletonPhotoUpdate(params: { updateId: number; messageId: number }) {
+  const update = photoUpdate(params);
+  const { media_group_id: _mediaGroupId, ...message } = update.message;
+  return { ...update, message };
+}
+
+function textUpdate(params: { updateId: number; messageId: number; text: string }) {
+  return {
+    update_id: params.updateId,
+    message: {
+      message_id: params.messageId,
+      date: 1_736_380_800 + params.messageId,
+      chat: { id: 111, type: "private" as const, first_name: "Ada" },
+      from: { id: 111, is_bot: false, first_name: "Ada" },
+      text: params.text,
+    },
+  };
+}
+
 function forwardedTextUpdate(params: { updateId: number; messageId: number; text: string }) {
   return {
     update_id: params.updateId,
@@ -133,12 +152,15 @@ function forwardedTextUpdate(params: { updateId: number; messageId: number; text
   };
 }
 
-function createBotApiTransport(): TelegramTransport {
+function createBotApiTransport(params: { onGetFile?: (call: number) => Response } = {}) {
   let getFileCall = 0;
   const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
     const url = input instanceof Request ? input.url : input instanceof URL ? input.href : input;
     if (url.includes("/getFile")) {
       getFileCall += 1;
+      if (params.onGetFile) {
+        return params.onGetFile(getFileCall);
+      }
       return new Response(
         JSON.stringify({
           ok: true,
@@ -224,6 +246,7 @@ describe("Telegram durable ingress coalescing", () => {
   let activeResources: Array<{
     monitor: ReturnType<typeof createTelegramTransportIngressMonitor>;
     telegramTransport: TelegramTransport;
+    abortController: AbortController;
   }>;
 
   beforeEach(async () => {
@@ -247,7 +270,8 @@ describe("Telegram durable ingress coalescing", () => {
 
   afterEach(async () => {
     await Promise.all(
-      activeResources.map(async ({ monitor, telegramTransport }) => {
+      activeResources.map(async ({ monitor, telegramTransport, abortController }) => {
+        abortController.abort(new Error("test cleanup"));
         await monitor.stop();
         await telegramTransport.close();
       }),
@@ -262,20 +286,31 @@ describe("Telegram durable ingress coalescing", () => {
     await fs.rm(stateDir, { recursive: true, force: true });
   });
 
-  async function createMonitor() {
-    const telegramTransport = createBotApiTransport();
+  async function createMonitor(
+    options: {
+      telegramTransport?: TelegramTransport;
+      adoptionStallTimeoutMs?: number;
+      onRuntimeError?: (error: unknown) => void;
+    } = {},
+  ) {
+    const telegramTransport = options.telegramTransport ?? createBotApiTransport();
+    const abortController = new AbortController();
     const bot = createTelegramBot({
       token: "tok",
       botInfo: telegramBotInfoForTest,
       config: cfg,
       telegramDeps: createTelegramDeps(stateDir),
       telegramTransport,
+      fetchAbortSignal: abortController.signal,
+      mediaAbortSignal: abortController.signal,
       testTimings: { mediaGroupFlushMs: 40, textFragmentGapMs: 20 },
       runtime: {
         log: () => {},
-        error: (error) => {
-          throw error instanceof Error ? error : new Error(String(error));
-        },
+        error:
+          options.onRuntimeError ??
+          ((error) => {
+            throw error instanceof Error ? error : new Error(String(error));
+          }),
         getRuntimeConfig: () => cfg,
         exit: () => {
           throw new Error("unexpected runtime exit");
@@ -288,12 +323,93 @@ describe("Telegram durable ingress coalescing", () => {
       cfg,
       accountId: "default",
       botInfo: telegramBotInfoForTest,
+      ...(options.adoptionStallTimeoutMs === undefined
+        ? {}
+        : { adoptionStallTimeoutMs: options.adoptionStallTimeoutMs }),
       pollIntervalMs: 10,
     });
-    const resources = { monitor, telegramTransport };
+    const resources = { monitor, telegramTransport, abortController };
     activeResources.push(resources);
     return resources;
   }
+
+  it.each([
+    {
+      label: "current-message",
+      update: singletonPhotoUpdate({ updateId: 601, messageId: 1 }),
+      expectBufferedFailure: false,
+    },
+    {
+      label: "buffered media-group",
+      update: photoUpdate({ updateId: 602, messageId: 2 }),
+      expectBufferedFailure: true,
+    },
+  ])(
+    "cancels $label hydration at the claim watchdog and releases the same-chat lane",
+    async ({ update, expectBufferedFailure }) => {
+      const getFile = vi.fn(
+        () =>
+          new Response(
+            JSON.stringify({
+              ok: false,
+              error_code: 429,
+              description: "Too Many Requests: retry after 60",
+              parameters: { retry_after: 60 },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      );
+      const runtimeError = vi.fn();
+      const telegramTransport = createBotApiTransport({ onGetFile: getFile });
+      const { monitor } = await createMonitor({
+        telegramTransport,
+        adoptionStallTimeoutMs: 120,
+        onRuntimeError: runtimeError,
+      });
+      const nextUpdateId = update.update_id + 10;
+      const next = textUpdate({
+        updateId: nextUpdateId,
+        messageId: update.message.message_id + 10,
+        text: "next message after stalled media",
+      });
+      monitor.start();
+
+      await monitor.admit(update);
+      await vi.waitFor(() => expect(getFile).toHaveBeenCalledOnce(), {
+        timeout: 1_000,
+        interval: 5,
+      });
+      const nextAdmittedAt = Date.now();
+      await monitor.admit(next);
+      const turn = await awaitSingleDownstreamTurn();
+
+      expect(Date.now() - nextAdmittedAt).toBeLessThan(1_000);
+      expect(turn.Body).toContain("next message after stalled media");
+      expect(turn.Body).not.toContain("<media:image>");
+      const queue = openTelegramIngressQueue(spoolDir);
+      await vi.waitFor(async () => {
+        expect(await queue.listFailed?.({ limit: "all" })).toEqual([
+          expect.objectContaining({
+            id: telegramQueueEventId(update.update_id),
+            reason: "handler-timeout",
+          }),
+        ]);
+      });
+      await expect(
+        queue.enqueue(telegramQueueEventId(nextUpdateId), {} as never),
+      ).resolves.toMatchObject({ kind: "completed" });
+      if (expectBufferedFailure) {
+        await vi.waitFor(() => expect(runtimeError).toHaveBeenCalledOnce());
+      } else {
+        expect(runtimeError).not.toHaveBeenCalled();
+      }
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      expect(getFile).toHaveBeenCalledOnce();
+      expect(downstreamTurns).toHaveBeenCalledOnce();
+    },
+  );
 
   it("coalesces album members admitted a few milliseconds apart", async () => {
     const { monitor, telegramTransport } = await createMonitor();

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -5,6 +5,7 @@ import { request, type IncomingMessage } from "node:http";
 import os from "node:os";
 import nodePath from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
+import { DEFAULT_INGRESS_ADOPTION_STALL_MS } from "openclaw/plugin-sdk/channel-outbound";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests as createChannelIngressQueue,
@@ -16,6 +17,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { buildTelegramApprovalCallbackData } from "./approval-callback-data.js";
 import {
   createTelegramSpooledReplayDeferredParticipant,
+  getTelegramSpooledReplayLifecycle,
   type TelegramSpooledReplayDeferredParticipant,
   type TelegramSpooledReplaySettlementHold,
 } from "./bot-processing-outcome.js";
@@ -270,6 +272,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   vi.useRealTimers();
+  vi.unstubAllEnvs();
   clearTelegramRuntime();
   closeOpenClawStateDatabaseForTest();
   const stateDir = webhookStateDir;
@@ -1134,6 +1137,64 @@ describe("startTelegramWebhook", () => {
     }
   });
 
+  it.each([
+    {
+      label: "environment override",
+      envValue: "50",
+      timeoutMs: 50,
+    },
+    {
+      label: "canonical default",
+      envValue: undefined,
+      timeoutMs: DEFAULT_INGRESS_ADOPTION_STALL_MS,
+    },
+  ])("uses the $label for webhook adoption stalls", async ({ envValue, timeoutMs }) => {
+    vi.stubEnv("OPENCLAW_TELEGRAM_SPOOLED_HANDLER_TIMEOUT_MS", envValue);
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    let finishUpdate: (() => void) | undefined;
+    const active: {
+      dispatchStartedAt?: number;
+      lifecycle?: NonNullable<ReturnType<typeof getTelegramSpooledReplayLifecycle>>;
+    } = {};
+    await writeTelegramSpooledUpdate({
+      spoolDir: requireWebhookSpoolDir(),
+      update: { update_id: 39, message: { chat: { id: 123 }, text: "stalled" } },
+    });
+    handleUpdateSpy.mockImplementationOnce(async () => {
+      active.dispatchStartedAt = Date.now();
+      active.lifecycle = getTelegramSpooledReplayLifecycle();
+      await new Promise<void>((resolve) => {
+        finishUpdate = resolve;
+      });
+    });
+
+    const started = await startTelegramWebhook({
+      token: TELEGRAM_TOKEN,
+      port: 0,
+      secret: TELEGRAM_SECRET,
+      path: TELEGRAM_WEBHOOK_PATH,
+      spoolDir: requireWebhookSpoolDir(),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    });
+    try {
+      await waitForWebhookState(() => expect(active.lifecycle).toBeDefined());
+      const { dispatchStartedAt, lifecycle } = active;
+      if (!lifecycle || dispatchStartedAt === undefined) {
+        throw new Error("expected active webhook ingress lifecycle");
+      }
+      expect(lifecycle.abortSignal.aborted).toBe(false);
+      const remainingMs = timeoutMs - (Date.now() - dispatchStartedAt);
+      expect(remainingMs).toBeGreaterThan(0);
+      await vi.advanceTimersByTimeAsync(remainingMs - 1);
+      expect(lifecycle.abortSignal.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(lifecycle.abortSignal.aborted).toBe(true);
+    } finally {
+      finishUpdate?.();
+      await started.stop();
+    }
+  });
+
   it("keeps a timed-out webhook lane guarded until replay settles", async () => {
     vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
     try {
@@ -1169,7 +1230,7 @@ describe("startTelegramWebhook", () => {
       });
       try {
         await waitForWebhookState(() => expect(seenUpdateIds).toEqual([40]));
-        await vi.advanceTimersByTimeAsync(25 * 60_000 + 10_000);
+        await vi.advanceTimersByTimeAsync(DEFAULT_INGRESS_ADOPTION_STALL_MS + 10_000);
         await yieldWebhookTask();
         expect(seenUpdateIds).toEqual([40]);
 
@@ -1209,7 +1270,7 @@ describe("startTelegramWebhook", () => {
       });
       try {
         await waitForWebhookState(() => expect(participant).toBeDefined());
-        await vi.advanceTimersByTimeAsync(25 * 60_000 + 10_000);
+        await vi.advanceTimersByTimeAsync(DEFAULT_INGRESS_ADOPTION_STALL_MS + 10_000);
         await yieldWebhookTask();
 
         expect(participant?.abortSignal.aborted).toBe(false);

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -406,8 +406,6 @@ export async function startTelegramWebhook(opts: {
       botInfo,
       cfg: opts.config ?? {},
       accountId: opts.accountId ?? "default",
-      // Pre-migration product default: 25m claim→adoption stall for webhook.
-      adoptionStallTimeoutMs: 25 * 60_000,
       pollIntervalMs: TELEGRAM_WEBHOOK_SPOOLED_DRAIN_INTERVAL_MS,
       abortSignal: webhookAbortSignal,
       onLog: (message) => log(`webhook ${message}`),


### PR DESCRIPTION
Closes #120704

AI-assisted change; implementation and review were performed with coding agents and verified directly against the final diff.

## What Problem This Solves

Fixes an issue where a Telegram media update could time out in durable ingress while its `getFile` flood-control wait kept the chat's serialization lane alive. Later commands in the same chat could appear unresponsive until the media retry deadline, even though the original queue claim was already recorded as failed.

Webhook mode also used a private 25-minute claim-to-adoption timeout, so the documented/configured Telegram timeout did not apply consistently across transports.

## Why This Change Was Made

Telegram now resolves media cancellation at operation time from the account/fetch lifecycle, the active durable claim, and any buffered replay participants. Buffered participants retain their claim owner's signal after the async-local frame ends, so singleton media, reply-chain media, and albums all stop promptly when their claim is abandoned.

Webhook ingress no longer overrides the shared timeout; polling and webhook both use the configured environment value or canonical default. No retry duration, queue policy, config surface, or fallback path was added.

Production delta: `+37/-23` (net `+14`) for the claim-owner boundary. Test delta: `+209/-28` (net `+181`).

## User Impact

When Telegram asks OpenClaw to wait before retrying media, a durable claim timeout now releases stale pre-adoption work instead of leaving later messages blocked behind it. Timed-out media cannot execute or reply late, and webhook operators get the same timeout behavior as polling operators.

The shared multi-agent event-loop stall tracked in #120074 is separate and already fixed on `main`.

## Evidence

- Real macOS Telegram setup:
  - bot creation, channel configuration, DM pairing, and approval completed successfully
  - steady-state `/status`: 770 ms end to end
  - model-backed turn: 10.9 s total, 0 ms lane wait, 8.25 s model call, 0.91 s Telegram delivery
- Exact finalized boundary E2E: `telegram-ingress-coalescing.e2e.test.ts` — 7/7 passed, covering singleton media, buffered album cancellation after ALS ends, handler-timeout, same-chat progress, and no late retry/turn.
- Finalized focused Telegram suite — 389/389 passed across 7 files.
- Post-type-fix `bot.test.ts` + `webhook.test.ts` — 232/232 passed.
- `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build` — passed; standard `pnpm build` also passed.
- `check-changed` local fallback — passed formatting, production/test typechecks, extension lint, plugin boundaries, dead exports, database/media/runtime guards, and import-cycle checks.
- `git diff --check` — passed.
- Codex autoreview (`--mode uncommitted`, high reasoning) — TruffleHog clean; no accepted/actionable findings.

Remote proof note: Blacksmith Testbox could not start because the local `blacksmith` client is unavailable, and the brokered AWS/Azure backends returned unauthorized. Trusted-source heavy proof therefore used the repository's documented local fallback with worktree-scoped locks and unique Vitest cache paths.
