### PR TITLE
fix(gateway): isolate remote probe device auth

### DIFF
--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -258,6 +258,7 @@ type ProbeGatewayCall = {
   };
   preauthHandshakeTimeoutMs?: number;
   originScopedDeviceAuth?: boolean;
+  suppressStoredDeviceAuth?: boolean;
   timeoutMs?: number;
   tlsFingerprint?: string;
   url?: string;
@@ -999,9 +1000,16 @@ describe("gateway-status command", () => {
     expect(probeGateway).toHaveBeenCalled();
     const tunnelCall = probeGateway.mock.calls.find(
       (call) => typeof call?.[0]?.url === "string" && call[0].url.startsWith("ws://127.0.0.1:"),
-    )?.[0] as { auth?: { token?: string }; originScopedDeviceAuth?: boolean } | undefined;
+    )?.[0] as
+      | {
+          auth?: { token?: string };
+          originScopedDeviceAuth?: boolean;
+          suppressStoredDeviceAuth?: boolean;
+        }
+      | undefined;
     expect(tunnelCall?.auth?.token).toBe("rtok");
-    expect(tunnelCall?.originScopedDeviceAuth).toBe(true);
+    expect(tunnelCall?.originScopedDeviceAuth).toBeUndefined();
+    expect(tunnelCall?.suppressStoredDeviceAuth).toBe(true);
     expect(sshStop).toHaveBeenCalledTimes(1);
 
     const parsed = JSON.parse(runtimeLogs.join("\n")) as Record<string, unknown>;

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -257,6 +257,7 @@ type ProbeGatewayCall = {
     token?: string;
   };
   preauthHandshakeTimeoutMs?: number;
+  originScopedDeviceAuth?: boolean;
   timeoutMs?: number;
   tlsFingerprint?: string;
   url?: string;
@@ -998,8 +999,9 @@ describe("gateway-status command", () => {
     expect(probeGateway).toHaveBeenCalled();
     const tunnelCall = probeGateway.mock.calls.find(
       (call) => typeof call?.[0]?.url === "string" && call[0].url.startsWith("ws://127.0.0.1:"),
-    )?.[0] as { auth?: { token?: string } } | undefined;
+    )?.[0] as { auth?: { token?: string }; originScopedDeviceAuth?: boolean } | undefined;
     expect(tunnelCall?.auth?.token).toBe("rtok");
+    expect(tunnelCall?.originScopedDeviceAuth).toBe(true);
     expect(sshStop).toHaveBeenCalledTimes(1);
 
     const parsed = JSON.parse(runtimeLogs.join("\n")) as Record<string, unknown>;
@@ -1024,6 +1026,7 @@ describe("gateway-status command", () => {
 
     expect(loadGatewayTlsRuntime).toHaveBeenCalledTimes(1);
     const localProbeCall = requireProbeCall("wss://127.0.0.1:18789");
+    expect(localProbeCall.originScopedDeviceAuth).toBeUndefined();
     expect(localProbeCall.tlsFingerprint).toBe("sha256:local-fingerprint");
     expect(localProbeCall.timeoutMs).toBe(15_000);
   });
@@ -1142,7 +1145,9 @@ describe("gateway-status command", () => {
 
     await runGatewayStatus(runtime, { timeout: "15000", json: true });
 
-    expect(requireProbeCall("wss://remote.example:18789").timeoutMs).toBe(15_000);
+    const remoteProbeCall = requireProbeCall("wss://remote.example:18789");
+    expect(remoteProbeCall.timeoutMs).toBe(15_000);
+    expect(remoteProbeCall.originScopedDeviceAuth).toBe(true);
   });
 
   it("keeps inactive local loopback probes on the short timeout in remote mode", async () => {

--- a/src/commands/gateway-status/probe-run.ts
+++ b/src/commands/gateway-status/probe-run.ts
@@ -133,7 +133,11 @@ export async function runGatewayStatusProbePass(params: {
           url: target.url,
           // Explicit, configured-remote, and SSH targets must not inherit the
           // local Gateway's device token, even when the transport is loopback.
-          ...(target.kind !== "localLoopback" ? { originScopedDeviceAuth: true } : {}),
+          ...(target.kind === "sshTunnel"
+            ? { suppressStoredDeviceAuth: true }
+            : target.kind !== "localLoopback"
+              ? { originScopedDeviceAuth: true }
+              : {}),
           auth: {
             token: authResolution.token,
             password: authResolution.password,

--- a/src/commands/gateway-status/probe-run.ts
+++ b/src/commands/gateway-status/probe-run.ts
@@ -131,6 +131,9 @@ export async function runGatewayStatusProbePass(params: {
         });
         const probe = await probeGateway({
           url: target.url,
+          // Explicit, configured-remote, and SSH targets must not inherit the
+          // local Gateway's device token, even when the transport is loopback.
+          ...(target.kind !== "localLoopback" ? { originScopedDeviceAuth: true } : {}),
           auth: {
             token: authResolution.token,
             password: authResolution.password,

--- a/src/gateway/probe.device-auth-scope.test.ts
+++ b/src/gateway/probe.device-auth-scope.test.ts
@@ -90,10 +90,12 @@ async function captureProbeConnectFrame(params: {
   url: string;
   env: NodeJS.ProcessEnv;
   auth?: { token?: string; password?: string };
+  suppressStoredDeviceAuth?: boolean;
 }): Promise<ConnectFrame> {
   const probePromise = probeGateway({
     url: params.url,
     auth: params.auth,
+    suppressStoredDeviceAuth: params.suppressStoredDeviceAuth,
     env: params.env,
     timeoutMs: 2_000,
     includeDetails: false,
@@ -204,6 +206,51 @@ describe("probeGateway device auth scope", () => {
       });
 
       expect(connect.params?.auth?.token).toBe("explicit-remote-token");
+      expect(connect.params?.auth?.deviceToken).toBeUndefined();
+    });
+  });
+
+  it("does not reuse stored auth across SSH targets sharing a forwarded port", async () => {
+    await withTempDir("openclaw-probe-ssh-scope-", async (stateDir) => {
+      const env = createEnv(stateDir);
+      const identity = loadOrCreateDeviceIdentity({ env });
+      storeDeviceAuthToken({
+        deviceId: identity.deviceId,
+        role: "operator",
+        token: "local-device-token",
+        env,
+      });
+      storeOriginDeviceToken({
+        gatewayScope: gatewayOriginScope("ws://127.0.0.1:18789"),
+        deviceId: identity.deviceId,
+        role: "operator",
+        token: "prior-ssh-target-token",
+        env,
+      });
+
+      const connect = await captureProbeConnectFrame({
+        url: "ws://127.0.0.1:18789",
+        suppressStoredDeviceAuth: true,
+        env,
+      });
+
+      expect(connect.params?.auth?.token).toBeUndefined();
+      expect(connect.params?.auth?.deviceToken).toBeUndefined();
+      expect(connect.params?.device).toBeUndefined();
+    });
+  });
+
+  it("keeps explicit auth available through SSH forwarded transports", async () => {
+    await withTempDir("openclaw-probe-ssh-explicit-", async (stateDir) => {
+      const env = createEnv(stateDir);
+      const connect = await captureProbeConnectFrame({
+        url: "ws://127.0.0.1:18789",
+        auth: { token: "explicit-ssh-token" },
+        suppressStoredDeviceAuth: true,
+        env,
+      });
+
+      expect(connect.params?.auth?.token).toBe("explicit-ssh-token");
       expect(connect.params?.auth?.deviceToken).toBeUndefined();
     });
   });

--- a/src/gateway/probe.device-auth-scope.test.ts
+++ b/src/gateway/probe.device-auth-scope.test.ts
@@ -1,0 +1,207 @@
+// Probe device-auth scope tests exercise the real probe -> client -> connect-frame path.
+import { Buffer } from "node:buffer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { gatewayOriginScope } from "../../packages/gateway-client/src/gateway-origin-scope.js";
+import { storeDeviceAuthToken, storeOriginDeviceToken } from "../infra/device-auth-store.js";
+import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withTempDir } from "../test-utils/temp-dir.js";
+
+type WebSocketEvent = "open" | "message" | "close" | "error";
+
+const webSockets = vi.hoisted((): ProbeWebSocket[] => []);
+
+class ProbeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readonly sent: string[] = [];
+  readyState = ProbeWebSocket.CONNECTING;
+  binaryType = "nodebuffer";
+  private readonly handlers: Record<WebSocketEvent, Array<(...args: unknown[]) => void>> = {
+    open: [],
+    message: [],
+    close: [],
+    error: [],
+  };
+
+  constructor(_url: string, _options?: unknown) {
+    webSockets.push(this);
+  }
+
+  on(event: WebSocketEvent, handler: (...args: unknown[]) => void): void {
+    this.handlers[event].push(handler);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(code = 1000, reason = ""): void {
+    if (this.readyState === ProbeWebSocket.CLOSED) {
+      return;
+    }
+    this.emitClose(code, reason);
+  }
+
+  terminate(): void {
+    this.emitClose(1006, "terminated");
+  }
+
+  emitOpen(): void {
+    this.readyState = ProbeWebSocket.OPEN;
+    for (const handler of this.handlers.open) {
+      handler();
+    }
+  }
+
+  emitMessage(data: string): void {
+    for (const handler of this.handlers.message) {
+      handler(data);
+    }
+  }
+
+  emitClose(code: number, reason: string): void {
+    this.readyState = ProbeWebSocket.CLOSED;
+    for (const handler of this.handlers.close) {
+      handler(code, Buffer.from(reason));
+    }
+  }
+}
+
+vi.mock("ws", () => ({ WebSocket: ProbeWebSocket }));
+
+const { probeGateway } = await import("./probe.js");
+
+type ConnectFrame = {
+  params?: {
+    auth?: { token?: string; deviceToken?: string; password?: string };
+    device?: { id?: string };
+  };
+};
+
+function createEnv(stateDir: string): NodeJS.ProcessEnv {
+  return { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_TEST_FAST: "1" };
+}
+
+async function captureProbeConnectFrame(params: {
+  url: string;
+  env: NodeJS.ProcessEnv;
+  auth?: { token?: string; password?: string };
+}): Promise<ConnectFrame> {
+  const probePromise = probeGateway({
+    url: params.url,
+    auth: params.auth,
+    env: params.env,
+    timeoutMs: 2_000,
+    includeDetails: false,
+  });
+  await vi.waitFor(() => expect(webSockets).toHaveLength(1));
+  const socket = webSockets[0];
+  socket.emitOpen();
+  socket.emitMessage(
+    JSON.stringify({
+      type: "event",
+      event: "connect.challenge",
+      payload: { nonce: "probe-scope-nonce", ts: Date.now() },
+    }),
+  );
+  await vi.waitFor(() => {
+    expect(socket.sent.some((frame) => frame.includes('"method":"connect"'))).toBe(true);
+  });
+  const rawConnect = socket.sent.find((frame) => frame.includes('"method":"connect"'));
+  if (!rawConnect) {
+    throw new Error("missing probe connect frame");
+  }
+  const connect = JSON.parse(rawConnect) as ConnectFrame;
+  socket.emitClose(1008, "test complete");
+  await probePromise;
+  return connect;
+}
+
+beforeEach(() => {
+  webSockets.length = 0;
+});
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("probeGateway device auth scope", () => {
+  it("does not serialize origin-A legacy or scoped tokens to remote origin B", async () => {
+    await withTempDir("openclaw-probe-origin-scope-", async (stateDir) => {
+      const env = createEnv(stateDir);
+      const identity = loadOrCreateDeviceIdentity({ env });
+      storeDeviceAuthToken({
+        deviceId: identity.deviceId,
+        role: "operator",
+        token: "origin-a-legacy-token",
+        env,
+      });
+      storeOriginDeviceToken({
+        gatewayScope: gatewayOriginScope("wss://origin-a.example/rpc"),
+        deviceId: identity.deviceId,
+        role: "operator",
+        token: "origin-a-scoped-token",
+        env,
+      });
+
+      const connect = await captureProbeConnectFrame({
+        url: "wss://origin-b.example/rpc",
+        env,
+      });
+
+      expect(connect.params?.auth?.token).toBeUndefined();
+      expect(connect.params?.auth?.deviceToken).toBeUndefined();
+      expect(connect.params?.device).toBeUndefined();
+    });
+  });
+
+  it("keeps legacy stored device auth available to local loopback probes", async () => {
+    await withTempDir("openclaw-probe-local-scope-", async (stateDir) => {
+      const env = createEnv(stateDir);
+      const identity = loadOrCreateDeviceIdentity({ env });
+      storeDeviceAuthToken({
+        deviceId: identity.deviceId,
+        role: "operator",
+        token: "local-device-token",
+        env,
+      });
+
+      const connect = await captureProbeConnectFrame({
+        url: "ws://127.0.0.1:18789",
+        env,
+      });
+
+      expect(connect.params?.auth).toMatchObject({
+        token: "local-device-token",
+        deviceToken: "local-device-token",
+      });
+      expect(connect.params?.device?.id).toBe(identity.deviceId);
+    });
+  });
+
+  it("keeps explicit tokens authoritative for remote probes", async () => {
+    await withTempDir("openclaw-probe-explicit-scope-", async (stateDir) => {
+      const env = createEnv(stateDir);
+      const identity = loadOrCreateDeviceIdentity({ env });
+      storeDeviceAuthToken({
+        deviceId: identity.deviceId,
+        role: "operator",
+        token: "legacy-device-token",
+        env,
+      });
+
+      const connect = await captureProbeConnectFrame({
+        url: "wss://origin-b.example/rpc",
+        auth: { token: "explicit-remote-token" },
+        env,
+      });
+
+      expect(connect.params?.auth?.token).toBe("explicit-remote-token");
+      expect(connect.params?.auth?.deviceToken).toBeUndefined();
+    });
+  });
+});

--- a/src/gateway/probe.device-auth-scope.test.ts
+++ b/src/gateway/probe.device-auth-scope.test.ts
@@ -100,6 +100,9 @@ async function captureProbeConnectFrame(params: {
   });
   await vi.waitFor(() => expect(webSockets).toHaveLength(1));
   const socket = webSockets[0];
+  if (!socket) {
+    throw new Error("missing probe websocket");
+  }
   socket.emitOpen();
   socket.emitMessage(
     JSON.stringify({

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -40,8 +40,15 @@ const deviceIdentityState = vi.hoisted(() => ({
     scopes: ["operator.read"],
     updatedAtMs: 1,
   } as Record<string, unknown> | null,
+  cachedOriginToken: {
+    token: "cached-origin-operator-token",
+    role: "operator",
+    scopes: ["operator.read"],
+    updatedAtMs: 1,
+  } as Record<string, unknown> | null,
   identityPaths: [] as unknown[],
   tokenParams: [] as unknown[],
+  originTokenParams: [] as unknown[],
 }));
 
 const eventLoopReadyState = vi.hoisted(() => ({
@@ -185,6 +192,10 @@ vi.mock("../infra/device-auth-store.js", () => ({
     deviceIdentityState.tokenParams.push(params);
     return deviceIdentityState.cachedToken;
   },
+  loadOriginDeviceToken: (params: unknown) => {
+    deviceIdentityState.originTokenParams.push(params);
+    return deviceIdentityState.cachedOriginToken;
+  },
 }));
 
 vi.mock("./event-loop-ready.js", () => ({
@@ -293,8 +304,15 @@ describe("probeGateway", () => {
       scopes: ["operator.read"],
       updatedAtMs: 1,
     };
+    deviceIdentityState.cachedOriginToken = {
+      token: "cached-origin-operator-token",
+      role: "operator",
+      scopes: ["operator.read"],
+      updatedAtMs: 1,
+    };
     deviceIdentityState.identityPaths = [];
     deviceIdentityState.tokenParams = [];
+    deviceIdentityState.originTokenParams = [];
     gatewayClientState.startMode = "hello";
     gatewayClientState.socketOpened = true;
     gatewayClientState.transportValidated = true;
@@ -451,6 +469,16 @@ describe("probeGateway", () => {
     });
 
     expect(gatewayClientState.options?.deviceIdentity).toEqual(deviceIdentityState.value);
+    expect(gatewayClientState.options?.deviceAuthScope).toBe("wss://gateway.example/ws");
+    expect(deviceIdentityState.originTokenParams).toEqual([
+      {
+        gatewayScope: "wss://gateway.example/ws",
+        deviceId: "test-device-identity",
+        role: "operator",
+        env: undefined,
+      },
+    ]);
+    expect(deviceIdentityState.tokenParams).toEqual([]);
   });
 
   it("does not create or attach a device identity for first-time authenticated probes", async () => {

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -244,8 +244,10 @@ function resolveGatewayProbeCapability(params: {
 
 export async function probeGateway(opts: {
   url: string;
-  /** Treat a loopback transport (for example an SSH tunnel) as a remote auth target. */
+  /** Treat an explicitly remote loopback URL as a stable origin-scoped auth target. */
   originScopedDeviceAuth?: boolean;
+  /** Disable persisted device auth when the transport does not identify a stable Gateway origin. */
+  suppressStoredDeviceAuth?: boolean;
   auth?: GatewayProbeAuth;
   timeoutMs: number;
   preauthHandshakeTimeoutMs?: number;
@@ -265,9 +267,11 @@ export async function probeGateway(opts: {
   let authMetadataPresent = false;
 
   const detailLevel = opts.includeDetails === false ? "none" : (opts.detailLevel ?? "full");
-  const deviceAuthScope = opts.originScopedDeviceAuth
-    ? gatewayOriginScope(opts.url)
-    : resolveProbeDeviceAuthScope(opts.url);
+  const deviceAuthScope = opts.suppressStoredDeviceAuth
+    ? undefined
+    : opts.originScopedDeviceAuth
+      ? gatewayOriginScope(opts.url)
+      : resolveProbeDeviceAuthScope(opts.url);
 
   const deviceIdentity = await (async () => {
     try {
@@ -282,18 +286,20 @@ export async function probeGateway(opts: {
       // Keep probes non-mutating: only attach a device identity when this CLI
       // already has a cached operator device token. Fresh diagnostics should not
       // create a read-only pairing baseline that later blocks admin commands.
-      const cachedOperatorToken = deviceAuthScope
-        ? loadOriginDeviceToken({
-            gatewayScope: deviceAuthScope,
-            deviceId: identity.deviceId,
-            role: "operator",
-            env: opts.env,
-          })
-        : loadDeviceAuthToken({
-            deviceId: identity.deviceId,
-            role: "operator",
-            env: opts.env,
-          });
+      const cachedOperatorToken = opts.suppressStoredDeviceAuth
+        ? null
+        : deviceAuthScope
+          ? loadOriginDeviceToken({
+              gatewayScope: deviceAuthScope,
+              deviceId: identity.deviceId,
+              role: "operator",
+              env: opts.env,
+            })
+          : loadDeviceAuthToken({
+              deviceId: identity.deviceId,
+              role: "operator",
+              env: opts.env,
+            });
       return cachedOperatorToken ? identity : null;
     } catch {
       // Read-only or restricted environments should still be able to run

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -1,6 +1,7 @@
 // Gateway reachability probe client.
 // Connects to a gateway and summarizes auth, health, status, and presence.
 import { randomUUID } from "node:crypto";
+import { gatewayOriginScope } from "../../packages/gateway-client/src/gateway-origin-scope.js";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -9,13 +10,14 @@ import {
   readMissingScopeError,
   type MissingScopeErrorDetails,
 } from "../../packages/gateway-protocol/src/gateway-error-details.js";
-import { loadDeviceAuthToken } from "../infra/device-auth-store.js";
+import { loadDeviceAuthToken, loadOriginDeviceToken } from "../infra/device-auth-store.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { SystemPresence } from "../infra/system-presence.js";
 import { MAX_SAFE_TIMEOUT_DELAY_MS, resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { startGatewayClientWhenEventLoopReady } from "./client-start-readiness.js";
 import { GatewayClient, GatewayClientRequestError } from "./client.js";
 import { READ_SCOPE } from "./method-scopes.js";
+import { isLoopbackHost } from "./net.js";
 
 export type GatewayProbeAuth = {
   token?: string;
@@ -109,6 +111,14 @@ function isDeviceIdentityRequiredClose(close: GatewayProbeClose | null): boolean
 
 function hasProbeAuth(auth: GatewayProbeAuth | undefined): boolean {
   return Boolean(auth?.token?.trim() || auth?.password?.trim());
+}
+
+function resolveProbeDeviceAuthScope(url: string): string | undefined {
+  try {
+    return isLoopbackHost(new URL(url).hostname) ? undefined : gatewayOriginScope(url);
+  } catch {
+    return undefined;
+  }
 }
 
 function shouldShortCircuitDeviceRequiredProbe(cacheKey: string, nowMs: number): boolean {
@@ -234,6 +244,8 @@ function resolveGatewayProbeCapability(params: {
 
 export async function probeGateway(opts: {
   url: string;
+  /** Treat a loopback transport (for example an SSH tunnel) as a remote auth target. */
+  originScopedDeviceAuth?: boolean;
   auth?: GatewayProbeAuth;
   timeoutMs: number;
   preauthHandshakeTimeoutMs?: number;
@@ -253,6 +265,9 @@ export async function probeGateway(opts: {
   let authMetadataPresent = false;
 
   const detailLevel = opts.includeDetails === false ? "none" : (opts.detailLevel ?? "full");
+  const deviceAuthScope = opts.originScopedDeviceAuth
+    ? gatewayOriginScope(opts.url)
+    : resolveProbeDeviceAuthScope(opts.url);
 
   const deviceIdentity = await (async () => {
     try {
@@ -267,11 +282,18 @@ export async function probeGateway(opts: {
       // Keep probes non-mutating: only attach a device identity when this CLI
       // already has a cached operator device token. Fresh diagnostics should not
       // create a read-only pairing baseline that later blocks admin commands.
-      const cachedOperatorToken = loadDeviceAuthToken({
-        deviceId: identity.deviceId,
-        role: "operator",
-        env: opts.env,
-      });
+      const cachedOperatorToken = deviceAuthScope
+        ? loadOriginDeviceToken({
+            gatewayScope: deviceAuthScope,
+            deviceId: identity.deviceId,
+            role: "operator",
+            env: opts.env,
+          })
+        : loadDeviceAuthToken({
+            deviceId: identity.deviceId,
+            role: "operator",
+            env: opts.env,
+          });
       return cachedOperatorToken ? identity : null;
     } catch {
       // Read-only or restricted environments should still be able to run
@@ -370,6 +392,7 @@ export async function probeGateway(opts: {
 
     const client = new GatewayClient({
       url: opts.url,
+      ...(deviceAuthScope ? { deviceAuthScope } : {}),
       token: opts.auth?.token,
       password: opts.auth?.password,
       tlsFingerprint: opts.tlsFingerprint,


### PR DESCRIPTION
Related: #120533
Late review artifact: https://github.com/openclaw/clawsweeper/actions/runs/31277864003/artifacts/9027603058

## What Problem This Solves

Remote Gateway diagnostic probes created the host Gateway client without an origin-scoped device-auth boundary. When a local legacy device token existed, the shared client could therefore serialize that bearer token into a connect request for a different configured remote origin.

## Why This Change Was Made

This follow-up closes the late P1 found after #120533 merged. `probeGateway` now derives the canonical Gateway origin for non-loopback targets, loads only that origin's cached device token, and passes the scope into the Gateway client facade. Target-aware status probes also force origin scoping for explicit, configured-remote, and SSH-tunnel targets, including remote targets reached over a loopback transport.

Local loopback probes retain the existing legacy device-token path. Explicit token/password credentials remain authoritative. This adds no config, environment variable, protocol field, storage surface, or migration.

## User Impact

Remote health/status diagnostics can no longer disclose a device bearer token cached for another Gateway. A remote origin without its own paired token stays unpaired instead of inheriting local credentials. Existing local diagnostics and explicit remote credentials continue to work.

## Evidence

- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/gateway/probe.test.ts src/gateway/probe.device-auth-scope.test.ts src/gateway/probe.auth.integration.test.ts src/commands/gateway-status.test.ts` — 4 files, 74 tests passed.
- The new connect-frame regression seeds both a legacy global token and an origin-A scoped token, invokes the real probe → host facade → shared Gateway client path for origin B, and verifies neither token nor device identity is serialized.
- Local-loopback stored auth and explicit remote-token control cases pass.
- Targeted oxfmt, `git diff --check`, and conflict-marker scan passed.
- Fresh autoreview: clean, no accepted/actionable findings.
- `node scripts/check-changed.mjs` could not allocate the configured remote backend on this host; exact-head CI remains the authoritative broad gate.

AI-assisted: yes. The late finding, owner boundary, test seam, and final connect-frame behavior were independently reviewed before opening this PR.
