### PR TITLE
perf(agents): reuse prepared inbound plugin registry

### DIFF
--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -12,13 +12,16 @@ import {
   prepareAgentCatalogSource,
   prepareConfiguredRuntimeFactsBatch,
   prepareFullCatalogFacts,
-  preparedModelRuntimeWorkspaceFactsKey,
   prepareWorkspaceBuildGroup,
   type PreparedModelRuntimeAgentFacts,
   type PreparedModelRuntimeCatalogFacts,
   type PreparedModelRuntimeCatalogSource,
   type PreparedModelRuntimeWorkspaceFacts,
 } from "./prepared-model-runtime.facts.js";
+import {
+  createPreparedInboundRegistryLoader,
+  preparedModelRuntimeWorkspaceFactsKey,
+} from "./prepared-model-runtime.inbound-registry.js";
 import type {
   PreparedModelRuntimeBuildStats,
   PreparedModelRuntimeCatalogMode,
@@ -160,6 +163,7 @@ function createSnapshot(
   workspaceFacts: PreparedModelRuntimeWorkspaceFacts,
   catalogFacts: PreparedModelRuntimeCatalogFacts,
   catalogAccess: PreparedModelRuntimeCatalogAccess,
+  inboundPluginRegistry?: PreparedModelRuntimeWorkspaceFacts["inboundPluginRegistry"],
 ): PreparedModelRuntimeSnapshot {
   const { credentials, input } = agentFacts;
   const { mediaCapabilityProviders, messageToolCatalog, pluginMetadataSnapshot, pluginRegistry } =
@@ -182,6 +186,7 @@ function createSnapshot(
     metadataSnapshot: pluginMetadataSnapshot,
     allowGatewaySubagentBinding: input.allowGatewaySubagentBinding === true,
     ...(pluginRegistry ? { pluginRegistry } : {}),
+    ...(inboundPluginRegistry ? { inboundPluginRegistry } : {}),
     ...(messageToolCatalog ? { messageToolCatalog } : {}),
     ...(mediaCapabilityProviders ? { mediaCapabilityProviders } : {}),
     modelCatalog,
@@ -198,6 +203,7 @@ async function buildSnapshotBatch(
   agentBuildCompletions: Map<string, Promise<void>>,
   generationGuards: ReadonlyMap<PreparedModelRuntimeInput, () => boolean>,
   buildGuards: PreparedModelRuntimeBuildGuards,
+  inboundPluginRegistryInputs: ReadonlySet<PreparedModelRuntimeInput>,
   onBuildStats?: (stats: PreparedModelRuntimeBuildStats) => void,
 ): Promise<PreparedModelRuntimeSnapshot[]> {
   const groups = new Map<string, PreparedModelRuntimeInput[]>();
@@ -212,6 +218,7 @@ async function buildSnapshotBatch(
   }
   const preparedInputs = new Map<PreparedModelRuntimeInput, PreparedModelRuntimeAgentFacts>();
   const workspaceFacts = new Map<string, PreparedModelRuntimeWorkspaceFacts>();
+  const loadInboundPluginRegistry = createPreparedInboundRegistryLoader();
   const workspaceKeys = new Map<PreparedModelRuntimeInput, string>();
   let runtimePluginMs = 0;
   let pluginMetadataMs = 0;
@@ -226,7 +233,17 @@ async function buildSnapshotBatch(
     if (typeof buildGuards === "function") {
       assertPreparedModelRuntimeInputsCurrent(group, buildGuards);
     }
-    const prepared = await prepareWorkspaceBuildGroup(group, catalogMode);
+    // Auth refresh can batch configured and retained run owners. Share their expensive workspace
+    // facts, but prepare the generic inbound handle only when this exact group has an owner for it.
+    const prepareInboundPluginRegistry = group.some((input) =>
+      inboundPluginRegistryInputs.has(input),
+    );
+    const prepared = await prepareWorkspaceBuildGroup(
+      group,
+      catalogMode,
+      {},
+      prepareInboundPluginRegistry ? loadInboundPluginRegistry : undefined,
+    );
     assertPreparedModelRuntimeInputsCurrent(group, buildGuards);
     workspaceFacts.set(key, prepared.workspaceFacts);
     runtimePluginMs += prepared.buildStats.runtimePluginMs;
@@ -405,6 +422,7 @@ async function buildSnapshotBatch(
         isCurrent: generationGuards.get(input) ?? (() => false),
         ...(catalogMode === "live" ? { eagerCatalog: catalogFacts.modelCatalog } : {}),
       }),
+      inboundPluginRegistryInputs.has(input) ? facts.inboundPluginRegistry : undefined,
     );
   });
 }
@@ -417,6 +435,7 @@ export function startSerializedSnapshotBuildBatch(
   onBuildStats?: (stats: PreparedModelRuntimeBuildStats) => void,
   generationGuards: ReadonlyMap<PreparedModelRuntimeInput, () => boolean> = new Map(),
   buildGuards: PreparedModelRuntimeBuildGuards = generationGuards,
+  inboundPluginRegistryInputs: ReadonlySet<PreparedModelRuntimeInput> = new Set(),
 ): {
   pending: Promise<PreparedModelRuntimeSnapshot[]>;
   completion: Promise<void>;
@@ -442,6 +461,7 @@ export function startSerializedSnapshotBuildBatch(
         agentBuildCompletions,
         generationGuards,
         buildGuards,
+        inboundPluginRegistryInputs,
         onBuildStats,
       ),
     };
