### PR TITLE
fix(release): isolate prepublish plugin startup probe

### DIFF
--- a/scripts/e2e/lib/clawhub-fixture-server.cjs
+++ b/scripts/e2e/lib/clawhub-fixture-server.cjs
@@ -39,6 +39,90 @@ async function assertPrepublishRequests(baseUrl, requestedPackage, version) {
   }
 }
 
+async function assertNoRequests(baseUrl) {
+  if (!baseUrl) {
+    throw new Error("assert-no-requests requires <base-url>");
+  }
+  const response = await fetch(new URL("/__fixture__/requests", baseUrl));
+  if (!response.ok) {
+    throw new Error(`ClawHub fixture request ledger returned HTTP ${response.status}`);
+  }
+  const payload = await response.json();
+  if (!Array.isArray(payload?.requests)) {
+    throw new Error("ClawHub fixture request ledger must contain a requests array");
+  }
+  if (payload.requests.length !== 0) {
+    throw new Error(`unexpected ClawHub fixture requests: ${JSON.stringify(payload.requests)}`);
+  }
+}
+
+function parkPrepublishAuthoredConfig(configPath, snapshotPath) {
+  if (!configPath || !snapshotPath) {
+    throw new Error("park-prepublish-auth-config requires <config-path> <snapshot-path>");
+  }
+  const authoredConfig = fs.readFileSync(configPath);
+  const config = JSON.parse(authoredConfig.toString("utf8"));
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    throw new Error("prepublish auth config must be a JSON object");
+  }
+  for (const key of ["plugins", "channels", "gateway"]) {
+    const value = config[key];
+    if (value !== undefined && (!value || typeof value !== "object" || Array.isArray(value))) {
+      throw new Error(`prepublish auth config ${key} must be an object`);
+    }
+  }
+  if (config.plugins?.allow !== undefined && !Array.isArray(config.plugins.allow)) {
+    throw new Error("prepublish auth config plugins.allow must be an array");
+  }
+  if (
+    config.plugins?.entries !== undefined &&
+    (!config.plugins.entries ||
+      typeof config.plugins.entries !== "object" ||
+      Array.isArray(config.plugins.entries))
+  ) {
+    throw new Error("prepublish auth config plugins.entries must be an object");
+  }
+  if (
+    config.gateway?.reload !== undefined &&
+    (!config.gateway.reload ||
+      typeof config.gateway.reload !== "object" ||
+      Array.isArray(config.gateway.reload))
+  ) {
+    throw new Error("prepublish auth config gateway.reload must be an object");
+  }
+  if (Array.isArray(config.plugins?.allow)) {
+    config.plugins.allow = config.plugins.allow.filter((id) => id !== "whatsapp");
+  }
+  if (config.plugins?.entries && typeof config.plugins.entries === "object") {
+    delete config.plugins.entries.whatsapp;
+  }
+  if (config.channels && typeof config.channels === "object") {
+    delete config.channels.whatsapp;
+  }
+  config.gateway ??= {};
+  config.gateway.reload = { ...config.gateway.reload, mode: "off" };
+  fs.writeFileSync(snapshotPath, authoredConfig, { mode: 0o600 });
+  replaceFileAtomically(configPath, Buffer.from(`${JSON.stringify(config, null, 2)}\n`));
+}
+
+function restorePrepublishAuthoredConfig(configPath, snapshotPath) {
+  if (!configPath || !snapshotPath) {
+    throw new Error("restore-prepublish-auth-config requires <config-path> <snapshot-path>");
+  }
+  replaceFileAtomically(configPath, fs.readFileSync(snapshotPath));
+}
+
+function replaceFileAtomically(filePath, contents) {
+  const tempPath = `${filePath}.tmp.${process.pid}`;
+  const mode = fs.statSync(filePath).mode;
+  try {
+    fs.writeFileSync(tempPath, contents, { mode });
+    fs.renameSync(tempPath, filePath);
+  } finally {
+    fs.rmSync(tempPath, { force: true });
+  }
+}
+
 function startPrepublishArtifactServer() {
   const manifest = JSON.parse(fs.readFileSync(artifactManifestFile, "utf8"));
   if (!Array.isArray(manifest.packages) || manifest.packages.length === 0) {
@@ -625,6 +709,26 @@ if (profile === "assert-prepublish-requests") {
       process.exit(1);
     },
   );
+  return;
+}
+
+if (profile === "assert-no-requests") {
+  assertNoRequests(portFile).catch(
+    /** @param {unknown} error */ (error) => {
+      console.error(error);
+      process.exit(1);
+    },
+  );
+  return;
+}
+
+if (profile === "park-prepublish-auth-config") {
+  parkPrepublishAuthoredConfig(portFile, artifactManifestFile);
+  return;
+}
+
+if (profile === "restore-prepublish-auth-config") {
+  restorePrepublishAuthoredConfig(portFile, artifactManifestFile);
   return;
 }
 

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -86,6 +86,7 @@ SYSTEMCTL_SHIM_LOG="$ARTIFACT_ROOT/systemctl-shim.log"
 SYSTEMCTL_SHIM_PID_FILE="$ARTIFACT_ROOT/systemctl-shim.pid"
 SYSTEMCTL_SHIM_DAEMON_LOG="$ARTIFACT_ROOT/systemctl-shim-gateway.log"
 CONFIG_COVERAGE_JSON="$ARTIFACT_ROOT/config-recipe.json"
