### PR TITLE
refactor(chutes): move OAuth refresh into provider plugin

### DIFF
--- a/extensions/chutes/implicit-provider.test.ts
+++ b/extensions/chutes/implicit-provider.test.ts
@@ -69,12 +69,47 @@ async function withRealChutesDiscovery<T>(
 describe("chutes implicit provider auth mode", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
   });
 
   it("publishes the env vars used by core api-key auto-detection", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
 
     expect(provider.envVars).toEqual(["CHUTES_API_KEY", "CHUTES_OAUTH_TOKEN"]);
+  });
+
+  it("registers plugin-owned OAuth refresh behavior", async () => {
+    vi.stubEnv("CHUTES_CLIENT_SECRET", "");
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ access_token: "at_new", refresh_token: "rt_new", expires_in: 1800 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = await registerSingleProviderPlugin(plugin);
+    const credential = {
+      type: "oauth" as const,
+      provider: "chutes",
+      access: "at_old",
+      refresh: "rt_old",
+      expires: 1,
+      clientId: "cid_test",
+      email: "fred@example.com",
+    };
+
+    expect(provider.refreshOAuth).toBeTypeOf("function");
+    await expect(provider.refreshOAuth!(credential)).resolves.toMatchObject({
+      type: "oauth",
+      provider: "chutes",
+      access: "at_new",
+      refresh: "rt_new",
+      clientId: "cid_test",
+      email: "fred@example.com",
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.chutes.ai/idp/token",
+      expect.objectContaining({ method: "POST" }),
+    );
   });
 
   it("does not publish a provider when no API key is resolved", async () => {

--- a/extensions/chutes/index.ts
+++ b/extensions/chutes/index.ts
@@ -13,7 +13,7 @@ import {
   normalizeOptionalString,
   readStringValue,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { loginChutes } from "./oauth.js";
+import { loginChutes, refreshChutesOAuthCredential } from "./oauth.js";
 import {
   CHUTES_DEFAULT_MODEL_REF,
   applyChutesApiKeyConfig,
@@ -193,6 +193,7 @@ export default definePluginEntry({
           provider: buildStaticChutesProvider(),
         }),
       },
+      refreshOAuth: refreshChutesOAuthCredential,
     });
   },
 });

--- a/extensions/chutes/oauth.test.ts
+++ b/extensions/chutes/oauth.test.ts
@@ -1,6 +1,7 @@
 // Chutes tests cover oauth plugin behavior.
+import type { OAuthCredential } from "openclaw/plugin-sdk/provider-auth";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { loginChutes } from "./oauth.js";
+import { loginChutes, refreshChutesOAuthCredential } from "./oauth.js";
 
 const CHUTES_TOKEN_ENDPOINT = "https://api.chutes.ai/idp/token";
 const CHUTES_USERINFO_ENDPOINT = "https://api.chutes.ai/idp/userinfo";
@@ -93,8 +94,25 @@ function loginWithFetch(fetchFn: typeof fetch) {
   });
 }
 
