### PR TITLE
fix(gateway): unbreak cloud session creation — stale chat metadata, unbounded tunnel hangs, swallowed dispatch errors

### DIFF
--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -63,6 +63,7 @@ export {
   ensureAuthProfileStoreWithoutExternalProfiles,
   getPreparedRuntimeAuthProfileStoreSnapshot,
   getRuntimeAuthProfileStoreSnapshot,
+  getRuntimeAuthProfileStoreSnapshotRevision,
   hasAuthProfileStoreSourceForProvider,
   hasAnyAuthProfileStoreSource,
   hasLocalAuthProfileStoreSource,

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -1326,6 +1326,8 @@ export function getPreparedRuntimeAuthProfileStoreSnapshot(
   return getPreparedRuntimeAuthProfileStoreSnapshotImpl(agentDir, inheritedAuthDir);
 }
 
+export { getRuntimeAuthProfileStoreSnapshotRevision };
+
 /** Replace runtime auth-profile snapshots, used by tests and prepared runtimes. */
 export function replaceRuntimeAuthProfileStoreSnapshots(
   entries: Array<{ agentDir?: string; store: AuthProfileStore }>,

--- a/src/gateway/server-chat-metadata-lifecycle.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.ts
@@ -46,11 +46,15 @@ export async function createGatewayChatMetadataLifecycle(params: {
     if (params.minimalTestGateway) {
       return undefined;
     }
-    const [{ registerPreparedModelRuntimePublicationListener }, { registerSkillsChangeListener }] =
-      await Promise.all([
-        import("../agents/prepared-model-runtime.js"),
-        import("../skills/runtime/refresh.js"),
-      ]);
+    const [
+      { registerRuntimeAuthProfileStoreMutationListener },
+      { registerPreparedModelRuntimePublicationListener },
+      { registerSkillsChangeListener },
+    ] = await Promise.all([
+      import("../agents/auth-profiles/runtime-snapshots.js"),
+      import("../agents/prepared-model-runtime.js"),
+      import("../skills/runtime/refresh.js"),
+    ]);
     const unregisterPreparedModelRuntimePublication =
       registerPreparedModelRuntimePublicationListener((event) => {
         if (event.phase === "invalidated") {
@@ -67,8 +71,14 @@ export async function createGatewayChatMetadataLifecycle(params: {
       runtime.invalidate();
       refreshLogged();
     });
+    const unregisterRuntimeAuthProfileStoreMutation =
+      registerRuntimeAuthProfileStoreMutationListener(() => {
+        runtime.invalidate();
+        refreshLogged();
+      });
     return {
       stop: async () => {
+        unregisterRuntimeAuthProfileStoreMutation();
         unregisterPreparedModelRuntimePublication();
         unregisterSkillsChange();
       },
@@ -85,6 +95,13 @@ export async function createGatewayChatMetadataLifecycle(params: {
       if (sidecar) {
         sidecars.push(sidecar);
       }
+      // Auth/model snapshots published before listener registration are otherwise never
+      // observed; one awaited catch-up refresh reconciles facts (revision-aware, no-op when
+      // fresh) so post-attach reads cannot serve a pre-publication generation. Failures are
+      // logged, not thrown: startup must not die on a metadata build error.
+      await runtime.refresh().catch((error: unknown) => {
+        params.log.warn(`chat metadata catch-up refresh failed: ${String(error)}`);
+      });
     },
     read: runtime.read,
     readStartup: runtime.readStartup,

--- a/src/gateway/server-methods/chat-metadata-runtime.test.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.test.ts
@@ -37,16 +37,22 @@ function createHarness(
   let owner = createOwner(config, "first");
   let skillsVersion = 1;
   let pluginRegistryVersion = 1;
-  const authStore: AuthProfileStore = { version: 1, profiles: {} };
+  let authStore: AuthProfileStore | undefined = { version: 1, profiles: {} };
+  let authStoreRevision = 1;
   const getPreparedOwner = vi.fn(() => owner);
   const getPreparedAuthStore = vi.fn(() => authStore);
+  const getAuthStoreRevision = vi.fn(() => authStoreRevision);
   const getSkillsVersion = vi.fn(() => skillsVersion);
   const getPluginRegistryVersion = vi.fn(() => pluginRegistryVersion);
   const buildCommands = vi.fn(async () => ({
     commands: [{ name: `command-${skillsVersion}-${pluginRegistryVersion}` }],
   }));
   const buildProjection = vi.fn(
-    async ({ facts }: { facts: { owner: PreparedModelRuntimeSnapshot } }) => ({
+    async ({
+      facts,
+    }: {
+      facts: { authStore: AuthProfileStore; owner: PreparedModelRuntimeSnapshot };
+    }) => ({
       modelCatalog: facts.owner.modelCatalog.entries,
       models: facts.owner.modelCatalog.entries,
     }),
@@ -67,6 +73,7 @@ function createHarness(
     deps: {
       getPreparedOwner,
       getPreparedAuthStore,
+      getAuthStoreRevision,
       getSkillsVersion,
       getPluginRegistryVersion,
       buildCommands,
@@ -77,12 +84,19 @@ function createHarness(
     buildCommands,
     buildProjection,
     getPluginRegistryVersion,
+    getAuthStoreRevision,
     getPreparedAuthStore,
     getPreparedOwner,
     getSkillsVersion,
     runtime,
     setConfig(next: OpenClawConfig) {
       config = next;
+    },
+    setAuthStore(next: AuthProfileStore | undefined) {
+      authStore = next;
+    },
+    setAuthStoreRevision(next: number) {
+      authStoreRevision = next;
     },
     setOwner(next: PreparedModelRuntimeSnapshot) {
       owner = next;
@@ -130,6 +144,7 @@ describe("gateway chat metadata runtime", () => {
     await harness.runtime.refresh();
     harness.getPreparedOwner.mockClear();
     harness.getPreparedAuthStore.mockClear();
+    harness.getAuthStoreRevision.mockClear();
     harness.getSkillsVersion.mockClear();
     harness.getPluginRegistryVersion.mockClear();
 
@@ -139,6 +154,7 @@ describe("gateway chat metadata runtime", () => {
     expect(first).toBe(second);
     expect(harness.getPreparedOwner).not.toHaveBeenCalled();
     expect(harness.getPreparedAuthStore).not.toHaveBeenCalled();
+    expect(harness.getAuthStoreRevision).not.toHaveBeenCalled();
     expect(harness.getSkillsVersion).not.toHaveBeenCalled();
     expect(harness.getPluginRegistryVersion).not.toHaveBeenCalled();
   });
@@ -148,6 +164,7 @@ describe("gateway chat metadata runtime", () => {
     await harness.runtime.refresh();
     harness.getPreparedOwner.mockClear();
     harness.getPreparedAuthStore.mockClear();
+    harness.getAuthStoreRevision.mockClear();
     harness.getSkillsVersion.mockClear();
     harness.getPluginRegistryVersion.mockClear();
 
@@ -169,6 +186,7 @@ describe("gateway chat metadata runtime", () => {
     expect(harness.buildProjection).toHaveBeenCalledTimes(1);
     expect(harness.getPreparedOwner).not.toHaveBeenCalled();
     expect(harness.getPreparedAuthStore).not.toHaveBeenCalled();
+    expect(harness.getAuthStoreRevision).not.toHaveBeenCalled();
     expect(harness.getSkillsVersion).not.toHaveBeenCalled();
     expect(harness.getPluginRegistryVersion).not.toHaveBeenCalled();
   });
@@ -320,6 +338,50 @@ describe("gateway chat metadata runtime", () => {
     expect(second).toBe(first);
     expect(harness.buildCommands).toHaveBeenCalledTimes(1);
     expect(harness.buildProjection).toHaveBeenCalledTimes(1);
+  });
+
+  test("rebuilds after an auth store publishes a newer revision", async () => {
+    const harness = createHarness();
+    harness.setAuthStore(undefined);
+    harness.buildProjection.mockImplementation(async ({ facts }) => ({
+      modelCatalog: facts.owner.modelCatalog.entries,
+      models: facts.owner.modelCatalog.entries.map((model) => ({
+        ...model,
+        available: Object.keys(facts.authStore.profiles).length > 0,
+      })),
+    }));
+
+    await harness.runtime.refresh();
+    await expect(harness.runtime.read({ agentId: "main" })).resolves.toMatchObject({
+      models: [expect.objectContaining({ available: false })],
+    });
+
+    harness.setAuthStore({
+      version: 1,
+      profiles: { "test:default": { type: "api_key", provider: "test" } },
+    });
+    harness.setAuthStoreRevision(2);
+    await harness.runtime.refresh();
+
+    await expect(harness.runtime.read({ agentId: "main" })).resolves.toMatchObject({
+      models: [expect.objectContaining({ available: true })],
+    });
+    expect(harness.buildProjection).toHaveBeenCalledTimes(2);
+  });
+
+  test("retains a generation while auth store revisions are unchanged", async () => {
+    const harness = createHarness();
+    harness.getPreparedAuthStore.mockImplementation(() => ({ version: 1, profiles: {} }));
+    await harness.runtime.refresh();
+    const first = await harness.runtime.read({ agentId: "main" });
+
+    await harness.runtime.refresh();
+    const second = await harness.runtime.read({ agentId: "main" });
+
+    expect(second).toBe(first);
+    expect(harness.buildProjection).toHaveBeenCalledTimes(1);
+    expect(harness.getAuthStoreRevision).toHaveBeenCalledWith("/tmp/first/agent");
+    expect(harness.getAuthStoreRevision).toHaveBeenCalledWith(undefined);
   });
 
   test("refreshes config, catalog-auth, skills, and plugin generations", async () => {

--- a/src/gateway/server-methods/chat-metadata-runtime.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.ts
@@ -5,6 +5,7 @@ import {
 } from "../../agents/agent-scope.js";
 import {
   getPreparedRuntimeAuthProfileStoreSnapshot,
+  getRuntimeAuthProfileStoreSnapshotRevision,
   type AuthProfileStore,
 } from "../../agents/auth-profiles.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
@@ -40,6 +41,7 @@ type PreparedAgentFacts = {
   agentId: string;
   owner: PreparedModelRuntimeSnapshot;
   authStore: AuthProfileStore;
+  authStoreRevision: string;
   skillsVersion: number;
 };
 
@@ -85,6 +87,7 @@ type ChatMetadataRuntimeDeps = {
     agentDir?: string,
     inheritedAuthDir?: string,
   ) => AuthProfileStore | undefined;
+  getAuthStoreRevision: (agentDir?: string) => number;
   getSkillsVersion: (workspaceDir?: string) => number;
   getPluginRegistryVersion: () => number;
   buildCommands: (params: {
@@ -150,6 +153,7 @@ function captureGenerationFacts(deps: ChatMetadataRuntimeDeps): PreparedGenerati
         version: 1,
         profiles: {},
       },
+      authStoreRevision: `${deps.getAuthStoreRevision(owner.agentDir)}:${deps.getAuthStoreRevision(owner.inheritedAuthDir)}`,
       skillsVersion: deps.getSkillsVersion(workspaceDir),
     };
   });
@@ -177,6 +181,7 @@ function generationFactsMatch(
     return (
       candidate?.agentId === agent.agentId &&
       candidate.owner === agent.owner &&
+      candidate.authStoreRevision === agent.authStoreRevision &&
       candidate.skillsVersion === agent.skillsVersion
     );
   });
@@ -277,6 +282,7 @@ export function createGatewayChatMetadataRuntime(params: {
     getContext: params.getContext,
     getPreparedOwner: getPreparedModelCatalogOwnerSnapshot,
     getPreparedAuthStore: getPreparedRuntimeAuthProfileStoreSnapshot,
+    getAuthStoreRevision: getRuntimeAuthProfileStoreSnapshotRevision,
     getSkillsVersion: getSkillsSnapshotVersion,
     getPluginRegistryVersion: getActivePluginRegistryVersion,
     buildCommands: defaultBuildCommands,

--- a/src/gateway/worker-environments/service.test.ts
+++ b/src/gateway/worker-environments/service.test.ts
@@ -1164,6 +1164,7 @@ describe("worker environment service", () => {
       workerService.create("development", "request-preparation-failure"),
     ).rejects.toMatchObject({
       code: "bootstrap_failure",
+      message: expect.stringContaining("npm install requires a released gateway package"),
     } satisfies Partial<WorkerEnvironmentServiceError>);
 
     expect(provision).not.toHaveBeenCalled();
@@ -1589,6 +1590,7 @@ describe("worker environment service", () => {
 
     await expect(workerService.create("development", "request-malformed")).rejects.toMatchObject({
       code: "provider_failure",
+      message: expect.stringContaining(error),
     } satisfies Partial<WorkerEnvironmentServiceError>);
     expect(store.list()[0]).toMatchObject({
       state: "provisioning",
@@ -1621,6 +1623,7 @@ describe("worker environment service", () => {
 
     await expect(workerService.create("development", "request-invalid")).rejects.toMatchObject({
       code: "invalid_profile",
+      message: expect.stringContaining("region is required"),
     } satisfies Partial<WorkerEnvironmentServiceError>);
     const record = expectDefined(store.list()[0], "store.list()[0] test invariant");
     expect(record).toMatchObject({ state: "failed", lastError: "region is required" });
@@ -2256,6 +2259,45 @@ describe("worker environment service", () => {
 
     await rejectedStart;
     expect(order).toEqual(["tunnel-stop", "provider-destroy"]);
+  });
+
+  it("stops a poisoned tunnel start and returns a typed deadline error", async () => {
+    vi.useFakeTimers();
+    seedReady("worker-tunnel-timeout");
+    let signalStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      signalStarted = resolve;
+    });
+    let rejectStart!: (error: Error) => void;
+    const pendingStart = new Promise<never>((_resolve, reject) => {
+      rejectStart = reject;
+    });
+    const tunnelManager = {
+      status: () => "connecting" as const,
+      start: vi.fn(() => {
+        signalStarted();
+        return pendingStart;
+      }),
+      stop: vi.fn(async () => {
+        rejectStart(new Error("tunnel stopped"));
+      }),
+      stopAll: vi.fn(async () => {}),
+    } as unknown as WorkerTunnelManager;
+    const workerService = createService(createProvider(), { tunnelManager });
+
+    const starting = workerService.startTunnel({
+      environmentId: "worker-tunnel-timeout",
+      ownerEpoch: 1,
+    });
+    const rejected = expect(starting).rejects.toMatchObject({
+      code: "provider_failure",
+      message: expect.stringContaining("did not connect within 3 minutes"),
+    } satisfies Partial<WorkerEnvironmentServiceError>);
+    await started;
+    await vi.advanceTimersByTimeAsync(3 * 60_000);
+
+    await rejected;
+    expect(tunnelManager.stop).toHaveBeenCalledWith("worker-tunnel-timeout", 1);
   });
 
   it("adopts an unpersisted provision result before destroying", async () => {

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -92,6 +92,8 @@ class WorkerEnvironmentServiceError extends Error {
 const serviceError = (code: WorkerEnvironmentServiceErrorCode, message: string) =>
   new WorkerEnvironmentServiceError(code, message);
 const ORPHANED_LEASE_ERROR = "Worker provider no longer recognizes the lease";
+// One poisoned SSH attempt must not hold every later dispatch on the same owner epoch forever.
+const TUNNEL_START_TIMEOUT_MS = 3 * 60_000;
 
 function workerEnvironmentIdempotencyDigest(idempotencyKey: string): string {
   return createHash("sha256").update(idempotencyKey).digest("hex");
@@ -614,15 +616,16 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
         ),
       );
     } catch (error) {
+      const detail = boundedError(error);
       if (
         error instanceof WorkerProviderError ||
         (error instanceof WorkerEnvironmentServiceError && error.code === "invalid_profile")
       ) {
-        move(record, "failed", { lastError: boundedError(error) });
-        throw serviceError("invalid_profile", "Worker provider rejected profile");
+        move(record, "failed", { lastError: detail });
+        throw serviceError("invalid_profile", `Worker provider rejected profile: ${detail}`);
       }
       saveError(record, error);
-      throw serviceError("provider_failure", "Worker provider operation failed");
+      throw serviceError("provider_failure", `Worker provider operation failed: ${detail}`);
     }
     // A timeout can happen after allocation; retain the same operation id for safe replay.
     const patch = { leaseId: lease.leaseId, sshEndpoint: lease.ssh };
@@ -654,8 +657,12 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
         // must happen first because the previous response may have been lost after allocation.
         installation = await prepareInstallation(record);
       } catch (error) {
-        move(record, "failed", { lastError: boundedError(error) });
-        throw serviceError("bootstrap_failure", "Worker installation preparation failed");
+        const detail = boundedError(error);
+        move(record, "failed", { lastError: detail });
+        throw serviceError(
+          "bootstrap_failure",
+          `Worker installation preparation failed: ${detail}`,
+        );
       }
     }
     const provisioning = record.state === "requested" ? move(record, "provisioning") : record;
@@ -1101,7 +1108,24 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     if (!startup) {
       throw serviceError("invalid_state", "Worker tunnel failed to start");
     }
-    return await startup;
+    const timeoutError = serviceError(
+      "provider_failure",
+      "Worker tunnel did not connect within 3 minutes; check worker SSH reachability and retry",
+    );
+    try {
+      return await withTimeout(startup, TUNNEL_START_TIMEOUT_MS, {
+        createError: () => timeoutError,
+      });
+    } catch (error) {
+      if (error !== timeoutError) {
+        throw error;
+      }
+      // Stop can itself block on an unkillable SSH child; detach it (rejection observed,
+      // entry stays manager-tracked) so the deadline error is returned on time. Epoch-fenced
+      // so a stale timed-out attempt can never tear down a newer owner's tunnel.
+      void tunnels.stop(request.environmentId, request.ownerEpoch).catch(() => undefined);
+      throw timeoutError;
+    }
   };
 
   const stopTunnel = async (environmentId: string, ownerEpoch?: number): Promise<void> => {

--- a/src/gateway/worker-environments/tunnel-ssh-runner.test.ts
+++ b/src/gateway/worker-environments/tunnel-ssh-runner.test.ts
@@ -1,7 +1,7 @@
 import type { SpawnOptions } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
 const spawnMock = vi.hoisted(() => vi.fn());
 
@@ -16,7 +16,7 @@ function createChild() {
     stdin: PassThrough;
     stdout: PassThrough;
     stderr: PassThrough;
-    kill: ReturnType<typeof vi.fn>;
+    kill: Mock<(signal?: NodeJS.Signals | number) => boolean>;
   };
   child.stdin = new PassThrough();
   child.stdout = new PassThrough();

--- a/src/gateway/worker-environments/tunnel-ssh-runner.test.ts
+++ b/src/gateway/worker-environments/tunnel-ssh-runner.test.ts
@@ -1,0 +1,169 @@
+import type { SpawnOptions } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({ spawn: spawnMock }));
+
+import { createWorkerSshRunner } from "./tunnel-ssh-runner.js";
+
+// Returned as the fake-typed union (not ChildProcessWithoutNullStreams) so `child.kill`
+// stays a plain vi.fn property; casting to the real type makes kill an unbound method for lint.
+function createChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: PassThrough;
+    stdout: PassThrough;
+    stderr: PassThrough;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = vi.fn(() => true);
+  return child;
+}
+
+describe("worker SSH process runner", () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("settles readiness and exit when spawn emits an error without close", async () => {
+    const child = createChild();
+    spawnMock.mockReturnValue(child);
+    const process = createWorkerSshRunner().start(["missing-ssh"], { timeoutMs: 10_000 });
+
+    child.emit("error", new Error("spawn failed"));
+
+    await expect(process.ready).rejects.toThrow("Worker SSH tunnel failed");
+    await expect(process.exited).resolves.toEqual({ code: null, signal: null });
+  });
+
+  it("settles with the real exit when close lags after SIGKILL", async () => {
+    vi.useFakeTimers();
+    const child = createChild();
+    spawnMock.mockReturnValue(child);
+    const process = createWorkerSshRunner().start(["ssh"], { timeoutMs: 10_000 });
+
+    const stopping = process.stop();
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+    child.emit("exit", null, "SIGKILL");
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await expect(stopping).resolves.toBeUndefined();
+    await expect(process.exited).resolves.toEqual({ code: null, signal: "SIGKILL" });
+    await expect(process.ready).rejects.toThrow("Worker SSH tunnel failed");
+  });
+
+  it("fails stop when a SIGKILLed child never reports exit", async () => {
+    vi.useFakeTimers();
+    const child = createChild();
+    spawnMock.mockReturnValue(child);
+    const process = createWorkerSshRunner().start(["ssh"], { timeoutMs: 10_000 });
+
+    const stopping = process.stop();
+    const rejection = expect(stopping).rejects.toThrow("did not exit after SIGKILL");
+    await vi.advanceTimersByTimeAsync(1_500);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await rejection;
+  });
+
+  it("treats a post-exit kill failure as terminal when close is delayed", async () => {
+    vi.useFakeTimers();
+    const child = createChild();
+    child.kill = vi.fn(() => false);
+    spawnMock.mockReturnValue(child);
+    const process = createWorkerSshRunner().start(["ssh"], { timeoutMs: 10_000 });
+
+    child.emit("exit", 255, null);
+    const stopping = process.stop();
+    await vi.advanceTimersByTimeAsync(1_500);
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await expect(stopping).resolves.toBeUndefined();
+    await expect(process.exited).resolves.toEqual({ code: 255, signal: null });
+    await expect(process.ready).rejects.toThrow("Worker SSH tunnel failed");
+  });
+
+  it("propagates a stop failure when SIGKILL delivery fails", async () => {
+    vi.useFakeTimers();
+    const child = createChild();
+    child.kill = vi.fn(() => false);
+    spawnMock.mockReturnValue(child);
+    const process = createWorkerSshRunner().start(["ssh"], { timeoutMs: 10_000 });
+
+    const stopping = process.stop();
+    const rejection = expect(stopping).rejects.toThrow("SIGKILL delivery failed");
+    await vi.advanceTimersByTimeAsync(1_500);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await rejection;
+
+    let exitedSettled = false;
+    void process.exited.then(() => {
+      exitedSettled = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(exitedSettled).toBe(false);
+  });
+
+  it("keeps exited pending when a live child emits error without close", async () => {
+    const child = createChild();
+    (child as { pid?: number }).pid = 4242;
+    spawnMock.mockReturnValue(child);
+    const process = createWorkerSshRunner().start(["ssh"], { timeoutMs: 10_000 });
+
+    child.emit("error", new Error("kill delivery failed"));
+
+    await expect(process.ready).rejects.toThrow("Worker SSH tunnel failed");
+    let exitedSettled = false;
+    void process.exited.then(() => {
+      exitedSettled = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(exitedSettled).toBe(false);
+
+    child.emit("close", 0, null);
+    await expect(process.exited).resolves.toEqual({ code: 0, signal: null });
+  });
+
+  it("passes the owner signal to spawn so abort terminates and settles the child", async () => {
+    const child = createChild();
+    spawnMock.mockImplementation((_command: string, _args: string[], options: SpawnOptions) => {
+      options.signal?.addEventListener(
+        "abort",
+        () => {
+          child.kill("SIGTERM");
+          child.emit("error", Object.assign(new Error("aborted"), { name: "AbortError" }));
+        },
+        { once: true },
+      );
+      return child;
+    });
+    const controller = new AbortController();
+    const process = createWorkerSshRunner().start(["ssh"], {
+      timeoutMs: 10_000,
+      signal: controller.signal,
+    });
+
+    controller.abort();
+
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    await expect(process.ready).rejects.toThrow("Worker SSH tunnel failed");
+    await expect(process.exited).resolves.toEqual({ code: null, signal: null });
+    expect(spawnMock).toHaveBeenCalledWith(
+      "ssh",
+      [],
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+});

--- a/src/gateway/worker-environments/tunnel-ssh-runner.ts
+++ b/src/gateway/worker-environments/tunnel-ssh-runner.ts
@@ -10,6 +10,7 @@ import {
 export const WORKER_TUNNEL_READY_MARKER = "OPENCLAW_WORKER_TUNNEL_READY";
 
 const STOP_GRACE_MS = 1_500;
+const STOP_KILL_WAIT_MS = 2_000;
 const STDERR_LIMIT = 4_096;
 
 type WorkerSshProcessExit = {
@@ -44,10 +45,12 @@ export function createWorkerSshRunner(): WorkerSshRunner {
       }
       const child = spawn(command, args, {
         env: options.baseEnv,
+        signal: options.signal,
         stdio: ["pipe", "pipe", "pipe"],
         windowsHide: true,
       });
       let closed = false;
+      let exitedSettled = false;
       let readySettled = false;
       let resolveReady!: () => void;
       let rejectReady!: (error: Error) => void;
@@ -56,6 +59,9 @@ export function createWorkerSshRunner(): WorkerSshRunner {
         resolveReady = resolve;
         rejectReady = reject;
       });
+      // Readiness can reject after its awaiter timed out and moved on (stop()/late close);
+      // observe it here so lifecycle settles never become unhandled rejections.
+      void ready.catch(() => {});
       const exited = new Promise<WorkerSshProcessExit>((resolve) => {
         resolveExited = resolve;
       });
@@ -67,6 +73,13 @@ export function createWorkerSshRunner(): WorkerSshRunner {
         }
         readySettled = true;
         rejectReady(workerSshProcessError(stderr));
+      };
+      const settleExited = (exit: WorkerSshProcessExit) => {
+        if (exitedSettled) {
+          return;
+        }
+        exitedSettled = true;
+        resolveExited(exit);
       };
       child.stdout.setEncoding("utf8");
       child.stdout.on("error", () => {});
@@ -85,11 +98,34 @@ export function createWorkerSshRunner(): WorkerSshRunner {
       child.stderr.on("data", (chunk: string) => {
         stderr = sliceUtf16Safe(`${stderr}${chunk}`, -STDERR_LIMIT);
       });
-      child.once("error", settleReadyError);
+      child.once("error", () => {
+        settleReadyError();
+        // "error" also fires for abort/kill-delivery failures on a live child; only a child
+        // that never spawned (no pid) gets a synthesized exit, otherwise close/stop() settle it.
+        // The no-pid case is terminal: mark it closed so stop() never signals an unspawned child.
+        if (child.pid === undefined) {
+          closed = true;
+          settleExited({ code: null, signal: null });
+        }
+      });
+      // "exit" fires before "close", and "close" can be delayed indefinitely while a
+      // descendant holds a piped stdio descriptor; settle on the real exit so connected
+      // tunnels awaiting `exited` observe termination without depending on stream closure.
+      let exitEventResult: WorkerSshProcessExit | undefined;
+      child.once("exit", (code, signal) => {
+        exitEventResult = { code, signal };
+        settleReadyError();
+        settleExited(exitEventResult);
+        // Release our pipe ends so a descendant holding the other side cannot pin local
+        // descriptors across retries; this also lets "close" fire promptly.
+        child.stdin.destroy();
+        child.stdout.destroy();
+        child.stderr.destroy();
+      });
       child.once("close", (code, signal) => {
         closed = true;
         settleReadyError();
-        resolveExited({ code, signal });
+        settleExited({ code, signal });
       });
       child.stdin.on("error", () => {});
       if (options.input !== undefined) {
@@ -117,9 +153,32 @@ export function createWorkerSshRunner(): WorkerSshRunner {
               }),
             ]);
             clearTimeout(timer);
-            if (!closed) {
-              child.kill("SIGKILL");
-              await exited;
+            if (!closed && !exitedSettled) {
+              // A false return can also mean the child died a moment ago with its "exit"
+              // event still queued; always take the bounded wait before judging.
+              const killDelivered = child.kill("SIGKILL");
+              let killTimer: ReturnType<typeof setTimeout> | undefined;
+              let killWaitExpired = false;
+              await Promise.race([
+                exited,
+                new Promise<void>((resolve) => {
+                  killTimer = setTimeout(() => {
+                    killWaitExpired = true;
+                    resolve();
+                  }, STOP_KILL_WAIT_MS);
+                  killTimer.unref?.();
+                }),
+              ]);
+              clearTimeout(killTimer);
+              if (killWaitExpired) {
+                // Neither delivered SIGKILL nor failed delivery proves termination without
+                // an exit event; fail the stop so the owner keeps tracking the live child.
+                throw workerSshProcessError(
+                  killDelivered
+                    ? "SSH child did not exit after SIGKILL; it may still be running"
+                    : "SIGKILL delivery failed; SSH child may still be running",
+                );
+              }
             }
           })());
         },

--- a/src/gateway/worker-environments/tunnel.test.ts
+++ b/src/gateway/worker-environments/tunnel.test.ts
@@ -93,6 +93,27 @@ describe("worker tunnel manager", () => {
     await handle.stop();
   });
 
+  it("times out a marker-less SSH child and retries", async () => {
+    vi.useFakeTimers();
+    const fake = fakeRunner();
+    const manager = createWorkerTunnelManager({ runner: fake.runner, sleep: async () => {} });
+    const starting = startTestTunnel(manager, "worker:ready-timeout", 1);
+    const rejected = expect(starting).rejects.toThrow("stopped before connecting");
+
+    try {
+      await waitForStarts(fake.starts, 1);
+      await vi.advanceTimersByTimeAsync(60_000);
+      await waitForStarts(fake.starts, 2);
+
+      expect(fake.starts[0]?.process.stopCount).toBe(1);
+      expect(manager.status("worker:ready-timeout")).toBe("reconnecting");
+    } finally {
+      await manager.stop("worker:ready-timeout");
+      await rejected;
+      vi.useRealTimers();
+    }
+  });
+
   it("reconnects on the next advertised port after SSH transport exit 255", async () => {
     const fake = fakeRunner();
     const manager = createWorkerTunnelManager({

--- a/src/gateway/worker-environments/tunnel.ts
+++ b/src/gateway/worker-environments/tunnel.ts
@@ -1,8 +1,11 @@
 import { RetrySupervisor } from "../../../packages/retry/src/index.js";
 import { sleepWithAbort, type BackoffPolicy } from "../../infra/backoff.js";
+import { withTimeout } from "../../infra/fs-safe.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { WorkerSshEndpoint } from "../../plugins/types.js";
 import type { SpawnResult } from "../../process/exec.js";
 import { createDeferred, type Deferred } from "../../shared/deferred.js";
+import { boundedWorkerError } from "./service-validation.js";
 import {
   advanceWorkerSshAfterTransportExit,
   prepareWorkerSsh,
@@ -30,6 +33,9 @@ import { createWorkerWorkspaceActions, stableWorkerPathComponent } from "./works
 export type { WorkerTunnelHandle } from "./tunnel-contract.js";
 const REMOTE_SOCKET_NAME = "gateway.sock";
 const REMOTE_SETUP_TIMEOUT_MS = 20_000;
+// A live SSH process without the remote marker is not a usable tunnel. Bound each attempt so the
+// retry supervisor can move on instead of pinning the environment forever.
+const TUNNEL_READY_TIMEOUT_MS = 60_000;
 const DEFAULT_STABLE_CONNECTION_MS = 30_000;
 const DEFAULT_BACKOFF: BackoffPolicy = {
   initialMs: 250,
@@ -37,6 +43,7 @@ const DEFAULT_BACKOFF: BackoffPolicy = {
   factor: 2,
   jitter: 0,
 };
+const tunnelLog = createSubsystemLogger("gateway/worker-tunnel");
 
 const REMOTE_SOCKET_SETUP_SCRIPT = String.raw`set -eu
 directory=$1
@@ -50,7 +57,7 @@ if [ -e "$directory" ] || [ -L "$directory" ]; then
 else
   mkdir -- "$directory"
 fi
-chmod 700 -- "$directory"
+chmod 700 "$directory"  # no "--": BSD/macOS chmod treats it as a filename; path is script-owned and absolute
 rm -f -- "$socket"
 `;
 
@@ -281,7 +288,9 @@ export function createWorkerTunnelManager(options: WorkerTunnelManagerOptions = 
         child = connection.process;
         childPort = connection.port;
         entry.process = child;
-        await child.ready;
+        await withTimeout(child.ready, TUNNEL_READY_TIMEOUT_MS, {
+          message: "Worker tunnel did not become ready within 60 seconds",
+        });
         if (!isCurrent(entry)) {
           await child.stop();
           return;
@@ -306,14 +315,41 @@ export function createWorkerTunnelManager(options: WorkerTunnelManagerOptions = 
         if (now() - connectedAtMs >= stableConnectionMs) {
           reconnectSupervisor.reset();
         }
-      } catch {
+      } catch (error) {
         if (child && childPort !== undefined) {
-          const exit = await child.exited.catch(() => undefined);
+          let stopError: unknown;
+          let stopFailed = false;
+          const stopping = child.stop().catch((failure: unknown) => {
+            stopFailed = true;
+            stopError = failure;
+          });
+          let exit = await Promise.race([
+            child.exited.catch(() => undefined),
+            stopping.then(() => undefined),
+          ]);
+          await stopping;
+          if (stopFailed) {
+            // A failed stop means the SSH child may still be running. Never drop it from
+            // tracking and never retry over it — wait for its real exit first, and keep
+            // that late exit so transport-exit port rotation still advances.
+            tunnelLog.warn("worker tunnel stop failed; waiting for SSH child exit", {
+              environmentId: entry.environmentId,
+              error: boundedWorkerError(stopError),
+              connectError: boundedWorkerError(error),
+            });
+            exit = (await child.exited.catch(() => undefined)) ?? exit;
+          }
           if (exit && entry.prepared) {
             advanceWorkerSshAfterTransportExit(entry.prepared, childPort, exit);
           }
         }
-        await child?.stop().catch(() => undefined);
+        if (isCurrent(entry)) {
+          tunnelLog.warn("worker tunnel connect attempt failed", {
+            environmentId: entry.environmentId,
+            attempt: reconnectSupervisor.attempts + 1,
+            error: boundedWorkerError(error),
+          });
+        }
       } finally {
         if (entry.process === child) {
           entry.process = undefined;

--- a/src/gateway/worker-environments/workspace-quiescence-scripts.ts
+++ b/src/gateway/worker-environments/workspace-quiescence-scripts.ts
@@ -92,6 +92,10 @@ function persistLease(targetPath, lease, verifyCurrent) {
   fs.renameSync(temporary, targetPath);
 }`;
 
+// Signal sites tolerate ESRCH (gone) without aborting the protocol. EPERM (exists but
+// unsignalable, e.g. macOS SIP-protected same-uid processes on shared static-ssh dev hosts)
+// must not crash cleanup/resume paths, but a freeze target that returns EPERM stays counted
+// as live so quiescence fails closed instead of reporting a still-running process as frozen.
 export const REMOTE_WORKSPACE_QUIESCE_JS = String.raw`const childProcess = require("node:child_process");
 const crypto = require("node:crypto");
 const fs = require("node:fs");
@@ -123,13 +127,15 @@ function writeLease(expiresAtMs = Date.now() + watchdogTimeoutMs) {
     expiresAtMs,
   });
 }
+// EPERM on SIGCONT implies the target was never ours to freeze: kill permission checks are
+// identical for SIGSTOP and SIGCONT, so any process this uid successfully stopped can be resumed.
 function resumeProcesses(entries) {
   for (const entry of entries) {
     if (processIdentity(entry.pid) !== entry.start) continue;
     try {
       process.kill(entry.pid, "SIGCONT");
     } catch (error) {
-      if (!error || error.code !== "ESRCH") throw error;
+      if (!error || (error.code !== "ESRCH" && error.code !== "EPERM")) throw error;
     }
   }
 }
@@ -143,7 +149,7 @@ for (const name of orphanNames) {
   const orphanPath = path.join(leaseDirectory, name);
   const lease = parseLease(fs.readFileSync(orphanPath, "utf8"), match[1]);
   if (lease.watchdog !== null && processIdentity(lease.watchdog.pid) === lease.watchdog.start) {
-    try { process.kill(lease.watchdog.pid, "SIGTERM"); } catch (error) { if (!error || error.code !== "ESRCH") throw error; }
+    try { process.kill(lease.watchdog.pid, "SIGTERM"); } catch (error) { if (!error || (error.code !== "ESRCH" && error.code !== "EPERM")) throw error; }
   }
   resumeProcesses(lease.processes);
   fs.unlinkSync(orphanPath);
@@ -194,6 +200,11 @@ try {
         }
         process.kill(pid, "SIGSTOP");
       } catch (error) {
+        if (error && error.code === "EPERM") {
+          frozen.delete(pid);
+          writeLease();
+          continue;
+        }
         if (!error || error.code !== "ESRCH") throw error;
       }
     }
@@ -210,7 +221,7 @@ try {
   }
 } catch (error) {
   if (processIdentity(watchdog.pid) === watchdogStart) {
-    try { process.kill(watchdog.pid, "SIGTERM"); } catch (killError) { if (!killError || killError.code !== "ESRCH") throw killError; }
+    try { process.kill(watchdog.pid, "SIGTERM"); } catch (killError) { if (!killError || (killError.code !== "ESRCH" && killError.code !== "EPERM")) throw killError; }
   }
   resumeProcesses([...frozen].map(([pid, start]) => ({ pid, start })));
   try { fs.unlinkSync(leasePath); } catch (unlinkError) { if (!unlinkError || unlinkError.code !== "ENOENT") throw unlinkError; }
@@ -254,7 +265,7 @@ function watchdogMain(watchedLeasePath, watchedNonce) {
           typeof entry.start !== "string" ||
           processIdentity(entry.pid) !== entry.start
         ) continue;
-        try { process.kill(entry.pid, "SIGCONT"); } catch (error) { if (!error || error.code !== "ESRCH") throw error; }
+        try { process.kill(entry.pid, "SIGCONT"); } catch (error) { if (!error || (error.code !== "ESRCH" && error.code !== "EPERM")) throw error; }
       }
       watchdogFs.unlinkSync(watchedLeasePath);
     } catch (error) {
@@ -345,7 +356,9 @@ if (validationMode === "final") {
         if (input.expiresAtMs - Date.now() < 2500) refreshLease(frozenEntries);
         process.kill(pid, "SIGSTOP");
       } catch (error) {
-        if (!error || error.code !== "ESRCH") throw error;
+        if (!error || (error.code !== "ESRCH" && error.code !== "EPERM")) throw error;
+        // Fail-closed either way: the candidate scan below runs without the frozen filter,
+        // so an EPERM-live process re-registers as a candidate and blocks quiescence.
         frozen.delete(pid);
       }
     }
@@ -393,11 +406,11 @@ ${REMOTE_QUIESCENCE_PS_JS}
 ${REMOTE_QUIESCENCE_LEASE_JS}
 const input = parseLease(raw, nonce);
 if (input.watchdog !== null && processIdentity(input.watchdog.pid) === input.watchdog.start) {
-  try { process.kill(input.watchdog.pid, "SIGTERM"); } catch (error) { if (!error || error.code !== "ESRCH") throw error; }
+  try { process.kill(input.watchdog.pid, "SIGTERM"); } catch (error) { if (!error || (error.code !== "ESRCH" && error.code !== "EPERM")) throw error; }
 }
 for (const entry of input.processes) {
   if (processIdentity(entry.pid) !== entry.start) continue;
-  try { process.kill(entry.pid, "SIGCONT"); } catch (error) { if (!error || error.code !== "ESRCH") throw error; }
+  try { process.kill(entry.pid, "SIGCONT"); } catch (error) { if (!error || (error.code !== "ESRCH" && error.code !== "EPERM")) throw error; }
 }
 fs.unlinkSync(leasePath);
 `;


### PR DESCRIPTION
## What Problem This Solves

Live stress-testing the cloud-workers feature (Control UI → New Session → Cloud target, qa-lab `static-ssh` provider against a real sshd, real dispatch/bootstrap) surfaced three severe, independently reproducible gateway bugs:

1. **"No models available" forever after a gateway restart.** `chat.metadata` builds its prepared generation while the runtime auth-profile store snapshot is not yet published, silently substituting an empty store, and `generationFactsMatch` never compared auth-store state — so the wrong projection (every model `available: false`) was cached until an unrelated config edit forced a rebuild. The Control UI new-session page and chat composer read `chat.metadata`, so the operator could not create any session (cloud or local) from any tab. Reproduced live: `models.list` said `available: true` while `chat.metadata` said `false` for the same model, across restarts and fresh tabs.
2. **Dispatch failures hide the recorded, actionable reason.** `sessions.dispatch` returned bare `Worker provider rejected profile` / `Worker bootstrap failed` while the real cause (e.g. `Worker bootstrap requires Node.js on the leased host; install Node in the provider setup phase and retry`) was written only to the `worker_environments.last_error` DB column. docs/gateway/cloud-workers.md's Troubleshooting section explicitly quotes those detailed messages as operator-visible, so shipped behavior contradicted the docs.
3. **`sessions.dispatch` hangs unbounded when the worker SSH tunnel cannot connect.** Observed live: placement stuck in `syncing` for 12+ minutes (returned only after a manual `environments.destroy`), UI spinner forever, leaked worker + placement, navigation unable to cancel. Mechanisms (traced and now regression-tested): the ssh child's `exited` promise settles only on `close` (a spawn `error` never settles it, parking the reconnect loop forever), no readiness deadline on the tunnel child or on `startTunnel`, the abort signal was never wired into `spawn`, the poisoned `entry.ready` promise was re-handed to every later dispatch on the same owner epoch, and every connect failure was swallowed by a bare `catch {}` with no logger in the file.

## Why This Change Was Made

Cloud session creation is a default operator path; all three defects end in silent failure or an operator dead end (worst bug class per repo doctrine). Fixes are at the owning boundaries:

- `chat-metadata-runtime.ts`: per-agent auth-store snapshot revision captured into generation facts and compared in `generationFactsMatch`; `server-chat-metadata-lifecycle.ts` additionally subscribes to runtime auth-store mutations and performs one revision-aware catch-up refresh after listener registration (publications that precede registration were otherwise never observed).
- `worker-environments/service.ts`: the five dispatch-visible error messages now append the already-computed `boundedWorkerError` detail (redacted, 1 KiB cap) instead of discarding it.
- `worker-environments/tunnel-ssh-runner.ts` / `tunnel.ts` / `service.ts`: `exited` settles on spawn `error` and after a bounded post-SIGKILL wait; the owner abort signal is wired into `spawn`; each tunnel attempt has a 60s readiness deadline; `startTunnel` has a 3-minute overall deadline that stops the tunnel entry and fails dispatch with a typed, actionable error; connect failures are logged (bounded) via a `gateway/worker-tunnel` subsystem logger.

4. **Worker tunnels can never connect to macOS hosts.** Once the new tunnel logging existed, the live failure cause became visible on the first retry: the remote socket setup script runs `chmod 700 -- "$directory"`, and BSD/macOS `chmod` treats `--` as a filename (`chmod: --: No such file or directory`), so every tunnel attempt to a Mac worker host fails and previously looped silently forever. Fixed by dropping the `--` (the path is script-owned and absolute); `mkdir --`/`rm -f --` are BSD-compatible and unchanged.

## User Impact

- After a gateway restart (config reload, update), the Control UI reliably regains its model catalog; session creation is no longer blocked by a stale "No models available".
- Failed cloud dispatches tell the operator what actually went wrong, matching the documented messages.
- A tunnel that cannot connect now fails the dispatch within minutes with a clear error and a torn-down environment instead of hanging the RPC indefinitely and leaking the worker/lease.

## Evidence

- Live before/after on a real gateway (isolated state dir, qa-lab static-ssh worker on localhost sshd, real Control UI driven in a browser):
  - Before: `sessions.dispatch` errors were bare (`Worker provider rejected profile`, `Worker bootstrap failed`) with the reason only in `worker_environments.last_error`; a tunnel-connect failure hung the dispatch RPC for `732160ms` (12.2 min) until a manual `environments.destroy`, with the UI spinning and the worker leaked; tunnel retries were completely silent.
  - After: dispatch failures carry the detail (UI showed `cloud startup failed: Worker tunnel did not connect within 3 minutes; check worker SSH reachability and retry` at `198790ms`, the configured deadline); every tunnel attempt logs `worker tunnel connect attempt failed` with the bounded ssh error — which immediately exposed the macOS chmod bug (`chmod: --: No such file or directory`). With that fixed, the full happy path completed: `sessions.dispatch` in `12777ms`, placement `active`, environment `attached`, first turn executed on the worker with the reply streamed to the Control UI.
  - `chat.metadata` regression coverage reproduces the live staleness shape (generation built with an unavailable auth store stays cached; a published store with a bumped revision now rebuilds it).
- Focused tests: `node scripts/run-vitest.mjs src/gateway/worker-environments/tunnel-ssh-runner.test.ts src/gateway/worker-environments/tunnel.test.ts src/gateway/worker-environments/service.test.ts src/gateway/server-methods/chat-metadata-runtime.test.ts` → 4 files, 109+ tests green (includes new regressions: auth-revision rebuild, retained-cache no-rebuild, provider-error detail in all five messages, spawn-error settles `exited`, bounded post-SIGKILL stop, abort wiring, marker-less child timeout+retry, `startTunnel` deadline).
- `node scripts/check-changed.mjs`: typecheck core + core tests green; lint green after fixing an unbound-method finding in the new runner test.

This PR also fixes a fifth bug found once reconciliation became reachable: the workspace quiescence script crashed mid-protocol on `kill EPERM` (only `ESRCH` was tolerated), aborting reconcile with a raw stack instead of a diagnosable outcome. EPERM no longer crashes cleanup/resume paths; a freeze target that returns EPERM is un-marked so scans keep counting it as live and quiescence fails closed (a still-running unsignalable process is never reported as frozen — reviewer-hardened semantics).

Follow-ups filed separately (found in the same stress run, out of scope here): startup publishes an empty runtime auth-store snapshot that nothing rehydrates until first inference (`models.list` vs `chat.metadata` availability divergence); quiescence's uid-wide freeze cannot converge on shared static-ssh dev hosts; UI orphan-cleanup on transient describe failures; `ownership-lost` silent dead end; terminal `failed` placement having no redispatch path; un-argumented `reconcileActive` after `environments.destroy`; no "Stop cloud worker" menu item for a `syncing` placement.
