### PR TITLE
fix(tui): surface process terminal failures

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.process-errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.process-errors.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { ProcessTerminalDiagnostic, ToolErrorSummary } from "../../tool-error-summary.js";
+import { buildPayloads, expectSingleToolErrorPayload } from "./payloads.test-helpers.js";
+
+describe("buildEmbeddedRunPayloads process-error warnings", () => {
+  it("surfaces safe terminal diagnostics when verbose mode is off", () => {
+    const dummyTelegramToken = `123456:${"A".repeat(28)}WXYZ`;
+    const lastToolError: ToolErrorSummary = {
+      toolName: "process",
+      error: `SAFE_PROCESS_STDERR ${dummyTelegramToken}`,
+      terminalDiagnostic: {
+        kind: "process",
+        sessionId: "wild-lagoon",
+        reason: { kind: "exit", exitCode: 7 },
+      },
+    };
+    const payloads = buildPayloads({ lastToolError, verboseLevel: "off" });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "Process: wild-lagoon",
+      absentDetail: "SAFE_PROCESS_STDERR",
+    });
+    expect(payloads[0]?.text).not.toContain(dummyTelegramToken);
+    expect(payloads[0]?.text).toContain("exit 7");
+    expect(payloads[0]?.text).toContain("/verbose full");
+  });
+
+  it("shows a sanitized bounded error only at full verbosity", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "process",
+        error: "SAFE_PROCESS_STDERR",
+        terminalDiagnostic: {
+          kind: "process",
+          sessionId: "wild-lagoon",
+          reason: { kind: "exit", exitCode: 7 },
+        },
+      },
+      verboseLevel: "full",
+    });
+
+    expect(payloads[0]?.text).toContain("SAFE_PROCESS_STDERR");
+    expect(payloads[0]?.text).not.toContain("/verbose full");
+  });
+
+  it.each([
+    {
+      label: "signal",
+      reason: { kind: "signal", signal: "SIGKILL" } as const,
+      expected: "signal SIGKILL",
+    },
+    {
+      label: "overall timeout",
+      reason: { kind: "timeout", timeoutKind: "overall-timeout" } as const,
+      expected: "timed out",
+    },
+    {
+      label: "no-output timeout",
+      reason: { kind: "timeout", timeoutKind: "no-output-timeout" } as const,
+      expected: "timed out waiting for output",
+    },
+  ])("renders $label without fabricating an exit code", ({ reason, expected }) => {
+    const terminalDiagnostic: ProcessTerminalDiagnostic = {
+      kind: "process",
+      sessionId: "wild-lagoon",
+      reason,
+    };
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "process", terminalDiagnostic },
+      verboseLevel: "off",
+    });
+
+    expect(payloads[0]?.text).toContain(expected);
+    expect(payloads[0]?.text).not.toMatch(/exit -?\d+/u);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -185,6 +185,25 @@ function formatToolErrorWarningText(params: {
   includeDetails: boolean;
   useMarkdown: boolean;
 }): string {
+  const terminalDiagnostic = params.lastToolError.terminalDiagnostic;
+  if (terminalDiagnostic?.kind === "process") {
+    const toolLabel = formatToolAggregate("process", [terminalDiagnostic.sessionId], {
+      markdown: params.useMarkdown,
+    });
+    const reason =
+      terminalDiagnostic.reason.kind === "exit"
+        ? `exit ${terminalDiagnostic.reason.exitCode}`
+        : terminalDiagnostic.reason.kind === "signal"
+          ? `signal ${terminalDiagnostic.reason.signal}`
+          : terminalDiagnostic.reason.timeoutKind === "no-output-timeout"
+            ? "timed out waiting for output"
+            : "timed out";
+    const errorSuffix =
+      params.includeDetails && params.lastToolError.error ? `: ${params.lastToolError.error}` : "";
+    const recoveryHint = params.includeDetails ? "" : ". Use /verbose full for complete output";
+    return `⚠️ ${toolLabel} failed (${reason})${errorSuffix}${recoveryHint}.`;
+  }
+
   if (isExecLikeToolName(params.lastToolError.toolName)) {
     const toolLabel = formatToolAggregate(params.lastToolError.toolName, undefined, {
       markdown: params.useMarkdown,
@@ -475,6 +494,9 @@ function resolveToolErrorWarningPolicy(params: {
   if (isExecLikeToolName(params.lastToolError.toolName)) {
     // No recoverable-keyword suppression here: with no reply at all, the exec
     // warning may be the run's only failure signal.
+    return { showWarning: !params.hasUserFacingReply, includeDetails };
+  }
+  if (params.lastToolError.terminalDiagnostic?.kind === "process") {
     return { showWarning: !params.hasUserFacingReply, includeDetails };
   }
   const isMutatingToolError =

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -2075,6 +2075,177 @@ describe("handleToolExecutionEnd timeout metadata", () => {
     ]);
   });
 
+  async function executeProcessResult(
+    ctx: ToolHandlerContext,
+    params: {
+      action?: string;
+      details?: Record<string, unknown>;
+      isError?: boolean;
+      output?: string;
+    } = {},
+  ) {
+    const action = params.action ?? "poll";
+    const output = params.output ?? "SAFE_PROCESS_STDERR";
+    await executeTool(ctx, {
+      toolName: "process",
+      toolCallId: `tool-process-${action}`,
+      args: { action, sessionId: "wild-lagoon" },
+      isError: params.isError ?? true,
+      result: {
+        content: [{ type: "text", text: output }],
+        details: {
+          status: "completed",
+          sessionId: "wild-lagoon",
+          exitReason: "exit",
+          aggregated: output,
+          ...params.details,
+        },
+      },
+    });
+  }
+
+  it.each(["poll", "log"])(
+    "projects a structured terminal process diagnostic from %s",
+    async (action) => {
+      const { ctx } = createTestContext();
+      await executeProcessResult(ctx, { action, details: { exitCode: 7 } });
+
+      expect(ctx.state.lastToolError).toMatchObject({
+        toolName: "process",
+        terminalDiagnostic: {
+          kind: "process",
+          sessionId: "wild-lagoon",
+          reason: { kind: "exit", exitCode: 7 },
+        },
+      });
+    },
+  );
+
+  it.each([
+    {
+      label: "signal",
+      details: { exitCode: 0, exitSignal: "SIGKILL", exitReason: "signal" },
+      reason: { kind: "signal", signal: "SIGKILL" },
+    },
+    {
+      label: "overall timeout",
+      details: {
+        exitCode: 0,
+        exitSignal: "SIGTERM",
+        exitReason: "overall-timeout",
+        timedOut: true,
+      },
+      reason: { kind: "timeout", timeoutKind: "overall-timeout" },
+    },
+    {
+      label: "no-output timeout",
+      details: {
+        exitCode: 0,
+        exitSignal: "SIGTERM",
+        exitReason: "no-output-timeout",
+        timedOut: true,
+      },
+      reason: { kind: "timeout", timeoutKind: "no-output-timeout" },
+    },
+  ])(
+    "preserves a typed process $label without fabricating exit status",
+    async ({ details, reason }) => {
+      const { ctx } = createTestContext();
+      await executeProcessResult(ctx, { details });
+
+      expect(ctx.state.lastToolError?.terminalDiagnostic).toMatchObject({ reason });
+      expect(ctx.state.lastToolError?.terminalDiagnostic?.reason).not.toHaveProperty("exitCode");
+    },
+  );
+
+  it("keeps child output out of the terminal diagnostic while retaining a safe full-verbosity error", async () => {
+    const { ctx } = createTestContext();
+    const dummyTelegramToken = `123456:${"A".repeat(28)}WXYZ`;
+    await executeProcessResult(ctx, {
+      output: `${dummyTelegramToken} ${"x".repeat(500)}`,
+      details: { exitCode: 7 },
+    });
+
+    const diagnostic = ctx.state.lastToolError?.terminalDiagnostic;
+    expect(diagnostic).toEqual({
+      kind: "process",
+      sessionId: "wild-lagoon",
+      reason: { kind: "exit", exitCode: 7 },
+    });
+    expect(ctx.state.lastToolError?.error?.length).toBeLessThanOrEqual(401);
+    expect(ctx.state.lastToolError?.error).toMatch(/…$/u);
+    expect(JSON.stringify(ctx.state.lastToolError)).not.toContain(dummyTelegramToken);
+  });
+
+  it("omits full-verbosity process output containing terminal control characters", async () => {
+    const { ctx } = createTestContext();
+    await executeProcessResult(ctx, {
+      output: "SAFE\u001b[31m_PROCESS_STDERR",
+      details: { exitCode: 7 },
+    });
+
+    expect(ctx.state.lastToolError?.terminalDiagnostic).toEqual({
+      kind: "process",
+      sessionId: "wild-lagoon",
+      reason: { kind: "exit", exitCode: 7 },
+    });
+    expect(ctx.state.lastToolError?.error).toBeUndefined();
+  });
+
+  it.each([
+    {
+      label: "running poll",
+      isError: false,
+      details: { status: "running", exitReason: undefined, exitCode: undefined },
+    },
+    {
+      label: "failed process operation",
+      details: { status: "failed", exitReason: undefined, exitCode: undefined },
+    },
+    {
+      label: "missing session",
+      details: { status: "failed", sessionId: undefined, exitReason: undefined, exitCode: 7 },
+    },
+    {
+      label: "successful poll",
+      isError: false,
+      details: { exitCode: 0 },
+    },
+    {
+      label: "log without terminal provenance",
+      action: "log",
+      details: { exitReason: undefined, exitCode: 7, exitSignal: "SIGKILL" },
+    },
+    {
+      label: "non-observing process action",
+      action: "write",
+      details: { status: "failed", sessionId: "wild-lagoon", exitCode: 7 },
+    },
+    {
+      label: "kill result",
+      action: "kill",
+      details: {
+        status: "failed",
+        sessionId: undefined,
+        exitReason: undefined,
+        name: "node command.js",
+      },
+    },
+  ])(
+    "does not project a terminal diagnostic for a $label",
+    async ({ label, action, details, isError }) => {
+      const { ctx } = createTestContext();
+      await executeProcessResult(ctx, {
+        action,
+        details,
+        isError,
+        output: `No terminal process result for ${label}.`,
+      });
+
+      expect(ctx.state.lastToolError?.terminalDiagnostic).toBeUndefined();
+    },
+  );
+
   it("projects outcome-unknown exec results as errors with typed details", async () => {
     resetAgentEventsForTest();
     const events: Array<{ stream?: string; data?: Record<string, unknown> }> = [];

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -95,6 +95,7 @@ import type { AgentEvent } from "./runtime/index.js";
 import {
   createToolValidationErrorSummary,
   summarizeToolValidationError,
+  type ProcessTerminalDiagnostic,
 } from "./tool-error-summary.js";
 import { buildToolMutationState } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
@@ -191,6 +192,90 @@ function isMiddlewareToolResultError(result: unknown): boolean {
     !Array.isArray(details) &&
     (details as { middlewareError?: unknown }).middlewareError === true,
   );
+}
+
+function hasTerminalControlCharacter(value: string): boolean {
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const PROCESS_TERMINATION_REASONS = new Set([
+  "manual-cancel",
+  "overall-timeout",
+  "no-output-timeout",
+  "spawn-error",
+  "signal",
+  "exit",
+]);
+
+function readSafeProcessSessionId(value: unknown): string | undefined {
+  const sessionId = readStringValue(value)?.trim();
+  if (!sessionId || sessionId.length > 160 || hasTerminalControlCharacter(sessionId)) {
+    return undefined;
+  }
+  return sessionId;
+}
+
+function buildProcessTerminalDiagnostic(
+  toolName: string,
+  args: Record<string, unknown>,
+  sanitizedResult: unknown,
+): ProcessTerminalDiagnostic | undefined {
+  if (toolName !== "process") {
+    return undefined;
+  }
+  const action = normalizeOptionalLowercaseString(args.action);
+  if (action !== "poll" && action !== "log") {
+    return undefined;
+  }
+  const details = readToolResultDetails(sanitizedResult);
+  const sessionId = readSafeProcessSessionId(details?.sessionId);
+  if (!sessionId) {
+    return undefined;
+  }
+
+  const exitReason = normalizeOptionalLowercaseString(details?.exitReason);
+  const hasCanonicalExitReason = PROCESS_TERMINATION_REASONS.has(exitReason ?? "");
+  if (action === "log" && !hasCanonicalExitReason) {
+    return undefined;
+  }
+  const timeoutKind =
+    exitReason === "overall-timeout" || exitReason === "no-output-timeout" ? exitReason : undefined;
+  let reason: ProcessTerminalDiagnostic["reason"] | undefined;
+  if (details?.timedOut === true || timeoutKind) {
+    reason = { kind: "timeout", ...(timeoutKind ? { timeoutKind } : {}) };
+  } else if (
+    (typeof details?.exitSignal === "string" &&
+      details.exitSignal.trim().length > 0 &&
+      details.exitSignal.trim().length <= 32) ||
+    (typeof details?.exitSignal === "number" && Number.isFinite(details.exitSignal))
+  ) {
+    const signal =
+      typeof details.exitSignal === "string" ? details.exitSignal.trim() : details.exitSignal;
+    if (!hasTerminalControlCharacter(String(signal))) {
+      reason = { kind: "signal", signal };
+    }
+  } else if (
+    typeof details?.exitCode === "number" &&
+    Number.isSafeInteger(details.exitCode) &&
+    details.exitCode !== 0
+  ) {
+    reason = { kind: "exit", exitCode: details.exitCode };
+  }
+  if (!reason) {
+    return undefined;
+  }
+
+  return {
+    kind: "process",
+    sessionId,
+    reason,
+  };
 }
 
 function loadExecApprovalReply(): Promise<ExecApprovalReplyModule> {
@@ -1481,6 +1566,13 @@ export async function handleToolExecutionEnd(
   ctx.state.toolSummaryById.delete(toolCallId);
   const errorMessage = isToolError ? extractToolErrorMessage(sanitizedResult) : undefined;
   const errorCode = isToolError ? extractToolErrorCode(sanitizedResult) : undefined;
+  const terminalDiagnostic = isToolError
+    ? buildProcessTerminalDiagnostic(toolName, startArgs, sanitizedResult)
+    : undefined;
+  const terminalErrorMessage =
+    terminalDiagnostic && errorMessage && hasTerminalControlCharacter(errorMessage)
+      ? undefined
+      : errorMessage;
   const validationErrorSummary =
     isToolError && evt.executionStarted === false && evt.errorKind === "argument-validation"
       ? createToolValidationErrorSummary(toolName)
@@ -1496,7 +1588,8 @@ export async function handleToolExecutionEnd(
       ? {
           failure: {
             ...(errorCode ? { errorCode } : {}),
-            ...(errorMessage ? { error: errorMessage } : {}),
+            ...(terminalErrorMessage ? { error: terminalErrorMessage } : {}),
+            ...(terminalDiagnostic ? { terminalDiagnostic } : {}),
             ...(validationErrorSummary ? { validationErrorSummary } : {}),
             timedOut: isToolResultTimedOut(sanitizedResult) || undefined,
             middlewareError: isMiddlewareToolResultError(sanitizedResult) || undefined,

--- a/src/agents/tool-error-summary.ts
+++ b/src/agents/tool-error-summary.ts
@@ -6,6 +6,18 @@
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { FileTarget } from "./tool-mutation.js";
 
+export type ProcessTerminalDiagnostic = {
+  kind: "process";
+  sessionId: string;
+  reason:
+    | { kind: "exit"; exitCode: number }
+    | { kind: "signal"; signal: string | number }
+    | {
+        kind: "timeout";
+        timeoutKind?: "overall-timeout" | "no-output-timeout";
+      };
+};
+
 export type ToolErrorSummary = {
   toolName: string;
   meta?: string;
@@ -17,6 +29,7 @@ export type ToolErrorSummary = {
   mutatingAction?: boolean;
   actionFingerprint?: string;
   fileTarget?: FileTarget;
+  terminalDiagnostic?: ProcessTerminalDiagnostic;
 };
 
 const EXEC_LIKE_TOOL_NAMES = new Set(["exec", "bash"]);


### PR DESCRIPTION
Related #52826

## What Problem This Solves

Fixes an issue where TUI users could receive only an opaque message such as `Process: wild-lagoon failed` after a background process terminated. The message omitted whether the process exited, was signaled, or timed out, and gave no actionable recovery step.

## Why This Change Was Made

The process-result boundary now carries a typed, attempt-local terminal diagnostic into TUI payload construction. Default verbosity reports the bounded process identity plus an exit code, signal, or timeout reason and points users to `/verbose full`; full verbosity continues to use the existing sanitized and bounded error detail.

Arbitrary child output and raw argv, environment, and working-directory values remain hidden by default. The diagnostic is limited to terminal `process poll` and canonical `process log` results, rejects success and non-terminal operations, and does not add a broader persisted event journal.

## User Impact

Operators can distinguish a nonzero exit, signal termination, and timeout directly in the TUI and know how to request more sanitized detail. Existing redaction and output bounds continue to protect command-line secrets and unbounded child output.

Release note: TUI process failures now include a safe terminal reason and `/verbose full` recovery guidance instead of only an opaque process slug.

## Evidence

- Exact tested head `c2125587`: 399/399 focused tests passed, including process poll/log, exit/signal/timeout, notify-on-exit, embedded backend, and real process E2E coverage.
- Exact detached `pnpm check:changed`: passed for the five changed files (`core`, `coreTests`).
- Source-blind live PTY and history-replay validation: 0.97; default output hid child/token fixtures, while full verbosity showed only sanitized bounded child detail.
- Final autoreview: clean.
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31279336204
- Final PR head `d23ca15f` is patch-identical to the tested head after rebasing over unrelated upstream changes: stable patch ID, binary diff, and all five changed blobs are unchanged.
