### PR TITLE
fix(gateway): fall back to defaults for non-positive auth rate-limit values

### DIFF
--- a/docs/gateway/security/rate-limiting.md
+++ b/docs/gateway/security/rate-limiting.md
@@ -74,6 +74,11 @@ Tune it under `gateway.auth.rateLimit` in `openclaw.json`:
 }
 ```
 
+`maxAttempts`, `windowMs`, and `lockoutMs` must be positive. A zero or
+negative value is treated as a config mistake and falls back to the default —
+`maxAttempts: 0` would lock out every IP after a single failure, while
+`windowMs: 0` or `lockoutMs: 0` would silently disable brute-force protection.
+
 Repeated `AUTH_RATE_LIMITED` entries in the Gateway log mean someone is
 guessing credentials; see the [exposure runbook](/gateway/security/exposure-runbook).
 

--- a/docs/gateway/security/rate-limiting.md
+++ b/docs/gateway/security/rate-limiting.md
@@ -78,6 +78,8 @@ Tune it under `gateway.auth.rateLimit` in `openclaw.json`:
 negative value is treated as a config mistake and falls back to the default —
 `maxAttempts: 0` would lock out every IP after a single failure, while
 `windowMs: 0` or `lockoutMs: 0` would silently disable brute-force protection.
+Sub-millisecond durations are clamped to 1 ms so they cannot collapse into a
+zero-width window or an instant lockout either.
 
 Repeated `AUTH_RATE_LIMITED` entries in the Gateway log mean someone is
 guessing credentials; see the [exposure runbook](/gateway/security/exposure-runbook).

--- a/docs/gateway/security/rate-limiting.md
+++ b/docs/gateway/security/rate-limiting.md
@@ -76,10 +76,11 @@ Tune it under `gateway.auth.rateLimit` in `openclaw.json`:
 
 `maxAttempts`, `windowMs`, and `lockoutMs` must be positive. A zero or
 negative value is treated as a config mistake and falls back to the default —
-`maxAttempts: 0` would lock out every IP after a single failure, while
-`windowMs: 0` or `lockoutMs: 0` would silently disable brute-force protection.
-Sub-millisecond durations are clamped to 1 ms so they cannot collapse into a
-zero-width window or an instant lockout either.
+`maxAttempts: 0` would lock out every non-exempt IP after a single failure,
+while `windowMs: 0` or `lockoutMs: 0` would silently disable brute-force
+protection. Durations below 1 ms fall back to the default too: timer
+resolution truncates fractional milliseconds, so a sub-millisecond value would
+otherwise collapse into a zero-width window or an instant lockout.
 
 Repeated `AUTH_RATE_LIMITED` entries in the Gateway log mean someone is
 guessing credentials; see the [exposure runbook](/gateway/security/exposure-runbook).

--- a/src/config/schema.help.core.ts
+++ b/src/config/schema.help.core.ts
@@ -108,7 +108,7 @@ export const CORE_FIELD_HELP: Record<string, string> = {
   "gateway.auth.allowTailscale":
     "Allows trusted Tailscale identity paths to satisfy gateway auth checks when configured. Use this only when your tailnet identity posture is strong and operator workflows depend on it.",
   "gateway.auth.rateLimit":
-    "Login/auth attempt throttling controls to reduce credential brute-force risk at the gateway boundary. Keep enabled in exposed environments and tune thresholds to your traffic baseline.",
+    "Login/auth attempt throttling controls to reduce credential brute-force risk at the gateway boundary. Keep enabled in exposed environments and tune thresholds to your traffic baseline. Thresholds must be positive; zero or negative values fall back to the defaults.",
   "gateway.auth.trustedProxy":
     "Trusted-proxy auth header mapping for upstream identity providers that inject user claims. Use only with known proxy CIDRs and strict header allowlists to prevent spoofed identity headers.",
   "gateway.auth.trustedProxy.deviceAutoApprove":

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -554,6 +554,48 @@ describe("auth rate limiter", () => {
     }
   });
 
+  it("clamps a sub-millisecond windowMs to 1ms instead of a zero-width window", () => {
+    vi.useFakeTimers();
+    try {
+      limiter = createAuthRateLimiter({
+        maxAttempts: 2,
+        windowMs: 0.5,
+        lockoutMs: 60_000,
+        pruneIntervalMs: 0,
+      });
+      // resolveTimerTimeoutMs truncates, so without the 1ms floor 0.5 would
+      // become 0 and every failure would expire in the same tick.
+      limiter.recordFailure("10.0.0.61");
+      limiter.recordFailure("10.0.0.61");
+      const result = limiter.check("10.0.0.61");
+      expect(result.allowed).toBe(false);
+      expect(result.retryAfterMs).toBeGreaterThan(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clamps a sub-millisecond lockoutMs to 1ms instead of an instant lockout", () => {
+    vi.useFakeTimers();
+    try {
+      limiter = createAuthRateLimiter({
+        maxAttempts: 1,
+        windowMs: 60_000,
+        lockoutMs: 0.5,
+        pruneIntervalMs: 0,
+      });
+      limiter.recordFailure("10.0.0.62");
+      const locked = limiter.check("10.0.0.62");
+      expect(locked.allowed).toBe(false);
+      expect(locked.retryAfterMs).toBe(1);
+
+      vi.advanceTimersByTime(2);
+      expect(limiter.check("10.0.0.62").allowed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("falls back to the default window when windowMs is 0", () => {
     limiter = createAuthRateLimiter({ maxAttempts: 2, windowMs: 0, lockoutMs: 60_000 });
     limiter.recordFailure("10.0.0.51");

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -512,6 +512,44 @@ describe("auth rate limiter", () => {
     expect(limiter.check("").allowed).toBe(false);
   });
 
+  // ---------- non-positive config values ----------
+
+  it("falls back to the default maxAttempts when configured with 0", () => {
+    limiter = createAuthRateLimiter({ maxAttempts: 0, windowMs: 60_000, lockoutMs: 300_000 });
+    limiter.recordFailure("10.0.0.50");
+    // Honoring maxAttempts: 0 would leave remaining at 0 forever and deny this
+    // IP on its first failure; the fallback keeps the default budget.
+    const result = limiter.check("10.0.0.50");
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(9);
+  });
+
+  it("falls back to the default maxAttempts when configured with a negative value", () => {
+    limiter = createAuthRateLimiter({ maxAttempts: -3, windowMs: 60_000, lockoutMs: 300_000 });
+    limiter.recordFailure("10.0.0.53");
+    expect(limiter.check("10.0.0.53").remaining).toBe(9);
+  });
+
+  it("falls back to the default window when windowMs is 0", () => {
+    limiter = createAuthRateLimiter({ maxAttempts: 2, windowMs: 0, lockoutMs: 60_000 });
+    limiter.recordFailure("10.0.0.51");
+    limiter.recordFailure("10.0.0.51");
+    // windowMs: 0 would expire every failure instantly, so the limiter could
+    // never lock; the fallback keeps failures inside the default window.
+    const result = limiter.check("10.0.0.51");
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it("falls back to the default lockout when lockoutMs is 0", () => {
+    limiter = createAuthRateLimiter({ maxAttempts: 1, windowMs: 60_000, lockoutMs: 0 });
+    limiter.recordFailure("10.0.0.52");
+    // lockoutMs: 0 would expire the lockout in the same tick it is set.
+    const result = limiter.check("10.0.0.52");
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+  });
+
   // ---------- dispose ----------
 
   it("dispose clears all entries", () => {

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -554,7 +554,7 @@ describe("auth rate limiter", () => {
     }
   });
 
-  it("clamps a sub-millisecond windowMs to 1ms instead of a zero-width window", () => {
+  it("falls back to the default window for sub-millisecond windowMs", () => {
     vi.useFakeTimers();
     try {
       limiter = createAuthRateLimiter({
@@ -563,9 +563,11 @@ describe("auth rate limiter", () => {
         lockoutMs: 60_000,
         pruneIntervalMs: 0,
       });
-      // resolveTimerTimeoutMs truncates, so without the 1ms floor 0.5 would
-      // become 0 and every failure would expire in the same tick.
+      // resolveTimerTimeoutMs truncates, so 0.5 would collapse to a zero-width
+      // (or toy 1ms) window; the default window must apply instead, and
+      // attempts spaced past 1ms still accumulate.
       limiter.recordFailure("10.0.0.61");
+      vi.advanceTimersByTime(2);
       limiter.recordFailure("10.0.0.61");
       const result = limiter.check("10.0.0.61");
       expect(result.allowed).toBe(false);
@@ -575,7 +577,7 @@ describe("auth rate limiter", () => {
     }
   });
 
-  it("clamps a sub-millisecond lockoutMs to 1ms instead of an instant lockout", () => {
+  it("falls back to the default lockout for sub-millisecond lockoutMs", () => {
     vi.useFakeTimers();
     try {
       limiter = createAuthRateLimiter({
@@ -587,10 +589,11 @@ describe("auth rate limiter", () => {
       limiter.recordFailure("10.0.0.62");
       const locked = limiter.check("10.0.0.62");
       expect(locked.allowed).toBe(false);
-      expect(locked.retryAfterMs).toBe(1);
+      expect(locked.retryAfterMs).toBeGreaterThan(60_000);
 
+      // Still locked well past the would-be instant lockout.
       vi.advanceTimersByTime(2);
-      expect(limiter.check("10.0.0.62").allowed).toBe(true);
+      expect(limiter.check("10.0.0.62").allowed).toBe(false);
     } finally {
       vi.useRealTimers();
     }

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -530,6 +530,30 @@ describe("auth rate limiter", () => {
     expect(limiter.check("10.0.0.53").remaining).toBe(9);
   });
 
+  it("preserves positive fractional maxAttempts, including across lockout expiry", () => {
+    vi.useFakeTimers();
+    try {
+      limiter = createAuthRateLimiter({
+        maxAttempts: 0.5,
+        windowMs: 60_000,
+        lockoutMs: 5_000,
+        pruneIntervalMs: 0,
+      });
+      // A schema-accepted fraction keeps its established semantics: the first
+      // failure locks, and once the lockout expires the fractional budget is
+      // back. Flooring it to 0 would deny the IP forever (remaining always 0).
+      limiter.recordFailure("10.0.0.60");
+      expect(limiter.check("10.0.0.60").allowed).toBe(false);
+
+      vi.advanceTimersByTime(5_001);
+      const result = limiter.check("10.0.0.60");
+      expect(result.allowed).toBe(true);
+      expect(result.remaining).toBe(0.5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("falls back to the default window when windowMs is 0", () => {
     limiter = createAuthRateLimiter({ maxAttempts: 2, windowMs: 0, lockoutMs: 60_000 });
     limiter.recordFailure("10.0.0.51");

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -27,9 +27,9 @@ import { isLoopbackAddress, resolveClientIp } from "./net.js";
 export interface RateLimitConfig {
   /** Maximum failed attempts before blocking; must be positive, otherwise the default applies.  @default 10 */
   maxAttempts?: number;
-  /** Sliding window duration in milliseconds; must be positive, otherwise the default applies. Values below 1 ms clamp to 1 ms.  @default 60_000 (1 min) */
+  /** Sliding window duration in milliseconds; must be at least 1, otherwise the default applies.  @default 60_000 (1 min) */
   windowMs?: number;
-  /** Lockout duration in milliseconds after the limit is exceeded; must be positive, otherwise the default applies. Values below 1 ms clamp to 1 ms.  @default 300_000 (5 min) */
+  /** Lockout duration in milliseconds after the limit is exceeded; must be at least 1, otherwise the default applies.  @default 300_000 (5 min) */
   lockoutMs?: number;
   /** Exempt loopback (localhost) addresses from rate limiting.  @default true */
   exemptLoopback?: boolean;
@@ -154,32 +154,37 @@ function resolvePruneIntervalMs(value: number | undefined): number {
 
 /**
  * Non-positive configured values fall back to the default. They are config
- * mistakes, not "off" switches: maxAttempts: 0 would deny every IP with any
- * failure history (remaining is always 0), while windowMs/lockoutMs: 0 would
- * silently turn the limiter into a no-op.
+ * mistakes, not "off" switches: maxAttempts: 0 would deny every non-exempt IP
+ * with any failure history (remaining is always 0), while windowMs/lockoutMs: 0
+ * would silently turn the limiter into a no-op.
  *
- * Positive values pass through untouched — including fractions. Flooring a
- * schema-accepted fraction like maxAttempts: 0.5 to 0 would recreate the
- * permanent-denial trap, so no rounding happens here.
+ * Positive values pass through untouched — including fractional attempt
+ * counts. Flooring a schema-accepted fraction like maxAttempts: 0.5 to 0 would
+ * recreate the permanent-denial trap, so no rounding happens here.
  */
 function resolvePositiveConfigValue(value: number | undefined, fallback: number): number {
   return value !== undefined && Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
+/**
+ * Durations must survive timer truncation: resolveTimerTimeoutMs floors, so a
+ * sub-millisecond value like 0.5 would collapse to a zero-width window or an
+ * instant lockout — the same silently-disabled outcome as 0. Anything below
+ * 1ms falls back to the default as well.
+ */
+function resolveDurationConfigValue(value: number | undefined, fallback: number): number {
+  return value !== undefined && Number.isFinite(value) && value >= 1 ? value : fallback;
+}
+
 export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter {
   const maxAttempts = resolvePositiveConfigValue(config?.maxAttempts, DEFAULT_MAX_ATTEMPTS);
-  // Durations resolve with a 1ms floor: resolveTimerTimeoutMs truncates, so a
-  // sub-millisecond value like 0.5 would otherwise collapse to a zero-width
-  // window or an instant lockout.
   const windowMs = resolveTimerTimeoutMs(
-    resolvePositiveConfigValue(config?.windowMs, DEFAULT_WINDOW_MS),
+    resolveDurationConfigValue(config?.windowMs, DEFAULT_WINDOW_MS),
     DEFAULT_WINDOW_MS,
-    1,
   );
   const lockoutMs = resolveTimerTimeoutMs(
-    resolvePositiveConfigValue(config?.lockoutMs, DEFAULT_LOCKOUT_MS),
+    resolveDurationConfigValue(config?.lockoutMs, DEFAULT_LOCKOUT_MS),
     DEFAULT_LOCKOUT_MS,
-    1,
   );
   const exemptLoopback = config?.exemptLoopback ?? true;
   const pruneIntervalMs = resolvePruneIntervalMs(config?.pruneIntervalMs);

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -25,11 +25,11 @@ import { isLoopbackAddress, resolveClientIp } from "./net.js";
 // ---------------------------------------------------------------------------
 
 export interface RateLimitConfig {
-  /** Maximum failed attempts before blocking.  @default 10 */
+  /** Maximum failed attempts before blocking; must be positive, otherwise the default applies.  @default 10 */
   maxAttempts?: number;
-  /** Sliding window duration in milliseconds.     @default 60_000 (1 min) */
+  /** Sliding window duration in milliseconds; must be positive, otherwise the default applies.  @default 60_000 (1 min) */
   windowMs?: number;
-  /** Lockout duration in milliseconds after the limit is exceeded.  @default 300_000 (5 min) */
+  /** Lockout duration in milliseconds after the limit is exceeded; must be positive, otherwise the default applies.  @default 300_000 (5 min) */
   lockoutMs?: number;
   /** Exempt loopback (localhost) addresses from rate limiting.  @default true */
   exemptLoopback?: boolean;
@@ -152,10 +152,30 @@ function resolvePruneIntervalMs(value: number | undefined): number {
   return resolveTimerTimeoutMs(value, PRUNE_INTERVAL_MS);
 }
 
+/**
+ * Non-positive configured values fall back to the default. They are config
+ * mistakes, not "off" switches: maxAttempts: 0 would deny every IP with any
+ * failure history (remaining is always 0), while windowMs/lockoutMs: 0 would
+ * silently turn the limiter into a no-op.
+ */
+function resolvePositiveConfigValue(value: number | undefined, fallback: number): number {
+  return value !== undefined && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
 export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter {
-  const maxAttempts = config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
-  const windowMs = resolveTimerTimeoutMs(config?.windowMs, DEFAULT_WINDOW_MS, 0);
-  const lockoutMs = resolveTimerTimeoutMs(config?.lockoutMs, DEFAULT_LOCKOUT_MS, 0);
+  const maxAttempts = Math.floor(
+    resolvePositiveConfigValue(config?.maxAttempts, DEFAULT_MAX_ATTEMPTS),
+  );
+  const windowMs = resolveTimerTimeoutMs(
+    resolvePositiveConfigValue(config?.windowMs, DEFAULT_WINDOW_MS),
+    DEFAULT_WINDOW_MS,
+    0,
+  );
+  const lockoutMs = resolveTimerTimeoutMs(
+    resolvePositiveConfigValue(config?.lockoutMs, DEFAULT_LOCKOUT_MS),
+    DEFAULT_LOCKOUT_MS,
+    0,
+  );
   const exemptLoopback = config?.exemptLoopback ?? true;
   const pruneIntervalMs = resolvePruneIntervalMs(config?.pruneIntervalMs);
   const maxEntries = resolveIntegerOption(config?.maxEntries, DEFAULT_MAX_ENTRIES, { min: 1 });

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -27,9 +27,9 @@ import { isLoopbackAddress, resolveClientIp } from "./net.js";
 export interface RateLimitConfig {
   /** Maximum failed attempts before blocking; must be positive, otherwise the default applies.  @default 10 */
   maxAttempts?: number;
-  /** Sliding window duration in milliseconds; must be positive, otherwise the default applies.  @default 60_000 (1 min) */
+  /** Sliding window duration in milliseconds; must be positive, otherwise the default applies. Values below 1 ms clamp to 1 ms.  @default 60_000 (1 min) */
   windowMs?: number;
-  /** Lockout duration in milliseconds after the limit is exceeded; must be positive, otherwise the default applies.  @default 300_000 (5 min) */
+  /** Lockout duration in milliseconds after the limit is exceeded; must be positive, otherwise the default applies. Values below 1 ms clamp to 1 ms.  @default 300_000 (5 min) */
   lockoutMs?: number;
   /** Exempt loopback (localhost) addresses from rate limiting.  @default true */
   exemptLoopback?: boolean;
@@ -168,15 +168,18 @@ function resolvePositiveConfigValue(value: number | undefined, fallback: number)
 
 export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter {
   const maxAttempts = resolvePositiveConfigValue(config?.maxAttempts, DEFAULT_MAX_ATTEMPTS);
+  // Durations resolve with a 1ms floor: resolveTimerTimeoutMs truncates, so a
+  // sub-millisecond value like 0.5 would otherwise collapse to a zero-width
+  // window or an instant lockout.
   const windowMs = resolveTimerTimeoutMs(
     resolvePositiveConfigValue(config?.windowMs, DEFAULT_WINDOW_MS),
     DEFAULT_WINDOW_MS,
-    0,
+    1,
   );
   const lockoutMs = resolveTimerTimeoutMs(
     resolvePositiveConfigValue(config?.lockoutMs, DEFAULT_LOCKOUT_MS),
     DEFAULT_LOCKOUT_MS,
-    0,
+    1,
   );
   const exemptLoopback = config?.exemptLoopback ?? true;
   const pruneIntervalMs = resolvePruneIntervalMs(config?.pruneIntervalMs);

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -157,15 +157,17 @@ function resolvePruneIntervalMs(value: number | undefined): number {
  * mistakes, not "off" switches: maxAttempts: 0 would deny every IP with any
  * failure history (remaining is always 0), while windowMs/lockoutMs: 0 would
  * silently turn the limiter into a no-op.
+ *
+ * Positive values pass through untouched — including fractions. Flooring a
+ * schema-accepted fraction like maxAttempts: 0.5 to 0 would recreate the
+ * permanent-denial trap, so no rounding happens here.
  */
 function resolvePositiveConfigValue(value: number | undefined, fallback: number): number {
   return value !== undefined && Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
 export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter {
-  const maxAttempts = Math.floor(
-    resolvePositiveConfigValue(config?.maxAttempts, DEFAULT_MAX_ATTEMPTS),
-  );
+  const maxAttempts = resolvePositiveConfigValue(config?.maxAttempts, DEFAULT_MAX_ATTEMPTS);
   const windowMs = resolveTimerTimeoutMs(
     resolvePositiveConfigValue(config?.windowMs, DEFAULT_WINDOW_MS),
     DEFAULT_WINDOW_MS,


### PR DESCRIPTION
## Summary

Non-positive `gateway.auth.rateLimit` thresholds (`maxAttempts`, `windowMs`, `lockoutMs`) no longer take effect literally — they fall back to the documented defaults. Previously `maxAttempts: 0` made the gateway deny **every** login from an IP after a single failure (valid credentials included, persisting past lockout expiry), while `windowMs: 0` / `lockoutMs: 0` silently disabled brute-force protection.

## What Problem This Solves

The gateway passes `openclaw.json`'s `gateway.auth.rateLimit` straight into `createAuthRateLimiter` (`src/gateway/server-runtime-state-prepare.ts:261-263`). The config schema types all three thresholds as bare `z.number()` (`src/config/zod-schema.gateway.ts:61-68`), and the limiter itself never range-checks them, so a zero or negative value slips through both layers:

- **`maxAttempts: 0`** — `config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS` keeps `0` (`??` only catches nullish). From then on `remaining` is always `0` (`src/gateway/auth-rate-limit.ts:245-246`), so after **one** wrong password from an IP, every further attempt from that IP is denied — including requests carrying the **correct** credential. The denial even survives lockout expiry: when the lockout lapses the attempts are cleared, but `remaining` is still `max(0, 0 - 0) = 0`, so `allowed` stays `false`. Only an eventual prune of the entry lifts it, and any client that keeps retrying (the Control UI auto-reconnects, and the browser-origin limiter is deliberately not loopback-exempt) re-locks on every single failure. To the operator it looks like the gateway permanently rejects valid logins until restart.
- **`windowMs: 0`** — resolves to a zero-width sliding window, so every recorded failure expires in the same tick and the limiter can never lock. Brute-force protection is silently off.
- **`lockoutMs: 0`** — `lockedUntil = now + 0` expires the moment it is set; the lock never holds. Same silent-off outcome.

There is no documented "0 disables rate limiting" contract for these fields, and a threshold of `0` should never silently switch off a security boundary.

**Code evidence**: `src/gateway/auth-rate-limit.ts:156-158` — `maxAttempts` uses `??` (zero passes straight through), and `windowMs`/`lockoutMs` are resolved with an explicit minimum of `0`, blessing a zero-width window and a zero-length lockout as valid.

## Root Cause

- The `maxAttempts ?? DEFAULT` line dates to the limiter's introduction (`30b6eccae5af`, 2026-02-13); it was written as if "unset" were the only invalid state.
- The duration clamp (`54a27f4e575`, 2026-05-31) bounded oversized `windowMs`/`lockoutMs` against `setTimeout` overflow but set the lower clamp to `0`, so zero and negative durations became accepted values.
- The zod schema only checks "is a number", so nothing rejects the value at load time either.

Violated invariant: the limiter assumes `maxAttempts >= 1`, `windowMs > 0`, `lockoutMs > 0`. `check()` allows only while `remaining > 0`; `recordFailure` locks once `attempts.length >= maxAttempts` for `lockoutMs`. All three assumptions break at zero, in two opposite directions: permanent self-lockout (`maxAttempts`) or protection fully off (`windowMs`/`lockoutMs`).

## Why This Fix

Resolve non-positive (and non-finite) values to the defaults inside `createAuthRateLimiter`, at the single resolution point every caller goes through. Alternatives considered:

- **Schema `.positive()` rejection** — a hard validation error at config load strands existing configs that already carry `0` and pushes operators into a repair flow for a value the runtime can safely neutralize. (A reject-and-migrate variant is being explored in #115085 and has been pending proof; this PR takes the lighter neutralize-at-resolution route.)
- **Clamping to a minimum of 1** — `windowMs: 0 → 1ms` is still a no-op limiter in practice; falling back to the documented default is the only behavior that keeps protection intact.
- **No rounding of attempt counts** — positive `maxAttempts` values pass through byte-identical to main, including fractions: a schema-accepted `maxAttempts: 0.5` keeps its established semantics (first failure locks; the fractional budget returns when the lockout expires). Flooring it to `0` would recreate the exact permanent-denial trap this PR removes. Covered by a dedicated lockout-expiry regression test.
- **Durations must survive timer truncation** — `resolveTimerTimeoutMs` floors fractional milliseconds, so a schema-accepted `windowMs: 0.5` / `lockoutMs: 0.5` would collapse to a zero-width window / instant lockout (same disable-protection outcome as `0`, just sneakier). Sub-millisecond durations therefore fall back to the documented default as well — clamping to 1 ms instead would still let ordinary request timing evade the window. Regression tests cover both sub-millisecond cases with frozen timers, including attempts spaced past the collapsed window.
- **Treating `0` as "disable"** — silently turning off brute-force protection on the gateway boundary is the worst of the three interpretations, and unlike `cron.sessionRetention` (#119422) there is no established `false`-style disable idiom here.

This mirrors the merged precedent for zero-value config traps: #119422 (`session.maintenance.maxDiskBytes: 0`) and #119909 (`highWaterBytes: 0`) both resolve invalid zeros back to safe behavior and document the contract rather than rejecting the config.

## User Impact

- A config with `gateway.auth.rateLimit.maxAttempts: 0` previously made the gateway reject every login — valid or not — from any IP after its first failed attempt, including the local Control UI through the browser-origin limiter. Now the default budget of 10 attempts applies.
- `windowMs: 0` / `lockoutMs: 0` previously disabled brute-force protection without any warning. Now the defaults (60s window / 5min lockout) apply.
- Positive values are honored exactly as before; only non-positive or non-finite input changes behavior.

## Evidence

- **Before**: on main, the real `createAuthRateLimiter` wired the way the gateway wires it shows `maxAttempts: 0` → first failure locks the IP and denial persists past lockout expiry (`allowed: false, remaining: 0`); `windowMs: 0` → 3 failures above `maxAttempts: 2` still `allowed: true`; `lockoutMs: 0` → lock expires same tick. FAIL ×3.
- **After**: same script on this branch — correct credential keeps working after one failure (`remaining: 9` of 10), the lockout engages at the configured threshold, and `retryAfterMs` carries the real default lockout. PASS ×3.
- **Production boundary**: driving real HTTP requests through the real `authorizeHttpGatewayConnect()` (the function the gateway's HTTP/WS auth surfaces call) with the limiter built exactly as `server-runtime-state-prepare.ts` builds it from `cfg.gateway.auth.rateLimit`: on main a wrong token → 401, then the **correct** token → **HTTP 429 rate_limited**, and it is **still 429 after the lockout expires**. On this branch the same trace is 401 → 200 → 200.

## Real Behavior Proof

### Before (on main)

```bash
$ node --import tsx proof.mjs
=== Scenario A: rateLimit.maxAttempts: 0 ===
fresh check:           {"allowed":true,"remaining":0,"retryAfterMs":0}
after 1 failure:       {"allowed":false,"remaining":0,"retryAfterMs":1}
after lockout expired: {"allowed":false,"remaining":0,"retryAfterMs":0}
FAIL: correct credential denied (429) after a single failure, denial persists past lockout expiry

