### PR TITLE
fix(context-engine): avoid legacy self-degradation

### DIFF
--- a/src/agents/harness/context-engine-logical-turn.ts
+++ b/src/agents/harness/context-engine-logical-turn.ts
@@ -75,6 +75,9 @@ export async function createContextEngineLogicalTurnLease(params: {
   let degradedReason = resolution.configuredFailure;
   let warned = false;
   const disposalHolds = new Set<Promise<unknown>>();
+  const isBaselineEngineSelection =
+    resolution.configuredFailure === undefined &&
+    resolution.configured.registeredId === resolution.fallback.registeredId;
 
   const asEffective = (): EffectiveContextEngineRef =>
     Object.freeze({
@@ -89,12 +92,22 @@ export async function createContextEngineLogicalTurnLease(params: {
     }
     warned = true;
     (params.warn ?? console.warn)(
-      `[context-engine] Context engine "${sanitizeForLog(resolution.configuredId)}" degraded to "${sanitizeForLog(resolution.fallback.registeredId)}" for this logical turn: ${sanitizeForLog(reason)}`,
+      `[context-engine] Context engine "${sanitizeForLog(resolution.configuredId)}" degraded to "${sanitizeForLog(resolution.fallback.registeredId)}" for this logical turn: ${sanitizeForLog(reason)}. ` +
+        `The "${sanitizeForLog(resolution.fallback.registeredId)}" engine will handle only this turn; configuration is unchanged, and "${sanitizeForLog(resolution.configuredId)}" will be retried next turn.`,
     );
   };
 
   const degradeBeforeStart = (reason: string): EffectiveContextEngineRef => {
-    if (state === "started" || state === "disposed") {
+    if (state === "disposed") {
+      throw new Error("context-engine logical turn selection is already pinned");
+    }
+    if (isBaselineEngineSelection) {
+      if (state === "unselected") {
+        state = "selected";
+      }
+      return asEffective();
+    }
+    if (state === "started") {
       throw new Error("context-engine logical turn selection is already pinned");
     }
     degradedReason ??= reason;
@@ -117,6 +130,11 @@ export async function createContextEngineLogicalTurnLease(params: {
     });
     if (!support.ok) {
       return `host "${selection.host.id}" is missing ${support.missingCapabilities.join(", ")}`;
+    }
+    if (isBaselineEngineSelection) {
+      // Legacy delegates durable transcript ownership to SessionManager, so only its
+      // actual host requirements apply to repeated logical-turn selection.
+      return undefined;
     }
     if (
       selection.hasAdmissionFence &&

--- a/src/agents/harness/context-engine-turn-attempt.test.ts
+++ b/src/agents/harness/context-engine-turn-attempt.test.ts
@@ -16,6 +16,7 @@ import type { ContextEngineLogicalTurnLease } from "./context-engine-logical-tur
 import {
   drainPendingContextEngineTurnsBeforeRun,
   finalizeAcceptedContextEngineTurn,
+  type ContextEngineTurnAttemptFacts,
 } from "./context-engine-turn-attempt.js";
 import { enqueueContextEngineTurnIntent } from "./context-engine-turn-outbox.js";
 
@@ -24,6 +25,87 @@ afterEach(() => {
 });
 
 describe("accepted context-engine turn finalization", () => {
+  it("silently skips engines without durable turn ownership but rejects partial declarations", async () => {
+    const admission = {
+      agentId: "main",
+      sessionId: "accepted-turn",
+      sessionKey: "agent:main:accepted-turn",
+      storePath: "sqlite://accepted-turn",
+      generation: "generation",
+      entryId: "user-entry",
+      rawSeq: 1,
+      effectiveParentId: null,
+      activeMessagePosition: 0,
+      logicalTurnId: "logical-turn",
+      role: "user" as const,
+    };
+    const facts = {
+      boundary: {
+        admission,
+        terminal: {
+          ...admission,
+          entryId: "assistant-entry",
+          rawSeq: 2,
+          activeMessagePosition: 1,
+        },
+      },
+      sessionIdUsed: admission.sessionId,
+      sessionKey: admission.sessionKey,
+      sessionFile: admission.storePath,
+      promptError: false,
+      aborted: false,
+      yieldAborted: false,
+    } satisfies ContextEngineTurnAttemptFacts;
+    const makeLease = (engine: ContextEngine): ContextEngineLogicalTurnLease => ({
+      engine,
+      effectiveEngine: engine,
+      effectiveEngineId: engine.info.id,
+      effectiveEnginePluginId: undefined,
+      degraded: false,
+      degradedReason: undefined,
+      selectForHost: vi.fn(),
+      degradeBeforeStart: vi.fn(),
+      begin: vi.fn(),
+      deferDisposalUntil: () => undefined,
+      dispose: async () => undefined,
+    });
+    const makeEngine = (declaresDurableAdvancement: boolean): ContextEngine => ({
+      info: {
+        id: declaresDurableAdvancement ? "partial" : "legacy",
+        name: declaresDurableAdvancement ? "Partial" : "Legacy",
+        ...(declaresDurableAdvancement
+          ? {
+              transcriptSemantics: {
+                turnAdvancementIdempotency: "atomic-idempotent-v1" as const,
+              },
+            }
+          : {}),
+      },
+      ingest: async () => ({ ingested: false }),
+      assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
+      compact: async () => ({ ok: true, compacted: false }),
+    });
+    const warn = vi.fn();
+
+    await finalizeAcceptedContextEngineTurn({
+      facts,
+      lease: makeLease(makeEngine(false)),
+      warn,
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+
+    await finalizeAcceptedContextEngineTurn({
+      facts,
+      lease: makeLease(makeEngine(true)),
+      warn,
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      "[context-engine] skipped accepted turn advancement: accepted context engine does not support durable turn advancement",
+    );
+  });
+
   it("advances only the admitted durable range and rejects stale admission facts", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-context-turn-attempt-"));
     const target = {

--- a/src/agents/harness/context-engine-turn-attempt.ts
+++ b/src/agents/harness/context-engine-turn-attempt.ts
@@ -159,6 +159,15 @@ export async function finalizeAcceptedContextEngineTurn(params: {
   lease: ContextEngineLogicalTurnLease;
   warn?: (message: string) => void;
 }): Promise<void> {
+  const declaresDurableAdvancement =
+    params.lease.engine.info.transcriptSemantics?.turnAdvancementIdempotency ===
+    "atomic-idempotent-v1";
+  const implementsDurableAdvancement = typeof params.lease.engine.commitTurn === "function";
+  // Legacy leaves persistence to SessionManager and owns neither side of this contract.
+  // Partial durable declarations remain invariant failures in the guarded path below.
+  if (!declaresDurableAdvancement && !implementsDurableAdvancement) {
+    return;
+  }
   const warn = params.warn ?? console.warn;
   if (params.facts.promptError || params.facts.aborted || params.facts.yieldAborted) {
     discardContextEngineTurnAttemptIntent({ facts: params.facts, lease: params.lease, warn });
@@ -166,12 +175,7 @@ export async function finalizeAcceptedContextEngineTurn(params: {
   }
   try {
     assertAcceptedTranscriptTarget(params.facts);
-    if (
-      params.lease.degraded ||
-      params.lease.engine.info.transcriptSemantics?.turnAdvancementIdempotency !==
-        "atomic-idempotent-v1" ||
-      typeof params.lease.engine.commitTurn !== "function"
-    ) {
+    if (params.lease.degraded || !declaresDurableAdvancement || !implementsDurableAdvancement) {
       throw new Error("accepted context engine does not support durable turn advancement");
     }
     const admission = params.facts.boundary.admission;

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -23,6 +23,7 @@ import {
   setActivePluginRegistry,
   withPluginRegistrationContext,
 } from "../plugins/runtime.js";
+import type { UserTurnTranscriptAdmissionReceipt } from "../sessions/user-turn-transcript.types.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 // ---------------------------------------------------------------------------
 // We dynamically import the registry so we can get a fresh module per test
@@ -106,6 +107,22 @@ function requireCompactRuntimeParams(callIndex: number): Record<string, unknown>
 /** Build a config object with a contextEngine slot for testing. */
 function configWithSlot(engineId: string): OpenClawConfig {
   return { plugins: { slots: { contextEngine: engineId } } };
+}
+
+function testAdmissionReceipt(): UserTurnTranscriptAdmissionReceipt {
+  return {
+    agentId: "main",
+    sessionId: "session",
+    sessionKey: "agent:main:session",
+    storePath: "sqlite://session",
+    generation: "generation",
+    entryId: "user-entry",
+    rawSeq: 1,
+    effectiveParentId: null,
+    activeMessagePosition: 0,
+    logicalTurnId: "logical-turn",
+    role: "user",
+  };
 }
 
 function makeMockMessage(role: "user" | "assistant" = "user", text = "hello"): AgentMessage {
@@ -708,6 +725,223 @@ describe("Default engine selection", () => {
     expect(engine.info.id).toBe("test-engine");
   });
 
+  it.each([
+    {
+      label: "implicit legacy without an admission receipt",
+      config: undefined,
+      admission: undefined,
+    },
+    {
+      label: "explicit legacy without an admission receipt",
+      config: configWithSlot("legacy"),
+      admission: undefined,
+    },
+    {
+      label: "implicit legacy without declared transcript fencing",
+      config: undefined,
+      admission: testAdmissionReceipt(),
+    },
+  ])("keeps $label configured without a warning", async ({ config, admission }) => {
+    const warn = vi.fn();
+    const lease = await createContextEngineLogicalTurnLease({ config, warn });
+
+    const selected = selectContextEngineForTranscriptHost({
+      lease,
+      host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
+      operation: "agent-run",
+      recorder: { getAdmissionReceipt: () => admission },
+    });
+
+    expect(selected).toMatchObject({ registeredId: "legacy", mode: "configured" });
+    expect(lease.effectiveEngineId).toBe("legacy");
+    expect(lease.degraded).toBe(false);
+    expect(lease.degradedReason).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+    await lease.dispose();
+  });
+
+  it("keeps repeated baseline host selection stable after the turn starts", async () => {
+    const warn = vi.fn();
+    const lease = await createContextEngineLogicalTurnLease({ warn });
+    const selection = {
+      host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
+      operation: "agent-run" as const,
+      requiresDurableCommit: true,
+      hasAdmissionFence: true,
+    };
+
+    const first = lease.selectForHost(selection);
+    lease.begin();
+    const second = lease.selectForHost(selection);
+
+    expect(second).toMatchObject({ registeredId: "legacy", mode: "configured" });
+    expect(second.engine).toBe(first.engine);
+    expect(lease.degraded).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+    await lease.dispose();
+  });
+
+  it("keeps repeated baseline transcript-host selection stable after the turn starts", async () => {
+    const warn = vi.fn();
+    const lease = await createContextEngineLogicalTurnLease({ warn });
+    const selection = {
+      lease,
+      host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
+      operation: "agent-run" as const,
+      recorder: { getAdmissionReceipt: () => undefined },
+    };
+
+    const first = selectContextEngineForTranscriptHost(selection);
+    lease.begin();
+    const second = selectContextEngineForTranscriptHost(selection);
+
+    expect(second).toMatchObject({ registeredId: "legacy", mode: "configured" });
+    expect(second.engine).toBe(first.engine);
+    expect(lease.degraded).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+    await lease.dispose();
+  });
+
+  it("rejects baseline transcript-host selection after disposal", async () => {
+    const lease = await createContextEngineLogicalTurnLease({});
+    await lease.dispose();
+
+    expect(() =>
+      selectContextEngineForTranscriptHost({
+        lease,
+        host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
+        operation: "agent-run",
+        recorder: { getAdmissionReceipt: () => undefined },
+      }),
+    ).toThrow("context-engine logical turn selection is already pinned");
+  });
+
+  it("still rejects an attempted custom-engine transition after the turn starts", async () => {
+    const engineId = uniqueEngineId("logical-turn-late-transition");
+    registerTestContextEngine(engineId, () => ({
+      info: {
+        id: engineId,
+        name: "Late Transition",
+        transcriptSemantics: {
+          currentTurnFence: "before-current-turn-entry-v1",
+          turnAdvancementIdempotency: "atomic-idempotent-v1",
+        },
+      },
+      async ingest() {
+        return { ingested: true };
+      },
+      async assemble({ messages }) {
+        return { messages, estimatedTokens: 0 };
+      },
+      async compact() {
+        return { ok: true, compacted: false };
+      },
+      async commitTurn() {
+        return { status: "committed" };
+      },
+    }));
+    const lease = await createContextEngineLogicalTurnLease({
+      config: configWithSlot(engineId),
+    });
+    lease.begin();
+
+    expect(() => lease.degradeBeforeStart("late transition")).toThrow(
+      "context-engine logical turn selection is already pinned",
+    );
+    await lease.dispose();
+  });
+
+  it("degrades and warns when an invalid configured id resolves to legacy", async () => {
+    const engineId = uniqueEngineId("logical-turn-invalid");
+    const warn = vi.fn();
+
+    const lease = await createContextEngineLogicalTurnLease({
+      config: configWithSlot(engineId),
+      warn,
+    });
+
+    expect(lease.effectiveEngineId).toBe("legacy");
+    expect(lease.degraded).toBe(true);
+    expect(lease.degradedReason).toBe(`context engine "${engineId}" is not registered`);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(`Context engine "${engineId}" degraded to "legacy"`),
+    );
+    await lease.dispose();
+  });
+
+  it("degrades and warns when configured engine discovery is read-only", async () => {
+    const engineId = uniqueEngineId("logical-turn-discovery");
+    registerContextEngineForOwner(engineId, () => new MockContextEngine(), `test:${engineId}`, {
+      lifecycle: "readOnlyDiscovery",
+    });
+    const warn = vi.fn();
+
+    const lease = await createContextEngineLogicalTurnLease({
+      config: configWithSlot(engineId),
+      warn,
+    });
+
+    expect(lease.effectiveEngineId).toBe("legacy");
+    expect(lease.degradedReason).toBe(
+      `context engine "${engineId}" is available for discovery only`,
+    );
+    expect(warn).toHaveBeenCalledOnce();
+    await lease.dispose();
+  });
+
+  it("degrades and warns when the configured engine factory fails", async () => {
+    const engineId = uniqueEngineId("logical-turn-factory");
+    registerTestContextEngine(engineId, () => {
+      throw new Error("factory unavailable");
+    });
+    const warn = vi.fn();
+
+    const lease = await createContextEngineLogicalTurnLease({
+      config: configWithSlot(engineId),
+      warn,
+    });
+
+    expect(lease.effectiveEngineId).toBe("legacy");
+    expect(lease.degradedReason).toBe("factory unavailable");
+    expect(warn).toHaveBeenCalledOnce();
+    await lease.dispose();
+  });
+
+  it("uses registered identity when custom engine metadata is also legacy", async () => {
+    const engineId = uniqueEngineId("logical-turn-legacy-alias");
+    registerTestContextEngine(engineId, () => ({
+      info: { id: "legacy", name: "Legacy Alias" },
+      async ingest() {
+        return { ingested: true };
+      },
+      async assemble({ messages }) {
+        return { messages, estimatedTokens: 0 };
+      },
+      async compact() {
+        return { ok: true, compacted: false };
+      },
+    }));
+    const warn = vi.fn();
+    const lease = await createContextEngineLogicalTurnLease({
+      config: configWithSlot(engineId),
+      warn,
+    });
+
+    const selected = selectContextEngineForTranscriptHost({
+      lease,
+      host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
+      operation: "agent-run",
+      recorder: { getAdmissionReceipt: testAdmissionReceipt },
+    });
+
+    expect(selected).toMatchObject({ registeredId: "legacy", mode: "legacy-degraded" });
+    expect(lease.degradedReason).toBe("current-turn transcript fencing is not declared");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(`Context engine "${engineId}" degraded to "legacy"`),
+    );
+    await lease.dispose();
+  });
+
   it("does not replay a started engine operation and retries the configured engine next turn", async () => {
     const engineId = uniqueEngineId("logical-turn-retry");
     const assemble = vi
@@ -855,7 +1089,9 @@ describe("Default engine selection", () => {
 
     expect(selected.engine.info.id).toBe("legacy");
     expect(lease.degradedReason).toBe("current-turn transcript admission receipt is unavailable");
-    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      `[context-engine] Context engine "${engineId}" degraded to "legacy" for this logical turn: current-turn transcript admission receipt is unavailable. The "legacy" engine will handle only this turn; configuration is unchanged, and "${engineId}" will be retried next turn.`,
+    );
     await lease.dispose();
   });
 });


### PR DESCRIPTION
Refs #119311

Follow-up TUI report: https://github.com/openclaw/openclaw/issues/119311#issuecomment-5227355995

Reported by @Sedrak-Hovhannisyan. AI-assisted: yes (Codex).

## What Problem This Solves

Fixes an issue where ordinary prompts using the default legacy context engine could show `legacy` degrading to `legacy` on every affected TUI turn. The warning falsely implied a context or memory failure even though the effective engine did not change.

## Why This Change Was Made

The logical-turn lease applied plugin durability and fencing gates to the baseline legacy engine, then selected its same registered fallback. This violated the degradation invariant: a degraded selection must change the effective engine or represent a failed configured selection.

The fix lives at the two owning boundaries:

- `src/agents/harness/context-engine-logical-turn.ts` recognizes a clean same-registered-ID selection as the baseline engine, applies only its real host requirements, and preserves genuine invalid/custom-engine fallback.
- `src/agents/harness/context-engine-turn-attempt.ts` leaves persistence to SessionManager only when an engine declares neither side of the durable-advancement contract; partial declarations remain invariant failures.

Genuine fallback warnings now explain that only the current turn uses the fallback, configuration is unchanged, and the configured engine will be retried next turn. The TUI is not filtering or hiding the warning; the producer now reports the real state.

Best-fix verdict: this repairs selection and finalization at their canonical owners rather than adding a TUI-only filter, warning dedupe, or display-name workaround. Provenance: the durable-selection checks in #119325 (squash [`5621979a`](https://github.com/openclaw/openclaw/commit/5621979a469a28db8c618b42b2a5be1af403803d)) made the default legacy path enter the plugin-degradation flow.

Production LOC: +30/-8 (net +22) | Tests: +319/-1. The production growth makes the baseline-vs-fallback ownership invariant explicit and makes real fallback diagnostics actionable; there is no config, SDK, or TUI surface change.

## User Impact

Ordinary TUI prompts using the default legacy engine no longer show a false `legacy` to `legacy` degradation. Real custom-engine fallback remains visible and now states its per-turn impact and automatic retry behavior.

Release note: prevent misleading legacy-to-legacy context-engine degradation warnings during normal prompts, while improving guidance for genuine fallback.

## Evidence

- Exact local full-screen PTY matrix on capture base `0f43212fb4a1eaa3284e284877663134541c6875`: 5/5 replies and 5/5 false degradation warnings. The same matrix on capture head `45b5300735d63b1f3a27b539818cb28d0933436b`: 5/5 replies, 0 degradation warnings, and 0 skipped-advancement warnings. Published head `04798a62a0113646b74640d77ee57242ed14a1bd` is patch- and changed-blob-identical after audited unrelated rebases.
- The published head is a clean rebase onto current `main`; its patch SHA-256 (`2d2118418a24e83a8c5d693729c964e2bfa3e195891e3388415de201f2b4cb3c`) and all four changed blobs are byte-identical to the verified head.
- Focused Vitest: 65/65 tests passed across logical-turn selection, turn-attempt finalization, and context-engine contract coverage.
- Source-blind behavior validation: all contract clauses passed.
- Autoreview: clean with `gpt-5.6-sol`; no findings.
- Trusted Testbox: `pnpm check:changed` passed, lease `tbx_01kzhmgbd54xr2xzsk4kb4d6j2`; [Actions run 31279442810](https://github.com/openclaw/openclaw/actions/runs/31279442810).
- Direct AWS Crabbox product runs were infrastructure-blocked before product evidence was produced: [`run_323a5e843cff`](https://crabbox.openclaw.ai/portal/runs/run_323a5e843cff) and [`run_383dc40bdf2e`](https://crabbox.openclaw.ai/portal/runs/run_383dc40bdf2e). These are not counted as product proof.
- [Sanitized before/after PTY proof with both uploaded MP4s](https://github.com/openclaw/openclaw/pull/120722#issuecomment-5228330983).
