### PR TITLE
refactor(doctor): simplify deprecation registry metadata

### DIFF
--- a/scripts/check-doctor-deprecation-registry.ts
+++ b/scripts/check-doctor-deprecation-registry.ts
@@ -1,11 +1,14 @@
-import { pathToFileURL } from "node:url";
 import {
   listDoctorDeprecationCompatRecords,
   type DoctorDeprecationCompatRecord,
 } from "../src/commands/doctor/shared/deprecation-compat.js";
+import { hasValidIsoCalendarComponents } from "../src/shared/iso-time.js";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
 
 type DeadlineRecord = Pick<DoctorDeprecationCompatRecord, "code" | "status" | "removeAfter">;
 type ExpiredDeadlineRecord = DeadlineRecord & { removeAfter: string };
+type OutputWriter = { write(chunk: string): unknown };
+type RegistryCheckIo = { stdout: OutputWriter; stderr: OutputWriter };
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
 
@@ -27,11 +30,7 @@ export function findExpiredDeprecatedDoctorRecords(
 }
 
 function isUtcDate(value: string): boolean {
-  if (!DATE_PATTERN.test(value)) {
-    return false;
-  }
-  const timestamp = Date.parse(`${value}T00:00:00Z`);
-  return Number.isFinite(timestamp) && new Date(timestamp).toISOString().slice(0, 10) === value;
+  return DATE_PATTERN.test(value) && hasValidIsoCalendarComponents(value);
 }
 
 function parseAsOf(argv: readonly string[]): string | undefined {
@@ -46,35 +45,40 @@ function parseAsOf(argv: readonly string[]): string | undefined {
   );
 }
 
