### PR TITLE
fix(release): accept stale historical record counts

### DIFF
--- a/scripts/release-candidate-checklist.mjs
+++ b/scripts/release-candidate-checklist.mjs
@@ -752,10 +752,14 @@ function candidateContributionRecordPullRequests(
     Number(match.groups.number),
   );
   const rows = new Set(rowNumbers);
-  const provenance = parseContributionRecordProvenance(record);
+  if (rows.size !== rowNumbers.length) {
+    const duplicate = rowNumbers.find((number, index) => rowNumbers.indexOf(number) !== index);
+    throw new Error(`${label} contains duplicate contribution record PR #${duplicate}`);
+  }
   if (!requireExactProvenance) {
     return rows;
   }
+  const provenance = parseContributionRecordProvenance(record);
   if (!provenance || !/^[0-9a-f]{40}$/u.test(provenance.target)) {
     throw new Error(`${label} is missing exact complete contribution record provenance`);
   }

--- a/test/scripts/release-candidate-checklist.test.ts
+++ b/test/scripts/release-candidate-checklist.test.ts
@@ -410,7 +410,7 @@ describe("release candidate checklist", () => {
       "",
       "### Complete contribution record",
       "",
-      "This audited record covers the complete base..HEAD history: 1 merged PR.",
+      "This audited record covers the complete base..HEAD history: 0 merged PRs.",
       "",
       "#### Pull requests",
       "",
@@ -418,6 +418,27 @@ describe("release candidate checklist", () => {
     ].join("\n");
 
     expect([...candidateCumulativeShippedPullRequests(changelog, "test baseline")]).toEqual([2]);
+  });
+
+  it("rejects duplicate historical contribution record rows without exact provenance", () => {
+    const changelog = [
+      "# Changelog",
+      "",
+      "## 2026.6.11",
+      "",
+      "### Complete contribution record",
+      "",
+      "This audited record covers the complete base..HEAD history: 1 merged PR.",
+      "",
+      "#### Pull requests",
+      "",
+      "- **PR #2** fix: shipped.",
+      "- **PR #2** fix: duplicate.",
+    ].join("\n");
+
+    expect(() => candidateCumulativeShippedPullRequests(changelog, "test baseline")).toThrow(
+      "test baseline section 2026.6.11 contains duplicate contribution record PR #2",
+    );
   });
 
   it("validates cumulative shipped baseline exclusion metadata", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where beta release candidate validation would reject an immutable shipped changelog when an older contribution-record section had a stale declared count, even though the historical PR rows were unique and usable for cumulative baseline exclusion.

## Why This Change Was Made

Historical cumulative scans now parse numbered PR rows and reject duplicates directly, then skip shared provenance/count parsing. Exact candidate and selected-baseline sections still use the strict provenance parser and count validation.

No changelog, product runtime, release branch, or frozen product SHA changes are included.

## User Impact

Release operators can validate candidates against immutable historical beta changelogs without weakening exact provenance checks for the candidate being published.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/release-candidate-checklist.test.ts test/scripts/render-github-release-notes.test.ts` (78 tests passed)
- Direct `v2026.7.2-beta.7` cumulative probe: 6,556 unique PRs
- `node scripts/check-changed.mjs -- scripts/release-candidate-checklist.mjs test/scripts/release-candidate-checklist.test.ts`
  - Delegated Testbox command returned `exitCode: 0` and `runStatus: succeeded`
  - The backing Actions run was cancelled by one-shot lease teardown after command completion: https://github.com/openclaw/openclaw/actions/runs/31282450587
- `git diff --check`

Root cause: the historical opt-out was evaluated after strict shared provenance parsing.

Architectural owner: release candidate checklist historical-baseline aggregation.

Canonical fix: duplicate validation remains mandatory for all records; exact provenance/count validation runs only for exact-mode records.

Production/tooling LOC: +5 / -1. Tests: +22 / -1.
