### PR TITLE
fix(windows): preserve configured child env overrides across key casing

### DIFF
--- a/src/agents/cli-executable-identity.test.ts
+++ b/src/agents/cli-executable-identity.test.ts
@@ -60,6 +60,40 @@ describe("CLI executable implementation identity", () => {
     );
   });
 
+  it.runIf(process.platform === "win32")(
+    "rejects mixed-case relative PATH entries and accepts mixed-case absolute entries",
+    async () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-path-case-"));
+      tempDirs.push(root);
+      const binDir = path.join(root, "bin");
+      const executable = path.join(binDir, "mixed-identity.exe");
+      fs.mkdirSync(binDir);
+      fs.linkSync(process.execPath, executable);
+      const relativeBinDir = path.relative(process.cwd(), binDir);
+      const runtimeArtifact: CliBackendRuntimeArtifactPolicy = {
+        ...commandPackagePolicy,
+        nativeExecutableNames: ["mixed-identity.exe"],
+      };
+
+      expect(path.isAbsolute(relativeBinDir)).toBe(false);
+      await expect(
+        resolveCliExecutableIdentity({
+          command: "mixed-identity",
+          env: { pAtH: relativeBinDir, pAtHeXt: ".EXE" },
+          runtimeArtifact,
+        }),
+      ).resolves.toBeUndefined();
+
+      const identity = await resolveCliExecutableIdentity({
+        command: "mixed-identity",
+        env: { pAtH: binDir, pAtHeXt: ".EXE" },
+        runtimeArtifact,
+      });
+      expect(identity?.resolvedPath).toBe(fs.realpathSync(executable));
+      expect(identity?.runtimeArtifact).toEqual({ kind: "self-contained-executable" });
+    },
+  );
+
   it("does not depend on host locale collation when ordering package files", async () => {
     const fixture = makePackage();
     fs.writeFileSync(path.join(fixture.root, "dist", "z.js"), "z\n");

--- a/src/agents/cli-executable-identity.ts
+++ b/src/agents/cli-executable-identity.ts
@@ -3,6 +3,7 @@ import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveExecutablePath } from "../infra/executable-path.js";
+import { resolveEnvironmentValue } from "../infra/process-env.js";
 import {
   resolveWindowsExecutablePath,
   resolveWindowsSpawnProgramCandidate,
@@ -143,7 +144,7 @@ function isDurableRootedCommand(value: string): boolean {
 }
 
 function pathEntriesAreAbsolute(env: NodeJS.ProcessEnv): boolean {
-  const pathValue = env.PATH ?? env.Path ?? "";
+  const pathValue = resolveEnvironmentValue(env, "PATH") ?? "";
   const delimiter = process.platform === "win32" ? ";" : path.delimiter;
   return pathValue
     .split(delimiter)

--- a/src/agents/mcp-stdio-transport.ts
+++ b/src/agents/mcp-stdio-transport.ts
@@ -10,6 +10,7 @@ import { ReadBuffer, serializeMessage } from "@modelcontextprotocol/sdk/shared/s
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { mergeProcessEnv } from "../infra/process-env.js";
 import { killProcessTree, signalProcessTree } from "../process/kill-tree.js";
 import { prepareOomScoreAdjustedSpawn } from "../process/linux-oom-score.js";
 
@@ -67,10 +68,7 @@ export class OpenClawStdioClientTransport implements Transport {
     }
 
     await new Promise<void>((resolve, reject) => {
-      const baseEnv = {
-        ...getDefaultEnvironment(),
-        ...this.serverParams.env,
-      };
+      const baseEnv = mergeProcessEnv([getDefaultEnvironment(), this.serverParams.env]);
       const preparedSpawn = prepareOomScoreAdjustedSpawn(
         this.serverParams.command,
         this.serverParams.args ?? [],

--- a/src/agents/mcp-stdio-transport.windows.test.ts
+++ b/src/agents/mcp-stdio-transport.windows.test.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { OpenClawStdioClientTransport } from "./mcp-stdio-transport.js";
+import { resolveStdioMcpServerLaunchConfig } from "./mcp-stdio.js";
+
+describe.runIf(process.platform === "win32")("OpenClawStdioClientTransport on Windows", () => {
+  it("applies configured environment overrides regardless of key case", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mcp-env-case-"));
+    const inheritedTemp = path.join(root, "inherited");
+    const configuredTemp = path.join(root, "configured");
+    const capturePath = path.join(root, "captured.txt");
+    await fs.mkdir(inheritedTemp);
+    await fs.mkdir(configuredTemp);
+    const previousTemp = process.env.TEMP;
+    process.env.TEMP = inheritedTemp;
+    let transport: OpenClawStdioClientTransport | undefined;
+
+    try {
+      const resolved = resolveStdioMcpServerLaunchConfig({
+        command: process.execPath,
+        args: [
+          "-e",
+          'require("node:fs").writeFileSync(process.env.OPENCLAW_MCP_ENV_CAPTURE, process.env.TEMP)',
+        ],
+        env: {
+          temp: configuredTemp,
+          OPENCLAW_MCP_ENV_CAPTURE: capturePath,
+        },
+      });
+      expect(resolved.ok).toBe(true);
+      if (!resolved.ok) {
+        return;
+      }
+
+      transport = new OpenClawStdioClientTransport(resolved.config);
+      const closed = new Promise<void>((resolve, reject) => {
+        // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Transport uses callback properties, not EventTarget.
+        transport!.onclose = resolve;
+        // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Transport uses callback properties, not EventTarget.
+        transport!.onerror = reject;
+      });
+      await transport.start();
+      await closed;
+
+      await expect(fs.readFile(capturePath, "utf8")).resolves.toBe(configuredTemp);
+    } finally {
+      await transport?.forceClose();
+      if (previousTemp === undefined) {
+        delete process.env.TEMP;
+      } else {
+        process.env.TEMP = previousTemp;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/gateway/server-methods/terminal.test.ts
+++ b/src/gateway/server-methods/terminal.test.ts
@@ -201,7 +201,11 @@ describe("terminal gateway policy", () => {
     const openTerminal = vi.fn(async () => ({
       kind: "local" as const,
       argv: ["codex", "resume", "thread"],
-      env: { CODEX_HOME: "/agent/codex-home" },
+      env: {
+        CODEX_HOME: "/agent/codex-home",
+        ComSpec: "C:\\Windows\\System32\\ambient-cmd.exe",
+        COMSPEC: "C:\\Windows\\System32\\configured-cmd.exe",
+      },
       pathEnv: "/login-shell/bin:/usr/bin",
       title: "codex resume thread",
     }));
@@ -230,13 +234,22 @@ describe("terminal gateway policy", () => {
     expect(sessions.open).toHaveBeenCalledWith(
       expect.objectContaining({
         shell: expect.any(String),
-        args: ["-il", "-c", "'codex' 'resume' 'thread'"],
+        args:
+          process.platform === "win32"
+            ? ["resume", "thread"]
+            : ["-il", "-c", "'codex' 'resume' 'thread'"],
         env: expect.objectContaining({
           CODEX_HOME: "/agent/codex-home",
           PATH: "/login-shell/bin:/usr/bin",
         }),
       }),
     );
+    if (process.platform === "win32") {
+      const terminalEnv = sessions.open.mock.calls[0]?.[0] as { env: Record<string, string> };
+      expect(
+        Object.entries(terminalEnv.env).filter(([key]) => key.toUpperCase() === "COMSPEC"),
+      ).toEqual([["COMSPEC", "C:\\Windows\\System32\\configured-cmd.exe"]]);
+    }
     expect(respond).toHaveBeenCalledWith(
       true,
       expect.objectContaining({ sessionId: "terminal-1", title: "codex resume thread" }),
@@ -486,7 +499,10 @@ describe("terminal gateway policy", () => {
     await opening;
 
     expect(sessions.open).toHaveBeenCalledWith(
-      expect.objectContaining({ cwd: process.cwd(), shell: "/bin/refreshed" }),
+      expect.objectContaining({
+        cwd: process.cwd(),
+        shell: process.platform === "win32" ? "codex" : "/bin/refreshed",
+      }),
     );
   });
 

--- a/src/gateway/server-methods/terminal.ts
+++ b/src/gateway/server-methods/terminal.ts
@@ -21,6 +21,7 @@ import {
   validateTerminalUploadResult,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { NODE_TERMINAL_UPLOAD_COMMAND } from "../../infra/node-commands.js";
+import { mergeProcessEnv } from "../../infra/process-env.js";
 import type { TerminalUploadFile } from "../../infra/terminal-file-upload.js";
 import type { SessionCatalogTerminalPlan } from "../../plugins/session-catalog.js";
 import { applyPluginNodeInvokePolicy } from "../node-invoke-plugin-policy.js";
@@ -292,15 +293,16 @@ export const terminalHandlers: GatewayRequestHandlers = {
         });
     }
     const spawnPlan = resolveTerminalOpenSpawnPlan(refreshedLaunch.plan, catalogPlan);
-    const terminalEnv = buildTerminalEnv(process.env);
-    if (catalogPlan?.kind === "local") {
-      Object.assign(terminalEnv, catalogPlan.env);
-      if (catalogPlan.pathEnv) {
-        // Preserve the PATH that found a login-shell CLI so env-based shebangs
-        // can resolve their interpreter inside the spawned terminal process.
-        terminalEnv.PATH = catalogPlan.pathEnv;
-      }
-    }
+    const terminalEnv =
+      catalogPlan?.kind === "local"
+        ? mergeProcessEnv([
+            buildTerminalEnv(process.env),
+            catalogPlan.env,
+            // Preserve the PATH that found a login-shell CLI so env-based shebangs
+            // can resolve their interpreter inside the spawned terminal process.
+            catalogPlan.pathEnv ? { PATH: catalogPlan.pathEnv } : undefined,
+          ])
+        : buildTerminalEnv(process.env);
     let openingTerminal: ReturnType<typeof manager.open> | undefined;
     let outcome: Awaited<ReturnType<typeof manager.open>>;
     try {

--- a/src/infra/executable-path.ts
+++ b/src/infra/executable-path.ts
@@ -4,27 +4,10 @@ import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { expandHomePrefix } from "./home-dir.js";
 import { pruneMapToMaxSize } from "./map-size.js";
+import { resolveEnvironmentValue } from "./process-env.js";
 
 function isDriveLessWindowsRootedPath(value: string): boolean {
   return process.platform === "win32" && /^:[\\/]/.test(value);
-}
-
-function resolveEnvironmentValue(
-  env: NodeJS.ProcessEnv | undefined,
-  name: string,
-): string | undefined {
-  if (!env) {
-    return undefined;
-  }
-  const exactValue = env[name] ?? (name === "PATH" ? env.Path : undefined);
-  if (exactValue !== undefined) {
-    return exactValue;
-  }
-  if (process.platform !== "win32") {
-    return undefined;
-  }
-  const normalizedName = name.toLowerCase();
-  return Object.entries(env).find(([key]) => key.toLowerCase() === normalizedName)?.[1];
 }
 
 export function resolveExecutablePathCandidate(

--- a/src/infra/process-env.test.ts
+++ b/src/infra/process-env.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { mergeProcessEnv, resolveEnvironmentValue } from "./process-env.js";
+
+describe("resolveEnvironmentValue", () => {
+  it("preserves exact POSIX keys and the existing Path fallback", () => {
+    const env = { PATH: "exact", Path: "fallback", path: "lowercase" };
+
+    expect(resolveEnvironmentValue(env, "PATH", "linux")).toBe("exact");
+    expect(resolveEnvironmentValue({ Path: "fallback" }, "PATH", "linux")).toBe("fallback");
+    expect(resolveEnvironmentValue({ path: "lowercase" }, "PATH", "linux")).toBeUndefined();
+  });
+
+  it("reads arbitrary Windows key casing with child_process precedence", () => {
+    const env = { path: "lowercase", Path: "lexical-first", pAtHeXt: ".MiXeD" };
+
+    expect(resolveEnvironmentValue(env, "PATH", "win32")).toBe("lexical-first");
+    expect(resolveEnvironmentValue(env, "PATHEXT", "win32")).toBe(".MiXeD");
+  });
+
+  it("does not fall through a lexically preferred undefined Windows key", () => {
+    expect(
+      resolveEnvironmentValue({ PATH: undefined, Path: "later" }, "PATH", "win32"),
+    ).toBeUndefined();
+  });
+});
+
+describe("mergeProcessEnv", () => {
+  it("lets later Windows sources override inherited keys regardless of case", () => {
+    expect(
+      mergeProcessEnv([{ TEMP: "inherited", HOME: "base" }, { temp: "configured" }], "win32"),
+    ).toEqual({ HOME: "base", temp: "configured" });
+  });
+
+  it("keeps Node's lexicographically first Windows duplicate within one source", () => {
+    expect(mergeProcessEnv([{ temp: "lower", Temp: "first" }], "win32")).toEqual({
+      Temp: "first",
+    });
+  });
+
+  it("removes inherited Windows keys with a case-insensitive undefined override", () => {
+    expect(mergeProcessEnv([{ Path: "C:\\base" }, { PATH: undefined }], "win32")).toEqual({});
+  });
+
+  it("preserves case-distinct POSIX keys", () => {
+    expect(mergeProcessEnv([{ Path: "/base" }, { PATH: "/override" }], "linux")).toEqual({
+      Path: "/base",
+      PATH: "/override",
+    });
+  });
+});

--- a/src/infra/process-env.ts
+++ b/src/infra/process-env.ts
@@ -1,0 +1,57 @@
+/** Read one environment value using the same Windows key precedence as child_process. */
+export function resolveEnvironmentValue(
+  env: NodeJS.ProcessEnv | undefined,
+  name: string,
+  platform: NodeJS.Platform = process.platform,
+): string | undefined {
+  if (!env) {
+    return undefined;
+  }
+  if (platform !== "win32") {
+    return env[name] ?? (name === "PATH" ? env.Path : undefined);
+  }
+  const normalizedName = name.toUpperCase();
+  const key = Object.keys(env)
+    .toSorted()
+    .find((candidate) => candidate.toUpperCase() === normalizedName);
+  return key === undefined ? undefined : env[key];
+}
+
+/** Merge child environments while preserving Node's platform-specific key semantics. */
+export function mergeProcessEnv(
+  sources: ReadonlyArray<NodeJS.ProcessEnv | undefined>,
+  platform: NodeJS.Platform = process.platform,
+): Record<string, string> {
+  const merged: Record<string, string> = {};
+  for (const source of sources) {
+    if (!source) {
+      continue;
+    }
+    const keys = Object.keys(source);
+    // Node keeps the lexicographically first case-insensitive duplicate from each
+    // Windows env object. Later source objects still own override precedence.
+    const sourceKeys = new Set<string>();
+    for (const key of platform === "win32" ? keys.toSorted() : keys) {
+      if (platform === "win32") {
+        const normalizedKey = key.toUpperCase();
+        if (sourceKeys.has(normalizedKey)) {
+          continue;
+        }
+        sourceKeys.add(normalizedKey);
+        for (const previousKey of Object.keys(merged)) {
+          if (previousKey.toUpperCase() === normalizedKey) {
+            delete merged[previousKey];
+          }
+        }
+      }
+      const value = source[key];
+      if (value === undefined) {
+        delete merged[key];
+      } else {
+        merged[key] = value;
+      }
+    }
+  }
+
+  return merged;
+}

--- a/src/node-host/pty-command.test.ts
+++ b/src/node-host/pty-command.test.ts
@@ -1,11 +1,19 @@
 import os from "node:os";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginNodeHostCommandIo } from "../plugins/types.js";
 import { decodeNodePtyResumeParams, runNodePtyCommand } from "./pty-command.js";
+
+const { nodePtySpawn } = vi.hoisted(() => ({ nodePtySpawn: vi.fn() }));
+
+vi.mock("@lydell/node-pty", () => ({ spawn: nodePtySpawn }));
 
 type TerminalPtyHandle = Awaited<ReturnType<NonNullable<Parameters<typeof runNodePtyCommand>[2]>>>;
 
 describe("node PTY command", () => {
+  afterEach(() => {
+    nodePtySpawn.mockReset();
+  });
+
   it("validates closed resume params", () => {
     const validate = (value: unknown) => {
       if (typeof value !== "string" || !value) {
@@ -143,4 +151,64 @@ describe("node PTY command", () => {
     expect(pty.write).not.toHaveBeenCalled();
     expect(pty.resize).not.toHaveBeenCalled();
   });
+
+  it.runIf(process.platform === "win32")(
+    "uses a configured COMSPEC override for Windows batch commands",
+    async () => {
+      const previousComSpec = process.env.ComSpec;
+      const ambientComSpec = "C:\\Windows\\System32\\ambient-cmd.exe";
+      const configuredComSpec = "C:\\Windows\\System32\\configured-cmd.exe";
+      process.env.ComSpec = ambientComSpec;
+      try {
+        nodePtySpawn.mockReturnValueOnce({
+          pid: 42,
+          write: vi.fn(),
+          resize: vi.fn(),
+          pause: vi.fn(),
+          resume: vi.fn(),
+          kill: vi.fn(),
+          onData: vi.fn(),
+          onExit: (callback: (event: { exitCode: number }) => void) => {
+            queueMicrotask(() => callback({ exitCode: 0 }));
+          },
+        });
+        const io: OpenClawPluginNodeHostCommandIo = {
+          signal: new AbortController().signal,
+          emitChunk: vi.fn(async () => {}),
+          onInput: vi.fn(),
+        };
+
+        await expect(
+          runNodePtyCommand(
+            {
+              file: "C:\\tools\\catalog-command.cmd",
+              args: ["resume", "thread title"],
+              env: { COMSPEC: configuredComSpec },
+              cols: 80,
+              rows: 24,
+            },
+            io,
+          ),
+        ).resolves.toEqual({ exitCode: 0 });
+
+        expect(nodePtySpawn).toHaveBeenCalledWith(
+          configuredComSpec,
+          ["/d", "/s", "/c", 'C:\\tools\\catalog-command.cmd resume "thread title"'],
+          expect.objectContaining({
+            env: expect.objectContaining({ COMSPEC: configuredComSpec }),
+          }),
+        );
+        const spawnedEnv = nodePtySpawn.mock.calls[0]?.[2]?.env as Record<string, string>;
+        expect(Object.keys(spawnedEnv).filter((key) => key.toUpperCase() === "COMSPEC")).toEqual([
+          "COMSPEC",
+        ]);
+      } finally {
+        if (previousComSpec === undefined) {
+          delete process.env.ComSpec;
+        } else {
+          process.env.ComSpec = previousComSpec;
+        }
+      }
+    },
+  );
 });

--- a/src/node-host/pty-command.ts
+++ b/src/node-host/pty-command.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { mergeProcessEnv } from "../infra/process-env.js";
 import type { OpenClawPluginNodeHostCommandIo } from "../plugins/types.js";
 import { spawnTerminalPty } from "../process/terminal-pty.js";
 
@@ -110,17 +111,12 @@ export async function runNodePtyCommand(
   if (io.signal.aborted) {
     return { exitCode: 130 };
   }
-  const env = Object.fromEntries(
-    Object.entries(process.env).filter(
-      (entry): entry is [string, string] => entry[1] !== undefined,
-    ),
-  );
-  Object.assign(env, params.env);
-  env.TERM ??= "xterm-256color";
-  env.OPENCLAW_TERMINAL = "1";
-  if (params.pathEnv) {
-    env.PATH = params.pathEnv;
-  }
+  const env = mergeProcessEnv([
+    process.env,
+    params.env,
+    params.pathEnv ? { PATH: params.pathEnv } : undefined,
+    { OPENCLAW_TERMINAL: "1" },
+  ]);
   const pty = await spawn({
     file: params.file,
     args: params.args,

--- a/src/plugin-sdk/windows-spawn.test.ts
+++ b/src/plugin-sdk/windows-spawn.test.ts
@@ -1,7 +1,8 @@
 /**
  * Tests Windows spawn compatibility helpers.
  */
-import { writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { link, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createPluginSdkTestHarness } from "./test-helpers.js";
@@ -15,6 +16,33 @@ const { createTempDir } = createPluginSdkTestHarness({
 });
 
 describe("resolveWindowsSpawnProgram", () => {
+  it.runIf(process.platform === "win32")(
+    "resolves mixed-case PATH and PATHEXT keys for a native Windows spawn",
+    async () => {
+      const dir = await createTempDir("openclaw-windows-spawn-env-case-");
+      const executable = path.join(dir, "mixed-env-tool.MiXeD");
+      await link(process.execPath, executable);
+      const env = { pAtH: dir, pAtHeXt: ".MiXeD" };
+
+      const program = resolveWindowsSpawnProgram({
+        command: "mixed-env-tool",
+        platform: "win32",
+        env,
+        execPath: process.execPath,
+      });
+      const invocation = materializeWindowsSpawnProgram(program, [
+        "-e",
+        'process.stdout.write("native-ok")',
+      ]);
+      const child = spawnSync(invocation.command, invocation.argv, { env, encoding: "utf8" });
+
+      expect(program).toMatchObject({ command: executable, resolution: "direct" });
+      expect(child.error).toBeUndefined();
+      expect(child.status).toBe(0);
+      expect(child.stdout).toBe("native-ok");
+    },
+  );
+
   it("rejects node command strings that include inline entrypoint arguments on Windows", () => {
     expect(() =>
       resolveWindowsSpawnProgram({

--- a/src/plugin-sdk/windows-spawn.ts
+++ b/src/plugin-sdk/windows-spawn.ts
@@ -6,6 +6,7 @@ import {
   normalizeOptionalString,
 } from "../../packages/normalization-core/src/string-coerce.js";
 import { normalizeStringEntries } from "../../packages/normalization-core/src/string-normalization.js";
+import { resolveEnvironmentValue } from "../infra/process-env.js";
 
 /** Final execution strategy chosen for a Windows spawn command. */
 export type WindowsSpawnResolution =
@@ -143,14 +144,15 @@ export function resolveWindowsExecutablePath(command: string, env: NodeJS.Proces
     return command;
   }
 
-  const pathValue = env.PATH ?? env.Path ?? process.env.PATH ?? process.env.Path ?? "";
+  const pathValue =
+    resolveEnvironmentValue(env, "PATH", "win32") ??
+    resolveEnvironmentValue(process.env, "PATH", "win32") ??
+    "";
   const pathEntries = normalizeStringEntries(pathValue.split(";"));
   const hasExtension = path.extname(command).length > 0;
   const pathExtRaw =
-    env.PATHEXT ??
-    env.Pathext ??
-    process.env.PATHEXT ??
-    process.env.Pathext ??
+    resolveEnvironmentValue(env, "PATHEXT", "win32") ??
+    resolveEnvironmentValue(process.env, "PATHEXT", "win32") ??
     ".EXE;.CMD;.BAT;.COM";
   const pathExt = hasExtension
     ? [""]

--- a/src/process/exec-spawn.ts
+++ b/src/process/exec-spawn.ts
@@ -2,45 +2,10 @@ import path from "node:path";
 import process from "node:process";
 import { execa, type Options as ExecaOptions, type ResultPromise } from "execa";
 import { markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
+import { mergeProcessEnv } from "../infra/process-env.js";
 import { resolveSafeChildProcessInvocation } from "./windows-command.js";
 
 export const COMMAND_PROCESS_TREE_KILL_GRACE_MS = 300;
-
-function assignChildEnvValue(params: {
-  env: NodeJS.ProcessEnv;
-  key: string;
-  platform: NodeJS.Platform;
-  value: string | undefined;
-}): void {
-  if (params.platform === "win32") {
-    const normalizedKey = params.key.toLowerCase();
-    for (const existingKey of Object.keys(params.env)) {
-      if (existingKey.toLowerCase() === normalizedKey && existingKey !== params.key) {
-        delete params.env[existingKey];
-      }
-    }
-  }
-  if (params.value === undefined) {
-    delete params.env[params.key];
-    return;
-  }
-  params.env[params.key] = params.value;
-}
-
-function mergeChildEnv(params: {
-  baseEnv: NodeJS.ProcessEnv;
-  env?: NodeJS.ProcessEnv;
-  platform: NodeJS.Platform;
-}): NodeJS.ProcessEnv {
-  const resolvedEnv: NodeJS.ProcessEnv = {};
-  for (const [key, value] of Object.entries(params.baseEnv)) {
-    assignChildEnvValue({ env: resolvedEnv, key, platform: params.platform, value });
-  }
-  for (const [key, value] of Object.entries(params.env ?? {})) {
-    assignChildEnvValue({ env: resolvedEnv, key, platform: params.platform, value });
-  }
-  return resolvedEnv;
-}
 
 export function shouldSpawnWithShell(params: {
   resolvedCommand: string;
@@ -116,7 +81,7 @@ export function resolveCommandEnv(params: {
     return false;
   })();
 
-  const resolvedEnv = mergeChildEnv({ baseEnv, env: params.env, platform });
+  const resolvedEnv = mergeProcessEnv([baseEnv, params.env], platform);
   if (shouldSuppressNpmFund) {
     if (resolvedEnv.NPM_CONFIG_FUND == null) {
       resolvedEnv.NPM_CONFIG_FUND = "false";

--- a/src/process/pty-terminal-name.ts
+++ b/src/process/pty-terminal-name.ts
@@ -1,14 +1,12 @@
+import { resolveEnvironmentValue } from "../infra/process-env.js";
+
 const DEFAULT_PTY_TERMINAL_NAME = "xterm-256color";
 
 export function readPtyTerminalName(
   env: NodeJS.ProcessEnv | undefined,
   platform: NodeJS.Platform,
 ): string | undefined {
-  if (!env || platform !== "win32" || env.TERM !== undefined) {
-    return env?.TERM;
-  }
-  const termEntry = Object.entries(env).find(([key]) => key.toLowerCase() === "term");
-  return termEntry?.[1];
+  return resolveEnvironmentValue(env, "TERM", platform);
 }
 
 export function resolvePtyTerminalName(value: string | undefined): string {

--- a/src/process/terminal-pty.test.ts
+++ b/src/process/terminal-pty.test.ts
@@ -59,7 +59,11 @@ describe("terminal PTY teardown", () => {
     const { handle, pty } = await spawnFakePty();
     handle.kill("SIGHUP");
     expect(mocks.signalProcessTree).not.toHaveBeenCalled();
-    expect(pty.kill).toHaveBeenCalledWith("SIGHUP");
+    if (process.platform === "win32") {
+      expect(pty.kill).toHaveBeenCalledWith();
+    } else {
+      expect(pty.kill).toHaveBeenCalledWith("SIGHUP");
+    }
   });
 
   it("tolerates an already-exited process", async () => {
@@ -152,20 +156,32 @@ describe("terminal PTY invocation", () => {
     );
   });
 
-  it.each([".cmd", ".bat"])("wraps Windows %s shims through ComSpec", async (extension) => {
+  it.each([
+    [".cmd", { ComSpec: "C:\\Windows\\System32\\cmd.exe" }, "C:\\Windows\\System32\\cmd.exe"],
+    [".bat", { COMSPEC: "C:\\Windows\\System32\\cmd.exe" }, "C:\\Windows\\System32\\cmd.exe"],
+    [".cmd", { cOmSpEc: "C:\\tools\\custom-cmd.exe" }, "C:\\tools\\custom-cmd.exe"],
+    [
+      ".bat",
+      {
+        ComSpec: "C:\\Windows\\System32\\ambient-cmd.exe",
+        COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+      },
+      "C:\\Windows\\System32\\cmd.exe",
+    ],
+  ])("wraps Windows %s shims through ComSpec", async (extension, env, expectedComSpec) => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     mocks.spawn.mockReturnValueOnce(fakePty());
 
     await spawnTerminalPty({
       file: `C:\\Program Files\\Codex\\codex${extension}`,
       args: ["resume", "thread title"],
-      env: { ComSpec: "C:\\Windows\\System32\\cmd.exe" },
+      env,
       cols: 80,
       rows: 24,
     });
 
     expect(mocks.spawn).toHaveBeenCalledWith(
-      "C:\\Windows\\System32\\cmd.exe",
+      expectedComSpec,
       ["/d", "/s", "/c", `""C:\\Program Files\\Codex\\codex${extension}" resume "thread title""`],
       expect.objectContaining({ cols: 80, rows: 24 }),
     );

--- a/src/process/terminal-pty.ts
+++ b/src/process/terminal-pty.ts
@@ -1,4 +1,5 @@
 import type { IPty } from "@lydell/node-pty";
+import { resolveEnvironmentValue } from "../infra/process-env.js";
 import { signalProcessTree } from "./kill-tree.js";
 import {
   readPtyTerminalName,
@@ -53,7 +54,7 @@ export async function spawnTerminalPty(params: {
   // Passing it through makes interactive CLIs refuse to start in the web terminal.
   const terminalName = resolvePtyTerminalName(readPtyTerminalName(env, process.platform));
   setPtyTerminalName({ env, name: terminalName, platform: process.platform });
-  const comSpec = env.ComSpec ?? env.COMSPEC;
+  const comSpec = resolveEnvironmentValue(env, "COMSPEC");
   const invocation = resolveTerminalPtyInvocation({
     file: params.file,
     args: params.args,

--- a/src/process/windows-command.ts
+++ b/src/process/windows-command.ts
@@ -10,6 +10,7 @@ import {
   resolveExecutableFromPathEnv,
   resolveExecutablePathCandidate,
 } from "../infra/executable-path.js";
+import { resolveEnvironmentValue } from "../infra/process-env.js";
 import { getWindowsCmdExePath } from "../infra/windows-install-roots.js";
 
 const WINDOWS_UNSAFE_CMD_CHARS_RE = /[&|<>%\r\n]/;
@@ -44,11 +45,6 @@ function createWindowsCommandNotFoundError(command: string): NodeJS.ErrnoExcepti
   return error;
 }
 
-function resolveWindowsEnvironmentValue(env: NodeJS.ProcessEnv, name: string): string | undefined {
-  const normalizedName = name.toLowerCase();
-  return Object.entries(env).find(([key]) => key.toLowerCase() === normalizedName)?.[1];
-}
-
 function resolveWindowsCommandFromCwdOrPath(params: {
   command: string;
   cwd?: string;
@@ -77,8 +73,8 @@ function resolveWindowsCommandFromCwdOrPath(params: {
   }
   const cwd = params.cwd?.trim() || process.cwd();
   const pathValue =
-    resolveWindowsEnvironmentValue(params.env, "PATH") ??
-    resolveWindowsEnvironmentValue(process.env, "PATH") ??
+    resolveEnvironmentValue(params.env, "PATH") ??
+    resolveEnvironmentValue(process.env, "PATH") ??
     "";
   const pathEntries = pathValue
     .split(";")


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows child processes could ignore a configured environment override when its key used different casing from an inherited key. This affected command discovery, MCP stdio servers, and local or node-host catalog terminals; for example, configured `COMSPEC` could lose to inherited `ComSpec` and launch the wrong command processor.

## Why This Change Was Made

Windows environment names are case-insensitive, but JavaScript object merges are not. This change adds one internal environment lookup/merge owner that matches Node's Windows behavior: keys are compared case-insensitively, the lexicographically first duplicate in one source is retained, and later sources own overrides. Existing command, MCP, exec, identity, and PTY paths now use that owner instead of separate aliases or raw object assignment.

The current-main catalog-terminal feature has both local-gateway and paired-node execution paths, so both are normalized before `@lydell/node-pty`; terminal invocation also reads `COMSPEC` and `TERM` with the same semantics. There is no config, protocol, persistence, SDK-export, or dependency change.

Production LOC: `+97/-98` (net `-1`). Test LOC: `+279/-9` (net `+270`).

## User Impact

On Windows, explicit child-process environment settings now reliably override inherited values regardless of key casing. Catalog resume terminals use their configured command processor, PATH, and `CODEX_HOME`; MCP servers and other spawned tools receive the configured environment instead of a casing-dependent inherited value.

## Evidence

Exact reviewed head: `d394e43330f44f87ccdc0bca4cd5cf6a9072be96` (parent `56e00e078c1629bba163268674e32ca3f3c4f81f`). Fresh `origin/main` was `970a82624aa4b03318bd039ead74b810d5e73bd4`; none of the 18 changed paths changed since the parent, and three-way overlap was clean, so the reviewed head was not rebased merely for unrelated drift.

Native Windows before/after proof:

- Node-host catalog `.cmd`: current-main raw `Object.assign` failed `1/4`; configured `COMSPEC` lost to inherited `ComSpec`, and both keys reached PTY spawn. Fixed path passed `4/4` and forwarded one configured key.
- Local-gateway catalog: current-main raw `Object.assign` retained both `ComSpec` and `COMSPEC`; the configured-only assertion failed. Fixed full handler suite passed `24/24`.
- Terminal invocation: arbitrary-cased and duplicate `COMSPEC` cases passed; full file `16/16`.
- Real MCP stdio child captured configured lowercase `temp` over inherited uppercase `TEMP`: `12/12` MCP tests passed.
- Additional focused proof: process-env `7/7`; Windows spawn `7/7`; exec environment contracts `4/4`; CLI identity mixed-case PATH `2/2`; executable-path `19/19` with one platform skip; windows-command `11/11`; Codex session catalog `99/99`.
- Formatting for all 18 paths and `git diff --check` passed.

Dependency/source contracts checked:

- Installed Node `v24.18.0` `child_process` source sorts Windows environment keys, filters case-insensitive duplicates, retains the lexicographically first key, and omits `undefined` values.
- Installed `@lydell/node-pty` `1.2.0-beta.14` types accept the environment map; its Windows implementation copies object keys and serializes every entry without case-folding, so OpenClaw must normalize before the dependency boundary.
- Installed MCP SDK `1.30.0` inherits uppercase Windows variables and otherwise object-merges configured env, reproducing the `TEMP`/`temp` collision.
- The required sibling Codex source gate was checked at `2e3a1702c2e7adea5f2ae9ea2799c625024b4fda`: `codex-rs/utils/home-dir/src/lib.rs` owns `CODEX_HOME`, and `codex-rs/cli/src/main.rs` routes `resume` into the interactive TUI. OpenClaw's Codex catalog supplies `CODEX_HOME` through this changed terminal path.

Reviews:

- Initial exact-diff WSL autoreview: TruffleHog clean. One proposed P1 was rejected after verification: the private Windows command resolver is reachable only after the live `process.platform === "win32"` gate, while cross-host tests mock that same getter; the existing lowercase `path`/`pathext` test passes.
- Hosted `check-lint` then found five mechanical candidate lint errors. The corrected exact head uses non-mutating `toSorted()`, required braces, and two scoped suppressions because MCP `Transport` exposes `onclose`/`onerror` callback properties and is not an `EventTarget`.
- Corrected exact-head WSL autoreview: archive hash verified, TruffleHog clean, no findings (`patch is correct`, confidence `0.87`).
- Independent corrected exact-commit review: clean, no P0/P1 findings; reviewed tree and all 18 final blobs remained stable.

Local heavy-gate disclosure:

- `check-changed` delegated as required but no Crabbox/Testbox provider was ready in this environment.
- Targeted `scripts/run-oxlint.mjs` stopped before linting on an unrelated current-main plugin-SDK boundary error in `packages/terminal-core/src/ansi.ts` (`TS2554`). Exact-head hosted CI remains the authoritative static gate.
- Broader native runs also exposed pre-existing unrelated Windows-only assertions in `src/gateway/terminal/launch.test.ts` and two UTF-8 truncation cases in `src/process/exec.test.ts`; changed-surface focused proofs above are green.

Live duplicate audit found no exact PR. #111716 has a different blank-alias policy and does not cover merging, MCP, or PTY; #119235 overlaps one exec call for a separate `AI_AGENT` feature.

Discovered and verified through the Windows Auto-QA campaign.
