### PR TITLE
fix(sandbox): bound container control-plane provisioning when engine is unresponsive

### DIFF
--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -12,6 +12,7 @@ import {
 } from "./config-hash.js";
 import { resolveSandboxBrowserDockerCreateConfig } from "./config.js";
 import {
+  DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS,
   SANDBOX_BROWSER_IMAGE_CONTRACT_EPOCH,
   SANDBOX_BROWSER_SECURITY_HASH_EPOCH,
   SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
@@ -449,7 +450,7 @@ describe("ensureSandboxBrowser create args", () => {
 
     expect(dockerMocks.execDocker).toHaveBeenCalledWith(
       ["rm", "-f", "openclaw-sbx-browser-session-test-0661d10a"],
-      { allowFailure: true },
+      { allowFailure: true, timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS },
     );
     const rmCallIndex = dockerMocks.execDocker.mock.calls.findIndex(([args]) => args[0] === "rm");
     expect(bridgeMocks.stopBrowserBridgeServer.mock.invocationCallOrder[0]).toBeLessThan(
@@ -825,7 +826,7 @@ describe("ensureSandboxBrowser create args", () => {
 
     expect(dockerMocks.execDocker).toHaveBeenCalledWith(
       ["rm", "-f", "openclaw-sbx-browser-session-test-0661d10a"],
-      { allowFailure: true },
+      { allowFailure: true, timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS },
     );
   });
 
@@ -1015,7 +1016,7 @@ describe("ensureSandboxBrowser create args", () => {
 
     expect(dockerMocks.execDocker).toHaveBeenCalledWith(
       ["rm", "-f", "openclaw-sbx-browser-session-test-0661d10a"],
-      { allowFailure: true },
+      { allowFailure: true, timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS },
     );
     requireDockerCreateArgs();
   });

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -30,6 +30,7 @@ import { computeSandboxBrowserConfigHash } from "./config-hash.js";
 import { resolveSandboxBrowserDockerCreateConfig } from "./config.js";
 import {
   DEFAULT_SANDBOX_BROWSER_IMAGE,
+  DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS,
   SANDBOX_BROWSER_IMAGE_CONTRACT_EPOCH,
   SANDBOX_BROWSER_SECURITY_HASH_EPOCH,
   SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
@@ -185,7 +186,7 @@ async function ensureSandboxBrowserImage(image: string) {
       `{{ index .Config.Labels "${SANDBOX_BROWSER_IMAGE_CONTRACT_LABEL}" }}`,
       image,
     ],
-    { allowFailure: true },
+    { allowFailure: true, timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS },
   );
   if (result.code === 0) {
     const contract = result.stdout.trim();
@@ -218,11 +219,16 @@ async function ensureDockerNetwork(
     return;
   }
   await browserNetworkLifecycleQueue.enqueue(normalized, async () => {
-    const inspect = await execDocker(["network", "inspect", network], { allowFailure: true });
+    const inspect = await execDocker(["network", "inspect", network], {
+      allowFailure: true,
+      timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS,
+    });
     if (inspect.code === 0) {
       return;
     }
-    await execDocker(["network", "create", "--driver", "bridge", network]);
+    await execDocker(["network", "create", "--driver", "bridge", network], {
+      timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS,
+    });
   });
 }
 
@@ -330,7 +336,10 @@ async function ensureSandboxBrowserContainer(
         `Removing stale sandbox browser container ${containerName} because it lacks the current CDP relay auth contract; it will be recreated.`,
       );
       await stopExistingForContainer();
-      await execDocker(["rm", "-f", containerName], { allowFailure: true });
+      await execDocker(["rm", "-f", containerName], {
+        allowFailure: true,
+        timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS,
+      });
       hasContainer = false;
       running = false;
     }
@@ -365,7 +374,10 @@ async function ensureSandboxBrowserContainer(
         );
       } else {
         await stopExistingForContainer();
-        await execDocker(["rm", "-f", containerName], { allowFailure: true });
+        await execDocker(["rm", "-f", containerName], {
+          allowFailure: true,
+          timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS,
+        });
         hasContainer = false;
         running = false;
       }
@@ -448,10 +460,10 @@ async function ensureSandboxBrowserContainer(
       args.push("-e", `${NOVNC_PASSWORD_ENV_KEY}=${noVncPassword}`);
     }
     args.push(browserImage);
-    await execDocker(args);
-    await execDocker(["start", containerName]);
+    await execDocker(args, { timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS });
+    await execDocker(["start", containerName], { timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS });
   } else if (!running) {
-    await execDocker(["start", containerName]);
+    await execDocker(["start", containerName], { timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS });
   }
 
   const mappedCdp = await readDockerPort(containerName, params.cfg.browser.cdpPort);
@@ -518,7 +530,9 @@ async function ensureSandboxBrowserContainer(
       ? async () => {
           const currentState = await dockerContainerState(containerName);
           if (currentState.exists && !currentState.running) {
-            await execDocker(["start", containerName]);
+            await execDocker(["start", containerName], {
+              timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS,
+            });
           }
           const ok = await waitForSandboxCdp({
             cdpPort: mappedCdp,
@@ -526,7 +540,10 @@ async function ensureSandboxBrowserContainer(
             timeoutMs: params.cfg.browser.autoStartTimeoutMs,
           });
           if (!ok) {
-            await execDocker(["rm", "-f", containerName], { allowFailure: true });
+            await execDocker(["rm", "-f", containerName], {
+              allowFailure: true,
+              timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS,
+            });
             throw new Error(
               `Sandbox browser CDP did not become reachable on 127.0.0.1:${mappedCdp} within ${params.cfg.browser.autoStartTimeoutMs}ms. The hung container has been forcefully removed.`,
             );

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -67,6 +67,11 @@ export const DEFAULT_SANDBOX_BROWSER_VNC_PORT = 5900;
 export const DEFAULT_SANDBOX_BROWSER_NOVNC_PORT = 6080;
 export const DEFAULT_SANDBOX_BROWSER_AUTOSTART_TIMEOUT_MS = 12_000;
 
+// Bounds container control-plane calls (inspect/create/start/rm) during sandbox
+// provisioning so a wedged engine fails the run instead of hanging it forever.
+// Long-running sandboxed commands and setupCommand execs stay unbounded.
+export const DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS = 60_000;
+
 export const SANDBOX_AGENT_WORKSPACE_MOUNT = "/agent";
 
 export const SANDBOX_STATE_DIR = path.join(STATE_DIR, "sandbox");

--- a/src/agents/sandbox/container-engine.timeout.test.ts
+++ b/src/agents/sandbox/container-engine.timeout.test.ts
@@ -1,9 +1,7 @@
 // Container-engine timeout tests cover the typed fail-closed error for a
 // wedged engine and back-compat for calls that request no timeout.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS } from "./constants.js";
-import { DOCKER_SANDBOX_ENGINE, execContainerRaw } from "./container-engine.js";
-import { ensureSandboxContainer } from "./docker.js";
 import type { SandboxConfig } from "./types.js";
 
 type SpawnOptions = { timeout?: number };
@@ -67,6 +65,27 @@ vi.mock("./registry.js", () => ({
   updateRegistry: registryMocks.updateRegistry,
 }));
 
+let DOCKER_SANDBOX_ENGINE: typeof import("./container-engine.js").DOCKER_SANDBOX_ENGINE;
+let execContainerRaw: typeof import("./container-engine.js").execContainerRaw;
+let ensureSandboxContainer: typeof import("./docker.js").ensureSandboxContainer;
+
+// Shards run with --isolate=false, so a shared worker may already hold an
+// unmocked module graph; re-import through vi.doMock like the sibling suites.
+async function loadFreshContainerEngineForTest() {
+  vi.resetModules();
+  vi.doMock("../../process/exec.js", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../../process/exec.js")>()),
+    spawnCommand: spawnContainerEngineProcess,
+  }));
+  vi.doMock("./registry.js", () => ({
+    readRegistryEntry: registryMocks.readRegistryEntry,
+    removeRegistryEntry: registryMocks.removeRegistryEntry,
+    updateRegistry: registryMocks.updateRegistry,
+  }));
+  ({ DOCKER_SANDBOX_ENGINE, execContainerRaw } = await import("./container-engine.js"));
+  ({ ensureSandboxContainer } = await import("./docker.js"));
+}
+
 function wedgedSandboxConfig(): SandboxConfig {
   return {
     mode: "all",
@@ -113,13 +132,21 @@ function wedgedSandboxConfig(): SandboxConfig {
   };
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   spawnState.lastOptions = undefined;
   spawnState.wedged = false;
   spawnState.result = undefined;
   registryMocks.readRegistryEntry.mockReset();
   registryMocks.removeRegistryEntry.mockReset();
   registryMocks.updateRegistry.mockReset();
+  await loadFreshContainerEngineForTest();
+});
+
+// Later files share this worker under --isolate=false; leave no doMock behind.
+afterAll(() => {
+  vi.doUnmock("../../process/exec.js");
+  vi.doUnmock("./registry.js");
+  vi.resetModules();
 });
 
 describe("execContainerRaw timeout", () => {

--- a/src/agents/sandbox/container-engine.timeout.test.ts
+++ b/src/agents/sandbox/container-engine.timeout.test.ts
@@ -1,0 +1,185 @@
+// Container-engine timeout tests cover the typed fail-closed error for a
+// wedged engine and back-compat for calls that request no timeout.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS } from "./constants.js";
+import { DOCKER_SANDBOX_ENGINE, execContainerRaw } from "./container-engine.js";
+import { ensureSandboxContainer } from "./docker.js";
+import type { SandboxConfig } from "./types.js";
+
+type SpawnOptions = { timeout?: number };
+
+const spawnState = vi.hoisted(() => ({
+  lastOptions: undefined as SpawnOptions | undefined,
+  wedged: false,
+  result: undefined as Record<string, unknown> | undefined,
+}));
+
+const registryMocks = vi.hoisted(() => ({
+  readRegistryEntry: vi.fn(),
+  removeRegistryEntry: vi.fn(),
+  updateRegistry: vi.fn(),
+}));
+
+function timedOutSpawnResult(): Record<string, unknown> {
+  return {
+    failed: true,
+    timedOut: true,
+    isCanceled: false,
+    isTerminated: true,
+    signal: "SIGTERM",
+    exitCode: undefined,
+    stdout: Buffer.alloc(0),
+    stderr: Buffer.alloc(0),
+  };
+}
+
+async function spawnContainerEngineProcess(_argv: string[], options?: SpawnOptions) {
+  spawnState.lastOptions = options;
+  if (spawnState.result) {
+    return spawnState.result;
+  }
+  if (spawnState.wedged) {
+    // Mirrors verified execa behavior: with a timeout the promise settles as
+    // timedOut; without one a wedged engine never settles (a test hang).
+    if (typeof options?.timeout === "number") {
+      return timedOutSpawnResult();
+    }
+    return await new Promise(() => {});
+  }
+  return {
+    failed: false,
+    timedOut: false,
+    isCanceled: false,
+    exitCode: 0,
+    stdout: Buffer.alloc(0),
+    stderr: Buffer.alloc(0),
+  };
+}
+
+vi.mock("../../process/exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../process/exec.js")>()),
+  spawnCommand: spawnContainerEngineProcess,
+}));
+
+vi.mock("./registry.js", () => ({
+  readRegistryEntry: registryMocks.readRegistryEntry,
+  removeRegistryEntry: registryMocks.removeRegistryEntry,
+  updateRegistry: registryMocks.updateRegistry,
+}));
+
+function wedgedSandboxConfig(): SandboxConfig {
+  return {
+    mode: "all",
+    backend: "docker",
+    scope: "shared",
+    workspaceAccess: "rw",
+    workspaceRoot: "~/.openclaw/sandboxes",
+    dockerTmpfsSource: "default",
+    docker: {
+      image: "openclaw-sandbox:test",
+      containerPrefix: "oc-wedged-",
+      workdir: "/workspace",
+      readOnlyRoot: true,
+      tmpfs: ["/tmp"],
+      network: "none",
+      capDrop: ["ALL"],
+      env: {},
+      dns: [],
+      extraHosts: [],
+      binds: [],
+    },
+    ssh: {
+      command: "ssh",
+      workspaceRoot: "/tmp/openclaw-sandboxes",
+      strictHostKeyChecking: true,
+      updateHostKeys: true,
+    },
+    browser: {
+      enabled: false,
+      image: "openclaw-browser:test",
+      containerPrefix: "oc-browser-",
+      network: "bridge",
+      cdpPort: 9222,
+      vncPort: 5900,
+      noVncPort: 6080,
+      headless: true,
+      noVncEnabled: false,
+      allowHostControl: false,
+      autoStart: false,
+      autoStartTimeoutMs: 5000,
+    },
+    tools: { allow: [], deny: [] },
+    prune: { idleHours: 24, maxAgeDays: 7 },
+  };
+}
+
+beforeEach(() => {
+  spawnState.lastOptions = undefined;
+  spawnState.wedged = false;
+  spawnState.result = undefined;
+  registryMocks.readRegistryEntry.mockReset();
+  registryMocks.removeRegistryEntry.mockReset();
+  registryMocks.updateRegistry.mockReset();
+});
+
+describe("execContainerRaw timeout", () => {
+  it("fails closed with a typed error when the engine hits the timeout", async () => {
+    spawnState.result = timedOutSpawnResult();
+
+    const error = await execContainerRaw(
+      DOCKER_SANDBOX_ENGINE,
+      ["inspect", "-f", "{{.State.Running}}", "oc-test"],
+      { timeoutMs: 60_000 },
+    ).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    const typed = error as Error & { code?: string };
+    expect(typed.code).toBe("SANDBOX_CONTAINER_TIMEOUT");
+    expect(typed.message).toContain("Docker did not respond within 60000ms");
+    expect(typed.message).toContain("docker inspect -f");
+    expect(typed.message).toContain("agents.defaults.sandbox.mode=off");
+  });
+
+  it("prefers the abort error when a timed-out result is also canceled", async () => {
+    spawnState.result = { ...timedOutSpawnResult(), isCanceled: true };
+
+    const error = await execContainerRaw(DOCKER_SANDBOX_ENGINE, ["version"], {
+      timeoutMs: 60_000,
+    }).catch((caught: unknown) => caught);
+
+    expect((error as Error).name).toBe("AbortError");
+  });
+
+  it("passes the timeout through to the spawn layer and keeps success untouched", async () => {
+    const result = await execContainerRaw(DOCKER_SANDBOX_ENGINE, ["version"], {
+      timeoutMs: 1234,
+    });
+
+    expect(result.code).toBe(0);
+    expect(spawnState.lastOptions?.timeout).toBe(1234);
+  });
+
+  it("does not enable a spawn timeout when no timeoutMs is requested", async () => {
+    await execContainerRaw(DOCKER_SANDBOX_ENGINE, ["version"]);
+
+    expect(spawnState.lastOptions?.timeout).toBeUndefined();
+  });
+});
+
+describe("ensureSandboxContainer with a wedged engine", () => {
+  it("fails fast with the typed timeout on the first inspect instead of hanging", async () => {
+    spawnState.wedged = true;
+    registryMocks.readRegistryEntry.mockResolvedValue(null);
+
+    const error = await ensureSandboxContainer({
+      scopeKey: "shared",
+      workspaceDir: "/tmp/openclaw-wedged-test",
+      agentWorkspaceDir: "/tmp/openclaw-wedged-test",
+      cfg: wedgedSandboxConfig(),
+    }).catch((caught: unknown) => caught);
+
+    expect((error as Error & { code?: string }).code).toBe("SANDBOX_CONTAINER_TIMEOUT");
+    expect(spawnState.lastOptions?.timeout).toBe(DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS);
+    expect(registryMocks.updateRegistry).not.toHaveBeenCalled();
+  }, 10_000);
+});

--- a/src/agents/sandbox/container-engine.ts
+++ b/src/agents/sandbox/container-engine.ts
@@ -10,6 +10,7 @@ export type ExecContainerRawOptions = {
   allowFailure?: boolean;
   input?: Buffer | string;
   signal?: AbortSignal;
+  timeoutMs?: number;
 };
 
 export type SandboxContainerEngine = {
@@ -48,6 +49,15 @@ type ExecDockerRawError = Error & {
   stderr: Buffer;
 };
 
+function unresponsiveContainerEngineMessage(
+  engine: SandboxContainerEngine,
+  args: string[],
+  timeoutMs: number,
+): string {
+  const command = [engine.command, ...args.slice(0, 2)].join(" ");
+  return `${engine.displayName} did not respond within ${timeoutMs}ms (\`${command}\`). Check that ${engine.displayName} is healthy (restart it if needed), or set \`agents.defaults.sandbox.mode=off\` to disable sandboxing.`;
+}
+
 function missingContainerEngineMessage(engine: SandboxContainerEngine): string {
   if (engine.id === "docker") {
     return 'Sandbox mode requires Docker, but the "docker" command was not found in PATH. Install Docker (and ensure "docker" is available), or set `agents.defaults.sandbox.mode=off` to disable sandboxing.';
@@ -69,6 +79,8 @@ export async function execContainerRaw(
       maxBuffer: SANDBOX_COMMAND_MAX_BUFFER_BYTES,
       reject: false,
       stripFinalNewline: false,
+      // execa escalates SIGTERM to SIGKILL after its default 5s grace on expiry.
+      timeout: opts?.timeoutMs,
     });
   } catch (error) {
     if (opts?.signal?.aborted) {
@@ -84,6 +96,14 @@ export async function execContainerRaw(
   }
   if (opts?.signal?.aborted || result.isCanceled) {
     throw createAbortError("Aborted");
+  }
+  // Must precede the generic failed branch: a timed-out result is also failed,
+  // and provisioning callers rely on this typed code to fail closed.
+  if (opts?.timeoutMs !== undefined && result.timedOut) {
+    throw Object.assign(
+      new Error(unresponsiveContainerEngineMessage(engine, args, opts.timeoutMs)),
+      { code: "SANDBOX_CONTAINER_TIMEOUT", cause: result },
+    );
   }
   if (result.failed && !isPlainCommandExitFailure(result)) {
     if (result.code === "ENOENT") {

--- a/src/agents/sandbox/container-engine.wedged-runtime.test.ts
+++ b/src/agents/sandbox/container-engine.wedged-runtime.test.ts
@@ -1,0 +1,55 @@
+// Real-process proof that the execa-backed provisioning timeout kills a wedged
+// engine process and settles with the typed error, without any mocks.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { DOCKER_SANDBOX_ENGINE, execContainerRaw } from "./container-engine.js";
+
+const tmpDirs: string[] = [];
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("execContainerRaw wedged engine (real process)", () => {
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "times out against a wedged docker shim and kills the child",
+    async () => {
+      const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-wedged-shim-"));
+      tmpDirs.push(shimDir);
+      const pidFile = path.join(shimDir, "docker.pid");
+      const shimPath = path.join(shimDir, "docker");
+      fs.writeFileSync(shimPath, `#!/bin/sh\necho $$ > "${pidFile}"\nexec sleep 600\n`);
+      fs.chmodSync(shimPath, 0o755);
+
+      const shimPathEnv = `${shimDir}${path.delimiter}${process.env.PATH ?? ""}`;
+      await withEnvAsync({ PATH: shimPathEnv }, async () => {
+        const error = await execContainerRaw(DOCKER_SANDBOX_ENGINE, ["version"], {
+          timeoutMs: 500,
+        }).catch((caught: unknown) => caught);
+
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error & { code?: string }).code).toBe("SANDBOX_CONTAINER_TIMEOUT");
+
+        const pid = Number(fs.readFileSync(pidFile, "utf8").trim());
+        expect(Number.isInteger(pid) && pid > 0).toBe(true);
+        // execa escalates SIGTERM to SIGKILL after its 5s default grace.
+        await expect.poll(() => isProcessAlive(pid), { timeout: 8000 }).toBe(false);
+      });
+    },
+    20_000,
+  );
+});

--- a/src/agents/sandbox/docker-backend.test.ts
+++ b/src/agents/sandbox/docker-backend.test.ts
@@ -3,6 +3,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveSandboxConfigForAgent } from "./config.js";
+import { DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS } from "./constants.js";
 
 const dockerMocks = vi.hoisted(() => ({
   containerState: vi.fn(),
@@ -294,7 +295,7 @@ describe("docker sandbox backend manager", () => {
     expect(dockerMocks.execContainer).toHaveBeenCalledWith(
       expect.objectContaining({ id: "podman", command: "podman" }),
       ["rm", "-f", "sandbox-podman"],
-      { allowFailure: true },
+      { allowFailure: true, timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS },
     );
     expect(dockerMocks.validateSandboxContainerEngineTarget).toHaveBeenCalledWith(
       expect.objectContaining({ id: "podman", command: "podman" }),
@@ -412,7 +413,7 @@ describe("docker sandbox backend manager", () => {
       2,
       expect.objectContaining({ id: "podman", command: "podman" }),
       ["image", "inspect", "-f", "{{.Id}}", "openclaw-sandbox:bookworm-slim"],
-      { allowFailure: true },
+      { allowFailure: true, timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS },
     );
   });
 });

--- a/src/agents/sandbox/docker-backend.ts
+++ b/src/agents/sandbox/docker-backend.ts
@@ -11,6 +11,7 @@ import type {
   SandboxBackendManager,
 } from "./backend.types.js";
 import { resolveSandboxConfigForAgent } from "./config.js";
+import { DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS } from "./constants.js";
 import {
   containerState,
   bindPodmanSandboxEngine,
@@ -207,7 +208,7 @@ function createContainerSandboxBackendManager(
               runtimeEngine.id === "podman" ? "{{.ImageName}}\t{{.Image}}" : "{{.Config.Image}}",
               entry.containerName,
             ],
-            { allowFailure: true },
+            { allowFailure: true, timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS },
           );
           if (result.code === 0) {
             const inspected = result.stdout.trim();
@@ -234,7 +235,7 @@ function createContainerSandboxBackendManager(
           const result = await execContainer(
             runtimeEngine,
             ["image", "inspect", "-f", "{{.Id}}", configuredImage],
-            { allowFailure: true },
+            { allowFailure: true, timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS },
           );
           if (result.code === 0) {
             const normalizeImageId = (value: string) => value.trim().replace(/^sha256:/u, "");
@@ -256,6 +257,7 @@ function createContainerSandboxBackendManager(
       const runtimeEngine = podmanTarget ? bindPodmanSandboxEngine(podmanTarget) : engine;
       const result = await execContainer(runtimeEngine, ["rm", "-f", entry.containerName], {
         allowFailure: true,
+        timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS,
       });
       if (result.code !== 0) {
         const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`;

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -58,7 +58,11 @@ export async function execDockerRaw(
 import { markOpenClawExecEnv } from "../../infra/openclaw-exec-env.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import { computeSandboxConfigHash } from "./config-hash.js";
-import { DEFAULT_SANDBOX_IMAGE, SANDBOX_DOCKER_CREATE_ARGS_EPOCH } from "./constants.js";
+import {
+  DEFAULT_SANDBOX_IMAGE,
+  DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS,
+  SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
+} from "./constants.js";
 import { handleHotSandboxConfigMismatch } from "./current-config.js";
 import { readRegistryEntry, removeRegistryEntry, updateRegistry } from "./registry.js";
 import { buildSandboxContainerName, slugifySessionKey } from "./shared.js";
@@ -106,7 +110,7 @@ export async function readContainerLabel(
   const result = await execContainer(
     engine,
     ["inspect", "-f", `{{ index .Config.Labels "${label}" }}`, containerName],
-    { allowFailure: true },
+    { allowFailure: true, timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS },
   );
   if (result.code !== 0) {
     return null;
@@ -124,7 +128,7 @@ export async function readDockerContainerEnvVar(
 ): Promise<string | null> {
   const result = await execDocker(
     ["inspect", "-f", "{{range .Config.Env}}{{println .}}{{end}}", containerName],
-    { allowFailure: true },
+    { allowFailure: true, timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS },
   );
   if (result.code !== 0) {
     return null;
@@ -140,6 +144,7 @@ export async function readDockerContainerEnvVar(
 export async function readDockerPort(containerName: string, port: number) {
   const result = await execDocker(["port", containerName, `${port}/tcp`], {
     allowFailure: true,
+    timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS,
   });
   if (result.code !== 0) {
     return null;
@@ -181,6 +186,7 @@ async function inspectContainerImage(
 ): Promise<"exists" | "missing"> {
   const result = await execContainer(engine, ["image", "inspect", image], {
     allowFailure: true,
+    timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS,
   });
   if (result.code === 0) {
     return "exists";
@@ -236,6 +242,7 @@ export async function dockerContainerState(name: string) {
 export async function containerState(engine: SandboxContainerEngine, name: string) {
   const result = await execContainer(engine, ["inspect", "-f", "{{.State.Running}}", name], {
     allowFailure: true,
+    timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS,
   });
   if (result.code !== 0) {
     return { exists: false, running: false };
@@ -256,6 +263,7 @@ function isPodmanContainerNotFound(stderr: string): boolean {
 async function recordedPodmanContainerState(engine: SandboxContainerEngine, name: string) {
   const result = await execContainer(engine, ["inspect", "-f", "{{.State.Running}}", name], {
     allowFailure: true,
+    timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS,
   });
   if (result.code === 0) {
     return { exists: true, running: result.stdout.trim() === "true" };
@@ -527,9 +535,10 @@ async function createSandboxContainer(params: {
   });
   args.push(cfg.image, "sleep", "infinity");
 
-  await execContainer(engine, args);
-  await execContainer(engine, ["start", name]);
+  await execContainer(engine, args, { timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS });
+  await execContainer(engine, ["start", name], { timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS });
 
+  // setupCommand runs operator-owned workload inside the container; it stays unbounded.
   if (cfg.setupCommand?.trim()) {
     await execContainer(engine, ["exec", "-i", name, "/bin/sh", "-lc", cfg.setupCommand]);
   }
@@ -664,7 +673,10 @@ async function ensureSandboxContainerLifecycle(
             : {}),
         });
       } else {
-        await execContainer(engine, ["rm", "-f", containerName], { allowFailure: true });
+        await execContainer(engine, ["rm", "-f", containerName], {
+          allowFailure: true,
+          timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS,
+        });
         hasContainer = false;
         running = false;
       }
@@ -686,7 +698,9 @@ async function ensureSandboxContainerLifecycle(
       podmanRuntimeInfo,
     });
   } else if (!running) {
-    await execContainer(engine, ["start", containerName]);
+    await execContainer(engine, ["start", containerName], {
+      timeoutMs: DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS,
+    });
   }
   await updateRegistry({
     containerName,


### PR DESCRIPTION
## What Problem This Solves

A container engine that is present but unresponsive — the socket accepts connections but never replies (wedged), as opposed to daemon-down which fails fast with stderr — leaves every sandbox provisioning CLI call pending forever. `execContainerRaw` forwards only an optional caller `AbortSignal` and creates no deadline (`src/agents/sandbox/container-engine.ts`), and the provisioning path never supplies a signal (`src/agents/sandbox/context.ts`), so the `await` on the first `docker inspect` never settles and every `sandbox.mode=all` run hangs with no visible outcome (#90980, fresh repro of #5135).

## Why This Change Was Made

Per-call timeout at the shared executor, fail-closed, engine-neutral:

- `execContainerRaw` accepts `timeoutMs` and passes it through to execa's native `timeout` (SIGTERM with execa's default 5s SIGKILL escalation). No hand-rolled timers, settled-guards, or AbortSignal composition — execa@10 already resolves with `timedOut: true` under `reject: false` (verified against a real process, see Evidence).
- A timed-out result throws a typed error (`code: "SANDBOX_CONTAINER_TIMEOUT"`) with the engine name, the timeout, the command that hung, and an actionable hint. The check runs after the abort check (abort wins) and before the generic `failed` branch so a timeout cannot be swallowed as "command execution failed".
- All container control-plane provisioning calls opt in with an internal `DEFAULT_SANDBOX_PROVISION_TIMEOUT_MS = 60_000` (no new public config surface): container/image inspect, label/env/port reads, network inspect/create, create, start, rm — across `docker.ts`, `browser.ts`, and `docker-backend.ts`, for Docker and Podman alike.

**Why per-call, not a total provisioning deadline:** the bug's semantics are engine *responsiveness*, not total duration. A total deadline would mis-kill slow-but-progressing hosts (#85768 shows a legitimate ~30min cold-start prep); a wedged engine fails on the first control-plane call, so in practice the failure surfaces after ~1×timeout anyway.

**Fail-closed:** on timeout the affected sandboxed run fails with the typed error. No host fallback, no degraded mode — that is an explicit maintainer security decision tracked in #90980, whose review recommends exactly this scope ("**Preserve confinement after timeout:** Bound Docker provisioning and fail only the affected all-mode run with an actionable sandbox-unavailable outcome").

**Browser provisioning is included in the same invariant**, answering the review's open question ("determine whether browser-container provisioning shares the same deadline invariant"): browser image/network/state inspects, create/start/rm, and the CDP port/env reads are all bounded by the same per-call timeout.

**Exclusions (intentionally unbounded):** `setupCommand` exec inside the container (operator-owned workload), the user command exec path in `docker-backend.ts` (already cancellable via its caller's `signal`), and all long-running sandboxed commands. The Podman engine probes in `podman-runtime.ts` already bound themselves with `AbortSignal.timeout(5s)` and are untouched.

## User Impact

Operators with `sandbox.mode=all` and a wedged Docker/Podman engine now get a fast, typed, actionable failure (check/restart the engine, or set `agents.defaults.sandbox.mode=off`) after at most ~60s per control-plane call, instead of an indefinite hang with no visible outcome. Healthy-engine behavior is unchanged: callers that pass no `timeoutMs` spawn without a timer, and the existing ENOENT / daemon-stderr / abort semantics are preserved.

Production LOC delta: +77/−19 across 5 files (tests separately: +247/−5). No config schema, config-hash, doctor, or public API changes.

## Evidence

**execa@10 dependency contract (verified against a real process, not memory):**

```
$ node -e 'execa("sleep",["600"],{reject:false,timeout:500})...'
{"elapsed":529,"timedOut":true,"failed":true,"isCanceled":false,"isTerminated":true,"signal":"SIGTERM","pidAlive":false}
```

**Real-runtime proof (wedged engine shim, no mocks):** PATH fronted with an executable `docker` = `#!/bin/sh` + `echo $$ > docker.pid` + `exec sleep infinity`, then the real `ensureSandboxContainer` (via `node --import tsx`, isolated `OPENCLAW_STATE_DIR`) with the real 60s timer, on WSL2 Ubuntu / Node 24:

```
[proof] PATH head: /tmp/wedged-proof/shim
[proof] provisioning start: 2026-08-09T03:34:00.926Z
[proof] elapsed_ms=60683
[proof] error.code=SANDBOX_CONTAINER_TIMEOUT
[proof] error.message=Docker did not respond within 60000ms (`docker inspect -f`). Check that Docker is healthy (restart it if needed), or set `agents.defaults.sandbox.mode=off` to disable sandboxing.
[proof] fail-closed: no host fallback, run fails (exit non-zero)
=== CLEANUP CHECK ===
shim_pid=733
shim_alive=no(killed)
no wedged children, no zombies
```

The run fails closed with the typed error after ~60.7s (1×timeout, on the first `docker inspect`), the shim child is killed (no zombie), and nothing executes on the host.

**Tests** (run on Linux, WSL2 Ubuntu / Node 24, branch rebased on latest main):

- `container-engine.timeout.test.ts` — timed-out result → `SANDBOX_CONTAINER_TIMEOUT` typed error (message includes engine, timeout, command, remediation); abort error wins when `isCanceled` and `timedOut` are both true; `timeoutMs` passes through to the spawn layer; no `timeoutMs` → no spawn timeout (back-compat); `ensureSandboxContainer` with a wedged engine fails fast on the first inspect with the typed error instead of hanging (a wiring regression would surface as a test hang).
- `container-engine.wedged-runtime.test.ts` — real-process proof in CI: spawns a wedged `docker` shim via PATH, asserts the typed error and that the child process is actually killed (guards against the mock-only trap).
- Full `src/agents/sandbox` suite green: 87 files, 1124 tests, 0 failures (clean-main baseline also green).
- Gates: oxfmt clean; oxlint 0 warnings/0 errors on every touched file; tsgo core + core:test 0 errors.

Fixes #90980
Refs #5135
Supersedes #91015