### PR TITLE
fix(ci): stabilize Control UI history and reconnect checks

### DIFF
--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -505,6 +505,11 @@ suite.define(() => {
     await expect
       .poll(() => thread.evaluate((element) => element.scrollHeight > element.clientHeight + 100))
       .toBe(true);
+    await thread.evaluate((element) => {
+      element.scrollTop = element.scrollHeight;
+      element.dispatchEvent(new Event("scroll"));
+    });
+    await expect.poll(() => thread.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
     const initialReadCount = (await gateway.getRequests("sessions.catalog.read")).length;
     await gateway.deferNext("sessions.catalog.read");
     await thread.evaluate((element) => {

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -1,5 +1,9 @@
 import path from "node:path";
 import { expect, it } from "vitest";
+import {
+  waitForControlUiGatewayReady,
+  waitForControlUiGatewayReconnecting,
+} from "../test-helpers/control-ui-e2e-readiness.ts";
 import { expectRequestCountStable } from "./chat-flow.test-support.ts";
 import {
   actionOpacity,
@@ -434,12 +438,24 @@ suite.define(() => {
       await expect.poll(() => sidebarRows.count()).toBe(3);
       const initialListCount = (await gateway.getRequests("sessions.list")).length;
 
-      await gateway.deferNext("sessions.list");
-      await gateway.closeLatest(1006, "disconnect proof");
-      await sidebarRow.waitFor({ state: "visible" });
+      const socketsBefore = await gateway.getSocketCount();
+      await gateway.setOnline(false);
+      await waitForControlUiGatewayReconnecting(page);
+      await expect.poll(() => sidebarRow.textContent()).toContain("Disconnect proof");
+      await expect.poll(() => sidebarRows.count()).toBe(3);
+      for (const otherKey of otherSessionKeys) {
+        await page
+          .locator(`.sidebar-recent-session[data-session-key="${otherKey}"]`)
+          .waitFor({ state: "visible" });
+      }
       await captureUiProof(page, "sidebar-sessions-during-reconnect.png");
 
-      await expect.poll(() => gateway.getSocketCount(), { timeout: 15_000 }).toBeGreaterThan(1);
+      await expect
+        .poll(() => gateway.getSocketCount(), { timeout: 15_000 })
+        .toBe(socketsBefore + 1);
+      await gateway.deferNext("sessions.list");
+      await gateway.setOnline(true);
+      await waitForControlUiGatewayReady(page);
       await expect
         .poll(async () => (await gateway.getRequests("sessions.list")).length, { timeout: 15_000 })
         .toBeGreaterThan(initialListCount);
@@ -501,10 +517,18 @@ suite.define(() => {
       const initialObserverCount = (await gateway.getRequests("sessions.subscribe")).length;
       const initialListCount = (await gateway.getRequests("sessions.list")).length;
 
+      const socketsBefore = await gateway.getSocketCount();
+      await gateway.setOnline(false);
+      await waitForControlUiGatewayReconnecting(page);
+      await expect.poll(() => selectedRow.getAttribute("class")).toContain("--active");
+      expect(new URL(page.url()).pathname).toBe(controlUiSessionPath(selectedKey));
+      await expect
+        .poll(() => gateway.getSocketCount(), { timeout: 15_000 })
+        .toBe(socketsBefore + 1);
       await gateway.deferNext("sessions.subscribe");
       await gateway.deferNext("sessions.list");
-      await gateway.closeLatest(1006, "session route reconnect");
-      await expect.poll(() => gateway.getSocketCount(), { timeout: 15_000 }).toBeGreaterThan(1);
+      await gateway.setOnline(true);
+      await waitForControlUiGatewayReady(page);
       await expect
         .poll(async () => (await gateway.getRequests("sessions.subscribe")).length, {
           timeout: 15_000,


### PR DESCRIPTION
## What Problem This Solves

Resolves two race-prone Control UI end-to-end checks that failed the main CI run at https://github.com/openclaw/openclaw/actions/runs/31279593984 even though the exercised product behavior was correct. The failures affected external-session history autoload and same-client session-list reconnect coverage.

## Why This Change Was Made

The history scenario jumped directly to the top before recording a nonzero transcript position, so the UI did not always observe upward scroll intent. It now establishes and verifies the bottom position before triggering the older-page read, matching the adjacent native-history scenario.

The reconnect scenarios armed global one-shot Gateway deferrals while the old socket could still issue requests, allowing the wrong socket generation to consume the deferral and later drop the resolved response. They now use the existing offline gate: retire the old socket, wait for visible reconnect state and the replacement socket, arm deferrals while no socket can handshake, then resume online and verify the refreshed generation.

This is the test-owner fix: it changes no production behavior, retries, or timeouts. Production LOC: +0/-0. Tests: +35/-6.

Provenance: the external-history autoload scenario was introduced by #105209 on 2026-07-12 (code/PR author and merger @steipete). The reconnect coverage was split into its current file by #114889 and expanded by #117103; #120501 most recently changed the same-client deferral ordering, but the one-shot deferral still was not generation-bound (all code/PR author and merger @steipete).

## User Impact

No user-visible behavior changes. Maintainers get deterministic Control UI CI coverage for the existing history and reconnect contracts.

## Evidence

- Original failure: https://github.com/openclaw/openclaw/actions/runs/31279593984
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31281269988
  - Full touched files: 2 files, 16 tests passed.
  - Five bounded stress iterations of the three repaired scenarios: 15/15 passed.
- `pnpm format:check` on both files: passed.
- Type-aware `oxlint` on both files: 0 warnings, 0 errors.
- `pnpm check:changed`: passed (core test types, changed-file lint, guards, dead-code, i18n verification).
- Autoreview: clean, no accepted/actionable findings.