@@ -479,6 +499,7 @@ export function startSerializedSnapshotBuild(
   buildTimeoutMs: number,
   catalogMode: PreparedModelRuntimeCatalogMode = "live",
   generationGuard: () => boolean = () => true,
+  prepareInboundPluginRegistry = false,
 ): {
   pending: Promise<PreparedModelRuntimeSnapshot>;
   completion: Promise<void>;
@@ -490,6 +511,8 @@ export function startSerializedSnapshotBuild(
     catalogMode,
     undefined,
     new Map([[input, generationGuard]]),
+    undefined,
+    prepareInboundPluginRegistry ? new Set([input]) : undefined,
   );
   return {
     pending: build.pending.then((snapshots) => snapshots[0]!),

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -5,7 +5,6 @@ import type { ConfiguredModelRef } from "@openclaw/model-catalog-core/configured
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { stableStringify } from "@openclaw/normalization-core";
 import type { PreparedMessageToolCatalog } from "../channels/plugins/message-action-discovery.js";
-import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import { sha256Base64Url } from "../infra/crypto-digest.js";
 import { prepareMediaCapabilityProviders } from "../plugins/capability-provider-runtime.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
@@ -52,13 +51,16 @@ import {
   toStaticCatalogEntry,
   type PreparedConfiguredRuntimeModel,
 } from "./prepared-model-runtime.configured.js";
+import {
+  prepareWorkspacePluginRegistries,
+  type PreparedInboundRegistryLoader,
+} from "./prepared-model-runtime.inbound-registry.js";
 import { prepareOwnedPluginLoadContext } from "./prepared-model-runtime.plugin-context.js";
 import type {
   PreparedModelRuntimeBuildStats,
   PreparedModelRuntimeCatalogMode,
   PreparedModelRuntimeInput,
 } from "./prepared-model-runtime.types.js";
-import { loadAgentRuntimePluginRegistryHandle } from "./runtime-plugins.js";
 import type { AuthStorage, AuthStorageData } from "./sessions/auth-storage.js";
 import type { ModelRegistry } from "./sessions/model-registry.js";
 
@@ -89,6 +91,7 @@ export type PreparedModelRuntimeWorkspaceFacts = {
   inlineProviderModels: readonly InlineModelEntry[];
   configuredCatalogEntries: readonly ModelCatalogEntry[];
   pluginRegistry?: import("../plugins/registry-types.js").PluginRegistry;
+  inboundPluginRegistry?: import("../plugins/registry-types.js").PluginRegistry;
 };
 
 export type PreparedModelRuntimeCatalogFacts = {
@@ -189,23 +192,11 @@ function resolvePreparedSyntheticAuth(params: {
   );
 }
 
-export function preparedModelRuntimeWorkspaceFactsKey(input: PreparedModelRuntimeInput): string {
-  return JSON.stringify({
-    // Config is the process generation. Agent-specific configured refs are projected after these
-    // workspace/plugin facts are shared.
-    config: hashRuntimeConfigValue(input.config),
-    env: hashRuntimeConfigValue(input.env ?? process.env),
-    readOnly: input.readOnly === true,
-    workspaceDir: input.workspaceDir,
-    allowGatewaySubagentBinding: input.allowGatewaySubagentBinding === true,
-    runtimePluginSelections: input.runtimePluginSelections,
-  });
-}
-
 export async function prepareWorkspaceBuildGroup(
   inputs: readonly PreparedModelRuntimeInput[],
   catalogMode: PreparedModelRuntimeCatalogMode,
   options: { providerDiscoveryProviderIds?: readonly string[] } = {},
+  loadInboundPluginRegistry?: PreparedInboundRegistryLoader,
 ): Promise<{
   agentFacts: PreparedModelRuntimeAgentFacts[];
   workspaceFacts: PreparedModelRuntimeWorkspaceFacts;
@@ -225,19 +216,19 @@ export async function prepareWorkspaceBuildGroup(
   }
   const env = input.env ?? process.env;
   const runtimePluginStartedAt = performance.now();
-  const runtimePluginRegistry = !input.readOnly
-    ? loadAgentRuntimePluginRegistryHandle({
-        config: input.config,
-        env,
-        ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
-        ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
-        selections: input.runtimePluginSelections,
-      })
-    : undefined;
+  const { inboundPluginRegistry, runtimePluginRegistry } = prepareWorkspacePluginRegistries(
+    input,
+    loadInboundPluginRegistry,
+  );
   const runtimePluginMs = performance.now() - runtimePluginStartedAt;
   return await withPluginRuntimeRegistryScope(runtimePluginRegistry, async () => {
     const pluginMetadataStartedAt = performance.now();
-    const pluginMetadataSnapshot = prepareOwnedPluginLoadContext(input, env, runtimePluginRegistry);
+    const pluginMetadataSnapshot = prepareOwnedPluginLoadContext(
+      input,
+      env,
+      runtimePluginRegistry,
+      inboundPluginRegistry,
+    );
     const pluginMetadataMs = performance.now() - pluginMetadataStartedAt;
     const matchesStaticModelId = createStaticModelIdMatcher({
       manifestPlugins: pluginMetadataSnapshot.plugins,
@@ -425,6 +416,7 @@ export async function prepareWorkspaceBuildGroup(
         inlineProviderModels,
         configuredCatalogEntries,
         ...(runtimePluginRegistry ? { pluginRegistry: runtimePluginRegistry } : {}),
+        ...(inboundPluginRegistry ? { inboundPluginRegistry } : {}),
         ...(mediaCapabilityProviders ? { mediaCapabilityProviders } : {}),
         ...(preparedStaticProviderCatalog ? { preparedStaticProviderCatalog } : {}),
         ...(providerStaticModels ? { providerStaticModels } : {}),

--- a/src/agents/prepared-model-runtime.inbound-registry.test.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.test.ts
@@ -1,0 +1,167 @@
+import "./prepared-model-runtime.test-harness.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import {
+  acquireAgentRunPreparedModelRuntime,
+  getPreparedModelRuntimeSnapshot,
+  loadPublishedGatewayInboundPluginRegistry,
+  registerPreparedModelRuntimePublicationListener,
+  refreshPreparedModelRuntimeSnapshots,
+} from "./prepared-model-runtime.js";
+import {
+  getPreparedModelRuntimeMocks,
+  resetPreparedModelRuntimeHarness,
+} from "./prepared-model-runtime.test-harness.js";
+
+const mocks = getPreparedModelRuntimeMocks();
+
+describe("prepared model runtime inbound registry", () => {
+  beforeEach(() => {
+    resetPreparedModelRuntimeHarness();
+  });
+
+  it("atomically replaces the prepared inbound registry across a Gateway refresh", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const firstConfig = {};
+    const replacementConfig = { plugins: {} };
+    const firstRegistry = createEmptyPluginRegistry();
+    const replacementRegistry = createEmptyPluginRegistry();
+    mocks.loadAgentRuntimePluginRegistryHandle.mockImplementation((params) => {
+      const request = params as { config: unknown; selections?: unknown };
+      if (request.selections) {
+        return createEmptyPluginRegistry();
+      }
+      return request.config === firstConfig ? firstRegistry : replacementRegistry;
+    });
+    await refreshPreparedModelRuntimeSnapshots(firstConfig, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+      allowGatewaySubagentBinding: true,
+    });
+    const input = {
+      agentId: "default",
+      agentDir: "/tmp/unused-agent",
+      inheritedAuthDir: "/tmp/unused-agent",
+      config: firstConfig,
+      workspaceDir: "/tmp/unused-workspace",
+      allowGatewaySubagentBinding: true,
+    };
+    await expect(loadPublishedGatewayInboundPluginRegistry({ agentId: "default" })).resolves.toBe(
+      firstRegistry,
+    );
+
+    let finishReplacement!: () => void;
+    mocks.prepareStaticCatalog.mockImplementationOnce(
+      async () =>
+        await new Promise<{ entries: [] }>((resolve) => {
+          finishReplacement = () => resolve({ entries: [] });
+        }),
+    );
+    const refresh = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+      catalogMode: "static",
+      allowGatewaySubagentBinding: true,
+    });
+    await vi.waitFor(() =>
+      expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(4),
+    );
+    expect(getPreparedModelRuntimeSnapshot(input)).toBeUndefined();
+    let resolvedRegistry: unknown;
+    const read = loadPublishedGatewayInboundPluginRegistry({ agentId: "default" }).then(
+      (registry) => {
+        resolvedRegistry = registry;
+        return registry;
+      },
+    );
+    await Promise.resolve();
+    expect(resolvedRegistry).toBeUndefined();
+
+    finishReplacement();
+    await expect(refresh).resolves.toBeUndefined();
+    await expect(read).resolves.toBe(replacementRegistry);
+    expect(replacementRegistry).not.toBe(firstRegistry);
+  });
+
+  it("resolves the configured inbound registry across a launch-workspace override", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {};
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+      allowGatewaySubagentBinding: true,
+      defaultWorkspaceDir: "/tmp/gateway-launch-workspace",
+    });
+    const published = getPreparedModelRuntimeSnapshot({
+      agentId: "default",
+      agentDir: "/tmp/unused-agent",
+      inheritedAuthDir: "/tmp/unused-agent",
+      config,
+      workspaceDir: "/tmp/gateway-launch-workspace",
+      allowGatewaySubagentBinding: true,
+    })?.inboundPluginRegistry;
+    const publicationLoadCount = mocks.loadAgentRuntimePluginRegistryHandle.mock.calls.length;
+
+    await expect(
+      Promise.all([
+        loadPublishedGatewayInboundPluginRegistry({ agentId: "default" }),
+        loadPublishedGatewayInboundPluginRegistry({ agentId: "default" }),
+        loadPublishedGatewayInboundPluginRegistry({ agentId: "default" }),
+      ]),
+    ).resolves.toEqual([published, published, published]);
+    expect(published).toBeDefined();
+    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(publicationLoadCount);
+  });
+
+  it("keeps inbound registry ownership off retained run owners during auth refresh", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = { agents: { defaults: { model: "openai/gpt-5.5" } } };
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const dynamicInput = {
+      agentId: "default",
+      agentDir: "/tmp/unused-agent",
+      inheritedAuthDir: "/tmp/unused-agent",
+      config,
+      workspaceDir: "/tmp/dynamic-auth-workspace",
+      runtimePluginSelections: [{ provider: "openai", modelId: "gpt-5.5", runtime: "codex" }],
+    };
+    const dynamicLease = await acquireAgentRunPreparedModelRuntime(dynamicInput);
+    expect(dynamicLease.snapshot.inboundPluginRegistry).toBeUndefined();
+    dynamicLease.release();
+    const callsBeforeAuthRefresh = mocks.loadAgentRuntimePluginRegistryHandle.mock.calls.length;
+    let unregister = () => {};
+    const published = new Promise<void>((resolve) => {
+      unregister = registerPreparedModelRuntimePublicationListener((event) => {
+        if (event.phase === "published") {
+          resolve();
+        }
+      });
+    });
+
+    mocks.mutationListener?.({ affectsInheritedStores: true });
+    await published;
+    unregister();
+
+    const authRefreshCalls =
+      mocks.loadAgentRuntimePluginRegistryHandle.mock.calls.slice(callsBeforeAuthRefresh);
+    const genericCalls = authRefreshCalls.filter(
+      ([params]) => !Object.hasOwn(params as object, "selections"),
+    );
+    expect(genericCalls).toHaveLength(1);
+    expect(genericCalls[0]?.[0]).toMatchObject({ workspaceDir: "/tmp/unused-workspace" });
+    expect(
+      genericCalls.some(
+        ([params]) =>
+          (params as { workspaceDir?: string }).workspaceDir === "/tmp/dynamic-auth-workspace",
+      ),
+    ).toBe(false);
+    expect(getPreparedModelRuntimeSnapshot(dynamicInput)?.inboundPluginRegistry).toBeUndefined();
+    expect(
+      getPreparedModelRuntimeSnapshot({
+        agentId: "default",
+        agentDir: "/tmp/unused-agent",
+        inheritedAuthDir: "/tmp/unused-agent",
+        config,
+        workspaceDir: "/tmp/unused-workspace",
+      })?.inboundPluginRegistry,
+    ).toBeDefined();
+  });
+});

