### PR TITLE
test(macos): serialize unread suite on beta.1

### DIFF
--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelUnreadTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelUnreadTests.swift
@@ -202,6 +202,7 @@ extension UnreadTestTransportState {
     }
 }
 
+@Suite(.serialized)
 @MainActor
 struct ChatViewModelUnreadTests {
     @Test func `successful activation clears unread once`() async throws {


### PR DESCRIPTION
## What Problem This Solves

Resolves the remaining `2026.8.1-beta.1` Full Release Validation failure in the macOS Swift lane. In run https://github.com/openclaw/openclaw/actions/runs/31290871636, eight `ChatViewModelUnreadTests` timed out simultaneously at the same five-second async polling boundary while 1,311 other Swift tests passed.

Related: https://github.com/openclaw/openclaw/pull/120877

## Why This Change Was Made

This is the exact one-line test-only backport of PR #120877. `ChatViewModelUnreadTests` is a stateful `@MainActor` suite; marking only that suite `@Suite(.serialized)` prevents scheduler contention between its async polling tests. Assertions and timeout values are unchanged, and the wider OpenClawKit package remains parallel.

## User Impact

No runtime behavior changes. The macOS release gate becomes deterministic under full-suite load instead of intermittently failing all unread tests together.

## Evidence

- Failing Full Release Validation: https://github.com/openclaw/openclaw/actions/runs/31290871636
- Failing macOS Swift job: https://github.com/openclaw/openclaw/actions/runs/31290931054/job/93187882780
- Source fix: https://github.com/openclaw/openclaw/pull/120877
- Source exact-head CI: https://github.com/openclaw/openclaw/actions/runs/31294551343
- Source `macos-swift`: https://github.com/openclaw/openclaw/actions/runs/31294551343/job/93197429792 — green
- Focused release-branch suite: 15/15 passed in 1.021s
- SwiftFormat, SwiftLint, `git diff --check`: passed
- Codex autoreview of staged release backport: clean, no P0/P1 findings
- Production LOC: `+0/-0`; tests: `+1/-0`
