### PR TITLE
fix(codex): resume catalog sessions with the catalog's CODEX_HOME; add main-content terminal placement

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -397,7 +397,7 @@ The dockable operator terminal is enabled by default; set `gateway.terminal.enab
 The terminal is an unconfined host shell and inherits the Gateway process environment. Disable it with `gateway.terminal.enabled: false` on deployments where admin operators should not get a host shell. OpenClaw refuses terminal sessions for agents with `sandbox.mode: "all"`; changing an active agent to that mode closes its existing and in-flight terminal sessions.
 </Warning>
 
-Use **Ctrl + backtick** to toggle the dock. The layout supports bottom and right docking, resizes with the browser viewport, and keeps multiple shell tabs. See [Gateway configuration](/gateway/configuration-reference#gateway) for `gateway.terminal.enabled` and the optional `gateway.terminal.shell` override.
+Use **Ctrl + backtick** to toggle the terminal. The layout supports bottom and right docking or a main-content mode, resizes with the browser viewport, and keeps multiple shell tabs. Opening a Codex or Claude Code session from the catalog selects main-content mode. See [Gateway configuration](/gateway/configuration-reference#gateway) for `gateway.terminal.enabled` and the optional `gateway.terminal.shell` override.
 
 Owner-authorized, unsandboxed agents can use the `terminal` tool for long or interactive work that the operator should watch. Each tool call can open, read, write, resize, close, or list the agent's own gateway PTYs. New sessions open a co-attached Control UI tab by default, so the agent and operator share output and either can type or resize. Agent access is exact-session scoped: an agent cannot read or control operator-created terminals or terminals opened by another agent session.
 

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -133,9 +133,13 @@ export default definePluginEntry({
         api,
         bindingStore,
         control: sessionCatalogControl,
+        getPluginConfig: resolveCurrentPluginConfig,
         getRuntimeConfig: resolveCurrentConfig,
       });
-      for (const command of createCodexSessionCatalogNodeHostCommands(sessionCatalogControl)) {
+      for (const command of createCodexSessionCatalogNodeHostCommands(sessionCatalogControl, {
+        getPluginConfig: resolveCurrentPluginConfig,
+        getRuntimeConfig: resolveCurrentConfig,
+      })) {
         api.registerNodeHostCommand(command);
       }
     }

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -23,12 +23,15 @@ import {
 } from "openclaw/plugin-sdk/agent-runtime";
 import { hasUsableOAuthCredential } from "openclaw/plugin-sdk/provider-auth";
 import { readSecretFile } from "openclaw/plugin-sdk/secret-file";
-import { resolveCodexAppServerHomeDir, withEphemeralCodexAuthStore } from "./auth-start-options.js";
+import {
+  resolveCodexAppServerHomeDir,
+  resolveCodexAppServerLocalHomeDir,
+  withEphemeralCodexAuthStore,
+} from "./auth-start-options.js";
 import type { CodexAppServerClient } from "./client.js";
 import { ensureCodexComputerUseSharedPluginCache } from "./computer-use-cache.js";
 import { ensureCodexComputerUseServiceApp } from "./computer-use-service.js";
 import {
-  resolveCodexAppServerUserHomeDir,
   resolveCodexComputerUseConfig,
   type CodexAppServerHomeScope,
   type CodexAppServerStartOptions,
@@ -489,11 +492,7 @@ async function withCodexHomeEnvironment(
   agentDir: string,
   pluginConfig?: unknown,
 ): Promise<CodexAppServerStartOptions> {
-  const codexHome = startOptions.env?.[CODEX_HOME_ENV_VAR]?.trim()
-    ? startOptions.env[CODEX_HOME_ENV_VAR]
-    : startOptions.homeScope === "user"
-      ? resolveCodexAppServerUserHomeDir(process.env)
-      : resolveCodexAppServerHomeDir(agentDir);
+  const codexHome = resolveCodexAppServerLocalHomeDir(startOptions, agentDir);
   const nativeHome = startOptions.env?.[HOME_ENV_VAR]?.trim()
     ? startOptions.env[HOME_ENV_VAR]
     : undefined;

--- a/extensions/codex/src/app-server/auth-start-options.ts
+++ b/extensions/codex/src/app-server/auth-start-options.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { resolveCodexAppServerUserHomeDir } from "./config-reviewer.js";
 import type { CodexAppServerStartOptions } from "./config.js";
 
 const CODEX_APP_SERVER_HOME_DIRNAME = "codex-home";
@@ -6,6 +7,21 @@ const CODEX_EPHEMERAL_AUTH_STORE_OVERRIDE = 'cli_auth_credentials_store="ephemer
 
 export function resolveCodexAppServerHomeDir(agentDir: string): string {
   return path.join(path.resolve(agentDir), CODEX_APP_SERVER_HOME_DIRNAME);
+}
+
+/** Resolves the local CODEX_HOME used when starting one app-server connection. */
+export function resolveCodexAppServerLocalHomeDir(
+  startOptions: CodexAppServerStartOptions,
+  agentDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const configured = startOptions.env?.CODEX_HOME;
+  if (configured?.trim()) {
+    return configured;
+  }
+  return startOptions.homeScope === "user"
+    ? resolveCodexAppServerUserHomeDir(env)
+    : resolveCodexAppServerHomeDir(agentDir);
 }
 
 /** Forces OpenClaw-owned Codex auth to remain process-local. */

--- a/extensions/codex/src/app-server/plugin-app-cache-key.ts
+++ b/extensions/codex/src/app-server/plugin-app-cache-key.ts
@@ -10,7 +10,10 @@ import {
   buildCodexAppInventoryCacheKey,
   type CodexAppInventoryCacheKeyInput,
 } from "./app-inventory-cache.js";
-import { resolveCodexAppServerHomeDir } from "./auth-bridge.js";
+import {
+  resolveCodexAppServerHomeDir,
+  resolveCodexAppServerLocalHomeDir,
+} from "./auth-start-options.js";
 import type { CodexAppServerRuntimeIdentity } from "./client.js";
 import {
   resolveCodexAppServerUserHomeDir,
@@ -103,7 +106,7 @@ function resolveCodexAppServerConnectionHome(
   if (start.homeScope === "user") {
     return resolveCodexAppServerUserHomeDir(process.env);
   }
-  return agentDir ? resolveCodexAppServerHomeDir(agentDir) : null;
+  return agentDir ? resolveCodexAppServerLocalHomeDir(start, agentDir) : null;
 }
 
 /** Serializes app-server endpoint identity, including credential fingerprints. */

--- a/extensions/codex/src/session-catalog-terminal.ts
+++ b/extensions/codex/src/session-catalog-terminal.ts
@@ -1,4 +1,6 @@
 // Codex catalog terminal ownership: validated resume commands and terminal plans.
+import { resolveDefaultAgentDir } from "openclaw/plugin-sdk/agent-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   decodeNodePtyResumeParams,
   resolveNodeHostExecutable,
@@ -10,6 +12,8 @@ import type {
 } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import type { SessionCatalogTerminalPlan } from "openclaw/plugin-sdk/session-catalog";
+import { resolveCodexAppServerLocalHomeDir } from "./app-server/auth-start-options.js";
+import { resolveCodexSupervisionAppServerRuntimeOptions } from "./app-server/config.js";
 import {
   CatalogParamsError,
   CODEX_APP_SERVER_THREADS_CAPABILITY,
@@ -28,6 +32,22 @@ import type {
 } from "./session-catalog-types.js";
 
 export const CODEX_TERMINAL_RESUME_COMMAND = "codex.terminal.resume.v1";
+
+export type CodexTerminalConfigSources = {
+  getPluginConfig: () => unknown;
+  getRuntimeConfig: () => OpenClawConfig | undefined;
+};
+
+function resolveCodexCatalogTerminalHome(sources: CodexTerminalConfigSources): string {
+  const runtimeConfig = sources.getRuntimeConfig();
+  if (!runtimeConfig) {
+    throw new Error("OpenClaw runtime config is unavailable");
+  }
+  const startOptions = resolveCodexSupervisionAppServerRuntimeOptions({
+    pluginConfig: sources.getPluginConfig(),
+  }).start;
+  return resolveCodexAppServerLocalHomeDir(startOptions, resolveDefaultAgentDir(runtimeConfig));
+}
 
 export function resolveLocalCodexTerminalExecutable(
   env: NodeJS.ProcessEnv = process.env,
@@ -106,6 +126,7 @@ async function findCatalogEligibleThread(
 
 export function createCodexTerminalNodeHostCommand(
   control: CodexSessionCatalogControl,
+  configSources: CodexTerminalConfigSources,
 ): OpenClawPluginNodeHostCommand {
   return {
     command: CODEX_TERMINAL_RESUME_COMMAND,
@@ -148,6 +169,7 @@ export function createCodexTerminalNodeHostCommand(
             file: resolution.executable,
             args: ["resume", resume.threadId],
             cwd: record.cwd,
+            env: { CODEX_HOME: resolveCodexCatalogTerminalHome(configSources) },
             cols: resume.cols,
             rows: resume.rows,
           },
@@ -195,13 +217,15 @@ async function resolveNodeCatalogEligibleThread(params: {
   throw new CatalogParamsError("Codex session is not a non-archived interactive Codex session");
 }
 
-export async function openCodexCatalogTerminal(params: {
-  api: OpenClawPluginApi;
-  control: CodexSessionCatalogControl;
-  hostId: string;
-  threadId: string;
-  parseCatalogPage: (value: unknown) => CodexSessionCatalogPage;
-}): Promise<SessionCatalogTerminalPlan> {
+export async function openCodexCatalogTerminal(
+  params: {
+    api: OpenClawPluginApi;
+    control: CodexSessionCatalogControl;
+    hostId: string;
+    threadId: string;
+    parseCatalogPage: (value: unknown) => CodexSessionCatalogPage;
+  } & CodexTerminalConfigSources,
+): Promise<SessionCatalogTerminalPlan> {
   const title = `codex resume ${params.threadId.slice(0, 8)}…`;
   if (params.hostId === CODEX_LOCAL_SESSION_HOST_ID) {
     const record = await requireCatalogEligibleThread(params.control, params.threadId);
@@ -215,6 +239,7 @@ export async function openCodexCatalogTerminal(params: {
       kind: "local",
       argv: [resolution.executable, "resume", params.threadId],
       ...(record.cwd ? { cwd: record.cwd } : {}),
+      env: { CODEX_HOME: resolveCodexCatalogTerminalHome(params) },
       ...(resolution.pathEnv ? { pathEnv: resolution.pathEnv } : {}),
       title,
     };

--- a/extensions/codex/src/session-catalog.test.ts
+++ b/extensions/codex/src/session-catalog.test.ts
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resolveDefaultAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   validateJsonSchemaValue,
@@ -14,6 +15,8 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import type { SessionCatalogProvider } from "openclaw/plugin-sdk/session-catalog";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveCodexAppServerHomeDir } from "./app-server/auth-start-options.js";
+import { resolveCodexAppServerUserHomeDir } from "./app-server/config.js";
 import type { CodexThread } from "./app-server/protocol.js";
 import { sessionBindingIdentity } from "./app-server/session-binding.js";
 import {
@@ -26,12 +29,13 @@ import { catalogError, parseCatalogPage } from "./session-catalog-parsing.js";
 import {
   CODEX_TERMINAL_RESUME_COMMAND,
   requireCatalogEligibleThread,
+  type CodexTerminalConfigSources,
 } from "./session-catalog-terminal.js";
 import {
   CODEX_LOCAL_SESSION_HOST_ID,
   codexSessionCatalogRuntime,
   createCodexSessionCatalogControl,
-  createCodexSessionCatalogNodeHostCommands,
+  createCodexSessionCatalogNodeHostCommands as createCodexSessionCatalogNodeHostCommandsRuntime,
   createCodexSessionCatalogNodeInvokePolicies,
 } from "./session-catalog.js";
 
@@ -51,7 +55,28 @@ const archiveLocalCodexSession = codexSessionCatalogRuntime.archiveLocal;
 const continueLocalCodexSession = codexSessionCatalogRuntime.continueLocal;
 const listCodexSessionCatalog = codexSessionCatalogRuntime.list;
 const readCodexSessionTranscript = codexSessionCatalogRuntime.readTranscript;
-const registerCodexSessionCatalog = codexSessionCatalogRuntime.register;
+const registerCodexSessionCatalogRuntime = codexSessionCatalogRuntime.register;
+
+function registerCodexSessionCatalog(
+  params: Omit<Parameters<typeof registerCodexSessionCatalogRuntime>[0], "getPluginConfig"> & {
+    getPluginConfig?: () => unknown;
+  },
+) {
+  return registerCodexSessionCatalogRuntime({
+    ...params,
+    getPluginConfig: params.getPluginConfig ?? (() => undefined),
+  });
+}
+
+function createCodexSessionCatalogNodeHostCommands(
+  control: CodexSessionCatalogControl,
+  configSources: CodexTerminalConfigSources = {
+    getPluginConfig: () => undefined,
+    getRuntimeConfig: () => config,
+  },
+) {
+  return createCodexSessionCatalogNodeHostCommandsRuntime(control, configSources);
+}
 
 const commandRpcMocks = vi.hoisted(() => ({
   codexControlRequest: vi.fn(),
@@ -1537,6 +1562,10 @@ describe("Codex supervision catalog", () => {
           ],
         })),
       }),
+      {
+        getPluginConfig: () => ({ appServer: { homeScope: "agent" } }),
+        getRuntimeConfig: () => config,
+      },
     ).find((candidate) => candidate.command === CODEX_TERMINAL_RESUME_COMMAND);
     if (!command || command.duplex !== true) {
       throw new Error("Codex terminal command was not registered as duplex");
@@ -1550,7 +1579,13 @@ describe("Codex supervision catalog", () => {
 
     expect(command.dangerous).toBe(false);
     expect(nodeHostMocks.runNodePtyCommand).toHaveBeenCalledWith(
-      expect.objectContaining({ file: executable, cwd: "/node/catalog/cwd" }),
+      expect.objectContaining({
+        file: executable,
+        cwd: "/node/catalog/cwd",
+        env: {
+          CODEX_HOME: resolveCodexAppServerHomeDir(resolveDefaultAgentDir(config)),
+        },
+      }),
       expect.any(Object),
     );
   });
@@ -3760,10 +3795,12 @@ describe("Codex supervision actions", () => {
     };
     const { runtime } = createRuntime({ nodes: [node], invoke });
     const { api, getProvider } = createGatewayApi(runtime);
+    let pluginConfig: unknown = { appServer: { homeScope: "agent" } };
     registerCodexSessionCatalog({
       api,
       bindingStore: createCodexTestBindingStore(),
       control,
+      getPluginConfig: () => pluginConfig,
       getRuntimeConfig: () => config,
     });
 
@@ -3806,6 +3843,15 @@ describe("Codex supervision actions", () => {
       kind: "local",
       argv: [executable, "resume", threadId],
       cwd: "/workspace/local",
+      env: {
+        CODEX_HOME: resolveCodexAppServerHomeDir(resolveDefaultAgentDir(config)),
+      },
+    });
+    pluginConfig = { appServer: { homeScope: "user" } };
+    await expect(
+      getProvider()?.openTerminal?.({ hostId: CODEX_LOCAL_SESSION_HOST_ID, threadId }),
+    ).resolves.toMatchObject({
+      env: { CODEX_HOME: resolveCodexAppServerUserHomeDir(process.env) },
     });
     await expect(
       getProvider()?.openTerminal?.({ hostId: "node:devbox", threadId }),

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -101,6 +101,7 @@ import {
   openCodexCatalogTerminal,
   requireCatalogEligibleThread,
   resolveLocalCodexTerminalExecutable,
+  type CodexTerminalConfigSources,
 } from "./session-catalog-terminal.js";
 import { toGenericTranscriptItem } from "./session-catalog-transcript-item.js";
 import type {
@@ -667,6 +668,7 @@ async function listCodexSessionCatalog(params: {
 /** Builds the node-local read-only Codex app-server catalog command. */
 export function createCodexSessionCatalogNodeHostCommands(
   control: CodexSessionCatalogControl,
+  configSources: CodexTerminalConfigSources,
 ): OpenClawPluginNodeHostCommand[] {
   return [
     {
@@ -713,7 +715,7 @@ export function createCodexSessionCatalogNodeHostCommands(
         }
       },
     },
-    createCodexTerminalNodeHostCommand(control),
+    createCodexTerminalNodeHostCommand(control, configSources),
   ];
 }
 
@@ -1434,6 +1436,7 @@ function registerCodexSessionCatalog(params: {
   api: OpenClawPluginApi;
   bindingStore: CodexAppServerBindingStore;
   control: CodexSessionCatalogControl;
+  getPluginConfig: () => unknown;
   getRuntimeConfig: () => OpenClawConfig | undefined;
 }): void {
   const provider: SessionCatalogProvider = {
@@ -1531,6 +1534,8 @@ function registerCodexSessionCatalog(params: {
       openCodexCatalogTerminal({
         api: params.api,
         control: params.control,
+        getPluginConfig: params.getPluginConfig,
+        getRuntimeConfig: params.getRuntimeConfig,
         parseCatalogPage,
         ...request,
       }),

--- a/src/gateway/server-methods/terminal.test.ts
+++ b/src/gateway/server-methods/terminal.test.ts
@@ -201,6 +201,7 @@ describe("terminal gateway policy", () => {
     const openTerminal = vi.fn(async () => ({
       kind: "local" as const,
       argv: ["codex", "resume", "thread"],
+      env: { CODEX_HOME: "/agent/codex-home" },
       pathEnv: "/login-shell/bin:/usr/bin",
       title: "codex resume thread",
     }));
@@ -230,7 +231,10 @@ describe("terminal gateway policy", () => {
       expect.objectContaining({
         shell: expect.any(String),
         args: ["-il", "-c", "'codex' 'resume' 'thread'"],
-        env: expect.objectContaining({ PATH: "/login-shell/bin:/usr/bin" }),
+        env: expect.objectContaining({
+          CODEX_HOME: "/agent/codex-home",
+          PATH: "/login-shell/bin:/usr/bin",
+        }),
       }),
     );
     expect(respond).toHaveBeenCalledWith(

--- a/src/gateway/server-methods/terminal.ts
+++ b/src/gateway/server-methods/terminal.ts
@@ -293,10 +293,13 @@ export const terminalHandlers: GatewayRequestHandlers = {
     }
     const spawnPlan = resolveTerminalOpenSpawnPlan(refreshedLaunch.plan, catalogPlan);
     const terminalEnv = buildTerminalEnv(process.env);
-    if (catalogPlan?.kind === "local" && catalogPlan.pathEnv) {
-      // Preserve the PATH that found a login-shell CLI so env-based shebangs
-      // can resolve their interpreter inside the spawned terminal process.
-      terminalEnv.PATH = catalogPlan.pathEnv;
+    if (catalogPlan?.kind === "local") {
+      Object.assign(terminalEnv, catalogPlan.env);
+      if (catalogPlan.pathEnv) {
+        // Preserve the PATH that found a login-shell CLI so env-based shebangs
+        // can resolve their interpreter inside the spawned terminal process.
+        terminalEnv.PATH = catalogPlan.pathEnv;
+      }
     }
     let openingTerminal: ReturnType<typeof manager.open> | undefined;
     let outcome: Awaited<ReturnType<typeof manager.open>>;

--- a/src/node-host/pty-command.test.ts
+++ b/src/node-host/pty-command.test.ts
@@ -56,6 +56,7 @@ describe("node PTY command", () => {
         file: "/usr/bin/codex",
         args: ["resume", "id"],
         cwd: "/missing/catalog/cwd",
+        env: { CODEX_HOME: "/catalog/codex-home" },
         pathEnv: "/shell/bin:/usr/bin",
         cols: 80,
         rows: 24,
@@ -69,6 +70,8 @@ describe("node PTY command", () => {
     >;
     expect(spawnCalls[0]?.[0].cwd).toBe(os.homedir());
     expect(spawnCalls[0]?.[0].env?.PATH).toBe("/shell/bin:/usr/bin");
+    expect(spawnCalls[0]?.[0].env?.CODEX_HOME).toBe("/catalog/codex-home");
+    expect(spawnCalls[0]?.[0].env?.OPENCLAW_TERMINAL).toBe("1");
 
     onData?.("output");
     await vi.waitFor(() => expect(emitChunk).toHaveBeenCalledWith("output"));

--- a/src/node-host/pty-command.ts
+++ b/src/node-host/pty-command.ts
@@ -99,6 +99,7 @@ export async function runNodePtyCommand(
     file: string;
     args: string[];
     cwd?: string;
+    env?: Record<string, string>;
     pathEnv?: string;
     cols: number;
     rows: number;
@@ -114,6 +115,7 @@ export async function runNodePtyCommand(
       (entry): entry is [string, string] => entry[1] !== undefined,
     ),
   );
+  Object.assign(env, params.env);
   env.TERM ??= "xterm-256color";
   env.OPENCLAW_TERMINAL = "1";
   if (params.pathEnv) {

--- a/src/plugins/session-catalog.ts
+++ b/src/plugins/session-catalog.ts
@@ -40,6 +40,8 @@ export type SessionCatalogTerminalPlan =
       argv: string[];
       cwd?: string;
       title?: string;
+      /** Bounded command-specific environment overrides. */
+      env?: Record<string, string>;
       /** PATH that resolved argv[0], needed by env-based script interpreters. */
       pathEnv?: string;
     }

--- a/ui/src/components/dock-layout-controller.ts
+++ b/ui/src/components/dock-layout-controller.ts
@@ -6,11 +6,11 @@ import {
   type ReactiveControllerHost,
   type TemplateResult,
 } from "lit";
-import type { DockPanelLayoutStore, DockPanelSide } from "./dock-panel-layout.ts";
+import type { DockPanelLayoutStore, DockPanelPlacement } from "./dock-panel-layout.ts";
 
 type DockLayoutHost = ReactiveControllerHost & { readonly isConnected: boolean };
 
-type DockLayoutControllerOptions<TDock extends DockPanelSide> = {
+type DockLayoutControllerOptions<TDock extends DockPanelPlacement> = {
   layout: DockPanelLayoutStore<TDock>;
   reservationPrefix: string;
   isAvailable: () => boolean;
@@ -18,7 +18,7 @@ type DockLayoutControllerOptions<TDock extends DockPanelSide> = {
   onResize?: () => void;
 };
 
-export class DockLayoutController<TDock extends DockPanelSide> implements ReactiveController {
+export class DockLayoutController<TDock extends DockPanelPlacement> implements ReactiveController {
   open = false;
   dock: TDock;
   height: number;
@@ -195,7 +195,7 @@ export class DockLayoutController<TDock extends DockPanelSide> implements Reacti
   }
 
   renderResizer(classPrefix: string, label: string): TemplateResult | typeof nothing {
-    if (this.isFullscreen()) {
+    if (this.isFullscreen() || this.dock === "main") {
       return nothing;
     }
     return html`<div

