### PR TITLE
perf(gateway): stop penalizing device-token Control UI reads

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -226,6 +226,7 @@ describe("handleControlUiHttpRequest", () => {
     headers?: IncomingMessage["headers"];
     config?: OpenClawConfig;
     rateLimiter?: AuthRateLimiter;
+    trustedProxies?: string[];
   }) {
     const { res, end, setHeader } = makeMockHttpResponse();
     const url = params.basePath
@@ -244,6 +245,7 @@ describe("handleControlUiHttpRequest", () => {
         ...(params.auth ? { auth: params.auth } : {}),
         ...(params.config ? { config: params.config } : {}),
         ...(params.rateLimiter ? { rateLimiter: params.rateLimiter } : {}),
+        ...(params.trustedProxies ? { trustedProxies: params.trustedProxies } : {}),
         root: { kind: "resolved", path: params.rootPath },
       },
     );
@@ -1983,6 +1985,44 @@ describe("handleControlUiHttpRequest", () => {
           expect(rateLimiter.recordFailureAndDelay).toHaveBeenCalledTimes(2);
         },
       });
+    });
+  });
+
+  it("penalizes a trusted-proxy local password mismatch only as a shared secret", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const rateLimiter = createAuthRateLimiterSpy();
+        const { res, handled, end } = await runBootstrapConfigRequest({
+          rootPath: tmp,
+          auth: {
+            mode: "trusted-proxy",
+            allowTailscale: false,
+            password: "local-password",
+            trustedProxy: { userHeader: "x-forwarded-user" },
+          },
+          trustedProxies: ["127.0.0.1"],
+          headers: {
+            host: "localhost",
+            authorization: "Bearer wrong-password",
+          },
+          rateLimiter,
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(401);
+        expect(responseJson(end)).toEqual({
+          error: { message: "Unauthorized", type: "unauthorized" },
+        });
+        expect(rateLimiter.recordFailureAndDelay).toHaveBeenCalledTimes(1);
+        expect(rateLimiter.recordFailureAndDelay).toHaveBeenCalledWith(
+          "127.0.0.1",
+          AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+        );
+        expect(rateLimiter.recordFailureAndDelay).not.toHaveBeenCalledWith(
+          "127.0.0.1",
+          AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
+        );
+      },
     });
   });
 

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -2026,43 +2026,52 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
-  it("rejects a rate-limited Control UI read before shared-secret auth", async () => {
-    await withControlUiRoot({
-      fn: async (tmp) => {
-        const rateLimiter = createAuthRateLimiterSpy();
-        rateLimiter.check.mockReturnValue({ allowed: false, remaining: 0, retryAfterMs: 2_500 });
-        const readSharedToken = vi.fn(() => "shared-token");
-        const auth: ResolvedGatewayAuth = {
-          mode: "token",
-          get token() {
-            return readSharedToken();
-          },
-          allowTailscale: false,
-        };
-        const { res, handled, end, setHeader } = await runBootstrapConfigRequest({
-          rootPath: tmp,
-          auth,
-          headers: { authorization: "Bearer shared-token" },
-          rateLimiter,
-        });
+  it("rejects a rate-limited Control UI read when no valid device token is presented", async () => {
+    const tempHome = testTempDirs.make("openclaw-ui-rate-limited-token-");
+    await withEnvAsync({ OPENCLAW_HOME: tempHome }, async () => {
+      await withControlUiRoot({
+        fn: async (tmp) => {
+          const rateLimiter = createAuthRateLimiterSpy();
+          rateLimiter.check.mockImplementation((_ip, scope) =>
+            scope === AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET
+              ? { allowed: false, remaining: 0, retryAfterMs: 2_500 }
+              : { allowed: true, remaining: 10, retryAfterMs: 0 },
+          );
+          const auth: ResolvedGatewayAuth = {
+            mode: "token",
+            token: "shared-token",
+            allowTailscale: false,
+          };
+          const { res, handled, end, setHeader } = await runBootstrapConfigRequest({
+            rootPath: tmp,
+            auth,
+            headers: { authorization: "Bearer shared-token" },
+            rateLimiter,
+          });
 
-        expect(handled).toBe(true);
-        expect(res.statusCode).toBe(429);
-        expect(responseJson(end)).toEqual({
-          error: {
-            message: "Too many failed authentication attempts. Please try again later.",
-            type: "rate_limited",
-          },
-        });
-        expect(setHeader).toHaveBeenCalledWith("Retry-After", "3");
-        expect(rateLimiter.check).toHaveBeenCalledWith(
-          "127.0.0.1",
-          AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
-        );
-        expect(readSharedToken).not.toHaveBeenCalled();
-        expect(rateLimiter.reset).not.toHaveBeenCalled();
-        expect(rateLimiter.recordFailureAndDelay).not.toHaveBeenCalled();
-      },
+          expect(handled).toBe(true);
+          expect(res.statusCode).toBe(429);
+          expect(responseJson(end)).toEqual({
+            error: {
+              message: "Too many failed authentication attempts. Please try again later.",
+              type: "rate_limited",
+            },
+          });
+          expect(setHeader).toHaveBeenCalledWith("Retry-After", "3");
+          expect(rateLimiter.check).toHaveBeenNthCalledWith(
+            1,
+            "127.0.0.1",
+            AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+          );
+          expect(rateLimiter.check).toHaveBeenNthCalledWith(
+            2,
+            "127.0.0.1",
+            AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
+          );
+          expect(rateLimiter.reset).not.toHaveBeenCalled();
+          expect(rateLimiter.recordFailureAndDelay).not.toHaveBeenCalled();
+        },
+      });
     });
   });
 
@@ -2265,6 +2274,52 @@ describe("handleControlUiHttpRequest", () => {
             expect(res.statusCode).toBe(200);
             const parsed = parseBootstrapPayload(end);
             expect(parsed.assistantAgentId).toBeUndefined();
+            expect(rateLimiter.recordFailureAndDelay).not.toHaveBeenCalled();
+            expect(rateLimiter.reset).toHaveBeenCalledWith(
+              "127.0.0.1",
+              AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
+            );
+            expect(rateLimiter.reset).toHaveBeenCalledWith(
+              "127.0.0.1",
+              AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+            );
+          },
+        });
+      },
+    });
+  });
+
+  it("serves paired device-token bootstrap while the shared-secret scope is locked", async () => {
+    await withPairedOperatorDeviceToken({
+      fn: async (operatorToken) => {
+        await withControlUiRoot({
+          fn: async (tmp) => {
+            const rateLimiter = createAuthRateLimiterSpy();
+            rateLimiter.check.mockImplementation((_ip, scope) =>
+              scope === AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET
+                ? { allowed: false, remaining: 0, retryAfterMs: 2_500 }
+                : { allowed: true, remaining: 10, retryAfterMs: 0 },
+            );
+            const { res, handled, end } = await runBootstrapConfigRequest({
+              rootPath: tmp,
+              auth: { mode: "token", token: "shared-token", allowTailscale: false },
+              headers: { authorization: `Bearer ${operatorToken}` },
+              rateLimiter,
+            });
+
+            expect(handled).toBe(true);
+            expect(res.statusCode).toBe(200);
+            expect(parseBootstrapPayload(end).assistantAgentId).toBeUndefined();
+            expect(rateLimiter.check).toHaveBeenNthCalledWith(
+              1,
+              "127.0.0.1",
+              AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+            );
+            expect(rateLimiter.check).toHaveBeenNthCalledWith(
+              2,
+              "127.0.0.1",
+              AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
+            );
             expect(rateLimiter.recordFailureAndDelay).not.toHaveBeenCalled();
             expect(rateLimiter.reset).toHaveBeenCalledWith(
               "127.0.0.1",

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -24,6 +24,11 @@ import { AVATAR_MAX_DATA_URL_CHARS } from "../shared/avatar-limits.js";
 import { AVATAR_MAX_BYTES } from "../shared/avatar-policy.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { buildAssistantMediaContentDisposition } from "./assistant-media-content-disposition.js";
+import {
+  AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
+  AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+  type AuthRateLimiter,
+} from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import {
   CONTROL_UI_BOOTSTRAP_CONFIG_PATH,
@@ -92,6 +97,27 @@ const REAL_PNG = Buffer.from(
 );
 const REAL_PNG_DATA_URL = `data:image/png;base64,${REAL_PNG.toString("base64")}`;
 const testTempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function createAuthRateLimiterSpy() {
+  const check = vi.fn<AuthRateLimiter["check"]>(() => ({
+    allowed: true,
+    remaining: 10,
+    retryAfterMs: 0,
+  }));
+  const recordFailure = vi.fn<AuthRateLimiter["recordFailure"]>(() => {});
+  const recordFailureAndDelay = vi.fn<AuthRateLimiter["recordFailureAndDelay"]>(async () => {});
+  const reset = vi.fn<AuthRateLimiter["reset"]>(() => {});
+  return {
+    check,
+    recordFailure,
+    recordFailureAndDelay,
+    reset,
+    size: () => 0,
+    prune: () => {},
+    dispose: () => {},
+  } satisfies AuthRateLimiter;
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   resetPluginRuntimeStateForTest();
@@ -199,6 +225,7 @@ describe("handleControlUiHttpRequest", () => {
     auth?: ResolvedGatewayAuth;
     headers?: IncomingMessage["headers"];
     config?: OpenClawConfig;
+    rateLimiter?: AuthRateLimiter;
   }) {
     const { res, end, setHeader } = makeMockHttpResponse();
     const url = params.basePath
@@ -216,6 +243,7 @@ describe("handleControlUiHttpRequest", () => {
         ...(params.basePath ? { basePath: params.basePath } : {}),
         ...(params.auth ? { auth: params.auth } : {}),
         ...(params.config ? { config: params.config } : {}),
+        ...(params.rateLimiter ? { rateLimiter: params.rateLimiter } : {}),
         root: { kind: "resolved", path: params.rootPath },
       },
     );
@@ -1892,6 +1920,7 @@ describe("handleControlUiHttpRequest", () => {
   it("serves bootstrap config JSON when auth is enabled and the token is valid", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
+        const rateLimiter = createAuthRateLimiterSpy();
         await fs.writeFile(path.join(tmp, "avatar.png"), "avatar-bytes\n");
         const { res, handled, end, setHeader } = await runBootstrapConfigRequest({
           rootPath: tmp,
@@ -1903,6 +1932,7 @@ describe("handleControlUiHttpRequest", () => {
             agents: { defaults: { workspace: tmp } },
             ui: { assistant: { avatar: "avatar.png" } },
           },
+          rateLimiter,
         });
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(200);
@@ -1913,6 +1943,85 @@ describe("handleControlUiHttpRequest", () => {
           assistantAvatar: `data:image/png;base64,${Buffer.from("avatar-bytes\n").toString("base64")}`,
           assistantAvatarStatus: "local",
         });
+        expect(rateLimiter.reset).toHaveBeenCalledWith(
+          "127.0.0.1",
+          AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+        );
+        expect(rateLimiter.recordFailureAndDelay).not.toHaveBeenCalled();
+      },
+    });
+  });
+
+  it("penalizes both credential scopes when a Control UI read token is invalid", async () => {
+    const tempHome = testTempDirs.make("openclaw-ui-invalid-token-");
+    await withEnvAsync({ OPENCLAW_HOME: tempHome }, async () => {
+      await withControlUiRoot({
+        fn: async (tmp) => {
+          const rateLimiter = createAuthRateLimiterSpy();
+          const { res, handled, end } = await runBootstrapConfigRequest({
+            rootPath: tmp,
+            auth: { mode: "token", token: "shared-token", allowTailscale: false },
+            headers: { authorization: "Bearer invalid-token" },
+            rateLimiter,
+          });
+
+          expect(handled).toBe(true);
+          expect(res.statusCode).toBe(401);
+          expect(responseJson(end)).toEqual({
+            error: { message: "Unauthorized", type: "unauthorized" },
+          });
+          expect(rateLimiter.recordFailureAndDelay).toHaveBeenNthCalledWith(
+            1,
+            "127.0.0.1",
+            AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+          );
+          expect(rateLimiter.recordFailureAndDelay).toHaveBeenNthCalledWith(
+            2,
+            "127.0.0.1",
+            AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
+          );
+          expect(rateLimiter.recordFailureAndDelay).toHaveBeenCalledTimes(2);
+        },
+      });
+    });
+  });
+
+  it("rejects a rate-limited Control UI read before shared-secret auth", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const rateLimiter = createAuthRateLimiterSpy();
+        rateLimiter.check.mockReturnValue({ allowed: false, remaining: 0, retryAfterMs: 2_500 });
+        const readSharedToken = vi.fn(() => "shared-token");
+        const auth: ResolvedGatewayAuth = {
+          mode: "token",
+          get token() {
+            return readSharedToken();
+          },
+          allowTailscale: false,
+        };
+        const { res, handled, end, setHeader } = await runBootstrapConfigRequest({
+          rootPath: tmp,
+          auth,
+          headers: { authorization: "Bearer shared-token" },
+          rateLimiter,
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(429);
+        expect(responseJson(end)).toEqual({
+          error: {
+            message: "Too many failed authentication attempts. Please try again later.",
+            type: "rate_limited",
+          },
+        });
+        expect(setHeader).toHaveBeenCalledWith("Retry-After", "3");
+        expect(rateLimiter.check).toHaveBeenCalledWith(
+          "127.0.0.1",
+          AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+        );
+        expect(readSharedToken).not.toHaveBeenCalled();
+        expect(rateLimiter.reset).not.toHaveBeenCalled();
+        expect(rateLimiter.recordFailureAndDelay).not.toHaveBeenCalled();
       },
     });
   });
@@ -2103,17 +2212,28 @@ describe("handleControlUiHttpRequest", () => {
       fn: async (operatorToken) => {
         await withControlUiRoot({
           fn: async (tmp) => {
+            const rateLimiter = createAuthRateLimiterSpy();
             const { res, handled, end } = await runBootstrapConfigRequest({
               rootPath: tmp,
               auth: { mode: "token", token: "shared-token", allowTailscale: false },
               headers: {
                 authorization: `Bearer ${operatorToken}`,
               },
+              rateLimiter,
             });
             expect(handled).toBe(true);
             expect(res.statusCode).toBe(200);
             const parsed = parseBootstrapPayload(end);
             expect(parsed.assistantAgentId).toBeUndefined();
+            expect(rateLimiter.recordFailureAndDelay).not.toHaveBeenCalled();
+            expect(rateLimiter.reset).toHaveBeenCalledWith(
+              "127.0.0.1",
+              AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
+            );
+            expect(rateLimiter.reset).toHaveBeenCalledWith(
+              "127.0.0.1",
+              AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+            );
           },
         });
       },

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -2045,7 +2045,7 @@ describe("handleControlUiHttpRequest", () => {
           const { res, handled, end, setHeader } = await runBootstrapConfigRequest({
             rootPath: tmp,
             auth,
-            headers: { authorization: "Bearer shared-token" },
+            headers: { authorization: "Bearer invalid-token" },
             rateLimiter,
           });
 
@@ -2069,9 +2069,66 @@ describe("handleControlUiHttpRequest", () => {
             AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
           );
           expect(rateLimiter.reset).not.toHaveBeenCalled();
-          expect(rateLimiter.recordFailureAndDelay).not.toHaveBeenCalled();
+          expect(rateLimiter.recordFailureAndDelay).toHaveBeenCalledTimes(1);
+          expect(rateLimiter.recordFailureAndDelay).toHaveBeenCalledWith(
+            "127.0.0.1",
+            AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
+          );
+          expect(rateLimiter.recordFailureAndDelay).not.toHaveBeenCalledWith(
+            "127.0.0.1",
+            AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+          );
         },
       });
+    });
+  });
+
+  it("records a shared mismatch when the device-token scope is locked", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const rateLimiter = createAuthRateLimiterSpy();
+        rateLimiter.check.mockImplementation((_ip, scope) =>
+          scope === AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN
+            ? { allowed: false, remaining: 0, retryAfterMs: 2_500 }
+            : { allowed: true, remaining: 10, retryAfterMs: 0 },
+        );
+        const { res, handled, end, setHeader } = await runBootstrapConfigRequest({
+          rootPath: tmp,
+          auth: { mode: "token", token: "shared-token", allowTailscale: false },
+          headers: { authorization: "Bearer invalid-token" },
+          rateLimiter,
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(429);
+        expect(responseJson(end)).toEqual({
+          error: {
+            message: "Too many failed authentication attempts. Please try again later.",
+            type: "rate_limited",
+          },
+        });
+        expect(setHeader).toHaveBeenCalledWith("Retry-After", "3");
+        expect(rateLimiter.check).toHaveBeenNthCalledWith(
+          1,
+          "127.0.0.1",
+          AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+        );
+        expect(rateLimiter.check).toHaveBeenNthCalledWith(
+          2,
+          "127.0.0.1",
+          AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
+        );
+        expect(rateLimiter.reset).not.toHaveBeenCalled();
+        expect(rateLimiter.recordFailureAndDelay).toHaveBeenCalledTimes(1);
+        expect(rateLimiter.recordFailureAndDelay).toHaveBeenCalledWith(
+          "127.0.0.1",
+          AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+        );
+        expect(rateLimiter.recordFailureAndDelay).not.toHaveBeenCalledWith(
+          "127.0.0.1",
+          AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
+        );
+      },
     });
   });
 

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -309,6 +309,21 @@ async function authorizeControlUiReadRequest(
   const clientIp =
     resolveRequestClientIp(req, opts.trustedProxies, opts.allowRealIpFallback === true) ??
     req.socket?.remoteAddress;
+  const sharedSecretRateCheck = token
+    ? opts.rateLimiter?.check(clientIp, AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET)
+    : undefined;
+  if (sharedSecretRateCheck && !sharedSecretRateCheck.allowed) {
+    sendGatewayAuthFailure(res, {
+      ok: false,
+      reason: "rate_limited",
+      rateLimited: true,
+      retryAfterMs: sharedSecretRateCheck.retryAfterMs,
+    });
+    return false;
+  }
+
+  // A device token must not pay the shared-secret brute-force penalty.
+  // Apply penalties only after every credential class has failed.
   const authResult = await authorizeHttpGatewayConnect({
     auth: opts.auth,
     connectAuth: token ? { token, password: token } : null,
@@ -316,10 +331,13 @@ async function authorizeControlUiReadRequest(
     browserOriginPolicy: resolveHttpBrowserOriginPolicy(req),
     trustedProxies: opts.trustedProxies,
     allowRealIpFallback: opts.allowRealIpFallback,
-    rateLimiter: token ? opts.rateLimiter : undefined,
+    rateLimiter: undefined,
     clientIp,
     rateLimitScope: AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
   });
+  if (authResult.ok && (authResult.method === "token" || authResult.method === "password")) {
+    opts.rateLimiter?.reset(clientIp, AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET);
+  }
   const sharedAuthGeneration = resolveSharedGatewaySessionGeneration(
     opts.auth,
     opts.trustedProxies,
@@ -351,6 +369,10 @@ async function authorizeControlUiReadRequest(
         opts.rateLimiter?.reset(clientIp, AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET);
         resolvedAuthResult = { ok: true, method: "device-token" };
       } else {
+        await opts.rateLimiter?.recordFailureAndDelay(
+          clientIp,
+          AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+        );
         await opts.rateLimiter?.recordFailureAndDelay(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
       }
     }

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -46,7 +46,11 @@ import {
   AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
   type AuthRateLimiter,
 } from "./auth-rate-limit.js";
-import { authorizeHttpGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
+import {
+  authorizeHttpGatewayConnect,
+  type GatewayAuthResult,
+  type ResolvedGatewayAuth,
+} from "./auth.js";
 import {
   CONTROL_UI_BASE_PATH_ATTRIBUTE,
   CONTROL_UI_BOOTSTRAP_CONFIG_PATH,
@@ -309,33 +313,42 @@ async function authorizeControlUiReadRequest(
   const clientIp =
     resolveRequestClientIp(req, opts.trustedProxies, opts.allowRealIpFallback === true) ??
     req.socket?.remoteAddress;
-  const sharedSecretRateCheck = token
+  const supportsDeviceTokenFallback =
+    Boolean(token) && opts.auth.mode !== "trusted-proxy" && opts.auth.mode !== "none";
+  const sharedSecretRateCheck = supportsDeviceTokenFallback
     ? opts.rateLimiter?.check(clientIp, AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET)
     : undefined;
-  if (sharedSecretRateCheck && !sharedSecretRateCheck.allowed) {
-    sendGatewayAuthFailure(res, {
-      ok: false,
-      reason: "rate_limited",
-      rateLimited: true,
-      retryAfterMs: sharedSecretRateCheck.retryAfterMs,
-    });
-    return false;
-  }
 
   // A device token must not pay the shared-secret brute-force penalty.
-  // Apply penalties only after every credential class has failed.
-  const authResult = await authorizeHttpGatewayConnect({
-    auth: opts.auth,
-    connectAuth: token ? { token, password: token } : null,
-    req,
-    browserOriginPolicy: resolveHttpBrowserOriginPolicy(req),
-    trustedProxies: opts.trustedProxies,
-    allowRealIpFallback: opts.allowRealIpFallback,
-    rateLimiter: undefined,
-    clientIp,
-    rateLimitScope: AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
-  });
-  if (authResult.ok && (authResult.method === "token" || authResult.method === "password")) {
+  // Defer lockout and penalties until every credential class has failed.
+  const authResult: GatewayAuthResult =
+    sharedSecretRateCheck && !sharedSecretRateCheck.allowed
+      ? {
+          ok: false,
+          reason: "rate_limited",
+          rateLimited: true,
+          retryAfterMs: sharedSecretRateCheck.retryAfterMs,
+        }
+      : await authorizeHttpGatewayConnect({
+          auth: opts.auth,
+          connectAuth: token ? { token, password: token } : null,
+          req,
+          browserOriginPolicy: resolveHttpBrowserOriginPolicy(req),
+          trustedProxies: opts.trustedProxies,
+          allowRealIpFallback: opts.allowRealIpFallback,
+          rateLimiter: supportsDeviceTokenFallback
+            ? undefined
+            : token
+              ? opts.rateLimiter
+              : undefined,
+          clientIp,
+          rateLimitScope: AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+        });
+  if (
+    authResult.ok &&
+    supportsDeviceTokenFallback &&
+    (authResult.method === "token" || authResult.method === "password")
+  ) {
     opts.rateLimiter?.reset(clientIp, AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET);
   }
   const sharedAuthGeneration = resolveSharedGatewaySessionGeneration(
@@ -345,12 +358,7 @@ async function authorizeControlUiReadRequest(
   let resolvedAuthResult = authResult;
   let verifiedDeviceScopes: string[] | undefined;
   let deviceTokenValidationFailed = false;
-  if (
-    !resolvedAuthResult.ok &&
-    token &&
-    opts.auth.mode !== "trusted-proxy" &&
-    opts.auth.mode !== "none"
-  ) {
+  if (!resolvedAuthResult.ok && token && supportsDeviceTokenFallback) {
     const deviceRateCheck = opts.rateLimiter?.check(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
     if (deviceRateCheck && !deviceRateCheck.allowed) {
       resolvedAuthResult = {
@@ -375,14 +383,20 @@ async function authorizeControlUiReadRequest(
     }
   }
   if (!resolvedAuthResult.ok) {
-    if (
-      resolvedAuthResult.reason === "token_mismatch" ||
-      resolvedAuthResult.reason === "password_mismatch"
-    ) {
-      await opts.rateLimiter?.recordFailureAndDelay(clientIp, AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET);
-    }
-    if (deviceTokenValidationFailed) {
-      await opts.rateLimiter?.recordFailureAndDelay(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
+    if (resolvedAuthResult.reason !== "rate_limited") {
+      if (
+        supportsDeviceTokenFallback &&
+        (resolvedAuthResult.reason === "token_mismatch" ||
+          resolvedAuthResult.reason === "password_mismatch")
+      ) {
+        await opts.rateLimiter?.recordFailureAndDelay(
+          clientIp,
+          AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+        );
+      }
+      if (deviceTokenValidationFailed) {
+        await opts.rateLimiter?.recordFailureAndDelay(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
+      }
     }
     sendGatewayAuthFailure(res, resolvedAuthResult);
     return false;

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -344,6 +344,7 @@ async function authorizeControlUiReadRequest(
   );
   let resolvedAuthResult = authResult;
   let verifiedDeviceScopes: string[] | undefined;
+  let deviceTokenValidationFailed = false;
   if (
     !resolvedAuthResult.ok &&
     token &&
@@ -369,15 +370,20 @@ async function authorizeControlUiReadRequest(
         opts.rateLimiter?.reset(clientIp, AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET);
         resolvedAuthResult = { ok: true, method: "device-token" };
       } else {
-        await opts.rateLimiter?.recordFailureAndDelay(
-          clientIp,
-          AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
-        );
-        await opts.rateLimiter?.recordFailureAndDelay(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
+        deviceTokenValidationFailed = true;
       }
     }
   }
   if (!resolvedAuthResult.ok) {
+    if (
+      resolvedAuthResult.reason === "token_mismatch" ||
+      resolvedAuthResult.reason === "password_mismatch"
+    ) {
+      await opts.rateLimiter?.recordFailureAndDelay(clientIp, AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET);
+    }
+    if (deviceTokenValidationFailed) {
+      await opts.rateLimiter?.recordFailureAndDelay(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
+    }
     sendGatewayAuthFailure(res, resolvedAuthResult);
     return false;
   }

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -344,6 +344,8 @@ async function authorizeControlUiReadRequest(
           clientIp,
           rateLimitScope: AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
         });
+  const sharedSecretMismatch =
+    authResult.reason === "token_mismatch" || authResult.reason === "password_mismatch";
   if (
     authResult.ok &&
     supportsDeviceTokenFallback &&
@@ -383,20 +385,11 @@ async function authorizeControlUiReadRequest(
     }
   }
   if (!resolvedAuthResult.ok) {
-    if (resolvedAuthResult.reason !== "rate_limited") {
-      if (
-        supportsDeviceTokenFallback &&
-        (resolvedAuthResult.reason === "token_mismatch" ||
-          resolvedAuthResult.reason === "password_mismatch")
-      ) {
-        await opts.rateLimiter?.recordFailureAndDelay(
-          clientIp,
-          AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
-        );
-      }
-      if (deviceTokenValidationFailed) {
-        await opts.rateLimiter?.recordFailureAndDelay(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
-      }
+    if (supportsDeviceTokenFallback && sharedSecretMismatch) {
+      await opts.rateLimiter?.recordFailureAndDelay(clientIp, AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET);
+    }
+    if (deviceTokenValidationFailed) {
+      await opts.rateLimiter?.recordFailureAndDelay(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
     }
     sendGatewayAuthFailure(res, resolvedAuthResult);
     return false;


### PR DESCRIPTION
## What Problem This Solves

Every Control UI HTTP read authenticated with a paired-device token (`/control-ui-config.json`, `/avatar/<agentId>`, assistant media) was treated as a failed shared-secret attempt before device-token validation ran. `authorizeControlUiReadRequest` passed the punitive auth rate limiter into `authorizeHttpGatewayConnect`, so the device token hit the shared-secret `safeEqualSecret` mismatch and slept in the loopback brute-force penalty (`recordFailureAndDelay`, 250ms base doubling per recorded failure, 5s cap) on every request. During dashboard startup several such requests fly concurrently, each recording a failure before any success resets the scope, so penalties escalate across the burst.

Measured on loopback (isolated gateway, embedded Chromium, real pairing flow): `/control-ui-config.json` TTFB 716–1442ms, `/avatar/main?meta=1` 506–1673ms, and `/apple-touch-icon.png` up to 1382ms queued behind penalized requests on shared keep-alive sockets — while a concurrent independent probe of the same server measured ~1–3ms. It also pollutes the shared-secret failure counter for the client IP, inflating delays for real shared-secret logins.

## Why This Change Was Made

The invariant is that brute-force penalties exist for failed credentials, not for legitimate credentials of a different class. The fix reorders accounting, not authentication: the request still runs the exact same `authorizeHttpGatewayConnect` (origin policy, auth modes, order unchanged) but without the punitive limiter; a pre-check preserves the lockout gate; penalties are recorded once at the common failure exit, keyed on actual credential-mismatch reasons (`token_mismatch`/`password_mismatch`, plus the device scope when device validation was attempted and failed). Valid device tokens no longer sleep; total failures are penalized exactly as before, including the trusted-proxy localhost password sub-path.

## User Impact

Dashboard startup no longer stalls 0.5–5s per authenticated HTTP read on the default local flow; avatar/config/media fetches return at loopback speed. Brute-force protection semantics are unchanged for attackers.

## Evidence

Before (worktree @ 62b418d551b, isolated gateway, paired embedded browser, resource timing):
- `/control-ui-config.json` ttfb 1442ms (load 1), 716/936ms (load 2)
- `/avatar/main?meta=1` ttfb 1673ms (load 1), 506ms (load 2)
- concurrent 20Hz curl probe of a static asset on the same server during load 2: max 3.3ms — no server load; the latency is the penalty sleep.

After (same setup, rebuilt dist, fresh gateway): valid device-token requests `/control-ui-config.json` and `/avatar/main?meta=1` at 4-6ms TTFB, stable across repeats and unaffected by concurrent invalid-credential traffic. Brute-force behavior preserved: consecutive invalid bearers escalate 0.5s -> 1s -> 2s -> 4s (both scopes penalized); a valid device token authenticates at full speed during a shared-secret lockout (scope isolation, matching pre-change semantics).

Tests: `node scripts/run-vitest.mjs src/gateway/control-ui` — 148 passed, including new cases: valid device token records no penalty; invalid token penalizes both scopes; trusted-proxy local password mismatch penalizes shared-secret only; rate-limited IP rejected before auth.
