### PR TITLE
fix(ui): rank slash command results by relevance

### DIFF
--- a/ui/src/e2e/chat-slash-command-ranking.e2e.test.ts
+++ b/ui/src/e2e/chat-slash-command-ranking.e2e.test.ts
@@ -1,0 +1,98 @@
+// Control UI E2E tests cover slash command relevance and keyboard ordering.
+import path from "node:path";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI slash command ranking",
+});
+
+suite.define(() => {
+  it("keeps visible search results and keyboard selection in relevance order", async () => {
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    await suite.withPage(
+      {
+        viewport: { width: 1280, height: 900 },
+        ...(artifactDir
+          ? { recordVideo: { dir: artifactDir, size: { width: 1280, height: 900 } } }
+          : {}),
+      },
+      async ({ page }) => {
+        const commands = [
+          {
+            acceptsArgs: true,
+            category: "tools",
+            description: "Generate setup codes.",
+            name: "pair",
+            scope: "both",
+            source: "plugin",
+            textAliases: ["/pair"],
+          },
+          {
+            acceptsArgs: true,
+            category: "session",
+            description: "Pair a specific device.",
+            name: "pair-device",
+            scope: "both",
+            source: "plugin",
+            textAliases: ["/pair-device"],
+          },
+        ];
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "chat.startup": {
+              agentsList: {
+                agents: [{ id: "main", name: "OpenClaw" }],
+                defaultId: "main",
+                mainKey: "main",
+                scope: "agent",
+              },
+              messages: [],
+              metadata: { commands, models: [] },
+              sessionId: "slash-command-ranking-session",
+              thinkingLevel: null,
+            },
+            "commands.list": { commands },
+          },
+        });
+
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await gateway.waitForRequest("chat.startup");
+        const composer = page.locator(".agent-chat__composer-combobox textarea");
+        await composer.waitFor({ state: "visible" });
+        await expect.poll(() => composer.isEnabled()).toBe(true);
+        await composer.fill("/pair");
+
+        const picker = page.locator(".slash-menu[role='listbox']");
+        await picker.waitFor({ state: "visible" });
+        const options = picker.getByRole("option");
+        await expect
+          .poll(
+            async () =>
+              await options
+                .locator(".slash-menu-name")
+                .evaluateAll((names) => names.slice(0, 3).map((name) => name.textContent?.trim())),
+          )
+          .toEqual(["/pair", "/pair-device", "/openclaw"]);
+
+        await composer.press("ArrowDown");
+        await expect.poll(() => options.nth(1).getAttribute("aria-selected")).toBe("true");
+        await expect
+          .poll(() => options.nth(1).locator(".slash-menu-name").textContent())
+          .toContain("/pair-device");
+
+        if (artifactDir) {
+          await page.screenshot({
+            path: path.join(artifactDir, "slash-command-ranking-selected.png"),
+            fullPage: true,
+          });
+        }
+
+        await composer.press("Enter");
+        await expect.poll(() => composer.inputValue()).toBe("/pair-device ");
+        await expect.poll(() => picker.count()).toBe(0);
+      },
+    );
+  });
+});

