### PR TITLE
fix(msteams): paginate channel thread replies

### DIFF
--- a/extensions/msteams/src/graph-thread.test.ts
+++ b/extensions/msteams/src/graph-thread.test.ts
@@ -9,12 +9,15 @@ import {
 } from "./graph-thread.js";
 import { fetchGraphJson } from "./graph.js";
 
+const fetchAllGraphPagesMock = vi.hoisted(() => vi.fn());
+
 vi.mock("./graph.js", () => ({
   fetchGraphJson: vi.fn(),
+  fetchAllGraphPages: fetchAllGraphPagesMock,
 }));
 
 const firstGraphPath = () => {
-  const [call] = vi.mocked(fetchGraphJson).mock.calls;
+  const [call] = fetchAllGraphPagesMock.mock.calls;
   if (!call) {
     throw new Error("expected Graph fetch call");
   }
@@ -164,43 +167,121 @@ describe("fetchChatMessageText", () => {
 describe("fetchThreadReplies", () => {
   beforeEach(() => {
     vi.mocked(fetchGraphJson).mockReset();
+    fetchAllGraphPagesMock.mockReset();
   });
 
   it("fetches replies with correct path and default limit", async () => {
-    vi.mocked(fetchGraphJson).mockResolvedValueOnce({
-      value: [{ id: "reply-1" }, { id: "reply-2" }],
+    fetchAllGraphPagesMock.mockResolvedValueOnce({
+      items: [{ id: "reply-1" }, { id: "reply-2" }],
+      truncated: false,
     } as never);
 
     const result = await fetchThreadReplies("tok", "group-1", "channel-1", "msg-1");
 
     expect(result).toHaveLength(2);
-    expect(fetchGraphJson).toHaveBeenCalledWith({
+    expect(fetchAllGraphPagesMock).toHaveBeenCalledWith({
       token: "tok",
       path: "/teams/group-1/channels/channel-1/messages/msg-1/replies?$top=50&$select=id,from,body,createdDateTime",
+      maxPages: 50,
     });
   });
 
   it("clamps limit to 50 maximum", async () => {
-    vi.mocked(fetchGraphJson).mockResolvedValueOnce({ value: [] } as never);
+    fetchAllGraphPagesMock.mockResolvedValueOnce({
+      items: Array.from({ length: 60 }, (_, index) => ({
+        id: `reply-${index + 1}`,
+        createdDateTime: `2026-08-01T00:${String(index).padStart(2, "0")}:00Z`,
+      })),
+      truncated: false,
+    } as never);
 
-    await fetchThreadReplies("tok", "g", "c", "m", 200);
+    const result = await fetchThreadReplies("tok", "g", "c", "m", 200);
 
+    expect(result).toHaveLength(50);
     expect(firstGraphPath()).toContain("$top=50");
   });
 
   it("clamps limit to 1 minimum", async () => {
-    vi.mocked(fetchGraphJson).mockResolvedValueOnce({ value: [] } as never);
+    fetchAllGraphPagesMock.mockResolvedValueOnce({
+      items: [
+        { id: "reply-1", createdDateTime: "2026-08-01T00:00:00Z" },
+        { id: "reply-2", createdDateTime: "2026-08-01T00:01:00Z" },
+      ],
+      truncated: false,
+    } as never);
 
-    await fetchThreadReplies("tok", "g", "c", "m", 0);
+    const result = await fetchThreadReplies("tok", "g", "c", "m", 0);
 
-    expect(firstGraphPath()).toContain("$top=1");
+    expect(result).toStrictEqual([{ id: "reply-2", createdDateTime: "2026-08-01T00:01:00Z" }]);
+    expect(firstGraphPath()).toContain("$top=50");
   });
 
   it("returns empty array when value is missing", async () => {
-    vi.mocked(fetchGraphJson).mockResolvedValueOnce({} as never);
+    fetchAllGraphPagesMock.mockResolvedValueOnce({ items: [], truncated: false } as never);
 
     const result = await fetchThreadReplies("tok", "g", "c", "m");
     expect(result).toStrictEqual([]);
+  });
+
+  it("returns the newest replies after pagination", async () => {
+    fetchAllGraphPagesMock.mockResolvedValueOnce({
+      items: [
+        { id: "reply-3", createdDateTime: "2026-08-01T00:02:00Z" },
+        { id: "reply-1", createdDateTime: "2026-08-01T00:00:00Z" },
+        { id: "reply-4", createdDateTime: "2026-08-01T00:03:00Z" },
+        { id: "reply-2", createdDateTime: "2026-08-01T00:01:00Z" },
+      ],
+      truncated: false,
+    } as never);
+
+    const result = await fetchThreadReplies("tok", "g", "c", "m", 2);
+
+    expect(result.map((reply) => reply.id)).toStrictEqual(["reply-3", "reply-4"]);
+    expect(fetchAllGraphPagesMock).toHaveBeenCalledWith({
+      token: "tok",
+      path: "/teams/g/channels/c/messages/m/replies?$top=50&$select=id,from,body,createdDateTime",
+      maxPages: 50,
+    });
+  });
+
+  it("rejects a page-capped result instead of returning an old prefix", async () => {
+    fetchAllGraphPagesMock.mockResolvedValueOnce({
+      items: [{ id: "old-reply" }],
+      truncated: true,
+    } as never);
+
+    await expect(fetchThreadReplies("tok", "g", "c", "m")).rejects.toThrow(
+      "MS Teams thread replies pagination did not reach the newest replies",
+    );
+  });
+
+  it("rejects an incomplete timestamp set when selecting a newest window", async () => {
+    fetchAllGraphPagesMock.mockResolvedValueOnce({
+      items: [{ id: "reply-1" }, { id: "reply-2", createdDateTime: "2026-08-01T00:01:00Z" }],
+      truncated: false,
+    } as never);
+
+    await expect(fetchThreadReplies("tok", "g", "c", "m", 1)).rejects.toThrow(
+      "MS Teams thread replies have incomplete timestamps",
+    );
+  });
+
+  it("forwards the shared deadline to paginated replies", async () => {
+    fetchAllGraphPagesMock.mockResolvedValueOnce({ items: [], truncated: false } as never);
+    const deadline = {
+      label: "MS Teams inbound preprocessing",
+      timeoutMs: 10_000,
+      deadlineAtMs: Date.now() + 10_000,
+    };
+
+    await fetchThreadReplies("tok", "g", "c", "m", 50, deadline);
+
+    expect(fetchAllGraphPagesMock).toHaveBeenCalledWith({
+      token: "tok",
+      path: "/teams/g/channels/c/messages/m/replies?$top=50&$select=id,from,body,createdDateTime",
+      maxPages: 50,
+      deadline,
+    });
   });
 });
 

--- a/extensions/msteams/src/graph-thread.ts
+++ b/extensions/msteams/src/graph-thread.ts
@@ -1,6 +1,6 @@
 // Msteams plugin module implements graph thread behavior.
 import { decodeHtmlEntities } from "openclaw/plugin-sdk/html-entity-runtime";
-import { fetchGraphJson, type GraphResponse } from "./graph.js";
+import { fetchAllGraphPages, fetchGraphJson } from "./graph.js";
 import type { MSTeamsRequestDeadline } from "./request-timeout.js";
 
 export type GraphThreadMessage = {
@@ -12,6 +12,17 @@ export type GraphThreadMessage = {
   body?: { content?: string; contentType?: string };
   createdDateTime?: string;
 };
+
+/** Keep inbound thread enrichment bounded while still reaching recent replies. */
+const MAX_REPLY_PAGES = 50;
+
+function compareThreadMessagesChronologically(
+  a: GraphThreadMessage,
+  b: GraphThreadMessage,
+): number {
+  const timeDelta = Date.parse(a.createdDateTime ?? "") - Date.parse(b.createdDateTime ?? "");
+  return timeDelta || (a.id ?? "").localeCompare(b.id ?? "");
+}
 
 /**
  * Strip HTML tags from Teams message content, preserving @mention display names.
@@ -88,12 +99,8 @@ export async function fetchChatMessageText(
 /**
  * Fetch thread replies for a channel message, ordered chronologically.
  *
- * **Limitation:** The Graph API replies endpoint (`/messages/{id}/replies`) does not
- * support `$orderby`, so results are always returned in ascending (oldest-first) order.
- * Combined with the `$top` cap of 50, this means only the **oldest 50 replies** are
- * returned for long threads — newer replies are silently omitted. There is currently no
- * Graph API workaround for this; pagination via `@odata.nextLink` can retrieve more
- * replies but still in ascending order only.
+ * Graph caps each replies page at 50 and does not support `$orderby`. Follow
+ * `@odata.nextLink`, then return the newest bounded window in chronological order.
  */
 export async function fetchThreadReplies(
   token: string,
@@ -103,17 +110,31 @@ export async function fetchThreadReplies(
   limit = 50,
   deadline?: MSTeamsRequestDeadline,
 ): Promise<GraphThreadMessage[]> {
-  const top = Math.min(Math.max(limit, 1), 50);
-  // NOTE: Graph replies endpoint returns oldest-first and does not support $orderby.
-  // For threads with >50 replies, only the oldest 50 are returned. The most recent
-  // replies (often the most relevant context) may be truncated.
-  const path = `/teams/${encodeURIComponent(groupId)}/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}/replies?$top=${top}&$select=id,from,body,createdDateTime`;
-  const res = await fetchGraphJson<GraphResponse<GraphThreadMessage>>({
+  const requestedLimit = Math.min(Math.max(limit, 1), 50);
+  // Always request full pages so a small result window does not skip newer replies.
+  const path = `/teams/${encodeURIComponent(groupId)}/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}/replies?$top=50&$select=id,from,body,createdDateTime`;
+  const { items, truncated } = await fetchAllGraphPages<GraphThreadMessage>({
     token,
     path,
+    maxPages: MAX_REPLY_PAGES,
     ...(deadline ? { deadline } : {}),
   });
-  return res.value ?? [];
+  if (truncated) {
+    throw new Error("MS Teams thread replies pagination did not reach the newest replies");
+  }
+
+  if (items.length <= requestedLimit) {
+    return items;
+  }
+  // Once trimming is required, an incomplete timestamp set cannot identify the newest
+  // window safely; do not present an oldest or arrival-order prefix as current context.
+  const hasCompleteTimestamps = items.every((item) =>
+    Number.isFinite(Date.parse(item.createdDateTime ?? "")),
+  );
+  if (!hasCompleteTimestamps) {
+    throw new Error("MS Teams thread replies have incomplete timestamps");
+  }
+  return items.toSorted(compareThreadMessagesChronologically).slice(-requestedLimit);
 }
 
 /**

--- a/extensions/msteams/src/graph.test.ts
+++ b/extensions/msteams/src/graph.test.ts
@@ -44,6 +44,7 @@ vi.mock("../runtime-api.js", async (importOriginal) => {
   };
 });
 
+import { fetchThreadReplies } from "./graph-thread.js";
 import { findGraphUsersByExactIdentity, searchGraphUsers } from "./graph-users.js";
 import {
   deleteGraphRequest,
@@ -618,6 +619,72 @@ describe("msteams graph helpers", () => {
       expect(result.items).toEqual([...page1Items, ...page2Items, ...page3Items]);
       expect(result.truncated).toBe(false);
       expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("fetches the newest Teams thread replies across pages", async () => {
+      const page1Items = Array.from({ length: 50 }, (_, index) => ({
+        id: `reply-${index + 1}`,
+        name: `Reply ${index + 1}`,
+        createdDateTime: `2026-08-01T00:${String(index).padStart(2, "0")}:00Z`,
+      }));
+      const page2Items = Array.from({ length: 10 }, (_, index) => ({
+        id: `reply-${index + 51}`,
+        name: `Reply ${index + 51}`,
+        createdDateTime: `2026-08-01T00:${String(index + 50).padStart(2, "0")}:00Z`,
+      }));
+      let callCount = 0;
+
+      mockFetch(async () => {
+        callCount++;
+        return callCount === 1
+          ? jsonResponse(
+              pagedResponse(
+                page1Items,
+                "https://graph.microsoft.com/v1.0/teams/group/channels/channel/messages/root/replies?$skiptoken=page2",
+              ),
+            )
+          : jsonResponse(pagedResponse(page2Items));
+      });
+
+      const result = await fetchThreadReplies("tok", "group", "channel", "root");
+
+      expect(result).toHaveLength(50);
+      expect(result[0]?.id).toBe("reply-11");
+      expect(result.at(-1)?.id).toBe("reply-60");
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+      expectFetchPathContains(
+        1,
+        "/teams/group/channels/channel/messages/root/replies?$skiptoken=page2",
+      );
+    });
+
+    it("forwards the shared deadline to every paginated request", async () => {
+      const deadline = {
+        label: "MS Teams inbound preprocessing",
+        timeoutMs: 10_000,
+        deadlineAtMs: Date.now() + 10_000,
+      };
+      let callCount = 0;
+
+      mockFetch(async () => {
+        callCount++;
+        return callCount === 1
+          ? jsonResponse(
+              pagedResponse(
+                [{ id: "reply-1", name: "Reply 1" }],
+                "https://graph.microsoft.com/v1.0/teams/group/channels/channel/messages/root/replies?$skiptoken=page2",
+              ),
+            )
+          : jsonResponse(pagedResponse([{ id: "reply-2", name: "Reply 2" }]));
+      });
+
+      await fetchThreadReplies("tok", "group", "channel", "root", 50, deadline);
+
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
+      for (const [params] of fetchWithSsrFGuardMock.mock.calls) {
+        expect(params.timeoutMs).toBeGreaterThan(0);
+        expect(params.timeoutMs).toBeLessThanOrEqual(10_000);
+      }
     });
 
     it("truncation at maxPages", async () => {

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -183,6 +183,8 @@ export async function fetchAllGraphPages<T>(params: {
   token: string;
   path: string;
   headers?: Record<string, string>;
+  /** Optional shared operation deadline; actively aborts each guarded fetch when spent. */
+  deadline?: MSTeamsRequestDeadline;
   /** Max pages to fetch before stopping. Default: 50. */
   maxPages?: number;
   /** Stop pagination early when this predicate returns true. */
@@ -197,6 +199,7 @@ export async function fetchAllGraphPages<T>(params: {
       token: params.token,
       path: nextPath,
       headers: params.headers,
+      ...(params.deadline ? { deadline: params.deadline } : {}),
     });
 
     const pageItems = res.value ?? [];


### PR DESCRIPTION
Fixes #98870.

## What Problem This Solves

Fixes an issue where users running long Microsoft Teams channel threads would receive stale or incomplete thread context when the thread contained more than 50 replies. Microsoft Graph limits a replies page to 50 items, and the previous path returned only the first page.

## Why This Change Was Made

The Teams thread-reply owner now requests full Graph pages, follows the existing continuation flow within a bounded page limit and the inbound deadline, and selects the newest bounded reply window by timestamp before formatting context. Incomplete pagination or unreliable timestamps fail closed so an old prefix is not presented as current context.

## User Impact

Long Teams channel threads now include the newest available replies within the existing context limit. Short threads retain their current behavior. If Graph pagination cannot complete within the safety bounds, the reply portion is omitted while the parent context remains available.

## Evidence

- `node scripts/run-vitest.mjs extensions/msteams/src/graph-thread.test.ts extensions/msteams/src/graph.test.ts extensions/msteams/src/monitor-handler/message-handler.thread-parent.test.ts` — 3 files, 65 tests passed.
- `pnpm format:check --no-error-on-unmatched-pattern -- extensions/msteams/src/graph-thread.test.ts extensions/msteams/src/graph-thread.ts extensions/msteams/src/graph.test.ts extensions/msteams/src/graph.ts` passed.
- `git diff --check upstream/main..HEAD` passed.
- Added a two-page mocked Graph regression using `@odata.nextLink`, plus coverage for newest-window selection, limit clamping, deadline propagation, truncation, and incomplete timestamps.
- A live Microsoft Teams tenant with more than 50 replies is not available in this checkout; redacted tenant proof remains a pre-merge validation item.
- Full changed-file checks remain environment-limited: the Crabbox binary is unavailable, and the local oxlint preflight currently stops on unrelated existing `rejectSymlinks` declaration errors outside this change.


<!-- msteams-mock-gateway-e2e -->

### Secretless mock-gateway E2E (not tenant live-proof)

Executed: 2026-08-09T07:23:02Z (UTC)

- Production head: `7082cb1c310b29f55d2230321b34f3ebdd6e5423`. Proof harness: `3a04d7a500d945d31bd7972cf78f865965309d22`; its commit chain is based on the production head and adds only the QA harness/workflow.
- Run: https://github.com/Linux2010/openclaw/actions/runs/31300295866
- Artifact: https://github.com/Linux2010/openclaw/actions/runs/31300295866/artifacts/9034370884 — SHA256 `e8dcd1535488fe8c71548ead8b3835e9360198017521af8e231e31a7e9833f5b`.
- Results: 3 files / 15 tests passed; private QA build passed; scenario 1/1 passed.
- BEFORE / root-cause boundary: the old path consumed only the first `$top=50` reply page. When `nextLink` existed, newer replies were missing. This is a reproduced contract/regression test, not a tenant trace.
- AFTER E2E verdict JSON: success PASS — `nextLink: true`, `pageCounts: [1, 50, 10]`, `statuses: [200, 200, 200]`, window `has011/060`, `no010`, threaded outbound. 503 PASS — `partialRepliesInjected: false`, `[1, 50]` / `[200, 200, 503]`, threaded outbound.
- Mock boundary: loopback Bot Framework + Graph and a mock provider; the real Teams plugin runs with an ephemeral Gateway. This does not cover a real M365 tenant, Azure authentication, or real Teams delivery.
- The workflow has only `contents: read`, performs no secret hydration, and the artifact is redacted.

## Scope

- Production: 2 files, net +24 lines for bounded pagination, deadline propagation, and fail-closed ordering.
- Tests: 2 files, net +148 lines.
- No changelog or unrelated surface changes.

## AI Disclosure

This PR was prepared with OpenAI Codex. Codex was used for repository/issue investigation, implementation, test execution, and PR preparation; the author reviewed the resulting diff and validation evidence.
