### PR TITLE
fix(discord): remove only the bot own reactions

### DIFF
--- a/extensions/discord/src/send.reactions.ts
+++ b/extensions/discord/src/send.reactions.ts
@@ -77,15 +77,13 @@ export async function removeOwnReactionsDiscord(
   const { rest, request } = isDiscordReactionRuntimeContext(opts)
     ? createDiscordReactionRuntimeClient(opts)
     : resolveDiscordReactionClient(opts);
-  const message = (await request(
+  const message = await request(
     () => getChannelMessage(rest, channelId, messageId),
     "reaction-list",
-  )) as {
-    reactions?: Array<{ emoji: { id?: string | null; name?: string | null } }>;
-  };
+  );
   const identifiers = new Set<string>();
   for (const reaction of message.reactions ?? []) {
-    const identifier = buildReactionIdentifier(reaction.emoji);
+    const identifier = reaction.me ? buildReactionIdentifier(reaction.emoji) : undefined;
     if (identifier) {
       identifiers.add(identifier);
     }
@@ -116,15 +114,10 @@ export async function fetchReactionsDiscord(
   const { rest, request } = isDiscordReactionRuntimeContext(opts)
     ? createDiscordReactionRuntimeClient(opts)
     : resolveDiscordReactionClient(opts);
-  const message = (await request(
+  const message = await request(
     () => getChannelMessage(rest, channelId, messageId),
     "reaction-list",
-  )) as {
-    reactions?: Array<{
-      count: number;
-      emoji: { id?: string | null; name?: string | null };
-    }>;
-  };
+  );
   const reactions = message.reactions ?? [];
   if (reactions.length === 0) {
     return [];

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -1045,12 +1045,15 @@ describe("removeOwnReactionsDiscord", () => {
     vi.clearAllMocks();
   });
 
-  it("removes all own reactions on a message", async () => {
+  it("removes only owned unicode and custom reactions without repeating emoji", async () => {
     const { rest, getMock, deleteMock } = makeDiscordRest();
     getMock.mockResolvedValue({
       reactions: [
-        { emoji: { name: "✅", id: null } },
-        { emoji: { name: "party_blob", id: "123" } },
+        { me: false, emoji: { name: "👀", id: null } },
+        { me: true, emoji: { name: "✅", id: null } },
+        { me: true, emoji: { name: "✅", id: null } },
+        { me: true, emoji: { name: "party_blob", id: "123" } },
+        { me: false, emoji: { name: "other_blob", id: "456" } },
       ],
     });
     const res = await removeOwnReactionsDiscord("chan1", "msg1", {
@@ -1065,13 +1068,29 @@ describe("removeOwnReactionsDiscord", () => {
     expect(deleteMock).toHaveBeenCalledWith(
       Routes.channelMessageOwnReaction("chan1", "msg1", "party_blob%3A123"),
     );
+    expect(deleteMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not send removal requests when all reactions belong to other users", async () => {
+    const { rest, getMock, deleteMock } = makeDiscordRest();
+    getMock.mockResolvedValue({
+      reactions: [
+        { me: false, emoji: { name: "👀", id: null } },
+        { me: false, emoji: { name: "other_blob", id: "456" } },
+      ],
+    });
+
+    await expect(
+      removeOwnReactionsDiscord("chan1", "msg1", { rest, token: "t", cfg: DISCORD_TEST_CFG }),
+    ).resolves.toEqual({ ok: true, removed: [] });
+    expect(deleteMock).not.toHaveBeenCalled();
   });
 
   it("retries transient failures while listing and clearing owned reactions", async () => {
     const { rest, getMock, deleteMock } = makeDiscordRest();
     getMock
       .mockRejectedValueOnce(Object.assign(new Error("service unavailable"), { status: 503 }))
-      .mockResolvedValueOnce({ reactions: [{ emoji: { name: "✅", id: null } }] });
+      .mockResolvedValueOnce({ reactions: [{ me: true, emoji: { name: "✅", id: null } }] });
     deleteMock
       .mockRejectedValueOnce(Object.assign(new Error("bad gateway"), { status: 502 }))
       .mockResolvedValueOnce(undefined);
@@ -1092,8 +1111,8 @@ describe("removeOwnReactionsDiscord", () => {
     const { rest, getMock, deleteMock } = makeDiscordRest();
     getMock.mockResolvedValue({
       reactions: [
-        { emoji: { name: "✅", id: null } },
-        { emoji: { name: "party_blob", id: "123" } },
+        { me: true, emoji: { name: "✅", id: null } },
+        { me: true, emoji: { name: "party_blob", id: "123" } },
       ],
     });
     const apiError = new Error("Discord API 500");


### PR DESCRIPTION
## What Problem This Solves

Clearing a bot's Discord reactions also attempted self-removal for emoji added only by other users and could falsely report those unrelated reactions as removed.

## Why This Change Was Made

The Discord reaction owner now uses the upstream reaction object's existing current-user ownership field instead of casting that information away. Connected duplicate narrowing casts were removed from the same owner while preserving emoji normalization, deduplication, retry behavior, and failure propagation.

## User Impact

Reaction removal targets only emoji actually used by the bot, reports accurate results, and avoids unnecessary Discord API requests when the bot has no matching reactions.

## Evidence

- Tests against the actual mocked Discord REST owner reproduced two incorrect mixed-ownership and no-owned-reaction cases while retry controls passed.
- The final complete owner suite passes all 72 tests, including Unicode and custom emoji, duplicate reactions, retry handling, and transport failures.
- The complete remote changed-file gate and fresh structured review both pass without findings.
- An independent review verified the upstream typed reaction contract and the existing self-removal API route.
- Production code shrinks by seven lines; configuration, authentication, public interfaces, and unrelated users' reactions are unchanged.
