### PR TITLE
fix(plugins): surface safe administrator install warnings

### DIFF
--- a/src/plugins/install-persistence.ts
+++ b/src/plugins/install-persistence.ts
@@ -17,6 +17,7 @@ import { resolveUserPath, shortenHomePath } from "../utils.js";
 import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
 import { enablePluginInConfig } from "./enable.js";
 import { commitPluginInstallRecordsWithConfig } from "./install-record-commit.js";
+import type { PluginInstallLogger } from "./install-types.js";
 import {
   loadInstalledPluginIndexInstallRecords,
   recordPluginInstallInRecords,
@@ -319,7 +320,7 @@ function logShadowedNpmInstallWarning(params: {
   config: OpenClawConfig;
   pluginId: string;
   install: Omit<PluginInstallUpdate, "pluginId">;
-  runtime: RuntimeEnv;
+  warn: (message: string, managementMessage: string) => void;
 }): void {
   // Warn when a newly installed npm plugin is shadowed by an explicit config source.
   if (params.install.source !== "npm") {
@@ -343,22 +344,15 @@ function logShadowedNpmInstallWarning(params: {
     return;
   }
 
-  params.runtime.log(
-    theme.warn(
-      [
-        `Warning: installed plugin "${params.pluginId}" is not the active source because a config-selected plugin with the same id is currently selected:`,
-        `  active config source: ${shortenHomePath(active.source)}`,
-        `  installed npm source: ${shortenHomePath(installedSource)}`,
-        "Run `openclaw plugins doctor` for repair options.",
-      ].join("\n"),
-    ),
+  params.warn(
+    [
+      `Warning: installed plugin "${params.pluginId}" is not the active source because a config-selected plugin with the same id is currently selected:`,
+      `  active config source: ${shortenHomePath(active.source)}`,
+      `  installed npm source: ${shortenHomePath(installedSource)}`,
+      "Run `openclaw plugins doctor` for repair options.",
+    ].join("\n"),
+    `Installed plugin "${params.pluginId}" is shadowed by a configured plugin source. Run \`openclaw plugins doctor\`.`,
   );
-}
-
-function logSlotWarnings(warnings: string[], runtime: RuntimeEnv): void {
-  for (const warning of warnings) {
-    runtime.log(theme.warn(warning));
-  }
 }
 
 function resolveComparableInstallPath(
@@ -488,8 +482,17 @@ export async function persistPluginInstall(params: {
   successMessage?: string;
   warningMessage?: string;
   runtime?: RuntimeEnv;
+  persistenceLogger?: PluginInstallLogger;
 }): Promise<OpenClawConfig> {
   const runtime = params.runtime ?? defaultRuntime;
+  // Terminal diagnostics may contain paths/errors; management receives only producer-authored summaries.
+  const warn = (message: string, managementMessage: string): void => {
+    if (params.persistenceLogger?.warn) {
+      params.persistenceLogger.warn(managementMessage);
+      return;
+    }
+    runtime.log(theme.warn(message));
+  };
   const installRecords = await tracePluginLifecyclePhaseAsync(
     "install records load",
     () => loadInstalledPluginIndexInstallRecords(),
@@ -567,7 +570,10 @@ export async function persistPluginInstall(params: {
       { command: "install", pluginId: params.pluginId },
     );
     for (const warning of removalResult.warnings) {
-      runtime.log(theme.warn(warning));
+      warn(
+        warning,
+        "A previous plugin installation could not be fully cleaned up. Run `openclaw plugins doctor`.",
+      );
     }
     if (removalResult.directoryRemoved) {
       runtime.log(
@@ -584,24 +590,33 @@ export async function persistPluginInstall(params: {
     invalidateRuntimeCache: params.invalidateRuntimeCache,
     traceCommand: "install",
     logger: {
-      warn: (message) => runtime.log(theme.warn(message)),
+      warn: (message) =>
+        warn(
+          message,
+          "Plugin registry refresh or runtime cache invalidation failed. Restart the gateway.",
+        ),
     },
   });
-  logSlotWarnings(slotResult.warnings, runtime);
+  for (const warning of slotResult.warnings) {
+    warn(warning, warning);
+  }
   const configWarning =
     params.enable !== false && configEnablement.mode === "missing"
       ? `Installed plugin "${params.pluginId}" without enabling it because it requires configuration first. Configure it, then run \`openclaw plugins enable ${params.pluginId}\`.`
       : undefined;
   const warningMessage = [params.warningMessage, configWarning].filter(Boolean).join("\n");
   if (warningMessage) {
-    runtime.log(theme.warn(warningMessage));
+    warn(
+      warningMessage,
+      configWarning ?? "Plugin installation reported a warning. Run `openclaw plugins doctor`.",
+    );
   }
   runtime.log(params.successMessage ?? `Installed plugin: ${params.pluginId}`);
   logShadowedNpmInstallWarning({
     config: next,
     pluginId: params.pluginId,
     install: params.install,
-    runtime,
+    warn,
   });
   runtime.log("Restart the gateway to load plugins.");
   return next;

--- a/src/plugins/install-persistence.warning-sink.test.ts
+++ b/src/plugins/install-persistence.warning-sink.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  applyExclusiveSlotSelection,
+  applyPluginUninstallDirectoryRemoval,
+  buildPluginSnapshotReport,
+  loadPluginManifestRegistry,
+  planPluginUninstall,
+  refreshPluginRegistry,
+  resetPluginsCliTestState,
+  runtimeLogs,
+  setInstalledPluginIndexInstallRecords,
+} from "../cli/plugins-cli-test-helpers.js";
+
+const snapshot = {
+  config: {},
+  baseHash: "config-1",
+  writeOptions: { expectedConfigPath: "/tmp/openclaw.json" },
+};
+
+const install = {
+  source: "npm" as const,
+  spec: "workboard@1.0.0",
+  installPath: "/private/managed-source/workboard",
+};
+
+describe("plugin install persistence warning audiences", () => {
+  beforeEach(() => {
+    resetPluginsCliTestState();
+  });
+
+  it("reports missing required configuration without forwarding informational logs", async () => {
+    const { persistPluginInstall } = await import("./install-persistence.js");
+    const warn = vi.fn();
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "workboard",
+          manifestPath: "/tmp/workboard/openclaw.plugin.json",
+          configSchema: {
+            type: "object",
+            required: ["token"],
+            properties: { token: { type: "string" } },
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    const next = await persistPluginInstall({
+      snapshot,
+      pluginId: "workboard",
+      install,
+      persistenceLogger: { warn },
+    });
+
+    expect(next.plugins?.entries?.workboard).toEqual({ enabled: false });
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      'Installed plugin "workboard" without enabling it because it requires configuration first. Configure it, then run `openclaw plugins enable workboard`.',
+    );
+    expect(runtimeLogs).toEqual([
+      "Installed plugin: workboard",
+      "Restart the gateway to load plugins.",
+    ]);
+  });
+
+  it("preserves owner-authored exclusive-slot warnings verbatim", async () => {
+    const { persistPluginInstall } = await import("./install-persistence.js");
+    const warn = vi.fn();
+    const warning = 'Exclusive slot "memory" switched from "memory-core" to "workboard".';
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "workboard",
+          kind: "memory",
+          channels: [],
+          providers: [],
+          cliBackends: [],
+          skills: [],
+          hooks: [],
+          origin: "config",
+          rootDir: "/tmp/workboard",
+          source: "/tmp/workboard/index.js",
+          manifestPath: "/tmp/workboard/openclaw.plugin.json",
+        },
+      ],
+      diagnostics: [],
+    });
+    applyExclusiveSlotSelection.mockReturnValue({ config: {}, warnings: [warning], changed: true });
+
+    await persistPluginInstall({
+      snapshot,
+      pluginId: "workboard",
+      install,
+      persistenceLogger: { warn },
+    });
+
+    expect(warn).toHaveBeenCalledExactlyOnceWith(warning);
+  });
+
+  it.each(["management", "terminal"] as const)(
+    "keeps sensitive install details appropriate for the %s audience",
+    async (audience) => {
+      const { persistPluginInstall } = await import("./install-persistence.js");
+      const warn = vi.fn();
+      const cleanupDetail = "npm stderr PRIVATE_NPM_MARKER /private/previous-source/workboard";
+      const refreshDetail = "PRIVATE_REFRESH_MARKER /private/registry-source/workboard";
+      const configuredSource = "/private/configured-source/workboard/index.js";
+      setInstalledPluginIndexInstallRecords({
+        workboard: {
+          source: "clawhub",
+          spec: "clawhub:community/workboard",
+          installPath: "/private/previous-source/workboard",
+        },
+      });
+      planPluginUninstall.mockReturnValueOnce({
+        ok: true,
+        config: {},
+        pluginId: "workboard",
+        actions: {},
+        directoryRemoval: { target: "/private/previous-source/workboard" },
+      });
+      applyPluginUninstallDirectoryRemoval.mockResolvedValueOnce({
+        directoryRemoved: false,
+        warnings: [cleanupDetail],
+      });
+      refreshPluginRegistry.mockRejectedValueOnce(new Error(refreshDetail));
+      buildPluginSnapshotReport.mockReturnValue({
+        plugins: [{ id: "workboard", origin: "config", source: configuredSource }],
+        diagnostics: [],
+      });
+
+      await persistPluginInstall({
+        snapshot,
+        pluginId: "workboard",
+        install,
+        ...(audience === "management" ? { persistenceLogger: { warn } } : {}),
+      });
+
+      if (audience === "terminal") {
+        expect(warn).not.toHaveBeenCalled();
+        expect(runtimeLogs.join("\n")).toContain(cleanupDetail);
+        expect(runtimeLogs.join("\n")).toContain(refreshDetail);
+        expect(runtimeLogs.join("\n")).toContain(configuredSource);
+        expect(runtimeLogs.join("\n")).toContain(install.installPath);
+        return;
+      }
+
+      const warnings = warn.mock.calls.map(([message]) => String(message));
+      expect(warnings).toHaveLength(3);
+      expect(warnings.join("\n")).toContain("previous plugin installation");
+      expect(warnings.join("\n")).toContain("registry");
+      expect(warnings.join("\n")).toContain("shadowed");
+      expect(warnings.join("\n")).not.toContain("/private/");
+      expect(warnings.join("\n")).not.toContain("PRIVATE_NPM_MARKER");
+      expect(warnings.join("\n")).not.toContain("PRIVATE_REFRESH_MARKER");
+      expect(runtimeLogs).toEqual([
+        "Installed plugin: workboard",
+        "Restart the gateway to load plugins.",
+      ]);
+    },
+  );
+});

--- a/src/plugins/management-service.registry-refresh.test.ts
+++ b/src/plugins/management-service.registry-refresh.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  clawhubInstall: vi.fn(),
   metadata: vi.fn(),
   officialCatalog: vi.fn(),
+  persistInstall: vi.fn(),
   readConfig: vi.fn(),
   refreshRegistry: vi.fn(),
   replaceConfig: vi.fn(),
@@ -16,11 +18,16 @@ vi.mock("../config/config.js", () => ({
 
 vi.mock("./install-persistence.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./install-persistence.js")>()),
+  persistPluginInstall: (params: unknown) => mocks.persistInstall(params),
   resolveInstallConfigMutationPreflights: () => ({
     hookMutation: { mode: "allowed" },
     pluginMutation: { mode: "allowed" },
   }),
   selectInstallMutationWriteOptions: (writeOptions: unknown) => writeOptions,
+}));
+
+vi.mock("./clawhub.js", () => ({
+  installPluginFromClawHub: (params: unknown) => mocks.clawhubInstall(params),
 }));
 
 vi.mock("./plugin-metadata-snapshot.js", () => ({
@@ -42,8 +49,34 @@ vi.mock("./slot-selection.js", () => ({
   applySlotSelectionForPlugin: (config: unknown) => ({ config, warnings: [] }),
 }));
 
-const { clearManagedPluginOfficialCatalogCache, setManagedPluginEnabled } =
-  await import("./management-service.js");
+const {
+  clearManagedPluginOfficialCatalogCache,
+  installManagedPlugin,
+  installManagedPluginSource,
+  setManagedPluginEnabled,
+} = await import("./management-service.js");
+
+const installSnapshot = {
+  config: {},
+  baseHash: "base-hash",
+  writeOptions: { expectedConfigPath: "/tmp/openclaw.json" },
+};
+
+function mockClawHubWorkboardInstall() {
+  mocks.clawhubInstall.mockResolvedValue({
+    ok: true,
+    pluginId: "workboard",
+    targetDir: "/tmp/workboard",
+    extensions: ["index.js"],
+    packageName: "community/workboard",
+    clawhub: {
+      source: "clawhub",
+      clawhubUrl: "https://clawhub.ai",
+      clawhubPackage: "community/workboard",
+      clawhubFamily: "code-plugin",
+    },
+  });
+}
 
 function metadataSnapshot(enabled: boolean) {
   const manifest = {
@@ -110,4 +143,59 @@ describe("plugin management registry refresh", () => {
       expect(result.warnings).toEqual(["Plugin registry refresh failed: registry unavailable"]);
     },
   );
+
+  it("returns setup instructions after an administrative plugin installs disabled", async () => {
+    const instruction =
+      'Installed plugin "workboard" without enabling it because it requires configuration first.';
+    mockClawHubWorkboardInstall();
+    mocks.readConfig.mockResolvedValue({
+      snapshot: {
+        valid: true,
+        parsed: {},
+        path: "/tmp/openclaw.json",
+        sourceConfig: {},
+        hash: "base-hash",
+      },
+      writeOptions: installSnapshot.writeOptions,
+    });
+    mocks.persistInstall.mockImplementation(
+      async (params: {
+        persistenceLogger?: { warn?: (message: string) => void };
+        runtime?: { log?: (message: string) => void };
+      }) => {
+        params.persistenceLogger?.warn?.(instruction);
+        params.runtime?.log?.("Installed plugin: workboard");
+        params.runtime?.log?.("Restart the gateway to load plugins.");
+        return { plugins: { entries: { workboard: { enabled: false } } } };
+      },
+    );
+    mocks.metadata.mockReturnValue(metadataSnapshot(false));
+
+    const result = await installManagedPlugin({
+      request: { source: "clawhub", packageName: "community/workboard" },
+      env: {},
+    });
+
+    expect(result).toMatchObject({
+      plugin: { id: "workboard", enabled: false },
+      warnings: [instruction],
+    });
+  });
+
+  it("does not forward source-install loggers into private persistence warnings", async () => {
+    mockClawHubWorkboardInstall();
+    mocks.persistInstall.mockResolvedValue({});
+    const logger = { warn: vi.fn() };
+
+    await installManagedPluginSource({
+      request: { source: "clawhub", spec: "clawhub:community/workboard" },
+      snapshot: installSnapshot,
+      env: {},
+      logger,
+    });
+
+    expect(mocks.clawhubInstall).toHaveBeenCalledWith(expect.objectContaining({ logger }));
+    expect(mocks.persistInstall.mock.calls[0]?.[0]).not.toHaveProperty("persistenceLogger");
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
 });

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -1078,6 +1078,7 @@ async function persistManagedSourceInstall(params: {
   extensionsDir: string;
   invalidateRuntimeCache?: boolean;
   runtime?: RuntimeEnv;
+  persistenceLogger?: PluginInstallLogger;
   successMessage?: string;
   cleanupOnPersistenceFailure?: boolean;
 }): Promise<OpenClawConfig> {
@@ -1088,6 +1089,7 @@ async function persistManagedSourceInstall(params: {
       install: params.install,
       invalidateRuntimeCache: params.invalidateRuntimeCache,
       runtime: params.runtime,
+      ...(params.persistenceLogger ? { persistenceLogger: params.persistenceLogger } : {}),
       ...(params.successMessage ? { successMessage: params.successMessage } : {}),
     });
   if (!params.cleanupOnPersistenceFailure) {
@@ -1107,6 +1109,8 @@ export async function installManagedPluginSource(params: {
   snapshot: ConfigSnapshotForInstallPersist;
   env?: NodeJS.ProcessEnv;
   logger?: PluginInstallLogger & { terminalLinks?: boolean };
+  // Source loggers can feed chat replies; management diagnostics require explicit private opt-in.
+  persistenceLogger?: PluginInstallLogger;
   safetyOverrides?: InstallSafetyOverrides;
   runtime?: RuntimeEnv;
   invalidateRuntimeCache?: boolean;
@@ -1403,6 +1407,7 @@ export async function installManagedPlugin(params: {
     const snapshot = await readPluginMutationSnapshot(env);
     const officialCatalog = await loadOfficialCatalog();
     const warnings: string[] = [];
+    const installLogger = createInstallLogger(warnings);
     const request =
       params.request.source === "clawhub"
         ? resolveManagedClawHubInstallRequest({
@@ -1417,7 +1422,8 @@ export async function installManagedPlugin(params: {
       request,
       snapshot,
       env,
-      logger: createInstallLogger(warnings),
+      logger: installLogger,
+      persistenceLogger: installLogger,
       cleanupOnPersistenceFailure: true,
       invalidateRuntimeCache: false,
       runtime: createSilentRuntime(),


### PR DESCRIPTION
## What Problem This Solves

Administrator-managed plugin installs could successfully complete while required configuration or persistence cleanup warnings were silently discarded, leaving operators without the information needed to enable or repair the plugin.

## Why This Change Was Made

The plugin persistence owner now exposes a dedicated, private warning sink only to the existing authenticated administrator install workflow. Its administrator-facing warnings use bounded, code-authored summaries; existing command-line diagnostics retain their full details, while chat and ordinary direct-source installs do not inherit the administrator sink.

## User Impact

Administrators see actionable plugin setup warnings in the already supported install response without exposing local paths, package-manager output, internal exception text, or additional warnings to chat users.

## Evidence

- Tests against the real persistence and administrator-install owners reproduced three missing warnings while existing confidentiality controls passed.
- The final remote focused suites pass all 84 plugin persistence, management, chat, and warning-sink cases.
- The complete four-path changed gate includes the newly added warning-sink regression suite and passes production/test typechecks, lint, ownership, and storage/security guards.
- Independent implementation and product reviews plus a fresh structured review found no actionable issues.
- Production grows by 21 lines to maintain an explicit confidentiality-preserving administrator-only ownership boundary; no public configuration, authentication policy, UI, or persistent schema changes.
