### PR TITLE
refactor(acpx): reuse operation session snapshot

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -2034,35 +2034,77 @@ describe("AcpxRuntime fresh reset wrapper", () => {
 
   it("rejects reconnect operations for commands leased by another gateway", async () => {
     const foreignCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-foreign-operation ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-foreign`;
-    const baseStore: TestSessionStore = {
-      load: vi.fn(async () => ({
-        name: "agent:codex:acp:binding:test",
-        agentCommand: foreignCommand,
-      })),
-      save: vi.fn(async () => {}),
+    const handle = {
+      sessionKey: "agent:codex:acp:binding:test",
+      backend: "acpx" as const,
+      runtimeSessionName: "agent:codex:acp:binding:test",
     };
-    const leaseStore = makeLeaseStore();
-    const { runtime, delegate } = makeRuntime(baseStore, {
-      openclawGatewayInstanceId: "gateway-test",
-      openclawProcessLeaseStore: leaseStore.store,
-      openclawWrapperRoot: "/tmp/openclaw/acpx",
-    });
-    const setMode = vi.spyOn(delegate, "setMode").mockResolvedValue(undefined);
-
-    await expect(
-      runtime.setMode({
-        handle: {
-          sessionKey: "agent:codex:acp:binding:test",
-          backend: "acpx",
-          runtimeSessionName: "agent:codex:acp:binding:test",
-        },
-        mode: "plan",
-      }),
-    ).rejects.toMatchObject({
+    const expectedError = {
       code: "ACP_TURN_FAILED",
       message: "ACPX process lease lease-foreign-operation belongs to another gateway",
+    };
+    const createRuntime = () => {
+      const baseStore: TestSessionStore = {
+        load: vi.fn(async () => ({
+          name: handle.sessionKey,
+          agentCommand: foreignCommand,
+        })),
+        save: vi.fn(async () => {}),
+      };
+      const leaseStore = makeLeaseStore();
+      const { runtime } = makeRuntime(baseStore, {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawToolsMcpBridgeEnabled: true,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+        mcpServers: [
+          {
+            name: "openclaw-tools",
+            command: "node",
+            args: ["dist/mcp/openclaw-tools-serve.js"],
+            env: [],
+          },
+        ],
+      });
+      const managedToolsSessionDelegates = (
+        runtime as unknown as {
+          managedToolsSessionDelegates: Map<string, unknown>;
+        }
+      ).managedToolsSessionDelegates;
+      return { runtime, leaseStore, managedToolsSessionDelegates };
+    };
+    const expectRejectedWithoutDelegate = async (
+      operation: (runtime: AcpxRuntime) => Promise<unknown>,
+    ) => {
+      const { runtime, leaseStore, managedToolsSessionDelegates } = createRuntime();
+      await expect(operation(runtime)).rejects.toMatchObject(expectedError);
+      expect(managedToolsSessionDelegates.has(handle.sessionKey)).toBe(false);
+      expect(managedToolsSessionDelegates.size).toBe(0);
+      expect(leaseStore.leases.size).toBe(0);
+    };
+
+    await expectRejectedWithoutDelegate((runtime) =>
+      runtime.setConfigOption({ handle, key: "thinking", value: "minimal" }),
+    );
+    await expectRejectedWithoutDelegate((runtime) => runtime.setMode({ handle, mode: "plan" }));
+    await expectRejectedWithoutDelegate((runtime) => runtime.close({ handle, reason: "done" }));
+
+    const { runtime, leaseStore, managedToolsSessionDelegates } = createRuntime();
+    const turn = runtime.startTurn({
+      handle,
+      text: "Reply exactly OK",
+      mode: "prompt",
+      requestId: "foreign-gateway",
     });
-    expect(setMode).not.toHaveBeenCalled();
+    const outcomes = await Promise.allSettled([turn.result, turn.cancel(), turn.closeStream()]);
+    for (const outcome of outcomes) {
+      expect(outcome.status).toBe("rejected");
+      if (outcome.status === "rejected") {
+        expect(outcome.reason).toMatchObject(expectedError);
+      }
+    }
+    expect(managedToolsSessionDelegates.has(handle.sessionKey)).toBe(false);
+    expect(managedToolsSessionDelegates.size).toBe(0);
     expect(leaseStore.leases.size).toBe(0);
   });
 
@@ -2444,7 +2486,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(leaseStore.leases.size).toBe(0);
   });
 
-  it("tracks control-operation reconnects without leaving pending leases", async () => {
+  it("loads one wrapper snapshot per handle operation before mutation", async () => {
     const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-control-reconnect ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({
@@ -2459,23 +2501,52 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       openclawProcessLeaseStore: leaseStore.store,
       openclawWrapperRoot: "/tmp/openclaw/acpx",
     });
-    vi.spyOn(delegate, "setMode").mockImplementation(async () => {
+    const expectPendingLease = () => {
       expect(leaseStore.leases.get("lease-control-reconnect")).toMatchObject({
         rootPid: 0,
         sessionKey: "agent:codex:acp:binding:test",
       });
+    };
+    vi.spyOn(delegate, "startTurn").mockImplementation((input) => {
+      expectPendingLease();
+      return {
+        requestId: input.requestId,
+        events: (async function* () {})(),
+        result: Promise.resolve({ status: "completed" }),
+        cancel: vi.fn(async () => {}),
+        closeStream: vi.fn(async () => {}),
+      };
     });
+    vi.spyOn(delegate, "setMode").mockImplementation(async () => expectPendingLease());
+    const setConfigOption = vi
+      .spyOn(delegate, "setConfigOption")
+      .mockImplementation(async () => expectPendingLease());
+    vi.spyOn(delegate, "close").mockImplementation(async () => expectPendingLease());
+    const handle = {
+      sessionKey: "agent:codex:acp:binding:test",
+      backend: "acpx" as const,
+      runtimeSessionName: "agent:codex:acp:binding:test",
+    };
+    const operations = [
+      async () =>
+        await runtime.startTurn({ handle, text: "OK", mode: "prompt", requestId: "1" }).result,
+      async () => await runtime.setConfigOption({ handle, key: "thinking", value: "minimal" }),
+      async () => await runtime.setMode({ handle, mode: "plan" }),
+      async () => await runtime.close({ handle, reason: "done" }),
+    ];
 
-    await runtime.setMode({
-      handle: {
-        sessionKey: "agent:codex:acp:binding:test",
-        backend: "acpx",
-        runtimeSessionName: "agent:codex:acp:binding:test",
-      },
-      mode: "plan",
+    for (const operation of operations) {
+      vi.mocked(baseStore["load"]).mockClear();
+      await operation();
+      expect(baseStore["load"]).toHaveBeenCalledOnce();
+      expect(leaseStore.leases.size).toBe(0);
+    }
+
+    expect(setConfigOption).toHaveBeenCalledWith({
+      handle,
+      key: "reasoning_effort",
+      value: "low",
     });
-
-    expect(leaseStore.leases.size).toBe(0);
   });
 
   it("preserves a promoted PID when the session record save fails", async () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -109,6 +109,11 @@ type AcpxLaunchLeaseContext = {
   leasedCommand: string;
 };
 
+type AcpxHandleOperationSnapshot = Readonly<{
+  record: AcpLoadedSessionRecord;
+  command: string | undefined;
+}>;
+
 const CODEX_WRAPPER_STDERR_LOG_PREFIX = "codex-acp-wrapper.stderr";
 const CODEX_WRAPPER_ERROR_TAIL_MAX_CHARS = 6_000;
 
@@ -912,39 +917,31 @@ export class AcpxRuntime implements AcpRuntime {
     this.managedToolsSessionDelegates.delete(normalizedSessionKey);
   }
 
-  private async resolveDelegateForHandle(handle: AcpRuntimeHandle): Promise<BaseAcpxRuntime> {
-    const record = await this.sessionStore.load(handle.acpxRecordId ?? handle.sessionKey);
-    return this.resolveDelegateForLoadedRecord(handle, record);
-  }
-
-  private resolveDelegateForLoadedRecord(
+  private async loadOperationSnapshotForHandle(
     handle: AcpRuntimeHandle,
-    record: AcpLoadedSessionRecord,
-  ): BaseAcpxRuntime {
-    const recordCommand = readAgentCommandFromRecord(record);
-    if (recordCommand) {
-      return this.resolveDelegateForSession({
-        command: recordCommand,
-        sessionKey: handle.sessionKey,
+  ): Promise<AcpxHandleOperationSnapshot> {
+    const record = await this.sessionStore.load(handle.acpxRecordId ?? handle.sessionKey);
+    const command =
+      readAgentCommandFromRecord(record) ??
+      resolveAgentCommand({
+        agentName: readAgentFromHandle(handle),
+        agentRegistry: this.agentRegistry,
       });
-    }
-    const agentName = readAgentFromHandle(handle);
-    const command = resolveAgentCommand({
-      agentName,
-      agentRegistry: this.agentRegistry,
-    });
-    return this.resolveDelegateForSession({ command, sessionKey: handle.sessionKey });
+    return {
+      record,
+      command,
+    };
   }
 
-  private async resolveCommandForHandle(handle: AcpRuntimeHandle): Promise<string | undefined> {
-    const record = await this.sessionStore.load(handle.acpxRecordId ?? handle.sessionKey);
-    const recordCommand = readAgentCommandFromRecord(record);
-    if (recordCommand) {
-      return recordCommand;
-    }
-    return resolveAgentCommand({
-      agentName: readAgentFromHandle(handle),
-      agentRegistry: this.agentRegistry,
+  private resolveDelegateForOperationSnapshot(
+    handle: AcpRuntimeHandle,
+    snapshot: AcpxHandleOperationSnapshot,
+  ): BaseAcpxRuntime {
+    // Lease-owning callers project only after validation so a rejected record
+    // cannot populate the managed-tools delegate cache.
+    return this.resolveDelegateForSession({
+      command: snapshot.command,
+      sessionKey: handle.sessionKey,
     });
   }
 
@@ -1093,13 +1090,13 @@ export class AcpxRuntime implements AcpRuntime {
 
   private async prepareProcessLeaseForOperation(
     handle: AcpRuntimeHandle,
+    record: AcpLoadedSessionRecord,
   ): Promise<AcpxProcessLeaseIdentity | undefined> {
     if (!this.processLeaseStore || !this.gatewayInstanceId || !this.wrapperRoot) {
       return undefined;
     }
     const processLeaseStore = this.processLeaseStore;
     const wrapperRoot = this.wrapperRoot;
-    const record = await this.sessionStore.load(handle.acpxRecordId ?? handle.sessionKey);
     const recordPid = readRecordAgentPid(record);
     const command = readAgentCommandFromRecord(record);
     const identity = readAcpxProcessLeaseIdentity(command);
@@ -1268,9 +1265,10 @@ export class AcpxRuntime implements AcpRuntime {
 
   private async runWithProcessLeaseForHandle<T>(
     handle: AcpRuntimeHandle,
+    record: AcpLoadedSessionRecord,
     run: () => Promise<T>,
   ): Promise<T> {
-    const identity = await this.prepareProcessLeaseForOperation(handle);
+    const identity = await this.prepareProcessLeaseForOperation(handle, record);
     try {
       return await run();
     } finally {
@@ -1514,11 +1512,19 @@ export class AcpxRuntime implements AcpRuntime {
   }
 
   async *runTurn(input: Parameters<AcpRuntime["runTurn"]>[0]): AsyncIterable<AcpRuntimeEvent> {
-    const turnLease = await this.prepareProcessLeaseForOperation(input.handle);
+    const record = await this.sessionStore.load(
+      input.handle.acpxRecordId ?? input.handle.sessionKey,
+    );
+    const turnLease = await this.prepareProcessLeaseForOperation(input.handle, record);
     let command: string | undefined;
     try {
-      command = await this.resolveCommandForHandle(input.handle);
-      const delegate = await this.resolveDelegateForHandle(input.handle);
+      // Legacy runTurn keeps separate command/delegate loads; startTurn owns the
+      // one-snapshot contract until task #15 removes this compatibility path.
+      command = (await this.loadOperationSnapshotForHandle(input.handle)).command;
+      const delegate = this.resolveDelegateForOperationSnapshot(
+        input.handle,
+        await this.loadOperationSnapshotForHandle(input.handle),
+      );
       for await (const event of delegate.runTurn(withOpenClawManagedTurnTimeout(input))) {
         if (
           event.type !== "error" ||
@@ -1560,30 +1566,33 @@ export class AcpxRuntime implements AcpRuntime {
       this.readCodexTurnFailureStderr({
         handle: input.handle,
       });
-    const turnLeasePromise = this.prepareProcessLeaseForOperation(input.handle);
-    const turnPromise = Promise.all([
-      turnLeasePromise,
-      this.resolveCommandForHandle(input.handle),
-      this.resolveDelegateForHandle(input.handle),
-    ]).then(async ([, command, delegate]) => {
-      try {
-        return {
-          command,
-          turn: delegate.startTurn(withOpenClawManagedTurnTimeout(input)),
-        };
-      } catch (error) {
-        if (!isCodexAcpCommand(command) || !isGenericInternalAcpError(error)) {
-          throw error;
+    const snapshotPromise = this.loadOperationSnapshotForHandle(input.handle);
+    const turnLeasePromise = snapshotPromise.then(({ record }) =>
+      this.prepareProcessLeaseForOperation(input.handle, record),
+    );
+    const turnPromise = Promise.all([snapshotPromise, turnLeasePromise]).then(
+      async ([snapshot]) => {
+        const { command } = snapshot;
+        const delegate = this.resolveDelegateForOperationSnapshot(input.handle, snapshot);
+        try {
+          return {
+            command,
+            turn: delegate.startTurn(withOpenClawManagedTurnTimeout(input)),
+          };
+        } catch (error) {
+          if (!isCodexAcpCommand(command) || !isGenericInternalAcpError(error)) {
+            throw error;
+          }
+          const stderrTail = await readCodexTurnFailureStderr();
+          if (!stderrTail) {
+            throw error;
+          }
+          throw new AcpRuntimeError("ACP_TURN_FAILED", `Internal error: ${stderrTail}`, {
+            cause: error,
+          });
         }
-        const stderrTail = await readCodexTurnFailureStderr();
-        if (!stderrTail) {
-          throw error;
-        }
-        throw new AcpRuntimeError("ACP_TURN_FAILED", `Internal error: ${stderrTail}`, {
-          cause: error,
-        });
-      }
-    });
+      },
+    );
 
     return {
       requestId: input.requestId,
@@ -1682,28 +1691,32 @@ export class AcpxRuntime implements AcpRuntime {
   async getStatus(
     input: Parameters<NonNullable<AcpRuntime["getStatus"]>>[0],
   ): Promise<AcpRuntimeStatus> {
-    const delegate = await this.resolveDelegateForHandle(input.handle);
-    return delegate.getStatus(input);
+    const snapshot = await this.loadOperationSnapshotForHandle(input.handle);
+    return this.resolveDelegateForOperationSnapshot(input.handle, snapshot).getStatus(input);
   }
 
   async setMode(input: Parameters<NonNullable<AcpRuntime["setMode"]>>[0]): Promise<void> {
-    const delegate = await this.resolveDelegateForHandle(input.handle);
-    await this.runWithProcessLeaseForHandle(input.handle, () => delegate.setMode(input));
+    const snapshot = await this.loadOperationSnapshotForHandle(input.handle);
+    await this.runWithProcessLeaseForHandle(input.handle, snapshot.record, () =>
+      this.resolveDelegateForOperationSnapshot(input.handle, snapshot).setMode(input),
+    );
   }
 
   async setConfigOption(
     input: Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0],
   ): Promise<void> {
-    await this.runWithProcessLeaseForHandle(input.handle, () =>
-      this.setConfigOptionUnlocked(input),
+    const snapshot = await this.loadOperationSnapshotForHandle(input.handle);
+    await this.runWithProcessLeaseForHandle(input.handle, snapshot.record, () =>
+      this.setConfigOptionUnlocked(input, snapshot),
     );
   }
 
   private async setConfigOptionUnlocked(
     input: Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0],
+    snapshot: AcpxHandleOperationSnapshot,
   ): Promise<void> {
-    const delegate = await this.resolveDelegateForHandle(input.handle);
-    const command = await this.resolveCommandForHandle(input.handle);
+    const { command } = snapshot;
+    const delegate = this.resolveDelegateForOperationSnapshot(input.handle, snapshot);
     const key = input.key.trim().toLowerCase();
     const isCodexAcp = isCodexAcpCommand(command);
     if (WIRE_TIMEOUT_CONFIG_KEYS.has(key) && (isCodexAcp || isClaudeAcpCommand(command))) {
@@ -1754,11 +1767,8 @@ export class AcpxRuntime implements AcpRuntime {
   }
 
   async cancel(input: Parameters<AcpRuntime["cancel"]>[0]): Promise<void> {
-    const record = await this.sessionStore.load(
-      input.handle.acpxRecordId ?? input.handle.sessionKey,
-    );
-    const delegate = this.resolveDelegateForLoadedRecord(input.handle, record);
-    await delegate.cancel(input);
+    const snapshot = await this.loadOperationSnapshotForHandle(input.handle);
+    await this.resolveDelegateForOperationSnapshot(input.handle, snapshot).cancel(input);
   }
 
   async prepareFreshSession(input: { sessionKey: string }): Promise<void> {
@@ -1769,14 +1779,12 @@ export class AcpxRuntime implements AcpRuntime {
   }
 
   async close(input: Parameters<AcpRuntime["close"]>[0]): Promise<void> {
-    const closeLease = await this.prepareProcessLeaseForOperation(input.handle);
+    const snapshot = await this.loadOperationSnapshotForHandle(input.handle);
+    const closeLease = await this.prepareProcessLeaseForOperation(input.handle, snapshot.record);
     let cleanupSucceeded = false;
     try {
-      const record = await this.sessionStore.load(
-        input.handle.acpxRecordId ?? input.handle.sessionKey,
-      );
+      const delegate = this.resolveDelegateForOperationSnapshot(input.handle, snapshot);
       let closeSucceeded;
-      const delegate = this.resolveDelegateForLoadedRecord(input.handle, record);
       try {
         await delegate.close({
           handle: input.handle,
@@ -1785,7 +1793,7 @@ export class AcpxRuntime implements AcpRuntime {
         });
         closeSucceeded = true;
       } finally {
-        await this.cleanupProcessTreeForRecord(input.handle, record);
+        await this.cleanupProcessTreeForRecord(input.handle, snapshot.record);
         cleanupSucceeded = true;
       }
       if (closeSucceeded) {


### PR DESCRIPTION
## What Problem This Solves

Modern ACPX handle operations could reload the wrapper session record while separately resolving the agent command and managed-tools delegate. That split ownership made one logical operation observe more than one record snapshot and allowed a foreign-gateway lease rejection to occur only after a per-session delegate had already been cached.

## Why This Change Was Made

The OpenClaw ACPX wrapper now loads one record-and-command snapshot per modern handle operation. Lease-owning `startTurn`, mode, config, and close operations validate and retain the process lease before resolving the managed-tools delegate; status and cancel keep their intentionally non-lease semantics. Upstream `acpx@0.13.0` remains the mutation owner and continues its mutation-time `requireRecord` reloads.

The production diff is +83/-75 (net +8). That small growth establishes the explicit operation-snapshot ownership boundary and removes the older repeated command/delegate resolution paths. The legacy `runTurn` compatibility adapter remains excluded from the one-snapshot contract pending its separate removal path.

## User Impact

Operators get consistent ACPX wrapper routing for each modern handle operation, and a record leased by another Gateway is rejected without leaking a managed-tools delegate into the session cache. There is no new configuration or user-facing command surface.

## Evidence

- Diff: 2 files; production +83/-75 (net +8), tests +107/-36 (net +71).
- Focused ACPX runtime proof: 103 tests passed with strict unhandled-rejection handling clean.
- Full ACPX proof: 244 tests passed with strict unhandled-rejection handling clean.
- Retained Testbox command proof: [run 31295179602](https://github.com/openclaw/openclaw/actions/runs/31295179602), lease `tbx_01kzjdax5jm34genfs3htvvx68`.
- ACPX-relevant type, lint, boundary, and import lanes passed.
- Formatting and diff checks passed.
- Final commit-mode structured review was clean, followed by an independent exact-head review with a READY verdict.
- An earlier aggregate check reported three doctor-closure violations in unrelated Discord/Telegram base files. Exact tested-base `192885c4e811` and head `a085994b70c27a6724892faa79eb6da74cea213b` comparison shows this PR changes only `extensions/acpx/src/runtime.ts` and `extensions/acpx/src/runtime.test.ts`; later path-scoped checks passed.
- Direct dependency inspection covered the published `acpx@0.13.0` runtime and type contract, including mutation-time record reloads.
- The separate upstream ACPX result-before-finalization lifecycle issue remains tracked outside this patch; this PR deliberately adds no OpenClaw compatibility shim for it.

### Direct dependency and sibling runtime inspection

The required source contracts were inspected directly rather than inferred from OpenClaw wrappers:

- `acpx@0.13.0` resolves the authoritative record again when a turn actually starts (`prepareRuntimeTurn`), and independently reloads for status, mode, config, and close mutation boundaries. Its cancel path intentionally targets only the active controller. See [`manager.ts:938-951`](https://github.com/openclaw/acpx/blob/aeb45a0ba1e91c2cfa2a317d026a7423e81a4d19/src/runtime/engine/manager.ts#L938-L951), [`manager.ts:1303-1345`](https://github.com/openclaw/acpx/blob/aeb45a0ba1e91c2cfa2a317d026a7423e81a4d19/src/runtime/engine/manager.ts#L1303-L1345), and [`manager.ts:1348-1402`](https://github.com/openclaw/acpx/blob/aeb45a0ba1e91c2cfa2a317d026a7423e81a4d19/src/runtime/engine/manager.ts#L1348-L1402). The wrapper snapshot therefore prepares routing and lease facts without replacing dependency-owned mutation validation.
- Current Codex app-server `turn/start` is keyed by `threadId` and loads that thread before submitting input; `turn/interrupt` validates the requested active `turnId` against per-thread state. See [`turn.rs:71-99`](https://github.com/openai/codex/blob/646f7c0a91b8e327d263335da68ae8ef212895ce/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L71-L99), [`turn_processor.rs:474-503`](https://github.com/openai/codex/blob/646f7c0a91b8e327d263335da68ae8ef212895ce/codex-rs/app-server/src/request_processors/turn_processor.rs#L474-L503), [`turn_processor.rs:1409-1450`](https://github.com/openai/codex/blob/646f7c0a91b8e327d263335da68ae8ef212895ce/codex-rs/app-server/src/request_processors/turn_processor.rs#L1409-L1450), and [`thread_state.rs:92-104`](https://github.com/openai/codex/blob/646f7c0a91b8e327d263335da68ae8ef212895ce/codex-rs/app-server/src/thread_state.rs#L92-L104). This patch does not alter Codex thread/turn identity or cancellation semantics; it only makes OpenClaw's wrapper-local delegate and lease selection consume one consistent snapshot.

