### PR TITLE
fix(browser): reclaim stalled extension relay connections

### DIFF
--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -87,6 +87,131 @@ const flush = () =>
   });
 
 describe("ExtensionRelayBridge", () => {
+  it("retires an unresponsive extension and immediately fails pending CDP work", async () => {
+    vi.useFakeTimers();
+    const onStateChange = vi.fn();
+    const bridge = new ExtensionRelayBridge({ onStateChange });
+    try {
+      const { socket, handlers } = wireExtension(bridge);
+      sendHello(handlers);
+
+      const client = new FakeSocket();
+      const cdp = bridge.attachCdpClientSocket(client);
+      cdp.onMessage(
+        JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      const attached = client.frames().find((frame) => frame.method === "Target.attachedToTarget");
+      const sessionId = (attached?.params as { sessionId?: string } | undefined)?.sessionId;
+      expect(typeof sessionId).toBe("string");
+
+      socket.send = (data) => FakeSocket.prototype.send.call(socket, data);
+      await vi.advanceTimersByTimeAsync(50_000);
+      expect(socket.frames().filter((frame) => frame.type === "ping")).toHaveLength(2);
+
+      cdp.onMessage(JSON.stringify({ id: 2, sessionId, method: "Page.getFrameTree" }));
+      expect(socket.frames().at(-1)).toMatchObject({ type: "cdp", method: "Page.getFrameTree" });
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(bridge.extensionConnected).toBe(true);
+      expect(client.frames().find((frame) => frame.id === 2)).toBeUndefined();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(socket).toMatchObject({
+        closed: true,
+        closeCode: 4000,
+        closeReason: "extension heartbeat timeout",
+      });
+      expect(bridge.extensionConnected).toBe(false);
+      expect(client.frames().find((frame) => frame.id === 2)).toMatchObject({
+        error: { message: "extension disconnected" },
+      });
+      expect(onStateChange).toHaveBeenCalledTimes(2);
+
+      handlers.onClose();
+      expect(onStateChange).toHaveBeenCalledTimes(2);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      bridge.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps an extension alive when each heartbeat receives an immediate pong", async () => {
+    vi.useFakeTimers();
+    const bridge = new ExtensionRelayBridge();
+    try {
+      const { socket, handlers } = wireExtension(bridge);
+      const send = socket.send.bind(socket);
+      socket.send = (data) => {
+        send(data);
+        if ((JSON.parse(data) as { type: string }).type === "ping") {
+          handlers.onMessage(JSON.stringify({ type: "pong" }));
+        }
+      };
+      sendHello(handlers);
+
+      await vi.advanceTimersByTimeAsync(120_000);
+
+      expect(socket.frames().filter((frame) => frame.type === "ping")).toHaveLength(6);
+      expect(socket.closed).toBe(false);
+      expect(bridge.extensionConnected).toBe(true);
+    } finally {
+      bridge.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("gives a replacement extension its own heartbeat budget and ignores stale owners", async () => {
+    vi.useFakeTimers();
+    const bridge = new ExtensionRelayBridge();
+    try {
+      const previous = wireExtension(bridge);
+      sendHello(previous.handlers);
+      await vi.advanceTimersByTimeAsync(40_000);
+
+      const replacement = wireExtension(bridge);
+      sendHello(replacement.handlers);
+      expect(previous.socket.closed).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(40_000);
+      previous.handlers.onMessage(JSON.stringify({ type: "pong" }));
+      previous.handlers.onClose();
+      await vi.advanceTimersByTimeAsync(19_999);
+      expect(replacement.socket.closed).toBe(false);
+      expect(bridge.extensionConnected).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(replacement.socket).toMatchObject({
+        closed: true,
+        closeCode: 4000,
+        closeReason: "extension heartbeat timeout",
+      });
+      expect(bridge.extensionConnected).toBe(false);
+    } finally {
+      bridge.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears the extension heartbeat when its bridge is disposed", async () => {
+    vi.useFakeTimers();
+    const bridge = new ExtensionRelayBridge();
+    try {
+      const { socket, handlers } = wireExtension(bridge);
+      sendHello(handlers);
+      expect(vi.getTimerCount()).toBe(1);
+
+      bridge.dispose();
+
+      expect(vi.getTimerCount()).toBe(0);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(socket.frames().filter((frame) => frame.type === "ping")).toHaveLength(0);
+    } finally {
+      bridge.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it("reports the paired browser identity through Browser.getVersion", async () => {
     const bridge = new ExtensionRelayBridge();
     const { handlers } = wireExtension(bridge);

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -113,6 +113,7 @@ export class ExtensionRelayBridge {
   private nextExtensionCandidateOrdinal = 1;
   private latestPromotedCandidateOrdinal = 0;
   private pingTimer: NodeJS.Timeout | null = null;
+  private missedPongs = 0;
   private readonly onStateChange?: () => void;
   private readonly onPageShare?: (payload: PageSharePayload) => Promise<void>;
 
@@ -283,6 +284,8 @@ export class ExtensionRelayBridge {
         break;
       }
       case "pong":
+        this.missedPongs = 0;
+        break;
       case "hello":
         break;
     }
@@ -357,13 +360,27 @@ export class ExtensionRelayBridge {
 
   private startPing(): void {
     this.stopPing();
+    const owner = this.extension;
     this.pingTimer = setInterval(() => {
+      if (!owner || this.extension !== owner) {
+        return;
+      }
+      // An OPEN socket can outlive a dead worker; only its pong proves commands still arrive.
+      if (++this.missedPongs > 2) {
+        owner.socket.close(4000, "extension heartbeat timeout");
+        if (this.extension === owner) {
+          this.handleExtensionGone();
+          this.onStateChange?.();
+        }
+        return;
+      }
       this.sendToExtension({ type: "ping" });
     }, EXTENSION_PING_INTERVAL_MS);
     this.pingTimer.unref?.();
   }
 
   private stopPing(): void {
+    this.missedPongs = 0;
     if (this.pingTimer) {
       clearInterval(this.pingTimer);
       this.pingTimer = null;

--- a/extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts
@@ -576,6 +576,163 @@ describe.sequential("extension relay HTTP auth v2", () => {
     socket.close();
   });
 
+  it("retires an authenticated silent extension and immediately fails its pending CDP request", async () => {
+    const onStateChange = vi.fn();
+    handle = await startExtensionRelayServer({
+      port: 0,
+      token: KEY,
+      allowLegacyAuth: false,
+      onStateChange,
+    });
+    const extension = await authenticateV2Extension(handle);
+    let client: WebSocket | undefined;
+    let versionConnection: RawHttpConnection | undefined;
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    try {
+      extension.send(
+        JSON.stringify({
+          type: "hello",
+          userAgent: "test",
+          browserVersion: "Chrome/test",
+          extensionVersion: "2",
+          tabs: [{ tabId: 1, url: "https://example.test", title: "one", active: true }],
+        }),
+      );
+      await vi.waitFor(() => expect(handle?.bridge.extensionConnected).toBe(true));
+
+      const credential = Buffer.from(`openclaw-internal:${handle.internalToken}`).toString(
+        "base64",
+      );
+      client = new WebSocket(`ws://127.0.0.1:${handle.port}/cdp`, {
+        headers: { Authorization: `Basic ${credential}` },
+      });
+      client.on("error", () => {});
+      await once(client, "open");
+      const clientFrames: Array<Record<string, unknown>> = [];
+      client.on("message", (raw: RawData) => {
+        clientFrames.push(JSON.parse(rawDataText(raw)) as Record<string, unknown>);
+      });
+
+      const attachment = once(extension, "message");
+      client.send(
+        JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
+      );
+      const [attachmentData] = (await attachment) as [RawData];
+      const attachCommand = JSON.parse(rawDataText(attachmentData)) as {
+        type: string;
+        seq: number;
+      };
+      expect(attachCommand.type).toBe("attach");
+      extension.send(
+        JSON.stringify({
+          type: "result",
+          seq: attachCommand.seq,
+          result: { targetId: "target-1" },
+        }),
+      );
+      await vi.waitFor(() =>
+        expect(clientFrames.some((frame) => frame.method === "Target.attachedToTarget")).toBe(true),
+      );
+      const attached = clientFrames.find((frame) => frame.method === "Target.attachedToTarget");
+      const sessionId = (attached?.params as { sessionId?: string } | undefined)?.sessionId;
+      expect(typeof sessionId).toBe("string");
+
+      for (let index = 0; index < 2; index += 1) {
+        const ping = once(extension, "message");
+        await vi.advanceTimersByTimeAsync(20_000);
+        const [pingData] = (await ping) as [RawData];
+        expect(JSON.parse(rawDataText(pingData))).toEqual({ type: "ping" });
+      }
+      expect(extension.readyState).toBe(WebSocket.OPEN);
+
+      const pending = once(extension, "message");
+      client.send(JSON.stringify({ id: 2, sessionId, method: "Page.getFrameTree" }));
+      const [pendingData] = (await pending) as [RawData];
+      expect(JSON.parse(rawDataText(pendingData))).toMatchObject({
+        type: "cdp",
+        method: "Page.getFrameTree",
+      });
+
+      versionConnection = await RawHttpConnection.connect(handle.port);
+      expect(
+        (
+          await versionConnection.request("GET", "/json/version", "", {
+            Authorization: `Basic ${credential}`,
+          })
+        ).status,
+      ).toBe(200);
+
+      const closed = once(extension, "close");
+      await vi.advanceTimersByTimeAsync(20_000);
+      expect(handle.bridge.extensionConnected).toBe(false);
+      await vi.waitFor(() =>
+        expect(clientFrames.find((frame) => frame.id === 2)).toMatchObject({
+          error: { message: "extension disconnected" },
+        }),
+      );
+      const [code, reason] = (await closed) as [number, Buffer];
+      expect(code).toBe(4000);
+      expect(reason.toString()).toBe("extension heartbeat timeout");
+      expect(onStateChange).toHaveBeenCalledTimes(2);
+
+      expect(
+        (
+          await versionConnection.request("GET", "/json/version", "", {
+            Authorization: `Basic ${credential}`,
+          })
+        ).status,
+      ).toBe(503);
+    } finally {
+      versionConnection?.close();
+      client?.terminate();
+      extension.terminate();
+      await handle?.close();
+      handle = null;
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps an authenticated extension connected while its real socket answers heartbeat pings", async () => {
+    handle = await startExtensionRelayServer({ port: 0, token: KEY, allowLegacyAuth: false });
+    const extension = await authenticateV2Extension(handle);
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    try {
+      extension.send(
+        JSON.stringify({
+          type: "hello",
+          userAgent: "test",
+          browserVersion: "Chrome/test",
+          extensionVersion: "2",
+          tabs: [{ tabId: 1, url: "https://example.test", title: "initial", active: true }],
+        }),
+      );
+      await vi.waitFor(() => expect(handle?.bridge.extensionConnected).toBe(true));
+
+      for (let index = 0; index < 4; index += 1) {
+        const ping = once(extension, "message");
+        await vi.advanceTimersByTimeAsync(20_000);
+        const [pingData] = (await ping) as [RawData];
+        expect(JSON.parse(rawDataText(pingData))).toEqual({ type: "ping" });
+        extension.send(JSON.stringify({ type: "pong" }));
+        extension.send(
+          JSON.stringify({
+            type: "tabs",
+            tabs: [{ tabId: 1, url: "https://example.test", title: `beat-${index}`, active: true }],
+          }),
+        );
+        await vi.waitFor(() => expect(handle?.bridge.sharedTabs()[0]?.title).toBe(`beat-${index}`));
+      }
+
+      expect(extension.readyState).toBe(WebSocket.OPEN);
+      expect(handle.bridge.extensionConnected).toBe(true);
+    } finally {
+      extension.terminate();
+      await handle?.close();
+      handle = null;
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps an active extension while pending admission is full and recovers after release", async () => {
     handle = await startExtensionRelayServer({ port: 0, token: KEY, allowLegacyAuth: true });
     const active = await openExtensionSocket(handle, [


### PR DESCRIPTION
## Summary

An authenticated browser extension relay could remain falsely connected after its WebSocket stopped responding. The existing heartbeat still sent application pings, but the owner never recorded the already-supported pong response, leaving readiness endpoints healthy and read-only browser requests pending indefinitely.

Track the existing application pong on the currently active authenticated connection and reclaim that connection after three unanswered existing heartbeat probes. Reuse the current 20-second timer and normal owner cleanup; healthy connections, replacement sockets, disposal, and pending command rejection retain their existing boundaries.

The 17-line production increase represents explicit, identity-fenced connection lifecycle ownership. No authentication, wire format, configuration, browser permissions, or additional timers are introduced.

## Verification

- Tests-only proof reproduced a genuinely authenticated localhost relay, separately authenticated CDP connection, pending read-only command, and falsely healthy HTTP readiness response after the third unanswered heartbeat.
- The exact final relay-owner and authenticated-server suites pass all 46 tests; adjacent browser lifecycle coverage passes all 146 tests.
- The complete remote changed gate passes formatting, production/test typechecks, zero-warning lint, and all plugin, authentication-boundary, and runtime guards.
- Independent review confirmed all shipped extension clients already respond to the existing application ping; fresh structured review found no actionable issues.
