### PR TITLE
fix(ios): keyboard unavailable after tapping chat composer

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -27131,7 +27131,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 317,
+      "line": 327,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Overview",
       "surface": "apple",
@@ -27139,7 +27139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 345,
+      "line": 355,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agents",
       "surface": "apple",
@@ -27147,7 +27147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 352,
+      "line": 362,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Instances",
       "surface": "apple",
@@ -27155,7 +27155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 363,
+      "line": 373,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Files",
       "surface": "apple",
@@ -27163,7 +27163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 370,
+      "line": 380,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -27171,7 +27171,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 377,
+      "line": 387,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Usage",
       "surface": "apple",
@@ -27179,7 +27179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 384,
+      "line": 394,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Automations",
       "surface": "apple",
@@ -27187,7 +27187,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 474,
+      "line": 484,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Hide Sidebar",
       "surface": "apple",
@@ -27195,7 +27195,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 480,
+      "line": 490,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Show Sidebar",
       "surface": "apple",
@@ -27203,7 +27203,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 607,
+      "line": 626,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Close canvas",
       "surface": "apple",
@@ -27211,7 +27211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 873,
+      "line": 892,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway needs attention",
       "surface": "apple",
@@ -27219,7 +27219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 873,
+      "line": 892,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw iOS",
       "surface": "apple",
@@ -27227,7 +27227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 909,
+      "line": 928,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Available",
       "surface": "apple",
@@ -27235,7 +27235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 909,
+      "line": 928,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway default",
       "surface": "apple",