+PREPUBLISH_AUTHORED_CONFIG="$RUNTIME_ROOT/prepublish-authored-openclaw.json"
 export OPENCLAW_UPGRADE_SURVIVOR_CONFIG_COVERAGE_JSON="$CONFIG_COVERAGE_JSON"
 rm -f "$SUMMARY_JSON" "$CONFIG_COVERAGE_JSON"
 : >"$PHASE_LOG"
@@ -398,6 +399,36 @@ configure_clawhub_fixture() {
   clawhub_fixture_pid="$!"
   wait_for_fixture_port "$clawhub_fixture_pid" "$port_file" "$log_file" "ClawHub fixture"
   export OPENCLAW_CLAWHUB_URL="http://127.0.0.1:$(cat "$port_file")"
+}
+
+prepublish_auto_auth_enabled() {
+  [ "$UPDATE_RESTART_MODE" = "auto-auth" ] &&
+    [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]
+}
+
+park_prepublish_authored_config() {
+  prepublish_auto_auth_enabled || return 0
+  node "${OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER:-scripts/e2e/lib/clawhub-fixture-server.cjs}" \
+    park-prepublish-auth-config "$OPENCLAW_CONFIG_PATH" "$PREPUBLISH_AUTHORED_CONFIG"
+}
+
+assert_prepublish_fixture_idle() {
+  prepublish_auto_auth_enabled || return 0
+  node "${OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER:-scripts/e2e/lib/clawhub-fixture-server.cjs}" \
+    assert-no-requests "$OPENCLAW_CLAWHUB_URL"
+}
+
+restore_prepublish_authored_config() {
+  prepublish_auto_auth_enabled || return 0
+  if ! node "${OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER:-scripts/e2e/lib/clawhub-fixture-server.cjs}" \
+    restore-prepublish-auth-config "$OPENCLAW_CONFIG_PATH" "$PREPUBLISH_AUTHORED_CONFIG"; then
+    return 1
+  fi
+  if ! cmp -s "$PREPUBLISH_AUTHORED_CONFIG" "$OPENCLAW_CONFIG_PATH"; then
+    echo "restored prepublish config did not match authored bytes" >&2
+    return 1
+  fi
+  rm -f "$PREPUBLISH_AUTHORED_CONFIG"
 }
 
 configure_plugin_registry() {
@@ -1199,17 +1230,21 @@ writeJson(path.join(stateDir, "devices", "pending.json"), {});
 NODE
 }
 
