### PR TITLE
fix(telegram): prevent message latency from growing with session count

### DIFF
--- a/extensions/telegram/src/bot-deps.ts
+++ b/extensions/telegram/src/bot-deps.ts
@@ -17,7 +17,6 @@ import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import {
   getSessionEntry,
-  listSessionEntries,
   readSessionUpdatedAt,
   readAmbientTranscriptWatermark,
   resolveAmbientTranscriptWatermarkKey,
@@ -41,7 +40,6 @@ export type TelegramBotDeps = {
   getRuntimeConfig: typeof getRuntimeConfig;
   resolveStorePath: typeof resolveStorePath;
   getSessionEntry?: typeof getSessionEntry;
-  listSessionEntries?: typeof listSessionEntries;
   readSessionUpdatedAt?: typeof readSessionUpdatedAt;
   readAmbientTranscriptWatermark?: typeof readAmbientTranscriptWatermark;
   resolveAmbientTranscriptWatermarkKey?: typeof resolveAmbientTranscriptWatermarkKey;
@@ -79,9 +77,6 @@ export const defaultTelegramBotDeps: TelegramBotDeps = {
   },
   get getSessionEntry() {
     return getSessionEntry;
-  },
-  get listSessionEntries() {
-    return listSessionEntries;
   },
   get readChannelAllowFromStore() {
     return readChannelAllowFromStore;

--- a/extensions/telegram/src/bot-handlers.message-session.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.message-session.runtime.test.ts
@@ -1,0 +1,52 @@
+// Telegram tests cover message-session routing and persisted model inheritance.
+import type { SessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { describe, expect, it, vi } from "vitest";
+import type { TelegramBotDeps } from "./bot-deps.js";
+import { createTelegramMessageSessionRuntime } from "./bot-handlers.message-session.runtime.js";
+
+describe("createTelegramMessageSessionRuntime", () => {
+  it("inherits a DM topic model override through keyed session loads", () => {
+    const storePath = "/tmp/telegram-sessions.sqlite";
+    const childSessionKey = "agent:main:main:thread:12345:99";
+    const parentSessionKey = "agent:main:main";
+    const entries: Record<string, SessionEntry> = {
+      [childSessionKey]: { sessionId: "child", updatedAt: 2 },
+      [parentSessionKey]: {
+        sessionId: "parent",
+        updatedAt: 1,
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-7",
+        modelOverrideSource: "user",
+      },
+    };
+    const getSessionEntry = vi.fn<NonNullable<TelegramBotDeps["getSessionEntry"]>>(
+      ({ sessionKey }) => entries[sessionKey],
+    );
+    const telegramDeps = {
+      resolveStorePath: vi.fn(() => storePath),
+      getSessionEntry,
+    } as Pick<TelegramBotDeps, "resolveStorePath" | "getSessionEntry"> as TelegramBotDeps;
+    const { resolveTelegramSessionState } = createTelegramMessageSessionRuntime({
+      accountId: "default",
+      resolveTelegramGroupConfig: () => ({}),
+      telegramDeps,
+    });
+
+    const state = resolveTelegramSessionState({
+      chatId: 12345,
+      isGroup: false,
+      isForum: false,
+      messageThreadId: 99,
+      botHasTopicsEnabled: true,
+      senderId: 12345,
+      runtimeCfg: {},
+    });
+
+    expect(state.sessionKey).toBe(childSessionKey);
+    expect(state.model).toBe("anthropic/claude-opus-4-7");
+    expect(getSessionEntry.mock.calls.map(([params]) => params)).toEqual([
+      { storePath, sessionKey: childSessionKey },
+      { storePath, sessionKey: parentSessionKey },
+    ]);
+  });
+});

--- a/extensions/telegram/src/bot-handlers.message-session.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-session.runtime.ts
@@ -4,7 +4,6 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import {
   getSessionEntry,
-  listSessionEntries,
   readAmbientTranscriptWatermark,
   resolveAmbientTranscriptWatermarkKey,
 } from "openclaw/plugin-sdk/session-store-runtime";
@@ -25,6 +24,7 @@ export function createTelegramMessageSessionRuntime({
   RegisterTelegramHandlerParams,
   "accountId" | "resolveTelegramGroupConfig" | "telegramDeps"
 >) {
+  const loadSessionEntry = telegramDeps.getSessionEntry ?? getSessionEntry;
   const resolveTelegramSessionState = (params: {
     chatId: number | string;
     isGroup: boolean;
@@ -79,15 +79,11 @@ export function createTelegramMessageSessionRuntime({
     const storePath = telegramDeps.resolveStorePath(params.runtimeCfg.session?.store, {
       agentId: route.agentId,
     });
-    const entry = (telegramDeps.getSessionEntry ?? getSessionEntry)({ storePath, sessionKey });
-    const store = Object.fromEntries(
-      (telegramDeps.listSessionEntries ?? listSessionEntries)({ storePath, readOnly: true }).map(
-        ({ sessionKey: key, entry: value }) => [key, value],
-      ),
-    );
+    const entry = loadSessionEntry({ storePath, sessionKey });
     const storedOverride = resolveStoredModelOverride({
       sessionEntry: entry,
-      sessionStore: store,
+      loadSessionEntry: (parentSessionKey) =>
+        loadSessionEntry({ storePath, sessionKey: parentSessionKey }),
       sessionKey,
       defaultProvider: resolveDefaultModelForAgent({
         cfg: params.runtimeCfg,

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -15,8 +15,6 @@ type TelegramBotRuntimeForTest = typeof import("./bot.runtime.js");
 type GetRuntimeConfigFn =
   typeof import("openclaw/plugin-sdk/runtime-config-snapshot").getRuntimeConfig;
 type GetSessionEntryFn = typeof import("openclaw/plugin-sdk/session-store-runtime").getSessionEntry;
-type ListSessionEntriesFn =
-  typeof import("openclaw/plugin-sdk/session-store-runtime").listSessionEntries;
 type ResolveStorePathFn =
   typeof import("openclaw/plugin-sdk/session-store-runtime").resolveStorePath;
 type ReadSessionUpdatedAtFn =
@@ -68,7 +66,6 @@ vi.mock("openclaw/plugin-sdk/web-media", () => ({
 const {
   getSessionEntryMock,
   getRuntimeConfig,
-  listSessionEntriesMock,
   loadSessionStoreMock,
   readSessionUpdatedAtMock,
   recordInboundSessionMock,
@@ -78,7 +75,6 @@ const {
   (): {
     getSessionEntryMock: MockFn<GetSessionEntryFn>;
     getRuntimeConfig: MockFn<GetRuntimeConfigFn>;
-    listSessionEntriesMock: MockFn<ListSessionEntriesFn>;
     loadSessionStoreMock: MockFn<LoadSessionStoreFn>;
     readSessionUpdatedAtMock: MockFn<ReadSessionUpdatedAtFn>;
     recordInboundSessionMock: MockFn<NonNullable<TelegramBotDeps["recordInboundSession"]>>;
@@ -95,13 +91,6 @@ const {
     getSessionEntryMock: vi.fn<GetSessionEntryFn>(({ storePath, sessionKey, agentId }) => {
       const resolvedStorePath = storePath ?? resolveStorePathMock(undefined, { agentId });
       return loadSessionStoreMock(resolvedStorePath)[sessionKey];
-    }),
-    listSessionEntriesMock: vi.fn<ListSessionEntriesFn>(({ storePath, agentId } = {}) => {
-      const resolvedStorePath = storePath ?? resolveStorePathMock(undefined, { agentId });
-      return Object.entries(loadSessionStoreMock(resolvedStorePath)).map(([sessionKey, entry]) => ({
-        sessionKey,
-        entry,
-      }));
     }),
     readSessionUpdatedAtMock: vi.fn<ReadSessionUpdatedAtFn>(() => undefined),
     recordInboundSessionMock: vi.fn(async () => undefined),
@@ -509,7 +498,6 @@ const telegramBotRuntimeForTest = {
 export const telegramBotDepsForTest: TelegramBotDeps = {
   getRuntimeConfig,
   getSessionEntry: getSessionEntryMock,
-  listSessionEntries: listSessionEntriesMock,
   resolveStorePath: resolveStorePathMock,
   readSessionUpdatedAt: readSessionUpdatedAtMock,
   recordInboundSession: recordInboundSessionMock as TelegramBotDeps["recordInboundSession"],
@@ -634,14 +622,6 @@ beforeEach(() => {
   getSessionEntryMock.mockImplementation(({ storePath, sessionKey, agentId }) => {
     const resolvedStorePath = storePath ?? resolveStorePathMock(undefined, { agentId });
     return loadSessionStoreMock(resolvedStorePath)[sessionKey];
-  });
-  listSessionEntriesMock.mockReset();
-  listSessionEntriesMock.mockImplementation(({ storePath, agentId } = {}) => {
-    const resolvedStorePath = storePath ?? resolveStorePathMock(undefined, { agentId });
-    return Object.entries(loadSessionStoreMock(resolvedStorePath)).map(([sessionKey, entry]) => ({
-      sessionKey,
-      entry,
-    }));
   });
   readSessionUpdatedAtMock.mockReset();
   readSessionUpdatedAtMock.mockReturnValue(undefined);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram users with large session stores paid a synchronous full-store read and object materialization before every inbound message was routed, so message latency grew with unrelated session history.

## Why This Change Was Made

Normal Telegram ingress now loads the current session directly and performs one additional keyed load only when a DM topic needs its parent session's persisted model override. The obsolete whole-store dependency and test plumbing are removed; direct overrides, parent inheritance, and fallback provenance continue through the existing shared resolver.

## User Impact

Telegram message routing no longer gets progressively slower as an operator accumulates sessions. Existing per-session and parent-session model selections continue to behave the same.

## Evidence

- SQLite-backed scaling benchmark under a heavily loaded 32-core host:
  - 1 entry: current ingress shape 0.10 ms; keyed lookup 0.08 ms
  - 100 entries: 0.28 ms; keyed lookup 0.05 ms
  - 1,000 entries: 2.16 ms; keyed lookup 0.04 ms
  - 10,000 entries: 33.50 ms; keyed lookup 0.04 ms
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-handlers.message-session.runtime.test.ts` — 1/1 passed.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.test.ts` — 137/137 passed.
- Local worktree-scoped `scripts/check-changed.mjs` fallback passed extension/test typechecks, lint, formatting, API and plugin-boundary guards, dead-code scan, and import-cycle checks. Blacksmith Testbox and brokered Crabbox providers were unavailable, so the documented trusted-source local fallback was used.
- Credential-free Telegram QA passed against Crabline: real polling ingress, durable dispatch, streaming preview send, and final in-place edit (`QA-CHANNEL-STREAMING-PREVIEW-FINAL-OK-1234567890`).
- Private-QA build completed successfully.
- Structured Codex autoreview: clean, no accepted/actionable findings.

AI-assisted: yes.