--- a/src/agents/prepared-model-runtime.inbound-registry.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.ts
@@ -1,0 +1,120 @@
+import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
+import type { PluginRegistry } from "../plugins/registry-types.js";
+import { PreparedModelRuntimeOwnerNotPublishedError } from "./prepared-model-runtime.errors.js";
+import type {
+  PreparedModelRuntimeInput,
+  PreparedModelRuntimeSnapshot,
+} from "./prepared-model-runtime.types.js";
+import { loadAgentRuntimePluginRegistryHandle } from "./runtime-plugins.js";
+
+export type PreparedInboundRegistryLoader = (input: PreparedModelRuntimeInput) => PluginRegistry;
+
+function inboundRegistryIdentity(input: PreparedModelRuntimeInput): string {
+  return JSON.stringify({
+    config: hashRuntimeConfigValue(input.config),
+    env: hashRuntimeConfigValue(input.env ?? process.env),
+    workspaceDir: input.workspaceDir,
+    allowGatewaySubagentBinding: input.allowGatewaySubagentBinding === true,
+  });
+}
+
+/** Groups model-selected workspace facts while keeping generic inbound identity narrower. */
+export function preparedModelRuntimeWorkspaceFactsKey(input: PreparedModelRuntimeInput): string {
+  return JSON.stringify({
+    config: hashRuntimeConfigValue(input.config),
+    env: hashRuntimeConfigValue(input.env ?? process.env),
+    readOnly: input.readOnly === true,
+    workspaceDir: input.workspaceDir,
+    allowGatewaySubagentBinding: input.allowGatewaySubagentBinding === true,
+    runtimePluginSelections: input.runtimePluginSelections,
+  });
+}
+
+/** Creates one lifecycle-batch loader that shares exact generic registry identities. */
+export function createPreparedInboundRegistryLoader(): PreparedInboundRegistryLoader {
+  const registries = new Map<string, PluginRegistry>();
+  return (input) => {
+    const key = inboundRegistryIdentity(input);
+    const existing = registries.get(key);
+    if (existing) {
+      return existing;
+    }
+    const registry = loadAgentRuntimePluginRegistryHandle({
+      config: input.config,
+      env: input.env ?? process.env,
+      ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
+      ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
+    });
+    registries.set(key, registry);
+    return registry;
+  };
+}
+
+/** Prepares distinct generic-inbound and model-selected registries for one workspace generation. */
+export function prepareWorkspacePluginRegistries(
+  input: PreparedModelRuntimeInput,
+  loadInboundRegistry?: PreparedInboundRegistryLoader,
+): {
+  runtimePluginRegistry?: PluginRegistry;
+  inboundPluginRegistry?: PluginRegistry;
+} {
+  if (input.readOnly) {
+    return {};
+  }
+  const inboundPluginRegistry = loadInboundRegistry?.(input);
+  const runtimePluginRegistry =
+    input.runtimePluginSelections || !inboundPluginRegistry
+      ? loadAgentRuntimePluginRegistryHandle({
+          config: input.config,
+          env: input.env ?? process.env,
+          ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
+          ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
+          selections: input.runtimePluginSelections,
+        })
+      : inboundPluginRegistry;
+  return {
+    runtimePluginRegistry,
+    ...(inboundPluginRegistry ? { inboundPluginRegistry } : {}),
+  };
+}
+
+type PreparedInboundRegistryLifecycleHost<Owner> = Readonly<{
+  isGatewayLifecycleActive: () => boolean;
+  getPendingReplacement: () => Promise<void> | undefined;
+  resolveConfiguredOwner: (agentId: string) => Owner | undefined;
+  getPublishedSnapshot: (owner: Owner) => PreparedModelRuntimeSnapshot | undefined;
+  prepareSnapshot: (owner: Owner) => Promise<PreparedModelRuntimeSnapshot>;
+}>;
+
+function requireInboundRegistry(snapshot: PreparedModelRuntimeSnapshot): PluginRegistry {
+  if (!snapshot.inboundPluginRegistry) {
+    throw new Error(`prepared inbound plugin registry was not published for ${snapshot.agentDir}`);
+  }
+  return snapshot.inboundPluginRegistry;
+}
+
+/** Binds Gateway turns to the configured owner without exposing mutable lifecycle state. */
+export function createPublishedGatewayInboundPluginRegistryLoader<Owner>(
+  host: PreparedInboundRegistryLifecycleHost<Owner>,
+): (params: { agentId: string }) => Promise<PluginRegistry | undefined> {
+  return async ({ agentId }) => {
+    if (!host.isGatewayLifecycleActive()) {
+      return undefined;
+    }
+    for (;;) {
+      const replacement = host.getPendingReplacement();
+      if (replacement) {
+        await replacement;
+        continue;
+      }
+      const owner = host.resolveConfiguredOwner(agentId);
+      if (!owner) {
+        throw new PreparedModelRuntimeOwnerNotPublishedError(
+          `prepared inbound plugin registry owner was not published for ${agentId}`,
+        );
+      }
+      const published = host.getPublishedSnapshot(owner);
+      return requireInboundRegistry(published ?? (await host.prepareSnapshot(owner)));
+    }
+  };
+}

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -757,7 +757,7 @@ describe("prepared model runtime snapshots", () => {
       refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true, catalogMode: "static" }),
     ).resolves.toBeUndefined();
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
-    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledOnce();
+    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(2);
     expect(mocks.discoverAuthStorage).toHaveBeenCalledOnce();
     expect(mocks.discoverModels).toHaveBeenCalledOnce();
   });

