### PR TITLE
fix(cron): avoid no-op writes and unbounded page copies

### DIFF
--- a/src/cron/service.list-page-sort-guards.test.ts
+++ b/src/cron/service.list-page-sort-guards.test.ts
@@ -242,7 +242,7 @@ describe("cron listPage sort guards", () => {
     expect(page.jobs[0]?.state.lastStatus).toBeUndefined();
   });
 
-  it("clones only the requested page while revisions cover off-page changes", async () => {
+  it("listPage does not clone the complete store, detaches only requested rows, and revisions cover off-page changes", async () => {
     const jobs = [
       createBaseJob({ id: "job-a", name: "alpha" }),
       createBaseJob({ id: "job-b", name: "beta" }),
@@ -256,6 +256,7 @@ describe("cron listPage sort guards", () => {
       const page = await listPage(state, options);
       const clonedArrays = clone.mock.calls.filter(([value]) => Array.isArray(value));
 
+      expect(clone).not.toHaveBeenCalledWith(state.store);
       expect(clonedArrays).toHaveLength(1);
       expect(clonedArrays[0]?.[0]).toEqual([jobs[1]]);
       expect(page.jobs[0]).not.toBe(jobs[1]);

--- a/src/cron/service.list-page-sort-guards.test.ts
+++ b/src/cron/service.list-page-sort-guards.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createMockCronStateForJobs } from "./service.test-harness.js";
 import { list, listPage } from "./service/ops-read.js";
 import type { CronJob } from "./types.js";
@@ -240,6 +240,34 @@ describe("cron listPage sort guards", () => {
 
     expect(page.jobs[0]).not.toBe(job);
     expect(page.jobs[0]?.state.lastStatus).toBeUndefined();
+  });
+
+  it("clones only the requested page while revisions cover off-page changes", async () => {
+    const jobs = [
+      createBaseJob({ id: "job-a", name: "alpha" }),
+      createBaseJob({ id: "job-b", name: "beta" }),
+      createBaseJob({ id: "job-c", name: "gamma" }),
+    ];
+    const state = createMockCronStateForJobs({ jobs });
+    const clone = vi.spyOn(globalThis, "structuredClone");
+
+    try {
+      const options = { limit: 1, offset: 1, sortBy: "name" as const };
+      const page = await listPage(state, options);
+      const clonedArrays = clone.mock.calls.filter(([value]) => Array.isArray(value));
+
+      expect(clonedArrays).toHaveLength(1);
+      expect(clonedArrays[0]?.[0]).toEqual([jobs[1]]);
+      expect(page.jobs[0]).not.toBe(jobs[1]);
+
+      jobs[2]!.state.lastStatus = "ok";
+      const changed = await listPage(state, options);
+
+      expect(changed.jobs.map((job) => job.id)).toEqual(["job-b"]);
+      expect(changed.snapshotRevision).not.toBe(page.snapshotRevision);
+    } finally {
+      clone.mockRestore();
+    }
   });
 
   it("matches job ids in listPage text search", async () => {

--- a/src/cron/service.prevents-duplicate-timers.test.ts
+++ b/src/cron/service.prevents-duplicate-timers.test.ts
@@ -8,8 +8,10 @@ import {
   installCronTestHooks,
 } from "./service.test-harness.js";
 import { locked } from "./service/locked.js";
+import { add, remove } from "./service/ops-mutations.js";
+import { status } from "./service/ops-read.js";
 import { createCronServiceState } from "./service/state.js";
-import { loadCronStore } from "./store.js";
+import * as cronStoreModule from "./store.js";
 
 const noopLogger = createNoopLogger();
 const { makeStorePath } = createCronStoreHarness({ prefix: "openclaw-cron-" });
@@ -63,7 +65,7 @@ describe("CronService", () => {
     });
 
     await cronB.start();
-    expect((await loadCronStore(aliasedStorePath)).jobs).toHaveLength(1);
+    expect((await cronStoreModule.loadCronStore(aliasedStorePath)).jobs).toHaveLength(1);
 
     vi.setSystemTime(new Date("2025-12-13T00:00:01.000Z"));
     await vi.runOnlyPendingTimersAsync();
@@ -147,12 +149,71 @@ describe("CronService", () => {
     await addJob(cronA, "first-cached-service-job");
     await addJob(cronB, "second-cached-service-job");
 
-    expect((await loadCronStore(store.storePath)).jobs.map((job) => job.id)).toEqual([
-      "first-cached-service-job",
-      "second-cached-service-job",
-    ]);
+    expect(
+      (await cronStoreModule.loadCronStore(store.storePath)).jobs.map((job) => job.id),
+    ).toEqual(["first-cached-service-job", "second-cached-service-job"]);
     cronA.stop();
     cronB.stop();
+    await store.cleanup();
+  });
+
+  it("re-arms a stale service after a missing remove reloads an earlier job", async () => {
+    const store = await makeStorePath();
+    const createState = () => {
+      const enqueueSystemEvent = vi.fn();
+      const state = createCronServiceState({
+        storePath: store.storePath,
+        cronEnabled: true,
+        log: noopLogger,
+        enqueueSystemEvent,
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      });
+      return { state, enqueueSystemEvent };
+    };
+    const stale = createState();
+    const writer = createState();
+    await status(stale.state);
+    await status(writer.state);
+    const baseMs = Date.parse("2025-12-13T00:00:00.000Z");
+    const addAtJob = (state: ReturnType<typeof createCronServiceState>, id: string, atMs: number) =>
+      add(state, {
+        id,
+        name: id,
+        enabled: true,
+        schedule: { kind: "at", at: new Date(atMs).toISOString() },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: id },
+      });
+
+    await addAtJob(stale.state, "later-job", baseMs + 60_000);
+    const staleTimer = stale.state.timer;
+    await addAtJob(writer.state, "earlier-job", baseMs + 10_000);
+    if (writer.state.timer) {
+      clearTimeout(writer.state.timer);
+      writer.state.timer = null;
+    }
+    const previousRevision = cronStoreModule.getCronJobsStoreRevision(store.storePath);
+    const persist = vi.spyOn(cronStoreModule, "saveCronJobsStore");
+    persist.mockClear();
+
+    await expect(remove(stale.state, "missing-job")).resolves.toEqual({
+      ok: true,
+      removed: false,
+    });
+
+    expect(persist).not.toHaveBeenCalled();
+    expect(cronStoreModule.getCronJobsStoreRevision(store.storePath)).toBe(previousRevision);
+    expect(stale.state.timer).not.toBe(staleTimer);
+    expect(stale.state.store?.jobs.map((job) => job.id)).toEqual(["later-job", "earlier-job"]);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(stale.enqueueSystemEvent).toHaveBeenCalledWith("earlier-job", expect.any(Object));
+    if (stale.state.timer) {
+      clearTimeout(stale.state.timer);
+    }
     await store.cleanup();
   });
 });

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -480,22 +480,23 @@ export async function remove(
   const result = await locked(state, async () => {
     warnIfDisabled(state, "remove");
     await ensureLoaded(state, { skipRecompute: true });
-    const before = state.store?.jobs.length ?? 0;
     if (!state.store) {
       return { ok: false, removed: false } as const;
     }
-    const snapshot = snapshotStoreForRollback(state);
     const removedJob = state.store.jobs.find((j) => j.id === id);
+    if (!removedJob) {
+      return { ok: true, removed: false } as const;
+    }
     // Config is the monitor's source of truth: ad-hoc deletion would disable
     // heartbeats until an unrelated reload, so only gateway reconciliation
     // (stale-monitor cleanup) may remove one.
-    if (removedJob?.payload.kind === "heartbeat" && opts?.systemOwned !== true) {
+    if (removedJob.payload.kind === "heartbeat" && opts?.systemOwned !== true) {
       throw new Error(
         "heartbeat monitor jobs are system-owned; edit agents.*.heartbeat config instead",
       );
     }
+    const snapshot = snapshotStoreForRollback(state);
     state.store.jobs = state.store.jobs.filter((j) => j.id !== id);
-    const removed = (state.store.jobs.length ?? 0) !== before;
 
     const postPersistNotifications: DeferredCronNotifications = [];
     recomputeNextRunsForMaintenance(state, {
@@ -506,42 +507,38 @@ export async function remove(
       postPersistNotifications,
       suppressScheduledJobId: id,
     });
-    if (removed && removedJob) {
-      const activeMarker = noteActiveCronJobRemoval(id);
-      const agentId = resolveEffectiveJobAgentId(removedJob, resolveCurrentDefaultAgentId(state));
-      const sessionStorePath =
-        state.deps.resolveSessionStorePath?.(agentId) ?? state.deps.sessionStorePath;
-      if (
-        sessionStorePath &&
-        (removedJob.sessionTarget === "isolated" || removedJob.sessionTarget === "current")
-      ) {
-        let finish!: () => void;
-        const done = new Promise<void>((resolve) => {
-          finish = resolve;
-        });
-        const release = registerPendingCronSessionCleanup(state, id, done);
-        sessionCleanup = {
-          activeMarker,
-          agentId,
-          sessionStorePath,
-          done,
-          finish,
-          release,
-        };
-      }
-      try {
-        deleteCronJobScratch(state.deps.storePath, id);
-      } catch (error) {
-        // The job deletion is already durable. Scratch cleanup is idempotent and
-        // must not turn a committed removal into a retryable API failure.
-        state.deps.log.warn({ jobId: id, err: String(error) }, "cron: scratch cleanup failed");
-      }
+    const activeMarker = noteActiveCronJobRemoval(id);
+    const agentId = resolveEffectiveJobAgentId(removedJob, resolveCurrentDefaultAgentId(state));
+    const sessionStorePath =
+      state.deps.resolveSessionStorePath?.(agentId) ?? state.deps.sessionStorePath;
+    if (
+      sessionStorePath &&
+      (removedJob.sessionTarget === "isolated" || removedJob.sessionTarget === "current")
+    ) {
+      let finish!: () => void;
+      const done = new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+      const release = registerPendingCronSessionCleanup(state, id, done);
+      sessionCleanup = {
+        activeMarker,
+        agentId,
+        sessionStorePath,
+        done,
+        finish,
+        release,
+      };
+    }
+    try {
+      deleteCronJobScratch(state.deps.storePath, id);
+    } catch (error) {
+      // The job deletion is already durable. Scratch cleanup is idempotent and
+      // must not turn a committed removal into a retryable API failure.
+      state.deps.log.warn({ jobId: id, err: String(error) }, "cron: scratch cleanup failed");
     }
     armTimer(state);
-    if (removed) {
-      emit(state, { jobId: id, action: "removed", job: removedJob });
-    }
-    return { ok: true, removed } as const;
+    emit(state, { jobId: id, action: "removed", job: removedJob });
+    return { ok: true, removed: true } as const;
   });
   if (!sessionCleanup) {
     return result;

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -390,7 +390,6 @@ export async function updateLoadedJob(params: {
     throw new Error("heartbeat payloads are system-owned; jobs cannot be patched to them");
   }
   await ensureLoaded(state, { skipRecompute: true });
-  const snapshot = snapshotStoreForRollback(state);
   const job = findJobOrThrow(state, id);
   // Existing monitors are config-driven: any patch (disable, reschedule,
   // repurpose) would silently diverge from agents.*.heartbeat until the next
@@ -433,6 +432,7 @@ export async function updateLoadedJob(params: {
     scheduleChanged: patch.schedule !== undefined,
   });
   opts?.commitGuard?.();
+  const snapshot = snapshotStoreForRollback(state);
   await persistUpdatedJob({ state, snapshot, previousJob: job, nextJob });
   return nextJob;
 }
@@ -479,12 +479,16 @@ export async function remove(
     | undefined;
   const result = await locked(state, async () => {
     warnIfDisabled(state, "remove");
+    const previousStore = state.store;
     await ensureLoaded(state, { skipRecompute: true });
     if (!state.store) {
       return { ok: false, removed: false } as const;
     }
     const removedJob = state.store.jobs.find((j) => j.id === id);
     if (!removedJob) {
+      if (state.store !== previousStore) {
+        armTimer(state);
+      }
       return { ok: true, removed: false } as const;
     }
     // Config is the monitor's source of truth: ad-hoc deletion would disable

--- a/src/cron/service/ops-read.ts
+++ b/src/cron/service/ops-read.ts
@@ -305,15 +305,15 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
       );
       return haystack.includes(query);
     });
-    // Execution mutates stored job state in place. Detach the complete result
-    // under the lock so every returned page still matches its revision later.
-    const snapshot = structuredClone(sortCronJobs(filtered, sortBy, sortDir));
-    const snapshotRevision = resolveCronListSnapshotRevision(snapshot);
-    const total = snapshot.length;
+    // Hash the complete sorted result under the lock, but detach only the page
+    // that can outlive later in-place execution state changes.
+    const sortedJobs = sortCronJobs(filtered, sortBy, sortDir);
+    const snapshotRevision = resolveCronListSnapshotRevision(sortedJobs);
+    const total = sortedJobs.length;
     const offset = Math.max(0, Math.min(total, Math.floor(opts?.offset ?? 0)));
     const defaultLimit = total === 0 ? 50 : total;
     const limit = Math.max(1, Math.min(200, Math.floor(opts?.limit ?? defaultLimit)));
-    const jobs = snapshot.slice(offset, offset + limit);
+    const jobs = structuredClone(sortedJobs.slice(offset, offset + limit));
     const nextOffset = offset + jobs.length;
     return {
       jobs,

--- a/src/cron/service/ops-shared.ts
+++ b/src/cron/service/ops-shared.ts
@@ -6,7 +6,7 @@ import type { CronJob } from "../types.js";
 import { recomputeNextRunsForMaintenance } from "./jobs.js";
 import { normalizeOptionalAgentId } from "./normalize.js";
 import type { CronServiceState, DeferredCronNotifications } from "./state.js";
-import { ensureLoaded, persistOrRestore, snapshotStoreForRollback } from "./store.js";
+import { ensureLoaded, persist } from "./store.js";
 import {
   type IsolatedAgentSetupTimeoutSignal,
   maybeNotifyIsolatedAgentSetupTimeout,
@@ -74,13 +74,28 @@ export async function ensureLoadedForRead(state: CronServiceState) {
   }
   // Use the maintenance-only version so that read-only operations never
   // advance a past-due nextRunAtMs without executing the job (#16156).
-  const rollbackSnapshot = snapshotStoreForRollback(state);
+  // These are the only fields recomputeNextRunsForMaintenance and
+  // normalizeJobTickState may mutate. Keep this rollback shape aligned so a
+  // failed read repair preserves the live store and job object identities.
+  const rollbackJobs = state.store.jobs.map((job) => ({
+    job,
+    fields: structuredClone({ enabled: job.enabled, schedule: job.schedule, state: job.state }),
+  }));
   const postPersistNotifications: DeferredCronNotifications = [];
   const changed = recomputeNextRunsForMaintenance(state, {
     deferredNotifications: postPersistNotifications,
   });
   if (changed) {
-    await persistOrRestore(state, rollbackSnapshot, { postPersistNotifications });
+    try {
+      if (!(await persist(state, { postPersistNotifications }))) {
+        throw new Error("cron: durable store write did not complete");
+      }
+    } catch (error) {
+      for (const { job, fields } of rollbackJobs) {
+        Object.assign(job, fields);
+      }
+      throw error;
+    }
   }
 }
 

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -1768,6 +1768,37 @@ describe("cron service ops persist rollback", () => {
     } as const;
   }
 
+  it("does not persist, re-arm, or notify when removing a missing job", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-06-09T00:00:00.000Z");
+    const onEvent = vi.fn();
+    const state = createOkIsolatedCronState({ storePath, now, onEvent });
+    const job = await add(state, makeCreateInput("daily cleanup"));
+    const previousRevision = cronStoreModule.getCronJobsStoreRevision(storePath);
+    const originalTimer = state.timer;
+    onEvent.mockClear();
+    const persist = vi.spyOn(cronStoreModule, "saveCronJobsStore");
+    persist.mockClear();
+
+    await expect(remove(state, "missing-job")).resolves.toEqual({ ok: true, removed: false });
+
+    expect(persist).not.toHaveBeenCalled();
+    expect(cronStoreModule.getCronJobsStoreRevision(storePath)).toBe(previousRevision);
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(state.timer).toBe(originalTimer);
+    expect(state.store?.jobs.map((entry) => entry.id)).toEqual([job.id]);
+    expect((await loadCronStore(storePath)).jobs.map((entry) => entry.id)).toEqual([job.id]);
+
+    await expect(remove(state, job.id)).resolves.toEqual({ ok: true, removed: true });
+
+    expect(persist).toHaveBeenCalledOnce();
+    expect(cronStoreModule.getCronJobsStoreRevision(storePath)).toBeGreaterThan(previousRevision);
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: job.id, action: "removed" }),
+    );
+    expect((await loadCronStore(storePath)).jobs).toEqual([]);
+  });
+
   it("rolls back an added job from the live store when persist fails", async () => {
     const { storePath } = await makeStorePath();
     const now = Date.parse("2026-06-09T00:00:00.000Z");

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -1840,6 +1840,26 @@ describe("cron service ops persist rollback", () => {
     expect(stored?.name).toBe("daily cleanup");
   });
 
+  it("does not clone the store before a missing or invalid update reaches commit", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-06-09T00:00:00.000Z");
+    const state = createOkIsolatedCronState({ storePath, now });
+    const job = await add(state, makeCreateInput("daily cleanup"));
+    const clone = vi.spyOn(globalThis, "structuredClone");
+
+    await expect(update(state, "missing-job", { name: "missing" })).rejects.toThrow(
+      "unknown cron job id",
+    );
+    await expect(
+      update(state, job.id, { schedule: { kind: "cron", expr: "0 0 30 2 *" } }),
+    ).rejects.toThrow(/no upcoming run time/);
+
+    expect(clone).not.toHaveBeenCalledWith(state.store);
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+  });
+
   it("keeps a removed job in the live store when persist fails", async () => {
     const { storePath } = await makeStorePath();
     const now = Date.parse("2026-06-09T00:00:00.000Z");
@@ -1876,6 +1896,37 @@ describe("cron service ops persist rollback", () => {
 
     expect(state.store?.jobs[0]?.state.startupCatchupAtMs).toBe(now + 5_000);
     expect(state.store?.jobs.map((entry) => entry.id)).toEqual([job.id]);
+  });
+
+  it("restores read-maintenance fields in place when persist fails", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-06-09T00:00:00.000Z");
+    const state = createOkIsolatedCronState({ storePath, now });
+    const job = await add(state, {
+      ...makeCreateInput("read repair"),
+      schedule: { kind: "every", everyMs: 60_000 },
+    });
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+    job.schedule = { kind: "every", everyMs: 60_000 };
+    job.state.nextRunAtMs = Number.NaN;
+    job.state.startupCatchupAtMs = now - 1;
+    const storeIdentity = state.store;
+    const jobIdentity = job;
+    const before = structuredClone({
+      enabled: job.enabled,
+      schedule: job.schedule,
+      state: job.state,
+    });
+
+    vi.spyOn(cronStoreModule, "saveCronJobsStore").mockRejectedValueOnce(new Error("disk full"));
+
+    await expect(list(state, { includeDisabled: true })).rejects.toThrow("disk full");
+
+    expect(state.store).toBe(storeIdentity);
+    expect(state.store?.jobs[0]).toBe(jobIdentity);
+    expect({ enabled: job.enabled, schedule: job.schedule, state: job.state }).toEqual(before);
   });
 
   it("recovers after a failed persist so the next mutation succeeds", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes cron-service hot paths where removing a missing job still rewrote SQLite and re-armed the scheduler even though nothing was deleted. It also avoids cloning the complete sorted cron store merely to return one requested list page, and keeps stale service instances correctly scheduled after they load a newer sibling-service snapshot.

## Why This Change Was Made

The first page-only clone removed the obvious full-result copy, but read maintenance could still clone the full store for rollback. This change narrows rollback to the maintenance-owned job fields while preserving the live store and job object identities on failure. Mutation snapshots are now taken only at commit, list revisions still hash the complete sorted result while cloning only returned page rows, and a stale service re-arms its timer when a missing removal loads a replacement store snapshot.

No configuration, SQLite schema, protocol, or public API changes are included.

## User Impact

Cron reads and missing-job removals avoid unnecessary full-store copies and durable writes. Concurrent service instances also continue to fire the earliest loaded job instead of retaining a timer derived from a stale snapshot.

## Evidence

- Focused regression suite: `node scripts/run-vitest.mjs src/cron/service.list-page-sort-guards.test.ts src/cron/service/ops.test.ts src/cron/service.prevents-duplicate-timers.test.ts` — 3 files, 86 tests passed.
- Final list-page wording/assertion proof: 18 tests passed.
- Current-main session-cleanup integration: the loaded-host four-file run passed 92/93 before one cleanup wait timed out; an isolated no-code-change rerun passed all 7 session-cleanup tests.
- `git diff --check` passed.
- Fresh branch autoreview completed cleanly with no accepted/actionable P0-P2 findings.
- Production LOC after the current-main rebase: +64/-48 (net +16). Test LOC: +179/-7 (net +172).
- Exact-head hosted CI: run 31306022774 passed for `ed415b7aee338aae3f86fe865bfcf8726de1a14a` — https://github.com/openclaw/openclaw/actions/runs/31306022774.
- Exact-head Workflow Sanity: run 31306022788 passed — https://github.com/openclaw/openclaw/actions/runs/31306022788.
- Repository-native hosted prepare passed at the exact head on 2026-08-09 (`OPENCLAW_TESTBOX=1 scripts/pr prepare-run 120910`, gate artifact generated 2026-08-09T09:38:51Z). The guard marked Blacksmith Testbox, ARM Testbox, and Build Artifacts Testbox workflows not applicable, so no separate Testbox lease/run ID or URL was allocated.

Known follow-ups outside this PR: automatic cleanup of deletion scratch data, and revision-aware handling for multi-page consumers.
