### PR TITLE
feat(chat): add four rare working-claw stances and raise surprise odds

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -13627,7 +13627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 387,
+      "line": 432,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "${days}d",
       "surface": "android",
@@ -13635,7 +13635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 391,
+      "line": 436,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "${hours}h",
       "surface": "android",
@@ -13643,7 +13643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 395,
+      "line": 440,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "${minutes}m",
       "surface": "android",
@@ -13651,7 +13651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 399,
+      "line": 444,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "${seconds}s",
       "surface": "android",
@@ -13659,7 +13659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 440,
+      "line": 485,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Shelling",
       "surface": "android",
@@ -13667,7 +13667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 441,
+      "line": 486,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Scuttling",
       "surface": "android",
@@ -13675,7 +13675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 442,
+      "line": 487,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Clawing",
       "surface": "android",
@@ -13683,7 +13683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 443,
+      "line": 488,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Pinching",
       "surface": "android",
@@ -13691,7 +13691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 444,
+      "line": 489,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Molting",
       "surface": "android",
@@ -13699,7 +13699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 445,
+      "line": 490,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Bubbling",
       "surface": "android",
@@ -13707,7 +13707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 446,
+      "line": 491,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Tiding",
       "surface": "android",
@@ -13715,7 +13715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 447,
+      "line": 492,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Reefing",
       "surface": "android",
@@ -13723,7 +13723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 448,
+      "line": 493,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Cracking",
       "surface": "android",
@@ -13731,7 +13731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 449,
+      "line": 494,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Sifting",
       "surface": "android",
@@ -13739,7 +13739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 450,
+      "line": 495,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Brining",
       "surface": "android",
@@ -13747,7 +13747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 451,
+      "line": 496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Nautiling",
       "surface": "android",
@@ -13755,7 +13755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 452,
+      "line": 497,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Krilling",
       "surface": "android",
@@ -13763,7 +13763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 453,
+      "line": 498,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Barnacling",
       "surface": "android",
@@ -13771,7 +13771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 454,
+      "line": 499,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Lobstering",
       "surface": "android",
@@ -13779,7 +13779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 455,
+      "line": 500,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Tidepooling",
       "surface": "android",
@@ -13787,7 +13787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 456,
+      "line": 501,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Pearling",
       "surface": "android",
@@ -13795,7 +13795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 457,
+      "line": 502,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Snapping",
       "surface": "android",
@@ -13803,7 +13803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 458,
+      "line": 503,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Surfacing",
       "surface": "android",
@@ -42371,7 +42371,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 46,
+      "line": 54,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Shelling",
       "surface": "apple",
@@ -42379,7 +42379,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 47,
+      "line": 55,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Scuttling",
       "surface": "apple",
@@ -42387,7 +42387,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 48,
+      "line": 56,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Clawing",
       "surface": "apple",
@@ -42395,7 +42395,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 49,
+      "line": 57,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Pinching",
       "surface": "apple",
@@ -42403,7 +42403,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 50,
+      "line": 58,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Molting",
       "surface": "apple",
@@ -42411,7 +42411,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 51,
+      "line": 59,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Bubbling",
       "surface": "apple",
@@ -42419,7 +42419,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 52,
+      "line": 60,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Tiding",
       "surface": "apple",
@@ -42427,7 +42427,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 53,
+      "line": 61,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Reefing",
       "surface": "apple",
@@ -42435,7 +42435,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 54,
+      "line": 62,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Cracking",
       "surface": "apple",
@@ -42443,7 +42443,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 55,
+      "line": 63,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Sifting",
       "surface": "apple",
@@ -42451,7 +42451,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 56,
+      "line": 64,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Brining",
       "surface": "apple",
@@ -42459,7 +42459,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 57,
+      "line": 65,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Nautiling",
       "surface": "apple",
@@ -42467,7 +42467,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 58,
+      "line": 66,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Krilling",
       "surface": "apple",
@@ -42475,7 +42475,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 59,
+      "line": 67,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Barnacling",
       "surface": "apple",
@@ -42483,7 +42483,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 60,
+      "line": 68,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Lobstering",
       "surface": "apple",
@@ -42491,7 +42491,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 61,
+      "line": 69,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Tidepooling",
       "surface": "apple",
@@ -42499,7 +42499,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 62,
+      "line": 70,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Pearling",
       "surface": "apple",
@@ -42507,7 +42507,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 63,
+      "line": 71,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Snapping",
       "surface": "apple",
@@ -42515,7 +42515,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 64,
+      "line": 72,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Surfacing",
       "surface": "apple",
@@ -42523,7 +42523,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 118,
+      "line": 126,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "1 second",
       "surface": "apple",
@@ -42531,7 +42531,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 153,
+      "line": 161,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Done in %@",
       "surface": "apple",
@@ -42539,7 +42539,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 163,
+      "line": 171,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "1 token",
       "surface": "apple",
@@ -42547,7 +42547,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 166,
+      "line": 174,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "%@ tokens",
       "surface": "apple",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt
@@ -40,6 +40,7 @@ import kotlin.random.Random
 private const val DEFAULT_CLAW_CYCLE_MS = 2_400L
 private const val DRUMMER_CLAW_CYCLE_MS = 1_200L
 private const val FLURRY_CLAW_CYCLE_MS = 1_300L
+private const val NODOFF_CLAW_CYCLE_MS = 3_600L
 private const val SPIN_CLAW_CYCLE_MS = 3_600L
 private const val ZEN_CLAW_CYCLE_MS = 6_000L
 internal const val WORKING_PHRASE_SHOW_AFTER_MS = 30_000L
