### PR TITLE
refactor: simplify message channel routing

### DIFF
--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -7,7 +7,7 @@ import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { EventSessionRoutingPolicy } from "../infra/event-session-routing.js";
 import type { TerminationReason } from "../process/supervisor/types.js";
-import type { DeliveryContext } from "../utils/delivery-context.shared.js";
+import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import { readEnvInt } from "./bash-tools.shared.js";
 import { createSessionSlug as createSessionSlugId } from "./session-slug.js";
 

--- a/src/agents/subagent-announce-descendant-wake.ts
+++ b/src/agents/subagent-announce-descendant-wake.ts
@@ -1,15 +1,9 @@
 // Descendant-settle wake replaces an ended nested orchestrator run while
 // preserving lifecycle ownership.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import {
-  getAgentEventLifecycleGeneration,
-  isAgentEventLifecycleGenerationCurrent,
-} from "../infra/agent-events.js";
+import { getAgentEventLifecycleGeneration } from "../infra/agent-events.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
-import {
-  buildAnnounceIdFromChildRun,
-  buildAnnounceIdempotencyKey,
-} from "./announce-idempotency.js";
+import { buildAnnounceIdempotencyKey } from "./announce-idempotency.js";
 import {
   loadSessionEntryByKey,
   runAnnounceDeliveryWithRetry,
@@ -22,13 +16,11 @@ import type {
 } from "./subagent-announce.runtime.js";
 import { terminateAcceptedCollectorRun } from "./subagent-spawn-cleanup.js";
 
-type SubagentRegistryRuntime = typeof import("./subagent-registry-runtime.js");
-
-export type DescendantWakeDeps = {
+type DescendantWakeDeps = {
   callGateway: typeof callGateway;
   dispatchGatewayMethodInProcess: typeof dispatchGatewayMethodInProcess;
   getRuntimeConfig: typeof getRuntimeConfig;
-  loadSubagentRegistryRuntime: () => Promise<SubagentRegistryRuntime>;
+  replaceSubagentRunAfterSteer: typeof import("./subagent-registry-runtime.js").replaceSubagentRunAfterSteer;
 };
 
 type UsableSessionEntryGuard = (entry: unknown) => entry is Record<string, unknown>;
@@ -64,25 +56,21 @@ function buildDescendantWakeMessage(params: { findings: string; taskLabel: strin
 }
 
 export async function runDescendantWake(params: {
-  enabled: boolean;
   runId: string;
   childSessionKey: string;
   taskLabel: string;
-  findings?: string;
+  findings: string;
+  announceId: string;
   isChildSessionEffectsAllowed: () => boolean;
   hasUsableSessionEntry: UsableSessionEntryGuard;
   deps: DescendantWakeDeps;
   signal?: AbortSignal;
 }): Promise<boolean> {
   if (
-    !params.enabled ||
+    params.signal?.aborted ||
     !params.isChildSessionEffectsAllowed() ||
-    !params.findings?.trim() ||
     isWakeContinuation(params.runId)
   ) {
-    return false;
-  }
-  if (params.signal?.aborted || !params.isChildSessionEffectsAllowed()) {
     return false;
   }
 
@@ -98,20 +86,14 @@ export async function runDescendantWake(params: {
     findings: params.findings,
     taskLabel: params.taskLabel,
   });
-  const announceId = buildAnnounceIdFromChildRun({
-    childSessionKey: params.childSessionKey,
-    childRunId: stripWakeRunSuffixes(params.runId),
-  });
 
   let wakeRunId;
   try {
     const wakeResponse = await runAnnounceDeliveryWithRetry<{ runId?: string }>({
       operation: "descendant wake agent call",
       signal: params.signal,
+      isAttemptAllowed: params.isChildSessionEffectsAllowed,
       run: async () => {
-        if (!params.isChildSessionEffectsAllowed()) {
-          return {};
-        }
         return await params.deps.dispatchGatewayMethodInProcess(
           "agent",
           {
@@ -124,7 +106,7 @@ export async function runDescendantWake(params: {
               sourceChannel: INTERNAL_MESSAGE_CHANNEL,
               sourceTool: "subagent_announce",
             },
-            idempotencyKey: buildAnnounceIdempotencyKey(`${announceId}:wake`),
+            idempotencyKey: buildAnnounceIdempotencyKey(`${params.announceId}:wake`),
           },
           {
             timeoutMs: announceTimeoutMs,
@@ -160,15 +142,11 @@ export async function runDescendantWake(params: {
     });
   };
 
-  const { replaceSubagentRunAfterSteer } = await params.deps.loadSubagentRegistryRuntime();
-  if (
-    !params.isChildSessionEffectsAllowed() ||
-    !isAgentEventLifecycleGenerationCurrent(wakeLifecycleGeneration)
-  ) {
+  if (!params.isChildSessionEffectsAllowed()) {
     await terminateUnownedWake();
     return false;
   }
-  const replaced = await replaceSubagentRunAfterSteer({
+  const replaced = await params.deps.replaceSubagentRunAfterSteer({
     previousRunId: params.runId,
     nextRunId: wakeRunId,
     lifecycleGeneration: wakeLifecycleGeneration,

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -32,7 +32,7 @@ import {
   loadRequesterSessionEntry,
   loadSessionEntryByKey,
 } from "./subagent-announce-delivery.js";
-import { type DescendantWakeDeps, runDescendantWake } from "./subagent-announce-descendant-wake.js";
+import { runDescendantWake } from "./subagent-announce-descendant-wake.js";
 import type { SubagentAnnounceDeliveryResult } from "./subagent-announce-dispatch.js";
 import {
   resolveAnnounceOrigin,
@@ -62,7 +62,12 @@ import { deleteSubagentSessionForCleanup } from "./subagent-session-cleanup.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
 import { isAnnounceSkip } from "./tools/sessions-send-tokens.js";
 
-type SubagentAnnounceDeps = DescendantWakeDeps;
+type SubagentAnnounceDeps = {
+  callGateway: typeof callGateway;
+  dispatchGatewayMethodInProcess: typeof dispatchGatewayMethodInProcess;
+  getRuntimeConfig: typeof getRuntimeConfig;
+  loadSubagentRegistryRuntime: typeof loadSubagentRegistryRuntime;
+};
 
 const defaultSubagentAnnounceDeps: SubagentAnnounceDeps = {
   callGateway,
@@ -294,20 +299,31 @@ export async function runSubagentAnnounceFlow(params: {
       childRunId: params.childRunId,
     });
 
-    const woke = await runDescendantWake({
-      enabled: params.wakeOnDescendantSettle === true,
-      runId: params.childRunId,
-      childSessionKey: params.childSessionKey,
-      taskLabel: params.label || params.task || "task",
-      findings: childCompletionFindings,
-      isChildSessionEffectsAllowed: childSessionEffectsAllowed,
-      hasUsableSessionEntry,
-      deps: subagentAnnounceDeps,
-      signal: params.signal,
-    });
-    if (woke) {
-      shouldDeleteChildSession = false;
-      return true;
+    if (
+      params.wakeOnDescendantSettle === true &&
+      childCompletionFindings?.trim() &&
+      subagentRegistryRuntime
+    ) {
+      const woke = await runDescendantWake({
+        runId: params.childRunId,
+        childSessionKey: params.childSessionKey,
+        taskLabel: params.label || params.task || "task",
+        findings: childCompletionFindings,
+        announceId,
+        isChildSessionEffectsAllowed: childSessionEffectsAllowed,
+        hasUsableSessionEntry,
+        deps: {
+          callGateway: subagentAnnounceDeps.callGateway,
+          dispatchGatewayMethodInProcess: subagentAnnounceDeps.dispatchGatewayMethodInProcess,
+          getRuntimeConfig: subagentAnnounceDeps.getRuntimeConfig,
+          replaceSubagentRunAfterSteer: subagentRegistryRuntime.replaceSubagentRunAfterSteer,
+        },
+        signal: params.signal,
+      });
+      if (woke) {
+        shouldDeleteChildSession = false;
+        return true;
+      }
     }
 
     const fallbackReply = failedTerminalOutcome

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -39,7 +39,7 @@ import { saveMediaBuffer } from "../../media/store.js";
 import { loadWebMedia } from "../../media/web-media.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
 import { resolveUserPath } from "../../utils.js";
-import type { DeliveryContext } from "../../utils/delivery-context.shared.js";
+import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import {
   formatGeneratedAttachmentLines,

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -27,7 +27,7 @@ import {
   resolveRequiredCompletionDeliveryFailureTerminalResult,
   type RequiredCompletionTerminalResult,
 } from "../../tasks/task-completion-contract.js";
-import type { DeliveryContext } from "../../utils/delivery-context.shared.js";
+import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import {
   mediaUrlsFromGeneratedAttachments,

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -26,7 +26,7 @@ import type {
 } from "../../music-generation/types.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
 import { resolveUserPath } from "../../utils.js";
-import type { DeliveryContext } from "../../utils/delivery-context.shared.js";
+import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { buildTimeoutAbortSignal } from "../../utils/fetch-timeout.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import {

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -16,7 +16,7 @@ import { readSnakeCaseParamRaw } from "../../param-key.js";
 import { isManifestPluginAvailableForControlPlane } from "../../plugins/manifest-contract-eligibility.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import { resolveUserPath } from "../../utils.js";
-import type { DeliveryContext } from "../../utils/delivery-context.shared.js";
+import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { parseVideoGenerationModelRef } from "../../video-generation/model-ref.js";
 import {
   generateVideo,

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -15,7 +15,6 @@ import { isReservedTargetLiteralError } from "../../infra/outbound/target-errors
 import type { ResolvedMessagingTarget } from "../../infra/outbound/target-resolver.js";
 import { tryResolveLoadedOutboundTarget } from "../../infra/outbound/targets-loaded.js";
 import { resolveSessionDeliveryTarget } from "../../infra/outbound/targets-session.js";
-import type { OutboundChannel } from "../../infra/outbound/targets.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
@@ -26,7 +25,7 @@ import { resolveCronAgentSessionKey } from "./session-key.js";
 export type DeliveryTargetResolution =
   | {
       ok: true;
-      channel: OutboundChannel;
+      channel: string;
       to: string;
       accountId?: string;
       threadId?: string | number;
@@ -34,7 +33,7 @@ export type DeliveryTargetResolution =
     }
   | {
       ok: false;
-      channel?: OutboundChannel;
+      channel?: string;
       to?: string;
       accountId?: string;
       threadId?: string | number;
@@ -117,10 +116,7 @@ function shouldCarrySessionThread(params: {
   return routesSharePeer(params.route, params.lastRoute);
 }
 
-function stripSelectedProviderPrefix(params: {
-  channel: OutboundChannel;
-  to?: string;
-}): string | undefined {
+function stripSelectedProviderPrefix(params: { channel: string; to?: string }): string | undefined {
   const trimmed = params.to?.trim();
   if (!trimmed) {
     return undefined;
@@ -196,7 +192,7 @@ export async function resolveDeliveryTarget(
     allowMismatchedLastTo,
   });
 
-  let fallbackChannel: OutboundChannel | undefined;
+  let fallbackChannel: string | undefined;
   let channelResolutionError: Error | undefined;
   if (!preliminary.channel) {
     if (preliminary.lastChannel) {

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -24,13 +24,6 @@ export function normalizeDeliverableOutboundChannel(raw?: string | null): string
   return normalized;
 }
 
-function maybeBootstrapChannelPlugin(params: {
-  channel: string;
-  cfg?: OpenClawConfig;
-}): PluginRegistry | undefined {
-  return bootstrapOutboundChannelPlugin(params);
-}
-
 function getOutboundRuntimeRegistry(): PluginRegistry | null {
   return getPluginRuntimeGatewayRequestScope()?.pluginRegistry ?? getActivePluginRegistry();
 }
@@ -45,7 +38,8 @@ function normalizeOutboundChannelForResolution(params: {
   bootstrapRegistry?: PluginRegistry;
 } {
   const normalized = normalizeMessageChannel(params.channel);
-  const deliverable = normalizeDeliverableOutboundChannel(normalized);
+  const deliverable =
+    normalized && isDeliverableMessageChannel(normalized) ? normalized : undefined;
   if (deliverable || !normalized || normalized === INTERNAL_MESSAGE_CHANNEL) {
     return { channel: deliverable, didBootstrap: false };
   }
@@ -66,7 +60,7 @@ function normalizeOutboundChannelForResolution(params: {
 
   // External channel ids remain normalized before their runtime is registered.
   // Bootstrap first, then let the runtime candidate lookup confirm sendability.
-  const bootstrapRegistry = maybeBootstrapChannelPlugin({
+  const bootstrapRegistry = bootstrapOutboundChannelPlugin({
     channel: normalized,
     cfg: params.cfg,
   });
@@ -235,7 +229,7 @@ export function resolveOutboundChannelPlugin(params: {
     return undefined;
   }
 
-  const registry = maybeBootstrapChannelPlugin({ channel: normalized, cfg: params.cfg });
+  const registry = bootstrapOutboundChannelPlugin({ channel: normalized, cfg: params.cfg });
   return resolveRuntimeOutboundPluginCandidate({
     loaded: resolveLoaded(),
     runtime: resolveActivatedOutboundPluginFromRuntimeRegistry(normalized, registry),
@@ -270,7 +264,7 @@ export function resolveOutboundChannelMessageAdapter(params: {
   if (current || params.allowBootstrap !== true || didBootstrap) {
     return current;
   }
-  const registry = maybeBootstrapChannelPlugin({ channel: normalized, cfg: params.cfg });
+  const registry = bootstrapOutboundChannelPlugin({ channel: normalized, cfg: params.cfg });
   return (
     resolveSendCapableMessageAdapter(getLoadedChannelPlugin(normalized)) ??
     resolveValueFromRuntimeRegistry(normalized, resolveSendCapableMessageAdapter, registry) ??

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -32,6 +32,10 @@ vi.mock("../../utils/message-channel.js", () => ({
 }));
 
 vi.mock("./channel-resolution.js", () => ({
+  normalizeDeliverableOutboundChannel: (value?: string | null) => {
+    const normalized = typeof value === "string" ? value.trim().toLowerCase() : undefined;
+    return normalized && deliverableChannelIds.includes(normalized) ? normalized : undefined;
+  },
   resolveOutboundChannelPlugin: mocks.resolveOutboundChannelPlugin,
 }));
 

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -12,44 +12,24 @@ import {
 import { defaultRuntime } from "../../runtime.js";
 import { isAccountEnabled } from "../../shared/account-enabled.js";
 import {
-  listDeliverableMessageChannels,
   isDeliverableMessageChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 import { createDedupeCache } from "../dedupe.js";
 import { formatErrorMessage } from "../errors.js";
-import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
+import {
+  normalizeDeliverableOutboundChannel,
+  resolveOutboundChannelPlugin,
+} from "./channel-resolution.js";
 
-/** Deliverable message channel id that can be selected for message actions. */
-type MessageChannelId = string;
 /** Source that explains how message channel selection chose its result. */
 type MessageChannelSelectionSource = "explicit" | "tool-context-fallback" | "single-configured";
-
-const getMessageChannels = () => listDeliverableMessageChannels();
-
-function isKnownChannel(value: string): boolean {
-  return getMessageChannels().includes(value);
-}
-
-function resolveKnownChannel(value?: string | null): MessageChannelId | undefined {
-  const normalized = normalizeMessageChannel(value);
-  if (!normalized) {
-    return undefined;
-  }
-  if (!isDeliverableMessageChannel(normalized)) {
-    return undefined;
-  }
-  if (!isKnownChannel(normalized)) {
-    return undefined;
-  }
-  return normalized;
-}
 
 function resolveAvailableKnownChannel(params: {
   cfg: OpenClawConfig;
   value?: string | null;
-}): MessageChannelId | undefined {
-  const normalized = resolveKnownChannel(params.value);
+}): string | undefined {
+  const normalized = normalizeDeliverableOutboundChannel(params.value);
   if (!normalized) {
     return undefined;
   }
@@ -199,12 +179,10 @@ async function isPluginConfigured(plugin: ChannelPlugin, cfg: OpenClawConfig): P
 }
 
 /** Lists deliverable channels with at least one enabled, configured account. */
-export async function listConfiguredMessageChannels(
-  cfg: OpenClawConfig,
-): Promise<MessageChannelId[]> {
-  const channels: MessageChannelId[] = [];
+export async function listConfiguredMessageChannels(cfg: OpenClawConfig): Promise<string[]> {
+  const channels: string[] = [];
   for (const plugin of listChannelPlugins()) {
-    if (!isKnownChannel(plugin.id)) {
+    if (!isDeliverableMessageChannel(plugin.id)) {
       continue;
     }
     if (await isPluginConfigured(plugin, cfg)) {
@@ -220,15 +198,15 @@ export async function resolveMessageChannelSelection(params: {
   channel?: string | null;
   fallbackChannel?: string | null;
 }): Promise<{
-  channel: MessageChannelId;
-  configured: MessageChannelId[];
+  channel: string;
+  configured: string[];
   source: MessageChannelSelectionSource;
 }> {
   const normalized = normalizeMessageChannel(params.channel);
   if (normalized) {
     const availableExplicit = resolveAvailableKnownChannel({
       cfg: params.cfg,
-      value: normalized,
+      value: params.channel,
     });
     if (!availableExplicit) {
       const fallback = resolveAvailableKnownChannel({
@@ -242,7 +220,7 @@ export async function resolveMessageChannelSelection(params: {
           source: "tool-context-fallback",
         };
       }
-      if (!isKnownChannel(normalized)) {
+      if (!isDeliverableMessageChannel(normalized)) {
         throw new Error(`Unknown channel: ${normalized}`);
       }
       const repairHint = isConfiguredChannel(params.cfg, normalized)

--- a/src/infra/outbound/deliver-channel.ts
+++ b/src/infra/outbound/deliver-channel.ts
@@ -33,7 +33,6 @@ import {
   type OutboundDeliveryCommitHook,
 } from "./delivery-commit-hooks.js";
 import type { OutboundMessageSendOverrides } from "./message-plan.js";
-import type { OutboundChannel } from "./targets.js";
 
 const log = createSubsystemLogger("outbound/deliver");
 
@@ -42,7 +41,7 @@ const loadChannelBootstrapRuntime = createLazyRuntimeModule(
 );
 export async function resolveChannelOutboundDirectiveOptions(params: {
   cfg: OpenClawConfig;
-  channel: OutboundChannel;
+  channel: string;
 }): Promise<{ extractMarkdownImages?: boolean }> {
   const { outbound } = await loadBootstrappedOutboundAdapter(params);
   return {
@@ -64,7 +63,7 @@ export async function createChannelHandler(params: ChannelHandlerParams): Promis
 
 async function loadBootstrappedOutboundAdapter(params: {
   cfg: OpenClawConfig;
-  channel: OutboundChannel;
+  channel: string;
 }): Promise<{ outbound?: ChannelOutboundAdapter; pluginRegistry?: PluginRegistry }> {
   let outbound = await loadChannelOutboundAdapter(params.channel);
   if (outbound) {
@@ -158,7 +157,7 @@ async function runChannelMessageSendWithLifecycle<
 
 export async function resolveOutboundDurableFinalDeliverySupport(params: {
   cfg: OpenClawConfig;
-  channel: OutboundChannel;
+  channel: string;
   requirements?: DurableFinalDeliveryRequirements;
 }): Promise<OutboundDurableDeliverySupport> {
   const { outbound, pluginRegistry } = await loadBootstrappedOutboundAdapter(params);
@@ -502,7 +501,7 @@ function createPluginHandler(
 }
 
 function normalizeChannelMessageSendResult(
-  channel: OutboundChannel,
+  channel: string,
   result: ChannelMessageSendResult,
 ): OutboundDeliveryResult {
   const source = result as ChannelMessageSendResult & Partial<OutboundDeliveryResult>;

--- a/src/infra/outbound/deliver-contracts.ts
+++ b/src/infra/outbound/deliver-contracts.ts
@@ -25,13 +25,12 @@ import type { NormalizedOutboundPayload } from "./payloads.js";
 import type { PreparedOutboundBatch } from "./prepared-batch.js";
 import type { OutboundSendDeps } from "./send-deps.js";
 import type { OutboundSessionContext } from "./session-context.js";
-import type { OutboundChannel } from "./targets.js";
 
 export type OutboundDeliveryQueuePolicy = "required" | "best_effort";
 
 export type OutboundDeliveryIntent = {
   id: string;
-  channel: OutboundChannel;
+  channel: string;
   to: string;
   accountId?: string;
   queuePolicy: OutboundDeliveryQueuePolicy;
@@ -119,7 +118,7 @@ export type PlatformSendRoute = {
 
 export type ChannelHandlerParams = {
   cfg: OpenClawConfig;
-  channel: OutboundChannel;
+  channel: string;
   to: string;
   accountId?: string;
   replyToId?: string | null;
@@ -144,7 +143,7 @@ export type ChannelHandlerParams = {
 
 export type DeliverOutboundPayloadsCoreParams = {
   cfg: OpenClawConfig;
-  channel: OutboundChannel;
+  channel: string;
   to: string;
   accountId?: string;
   payloads: ReplyPayload[];

--- a/src/infra/outbound/deliver-payload.ts
+++ b/src/infra/outbound/deliver-payload.ts
@@ -33,7 +33,6 @@ import {
 } from "./payloads.js";
 import { stripInternalRuntimeScaffolding } from "./protocol-scaffolding.js";
 import type { OutboundSessionContext } from "./session-context.js";
-import type { OutboundChannel } from "./targets.js";
 
 const log = createSubsystemLogger("outbound/deliver");
 
@@ -58,7 +57,7 @@ export function deliveryKindForPayload(
 }
 
 export function emitMessageDeliveryStarted(params: {
-  channel: OutboundChannel;
+  channel: string;
   deliveryKind: DiagnosticMessageDeliveryKind;
   sessionKey?: string;
 }): void {
@@ -71,7 +70,7 @@ export function emitMessageDeliveryStarted(params: {
 }
 
 export function emitMessageDeliveryCompleted(params: {
-  channel: OutboundChannel;
+  channel: string;
   deliveryKind: DiagnosticMessageDeliveryKind;
   durationMs: number;
   resultCount: number;
@@ -88,7 +87,7 @@ export function emitMessageDeliveryCompleted(params: {
 }
 
 export function emitMessageDeliveryError(params: {
-  channel: OutboundChannel;
+  channel: string;
   deliveryKind: DiagnosticMessageDeliveryKind;
   durationMs: number;
   error: unknown;

--- a/src/infra/outbound/deliver-transcript.ts
+++ b/src/infra/outbound/deliver-transcript.ts
@@ -5,7 +5,6 @@ import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import { formatErrorMessage } from "../errors.js";
 import type { DeliverOutboundPayloadsCoreParams } from "./deliver-contracts.js";
 import type { NormalizedOutboundPayload } from "./payloads.js";
-import type { OutboundChannel } from "./targets.js";
 
 const log = createSubsystemLogger("outbound/deliver");
 const loadTranscriptRuntime = createLazyRuntimeModule(
@@ -15,7 +14,7 @@ const loadTranscriptRuntime = createLazyRuntimeModule(
 export async function mirrorDeliveredPayloads(params: {
   delivery: DeliverOutboundPayloadsCoreParams;
   payloads: readonly NormalizedOutboundPayload[];
-  channel: OutboundChannel;
+  channel: string;
   to: string;
 }): Promise<void> {
   const mirror = params.delivery.mirror;

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -58,7 +58,6 @@ import {
   type PreparedOutboundBatch,
 } from "./prepared-batch.js";
 import type { OutboundSessionContext } from "./session-context.js";
-import type { OutboundChannel } from "./targets.js";
 
 export type QueuedRenderedMessageBatchPlan = {
   payloadCount: number;
@@ -80,7 +79,7 @@ export type QueuedReplyPayloadSendingHook = {
 };
 
 export type QueuedDeliveryPayload = {
-  channel: OutboundChannel;
+  channel: string;
   to: string;
   accountId?: string;
   /** Original queue durability policy when known. */

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -32,6 +32,8 @@ const channelResolutionMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("./channel-resolution.js", () => ({
+  normalizeDeliverableOutboundChannel: (value?: string | null) =>
+    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
   resolveOutboundChannelPlugin: channelResolutionMocks.resolveOutboundChannelPlugin,
   resetOutboundChannelResolutionStateForTest: vi.fn(),
 }));

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -112,6 +112,8 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("./channel-resolution.js", () => ({
+  normalizeDeliverableOutboundChannel: (value?: string | null) =>
+    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
   resolveOutboundChannelPlugin: mocks.resolveOutboundChannelPlugin,
   resetOutboundChannelResolutionStateForTest: vi.fn(),
 }));

--- a/src/infra/outbound/message-action-runner.poll.test.ts
+++ b/src/infra/outbound/message-action-runner.poll.test.ts
@@ -28,6 +28,8 @@ function firstMockArg(
 }
 
 vi.mock("./channel-resolution.js", () => ({
+  normalizeDeliverableOutboundChannel: (value?: string | null) =>
+    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
   resolveOutboundChannelPlugin: mocks.resolveOutboundChannelPlugin,
   resetOutboundChannelResolutionStateForTest: vi.fn(),
 }));

--- a/src/infra/outbound/outbound-audit.ts
+++ b/src/infra/outbound/outbound-audit.ts
@@ -26,10 +26,9 @@ import {
 } from "./deliver-types.js";
 import type { DeliveryMirror } from "./mirror.js";
 import type { OutboundSessionContext } from "./session-context.js";
-import type { OutboundChannel } from "./targets.js";
 
 type OutboundAuditDeliveryContext = {
-  channel: OutboundChannel;
+  channel: string;
   to: string;
   accountId?: string;
   payloads?: readonly ReplyPayload[];

--- a/src/infra/outbound/targets-loaded.test.ts
+++ b/src/infra/outbound/targets-loaded.test.ts
@@ -48,10 +48,4 @@ describe("tryResolveLoadedOutboundTarget", () => {
       }),
     ).toEqual({ ok: true, to: "room-one" });
   });
-
-  it("trims channel ids before reading the loaded registry", () => {
-    tryResolveLoadedOutboundTarget({ channel: " alpha " as never, to: "room-one" });
-
-    expect(mocks.getLoadedChannelPlugin).toHaveBeenCalledWith("alpha");
-  });
 });

--- a/src/infra/outbound/targets-loaded.ts
+++ b/src/infra/outbound/targets-loaded.ts
@@ -1,23 +1,12 @@
 // Loaded-target resolution uses only already-loaded plugins so hot send paths
 // can avoid triggering channel discovery.
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { getLoadedChannelPluginForRead } from "../../channels/plugins/registry-loaded.js";
-import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   resolveOutboundTargetWithPlugin,
   type OutboundTargetResolution,
 } from "./targets-resolve-shared.js";
-
-function resolveLoadedOutboundChannelPlugin(channel: string): ChannelPlugin | undefined {
-  const normalized = normalizeOptionalString(channel);
-  if (!normalized) {
-    return undefined;
-  }
-
-  return getLoadedChannelPluginForRead(normalized);
-}
 
 /** Resolves targets through an already-loaded channel plugin without bootstrap discovery. */
 export function tryResolveLoadedOutboundTarget(params: {
@@ -29,7 +18,7 @@ export function tryResolveLoadedOutboundTarget(params: {
   mode?: ChannelOutboundTargetMode;
 }): OutboundTargetResolution | undefined {
   return resolveOutboundTargetWithPlugin({
-    plugin: resolveLoadedOutboundChannelPlugin(params.channel),
+    plugin: getLoadedChannelPluginForRead(params.channel),
     target: params,
   });
 }

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -30,15 +30,9 @@ import {
   type OutboundTargetResolution,
 } from "./targets-resolve-shared.js";
 
-/** Deliverable channel id accepted by outbound target resolution. */
-export type OutboundChannel = string;
-
-/** Heartbeat target channel id from agent/default heartbeat config. */
-type HeartbeatTarget = OutboundChannel;
-
 /** Resolved outbound delivery destination and routing hints. */
 type OutboundTarget = {
-  channel: OutboundChannel;
+  channel: string;
   to?: string;
   chatType?: ChatType;
   reason?: string;
@@ -102,7 +96,7 @@ export function resolveHeartbeatDeliveryTarget(params: {
   const { cfg, entry } = params;
   const heartbeat = params.heartbeat ?? cfg.agents?.defaults?.heartbeat;
   const rawTarget = heartbeat?.target;
-  let target: HeartbeatTarget = "none";
+  let target = "none";
   let preparedExplicitPlugin: ChannelPlugin | undefined;
   let preparedExplicitTo: string | undefined;
   if (rawTarget === "none" || rawTarget === "last") {
@@ -120,7 +114,7 @@ export function resolveHeartbeatDeliveryTarget(params: {
           allowBootstrap: true,
         });
         if (preparedExplicitPlugin) {
-          target = preparedExplicitPlugin.id as HeartbeatTarget;
+          target = preparedExplicitPlugin.id;
           preparedExplicitTo = explicitTo;
         }
       }
@@ -459,7 +453,7 @@ function resolveHeartbeatDeliveryChatType(params: {
 
 function shouldReuseHeartbeatRouteThreadId(params: {
   cfg: OpenClawConfig;
-  target: HeartbeatTarget;
+  target: string;
   heartbeat?: AgentDefaultsConfig["heartbeat"];
   turnSource?: DeliveryContext;
   entry?: SessionEntry;

--- a/src/utils/delivery-context.shared.ts
+++ b/src/utils/delivery-context.shared.ts
@@ -18,7 +18,7 @@ import {
   INTERNAL_MESSAGE_CHANNEL,
   isInternalNonDeliveryChannel,
 } from "./message-channel-constants.js";
-import { normalizeMessageChannel } from "./message-channel-core.js";
+import { isNormalizedMessageChannel, normalizeMessageChannel } from "./message-channel-core.js";
 export type { DeliveryContext } from "./delivery-context.types.js";
 
 /**
@@ -120,10 +120,10 @@ function isInternalRouteContext(context?: DeliveryContext): boolean {
 }
 
 function hasExternalDeliveryTarget(context?: DeliveryContext): boolean {
-  const channel = normalizeMessageChannel(context?.channel);
+  const channel = context?.channel;
   return Boolean(
     channel &&
-    channel !== INTERNAL_MESSAGE_CHANNEL &&
+    isNormalizedMessageChannel(channel) &&
     !isInternalNonDeliveryChannel(channel) &&
     context?.to,
   );

--- a/src/utils/message-channel-normalize.ts
+++ b/src/utils/message-channel-normalize.ts
@@ -6,27 +6,21 @@ import { INTERNAL_MESSAGE_CHANNEL } from "./message-channel-constants.js";
 import { normalizeMessageChannel } from "./message-channel-core.js";
 export { normalizeMessageChannel } from "./message-channel-core.js";
 
-const listPluginChannelIds = (): string[] => {
-  return listRegisteredChannelPluginIds();
-};
-
 /** Lists built-in and registered plugin channel ids that can receive delivery. */
 export const listDeliverableMessageChannels = (): string[] =>
-  uniqueStrings([...CHANNEL_IDS, ...listPluginChannelIds()]);
-
-const listGatewayMessageChannels = (): string[] => [
-  ...listDeliverableMessageChannels(),
-  INTERNAL_MESSAGE_CHANNEL,
-];
+  uniqueStrings([...CHANNEL_IDS, ...listRegisteredChannelPluginIds()]);
 
 /** Returns whether a normalized id is valid for Gateway routing. */
 export function isGatewayMessageChannel(value: string): boolean {
-  return listGatewayMessageChannels().includes(value);
+  return value === INTERNAL_MESSAGE_CHANNEL || isDeliverableMessageChannel(value);
 }
 
 /** Returns whether a normalized id is a deliverable non-internal channel. */
 export function isDeliverableMessageChannel(value: string): boolean {
-  return listDeliverableMessageChannels().includes(value);
+  return (
+    CHANNEL_IDS.some((channelId) => channelId === value) ||
+    listRegisteredChannelPluginIds().includes(value)
+  );
 }
 
 /** Normalizes and validates a raw channel value for Gateway routing. */

--- a/src/utils/message-channel.test.ts
+++ b/src/utils/message-channel.test.ts
@@ -61,9 +61,11 @@ describe("message-channel", () => {
   it("normalizes gateway message channels and rejects unknown values", () => {
     expect(resolveGatewayMessageChannel("discord")).toBe("discord");
     expect(resolveGatewayMessageChannel(" imsg ")).toBe("imessage");
+    expect(resolveGatewayMessageChannel("webchat")).toBe("webchat");
     expect(resolveGatewayMessageChannel("web")).toBeUndefined();
     expect(resolveGatewayMessageChannel("nope")).toBeUndefined();
     expect(isDeliverableMessageChannel("discord")).toBe(true);
+    expect(isDeliverableMessageChannel("imsg")).toBe(false);
     expect(isDeliverableMessageChannel("webchat")).toBe(false);
     expect(isDeliverableMessageChannel("nope")).toBe(false);
   });
@@ -95,6 +97,7 @@ describe("message-channel", () => {
     );
     expect(resolveGatewayMessageChannel("workspace-chat")).toBe("demo-alias-channel");
     expect(isDeliverableMessageChannel("demo-alias-channel")).toBe(true);
+    expect(isDeliverableMessageChannel("workspace-chat")).toBe(false);
   });
 
   it("recognises internal non-delivery channel sources", () => {


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.
-->

Related: #120872

AI-assisted: Yes. The final patch was maintainer-directed, tested, and reviewed.

## What Problem This Solves

This is a behavior-neutral follow-up to #120872 that removes redundant message-channel types, lists, wrappers, and lifecycle forwarding left behind after the routing repair. No separate issue is required for this explicit maintainer cleanup.

## Why This Change Was Made

The patch deletes the `MessageChannelId`, `OutboundChannel`, and `HeartbeatTarget` aliases in favor of honest string types. It also removes duplicate gateway/plugin channel lists, known-channel wrappers, redundant normalization and bootstrap forwarding, and the loaded-plugin wrapper.

The strict invariants remain unchanged: deliverable membership accepts exactly generated channel IDs or registered plugin IDs, while aliases and unknown IDs remain rejected. Unknown normalized external plugin IDs still bootstrap through channel resolution before sendability confirmation. Delivery context reuses normalized-channel validation only after normalization, and type-only imports now point directly to the delivery-context type owner.

Descendant wake now reuses the already-computed announce identity, loaded registry runtime, parent-owned dependency direction, and lifecycle-generation validation. It still terminates accepted unowned wakes and persists either the replacement task or frozen fallback.

## User Impact

There is no intended user-visible behavior change. The routing and wake paths have fewer duplicate concepts and lookups while preserving strict channel selection, external plugin bootstrap, sentinel handling, and lifecycle cleanup.

## Evidence

- Focused routing, delivery-context, channel selection/resolution/loaded-target, outbound-target, announce/requester-wake/timeout, and lifecycle proof: 360 tests passed.
- Full changed-file gate passed on Testbox `tbx_01kzjeqkv40crtqh99x60szfhx`: https://github.com/openclaw/openclaw/actions/runs/31296029725
- Replayed-head `git diff --check` passed.
- Final branch autoreview completed cleanly with no accepted or actionable findings.
- Production LOC: +97/-164 (net -67). Tests: +7/-6 (net +1).
