### PR TITLE
test(e2e): give doctor-auth-secretref outer timeout headroom over inner CLI budgets

### DIFF
--- a/test/e2e/qa-lab/runtime/doctor-auth-secretref-checks.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/doctor-auth-secretref-checks.e2e.test.ts
@@ -71,7 +71,12 @@ async function expectAclFixturePreservesExecFileContract(preloadUrl: string): Pr
 describe("doctor auth and SecretRef product proof", () => {
   it(
     "preserves SecretRef ownership while proving resolution, fallback, exec gating, and token generation",
-    { timeout: 240_000 },
+    // The case runs six sequential `doctor` CLI invocations, each capped at an
+    // inner timeoutMs of 120s (resolution, repair, file, exec-gated, exec-allowed,
+    // and token generation). An outer budget below their sum leaves zero headroom
+    // for setup/spawn overhead and fires on slow Windows runners even when every
+    // inner invocation stays within its own cap. 780s = 6 x 120s + 60s headroom.
+    { timeout: 780_000 },
     async () => {
       instance = await createOpenClawTestInstance({
         name: "qa-doctor-auth-secretref",


### PR DESCRIPTION
## What Problem

The e2e test `test/e2e/qa-lab/runtime/doctor-auth-secretref-checks.e2e.test.ts` flakes on `checks-windows-node-test` with the outer `it()` timeout firing at 240s:

```
Error: Test timed out in 240000ms.
❯ test/e2e/qa-lab/runtime/doctor-auth-secretref-checks.e2e.test.ts:72:3
```

The case sets an outer timeout of `240_000ms` and inside it runs **six sequential `doctor` CLI invocations**, each capped at an inner `timeoutMs: 120_000` (resolution, repair, file SecretRef, exec-gated, exec-allowed, and token generation). The outer budget of 240s is below the sum of the inner caps (6 × 120s = 720s) with zero headroom for the fixed per-invocation overhead: test-instance setup, Node subprocess spawn, module load, config resolution, and the `writeConfig` + `fs.readFile` calls between invocations.

## Why

On Linux each `doctor` run finishes in a few seconds, well under budget. On the slower Windows runners, subprocess spawn + startup is much heavier, so the six CLI runs plus setup accumulate past 240s and the **outer** `it` timeout fires — the reported error is the outer 240s timeout at the `it`, not any inner 120s CLI timeout. This makes the test structurally flaky on slow platforms: it fails even when every doctor invocation stays within its own budget.

## User Impact

Removes a Windows-only CI flake (`checks-windows-node-test`). No production behavior change; test-only change. The outer budget becomes a true ceiling that can never fire while every inner invocation respects its own cap.

## Evidence

- Diff (this PR): outer timeout `{ timeout: 240_000 }` → `{ timeout: 780_000 }`, with a comment documenting the 6 × 120s inner budget relationship. All six inner `timeoutMs: 120_000` budgets are preserved unchanged.
- Root-cause arithmetic: the test body contains six `instance.cli([...], { timeoutMs: 120_000 })` calls (lines ~92, ~109, ~160, ~201, ~211, ~232). `780s = 6 × 120s + 60s headroom`, so the outer budget can never fire while every inner invocation stays within its own cap — the exact headroom fix suggested by the issue (the issue's "2 × 120s" figure predates the file/exec ACL cases added by #120211, which brought the invocation count to six).
- Example failing job (from issue): https://github.com/openclaw/openclaw/actions/runs/31286094321/job/93175181438
- `grep -c "instance.cli("` on the test file: 6 sequential invocations, each with `timeoutMs: 120_000`.

[AI-assisted]

Fixes #120832
