### PR TITLE
fix(ai): preserve Responses history after compaction

### DIFF
--- a/packages/ai/src/host.ts
+++ b/packages/ai/src/host.ts
@@ -98,6 +98,7 @@ export type AiTransformTransportMessages = (
   options?: {
     normalizeSameModelToolCallIds?: boolean;
     preserveCrossModelToolCallThoughtSignature?: boolean;
+    preserveUnframedToolResults?: boolean;
   },
 ) => Context["messages"];
 

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -4,6 +4,8 @@ import type { ResponseCreateParamsStreaming } from "openai/resources/responses/r
 import { getEnvApiKey } from "../env-api-keys.js";
 import { getAiTransportHost } from "../host.js";
 import type { BaseOpenAIStreamOptions } from "../provider-options.js";
+import type { OpenAIResponsesReplayMode } from "../transports/openai-responses-compaction-replay.js";
+import type { OpenAIResponsesRequestParams } from "../transports/openai-responses-contracts.js";
 import type { Context, Model, SimpleStreamOptions, StreamFunction } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { resolveAzureDeploymentNameFromMap } from "./azure-deployment-map.js";
@@ -88,8 +90,14 @@ export const streamAzureOpenAIResponses: StreamFunction<
       const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
       return createClient(requestModel, apiKey, options);
     },
-    buildParams: (requestModel) =>
-      buildParams(requestModel, context, options, resolveDeploymentName(model, options)),
+    buildParams: (requestModel, replayMode) =>
+      buildParams(
+        requestModel,
+        context,
+        options,
+        resolveDeploymentName(model, options),
+        replayMode,
+      ),
     formatError: formatAzureOpenAIError,
   });
 
