### PR TITLE
fix(telegram): route channel direct messages replies to their topic

### DIFF
--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -162,6 +162,10 @@ function resolveActionTopicNameCacheScope(cfg: OpenClawConfig, accountId?: strin
 
 function formatTelegramDeliveryTarget(to: string, messageThreadId?: number | null): string {
   const parsed = parseTelegramTarget(to);
+  const directTopicId = parsed.directMessagesTopicId;
+  if (directTopicId != null) {
+    return `${parsed.chatId}:direct-topic:${directTopicId}`;
+  }
   const topicId = messageThreadId ?? parsed.messageThreadId;
   if (topicId == null) {
     return to;

--- a/extensions/telegram/src/bot-handlers.callback-actions.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.runtime.ts
@@ -1,6 +1,6 @@
 import type { Message } from "grammy/types";
 import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
-import { buildTelegramThreadParams, resolveTelegramThreadSpec } from "./bot/helpers.js";
+import { buildTelegramThreadParams, resolveTelegramMessageThreadSpec } from "./bot/helpers.js";
 import { buildInlineKeyboard } from "./send.js";
 
 export type TelegramCallbackButton = {
@@ -35,7 +35,7 @@ export function createTelegramCallbackMessageActions(params: {
   isGroup: boolean;
   isForum: boolean;
 }): TelegramCallbackMessageActions {
-  const { bot, callbackMessage, isGroup, isForum } = params;
+  const { bot, callbackMessage, isForum } = params;
   const callbackBusinessParams =
     callbackMessage.business_connection_id !== undefined
       ? { business_connection_id: callbackMessage.business_connection_id }
@@ -82,22 +82,16 @@ export function createTelegramCallbackMessageActions(params: {
     replyParams?: Parameters<typeof bot.api.sendMessage>[2],
   ) => {
     const threadParams = buildTelegramThreadParams(
-      resolveTelegramThreadSpec({
-        isGroup,
-        isForum,
-        messageThreadId: callbackMessage.message_thread_id,
-      }),
+      resolveTelegramMessageThreadSpec(callbackMessage, isForum),
     );
-    const topicParams = {
-      ...callbackBusinessParams,
-      ...threadParams,
-      ...(callbackMessage.direct_messages_topic?.topic_id != null
-        ? { direct_messages_topic_id: callbackMessage.direct_messages_topic.topic_id }
-        : {}),
-    };
+    const {
+      message_thread_id: _messageThreadId,
+      direct_messages_topic_id: _directMessagesTopicId,
+      ...ordinaryReplyParams
+    } = replyParams ?? {};
     const mergedParams =
-      Object.keys(topicParams).length > 0 || replyParams
-        ? { ...topicParams, ...replyParams }
+      callbackBusinessParams || threadParams || replyParams
+        ? { ...ordinaryReplyParams, ...callbackBusinessParams, ...threadParams }
         : replyParams;
     return await bot.api.sendMessage(callbackMessage.chat.id, text, mergedParams);
   };

--- a/extensions/telegram/src/bot-handlers.inbound-debounce.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-debounce.runtime.ts
@@ -12,7 +12,12 @@ import type { TelegramMediaRef } from "./bot-message-context.js";
 import type { TelegramAmbientTranscriptWatermark } from "./bot-message-context.types.js";
 import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import type { TelegramSpooledReplayDeferredParticipant } from "./bot-processing-outcome.js";
-import { getTelegramTextParts, joinTelegramTextParts } from "./bot/helpers.js";
+import {
+  buildTelegramThreadParams,
+  getTelegramTextParts,
+  joinTelegramTextParts,
+  resolveTelegramMessageThreadSpec,
+} from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import type { TelegramMessageDispatchReplayClaim } from "./message-dispatch-dedupe.js";
 
@@ -199,12 +204,15 @@ export function createTelegramInboundDebounceRuntime(
       }
       const chatId = items[0]?.msg.chat.id;
       if (chatId != null) {
-        const threadId = items[0]?.msg.message_thread_id;
+        const firstMessage = items[0]?.msg;
+        const threadParams = firstMessage
+          ? buildTelegramThreadParams(resolveTelegramMessageThreadSpec(firstMessage))
+          : undefined;
         void bot.api
           .sendMessage(
             chatId,
             "Something went wrong while processing your message. Please try again.",
-            threadId != null ? { message_thread_id: threadId } : undefined,
+            threadParams,
           )
           .catch((sendError: unknown) => {
             logVerbose(`telegram: error fallback send failed: ${String(sendError)}`);

--- a/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
@@ -33,8 +33,8 @@ import {
   buildTelegramThreadParams,
   getTelegramTextParts,
   hasBotMention,
+  resolveTelegramMessageThreadSpec,
   resolveTelegramPrimaryMedia,
-  resolveTelegramThreadSpec,
 } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import { isTelegramForumServiceMessage } from "./forum-service-message.js";
@@ -373,11 +373,7 @@ export function createTelegramInboundMediaGroupRuntime(
               `⚠️ Received ${materializedCount} of ${entry.messages.length} images — ${skippedCount} could not be fetched and ${verb} skipped.`,
               {
                 ...buildTelegramThreadParams(
-                  resolveTelegramThreadSpec({
-                    isGroup: entry.isGroup,
-                    isForum: entry.isForum,
-                    messageThreadId: entry.resolvedThreadId ?? entry.dmThreadId,
-                  }),
+                  resolveTelegramMessageThreadSpec(primary.msg, entry.isForum),
                 ),
                 reply_parameters: {
                   message_id: primary.msg.message_id,

--- a/extensions/telegram/src/bot-handlers.inbound.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound.runtime.ts
@@ -35,8 +35,8 @@ import { resolveMedia } from "./bot/delivery.resolve-media.js";
 import {
   buildTelegramThreadParams,
   getTelegramTextParts,
+  resolveTelegramMessageThreadSpec,
   resolveTelegramPrimaryMedia,
-  resolveTelegramThreadSpec,
 } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import { resolveTelegramCommandIngressAuthorization } from "./ingress.js";
@@ -236,11 +236,7 @@ export function createTelegramHandlerInboundRuntime(
     } catch (mediaErr) {
       const replayingSpooledUpdate = isTelegramSpooledReplayUpdate(ctx.update);
       const warningThreadParams = buildTelegramThreadParams(
-        resolveTelegramThreadSpec({
-          isGroup,
-          isForum,
-          messageThreadId: resolvedThreadId ?? dmThreadId,
-        }),
+        resolveTelegramMessageThreadSpec(msg, isForum),
       );
       if (mediaRuntime.abortSignal?.aborted && isDurablyRetryableInboundMediaError(mediaErr)) {
         // Abort mid-media-resolution must stay retryable for live updates too;

--- a/extensions/telegram/src/bot-message-context.dm-threads.test.ts
+++ b/extensions/telegram/src/bot-message-context.dm-threads.test.ts
@@ -88,7 +88,7 @@ describe("buildTelegramMessageContext dm thread sessions", () => {
     message: Record<string, unknown>,
     params?: Pick<
       Parameters<typeof buildTelegramMessageContextForTest>[0],
-      "cfg" | "me" | "resolveTelegramGroupConfig"
+      "cfg" | "me" | "resolveTelegramGroupConfig" | "sendChatActionHandler"
     >,
   ) =>
     await buildTelegramMessageContextForTest({
@@ -130,7 +130,7 @@ describe("buildTelegramMessageContext dm thread sessions", () => {
     expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:main:thread:1234:42");
   });
 
-  it("does not use configured DM topics without bot topic capability", async () => {
+  it("does not use configured bot-private topics without bot topic capability", async () => {
     const ctx = await buildContext(
       {
         ...dmThreadMessage,
@@ -149,7 +149,7 @@ describe("buildTelegramMessageContext dm thread sessions", () => {
     expect(ctx?.ctxPayload?.SessionKey).toBe("agent:support:main");
   });
 
-  it("uses configured DM topic routing once bot topic capability is present", async () => {
+  it("uses configured bot-private topic routing once bot topic capability is present", async () => {
     const ctx = await buildContext(
       {
         ...dmThreadMessage,
@@ -184,11 +184,18 @@ describe("buildTelegramMessageContext dm thread sessions", () => {
 });
 
 describe("buildTelegramMessageContext group sessions without forum", () => {
-  const buildContext = async (message: Record<string, unknown>) =>
+  const buildContext = async (
+    message: Record<string, unknown>,
+    params?: Pick<
+      Parameters<typeof buildTelegramMessageContextForTest>[0],
+      "sendChatActionHandler"
+    >,
+  ) =>
     await buildTelegramMessageContextForTest({
       message,
       options: { forceWasMentioned: true },
       resolveGroupActivation: () => true,
+      ...params,
     });
 
   it("ignores message_thread_id for regular groups (not forums)", async () => {
@@ -210,6 +217,45 @@ describe("buildTelegramMessageContext group sessions without forum", () => {
     expect(ctx.ctxPayload.SessionKey).toBe("agent:main:telegram:group:-1001234567890");
     // MessageThreadId should be undefined (not a forum)
     expect(ctx.ctxPayload.MessageThreadId).toBeUndefined();
+  });
+
+  it("round-trips channel Direct Messages topics with their distinct target marker", async () => {
+    const sendChatAction = vi.fn(async () => undefined);
+    const ctx = await buildContext(
+      {
+        message_id: 8,
+        chat: {
+          id: -1001234567890,
+          type: "supergroup",
+          title: "Channel Direct Messages",
+          is_direct_messages: true,
+        },
+        date: 1700000007,
+        text: "@bot hello",
+        message_thread_id: 999,
+        direct_messages_topic: {
+          topic_id: 77,
+          user: { id: 700, is_bot: false, first_name: "Subscriber" },
+        },
+        from: { id: 700, first_name: "Subscriber" },
+      },
+      {
+        sendChatActionHandler: {
+          sendChatAction,
+          isSuspended: () => false,
+          reset: () => {},
+        },
+      },
+    );
+
+    expect(ctx?.ctxPayload.MessageThreadId).toBe(77);
+    expect(ctx?.ctxPayload.OriginatingTo).toBe("telegram:-1001234567890:direct-topic:77");
+    expect(ctx?.ctxPayload.SessionKey).toBe("agent:main:telegram:group:-1001234567890:topic:77");
+    expect(ctx?.turn.record.updateLastRoute).toMatchObject({
+      to: "telegram:-1001234567890:direct-topic:77",
+      threadId: "77",
+    });
+    expect(sendChatAction).not.toHaveBeenCalled();
   });
 
   it("carries the body-layer inbound event kind instead of restamping from copied mention booleans", async () => {

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -36,6 +36,7 @@ import {
   extractTelegramForumFlag,
   resolveTelegramForumFlag,
   resolveTelegramBotHasTopicsEnabled,
+  resolveTelegramMessageThreadSpec,
   resolveTelegramThreadSpec,
   shouldUseTelegramDmThreadSession,
 } from "./bot/helpers.js";
@@ -146,7 +147,7 @@ export const buildTelegramMessageContext = async ({
   const chatId = msg.chat.id;
   const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
   const senderId = msg.from?.id ? String(msg.from.id) : "";
-  const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
+  const isDirectMessagesChat = msg.chat.is_direct_messages === true;
   const reactionApi =
     typeof bot.api.setMessageReaction === "function"
       ? bot.api.setMessageReaction.bind(bot.api)
@@ -155,20 +156,21 @@ export const buildTelegramMessageContext = async ({
     typeof bot.api.getChat === "function"
       ? (bot.api.getChat.bind(bot.api) as TelegramGetChat)
       : undefined;
-  const isForum = await resolveTelegramForumFlag({
-    chatId,
-    chatType: msg.chat.type,
-    isGroup,
-    isForum: extractTelegramForumFlag(msg.chat),
-    isTopicMessage: msg.is_topic_message,
-    getChat: getChatApi,
-  });
-  const threadSpec = resolveTelegramThreadSpec({
-    isGroup,
-    isForum,
-    messageThreadId,
-  });
-  const resolvedThreadId = threadSpec.scope === "forum" ? threadSpec.id : undefined;
+  const isForum = isDirectMessagesChat
+    ? false
+    : await resolveTelegramForumFlag({
+        chatId,
+        chatType: msg.chat.type,
+        isGroup,
+        isForum: extractTelegramForumFlag(msg.chat),
+        isTopicMessage: msg.is_topic_message,
+        getChat: getChatApi,
+      });
+  const threadSpec = resolveTelegramMessageThreadSpec(msg, isForum);
+  const resolvedThreadId =
+    threadSpec.scope === "forum" || threadSpec.scope === "direct-messages"
+      ? threadSpec.id
+      : undefined;
   const replyThreadId = threadSpec.id;
   const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
   let topicName: string | undefined;
@@ -321,6 +323,9 @@ export const buildTelegramMessageContext = async ({
   }
 
   const sendTyping = async () => {
+    if (threadSpec.scope === "direct-messages") {
+      return;
+    }
     await withTelegramApiErrorLogging({
       operation: "sendChatAction",
       fn: () =>
@@ -333,6 +338,9 @@ export const buildTelegramMessageContext = async ({
   };
 
   const sendRecordVoice = async () => {
+    if (threadSpec.scope === "direct-messages") {
+      return;
+    }
     try {
       await withTelegramApiErrorLogging({
         operation: "sendChatAction",

--- a/extensions/telegram/src/bot-message-dispatch-delivery.ts
+++ b/extensions/telegram/src/bot-message-dispatch-delivery.ts
@@ -32,8 +32,7 @@ import type {
 } from "./bot-message-dispatch.types.js";
 import type { TelegramBotOptions } from "./bot.types.js";
 import { deliverReplies, emitTelegramMessageSentHooks } from "./bot/delivery.js";
-import type { TelegramThreadSpec } from "./bot/helpers.js";
-import { resolveTelegramReplyId } from "./bot/helpers.js";
+import { resolveTelegramReplyId, type TelegramThreadSpec } from "./bot/helpers.js";
 import type { TelegramNativeQuoteCandidateByMessageId } from "./bot/native-quote.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { canonicalizeTelegramPresentationPayload } from "./interactive-fallback.js";
@@ -266,7 +265,8 @@ export function createTelegramDeliveryController(params: {
       const durable = await durableDelivery({
         cfg: params.cfg,
         channel: "telegram",
-        to: String(context.chatId),
+        to:
+          context.ctxPayload.OriginatingTo ?? context.ctxPayload.To ?? `telegram:${context.chatId}`,
         accountId: context.route.accountId,
         agentId: context.route.agentId,
         ctxPayload: context.ctxPayload,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -94,6 +94,7 @@ import {
   resolveTelegramForumFlag,
   resolveTelegramGroupAllowFromContext,
   resolveTelegramBotHasTopicsEnabled,
+  resolveTelegramMessageThreadSpec,
   resolveTelegramThreadSpec,
   shouldUseTelegramDmThreadSession,
 } from "./bot/helpers.js";
@@ -162,7 +163,6 @@ type TelegramNativeCommandThreadContext = {
   chatId: number;
   isGroup: boolean;
   isForum: boolean;
-  messageThreadId: number | undefined;
   threadSpec: ReturnType<typeof resolveTelegramThreadSpec>;
   threadParams: ReturnType<typeof buildTelegramThreadParams>;
 };
@@ -589,29 +589,26 @@ async function resolveTelegramNativeCommandThreadContext(params: {
   const { msg, bot } = params;
   const chatId = msg.chat.id;
   const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
-  const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
   const getChat =
     typeof bot.api.getChat === "function"
       ? (bot.api.getChat.bind(bot.api) as TelegramGetChat)
       : undefined;
-  const isForum = await resolveTelegramForumFlag({
-    chatId,
-    chatType: msg.chat.type,
-    isGroup,
-    isForum: extractTelegramForumFlag(msg.chat),
-    isTopicMessage: msg.is_topic_message,
-    getChat,
-  });
-  const threadSpec = resolveTelegramThreadSpec({
-    isGroup,
-    isForum,
-    messageThreadId,
-  });
+  const isForum =
+    msg.chat.is_direct_messages === true
+      ? false
+      : await resolveTelegramForumFlag({
+          chatId,
+          chatType: msg.chat.type,
+          isGroup,
+          isForum: extractTelegramForumFlag(msg.chat),
+          isTopicMessage: msg.is_topic_message,
+          getChat,
+        });
+  const threadSpec = resolveTelegramMessageThreadSpec(msg, isForum);
   return {
     chatId,
     isGroup,
     isForum,
-    messageThreadId,
     threadSpec,
     threadParams: buildTelegramThreadParams(threadSpec),
   };
@@ -715,7 +712,7 @@ async function resolveTelegramCommandAuth(params: {
     resolveTelegramGroupConfig,
     requireAuth,
   } = params;
-  const { chatId, isGroup, isForum, messageThreadId, threadParams } =
+  const { chatId, isGroup, isForum, threadSpec, threadParams } =
     await resolveTelegramNativeCommandThreadContext({ msg, bot });
   const senderId = msg.from?.id ? String(msg.from.id) : "";
   const senderUsername = msg.from?.username ?? "";
@@ -743,8 +740,7 @@ async function resolveTelegramCommandAuth(params: {
     allowFrom,
     senderId,
     isGroup,
-    isForum,
-    messageThreadId,
+    threadSpec,
     groupAllowFrom,
     skipPairingStoreRead: Boolean(preContextCommandsAllowFromAccess?.isAuthorizedSender),
     readChannelAllowFromStore,
@@ -1106,12 +1102,7 @@ export const registerTelegramNativeCommands = ({
   } | null> => {
     const { msg, runtimeCfg, isGroup, isForum, resolvedThreadId, senderId, topicAgentId } = params;
     const chatId = msg.chat.id;
-    const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
-    const threadSpec = resolveTelegramThreadSpec({
-      isGroup,
-      isForum,
-      messageThreadId: resolvedThreadId ?? messageThreadId,
-    });
+    const threadSpec = resolveTelegramMessageThreadSpec(msg, isForum);
     const { route, bindingMode } = resolveTelegramConversationRoute({
       cfg: runtimeCfg,
       accountId,
@@ -1975,7 +1966,10 @@ export const registerTelegramNativeCommands = ({
           richMessages: runtimeTelegramCfg.richMessages,
         });
         const from = isGroup ? buildTelegramGroupFrom(chatId, threadSpec.id) : `telegram:${chatId}`;
-        const to = `telegram:${chatId}`;
+        const to =
+          threadSpec.scope === "direct-messages"
+            ? buildTelegramRoutingTarget(chatId, threadSpec)
+            : `telegram:${chatId}`;
         const { deliverReplies, emitTelegramMessageSentHooks } =
           await loadTelegramNativeCommandDeliveryRuntime();
         let progressMessageId: number | undefined;

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -2,10 +2,6 @@
 import type { MessageEntity } from "grammy/types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  buildTelegramInboundOriginTarget,
-  buildTelegramRoutingTarget,
-  buildTelegramThreadParams,
-  buildTypingThreadParams,
   describeReplyTarget,
   getTelegramTextParts,
   hasBotMention,
@@ -97,7 +93,7 @@ describe("resolveTelegramForumFlag", () => {
     expect(getChat).not.toHaveBeenCalled();
   });
 
-  it("does not treat private DM topic metadata as forum metadata", async () => {
+  it("does not treat bot-private topic metadata as forum metadata", async () => {
     const getChat = vi.fn(async () => ({ is_forum: true }));
     await expect(
       resolveTelegramForumFlag({
@@ -182,23 +178,6 @@ describe("resolveTelegramForumFlag", () => {
   });
 });
 
-describe("buildTelegramThreadParams", () => {
-  it.each([
-    { input: { id: 1, scope: "forum" as const }, expected: undefined },
-    { input: { id: 99, scope: "forum" as const }, expected: { message_thread_id: 99 } },
-    { input: { id: 1, scope: "dm" as const }, expected: { message_thread_id: 1 } },
-    { input: { id: 2, scope: "dm" as const }, expected: { message_thread_id: 2 } },
-    { input: { id: 0, scope: "dm" as const }, expected: undefined },
-    { input: { id: -1, scope: "dm" as const }, expected: undefined },
-    { input: { id: 1.9, scope: "dm" as const }, expected: { message_thread_id: 1 } },
-    // id=0 should be included for forum scope (not falsy).
-    { input: { id: 0, scope: "forum" as const }, expected: { message_thread_id: 0 } },
-    { input: { id: 42, scope: "none" as const }, expected: undefined },
-  ])("builds thread params", ({ input, expected }) => {
-    expect(buildTelegramThreadParams(input)).toEqual(expected);
-  });
-});
-
 describe("shouldUseTelegramDmThreadSession", () => {
   it("requires a DM thread id", () => {
     expect(
@@ -237,71 +216,6 @@ describe("resolveTelegramBotHasTopicsEnabled", () => {
   });
 });
 
-describe("buildTelegramRoutingTarget", () => {
-  it.each([
-    {
-      name: "keeps General forum topic chat-scoped",
-      chatId: -100123,
-      thread: { id: 1, scope: "forum" as const },
-      expected: "telegram:-100123",
-    },
-    {
-      name: "includes real forum topic ids",
-      chatId: -100123,
-      thread: { id: 42, scope: "forum" as const },
-      expected: "telegram:-100123:topic:42",
-    },
-    {
-      name: "falls back to bare chat when thread is missing",
-      chatId: -100123,
-      thread: null,
-      expected: "telegram:-100123",
-    },
-  ])("$name", ({ chatId, thread, expected }) => {
-    expect(buildTelegramRoutingTarget(chatId, thread)).toBe(expected);
-  });
-});
-
-describe("buildTelegramInboundOriginTarget", () => {
-  it.each([
-    {
-      name: "keeps DM topic thread ids out of the origin target",
-      chatId: 42,
-      thread: { id: 77, scope: "dm" as const },
-      expected: "telegram:42",
-    },
-    {
-      name: "keeps regular groups chat-scoped",
-      chatId: -100123,
-      thread: { scope: "none" as const },
-      expected: "telegram:-100123",
-    },
-    {
-      name: "keeps General forum topic chat-scoped",
-      chatId: -100123,
-      thread: { id: 1, scope: "forum" as const },
-      expected: "telegram:-100123",
-    },
-    {
-      name: "includes real forum topic ids",
-      chatId: -100123,
-      thread: { id: 42, scope: "forum" as const },
-      expected: "telegram:-100123:topic:42",
-    },
-  ])("$name", ({ chatId, thread, expected }) => {
-    expect(buildTelegramInboundOriginTarget(chatId, thread)).toBe(expected);
-  });
-});
-
-describe("buildTypingThreadParams", () => {
-  it.each([
-    { input: undefined, expected: undefined },
-    { input: 1, expected: { message_thread_id: 1 } },
-  ])("builds typing params", ({ input, expected }) => {
-    expect(buildTypingThreadParams(input)).toEqual(expected);
-  });
-});
-
 describe("resolveTelegramDirectPeerId", () => {
   it("prefers sender id when available", () => {
     expect(resolveTelegramDirectPeerId({ chatId: 777777777, senderId: 123456789 })).toBe(
@@ -313,21 +227,6 @@ describe("resolveTelegramDirectPeerId", () => {
     expect(resolveTelegramDirectPeerId({ chatId: 777777777, senderId: undefined })).toBe(
       "777777777",
     );
-  });
-});
-
-describe("thread id normalization", () => {
-  it.each([
-    {
-      build: () => buildTelegramThreadParams({ id: 42.9, scope: "forum" }),
-      expected: { message_thread_id: 42 },
-    },
-    {
-      build: () => buildTypingThreadParams(42.9),
-      expected: { message_thread_id: 42 },
-    },
-  ])("normalizes thread ids to integers", ({ build, expected }) => {
-    expect(build()).toEqual(expected);
   });
 });
 

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -15,6 +15,7 @@ import type {
 import { readChannelAllowFromStore } from "openclaw/plugin-sdk/conversation-runtime";
 import {
   asDateTimestampMs,
+  parseStrictPositiveInteger,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
@@ -103,7 +104,13 @@ function hadUnsafeTelegramText(raw: unknown, sanitized: string): boolean {
 
 export type TelegramThreadSpec = {
   id?: number;
-  scope: "dm" | "forum" | "none";
+  /** dm is the historical bot-private topic scope. */
+  scope: "direct-messages" | "dm" | "forum" | "none";
+};
+
+type TelegramThreadParams = {
+  direct_messages_topic_id?: number;
+  message_thread_id?: number;
 };
 
 export function shouldUseTelegramDmThreadSession(params: {
@@ -214,6 +221,7 @@ export async function resolveTelegramGroupAllowFromContext(params: {
   isGroup?: boolean;
   isForum?: boolean;
   messageThreadId?: number | null;
+  threadSpec?: TelegramThreadSpec;
   groupAllowFrom?: Array<string | number>;
   // Set when the caller has already authorized the sender by some other config
   // path (e.g. commands.allowFrom) and the pairing-store outcome cannot change
@@ -239,13 +247,17 @@ export async function resolveTelegramGroupAllowFromContext(params: {
   hasGroupAllowOverride: boolean;
 }> {
   const accountId = normalizeAccountId(params.accountId);
-  // Use resolveTelegramThreadSpec to handle both forum groups AND DM topics
-  const threadSpec = resolveTelegramThreadSpec({
-    isGroup: params.isGroup ?? false,
-    isForum: params.isForum,
-    messageThreadId: params.messageThreadId,
-  });
-  const resolvedThreadId = threadSpec.scope === "forum" ? threadSpec.id : undefined;
+  const threadSpec =
+    params.threadSpec ??
+    resolveTelegramThreadSpec({
+      isGroup: params.isGroup ?? false,
+      isForum: params.isForum,
+      messageThreadId: params.messageThreadId,
+    });
+  const resolvedThreadId =
+    threadSpec.scope === "forum" || threadSpec.scope === "direct-messages"
+      ? threadSpec.id
+      : undefined;
   const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
   const threadIdForConfig = resolvedThreadId ?? dmThreadId;
   const { groupConfig, topicConfig } = params.resolveTelegramGroupConfig(
@@ -395,10 +407,7 @@ export function resolveTelegramThreadSpec(params: {
       isForum: params.isForum,
       messageThreadId: params.messageThreadId,
     });
-    return {
-      id,
-      scope: params.isForum ? "forum" : "none",
-    };
+    return id === undefined ? { scope: "none" } : { id, scope: "forum" };
   }
   if (params.messageThreadId == null) {
     return { scope: "dm" };
@@ -409,12 +418,35 @@ export function resolveTelegramThreadSpec(params: {
   };
 }
 
+export function resolveTelegramMessageThreadSpec(
+  message: Message,
+  isForum?: boolean,
+): TelegramThreadSpec {
+  if (message.chat.is_direct_messages === true) {
+    const id = parseStrictPositiveInteger(message.direct_messages_topic?.topic_id);
+    return id === undefined ? { scope: "none" } : { id, scope: "direct-messages" };
+  }
+  const isGroup = message.chat.type === "group" || message.chat.type === "supergroup";
+  return resolveTelegramThreadSpec({
+    isGroup,
+    isForum:
+      isForum ??
+      resolveTelegramMessageForumFlagHint({
+        chatType: message.chat.type,
+        isForum: message.chat.is_forum,
+        isTopicMessage: message.is_topic_message,
+      }),
+    messageThreadId: message.message_thread_id,
+  });
+}
+
 /**
  * Build thread params for Telegram API calls (messages, media).
  *
  * IMPORTANT: Thread IDs behave differently based on chat type:
- * - DMs (private chats): Include message_thread_id when present (DM topics)
+ * - Bot-private topics: Include message_thread_id when present
  * - Forum topics: Skip thread_id=1 (General topic), include others
+ * - Channel Direct Messages topics: Include direct_messages_topic_id
  * - Regular groups: Thread IDs are ignored by Telegram
  *
  * General forum topic (id=1) must be treated like a regular supergroup send:
@@ -423,14 +455,24 @@ export function resolveTelegramThreadSpec(params: {
  * @param thread - Thread specification with ID and scope
  * @returns API params object or undefined if thread_id should be omitted
  */
-export function buildTelegramThreadParams(thread?: TelegramThreadSpec | null) {
+export function buildTelegramThreadParams(
+  thread?: TelegramThreadSpec | null,
+): TelegramThreadParams | undefined {
   if (thread?.id == null) {
     return undefined;
   }
   const normalized = Math.trunc(thread.id);
 
+  if (!Number.isFinite(normalized)) {
+    return undefined;
+  }
+
   if (thread.scope === "dm") {
     return normalized > 0 ? { message_thread_id: normalized } : undefined;
+  }
+
+  if (thread.scope === "direct-messages") {
+    return normalized > 0 ? { direct_messages_topic_id: normalized } : undefined;
   }
 
   if (thread.scope === "none") {
@@ -458,22 +500,24 @@ export function buildTelegramRoutingTarget(
 ): string {
   const base = `telegram:${chatId}`;
   const threadParams = buildTelegramThreadParams(thread);
-  const messageThreadId = threadParams?.message_thread_id;
-  if (typeof messageThreadId !== "number") {
+  if (typeof threadParams?.direct_messages_topic_id === "number") {
+    return `${base}:direct-topic:${threadParams.direct_messages_topic_id}`;
+  }
+  if (typeof threadParams?.message_thread_id !== "number") {
     return base;
   }
-  return `${base}:topic:${messageThreadId}`;
+  return `${base}:topic:${threadParams.message_thread_id}`;
 }
 
 /**
  * Build the canonical Telegram inbound origin used by queued follow-up routing.
- * DM thread ids remain metadata-only; real forum topics must be in-band.
+ * Bot-private thread ids remain metadata-only; group topic ids must be in-band.
  */
 export function buildTelegramInboundOriginTarget(
   chatId: number | string,
   thread?: TelegramThreadSpec | null,
 ): string {
-  if (thread?.scope !== "forum") {
+  if (thread?.scope !== "forum" && thread?.scope !== "direct-messages") {
     return `telegram:${chatId}`;
   }
   return buildTelegramRoutingTarget(chatId, thread);

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -41,7 +41,7 @@ function createForumDraftStream(api: ReturnType<typeof createMockDraftApi>) {
 
 function createThreadedDraftStream(
   api: ReturnType<typeof createMockDraftApi>,
-  thread: { id: number; scope: "forum" | "dm" },
+  thread: { id: number; scope: "direct-messages" | "dm" | "forum" },
 ) {
   return createDraftStream(api, { thread });
 }
@@ -277,7 +277,7 @@ describe("createTelegramDraftStream", () => {
     await vi.waitFor(() => expectPreviewSend(api, "Hello"));
   });
 
-  it("uses text send/edit for dm thread previews", async () => {
+  it("uses message_thread_id for bot-private topic previews", async () => {
     const api = createMockDraftApi();
     const stream = createThreadedDraftStream(api, { id: 42, scope: "dm" });
 
@@ -291,9 +291,28 @@ describe("createTelegramDraftStream", () => {
     expectPreviewEdit(api, "Hello again");
   });
 
-  it.each(["forum", "dm"] as const)(
-    "does not retry %s message preview sends without the topic id",
-    async (scope) => {
+  it("uses direct_messages_topic_id only for channel Direct Messages previews", async () => {
+    const api = createMockDraftApi();
+    const stream = createThreadedDraftStream(api, { id: 77, scope: "direct-messages" });
+
+    stream.update("Hello");
+    await vi.waitFor(() => expectPreviewSend(api, "Hello", { direct_messages_topic_id: 77 }));
+    expect(api.editMessageText).not.toHaveBeenCalled();
+
+    stream.update("Hello again");
+    await stream.flush();
+
+    expectPreviewEdit(api, "Hello again");
+    expect(api.editMessageText.mock.calls[0]?.[3]).toBeUndefined();
+  });
+
+  it.each([
+    { scope: "forum" as const, expected: { message_thread_id: 42 } },
+    { scope: "dm" as const, expected: { message_thread_id: 42 } },
+    { scope: "direct-messages" as const, expected: { direct_messages_topic_id: 42 } },
+  ])(
+    "does not retry $scope message preview sends without the topic id",
+    async ({ scope, expected }) => {
       const api = createMockDraftApi();
       api.sendMessage.mockRejectedValueOnce(
         new Error("400: Bad Request: message thread not found"),
@@ -308,7 +327,7 @@ describe("createTelegramDraftStream", () => {
       await stream.flush();
 
       expect(api.sendMessage).toHaveBeenCalledTimes(1);
-      expectPreviewSend(api, "Hello", { message_thread_id: 42 });
+      expectPreviewSend(api, "Hello", expected);
       expect(warn).toHaveBeenCalledWith(
         "telegram stream preview failed: 400: Bad Request: message thread not found",
       );

--- a/extensions/telegram/src/normalize.ts
+++ b/extensions/telegram/src/normalize.ts
@@ -24,6 +24,9 @@ function normalizeTelegramTargetBody(raw: string): string | undefined {
   const keepLegacyGroupPrefix = /^group:/i.test(prefixStripped);
   const hasTopicSuffix = /:topic:\d+$/i.test(prefixStripped);
   const chatSegment = keepLegacyGroupPrefix ? `group:${normalizedChatId}` : normalizedChatId;
+  if (parsed.directMessagesTopicId != null) {
+    return `${chatSegment}:direct-topic:${parsed.directMessagesTopicId}`;
+  }
   if (parsed.messageThreadId == null) {
     return chatSegment;
   }

--- a/extensions/telegram/src/provider-thread-proof.ts
+++ b/extensions/telegram/src/provider-thread-proof.ts
@@ -3,6 +3,7 @@ import { TELEGRAM_GENERAL_TOPIC_ID, type TelegramThreadSpec } from "./bot/helper
 type TelegramThreadMessage = {
   message_id?: number;
   message_thread_id?: number;
+  direct_messages_topic?: { topic_id?: number };
   chat?: { type?: string };
 };
 
@@ -10,6 +11,9 @@ export function resolveTelegramProviderObservedThreadId(params: {
   message: TelegramThreadMessage;
   successfulSendThread?: TelegramThreadSpec;
 }): number | undefined {
+  if (params.successfulSendThread?.scope === "direct-messages") {
+    return params.message.direct_messages_topic?.topic_id;
+  }
   if (typeof params.message.message_thread_id === "number") {
     return params.message.message_thread_id;
   }

--- a/extensions/telegram/src/reply-parameters.test.ts
+++ b/extensions/telegram/src/reply-parameters.test.ts
@@ -88,7 +88,7 @@ describe("telegram reply parameters", () => {
     });
   });
 
-  it("keeps direct-message topic scope for Telegram DM topics", () => {
+  it("keeps message_thread_id for Telegram bot-private topics", () => {
     expect(
       buildTelegramThreadReplyParams({
         thread: resolveTelegramSendThreadSpec({
@@ -99,6 +99,23 @@ describe("telegram reply parameters", () => {
       }),
     ).toEqual({
       message_thread_id: 5,
+      reply_to_message_id: 42,
+      allow_sending_without_reply: true,
+    });
+  });
+
+  it("keeps direct_messages_topic_id independent from reply parameters", () => {
+    expect(
+      buildTelegramThreadReplyParams({
+        thread: resolveTelegramSendThreadSpec({
+          targetDirectMessagesTopicId: 77,
+          targetMessageThreadId: 999,
+          chatType: "group",
+        }),
+        replyToMessageId: 42,
+      }),
+    ).toEqual({
+      direct_messages_topic_id: 77,
       reply_to_message_id: 42,
       allow_sending_without_reply: true,
     });

--- a/extensions/telegram/src/reply-parameters.ts
+++ b/extensions/telegram/src/reply-parameters.ts
@@ -19,6 +19,7 @@ type TelegramReplyParameters = {
 
 type TelegramThreadReplyParams = {
   message_thread_id?: number;
+  direct_messages_topic_id?: number;
   reply_parameters?: TelegramReplyParameters;
   reply_to_message_id?: number;
   allow_sending_without_reply?: true;
@@ -26,16 +27,21 @@ type TelegramThreadReplyParams = {
 
 export function resolveTelegramSendThreadSpec(params: {
   targetMessageThreadId?: number;
+  targetDirectMessagesTopicId?: number;
   messageThreadId?: number;
   chatType?: "direct" | "group" | "unknown";
 }): TelegramThreadSpec | undefined {
+  if (params.targetDirectMessagesTopicId != null) {
+    return { id: params.targetDirectMessagesTopicId, scope: "direct-messages" };
+  }
   const messageThreadId =
     params.messageThreadId != null ? params.messageThreadId : params.targetMessageThreadId;
   if (messageThreadId == null) {
     return undefined;
   }
-  // Telegram supports DM topics; keep direct chat thread IDs and let invalid
-  // topics fail closed instead of sending to the base chat.
+  // Bot-private topics retain the historical dm scope. A :topic: marker on a
+  // group remains forum semantics; channel Direct Messages require their
+  // distinct :direct-topic: marker and never infer from a negative chat id.
   return {
     id: messageThreadId,
     scope: params.chatType === "direct" ? "dm" : "forum",
@@ -51,11 +57,7 @@ export function buildTelegramThreadReplyParams(opts?: {
   replyQuoteEntities?: unknown[];
   useReplyIdAsQuoteSource?: boolean;
 }): TelegramThreadReplyParams {
-  const params: TelegramThreadReplyParams = {};
-  const threadParams = buildTelegramThreadParams(opts?.thread);
-  if (threadParams) {
-    params.message_thread_id = threadParams.message_thread_id;
-  }
+  const params: TelegramThreadReplyParams = { ...buildTelegramThreadParams(opts?.thread) };
 
   const replyToMessageId = normalizeTelegramReplyToMessageId(opts?.replyToMessageId);
   if (replyToMessageId == null) {

--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -74,7 +74,7 @@ type TelegramSendRichMessageParams = {
 
 export type TelegramRichMessageContextParams = Pick<
   TelegramSendRichMessageParams,
-  "disable_notification" | "message_thread_id" | "reply_parameters"
+  "disable_notification" | "direct_messages_topic_id" | "message_thread_id" | "reply_parameters"
 >;
 
 export type TelegramEditRichMessageTextParams = {
@@ -129,9 +129,14 @@ export function toTelegramRichMessageContextParams(
   params: Record<string, unknown> | undefined,
 ): TelegramRichMessageContextParams {
   const richParams: TelegramRichMessageContextParams = {};
-  const messageThreadId = finiteInteger(params?.message_thread_id);
-  if (messageThreadId !== undefined) {
-    richParams.message_thread_id = messageThreadId;
+  const directMessagesTopicId = finiteInteger(params?.direct_messages_topic_id);
+  if (directMessagesTopicId !== undefined) {
+    richParams.direct_messages_topic_id = directMessagesTopicId;
+  } else {
+    const messageThreadId = finiteInteger(params?.message_thread_id);
+    if (messageThreadId !== undefined) {
+      richParams.message_thread_id = messageThreadId;
+    }
   }
   if (params?.disable_notification === true) {
     richParams.disable_notification = true;

--- a/extensions/telegram/src/send-actions.ts
+++ b/extensions/telegram/src/send-actions.ts
@@ -18,7 +18,7 @@ import type {
   TelegramSendOpts,
 } from "./send-message-types.js";
 import { prepareTelegramOutbound } from "./send-outbound.js";
-import { parseTelegramTarget } from "./targets.js";
+import { parseTelegramTarget, type TelegramTarget } from "./targets.js";
 
 type TelegramReactionOpts = TelegramApiCallOpts & {
   remove?: boolean;
@@ -31,17 +31,24 @@ export async function sendTypingTelegram(
   to: string,
   opts: TelegramTypingOpts,
 ): Promise<{ ok: true }> {
+  const target = parseTelegramTarget(to);
+  if (target.directMessagesTopicId != null) {
+    throw new Error("Telegram typing is not supported in channel Direct Messages chats.");
+  }
   const context = resolveTelegramApiContext(opts);
-  return withTelegramApiContextLease(context, sendTypingTelegramWithContext(to, opts, context));
+  return withTelegramApiContextLease(
+    context,
+    sendTypingTelegramWithContext(to, target, opts, context),
+  );
 }
 
 async function sendTypingTelegramWithContext(
   to: string,
+  target: TelegramTarget,
   opts: TelegramTypingOpts,
   context: TelegramApiContext,
 ): Promise<{ ok: true }> {
   const { cfg, account, api } = context;
-  const target = parseTelegramTarget(to);
   const chatId = await resolveAndPersistChatId({
     cfg,
     api,

--- a/extensions/telegram/src/send-context.ts
+++ b/extensions/telegram/src/send-context.ts
@@ -32,6 +32,7 @@ export type TelegramApi = Bot["api"];
 export type TelegramApiOverride = Partial<TelegramApi>;
 export type TelegramThreadScopedParams = {
   message_thread_id?: number;
+  direct_messages_topic_id?: number;
   reply_parameters?: { message_id?: number };
   reply_to_message_id?: number;
 };
@@ -104,6 +105,12 @@ export function toAcceptedThreadScopedParams(
   const scoped: TelegramThreadScopedParams = {};
   if (typeof params.message_thread_id === "number" && Number.isFinite(params.message_thread_id)) {
     scoped.message_thread_id = params.message_thread_id;
+  }
+  if (
+    typeof params.direct_messages_topic_id === "number" &&
+    Number.isFinite(params.direct_messages_topic_id)
+  ) {
+    scoped.direct_messages_topic_id = params.direct_messages_topic_id;
   }
   if (
     typeof params.reply_to_message_id === "number" &&

--- a/extensions/telegram/src/send-message.ts
+++ b/extensions/telegram/src/send-message.ts
@@ -88,6 +88,7 @@ async function sendMessageTelegramWithContext(
   });
   const threadSpec = resolveTelegramSendThreadSpec({
     targetMessageThreadId: target.messageThreadId,
+    targetDirectMessagesTopicId: target.directMessagesTopicId,
     messageThreadId: opts.messageThreadId,
     chatType: target.chatType,
   });

--- a/extensions/telegram/src/send-outbound.ts
+++ b/extensions/telegram/src/send-outbound.ts
@@ -116,6 +116,7 @@ export async function prepareTelegramOutbound<T extends string | number | undefi
   const threadSpec = params.thread
     ? resolveTelegramSendThreadSpec({
         targetMessageThreadId: target.messageThreadId,
+        targetDirectMessagesTopicId: target.directMessagesTopicId,
         messageThreadId: params.thread.messageThreadId,
         chatType: target.chatType,
       })

--- a/extensions/telegram/src/send-special.ts
+++ b/extensions/telegram/src/send-special.ts
@@ -18,6 +18,7 @@ import type {
 } from "./send-message-types.js";
 import { finalizeTelegramOutbound, prepareTelegramOutbound } from "./send-outbound.js";
 import { normalizePollInput, type PollInput } from "./send.runtime.js";
+import { parseTelegramTarget } from "./targets.js";
 import { resolveTelegramBotUserIdFromToken } from "./token.js";
 
 type TelegramSendPollParams = Parameters<TelegramApiContext["api"]["sendPoll"]>[3];
@@ -101,6 +102,9 @@ export async function sendPollTelegram(
   poll: PollInput,
   opts: TelegramPollOpts,
 ): Promise<TelegramPollSendResult> {
+  if (parseTelegramTarget(to).directMessagesTopicId != null) {
+    throw new Error("Telegram polls are not supported in channel Direct Messages chats.");
+  }
   const context = resolveTelegramApiContext(opts);
   return withTelegramApiContextLease(context, sendPollTelegramWithContext(to, poll, opts, context));
 }

--- a/extensions/telegram/src/targets.test.ts
+++ b/extensions/telegram/src/targets.test.ts
@@ -75,6 +75,23 @@ describe("parseTelegramTarget", () => {
     });
   });
 
+  it("parses channel Direct Messages topic markers without forum inference", () => {
+    expect(parseTelegramTarget("telegram:group:-1001234567890:direct-topic:77")).toEqual({
+      chatId: "-1001234567890",
+      directMessagesTopicId: 77,
+      chatType: "group",
+    });
+  });
+
+  it("rejects non-positive and unsafe channel Direct Messages topic ids", () => {
+    for (const target of [
+      "-1001234567890:direct-topic:0",
+      "-1001234567890:direct-topic:9007199254740992",
+    ]) {
+      expect(parseTelegramTarget(target)).toEqual({ chatId: target, chatType: "unknown" });
+    }
+  });
+
   it("trims whitespace", () => {
     expect(parseTelegramTarget("  -1001234567890:99  ")).toEqual({
       chatId: "-1001234567890",
@@ -130,6 +147,9 @@ describe("normalizeTelegramOutboundTarget", () => {
       "-1001234567890:topic:77",
     );
     expect(normalizeTelegramOutboundTarget("group:-1001234567890:77")).toBe("-1001234567890:77");
+    expect(normalizeTelegramOutboundTarget("group:-1001234567890:direct-topic:77")).toBe(
+      "-1001234567890:direct-topic:77",
+    );
   });
 
   it("keeps already-valid numeric and non-numeric targets on the send path", () => {
@@ -296,6 +316,9 @@ describe("telegram target normalization", () => {
     expect(normalizeTelegramMessagingTarget("tg:group:-100123")).toBe("telegram:group:-100123");
     expect(normalizeTelegramMessagingTarget("telegram:-100123:topic:99")).toBe(
       "telegram:-100123:topic:99",
+    );
+    expect(normalizeTelegramMessagingTarget("telegram:-100123:direct-topic:77")).toBe(
+      "telegram:-100123:direct-topic:77",
     );
   });
 

--- a/extensions/telegram/src/targets.ts
+++ b/extensions/telegram/src/targets.ts
@@ -1,9 +1,13 @@
 // Telegram plugin module implements targets behavior.
-import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
+import {
+  parseStrictNonNegativeInteger,
+  parseStrictPositiveInteger,
+} from "openclaw/plugin-sdk/number-runtime";
 
 export type TelegramTarget = {
   chatId: string;
   messageThreadId?: number;
+  directMessagesTopicId?: number;
   chatType: "direct" | "group" | "unknown";
 };
 
@@ -49,7 +53,7 @@ export function isNumericTelegramChatId(raw: string): boolean {
 
 export function normalizeTelegramOutboundTarget(raw: string): string {
   const trimmed = raw.trim();
-  const legacyGroupMatch = /^group:(-?\d+(?::topic:\d+|:\d+)?)$/i.exec(trimmed);
+  const legacyGroupMatch = /^group:(-?\d+(?::(?:direct-topic|topic):\d+|:\d+)?)$/i.exec(trimmed);
   if (legacyGroupMatch?.[1]) {
     return legacyGroupMatch[1];
   }
@@ -88,6 +92,7 @@ export function normalizeTelegramLookupTarget(raw: string): string | undefined {
  * - `chatId` (plain chat ID, t.me link, @username, or internal prefixes like `telegram:...`)
  * - `chatId:topicId` (numeric topic/thread ID)
  * - `chatId:topic:topicId` (explicit topic marker; preferred)
+ * - `chatId:direct-topic:topicId` (channel Direct Messages topic)
  */
 function resolveTelegramChatType(chatId: string): "direct" | "group" | "unknown" {
   const trimmed = chatId.trim();
@@ -102,6 +107,18 @@ function resolveTelegramChatType(chatId: string): "direct" | "group" | "unknown"
 
 export function parseTelegramTarget(to: string): TelegramTarget {
   const normalized = stripTelegramInternalPrefixes(to);
+  const directMatch = /^(.+?):direct-topic:(\d+)$/.exec(normalized);
+  if (directMatch) {
+    const chatId = directMatch[1];
+    const topicIdText = directMatch[2];
+    if (chatId !== undefined && topicIdText !== undefined) {
+      const directMessagesTopicId = parseStrictPositiveInteger(topicIdText);
+      if (directMessagesTopicId !== undefined) {
+        return { chatId, directMessagesTopicId, chatType: resolveTelegramChatType(chatId) };
+      }
+    }
+    return { chatId: normalized, chatType: "unknown" };
+  }
   const match = /^(.+?):topic:(\d+)$/.exec(normalized) ?? /^(.+):(\d+)$/.exec(normalized);
   if (match) {
     const chatId = match[1];

--- a/extensions/telegram/src/thread-spec.test.ts
+++ b/extensions/telegram/src/thread-spec.test.ts
@@ -1,0 +1,135 @@
+// Telegram tests cover canonical thread-scope resolution and encoding.
+import type { Message } from "grammy/types";
+import { describe, expect, it } from "vitest";
+import {
+  buildTelegramInboundOriginTarget,
+  buildTelegramRoutingTarget,
+  buildTelegramThreadParams,
+  buildTypingThreadParams,
+  resolveTelegramMessageThreadSpec,
+} from "./bot/helpers.js";
+
+describe("resolveTelegramMessageThreadSpec", () => {
+  it.each([
+    {
+      name: "bot-private topic",
+      message: { chat: { id: 123, type: "private" }, message_thread_id: 42 },
+      expected: { id: 42, scope: "dm" },
+    },
+    {
+      name: "forum topic from message hint",
+      message: {
+        chat: { id: -100123, type: "supergroup" },
+        is_topic_message: true,
+        message_thread_id: 99,
+      },
+      expected: { id: 99, scope: "forum" },
+    },
+    {
+      name: "forum General topic",
+      message: { chat: { id: -100123, type: "supergroup", is_forum: true } },
+      expected: { id: 1, scope: "forum" },
+    },
+    {
+      name: "channel Direct Messages topic",
+      message: {
+        chat: { id: -100123, type: "supergroup", is_direct_messages: true },
+        direct_messages_topic: { topic_id: 77 },
+        message_thread_id: 999,
+      },
+      expected: { id: 77, scope: "direct-messages" },
+    },
+    {
+      name: "invalid channel Direct Messages evidence",
+      message: {
+        chat: { id: -100123, type: "supergroup", is_direct_messages: true },
+        direct_messages_topic: { topic_id: 0 },
+        message_thread_id: 77,
+      },
+      expected: { scope: "none" },
+    },
+    {
+      name: "regular group without topic proof",
+      message: { chat: { id: -100123, type: "supergroup" }, message_thread_id: 42 },
+      expected: { scope: "none" },
+    },
+  ])("resolves $name", ({ message, expected }) => {
+    expect(resolveTelegramMessageThreadSpec(message as Message)).toEqual(expected);
+  });
+});
+
+describe("buildTelegramThreadParams", () => {
+  it.each([
+    { input: { id: 1, scope: "forum" as const }, expected: undefined },
+    { input: { id: 99, scope: "forum" as const }, expected: { message_thread_id: 99 } },
+    { input: { id: 2, scope: "dm" as const }, expected: { message_thread_id: 2 } },
+    {
+      input: { id: 77, scope: "direct-messages" as const },
+      expected: { direct_messages_topic_id: 77 },
+    },
+    { input: { id: -1, scope: "direct-messages" as const }, expected: undefined },
+    { input: { id: 42.9, scope: "forum" as const }, expected: { message_thread_id: 42 } },
+  ])("builds thread params", ({ input, expected }) => {
+    expect(buildTelegramThreadParams(input)).toEqual(expected);
+  });
+});
+
+describe("buildTelegramRoutingTarget", () => {
+  it.each([
+    {
+      name: "keeps General forum topic chat-scoped",
+      chatId: -100123,
+      thread: { id: 1, scope: "forum" as const },
+      expected: "telegram:-100123",
+    },
+    {
+      name: "includes real forum topic ids",
+      chatId: -100123,
+      thread: { id: 42, scope: "forum" as const },
+      expected: "telegram:-100123:topic:42",
+    },
+    {
+      name: "includes channel Direct Messages topic ids with a distinct marker",
+      chatId: -100123,
+      thread: { id: 77, scope: "direct-messages" as const },
+      expected: "telegram:-100123:direct-topic:77",
+    },
+  ])("$name", ({ chatId, thread, expected }) => {
+    expect(buildTelegramRoutingTarget(chatId, thread)).toBe(expected);
+  });
+});
+
+describe("buildTelegramInboundOriginTarget", () => {
+  it.each([
+    {
+      name: "keeps bot-private topic thread ids out of the origin target",
+      chatId: 42,
+      thread: { id: 77, scope: "dm" as const },
+      expected: "telegram:42",
+    },
+    {
+      name: "includes real forum topic ids",
+      chatId: -100123,
+      thread: { id: 42, scope: "forum" as const },
+      expected: "telegram:-100123:topic:42",
+    },
+    {
+      name: "includes channel Direct Messages topics",
+      chatId: -100123,
+      thread: { id: 77, scope: "direct-messages" as const },
+      expected: "telegram:-100123:direct-topic:77",
+    },
+  ])("$name", ({ chatId, thread, expected }) => {
+    expect(buildTelegramInboundOriginTarget(chatId, thread)).toBe(expected);
+  });
+});
+
+describe("buildTypingThreadParams", () => {
+  it.each([
+    { input: undefined, expected: undefined },
+    { input: 1, expected: { message_thread_id: 1 } },
+    { input: 42.9, expected: { message_thread_id: 42 } },
+  ])("builds typing params", ({ input, expected }) => {
+    expect(buildTypingThreadParams(input)).toEqual(expected);
+  });
+});

--- a/extensions/telegram/src/transport-payload.test.ts
+++ b/extensions/telegram/src/transport-payload.test.ts
@@ -1,0 +1,273 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+import { Bot } from "grammy";
+import type { Message } from "grammy/types";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  createPluginStateKeyedStoreForTests,
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createTelegramCallbackMessageActions } from "./bot-handlers.callback-actions.runtime.js";
+import { createTelegramDraftStream } from "./draft-stream.js";
+import { setTelegramRuntime } from "./runtime.js";
+import {
+  clearTelegramRuntimeForTest as clearTelegramRuntime,
+  resetTelegramMessageCacheForTest,
+} from "./runtime.test-support.js";
+import type { TelegramRuntime } from "./runtime.types.js";
+import { sendTypingTelegram } from "./send-actions.js";
+import { sendMessageTelegram } from "./send-message.js";
+import { sendPollTelegram } from "./send-special.js";
+
+type CapturedRequest = {
+  body: Buffer;
+  contentType: string;
+  method: string;
+};
+
+const TOKEN = "123456:transport-payload-test";
+const DIRECT_CHAT_ID = -100321;
+const DIRECT_TOPIC_ID = 77;
+const cfg = {
+  channels: { telegram: { botToken: TOKEN } },
+  session: { store: "/tmp/openclaw-telegram-transport-payload-test.json" },
+} satisfies OpenClawConfig;
+
+function installTelegramStateRuntimeForTest(): void {
+  setTelegramRuntime({
+    state: {
+      openKeyedStore: ((options) =>
+        createPluginStateKeyedStoreForTests(
+          "telegram",
+          options,
+        )) as TelegramRuntime["state"]["openKeyedStore"],
+      openSyncKeyedStore: ((options) =>
+        createPluginStateSyncKeyedStoreForTests(
+          "telegram",
+          options,
+        )) as TelegramRuntime["state"]["openSyncKeyedStore"],
+    },
+    channel: {},
+  } as TelegramRuntime);
+}
+
+function parseJsonBody(request: CapturedRequest): Record<string, unknown> {
+  return JSON.parse(request.body.toString("utf8")) as Record<string, unknown>;
+}
+
+function hasMultipartField(request: CapturedRequest, name: string, value?: string): boolean {
+  const body = request.body.toString("utf8");
+  const field = `name="${name}"\r\n\r\n`;
+  const index = body.indexOf(field);
+  if (index === -1) {
+    return false;
+  }
+  return value === undefined || body.slice(index + field.length).startsWith(value);
+}
+
+describe("Telegram topic transport payloads", () => {
+  const liveSockets = new Set<Socket>();
+  const requests: CapturedRequest[] = [];
+  let server: Server;
+  let bot: Bot;
+  let nextMessageId = 100;
+
+  beforeAll(async () => {
+    server = createServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk: Buffer) => chunks.push(chunk));
+      request.on("end", () => {
+        const body = Buffer.concat(chunks);
+        const method = request.url?.split("/").at(-1) ?? "unknown";
+        const captured = {
+          body,
+          contentType: request.headers["content-type"] ?? "",
+          method,
+        };
+        requests.push(captured);
+
+        let result: true | Record<string, unknown> = true;
+        if (method.startsWith("send")) {
+          const raw = body.toString("utf8");
+          const payload = captured.contentType.startsWith("application/json")
+            ? parseJsonBody(captured)
+            : undefined;
+          const directTopic =
+            payload?.direct_messages_topic_id ??
+            (hasMultipartField(captured, "direct_messages_topic_id", String(DIRECT_TOPIC_ID))
+              ? DIRECT_TOPIC_ID
+              : undefined);
+          const messageThread = payload?.message_thread_id;
+          result = {
+            message_id: nextMessageId++,
+            date: 1_700_000_000,
+            chat:
+              directTopic !== undefined
+                ? { id: DIRECT_CHAT_ID, type: "supergroup", is_direct_messages: true }
+                : {
+                    id: raw.includes('"chat_id":1234') ? 1234 : DIRECT_CHAT_ID,
+                    type: "supergroup",
+                  },
+            ...(directTopic !== undefined
+              ? {
+                  direct_messages_topic: {
+                    topic_id: Number(directTopic),
+                    user: { id: 700, is_bot: false, first_name: "Subscriber" },
+                  },
+                }
+              : typeof messageThread === "number"
+                ? { message_thread_id: messageThread }
+                : {}),
+            text: "accepted",
+          };
+        }
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ ok: true, result }));
+      });
+    });
+    server.on("connection", (socket) => {
+      liveSockets.add(socket);
+      socket.once("close", () => liveSockets.delete(socket));
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const apiRoot = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    bot = new Bot(TOKEN, { client: { apiRoot } });
+  });
+
+  beforeEach(() => {
+    requests.length = 0;
+    resetPluginStateStoreForTests();
+    resetTelegramMessageCacheForTest();
+    installTelegramStateRuntimeForTest();
+  });
+
+  afterEach(() => {
+    clearTelegramRuntime();
+    resetTelegramMessageCacheForTest();
+    resetPluginStateStoreForTests();
+  });
+
+  afterAll(async () => {
+    for (const socket of liveSockets) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  it("serializes direct draft destinations while keeping edits topic-free", async () => {
+    const direct = createTelegramDraftStream({
+      api: bot.api,
+      chatId: DIRECT_CHAT_ID,
+      thread: { id: DIRECT_TOPIC_ID, scope: "direct-messages" },
+    });
+    direct.update("direct preview");
+    await direct.flush();
+    direct.update("direct preview updated");
+    await direct.flush();
+    await direct.discard?.();
+
+    const directSend = requests.find((request) => request.method === "sendMessage");
+    const directEdit = requests.find((request) => request.method === "editMessageText");
+    expect(directSend && parseJsonBody(directSend)).toMatchObject({
+      direct_messages_topic_id: DIRECT_TOPIC_ID,
+    });
+    expect(directSend && parseJsonBody(directSend)).not.toHaveProperty("message_thread_id");
+    expect(directEdit && parseJsonBody(directEdit)).not.toHaveProperty("message_thread_id");
+    expect(directEdit && parseJsonBody(directEdit)).not.toHaveProperty("direct_messages_topic_id");
+  });
+
+  it("serializes a channel Direct Messages document through real multipart transport", async () => {
+    await sendMessageTelegram(`${DIRECT_CHAT_ID}:direct-topic:${DIRECT_TOPIC_ID}`, "document", {
+      cfg,
+      token: TOKEN,
+      api: bot.api,
+      mediaUrl: "/tmp/direct-topic-proof.pdf",
+      mediaAccess: {
+        localRoots: ["/tmp"],
+        readFile: async () => Buffer.from("%PDF-1.7 direct-topic-proof"),
+      },
+    });
+
+    const request = requests.find((candidate) => candidate.method === "sendDocument");
+    expect(request?.contentType).toMatch(/^multipart\/form-data; boundary=/i);
+    expect(request && hasMultipartField(request, "direct_messages_topic_id", "77")).toBe(true);
+    expect(request && hasMultipartField(request, "message_thread_id")).toBe(false);
+    expect(request && hasMultipartField(request, "document")).toBe(true);
+  });
+
+  it("serializes local rich delivery through the canonical direct topic field", async () => {
+    const richCfg = {
+      ...cfg,
+      channels: { telegram: { botToken: TOKEN, richMessages: true } },
+    } satisfies OpenClawConfig;
+    await sendMessageTelegram(`${DIRECT_CHAT_ID}:direct-topic:${DIRECT_TOPIC_ID}`, "**rich**", {
+      cfg: richCfg,
+      token: TOKEN,
+      api: bot.api,
+    });
+
+    const request = requests.find((candidate) => candidate.method === "sendRichMessage");
+    expect(request && parseJsonBody(request)).toMatchObject({
+      direct_messages_topic_id: DIRECT_TOPIC_ID,
+    });
+    expect(request && parseJsonBody(request)).not.toHaveProperty("message_thread_id");
+  });
+
+  it("rejects poll and typing for channel Direct Messages without transport", async () => {
+    const before = requests.length;
+    await expect(
+      sendPollTelegram(
+        `${DIRECT_CHAT_ID}:direct-topic:${DIRECT_TOPIC_ID}`,
+        { question: "Choose", options: ["A", "B"], maxSelections: 1 },
+        { cfg, token: TOKEN, api: bot.api },
+      ),
+    ).rejects.toThrow(/polls are not supported in channel Direct Messages/i);
+    await expect(
+      sendTypingTelegram(`${DIRECT_CHAT_ID}:direct-topic:${DIRECT_TOPIC_ID}`, {
+        cfg,
+        token: TOKEN,
+        api: bot.api,
+      }),
+    ).rejects.toThrow(/typing is not supported in channel Direct Messages/i);
+    expect(requests).toHaveLength(before);
+  });
+
+  it("serializes callback replies through only the canonical direct topic field", async () => {
+    const callbackMessage = {
+      message_id: 41,
+      date: 1_700_000_000,
+      chat: {
+        id: DIRECT_CHAT_ID,
+        type: "supergroup",
+        title: "Channel Direct Messages",
+        is_direct_messages: true,
+      },
+      message_thread_id: 999,
+      direct_messages_topic: {
+        topic_id: DIRECT_TOPIC_ID,
+        user: { id: 700, is_bot: false, first_name: "Subscriber" },
+      },
+      text: "button",
+    } as Message;
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      isGroup: true,
+      isForum: false,
+    });
+
+    await actions.replyToCallbackChat("callback reply");
+
+    const request = requests.find((candidate) => candidate.method === "sendMessage");
+    expect(request && parseJsonBody(request)).toMatchObject({
+      direct_messages_topic_id: DIRECT_TOPIC_ID,
+    });
+    expect(request && parseJsonBody(request)).not.toHaveProperty("message_thread_id");
+  });
+});


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users replying in a Telegram channel Direct Messages topic could receive previews, final messages, or media on the base or wrong topic because the distinct destination kind was lost.

## Why This Change Was Made

This establishes the Direct Messages topic from authoritative inbound fields, encodes it through one Telegram-owned thread-parameter boundary, preserves it through durable `:direct-topic:<id>` targets, keeps message-id edits topic-free, and rejects unsupported poll and typing operations before transport. Bot-private and forum topics continue using `message_thread_id`.

## User Impact

Previews, final text, rich content, media, native-command and callback replies, and late or durable replies now remain in the originating channel Direct Messages topic.

## Evidence

- Focused regression command: `node scripts/run-vitest.mjs extensions/telegram/src/bot/helpers.test.ts extensions/telegram/src/thread-spec.test.ts extensions/telegram/src/bot-message-context.dm-threads.test.ts extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/reply-parameters.test.ts extensions/telegram/src/targets.test.ts extensions/telegram/src/transport-payload.test.ts extensions/telegram/src/bot-native-commands.test.ts extensions/telegram/src/send.test.ts`
  - Pre-rebase result: 9 files, 518 tests passed.
  - Post-rebase result: 9 files, 516 tests passed; all tests discovered on the newer base passed.
- Production and extension-test `tsgo` typechecks passed.
- Focused oxlint, `oxfmt --check`, and `git diff --check` passed.
- A real local grammY HTTP transport recorder captured the expected JSON sends, multipart document sends, rich sends, callback sends, and topic-free edits.
- Final Codex autoreview reported no accepted or actionable findings.
- Proof gap: no authenticated live Telegram account probe was run; the local grammY recorder is transport proof, not live-channel proof.

AI-assisted: yes; implementation and final diff reviewed by Peter.
