### PR TITLE
fix(telegram): restore account reply mode on beta.1

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -90,6 +90,7 @@ import {
   createTelegramPluginBase,
   findTelegramTokenOwnerAccountId,
   formatDuplicateTelegramTokenReason,
+  resolveTelegramConfigAccessorAccount,
   telegramConfigAdapter,
 } from "./shared.js";
 import { withTelegramStartupProbeSlot } from "./startup-probe-limiter.js";
@@ -1246,7 +1247,8 @@ export const telegramPlugin = createChatChannelPlugin({
   },
   security: telegramSecurityAdapter,
   threading: {
-    topLevelReplyToMode: "telegram",
+    resolveReplyToMode: ({ cfg, accountId }) =>
+      resolveTelegramConfigAccessorAccount({ cfg, accountId }).config.replyToMode ?? "off",
     buildToolContext: (params) => buildTelegramThreadingToolContext(params),
     resolveAutoThreadId: ({ to, toolContext }) => resolveTelegramAutoThreadId({ to, toolContext }),
     resolveCurrentChannelId: ({ to, threadId }) => {

--- a/extensions/telegram/src/shared.ts
+++ b/extensions/telegram/src/shared.ts
@@ -104,7 +104,7 @@ function isBlockedByMultiBotGuard(cfg: OpenClawConfig, accountId: string): boole
   return !resolveNormalizedAccountEntry(accounts, accountId, normalizeAccountId);
 }
 
-function resolveTelegramConfigAccessorAccount(params: {
+export function resolveTelegramConfigAccessorAccount(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
 }): TelegramConfigAccessorAccount {

--- a/extensions/telegram/src/threading-tool-context.test.ts
+++ b/extensions/telegram/src/threading-tool-context.test.ts
@@ -1,7 +1,66 @@
 // Telegram tests cover threading tool context plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { telegramPlugin } from "./channel.js";
 import { buildTelegramThreadingToolContext } from "./threading-tool-context.js";
+
+const tryReadSecretFileSyncMock = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error("reply mode must not read Telegram credentials");
+  }),
+);
+
+vi.mock("openclaw/plugin-sdk/secret-file-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/secret-file-runtime")>()),
+  tryReadSecretFileSync: tryReadSecretFileSyncMock,
+}));
+
+describe("telegramPlugin reply threading", () => {
+  it.each([
+    {
+      name: "uses an account override",
+      telegram: {
+        accounts: {
+          sut: {
+            tokenFile: "/tmp/openclaw-telegram-reply-mode-must-not-read",
+            replyToMode: "first" as const,
+          },
+        },
+      },
+      expected: "first",
+    },
+    {
+      name: "inherits the top-level mode",
+      telegram: {
+        replyToMode: "all" as const,
+        accounts: {
+          sut: {
+            botToken: { source: "file", provider: "telegram_token", id: "value" },
+          },
+        },
+      },
+      expected: "all",
+    },
+    {
+      name: "allows an account to disable replies",
+      telegram: {
+        replyToMode: "all" as const,
+        accounts: { sut: { replyToMode: "off" as const } },
+      },
+      expected: "off",
+    },
+  ])("$name", ({ telegram, expected }) => {
+    tryReadSecretFileSyncMock.mockClear();
+    const resolveReplyToMode = telegramPlugin.threading?.resolveReplyToMode;
+    if (!resolveReplyToMode) {
+      throw new Error("Telegram reply mode resolver is unavailable");
+    }
+
+    const cfg = { channels: { telegram } } as unknown as OpenClawConfig;
+    expect(resolveReplyToMode({ cfg, accountId: "sut" })).toBe(expected);
+    expect(tryReadSecretFileSyncMock).not.toHaveBeenCalled();
+  });
+});
 
 describe("buildTelegramThreadingToolContext", () => {
   it("keeps topic thread state in plugin-owned tool context", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-blocking Telegram regression where account-specific `replyToMode` settings are ignored by the `2026.8.1-beta.1` candidate. Package Telegram proof showed an account configured with `replyToMode: "first"` sent replies without `replyToMessageId`, causing the channel canary to fail.

Related: https://github.com/openclaw/openclaw/pull/120527

## Why This Change Was Made

This is the exact three-file backport of the merged main repair from PR #120527. Telegram now resolves reply policy from the selected account's config-only projection, preserving account overrides, top-level inheritance, explicit `off`, and default-off behavior without resolving `tokenFile` or SecretRef credentials on the automatic-reply hot path.

The patch was already committed once directly, but GitHub could not verify that machine's local SSH signing key. The unreleased release branch was reset by exactly that one commit and this PR preserves the same tree change so GitHub can create the verified release Code SHA.

Co-authored-by: Tak Hoffman <781889+Takhoffman@users.noreply.github.com>

## User Impact

Telegram accounts on the beta candidate again honor account-level reply threading. The first response can attach to the triggering Telegram message as configured, while accounts set to `off` remain unthreaded. No config or public API changes.

## Evidence

- Source repair: https://github.com/openclaw/openclaw/pull/120527
- Pre-fix package Telegram evidence: https://github.com/openclaw/openclaw/actions/runs/31243345426
- Focused release-branch regression: 5/5 passed
- Channel contracts: 482/482 passed on Testbox `tbx_01kzhy9aermvqafw7c3v3p3yx9` / https://github.com/openclaw/openclaw/actions/runs/31285960232
- Extension production/test typechecks: passed
- Targeted lint, formatting, and `git diff --check`: passed
- Codex autoreview of the staged release backport: clean, no P0/P1 findings
- Aggregate stable patch ID matches PR #120527: `365f2884a2f4a0d8aea150d0f4f73c2a4c23c7ec`
