### PR TITLE
fix(secrets): avoid repeated plugin discovery during startup

### DIFF
--- a/src/agents/agent-runtime-config.ts
+++ b/src/agents/agent-runtime-config.ts
@@ -96,6 +96,7 @@ export async function resolveAgentRuntimeConfig(
           config: sourceConfig,
           assignmentConfig: cfg,
           includeConfigRefs: false,
+          ...(pluginMetadataSnapshot ? { pluginMetadataSnapshot } : {}),
         }),
       { config: cfg },
     );

--- a/src/commands/agent.runtime-config.test.ts
+++ b/src/commands/agent.runtime-config.test.ts
@@ -5,12 +5,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveAgentRuntimeConfig } from "../agents/agent-runtime-config.js";
 import { resolveSession } from "../agents/command/session.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createThrowingTestRuntime } from "./test-runtime-config-helpers.js";
 
 type ConfigSnapshotForWrite = {
   snapshot: { valid: boolean; resolved: OpenClawConfig };
-  writeOptions: Record<string, never>;
+  writeOptions: { basePluginMetadataSnapshot?: PluginMetadataSnapshot };
 };
 
 type ResolveCommandConfigParams = {
@@ -93,14 +94,20 @@ vi.mock("../config/runtime-snapshot.js", () => ({
 
 const getActiveSecretsRuntimeSnapshotMock = vi.hoisted(() => vi.fn<() => object | null>());
 const prepareSecretsRuntimeSnapshotMock = vi.hoisted(() =>
-  vi.fn(async (params: { config: OpenClawConfig; assignmentConfig: OpenClawConfig }) => ({
-    sourceConfig: params.config,
-    config: params.assignmentConfig,
-    authStores: [],
-    authStoreCredentialsRevision: 0,
-    warnings: [],
-    webTools: {},
-  })),
+  vi.fn(
+    async (params: {
+      config: OpenClawConfig;
+      assignmentConfig: OpenClawConfig;
+      pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins" | "manifestRegistry">;
+    }) => ({
+      sourceConfig: params.config,
+      config: params.assignmentConfig,
+      authStores: [],
+      authStoreCredentialsRevision: 0,
+      warnings: [],
+      webTools: {},
+    }),
+  ),
 );
 const activateSecretsRuntimeSnapshotMock = vi.hoisted(() => vi.fn());
 vi.mock("../secrets/runtime.js", () => ({
@@ -167,9 +174,13 @@ describe("agentCommand runtime config", () => {
       const store = path.join(home, "sessions.json");
       const loadedConfig = mockConfig(home, store);
       const sourceConfig = { ...loadedConfig, secrets: { providers: {} } } as OpenClawConfig;
+      const pluginMetadataSnapshot = {
+        plugins: [],
+        manifestRegistry: { plugins: [], diagnostics: [] },
+      } as unknown as PluginMetadataSnapshot;
       readConfigFileSnapshotForWriteMock.mockResolvedValue({
         snapshot: { valid: true, resolved: sourceConfig },
-        writeOptions: {},
+        writeOptions: { basePluginMetadataSnapshot: pluginMetadataSnapshot },
       });
       getActiveSecretsRuntimeSnapshotMock.mockReturnValue(null);
 
@@ -179,7 +190,11 @@ describe("agentCommand runtime config", () => {
         config: sourceConfig,
         assignmentConfig: loadedConfig,
         includeConfigRefs: false,
+        pluginMetadataSnapshot,
       });
+      expect(prepareSecretsRuntimeSnapshotMock.mock.calls[0]?.[0].pluginMetadataSnapshot).toBe(
+        pluginMetadataSnapshot,
+      );
       expect(activateSecretsRuntimeSnapshotMock).toHaveBeenCalledWith(
         expect.objectContaining({ sourceConfig, config: loadedConfig }),
       );

--- a/src/plugins/config-contracts.test.ts
+++ b/src/plugins/config-contracts.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => {
   const loadManifestRegistry = vi.fn();
   return {
     discoverOpenClawPlugins: vi.fn(() => ({ candidates: [], diagnostics: [] })),
+    findBundledPluginMetadataById: vi.fn(),
     loadBundledManifestRegistry: vi.fn(),
     loadPluginManifestRegistryForInstalledIndex: loadManifestRegistry,
     loadPluginManifestRegistryForPluginRegistry: loadManifestRegistry,
@@ -15,6 +16,10 @@ const mocks = vi.hoisted(() => {
 
 vi.mock("./discovery.js", () => ({
   discoverOpenClawPlugins: mocks.discoverOpenClawPlugins,
+}));
+
+vi.mock("./bundled-plugin-metadata.js", () => ({
+  findBundledPluginMetadataById: mocks.findBundledPluginMetadataById,
 }));
 
 vi.mock("./manifest-registry.js", () => ({
@@ -85,12 +90,55 @@ describe("resolvePluginConfigContractsById", () => {
   beforeEach(() => {
     mocks.discoverOpenClawPlugins.mockReset();
     mocks.discoverOpenClawPlugins.mockReturnValue({ candidates: [], diagnostics: [] });
+    mocks.findBundledPluginMetadataById.mockReset();
     mocks.loadBundledManifestRegistry.mockReset();
     mocks.loadBundledManifestRegistry.mockReturnValue(createRegistry([]));
     mocks.loadPluginManifestRegistryForInstalledIndex.mockReset();
     mocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue(createRegistry([]));
     mocks.loadPluginRegistrySnapshot.mockReset();
     mocks.loadPluginRegistrySnapshot.mockReturnValue({ plugins: [] });
+  });
+
+  it("uses a supplied manifest registry as the authoritative contract source", () => {
+    const manifestRegistry = createRegistry([
+      createPluginRecord({
+        id: "prepared-plugin",
+        origin: "config",
+        configContracts: {
+          secretInputs: {
+            paths: [{ path: "credentials.token", expected: "string" }],
+          },
+        },
+      }),
+    ]);
+
+    expect(
+      resolvePluginConfigContractsById({
+        pluginIds: ["prepared-plugin"],
+        manifestRegistry,
+        fallbackToBundledMetadata: true,
+        fallbackToBundledMetadataForResolvedBundled: true,
+        fallbackBundledPluginIds: ["prepared-plugin"],
+      }),
+    ).toEqual(
+      new Map([
+        [
+          "prepared-plugin",
+          {
+            origin: "config",
+            configContracts: {
+              secretInputs: {
+                paths: [{ path: "credentials.token", expected: "string" }],
+              },
+            },
+          },
+        ],
+      ]),
+    );
+    expect(mocks.loadPluginManifestRegistryForPluginRegistry).not.toHaveBeenCalled();
+    expect(mocks.discoverOpenClawPlugins).not.toHaveBeenCalled();
+    expect(mocks.loadBundledManifestRegistry).not.toHaveBeenCalled();
+    expect(mocks.findBundledPluginMetadataById).not.toHaveBeenCalled();
   });
 
   it("does not fall back to bundled registry when registry already resolved a plugin without config contracts", () => {
@@ -158,6 +206,8 @@ describe("resolvePluginConfigContractsById", () => {
         ],
       ]),
     );
+    expect(mocks.loadPluginManifestRegistryForPluginRegistry).toHaveBeenCalledTimes(1);
+    expect(mocks.loadBundledManifestRegistry).toHaveBeenCalledTimes(1);
   });
 
   it("refreshes stale bundled SecretInput contracts from bundled registry", () => {

--- a/src/plugins/config-contracts.ts
+++ b/src/plugins/config-contracts.ts
@@ -3,7 +3,7 @@ import { normalizeSortedUniqueStringEntries } from "@openclaw/normalization-core
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { findBundledPluginMetadataById } from "./bundled-plugin-metadata.js";
 import { discoverOpenClawPlugins, type PluginDiscoveryResult } from "./discovery.js";
-import { loadPluginManifestRegistry } from "./manifest-registry.js";
+import { loadPluginManifestRegistry, type PluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginManifestConfigContracts } from "./manifest.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
 import { loadPluginManifestRegistryForPluginRegistry } from "./plugin-registry.js";
@@ -26,6 +26,7 @@ export function resolvePluginConfigContractsById(params: {
   fallbackBundledPluginIds?: readonly string[];
   pluginIds: readonly string[];
   discovery?: PluginDiscoveryResult;
+  manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
 }): ReadonlyMap<string, PluginConfigContractMetadata> {
   const matches = new Map<string, PluginConfigContractMetadata>();
   const pluginIds = normalizeSortedUniqueStringEntries(params.pluginIds);
@@ -74,12 +75,14 @@ export function resolvePluginConfigContractsById(params: {
   };
 
   const resolvedPluginOrigins = new Map<string, PluginOrigin>();
-  const registry = loadPluginManifestRegistryForPluginRegistry({
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-    includeDisabled: true,
-  });
+  const registry =
+    params.manifestRegistry ??
+    loadPluginManifestRegistryForPluginRegistry({
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+      includeDisabled: true,
+    });
   for (const plugin of registry.plugins) {
     if (!pluginIds.includes(plugin.id)) {
       continue;
@@ -94,7 +97,7 @@ export function resolvePluginConfigContractsById(params: {
     });
   }
 
-  if (params.fallbackToBundledMetadata ?? true) {
+  if (!params.manifestRegistry && (params.fallbackToBundledMetadata ?? true)) {
     for (const pluginId of pluginIds) {
       const existing = matches.get(pluginId);
       const shouldHydrateBundledMatch =

--- a/src/secrets/runtime-config-collectors-plugins.test.ts
+++ b/src/secrets/runtime-config-collectors-plugins.test.ts
@@ -1,6 +1,7 @@
 /** Tests plugin-specific runtime config secret collectors. */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginOrigin } from "../plugins/types.js";
 import { collectPluginConfigAssignments } from "./runtime-config-collectors-plugins.js";
 import { createResolverContext, type ResolverContext } from "./runtime-shared.js";
@@ -25,10 +26,14 @@ function asConfig(value: unknown): OpenClawConfig {
   };
 }
 
-function makeContext(sourceConfig: OpenClawConfig): ResolverContext {
+function makeContext(
+  sourceConfig: OpenClawConfig,
+  manifestRegistry?: Pick<PluginManifestRegistry, "plugins">,
+): ResolverContext {
   return createResolverContext({
     sourceConfig,
     env: {},
+    ...(manifestRegistry ? { manifestRegistry } : {}),
   });
 }
 
@@ -153,6 +158,37 @@ describe("collectPluginConfigAssignments", () => {
     const assignment = requireAssignment(context, 0);
     expect(assignment.path).toBe("plugins.entries.acpx.config.mcpServers.github.env.GITHUB_TOKEN");
     expect(assignment.expected).toBe("string");
+  });
+
+  it("collects from a supplied manifest registry without cold registry loading", () => {
+    const config = createPluginConfig("prepared-plugin", {
+      credentials: { token: envRef("PREPARED_TOKEN") },
+    });
+    const context = makeContext(config, {
+      plugins: [
+        {
+          id: "prepared-plugin",
+          origin: "config",
+          configContracts: {
+            secretInputs: {
+              paths: [{ path: "credentials.token", expected: "string" }],
+            },
+          },
+        } as never,
+      ],
+    });
+
+    collectPluginConfigAssignments({
+      config,
+      defaults: undefined,
+      context,
+      loadablePluginOrigins: loadablePluginOrigins([["prepared-plugin", "config"]]),
+    });
+
+    expect(context.assignments.map((assignment) => assignment.path)).toEqual([
+      "plugins.entries.prepared-plugin.config.credentials.token",
+    ]);
+    expect(loadPluginManifestRegistryForPluginRegistryMock).not.toHaveBeenCalled();
   });
 
   it("resolves assignments via apply callback", () => {

--- a/src/secrets/runtime-config-collectors-plugins.ts
+++ b/src/secrets/runtime-config-collectors-plugins.ts
@@ -66,6 +66,7 @@ export function collectPluginConfigAssignments(params: {
         fallbackToBundledMetadataForResolvedBundled: true,
         fallbackBundledPluginIds: bundledLoadablePluginIds,
         pluginIds: Object.keys(entries),
+        manifestRegistry: params.context.manifestRegistry,
       }).entries(),
     ].flatMap(([pluginId, metadata]) => {
       const secretInputs = metadata.configContracts.secretInputs;

--- a/src/secrets/target-registry-data.current-snapshot.test.ts
+++ b/src/secrets/target-registry-data.current-snapshot.test.ts
@@ -2,7 +2,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const metadataMocks = vi.hoisted(() => ({
+  listBundledPluginMetadata: vi.fn(),
   resolvePluginMetadataSnapshot: vi.fn(() => ({ plugins: [] })),
+}));
+
+vi.mock("../plugins/bundled-plugin-metadata.js", () => ({
+  listBundledPluginMetadata: metadataMocks.listBundledPluginMetadata,
 }));
 
 vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
@@ -12,6 +17,10 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
 describe("getSecretTargetRegistry metadata reuse", () => {
   beforeEach(() => {
     vi.resetModules();
+    metadataMocks.listBundledPluginMetadata.mockReset();
+    metadataMocks.listBundledPluginMetadata.mockImplementation(() => {
+      throw new Error("source bundled metadata must not be scanned");
+    });
     metadataMocks.resolvePluginMetadataSnapshot.mockClear();
     metadataMocks.resolvePluginMetadataSnapshot.mockReturnValue({ plugins: [] });
   });
@@ -56,5 +65,26 @@ describe("getSecretTargetRegistry metadata reuse", () => {
 
     expect(ids).toContain("plugins.entries.exa.config.webSearch.apiKey");
     expect(isKnownSecretTargetId("plugins.entries.exa.config.webSearch.apiKey")).toBe(true);
+  });
+
+  it("registers config contract targets only from the resolved snapshot", async () => {
+    metadataMocks.resolvePluginMetadataSnapshot.mockReturnValue({
+      plugins: [
+        {
+          id: "snapshot-plugin",
+          origin: "config",
+          channels: [],
+          configContracts: {
+            secretInputs: { paths: [{ path: "credentials.token" }] },
+          },
+        },
+      ],
+    } as never);
+    const { getSecretTargetRegistry } = await import("./target-registry-data.js");
+
+    const ids = getSecretTargetRegistry().map((entry) => entry.id);
+
+    expect(ids).toContain("plugins.entries.snapshot-plugin.config.credentials.token");
+    expect(metadataMocks.listBundledPluginMetadata).not.toHaveBeenCalled();
   });
 });

--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -1,4 +1,3 @@
-import { listBundledPluginMetadata } from "../plugins/bundled-plugin-metadata.js";
 /** Builds the static and plugin-derived registry of secret migration targets. */
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
@@ -84,24 +83,6 @@ function listPluginConfigSecretTargetRegistryEntries(
     }
   }
   return entries.toSorted((left, right) => left.id.localeCompare(right.id));
-}
-
-function listSourceBundledPluginConfigContractRecords(): Array<
-  Pick<PluginManifestRecord, "id" | "configContracts">
-> {
-  return listBundledPluginMetadata({
-    includeChannelConfigs: false,
-    includeSyntheticChannelConfigs: false,
-  }).flatMap((metadata) =>
-    metadata.manifest.configContracts
-      ? [
-          {
-            id: metadata.manifest.id,
-            configContracts: metadata.manifest.configContracts,
-          },
-        ]
-      : [],
-  );
 }
 
 function listChannelSecretTargetRegistryEntries(
@@ -481,10 +462,7 @@ function loadSecretTargetRegistryFromPluginMetadata(params: {
   return [
     ...CORE_SECRET_TARGET_REGISTRY,
     ...listPluginWebProviderSecretTargetRegistryEntries(plugins),
-    ...listPluginConfigSecretTargetRegistryEntries([
-      ...plugins,
-      ...listSourceBundledPluginConfigContractRecords(),
-    ]),
+    ...listPluginConfigSecretTargetRegistryEntries(plugins),
     ...listChannelSecretTargetRegistryEntries(channelPlugins),
   ];
 }


### PR DESCRIPTION
## What Problem This Solves
Fixes an issue where Gateway and standalone agent SecretRef preparation could repeat plugin filesystem discovery even though a compatible plugin metadata snapshot had already been prepared. The repeated scan added startup work and split ownership of manifest facts across lifecycle and consumer code.

## Why This Change Was Made
Plugin contract collection now treats a supplied lifecycle manifest registry as authoritative and uses cold discovery only for standalone callers without prepared metadata. Standalone agent preparation forwards its config-read metadata snapshot, and the secret target registry no longer performs a second bundled source scan. Cold fallback behavior remains covered and unchanged.

## User Impact
Gateway and standalone agent startup avoid redundant plugin metadata filesystem work while retaining the same SecretRef behavior and standalone compatibility.

## Evidence
- `node scripts/run-vitest.mjs src/plugins/config-contracts.test.ts src/secrets/runtime-config-collectors-plugins.test.ts src/commands/agent.runtime-config.test.ts src/secrets/target-registry-data.current-snapshot.test.ts` — 40 tests passed.
- `node scripts/check-changed.mjs -- <eight paths>` — passed remotely, including core/test typechecks, formatting, lint, plugin boundaries, import cycles, and dead-export checks: https://github.com/openclaw/openclaw/actions/runs/31290798701
- `git diff --check` — passed before commit.
- `$autoreview --mode uncommitted` — clean; no accepted/actionable findings.
- Production code delta: 14 additions, 31 deletions (net -17).

AI-assisted; the patch and tests were reviewed and understood before landing.