=== Scenario B: rateLimit.windowMs: 0 ===
after 3 failures (maxAttempts: 2): {"allowed":true,"remaining":2,"retryAfterMs":0}
FAIL: 3 failures above maxAttempts: 2 and still allowed — protection silently disabled

=== Scenario C: rateLimit.lockoutMs: 0 ===
after hitting maxAttempts: 1:      {"allowed":true,"remaining":1,"retryAfterMs":0}
FAIL: lockout expired in the same tick it was set — protection silently disabled
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
=== Scenario A: rateLimit.maxAttempts: 0 ===
fresh check:           {"allowed":true,"remaining":10,"retryAfterMs":0}
after 1 failure:       {"allowed":true,"remaining":9,"retryAfterMs":0}
after lockout expired: {"allowed":true,"remaining":9,"retryAfterMs":0}
PASS: correct credential still allowed after a single failure

=== Scenario B: rateLimit.windowMs: 0 ===
after 3 failures (maxAttempts: 2): {"allowed":false,"remaining":0,"retryAfterMs":60000}
PASS: failures are counted, brute-force lockout engages

=== Scenario C: rateLimit.lockoutMs: 0 ===
after hitting maxAttempts: 1:      {"allowed":false,"remaining":0,"retryAfterMs":300000}
PASS: lockout holds with a real retryAfterMs
```

(The script drives the real `createAuthRateLimiter` from `src/gateway/auth-rate-limit.ts`, passing the rateLimit object exactly as `server-runtime-state-prepare.ts` passes `cfg.gateway?.auth?.rateLimit`.)

### Through the production auth boundary (real HTTP → real `authorizeHttpGatewayConnect`)

A loopback `node:http` server gates every request through the real `authorizeHttpGatewayConnect()` from `src/gateway/auth.ts` (token mode), with the limiter built the way the browser-origin limiter is built in production (`{ ...rateLimit, exemptLoopback: false }`), and maps the result to 401/429 exactly like `writeUpgradeAuthFailure` in `src/gateway/server-http.ts`. Config: `{"maxAttempts":0,"lockoutMs":50,"exemptLoopback":false}`.

Before (on main):

```bash
$ node --import tsx proof.mjs
1) wrong token  : HTTP 401 {"error":{"type":"unauthorized","reason":"token_mismatch"}}
2) correct token: HTTP 429 retry-after=1 {"error":{"type":"rate_limited"}}
3) correct token (after lockout expired): HTTP 429 {"error":{"type":"rate_limited"}}
FAIL: correct credential denied right after one failure (429 observed)
FAIL: correct credential still denied after the lockout expired — permanent 429
```

After (with fix):

```bash
$ node --import tsx proof.mjs
1) wrong token  : HTTP 401 {"error":{"type":"unauthorized","reason":"token_mismatch"}}
2) correct token: HTTP 200 {"ok":true,"method":"token"}
3) correct token (after lockout expired): HTTP 200 {"ok":true,"method":"token"}
PASS: one wrong-password attempt no longer locks out the correct credential
```

## Tests and Validation

- `node scripts/check.mjs` passed
- `npx vitest run src/gateway/auth-rate-limit.test.ts` passed (138 tests across 3 projects, incl. new regression cases: `maxAttempts: 0`, negative `maxAttempts`, `windowMs: 0`, `lockoutMs: 0`, fractional `maxAttempts: 0.5` preserved across lockout expiry, and sub-millisecond `windowMs: 0.5` / `lockoutMs: 0.5` falling back to the defaults)
- Contract documented on the `RateLimitConfig` field JSDoc, the `gateway.auth.rateLimit` schema help text, and `docs/gateway/security/rate-limiting.md`



