### PR TITLE
fix(providers): preserve realtime tool-result delivery ownership

### DIFF
--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -862,11 +862,13 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
   it("preserves tool ownership while reusing a resumption handle", async () => {
     vi.useFakeTimers();
     const provider = buildGoogleRealtimeVoiceProvider();
+    const onError = vi.fn();
     const onToolCall = vi.fn();
     const bridge = provider.createBridge({
       providerConfig: { apiKey: "gemini-key" },
       onAudio: vi.fn(),
       onClearAudio: vi.fn(),
+      onError,
       onToolCall,
     });
 
@@ -879,6 +881,11 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
       },
     });
     firstSession.onclose({ code: 1011, reason: "temporary" });
+
+    onError.mockClear();
+    expect(() => bridge.submitToolResult("call-1", { value: 1n })).toThrow(/serializ/i);
+    expect(onError).toHaveBeenCalledOnce();
+
     void bridge.submitToolResult("call-1", { result: "ok" });
     expect(session.sendToolResponse).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(250);
@@ -930,7 +937,9 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     firstSession.onclose({ code: 1011, reason: "temporary" });
     onError.mockClear();
 
-    void bridge.submitToolResult("call-1", { result: "x".repeat(1024 * 1024) });
+    expect(() => bridge.submitToolResult("call-1", { result: "x".repeat(1024 * 1024) })).toThrow(
+      "Google Live reconnect tool-response buffer limit exceeded",
+    );
 
     expect(requireFirstError(onError).message).toBe(
       "Google Live reconnect tool-response buffer limit exceeded",
@@ -2301,7 +2310,9 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
       },
     });
 
-    void bridge.submitToolResult("consult-call", { status: "working" }, { willContinue: true });
+    expect(() =>
+      bridge.submitToolResult("consult-call", { status: "working" }, { willContinue: true }),
+    ).toThrow("does not support continuing tool responses");
     expect(session.sendToolResponse).not.toHaveBeenCalled();
     expect(requireFirstError(onError).message).toContain(
       "does not support continuing tool responses",
@@ -2332,13 +2343,113 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
 
     await bridge.connect();
 
-    void bridge.submitToolResult("missing-call", { result: "ok" });
+    expect(() => bridge.submitToolResult("missing-call", { result: "ok" })).toThrow(
+      "Google Live function response is missing a matching function call for missing-call",
+    );
 
     expect(session.sendToolResponse).not.toHaveBeenCalled();
     const error = requireFirstError(onError);
     expect(error.message).toBe(
       "Google Live function response is missing a matching function call for missing-call",
     );
+  });
+
+  it.each([
+    ["undefined", (): undefined => undefined],
+    ["function", () => () => undefined],
+    ["symbol", () => Symbol("invalid-tool-result")],
+    ["bigint", () => ({ value: 1n })],
+    [
+      "circular",
+      () => {
+        const result: { self?: unknown } = {};
+        result.self = result;
+        return result;
+      },
+    ],
+    ["omitted custom serialization", () => ({ toJSON: () => undefined })],
+  ] as const)(
+    "rejects %s Google Live tool results while keeping the call retryable",
+    async (_label, create) => {
+      const onError = vi.fn();
+      const bridge = buildGoogleRealtimeVoiceProvider().createBridge({
+        providerConfig: { apiKey: ["google", "test"].join("-") },
+        onAudio: vi.fn(),
+        onClearAudio: vi.fn(),
+        onError,
+        onToolCall: vi.fn(),
+      });
+      await bridge.connect();
+      lastConnectParams().callbacks.onmessage({
+        setupComplete: { sessionId: "session-1" },
+        toolCall: { functionCalls: [{ id: "call-1", name: "lookup", args: {} }] },
+      });
+
+      expect(() => bridge.submitToolResult("call-1", create())).toThrow(/serializ/i);
+      expect(onError).toHaveBeenCalledOnce();
+      expect(session.sendToolResponse).not.toHaveBeenCalled();
+
+      await bridge.submitToolResult("call-1", { recovered: true });
+
+      expect(session.sendToolResponse).toHaveBeenCalledExactlyOnceWith({
+        functionResponses: [{ id: "call-1", name: "lookup", response: { recovered: true } }],
+      });
+    },
+  );
+
+  it("preserves valid Google Live tool results and nested serialization keys", async () => {
+    const bridge = buildGoogleRealtimeVoiceProvider().createBridge({
+      providerConfig: { apiKey: ["google", "test"].join("-") },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onToolCall: vi.fn(),
+    });
+    const objectSerialization = vi.fn((key: string) => ({ key }));
+    const arraySerialization = vi.fn((key: string) => [key]);
+    const customArray: unknown[] & { toJSON?: (key: string) => string[] } = [];
+    customArray.toJSON = arraySerialization;
+    const values: unknown[] = [
+      null,
+      false,
+      0,
+      "",
+      "text",
+      [1],
+      { ok: true },
+      { toJSON: objectSerialization },
+      customArray,
+    ];
+    await bridge.connect();
+    lastConnectParams().callbacks.onmessage({
+      setupComplete: { sessionId: "session-1" },
+      toolCall: {
+        functionCalls: values.map((_, index) => ({
+          id: `call-${index}`,
+          name: "lookup",
+          args: {},
+        })),
+      },
+    });
+
+    for (const [index, result] of values.entries()) {
+      await bridge.submitToolResult(`call-${index}`, result);
+    }
+
+    expect(
+      session.sendToolResponse.mock.calls.map(([request]) => request.functionResponses[0].response),
+    ).toEqual([
+      { output: null },
+      { output: false },
+      { output: 0 },
+      { output: "" },
+      { output: "text" },
+      { output: [1] },
+      { ok: true },
+      { key: "response" },
+      { output: ["output"] },
+    ]);
+    expect(objectSerialization).toHaveBeenCalledExactlyOnceWith("response");
+    expect(arraySerialization).toHaveBeenCalledExactlyOnceWith("output");
   });
 
   it("reports Google Live tool response send failures without losing the call name", async () => {
@@ -2364,9 +2475,9 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
       throw sendError;
     });
 