-function main(argv = process.argv.slice(2)): void {
+function writeLine(writer: OutputWriter, message: string): void {
+  writer.write(`${message}\n`);
+}
+
+export function main(argv = process.argv.slice(2), io: RegistryCheckIo = process): 0 | 1 | 2 {
   let requestedAsOf: string | undefined;
   try {
     requestedAsOf = parseAsOf(argv);
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exitCode = 2;
-    return;
+    writeLine(io.stderr, error instanceof Error ? error.message : String(error));
+    return 2;
   }
 
   const asOf = requestedAsOf ?? new Date().toISOString().slice(0, 10);
   const expired = findExpiredDeprecatedDoctorRecords(listDoctorDeprecationCompatRecords(), asOf);
   if (expired.length === 0) {
-    console.log(`[doctor-deprecation-registry] OK as of ${asOf}`);
-    return;
+    writeLine(io.stdout, `[doctor-deprecation-registry] OK as of ${asOf}`);
+    return 0;
   }
 
-  console.error(
+  writeLine(
+    io.stderr,
     `[doctor-deprecation-registry] ${expired.length} deprecated record(s) reached removeAfter by ${asOf}:`,
   );
   for (const record of expired) {
-    console.error(`- ${record.code}: removeAfter ${record.removeAfter}`);
+    writeLine(io.stderr, `- ${record.code}: removeAfter ${record.removeAfter}`);
   }
-  console.error(
+  writeLine(
+    io.stderr,
     "Remove each migration after supported-upgrade proof, or move it to removal-pending with a documented blocker.",
   );
-  process.exitCode = 1;
+  return 1;
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-  main();
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
+  process.exitCode = main();
 }

--- a/src/commands/doctor/shared/deprecation-compat.test.ts
+++ b/src/commands/doctor/shared/deprecation-compat.test.ts
@@ -1,12 +1,7 @@
 // Deprecation compatibility tests cover doctor warnings and repairs for deprecated config.
 import fs from "node:fs";
 import { describe, expect, it } from "vitest";
-import {
-  getDoctorDeprecationCompatRecord,
-  isDoctorDeprecationCompatCode,
-  listDeprecatedDoctorDeprecationCompatRecords,
-  listDoctorDeprecationCompatRecords,
-} from "./deprecation-compat.js";
+import { listDoctorDeprecationCompatRecords } from "./deprecation-compat.js";
 
 const datePattern = /^\d{4}-\d{2}-\d{2}$/u;
 
@@ -31,27 +26,30 @@ const requiredDoctorCompatCodes = [
 ] as const;
 
 describe("doctor deprecation compatibility inventory", () => {
-  it("keeps compatibility codes unique and lookup-safe", () => {
+  it("keeps compatibility codes unique", () => {
     const records = listDoctorDeprecationCompatRecords();
-    const codes = records.map((record) => record.code);
+    const codes = new Set(records.map((record) => record.code));
 
-    expect(records).toHaveLength(43);
-    expect(new Set(codes).size).toBe(codes.length);
-    expect(isDoctorDeprecationCompatCode("doctor-web-search-plugin-config")).toBe(true);
-    expect(isDoctorDeprecationCompatCode("missing-code")).toBe(false);
-    expect(getDoctorDeprecationCompatRecord("doctor-web-search-plugin-config").owner).toBe(
+    expect(codes.size).toBe(records.length);
+    expect(codes.has("doctor-web-search-plugin-config")).toBe(true);
+    expect(codes.has("missing-code")).toBe(false);
+    expect(records.find((record) => record.code === "doctor-web-search-plugin-config")?.owner).toBe(
       "provider",
     );
   });
 
   it("tracks the known doctor migrations that protect plugin/config rollout", () => {
+    const codes = new Set(listDoctorDeprecationCompatRecords().map((record) => record.code));
     for (const code of requiredDoctorCompatCodes) {
-      expect(isDoctorDeprecationCompatCode(code), code).toBe(true);
+      expect(codes.has(code), code).toBe(true);
     }
   });
 
   it("keeps dated deprecation metadata in chronological order", () => {
-    for (const record of listDeprecatedDoctorDeprecationCompatRecords()) {
+    const records = listDoctorDeprecationCompatRecords().filter(
+      (record) => record.status === "deprecated" || record.status === "removal-pending",
+    );
+    for (const record of records) {
       expect(record.introduced, record.code).toMatch(datePattern);
       expect(record.deprecated, record.code).toMatch(datePattern);
       expect(record.warningStarts, record.code).toMatch(datePattern);

--- a/src/commands/doctor/shared/deprecation-compat.ts
+++ b/src/commands/doctor/shared/deprecation-compat.ts
@@ -1,7 +1,7 @@
 // Inventory of doctor compatibility migrations that outlive deprecated runtime/config paths.
-export type DoctorDeprecationCompatStatus = "active" | "deprecated" | "removal-pending" | "removed";
+type DoctorDeprecationCompatStatus = "active" | "deprecated" | "removal-pending" | "removed";
 
-export type DoctorDeprecationCompatOwner =
+type DoctorDeprecationCompatOwner =
   | "agent-runtime"
   | "audio"
   | "browser"
@@ -13,9 +13,9 @@ export type DoctorDeprecationCompatOwner =
   | "tools"
   | "tts";
 
-export type DoctorDeprecationCompatRecord<Code extends string = string> = {
+export type DoctorDeprecationCompatRecord = {
   /** Stable inventory code for a doctor compatibility surface. */
-  code: Code;
+  code: string;
   /** Current lifecycle state for the compatibility surface. */
   status: DoctorDeprecationCompatStatus;
   /** Area that owns the deprecated input or migration. */
@@ -35,25 +35,54 @@ export type DoctorDeprecationCompatRecord<Code extends string = string> = {
 
 const DEFAULT_TESTS = ["src/commands/doctor/shared/legacy-config-migrate.test.ts"] as const;
 
-function deprecatedCompatRecord<Code extends string>(
-  code: Code,
-  record: Omit<
-    DoctorDeprecationCompatRecord<Code>,
-    "code" | "introduced" | "deprecated" | "warningStarts" | "removeAfter" | "status" | "tests"
-  > &
-    Required<Pick<DoctorDeprecationCompatRecord<Code>, "introduced" | "removeAfter">> &
-    Partial<
-      Pick<DoctorDeprecationCompatRecord<Code>, "deprecated" | "status" | "warningStarts" | "tests">
-    >,
-): DoctorDeprecationCompatRecord<Code> {
+type CompatRecordInput = {
+  owner: DoctorDeprecationCompatOwner;
+  introduced: string;
+  deprecated?: string;
+  warningStarts?: string;
+  removeAfter: string;
+  source: string;
+  migration: string;
+  replacement: string;
+  docsPath: string;
+  tests?: readonly string[];
+  notes?: string;
+};
+
+function compatRecord(
+  code: string,
+  status: DoctorDeprecationCompatStatus,
+  record: CompatRecordInput,
+): DoctorDeprecationCompatRecord {
   return {
     code,
-    status: "deprecated",
+    status,
     deprecated: record.introduced,
     warningStarts: record.introduced,
     tests: DEFAULT_TESTS,
     ...record,
   };
+}
+
+function deprecatedCompatRecord(
+  code: string,
+  record: CompatRecordInput,
+): DoctorDeprecationCompatRecord {
+  return compatRecord(code, "deprecated", record);
+}
+
+function removalPendingCompatRecord(
+  code: string,
+  record: CompatRecordInput,
+): DoctorDeprecationCompatRecord {
+  return compatRecord(code, "removal-pending", record);
+}
+
+function removedCompatRecord(
+  code: string,
+  record: CompatRecordInput,
+): DoctorDeprecationCompatRecord {
+  return compatRecord(code, "removed", record);
 }
 
 // Doctor migrations and repair shims can outlive the runtime/config compatibility
@@ -236,8 +265,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/channels/channel-routing",
     tests: ["src/config/dead-config-keys.test.ts"],
   }),
-  deprecatedCompatRecord("doctor-agent-llm-timeout", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-agent-llm-timeout", {
     owner: "agent-runtime",
     introduced: "2026-04-27",
     removeAfter: "2026-07-26",
@@ -248,8 +276,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     notes:
       "The old agent-level idle timeout knob was collapsed into provider request timeout handling, bounded by the agent/run timeout ceiling.",
   }),
-  deprecatedCompatRecord("doctor-agent-runtime-embedded-harness", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-agent-runtime-embedded-harness", {
     owner: "agent-runtime",
     introduced: "2026-04-25",
     deprecated: "2026-04-26",
@@ -262,8 +289,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     notes:
       "Whole-agent runtime pins are retired; doctor preserves intent only when it can move the value to provider/model runtime policy.",
   }),
-  deprecatedCompatRecord("doctor-agent-embedded-pi-config", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-agent-embedded-pi-config", {
     owner: "agent-runtime",
     introduced: "2026-05-21",
     removeAfter: "2026-07-26",
@@ -274,8 +300,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     notes:
       "Runtime code no longer reads the legacy key; doctor keeps this migration only to preserve shipped configs during upgrade.",
   }),
-  deprecatedCompatRecord("doctor-agent-sandbox-persession", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-agent-sandbox-persession", {
     owner: "agent-runtime",
     introduced: "2026-04-26",
     removeAfter: "2026-07-26",
@@ -302,8 +327,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     replacement: "agents.defaults.typingMode or agents.list[].typingMode",
     docsPath: "/concepts/typing-indicators",
   }),
-  deprecatedCompatRecord("doctor-top-level-heartbeat", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-top-level-heartbeat", {
     owner: "config",
     introduced: "2026-04-26",
     removeAfter: "2026-07-26",
@@ -312,8 +336,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     replacement: "agents.defaults.heartbeat and channels.defaults.heartbeat",
     docsPath: "/automation",
   }),
-  deprecatedCompatRecord("doctor-mcp-server-type-alias", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-mcp-server-type-alias", {
     owner: "config",
     introduced: "2026-04-27",
     removeAfter: "2026-07-26",
@@ -324,8 +347,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     notes:
       "OpenClaw stores transport names; CLI backends receive their own type fields through runtime adapters.",
   }),
-  deprecatedCompatRecord("doctor-gateway-bind-host-aliases", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-gateway-bind-host-aliases", {
     owner: "gateway",
     introduced: "2026-04-26",
     removeAfter: "2026-07-26",
@@ -334,8 +356,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     replacement: "gateway.bind.mode values such as lan, loopback, custom, tailnet, and auto",
     docsPath: "/gateway/configuration",
   }),
-  deprecatedCompatRecord("doctor-audio-transcription-command", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-audio-transcription-command", {
     owner: "audio",
     introduced: "2026-04-26",
     removeAfter: "2026-07-26",
@@ -344,8 +365,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     replacement: "capability-tagged tools.media.models",
     docsPath: "/tools/media-overview",
   }),
-  deprecatedCompatRecord("doctor-channel-thread-binding-ttl", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-channel-thread-binding-ttl", {
     owner: "channel",
     introduced: "2026-04-26",
     removeAfter: "2026-07-26",
@@ -354,8 +374,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     replacement: "threadBindings.idleHours",
     docsPath: "/channels/channel-routing",
   }),
-  deprecatedCompatRecord("doctor-message-queue-steering-modes", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-message-queue-steering-modes", {
     owner: "config",
     introduced: "2026-05-04",
     removeAfter: "2026-07-26",
@@ -364,8 +383,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     replacement: "steer, followup, collect, or interrupt queue modes",
     docsPath: "/concepts/queue",
   }),
-  deprecatedCompatRecord("doctor-channel-dm-aliases", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-channel-dm-aliases", {
     owner: "channel",
     introduced: "2026-04-26",
     removeAfter: "2026-07-26",
@@ -375,8 +393,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/channels/channel-routing",
     tests: ["src/commands/doctor/shared/channel-legacy-config-migrate.test.ts"],
   }),
-  deprecatedCompatRecord("doctor-channel-streaming-aliases", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-channel-streaming-aliases", {
     owner: "channel",
     introduced: "2026-04-26",
     removeAfter: "2026-07-26",
@@ -388,8 +405,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     notes:
       "Runtime reads are nested-only; doctor keeps this migration to move shipped configs during upgrade.",
   }),
-  deprecatedCompatRecord("doctor-webchat-channel-config", {
-    status: "removed",
+  removedCompatRecord("doctor-webchat-channel-config", {
     owner: "channel",
     introduced: "2026-05-18",
     deprecated: "2026-05-31",
@@ -412,8 +428,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/tools/tts",
     tests: ["src/commands/doctor/shared/legacy-config-migrate.provider-shapes.test.ts"],
   }),
-  deprecatedCompatRecord("doctor-tts-provider-aliases", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-tts-provider-aliases", {
     owner: "tts",
     introduced: "2026-04-26",
     removeAfter: "2026-07-26",
@@ -422,8 +437,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     replacement: "tts.providers.<provider> and microsoft instead of edge",
     docsPath: "/tools/tts",
   }),
-  deprecatedCompatRecord("doctor-tts-enabled-auto-mode", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-tts-enabled-auto-mode", {
     owner: "tts",
     introduced: "2026-04-29",
     removeAfter: "2026-07-26",
@@ -435,8 +449,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/tools/tts",
     tests: ["src/commands/doctor/shared/legacy-config-migrate.provider-shapes.test.ts"],
   }),
-  deprecatedCompatRecord("doctor-tts-speaker-selection-fields", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-tts-speaker-selection-fields", {
     owner: "tts",
     introduced: "2026-05-28",
     removeAfter: "2026-07-26",
@@ -446,8 +459,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/tools/tts",
     tests: ["src/commands/doctor/shared/legacy-config-migrate.provider-shapes.test.ts"],
   }),
-  deprecatedCompatRecord("doctor-plugin-install-config-ledger", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-plugin-install-config-ledger", {
     owner: "plugin",
     introduced: "2026-04-25",
     deprecated: "2026-04-26",
@@ -462,8 +474,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
       "src/commands/doctor/shared/plugin-registry-migration.test.ts",
     ],
   }),
