### PR TITLE
fix(ui): add space above session rail

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -823,7 +823,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
-  it("pins the collapsed session rail to the pane header edge", async () => {
+  it("insets the collapsed session rail from the pane header edge", async () => {
     const page = await openBrowserPage(922, 282);
     try {
       const splitViewCss = readStyleSheet("ui/src/styles/chat/split-view.css");
@@ -846,7 +846,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       const header = await getBoundingBox(page, ".chat-pane__header");
       const observer = await getBoundingBox(page, ".chat-session-rail");
 
-      expect(observer.y).toBeCloseTo(header.y + header.height, 0);
+      expect(observer.y).toBeCloseTo(header.y + header.height + 12, 0);
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1713,7 +1713,7 @@ openclaw-chat-session-rail {
 
 .chat-session-rail {
   position: absolute;
-  top: 0;
+  top: 12px;
   right: 12px;
   z-index: 30;
   border: 1px solid var(--border);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the hidden session companion rail’s restore button touched the chat pane header divider, making the control look cramped at the top of the conversation.

## Why This Change Was Made

The shared desktop rail positioning now uses a balanced 12px top and right inset. Mobile keeps its existing fixed-bottom placement, and docked rails remain in normal flow. The existing browser geometry test now protects the intended spacing.

This PR is AI-assisted. I reviewed the implementation, exercised the live UI, and ran the repository validation below.

## User Impact

The session rail restore control now has consistent breathing room below the chat header instead of sitting directly against the divider.

## Evidence

Before: the restore control was positioned at the pane content’s top edge (`0px` below the header).

After: live desktop geometry reports a `12px` gap below the unchanged `48px` header and a `12px` right inset. Clicking the control restores the session rail. At a mobile viewport, the control remains fixed `108px` above the bottom composer with `8px` side insets.

Validation:

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts -t "insets the collapsed session rail from the pane header edge"`
- `./node_modules/.bin/stylelint --config config/stylelint.config.mjs ui/src/styles/components.css`
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- ui/src/styles/components.css ui/src/pages/chat/chat-responsive.browser.test.ts`
- `pnpm ui:build`
- Codex autoreview: clean, no accepted/actionable findings

The changed-file gate first attempted hosted Testbox validation, but the broker was unavailable; the repository wrapper then ran the same validation locally and passed.