--- a/ui/src/components/dock-panel-layout.test.ts
+++ b/ui/src/components/dock-panel-layout.test.ts
@@ -86,4 +86,20 @@ describe("createDockPanelLayout", () => {
 
     expect(layout.load()).toEqual({ open: true, dock: "bottom", height: 400, width: 600 });
   });
+
+  it("round-trips an opted-in main placement", () => {
+    const layout = createDockPanelLayout({
+      storageKey: "test.dock-panel.main",
+      minHeight: 140,
+      minWidth: 320,
+      defaultDock: "bottom",
+      supportedDocks: ["bottom", "right", "main"],
+      defaultHeight: 320,
+      defaultWidth: 520,
+    });
+
+    layout.save({ open: true, dock: "main", height: 320, width: 520 });
+
+    expect(layout.load()).toEqual({ open: true, dock: "main", height: 320, width: 520 });
+  });
 });

--- a/ui/src/components/dock-panel-layout.ts
+++ b/ui/src/components/dock-panel-layout.ts
@@ -1,13 +1,14 @@
 export type DockPanelSide = "bottom" | "left" | "right";
+export type DockPanelPlacement = DockPanelSide | "main";
 
-type DockPanelLayout<TDock extends DockPanelSide> = {
+type DockPanelLayout<TDock extends DockPanelPlacement> = {
   open: boolean;
   dock: TDock;
   height: number;
   width: number;
 };
 
-export type DockPanelLayoutStore<TDock extends DockPanelSide> = {
+export type DockPanelLayoutStore<TDock extends DockPanelPlacement> = {
   defaults: DockPanelLayout<TDock>;
   minHeight: number;
   minWidth: number;
@@ -17,7 +18,7 @@ export type DockPanelLayoutStore<TDock extends DockPanelSide> = {
   save(layout: DockPanelLayout<TDock>): void;
 };
 
-type DockPanelLayoutOptions<TDock extends DockPanelSide> = {
+type DockPanelLayoutOptions<TDock extends DockPanelPlacement> = {
   storageKey: string;
   minHeight: number;
   minWidth: number;
@@ -27,7 +28,7 @@ type DockPanelLayoutOptions<TDock extends DockPanelSide> = {
   defaultWidth: number;
 };
 
-export function createDockPanelLayout<TDock extends DockPanelSide>(
+export function createDockPanelLayout<TDock extends DockPanelPlacement>(
   options: DockPanelLayoutOptions<TDock>,
 ) {
   const defaults: DockPanelLayout<TDock> = {

--- a/ui/src/components/terminal/terminal-panel-accessibility.test.ts
+++ b/ui/src/components/terminal/terminal-panel-accessibility.test.ts
@@ -46,6 +46,19 @@ describe("OpenClawTerminalPanel accessibility", () => {
     await i18n.setLocale("en");
   });
 
+  it("labels the terminal placement switcher and all three modes", async () => {
+    const panel = createPanel(createPickerClient());
+    await waitForFast(() => expect(panel.renderRoot.querySelector(".tp-actions")).not.toBeNull());
+
+    const switcher = panel.renderRoot.querySelector('[role="group"]');
+    expect(switcher?.getAttribute("aria-label")).toBe("Terminal panel position");
+    expect(
+      ["Dock to bottom", "Dock to right", "Fill main content area"].every((label) =>
+        switcher?.querySelector(`[aria-label="${label}"]`),
+      ),
+    ).toBe(true);
+  });
+
   afterEach(async () => {
     document.body.replaceChildren();
     localStorage.clear();

--- a/ui/src/components/terminal/terminal-panel-chrome.ts
+++ b/ui/src/components/terminal/terminal-panel-chrome.ts
@@ -1,6 +1,6 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { t } from "../../i18n/index.ts";
-import type { DockPanelSide } from "../dock-panel-layout.ts";
+import type { DockPanelPlacement } from "../dock-panel-layout.ts";
 import type { TerminalPanelSessionTab } from "./terminal-panel-session-types.ts";
 import { renderTerminalPanelTabs } from "./terminal-panel-tabs.ts";
 import {
@@ -9,7 +9,7 @@ import {
   type TerminalPanelUploadController,
 } from "./terminal-panel-upload.ts";
 
-type TerminalDock = Exclude<DockPanelSide, "left">;
+type TerminalDock = Exclude<DockPanelPlacement, "left">;
 
 export function renderTerminalPanelToolbar(
   fullscreen: boolean,

--- a/ui/src/components/terminal/terminal-panel-styles.ts
+++ b/ui/src/components/terminal/terminal-panel-styles.ts
@@ -13,6 +13,14 @@ export const terminalPanelStyles = css`
     bottom: 0;
     --tp-session-menu-max-height: calc(100dvh - var(--shell-topbar-height, 0px) - 44px);
   }
+  .tp--main {
+    /* Main mode owns the content region; later sibling docks may overlay it. */
+    top: var(--shell-topbar-height, 0);
+    left: var(--shell-nav-width, 0);
+    right: 0;
+    bottom: 0;
+    --tp-session-menu-max-height: calc(100dvh - var(--shell-topbar-height, 0px) - 44px);
+  }
   .tp--fullscreen {
     inset: 0;
   }
@@ -22,6 +30,11 @@ export const terminalPanelStyles = css`
   .tp-icon.is-active {
     color: var(--text, #d7dae0);
     background: color-mix(in srgb, var(--text, #d7dae0) 10%, transparent);
+  }
+  .tp-dock-modes {
+    display: flex;
+    align-items: center;
+    gap: 2px;
   }
   .tp-session-picker {
     position: relative;

--- a/ui/src/components/terminal/terminal-panel-suppression.test.ts
+++ b/ui/src/components/terminal/terminal-panel-suppression.test.ts
@@ -59,6 +59,28 @@ describe("OpenClawTerminalPanel dock suppression", () => {
     expect(panel.renderRoot.querySelector(".tp")).not.toBeNull();
   });
 
+  it("restores a suppressed main placement", async () => {
+    localStorage.setItem(
+      "openclaw.terminal.panel.v1",
+      JSON.stringify({ open: true, dock: "main", height: 320, width: 520 }),
+    );
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+    panel.available = true;
+    document.body.append(panel);
+    await panel.updateComplete;
+    expect(panel.renderRoot.querySelector(".tp--main")).not.toBeNull();
+
+    panel.suppressed = true;
+    await waitForFast(() => expect(panel.renderRoot.querySelector(".tp")).toBeNull());
+    expect(JSON.parse(localStorage.getItem("openclaw.terminal.panel.v1") ?? "{}")).toMatchObject({
+      open: true,
+      dock: "main",
+    });
+
+    panel.suppressed = false;
+    await waitForFast(() => expect(panel.renderRoot.querySelector(".tp--main")).not.toBeNull());
+  });
+
   it("defers availability restore until suppression ends", async () => {
     localStorage.setItem(
       "openclaw.terminal.panel.v1",

--- a/ui/src/components/terminal/terminal-panel-upload.ts
+++ b/ui/src/components/terminal/terminal-panel-upload.ts
@@ -11,6 +11,7 @@ import {
 const CLOSE_GLYPH = svg`<svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M4 4l8 8M12 4l-8 8" /></svg>`;
 const DOCK_BOTTOM_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.3"><rect x="2" y="2.5" width="12" height="11" rx="1.5" /><path d="M2 10h12" /></svg>`;
 const DOCK_RIGHT_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.3"><rect x="2" y="2.5" width="12" height="11" rx="1.5" /><path d="M10 2.5v11" /></svg>`;
+const DOCK_MAIN_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"><path d="M6 2.5H2.5V6M10 2.5h3.5V6M6 13.5H2.5V10M10 13.5h3.5V10" /></svg>`;
 const UPLOAD_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5.2 8.1 9.8 3.5a2.5 2.5 0 0 1 3.5 3.5l-6 6a3.5 3.5 0 0 1-5-5l5.8-5.8" /><path d="m4.4 9 5.2-5.2a1.4 1.4 0 0 1 2 2l-5.3 5.3a2.3 2.3 0 0 1-3.2-3.2l4.6-4.6" /></svg>`;
 
 type TerminalUploadTab = {
@@ -315,10 +316,10 @@ export class TerminalPanelUploadController {
 
 export function renderTerminalPanelActions(params: {
   fullscreen: boolean;
-  dock: "bottom" | "right";
+  dock: "bottom" | "right" | "main";
   upload: TerminalPanelUploadController;
   sessionPicker: unknown;
-  onDock: (dock: "bottom" | "right") => void;
+  onDock: (dock: "bottom" | "right" | "main") => void;
   onHide: () => void;
 }) {
   return html`<div class="tp-actions">
@@ -342,24 +343,37 @@ export function renderTerminalPanelActions(params: {
     </button>
     ${params.fullscreen
       ? nothing
-      : html`${params.sessionPicker}<button
-            class="tp-icon ${params.dock === "bottom" ? "is-active" : ""}"
-            type="button"
-            title=${t("terminal.dockBottom")}
-            aria-label=${t("terminal.dockBottom")}
-            @click=${() => params.onDock("bottom")}
-          >
-            ${DOCK_BOTTOM_GLYPH}
-          </button>
-          <button
-            class="tp-icon ${params.dock === "right" ? "is-active" : ""}"
-            type="button"
-            title=${t("terminal.dockRight")}
-            aria-label=${t("terminal.dockRight")}
-            @click=${() => params.onDock("right")}
-          >
-            ${DOCK_RIGHT_GLYPH}
-          </button>
+      : html`${params.sessionPicker}<span
+            class="tp-dock-modes"
+            role="group"
+            aria-label=${t("terminal.dockMode")}
+            ><button
+              class="tp-icon ${params.dock === "bottom" ? "is-active" : ""}"
+              type="button"
+              title=${t("terminal.dockBottom")}
+              aria-label=${t("terminal.dockBottom")}
+              @click=${() => params.onDock("bottom")}
+            >
+              ${DOCK_BOTTOM_GLYPH}
+            </button>
+            <button
+              class="tp-icon ${params.dock === "right" ? "is-active" : ""}"
+              type="button"
+              title=${t("terminal.dockRight")}
+              aria-label=${t("terminal.dockRight")}
+              @click=${() => params.onDock("right")}
+            >
+              ${DOCK_RIGHT_GLYPH}</button
+            ><button
+              class="tp-icon ${params.dock === "main" ? "is-active" : ""}"
+              type="button"
+              title=${t("terminal.dockMain")}
+              aria-label=${t("terminal.dockMain")}
+              @click=${() => params.onDock("main")}
+            >
+              ${DOCK_MAIN_GLYPH}
+            </button>
+          </span>
           <button
             class="tp-icon"
             type="button"

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -87,6 +87,36 @@ describe("OpenClawTerminalPanel", () => {
     await waitForFast(() => expect(panel.terminalPanelOpen).toBe(true));
   });
 
+  it("persists and restores the main content placement without a resizer", async () => {
+    localStorage.setItem(
+      "openclaw.terminal.panel.v1",
+      JSON.stringify({ open: true, dock: "bottom", height: 320, width: 520 }),
+    );
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+    panel.available = true;
+    document.body.append(panel);
+    await panel.updateComplete;
+
+    panel.renderRoot
+      .querySelector<HTMLButtonElement>('[aria-label="Fill main content area"]')
+      ?.click();
+    await panel.updateComplete;
+
+    expect(panel.renderRoot.querySelector(".tp")?.classList.contains("tp--main")).toBe(true);
+    expect(panel.renderRoot.querySelector(".tp-resizer")).toBeNull();
+    expect(JSON.parse(localStorage.getItem("openclaw.terminal.panel.v1") ?? "{}")).toMatchObject({
+      open: true,
+      dock: "main",
+    });
+
+    panel.remove();
+    const restored = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+    restored.available = true;
+    document.body.append(restored);
+    await restored.updateComplete;
+    expect(restored.renderRoot.querySelector(".tp")?.classList.contains("tp--main")).toBe(true);
+  });
+
   it("opens new sessions for the selected agent", async () => {
     let createOptions: CreateOptions | undefined;
     createGhosttyTerminalMock.mockImplementation(async (options: CreateOptions) => {
@@ -339,6 +369,13 @@ describe("OpenClawTerminalPanel", () => {
     const catalog = { catalogId: "codex", hostId: "node:mac", threadId: "thread" };
 
     panel.handleToggleRequest(new CustomEvent("openclaw:terminal-toggle", { detail: { catalog } }));
+
+    await panel.updateComplete;
+    expect(panel.renderRoot.querySelector(".tp")?.classList.contains("tp--main")).toBe(true);
+    expect(JSON.parse(localStorage.getItem("openclaw.terminal.panel.v1") ?? "{}")).toMatchObject({
+      open: true,
+      dock: "main",
+    });
 
     await waitForFast(() => {
       expect(requests.filter((entry) => entry.method === "terminal.attach")).toHaveLength(1);

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -1,6 +1,6 @@
 // Dockable operator terminal panel for the Control UI shell.
 //
-// Renders a VS Code-style shell dock (bottom by default, or right) with session
+// Renders a VS Code-style shell dock (bottom by default, right, or main) with session
 // tabs. Each tab hosts one libterminal Ghostty controller wired to a gateway PTY
 // session. The browser runtime is dynamically imported on first open so it
 // never weighs down the initial Control UI bundle.
@@ -10,7 +10,7 @@ import { property, state } from "lit/decorators.js";
 import { t } from "../../i18n/index.ts";
 import { OpenClawLitElement } from "../../lit/openclaw-element.ts";
 import { DockLayoutController, dockPanelStyles } from "../dock-layout-controller.ts";
-import { createDockPanelLayout, type DockPanelSide } from "../dock-panel-layout.ts";
+import { createDockPanelLayout, type DockPanelPlacement } from "../dock-panel-layout.ts";
 import { panelTabStripStyles } from "../panel-tab-strip.ts";
 import {
   isTerminalPanelShortcut,
@@ -38,14 +38,14 @@ import { TerminalPanelUploadController } from "./terminal-panel-upload.ts";
 import { createIsolatedGhosttyTerminal } from "./terminal-runtime.ts";
 import { renderTerminalSessionPicker } from "./terminal-session-picker.ts";
 
-type TerminalDock = Exclude<DockPanelSide, "left">;
+type TerminalDock = Exclude<DockPanelPlacement, "left">;
 
 const panelLayout = createDockPanelLayout({
   storageKey: "openclaw.terminal.panel.v1",
   minHeight: 140,
   minWidth: 320,
   defaultDock: "bottom",
-  supportedDocks: ["bottom", "right"],
+  supportedDocks: ["bottom", "right", "main"],
   defaultHeight: 320,
   defaultWidth: 520,
 });
@@ -191,6 +191,9 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       if (!this.available) {
         return;
       }
+      if (detail.catalog) {
+        this.dockLayout.setDock("main");
+      }
       this.dockLayout.setOpen(true);
       void (detail.terminalSessionId
         ? this.terminalSessions.openRequestedSession(detail.terminalSessionId)
@@ -325,11 +328,12 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       return nothing;
     }
     const mode = this.fullscreen ? "fullscreen" : this.dockLayout.dock;
-    const style = this.fullscreen
-      ? nothing
-      : this.dockLayout.dock === "bottom"
-        ? `height:${this.dockLayout.height}px;--tp-panel-height:${this.dockLayout.height}px`
-        : `width:${this.dockLayout.width}px`;
+    const style =
+      this.fullscreen || this.dockLayout.dock === "main"
+        ? nothing
+        : this.dockLayout.dock === "bottom"
+          ? `height:${this.dockLayout.height}px;--tp-panel-height:${this.dockLayout.height}px`
+          : `width:${this.dockLayout.width}px`;
     const activeTab = this.terminalSessions.tabs.find(
       (tab) => tab.id === this.terminalSessions.activeId,
     );

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1817,6 +1817,8 @@ export const en: TranslationMap = {
     detached: "detached",
     dockBottom: "Dock to bottom",
     dockRight: "Dock to right",
+    dockMain: "Fill main content area",
+    dockMode: "Terminal panel position",
     unavailable: "The terminal is not available on this gateway.",
     uploadTooLarge: "File exceeds the 16 MiB terminal upload limit: {file}",
     uploadUnsafeCmdPath: "Cannot safely insert an uploaded path containing % or ! into cmd.exe",


### PR DESCRIPTION
## What Problem This Solves

Opening a Codex session from the Control UI session catalog into a terminal failed with:

```
ERROR: No saved session found with ID <threadId>. Run `codex resume` without an ID to choose from existing sessions.
```

Additionally, the terminal only rendered as a bottom/right dock strip; a resumed session could not occupy the main content area like the transcript viewer does.

## Why This Change Was Made

**Bug root cause:** the Codex session catalog lists threads through the plugin's supervision app-server connection, which can run on the agent-scoped Codex home (`plugins.entries.codex.config.appServer.homeScope: "agent"` → `<agentDir>/codex-home`). Verified on a live gateway: the failing thread existed in the agent home's `state_5.sqlite` and sessions tree, not in `~/.codex`. The terminal plan spawned a bare `codex resume <threadId>` under the operator login shell env, so the CLI resolved its default `~/.codex` (`codex-rs/utils/home-dir`) and correctly reported no such session. The catalog knew which `CODEX_HOME` it listed from and discarded that fact before the spawn — an env ownership gap on both the gateway-local and paired-node PTY paths.

**Fix shape:** record the fact where it is produced. `SessionCatalogTerminalPlan` (local variant) gains a bounded `env` map; `openCodexCatalogTerminal` resolves the supervision connection's home and pins `CODEX_HOME` on local and node resume plans; the gateway merges plan env into the PTY spawn; `runNodePtyCommand` accepts env overrides. The home-scope resolution that existed in three copies (auth-bridge startup, cache-key identity, and now the terminal) is consolidated into one shared `resolveCodexAppServerLocalHomeDir`, so the terminal cannot drift from what the app-server actually used.

**Main-pane terminal:** the dock system gains a third placement `"main"` alongside bottom/right — the panel fills the content region next to the sidebar (no resize divider; routed content stays mounted underneath). A three-way placement switcher in the panel header persists through the existing `openclaw.terminal.panel.v1` store. Opening a session from the catalog selects main mode so a resumed session comes up as a full window. Named tradeoff (commented): main mode ignores sibling dock reservations; a right-docked browser/custodian panel overlays rather than shrinks it.

## User Impact

- "Open in terminal" on a catalog Codex session now resumes the correct session on gateways using agent-scoped Codex homes (the default supervision scope on stdio transports resolves to the user home, so `~/.codex` setups keep working unchanged — `startOptions.env.CODEX_HOME` still wins when set).
- The terminal can now act as the primary window: catalog-opened sessions fill the main content area, and the mode is switchable/persistent from the panel header.

## Evidence

Focused suites (via `node scripts/run-vitest.mjs`), all green:

- `extensions/codex/src/session-catalog.test.ts` — 99 passed (new: agent-home vs user-home plan env, node PTY `CODEX_HOME` injection)
- `src/gateway/server-methods/terminal.test.ts` — 24 passed (spawn env contains plan `CODEX_HOME` and preserves `pathEnv` PATH)
- `src/node-host/pty-command.test.ts` — 3 passed (env override precedence, TERM/OPENCLAW_TERMINAL markers)
- `ui/src/components/{dock-panel-layout,terminal/terminal-panel,terminal/terminal-panel-suppression,terminal/terminal-panel-accessibility}.test.ts` — 37 passed (main-mode persistence round-trip, no resizer in main mode, catalog-open forcing main, settings-takeover suppression, switcher a11y labels)

Gates: `pnpm plugin-sdk:surface:check` green, i18n baseline green, `git diff --check` clean, changed-files check gate green (remote routing unavailable; documented trusted-source local fallback used). Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings.

Dependency proof: `codex resume` id lookup path read directly in sibling `../codex` checkout — `codex-rs/tui/src/lib.rs` (`lookup_session_target_with_app_server` → `thread/read`), `codex-rs/app-server/src/request_processors/thread_processor.rs` (`read_thread_view`), `codex-rs/thread-store/src/local/read_thread.rs` (`resolve_rollout_path` scoped to `config.codex_home`) — confirming resume resolution is strictly CODEX_HOME-scoped.

Production LOC: +93 net (new placement + env ownership boundary; resolver consolidation nets negative inside the codex plugin). Tests: +141.
