### PR TITLE
fix(browser): cancel waiting profile operations promptly

### DIFF
--- a/extensions/browser/src/browser/server-context.lifecycle.ts
+++ b/extensions/browser/src/browser/server-context.lifecycle.ts
@@ -302,7 +302,7 @@ export async function withProfileOperationLease<T>(params: {
   // skipped between observing an old settled tail and lease admission.
   for (;;) {
     const ready = actor.tail;
-    await ready;
+    await waitForProfileOperation(ready, params.signal);
     if (actor.tail === ready) {
       break;
     }

--- a/extensions/browser/src/browser/server-context.lifecycle.ts
+++ b/extensions/browser/src/browser/server-context.lifecycle.ts
@@ -299,7 +299,7 @@ export async function withProfileOperationLease<T>(params: {
   // skipped between observing an old settled tail and lease admission.
   for (;;) {
     const ready = actor.tail;
-    await ready;
+    await waitForStart(ready, params.signal);
     if (actor.tail === ready) {
       break;
     }

--- a/extensions/browser/src/browser/server-context.list-profiles.test.ts
+++ b/extensions/browser/src/browser/server-context.list-profiles.test.ts
@@ -266,6 +266,70 @@ describe("browser server-context listProfiles", () => {
     }
   });
 
+  it("cancels one profile operation without interrupting a shared transition", async () => {
+    const state = makeBrowserServerState();
+    const ctx = createBrowserRouteContext({ getState: () => state });
+    const profile = ctx.forProfile("openclaw");
+    const runtime = state.profiles.get("openclaw");
+    if (!runtime) {
+      throw new Error("expected profile runtime");
+    }
+
+    let releaseCleanup!: () => void;
+    const cleanupGate = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    let transitionCompleted = false;
+    const transition = beginProfileTransition({
+      state,
+      runtime,
+      reason: "profile refresh requested",
+      closeSharedAdapters: false,
+      afterCleanup: async () => {
+        await cleanupGate;
+        transitionCompleted = true;
+      },
+    });
+    const isChromeCdpReady = vi.mocked(chromeModule.isChromeCdpReady);
+    isChromeCdpReady.mockResolvedValue(true);
+
+    const controller = new AbortController();
+    const aborted = profile.isReachable(undefined, { signal: controller.signal });
+    const surviving = profile.isReachable();
+    let survivingCompleted = false;
+    void surviving.then(() => {
+      survivingCompleted = true;
+    });
+
+    const reason = new Error("profile request cancelled during transition");
+    controller.abort(reason);
+
+    try {
+      const outcome = await Promise.race([
+        aborted.then(
+          () => ({ state: "resolved" as const }),
+          (error: unknown) => ({ state: "rejected" as const, error }),
+        ),
+        new Promise<{ state: "pending" }>((resolve) => {
+          setTimeout(() => resolve({ state: "pending" }), 50);
+        }),
+      ]);
+
+      expect(outcome).toEqual({ state: "rejected", error: reason });
+      expect(transitionCompleted).toBe(false);
+      expect(survivingCompleted).toBe(false);
+      expect(isChromeCdpReady).not.toHaveBeenCalled();
+    } finally {
+      releaseCleanup();
+      await transition;
+    }
+
+    await expect(surviving).resolves.toBe(true);
+    expect(survivingCompleted).toBe(true);
+    await expect(profile.isReachable()).resolves.toBe(true);
+    expect(isChromeCdpReady).toHaveBeenCalledTimes(2);
+  });
+
   it("reads running state only after an in-flight profile transition settles", async () => {
     const state = makeBrowserServerState();
     const ctx = createBrowserRouteContext({ getState: () => state });

--- a/extensions/browser/src/browser/server-context.list-profiles.test.ts
+++ b/extensions/browser/src/browser/server-context.list-profiles.test.ts
@@ -12,6 +12,70 @@ afterEach(() => {
 });
 
 describe("browser server-context listProfiles", () => {
+  it("cancels one profile operation without interrupting a shared transition", async () => {
+    const state = makeBrowserServerState();
+    const ctx = createBrowserRouteContext({ getState: () => state });
+    const profile = ctx.forProfile("openclaw");
+    const runtime = state.profiles.get("openclaw");
+    if (!runtime) {
+      throw new Error("expected profile runtime");
+    }
+
+    let releaseCleanup!: () => void;
+    const cleanupGate = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    let transitionCompleted = false;
+    const transition = beginProfileTransition({
+      state,
+      runtime,
+      reason: "profile refresh requested",
+      closeSharedAdapters: false,
+      afterCleanup: async () => {
+        await cleanupGate;
+        transitionCompleted = true;
+      },
+    });
+    const isChromeCdpReady = vi.mocked(chromeModule.isChromeCdpReady);
+    isChromeCdpReady.mockResolvedValue(true);
+
+    const controller = new AbortController();
+    const aborted = profile.isReachable(undefined, { signal: controller.signal });
+    const surviving = profile.isReachable();
+    let survivingCompleted = false;
+    void surviving.then(() => {
+      survivingCompleted = true;
+    });
+
+    const reason = new Error("profile request cancelled during transition");
+    controller.abort(reason);
+
+    try {
+      const outcome = await Promise.race([
+        aborted.then(
+          () => ({ state: "resolved" as const }),
+          (error: unknown) => ({ state: "rejected" as const, error }),
+        ),
+        new Promise<{ state: "pending" }>((resolve) => {
+          setTimeout(() => resolve({ state: "pending" }), 50);
+        }),
+      ]);
+
+      expect(outcome).toEqual({ state: "rejected", error: reason });
+      expect(transitionCompleted).toBe(false);
+      expect(survivingCompleted).toBe(false);
+      expect(isChromeCdpReady).not.toHaveBeenCalled();
+    } finally {
+      releaseCleanup();
+      await transition;
+    }
+
+    await expect(surviving).resolves.toBe(true);
+    expect(survivingCompleted).toBe(true);
+    await expect(profile.isReachable()).resolves.toBe(true);
+    expect(isChromeCdpReady).toHaveBeenCalledTimes(2);
+  });
+
   it("reads running state only after an in-flight profile transition settles", async () => {
     const state = makeBrowserServerState();
     const ctx = createBrowserRouteContext({ getState: () => state });


### PR DESCRIPTION
## Summary

Browser operations waiting behind a profile transition ignored their caller's existing cancellation signal. A canceled request could therefore remain blocked on the shared profile transition long after its own work should have stopped.

Replace the bare profile-admission wait with the lifecycle owner's existing cancellation-aware wait helper. The canceled caller receives its original error immediately, while the shared transition, another waiting caller, and later profile operations continue normally.

This is a one-expression production change with zero net production growth. It performs no browser action and changes no authentication, configuration, or public API behavior.

## Verification

- Tests-only proof reproduced a real profile operation remaining pending after its caller was canceled during an actual deferred profile transition.
- The exact focused lifecycle suite passes all seven tests; four adjacent browser lifecycle suites pass all 46 tests.
- The complete remote changed gate passes formatting, production/test typechecks, zero-warning lint, and all plugin, ownership, and runtime guards.
- Independent owner-boundary review and fresh structured code review found no actionable issues.
