### PR TITLE
fix(telegram): clean up every failed webhook startup phase

### DIFF
--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { once } from "node:events";
 import fs from "node:fs/promises";
-import { request, type IncomingMessage } from "node:http";
+import { createServer, request, type IncomingMessage } from "node:http";
 import os from "node:os";
 import nodePath from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -165,13 +165,21 @@ let startTelegramWebhook: typeof import("./webhook.js").startTelegramWebhook;
 let webhookStateDir: string | undefined;
 let webhookSpoolDir: string | undefined;
 
-function installTelegramIngressQueueRuntime(resolveStateDir: () => string): void {
+function installTelegramIngressQueueRuntime(
+  resolveStateDir: () => string,
+  queueOpenError?: Error,
+): void {
   setTelegramRuntime({
     state: {
       resolveStateDir,
       openChannelIngressQueue: (
         options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
-      ) => createChannelIngressQueue({ ...options, channelId: "telegram" }),
+      ) => {
+        if (queueOpenError) {
+          throw queueOpenError;
+        }
+        return createChannelIngressQueue({ ...options, channelId: "telegram" });
+      },
     },
   } as TelegramRuntime);
 }
@@ -232,6 +240,18 @@ function requireMockCall(mock: unknown, index: number, label: string): unknown[]
     throw new Error(`expected ${label} call ${index}`);
   }
   return call;
