### PR TITLE
refactor(plugins): simplify activation compatibility flow

### DIFF
--- a/src/plugins/activation-context.test.ts
+++ b/src/plugins/activation-context.test.ts
@@ -16,19 +16,27 @@ const applyPluginAutoEnableMock = vi.hoisted(() =>
     autoEnabledReasons: {},
   })),
 );
+const withBundledPluginEnablementCompatMock = vi.hoisted(() =>
+  vi.fn((params: { config?: OpenClawConfig }) => params.config),
+);
 
 vi.mock("../config/plugin-auto-enable.js", () => ({
   applyPluginAutoEnable: applyPluginAutoEnableMock,
 }));
+vi.mock("./bundled-compat.js", () => ({
+  withBundledPluginEnablementCompat: withBundledPluginEnablementCompatMock,
+}));
 
 import {
-  resolveBundledPluginCompatibleActivationInputs,
+  resolveBundledCompatActivationInputs,
+  resolvePluginActivationInputs,
   withActivatedPluginIds,
 } from "./activation-context.js";
 
 afterEach(() => {
   clearCurrentPluginMetadataSnapshot();
   applyPluginAutoEnableMock.mockClear();
+  withBundledPluginEnablementCompatMock.mockClear();
 });
 
 describe("withActivatedPluginIds", () => {
@@ -58,7 +66,7 @@ describe("withActivatedPluginIds", () => {
   });
 });
 
