### PR TITLE
fix(ai): preserve final ChatGPT Responses frames at stream end

### DIFF
--- a/packages/ai/src/providers/openai-chatgpt-responses-streaming.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses-streaming.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost } from "../host.js";
+import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../transports/transport-utils.js";
 import type { Context, Model } from "../types.js";
 import {
   closeOpenAICodexWebSocketSessions,
@@ -444,5 +445,57 @@ describe("ChatGPT Responses SSE frame boundaries", () => {
     }
 
     expect(canceled).toBe(true);
+  });
+
+  function streamOf(...chunks: string[]): ReadableStream<Uint8Array> {
+    const encoded = chunks.map((chunk) => new TextEncoder().encode(chunk));
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of encoded) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    });
+  }
+
+  it("parses a trailing frame that reaches EOF without its blank-line terminator", async () => {
+    // A proxy that trims the final "\n\n" must not cost the terminal event:
+    // the residue is still a complete data frame.
+    const events: Record<string, unknown>[] = [];
+    for await (const event of parseSSEForTest(
+      new Response(
+        streamOf(
+          'data: {"type":"response.output_item.done"}\n\n',
+          'data: {"type":"response.completed"}',
+        ),
+      ),
+    )) {
+      events.push(event);
+    }
+    expect(events.map((event) => event.type)).toEqual([
+      "response.output_item.done",
+      "response.completed",
+    ]);
+  });
+
+  it("does not duplicate the final frame when the stream ends with a blank line", async () => {
+    const events: Record<string, unknown>[] = [];
+    for await (const event of parseSSEForTest(
+      new Response(streamOf('data: {"type":"response.completed"}\n\n')),
+    )) {
+      events.push(event);
+    }
+    expect(events).toHaveLength(1);
+  });
+
+  it("rejects a malformed trailing frame at EOF", async () => {
+    await expect(async () => {
+      for await (const event of parseSSEForTest(
+        new Response(streamOf('data: {"type":"response.output_item.done"}\n\n', "data: {not-json")),
+      )) {
+        void event;
+      }
+    }).rejects.toThrow(MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE);
   });
 });

--- a/packages/ai/src/providers/openai-chatgpt-responses.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.test.ts
@@ -4,6 +4,7 @@ import { zstdDecompressSync } from "node:zlib";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost } from "../host.js";
+import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../transports/transport-utils.js";
 import type { Context, Model } from "../types.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
 import {
@@ -1110,5 +1111,57 @@ describe("parseSSEForTest", () => {
     // 16 MiB + a couple of overshoot pulls, well under 32.
     expect(pullCount).toBeGreaterThanOrEqual(17);
     expect(pullCount).toBeLessThanOrEqual(20);
+  });
+
+  function streamOf(...chunks: string[]): ReadableStream<Uint8Array> {
+    const encoded = chunks.map((chunk) => new TextEncoder().encode(chunk));
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of encoded) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    });
+  }
+
+  it("parses a trailing frame that reaches EOF without its blank-line terminator", async () => {
+    // A proxy that trims the final "\n\n" must not cost the terminal event:
+    // the residue is still a complete data frame.
+    const events: Record<string, unknown>[] = [];
+    for await (const event of parseSSEForTest(
+      new Response(
+        streamOf(
+          'data: {"type":"response.output_item.done"}\n\n',
+          'data: {"type":"response.completed"}',
+        ),
+      ),
+    )) {
+      events.push(event);
+    }
+    expect(events.map((event) => event.type)).toEqual([
+      "response.output_item.done",
+      "response.completed",
+    ]);
+  });
+
+  it("does not duplicate the final frame when the stream ends with a blank line", async () => {
+    const events: Record<string, unknown>[] = [];
+    for await (const event of parseSSEForTest(
+      new Response(streamOf('data: {"type":"response.completed"}\n\n')),
+    )) {
+      events.push(event);
+    }
+    expect(events).toHaveLength(1);
+  });
+
+  it("rejects a malformed trailing frame at EOF", async () => {
+    await expect(async () => {
+      for await (const event of parseSSEForTest(
+        new Response(streamOf('data: {"type":"response.output_item.done"}\n\n', "data: {not-json")),
+      )) {
+        void event;
+      }
+    }).rejects.toThrow(MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE);
   });
 });

