### PR TITLE
fix(google-meet): stop failed voice gateway connections

### DIFF
--- a/extensions/google-meet/src/voice-call-gateway.test.ts
+++ b/extensions/google-meet/src/voice-call-gateway.test.ts
@@ -1,4 +1,5 @@
 // Google Meet tests cover voice call gateway plugin behavior.
+import { createServer } from "node:http";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveGoogleMeetConfig } from "./config.js";
 import {
@@ -8,16 +9,41 @@ import {
   joinMeetViaVoiceCallGateway,
 } from "./voice-call-gateway.js";
 
+type GatewayRuntime = typeof import("openclaw/plugin-sdk/gateway-runtime");
+type GatewayClientOptions = ConstructorParameters<GatewayRuntime["GatewayClient"]>[0];
+type GatewayClientInstance = InstanceType<GatewayRuntime["GatewayClient"]>;
+
 const gatewayMocks = vi.hoisted(() => ({
   runtimeRequest: vi.fn(),
   request: vi.fn(),
   stopAndWait: vi.fn(async () => {}),
-  startGatewayClientWhenEventLoopReady: vi.fn(async () => ({ ready: true, aborted: false })),
+  startGatewayClientWhenEventLoopReady: vi.fn(
+    async (_client: unknown, _options?: { signal?: AbortSignal }) => ({
+      ready: true,
+      aborted: false,
+    }),
+  ),
+  autoHello: true,
+  clientOptions: undefined as GatewayClientOptions | undefined,
+  constructorError: undefined as Error | undefined,
+  actualGatewayClient: undefined as GatewayRuntime["GatewayClient"] | undefined,
+  actualClients: [] as GatewayClientInstance[],
 }));
 
 vi.mock("openclaw/plugin-sdk/gateway-runtime", () => ({
-  GatewayClient: vi.fn(function MockGatewayClient(params: { onHelloOk?: () => void }) {
-    queueMicrotask(() => params.onHelloOk?.());
+  GatewayClient: vi.fn(function MockGatewayClient(params: GatewayClientOptions) {
+    gatewayMocks.clientOptions = params;
+    if (gatewayMocks.constructorError) {
+      throw gatewayMocks.constructorError;
+    }
+    if (gatewayMocks.actualGatewayClient) {
+      const client = new gatewayMocks.actualGatewayClient(params);
+      gatewayMocks.actualClients.push(client);
+      return client;
+    }
+    if (gatewayMocks.autoHello) {
+      queueMicrotask(() => params.onHelloOk?.({} as never));
+    }
     return {
       request: gatewayMocks.request,
       stopAndWait: gatewayMocks.stopAndWait,
@@ -33,8 +59,18 @@ describe("Google Meet voice-call gateway", () => {
     gatewayMocks.request.mockResolvedValue({ success: true });
     gatewayMocks.runtimeRequest.mockReset();
     gatewayMocks.runtimeRequest.mockResolvedValue({ callId: "call-1" });
-    gatewayMocks.stopAndWait.mockClear();
-    gatewayMocks.startGatewayClientWhenEventLoopReady.mockClear();
+    gatewayMocks.stopAndWait.mockReset();
+    gatewayMocks.stopAndWait.mockResolvedValue(undefined);
+    gatewayMocks.startGatewayClientWhenEventLoopReady.mockReset();
+    gatewayMocks.startGatewayClientWhenEventLoopReady.mockResolvedValue({
+      ready: true,
+      aborted: false,
+    });
+    gatewayMocks.autoHello = true;
+    gatewayMocks.clientOptions = undefined;
+    gatewayMocks.constructorError = undefined;
+    gatewayMocks.actualGatewayClient = undefined;
+    gatewayMocks.actualClients.length = 0;
   });
 
   afterEach(() => {
@@ -44,6 +80,198 @@ describe("Google Meet voice-call gateway", () => {
   afterAll(() => {
     vi.doUnmock("openclaw/plugin-sdk/gateway-runtime");
     vi.resetModules();
+  });
+
+  it("stops the real gateway client's referenced reconnect after a localhost connection fails", async () => {
+    const actual = await vi.importActual<GatewayRuntime>("openclaw/plugin-sdk/gateway-runtime");
+    gatewayMocks.actualGatewayClient = actual.GatewayClient;
+    gatewayMocks.startGatewayClientWhenEventLoopReady.mockImplementation((client, options) =>
+      actual.startGatewayClientWhenEventLoopReady(
+        client as Parameters<GatewayRuntime["startGatewayClientWhenEventLoopReady"]>[0],
+        options,
+      ),
+    );
+
+    const server = createServer();
+    let connectionCount = 0;
+    let resolveReconnect: ((observed: boolean) => void) | undefined;
+    const reconnected = new Promise<boolean>((resolve) => {
+      resolveReconnect = resolve;
+    });
+    server.on("upgrade", (_request, socket) => {
+      connectionCount += 1;
+      socket.destroy();
+      if (connectionCount > 1) {
+        resolveReconnect?.(true);
+      }
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("localhost gateway server did not receive a TCP port");
+    }
+
+    const stopAndWait = vi.spyOn(actual.GatewayClient.prototype, "stopAndWait");
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    let observationTimer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const config = resolveGoogleMeetConfig({
+        voiceCall: {
+          gatewayUrl: `ws://127.0.0.1:${address.port}`,
+          requestTimeoutMs: 3_000,
+        },
+      });
+      const gateway = createVoiceCallGateway({
+        config,
+        runtime: { gateway: { request: gatewayMocks.runtimeRequest } } as never,
+      });
+
+      await expect(
+        getMeetVoiceCallGatewayCall({ gateway, callId: "call-1" }),
+      ).rejects.toMatchObject({ code: "ECONNRESET", message: "socket hang up" });
+      expect(connectionCount).toBe(1);
+      expect(gatewayMocks.actualClients).toHaveLength(1);
+
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      const referencedRetry = setTimeoutSpy.mock.calls.some(([, delay], index) => {
+        const timer = setTimeoutSpy.mock.results[index]?.value as NodeJS.Timeout | undefined;
+        return (
+          delay === 1_000 &&
+          timer?.hasRef() === true &&
+          !clearTimeoutSpy.mock.calls.some(([cleared]) => cleared === timer)
+        );
+      });
+
+      const retryObserved = await Promise.race([
+        reconnected,
+        new Promise<boolean>((resolve) => {
+          observationTimer = setTimeout(() => resolve(false), 1_150);
+        }),
+      ]);
+      if (observationTimer) {
+        clearTimeout(observationTimer);
+        observationTimer = undefined;
+      }
+
+      expect({
+        stopCalls: stopAndWait.mock.calls.length,
+        reconnected: retryObserved,
+        connectionCount,
+        referencedRetry,
+      }).toEqual({
+        stopCalls: 1,
+        reconnected: false,
+        connectionCount: 1,
+        referencedRetry: false,
+      });
+      expect(gatewayMocks.runtimeRequest).not.toHaveBeenCalled();
+    } finally {
+      if (observationTimer) {
+        clearTimeout(observationTimer);
+      }
+      await Promise.all(gatewayMocks.actualClients.map((client) => client.stopAndWait()));
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+      setTimeoutSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+      stopAndWait.mockRestore();
+    }
+  });
+
+  it("preserves the original startup failure when failed-client teardown also rejects", async () => {
+    gatewayMocks.autoHello = false;
+    gatewayMocks.stopAndWait.mockRejectedValueOnce(new Error("gateway teardown failed"));
+    const originalError = new Error("external voice gateway refused the connection");
+    const config = resolveGoogleMeetConfig({
+      voiceCall: { gatewayUrl: "wss://voice.example.test" },
+    });
+    const gateway = createVoiceCallGateway({
+      config,
+      runtime: { gateway: { request: gatewayMocks.runtimeRequest } } as never,
+    });
+
+    const request = getMeetVoiceCallGatewayCall({ gateway, callId: "call-1" });
+    gatewayMocks.clientOptions?.onConnectError?.(originalError);
+
+    await expect(request).rejects.toBe(originalError);
+    expect(gatewayMocks.stopAndWait).toHaveBeenCalledOnce();
+    expect(
+      gatewayMocks.startGatewayClientWhenEventLoopReady.mock.calls[0]?.[1]?.signal?.aborted,
+    ).toBe(true);
+    expect(gatewayMocks.request).not.toHaveBeenCalled();
+  });
+
+  it("stops a gateway client when its event-loop readiness fails", async () => {
+    gatewayMocks.autoHello = false;
+    gatewayMocks.startGatewayClientWhenEventLoopReady.mockResolvedValueOnce({
+      ready: false,
+      aborted: false,
+    });
+    const config = resolveGoogleMeetConfig({
+      voiceCall: { gatewayUrl: "wss://voice.example.test" },
+    });
+    const gateway = createVoiceCallGateway({
+      config,
+      runtime: { gateway: { request: gatewayMocks.runtimeRequest } } as never,
+    });
+
+    await expect(getMeetVoiceCallGatewayCall({ gateway, callId: "call-1" })).rejects.toThrow(
+      "gateway event loop readiness timeout",
+    );
+
+    expect(gatewayMocks.stopAndWait).toHaveBeenCalledOnce();
+    expect(
+      gatewayMocks.startGatewayClientWhenEventLoopReady.mock.calls[0]?.[1]?.signal?.aborted,
+    ).toBe(true);
+  });
+
+  it("stops a gateway client when the connection deadline expires", async () => {
+    vi.useFakeTimers();
+    gatewayMocks.autoHello = false;
+    const config = resolveGoogleMeetConfig({
+      voiceCall: { gatewayUrl: "wss://voice.example.test", requestTimeoutMs: 25 },
+    });
+    const gateway = createVoiceCallGateway({
+      config,
+      runtime: { gateway: { request: gatewayMocks.runtimeRequest } } as never,
+    });
+
+    const rejected = expect(
+      getMeetVoiceCallGatewayCall({ gateway, callId: "call-1" }),
+    ).rejects.toThrow("gateway connect timeout");
+    await vi.advanceTimersByTimeAsync(25);
+    await rejected;
+
+    expect(gatewayMocks.stopAndWait).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("clears the startup deadline when constructing the gateway client fails", async () => {
+    vi.useFakeTimers();
+    const constructorError = new Error("gateway client constructor failed");
+    gatewayMocks.constructorError = constructorError;
+    const config = resolveGoogleMeetConfig({
+      voiceCall: { gatewayUrl: "wss://voice.example.test", requestTimeoutMs: 25 },
+    });
+    const gateway = createVoiceCallGateway({
+      config,
+      runtime: { gateway: { request: gatewayMocks.runtimeRequest } } as never,
+    });
+
+    await expect(getMeetVoiceCallGatewayCall({ gateway, callId: "call-1" })).rejects.toBe(
+      constructorError,
+    );
+
+    expect(gatewayMocks.stopAndWait).not.toHaveBeenCalled();
+    expect(gatewayMocks.startGatewayClientWhenEventLoopReady).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("starts Twilio Meet calls with pre-connect DTMF, then speaks the intro without TwiML fallback", async () => {

--- a/extensions/google-meet/src/voice-call-gateway.ts
+++ b/extensions/google-meet/src/voice-call-gateway.ts
@@ -32,46 +32,54 @@ async function createConnectedGatewayClient(params: {
   config: MeetingVoiceCallConfig;
   surface: MeetingVoiceCallSurface;
 }): Promise<MeetingVoiceCallGatewayClient> {
-  let client: InstanceType<typeof GatewayClient>;
-  await new Promise<void>((resolve, reject) => {
-    const abortStart = new AbortController();
-    const timer = setTimeout(() => {
-      abortStart.abort();
-      reject(new Error("gateway connect timeout"));
-    }, params.config.requestTimeoutMs);
-    client = new GatewayClient({
-      url: params.config.gatewayUrl,
-      token: params.config.token,
-      requestTimeoutMs: params.config.requestTimeoutMs,
-      clientName: "cli",
-      clientDisplayName: params.surface.clientDisplayName,
-      scopes: ["operator.write"],
-      onHelloOk: () => {
-        clearTimeout(timer);
-        resolve();
-      },
-      onConnectError: (error) => {
-        clearTimeout(timer);
+  let client: InstanceType<typeof GatewayClient> | undefined;
+  const abortStart = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      timer = setTimeout(() => {
         abortStart.abort();
-        reject(error);
-      },
-    });
-    void startGatewayClientWhenEventLoopReady(client, {
-      timeoutMs: params.config.requestTimeoutMs,
-      signal: abortStart.signal,
-    })
-      .then((readiness) => {
-        if (!readiness.ready && !readiness.aborted) {
+        reject(new Error("gateway connect timeout"));
+      }, params.config.requestTimeoutMs);
+      client = new GatewayClient({
+        url: params.config.gatewayUrl,
+        token: params.config.token,
+        requestTimeoutMs: params.config.requestTimeoutMs,
+        clientName: "cli",
+        clientDisplayName: params.surface.clientDisplayName,
+        scopes: ["operator.write"],
+        onHelloOk: () => {
           clearTimeout(timer);
-          reject(new Error("gateway event loop readiness timeout"));
-        }
-      })
-      .catch((error: unknown) => {
-        clearTimeout(timer);
-        reject(error instanceof Error ? error : new Error(String(error)));
+          resolve();
+        },
+        onConnectError: (error) => {
+          clearTimeout(timer);
+          abortStart.abort();
+          reject(error);
+        },
       });
-  });
-  return client!;
+      void startGatewayClientWhenEventLoopReady(client, {
+        timeoutMs: params.config.requestTimeoutMs,
+        signal: abortStart.signal,
+      })
+        .then((readiness) => {
+          if (!readiness.ready && !readiness.aborted) {
+            clearTimeout(timer);
+            reject(new Error("gateway event loop readiness timeout"));
+          }
+        })
+        .catch((error: unknown) => {
+          clearTimeout(timer);
+          reject(error instanceof Error ? error : new Error(String(error)));
+        });
+    });
+    return client!;
+  } catch (error) {
+    clearTimeout(timer);
+    abortStart.abort();
+    await client?.stopAndWait().catch(() => {});
+    throw error;
+  }
 }
 
 export function createVoiceCallGateway(params: {


### PR DESCRIPTION
## Summary

When an optionally configured meeting voice gateway failed during connection startup, the plugin rejected the caller but left its actual gateway client and retry timer running. A refused or broken local WebSocket could therefore reconnect after the original startup had already failed.

Make the private connector own failure cleanup: stop and await the partially started client through its existing bounded shutdown API, preserve the original connection error even if cleanup fails, and retain the existing successful-session cleanup path exactly once.

The eight-line production increase represents explicit ownership of an already-created connection, retry timer, and startup deadline. There are no authentication, configuration, persistence, shared-client, external-provider, or public protocol changes.

## Verification

- Tests-only execution used the actual gateway client and a real localhost WebSocket to reproduce an unexpected second connection, referenced retry timer, and missing shutdown after the original connection failure.
- The exact repaired owner suite passes all 12 cases, including failed shutdown, readiness, construction, timeout, and successful single cleanup.
- Adjacent meeting, CLI, and shared-client suites pass all 216 tests.
- The complete remote changed gate passes formatting, production/test typechecks, zero-warning lint, and all plugin, ownership, and runtime guards.
- Independent direct dependency-contract review and fresh structured code review found no actionable issues.

No real calls or external provider requests were made.