+function createStoredCredential(overrides: Partial<OAuthCredential> = {}): OAuthCredential {
+  return {
+    type: "oauth",
+    provider: "chutes",
+    access: "at_old",
+    refresh: "rt_old",
+    expires: 1_000_000,
+    clientId: "cid_stored",
+    email: "fred@example.com",
+    displayName: "Fred",
+    accountId: "acct_123",
+    copyToAgents: true,
+    ...overrides,
+  };
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 describe("chutes plugin OAuth", () => {
@@ -340,5 +358,169 @@ describe("chutes plugin OAuth", () => {
         signal: controller.signal,
       }),
     ).rejects.toBe(reason);
+  });
+
+  it("refreshes through the Chutes token endpoint and preserves credential metadata", async () => {
+    vi.stubEnv("CHUTES_CLIENT_ID", "cid_env");
+    vi.stubEnv("CHUTES_CLIENT_SECRET", "secret_env");
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const fetchFn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(fetchInputUrl(input)).toBe(CHUTES_TOKEN_ENDPOINT);
+      expect(init?.method).toBe("POST");
+      expect(new Headers(init?.headers).get("content-type")).toBe(
+        "application/x-www-form-urlencoded",
+      );
+      const body = init?.body as URLSearchParams;
+      expect(Object.fromEntries(body)).toEqual({
+        grant_type: "refresh_token",
+        client_id: "cid_stored",
+        refresh_token: "rt_old",
+        client_secret: "secret_env",
+      });
+      return new Response(
+        JSON.stringify({
+          access_token: "at_new",
+          refresh_token: "rt_new",
+          expires_in: 1800,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const credential = createStoredCredential();
+    const now = 2_000_000;
+
+    await expect(refreshChutesOAuthCredential(credential, { fetchFn, now })).resolves.toEqual({
+      ...credential,
+      access: "at_new",
+      refresh: "rt_new",
+      expires: now + 1800 * 1000 - 5 * 60 * 1000,
+    });
+    expect(timeoutSpy).toHaveBeenCalledOnce();
+    expect(timeoutSpy).toHaveBeenCalledWith(30_000);
+  });
+
+  it("times out token refresh requests", async () => {
+    const timeoutSpy = useImmediateOAuthDeadline();
+    const fetchFn = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => await rejectWhenAborted(init),
+    );
+
+    await expect(
+      refreshChutesOAuthCredential(createStoredCredential(), { fetchFn }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(fetchFn).toHaveBeenCalledOnce();
+    expect(timeoutSpy).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to CHUTES_CLIENT_ID when the credential has no client id", async () => {
+    vi.stubEnv("CHUTES_CLIENT_ID", "cid_env");
+    const fetchFn = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = init?.body;
+      if (!(body instanceof URLSearchParams)) {
+        throw new Error("expected URL-encoded Chutes refresh request");
+      }
+      expect(body.get("client_id")).toBe("cid_env");
+      return new Response('{"access_token":"at_new","expires_in":1800}', {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const refreshed = await refreshChutesOAuthCredential(
+      createStoredCredential({ clientId: undefined }),
+      { fetchFn, now: 3_000_000 },
+    );
+
+    expect(refreshed.clientId).toBe("cid_env");
+  });
+
+  it.each([
+    { label: "omitted", response: { access_token: "at_new", expires_in: 1800 } },
+    {
+      label: "empty",
+      response: { access_token: "at_new", refresh_token: "", expires_in: 1800 },
+    },
+  ])("preserves the old refresh token when the replacement is $label", async ({ response }) => {
+    const fetchFn = vi.fn(
+      async () =>
+        new Response(JSON.stringify(response), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    const refreshed = await refreshChutesOAuthCredential(createStoredCredential(), {
+      fetchFn,
+      now: 4_000_000,
+    });
+
+    expect(refreshed.refresh).toBe("rt_old");
+  });
+
+  it("requires a refresh token", async () => {
+    await expect(
+      refreshChutesOAuthCredential(createStoredCredential({ refresh: "" })),
+    ).rejects.toThrow("Chutes OAuth credential is missing refresh token");
+  });
+
+  it("requires a client id from the credential or environment", async () => {
+    vi.stubEnv("CHUTES_CLIENT_ID", "");
+
+    await expect(
+      refreshChutesOAuthCredential(createStoredCredential({ clientId: undefined })),
+    ).rejects.toThrow(
+      "Missing CHUTES_CLIENT_ID for Chutes OAuth refresh (set env var or re-auth).",
+    );
+  });
+
+  it.each([
+    {
+      label: "missing access tokens",
+      response: { expires_in: 1800 },
+      message: "Chutes token refresh returned no access_token",
+    },
+    {
+      label: "invalid expiry values",
+      response: { access_token: "at_new", expires_in: Number.POSITIVE_INFINITY },
+      message: "Chutes token refresh returned invalid expires_in",
+    },
+  ])("rejects $label", async ({ response, message }) => {
+    const fetchFn = vi.fn(
+      async () =>
+        new Response(JSON.stringify(response), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    await expect(
+      refreshChutesOAuthCredential(createStoredCredential(), { fetchFn, now: 5_000_000 }),
+    ).rejects.toThrow(message);
+  });
+
+  it("bounds and redacts token refresh errors", async () => {
+    const leakedRefreshToken = "oauth-refresh-secret-1234567890";
+    const errorResponse = boundedErrorResponse(
+      `${`refresh_token=${leakedRefreshToken} unavailable `.repeat(1024)}tail-marker`,
+      401,
+    );
+    const fetchFn = vi.fn(async () => errorResponse.response);
+
+    let error: unknown;
+    try {
+      await refreshChutesOAuthCredential(createStoredCredential(), { fetchFn });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toMatchObject({ name: "ProviderHttpError", status: 401 });
+    const message = (error as Error).message;
+    expect(message).toContain("Chutes token refresh failed (401): refresh_token=");
+    expect(message).not.toContain(leakedRefreshToken);
+    expect(message).not.toContain("tail-marker");
+    expect((error as { errorBody?: string }).errorBody).not.toContain(leakedRefreshToken);
+    expect(errorResponse.text).not.toHaveBeenCalled();
+    expect(errorResponse.cancel).toHaveBeenCalledOnce();
+    expect(errorResponse.releaseLock).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/chutes/oauth.ts
+++ b/extensions/chutes/oauth.ts
@@ -3,7 +3,11 @@
  */
 import { randomBytes } from "node:crypto";
 import { resolveExpiresAtMsFromDurationSeconds } from "openclaw/plugin-sdk/number-runtime";
-import { generatePkceVerifierChallenge, toFormUrlEncoded } from "openclaw/plugin-sdk/provider-auth";
+import {
+  generatePkceVerifierChallenge,
+  toFormUrlEncoded,
+  type OAuthCredential,
+} from "openclaw/plugin-sdk/provider-auth";
 import {
   parseOAuthCallbackInput,
   waitForLocalOAuthCallback,
@@ -211,6 +215,65 @@ async function exchangeChutesCodeForTokens(params: {
     accountId: info?.sub,
     clientId: params.app.clientId,
   } as ChutesStoredOAuth;
+}
+
+/** Refreshes a stored Chutes OAuth credential through the provider token endpoint. */
+export async function refreshChutesOAuthCredential(
+  credential: OAuthCredential,
+  options: { fetchFn?: typeof fetch; now?: number } = {},
+): Promise<OAuthCredential> {
+  const refreshToken = normalizeOptionalString(credential.refresh);
+  if (!refreshToken) {
+    throw new Error("Chutes OAuth credential is missing refresh token");
+  }
+
+  const clientId = normalizeOptionalString(credential.clientId ?? process.env.CHUTES_CLIENT_ID);
+  if (!clientId) {
+    throw new Error("Missing CHUTES_CLIENT_ID for Chutes OAuth refresh (set env var or re-auth).");
+  }
+  const clientSecret = normalizeOptionalString(process.env.CHUTES_CLIENT_SECRET);
+  const body = new URLSearchParams(
+    toFormUrlEncoded({
+      grant_type: "refresh_token",
+      client_id: clientId,
+      refresh_token: refreshToken,
+    }),
+  );
+  if (clientSecret) {
+    body.set("client_secret", clientSecret);
+  }
+
+  const response = await (options.fetchFn ?? fetch)(CHUTES_TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+    signal: buildOAuthRequestSignal({ timeoutMs: CHUTES_OAUTH_REQUEST_TIMEOUT_MS }),
+  });
+  await assertOkOrThrowProviderError(response, "Chutes token refresh failed");
+
+  const data = await readProviderJsonResponse<{
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+  }>(response, "Chutes token refresh");
+  const access = normalizeOptionalString(data.access_token);
+  const replacementRefresh = normalizeOptionalString(data.refresh_token);
+  const expires = resolveChutesExpiresAt(data.expires_in, options.now ?? Date.now());
+  if (!access) {
+    throw new Error("Chutes token refresh returned no access_token");
+  }
+  if (expires === undefined) {
+    throw new Error("Chutes token refresh returned invalid expires_in");
+  }
+
+  return {
+    ...credential,
+    access,
+    // RFC 6749 section 6 makes replacement refresh tokens optional.
+    refresh: replacementRefresh ?? refreshToken,
+    expires,
+    clientId,
+  };
 }
 
 /** Runs Chutes OAuth and returns refreshable stored credentials. */

--- a/src/agents/auth-profiles.chutes.lifecycle.test.ts
+++ b/src/agents/auth-profiles.chutes.lifecycle.test.ts
@@ -1,0 +1,199 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resetFileLockStateForTest } from "../infra/file-lock.js";
+import { isPluginRegistryLoadInFlight } from "../plugins/loader-cache.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  loadOpenClawPlugins,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import { resolveProviderOAuthCredentialWithPlugin } from "../plugins/provider-runtime.runtime.js";
+import { resolveProviderRefOwnership } from "../plugins/providers.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  ensureAuthProfileStore,
+  resolveApiKeyForProfile,
+  type AuthProfileStore,
+} from "./auth-profiles.js";
+import { loadPersistedAuthProfileStore } from "./auth-profiles/persisted.js";
+
+const START_AUTH_CALLBACK = "__openclawChutesLifecycleStart";
+const DISABLED_REGISTER_CALLBACK = "__openclawDisabledChutesRegister";
+
+function writeChutesPlugin(params: { id: string; registerBody: string }) {
+  useNoBundledPlugins();
+  const plugin = writePlugin({
+    id: params.id,
+    body: `module.exports = {
+      id: ${JSON.stringify(params.id)},
+      register(api) {
+        ${params.registerBody}
+      },
+    };`,
+  });
+  fs.writeFileSync(
+    path.join(plugin.dir, "openclaw.plugin.json"),
+    JSON.stringify(
+      {
+        id: params.id,
+        providers: ["chutes"],
+        configSchema: { type: "object", additionalProperties: false, properties: {} },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  return plugin;
+}
+
+function createPluginConfig(params: { id: string; file: string; enabled: boolean }) {
+  return {
+    plugins: {
+      allow: [params.id],
+      load: { paths: [params.file] },
+      entries: { [params.id]: { enabled: params.enabled } },
+    },
+  } satisfies OpenClawConfig;
+}
+
+beforeEach(() => {
+  clearRuntimeAuthProfileStoreSnapshots();
+  resetFileLockStateForTest();
+  resetPluginLoaderTestStateForTest();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  clearRuntimeAuthProfileStoreSnapshots();
+  resetFileLockStateForTest();
+  resetPluginLoaderTestStateForTest();
+});
+
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+describe("Chutes auth-profile plugin lifecycle", () => {
+  it("resumes an expired OAuth refresh after synchronous provider registration completes", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-chutes-lifecycle-", agentEnv: "main" },
+      async (state) => {
+        const expiredCredential = {
+          type: "oauth" as const,
+          provider: "chutes",
+          access: "at_old",
+          refresh: "rt_old",
+          expires: 1,
+          clientId: "cid_test",
+        };
+        const refreshedCredential = {
+          ...expiredCredential,
+          access: "at_new",
+          refresh: "rt_new",
+          expires: 4_102_444_800_000,
+        };
+        const initialStore: AuthProfileStore = {
+          version: 1,
+          profiles: { "chutes:default": expiredCredential },
+        };
+        await state.writeAuthProfiles(initialStore);
+        const store = ensureAuthProfileStore();
+        const plugin = writeChutesPlugin({
+          id: "chutes-lifecycle",
+          registerBody: `
+            globalThis[${JSON.stringify(START_AUTH_CALLBACK)}]();
+            api.registerProvider({
+              id: "chutes",
+              label: "Chutes",
+              auth: [],
+              async refreshOAuth(credential) {
+                return {
+                  ...credential,
+                  access: "at_new",
+                  refresh: "rt_new",
+                  expires: 4102444800000,
+                };
+              },
+            });
+          `,
+        });
+        const config = createPluginConfig({ id: plugin.id, file: plugin.file, enabled: true });
+        const loadOptions: NonNullable<Parameters<typeof loadOpenClawPlugins>[0]> = {
+          cache: false,
+          workspaceDir: plugin.dir,
+          config,
+          onlyPluginIds: [plugin.id],
+        };
+        let authResolution: ReturnType<typeof resolveApiKeyForProfile> | undefined;
+        const startAuthDuringRegister = vi.fn(() => {
+          if (authResolution) {
+            throw new Error("Chutes lifecycle fixture registered more than once");
+          }
+          expect(isPluginRegistryLoadInFlight(loadOptions)).toBe(true);
+          authResolution = resolveApiKeyForProfile({
+            cfg: config,
+            store,
+            profileId: "chutes:default",
+          });
+        });
+        vi.stubGlobal(START_AUTH_CALLBACK, startAuthDuringRegister);
+
+        loadOpenClawPlugins(loadOptions);
+
+        expect(isPluginRegistryLoadInFlight(loadOptions)).toBe(false);
+        if (!authResolution) {
+          throw new Error("Chutes lifecycle fixture did not start auth resolution");
+        }
+        await expect(authResolution).resolves.toMatchObject({ apiKey: "at_new" });
+        expect(loadPersistedAuthProfileStore(state.agentDir())?.profiles["chutes:default"]).toEqual(
+          refreshedCredential,
+        );
+        expect(startAuthDuringRegister).toHaveBeenCalledOnce();
+      },
+    );
+  });
+
+  it("distinguishes an explicitly disabled owner from an unowned provider", async () => {
+    const disabledRegister = vi.fn();
+    vi.stubGlobal(DISABLED_REGISTER_CALLBACK, disabledRegister);
+    const plugin = writeChutesPlugin({
+      id: "disabled-chutes",
+      registerBody: `globalThis[${JSON.stringify(DISABLED_REGISTER_CALLBACK)}]();`,
+    });
+    const config = createPluginConfig({ id: plugin.id, file: plugin.file, enabled: false });
+    const credential = {
+      type: "oauth" as const,
+      provider: "chutes",
+      access: "at_old",
+      refresh: "rt_old",
+      expires: 1,
+    };
+
+    expect(
+      resolveProviderRefOwnership({ provider: "chutes", config, workspaceDir: plugin.dir }),
+    ).toEqual({ status: "owned", pluginIds: [plugin.id] });
+    await expect(
+      resolveProviderOAuthCredentialWithPlugin({
+        provider: "chutes",
+        config,
+        workspaceDir: plugin.dir,
+        credential,
+        refresh: true,
+      }),
+    ).resolves.toEqual({ status: "configured-unavailable" });
+    await expect(
+      resolveProviderOAuthCredentialWithPlugin({
+        provider: "not-owned",
+        config,
+        workspaceDir: plugin.dir,
+        credential: { ...credential, provider: "not-owned" },
+        refresh: true,
+      }),
+    ).resolves.toEqual({ status: "unowned" });
+    expect(disabledRegister).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/auth-profiles.chutes.test.ts
+++ b/src/agents/auth-profiles.chutes.test.ts
@@ -1,18 +1,23 @@
 /**
  * Chutes auth profile integration tests.
- * Verifies expired OAuth profiles refresh through the provider token endpoint
+ * Verifies expired OAuth profiles refresh through the generic provider seam
  * while preserving the shared auth-profile store contracts.
  */
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
 
-const CHUTES_TOKEN_ENDPOINT = "https://api.chutes.ai/idp/token";
+type ResolveProviderOAuthCredentialWithPlugin =
+  typeof import("../plugins/provider-runtime.runtime.js").resolveProviderOAuthCredentialWithPlugin;
+
+const { resolveProviderOAuthCredentialWithPluginMock } = vi.hoisted(() => ({
+  resolveProviderOAuthCredentialWithPluginMock: vi.fn<ResolveProviderOAuthCredentialWithPlugin>(),
+}));
 
 vi.mock("../plugins/provider-runtime.runtime.js", () => ({
   buildProviderAuthDoctorHintWithPlugin: async () => undefined,
   formatProviderAuthProfileApiKeyWithPlugin: async () => undefined,
-  resolveProviderOAuthCredentialWithPlugin: async () => ({ status: "unowned" }),
+  resolveProviderOAuthCredentialWithPlugin: resolveProviderOAuthCredentialWithPluginMock,
 }));
 
 vi.mock("../plugins/provider-runtime.js", () => ({
@@ -39,11 +44,13 @@ describe("auth-profiles (chutes)", () => {
   });
 
   beforeEach(() => {
+    resolveProviderOAuthCredentialWithPluginMock.mockReset();
     clearRuntimeAuthProfileStoreSnapshots();
     resetFileLockStateForTest();
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
     clearRuntimeAuthProfileStoreSnapshots();
     resetFileLockStateForTest();
@@ -55,40 +62,35 @@ describe("auth-profiles (chutes)", () => {
         layout: "state-only",
         prefix: "openclaw-chutes-",
         agentEnv: "main",
-        env: {
-          CHUTES_CLIENT_ID: undefined,
-        },
       },
       async (state) => {
+        const storedCredential = {
+          type: "oauth" as const,
+          provider: "chutes",
+          access: "at_old",
+          refresh: "rt_old",
+          expires: Date.now() - 60_000,
+          clientId: "cid_test",
+        };
         const store: AuthProfileStore = {
           version: 1,
           profiles: {
-            "chutes:default": {
-              type: "oauth",
-              provider: "chutes",
-              access: "at_old",
-              refresh: "rt_old",
-              expires: Date.now() - 60_000,
-              clientId: "cid_test",
-            },
+            "chutes:default": storedCredential,
           },
         };
         await state.writeAuthProfiles(store);
-
-        const fetchSpy = vi.fn(async (input: string | URL) => {
-          const url = typeof input === "string" ? input : input.toString();
-          if (url !== CHUTES_TOKEN_ENDPOINT) {
-            return new Response("not found", { status: 404 });
-          }
-          return new Response(
-            JSON.stringify({
-              access_token: "at_new",
-              expires_in: 3600,
-            }),
-            { status: 200, headers: { "Content-Type": "application/json" } },
-          );
+        const refreshedCredential = {
+          ...storedCredential,
+          access: "at_new",
+          refresh: "rt_new",
+          expires: Date.now() + 3_600_000,
+        };
+        resolveProviderOAuthCredentialWithPluginMock.mockResolvedValue({
+          status: "available",
+          credential: refreshedCredential,
+          apiKey: refreshedCredential.access,
         });
-        vi.stubGlobal("fetch", fetchSpy);
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
 
         const loaded = ensureAuthProfileStore();
         const resolved = await resolveApiKeyForProfile({
@@ -97,15 +99,17 @@ describe("auth-profiles (chutes)", () => {
         });
 
         expect(resolved?.apiKey).toBe("at_new");
-        expect(fetchSpy).toHaveBeenCalledTimes(1);
-        expect(fetchSpy).toHaveBeenCalledWith(CHUTES_TOKEN_ENDPOINT, expect.any(Object));
+        expect(resolveProviderOAuthCredentialWithPluginMock).toHaveBeenCalledOnce();
+        expect(resolveProviderOAuthCredentialWithPluginMock).toHaveBeenCalledWith({
+          provider: "chutes",
+          config: undefined,
+          credential: storedCredential,
+          refresh: true,
+        });
+        expect(fetchSpy).not.toHaveBeenCalled();
 
         const persisted = loadPersistedAuthProfileStore(state.agentDir());
-        const persistedCredential = persisted?.profiles["chutes:default"];
-        expect(persistedCredential?.type).toBe("oauth");
-        expect(persistedCredential?.type === "oauth" ? persistedCredential.access : undefined).toBe(
-          "at_new",
-        );
+        expect(persisted?.profiles["chutes:default"]).toEqual(refreshedCredential);
       },
     );
   });

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -27,7 +27,6 @@ import {
   SecretSurfaceUnavailableError,
 } from "../../secrets/runtime-degraded-state.js";
 import { normalizeOptionalSecretInput } from "../../utils/normalize-secret-input.js";
-import { refreshChutesTokens } from "../chutes-oauth.js";
 import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
 import {
   evaluateStoredCredentialEligibility,
@@ -202,12 +201,6 @@ async function refreshOAuthCredential(
   }
   if (pluginResult.status === "configured-unavailable") {
     throw new OAuthProviderConfiguredUnavailableError(credential.provider);
-  }
-
-  if (credential.provider === "chutes") {
-    // Chutes refresh shipped before provider hooks and still covers registry-load
-    // windows where the synchronous hook resolver intentionally returns no owner.
-    return await refreshChutesTokens({ credential });
   }
 
   const oauthProvider = resolveOAuthProvider(credential.provider);

--- a/src/agents/chutes-oauth.flow.test.ts
+++ b/src/agents/chutes-oauth.flow.test.ts
@@ -1,7 +1,7 @@
-/** Tests Chutes OAuth token exchange and refresh HTTP flows. */
+/** Tests the retained core Chutes OAuth token exchange compatibility flow. */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
-import { exchangeChutesCodeForTokens, refreshChutesTokens } from "./chutes-oauth.js";
+import { exchangeChutesCodeForTokens } from "./chutes-oauth.js";
 
 const CHUTES_TOKEN_ENDPOINT = "https://api.chutes.ai/idp/token";
 const CHUTES_USERINFO_ENDPOINT = "https://api.chutes.ai/idp/userinfo";
@@ -12,51 +12,6 @@ const urlToString = (url: Request | URL | string): string => {
   }
   return "url" in url ? url.url : String(url);
 };
-
-function createStoredCredential(
-  now: number,
-): Parameters<typeof refreshChutesTokens>[0]["credential"] {
-  return {
-    access: "at_old",
-    refresh: "rt_old",
-    expires: now - 10_000,
-    email: "fred",
-    clientId: "cid_test",
-  } as unknown as Parameters<typeof refreshChutesTokens>[0]["credential"];
-}
-
-function cancelTrackedResponse(
-  text: string,
-  init: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
-}
-
-function expectRefreshedCredential(
-  refreshed: Awaited<ReturnType<typeof refreshChutesTokens>>,
-  now: number,
-) {
-  // Refresh responses may omit refresh_token; the stored token remains valid and
-  // expiry keeps the safety skew applied.
-  expect(refreshed.access).toBe("at_new");
-  expect(refreshed.refresh).toBe("rt_old");
-  expect(refreshed.expires).toBe(now + 1800 * 1000 - 5 * 60 * 1000);
-}
 
 function rejectWhenAborted(init?: RequestInit): Promise<Response> {
   const signal = init?.signal;
@@ -235,81 +190,6 @@ describe("chutes-oauth", () => {
     expect(timeoutSpy).toHaveBeenCalledTimes(2);
   });
 
-  it("refreshes tokens using stored client id and falls back to old refresh token", async () => {
-    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
-    const fetchFn = withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = urlToString(input);
-      if (url !== CHUTES_TOKEN_ENDPOINT) {
-        return new Response("not found", { status: 404 });
-      }
-      expect(init?.method).toBe("POST");
-      const body = init?.body as URLSearchParams;
-      expect(String(body.get("grant_type"))).toBe("refresh_token");
-      expect(String(body.get("client_id"))).toBe("cid_test");
-      expect(String(body.get("refresh_token"))).toBe("rt_old");
-      return new Response(
-        JSON.stringify({
-          access_token: "at_new",
-          expires_in: 1800,
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
-    });
-
-    const now = 2_000_000;
-    const refreshed = await refreshChutesTokens({
-      credential: createStoredCredential(now),
-      fetchFn,
-      now,
-    });
-
-    expectRefreshedCredential(refreshed, now);
-    expect(timeoutSpy).toHaveBeenCalledOnce();
-    expect(timeoutSpy).toHaveBeenCalledWith(30_000);
-  });
-
-  it("times out token refresh requests", async () => {
-    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((delay) => {
-      expect(delay).toBe(30_000);
-      return AbortSignal.abort(new DOMException("OAuth request timed out", "TimeoutError"));
-    });
-    const fetchFn = withFetchPreconnect(
-      async (_input: RequestInfo | URL, init?: RequestInit) => await rejectWhenAborted(init),
-    );
-
-    await expect(
-      refreshChutesTokens({ credential: createStoredCredential(2_000_000), fetchFn }),
-    ).rejects.toMatchObject({ name: "TimeoutError" });
-    expect(timeoutSpy).toHaveBeenCalledOnce();
-  });
-
-  it("refreshes tokens and ignores empty refresh_token values", async () => {
-    const fetchFn = withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = urlToString(input);
-      if (url !== CHUTES_TOKEN_ENDPOINT) {
-        return new Response("not found", { status: 404 });
-      }
-      expect(init?.method).toBe("POST");
-      return new Response(
-        JSON.stringify({
-          access_token: "at_new",
-          refresh_token: "",
-          expires_in: 1800,
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
-    });
-
-    const now = 3_000_000;
-    const refreshed = await refreshChutesTokens({
-      credential: createStoredCredential(now),
-      fetchFn,
-      now,
-    });
-
-    expectRefreshedCredential(refreshed, now);
-  });
-
   it("normalizes and redacts structured token exchange errors", async () => {
     const leakedClientSecret = "oauth-client-secret-1234567890";
     const response = new Response(
@@ -364,65 +244,5 @@ describe("chutes-oauth", () => {
     expect(message).not.toContain("error_description");
     expect((error as { errorBody?: string }).errorBody).not.toContain(leakedClientSecret);
     expect(textSpy).not.toHaveBeenCalled();
-  });
-
-  it("bounds and redacts plain-text token refresh errors", async () => {
-    const leakedRefreshToken = "oauth-refresh-secret-1234567890";
-    const tracked = cancelTrackedResponse(
-      `${`refresh_token=${leakedRefreshToken} unavailable `.repeat(1024)}tail-marker`,
-      {
-        status: 401,
-        headers: { "content-type": "text/plain" },
-      },
-    );
-    const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
-    const fetchFn = withFetchPreconnect(async (input: RequestInfo | URL) => {
-      const url = urlToString(input);
-      if (url === CHUTES_TOKEN_ENDPOINT) {
-        return tracked.response;
-      }
-      return new Response("not found", { status: 404 });
-    });
-
-    let error: unknown;
-    try {
-      await refreshChutesTokens({
-        credential: createStoredCredential(5_000_000),
-        fetchFn,
-        now: 5_000_000,
-      });
-    } catch (caught) {
-      error = caught;
-    }
-
-    expect(error).toMatchObject({ name: "ProviderHttpError", status: 401 });
-    const message = (error as Error).message;
-    expect(message).toContain("Chutes token refresh failed (401): refresh_token=");
-    expect(message).not.toContain(leakedRefreshToken);
-    expect(message).not.toContain("tail-marker");
-    expect((error as { errorBody?: string }).errorBody).not.toContain(leakedRefreshToken);
-    expect(textSpy).not.toHaveBeenCalled();
-    expect(tracked.wasCanceled()).toBe(true);
-  });
-
-  it("rejects unsafe refresh token lifetimes", async () => {
-    const fetchFn = withFetchPreconnect(async (input: RequestInfo | URL) => {
-      const url = urlToString(input);
-      if (url !== CHUTES_TOKEN_ENDPOINT) {
-        return new Response("not found", { status: 404 });
-      }
-      return new Response('{"access_token":"at_new","expires_in":1e309}', {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
-    });
-
-    await expect(
-      refreshChutesTokens({
-        credential: createStoredCredential(4_000_000),
-        fetchFn,
-        now: 4_000_000,
-      }),
-    ).rejects.toThrow("Chutes token refresh returned invalid expires_in");
   });
 });

--- a/src/agents/chutes-oauth.ts
+++ b/src/agents/chutes-oauth.ts
@@ -1,6 +1,6 @@
 /**
- * Implements Chutes OAuth PKCE, callback parsing, token exchange, and refresh
- * for agent model authentication.
+ * Implements Chutes OAuth PKCE, callback parsing, and token exchange for the
+ * deprecated core login compatibility surface.
  */
 import { randomBytes } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -189,69 +189,5 @@ export async function exchangeChutesCodeForTokens(params: {
     email: info?.username,
     accountId: info?.sub,
     clientId: params.app.clientId,
-  } as unknown as ChutesStoredOAuth;
-}
-
-/** Refreshes stored Chutes OAuth credentials, preserving refresh tokens when absent. */
-export async function refreshChutesTokens(params: {
-  credential: ChutesStoredOAuth;
-  fetchFn?: typeof fetch;
-  now?: number;
-}): Promise<ChutesStoredOAuth> {
-  const fetchFn = params.fetchFn ?? fetch;
-  const now = params.now ?? Date.now();
-
-  const refreshToken = params.credential.refresh?.trim();
-  if (!refreshToken) {
-    throw new Error("Chutes OAuth credential is missing refresh token");
-  }
-
-  const clientId = params.credential.clientId?.trim() ?? process.env.CHUTES_CLIENT_ID?.trim();
-  if (!clientId) {
-    throw new Error("Missing CHUTES_CLIENT_ID for Chutes OAuth refresh (set env var or re-auth).");
-  }
-  const clientSecret = normalizeOptionalString(process.env.CHUTES_CLIENT_SECRET);
-
-  const body = new URLSearchParams({
-    grant_type: "refresh_token",
-    client_id: clientId,
-    refresh_token: refreshToken,
-  });
-  if (clientSecret) {
-    body.set("client_secret", clientSecret);
-  }
-
-  const response = await fetchFn(CHUTES_TOKEN_ENDPOINT, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body,
-    signal: buildOAuthRequestSignal({ timeoutMs: CHUTES_OAUTH_REQUEST_TIMEOUT_MS }),
-  });
-  await assertOkOrThrowProviderError(response, "Chutes token refresh failed");
-
-  const data = await readProviderJsonResponse<{
-    access_token?: string;
-    refresh_token?: string;
-    expires_in?: number;
-  }>(response, "Chutes token refresh");
-  const access = data.access_token?.trim();
-  const newRefresh = data.refresh_token?.trim();
-  const expires = resolveChutesExpiresAt(data.expires_in, now);
-
-  if (!access) {
-    throw new Error("Chutes token refresh returned no access_token");
-  }
-  if (expires === undefined) {
-    throw new Error("Chutes token refresh returned invalid expires_in");
-  }
-
-  return {
-    ...params.credential,
-    access,
-    // RFC 6749 section 6 makes new refresh tokens optional; Chutes may omit one
-    // on refresh, so preserve the old token unless a replacement is returned.
-    refresh: newRefresh || refreshToken,
-    expires,
-    clientId,
   } as unknown as ChutesStoredOAuth;
 }


### PR DESCRIPTION
## What Problem This Solves

Chutes OAuth refresh was duplicated and live in core while login was provider-owned. Core hardcoded a Chutes fallback after generic provider dispatch.

## Why This Change Was Made

Provider-specific auth belongs to the owner plugin. This registers the existing generic `ProviderPlugin.refreshOAuth` hook and removes the core refresh implementation and fallback, without adding a new SDK or provider-named seam.

Compatibility decision: retain the shipped deprecated `provider-auth-login.runtime` `loginChutes` shim plus the core login/token-exchange implementation and its deprecation inventory. The latest stable release shipped it; `removeAfter` is 2026-10-01, and explicit breaking-release approval is required. This PR does not shorten that window.

The maintainer owner decision accepts the generic `configured-unavailable` outcome when the Chutes owner plugin is disabled or removed; core must not continue executing Chutes vendor protocol in that state.

## User Impact

Installed and enabled Chutes plugins keep existing OAuth profiles auto-refreshing. When the owner plugin is missing or disabled, Chutes now follows the generic configured-unavailable behavior instead of silently running vendor protocol in core.

## Evidence

- `node scripts/run-vitest.mjs extensions/chutes/oauth.test.ts extensions/chutes/implicit-provider.test.ts src/agents/auth-profiles.chutes.test.ts` — 24 passed.
- `node scripts/run-vitest.mjs src/agents/chutes-oauth.flow.test.ts src/agents/chutes-oauth.test.ts src/commands/chutes-oauth.test.ts` — 15 passed.
- `node scripts/run-vitest.mjs src/agents/auth-profiles.chutes.lifecycle.test.ts` — 2 passed, covering synchronous provider registration, persisted refresh, and disabled-versus-absent ownership.
- `node scripts/run-vitest.mjs src/agents/auth-profiles.chutes.test.ts src/plugins/provider-runtime.test.ts extensions/chutes/oauth.test.ts` — 84 passed.
- Full `pnpm check:changed` passed on Blacksmith Testbox `tbx_01kzj4jwnda1589cje9gcctsbp` after one test-only lint correction: https://github.com/openclaw/openclaw/actions/runs/31289799926
- The path-scoped lifecycle changed gate passed on Blacksmith Testbox `tbx_01kzjbnaesrdb98vtxcb9sghx0`: https://github.com/openclaw/openclaw/actions/runs/31294140350
- Exact-head CI passed for `a1c0f95295039bc081449f80b996da5da5b2ea20`: https://github.com/openclaw/openclaw/actions/runs/31294769803
- Fresh implementation and lifecycle autoreviews reported no actionable findings.
- ClawSweeper's current-head review reported no findings; its owner-decision and exact-head-CI rank-up moves are satisfied.
- No live Chutes credentials or network were used; HTTP behavior is covered with mocks.
- Production LOC: +68/-75 (net -7). Tests: +458/-218 (net +240).
