### PR TITLE
fix(agents): preserve exact steering delivery ownership

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
@@ -9,6 +9,15 @@ type EmbeddedAgentActiveSessionSteerTarget = Parameters<
   typeof steerActiveSessionWithOptionalDeliveryWait
 >[0];
 
+function createIdentityAwareSteer(message: object): EmbeddedAgentActiveSessionSteerTarget["steer"] {
+  return async (_text, _images, _recorder, _media, _imageOrder, queueIdentity) => {
+    setSteeringMessageIdentity(
+      message as Parameters<typeof setSteeringMessageIdentity>[0],
+      queueIdentity,
+    );
+  };
+}
+
 function steerWithDeliveryWait(
   activeSession: EmbeddedAgentActiveSessionSteerTarget,
   text: string,
@@ -88,9 +97,13 @@ describe("embedded OpenClaw queued steering cancellation", () => {
     // A queued steer is only durable once the user message_end event lands in
     // the active transcript.
     let emit!: (event: unknown) => void;
+    const queuedMessage = {
+      role: "user",
+      content: [{ type: "text", text: "queued completion" }],
+    };
     const activeSession: EmbeddedAgentActiveSessionSteerTarget = {
       getSteeringMessages: () => [],
-      steer: async () => {},
+      steer: createIdentityAwareSteer(queuedMessage),
       subscribe: (listener) => {
         emit = listener;
         return () => {};
@@ -104,20 +117,14 @@ describe("embedded OpenClaw queued steering cancellation", () => {
 
     emit({
       type: "message_start",
-      message: {
-        role: "user",
-        content: [{ type: "text", text: "queued completion" }],
-      },
+      message: queuedMessage,
     });
     await Promise.resolve();
     expect(settled).toBe(false);
 
     emit({
       type: "message_end",
-      message: {
-        role: "user",
-        content: [{ type: "text", text: "queued completion" }],
-      },
+      message: queuedMessage,
     });
 
     await expect(wait).resolves.toBeUndefined();
@@ -156,7 +163,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
         },
       },
       getSteeringMessages: () => steeringUiMessages,
-      steer: async () => {},
+      steer: createIdentityAwareSteer(targetMessage),
       subscribe: () => () => {},
     };
 
@@ -202,7 +209,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
         },
       },
       getSteeringMessages: () => steeringUiMessages,
-      steer: async () => {},
+      steer: createIdentityAwareSteer(targetMessage),
       subscribe: (listener) => {
         emit = listener;
         return () => {
@@ -294,6 +301,67 @@ describe("embedded OpenClaw queued steering cancellation", () => {
     expect(steeringUiMessages).toEqual(["same text"]);
   });
 
+  it("cancels the exact expanded steer without leaving a duplicate UI entry", async () => {
+    const expandedText = "expanded steering text";
+    const first = {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: expandedText }],
+      timestamp: 1,
+    };
+    const second = { ...first, content: [...first.content], timestamp: 2 };
+    setSteeringMessageIdentity(first, "keep-first");
+    setSteeringMessageIdentity(second, "cancel-second");
+    const queueMessages = [first, second];
+    const steeringUiMessages = [expandedText, expandedText];
+    const controller = new AbortController();
+    const activeSession: EmbeddedAgentActiveSessionSteerTarget = {
+      agent: { steeringQueue: { messages: queueMessages } },
+      getSteeringMessages: () => steeringUiMessages,
+      steer: async () => {},
+      subscribe: () => () => {},
+    };
+
+    const wait = steerWithDeliveryWait(activeSession, "/expand same text", 10_000, {
+      queueIdentity: "cancel-second",
+      abortSignal: controller.signal,
+    });
+    await Promise.resolve();
+    controller.abort();
+
+    await expect(wait).rejects.toThrow("queued steering message was cancelled before delivery");
+    expect(queueMessages).toEqual([first]);
+    expect(steeringUiMessages).toEqual([expandedText]);
+  });
+
+  it("removes the empty UI entry for an image-only queued steer", async () => {
+    const image = { type: "image" as const, data: "image-data", mimeType: "image/png" };
+    const message = { role: "user" as const, content: [image], timestamp: 1 };
+    setSteeringMessageIdentity(message, "image-only");
+    const queueMessages = [message];
+    const steeringUiMessages = [""];
+    const controller = new AbortController();
+    const activeSession: EmbeddedAgentActiveSessionSteerTarget = {
+      agent: { steeringQueue: { messages: queueMessages } },
+      getSteeringMessages: () => steeringUiMessages,
+      steer: async () => {},
+      subscribe: () => () => {},
+    };
+
+    const wait = steerActiveSessionWithOptionalDeliveryWait(activeSession, "", {
+      images: [image],
+      queueIdentity: "image-only",
+      abortSignal: controller.signal,
+      deliveryTimeoutMs: 10_000,
+      waitForTranscriptCommit: true,
+    });
+    await Promise.resolve();
+    controller.abort();
+
+    await expect(wait).rejects.toThrow("queued steering message was cancelled before delivery");
+    expect(queueMessages).toEqual([]);
+    expect(steeringUiMessages).toEqual([]);
+  });
+
   it("marks a missing queued message as accepted without transcript confirmation", async () => {
     vi.useFakeTimers();
     const activeSession: EmbeddedAgentActiveSessionSteerTarget = {
@@ -336,7 +404,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
           },
         },
         getSteeringMessages: () => steeringUiMessages,
-        steer: async () => {},
+        steer: createIdentityAwareSteer(targetMessage),
         subscribe: (listener) => {
           emit = listener;
           return () => {};
@@ -354,10 +422,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
 
       emit({
         type: "message_end",
-        message: {
-          role: "user",
-          content: [{ type: "text", text: "completion survives retry" }],
-        },
+        message: targetMessage,
       });
 
       await expect(wait).resolves.toBeUndefined();
@@ -384,7 +449,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
           },
         },
         getSteeringMessages: () => steeringUiMessages,
-        steer: async () => {},
+        steer: createIdentityAwareSteer(targetMessage),
         subscribe: (listener) => {
           emit = listener;
           return () => {};
@@ -402,10 +467,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
 
       emit({
         type: "message_end",
-        message: {
-          role: "user",
-          content: [{ type: "text", text: "completion survives compaction" }],
-        },
+        message: targetMessage,
       });
 
       await expect(wait).resolves.toBeUndefined();

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
@@ -98,16 +98,13 @@ function extractQueuedUserMessageText(message: unknown): string | undefined {
   return text || undefined;
 }
 
-function isQueuedUserMessageEnd(event: unknown, text: string, queueIdentity?: string): boolean {
+function isQueuedUserMessageEnd(event: unknown, queueIdentity: string): boolean {
   if (!event || typeof event !== "object") {
     return false;
   }
   const record = event as { message?: unknown; type?: unknown };
   return (
-    record.type === "message_end" &&
-    (queueIdentity
-      ? getSteeringMessageIdentity(record.message) === queueIdentity
-      : extractQueuedUserMessageText(record.message) === text)
+    record.type === "message_end" && getSteeringMessageIdentity(record.message) === queueIdentity
   );
 }
 
@@ -143,13 +140,13 @@ function getAgentSteeringQueueMessages(agent: unknown): unknown[] | undefined {
 
 /**
  * Removes one pending steered user message from both the runtime queue and UI
- * steering list. This targets the exact text so unrelated queued messages keep
- * their payloads and ordering.
+ * steering list. The private identity targets the exact runtime message, while
+ * its expanded text selects the corresponding UI entry.
  */
 async function cancelQueuedSteeringMessage(
   activeSession: EmbeddedAgentActiveSessionSteerTarget,
   text: string,
-  queueIdentity?: string,
+  queueIdentity: string,
 ): Promise<boolean> {
   const queuedMessages = getAgentSteeringQueueMessages(activeSession.agent);
   if (!queuedMessages) {
@@ -157,24 +154,23 @@ async function cancelQueuedSteeringMessage(
   }
   // The session runtime exposes only all-queue clears publicly; mutate the exact pending message
   // so unrelated queued messages keep their full payloads.
-  const queueIndex = queuedMessages.findIndex((message) =>
-    queueIdentity
-      ? getSteeringMessageIdentity(message) === queueIdentity
-      : extractQueuedUserMessageText(message) === text,
+  const queueIndex = queuedMessages.findIndex(
+    (message) => getSteeringMessageIdentity(message) === queueIdentity,
   );
   if (queueIndex === -1) {
     return false;
   }
+  const queuedText = extractQueuedUserMessageText(queuedMessages[queueIndex]) ?? text;
   const matchingOrdinal = queuedMessages
     .slice(0, queueIndex)
-    .filter((message) => extractQueuedUserMessageText(message) === text).length;
+    .filter((message) => extractQueuedUserMessageText(message) === queuedText).length;
   queuedMessages.splice(queueIndex, 1);
   const uiSteeringMessages = activeSession.getSteeringMessages?.();
   if (Array.isArray(uiSteeringMessages)) {
     const uiIndex = uiSteeringMessages.findIndex(
       (candidate, index) =>
-        candidate === text &&
-        uiSteeringMessages.slice(0, index).filter((value) => value === text).length ===
+        candidate === queuedText &&
+        uiSteeringMessages.slice(0, index).filter((value) => value === queuedText).length ===
           matchingOrdinal,
     );
     if (uiIndex !== -1) {
@@ -197,7 +193,7 @@ async function steerAndWaitForTranscriptCommit(
   images?: ImageContent[],
   media?: MediaFact[],
   imageOrder?: PromptImageOrderEntry[],
-  queueIdentity?: string,
+  queueIdentity: string = crypto.randomUUID(),
   abortSignal?: AbortSignal,
   onQueueAccepted?: (accepted: boolean) => void,
 ): Promise<void> {
@@ -290,7 +286,7 @@ async function steerAndWaitForTranscriptCommit(
         }
         return;
       }
-      if (isQueuedUserMessageEnd(event, text, queueIdentity)) {
+      if (isQueuedUserMessageEnd(event, queueIdentity)) {
         finish();
         return;
       }

--- a/src/agents/sessions/agent-session-base.ts
+++ b/src/agents/sessions/agent-session-base.ts
@@ -277,9 +277,9 @@ export abstract class AgentSessionBase {
   // Event Subscription
   // =========================================================================
 
-  /** Emit an event to all listeners */
+  /** Snapshot listeners because delivery confirmation can unsubscribe during dispatch. */
   protected emit(event: AgentSessionEvent): void {
-    for (const l of this.eventListeners) {
+    for (const l of this.eventListeners.slice()) {
       void l(event);
     }
   }

--- a/src/agents/sessions/agent-session-loop-correctness.test.ts
+++ b/src/agents/sessions/agent-session-loop-correctness.test.ts
@@ -5,6 +5,7 @@ import {
 } from "openclaw/plugin-sdk/llm";
 import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
+import { steerActiveSessionWithOptionalDeliveryWait } from "../embedded-agent-runner/run/attempt.queue-message.js";
 import { agentSessionAutomaticCompaction } from "./agent-session-compaction.js";
 import {
   appendHistory,
@@ -26,10 +27,140 @@ import type { AgentSessionEvent } from "./agent-session-types.js";
 import type { ToolDefinition } from "./extensions/types.js";
 import { SessionManager } from "./session-manager.js";
 import { SettingsManager } from "./settings-manager.js";
+import { getSteeringMessageIdentity } from "./steering-message-identity.js";
 
 registerAgentSessionLoopTestLifecycle();
 
 describe("AgentSession loop correctness", () => {
+  it.each([2, 3])(
+    "confirms each of %i identical queued messages only after its own transcript commit",
+    async (waiterCount) => {
+      const { session, sessionManager } = await createTestSession();
+      type QueuedMessage = Parameters<SessionManager["appendMessage"]>[0];
+      const queuedMessages = (
+        session.agent as unknown as { steeringQueue: { messages: QueuedMessage[] } }
+      ).steeringQueue.messages;
+      const handleAgentEvent = Reflect.get(session, "handleAgentEvent") as (event: {
+        type: "message_start" | "message_end";
+        message: QueuedMessage;
+      }) => Promise<void>;
+      const confirmed: number[] = [];
+      const waits = Array.from({ length: waiterCount }, (_, index) =>
+        steerActiveSessionWithOptionalDeliveryWait(session, "same queued message", {
+          deliveryTimeoutMs: 10_000,
+          waitForTranscriptCommit: true,
+        }).then(() => confirmed.push(index + 1)),
+      );
+
+      await vi.waitFor(() => expect(queuedMessages).toHaveLength(waiterCount));
+      const originalMessages = [...queuedMessages];
+
+      try {
+        for (let index = 0; index < waiterCount; index += 1) {
+          const message = queuedMessages.shift();
+          expect(message).toBeDefined();
+          if (!message) {
+            return;
+          }
+          await handleAgentEvent({ type: "message_start", message });
+          await handleAgentEvent({ type: "message_end", message });
+          await vi.waitFor(() =>
+            expect(confirmed).toEqual(
+              Array.from({ length: index + 1 }, (_, position) => position + 1),
+            ),
+          );
+        }
+        await Promise.all(waits);
+
+        const identities = originalMessages.map(getSteeringMessageIdentity);
+        expect(identities.every((identity) => typeof identity === "string")).toBe(true);
+        expect(new Set(identities).size).toBe(waiterCount);
+        for (const message of originalMessages) {
+          const identitySymbol = Object.getOwnPropertySymbols(message).find(
+            (symbol) => symbol === Symbol.for("openclaw.steeringMessageIdentity"),
+          );
+          expect(identitySymbol).toBeDefined();
+          if (identitySymbol) {
+            expect(Object.getOwnPropertyDescriptor(message, identitySymbol)?.enumerable).toBe(
+              false,
+            );
+          }
+          expect(JSON.stringify(message)).not.toContain(getSteeringMessageIdentity(message));
+        }
+        const persistedMessages = sessionManager
+          .getEntries()
+          .filter((entry) => entry.type === "message")
+          .map((entry) => entry.message);
+        expect(persistedMessages).toHaveLength(waiterCount);
+        expect(persistedMessages.every((message) => !getSteeringMessageIdentity(message))).toBe(
+          true,
+        );
+      } finally {
+        for (const message of queuedMessages.splice(0)) {
+          await handleAgentEvent({ type: "message_end", message });
+        }
+        await Promise.allSettled(waits);
+      }
+    },
+  );
+
+  it("snapshots ordinary event listeners before self-removal and late subscription", async () => {
+    streamMocks.streamSimple.mockImplementation((activeModel: Model) =>
+      createAssistantResultStream(
+        createAssistant(activeModel, [{ type: "text", text: "complete answer" }]),
+      ),
+    );
+    const { session } = await createTestSession();
+    const observed: string[] = [];
+    const unsubscribeFirst = session.subscribe((event) => {
+      if (event.type !== "message_end" || event.message.role !== "user") {
+        return;
+      }
+      observed.push("first");
+      unsubscribeFirst();
+      session.subscribe((laterEvent) => {
+        if (laterEvent.type === "message_end" && laterEvent.message.role === "user") {
+          observed.push("late");
+        }
+      });
+    });
+    session.subscribe((event) => {
+      if (event.type === "message_end" && event.message.role === "user") {
+        observed.push("second");
+      }
+    });
+
+    await session.prompt("first prompt");
+    expect(observed).toEqual(["first", "second"]);
+    await session.prompt("second prompt");
+    expect(observed).toEqual(["first", "second", "second", "late"]);
+  });
+
+  it("finishes an ordinary event snapshot when another listener is unsubscribed", async () => {
+    streamMocks.streamSimple.mockImplementation((activeModel: Model) =>
+      createAssistantResultStream(
+        createAssistant(activeModel, [{ type: "text", text: "complete answer" }]),
+      ),
+    );
+    const { session } = await createTestSession();
+    const observed: string[] = [];
+    session.subscribe((event) => {
+      if (event.type === "message_end" && event.message.role === "user") {
+        observed.push("first");
+        unsubscribeSecond();
+      }
+    });
+    const unsubscribeSecond = session.subscribe((event) => {
+      if (event.type === "message_end" && event.message.role === "user") {
+        observed.push("second");
+      }
+    });
+
+    await session.prompt("first prompt");
+
+    expect(observed).toEqual(["first", "second"]);
+  });
+
   it("carries the canonical assistant entry id through ordered terminal listeners", async () => {
     const assistant = createAssistant(testModel, [{ type: "text", text: "same answer" }]);
     const sessionManager = SessionManager.inMemory();


### PR DESCRIPTION
## What Problem This Solves

Concurrent identical steering messages could be acknowledged out of order or before their own transcript entry existed. Removing a listener during dispatch could also skip another registered listener, and cancelling a transformed queued message could leave a stale duplicate visible in the session UI.

## Why This Change Was Made

The session event owner now dispatches against an immutable listener snapshot, and the existing transcript-wait owner assigns a private, non-enumerable identity whenever a waiting caller did not provide one. Commit matching and cancellation consistently use that identity, while transformed-message cleanup derives its visible queue position from the actual queued message.

The listener and identity repairs must land together: snapshotting listeners alone makes two identical concurrent messages acknowledge the same transcript event. Existing caller-provided identities, ordinary nonwaiting delivery, image-only messages, persisted transcript shapes, and public event payloads remain unchanged.

## User Impact

Simultaneous steering requests complete exactly once and in order, all existing listeners observe their events, and cancelling transformed duplicate messages no longer leaves a ghost UI entry.

## Evidence

- The untouched owners reproduced five focused failures, including three concurrent identical steering requests and transformed duplicate cancellation.
- The final implementation passes all 35 focused remote owner and real-session tests, including actual transcript persistence and private-identity serialization checks.
- The complete remote changed-file gate passes production and test typechecks, formatting, lint, and all ownership/security guards.
- Two independent final reviews and a fresh structured review report no actionable findings.
- Production code shrinks by four lines; no public configuration, protocol, authentication, or database schema changes.
