### PR TITLE
fix(cron): resolve timer scheduling infinite loops and dropped timeouts

### DIFF
--- a/src/cron/service/timer-job-runner.ts
+++ b/src/cron/service/timer-job-runner.ts
@@ -258,7 +258,20 @@ export async function executeJobCoreWithTimeout(
           );
         }
       });
-      const first = await Promise.race([runPromise, operatorCancellationPromise]);
+      const first = await Promise.race([
+        runPromise.catch((err: unknown): CronCoreRunOutcome => {
+          const error = formatErrorMessage(err);
+          return {
+            status: "error",
+            error,
+            ...cronRunAttributionFromExecution(activeExecution),
+            diagnostics: createCronRunDiagnosticsFromError("cron-setup", error, {
+              nowMs: state.deps.nowMs,
+            }),
+          };
+        }),
+        operatorCancellationPromise,
+      ]);
       if (first !== operatorCancellationMarker) {
         return first;
       }
@@ -342,7 +355,21 @@ export async function executeJobCoreWithTimeout(
       }
     });
     try {
-      const first = await Promise.race([runPromise, timeoutPromise, operatorCancellationPromise]);
+      const first = await Promise.race([
+        runPromise.catch((err: unknown): CronCoreRunOutcome => {
+          const error = formatErrorMessage(err);
+          return {
+            status: "error",
+            error,
+            ...cronRunAttributionFromExecution(watchdog.activeExecution()),
+            diagnostics: createCronRunDiagnosticsFromError("cron-setup", error, {
+              nowMs: state.deps.nowMs,
+            }),
+          };
+        }),
+        timeoutPromise,
+        operatorCancellationPromise,
+      ]);
       if (first === operatorCancellationMarker) {
         const settled = resolveInterruptedRunProgress({
           progress,

--- a/src/cron/service/timer-scheduler.ts
+++ b/src/cron/service/timer-scheduler.ts
@@ -481,32 +481,14 @@ async function onAdmittedTimer(state: CronServiceState) {
                 releaseQueuedCronRun(state, due.id, due.reservationIdentity);
                 throw error;
               }
-              if (!result.isolatedAgentSetupTimeout) {
-                // Drain finished state independently: a slow sibling must not
-                // strand outcomes, and store I/O must not own execution slots.
-                completedOutcomeDrain.enqueue(result);
-                return pMapSkip;
-              }
-              let finalizedResults: TimedCronRunOutcome[];
-              try {
-                finalizedResults = await finalizeCompletedCronRunOutcomes(state, [result], {
-                  clearOnFailure: false,
-                });
-              } catch {
-                return result;
-              }
-              if (!hasSetupTimeoutRecoveryHandler || finalizedResults.length === 0) {
-                return pMapSkip;
-              }
-              if (!setupTimeoutNotified) {
-                setupTimeoutNotified = true;
+              completedOutcomeDrain.enqueue(result);
+              if (result.isolatedAgentSetupTimeout && hasSetupTimeoutRecoveryHandler) {
                 stopAdmittingDueJobs = true;
                 try {
                   await releaseUnclaimedDueJobReservationsWithRetry();
                 } catch (err) {
                   reservationReleaseError = err;
                 }
-                maybeNotifyIsolatedAgentSetupTimeout(state, result);
               }
               return pMapSkip;
             });
@@ -541,8 +523,9 @@ async function onAdmittedTimer(state: CronServiceState) {
       throw error instanceof AggregateError && error.errors.length > 0 ? error.errors[0] : error;
     }
     let postBatchError = reservationReleaseError;
+    let flushedOutcomes: TimedCronRunOutcome[] = [];
     try {
-      await completedOutcomeDrain.flush();
+      flushedOutcomes = await completedOutcomeDrain.flush();
     } catch (error) {
       // Finalization errors still need to release every unclaimed durable
       // reservation before the failed timer batch can exit.
@@ -557,9 +540,8 @@ async function onAdmittedTimer(state: CronServiceState) {
       }
     }
 
-    if (completedResults.length > 0) {
-      const finalizedResults = await finalizeCompletedCronRunOutcomes(state, completedResults);
-      for (const result of finalizedResults) {
+    if (flushedOutcomes.length > 0) {
+      for (const result of flushedOutcomes) {
         if (
           !setupTimeoutNotified &&
           result.isolatedAgentSetupTimeout &&


### PR DESCRIPTION
This PR fixes two critical stability bugs in the cron timer infrastructure:

1. **Unhandled Rejections in timer-job-runner.ts**: `executeJobCoreWithTimeout` now safely catches `runPromise` rejections. Previously, if the run promise rejected *after* a timeout or cancellation resolved the `Promise.race`, the unhandled rejection could destabilize the Node process and cause infinite retry loops.
2. **Silent Drops in timer-scheduler.ts**: Fixed an issue where `isolatedAgentSetupTimeout` results were bypassing the shared `completedOutcomeDrain`. Synchronous finalization failures would cause these timeouts to drop silently, stranding jobs in an active state.

All cron unit tests pass. 

Note: This PR was developed with the assistance of an AI agent, following AGENTS.md compliance guidelines.