### PR TITLE
fix(test): gate long-context live shard by opt-in

### DIFF
--- a/scripts/test-live-shard.mjs
+++ b/scripts/test-live-shard.mjs
@@ -42,6 +42,7 @@ const OPTIONAL_LIVE_SHARD_FILE_ENVS = new Map([
   ["src/gateway/gateway-cli-backend.live.test.ts", ["OPENCLAW_LIVE_CLI_BACKEND"]],
   ["src/gateway/gateway-codex-bind.live.test.ts", ["OPENCLAW_LIVE_CODEX_BIND"]],
   ["src/gateway/gateway-codex-harness.live.test.ts", ["OPENCLAW_LIVE_CODEX_HARNESS"]],
+  ["src/gateway/gateway-openai-long-context.live.test.ts", ["OPENCLAW_LIVE_OPENAI_LONG_CONTEXT"]],
   ["src/gateway/gateway-trajectory-export.live.test.ts", ["OPENCLAW_LIVE_CODEX_HARNESS"]],
   ["src/infra/push-apns-http2.live.test.ts", ["OPENCLAW_LIVE_APNS_REACHABILITY"]],
   ["test/image-generation.infer-cli.live.test.ts", ["OPENCLAW_LIVE_INFER_CLI_TEST"]],

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -394,6 +394,38 @@ describe("scripts/test-live-shard", () => {
     });
   });
 
+  it("allows the OpenAI long-context live file to be skipped until its env is enabled", () => {
+    const profilesFile = "src/gateway/gateway-models.profiles.live.test.ts";
+    const longContextFile = "src/gateway/gateway-openai-long-context.live.test.ts";
+    const payload = {
+      numPassedTests: 1,
+      numTotalTests: 2,
+      testResults: [
+        {
+          name: path.join(process.cwd(), profilesFile),
+          assertionResults: [{ status: "passed" }],
+        },
+        {
+          name: path.join(process.cwd(), longContextFile),
+          assertionResults: [{ status: "skipped" }],
+        },
+      ],
+    };
+    const expectedFiles = [profilesFile, longContextFile];
+
+    expect(validateLiveShardReportPayload(payload, expectedFiles, process.cwd(), {})).toEqual({
+      ok: true,
+    });
+    expect(
+      validateLiveShardReportPayload(payload, expectedFiles, process.cwd(), {
+        OPENCLAW_LIVE_OPENAI_LONG_CONTEXT: "1",
+      }),
+    ).toEqual({
+      ok: false,
+      reason: `Vitest report selected live test files had no passing assertions: ${longContextFile}`,
+    });
+  });
+
   it("allows the experience review live file to be skipped until its env is enabled", () => {
     const reviewFile = "src/skills/workshop/experience-review.live.test.ts";
     const payload = {


### PR DESCRIPTION
## What Problem This Solves

The release gateway-profiles shard selected the expensive OpenAI long-context live test, but that file skips unless OPENCLAW_LIVE_OPENAI_LONG_CONTEXT is enabled and was not registered as optional. Normal release profile reports therefore failed with a selected file that had no passing assertion.

## Why This Change Was Made

Register the file with its existing dedicated opt-in flag while keeping it selected in the shard. Add report-validation coverage proving disabled skip is accepted and enabled skip is rejected. No paid test default, docs, runtime, config, protocol, or product behavior change. Related: #120457.

## User Impact

Release-live validation no longer fails merely because the deliberately opt-in paid million-token proof is disabled; enabling the flag still requires it to pass.

## Evidence

`node scripts/run-vitest.mjs test/scripts/test-live-shard.test.ts` — 23 passed. Formatting/diff/autoreview clean. Source/tooling +1; tests +32.
