### PR TITLE
fix(mcp): preserve client and requester lifecycle ownership

### DIFF
--- a/extensions/codex/src/app-server/effective-mcp-catalog.test.ts
+++ b/extensions/codex/src/app-server/effective-mcp-catalog.test.ts
@@ -97,6 +97,55 @@ describe("loadCodexEffectiveMcpCatalog", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
+  it.each(["success", "failure"] as const)(
+    "retains the bound client until its final catalog page settles with %s",
+    async (outcome) => {
+      let resolveFinalPage!: () => void;
+      let rejectFinalPage!: (error: Error) => void;
+      const finalPage = new Promise<void>((resolve, reject) => {
+        resolveFinalPage = resolve;
+        rejectFinalPage = reject;
+      });
+      const release = vi.fn();
+      const request = vi
+        .fn()
+        .mockResolvedValueOnce({ data: [], nextCursor: "page-2" })
+        .mockImplementationOnce(async () => {
+          await finalPage;
+          return { data: [], nextCursor: null };
+        });
+      sharedClientMocks.retainById.mockReturnValueOnce({ client: { request }, release });
+      const bindingStore = {
+        read: vi.fn().mockResolvedValue({ threadId: "thread-1", clientId: "client-1" }),
+      };
+
+      const catalog = loadCodexEffectiveMcpCatalog(
+        {
+          config: {},
+          agentId: "main",
+          sessionId: "session-1",
+          sessionKey: "agent:main:session-1",
+          workspaceDir: "/workspace",
+          mcpServerNames: [],
+        },
+        { bindingStore: bindingStore as never },
+      );
+
+      await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+      expect(release).not.toHaveBeenCalled();
+
+      if (outcome === "success") {
+        resolveFinalPage();
+        await expect(catalog).resolves.toMatchObject({ tools: [] });
+      } else {
+        rejectFinalPage(new Error("final MCP catalog page failed"));
+        await expect(catalog).rejects.toThrow("final MCP catalog page failed");
+      }
+
+      expect(release).toHaveBeenCalledOnce();
+    },
+  );
+
   it("does not start a new Codex process when the binding has no live client", async () => {
     const bindingStore = {
       read: vi.fn().mockResolvedValue({ threadId: "thread-1", cwd: "/workspace" }),

--- a/extensions/codex/src/app-server/effective-mcp-catalog.ts
+++ b/extensions/codex/src/app-server/effective-mcp-catalog.ts
@@ -157,7 +157,7 @@ async function loadCodexEffectiveMcpCatalogFromThread(params: {
   return buildCodexEffectiveMcpCatalog(statuses, params.toolOverrides);
 }
 
-/** Loads MCP inventory only from the already-bound Codex process and thread. */
+/** Loads MCP inventory from the bound Codex client while retaining its lease through all pages. */
 export async function loadCodexEffectiveMcpCatalog(
   params: AgentHarnessMcpCatalogParams,
   options: { bindingStore: CodexAppServerBindingStore },
@@ -178,7 +178,7 @@ export async function loadCodexEffectiveMcpCatalog(
     return undefined;
   }
   try {
-    return loadCodexEffectiveMcpCatalogFromThread({
+    return await loadCodexEffectiveMcpCatalogFromThread({
       client: retained.client,
       threadId: binding.threadId,
       mcpServerNames: params.mcpServerNames,

--- a/extensions/codex/src/app-server/run-attempt-cleanup.ts
+++ b/extensions/codex/src/app-server/run-attempt-cleanup.ts
@@ -1,8 +1,4 @@
-import {
-  clearActiveEmbeddedRun,
-  embeddedAgentLog,
-  runAgentCleanupStep,
-} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { clearActiveEmbeddedRun } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { isIncognitoSessionKey } from "../incognito-session.js";
 import {
   CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
@@ -33,6 +29,7 @@ export async function cleanupCodexAttempt(
     releaseCurrentRoute,
     releaseSharedClientLeaseAndRetireOneShotClient,
     releaseSandboxExecEnvironment,
+    runCleanupStep,
   } = resources;
   const { connection } = prompt.context.runtime;
   const { params, options, runAbortController, terminalState, bindingStore, bindingIdentity } =
@@ -45,138 +42,148 @@ export async function cleanupCodexAttempt(
   } = lifecycle;
   const { codexModelCallDiagnostics } = requestRuntime;
   const { activeTurnId, abortListener, handle, freezeRunTerminalOutcome } = activeTurn;
-  if (params.isFinalFallbackAttempt !== false) {
-    await maybeEmitFastModeAutoResetBestEffort();
-  }
-  codexModelCallDiagnostics.emitError(
-    "codex app-server run completed without model-call terminal event",
-  );
-  emitLifecycleTerminal({
-    phase: "error",
-    error: "codex app-server run completed without lifecycle terminal event",
-    ...buildLifecycleTerminalMeta({
-      aborted: runAbortController.signal.aborted && !state.clientClosedAbort,
-      timedOut: state.timedOut,
-    }),
-  });
-  if (trajectoryRecorder && !resourceState.trajectoryEndRecorded) {
-    trajectoryRecorder.recordEvent("session.ended", {
-      status:
-        state.timedOut || (runAbortController.signal.aborted && !state.clientClosedAbort)
-          ? "interrupted"
-          : "cleanup",
-      threadId: resourceState.thread.threadId,
-      turnId: activeTurnId,
-      timedOut: state.timedOut,
-      aborted: runAbortController.signal.aborted && !state.clientClosedAbort,
+  try {
+    if (params.isFinalFallbackAttempt !== false) {
+      await maybeEmitFastModeAutoResetBestEffort();
+    }
+    codexModelCallDiagnostics.emitError(
+      "codex app-server run completed without model-call terminal event",
+    );
+    emitLifecycleTerminal({
+      phase: "error",
+      error: "codex app-server run completed without lifecycle terminal event",
+      ...buildLifecycleTerminalMeta({
+        aborted: runAbortController.signal.aborted && !state.clientClosedAbort,
+        timedOut: state.timedOut,
+      }),
     });
-  }
-  await runAgentCleanupStep({
-    runId: params.runId,
-    sessionId: params.sessionId,
-    step: "codex-trajectory-flush",
-    log: embeddedAgentLog,
-    cleanup: async () => trajectoryRecorder?.flush(),
-  });
-  if (!state.timedOut && !runAbortController.signal.aborted) {
-    await steeringQueueRef.current?.flushPending();
-  }
-  const retainLiveIncognitoThread =
-    terminalState.turnSucceeded && isIncognitoSessionKey(params.sessionKey);
-  // Native-preserved and supervision threads have separate ownership and can
-  // never enter the ordinary persistent warm-thread cache.
-  const retainedPersistentThread =
-    terminalState.turnSucceeded &&
-    !isIncognitoSessionKey(params.sessionKey) &&
-    params.cleanupBundleMcpOnRunEnd !== true &&
-    resourceState.thread.liveThreadConfigFingerprint !== undefined &&
-    resourceState.thread.clientId === resolveCodexAppServerClientInstanceId(resourceState.client) &&
-    resourceState.thread.preserveNativeModel !== true &&
-    resourceState.thread.connectionScope !== "supervision" &&
-    !resourceState.thread.ringZeroConfigFingerprint
-      ? (await bindingStore.read(bindingIdentity))?.threadId === resourceState.thread.threadId &&
-        (await bindingStore.withLease(bindingIdentity, async () => {
-          // Reset/end uses this same generation lease. Never publish an old
-          // active turn after its session binding has already been retired.
-          if (
-            (await bindingStore.read(bindingIdentity))?.threadId !== resourceState.thread.threadId
-          ) {
-            return false;
-          }
-          return await retainCodexAppServerLiveThread(
-            resourceState.client,
-            resourceState.thread.threadId,
-            resourceState.thread.liveThreadOwnership?.release ??
-              (async (threadId) => {
-                const released = await unsubscribeCodexThreadBestEffort(resourceState.client, {
-                  threadId,
-                  timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
-                });
-                if (!released) {
-                  await closeCodexStartupClientBestEffort(resourceState.client);
-                  throw new CodexAppServerUnsafeSubscriptionError(
-                    `Codex retained thread subscription could not be released: ${threadId}`,
-                  );
-                }
-              }),
-            resourceState.thread.liveThreadConfigFingerprint,
-            connection.mutable.pluginAppServer.serviceTier,
-          );
-        }))
-      : false;
-  // Codex keeps approvals in its native session; independent conversations
-  // must retain their own subscriptions instead of evicting one another.
-  const retainLiveThread = retainLiveIncognitoThread || retainedPersistentThread;
-  const bindingReleased =
-    isIncognitoSessionKey(params.sessionKey) && !retainLiveIncognitoThread
-      ? await bindingStore.mutate(bindingIdentity, {
-          kind: "clear",
-          threadId: resourceState.thread.threadId,
-        })
-      : true;
-  // Only explicitly retained live threads may skip the next thread/resume.
-  if (!state.timedOut && !retainLiveThread) {
-    // Clear first: if a newer owner won the binding, its live subscription must remain intact.
-    if (bindingReleased) {
-      const released = await unsubscribeCodexThreadBestEffort(resourceState.client, {
+    if (trajectoryRecorder && !resourceState.trajectoryEndRecorded) {
+      trajectoryRecorder.recordEvent("session.ended", {
+        status:
+          state.timedOut || (runAbortController.signal.aborted && !state.clientClosedAbort)
+            ? "interrupted"
+            : "cleanup",
         threadId: resourceState.thread.threadId,
-        timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+        turnId: activeTurnId,
+        timedOut: state.timedOut,
+        aborted: runAbortController.signal.aborted && !state.clientClosedAbort,
       });
-      if (!released) {
-        // Never reuse a client whose previous thread may still publish notifications.
-        await closeCodexStartupClientBestEffort(resourceState.client);
+    }
+    await runCleanupStep("codex-trajectory-flush", () => trajectoryRecorder?.flush());
+    if (!state.timedOut && !runAbortController.signal.aborted) {
+      await steeringQueueRef.current?.flushPending();
+    }
+    const retainLiveIncognitoThread =
+      terminalState.turnSucceeded && isIncognitoSessionKey(params.sessionKey);
+    // Native-preserved and supervision threads have separate ownership and can
+    // never enter the ordinary persistent warm-thread cache.
+    const retainedPersistentThread =
+      terminalState.turnSucceeded &&
+      !isIncognitoSessionKey(params.sessionKey) &&
+      params.cleanupBundleMcpOnRunEnd !== true &&
+      resourceState.thread.liveThreadConfigFingerprint !== undefined &&
+      resourceState.thread.clientId ===
+        resolveCodexAppServerClientInstanceId(resourceState.client) &&
+      resourceState.thread.preserveNativeModel !== true &&
+      resourceState.thread.connectionScope !== "supervision" &&
+      !resourceState.thread.ringZeroConfigFingerprint
+        ? (await bindingStore.read(bindingIdentity))?.threadId === resourceState.thread.threadId &&
+          (await bindingStore.withLease(bindingIdentity, async () => {
+            // Reset/end uses this same generation lease. Never publish an old
+            // active turn after its session binding has already been retired.
+            if (
+              (await bindingStore.read(bindingIdentity))?.threadId !== resourceState.thread.threadId
+            ) {
+              return false;
+            }
+            return await retainCodexAppServerLiveThread(
+              resourceState.client,
+              resourceState.thread.threadId,
+              resourceState.thread.liveThreadOwnership?.release ??
+                (async (threadId) => {
+                  const released = await unsubscribeCodexThreadBestEffort(resourceState.client, {
+                    threadId,
+                    timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+                  });
+                  if (!released) {
+                    await closeCodexStartupClientBestEffort(resourceState.client);
+                    throw new CodexAppServerUnsafeSubscriptionError(
+                      `Codex retained thread subscription could not be released: ${threadId}`,
+                    );
+                  }
+                }),
+              resourceState.thread.liveThreadConfigFingerprint,
+              connection.mutable.pluginAppServer.serviceTier,
+            );
+          }))
+        : false;
+    // Codex keeps approvals in its native session; independent conversations
+    // must retain their own subscriptions instead of evicting one another.
+    const retainLiveThread = retainLiveIncognitoThread || retainedPersistentThread;
+    const bindingReleased =
+      isIncognitoSessionKey(params.sessionKey) && !retainLiveIncognitoThread
+        ? await bindingStore.mutate(bindingIdentity, {
+            kind: "clear",
+            threadId: resourceState.thread.threadId,
+          })
+        : true;
+    // Only explicitly retained live threads may skip the next thread/resume.
+    if (!state.timedOut && !retainLiveThread) {
+      // Clear first: if a newer owner won the binding, its live subscription must remain intact.
+      if (bindingReleased) {
+        const released = await unsubscribeCodexThreadBestEffort(resourceState.client, {
+          threadId: resourceState.thread.threadId,
+          timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+        });
+        if (!released) {
+          // Never reuse a client whose previous thread may still publish notifications.
+          await closeCodexStartupClientBestEffort(resourceState.client);
+        }
       }
     }
+  } finally {
+    await runCleanupStep("codex-user-input-cancel", () =>
+      userInputBridgeRef.current?.cancelPending(),
+    );
+    await runCleanupStep("codex-turn-watch-clear", () => turnWatches.clearAllTimers());
+    await runCleanupStep("codex-route-release", releaseCurrentRoute);
+    await runCleanupStep(
+      "codex-shared-client-release",
+      releaseSharedClientLeaseAndRetireOneShotClient,
+    );
+    const nativeHookRelay = resourceState.nativeHookRelay;
+    resourceState.nativeHookRelay = undefined;
+    await runCleanupStep("codex-native-hook-relay-release", () => {
+      if (!nativeHookRelay) {
+        return;
+      }
+      if (state.shouldDelayNativeHookRelayUnregister) {
+        // Native hook subprocesses can finish shortly after turn completion.
+        scheduleCodexNativeHookRelayUnregister({
+          relay: nativeHookRelay,
+          hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
+        });
+      } else {
+        nativeHookRelay.unregister();
+      }
+    });
+    await runCleanupStep("codex-sandbox-release", releaseSandboxExecEnvironment);
+    await runCleanupStep("codex-scoped-mcp-dispose", () =>
+      prompt.context.attemptTools.scopedMcpTools?.dispose(),
+    );
+    await runCleanupStep("codex-scheduled-mcp-dispose", () =>
+      prompt.context.attemptTools.scheduledConfiguredMcp?.dispose(),
+    );
+    await runCleanupStep("codex-abort-listener-remove", () => {
+      runAbortController.signal.removeEventListener("abort", abortListener);
+    });
+    await runCleanupStep("codex-steering-cancel", () => steeringQueueRef.current?.cancel());
+    await runCleanupStep("codex-terminal-freeze", freezeRunTerminalOutcome);
+    await runCleanupStep("codex-reply-backend-detach", () =>
+      params.replyOperation?.detachBackend(handle),
+    );
+    await runCleanupStep("codex-active-run-clear", () => {
+      clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
+    });
   }
-  userInputBridgeRef.current?.cancelPending();
-  turnWatches.clearAllTimers();
-  releaseCurrentRoute();
-  await releaseSharedClientLeaseAndRetireOneShotClient();
-  if (resourceState.nativeHookRelay) {
-    if (state.shouldDelayNativeHookRelayUnregister) {
-      // Native hook subprocesses can finish shortly after turn completion.
-      scheduleCodexNativeHookRelayUnregister({
-        relay: resourceState.nativeHookRelay,
-        hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
-      });
-    } else {
-      resourceState.nativeHookRelay.unregister();
-    }
-  }
-  await releaseSandboxExecEnvironment();
-  await runAgentCleanupStep({
-    runId: params.runId,
-    sessionId: params.sessionId,
-    step: "codex-scoped-mcp-dispose",
-    log: embeddedAgentLog,
-    cleanup: async () => {
-      await prompt.context.attemptTools.scopedMcpTools?.dispose();
-      await prompt.context.attemptTools.scheduledConfiguredMcp?.dispose();
-    },
-  });
-  runAbortController.signal.removeEventListener("abort", abortListener);
-  steeringQueueRef.current?.cancel();
-  freezeRunTerminalOutcome();
-  params.replyOperation?.detachBackend(handle);
-  clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
 }

--- a/extensions/codex/src/app-server/run-attempt-resources.ts
+++ b/extensions/codex/src/app-server/run-attempt-resources.ts
@@ -1,5 +1,6 @@
 import {
   embeddedAgentLog,
+  runAgentCleanupStep,
   type AgentHarnessRuntimeArtifactBinding,
   type NativeHookRelayRegistrationHandle,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
@@ -158,6 +159,16 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
       await releaseCodexSandboxExecServerEnvironment(sandbox);
     }
   };
+  const runCleanupStep = (step: string, operation: () => Promise<void> | void | undefined) =>
+    runAgentCleanupStep({
+      runId: params.runId,
+      sessionId: params.sessionId,
+      step,
+      log: embeddedAgentLog,
+      cleanup: async () => {
+        await operation();
+      },
+    });
   const unregisterNativeSubagentMonitor = () => {
     state.nativeSubagentMonitor?.unregister();
     state.nativeSubagentMonitor = undefined;
@@ -260,6 +271,7 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
     releaseSharedClientLeaseOnce,
     releaseSharedClientLeaseAndRetireOneShotClient,
     releaseSandboxExecEnvironment,
+    runCleanupStep,
     registerNativeSubagentMonitor,
     releaseCurrentRoute,
     startupTimeoutMs,

--- a/extensions/codex/src/app-server/run-attempt-start.ts
+++ b/extensions/codex/src/app-server/run-attempt-start.ts
@@ -18,8 +18,9 @@ export async function startCodexAttemptRuntime(resources: CodexAttemptResources)
     trajectoryRecorder,
     activateNativePreToolUseFailureFallback,
     releaseSandboxExecEnvironment,
-    releaseSharedClientLeaseOnce,
+    releaseSharedClientLeaseAndRetireOneShotClient,
     releaseCurrentRoute,
+    runCleanupStep,
     startupTimeoutMs,
     buildNativeHookRelayFinalConfigPatch,
   } = resources;
@@ -114,6 +115,15 @@ export async function startCodexAttemptRuntime(resources: CodexAttemptResources)
       spawnedBy: params.spawnedBy,
     });
     state.client = startupResult.client;
+    state.thread = startupResult.thread;
+    state.runtimeArtifact = startupResult.runtimeArtifact;
+    state.turnRouter = startupResult.turnRouter;
+    state.turnRoute = startupResult.turnRoute;
+    // Adopt cleanup ownership before any fallible validation of the started thread.
+    state.sandboxExecEnvironmentAcquired = Boolean(startupResult.sandboxEnvironment);
+    state.releaseSharedClientLease = startupResult.releaseSharedClientLease;
+    state.restartContextEngineCodexThread = startupResult.restartContextEngineCodexThread;
+    pluginAppServer = startupResult.pluginAppServer;
     toolBridge.setRemoteWorkspaceFileReader?.(
       ({ path, maxBytes, workspaceRoot, signal, timeoutMs }) =>
         readBoundedCodexRemoteWorkspaceFile({
@@ -125,15 +135,6 @@ export async function startCodexAttemptRuntime(resources: CodexAttemptResources)
           timeoutMs,
         }),
     );
-    state.thread = startupResult.thread;
-    state.runtimeArtifact = startupResult.runtimeArtifact;
-    state.turnRouter = startupResult.turnRouter;
-    state.turnRoute = startupResult.turnRoute;
-    // Adopt cleanup ownership before any fallible validation of the started thread.
-    state.sandboxExecEnvironmentAcquired = Boolean(startupResult.sandboxEnvironment);
-    state.releaseSharedClientLease = startupResult.releaseSharedClientLease;
-    state.restartContextEngineCodexThread = startupResult.restartContextEngineCodexThread;
-    pluginAppServer = startupResult.pluginAppServer;
     if (
       usesSupervisionConnection &&
       (state.thread.connectionScope !== "supervision" ||
@@ -184,34 +185,46 @@ export async function startCodexAttemptRuntime(resources: CodexAttemptResources)
         clientId: state.client.getInstanceId(),
       },
     });
+    if (applyNoContextEngineContinuityProjection(state.thread.lifecycle.action, state.thread)) {
+      await rebuildCodexTurnPromptTextFromCurrentProjection();
+    }
+    trajectoryRecorder?.recordEvent("session.started", {
+      sessionFile: params.sessionFile,
+      threadId: state.thread.threadId,
+      authProfileId: startupAuthProfileId,
+      workspaceDir: effectiveWorkspace,
+      toolCount: flattenCodexDynamicToolFunctions(toolBridge.specs).length,
+    });
+    recordCodexTrajectoryContext(trajectoryRecorder, {
+      attempt: params,
+      cwd: effectiveCwd,
+      developerInstructions: joinPresentSections(
+        buildRenderedCodexDeveloperInstructions(),
+        attemptTools.scheduledConfiguredMcp?.diagnosticNotice,
+      ),
+      prompt: turnState.codexTurnPromptText,
+      tools: toolBridge.availableSpecs,
+    });
+    connection.mutable.pluginAppServer = pluginAppServer;
   } catch (error) {
-    activateNativePreToolUseFailureFallback();
-    releaseCurrentRoute();
-    state.nativeHookRelay?.unregister();
-    await releaseSandboxExecEnvironment();
-    releaseSharedClientLeaseOnce();
-    params.abortSignal?.removeEventListener("abort", abortFromUpstream);
+    await runCleanupStep(
+      "codex-start-failure-hook-fallback",
+      activateNativePreToolUseFailureFallback,
+    );
+    await runCleanupStep("codex-start-failure-route-release", releaseCurrentRoute);
+    const nativeHookRelay = state.nativeHookRelay;
+    state.nativeHookRelay = undefined;
+    await runCleanupStep("codex-start-failure-native-hook-relay", () =>
+      nativeHookRelay?.unregister(),
+    );
+    await runCleanupStep("codex-start-failure-sandbox-release", releaseSandboxExecEnvironment);
+    await runCleanupStep(
+      "codex-start-failure-shared-client-release",
+      releaseSharedClientLeaseAndRetireOneShotClient,
+    );
+    await runCleanupStep("codex-start-failure-abort-listener", () =>
+      params.abortSignal?.removeEventListener("abort", abortFromUpstream),
+    );
     throw error;
   }
-  if (applyNoContextEngineContinuityProjection(state.thread.lifecycle.action, state.thread)) {
-    await rebuildCodexTurnPromptTextFromCurrentProjection();
-  }
-  trajectoryRecorder?.recordEvent("session.started", {
-    sessionFile: params.sessionFile,
-    threadId: state.thread.threadId,
-    authProfileId: startupAuthProfileId,
-    workspaceDir: effectiveWorkspace,
-    toolCount: flattenCodexDynamicToolFunctions(toolBridge.specs).length,
-  });
-  recordCodexTrajectoryContext(trajectoryRecorder, {
-    attempt: params,
-    cwd: effectiveCwd,
-    developerInstructions: joinPresentSections(
-      buildRenderedCodexDeveloperInstructions(),
-      attemptTools.scheduledConfiguredMcp?.diagnosticNotice,
-    ),
-    prompt: turnState.codexTurnPromptText,
-    tools: toolBridge.availableSpecs,
-  });
-  connection.mutable.pluginAppServer = pluginAppServer;
 }

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -98,7 +98,11 @@ import {
   releaseCodexSandboxExecServerEnvironment,
 } from "./sandbox-exec-server.js";
 import { createSandboxContext } from "./sandbox-exec-server.test-helpers.js";
-import { resetCodexTestBindingStore } from "./session-binding.test-helpers.js";
+import {
+  createCodexTestBindingStore,
+  resetCodexTestBindingStore,
+  type CodexAppServerBindingIdentity,
+} from "./session-binding.test-helpers.js";
 import {
   readCodexAppServerBinding,
   registerCodexTestSessionIdentity,
@@ -2547,6 +2551,83 @@ describe("runCodexAppServerAttempt", () => {
     await expect(runCodexAppServerAttempt(createParams(sessionFile, workspaceDir))).rejects.toThrow(
       "Codex app-server cannot enforce before_prompt_build toolsAllow",
     );
+  });
+
+  it("releases adopted startup resources when continuity prompt rebuilding fails", async () => {
+    let promptBuildCount = 0;
+    const beforePromptBuild = vi.fn(async () => {
+      promptBuildCount += 1;
+      return { toolsAllow: promptBuildCount === 1 ? ["*"] : ["message"] };
+    });
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_prompt_build", handler: beforePromptBuild }]),
+    );
+    const { sessionFile, workspaceDir } = createRunPaths();
+    openRunSession(sessionFile).appendMessage(userMessage("previous request", Date.now()));
+    const { closeAndWait, events, retireSpy, state } = installCleanupTrackingClient();
+    const abortController = new AbortController();
+    const removeAbortListener = vi.spyOn(abortController.signal, "removeEventListener");
+    const params = createParams(sessionFile, workspaceDir);
+    params.abortSignal = abortController.signal;
+    params.cleanupBundleMcpOnRunEnd = true;
+
+    await expect(runCodexAppServerAttempt(params)).rejects.toThrow(
+      "Codex app-server cannot enforce before_prompt_build toolsAllow",
+    );
+
+    expect(beforePromptBuild).toHaveBeenCalledTimes(2);
+    expect(events).toContain("request:thread/start");
+    expect(events).not.toContain("request:turn/start");
+    expect(retireSpy).toHaveBeenCalledOnce();
+    expect(retireSpy).toHaveBeenCalledWith(state.client);
+    expect(closeAndWait).toHaveBeenCalledOnce();
+    expect(removeAbortListener).toHaveBeenCalledWith("abort", expect.any(Function));
+  });
+
+  it("preserves binding retention errors while releasing fundamental resources", async () => {
+    const bindingStore = createCodexTestBindingStore();
+    const originalWithLease = bindingStore.withLease.bind(bindingStore);
+    const { sessionFile, workspaceDir } = createRunPaths();
+    const params = createParams(sessionFile, workspaceDir);
+    let failBindingRetention = false;
+    let bindingCleanupFailures = 0;
+    const failingBindingStore: typeof bindingStore = {
+      ...bindingStore,
+      async withLease<T>(
+        identity: CodexAppServerBindingIdentity,
+        run: () => Promise<T>,
+      ): Promise<T> {
+        if (!failBindingRetention) {
+          return await originalWithLease(identity, run);
+        }
+        bindingCleanupFailures += 1;
+        params.cleanupBundleMcpOnRunEnd = true;
+        throw new Error("binding retention cleanup failed");
+      },
+    };
+    const { closeAndWait, events, retireSpy, state } = installCleanupTrackingClient();
+    const abortController = new AbortController();
+    const removeAbortListener = vi.spyOn(abortController.signal, "removeEventListener");
+    params.abortSignal = abortController.signal;
+    const run = runCodexAppServerAttempt(params, { bindingStore: failingBindingStore });
+    await vi.waitFor(() => expect(events).toContain("request:turn/start"), fastWait);
+    failBindingRetention = true;
+    if (!state.notify) {
+      throw new Error("expected turn notification handler");
+    }
+    await state.notify(turnCompleted({ id: "turn-1", status: "completed" }));
+
+    await expect(run).rejects.toThrow("binding retention cleanup failed");
+
+    expect(bindingCleanupFailures).toBe(1);
+    expect(params.cleanupBundleMcpOnRunEnd).toBe(true);
+    expect(events).toContain("request:turn/start");
+    expect(events).toContain("closeAndWait");
+    expect(retireSpy).toHaveBeenCalledOnce();
+    expect(retireSpy).toHaveBeenCalledWith(state.client);
+    expect(closeAndWait).toHaveBeenCalledOnce();
+    expect(removeAbortListener).toHaveBeenCalledWith("abort", expect.any(Function));
+    expect(queueActiveRunMessageForTest("session-1", "after cleanup")).toBe(false);
   });
 
   it("projects bounded continuity when starting Codex without a native thread binding", async () => {

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -87,6 +87,7 @@ import {
 
 let listCodexAppServerModels: typeof import("./models.js").listCodexAppServerModels;
 let clearSharedCodexAppServerClient: typeof import("./shared-client.js").clearSharedCodexAppServerClient;
+let clearSharedCodexAppServerClientAndWait: typeof import("./shared-client.js").clearSharedCodexAppServerClientAndWait;
 let clearSharedCodexAppServerClientIfCurrent: typeof import("./shared-client.js").clearSharedCodexAppServerClientIfCurrent;
 let clearSharedCodexAppServerClientIfCurrentAndUnclaimed: typeof import("./shared-client.js").clearSharedCodexAppServerClientIfCurrentAndUnclaimed;
 let clearSharedCodexAppServerClientIfCurrentAndWait: typeof import("./shared-client.js").clearSharedCodexAppServerClientIfCurrentAndWait;
@@ -190,6 +191,7 @@ describe("shared Codex app-server client", () => {
     ({ listCodexAppServerModels } = await import("./models.js"));
     ({
       clearSharedCodexAppServerClient,
+      clearSharedCodexAppServerClientAndWait,
       clearSharedCodexAppServerClientIfCurrent,
       clearSharedCodexAppServerClientIfCurrentAndUnclaimed,
       clearSharedCodexAppServerClientIfCurrentAndWait,
@@ -1942,6 +1944,31 @@ describe("shared Codex app-server client", () => {
 
     expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
     expect(first.process.stdin.destroyed).toBe(true);
+  });
+
+  it("globally disposes a gracefully detached client with an explicit retain", async () => {
+    const harness = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start").mockReturnValueOnce(harness.client);
+
+    const lease = getLeasedSharedCodexAppServerClient({ timeoutMs: 1000 });
+    await sendInitializeResult(harness, "openclaw/0.147.0 (Linux; test)");
+    const client = await lease;
+    const releaseRetain = retainSharedCodexAppServerClientIfCurrent(client);
+    expect(releaseRetain).toBeTypeOf("function");
+
+    expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
+    expect(retireSharedCodexAppServerClientIfCurrent(client)).toEqual({
+      activeLeases: 1,
+      closed: false,
+    });
+    expect(harness.process.stdin.destroyed).toBe(false);
+
+    await clearSharedCodexAppServerClientAndWait({
+      exitTimeoutMs: 25,
+      forceKillDelayMs: 5,
+    });
+    expect(harness.process.stdin.destroyed).toBe(true);
+    releaseRetain?.();
   });
 
   it("waits only for the shared client that is still current", async () => {

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -59,6 +59,7 @@ type SharedCodexAppServerClientStartup = {
 
 type SharedCodexAppServerClientState = {
   clients: Map<string, SharedCodexAppServerClientEntry>;
+  liveClients: Set<CodexAppServerClient>;
   entriesByClient: WeakMap<CodexAppServerClient, SharedCodexAppServerClientEntry>;
   leasedReleases: WeakMap<CodexAppServerClient, Array<() => void>>;
   warmClientsByConfig?: WeakMap<
@@ -118,6 +119,7 @@ function getSharedCodexAppServerClientState(): SharedCodexAppServerClientState {
   };
   globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE] ??= {
     clients: new Map(),
+    liveClients: new Set(),
     entriesByClient: new WeakMap(),
     leasedReleases: new WeakMap(),
   };
@@ -843,8 +845,16 @@ function createSharedCodexAppServerClientStartup(params: {
     runtimeArtifactSignal: params.runtimeArtifactSignal,
     config: params.config,
     onStartedClient: (startedClient) => {
+      const state = getSharedCodexAppServerClientState();
       params.entry.client = startedClient;
-      getSharedCodexAppServerClientState().entriesByClient.set(startedClient, params.entry);
+      state.entriesByClient.set(startedClient, params.entry);
+      // Graceful retirement detaches active clients from the acquisition map,
+      // so global teardown tracks physical lifetime until the close notification.
+      state.liveClients.add(startedClient);
+      startedClient.addCloseHandler((closedClient) => {
+        getSharedCodexAppServerClientState().liveClients.delete(closedClient);
+        clearSharedClientEntryIfCurrent(params.key, closedClient);
+      });
       for (const callback of params.entry.onStartedClientCallbacks) {
         callback(startedClient);
       }
@@ -854,9 +864,6 @@ function createSharedCodexAppServerClientStartup(params: {
   }).then(
     (client) => {
       params.entry.client = client;
-      client.addCloseHandler((closedClient) =>
-        clearSharedClientEntryIfCurrent(params.key, closedClient),
-      );
       return client;
     },
     (error: unknown) => {
@@ -1402,12 +1409,6 @@ function retirePendingSharedClientEntryIfUnclaimed(
 }
 
 function collectSharedClients(state: SharedCodexAppServerClientState): CodexAppServerClient[] {
-  return [
-    ...new Set(
-      [...state.clients.values()]
-        .map((entry) => entry.client)
-        .filter((client): client is CodexAppServerClient => Boolean(client)),
-    ),
-  ];
+  return [...state.liveClients];
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/agent-bundle-mcp-manager.ts
+++ b/src/agents/agent-bundle-mcp-manager.ts
@@ -214,8 +214,12 @@ export function createSessionMcpRuntimeManager(
       });
     },
     async getOrCreateRequesterScoped(params) {
-      // Scoped-only path for shared-thread harnesses: never open static transports
-      // (those stay harness-native) so we do not double-connect.
+      // Anonymous turns own no requester runtime; avoid leaking session keys or
+      // sweeping unrelated runtimes before confirming the requester exists.
+      const requesterSenderId = normalizeOptionalString(params.requesterSenderId);
+      if (!requesterSenderId) {
+        return undefined;
+      }
       const idleTtlMs = resolveSessionMcpRuntimeIdleTtlMs();
       await lifecycle.sweepIdleRuntimes();
       if (idleTtlMs > 0) {
@@ -223,10 +227,6 @@ export function createSessionMcpRuntimeManager(
       }
       if (params.sessionKey) {
         store.sessionIdBySessionKey.set(params.sessionKey, params.sessionId);
-      }
-      const requesterSenderId = normalizeOptionalString(params.requesterSenderId);
-      if (!requesterSenderId) {
-        return undefined;
       }
       const fullConfig = loadSessionMcpConfig({
         workspaceDir: params.workspaceDir,

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -4501,7 +4501,7 @@ describe("requester-scoped MCP connection resolution", () => {
     await manager.disposeAll();
   });
 
-  it("getOrCreateRequesterScoped returns undefined without senderId and never creates static transports", async () => {
+  it("rejects anonymous requester identities before touching existing requester state", async () => {
     const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
     resolverTesting.setMcpServerConnectionResolversForTest([
       {
@@ -4516,7 +4516,10 @@ describe("requester-scoped MCP connection resolution", () => {
       include?: string[];
       exclude?: string[];
     }> = [];
+    const dispose = vi.fn(async () => {});
+    let nowMs = 100_000;
     const createRuntime: RuntimeFactory = (params) => {
+      const createdAt = nowMs;
       created.push({
         requesterScope: params.requesterScope,
         include: params.includeServerNames ? [...params.includeServerNames] : undefined,
@@ -4528,9 +4531,14 @@ describe("requester-scoped MCP connection resolution", () => {
         workspaceDir: params.workspaceDir,
         configFingerprint: params.configFingerprint ?? "fingerprint",
         requesterScope: params.requesterScope,
+        get lastUsedAt() {
+          return createdAt;
+        },
+        markUsed: () => {},
+        dispose,
       };
     };
-    const now = vi.fn(() => Date.now());
+    const now = vi.fn(() => nowMs);
     const manager = testing.createSessionMcpRuntimeManager({ createRuntime, now });
     const cfg = {
       mcp: {
@@ -4541,39 +4549,59 @@ describe("requester-scoped MCP connection resolution", () => {
       },
     };
 
-    for (const { sessionId, requesterSenderId } of [
-      { sessionId: "session-scoped-only", requesterSenderId: undefined },
-      { sessionId: "session-scoped-empty", requesterSenderId: "  " },
-      { sessionId: "session-scoped-null", requesterSenderId: null },
-    ]) {
-      const sessionKey = `agent:main:${sessionId}`;
-      await expect(
-        manager.getOrCreateRequesterScoped({
-          sessionId,
-          sessionKey,
-          requesterSenderId,
-          workspaceDir: "/workspace",
-          cfg: cfg as never,
-        }),
-      ).resolves.toBeUndefined();
-      expect(manager.resolveSessionId(sessionKey)).toBeUndefined();
-    }
-    expect(created).toEqual([]);
-    expect(now).not.toHaveBeenCalled();
-    expect(testing.getBookkeepingSizes(manager)).toMatchObject({ runtimes: 0, sessionKeys: 0 });
-
+    const sessionId = "session-scoped-only";
+    const sessionKey = "agent:main:session-scoped-only";
     const scoped = await manager.getOrCreateRequesterScoped({
-      sessionId: "session-scoped-only",
-      sessionKey: "agent:main:session-scoped-only",
+      sessionId,
+      sessionKey,
       workspaceDir: "/workspace",
       cfg: cfg as never,
       requesterSenderId: "sender-a",
       messageChannel: "telegram",
     });
     expect(scoped?.requesterScope?.requesterSenderId).toBe("sender-a");
-    expect(manager.resolveSessionId("agent:main:session-scoped-only")).toBe("session-scoped-only");
-    expect(now).toHaveBeenCalled();
-    // Only the requester partition — no bare static runtime entry.
+    await vi.waitFor(() =>
+      expect(testing.getBookkeepingSizes(manager).requesterWorkChains).toBe(0),
+    );
+    const runtimeKeys = manager.listRuntimeKeys();
+    const bookkeeping = testing.getBookkeepingSizes(manager);
+    expect(runtimeKeys).toHaveLength(1);
+    expect(runtimeKeys[0]).toMatch(/^\{/);
+    expect(manager.resolveSessionId(sessionKey)).toBe(sessionId);
+    expect(created).toHaveLength(1);
+    expect(bookkeeping).toMatchObject({
+      runtimes: 1,
+      connectionMeta: 1,
+      requesterWorkChains: 0,
+      sessionKeys: 1,
+      idleTtl: 1,
+    });
+
+    now.mockClear();
+    nowMs += testing.resolveSessionMcpRuntimeIdleTtlMs() + 1;
+    for (const [requesterSenderId, attemptedSessionId] of [
+      [undefined, "session-missing"],
+      ["  ", "session-blank"],
+      [null, "session-null"],
+    ] as const) {
+      await expect(
+        manager.getOrCreateRequesterScoped({
+          sessionId: attemptedSessionId,
+          sessionKey,
+          requesterSenderId,
+          workspaceDir: "/workspace",
+          cfg: cfg as never,
+        }),
+      ).resolves.toBeUndefined();
+      expect(manager.resolveSessionId(sessionKey)).toBe(sessionId);
+    }
+
+    expect(now).not.toHaveBeenCalled();
+    expect(dispose).not.toHaveBeenCalled();
+    expect(manager.listRuntimeKeys()).toEqual(runtimeKeys);
+    expect(testing.getBookkeepingSizes(manager)).toEqual(bookkeeping);
+    // The existing requester partition remains the only runtime; no static or
+    // anonymous replacement runtime was created.
     expect(created).toEqual([
       {
         requesterScope: {
@@ -4584,7 +4612,6 @@ describe("requester-scoped MCP connection resolution", () => {
         exclude: undefined,
       },
     ]);
-    expect(manager.listRuntimeKeys().every((key) => key.startsWith("{"))).toBe(true);
 
     await manager.disposeAll();
   });

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -4530,7 +4530,8 @@ describe("requester-scoped MCP connection resolution", () => {
         requesterScope: params.requesterScope,
       };
     };
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const now = vi.fn(() => Date.now());
+    const manager = testing.createSessionMcpRuntimeManager({ createRuntime, now });
     const cfg = {
       mcp: {
         servers: {
@@ -4540,23 +4541,38 @@ describe("requester-scoped MCP connection resolution", () => {
       },
     };
 
-    await expect(
-      manager.getOrCreateRequesterScoped({
-        sessionId: "session-scoped-only",
-        workspaceDir: "/workspace",
-        cfg: cfg as never,
-      }),
-    ).resolves.toBeUndefined();
+    for (const { sessionId, requesterSenderId } of [
+      { sessionId: "session-scoped-only", requesterSenderId: undefined },
+      { sessionId: "session-scoped-empty", requesterSenderId: "  " },
+      { sessionId: "session-scoped-null", requesterSenderId: null },
+    ]) {
+      const sessionKey = `agent:main:${sessionId}`;
+      await expect(
+        manager.getOrCreateRequesterScoped({
+          sessionId,
+          sessionKey,
+          requesterSenderId,
+          workspaceDir: "/workspace",
+          cfg: cfg as never,
+        }),
+      ).resolves.toBeUndefined();
+      expect(manager.resolveSessionId(sessionKey)).toBeUndefined();
+    }
     expect(created).toEqual([]);
+    expect(now).not.toHaveBeenCalled();
+    expect(testing.getBookkeepingSizes(manager)).toMatchObject({ runtimes: 0, sessionKeys: 0 });
 
     const scoped = await manager.getOrCreateRequesterScoped({
       sessionId: "session-scoped-only",
+      sessionKey: "agent:main:session-scoped-only",
       workspaceDir: "/workspace",
       cfg: cfg as never,
       requesterSenderId: "sender-a",
       messageChannel: "telegram",
     });
     expect(scoped?.requesterScope?.requesterSenderId).toBe("sender-a");
+    expect(manager.resolveSessionId("agent:main:session-scoped-only")).toBe("session-scoped-only");
+    expect(now).toHaveBeenCalled();
     // Only the requester partition — no bare static runtime entry.
     expect(created).toEqual([
       {

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -83,7 +83,7 @@ afterAll(async () => {
 });
 
 afterEach(async () => {
-  for (const state of cleanupTestStates.splice(0).reverse()) {
+  for (const state of cleanupTestStates.splice(0).toReversed()) {
     await state.cleanup();
   }
   await Promise.all(

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -31,6 +31,10 @@ import * as transcriptEvents from "../sessions/transcript-events.js";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { persistUserTurnTranscript } from "../sessions/user-turn-transcript.test-support.js";
 import { ensureProfileForEmail, setAvatar, setDisplayName } from "../state/user-profiles.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import { resolveCurrentUserProfileDisplay } from "./current-user-profile-display.js";
 import { testState } from "./test-helpers.runtime-state.js";
 import {
@@ -50,6 +54,7 @@ import { createWorkerTranscriptCommitter } from "./worker-environments/transcrip
 installGatewayTestHooks({ scope: "suite" });
 
 const cleanupDirs: string[] = [];
+const cleanupTestStates: OpenClawTestState[] = [];
 const SETUP_RPC_TIMEOUT_MS = 30_000;
 let harness: Awaited<ReturnType<typeof createGatewaySuiteHarness>>;
 let subscribedOperatorWs:
@@ -78,6 +83,9 @@ afterAll(async () => {
 });
 
 afterEach(async () => {
+  for (const state of cleanupTestStates.splice(0).reverse()) {
+    await state.cleanup();
+  }
   await Promise.all(
     cleanupDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
   );
@@ -943,6 +951,11 @@ describe("session.message websocket events", () => {
 
   test("projects current revisioned sender avatars consistently across live events and RPC reads", async () => {
     const SHARED_REV = 1_800_000_000_000;
+    const profileState = await createOpenClawTestState({
+      label: "session-message-current-profile-display",
+      layout: "state-only",
+    });
+    cleanupTestStates.push(profileState);
     const storePath = await createSessionStoreFile();
     const sessionId = "sess-current-profile-display";
     const sessionKey = "agent:main:current-profile-display";


### PR DESCRIPTION
## What Problem This Solves

MCP discovery could release the bound Codex app-server client before cursor pagination settled. Anonymous requester-scoped calls could also sweep unrelated runtimes and overwrite session-key state before confirming a requester owner. Adjacent cleanup paths could leak adopted Codex resources after post-start failures or omit gracefully detached clients during global shutdown.

## Why This Change Was Made

The repair puts ownership checks and releases at their lifecycle owners: requester identity is validated before shared-state mutation; retained clients stay leased through asynchronous work; post-start and terminal cleanup always releases fundamental resources; and global disposal tracks physical clients independently of the acquisition map.

## User Impact

Prevents intermittent missing MCP tools, stale requester-runtime mappings, leaked Codex app-server resources, and shutdowns that leave a detached client alive.

## Evidence

- Focused boundary tests: 277 passing across the effective catalog, shared-client lifecycle, run-attempt cleanup, and requester-runtime suites.
- Exact-dependency changed-file gate passed formatting, guard tests, SDK/API contracts, plugin boundaries, dead-code scans, all four TypeScript lanes, targeted lint, schema/store guards, and import-cycle checks.
- Exact-head CI initially exposed an unrelated gateway profile-state flake; the test now owns a per-test SQLite state root, reproduced before and passed 10/10 plus the 4,887-test gateway-core envelope after.
- `git diff --check` passed.
- Fresh Codex autoreview passed with no accepted/actionable findings.
- Upstream Codex app-server pagination and asynchronous MCP status collection were verified directly in source.
- No live gateway/app-server E2E was run; deterministic ownership tests plus exact-head CI cover the changed boundaries.
