### PR TITLE
fix(ui): dashboard widgets no longer flash white in dark mode

### DIFF
--- a/ui/src/components/mcp-app-view.ts
+++ b/ui/src/components/mcp-app-view.ts
@@ -135,7 +135,7 @@ export class McpAppView extends LitElement {
       display: block;
       width: 100%;
       border: 0;
-      background: transparent;
+      background: var(--board-surface, var(--card));
     }
     .error {
       padding: 14px;

--- a/ui/src/e2e/board-fixture.e2e.test.ts
+++ b/ui/src/e2e/board-fixture.e2e.test.ts
@@ -186,6 +186,22 @@ describeStandaloneMockServer("standalone Control UI mock server", () => {
         const colors = await readMenuColors(page);
         expect(colorContrast(colors.foreground, colors.background)).toBeGreaterThanOrEqual(4.5);
 
+        const widgetBackgrounds = await page
+          .locator('[data-test-id="board-widget"]')
+          .first()
+          .evaluate((widget) => {
+            const frame = widget.querySelector(".board-widget__frame");
+            if (!(frame instanceof HTMLIFrameElement)) {
+              throw new Error("board widget frame is missing");
+            }
+            return {
+              frame: getComputedStyle(frame).backgroundColor,
+              widget: getComputedStyle(widget).backgroundColor,
+            };
+          });
+        expect(widgetBackgrounds.frame).toBe(widgetBackgrounds.widget);
+        expect(widgetBackgrounds.frame).not.toBe("rgba(0, 0, 0, 0)");
+
         await expect
           .poll(() => page.frames().some((frame) => frame.url().startsWith("data:text/html")))
           .toBe(true);

--- a/ui/src/e2e/board-mcp-app.e2e.test.ts
+++ b/ui/src/e2e/board-mcp-app.e2e.test.ts
@@ -232,16 +232,16 @@ describeControlUiE2e("Control UI dashboard MCP Apps", () => {
       .toBeGreaterThan(0);
     await waitForMountedApp(page);
     const widgetBackgrounds = await page.evaluate(() => {
-      const widget = document.querySelector<HTMLElement>('[data-test-id="board-widget"]');
+      const widgetElement = document.querySelector<HTMLElement>('[data-test-id="board-widget"]');
       const frame = document
         .querySelector("mcp-app-view")
         ?.shadowRoot?.querySelector<HTMLIFrameElement>("iframe");
-      if (!widget || !frame) {
+      if (!widgetElement || !frame) {
         throw new Error("dashboard MCP App frame is missing");
       }
       return {
         frame: getComputedStyle(frame).backgroundColor,
-        widget: getComputedStyle(widget).backgroundColor,
+        widget: getComputedStyle(widgetElement).backgroundColor,
       };
     });
     expect(widgetBackgrounds.frame).toBe(widgetBackgrounds.widget);

--- a/ui/src/e2e/board-mcp-app.e2e.test.ts
+++ b/ui/src/e2e/board-mcp-app.e2e.test.ts
@@ -196,7 +196,10 @@ describeControlUiE2e("Control UI dashboard MCP Apps", () => {
   });
 
   it("renders a pinned app and proactively renews its board lease", async () => {
-    const context = await browser.newContext({ permissions: ["local-network-access"] });
+    const context = await browser.newContext({
+      colorScheme: "dark",
+      permissions: ["local-network-access"],
+    });
     contexts.add(context);
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -228,6 +231,21 @@ describeControlUiE2e("Control UI dashboard MCP Apps", () => {
       })
       .toBeGreaterThan(0);
     await waitForMountedApp(page);
+    const widgetBackgrounds = await page.evaluate(() => {
+      const widget = document.querySelector<HTMLElement>('[data-test-id="board-widget"]');
+      const frame = document
+        .querySelector("mcp-app-view")
+        ?.shadowRoot?.querySelector<HTMLIFrameElement>("iframe");
+      if (!widget || !frame) {
+        throw new Error("dashboard MCP App frame is missing");
+      }
+      return {
+        frame: getComputedStyle(frame).backgroundColor,
+        widget: getComputedStyle(widget).backgroundColor,
+      };
+    });
+    expect(widgetBackgrounds.frame).toBe(widgetBackgrounds.widget);
+    expect(widgetBackgrounds.frame).not.toBe("rgba(0, 0, 0, 0)");
     await expect
       .poll(async () => (await gateway.getRequests("board.widget.appView")).length, {
         timeout: 15_000,

--- a/ui/src/styles/board.css
+++ b/ui/src/styles/board.css
@@ -307,7 +307,7 @@ openclaw-board-widget-cell {
 }
 
 .board-widget__frame {
-  background: transparent;
+  background: var(--board-surface);
   border: 0;
   display: block;
   height: 100%;


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

AI-assisted: this fix and its regression coverage were developed with Codex assistance, reviewed, and verified against the behavior described below.

## What Problem This Solves

Fixes an issue where dashboard widgets could expose a white loading canvas in system dark mode while their sandbox content was starting.

## Why This Change Was Made

The host already resolves the active theme before iframe content exists. Canvas and MCP App frames now paint the surrounding theme-derived widget surface during startup instead of remaining transparent, avoiding a second theme-resolution path and leaving loaded widget content unchanged.

## User Impact

Dashboard widgets remain dark while loading in dark mode and light while loading in light mode. Once loaded, widget content and live theme behavior are unchanged.

Release-note context: Control UI dashboard Canvas and MCP App widgets no longer flash white while loading in dark mode.

## Evidence

| Before | After |
| --- | --- |
| [![Before: transparent widget frame exposes a white loading canvas in dark mode](https://artifacts.openclaw.ai/pr-120820/artifacts/20260809-020520-597397000/dark-widget-before.png)](https://artifacts.openclaw.ai/pr-120820/artifacts/20260809-020520-597397000/dark-widget-before.png) | [![After: widget frame paints the surrounding dark widget surface while loading](https://artifacts.openclaw.ai/pr-120820/artifacts/20260809-020520-597397000/dark-widget-after.png)](https://artifacts.openclaw.ai/pr-120820/artifacts/20260809-020520-597397000/dark-widget-after.png) |

- Published proof: [artifact manifest](https://artifacts.openclaw.ai/pr-120820/artifacts/20260809-020520-597397000/artifact-manifest.json) · [evidence comment](https://github.com/openclaw/openclaw/pull/120820#issuecomment-5229292844)
- Local Chromium: `node scripts/run-vitest.mjs ui/src/e2e/board-fixture.e2e.test.ts` — 4/4 passed; `node scripts/run-vitest.mjs ui/src/e2e/board-mcp-app.e2e.test.ts` — 3/3 passed.
- Local formatting/style checks: `pnpm format ui/src/components/mcp-app-view.ts ui/src/e2e/board-fixture.e2e.test.ts ui/src/e2e/board-mcp-app.e2e.test.ts ui/src/styles/board.css`, `./node_modules/.bin/stylelint ui/src/styles/board.css ui/src/components/mcp-app-view.ts --config config/stylelint.config.mjs`, and `git diff --check` — passed.
- The first exact-head CI run found a test-only `eslint(no-shadow)` issue. Follow-up commit `dc7e0437ae7d8f4c8c44ceab57957d41983b3261` renames the local DOM variable without changing behavior; `node scripts/run-oxlint.mjs ui/src/e2e/board-mcp-app.e2e.test.ts` passed and `node scripts/run-vitest.mjs ui/src/e2e/board-mcp-app.e2e.test.ts` passed 3/3.
- AWS Crabbox Linux Chromium: both focused files, 7/7 passed — https://crabbox.openclaw.ai/portal/runs/run_a74a1a640fea
- Visual diagnostic: before measured a transparent frame (`rgba(0,0,0,0)`) against the dark widget surface; after measured an exact frame/widget dark-surface match — https://crabbox.openclaw.ai/portal/runs/run_9a7f6da1f815
- Source-blind behavior validation: 4 pass, 0 fail, 0 blocked. Canvas dark/light startup, MCP App dark startup, and live theme/content behavior all passed.
- Codex autoreview (`--mode uncommitted`): clean for both the original fix and the test-only follow-up, with no accepted or actionable findings.
- LOC split: production is net-neutral (two one-value replacements: +2/-2); tests are +34 net (+35/-1).
