### PR TITLE
fix(ui): label the pasted-text action Edit as text

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5151,6 +5151,7 @@ export const en: TranslationMap = {
     },
     attachments: {
       attachedFile: "Attached file",
+      editAsText: "Edit as text",
       outsideAllowedFolders: "Outside allowed folders",
       unavailable: "Unavailable",
       checking: "Checking...",

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -4408,9 +4408,11 @@ describe("chat attachment picker", () => {
     expect(container.querySelector(".chat-attachment-file__name")?.textContent).toContain(
       "First words from a l...",
     );
-    expect(container.querySelector(".chat-attachment-text-action")?.textContent).toContain(
-      "Restore",
-    );
+    // The action returns the staged text to the composer for editing; it used to
+    // borrow the worktrees "Restore" string, which described a different feature.
+    const textAction = container.querySelector(".chat-attachment-text-action");
+    expect(textAction?.textContent).toContain("Edit as text");
+    expect(textAction?.getAttribute("aria-label")).toBe("Edit as text");
   });
 
   it("keeps large paste previews UTF-16 well-formed at the display boundary", () => {
@@ -4469,8 +4471,8 @@ describe("chat attachment picker", () => {
     );
     const showButton = requireElement(
       preview,
-      '[aria-label="Restore"]',
-      "show pasted text button",
+      '[aria-label="Edit as text"]',
+      "edit as text button",
     ) as HTMLButtonElement;
 
     showButton.click();

--- a/ui/src/pages/chat/components/chat-attachments.ts
+++ b/ui/src/pages/chat/components/chat-attachments.ts
@@ -550,11 +550,11 @@ export function renderAttachmentPreview(props: ChatAttachmentControlsProps) {
                         <button
                           class="chat-attachment-text-action"
                           type="button"
-                          aria-label=${t("worktrees.restore")}
+                          aria-label=${t("chat.attachments.editAsText")}
                           ?disabled=${props.disabled}
                           @click=${() => showPastedTextInComposer(att, props)}
                         >
-                          ${t("worktrees.restore")}
+                          ${t("chat.attachments.editAsText")}
                           <span aria-hidden="true">${icons.chevronRight}</span>
                         </button>
                       </span>


### PR DESCRIPTION
## What Problem This Solves

Fixes #120767.

Paste more than 1,000 characters into the Control UI composer and the text becomes a compact attachment card with one action on it. That action puts the text back into the composer for editing, but it is labelled **Restore**, both visibly and as its accessible name. Nothing is being restored, so a screen-reader user hears an action name that does not match what happens, and a sighted user has to click it to find out.

The underlying cause is narrower than wording. The card was reusing a translation key that belongs to a different feature:

```ts
aria-label=${t("worktrees.restore")}
...
${t("worktrees.restore")}
```

`worktrees.restore` is the worktrees "Restore" string. The chat composer had no key of its own, so it borrowed one. That is a live coupling, not just a cosmetic slip: any future edit to the worktrees copy silently changes this chat action too, and a translator working on worktrees has no way to know a composer control depends on their wording.

## Why This Change Was Made

The card now uses its own key, `chat.attachments.editAsText`, added to the `chat.attachments` group next to the strings already used by that component. Both the visible label and the `aria-label` read "Edit as text", which is what the button does.

I added the string to `en.ts` only. Locale lookup falls back to English for missing keys, which `ui/src/i18n/test/translate.test.ts` covers, so the other 21 locales keep working and can translate the new key on their own schedule rather than being blocked by this change.

No behaviour changed. `showPastedTextInComposer` is untouched, so the draft-merge behaviour on activation is exactly as before.

## User Impact

The pasted-text attachment action reads "Edit as text" instead of "Restore", in both the visible label and the accessible name. Editing the worktrees copy no longer silently changes a chat composer control.

## Evidence

Two existing tests were pinning the borrowed label, which is why the coupling survived. Both are updated to the new copy rather than deleted, and one is strengthened to assert the accessible name as well as the visible text, since the accessibility mismatch is the part that actually hurts:

```ts
const textAction = container.querySelector(".chat-attachment-text-action");
expect(textAction?.textContent).toContain("Edit as text");
expect(textAction?.getAttribute("aria-label")).toBe("Edit as text");
```

The second test selected the button by `[aria-label="Restore"]`, so it now selects by `[aria-label="Edit as text"]` and still exercises the click-through into the composer.

Confirmed the tests pin the fix by reverting the component to `t("worktrees.restore")` and rerunning:

```
× shows a cached short preview for pasted text
× moves a pasted text attachment back into the composer
Tests  2 failed | 226 passed (228)
```

then restored for 228/228. The whole `ui/src/pages/chat` suite is green at 115 files / 2577 tests, `tsgo -p tsconfig.ui.json` reports zero errors, oxlint is clean on the three changed files.

Production delta is +3/-2 across the component and the English locale; the rest is test updates.

AI-assisted: written with AI assistance. I traced the label to the shared `worktrees.restore` key myself and checked the locale fallback behaviour before adding the string to English only.