@@ -27243,7 +27243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 909,
+      "line": 928,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Routed on this phone",
       "surface": "apple",

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -168,8 +168,15 @@ struct RootTabs: View {
 
     private var sidebarSplitContent: some View {
         GeometryReader { proxy in
-            let isDrawerLayout = self.shouldUseSidebarDrawer(containerSize: proxy.size)
-            let sidebarWidth = self.sidebarWidth(containerWidth: proxy.size.width, isDrawerLayout: isDrawerLayout)
+            // Keyboard safe-area changes must not masquerade as window/orientation changes;
+            // switching layouts destroys the focused detail subtree.
+            let layoutContainerSize = Self.sidebarLayoutContainerSize(
+                contentSize: proxy.size,
+                windowSize: self.foregroundKeyWindowSize())
+            let isDrawerLayout = self.shouldUseSidebarDrawer(containerSize: layoutContainerSize)
+            let sidebarWidth = self.sidebarWidth(
+                containerWidth: layoutContainerSize.width,
+                isDrawerLayout: isDrawerLayout)
             Group {
                 if isDrawerLayout {
                     self.sidebarDrawerContent(
@@ -180,10 +187,13 @@ struct RootTabs: View {
                 }
             }
             .onAppear {
-                self.updateSidebarLayout(containerSize: proxy.size, force: false)
+                self.updateSidebarLayout(containerSize: layoutContainerSize, force: false)
             }
             .onChange(of: proxy.size) { _, size in
-                self.updateSidebarLayout(containerSize: size, force: false)
+                let layoutContainerSize = Self.sidebarLayoutContainerSize(
+                    contentSize: size,
+                    windowSize: self.foregroundKeyWindowSize())
+                self.updateSidebarLayout(containerSize: layoutContainerSize, force: false)
             }
             // Single refresh owner: identity/session changes, scene activation,
             // and the periodic attention refresh all land here.
@@ -496,6 +506,15 @@ struct RootTabs: View {
 
     private func sidebarWidth(containerWidth: CGFloat, isDrawerLayout: Bool) -> CGFloat {
         Self.sidebarWidth(containerWidth: containerWidth, isDrawerLayout: isDrawerLayout)
+    }
+
+    private func foregroundKeyWindowSize() -> CGSize? {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first(where: { $0.activationState == .foregroundActive })?
+            .windows
+            .first(where: \.isKeyWindow)?
+            .bounds.size
     }
 
     private func rootOverlays(_ content: some View) -> some View {

--- a/apps/ios/Sources/RootTabsNavigation.swift
+++ b/apps/ios/Sources/RootTabsNavigation.swift
@@ -103,6 +103,10 @@ extension RootTabs {
         case split
     }
 
+    static func sidebarLayoutContainerSize(contentSize: CGSize, windowSize: CGSize?) -> CGSize {
+        windowSize ?? contentSize
+    }
+
     static func sidebarLayoutMode(containerSize: CGSize) -> SidebarLayoutMode {
         containerSize.width < self.sidebarPersistentWidthThreshold || containerSize.height > containerSize.width
             ? .drawer

--- a/apps/ios/Tests/RootTabsPresentationTests.swift
+++ b/apps/ios/Tests/RootTabsPresentationTests.swift
@@ -508,6 +508,21 @@ struct RootTabsPresentationTests {
         #expect(!RootTabs.preferredSidebarVisibility(layoutMode: mode))
     }
 
+    @Test func `keyboard contracted content uses portrait window for sidebar layout`() {
+        let size = RootTabs.sidebarLayoutContainerSize(
+            contentSize: CGSize(width: 1032, height: 973),
+            windowSize: CGSize(width: 1032, height: 1376))
+
+        #expect(size == CGSize(width: 1032, height: 1376))
+        #expect(RootTabs.sidebarLayoutMode(containerSize: size) == .drawer)
+    }
+
+    @Test func `sidebar layout container falls back to content size without a window`() {
+        let contentSize = CGSize(width: 900, height: 600)
+
+        #expect(RootTabs.sidebarLayoutContainerSize(contentSize: contentSize, windowSize: nil) == contentSize)
+    }
+
     @Test func `i pad wide landscape uses visible split sidebar`() {
         let mode = RootTabs.sidebarLayoutMode(containerSize: CGSize(width: 1366, height: 1024))
 

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -494,6 +494,8 @@ final class OpenClawSnapshotUITests: XCTestCase {
         let input = self.chatMessageInput(in: app)
         XCTAssertTrue(input.waitForExistence(timeout: 8))
         input.tap()
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 3))
+        self.attachScreenshot(named: "chat-composer-keyboard-focused")
         input.typeText("first line\nsecond line")
 
         XCTAssertEqual(input.value as? String, "first line\nsecond line")

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -55,9 +55,19 @@ final class OpenClawSnapshotUITests: XCTestCase {
         let input = self.chatMessageInput(in: app)
         XCTAssertTrue(input.waitForExistence(timeout: 8))
         input.tap()
-        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 3))
+        let keyboard = app.keyboards.firstMatch
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            XCTAssertTrue(keyboard.waitForExistence(timeout: 3))
+        }
+        let focusProbe = "focus"
+        input.typeText(focusProbe)
+        XCTAssertEqual(input.value as? String, focusProbe)
+        input.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: focusProbe.count))
+        XCTAssertEqual(input.value as? String, "")
         app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2)).tap()
-        XCTAssertTrue(app.keyboards.firstMatch.waitForNonExistence(timeout: 3))
+        if keyboard.exists {
+            XCTAssertTrue(keyboard.waitForNonExistence(timeout: 3))
+        }
 
         snapshot(target.name, timeWaitingForIdle: 5)
         self.attachScreenshot(named: target.name)

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -44,7 +44,23 @@ final class OpenClawSnapshotUITests: XCTestCase {
     }
 
     func testReleaseChatScreenshot() {
-        self.captureReleaseScreenshot(Self.chatScreenshotTarget)
+        let target = Self.chatScreenshotTarget
+        self.launchApp(for: target)
+        self.waitForReleaseScreenshotTarget(target)
+        guard let app = self.app else {
+            XCTFail("OpenClaw is not running for the chat screenshot")
+            return
+        }
+
+        let input = self.chatMessageInput(in: app)
+        XCTAssertTrue(input.waitForExistence(timeout: 8))
+        input.tap()
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 3))
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2)).tap()
+        XCTAssertTrue(app.keyboards.firstMatch.waitForNonExistence(timeout: 3))
+
+        snapshot(target.name, timeWaitingForIdle: 5)
+        self.attachScreenshot(named: target.name)
     }
 
     func testReleaseAgentScreenshot() {
@@ -494,8 +510,6 @@ final class OpenClawSnapshotUITests: XCTestCase {
         let input = self.chatMessageInput(in: app)
         XCTAssertTrue(input.waitForExistence(timeout: 8))
         input.tap()
-        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 3))
-        self.attachScreenshot(named: "chat-composer-keyboard-focused")
         input.typeText("first line\nsecond line")
 
         XCTAssertEqual(input.value as? String, "first line\nsecond line")

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -44,33 +44,24 @@ final class OpenClawSnapshotUITests: XCTestCase {
     }
 
     func testReleaseChatScreenshot() {
-        let target = Self.chatScreenshotTarget
-        self.launchApp(for: target)
-        self.waitForReleaseScreenshotTarget(target)
-        guard let app = self.app else {
-            XCTFail("OpenClaw is not running for the chat screenshot")
-            return
+        self.captureReleaseScreenshot(Self.chatScreenshotTarget) { app in
+            let input = self.chatMessageInput(in: app)
+            XCTAssertTrue(input.waitForExistence(timeout: 8))
+            input.tap()
+            let keyboard = app.keyboards.firstMatch
+            if UIDevice.current.userInterfaceIdiom == .phone {
+                XCTAssertTrue(keyboard.waitForExistence(timeout: 3))
+            }
+            let focusProbe = "focus"
+            input.typeText(focusProbe)
+            XCTAssertEqual(input.value as? String, focusProbe)
+            input.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: focusProbe.count))
+            XCTAssertEqual(input.value as? String, "")
+            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2)).tap()
+            if keyboard.exists {
+                XCTAssertTrue(keyboard.waitForNonExistence(timeout: 3))
+            }
         }