--- a/ui/src/lib/chat/commands.test.ts
+++ b/ui/src/lib/chat/commands.test.ts
@@ -7,9 +7,11 @@ import {
   buildSlashCommandsFromEntries,
   getRemoteCommandEntries,
   getSkillCommandCompletions,
+  getSlashCommandCompletions,
   parseSlashCommand,
   replaceSlashCommands,
   SLASH_COMMANDS,
+  type SlashCommandDef,
 } from "./commands.ts";
 
 afterEach(() => {
@@ -59,6 +61,149 @@ function expectParsedSlash(input: string, commandFields: Record<string, unknown>
   expectRecordFields(parsed.command, `parsed ${input} command`, commandFields);
   expect(parsed.args).toBe(args);
 }
+
+function completionNames(filter: string, options?: { showAll?: boolean }): string[] {
+  return getSlashCommandCompletions(filter, options).map((command) => command.name);
+}
+
+function slashCommand(
+  name: string,
+  options: Partial<Omit<SlashCommandDef, "key" | "name">> = {},
+): SlashCommandDef {
+  return { key: name, name, description: `${name} command.`, ...options };
+}
+
+describe("getSlashCommandCompletions", () => {
+  it("ranks an exact name above prefixes and description-only matches", () => {
+    replaceSlashCommands([
+      slashCommand("openclaw", {
+        description: "Run the setup and repair helper.",
+        tier: "essential",
+        category: "session",
+      }),
+      slashCommand("pair-device", {
+        tier: "standard",
+        category: "tools",
+      }),
+      slashCommand("pair", { tier: "power", category: "agents" }),
+    ]);
+
+    expect(completionNames("pair")).toEqual(["pair", "pair-device", "openclaw"]);
+  });
+
+  it("ranks exact and prefix alias matches like primary names", () => {
+    replaceSlashCommands([
+      slashCommand("pair-device", {
+        tier: "power",
+        category: "agents",
+      }),
+      slashCommand("connect", {
+        aliases: ["pairing"],
+        tier: "essential",
+        category: "session",
+      }),
+      slashCommand("handoff", {
+        aliases: ["pair"],
+        tier: "power",
+        category: "agents",
+      }),
+    ]);
+
+    expect(completionNames("pair")).toEqual(["handoff", "connect", "pair-device"]);
+  });
+
+  it("ranks name and alias substrings above description-only matches", () => {
+    replaceSlashCommands([
+      slashCommand("helper", {
+        description: "Repair a device.",
+        tier: "essential",
+        category: "session",
+      }),
+      slashCommand("connect", {
+        aliases: ["repairing"],
+        tier: "standard",
+        category: "tools",
+      }),
+      slashCommand("repair", {
+        tier: "power",
+        category: "agents",
+      }),
+      slashCommand("pairing", {
+        tier: "power",
+        category: "agents",
+      }),
+    ]);
+
+    expect(completionNames("pair")).toEqual(["pairing", "connect", "repair", "helper"]);
+  });
+
+  it("uses tier and category tie-breakers while keeping equal matches stable", () => {
+    replaceSlashCommands([
+      slashCommand("path-first", {
+        tier: "essential",
+        category: "session",
+      }),
+      slashCommand("path-standard", {
+        tier: "standard",
+        category: "session",
+      }),
+      slashCommand("path-agent", {
+        tier: "essential",
+        category: "agents",
+      }),
+      slashCommand("path-second", {
+        tier: "essential",
+        category: "session",
+      }),
+    ]);
+
+    expect(completionNames("path-")).toEqual([
+      "path-first",
+      "path-second",
+      "path-agent",
+      "path-standard",
+    ]);
+  });
+
+  it("keeps empty-query tier and category ordering unchanged", () => {
+    replaceSlashCommands([
+      slashCommand("standard-agent", {
+        tier: "standard",
+        category: "agents",
+      }),
+      slashCommand("essential-tools", {
+        tier: "essential",
+        category: "tools",
+      }),
+      slashCommand("power-session", {
+        tier: "power",
+        category: "session",
+      }),
+      slashCommand("essential-session", {
+        tier: "essential",
+        category: "session",
+      }),
+      slashCommand("standard-session", {
+        tier: "standard",
+        category: "session",
+      }),
+    ]);
+
+    expect(completionNames("")).toEqual([
+      "essential-session",
+      "essential-tools",
+      "standard-session",
+      "standard-agent",
+    ]);
+    expect(completionNames("", { showAll: true })).toEqual([
+      "essential-session",
+      "essential-tools",
+      "standard-session",
+      "standard-agent",
+      "power-session",
+    ]);
+  });
+});
 
 describe("parseSlashCommand", () => {
   it("parses commands with an optional colon separator", () => {

--- a/ui/src/lib/chat/commands.ts
+++ b/ui/src/lib/chat/commands.ts
@@ -459,6 +459,24 @@ const TIER_ORDER: Record<SlashCommandTier, number> = {
   power: 2,
 };
 
+const NON_MATCHING_COMMAND_RANK = 4;
+
+function getSlashCommandRelevance(command: SlashCommandDef, filter: string): number {
+  const names = [command.name, ...(command.aliases ?? [])].map(normalizeLowercaseStringOrEmpty);
+  if (names.some((name) => name === filter)) {
+    return 0;
+  }
+  if (names.some((name) => name.startsWith(filter))) {
+    return 1;
+  }
+  if (names.some((name) => name.includes(filter))) {
+    return 2;
+  }
+  return normalizeLowercaseStringOrEmpty(getSlashCommandDescription(command)).includes(filter)
+    ? 3
+    : NON_MATCHING_COMMAND_RANK;
+}
+
 export function getSlashCommandCompletions(
   filter: string,
   options?: { showAll?: boolean },
@@ -467,10 +485,7 @@ export function getSlashCommandCompletions(
   const showAll = options?.showAll ?? false;
   let commands = lower
     ? SLASH_COMMANDS.filter(
-        (cmd) =>
-          cmd.name.startsWith(lower) ||
-          cmd.aliases?.some((alias) => normalizeLowercaseStringOrEmpty(alias).startsWith(lower)) ||
-          normalizeLowercaseStringOrEmpty(getSlashCommandDescription(cmd)).includes(lower),
+        (command) => getSlashCommandRelevance(command, lower) < NON_MATCHING_COMMAND_RANK,
       )
     : SLASH_COMMANDS;
 
@@ -480,7 +495,12 @@ export function getSlashCommandCompletions(
   }
 
   return commands.toSorted((a, b) => {
-    // Sort by tier first (essential → standard → power)
+    if (lower) {
+      const relevance = getSlashCommandRelevance(a, lower) - getSlashCommandRelevance(b, lower);
+      if (relevance !== 0) {
+        return relevance;
+      }
+    }
     const aTier = TIER_ORDER[a.tier ?? "standard"] ?? 1;
     const bTier = TIER_ORDER[b.tier ?? "standard"] ?? 1;
     if (aTier !== bTier) {
@@ -490,13 +510,6 @@ export function getSlashCommandCompletions(
     const bi = CATEGORY_ORDER.indexOf(b.category ?? "session");
     if (ai !== bi) {
       return ai - bi;
-    }
-    if (lower) {
-      const aExact = a.name.startsWith(lower) ? 0 : 1;
-      const bExact = b.name.startsWith(lower) ? 0 : 1;
-      if (aExact !== bExact) {
-        return aExact - bExact;
-      }
     }
     return 0;
   });

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -3898,6 +3898,59 @@ describe("chat slash menu accessibility", () => {
     expect(listbox?.querySelector(`#${activeId}`)?.getAttribute("role")).toBe("option");
   });
 
+  it("keeps filtered command DOM and keyboard order aligned with relevance", () => {
+    replaceSlashCommands([
+      {
+        key: "pair",
+        name: "pair",
+        description: "Pair a device.",
+        tier: "power",
+        category: "tools",
+      },
+      {
+        key: "pair-device",
+        name: "pair-device",
+        description: "Pair a specific device.",
+        tier: "standard",
+        category: "session",
+      },
+      {
+        key: "openclaw",
+        name: "openclaw",
+        description: "Run the setup and repair helper.",
+        tier: "essential",
+        category: "tools",
+      },
+    ]);
+    const harness = createSlashRerenderHarness();
+    let container = harness.inputAndRender(harness.container, "/pair");
+
+    expect(
+      Array.from(container.querySelectorAll<HTMLElement>(".slash-menu [role='option']")).map(
+        (option) => option.querySelector(".slash-menu-name")?.textContent?.trim(),
+      ),
+    ).toEqual(["/pair", "/pair-device", "/openclaw"]);
+    expect(
+      Array.from(container.querySelectorAll(".slash-menu-group__label")).map((label) =>
+        label.textContent?.trim(),
+      ),
+    ).toEqual(["Tools", "Session", "Tools"]);
+
+    keydownComposer(container, "ArrowDown");
+    container = harness.renderCurrent();
+    const options = container.querySelectorAll<HTMLElement>(".slash-menu [role='option']");
+    const activeId = container
+      .querySelector<HTMLTextAreaElement>("textarea")
+      ?.getAttribute("aria-activedescendant");
+    expect(options[1]?.id).toBe(activeId);
+    expect(options[1]?.getAttribute("aria-selected")).toBe("true");
+
+    keydownComposer(container, "Enter");
+    container = harness.renderCurrent();
+    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe("/pair-device ");
+    expect(container.querySelector(".slash-menu")).toBeNull();
+  });
+
   it("updates the active descendant and live announcement during command navigation", () => {
     const harness = createSlashRerenderHarness();
     let container = harness.inputAndRender(harness.container, "/");

--- a/ui/src/pages/chat/components/chat-composer-slash-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-slash-menu.ts
@@ -364,25 +364,23 @@ export function renderSlashMenu(
     return nothing;
   }
 
-  const grouped = new Map<
-    SlashCommandCategory,
-    Array<{ cmd: SlashCommandDef; globalIdx: number }>
-  >();
-  for (const [i, cmd] of state.slashMenuItems.entries()) {
-    const cat = cmd.category ?? "session";
-    let list = grouped.get(cat);
-    if (!list) {
-      list = [];
-      grouped.set(cat, list);
+  const groups: Array<[SlashCommandCategory, Array<{ cmd: SlashCommandDef; globalIdx: number }>]> =
+    [];
+  for (const [globalIdx, cmd] of state.slashMenuItems.entries()) {
+    const category = cmd.category ?? "session";
+    const group =
+      draft === "/" ? groups.find(([groupCategory]) => groupCategory === category) : groups.at(-1);
+    if (group?.[0] === category) {
+      group[1].push({ cmd, globalIdx });
+    } else {
+      groups.push([category, [{ cmd, globalIdx }]]);
     }
-    list.push({ cmd, globalIdx: i });
   }
 
-  const sections: TemplateResult[] = [];
-  for (const [cat, entries] of grouped) {
-    sections.push(html`
+  const sections = groups.map(
+    ([category, entries]) => html`
       <div class="slash-menu-group">
-        <div class="slash-menu-group__label">${getSlashCommandCategoryLabel(cat)}</div>
+        <div class="slash-menu-group__label">${getSlashCommandCategoryLabel(category)}</div>
         ${entries.map(
           ({ cmd, globalIdx }) => html`
             <div
@@ -417,8 +415,8 @@ export function renderSlashMenu(
           `,
         )}
       </div>
-    `);
-  }
+    `,
+  );
 
   const hiddenCount = state.slashMenuExpanded ? 0 : getHiddenCommandCount();
 


### PR DESCRIPTION
Closes #120750

## What Problem This Solves

Fixes an issue where Control UI users searching the slash-command picker could see a weaker description match above an exact command name. The returned order also drives the default selection and keyboard navigation, so the mismatch made it easier to choose a command other than the one the operator typed.

## Why This Change Was Made

The Control UI completion owner now applies one generic relevance contract to normalized command names and aliases: exact match, prefix, substring, then description-only match. Existing tier and category ordering remains as tie-breakers within equal relevance, while empty-query ordering and power-command disclosure remain unchanged.

The menu renderer now preserves that canonical result sequence in both DOM and keyboard order, including when relevance interleaves categories. The implementation does not special-case `/pair`, `/openclaw`, or any catalog entry and does not change Gateway, plugin, protocol, configuration, or command metadata contracts.

Production LOC: +40/-29 (net +11) | Tests: +296/-0. The production growth establishes the missing ranking-owner contract and keeps rendered and keyboard ordering aligned with it.

## User Impact

Operators now see exact command names or aliases before weaker matches and can move through the visible results in the same order with the keyboard. Empty slash-menu discovery behaves as before.

## Evidence

### Automated and source proof

- Focused unit and mounted Control UI coverage: 250/250 passed.
- Deterministic Chromium Control UI E2E: 1/1 passed, covering visible relevance order, keyboard selection, and command insertion.
- Final visual artifacts were captured at `78df14a6a83f52055e14d5d0940f203b780171ab` for desktop dark, desktop light, mobile dark, keyboard focus, and empty-query states.
- Empty-query verdict order is byte-for-byte equivalent between the baseline and proposed captures.
- Targeted `oxfmt` and `git diff --check` passed.
- Technical deslop review was applied before final proof.
- Structured autoreview completed cleanly with no accepted or actionable findings.

### Visual comparison

#### Search relevance — desktop dark

| Baseline at 257ac20f | Proposed behavior in this PR at 78df14a6 |
| --- | --- |
| <img width="1440" height="1000" alt="Baseline desktop dark slash-command search ordering at 257ac20f" src="https://github.com/user-attachments/assets/2eedfe52-e6f5-4293-8c51-01476ce41281" /> | <img width="1440" height="1000" alt="Proposed desktop dark slash-command search ordering in this PR at 78df14a6" src="https://github.com/user-attachments/assets/bc2cd648-fd76-4b97-bd5e-418c71ccc9ed" /> |

<details>
<summary>Additional responsive, theme, keyboard, and empty-query evidence</summary>

#### Desktop light

| Baseline at 257ac20f | Proposed behavior in this PR at 78df14a6 |
| --- | --- |
| <img width="1440" height="1000" alt="Baseline desktop light slash-command search ordering at 257ac20f" src="https://github.com/user-attachments/assets/5b32f6e3-6b92-44a6-a47d-0857d565c732" /> | <img width="1440" height="1000" alt="Proposed desktop light slash-command search ordering in this PR at 78df14a6" src="https://github.com/user-attachments/assets/122db8da-aebc-418a-b1c6-d3fa0ee2b3a9" /> |

#### Mobile dark

| Baseline at 257ac20f | Proposed behavior in this PR at 78df14a6 |
| --- | --- |
| <img width="390" height="844" alt="Baseline mobile dark slash-command search ordering at 257ac20f" src="https://github.com/user-attachments/assets/281f45dd-d6ea-49e7-97a5-1477fc308a20" /> | <img width="390" height="844" alt="Proposed mobile dark slash-command search ordering in this PR at 78df14a6" src="https://github.com/user-attachments/assets/3010ba8c-fa30-4ee6-8486-6412336ca470" /> |

#### Keyboard focus

| Baseline at 257ac20f | Proposed behavior in this PR at 78df14a6 |
| --- | --- |
| <img width="1440" height="1000" alt="Baseline keyboard focus at 257ac20f" src="https://github.com/user-attachments/assets/a1450000-36bd-413a-93fb-9090dd713d4e" /> | <img width="1440" height="1000" alt="Proposed keyboard focus in this PR at 78df14a6" src="https://github.com/user-attachments/assets/006038d1-d93e-46e0-8e88-e1e6575f6ba1" /> |

#### Empty query — unchanged

| Baseline at 257ac20f | Proposed behavior in this PR at 78df14a6 |
| --- | --- |
| <img width="1440" height="1000" alt="Baseline empty-query ordering at 257ac20f" src="https://github.com/user-attachments/assets/ed4cd3ac-1567-4cbd-9f39-1638ce5fb6d8" /> | <img width="1440" height="1000" alt="Proposed unchanged empty-query ordering in this PR at 78df14a6" src="https://github.com/user-attachments/assets/535338fa-4303-4ec4-b85a-d14b0d27ab18" /> |

</details>

### Validation limit

The broader remote changed gate is incomplete. Blacksmith doctor failed, Daytona timed out, and Azure returned `403 admin_required`. The local heavy fallback was then stopped externally during `tsgo`, so it is not reported as passing. The focused unit, mounted, and deterministic Chromium proof above completed successfully.
