### PR TITLE
fix(ai): fence Responses replay metadata

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -96,6 +96,7 @@ const gpt56SolModel = {
 } satisfies Model<"openai-responses">;
 
 const testAllowedToolCallProviders = new Set(["openai", "openai-codex", "opencode"]);
+const reasoningReplayIdentity = { sessionId: "session-a", authProfileId: "profile-a" };
 
 function createAssistantOutput(): AssistantMessage {
   return {
@@ -830,6 +831,87 @@ describe("convertResponsesMessages", () => {
       summary: [],
     });
   });
+
+  const sameRouteReplayMetadata = buildOpenAIResponsesReasoningReplayMetadata(
+    nativeOpenAIModel,
+    reasoningReplayIdentity,
+  );
+  const sessionMismatchReplayMetadata = buildOpenAIResponsesReasoningReplayMetadata(
+    nativeOpenAIModel,
+    { ...reasoningReplayIdentity, sessionId: "session-b" },
+  );
+  const authMismatchReplayMetadata = buildOpenAIResponsesReasoningReplayMetadata(
+    nativeOpenAIModel,
+    { ...reasoningReplayIdentity, authProfileId: "profile-b" },
+  );
+  const endpointMismatchReplayMetadata = buildOpenAIResponsesReasoningReplayMetadata(
+    { ...nativeOpenAIModel, baseUrl: "https://proxy.example.com/v1" },
+    reasoningReplayIdentity,
+  );
+
+  it.each([
+    ["matching block metadata", sameRouteReplayMetadata, sessionMismatchReplayMetadata, true],
+    ["mismatched block metadata", sessionMismatchReplayMetadata, sameRouteReplayMetadata, false],
+    ["auth-mismatched block metadata", authMismatchReplayMetadata, undefined, false],
+    ["endpoint-mismatched block metadata", endpointMismatchReplayMetadata, undefined, false],
+    ["malformed block metadata", null, sameRouteReplayMetadata, false],
+    ["matching embedded metadata", undefined, sameRouteReplayMetadata, true],
+    ["mismatched embedded metadata", undefined, sessionMismatchReplayMetadata, false],
+    ["malformed embedded metadata", undefined, null, false],
+  ])(
+    "fences encrypted reasoning with %s",
+    (_name, blockMetadata, embeddedMetadata, preservesCiphertext) => {
+      const input = convertResponsesMessages(
+        nativeOpenAIModel,
+        {
+          messages: [
+            {
+              ...createAssistantOutput(),
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "Safe visible reasoning.",
+                  thinkingSignature: JSON.stringify({
+                    type: "reasoning",
+                    id: "rs_route_fenced",
+                    summary: [{ type: "summary_text", text: "safe summary" }],
+                    content: [{ type: "reasoning_text", text: "safe content" }],
+                    encrypted_content: "route-bound-ciphertext",
+                    ...(embeddedMetadata !== undefined
+                      ? { __openclaw_replay: embeddedMetadata }
+                      : {}),
+                  }),
+                  ...(blockMetadata !== undefined
+                    ? { openclawReasoningReplay: blockMetadata }
+                    : {}),
+                },
+              ] as unknown as AssistantMessage["content"],
+            },
+          ],
+        },
+        allowedToolCallProviders,
+        {
+          includeSystemPrompt: false,
+          replayResponsesItemIds: true,
+          ...reasoningReplayIdentity,
+        },
+      ) as unknown as Array<Record<string, unknown>>;
+
+      const reasoningItem = input.find((item) => item.type === "reasoning");
+      expect(reasoningItem).toMatchObject({
+        type: "reasoning",
+        id: "rs_route_fenced",
+        summary: [{ type: "summary_text", text: "safe summary" }],
+        content: [{ type: "reasoning_text", text: "safe content" }],
+      });
+      expect(reasoningItem).not.toHaveProperty("__openclaw_replay");
+      if (preservesCiphertext) {
+        expect(reasoningItem).toHaveProperty("encrypted_content", "route-bound-ciphertext");
+      } else {
+        expect(reasoningItem).not.toHaveProperty("encrypted_content");
+      }
+    },
+  );
 
   it("serializes structured tool results as text instead of image placeholders", () => {
     const input = convertResponsesMessages(

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -16,11 +16,16 @@ import type { BaseOpenAIStreamOptions } from "../provider-options.js";
 import {
   buildOpenAIResponsesCompactionReplayPlan,
   buildOpenAIResponsesReasoningReplayMetadata,
+  buildOpenAIResponsesReplayContext,
   suppressOpenAIResponsesCompaction,
   type OpenAIResponsesReplayMode,
 } from "../transports/openai-responses-compaction-replay.js";
 import type { OpenAIResponsesRequestParams } from "../transports/openai-responses-contracts.js";
-import { createResponsesStreamWithEncryptedContentRetry } from "../transports/openai-responses-replay-internal.js";
+import {
+  createResponsesStreamWithEncryptedContentRetry,
+  prepareOpenAIResponsesReasoningItemForReplay,
+  readOpenAIResponsesReasoningReplayBlockMetadata,
+} from "../transports/openai-responses-replay-internal.js";
 import { processResponsesStream } from "../transports/openai-responses-stream-internal.js";
 import { transportAbortError } from "../transports/transport-stream-shared.js";
 import type {
@@ -79,19 +84,6 @@ function sanitizeToolResultText(text: string, fallback: string): string {
 
 type ReplayableResponseOutputMessage = Omit<ResponseOutputMessage, "id"> & { id?: string };
 type ReplayableResponseReasoningItem = Omit<ResponseReasoningItem, "id"> & { id?: string };
-function normalizeResponsesReasoningReplayItem(params: {
-  item: ReplayableResponseReasoningItem;
-  replayResponsesItemIds: boolean;
-}): ReplayableResponseReasoningItem {
-  const next = { ...(params.item as ReplayableResponseReasoningItem & Record<string, unknown>) };
-  if (!Array.isArray(next.summary)) {
-    next.summary = [];
-  }
-  if (!params.replayResponsesItemIds) {
-    delete next.id;
-  }
-  return next as ReplayableResponseReasoningItem;
-}
 
 function parseTextSignature(
   signature: string | undefined,
@@ -223,6 +215,10 @@ export function convertResponsesMessages<TApi extends Api>(
 ): ResponseInput {
   const messages: ResponseInput = [];
   const shouldReplayResponsesItemIds = options?.replayResponsesItemIds ?? true;
+  const replayContext = buildOpenAIResponsesReplayContext(model, {
+    sessionId: options?.sessionId,
+    authProfileId: options?.authProfileId,
+  });
 
   const normalizeIdPart = (part: string): string => {
     const sanitized = part.replace(/[^a-zA-Z0-9_-]/g, "_");
@@ -333,11 +329,24 @@ export function convertResponsesMessages<TApi extends Api>(
       for (const block of msg.content) {
         if (block.type === "thinking") {
           if (block.thinkingSignature) {
-            const reasoningItem = normalizeResponsesReasoningReplayItem({
-              item: JSON.parse(block.thinkingSignature) as ReplayableResponseReasoningItem,
-              replayResponsesItemIds: shouldReplayResponsesItemIds,
-            });
-            output.push(reasoningItem as ResponseInputItem);
+            const reasoningItem = JSON.parse(
+              block.thinkingSignature,
+            ) as ReplayableResponseReasoningItem;
+            const blockMetadata = readOpenAIResponsesReasoningReplayBlockMetadata(
+              block as unknown as Record<string, unknown>,
+            );
+            // Unannotated items retain the shipped public-provider stateless replay contract.
+            // Once capture provenance exists, ciphertext is fenced to that exact route.
+            const replayableReasoningItem = prepareOpenAIResponsesReasoningItemForReplay(
+              reasoningItem,
+              replayContext,
+              blockMetadata,
+              { preserveUnattributedEncryptedContent: true },
+            );
+            if (!shouldReplayResponsesItemIds) {
+              delete replayableReasoningItem.id;
+            }
+            output.push(replayableReasoningItem as ResponseInputItem);
             previousReplayItemWasReasoning = true;
           }
         } else if (block.type === "text") {

--- a/packages/ai/src/transports/openai-responses-compaction-replay.test.ts
+++ b/packages/ai/src/transports/openai-responses-compaction-replay.test.ts
@@ -218,6 +218,122 @@ describe("OpenAI Responses compaction replay", () => {
     });
   });
 
+  it("recovers and replays a terminal-only compaction without an id", async () => {
+    const output = await processEvents([
+      {
+        type: "response.completed",
+        response: {
+          id: "resp_terminal_idless",
+          status: "completed",
+          output: [
+            {
+              type: "compaction",
+              encrypted_content: "opaque-terminal-idless",
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(output.providerReplay).toMatchObject({
+      type: "openai-responses-compaction",
+      data: "opaque-terminal-idless",
+      replayIndex: 0,
+    });
+    expect(output.providerReplay).not.toHaveProperty("id");
+    expect(
+      convertResponsesMessages(
+        model,
+        { messages: [output] },
+        new Set(["openai"]),
+        replayIdentity,
+      ).find((item) => item.type === "compaction"),
+    ).toEqual({
+      type: "compaction",
+      encrypted_content: "opaque-terminal-idless",
+    });
+  });
+
+  it("keeps an identical captured idless compaction without replacing its state", async () => {
+    const output = createOutput();
+    const existingReplay = compactionState(model, {
+      id: undefined,
+      data: "opaque-terminal-idless",
+      replayIndex: 7,
+    });
+    delete existingReplay.id;
+    output.providerReplay = existingReplay;
+
+    await processResponsesStream(
+      events([
+        {
+          type: "response.completed",
+          response: {
+            id: "resp_terminal_idless_duplicate",
+            status: "completed",
+            output: [
+              {
+                type: "compaction",
+                encrypted_content: "opaque-terminal-idless",
+              },
+            ],
+          },
+        },
+      ]),
+      output,
+      { push: () => undefined },
+      model,
+      {
+        reasoningReplayMetadata: buildOpenAIResponsesReasoningReplayMetadata(model, replayIdentity),
+      },
+    );
+
+    expect(output.providerReplay).toBe(existingReplay);
+    expect(output.providerReplay.replayIndex).toBe(7);
+  });
+
+  it("replaces an idless compaction when its encrypted payload changes", async () => {
+    const output = createOutput();
+    const existingReplay = compactionState(model, {
+      id: undefined,
+      data: "opaque-terminal-idless-old",
+      replayIndex: 0,
+    });
+    delete existingReplay.id;
+    output.providerReplay = existingReplay;
+
+    await processResponsesStream(
+      events([
+        {
+          type: "response.completed",
+          response: {
+            id: "resp_terminal_idless_changed",
+            status: "completed",
+            output: [
+              {
+                type: "compaction",
+                encrypted_content: "opaque-terminal-idless-new",
+              },
+            ],
+          },
+        },
+      ]),
+      output,
+      { push: () => undefined },
+      model,
+      {
+        reasoningReplayMetadata: buildOpenAIResponsesReasoningReplayMetadata(model, replayIdentity),
+      },
+    );
+
+    expect(output.providerReplay).not.toBe(existingReplay);
+    expect(output.providerReplay).toMatchObject({
+      type: "openai-responses-compaction",
+      data: "opaque-terminal-idless-new",
+      replayIndex: 0,
+    });
+  });
+
   it("orders reasoning, compaction, and message by normalized replay content", async () => {
     const output = await processEvents([
       {

--- a/packages/ai/src/transports/openai-responses-replay-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-internal.ts
@@ -223,11 +223,14 @@ function encryptedReasoningReplayMetadataMatches(
   );
 }
 
-function readOpenAIResponsesReasoningReplayBlockMetadata(
+export function readOpenAIResponsesReasoningReplayBlockMetadata(
   block: Record<string, unknown>,
-): OpenAIResponsesReasoningReplayMetadata | undefined {
+): OpenAIResponsesReasoningReplayMetadata | null | undefined {
+  if (!Object.hasOwn(block, OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY)) {
+    return undefined;
+  }
   const value = block[OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY];
-  return isOpenAIResponsesReasoningReplayMetadata(value) ? value : undefined;
+  return isOpenAIResponsesReasoningReplayMetadata(value) ? value : null;
 }
 
 function normalizeOpenAIResponsesReasoningReplayItem(
@@ -243,17 +246,26 @@ function normalizeOpenAIResponsesReasoningReplayItem(
 export function prepareOpenAIResponsesReasoningItemForReplay(
   item: ReplayableResponseReasoningItem,
   context: OpenAIResponsesReplayContext,
-  blockMetadata?: OpenAIResponsesReasoningReplayMetadata,
+  blockMetadata?: OpenAIResponsesReasoningReplayMetadata | null,
+  options?: { preserveUnattributedEncryptedContent?: boolean },
 ): ReplayableResponseReasoningItem {
-  const { [OPENAI_RESPONSES_REASONING_REPLAY_META_KEY]: rawMetadata, ...rest } =
-    item as ReplayableResponseReasoningItem & Record<string, unknown>;
+  const record = item as ReplayableResponseReasoningItem & Record<string, unknown>;
+  const hasRawMetadata = Object.hasOwn(record, OPENAI_RESPONSES_REASONING_REPLAY_META_KEY);
+  const { [OPENAI_RESPONSES_REASONING_REPLAY_META_KEY]: rawMetadata, ...rest } = record;
   if (!("encrypted_content" in rest)) {
     return normalizeOpenAIResponsesReasoningReplayItem(rest as ReplayableResponseReasoningItem);
   }
   const metadata =
-    blockMetadata ??
-    (isOpenAIResponsesReasoningReplayMetadata(rawMetadata) ? rawMetadata : undefined);
-  if (encryptedReasoningReplayMetadataMatches(metadata, context)) {
+    blockMetadata !== undefined
+      ? (blockMetadata ?? undefined)
+      : isOpenAIResponsesReasoningReplayMetadata(rawMetadata)
+        ? rawMetadata
+        : undefined;
+  const preserveUnattributed =
+    blockMetadata === undefined &&
+    !hasRawMetadata &&
+    options?.preserveUnattributedEncryptedContent === true;
+  if (preserveUnattributed || encryptedReasoningReplayMetadataMatches(metadata, context)) {
     return normalizeOpenAIResponsesReasoningReplayItem(rest as ReplayableResponseReasoningItem);
   }
   const stripped = stripEncryptedReasoningContentFields(rest);

--- a/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
@@ -26,6 +26,7 @@ import type {
 import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
 import { captureOpenAIResponsesCompaction } from "./openai-responses-compaction-replay.js";
 import {
+  OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE,
   OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY,
   type OpenAIResponsesReasoningReplayMetadata,
 } from "./openai-responses-contracts.js";
@@ -267,7 +268,12 @@ export function createResponsesTerminalController(params: {
         }
       } else {
         params.setLastTextBlock(null);
-        if (item.type === "compaction" && output.providerReplay?.id !== item.id) {
+        const alreadyCapturedCompaction =
+          item.type === "compaction" &&
+          output.providerReplay?.type === OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE &&
+          output.providerReplay.id === item.id &&
+          output.providerReplay.data === item.encrypted_content;
+        if (item.type === "compaction" && !alreadyCapturedCompaction) {
           let replayIndex = blocks.length;
           for (const laterItem of items.slice(terminalIndex + 1)) {
             const laterContentIndex = params.outputItemContentIndexes.get(laterItem);

--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -284,6 +284,7 @@ describe("redactTranscriptMessage", () => {
       providerReplay: {
         v: 1,
         type: "openai-responses-compaction-suppression",
+        id: "unexpected-suppression-id",
         data: "rejected",
         provider: "openai",
         api: "openai-responses",
@@ -314,8 +315,48 @@ describe("redactTranscriptMessage", () => {
   });
 
   it.each([
+    ["oversized", "i".repeat(10_000)],
+    ["non-string", 42],
+  ])("removes an %s optional OpenAI compaction id while preserving state", (_name, id) => {
+    const msg = {
+      role: "assistant",
+      api: "openclaw-openai-responses-transport",
+      model: "gpt-5.6-luna",
+      provider: "openai",
+      content: [{ type: "text", text: "visible" }],
+      providerReplay: {
+        v: 1,
+        type: "openai-responses-compaction",
+        id,
+        data: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+        replayIndex: 0,
+        provider: "openai",
+        api: "openai-responses",
+        model: "gpt-5.6-luna",
+        baseUrlHash: "ozhevd1smnk8s",
+      },
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools")) as unknown as {
+      providerReplay: Record<string, unknown>;
+    };
+
+    expect(result.providerReplay).toEqual({
+      v: 1,
+      type: "openai-responses-compaction",
+      data: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+      replayIndex: 0,
+      provider: "openai",
+      api: "openai-responses",
+      model: "gpt-5.6-luna",
+      baseUrlHash: "ozhevd1smnk8s",
+    });
+  });
+
+  it.each([
     ["malformed content", { data: "" }],
-    ["oversized id", { id: "i".repeat(10_000) }],
+    ["invalid replay index", { replayIndex: -1 }],
+    ["invalid context hash", { baseUrlHash: "not-a-context-hash" }],
     ["foreign route", { provider: "azure" }],
   ])("omits invalid OpenAI compaction replay state for %s", (_name, override) => {
     const providerReplay = {

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -295,10 +295,6 @@ function sanitizeOpenAICompactionReplayState(
     (isSuppression
       ? value.data !== OPENAI_COMPACTION_SUPPRESSION_DATA
       : !isStructurallyValidOpaqueReplayToken(value.data)) ||
-    (value.id !== undefined &&
-      (isSuppression ||
-        typeof value.id !== "string" ||
-        !isOpenAIResponseItemId(value.id, route))) ||
     (value.replayIndex !== undefined &&
       (isSuppression ||
         !Number.isSafeInteger(value.replayIndex) ||
@@ -313,10 +309,14 @@ function sanitizeOpenAICompactionReplayState(
   ) {
     return undefined;
   }
+  const replayId =
+    !isSuppression && typeof value.id === "string" && isOpenAIResponseItemId(value.id, route)
+      ? value.id
+      : undefined;
   return {
     v: 1,
     type: replayType,
-    ...(value.id !== undefined ? { id: value.id } : {}),
+    ...(replayId !== undefined ? { id: replayId } : {}),
     data: value.data,
     ...(value.replayIndex !== undefined ? { replayIndex: value.replayIndex } : {}),
     provider: value.provider,


### PR DESCRIPTION
Related: #120457 and #120729.

## What Problem This Solves

This fixes three replay-integrity bugs in the OpenAI Responses path:

- Tagged encrypted reasoning in the public Responses converter ignored route, session, and authentication provenance, allowing captured ciphertext to be considered for replay outside its originating context.
- An idless terminal-only compaction could be skipped because two missing IDs compared equal even when no matching compaction had actually been captured.
- An unsafe optional compaction ID caused otherwise valid exact-route ciphertext replay state to be discarded instead of preserving the state without the malformed ID.

## Why This Change Was Made

The public converter now reuses the canonical reasoning replay metadata validator, terminal duplicate detection requires an exact type, ID, and encrypted-payload match, and optional compaction IDs are canonicalized independently from otherwise valid replay state.

The shipped compatibility from commit `03dec8bb3a00` remains preserved: metadata-less public stateless reasoning replay continues to work, while tagged or malformed provenance is fenced. There is no config, protocol, or schema change.

## User Impact

Newly captured tagged reasoning cannot cross session, authentication, or endpoint boundaries; idless compaction survives terminal recovery; and valid exact-route replay state survives a malformed optional ID.

## Evidence

- `node scripts/run-vitest.mjs packages/ai/src/providers/openai-responses-shared.test.ts packages/ai/src/transports/openai-responses-compaction-replay.test.ts src/agents/transcript-redact.test.ts` — 178 tests passed (117 + 61), 0 failed.
- Touched-file `oxfmt --check`, targeted lint, and `git diff --check origin/main...HEAD` passed.
- Autoreview was clean before rebase at 0.97 and clean after rebase at 0.98, with no accepted/actionable findings.
- Before rebase: production +61/-34 and tests +240/-1. The clean rebase produced no conflicts and left the current split unchanged: production +61/-34, tests +240/-1; aggregate +301/-35 across seven files.
- OpenAI Node v6.49.0 compaction type contract: https://github.com/openai/openai-node/blob/v6.49.0/src/resources/responses/responses.ts#L1918-L1963
- Pinned Codex optional-ID contract: https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/protocol/src/models.rs#L1020-L1028
