### PR TITLE
refactor(sandbox): move legacy registry migration into doctor

### DIFF
--- a/src/agents/sandbox/registry.test.ts
+++ b/src/agents/sandbox/registry.test.ts
@@ -1,17 +1,9 @@
-// Sandbox registry tests cover legacy registry migration, ordering,
-// and race-safety for container/browser runtime records.
+// Sandbox registry tests cover SQLite ordering and race safety for container/browser runtime records.
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 
-const {
-  TEST_STATE_DIR,
-  PREVIOUS_OPENCLAW_STATE_DIR,
-  SANDBOX_REGISTRY_PATH,
-  SANDBOX_BROWSER_REGISTRY_PATH,
-  SANDBOX_CONTAINERS_DIR,
-  SANDBOX_BROWSERS_DIR,
-} = vi.hoisted(() => {
+const { TEST_STATE_DIR, PREVIOUS_OPENCLAW_STATE_DIR, SANDBOX_REGISTRY_PATH } = vi.hoisted(() => {
   const nodePath = require("node:path");
   const { mkdtempSync } = require("node:fs");
   const { tmpdir } = require("node:os");
@@ -23,25 +15,12 @@ const {
     TEST_STATE_DIR: baseDir,
     PREVIOUS_OPENCLAW_STATE_DIR: previousStateDir,
     SANDBOX_REGISTRY_PATH: nodePath.join(baseDir, "containers.json"),
-    SANDBOX_BROWSER_REGISTRY_PATH: nodePath.join(baseDir, "browsers.json"),
-    SANDBOX_CONTAINERS_DIR: nodePath.join(baseDir, "containers"),
-    SANDBOX_BROWSERS_DIR: nodePath.join(baseDir, "browsers"),
   };
 });
 
-vi.mock("./constants.js", () => ({
-  SANDBOX_STATE_DIR: TEST_STATE_DIR,
-  SANDBOX_REGISTRY_PATH,
-  SANDBOX_BROWSER_REGISTRY_PATH,
-  SANDBOX_CONTAINERS_DIR,
-  SANDBOX_BROWSERS_DIR,
-}));
-
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
-import { hashTextSha256 } from "./hash.js";
 import {
-  migrateLegacySandboxRegistryFiles,
   readBrowserRegistry,
   readRegisteredSandboxRuntimeIds,
   readRegistry,
@@ -54,25 +33,11 @@ import {
 
 type SandboxBrowserRegistryEntry = import("./registry.js").SandboxBrowserRegistryEntry;
 type SandboxRegistryEntry = import("./registry.js").SandboxRegistryEntry;
-type MigrationResult = Awaited<ReturnType<typeof migrateLegacySandboxRegistryFiles>>[number];
-
-async function seedMalformedContainerRegistry(payload: string) {
-  await fs.writeFile(SANDBOX_REGISTRY_PATH, payload, "utf-8");
-}
-
-async function seedMalformedBrowserRegistry(payload: string) {
-  await fs.writeFile(SANDBOX_BROWSER_REGISTRY_PATH, payload, "utf-8");
-}
 
 afterEach(async () => {
   closeOpenClawStateDatabaseForTest();
   await fs.rm(path.join(TEST_STATE_DIR, "state"), { recursive: true, force: true });
-  await fs.rm(SANDBOX_CONTAINERS_DIR, { recursive: true, force: true });
-  await fs.rm(SANDBOX_BROWSERS_DIR, { recursive: true, force: true });
   await fs.rm(SANDBOX_REGISTRY_PATH, { force: true });
-  await fs.rm(SANDBOX_BROWSER_REGISTRY_PATH, { force: true });
-  await fs.rm(`${SANDBOX_REGISTRY_PATH}.lock`, { force: true });
-  await fs.rm(`${SANDBOX_BROWSER_REGISTRY_PATH}.lock`, { force: true });
 });
 
 afterAll(async () => {
@@ -110,48 +75,6 @@ function containerEntry(overrides: Partial<SandboxRegistryEntry> = {}): SandboxR
   };
 }
 
-async function seedContainerRegistry(entries: SandboxRegistryEntry[]) {
-  await fs.writeFile(SANDBOX_REGISTRY_PATH, `${JSON.stringify({ entries }, null, 2)}\n`, "utf-8");
-}
-
-async function seedBrowserRegistry(entries: SandboxBrowserRegistryEntry[]) {
-  await fs.writeFile(
-    SANDBOX_BROWSER_REGISTRY_PATH,
-    `${JSON.stringify({ entries }, null, 2)}\n`,
-    "utf-8",
-  );
-}
-
-async function seedShardedContainerRegistry(entries: SandboxRegistryEntry[]) {
-  await fs.mkdir(SANDBOX_CONTAINERS_DIR, { recursive: true });
-  for (const entry of entries) {
-    await fs.writeFile(
-      path.join(SANDBOX_CONTAINERS_DIR, `${hashTextSha256(entry.containerName)}.json`),
-      `${JSON.stringify(entry, null, 2)}\n`,
-      "utf-8",
-    );
-  }
-}
-
-async function seedShardedBrowserRegistry(entries: SandboxBrowserRegistryEntry[]) {
-  await fs.mkdir(SANDBOX_BROWSERS_DIR, { recursive: true });
-  for (const entry of entries) {
-    await fs.writeFile(
-      path.join(SANDBOX_BROWSERS_DIR, `${hashTextSha256(entry.containerName)}.json`),
-      `${JSON.stringify(entry, null, 2)}\n`,
-      "utf-8",
-    );
-  }
-}
-
-async function seedStaleLock(lockPath: string) {
-  await fs.writeFile(
-    lockPath,
-    `${JSON.stringify({ pid: 999_999_999, createdAt: "2000-01-01T00:00:00.000Z" })}\n`,
-    "utf-8",
-  );
-}
-
 async function expectPathMissing(targetPath: string): Promise<void> {
   try {
     await fs.access(targetPath);
@@ -162,173 +85,21 @@ async function expectPathMissing(targetPath: string): Promise<void> {
   }
 }
 
-function requireMigrationResult(
-  results: readonly MigrationResult[],
-  kind: MigrationResult["kind"],
-): MigrationResult {
-  const result = results.find((candidate) => candidate.kind === kind);
-  if (!result) {
-    throw new Error(`expected migration result for ${kind}`);
-  }
-  return result;
-}
-
 describe("registry race safety", () => {
   it("does not migrate legacy registry files from runtime reads", async () => {
     // Runtime reads should ignore old monolithic files; explicit doctor/repair
     // owns migration so normal startup cannot mutate registry layout.
-    await seedContainerRegistry([containerEntry({ containerName: "legacy-container" })]);
+    const legacyEntry = containerEntry({ containerName: "legacy-container" });
+    await fs.writeFile(
+      SANDBOX_REGISTRY_PATH,
+      `${JSON.stringify({ entries: [legacyEntry] }, null, 2)}\n`,
+      "utf-8",
+    );
 
     await expect(readRegistry()).resolves.toEqual({ entries: [] });
     await expect(readRegistryEntry("legacy-container")).resolves.toBeNull();
     await expect(fs.access(SANDBOX_REGISTRY_PATH)).resolves.toBeUndefined();
     await expectPathMissing(path.join(TEST_STATE_DIR, "state", "openclaw.sqlite"));
-  });
-
-  it("normalizes legacy registry entries after explicit migration", async () => {
-    await seedContainerRegistry([
-      {
-        containerName: "legacy-container",
-        sessionKey: "agent:main",
-        createdAtMs: 1,
-        lastUsedAtMs: 1,
-        image: "openclaw-sandbox:test",
-      },
-    ]);
-
-    await migrateLegacySandboxRegistryFiles();
-    const registry = await readRegistry();
-    expect(registry.entries).toHaveLength(1);
-    const [entry] = registry.entries;
-    expect(entry?.containerName).toBe("legacy-container");
-    expect(entry?.backendId).toBe("docker");
-    expect(entry?.runtimeLabel).toBe("legacy-container");
-    expect(entry?.configLabelKind).toBe("Image");
-  });
-
-  it("migrates legacy monolithic container and browser registry files after explicit repair", async () => {
-    await seedContainerRegistry([
-      containerEntry({
-        containerName: "legacy-container",
-        sessionKey: "agent:legacy",
-        lastUsedAtMs: 7,
-        configHash: "legacy-container-hash",
-      }),
-    ]);
-    await seedBrowserRegistry([
-      browserEntry({
-        containerName: "legacy-browser",
-        sessionKey: "agent:legacy",
-        cdpPort: 9333,
-        noVncPort: 6081,
-        configHash: "legacy-browser-hash",
-      }),
-    ]);
-    await seedStaleLock(`${SANDBOX_REGISTRY_PATH}.lock`);
-    await seedStaleLock(`${SANDBOX_BROWSER_REGISTRY_PATH}.lock`);
-
-    const migrationResults = await migrateLegacySandboxRegistryFiles();
-    const containerMigration = requireMigrationResult(migrationResults, "containers");
-    const browserMigration = requireMigrationResult(migrationResults, "browsers");
-    expect(containerMigration.status).toBe("migrated");
-    expect(containerMigration.entries).toBe(1);
-    expect(browserMigration.status).toBe("migrated");
-    expect(browserMigration.entries).toBe(1);
-
-    await expectPathMissing(SANDBOX_REGISTRY_PATH);
-    await expectPathMissing(SANDBOX_BROWSER_REGISTRY_PATH);
-    await expectPathMissing(`${SANDBOX_REGISTRY_PATH}.lock`);
-    await expectPathMissing(`${SANDBOX_BROWSER_REGISTRY_PATH}.lock`);
-    const containerRegistry = await readRegistry();
-    expect(containerRegistry.entries).toHaveLength(1);
-    const [container] = containerRegistry.entries;
-    expect(container?.containerName).toBe("legacy-container");
-    expect(container?.backendId).toBe("docker");
-    expect(container?.runtimeLabel).toBe("legacy-container");
-    expect(container?.sessionKey).toBe("agent:legacy");
-    expect(container?.configHash).toBe("legacy-container-hash");
-    const browserRegistry = await readBrowserRegistry();
-    expect(browserRegistry.entries).toHaveLength(1);
-    const [browser] = browserRegistry.entries;
-    expect(browser?.containerName).toBe("legacy-browser");
-    expect(browser?.sessionKey).toBe("agent:legacy");
-    expect(browser?.cdpPort).toBe(9333);
-    expect(browser?.noVncPort).toBe(6081);
-    expect(browser?.configHash).toBe("legacy-browser-hash");
-  });
-
-  it("migrates legacy sharded container and browser registry files after explicit repair", async () => {
-    await seedShardedContainerRegistry([
-      containerEntry({
-        containerName: "legacy-container",
-        sessionKey: "agent:legacy",
-        lastUsedAtMs: 7,
-        configHash: "legacy-container-hash",
-      }),
-    ]);
-    await seedShardedBrowserRegistry([
-      browserEntry({
-        containerName: "legacy-browser",
-        sessionKey: "agent:legacy",
-        cdpPort: 9333,
-        noVncPort: 6081,
-        configHash: "legacy-browser-hash",
-      }),
-    ]);
-
-    const migrationResults = await migrateLegacySandboxRegistryFiles();
-    expect(requireMigrationResult(migrationResults, "containers").status).toBe("migrated");
-    expect(requireMigrationResult(migrationResults, "browsers").status).toBe("migrated");
-    await expectPathMissing(SANDBOX_CONTAINERS_DIR);
-    await expectPathMissing(SANDBOX_BROWSERS_DIR);
-    expect((await readRegistry()).entries[0]?.containerName).toBe("legacy-container");
-    expect((await readBrowserRegistry()).entries[0]?.containerName).toBe("legacy-browser");
-  });
-
-  it("does not overwrite newer SQLite entries during legacy migration", async () => {
-    await updateRegistry(
-      containerEntry({
-        containerName: "container-a",
-        sessionKey: "new-session",
-        lastUsedAtMs: 10,
-      }),
-    );
-    await seedContainerRegistry([
-      containerEntry({
-        containerName: "container-a",
-        sessionKey: "legacy-session",
-        lastUsedAtMs: 1,
-      }),
-    ]);
-
-    await migrateLegacySandboxRegistryFiles();
-
-    const entry = await readRegistryEntry("container-a");
-    expect(entry?.sessionKey).toBe("new-session");
-    expect(entry?.lastUsedAtMs).toBe(10);
-  });
-
-  it("prefers newer sharded entries over stale monolithic entries during legacy migration", async () => {
-    await seedContainerRegistry([
-      containerEntry({
-        containerName: "container-a",
-        sessionKey: "legacy-session",
-        lastUsedAtMs: 1,
-      }),
-    ]);
-    await seedShardedContainerRegistry([
-      containerEntry({
-        containerName: "container-a",
-        sessionKey: "sharded-session",
-        lastUsedAtMs: 10,
-      }),
-    ]);
-
-    await migrateLegacySandboxRegistryFiles();
-
-    const entry = await readRegistryEntry("container-a");
-    expect(entry?.sessionKey).toBe("sharded-session");
-    expect(entry?.lastUsedAtMs).toBe(10);
   });
 
   it("reads a single SQLite entry without scanning the full registry", async () => {
@@ -490,53 +261,5 @@ describe("registry race safety", () => {
 
     const registry = await readBrowserRegistry();
     expect(registry.entries).toHaveLength(0);
-  });
-
-  it("quarantines malformed legacy registry files during migration", async () => {
-    await seedMalformedContainerRegistry("{bad json");
-    await seedMalformedBrowserRegistry("{bad json");
-    const results = await migrateLegacySandboxRegistryFiles();
-
-    await expectPathMissing(SANDBOX_REGISTRY_PATH);
-    await expectPathMissing(SANDBOX_BROWSER_REGISTRY_PATH);
-    expect(results.map((result) => result.status)).toEqual([
-      "quarantined-invalid",
-      "quarantined-invalid",
-    ]);
-  });
-
-  it("quarantines legacy registry files with invalid entries during migration", async () => {
-    const invalidEntries = `{"entries":[{"sessionKey":"agent:main"}]}`;
-    await seedMalformedContainerRegistry(invalidEntries);
-    await seedMalformedBrowserRegistry(invalidEntries);
-    const migrationResults = await migrateLegacySandboxRegistryFiles();
-    expect(requireMigrationResult(migrationResults, "containers").status).toBe(
-      "quarantined-invalid",
-    );
-    expect(requireMigrationResult(migrationResults, "browsers").status).toBe("quarantined-invalid");
-  });
-
-  it("quarantines malformed sharded registry directories during migration", async () => {
-    await fs.mkdir(SANDBOX_CONTAINERS_DIR, { recursive: true });
-    await fs.mkdir(SANDBOX_BROWSERS_DIR, { recursive: true });
-    await seedShardedContainerRegistry([
-      containerEntry({ containerName: "valid-container", sessionKey: "agent:valid" }),
-    ]);
-    await seedShardedBrowserRegistry([
-      browserEntry({ containerName: "valid-browser", sessionKey: "agent:valid" }),
-    ]);
-    await fs.writeFile(path.join(SANDBOX_CONTAINERS_DIR, "bad.json"), "{bad json", "utf-8");
-    await fs.writeFile(path.join(SANDBOX_BROWSERS_DIR, "bad.json"), "{bad json", "utf-8");
-
-    const migrationResults = await migrateLegacySandboxRegistryFiles();
-
-    expect(requireMigrationResult(migrationResults, "containers").status).toBe(
-      "quarantined-invalid",
-    );
-    expect(requireMigrationResult(migrationResults, "browsers").status).toBe("quarantined-invalid");
-    expect((await readRegistry()).entries[0]?.containerName).toBe("valid-container");
-    expect((await readBrowserRegistry()).entries[0]?.containerName).toBe("valid-browser");
-    await expectPathMissing(SANDBOX_CONTAINERS_DIR);
-    await expectPathMissing(SANDBOX_BROWSERS_DIR);
   });
 });

--- a/src/agents/sandbox/registry.ts
+++ b/src/agents/sandbox/registry.ts
@@ -1,27 +1,16 @@
 /**
  * Persistent sandbox registry storage.
  *
- * Tracks runtime and browser containers in the shared state DB plus migration support for legacy registries.
+ * Tracks runtime and browser containers in the shared state DB.
  */
 import fsSync from "node:fs";
-import fs from "node:fs/promises";
-import path from "node:path";
 import type { Insertable, Selectable, Updateable } from "kysely";
-import { z } from "zod";
-import { acquireFileLock } from "../../infra/file-lock.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import { withOpenClawStateDatabaseReadOnly } from "../../state/openclaw-state-db-readonly.js";
 import { tableExists } from "../../state/openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
-import { safeParseJsonWithSchema } from "../../utils/zod-parse.js";
-import {
-  SANDBOX_BROWSER_REGISTRY_PATH,
-  SANDBOX_BROWSERS_DIR,
-  SANDBOX_CONTAINERS_DIR,
-  SANDBOX_REGISTRY_PATH,
-} from "./constants.js";
 import type { SandboxContainerEngineTarget } from "./container-engine.js";
 
 export type SandboxRegistryEntry = {
@@ -56,59 +45,13 @@ type SandboxBrowserRegistry = {
   entries: SandboxBrowserRegistryEntry[];
 };
 
-type RegistryEntry = {
-  containerName: string;
-};
-
-type RegistryEntryPayload = RegistryEntry & Record<string, unknown>;
-
-type RegistryFile = {
-  entries: RegistryEntryPayload[];
-};
-
-type ShardedRegistryRead<T extends RegistryEntry> = {
-  entries: T[];
-  validFiles: string[];
-  invalidFiles: string[];
-};
-
-type LegacyRegistryKind = "containers" | "browsers";
+type RegistryEntryPayload = { containerName: string } & Record<string, unknown>;
 type SandboxRegistryKind = "container" | "browser";
 type SandboxRegistryTable = OpenClawStateKyselyDatabase["sandbox_registry_entries"];
 type SandboxRegistryDatabase = Pick<OpenClawStateKyselyDatabase, "sandbox_registry_entries">;
 type SandboxRegistryRow = Selectable<SandboxRegistryTable>;
 type SandboxRegistryInsert = Insertable<SandboxRegistryTable>;
 type SandboxRegistryUpdate = Updateable<SandboxRegistryTable>;
-
-type LegacyRegistryTarget = {
-  kind: LegacyRegistryKind;
-  registryPath: string;
-  shardedDir: string;
-};
-
-export type LegacySandboxRegistryInspection = LegacyRegistryTarget & {
-  exists: boolean;
-  valid: boolean;
-  entries: number;
-  source: "monolithic" | "sharded";
-};
-
-export type LegacySandboxRegistryMigrationResult = LegacyRegistryTarget & {
-  status: "missing" | "migrated" | "removed-empty" | "quarantined-invalid";
-  entries: number;
-  source?: "monolithic" | "sharded";
-  quarantinePath?: string;
-};
-
-const RegistryEntrySchema = z
-  .object({
-    containerName: z.string(),
-  })
-  .passthrough();
-
-const RegistryFileSchema = z.object({
-  entries: z.array(RegistryEntrySchema),
-});
 
 function getSandboxRegistryKysely(db: import("node:sqlite").DatabaseSync) {
   return getNodeSqliteKysely<SandboxRegistryDatabase>(db);
@@ -364,35 +307,6 @@ function normalizeSandboxRegistryEntry(entry: SandboxRegistryEntry): SandboxRegi
   };
 }
 
-async function withRegistryLock<T>(registryPath: string, fn: () => Promise<T>): Promise<T> {
-  const lock = await acquireFileLock(registryPath, {
-    stale: 30_000,
-    retries: { retries: 59, factor: 1, minTimeout: 1_000, maxTimeout: 1_000 },
-  });
-  try {
-    return await fn();
-  } finally {
-    await lock.release();
-  }
-}
-
-async function readLegacyRegistryFile(registryPath: string): Promise<RegistryFile | null> {
-  try {
-    const raw = await fs.readFile(registryPath, "utf-8");
-    const parsed = safeParseJsonWithSchema(RegistryFileSchema, raw) as RegistryFile | null;
-    return parsed;
-  } catch (error) {
-    const code = (error as { code?: string } | null)?.code;
-    if (code === "ENOENT") {
-      return { entries: [] };
-    }
-    if (error instanceof Error) {
-      throw error;
-    }
-    throw new Error(`Failed to read sandbox registry file: ${registryPath}`, { cause: error });
-  }
-}
-
 /** Reads all registered sandbox runtime containers from SQLite. */
 export async function readRegistry(): Promise<SandboxRegistry> {
   const entries = readRegistryRows("container")
@@ -401,311 +315,6 @@ export async function readRegistry(): Promise<SandboxRegistry> {
   return {
     entries: entries.map((entry) => normalizeSandboxRegistryEntry(entry)),
   };
-}
-
-async function readShardedEntriesDetailed<T extends RegistryEntry>(
-  dir: string,
-): Promise<ShardedRegistryRead<T>> {
-  let files: string[];
-  try {
-    files = await fs.readdir(dir);
-  } catch (error) {
-    const code = (error as { code?: string } | null)?.code;
-    if (code === "ENOENT") {
-      return { entries: [], validFiles: [], invalidFiles: [] };
-    }
-    throw error;
-  }
-
-  const invalidFiles: string[] = [];
-  const validFiles: string[] = [];
-  const entries = await Promise.all(
-    files
-      .filter((name) => name.endsWith(".json"))
-      .toSorted()
-      .map(async (name) => {
-        const filePath = path.join(dir, name);
-        try {
-          const raw = await fs.readFile(filePath, "utf-8");
-          const entry = safeParseJsonWithSchema(RegistryEntrySchema, raw) as T | null;
-          if (!entry) {
-            invalidFiles.push(filePath);
-          } else {
-            validFiles.push(filePath);
-          }
-          return entry;
-        } catch {
-          invalidFiles.push(filePath);
-          return null;
-        }
-      }),
-  );
-  const validEntries: T[] = [];
-  for (const entry of entries) {
-    if (entry) {
-      validEntries.push(entry);
-    }
-  }
-  return {
-    entries: validEntries.toSorted((left, right) =>
-      left.containerName.localeCompare(right.containerName),
-    ),
-    validFiles: validFiles.toSorted(),
-    invalidFiles: invalidFiles.toSorted(),
-  };
-}
-
-async function quarantineLegacyRegistry(registryPath: string): Promise<string> {
-  const quarantinePath = `${registryPath}.invalid-${Date.now()}`;
-  await fs.rename(registryPath, quarantinePath).catch(async (error: unknown) => {
-    const code = (error as { code?: string } | null)?.code;
-    if (code !== "ENOENT") {
-      await fs.rm(registryPath, { force: true });
-    }
-  });
-  return quarantinePath;
-}
-
-async function quarantineInvalidShards(
-  dir: string,
-  invalidFiles: readonly string[],
-): Promise<string> {
-  const quarantineDir = `${dir}.invalid-${Date.now()}`;
-  await fs.mkdir(quarantineDir, { recursive: true });
-  for (const invalidFile of invalidFiles) {
-    await fs
-      .rename(invalidFile, path.join(quarantineDir, path.basename(invalidFile)))
-      .catch(async (error: unknown) => {
-        const code = (error as { code?: string } | null)?.code;
-        if (code !== "ENOENT") {
-          throw error;
-        }
-      });
-  }
-  return quarantineDir;
-}
-
-async function removeFiles(files: readonly string[]): Promise<void> {
-  await Promise.all(files.map((file) => fs.rm(file, { force: true })));
-}
-
-async function migrateMonolithicIfNeeded(
-  target: LegacyRegistryTarget,
-): Promise<LegacySandboxRegistryMigrationResult> {
-  const { registryPath } = target;
-  try {
-    await fs.access(registryPath);
-  } catch (error) {
-    const code = (error as { code?: string } | null)?.code;
-    if (code === "ENOENT") {
-      return { ...target, source: "monolithic", status: "missing", entries: 0 };
-    }
-    throw error;
-  }
-
-  return await withRegistryLock(registryPath, async () => {
-    const registry = await readLegacyRegistryFile(registryPath);
-    if (!registry) {
-      const quarantinePath = await quarantineLegacyRegistry(registryPath);
-      return {
-        ...target,
-        source: "monolithic",
-        status: "quarantined-invalid",
-        entries: 0,
-        quarantinePath,
-      };
-    }
-    if (registry.entries.length === 0) {
-      await fs.rm(registryPath, { force: true });
-      return { ...target, source: "monolithic", status: "removed-empty", entries: 0 };
-    }
-    for (const entry of registry.entries) {
-      writeLegacyEntryIfMissing(target.kind, entry);
-    }
-    await fs.rm(registryPath, { force: true });
-    return {
-      ...target,
-      source: "monolithic",
-      status: "migrated",
-      entries: registry.entries.length,
-    };
-  });
-}
-
-function writeLegacyEntryIfMissing(kind: LegacyRegistryKind, entry: RegistryEntryPayload): boolean {
-  if (kind === "containers") {
-    insertRegistryRowIfMissing(
-      containerEntryToRow({
-        ...entry,
-        containerName: entry.containerName,
-        sessionKey: typeof entry.sessionKey === "string" ? entry.sessionKey : "",
-        createdAtMs: typeof entry.createdAtMs === "number" ? entry.createdAtMs : 0,
-        lastUsedAtMs: typeof entry.lastUsedAtMs === "number" ? entry.lastUsedAtMs : 0,
-        image: typeof entry.image === "string" ? entry.image : "",
-      }),
-    );
-    return true;
-  }
-  insertRegistryRowIfMissing(
-    browserEntryToRow({
-      ...entry,
-      containerName: entry.containerName,
-      sessionKey: typeof entry.sessionKey === "string" ? entry.sessionKey : "",
-      createdAtMs: typeof entry.createdAtMs === "number" ? entry.createdAtMs : 0,
-      lastUsedAtMs: typeof entry.lastUsedAtMs === "number" ? entry.lastUsedAtMs : 0,
-      image: typeof entry.image === "string" ? entry.image : "",
-      cdpPort: typeof entry.cdpPort === "number" ? entry.cdpPort : 0,
-    }),
-  );
-  return true;
-}
-
-async function migrateShardedIfNeeded(
-  target: LegacyRegistryTarget,
-): Promise<LegacySandboxRegistryMigrationResult> {
-  let dirExists = false;
-  try {
-    const stat = await fs.stat(target.shardedDir);
-    dirExists = stat.isDirectory();
-  } catch (error) {
-    const code = (error as { code?: string } | null)?.code;
-    if (code !== "ENOENT") {
-      throw error;
-    }
-  }
-  if (!dirExists) {
-    return { ...target, source: "sharded", status: "missing", entries: 0 };
-  }
-  const { entries, validFiles, invalidFiles } =
-    await readShardedEntriesDetailed<RegistryEntryPayload>(target.shardedDir);
-  if (invalidFiles.length > 0) {
-    for (const entry of entries) {
-      writeLegacyEntryIfMissing(target.kind, entry);
-    }
-    await removeFiles(validFiles);
-    const quarantinePath = await quarantineInvalidShards(target.shardedDir, invalidFiles);
-    await fs.rm(target.shardedDir, { recursive: true, force: true });
-    return {
-      ...target,
-      source: "sharded",
-      status: "quarantined-invalid",
-      entries: entries.length,
-      quarantinePath,
-    };
-  }
-  if (entries.length === 0) {
-    await fs.rm(target.shardedDir, { recursive: true, force: true });
-    return { ...target, source: "sharded", status: "removed-empty", entries: 0 };
-  }
-  for (const entry of entries) {
-    writeLegacyEntryIfMissing(target.kind, entry);
-  }
-  await fs.rm(target.shardedDir, { recursive: true, force: true });
-  return { ...target, source: "sharded", status: "migrated", entries: entries.length };
-}
-
-function combineMigrationResults(
-  target: LegacyRegistryTarget,
-  monolithic: LegacySandboxRegistryMigrationResult,
-  sharded: LegacySandboxRegistryMigrationResult,
-): LegacySandboxRegistryMigrationResult {
-  if (monolithic.status === "quarantined-invalid") {
-    return monolithic;
-  }
-  if (sharded.status === "quarantined-invalid") {
-    return sharded;
-  }
-  const entries = monolithic.entries + sharded.entries;
-  if (entries > 0) {
-    return { ...target, status: "migrated", entries };
-  }
-  if (monolithic.status === "removed-empty" || sharded.status === "removed-empty") {
-    return { ...target, status: "removed-empty", entries: 0 };
-  }
-  return { ...target, status: "missing", entries: 0 };
-}
-
-function legacyRegistryTargets(): LegacyRegistryTarget[] {
-  return [
-    {
-      kind: "containers",
-      registryPath: SANDBOX_REGISTRY_PATH,
-      shardedDir: SANDBOX_CONTAINERS_DIR,
-    },
-    {
-      kind: "browsers",
-      registryPath: SANDBOX_BROWSER_REGISTRY_PATH,
-      shardedDir: SANDBOX_BROWSERS_DIR,
-    },
-  ];
-}
-
-/** Inspects old registry files without mutating them. */
-export async function inspectLegacySandboxRegistryFiles(): Promise<
-  LegacySandboxRegistryInspection[]
-> {
-  const inspections: LegacySandboxRegistryInspection[] = [];
-  for (const target of legacyRegistryTargets()) {
-    try {
-      await fs.access(target.registryPath);
-    } catch (error) {
-      const code = (error as { code?: string } | null)?.code;
-      if (code === "ENOENT") {
-        inspections.push({
-          ...target,
-          source: "monolithic",
-          exists: false,
-          valid: true,
-          entries: 0,
-        });
-      } else {
-        throw error;
-      }
-    }
-
-    if (!inspections.some((entry) => entry.kind === target.kind && entry.source === "monolithic")) {
-      const registry = await readLegacyRegistryFile(target.registryPath);
-      inspections.push({
-        ...target,
-        source: "monolithic",
-        exists: true,
-        valid: Boolean(registry),
-        entries: registry?.entries.length ?? 0,
-      });
-    }
-
-    const sharded = await readShardedEntriesDetailed<RegistryEntryPayload>(target.shardedDir);
-    let shardedExists = false;
-    try {
-      shardedExists = (await fs.stat(target.shardedDir)).isDirectory();
-    } catch (error) {
-      const code = (error as { code?: string } | null)?.code;
-      if (code !== "ENOENT") {
-        throw error;
-      }
-    }
-    inspections.push({
-      ...target,
-      source: "sharded",
-      exists: shardedExists,
-      valid: sharded.invalidFiles.length === 0,
-      entries: sharded.entries.length,
-    });
-  }
-  return inspections;
-}
-
-/** Migrates old registry files into SQLite when present. */
-export async function migrateLegacySandboxRegistryFiles(): Promise<
-  LegacySandboxRegistryMigrationResult[]
-> {
-  const results: LegacySandboxRegistryMigrationResult[] = [];
-  for (const target of legacyRegistryTargets()) {
-    const sharded = await migrateShardedIfNeeded(target);
-    const monolithic = await migrateMonolithicIfNeeded(target);
-    results.push(combineMigrationResults(target, monolithic, sharded));
-  }
-  return results;
 }
 
 /** Reads one registered sandbox runtime container by container name. */
@@ -726,6 +335,11 @@ export async function readRegisteredSandboxRuntimeIds(params: {
     .map((row) => rowToContainerEntry(row))
     .filter((entry): entry is SandboxRegistryEntry => entry != null)
     .map((entry) => entry.containerName);
+}
+
+/** Inserts one sandbox runtime registry entry without replacing an existing entry. */
+export function insertSandboxRegistryEntryIfMissing(entry: SandboxRegistryEntry): void {
+  insertRegistryRowIfMissing(containerEntryToRow(entry));
 }
 
 /** Creates or updates one sandbox runtime registry entry, preserving immutable creation fields. */
@@ -749,6 +363,13 @@ export async function readBrowserRegistry(): Promise<SandboxBrowserRegistry> {
       .map((row) => rowToBrowserEntry(row))
       .filter((entry): entry is SandboxBrowserRegistryEntry => entry != null),
   };
+}
+
+/** Inserts one browser sandbox registry entry without replacing an existing entry. */
+export function insertSandboxBrowserRegistryEntryIfMissing(
+  entry: SandboxBrowserRegistryEntry,
+): void {
+  insertRegistryRowIfMissing(browserEntryToRow(entry));
 }
 
 /** Creates or updates one browser sandbox registry entry, preserving immutable creation fields. */

--- a/src/commands/doctor-sandbox-legacy-registry.test.ts
+++ b/src/commands/doctor-sandbox-legacy-registry.test.ts
@@ -1,0 +1,358 @@
+// Doctor sandbox legacy registry tests cover migration, ordering, and invalid source cleanup.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+
+const {
+  TEST_STATE_DIR,
+  PREVIOUS_OPENCLAW_STATE_DIR,
+  SANDBOX_REGISTRY_PATH,
+  SANDBOX_BROWSER_REGISTRY_PATH,
+  SANDBOX_CONTAINERS_DIR,
+  SANDBOX_BROWSERS_DIR,
+} = vi.hoisted(() => {
+  const nodePath = require("node:path");
+  const { mkdtempSync } = require("node:fs");
+  const { tmpdir } = require("node:os");
+  const baseDir = mkdtempSync(nodePath.join(tmpdir(), "openclaw-sandbox-registry-"));
+  const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+  Reflect.set(process.env, "OPENCLAW_STATE_DIR", baseDir);
+
+  return {
+    TEST_STATE_DIR: baseDir,
+    PREVIOUS_OPENCLAW_STATE_DIR: previousStateDir,
+    SANDBOX_REGISTRY_PATH: nodePath.join(baseDir, "containers.json"),
+    SANDBOX_BROWSER_REGISTRY_PATH: nodePath.join(baseDir, "browsers.json"),
+    SANDBOX_CONTAINERS_DIR: nodePath.join(baseDir, "containers"),
+    SANDBOX_BROWSERS_DIR: nodePath.join(baseDir, "browsers"),
+  };
+});
+
+vi.mock("../agents/sandbox/constants.js", () => ({
+  SANDBOX_STATE_DIR: TEST_STATE_DIR,
+  SANDBOX_REGISTRY_PATH,
+  SANDBOX_BROWSER_REGISTRY_PATH,
+  SANDBOX_CONTAINERS_DIR,
+  SANDBOX_BROWSERS_DIR,
+}));
+
+import { hashTextSha256 } from "../agents/sandbox/hash.js";
+import {
+  readBrowserRegistry,
+  readRegistry,
+  readRegistryEntry,
+  updateRegistry,
+} from "../agents/sandbox/registry.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
+import { migrateLegacySandboxRegistryFiles } from "./doctor-sandbox-legacy-registry.js";
+
+type SandboxBrowserRegistryEntry =
+  import("../agents/sandbox/registry.js").SandboxBrowserRegistryEntry;
+type SandboxRegistryEntry = import("../agents/sandbox/registry.js").SandboxRegistryEntry;
+type MigrationResult = Awaited<ReturnType<typeof migrateLegacySandboxRegistryFiles>>[number];
+
+afterEach(async () => {
+  closeOpenClawStateDatabaseForTest();
+  await fs.rm(path.join(TEST_STATE_DIR, "state"), { recursive: true, force: true });
+  await fs.rm(SANDBOX_CONTAINERS_DIR, { recursive: true, force: true });
+  await fs.rm(SANDBOX_BROWSERS_DIR, { recursive: true, force: true });
+  await fs.rm(SANDBOX_REGISTRY_PATH, { force: true });
+  await fs.rm(SANDBOX_BROWSER_REGISTRY_PATH, { force: true });
+  await fs.rm(`${SANDBOX_REGISTRY_PATH}.lock`, { force: true });
+  await fs.rm(`${SANDBOX_BROWSER_REGISTRY_PATH}.lock`, { force: true });
+});
+
+afterAll(async () => {
+  closeOpenClawStateDatabaseForTest();
+  await fs.rm(TEST_STATE_DIR, { recursive: true, force: true });
+  if (PREVIOUS_OPENCLAW_STATE_DIR === undefined) {
+    deleteTestEnvValue("OPENCLAW_STATE_DIR");
+  } else {
+    setTestEnvValue("OPENCLAW_STATE_DIR", PREVIOUS_OPENCLAW_STATE_DIR);
+  }
+});
+
+function browserEntry(
+  overrides: Partial<SandboxBrowserRegistryEntry> = {},
+): SandboxBrowserRegistryEntry {
+  return {
+    containerName: "browser-a",
+    sessionKey: "agent:main",
+    createdAtMs: 1,
+    lastUsedAtMs: 1,
+    image: "openclaw-browser:test",
+    cdpPort: 9222,
+    ...overrides,
+  };
+}
+
+function containerEntry(overrides: Partial<SandboxRegistryEntry> = {}): SandboxRegistryEntry {
+  return {
+    containerName: "container-a",
+    sessionKey: "agent:main",
+    createdAtMs: 1,
+    lastUsedAtMs: 1,
+    image: "openclaw-sandbox:test",
+    ...overrides,
+  };
+}
+
+async function seedContainerRegistry(entries: SandboxRegistryEntry[]) {
+  await fs.writeFile(SANDBOX_REGISTRY_PATH, `${JSON.stringify({ entries }, null, 2)}\n`, "utf-8");
+}
+
+async function seedBrowserRegistry(entries: SandboxBrowserRegistryEntry[]) {
+  await fs.writeFile(
+    SANDBOX_BROWSER_REGISTRY_PATH,
+    `${JSON.stringify({ entries }, null, 2)}\n`,
+    "utf-8",
+  );
+}
+
+async function seedShardedContainerRegistry(entries: SandboxRegistryEntry[]) {
+  await fs.mkdir(SANDBOX_CONTAINERS_DIR, { recursive: true });
+  for (const entry of entries) {
+    await fs.writeFile(
+      path.join(SANDBOX_CONTAINERS_DIR, `${hashTextSha256(entry.containerName)}.json`),
+      `${JSON.stringify(entry, null, 2)}\n`,
+      "utf-8",
+    );
+  }
+}
+
+async function seedShardedBrowserRegistry(entries: SandboxBrowserRegistryEntry[]) {
+  await fs.mkdir(SANDBOX_BROWSERS_DIR, { recursive: true });
+  for (const entry of entries) {
+    await fs.writeFile(
+      path.join(SANDBOX_BROWSERS_DIR, `${hashTextSha256(entry.containerName)}.json`),
+      `${JSON.stringify(entry, null, 2)}\n`,
+      "utf-8",
+    );
+  }
+}
+
+async function seedStaleLock(lockPath: string) {
+  await fs.writeFile(
+    lockPath,
+    `${JSON.stringify({ pid: 999_999_999, createdAt: "2000-01-01T00:00:00.000Z" })}\n`,
+    "utf-8",
+  );
+}
+
+async function expectPathMissing(targetPath: string): Promise<void> {
+  try {
+    await fs.access(targetPath);
+    throw new Error(`expected ${targetPath} to be missing`);
+  } catch (error) {
+    const code = error && typeof error === "object" && "code" in error ? error.code : undefined;
+    expect(code).toBe("ENOENT");
+  }
+}
+
+function requireMigrationResult(
+  results: readonly MigrationResult[],
+  kind: MigrationResult["kind"],
+): MigrationResult {
+  const result = results.find((candidate) => candidate.kind === kind);
+  if (!result) {
+    throw new Error(`expected migration result for ${kind}`);
+  }
+  return result;
+}
+
+describe("legacy sandbox registry migration", () => {
+  it("normalizes legacy registry entries after explicit migration", async () => {
+    await seedContainerRegistry([
+      {
+        containerName: "legacy-container",
+        sessionKey: "agent:main",
+        createdAtMs: 1,
+        lastUsedAtMs: 1,
+        image: "openclaw-sandbox:test",
+      },
+    ]);
+
+    await migrateLegacySandboxRegistryFiles();
+    const registry = await readRegistry();
+    expect(registry.entries).toHaveLength(1);
+    const [entry] = registry.entries;
+    expect(entry?.containerName).toBe("legacy-container");
+    expect(entry?.backendId).toBe("docker");
+    expect(entry?.runtimeLabel).toBe("legacy-container");
+    expect(entry?.configLabelKind).toBe("Image");
+  });
+
+  it("migrates legacy monolithic container and browser registry files after explicit repair", async () => {
+    await seedContainerRegistry([
+      containerEntry({
+        containerName: "legacy-container",
+        sessionKey: "agent:legacy",
+        lastUsedAtMs: 7,
+        configHash: "legacy-container-hash",
+      }),
+    ]);
+    await seedBrowserRegistry([
+      browserEntry({
+        containerName: "legacy-browser",
+        sessionKey: "agent:legacy",
+        cdpPort: 9333,
+        noVncPort: 6081,
+        configHash: "legacy-browser-hash",
+      }),
+    ]);
+    await seedStaleLock(`${SANDBOX_REGISTRY_PATH}.lock`);
+    await seedStaleLock(`${SANDBOX_BROWSER_REGISTRY_PATH}.lock`);
+
+    const migrationResults = await migrateLegacySandboxRegistryFiles();
+    const containerMigration = requireMigrationResult(migrationResults, "containers");
+    const browserMigration = requireMigrationResult(migrationResults, "browsers");
+    expect(containerMigration.status).toBe("migrated");
+    expect(containerMigration.entries).toBe(1);
+    expect(browserMigration.status).toBe("migrated");
+    expect(browserMigration.entries).toBe(1);
+
+    await expectPathMissing(SANDBOX_REGISTRY_PATH);
+    await expectPathMissing(SANDBOX_BROWSER_REGISTRY_PATH);
+    await expectPathMissing(`${SANDBOX_REGISTRY_PATH}.lock`);
+    await expectPathMissing(`${SANDBOX_BROWSER_REGISTRY_PATH}.lock`);
+    const containerRegistry = await readRegistry();
+    expect(containerRegistry.entries).toHaveLength(1);
+    const [container] = containerRegistry.entries;
+    expect(container?.containerName).toBe("legacy-container");
+    expect(container?.backendId).toBe("docker");
+    expect(container?.runtimeLabel).toBe("legacy-container");
+    expect(container?.sessionKey).toBe("agent:legacy");
+    expect(container?.configHash).toBe("legacy-container-hash");
+    const browserRegistry = await readBrowserRegistry();
+    expect(browserRegistry.entries).toHaveLength(1);
+    const [browser] = browserRegistry.entries;
+    expect(browser?.containerName).toBe("legacy-browser");
+    expect(browser?.sessionKey).toBe("agent:legacy");
+    expect(browser?.cdpPort).toBe(9333);
+    expect(browser?.noVncPort).toBe(6081);
+    expect(browser?.configHash).toBe("legacy-browser-hash");
+  });
+
+  it("migrates legacy sharded container and browser registry files after explicit repair", async () => {
+    await seedShardedContainerRegistry([
+      containerEntry({
+        containerName: "legacy-container",
+        sessionKey: "agent:legacy",
+        lastUsedAtMs: 7,
+        configHash: "legacy-container-hash",
+      }),
+    ]);
+    await seedShardedBrowserRegistry([
+      browserEntry({
+        containerName: "legacy-browser",
+        sessionKey: "agent:legacy",
+        cdpPort: 9333,
+        noVncPort: 6081,
+        configHash: "legacy-browser-hash",
+      }),
+    ]);
+
+    const migrationResults = await migrateLegacySandboxRegistryFiles();
+    expect(requireMigrationResult(migrationResults, "containers").status).toBe("migrated");
+    expect(requireMigrationResult(migrationResults, "browsers").status).toBe("migrated");
+    await expectPathMissing(SANDBOX_CONTAINERS_DIR);
+    await expectPathMissing(SANDBOX_BROWSERS_DIR);
+    expect((await readRegistry()).entries[0]?.containerName).toBe("legacy-container");
+    expect((await readBrowserRegistry()).entries[0]?.containerName).toBe("legacy-browser");
+  });
+
+  it("does not overwrite newer SQLite entries during legacy migration", async () => {
+    await updateRegistry(
+      containerEntry({
+        containerName: "container-a",
+        sessionKey: "new-session",
+        lastUsedAtMs: 10,
+      }),
+    );
+    await seedContainerRegistry([
+      containerEntry({
+        containerName: "container-a",
+        sessionKey: "legacy-session",
+        lastUsedAtMs: 1,
+      }),
+    ]);
+
+    await migrateLegacySandboxRegistryFiles();
+
+    const entry = await readRegistryEntry("container-a");
+    expect(entry?.sessionKey).toBe("new-session");
+    expect(entry?.lastUsedAtMs).toBe(10);
+  });
+
+  it("prefers newer sharded entries over stale monolithic entries during legacy migration", async () => {
+    await seedContainerRegistry([
+      containerEntry({
+        containerName: "container-a",
+        sessionKey: "legacy-session",
+        lastUsedAtMs: 1,
+      }),
+    ]);
+    await seedShardedContainerRegistry([
+      containerEntry({
+        containerName: "container-a",
+        sessionKey: "sharded-session",
+        lastUsedAtMs: 10,
+      }),
+    ]);
+
+    await migrateLegacySandboxRegistryFiles();
+
+    const entry = await readRegistryEntry("container-a");
+    expect(entry?.sessionKey).toBe("sharded-session");
+    expect(entry?.lastUsedAtMs).toBe(10);
+  });
+
+  it("quarantines malformed legacy registry files during migration", async () => {
+    await fs.writeFile(SANDBOX_REGISTRY_PATH, "{bad json", "utf-8");
+    await fs.writeFile(SANDBOX_BROWSER_REGISTRY_PATH, "{bad json", "utf-8");
+    const results = await migrateLegacySandboxRegistryFiles();
+
+    await expectPathMissing(SANDBOX_REGISTRY_PATH);
+    await expectPathMissing(SANDBOX_BROWSER_REGISTRY_PATH);
+    expect(results.map((result) => result.status)).toEqual([
+      "quarantined-invalid",
+      "quarantined-invalid",
+    ]);
+  });
+
+  it("quarantines legacy registry files with invalid entries during migration", async () => {
+    const invalidEntries = `{"entries":[{"sessionKey":"agent:main"}]}`;
+    await fs.writeFile(SANDBOX_REGISTRY_PATH, invalidEntries, "utf-8");
+    await fs.writeFile(SANDBOX_BROWSER_REGISTRY_PATH, invalidEntries, "utf-8");
+    const migrationResults = await migrateLegacySandboxRegistryFiles();
+    expect(requireMigrationResult(migrationResults, "containers").status).toBe(
+      "quarantined-invalid",
+    );
+    expect(requireMigrationResult(migrationResults, "browsers").status).toBe("quarantined-invalid");
+  });
+
+  it("quarantines malformed sharded registry directories during migration", async () => {
+    await fs.mkdir(SANDBOX_CONTAINERS_DIR, { recursive: true });
+    await fs.mkdir(SANDBOX_BROWSERS_DIR, { recursive: true });
+    await seedShardedContainerRegistry([
+      containerEntry({ containerName: "valid-container", sessionKey: "agent:valid" }),
+    ]);
+    await seedShardedBrowserRegistry([
+      browserEntry({ containerName: "valid-browser", sessionKey: "agent:valid" }),
+    ]);
+    await fs.writeFile(path.join(SANDBOX_CONTAINERS_DIR, "bad.json"), "{bad json", "utf-8");
+    await fs.writeFile(path.join(SANDBOX_BROWSERS_DIR, "bad.json"), "{bad json", "utf-8");
+
+    const migrationResults = await migrateLegacySandboxRegistryFiles();
+
+    expect(requireMigrationResult(migrationResults, "containers").status).toBe(
+      "quarantined-invalid",
+    );
+    expect(requireMigrationResult(migrationResults, "browsers").status).toBe("quarantined-invalid");
+    expect((await readRegistry()).entries[0]?.containerName).toBe("valid-container");
+    expect((await readBrowserRegistry()).entries[0]?.containerName).toBe("valid-browser");
+    await expectPathMissing(SANDBOX_CONTAINERS_DIR);
+    await expectPathMissing(SANDBOX_BROWSERS_DIR);
+  });
+});

--- a/src/commands/doctor-sandbox-legacy-registry.ts
+++ b/src/commands/doctor-sandbox-legacy-registry.ts
@@ -1,0 +1,393 @@
+/** Doctor-only inspection and migration for legacy sandbox registry files. */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import {
+  SANDBOX_BROWSER_REGISTRY_PATH,
+  SANDBOX_BROWSERS_DIR,
+  SANDBOX_CONTAINERS_DIR,
+  SANDBOX_REGISTRY_PATH,
+} from "../agents/sandbox/constants.js";
+import {
+  insertSandboxBrowserRegistryEntryIfMissing,
+  insertSandboxRegistryEntryIfMissing,
+} from "../agents/sandbox/registry.js";
+import { acquireFileLock } from "../infra/file-lock.js";
+import { safeParseJsonWithSchema } from "../utils/zod-parse.js";
+
+type RegistryEntry = {
+  containerName: string;
+};
+
+type RegistryEntryPayload = RegistryEntry & Record<string, unknown>;
+
+type RegistryFile = {
+  entries: RegistryEntryPayload[];
+};
+
+type ShardedRegistryRead<T extends RegistryEntry> = {
+  entries: T[];
+  validFiles: string[];
+  invalidFiles: string[];
+};
+
+type LegacyRegistryKind = "containers" | "browsers";
+
+type LegacyRegistryTarget = {
+  kind: LegacyRegistryKind;
+  registryPath: string;
+  shardedDir: string;
+};
+
+export type LegacySandboxRegistryInspection = LegacyRegistryTarget & {
+  exists: boolean;
+  valid: boolean;
+  entries: number;
+  source: "monolithic" | "sharded";
+};
+
+export type LegacySandboxRegistryMigrationResult = LegacyRegistryTarget & {
+  status: "missing" | "migrated" | "removed-empty" | "quarantined-invalid";
+  entries: number;
+  source?: "monolithic" | "sharded";
+  quarantinePath?: string;
+};
+
+const RegistryEntrySchema = z
+  .object({
+    containerName: z.string(),
+  })
+  .passthrough();
+
+const RegistryFileSchema = z.object({
+  entries: z.array(RegistryEntrySchema),
+});
+
+async function withRegistryLock<T>(registryPath: string, fn: () => Promise<T>): Promise<T> {
+  const lock = await acquireFileLock(registryPath, {
+    stale: 30_000,
+    retries: { retries: 59, factor: 1, minTimeout: 1_000, maxTimeout: 1_000 },
+  });
+  try {
+    return await fn();
+  } finally {
+    await lock.release();
+  }
+}
+
+async function readLegacyRegistryFile(registryPath: string): Promise<RegistryFile | null> {
+  try {
+    const raw = await fs.readFile(registryPath, "utf-8");
+    const parsed = safeParseJsonWithSchema(RegistryFileSchema, raw) as RegistryFile | null;
+    return parsed;
+  } catch (error) {
+    const code = (error as { code?: string } | null)?.code;
+    if (code === "ENOENT") {
+      return { entries: [] };
+    }
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error(`Failed to read sandbox registry file: ${registryPath}`, { cause: error });
+  }
+}
+
+async function readShardedEntriesDetailed<T extends RegistryEntry>(
+  dir: string,
+): Promise<ShardedRegistryRead<T>> {
+  let files: string[];
+  try {
+    files = await fs.readdir(dir);
+  } catch (error) {
+    const code = (error as { code?: string } | null)?.code;
+    if (code === "ENOENT") {
+      return { entries: [], validFiles: [], invalidFiles: [] };
+    }
+    throw error;
+  }
+
+  const invalidFiles: string[] = [];
+  const validFiles: string[] = [];
+  const entries = await Promise.all(
+    files
+      .filter((name) => name.endsWith(".json"))
+      .toSorted()
+      .map(async (name) => {
+        const filePath = path.join(dir, name);
+        try {
+          const raw = await fs.readFile(filePath, "utf-8");
+          const entry = safeParseJsonWithSchema(RegistryEntrySchema, raw) as T | null;
+          if (!entry) {
+            invalidFiles.push(filePath);
+          } else {
+            validFiles.push(filePath);
+          }
+          return entry;
+        } catch {
+          invalidFiles.push(filePath);
+          return null;
+        }
+      }),
+  );
+  const validEntries: T[] = [];
+  for (const entry of entries) {
+    if (entry) {
+      validEntries.push(entry);
+    }
+  }
+  return {
+    entries: validEntries.toSorted((left, right) =>
+      left.containerName.localeCompare(right.containerName),
+    ),
+    validFiles: validFiles.toSorted(),
+    invalidFiles: invalidFiles.toSorted(),
+  };
+}
+
+async function quarantineLegacyRegistry(registryPath: string): Promise<string> {
+  const quarantinePath = `${registryPath}.invalid-${Date.now()}`;
+  await fs.rename(registryPath, quarantinePath).catch(async (error: unknown) => {
+    const code = (error as { code?: string } | null)?.code;
+    if (code !== "ENOENT") {
+      await fs.rm(registryPath, { force: true });
+    }
+  });
+  return quarantinePath;
+}
+
+async function quarantineInvalidShards(
+  dir: string,
+  invalidFiles: readonly string[],
+): Promise<string> {
+  const quarantineDir = `${dir}.invalid-${Date.now()}`;
+  await fs.mkdir(quarantineDir, { recursive: true });
+  for (const invalidFile of invalidFiles) {
+    await fs
+      .rename(invalidFile, path.join(quarantineDir, path.basename(invalidFile)))
+      .catch(async (error: unknown) => {
+        const code = (error as { code?: string } | null)?.code;
+        if (code !== "ENOENT") {
+          throw error;
+        }
+      });
+  }
+  return quarantineDir;
+}
+
+async function removeFiles(files: readonly string[]): Promise<void> {
+  await Promise.all(files.map((file) => fs.rm(file, { force: true })));
+}
+
+function writeLegacyEntryIfMissing(kind: LegacyRegistryKind, entry: RegistryEntryPayload): void {
+  if (kind === "containers") {
+    insertSandboxRegistryEntryIfMissing({
+      ...entry,
+      containerName: entry.containerName,
+      sessionKey: typeof entry.sessionKey === "string" ? entry.sessionKey : "",
+      createdAtMs: typeof entry.createdAtMs === "number" ? entry.createdAtMs : 0,
+      lastUsedAtMs: typeof entry.lastUsedAtMs === "number" ? entry.lastUsedAtMs : 0,
+      image: typeof entry.image === "string" ? entry.image : "",
+    });
+    return;
+  }
+  insertSandboxBrowserRegistryEntryIfMissing({
+    ...entry,
+    containerName: entry.containerName,
+    sessionKey: typeof entry.sessionKey === "string" ? entry.sessionKey : "",
+    createdAtMs: typeof entry.createdAtMs === "number" ? entry.createdAtMs : 0,
+    lastUsedAtMs: typeof entry.lastUsedAtMs === "number" ? entry.lastUsedAtMs : 0,
+    image: typeof entry.image === "string" ? entry.image : "",
+    cdpPort: typeof entry.cdpPort === "number" ? entry.cdpPort : 0,
+  });
+}
+
+async function migrateMonolithicIfNeeded(
+  target: LegacyRegistryTarget,
+): Promise<LegacySandboxRegistryMigrationResult> {
+  const { registryPath } = target;
+  try {
+    await fs.access(registryPath);
+  } catch (error) {
+    const code = (error as { code?: string } | null)?.code;
+    if (code === "ENOENT") {
+      return { ...target, source: "monolithic", status: "missing", entries: 0 };
+    }
+    throw error;
+  }
+
+  return await withRegistryLock(registryPath, async () => {
+    const registry = await readLegacyRegistryFile(registryPath);
+    if (!registry) {
+      const quarantinePath = await quarantineLegacyRegistry(registryPath);
+      return {
+        ...target,
+        source: "monolithic",
+        status: "quarantined-invalid",
+        entries: 0,
+        quarantinePath,
+      };
+    }
+    if (registry.entries.length === 0) {
+      await fs.rm(registryPath, { force: true });
+      return { ...target, source: "monolithic", status: "removed-empty", entries: 0 };
+    }
+    for (const entry of registry.entries) {
+      writeLegacyEntryIfMissing(target.kind, entry);
+    }
+    await fs.rm(registryPath, { force: true });
+    return {
+      ...target,
+      source: "monolithic",
+      status: "migrated",
+      entries: registry.entries.length,
+    };
+  });
+}
+
+async function migrateShardedIfNeeded(
+  target: LegacyRegistryTarget,
+): Promise<LegacySandboxRegistryMigrationResult> {
+  let dirExists = false;
+  try {
+    const stat = await fs.stat(target.shardedDir);
+    dirExists = stat.isDirectory();
+  } catch (error) {
+    const code = (error as { code?: string } | null)?.code;
+    if (code !== "ENOENT") {
+      throw error;
+    }
+  }
+  if (!dirExists) {
+    return { ...target, source: "sharded", status: "missing", entries: 0 };
+  }
+  const { entries, validFiles, invalidFiles } =
+    await readShardedEntriesDetailed<RegistryEntryPayload>(target.shardedDir);
+  if (invalidFiles.length > 0) {
+    for (const entry of entries) {
+      writeLegacyEntryIfMissing(target.kind, entry);
+    }
+    await removeFiles(validFiles);
+    const quarantinePath = await quarantineInvalidShards(target.shardedDir, invalidFiles);
+    await fs.rm(target.shardedDir, { recursive: true, force: true });
+    return {
+      ...target,
+      source: "sharded",
+      status: "quarantined-invalid",
+      entries: entries.length,
+      quarantinePath,
+    };
+  }
+  if (entries.length === 0) {
+    await fs.rm(target.shardedDir, { recursive: true, force: true });
+    return { ...target, source: "sharded", status: "removed-empty", entries: 0 };
+  }
+  for (const entry of entries) {
+    writeLegacyEntryIfMissing(target.kind, entry);
+  }
+  await fs.rm(target.shardedDir, { recursive: true, force: true });
+  return { ...target, source: "sharded", status: "migrated", entries: entries.length };
+}
+
+function combineMigrationResults(
+  target: LegacyRegistryTarget,
+  monolithic: LegacySandboxRegistryMigrationResult,
+  sharded: LegacySandboxRegistryMigrationResult,
+): LegacySandboxRegistryMigrationResult {
+  if (monolithic.status === "quarantined-invalid") {
+    return monolithic;
+  }
+  if (sharded.status === "quarantined-invalid") {
+    return sharded;
+  }
+  const entries = monolithic.entries + sharded.entries;
+  if (entries > 0) {
+    return { ...target, status: "migrated", entries };
+  }
+  if (monolithic.status === "removed-empty" || sharded.status === "removed-empty") {
+    return { ...target, status: "removed-empty", entries: 0 };
+  }
+  return { ...target, status: "missing", entries: 0 };
+}
+
+function legacyRegistryTargets(): LegacyRegistryTarget[] {
+  return [
+    {
+      kind: "containers",
+      registryPath: SANDBOX_REGISTRY_PATH,
+      shardedDir: SANDBOX_CONTAINERS_DIR,
+    },
+    {
+      kind: "browsers",
+      registryPath: SANDBOX_BROWSER_REGISTRY_PATH,
+      shardedDir: SANDBOX_BROWSERS_DIR,
+    },
+  ];
+}
+
+/** Inspects old registry files without mutating them. */
+export async function inspectLegacySandboxRegistryFiles(): Promise<
+  LegacySandboxRegistryInspection[]
+> {
+  const inspections: LegacySandboxRegistryInspection[] = [];
+  for (const target of legacyRegistryTargets()) {
+    try {
+      await fs.access(target.registryPath);
+    } catch (error) {
+      const code = (error as { code?: string } | null)?.code;
+      if (code === "ENOENT") {
+        inspections.push({
+          ...target,
+          source: "monolithic",
+          exists: false,
+          valid: true,
+          entries: 0,
+        });
+      } else {
+        throw error;
+      }
+    }
+
+    if (!inspections.some((entry) => entry.kind === target.kind && entry.source === "monolithic")) {
+      const registry = await readLegacyRegistryFile(target.registryPath);
+      inspections.push({
+        ...target,
+        source: "monolithic",
+        exists: true,
+        valid: Boolean(registry),
+        entries: registry?.entries.length ?? 0,
+      });
+    }
+
+    const sharded = await readShardedEntriesDetailed<RegistryEntryPayload>(target.shardedDir);
+    let shardedExists = false;
+    try {
+      shardedExists = (await fs.stat(target.shardedDir)).isDirectory();
+    } catch (error) {
+      const code = (error as { code?: string } | null)?.code;
+      if (code !== "ENOENT") {
+        throw error;
+      }
+    }
+    inspections.push({
+      ...target,
+      source: "sharded",
+      exists: shardedExists,
+      valid: sharded.invalidFiles.length === 0,
+      entries: sharded.entries.length,
+    });
+  }
+  return inspections;
+}
+
+/** Migrates old registry files into SQLite when present. */
+export async function migrateLegacySandboxRegistryFiles(): Promise<
+  LegacySandboxRegistryMigrationResult[]
+> {
+  const results: LegacySandboxRegistryMigrationResult[] = [];
+  for (const target of legacyRegistryTargets()) {
+    const sharded = await migrateShardedIfNeeded(target);
+    const monolithic = await migrateMonolithicIfNeeded(target);
+    results.push(combineMigrationResults(target, monolithic, sharded));
+  }
+  return results;
+}

--- a/src/commands/doctor-sandbox.ts
+++ b/src/commands/doctor-sandbox.ts
@@ -14,12 +14,6 @@ import {
   PODMAN_SANDBOX_ENGINE,
   validateSandboxContainerEngineTarget,
 } from "../agents/sandbox/docker.js";
-import {
-  inspectLegacySandboxRegistryFiles,
-  migrateLegacySandboxRegistryFiles,
-  type LegacySandboxRegistryInspection,
-  type LegacySandboxRegistryMigrationResult,
-} from "../agents/sandbox/registry.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
@@ -28,6 +22,12 @@ import { runCommandWithTimeout, runExec } from "../process/exec.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { shortenHomePath } from "../utils.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
+import {
+  inspectLegacySandboxRegistryFiles,
+  migrateLegacySandboxRegistryFiles,
+  type LegacySandboxRegistryInspection,
+  type LegacySandboxRegistryMigrationResult,
+} from "./doctor-sandbox-legacy-registry.js";
 
 const SANDBOX_REGISTRY_FILES_CHECK_ID = "core/doctor/sandbox/registry-files";
 

--- a/src/commands/doctor-sandbox.warns-sandbox-enabled-without-docker.test.ts
+++ b/src/commands/doctor-sandbox.warns-sandbox-enabled-without-docker.test.ts
@@ -37,7 +37,7 @@ vi.mock("../agents/sandbox/docker.js", () => ({
   validateSandboxContainerEngineTarget,
 }));
 
-vi.mock("../agents/sandbox/registry.js", () => ({
+vi.mock("./doctor-sandbox-legacy-registry.js", () => ({
   inspectLegacySandboxRegistryFiles,
   migrateLegacySandboxRegistryFiles,
 }));


### PR DESCRIPTION
## What Problem This Solves
Keeps legacy sandbox registry file migration out of the steady-state runtime registry module. These helpers are consumed only by doctor, so their previous location blurred the ownership boundary between current SQLite runtime storage and one-time legacy repair.

## Why This Change Was Made
Moves legacy file inspection, quarantine, and migration into a doctor-owned module and colocates its migration tests there. The runtime registry retains only the narrow atomic insert-if-missing storage seams needed for doctor to preserve existing SQLite conflict behavior. No migration behavior, ordering, messages, config, or schema changed.

## User Impact
No user-visible behavior change. This is an ownership refactor that makes the runtime/doctor boundary explicit and keeps legacy file handling out of normal sandbox registry code.

## Evidence
- `node scripts/run-vitest.mjs src/agents/sandbox/registry.test.ts src/commands/doctor-sandbox-legacy-registry.test.ts src/commands/doctor-sandbox.warns-sandbox-enabled-without-docker.test.ts` — 31 tests passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs --staged --timed` — all planned changed-file checks passed.
- `git diff --check`
- Mandatory autoreview: clean, no accepted/actionable findings.
- AI-assisted; implementation reviewed and understood.
