### PR TITLE
fix(macos): prevent shared state in parallel test suites

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -32683,7 +32683,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 913,
+      "line": 947,
       "path": "apps/macos/Sources/OpenClaw/ExecApprovalsStore.swift",
       "source": "missing:\\(hash)",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsStore.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsStore.swift
@@ -98,6 +98,9 @@ final class ExecApprovalsMigrationRequiredCache: @unchecked Sendable {
 }
 
 enum ExecApprovalsStore {
+    // Test stores are task-scoped so parallel suites cannot redirect unrelated
+    // shared-state consumers through the process environment.
+    @TaskLocal private static var scopedStateDirectoryURL: URL?
     private static let logger = Logger(subsystem: "ai.openclaw", category: "exec-approvals")
     private static let migrationRequiredCache = ExecApprovalsMigrationRequiredCache { event in
         switch event {
@@ -115,6 +118,29 @@ enum ExecApprovalsStore {
     private static let defaultAsk: ExecAsk = .off
     private static let defaultAskFallback: ExecSecurity = .deny
     private static let defaultAutoAllowSkills = false
+
+    #if compiler(>=6.4)
+    nonisolated(nonsending) static func withStateDirectory<T>(
+        _ url: URL,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$scopedStateDirectoryURL.withValue(url) {
+            try await operation()
+        }
+    }
+    #else
+    static func withStateDirectory<T>(
+        _ url: URL,
+        operation: () async throws -> T,
+        isolation: isolated (any Actor)? = #isolation) async rethrows -> T
+    {
+        try await self.$scopedStateDirectoryURL.withValue(
+            url,
+            operation: operation,
+            isolation: isolation)
+    }
+    #endif
+
     static func databaseURL() -> URL {
         ExecApprovalsSQLiteStore.databaseURL(stateDirectoryURL: self.stateDirURL())
     }
@@ -133,6 +159,9 @@ enum ExecApprovalsStore {
     }
 
     private static func stateDirURL() -> URL {
+        if let scopedStateDirectoryURL {
+            return scopedStateDirectoryURL
+        }
         guard let configured = OpenClawEnv.path("OPENCLAW_STATE_DIR") else {
             return self.homeURL().appendingPathComponent(".openclaw", isDirectory: true)
         }
@@ -387,8 +416,13 @@ enum ExecApprovalsStore {
     static func resolveAsyncResult(
         agentId: String?) async -> Result<ExecApprovalsResolved, ExecApprovalsReadError>
     {
-        await Task.detached(priority: .userInitiated) {
-            self.resolveResult(agentId: agentId)
+        let stateDirectoryURL = self.stateDirURL()
+        // Detached work does not inherit task-local values; bind the prepared
+        // root again so one read cannot mix database and socket directories.
+        return await Task.detached(priority: .userInitiated) {
+            self.$scopedStateDirectoryURL.withValue(stateDirectoryURL) {
+                self.resolveResult(agentId: agentId)
+            }
         }.value
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/ExecAllowlistTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecAllowlistTests.swift
@@ -973,7 +973,8 @@ struct ExecAllowlistTests {
         #expect(resolutions[0].executableName == "env")
     }
 
-    @Test func `approval evaluator resolves shell payload from canonical wrapper text`() async {
+    @Test(.execApprovalsStateIsolated)
+    func `approval evaluator resolves shell payload from canonical wrapper text`() async {
         let command = ["/bin/sh", "-c", "/usr/bin/printf ok"]
         let rawCommand = "/bin/sh -c \"/usr/bin/printf ok\""
         let evaluation = await ExecApprovalEvaluator.evaluate(
@@ -990,7 +991,8 @@ struct ExecAllowlistTests {
         #expect(evaluation.boundCommand == ["/usr/bin/printf", "ok"])
     }
 
-    @Test func `approval evaluator keeps login shell requests non-reusable`() async {
+    @Test(.execApprovalsStateIsolated)
+    func `approval evaluator keeps login shell requests non-reusable`() async {
         let rawCommand = "/usr/bin/printf safe"
         let evaluation = await ExecApprovalEvaluator.evaluate(
             command: ["/bin/sh", "-lc", rawCommand],

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
@@ -159,18 +159,12 @@ struct ExecApprovalsSocketPathGuardTests {
     }
 
     @Test
-    func `socket path resolves under the configured state directory`() async throws {
+    func `socket path resolves under the configured state directory`() async {
         let stateDir = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager().removeItem(at: stateDir) }
 
-        // String-level assertion only. The isolation lock serializes env
-        // mutation but not env consumption: concurrent suites that resolve
-        // OPENCLAW_STATE_DIR mid-window would create this directory and the
-        // old filesystem assertions here flaked on their 0755 default
-        // (#104019). Creation-with-0700 is covered by the explicit-path
-        // tests in this suite.
-        await TestIsolation.withEnvValues(["OPENCLAW_STATE_DIR": stateDir.path]) {
+        await ExecApprovalsStore.withStateDirectory(stateDir) {
             let socketPath = ExecApprovalsStore.socketPath()
             #expect(socketPath == stateDir.appendingPathComponent("exec-approvals.sock").path)
         }

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
@@ -14,77 +14,20 @@ struct ExecApprovalsStoreRefactorTests {
         return FileManager().temporaryDirectory.resolvingSymlinksInPath()
     }
 
-    private func withLockedEnv(
-        _ values: [String: String?],
-        _ body: () async throws -> Void) async throws
-    {
-        func restoreEnv(_ values: [String: String?]) {
-            for (key, value) in values {
-                if let value {
-                    setenv(key, value, 1)
-                } else {
-                    unsetenv(key)
-                }
-            }
-        }
-
-        await TestIsolationLock.shared.acquire()
-        var previousEnv: [String: String?] = [:]
-        for (key, value) in values {
-            previousEnv[key] = getenv(key).map { String(cString: $0) }
-            if let value {
-                setenv(key, value, 1)
-            } else {
-                unsetenv(key)
-            }
-        }
-
-        do {
-            try await body()
-            restoreEnv(previousEnv)
-            await TestIsolationLock.shared.release()
-        } catch {
-            restoreEnv(previousEnv)
-            await TestIsolationLock.shared.release()
-            throw error
-        }
-    }
-
     private func withTempStateDir(
+        seedCurrentApprovals: Bool = true,
         _ body: @escaping @Sendable (URL) async throws -> Void) async throws
     {
         let root = self.realTemporaryDirectory
             .appendingPathComponent("openclaw-state-\(UUID().uuidString)", isDirectory: true)
-        let home = root.appendingPathComponent("home", isDirectory: true)
         let stateDir = root.appendingPathComponent("state", isDirectory: true)
         defer { try? FileManager().removeItem(at: root) }
-        try Self.seedCurrentApprovalsFile(in: stateDir)
-
-        try await self.withLockedEnv([
-            "OPENCLAW_HOME": home.path,
-            "OPENCLAW_PROFILE": nil,
-            "OPENCLAW_STATE_DIR": stateDir.path,
-        ]) {
-            try await body(stateDir)
+        if seedCurrentApprovals {
+            try Self.seedCurrentApprovalsFile(in: stateDir)
         }
-    }
 
-    private func withTempHomeAndStateDir(
-        profile: String? = nil,
-        _ body: @escaping @Sendable (URL, URL) async throws -> Void) async throws
-    {
-        let root = self.realTemporaryDirectory
-            .appendingPathComponent("openclaw-home-state-\(UUID().uuidString)", isDirectory: true)
-        let home = root.appendingPathComponent("home", isDirectory: true)
-        let stateDir = root.appendingPathComponent("state", isDirectory: true)
-        defer { try? FileManager().removeItem(at: root) }
-
-        try await self.withLockedEnv([
-            "OPENCLAW_HOME": home.path,
-            "OPENCLAW_PROFILE": profile,
-            "OPENCLAW_STATE_DIR": stateDir.path,
-        ]) {
-            try await body(home, stateDir)
+        try await ExecApprovalsStore.withStateDirectory(stateDir) {
+            try await body(stateDir)
         }
     }
 
@@ -108,6 +51,23 @@ struct ExecApprovalsStoreRefactorTests {
             #expect(resolved.agent.ask == .off)
             #expect(resolved.agent.askFallback == .deny)
             #expect(!resolved.agent.autoAllowSkills)
+        }
+    }
+
+    @Test
+    func `task scoped state directory survives detached async reads`() async throws {
+        try await self.withTempStateDir { stateDirectoryURL in
+            _ = try ExecApprovalsStore.updateDefaults { defaults in
+                defaults.security = .allowlist
+                defaults.ask = .onMiss
+            }.get()
+
+            let resolved = try await ExecApprovalsStore.resolveDefaultsAsyncResult().get()
+
+            #expect(resolved.security == .allowlist)
+            #expect(resolved.ask == .onMiss)
+            #expect(ExecApprovalsStore.databaseURL() == ExecApprovalsSQLiteStore.databaseURL(
+                stateDirectoryURL: stateDirectoryURL))
         }
     }
 
@@ -150,7 +110,7 @@ struct ExecApprovalsStoreRefactorTests {
 
     @Test
     func `legacy migration failure is typed and removal recovers without restart`() async throws {
-        try await self.withTempHomeAndStateDir { _, stateDirectoryURL in
+        try await self.withTempStateDir { stateDirectoryURL in
             let legacyFileURL = stateDirectoryURL.appendingPathComponent("exec-approvals.json")
             try FileManager.default.createDirectory(
                 at: stateDirectoryURL,
@@ -184,7 +144,7 @@ struct ExecApprovalsStoreRefactorTests {
         defer { try? FileManager().removeItem(at: root) }
         try Self.seedCurrentApprovalsFile(in: stateDir)
 
-        try await self.withLockedEnv([
+        try await TestIsolation.withEnvValues([
             "OPENCLAW_HOME": home.path,
             "OPENCLAW_STATE_DIR": nil,
         ]) {
@@ -308,7 +268,7 @@ struct ExecApprovalsStoreRefactorTests {
 
     @Test
     func `missing and present empty snapshots have distinct hashes`() async throws {
-        try await self.withTempHomeAndStateDir { _, _ in
+        try await self.withTempStateDir(seedCurrentApprovals: false) { _ in
             let missing = ExecApprovalsStore.readSnapshot()
             #expect(!missing.exists)
             #expect(missing.hash.hasPrefix("missing:"))

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsUIRollbackTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsUIRollbackTests.swift
@@ -292,14 +292,10 @@ struct ExecApprovalsUIRollbackTests {
     {
         let root = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-approvals-ui-\(UUID().uuidString)", isDirectory: true)
-        let home = root.appendingPathComponent("home", isDirectory: true)
         let stateDir = root.appendingPathComponent("state", isDirectory: true)
         defer { try? FileManager().removeItem(at: root) }
 
-        return try await TestIsolation.withIsolatedState(env: [
-            "OPENCLAW_HOME": home.path,
-            "OPENCLAW_STATE_DIR": stateDir.path,
-        ]) {
+        return try await ExecApprovalsStore.withStateDirectory(stateDir) {
             try await body(stateDir)
         }
     }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
@@ -206,12 +206,27 @@ struct GatewayChannelConnectTests {
         }
     }
 
+    private func withChannel<T>(
+        _ channel: GatewayChannelActor,
+        operation: (GatewayChannelActor) async throws -> T) async throws -> T
+    {
+        do {
+            let result = try await operation(channel)
+            await channel.shutdown()
+            return result
+        } catch {
+            await channel.shutdown()
+            throw error
+        }
+    }
+
     @Test func `concurrent connect is single flight on success`() async throws {
         let session = self.makeSession(response: .helloOk(delayMs: 200))
         let channel = try GatewayChannelActor(
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
 
         let t1 = Task { try await channel.connect() }
         let t2 = Task { try await channel.connect() }
@@ -235,7 +250,8 @@ struct GatewayChannelConnectTests {
         let channel = try GatewayChannelActor(
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
 
         try await channel.connect()
 
@@ -282,7 +298,8 @@ struct GatewayChannelConnectTests {
         let channel = try GatewayChannelActor(
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
 
         let t1 = Task { try await channel.connect() }
         let t2 = Task { try await channel.connect() }
@@ -291,10 +308,18 @@ struct GatewayChannelConnectTests {
         let r2 = await t2.result
 
         #expect({
-            if case .failure = r1 { true } else { false }
+            if case .failure = r1 {
+                true
+            } else {
+                false
+            }
         }())
         #expect({
-            if case .failure = r2 { true } else { false }
+            if case .failure = r2 {
+                true
+            } else {
+                false
+            }
         }())
         #expect(session.snapshotMakeCount() == 1)
     }
@@ -305,7 +330,8 @@ struct GatewayChannelConnectTests {
         let channel = try GatewayChannelActor(
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
 
         await #expect(throws: (any Error).self) {
             try await channel.connect()
@@ -352,7 +378,8 @@ struct GatewayChannelConnectTests {
         let channel = try GatewayChannelActor(
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
 
         await #expect(throws: (any Error).self) {
             try await channel.connect()
@@ -449,16 +476,18 @@ struct GatewayChannelConnectTests {
                 token: nil,
                 session: WebSocketSessionBox(session: session))
 
-            try await channel.connect()
+            try await self.withChannel(channel) { channel in
+                try await channel.connect()
 
-            #expect(capture.snapshot() == [
-                "operator.admin",
-                "operator.read",
-                "operator.write",
-                "operator.approvals",
-                "operator.questions",
-                "operator.pairing",
-            ])
+                #expect(capture.snapshot() == [
+                    "operator.admin",
+                    "operator.read",
+                    "operator.write",
+                    "operator.approvals",
+                    "operator.questions",
+                    "operator.pairing",
+                ])
+            }
         }
     }
 
@@ -476,7 +505,8 @@ struct GatewayChannelConnectTests {
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
             bootstrapToken: "setup-bootstrap-token",
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
 
         try await channel.connect()
 
@@ -511,9 +541,11 @@ struct GatewayChannelConnectTests {
                 token: nil,
                 session: WebSocketSessionBox(session: session))
 
-            try await channel.connect()
+            try await self.withChannel(channel) { channel in
+                try await channel.connect()
 
-            #expect(capture.snapshot() == storedEntry.scopes)
+                #expect(capture.snapshot() == storedEntry.scopes)
+            }
         }
     }
 
@@ -550,9 +582,11 @@ struct GatewayChannelConnectTests {
                     clientMode: "ui",
                     clientDisplayName: "OpenClaw macOS Debug CLI"))
 
-            try await channel.connect()
+            try await self.withChannel(channel) { channel in
+                try await channel.connect()
 
-            #expect(capture.snapshot() == requestedScopes)
+                #expect(capture.snapshot() == requestedScopes)
+            }
         }
     }
 
@@ -565,7 +599,8 @@ struct GatewayChannelConnectTests {
         let channel = try GatewayChannelActor(
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
 
         do {
             try await channel.connect()
@@ -593,7 +628,8 @@ struct GatewayChannelConnectTests {
         let channel = try GatewayChannelActor(
             url: #require(URL(string: "wss://gateway.example.ts.net")),
             token: nil,
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
 
         do {
             try await channel.connect()

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelDisconnectTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelDisconnectTests.swift
@@ -110,6 +110,7 @@ struct GatewayChannelDisconnectTests {
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
             session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions,
             disconnectHandler: { reason, _ in await disconnects.record(reason) })
 
         try await channel.connect()
@@ -164,6 +165,7 @@ struct GatewayChannelDisconnectTests {
                     await snapshots.record()
                 }
             },
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions,
             disconnectHandler: { reason, _ in
                 await disconnects.record(reason)
                 await cleanupGate.wait()
@@ -271,6 +273,7 @@ struct GatewayChannelDisconnectTests {
                     await snapshots.record()
                 }
             },
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions,
             disconnectHandler: { _, _ in })
 
         try await channel.connect()
@@ -318,6 +321,7 @@ struct GatewayChannelDisconnectTests {
                     await seqGapGate.wait()
                 }
             },
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions,
             disconnectHandler: { _, _ in })
 
         try await channel.connect()
@@ -353,6 +357,7 @@ struct GatewayChannelDisconnectTests {
                     await snapshots.record()
                 }
             },
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions,
             disconnectHandler: { _, _ in })
 
         try await channel.connect()
@@ -406,6 +411,7 @@ struct GatewayChannelDisconnectTests {
                     await snapshots.record()
                 }
             },
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions,
             disconnectHandler: { reason, _ in
                 await disconnects.record(reason)
                 await cleanupGate.wait()

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelRequestTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelRequestTests.swift
@@ -66,7 +66,8 @@ struct GatewayChannelRequestTests {
         let channel = try GatewayChannelActor(
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
 
         do {
             _ = try await channel.request(method: "test", params: nil, timeoutMs: 10)
@@ -97,7 +98,8 @@ struct GatewayChannelRequestTests {
         let channel = try GatewayChannelActor(
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
 
         await #expect(throws: CancellationError.self) {
             try await channel.request(method: "cancelled-send", params: nil, timeoutMs: 5000)
@@ -123,7 +125,8 @@ struct GatewayChannelRequestTests {
         let channel = try GatewayChannelActor(
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
         let request = Task {
             try await channel.request(method: "cancel-me", params: nil, timeoutMs: 5000)
         }
@@ -160,7 +163,8 @@ struct GatewayChannelRequestTests {
         let channel = try GatewayChannelActor(
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
         let resumedGate = GatewayRequestStartGate()
         await channel._test_setRequestResumedHandler { await resumedGate.wait() }
         let request = Task {
@@ -194,7 +198,8 @@ struct GatewayChannelRequestTests {
         let channel = try GatewayChannelActor(
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
         let resumedGate = GatewayRequestStartGate()
         await channel._test_setRequestResumedHandler { await resumedGate.wait() }
         let request = Task {
@@ -219,7 +224,8 @@ struct GatewayChannelRequestTests {
         let channel = try GatewayChannelActor(
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
         try await channel.connect()
         let socket = try #require(session.latestTask())
         #expect(socket.snapshotSendCount() == 1)
@@ -246,7 +252,8 @@ struct GatewayChannelRequestTests {
         let channel = try GatewayChannelActor(
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
         try await channel.connect()
         let socket = try #require(session.latestTask())
         #expect(socket.snapshotSendCount() == 1)
@@ -279,7 +286,8 @@ struct GatewayChannelRequestTests {
         let channel = try GatewayChannelActor(
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
         let connecting = Task { try await channel.connect() }
         await connectGate.waitUntilEntered()
         let request = Task {
@@ -322,7 +330,8 @@ struct GatewayChannelRequestTests {
         let channel = try GatewayChannelActor(
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
         let initiator = Task { try await channel.connect() }
         await connectGate.waitUntilEntered()
         let peer = Task { try await channel.connect() }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelShutdownTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelShutdownTests.swift
@@ -50,7 +50,8 @@ struct GatewayChannelShutdownTests {
         let channel = try GatewayChannelActor(
             url: #require(URL(string: "ws://example.invalid")),
             token: nil,
-            session: WebSocketSessionBox(session: session))
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
 
         // Establish a connection so `listen()` is active.
         try await channel.connect()

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
@@ -1,5 +1,5 @@
 import Foundation
-import OpenClawKit
+@testable import OpenClawKit
 
 extension WebSocketTasking {
     /// Keep unit-test doubles resilient to protocol additions.
@@ -9,6 +9,17 @@ extension WebSocketTasking {
 }
 
 enum GatewayWebSocketTestSupport {
+    static let identityFreeOperatorConnectOptions = GatewayConnectOptions(
+        role: "operator",
+        scopes: GatewayChannelActor.defaultOperatorConnectScopes,
+        caps: [],
+        commands: [],
+        permissions: [:],
+        clientId: "openclaw-macos",
+        clientMode: "ui",
+        clientDisplayName: "OpenClaw macOS Test",
+        includeDeviceIdentity: false)
+
     static func connectChallengeData(
         nonce: String = "test-nonce",
         ts: Int64 = 1_800_000_000_000) -> Data

--- a/apps/macos/Tests/OpenClawIPCTests/TestIsolation.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TestIsolation.swift
@@ -1,4 +1,7 @@
 import Foundation
+import Testing
+@testable import OpenClaw
+@testable import OpenClawKit
 
 actor TestIsolationLock {
     static let shared = TestIsolationLock()
@@ -108,5 +111,25 @@ enum TestIsolation {
         FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-test-config-\(UUID().uuidString).json")
             .path
+    }
+}
+
+struct ExecApprovalsStateIsolationTrait: TestTrait, TestScoping {
+    func provideScope(
+        for test: Test,
+        testCase: Test.Case?,
+        performing function: @Sendable () async throws -> Void) async throws
+    {
+        let stateDirectory = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-approvals-state-\(UUID().uuidString)", isDirectory: true)
+        try FileManager().createDirectory(at: stateDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager().removeItem(at: stateDirectory) }
+        try await ExecApprovalsStore.withStateDirectory(stateDirectory, operation: function)
+    }
+}
+
+extension Trait where Self == ExecApprovalsStateIsolationTrait {
+    static var execApprovalsStateIsolated: Self {
+        Self()
     }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the macOS Swift test suite could fail nondeterministically when suites ran in parallel. Tests changed the process-global `OPENCLAW_STATE_DIR`, so concurrent work could resolve the shared SQLite state through another test's temporary directory. This surfaced as repeated `ExecApprovalsStoreRefactorTests.update` failures and gateway tests reporting that persisted identity was unavailable.

## Why This Change Was Made

Test state-directory overrides are now scoped with `TaskLocal` state instead of mutating process-global environment state. The override is propagated explicitly into detached work, which does not inherit task-local values automatically, so the shared SQLite owner resolves the intended state directory throughout each test's asynchronous lifetime.

Gateway tests no longer depend on persisted operator identity when identity is irrelevant to the behavior under test, and shutdown is scoped to the gateway channel owned by each test. Together these changes isolate parallel suites at the state owner and lifecycle boundaries instead of serializing the suite or masking the race downstream.

## User Impact

There is no end-user behavior change. Contributors and maintainers get deterministic parallel macOS test runs without cross-suite state collisions or one test shutting down another test's gateway channel.

## Evidence

- Before the repair, a full warm parallel run reproduced 10 `ExecApprovalsStoreRefactorTests.update` failures plus a gateway-channel failure reporting persisted identity unavailable.
- The affected suites passed 139/139 tests after the repair.
- `swift test --package-path apps/macos --parallel` passed three consecutive full runs, each with 1,654 tests across 180 suites.
- Fresh Codex autoreview completed with no findings.
- Additional remote proof on `megaclaw` with Xcode beta was limited by the environment's Sparkle rpath failure, so it did not provide an independent full-suite signal; the three complete SwiftPM parallel runs above are the full-run proof for this change.
