### PR TITLE
fix(agents): acknowledge steering only after durable transcript commits

### DIFF
--- a/src/agents/embedded-agent-runner.guard.test.ts
+++ b/src/agents/embedded-agent-runner.guard.test.ts
@@ -326,6 +326,36 @@ describe("guardSessionManager integration", () => {
     expect(recorder.hasPersisted()).toBe(true);
   });
 
+  it("marks the exact queued recorder blocked when a write hook suppresses its user message", () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_message_write",
+          handler: () => ({ block: true }),
+        },
+      ]),
+    );
+    const recorder = createUserTurnTranscriptRecorder({
+      input: { text: "queued prompt" },
+      target: createTestUserTurnTranscriptTarget(),
+    });
+    const preparedMessage = expectDefined(recorder.message, "expected prepared queued turn");
+    const runtimeMessage = attachRuntimeUserTurnTranscriptContext(
+      {
+        role: "user",
+        content: "runtime queued prompt",
+        timestamp: 456,
+      },
+      { message: preparedMessage, recorder },
+    );
+    const sm = guardSessionManager(SessionManager.inMemory());
+
+    sm.appendMessage(runtimeMessage);
+
+    expect(getMessages(sm)).toEqual([]);
+    expect(recorder.isBlocked()).toBe(true);
+  });
+
   it("does not consume prepared user persistence for before-agent-run blocked messages", () => {
     // Blocked messages are audit records, not the actual user turn that should
     // receive prepared media metadata.

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
@@ -2,7 +2,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { createUserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.js";
 import { createTestUserTurnTranscriptTarget } from "../../../sessions/user-turn-transcript.test-support.js";
-import { setSteeringMessageIdentity } from "../../sessions/steering-message-identity.js";
+import {
+  reportSteeringMessagePersistenceFailure,
+  setSteeringMessageIdentity,
+} from "../../sessions/steering-message-identity.js";
 import { steerActiveSessionWithOptionalDeliveryWait } from "./attempt.queue-message.js";
 
 type EmbeddedAgentActiveSessionSteerTarget = Parameters<
@@ -129,6 +132,47 @@ describe("embedded OpenClaw queued steering cancellation", () => {
 
     await expect(wait).resolves.toBeUndefined();
     expect(settled).toBe(true);
+  });
+
+  it("rejects only the exact drained steer when its transcript append fails", async () => {
+    const failedMessage = {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "same text" }],
+      timestamp: 1,
+    };
+    const survivingMessage = { ...failedMessage, timestamp: 2 };
+    setSteeringMessageIdentity(failedMessage, "failed-turn");
+    setSteeringMessageIdentity(survivingMessage, "surviving-turn");
+    const listeners = new Set<(event: unknown) => void>();
+    const activeSession: EmbeddedAgentActiveSessionSteerTarget = {
+      agent: { steeringQueue: { messages: [] } },
+      getSteeringMessages: () => [],
+      steer: async () => {},
+      subscribe: (listener) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    };
+    const failedWait = steerWithDeliveryWait(activeSession, "same text", 10_000, {
+      queueIdentity: "failed-turn",
+    });
+    const survivingWait = steerWithDeliveryWait(activeSession, "same text", 10_000, {
+      queueIdentity: "surviving-turn",
+    });
+    const rejection = expect(failedWait).rejects.toThrow("SQLite transcript append failed");
+
+    reportSteeringMessagePersistenceFailure(
+      failedMessage,
+      new Error("SQLite transcript append failed"),
+    );
+    await rejection;
+    expect(listeners).toHaveLength(1);
+
+    for (const listener of listeners) {
+      listener({ type: "message_end", message: survivingMessage });
+    }
+    await expect(survivingWait).resolves.toBeUndefined();
+    expect(listeners).toHaveLength(0);
   });
 
   it("removes only the timed-out steering message and preserves unrelated payloads", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
@@ -153,26 +153,34 @@ describe("embedded OpenClaw queued steering cancellation", () => {
         return () => listeners.delete(listener);
       },
     };
+    const abortController = new AbortController();
     const failedWait = steerWithDeliveryWait(activeSession, "same text", 10_000, {
       queueIdentity: "failed-turn",
+      abortSignal: abortController.signal,
     });
     const survivingWait = steerWithDeliveryWait(activeSession, "same text", 10_000, {
       queueIdentity: "surviving-turn",
+      abortSignal: abortController.signal,
     });
     const rejection = expect(failedWait).rejects.toThrow("SQLite transcript append failed");
 
-    reportSteeringMessagePersistenceFailure(
-      failedMessage,
-      new Error("SQLite transcript append failed"),
-    );
-    await rejection;
-    expect(listeners).toHaveLength(1);
+    try {
+      reportSteeringMessagePersistenceFailure(
+        failedMessage,
+        new Error("SQLite transcript append failed"),
+      );
+      await rejection;
+      expect(listeners).toHaveLength(1);
 
-    for (const listener of listeners) {
-      listener({ type: "message_end", message: survivingMessage });
+      for (const listener of listeners) {
+        listener({ type: "message_end", message: survivingMessage });
+      }
+      await expect(survivingWait).resolves.toBeUndefined();
+      expect(listeners).toHaveLength(0);
+    } finally {
+      abortController.abort();
+      await Promise.allSettled([failedWait, survivingWait, rejection]);
     }
-    await expect(survivingWait).resolves.toBeUndefined();
-    expect(listeners).toHaveLength(0);
   });
 
   it("removes only the timed-out steering message and preserves unrelated payloads", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
@@ -10,7 +10,10 @@ import {
   cancelPendingAgentQuestionForSession,
   claimPendingAgentQuestionAnswer,
 } from "../../harness/gateway-question.js";
-import { getSteeringMessageIdentity } from "../../sessions/steering-message-identity.js";
+import {
+  getSteeringMessageIdentity,
+  subscribeSteeringMessagePersistenceFailure,
+} from "../../sessions/steering-message-identity.js";
 import { log } from "../logger.js";
 import type {
   EmbeddedAgentQueueMessageOptions,
@@ -223,6 +226,7 @@ async function steerAndWaitForTranscriptCommit(
         clearTimeout(terminalTimer);
       }
       unsubscribe?.();
+      unsubscribePersistenceFailure?.();
       abortSignal?.removeEventListener("abort", onAbort);
       if (err) {
         reject(toErrorObject(err, "Non-Error rejection"));
@@ -297,6 +301,10 @@ async function steerAndWaitForTranscriptCommit(
         scheduleTerminalCancellation();
       }
     });
+    const unsubscribePersistenceFailure = subscribeSteeringMessagePersistenceFailure(
+      queueIdentity,
+      (error) => finish(error),
+    );
     if (abortRequested) {
       reportAcceptance(false);
       finish(new Error("queued steering message was cancelled before acceptance"));

--- a/src/agents/sessions/agent-session-base.ts
+++ b/src/agents/sessions/agent-session-base.ts
@@ -43,6 +43,7 @@ import type { ResourceLoader } from "./resource-loader.js";
 import type { SessionManager } from "./session-manager.js";
 import type { SettingsManager } from "./settings-manager.js";
 import type { SourceInfo } from "./source-info.js";
+import { reportSteeringMessagePersistenceFailure } from "./steering-message-identity.js";
 import { type BuildSystemPromptOptions, buildSystemPrompt } from "./system-prompt.js";
 
 const log = createSubsystemLogger("agents/session");
@@ -277,9 +278,9 @@ export abstract class AgentSessionBase {
   // Event Subscription
   // =========================================================================
 
-  /** Snapshot listeners because delivery confirmation can unsubscribe during dispatch. */
+  /** Copy-on-write listener registration keeps dispatch stable without per-event snapshots. */
   protected emit(event: AgentSessionEvent): void {
-    for (const l of this.eventListeners.slice()) {
+    for (const l of this.eventListeners) {
       void l(event);
     }
   }
@@ -288,7 +289,7 @@ export abstract class AgentSessionBase {
   private async emitTerminal(
     event: Extract<AgentSessionEvent, { type: "agent_end" }>,
   ): Promise<void> {
-    const listeners = this.eventListeners.slice();
+    const listeners = this.eventListeners;
     for (const listener of listeners) {
       try {
         await listener(event);
@@ -357,6 +358,7 @@ export abstract class AgentSessionBase {
 
     // Emit to extensions first
     const messageChangedByExtension = await this.emitExtensionEvent(event);
+    const publishAfterPersistence = event.type === "message_end" && event.message.role === "user";
 
     // Notify all listeners
     if (event.type === "agent_end") {
@@ -365,7 +367,7 @@ export abstract class AgentSessionBase {
         willRetry: this.willRetryAfterAgentEnd(event),
         ...(this.lastAssistantEntryId ? { assistantEntryId: this.lastAssistantEntryId } : {}),
       });
-    } else {
+    } else if (!publishAfterPersistence) {
       this.emit(event);
     }
 
@@ -389,12 +391,23 @@ export abstract class AgentSessionBase {
         const toolResultChangedByExtension =
           event.message.role === "toolResult" &&
           this.extensionModifiedToolResultIds.delete(event.message.toolCallId);
-        const entryId = this.sessionManager.appendMessage(event.message, {
-          invalidateSerializedPrefixCache:
-            messageChangedByExtension || toolResultChangedByExtension,
-        });
+        let entryId: string;
+        try {
+          entryId = this.sessionManager.appendMessage(event.message, {
+            invalidateSerializedPrefixCache:
+              messageChangedByExtension || toolResultChangedByExtension,
+          });
+        } catch (error) {
+          if (event.message.role === "user") {
+            reportSteeringMessagePersistenceFailure(event.message, error);
+          }
+          throw error;
+        }
         if (event.message.role === "assistant") {
           this.lastAssistantEntryId = entryId;
+        } else if (event.message.role === "user") {
+          // Receipt listeners may consume the queued source as soon as this event arrives.
+          this.emit(event);
         }
       }
       // Other message types (bashExecution, compactionSummary, branchSummary) are persisted elsewhere
@@ -547,13 +560,13 @@ export abstract class AgentSessionBase {
    * Multiple listeners can be added. Returns unsubscribe function for this listener.
    */
   subscribe(listener: AgentSessionEventListener): () => void {
-    this.eventListeners.push(listener);
+    this.eventListeners = [...this.eventListeners, listener];
 
     // Return unsubscribe function for this specific listener
     return () => {
       const index = this.eventListeners.indexOf(listener);
       if (index !== -1) {
-        this.eventListeners.splice(index, 1);
+        this.eventListeners = this.eventListeners.toSpliced(index, 1);
       }
     };
   }

--- a/src/agents/sessions/agent-session-base.ts
+++ b/src/agents/sessions/agent-session-base.ts
@@ -406,7 +406,8 @@ export abstract class AgentSessionBase {
         if (event.message.role === "assistant") {
           this.lastAssistantEntryId = entryId;
         } else if (event.message.role === "user") {
-          // Receipt listeners may consume the queued source as soon as this event arrives.
+          // A queued user message_end normally follows a committed append before listeners consume it.
+          // before_message_write suppression marks its recorder blocked first and is terminal without retry.
           this.emit(event);
         }
       }

--- a/src/agents/sessions/agent-session-loop-correctness.test.ts
+++ b/src/agents/sessions/agent-session-loop-correctness.test.ts
@@ -57,22 +57,29 @@ describe("AgentSession loop correctness", () => {
         );
       }
     });
+    const abortController = new AbortController();
     const wait = steerActiveSessionWithOptionalDeliveryWait(session, "commit before receipt", {
       deliveryTimeoutMs: 10_000,
       waitForTranscriptCommit: true,
+      abortSignal: abortController.signal,
     });
 
-    await vi.waitFor(() => expect(queuedMessages).toHaveLength(1));
-    const message = queuedMessages.shift();
-    expect(message).toBeDefined();
-    if (!message) {
-      return;
-    }
-    await handleAgentEvent({ type: "message_start", message });
-    await handleAgentEvent({ type: "message_end", message });
-    await expect(wait).resolves.toBeUndefined();
+    try {
+      await vi.waitFor(() => expect(queuedMessages).toHaveLength(1));
+      const message = queuedMessages.shift();
+      expect(message).toBeDefined();
+      if (!message) {
+        return;
+      }
+      await handleAgentEvent({ type: "message_start", message });
+      await handleAgentEvent({ type: "message_end", message });
+      await expect(wait).resolves.toBeUndefined();
 
-    expect(observedPersistedMessages).toEqual([true]);
+      expect(observedPersistedMessages).toEqual([true]);
+    } finally {
+      abortController.abort();
+      await Promise.allSettled([wait]);
+    }
   });
 
   it("rejects a consumed steer immediately when its transcript append fails", async () => {
@@ -96,27 +103,36 @@ describe("AgentSession loop correctness", () => {
       }
     });
     let sourceConsumed = false;
+    const abortController = new AbortController();
     const wait = steerActiveSessionWithOptionalDeliveryWait(session, "retain queued source", {
       deliveryTimeoutMs: 10_000,
       waitForTranscriptCommit: true,
+      abortSignal: abortController.signal,
     }).then(() => {
       sourceConsumed = true;
     });
     const rejection = expect(wait).rejects.toBe(persistenceError);
 
-    await vi.waitFor(() => expect(queuedMessages).toHaveLength(1));
-    const message = queuedMessages.shift();
-    expect(message).toBeDefined();
-    if (!message) {
-      return;
-    }
-    await handleAgentEvent({ type: "message_start", message });
-    await expect(handleAgentEvent({ type: "message_end", message })).rejects.toBe(persistenceError);
-    await rejection;
+    try {
+      await vi.waitFor(() => expect(queuedMessages).toHaveLength(1));
+      const message = queuedMessages.shift();
+      expect(message).toBeDefined();
+      if (!message) {
+        return;
+      }
+      await handleAgentEvent({ type: "message_start", message });
+      await expect(handleAgentEvent({ type: "message_end", message })).rejects.toBe(
+        persistenceError,
+      );
+      await rejection;
 
-    expect(sourceConsumed).toBe(false);
-    expect(publishedUserMessages).toEqual([]);
-    expect(sessionManager.getEntries().filter((entry) => entry.type === "message")).toEqual([]);
+      expect(sourceConsumed).toBe(false);
+      expect(publishedUserMessages).toEqual([]);
+      expect(sessionManager.getEntries().filter((entry) => entry.type === "message")).toEqual([]);
+    } finally {
+      abortController.abort();
+      await Promise.allSettled([wait, rejection]);
+    }
   });
 
   it.each([2, 3])(

--- a/src/agents/sessions/agent-session-loop-correctness.test.ts
+++ b/src/agents/sessions/agent-session-loop-correctness.test.ts
@@ -32,6 +32,93 @@ import { getSteeringMessageIdentity } from "./steering-message-identity.js";
 registerAgentSessionLoopTestLifecycle();
 
 describe("AgentSession loop correctness", () => {
+  it("publishes a queued user message only after its transcript entry is committed", async () => {
+    const { session, sessionManager } = await createTestSession();
+    type QueuedMessage = Parameters<SessionManager["appendMessage"]>[0];
+    const queuedMessages = (
+      session.agent as unknown as { steeringQueue: { messages: QueuedMessage[] } }
+    ).steeringQueue.messages;
+    const handleAgentEvent = Reflect.get(session, "handleAgentEvent") as (event: {
+      type: "message_start" | "message_end";
+      message: QueuedMessage;
+    }) => Promise<void>;
+    const observedPersistedMessages: boolean[] = [];
+    session.subscribe((event) => {
+      if (event.type === "message_end" && event.message.role === "user") {
+        observedPersistedMessages.push(
+          sessionManager
+            .getEntries()
+            .some(
+              (entry) =>
+                entry.type === "message" &&
+                entry.message.role === "user" &&
+                entry.message.timestamp === event.message.timestamp,
+            ),
+        );
+      }
+    });
+    const wait = steerActiveSessionWithOptionalDeliveryWait(session, "commit before receipt", {
+      deliveryTimeoutMs: 10_000,
+      waitForTranscriptCommit: true,
+    });
+
+    await vi.waitFor(() => expect(queuedMessages).toHaveLength(1));
+    const message = queuedMessages.shift();
+    expect(message).toBeDefined();
+    if (!message) {
+      return;
+    }
+    await handleAgentEvent({ type: "message_start", message });
+    await handleAgentEvent({ type: "message_end", message });
+    await expect(wait).resolves.toBeUndefined();
+
+    expect(observedPersistedMessages).toEqual([true]);
+  });
+
+  it("rejects a consumed steer immediately when its transcript append fails", async () => {
+    const { session, sessionManager } = await createTestSession();
+    type QueuedMessage = Parameters<SessionManager["appendMessage"]>[0];
+    const queuedMessages = (
+      session.agent as unknown as { steeringQueue: { messages: QueuedMessage[] } }
+    ).steeringQueue.messages;
+    const handleAgentEvent = Reflect.get(session, "handleAgentEvent") as (event: {
+      type: "message_start" | "message_end";
+      message: QueuedMessage;
+    }) => Promise<void>;
+    const persistenceError = new Error("SQLite transcript append failed");
+    vi.spyOn(sessionManager, "appendMessage").mockImplementation(() => {
+      throw persistenceError;
+    });
+    const publishedUserMessages: unknown[] = [];
+    session.subscribe((event) => {
+      if (event.type === "message_end" && event.message.role === "user") {
+        publishedUserMessages.push(event.message);
+      }
+    });
+    let sourceConsumed = false;
+    const wait = steerActiveSessionWithOptionalDeliveryWait(session, "retain queued source", {
+      deliveryTimeoutMs: 10_000,
+      waitForTranscriptCommit: true,
+    }).then(() => {
+      sourceConsumed = true;
+    });
+    const rejection = expect(wait).rejects.toBe(persistenceError);
+
+    await vi.waitFor(() => expect(queuedMessages).toHaveLength(1));
+    const message = queuedMessages.shift();
+    expect(message).toBeDefined();
+    if (!message) {
+      return;
+    }
+    await handleAgentEvent({ type: "message_start", message });
+    await expect(handleAgentEvent({ type: "message_end", message })).rejects.toBe(persistenceError);
+    await rejection;
+
+    expect(sourceConsumed).toBe(false);
+    expect(publishedUserMessages).toEqual([]);
+    expect(sessionManager.getEntries().filter((entry) => entry.type === "message")).toEqual([]);
+  });
+
   it.each([2, 3])(
     "confirms each of %i identical queued messages only after its own transcript commit",
     async (waiterCount) => {

--- a/src/agents/sessions/steering-message-identity.ts
+++ b/src/agents/sessions/steering-message-identity.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "../runtime/index.js";
 
 const STEERING_MESSAGE_IDENTITY = Symbol.for("openclaw.steeringMessageIdentity");
+const steeringMessagePersistenceFailureListeners = new Map<string, Set<(error: unknown) => void>>();
 
 export function setSteeringMessageIdentity(
   message: AgentMessage,
@@ -18,4 +19,33 @@ export function getSteeringMessageIdentity(message: unknown): string | undefined
   return message && typeof message === "object"
     ? ((message as Record<PropertyKey, unknown>)[STEERING_MESSAGE_IDENTITY] as string | undefined)
     : undefined;
+}
+
+/** Keeps persistence failures private to the exact in-flight steering identity. */
+export function subscribeSteeringMessagePersistenceFailure(
+  identity: string,
+  listener: (error: unknown) => void,
+): () => void {
+  const listeners = steeringMessagePersistenceFailureListeners.get(identity) ?? new Set();
+  listeners.add(listener);
+  steeringMessagePersistenceFailureListeners.set(identity, listeners);
+  return () => {
+    listeners.delete(listener);
+    if (
+      listeners.size === 0 &&
+      steeringMessagePersistenceFailureListeners.get(identity) === listeners
+    ) {
+      steeringMessagePersistenceFailureListeners.delete(identity);
+    }
+  };
+}
+
+/** Rejects a queued receipt before a failed append can strand or acknowledge its source. */
+export function reportSteeringMessagePersistenceFailure(message: unknown, error: unknown): void {
+  const identity = getSteeringMessageIdentity(message);
+  if (identity) {
+    steeringMessagePersistenceFailureListeners
+      .get(identity)
+      ?.forEach((listener) => listener(error));
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

Queued steering with transcript-commit waiting treated the embedded session's user `message_end` event as durable adoption, but `AgentSessionBase` published that event before `SessionManager.appendMessage()` committed the authoritative SQLite transcript row. If the append failed, the channel ingress source could be finalized even though the user turn was not durable.

## Why This Change Was Made

The session persistence owner now publishes queued user `message_end` only after the synchronous transcript append returns. If the append throws, an identity-scoped failure signal rejects only the exact steering waiter instead of stranding it until timeout or acknowledging a different identical message.

Listener registration is copy-on-write so unsubscribe and late-subscribe behavior remains snapshot-stable without allocating a listener copy for every event. Intentional `before_message_write` suppression remains a terminal non-retry disposition and is covered explicitly.

## User Impact

Messages steered into a busy embedded agent are no longer acknowledged as durably adopted before their transcript row exists. A real persistence failure preserves the source for the existing fallback path rather than silently consuming it, while intentional hook suppression still avoids replay.

Release-note context: busy-session steering now waits for authoritative transcript adoption before acknowledging the inbound message.

## Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts src/agents/sessions/agent-session-loop-correctness.test.ts src/agents/embedded-agent-runner.guard.test.ts` — 56 tests passed.
- `git diff --check` — clean.
- Codex-backed autoreview of the bounded maintainer prep diff — no accepted/actionable findings.
- Hosted exact-head CI is required again after the prep commit is pushed.