### PR TITLE
fix(qa): update Control UI scenario code references

### DIFF
--- a/qa/scenarios/ui/control-ui-exec-approvals-agents.yaml
+++ b/qa/scenarios/ui/control-ui-exec-approvals-agents.yaml
@@ -20,7 +20,7 @@ scenario:
     - docs/help/testing.md
   codeRefs:
     - ui/src/e2e/operator-admin.e2e.test.ts
-    - ui/src/pages/nodes/view-exec-approvals.ts
+    - ui/src/pages/devices/view-exec-approvals.ts
     - ui/src/lib/nodes/index.ts
   execution:
     kind: playwright

--- a/qa/scenarios/ui/control-ui-skills-nodes.yaml
+++ b/qa/scenarios/ui/control-ui-skills-nodes.yaml
@@ -21,7 +21,7 @@ scenario:
   codeRefs:
     - ui/src/e2e/operator-admin.e2e.test.ts
     - ui/src/pages/skills/skills-page.ts
-    - ui/src/pages/nodes/nodes-page.ts
+    - ui/src/pages/devices/devices-page.ts
   execution:
     kind: playwright
     path: ui/src/e2e/operator-admin.e2e.test.ts


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the QA scenario catalog referenced Control UI source files that moved from `pages/nodes` to `pages/devices`, causing repository-backed code reference validation to fail.

## Why This Change Was Made

Updates only the two stale scenario `codeRefs` to the current device-page source paths. No runtime behavior, scenario wording, or execution coverage changes.

## User Impact

No runtime user impact. Release and QA validation can resolve the Control UI scenario references against the current repository layout.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.test.ts` - 58/58 passed.
- `node scripts/check-changed.mjs -- qa/scenarios/ui/control-ui-exec-approvals-agents.yaml qa/scenarios/ui/control-ui-skills-nodes.yaml` - exit 0 through Testbox: https://github.com/openclaw/openclaw/actions/runs/31286473329
- `git diff --check` - passed.
- Diff: 2 insertions, 2 deletions; production LOC delta 0.

AI-assisted: yes.
