### PR TITLE
fix(discord): remove temporary voice files after failed sends

### DIFF
--- a/extensions/discord/src/send.voice.test.ts
+++ b/extensions/discord/src/send.voice.test.ts
@@ -2,12 +2,18 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeDiscordRest } from "./send.test-harness.js";
 
 const loadWebMediaRawMock = vi.hoisted(() => vi.fn());
 vi.mock("openclaw/plugin-sdk/web-media", () => ({
   loadWebMediaRaw: loadWebMediaRawMock,
+}));
+
+const tempPathMocks = vi.hoisted(() => ({ rootDir: "" }));
+vi.mock("openclaw/plugin-sdk/temp-path", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/temp-path")>()),
+  resolvePreferredOpenClawTmpDir: () => tempPathMocks.rootDir,
 }));
 
 const voiceMocks = vi.hoisted(() => ({
@@ -25,7 +31,14 @@ let sendVoiceMessageDiscord: typeof import("./send.voice.js").sendVoiceMessageDi
 
 describe("sendVoiceMessageDiscord", () => {
   beforeAll(async () => {
+    tempPathMocks.rootDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-discord-voice-send-"),
+    );
     ({ sendVoiceMessageDiscord } = await import("./send.voice.js"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tempPathMocks.rootDir, { recursive: true, force: true });
   });
 
   beforeEach(() => {
@@ -45,6 +58,32 @@ describe("sendVoiceMessageDiscord", () => {
       id: "msg1",
       channel_id: "273512430271856640",
     });
+  });
+
+  it("validates runtime config before materializing voice media", async () => {
+    await expect(
+      sendVoiceMessageDiscord("273512430271856640", "https://example.com/voice.ogg", {
+        cfg: undefined as never,
+      }),
+    ).rejects.toThrow(/requires a resolved runtime config/i);
+
+    expect(loadWebMediaRawMock).not.toHaveBeenCalled();
+    await expect(fs.readdir(tempPathMocks.rootDir)).resolves.toEqual([]);
+  });
+
+  it("cleans materialized voice media when pre-send conversion fails", async () => {
+    const { rest } = makeDiscordRest();
+    voiceMocks.ensureOggOpus.mockRejectedValueOnce(new Error("ffmpeg unavailable"));
+
+    await expect(
+      sendVoiceMessageDiscord("273512430271856640", "https://example.com/voice.ogg", {
+        cfg: DISCORD_TEST_CFG,
+        rest,
+        token: "t",
+      }),
+    ).rejects.toThrow("ffmpeg unavailable");
+
+    await expect(fs.readdir(tempPathMocks.rootDir)).resolves.toEqual([]);
   });
 
   it("treats bare numeric voice targets as channels", async () => {

--- a/extensions/discord/src/send.voice.ts
+++ b/extensions/discord/src/send.voice.ts
@@ -9,7 +9,7 @@ import {
   unlinkIfExists,
 } from "openclaw/plugin-sdk/media-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
-import { tempWorkspace, resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+import { withTempWorkspace, resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { loadWebMediaRaw } from "openclaw/plugin-sdk/web-media";
 import { resolveDiscordAccount } from "./accounts.js";
 import type { RequestClient } from "./internal/discord.js";
@@ -53,10 +53,11 @@ function toDiscordSendResult(
   });
 }
 
-async function materializeVoiceMessageInput(
+async function withMaterializedVoiceMessageInput<T>(
   mediaUrl: string,
   opts: VoiceMessageOpts,
-): Promise<{ filePath: string; cleanup: () => Promise<void> }> {
+  run: (filePath: string) => Promise<T>,
+): Promise<T> {
   // Security: reuse the standard media loader so we apply SSRF guards + allowed-local-root checks.
   // Then write to a private temp file so ffmpeg/ffprobe never sees the original URL/path string.
   const media = await loadWebMediaRaw(
@@ -71,15 +72,13 @@ async function materializeVoiceMessageInput(
   const extFromName = media.fileName ? path.extname(media.fileName) : "";
   const extFromMime = media.contentType ? extensionForMime(media.contentType) : "";
   const ext = extFromName || extFromMime || ".bin";
-  const workspace = await tempWorkspace({
-    rootDir: resolvePreferredOpenClawTmpDir(),
-    prefix: "voice-src-",
-  });
-  const filePath = await workspace.write(`input${ext}`, media.buffer);
-  return {
-    filePath,
-    cleanup: () => workspace.cleanup().then(() => undefined),
-  };
+  return await withTempWorkspace(
+    {
+      rootDir: resolvePreferredOpenClawTmpDir(),
+      prefix: "voice-src-",
+    },
+    async (workspace) => await run(await workspace.write(`input${ext}`, media.buffer)),
+  );
 }
 
 /**
@@ -97,64 +96,63 @@ export async function sendVoiceMessageDiscord(
   audioPath: string,
   opts: VoiceMessageOpts,
 ): Promise<DiscordSendResult> {
-  const { filePath: localInputPath, cleanup: cleanupLocalInput } =
-    await materializeVoiceMessageInput(audioPath, opts);
-  let oggPath: string | null = null;
-  let oggCleanup = false;
-  let token: string | undefined;
-  let rest: RequestClient | undefined;
-  let channelId: string | undefined;
   const cfg = requireRuntimeConfig(opts.cfg, "Discord voice send");
+  return await withMaterializedVoiceMessageInput(audioPath, opts, async (localInputPath) => {
+    let oggPath: string | null = null;
+    let oggCleanup = false;
+    let token: string | undefined;
+    let rest: RequestClient | undefined;
+    let channelId: string | undefined;
 
-  try {
-    const accountInfo = resolveDiscordAccount({
-      cfg,
-      accountId: opts.accountId,
-    });
-    const client = createDiscordClient({ ...opts, cfg });
-    token = client.token;
-    rest = client.rest;
-    const request = client.request;
-    const recipient = await parseAndResolveChannelRecipient(to, cfg, opts.accountId);
-    channelId = (await resolveChannelId(rest, recipient, request)).channelId;
-
-    const ogg = await ensureOggOpus(localInputPath);
-    oggPath = ogg.path;
-    oggCleanup = ogg.cleanup;
-
-    const metadata = await getVoiceMessageMetadata(oggPath);
-    const audioBuffer = await fs.readFile(oggPath);
-    const result = await sendDiscordVoiceMessage(
-      rest,
-      channelId,
-      audioBuffer,
-      metadata,
-      opts.reply?.messageId,
-      request,
-      opts.silent,
-      token,
-    );
-
-    recordChannelActivity({
-      channel: "discord",
-      accountId: accountInfo.accountId,
-      direction: "outbound",
-    });
-
-    return toDiscordSendResult(result, channelId, opts.reply);
-  } catch (err) {
-    if (channelId && rest && token) {
-      throw await buildDiscordSendError(err, {
-        channelId,
+    try {
+      const accountInfo = resolveDiscordAccount({
         cfg,
-        rest,
-        token,
-        hasMedia: true,
+        accountId: opts.accountId,
       });
+      const client = createDiscordClient({ ...opts, cfg });
+      token = client.token;
+      rest = client.rest;
+      const request = client.request;
+      const recipient = await parseAndResolveChannelRecipient(to, cfg, opts.accountId);
+      channelId = (await resolveChannelId(rest, recipient, request)).channelId;
+
+      const ogg = await ensureOggOpus(localInputPath);
+      oggPath = ogg.path;
+      oggCleanup = ogg.cleanup;
+
+      const metadata = await getVoiceMessageMetadata(oggPath);
+      const audioBuffer = await fs.readFile(oggPath);
+      const result = await sendDiscordVoiceMessage(
+        rest,
+        channelId,
+        audioBuffer,
+        metadata,
+        opts.reply?.messageId,
+        request,
+        opts.silent,
+        token,
+      );
+
+      recordChannelActivity({
+        channel: "discord",
+        accountId: accountInfo.accountId,
+        direction: "outbound",
+      });
+
+      return toDiscordSendResult(result, channelId, opts.reply);
+    } catch (err) {
+      if (channelId && rest && token) {
+        throw await buildDiscordSendError(err, {
+          channelId,
+          cfg,
+          rest,
+          token,
+          hasMedia: true,
+        });
+      }
+      throw err;
+    } finally {
+      await unlinkIfExists(oggCleanup ? oggPath : null);
     }
-    throw err;
-  } finally {
-    await unlinkIfExists(oggCleanup ? oggPath : null);
-    await cleanupLocalInput();
-  }
+  });
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where sending a Discord voice message could leave a private materialized media file in OpenClaw's temp directory when configuration validation, account/channel setup, conversion, metadata extraction, file reading, or the Discord send failed.

## Why This Change Was Made

The voice sender acquired its source workspace before validating runtime configuration, while the workspace cleanup owner existed only in a later `try/finally`. Runtime config is now validated before media acquisition, and the materialized input is owned by `withTempWorkspace` for the complete downstream callback. The existing inner OGG cleanup remains responsible for converted output.

This follows the installed `@openclaw/fs-safe` 0.5.2 contract: `withTempWorkspace` cleans the identity-fenced workspace after its callback resolves or rejects. It does not weaken media root/SSRF validation, change Discord request behavior, add a fallback, or require credentials/network access.

Root cause owner: `extensions/discord/src/send.voice.ts` acquired a temp workspace before the only cleanup boundary. The canonical fix places validation before acquisition and makes the acquisition helper own every callback exit.

Production LOC: `+62/-64` (net `-2`). Tests: `+40/-1` (net `+39`).

## User Impact

Failed Discord voice sends no longer retain OpenClaw-owned source-media temp artifacts. Successful sends, converted OGG cleanup, trusted local-media roots, replies, receipts, and channel activity behavior are unchanged.

## Evidence

- Native Windows focused proof: `node scripts/run-vitest.mjs extensions/discord/src/send.voice.test.ts extensions/discord/src/outbound-adapter.test.ts extensions/discord/src/monitor/reply-delivery.test.ts` — 3 files, 81 tests passed with one worker.
- The regression uses a real disposable Windows temp root and real filesystem cleanup while mocking media/Discord boundaries; invalid config performs no media materialization, and a forced pre-send conversion failure leaves the root empty. No Discord request, credential, listener, or operator state was used.
- Exact two-path formatting check and `git diff --check HEAD^ HEAD` passed.
- Fresh-main audit: both touched parent blobs were byte-identical from `b5180b6` through `7f3cc699`; fresh `origin/main` `150670c64ad` added no overlap. Bounded live searches found no open duplicate PR or issue.
- Exact-head synthetic autoreview used a SHA-256-verified `7f3cc699` archive and verified both candidate blobs. TruffleHog was clean; the review returned no accepted/actionable findings and `patch is correct` with confidence `0.97`.
- Independent exact-commit review of `a06cadc16ba68dd6cbe344cffb8d2e730925315b` found no P0/P1 and judged the owner-level lifecycle repair the best fix. It verified config-before-materialization, `withTempWorkspace` cleanup on every callback exit, unchanged cleanup-error precedence, the real Windows filesystem fixture, and non-isolated test state.

Credit: discovered, reproduced, repaired, and independently reviewed through the OpenClaw Windows Auto-QA campaign.