@@ -72,19 +73,27 @@ internal enum class WorkingClawStance {
   Zen,
   Drummer,
   Peekaboo,
+  NodOff,
+  Curious,
+  OmNom,
+  FakeOut,
 }
 
 private val stanceWeights =
   listOf(
-    WorkingClawStance.Default to 63,
-    WorkingClawStance.Southpaw to 19,
+    WorkingClawStance.Default to 55,
+    WorkingClawStance.Southpaw to 18,
     WorkingClawStance.Flurry to 5,
     WorkingClawStance.Spin to 4,
     WorkingClawStance.Shadowbox to 3,
     WorkingClawStance.Backflip to 2,
     WorkingClawStance.Zen to 2,
-    WorkingClawStance.Drummer to 1,
-    WorkingClawStance.Peekaboo to 1,
+    WorkingClawStance.Drummer to 2,
+    WorkingClawStance.Peekaboo to 2,
+    WorkingClawStance.NodOff to 2,
+    WorkingClawStance.Curious to 2,
+    WorkingClawStance.OmNom to 2,
+    WorkingClawStance.FakeOut to 1,
   )
 private val processStanceSalt = Random.nextInt()
 
@@ -138,6 +147,20 @@ private val drummerJawFrames = frames(0f to -10f, 0.10f to -20f, 0.15f to 2f, 0.
 private val peekabooScaleFrames = frames(0f to 1f, 0.55f to 1f, 0.62f to 0.72f, 0.72f to 0.72f, 0.78f to 1.06f, 0.84f to 1f, 1f to 1f)
 private val peekabooYFrames = frames(0f to 0f, 0.55f to 0f, 0.62f to 5f, 0.72f to 5f, 0.78f to -1.5f, 0.84f to 0f, 1f to 0f)
 private val peekabooJawFrames = frames(0f to -10f, 0.55f to -10f, 0.62f to -2f, 0.72f to -2f, 0.78f to -28f, 0.86f to -10f, 1f to -10f)
+private val nodOffRotationFrames =
+  frames(0f to 0f, 0.10f to 0f, 0.35f to 10f, 0.55f to 14f, 0.60f to 15f, 0.64f to -3f, 0.70f to 0f, 1f to 0f)
+private val nodOffYFrames = frames(0f to 0f, 0.10f to 0f, 0.35f to 1f, 0.60f to 1.5f, 0.64f to -0.5f, 0.70f to 0f, 1f to 0f)
+private val nodOffJawFrames =
+  frames(0f to -10f, 0.10f to -10f, 0.35f to -16f, 0.60f to -21f, 0.64f to -6f, 0.70f to -24f, 0.74f to 4f, 0.80f to -22f, 0.84f to 4f, 0.90f to -10f, 1f to -10f)
+private val curiousRotationFrames = frames(0f to 0f, 0.30f to 0f, 0.40f to -14f, 0.62f to -14f, 0.70f to 4f, 0.76f to 0f, 1f to 0f)
+private val curiousJawFrames = frames(0f to -10f, 0.30f to -10f, 0.40f to -16f, 0.62f to -16f, 0.70f to -6f, 0.76f to -10f, 1f to -10f)
+private val omNomXFrames = frames(0f to 0f, 0.30f to 0f, 0.36f to 2.5f, 0.40f to 1f, 0.46f to 2.5f, 0.50f to 1f, 0.56f to 2.5f, 0.64f to 0f, 1f to 0f)
+private val omNomJawFrames =
+  frames(0f to -10f, 0.26f to -10f, 0.30f to -30f, 0.36f to 8f, 0.42f to -30f, 0.46f to 8f, 0.52f to -30f, 0.56f to 8f, 0.64f to -10f, 1f to -10f)
+private val fakeOutRotationFrames =
+  frames(0f to 0f, 0.06f to 0f, 0.10f to -4f, 0.55f to -4f, 0.58f to 3f, 0.62f to -4f, 0.66f to 3f, 0.70f to -4f, 0.74f to 3f, 0.80f to 0f, 1f to 0f)
+private val fakeOutJawFrames =
+  frames(0f to -10f, 0.06f to -10f, 0.10f to -26f, 0.55f to -26f, 0.58f to 4f, 0.62f to -24f, 0.66f to 4f, 0.70f to -22f, 0.74f to 4f, 0.80f to -10f, 1f to -10f)
 
 private fun frames(vararg values: Pair<Float, Float>): List<ClawKeyframe> = values.map { (phase, value) -> ClawKeyframe(phase, value) }
 
@@ -207,6 +230,27 @@ internal fun workingClawPose(
         scale = sampleFrames(peekabooScaleFrames, phase),
         jawRotation = sampleFrames(peekabooJawFrames, phase),
       )
+    WorkingClawStance.NodOff ->
+      WorkingClawPose(
+        rotationZ = sampleFrames(nodOffRotationFrames, phase),
+        translationYDp = sampleFrames(nodOffYFrames, phase),
+        jawRotation = sampleFrames(nodOffJawFrames, phase),
+      )
+    WorkingClawStance.Curious ->
+      WorkingClawPose(
+        rotationZ = sampleFrames(curiousRotationFrames, phase),
+        jawRotation = sampleFrames(curiousJawFrames, phase),
+      )
+    WorkingClawStance.OmNom ->
+      WorkingClawPose(
+        translationXDp = sampleFrames(omNomXFrames, phase),
+        jawRotation = sampleFrames(omNomJawFrames, phase),
+      )
+    WorkingClawStance.FakeOut ->
+      WorkingClawPose(
+        rotationZ = sampleFrames(fakeOutRotationFrames, phase),
+        jawRotation = sampleFrames(fakeOutJawFrames, phase),
+      )
     WorkingClawStance.Default,
     WorkingClawStance.Southpaw,
     WorkingClawStance.Flurry,
@@ -221,6 +265,7 @@ internal fun workingClawCycleMs(stance: WorkingClawStance): Long =
   when (stance) {
     WorkingClawStance.Drummer -> DRUMMER_CLAW_CYCLE_MS
     WorkingClawStance.Flurry -> FLURRY_CLAW_CYCLE_MS
+    WorkingClawStance.NodOff -> NODOFF_CLAW_CYCLE_MS
     WorkingClawStance.Spin -> SPIN_CLAW_CYCLE_MS
     WorkingClawStance.Zen -> ZEN_CLAW_CYCLE_MS
     else -> DEFAULT_CLAW_CYCLE_MS

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatWorkingIndicatorTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatWorkingIndicatorTest.kt
@@ -28,15 +28,19 @@ class ChatWorkingIndicatorTest {
 
     assertEquals(1_000, counts.values.sum())
     assertEquals(WorkingClawStance.entries.toSet(), counts.keys)
-    assertEquals(630, counts[WorkingClawStance.Default])
-    assertEquals(190, counts[WorkingClawStance.Southpaw])
+    assertEquals(550, counts[WorkingClawStance.Default])
+    assertEquals(180, counts[WorkingClawStance.Southpaw])
     assertEquals(50, counts[WorkingClawStance.Flurry])
     assertEquals(40, counts[WorkingClawStance.Spin])
     assertEquals(30, counts[WorkingClawStance.Shadowbox])
     assertEquals(20, counts[WorkingClawStance.Backflip])
     assertEquals(20, counts[WorkingClawStance.Zen])
-    assertEquals(10, counts[WorkingClawStance.Drummer])
-    assertEquals(10, counts[WorkingClawStance.Peekaboo])
+    assertEquals(20, counts[WorkingClawStance.Drummer])
+    assertEquals(20, counts[WorkingClawStance.Peekaboo])
+    assertEquals(20, counts[WorkingClawStance.NodOff])
+    assertEquals(20, counts[WorkingClawStance.Curious])
+    assertEquals(20, counts[WorkingClawStance.OmNom])
+    assertEquals(10, counts[WorkingClawStance.FakeOut])
   }
 
   @Test
@@ -83,6 +87,35 @@ class ChatWorkingIndicatorTest {
       translationYDp = -1.5f,
       scale = 1.06f,
       jawRotation = -28f,
+    )
+
+    assertEquals(3_600L, workingClawCycleMs(WorkingClawStance.NodOff))
+    assertPose(
+      workingClawPose(WorkingClawStance.NodOff, 0.64f),
+      rotationZ = -3f,
+      translationYDp = -0.5f,
+      jawRotation = -6f,
+    )
+
+    assertEquals(2_400L, workingClawCycleMs(WorkingClawStance.Curious))
+    assertPose(
+      workingClawPose(WorkingClawStance.Curious, 0.40f),
+      rotationZ = -14f,
+      jawRotation = -16f,
+    )
+
+    assertEquals(2_400L, workingClawCycleMs(WorkingClawStance.OmNom))
+    assertPose(
+      workingClawPose(WorkingClawStance.OmNom, 0.36f),
+      translationXDp = 2.5f,
+      jawRotation = 8f,
+    )
+
+    assertEquals(2_400L, workingClawCycleMs(WorkingClawStance.FakeOut))
+    assertPose(
+      workingClawPose(WorkingClawStance.FakeOut, 0.58f),
+      rotationZ = 3f,
+      jawRotation = 4f,
     )
   }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingClawView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingClawView.swift
@@ -176,6 +176,105 @@ enum ChatWorkingClawMotion {
         ChatWorkingClawKeyframe(progress: 0.86, value: -10),
         ChatWorkingClawKeyframe(progress: 1, value: -10),
     ]
+    private static let nodOffBodyRotation = [
+        ChatWorkingClawKeyframe(progress: 0, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.10, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.35, value: 10),
+        ChatWorkingClawKeyframe(progress: 0.55, value: 14),
+        ChatWorkingClawKeyframe(progress: 0.60, value: 15),
+        ChatWorkingClawKeyframe(progress: 0.64, value: -3),
+        ChatWorkingClawKeyframe(progress: 0.70, value: 0),
+        ChatWorkingClawKeyframe(progress: 1, value: 0),
+    ]
+    private static let nodOffY = [
+        ChatWorkingClawKeyframe(progress: 0, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.10, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.35, value: 1),
+        ChatWorkingClawKeyframe(progress: 0.60, value: 1.5),
+        ChatWorkingClawKeyframe(progress: 0.64, value: -0.5),
+        ChatWorkingClawKeyframe(progress: 0.70, value: 0),
+        ChatWorkingClawKeyframe(progress: 1, value: 0),
+    ]
+    private static let nodOffJaw = [
+        ChatWorkingClawKeyframe(progress: 0, value: -10),
+        ChatWorkingClawKeyframe(progress: 0.10, value: -10),
+        ChatWorkingClawKeyframe(progress: 0.35, value: -16),
+        ChatWorkingClawKeyframe(progress: 0.60, value: -21),
+        ChatWorkingClawKeyframe(progress: 0.64, value: -6),
+        ChatWorkingClawKeyframe(progress: 0.70, value: -24),
+        ChatWorkingClawKeyframe(progress: 0.74, value: 4),
+        ChatWorkingClawKeyframe(progress: 0.80, value: -22),
+        ChatWorkingClawKeyframe(progress: 0.84, value: 4),
+        ChatWorkingClawKeyframe(progress: 0.90, value: -10),
+        ChatWorkingClawKeyframe(progress: 1, value: -10),
+    ]
+    private static let curiousBodyRotation = [
+        ChatWorkingClawKeyframe(progress: 0, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.30, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.40, value: -14),
+        ChatWorkingClawKeyframe(progress: 0.62, value: -14),
+        ChatWorkingClawKeyframe(progress: 0.70, value: 4),
+        ChatWorkingClawKeyframe(progress: 0.76, value: 0),
+        ChatWorkingClawKeyframe(progress: 1, value: 0),
+    ]
+    private static let curiousJaw = [
+        ChatWorkingClawKeyframe(progress: 0, value: -10),
+        ChatWorkingClawKeyframe(progress: 0.30, value: -10),
+        ChatWorkingClawKeyframe(progress: 0.40, value: -16),
+        ChatWorkingClawKeyframe(progress: 0.62, value: -16),
+        ChatWorkingClawKeyframe(progress: 0.70, value: -6),
+        ChatWorkingClawKeyframe(progress: 0.76, value: -10),
+        ChatWorkingClawKeyframe(progress: 1, value: -10),
+    ]
+    private static let omNomX = [
+        ChatWorkingClawKeyframe(progress: 0, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.30, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.36, value: 2.5),
+        ChatWorkingClawKeyframe(progress: 0.40, value: 1),
+        ChatWorkingClawKeyframe(progress: 0.46, value: 2.5),
+        ChatWorkingClawKeyframe(progress: 0.50, value: 1),
+        ChatWorkingClawKeyframe(progress: 0.56, value: 2.5),
+        ChatWorkingClawKeyframe(progress: 0.64, value: 0),
+        ChatWorkingClawKeyframe(progress: 1, value: 0),
+    ]
+    private static let omNomJaw = [
+        ChatWorkingClawKeyframe(progress: 0, value: -10),
+        ChatWorkingClawKeyframe(progress: 0.26, value: -10),
+        ChatWorkingClawKeyframe(progress: 0.30, value: -30),
+        ChatWorkingClawKeyframe(progress: 0.36, value: 8),
+        ChatWorkingClawKeyframe(progress: 0.42, value: -30),
+        ChatWorkingClawKeyframe(progress: 0.46, value: 8),
+        ChatWorkingClawKeyframe(progress: 0.52, value: -30),
+        ChatWorkingClawKeyframe(progress: 0.56, value: 8),
+        ChatWorkingClawKeyframe(progress: 0.64, value: -10),
+        ChatWorkingClawKeyframe(progress: 1, value: -10),
+    ]
+    private static let fakeOutBodyRotation = [
+        ChatWorkingClawKeyframe(progress: 0, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.06, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.10, value: -4),
+        ChatWorkingClawKeyframe(progress: 0.55, value: -4),
+        ChatWorkingClawKeyframe(progress: 0.58, value: 3),
+        ChatWorkingClawKeyframe(progress: 0.62, value: -4),
+        ChatWorkingClawKeyframe(progress: 0.66, value: 3),
+        ChatWorkingClawKeyframe(progress: 0.70, value: -4),
+        ChatWorkingClawKeyframe(progress: 0.74, value: 3),
+        ChatWorkingClawKeyframe(progress: 0.80, value: 0),
+        ChatWorkingClawKeyframe(progress: 1, value: 0),
+    ]
+    private static let fakeOutJaw = [
+        ChatWorkingClawKeyframe(progress: 0, value: -10),
+        ChatWorkingClawKeyframe(progress: 0.06, value: -10),
+        ChatWorkingClawKeyframe(progress: 0.10, value: -26),
+        ChatWorkingClawKeyframe(progress: 0.55, value: -26),
+        ChatWorkingClawKeyframe(progress: 0.58, value: 4),
+        ChatWorkingClawKeyframe(progress: 0.62, value: -24),
+        ChatWorkingClawKeyframe(progress: 0.66, value: 4),
+        ChatWorkingClawKeyframe(progress: 0.70, value: -22),
+        ChatWorkingClawKeyframe(progress: 0.74, value: 4),
+        ChatWorkingClawKeyframe(progress: 0.80, value: -10),
+        ChatWorkingClawKeyframe(progress: 1, value: -10),
+    ]
 
     static func pose(stance: ChatWorkingClawStance, elapsed: TimeInterval) -> ChatWorkingClawPose {
         let duration: TimeInterval = switch stance {
@@ -183,6 +282,7 @@ enum ChatWorkingClawMotion {
         case .spin: 3.6
         case .zen: 6
         case .drummer: 1.2
+        case .nodOff: 3.6
         default: 2.4
         }
         let progress = max(0, elapsed).truncatingRemainder(dividingBy: duration) / duration
@@ -228,6 +328,19 @@ enum ChatWorkingClawMotion {
             pose.yOffset = self.sample(self.peekabooY, at: progress)
             pose.bodyScale = self.sample(self.peekabooScale, at: progress)
             pose.jawRotation = self.sample(self.peekabooJaw, at: progress)
+        case .nodOff:
+            pose.bodyRotation = self.sample(self.nodOffBodyRotation, at: progress)
+            pose.yOffset = self.sample(self.nodOffY, at: progress)
+            pose.jawRotation = self.sample(self.nodOffJaw, at: progress)
+        case .curious:
+            pose.bodyRotation = self.sample(self.curiousBodyRotation, at: progress)
+            pose.jawRotation = self.sample(self.curiousJaw, at: progress)
+        case .omNom:
+            pose.xOffset = self.sample(self.omNomX, at: progress)
+            pose.jawRotation = self.sample(self.omNomJaw, at: progress)
+        case .fakeOut:
+            pose.bodyRotation = self.sample(self.fakeOutBodyRotation, at: progress)
+            pose.jawRotation = self.sample(self.fakeOutJaw, at: progress)
         }
         return pose
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift
@@ -10,17 +10,25 @@ enum ChatWorkingClawStance: CaseIterable, Equatable, Sendable {
     case zen
     case drummer
     case peekaboo
+    case nodOff
+    case curious
+    case omNom
+    case fakeOut
 
     static let weightedStances: [(stance: Self, weight: Double)] = [
-        (.standard, 63),
-        (.southpaw, 19),
+        (.standard, 55),
+        (.southpaw, 18),
         (.flurry, 5),
         (.spin, 4),
         (.shadowbox, 3),
         (.backflip, 2),
         (.zen, 2),
-        (.drummer, 1),
-        (.peekaboo, 1),
+        (.drummer, 2),
+        (.peekaboo, 2),
+        (.nodOff, 2),
+        (.curious, 2),
+        (.omNom, 2),
+        (.fakeOut, 1),
     ]
 
     static func seeded(_ key: String, salt: UInt32) -> Self {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatWorkingProgressTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatWorkingProgressTests.swift
@@ -14,13 +14,13 @@ struct ChatWorkingProgressTests {
         #expect(first == ChatWorkingClawStance.seeded(run, salt: salt))
         #expect(first == .southpaw)
         #expect(ChatWorkingClawStance.seeded("run-a", salt: salt) == .standard)
-        #expect(ChatWorkingClawStance.seeded("run-21", salt: salt) == .spin)
+        #expect(ChatWorkingClawStance.seeded("run-6", salt: salt) == .spin)
     }
 
     @Test func `stance weights total one hundred and match the allowlist`() {
         let weightedStances = ChatWorkingClawStance.weightedStances
         #expect(weightedStances.reduce(0) { $0 + $1.weight } == 100)
-        #expect(weightedStances.map(\.weight) == [63, 19, 5, 4, 3, 2, 2, 1, 1])
+        #expect(weightedStances.map(\.weight) == [55, 18, 5, 4, 3, 2, 2, 2, 2, 2, 2, 2, 1])
         #expect(weightedStances.map(\.stance) == [
             .standard,
             .southpaw,
@@ -31,15 +31,23 @@ struct ChatWorkingProgressTests {
             .zen,
             .drummer,
             .peekaboo,
+            .nodOff,
+            .curious,
+            .omNom,
+            .fakeOut,
         ])
         #expect(weightedStances.map(\.stance) == ChatWorkingClawStance.allCases)
     }
 
-    @Test func `new rare stances are selectable`() {
+    @Test func `rare stances are selectable`() {
         let salt: UInt32 = 0xA1B2_C3D4
-        #expect(ChatWorkingClawStance.seeded("run-10", salt: salt) == .zen)
-        #expect(ChatWorkingClawStance.seeded("run-299", salt: salt) == .drummer)
-        #expect(ChatWorkingClawStance.seeded("run-22", salt: salt) == .peekaboo)
+        #expect(ChatWorkingClawStance.seeded("run-38", salt: salt) == .zen)
+        #expect(ChatWorkingClawStance.seeded("run-21", salt: salt) == .drummer)
+        #expect(ChatWorkingClawStance.seeded("run-8", salt: salt) == .peekaboo)
+        #expect(ChatWorkingClawStance.seeded("run-15", salt: salt) == .nodOff)
+        #expect(ChatWorkingClawStance.seeded("run-10", salt: salt) == .curious)
+        #expect(ChatWorkingClawStance.seeded("run-24", salt: salt) == .omNom)
+        #expect(ChatWorkingClawStance.seeded("run-22", salt: salt) == .fakeOut)
     }
 
     @Test func `zen samples the breath and deliberate snip keyframes`() {
@@ -100,6 +108,31 @@ struct ChatWorkingProgressTests {
         ] {
             let pose = ChatWorkingClawMotion.pose(stance: .peekaboo, elapsed: elapsed)
             self.expectClose(pose.jawRotation, jaw)
+        }
+    }
+
+    @Test func `latest rare stances sample their defining beats`() {
+        let samples: [(
+            stance: ChatWorkingClawStance,
+            elapsed: TimeInterval,
+            bodyRotation: CGFloat,
+            xOffset: CGFloat,
+            yOffset: CGFloat,
+            jawRotation: CGFloat
+        )] = [
+            (.nodOff, 2.304, -3, 0, -0.5, -6),
+            (.curious, 0.96, -14, 0, 0, -16),
+            (.omNom, 0.864, 0, 2.5, 0, 8),
+            (.fakeOut, 1.392, 3, 0, 0, 4),
+        ]
+
+        for sample in samples {
+            let pose = ChatWorkingClawMotion.pose(stance: sample.stance, elapsed: sample.elapsed)
+            self.expectClose(pose.bodyRotation, sample.bodyRotation)
+            self.expectClose(pose.xOffset, sample.xOffset)
+            self.expectClose(pose.yOffset, sample.yOffset)
+            self.expectClose(pose.jawRotation, sample.jawRotation)
+            #expect(pose.bodyScale == 1)
         }
     }
 

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -15,7 +15,7 @@ import {
   renderMessageGroup,
   renderStreamGroup,
 } from "./chat-message.ts";
-import { SURPRISE_CLASSES } from "./chat-working-indicator-surprise.ts";
+import { selectWorkingClawSurprise } from "./chat-working-indicator-surprise.ts";
 import { renderTurnRecapRow } from "./chat-working-indicator.ts";
 
 const localStorageValues = new Map<string, string>();
@@ -1703,11 +1703,10 @@ describe("grouped chat rendering", () => {
     const first = surpriseFor("stream:agent:main:pending");
     // Stable across re-renders: the same key keeps the same surprise decision.
     expect(surpriseFor("stream:agent:main:pending")).toEqual(first);
-    // At most one surprise modifier; plain in-place clawing is the unmarked default.
-    expect(first.length).toBeLessThanOrEqual(1);
-    for (const cls of first) {
-      expect(SURPRISE_CLASSES).toContain(cls);
-    }
+    // The render must route exactly the picker's seeded decision — nothing
+    // extra, nothing hand-rolled — so new stances can never drift this test.
+    const decision = selectWorkingClawSurprise("stream:agent:main:pending");
+    expect(first).toEqual(decision ? [decision] : []);
   });
 
   it("keeps the synthetic progress word screen-reader-only across runs", () => {

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -15,6 +15,7 @@ import {
   renderMessageGroup,
   renderStreamGroup,
 } from "./chat-message.ts";
+import { SURPRISE_CLASSES } from "./chat-working-indicator-surprise.ts";
 import { renderTurnRecapRow } from "./chat-working-indicator.ts";
 
 const localStorageValues = new Map<string, string>();
@@ -1705,16 +1706,7 @@ describe("grouped chat rendering", () => {
     // At most one surprise modifier; plain in-place clawing is the unmarked default.
     expect(first.length).toBeLessThanOrEqual(1);
     for (const cls of first) {
-      expect([
-        "chat-reading-indicator--southpaw",
-        "chat-reading-indicator--flurry",
-        "chat-reading-indicator--spin",
-        "chat-reading-indicator--shadowbox",
-        "chat-reading-indicator--backflip",
-        "chat-reading-indicator--zen",
-        "chat-reading-indicator--drummer",
-        "chat-reading-indicator--peekaboo",
-      ]).toContain(cls);
+      expect(SURPRISE_CLASSES).toContain(cls);
     }
   });
 

--- a/ui/src/pages/chat/components/chat-working-indicator-surprise.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator-surprise.ts
@@ -2,7 +2,7 @@ import { fnv1aUtf16 } from "../../../lib/fnv1a.ts";
 
 // One salt per page load keeps each run stable while varying the surprise between visits.
 const SURPRISE_SALT = Math.trunc(Math.random() * 0xffffffff);
-const SURPRISE_CHANCE_PER_THOUSAND = 30;
+const SURPRISE_CHANCE_PER_THOUSAND = 50;
 const SURPRISE_CLASSES = [
   "chat-reading-indicator--southpaw",
   "chat-reading-indicator--flurry",
@@ -12,6 +12,10 @@ const SURPRISE_CLASSES = [
   "chat-reading-indicator--zen",
   "chat-reading-indicator--drummer",
   "chat-reading-indicator--peekaboo",
+  "chat-reading-indicator--nodoff",
+  "chat-reading-indicator--curious",
+  "chat-reading-indicator--omnom",
+  "chat-reading-indicator--fakeout",
 ] as const;
 
 export function selectWorkingClawSurprise(

--- a/ui/src/pages/chat/components/chat-working-indicator-surprise.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator-surprise.ts
@@ -3,7 +3,7 @@ import { fnv1aUtf16 } from "../../../lib/fnv1a.ts";
 // One salt per page load keeps each run stable while varying the surprise between visits.
 const SURPRISE_SALT = Math.trunc(Math.random() * 0xffffffff);
 const SURPRISE_CHANCE_PER_THOUSAND = 50;
-export const SURPRISE_CLASSES = [
+const SURPRISE_CLASSES = [
   "chat-reading-indicator--southpaw",
   "chat-reading-indicator--flurry",
   "chat-reading-indicator--spin",

--- a/ui/src/pages/chat/components/chat-working-indicator-surprise.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator-surprise.ts
@@ -3,7 +3,7 @@ import { fnv1aUtf16 } from "../../../lib/fnv1a.ts";
 // One salt per page load keeps each run stable while varying the surprise between visits.
 const SURPRISE_SALT = Math.trunc(Math.random() * 0xffffffff);
 const SURPRISE_CHANCE_PER_THOUSAND = 50;
-const SURPRISE_CLASSES = [
+export const SURPRISE_CLASSES = [
   "chat-reading-indicator--southpaw",
   "chat-reading-indicator--flurry",
   "chat-reading-indicator--spin",

--- a/ui/src/pages/chat/components/chat-working-indicator.test.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.test.ts
@@ -1,7 +1,23 @@
 import { render } from "lit";
 import { describe, expect, it } from "vitest";
-import { SURPRISE_CLASSES, selectWorkingClawSurprise } from "./chat-working-indicator-surprise.ts";
+import { selectWorkingClawSurprise } from "./chat-working-indicator-surprise.ts";
 import { renderChatWorkingIndicator } from "./chat-working-indicator.ts";
+
+// The picker's spec: every seeded surprise must come from this fixed rotation.
+const SURPRISE_CLASSES = [
+  "chat-reading-indicator--southpaw",
+  "chat-reading-indicator--flurry",
+  "chat-reading-indicator--spin",
+  "chat-reading-indicator--shadowbox",
+  "chat-reading-indicator--backflip",
+  "chat-reading-indicator--zen",
+  "chat-reading-indicator--drummer",
+  "chat-reading-indicator--peekaboo",
+  "chat-reading-indicator--nodoff",
+  "chat-reading-indicator--curious",
+  "chat-reading-indicator--omnom",
+  "chat-reading-indicator--fakeout",
+] as const;
 
 // The keyed sample is deterministic for a fixed salt, so the rarity and spread
 // assertions below are exact re-runs, not statistical flakes.

--- a/ui/src/pages/chat/components/chat-working-indicator.test.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.test.ts
@@ -1,22 +1,7 @@
 import { render } from "lit";
 import { describe, expect, it } from "vitest";
-import { selectWorkingClawSurprise } from "./chat-working-indicator-surprise.ts";
+import { SURPRISE_CLASSES, selectWorkingClawSurprise } from "./chat-working-indicator-surprise.ts";
 import { renderChatWorkingIndicator } from "./chat-working-indicator.ts";
-
-const SURPRISE_CLASSES = [
-  "chat-reading-indicator--southpaw",
-  "chat-reading-indicator--flurry",
-  "chat-reading-indicator--spin",
-  "chat-reading-indicator--shadowbox",
-  "chat-reading-indicator--backflip",
-  "chat-reading-indicator--zen",
-  "chat-reading-indicator--drummer",
-  "chat-reading-indicator--peekaboo",
-  "chat-reading-indicator--nodoff",
-  "chat-reading-indicator--curious",
-  "chat-reading-indicator--omnom",
-  "chat-reading-indicator--fakeout",
-] as const;
 
 // The keyed sample is deterministic for a fixed salt, so the rarity and spread
 // assertions below are exact re-runs, not statistical flakes.

--- a/ui/src/pages/chat/components/chat-working-indicator.test.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.test.ts
@@ -12,6 +12,10 @@ const SURPRISE_CLASSES = [
   "chat-reading-indicator--zen",
   "chat-reading-indicator--drummer",
   "chat-reading-indicator--peekaboo",
+  "chat-reading-indicator--nodoff",
+  "chat-reading-indicator--curious",
+  "chat-reading-indicator--omnom",
+  "chat-reading-indicator--fakeout",
 ] as const;
 
 // The keyed sample is deterministic for a fixed salt, so the rarity and spread
@@ -33,9 +37,9 @@ describe("selectWorkingClawSurprise", () => {
   it("keeps surprises rare, deterministic, and spread across every move", () => {
     const surprises = sampleDecisions.filter(Boolean);
 
-    // ~3% target: SURPRISE_CHANCE_PER_THOUSAND=30 over 10k keys lands near 300.
-    expect(surprises.length).toBeGreaterThan(200);
-    expect(surprises.length).toBeLessThan(400);
+    // ~5% target: SURPRISE_CHANCE_PER_THOUSAND=50 over 10k keys lands near 500.
+    expect(surprises.length).toBeGreaterThan(400);
+    expect(surprises.length).toBeLessThan(600);
     expect(selectWorkingClawSurprise("run:42", { salt: SAMPLE_SALT })).toBe(
       selectWorkingClawSurprise("run:42", { salt: SAMPLE_SALT }),
     );

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -1400,6 +1400,54 @@
     chatWorkingClawPeekabooJaw 1.2s ease-out var(--claw-surprise-delay) 1;
 }
 
+.chat-reading-indicator--nodoff svg {
+  animation:
+    chatWorkingClawFlex var(--claw-cycle) ease-out infinite,
+    chatWorkingClawNodOff 2.8s ease-out var(--claw-surprise-delay) 1;
+}
+
+.chat-reading-indicator--nodoff svg .claw-icon__jaw {
+  animation:
+    chatWorkingClawSnip var(--claw-cycle) ease-out infinite,
+    chatWorkingClawNodOffJaw 2.8s ease-out var(--claw-surprise-delay) 1;
+}
+
+.chat-reading-indicator--curious svg {
+  animation:
+    chatWorkingClawFlex var(--claw-cycle) ease-out infinite,
+    chatWorkingClawCurious 1.8s ease-out var(--claw-surprise-delay) 1;
+}
+
+.chat-reading-indicator--curious svg .claw-icon__jaw {
+  animation:
+    chatWorkingClawSnip var(--claw-cycle) ease-out infinite,
+    chatWorkingClawCuriousJaw 1.8s ease-out var(--claw-surprise-delay) 1;
+}
+
+.chat-reading-indicator--omnom svg {
+  animation:
+    chatWorkingClawFlex var(--claw-cycle) ease-out infinite,
+    chatWorkingClawOmNom 1.8s ease-out var(--claw-surprise-delay) 1;
+}
+
+.chat-reading-indicator--omnom svg .claw-icon__jaw {
+  animation:
+    chatWorkingClawSnip var(--claw-cycle) ease-out infinite,
+    chatWorkingClawOmNomJaw 1.8s ease-out var(--claw-surprise-delay) 1;
+}
+
+.chat-reading-indicator--fakeout svg {
+  animation:
+    chatWorkingClawFlex var(--claw-cycle) ease-out infinite,
+    chatWorkingClawFakeOut 2.4s ease-out var(--claw-surprise-delay) 1;
+}
+
+.chat-reading-indicator--fakeout svg .claw-icon__jaw {
+  animation:
+    chatWorkingClawSnip var(--claw-cycle) ease-out infinite,
+    chatWorkingClawFakeOutJaw 2.4s ease-out var(--claw-surprise-delay) 1;
+}
+
 @keyframes chatWorkingClawSouthpaw {
   0%,
   100% {
@@ -1577,6 +1625,274 @@
   }
 
   86%,
+  100% {
+    transform: rotate(-10deg);
+  }
+}
+
+/* Nodoff body: droop through 60%, jolt awake at 64%, then settle by 70%.
+   Translation stays first so the sleepy dip remains vertical. */
+@keyframes chatWorkingClawNodOff {
+  0%,
+  10% {
+    transform: translateY(0) rotate(0deg);
+  }
+
+  35% {
+    transform: translateY(1px) rotate(10deg);
+  }
+
+  55% {
+    transform: translateY(1.4px) rotate(14deg);
+  }
+
+  60% {
+    transform: translateY(1.5px) rotate(15deg);
+  }
+
+  64% {
+    transform: translateY(-0.5px) rotate(-3deg);
+  }
+
+  70%,
+  100% {
+    transform: translateY(0) rotate(0deg);
+  }
+}
+
+/* Nodoff jaw: slackens during the droop, then wakes for guilty snips at
+   74% and 84%. */
+@keyframes chatWorkingClawNodOffJaw {
+  0%,
+  10% {
+    transform: rotate(-10deg);
+  }
+
+  35% {
+    transform: rotate(-16deg);
+  }
+
+  60% {
+    transform: rotate(-21deg);
+  }
+
+  64% {
+    transform: rotate(-6deg);
+  }
+
+  70% {
+    transform: rotate(-24deg);
+  }
+
+  74% {
+    transform: rotate(4deg);
+  }
+
+  80% {
+    transform: rotate(-22deg);
+  }
+
+  84% {
+    transform: rotate(4deg);
+  }
+
+  90%,
+  100% {
+    transform: rotate(-10deg);
+  }
+}
+
+/* Curious body: tilt into the question at 40%, hold through 62%, then
+   spring past center at 70% before settling. */
+@keyframes chatWorkingClawCurious {
+  0%,
+  30% {
+    transform: rotate(0deg);
+  }
+
+  40%,
+  62% {
+    transform: rotate(-14deg);
+  }
+
+  70% {
+    transform: rotate(4deg);
+  }
+
+  76%,
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+/* Curious jaw: tuck at the 40-62% head tilt, then pop open on the 70%
+   overshoot before returning to rest. */
+@keyframes chatWorkingClawCuriousJaw {
+  0%,
+  30% {
+    transform: rotate(-10deg);
+  }
+
+  40%,
+  62% {
+    transform: rotate(-16deg);
+  }
+
+  70% {
+    transform: rotate(-6deg);
+  }
+
+  76%,
+  100% {
+    transform: rotate(-10deg);
+  }
+}
+
+/* Om nom body: three tiny forward lunges land at 36%, 46%, and 56%,
+   then the claw slides home by 64%. */
+@keyframes chatWorkingClawOmNom {
+  0%,
+  30% {
+    transform: translateX(0);
+  }
+
+  36% {
+    transform: translateX(2.5px);
+  }
+
+  40% {
+    transform: translateX(1px);
+  }
+
+  46% {
+    transform: translateX(2.5px);
+  }
+
+  50% {
+    transform: translateX(1px);
+  }
+
+  56% {
+    transform: translateX(2.5px);
+  }
+
+  64%,
+  100% {
+    transform: translateX(0);
+  }
+}
+
+/* Om nom jaw: wide wind-ups at 30%, 42%, and 52% snap into three fast
+   chomps at 36%, 46%, and 56%. */
+@keyframes chatWorkingClawOmNomJaw {
+  0%,
+  26% {
+    transform: rotate(-10deg);
+  }
+
+  30% {
+    transform: rotate(-30deg);
+  }
+
+  36% {
+    transform: rotate(8deg);
+  }
+
+  42% {
+    transform: rotate(-30deg);
+  }
+
+  46% {
+    transform: rotate(8deg);
+  }
+
+  52% {
+    transform: rotate(-30deg);
+  }
+
+  56% {
+    transform: rotate(8deg);
+  }
+
+  64%,
+  100% {
+    transform: rotate(-10deg);
+  }
+}
+
+/* Fakeout body: wind up at 10%, freeze through 55%, then recoil across
+   the triple-snip hits at 58%, 66%, and 74%. */
+@keyframes chatWorkingClawFakeOut {
+  0%,
+  6% {
+    transform: rotate(0deg);
+  }
+
+  10%,
+  55% {
+    transform: rotate(-4deg);
+  }
+
+  58% {
+    transform: rotate(3deg);
+  }
+
+  62% {
+    transform: rotate(-4deg);
+  }
+
+  66% {
+    transform: rotate(3deg);
+  }
+
+  70% {
+    transform: rotate(-4deg);
+  }
+
+  74% {
+    transform: rotate(3deg);
+  }
+
+  80%,
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+/* Fakeout jaw: hold the mid-open wind-up from 10-55%, then fire the
+   accelerated triple snip at 58%, 66%, and 74%. */
+@keyframes chatWorkingClawFakeOutJaw {
+  0%,
+  6% {
+    transform: rotate(-10deg);
+  }
+
+  10%,
+  55% {
+    transform: rotate(-26deg);
+  }
+
+  58% {
+    transform: rotate(4deg);
+  }
+
+  62% {
+    transform: rotate(-24deg);
+  }
+
+  66% {
+    transform: rotate(4deg);
+  }
+
+  70% {
+    transform: rotate(-22deg);
+  }
+
+  74% {
+    transform: rotate(4deg);
+  }
+
+  80%,
   100% {
     transform: rotate(-10deg);
   }


### PR DESCRIPTION
## What Problem This Solves

The working-claw indicator picked from eight seeded rare stances, and rares were scarce enough that most operators never saw one (web: 3% one-shot chance; apps: drummer/peekaboo at 1% each). Follow-up to the silhouette redesign in #114939: make the delight loop actually observable and grow the move pool.

## Why This Change Was Made

Adds four pose-only stances designed as shared phase→value keyframe tables, ported byte-parallel to all three platforms like the existing set:

- **nodoff** — drowsy 15° droop with slackening jaw, jolt awake, two guilty snips (3.6s native cycle, like zen)
- **curious** — held 14° "hm?" head-tilt, spring back with overshoot
- **omnom** — three fast chomps with ≤2.5px forward lunges that snap back
- **fakeout** — normal wind-up, comedic mid-open freeze, triple-snip at double speed (kept rarest)

Odds: web `SURPRISE_CHANCE_PER_THOUSAND` 30 → 50 (per-stance frequency slightly up despite 8 → 12 classes). Native weight table: standard 63 → 55, southpaw 19 → 18, drummer/peekaboo 1 → 2, newcomers at 2/2/2 and fakeout 1 (sum stays 100). No rig changes: pure keyframe additions on the existing body/jaw channels; reduced-motion and parked behavior untouched. The web tests now assert against the exported `SURPRISE_CLASSES` instead of two hand-copied allowlists (the `chat-message.test.ts` copy would have flaked once new classes could be seeded).

## User Impact

Roughly one in twenty runs shows a rare stance on web (previously ~1 in 33), with twelve moves in rotation on every platform. No API, config, or behavior surface beyond the animation.

## Evidence

- Web: `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-working-indicator.test.ts ui/src/pages/chat/components/chat-message.test.ts` — 2 files, 167 tests passed
- Swift: `swift build` + `swift test --filter ChatWorkingProgressTests` — 27 tests passed
- Android: `./gradlew :app:testPlayDebugUnitTest --tests 'ai.openclaw.app.ui.chat.ChatWorkingIndicatorTest'` — BUILD SUCCESSFUL
- `git diff --check` clean; oxfmt clean; Codex autoreview clean (0.96, no findings)
- Animated visual review: all four stances rendered through the production markup (18px fill + big judging size) and approved by the operator in an interactive harness; keyframes in the diff match the reviewed spec value-for-value
