### PR TITLE
fix(memory): keep session reconciliation off search path

### DIFF
--- a/extensions/memory-core/src/memory/manager-async-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-async-state.test.ts
@@ -68,4 +68,45 @@ describe("memory manager async state", () => {
     });
     expect(syncMock).not.toHaveBeenCalled();
   });
+
+  it("reports background search sync failures", async () => {
+    const syncError = new Error("sync failed");
+    const onError = vi.fn();
+
+    await startAsyncSearchSync({
+      enabled: true,
+      dirty: false,
+      sessionsDirty: true,
+      sync: vi.fn(async () => {
+        throw syncError;
+      }),
+      onError,
+    });
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledWith(syncError));
+  });
+
+  it("waits for ordinary dirty sync", async () => {
+    let releaseSync = () => {};
+    const pendingSync = new Promise<void>((resolve) => {
+      releaseSync = () => resolve();
+    });
+    const syncMock = vi.fn(async () => await pendingSync);
+    let settled = false;
+
+    const searchSync = startAsyncSearchSync({
+      enabled: true,
+      dirty: true,
+      sessionsDirty: false,
+      sync: syncMock,
+      onError: vi.fn(),
+    }).then(() => {
+      settled = true;
+    });
+
+    await vi.waitFor(() => expect(syncMock).toHaveBeenCalledWith({ reason: "search" }));
+    expect(settled).toBe(false);
+    releaseSync();
+    await searchSync;
+  });
 });

