### PR TITLE
fix(release): match ClawHub security fixture contract

### DIFF
--- a/scripts/e2e/lib/clawhub-fixture-server.cjs
+++ b/scripts/e2e/lib/clawhub-fixture-server.cjs
@@ -144,7 +144,24 @@ function startPrepublishArtifactServer() {
       json(response, { package: packageRecord, version: versionRecord });
     } else if (match[3] === "security") {
       json(response, {
+        package: {
+          name: entry.name,
+          displayName: entry.name,
+          family: "code-plugin",
+        },
+        release: {
+          releaseId: `fixture:${entry.name}@${entry.version}`,
+          version: entry.version,
+          artifactKind: "npm-pack",
+          artifactSha256: entry.sha256,
+          npmIntegrity: entry.npmIntegrity,
+          npmShasum: entry.npmShasum,
+          npmTarballName: entry.tarball,
+          createdAt: 0,
+        },
         trust: {
+          scanStatus: "clean",
+          moderationState: null,
           blockedFromDownload: false,
           reasons: [],
           pending: false,

--- a/test/scripts/clawhub-fixture-server.test.ts
+++ b/test/scripts/clawhub-fixture-server.test.ts
@@ -5,7 +5,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { Readable } from "node:stream";
 import { setTimeout as delay } from "node:timers/promises";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ensureClawHubPackageTrustAcknowledged } from "../../src/infra/clawhub-install-trust.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const SCRIPT_PATH = path.resolve("scripts/e2e/lib/clawhub-fixture-server.cjs");
@@ -16,6 +17,7 @@ type FixtureServerChild = ChildProcessByStdio<null, Readable, Readable>;
 const servers: FixtureServerChild[] = [];
 
 afterEach(async () => {
+  vi.unstubAllGlobals();
   await Promise.all(servers.splice(0).map(stopServer));
 });
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -163,6 +165,8 @@ describe("ClawHub fixture server", () => {
     execFileSync("tar", ["-czf", tarballPath, "-C", root, "package"]);
     const archive = readFileSync(tarballPath);
     const sha256 = createHash("sha256").update(archive).digest("hex");
+    const npmIntegrity = `sha512-${createHash("sha512").update(archive).digest("base64")}`;
+    const npmShasum = createHash("sha1").update(archive).digest("hex");
     const manifestPath = path.join(root, "prepublish-plugin-registry.json");
     writeFileSync(
       manifestPath,
@@ -188,8 +192,57 @@ describe("ClawHub fixture server", () => {
       artifactKind: "npm-pack",
       artifactSha256: sha256,
     });
-    const security = await fetchJson(baseUrl, `${whatsappPath}/versions/${version}/security`);
-    expect(security.trust).toMatchObject({ blockedFromDownload: false, pending: false });
+    const securityUrl = `${baseUrl}${whatsappPath}/versions/${version}/security`;
+    const fetchImpl = globalThis.fetch;
+    let security: unknown;
+    vi.stubGlobal("fetch", async (input: string | URL | Request, init?: RequestInit) => {
+      const response = await fetchImpl(input, init);
+      const requestUrl =
+        typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (requestUrl === securityUrl) {
+        security = await response.clone().json();
+      }
+      return response;
+    });
+    const trust = await ensureClawHubPackageTrustAcknowledged({
+      subject: { kind: "plugin", packageName: "@openclaw/whatsapp" },
+      version,
+      baseUrl,
+      mode: "update",
+    });
+    expect(security).toEqual({
+      package: {
+        name: "@openclaw/whatsapp",
+        displayName: "@openclaw/whatsapp",
+        family: "code-plugin",
+      },
+      release: {
+        releaseId: `fixture:@openclaw/whatsapp@${version}`,
+        version,
+        artifactKind: "npm-pack",
+        artifactSha256: sha256,
+        npmIntegrity,
+        npmShasum,
+        npmTarballName: tarball,
+        createdAt: 0,
+      },
+      trust: {
+        scanStatus: "clean",
+        moderationState: null,
+        blockedFromDownload: false,
+        reasons: [],
+        pending: false,
+        stale: false,
+      },
+    });
+    expect(trust).toEqual({
+      ok: true,
+      trustInstallRecordFields: {
+        clawhubTrustDisposition: "clean",
+        clawhubTrustScanStatus: "clean",
+        clawhubTrustCheckedAt: expect.any(String),
+      },
+    });
     const download = await fetch(`${baseUrl}${whatsappPath}/versions/${version}/artifact/download`);
     expect(download.headers.get("x-clawhub-artifact-sha256")).toBe(sha256);
     expect(Buffer.from(await download.arrayBuffer())).toEqual(archive);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the authenticated update/restart package-acceptance lane could reject its hermetic ClawHub fixture when the fixture's security endpoint omitted fields required by the live ClawHub package security contract.

## Why This Change Was Made

The prepublish fixture now returns the same package, release, artifact identity, and clean trust shape as ClawHub's `ApiV1PackageSecurityResponse`. Its focused regression test exercises the real OpenClaw trust gate against the live fixture while preserving the unchanged four-request ledger.

The product release Code SHA remains frozen; this changes only the trusted release harness on `main`.

## User Impact

No product runtime behavior changes. Release validation can prove the exact prepublish plugin update path without failing on an incomplete fixture response.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/clawhub-fixture-server.test.ts` (4/4 passed)
- `./node_modules/.bin/oxfmt --check --threads=1 scripts/e2e/lib/clawhub-fixture-server.cjs test/scripts/clawhub-fixture-server.test.ts`
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings
- Production LOC: `+17/-0`; tests: `+56/-3`
- Blacksmith Testbox changed gate: passed (`tbx_01kzhnwmz6959p96p38nrjkr73`, run `31280420286`)

AI-assisted: yes. Maintainer-authored and reviewed.
