### PR TITLE
fix(google-meet): redial after completed voice calls

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -316,7 +316,10 @@ const voiceCallMocks = vi.hoisted(() => ({
   })),
   endMeetVoiceCallGatewayCall: vi.fn(async () => {}),
   getMeetVoiceCallGatewayCall: vi.fn(
-    async (): Promise<{ found: boolean; call?: { callId: string } }> => ({
+    async (): Promise<{
+      found: boolean;
+      call?: { callId: string; state?: string; endedAt?: number; endReason?: string };
+    }> => ({
       found: true,
       call: { callId: "call-1" },
     }),
@@ -2288,6 +2291,88 @@ describe("google-meet plugin", () => {
     expect(first.details.session.notes).toContain("Voice Call is no longer active.");
     expect(second.details.session.id).not.toBe(first.details.session.id);
     expect(voiceCallMocks.joinMeetViaVoiceCallGateway).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    {
+      name: "the authoritative end timestamp",
+      call: { callId: "call-1", state: "completed", endedAt: 1_780_000_000_000 },
+    },
+    {
+      name: "the authoritative end reason",
+      call: { callId: "call-1", state: "completed", endReason: "completed" },
+    },
+  ])("redials a persisted completed Twilio call identified by $name", async ({ call }) => {
+    voiceCallMocks.getMeetVoiceCallGatewayCall.mockResolvedValueOnce({ found: true, call });
+    const { tools } = setup({ defaultTransport: "twilio" });
+    const tool = getMeetTool({ tools });
+    const request = {
+      action: "join" as const,
+      url: MEET_URL,
+      dialInNumber: "+15551234567",
+      pin: "123456",
+    };
+
+    const first = await tool.execute("first", request);
+    const second = await tool.execute("second", request);
+
+    expect(voiceCallMocks.joinMeetViaVoiceCallGateway).toHaveBeenCalledTimes(2);
+    expect(first.details.session.state).toBe("ended");
+    expect(first.details.session.notes).toContain("Voice Call is no longer active.");
+    expect(second.details.session.id).not.toBe(first.details.session.id);
+  });
+
+  it.each([
+    {
+      name: "an active delegated call",
+      result: { found: true, call: { callId: "call-1", state: "active" } },
+    },
+    {
+      name: "a terminal-looking state without an authoritative terminal fact",
+      result: { found: true, call: { callId: "call-1", state: "completed" } },
+    },
+    {
+      name: "an unknown call record",
+      result: { found: true },
+    },
+  ])("reuses the active Meet session for $name", async ({ result }) => {
+    voiceCallMocks.getMeetVoiceCallGatewayCall.mockResolvedValueOnce(result);
+    const { tools } = setup({ defaultTransport: "twilio" });
+    const tool = getMeetTool({ tools });
+    const request = {
+      action: "join" as const,
+      url: MEET_URL,
+      dialInNumber: "+15551234567",
+      pin: "123456",
+    };
+
+    const first = await tool.execute("first", request);
+    const second = await tool.execute("second", request);
+
+    expect(second.details.session.id).toBe(first.details.session.id);
+    expect(first.details.session.state).toBe("active");
+    expect(voiceCallMocks.joinMeetViaVoiceCallGateway).toHaveBeenCalledOnce();
+  });
+
+  it("reuses the active Meet session when delegated call status temporarily rejects", async () => {
+    voiceCallMocks.getMeetVoiceCallGatewayCall.mockRejectedValueOnce(
+      new Error("temporary voice gateway failure"),
+    );
+    const { tools } = setup({ defaultTransport: "twilio" });
+    const tool = getMeetTool({ tools });
+    const request = {
+      action: "join" as const,
+      url: MEET_URL,
+      dialInNumber: "+15551234567",
+      pin: "123456",
+    };
+
+    const first = await tool.execute("first", request);
+    const second = await tool.execute("second", request);
+
+    expect(second.details.session.id).toBe(first.details.session.id);
+    expect(first.details.session.state).toBe("active");
+    expect(voiceCallMocks.joinMeetViaVoiceCallGateway).toHaveBeenCalledOnce();
   });
 
   it("serializes concurrent identical Twilio joins", async () => {

--- a/extensions/google-meet/src/runtime.ts
+++ b/extensions/google-meet/src/runtime.ts
@@ -12,7 +12,10 @@ import {
 } from "openclaw/plugin-sdk/meeting-runtime";
 import type { PluginRuntime, RuntimeLogger } from "openclaw/plugin-sdk/plugin-runtime";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  asOptionalRecord,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import type {
   GoogleMeetConfig,
   GoogleMeetMode,
@@ -581,7 +584,8 @@ export class GoogleMeetRuntime {
         gateway: this.#voiceCallGateway,
         callId,
       });
-      if (status.found === false) {
+      const call = asOptionalRecord(status.call);
+      if (status.found === false || call?.endedAt !== undefined || call?.endReason !== undefined) {
         this.#sessions.markSessionEnded(session, "Voice Call is no longer active.");
       }
     } catch (error) {


### PR DESCRIPTION
## Summary

The meeting plugin treated every found voice-call record as an active call, even when the persisted call had already completed. A second attempt to join the meeting could therefore reuse a dead call instead of dialing again.

Recognize the existing authoritative call completion facts in the plugin-owned session refresh and reuse the existing ended-session/rejoin path. Active calls, unknown status, rejected lookups, missing calls, and concurrently serialized joins retain their current behavior.

The change adds four production lines for the plugin's terminal-call ownership boundary. It changes no provider persistence, authentication, configuration, public protocol, or concurrency policy.

## Verification

- Tests-only actual public meeting-tool execution against an in-memory fake voice provider reproduced both completed-call variants; 166 existing controls passed.
- The final public meeting-tool suite passes all 168 tests; the actual voice-call status producer and meeting gateway suites bring total focused coverage to 222 tests.
- The complete remote changed gate passes formatting, production/test typechecks, zero-warning lint, and all plugin, ownership, and runtime guards.
- Independent direct producer-contract review, exact immutable source review, and fresh structured review found no actionable issues.

No real calls or external provider requests were made.