-describe("resolveBundledPluginCompatibleActivationInputs", () => {
+describe("plugin activation inputs", () => {
   it("passes the current manifest registry into activation auto-enable", () => {
     const manifestRegistry = makeRegistry([{ id: "openai", channels: [], providers: ["openai"] }]);
     const workspaceDir = "/tmp/openclaw-activation-workspace";
@@ -74,12 +82,10 @@ describe("resolveBundledPluginCompatibleActivationInputs", () => {
       },
     );
 
-    resolveBundledPluginCompatibleActivationInputs({
+    resolvePluginActivationInputs({
       rawConfig: { plugins: { allow: ["openai"] } },
       workspaceDir,
       applyAutoEnable: true,
-      compatMode: {},
-      resolveCompatPluginIds: () => [],
     });
 
     expect(applyPluginAutoEnableMock).toHaveBeenCalledWith({
@@ -103,13 +109,11 @@ describe("resolveBundledPluginCompatibleActivationInputs", () => {
       [firstManifestRegistry, firstDiscovery],
       [secondManifestRegistry, secondDiscovery],
     ] as const) {
-      resolveBundledPluginCompatibleActivationInputs({
+      resolvePluginActivationInputs({
         rawConfig: { plugins: { allow: [manifestRegistry.plugins[0]!.id] } },
         manifestRegistry,
         discovery,
         applyAutoEnable: true,
-        compatMode: {},
-        resolveCompatPluginIds: () => [],
       });
     }
 
@@ -125,5 +129,50 @@ describe("resolveBundledPluginCompatibleActivationInputs", () => {
       manifestRegistry: secondManifestRegistry,
       discovery: secondDiscovery,
     });
+  });
+
+  it("applies bundled enablement once after canonical auto-enable", () => {
+    const rawConfig = { plugins: { allow: ["openai"] } } satisfies OpenClawConfig;
+    const autoEnabledConfig = {
+      plugins: { allow: ["openai"], entries: { openai: { enabled: true } } },
+    } satisfies OpenClawConfig;
+    const compatConfig = {
+      plugins: {
+        allow: ["openai", "anthropic"],
+        entries: { openai: { enabled: true }, anthropic: { enabled: true } },
+      },
+    } satisfies OpenClawConfig;
+    const resolveBundledPluginIds = vi.fn(() => ["anthropic"]);
+    applyPluginAutoEnableMock.mockReturnValueOnce({
+      config: autoEnabledConfig,
+      changes: [],
+      autoEnabledReasons: { openai: ["configured"] },
+    });
+    withBundledPluginEnablementCompatMock.mockReturnValueOnce(compatConfig);
+
+    const activation = resolveBundledCompatActivationInputs({
+      rawConfig,
+      env: process.env,
+      workspaceDir: "/tmp/openclaw-activation-workspace",
+      onlyPluginIds: ["anthropic"],
+      applyAutoEnable: true,
+      resolveBundledPluginIds,
+    });
+
+    expect(resolveBundledPluginIds).toHaveBeenCalledWith({
+      config: autoEnabledConfig,
+      workspaceDir: "/tmp/openclaw-activation-workspace",
+      env: process.env,
+      onlyPluginIds: ["anthropic"],
+    });
+    expect(withBundledPluginEnablementCompatMock).toHaveBeenCalledOnce();
+    expect(withBundledPluginEnablementCompatMock).toHaveBeenCalledWith({
+      config: autoEnabledConfig,
+      pluginIds: ["anthropic"],
+    });
+    expect(activation.config).toBe(compatConfig);
+    expect(activation.normalized.entries.anthropic?.enabled).toBe(true);
+    expect(activation.activationSourceConfig).toBe(rawConfig);
+    expect(activation.autoEnabledReasons).toEqual({ openai: ["configured"] });
   });
 });

--- a/src/plugins/activation-context.ts
+++ b/src/plugins/activation-context.ts
@@ -12,14 +12,6 @@ import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snap
 import type { PluginDiscoveryResult } from "./discovery.js";
 import type { PluginManifestRegistry } from "./manifest-registry.js";
 
-type PluginActivationCompatConfig = {
-  enablementPluginIds?: readonly string[];
-};
-
-export type PluginActivationBundledCompatMode = {
-  enablement?: "always";
-};
-
 type PluginActivationInputs = {
   rawConfig?: OpenClawConfig;
   config?: OpenClawConfig;
@@ -29,32 +21,25 @@ type PluginActivationInputs = {
   autoEnabledReasons: Record<string, string[]>;
 };
 
-type BundledPluginCompatibleActivationInputs = PluginActivationInputs & {
-  compatPluginIds: string[];
-};
-
-type BundledPluginCompatibleLoadValues = Pick<
-  BundledPluginCompatibleActivationInputs,
-  "rawConfig" | "config" | "activationSourceConfig" | "autoEnabledReasons" | "compatPluginIds"
->;
-
-type BundledPluginCompatibleActivationParams = {
+type PluginActivationParams = {
   rawConfig?: OpenClawConfig;
   resolvedConfig?: OpenClawConfig;
   autoEnabledReasons?: Record<string, string[]>;
   env?: NodeJS.ProcessEnv;
   workspaceDir?: string;
-  onlyPluginIds?: readonly string[];
   applyAutoEnable?: boolean;
-  compatMode: PluginActivationBundledCompatMode;
-  resolveCompatPluginIds: (params: {
+  discovery?: PluginDiscoveryResult;
+  manifestRegistry?: PluginManifestRegistry;
+};
+
+type BundledCompatActivationParams = PluginActivationParams & {
+  onlyPluginIds?: readonly string[];
+  resolveBundledPluginIds: (params: {
     config?: OpenClawConfig;
     workspaceDir?: string;
     env?: NodeJS.ProcessEnv;
     onlyPluginIds?: readonly string[];
   }) => string[];
-  discovery?: PluginDiscoveryResult;
-  manifestRegistry?: PluginManifestRegistry;
 };
 
 export function withActivatedPluginIds(params: {
@@ -101,34 +86,6 @@ export function withActivatedPluginIds(params: {
   };
 }
 
-function applyPluginCompatibilityOverrides(params: {
-  config?: OpenClawConfig;
-  compat?: PluginActivationCompatConfig;
-}): OpenClawConfig | undefined {
-  return params.compat?.enablementPluginIds?.length
-    ? withBundledPluginEnablementCompat({
-        config: params.config,
-        pluginIds: params.compat.enablementPluginIds,
-      })
-    : params.config;
-}
-
-function shouldResolveBundledCompatPluginIds(params: {
-  compatMode: PluginActivationBundledCompatMode;
-}): boolean {
-  return params.compatMode.enablement === "always";
-}
-
-function createBundledPluginCompatConfig(params: {
-  compatMode: PluginActivationBundledCompatMode;
-  compatPluginIds: string[];
-}): PluginActivationCompatConfig {
-  return {
-    enablementPluginIds:
-      params.compatMode.enablement === "always" ? params.compatPluginIds : undefined,
-  };
-}
-
 function applyPluginAutoEnableForActivation(params: {
   config: OpenClawConfig;
   env: NodeJS.ProcessEnv;
@@ -166,16 +123,9 @@ function applyPluginAutoEnableForActivation(params: {
   });
 }
 
-function resolvePluginActivationSnapshot(params: {
-  rawConfig?: OpenClawConfig;
-  resolvedConfig?: OpenClawConfig;
-  autoEnabledReasons?: Record<string, string[]>;
-  env?: NodeJS.ProcessEnv;
-  workspaceDir?: string;
-  applyAutoEnable?: boolean;
-  discovery?: PluginDiscoveryResult;
-  manifestRegistry?: PluginManifestRegistry;
-}): PluginActivationInputs {
+export function resolvePluginActivationInputs(
+  params: PluginActivationParams,
+): PluginActivationInputs {
   const env = params.env ?? process.env;
   const rawConfig = params.rawConfig ?? params.resolvedConfig;
   let resolvedConfig = params.resolvedConfig ?? params.rawConfig;
@@ -205,19 +155,11 @@ function resolvePluginActivationSnapshot(params: {
   };
 }
 
-function resolvePluginActivationInputs(params: {
-  rawConfig?: OpenClawConfig;
-  resolvedConfig?: OpenClawConfig;
-  autoEnabledReasons?: Record<string, string[]>;
-  env?: NodeJS.ProcessEnv;
-  workspaceDir?: string;
-  compat?: PluginActivationCompatConfig;
-  applyAutoEnable?: boolean;
-  discovery?: PluginDiscoveryResult;
-  manifestRegistry?: PluginManifestRegistry;
-}): PluginActivationInputs {
+export function resolveBundledCompatActivationInputs(
+  params: BundledCompatActivationParams,
+): PluginActivationInputs {
   const env = params.env ?? process.env;
-  const snapshot = resolvePluginActivationSnapshot({
+  const snapshot = resolvePluginActivationInputs({
     rawConfig: params.rawConfig,
     resolvedConfig: params.resolvedConfig,
     autoEnabledReasons: params.autoEnabledReasons,
@@ -227,109 +169,20 @@ function resolvePluginActivationInputs(params: {
     discovery: params.discovery,
     manifestRegistry: params.manifestRegistry,
   });
-  const config = applyPluginCompatibilityOverrides({
+  const bundledPluginIds = params.resolveBundledPluginIds({
     config: snapshot.config,
-    compat: params.compat,
+    workspaceDir: params.workspaceDir,
+    env,
+    onlyPluginIds: params.onlyPluginIds,
+  });
+  const config = withBundledPluginEnablementCompat({
+    config: snapshot.config,
+    pluginIds: bundledPluginIds,
   });
 
   return {
-    rawConfig: snapshot.rawConfig,
+    ...snapshot,
     config,
     normalized: normalizePluginsConfig(config?.plugins),
-    activationSourceConfig: snapshot.activationSourceConfig,
-    activationSource: snapshot.activationSource,
-    autoEnabledReasons: snapshot.autoEnabledReasons,
-  };
-}
-
-export function resolveBundledPluginCompatibleActivationInputs(
-  params: BundledPluginCompatibleActivationParams,
-): BundledPluginCompatibleActivationInputs {
-  const snapshot = resolvePluginActivationSnapshot({
-    rawConfig: params.rawConfig,
-    resolvedConfig: params.resolvedConfig,
-    autoEnabledReasons: params.autoEnabledReasons,
-    env: params.env,
-    workspaceDir: params.workspaceDir,
-    applyAutoEnable: params.applyAutoEnable,
-    discovery: params.discovery,
-    manifestRegistry: params.manifestRegistry,
-  });
-  const shouldResolveCompatPluginIds = shouldResolveBundledCompatPluginIds({
-    compatMode: params.compatMode,
-  });
-  const compatPluginIds = shouldResolveCompatPluginIds
-    ? params.resolveCompatPluginIds({
-        config: snapshot.config,
-        workspaceDir: params.workspaceDir,
-        env: params.env,
-        onlyPluginIds: params.onlyPluginIds,
-      })
-    : [];
-  const activation = resolvePluginActivationInputs({
-    rawConfig: snapshot.rawConfig,
-    resolvedConfig: snapshot.config,
-    autoEnabledReasons: snapshot.autoEnabledReasons,
-    env: params.env,
-    workspaceDir: params.workspaceDir,
-    compat: createBundledPluginCompatConfig({
-      compatMode: params.compatMode,
-      compatPluginIds,
-    }),
-    discovery: params.discovery,
-    manifestRegistry: params.manifestRegistry,
-  });
-
-  return {
-    ...activation,
-    compatPluginIds,
-  };
-}
-
-export function resolveBundledPluginCompatibleLoadValues(
-  params: BundledPluginCompatibleActivationParams,
-): BundledPluginCompatibleLoadValues {
-  const env = params.env ?? process.env;
-  const rawConfig = params.rawConfig ?? params.resolvedConfig;
-  let resolvedConfig = params.resolvedConfig ?? params.rawConfig;
-  let autoEnabledReasons = params.autoEnabledReasons ?? {};
-
-  if (params.applyAutoEnable && rawConfig !== undefined) {
-    const autoEnabled = applyPluginAutoEnableForActivation({
-      config: rawConfig,
-      env,
-      workspaceDir: params.workspaceDir,
-      discovery: params.discovery,
-      manifestRegistry: params.manifestRegistry,
-    });
-    resolvedConfig = autoEnabled.config;
-    autoEnabledReasons = autoEnabled.autoEnabledReasons;
-  }
-
-  const shouldResolveCompatPluginIds = shouldResolveBundledCompatPluginIds({
-    compatMode: params.compatMode,
-  });
-  const compatPluginIds = shouldResolveCompatPluginIds
-    ? params.resolveCompatPluginIds({
-        config: resolvedConfig,
-        workspaceDir: params.workspaceDir,
-        env,
-        onlyPluginIds: params.onlyPluginIds,
-      })
-    : [];
-  const config = applyPluginCompatibilityOverrides({
-    config: resolvedConfig,
-    compat: createBundledPluginCompatConfig({
-      compatMode: params.compatMode,
-      compatPluginIds,
-    }),
-  });
-
-  return {
-    rawConfig,
-    config,
-    activationSourceConfig: rawConfig,
-    autoEnabledReasons,
-    compatPluginIds,
   };
 }

--- a/src/plugins/bundled-capability-runtime.ts
+++ b/src/plugins/bundled-capability-runtime.ts
@@ -10,17 +10,6 @@ import type { PluginSdkResolutionPreference } from "./sdk-alias.js";
 
 const log = createSubsystemLogger("plugins");
 
-function buildBundledCapabilityRuntimeConfig(
-  pluginIds: readonly string[],
-  config?: PluginLoadOptions["config"],
-): NonNullable<PluginLoadOptions["config"]> {
-  // Only the speech owner may opt into legacy global-disable compatibility before capture.
-  if (config?.plugins?.enabled === false) {
-    return config;
-  }
-  return withBundledPluginEnablementCompat({ config, pluginIds }) ?? {};
-}
-
 function createCapabilityRegistrationRuntime(
   config: NonNullable<PluginLoadOptions["config"]>,
 ): Pick<PluginRuntime, "config"> {
@@ -45,7 +34,14 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
   discovery?: PluginDiscoveryResult;
 }) {
   const env = params.env ?? process.env;
-  const config = buildBundledCapabilityRuntimeConfig(params.pluginIds, params.config);
+  // Only the speech owner may opt into legacy global-disable compatibility before capture.
+  const config =
+    params.config?.plugins?.enabled === false
+      ? params.config
+      : (withBundledPluginEnablementCompat({
+          config: params.config,
+          pluginIds: params.pluginIds,
+        }) ?? {});
   const discovery = params.discovery ?? discoverOpenClawPlugins({ env });
   const pluginIds = new Set(params.pluginIds);
   const manifestRegistry = loadPluginManifestRegistry({

--- a/src/plugins/bundled-compat.test.ts
+++ b/src/plugins/bundled-compat.test.ts
@@ -9,7 +9,15 @@ vi.mock("./bundled-discovery-state.js", () => ({ readBundledDiscoveryMode }));
 
 describe("withBundledPluginEnablementCompat", () => {
   beforeEach(() => {
+    readBundledDiscoveryMode.mockClear();
     readBundledDiscoveryMode.mockReturnValue("allowlist");
+  });
+
+  it("returns unchanged config for an empty plugin list without reading upgrade state", () => {
+    const config = { plugins: { allow: ["openai"] } } satisfies OpenClawConfig;
+
+    expect(withBundledPluginEnablementCompat({ config, pluginIds: [] })).toBe(config);
+    expect(readBundledDiscoveryMode).not.toHaveBeenCalled();
   });
 
   it("honors bundledDiscovery compat before plugin allowlists", () => {

--- a/src/plugins/bundled-compat.ts
+++ b/src/plugins/bundled-compat.ts
@@ -9,6 +9,9 @@ export function withBundledPluginEnablementCompat(params: {
   config: OpenClawConfig | undefined;
   pluginIds: readonly string[];
 }): OpenClawConfig | undefined {
+  if (params.pluginIds.length === 0) {
+    return params.config;
+  }
   const existingEntries = params.config?.plugins?.entries ?? {};
   const forcePluginsEnabled = params.config?.plugins?.enabled === false;
   const allow = params.config?.plugins?.allow;
@@ -51,10 +54,7 @@ export function withBundledPluginEnablementCompat(params: {
       ...params.config?.plugins,
       ...(forcePluginsEnabled ? { enabled: true } : {}),
       ...(nextAllow ? { allow: [...nextAllow] } : {}),
-      entries: {
-        ...existingEntries,
-        ...nextEntries,
-      },
+      entries: nextEntries,
     },
   };
 }

--- a/src/plugins/bundled-manifest-contract-plugins.test.ts
+++ b/src/plugins/bundled-manifest-contract-plugins.test.ts
@@ -38,18 +38,12 @@ describe("resolveEnabledBundledManifestContractPlugins", () => {
     expect(
       resolveEnabledBundledManifestContractPlugins({
         contract: "documentExtractors",
-        compatMode: {
-          enablement: "always",
-        },
       }).map((plugin) => plugin.id),
     ).toStrictEqual(["document-extract"]);
     expect(
       resolveEnabledBundledManifestContractPlugins({
         onlyPluginIds: [],
         contract: "documentExtractors",
-        compatMode: {
-          enablement: "always",
-        },
       }),
     ).toStrictEqual([]);
   });

--- a/src/plugins/bundled-manifest-contract-plugins.ts
+++ b/src/plugins/bundled-manifest-contract-plugins.ts
@@ -1,14 +1,7 @@
 /** Resolves enabled bundled plugins that advertise a specific manifest contract list. */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  resolveBundledPluginCompatibleLoadValues,
-  type PluginActivationBundledCompatMode,
-} from "./activation-context.js";
-import {
-  createPluginActivationSource,
-  normalizePluginsConfig,
-  resolveEffectivePluginActivationState,
-} from "./config-state.js";
+import { resolveBundledCompatActivationInputs } from "./activation-context.js";
+import { resolveEffectivePluginActivationState } from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
 import { loadManifestContractSnapshot } from "./manifest-contract-eligibility.js";
 import type { PluginManifestContractListKey, PluginManifestRecord } from "./manifest-registry.js";
@@ -39,7 +32,6 @@ export function resolveEnabledBundledManifestContractPlugins(params: {
   env?: NodeJS.ProcessEnv;
   onlyPluginIds?: readonly string[];
   contract: PluginManifestContractListKey;
-  compatMode: PluginActivationBundledCompatMode;
 }): PluginManifestRecord[] {
   if (params.config?.plugins?.enabled === false) {
     return [];
@@ -54,23 +46,18 @@ export function resolveEnabledBundledManifestContractPlugins(params: {
     return manifestRecords;
   };
 
-  const activation = resolveBundledPluginCompatibleLoadValues({
+  const activation = resolveBundledCompatActivationInputs({
     rawConfig: params.config,
     env: params.env,
     workspaceDir: params.workspaceDir,
     onlyPluginIds: params.onlyPluginIds,
     applyAutoEnable: true,
-    compatMode: params.compatMode,
-    resolveCompatPluginIds: (compatParams) =>
+    resolveBundledPluginIds: (compatParams) =>
       listBundledManifestContractPluginIds({
         plugins: loadManifestRecords(compatParams.config),
         contract: params.contract,
         onlyPluginIds: compatParams.onlyPluginIds,
       }),
-  });
-  const normalizedPlugins = normalizePluginsConfig(activation.config?.plugins);
-  const activationSource = createPluginActivationSource({
-    config: activation.activationSourceConfig,
   });
   const onlyPluginIdSet = createPluginIdScopeSet(params.onlyPluginIds);
   return loadManifestRecords(activation.config).filter((plugin) => {
@@ -84,10 +71,10 @@ export function resolveEnabledBundledManifestContractPlugins(params: {
     return resolveEffectivePluginActivationState({
       id: plugin.id,
       origin: plugin.origin,
-      config: normalizedPlugins,
+      config: activation.normalized,
       rootConfig: activation.config,
       enabledByDefault: isPluginEnabledByDefaultForPlatform(plugin),
-      activationSource,
+      activationSource: activation.activationSource,
     }).enabled;
   });
 }

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -1487,6 +1487,7 @@ describe("resolvePluginCapabilityProviders", () => {
 
     expect(provider?.id).toBe("openai");
     expectActiveRegistryLookup(["deepgram", "openai"]);
+    expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledOnce();
   });
 
   it("prefers a canonical provider id over an earlier provider alias", () => {
@@ -1538,6 +1539,33 @@ describe("resolvePluginCapabilityProviders", () => {
     });
 
     expectResolvedCapabilityProviderIds(providers, ["openai", "microsoft"]);
+  });
+
+  it("reuses one manifest snapshot for multiple requested speech providers", () => {
+    const loaded = createEmptyPluginRegistry();
+    addSpeechProvider(loaded, "google");
+    addSpeechProvider(loaded, "microsoft");
+    setCapabilityManifestPlugins([
+      { id: "google", contracts: { speechProviders: ["google"] } },
+      { id: "microsoft", contracts: { speechProviders: ["microsoft"] } },
+    ]);
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined ? undefined : loaded,
+    );
+
+    const providers = resolvePluginCapabilityProviders({
+      key: "speechProviders",
+      cfg: {
+        tts: {
+          provider: "google",
+          providers: { microsoft: {} },
+        },
+      } as OpenClawConfig,
+    });
+
+    expectResolvedCapabilityProviderIds(providers, ["google", "microsoft"]);
+    expectActiveRegistryLookup(["google", "microsoft"]);
+    expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledOnce();
   });
 
   it.each([
@@ -1728,6 +1756,7 @@ describe("resolvePluginCapabilityProviders", () => {
     });
     expectInitialRuntimeRegistryLookup();
     expectActiveRegistryLookup(["microsoft"]);
+    expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledOnce();
   });
 
   it.each([

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -386,6 +386,7 @@ function resolveRequestedCapabilityPluginIds(params: {
   key: CapabilityProviderRegistryKey;
   cfg?: OpenClawConfig;
   requested?: Set<string>;
+  pluginMetadataSnapshot: Pick<PluginMetadataSnapshot, "index" | "plugins">;
 }): CapabilityPluginResolution | undefined {
   if (!params.requested || params.requested.size === 0) {
     return undefined;
@@ -397,6 +398,7 @@ function resolveRequestedCapabilityPluginIds(params: {
       key: params.key,
       cfg: params.cfg,
       providerId,
+      pluginMetadataSnapshot: params.pluginMetadataSnapshot,
     });
     for (const pluginId of resolution.runtimePluginIds) {
       runtimePluginIds.add(pluginId);
@@ -510,16 +512,22 @@ export function resolvePluginCapabilityProvider<K extends CapabilityProviderRegi
     return activeProvider;
   }
 
+  const pluginMetadataSnapshot = loadCapabilityManifestSnapshot({ cfg: params.cfg });
   let pluginIds = resolveCapabilityPluginIds({
     key: params.key,
     cfg: params.cfg,
     providerId: params.providerId,
+    pluginMetadataSnapshot,
   });
   if (pluginIds.runtimePluginIds.length === 0) {
     // Manifest contracts index canonical provider ids, while runtime providers
     // may expose aliases. Fall back to the capability owners so a configured
     // alias can still resolve when its provider is absent from the active registry.
-    pluginIds = resolveCapabilityPluginIds({ key: params.key, cfg: params.cfg });
+    pluginIds = resolveCapabilityPluginIds({
+      key: params.key,
+      cfg: params.cfg,
+      pluginMetadataSnapshot,
+    });
     if (pluginIds.runtimePluginIds.length === 0) {
       return undefined;
     }
@@ -585,10 +593,12 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
     requestedProviders && shouldScopeCapabilityLoadToRequestedProviders(params.key)
       ? requestedProviders
       : undefined;
+  const pluginMetadataSnapshot = loadCapabilityManifestSnapshot({ cfg: params.cfg });
   const requestedPluginIds = resolveRequestedCapabilityPluginIds({
     key: params.key,
     cfg: params.cfg,
     requested: requestedProviderLoadScope,
+    pluginMetadataSnapshot,
   });
   const requestedProviderFilter =
     requestedProviders &&
@@ -600,6 +610,7 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
     resolveCapabilityPluginIds({
       key: params.key,
       cfg: params.cfg,
+      pluginMetadataSnapshot,
     });
   const loadOptions = createCapabilityProviderLoadOptions({
     cfg: params.cfg,

--- a/src/plugins/document-extractors.runtime.ts
+++ b/src/plugins/document-extractors.runtime.ts
@@ -61,9 +61,6 @@ export function resolvePluginDocumentExtractors(params?: {
       env: params?.env,
       onlyPluginIds: params?.onlyPluginIds,
       contract: "documentExtractors",
-      compatMode: {
-        enablement: "always",
-      },
     }).map((plugin) => plugin.id);
   for (const pluginId of pluginIds) {
     let loaded: PluginDocumentExtractorEntry[] | null;

--- a/src/plugins/loader-module-runtime.ts
+++ b/src/plugins/loader-module-runtime.ts
@@ -109,7 +109,6 @@ export function runPluginRegisterSyncInRegistry(
 export function createPluginModuleLoader(options: {
   devSourceRoot?: string | null;
   pluginSdkResolution?: PluginSdkResolutionPreference;
-  aliasOverrides?: Readonly<Record<string, string>>;
   tryNative?: boolean;
   loaderFilename?: string;
   installNativeSdkResolver?: boolean;
@@ -125,16 +124,13 @@ export function createPluginModuleLoader(options: {
         pluginSdkResolution: options.pluginSdkResolution,
       });
     }
-    const defaultAliasMap = buildPluginLoaderAliasMap(
+    const aliasMap = buildPluginLoaderAliasMap(
       modulePath,
       process.argv[1],
       import.meta.url,
       options.pluginSdkResolution,
       options.devSourceRoot,
     );
-    const aliasMap = options.aliasOverrides
-      ? { ...defaultAliasMap, ...options.aliasOverrides }
-      : defaultAliasMap;
     return getCachedPluginModuleLoader({
       cache: moduleLoaders,
       modulePath,

--- a/src/plugins/loader-runtime-load.ts
+++ b/src/plugins/loader-runtime-load.ts
@@ -35,7 +35,7 @@ import type { PluginRuntime } from "./runtime/types.js";
 
 type PluginModuleLoaderOverrides = Pick<
   Parameters<typeof createPluginModuleLoader>[0],
-  "aliasOverrides" | "tryNative" | "loaderFilename" | "installNativeSdkResolver"
+  "tryNative" | "loaderFilename" | "installNativeSdkResolver"
 >;
 type InternalPluginLoadOverrides = {
   moduleLoader: PluginModuleLoaderOverrides;

--- a/src/plugins/migration-provider-runtime.ts
+++ b/src/plugins/migration-provider-runtime.ts
@@ -55,16 +55,6 @@ function bindMigrationProviderToRegistry(
   };
 }
 
-function resolveMigrationProviderConfig(params: {
-  cfg?: OpenClawConfig;
-  bundledCompatPluginIds: readonly string[];
-}): OpenClawConfig | undefined {
-  return withBundledPluginEnablementCompat({
-    config: params.cfg,
-    pluginIds: [...params.bundledCompatPluginIds],
-  });
-}
-
 function resolveMigrationProviderRegistry(params: { cfg?: OpenClawConfig; pluginIds: string[] }) {
   const active = getLoadedRuntimePluginRegistry({ requiredPluginIds: params.pluginIds });
   if (active) {
@@ -135,9 +125,9 @@ export function ensureStandaloneMigrationProviderRegistryLoaded(
   if (resolution.pluginIds.length === 0) {
     return;
   }
-  const compatConfig = resolveMigrationProviderConfig({
-    cfg: params.cfg,
-    bundledCompatPluginIds: resolution.bundledCompatPluginIds,
+  const compatConfig = withBundledPluginEnablementCompat({
+    config: params.cfg,
+    pluginIds: resolution.bundledCompatPluginIds,
   });
   const registry = loadPluginRegistryHandle({
     ...(compatConfig === undefined ? {} : { config: compatConfig }),

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -1,7 +1,6 @@
 // Runtime boundary for resolving provider plugins from metadata and config.
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { withActivatedPluginIds } from "./activation-context.js";
-import { resolveBundledPluginCompatibleActivationInputs } from "./activation-context.js";
+import { resolvePluginActivationInputs, withActivatedPluginIds } from "./activation-context.js";
 import { resolveManifestActivationPluginIds } from "./activation-planner.js";
 import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "./installed-plugin-index-install-records.js";
@@ -246,16 +245,13 @@ function resolveRuntimeProviderPluginLoadState(
     config: base.rawConfig,
     pluginIds: explicitOwnerPluginIds,
   });
-  const activation = resolveBundledPluginCompatibleActivationInputs({
+  const activation = resolvePluginActivationInputs({
     rawConfig: requestConfig,
     env: base.env,
     workspaceDir: base.workspaceDir,
-    onlyPluginIds: runtimeRequestedPluginIds,
     applyAutoEnable: params.applyAutoEnable ?? true,
     discovery: snapshot.discovery,
     manifestRegistry: snapshot.manifestRegistry,
-    compatMode: {},
-    resolveCompatPluginIds: () => [],
   });
   const providerPluginIds = mergeExplicitOwnerPluginIds(
     resolveEnabledProviderPluginIds({

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -1025,6 +1025,24 @@ describe("resolvePluginProviders", () => {
     expect(getLastResolvedPluginConfig()).toBeUndefined();
   });
 
+  it("ignores every bundledProviderVitestCompat value without changing loader input", () => {
+    const env = { VITEST: "true" } as NodeJS.ProcessEnv;
+    const inputs = ([undefined, true, false] as const).map((bundledProviderVitestCompat) => {
+      resolvePluginProviders({
+        env,
+        ...(bundledProviderVitestCompat === undefined ? {} : { bundledProviderVitestCompat }),
+      });
+      const { logger: _logger, ...input } = getLastRuntimeRegistryCall();
+      expect(input.config).toBeUndefined();
+      expect(input.activationSourceConfig).toBeUndefined();
+      expect(input.onlyPluginIds).toEqual(["google", "kilocode", "moonshot"]);
+      return input;
+    });
+
+    expect(inputs[1]).toEqual(inputs[0]);
+    expect(inputs[2]).toEqual(inputs[0]);
+  });
+
   it("scopes setup provider plugin discovery to the allowlist by default", () => {
     resolvePluginProviders({
       config: {

--- a/src/plugins/web-content-extractors.runtime.ts
+++ b/src/plugins/web-content-extractors.runtime.ts
@@ -29,9 +29,6 @@ export function resolvePluginWebContentExtractors(params?: {
     env: params?.env,
     onlyPluginIds: params?.onlyPluginIds,
     contract: "webContentExtractors",
-    compatMode: {
-      enablement: "always",
-    },
   })) {
     const loaded = loadBundledWebContentExtractorEntriesFromDir({
       dirName: plugin.id,

--- a/src/plugins/web-provider-public-artifacts.ts
+++ b/src/plugins/web-provider-public-artifacts.ts
@@ -139,9 +139,6 @@ function resolveBundledRuntimeCandidatePluginIds(params: {
       env: params.env,
       onlyPluginIds: pluginIds,
       contract: params.contract,
-      compatMode: {
-        enablement: "always",
-      },
     }).map((plugin) => plugin.id),
   );
   return pluginIds.filter((pluginId) => enabledPluginIds.has(pluginId));

--- a/src/plugins/web-provider-resolution-shared.ts
+++ b/src/plugins/web-provider-resolution-shared.ts
@@ -1,5 +1,5 @@
 // Shares web-provider plugin resolution helpers without eager runtime imports.
-import { resolveBundledPluginCompatibleLoadValues } from "./activation-context.js";
+import { resolveBundledCompatActivationInputs } from "./activation-context.js";
 import type { PluginLoadOptions } from "./loader.js";
 import { loadManifestMetadataSnapshot } from "./manifest-contract-eligibility.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
@@ -168,15 +168,12 @@ export function resolveBundledWebProviderResolutionConfig(params: {
   activationSourceConfig?: PluginLoadOptions["config"];
   autoEnabledReasons: Record<string, string[]>;
 } {
-  const activation = resolveBundledPluginCompatibleLoadValues({
+  const activation = resolveBundledCompatActivationInputs({
     rawConfig: params.config,
     env: params.env,
     workspaceDir: params.workspaceDir,
     applyAutoEnable: true,
-    compatMode: {
-      enablement: "always",
-    },
-    resolveCompatPluginIds: (compatParams) =>
+    resolveBundledPluginIds: (compatParams) =>
       resolveBundledWebProviderCompatPluginIds({
         contract: params.contract,
         ...compatParams,


### PR DESCRIPTION
Related: #120866

## What Problem This Solves

After the Vitest-only runtime path was removed, plugin activation still retained compatibility modes, duplicate activation pipelines, no-op resolver arguments, and loader options that no production caller used. This made ordinary provider loading depend on abstractions for states that could no longer occur.

## Why This Change Was Made

Use one canonical activation flow and layer the preserved bundled-discovery upgrade behavior through one narrow compatibility wrapper. Remove dead alias-override plumbing and one-use wrappers, and reuse one prepared capability metadata snapshot per logical resolution. The SQLite upgrade contract and deprecated inert Plugin SDK field remain unchanged.

## User Impact

No intended user-visible behavior change. Plugin activation and capability resolution now have fewer code paths and less repeated metadata work, while upgraded installations retain their existing compatibility behavior.

## Evidence

- 18 focused test files, 225 tests passed.
- Full build and changed-file gates passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31295851373
- Plugin SDK baseline, typechecks, lint, plugin boundaries, dead exports, import cycles, and state/database guards passed.
- Production code is net 183 lines smaller; overall diff is net 85 lines smaller.
- `git diff --check` passed.
- Mandatory autoreview passed with no accepted/actionable findings; secret scan clean.
- AI-assisted; maintainer reviewed the full diff and understands the change.