-    void bridge.submitToolResult("call-1", ["retryable"]);
+    expect(() => bridge.submitToolResult("call-1", ["retryable"])).toThrow(sendError);
 
-    expect(onError).toHaveBeenCalledWith(sendError);
+    expect(onError).toHaveBeenCalledExactlyOnceWith(sendError);
 
     void bridge.submitToolResult("call-1", { result: "ok" });
 

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -49,6 +49,7 @@ import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-i
 import {
   asBoolean,
   asFiniteNumber,
+  isRecord,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { canonicalizeGoogleProviderBase64 } from "./base64.js";
@@ -725,6 +726,11 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
     this.sendUserMessage(greetingPrompt);
   }
 
+  private rejectToolResult(error: Error): never {
+    this.config.onError?.(error);
+    throw error;
+  }
+
   submitToolResult(
     callId: string,
     result: unknown,
@@ -735,52 +741,65 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
       if (this.seenFunctionCallIds.has(callId)) {
         return;
       }
-      this.config.onError?.(
+      this.rejectToolResult(
         new Error(
           `Google Live function response is missing a matching function call for ${callId}`,
         ),
       );
-      return;
     }
+    const isConsultTool = name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME;
+    if (options?.willContinue === true && !this.supportsToolResultContinuation) {
+      this.rejectToolResult(
+        new Error(`Google Live model ${this.model} does not support continuing tool responses`),
+      );
+    }
+    const wrapsResult = !result || typeof result !== "object" || Array.isArray(result);
+    const functionResponse: FunctionResponse = {
+      id: callId,
+      name,
+      response: wrapsResult ? { output: result } : (result as Record<string, unknown>),
+    };
+    if (isConsultTool && this.supportsToolResultContinuation) {
+      functionResponse.scheduling = FunctionResponseScheduling.WHEN_IDLE;
+      if (options?.willContinue === true) {
+        functionResponse.willContinue = true;
+      }
+    } else if (options?.willContinue === true) {
+      this.rejectToolResult(
+        new Error(
+          `Google Live continuation is only supported for ${REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME}`,
+        ),
+      );
+    }
+
+    let serializedResponse: string;
+    let normalizedResponse: FunctionResponse;
     try {
-      const isConsultTool = name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME;
-      if (options?.willContinue === true && !this.supportsToolResultContinuation) {
-        this.config.onError?.(
-          new Error(`Google Live model ${this.model} does not support continuing tool responses`),
-        );
-        return;
+      serializedResponse = JSON.stringify(functionResponse);
+      normalizedResponse = JSON.parse(serializedResponse) as FunctionResponse;
+      if (
+        !isRecord(normalizedResponse.response) ||
+        (wrapsResult && !Object.hasOwn(normalizedResponse.response, "output"))
+      ) {
+        throw new Error("Google Live function response is missing required JSON output");
       }
-      const functionResponse: FunctionResponse = {
-        id: callId,
-        name,
-        response:
-          result && typeof result === "object" && !Array.isArray(result)
-            ? (result as Record<string, unknown>)
-            : { output: result },
-      };
-      if (isConsultTool && this.supportsToolResultContinuation) {
-        functionResponse.scheduling = FunctionResponseScheduling.WHEN_IDLE;
-        if (options?.willContinue === true) {
-          functionResponse.willContinue = true;
-        }
-      } else if (options?.willContinue === true) {
-        this.config.onError?.(
-          new Error(
-            `Google Live continuation is only supported for ${REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME}`,
-          ),
-        );
-        return;
-      }
+    } catch (cause) {
+      this.rejectToolResult(
+        new Error("Google Live function response result is not JSON-serializable", { cause }),
+      );
+    }
+
+    try {
       const session = this.session;
       const canSendImmediately = Boolean(
         session && (!this.resumingSession || this.sessionConfigured),
       );
       if (session && canSendImmediately) {
         session.sendToolResponse({
-          functionResponses: [functionResponse],
+          functionResponses: [normalizedResponse],
         });
       } else {
-        this.queueToolResponseForReconnect(callId, functionResponse);
+        this.queueToolResponseForReconnect(callId, serializedResponse);
       }
       if (options?.willContinue !== true) {
         this.pendingFunctionNames.delete(callId);
@@ -793,6 +812,7 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
       } else {
         this.failConnection(sendError);
       }
+      throw sendError;
     }
   }
 
@@ -1131,8 +1151,7 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
     this.pendingToolResponseBytes = 0;
   }
 
