### PR TITLE
fix(release): keep upgrade survivor sessions fresh

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -96,13 +96,14 @@ function assert(condition, message) {
 
 function seedLegacySessionMetadata(stateDir) {
   const legacySessionsDir = path.join(stateDir, "sessions");
+  const baseUpdatedAt = Date.now() - 24 * 60 * 60 * 1000;
   writeJson(path.join(legacySessionsDir, "sessions.json"), {
     main: {
       sessionId: LEGACY_SESSION_MAIN_ID,
       sessionFile: path.join(legacySessionsDir, `${LEGACY_SESSION_MAIN_ID}.jsonl`),
       provider: "openai",
       model: "gpt-5.5",
-      updatedAt: 1710000000000,
+      updatedAt: baseUpdatedAt,
       skillsSnapshot: {
         prompt: "legacy prompt survives as metadata",
         resolvedSkills: [
@@ -118,14 +119,14 @@ function seedLegacySessionMetadata(stateDir) {
       sessionFile: path.join(legacySessionsDir, `${LEGACY_SESSION_DIRECT_ID}.jsonl`),
       provider: "openai",
       model: "gpt-5.5",
-      updatedAt: 1710000000100,
+      updatedAt: baseUpdatedAt + 100,
     },
     "slack:channel:CUPGRADE": {
       sessionId: LEGACY_SESSION_GROUP_ID,
       sessionFile: path.join(legacySessionsDir, `${LEGACY_SESSION_GROUP_ID}.jsonl`),
       provider: "openai",
       model: "gpt-5.5",
-      updatedAt: 1710000000200,
+      updatedAt: baseUpdatedAt + 200,
       lastChannel: "slack",
       lastTo: "CUPGRADE",
     },

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -1,6 +1,6 @@
 // Upgrade Survivor Assertions tests cover upgrade survivor assertions script behavior.
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -246,6 +246,71 @@ describe("upgrade survivor assertions", () => {
     expect(scenarios).toContain("base");
     expect(scenarios).toContain("acpx-openclaw-tools-bridge");
     expect(new Set(scenarios).size).toBe(scenarios.length);
+  });
+
+  it("seeds recent ordered legacy session timestamps", () => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-seed-"));
+    try {
+      const stateDir = join(root, "state");
+      const workspace = join(root, "workspace");
+      mkdirSync(stateDir, { recursive: true });
+      mkdirSync(workspace, { recursive: true });
+
+      const beforeSeed = Date.now();
+      execFileSync(process.execPath, [ASSERTIONS_PATH, "seed"], {
+        env: {
+          ...process.env,
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_TEST_WORKSPACE_DIR: workspace,
+          OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: "base",
+        },
+        stdio: "pipe",
+      });
+      const afterSeed = Date.now();
+
+      const sessions = JSON.parse(
+        readFileSync(join(stateDir, "sessions", "sessions.json"), "utf8"),
+      ) as Record<string, { sessionId?: unknown; updatedAt?: unknown }>;
+      const seededRows = [
+        sessions.main,
+        sessions["+15551234567"],
+        sessions["slack:channel:CUPGRADE"],
+      ];
+      expect(seededRows.map((row) => row?.sessionId)).toEqual([
+        "upgrade-main-session",
+        "upgrade-direct-session",
+        "upgrade-group-session",
+      ]);
+
+      const timestamps = seededRows.map((row) => row?.updatedAt);
+      for (const timestamp of timestamps) {
+        expect(typeof timestamp).toBe("number");
+      }
+      const [mainUpdatedAt, directUpdatedAt, groupUpdatedAt] = timestamps as [
+        number,
+        number,
+        number,
+      ];
+      expect(directUpdatedAt - mainUpdatedAt).toBe(100);
+      expect(groupUpdatedAt - mainUpdatedAt).toBe(200);
+      expect(mainUpdatedAt).toBeLessThan(directUpdatedAt);
+      expect(directUpdatedAt).toBeLessThan(groupUpdatedAt);
+
+      const dayMs = 24 * 60 * 60 * 1000;
+      const thirtyDaysMs = 30 * dayMs;
+      for (const [timestamp, offset] of [
+        [mainUpdatedAt, 0],
+        [directUpdatedAt, 100],
+        [groupUpdatedAt, 200],
+      ] as const) {
+        expect(timestamp).toBeGreaterThanOrEqual(beforeSeed - dayMs + offset);
+        expect(timestamp).toBeLessThanOrEqual(afterSeed - dayMs + offset);
+        expect(timestamp).toBeGreaterThan(afterSeed - thirtyDaysMs);
+        expect(timestamp).toBeLessThanOrEqual(afterSeed);
+      }
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
   });
 
   it("accepts the ACPX OpenClaw tools bridge scenario during seed", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the package update survivor lane could age its seeded legacy sessions out before validating their migration because the fixture used timestamps from 2024.

## Why This Change Was Made

The legacy session seed now captures one timestamp 24 hours in the past and preserves deterministic main/direct/group ordering at 100 ms offsets. The existing post-upgrade survival assertions remain exact and unchanged.

## User Impact

No runtime product behavior changes. Release validation now consistently exercises legacy session migration instead of failing when wall-clock retention advances.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/upgrade-survivor-assertions.test.ts`: 13/13 passed.
- `node scripts/check-changed.mjs -- scripts/e2e/lib/upgrade-survivor/assertions.mjs test/scripts/upgrade-survivor-assertions.test.ts`: passed via Testbox lease `tbx_01kzhwfpaa3v3h1j72nj2tyg5y`; wrapper exit 0.
- Testbox backing run: https://github.com/openclaw/openclaw/actions/runs/31284828976
- Autoreview: clean, no accepted/actionable P0 findings, overall 0.99.
- `git diff --check`: passed.
- LOC: production `+4/-3`; tests `+66/-1`.
- AI-assisted: yes.
