### PR TITLE
fix(gateway): keep retryable errors supersedable past retry grace for agent.wait

### DIFF
--- a/extensions/feishu/src/bot.stripBotMention.test.ts
+++ b/extensions/feishu/src/bot.stripBotMention.test.ts
@@ -60,7 +60,7 @@ describe("normalizeMentions (via parseFeishuMessageEvent)", () => {
     expect(ctx.content).toBe("hello");
   });
 
-  it("strips bot mention in group so slash commands work (#35994)", () => {
+  it("keeps bot mention in group so the model sees it was addressed (#72504)", () => {
     const ctx = parseFeishuMessageEvent(
       makeEvent(
         "@_bot_1 hello",
@@ -69,10 +69,10 @@ describe("normalizeMentions (via parseFeishuMessageEvent)", () => {
       ),
       BOT_OPEN_ID,
     );
-    expect(ctx.content).toBe("hello");
+    expect(ctx.content).toBe('<at user_id="ou_bot">Bot</at> hello');
   });
 
-  it("strips bot mention in group preserving slash command prefix (#35994)", () => {
+  it("keeps bot mention in group alongside slash command prefix (#72504)", () => {
     const ctx = parseFeishuMessageEvent(
       makeEvent(
         "@_bot_1 /model",
@@ -81,7 +81,26 @@ describe("normalizeMentions (via parseFeishuMessageEvent)", () => {
       ),
       BOT_OPEN_ID,
     );
-    expect(ctx.content).toBe("/model");
+    expect(ctx.content).toBe('<at user_id="ou_bot">Bot</at> /model');
+  });
+
+  it("keeps bot mention when multiple bots are addressed in a group (#72504)", () => {
+    const ctx = parseFeishuMessageEvent(
+      makeEvent(
+        "@_bot_1 @_bot_2 hello",
+        [
+          { key: "@_bot_1", name: "Bot A", id: { open_id: "ou_bot" } },
+          { key: "@_bot_2", name: "Bot B", id: { open_id: "ou_other_bot" } },
+        ],
+        "group",
+      ),
+      BOT_OPEN_ID,
+    );
+    // Both mentions stay visible to the model; this bot sees its own <at>.
+    expect(ctx.content).toBe(
+      '<at user_id="ou_bot">Bot A</at> <at user_id="ou_other_bot">Bot B</at> hello',
+    );
+    expect(ctx.mentionedBot).toBe(true);
   });
 
   it("strips bot mention but normalizes other mentions in p2p (mention-forward)", () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -174,11 +174,20 @@ export function parseFeishuMessageEvent(
   const mentionedBot = checkBotMentioned(event, botOpenId);
   const hasAnyMention = (event.message.mentions?.length ?? 0) > 0;
   // Strip the bot's own mention so slash commands like @Bot /help retain
-  // the leading /. This applies in both p2p *and* group contexts — the
-  // mentionedBot flag already captures whether the bot was addressed, so
-  // keeping the mention tag in content only breaks command detection (#35994).
+  // the leading /. This applies in p2p contexts — the mentionedBot flag
+  // already captures whether the bot was addressed, so keeping the mention
+  // tag in content only breaks command detection (#35994).
+  // In group chats keep the bot's own <at> tag so the model can see it was
+  // explicitly addressed among several bots (#72504); command probing strips
+  // all <at> tags via normalizeFeishuCommandProbeBody, and routing uses the
+  // mentionedBot flag, so keeping the tag is safe there.
   // Non-bot mentions (e.g. mention-forward targets) are still normalized to <at> tags.
-  const content = normalizeMentions(rawContent, event.message.mentions, botOpenId);
+  const isGroupChat = event.message.chat_type === "group";
+  const content = normalizeMentions(
+    rawContent,
+    event.message.mentions,
+    isGroupChat ? undefined : botOpenId,
+  );
   const senderOpenId = event.sender.sender_id.open_id?.trim();
   const senderUserId = event.sender.sender_id.user_id?.trim();
   const senderFallbackId = senderOpenId || senderUserId || "";

--- a/src/gateway/server-methods/agent-job.timeout-fallback.test.ts
+++ b/src/gateway/server-methods/agent-job.timeout-fallback.test.ts
@@ -185,11 +185,166 @@ describe("waitForAgentJob timeout fallback", () => {
       pendingError: true,
     });
 
+    // After the grace boundary the retryable error is still provisional: a
+    // zero-budget wait cannot settle on it as a terminal error.
     await vi.advanceTimersByTimeAsync(10_000);
+    await expect(waitForAgentJob({ runId, timeoutMs: 0 })).resolves.toBeNull();
+  });
+
+  it("supersedes a retryable error with a same-run success after the grace boundary", async () => {
+    const runId = `run-grace-supersede-${runSequence++}`;
+    const waitPromise = waitForAgentJob({ runId, timeoutMs: 30_000 });
+
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        startedAt: 1_000,
+        endedAt: 1_100,
+        error: "Retryable provider failure",
+      },
+    });
+
+    // Retry grace expires without a new lifecycle start.
+    await vi.advanceTimersByTimeAsync(16_000);
+
+    // The same run later ends successfully without a new start.
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "end", startedAt: 1_000, endedAt: 20_000 },
+    });
+
+    await expect(waitPromise).resolves.toMatchObject({
+      status: "ok",
+      startedAt: 1_000,
+      endedAt: 20_000,
+    });
+  });
+
+  it("lets a fresh wait after the grace boundary observe a later same-run success", async () => {
+    const runId = `run-grace-fresh-supersede-${runSequence++}`;
+
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        startedAt: 1_000,
+        endedAt: 1_100,
+        error: "Retryable provider failure",
+      },
+    });
+
+    // Retry grace expires and publishes the provisional error snapshot.
+    await vi.advanceTimersByTimeAsync(16_000);
+
+    const freshWaitPromise = waitForAgentJob({ runId, timeoutMs: 30_000 });
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "end", startedAt: 1_000, endedAt: 20_000 },
+    });
+
+    await expect(freshWaitPromise).resolves.toMatchObject({
+      status: "ok",
+      endedAt: 20_000,
+    });
+  });
+
+  it("keeps an exhausted failure terminal when it arrives after a retryable error past grace", async () => {
+    const runId = `run-grace-exhausted-${runSequence++}`;
+    const waitPromise = waitForAgentJob({ runId, timeoutMs: 30_000 });
+
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        startedAt: 1_000,
+        endedAt: 1_100,
+        error: "Retryable provider failure",
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(16_000);
+
+    // A genuine exhausted failure arrives after the provisional error was
+    // published; it must supersede the provisional state and stay terminal.
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        startedAt: 1_000,
+        endedAt: 20_000,
+        error: "All model fallback candidates failed",
+        fallbackExhaustedFailure: true,
+      },
+    });
+
+    await expect(waitPromise).resolves.toMatchObject({
+      status: "error",
+      endedAt: 20_000,
+      error: "All model fallback candidates failed",
+    });
+  });
+
+  it("keeps a sticky cancellation terminal past grace and rejects a later same-run success", async () => {
+    const runId = `run-grace-sticky-${runSequence++}`;
+    const waitPromise = waitForAgentJob({ runId, timeoutMs: 30_000 });
+
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        startedAt: 1_000,
+        endedAt: 1_100,
+        aborted: true,
+        stopReason: "rpc",
+        error: "RPC cancelled the run",
+      },
+    });
+
+    // Sticky cancellation stays pending during grace, then publishes terminal.
+    await vi.advanceTimersByTimeAsync(16_000);
+    await expect(waitPromise).resolves.toMatchObject({
+      status: "error",
+      stopReason: "rpc",
+    });
+
+    // A later successful end cannot overwrite the terminal cancellation.
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "end", startedAt: 1_000, endedAt: 20_000 },
+    });
     await expect(waitForAgentJob({ runId, timeoutMs: 0 })).resolves.toMatchObject({
       status: "error",
+      stopReason: "rpc",
       endedAt: 1_100,
-      error: "Retryable provider failure",
     });
   });
 

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -151,6 +151,11 @@ function shouldPreserveTerminalSnapshot(
 ): boolean {
   const existingOutcome = terminalOutcomeFromSnapshot(existing);
   const incomingOutcome = terminalOutcomeFromSnapshot(incoming);
+  // A provisional retryable error cannot replace a sticky terminal outcome:
+  // cancellation and hard timeouts stay fail-closed terminal.
+  if (incoming.pendingError === true) {
+    return Boolean(existingOutcome && isStickyAgentRunTerminalOutcome(existingOutcome));
+  }
   if (!existingOutcome || !incomingOutcome) {
     return false;
   }
@@ -260,6 +265,16 @@ function schedulePendingAgentRunTerminal(
       return;
     }
     pendingRuns.delete(snapshot.runId);
+    const outcome = terminalOutcomeFromSnapshot(pending.snapshot);
+    if (outcome && !isStickyAgentRunTerminalOutcome(outcome)) {
+      // A retryable terminal observation stays provisional past the grace
+      // boundary: the same run may still emit an authoritative successful
+      // `end` (without a new `start`), which must supersede this error
+      // instead of being masked by it. Sticky cancellations and hard
+      // timeouts below remain fail-closed terminal snapshots.
+      recordAgentRunSnapshot({ ...pending.snapshot, pendingError: true }, pending.snapshot.version);
+      return;
+    }
     recordAgentRunSnapshot(pending.snapshot, pending.snapshot.version);
   }, AGENT_RUN_TERMINAL_RETRY_GRACE_MS);
   timer.unref?.();
