### PR TITLE
fix(memory): keep session tests reliable on Windows

### DIFF
--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -15,11 +15,14 @@ import {
   resetSessionEntryLifecycle,
   upsertSessionEntry,
 } from "../../../../src/config/sessions/session-accessor.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../../../src/state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../../../src/state/openclaw-state-db.js";
 import {
   buildSessionEntry,
   listSessionFilesForAgent,
   listSessionTranscriptCorpusEntriesForAgent,
   loadSessionTranscriptClassificationForAgent,
+  normalizeSessionTranscriptPathForComparison,
   parseCanonicalSessionSyncTargetFromPath,
   resolveSessionIdentityForTranscriptFile,
   resolveSessionFileForSyncTarget,
@@ -70,10 +73,15 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Agent close releases leases through shared state; close agent handles first while the fixture
+  // env is active, then close shared state before removing the Windows-owned directory.
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
   envSnapshot?.restore();
   envSnapshot = undefined;
   clearRuntimeConfigSnapshot();
   clearConfigCache();
+  fsSync.rmSync(tmpDir, { recursive: true, force: true });
 });
 
 function requireSessionEntry(entry: SessionFileEntry | null): SessionFileEntry {
@@ -221,7 +229,9 @@ describe("listSessionTranscriptCorpusEntriesForAgent", () => {
 
     const classification = loadSessionTranscriptClassificationForAgent("main");
 
-    expect(classification.cronRunTranscriptPaths).toEqual(new Set([path.resolve(archivePath)]));
+    expect(classification.cronRunTranscriptPaths).toEqual(
+      new Set([normalizeSessionTranscriptPathForComparison(archivePath)]),
+    );
     await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toContainEqual({
       agentId: "main",
       artifactKind: "archive-artifact",
@@ -447,7 +457,9 @@ describe("listSessionTranscriptCorpusEntriesForAgent", () => {
     const expectedArchivePath = archivePath;
     const classification = loadSessionTranscriptClassificationForAgent("main");
 
-    expect(classification.cronRunTranscriptPaths).toEqual(new Set([expectedArchivePath]));
+    expect(classification.cronRunTranscriptPaths).toEqual(
+      new Set([normalizeSessionTranscriptPathForComparison(expectedArchivePath)]),
+    );
     await expect(listSessionFilesForAgent("main")).resolves.toEqual([expectedArchivePath]);
     await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toEqual(
       expect.arrayContaining([
@@ -481,22 +493,30 @@ describe("listSessionTranscriptCorpusEntriesForAgent", () => {
     await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toEqual([]);
   });
 
-  it("omits active session entries whose transcript path is a symlink", async () => {
+  it("omits symlinked archive artifacts from the session corpus", async () => {
     const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
     const targetPath = path.join(tmpDir, "external.jsonl");
-    const symlinkPath = path.join(sessionsDir, "linked.jsonl");
+    const symlinkPath = path.join(sessionsDir, "linked.jsonl.deleted.2026-02-16T22-27-33.000Z");
     fsSync.mkdirSync(sessionsDir, { recursive: true });
-    fsSync.writeFileSync(targetPath, "");
-    fsSync.symlinkSync(targetPath, symlinkPath);
-    fsSync.writeFileSync(
-      path.join(sessionsDir, "sessions.json"),
-      JSON.stringify({
-        "agent:main:chat:linked": {
-          sessionFile: "linked.jsonl",
-          sessionId: "linked",
-        },
+    fsSync.writeFileSync(symlinkPath, "");
+    await expect(listSessionFilesForAgent("main")).resolves.toEqual([symlinkPath]);
+    await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toContainEqual(
+      expect.objectContaining({
+        artifactKind: "archive-artifact",
+        sessionFile: symlinkPath,
+        sessionId: "linked",
       }),
     );
+    fsSync.unlinkSync(symlinkPath);
+
+    if (process.platform === "win32") {
+      fsSync.mkdirSync(targetPath);
+      fsSync.symlinkSync(targetPath, symlinkPath, "junction");
+    } else {
+      fsSync.writeFileSync(targetPath, "");
+      fsSync.symlinkSync(targetPath, symlinkPath);
+    }
+    expect(fsSync.lstatSync(symlinkPath).isSymbolicLink()).toBe(true);
 
     await expect(listSessionFilesForAgent("main")).resolves.toEqual([]);
     await expect(listSessionTranscriptCorpusEntriesForAgent("main")).resolves.toEqual([]);

--- a/packages/memory-host-sdk/src/host/session-files.windows-ownership.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.windows-ownership.test.ts
@@ -5,10 +5,15 @@ import {
   clearConfigCache,
   clearRuntimeConfigSnapshot,
 } from "openclaw/plugin-sdk/runtime-config-snapshot";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { upsertSessionEntry } from "../../../../src/config/sessions/session-accessor.js";
-import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
-import { extractAgentIdFromSessionsDir } from "./openclaw-runtime-session.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../../../src/state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../../../src/state/openclaw-state-db.js";
+import { createTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import {
+  extractAgentIdFromSessionsDir,
+  resolveSessionTranscriptsDirForAgent,
+} from "./openclaw-runtime-session.js";
 import {
   listSessionTranscriptCorpusEntriesForAgent,
   parseCanonicalSessionSyncTargetFromPath,
@@ -16,44 +21,20 @@ import {
 } from "./session-files.js";
 
 const invalidWindowsAgentIds = ["bad owner", "!!!", " Main", "Main ", "a".repeat(65)];
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-let tmpDir = "";
-let originalStateDir: string | undefined;
-let originalConfigPath: string | undefined;
-
-beforeEach(() => {
-  tmpDir = tempDirs.make("session-windows-ownership-");
-  originalStateDir = process.env.OPENCLAW_STATE_DIR;
-  originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
-  process.env.OPENCLAW_STATE_DIR = tmpDir;
-  delete process.env.OPENCLAW_CONFIG_PATH;
-  clearRuntimeConfigSnapshot();
-  clearConfigCache();
-});
-
-afterEach(() => {
-  if (originalStateDir === undefined) {
-    delete process.env.OPENCLAW_STATE_DIR;
-  } else {
-    process.env.OPENCLAW_STATE_DIR = originalStateDir;
-  }
-  if (originalConfigPath === undefined) {
-    delete process.env.OPENCLAW_CONFIG_PATH;
-  } else {
-    process.env.OPENCLAW_CONFIG_PATH = originalConfigPath;
-  }
-  clearRuntimeConfigSnapshot();
-  clearConfigCache();
-});
+function resolveFixtureStateDir(): string {
+  return path.resolve(resolveSessionTranscriptsDirForAgent("main"), "../../..");
+}
 
 describe("memory session directory ownership", () => {
   it("preserves the canonical owner for case-variant Windows session directories", () => {
     const platform = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     try {
-      expect(extractAgentIdFromSessionsDir(path.join(tmpDir, "AGENTS", "Main", "SESSIONS"))).toBe(
-        "main",
-      );
+      expect(
+        extractAgentIdFromSessionsDir(
+          path.join(resolveFixtureStateDir(), "AGENTS", "Main", "SESSIONS"),
+        ),
+      ).toBe("main");
     } finally {
       platform.mockRestore();
     }
@@ -63,7 +44,9 @@ describe("memory session directory ownership", () => {
     const platform = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
     try {
       expect(
-        extractAgentIdFromSessionsDir(path.join(tmpDir, "AGENTS", "Main", "SESSIONS")),
+        extractAgentIdFromSessionsDir(
+          path.join(resolveFixtureStateDir(), "AGENTS", "Main", "SESSIONS"),
+        ),
       ).toBeNull();
     } finally {
       platform.mockRestore();
@@ -73,7 +56,13 @@ describe("memory session directory ownership", () => {
   it("preserves case-variant Windows ownership in logical transcript paths", () => {
     const platform = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     try {
-      const sessionFile = path.join(tmpDir, "AGENTS", "Main", "SESSIONS", "active.jsonl");
+      const sessionFile = path.join(
+        resolveFixtureStateDir(),
+        "AGENTS",
+        "Main",
+        "SESSIONS",
+        "active.jsonl",
+      );
       expect(sessionPathForFile(sessionFile)).toBe("sessions/main/active.jsonl");
       expect(parseCanonicalSessionSyncTargetFromPath(sessionFile)).toEqual({
         agentId: "main",
@@ -88,7 +77,7 @@ describe("memory session directory ownership", () => {
     const platform = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     try {
       const sessionFile = path.join(
-        tmpDir,
+        resolveFixtureStateDir(),
         "AGENTS",
         "OPS",
         "SESSIONS",
@@ -105,7 +94,7 @@ describe("memory session directory ownership", () => {
     const platform = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     try {
       const sessionFile = path.join(
-        tmpDir,
+        resolveFixtureStateDir(),
         "agents",
         "main",
         "sessions",
@@ -121,7 +110,16 @@ describe("memory session directory ownership", () => {
 
   it("preserves canonical SQLite session identity on Windows", async () => {
     const platform = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const tempDirs = createTempDirTracker();
+    const tmpDir = tempDirs.make("session-windows-ownership-");
+    const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+    const originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
     try {
+      process.env.OPENCLAW_STATE_DIR = tmpDir;
+      delete process.env.OPENCLAW_CONFIG_PATH;
+      clearRuntimeConfigSnapshot();
+      clearConfigCache();
+
       const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
       const storePath = path.join(sessionsDir, "sessions.json");
       const sessionKey = "agent:main:chat:windows-transcript";
@@ -141,6 +139,23 @@ describe("memory session directory ownership", () => {
       );
     } finally {
       platform.mockRestore();
+      // Agent close releases leases through shared state; close agent handles first while the
+      // fixture env is active, then close shared state before removing the Windows-owned directory.
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+      if (originalStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = originalStateDir;
+      }
+      if (originalConfigPath === undefined) {
+        delete process.env.OPENCLAW_CONFIG_PATH;
+      } else {
+        process.env.OPENCLAW_CONFIG_PATH = originalConfigPath;
+      }
+      clearRuntimeConfigSnapshot();
+      clearConfigCache();
+      tempDirs.cleanup();
     }
   });
 
@@ -149,7 +164,7 @@ describe("memory session directory ownership", () => {
     (owner) => {
       const platform = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
       try {
-        const sessionsDir = path.join(tmpDir, "agents", owner, "sessions");
+        const sessionsDir = path.join(resolveFixtureStateDir(), "agents", owner, "sessions");
         const sessionFile = path.join(sessionsDir, "active.jsonl");
         expect(extractAgentIdFromSessionsDir(sessionsDir)).toBeNull();
         expect(sessionPathForFile(sessionFile)).toBe("sessions/active.jsonl");


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where contributors running the Memory Host session-file suites on Windows would see deterministic test failures and `EPERM` teardown errors because fixture-owned SQLite handles remained open while their temporary state directories were removed. The same suites also relied on case-sensitive path expectations and privileged file-symlink creation that do not match the Windows behavior under test.

## Why This Change Was Made

The fixture now closes cached agent databases before the shared state database while its environment is still authoritative, then restores config and removes its owned directory. Mutable SQLite setup is scoped to the one identity test that needs it; path assertions use the production comparison normalizer; and archive-link coverage uses an unprivileged Windows directory junction while preserving the POSIX file-symlink branch.

This is test-only lifecycle and portability work. It changes no production runtime, SQLite schema, configuration, dependency, protocol, or public API surface.

Production LOC: `+0/-0`. Test LOC: `+88/-53` (net `+35`).

Credit: @steipete for the Windows Auto QA campaign, reproduction, and candidate authorship.

## User Impact

There is no runtime user-visible behavior change. Windows contributors and CI receive reliable Memory Host coverage without leaked database handles, privileged symlink requirements, or platform-invalid path assertions.

## Evidence

- Native Windows baseline on the original candidate base:
  - `session-files.windows-ownership.test.ts`: 6/11 failed, followed by `EPERM` cleanup.
  - `session-files.test.ts`: 3/39 failed from two lowercase-path mismatches and unprivileged file-symlink `EPERM`; teardown also hit `EPERM` from the retained SQLite handle.
- Exact rebased head `d527b6180a62d285bd4daac9f6c72c40d08b558e` on current `main` `e6353d85ef3ac52ed33b1ed454c4c7f9ce88cc73`:
  - `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/session-files.windows-ownership.test.ts packages/memory-host-sdk/src/host/session-files.test.ts packages/memory-host-sdk/src/host/session-files.provenance.test.ts packages/memory-host-sdk/src/host/session-files-yield.test.ts`
  - 4 files passed, 59/59 assertions passed.
  - Targeted `oxfmt --check` and `git diff --check` passed.
- Fresh exact-head structured autoreview:
  - TruffleHog clean.
  - No accepted/actionable P0/P1 findings.
  - `patch is correct`, confidence `0.96`.
- Two earlier independent exact-diff reviews reported no P0/P1 and accepted the fixture owner boundary, close order, canonical path expectation, and Windows junction coverage.
- Local targeted `run-oxlint.mjs` did not reach lint: its unrelated Plugin SDK declaration-artifact preparation remained silent in `tsgo` and was terminated after a 304-second command timeout. The exact owned child tree was removed. Hosted exact-head CI is the authoritative broad static gate for this PR.

