### PR TITLE
fix: announce theme import as a command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI appearance accessibility:** keep the unavailable custom-theme card announced as an Import command while preserving selected-state semantics for selectable themes and text sizes. Thanks @shakkernerd.
 - **Control UI dashboard index refresh:** keep an open Dashboards page current after session changes, agent-scope updates, and Gateway reconnects while preserving the last safe list until replacement hydration completes. Fixes #120602. Thanks @shakkernerd.
 - **Browser extension relay security:** require canonical 64-character relay secrets and safe WebSocket pairing URLs, and recheck OpenClaw tab-group consent at the extension edge before every authority-bearing existing-tab command.
 - **Control UI debug diagnostics:** keep last-good status, health, model, and heartbeat snapshots visible when refreshes fail, show the failure inside Snapshots, isolate it from Manual RPC state, and prevent older manual calls from overwriting newer ones. Thanks @shakkernerd.

--- a/ui/src/pages/config/view-appearance.ts
+++ b/ui/src/pages/config/view-appearance.ts
@@ -184,7 +184,9 @@ export function renderAppearanceSection(
                     props.theme
                       ? "settings-theme-card--active"
                       : ""}"
-                    aria-pressed=${String(opt.id === props.theme)}
+                    aria-pressed=${opt.id === "custom" && !props.hasCustomTheme
+                      ? nothing
+                      : String(opt.id === props.theme)}
                     title=${opt.description}
                     @click=${(e: Event) => {
                       if (opt.id === "custom" && !props.hasCustomTheme) {

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -1474,6 +1474,7 @@ describe("config view", () => {
     const customButton = findButtonByText(container, "Import");
 
     expect(customButton.disabled).toBe(false);
+    expect(customButton.hasAttribute("aria-pressed")).toBe(false);
     expect(
       normalizedText(
         queryRequired(container, ".settings-theme-import__inline-hint", HTMLParagraphElement),
@@ -1510,6 +1511,18 @@ describe("config view", () => {
         .find((button) => button.textContent?.includes("100%"))
         ?.getAttribute("aria-pressed"),
     ).toBe("false");
+
+    const { container: customContainer } = renderConfigView({
+      activeSection: "__appearance__",
+      includeSections: ["__appearance__"],
+      hasCustomTheme: true,
+      customThemeLabel: "Light Green",
+      theme: "custom",
+    });
+    expect(findButtonByText(customContainer, "Light Green").getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+    expect(findButtonByText(customContainer, "Claw").getAttribute("aria-pressed")).toBe("false");
   });
 
   it("shows Appearance defaults without reset actions", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where screen readers announced the unavailable custom-theme Import action as an unpressed toggle, even though activating it opens the importer instead of selecting a theme.

## Why This Change Was Made

The Appearance page now omits selected-state semantics only while the custom-theme card represents Import. Once a custom theme exists, that card continues to expose its selected state, and built-in themes and text-size choices retain their existing behavior.

## User Impact

Screen-reader users hear Import as an ordinary button, while selectable themes and text sizes continue to announce whether they are selected.

## Evidence

- Blacksmith Testbox `tbx_01kzj4g75pewmew4d04kyzkj1b`: all 52 config-view browser tests passed.
- Served Chromium mocked-Gateway E2E confirmed Import is exposed as role `button` with no pressed state.
- `pnpm check:changed` passed UI and core-test typechecks, lint, formatting, i18n, dead-export, dependency, and changelog-attribution checks.
- Independent Workloop review and bundled autoreview reported no blocking or actionable findings.
