### PR TITLE
fix(macos): prevent parallel Swift test hangs after coordinator timeouts

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -113,6 +113,7 @@ final class MacNodeModeCoordinator: NSObject {
     private let presenceReporter: MacNodePresenceReporter
     private let notificationCenter: NotificationCenter
     private let routeInvalidationHook: (@Sendable () async -> Void)?
+    private let nodeHostWorkerRetrySleep: @Sendable (UInt64) async throws -> Void
     private let refreshEvents: AsyncStream<Void>
     private let refreshContinuation: AsyncStream<Void>.Continuation
     private var tlsSessionCache = MacNodeGatewayTLSSessionCache()
@@ -149,6 +150,9 @@ final class MacNodeModeCoordinator: NSObject {
         initialPaused: Bool? = nil,
         initialComputerControlEnabled: Bool? = nil,
         routeInvalidationHook: (@Sendable () async -> Void)? = nil,
+        nodeHostWorkerRetrySleep: @escaping @Sendable (UInt64) async throws -> Void = {
+            try await Task.sleep(nanoseconds: $0)
+        },
         nodeHostWorkerRetryPolicy: MacNodeHostWorkerRetryPolicy = MacNodeHostWorkerRetryPolicy())
     {
         let refreshEvents = AsyncStream.makeStream(of: Void.self, bufferingPolicy: .bufferingNewest(1))
@@ -158,6 +162,7 @@ final class MacNodeModeCoordinator: NSObject {
         self.presenceReporter = presenceReporter
         self.notificationCenter = notificationCenter
         self.routeInvalidationHook = routeInvalidationHook
+        self.nodeHostWorkerRetrySleep = nodeHostWorkerRetrySleep
         self.nodeHostWorkerRetryPolicy = nodeHostWorkerRetryPolicy
         self.refreshEvents = refreshEvents.stream
         self.refreshContinuation = refreshEvents.continuation
@@ -762,6 +767,14 @@ final class MacNodeModeCoordinator: NSObject {
     func handleNodeHostWorkerFailureForTesting() {
         self.handleNodeHostWorkerFailure()
     }
+
+    func waitForNodeHostWorkerRetryForTesting() async {
+        await self.nodeHostWorkerRetryTask?.value
+    }
+
+    func handleNodeHostConfigurationChangeForTesting() async {
+        await self.handleNodeHostConfigurationChange().value
+    }
     #endif
 
     private func cancelReconnectProbe() {
@@ -783,12 +796,17 @@ final class MacNodeModeCoordinator: NSObject {
 
     @objc private nonisolated func nodeHostConfigurationChanged(_: Notification) {
         Task { @MainActor [weak self] in
-            self?.nodeHostWorkerConfigurationGeneration &+= 1
-            self?.resetNodeHostWorkerRetryState()
-            // Worker code, plugin availability, and its manifest are startup-scoped.
-            // Replace the process before reconnecting so updates cannot leave a stale route.
-            self?.enqueueRouteInvalidation(yieldRefresh: true, restartNodeHostWorker: true)
+            self?.handleNodeHostConfigurationChange()
         }
+    }
+
+    @discardableResult
+    private func handleNodeHostConfigurationChange() -> Task<Void, Never> {
+        self.nodeHostWorkerConfigurationGeneration &+= 1
+        self.resetNodeHostWorkerRetryState()
+        // Worker code, plugin availability, and its manifest are startup-scoped.
+        // Replace the process before reconnecting so updates cannot leave a stale route.
+        return self.enqueueRouteInvalidation(yieldRefresh: true, restartNodeHostWorker: true)
     }
 
     private func currentCaps(
@@ -862,10 +880,11 @@ final class MacNodeModeCoordinator: NSObject {
             let delaySeconds = Double(delayNanoseconds) / 1_000_000_000
             self.logger.error(
                 "node-host worker retry \(attempt, privacy: .public) in \(delaySeconds, privacy: .public)s")
+            let retrySleep = self.nodeHostWorkerRetrySleep
             self.nodeHostWorkerRetryTask = Task { @MainActor [weak self] in
                 await invalidation.value
                 do {
-                    try await Task.sleep(nanoseconds: delayNanoseconds)
+                    try await retrySleep(delayNanoseconds)
                 } catch {
                     return
                 }

--- a/apps/macos/Tests/OpenClawIPCTests/AsyncTestGate.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AsyncTestGate.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+final class AsyncTestGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var isOpen = false
+    private var waiters: [UUID: CheckedContinuation<Void, Never>] = [:]
+
+    func wait() async {
+        let id = UUID()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                let resumeImmediately = self.lock.withLock {
+                    guard !self.isOpen, !Task.isCancelled else { return true }
+                    self.waiters[id] = continuation
+                    return false
+                }
+                if resumeImmediately {
+                    continuation.resume()
+                }
+            }
+        } onCancel: {
+            let continuation = self.lock.withLock {
+                self.waiters.removeValue(forKey: id)
+            }
+            continuation?.resume()
+        }
+    }
+
+    func open() {
+        let continuations = self.lock.withLock {
+            self.isOpen = true
+            defer { self.waiters.removeAll() }
+            return Array(self.waiters.values)
+        }
+        for continuation in continuations {
+            continuation.resume()
+        }
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
@@ -8,10 +8,13 @@ private actor CoordinatorInvokeLifecycleProbe {
     private var invokeStarted = false
     private var invokeCancelled = false
     private var routeInvalidated = false
-    private var routeInvalidationReleased = false
-    private var routeInvalidationContinuation: CheckedContinuation<Void, Never>?
+    private let routeInvalidationGate: AsyncTestGate
     private var successorConnected = false
     private var events: [String] = []
+
+    init(routeInvalidationGate: AsyncTestGate) {
+        self.routeInvalidationGate = routeInvalidationGate
+    }
 
     func invoke(_ request: BridgeInvokeRequest) async -> BridgeInvokeResponse {
         self.invokeStarted = true
@@ -32,21 +35,8 @@ private actor CoordinatorInvokeLifecycleProbe {
     func recordInvalidation() async {
         self.routeInvalidated = true
         self.events.append("invalidation-started")
-        guard !self.routeInvalidationReleased else {
-            self.events.append("invalidation-finished")
-            return
-        }
-        await withCheckedContinuation { continuation in
-            self.routeInvalidationContinuation = continuation
-        }
+        await self.routeInvalidationGate.wait()
         self.events.append("invalidation-finished")
-    }
-
-    func releaseInvalidation() {
-        self.routeInvalidationReleased = true
-        let continuation = self.routeInvalidationContinuation
-        self.routeInvalidationContinuation = nil
-        continuation?.resume()
     }
 
     func recordSuccessorConnected() {
@@ -65,26 +55,20 @@ private actor CoordinatorInvokeLifecycleProbe {
 
 private actor CoordinatorRouteInvalidationHookProbe {
     private var callCount = 0
-    private var blockedCallContinuation: CheckedContinuation<Void, Never>?
-    private var blockedCallReleased = false
+    private let blockedCallGate: AsyncTestGate
+
+    init(blockedCallGate: AsyncTestGate) {
+        self.blockedCallGate = blockedCallGate
+    }
 
     func run() async {
         self.callCount += 1
-        guard self.callCount == 2, !self.blockedCallReleased else { return }
-        await withCheckedContinuation { continuation in
-            self.blockedCallContinuation = continuation
-        }
+        guard self.callCount == 2 else { return }
+        await self.blockedCallGate.wait()
     }
 
     func calls() -> Int {
         self.callCount
-    }
-
-    func releaseBlockedCall() {
-        self.blockedCallReleased = true
-        let continuation = self.blockedCallContinuation
-        self.blockedCallContinuation = nil
-        continuation?.resume()
     }
 }
 
@@ -121,6 +105,33 @@ private actor CoordinatorNodeHostWorkerProbe: MacNodeHostWorking {
     func stops() -> Int { self.stopCount }
 }
 
+private final class CoordinatorRetrySleeperProbe: @unchecked Sendable {
+    private let entered = AsyncTestGate()
+    private let releaseGate = AsyncTestGate()
+
+    func sleep(_: UInt64) async throws {
+        self.entered.open()
+        await self.releaseGate.wait()
+        try Task.checkCancellation()
+    }
+
+    func waitUntilEntered() async {
+        await self.entered.wait()
+    }
+
+    func release() {
+        self.releaseGate.open()
+    }
+}
+
+private struct CoordinatorWaitTimeout: Error, CustomStringConvertible {
+    let operation: String
+
+    var description: String {
+        "timed out waiting for \(self.operation)"
+    }
+}
+
 struct MacNodeModeCoordinatorTests {
     private func waitUntil(
         _ description: String,
@@ -137,7 +148,25 @@ struct MacNodeModeCoordinatorTests {
             // notification task make progress instead of polling it out.
             try await Task.sleep(for: .milliseconds(10))
         }
-        Issue.record("timed out waiting for \(description)")
+        throw CoordinatorWaitTimeout(operation: description)
+    }
+
+    @MainActor
+    private func cleanupRevocationTest(
+        lifecycleInvalidationGate: AsyncTestGate,
+        routeInvalidationGate: AsyncTestGate,
+        successor: Task<Void, Error>?,
+        gateway: GatewayNodeSession,
+        coordinator: MacNodeModeCoordinator) async
+    {
+        lifecycleInvalidationGate.open()
+        routeInvalidationGate.open()
+        successor?.cancel()
+        if let successor {
+            _ = await successor.result
+        }
+        await gateway.disconnect()
+        await coordinator.stopAndWait()
     }
 
     @Test func `stale endpoint attempt is rejected after a suspended permission query`() {
@@ -149,31 +178,21 @@ struct MacNodeModeCoordinatorTests {
             currentGeneration: 8))
     }
 
-    @Test @MainActor func `config and CLI changes restart startup scoped node host worker`() async throws {
+    @Test @MainActor func `config and CLI changes restart startup scoped node host worker`() async {
         let worker = CoordinatorNodeHostWorkerProbe()
         let session = GatewayNodeSession()
-        let notificationCenter = NotificationCenter()
         let coordinator = MacNodeModeCoordinator(
             session: session,
             runtime: MacNodeRuntime(nodeHostWorker: worker),
-            nodeHostWorker: worker,
-            notificationCenter: notificationCenter,
-            observeNotifications: true)
-        // The full parallel suite can keep MainActor busy for several seconds.
-        let restartTimeout: Duration = .seconds(15)
-        defer { withExtendedLifetime(coordinator) {} }
+            nodeHostWorker: worker)
 
-        notificationCenter.post(name: .openclawConfigDidChange, object: nil)
+        await coordinator.handleNodeHostConfigurationChangeForTesting()
+        #expect(await worker.stops() == 1)
 
-        try await self.waitUntil("node-host worker restart", timeout: restartTimeout) {
-            await worker.stops() == 1
-        }
+        await coordinator.handleNodeHostConfigurationChangeForTesting()
+        #expect(await worker.stops() == 2)
 
-        notificationCenter.post(name: .openclawCLIInstalled, object: nil)
-
-        try await self.waitUntil("node-host worker restart", timeout: restartTimeout) {
-            await worker.stops() == 2
-        }
+        await coordinator.stopAndWait()
     }
 
     @Test @MainActor func `terminal worker failure is reported instead of scheduling another restart`() async throws {
@@ -208,37 +227,31 @@ struct MacNodeModeCoordinatorTests {
     @Test @MainActor func `worker cannot restart before its crash backoff expires`() async throws {
         let worker = CoordinatorNodeHostWorkerProbe()
         let session = GatewayNodeSession()
+        let sleeper = CoordinatorRetrySleeperProbe()
         let coordinator = MacNodeModeCoordinator(
             session: session,
             runtime: MacNodeRuntime(nodeHostWorker: worker),
             nodeHostWorker: worker,
             observeNotifications: false,
+            nodeHostWorkerRetrySleep: { try await sleeper.sleep($0) },
             nodeHostWorkerRetryPolicy: MacNodeHostWorkerRetryPolicy(
                 maximumRetryCount: 1,
                 initialDelayNanoseconds: 50_000_000,
                 maximumDelayNanoseconds: 50_000_000))
         let command = ["/usr/local/bin/openclaw", "node", "worker"]
+        defer { sleeper.release() }
 
         try coordinator.prepareNodeHostWorkerRetryForTesting(command: command)
         coordinator.handleNodeHostWorkerFailureForTesting()
+        await sleeper.waitUntilEntered()
         #expect(throws: MacNodeHostWorkerRetryPolicy.RetryBackoffPending.self) {
             try coordinator.prepareNodeHostWorkerRetryForTesting(command: command)
         }
 
-        try await self.waitUntil("node-host worker retry backoff") {
-            do {
-                try await MainActor.run {
-                    try coordinator.prepareNodeHostWorkerRetryForTesting(command: command)
-                }
-                return true
-            } catch is MacNodeHostWorkerRetryPolicy.RetryBackoffPending {
-                return false
-            } catch {
-                Issue.record("unexpected retry admission error: \(error)")
-                return false
-            }
-        }
-        await coordinator.waitForRouteInvalidationForTesting()
+        sleeper.release()
+        await coordinator.waitForNodeHostWorkerRetryForTesting()
+        try coordinator.prepareNodeHostWorkerRetryForTesting(command: command)
+        await coordinator.stopAndWait()
     }
 
     @Test func `paused node state requires route disconnect`() {
@@ -358,8 +371,12 @@ struct MacNodeModeCoordinatorTests {
     @Test @MainActor func `revocation finishes before successor admission`() async throws {
         let webSocketSession = GatewayTestWebSocketSession()
         let gateway = GatewayNodeSession()
-        let lifecycle = CoordinatorInvokeLifecycleProbe()
-        let routeInvalidationHook = CoordinatorRouteInvalidationHookProbe()
+        let lifecycleInvalidationGate = AsyncTestGate()
+        let routeInvalidationGate = AsyncTestGate()
+        let lifecycle = CoordinatorInvokeLifecycleProbe(
+            routeInvalidationGate: lifecycleInvalidationGate)
+        let routeInvalidationHook = CoordinatorRouteInvalidationHookProbe(
+            blockedCallGate: routeInvalidationGate)
         let drainSnapshot = CoordinatorDrainSnapshotProbe()
         let runtime = MacNodeRuntime(computerControlEnabled: { true })
         let coordinator = MacNodeModeCoordinator(
@@ -378,123 +395,140 @@ struct MacNodeModeCoordinatorTests {
             clientMode: "node",
             clientDisplayName: "macOS Test",
             includeDeviceIdentity: false)
+        var successor: Task<Void, Error>?
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://first.example.invalid")),
-            token: nil,
-            bootstrapToken: nil,
-            password: nil,
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: webSocketSession),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { request in await lifecycle.invoke(request) },
-            onRouteInvalidated: { await lifecycle.recordInvalidation() })
-        let task = try #require(webSocketSession.latestTask())
-        while !task.hasPendingReceiveHandler() {
-            await Task.yield()
-        }
-        let invokeEvent = try JSONSerialization.data(withJSONObject: [
-            "type": "event",
-            "event": "node.invoke.request",
-            "payload": [
-                "id": "in-flight-computer",
-                "nodeId": "test-node",
-                "command": "computer.act",
-                "paramsJSON": "{}",
-                "timeoutMs": 0,
-            ],
-        ])
-        task.emitReceiveSuccessOnce(.data(invokeEvent))
-        try await self.waitUntil("computer invoke start") {
-            await lifecycle.state().started
-        }
-
-        let originalRoute = try #require(await gateway.currentRoute())
-        let generationsBeforeRefresh = coordinator.generationsForTesting()
-        coordinator.refreshForTesting(
-            isPaused: false,
-            computerControlEnabled: true)
-        for _ in 0..<20 {
-            await Task.yield()
-        }
-        let stateAfterOrdinaryRefresh = await lifecycle.state()
-        let generationsAfterOrdinaryRefresh = coordinator.generationsForTesting()
-        #expect(await gateway.currentRoute() == originalRoute)
-        #expect(!stateAfterOrdinaryRefresh.cancelled)
-        #expect(!stateAfterOrdinaryRefresh.invalidated)
-        #expect(generationsAfterOrdinaryRefresh.endpointAttempt == generationsBeforeRefresh.endpointAttempt + 1)
-        #expect(generationsAfterOrdinaryRefresh.routeAuthority == generationsBeforeRefresh.routeAuthority)
-        #expect(coordinator.routeAuthorityAllowsInvokeForTesting(
-            generationsBeforeRefresh.routeAuthority,
-            isPaused: false))
-
-        coordinator.refreshForTesting(
-            isPaused: true,
-            computerControlEnabled: true)
-        let generationsAfterPause = coordinator.generationsForTesting()
-        #expect(generationsAfterPause.routeAuthority == generationsBeforeRefresh.routeAuthority + 1)
-        #expect(!coordinator.routeAuthorityAllowsInvokeForTesting(
-            generationsBeforeRefresh.routeAuthority,
-            isPaused: true))
-        try await self.waitUntil("route invalidation start") {
-            await lifecycle.state().invalidated
-        }
-
-        let successorURL = try #require(URL(string: "ws://successor.example.invalid"))
-        let successor = Task {
-            await coordinator.waitForRouteInvalidationForTesting(
-                onPendingSnapshot: { await drainSnapshot.recordCapture() })
+        do {
             try await gateway.connect(
-                url: successorURL,
+                url: #require(URL(string: "ws://first.example.invalid")),
                 token: nil,
                 bootstrapToken: nil,
                 password: nil,
                 connectOptions: options,
                 sessionBox: WebSocketSessionBox(session: webSocketSession),
-                onConnected: { await lifecycle.recordSuccessorConnected() },
+                onConnected: {},
                 onDisconnected: { _ in },
-                onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
-        }
-        try await waitUntil("successor captured first invalidation") {
-            await drainSnapshot.hasCaptured()
-        }
-        coordinator.enqueueRouteInvalidationForTesting()
-        let generationsAfterSecondRevocation = coordinator.generationsForTesting()
-        #expect(generationsAfterSecondRevocation.routeAuthority == generationsBeforeRefresh.routeAuthority + 2)
-        #expect(generationsAfterSecondRevocation.completedRouteAuthority == generationsBeforeRefresh.routeAuthority)
+                onInvoke: { request in await lifecycle.invoke(request) },
+                onRouteInvalidated: { await lifecycle.recordInvalidation() })
+            let task = try #require(webSocketSession.latestTask())
+            while !task.hasPendingReceiveHandler() {
+                await Task.yield()
+            }
+            let invokeEvent = try JSONSerialization.data(withJSONObject: [
+                "type": "event",
+                "event": "node.invoke.request",
+                "payload": [
+                    "id": "in-flight-computer",
+                    "nodeId": "test-node",
+                    "command": "computer.act",
+                    "paramsJSON": "{}",
+                    "timeoutMs": 0,
+                ],
+            ])
+            task.emitReceiveSuccessOnce(.data(invokeEvent))
+            try await self.waitUntil("computer invoke start") {
+                await lifecycle.state().started
+            }
 
-        await lifecycle.releaseInvalidation()
-        try await self.waitUntil("second route invalidation hook") {
-            await routeInvalidationHook.calls() == 2
+            let originalRoute = try #require(await gateway.currentRoute())
+            let generationsBeforeRefresh = coordinator.generationsForTesting()
+            coordinator.refreshForTesting(
+                isPaused: false,
+                computerControlEnabled: true)
+            for _ in 0..<20 {
+                await Task.yield()
+            }
+            let stateAfterOrdinaryRefresh = await lifecycle.state()
+            let generationsAfterOrdinaryRefresh = coordinator.generationsForTesting()
+            #expect(await gateway.currentRoute() == originalRoute)
+            #expect(!stateAfterOrdinaryRefresh.cancelled)
+            #expect(!stateAfterOrdinaryRefresh.invalidated)
+            #expect(generationsAfterOrdinaryRefresh.endpointAttempt == generationsBeforeRefresh.endpointAttempt + 1)
+            #expect(generationsAfterOrdinaryRefresh.routeAuthority == generationsBeforeRefresh.routeAuthority)
+            #expect(coordinator.routeAuthorityAllowsInvokeForTesting(
+                generationsBeforeRefresh.routeAuthority,
+                isPaused: false))
+
+            coordinator.refreshForTesting(
+                isPaused: true,
+                computerControlEnabled: true)
+            let generationsAfterPause = coordinator.generationsForTesting()
+            #expect(generationsAfterPause.routeAuthority == generationsBeforeRefresh.routeAuthority + 1)
+            #expect(!coordinator.routeAuthorityAllowsInvokeForTesting(
+                generationsBeforeRefresh.routeAuthority,
+                isPaused: true))
+            try await self.waitUntil("route invalidation start") {
+                await lifecycle.state().invalidated
+            }
+
+            let successorURL = try #require(URL(string: "ws://successor.example.invalid"))
+            let successorTask = Task {
+                await coordinator.waitForRouteInvalidationForTesting(
+                    onPendingSnapshot: { await drainSnapshot.recordCapture() })
+                try await gateway.connect(
+                    url: successorURL,
+                    token: nil,
+                    bootstrapToken: nil,
+                    password: nil,
+                    connectOptions: options,
+                    sessionBox: WebSocketSessionBox(session: webSocketSession),
+                    onConnected: { await lifecycle.recordSuccessorConnected() },
+                    onDisconnected: { _ in },
+                    onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
+            }
+            successor = successorTask
+            try await self.waitUntil("successor captured first invalidation") {
+                await drainSnapshot.hasCaptured()
+            }
+            coordinator.enqueueRouteInvalidationForTesting()
+            let generationsAfterSecondRevocation = coordinator.generationsForTesting()
+            #expect(generationsAfterSecondRevocation.routeAuthority == generationsBeforeRefresh.routeAuthority + 2)
+            #expect(generationsAfterSecondRevocation.completedRouteAuthority == generationsBeforeRefresh.routeAuthority)
+
+            lifecycleInvalidationGate.open()
+            try await self.waitUntil("second route invalidation hook") {
+                await routeInvalidationHook.calls() == 2
+            }
+            let stateWhileSecondRevocationBlocked = await lifecycle.state()
+            #expect(webSocketSession.snapshotMakeCount() == 1)
+            #expect(!stateWhileSecondRevocationBlocked.successorConnected)
+            let generationsWhileSecondRevocationBlocked = coordinator.generationsForTesting()
+            #expect(generationsWhileSecondRevocationBlocked.completedRouteAuthority ==
+                generationsBeforeRefresh.routeAuthority + 1)
+            #expect(!coordinator.routeAuthorityAllowsInvokeForTesting(
+                generationsAfterSecondRevocation.routeAuthority,
+                isPaused: false))
+
+            routeInvalidationGate.open()
+            try await successorTask.value
+
+            let finalState = await lifecycle.state()
+            #expect(finalState.cancelled)
+            #expect(finalState.invalidated)
+            #expect(finalState.successorConnected)
+            #expect(webSocketSession.snapshotMakeCount() == 2)
+            #expect(await lifecycle.recordedEvents() == [
+                "invalidation-started",
+                "invalidation-finished",
+                "successor-connected",
+            ])
+            #expect(await gateway.currentRoute() != nil)
+            let finalGenerations = coordinator.generationsForTesting()
+            #expect(finalGenerations.completedRouteAuthority == finalGenerations.routeAuthority)
+        } catch {
+            await self.cleanupRevocationTest(
+                lifecycleInvalidationGate: lifecycleInvalidationGate,
+                routeInvalidationGate: routeInvalidationGate,
+                successor: successor,
+                gateway: gateway,
+                coordinator: coordinator)
+            throw error
         }
-        let stateWhileSecondRevocationBlocked = await lifecycle.state()
-        #expect(webSocketSession.snapshotMakeCount() == 1)
-        #expect(!stateWhileSecondRevocationBlocked.successorConnected)
-        let generationsWhileSecondRevocationBlocked = coordinator.generationsForTesting()
-        #expect(generationsWhileSecondRevocationBlocked.completedRouteAuthority ==
-            generationsBeforeRefresh.routeAuthority + 1)
-        #expect(!coordinator.routeAuthorityAllowsInvokeForTesting(
-            generationsAfterSecondRevocation.routeAuthority,
-            isPaused: false))
-
-        await routeInvalidationHook.releaseBlockedCall()
-        try await successor.value
-
-        let finalState = await lifecycle.state()
-        #expect(finalState.cancelled)
-        #expect(finalState.invalidated)
-        #expect(finalState.successorConnected)
-        #expect(webSocketSession.snapshotMakeCount() == 2)
-        #expect(await lifecycle.recordedEvents() == [
-            "invalidation-started",
-            "invalidation-finished",
-            "successor-connected",
-        ])
-        #expect(await gateway.currentRoute() != nil)
-        let finalGenerations = coordinator.generationsForTesting()
-        #expect(finalGenerations.completedRouteAuthority == finalGenerations.routeAuthority)
-        await gateway.disconnect()
+        await self.cleanupRevocationTest(
+            lifecycleInvalidationGate: lifecycleInvalidationGate,
+            routeInvalidationGate: routeInvalidationGate,
+            successor: successor,
+            gateway: gateway,
+            coordinator: coordinator)
     }
 
     @Test @MainActor func `effective endpoint transitions require route teardown`() throws {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -6,27 +6,6 @@ import Testing
 @testable import OpenClaw
 
 struct MacNodeRuntimeTests {
-    actor AsyncGate {
-        private var isOpen = false
-        private var waiters: [CheckedContinuation<Void, Never>] = []
-
-        func wait() async {
-            guard !self.isOpen else { return }
-            await withCheckedContinuation { continuation in
-                self.waiters.append(continuation)
-            }
-        }
-
-        func open() {
-            self.isOpen = true
-            let waiters = self.waiters
-            self.waiters.removeAll()
-            for waiter in waiters {
-                waiter.resume()
-            }
-        }
-    }
-
     private final class LockedCounter: @unchecked Sendable {
         private let lock = NSLock()
         private var count = 0
@@ -154,8 +133,8 @@ struct MacNodeRuntimeTests {
         var receivedLifecycleGenerations: [UInt64] = []
         var receivedReleaseGenerations: [UInt64] = []
         private let snapshotInspection: SnapshotInspection?
-        private let performEnteredGate: AsyncGate?
-        private let allowPerformGate: AsyncGate?
+        private let performEnteredGate: AsyncTestGate?
+        private let allowPerformGate: AsyncTestGate?
         private var latestLifecycleGeneration: UInt64 = 0
 
         init(
@@ -168,8 +147,8 @@ struct MacNodeRuntimeTests {
             snapshotError: Error? = nil,
             snapshotInspection: SnapshotInspection? = nil,
             actError: Error? = nil,
-            performEnteredGate: AsyncGate? = nil,
-            allowPerformGate: AsyncGate? = nil)
+            performEnteredGate: AsyncTestGate? = nil,
+            allowPerformGate: AsyncTestGate? = nil)
         {
             self.snapshotResult = snapshotResult
             self.snapshotError = snapshotError
@@ -238,7 +217,7 @@ struct MacNodeRuntimeTests {
             self.performCallCount += 1
             self.receivedParams = params
             self.receivedLifecycleGenerations.append(lifecycleGeneration)
-            await self.performEnteredGate?.open()
+            self.performEnteredGate?.open()
             await self.allowPerformGate?.wait()
             guard lifecycleGeneration >= self.latestLifecycleGeneration else {
                 throw ComputerActionService.ComputerActionError.lifecycleChanged
@@ -606,7 +585,8 @@ struct MacNodeRuntimeTests {
 
     @Test func `concurrent invokes share one main actor services initialization`() async throws {
         let services = await MainActor.run { MainActorServicesProbe() }
-        let factoryGate = AsyncGate()
+        let factoryGate = AsyncTestGate()
+        defer { factoryGate.open() }
         let factoryCalls = LockedCounter()
         let admissionCalls = LockedCounter()
         let runtime = MacNodeRuntime(
@@ -625,16 +605,16 @@ struct MacNodeRuntimeTests {
         let first = Task {
             await self.invoke(runtime, "req-computer-single-flight-1", OpenClawComputerCommand.act.rawValue, json)
         }
-        #expect(await self.waitForCount(1, counter: factoryCalls))
+        try #require(await self.waitForCount(1, counter: factoryCalls))
         let second = Task {
             await self.invoke(runtime, "req-computer-single-flight-2", OpenClawComputerCommand.act.rawValue, json)
         }
-        #expect(await self.waitForCount(2, counter: admissionCalls))
+        try #require(await self.waitForCount(2, counter: admissionCalls))
         // The actor barrier proves the second invoke reached its first suspension.
         await runtime.updateMainSessionKey("single-flight-barrier")
 
         #expect(factoryCalls.value() == 1)
-        await factoryGate.open()
+        factoryGate.open()
         let firstResponse = await first.value
         let secondResponse = await second.value
         #expect(firstResponse.ok)
@@ -643,7 +623,8 @@ struct MacNodeRuntimeTests {
 
     @Test func `lifecycle release invalidates first invoke awaiting service initialization`() async throws {
         let services = await MainActor.run { MainActorServicesProbe() }
-        let factoryGate = AsyncGate()
+        let factoryGate = AsyncTestGate()
+        defer { factoryGate.open() }
         let factoryCalls = LockedCounter()
         let runtime = MacNodeRuntime(
             makeMainActorServices: {
@@ -657,10 +638,10 @@ struct MacNodeRuntimeTests {
         let invoke = Task {
             await self.invoke(runtime, "req-computer-release-during-init", OpenClawComputerCommand.act.rawValue, json)
         }
-        #expect(await self.waitForCount(1, counter: factoryCalls))
+        try #require(await self.waitForCount(1, counter: factoryCalls))
 
         await runtime.releaseHeldComputerInput()
-        await factoryGate.open()
+        factoryGate.open()
         let response = await invoke.value
         let counts = await MainActor.run {
             (perform: services.performCallCount, release: services.releaseCallCount)
@@ -674,8 +655,12 @@ struct MacNodeRuntimeTests {
     }
 
     @Test func `lifecycle release after runtime admission invalidates service execution`() async throws {
-        let performEntered = AsyncGate()
-        let allowPerform = AsyncGate()
+        let performEntered = AsyncTestGate()
+        let allowPerform = AsyncTestGate()
+        defer {
+            performEntered.open()
+            allowPerform.open()
+        }
         let services = await MainActor.run {
             MainActorServicesProbe(
                 performEnteredGate: performEntered,
@@ -692,7 +677,7 @@ struct MacNodeRuntimeTests {
         await performEntered.wait()
 
         await runtime.releaseHeldComputerInput()
-        await allowPerform.open()
+        allowPerform.open()
         let response = await invoke.value
         let generations = await MainActor.run {
             (


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Full macOS parallel Swift runs could time out in node-host restart/backoff checks, leak `wait()` or `recordInvalidation()` continuations, and fail to terminate.

## Why This Change Was Made

This adds deterministic owner-boundary retry and configuration hooks plus cancellation-safe test lifecycle cleanup while preserving the production retry policy and invalidation → backoff → readmission ordering. It is intentionally separate from GatewayProcessManager readiness and unrelated shared-state flakes.

## User Impact

There is no product behavior change. Developers and CI get reliable, terminating parallel macOS test runs.

## Evidence

- 64 coordinator/runtime tests passed in parallel.
- The combined focused command passed 20 consecutive `--skip-build --parallel` repeats.
- Six full `swift test --package-path apps/macos --parallel` attempts completed: the repaired tests passed every time, all processes terminated, and there were zero continuation-misuse diagnostics. Three package runs were fully green; three failed only in separate pre-existing ExecApprovals SQLite/device identity shared-state tests.
- `git diff --check` passed.
- Fresh uncommitted autoreview completed cleanly with no accepted or actionable findings.

AI-assisted: yes