--- a/packages/ai/src/providers/openai-chatgpt-responses.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.test.ts
@@ -4,7 +4,6 @@ import { zstdDecompressSync } from "node:zlib";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost } from "../host.js";
-import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../transports/transport-utils.js";
 import type { Context, Model } from "../types.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
 import {
@@ -1111,57 +1110,5 @@ describe("parseSSEForTest", () => {
     // 16 MiB + a couple of overshoot pulls, well under 32.
     expect(pullCount).toBeGreaterThanOrEqual(17);
     expect(pullCount).toBeLessThanOrEqual(20);
-  });
-
-  function streamOf(...chunks: string[]): ReadableStream<Uint8Array> {
-    const encoded = chunks.map((chunk) => new TextEncoder().encode(chunk));
-    return new ReadableStream<Uint8Array>({
-      start(controller) {
-        for (const chunk of encoded) {
-          controller.enqueue(chunk);
-        }
-        controller.close();
-      },
-    });
-  }
-
-  it("parses a trailing frame that reaches EOF without its blank-line terminator", async () => {
-    // A proxy that trims the final "\n\n" must not cost the terminal event:
-    // the residue is still a complete data frame.
-    const events: Record<string, unknown>[] = [];
-    for await (const event of parseSSEForTest(
-      new Response(
-        streamOf(
-          'data: {"type":"response.output_item.done"}\n\n',
-          'data: {"type":"response.completed"}',
-        ),
-      ),
-    )) {
-      events.push(event);
-    }
-    expect(events.map((event) => event.type)).toEqual([
-      "response.output_item.done",
-      "response.completed",
-    ]);
-  });
-
-  it("does not duplicate the final frame when the stream ends with a blank line", async () => {
-    const events: Record<string, unknown>[] = [];
-    for await (const event of parseSSEForTest(
-      new Response(streamOf('data: {"type":"response.completed"}\n\n')),
-    )) {
-      events.push(event);
-    }
-    expect(events).toHaveLength(1);
-  });
-
-  it("rejects a malformed trailing frame at EOF", async () => {
-    await expect(async () => {
-      for await (const event of parseSSEForTest(
-        new Response(streamOf('data: {"type":"response.output_item.done"}\n\n', "data: {not-json")),
-      )) {
-        void event;
-      }
-    }).rejects.toThrow(MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE);
   });
 });

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -884,6 +884,32 @@ async function* parseSSE(response: Response): AsyncGenerator<Record<string, unkn
   const decoder = new TextDecoder();
   let buffer = "";
 
