### PR TITLE
fix: prevent macOS unread tests from timing out in parallel CI

### DIFF
--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelUnreadTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelUnreadTests.swift
@@ -202,6 +202,7 @@ extension UnreadTestTransportState {
     }
 }
 
+@Suite(.serialized)
 @MainActor
 struct ChatViewModelUnreadTests {
     @Test func `successful activation clears unread once`() async throws {


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a release-validation blocker where the `macos-swift` lane could fail the otherwise-green candidate when `ChatViewModelUnreadTests` ran its main-actor polling tests concurrently. In [Full Release Validation 31290871636](https://github.com/openclaw/openclaw/actions/runs/31290871636), the release/live, Docker/QA, plugin-prerelease, and performance paths completed successfully, but [Normal CI 31290931054](https://github.com/openclaw/openclaw/actions/runs/31290931054) failed in [macos-swift job 93187882780](https://github.com/openclaw/openclaw/actions/runs/31290931054/job/93187882780) for candidate `da4e341b070b54c9fd3639453f88708eae226bf0`.

The OpenClawKit suite ran 1,319 tests. Eight unread tests started within 1.9 ms of one another and all recorded the same `waitUntil` issue at line 582 after roughly six seconds; no other test issue was reported.

## Why This Change Was Made

Marks the stateful `@MainActor` unread suite as `@Suite(.serialized)`, matching the existing project pattern for main-actor/stateful suites while leaving the rest of OpenClawKit's package-level parallelism intact.

Root cause: concurrent cases in this suite all drive asynchronous main-actor view-model work and poll five-second deadlines, so parallel execution can starve the expected progress under a loaded full-package run. Increasing the timeout would only widen the race window; serializing the suite enforces the actual execution invariant.

Best-fix verdict: this is the narrow owner-boundary fix. It changes no runtime code, retry behavior, timeout, CI baseline, ignore, or package-wide test policy.

## User Impact

No production behavior changes. Release candidates and normal macOS CI retain parallel package coverage without intermittent unread-suite timeout failures.

Production LOC: +0/-0 (net 0) | Tests: +1/-0

## Evidence

- Failure evidence: [Full Release Validation 31290871636](https://github.com/openclaw/openclaw/actions/runs/31290871636), [Normal CI 31290931054](https://github.com/openclaw/openclaw/actions/runs/31290931054), and [macos-swift job 93187882780](https://github.com/openclaw/openclaw/actions/runs/31290931054/job/93187882780).
- Focused parallel proof: `swift test --package-path apps/shared/OpenClawKit --filter ChatViewModelUnreadTests --parallel` — 15 tests in 1 suite passed in 1.021 seconds; the suite's tests executed serially.
- Formatting: `swiftformat --lint apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelUnreadTests.swift --config config/swiftformat` — clean.
- Lint: `swiftlint lint --strict --config config/swiftlint.yml apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelUnreadTests.swift` — 0 violations.
- Diff hygiene: `git diff --check` — clean.
- Exact full-package proof is delegated to this PR's hosted `macos-swift` check, which runs `swift test --package-path apps/shared/OpenClawKit --scratch-path <temporary-directory> --parallel`.
