### PR TITLE
fix: make Linux adapter wiring tests portable on Windows

### DIFF
--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -10,6 +10,7 @@ import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.
 import {
   expectRealExitWinsOverSigkillFallback,
   expectWaitStaysPendingUntilSigkillFallback,
+  mockLinuxOomWrapperShell,
 } from "./test-support.js";
 
 const { spawnWithFallbackMock, signalProcessTreeMock, createWindowsOutputDecoderMock } = vi.hoisted(
@@ -742,6 +743,7 @@ describe("createChildAdapter", () => {
     const originalEnv = process.env.ENV;
     const originalCdpath = process.env.CDPATH;
     setPlatform("linux");
+    const restoreLinuxShell = mockLinuxOomWrapperShell();
     process.env.BASH_ENV = "/tmp/bashenv";
     process.env.ENV = "/tmp/env";
     process.env.CDPATH = "/tmp";
@@ -752,6 +754,7 @@ describe("createChildAdapter", () => {
       });
       expect(adapter.oomScoreWrapperSelected).toBe(true);
     } finally {
+      restoreLinuxShell();
       if (originalBashEnv === undefined) {
         delete process.env.BASH_ENV;
       } else {

--- a/src/process/supervisor/adapters/pty.test.ts
+++ b/src/process/supervisor/adapters/pty.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import {
   expectRealExitWinsOverSigkillFallback,
   expectWaitStaysPendingUntilSigkillFallback,
+  mockLinuxOomWrapperShell,
 } from "./test-support.js";
 
 const { spawnMock, ptyKillMock, signalProcessTreeMock } = vi.hoisted(() => ({
@@ -157,7 +158,7 @@ describe("createPtyAdapter", () => {
 
   it("forwards non-SIGTERM explicit signals to node-pty kill on non-Windows", async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
-    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
     try {
       spawnMock.mockReturnValue(createStubPty());
 
@@ -316,17 +317,21 @@ describe("createPtyAdapter", () => {
   it("wraps Linux PTY spawns so shell children inherit higher OOM score", async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
     Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const restoreLinuxShell = mockLinuxOomWrapperShell();
+    vi.resetModules();
     try {
+      const { createPtyAdapter: createLinuxPtyAdapter } = await import("./pty.js");
       const stub = createStubPty();
       spawnMock.mockReturnValue(stub);
 
-      const adapter = await createPtyAdapter({
+      const adapter = await createLinuxPtyAdapter({
         shell: "bash",
         args: ["-lc", "env"],
         env: { PATH: "/usr/bin", BASH_ENV: "/tmp/bashenv", TERM: "dumb" },
       });
       expect(adapter.oomScoreWrapperSelected).toBe(true);
     } finally {
+      restoreLinuxShell();
       if (originalPlatform) {
         Object.defineProperty(process, "platform", originalPlatform);
       }

--- a/src/process/supervisor/adapters/test-support.ts
+++ b/src/process/supervisor/adapters/test-support.ts
@@ -1,4 +1,5 @@
 // Supervisor adapter test support builds mock process handles for adapter tests.
+import fs from "node:fs";
 import { expect, vi } from "vitest";
 
 /**
@@ -10,6 +11,22 @@ type WaitResult = {
   code: number | null;
   signal: number | NodeJS.Signals | null;
 };
+
+/** Keep Linux adapter wiring tests deterministic on hosts without `/bin/sh`. */
+export function mockLinuxOomWrapperShell(): () => void {
+  const statSync = fs.statSync.bind(fs);
+  const fileStats = statSync(process.execPath);
+  const statSyncMock = vi
+    .spyOn(fs, "statSync")
+    .mockImplementation((target, options) =>
+      String(target) === "/bin/sh" ? fileStats : statSync(target, options as never),
+    );
+  return () => {
+    statSyncMock.mockRestore();
+    // The production helper memoizes shell availability; clear it for later tests.
+    vi.resetModules();
+  };
+}
 
 /** Assert fallback SIGKILL resolves only after the grace timer expires. */
 export async function expectWaitStaysPendingUntilSigkillFallback(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows contributors running the process supervisor adapter tests would get Linux-only wiring failures because the tests probed the Windows host for `/bin/sh` while simulating Linux.

## Why This Change Was Made

The test fixture now models Linux shell availability at the filesystem boundary and reloads the PTY adapter only while that fixture is active. The spy is restored and Vitest's evaluated-module cache is reset in `finally`, so the non-isolated suite cannot leak forced host behavior or the memoized Linux shell result. The earlier cross-platform signal test uses Darwin, which still covers the intended non-Windows production branch without priming Linux-only state.

This is deliberately test-only. It does not skip Windows coverage, weaken assertions, change production behavior, add configuration, or alter dependencies.

## User Impact

Windows contributors and CI can run the Linux adapter wiring coverage reliably. There is no runtime behavior change for OpenClaw operators.

## Evidence

- Exact candidate: `b2210c8270d1d818953a9d7890781bde1e80b337` (parent `b5180b68163a0dec24ac7615b81e7f12aadbd5e2`)
- Native Windows focused proof: 3 files, 55/55 tests passed via `node scripts/run-vitest.mjs src/process/supervisor/adapters/child.test.ts src/process/supervisor/adapters/pty.test.ts src/process/linux-oom-score.test.ts`
- Targeted `oxfmt --check`: passed for all three changed files
- `git diff --check HEAD^ HEAD`: passed
- Current-main audit at `08d2062c7f6027fa5d99493247ae3abb3fb29364`: all three parent blobs are byte-identical to main; clean three-way merge; no rebase required
- Duplicate audit: no semantic duplicate among open PRs; #120398 touches a separate `child.test.ts` service-detach section and leaves these hunks intact
- Autoreview: TruffleHog clean; Codex returned no findings, patch correct, confidence 0.99 on a synthetic commit whose before/after blob hashes and stable patch ID exactly match this commit
- Two independent owner/sibling reviews: clean after preserving the accepted spy-restoration and fresh-dynamic-import isolation fixes
- LOC: production +0/-0; tests/support +27/-2

Contributor credit: Peter Steinberger (`steipete`).