### PR TITLE
chore(claws): require complete export fixtures

### DIFF
--- a/src/claws/export.test.ts
+++ b/src/claws/export.test.ts
@@ -166,7 +166,7 @@ async function installedFixture(
     context: { workspace: join(root, "workspace-worker") },
   });
   let config: OpenClawConfig = {};
-  await applyClawAddPlan(plan, {
+  const added = await applyClawAddPlan(plan, {
     consentPlanIntegrity: plan.planIntegrity,
     env: { OPENCLAW_STATE_DIR: join(root, "state") },
     commitConfig: async (transform) => {
@@ -183,6 +183,11 @@ async function installedFixture(
       }),
     cronGateway: { add: async () => ({ id: "scheduler-daily" }) },
   });
+  if (added.status !== "complete") {
+    throw new Error(
+      `installedFixture applyClawAddPlan incomplete (${added.error?.code ?? "unknown_error"}): ${added.error?.message ?? "missing error details"}`,
+    );
+  }
   if (options.withPackage) {
     persistClawPackageRef(
       plan,

--- a/src/claws/export.test.ts
+++ b/src/claws/export.test.ts
@@ -151,7 +151,7 @@ async function installedFixture(
     context: { workspace: join(root, "workspace-worker") },
   });
   let config: OpenClawConfig = {};
-  await applyClawAddPlan(plan, {
+  const added = await applyClawAddPlan(plan, {
     consentPlanIntegrity: plan.planIntegrity,
     env: { OPENCLAW_STATE_DIR: join(root, "state") },
     commitConfig: async (transform) => {
@@ -168,6 +168,11 @@ async function installedFixture(
       }),
     cronGateway: { add: async () => ({ id: "scheduler-daily" }) },
   });
+  if (added.status !== "complete") {
+    throw new Error(
+      `installedFixture applyClawAddPlan incomplete (${added.error?.code ?? "unknown_error"}): ${added.error?.message ?? "missing error details"}`,
+    );
+  }
   if (options.withPackage) {
     persistClawPackageRef(
       plan,


### PR DESCRIPTION
Related: #120644

## What Problem This Solves

The installed-Claw export fixture discarded `applyClawAddPlan()`'s structured `complete | partial` result. A partial installation could therefore continue into package persistence and downstream export assertions as though fixture setup had succeeded.

## Why This Change Was Made

The fixture now requires a `complete` result at the setup owner boundary and reports the structured error code and message otherwise. The branch was reconstructed from current `main`; it carries no historical file drift.

No production code, config, protocol, or storage surface changes.

## User Impact

No direct user-visible behavior changes. Developers and maintainers get an immediate, attributable fixture failure instead of misleading downstream export results.

## Evidence

- Exact head: `febfbde64ca72d6679d5a1eede6b5d63d20190a2`
- `node scripts/run-vitest.mjs src/claws/export.test.ts`: 28/28 passed.
- `node scripts/run-vitest.mjs src/claws/add.test.ts src/claws/bootstrap.test.ts`: 19/19 passed.
- Transient cron-failure probe: fixture stopped at `installedFixture applyClawAddPlan incomplete (cron_install_failed)` before downstream assertions.
- `node scripts/check-changed.mjs --dry-run -- src/claws/export.test.ts`: `coreTests`.
- `node scripts/check-changed.mjs -- src/claws/export.test.ts`: all gates through the core graph boundary passed; test typecheck then refused the nested shared-`node_modules` worktree topology and requires isolated hosted CI.
- `oxfmt --check src/claws/export.test.ts`: passed.
- `git diff --check`: passed.
- Autoreview through P2: scoped clean, patch correct with 0.98 confidence.
- Delta: test +6/-1; production +0/-0.