+  // Parse one complete SSE frame into its event payload. Returns undefined for
+  // comment/heartbeat frames and the [DONE] sentinel.
+  const parseFrameEvent = (chunk: string): Record<string, unknown> | undefined => {
+    const dataLines = chunk
+      .split(/\r\n|\r|\n/)
+      .filter((l) => l.startsWith("data:"))
+      .map((l) => l.slice(5).trim());
+    if (dataLines.length === 0) {
+      return undefined;
+    }
+    const data = dataLines.join("\n").trim();
+    if (!data || data === "[DONE]") {
+      return undefined;
+    }
+    try {
+      return JSON.parse(data) as Record<string, unknown>;
+    } catch (cause) {
+      if (!(cause instanceof SyntaxError)) {
+        throw cause;
+      }
+      // Align with the canonical transport contract: the shared marker is what
+      // assistant error formatting maps to the malformed-fragment retry copy.
+      throw new CodexProtocolError(MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE, { cause });
+    }
+  };
+
   try {
     while (true) {
       const { done, value } = await guard.read();
@@ -907,32 +933,23 @@ async function* parseSSE(response: Response): AsyncGenerator<Record<string, unkn
         const chunk = buffer.slice(0, boundary.index);
         buffer = buffer.slice(boundary.index + boundary[0].length);
 
-        const dataLines = chunk
-          .split(/\r\n|\r|\n/)
-          .filter((l) => l.startsWith("data:"))
-          .map((l) => l.slice(5).trim());
-        if (dataLines.length > 0) {
-          const data = dataLines.join("\n").trim();
-          if (data && data !== "[DONE]") {
-            let event: Record<string, unknown>;
-            try {
-              event = JSON.parse(data) as Record<string, unknown>;
-            } catch (cause) {
-              if (!(cause instanceof SyntaxError)) {
-                throw cause;
-              }
-              // Align with the canonical transport contract: the shared marker is what
-              // assistant error formatting maps to the malformed-fragment retry copy.
-              throw new CodexProtocolError(MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE, { cause });
-            }
-            // Keep suspension outside the parse catch so iterator.throw() cannot relabel a
-            // consumer failure as malformed provider input.
-            yield event;
-          }
+        const event = parseFrameEvent(chunk);
+        if (event !== undefined) {
+          // Keep suspension outside the parse catch so iterator.throw() cannot relabel a
+          // consumer failure as malformed provider input.
+          yield event;
         }
       }
 
       if (done) {
+        // A proxy that drops the trailing blank line would otherwise silently
+        // discard the final frame (often response.completed), which surfaces
+        // downstream as a confusing "ended before a terminal response event".
+        // Parse any non-empty residue as one last frame instead.
+        const tailEvent = parseFrameEvent(buffer);
+        if (tailEvent !== undefined) {
+          yield tailEvent;
+        }
         break;
       }
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ChatGPT Responses turns fail when a proxy or endpoint omits the final blank line of the event stream. OpenClaw discards the final completion event, retries the turn, and eventually reports a timeout. Malformed final data is also discarded and produces the wrong error.

## Why This Change Was Made

The canonical protocol parser now consumes the remaining frame at end-of-stream through its existing frame parser. This ports the contributor's repair to the owner introduced by #122930, without restoring the old parser or adding another parsing path.

The earlier SDK-parity claim is withdrawn: inspecting OpenAI SDK 6.49.0 confirms that its line decoder flush alone does not establish dispatch of an undelimited SSE event. This change implements the requested EOF recovery and matches OpenClaw's existing Anthropic tail policy. It changes no stored data, schema, configuration, or migration contract.

## User Impact

Valid final responses complete normally. Malformed final data produces the existing malformed-fragment guidance. Delimited frames, consumer errors, stream limits, WebSocket behavior, retries, and cache policy retain their existing handling.

## Evidence

- Built public `openclaw agent --local` with synthetic credentials and a guarded local TLS endpoint; no ChatGPT contact or request-body capture.
- Baseline `87261acd0557`: a delimited control returns one exact answer. Both valid and malformed undelimited tails report `OpenAI Responses stream ended before a terminal response event`; the public command ultimately reports `LLM request timed out.`
- Original-source regression run: eight expected failures and 23 passing controls.
- Candidate: 114 focused protocol/provider tests pass, including the 16 MiB limit, cancellation, consumer failures, timeout/retry, cache, and WebSocket controls.
- Candidate `f5ac482410a4`: the same public valid-tail turn returns the exact answer with one request; malformed-tail output is `LLM streaming response contained a malformed fragment. Please try again.` All per-case cleanup checks pass.
- Independent source review is clean. Source-blind public acceptance passes all nine scenarios, including multiline data, CRLF, Unicode byte writes, comments, empty data, and `[DONE]` before completion.
- Targeted lint, formatting, size and assertion checks pass. Exact-head hosted checks are in progress.
