### PR TITLE
fix: label pasted text attachments "Show in text field"

### DIFF
--- a/ui/src/e2e/chat-pasted-text-show-in-text-field.e2e.test.ts
+++ b/ui/src/e2e/chat-pasted-text-show-in-text-field.e2e.test.ts
@@ -1,0 +1,55 @@
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI pasted text field action",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
+const pastedText = `Quarterly launch plan\n\n${"x".repeat(1100)}`;
+
+suite.define(() => {
+  it("returns a pasted text attachment to the text field without sending", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        reducedMotion: "reduce",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page);
+        await page.goto(`${suite.server.baseUrl}chat`);
+
+        const composer = page.locator(".agent-chat__composer-combobox textarea");
+        await composer.waitFor({ state: "visible" });
+        await composer.evaluate((element, text) => {
+          const clipboard = new DataTransfer();
+          clipboard.setData("text/plain", text);
+          element.dispatchEvent(
+            new ClipboardEvent("paste", {
+              bubbles: true,
+              cancelable: true,
+              clipboardData: clipboard,
+            }),
+          );
+        }, pastedText);
+
+        const showInTextField = page.getByRole("button", {
+          name: "Show in text field",
+          exact: true,
+        });
+        await showInTextField.waitFor({ state: "visible" });
+        expect((await showInTextField.textContent())?.trim()).toBe("Show in text field");
+
+        await showInTextField.click();
+
+        await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(0);
+        await expect.poll(() => composer.inputValue()).toBe(pastedText);
+        expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+      },
+    );
+  });
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5151,6 +5151,7 @@ export const en: TranslationMap = {
     },
     attachments: {
       attachedFile: "Attached file",
+      showInTextField: "Show in text field",
       outsideAllowedFolders: "Outside allowed folders",
       unavailable: "Unavailable",
       checking: "Checking...",

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -4408,8 +4408,8 @@ describe("chat attachment picker", () => {
     expect(container.querySelector(".chat-attachment-file__name")?.textContent).toContain(
       "First words from a l...",
     );
-    expect(container.querySelector(".chat-attachment-text-action")?.textContent).toContain(
-      "Restore",
+    expect(container.querySelector(".chat-attachment-text-action")?.textContent?.trim()).toBe(
+      "Show in text field",
     );
   });
 
@@ -4441,7 +4441,7 @@ describe("chat attachment picker", () => {
     expect(onAttachmentsChange).not.toHaveBeenCalled();
   });
 
-  it("moves a pasted text attachment back into the composer", async () => {
+  it("shows a pasted text attachment in the composer text field", async () => {
     const onAttachmentsChange = vi.fn();
     const firstRender = renderChatView({ onAttachmentsChange });
     const textarea = getComposerTextarea(firstRender);
@@ -4467,13 +4467,13 @@ describe("chat attachment picker", () => {
       }),
       'renderChatView({ attachments: [attachment], draft: "intro", getDraft:... test invariant',
     );
-    const showButton = requireElement(
+    const showInTextFieldButton = requireElement(
       preview,
-      '[aria-label="Restore"]',
-      "show pasted text button",
+      '[aria-label="Show in text field"]',
+      "show pasted text in text field button",
     ) as HTMLButtonElement;
 
-    showButton.click();
+    showInTextFieldButton.click();
 
     expect(onShowAttachmentsChange).toHaveBeenCalledWith([]);
     expect(onDraftChange).toHaveBeenCalledWith(`intro\n\n${pastedText}`);

--- a/ui/src/pages/chat/components/chat-attachments.ts
+++ b/ui/src/pages/chat/components/chat-attachments.ts
@@ -550,11 +550,11 @@ export function renderAttachmentPreview(props: ChatAttachmentControlsProps) {
                         <button
                           class="chat-attachment-text-action"
                           type="button"
-                          aria-label=${t("worktrees.restore")}
+                          aria-label=${t("chat.attachments.showInTextField")}
                           ?disabled=${props.disabled}
                           @click=${() => showPastedTextInComposer(att, props)}
                         >
-                          ${t("worktrees.restore")}
+                          ${t("chat.attachments.showInTextField")}
                           <span aria-hidden="true">${icons.chevronRight}</span>
                         </button>
                       </span>


### PR DESCRIPTION
Closes #120767

## What Problem This Solves

Fixes an issue where users who paste more than 1,000 characters of plain text into the Chat or New Session composer see an action labeled “Restore,” even though the action puts the staged text back into the composer text field.

## Why This Change Was Made

This change gives the shared attachment renderer an English `chat.attachments.showInTextField` label and uses it for both visible copy and the accessible name. Attachment identity, payload release, removal, draft merging, request updates, and disabled behavior remain unchanged; foreign locale catalogs continue through the normal fallback and translation workflow.

## User Impact

With this proposal, pasted-text attachment cards offer the precise action “Show in text field.” Activating it still removes only that attachment and returns its exact contents to the composer without sending a message.

## Evidence

### Focused automated proof

- Red proof before the production change: the updated semantic test failed only on the superseded visible and accessible names (226 passed, 2 expected failures).
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts` — 228 passed at the final patch.
- Deterministic mocked Control UI browser test — 1 passed; proves the exact label/access name, 1 → 0 attachment transition, exact draft rehydration, and zero `chat.send` requests.
- `pnpm ui:i18n:baseline`, `pnpm ui:i18n:verify`, and `pnpm lint:ui:i18n` — passed with 4,612 source keys and 97 raw-copy baseline entries.
- Targeted `oxfmt --check` and `git diff --check` — passed.
- Mandatory autoreview — clean with no accepted or actionable findings. Publication rebases preserved the reviewed patch exactly (`git patch-id --stable`: `a315401ad6eac7133b40652a93327df5939de9fb`).

No full changed gate or build was run for this copy-only correction. The focused unit, Control UI E2E, i18n, formatting, and static proof ran against trusted source. Blacksmith Testbox became available after the focused proof; no genuinely heavy follow-up was necessary, so no lease, provider ID, or remote run URL exists.

Production LOC: +3/−2 (net +1). Test LOC: +62/−7 (net +55).

### Deterministic visual proof

Every frame uses the same 1,242 UTF-16-code-unit payload (`SHA-256 5ac05d8ac9271c78e2d186087e001bc50331070e2568384805b93c94f9e916f1`). Proposed-state screenshots were captured from final implementation commit `dab7d14e4ddea3a2719ee3c137bec9f21ce57aac` on parent `a663063d4dc7621c8092323e40ca9a2e29e7bfe8`.

Baseline attribution: the baseline was captured at `115e5a6f258bf1704c4f8a6ac6c2d8de6f08e890`, not at the final parent. Its complete `ui/` tree (`a5dcc1ea1d53626e3c2fdc18466b6c30058a489d`) was cryptographically identical to the then-current parent `9f2c2bd4c0aab6d0ca532ba4f156d97036779980` across 17 intervening non-UI commits. The branch was subsequently rebased over unrelated work; the affected attachment component blob remains identical between the baseline and final parent.

#### Desktop light — attachment card, 1280×900

| Before — mislabeled action | Proposed — exact label and accessible name |
| --- | --- |
| <img width="1280" height="900" alt="01-attachment-card-restore" src="https://github.com/user-attachments/assets/552300c3-a4af-447e-8840-c794358034b9" /> | <img width="1280" height="900" alt="01-desktop-light-attachment-card-show-in-text-field" src="https://github.com/user-attachments/assets/7f79ea69-6c62-4b0f-b9ea-e458e2b5f761" /> |

#### Desktop light — resulting editable draft

| Before — exact rehydrated draft | Proposed — exact rehydrated draft |
| --- | --- |
| <img width="1280" height="900" alt="02-editable-draft-after-restore" src="https://github.com/user-attachments/assets/0e80c78b-ebbe-40f1-8f9f-8140f574aded" /> | <img width="1280" height="900" alt="02-desktop-light-editable-draft" src="https://github.com/user-attachments/assets/ccfee0dd-30cf-4464-8ec9-f1d483779443" /> |

The before and proposed desktop draft frames are byte-identical (`SHA-256 5ed1c7808ddac658fa4753a4ad112541ffe0a7b730edae8b18cb618a8846ade1`).

#### Mobile dark — attachment card, 390×844

| Before — “Restore” | Proposed — “Show in text field” |
| --- | --- |
| <img width="390" height="844" alt="03-mobile-dark-attachment-card-restore" src="https://github.com/user-attachments/assets/5392ecc8-7c30-4ca2-b8ef-e6e4daf26446" /> | <img width="390" height="844" alt="03-mobile-dark-attachment-card-show-in-text-field" src="https://github.com/user-attachments/assets/56c13bf4-2d59-4555-9551-bad5821ba049" /> |

#### Mobile dark — resulting editable draft

| Before — complete composer | Proposed — complete stable composer |
| --- | --- |
| <img width="390" height="844" alt="04-mobile-dark-editable-draft-after-restore" src="https://github.com/user-attachments/assets/970f524a-53e1-4558-a7dd-5e84f9998166" /> | <img width="390" height="844" alt="04-mobile-dark-editable-draft" src="https://github.com/user-attachments/assets/e3f6e0d0-962b-46eb-bc01-e82f8ce000de" /> |

The before and proposed mobile draft frames are byte-identical (`SHA-256 e561787686314f0fea25da306f18e88f36f2964d0c7c41cb85e3519cbace9728`). The proposed mobile composer stabilizes at 374×179 px inside the viewport with a 26 px bottom margin. The card, preview, action, textarea, composer, and document have no clipping, overlap, wrapping regression, or horizontal overflow.

#### Desktop light — hover and keyboard focus

| Before — “Restore” focused | Proposed — “Show in text field” focused |
| --- | --- |
| <img width="1280" height="900" alt="05-desktop-light-restore-hover-focus" src="https://github.com/user-attachments/assets/6cc493c8-338e-40de-82fd-cc84ea0a92bd" /> | <img width="1280" height="900" alt="05-desktop-light-show-in-text-field-hover-focus" src="https://github.com/user-attachments/assets/08c33e5b-f520-449a-8b55-4aaa35c2b689" /> |

The proposed action retains the 2 px solid accent focus ring and hover treatment without overlapping the remove control.

#### New Session — reachable disabled state

| Before — disabled “Restore” | Proposed — disabled “Show in text field” |
| --- | --- |
| <img width="1280" height="900" alt="06-new-session-disabled-restore" src="https://github.com/user-attachments/assets/50b3667c-0f55-46d5-aafa-1bb24ff6efc0" /> | <img width="1280" height="900" alt="06-new-session-disabled-show-in-text-field" src="https://github.com/user-attachments/assets/b910e6f5-1897-419a-a577-995188ee71f4" /> |

The disabled state is reached by holding `sessions.create` pending: the attachment remains, the action and textarea are disabled, `aria-busy` is true, and no `chat.send` request occurs.

Named follow-up: the existing disabled action is semantically disabled but still inherits `cursor: pointer` and full opacity, so its visual treatment is not distinct. This patch intentionally preserves that pre-existing behavior to keep the fix limited to the copy contract; disabled styling should be aligned with the platform in separate UI work.