-write_update_restart_service_secretref_env() {
+write_update_restart_service_env() {
   mkdir -p "$OPENCLAW_STATE_DIR"
   local dotenv_path="$OPENCLAW_STATE_DIR/.env"
   local tmp_path="$dotenv_path.tmp.$$"
   if [ -f "$dotenv_path" ]; then
-    grep -v '^GATEWAY_AUTH_TOKEN_REF=' "$dotenv_path" >"$tmp_path" || true
+    grep -Ev '^(GATEWAY_AUTH_TOKEN_REF|OPENCLAW_CLAWHUB_URL)=' "$dotenv_path" >"$tmp_path" || true
   else
     : >"$tmp_path"
   fi
-  # Managed restarts resolve SecretRefs from service-owned durable env, not the update caller.
+  # Managed restarts resolve auth and fixture routing from service-owned durable env.
   printf 'GATEWAY_AUTH_TOKEN_REF=%s\n' "$GATEWAY_AUTH_TOKEN_REF" >>"$tmp_path"
+  if [ -n "${OPENCLAW_CLAWHUB_URL:-}" ]; then
+    printf 'OPENCLAW_CLAWHUB_URL=%s\n' "$OPENCLAW_CLAWHUB_URL" >>"$tmp_path"
+  fi
+  chmod 600 "$tmp_path"
   mv "$tmp_path" "$dotenv_path"
 }
 
@@ -1220,8 +1255,22 @@ prepare_update_restart_probe() {
   echo "Preparing configured-auth gateway for automatic update restart."
   install_update_restart_systemctl_shim
   seed_update_restart_probe_device_auth
-  start_gateway legacy-ready-log-ok
-  write_update_restart_service_secretref_env
+  park_prepublish_authored_config
+  local probe_status=0
+  start_gateway legacy-ready-log-ok || probe_status=$?
+  if [ "$probe_status" -eq 0 ]; then
+    assert_prepublish_fixture_idle || probe_status=$?
+  fi
+  local restore_status=0
+  restore_prepublish_authored_config || restore_status=$?
+  if [ "$probe_status" -ne 0 ]; then
+    return "$probe_status"
+  fi
+  if [ "$restore_status" -ne 0 ]; then
+    return "$restore_status"
+  fi
+  assert_baseline_state
+  write_update_restart_service_env
   install_update_restart_service_unit
 }
 

--- a/test/scripts/clawhub-fixture-server.test.ts
+++ b/test/scripts/clawhub-fixture-server.test.ts
@@ -94,6 +94,14 @@ function runPrepublishAssertion(
   );
 }
 