-  deprecatedCompatRecord("doctor-bundled-plugin-load-paths", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-bundled-plugin-load-paths", {
     owner: "plugin",
     introduced: "2026-04-25",
     deprecated: "2026-04-26",
@@ -475,8 +486,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/cli/plugins#registry",
     tests: ["src/commands/doctor/shared/bundled-plugin-load-paths.test.ts"],
   }),
-  deprecatedCompatRecord("doctor-bundled-provider-discovery-allowlist", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-bundled-provider-discovery-allowlist", {
     owner: "plugin",
     introduced: "2026-04-25",
     deprecated: "2026-04-26",
@@ -502,8 +512,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     notes:
       "The core bootstrap migration must remain available when the external Codex plugin is not installed yet.",
   }),
-  deprecatedCompatRecord("doctor-web-search-plugin-config", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-web-search-plugin-config", {
     owner: "provider",
     introduced: "2026-04-26",
     removeAfter: "2026-07-26",
@@ -515,8 +524,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     notes:
       "Provider/plugin ownership can move as bundled providers externalize; verify the current manifest owner before deleting migration support.",
   }),
-  deprecatedCompatRecord("doctor-web-fetch-plugin-config", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-web-fetch-plugin-config", {
     owner: "provider",
     introduced: "2026-04-26",
     removeAfter: "2026-07-26",
@@ -526,8 +534,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/tools/web-fetch",
     tests: ["src/commands/doctor/shared/legacy-web-fetch-migrate.test.ts"],
   }),