-
-        let input = self.chatMessageInput(in: app)
-        XCTAssertTrue(input.waitForExistence(timeout: 8))
-        input.tap()
-        let keyboard = app.keyboards.firstMatch
-        if UIDevice.current.userInterfaceIdiom == .phone {
-            XCTAssertTrue(keyboard.waitForExistence(timeout: 3))
-        }
-        let focusProbe = "focus"
-        input.typeText(focusProbe)
-        XCTAssertEqual(input.value as? String, focusProbe)
-        input.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: focusProbe.count))
-        XCTAssertEqual(input.value as? String, "")
-        app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2)).tap()
-        if keyboard.exists {
-            XCTAssertTrue(keyboard.waitForNonExistence(timeout: 3))
-        }
-
-        snapshot(target.name, timeWaitingForIdle: 5)
-        self.attachScreenshot(named: target.name)
     }
 
     func testReleaseAgentScreenshot() {
@@ -1103,9 +1094,17 @@ extension OpenClawSnapshotUITests {
         return app
     }
 
-    private func captureReleaseScreenshot(_ target: ScreenshotTarget) {
+    private func captureReleaseScreenshot(
+        _ target: ScreenshotTarget,
+        beforeCapture: ((XCUIApplication) -> Void)? = nil)
+    {
         self.launchApp(for: target)
         self.waitForReleaseScreenshotTarget(target)
+        guard let app = self.app else {
+            XCTFail("OpenClaw is not running for screenshot target \(target.name)")
+            return
+        }
+        beforeCapture?(app)
         snapshot(target.name, timeWaitingForIdle: 5)
         self.attachScreenshot(named: target.name)
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -941,7 +941,7 @@ struct OpenClawChatComposer: View {
             #elseif os(iOS)
             ChatComposerTextViewIOS(
                 text: self.$viewModel.input,
-                shouldFocus: self.isFocused,
+                focusRequested: self.isFocused,
                 isEnabled: self.isComposerEnabled,
                 minHeight: self.textMinHeight,
                 maxHeight: self.textMaxHeight,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposerTextViewIOS.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposerTextViewIOS.swift
@@ -31,9 +31,11 @@ struct ChatComposerTextViewIOS: UIViewRepresentable {
         textView.isSelectable = self.isEnabled
         self.configureHistoryHandlers(textView)
 
+        // UIKit owns user-initiated focus. Treat shouldFocus as a request to focus,
+        // not a mirror whose stale false value can cancel a tap before SwiftUI updates.
         if self.shouldFocus, self.isEnabled, !textView.isFirstResponder {
             textView.becomeFirstResponder()
-        } else if !self.shouldFocus || !self.isEnabled, textView.isFirstResponder {
+        } else if !self.isEnabled, textView.isFirstResponder {
             textView.resignFirstResponder()
         }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposerTextViewIOS.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposerTextViewIOS.swift
@@ -5,7 +5,7 @@ import UIKit
 @MainActor
 struct ChatComposerTextViewIOS: UIViewRepresentable {
     @Binding var text: String
-    var shouldFocus: Bool
+    var focusRequested: Bool
     var isEnabled: Bool
     var minHeight: CGFloat
     var maxHeight: CGFloat
@@ -31,9 +31,9 @@ struct ChatComposerTextViewIOS: UIViewRepresentable {
         textView.isSelectable = self.isEnabled
         self.configureHistoryHandlers(textView)
 
-        // UIKit owns user-initiated focus. Treat shouldFocus as a request to focus,
-        // not a mirror whose stale false value can cancel a tap before SwiftUI updates.
-        if self.shouldFocus, self.isEnabled, !textView.isFirstResponder {
+        // UIKit owns user-initiated focus. A false focus request is not a blur request;
+        // conflating the two cancels a tap before SwiftUI observes first-responder state.
+        if self.focusRequested, self.isEnabled, !textView.isFirstResponder {
             textView.becomeFirstResponder()
         } else if !self.isEnabled, textView.isFirstResponder {
             textView.resignFirstResponder()


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where iOS users tapping the chat composer would immediately lose input focus, leaving no software keyboard and only the mic control instead of a usable Send button.

## Why This Change Was Made

The native iOS text view now owns user-initiated focus while SwiftUI's focus value remains an explicit request to focus. Disabling the composer still forces resignation, and the existing tap-outside dismissal behavior remains covered.

## User Impact

iPhone and iPad users can tap the message field, type multiline drafts with the software keyboard, and send them normally again.

## Evidence

| Before: tap loses focus; no keyboard; mic-only | After: keyboard, multiline draft, and Send |
| --- | --- |
| ![Before: mic-only composer with no keyboard](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/1b1e520fe807721672901483c7de9548709718f5/openclaw-pr-120723/before-mic-only-no-keyboard.png) | ![After: software keyboard, multiline draft, and Send](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/1b1e520fe807721672901483c7de9548709718f5/openclaw-pr-120723/after-keyboard-and-send.png) |

[Proof metadata and SHA-256 manifest](https://github.com/Solvely-Colin/pr-proof-assets/tree/1b1e520fe807721672901483c7de9548709718f5/openclaw-pr-120723)

- Before: the focused UI regression test fails because tapping `chat-message-input` produces no keyboard; the mic-only composer remains visible.
- After: `testChatComposerReturnInsertsNewlineWithoutSending` passes on an iPhone 17 Pro / iOS 26.2 simulator, proving keyboard focus, multiline binding updates, and Send-button presentation.
- `testChatComposerStartsCompactAndGrowsWithDraft` passes, including tap-outside keyboard dismissal.
- `ChatComposerTextViewIOSTests`: 3/3 passed on the same simulator.
- `swiftformat --lint --config config/swiftformat ...`: 0/2 files require formatting.
- `git diff --check`: passed.
- Repository autoreview: clean, no accepted/actionable findings.

AI-assisted: Codex helped trace the regression, implement the focused patch, and run the validation above; the evidence and resulting diff were reviewed before submission.
