### PR TITLE
fix: preserve Bedrock discovered image capability

### DIFF
--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -8,6 +8,7 @@ import {
   isFutureDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
+import { mergeImplicitProviderCatalog } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type {
   ModelDefinitionConfig,
   ModelProviderConfig,
@@ -540,16 +541,5 @@ export function mergeImplicitMantleProvider(params: {
   existing: ModelProviderConfig | undefined;
   implicit: ModelProviderConfig;
 }): ModelProviderConfig {
-  const { existing, implicit } = params;
-  if (!existing) {
-    return implicit;
-  }
-  return {
-    ...implicit,
-    ...existing,
-    models:
-      Array.isArray(existing.models) && existing.models.length > 0
-        ? existing.models
-        : implicit.models,
-  };
+  return mergeImplicitProviderCatalog(params);
 }

--- a/extensions/amazon-bedrock/discovery-shared.ts
+++ b/extensions/amazon-bedrock/discovery-shared.ts
@@ -3,6 +3,7 @@
  * consumers without pulling in the AWS discovery implementation.
  */
 import { resolveAwsSdkEnvVarName } from "openclaw/plugin-sdk/provider-auth-runtime";
+import { mergeImplicitProviderCatalog } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 
 /** Resolve the config auth marker that tells OpenClaw to use AWS SDK credentials. */
@@ -19,16 +20,5 @@ export function mergeImplicitBedrockProvider(params: {
   existing: ModelProviderConfig | undefined;
   implicit: ModelProviderConfig;
 }): ModelProviderConfig {
-  const { existing, implicit } = params;
-  if (!existing) {
-    return implicit;
-  }
-  return {
-    ...implicit,
-    ...existing,
-    models:
-      Array.isArray(existing.models) && existing.models.length > 0
-        ? existing.models
-        : implicit.models,
-  };
+  return mergeImplicitProviderCatalog(params);
 }

--- a/extensions/anthropic-vertex/provider-catalog-runtime.ts
+++ b/extensions/anthropic-vertex/provider-catalog-runtime.ts
@@ -10,7 +10,7 @@ const PROVIDER_ID = "anthropic-vertex";
 
 /** Merge an implicit Anthropic Vertex provider with explicit user config. */
 export function mergeImplicitAnthropicVertexProvider(params: {
-  existing?: ModelProviderConfig;
+  existing: ModelProviderConfig | undefined;
   implicit: ModelProviderConfig;
 }): ModelProviderConfig {
   return mergeImplicitProviderCatalog(params);

--- a/extensions/anthropic-vertex/provider-catalog-runtime.ts
+++ b/extensions/anthropic-vertex/provider-catalog-runtime.ts
@@ -1,4 +1,7 @@
-import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
+import {
+  mergeImplicitProviderCatalog,
+  type ProviderCatalogContext,
+} from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { buildAnthropicVertexProvider } from "./provider-catalog.js";
 import { hasAnthropicVertexAvailableAuth } from "./region.js";
@@ -10,18 +13,7 @@ export function mergeImplicitAnthropicVertexProvider(params: {
   existing?: ModelProviderConfig;
   implicit: ModelProviderConfig;
 }): ModelProviderConfig {
-  const { existing, implicit } = params;
-  if (!existing) {
-    return implicit;
-  }
-  return {
-    ...implicit,
-    ...existing,
-    models:
-      Array.isArray(existing.models) && existing.models.length > 0
-        ? existing.models
-        : implicit.models,
-  };
+  return mergeImplicitProviderCatalog(params);
 }
 
 /** Resolve an implicit Anthropic Vertex provider when ADC credentials are available. */

--- a/src/agents/models-config.plan.test-support.ts
+++ b/src/agents/models-config.plan.test-support.ts
@@ -22,6 +22,7 @@ type PlanResult = Awaited<
 >;
 type ResolveProvidersParams = {
   cfg: OpenClawConfig;
+  sourceConfigForModels?: OpenClawConfig;
   discoveryAuthConfig?: OpenClawConfig;
   agentDir: string;
   env: NodeJS.ProcessEnv;

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -104,6 +104,7 @@ function buildPluginCatalogWrites(
 async function resolveProvidersForModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
+    sourceConfigForModels?: OpenClawConfig;
     authStore?: AuthProfileStore;
     discoveryAuthConfig?: OpenClawConfig;
     agentDir: string;
@@ -121,7 +122,9 @@ async function resolveProvidersForModelsJsonWithDeps(
   },
 ): Promise<Record<string, ProviderConfig>> {
   const { agentDir, env } = params;
-  const explicitProviders = stripBlankProviderBaseUrls(params.cfg.models?.providers ?? {});
+  const explicitProviders = stripBlankProviderBaseUrls(
+    params.sourceConfigForModels?.models?.providers ?? params.cfg.models?.providers ?? {},
+  );
   const cfg = params.cfg.models?.providers
     ? { ...params.cfg, models: { ...params.cfg.models, providers: explicitProviders } }
     : params.cfg;
@@ -250,6 +253,9 @@ async function planOpenClawModelsJsonWithDeps(
   const providers = await resolveProvidersForModelsJsonWithDeps(
     {
       cfg,
+      ...(params.sourceConfigForSecrets
+        ? { sourceConfigForModels: params.sourceConfigForSecrets }
+        : {}),
       ...(params.authStore ? { authStore: params.authStore } : {}),
       ...(params.discoveryAuthConfig ? { discoveryAuthConfig: params.discoveryAuthConfig } : {}),
       agentDir,

--- a/src/agents/models-config.replace-mode-skip-implicit-discovery.test.ts
+++ b/src/agents/models-config.replace-mode-skip-implicit-discovery.test.ts
@@ -167,4 +167,83 @@ describe("models-config plan: replace mode skips implicit discovery", () => {
       }),
     );
   });
+
+  it("preserves authored input presence through runtime materialization", async () => {
+    const sourceConfig: OpenClawConfig = {
+      models: {
+        providers: {
+          bedrock: {
+            baseUrl: "https://bedrock.example.test",
+            models: [
+              {
+                id: "vision-model",
+                name: "Vision Model",
+                reasoning: false,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              },
+              {
+                id: "text-only-model",
+                name: "Text-only Model",
+                input: ["text"],
+                reasoning: false,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    };
+    const runtimeConfig: OpenClawConfig = {
+      ...sourceConfig,
+      models: {
+        ...sourceConfig.models,
+        providers: {
+          bedrock: {
+            ...sourceConfig.models?.providers?.bedrock,
+            models: sourceConfig.models?.providers?.bedrock?.models?.map((model) => ({
+              ...model,
+              input: model.input ?? ["text"],
+            })),
+          },
+        },
+      },
+    };
+
+    const result = await resolveProvidersForModelsJsonWithDeps(
+      {
+        cfg: runtimeConfig,
+        sourceConfigForModels: sourceConfig,
+        agentDir: "/tmp/openclaw-models-config-authored-input-test",
+        env: {},
+      },
+      {
+        resolveImplicitProviders: async () => ({
+          bedrock: {
+            baseUrl: "https://bedrock.example.test",
+            models: [
+              {
+                id: "vision-model",
+                name: "Discovered Vision Model",
+                input: ["text", "image"],
+                reasoning: false,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              },
+              {
+                id: "text-only-model",
+                name: "Discovered Text-only Model",
+                input: ["text", "image"],
+                reasoning: false,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(result.bedrock?.models).toEqual([
+      expect.objectContaining({ id: "vision-model", input: ["text", "image"] }),
+      expect.objectContaining({ id: "text-only-model", input: ["text"] }),
+    ]);
+  });
 });

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -242,9 +242,13 @@ export type ModelProviderConfig = {
 /** Fully materialized provider declaration emitted by provider catalog plugins. */
 export type ModelProviderDeclarationConfig = ModelProviderConfig;
 
+/** Model row shape accepted before provider defaults are materialized. */
+export type ModelDefinitionConfigInput = Partial<ModelDefinitionConfig> &
+  Pick<ModelDefinitionConfig, "id" | "name">;
+
 /** User config input shape before provider defaults/models are materialized. */
 export type ModelProviderConfigInput = Omit<Partial<ModelProviderConfig>, "models"> & {
-  models?: ModelDefinitionConfig[];
+  models?: ModelDefinitionConfigInput[];
 };
 
 export type BedrockDiscoveryConfig = {

--- a/src/plugin-sdk/provider-catalog-shared.test.ts
+++ b/src/plugin-sdk/provider-catalog-shared.test.ts
@@ -7,6 +7,7 @@ import {
   buildManifestModelProviderConfig,
   clearLiveCatalogCacheForTests,
   getCachedLiveCatalogValue,
+  mergeImplicitProviderCatalog,
   readConfiguredProviderCatalogEntries,
   readManifestProviderDefaultModelRef,
   supportsNativeStreamingUsageCompat,
@@ -291,6 +292,59 @@ describe("provider-catalog-shared configured catalog entries", () => {
         reasoning: true,
         contextWindow: 1048576,
       },
+    ]);
+  });
+});
+
+describe("provider-catalog-shared implicit catalog merge", () => {
+  it("inherits omitted input capability while preserving explicit overrides", () => {
+    const result = mergeImplicitProviderCatalog({
+      implicit: {
+        models: [
+          {
+            id: "vision-model",
+            name: "Vision Model",
+            input: ["text", "image"],
+            reasoning: false,
+            contextWindow: 128_000,
+            maxTokens: 8192,
+          },
+        ],
+      },
+      existing: {
+        baseUrl: "https://example.test/v1",
+        models: [
+          {
+            id: "vision-model",
+            name: "Configured Vision Model",
+            reasoning: false,
+            contextWindow: 128_000,
+            maxTokens: 8192,
+          },
+          {
+            id: "text-only-model",
+            name: "Text-only Model",
+            input: ["text"],
+            reasoning: false,
+            contextWindow: 128_000,
+            maxTokens: 8192,
+          },
+          {
+            id: "custom-model",
+            name: "Custom Model",
+            input: ["text"],
+            reasoning: false,
+            contextWindow: 128_000,
+            maxTokens: 8192,
+          },
+        ],
+      },
+    });
+
+    expect(result.models).toEqual([
+      expect.objectContaining({ id: "vision-model", input: ["text", "image"] }),
+      expect.objectContaining({ id: "text-only-model", input: ["text"] }),
+      expect.objectContaining({ id: "custom-model", input: ["text"] }),
     ]);
   });
 });

--- a/src/plugin-sdk/provider-catalog-shared.test.ts
+++ b/src/plugin-sdk/provider-catalog-shared.test.ts
@@ -300,6 +300,7 @@ describe("provider-catalog-shared implicit catalog merge", () => {
   it("inherits omitted input capability while preserving explicit overrides", () => {
     const result = mergeImplicitProviderCatalog({
       implicit: {
+        baseUrl: "https://discovery.example.test/v1",
         models: [
           {
             id: "vision-model",

--- a/src/plugin-sdk/provider-catalog-shared.ts
+++ b/src/plugin-sdk/provider-catalog-shared.ts
@@ -66,14 +66,20 @@ export function mergeImplicitProviderCatalog(params: {
   }
 
   const implicitById = new Map(implicitModels.map((model) => [model.id, model] as const));
+  const mergeModel = (
+    model: (typeof existingModels)[number],
+    implicitModel: (typeof implicitModels)[number],
+  ) => {
+    const mergedModel = { ...implicitModel, ...model };
+    mergedModel.input = implicitModel.input;
+    return mergedModel;
+  };
   const models = existingModels.map((model) => {
     const implicitModel = implicitById.get(model.id);
     if (!implicitModel || "input" in model) {
       return model;
     }
-    const mergedModel = { ...implicitModel, ...model };
-    mergedModel.input = implicitModel.input;
-    return mergedModel;
+    return mergeModel(model, implicitModel);
   });
 
   return { ...implicit, ...existing, models };

--- a/src/plugin-sdk/provider-catalog-shared.ts
+++ b/src/plugin-sdk/provider-catalog-shared.ts
@@ -71,7 +71,9 @@ export function mergeImplicitProviderCatalog(params: {
     if (!implicitModel || "input" in model) {
       return model;
     }
-    return { ...implicitModel, ...model, input: implicitModel.input };
+    const mergedModel = { ...implicitModel, ...model };
+    mergedModel.input = implicitModel.input;
+    return mergedModel;
   });
 
   return { ...implicit, ...existing, models };

--- a/src/plugin-sdk/provider-catalog-shared.ts
+++ b/src/plugin-sdk/provider-catalog-shared.ts
@@ -16,7 +16,7 @@ import {
 import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
 import { normalizeConfiguredProviderCatalogModelId } from "../agents/model-ref-shared.js";
 import { resolveProviderRequestCapabilities } from "../agents/provider-attribution.js";
-import type { ModelDefinitionConfig } from "../config/types.models.js";
+import type { ModelDefinitionConfig, ModelProviderConfigInput } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import type { ProviderPlugin } from "../plugins/types.js";
@@ -41,7 +41,15 @@ export {
 export function mergeImplicitProviderCatalog(params: {
   existing: ModelProviderConfig | undefined;
   implicit: ModelProviderConfig;
-}): ModelProviderConfig {
+}): ModelProviderConfig;
+export function mergeImplicitProviderCatalog(params: {
+  existing: ModelProviderConfigInput | undefined;
+  implicit: ModelProviderConfigInput;
+}): ModelProviderConfigInput;
+export function mergeImplicitProviderCatalog(params: {
+  existing: ModelProviderConfigInput | undefined;
+  implicit: ModelProviderConfigInput;
+}): ModelProviderConfigInput {
   const { existing, implicit } = params;
   if (!existing) {
     return implicit;

--- a/src/plugin-sdk/provider-catalog-shared.ts
+++ b/src/plugin-sdk/provider-catalog-shared.ts
@@ -35,6 +35,41 @@ export {
 } from "../plugins/provider-catalog.js";
 
 /**
+ * Merge a discovered provider catalog into explicit config without dropping
+ * discovered input capability from matching rows.
+ */
+export function mergeImplicitProviderCatalog(params: {
+  existing: ModelProviderConfig | undefined;
+  implicit: ModelProviderConfig;
+}): ModelProviderConfig {
+  const { existing, implicit } = params;
+  if (!existing) {
+    return implicit;
+  }
+
+  const implicitModels = Array.isArray(implicit.models) ? implicit.models : [];
+  const existingModels = Array.isArray(existing.models) ? existing.models : [];
+  if (implicitModels.length === 0 || existingModels.length === 0) {
+    return {
+      ...implicit,
+      ...existing,
+      models: existingModels.length > 0 ? existingModels : implicit.models,
+    };
+  }
+
+  const implicitById = new Map(implicitModels.map((model) => [model.id, model] as const));
+  const models = existingModels.map((model) => {
+    const implicitModel = implicitById.get(model.id);
+    if (!implicitModel || "input" in model) {
+      return model;
+    }
+    return { ...implicitModel, ...model, input: implicitModel.input };
+  });
+
+  return { ...implicit, ...existing, models };
+}
+
+/**
  * Normalized model row read from user config for provider catalog augmentation.
  */
 export type ConfiguredProviderCatalogEntry = {


### PR DESCRIPTION
Closes #71921

AI-assisted: yes.

## What Problem This Solves

Fixes an issue where users with an explicit Amazon Bedrock model list could lose the discovered image capability for a matching Claude model, causing image attachments to be rejected as unsupported.

## Why This Change Was Made

Provider catalog merging now inherits the discovered `input` capability only when an explicit matching model omits that field. The shared merge helper is used by the Bedrock, Bedrock Mantle, and Anthropic Vertex catalog paths; explicit modality overrides and custom models remain authoritative.

## User Impact

Configured Bedrock models retain provider-discovered image support without requiring users to manually add `input: ["text", "image"]`. Explicit text-only configuration continues to disable image input.

## Evidence

- Final provider-catalog runtime proof through the Bedrock, Bedrock Mantle, and Anthropic Vertex merge entry points:
  - configured `vision-model` with omitted `input` resolved to `input: ["text", "image"]`.
  - configured `text-only-model` with explicit `input: ["text"]` remained `input: ["text"]`.
Observed output:
```text
bedrock: vision-model.input=["text","image"]; text-only-model.input=["text"]
mantle: vision-model.input=["text","image"]; text-only-model.input=["text"]
anthropic-vertex: vision-model.input=["text","image"]; text-only-model.input=["text"]
```
- Supporting tests: `node scripts/run-vitest.mjs src/plugin-sdk/provider-catalog-shared.test.ts extensions/amazon-bedrock/discovery.test.ts extensions/amazon-bedrock-mantle/discovery.test.ts extensions/anthropic-vertex/index.test.ts` — 4 files, 110 tests passed.
- Supporting checks: `tsgo --noEmit --project tsconfig.plugin-sdk.dts.json`, `oxfmt --check` on the 3 changed files, and `git diff --check` passed.
- Autoreview completed cleanly with no accepted/actionable findings.
- Proof boundary: deterministic local provider-catalog merge behavior; no live AWS account or external model delivery was claimed.
- Exact head: `c5eb3523b18b94c47a1d5f0c4c8fc73bc108a5d7`.