-  deprecatedCompatRecord("doctor-x-search-plugin-config", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-x-search-plugin-config", {
     owner: "provider",
     introduced: "2026-04-26",
     removeAfter: "2026-07-26",
@@ -540,8 +547,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
       "src/commands/doctor/shared/legacy-config-migrate.test.ts",
     ],
   }),
-  deprecatedCompatRecord("doctor-talk-provider-shape", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-talk-provider-shape", {
     owner: "tts",
     introduced: "2026-04-26",
     removeAfter: "2026-07-26",
@@ -550,8 +556,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     replacement: "talk.providers.<provider>",
     docsPath: "/tools/tts",
   }),
-  deprecatedCompatRecord("doctor-legacy-tools-by-sender", {
-    status: "removal-pending",
+  removalPendingCompatRecord("doctor-legacy-tools-by-sender", {
     owner: "tools",
     introduced: "2026-04-26",
     removeAfter: "2026-07-26",
@@ -563,38 +568,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
   }),
 ] as const satisfies readonly DoctorDeprecationCompatRecord[];
 
-export type DoctorDeprecationCompatCode =
-  (typeof DOCTOR_DEPRECATION_COMPAT_RECORDS)[number]["code"];
-export type KnownDoctorDeprecationCompatRecord = DoctorDeprecationCompatRecord;
-
-const doctorDeprecationCompatRecordByCode = new Map<string, KnownDoctorDeprecationCompatRecord>(
-  DOCTOR_DEPRECATION_COMPAT_RECORDS.map((record) => [record.code, record]),
-);
-
 /** List every doctor compatibility record, including removed or still-active entries. */
-export function listDoctorDeprecationCompatRecords(): readonly KnownDoctorDeprecationCompatRecord[] {
+export function listDoctorDeprecationCompatRecords(): readonly DoctorDeprecationCompatRecord[] {
   return DOCTOR_DEPRECATION_COMPAT_RECORDS;
-}
-
-/** List compatibility records currently in a deprecated/removal-pending lifecycle. */
-export function listDeprecatedDoctorDeprecationCompatRecords(): readonly KnownDoctorDeprecationCompatRecord[] {
-  return DOCTOR_DEPRECATION_COMPAT_RECORDS.filter((record) =>
-    (["deprecated", "removal-pending"] as readonly string[]).includes(record.status),
-  );
-}
-
-/** Return true when a string is a known doctor compatibility inventory code. */
-export function isDoctorDeprecationCompatCode(code: string): code is DoctorDeprecationCompatCode {
-  return doctorDeprecationCompatRecordByCode.has(code);
-}
-
-/** Return a doctor compatibility record by code, throwing for impossible stale callers. */
-export function getDoctorDeprecationCompatRecord(
-  code: DoctorDeprecationCompatCode,
-): KnownDoctorDeprecationCompatRecord {
-  const record = doctorDeprecationCompatRecordByCode.get(code);
-  if (!record) {
-    throw new Error(`Unknown doctor deprecation compatibility code: ${code}`);
-  }
-  return record;
 }

--- a/test/scripts/check-doctor-deprecation-registry.test.ts
+++ b/test/scripts/check-doctor-deprecation-registry.test.ts
@@ -1,7 +1,10 @@
-import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
-import { findExpiredDeprecatedDoctorRecords } from "../../scripts/check-doctor-deprecation-registry.js";
+import {
+  findExpiredDeprecatedDoctorRecords,
+  main,
+} from "../../scripts/check-doctor-deprecation-registry.js";
 import { listDoctorDeprecationCompatRecords } from "../../src/commands/doctor/shared/deprecation-compat.js";
+import { createCapturedIo } from "../helpers/captured-io.js";
 
 const deadlineRecord = {
   code: "doctor-test-deadline",
@@ -27,36 +30,22 @@ describe("doctor deprecation registry guard", () => {
     ).toEqual([]);
   });
 
-  it("keeps the real registry current as of 2026-08-08", () => {
-    const records = listDoctorDeprecationCompatRecords();
-    const removalPending = records.filter((record) => record.status === "removal-pending");
-
-    expect(records).toHaveLength(43);
-    expect(removalPending).toHaveLength(23);
-    expect(new Set(removalPending.map((record) => record.removeAfter))).toEqual(
-      new Set(["2026-07-26"]),
-    );
-    expect(findExpiredDeprecatedDoctorRecords(records, "2026-08-08")).toEqual([]);
-  });
-
   it("prints every offending code and date with actionable guidance", () => {
     const asOf = "9999-12-31";
     const offenders = findExpiredDeprecatedDoctorRecords(
       listDoctorDeprecationCompatRecords(),
       asOf,
     );
-    const result = spawnSync(
-      process.execPath,
-      ["--import", "tsx", "scripts/check-doctor-deprecation-registry.ts", "--as-of", asOf],
-      { encoding: "utf8" },
-    );
+    const { io, readStderr } = createCapturedIo();
+    const exitCode = main(["--as-of", asOf], io);
+    const stderr = readStderr();
 
     expect(offenders.length).toBeGreaterThan(0);
-    expect(result.status).toBe(1);
+    expect(exitCode).toBe(1);
     for (const offender of offenders) {
-      expect(result.stderr).toContain(`${offender.code}: removeAfter ${offender.removeAfter}`);
+      expect(stderr).toContain(`${offender.code}: removeAfter ${offender.removeAfter}`);
     }
-    expect(result.stderr).toContain("Remove each migration after supported-upgrade proof");
-    expect(result.stderr).toContain("move it to removal-pending with a documented blocker");
+    expect(stderr).toContain("Remove each migration after supported-upgrade proof");
+    expect(stderr).toContain("move it to removal-pending with a documented blocker");
   });
 });