+}
+
+function expectWebhookBotScopesAborted(): void {
+  const botParams = requireRecord(
+    requireMockCall(createTelegramBotSpy, 0, "createTelegramBot")[0],
+    "createTelegramBot params",
+  );
+  for (const key of ["fetchAbortSignal", "accountAbortSignal"]) {
+    const signal = botParams[key];
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect((signal as AbortSignal).aborted).toBe(true);
+  }
 }
 
 function mockMessages(mock: unknown): string[] {
@@ -857,6 +877,123 @@ describe("startTelegramWebhook", () => {
       lifecycle: "blocked",
       lastError: "unauthorized",
     });
+  });
+
+  it("preserves the initialization failure when bot shutdown also fails", async () => {
+    const runtimeError = vi.fn();
+    const setStatus = vi.fn();
+    const initializationError = Object.assign(new Error("unauthorized"), { error_code: 401 });
+    initSpy.mockRejectedValueOnce(initializationError);
+    stopSpy.mockRejectedValueOnce(new Error("bot stop failed"));
+
+    await expect(
+      startTelegramWebhook({
+        token: TELEGRAM_TOKEN,
+        port: 0,
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+        spoolDir: requireWebhookSpoolDir(),
+        runtime: { log: vi.fn(), error: runtimeError, exit: vi.fn() },
+        setStatus,
+      }),
+    ).rejects.toBe(initializationError);
+
+    expect(stopSpy).toHaveBeenCalledOnce();
+    expect(transportCloseSpies[0]).toHaveBeenCalledOnce();
+    expect(deleteWebhookSpy).not.toHaveBeenCalled();
+    expectWebhookBotScopesAborted();
+    expectMockMessageContains(runtimeError, "telegram webhook bot stop failed: bot stop failed");
+    expectStatusCall(setStatus, { lifecycle: "blocked", lastError: "unauthorized" });
+  });
+
+  it("releases webhook startup resources when its listener port is already occupied", async () => {
+    const blocker = createServer();
+    blocker.listen(0, "127.0.0.1");
+    await once(blocker, "listening");
+    const setStatus = vi.fn();
+
+    try {
+      await expect(
+        startTelegramWebhook({
+          token: TELEGRAM_TOKEN,
+          port: getServerPort(blocker),
+          host: "127.0.0.1",
+          secret: TELEGRAM_SECRET,
+          path: TELEGRAM_WEBHOOK_PATH,
+          spoolDir: requireWebhookSpoolDir(),
+          runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+          setStatus,
+        }),
+      ).rejects.toMatchObject({ code: "EADDRINUSE" });
+
+      expect(blocker.listening).toBe(true);
+      expect(initSpy).toHaveBeenCalledOnce();
+      expect(setWebhookSpy).not.toHaveBeenCalled();
+      expect(stopSpy).toHaveBeenCalledOnce();
+      expect(transportCloseSpies[0]).toHaveBeenCalledOnce();
+      expect(deleteWebhookSpy).not.toHaveBeenCalled();
+      expectWebhookBotScopesAborted();
+      expect(
+        setStatus.mock.calls.some(([patch]) => String(patch.lastError).includes("EADDRINUSE")),
+      ).toBe(true);
+    } finally {
+      const closed = once(blocker, "close");
+      blocker.close();
+      await closed;
+    }
+  });
+
+  it("closes an advertised listener when opening its durable ingress queue fails", async () => {
+    const abort = new AbortController();
+    const setStatus = vi.fn();
+    const queueError = new Error("state database unavailable");
+    let advertisedPort: number | undefined;
+    setWebhookSpy.mockImplementationOnce(async (publicUrl: string) => {
+      advertisedPort = Number(new URL(publicUrl).port);
+      return true;
+    });
+    installTelegramIngressQueueRuntime(() => webhookStateDir ?? os.tmpdir(), queueError);
+
+    try {
+      await expect(
+        startTelegramWebhook({
+          token: TELEGRAM_TOKEN,
+          port: 0,
+          host: "127.0.0.1",
+          secret: TELEGRAM_SECRET,
+          path: TELEGRAM_WEBHOOK_PATH,
+          spoolDir: requireWebhookSpoolDir(),
+          abortSignal: abort.signal,
+          runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+          setStatus,
+        }),
+      ).rejects.toBe(queueError);
+
+      expect(setWebhookSpy).toHaveBeenCalledOnce();
+      expect(advertisedPort).toBeGreaterThan(0);
+      expect(stopSpy).toHaveBeenCalledOnce();
+      expect(transportCloseSpies[0]).toHaveBeenCalledOnce();
+      expect(deleteWebhookSpy).not.toHaveBeenCalled();
+      expectWebhookBotScopesAborted();
+      expectStatusCall(setStatus, { lastError: "state database unavailable" });
+      expect(setStatus).toHaveBeenLastCalledWith({ mode: "webhook", connected: false });
+
+      const rebound = createServer();
+      try {
+        rebound.listen(advertisedPort, "127.0.0.1");
+        await once(rebound, "listening");
+        expect(rebound.listening).toBe(true);
+      } finally {
+        if (rebound.listening) {
+          const closed = once(rebound, "close");
+          rebound.close();
+          await closed;
+        }
+      }
+    } finally {
+      abort.abort();
+      await waitForWebhookState(() => expect(transportCloseSpies[0]).toHaveBeenCalledOnce());
+    }
   });
 
   it("registers webhook with certificate when webhookCertPath is provided", async () => {

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -330,6 +330,9 @@ export async function startTelegramWebhook(opts: {
   const diagnosticsEnabled = isDiagnosticsEnabled(opts.config);
   const spoolDir = opts.spoolDir ?? resolveTelegramIngressSpoolDir({ accountId: opts.accountId });
   let shutDown = false;
+  let ownedServer: ReturnType<typeof createServer> | undefined = undefined;
+  let webhookIngressMonitor: ReturnType<typeof createTelegramTransportIngressMonitor> | undefined;
+  let diagnosticsStarted = false;
   const shutdownAbortController = new AbortController();
   const telegramAccountConfig = opts.config
     ? mergeTelegramAccountConfig(opts.config, opts.accountId ?? "default")
@@ -359,26 +362,66 @@ export async function startTelegramWebhook(opts: {
     accountId: opts.accountId,
     telegramTransport,
   });
-  try {
-    await initializeTelegramWebhookBot({
+  const runShutdownPhase = async (
+    label: string,
+    run: () => void | Promise<void>,
+  ): Promise<void> => {
+    try {
+      await run();
+    } catch (err) {
+      runtime.error?.(`telegram webhook ${label} failed: ${formatErrorMessage(err)}`);
+    }
+  };
+  const shutdown = async () => {
+    if (shutDown) {
+      return;
+    }
+    shutDown = true;
+    botAbortController.abort();
+    shutdownAbortController.abort();
+    // Every fallible phase is isolated so one failed release cannot skip the
+    // remaining resources or reject the fire-and-forget abort hook.
+    const ingressMonitor = webhookIngressMonitor;
+    webhookIngressMonitor = undefined;
+    const ingressStopTask = ingressMonitor
+      ? runShutdownPhase("ingress stop", () => ingressMonitor.stop())
+      : undefined;
+    await runShutdownPhase("server close", () => {
+      ownedServer?.close();
+    });
+    await runShutdownPhase("bot stop", () => bot.stop());
+    // The webhook owns this transport because it resolved and injected it into
+    // createTelegramBot; close once so abort/startup-failure paths cannot leak sockets.
+    await runShutdownPhase("transport close", closeTransportOnce);
+    await runShutdownPhase("ingress drain", () => waitForWebhookIngressStop(ingressStopTask));
+    await runShutdownPhase("status update", () => status.noteWebhookStop());
+    if (diagnosticsStarted) {
+      await runShutdownPhase("diagnostics stop", () => stopDiagnosticHeartbeat());
+    }
+  };
+  const runStartupPhase = async <T>(run: () => T | Promise<T>): Promise<T> => {
+    try {
+      return await run();
+    } catch (err) {
+      if (!opts.abortSignal?.aborted) {
+        status.noteWebhookRegistrationFailure(
+          formatErrorMessage(err),
+          isTelegramAuthenticationError(err) ? "blocked" : undefined,
+        );
+      }
+      await shutdown();
+      throw err;
+    }
+  };
+  await runStartupPhase(() =>
+    initializeTelegramWebhookBot({
       bot,
       runtime,
       abortSignal: opts.abortSignal,
       onRetry: () => status.noteWebhookRecovery(),
       retryPolicy: webhookRegistrationRetryPolicy,
-    });
-  } catch (err) {
-    if (!opts.abortSignal?.aborted) {
-      status.noteWebhookRegistrationFailure(
-        formatErrorMessage(err),
-        isTelegramAuthenticationError(err) ? "blocked" : undefined,
-      );
-    }
-    botAbortController.abort();
-    await bot.stop();
-    await closeTransportOnce();
-    throw err;
-  }
+    }),
+  );
   const botInfo = bot.botInfo;
   const telegramWebhookRateLimiter = createFixedWindowRateLimiter({
     windowMs: WEBHOOK_RATE_LIMIT_DEFAULTS.windowMs,
@@ -387,10 +430,10 @@ export async function startTelegramWebhook(opts: {
   });
   if (diagnosticsEnabled) {
     startDiagnosticHeartbeat(opts.config);
+    diagnosticsStarted = true;
   }
 
   const log = (line: string) => runtime.log?.(line);
-  let webhookIngressMonitor: ReturnType<typeof createTelegramTransportIngressMonitor> | undefined;
   const startWebhookSpoolDrain = () => {
     if (webhookIngressMonitor) {
       return;
@@ -512,12 +555,15 @@ export async function startTelegramWebhook(opts: {
       respondText(500);
     });
   });
+  ownedServer = server;
 
-  await listenHttpServer({
-    server,
-    port,
-    host,
-  });
+  await runStartupPhase(() =>
+    listenHttpServer({
+      server,
+      port,
+      host,
+    }),
+  );
   const boundAddress = server.address();
   const boundPort = boundAddress && typeof boundAddress !== "string" ? boundAddress.port : port;
 
@@ -530,43 +576,6 @@ export async function startTelegramWebhook(opts: {
   });
 
   let webhookAdvertised = false;
-  const runShutdownPhase = async (
-    label: string,
-    run: () => void | Promise<void>,
-  ): Promise<void> => {
-    try {
-      await run();
-    } catch (err) {
-      runtime.error?.(`telegram webhook ${label} failed: ${formatErrorMessage(err)}`);
-    }
-  };
-  const shutdown = async () => {
-    if (shutDown) {
-      return;
-    }
-    shutDown = true;
-    botAbortController.abort();
-    shutdownAbortController.abort();
-    // Every fallible phase is isolated so one failed release cannot skip the
-    // remaining resources or reject the fire-and-forget abort hook.
-    const ingressMonitor = webhookIngressMonitor;
-    webhookIngressMonitor = undefined;
-    const ingressStopTask = ingressMonitor
-      ? runShutdownPhase("ingress stop", () => ingressMonitor.stop())
-      : undefined;
-    await runShutdownPhase("server close", () => {
-      server.close();
-    });
-    await runShutdownPhase("bot stop", () => bot.stop());
-    // The webhook owns this transport because it resolved and injected it into
-    // createTelegramBot; close once so abort/startup-failure paths cannot leak sockets.
-    await runShutdownPhase("transport close", closeTransportOnce);
-    await runShutdownPhase("ingress drain", () => waitForWebhookIngressStop(ingressStopTask));
-    await runShutdownPhase("status update", () => status.noteWebhookStop());
-    if (diagnosticsEnabled) {
-      await runShutdownPhase("diagnostics stop", () => stopDiagnosticHeartbeat());
-    }
-  };
   if (opts.abortSignal?.aborted) {
     void shutdown();
   } else if (opts.abortSignal) {
@@ -658,7 +667,7 @@ export async function startTelegramWebhook(opts: {
   // Drain only after registration succeeds or after the retrying startup path
   // is ready to return a stop handle; failed startup must not claim durable work.
   if (!shutDown) {
-    startWebhookSpoolDrain();
+    await runStartupPhase(startWebhookSpoolDrain);
   }
 
   return { server, bot, stop: shutdown };


### PR DESCRIPTION
## Summary

Telegram webhook startup created its local shutdown owner after several fallible initialization steps. Authentication failures, an occupied listening port, or queue initialization errors after webhook registration could therefore leak owned resources, hide the original error, or leave a listening port occupied.

Move the existing idempotent local shutdown owner before startup begins and protect every initialization phase with the same resource lifecycle. Preserve the original failure and status, release the owned transport and abort scopes exactly once, and never delete a remote webhook registration during local rollback.

The production owner grows by nine lines to represent partial resource acquisition explicitly; the regression tests add 137 lines. No authentication, configuration, storage, external registration, or public protocol behavior changes.

## Verification

- Tests-only baseline reproduced all three actual startup failures.
- All 98 Telegram webhook owner tests pass.
- Independent verification executed the changed production owner against genuine local HTTP listeners for authentication failure with rejected cleanup, an occupied listening port, and queue failure after registration with successful port rebinding.
- The complete remote changed gate passes production/test typechecks, zero-warning lint, formatting, and all ownership, storage, and runtime guards.
- Fresh independent review and structured code review found no actionable issues.

Follow-up: separately investigate the polling-worker startup transaction; it is outside this webhook owner boundary.