--- a/extensions/memory-core/src/memory/manager-async-state.ts
+++ b/extensions/memory-core/src/memory/manager-async-state.ts
@@ -9,6 +9,12 @@ export async function startAsyncSearchSync(params: {
   if (!params.enabled || (!params.dirty && !params.sessionsDirty)) {
     return;
   }
+  if (params.sessionsDirty && !params.dirty) {
+    // Session reconciliation can enumerate and parse a large transcript corpus. Keep
+    // the existing sync admission/close ownership while letting indexed searches proceed.
+    void params.sync({ reason: "search" }).catch(params.onError);
+    return;
+  }
   try {
     await params.sync({ reason: "search" });
   } catch (err: unknown) {

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -827,7 +827,6 @@ describe("memory index", () => {
   });
 
   it("does not block querying on session reconciliation", async () => {
-    forceNoProvider = true;
     const manager = await getPersistentManager(
       createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
     );

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -826,6 +826,41 @@ describe("memory index", () => {
     expect(providerCalls).toHaveLength(0);
   });
 
+  it("does not block querying on session reconciliation", async () => {
+    forceNoProvider = true;
+    const manager = await getPersistentManager(
+      createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
+    );
+    await manager.sync({ reason: "test" });
+
+    let releaseSync = () => {};
+    const pendingSync = new Promise<void>((resolve) => {
+      releaseSync = () => resolve();
+    });
+    const syncAdmitted = vi
+      .spyOn(
+        manager as unknown as {
+          syncAdmitted: (params: { reason: string }) => Promise<void>;
+        },
+        "syncAdmitted",
+      )
+      .mockImplementation(async () => await pendingSync);
+
+    Reflect.set(manager, "dirty", false);
+    Reflect.set(manager, "sessionsDirty", true);
+
+    const searchPromise = manager.search("zebra", {
+      maxResults: 5,
+      minScore: 0,
+    });
+    await vi.waitFor(() => expect(syncAdmitted).toHaveBeenCalledWith({ reason: "search" }));
+
+    const results = await searchPromise;
+    expect(results.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
+    releaseSync();
+    await pendingSync;
+  });
+
   it("waits for dirty sync before querying", async () => {
     forceNoProvider = true;
     const manager = await getPersistentManager(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `memory_search` could spend the entire request budget reconciling a large session transcript corpus before querying an already usable builtin index.

Fixes #120671

## Why This Change Was Made

`MemoryIndexManager.search` now backgrounds only session-only reconciliation (`sessionsDirty && !dirty`) while continuing to await ordinary dirty-memory synchronization. This keeps an existing indexed search responsive during session catch-up without allowing ordinary memory-file edits to be queried before their index update completes.

The existing synchronous empty-index bootstrap, sync admission/close ownership, and query cancellation behavior are unchanged.

## User Impact

Searches over an existing valid index can return while session reconciliation continues, so session results may be temporarily stale. Ordinary indexed-memory edits remain fresh because search still waits for their synchronization.

## Evidence

- Before-fix baseline proof was captured on `0a6a1d94192b5ffe3532df0195ac383f53b4b772`; exact rebased head proof was rerun on `25bf4eb2cc2d7ec0de1e1f8b4b7ba62402c9ab30`.
- Base: session-only search did not return before the delayed sync gate (`elapsedBeforeReleaseMs=701`, `returnedBeforeSyncRelease=false`); ordinary dirty search also waited.
- Rebased head: session-only search returned one real indexed result in `4ms` before the sync gate released (`returnedBeforeSyncRelease=true`); ordinary dirty search waited `701ms` and returned one result. The unchanged negative control returned zero results.
- Focused regression: `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-async-state.test.ts extensions/memory-core/src/memory/manager-search-orchestration.test.ts` — 2 files passed, including session-only background sync, background error reporting, and ordinary dirty sync waiting.

Reproduction from the repository root (copy the source below into `builtin-real-proof.mjs` first):

```text
$ OPENCLAW_BUILTIN_PROOF_EXPECT_FIX=0 node --import tsx builtin-real-proof.mjs
base 0a6a1d94192: session returnedBeforeSyncRelease=false; ordinary returnedBeforeSyncRelease=false; negativeControl=0
$ node --import tsx builtin-real-proof.mjs
head 25bf4eb2cc2: session returnedBeforeSyncRelease=true; ordinary returnedBeforeSyncRelease=false; negativeControl=0
```

<details>
<summary>Exact production proof source</summary>

```js
import fs from "node:fs/promises";
import os from "node:os";
import path from "node:path";
import { pathToFileURL } from "node:url";

const repoRoot = process.cwd();
const expectSessionBackground = process.env.OPENCLAW_BUILTIN_PROOF_EXPECT_FIX !== "0";
const proofRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-120837-builtin-real-"));
const workspaceDir = path.join(proofRoot, "workspace");
const stateDir = path.join(proofRoot, "state");
await fs.mkdir(workspaceDir, { recursive: true });
await fs.writeFile(
  path.join(workspaceDir, "MEMORY.md"),
  "# Memory\n\nopenclaw builtin proof marker\n",
);
process.env.OPENCLAW_STATE_DIR = stateDir;

const { configureMemoryCoreDreamingState } = await import(
  pathToFileURL(path.join(repoRoot, "extensions/memory-core/src/dreaming-state.ts")).href
);
const { createPluginStateKeyedStoreForTests } = await import(
  "openclaw/plugin-sdk/plugin-state-test-runtime"
);
configureMemoryCoreDreamingState((options) =>
  createPluginStateKeyedStoreForTests("memory-core", { ...options, env: process.env }),
);

const { closeAllMemorySearchManagers, getMemorySearchManager } = await import(
  pathToFileURL(path.join(repoRoot, "extensions/memory-core/src/memory/index.ts")).href
);

const cfg = {
  agents: {
    defaults: { workspace: workspaceDir },
    list: [{ id: "main", default: true, workspace: workspaceDir }],
  },
  memory: {
    search: {
      provider: "none",
      model: "none",
      sources: ["memory", "sessions"],
      rememberAcrossConversations: true,
      store: { vector: { enabled: false } },
      query: { minScore: 0.01, maxResults: 5 },
      sync: { onSearch: true, onSessionStart: false, watch: false },
    },
  },
  plugins: { enabled: false },
};

function deferred() {
  let release;
  const promise = new Promise((resolve) => {
    release = resolve;
  });
  return { promise, release };
}

async function createManager() {
  const result = await getMemorySearchManager({ cfg, agentId: "main" });
  if (!result.manager) {
    throw new Error(`builtin memory manager did not initialize: ${result.error ?? "unknown error"}`);
  }
  return result.manager;
}

async function runCase({ dirty, sessionsDirty }) {
  const manager = await createManager();
  await manager.sync({ reason: "proof-initial", force: true });
  const internal = manager;
  const originalSyncAdmitted = internal.syncAdmitted;
  const syncGate = deferred();
  let syncCalls = 0;
  let syncPromise;
  internal.syncAdmitted = async () => {
    syncCalls += 1;
    syncPromise = syncGate.promise;
    await syncPromise;
  };
  internal.dirty = dirty;
  internal.sessionsDirty = sessionsDirty;
  const startedAt = Date.now();
  const searchPromise = manager.search("openclaw builtin proof marker");
  const earlyResult = await Promise.race([
    searchPromise.then((results) => ({ settled: true, results })),
    new Promise((resolve) => setTimeout(() => resolve({ settled: false }), 700)),
  ]);
  const elapsedBeforeReleaseMs = Date.now() - startedAt;
  syncGate.release();
  const results = earlyResult.settled ? earlyResult.results : await searchPromise;
  await syncPromise;
  internal.syncAdmitted = originalSyncAdmitted;
  await manager.close();
  return {
    dirty,
    sessionsDirty,
    elapsedBeforeReleaseMs,
    returnedBeforeSyncRelease: earlyResult.settled === true,
    syncCalls,
    resultCount: results.length,
    resultPath: results[0]?.path ?? null,
  };
}

try {
  const headSha = (await import("node:child_process")).execFileSync(
    "git",
    ["rev-parse", "HEAD"],
    { cwd: repoRoot, encoding: "utf8" },
  ).trim();
  const sessionOnly = await runCase({ dirty: false, sessionsDirty: true });
  const ordinaryDirty = await runCase({ dirty: true, sessionsDirty: false });
  const negativeControl = await (async () => {
    const manager = await createManager();
    await manager.sync({ reason: "proof-negative", force: true });
    const results = await manager.search("zzzz-no-match-120837");
    await manager.close();
    return { resultCount: results.length };
  })();
  if (
    (expectSessionBackground && !sessionOnly.returnedBeforeSyncRelease) ||
    (!expectSessionBackground && sessionOnly.returnedBeforeSyncRelease) ||
    sessionOnly.resultCount < 1 ||
    ordinaryDirty.returnedBeforeSyncRelease ||
    ordinaryDirty.resultCount < 1 ||
    negativeControl.resultCount !== 0
  ) {
    throw new Error("builtin production proof did not observe the expected sync boundary");
  }
  console.log(
    JSON.stringify(
      {
        headSha,
        expectSessionBackground,
        boundary: "getMemorySearchManager -> MemoryIndexManager.search -> SQLite FTS",
        sessionOnly,
        ordinaryDirty,
        negativeControl,
      },
      null,
      2,
    ),
  );
} finally {
  await closeAllMemorySearchManagers().catch(() => undefined);
  await fs.rm(proofRoot, { recursive: true, force: true });
}
```
</details>

AI-assisted: built with Codex