### PR DESCRIPTION
Related: #120868

## What Problem This Solves

The doctor deprecation registry enforcement added in #120868 preserved the right behavior, but its initial implementation still carried avoidable internal machinery: test-only lookup exports, a registry map and defensive branch with no production caller, 23 repeated lifecycle overrides, duplicate date/direct-run logic, a subprocess-backed checker test, and brittle cardinality/date snapshots.

This behavior-neutral follow-up simplifies that metadata and its checker without changing any registry record or deadline policy.

## Why This Change Was Made

The registry now uses lifecycle-specific record constructors, and the unused lookup API, map, and impossible defensive path are removed. The checker reuses the existing ISO-date and direct-run helpers, accepts injected I/O for in-process diagnostics tests, and drops incidental snapshots while retaining the behavior-focused assertions.

All record contents, dates, migrations, replacement text, and queue entries remain unchanged. Deadline failure remains inclusive for `deprecated` records whose `removeAfter` date is on or before the as-of date, while `removal-pending` records remain excluded.

AI assistance was used for implementation and verification. The change and its proof were reviewed; no agent transcript is included.

## User Impact

None. Runtime behavior, doctor migrations, CLI output, and exit status are unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/commands/doctor/shared/deprecation-compat.test.ts test/scripts/check-doctor-deprecation-registry.test.ts` — 9 passed.
- `node --import tsx scripts/check-doctor-deprecation-registry.ts --as-of 2026-08-08` — `[doctor-deprecation-registry] OK as of 2026-08-08`.
- Lifecycle count probe — exactly 19 `deprecated`, 23 `removal-pending`, and 1 `removed`.
- `git diff --check` — clean.
- Codex autoreview in uncommitted mode — clean, with no accepted/actionable findings.
- Production/tooling: +92/-114 (net -22). Tests: +25/-38 (net -13). Aggregate: +117/-152 (net -35).
