### PR TITLE
fix(agents): bound session lock teardown and report real lease owners

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -373,6 +373,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       {
         sessionKey: TEST_SESSION_KEY,
         sessionTarget: wrappedCompactionArgs().sessionTarget,
+        assertOwned: () => undefined,
         withSessionWriteLock,
       },
       async () => await compactEmbeddedAgentSessionDirect(wrappedCompactionArgs()),

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-execution-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-execution-prepare.ts
@@ -62,6 +62,7 @@ export async function prepareEmbeddedAttemptPromptExecution(input: {
     sessionTarget: attempt.sessionTarget,
     withSessionWriteLock: (run, options) =>
       input.sessionLockController.withSessionWriteLock(run, options),
+    assertSessionWriteLockOwned: () => input.sessionLockController.assertOwned(),
     canAdvanceSessionEntryCache: (snapshot: OwnedSessionTranscriptCacheSnapshot) =>
       input.sessionLockController.canAdvanceSessionEntryCache(snapshot),
     publishSessionFileSnapshot: (snapshot: OwnedSessionTranscriptCacheSnapshot) =>

--- a/src/agents/embedded-agent-runner/run/attempt-session-lock-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-lock-prepare.test.ts
@@ -40,7 +40,6 @@ type CreateControllerInput = {
     staleMs: number;
     maxHoldMs: number;
   };
-  mergePromptReleasedSessionEntries: (entries: never[]) => unknown;
   reloadPromptReleasedSessionFile: () => void;
 };
 
@@ -48,10 +47,10 @@ function createFixture(options?: { rejectPostArmFence?: Error }) {
   const order: string[] = [];
   const sessionFileOwner = { release: vi.fn() };
   const sessionManager = {
-    mergePromptReleasedSessionEntries: vi.fn(() => "merged"),
     reloadPersistedTranscript: vi.fn(),
   };
   const sessionLockController = {
+    assertOwned: vi.fn(),
     canAdvanceSessionEntryCache: vi.fn(() => true),
     dispose: vi.fn(async () => undefined),
     publishOwnedSessionFileSnapshot: vi.fn(() => true),
@@ -161,10 +160,6 @@ describe("prepareEmbeddedAttemptSessionLock", () => {
     expect(mocks.resolveSessionWriteLockTargetKey).toHaveBeenCalledWith(
       fixture.input.attempt.sessionTarget,
     );
-    expect(controllerInput?.mergePromptReleasedSessionEntries([])).toBe("merged");
-    expect(fixture.sessionManager.mergePromptReleasedSessionEntries).toHaveBeenCalledWith([], {
-      persistLeaf: true,
-    });
     controllerInput?.reloadPromptReleasedSessionFile();
     expect(fixture.sessionManager.reloadPersistedTranscript).toHaveBeenCalledOnce();
 

--- a/src/agents/embedded-agent-runner/run/attempt-session-lock-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-lock-prepare.ts
@@ -24,7 +24,13 @@ type WithOwnedSessionWriteLock = <T>(operation: () => Promise<T> | T) => Promise
 export async function prepareEmbeddedAttemptSessionLock(input: {
   attempt: Pick<
     EmbeddedRunAttemptParams,
-    "abortSignal" | "config" | "sessionFile" | "sessionId" | "sessionKey" | "sessionTarget"
+    | "abortSignal"
+    | "config"
+    | "runId"
+    | "sessionFile"
+    | "sessionId"
+    | "sessionKey"
+    | "sessionTarget"
   >;
   externalAbortController: {
     arm: () => void;
@@ -65,27 +71,25 @@ export async function prepareEmbeddedAttemptSessionLock(input: {
   // controller setup or the post-arm abort fence fails.
   input.onSessionFileOwnerAcquired(sessionFileOwner);
 
-  const getSessionManager = (operation: "entry merge" | "file reload") => {
+  const getSessionManager = () => {
     const sessionManager = input.getSessionManager();
     if (!sessionManager) {
-      throw new Error(`session manager unavailable during prompt-released ${operation}`);
+      throw new Error("session manager unavailable during prompt-released file reload");
     }
     return sessionManager;
   };
   const sessionLockController = await createEmbeddedAttemptSessionLockController({
     acquireSessionWriteLock,
     initialAcquireSignal: attempt.abortSignal,
+    runId: attempt.runId,
+    sessionId: attempt.sessionId,
     lockOptions: {
       sessionFile: resolveSessionWriteLockTargetKey(sessionTarget),
       targetKind: "session-key",
       ...sessionWriteLockOptions,
     },
-    mergePromptReleasedSessionEntries: (entries) =>
-      getSessionManager("entry merge").mergePromptReleasedSessionEntries(entries, {
-        persistLeaf: true,
-      }),
     reloadPromptReleasedSessionFile: () => {
-      getSessionManager("file reload").reloadPersistedTranscript();
+      getSessionManager().reloadPersistedTranscript();
     },
   });
   input.onSessionLockReleaseReady(() => sessionLockController.dispose());
@@ -94,6 +98,7 @@ export async function prepareEmbeddedAttemptSessionLock(input: {
     sessionFile: attempt.sessionFile,
     sessionKey: attempt.sessionKey,
     sessionTarget: attempt.sessionTarget,
+    assertOwned: () => sessionLockController.assertOwned(),
     canAdvanceSessionEntryCache: (snapshot) =>
       sessionLockController.canAdvanceSessionEntryCache(snapshot),
     publishSessionFileSnapshot: (snapshot) =>

--- a/src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts
@@ -10,9 +10,8 @@ import {
 } from "./attempt.run-decisions.js";
 
 describe("resolveEmbeddedAttemptSessionWriteLockOptions", () => {
-  it("bounds post-prompt session lock max hold to compaction timeout instead of run timeout", () => {
-    // Cleanup writes should not inherit the full model run timeout; the
-    // compaction window is the larger session-write risk.
+  it("derives the dead-process lease TTL from the compaction timeout", () => {
+    // Live owners renew until explicit release; this only bounds stale metadata after owner death.
     const options = resolveEmbeddedAttemptSessionWriteLockOptions({
       config: {},
       compactionTimeoutMs: 600_000,

--- a/src/agents/embedded-agent-runner/run/attempt.run-decisions.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.run-decisions.ts
@@ -9,19 +9,14 @@ import {
 import { UNKNOWN_TOOL_THRESHOLD } from "../../tool-loop-detection.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
-/**
- * Builds the session write-lock timing for a live embedded attempt. The lock is
- * capped by compaction time because cleanup may keep writing after model abort,
- * but should not inherit the much larger full run timeout.
- */
+/** Builds the session write-lock timing for a live embedded attempt. */
 export function resolveEmbeddedAttemptSessionWriteLockOptions(params: {
   config?: OpenClawConfig;
   compactionTimeoutMs: number;
   env?: NodeJS.ProcessEnv;
 }): { timeoutMs: number; staleMs: number; maxHoldMs: number } {
-  // Bound embedded-attempt lock holds to the compaction window, not the full run timeout.
-  // With defaults this permits roughly 180s compaction time plus the shared 120s
-  // timeout grace before the watchdog releases a stuck live-process lock.
+  // maxHoldMs is the SQLite lease TTL for dead-process reclamation, not a live-owner watchdog.
+  // A live process renews the lease until teardown releases it.
   return resolveSessionWriteLockOptions(params.config, {
     env: params.env,
     maxHoldMsFallback: resolveSessionLockMaxHoldFromTimeout({

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.teardown.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.teardown.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  loadTranscriptEvents,
+  upsertSessionEntry,
+} from "../../../config/sessions/session-accessor.js";
+import { withOwnedSessionTranscriptWrites } from "../../../config/sessions/transcript-write-context.js";
+import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
+import { SessionWriteLockStaleError } from "../../session-write-lock-error.js";
+import { SessionManager } from "../../sessions/session-manager.js";
+import { createEmbeddedAttemptSessionLockController } from "./attempt.session-lock.js";
+
+describe("attempt session-lock teardown budgets", () => {
+  it("bounds cleanup acquisition and releases before a started writer settles", async () => {
+    vi.useFakeTimers();
+    try {
+      let markWriteStarted!: () => void;
+      const writeStarted = new Promise<void>((resolve) => {
+        markWriteStarted = resolve;
+      });
+      let resumeWrite!: () => void;
+      const writeBlocked = new Promise<void>((resolve) => {
+        resumeWrite = resolve;
+      });
+      const release = vi.fn(async () => undefined);
+      const controller = await createEmbeddedAttemptSessionLockController({
+        acquireSessionWriteLock: vi.fn(async () => ({ release })),
+        lockOptions: { sessionFile: "agent:main:main" },
+        runId: "cleanup-budget-run",
+        sessionId: "cleanup-budget-session",
+      });
+      const write = controller.withSessionWriteLock(async () => {
+        markWriteStarted();
+        await writeBlocked;
+      });
+      await writeStarted;
+
+      const cleanupAcquisition = controller.acquireForCleanup();
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(release).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      const cleanupLock = await cleanupAcquisition;
+      expect(release).toHaveBeenCalledOnce();
+      expect(controller.hasSessionTakeover()).toBe(true);
+
+      await cleanupLock.release();
+      await expect(controller.dispose()).resolves.toBeUndefined();
+      resumeWrite();
+      await expect(write).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("force-releases a started writer at the teardown budget and fences its late persist", async () => {
+    vi.useFakeTimers();
+    try {
+      await withOpenClawTestState({ label: "attempt-session-lock-late-persist" }, async (state) => {
+        const target = {
+          agentId: "main",
+          sessionId: "late-persist-session",
+          sessionKey: "agent:main:late-persist-session",
+          storePath: state.path("sessions.json"),
+        };
+        await upsertSessionEntry(target, { sessionId: target.sessionId, updatedAt: 1 });
+        const sessionManager = SessionManager.open(target, state.workspaceDir);
+        sessionManager.appendModelChange("test", "before");
+        const before = await loadTranscriptEvents(target);
+        const leaseError = new SessionWriteLockStaleError({
+          lockPath: `sqlite:session-write:${target.sessionKey}`,
+          owner: "released teardown lease",
+          staleReasons: ["lease-lost"],
+        });
+        let owned = true;
+        const release = vi.fn(async () => {
+          owned = false;
+        });
+        const controller = await createEmbeddedAttemptSessionLockController({
+          acquireSessionWriteLock: vi.fn(async () => ({
+            assertOwned: () => {
+              if (!owned) {
+                throw leaseError;
+              }
+            },
+            release,
+          })),
+          lockOptions: { sessionFile: target.sessionKey },
+          runId: "late-persist-run",
+          sessionId: target.sessionId,
+        });
+        let markWriteStarted!: () => void;
+        const writeStarted = new Promise<void>((resolve) => {
+          markWriteStarted = resolve;
+        });
+        let resumeWrite!: () => void;
+        const writeBlocked = new Promise<void>((resolve) => {
+          resumeWrite = resolve;
+        });
+        const write = withOwnedSessionTranscriptWrites(
+          {
+            sessionFile: target.sessionKey,
+            sessionKey: target.sessionKey,
+            sessionTarget: target,
+            assertOwned: () => controller.assertOwned(),
+            withSessionWriteLock: (run, options) => controller.withSessionWriteLock(run, options),
+          },
+          async () =>
+            await controller.withSessionWriteLock(async () => {
+              markWriteStarted();
+              await writeBlocked;
+              sessionManager.appendModelChange("test", "too-late");
+            }),
+        );
+        await writeStarted;
+
+        const disposal = controller.dispose();
+        await vi.advanceTimersByTimeAsync(5_000 + 29_999);
+        expect(release).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        await expect(disposal).resolves.toBeUndefined();
+        expect(release).toHaveBeenCalledOnce();
+
+        resumeWrite();
+        await expect(write).rejects.toBe(leaseError);
+        await expect(loadTranscriptEvents(target)).resolves.toEqual(before);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("lets a started persist settle within the teardown budget before releasing", async () => {
+    await withOpenClawTestState(
+      { label: "attempt-session-lock-settled-persist" },
+      async (state) => {
+        const target = {
+          agentId: "main",
+          sessionId: "settled-persist-session",
+          sessionKey: "agent:main:settled-persist-session",
+          storePath: state.path("sessions.json"),
+        };
+        await upsertSessionEntry(target, { sessionId: target.sessionId, updatedAt: 1 });
+        const sessionManager = SessionManager.open(target, state.workspaceDir);
+        sessionManager.appendModelChange("test", "before");
+        const release = vi.fn(async () => undefined);
+        const controller = await createEmbeddedAttemptSessionLockController({
+          acquireSessionWriteLock: vi.fn(async () => ({ assertOwned: () => undefined, release })),
+          lockOptions: { sessionFile: target.sessionKey },
+        });
+        let markWriteStarted!: () => void;
+        const writeStarted = new Promise<void>((resolve) => {
+          markWriteStarted = resolve;
+        });
+        let resumeWrite!: () => void;
+        const writeBlocked = new Promise<void>((resolve) => {
+          resumeWrite = resolve;
+        });
+        const write = withOwnedSessionTranscriptWrites(
+          {
+            sessionFile: target.sessionKey,
+            sessionKey: target.sessionKey,
+            sessionTarget: target,
+            assertOwned: () => controller.assertOwned(),
+            withSessionWriteLock: (run, options) => controller.withSessionWriteLock(run, options),
+          },
+          async () =>
+            await controller.withSessionWriteLock(async () => {
+              markWriteStarted();
+              await writeBlocked;
+              sessionManager.appendModelChange("test", "within-budget");
+            }),
+        );
+        await writeStarted;
+        const disposal = controller.dispose();
+        await Promise.resolve();
+        expect(release).not.toHaveBeenCalled();
+
+        resumeWrite();
+        await Promise.all([write, disposal]);
+        expect(release).toHaveBeenCalledOnce();
+        await expect(loadTranscriptEvents(target)).resolves.toContainEqual(
+          expect.objectContaining({ modelId: "within-budget", type: "model_change" }),
+        );
+      },
+    );
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -542,41 +542,6 @@ describe("createEmbeddedAttemptSessionLockController", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
-  it("keeps a started write callback locked beyond the disposal timeout", async () => {
-    vi.useFakeTimers();
-    try {
-      let releaseWrite!: () => void;
-      const writeBlocked = new Promise<void>((resolve) => {
-        releaseWrite = resolve;
-      });
-      const release = vi.fn(async () => undefined);
-      const controller = await createEmbeddedAttemptSessionLockController({
-        acquireSessionWriteLock: vi.fn(async () => ({ release })),
-        lockOptions: { sessionFile: "agent:main:main" },
-      });
-      const writeStarted = vi.fn();
-      const write = controller.withSessionWriteLock(async () => {
-        writeStarted();
-        await writeBlocked;
-      });
-      await vi.waitFor(() => expect(writeStarted).toHaveBeenCalledOnce());
-
-      let disposeSettled = false;
-      const disposal = controller.dispose().then(() => {
-        disposeSettled = true;
-      });
-      await vi.advanceTimersByTimeAsync(5_000);
-      expect(disposeSettled).toBe(false);
-      expect(release).not.toHaveBeenCalled();
-
-      releaseWrite();
-      await Promise.all([write, disposal]);
-      expect(release).toHaveBeenCalledOnce();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
   it("lets a started write finish nested writes after disposal begins", async () => {
     let resumeOuter!: () => void;
     const outerBlocked = new Promise<void>((resolve) => {

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -8,10 +8,7 @@ import type {
 import { withOwnedSessionTranscriptWrites } from "../../../config/sessions/transcript-write-context.js";
 import { isSessionWriteLockAcquireError } from "../../session-write-lock-error.js";
 import type { acquireSessionWriteLock } from "../../session-write-lock.js";
-import type {
-  PromptReleasedSessionEntry,
-  PromptReleasedSessionMergeResult,
-} from "../../sessions/session-manager.js";
+import { log } from "../logger.js";
 
 type SessionLock = Awaited<ReturnType<typeof acquireSessionWriteLock>>;
 type AcquireSessionWriteLock = typeof acquireSessionWriteLock;
@@ -23,6 +20,8 @@ type LockOptions = Omit<SessionKeyLockOptions, "targetKind"> & {
   targetKind?: "session-key";
 };
 const PROMPT_DISPOSE_SETTLE_TIMEOUT_MS = 5_000;
+// Teardown must release the process-owned lease even when an admitted writer never settles.
+const SESSION_LOCK_TEARDOWN_BUDGET_MS = 30_000;
 
 function createPromptSubmissionAbortError(reason: unknown): Error {
   if (reason instanceof Error) {
@@ -58,6 +57,7 @@ export class EmbeddedAttemptSessionTakeoverError extends Error {
 }
 
 export type EmbeddedAttemptSessionLockController = {
+  assertOwned(): void;
   canAdvanceSessionEntryCache(snapshot: OwnedSessionTranscriptCacheSnapshot): boolean;
   publishOwnedSessionFileSnapshot(snapshot: OwnedSessionTranscriptCacheSnapshot): boolean;
   publishValidatedSessionFileSnapshot(snapshot: OwnedSessionTranscriptCacheSnapshot): boolean;
@@ -80,9 +80,8 @@ export async function createEmbeddedAttemptSessionLockController(params: {
   acquireSessionWriteLock: AcquireSessionWriteLock;
   initialAcquireSignal?: AbortSignal;
   lockOptions: LockOptions;
-  mergePromptReleasedSessionEntries?: (
-    entries: readonly PromptReleasedSessionEntry[],
-  ) => Promise<PromptReleasedSessionMergeResult | void> | PromptReleasedSessionMergeResult | void;
+  runId?: string;
+  sessionId?: string;
   reloadPromptReleasedSessionFile?: () => Promise<void> | void;
 }): Promise<EmbeddedAttemptSessionLockController> {
   // The runtime caller supplies resolveSessionWriteLockTargetKey(sessionTarget),
@@ -124,7 +123,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     }
   };
   let promptReleaseNeedsReload = false;
-  let cleanupStarted = false;
+  let cleanupRequested = false;
   let promptSettled = Promise.resolve();
   let settlePrompt: (() => void) | undefined;
   let lifecycle = Promise.resolve();
@@ -156,6 +155,57 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     pendingOperations: new Set(),
   });
   const lifecycleOwner = new AsyncLocalStorage<LifecycleOwner>();
+  let teardownBudgetLogged = false;
+  const createTeardownDeadline = (budgetMs = SESSION_LOCK_TEARDOWN_BUDGET_MS): number =>
+    performance.now() + budgetMs;
+  const pendingWriteCount = (): number => activeWriteOperations.size;
+  const logTeardownBudgetExpiry = (phase: string): void => {
+    if (teardownBudgetLogged) {
+      return;
+    }
+    teardownBudgetLogged = true;
+    log.error(
+      `session lock teardown budget expired; releasing ownership: ` +
+        `phase=${phase} runId=${params.runId ?? "unknown"} ` +
+        `sessionId=${params.sessionId ?? "unknown"} ` +
+        `pendingWrites=${pendingWriteCount()} timeoutMs=${SESSION_LOCK_TEARDOWN_BUDGET_MS}`,
+    );
+  };
+  const settleWithinTeardownDeadline = async (
+    operation: Promise<void>,
+    deadline: number,
+  ): Promise<boolean> => {
+    const waitMs = Math.max(0, deadline - performance.now());
+    if (waitMs <= 0) {
+      void operation.catch(() => {});
+      return false;
+    }
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        operation.then(() => true),
+        new Promise<false>((resolve) => {
+          timeout = setTimeout(() => resolve(false), waitMs);
+          timeout.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
+  };
+  const drainActiveWrites = async (startedOnly: boolean): Promise<void> => {
+    while (true) {
+      const pendingWrites = [...activeWriteOperations]
+        .filter((operation) => !startedOnly || operation.started)
+        .flatMap((operation) => (operation.settlement ? [operation.settlement] : []));
+      if (pendingWrites.length === 0) {
+        return;
+      }
+      await Promise.all(pendingWrites);
+    }
+  };
   const drainLifecycleOwner = async (owner: LifecycleOwner): Promise<void> => {
     let failed = false;
     let firstError: unknown;
@@ -275,6 +325,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     settlePrompt = undefined;
   };
   return {
+    assertOwned: assertInitialLockOwned,
     canAdvanceSessionEntryCache: () => false,
     publishOwnedSessionFileSnapshot: () => false,
     publishValidatedSessionFileSnapshot: () => false,
@@ -290,7 +341,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         if (promptSubmissionBlockedError) {
           throw promptSubmissionBlockedError;
         }
-        if (cleanupStarted) {
+        if (cleanupRequested) {
           throw new Error("attempt cleanup started before prompt submission");
         }
         assertInitialLockOwned();
@@ -319,7 +370,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       }
       await serializeLifecycle(async () => {
         try {
-          if (disposed || cleanupStarted || (promptAborted && !promptReleaseNeedsReload)) {
+          if (disposed || cleanupRequested || (promptAborted && !promptReleaseNeedsReload)) {
             return;
           }
           await reloadPromptReleasedState();
@@ -341,7 +392,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       if (disposed && !activeDescendant) {
         return rejectWrite(new Error("attempt disposed before transcript write"));
       }
-      if (cleanupStarted) {
+      if (cleanupRequested && !activeDescendant) {
         return rejectWrite(new Error("attempt cleanup started before transcript write"));
       }
       const writeOperation: ActiveWriteOperation = { active: true, started: false };
@@ -349,7 +400,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         if (disposed && !activeDescendant) {
           throw new Error("attempt disposed before transcript write");
         }
-        if (cleanupStarted) {
+        if (cleanupRequested && !activeDescendant) {
           throw new Error("attempt cleanup started before transcript write");
         }
         if (reloadFailed) {
@@ -380,25 +431,46 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       if (disposed) {
         throw new Error("attempt disposed before cleanup");
       }
-      await serializeLifecycle(async () => {
-        if (disposed) {
-          throw new Error("attempt disposed before cleanup");
-        }
-        if (cleanupStarted) {
-          throw new Error("attempt cleanup already started");
-        }
-        cleanupStarted = true;
-        if (promptReleaseNeedsReload) {
-          try {
-            if (!disposed) {
-              await reloadPromptReleasedState();
-            }
-          } finally {
-            settlePromptRelease();
+      if (cleanupRequested) {
+        throw new Error("attempt cleanup already started");
+      }
+      cleanupRequested = true;
+      const deadline = createTeardownDeadline();
+      const cleanupAdmission = (async () => {
+        await serializeLifecycle(async () => {
+          if (disposed) {
+            throw new Error("attempt disposed before cleanup");
           }
-        }
-      });
-      await serializeLifecycle(() => {});
+          if (promptReleaseNeedsReload) {
+            try {
+              if (!disposed) {
+                await reloadPromptReleasedState();
+              }
+            } finally {
+              settlePromptRelease();
+            }
+          }
+        });
+        await serializeLifecycle(() => {});
+      })();
+      if (!(await settleWithinTeardownDeadline(cleanupAdmission, deadline))) {
+        disposed = true;
+        promptAborted = true;
+        takeoverDetected = true;
+        settlePromptRelease();
+        logTeardownBudgetExpiry("cleanup-acquire");
+        await releaseInitialLock();
+        cleanupLockGranted = true;
+        cleanupOwnershipReleased = new Promise<void>((resolve) => {
+          resolveCleanupOwnershipReleased = resolve;
+        });
+        return {
+          release: () => {
+            resolveCleanupOwnershipReleased?.();
+            return Promise.resolve();
+          },
+        } as SessionLock;
+      }
       if (disposed) {
         throw new Error("attempt disposed before cleanup");
       }
@@ -413,12 +485,12 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         release: () => {
           cleanupReleasePromise ??= (async () => {
             try {
-              while (activeWriteOperations.size > 0) {
-                await Promise.all(
-                  [...activeWriteOperations].flatMap((operation) =>
-                    operation.settlement ? [operation.settlement] : [],
-                  ),
-                );
+              const writesSettled = await settleWithinTeardownDeadline(
+                drainActiveWrites(false),
+                createTeardownDeadline(),
+              );
+              if (!writesSettled) {
+                logTeardownBudgetExpiry("cleanup-release");
               }
               await releaseInitialLock();
               resolveCleanupOwnershipReleased?.();
@@ -450,38 +522,20 @@ export async function createEmbeddedAttemptSessionLockController(params: {
           }
           return;
         }
-        let timeout: ReturnType<typeof setTimeout> | undefined;
         try {
-          await Promise.race([
+          await settleWithinTeardownDeadline(
             (async () => {
               await Promise.all([promptSettled, serializeLifecycle(() => {})]);
-              while (true) {
-                const pendingWrites = [...activeWriteOperations].flatMap((operation) =>
-                  operation.settlement ? [operation.settlement] : [],
-                );
-                if (pendingWrites.length === 0) {
-                  break;
-                }
-                await Promise.all(pendingWrites);
-              }
+              await drainActiveWrites(false);
             })(),
-            new Promise<void>((resolve) => {
-              timeout = setTimeout(resolve, PROMPT_DISPOSE_SETTLE_TIMEOUT_MS);
-            }),
-          ]);
-          while (true) {
-            const startedWrites = [...activeWriteOperations]
-              .filter((operation) => operation.started)
-              .flatMap((operation) => (operation.settlement ? [operation.settlement] : []));
-            if (startedWrites.length === 0) {
-              break;
-            }
-            await Promise.all(startedWrites);
+            createTeardownDeadline(PROMPT_DISPOSE_SETTLE_TIMEOUT_MS),
+          );
+          if (
+            !(await settleWithinTeardownDeadline(drainActiveWrites(true), createTeardownDeadline()))
+          ) {
+            logTeardownBudgetExpiry("dispose");
           }
         } finally {
-          if (timeout) {
-            clearTimeout(timeout);
-          }
           await releaseInitialLock();
         }
       })().catch((error: unknown) => {
@@ -532,6 +586,7 @@ export function installPromptSubmissionLockRelease(params: {
     run: () => Promise<T> | T,
     options?: OwnedSessionTranscriptWriteOptions<T>,
   ) => Promise<T>;
+  assertSessionWriteLockOwned?: () => void;
   canAdvanceSessionEntryCache?: (snapshot: OwnedSessionTranscriptCacheSnapshot) => boolean;
   publishSessionFileSnapshot?: (snapshot: OwnedSessionTranscriptCacheSnapshot) => boolean;
 }): void {
@@ -553,11 +608,15 @@ export function installPromptSubmissionLockRelease(params: {
     let promptResult: unknown;
     try {
       if (params.sessionFile && params.withSessionWriteLock) {
+        if (!params.assertSessionWriteLockOwned) {
+          throw new Error("owned transcript write context requires a session lock ownership fence");
+        }
         promptResult = await withOwnedSessionTranscriptWrites(
           {
             sessionFile: params.sessionFile,
             sessionKey: params.sessionKey,
             sessionTarget: params.sessionTarget,
+            assertOwned: params.assertSessionWriteLockOwned,
             withSessionWriteLock: params.withSessionWriteLock,
             canAdvanceSessionEntryCache: params.canAdvanceSessionEntryCache,
             publishSessionFileSnapshot: params.publishSessionFileSnapshot,

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -78,7 +78,6 @@ type SessionManagerMocks = {
   flushPendingPersistence: UnknownMock;
   flushPendingToolResults: UnknownMock;
   clearPendingToolResults: UnknownMock;
-  mergePromptReleasedSessionEntries: UnknownMock;
   reloadPersistedTranscript: UnknownMock;
   clearNextUserMessagePersistenceSuppression: UnknownMock;
   removeTrailingEntries: UnknownMock;
@@ -250,7 +249,6 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     flushPendingPersistence: vi.fn(),
     flushPendingToolResults: vi.fn(),
     clearPendingToolResults: vi.fn(),
-    mergePromptReleasedSessionEntries: vi.fn(),
     reloadPersistedTranscript: vi.fn(),
     clearNextUserMessagePersistenceSuppression: vi.fn(),
     removeTrailingEntries: vi.fn(() => 0),
@@ -1139,7 +1137,6 @@ export function resetEmbeddedAttemptHarness(
   hoisted.sessionManager.appendSessionInfo.mockReset();
   hoisted.sessionManager.appendLabelChange.mockReset();
   hoisted.sessionManager.flushPendingPersistence.mockReset();
-  hoisted.sessionManager.mergePromptReleasedSessionEntries.mockReset();
   hoisted.sessionManager.reloadPersistedTranscript.mockReset();
   if (params.subscribeImpl) {
     hoisted.subscribeEmbeddedAgentSessionMock.mockImplementation(params.subscribeImpl);

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -1,9 +1,13 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { acquireOpenClawStateLease } from "../state/openclaw-state-lease.js";
+import { SessionWriteLockTimeoutError } from "./session-write-lock-error.js";
 import {
   acquireSessionWriteLock,
   drainSessionWriteLockStateForTest,
@@ -57,13 +61,55 @@ describe("SQLite session write leases", () => {
     const sessionFile = target();
     const first = await acquire(sessionFile);
 
-    await expect(acquire(sessionFile, { timeoutMs: 5 })).rejects.toThrow(/session file locked/);
+    const timeout = await acquire(sessionFile, { timeoutMs: 5 }).catch((error: unknown) => error);
+    expect(timeout).toBeInstanceOf(SessionWriteLockTimeoutError);
+    expect(timeout).toMatchObject({
+      owner: `held by this process (pid ${process.pid}); an earlier run has not released it`,
+    });
+    expect(String(timeout)).toContain(`pid ${process.pid}`);
     await expect(fs.access(`${sessionFile}.lock`)).rejects.toMatchObject({ code: "ENOENT" });
 
     await first.release();
     const second = await acquire(sessionFile, { timeoutMs: 500 });
     expect(() => second.assertOwned?.()).not.toThrow();
     await second.release();
+  });
+
+  it("reports the live foreign process that holds the session lease", async () => {
+    const databasePath = path.join(root, "foreign-openclaw-agent.sqlite");
+    const sessionFile = target({ sessionId: "foreign-session", storePath: databasePath });
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    await once(child, "spawn");
+    const childPid = child.pid;
+    if (!childPid) {
+      throw new Error("foreign lease fixture did not start");
+    }
+    const foreignLease = await acquireOpenClawStateLease({
+      scope: "session-write",
+      key: sessionFile,
+      database: { scope: "agent", agentId: "main", path: databasePath },
+      leaseMs: 1_000,
+      waitMs: 0,
+      processOwner: {
+        pid: childPid,
+        startTime: null,
+        isAlive: () => true,
+        readStartTime: () => null,
+      },
+    });
+    try {
+      const timeout = await acquire(sessionFile, { timeoutMs: 5 }).catch((error: unknown) => error);
+      expect(timeout).toBeInstanceOf(SessionWriteLockTimeoutError);
+      expect(timeout).toMatchObject({ owner: `held by OpenClaw process pid ${childPid}` });
+    } finally {
+      await foreignLease.release();
+      child.kill();
+      if (child.exitCode === null && child.signalCode === null) {
+        await once(child, "exit");
+      }
+    }
   });
 
   it("reference-counts intentional process-local reentrancy", async () => {

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -218,6 +218,28 @@ function leaseLost(sessionKey: string): SessionWriteLockStaleError {
   });
 }
 
+function describeLeaseTimeoutOwner(error: OpenClawStateLeaseError): string {
+  const payload = error.ownerPayload;
+  if (!payload) {
+    return "another OpenClaw process";
+  }
+  if (payload.pid === process.pid) {
+    return `held by this process (pid ${payload.pid}); an earlier run has not released it`;
+  }
+  if (!isPidAlive(payload.pid)) {
+    return "another OpenClaw process";
+  }
+  const observedStartTime = resolveProcessStartTimeForLock(payload.pid);
+  if (
+    payload.starttime !== undefined &&
+    observedStartTime !== null &&
+    payload.starttime !== observedStartTime
+  ) {
+    return "another OpenClaw process";
+  }
+  return `held by OpenClaw process pid ${payload.pid}`;
+}
+
 function createLeaseHandle(sessionKey: string, entry: SessionWriteLeaseEntry) {
   let released = false;
   let releasePromise: Promise<void> | undefined;
@@ -336,7 +358,7 @@ export async function acquireSessionWriteLock(params: {
     if (error instanceof OpenClawStateLeaseError && error.code === "OPENCLAW_STATE_LEASE_TIMEOUT") {
       throw new SessionWriteLockTimeoutError({
         timeoutMs,
-        owner: "another OpenClaw process",
+        owner: describeLeaseTimeoutOwner(error),
         lockPath: leasePath(params.sessionFile),
       });
     }

--- a/src/agents/sessions/session-manager-core.ts
+++ b/src/agents/sessions/session-manager-core.ts
@@ -40,7 +40,6 @@ export class SessionManagerCore {
   protected appendParentId: string | null = null;
   protected appendMode: "side" | undefined;
   protected pendingDeliberateAppend = false;
-  protected promptReleasedSideBranchParentId: string | null | undefined;
   protected persistenceTarget: SessionManagerPersistenceTarget | undefined;
   protected persistenceHeaderPending = false;
 
@@ -139,7 +138,6 @@ export class SessionManagerCore {
     this.appendParentId = null;
     this.appendMode = undefined;
     this.pendingDeliberateAppend = false;
-    this.promptReleasedSideBranchParentId = undefined;
     return this.persistenceTarget ? this.sessionId : undefined;
   }
 
@@ -195,7 +193,6 @@ export class SessionManagerCore {
     this.appendParentId = null;
     this.appendMode = undefined;
     this.pendingDeliberateAppend = false;
-    this.promptReleasedSideBranchParentId = undefined;
     let opaqueIndex = 0;
     let latestResetId: string | undefined;
     const resetDescendantIds = new Set<string>();
@@ -231,10 +228,6 @@ export class SessionManagerCore {
           this.leafId = effectiveLeafState.leafId;
           this.appendParentId = effectiveLeafState.appendParentId;
           this.appendMode = effectiveLeafState.appendMode;
-          this.promptReleasedSideBranchParentId =
-            effectiveLeafState.appendMode === "side"
-              ? effectiveLeafState.appendParentId
-              : undefined;
           opaqueIndex += 1;
           continue;
         }
@@ -249,9 +242,6 @@ export class SessionManagerCore {
             resetDescendantIds.add(link.id);
           }
           this.appendParentId = link.id;
-          if (this.promptReleasedSideBranchParentId !== undefined) {
-            this.promptReleasedSideBranchParentId = link.id;
-          }
         }
         opaqueIndex += 1;
       }
@@ -296,11 +286,9 @@ export class SessionManagerCore {
       this.appendParentId = entry.id;
       if (isSessionTranscriptSideAppendEntry(entry)) {
         this.appendMode = "side";
-        this.promptReleasedSideBranchParentId = entry.id;
       } else {
         this.leafId = entry.id;
         this.appendMode = undefined;
-        this.promptReleasedSideBranchParentId = undefined;
       }
       if (entry.type === "label") {
         if (entry.label) {
@@ -521,7 +509,6 @@ export class SessionManagerCore {
     this.appendParentId = null;
     this.appendMode = undefined;
     this.pendingDeliberateAppend = false;
-    this.promptReleasedSideBranchParentId = undefined;
   }
 
   protected replacePersistedTranscript(options?: {

--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -87,11 +87,9 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     this.pendingDeliberateAppend = false;
     if (isSessionTranscriptSideAppendEntry(canonicalEntry)) {
       this.appendMode = "side";
-      this.promptReleasedSideBranchParentId = canonicalEntry.id;
     } else {
       this.leafId = canonicalEntry.id;
       this.appendMode = undefined;
-      this.promptReleasedSideBranchParentId = undefined;
     }
     return persistenceResult && typeof persistenceResult === "object"
       ? persistenceResult.anchor
@@ -304,8 +302,6 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     this.leafId = params.targetId;
     this.appendParentId = params.appendParentId;
     this.appendMode = params.appendMode;
-    this.promptReleasedSideBranchParentId =
-      params.appendMode === "side" ? params.appendParentId : undefined;
     this.pendingDeliberateAppend = false;
     return entry;
   }
@@ -441,7 +437,6 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     this.leafId = branchTargetId;
     this.appendParentId = branchTargetId;
     this.appendMode = undefined;
-    this.promptReleasedSideBranchParentId = undefined;
     this.pendingDeliberateAppend = true;
   }
 
@@ -449,7 +444,6 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     this.leafId = null;
     this.appendParentId = null;
     this.appendMode = undefined;
-    this.promptReleasedSideBranchParentId = undefined;
     this.pendingDeliberateAppend = true;
   }
 

--- a/src/agents/sessions/session-manager-persistence.ts
+++ b/src/agents/sessions/session-manager-persistence.ts
@@ -4,20 +4,13 @@ import {
   ensureSessionEntrySync,
   type TranscriptEntryAnchor,
 } from "../../config/sessions/session-accessor.js";
-import { isSessionTranscriptSideAppendEntry } from "../../config/sessions/transcript-tree.js";
 import {
   isIndexedSessionEntry,
   isJsonRecord,
   parseOpaqueLeafEntry,
-  parseParentLinkedOpaqueEntry,
 } from "./session-manager-codec.js";
 import { SessionManagerCore } from "./session-manager-core.js";
-import type {
-  AppendPersistenceOptions,
-  PromptReleasedSessionEntry,
-  PromptReleasedSessionMergeResult,
-  SessionEntry,
-} from "./session-manager-types.js";
+import type { AppendPersistenceOptions, SessionEntry } from "./session-manager-types.js";
 
 type PersistRecordResult =
   | string
@@ -262,140 +255,5 @@ export class SessionManagerPersistence extends SessionManagerCore {
       ...(result.anchor ? { anchor: result.anchor } : {}),
       effectiveParentId: result.effectiveParentId,
     };
-  }
-
-  mergePromptReleasedSessionEntries(
-    entries: readonly PromptReleasedSessionEntry[],
-    options?: { persistLeaf?: boolean },
-  ): PromptReleasedSessionMergeResult | undefined {
-    this.assertPromptReleasedEntriesPreserveActiveLeaf(entries);
-    let sideBranchParentId =
-      this.promptReleasedSideBranchParentId === undefined
-        ? this.leafId
-        : this.promptReleasedSideBranchParentId;
-    let persistedLeafId = this.leafId;
-    let persistedAppendParentId = this.appendParentId;
-    let persistedAppendMode: "active" | "side" =
-      this.promptReleasedSideBranchParentId === undefined ? "active" : "side";
-    let sawPersistedStateUpdate = false;
-    let rawTailId: string | null = null;
-
-    for (const sourceEntry of entries) {
-      if (sourceEntry.type === "prompt_released_opaque") {
-        this.opaqueFileEntries.push({ index: this.fileEntries.length, record: sourceEntry.record });
-        const leafEntry = parseOpaqueLeafEntry(sourceEntry.record);
-        if (leafEntry) {
-          rawTailId = leafEntry.id;
-          const leafState = this.resolveOpaqueLeafControl(leafEntry);
-          if (!leafState) {
-            this.invalidLeafControlIds.add(leafEntry.id);
-            this.opaqueParentsById.set(
-              leafEntry.id,
-              this.resolveOpaqueAppendParentId(leafEntry.parentId),
-            );
-            continue;
-          }
-          this.opaqueParentsById.set(leafEntry.id, leafState.leafId);
-          sideBranchParentId = leafState.appendParentId;
-          persistedLeafId = leafState.leafId;
-          persistedAppendParentId = leafState.appendParentId;
-          persistedAppendMode = leafState.appendMode === "side" ? "side" : "active";
-          sawPersistedStateUpdate = true;
-          continue;
-        }
-        const link = parseParentLinkedOpaqueEntry(sourceEntry.record);
-        if (link) {
-          this.opaqueParentsById.set(link.id, link.parentId);
-          sideBranchParentId = link.id;
-          persistedAppendParentId = link.id;
-          sawPersistedStateUpdate = true;
-          rawTailId = link.id;
-        }
-        continue;
-      }
-
-      if (this.byId.has(sourceEntry.id)) {
-        throw new Error(`Entry ${sourceEntry.id} already exists`);
-      }
-      if (sourceEntry.type === "label" && !this.byId.has(sourceEntry.targetId)) {
-        throw new Error(`Entry ${sourceEntry.targetId} not found`);
-      }
-      const entry: PromptReleasedSessionEntry = {
-        ...sourceEntry,
-        parentId: sideBranchParentId,
-      };
-      this.fileEntries.push(entry);
-      this.byId.set(entry.id, entry);
-      sideBranchParentId = entry.id;
-      persistedAppendParentId = entry.id;
-      if (isSessionTranscriptSideAppendEntry(entry)) {
-        persistedAppendMode = "side";
-      } else {
-        persistedLeafId = entry.id;
-        persistedAppendMode = "active";
-      }
-      sawPersistedStateUpdate = true;
-      rawTailId = entry.id;
-      if (entry.type === "label") {
-        if (entry.label) {
-          this.labelsById.set(entry.targetId, entry.label);
-          this.labelTimestampsById.set(entry.targetId, entry.timestamp);
-        } else {
-          this.labelsById.delete(entry.targetId);
-          this.labelTimestampsById.delete(entry.targetId);
-        }
-      }
-    }
-    this.promptReleasedSideBranchParentId = sideBranchParentId;
-    if (
-      options?.persistLeaf !== true ||
-      !this.persistenceTarget ||
-      !sawPersistedStateUpdate ||
-      (persistedLeafId === this.leafId &&
-        persistedAppendParentId === sideBranchParentId &&
-        persistedAppendMode === "side")
-    ) {
-      return undefined;
-    }
-
-    const leafEntry = this.createLeafControl(rawTailId, sideBranchParentId, "side");
-    this.persistRecord(leafEntry);
-    this.rememberLeafControl(leafEntry);
-    this.appendParentId = sideBranchParentId;
-    this.appendMode = "side";
-    return { publishedEntries: [{ kind: "id", id: leafEntry.id }] };
-  }
-
-  private assertPromptReleasedEntriesPreserveActiveLeaf(
-    entries: readonly PromptReleasedSessionEntry[],
-  ): void {
-    let sideBranchParentId =
-      this.promptReleasedSideBranchParentId === undefined
-        ? this.leafId
-        : this.promptReleasedSideBranchParentId;
-    for (const entry of entries) {
-      if (entry.type !== "prompt_released_opaque") {
-        sideBranchParentId = entry.id;
-        continue;
-      }
-      const leaf = parseOpaqueLeafEntry(entry.record);
-      if (leaf && entry.preserveActiveLeaf) {
-        const appendParentId =
-          leaf.appendParentId === undefined ? leaf.targetId : leaf.appendParentId;
-        if (
-          leaf.appendMode !== "side" ||
-          leaf.targetId !== this.leafId ||
-          leaf.parentId !== sideBranchParentId ||
-          appendParentId !== sideBranchParentId
-        ) {
-          throw new Error("prompt-released side leaf changed the active branch");
-        }
-        continue;
-      }
-      const link = parseParentLinkedOpaqueEntry(entry.record);
-      if (link) {
-        sideBranchParentId = link.id;
-      }
-    }
   }
 }

--- a/src/agents/sessions/session-manager-types.ts
+++ b/src/agents/sessions/session-manager-types.ts
@@ -1,4 +1,3 @@
-import type { OwnedSessionTranscriptPublishedEntry } from "../../config/sessions/transcript-write-context.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ImageContent, TextContent } from "../../llm/types.js";
 import type { AgentMessage } from "../runtime/index.js";
@@ -131,24 +130,6 @@ export interface SessionContext {
   thinkingLevel: string;
   model: { provider: string; modelId: string } | null;
 }
-
-interface PromptReleasedOpaqueEntry {
-  type: "prompt_released_opaque";
-  record: unknown;
-  preserveActiveLeaf?: true;
-}
-
-export type PromptReleasedSessionEntry =
-  | SessionMessageEntry
-  | CustomEntry
-  | LabelEntry
-  | SessionInfoEntry
-  | PromptReleasedOpaqueEntry;
-
-export type PromptReleasedSessionMergeResult = {
-  publishedEntries?: readonly OwnedSessionTranscriptPublishedEntry[];
-  requiresReload?: true;
-};
 
 export type PreservedOpaqueFileEntry = {
   index: number;

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -763,75 +763,7 @@ describe("SessionManager.open", () => {
     expect(loaded.getCwd()).toBe(dir);
   });
 
-  it("persists prompt-released leaf controls through SQLite markers", async () => {
-    const dir = await makeTempDir();
-    const storePath = path.join(dir, "sessions.json");
-    const sessionId = "sqlite-prompt-release";
-    const sessionKey = "agent:main:dashboard:sqlite-prompt-release";
-    const marker = formatSqliteSessionFileMarker({
-      agentId: "main",
-      sessionId,
-      storePath,
-    });
-    const scope = { agentId: "main", sessionId, sessionKey, storePath };
-    await upsertSessionEntry(
-      { agentId: "main", sessionKey, storePath },
-      {
-        sessionFile: marker,
-        sessionId,
-        updatedAt: 10,
-      },
-    );
-    const user = await appendTranscriptMessage(scope, {
-      cwd: dir,
-      eventId: "user-message",
-      message: { role: "user", content: "question" },
-    });
-    const assistant = await appendTranscriptMessage(scope, {
-      cwd: dir,
-      eventId: "base-answer",
-      message: buildAssistantMessage("base answer"),
-      parentId: user.messageId,
-    });
-    const sessionManager = openMarker(marker, sessionKey, dir);
-    const sideEntry = {
-      type: "message" as const,
-      id: "side-delivery",
-      parentId: assistant.messageId,
-      timestamp: "2026-06-15T00:00:03.000Z",
-      message: buildAssistantMessage("side delivery"),
-    };
-    await appendTranscriptMessage(scope, {
-      cwd: dir,
-      eventId: sideEntry.id,
-      message: sideEntry.message,
-      parentId: sideEntry.parentId,
-    });
-
-    const mergeResult = sessionManager.mergePromptReleasedSessionEntries([sideEntry], {
-      persistLeaf: true,
-    });
-
-    expect(mergeResult?.publishedEntries).toEqual([{ kind: "id", id: expect.any(String) }]);
-    const records = await loadTranscriptEvents(scope);
-    expect(records.at(-1)).toMatchObject({
-      type: "leaf",
-      parentId: sideEntry.id,
-      targetId: assistant.messageId,
-      appendParentId: sideEntry.id,
-      appendMode: "side",
-    });
-    expect(sessionManager.getAppendParentId()).toBe(sideEntry.id);
-    expect(sessionManager.getAppendMode()).toBe("side");
-    const reopened = openMarker(marker, sessionKey, dir);
-    expect(reopened.getAppendParentId()).toBe(sideEntry.id);
-    expect(reopened.getAppendMode()).toBe("side");
-    await expect(fs.stat(path.join(process.cwd(), marker))).rejects.toMatchObject({
-      code: "ENOENT",
-    });
-  });
-
-  it("rejects a prompt-released leaf control after the session target rebounds", async () => {
+  it("rejects persistence after the session target rebounds", async () => {
     const dir = await makeTempDir();
     const storePath = path.join(dir, "sessions.json");
     const sessionId = "sqlite-prompt-release-rebound";
@@ -851,19 +783,6 @@ describe("SessionManager.open", () => {
       parentId: user.messageId,
     });
     const sessionManager = openMarker(marker, sessionKey, dir);
-    const sideEntry = {
-      type: "message" as const,
-      id: "rebound-side-delivery",
-      parentId: assistant.messageId,
-      timestamp: "2026-07-26T00:00:00.000Z",
-      message: buildAssistantMessage("side delivery"),
-    };
-    await appendTranscriptMessage(scope, {
-      cwd: dir,
-      eventId: sideEntry.id,
-      message: sideEntry.message,
-      parentId: sideEntry.parentId,
-    });
     await upsertSessionEntry(
       { agentId: "main", sessionKey, storePath },
       { sessionId: "replacement-session", updatedAt: 20 },
@@ -883,9 +802,6 @@ describe("SessionManager.open", () => {
       });
     }
 
-    expect(() =>
-      sessionManager.mergePromptReleasedSessionEntries([sideEntry], { persistLeaf: true }),
-    ).toThrow("leaf control was not persisted");
     const entriesBeforeRejectedAppends = sessionManager.getEntries();
     const leafBeforeRejectedAppends = sessionManager.getLeafId();
     const appendParentBeforeRejectedAppends = sessionManager.getAppendParentId();

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -33,8 +33,6 @@ export type {
   LabelEntry,
   ModelChangeEntry,
   NewSessionOptions,
-  PromptReleasedSessionEntry,
-  PromptReleasedSessionMergeResult,
   ResetEntry,
   ResetReason,
   SessionContext,

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -581,7 +581,7 @@ describe("subagent registry lifecycle hardening", () => {
     const controller = createLifecycleController({ entry, runSubagentAnnounceFlow });
 
     await withOwnedSessionTranscriptWrites(
-      { sessionKey, withSessionWriteLock: withStaleWriteLock },
+      { sessionKey, assertOwned: () => undefined, withSessionWriteLock: withStaleWriteLock },
       async () => {
         expect(controller.startSubagentAnnounceCleanupFlow(entry.runId, entry)).toBe(true);
       },
@@ -3856,7 +3856,7 @@ describe("requester settle wake trigger", () => {
     });
 
     await withOwnedSessionTranscriptWrites(
-      { sessionKey, withSessionWriteLock: withStaleWriteLock },
+      { sessionKey, assertOwned: () => undefined, withSessionWriteLock: withStaleWriteLock },
       async () => {
         controller.completeCleanupBookkeeping({
           runId: entry.runId,

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -2017,7 +2017,7 @@ describe("subagent registry seam flow", () => {
     });
 
     await withOwnedSessionTranscriptWrites(
-      { sessionKey, withSessionWriteLock: withStaleWriteLock },
+      { sessionKey, assertOwned: () => undefined, withSessionWriteLock: withStaleWriteLock },
       async () => {
         mod.registerSubagentRun({
           runId: "run-detached-requester-owner",

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -159,7 +159,7 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
     }));
 
     await withOwnedSessionTranscriptWrites(
-      { sessionKey, withSessionWriteLock: withStaleWriteLock },
+      { sessionKey, assertOwned: () => undefined, withSessionWriteLock: withStaleWriteLock },
       async () => {
         scheduleMediaGenerationTaskCompletion({
           lifecycle,

--- a/src/config/sessions/session-accessor.entry.ts
+++ b/src/config/sessions/session-accessor.entry.ts
@@ -12,7 +12,7 @@ import { clearPluginOwnedSessionState } from "./plugin-host-cleanup.js";
 import {
   countSqliteSessionEntryRowsReadOnly as countSessionEntryRowsReadOnly,
   copySqliteSessionOwnedStateForCanonicalRepair as copySessionOwnedStateForCanonicalRepair,
-  ensureSqliteSessionEntrySync,
+  ensureSqliteSessionEntrySync as ensureSessionEntrySyncRaw,
   hasSqliteSessionEntriesByStatusReadOnly as hasSessionEntriesByStatusReadOnly,
   listSqliteSessionGenerationIdsForCanonicalRepair as listSessionGenerationIdsForCanonicalRepair,
   listSqliteSessionChildEntriesReadOnly as listSessionChildEntriesReadOnly,
@@ -54,16 +54,16 @@ import { canonicalSessionKeyMigrationRequiredError } from "./session-canonical-k
 import { resolveSessionStorePathForScope } from "./session-store-path.js";
 import { normalizeStoreSessionKey, resolveSessionStoreEntry } from "./store-entry.js";
 import { resolveAllAgentSessionStoreTargetsSync, type SessionStoreTarget } from "./targets.js";
+import { assertOwnedSessionTranscriptWrite } from "./transcript-write-context.js";
 import type { SessionEntry } from "./types.js";
 
 export { clearPluginOwnedSessionState };
 
 // SQLite is the only runtime session store. Re-export its canonical entry
-// operations directly instead of maintaining a second pass-through layer.
+// operations directly except the sync initializer fenced below.
 export {
   countSessionEntryRowsReadOnly,
   copySessionOwnedStateForCanonicalRepair,
-  ensureSqliteSessionEntrySync,
   hasSessionEntriesByStatusReadOnly,
   listSessionGenerationIdsForCanonicalRepair,
   listSessionChildEntriesReadOnly,
@@ -82,6 +82,14 @@ export {
   replaceSessionEntry,
   replaceSessionEntrySync,
   upsertSessionEntry,
+};
+
+export const ensureSessionEntrySync: typeof ensureSessionEntrySyncRaw = (scope, entry) => {
+  assertOwnedSessionTranscriptWrite({
+    sessionKey: scope.sessionKey,
+    sessionTarget: scope,
+  });
+  return ensureSessionEntrySyncRaw(scope, entry);
 };
 
 /** Keeps legacy store-key alias resolution behind the entry owner boundary. */

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -32,6 +32,7 @@ import {
   createSessionEntryWithTranscript,
   deleteSessionEntryLifecycle,
   findTranscriptEvent,
+  ensureSessionEntrySync,
   listSessionEntries,
   listSessionEntriesByStatus,
   listSessionTranscriptInstances,
@@ -48,6 +49,7 @@ import {
   readSessionUpdatedAt,
   recordInboundSessionMeta,
   replaceSessionEntry,
+  replaceTranscriptEventsSync,
   resetSessionEntryLifecycle,
   SessionInitializationAgentScopeMismatchError,
   type SessionPatchProjectionOperation,
@@ -3619,6 +3621,7 @@ describe("session accessor seam", () => {
         sessionFile: scope.sessionKey,
         sessionKey: scope.sessionKey,
         sessionTarget: scope,
+        assertOwned: () => undefined,
         withSessionWriteLock: async (run, options) => {
           publishOptions.push(options?.publishOwnedWrite);
           const result = await run();
@@ -3647,6 +3650,37 @@ describe("session accessor seam", () => {
     expect(publishOptions).toEqual([undefined]);
     expect(publishedEntryBatches).toEqual([[]]);
     await expect(loadTranscriptEvents(scope)).resolves.toHaveLength(2);
+  });
+
+  it("fences matching sync transcript and entry writes before SQLite mutation", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "session-owned-fence",
+      sessionKey: "agent:main:owned-fence",
+      storePath,
+    };
+    const stale = new Error("lease lost");
+
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile: scope.sessionKey,
+        sessionKey: scope.sessionKey,
+        sessionTarget: scope,
+        assertOwned: () => {
+          throw stale;
+        },
+        withSessionWriteLock: async (run) => await run(),
+      },
+      async () => {
+        expect(() =>
+          ensureSessionEntrySync(scope, { sessionId: scope.sessionId, updatedAt: 1 }),
+        ).toThrow(stale);
+        expect(() => replaceTranscriptEventsSync(scope, [])).toThrow(stale);
+      },
+    );
+
+    expect(loadSessionEntry(scope)).toBeUndefined();
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([]);
   });
 
   it("resolves store-backed runtime transcript targets from structured identity", async () => {

--- a/src/config/sessions/session-accessor.transcript.ts
+++ b/src/config/sessions/session-accessor.transcript.ts
@@ -1,9 +1,9 @@
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import {
   appendSqliteTranscriptEvent as appendTranscriptEvent,
-  appendSqliteTranscriptEventSync as appendTranscriptEventSync,
+  appendSqliteTranscriptEventSync,
   appendSqliteTranscriptMessage as appendTranscriptMessage,
-  appendSqliteTranscriptMessageSync as appendTranscriptMessageSync,
+  appendSqliteTranscriptMessageSync,
   findSqliteTranscriptEvent,
   loadLatestSqliteAssistantText as readLatestTranscriptAssistantText,
   loadSqliteTranscriptEventRowsAfterSeqSync as loadTranscriptEventRowsAfterSeqSync,
@@ -16,7 +16,7 @@ import {
   readSqliteTranscriptRawDelta as readTranscriptRawDelta,
   publishSqliteTranscriptUpdate as publishTranscriptUpdate,
   replaceSqliteTranscriptEvents as replaceTranscriptEvents,
-  replaceSqliteTranscriptEventsSync as replaceTranscriptEventsSync,
+  replaceSqliteTranscriptEventsSync,
   rewriteSqliteTranscriptEventRowsExact as rewriteTranscriptEventRowsExact,
   resolveSqliteSessionKeyBySessionId as resolveTranscriptSessionKeyBySessionId,
   trimSqliteTranscriptForManualCompact,
@@ -26,6 +26,7 @@ import {
 import type {
   SessionTranscriptRuntimeScope,
   SessionTranscriptReadScope,
+  SessionTranscriptWriteScope,
   TranscriptEvent,
   SessionTranscriptManualTrimResult,
   SessionTranscriptManualTrimPreflightResult,
@@ -34,14 +35,13 @@ import {
   scanSessionTranscriptTree,
   selectSessionTranscriptTreePathNodes,
 } from "./transcript-tree.js";
+import { assertOwnedSessionTranscriptWrite } from "./transcript-write-context.js";
 
-// Persisted transcripts have one SQLite owner. Preserve public operation names
-// as direct exports so append, idempotency, locks, and events cannot drift.
+// Persisted transcripts have one SQLite owner. Async operations keep direct
+// exports; sync runtime writes use the ownership-fenced wrappers below.
 export {
   appendTranscriptEvent,
-  appendTranscriptEventSync,
   appendTranscriptMessage,
-  appendTranscriptMessageSync,
   loadTranscriptEventRowsAfterSeqSync,
   loadTranscriptEvents,
   loadTranscriptEventsSync,
@@ -53,11 +53,43 @@ export {
   readTranscriptRawDelta,
   readTranscriptStatsSync,
   replaceTranscriptEvents,
-  replaceTranscriptEventsSync,
   rewriteTranscriptEventRowsExact,
   resolveTranscriptSessionKeyBySessionId,
   withTranscriptWriteLock,
   withTranscriptWriteTransaction,
+};
+
+function assertOwnedTranscriptScope(scope: SessionTranscriptWriteScope): void {
+  assertOwnedSessionTranscriptWrite({
+    sessionFile: scope.sessionFile,
+    sessionKey: scope.sessionKey,
+    sessionTarget: scope,
+  });
+}
+
+export const appendTranscriptEventSync: typeof appendSqliteTranscriptEventSync = (
+  scope,
+  event,
+  options,
+) => {
+  assertOwnedTranscriptScope(scope);
+  return appendSqliteTranscriptEventSync(scope, event, options);
+};
+
+export const appendTranscriptMessageSync: typeof appendSqliteTranscriptMessageSync = (
+  scope,
+  options,
+) => {
+  assertOwnedTranscriptScope(scope);
+  return appendSqliteTranscriptMessageSync(scope, options);
+};
+
+export const replaceTranscriptEventsSync: typeof replaceSqliteTranscriptEventsSync = (
+  scope,
+  events,
+) => {
+  assertOwnedTranscriptScope(scope);
+  return replaceSqliteTranscriptEventsSync(scope, events);
 };
 
 /** Keeps transcript event delivery behind the transcript owner boundary. */

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -126,7 +126,7 @@ export type {
 } from "./session-accessor.entry-mutation.js";
 export {
   countSessionEntryRowsReadOnly,
-  ensureSqliteSessionEntrySync as ensureSessionEntrySync,
+  ensureSessionEntrySync,
   copySessionOwnedStateForCanonicalRepair,
   hasSessionEntriesByStatusReadOnly,
   listSessionGenerationIdsForCanonicalRepair,

--- a/src/config/sessions/transcript-write-context.ts
+++ b/src/config/sessions/transcript-write-context.ts
@@ -6,6 +6,8 @@ type OwnedSessionTranscriptWriteContext = {
   sessionFile?: string;
   sessionKey?: string;
   sessionTarget?: SessionTranscriptWriteLockTarget;
+  /** Fence each durable mutation at the transaction boundary, not only callback admission. */
+  assertOwned(): void;
   canAdvanceSessionEntryCache?: (snapshot: OwnedSessionTranscriptCacheSnapshot) => boolean;
   publishSessionFileSnapshot?: (snapshot: OwnedSessionTranscriptCacheSnapshot) => boolean;
   withSessionWriteLock: <T>(
@@ -27,7 +29,7 @@ export type OwnedSessionTranscriptWriteOptions<T> = {
   resolvePublishedEntriesAfterFailure?: () => readonly OwnedSessionTranscriptPublishedEntry[];
 };
 
-export type OwnedSessionTranscriptPublishedEntry =
+type OwnedSessionTranscriptPublishedEntry =
   | { kind: "id"; id: string }
   | { kind: "header"; serialized: string }
   | { kind: "serialized"; serialized: string };
@@ -113,6 +115,18 @@ export function bindOwnedSessionTranscriptWrites<TArgs extends unknown[], TResul
 ): (...args: TArgs) => TResult {
   // Bind callbacks that will run later but must still see the parent write-lock context.
   return (...args) => ownedTranscriptWriteContext.run(context, () => run(...args));
+}
+
+/** Revalidates a matching attempt-owned lease immediately before durable mutation. */
+export function assertOwnedSessionTranscriptWrite(params: {
+  sessionFile?: string;
+  sessionKey?: string;
+  sessionTarget?: SessionTranscriptWriteLockTarget;
+}): void {
+  const context = ownedTranscriptWriteContext.getStore();
+  if (context && contextMatches({ context, ...params })) {
+    context.assertOwned();
+  }
 }
 
 export async function runWithOwnedSessionTranscriptWriteLock<T>(

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -463,6 +463,7 @@ describe("appendAssistantMessageToSessionTranscript", () => {
           sessionKey,
           storePath: fixture.storePath(),
         },
+        assertOwned: () => undefined,
         withSessionWriteLock: async (run) => {
           events.push("lock");
           return await run();
@@ -492,6 +493,7 @@ describe("appendAssistantMessageToSessionTranscript", () => {
       {
         sessionFile: oldSessionFile,
         sessionKey,
+        assertOwned: () => undefined,
         withSessionWriteLock: async (run) => {
           events.push("lock");
           return await run();
@@ -530,6 +532,7 @@ describe("appendAssistantMessageToSessionTranscript", () => {
           sessionFile: ownerTarget.sessionKey,
           sessionKey: ownerTarget.sessionKey,
           sessionTarget: ownerTarget,
+          assertOwned: () => undefined,
           withSessionWriteLock: async (run) => {
             events.push("lock");
             return await run();
@@ -561,6 +564,7 @@ describe("appendAssistantMessageToSessionTranscript", () => {
       {
         sessionFile,
         sessionKey,
+        assertOwned: () => undefined,
         withSessionWriteLock: async (run) => {
           events.push("lock");
           return await run();

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -436,6 +436,7 @@ dispatchInboundMessageMock.mockImplementation(
               sessionKey,
               storePath,
             },
+            assertOwned: () => undefined,
             withSessionWriteLock: async () => {
               mockState.disposedTranscriptWriteAttempts += 1;
               throw new Error("attempt disposed before transcript write");

--- a/src/state/openclaw-state-lease-owner.ts
+++ b/src/state/openclaw-state-lease-owner.ts
@@ -1,0 +1,78 @@
+export type OpenClawStateLeaseProcessOwner = {
+  pid: number;
+  startTime: number | null;
+  isAlive(pid: number): boolean;
+  readStartTime(pid: number): number | null;
+};
+
+export type OpenClawStateLeaseOwnerPayload = Readonly<{
+  pid: number;
+  starttime?: number;
+}>;
+
+export type OpenClawStateLeaseErrorCode =
+  | "OPENCLAW_STATE_LEASE_INVALID_INPUT"
+  | "OPENCLAW_STATE_LEASE_TIMEOUT"
+  | "OPENCLAW_STATE_LEASE_ABORTED"
+  | "OPENCLAW_STATE_LEASE_LOST"
+  | "OPENCLAW_STATE_LEASE_STORAGE_FAILED";
+
+export class OpenClawStateLeaseError extends Error {
+  readonly code: OpenClawStateLeaseErrorCode;
+  declare readonly ownerPayload?: OpenClawStateLeaseOwnerPayload;
+
+  constructor(
+    message: string,
+    options: {
+      code: OpenClawStateLeaseErrorCode;
+      cause?: unknown;
+      ownerPayload?: OpenClawStateLeaseOwnerPayload;
+    },
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "OpenClawStateLeaseError";
+    this.code = options.code;
+    if (options.ownerPayload) {
+      this.ownerPayload = options.ownerPayload;
+    }
+  }
+}
+
+export function parseOpenClawStateLeaseOwnerPayload(
+  payloadJson: string | null,
+): OpenClawStateLeaseOwnerPayload | undefined {
+  let payload: { pid?: unknown; starttime?: unknown } | undefined;
+  try {
+    payload = payloadJson ? (JSON.parse(payloadJson) as typeof payload) : undefined;
+  } catch {
+    return undefined;
+  }
+  const pid = payload?.pid;
+  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) {
+    return undefined;
+  }
+  const starttime = payload?.starttime;
+  return typeof starttime === "number" && Number.isInteger(starttime) && starttime >= 0
+    ? { pid, starttime }
+    : { pid };
+}
+
+export function processLeaseIsReclaimable(
+  row: { expires_at: number | null; payload_json: string | null },
+  processOwner: OpenClawStateLeaseProcessOwner,
+): boolean {
+  const payload = parseOpenClawStateLeaseOwnerPayload(row.payload_json);
+  if (!payload) {
+    // A malformed owner can only be reclaimed after its persisted deadline.
+    return Number(row.expires_at) <= Date.now();
+  }
+  if (!processOwner.isAlive(payload.pid)) {
+    return true;
+  }
+  const observedStartTime = processOwner.readStartTime(payload.pid);
+  return (
+    payload.starttime !== undefined &&
+    observedStartTime !== null &&
+    payload.starttime !== observedStartTime
+  );
+}

--- a/src/state/openclaw-state-lease.test.ts
+++ b/src/state/openclaw-state-lease.test.ts
@@ -206,7 +206,10 @@ describe("OpenClaw state lease", () => {
 
         await expect(
           withOpenClawStateLease({ ...options, waitMs: 5 }, async () => undefined),
-        ).rejects.toMatchObject({ code: "OPENCLAW_STATE_LEASE_TIMEOUT" });
+        ).rejects.toMatchObject({
+          code: "OPENCLAW_STATE_LEASE_TIMEOUT",
+          ownerPayload: { pid: process.pid },
+        });
         expect(() => owner.assertOwned()).not.toThrow();
       });
     });

--- a/src/state/openclaw-state-lease.ts
+++ b/src/state/openclaw-state-lease.ts
@@ -21,6 +21,17 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db.js";
+import {
+  OpenClawStateLeaseError,
+  parseOpenClawStateLeaseOwnerPayload,
+  processLeaseIsReclaimable,
+  type OpenClawStateLeaseErrorCode,
+  type OpenClawStateLeaseOwnerPayload,
+  type OpenClawStateLeaseProcessOwner,
+} from "./openclaw-state-lease-owner.js";
+
+export { OpenClawStateLeaseError };
+export type { OpenClawStateLeaseErrorCode };
 
 type LeaseDatabase = Pick<OpenClawStateKyselyDatabase, "state_leases">;
 type AgentLeaseDatabase = Pick<OpenClawAgentKyselyDatabase, "state_leases">;
@@ -29,13 +40,6 @@ type LeaseKysely = ReturnType<typeof getNodeSqliteKysely<LeaseDatabase>>;
 type OpenClawStateLeaseDatabase =
   | { scope: "shared"; options?: OpenClawStateDatabaseOptions }
   | { scope: "agent"; agentId: string; path?: string };
-
-type OpenClawStateLeaseProcessOwner = {
-  pid: number;
-  startTime: number | null;
-  isAlive(pid: number): boolean;
-  readStartTime(pid: number): number | null;
-};
 
 type OpenClawStateLeaseOptions = {
   scope: string;
@@ -67,23 +71,6 @@ export type OpenClawStateLeaseHandle = OpenClawStateLeaseContext & {
   /** Release a manually held process lease during synchronous termination cleanup. */
   releaseSynchronously(): void;
 };
-
-export type OpenClawStateLeaseErrorCode =
-  | "OPENCLAW_STATE_LEASE_INVALID_INPUT"
-  | "OPENCLAW_STATE_LEASE_TIMEOUT"
-  | "OPENCLAW_STATE_LEASE_ABORTED"
-  | "OPENCLAW_STATE_LEASE_LOST"
-  | "OPENCLAW_STATE_LEASE_STORAGE_FAILED";
-
-export class OpenClawStateLeaseError extends Error {
-  readonly code: OpenClawStateLeaseErrorCode;
-
-  constructor(message: string, options: { code: OpenClawStateLeaseErrorCode; cause?: unknown }) {
-    super(message, { cause: options.cause });
-    this.name = "OpenClawStateLeaseError";
-    this.code = options.code;
-  }
-}
 
 const ACQUIRE_BACKOFF = {
   initialMs: 25,
@@ -138,10 +125,12 @@ function leaseError(
   code: OpenClawStateLeaseErrorCode,
   message: string,
   cause?: unknown,
+  ownerPayload?: OpenClawStateLeaseOwnerPayload,
 ): OpenClawStateLeaseError {
   return new OpenClawStateLeaseError(message, {
     code,
     ...(cause === undefined ? {} : { cause }),
+    ...(ownerPayload ? { ownerPayload } : {}),
   });
 }
 
@@ -282,32 +271,9 @@ type LeaseIdentity = {
   processOwner?: OpenClawStateLeaseProcessOwner;
 };
 
-function processLeaseIsReclaimable(
-  row: { expires_at: number | null; payload_json: string | null },
-  processOwner: OpenClawStateLeaseProcessOwner,
-): boolean {
-  let payload: { pid?: unknown; starttime?: unknown } | undefined;
-  try {
-    payload = row.payload_json ? (JSON.parse(row.payload_json) as typeof payload) : undefined;
-  } catch {
-    // A malformed owner can only be reclaimed after its persisted deadline.
-  }
-  const pid = payload?.pid;
-  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) {
-    return Number(row.expires_at) <= Date.now();
-  }
-  if (!processOwner.isAlive(pid)) {
-    return true;
-  }
-  const observedStartTime = processOwner.readStartTime(pid);
-  return (
-    typeof payload?.starttime === "number" &&
-    Number.isInteger(payload.starttime) &&
-    payload.starttime >= 0 &&
-    observedStartTime !== null &&
-    payload.starttime !== observedStartTime
-  );
-}
+type LeaseAcquireResult =
+  | { status: "acquired"; expiresAt: number }
+  | { status: "contended"; ownerPayload?: OpenClawStateLeaseOwnerPayload };
 
 function tryAcquire(
   params: LeaseIdentity & {
@@ -315,7 +281,7 @@ function tryAcquire(
     operationLabel: string;
     leaseMs: number;
   },
-): number | undefined {
+): LeaseAcquireResult {
   const observed = params.processOwner
     ? withLeaseRead(params.database, (db, kysely) =>
         executeSqliteQueryTakeFirstSync(
@@ -372,7 +338,22 @@ function tryAcquire(
         })
         .onConflict((conflict) => conflict.columns(["scope", "lease_key"]).doNothing()),
     );
-    return inserted.numAffectedRows === 1n ? expiresAt : undefined;
+    if (inserted.numAffectedRows === 1n) {
+      return { status: "acquired", expiresAt };
+    }
+    const contender = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("state_leases")
+        .select("payload_json")
+        .where("scope", "=", params.scope)
+        .where("lease_key", "=", params.key),
+    );
+    const ownerPayload = parseOpenClawStateLeaseOwnerPayload(contender?.payload_json ?? null);
+    return {
+      status: "contended",
+      ...(ownerPayload ? { ownerPayload } : {}),
+    };
   });
 }
 
@@ -528,12 +509,13 @@ export async function acquireOpenClawStateLease(
   const deadline = performance.now() + validated.waitMs;
   let attempt = 0;
   let confirmedExpiresAt: number | undefined;
+  let lastObservedOwnerPayload: OpenClawStateLeaseOwnerPayload | undefined;
   while (confirmedExpiresAt === undefined) {
     if (validated.signal?.aborted) {
       throw abortError(validated.signal, "acquisition", validated.leaseLabel);
     }
     try {
-      confirmedExpiresAt = tryAcquire({
+      const result = tryAcquire({
         database: validated.database,
         operationLabel: validated.operationLabel,
         scope: validated.scope,
@@ -543,6 +525,12 @@ export async function acquireOpenClawStateLease(
         leaseLabel: validated.leaseLabel,
         processOwner: validated.processOwner,
       });
+      if (result.status === "acquired") {
+        confirmedExpiresAt = result.expiresAt;
+        lastObservedOwnerPayload = undefined;
+      } else {
+        lastObservedOwnerPayload = result.ownerPayload;
+      }
     } catch (error) {
       if (error instanceof OpenClawStateLeaseError) {
         throw error;
@@ -572,6 +560,8 @@ export async function acquireOpenClawStateLease(
         throw leaseError(
           "OPENCLAW_STATE_LEASE_TIMEOUT",
           `timed out waiting for ${validated.leaseLabel} ${validated.scope}/${validated.key}`,
+          undefined,
+          lastObservedOwnerPayload,
         );
       }
       break;
@@ -580,6 +570,8 @@ export async function acquireOpenClawStateLease(
       throw leaseError(
         "OPENCLAW_STATE_LEASE_TIMEOUT",
         `timed out waiting for ${validated.leaseLabel} ${validated.scope}/${validated.key}`,
+        undefined,
+        lastObservedOwnerPayload,
       );
     }
     attempt += 1;


### PR DESCRIPTION
## What Problem This Solves

A wedged embedded-attempt teardown could hold and heartbeat-renew the SQLite session-write lease indefinitely (observed in production: a heartbeat turn renewed for 3+ hours), blocking every successor run on the session with a misleading "another OpenClaw process" timeout error — the owner was the same PID. Teardown had three unbounded waits, and the lock-timeout error discarded the persisted owner identity.

## Why This Change Was Made

Sync SessionManager SQLite writes now reassert lease ownership immediately before mutation, which makes bounded teardown safe: late started writers fail with SessionWriteLockStaleError instead of writing unfenced. Teardown waits are bounded (budget + loud log with run/session/pending-write counts) and always release. Timeout diagnostics now name the real owner: same-process ("held by this process (pid N); an earlier run has not released it") vs live foreign PID. Also removes dead prompt-release merge plumbing (its trigger condition — actual mid-prompt lock release — no longer exists since the lease became prompt-spanning) and corrects a comment describing a watchdog that only exists on the legacy file-lock path.

## User Impact

A hung turn can no longer wedge its session forever; successors proceed after the teardown budget instead of failing every 60s. Lock-timeout errors become actionable.

## Evidence

Teardown suites: 44 tests; session accessor: 94; lock/state-lease: 21; SessionManager: 24; helpers: 10; staged check-changed passed; Codex autoreview clean (no P0).

Named follow-up (coordinator-tracked, addressed by the writer-claim fence PR): already-admitted async accessor operations that await before their transaction are not covered by this synchronous fence.
