### PR TITLE
refactor(ui): rename stale delete-confirm surface to confirmed-action after hide removal

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4826,6 +4826,7 @@ export const en: TranslationMap = {
       askInSideChat: "Ask in side chat",
       rewind: "Rewind",
       rewindConfirm: "Rewind to before this message?",
+      dontAskAgain: "Don't ask again",
       rewindToHere: "Rewind to here",
       rewindUnavailable: "Rewind is unavailable while the agent is working",
       forkUnavailable: "Fork is unavailable while the agent is working",

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -696,13 +696,13 @@ describe("chat pane session suggestion lifecycle", () => {
 
 function createConfirmationOwner() {
   const owner = document.createElement("span");
-  owner.className = "chat-delete-wrap";
+  owner.className = "chat-confirm-wrap";
   const trigger = document.createElement("button");
   owner.appendChild(trigger);
   document.body.appendChild(owner);
   confirmationOwners.add(owner);
   openChatRewindConfirmation(trigger, vi.fn());
-  const popover = [...document.querySelectorAll<HTMLElement>(".chat-delete-confirm")].at(-1);
+  const popover = [...document.querySelectorAll<HTMLElement>(".chat-confirm-popover")].at(-1);
   expect(popover).toBeInstanceOf(HTMLElement);
   return { owner, popover: popover! };
 }

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -6222,13 +6222,13 @@ describe("right-click Reply", () => {
     document.body.appendChild(container);
     const section = container.querySelector<HTMLElement>(".card.chat")!;
     const confirmationOwner = document.createElement("span");
-    confirmationOwner.className = "chat-delete-wrap";
+    confirmationOwner.className = "chat-confirm-wrap";
     const confirmationTrigger = document.createElement("button");
     confirmationOwner.appendChild(confirmationTrigger);
     section.appendChild(confirmationOwner);
     window.localStorage.removeItem("openclaw:skip-rewind-confirm");
     chatMessage.openChatRewindConfirmation(confirmationTrigger, vi.fn());
-    const confirmation = document.querySelector<HTMLElement>(".chat-delete-confirm");
+    const confirmation = document.querySelector<HTMLElement>(".chat-confirm-popover");
     const { bubble } = appendChatBubble(container, { text: "open message actions" });
 
     try {
@@ -6370,7 +6370,7 @@ describe("right-click Reply", () => {
     rewindButton!.click();
     flushFrames();
 
-    const cancel = document.querySelector<HTMLButtonElement>(".chat-delete-confirm__cancel");
+    const cancel = document.querySelector<HTMLButtonElement>(".chat-confirm-popover__cancel");
     expect(cancel).toBeInstanceOf(HTMLButtonElement);
     expect(document.activeElement).toBe(cancel);
     const confirmationEscape = new KeyboardEvent("keydown", {
@@ -6381,7 +6381,7 @@ describe("right-click Reply", () => {
     cancel!.dispatchEvent(confirmationEscape);
 
     expect(confirmationEscape.defaultPrevented).toBe(true);
-    expect(document.querySelector(".chat-delete-confirm")).toBeNull();
+    expect(document.querySelector(".chat-confirm-popover")).toBeNull();
     expect(document.querySelector(".chat-reply-context-menu")).not.toBeNull();
     expect(document.activeElement).toBe(rewindButton);
 
@@ -6410,12 +6410,12 @@ describe("right-click Reply", () => {
 
     resetChatThreadPresentationState("pane-b");
     expect(document.querySelector(".chat-reply-context-menu")).not.toBeNull();
-    expect(document.querySelector(".chat-delete-confirm")).not.toBeNull();
+    expect(document.querySelector(".chat-confirm-popover")).not.toBeNull();
 
     resetChatThreadPresentationState("pane-a");
 
     expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
-    expect(document.querySelector(".chat-delete-confirm")).toBeNull();
+    expect(document.querySelector(".chat-confirm-popover")).toBeNull();
     expect(onRewindMessage).not.toHaveBeenCalled();
     expect(removeDocumentListener).toHaveBeenCalledWith("click", expect.any(Function), true);
     expect(removeWindowListener).toHaveBeenCalledWith("keydown", expect.any(Function), true);

--- a/ui/src/pages/chat/components/chat-message-confirmation.ts
+++ b/ui/src/pages/chat/components/chat-message-confirmation.ts
@@ -3,18 +3,18 @@ import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import { getSafeLocalStorage } from "../../../local-storage.ts";
 
+// Persisted preference key: renaming it would reset users' "Don't ask again" choice.
 const SKIP_REWIND_CONFIRM_PREFERENCE = "openclaw:skip-rewind-confirm";
-const DELETE_CONFIRM_VIEWPORT_MARGIN_PX = 8;
-const DELETE_CONFIRM_TRIGGER_GAP_PX = 6;
+const CONFIRMED_ACTION_VIEWPORT_MARGIN_PX = 8;
+const CONFIRMED_ACTION_TRIGGER_GAP_PX = 6;
 
-type DeleteConfirmSide = "left" | "right";
-type DeleteConfirmDismissOptions = { restoreFocus?: boolean };
-type DeleteConfirmDismisser = (options?: DeleteConfirmDismissOptions) => void;
+type ConfirmedActionDismissOptions = { restoreFocus?: boolean };
+type ConfirmedActionDismisser = (options?: ConfirmedActionDismissOptions) => void;
 
-const deleteConfirmDismissers = new WeakMap<Element, DeleteConfirmDismisser>();
-const deleteConfirmOwners = new WeakMap<Element, Element>();
-const deleteConfirmPopovers = new Set<HTMLElement>();
-const deleteConfirmPopoversByOwner = new WeakMap<Element, HTMLElement>();
+const confirmedActionDismissers = new WeakMap<Element, ConfirmedActionDismisser>();
+const confirmedActionOwners = new WeakMap<Element, Element>();
+const confirmedActionPopovers = new Set<HTMLElement>();
+const confirmedActionPopoversByOwner = new WeakMap<Element, HTMLElement>();
 
 function shouldSkipActionConfirm(preferenceName: string): boolean {
   try {
@@ -24,8 +24,8 @@ function shouldSkipActionConfirm(preferenceName: string): boolean {
   }
 }
 
-function dismissDeleteConfirm(element: Element, options?: DeleteConfirmDismissOptions) {
-  const dismiss = deleteConfirmDismissers.get(element);
+function dismissConfirmedAction(element: Element, options?: ConfirmedActionDismissOptions) {
+  const dismiss = confirmedActionDismissers.get(element);
   if (dismiss) {
     dismiss(options);
     return;
@@ -34,10 +34,10 @@ function dismissDeleteConfirm(element: Element, options?: DeleteConfirmDismissOp
 }
 
 export function dismissConfirmedActionPopovers(owner: ParentNode): void {
-  for (const popover of deleteConfirmPopovers) {
-    const popoverOwner = deleteConfirmOwners.get(popover);
+  for (const popover of confirmedActionPopovers) {
+    const popoverOwner = confirmedActionOwners.get(popover);
     if (popoverOwner && owner instanceof Node && owner.contains(popoverOwner)) {
-      dismissDeleteConfirm(popover);
+      dismissConfirmedAction(popover);
     }
   }
 }
@@ -57,23 +57,19 @@ function resolveViewportBounds() {
   };
 }
 
-function clampDeleteConfirmPosition(value: number, min: number, max: number) {
+function clampConfirmedActionPosition(value: number, min: number, max: number) {
   if (max < min) {
     return min;
   }
   return Math.min(Math.max(value, min), max);
 }
 
-function placeDeleteConfirmPopover(
-  trigger: HTMLElement,
-  popover: HTMLElement,
-  side: DeleteConfirmSide,
-) {
+function placeConfirmedActionPopover(trigger: HTMLElement, popover: HTMLElement) {
   const triggerRect = trigger.getBoundingClientRect();
   const popoverRect = popover.getBoundingClientRect();
   const viewport = resolveViewportBounds();
-  const margin = DELETE_CONFIRM_VIEWPORT_MARGIN_PX;
-  const gap = DELETE_CONFIRM_TRIGGER_GAP_PX;
+  const margin = CONFIRMED_ACTION_VIEWPORT_MARGIN_PX;
+  const gap = CONFIRMED_ACTION_TRIGGER_GAP_PX;
   const viewportWidth = viewport.right - viewport.left;
   const viewportHeight = viewport.bottom - viewport.top;
   const popoverWidth = Math.min(popoverRect.width, viewportWidth - margin * 2);
@@ -81,14 +77,14 @@ function placeDeleteConfirmPopover(
   const spaceAbove = triggerRect.top - viewport.top - margin - gap;
   const spaceBelow = viewport.bottom - triggerRect.bottom - margin - gap;
   const placeBelow = spaceAbove < popoverHeight && spaceBelow >= spaceAbove;
-  const desiredLeft = side === "left" ? triggerRect.right - popoverWidth : triggerRect.left;
-  const left = clampDeleteConfirmPosition(
+  const desiredLeft = triggerRect.right - popoverWidth;
+  const left = clampConfirmedActionPosition(
     desiredLeft,
     viewport.left + margin,
     viewport.right - margin - popoverWidth,
   );
   const desiredTop = placeBelow ? triggerRect.bottom + gap : triggerRect.top - gap - popoverHeight;
-  const top = clampDeleteConfirmPosition(
+  const top = clampConfirmedActionPosition(
     desiredTop,
     viewport.top + margin,
     viewport.bottom - margin - popoverHeight,
@@ -99,39 +95,37 @@ function placeDeleteConfirmPopover(
   popover.dataset.placement = placeBelow ? "below" : "above";
 }
 
-export function renderRewindButton(
-  onRewind: () => void,
-  disabled: boolean,
-  side: DeleteConfirmSide,
-) {
-  return renderConfirmedActionButton({
-    action: onRewind,
-    ariaLabel: t("chat.messages.rewind"),
-    buttonClass: "chat-group-rewind",
-    confirmLabel: t("chat.messages.rewind"),
-    confirmText: t("chat.messages.rewindConfirm"),
-    disabled,
-    icon: icons.refresh,
-    preferenceName: SKIP_REWIND_CONFIRM_PREFERENCE,
-    side,
-    tooltip: disabled ? t("chat.messages.rewindUnavailable") : t("chat.messages.rewind"),
-    wrapClass: "chat-rewind-wrap",
-  });
-}
-
 type ConfirmedActionParams = {
   action: () => void;
-  ariaLabel: string;
-  buttonClass?: string;
   confirmLabel: string;
   confirmText: string;
-  disabled?: boolean;
-  icon: unknown;
   preferenceName: string;
-  side: DeleteConfirmSide;
-  tooltip: string;
-  wrapClass?: string;
 };
+
+export function renderRewindButton(onRewind: () => void, disabled: boolean) {
+  const label = t("chat.messages.rewind");
+  const params: ConfirmedActionParams = {
+    action: onRewind,
+    confirmLabel: label,
+    confirmText: t("chat.messages.rewindConfirm"),
+    preferenceName: SKIP_REWIND_CONFIRM_PREFERENCE,
+  };
+  return html`
+    <span class="chat-confirm-wrap chat-rewind-wrap">
+      <openclaw-tooltip .content=${disabled ? t("chat.messages.rewindUnavailable") : label}>
+        <button
+          class="chat-group-rewind"
+          aria-label=${label}
+          ?disabled=${disabled}
+          @click=${(event: Event) =>
+            openConfirmedActionPopover(event.currentTarget as HTMLElement, params)}
+        >
+          ${icons.refresh}
+        </button>
+      </openclaw-tooltip>
+    </span>
+  `;
+}
 
 export function openChatRewindConfirmation(trigger: HTMLElement, action: () => void): void {
   openConfirmedActionPopover(trigger, {
@@ -139,70 +133,71 @@ export function openChatRewindConfirmation(trigger: HTMLElement, action: () => v
     confirmLabel: t("chat.messages.rewind"),
     confirmText: t("chat.messages.rewindConfirm"),
     preferenceName: SKIP_REWIND_CONFIRM_PREFERENCE,
-    side: "left",
   });
 }
 
-function openConfirmedActionPopover(
-  btn: HTMLElement,
-  params: Pick<
-    ConfirmedActionParams,
-    "action" | "confirmLabel" | "confirmText" | "preferenceName" | "side"
-  >,
-): void {
+function openConfirmedActionPopover(btn: HTMLElement, params: ConfirmedActionParams): void {
   if (shouldSkipActionConfirm(params.preferenceName)) {
     params.action();
     return;
   }
-  const wrap = btn.closest(".chat-delete-wrap") as HTMLElement | null;
+  const wrap = btn.closest(".chat-confirm-wrap") as HTMLElement | null;
   if (!wrap) {
     return;
   }
   const owner = wrap;
-  const existing = deleteConfirmPopoversByOwner.get(owner);
+  const existing = confirmedActionPopoversByOwner.get(owner);
   if (existing) {
-    dismissDeleteConfirm(existing, { restoreFocus: true });
+    dismissConfirmedAction(existing, { restoreFocus: true });
     return;
   }
   const popover = document.createElement("div");
-  popover.className = `chat-delete-confirm chat-delete-confirm--${params.side}`;
+  popover.className = "chat-confirm-popover";
   popover.setAttribute("role", "dialog");
   popover.setAttribute("aria-modal", "true");
   popover.setAttribute("aria-label", params.confirmText);
   popover.innerHTML = `
-    <p class="chat-delete-confirm__text"></p>
-    <label class="chat-delete-confirm__remember">
-      <input type="checkbox" class="chat-delete-confirm__check" />
-      <span>Don't ask again</span>
+    <p class="chat-confirm-popover__text"></p>
+    <label class="chat-confirm-popover__remember">
+      <input type="checkbox" class="chat-confirm-popover__check" />
+      <span></span>
     </label>
-    <div class="chat-delete-confirm__actions">
-      <button class="chat-delete-confirm__cancel" type="button">Cancel</button>
-      <button class="chat-delete-confirm__yes" type="button"></button>
+    <div class="chat-confirm-popover__actions">
+      <button class="chat-confirm-popover__cancel" type="button"></button>
+      <button class="chat-confirm-popover__yes" type="button"></button>
     </div>
   `;
-  const confirmText = popover.querySelector(".chat-delete-confirm__text");
-  const confirmButton = popover.querySelector(".chat-delete-confirm__yes");
+  const confirmText = popover.querySelector(".chat-confirm-popover__text");
+  const rememberText = popover.querySelector(".chat-confirm-popover__remember span");
+  const cancelButton = popover.querySelector(".chat-confirm-popover__cancel");
+  const confirmButton = popover.querySelector(".chat-confirm-popover__yes");
   if (confirmText) {
     confirmText.textContent = params.confirmText;
   }
   if (confirmButton) {
     confirmButton.textContent = params.confirmLabel;
   }
+  if (rememberText) {
+    rememberText.textContent = t("chat.messages.dontAskAgain");
+  }
+  if (cancelButton) {
+    cancelButton.textContent = t("common.cancel");
+  }
   // Virtual transcript rows use transforms for positioning, which makes fixed
   // descendants relative to the row instead of the viewport. Portal the dialog
   // so the viewport-clamped coordinates stay correct in web and native hosts.
   owner.ownerDocument.body.appendChild(popover);
-  deleteConfirmOwners.set(popover, owner);
-  deleteConfirmPopovers.add(popover);
-  deleteConfirmPopoversByOwner.set(owner, popover);
-  placeDeleteConfirmPopover(btn, popover, params.side);
+  confirmedActionOwners.set(popover, owner);
+  confirmedActionPopovers.add(popover);
+  confirmedActionPopoversByOwner.set(owner, popover);
+  placeConfirmedActionPopover(btn, popover);
 
-  const cancel = popover.querySelector<HTMLButtonElement>(".chat-delete-confirm__cancel")!;
-  const yes = popover.querySelector<HTMLButtonElement>(".chat-delete-confirm__yes")!;
-  const check = popover.querySelector<HTMLInputElement>(".chat-delete-confirm__check")!;
+  const cancel = popover.querySelector<HTMLButtonElement>(".chat-confirm-popover__cancel")!;
+  const yes = popover.querySelector<HTMLButtonElement>(".chat-confirm-popover__yes")!;
+  const check = popover.querySelector<HTMLInputElement>(".chat-confirm-popover__check")!;
   let dismissed = false;
   let ownerObserver: MutationObserver | null = null;
-  function dismissPopover(options?: DeleteConfirmDismissOptions) {
+  function dismissPopover(options?: ConfirmedActionDismissOptions) {
     if (dismissed) {
       return;
     }
@@ -211,10 +206,10 @@ function openConfirmedActionPopover(
     document.removeEventListener("click", closeOnOutside, true);
     document.removeEventListener("contextmenu", closeOnContextMenu, true);
     window.removeEventListener("keydown", closeOnEscape, true);
-    deleteConfirmDismissers.delete(popover);
-    deleteConfirmOwners.delete(popover);
-    deleteConfirmPopovers.delete(popover);
-    deleteConfirmPopoversByOwner.delete(owner);
+    confirmedActionDismissers.delete(popover);
+    confirmedActionOwners.delete(popover);
+    confirmedActionPopovers.delete(popover);
+    confirmedActionPopoversByOwner.delete(owner);
     popover.remove();
     if (options?.restoreFocus && btn.isConnected) {
       btn.focus({ preventScroll: true });
@@ -254,7 +249,7 @@ function openConfirmedActionPopover(
       first.focus();
     }
   }
-  deleteConfirmDismissers.set(popover, dismissPopover);
+  confirmedActionDismissers.set(popover, dismissPopover);
   cancel.addEventListener("click", () => dismissPopover({ restoreFocus: true }));
   yes.addEventListener("click", () => {
     if (check.checked) {
@@ -277,26 +272,8 @@ function openConfirmedActionPopover(
   cancel.focus({ preventScroll: true });
   requestAnimationFrame(() => {
     if (!dismissed && popover.isConnected) {
-      placeDeleteConfirmPopover(btn, popover, params.side);
+      placeConfirmedActionPopover(btn, popover);
       document.addEventListener("click", closeOnOutside, true);
     }
   });
-}
-
-function renderConfirmedActionButton(params: ConfirmedActionParams) {
-  return html`
-    <span class="chat-delete-wrap ${params.wrapClass ?? ""}">
-      <openclaw-tooltip .content=${params.tooltip}>
-        <button
-          class=${params.buttonClass ?? ""}
-          aria-label=${params.ariaLabel}
-          ?disabled=${params.disabled}
-          @click=${(event: Event) =>
-            openConfirmedActionPopover(event.currentTarget as HTMLElement, params)}
-        >
-          ${params.icon}
-        </button>
-      </openclaw-tooltip>
-    </span>
-  `;
 }

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -485,7 +485,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
                     ? renderReplyButton(footerActionDetails.replyTarget, opts.onReply)
                     : nothing}
                   ${opts.onRewind
-                    ? renderRewindButton(opts.onRewind, Boolean(opts.rewindDisabled), "left")
+                    ? renderRewindButton(opts.onRewind, Boolean(opts.rewindDisabled))
                     : nothing}
                 </div>
               `

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -551,7 +551,7 @@ function stubConfirmedActionGeometry(params: {
       if (this.classList.contains("chat-group-rewind")) {
         return domRect(params.trigger);
       }
-      if (this.classList.contains("chat-delete-confirm")) {
+      if (this.classList.contains("chat-confirm-popover")) {
         return domRect(params.popover);
       }
       return domRect({});
@@ -581,7 +581,7 @@ function setupArmedConfirmedAction() {
   const outsideClickListener = expectLastCaptureClickListener(addListenerSpy.mock.calls);
   const outsideContextMenuListener = getLastCaptureContextMenuListener(addListenerSpy.mock.calls);
   const escapeListener = getLastCaptureKeydownListener(addKeyListenerSpy.mock.calls);
-  const popover = expectElement(document.body, ".chat-delete-confirm", HTMLElement);
+  const popover = expectElement(document.body, ".chat-confirm-popover", HTMLElement);
   expect(typeof outsideContextMenuListener).toBe("function");
   expect(typeof escapeListener).toBe("function");
 
@@ -980,10 +980,10 @@ describe("grouped chat rendering", () => {
     const rewindButtons = container.querySelectorAll<HTMLButtonElement>(".chat-group-rewind");
     expect(rewindButtons).toHaveLength(1);
     rewindButtons[0]!.click();
-    expect(document.querySelector(".chat-delete-confirm__text")?.textContent).toBe(
+    expect(document.querySelector(".chat-confirm-popover__text")?.textContent).toBe(
       "Rewind to before this message?",
     );
-    document.querySelector<HTMLButtonElement>(".chat-delete-confirm__yes")!.click();
+    document.querySelector<HTMLButtonElement>(".chat-confirm-popover__yes")!.click();
     expect(onRewind).toHaveBeenCalledTimes(1);
   });
 
@@ -1042,7 +1042,7 @@ describe("grouped chat rendering", () => {
 
     openConfirmedAction(fixture.actionButton);
 
-    const element = expectElement(document.body, ".chat-delete-confirm", HTMLElement);
+    const element = expectElement(document.body, ".chat-confirm-popover", HTMLElement);
     expect(element.parentElement).toBe(document.body);
     if (placement) {
       expect(element.dataset.placement).toBe(placement);
@@ -1057,15 +1057,19 @@ describe("grouped chat rendering", () => {
 
     openConfirmedAction(fixture.actionButton);
 
-    const popover = expectElement(document.body, ".chat-delete-confirm", HTMLElement);
-    const check = expectElement(popover, ".chat-delete-confirm__check", HTMLInputElement);
-    const cancel = expectElement(popover, ".chat-delete-confirm__cancel", HTMLButtonElement);
-    const confirm = expectElement(popover, ".chat-delete-confirm__yes", HTMLButtonElement);
+    const popover = expectElement(document.body, ".chat-confirm-popover", HTMLElement);
+    const check = expectElement(popover, ".chat-confirm-popover__check", HTMLInputElement);
+    const cancel = expectElement(popover, ".chat-confirm-popover__cancel", HTMLButtonElement);
+    const confirm = expectElement(popover, ".chat-confirm-popover__yes", HTMLButtonElement);
     expect(popover.getAttribute("role")).toBe("dialog");
     expect(popover.getAttribute("aria-modal")).toBe("true");
     expect(popover.getAttribute("aria-label")).toBe(
-      popover.querySelector(".chat-delete-confirm__text")?.textContent,
+      popover.querySelector(".chat-confirm-popover__text")?.textContent,
     );
+    expect(popover.querySelector(".chat-confirm-popover__remember span")?.textContent).toBe(
+      "Don't ask again",
+    );
+    expect(cancel.textContent).toBe("Cancel");
     expect(document.activeElement).toBe(cancel);
 
     confirm.focus();
@@ -1093,7 +1097,7 @@ describe("grouped chat rendering", () => {
     const fixture = setupArmedConfirmedAction();
     const cancel = expectElement(
       fixture.popover,
-      ".chat-delete-confirm__cancel",
+      ".chat-confirm-popover__cancel",
       HTMLButtonElement,
     );
     const leakedKeydown = vi.fn();
@@ -1121,9 +1125,9 @@ describe("grouped chat rendering", () => {
     const fixture = setupArmedConfirmedAction();
     const sibling = renderConfirmedActionFixture();
     openConfirmedAction(sibling.actionButton);
-    const siblingPopover = [...document.querySelectorAll<HTMLElement>(".chat-delete-confirm")].find(
-      (popover) => popover !== fixture.popover,
-    );
+    const siblingPopover = [
+      ...document.querySelectorAll<HTMLElement>(".chat-confirm-popover"),
+    ].find((popover) => popover !== fixture.popover);
 
     dismissConfirmedActionPopovers(fixture.container);
 
@@ -1157,7 +1161,7 @@ describe("grouped chat rendering", () => {
     dismissConfirmedActionPopovers(fixture.container);
     flushAnimationFrames();
 
-    expect(document.querySelector(".chat-delete-confirm")).toBeNull();
+    expect(document.querySelector(".chat-confirm-popover")).toBeNull();
     expect(getLastCaptureClickListener(addListenerSpy.mock.calls)).toBeNull();
     expect(
       countCaptureContextMenuListenerRemovals(removeListenerSpy.mock.calls, contextMenuListener),
@@ -1169,7 +1173,9 @@ describe("grouped chat rendering", () => {
 
   it("removes the confirmation outside-click listener when Cancel dismisses it", () => {
     const fixture = setupArmedConfirmedAction();
-    const cancel = fixture.popover.querySelector<HTMLButtonElement>(".chat-delete-confirm__cancel");
+    const cancel = fixture.popover.querySelector<HTMLButtonElement>(
+      ".chat-confirm-popover__cancel",
+    );
 
     expect(cancel).toBeInstanceOf(HTMLButtonElement);
     cancel!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -1181,7 +1187,7 @@ describe("grouped chat rendering", () => {
 
   it("removes the confirmation outside-click listener when Rewind dismisses it", () => {
     const fixture = setupArmedConfirmedAction();
-    const confirm = fixture.popover.querySelector<HTMLButtonElement>(".chat-delete-confirm__yes");
+    const confirm = fixture.popover.querySelector<HTMLButtonElement>(".chat-confirm-popover__yes");
 
     expect(confirm).toBeInstanceOf(HTMLButtonElement);
     confirm!.focus();
@@ -1236,7 +1242,7 @@ describe("grouped chat rendering", () => {
     openConfirmedAction(fixture.actionButton);
     flushAnimationFrames();
 
-    expect(document.querySelector(".chat-delete-confirm")).toBeNull();
+    expect(document.querySelector(".chat-confirm-popover")).toBeNull();
     expect(getLastCaptureClickListener(addListenerSpy.mock.calls)).toBeNull();
     expect(fixture.onAction).not.toHaveBeenCalled();
   });

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -1193,7 +1193,7 @@ function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
         });
       },
     });
-    action.element.classList.add("chat-delete-wrap", "chat-rewind-wrap");
+    action.element.classList.add("chat-confirm-wrap", "chat-rewind-wrap");
     menu.append(action.element);
     focusCandidates.push(action.button);
   }

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -151,7 +151,7 @@
   pointer-events: none;
 }
 
-.chat-group-footer--persistent-identity .chat-delete-wrap,
+.chat-group-footer--persistent-identity .chat-confirm-wrap,
 .chat-group-footer--persistent-identity .chat-group-timestamp,
 .chat-group-footer--persistent-identity .msg-meta,
 .chat-group-footer--persistent-identity .chat-group-footer-actions {
@@ -166,13 +166,13 @@
   pointer-events: auto;
 }
 
-.chat-group:hover .chat-group-footer--persistent-identity .chat-delete-wrap,
+.chat-group:hover .chat-group-footer--persistent-identity .chat-confirm-wrap,
 .chat-group:hover .chat-group-footer--persistent-identity .chat-group-timestamp,
 .chat-group:hover .chat-group-footer--persistent-identity .msg-meta,
-.chat-group:focus-within .chat-group-footer--persistent-identity .chat-delete-wrap,
+.chat-group:focus-within .chat-group-footer--persistent-identity .chat-confirm-wrap,
 .chat-group:focus-within .chat-group-footer--persistent-identity .chat-group-timestamp,
 .chat-group:focus-within .chat-group-footer--persistent-identity .msg-meta,
-.chat-group-footer--persistent-identity:has(details.msg-meta[open]) .chat-delete-wrap,
+.chat-group-footer--persistent-identity:has(details.msg-meta[open]) .chat-confirm-wrap,
 .chat-group-footer--persistent-identity:has(details.msg-meta[open]) .chat-group-timestamp,
 .chat-group-footer--persistent-identity:has(details.msg-meta[open]) .msg-meta,
 .chat-group:hover .chat-group-footer--persistent-identity .chat-group-footer-actions,
@@ -653,7 +653,7 @@ img.chat-avatar.chat-avatar--logo {
     margin-bottom: 14px;
   }
 
-  .chat-group-footer--persistent-identity .chat-delete-wrap,
+  .chat-group-footer--persistent-identity .chat-confirm-wrap,
   .chat-group-footer--persistent-identity .chat-group-timestamp,
   .chat-group-footer--persistent-identity .msg-meta,
   .chat-group-footer--persistent-identity .chat-group-footer-actions {
@@ -923,13 +923,13 @@ details.msg-meta:not([open]) .msg-meta__details {
   color: var(--danger);
 }
 
-/* ── Delete confirmation popover ── */
-.chat-delete-wrap {
+/* ── Confirmed action popover ── */
+.chat-confirm-wrap {
   position: relative;
   display: inline-flex;
 }
 
-.chat-delete-confirm {
+.chat-confirm-popover {
   position: fixed;
   background: var(--card, #1a1a1a);
   border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
@@ -940,24 +940,17 @@ details.msg-meta:not([open]) .msg-meta__details {
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
   z-index: 100;
   animation: scale-in 0.15s ease-out;
-}
-
-.chat-delete-confirm--left {
   transform-origin: top right;
 }
 
-.chat-delete-confirm--right {
-  transform-origin: top left;
-}
-
-.chat-delete-confirm__text {
+.chat-confirm-popover__text {
   margin: 0 0 8px;
   font-size: 13px;
   font-weight: 500;
   color: var(--text);
 }
 
-.chat-delete-confirm__remember {
+.chat-confirm-popover__remember {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -967,20 +960,20 @@ details.msg-meta:not([open]) .msg-meta__details {
   user-select: none;
 }
 
-.chat-delete-confirm__check {
+.chat-confirm-popover__check {
   width: 14px;
   height: 14px;
   accent-color: var(--accent);
 }
 
-.chat-delete-confirm__actions {
+.chat-confirm-popover__actions {
   display: flex;
   gap: 6px;
   justify-content: flex-end;
 }
 
-.chat-delete-confirm__cancel,
-.chat-delete-confirm__yes {
+.chat-confirm-popover__cancel,
+.chat-confirm-popover__yes {
   border: none;
   border-radius: var(--radius-sm, 4px);
   padding: 4px 12px;
@@ -989,41 +982,41 @@ details.msg-meta:not([open]) .msg-meta__details {
   transition: background 120ms ease-out;
 }
 
-.chat-delete-confirm__cancel {
+.chat-confirm-popover__cancel {
   background: var(--bg-hover, rgba(255, 255, 255, 0.08));
   color: var(--muted, #888);
 }
 
-.chat-delete-confirm__cancel:hover {
+.chat-confirm-popover__cancel:hover {
   background: rgba(255, 255, 255, 0.12);
 }
 
-.chat-delete-confirm__yes {
+.chat-confirm-popover__yes {
   background: var(--danger);
   color: #fff;
 }
 
-:root[data-theme="dark"] .chat-delete-confirm__yes {
+:root[data-theme="dark"] .chat-confirm-popover__yes {
   background: var(--destructive);
   color: var(--destructive-foreground);
 }
 
-:root[data-theme="openknot"] .chat-delete-confirm__yes,
-:root[data-theme="dash"] .chat-delete-confirm__yes {
+:root[data-theme="openknot"] .chat-confirm-popover__yes,
+:root[data-theme="dash"] .chat-confirm-popover__yes {
   background: var(--destructive);
   color: var(--destructive-foreground);
 }
 
-.chat-delete-confirm__yes:hover {
+.chat-confirm-popover__yes:hover {
   background: #dc2626;
 }
 
-:root[data-theme="dark"] .chat-delete-confirm__yes:hover {
+:root[data-theme="dark"] .chat-confirm-popover__yes:hover {
   background: var(--destructive-hover);
 }
 
-:root[data-theme="openknot"] .chat-delete-confirm__yes:hover,
-:root[data-theme="dash"] .chat-delete-confirm__yes:hover {
+:root[data-theme="openknot"] .chat-confirm-popover__yes:hover,
+:root[data-theme="dash"] .chat-confirm-popover__yes:hover {
   background: var(--destructive-hover);
 }
 


### PR DESCRIPTION
## What Problem This Solves

After #120681 removed the local-only hide feature, the shared confirmation-popover module in `ui/src/pages/chat/components/chat-message-confirmation.ts` became rewind-only but kept the dead feature's identity: 32 `deleteConfirm`/`DeleteConfirm` identifiers, `.chat-delete-wrap`/`.chat-delete-confirm` DOM and CSS classes, a dead right-side placement variant (the only caller passes `"left"`), a single-caller `renderConfirmedActionButton` indirection, and two hardcoded English strings (`"Cancel"`, `"Don't ask again"`) in an otherwise localized popover.

## Why This Change Was Made

The repository naming rule calls for one spelling per concept so the surface stays grep-navigable. The `delete` naming is actively misleading for a popover that now only confirms rewind, and the dead generality is removed per the lean-code policy.

## User Impact

There is no visual change. `Cancel` and `Don't ask again` become localizable: Cancel reuses `common.cancel`, and the new string uses `chat.messages.dontAskAgain`. The `openclaw:skip-rewind-confirm` localStorage preference key is intentionally unchanged so users' “Don't ask again” choice survives; the invariant is commented in code. The CSS classes are internal, not a shipped contract.

## Evidence

- Focused message tests: 163/163 passed.
- Focused lifecycle tests: 28/28 passed.
- Control UI chat sweep: 2,574 tests passed.
- Full local changed gate passed (lint, typecheck, and i18n). The remote Testbox backend was down because broker authentication was unavailable, so trusted-source proof used the local fallback permitted by `AGENTS.md` Validation; the fallback and reason are recorded here per policy.
- Codex autoreview: clean (0.98).
- Grep proof: zero `chat-delete` or `deleteConfirm` remnants under `ui/src`.
- Production LOC: -27 in the module (+82/-109), net -23 overall including tests.
