### PR TITLE
fix(imessage): preserve native attachment message identities

### DIFF
--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -1755,7 +1755,7 @@ describe("sendMessageIMessage receipts", () => {
     const client = createClient({ message_id: 12345 });
     const runCliJson = vi
       .fn()
-      .mockResolvedValueOnce({ messageId: "p:0/media-guid", transferGuid: "transfer-1" });
+      .mockResolvedValueOnce({ messageGuid: "p:0/media-guid", transferGuid: "transfer-1" });
 
     const result = await sendMessageIMessage("chat_guid:chat-1", "", {
       config: IMESSAGE_TEST_CFG,
@@ -1765,10 +1765,20 @@ describe("sendMessageIMessage receipts", () => {
       runCliJson,
     });
     expect(result.messageId).toBe("p:0/media-guid");
+    expect(result.guid).toBe("p:0/media-guid");
     expect(result.echoText).toBeUndefined();
     expect(result.echoMedia).toEqual({ contentType: "image/png", kind: "image" });
     expect(result.receipt.primaryPlatformMessageId).toBe("p:0/media-guid");
     expect(result.receipt.platformMessageIds).toEqual(["p:0/media-guid"]);
+    expect(findLatestIMessageEntryForChat({ accountId: "default", chatGuid: "chat-1" })).toEqual(
+      expect.objectContaining({ messageId: "p:0/media-guid", isFromMe: true }),
+    );
+    expect(
+      hasPersistedIMessageEcho({
+        scope: "default:chat_guid:chat-1",
+        messageId: "p:0/media-guid",
+      }),
+    ).toBe(true);
     expect(client["request"]).not.toHaveBeenCalled();
     expect(runCliJson.mock.calls).toEqual([
       [["send-attachment", "--chat", "chat-1", "--file", "/tmp/image.png", "--transport", "auto"]],
@@ -1795,6 +1805,71 @@ describe("sendMessageIMessage receipts", () => {
       },
     ]);
     expect(result.receipt.sentAt).toBeGreaterThan(0);
+  });
+
+  it.each(["ok", "unknown"])(
+    "does not cache or expose attachment placeholder %s as a message GUID",
+    async (messageId) => {
+      const client = createClient({ guid: "should-not-send" });
+      const runCliJson = vi.fn().mockResolvedValueOnce({ success: true, messageId });
+
+      const result = await sendMessageIMessage("chat_guid:chat-1", "", {
+        config: IMESSAGE_TEST_CFG,
+        client,
+        mediaUrl: "/tmp/image.png",
+        resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
+        runCliJson,
+      });
+
+      expect(result.messageId).toBe(messageId);
+      expect(result.guid).toBeUndefined();
+      expect(result.receipt.platformMessageIds).toEqual([]);
+      expect(
+        findLatestIMessageEntryForChat({ accountId: "default", chatGuid: "chat-1" }),
+      ).toBeUndefined();
+      expect(getClientMocks(client).request).not.toHaveBeenCalled();
+    },
+  );
+
+  it("preserves successful AppleScript attachment sends without a message GUID", async () => {
+    const client = createClient({ guid: "should-not-send" });
+    const runCliJson = vi.fn().mockResolvedValueOnce({ success: true, transport: "applescript" });
+
+    const result = await sendMessageIMessage("chat_guid:chat-1", "", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      mediaUrl: "/tmp/image.png",
+      resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
+      runCliJson,
+    });
+
+    expect(result.messageId).toBe("ok");
+    expect(result.guid).toBeUndefined();
+    expect(result.receipt.platformMessageIds).toEqual([]);
+    expect(
+      findLatestIMessageEntryForChat({ accountId: "default", chatGuid: "chat-1" }),
+    ).toBeUndefined();
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { messageId: "ok", messageGuid: "p:0/native-guid" },
+    { message_id: 12345, messageGuid: "p:0/native-guid" },
+  ])("prefers the native attachment GUID over another bridge identifier", async (response) => {
+    const client = createClient({ guid: "should-not-send" });
+    const runCliJson = vi.fn().mockResolvedValueOnce(response);
+
+    const result = await sendMessageIMessage("chat_guid:chat-1", "", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      mediaUrl: "/tmp/image.png",
+      resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
+      runCliJson,
+    });
+
+    expect(result.messageId).toBe("p:0/native-guid");
+    expect(result.guid).toBe("p:0/native-guid");
+    expect(result.receipt.platformMessageIds).toEqual(["p:0/native-guid"]);
   });
 
   it.each([
@@ -1864,7 +1939,7 @@ describe("sendMessageIMessage receipts", () => {
 
   it("sends audioAsVoice media through send-attachment audio transport", async () => {
     const client = createClient({ message_id: 12345 });
-    const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/voice-guid" });
+    const runCliJson = vi.fn().mockResolvedValueOnce({ messageGuid: "p:0/voice-guid" });
 
     const result = await sendMessageIMessage("chat_guid:chat-1", "", {
       config: IMESSAGE_TEST_CFG,
@@ -1876,6 +1951,7 @@ describe("sendMessageIMessage receipts", () => {
     });
 
     expect(result.messageId).toBe("p:0/voice-guid");
+    expect(result.guid).toBe("p:0/voice-guid");
     expect(runCliJson.mock.calls).toEqual([
       [
         [
@@ -1890,6 +1966,7 @@ describe("sendMessageIMessage receipts", () => {
         ],
       ],
     ]);
+    expect(result.receipt.platformMessageIds).toEqual(["p:0/voice-guid"]);
     expect(result.receipt.parts.map((part) => part.kind)).toEqual(["voice"]);
     expect(client["request"]).not.toHaveBeenCalled();
   });
@@ -2058,7 +2135,7 @@ describe("sendMessageIMessage receipts", () => {
     const runCliJson = vi
       .fn()
       .mockResolvedValueOnce({ guid: "any;+;group-guid" })
-      .mockResolvedValueOnce({ messageId: "p:0/media-guid" });
+      .mockResolvedValueOnce({ messageGuid: "p:0/media-guid" });
 
     const result = await sendMessageIMessage("chat_id:42", "", {
       config: IMESSAGE_TEST_CFG,
@@ -2171,7 +2248,7 @@ describe("sendMessageIMessage receipts", () => {
 
   it("routes DM handle media-only sends through send-attachment", async () => {
     const client = createClient({ message_id: 12345 });
-    const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/dm-media-guid" });
+    const runCliJson = vi.fn().mockResolvedValueOnce({ messageGuid: "p:0/dm-media-guid" });
 
     const result = await sendMessageIMessage("+15550004567", "", {
       config: IMESSAGE_TEST_CFG,
@@ -2351,7 +2428,8 @@ describe("sendMessageIMessage receipts", () => {
 
   it("sends DM handle media captions as attachment plus follow-up text", async () => {
     const client = createClient({ guid: "p:0/caption-guid" });
-    const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/dm-media-guid" });
+    const runCliJson = vi.fn().mockResolvedValueOnce({ messageGuid: "p:0/dm-media-guid" });
+    const onDeliveryResult = vi.fn();
 
     const result = await sendMessageIMessage("imessage:+15550004567", "caption", {
       config: IMESSAGE_TEST_CFG,
@@ -2359,6 +2437,7 @@ describe("sendMessageIMessage receipts", () => {
       mediaUrl: "/tmp/image.png",
       resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
       runCliJson,
+      onDeliveryResult,
     });
 
     expect(runCliJson).toHaveBeenCalledTimes(1);
@@ -2383,12 +2462,25 @@ describe("sendMessageIMessage receipts", () => {
     expect(result.sentText).toBe("caption");
     expect(result.receipt.platformMessageIds).toEqual(["p:0/dm-media-guid", "p:0/caption-guid"]);
     expect(result.receipt.parts.map((part) => part.kind)).toEqual(["media", "text"]);
+    expect(onDeliveryResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "p:0/dm-media-guid",
+        messageIds: ["p:0/dm-media-guid"],
+        receipt: expect.objectContaining({ platformMessageIds: ["p:0/dm-media-guid"] }),
+      }),
+    );
+    expect(
+      hasPersistedIMessageEcho({
+        scope: "default:imessage:+15550004567",
+        messageId: "p:0/dm-media-guid",
+      }),
+    ).toBe(true);
   });
 
   it("does not persist caption text when the caption follow-up send fails", async () => {
     const captionError = new Error("caption failed");
     const client = createRejectingClient(captionError);
-    const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/dm-media-guid" });
+    const runCliJson = vi.fn().mockResolvedValueOnce({ messageGuid: "p:0/dm-media-guid" });
     const onDeliveryResult = vi.fn();
 
     let observedError: unknown;
@@ -2660,7 +2752,27 @@ describe("sendMessageIMessage receipts", () => {
       dbPath: "/Users/me/Library/Messages/chat.db",
       messageId: "12345",
     });
+    expect(findLatestIMessageEntryForChat({ accountId: "default", chatId: 42 })).toEqual(
+      expect.objectContaining({ messageId: "12345", isFromMe: true }),
+    );
   });
+
+  it.each(["ok", "unknown"])(
+    "does not cache or expose RPC placeholder %s as a message GUID",
+    async (messageId) => {
+      const client = createClient({ messageId, status: "sent" });
+
+      const result = await sendMessageIMessage("chat_id:42", "hello", {
+        config: IMESSAGE_TEST_CFG,
+        client,
+      });
+
+      expect(result.messageId).toBe(messageId);
+      expect(result.guid).toBeUndefined();
+      expect(result.receipt.platformMessageIds).toEqual([]);
+      expect(findLatestIMessageEntryForChat({ accountId: "default", chatId: 42 })).toBeUndefined();
+    },
+  );
 
   it("does not resolve chat.db GUIDs when the bridge already returned a GUID", async () => {
     const client = createClient({ guid: "p:0/native-guid" });
@@ -2943,8 +3055,16 @@ describe("sendMessageIMessage receipts", () => {
     expect(resolveSentMessageGuidImpl).toHaveBeenCalled();
   });
 
-  it("recovers a GUID for approval prompts when rpc send returns only sent status", async () => {
-    const client = createClient({ status: "sent" });
+  it.each([
+    { response: { status: "sent" }, messageId: "ok", label: "sent status" },
+    { response: { messageId: "ok", status: "sent" }, messageId: "ok", label: "ok placeholder" },
+    {
+      response: { messageId: "unknown", status: "sent" },
+      messageId: "unknown",
+      label: "unknown placeholder",
+    },
+  ])("recovers approval tapback GUIDs when RPC returns $label", async ({ response, messageId }) => {
+    const client = createClient(response);
     const resolveSentMessageGuidImpl = vi.fn(async () => "p:0/recovered-guid");
     const approvalText = createApprovalText();
 
@@ -2956,7 +3076,7 @@ describe("sendMessageIMessage receipts", () => {
       resolveSentMessageGuidImpl,
     });
 
-    expect(result.messageId).toBe("ok");
+    expect(result.messageId).toBe(messageId);
     expect(result.guid).toBe("p:0/recovered-guid");
     await expect(
       resolveIMessageApprovalReactionTargetWithPersistence({

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -141,6 +141,7 @@ function resolveMessageId(result: Record<string, unknown> | null | undefined): s
     return null;
   }
   const raw =
+    (typeof result.messageGuid === "string" && result.messageGuid.trim()) ||
     (typeof result.messageId === "string" && result.messageId.trim()) ||
     (typeof result.message_id === "string" && result.message_id.trim()) ||
     (typeof result.id === "string" && result.id.trim()) ||
@@ -161,17 +162,10 @@ function resolveOutboundMessageGuid(
   if (!result) {
     return null;
   }
-  const candidates = [result.guid, result.messageId, result.message_id, result.id];
-  for (const value of candidates) {
-    if (typeof value !== "string") {
-      continue;
-    }
-    const trimmed = value.trim();
-    // Reject all-digit strings: they came from numeric ROWIDs coerced to
-    // strings (e.g. "12345"), not real GUIDs (which look like
-    // "p:0/ABCD-EFGH-..." or contain non-digit characters).
-    if (trimmed && !/^\d+$/.test(trimmed)) {
-      return trimmed;
+  for (const key of ["messageGuid", "guid", "messageId", "message_id", "id"]) {
+    const guid = normalizeResolvedMessageGuid(result[key]);
+    if (guid) {
+      return guid;
     }
   }
   return null;
@@ -196,7 +190,8 @@ function normalizeResolvedMessageGuid(value: unknown): string | null {
     return null;
   }
   const trimmed = value.trim();
-  return trimmed && !isNumericMessageRowId(trimmed) ? trimmed : null;
+  // Status placeholders and numeric ROWIDs cannot match inbound tapback GUIDs.
+  return isConcreteIMessageMessageId(trimmed) && !isNumericMessageRowId(trimmed) ? trimmed : null;
 }
 
 function resolveMessageGuidFromChatDb(params: {
@@ -416,18 +411,17 @@ function createIMessageSendReceipt(params: {
   replyToId?: string;
 }): MessageReceipt {
   const messageId = params.messageId.trim();
-  const results: MessageReceiptSourceResult[] =
-    messageId && messageId !== "unknown" && messageId !== "ok"
-      ? [
-          {
-            channel: "imessage",
-            messageId,
-            meta: {
-              targetKind: params.target.kind,
-            },
+  const results: MessageReceiptSourceResult[] = isConcreteIMessageMessageId(messageId)
+    ? [
+        {
+          channel: "imessage",
+          messageId,
+          meta: {
+            targetKind: params.target.kind,
           },
-        ]
-      : [];
+        },
+      ]
+    : [];
   if (results[0]) {
     if (params.target.kind === "chat_id") {
       results[0].chatId = String(params.target.chatId);
@@ -693,7 +687,7 @@ async function trySendAttachmentForTarget(params: {
       messageId: resolvedId ?? undefined,
     });
   }
-  if (resolvedId) {
+  if (resolvedId && isConcreteIMessageMessageId(resolvedId)) {
     rememberIMessageReplyCache({
       accountId: params.accountId,
       messageId: resolvedId,
@@ -1063,7 +1057,7 @@ export async function sendMessageIMessage(
       resultService(result.service) ??
       resultChatGuidService(providerChatGuid) ??
       (service === "imessage" || service === "sms" ? service : undefined);
-    if (resolvedId) {
+    if (resolvedId && isConcreteIMessageMessageId(resolvedId)) {
       const chatContext = chatContextFromIMessageTarget(target, confirmedService ?? service);
       rememberIMessageReplyCache({
         accountId: account.accountId,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where iMessage attachments, voice notes, and approval reactions silently lost their actual message identity, leaving delivery receipts, replies, and tapback approvals broken.

## Why This Change Was Made

The native attachment bridge returns its real message identifier under its documented camel-case field, while the iMessage sender looked only for unrelated aliases and sometimes accepted placeholder success strings as actual identifiers. Normalize the native bridge response once at the sender ownership boundary, prefer genuine identifiers, and reject placeholders while preserving ordinary numeric identifiers and existing no-identifier behavior.

## User Impact

iMessage attachments and voice messages retain their genuine delivery identity. Caption and reply ownership stays attached to the correct message, and reaction-based approvals recover the actual message instead of silently binding to a success placeholder.

## Evidence

- Independently inspected the released native bridge implementation and the existing iMessage sender, approval, reply, and attachment consumers.
- Before the repair, authentic native bridge response regressions failed in 11 cases.
- After the repair, all 75 focused iMessage tests passed on an isolated hosted runner.
- The complete changed-file validation passed, including production and test typechecking, formatting, linting, and repository ownership guards.
- Fresh structured review and an independent owner-boundary review reported no actionable findings.
- Production code decreases by six lines; no public interface, authorization, persistent state, configuration, or dependency changes.