--- a/src/agents/prepared-model-runtime.owner-selection.test.ts
+++ b/src/agents/prepared-model-runtime.owner-selection.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
   acquireAgentRunPreparedModelRuntime,
   getPreparedModelRuntimeSnapshot,
@@ -11,6 +12,7 @@ import {
   publishPreparedModelRuntimeSnapshot,
   refreshPreparedModelRuntimeSnapshots,
 } from "./prepared-model-runtime.js";
+import { getPreparedPluginRuntimeLoadContext } from "./prepared-model-runtime.plugin-context.js";
 import {
   getPreparedModelRuntimeMocks,
   getPreparedModelRuntimeTestApi,
@@ -125,6 +127,9 @@ describe("prepared model runtime owner selection", () => {
   it("reuses the configured owner for its prepared plugin harness selections", async () => {
     mocks.configuredAgentIds = ["default"];
     const config = { agents: { defaults: { model: "openai/gpt-5.5" } } };
+    mocks.loadAgentRuntimePluginRegistryHandle.mockImplementation(() =>
+      createEmptyPluginRegistry(),
+    );
     await refreshPreparedModelRuntimeSnapshots(config, {
       allowGatewaySubagentBinding: true,
       catalogMode: "static",
@@ -153,7 +158,19 @@ describe("prepared model runtime owner selection", () => {
 
     expect(first.snapshot).toBe(configured);
     expect(second.snapshot).toBe(first.snapshot);
-    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledOnce();
+    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(2);
+    expect(mocks.loadAgentRuntimePluginRegistryHandle.mock.calls[0]?.[0]).not.toHaveProperty(
+      "selections",
+    );
+    expect(mocks.loadAgentRuntimePluginRegistryHandle.mock.calls[1]?.[0]).toMatchObject({
+      selections: [{ provider: "openai", modelId: "gpt-5.5", runtime: "codex" }],
+    });
+    expect(configured?.inboundPluginRegistry).toBeDefined();
+    expect(configured?.pluginRegistry).not.toBe(configured?.inboundPluginRegistry);
+    expect(getPreparedPluginRuntimeLoadContext(configured?.inboundPluginRegistry)).toMatchObject({
+      rawConfig: config,
+      workspaceDir: "/tmp/unused-workspace",
+    });
     expect(mocks.prepareStaticCatalog).toHaveBeenCalledOnce();
     expect(mocks.discoverModels).toHaveBeenCalledOnce();
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
@@ -182,11 +199,11 @@ describe("prepared model runtime owner selection", () => {
     for (let index = 1; index < 9; index += 1) {
       await acquire(`run-model-${index}`);
     }
-    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(10);
+    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(11);
 
     const rebuilt = await acquire("run-model-0");
     expect(rebuilt).not.toBe(first);
-    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(11);
+    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(12);
   });
 
   it("never evicts a configured owner acquired through the gateway run path", async () => {
@@ -365,7 +382,7 @@ describe("prepared model runtime owner selection", () => {
     });
 
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
-    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(2);
+    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(4);
     expect(mocks.resolveAmbientCredentials).toHaveBeenCalledTimes(2);
     expect(mocks.prepareStaticCatalog).toHaveBeenCalledTimes(2);
     expect(mocks.resolveStaticCatalogModel).toHaveBeenCalledTimes(2);
@@ -591,7 +608,7 @@ describe("prepared model runtime owner selection", () => {
       catalogMode: "static",
     });
 
-    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledOnce();
+    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(2);
     expect(mocks.prepareStaticCatalog).toHaveBeenCalledOnce();
     expect(mocks.discoverModels).toHaveBeenCalledTimes(2);
     const loadAgentCatalog = (agentId: string) =>

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -148,6 +148,17 @@ export function hasConfiguredOwnerMatching(
   return findConfiguredOwnerCandidates(owners, rawInput).length > 0;
 }
 
+/** Resolves the unique configured owner for one Gateway agent identity. */
+export function resolveConfiguredOwnerByAgentId(
+  owners: Map<string, PreparedModelRuntimeOwner>,
+  agentId: string,
+): PreparedModelRuntimeOwner | undefined {
+  const candidates = [...owners.values()].filter(
+    (owner) => owner.provenance === "configured" && owner.input.agentId === agentId,
+  );
+  return candidates.length === 1 ? candidates[0] : undefined;
+}
+
 export function rebindInputToCommittedConfiguredOwner(
   owners: Map<string, PreparedModelRuntimeOwner>,
   rawInput: PreparedModelRuntimeInput,
@@ -460,6 +471,11 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
               params.onBuildStats,
               new Map(currentGroup.map((candidate) => [candidate.input, candidate.isCurrent])),
               params.isBuildCurrent,
+              new Set(
+                currentGroup
+                  .filter((candidate) => candidate.owner.provenance === "configured")
+                  .map((candidate) => candidate.input),
+              ),
             );
             for (const candidate of currentGroup) {
               if (params.registerEntriesAfterBuildStart === true) {
@@ -564,6 +580,7 @@ export async function publishModelRuntimeSnapshot(
     buildTimeoutMs,
     catalogMode,
     () => owner.generation === generation && owners.get(key) === owner,
+    provenance === "configured",
   );
   owner.buildCompletion = build.completion;
   void build.completion.then(() => {

--- a/src/agents/prepared-model-runtime.plugin-context.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.ts
@@ -58,13 +58,19 @@ export function prepareOwnedPluginLoadContext(
   input: PreparedModelRuntimeInput,
   env: NodeJS.ProcessEnv,
   registry: PluginRegistry | undefined,
+  additionalRegistry?: PluginRegistry,
 ): PluginMetadataSnapshot {
   const metadataSnapshot = resolvePluginMetadataSnapshot({
     config: input.config,
     env,
     ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
   });
-  preparePluginLoadContext(input, env, registry, metadataSnapshot);
+  const context = preparePluginLoadContext(input, env, registry, metadataSnapshot);
+  if (additionalRegistry && additionalRegistry !== registry) {
+    // Generic inbound and model-selected registries keep distinct activation scopes while sharing
+    // the exact lifecycle-owned config, metadata, and install generation.
+    setPreparedPluginRuntimeLoadContext(additionalRegistry, context);
+  }
   return metadataSnapshot;
 }
 

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isReservedSystemAgentId } from "../system-agent/agent-id.js";
 import { registerRuntimeAuthProfileStoreMutationListener } from "./auth-profiles/runtime-snapshots.js";
+import { createPublishedGatewayInboundPluginRegistryLoader } from "./prepared-model-runtime.inbound-registry.js";
 import {
   PreparedModelRuntimeOwnerNotPublishedError,
   PreparedModelRuntimeOwnerRetention,
@@ -20,6 +21,7 @@ import {
   publishPreparedModelRuntimeOwnerBatch,
   publishModelRuntimeSnapshot,
   rebindInputToCommittedConfiguredOwner,
+  resolveConfiguredOwnerByAgentId,
   resolvePublishedOwner,
   toError,
   type PreparedModelRuntimeOwner,
@@ -66,6 +68,16 @@ type PreparedModelRuntimePublicationEvent =
   | { phase: "invalidated" | "published" }
   | { phase: "failed"; error: Error };
 const publicationListeners = new Set<(event: PreparedModelRuntimePublicationEvent) => void>();
+
+export const loadPublishedGatewayInboundPluginRegistry =
+  createPublishedGatewayInboundPluginRegistryLoader({
+    isGatewayLifecycleActive: () => gatewayLifecycleActive,
+    getPendingReplacement: () => pendingModelRuntimeReplacement?.promise,
+    resolveConfiguredOwner: (agentId) => resolveConfiguredOwnerByAgentId(owners, agentId),
+    getPublishedSnapshot: (owner) =>
+      owner.snapshot && !owner.needsRefresh && !owner.pending ? owner.snapshot : undefined,
+    prepareSnapshot: (owner) => prepareModelRuntimeSnapshot(owner.input),
+  });
 
 /** Observes committed prepared model/auth generations without starting discovery. */
 export function registerPreparedModelRuntimePublicationListener(

--- a/src/agents/prepared-model-runtime.types.ts
+++ b/src/agents/prepared-model-runtime.types.ts
@@ -29,6 +29,8 @@ export type PreparedModelRuntimeSnapshot = Readonly<{
   mediaCapabilityProviders?: ReturnType<typeof prepareMediaCapabilityProviders>;
   /** Registry value owned by this generation; omitted from read-only/static-catalog builds. */
   pluginRegistry?: PluginRegistry;
+  /** Generic inbound registry owned by the same Gateway publication generation. */
+  inboundPluginRegistry?: PluginRegistry;
   allowGatewaySubagentBinding: boolean;
   /**
    * Configured model projection used by turn admission and synchronous callers.

--- a/src/auto-reply/reply/dispatch-from-config.base.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.base.test-utils.ts
@@ -119,6 +119,58 @@ describe("dispatchReplyFromConfig", () => {
     );
   });
 
+  it("uses zero per-turn registry loads after Gateway publication and preserves cold fallback", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
+    for (let index = 0; index < 3; index += 1) {
+      await dispatchReplyFromConfig({
+        ctx: buildTestCtx({
+          Provider: "whatsapp",
+          SessionKey: "agent:main:main",
+          MessageSid: `cold-${index}`,
+        }),
+        cfg,
+        dispatcher: createDispatcher(),
+        replyResolver,
+      });
+    }
+    expect(runtimePluginMocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(3);
+
+    const preparedRegistry = createTestRegistry([]);
+    const preparedRuntime = await import("../../agents/prepared-model-runtime.js");
+    const preparedLookup = vi
+      .spyOn(preparedRuntime, "loadPublishedGatewayInboundPluginRegistry")
+      .mockResolvedValue(preparedRegistry);
+    runtimePluginMocks.loadAgentRuntimePluginRegistryHandle.mockClear();
+    try {
+      for (let index = 0; index < 3; index += 1) {
+        await dispatchReplyFromConfig({
+          ctx: buildTestCtx({
+            Provider: "whatsapp",
+            SessionKey: "agent:main:main",
+            MessageSid: `prepared-${index}`,
+          }),
+          cfg,
+          dispatcher: createDispatcher(),
+          replyResolver,
+          usePublishedModelRuntime: true,
+        });
+      }
+      expect(preparedLookup).toHaveBeenCalledTimes(3);
+      expect(
+        preparedLookup.mock.calls.every(
+          ([input]) =>
+            Object.keys(input as object).length === 1 &&
+            (input as { agentId?: string }).agentId === "main",
+        ),
+      ).toBe(true);
+      expect(runtimePluginMocks.loadAgentRuntimePluginRegistryHandle).not.toHaveBeenCalled();
+    } finally {
+      preparedLookup.mockRestore();
+    }
+  });
+
   it("drops a durable source duplicate before before_dispatch hooks", async () => {
     setNoAbort();
     const sessionKey = "agent:main:discord:direct:123";

--- a/src/auto-reply/reply/dispatch-from-config.gather.ts
+++ b/src/auto-reply/reply/dispatch-from-config.gather.ts
@@ -39,7 +39,10 @@ import { createShouldEmitVerboseProgress } from "./dispatch-from-config.harness-
 import { createDispatchReplyOperationCoordinator } from "./dispatch-from-config.lifecycle.js";
 import { createFinalizationAwareTtsPayloadApplier } from "./dispatch-from-config.payloads.js";
 import { extendPreparedDispatchState } from "./dispatch-from-config.phase-state.js";
-import { loadRuntimePlugins } from "./dispatch-from-config.runtime-loaders.js";
+import {
+  loadPreparedModelRuntime,
+  loadRuntimePlugins,
+} from "./dispatch-from-config.runtime-loaders.js";
 import { createReplyHotPathTimingTracker } from "./dispatch-from-config.timing.js";
 import type { DispatchFromConfigParams } from "./dispatch-from-config.types.js";
 import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
@@ -359,17 +362,27 @@ export async function gatherDispatchRequest(
     hasInboundAudio: () =>
       inboundAudio || getDispatchReplyOperation()?.acceptedSteeredInboundAudio === true,
   });
-  const { loadAgentRuntimePluginRegistryHandle } = await traceReplyPhase(
-    "reply.load_runtime_plugins",
-    loadRuntimePlugins,
-  );
-  const pluginRegistry = await traceReplyPhase("reply.load_runtime_plugin_registry_handle", () =>
-    loadAgentRuntimePluginRegistryHandle({
-      config: cfg,
-      workspaceDir,
-      allowGatewaySubagentBinding: true,
-    }),
-  );
+  const preparedPluginRegistry = params.usePublishedModelRuntime
+    ? await traceReplyPhase("reply.load_prepared_inbound_plugin_registry", async () => {
+        const { loadPublishedGatewayInboundPluginRegistry } = await loadPreparedModelRuntime();
+        return await loadPublishedGatewayInboundPluginRegistry({
+          agentId: sessionAgentId,
+        });
+      })
+    : undefined;
+  const pluginRegistry =
+    preparedPluginRegistry ??
+    (await traceReplyPhase("reply.load_runtime_plugin_registry_handle", async () => {
+      const { loadAgentRuntimePluginRegistryHandle } = await traceReplyPhase(
+        "reply.load_runtime_plugins",
+        loadRuntimePlugins,
+      );
+      return loadAgentRuntimePluginRegistryHandle({
+        config: cfg,
+        workspaceDir,
+        allowGatewaySubagentBinding: true,
+      });
+    }));
   return await withPluginRuntimeRegistryScope(pluginRegistry, async () => {
     const hookRunner = getGlobalHookRunner();
     // Extract message context for hooks (plugin and internal)

--- a/src/auto-reply/reply/dispatch-from-config.runtime-loaders.ts
+++ b/src/auto-reply/reply/dispatch-from-config.runtime-loaders.ts
@@ -12,6 +12,9 @@ const replyMediaPathsRuntimeLoader = createLazyImportLoader(
 const runtimePluginsLoader = createLazyImportLoader(
   () => import("../../agents/runtime-plugins.js"),
 );
+const preparedModelRuntimeLoader = createLazyImportLoader(
+  () => import("../../agents/prepared-model-runtime.js"),
+);
 
 export function loadRouteReplyRuntime() {
   return routeReplyRuntimeLoader.load();
@@ -35,4 +38,8 @@ export function loadReplyMediaPathsRuntime() {
 
 export function loadRuntimePlugins() {
   return runtimePluginsLoader.load();
+}
+
+export function loadPreparedModelRuntime() {
+  return preparedModelRuntimeLoader.load();
 }

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -1410,7 +1410,7 @@ describe("startGatewayPostAttachRuntime", () => {
       await vi.advanceTimersToNextTimerAsync();
       expect(postReadyRequestTurn).toHaveBeenCalledTimes(1);
       expect(onPostReadySidecars.mock.calls[0]?.[0]).toHaveLength(1);
-      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(4);
+      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(3);
       await vi.dynamicImportSettled();
       await waitForGatewayTestState(() => {
         expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
@@ -1442,7 +1442,7 @@ describe("startGatewayPostAttachRuntime", () => {
       await waitForGatewayTestState(() => {
         expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
       });
-      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(4);
+      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(3);
 
       await vi.advanceTimersByTimeAsync(10_000);
       expect(hoisted.warmCurrentProviderAuthStateOffMainThread).not.toHaveBeenCalled();
@@ -1552,7 +1552,7 @@ describe("startGatewayPostAttachRuntime", () => {
         | { stop: () => void }[]
         | undefined;
       expect(gmailSidecars).toHaveLength(2);
-      expect(lifetimeSidecars).toHaveLength(4);
+      expect(lifetimeSidecars).toHaveLength(3);
 
       for (const sidecar of gmailSidecars ?? []) {
         await stopTrackedSidecar(sidecar);
@@ -1614,7 +1614,7 @@ describe("startGatewayPostAttachRuntime", () => {
       | Array<{ stop: () => Promise<void> | void }>
       | undefined;
     expect(gmailSidecars).toHaveLength(2);
-    expect(lifetimeSidecars).toHaveLength(4);
+    expect(lifetimeSidecars).toHaveLength(3);
 
     await waitForGatewayTestState(() => {
       expect(hoisted.transcriptsAutoStartService.start).toHaveBeenCalledTimes(1);
@@ -2310,7 +2310,7 @@ describe("startGatewayPostAttachRuntime", () => {
       name: "sidecars.ready",
       metrics: [
         ["loadedPluginCount", 2],
-        ["postReadySidecarCount", 4],
+        ["postReadySidecarCount", 3],
       ],
     });
   });

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -67,7 +67,6 @@ const hoisted = vi.hoisted(() => {
     async (_cfg?: unknown, _options?: unknown) => {},
   );
   const prewarmConfigDrivenReplyRuntime = vi.fn(async () => {});
-  const loadAgentRuntimePluginRegistryHandle = vi.fn();
   const prewarmContextWindowCacheAfterReady = vi.fn(async () => {});
   const scheduleGatewayHandlerPrewarm = vi.fn(() => ({ stop: vi.fn() }));
   const clearCurrentProviderAuthState = vi.fn();
@@ -108,7 +107,6 @@ const hoisted = vi.hoisted(() => {
     prepareModelRuntimeSnapshot,
     refreshPreparedModelRuntimeSnapshots,
     prewarmConfigDrivenReplyRuntime,
-    loadAgentRuntimePluginRegistryHandle,
     prewarmContextWindowCacheAfterReady,
     scheduleGatewayHandlerPrewarm,
     clearCurrentProviderAuthState,
@@ -218,11 +216,6 @@ vi.mock("../auto-reply/reply/get-reply-from-config.runtime.js", () => ({
   getReplyFromConfig: vi.fn(),
   prewarmConfigDrivenReplyRuntime: hoisted.prewarmConfigDrivenReplyRuntime,
 }));
-
-vi.mock("../agents/runtime-plugins.js", () => ({
-  loadAgentRuntimePluginRegistryHandle: hoisted.loadAgentRuntimePluginRegistryHandle,
-}));
-
 vi.mock("../agents/context.js", () => ({
   prewarmContextWindowCacheAfterReady: hoisted.prewarmContextWindowCacheAfterReady,
 }));
@@ -498,7 +491,6 @@ describe("startGatewayPostAttachRuntime", () => {
     hoisted.refreshPreparedModelRuntimeSnapshots.mockResolvedValue(undefined);
     hoisted.prewarmConfigDrivenReplyRuntime.mockReset();
     hoisted.prewarmConfigDrivenReplyRuntime.mockResolvedValue(undefined);
-    hoisted.loadAgentRuntimePluginRegistryHandle.mockReset();
     hoisted.prewarmContextWindowCacheAfterReady.mockReset();
     hoisted.prewarmContextWindowCacheAfterReady.mockResolvedValue(undefined);
     hoisted.scheduleGatewayHandlerPrewarm.mockClear();
@@ -1466,57 +1458,6 @@ describe("startGatewayPostAttachRuntime", () => {
     } finally {
       vi.useRealTimers();
     }
-  });
-
-  it("uses current config when agent runtime plugin prewarm runs", async () => {
-    const startupConfig = { marker: "startup" } as never;
-    const currentConfig = { marker: "current" } as never;
-    let releaseGatewayReady!: () => void;
-    const gatewayReady = new Promise<void>((resolve) => {
-      releaseGatewayReady = resolve;
-    });
-
-    await startGatewayPostAttachRuntime({
-      ...createPostAttachParams({
-        gatewayPluginConfigAtStart: startupConfig,
-      }),
-      waitForPostReadyWork: () => gatewayReady,
-      providerAuthPrewarm: {
-        enabled: false,
-        getConfig: () => currentConfig,
-      },
-    });
-
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
-    expect(hoisted.loadAgentRuntimePluginRegistryHandle).not.toHaveBeenCalled();
-
-    const admission = tryBeginGatewayRootWorkAdmission();
-    if (!admission) {
-      throw new Error("Expected request work admission");
-    }
-    releaseGatewayReady();
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 20);
-    });
-    expect(hoisted.loadAgentRuntimePluginRegistryHandle).not.toHaveBeenCalled();
-
-    admission.release();
-    await waitForGatewayTestState(() => {
-      expect(hoisted.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledWith({
-        config: currentConfig,
-        workspaceDir: "/tmp/openclaw-workspace",
-        allowGatewaySubagentBinding: true,
-      });
-    });
-    expect(hoisted.loadAgentRuntimePluginRegistryHandle).not.toHaveBeenCalledWith(
-      expect.objectContaining({ config: startupConfig }),
-    );
-  });
-
-  it("starts agent runtime plugin prewarm in the first post-ready turn", () => {
-    expect(testing.agentRuntimePluginPrewarmStartDelayMs).toBe(0);
   });
 
   it("defers context-window cache prewarm to a post-ready sidecar", async () => {

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -18,10 +18,7 @@ import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { getPluginModuleLoaderStats } from "../plugins/plugin-module-loader-cache.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
-import {
-  getActiveGatewayRootWorkCount,
-  runWithGatewayIndependentRootWorkAdmission,
-} from "../process/gateway-work-admission.js";
+import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
 import { sweepSessionStateWatchNotices } from "../sessions/session-state-events.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import {
@@ -33,7 +30,6 @@ import {
 import { STARTUP_UNAVAILABLE_GATEWAY_METHODS } from "./methods/core-descriptors.js";
 import type { GatewayBroadcastToConnIdsFn } from "./server-broadcast-types.js";
 import type { GatewayControlUiRootLifecycle } from "./server-control-ui-root.js";
-import { scheduleGatewayIdleTask, type GatewayIdleTaskHandle } from "./server-idle-task.js";
 import type { GatewayRecoveryRuntime } from "./server-instance-runtime.types.js";
 import type { GatewayClient } from "./server-methods/shared-types.js";
 import type { refreshLatestUpdateRestartSentinel } from "./server-restart-sentinel.js";
@@ -53,8 +49,6 @@ const ACP_BACKEND_READY_TIMEOUT_MS = 5_000;
 const ACP_BACKEND_READY_POLL_MS = 50;
 const PROVIDER_AUTH_PREWARM_START_DELAY_MS = 5_000;
 const PROVIDER_AUTH_REWARM_DELAY_MS = 1_000;
-const AGENT_RUNTIME_PLUGIN_PREWARM_START_DELAY_MS = 0;
-const AGENT_RUNTIME_PLUGIN_PREWARM_RETRY_DELAY_MS = 250;
 const DEFERRED_SIDECAR_START_DELAY_MS = 100;
 const SKIP_STARTUP_MODEL_PREWARM_ENV = "OPENCLAW_SKIP_STARTUP_MODEL_PREWARM";
 type Awaitable<T> = T | Promise<T>;
@@ -305,73 +299,6 @@ function scheduleProviderAuthStatePrewarm(params: {
         clearTimeout(rewarmTimer);
         rewarmTimer = undefined;
       }
-    },
-  };
-}
-
-function scheduleAgentRuntimePluginPrewarm(params: {
-  getConfig: () => OpenClawConfig;
-  workspaceDir: string;
-  startupTrace?: GatewayStartupTrace;
-  log: {
-    info: (msg: string) => void;
-    warn: (msg: string) => void;
-  };
-  delayMs?: number;
-  waitForPostReadyWork?: () => Promise<void>;
-}): GatewayPostReadySidecarHandle {
-  let stopped = false;
-  let idleTask: GatewayIdleTaskHandle | undefined;
-  const isStopped = () => stopped;
-  const scheduledAt = performance.now();
-  const delayMs = Math.max(0, params.delayMs ?? AGENT_RUNTIME_PLUGIN_PREWARM_START_DELAY_MS);
-  void (async () => {
-    await params.waitForPostReadyWork?.();
-    if (isStopped()) {
-      return;
-    }
-    idleTask = scheduleGatewayIdleTask({
-      // The readiness barrier and configured delay overlap; do not turn two startup windows
-      // into one additive delay before the first agent request can use the warm registry.
-      delayMs: Math.max(0, delayMs - (performance.now() - scheduledAt)),
-      retryDelayMs: AGENT_RUNTIME_PLUGIN_PREWARM_RETRY_DELAY_MS,
-      isClosing: isStopped,
-      isBusy: () => getActiveGatewayRootWorkCount({ excludeCurrent: true }) > 0,
-      run: async () => {
-        await measureStartup(params.startupTrace, "post-ready.agent-runtime-plugins", async () => {
-          if (isStopped()) {
-            return;
-          }
-          const started = performance.now();
-          const { loadAgentRuntimePluginRegistryHandle } =
-            await import("../agents/runtime-plugins.js");
-          const cfg = params.getConfig();
-          if (isStopped()) {
-            return;
-          }
-          loadAgentRuntimePluginRegistryHandle({
-            config: cfg,
-            workspaceDir: params.workspaceDir,
-            allowGatewaySubagentBinding: true,
-          });
-          if (!isStopped()) {
-            params.log.info(
-              `agent runtime plugins pre-warmed in ${(performance.now() - started).toFixed(0)}ms`,
-            );
-          }
-        });
-      },
-      log: params.log,
-      errorMessage: "agent runtime plugin pre-warm failed",
-    });
-  })().catch((err: unknown) => {
-    params.log.warn(`agent runtime plugin pre-warm failed: ${String(err)}`);
-  });
-  return {
-    stop: () => {
-      stopped = true;
-      idleTask?.stop();
-      idleTask = undefined;
     },
   };
 }
@@ -1386,16 +1313,6 @@ export async function startGatewayPostAttachRuntime(
         if (workerEnvironmentSidecar) {
           gatewayLifetimeSidecars.push(workerEnvironmentSidecar);
         }
-        gatewayLifetimeSidecars.push(
-          scheduleAgentRuntimePluginPrewarm({
-            getConfig:
-              params.providerAuthPrewarm?.getConfig ?? (() => params.gatewayPluginConfigAtStart),
-            workspaceDir: params.defaultWorkspaceDir,
-            startupTrace: params.startupTrace,
-            log: params.log,
-            waitForPostReadyWork: params.waitForPostReadyWork,
-          }),
-        );
         if (params.providerAuthPrewarm && params.providerAuthPrewarm.enabled !== false) {
           gatewayLifetimeSidecars.push(
             scheduleProviderAuthStatePrewarm({
@@ -1509,7 +1426,6 @@ export async function startGatewayPostAttachRuntime(
 }
 
 export const testing = {
-  agentRuntimePluginPrewarmStartDelayMs: AGENT_RUNTIME_PLUGIN_PREWARM_START_DELAY_MS,
   providerAuthPrewarmStartDelayMs: PROVIDER_AUTH_PREWARM_START_DELAY_MS,
   hasRestartSentinelFast,
   prewarmConfiguredPrimaryModel,


### PR DESCRIPTION
## What Problem This Solves

Resolves an agent-turn performance problem where every inbound Gateway turn rebuilt the generic plugin registry load plan and cache identity even after the Gateway had already published the same stable plugin generation. Three warm turns therefore still performed three SHA-256 operations, six JSON serializations, and three existence checks, with a median 33.6 microseconds spent in warm cache-hit preparation.

## Why This Change Was Made

The prepared model runtime now owns and publishes the generic inbound plugin registry alongside its existing lifecycle generation. Generic inbound registries remain distinct from model-selected registries so provider/runtime selections keep their narrower activation scope, while direct and non-Gateway hosts retain the existing cold fallback. The delayed duplicate Gateway prewarm path is removed because publication now prepares the authoritative registry at the lifecycle owner boundary.

## User Impact

Published Gateway turns reuse the already prepared inbound plugin registry without repeating generic registry discovery work. There is no configuration, protocol, or user-visible behavior change; model-selected plugin behavior and direct-host fallback remain unchanged.

## Evidence

- Deterministic operation-count proof: before, three warm turns caused 3 SHA-256 operations, 6 JSON serializations, and 3 existence checks; after, three published Gateway turns cause 0 generic registry loads, while three direct/cold turns still cause 3.
- Local focused proof after the required conflict rebase: 100 prepared-runtime tests, 336 dispatch tests, and 71 Gateway startup tests passed (507 total).
- Blacksmith Testbox lease `tbx_01kzj8g3txp09eemvxtqyz51e7` (stopped): `pnpm check:changed` passed in 4m20s and `pnpm build` passed in 3m18s. Run: https://github.com/openclaw/openclaw/actions/runs/31292179447
- Automated autoreview completed cleanly with no accepted or actionable findings.
- Production LOC: +233/-125 (net +108), justified by moving the generic registry to the prepared-runtime ownership boundary and deleting the duplicate Gateway prewarm path. Tests: +247/-70.
