### PR TITLE
fix(telegram): honor polling retry cooldown in watchdog

### DIFF
--- a/extensions/telegram/src/polling-liveness.test.ts
+++ b/extensions/telegram/src/polling-liveness.test.ts
@@ -40,6 +40,58 @@ describe("TelegramPollingLivenessTracker", () => {
     ).toContain("Polling stall detected");
   });
 
+  it("keeps idle polling alive only until its recorded server-directed wait expires", () => {
+    let now = 0;
+    const tracker = new TelegramPollingLivenessTracker({ monotonicNow: () => now });
+
+    tracker.noteGetUpdatesStarted({ offset: null });
+    tracker.noteGetUpdatesError(new Error("Too Many Requests"), 0, 180_000);
+    tracker.noteGetUpdatesFinished();
+
+    for (const elapsedMs of [30_000, 60_000, 90_000, 120_000, 150_000, 180_000]) {
+      now = elapsedMs;
+      expect(tracker.detectStall({ thresholdMs: 120_000 })).toBeNull();
+    }
+
+    now = 180_001;
+    expect(tracker.detectStall({ thresholdMs: 120_000 })?.message).toContain(
+      "Polling stall detected",
+    );
+  });
+
+  it("never lets an old flood wait hide a newly stuck getUpdates request", () => {
+    let now = 0;
+    const tracker = new TelegramPollingLivenessTracker({ monotonicNow: () => now });
+
+    tracker.noteGetUpdatesStarted({ offset: null });
+    tracker.noteGetUpdatesError(new Error("Too Many Requests"), 0, 180_000);
+    tracker.noteGetUpdatesFinished();
+    now = 10_000;
+    tracker.noteGetUpdatesStarted({ offset: 1 });
+
+    now = 150_000;
+    expect(tracker.detectStall({ thresholdMs: 120_000 })?.message).toContain(
+      "active getUpdates stuck",
+    );
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, 0, -1])(
+    "ignores an invalid server-directed wait (%s)",
+    (retryAfterMs) => {
+      let now = 0;
+      const tracker = new TelegramPollingLivenessTracker({ monotonicNow: () => now });
+
+      tracker.noteGetUpdatesStarted({ offset: null });
+      tracker.noteGetUpdatesError(new Error("Too Many Requests"), 0, retryAfterMs);
+      tracker.noteGetUpdatesFinished();
+
+      now = 150_000;
+      expect(tracker.detectStall({ thresholdMs: 120_000 })?.message).toContain(
+        "Polling stall detected",
+      );
+    },
+  );
+
   it("detects and throttles stale polling diagnostics", () => {
     let now = 0;
     const tracker = new TelegramPollingLivenessTracker({ monotonicNow: () => now });

--- a/extensions/telegram/src/polling-liveness.ts
+++ b/extensions/telegram/src/polling-liveness.ts
@@ -24,6 +24,7 @@ export class TelegramPollingLivenessTracker {
   #inFlightGetUpdates = 0;
   #stallDiagLoggedMonotonicAt = 0;
   #lastStallCheckMonotonicAt: number;
+  #retryAfterUntilMonotonicAt: number | null = null;
 
   constructor(private readonly options: TelegramPollingLivenessTrackerOptions = {}) {
     const monotonicNow = this.#monotonicNow();
@@ -37,6 +38,7 @@ export class TelegramPollingLivenessTracker {
 
   noteGetUpdatesStarted(payload: unknown, at = this.#now()) {
     const startedMonotonicAt = this.#monotonicNow();
+    this.#retryAfterUntilMonotonicAt = null;
     this.#lastGetUpdatesActivityMonotonicAt = startedMonotonicAt;
     this.#lastGetUpdatesStartedAt = at;
     this.#lastGetUpdatesStartedMonotonicAt = startedMonotonicAt;
@@ -61,8 +63,11 @@ export class TelegramPollingLivenessTracker {
     this.options.onPollSuccess?.(at);
   }
 
-  noteGetUpdatesError(err: unknown, at = this.#now()) {
+  noteGetUpdatesError(err: unknown, at = this.#now(), retryAfterMs?: number) {
     this.#noteGetUpdatesCompleted(at);
+    if (retryAfterMs !== undefined && Number.isFinite(retryAfterMs) && retryAfterMs > 0) {
+      this.#retryAfterUntilMonotonicAt = this.#monotonicNow() + retryAfterMs;
+    }
     this.#lastGetUpdatesOutcome = "error";
     this.#lastGetUpdatesError = formatErrorMessage(err);
   }
@@ -83,6 +88,14 @@ export class TelegramPollingLivenessTracker {
     // missing two full detection windows. Rebase once, then observe normally.
     if (checkGap > params.thresholdMs * 2) {
       this.#lastGetUpdatesActivityMonotonicAt = monotonicNow;
+      return null;
+    }
+    // Flood waits excuse an idle worker, never a newly stuck in-flight poll.
+    if (
+      this.#inFlightGetUpdates === 0 &&
+      this.#retryAfterUntilMonotonicAt !== null &&
+      monotonicNow <= this.#retryAfterUntilMonotonicAt
+    ) {
       return null;
     }
     const elapsed = monotonicNow - this.#lastGetUpdatesActivityMonotonicAt;
@@ -122,6 +135,7 @@ export class TelegramPollingLivenessTracker {
 
   #noteGetUpdatesCompleted(finishedAt: number): void {
     const finishedMonotonicAt = this.#monotonicNow();
+    this.#retryAfterUntilMonotonicAt = null;
     this.#lastGetUpdatesActivityMonotonicAt = finishedMonotonicAt;
     this.#lastGetUpdatesFinishedAt = finishedAt;
     this.#lastGetUpdatesDurationMs =

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { Worker } from "node:worker_threads";
@@ -44,7 +45,10 @@ const shouldDeadLetterRetryableSpooledUpdate = (
   now?: number,
 ) => shouldDeadLetterRetryableIngressEvent(update, attempt, undefined, now);
 import type { TelegramSpooledUpdate } from "./telegram-ingress-spool.test-support.js";
-import type { TelegramIngressWorkerMessage } from "./telegram-ingress-worker.js";
+import {
+  TELEGRAM_INGRESS_WORKER_RUNTIME_MARKER,
+  type TelegramIngressWorkerMessage,
+} from "./telegram-ingress-worker.js";
 
 async function waitForTelegramTestState<T>(assertion: () => T | Promise<T>): Promise<T> {
   return await vi.waitFor(assertion, { interval: 1 });
@@ -1970,6 +1974,244 @@ describe("TelegramPollingSession", () => {
 
     expect(createWorker).toHaveBeenCalledTimes(2);
     expect(computeBackoffMock.mock.calls.map((call) => call[1])).toEqual([1, 1]);
+  });
+
+  it("keeps a real polling worker alive during Telegram's server-directed flood wait", async () => {
+    await withTempSpool(async (spoolDir) => {
+      let requestCount = 0;
+      const server = createServer((_request, response) => {
+        requestCount += 1;
+        response.writeHead(429, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({
+            ok: false,
+            error_code: 429,
+            description: "Too Many Requests: retry after 180",
+            parameters: { retry_after: 180 },
+          }),
+        );
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Expected a real loopback Bot API listener");
+      }
+
+      const abort = new AbortController();
+      const log = vi.fn();
+      const watchdogHarness = installPollingStallWatchdogHarness([0]);
+      createTelegramBotMock.mockReturnValue(makeIsolatedBot());
+      let actualWorker: Worker | undefined;
+      let reportPollError: ((message: TelegramIngressWorkerMessage) => void) | undefined;
+      const pollErrorReceived = new Promise<TelegramIngressWorkerMessage>((resolve) => {
+        reportPollError = resolve;
+      });
+      const workerStop = vi.fn(async () => {
+        if (actualWorker) {
+          Reflect.apply(
+            Reflect.get(actualWorker, "postMessage") as (message: unknown) => void,
+            actualWorker,
+            [{ type: "stop" }],
+          );
+          await actualWorker.terminate();
+        }
+      });
+      const createWorker = vi.fn(() => {
+        const worker = new Worker(
+          new URL("./telegram-ingress-worker.runtime.ts", import.meta.url),
+          {
+            execArgv: ["--import", "tsx"],
+            workerData: {
+              runtime: TELEGRAM_INGRESS_WORKER_RUNTIME_MARKER,
+              token: "tok",
+              accountId: "default",
+              initialUpdateId: null,
+              spoolDir,
+              apiRoot: `http://127.0.0.1:${address.port}`,
+              timeoutSeconds: 1,
+            },
+          },
+        );
+        actualWorker = worker;
+        const task = new Promise<void>((resolve, reject) => {
+          worker.once("error", reject);
+          worker.once("exit", (code) => {
+            if (code === 0) {
+              resolve();
+            } else {
+              reject(new Error(`Telegram test worker exited with code ${code}`));
+            }
+          });
+        });
+        return {
+          onMessage: vi.fn((listener: WorkerMessageListener) => {
+            const forwardMessage = (message: TelegramIngressWorkerMessage) => {
+              listener(message);
+              if (message.type === "poll-error") {
+                reportPollError?.(message);
+              }
+            };
+            worker.on("message", forwardMessage);
+            return () => worker.off("message", forwardMessage);
+          }),
+          stop: workerStop,
+          task: () => task,
+        };
+      });
+      const session = createPollingSession({
+        abortSignal: abort.signal,
+        log,
+        isolatedIngress: {
+          enabled: true,
+          createWorker,
+          spoolDir,
+        },
+      });
+      const runPromise = session.runUntilAbort();
+
+      try {
+        const watchdog = await watchdogHarness.waitForWatchdog();
+        const pollError = await pollErrorReceived;
+        expect(pollError).toMatchObject({ type: "poll-error", errorCode: 429 });
+        expect(requestCount).toBe(1);
+
+        for (const elapsedMs of [30_000, 60_000, 90_000, 120_000, 150_000]) {
+          watchdogHarness.setNow(elapsedMs);
+          watchdog();
+        }
+
+        expect(workerStop).not.toHaveBeenCalled();
+        expect(createWorker).toHaveBeenCalledTimes(1);
+        expect(pollError).toMatchObject({ retryAfterMs: 180_000 });
+        expectLogExcludes(log, "Polling stall detected");
+      } finally {
+        abort.abort();
+        await runPromise.catch(() => undefined);
+        await actualWorker?.terminate();
+        watchdogHarness.restore();
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error) {
+              reject(error);
+            } else {
+              resolve();
+            }
+          });
+        });
+      }
+    });
+  });
+
+  it("caps an untrusted Telegram flood wait at the existing maximum polling threshold", async () => {
+    const abort = new AbortController();
+    const worker = createListeningIngressWorker();
+    const watchdogHarness = installPollingStallWatchdogHarness([0]);
+    const { runPromise } = startIsolatedIngressSession({
+      abort,
+      handleUpdate: async () => undefined,
+      createWorker: worker.createWorker,
+    });
+
+    try {
+      const watchdog = await watchdogHarness.waitForWatchdog();
+      worker.emit({
+        type: "poll-error",
+        errorCode: 429,
+        message: "Too Many Requests",
+        finishedAt: 0,
+        retryAfterMs: Number.MAX_VALUE,
+      });
+
+      for (let elapsedMs = 30_000; elapsedMs <= 600_000; elapsedMs += 30_000) {
+        watchdogHarness.setNow(elapsedMs);
+        watchdog();
+        expect(worker.workerStop).not.toHaveBeenCalled();
+      }
+
+      watchdogHarness.setNow(630_000);
+      watchdog();
+      expect(worker.workerStop).toHaveBeenCalledTimes(1);
+    } finally {
+      abort.abort();
+      await runPromise;
+      watchdogHarness.restore();
+    }
+  });
+
+  it.each([
+    { name: "missing flood wait", errorCode: 429, retryAfterMs: undefined },
+    { name: "negative flood wait", errorCode: 429, retryAfterMs: -1 },
+    { name: "zero flood wait", errorCode: 429, retryAfterMs: 0 },
+    { name: "non-finite flood wait", errorCode: 429, retryAfterMs: Number.POSITIVE_INFINITY },
+    { name: "server error", errorCode: 502, retryAfterMs: 180_000 },
+    { name: "unauthorized bot", errorCode: 401, retryAfterMs: 180_000 },
+    { name: "missing bot", errorCode: 404, retryAfterMs: 180_000 },
+    { name: "webhook conflict", errorCode: 409, retryAfterMs: 180_000 },
+  ])("does not disable the polling watchdog for $name", async ({ errorCode, retryAfterMs }) => {
+    const abort = new AbortController();
+    const worker = createListeningIngressWorker();
+    const watchdogHarness = installPollingStallWatchdogHarness([0]);
+    const { runPromise } = startIsolatedIngressSession({
+      abort,
+      handleUpdate: async () => undefined,
+      createWorker: worker.createWorker,
+    });
+
+    try {
+      const watchdog = await watchdogHarness.waitForWatchdog();
+      worker.emit({
+        type: "poll-error",
+        errorCode,
+        message: "Telegram polling error",
+        finishedAt: 0,
+        ...(retryAfterMs === undefined ? {} : { retryAfterMs }),
+      });
+
+      watchdogHarness.setNow(150_000);
+      watchdog();
+      expect(worker.workerStop).toHaveBeenCalledTimes(1);
+    } finally {
+      abort.abort();
+      await runPromise;
+      watchdogHarness.restore();
+    }
+  });
+
+  it("restores hung-poll detection when a new request ends a Telegram flood wait", async () => {
+    const abort = new AbortController();
+    const worker = createListeningIngressWorker();
+    const watchdogHarness = installPollingStallWatchdogHarness([0]);
+    const { runPromise } = startIsolatedIngressSession({
+      abort,
+      handleUpdate: async () => undefined,
+      createWorker: worker.createWorker,
+    });
+
+    try {
+      const watchdog = await watchdogHarness.waitForWatchdog();
+      worker.emit({
+        type: "poll-error",
+        errorCode: 429,
+        message: "Too Many Requests",
+        finishedAt: 0,
+        retryAfterMs: 180_000,
+      });
+
+      watchdogHarness.setNow(150_000);
+      watchdog();
+      expect(worker.workerStop).not.toHaveBeenCalled();
+
+      worker.emit({ type: "poll-start", offset: null, startedAt: 150_000 });
+      watchdogHarness.setNow(300_001);
+      watchdog();
+      expect(worker.workerStop).toHaveBeenCalledTimes(1);
+    } finally {
+      abort.abort();
+      await runPromise;
+      watchdogHarness.restore();
+    }
   });
 
   it("restarts isolated ingress when worker liveness stalls", async () => {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -515,7 +515,14 @@ export class TelegramPollingSession {
       }
       if (message.type === "poll-error") {
         this.#rearmPendingDeliveryDrain();
-        liveness.noteGetUpdatesError(new Error(message.message), message.finishedAt);
+        const retryAfterMs =
+          message.errorCode === 429 &&
+          message.retryAfterMs !== undefined &&
+          Number.isFinite(message.retryAfterMs) &&
+          message.retryAfterMs > 0
+            ? Math.min(message.retryAfterMs, MAX_POLL_STALL_THRESHOLD_MS)
+            : undefined;
+        liveness.noteGetUpdatesError(new Error(message.message), message.finishedAt, retryAfterMs);
         liveness.noteGetUpdatesFinished();
         pollState.outcome = "error";
         pollState.error = message.message;

--- a/extensions/telegram/src/telegram-ingress-worker.runtime.test.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.runtime.test.ts
@@ -288,7 +288,7 @@ describe("telegram ingress worker retry policy", () => {
     expect(runtime.calls).toHaveLength(1);
     await flushRuntime();
     expect(runtime.messages).toContainEqual(
-      expect.objectContaining({ type: "poll-error", errorCode: 429 }),
+      expect.objectContaining({ type: "poll-error", errorCode: 429, retryAfterMs: 50 }),
     );
     await vi.advanceTimersByTimeAsync(49);
     expect(runtime.calls).toHaveLength(1);
@@ -303,6 +303,30 @@ describe("telegram ingress worker retry policy", () => {
       expect.objectContaining({ type: "poll-success", count: 0 }),
     );
   });
+
+  it.each([0, -1, Number.MAX_VALUE])(
+    "does not publish an invalid effective flood wait (%s)",
+    async (retryAfterSeconds) => {
+      vi.useFakeTimers();
+      const runtime = createRuntime([
+        jsonResponse(429, {
+          ok: false,
+          error_code: 429,
+          description: "Too Many Requests",
+          parameters: { retry_after: retryAfterSeconds },
+        }),
+        jsonResponse(200, { ok: true, result: [] }),
+      ]);
+
+      await flushRuntime();
+      await runtime.done;
+
+      const floodError = runtime.messages.find((message) => message.type === "poll-error");
+      expect(floodError).toMatchObject({ type: "poll-error", errorCode: 429 });
+      expect(floodError).not.toHaveProperty("retryAfterMs");
+      expect(runtime.calls).toHaveLength(2);
+    },
+  );
 
   it.each([500, 502])("retries getUpdates %s responses with backoff", async (status) => {
     vi.useFakeTimers();

--- a/extensions/telegram/src/telegram-ingress-worker.runtime.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.runtime.ts
@@ -81,12 +81,22 @@ function readTelegramErrorCode(err: unknown): number | undefined {
   return undefined;
 }
 
-function postPollError(port: TelegramIngressRuntimePort, err: unknown): void {
+function postPollError(
+  port: TelegramIngressRuntimePort,
+  err: unknown,
+  retryAfterMs?: number,
+): void {
   const errorCode = readTelegramErrorCode(err);
   port.postMessage({
     type: "poll-error",
     message: formatErrorMessage(err),
     ...(errorCode === undefined ? {} : { errorCode }),
+    ...(errorCode === 429 &&
+    retryAfterMs !== undefined &&
+    Number.isFinite(retryAfterMs) &&
+    retryAfterMs > 0
+      ? { retryAfterMs }
+      : {}),
     finishedAt: Date.now(),
   });
 }
@@ -303,7 +313,9 @@ export async function runTelegramIngressWorkerRuntime(params: {
         }
         consecutiveEmptyPolls = 0;
         failures += 1;
-        postPollError(port, err);
+        const retryAfterMs = readTelegramRetryAfterMs(err);
+        // The parent must observe the exact flood wait this worker actually honors.
+        postPollError(port, err, retryAfterMs);
         // 409 must propagate to the parent: it owns duplicate-poller/webhook
         // conflict recovery. Transient Bot API errors stay local to this worker.
         if (!isRetryableTelegramApiError(err, { context: "polling" })) {
@@ -311,8 +323,7 @@ export async function runTelegramIngressWorkerRuntime(params: {
         }
         try {
           await sleepWithAbort(
-            readTelegramRetryAfterMs(err) ??
-              computeBackoff(TELEGRAM_RETRY_BACKOFF_POLICY, failures),
+            retryAfterMs ?? computeBackoff(TELEGRAM_RETRY_BACKOFF_POLICY, failures),
             stopController.signal,
             { ref: false },
           );

--- a/extensions/telegram/src/telegram-ingress-worker.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.ts
@@ -22,6 +22,8 @@ export type TelegramIngressWorkerMessage =
       message: string;
       /** Telegram Bot API error_code (e.g. 409 for getUpdates conflicts). */
       errorCode?: number;
+      /** Actual server-directed flood wait currently being honored by the worker. */
+      retryAfterMs?: number;
       finishedAt: number;
     }
   | {


### PR DESCRIPTION
## Summary

Telegram's isolated polling worker correctly honored an HTTP 429 retry delay, but its parent watchdog had no authoritative record of that cooldown and killed a healthy worker after 150 seconds even when Telegram required 180 seconds of backoff.

Record the actual finite retry delay at the private worker owner and carry that bounded fact to the parent polling liveness tracker. The existing maximum remains unchanged, cooldown applies only while polling is idle, and normal polling, fatal errors, invalid hints, aborts, and genuinely stalled workers retain their existing behavior.

## Verification

- Tests-first production proof ran a genuine Node worker, a real localhost Telegram HTTP 429 response, the actual parent polling session, and the original watchdog clock; the unchanged owner stopped a healthy worker at 150 seconds.
- Final owner coverage: 123 passed across polling session, worker runtime, and liveness suites, including the real-worker regression, maximum cooldown, malformed hints, fatal responses, resets, and genuine hangs.
- An independent reviewer separately executed the final production worker, real HTTP response, parent handler, and monotonic tracker and confirmed the actual 180-second provider delay is preserved.
- Targeted lint, plugin test typechecking, the complete seven-file changed gate, and fresh independent review all passed.
- Production change: four existing private owner files, net +34 lines for authoritative cross-worker cooldown ownership; three existing regression suites, net +318 lines.