-  private queueToolResponseForReconnect(callId: string, functionResponse: FunctionResponse): void {
-    const payload = JSON.stringify(functionResponse);
+  private queueToolResponseForReconnect(callId: string, payload: string): void {
     const payloadBytes = Buffer.byteLength(payload, "utf8");
     if (
       this.pendingToolResponses.length >= GOOGLE_REALTIME_MAX_PENDING_TOOL_RESPONSES ||

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -3421,6 +3421,74 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     );
   });
 
+  it.each([
+    ["undefined", (): undefined => undefined],
+    ["function", () => () => undefined],
+    ["symbol", () => Symbol("invalid-tool-result")],
+    ["bigint", () => ({ value: 1n })],
+    [
+      "circular",
+      () => {
+        const result: { self?: unknown } = {};
+        result.self = result;
+        return result;
+      },
+    ],
+    ["omitted custom serialization", () => ({ toJSON: () => undefined })],
+  ] as const)(
+    "rejects %s tool results without consuming a retryable call",
+    async (_label, create) => {
+      const bridge = createNativeBridge({ onToolCall: vi.fn() });
+      const socket = await connectReadyBridge(bridge);
+      emitCompletedToolCalls(socket);
+      const previousEventCount = socket.sent.length;
+
+      expect(() => bridge.submitToolResult("call_1", create())).toThrow();
+      expect(socket.sent).toHaveLength(previousEventCount);
+      expect(hasSentEventType(socket, "response.create")).toBe(false);
+
+      await bridge.submitToolResult("call_1", { recovered: true });
+
+      expect(parseSent(socket).find((event) => event.type === "conversation.item.create")).toEqual({
+        type: "conversation.item.create",
+        item: {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: JSON.stringify({ recovered: true }),
+        },
+      });
+    },
+  );
+
+  it("preserves valid JSON tool results and invokes custom serialization once", async () => {
+    const bridge = createNativeBridge({ onToolCall: vi.fn() });
+    const socket = await connectReadyBridge(bridge);
+    const values: unknown[] = [null, false, 0, "", "text", [1], { ok: true }];
+    const customSerialization = vi.fn((key: string) => ({ key }));
+    values.push({ toJSON: customSerialization });
+    const callIds = values.map((_, index) => `call_${index}`);
+    emitCompletedToolCalls(socket, callIds);
+
+    for (const [index, result] of values.entries()) {
+      await bridge.submitToolResult(callIds[index]!, result, { suppressResponse: true });
+    }
+
+    const outputs = parseSent(socket)
+      .filter((event) => event.type === "conversation.item.create")
+      .map((event) => (event.item as { output: string }).output);
+    expect(outputs).toEqual([
+      "null",
+      "false",
+      "0",
+      '""',
+      '"text"',
+      "[1]",
+      '{"ok":true}',
+      '{"key":""}',
+    ]);
+    expect(customSerialization).toHaveBeenCalledExactlyOnceWith("");
+  });
+
   it("does not request a realtime response for continuing tool results", async () => {
     const bridge = createNativeBridge({ onToolCall: vi.fn() });
     const socket = await connectReadyBridge(bridge);

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -697,12 +697,16 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     if (this.lifecycle.phase() === "terminal" || !this.pendingToolCallIds.has(callId)) {
       return;
     }
+    const output = JSON.stringify(result);
+    if (typeof output !== "string") {
+      throw new Error("OpenAI realtime voice tool result is not JSON-serializable");
+    }
     this.sendEvent({
       type: "conversation.item.create",
       item: {
         type: "function_call_output",
         call_id: callId,
-        output: JSON.stringify(result),
+        output,
       },
     });
     if (options?.willContinue === true) {

--- a/extensions/xai/lazy-capability-providers.test.ts
+++ b/extensions/xai/lazy-capability-providers.test.ts
@@ -398,6 +398,75 @@ describe("xAI lazy capability providers", () => {
     );
   });
 
+  it.each([
+    ["undefined", (): undefined => undefined],
+    ["function", () => () => undefined],
+    ["symbol", () => Symbol("invalid-tool-result")],
+    ["bigint", () => ({ value: 1n })],
+    [
+      "circular",
+      () => {
+        const result: { self?: unknown } = {};
+        result.self = result;
+        return result;
+      },
+    ],
+    ["omitted custom serialization", () => ({ toJSON: () => undefined })],
+  ] as const)(
+    "rejects %s voice tool results before lazy queue admission",
+    async (_label, create) => {
+      const lazy = await loadLazyProviders();
+      const onError = vi.fn();
+      const bridge = lazy
+        .createLazyXaiRealtimeVoiceProvider()
+        .createBridge(createVoiceRequest({ onError }));
+
+      expect(() => bridge.submitToolResult("call-1", create())).toThrow(/serializ/i);
+      expect(onError).toHaveBeenCalledOnce();
+
+      await bridge.submitToolResult("call-1", { recovered: true });
+      await bridge.connect();
+
+      expect(runtimeMocks.voiceSubmitToolResult).toHaveBeenCalledExactlyOnceWith(
+        "call-1",
+        { recovered: true },
+        undefined,
+      );
+    },
+  );
+
+  it("snapshots lazy voice tool results with one canonical serialization", async () => {
+    const lazy = await loadLazyProviders();
+    const bridge = lazy.createLazyXaiRealtimeVoiceProvider().createBridge(createVoiceRequest());
+    const toJSON = vi.fn((key: string) => ({ key, ok: true }));
+
+    await bridge.submitToolResult("call-1", { toJSON });
+    await bridge.connect();
+
+    expect(toJSON).toHaveBeenCalledExactlyOnceWith("");
+    expect(runtimeMocks.voiceSubmitToolResult).toHaveBeenCalledExactlyOnceWith(
+      "call-1",
+      { key: "", ok: true },
+      undefined,
+    );
+  });
+
+  it("ignores unsupported interim voice results before lazy queue admission", async () => {
+    const lazy = await loadLazyProviders();
+    const onError = vi.fn();
+    const bridge = lazy
+      .createLazyXaiRealtimeVoiceProvider()
+      .createBridge(createVoiceRequest({ onError }));
+
+    expect(() =>
+      bridge.submitToolResult("call-1", undefined, { willContinue: true }),
+    ).not.toThrow();
+    await bridge.connect();
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(runtimeMocks.voiceSubmitToolResult).not.toHaveBeenCalled();
+  });
+
   it("bounds pending voice tool results by aggregate serialized bytes", async () => {
     const lazy = await loadLazyProviders();
     const onError = vi.fn();
@@ -407,7 +476,9 @@ describe("xAI lazy capability providers", () => {
     const accepted = { text: "a".repeat(200 * 1024) };
 
     await bridge.submitToolResult("call-1", accepted);
-    await bridge.submitToolResult("call-2", { text: "b".repeat(64 * 1024) });
+    expect(() => bridge.submitToolResult("call-2", { text: "b".repeat(64 * 1024) })).toThrow(
+      "xAI realtime voice pending tool result overflow during lazy startup",
+    );
     await bridge.connect();
 
     expect(runtimeMocks.voiceSubmitToolResult).toHaveBeenCalledOnce();
@@ -434,7 +505,9 @@ describe("xAI lazy capability providers", () => {
     bridge.sendUserMessage?.(acceptedMessage);
     bridge.sendUserMessage?.("c".repeat(64 * 1024));
     await bridge.submitToolResult("call-1", acceptedResult);
-    await bridge.submitToolResult("call-2", { text: "d".repeat(64 * 1024) });
+    expect(() => bridge.submitToolResult("call-2", { text: "d".repeat(64 * 1024) })).toThrow(
+      "xAI realtime voice pending tool result overflow during lazy startup",
+    );
 
     expect(runtimeMocks.voiceSendUserMessage).not.toHaveBeenCalled();
     expect(runtimeMocks.voiceSubmitToolResult).not.toHaveBeenCalled();
@@ -513,8 +586,11 @@ describe("xAI lazy capability providers", () => {
     await bridge.submitToolResult("call-1", { text: "a".repeat(200 * 1024) });
     const connectPromise = bridge.connect();
     await vi.waitFor(() => expect(runtimeMocks.voiceSubmitToolResult).toHaveBeenCalledOnce());
-    await bridge.submitToolResult("call-2", { text: "b".repeat(64 * 1024) });
+    expect(() => bridge.submitToolResult("call-2", { text: "b".repeat(64 * 1024) })).toThrow(
+      "xAI realtime voice pending tool result overflow during lazy startup",
+    );
 
+    expect(onError).toHaveBeenCalledOnce();
     expect(onError.mock.calls[0]?.[0]).toEqual(
       new Error("xAI realtime voice pending tool result overflow during lazy startup"),
     );

--- a/extensions/xai/lazy-capability-providers.ts
+++ b/extensions/xai/lazy-capability-providers.ts
@@ -28,6 +28,7 @@ import {
   createXaiVideoGenerationProviderMetadata,
   normalizeXaiRealtimeTranscriptionProviderConfig,
 } from "./capability-provider-metadata.js";
+import { serializeXaiRealtimeToolResult } from "./realtime-voice-config.js";
 import { createXaiSpeechProviderMetadata } from "./speech-provider-metadata.js";
 
 const MAX_LAZY_REALTIME_TRANSCRIPTION_AUDIO_BYTES = 2 * 1024 * 1024;
@@ -35,15 +36,6 @@ const MAX_LAZY_REALTIME_VOICE_USER_MESSAGES = 128;
 const MAX_LAZY_REALTIME_VOICE_USER_MESSAGE_BYTES = 256 * 1024;
 const MAX_LAZY_REALTIME_VOICE_TOOL_RESULTS = 128;
 const MAX_LAZY_REALTIME_VOICE_TOOL_RESULT_BYTES = 256 * 1024;
-
-function serializedJsonBytes(value: unknown): number | undefined {
-  try {
-    const serialized = JSON.stringify(value);
-    return typeof serialized === "string" ? Buffer.byteLength(serialized, "utf8") : undefined;
-  } catch {
-    return undefined;
-  }
-}
 
 const loadXaiImageGenerationProvider = createLazyRuntimeModule(async () =>
   (await import("./image-generation-provider.js")).buildXaiImageGenerationProvider(),
@@ -545,23 +537,34 @@ function createLazyXaiRealtimeVoiceBridge(
       }
     },
     submitToolResult: (callId, result, options) => {
-      if (!acceptsCurrentInput()) {
+      if (!acceptsCurrentInput() || options?.willContinue === true) {
         return;
       }
       if (acceptsInput && bridge) {
         return bridge.submitToolResult(callId, result, options);
       }
-      const pending = { callId, result, ...(options ? { options } : {}) };
-      const resultBytes = serializedJsonBytes(pending);
+      let serialized: string;
+      try {
+        serialized = serializeXaiRealtimeToolResult(result);
+      } catch (error) {
+        req.onError?.(error as Error);
+        throw error;
+      }
+      const pending = {
+        callId,
+        result: JSON.parse(serialized) as unknown,
+        ...(options ? { options } : {}),
+      };
+      const resultBytes = Buffer.byteLength(JSON.stringify(pending), "utf8");
       if (
-        resultBytes === undefined ||
         pendingToolResultCount >= MAX_LAZY_REALTIME_VOICE_TOOL_RESULTS ||
         pendingToolResultBytes + resultBytes > MAX_LAZY_REALTIME_VOICE_TOOL_RESULT_BYTES
       ) {
-        req.onError?.(
-          new Error("xAI realtime voice pending tool result overflow during lazy startup"),
+        const error = new Error(
+          "xAI realtime voice pending tool result overflow during lazy startup",
         );
-        return;
+        req.onError?.(error);
+        throw error;
       }
       pendingOperations.push({
         ...pending,

--- a/extensions/xai/realtime-voice-bridge.ts
+++ b/extensions/xai/realtime-voice-bridge.ts
@@ -22,6 +22,7 @@ import {
   XAI_REALTIME_MAX_RECONNECT_ATTEMPTS,
   XAI_REALTIME_WS_MAX_PAYLOAD_BYTES,
   readXaiRealtimeErrorDetail,
+  serializeXaiRealtimeToolResult,
   toXaiRealtimeWsUrl,
   type XaiRealtimeEvent,
 } from "./realtime-voice-config.js";
@@ -98,17 +99,29 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
     result: unknown,
     options?: RealtimeVoiceToolResultOptions,
   ): void {
-    if (this.lifecycle.phase() === "terminal") {
+    if (this.lifecycle.phase() === "terminal" || options?.willContinue === true) {
       return;
     }
     if (!this.canSubmitInput()) {
-      if (this.pendingToolResults.length < XAI_REALTIME_MAX_PENDING_TOOL_RESULTS) {
-        this.pendingToolResults.push({ callId, result, ...(options ? { options } : {}) });
-      } else {
-        this.config.onError?.(
-          new Error("xAI realtime voice pending tool result queue overflow during reconnect"),
-        );
+      let serialized: string;
+      try {
+        serialized = serializeXaiRealtimeToolResult(result);
+      } catch (error) {
+        this.config.onError?.(error as Error);
+        throw error;
       }
+      if (this.pendingToolResults.length >= XAI_REALTIME_MAX_PENDING_TOOL_RESULTS) {
+        const error = new Error(
+          "xAI realtime voice pending tool result queue overflow during reconnect",
+        );
+        this.config.onError?.(error);
+        throw error;
+      }
+      this.pendingToolResults.push({
+        callId,
+        result: JSON.parse(serialized) as unknown,
+        ...(options ? { options } : {}),
+      });
       return;
     }
     this.submitToolResultNow(callId, result, options);

--- a/extensions/xai/realtime-voice-config.ts
+++ b/extensions/xai/realtime-voice-config.ts
@@ -131,6 +131,19 @@ export const XAI_REALTIME_VOICES = [
   "leo",
 ] as const satisfies readonly XaiRealtimeVoice[];
 
+export function serializeXaiRealtimeToolResult(result: unknown): string {
+  const message = "xAI realtime voice tool result is not JSON-serializable";
+  try {
+    const serialized = JSON.stringify(result);
+    if (typeof serialized === "string") {
+      return serialized;
+    }
+  } catch (cause) {
+    throw new Error(message, { cause });
+  }
+  throw new Error(message);
+}
+
 function readRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
 }

--- a/extensions/xai/realtime-voice-protocol.ts
+++ b/extensions/xai/realtime-voice-protocol.ts
@@ -13,6 +13,7 @@ import {
   XAI_REALTIME_DEFAULT_VAD_THRESHOLD,
   XAI_REALTIME_INPUT_TRANSCRIPTION_MODEL,
   XAI_REALTIME_MAX_PENDING_PLAYBACK_MARKS,
+  serializeXaiRealtimeToolResult,
   type XaiRealtimeAudioFormatConfig,
   type XaiRealtimeEvent,
   type XaiRealtimeSessionUpdate,
@@ -35,10 +36,7 @@ export abstract class XaiRealtimeVoiceProtocol {
   protected lastAssistantItemId: string | null = null;
   protected toolCallBuffers = new Map<string, { name: string; callId: string; args: string }>();
   protected deliveredToolCallKeys = new Set<string>();
-  protected pendingToolResultAcks = new Map<
-    string,
-    { result: unknown; options?: RealtimeVoiceToolResultOptions }
-  >();
+  protected pendingToolResultAcks = new Set<string>();
   protected conversationId: string | null = null;
 
   constructor(protected readonly config: XaiRealtimeVoiceBridgeConfig) {
@@ -67,18 +65,16 @@ export abstract class XaiRealtimeVoiceProtocol {
     if (options?.willContinue === true) {
       return;
     }
-    this.pendingToolResultAcks.set(callId, {
-      result,
-      ...(options ? { options } : {}),
-    });
+    const output = serializeXaiRealtimeToolResult(result);
     this.sendEvent({
       type: "conversation.item.create",
       item: {
         type: "function_call_output",
         call_id: callId,
-        output: JSON.stringify(result),
+        output,
       },
     });
+    this.pendingToolResultAcks.add(callId);
     this.continuingToolCallIds.delete(callId);
     this.pendingToolCallIds.delete(callId);
     if (options?.suppressResponse !== true) {

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -1258,6 +1258,117 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     bridge.close();
   });
 
+  it.each([
+    ["undefined", (): undefined => undefined],
+    ["function", () => () => undefined],
+    ["symbol", () => Symbol("invalid-tool-result")],
+    ["bigint", () => ({ value: 1n })],
+    [
+      "circular",
+      () => {
+        const result: { self?: unknown } = {};
+        result.self = result;
+        return result;
+      },
+    ],
+    ["omitted custom serialization", () => ({ toJSON: () => undefined })],
+  ] as const)(
+    "rejects %s realtime tool results before transport ownership changes",
+    async (_label, create) => {
+      const onError = vi.fn();
+      const bridge = createTestBridge({ onError, onToolCall: vi.fn() });
+      const socket = await openRealtimeBridge(bridge);
+      socket.emitServer({
+        type: "response.function_call_arguments.done",
+        item_id: "item_call_1",
+        name: "openclaw_agent_consult",
+        call_id: "call_1",
+        arguments: "{}",
+      });
+
+      expect(() => bridge.submitToolResult("call_1", create())).toThrow(/serializ/i);
+      expect(onError).not.toHaveBeenCalled();
+      expect(
+        parseSent(socket).filter((event) => event.type === "conversation.item.create"),
+      ).toEqual([]);
+
+      await bridge.submitToolResult("call_1", { recovered: true });
+
+      expect(parseSent(socket).slice(-2)).toEqual([
+        {
+          type: "conversation.item.create",
+          item: {
+            type: "function_call_output",
+            call_id: "call_1",
+            output: JSON.stringify({ recovered: true }),
+          },
+        },
+        { type: "response.create" },
+      ]);
+      bridge.close();
+    },
+  );
+
+  it("preserves valid realtime tool results with one canonical serialization", async () => {
+    const bridge = createTestBridge({ onToolCall: vi.fn() });
+    const socket = await openRealtimeBridge(bridge);
+    const customSerialization = vi.fn((key: string) => ({ key }));
+    const values: unknown[] = [
+      null,
+      false,
+      0,
+      "",
+      "text",
+      [1],
+      { ok: true },
+      {
+        toJSON: customSerialization,
+      },
+    ];
+
+    for (const [index, result] of values.entries()) {
+      const callId = `call_${index}`;
+      socket.emitServer({
+        type: "response.function_call_arguments.done",
+        item_id: `item_${callId}`,
+        name: "openclaw_agent_consult",
+        call_id: callId,
+        arguments: "{}",
+      });
+      await bridge.submitToolResult(callId, result, { suppressResponse: true });
+    }
+
+    const outputs = parseSent(socket)
+      .filter((event) => event.type === "conversation.item.create")
+      .map((event) => (event.item as { output: string }).output);
+    expect(outputs).toEqual([
+      "null",
+      "false",
+      "0",
+      '""',
+      '"text"',
+      "[1]",
+      '{"ok":true}',
+      '{"key":""}',
+    ]);
+    expect(customSerialization).toHaveBeenCalledExactlyOnceWith("");
+    bridge.close();
+  });
+
+  it("rejects reconnect queue overflow without reporting successful delivery", async () => {
+    const onError = vi.fn();
+    const bridge = createTestBridge({ onError });
+
+    for (let index = 0; index < 128; index += 1) {
+      await bridge.submitToolResult(`call_${index}`, { ok: true });
+    }
+
+    expect(() => bridge.submitToolResult("overflow", { ok: true })).toThrow(
+      "xAI realtime voice pending tool result queue overflow during reconnect",
+    );
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
   it("waits for all parallel tool results before sending response.create", async () => {
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
     const bridge = createTestBridge({
@@ -1310,6 +1421,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     });
 
     await bridge.submitToolResult("call_1", { status: "working" }, { willContinue: true });
+    await bridge.submitToolResult("call_1", undefined, { willContinue: true });
     expect(parseSent(socket).filter((event) => event.type === "conversation.item.create")).toEqual(
       [],
     );
@@ -1485,6 +1597,57 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     bridge.close();
   });
 
+  it("keeps failed realtime transport sends retryable across reconnect", async () => {
+    vi.useFakeTimers();
+    resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: ["xai", "test"].join("-") });
+    const onEvent = vi.fn();
+    const bridge = createTestBridge({
+      providerConfig: { sessionResumption: true },
+      onEvent,
+      onToolCall: vi.fn(),
+    });
+    const firstSocket = await openRealtimeBridge(bridge, 0, "conv_failed_output");
+    firstSocket.emitServer({
+      type: "response.function_call_arguments.done",
+      item_id: "item_failed_output",
+      call_id: "call_failed_output",
+      name: "openclaw_agent_consult",
+      arguments: "{}",
+    });
+    const sendError = new Error("realtime transport rejected the output");
+    vi.spyOn(firstSocket, "send").mockImplementationOnce(() => {
+      throw sendError;
+    });
+
+    expect(() => bridge.submitToolResult("call_failed_output", { failed: true })).toThrow(
+      sendError,
+    );
+
+    firstSocket.close(1006, "connection lost after rejected output");
+    await vi.advanceTimersByTimeAsync(1000);
+    await waitForRealtimeState(() => expect(FakeWebSocket.instances).toHaveLength(2));
+    const resumedSocket = requireSocket(1);
+    resumedSocket.open();
+    resumedSocket.emitServer({ type: "session.updated" });
+
+    await bridge.submitToolResult("call_failed_output", { recovered: true });
+
+    expect(
+      parseSent(resumedSocket).find((event) => event.type === "conversation.item.create"),
+    ).toEqual({
+      type: "conversation.item.create",
+      item: {
+        type: "function_call_output",
+        call_id: "call_failed_output",
+        output: JSON.stringify({ recovered: true }),
+      },
+    });
+    expect(onEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "session.reconnect.blocked" }),
+    );
+    bridge.close();
+  });
+
   it("fails closed when a tool output was not acknowledged before reconnect", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
@@ -1585,8 +1748,10 @@ describe("buildXaiRealtimeVoiceProvider", () => {
   it("queues tool results submitted while a resumed session is reconnecting", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const onError = vi.fn();
     const bridge = createTestBridge({
       providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
+      onError,
       onToolCall: vi.fn(),
     });
 
@@ -1608,6 +1773,14 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     const secondSocket = requireSocket(1);
     expect(String(secondSocket.args[0])).toContain("conversation_id=conv_tool_queue");
     secondSocket.open();
+
+    onError.mockClear();
+    expect(() => bridge.submitToolResult("call_1", { invalid: 1n })).toThrow(/serializ/i);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(() =>
+      bridge.submitToolResult("call_1", undefined, { willContinue: true }),
+    ).not.toThrow();
+    expect(onError).toHaveBeenCalledOnce();
 
     await bridge.submitToolResult("call_1", { text: "first" });
     expect(


### PR DESCRIPTION
## What Problem This Solves

Realtime tool-result submissions could appear successful even when their payload was not representable on the provider's wire format, the connection rejected the send, or a reconnect queue overflowed. Once the gateway accepted that false success, the original tool call could not be retried.

## Why This Change Was Made

Each provider now validates and snapshots its own wire payload before consuming pending ownership, acknowledges delivery only after its actual transport accepts the message, and propagates genuine send and queue failures through the existing provider lifecycle.

The provider-specific owners preserve valid JSON values and custom serialization semantics, unsupported interim behavior, reconnect policies, and exactly-once error callbacks. No core or public provider contracts were changed.

## User Impact

Failed realtime tool outputs now produce an actionable failure and remain retryable instead of silently disappearing after the gateway reports success.

## Evidence

- Tests against the existing registered provider and gateway paths reproduced 34 failures while 267 existing controls passed.
- The final three-provider focused suites pass all 301 cases, including malformed values, custom serializers, lazy startup, reconnect queues, transport errors, and acknowledgement ownership.
- The complete ten-file changed gate passes production and test typechecks, both lint lanes, provider ownership, and all runtime/security guards.
- An independent review verified the upstream websocket and SDK contracts, and a fresh structured review reported no actionable findings.
- Production grows by 48 lines across three distinct provider-owned wire and lifecycle boundaries; no public configuration, authentication, core routing, or persistent state changes.