+function runNoRequestsAssertion(baseUrl?: string, cwd = process.cwd()) {
+  return spawnSync(process.execPath, [SCRIPT_PATH, "assert-no-requests", baseUrl ?? ""], {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env },
+  });
+}
+
 describe("ClawHub fixture server", () => {
   it("serves package metadata and npm-pack artifacts for kitchen-sink fixtures", async () => {
     const { baseUrl } = await startFixtureServer("kitchen-sink-plugin");
@@ -144,6 +152,67 @@ describe("ClawHub fixture server", () => {
     expect(assertion.stderr).toContain(
       "assert-prepublish-requests requires <base-url> <package-name> <version>",
     );
+    const emptyAssertion = runNoRequestsAssertion();
+    expect(emptyAssertion.status).toBe(1);
+    expect(emptyAssertion.stderr).toContain("assert-no-requests requires <base-url>");
+  });
+
+  it("parks WhatsApp startup config and restores the authored bytes exactly", () => {
+    const root = tempDirs.make("openclaw-clawhub-auth-config-");
+    const configPath = path.join(root, "openclaw.json");
+    const snapshotPath = path.join(root, "openclaw.authored.json");
+    const authoredConfig = `{
+  "gateway": { "mode": "local", "reload": { "mode": "hybrid" } },
+  "plugins": {
+    "allow": ["discord", "whatsapp"],
+    "entries": { "discord": { "enabled": true }, "whatsapp": { "enabled": true } }
+  },
+  "channels": { "discord": { "enabled": true }, "whatsapp": { "enabled": true } }
+}
+`;
+    writeFileSync(configPath, authoredConfig);
+
+    const park = spawnSync(
+      process.execPath,
+      [SCRIPT_PATH, "park-prepublish-auth-config", configPath, snapshotPath],
+      { encoding: "utf8", env: { ...process.env } },
+    );
+    expect(park.status, park.stderr).toBe(0);
+    expect(readFileSync(snapshotPath, "utf8")).toBe(authoredConfig);
+    expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual({
+      gateway: { mode: "local", reload: { mode: "off" } },
+      plugins: {
+        allow: ["discord"],
+        entries: { discord: { enabled: true } },
+      },
+      channels: { discord: { enabled: true } },
+    });
+
+    const restore = spawnSync(
+      process.execPath,
+      [SCRIPT_PATH, "restore-prepublish-auth-config", configPath, snapshotPath],
+      { encoding: "utf8", env: { ...process.env } },
+    );
+    expect(restore.status, restore.stderr).toBe(0);
+    expect(readFileSync(configPath, "utf8")).toBe(authoredConfig);
+  });
+
+  it("rejects malformed probe config without changing authored bytes", () => {
+    const root = tempDirs.make("openclaw-clawhub-invalid-auth-config-");
+    const configPath = path.join(root, "openclaw.json");
+    const snapshotPath = path.join(root, "openclaw.authored.json");
+    const authoredConfig = '{"plugins":{"allow":"whatsapp"}}\n';
+    writeFileSync(configPath, authoredConfig);
+
+    const park = spawnSync(
+      process.execPath,
+      [SCRIPT_PATH, "park-prepublish-auth-config", configPath, snapshotPath],
+      { encoding: "utf8", env: { ...process.env } },
+    );
+    expect(park.status).toBe(1);
+    expect(park.stderr).toContain("plugins.allow must be an array");
+    expect(readFileSync(configPath, "utf8")).toBe(authoredConfig);
+    expect(existsSync(snapshotPath)).toBe(false);
   });
 
   it("serves exact prepublish tarballs through the ClawHub artifact contract", async () => {
@@ -180,6 +249,7 @@ describe("ClawHub fixture server", () => {
       [manifestPath],
       isolatedCwd,
     );
+    expect(runNoRequestsAssertion(baseUrl, isolatedCwd).status).toBe(0);
     const whatsappPath = `/api/v1/packages/${encodeURIComponent("@openclaw/whatsapp")}`;
     const detail = await fetchJson(baseUrl, whatsappPath);
     expect(detail.package).toMatchObject({
@@ -255,6 +325,9 @@ describe("ClawHub fixture server", () => {
     expect(runPrepublishAssertion(baseUrl, "@openclaw/whatsapp", version, isolatedCwd).status).toBe(
       0,
     );
+    const unexpectedStartupRequest = runNoRequestsAssertion(baseUrl, isolatedCwd);
+    expect(unexpectedStartupRequest.status).toBe(1);
+    expect(unexpectedStartupRequest.stderr).toContain("unexpected ClawHub fixture requests");
     expect((await fetch(`${baseUrl}${whatsappPath}/versions/0.0.0/artifact`)).status).toBe(404);
     const mismatch = runPrepublishAssertion(baseUrl, "@openclaw/whatsapp", version);
     expect(mismatch.status).toBe(1);

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2301,6 +2301,7 @@ docker_e2e_docker_run_cmd run demo
   it("starts the upgrade survivor plugin registry before updates with scenario-owned config", () => {
     const runner = readFileSync(UPGRADE_SURVIVOR_DOCKER_E2E_PATH, "utf8");
     const publishedRunner = readFileSync(UPGRADE_SURVIVOR_RUN_SCRIPT, "utf8");
+    const updateRestartAuth = readFileSync(UPGRADE_SURVIVOR_UPDATE_RESTART_AUTH_PATH, "utf8");
 
     expect(runner.indexOf("\nconfigure_plugin_registry\n")).toBeLessThan(
       runner.indexOf('\necho "Running package update against the mounted tarball..."\n'),
@@ -2388,6 +2389,30 @@ docker_e2e_docker_run_cmd run demo
       expect(emptyRegistryGuardIndex).toBeLessThan(fixtureDirectoryIndex);
       expect(fixtureDirectoryIndex).toBeLessThan(registryServerIndex);
       expect(script).not.toContain('\nexport FEISHU_APP_SECRET="upgrade-survivor-feishu-secret"\n');
+    }
+    expectTextToIncludeAll(publishedRunner, [
+      "park_prepublish_authored_config",
+      "park-prepublish-auth-config",
+      "assert_prepublish_fixture_idle",
+      "assert-no-requests",
+      "restore_prepublish_authored_config",
+      "restore-prepublish-auth-config",
+      "cmp -s",
+      "'^(GATEWAY_AUTH_TOKEN_REF|OPENCLAW_CLAWHUB_URL)='",
+      "OPENCLAW_CLAWHUB_URL=%s",
+    ]);
+    expect(publishedRunner.indexOf("park_prepublish_authored_config")).toBeLessThan(
+      publishedRunner.lastIndexOf("assert_prepublish_fixture_idle"),
+    );
+    expect(publishedRunner.lastIndexOf("assert_prepublish_fixture_idle")).toBeLessThan(
+      publishedRunner.lastIndexOf("restore_prepublish_authored_config"),
+    );
+    expect(publishedRunner.lastIndexOf("restore_prepublish_authored_config")).toBeLessThan(
+      publishedRunner.lastIndexOf("write_update_restart_service_env"),
+    );
+    for (const script of [runner, updateRestartAuth]) {
+      expect(script).not.toContain("park-prepublish-auth-config");
+      expect(script).not.toContain("assert-no-requests");
     }
     expect(publishedRunner).not.toContain(
       '\nexport MATRIX_ACCESS_TOKEN="upgrade-survivor-matrix-token"\n',

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2537,8 +2537,10 @@ describe("package artifact reuse", () => {
     expect(publishedUpgradeSurvivor).toContain('local shim_dir="$npm_config_prefix/bin"');
     expect(publishedUpgradeSurvivor).toContain("seed_update_restart_probe_device_auth");
     expect(publishedUpgradeSurvivor).toContain("upgrade survivor restart probe");
-    expect(publishedUpgradeSurvivor).toContain("write_update_restart_service_secretref_env");
+    expect(publishedUpgradeSurvivor).toContain("write_update_restart_service_env");
     expect(publishedUpgradeSurvivor).toContain("GATEWAY_AUTH_TOKEN_REF=%s");
+    expect(publishedUpgradeSurvivor).toContain("OPENCLAW_CLAWHUB_URL=%s");
+    expect(publishedUpgradeSurvivor).toContain("assert-no-requests");
     expect(publishedUpgradeSurvivor).toContain(
       "env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD openclaw",
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the published update-restart-auth release lane could start an old baseline Gateway with the beta ClawHub fixture and authored WhatsApp config already active. The old core then tried to install a candidate-only WhatsApp plugin before the core update and failed its API compatibility check.

## Why This Change Was Made

The prepublish fixture remains configured before baseline startup as a fail-closed sentinel. For auto-auth prepublish runs only, the harness now parks the exact authored config bytes, removes WhatsApp from the temporary startup config, disables config reload, proves the baseline made zero ClawHub requests, restores and verifies the exact authored bytes, then persists the fixture URL alongside auth in service-owned environment state before update/restart.

The existing exact four-request post-update assertion is unchanged. The embedded candidate-core survivor lane is intentionally unchanged because its request ledger covers the candidate probe and self-update together.

## User Impact

No product runtime behavior changes. Beta release validation can prove old-core startup isolation, candidate plugin convergence, managed restart environment inheritance, and configured auth without contacting live ClawHub.

## Evidence

- `bash -n scripts/e2e/lib/upgrade-survivor/run.sh`
- `node scripts/run-vitest.mjs test/scripts/clawhub-fixture-server.test.ts` (6 passed)
- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts` (189 passed)
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts -- -t "lets reusable Docker E2E consume an already resolved package artifact"` (1 passed)
- Blacksmith Testbox `tbx_01kzhsardbr12qytq8cj8szza5`: changed `testRoot + tooling` gates passed and the wrapper exited 0
- Backing Actions run: https://github.com/openclaw/openclaw/actions/runs/31282757736 (shows cancelled because one-shot lease cleanup stopped the externally owned Testbox after the command completed; no test/check step failed)
- Autoreview: clean, no accepted/actionable findings