@@ -228,13 +236,15 @@ function buildParams(
   context: Context,
   options: AzureOpenAIResponsesOptions | undefined,
   deploymentName: string,
+  replayMode: OpenAIResponsesReplayMode = "checkpoint",
 ) {
   const messages = convertResponsesMessages(model, context, AZURE_TOOL_CALL_PROVIDERS, {
     sessionId: options?.sessionId,
     authProfileId: options?.authProfileId,
+    replayMode,
   });
 
-  const params: ResponseCreateParamsStreaming = {
+  const params: ResponseCreateParamsStreaming & OpenAIResponsesRequestParams = {
     model: deploymentName,
     input: messages,
     stream: true,

--- a/packages/ai/src/providers/openai-chatgpt-responses.encrypted-retry.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.encrypted-retry.test.ts
@@ -5,8 +5,8 @@ import { responsesPromptObserver, type ResponsesPromptObservation } from "../int
 import {
   buildOpenAIResponsesReasoningReplayMetadata,
   captureOpenAIResponsesCompaction,
-  tagOpenAIResponsesReasoningReplayItem,
-} from "../transports/openai-responses-replay-internal.js";
+} from "../transports/openai-responses-compaction-replay.js";
+import { tagOpenAIResponsesReasoningReplayItem } from "../transports/openai-responses-replay-internal.js";
 import type { AssistantMessage, Context, Model } from "../types.js";
 import {
   closeOpenAICodexWebSocketSessions,
@@ -16,6 +16,7 @@ import {
 
 const REASONING_CIPHERTEXT = "opaque-reasoning-replay";
 const COMPACTION_CIPHERTEXT = "opaque-compaction-replay";
+const FULL_HISTORY_PREFIX = "native full history before compaction";
 const REPLAY_IDENTITY = { sessionId: "retry-session", authProfileId: "retry-profile" };
 
 const model = {
@@ -88,7 +89,11 @@ function createReplayContext(kind: "compaction" | "mixed"): Context {
   );
   return {
     systemPrompt: "PRIVATE-NATIVE-RECOVERY-PROMPT",
-    messages: [prior, { role: "user", content: "continue", timestamp: 2 }],
+    messages: [
+      { role: "user", content: FULL_HISTORY_PREFIX, timestamp: 0 },
+      prior,
+      { role: "user", content: "continue", timestamp: 2 },
+    ],
   };
 }
 
@@ -169,6 +174,13 @@ function containsCiphertext(
 ): boolean {
   const body = requestBody(request);
   return JSON.stringify(body.input).includes(ciphertext);
+}
+
+function containsInputText(
+  request: RecordedRequest | Record<string, unknown>,
+  text: string,
+): boolean {
+  return JSON.stringify(requestBody(request).input).includes(text);
 }
 
 function requestBody(request: RecordedRequest | Record<string, unknown>): Record<string, unknown> {
@@ -302,6 +314,8 @@ describe("ChatGPT Responses encrypted replay recovery", () => {
     expect(requests).toHaveLength(3);
     expect(hasInputType(requireItem(requests, 0), "compaction")).toBe(true);
     expect(hasInputType(requireItem(requests, 1), "compaction")).toBe(false);
+    expect(containsInputText(requireItem(requests, 0), FULL_HISTORY_PREFIX)).toBe(false);
+    expect(containsInputText(requireItem(requests, 1), FULL_HISTORY_PREFIX)).toBe(true);
     expect(hasInputType(requireItem(requests, 2), "compaction")).toBe(false);
     expect(requests.every((request) => request.contentEncoding === "zstd")).toBe(true);
     expect(observations.map((entry) => entry.payloadVariant)).toEqual([
@@ -378,6 +392,8 @@ describe("ChatGPT Responses encrypted replay recovery", () => {
 
     expect(requests).toHaveLength(4);
     expect(hasInputType(requireItem(requests, 2), "compaction")).toBe(false);
+    expect(containsInputText(requireItem(requests, 2), FULL_HISTORY_PREFIX)).toBe(true);
+    expect(containsCiphertext(requireItem(requests, 2), REASONING_CIPHERTEXT)).toBe(false);
     expect(hasInputType(requireItem(requests, 3), "compaction")).toBe(true);
   });
 
@@ -502,6 +518,8 @@ describe("ChatGPT Responses encrypted replay recovery", () => {
     expect(scripted.sockets[1]?.closed).toBe(false);
     expect(hasInputType(requireItem(scripted.requests, 0), "compaction")).toBe(true);
     expect(hasInputType(requireItem(scripted.requests, 1), "compaction")).toBe(false);
+    expect(containsInputText(requireItem(scripted.requests, 0), FULL_HISTORY_PREFIX)).toBe(false);
+    expect(containsInputText(requireItem(scripted.requests, 1), FULL_HISTORY_PREFIX)).toBe(true);
     expect(hasInputType(requireItem(scripted.requests, 2), "compaction")).toBe(false);
     expect(observations.map((entry) => entry.payloadVariant)).toEqual([
       "initial",
@@ -555,6 +573,8 @@ describe("ChatGPT Responses encrypted replay recovery", () => {
 
     expect(scripted.sockets.slice(0, 3).every((socket) => socket.closed)).toBe(true);
     expect(hasInputType(requireItem(scripted.requests, 2), "compaction")).toBe(false);
+    expect(containsInputText(requireItem(scripted.requests, 2), FULL_HISTORY_PREFIX)).toBe(true);
+    expect(containsCiphertext(requireItem(scripted.requests, 2), REASONING_CIPHERTEXT)).toBe(false);
     expect(hasInputType(requireItem(scripted.requests, 3), "compaction")).toBe(true);
   });
 
@@ -643,6 +663,52 @@ describe("ChatGPT Responses encrypted replay recovery", () => {
       { egress: "native-codex-websocket", payloadVariant: "initial" },
       { egress: "native-codex-websocket", payloadVariant: "reasoning-stripped" },
       { egress: "native-codex-sse", payloadVariant: "reasoning-stripped" },
+    ]);
+  });
+
+  it("auto fallback reuses the lazily rebuilt full-history attempt in SSE", async () => {
+    const context = createReplayContext("compaction");
+    const observations: ResponsesPromptObservation[] = [];
+    const scripted = installScriptedWebSocket([
+      { events: [invalidEncryptedEvent()] },
+      { beforeEvents: (socket) => socket.dispatchEvent(new Event("error")) },
+    ]);
+    const sseRequests: RecordedRequest[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (_input, init) => {
+        sseRequests.push(decodeRequest(init));
+        return successResponse("resp_full_history_fallback");
+      }),
+    );
+    const onPayload = vi.fn((request: unknown) => request);
+    const options = createObservedOptions(
+      {
+        apiKey: createJwt(),
+        transport: "auto" as const,
+        ...REPLAY_IDENTITY,
+        onPayload,
+      },
+      observations,
+    );
+
+    const result = await streamOpenAICodexResponses(model, context, options).result();
+
+    expect(result.stopReason).toBe("stop");
+    expect(scripted.sockets).toHaveLength(2);
+    expect(scripted.sockets.every((socket) => socket.closed)).toBe(true);
+    expect(hasInputType(requireItem(scripted.requests, 0), "compaction")).toBe(true);
+    expect(containsInputText(requireItem(scripted.requests, 0), FULL_HISTORY_PREFIX)).toBe(false);
+    expect(hasInputType(requireItem(scripted.requests, 1), "compaction")).toBe(false);
+    expect(containsInputText(requireItem(scripted.requests, 1), FULL_HISTORY_PREFIX)).toBe(true);
+    expect(sseRequests).toHaveLength(1);
+    expect(hasInputType(requireItem(sseRequests, 0), "compaction")).toBe(false);
+    expect(containsInputText(requireItem(sseRequests, 0), FULL_HISTORY_PREFIX)).toBe(true);
+    expect(onPayload).toHaveBeenCalledTimes(2);
+    expect(observations.map(({ egress, payloadVariant }) => ({ egress, payloadVariant }))).toEqual([
+      { egress: "native-codex-websocket", payloadVariant: "initial" },
+      { egress: "native-codex-websocket", payloadVariant: "compaction-stripped" },
+      { egress: "native-codex-sse", payloadVariant: "compaction-stripped" },
     ]);
   });
 });

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -37,12 +37,15 @@ import { parseRetryAfterHttpDateMs } from "../internal/retry-after.js";
 import { sleepWithAbort } from "../internal/retry-sleep.js";
 import type { BaseOpenAIStreamOptions } from "../provider-options.js";
 import { registerSessionResourceCleanup } from "../session-resources.js";
-import { suppressOpenAIResponsesCompaction } from "../transports/openai-responses-compaction-replay.js";
+import {
+  buildOpenAIResponsesReasoningReplayMetadata,
+  suppressOpenAIResponsesCompaction,
+  type OpenAIResponsesReplayMode,
+} from "../transports/openai-responses-compaction-replay.js";
 import { responsesPromptObserver } from "../transports/openai-responses-contracts.js";
 import { ResponsesStreamFailure } from "../transports/openai-responses-debug.js";
 import { createResponsesPromptEgressObserver } from "../transports/openai-responses-prompt-observer-internal.js";
 import {
-  buildOpenAIResponsesReasoningReplayMetadata,
   isInvalidEncryptedContentError,
   resolveNextResponsesEncryptedContentAttempt,
   type ResponsesEncryptedContentAttempt,
@@ -290,14 +293,17 @@ export const streamOpenAICodexResponses: StreamFunction<
       const optionHeaders = resolveAiTransportHeaderSentinels(options?.headers);
 
       const accountId = extractOpenAICodexAccountId(apiKey);
-      let body = buildRequestBody(model, context, options);
-      const nextBody = await options?.onPayload?.(body, model);
-      if (nextBody !== undefined) {
-        body = nextBody as RequestBody;
-      }
+      const buildBody = async (replayMode: OpenAIResponsesReplayMode) => {
+        let body = buildRequestBody(model, context, options, replayMode);
+        const nextBody = await options?.onPayload?.(body, model);
+        if (nextBody !== undefined) {
+          body = nextBody as RequestBody;
+        }
+        return body;
+      };
       let semanticAttempt: ResponsesEncryptedContentAttempt<RequestBody> = {
         kind: "initial",
-        request: body,
+        request: await buildBody("checkpoint"),
       };
       const observePromptEgress = createResponsesPromptEgressObserver(
         options,
@@ -327,10 +333,12 @@ export const streamOpenAICodexResponses: StreamFunction<
           sessionId || createCodexRequestId(),
         );
         let websocketStarted = false;
+        let websocketRequestSent = false;
         let retriedWebSocketConnectionLimit = false;
         while (true) {
           const activeAttempt = semanticAttempt;
           websocketStarted = false;
+          websocketRequestSent = false;
           try {
             await processWebSocketStream(
               resolveCodexWebSocketUrl(model.baseUrl),
@@ -352,6 +360,9 @@ export const streamOpenAICodexResponses: StreamFunction<
               firstEventAbort.abort,
               observePromptEgress,
               activeAttempt.kind,
+              () => {
+                websocketRequestSent = true;
+              },
             );
 
             if (activeSignal?.aborted) {
@@ -369,12 +380,17 @@ export const streamOpenAICodexResponses: StreamFunction<
             return;
           } catch (error) {
             const aborted = activeSignal?.aborted;
+            // Observer and local send failures happen before dispatch and must not
+            // be classified as provider rejection of encrypted replay state.
             const nextSemanticAttempt =
               !aborted &&
+              websocketRequestSent &&
               !websocketStarted &&
               error instanceof CodexApiError &&
               isInvalidEncryptedContentError(error)
-                ? resolveNextResponsesEncryptedContentAttempt(activeAttempt, error)
+                ? await resolveNextResponsesEncryptedContentAttempt(activeAttempt, error, {
+                    buildFullHistoryRequest: () => buildBody("full-history"),
+                  })
                 : undefined;
             if (nextSemanticAttempt) {
               semanticAttempt = nextSemanticAttempt;
@@ -533,7 +549,11 @@ export const streamOpenAICodexResponses: StreamFunction<
           throw transportAbortError(activeSignal);
         }
         const nextSemanticAttempt = terminalResponseError
-          ? resolveNextResponsesEncryptedContentAttempt(activeAttempt, terminalResponseError)
+          ? await resolveNextResponsesEncryptedContentAttempt(
+              activeAttempt,
+              terminalResponseError,
+              { buildFullHistoryRequest: () => buildBody("full-history") },
+            )
           : undefined;
         if (!nextSemanticAttempt) {
           throw terminalResponseError ?? new Error("Failed after retries");
@@ -608,12 +628,14 @@ function buildRequestBody(
   model: Model<"openai-chatgpt-responses">,
   context: Context,
   options?: OpenAICodexResponsesOptions,
+  replayMode: OpenAIResponsesReplayMode = "checkpoint",
 ): RequestBody {
   const messages = convertResponsesMessages(model, context, CODEX_TOOL_CALL_PROVIDERS, {
     includeSystemPrompt: false,
     replayResponsesItemIds: false,
     sessionId: options?.sessionId,
     authProfileId: options?.authProfileId,
+    replayMode,
   });
 
   const body: RequestBody = {
@@ -1546,6 +1568,7 @@ async function processWebSocketStream(
   abortFirstEventStream?: (reason: Error) => void,
   observePromptEgress?: ObserveResponsesPromptEgress,
   payloadVariant: ResponsesEncryptedContentAttempt<RequestBody>["kind"] = "initial",
+  onRequestSent?: () => void,
 ): Promise<void> {
   const { socket, entry, release } = await acquireWebSocket(
     url,
@@ -1570,6 +1593,7 @@ async function processWebSocketStream(
       payloadVariant,
     });
     socket.send(JSON.stringify({ type: "response.create", ...requestBody }));
+    onRequestSent?.();
     await processResponsesStream(
       startWebSocketOutputOnFirstEvent(
         mapCodexEvents(parseWebSocket(socket, options?.signal)),

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -9,7 +9,7 @@ import { configureAiTransportHost } from "../host.js";
 import {
   buildOpenAIResponsesReasoningReplayMetadata,
   captureOpenAIResponsesCompaction,
-} from "../transports/openai-responses-replay-internal.js";
+} from "../transports/openai-responses-compaction-replay.js";
 import { processResponsesStream } from "../transports/openai-responses-stream-internal.js";
 import type { AssistantMessage, AssistantMessageEvent, Context, Model, Tool } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
@@ -988,16 +988,21 @@ describe("processResponsesStream", () => {
       buildOpenAIResponsesReasoningReplayMetadata(nativeOpenAIModel, replayIdentity),
     );
     const context: Context = {
-      messages: [prior, { role: "user", content: "recover", timestamp: 1 }],
+      messages: [
+        { role: "user", content: "full history prefix", timestamp: 0 },
+        prior,
+        { role: "user", content: "recover", timestamp: 1 },
+      ],
     };
     const requests: ResponseCreateParamsStreaming[] = [];
     const output = createAssistantOutput();
+    const onPayload = vi.fn((request: unknown) => request);
 
     await runResponsesStreamLifecycle({
       stream: new AssistantMessageEventStream(),
       model: nativeOpenAIModel,
       output,
-      options: replayIdentity,
+      options: { ...replayIdentity, onPayload },
       createClient: () => ({
         responses: {
           create: (request) => {
@@ -1026,14 +1031,12 @@ describe("processResponsesStream", () => {
           },
         },
       }),
-      buildParams: () => ({
+      buildParams: (_model, replayMode) => ({
         model: nativeOpenAIModel.id,
-        input: convertResponsesMessages(
-          nativeOpenAIModel,
-          context,
-          testAllowedToolCallProviders,
-          replayIdentity,
-        ),
+        input: convertResponsesMessages(nativeOpenAIModel, context, testAllowedToolCallProviders, {
+          ...replayIdentity,
+          replayMode,
+        }),
         stream: true,
       }),
       formatError: (error) => (error instanceof Error ? error.message : String(error)),
@@ -1043,10 +1046,13 @@ describe("processResponsesStream", () => {
     expect(requests[0]?.input).toEqual(
       expect.arrayContaining([expect.objectContaining({ type: "compaction", id: "cmp_rejected" })]),
     );
+    expect(JSON.stringify(requests[0]?.input)).not.toContain("full history prefix");
     const retryInput = requests[1]?.input;
     expect(Array.isArray(retryInput)).toBe(true);
     const retryItems = Array.isArray(retryInput) ? retryInput : [];
     expect(retryItems.some((item) => item.type === "compaction")).toBe(false);
+    expect(JSON.stringify(retryInput)).toContain("full history prefix");
+    expect(onPayload).toHaveBeenCalledTimes(2);
     expect(output.stopReason).toBe("stop");
     expect(output.providerReplay).toMatchObject({
       type: "openai-responses-compaction-suppression",

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -13,13 +13,14 @@ import type {
 } from "openai/resources/responses/responses.js";
 import { clampThinkingLevel } from "../model-utils.js";
 import type { BaseOpenAIStreamOptions } from "../provider-options.js";
-import { suppressOpenAIResponsesCompaction } from "../transports/openai-responses-compaction-replay.js";
 import {
+  buildOpenAIResponsesCompactionReplayPlan,
   buildOpenAIResponsesReasoningReplayMetadata,
-  createOpenAIResponsesCompactionPrefixPruner,
-  createResponsesStreamWithEncryptedContentRetry,
-  resolveNewestOpenAIResponsesCompactionReplay,
-} from "../transports/openai-responses-replay-internal.js";
+  suppressOpenAIResponsesCompaction,
+  type OpenAIResponsesReplayMode,
+} from "../transports/openai-responses-compaction-replay.js";
+import type { OpenAIResponsesRequestParams } from "../transports/openai-responses-contracts.js";
+import { createResponsesStreamWithEncryptedContentRetry } from "../transports/openai-responses-replay-internal.js";
 import { processResponsesStream } from "../transports/openai-responses-stream-internal.js";
 import { transportAbortError } from "../transports/transport-stream-shared.js";
 import type {
@@ -151,6 +152,7 @@ interface ConvertResponsesMessagesOptions {
   replayResponsesItemIds?: boolean;
   sessionId?: string;
   authProfileId?: string;
+  replayMode?: OpenAIResponsesReplayMode;
 }
 export { convertResponsesToolPayload };
 
@@ -207,6 +209,8 @@ type ResponsesCommonParamsOptions = Pick<StreamOptions, "maxTokens" | "temperatu
   reasoningSummary?: ResponsesReasoningSummary;
 };
 
+type ResponsesLifecycleRequest = OpenAIResponsesRequestParams;
+
 // =============================================================================
 // Message conversion
 // =============================================================================
@@ -257,12 +261,12 @@ export function convertResponsesMessages<TApi extends Api>(
     return `${normalizedCallId}|${normalizedItemId}`;
   };
 
-  const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId);
-  const compaction = resolveNewestOpenAIResponsesCompactionReplay(transformedMessages, model, {
+  const replayPlan = buildOpenAIResponsesCompactionReplayPlan(context.messages, model, {
     sessionId: options?.sessionId,
     authProfileId: options?.authProfileId,
+    mode: options?.replayMode,
   });
-  const compactionPruner = createOpenAIResponsesCompactionPrefixPruner(compaction);
+  const transformedMessages = transformMessages(replayPlan.messages, model, normalizeToolCallId);
 
   const includeSystemPrompt = options?.includeSystemPrompt ?? true;
   if (includeSystemPrompt && context.systemPrompt) {
@@ -280,13 +284,12 @@ export function convertResponsesMessages<TApi extends Api>(
       ],
     });
   }
+  if (replayPlan.compaction) {
+    messages.push(replayPlan.compaction);
+  }
 
   let msgIndex = 0;
   for (const msg of transformedMessages) {
-    if (compactionPruner.shouldSkipMessage(msg)) {
-      msgIndex += 1;
-      continue;
-    }
     if (msg.role === "user") {
       if (typeof msg.content === "string") {
         messages.push({
@@ -319,7 +322,6 @@ export function convertResponsesMessages<TApi extends Api>(
       }
     } else if (msg.role === "assistant") {
       const output: ResponseInput = [];
-      const assistantCompaction = msg === compaction?.owner ? compaction : undefined;
       let textFallbackOrdinal = 0;
       const assistantMsg = msg;
       let previousReplayItemWasReasoning = false;
@@ -328,13 +330,7 @@ export function convertResponsesMessages<TApi extends Api>(
         assistantMsg.provider === model.provider &&
         assistantMsg.api === model.api;
 
-      for (const [contentIndex, block] of msg.content.entries()) {
-        if (compactionPruner.shouldSkipAssistantBlock(msg, contentIndex)) {
-          continue;
-        }
-        if (assistantCompaction && contentIndex === assistantCompaction.replayIndex) {
-          output.push(assistantCompaction.item);
-        }
+      for (const block of msg.content) {
         if (block.type === "thinking") {
           if (block.thinkingSignature) {
             const reasoningItem = normalizeResponsesReasoningReplayItem({
@@ -374,7 +370,6 @@ export function convertResponsesMessages<TApi extends Api>(
           output.push(messageItem as ResponseInputItem);
           previousReplayItemWasReasoning = false;
         } else if (block.type === "toolCall") {
-          compactionPruner.recordToolCall(block.id);
           const toolCall = block;
           const [callId, itemIdRaw] = splitResponsesToolCallId(toolCall.id);
           let itemId: string | undefined = shouldReplayResponsesItemIds ? itemIdRaw : undefined;
@@ -396,9 +391,6 @@ export function convertResponsesMessages<TApi extends Api>(
           previousReplayItemWasReasoning = false;
         }
       }
-      if (assistantCompaction && assistantCompaction.replayIndex >= msg.content.length) {
-        output.push(assistantCompaction.item);
-      }
       if (output.length === 0) {
         continue;
       }
@@ -409,10 +401,6 @@ export function convertResponsesMessages<TApi extends Api>(
       const hasImages = msg.content.some(isImageWithMediaPayload);
       const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
       const hasText = sanitizedTextResult.trim().length > 0;
-      if (!compactionPruner.shouldKeepToolResult(msg.toolCallId)) {
-        msgIndex++;
-        continue;
-      }
       const [callId] = splitResponsesToolCallId(msg.toolCallId);
 
       let output: string | ResponseFunctionCallOutputItemList;
@@ -599,7 +587,10 @@ export async function runResponsesStreamLifecycle<TApi extends Api>(params: {
   options?: ResponsesLifecycleStreamOptions;
   resolveRequestModel?: (model: Model<TApi>) => Model<TApi>;
   createClient: (model: Model<TApi>) => ResponsesStreamClient;
-  buildParams: (model: Model<TApi>) => ResponseCreateParamsStreaming;
+  buildParams: (
+    model: Model<TApi>,
+    replayMode: OpenAIResponsesReplayMode,
+  ) => ResponsesLifecycleRequest;
   processStreamOptions?: OpenAIResponsesProcessStreamOptions;
   formatError: (error: unknown) => string;
 }): Promise<void> {
@@ -609,11 +600,15 @@ export async function runResponsesStreamLifecycle<TApi extends Api>(params: {
   try {
     const model = params.resolveRequestModel?.(params.model) ?? params.model;
     const client = params.createClient(model);
-    let requestParams = params.buildParams(model);
-    const nextParams = await options?.onPayload?.(requestParams, model);
-    if (nextParams !== undefined) {
-      requestParams = nextParams as ResponseCreateParamsStreaming;
-    }
+    const buildRequest = async (replayMode: OpenAIResponsesReplayMode) => {
+      let request = params.buildParams(model, replayMode);
+      const nextRequest = await options?.onPayload?.(request, model);
+      if (nextRequest !== undefined) {
+        request = nextRequest as ResponsesLifecycleRequest;
+      }
+      return request;
+    };
+    const requestParams = await buildRequest("checkpoint");
 
     firstEventAbort = createFirstStreamEventAbortController(options?.signal);
     const { stream: openaiStream, response } = await createResponsesStreamWithEncryptedContentRetry(
@@ -625,6 +620,7 @@ export async function runResponsesStreamLifecycle<TApi extends Api>(params: {
           signal: firstEventAbort.signal,
         },
         model,
+        buildFullHistoryRequest: () => buildRequest("full-history"),
         onCompactionRejected: () =>
           suppressOpenAIResponsesCompaction(output, model, {
             sessionId: options?.sessionId,

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -4,6 +4,8 @@ import type { ResponseCreateParamsStreaming } from "openai/resources/responses/r
 import { getEnvApiKey } from "../env-api-keys.js";
 import { getAiTransportHost } from "../host.js";
 import type { BaseOpenAIStreamOptions } from "../provider-options.js";
+import type { OpenAIResponsesReplayMode } from "../transports/openai-responses-compaction-replay.js";
+import type { OpenAIResponsesRequestParams } from "../transports/openai-responses-contracts.js";
 import type {
   CacheRetention,
   Context,
@@ -100,7 +102,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIRes
       const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
       return createClient(model, context, apiKey, options?.headers, cacheSessionId);
     },
-    buildParams: () => buildParams(model, context, options),
+    buildParams: (_requestModel, replayMode) => buildParams(model, context, options, replayMode),
     processStreamOptions: {
       serviceTier: options?.serviceTier,
       applyServiceTierPricing: (usage, serviceTier) =>
@@ -189,16 +191,18 @@ function buildParams(
   model: Model<"openai-responses">,
   context: Context,
   options?: OpenAIResponsesOptions,
+  replayMode: OpenAIResponsesReplayMode = "checkpoint",
 ) {
   const messages = convertResponsesMessages(model, context, OPENAI_TOOL_CALL_PROVIDERS, {
     replayResponsesItemIds: options?.replayResponsesItemIds ?? false,
     sessionId: options?.sessionId,
     authProfileId: options?.authProfileId,
+    replayMode,
   });
 
   const cacheRetention = resolveCacheRetention(options?.cacheRetention);
   const compat = getCompat(model);
-  const params: ResponseCreateParamsStreaming = {
+  const params: ResponseCreateParamsStreaming & OpenAIResponsesRequestParams = {
     model: model.id,
     input: messages,
     stream: true,

--- a/packages/ai/src/transports/host-policy.ts
+++ b/packages/ai/src/transports/host-policy.ts
@@ -59,6 +59,7 @@ export function transformTransportMessages(
   options?: {
     normalizeSameModelToolCallIds?: boolean;
     preserveCrossModelToolCallThoughtSignature?: boolean;
+    preserveUnframedToolResults?: boolean;
   },
 ): Context["messages"] {
   return getAiTransportHost().transformTransportMessages(

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -15,7 +15,11 @@ import {
 import { buildGuardedModelFetch } from "./host-policy.js";
 import { emitModelTransportDebug } from "./model-transport-debug.js";
 import { formatModelTransportDebugBaseUrl } from "./model-transport-url.js";
-import { suppressOpenAIResponsesCompaction } from "./openai-responses-compaction-replay.js";
+import {
+  buildOpenAIResponsesReasoningReplayMetadata,
+  suppressOpenAIResponsesCompaction,
+  type OpenAIResponsesReplayMode,
+} from "./openai-responses-compaction-replay.js";
 import {
   AZURE_RESPONSES_FIRST_EVENT_TIMEOUT_MS,
   type OpenAIResponsesOptions,
@@ -34,7 +38,6 @@ import {
 } from "./openai-responses-params-internal.js";
 import { createResponsesPromptEgressObserver } from "./openai-responses-prompt-observer-internal.js";
 import {
-  buildOpenAIResponsesReasoningReplayMetadata,
   createResponsesStreamWithEncryptedContentRetry,
   resolveAzureOpenAIApiVersion,
 } from "./openai-responses-replay-internal.js";
@@ -126,6 +129,7 @@ type ResponsesTransportExecutorOptions = {
     context: Context,
     options: OpenAIResponsesOptions | undefined,
     metadata?: Record<string, string>,
+    replayMode?: OpenAIResponsesReplayMode,
   ) => ReturnType<typeof buildOpenAIResponsesParams>;
   createResponseStream: (
     params: ResponsesStreamParams,
@@ -173,27 +177,39 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
           turnState?.headers,
           options?.sessionId,
         );
-        let params = config.buildRequest(model, context, responsesOptions, turnState?.metadata);
-        const nextParams = await options?.onPayload?.(params, model);
-        if (nextParams !== undefined) {
-          params = nextParams as typeof params;
-        }
-        if (!isOpenAICodexResponsesModel(model)) {
-          params = mergeTransportMetadata(params, turnState?.metadata);
-        }
-        params = sanitizeOpenAICodexResponsesParams(
-          model,
-          params as Record<string, unknown>,
-        ) as typeof params;
-        params = sanitizeResponsesImagePayload(params as Record<string, unknown>) as typeof params;
-        if (
-          (options as { openclawCodeModeToolSurface?: unknown } | undefined)
-            ?.openclawCodeModeToolSurface === true
-        ) {
-          const visibleToolNames = resolveCodeModeResponsesVisibleToolNames(context);
-          enforceCodeModeResponsesToolSurface(params, visibleToolNames);
-          assertCodeModeResponsesToolSurface(params, visibleToolNames);
-        }
+        const buildRequest = async (replayMode: OpenAIResponsesReplayMode) => {
+          let params = config.buildRequest(
+            model,
+            context,
+            responsesOptions,
+            turnState?.metadata,
+            replayMode,
+          );
+          const nextParams = await options?.onPayload?.(params, model);
+          if (nextParams !== undefined) {
+            params = nextParams as typeof params;
+          }
+          if (!isOpenAICodexResponsesModel(model)) {
+            params = mergeTransportMetadata(params, turnState?.metadata);
+          }
+          params = sanitizeOpenAICodexResponsesParams(
+            model,
+            params as Record<string, unknown>,
+          ) as typeof params;
+          params = sanitizeResponsesImagePayload(
+            params as Record<string, unknown>,
+          ) as typeof params;
+          if (
+            (options as { openclawCodeModeToolSurface?: unknown } | undefined)
+              ?.openclawCodeModeToolSurface === true
+          ) {
+            const visibleToolNames = resolveCodeModeResponsesVisibleToolNames(context);
+            enforceCodeModeResponsesToolSurface(params, visibleToolNames);
+            assertCodeModeResponsesToolSurface(params, visibleToolNames);
+          }
+          return params;
+        };
+        const params = await buildRequest("checkpoint");
         const observePrompt = createResponsesPromptEgressObserver(
           responsesOptions,
           context.systemPrompt,
@@ -218,6 +234,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
           requestOptions,
           model,
           observePrompt,
+          buildFullHistoryRequest: () => buildRequest("full-history"),
           onCompactionRejected: () =>
             suppressOpenAIResponsesCompaction(output, model, {
               sessionId: options?.sessionId,
@@ -294,13 +311,14 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
     outputApi: "azure-openai-responses",
     firstEventTimeoutMs: AZURE_RESPONSES_FIRST_EVENT_TIMEOUT_MS,
     createClient: createAzureOpenAIClient,
-    buildRequest: (model, context, options, metadata) =>
+    buildRequest: (model, context, options, metadata, replayMode) =>
       buildAzureOpenAIResponsesParams(
         model,
         context,
         options,
         resolveAzureDeploymentName(model),
         metadata,
+        replayMode,
       ),
     createResponseStream: createResponsesStreamWithEncryptedContentRetry,
   });
@@ -350,8 +368,9 @@ function buildAzureOpenAIResponsesParams(
   options: OpenAIResponsesOptions | undefined,
   deploymentName: string,
   metadata?: Record<string, string>,
+  replayMode: OpenAIResponsesReplayMode = "checkpoint",
 ) {
-  const params = buildOpenAIResponsesParams(model, context, options, metadata);
+  const params = buildOpenAIResponsesParams(model, context, options, metadata, replayMode);
   params.model = deploymentName;
   delete params.store;
   return params;

--- a/packages/ai/src/transports/openai-responses-compaction-replay.test.ts
+++ b/packages/ai/src/transports/openai-responses-compaction-replay.test.ts
@@ -7,12 +7,12 @@ import type {
 } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
 import { convertResponsesMessages as convertProviderResponsesMessages } from "../providers/openai-responses-shared.js";
-import { suppressOpenAIResponsesCompaction } from "./openai-responses-compaction-replay.js";
-import { stringifyRedactedEvent, stringifyRedactedPayload } from "./openai-responses-debug.js";
 import {
   buildOpenAIResponsesReasoningReplayMetadata,
-  convertResponsesMessages,
-} from "./openai-responses-replay-internal.js";
+  suppressOpenAIResponsesCompaction,
+} from "./openai-responses-compaction-replay.js";
+import { stringifyRedactedEvent, stringifyRedactedPayload } from "./openai-responses-debug.js";
+import { convertResponsesMessages } from "./openai-responses-replay-internal.js";
 import {
   processResponsesStream,
   type OpenAIResponsesStreamEvent,
@@ -649,7 +649,7 @@ describe("OpenAI Responses compaction replay", () => {
   );
 
   it.each(responseConverters)(
-    "$name drops an orphaned pre-boundary tool output and keeps the later pair valid",
+    "$name keeps a real post-compaction output whose call was compacted",
     ({ convert }) => {
       const owner = createAssistant(
         [
@@ -658,12 +658,6 @@ describe("OpenAI Responses compaction replay", () => {
             id: "call_before|fc_before",
             name: "lookup",
             arguments: { before: true },
-          },
-          {
-            type: "toolCall",
-            id: "call_after|fc_after",
-            name: "lookup",
-            arguments: { after: true },
           },
         ],
         compactionState(model, { replayIndex: 1 }),
@@ -679,29 +673,19 @@ describe("OpenAI Responses compaction replay", () => {
             isError: false,
             timestamp: 1,
           },
-          {
-            role: "toolResult",
-            toolCallId: "call_after|fc_after",
-            toolName: "lookup",
-            content: [{ type: "text", text: "after output" }],
-            isError: false,
-            timestamp: 2,
-          },
         ],
       });
 
-      expect(input.map((item) => item.type)).toEqual([
-        "compaction",
-        "function_call",
-        "function_call_output",
-      ]);
-      expect(input.filter((item) => item.type === "function_call")).toMatchObject([
-        { call_id: "call_after" },
-      ]);
+      expect(input.map((item) => item.type)).toEqual(["compaction", "function_call_output"]);
+      expect(input.some((item) => item.type === "function_call")).toBe(false);
       expect(input.filter((item) => item.type === "function_call_output")).toMatchObject([
-        { call_id: "call_after", output: "after output" },
+        { call_id: "call_before", output: "before output" },
       ]);
-      expect(JSON.stringify(input)).not.toContain("before output");
+      expect(JSON.stringify(input)).not.toContain("No result provided");
+      expect(JSON.stringify(input)).not.toContain("aborted");
+      expect(owner.content).toEqual([
+        expect.objectContaining({ type: "toolCall", id: "call_before|fc_before" }),
+      ]);
     },
   );
 
@@ -733,8 +717,10 @@ describe("OpenAI Responses compaction replay", () => {
         "function_call_output",
       ]);
       expect(input.filter((item) => item.type === "function_call_output")).toMatchObject([
-        { call_id: "call_after" },
+        { call_id: "call_after", output: "No result provided" },
       ]);
+      expect(input.filter((item) => item.type === "function_call_output")).toHaveLength(1);
+      expect(JSON.stringify(input)).not.toContain("call_before");
     },
   );
 

--- a/packages/ai/src/transports/openai-responses-compaction-replay.ts
+++ b/packages/ai/src/transports/openai-responses-compaction-replay.ts
@@ -215,7 +215,7 @@ function prepareOpenAIResponsesCompactionForReplay(
   };
 }
 
-export function resolveNewestOpenAIResponsesCompactionReplay(
+function resolveNewestOpenAIResponsesCompactionReplay(
   messages: Context["messages"],
   model: Model,
   options?: Pick<BaseOpenAIStreamOptions, "authProfileId" | "sessionId">,
@@ -243,49 +243,41 @@ export function resolveNewestOpenAIResponsesCompactionReplay(
   return undefined;
 }
 
-export function createOpenAIResponsesCompactionPrefixPruner(
-  compaction: { owner: AssistantMessage; replayIndex: number } | undefined,
-) {
-  let reachedOwner = compaction === undefined;
-  const retainedToolCalls = new Map<string, number>();
+export type OpenAIResponsesReplayMode = "checkpoint" | "full-history";
 
+type OpenAIResponsesCompactionReplayPlan = {
+  messages: Context["messages"];
+  compaction?: ResponseCompactionItemParam;
+  preserveUnframedToolResults: boolean;
+};
+
+export function buildOpenAIResponsesCompactionReplayPlan(
+  messages: Context["messages"],
+  model: Model,
+  options?: Pick<BaseOpenAIStreamOptions, "authProfileId" | "sessionId"> & {
+    mode?: OpenAIResponsesReplayMode;
+  },
+): OpenAIResponsesCompactionReplayPlan {
+  if (options?.mode === "full-history") {
+    // Checkpoint rejection must rebuild from the untouched transcript; consulting
+    // providerReplay here would recreate the same rejected compaction window.
+    return { messages, preserveUnframedToolResults: false };
+  }
+  const compaction = resolveNewestOpenAIResponsesCompactionReplay(messages, model, options);
+  if (!compaction) {
+    return { messages, preserveUnframedToolResults: false };
+  }
+  const ownerIndex = messages.indexOf(compaction.owner);
+  const owner = {
+    ...compaction.owner,
+    content: compaction.owner.content.slice(compaction.replayIndex),
+  };
+  // Slice before transcript repair so compacted calls cannot synthesize outputs,
+  // while real results emitted after the checkpoint remain in chronological order.
   return {
-    shouldSkipMessage(message: Context["messages"][number]): boolean {
-      if (reachedOwner) {
-        return false;
-      }
-      if (message === compaction?.owner) {
-        reachedOwner = true;
-        return false;
-      }
-      return true;
-    },
-    shouldSkipAssistantBlock(message: AssistantMessage, contentIndex: number): boolean {
-      // Capture records output.content.length, so replayIndex is the normalized
-      // assistant-block boundary even when the provider emitted unsupported items.
-      return message === compaction?.owner && contentIndex < compaction.replayIndex;
-    },
-    recordToolCall(toolCallId: string): void {
-      if (!compaction) {
-        return;
-      }
-      retainedToolCalls.set(toolCallId, (retainedToolCalls.get(toolCallId) ?? 0) + 1);
-    },
-    shouldKeepToolResult(toolCallId: string): boolean {
-      if (!compaction) {
-        return true;
-      }
-      const remaining = retainedToolCalls.get(toolCallId) ?? 0;
-      if (remaining === 0) {
-        return false;
-      }
-      if (remaining === 1) {
-        retainedToolCalls.delete(toolCallId);
-      } else {
-        retainedToolCalls.set(toolCallId, remaining - 1);
-      }
-      return true;
-    },
+    messages: [owner, ...messages.slice(ownerIndex + 1)],
+    compaction: compaction.item,
+    preserveUnframedToolResults: true,
   };
 }
 

--- a/packages/ai/src/transports/openai-responses-params-internal.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.ts
@@ -19,6 +19,7 @@ import {
 import { normalizeOpenAIStrictToolParameters } from "../providers/openai-tool-schema.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
 import { resolveOpenAIStrictToolSetting } from "./host-policy.js";
+import type { OpenAIResponsesReplayMode } from "./openai-responses-compaction-replay.js";
 import {
   OPENAI_CODEX_RESPONSES_DEFAULT_INSTRUCTIONS,
   OPENAI_CODEX_RESPONSES_EMPTY_INPUT_TEXT,
@@ -230,6 +231,7 @@ export function buildOpenAIResponsesParams(
   context: Context,
   options: OpenAIResponsesOptions | undefined,
   metadata?: Record<string, string>,
+  replayMode: OpenAIResponsesReplayMode = "checkpoint",
 ) {
   const isCodexResponses = isOpenAICodexResponsesModel(model);
   const isNativeCodexResponses = usesNativeOpenAICodexResponsesBackend(model);
@@ -254,6 +256,7 @@ export function buildOpenAIResponsesParams(
       replayResponsesItemIds,
       authProfileId: options?.authProfileId,
       sessionId: options?.sessionId,
+      replayMode,
     },
   );
   if (isCodexResponses) {

--- a/packages/ai/src/transports/openai-responses-prompt-observer.test.ts
+++ b/packages/ai/src/transports/openai-responses-prompt-observer.test.ts
@@ -13,9 +13,12 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-bound
 import {
   buildOpenAIResponsesReasoningReplayMetadata,
   captureOpenAIResponsesCompaction,
-} from "./openai-responses-replay-internal.js";
+} from "./openai-responses-compaction-replay.js";
+import { tagOpenAIResponsesReasoningReplayItem } from "./openai-responses-replay-internal.js";
 
 type SdkResponse = { data: AsyncIterable<unknown>; response: Response };
+const SDK_FULL_HISTORY_PREFIX = "full history before compaction";
+const SDK_REASONING_CIPHERTEXT = "opaque-sdk-reasoning";
 
 const sdkState = vi.hoisted(() => ({
   clients: [] as Array<"openai" | "azure">,
@@ -123,10 +126,30 @@ function completedSdkResponse(responseId: string): SdkResponse {
 function createCompactionContext(
   model: Model,
   identity: { authProfileId: string; sessionId: string },
+  includeReasoning = false,
 ): Context {
   const prior: AssistantMessage = {
     role: "assistant",
-    content: [],
+    content: includeReasoning
+      ? [
+          {
+            type: "thinking",
+            thinking: "prior reasoning",
+            thinkingSignature: JSON.stringify(
+              tagOpenAIResponsesReasoningReplayItem(
+                {
+                  type: "reasoning",
+                  id: "rs_sdk_retry",
+                  encrypted_content: SDK_REASONING_CIPHERTEXT,
+                  summary: [],
+                },
+                model,
+                identity,
+              ),
+            ),
+          },
+        ]
+      : [],
     api: model.api,
     provider: model.provider,
     model: model.id,
@@ -154,7 +177,11 @@ function createCompactionContext(
   );
   return {
     systemPrompt: "PRIVATE-AZURE-RECOVERY-PROMPT",
-    messages: [prior, { role: "user", content: "continue", timestamp: 2 }],
+    messages: [
+      { role: "user", content: SDK_FULL_HISTORY_PREFIX, timestamp: 0 },
+      prior,
+      { role: "user", content: "continue", timestamp: 2 },
+    ],
   };
 }
 
@@ -301,12 +328,74 @@ describe("OpenAI Responses provider prompt observer", () => {
     expect(requestHasCompaction(sdkState.requests[0])).toBe(true);
     expect(requestHasCompaction(sdkState.requests[1])).toBe(false);
     expect(requestHasCompaction(sdkState.requests[2])).toBe(false);
+    expect(JSON.stringify(sdkState.requests[0]?.input)).not.toContain(SDK_FULL_HISTORY_PREFIX);
+    expect(JSON.stringify(sdkState.requests[1]?.input)).toContain(SDK_FULL_HISTORY_PREFIX);
     expect(observations.map((entry) => entry.payloadVariant)).toEqual([
       "initial",
       "compaction-stripped",
       "initial",
     ]);
     expect(JSON.stringify(observations)).not.toContain("opaque-azure-compaction");
+  });
+
+  it("lazily rebuilds full history after reasoning and compaction rejection", async () => {
+    const identity = { sessionId: "sdk-recovery-session", authProfileId: "sdk-profile" };
+    const openAIModel = createModel();
+    const context = createCompactionContext(openAIModel, identity, true);
+    const invalidEncryptedContent = () =>
+      Object.assign(new Error("invalid encrypted content"), {
+        code: "invalid_encrypted_content",
+      });
+    const onPayload = vi.fn((request: unknown) => request);
+    sdkState.outcomes = [
+      invalidEncryptedContent(),
+      invalidEncryptedContent(),
+      completedSdkResponse("resp_sdk_recovered"),
+    ];
+
+    const stream = await Promise.resolve(
+      createOpenAIResponsesTransportStreamFn()(openAIModel, context, {
+        apiKey: "test-key",
+        ...identity,
+        onPayload,
+      } as never),
+    );
+    expect((await stream.result()).stopReason).toBe("stop");
+
+    expect(sdkState.requests).toHaveLength(3);
+    expect(requestHasCompaction(sdkState.requests[0])).toBe(true);
+    expect(JSON.stringify(sdkState.requests[0]?.input)).toContain(SDK_REASONING_CIPHERTEXT);
+    expect(JSON.stringify(sdkState.requests[0]?.input)).not.toContain(SDK_FULL_HISTORY_PREFIX);
+    expect(requestHasCompaction(sdkState.requests[1])).toBe(true);
+    expect(JSON.stringify(sdkState.requests[1]?.input)).not.toContain(SDK_REASONING_CIPHERTEXT);
+    expect(requestHasCompaction(sdkState.requests[2])).toBe(false);
+    expect(JSON.stringify(sdkState.requests[2]?.input)).toContain(SDK_FULL_HISTORY_PREFIX);
+    expect(JSON.stringify(sdkState.requests[2]?.input)).not.toContain(SDK_REASONING_CIPHERTEXT);
+    expect(onPayload).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not invoke the provider or retry when prompt observation throws", async () => {
+    const options = { apiKey: "test-key" };
+    responsesPromptObserver.set(options, () => {
+      throw Object.assign(new Error("observer failed"), {
+        code: "invalid_encrypted_content",
+      });
+    });
+    sdkState.outcomes = [completedSdkResponse("resp_unexpected")];
+
+    const stream = await Promise.resolve(
+      createOpenAIResponsesTransportStreamFn()(
+        createModel(),
+        createContext("PRIVATE-OBSERVER-FAILURE-PROMPT"),
+        options as never,
+      ),
+    );
+    expect(await stream.result()).toMatchObject({
+      stopReason: "error",
+      errorMessage: "observer failed",
+    });
+    expect(sdkState.clients).toEqual([]);
+    expect(sdkState.requests).toEqual([]);
   });
 
   it("observes the async replacement immediately before final transformed egress", async () => {
@@ -359,23 +448,22 @@ describe("OpenAI Responses provider prompt observer", () => {
     const invalidEncryptedContent = Object.assign(new Error("invalid encrypted content"), {
       code: "invalid_encrypted_content",
     });
+    const onPayload = vi.fn((request: Record<string, unknown>) => ({
+      ...request,
+      input: [
+        ...((request.input as unknown[]) ?? []),
+        { type: "reasoning", encrypted_content: "opaque", summary: [] },
+        {
+          type: "compaction",
+          id: "cmp_invalid",
+          encrypted_content: "opaque-compaction",
+        },
+      ],
+    }));
     const run = await runObservedRequest({
       context: createContext(prompt),
       errors: [invalidEncryptedContent, invalidEncryptedContent, new Error("stop after retry")],
-      options: {
-        onPayload: (request: Record<string, unknown>) => ({
-          ...request,
-          input: [
-            ...((request.input as unknown[]) ?? []),
-            { type: "reasoning", encrypted_content: "opaque", summary: [] },
-            {
-              type: "compaction",
-              id: "cmp_invalid",
-              encrypted_content: "opaque-compaction",
-            },
-          ],
-        }),
-      },
+      options: { onPayload },
     });
 
     expect(run.order).toEqual([
@@ -407,6 +495,7 @@ describe("OpenAI Responses provider prompt observer", () => {
         (item) => item.type === "compaction",
       ),
     ).toBe(false);
+    expect(onPayload).toHaveBeenCalledTimes(2);
   });
 
   it("uses cache-boundary and surrogate normalization as the expected prompt owner", async () => {

--- a/packages/ai/src/transports/openai-responses-replay-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-internal.ts
@@ -18,9 +18,9 @@ import type { createOpenAIResponsesClient } from "./openai-responses-client.js";
 import {
   buildOpenAIResponsesReasoningReplayMetadata,
   buildOpenAIResponsesReplayContext,
-  createOpenAIResponsesCompactionPrefixPruner,
+  buildOpenAIResponsesCompactionReplayPlan,
   isSafeResponsesReplayItemId,
-  resolveNewestOpenAIResponsesCompactionReplay,
+  type OpenAIResponsesReplayMode,
 } from "./openai-responses-compaction-replay.js";
 import {
   DEFAULT_AZURE_OPENAI_API_VERSION,
@@ -40,14 +40,6 @@ import {
   sanitizeNonEmptyTransportPayloadText,
   sanitizeTransportPayloadText,
 } from "./transport-stream-shared.js";
-
-export {
-  buildOpenAIResponsesReasoningReplayMetadata,
-  captureOpenAIResponsesCompaction,
-  createCompactionTracker,
-  createOpenAIResponsesCompactionPrefixPruner,
-  resolveNewestOpenAIResponsesCompactionReplay,
-} from "./openai-responses-compaction-replay.js";
 
 type ResponsesClientLike = ReturnType<typeof createOpenAIResponsesClient>;
 
@@ -146,12 +138,13 @@ function stripResponsesRequestCompaction<TRequest extends ResponsesEncryptedCont
   return input.length === request.input.length ? request : { ...request, input };
 }
 
-export function resolveNextResponsesEncryptedContentAttempt<
+export async function resolveNextResponsesEncryptedContentAttempt<
   TRequest extends ResponsesEncryptedContentRequest,
 >(
   attempt: ResponsesEncryptedContentAttempt<TRequest>,
   error: unknown,
-): ResponsesEncryptedContentAttempt<TRequest> | undefined {
+  options?: { buildFullHistoryRequest?: () => TRequest | Promise<TRequest> },
+): Promise<ResponsesEncryptedContentAttempt<TRequest> | undefined> {
   if (!isInvalidEncryptedContentError(error) || attempt.kind === "compaction-stripped") {
     return undefined;
   }
@@ -161,10 +154,20 @@ export function resolveNextResponsesEncryptedContentAttempt<
       return { kind: "reasoning-stripped", request: reasoningStripped };
     }
   }
-  const compactionStripped = stripResponsesRequestCompaction(attempt.request);
-  return compactionStripped === attempt.request
-    ? undefined
-    : { kind: "compaction-stripped", request: compactionStripped };
+  const locallyStripped = stripResponsesRequestCompaction(attempt.request);
+  if (locallyStripped === attempt.request) {
+    return undefined;
+  }
+  // Filtering the already-pruned checkpoint request would leave a context-blind
+  // suffix. Rebuild full history lazily, then preserve any earlier reasoning strip.
+  let compactionStripped = options?.buildFullHistoryRequest
+    ? await options.buildFullHistoryRequest()
+    : locallyStripped;
+  compactionStripped = stripResponsesRequestCompaction(compactionStripped);
+  if (attempt.kind === "reasoning-stripped") {
+    compactionStripped = stripResponsesRequestEncryptedReasoning(compactionStripped);
+  }
+  return { kind: "compaction-stripped", request: compactionStripped };
 }
 
 export function tagOpenAIResponsesReasoningReplayItem(
@@ -266,14 +269,13 @@ export async function createResponsesStreamWithEncryptedContentRetry(params: {
   model: Model;
   observePrompt?: NonNullable<ReturnType<typeof createResponsesPromptEgressObserver>>;
   onCompactionRejected?: () => void;
+  buildFullHistoryRequest?: () =>
+    | OpenAIResponsesRequestParams
+    | Promise<OpenAIResponsesRequestParams>;
 }): Promise<{ stream: AsyncIterable<unknown>; response: Response }> {
   const sendAttempt = async (
     attempt: ResponsesEncryptedContentAttempt<OpenAIResponsesRequestParams>,
   ) => {
-    params.observePrompt?.(attempt.request, {
-      egress: "responses-sdk",
-      payloadVariant: attempt.kind,
-    });
     const { data, response } = await params.client.responses
       .create(attempt.request as never, params.requestOptions as never)
       .withResponse();
@@ -288,10 +290,16 @@ export async function createResponsesStreamWithEncryptedContentRetry(params: {
     request: params.request,
   };
   while (true) {
+    params.observePrompt?.(attempt.request, {
+      egress: "responses-sdk",
+      payloadVariant: attempt.kind,
+    });
     try {
       return await sendAttempt(attempt);
     } catch (error) {
-      const nextAttempt = resolveNextResponsesEncryptedContentAttempt(attempt, error);
+      const nextAttempt = await resolveNextResponsesEncryptedContentAttempt(attempt, error, {
+        buildFullHistoryRequest: params.buildFullHistoryRequest,
+      });
       if (!nextAttempt) {
         throw error;
       }
@@ -378,6 +386,7 @@ export function convertResponsesMessages(
     replayResponsesItemIds?: boolean;
     sessionId?: string;
     authProfileId?: string;
+    replayMode?: OpenAIResponsesReplayMode;
   },
 ): ResponseInput {
   const messages: ResponseInput = [];
@@ -429,17 +438,20 @@ export function convertResponsesMessages(
     }
     return `${normalizedCallId}|${normalizedItemId}`;
   };
-  const transformedMessages = transformTransportMessages(
-    context.messages,
-    model,
-    normalizeToolCallId,
-    { normalizeSameModelToolCallIds: shouldNormalizeSameModelToolCallIds },
-  );
-  const compaction = resolveNewestOpenAIResponsesCompactionReplay(transformedMessages, model, {
+  const replayPlan = buildOpenAIResponsesCompactionReplayPlan(context.messages, model, {
     sessionId: options?.sessionId,
     authProfileId: options?.authProfileId,
+    mode: options?.replayMode,
   });
-  const compactionPruner = createOpenAIResponsesCompactionPrefixPruner(compaction);
+  const transformedMessages = transformTransportMessages(
+    replayPlan.messages,
+    model,
+    normalizeToolCallId,
+    {
+      normalizeSameModelToolCallIds: shouldNormalizeSameModelToolCallIds,
+      preserveUnframedToolResults: replayPlan.preserveUnframedToolResults,
+    },
+  );
   const includeSystemPrompt = options?.includeSystemPrompt ?? true;
   if (includeSystemPrompt && context.systemPrompt) {
     messages.push(
@@ -456,12 +468,11 @@ export function convertResponsesMessages(
       ),
     );
   }
+  if (replayPlan.compaction) {
+    messages.push(replayPlan.compaction);
+  }
   let msgIndex = 0;
   for (const msg of transformedMessages) {
-    if (compactionPruner.shouldSkipMessage(msg)) {
-      msgIndex += 1;
-      continue;
-    }
     if (msg.role === "user") {
       if (typeof msg.content === "string") {
         messages.push(
@@ -487,18 +498,11 @@ export function convertResponsesMessages(
       }
     } else if (msg.role === "assistant") {
       const output: ResponseInput = [];
-      const assistantCompaction = msg === compaction?.owner ? compaction : undefined;
       let textFallbackOrdinal = 0;
       let previousReplayItemWasReasoning = false;
       const isDifferentModel =
         msg.model !== model.id && msg.provider === model.provider && msg.api === model.api;
-      for (const [contentIndex, block] of msg.content.entries()) {
-        if (compactionPruner.shouldSkipAssistantBlock(msg, contentIndex)) {
-          continue;
-        }
-        if (assistantCompaction && contentIndex === assistantCompaction.replayIndex) {
-          output.push(assistantCompaction.item);
-        }
+      for (const block of msg.content) {
         if (block.type === "thinking") {
           if (
             shouldReplayReasoningItems &&
@@ -563,7 +567,6 @@ export function convertResponsesMessages(
           output.push(messageItem as ResponseInputItem);
           previousReplayItemWasReasoning = false;
         } else if (block.type === "toolCall") {
-          compactionPruner.recordToolCall(block.id);
           const separatorIndex = block.id.indexOf("|");
           const callId = separatorIndex === -1 ? block.id : block.id.slice(0, separatorIndex);
           const itemIdRaw = separatorIndex === -1 ? undefined : block.id.slice(separatorIndex + 1);
@@ -584,9 +587,6 @@ export function convertResponsesMessages(
           previousReplayItemWasReasoning = false;
         }
       }
-      if (assistantCompaction && assistantCompaction.replayIndex >= msg.content.length) {
-        output.push(assistantCompaction.item);
-      }
       if (output.length > 0) {
         messages.push(...output);
       }
@@ -596,10 +596,6 @@ export function convertResponsesMessages(
       const hasText = sanitizedTextResult.trim().length > 0;
       const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
       const hasImages = msg.content.some(isImageWithMediaPayload);
-      if (!compactionPruner.shouldKeepToolResult(msg.toolCallId)) {
-        msgIndex += 1;
-        continue;
-      }
       const separatorIndex = msg.toolCallId.indexOf("|");
       const callId =
         separatorIndex === -1 ? msg.toolCallId : msg.toolCallId.slice(0, separatorIndex);

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -25,15 +25,13 @@ import {
   type FirstStreamEventInternalOptions,
   withFirstStreamEventTimeout,
 } from "../utils/stream-first-event-timeout.js";
+import { createCompactionTracker } from "./openai-responses-compaction-replay.js";
 import {
   OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY,
   type OpenAIResponsesReasoningReplayMetadata,
 } from "./openai-responses-contracts.js";
 import { normalizeResponsesFailedEvent, ResponsesStreamFailure } from "./openai-responses-debug.js";
-import {
-  createCompactionTracker,
-  encodeTextSignatureV1,
-} from "./openai-responses-replay-internal.js";
+import { encodeTextSignatureV1 } from "./openai-responses-replay-internal.js";
 import { adaptResponsesStream } from "./openai-responses-stream-observer-internal.js";
 import {
   appendResponsesPendingTextDelta,

--- a/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
@@ -24,14 +24,12 @@ import type {
   Usage,
 } from "../types.js";
 import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
+import { captureOpenAIResponsesCompaction } from "./openai-responses-compaction-replay.js";
 import {
   OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY,
   type OpenAIResponsesReasoningReplayMetadata,
 } from "./openai-responses-contracts.js";
-import {
-  captureOpenAIResponsesCompaction,
-  encodeTextSignatureV1,
-} from "./openai-responses-replay-internal.js";
+import { encodeTextSignatureV1 } from "./openai-responses-replay-internal.js";
 
 export type ResponsesEventSink = { push(event: AssistantMessageEvent): void };
 export type TextBlockReference = {

--- a/packages/ai/src/transports/openai-responses-transport.ts
+++ b/packages/ai/src/transports/openai-responses-transport.ts
@@ -6,6 +6,7 @@ import {
   createOpenAIResponsesClient,
   createOpenAIResponsesTransportStreamFn,
 } from "./openai-responses-client.js";
+import { buildOpenAIResponsesReasoningReplayMetadata } from "./openai-responses-compaction-replay.js";
 import {
   buildResponsesFailedNoDetailsObservation,
   normalizeResponsesFailedEvent,
@@ -20,7 +21,6 @@ import {
   sanitizeOpenAICodexResponsesParams,
 } from "./openai-responses-params-internal.js";
 import {
-  buildOpenAIResponsesReasoningReplayMetadata,
   createResponsesStreamWithEncryptedContentRetry,
   isInvalidEncryptedContentError,
   prepareOpenAIResponsesReasoningItemForReplay,

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -298,6 +298,9 @@ type ErroredAssistantResultPolicy = "preserve" | "drop";
 type ToolUseResultPairingOptions = {
   erroredAssistantResultPolicy?: ErroredAssistantResultPolicy;
   missingToolResultText?: string;
+  // A valid Responses checkpoint may split a call from its later output.
+  // Only that replay owner may retain results that normal repair treats as orphaned.
+  preserveUnframedToolResults?: boolean;
 };
 
 export function stripToolResultDetails(messages: AgentMessage[]): AgentMessage[] {
@@ -586,7 +589,11 @@ type ToolUseFrame = {
   failed: boolean;
 };
 
-function buildToolUseFrames(messages: AgentMessage[], onDuplicate: () => void): ToolUseFrame[] {
+function buildToolUseFrames(
+  messages: AgentMessage[],
+  onDuplicate: () => void,
+  preserveUnframed: boolean,
+): ToolUseFrame[] {
   const frameStartIndexes: number[] = [];
   for (const [index, message] of messages.entries()) {
     if (message && typeof message === "object" && assistantHasToolCalls(message)) {
@@ -634,6 +641,9 @@ function buildToolUseFrames(messages: AgentMessage[], onDuplicate: () => void): 
       const sameIdGroup = id ? occurrencesById.get(id) : undefined;
       if (!id || !sameIdGroup) {
         unclaimedResults.push({ result: legacyNormalized, id: id ?? undefined });
+        if (preserveUnframed) {
+          remainder.push(legacyNormalized);
+        }
         continue;
       }
 
@@ -693,9 +703,8 @@ export function repairToolUseResultPairing(
   const added: Array<Extract<AgentMessage, { role: "toolResult" }>> = [];
   let droppedDuplicateCount = 0;
   let droppedOrphanCount = 0;
-  const frames = buildToolUseFrames(messages, () => {
-    droppedDuplicateCount += 1;
-  });
+  const preserveUnframed = options?.preserveUnframedToolResults === true;
+  const frames = buildToolUseFrames(messages, () => (droppedDuplicateCount += 1), preserveUnframed);
 
   // Cross-frame recovery is intentionally conservative. A displaced result is moved only
   // when exactly one still-unresolved call occurrence can own it; repeated ids otherwise
@@ -714,30 +723,25 @@ export function repairToolUseResultPairing(
     }
 
     for (const record of frame.unclaimedResults) {
-      if (!record.id) {
-        droppedOrphanCount += 1;
-        continue;
-      }
-      const candidates = (unresolvedById.get(record.id) ?? []).filter(
-        (candidate) =>
-          !candidate.result ||
-          (isSyntheticMissingToolResult(candidate.result) &&
-            !isSyntheticMissingToolResult(record.result)),
-      );
+      const candidates = record.id
+        ? (unresolvedById.get(record.id) ?? []).filter(
+            (candidate) =>
+              !candidate.result ||
+              (isSyntheticMissingToolResult(candidate.result) &&
+                !isSyntheticMissingToolResult(record.result)),
+          )
+        : [];
       if (candidates.length !== 1) {
-        droppedOrphanCount += 1;
+        droppedOrphanCount += preserveUnframed ? 0 : 1;
         continue;
       }
 
-      const [candidate] = candidates;
-      if (!candidate) {
-        droppedOrphanCount += 1;
-        continue;
-      }
-      if (candidate.result) {
-        droppedDuplicateCount += 1;
-      }
+      const candidate = candidates[0]!;
+      droppedDuplicateCount += candidate.result ? 1 : 0;
       candidate.result = normalizeToolResultName(record.result, candidate.name);
+      if (preserveUnframed) {
+        frame.remainder = frame.remainder.filter((message) => message !== record.result);
+      }
     }
   }
 
@@ -749,7 +753,7 @@ export function repairToolUseResultPairing(
       if (!message || typeof message !== "object") {
         continue;
       }
-      if (message.role === "toolResult") {
+      if (message.role === "toolResult" && !preserveUnframed) {
         droppedOrphanCount += 1;
         continue;
       }

--- a/src/agents/transport-message-transform.test.ts
+++ b/src/agents/transport-message-transform.test.ts
@@ -55,6 +55,60 @@ function assistantToolCall(
 }
 
 describe("transformTransportMessages synthetic tool-result policy", () => {
+  it("preserves unframed tool results only for a selected compaction replay window", () => {
+    const model = makeModel("openai-responses", "openai", "gpt-5.4");
+    const messages = [
+      assistantToolCall("call_early"),
+      { role: "user", content: "continue", timestamp: Date.now() },
+      assistantToolCall("call_after"),
+      {
+        role: "toolResult",
+        toolCallId: "call_early",
+        toolName: "read",
+        content: [{ type: "text", text: "displaced retained result" }],
+        isError: false,
+        timestamp: Date.now(),
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_before",
+        toolName: "read",
+        content: [{ type: "text", text: "real result after compaction" }],
+        isError: false,
+        timestamp: Date.now(),
+      },
+    ] as Context["messages"];
+
+    const normal = transformTransportMessages(messages, model);
+    const compactionReplay = transformTransportMessages(messages, model, undefined, {
+      preserveUnframedToolResults: true,
+    });
+
+    expect(normal.filter((message) => message.role === "toolResult")).toMatchObject([
+      {
+        toolCallId: "call_early",
+        content: [{ type: "text", text: "displaced retained result" }],
+      },
+      { toolCallId: "call_after", content: [{ type: "text", text: "aborted" }] },
+    ]);
+    expect(compactionReplay.filter((message) => message.role === "toolResult")).toMatchObject([
+      {
+        toolCallId: "call_early",
+        content: [{ type: "text", text: "displaced retained result" }],
+      },
+      { toolCallId: "call_after", content: [{ type: "text", text: "aborted" }] },
+      {
+        toolCallId: "call_before",
+        content: [{ type: "text", text: "real result after compaction" }],
+      },
+    ]);
+    expect(
+      compactionReplay.filter(
+        (message) => message.role === "toolResult" && message.toolCallId === "call_early",
+      ),
+    ).toHaveLength(1);
+  });
+
   it.each([
     {
       source: { provider: "anthropic", model: "claude-fable-5" },

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -71,6 +71,7 @@ export function transformTransportMessages(
   options?: {
     normalizeSameModelToolCallIds?: boolean;
     preserveCrossModelToolCallThoughtSignature?: boolean;
+    preserveUnframedToolResults?: boolean;
   },
 ): Context["messages"] {
   const allowSyntheticToolResults = defaultAllowSyntheticToolResults(model.api);
@@ -189,5 +190,6 @@ export function transformTransportMessages(
   return repairToolUseResultPairing(replayable, {
     erroredAssistantResultPolicy: "drop",
     missingToolResultText: syntheticToolResultText,
+    preserveUnframedToolResults: options?.preserveUnframedToolResults,
   }).messages as Context["messages"];
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes two confirmed failures from #120457 in long embedded Responses sessions. First, a `function_call_output` arriving after compaction was dropped when its matching `function_call` lived inside the compacted prefix. Second, when a compaction checkpoint was rejected, the retry started from an already-pruned suffix, allowing a plausible but context-blind answer to be committed.

## Why This Change Was Made

The replay plan now keeps the raw transcript immutable before any projection or pruning. The normal request sends the compaction checkpoint plus its chronological suffix; rejection lazily builds a fallback from the untouched full history instead of reusing the pruned request. Within the narrow compaction window, unframed function results are preserved even when their calls moved into the compacted prefix, while the existing pairing policy remains in place outside that window.

The same replay plan is carried through the SDK, SSE, WebSocket, and Azure success boundaries. This changes no configuration, protocol, or storage schema.

Related: #120457

## User Impact

Long embedded Responses sessions retain chronological tool outputs and recover rejected checkpoints with full conversation history instead of silently losing context.

## Evidence

- `node scripts/run-vitest.mjs packages/ai/src/transports/openai-responses-compaction-replay.test.ts packages/ai/src/transports/openai-responses-prompt-observer.test.ts src/agents/transport-message-transform.test.ts` — 3 files passed across 2 shards, 78 tests passed (31 + 47).
- `node scripts/run-vitest.mjs packages/ai/src/providers/openai-chatgpt-responses.encrypted-retry.test.ts packages/ai/src/providers/openai-responses-shared.test.ts packages/ai/src/providers/azure-openai-responses.test.ts` — 3 files passed in 1 shard, 95 tests passed.
- `git diff --check origin/main...HEAD` — passed.
- `node_modules/.bin/oxfmt --check <all 20 touched files>` — passed; all matched files use the correct format.
- Autoreview was clean at 0.97 before the rebase. A fresh post-rebase review remains a pre-land gate.
- Production LOC: +245/-197 (net +48) across 15 files. Tests: +261/-60 (net +201) across 5 files.
- OpenAI compaction contract: https://developers.openai.com/api/docs/guides/compaction
