### PR TITLE
fix(doctor): migrate legacy agent databases and bound registry writes to the active state dir

### DIFF
--- a/src/flows/doctor-health-contributions.test-support.ts
+++ b/src/flows/doctor-health-contributions.test-support.ts
@@ -34,6 +34,10 @@ type DoctorHealthContributionTestApi = {
     run?: (ctx: DoctorHealthFlowContext) => Promise<void>;
   }): DoctorHealthContribution;
   resolveDoctorHealthContributions(): DoctorHealthContribution[];
+  runDoctorHealthContributionList(
+    ctx: DoctorHealthFlowContext,
+    contributions: readonly DoctorHealthContribution[],
+  ): Promise<void>;
 };
 
 function getTestApi(): DoctorHealthContributionTestApi {
@@ -54,4 +58,11 @@ export function createDoctorHealthContribution(
 
 export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
   return getTestApi().resolveDoctorHealthContributions();
+}
+
+export async function runDoctorHealthContributionList(
+  ctx: DoctorHealthFlowContext,
+  contributions: readonly DoctorHealthContribution[],
+): Promise<void> {
+  await getTestApi().runDoctorHealthContributionList(ctx, contributions);
 }

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -13,6 +13,7 @@ import { resolveDoctorContributionHealthChecks } from "./doctor-health-contribut
 import {
   createDoctorHealthContribution,
   resolveDoctorHealthContributions,
+  runDoctorHealthContributionList,
 } from "./doctor-health-contributions.test-support.js";
 import { runDoctorLintChecks } from "./doctor-lint-flow.js";
 import type { HealthCheck, HealthFinding } from "./health-checks.js";
@@ -804,6 +805,43 @@ describe("doctor health contributions", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
+  });
+
+  it("continues after one doctor contribution throws", async () => {
+    const laterRun = vi.fn(async () => undefined);
+    const contributions = [
+      createDoctorHealthContribution({
+        id: "doctor:test-failure",
+        label: "Test failure",
+        run: async () => {
+          throw new Error("media migration required");
+        },
+      }),
+      createDoctorHealthContribution({
+        id: "doctor:test-later",
+        label: "Test later",
+        run: laterRun,
+      }),
+    ];
+    const ctx = {
+      cfg: {},
+      cfgForPersistence: {},
+      configResult: { cfg: {} },
+      configPath: "/tmp/fake-openclaw.json",
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(true),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      env: {},
+    } as DoctorContributionRunContext;
+
+    await runDoctorHealthContributionList(ctx, contributions);
+
+    expect(laterRun).toHaveBeenCalledOnce();
+    expect(mocks.note).toHaveBeenCalledWith(
+      "doctor:test-failure run failed: media migration required",
+      "Doctor warnings",
+    );
   });
 
   it("keeps legacy plugin manifest lint opt-in for structured findings", async () => {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1,6 +1,7 @@
 // Doctor health contributions preserve the ordered interactive doctor flow while
 // exposing the same checks to structured lint and repair commands.
 import fs from "node:fs";
+import { scrubDoctorErrorMessage } from "./doctor-error-message.js";
 import { hasActiveGatewayExecCredential } from "./doctor-gateway-exec-credential.js";
 import {
   runCoreContributionHealth,
@@ -414,31 +415,44 @@ export async function resolveDoctorContributionHealthChecks(): Promise<readonly 
   return checks;
 }
 
-export async function runDoctorHealthContributions(ctx: DoctorHealthFlowContext): Promise<void> {
+async function runDoctorHealthContributionList(
+  ctx: DoctorHealthFlowContext,
+  contributions: readonly DoctorHealthContribution[],
+): Promise<void> {
   const runWithPluginMetadataSnapshot = ctx.runWithPluginMetadataSnapshot;
-  if (!runWithPluginMetadataSnapshot) {
-    for (const contribution of resolveDoctorHealthContributions()) {
-      await contribution.run(ctx);
+  for (const contribution of contributions) {
+    try {
+      if (!runWithPluginMetadataSnapshot) {
+        await contribution.run(ctx);
+        continue;
+      }
+      const { resolveAgentWorkspaceDir, resolveDefaultAgentId } =
+        await import("../agents/agent-scope.js");
+      const workspaceDir = resolveAgentWorkspaceDir(
+        ctx.cfg,
+        resolveDefaultAgentId(ctx.cfg),
+        ctx.env ?? process.env,
+      );
+      await runWithPluginMetadataSnapshot({ config: ctx.cfg, workspaceDir }, () =>
+        contribution.run(ctx),
+      );
+    } catch (error) {
+      const { note } = await loadNoteModule();
+      note(`${contribution.id} run failed: ${scrubDoctorErrorMessage(error)}`, "Doctor warnings");
     }
-    return;
   }
+}
 
-  const { resolveAgentWorkspaceDir, resolveDefaultAgentId } =
-    await import("../agents/agent-scope.js");
-  for (const contribution of resolveDoctorHealthContributions()) {
-    const workspaceDir = resolveAgentWorkspaceDir(
-      ctx.cfg,
-      resolveDefaultAgentId(ctx.cfg),
-      ctx.env ?? process.env,
-    );
-    await runWithPluginMetadataSnapshot({ config: ctx.cfg, workspaceDir }, () =>
-      contribution.run(ctx),
-    );
-  }
+export async function runDoctorHealthContributions(ctx: DoctorHealthFlowContext): Promise<void> {
+  await runDoctorHealthContributionList(ctx, resolveDoctorHealthContributions());
 }
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[
     Symbol.for("openclaw.doctorHealthContributionsTestApi")
-  ] = { createDoctorHealthContribution, resolveDoctorHealthContributions };
+  ] = {
+    createDoctorHealthContribution,
+    resolveDoctorHealthContributions,
+    runDoctorHealthContributionList,
+  };
 }

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -1301,18 +1301,18 @@ export async function autoMigrateLegacyState(params: {
   const mediaPersistence =
     params.doctorOnlyStateMigrations === true
       ? migrateLegacyMediaPersistence({
-          allowedAgentDatabasePaths: resolveSessionStoreTargets(
+          configuredAgentDatabaseTargets: resolveSessionStoreTargets(
             params.cfg,
             { allAgents: true },
             { env },
-          ).map(
-            (target) =>
-              resolveSqliteTargetFromSessionStorePath(target.storePath, {
-                agentId: target.agentId,
-                defaultAgentId: resolveDefaultAgentId(params.cfg),
-                env,
-              }).path,
-          ),
+          ).map((target) => ({
+            agentId: target.agentId,
+            path: resolveSqliteTargetFromSessionStorePath(target.storePath, {
+              agentId: target.agentId,
+              defaultAgentId: resolveDefaultAgentId(params.cfg),
+              env,
+            }).path,
+          })),
           env: { ...env, OPENCLAW_STATE_DIR: stateDir },
         })
       : { changes: [], warnings: [] };

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -12,6 +12,8 @@ import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { getChannelPlugin } from "../channels/plugins/registry.js";
 import type { ChannelId } from "../channels/plugins/types.public.js";
 import { resolveOAuthDir, resolveStateDir } from "../config/paths.js";
+import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
+import { resolveSessionStoreTargets } from "../config/sessions/targets.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
@@ -1298,7 +1300,21 @@ export async function autoMigrateLegacyState(params: {
   }
   const mediaPersistence =
     params.doctorOnlyStateMigrations === true
-      ? migrateLegacyMediaPersistence({ env: { ...env, OPENCLAW_STATE_DIR: stateDir } })
+      ? migrateLegacyMediaPersistence({
+          allowedAgentDatabasePaths: resolveSessionStoreTargets(
+            params.cfg,
+            { allAgents: true },
+            { env },
+          ).map(
+            (target) =>
+              resolveSqliteTargetFromSessionStorePath(target.storePath, {
+                agentId: target.agentId,
+                defaultAgentId: resolveDefaultAgentId(params.cfg),
+                env,
+              }).path,
+          ),
+          env: { ...env, OPENCLAW_STATE_DIR: stateDir },
+        })
       : { changes: [], warnings: [] };
   if (mediaPersistence.warnings.length > 0) {
     return {

--- a/src/infra/state-migrations.media-persistence-targets.test.ts
+++ b/src/infra/state-migrations.media-persistence-targets.test.ts
@@ -4,7 +4,10 @@ import { afterEach, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
-import { unregisterOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
+import {
+  registerOpenClawAgentDatabase,
+  unregisterOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db-registry.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   listOpenClawRegisteredAgentDatabases,
@@ -21,9 +24,14 @@ import { migrateLegacyMediaPersistence } from "./state-migrations.media-persiste
 const tempDirs: string[] = [];
 const PREVIOUS_VERSION = OPENCLAW_AGENT_SCHEMA_VERSION - 1;
 
-function createLegacyAgentDatabase(params: { env: NodeJS.ProcessEnv; path?: string }): string {
+function createLegacyAgentDatabase(params: {
+  agentId?: string;
+  env: NodeJS.ProcessEnv;
+  path?: string;
+}): string {
+  const agentId = params.agentId ?? "main";
   const opened = openOpenClawAgentDatabase({
-    agentId: "main",
+    agentId,
     env: params.env,
     ...(params.path ? { path: params.path } : {}),
   });
@@ -81,6 +89,37 @@ describe("media persistence migration targets", () => {
         schemaVersion: OPENCLAW_AGENT_SCHEMA_VERSION,
       }),
     ]);
+  });
+
+  it("preserves filesystem traversal for registered paths containing dot-dot segments", () => {
+    const stateDir = fs.realpathSync.native(
+      makeTempDir(tempDirs, "media-persistence-symlink-path-"),
+    );
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const symlinkTarget = path.join(stateDir, "external", "subdir");
+    fs.mkdirSync(symlinkTarget, { recursive: true });
+    fs.symlinkSync(symlinkTarget, path.join(stateDir, "link"), "dir");
+    const filesystemPath = path.join(stateDir, "external", "x", "openclaw-agent.sqlite");
+    const lexicalPath = path.join(stateDir, "x", "openclaw-agent.sqlite");
+    createLegacyAgentDatabase({ env, path: filesystemPath });
+    createLegacyAgentDatabase({ env, path: lexicalPath });
+    unregisterOpenClawAgentDatabase({ agentId: "main", env, path: filesystemPath });
+    unregisterOpenClawAgentDatabase({ agentId: "main", env, path: lexicalPath });
+    const registeredPath = `${path.join(stateDir, "link")}${path.sep}..${path.sep}x${path.sep}openclaw-agent.sqlite`;
+    expect(fs.realpathSync.native(registeredPath)).toBe(filesystemPath);
+    expect(path.resolve(registeredPath)).toBe(lexicalPath);
+    registerOpenClawAgentDatabase({
+      agentId: "main",
+      env,
+      path: registeredPath,
+      schemaVersion: PREVIOUS_VERSION,
+    });
+
+    const result = migrateLegacyMediaPersistence({ env });
+
+    expect(result.warnings).toEqual([]);
+    expect(readUserVersion(filesystemPath)).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
+    expect(readUserVersion(lexicalPath)).toBe(PREVIOUS_VERSION);
   });
 
   it("unregisters foreign registry paths without touching their databases", () => {
@@ -156,6 +195,41 @@ describe("media persistence migration targets", () => {
         includeIncompatibleSchemaVersions: true,
       }),
     ).toEqual([expect.objectContaining({ agentId: "main", path: databasePath })]);
+  });
+
+  it("prefers the configured owner over a stale registry owner for the same path", () => {
+    const stateDir = fs.realpathSync.native(
+      makeTempDir(tempDirs, "media-persistence-stale-owner-active-"),
+    );
+    const customRoot = fs.realpathSync.native(
+      makeTempDir(tempDirs, "media-persistence-stale-owner-store-"),
+    );
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = path.join(customRoot, "openclaw-agent.sqlite");
+    createLegacyAgentDatabase({ agentId: "new", env, path: databasePath });
+    unregisterOpenClawAgentDatabase({ agentId: "new", env, path: databasePath });
+    registerOpenClawAgentDatabase({
+      agentId: "old",
+      env,
+      path: databasePath,
+      schemaVersion: PREVIOUS_VERSION,
+    });
+
+    const result = migrateLegacyMediaPersistence({
+      configuredAgentDatabaseTargets: [{ agentId: "new", path: databasePath }],
+      env,
+    });
+
+    expect(result.warnings).toContain(
+      `Skipped foreign agent database ${databasePath}; it is outside the active state directory and is not a configured session store.`,
+    );
+    expect(readUserVersion(databasePath)).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
+    expect(
+      listOpenClawRegisteredAgentDatabases({
+        env,
+        includeIncompatibleSchemaVersions: true,
+      }),
+    ).toEqual([expect.objectContaining({ agentId: "new", path: databasePath })]);
   });
 
   it("prunes missing and archived registry entries before migration", () => {

--- a/src/infra/state-migrations.media-persistence-targets.test.ts
+++ b/src/infra/state-migrations.media-persistence-targets.test.ts
@@ -135,9 +135,16 @@ describe("media persistence migration targets", () => {
       env,
     }).path;
     createLegacyAgentDatabase({ env, path: databasePath });
+    unregisterOpenClawAgentDatabase({ agentId: "main", env, path: databasePath });
+    expect(
+      listOpenClawRegisteredAgentDatabases({
+        env,
+        includeIncompatibleSchemaVersions: true,
+      }),
+    ).toEqual([]);
 
     const result = migrateLegacyMediaPersistence({
-      allowedAgentDatabasePaths: [databasePath],
+      configuredAgentDatabaseTargets: [{ agentId: "main", path: databasePath }],
       env,
     });
 

--- a/src/infra/state-migrations.media-persistence-targets.test.ts
+++ b/src/infra/state-migrations.media-persistence-targets.test.ts
@@ -91,6 +91,30 @@ describe("media persistence migration targets", () => {
     ]);
   });
 
+  it("prefers a renamed configured owner over the default-layout directory name", () => {
+    const stateDir = fs.realpathSync.native(
+      makeTempDir(tempDirs, "media-persistence-renamed-owner-"),
+    );
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = path.join(stateDir, "agents", "oldname", "agent", "openclaw-agent.sqlite");
+    createLegacyAgentDatabase({ agentId: "renamed", env, path: databasePath });
+    unregisterOpenClawAgentDatabase({ agentId: "renamed", env, path: databasePath });
+
+    const result = migrateLegacyMediaPersistence({
+      configuredAgentDatabaseTargets: [{ agentId: "renamed", path: databasePath }],
+      env,
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(readUserVersion(databasePath)).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
+    expect(
+      listOpenClawRegisteredAgentDatabases({
+        env,
+        includeIncompatibleSchemaVersions: true,
+      }),
+    ).toEqual([expect.objectContaining({ agentId: "renamed", path: databasePath })]);
+  });
+
   it("preserves filesystem traversal for registered paths containing dot-dot segments", () => {
     const stateDir = fs.realpathSync.native(
       makeTempDir(tempDirs, "media-persistence-symlink-path-"),

--- a/src/infra/state-migrations.media-persistence-targets.test.ts
+++ b/src/infra/state-migrations.media-persistence-targets.test.ts
@@ -1,0 +1,186 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
+import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
+import { unregisterOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  listOpenClawRegisteredAgentDatabases,
+  OPENCLAW_AGENT_SCHEMA_VERSION,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
+
+const tempDirs: string[] = [];
+const PREVIOUS_VERSION = OPENCLAW_AGENT_SCHEMA_VERSION - 1;
+
+function createLegacyAgentDatabase(params: { env: NodeJS.ProcessEnv; path?: string }): string {
+  const opened = openOpenClawAgentDatabase({
+    agentId: "main",
+    env: params.env,
+    ...(params.path ? { path: params.path } : {}),
+  });
+  const databasePath = opened.path;
+  closeOpenClawAgentDatabasesForTest();
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath);
+  try {
+    database.exec(`PRAGMA user_version = ${PREVIOUS_VERSION};`);
+    database
+      .prepare("UPDATE schema_meta SET schema_version = ? WHERE meta_key = 'primary'")
+      .run(PREVIOUS_VERSION);
+  } finally {
+    database.close();
+  }
+  return databasePath;
+}
+
+function readUserVersion(databasePath: string): number {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    return (database.prepare("PRAGMA user_version").get() as { user_version: number }).user_version;
+  } finally {
+    database.close();
+  }
+}
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  cleanupTempDirs(tempDirs);
+});
+
+describe("media persistence migration targets", () => {
+  it("migrates and registers an unregistered default-layout agent database", () => {
+    const stateDir = fs.realpathSync.native(makeTempDir(tempDirs, "media-persistence-disk-scan-"));
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = createLegacyAgentDatabase({ env });
+    unregisterOpenClawAgentDatabase({ agentId: "main", env, path: databasePath });
+
+    const result = migrateLegacyMediaPersistence({ env });
+
+    expect(result.warnings).toEqual([]);
+    expect(readUserVersion(databasePath)).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
+    expect(
+      listOpenClawRegisteredAgentDatabases({
+        env,
+        includeIncompatibleSchemaVersions: true,
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        agentId: "main",
+        path: databasePath,
+        schemaVersion: OPENCLAW_AGENT_SCHEMA_VERSION,
+      }),
+    ]);
+  });
+
+  it("unregisters foreign registry paths without touching their databases", () => {
+    const stateDir = fs.realpathSync.native(
+      makeTempDir(tempDirs, "media-persistence-active-state-"),
+    );
+    const foreignStateDir = fs.realpathSync.native(
+      makeTempDir(tempDirs, "media-persistence-foreign-state-"),
+    );
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = path.join(
+      foreignStateDir,
+      "agents",
+      "main",
+      "agent",
+      "openclaw-agent.sqlite",
+    );
+    createLegacyAgentDatabase({ env, path: databasePath });
+    const beforeBytes = fs.readFileSync(databasePath);
+    const beforeMtimeMs = fs.statSync(databasePath).mtimeMs;
+
+    const result = migrateLegacyMediaPersistence({ env });
+
+    expect(result.warnings).toContain(
+      `Skipped foreign agent database ${databasePath}; it is outside the active state directory and is not a configured session store.`,
+    );
+    expect(
+      listOpenClawRegisteredAgentDatabases({
+        env,
+        includeIncompatibleSchemaVersions: true,
+      }),
+    ).toEqual([]);
+    expect(fs.readFileSync(databasePath)).toEqual(beforeBytes);
+    expect(fs.statSync(databasePath).mtimeMs).toBe(beforeMtimeMs);
+  });
+
+  it("migrates a configured out-of-tree session store", () => {
+    const stateDir = fs.realpathSync.native(
+      makeTempDir(tempDirs, "media-persistence-custom-active-"),
+    );
+    const customRoot = fs.realpathSync.native(
+      makeTempDir(tempDirs, "media-persistence-custom-store-"),
+    );
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const storePath = resolveStorePath(path.join(customRoot, "{agentId}", "sessions.json"), {
+      agentId: "main",
+      env,
+    });
+    const databasePath = resolveSqliteTargetFromSessionStorePath(storePath, {
+      agentId: "main",
+      defaultAgentId: "main",
+      env,
+    }).path;
+    createLegacyAgentDatabase({ env, path: databasePath });
+
+    const result = migrateLegacyMediaPersistence({
+      allowedAgentDatabasePaths: [databasePath],
+      env,
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(readUserVersion(databasePath)).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
+    expect(
+      listOpenClawRegisteredAgentDatabases({
+        env,
+        includeIncompatibleSchemaVersions: true,
+      }),
+    ).toEqual([expect.objectContaining({ agentId: "main", path: databasePath })]);
+  });
+
+  it("prunes missing and archived registry entries before migration", () => {
+    const stateDir = fs.realpathSync.native(
+      makeTempDir(tempDirs, "media-persistence-registry-hygiene-"),
+    );
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const missingPath = path.join(stateDir, "agents", "missing", "agent", "openclaw-agent.sqlite");
+    const archivedPath = path.join(stateDir, "imports", "archived", "openclaw-agent.sqlite");
+    fs.mkdirSync(path.dirname(archivedPath), { recursive: true });
+    fs.writeFileSync(archivedPath, "archived fixture");
+    const state = openOpenClawStateDatabase({ env });
+    const insert = state.db.prepare(
+      "INSERT INTO agent_databases(agent_id,path,schema_version,last_seen_at,size_bytes) VALUES(?,?,?,?,?)",
+    );
+    insert.run("missing", missingPath, OPENCLAW_AGENT_SCHEMA_VERSION, 1, null);
+    insert.run("archived", archivedPath, 8, 1, null);
+
+    const result = migrateLegacyMediaPersistence({ env });
+
+    expect(result.changes).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Removed missing agent database registry entry"),
+        expect.stringContaining("Removed archived or transient agent database registry entry"),
+      ]),
+    );
+    expect(result.warnings).toContain(`Skipped missing registered agent database ${missingPath}.`);
+    expect(
+      listOpenClawRegisteredAgentDatabases({
+        env,
+        includeIncompatibleSchemaVersions: true,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/src/infra/state-migrations.media-persistence-targets.test.ts
+++ b/src/infra/state-migrations.media-persistence-targets.test.ts
@@ -115,6 +115,26 @@ describe("media persistence migration targets", () => {
     ).toEqual([expect.objectContaining({ agentId: "renamed", path: databasePath })]);
   });
 
+  it("prefers a recorded owner over the default-layout directory name", () => {
+    const stateDir = fs.realpathSync.native(
+      makeTempDir(tempDirs, "media-persistence-recorded-owner-"),
+    );
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = path.join(stateDir, "agents", "dirname", "agent", "openclaw-agent.sqlite");
+    createLegacyAgentDatabase({ agentId: "recorded", env, path: databasePath });
+
+    const result = migrateLegacyMediaPersistence({ env });
+
+    expect(result.warnings).toEqual([]);
+    expect(readUserVersion(databasePath)).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
+    expect(
+      listOpenClawRegisteredAgentDatabases({
+        env,
+        includeIncompatibleSchemaVersions: true,
+      }),
+    ).toEqual([expect.objectContaining({ agentId: "recorded", path: databasePath })]);
+  });
+
   it("preserves filesystem traversal for registered paths containing dot-dot segments", () => {
     const stateDir = fs.realpathSync.native(
       makeTempDir(tempDirs, "media-persistence-symlink-path-"),

--- a/src/infra/state-migrations.media-persistence-targets.ts
+++ b/src/infra/state-migrations.media-persistence-targets.ts
@@ -59,15 +59,15 @@ export function resolveAgentDatabaseMediaMigrationTargets(params: {
   }
   const candidates: CandidateTarget[] = [
     ...listDefaultAgentDatabaseTargets(params.env, params.warnings),
-    ...registered.map((entry) => ({
-      agentId: entry.agentId,
-      path: entry.path,
-      source: "registry" as const,
-    })),
     ...params.configuredAgentDatabaseTargets.map((target) => ({
       agentId: target.agentId,
       path: target.path,
       source: "configured" as const,
+    })),
+    ...registered.map((entry) => ({
+      agentId: entry.agentId,
+      path: entry.path,
+      source: "registry" as const,
     })),
   ];
   const activeStateDir = resolveStateDir(params.env);
@@ -84,7 +84,9 @@ export function resolveAgentDatabaseMediaMigrationTargets(params: {
   const configuredPathMatcher = createOpenClawAgentDatabasePathMatcher();
   const targets: AgentDatabaseMediaMigrationTarget[] = [];
   for (const candidate of candidates) {
-    const pathname = path.resolve(candidate.path);
+    // Preserve the original locator: lexical normalization of `link/../file`
+    // can select a different file than filesystem symlink traversal does.
+    const pathname = candidate.path;
     if (!isPersistentOpenClawAgentDatabasePath(pathname, params.env)) {
       if (candidate.source === "registry") {
         unregisterOpenClawAgentDatabase({
@@ -107,6 +109,9 @@ export function resolveAgentDatabaseMediaMigrationTargets(params: {
       }
     }
     const isConfiguredPath = params.configuredAgentDatabaseTargets.some((configuredTarget) => {
+      if (normalizeAgentId(configuredTarget.agentId) !== normalizeAgentId(candidate.agentId)) {
+        return false;
+      }
       try {
         return configuredPathMatcher(pathname, configuredTarget.path);
       } catch {

--- a/src/infra/state-migrations.media-persistence-targets.ts
+++ b/src/infra/state-migrations.media-persistence-targets.ts
@@ -57,20 +57,20 @@ export function resolveAgentDatabaseMediaMigrationTargets(params: {
       `Failed enumerating registered agent databases for media migration: ${String(error)}`,
     );
   }
-  // Explicit config owns identity; disk layout is a fallback heuristic, and
-  // registry rows are last because copied or renamed state can leave them stale.
+  // Owner authority is explicit config, then the recorded registry fact, then
+  // directory-name inference. Recorded identity must beat a stale directory basename.
   const candidates: CandidateTarget[] = [
     ...params.configuredAgentDatabaseTargets.map((target) => ({
       agentId: target.agentId,
       path: target.path,
       source: "configured" as const,
     })),
-    ...listDefaultAgentDatabaseTargets(params.env, params.warnings),
     ...registered.map((entry) => ({
       agentId: entry.agentId,
       path: entry.path,
       source: "registry" as const,
     })),
+    ...listDefaultAgentDatabaseTargets(params.env, params.warnings),
   ];
   const activeStateDir = resolveStateDir(params.env);
   let activeStateDirRealPath: string | undefined;

--- a/src/infra/state-migrations.media-persistence-targets.ts
+++ b/src/infra/state-migrations.media-persistence-targets.ts
@@ -57,13 +57,15 @@ export function resolveAgentDatabaseMediaMigrationTargets(params: {
       `Failed enumerating registered agent databases for media migration: ${String(error)}`,
     );
   }
+  // Explicit config owns identity; disk layout is a fallback heuristic, and
+  // registry rows are last because copied or renamed state can leave them stale.
   const candidates: CandidateTarget[] = [
-    ...listDefaultAgentDatabaseTargets(params.env, params.warnings),
     ...params.configuredAgentDatabaseTargets.map((target) => ({
       agentId: target.agentId,
       path: target.path,
       source: "configured" as const,
     })),
+    ...listDefaultAgentDatabaseTargets(params.env, params.warnings),
     ...registered.map((entry) => ({
       agentId: entry.agentId,
       path: entry.path,
@@ -83,6 +85,7 @@ export function resolveAgentDatabaseMediaMigrationTargets(params: {
   }
   const configuredPathMatcher = createOpenClawAgentDatabasePathMatcher();
   const targets: AgentDatabaseMediaMigrationTarget[] = [];
+  const seenRealPaths = new Set<string>();
   for (const candidate of candidates) {
     // Preserve the original locator: lexical normalization of `link/../file`
     // can select a different file than filesystem symlink traversal does.
@@ -172,6 +175,11 @@ export function resolveAgentDatabaseMediaMigrationTargets(params: {
       );
       continue;
     }
+    if (seenRealPaths.has(realPath)) {
+      continue;
+    }
+    // Claim identity only after every persistence, boundary, and file gate passed.
+    seenRealPaths.add(realPath);
     targets.push({ ...candidate, path: pathname, realPath });
   }
   return targets;

--- a/src/infra/state-migrations.media-persistence-targets.ts
+++ b/src/infra/state-migrations.media-persistence-targets.ts
@@ -1,0 +1,168 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveAgentSessionDirsFromAgentsDirSync } from "../agents/session-dirs.js";
+import { resolveStateDir } from "../config/paths.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import {
+  createOpenClawAgentDatabasePathMatcher,
+  isPersistentOpenClawAgentDatabasePath,
+  listOpenClawRegisteredAgentDatabases,
+  unregisterOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db-registry.js";
+import { isPathInside } from "./path-guards.js";
+
+type AgentDatabaseMediaMigrationTarget = {
+  agentId: string;
+  path: string;
+  realPath: string;
+  source: "disk" | "registry";
+};
+
+type CandidateTarget = Omit<AgentDatabaseMediaMigrationTarget, "realPath">;
+
+function listDefaultAgentDatabaseTargets(
+  env: NodeJS.ProcessEnv,
+  warnings: string[],
+): CandidateTarget[] {
+  const agentsDir = path.join(resolveStateDir(env), "agents");
+  try {
+    return resolveAgentSessionDirsFromAgentsDirSync(agentsDir).map((sessionsDir) => {
+      const agentDir = path.dirname(sessionsDir);
+      return {
+        agentId: normalizeAgentId(path.basename(agentDir)),
+        path: path.join(agentDir, "agent", "openclaw-agent.sqlite"),
+        source: "disk" as const,
+      };
+    });
+  } catch (error) {
+    warnings.push(`Could not enumerate agent databases under ${agentsDir}: ${String(error)}`);
+    return [];
+  }
+}
+
+export function resolveAgentDatabaseMediaMigrationTargets(params: {
+  allowedAgentDatabasePaths: readonly string[];
+  changes: string[];
+  env: NodeJS.ProcessEnv;
+  warnings: string[];
+}): AgentDatabaseMediaMigrationTarget[] {
+  let registered: ReturnType<typeof listOpenClawRegisteredAgentDatabases> = [];
+  try {
+    registered = listOpenClawRegisteredAgentDatabases({
+      env: params.env,
+      includeIncompatibleSchemaVersions: true,
+    });
+  } catch (error) {
+    params.warnings.push(
+      `Failed enumerating registered agent databases for media migration: ${String(error)}`,
+    );
+  }
+  const candidates: CandidateTarget[] = [
+    ...listDefaultAgentDatabaseTargets(params.env, params.warnings),
+    ...registered.map((entry) => ({
+      agentId: entry.agentId,
+      path: entry.path,
+      source: "registry" as const,
+    })),
+  ];
+  const activeStateDir = resolveStateDir(params.env);
+  let activeStateDirRealPath: string | undefined;
+  try {
+    activeStateDirRealPath = fs.realpathSync.native(activeStateDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      params.warnings.push(
+        `Could not resolve active state directory ${activeStateDir}: ${String(error)}`,
+      );
+    }
+  }
+  const configuredPathMatcher = createOpenClawAgentDatabasePathMatcher();
+  const targets: AgentDatabaseMediaMigrationTarget[] = [];
+  for (const candidate of candidates) {
+    const pathname = path.resolve(candidate.path);
+    if (!isPersistentOpenClawAgentDatabasePath(pathname, params.env)) {
+      if (candidate.source === "registry") {
+        unregisterOpenClawAgentDatabase({
+          agentId: candidate.agentId,
+          env: params.env,
+          path: candidate.path,
+        });
+        params.changes.push(
+          `Removed archived or transient agent database registry entry ${pathname}.`,
+        );
+      }
+      continue;
+    }
+    let realPath: string | undefined;
+    try {
+      realPath = fs.realpathSync.native(pathname);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        params.warnings.push(`Could not resolve agent database ${pathname}: ${String(error)}`);
+      }
+    }
+    const isConfiguredPath = params.allowedAgentDatabasePaths.some((allowedPath) => {
+      try {
+        return configuredPathMatcher(pathname, allowedPath);
+      } catch {
+        return false;
+      }
+    });
+    const isInsideActiveStateDir = Boolean(
+      realPath &&
+      activeStateDirRealPath &&
+      (realPath === activeStateDirRealPath || isPathInside(activeStateDirRealPath, realPath)),
+    );
+    if (realPath && !isInsideActiveStateDir && !isConfiguredPath) {
+      if (candidate.source === "registry") {
+        unregisterOpenClawAgentDatabase({
+          agentId: candidate.agentId,
+          env: params.env,
+          path: candidate.path,
+        });
+      }
+      params.warnings.push(
+        `Skipped foreign agent database ${pathname}; it is outside the active state directory and is not a configured session store.`,
+      );
+      continue;
+    }
+    let stat: fs.Stats | undefined;
+    try {
+      stat = fs.statSync(pathname);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        params.warnings.push(
+          `Could not inspect ${candidate.source === "registry" ? "registered " : ""}agent database ${pathname}: ${String(error)}`,
+        );
+        continue;
+      }
+    }
+    if (!stat?.isFile()) {
+      if (candidate.source === "registry") {
+        unregisterOpenClawAgentDatabase({
+          agentId: candidate.agentId,
+          env: params.env,
+          path: candidate.path,
+        });
+        params.changes.push(`Removed missing agent database registry entry ${pathname}.`);
+        params.warnings.push(`Skipped missing registered agent database ${pathname}.`);
+      }
+      continue;
+    }
+    if (!realPath) {
+      if (candidate.source === "registry") {
+        unregisterOpenClawAgentDatabase({
+          agentId: candidate.agentId,
+          env: params.env,
+          path: candidate.path,
+        });
+      }
+      params.warnings.push(
+        `Skipped agent database ${pathname}; its filesystem boundary is unresolved.`,
+      );
+      continue;
+    }
+    targets.push({ ...candidate, path: pathname, realPath });
+  }
+  return targets;
+}

--- a/src/infra/state-migrations.media-persistence-targets.ts
+++ b/src/infra/state-migrations.media-persistence-targets.ts
@@ -15,7 +15,7 @@ type AgentDatabaseMediaMigrationTarget = {
   agentId: string;
   path: string;
   realPath: string;
-  source: "disk" | "registry";
+  source: "configured" | "disk" | "registry";
 };
 
 type CandidateTarget = Omit<AgentDatabaseMediaMigrationTarget, "realPath">;
@@ -41,8 +41,8 @@ function listDefaultAgentDatabaseTargets(
 }
 
 export function resolveAgentDatabaseMediaMigrationTargets(params: {
-  allowedAgentDatabasePaths: readonly string[];
   changes: string[];
+  configuredAgentDatabaseTargets: readonly { agentId: string; path: string }[];
   env: NodeJS.ProcessEnv;
   warnings: string[];
 }): AgentDatabaseMediaMigrationTarget[] {
@@ -63,6 +63,11 @@ export function resolveAgentDatabaseMediaMigrationTargets(params: {
       agentId: entry.agentId,
       path: entry.path,
       source: "registry" as const,
+    })),
+    ...params.configuredAgentDatabaseTargets.map((target) => ({
+      agentId: target.agentId,
+      path: target.path,
+      source: "configured" as const,
     })),
   ];
   const activeStateDir = resolveStateDir(params.env);
@@ -101,9 +106,9 @@ export function resolveAgentDatabaseMediaMigrationTargets(params: {
         params.warnings.push(`Could not resolve agent database ${pathname}: ${String(error)}`);
       }
     }
-    const isConfiguredPath = params.allowedAgentDatabasePaths.some((allowedPath) => {
+    const isConfiguredPath = params.configuredAgentDatabaseTargets.some((configuredTarget) => {
       try {
-        return configuredPathMatcher(pathname, allowedPath);
+        return configuredPathMatcher(pathname, configuredTarget.path);
       } catch {
         return false;
       }

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -17,10 +17,7 @@ import {
   openOpenClawAgentDatabase,
   runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
-import {
-  closeOpenClawStateDatabaseForTest,
-  openOpenClawStateDatabase,
-} from "../state/openclaw-state-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
 import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
 
@@ -817,37 +814,6 @@ describe("legacy media persistence doctor migration", () => {
         includeIncompatibleSchemaVersions: true,
       }),
     ).toEqual([expect.objectContaining({ path: databasePath, schemaVersion: PREVIOUS_VERSION })]);
-  });
-
-  it("prunes missing and archived registry entries before migration", () => {
-    const stateDir = makeTempDir(tempDirs, "media-persistence-registry-hygiene-");
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    const missingPath = path.join(stateDir, "agents", "missing", "agent", "openclaw-agent.sqlite");
-    const archivedPath = path.join(stateDir, "imports", "archived", "openclaw-agent.sqlite");
-    fs.mkdirSync(path.dirname(archivedPath), { recursive: true });
-    fs.writeFileSync(archivedPath, "archived fixture");
-    const state = openOpenClawStateDatabase({ env });
-    const insert = state.db.prepare(
-      "INSERT INTO agent_databases(agent_id,path,schema_version,last_seen_at,size_bytes) VALUES(?,?,?,?,?)",
-    );
-    insert.run("missing", missingPath, OPENCLAW_AGENT_SCHEMA_VERSION, 1, null);
-    insert.run("archived", archivedPath, 8, 1, null);
-
-    const result = migrateLegacyMediaPersistence({ env });
-
-    expect(result.changes).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining("Removed missing agent database registry entry"),
-        expect.stringContaining("Removed archived or transient agent database registry entry"),
-      ]),
-    );
-    expect(result.warnings).toContain(`Skipped missing registered agent database ${missingPath}.`);
-    expect(
-      listOpenClawRegisteredAgentDatabases({
-        env,
-        includeIncompatibleSchemaVersions: true,
-      }),
-    ).toEqual([]);
   });
 
   it("aborts one database on invalid trajectory JSON without advancing its version", () => {

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -590,7 +590,7 @@ function listTranscriptArchives(directory: string): string[] {
 /** Doctor-only migration from top-level Media* transcript fields to canonical facts. */
 export function migrateLegacyMediaPersistence(
   params: {
-    allowedAgentDatabasePaths?: readonly string[];
+    configuredAgentDatabaseTargets?: readonly { agentId: string; path: string }[];
     hooks?: {
       beforeArchiveReplace?: (archivePath: string) => void;
       beforeDatabaseTransaction?: (databasePath: string) => void;
@@ -602,8 +602,8 @@ export function migrateLegacyMediaPersistence(
   const changes: string[] = [];
   const warnings: string[] = [];
   const targets = resolveAgentDatabaseMediaMigrationTargets({
-    allowedAgentDatabasePaths: params.allowedAgentDatabasePaths ?? [],
     changes,
+    configuredAgentDatabaseTargets: params.configuredAgentDatabaseTargets ?? [],
     env,
     warnings,
   });
@@ -630,7 +630,7 @@ export function migrateLegacyMediaPersistence(
           : undefined,
         pathname,
       });
-      if (entry.source === "disk" || result.versionAdvanced) {
+      if (entry.source !== "registry" || result.versionAdvanced) {
         registerOpenClawAgentDatabase({ agentId: entry.agentId, env, path: pathname });
       }
       if (

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -18,12 +18,7 @@ import {
   hasMeaningfulRetiredMediaCarrier,
 } from "../media/media-facts.js";
 import { assertOpenClawAgentDatabaseOwner } from "../state/openclaw-agent-db-maintenance.js";
-import {
-  isPersistentOpenClawAgentDatabasePath,
-  listOpenClawRegisteredAgentDatabases,
-  registerOpenClawAgentDatabase,
-  unregisterOpenClawAgentDatabase,
-} from "../state/openclaw-agent-db-registry.js";
+import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
 import { assertOpenClawAgentSchemaContains } from "../state/openclaw-agent-db-schema-helpers.js";
 import {
   ensureOpenClawAgentDatabaseSchema,
@@ -48,6 +43,7 @@ import { replaceFileAtomicSync } from "./replace-file.js";
 import { repairCanonicalSqliteIndexes } from "./sqlite-index-schema.js";
 import { runSqliteImmediateTransactionSync } from "./sqlite-transaction.js";
 import { readSqliteUserVersion } from "./sqlite-user-version.js";
+import { resolveAgentDatabaseMediaMigrationTargets } from "./state-migrations.media-persistence-targets.js";
 import type { MigrationMessages } from "./state-migrations.types.js";
 
 const PREVIOUS_MEDIA_SCHEMA_VERSION = OPENCLAW_AGENT_SCHEMA_VERSION - 1;
@@ -308,7 +304,7 @@ function createMigrationDatabaseHandle(
   };
 }
 
-function migrateRegisteredDatabase(params: {
+function migrateAgentDatabase(params: {
   agentId: string;
   beforeTransaction?: () => void;
   pathname: string;
@@ -594,6 +590,7 @@ function listTranscriptArchives(directory: string): string[] {
 /** Doctor-only migration from top-level Media* transcript fields to canonical facts. */
 export function migrateLegacyMediaPersistence(
   params: {
+    allowedAgentDatabasePaths?: readonly string[];
     hooks?: {
       beforeArchiveReplace?: (archivePath: string) => void;
       beforeDatabaseTransaction?: (databasePath: string) => void;
@@ -604,65 +601,36 @@ export function migrateLegacyMediaPersistence(
   const env = params.env ?? process.env;
   const changes: string[] = [];
   const warnings: string[] = [];
-  let registered: ReturnType<typeof listOpenClawRegisteredAgentDatabases>;
-  try {
-    registered = listOpenClawRegisteredAgentDatabases({
-      env,
-      includeIncompatibleSchemaVersions: true,
-    });
-  } catch (error) {
-    return {
-      changes,
-      warnings: [
-        `Failed enumerating registered agent databases for media migration: ${String(error)}`,
-      ],
-    };
-  }
-
+  const targets = resolveAgentDatabaseMediaMigrationTargets({
+    allowedAgentDatabasePaths: params.allowedAgentDatabasePaths ?? [],
+    changes,
+    env,
+    warnings,
+  });
   const seenPaths = new Set<string>();
   let databaseMigrationFailed = false;
   const archiveDirectories = new Set<string>();
-  for (const entry of registered) {
-    const pathname = path.resolve(entry.path);
-    if (!isPersistentOpenClawAgentDatabasePath(pathname, env)) {
-      unregisterOpenClawAgentDatabase({ agentId: entry.agentId, env, path: entry.path });
-      changes.push(`Removed archived or transient agent database registry entry ${pathname}.`);
-      continue;
-    }
-    let stat: fs.Stats | undefined;
-    try {
-      stat = fs.statSync(pathname);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        warnings.push(`Could not inspect registered agent database ${pathname}: ${String(error)}`);
-        continue;
-      }
-    }
-    if (!stat?.isFile()) {
-      unregisterOpenClawAgentDatabase({ agentId: entry.agentId, env, path: entry.path });
-      changes.push(`Removed missing agent database registry entry ${pathname}.`);
-      warnings.push(`Skipped missing registered agent database ${pathname}.`);
-      continue;
-    }
+  for (const entry of targets) {
+    const pathname = entry.path;
     archiveDirectories.add(
       resolveSqliteTranscriptArchiveDirectory({
         agentId: entry.agentId,
         path: pathname,
       }),
     );
-    if (seenPaths.has(pathname)) {
+    if (seenPaths.has(entry.realPath)) {
       continue;
     }
-    seenPaths.add(pathname);
+    seenPaths.add(entry.realPath);
     try {
-      const result = migrateRegisteredDatabase({
+      const result = migrateAgentDatabase({
         agentId: entry.agentId,
         beforeTransaction: params.hooks?.beforeDatabaseTransaction
           ? () => params.hooks?.beforeDatabaseTransaction?.(pathname)
           : undefined,
         pathname,
       });
-      if (result.versionAdvanced) {
+      if (entry.source === "disk" || result.versionAdvanced) {
         registerOpenClawAgentDatabase({ agentId: entry.agentId, env, path: pathname });
       }
       if (

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -100,6 +100,29 @@ function dropLegacyMemoryIndexSchema(db: DatabaseSync): void {
   `);
 }
 
+function dropLegacyRuntimeJournalSchemas(db: DatabaseSync): void {
+  const acpParentStreamColumns = readSqliteTableColumns(db, "acp_parent_stream_events");
+  if (acpParentStreamColumns && !acpParentStreamColumns.has("session_id")) {
+    // The reverted f91de52 journal keyed events only by run_id. It is derived runtime
+    // state, so discard that incompatible shape and let the canonical schema recreate it.
+    db.exec(`
+      DROP INDEX IF EXISTS idx_agent_acp_parent_stream_events_created;
+      DROP TABLE acp_parent_stream_events;
+    `);
+  }
+
+  const trajectoryColumns = readSqliteTableColumns(db, "trajectory_runtime_events");
+  if (trajectoryColumns?.has("event_id")) {
+    // The reverted f91de52 journal used event_id instead of the canonical session/seq key.
+    // Trajectory runtime events are derived, so rebuild rather than preserving stale rows.
+    db.exec(`
+      DROP INDEX IF EXISTS idx_agent_trajectory_runtime_events_session;
+      DROP INDEX IF EXISTS idx_agent_trajectory_runtime_events_run;
+      DROP TABLE trajectory_runtime_events;
+    `);
+  }
+}
+
 function hasLegacyMemoryChunkProvenanceTrigger(db: DatabaseSync): boolean {
   return Boolean(
     db
@@ -597,6 +620,7 @@ function ensureAgentSchema(
       // v1/v2 and pre-merge flip v1/v4 — without version-number coupling.
       dropLegacyMemoryIndexSchema(db);
       dropLegacySessionTranscriptSearchSchema(db);
+      dropLegacyRuntimeJournalSchemas(db);
       migrateMemoryIndexSourcesIdentity(db);
       migrateOpenClawAgentSchema(db);
       migrateConversationDeliveryTargetColumn(db);

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -1639,6 +1639,102 @@ describe("openclaw agent database", () => {
     });
   });
 
+  it("drops reverted v9 runtime journals before STRICT migration", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = materializeV13WorkerAgentDatabase(stateDir);
+    const { DatabaseSync } = requireNodeSqlite();
+    const legacy = new DatabaseSync(databasePath);
+    legacy.exec(`
+      DROP INDEX idx_agent_acp_parent_stream_run;
+      DROP TABLE acp_parent_stream_events;
+      CREATE TABLE acp_parent_stream_events (
+        run_id TEXT NOT NULL,
+        seq INTEGER NOT NULL,
+        event_json TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (run_id, seq)
+      );
+      CREATE INDEX idx_agent_acp_parent_stream_events_created
+        ON acp_parent_stream_events(created_at DESC, run_id, seq);
+
+      DROP INDEX idx_agent_trajectory_runtime_run;
+      DROP TABLE trajectory_runtime_events;
+      CREATE TABLE trajectory_runtime_events (
+        event_id INTEGER NOT NULL PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        run_id TEXT,
+        seq INTEGER NOT NULL,
+        event_json TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+      );
+      CREATE INDEX idx_agent_trajectory_runtime_events_session
+        ON trajectory_runtime_events(session_id, event_id);
+      CREATE INDEX idx_agent_trajectory_runtime_events_run
+        ON trajectory_runtime_events(run_id, event_id)
+        WHERE run_id IS NOT NULL;
+
+      INSERT INTO sessions (session_id, session_key, created_at, updated_at)
+      VALUES ('legacy-session', 'agent:worker-1:legacy-session', 10, 20);
+      INSERT INTO acp_parent_stream_events (run_id, seq, event_json, created_at)
+      VALUES ('run-1', 1, '{"type":"delta"}', 20);
+      INSERT INTO trajectory_runtime_events
+        (event_id, session_id, run_id, seq, event_json, created_at)
+      VALUES (1, 'legacy-session', 'run-1', 1, '{"type":"runtime"}', 20);
+      PRAGMA user_version = 9;
+      UPDATE schema_meta SET schema_version = 9 WHERE meta_key = 'primary';
+    `);
+    legacy.close();
+
+    const migrated = migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env });
+    const tableColumns = (table: string) =>
+      (migrated.db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map(
+        (column) => column.name,
+      );
+
+    expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
+    expect(tableColumns("acp_parent_stream_events")).toEqual([
+      "session_id",
+      "run_id",
+      "seq",
+      "event_json",
+      "created_at",
+    ]);
+    expect(tableColumns("trajectory_runtime_events")).toEqual([
+      "session_id",
+      "seq",
+      "run_id",
+      "event_json",
+      "created_at",
+    ]);
+    for (const table of ["acp_parent_stream_events", "trajectory_runtime_events"]) {
+      expect(
+        migrated.db.prepare("SELECT strict FROM pragma_table_list WHERE name = ?").get(table),
+      ).toEqual({ strict: 1 });
+      expect(migrated.db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get()).toEqual({
+        count: 0,
+      });
+    }
+    expect(
+      migrated.db
+        .prepare(
+          "SELECT name FROM sqlite_schema WHERE type = 'index' AND name IN ('idx_agent_acp_parent_stream_events_created', 'idx_agent_trajectory_runtime_events_session', 'idx_agent_trajectory_runtime_events_run')",
+        )
+        .all(),
+    ).toEqual([]);
+    expect(
+      migrated.db
+        .prepare(
+          "SELECT name FROM sqlite_schema WHERE type = 'index' AND name IN ('idx_agent_acp_parent_stream_run', 'idx_agent_trajectory_runtime_run') ORDER BY name",
+        )
+        .all(),
+    ).toEqual([
+      { name: "idx_agent_acp_parent_stream_run" },
+      { name: "idx_agent_trajectory_runtime_run" },
+    ]);
+  });
+
   it("migrates version 8 tables to STRICT without losing agent state", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };


### PR DESCRIPTION
## What Problem This Solves

Four coupled defects around agent-database migration, all reproduced live against a copy of a real state dir:

1. **Legacy runtime journals brick migration.** Agent DBs created during the briefly-landed-then-reverted f91de52f0d2 window (May 2026) carry `acp_parent_stream_events` (and `trajectory_runtime_events`) in a pre-`session_id`, non-STRICT shape. The canonical schema re-landed at v12 with `session_id` and no ALTER path, so the `previousVersion < 11` STRICT rebuild in `ensureAgentSchema` fails `assertMatchingColumns` ("missing session_id") and the whole doctor migration rolls back — the DB is stuck at v9 forever, and the gateway refuses to start.
2. **Registry-only discovery vs disk-scanning readers.** The media-persistence migration iterated only `agent_databases` registry rows, while doctor's session steps scan the agents tree on disk. An on-disk DB with no registry row (state dir copied or restored) is never migrated — and can never self-register because `openOpenClawAgentDatabase` asserts the media version *before* registering. Doctor's later steps then crash on the unmigrated DB.
3. **Registry absolute paths escape the active state dir.** With `OPENCLAW_STATE_DIR` pointing at a copy, the copied registry rows still name the ORIGINAL `~/.openclaw/agents/...` paths, and the migration followed them — opening and (absent defect 1) *writing schema migrations into a foreign live state dir*. Verified live: a sandboxed `doctor --fix` attempted exactly that against the real home state dir.
4. **One failing doctor step aborts the whole run with circular advice.** `runDoctorHealthContributions` had no per-step isolation, so the crash from defect 2 killed doctor entirely — with the error text "run `openclaw doctor --fix`", printed by doctor --fix itself.

## Why This Change Was Made

- `ensureAgentSchema` gains a structure-gated drop for the reverted-lineage runtime journals (both are derived runtime state; drop-and-recreate is the sanctioned shape, precedent `dropLegacyMemoryIndexSchema`).
- Migration target discovery becomes a single resolver (`state-migrations.media-persistence-targets.ts`) that unions **configured session-store targets**, **registry rows**, and **disk-discovered default-layout DBs**, deduplicated by filesystem identity with explicit owner authority: configuration → recorded registry fact → directory-name inference. Filesystem operations use original paths (no lexical `..` collapse across symlinks); realpath is used only for identity/boundary checks.
- Registry rows resolving outside the active state dir that are not configured stores are skipped, unregistered, and warned about — a doctor run can no longer write into another state dir. Custom out-of-tree `session.store` paths (a documented contract) still migrate, now even without a registry row.
- Doctor health contributions are individually isolated: a throwing step degrades to a named warning and the remaining steps run.

No schema-version bump; no runtime steady-state behavior changes; runtime asserts stay.

## User Impact

Users upgrading DBs that crossed the reverted May window, and anyone who copies/restores/moves a state dir (backup restore, machine migration, sandboxing), get a working `openclaw doctor --fix` instead of a permanently stuck gateway with circular advice. Doctor can no longer mutate a different installation's databases.

## Evidence

Live before/after on a copy of a real state dir (v9 `main` agent DB with legacy `acp_parent_stream_events`, 21 registry rows pointing at the original `~/.openclaw`):

- Before: `doctor --fix` exits 1 with `OpenClawAgentDatabaseMediaMigrationRequiredError ... run openclaw doctor --fix`, after attempting migration of the ORIGINAL state dir's DBs (blocked only by defect 1).
- After: exit 0; `main` migrates v9 → v16 with canonical `acp_parent_stream_events` (session_id, STRICT); all 21 foreign registry rows skipped + unregistered with warnings; original `~/.openclaw` agent DB mtimes byte-identical before/after (sorted stat comparison).

Tests: `node scripts/run-vitest.mjs src/infra/state-migrations` (503 passed / 2 skipped incl. new coverage for legacy-journal rebuild, unregistered disk discovery, foreign-row skip with untouched bytes, configured-store discovery without registry rows, symlinked `..` path identity, owner-authority precedence, doctor step isolation), `node scripts/run-vitest.mjs src/state/openclaw-agent-db` (111 passed / 4 skipped), doctor-health suite (107 passed).
