### PR TITLE
refactor(approvals): simplify resolver plumbing

### DIFF
--- a/extensions/imessage/src/approval-handler.runtime.test.ts
+++ b/extensions/imessage/src/approval-handler.runtime.test.ts
@@ -24,8 +24,8 @@ const timersMock = vi.hoisted(() => ({
   delay: vi.fn(async () => undefined),
 }));
 
-const approvalResolverMock = vi.hoisted(() => ({
-  resolveIMessageApproval: vi.fn(),
+const approvalGatewayMock = vi.hoisted(() => ({
+  resolveApprovalOverGateway: vi.fn(),
   isApprovalNotFoundError: vi.fn(() => false),
 }));
 
@@ -148,7 +148,12 @@ vi.mock("./actions.runtime.js", () => ({
   },
 }));
 
-vi.mock("./approval-resolver.js", () => approvalResolverMock);
+vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
+  resolveApprovalOverGateway: approvalGatewayMock.resolveApprovalOverGateway,
+}));
+vi.mock("openclaw/plugin-sdk/error-runtime", () => ({
+  isApprovalNotFoundError: approvalGatewayMock.isApprovalNotFoundError,
+}));
 
 describe("imessageApprovalNativeRuntime", () => {
   it("renders shared reactions in pending exec approvals", async () => {
@@ -245,8 +250,8 @@ describe("imessageApprovalNativeRuntime", () => {
   describe("deliverPending GUID-only binding", () => {
     beforeEach(() => {
       iMessageApprovalPollTargets.clearForTest();
-      approvalResolverMock.resolveIMessageApproval.mockReset();
-      approvalResolverMock.resolveIMessageApproval.mockResolvedValue({
+      approvalGatewayMock.resolveApprovalOverGateway.mockReset();
+      approvalGatewayMock.resolveApprovalOverGateway.mockResolvedValue({
         applied: true,
         approval: {},
       });
@@ -452,8 +457,8 @@ describe("imessageApprovalNativeRuntime", () => {
 
     beforeEach(() => {
       iMessageApprovalPollTargets.clearForTest();
-      approvalResolverMock.resolveIMessageApproval.mockReset();
-      approvalResolverMock.resolveIMessageApproval.mockResolvedValue({
+      approvalGatewayMock.resolveApprovalOverGateway.mockReset();
+      approvalGatewayMock.resolveApprovalOverGateway.mockResolvedValue({
         applied: true,
         approval: {},
       });
@@ -552,10 +557,11 @@ describe("imessageApprovalNativeRuntime", () => {
           pollGuid: POLL_GUID,
         }),
       ).resolves.toBe(true);
-      expect(approvalResolverMock.resolveIMessageApproval).toHaveBeenCalledWith(
+      expect(approvalGatewayMock.resolveApprovalOverGateway).toHaveBeenCalledWith(
         expect.objectContaining({
           approvalId: "exec-poll",
           decision: "allow-once",
+          channel: "imessage",
         }),
       );
     });
@@ -594,7 +600,7 @@ describe("imessageApprovalNativeRuntime", () => {
           pollGuid: POLL_GUID,
         }),
       ).resolves.toBe(true);
-      expect(approvalResolverMock.resolveIMessageApproval).toHaveBeenCalledTimes(1);
+      expect(approvalGatewayMock.resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
     });
 
     [

--- a/extensions/imessage/src/approval-polls.test.ts
+++ b/extensions/imessage/src/approval-polls.test.ts
@@ -10,12 +10,12 @@ import {
 import type { IMessagePayload } from "./monitor/types.js";
 
 const resolverMocks = vi.hoisted(() => ({
-  resolveIMessageApproval: vi.fn(),
+  resolveApprovalOverGateway: vi.fn(),
   isApprovalNotFoundError: vi.fn(() => false),
 }));
 
 vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
-  resolveApprovalOverGateway: resolverMocks.resolveIMessageApproval,
+  resolveApprovalOverGateway: resolverMocks.resolveApprovalOverGateway,
 }));
 vi.mock("openclaw/plugin-sdk/error-runtime", () => ({
   isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
@@ -78,8 +78,8 @@ function buildVote(overrides?: {
 
 beforeEach(() => {
   iMessageApprovalPollTargets.clearForTest();
-  resolverMocks.resolveIMessageApproval.mockReset();
-  resolverMocks.resolveIMessageApproval.mockResolvedValue({ applied: true, approval: {} });
+  resolverMocks.resolveApprovalOverGateway.mockReset();
+  resolverMocks.resolveApprovalOverGateway.mockResolvedValue({ applied: true, approval: {} });
   resolverMocks.isApprovalNotFoundError.mockReset();
   resolverMocks.isApprovalNotFoundError.mockReturnValue(false);
 });
@@ -168,7 +168,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith(
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith(
       expect.objectContaining({
         approvalId: "exec-1",
         decision: "allow-once",
@@ -212,7 +212,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith(
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith(
       expect.objectContaining({ approvalId: "exec-1", decision: "deny" }),
     );
   });
@@ -246,7 +246,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("accepts a complete multi-record set for one participant alias", async () => {
@@ -278,7 +278,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith(
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith(
       expect.objectContaining({ approvalId: "exec-1", decision: "allow-once" }),
     );
   });
@@ -312,7 +312,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("authenticates paired-device self votes with destination_caller_id", async () => {
@@ -331,7 +331,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith(
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith(
       expect.objectContaining({ decision: "allow-once", senderId: APPROVER }),
     );
   });
@@ -352,7 +352,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(false);
 
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("rejects imsg's local-identity sender fallback on received rows", async () => {
@@ -371,7 +371,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(false);
 
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("uses the option id when imsg reports the prompt GUID instead of the poll GUID", async () => {
@@ -393,7 +393,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith(
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith(
       expect.objectContaining({
         approvalId: "exec-racy-guid",
         decision: "allow-once",
@@ -438,7 +438,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("denies a group vote from a member outside allowFrom", async () => {
@@ -452,7 +452,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("resolves a group vote from an approver", async () => {
@@ -466,7 +466,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith(
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith(
       expect.objectContaining({ approvalId: "exec-group", senderId: APPROVER }),
     );
   });
@@ -495,7 +495,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith(
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith(
       expect.objectContaining({ approvalId: "exec-email", decision: "deny" }),
     );
   });
@@ -511,7 +511,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("owns an un-vote without resolving it", async () => {
@@ -525,7 +525,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("ignores an option id that is not bound to a decision", async () => {
@@ -539,7 +539,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -571,7 +571,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("fails closed on a malformed complete vote set for an owned poll", async () => {
@@ -592,7 +592,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("falls through for a poll it does not own so ordinary polls still render", async () => {
@@ -613,14 +613,14 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
   it("swallows late votes after the approval resolved", async () => {
     bind();
     await maybeResolveIMessageApprovalPollVote({ cfg, accountId: "default", message: buildVote() });
-    resolverMocks.resolveIMessageApproval.mockClear();
+    resolverMocks.resolveApprovalOverGateway.mockClear();
 
     // Messages cannot close a poll, so the balloon stays tappable; a late tap
     // must not reach the agent as prose.
     await expect(
       maybeResolveIMessageApprovalPollVote({ cfg, accountId: "default", message: buildVote() }),
     ).resolves.toBe(true);
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("retains a tombstone after the live target expires", async () => {
@@ -647,7 +647,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
           message: buildVote({ pollGuid: expiringPollGuid }),
         }),
       ).resolves.toBe(true);
-      expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+      expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }
@@ -671,36 +671,36 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
         message: buildVote({ pollGuid: orphanPollGuid }),
       }),
     ).resolves.toBe(true);
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("clears the binding when the approval is already gone", async () => {
     bind();
     resolverMocks.isApprovalNotFoundError.mockReturnValue(true);
-    resolverMocks.resolveIMessageApproval.mockRejectedValue(new Error("not found"));
+    resolverMocks.resolveApprovalOverGateway.mockRejectedValue(new Error("not found"));
 
     await maybeResolveIMessageApprovalPollVote({ cfg, accountId: "default", message: buildVote() });
 
-    resolverMocks.resolveIMessageApproval.mockClear();
+    resolverMocks.resolveApprovalOverGateway.mockClear();
     resolverMocks.isApprovalNotFoundError.mockReturnValue(false);
-    resolverMocks.resolveIMessageApproval.mockResolvedValue({ applied: true, approval: {} });
+    resolverMocks.resolveApprovalOverGateway.mockResolvedValue({ applied: true, approval: {} });
 
     await maybeResolveIMessageApprovalPollVote({ cfg, accountId: "default", message: buildVote() });
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("retains the binding on a transient resolver error so a retry can land", async () => {
     bind();
-    resolverMocks.resolveIMessageApproval.mockRejectedValueOnce(new Error("gateway 503"));
+    resolverMocks.resolveApprovalOverGateway.mockRejectedValueOnce(new Error("gateway 503"));
 
     await expect(
       maybeResolveIMessageApprovalPollVote({ cfg, accountId: "default", message: buildVote() }),
     ).rejects.toThrow("gateway 503");
 
-    resolverMocks.resolveIMessageApproval.mockResolvedValue({ applied: true, approval: {} });
+    resolverMocks.resolveApprovalOverGateway.mockResolvedValue({ applied: true, approval: {} });
     await maybeResolveIMessageApprovalPollVote({ cfg, accountId: "default", message: buildVote() });
 
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenLastCalledWith(
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenLastCalledWith(
       expect.objectContaining({ approvalId: "exec-1", decision: "allow-once" }),
     );
   });
@@ -729,7 +729,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
         message: buildVote({ pollGuid: expiredPollGuid }),
       }),
     ).resolves.toBe(false);
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("matches a vote that arrives keyed by chat guid instead of handle", async () => {
@@ -751,7 +751,7 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
     await expect(
       maybeResolveIMessageApprovalPollVote({ cfg, accountId: "default", message }),
     ).resolves.toBe(true);
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith(
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith(
       expect.objectContaining({ approvalId: "exec-chat" }),
     );
   });
@@ -769,6 +769,6 @@ describe("maybeResolveIMessageApprovalPollVote", () => {
     });
 
     await maybeResolveIMessageApprovalPollVote({ cfg, accountId: "default", message: buildVote() });
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 });

--- a/extensions/imessage/src/approval-polls.ts
+++ b/extensions/imessage/src/approval-polls.ts
@@ -10,7 +10,7 @@ import {
 import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
-import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { createLazyRuntimeSurface } from "openclaw/plugin-sdk/lazy-runtime";
 import { asDateTimestampMs } from "openclaw/plugin-sdk/number-runtime";
 import { createPluginStateErrorReporter } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { getIMessageApprovalApprovers, imessageApprovalAuth } from "./approval-auth.js";
@@ -53,8 +53,9 @@ type IMessageApprovalPollTarget = {
 
 type IMessageApprovalPollTombstone = { approvalId: string };
 
-const loadApprovalResolver = createLazyRuntimeModule(
+const loadResolveApprovalOverGateway = createLazyRuntimeSurface(
   () => import("openclaw/plugin-sdk/approval-gateway-runtime"),
+  (runtime) => runtime.resolveApprovalOverGateway,
 );
 
 const reportPersistentError = createPluginStateErrorReporter(
@@ -534,7 +535,7 @@ export async function maybeResolveIMessageApprovalPollVote(params: {
     return true;
   }
 
-  const { resolveApprovalOverGateway } = await loadApprovalResolver();
+  const resolveApprovalOverGateway = await loadResolveApprovalOverGateway();
   try {
     const result = await resolveApprovalOverGateway({
       cfg: params.cfg,
@@ -583,7 +584,7 @@ export async function maybeResolveIMessageApprovalPollVote(params: {
 function clearIMessageApprovalPollTargetsForTest(): void {
   pollTargets.clearForTest();
   pollTombstones.clearForTest();
-  loadApprovalResolver.clear();
+  loadResolveApprovalOverGateway.clear();
 }
 
 export const iMessageApprovalPollTargets = {

--- a/extensions/imessage/src/approval-reaction-poller.test.ts
+++ b/extensions/imessage/src/approval-reaction-poller.test.ts
@@ -8,7 +8,7 @@ import {
 import type { IMessageRpcClient } from "./client.js";
 
 const resolverMocks = vi.hoisted(() => ({
-  resolveIMessageApproval: vi.fn(),
+  resolveApprovalOverGateway: vi.fn(),
   isApprovalNotFoundError: vi.fn(() => false),
 }));
 
@@ -17,8 +17,10 @@ const registerIMessageApprovalReactionTarget = (
   params: Omit<IMessageTargetParams, "approvalKind">,
 ) => registerIMessageApprovalReactionTargetRaw({ ...params, approvalKind: "exec" });
 
-vi.mock("./approval-resolver.js", () => ({
-  resolveIMessageApproval: resolverMocks.resolveIMessageApproval,
+vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
+  resolveApprovalOverGateway: resolverMocks.resolveApprovalOverGateway,
+}));
+vi.mock("openclaw/plugin-sdk/error-runtime", () => ({
   isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
 }));
 
@@ -131,8 +133,8 @@ describe("iMessage approval reaction poller", () => {
     clearIMessageApprovalReactionTargetsForTest();
     accountSequence += 1;
     accountId = `test-${accountSequence}`;
-    resolverMocks.resolveIMessageApproval.mockReset();
-    resolverMocks.resolveIMessageApproval.mockImplementation(
+    resolverMocks.resolveApprovalOverGateway.mockReset();
+    resolverMocks.resolveApprovalOverGateway.mockImplementation(
       async ({ decision }: { decision: "allow-once" | "allow-always" | "deny" }) => ({
         applied: true,
         approval:
@@ -172,11 +174,12 @@ describe("iMessage approval reaction poller", () => {
     );
 
     expect(request).toHaveBeenCalledWith("chats.list", { limit: 50 }, { timeoutMs: 10_000 });
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith({
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
       cfg: buildApprovalConfig(),
       approvalId: "exec-1",
       approvalKind: "exec",
       decision: "allow-once",
+      channel: "imessage",
       senderId: "+15551230000",
       gatewayUrl: undefined,
     });
@@ -218,7 +221,7 @@ describe("iMessage approval reaction poller", () => {
     await pollPendingIMessageApprovalReactions(pollParams);
     await pollPendingIMessageApprovalReactions(pollParams);
 
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledTimes(1);
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
     expect(request.mock.calls.filter(([method]) => method === "chats.list")).toHaveLength(1);
     expect(request.mock.calls.filter(([method]) => method === "messages.history")).toHaveLength(2);
     expect(request).toHaveBeenCalledWith(
@@ -229,7 +232,7 @@ describe("iMessage approval reaction poller", () => {
   });
 
   it("retries no-target discovery after resolver failures expire observed targets", async () => {
-    resolverMocks.resolveIMessageApproval.mockRejectedValue(new Error("gateway down"));
+    resolverMocks.resolveApprovalOverGateway.mockRejectedValue(new Error("gateway down"));
     const request = createRpcRequest([buildApprovalMessage()], [42]);
     const dateNow = vi.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
 
@@ -243,7 +246,7 @@ describe("iMessage approval reaction poller", () => {
       dateNow.mockRestore();
     }
 
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledTimes(2);
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledTimes(2);
     expect(request.mock.calls.filter(([method]) => method === "chats.list")).toHaveLength(2);
   });
 
@@ -320,7 +323,7 @@ describe("iMessage approval reaction poller", () => {
       dateNow.mockRestore();
     }
 
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("uses learned chat ids for fast scoped polling after discovery", async () => {
@@ -403,11 +406,12 @@ describe("iMessage approval reaction poller", () => {
       { chat_id: 99, limit: 30 },
       { timeoutMs: 10_000 },
     );
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith({
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
       cfg: buildApprovalConfig("+15551239999"),
       approvalId: "exec-handle",
       approvalKind: "exec",
       decision: "allow-once",
+      channel: "imessage",
       senderId: "+15551239999",
       gatewayUrl: undefined,
     });
@@ -450,19 +454,20 @@ describe("iMessage approval reaction poller", () => {
       buildPollParams(request, { cfg: buildApprovalConfig(APPROVER) }),
     );
 
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledTimes(1);
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith({
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
       cfg: buildApprovalConfig(APPROVER),
       approvalId: "exec-1",
       approvalKind: "exec",
       decision: "allow-once",
+      channel: "imessage",
       senderId: "+15551230000",
       gatewayUrl: undefined,
     });
   });
 
   it("stops polling after another surface records the canonical winner", async () => {
-    resolverMocks.resolveIMessageApproval.mockResolvedValueOnce({
+    resolverMocks.resolveApprovalOverGateway.mockResolvedValueOnce({
       applied: false,
       approval: { status: "denied", decision: "deny", reason: "user" },
     });
@@ -508,7 +513,7 @@ describe("iMessage approval reaction poller", () => {
     await pollPendingIMessageApprovalReactions(pollParams);
     await pollPendingIMessageApprovalReactions(pollParams);
 
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledTimes(1);
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
     expect(request).toHaveBeenCalledTimes(1);
     expect(logVerboseMessage).toHaveBeenCalledWith(
       "imessage: approval reaction already resolved id=exec-1 sender=+15551230000 status=denied decision=deny reason=user via messageId=msg-1",
@@ -517,7 +522,7 @@ describe("iMessage approval reaction poller", () => {
   });
 
   it("stops scanning after an authorized resolver failure", async () => {
-    resolverMocks.resolveIMessageApproval.mockRejectedValueOnce(new Error("gateway down"));
+    resolverMocks.resolveApprovalOverGateway.mockRejectedValueOnce(new Error("gateway down"));
     registerIMessageApprovalReactionTarget({
       accountId,
       conversation: { chatId: 42, chatGuid: "iMessage;+;chat-guid" },
@@ -556,12 +561,13 @@ describe("iMessage approval reaction poller", () => {
       buildPollParams(request, { cfg: buildApprovalConfig(APPROVER) }),
     );
 
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledTimes(1);
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith({
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
       cfg: buildApprovalConfig(APPROVER),
       approvalId: "exec-1",
       approvalKind: "exec",
       decision: "allow-once",
+      channel: "imessage",
       senderId: "+15551230000",
       gatewayUrl: undefined,
     });

--- a/extensions/imessage/src/approval-reactions.test.ts
+++ b/extensions/imessage/src/approval-reactions.test.ts
@@ -20,7 +20,7 @@ import {
 import type { IMessagePayload } from "./monitor/types.js";
 
 const resolverMocks = vi.hoisted(() => ({
-  resolveIMessageApproval: vi.fn(),
+  resolveApprovalOverGateway: vi.fn(),
   isApprovalNotFoundError: vi.fn(() => false),
 }));
 
@@ -38,7 +38,7 @@ function registerIMessageApprovalReactionTarget(
 }
 
 vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
-  resolveApprovalOverGateway: resolverMocks.resolveIMessageApproval,
+  resolveApprovalOverGateway: resolverMocks.resolveApprovalOverGateway,
 }));
 vi.mock("openclaw/plugin-sdk/error-runtime", () => ({
   isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
@@ -65,8 +65,8 @@ function buildTapbackReactionPayload(overrides: Partial<IMessagePayload>): IMess
 describe("iMessage approval reactions", () => {
   beforeEach(() => {
     clearIMessageApprovalReactionTargetsForTest();
-    resolverMocks.resolveIMessageApproval.mockReset();
-    resolverMocks.resolveIMessageApproval.mockImplementation(
+    resolverMocks.resolveApprovalOverGateway.mockReset();
+    resolverMocks.resolveApprovalOverGateway.mockImplementation(
       async ({ decision }: { decision: "allow-once" | "allow-always" | "deny" }) => ({
         applied: true,
         approval:
@@ -769,7 +769,7 @@ describe("iMessage approval reactions", () => {
     });
 
     expect(handled).toBe(true);
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith(
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith(
       expect.objectContaining({
         approvalId: "exec-self",
         decision: "allow-once",
@@ -803,7 +803,7 @@ describe("iMessage approval reactions", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledTimes(1);
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
 
     // Second tapback (toggle to 👎) must not hit the resolver — the in-memory
     // binding was cleared on the first success.
@@ -819,7 +819,7 @@ describe("iMessage approval reactions", () => {
         bodyText: "",
       }),
     ).resolves.toBe(false);
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledTimes(1);
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
   });
 
   it("resolves a reaction when the approver was configured with a service-prefixed allowFrom entry", async () => {
@@ -851,7 +851,7 @@ describe("iMessage approval reactions", () => {
     });
 
     expect(handled).toBe(true);
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith({
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
       cfg,
       approvalId: "exec-service-prefix",
       approvalKind: "exec",
@@ -895,7 +895,7 @@ describe("iMessage approval reactions", () => {
     });
 
     expect(handled).toBe(true);
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith({
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
       cfg,
       approvalId: "exec-prefixed",
       approvalKind: "exec",
@@ -953,7 +953,7 @@ describe("iMessage approval reactions", () => {
     });
 
     expect(handled).toBe(true);
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith({
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
       cfg,
       approvalId: "exec-dm",
       approvalKind: "exec",
@@ -991,7 +991,7 @@ describe("iMessage approval reactions", () => {
     });
 
     expect(handled).toBe(false);
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("resolves a direct approval reaction from an authorized sender", async () => {
@@ -1021,7 +1021,7 @@ describe("iMessage approval reactions", () => {
     });
 
     expect(handled).toBe(true);
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith({
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
       cfg,
       approvalId: "plugin:abc",
       approvalKind: "plugin",
@@ -1061,7 +1061,7 @@ describe("iMessage approval reactions", () => {
     });
 
     expect(handled).toBe(true);
-    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledWith({
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
       cfg,
       approvalId: "exec-group",
       approvalKind: "exec",
@@ -1097,7 +1097,7 @@ describe("iMessage approval reactions", () => {
     });
 
     expect(handled).toBe(true);
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("requires explicit approvers for direct approval reactions", async () => {
@@ -1121,7 +1121,7 @@ describe("iMessage approval reactions", () => {
     });
 
     expect(handled).toBe(true);
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 
   it("forgets stale bindings when the gateway reports an unknown approval", async () => {
@@ -1132,7 +1132,7 @@ describe("iMessage approval reactions", () => {
       approvalId: "exec-expired",
       allowedDecisions: ["allow-once"],
     });
-    resolverMocks.resolveIMessageApproval.mockRejectedValueOnce(new Error("approval not found"));
+    resolverMocks.resolveApprovalOverGateway.mockRejectedValueOnce(new Error("approval not found"));
     resolverMocks.isApprovalNotFoundError.mockReturnValue(true);
 
     const handled = await maybeResolveIMessageApprovalReaction({
@@ -1168,7 +1168,7 @@ describe("iMessage approval reactions", () => {
       approvalId: "exec-already-resolved",
       allowedDecisions: ["allow-once", "deny"],
     });
-    resolverMocks.resolveIMessageApproval.mockResolvedValueOnce({
+    resolverMocks.resolveApprovalOverGateway.mockResolvedValueOnce({
       applied: false,
       approval: { status: "denied", decision: "deny", reason: "user" },
     });
@@ -1227,7 +1227,7 @@ describe("iMessage approval reactions", () => {
     // should fall through to the dispatch pipeline rather than resolving an
     // approval here.
     expect(handled).toBe(false);
-    expect(resolverMocks.resolveIMessageApproval).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -20,7 +20,7 @@ import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-rep
 import type { OutboundDeliveryResult } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
-import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { createLazyRuntimeSurface } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   asDateTimestampMs,
   isFutureDateTimestampMs,
@@ -79,12 +79,11 @@ export type PendingIMessageApprovalReactionPollTarget = {
   expiresAtMs: number;
 };
 
-const resolverRuntimeLoader = createLazyRuntimeModule(
+const loadResolveApprovalOverGateway = createLazyRuntimeSurface(
   () => import("openclaw/plugin-sdk/approval-gateway-runtime"),
+  (runtime) => runtime.resolveApprovalOverGateway,
 );
 const pendingReactionPollTargets = new Map<string, PendingIMessageApprovalReactionPollTarget>();
-
-const loadApprovalResolver = resolverRuntimeLoader;
 
 function prunePendingReactionPollTargets(nowMs = Date.now()): void {
   for (const [key, target] of pendingReactionPollTargets.entries()) {
@@ -687,7 +686,7 @@ export async function handleIMessageApprovalReaction(params: {
     return { handled: true, stopPolling: false };
   }
 
-  const { resolveApprovalOverGateway } = await loadApprovalResolver();
+  const resolveApprovalOverGateway = await loadResolveApprovalOverGateway();
   try {
     const result = await resolveApprovalOverGateway({
       cfg: params.cfg,
@@ -763,5 +762,5 @@ export async function maybeResolveIMessageApprovalReaction(params: {
 export function clearIMessageApprovalReactionTargetsForTest(): void {
   imessageApprovalReactionTargets.clearForTest();
   pendingReactionPollTargets.clear();
-  resolverRuntimeLoader.clear();
+  loadResolveApprovalOverGateway.clear();
 }

--- a/extensions/signal/src/approval-reactions.ts
+++ b/extensions/signal/src/approval-reactions.ts
@@ -18,7 +18,7 @@ import {
 } from "openclaw/plugin-sdk/approval-reply-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
-import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { createLazyRuntimeSurface } from "openclaw/plugin-sdk/lazy-runtime";
 import { createPluginStateErrorReporter } from "openclaw/plugin-sdk/plugin-state-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
@@ -83,8 +83,9 @@ type SignalApprovalDeliveryResult = {
   meta?: Record<string, unknown>;
 };
 
-const resolverRuntimeLoader = createLazyRuntimeModule(
+const loadResolveApprovalOverGateway = createLazyRuntimeSurface(
   () => import("openclaw/plugin-sdk/approval-gateway-runtime"),
+  (runtime) => runtime.resolveApprovalOverGateway,
 );
 
 const reportPersistentApprovalReactionError = createPluginStateErrorReporter(
@@ -103,8 +104,6 @@ const signalApprovalReactionTargets =
     logPersistentError: reportPersistentApprovalReactionError,
     readPersistedTarget,
   });
-
-const loadApprovalResolver = resolverRuntimeLoader;
 
 function resolveApprovalForwardingConfig(params: {
   cfg: OpenClawConfig;
@@ -910,7 +909,7 @@ export async function maybeResolveSignalApprovalReaction(params: {
     return true;
   }
 
-  const { resolveApprovalOverGateway } = await loadApprovalResolver();
+  const resolveApprovalOverGateway = await loadResolveApprovalOverGateway();
   try {
     const result = await resolveApprovalOverGateway({
       cfg: params.cfg,
@@ -958,6 +957,6 @@ export async function maybeResolveSignalApprovalReaction(params: {
 
 export function clearSignalApprovalReactionTargetsForTest(): void {
   signalApprovalReactionTargets.clearForTest();
-  resolverRuntimeLoader.clear();
+  loadResolveApprovalOverGateway.clear();
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/telegram/src/bot-deps.ts
+++ b/extensions/telegram/src/bot-deps.ts
@@ -38,25 +38,21 @@ import { recordOutboundMessageForPromptContext } from "./outbound-message-contex
 import { editMessageTelegram } from "./send.js";
 import { wasSentByBot } from "./sent-message-cache.js";
 
-type ResolveTelegramApproval = (params: {
+type ResolveTelegramApprovalParams = {
   cfg: OpenClawConfig;
   approvalId: string;
-  approvalKind: "exec" | "plugin";
   decision: ExecApprovalReplyDecision;
   channel: "telegram";
   senderId?: string | null;
   gatewayUrl?: string;
-}) => Promise<ApprovalResolveResult>;
+} & (
+  | { approvalKind: "exec" | "plugin"; resolveMethod?: never }
+  | { approvalKind?: never; resolveMethod: "exec" | "plugin" }
+);
 
-type ResolveTelegramLegacyApproval = (params: {
-  cfg: OpenClawConfig;
-  approvalId: string;
-  decision: ExecApprovalReplyDecision;
-  channel: "telegram";
-  senderId?: string | null;
-  gatewayUrl?: string;
-  resolveMethod: "exec" | "plugin";
-}) => Promise<void>;
+type ResolveTelegramApproval = (
+  params: ResolveTelegramApprovalParams,
+) => Promise<ApprovalResolveResult | void>;
 
 export type TelegramBotDeps = {
   getRuntimeConfig: typeof getRuntimeConfig;
@@ -80,7 +76,6 @@ export type TelegramBotDeps = {
   syncTelegramMenuCommands?: typeof syncTelegramMenuCommands;
   wasSentByBot: typeof wasSentByBot;
   resolveApproval?: ResolveTelegramApproval;
-  resolveLegacyApproval?: ResolveTelegramLegacyApproval;
   createTelegramDraftStream?: typeof createTelegramDraftStream;
   deliverReplies?: typeof deliverReplies;
   deliverInboundReplyWithMessageSendContext?: typeof deliverInboundReplyWithMessageSendContext;
@@ -152,10 +147,7 @@ export const defaultTelegramBotDeps: TelegramBotDeps = {
     return wasSentByBot;
   },
   get resolveApproval() {
-    return resolveApprovalOverGateway;
-  },
-  get resolveLegacyApproval() {
-    return resolveApprovalOverGateway;
+    return resolveApprovalOverGateway as ResolveTelegramApproval;
   },
   get createTelegramDraftStream() {
     return createTelegramDraftStream;

--- a/extensions/telegram/src/bot-handlers.callback-approvals.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.callback-approvals.runtime.ts
@@ -1,4 +1,7 @@
-import { resolveApprovalOverGateway } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import {
+  resolveApprovalOverGateway,
+  type ApprovalResolveResult,
+} from "openclaw/plugin-sdk/approval-gateway-runtime";
 import type { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
@@ -86,15 +89,19 @@ export function createTelegramCallbackApprovalRuntime(params: {
     }
   };
 
-  const resolveCanonicalApproval = async (approvalCallback: TelegramApprovalCallback) =>
-    await (telegramDeps.resolveApproval ?? resolveApprovalOverGateway)({
+  const resolveApproval = telegramDeps.resolveApproval ?? resolveApprovalOverGateway;
+
+  const resolveCanonicalApproval = async (
+    approvalCallback: TelegramApprovalCallback,
+  ): Promise<ApprovalResolveResult> =>
+    (await resolveApproval({
       cfg: runtimeCfg,
       approvalId: approvalCallback.approvalId,
       approvalKind: approvalCallback.approvalKind,
       decision: approvalCallback.decision,
       channel: "telegram",
       senderId,
-    });
+    })) as ApprovalResolveResult;
 
   const terminalizeCanonicalApproval = async (
     approvalCallback: TelegramApprovalCallback,
@@ -176,7 +183,6 @@ export function createTelegramCallbackApprovalRuntime(params: {
       return;
     }
 
-    const resolveLegacy = telegramDeps.resolveLegacyApproval ?? resolveApprovalOverGateway;
     for (const approvalKind of approvalKinds) {
       const canonicalCallback: TelegramApprovalCallback = {
         type: "approval",
@@ -186,7 +192,7 @@ export function createTelegramCallbackApprovalRuntime(params: {
       };
       try {
         // Legacy callbacks lack an owner. Probe only adapters this sender may use.
-        await resolveLegacy({
+        await resolveApproval({
           cfg: runtimeCfg,
           approvalId: approvalCallback.approvalId,
           decision: approvalCallback.decision,

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -22,11 +22,7 @@ type ReadSessionUpdatedAtFn =
 type SessionEntry = import("openclaw/plugin-sdk/session-store-runtime").SessionEntry;
 type SessionStore = Record<string, SessionEntry>;
 type LoadSessionStoreFn = (storePath?: string, opts?: unknown) => SessionStore;
-type ResolveTelegramApprovalForTest = (
-  params:
-    | Parameters<NonNullable<TelegramBotDeps["resolveApproval"]>>[0]
-    | Parameters<NonNullable<TelegramBotDeps["resolveLegacyApproval"]>>[0],
-) => ReturnType<NonNullable<TelegramBotDeps["resolveApproval"]>>;
+type ResolveTelegramApprovalForTest = NonNullable<TelegramBotDeps["resolveApproval"]>;
 type DispatchReplyWithBufferedBlockDispatcherFn =
   typeof import("openclaw/plugin-sdk/reply-dispatch-runtime").dispatchReplyWithBufferedBlockDispatcher;
 type DispatchReplyWithBufferedBlockDispatcherResult = Awaited<
@@ -523,9 +519,6 @@ export const telegramBotDepsForTest: TelegramBotDeps = {
   syncTelegramMenuCommands: syncTelegramMenuCommands as TelegramBotDeps["syncTelegramMenuCommands"],
   wasSentByBot: wasSentByBot as TelegramBotDeps["wasSentByBot"],
   resolveApproval: resolveExecApprovalSpy,
-  resolveLegacyApproval: async (params) => {
-    await resolveExecApprovalSpy(params);
-  },
 };
 
 vi.doMock("./bot.runtime.js", () => telegramBotRuntimeForTest);

--- a/extensions/whatsapp/src/approval-reactions.ts
+++ b/extensions/whatsapp/src/approval-reactions.ts
@@ -17,7 +17,7 @@ import type { OutboundDeliveryResult } from "openclaw/plugin-sdk/channel-send-re
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
 import type { MessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
-import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { createLazyRuntimeSurface } from "openclaw/plugin-sdk/lazy-runtime";
 import { createPluginStateErrorReporter } from "openclaw/plugin-sdk/plugin-state-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveWhatsAppAccount } from "./accounts.js";
@@ -56,8 +56,9 @@ type ResolvedWhatsAppApprovalReactionTarget = WhatsAppApprovalReactionResolution
   remoteJid: string;
 };
 
-const resolverRuntimeLoader = createLazyRuntimeModule(
+const loadResolveApprovalOverGateway = createLazyRuntimeSurface(
   () => import("openclaw/plugin-sdk/approval-gateway-runtime"),
+  (runtime) => runtime.resolveApprovalOverGateway,
 );
 
 const reportPersistentApprovalReactionError = createPluginStateErrorReporter(
@@ -76,8 +77,6 @@ const whatsappApprovalReactionTargets =
     logPersistentError: reportPersistentApprovalReactionError,
     readPersistedTarget,
   });
-
-const loadApprovalResolver = resolverRuntimeLoader;
 
 function buildReactionTargetKey(params: {
   accountId: string;
@@ -511,7 +510,7 @@ export async function maybeResolveWhatsAppApprovalReaction(params: {
     return true;
   }
 
-  const { resolveApprovalOverGateway } = await loadApprovalResolver();
+  const resolveApprovalOverGateway = await loadResolveApprovalOverGateway();
   try {
     const result = await resolveApprovalOverGateway({
       cfg: params.cfg,
@@ -556,5 +555,5 @@ export async function maybeResolveWhatsAppApprovalReaction(params: {
 
 export function clearWhatsAppApprovalReactionTargetsForTest(): void {
   whatsappApprovalReactionTargets.clearForTest();
-  resolverRuntimeLoader.clear();
+  loadResolveApprovalOverGateway.clear();
 }

--- a/src/channels/ids.test.ts
+++ b/src/channels/ids.test.ts
@@ -1,6 +1,6 @@
 // Channel id tests cover identifier normalization and validation helpers.
 import { describe, expect, it } from "vitest";
-import { normalizeChatChannelId } from "./ids.js";
+import { findChatChannelLabel, normalizeChatChannelId } from "./ids.js";
 
 describe("channel ids", () => {
   it("normalizes built-in aliases + trims whitespace", () => {
@@ -11,5 +11,20 @@ describe("channel ids", () => {
     expect(normalizeChatChannelId("telegram")).toBe("telegram");
     expect(normalizeChatChannelId("web")).toBeNull();
     expect(normalizeChatChannelId("nope")).toBeNull();
+  });
+
+  it.each([
+    ["whatsapp", "WhatsApp"],
+    ["imessage", "iMessage"],
+    ["googlechat", "Google Chat"],
+    [" imsg ", "iMessage"],
+    ["GOOGLE-CHAT", "Google Chat"],
+  ])("finds the exact generated label for %s", (channel, label) => {
+    expect(findChatChannelLabel(channel)).toBe(label);
+  });
+
+  it("does not fall back to runtime metadata for unknown channels", () => {
+    expect(findChatChannelLabel("external-chat")).toBeUndefined();
+    expect(findChatChannelLabel(" ")).toBeUndefined();
   });
 });

--- a/src/channels/ids.ts
+++ b/src/channels/ids.ts
@@ -15,6 +15,7 @@ export type ChatChannelId = string;
 type BundledChatChannelEntry = {
   id: ChatChannelId;
   aliases: readonly string[];
+  label?: string;
   order: number;
 };
 
@@ -23,6 +24,7 @@ function listBundledChatChannelEntries(): BundledChatChannelEntry[] {
     .map((entry) => ({
       id: normalizeOptionalLowercaseString(entry.channelId) ?? entry.channelId,
       aliases: entry.aliases ?? [],
+      label: entry.label?.trim() || undefined,
       order: entry.order ?? Number.MAX_SAFE_INTEGER,
     }))
     .toSorted(
@@ -57,6 +59,16 @@ const CHAT_CHANNEL_ALIASES: Record<string, ChatChannelId> = Object.freeze(
     ),
   ),
 ) as Record<string, ChatChannelId>;
+
+/** Finds the generated operator-facing label for a built-in channel id or alias. */
+export function findChatChannelLabel(raw?: string | null): string | undefined {
+  const normalized = normalizeOptionalLowercaseString(raw);
+  if (!normalized) {
+    return undefined;
+  }
+  const resolved = CHAT_CHANNEL_ALIASES[normalized] ?? normalized;
+  return BUNDLED_CHAT_CHANNEL_ENTRIES.find((entry) => entry.id === resolved)?.label;
+}
 
 function listRuntimeBundledChatChannelEntries(): BundledChatChannelEntry[] {
   // Generated metadata is the hot-path source. The runtime catalog fallback covers

--- a/src/infra/approval-gateway-resolver.test.ts
+++ b/src/infra/approval-gateway-resolver.test.ts
@@ -30,10 +30,10 @@ vi.mock("../gateway/operator-approvals-client.js", () => ({
   withOperatorApprovalsGatewayClient: hoisted.withOperatorApprovalsGatewayClient,
 }));
 
-function requireFirstMockCall<T>(mock: { mock: { calls: T[][] } }, label: string): T[] {
+function requireFirstMockCall<T>(mock: { mock: { calls: T[][] } }): T[] {
   const call = mock.mock.calls[0];
   if (!call) {
-    throw new Error(`expected ${label} call`);
+    throw new Error("expected gateway client call");
   }
   return call;
 }
@@ -62,7 +62,6 @@ describe("resolveApprovalOverGateway", () => {
     expect(hoisted.withOperatorApprovalsGatewayClient).toHaveBeenCalledTimes(1);
     const [gatewayClientOptions, gatewayClientRunner] = requireFirstMockCall(
       hoisted.withOperatorApprovalsGatewayClient,
-      "gateway client",
     );
     expect(gatewayClientOptions).toEqual({
       config: { gateway: { auth: { token: "cfg-token" } } },
@@ -101,13 +100,28 @@ describe("resolveApprovalOverGateway", () => {
 
       const [gatewayClientOptions] = requireFirstMockCall(
         hoisted.withOperatorApprovalsGatewayClient,
-        "gateway client",
       );
       expect(gatewayClientOptions).toMatchObject({
         clientDisplayName: `${label} approval (owner)`,
       });
     },
   );
+
+  it("preserves the raw id in the approval label for unknown channels", async () => {
+    await resolveApprovalOverGateway({
+      cfg: {} as never,
+      approvalId: "approval-1",
+      approvalKind: "exec",
+      decision: "deny",
+      channel: "external-chat",
+      senderId: "owner",
+    });
+
+    const [gatewayClientOptions] = requireFirstMockCall(hoisted.withOperatorApprovalsGatewayClient);
+    expect(gatewayClientOptions).toMatchObject({
+      clientDisplayName: "external-chat approval (owner)",
+    });
+  });
 
   it("uses explicit plugin kind without inspecting the approval id", async () => {
     await resolveApprovalOverGateway({

--- a/src/infra/approval-gateway-resolver.ts
+++ b/src/infra/approval-gateway-resolver.ts
@@ -6,7 +6,7 @@ import type {
   ApprovalResolveResult,
 } from "../../packages/gateway-protocol/src/index.js";
 import { isWellFormedApprovalId } from "../../packages/gateway-protocol/src/schema/approvals.js";
-import { findChatChannelMeta } from "../channels/chat-meta.js";
+import { findChatChannelLabel } from "../channels/ids.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withOperatorApprovalsGatewayClient } from "../gateway/operator-approvals-client.js";
 import { isApprovalNotFoundError } from "./approval-errors.js";
@@ -110,7 +110,7 @@ export async function resolveApprovalOverGateway(
   const channel = params.channel?.trim();
   // Channel manifests own operator-facing labels; using their generated metadata
   // keeps approval clients aligned without importing plugin runtime or hardcoding ids.
-  const channelLabel = channel ? (findChatChannelMeta(channel)?.label ?? channel) : undefined;
+  const channelLabel = channel ? (findChatChannelLabel(channel) ?? channel) : undefined;
   const clientDisplayName =
     params.clientDisplayName ??
     (channelLabel ? `${channelLabel} approval (${senderId})` : `Approval (${senderId})`);


### PR DESCRIPTION
## What Problem This Solves

Approval resolution still performed avoidable runtime plumbing: the approval client could trigger cold synchronous package/catalog filesystem discovery just to recover built-in channel labels, Telegram carried separate canonical and legacy dependency slots for the same approval resolver, and several channel lazy loaders imported broader resolver modules than they consumed. iMessage tests also retained mocks for a resolver module that the cleanup removes.

## Why This Change Was Made

This follow-up uses generated channel metadata for approval labels, preserving every built-in label and the raw unknown-channel fallback without cold-path filesystem discovery. Telegram now has one local typed approval dependency resolver. The iMessage, Signal, and WhatsApp lazy loaders select only `resolveApprovalOverGateway` while preserving their existing clear/reset lifecycle, and the stale iMessage mocks are removed or redirected to the current seam.

The production delta is +55/-47 (net +8). That small increase establishes the generated-label ownership boundary and removes synchronous runtime discovery; tests and harnesses are +128/-94 (net +34).

## User Impact

There is no user-visible behavior change. Built-in and unknown channel labels remain identical. This does not change configuration, the public Plugin SDK, protocol surfaces, docs, or approval semantics.

## Evidence

- Focused Vitest: 475 tests passed across channel IDs, the Gateway approval resolver, iMessage, Signal, WhatsApp, and Telegram.
- Full changed checks and full build passed together on Blacksmith Testbox `tbx_01kzjdw8n0e8xdnghrge0d4mnm`: https://github.com/openclaw/openclaw/actions/runs/31295508549
- Fresh uncommitted autoreview reported no accepted/actionable findings.
- `git diff --check` passed.
