### PR TITLE
fix(agents): preserve blank lines across read pages

### DIFF
--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -345,7 +345,7 @@ async function executeReadWithAdaptivePaging(params: {
       (truncation?.outputLines ?? 0) > 0 &&
       page < MAX_ADAPTIVE_READ_PAGES - 1;
     const pageText = canContinue ? stripReadContinuationNotice(rawText) : rawText;
-    const delimiter = aggregatedText && pageText ? "\n\n" : "";
+    const delimiter = aggregatedText && pageText ? "\n" : "";
     const nextBytes = Buffer.byteLength(`${delimiter}${pageText}`, "utf-8");
 
     if (aggregatedText && aggregatedBytes + nextBytes > params.maxBytes) {

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -353,7 +353,7 @@ async function executeReadWithAdaptivePaging(params: {
     const pageContinuation = truncation?.continuation;
     const pageText =
       pageContinuation || reachedEof ? stripReadContinuationNotice(rawText) : rawText;
-    const delimiter = aggregatedText && pageText && next.kind === "line" ? "\n" : "";
+    const delimiter = page > 0 && next.kind === "line" ? "\n" : "";
     const candidateBytes = aggregatedBytes + delimiter.length + Buffer.byteLength(pageText, "utf8");
     const continuationNotice = pageContinuation
       ? formatReadContinuationNotice(pageContinuation, params.maxBytes)
@@ -366,7 +366,7 @@ async function executeReadWithAdaptivePaging(params: {
         params.modelBudget,
       )
     ) {
-      if (aggregatedText) {
+      if (page > 0) {
         return withReadContinuation(
           firstResult,
           `${aggregatedText}${previousNotice}`,

--- a/src/agents/filesystem-tools-output-contract.test.ts
+++ b/src/agents/filesystem-tools-output-contract.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createOpenClawReadTool } from "./agent-tools.read.js";
+import { createOpenClawReadTool, wrapReadToolWithSkillContent } from "./agent-tools.read.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { createApplyPatchTool } from "./apply-patch.js";
 import { createEditTool, createReadTool, createWriteTool } from "./sessions/index.js";
@@ -57,6 +57,84 @@ describe("filesystem tool output contracts", () => {
     expect(compactToolOutputHint(tool.outputSchema)).toBe(
       '{ content: string; kind: "text" } | { content: string; kind: "image"; mimeType: string } | { content: string; kind: "truncated"; truncation: { firstLineExceedsLimit: boolean; lastLinePartial: boolean; maxBytes: number; maxLines: number; outputBytes: number; outputLines: number; totalBytes: number; totalLines: number; truncated: true; truncatedBy: "lines" | "bytes" } } | { kind: "not_found"; optional: true; path: string; status: "not_found" }',
     );
+  });
+
+  it.each([
+    {
+      label: "multiple ASCII pages",
+      lines: Array.from({ length: 5000 }, (_, index) => String(index + 1)),
+      trailingNewline: false,
+    },
+    {
+      label: "multiple CJK pages",
+      lines: Array.from({ length: 3001 }, (_, index) => `漢${index + 1}`),
+      trailingNewline: false,
+    },
+    {
+      label: "empty boundary lines and a trailing newline",
+      lines: Array.from({ length: 2505 }, (_, index) =>
+        index === 1999 || index === 2000 ? "" : `line-${index + 1}`,
+      ),
+      trailingNewline: true,
+    },
+  ])("returns the original file bytes across $label", async ({ lines, trailingNewline }) => {
+    const source = `${lines.join("\n")}${trailingNewline ? "\n" : ""}`;
+    await fs.writeFile(path.join(tmpDir, "multi-page.txt"), source, "utf8");
+    const tool = createOpenClawReadTool(createReadTool(tmpDir) as unknown as AnyAgentTool);
+
+    const result = await tool.execute("read-multi-page", { path: "multi-page.txt" });
+
+    expect(result.content).toEqual([{ type: "text", text: source }]);
+    expect(result.details).toEqual({ kind: "text", content: source });
+    expectContract(tool, result.details);
+  });
+
+  it("returns complete virtual skill content without inserting page separators", async () => {
+    const locator = "node://node-1/skills/pond/SKILL.md";
+    const source = Array.from({ length: 2501 }, (_, index) => String(index + 1)).join("\n");
+    const base = createOpenClawReadTool(createReadTool(tmpDir) as unknown as AnyAgentTool);
+    const tool = wrapReadToolWithSkillContent(base, [{ filePath: locator, readContent: source }]);
+
+    const result = await tool.execute("read-whole-skill", { path: locator });
+
+    expect(result.content).toEqual([{ type: "text", text: source }]);
+    expect(result.details).toEqual({ kind: "text", content: source });
+    expectContract(tool, result.details);
+  });
+
+  it("preserves explicit limits, offsets, and their continuation notices", async () => {
+    const lines = Array.from({ length: 5000 }, (_, index) => String(index + 1));
+    await fs.writeFile(path.join(tmpDir, "offset.txt"), lines.join("\n"), "utf8");
+    const tool = createOpenClawReadTool(createReadTool(tmpDir) as unknown as AnyAgentTool);
+
+    const limited = await tool.execute("read-limited", { path: "offset.txt", limit: 5 });
+    const expectedLimited = `${lines.slice(0, 5).join("\n")}\n\n[4995 more lines in file. Use offset=6 to continue.]`;
+    expect(limited.content).toEqual([{ type: "text", text: expectedLimited }]);
+    expect(limited.details).toEqual({ kind: "text", content: expectedLimited });
+
+    const offset = await tool.execute("read-offset", { path: "offset.txt", offset: 1990 });
+    const expectedOffset = lines.slice(1989).join("\n");
+    expect(offset.content).toEqual([{ type: "text", text: expectedOffset }]);
+    expect(offset.details).toEqual({ kind: "text", content: expectedOffset });
+  });
+
+  it("preserves adaptive continuation offsets and their separate notice", async () => {
+    const lines = Array.from(
+      { length: 8000 },
+      (_, index) => `line-${String(index + 1).padStart(4, "0")}-abcdefghijklmnopqrstuvwxyz`,
+    );
+    await fs.writeFile(path.join(tmpDir, "capped.txt"), lines.join("\n"), "utf8");
+    const tool = createOpenClawReadTool(createReadTool(tmpDir) as unknown as AnyAgentTool);
+
+    const result = await tool.execute("read-capped", { path: "capped.txt" });
+    const output = result.content.find((block) => block.type === "text")?.text;
+
+    expect(output).toBeDefined();
+    expect(output).toMatch(
+      /\n\n\[Read output capped at 32KB for this call\. Use offset=1384 to continue\.\]$/,
+    );
+    expect(result.details).toMatchObject({ kind: "truncated", content: output });
+    expectContract(tool, result.details);
   });
 
   it("validates edit changed and no-op results", async () => {

--- a/src/agents/filesystem-tools-output-contract.test.ts
+++ b/src/agents/filesystem-tools-output-contract.test.ts
@@ -3,10 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createOpenClawReadTool } from "./agent-tools.read.js";
+import { createOpenClawReadTool, resolveAdaptiveReadMaxBytes } from "./agent-tools.read.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { createApplyPatchTool } from "./apply-patch.js";
 import { createEditTool, createReadTool, createWriteTool } from "./sessions/index.js";
+import type { ReadToolDetails } from "./sessions/tools/tool-contracts.js";
 import { DEFAULT_MAX_BYTES } from "./sessions/tools/truncate.js";
 import { compactToolOutputHint } from "./tool-schema-hints.js";
 
@@ -63,6 +64,64 @@ describe("filesystem tool output contracts", () => {
     expect(compactToolOutputHint(tool.outputSchema)).toBe(
       '{ content: string; kind: "text" } | { content: string; kind: "image"; mimeType: string } | { content: string; continuation: { kind: "line"; offset: number; limit?: number } | { cursor: number; kind: "cursor"; offset: number; limit?: number }; kind: "truncated"; truncation: { firstLineExceedsLimit: boolean; lastLinePartial: boolean; maxBytes: number; maxLines: number; outputBytes: number; outputLines: number; totalBytes: number; totalLines: number; truncated: true; truncatedBy: "lines" | "bytes" } } | { kind: "not_found"; optional: true; path: string; status: "not_found" }',
     );
+  });
+
+  it.each([
+    { name: "one leading blank line", prefix: "\n", size: 52 * 1024 },
+    { name: "no leading blank line", prefix: "", size: 52 * 1024 },
+    { name: "two leading blank lines", prefix: "\n\n", size: 52 * 1024 },
+    { name: "a short file", prefix: "\n", size: 10 },
+    { name: "an offset on a blank line", prefix: "\n", size: 52 * 1024, offset: 2 },
+  ])("preserves $name across read continuations", async ({ prefix, size, offset }) => {
+    const expected = `${prefix}${JSON.stringify({ generated: "x".repeat(size) })}`;
+    await fs.writeFile(
+      path.join(tmpDir, "paged.json"),
+      `${offset ? "before\n" : ""}${expected}`,
+      "utf8",
+    );
+    const tool = createOpenClawReadTool(
+      createReadTool(tmpDir, {
+        maxBytes: resolveAdaptiveReadMaxBytes(),
+      }) as unknown as AnyAgentTool,
+    );
+    let args: { path: string; offset?: number; cursor?: number; limit?: number } = {
+      path: "paged.json",
+      ...(offset ? { offset } : {}),
+    };
+    let actual = "";
+    let separator = "";
+    let complete = false;
+    for (let page = 0; page < 8; page++) {
+      const result = await tool.execute(`read-page-${page}`, args);
+      expectContract(tool, result.details);
+      const details = result.details as ReadToolDetails;
+      const text = result.content.find((block) => block.type === "text")!.text;
+      expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(resolveAdaptiveReadMaxBytes());
+      expect(details).toMatchObject({ content: text });
+      if (details.kind !== "truncated") {
+        actual += separator + text;
+        complete = true;
+        break;
+      }
+      const footer = text.lastIndexOf("\n\n[Read output capped at ");
+      expect(footer).toBeGreaterThanOrEqual(0);
+      const next = details.continuation;
+      expect(text.slice(footer)).toContain(`offset=${next.offset}`);
+      if (next.kind === "cursor") {
+        expect(text.slice(footer)).toContain(`cursor=${next.cursor}`);
+      }
+      actual += separator + text.slice(0, footer);
+      separator = next.kind === "line" ? "\n" : "";
+      args = {
+        path: "paged.json",
+        offset: next.offset,
+        ...(next.kind === "cursor" ? { cursor: next.cursor } : {}),
+        ...(next.limit === undefined ? {} : { limit: next.limit }),
+      };
+    }
+    expect(complete).toBe(true);
+    expect(Buffer.byteLength(actual)).toBe(Buffer.byteLength(expected));
+    expect(actual).toBe(expected);
   });
 
   it("validates edit changed and no-op results", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents reading a file would lose one blank line when that line formed an otherwise empty page before an oversized line. The same loss occurred when an explicit offset selected that blank line. Following the returned continuation could not recover the omitted newline.

## Why This Change Was Made

The adaptive reader now uses its existing consumed-page index in both page joining and overflow handling. Empty text can represent a real blank line; it does not mean that no page was consumed. The current typed line-versus-cursor continuation flow, byte/model budgets, and standalone reader remain unchanged.

The original single-newline join repair is already present on main. This update retains the PR's ancestry and content-fidelity scope while addressing the remaining empty-page defect on the current implementation. The final regression cases target that distinct boundary rather than replaying the stale separator patch. Production: +2/-2, net zero; tests: +60/-1.

## User Impact

Read continuations preserve the selected file text, including leading blank lines, without inserting newlines into cursor resumes. When the unchanged aggregate budget cannot fit the next page, the tool returns the already-consumed page and its correct continuation—even when that page contains only a blank line.

## Evidence

- Actual local Read flow, assembled by the production core-tool factory with default budgets and real temporary UTF-8 files: the default leading-blank-line case and explicit-offset case each lost one byte before the repair. Both now reconstruct the exact original text; no-leading-blank, two-leading-blank, and short-file controls also pass. The same five-case probe ran before and after on Node 24.20.0, Darwin arm64, with source/dependency hash guards. No native Windows execution is claimed.
- The regression failed in the two affected cases before the production change and passed all five cases afterward. The full filesystem contract, session Read, shared truncation, and selected assembled paging/whole-skill checks passed: 76 tests. The assembled check intentionally excluded unrelated tests.
- Independent source/behavior review and managed P0–P2 autoreview found no actionable defects on the tested patch. The final test-only formatting adjustment passed the two-file formatter check; production bytes are unchanged.
- The local full maintained gate has not run because execution is paused for a shared-dependency audit. Hosted CI on final descendant commit `0ec1da56bd98c572f79b978a3d384bf00e9e83a4` is required before native preparation and merge; its result is pending.
