### PR TITLE
fix(telegram): honor root group access in multi-account setups

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -200,6 +200,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     `groupAllowFrom` filters group senders; if unset, Telegram falls back to `allowFrom` (not the pairing store — group sender auth never inherits DM pairing-store approvals, a security boundary since `2026.2.25`).
     `groupAllowFrom` entries should be numeric Telegram user IDs (`telegram:` / `tg:` prefixes are normalized); non-numeric entries are ignored. Do not put group or supergroup chat IDs here — negative chat IDs belong under `channels.telegram.groups`.
+    In multi-account configs, root `channels.telegram.groups` is the shared default for accounts that omit `groups`. An account-level `groups` map replaces the root map for that account; it is not deep-merged. An explicit empty account map (`groups: {}`) keeps that account isolated from the shared groups.
     Practical pattern for one-owner bots: set your user ID in `channels.telegram.allowFrom`, leave `groupAllowFrom` unset, and allow the target groups under `channels.telegram.groups`.
     If `channels.telegram` is entirely missing from config, runtime defaults to fail-closed `groupPolicy="allowlist"` unless `channels.defaults.groupPolicy` is explicitly set.
 

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -625,7 +625,7 @@ Resolution for direct messages follows the identical pattern against the `direct
 This account-replaces-root behavior for prompt resolution is a plain shallow override: any account `groups`/`direct` key, including an explicit empty object, replaces the root map. It differs from the group-membership allowlist check described above, which has a single-account safety net for an accidentally empty `groups: {}`.
 </Note>
 
-**Difference from Telegram:** Telegram suppresses root `groups` for every account in a multi-account setup (even accounts with no `groups` of their own) to stop a bot receiving group messages for groups it does not belong to. WhatsApp does not apply that guard — root `groups`/`direct` are inherited by any account without its own override, regardless of account count. In a multi-account WhatsApp setup, define the full map under each account explicitly if you want per-account prompts.
+**Difference from Telegram:** Telegram uses the same whole-map account override for `groups` in multi-account configs, but a single account's empty `groups: {}` falls back to root groups as a migration safety net. Telegram's `direct` map also has separate DM-topic semantics. In WhatsApp—or for one account among several Telegram accounts—use an explicit empty `groups: {}` when that account should not inherit root group defaults.
 
 Important behavior:
 

--- a/extensions/policy/src/doctor/register.ingress-and-secrets.test-utils.ts
+++ b/extensions/policy/src/doctor/register.ingress-and-secrets.test-utils.ts
@@ -398,7 +398,7 @@ describe("registerPolicyDoctorChecks", () => {
     );
   });
 
-  it("does not inherit Telegram root groups into multi-account named accounts", async () => {
+  it("records inherited Telegram root groups for multi-account named accounts", async () => {
     const { cfg, result } = await runIngressPolicyScenario({
       telegram: {
         dmPolicy: "pairing",
@@ -427,19 +427,41 @@ describe("registerPolicyDoctorChecks", () => {
     });
     const evidence = scanPolicyIngress(cfg as unknown as Record<string, unknown>);
 
-    expect(evidence).not.toEqual(
+    expect(evidence).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           accountId: "work",
           groupId: "ops",
           kind: "channelRequireMention",
+          source: "oc://openclaw.config/channels/telegram/groups/ops/requireMention",
+          value: false,
+        }),
+        expect.objectContaining({
+          accountId: "personal",
+          groupId: "ops",
+          kind: "channelRequireMention",
+          source: "oc://openclaw.config/channels/telegram/groups/ops/requireMention",
+          value: false,
         }),
       ]),
     );
-    expect(result.findings).toEqual([]);
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/ingress-group-mention-required",
+          ocPath: "oc://openclaw.config/channels/telegram/groups/ops/requireMention",
+          message: expect.stringContaining("account 'work'"),
+        }),
+        expect.objectContaining({
+          checkId: "policy/ingress-group-mention-required",
+          ocPath: "oc://openclaw.config/channels/telegram/groups/ops/requireMention",
+          message: expect.stringContaining("account 'personal'"),
+        }),
+      ]),
+    );
   });
 
-  it("lets Telegram account groups override root group inheritance", () => {
+  it("lets an explicit Telegram account groups map override root inheritance", () => {
     const cfg = {
       channels: {
         telegram: {
@@ -453,6 +475,7 @@ describe("registerPolicyDoctorChecks", () => {
             work: {
               groups: {},
             },
+            personal: {},
           },
         },
       },
@@ -466,6 +489,37 @@ describe("registerPolicyDoctorChecks", () => {
           accountId: "work",
           groupId: "ops",
           kind: "channelRequireMention",
+        }),
+      ]),
+    );
+  });
+
+  it("inherits root groups through a single Telegram account empty map", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          groups: {
+            ops: {
+              requireMention: false,
+            },
+          },
+          accounts: {
+            work: {
+              groups: {},
+            },
+          },
+        },
+      },
+    };
+
+    expect(scanPolicyIngress(cfg)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountId: "work",
+          groupId: "ops",
+          kind: "channelRequireMention",
+          source: "oc://openclaw.config/channels/telegram/groups/ops/requireMention",
+          value: false,
         }),
       ]),
     );

--- a/extensions/policy/src/policy-state-ingress.ts
+++ b/extensions/policy/src/policy-state-ingress.ts
@@ -60,13 +60,13 @@ export function scanPolicyIngress(cfg: Record<string, unknown>): readonly Policy
       });
     }
     for (const [accountId, account] of activeAccounts) {
-      const inheritsNestedContainers = channel !== "telegram" || configuredAccounts.length <= 1;
       pushChannelIngress(entries, {
         channel,
         accountId,
         config: account,
         inheritedConfig: value,
-        inheritNestedContainers: inheritsNestedContainers,
+        inheritNestedContainers: true,
+        inheritEmptyNestedContainers: channel === "telegram" && configuredAccounts.length <= 1,
         sourceBase: `${channelSource}/accounts/${ocPathSegment(accountId)}`,
         inheritedSourceBase: channelSource,
         fallbackConfig: inheritedChannelDefaults,
@@ -140,6 +140,7 @@ type ChannelIngressParams = {
   readonly config: Record<string, unknown>;
   readonly inheritedConfig: Record<string, unknown>;
   readonly inheritNestedContainers?: boolean;
+  readonly inheritEmptyNestedContainers?: boolean;
   readonly sourceBase: string;
   readonly inheritedSourceBase: string;
   readonly fallbackConfig?: Record<string, unknown>;
@@ -212,22 +213,15 @@ function channelImplicitGroupPolicy(params: ChannelIngressParams): {
   readonly source: string;
   readonly value: "allowlist" | "open";
 } {
-  for (const [config, sourceBase] of [
-    [params.config, params.sourceBase],
-    ...(params.inheritNestedContainers === true
-      ? ([[params.inheritedConfig, params.inheritedSourceBase]] as const)
-      : []),
-    [params.fallbackConfig, params.fallbackSourceBase],
-  ] as const) {
-    if (config === undefined || sourceBase === undefined) {
-      continue;
-    }
-    for (const key of ["groups"] as const) {
-      const container = isRecord(config[key]) ? config[key] : undefined;
-      if (container !== undefined && Object.keys(container).length > 0) {
-        return { source: `${sourceBase}/${key}`, value: "allowlist" };
-      }
-    }
+  const groups = effectiveNestedIngressContainer(params, "groups");
+  if (groups !== undefined) {
+    return { source: `${groups.sourceBase}/groups`, value: "allowlist" };
+  }
+  const fallbackGroups = isRecord(params.fallbackConfig?.groups)
+    ? params.fallbackConfig.groups
+    : undefined;
+  if (fallbackGroups !== undefined && Object.keys(fallbackGroups).length > 0) {
+    return { source: `${params.fallbackSourceBase}/groups`, value: "allowlist" };
   }
   return {
     source: `${params.sourceBase}/groupPolicy`,
@@ -306,24 +300,28 @@ function channelDefaultRequireMention(params: ChannelIngressParams): boolean {
 function channelWildcardRequireMention(
   params: ChannelIngressParams,
 ): { readonly source: string; readonly value: boolean } | undefined {
-  for (const [config, sourceBase] of [
-    [params.config, params.sourceBase],
-    [params.inheritedConfig, params.inheritedSourceBase],
-    [params.fallbackConfig, params.fallbackSourceBase],
-  ] as const) {
-    if (config === undefined || sourceBase === undefined) {
-      continue;
+  for (const key of ["groups", "guilds", "channels", "rooms", "teams"] as const) {
+    const effective = effectiveNestedIngressContainer(params, key);
+    const wildcard = isRecord(effective?.container["*"]) ? effective.container["*"] : undefined;
+    const requireMention = readBoolean(wildcard?.requireMention);
+    if (wildcard?.enabled !== false && requireMention !== undefined && effective !== undefined) {
+      return {
+        source: `${effective.sourceBase}/${key}/${ocPathSegment("*")}/requireMention`,
+        value: requireMention,
+      };
     }
-    for (const key of ["groups", "guilds", "channels", "rooms", "teams"] as const) {
-      const container = isRecord(config[key]) ? config[key] : undefined;
-      const wildcard = isRecord(container?.["*"]) ? container["*"] : undefined;
-      const requireMention = readBoolean(wildcard?.requireMention);
-      if (wildcard?.enabled !== false && requireMention !== undefined) {
-        return {
-          source: `${sourceBase}/${key}/${ocPathSegment("*")}/requireMention`,
-          value: requireMention,
-        };
-      }
+    const fallbackContainer = isRecord(params.fallbackConfig?.[key])
+      ? params.fallbackConfig[key]
+      : undefined;
+    const fallbackWildcard = isRecord(fallbackContainer?.["*"])
+      ? fallbackContainer["*"]
+      : undefined;
+    const fallbackRequireMention = readBoolean(fallbackWildcard?.requireMention);
+    if (fallbackWildcard?.enabled !== false && fallbackRequireMention !== undefined) {
+      return {
+        source: `${params.fallbackSourceBase}/${key}/${ocPathSegment("*")}/requireMention`,
+        value: fallbackRequireMention,
+      };
     }
   }
   return undefined;
@@ -340,23 +338,29 @@ function nestedIngressContainers(params: ChannelIngressParams): readonly {
     readonly sourceBase: string;
   }[] = [];
   for (const key of ["groups", "guilds", "channels", "rooms", "teams"] as const) {
-    const local = isRecord(params.config[key]) ? params.config[key] : undefined;
-    const inherited = isRecord(params.inheritedConfig[key])
-      ? params.inheritedConfig[key]
-      : undefined;
-    if (local !== undefined) {
-      if (Object.keys(local).length > 0) {
-        containers.push({ containerKey: key, container: local, sourceBase: params.sourceBase });
-      }
-    } else if (params.inheritNestedContainers === true && inherited !== undefined) {
-      containers.push({
-        containerKey: key,
-        container: inherited,
-        sourceBase: params.inheritedSourceBase,
-      });
+    const effective = effectiveNestedIngressContainer(params, key);
+    if (effective !== undefined) {
+      containers.push({ containerKey: key, ...effective });
     }
   }
   return containers;
+}
+
+function effectiveNestedIngressContainer(
+  params: ChannelIngressParams,
+  key: "groups" | "guilds" | "channels" | "rooms" | "teams",
+): { readonly container: Record<string, unknown>; readonly sourceBase: string } | undefined {
+  const local = isRecord(params.config[key]) ? params.config[key] : undefined;
+  const inherited = isRecord(params.inheritedConfig[key]) ? params.inheritedConfig[key] : undefined;
+  if (local !== undefined && Object.keys(local).length > 0) {
+    return { container: local, sourceBase: params.sourceBase };
+  }
+  const inheritsEmpty = local !== undefined && params.inheritEmptyNestedContainers === true;
+  const inheritsMissing = local === undefined && params.inheritNestedContainers === true;
+  if ((inheritsEmpty || inheritsMissing) && inherited !== undefined) {
+    return { container: inherited, sourceBase: params.inheritedSourceBase };
+  }
+  return undefined;
 }
 
 function pushNestedRequireMentionIngress(

--- a/extensions/telegram/src/account-config.ts
+++ b/extensions/telegram/src/account-config.ts
@@ -72,17 +72,14 @@ export function mergeTelegramAccountConfig(
   };
   const account = resolveTelegramAccountConfig(cfg, accountId) ?? {};
 
-  // Multi-account bots must not inherit channel-level groups unless explicitly set.
-  // Single-account bots fall back to root `channels.telegram.groups` when the
-  // account does not declare its own groups — including the empty-literal case
-  // `accounts.<id>.groups: {}`, which is almost always a config-migration
-  // artifact rather than an intentional "block all" declaration (use
-  // `groupPolicy: "disabled"` for that).
+  // Root groups are shared defaults; an account groups map replaces the whole map.
+  // In multi-account configs an explicit empty map remains an account-local opt-out,
+  // while the single-account empty-map migration artifact still falls back to root.
   const configuredAccountIds = Object.keys(cfg.channels?.telegram?.accounts ?? {});
   const isMultiAccount = configuredAccountIds.length > 1;
   const hasAccountGroups = account.groups && Object.keys(account.groups).length > 0;
   const groups = isMultiAccount
-    ? account.groups
+    ? (account.groups ?? channelGroups)
     : hasAccountGroups
       ? account.groups
       : channelGroups;

--- a/extensions/telegram/src/accounts.test.ts
+++ b/extensions/telegram/src/accounts.test.ts
@@ -666,22 +666,34 @@ describe("resolveTelegramAccount groups inheritance (#30673)", () => {
     expect(resolved.config.groups).toEqual({ "-100123": { requireMention: false } });
   });
 
-  it("does NOT inherit channel-level groups to secondary account in multi-account setup", () => {
+  it("inherits channel-level groups to secondary account when no account map is configured", () => {
     const resolved = resolveTelegramAccount({
       cfg: createMultiAccountGroupsConfig(),
       accountId: "dev",
     });
 
-    expect(resolved.config.groups).toBeUndefined();
+    expect(resolved.config.groups).toEqual({ "-100123": { requireMention: false } });
   });
 
-  it("does NOT inherit channel-level groups to default account in multi-account setup", () => {
+  it("inherits channel-level groups to default account when no account map is configured", () => {
     const resolved = resolveTelegramAccount({
       cfg: createMultiAccountGroupsConfig(),
       accountId: "default",
     });
 
-    expect(resolved.config.groups).toBeUndefined();
+    expect(resolved.config.groups).toEqual({ "-100123": { requireMention: false } });
+  });
+
+  it("keeps an explicit empty account groups map isolated in multi-account setup", () => {
+    const cfg = createMultiAccountGroupsConfig();
+    if (!cfg.channels?.telegram?.accounts?.dev) {
+      throw new Error("expected dev Telegram account");
+    }
+    cfg.channels.telegram.accounts.dev.groups = {};
+
+    const resolved = resolveTelegramAccount({ cfg, accountId: "dev" });
+
+    expect(resolved.config.groups).toEqual({});
   });
 
   it("uses account-level groups even in multi-account setup", () => {

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -3470,6 +3470,36 @@ describe("createTelegramBot", () => {
       expectedReplyCount: 1,
     }),
     makeMessagePolicyCase({
+      name: "inherits root per-group sender access in multi-account config",
+      telegram: {
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["111111111"],
+        groups: {
+          "-100123456789": { allowFrom: ["123456789"], requireMention: false },
+        },
+        accounts: {
+          default: { botToken: "123:default" },
+          shadow: { enabled: false },
+        },
+      },
+      expectedReplyCount: 1,
+    }),
+    makeMessagePolicyCase({
+      name: "enforces root per-group sender access in multi-account config",
+      telegram: {
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["123456789"],
+        groups: {
+          "-100123456789": { allowFrom: ["111111111"], requireMention: false },
+        },
+        accounts: {
+          default: { botToken: "123:default" },
+          shadow: { enabled: false },
+        },
+      },
+      expectedReplyCount: 0,
+    }),
+    makeMessagePolicyCase({
       name: "blocks group messages when allowFrom is configured with @username entries (numeric IDs required)",
       telegram: {
         groupPolicy: "allowlist",


### PR DESCRIPTION
Closes #115361

## What Problem This Solves

Fixes an issue where Telegram users in a configured group could be silently rejected—or admitted without the intended per-group sender restriction—when the bot had multiple accounts and the group rules lived at `channels.telegram.groups`.

## Why This Change Was Made

Root Telegram groups now act as shared defaults for accounts that omit `groups`. An account-level map still replaces the root map, and an explicit empty map remains an opt-out in multi-account configs. The prior isolation branch did not isolate chat admission because the shared resolver still read the root map; it only removed that map's per-group sender restrictions. The policy scanner now uses the same precedence, including the existing single-account empty-map migration fallback.

## User Impact

Operators can define shared Telegram group access once at the channel root. Multi-account bots now apply the full group rule consistently: chat admission, mention policy, sender allowlists, policy diagnostics, and docs agree.

## Evidence

- Regression proof: with the old merge expression, the composed Telegram authorization test fails: `inherits root per-group sender access in multi-account config: expected 1, got 0`. It passes with this change. A paired case proves the root per-group allowlist still blocks an unlisted sender.
- Focused Vitest: Telegram account/authorization/group policy plus policy Doctor: 503 tests passed across 5 files.
- Blacksmith Testbox `tbx_01kzjc0j374cvrm7vc1bj681ag`: extension production tsgo, extension test tsgo, extension lint (0 errors), and full docs checks passed; 6,411 internal links, 0 broken.
- Autoreview: Codex `gpt-5.6-sol`, high reasoning; no findings, correctness 0.96.
- Live Telegram user proof with the reporter-shaped config: root `groupAllowFrom` excluded the QA sender, the root per-group `allowFrom` included it, and two extra accounts were configured. IDs are redacted.

```json
{
  "before_current_main": {
    "provider_requests": 0,
    "telegram_events": 0,
    "sut_messages": 0
  },
  "after_this_change": {
    "provider_requests": 1,
    "timeline": [
      { "elapsed_ms": 2321, "kind": "reaction", "value": "eyes" },
      { "elapsed_ms": 3199, "kind": "message", "is_sut": true, "text": "OPENCLAW_E2E_OK" }
    ]
  }
}
```

Production LOC: +57/-56 (net +1) | Tests: +104/-8 | Docs: +2/-1
