### PR TITLE
fix(cli): keep QR codes within standard terminal widths

### DIFF
--- a/src/cli/qr-cli.test.ts
+++ b/src/cli/qr-cli.test.ts
@@ -287,7 +287,11 @@ describe("registerQrCli", () => {
 
     await runQr([]);
 
-    expect(renderTerminal).toHaveBeenCalledTimes(1);
+    const expected = encodePairingSetupCode({
+      url: "ws://127.0.0.1:18789",
+      bootstrapToken: "bootstrap-123",
+    });
+    expect(renderTerminal).toHaveBeenCalledWith(expected, { small: true });
     const output = runtimeLog.mock.calls.map((call) => readRuntimeCallText(call)).join("\n");
     expect(output).toContain("Pairing QR");
     expect(output).toContain("ASCII-QR");

--- a/src/cli/qr-cli.ts
+++ b/src/cli/qr-cli.ts
@@ -33,7 +33,7 @@ const LIMITED_TRANSPORT_WARNING =
   "This Gateway URL uses plaintext ws://, so the setup code was limited for safety. Use wss:// or Tailscale Serve, then generate a new code for full access.";
 
 function renderQrAscii(data: string): Promise<string> {
-  return renderQrTerminal(data);
+  return renderQrTerminal(data, { small: true });
 }
 function readDevicePairPublicUrlFromConfig(cfg: OpenClawConfig): string | undefined {
   const value = cfg.plugins?.entries?.["device-pair"]?.config?.["publicUrl"];


### PR DESCRIPTION
Closes #120758

## What Problem This Solves

Fixes an issue where users running `openclaw qr` would receive a 102-column QR code that wraps or clips in common 80-column terminals. OpenClaw stopped using `qrcode`'s compact terminal renderer after its pathological ANSI final row caused scanning failures, but the CLI remained on full blocks after OpenClaw added its own matrix-backed compact renderer.

## Why This Change Was Made

In this PR, only the CLI caller opts into OpenClaw's existing safe compact renderer. The shared renderer default, configuration and environment surfaces, and the pinned `qrcode` dependency remain unchanged; using the dependency's compact output was rejected because it would reintroduce the ANSI behavior that prompted the full-block fallback.

The focused CLI regression test now verifies both the exact generated setup code and `{ small: true }`, so it covers the setup payload passed across the caller boundary as well as the compact-rendering option.

## User Impact

With this PR, `openclaw qr` produces a 51×26 half-block QR code from the same 49×49 matrix. It fits within an 80-column terminal while preserving the setup payload exactly.

## Evidence

### Before

![Before: full-block QR exceeds 80 columns](https://github.com/user-attachments/assets/badf0997-0581-45ef-9443-76fb3fbe69cc)

Pinned `qrcode@1.5.4` full terminal renderer, using the reviewed synthetic reserved-domain fixture in Terminal.app Basic, Menlo Regular 13 pt, 100% zoom, 132×56 cells: 102×51 output from a 49×49 matrix. macOS Vision did not decode this terminal screenshot; a reference PNG decoded successfully, confirming the fixture itself was valid. This is renderer-level baseline evidence rather than an end-to-end CLI capture.

### After

<img width="1205" height="1148" alt="After: compact QR at 132 columns" src="https://github.com/user-attachments/assets/51fd90da-1a08-42d9-a16d-cb693e1c5fe3" />

Final implementation SHA `ed0266ec9821af84b39b1f3e58eb13ccdfda37e9`, with the same synthetic fixture and Terminal.app settings: 51×26 output from the same 49×49 matrix.

<img width="789" height="876" alt="After: compact QR fits an 80-column terminal" src="https://github.com/user-attachments/assets/e019f39e-dbde-4548-bae6-8bb8b48b8ced" />

The 80×40 capture shows the complete QR without horizontal wrap or clipping. The matrix sampled from the 132-column terminal screenshot matched the generated 49×49 dependency matrix with zero mismatches. Its screenshot-derived normalized crop decoded to the exact setup code with `jsQR`, and macOS Vision detected one QR code.

### Validation

- Exact-head Blacksmith Testbox proof at `ed0266ec9821af84b39b1f3e58eb13ccdfda37e9`: 31/31 tests passed across `src/cli/qr-cli.test.ts`, `src/media/qr-terminal.test.ts`, and `src/media/qr-terminal.render.test.ts`.
- The same exact-head Testbox run passed `pnpm check:changed` for the `core` and `coreTests` lanes, including guards, type checks, formatting, and lint. Complete redacted output: [validation log](https://github.com/user-attachments/files/30866789/openclaw-qr-final-proof.log); timing, lease, and checksum metadata: [validation JSON](https://github.com/user-attachments/files/30866790/openclaw-qr-final-proof.json).
- Direct dependency proof: `qrcode@1.5.4` dispatches `small: true` to its ANSI compact renderer; OpenClaw's compact path instead renders directly from `qrcode.create(...).modules`.
- Diff checks and focused formatting passed. Production code is net zero lines; regression coverage is net +4 lines.
