### PR TITLE
fix(exec): preserve background process failures and completion wakes

### DIFF
--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -90,6 +90,8 @@ export interface ProcessSession {
   exitCode?: number | null;
   exitSignal?: NodeJS.Signals | number | null;
   exitReason?: TerminationReason;
+  /** Preserve the lifecycle owner's verdict for polls that captured the running session. */
+  terminalStatus?: Exclude<ProcessStatus, "running">;
   noOutputTimedOut?: boolean;
   exited: boolean;
   /** Process exit observed; backend cleanup still owns the terminal transition. */
@@ -240,13 +242,14 @@ export function markExited(
   session: ProcessSession,
   exitCode: number | null,
   exitSignal: NodeJS.Signals | number | null,
-  status: ProcessStatus,
+  status: Exclude<ProcessStatus, "running">,
   exitReason?: TerminationReason,
   noOutputTimedOut?: boolean,
 ) {
   // Visibility can be cleared before process termination. Keep suspension
   // blocked until the process owner reports the actual terminal transition.
   activeBackgroundExecSessionIds.delete(session.id);
+  session.terminalStatus = status;
   session.exited = true;
   session.exitCode = exitCode;
   session.exitSignal = exitSignal;

--- a/src/agents/bash-tools.exec-approval-output.test.ts
+++ b/src/agents/bash-tools.exec-approval-output.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./bash-tools.exec-approval-output.js";
 import {
   appendExecTimeoutRetryGuidance,
+  renderExecExitLabel,
   renderExecOutputText,
   renderExecUpdateText,
 } from "./bash-tools.exec-output.js";
@@ -209,6 +210,20 @@ describe("exec output rendering", () => {
 
   it("leaves non-timeout exits unchanged", () => {
     expect(appendExecTimeoutRetryGuidance("Command failed.", "signal")).toBe("Command failed.");
+  });
+
+  it.each([
+    { name: "successful exit", exit: { exitCode: 0 }, expected: "code 0" },
+    { name: "nonzero exit", exit: { exitCode: 7 }, expected: "code 7" },
+    {
+      name: "signal exit",
+      exit: { exitCode: null, exitSignal: "SIGKILL" },
+      expected: "signal SIGKILL",
+    },
+    { name: "missing exit code", exit: { exitCode: null }, expected: "unknown exit code" },
+    { name: "missing exit details", exit: {}, expected: "unknown exit code" },
+  ] as const)("renders $name without inventing exit details", ({ exit, expected }) => {
+    expect(renderExecExitLabel(exit)).toBe(expected);
   });
 
   it.each([

--- a/src/agents/bash-tools.exec-output.ts
+++ b/src/agents/bash-tools.exec-output.ts
@@ -14,6 +14,17 @@ export function renderExecOutputText(value: string | undefined): string {
   return value || EXEC_NO_OUTPUT_PLACEHOLDER;
 }
 
+/** Render the authoritative process exit without inventing a successful code. */
+export function renderExecExitLabel(exit: {
+  exitCode?: number | null;
+  exitSignal?: NodeJS.Signals | number | null;
+}): string {
+  if (exit.exitSignal != null) {
+    return `signal ${exit.exitSignal}`;
+  }
+  return typeof exit.exitCode === "number" ? `code ${exit.exitCode}` : "unknown exit code";
+}
+
 /** Render the text shown in exec progress updates, including warnings first. */
 export function renderExecUpdateText(params: { tailText?: string; warnings: string[] }): string {
   const warningText = params.warnings.length ? `${params.warnings.join("\n")}\n\n` : "";

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { emitDiagnosticEventWithTrustedTraceContext } from "../infra/diagnostic-events.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import {
   type EventSessionRoutingPolicy,
   resolveEventSessionKeyForPolicy,
@@ -33,6 +34,7 @@ import type { BashSandboxConfig } from "./bash-tools.shared.js";
 import type { AgentToolResult } from "./runtime/index.js";
 export { applyPathPrepend, normalizePathPrepend } from "../infra/path-prepend.js";
 import { logWarn } from "../logger.js";
+import { redactToolPayloadText } from "../logging/redact.js";
 import type { ManagedRun } from "../process/supervisor/index.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
 import type { RunExit, TerminationReason } from "../process/supervisor/types.js";
@@ -49,7 +51,11 @@ import {
   recordNotifyOnExitRemoval,
   tail,
 } from "./bash-process-registry.js";
-import { appendExecTimeoutRetryGuidance, renderExecUpdateText } from "./bash-tools.exec-output.js";
+import {
+  appendExecTimeoutRetryGuidance,
+  renderExecExitLabel,
+  renderExecUpdateText,
+} from "./bash-tools.exec-output.js";
 import {
   buildDockerExecArgs,
   chunkString,
@@ -328,16 +334,19 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
     return;
   }
   session.exitNotified = true;
-  const exitLabel = session.exitSignal
-    ? `signal ${session.exitSignal}`
-    : `code ${session.exitCode ?? 0}`;
+  const exitLabel = renderExecExitLabel(session);
   const output = compactNotifyOutput(
     tail(session.tail || session.aggregated || "", DEFAULT_NOTIFY_TAIL_CHARS),
   );
   if (status === "failed" && session.exitReason === "manual-cancel" && !output) {
     return;
   }
-  if (status === "completed" && !output && session.notifyOnExitEmptySuccess !== true) {
+  if (
+    status === "completed" &&
+    session.exitCode === 0 &&
+    !output &&
+    session.notifyOnExitEmptySuccess !== true
+  ) {
     return;
   }
   const summary = output
@@ -778,6 +787,8 @@ export async function runExecProcess(opts: {
           aggregated: session.aggregated.trim(),
           durationMs: Date.now() - startedAt,
         });
+        // Background observers need the finalizer failure in the same bounded, redacted output.
+        appendOutput(session, "stderr", `\n${redactToolPayloadText(formatErrorMessage(error))}\n`);
       } else {
         logWarn(`exec: sandbox finalize after process failure failed (${String(error)}).`);
       }

--- a/src/agents/bash-tools.process.e2e.test.ts
+++ b/src/agents/bash-tools.process.e2e.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, expect, test } from "vitest";
 import { peekSystemEventEntries, resetSystemEventsForTest } from "../infra/system-events.js";
-import { getSession } from "./bash-process-registry.js";
+import { findTaskByRunId } from "../tasks/task-registry-query.js";
+import { getFinishedSession, getSession, markBackgrounded } from "./bash-process-registry.js";
 import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
 import { createExecTool } from "./bash-tools.exec-run.js";
+import { runExecProcess } from "./bash-tools.exec-runtime.js";
 import { createProcessTool } from "./bash-tools.process.js";
 
 afterEach(() => {
@@ -23,6 +25,161 @@ function currentNodeEvalCommand(source: string): string {
 function textContent(result: { content: Array<{ type: string; text?: string }> }): string {
   return result.content.find((part) => part.type === "text")?.text ?? "";
 }
+
+const SYNTHETIC_FINALIZER_CREDENTIAL = ["sk", "synthetic", "fixture", "never", "real"].join("-");
+
+test.skipIf(process.platform === "win32").each([
+  {
+    name: "post-exit finalizer failure",
+    child: 'setTimeout(() => { process.stdout.write("REAL_CHILD_OUTPUT"); process.exit(0); }, 80)',
+    timeoutSec: 5,
+    finalizerError: `REAL_FINALIZER_DIAGNOSTIC Authorization: Bearer ${SYNTHETIC_FINALIZER_CREDENTIAL}`,
+    expectedStatus: "failed",
+    expectedExitCode: undefined,
+    expectedExitLabel: "unknown exit code",
+  },
+  {
+    name: "normal nonzero child exit",
+    child: 'setTimeout(() => { process.stdout.write("REAL_CHILD_OUTPUT"); process.exit(7); }, 80)',
+    timeoutSec: 5,
+    finalizerError: undefined,
+    expectedStatus: "completed",
+    expectedExitCode: 7,
+    expectedExitLabel: "code 7",
+  },
+  {
+    name: "timeout after a clean child exit",
+    child:
+      'process.on("SIGTERM", () => process.exit(0)); process.stdout.write("REAL_CHILD_OUTPUT"); setInterval(() => {}, 1000)',
+    timeoutSec: 1,
+    finalizerError: undefined,
+    expectedStatus: "failed",
+    expectedExitCode: 0,
+    expectedExitLabel: "code 0",
+  },
+] as const)(
+  "keeps $name truthful across a real background child, notification, and waiting poll",
+  async ({
+    name,
+    child,
+    timeoutSec,
+    finalizerError,
+    expectedStatus,
+    expectedExitCode,
+    expectedExitLabel,
+  }) => {
+    const scopeKey = `agent:main:process-terminal-${name.replaceAll(" ", "-")}`;
+    const run = await runExecProcess({
+      command: `real-process-terminal-${name}`,
+      workdir: process.cwd(),
+      env: {},
+      sandbox: {
+        containerName: "process-terminal-proof",
+        workspaceDir: process.cwd(),
+        containerWorkdir: process.cwd(),
+        async buildExecSpec() {
+          return {
+            argv: [process.execPath, "-e", child],
+            env: {},
+            stdinMode: "pipe-closed",
+          };
+        },
+        async finalizeExec() {
+          if (finalizerError) {
+            throw new Error(finalizerError);
+          }
+        },
+      },
+      usePty: false,
+      warnings: [],
+      maxOutput: 10_000,
+      pendingMaxOutput: 10_000,
+      notifyOnExit: true,
+      notifyOnExitEmptySuccess: true,
+      sessionKey: scopeKey,
+      scopeKey,
+      timeoutSec,
+    });
+    markBackgrounded(run.session);
+
+    const processTool = createProcessTool({ scopeKey });
+    const pendingPoll = processTool.execute(`process-terminal-poll-${name}`, {
+      action: "poll",
+      sessionId: run.session.id,
+      timeout: 2_000,
+    });
+
+    const outcome = await run.promise;
+    const notification = peekSystemEventEntries(scopeKey)[0]?.text;
+    const poll = await pendingPoll;
+    const details = poll.details as { status?: string; exitCode?: number };
+
+    expect(outcome.status).toBe(expectedStatus);
+    expect(details.status).toBe(expectedStatus);
+    expect(details.exitCode).toBe(expectedExitCode);
+    expect(getFinishedSession(run.session.id)?.status).toBe(expectedStatus);
+    expect(textContent(poll)).toContain(`Process exited with ${expectedExitLabel}.`);
+    expect(notification).toContain(expectedExitLabel);
+    if (finalizerError) {
+      expect(textContent(poll)).toContain("REAL_FINALIZER_DIAGNOSTIC");
+      expect(notification).toContain("REAL_FINALIZER_DIAGNOSTIC");
+      expect(textContent(poll)).not.toContain(SYNTHETIC_FINALIZER_CREDENTIAL);
+      expect(notification).not.toContain(SYNTHETIC_FINALIZER_CREDENTIAL);
+      expect(getFinishedSession(run.session.id)?.aggregated).not.toContain(
+        SYNTHETIC_FINALIZER_CREDENTIAL,
+      );
+      expect(notification).not.toContain("code 0");
+    }
+  },
+);
+
+test.skipIf(process.platform === "win32").each([
+  { name: "quiet successful exit", exitCode: 0, output: "", expectsNotification: false },
+  { name: "quiet nonzero exit", exitCode: 7, output: "", expectsNotification: true },
+  { name: "nonzero exit with output", exitCode: 7, output: "VISIBLE", expectsNotification: true },
+])(
+  "preserves default completion wake behavior for a real $name",
+  async ({ name, exitCode, output, expectsNotification }) => {
+    const scopeKey = `agent:main:process-default-wake-${name.replaceAll(" ", "-")}`;
+    const execTool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      allowBackground: true,
+      backgroundMs: 0,
+      timeoutSec: 10,
+      notifyOnExit: true,
+      notifyOnExitEmptySuccess: false,
+      sessionKey: scopeKey,
+      scopeKey,
+    });
+    const script = `process.stdout.write(${JSON.stringify(output)}); process.exit(${exitCode});`;
+    const started = await execTool.execute(`process-default-wake-${name}`, {
+      command: currentNodeEvalCommand(script),
+      background: true,
+    });
+    const sessionId = (started.details as { sessionId?: string }).sessionId;
+    expect(sessionId).toEqual(expect.any(String));
+    if (!sessionId) {
+      throw new Error("exec did not return a background session id");
+    }
+
+    await expect
+      .poll(() => getFinishedSession(sessionId), { timeout: 5_000, interval: 25 })
+      .toBeDefined();
+    expect(findTaskByRunId(`exec:${sessionId}`)?.status).toBe(
+      exitCode === 0 ? "succeeded" : "failed",
+    );
+    const events = peekSystemEventEntries(scopeKey);
+    expect(events).toHaveLength(expectsNotification ? 1 : 0);
+    if (expectsNotification) {
+      expect(events[0]?.text).toContain(`code ${exitCode}`);
+      if (output) {
+        expect(events[0]?.text).toContain(output);
+      }
+    }
+  },
+);
 
 test.skipIf(process.platform === "win32")(
   "consumes a real notify-on-exit event when process poll returns the terminal result",

--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -4,7 +4,12 @@
  */
 import { afterEach, expect, test, vi } from "vitest";
 import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
-import { addSession, appendOutput, markExited } from "./bash-process-registry.js";
+import {
+  addSession,
+  appendOutput,
+  getFinishedSession,
+  markExited,
+} from "./bash-process-registry.js";
 import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
 import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
 import { createProcessTool } from "./bash-tools.process.js";
@@ -137,6 +142,84 @@ test("process poll warns when the session times out while poll is waiting", asyn
     vi.useRealTimers();
   }
 });
+
+test.each([
+  {
+    name: "successful zero exit",
+    exitCode: 0,
+    exitSignal: null,
+    ownerStatus: "completed",
+    exitReason: undefined,
+    expectedExit: "code 0",
+  },
+  {
+    name: "successful nonzero exit",
+    exitCode: 7,
+    exitSignal: null,
+    ownerStatus: "completed",
+    exitReason: undefined,
+    expectedExit: "code 7",
+  },
+  {
+    name: "runtime failure without an exit code",
+    exitCode: null,
+    exitSignal: null,
+    ownerStatus: "failed",
+    exitReason: undefined,
+    expectedExit: "unknown exit code",
+  },
+  {
+    name: "timeout after a clean child exit",
+    exitCode: 0,
+    exitSignal: null,
+    ownerStatus: "failed",
+    exitReason: "overall-timeout",
+    expectedExit: "code 0",
+  },
+  {
+    name: "signal failure without an exit code",
+    exitCode: null,
+    exitSignal: "SIGKILL",
+    ownerStatus: "failed",
+    exitReason: "manual-cancel",
+    expectedExit: "signal SIGKILL",
+  },
+] as const)(
+  "preserves the lifecycle owner's $name when completion races a process poll",
+  async ({ name, exitCode, exitSignal, ownerStatus, exitReason, expectedExit }) => {
+    vi.useFakeTimers();
+    try {
+      const sessionId = `sess-terminal-${name.replaceAll(" ", "-")}`;
+      const { processTool, session } = createProcessSessionHarness(sessionId);
+
+      setTimeout(() => {
+        markExited(session, exitCode, exitSignal, ownerStatus, exitReason);
+      }, 10);
+
+      const pendingPoll = pollSession(processTool, "toolcall-terminal-race", sessionId, 1_000);
+      await vi.advanceTimersByTimeAsync(250);
+      const racedPoll = await pendingPoll;
+      const racedDetails = racedPoll.details as { status?: string; exitCode?: number };
+
+      expect(racedDetails.status).toBe(ownerStatus);
+      expect(racedDetails.exitCode).toBe(exitCode ?? undefined);
+      expect(racedPoll.content[0]).toMatchObject({
+        type: "text",
+        text: expect.stringContaining(`Process exited with ${expectedExit}.`),
+      });
+      expect(getFinishedSession(sessionId)?.status).toBe(ownerStatus);
+
+      const retainedPoll = await pollSession(processTool, "toolcall-terminal-retained", sessionId);
+      expect(retainedPoll.details).toMatchObject({ status: ownerStatus });
+      expect(retainedPoll.content[0]).toMatchObject({
+        type: "text",
+        text: expect.stringContaining(`Process exited with ${expectedExit}.`),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  },
+);
 
 test("process poll clamps long waits to 30 seconds", async () => {
   vi.useFakeTimers();

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -22,7 +22,7 @@ import {
   setJobTtlMs,
 } from "./bash-process-registry.js";
 import { describeProcessTool } from "./bash-tools.descriptions.js";
-import { appendExecTimeoutRetryGuidance } from "./bash-tools.exec-output.js";
+import { appendExecTimeoutRetryGuidance, renderExecExitLabel } from "./bash-tools.exec-output.js";
 import {
   handleProcessSendKeys,
   type WritableStdin,
@@ -410,11 +410,7 @@ export function createProcessTool(
                           scopedFinished.truncated ? " — truncated to cap" : ""
                         })`) +
                         retainedOutputNote +
-                        `\n\nProcess exited with ${
-                          scopedFinished.exitSignal
-                            ? `signal ${scopedFinished.exitSignal}`
-                            : `code ${scopedFinished.exitCode ?? 0}`
-                        }.`,
+                        `\n\nProcess exited with ${renderExecExitLabel(scopedFinished)}.`,
                       scopedFinished.exitReason,
                     ),
                   },
@@ -457,23 +453,12 @@ export function createProcessTool(
           }
           const { stdout, stderr, outputDropped } = drainSession(scopedSession);
           const exited = scopedSession.exited;
-          const exitCode = scopedSession.exitCode ?? 0;
-          const exitSignal = scopedSession.exitSignal ?? undefined;
           if (exited) {
             markTerminalPollObserved(scopedSession);
             acknowledgeNotifyOnExit(scopedSession);
-            const status = exitCode === 0 && exitSignal == null ? "completed" : "failed";
-            markExited(
-              scopedSession,
-              scopedSession.exitCode ?? null,
-              scopedSession.exitSignal ?? null,
-              status,
-              scopedSession.exitReason,
-              scopedSession.noOutputTimedOut,
-            );
           }
           const status = exited
-            ? exitCode === 0 && exitSignal == null
+            ? scopedSession.terminalStatus === "completed"
               ? "completed"
               : "failed"
             : "running";
@@ -497,9 +482,7 @@ export function createProcessTool(
                   (output || "(no new output)") +
                     retainedOutputNote +
                     (exited
-                      ? `\n\nProcess exited with ${
-                          exitSignal ? `signal ${exitSignal}` : `code ${exitCode}`
-                        }.`
+                      ? `\n\nProcess exited with ${renderExecExitLabel(scopedSession)}.`
                       : buildInputWaitHint(runtime) || "\n\nProcess still running."),
                   exited ? scopedSession.exitReason : undefined,
                 ),
@@ -508,7 +491,7 @@ export function createProcessTool(
             details: {
               status,
               sessionId: params.sessionId,
-              exitCode: exited ? exitCode : undefined,
+              exitCode: exited ? (scopedSession.exitCode ?? undefined) : undefined,
               ...(exited && scopedSession.exitSignal != null
                 ? { exitSignal: scopedSession.exitSignal }
                 : {}),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a failed background process could be reported as successful, an unknown exit code could be invented as zero, and an in-flight process poll could overwrite the process owner's authoritative final outcome. Quiet nonzero exits also failed to wake their waiting owner.

## Why This Change Was Made

The process lifecycle owner now records its terminal outcome once and all polling and notification projections consume that same authoritative fact. This removes duplicate consumer-side finalization, preserves unknown exit codes and normal nonzero completion semantics, and applies the canonical tool-output secret redactor before exposing finalization diagnostics.

## User Impact

Background execution reports truthful failure, timeout, cancellation, and exit information; operator-visible task state remains consistent during races; and genuinely failed quiet processes reliably wake their owners without leaking sensitive diagnostic material.

## Evidence

- Reproduced the original producer-to-poll ordering against real spawned child processes, including failed finalization, ordinary nonzero completion, and zero-code timeout.
- Eight real-child end-to-end scenarios pass after the repair, including quiet-success and quiet-failure notification behavior and authoritative task finalization.
- All 125 focused hosted tests pass across six suites, including an explicit synthetic-credential redaction regression.
- The private QA runtime build and 40 generated-module loading checks pass.
- The full changed-file validation passes, and fresh structured review plus an independent adversarial source review report no actionable findings.
- Production grows by eight lines to preserve the authoritative lifecycle and mandatory redaction boundary; no configuration, public protocol, authorization, or persistent-schema changes.