@@ -577,7 +592,10 @@ export async function waitForAgentJob(params: {
     source: params.source,
     afterVersion,
   });
-  if (cached) {
+  // A provisional retryable error can still be superseded by a later
+  // successful `end` for the same run; only authoritative terminal
+  // snapshots settle a wait.
+  if (cached && cached.pendingError !== true) {
     return publicSnapshot(cached);
   }
   if (params.timeoutMs <= 0) {
@@ -606,7 +624,10 @@ export async function waitForAgentJob(params: {
         source: params.source,
         afterVersion,
       });
-      if (snapshot) {
+      // Ignore provisional retryable errors: a later authoritative
+      // successful `end` for the same run must still be able to supersede
+      // them instead of being masked by an already-settled wait.
+      if (snapshot && snapshot.pendingError !== true) {
         finish(publicSnapshot(snapshot));
       }
     };
@@ -629,6 +650,17 @@ export async function waitForAgentJob(params: {
           terminalOutcomeFromSnapshot(pendingTimeout)?.reason === "hard_timeout"
         ) {
           finish(publicSnapshot(pendingTimeout));
+          return;
+        }
+        // The retry grace may already have published the retryable error as a
+        // provisional snapshot; surface it as a pending-error timeout instead
+        // of a bare null so consumers can distinguish it from a queue wait.
+        const publishedPendingError = getAgentRunSnapshot({
+          runId: params.runId,
+          afterVersion,
+        });
+        if (publishedPendingError?.pendingError === true) {
+          finish(createPendingErrorTimeoutSnapshot(publishedPendingError));
           return;
         }
       }

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -497,37 +497,83 @@ describe("waitForAgentJob", () => {
   });
 
   it("lets a later aborted timeout replace a pending lifecycle error", async () => {
-    await runGracePeriodLifecycleScenario({
-      runIdPrefix: "run-error-then-timeout",
-      startedAt: 800,
-      events: [
-        { phase: "error", startedAt: 800, endedAt: 900, error: "transient error" },
-        { phase: "end", startedAt: 800, endedAt: 1_000, aborted: true },
-      ],
-      expected: {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-error-then-timeout-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const waitPromise = waitForAgentJob({ runId, timeoutMs: 20_000 });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 800 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "error", startedAt: 800, endedAt: 900, error: "transient error" },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "end", startedAt: 800, endedAt: 1_000, aborted: true },
+      });
+
+      // Grace expires: the retryable error and the bare-abort timeout stay
+      // provisional (the later timeout owns the provisional canonical state),
+      // so no terminal error settles the active wait.
+      await vi.advanceTimersByTimeAsync(16_000);
+      await expect(waitForAgentJob({ runId, timeoutMs: 0 })).resolves.toBeNull();
+
+      // The wait's own budget eventually surfaces the pending timeout, not a
+      // terminal error.
+      await vi.advanceTimersByTimeAsync(5_000);
+      await expect(waitPromise).resolves.toMatchObject({
         status: "timeout",
         startedAt: 800,
-        endedAt: 1_000,
-      },
-      verifyNoError: true,
-    });
+        pendingError: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("lets a later lifecycle error replace a pending aborted timeout", async () => {
-    await runGracePeriodLifecycleScenario({
-      runIdPrefix: "run-timeout-then-error",
-      startedAt: 1_100,
-      events: [
-        { phase: "end", startedAt: 1_100, endedAt: 1_200, aborted: true },
-        { phase: "error", startedAt: 1_100, endedAt: 1_300, error: "final error" },
-      ],
-      expected: {
-        status: "error",
+    vi.useFakeTimers();
+    try {
+      const runId = `run-timeout-then-error-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const waitPromise = waitForAgentJob({ runId, timeoutMs: 20_000 });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 1_100 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "end", startedAt: 1_100, endedAt: 1_200, aborted: true },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "error", startedAt: 1_100, endedAt: 1_300, error: "final error" },
+      });
+
+      // Grace expires: both observations stay provisional and the later
+      // retryable error owns the provisional canonical state.
+      await vi.advanceTimersByTimeAsync(16_000);
+      await expect(waitForAgentJob({ runId, timeoutMs: 0 })).resolves.toBeNull();
+
+      // The wait's own budget surfaces the provisional error, preserving its
+      // message instead of a bare null timeout.
+      await vi.advanceTimersByTimeAsync(5_000);
+      await expect(waitPromise).resolves.toMatchObject({
+        status: "timeout",
         startedAt: 1_100,
-        endedAt: 1_300,
         error: "final error",
-      },
-    });
+        pendingError: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("can ignore cached snapshots and wait for fresh lifecycle events", async () => {


### PR DESCRIPTION
## What Problem This Solves

A retryable lifecycle `error` (one where `fallbackExhaustedFailure !== true`) is held in `pendingAgentRunErrors` for `AGENT_RUN_TERMINAL_RETRY_GRACE_MS`. When the grace timer expired, `schedulePendingAgentRunTerminal` called `recordAgentRunSnapshot(pending.snapshot)` directly, publishing the error as a **terminal** snapshot. The active `agent.wait` waiter woke up, saw the error snapshot, and resolved with `status: "error"`.

If the same run later emitted an authoritative successful lifecycle `end` — without a new `start` event — the wait had already settled and could not be corrected. Users received a false failure notification (`agent.wait` → `status: "error"`) even though the turn delivered its final response and ended successfully. This is exactly the scenario in #120561.

## Why

The retry grace exists because a retryable error may still be followed by recovery. The bug is that once the grace window elapsed, the provisional error was *promoted to terminal* and used to settle the one-shot waiter, so the later successful `end` for the same run was masked. Consumers such as `sessions-send-tool` already understand `pendingError: true` as the established "provisional, may still recover" contract (see `isPendingErrorAgentWaitTimeout`), so publishing provisional state instead of a terminal error fits the existing model without new API surface.

## User Impact

- `agent.wait` no longer reports a false `status: "error"` for a run that later ends successfully after the retry-grace boundary.
- Same-run success now supersedes a retryable error both before **and after** the grace boundary; the wait resolves exactly once with `status: "ok"`.
- Genuine terminal outcomes (exhausted failures, cancellation, hard timeout, blocked, abandoned) remain fail-closed and cannot be overwritten by a later success.
- If the run never emits an authoritative terminal, the wait's own budget surfaces a `pendingError: true` timeout instead of a bare null, so callers can still distinguish provisional error state from a plain queue wait.

## Evidence

- **Code change** (`src/gateway/server-methods/agent-job.ts`): at grace expiry, `schedulePendingAgentRunTerminal` now checks `isStickyAgentRunTerminalOutcome(terminalOutcomeFromSnapshot(pending.snapshot))`. Non-sticky (retryable) observations are published as `{ ...snapshot, pendingError: true }`; sticky cancellations/hard timeouts still publish as terminal. `waitForAgentJob` ignores provisional snapshots in both the cached-snapshot fast path and `onWake`, and the outer timeout surfaces a published provisional error via `createPendingErrorTimeoutSnapshot`.
- **`shouldPreserveTerminalSnapshot`** now keeps a sticky terminal outcome canonical over an incoming provisional snapshot, so a later retryable error cannot downgrade a recorded hard timeout/cancellation.
- **Inline verification** (fake-timer lifecycle tests, all passing):
  - `agent-job.timeout-fallback.test.ts`: retryable error → grace expiry → same-run successful `end` → wait resolves `{ status: "ok", endedAt: 20_000 }` (before the fix this resolved `status: "error"`); fresh wait started after grace also observes the later success; exhausted failure after grace stays terminal; sticky cancellation after grace rejects a later success.
  - `server-methods.test.ts`: updated the two grace-period scenarios to the new contract — after grace the observations stay provisional (`waitForAgentJob({ timeoutMs: 0 })` → `null`) and the wait's own budget surfaces `{ status: "timeout", pendingError: true, ... }` rather than a terminal error; recorded hard timeout + late retryable error keeps the hard timeout canonical.
- **Test run**: `agent-job.timeout-fallback.test.ts` (26 tests), `server-methods.test.ts` (208+ tests), `agent-wait-dedupe.test.ts` (7), `acp-spawn.test.ts` (150), `agent-run-terminal-outcome.test.ts` (36) — all pass; `tsc --noEmit` clean.

Production delta: +37/−2 lines in `agent-job.ts` (tests counted separately).

Fixes #120561
