### PR TITLE
fix: report indeterminate port availability on Windows

### DIFF
--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -11,7 +11,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 import { VERSION } from "../../version.js";
 import type { GatewayRestartSnapshot } from "./restart-health.js";
-import { gatherDaemonStatus } from "./status.gather.js";
+import { gatherDaemonStatus, renderPortDiagnosticsForCli } from "./status.gather.js";
 import { printDaemonStatus } from "./status.print.js";
 
 type PortConnections = Awaited<
@@ -86,6 +86,7 @@ const inspectPortConnections = vi.fn<(port: number) => Promise<PortConnections>>
     connections: [],
   }),
 );
+const formatPortDiagnostics = vi.fn<(usage: PortUsageTestSummary) => string[]>(() => []);
 const readLastGatewayErrorLine = vi.fn<
   (_env?: NodeJS.ProcessEnv, _options?: { requirePatternMatch?: boolean }) => Promise<string | null>
 >(async (_env?: NodeJS.ProcessEnv, _options?: { requirePatternMatch?: boolean }) => null);
@@ -281,7 +282,7 @@ vi.mock("../../infra/ports-inspect.js", () => ({
 }));
 
 vi.mock("../../infra/ports-format.js", () => ({
-  formatPortDiagnostics: () => [],
+  formatPortDiagnostics: (usage: PortUsageTestSummary) => formatPortDiagnostics(usage),
 }));
 
 vi.mock("../../infra/restart-handoff.js", () => ({
@@ -390,6 +391,7 @@ describe("gatherDaemonStatus", () => {
       );
     });
     inspectPortConnections.mockClear();
+    formatPortDiagnostics.mockReset().mockReturnValue(["port diagnostics"]);
     inspectWindowsGatewayFirewall.mockClear();
     inspectWindowsGatewayFirewall.mockResolvedValue({
       applies: false,
@@ -424,6 +426,26 @@ describe("gatherDaemonStatus", () => {
 
   afterEach(() => {
     envSnapshot.restore();
+  });
+
+  it("reports indeterminate port availability unless the RPC probe succeeded", () => {
+    const status = {
+      service: {
+        label: "Scheduled Task",
+        loaded: true,
+        loadedText: "registered",
+        notLoadedText: "not registered",
+      },
+      port: { port: 18789, status: "unknown" as const, listeners: [], hints: [] },
+      extraServices: [],
+    };
+
+    expect(renderPortDiagnosticsForCli(status, false)).toEqual(["port diagnostics"]);
+    expect(formatPortDiagnostics).toHaveBeenCalledWith(status.port);
+    expect(renderPortDiagnosticsForCli(status, true)).toEqual([]);
+    expect(
+      renderPortDiagnosticsForCli({ ...status, port: { ...status.port, status: "free" } }, false),
+    ).toEqual([]);
   });
 
   it("uses wss probe URL and forwards TLS fingerprint when daemon TLS is enabled", async () => {

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -368,7 +368,7 @@ export type DaemonStatus = {
 };
 
 function shouldReportPortUsage(status: PortUsageStatus | undefined, rpcOk?: boolean) {
-  if (status !== "busy") {
+  if (status === undefined || status === "free") {
     return false;
   }
   if (rpcOk === true) {

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -382,6 +382,45 @@ describe("printDaemonStatus", () => {
     expect(errors.match(/Last gateway error:/g)).toHaveLength(1);
   });
 
+  it("does not claim an indeterminate port is not listening", () => {
+    printDaemonStatus(
+      {
+        service: {
+          label: "Scheduled Task",
+          loaded: true,
+          loadedText: "registered",
+          notLoadedText: "not registered",
+          runtime: { status: "running", pid: 8000 },
+        },
+        gateway: {
+          bindMode: "loopback",
+          bindHost: "127.0.0.1",
+          port: 18789,
+          portSource: "env/config",
+          probeUrl: "ws://127.0.0.1:18789",
+        },
+        port: {
+          port: 18789,
+          status: "unknown",
+          listeners: [],
+          hints: [],
+        },
+        rpc: {
+          ok: false,
+          kind: "connect",
+          capability: "unknown",
+          error: "gateway closed (1000): ",
+          url: "ws://127.0.0.1:18789",
+        },
+        extraServices: [],
+      },
+      { json: false },
+    );
+
+    const errors = runtime.error.mock.calls.map(([line]) => line).join("\n");
+    expect(errors).not.toContain("Gateway port 18789 is not listening");
+  });
+
   it("prints GUI-session wording before generic missing-supervision wording", () => {
     printDaemonStatus(
       {

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -486,7 +486,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
     service.loaded &&
     service.runtime?.status === "running" &&
     status.port &&
-    status.port.status !== "busy"
+    status.port.status === "free"
   ) {
     defaultRuntime.error(
       errorText(`Gateway port ${status.port.port} is not listening (service appears running).`),

--- a/src/commands/status-all/diagnosis.test.ts
+++ b/src/commands/status-all/diagnosis.test.ts
@@ -155,6 +155,32 @@ describe("status-all diagnosis port checks", () => {
     expect(output).toContain("Port 18789 is already in use.");
   });
 
+  it("warns when port availability could not be determined", async () => {
+    const params = createBaseParams([]);
+    params.portUsage = { port: 18789, status: "unknown", listeners: [], hints: [] };
+
+    await appendStatusAllDiagnosis(params);
+
+    const output = params.lines.join("\n");
+    expect(output).toContain("! Port 18789");
+    expect(output).toContain("Port 18789 availability could not be determined.");
+    expect(output).not.toContain("Port 18789 is free.");
+  });
+
+  it("does not let attributed listeners override indeterminate availability", async () => {
+    const params = createBaseParams([
+      { pid: 5001, commandLine: "openclaw-gateway", address: "127.0.0.1:18789" },
+    ]);
+    params.portUsage!.status = "unknown";
+
+    await appendStatusAllDiagnosis(params);
+
+    const output = params.lines.join("\n");
+    expect(output).toContain("! Port 18789");
+    expect(output).toContain("Port 18789 availability could not be determined.");
+    expect(output).not.toContain("Detected OpenClaw Gateway listener");
+  });
+
   it("adds direct update restart guidance for failed update sentinels", async () => {
     const params = createBaseParams([]);
     params.sentinel = {

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -253,7 +253,9 @@ export async function appendStatusAllDiagnosis(params: {
       params.portUsage.listeners,
       params.port,
     );
-    const portOk = params.portUsage.listeners.length === 0 || expectedGatewayListeners;
+    const portOk =
+      params.portUsage.status === "free" ||
+      (params.portUsage.status === "busy" && expectedGatewayListeners);
     emitCheck(`Port ${params.port}`, portOk ? "ok" : "warn");
     if (!portOk) {
       const gatewayPidCount = countGatewayListenerPids(params.portUsage);

--- a/src/infra/ports-format.test.ts
+++ b/src/infra/ports-format.test.ts
@@ -167,7 +167,7 @@ describe("ports-format", () => {
     ).toEqual([gatewayAlreadyRunningHint, multipleListenersHint]);
   });
 
-  it("formats free and busy port diagnostics", () => {
+  it("formats free, unknown, and busy port diagnostics", () => {
     expect(
       formatPortDiagnostics({
         port: 18789,
@@ -176,6 +176,15 @@ describe("ports-format", () => {
         hints: [],
       }),
     ).toEqual(["Port 18789 is free."]);
+
+    expect(
+      formatPortDiagnostics({
+        port: 18789,
+        status: "unknown",
+        listeners: [],
+        hints: [],
+      }),
+    ).toEqual(["Port 18789 availability could not be determined."]);
 
     const lines = formatPortDiagnostics({
       port: 18789,

--- a/src/infra/ports-format.ts
+++ b/src/infra/ports-format.ts
@@ -210,10 +210,13 @@ function formatPortListener(listener: PortListener): string {
   return `${pid}${user}: ${command}${address}`;
 }
 
-/** Formats free/busy port diagnostics into CLI output lines. */
+/** Formats port diagnostics into CLI output lines. */
 export function formatPortDiagnostics(diagnostics: PortUsage): string[] {
-  if (diagnostics.status !== "busy") {
+  if (diagnostics.status === "free") {
     return [`Port ${diagnostics.port} is free.`];
+  }
+  if (diagnostics.status === "unknown") {
+    return [`Port ${diagnostics.port} availability could not be determined.`];
   }
   const lines = [`Port ${diagnostics.port} is already in use.`];
   for (const listener of diagnostics.listeners) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows users running daemon or full-status diagnostics could be told that a port was free, or that the Gateway was not listening, when Windows could not determine the port's availability. This is reproducible with a TCP port from a Windows excluded range: the bind probe returns `unknown`, even though no listener owns the port.

## Why This Change Was Made

The port probe and inspector already own an explicit `free | busy | unknown` result, but four downstream projections collapsed `unknown` into a successful/free outcome. This change preserves that tri-state through the shared formatter, daemon status gathering/printing, and `status --all`. A successful Gateway RPC remains authoritative and suppresses an indeterminate local-port warning; an expected Gateway listener counts as healthy only when the probe state is actually `busy`.

This keeps the existing producer and inspection contracts unchanged. It does not retry failed probes, broaden mocks, add configuration, or change protocol/API surfaces.

## User Impact

Windows diagnostics now say `Port <n> availability could not be determined.` when inspection is indeterminate. Operators no longer receive a false "free" or "not listening" conclusion and can distinguish that state from both a confirmed free port and a real listener conflict.

## Evidence

- Native Windows production-path reproduction (production blobs unchanged at corrected head `259ca412da4`):
  - `netsh interface ipv4 show excludedportrange protocol=tcp` showed `54758-54857` as excluded.
  - `Get-NetTCPConnection -State Listen -LocalPort 54758` returned no listener before or after both probes.
  - Exact pre-fix production inspection returned `{ status: "unknown", listeners: [] }`, while the formatter rendered `Port 54758 is free.`
  - The repaired current-main production inspector returned the same authoritative unknown state and rendered `Port 54758 availability could not be determined.` (exit 0, no listener/process residue).
- Focused native Windows Vitest proof: 121 passed, 1 intentionally skipped across:
  - `src/infra/ports-format.test.ts`
  - `src/commands/status-all/diagnosis.test.ts`
  - `src/cli/daemon-cli/status.gather.test.ts`
  - `src/cli/daemon-cli/status.print.test.ts`
- `pnpm format:check` passed for all eight changed files; `git diff HEAD^ HEAD --check` passed.
- The first hosted `check-test-types` run caught a test-fixture TS18047 at the unknown-listener regression. The corrected head adds only the compile-time non-null assertion guaranteed by `createBaseParams`; the runtime assertion and all production blobs are unchanged.
- Fresh corrected-head autoreview: TruffleHog clean, no accepted/actionable P0/P1 findings, correctness 0.96.
- Independent corrected-head owner/sibling review: clean, no P0/P1; confirmed the tri-state projection boundary is the best fix and the test-only nullability correction is exact. The earlier review P1 was incorporated: synthetic unknown results with expected-looking listeners cannot be rendered healthy unless `status === "busy"`.
- Scope: production `+10/-5`; tests `+99/-3`. Positive production LOC records the existing authoritative tri-state at each user-visible projection boundary.
