### PR TITLE
fix: canonicalize targeted channel setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -392,6 +392,7 @@ Docs: https://docs.openclaw.ai
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 - **Cron llama.cpp tool schemas:** keep the model-facing cron declaration schema compatible with llama.cpp while retaining gateway and runtime nonblank validation. Fixes #107449. (#108360) Thanks @lee-xydt.
 - **System-agent recovery guidance:** direct browser and app users to Settings or the OpenClaw host instead of terminal-only exit guidance while preserving the required stop, onboard, and restart lifecycle. (#114633) Thanks @jesse-merhi.
+- **Targeted channel setup:** skip the generic channel primer after a user has already selected a specific channel, keeping chat-guided setup focused on that channel's instructions.
 
 ## 2026.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -392,6 +392,7 @@ Docs: https://docs.openclaw.ai
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 - **Cron llama.cpp tool schemas:** keep the model-facing cron declaration schema compatible with llama.cpp while retaining gateway and runtime nonblank validation. Fixes #107449. (#108360) Thanks @lee-xydt.
 - **System-agent recovery guidance:** direct browser and app users to Settings or the OpenClaw host instead of terminal-only exit guidance while preserving the required stop, onboard, and restart lifecycle. (#114633) Thanks @jesse-merhi.
+
 ## 2026.7.1
 
 OpenClaw v2026.7.1 brings major Control UI and onboarding overhauls, major updates to the official iOS, Android, and macOS apps, expanded model and provider support including GPT-5.6 compatibility, Tencent Hy3, and Meta Muse Spark 1.1, and stronger Codex and connected coding-agent workflows. Telegram, Slack, Discord, and Apple Messages each receive substantial updates, while Gateway crash loops, scheduled work, remote browser control, workspace terminals, sessions, and goals also improve. There are also many general fixes and refinements throughout OpenClaw.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -392,8 +392,6 @@ Docs: https://docs.openclaw.ai
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 - **Cron llama.cpp tool schemas:** keep the model-facing cron declaration schema compatible with llama.cpp while retaining gateway and runtime nonblank validation. Fixes #107449. (#108360) Thanks @lee-xydt.
 - **System-agent recovery guidance:** direct browser and app users to Settings or the OpenClaw host instead of terminal-only exit guidance while preserving the required stop, onboard, and restart lifecycle. (#114633) Thanks @jesse-merhi.
-- **Targeted channel setup:** skip the generic channel primer after a user has already selected a specific channel, keeping chat-guided setup focused on that channel's instructions.
-
 ## 2026.7.1
 
 OpenClaw v2026.7.1 brings major Control UI and onboarding overhauls, major updates to the official iOS, Android, and macOS apps, expanded model and provider support including GPT-5.6 compatibility, Tencent Hy3, and Meta Muse Spark 1.1, and stronger Codex and connected coding-agent workflows. Telegram, Slack, Discord, and Apple Messages each receive substantial updates, while Gateway crash loops, scheduled work, remote browser control, workspace terminals, sessions, and goals also improve. There are also many general fixes and refinements throughout OpenClaw.

--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -227,6 +227,29 @@ describe("channel-auth", () => {
     });
   });
 
+  it("keeps an exact catalog id authoritative over an active plugin alias", async () => {
+    const exactPlugin = { ...plugin, id: "exact-id" };
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        id: "exact-id",
+        pluginId: "exact-plugin",
+        meta: { id: "exact-id", label: "Exact", aliases: [] },
+        origin: "bundled",
+      },
+    ]);
+    mocks.normalizeChannelId.mockReturnValue("alias-owner");
+    mocks.getChannelPlugin.mockImplementation((id) =>
+      id === "exact-id" ? exactPlugin : undefined,
+    );
+
+    await runChannelLogin({ channel: "exact-id", account: "acct-1" }, runtime);
+
+    expectFields(readFirstCallArg(mocks.login), { channelInput: "exact-id" });
+    expect(mocks.callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { channel: "exact-id", accountId: "acct-1" } }),
+    );
+  });
+
   it("skips gateway runtime reconcile in remote mode and warns without failing login", async () => {
     mocks.loadConfig.mockReturnValue({
       gateway: { mode: "remote" },

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -3,11 +3,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
-import {
-  getChannelPlugin,
-  listChannelPlugins,
-  normalizeChannelId,
-} from "../channels/plugins/index.js";
+import { getChannelPlugin, listChannelPlugins } from "../channels/plugins/index.js";
 import { resolveInstallableChannelPlugin } from "../commands/channel-setup/channel-plugin-resolution.js";
 import { getRuntimeConfig, readConfigFileSnapshot, type OpenClawConfig } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
@@ -102,17 +98,15 @@ async function resolveChannelPluginForMode(
 }> {
   const explicitChannel = opts.channel?.trim();
   const channelInput = explicitChannel || resolveConfiguredAuthChannelInput(cfg, mode);
-  const normalizedChannelId = normalizeChannelId(channelInput);
 
   const resolved = await resolveInstallableChannelPlugin({
     cfg,
     runtime,
     rawChannel: channelInput,
-    ...(normalizedChannelId ? { channelId: normalizedChannelId } : {}),
     allowInstall: true,
     supports: (candidate) => supportsChannelAuthMode(candidate, mode),
   });
-  const channelId = resolved.channelId ?? normalizedChannelId;
+  const channelId = resolved.channelId;
   if (!channelId) {
     throw new Error(
       `Unsupported channel "${channelInput}". Run ${formatCliCommand("openclaw channels list")} to see available channels.`,

--- a/src/cli/channels-cli-add-args.ts
+++ b/src/cli/channels-cli-add-args.ts
@@ -134,6 +134,7 @@ export function resolveChannelsAddOptions(
   channelArg: string | undefined,
   opts: Record<string, unknown>,
   command?: Pick<Command, "getOptionValueSource">,
+  resolvedChannel?: string,
 ): Record<string, unknown> {
   const forwardedOpts = command
     ? Object.fromEntries(
@@ -142,6 +143,6 @@ export function resolveChannelsAddOptions(
     : opts;
   return {
     ...forwardedOpts,
-    channel: forwardedOpts.channel ?? channelArg,
+    channel: resolvedChannel ?? forwardedOpts.channel ?? channelArg,
   };
 }

--- a/src/cli/channels-cli.test.ts
+++ b/src/cli/channels-cli.test.ts
@@ -303,6 +303,81 @@ describe("registerChannelsCli", () => {
     expect(flags).not.toContain("--url <url>");
   });
 
+  it("carries the catalog-selected alias owner from option registration into execution", async () => {
+    listRawChannelPluginCatalogEntriesMock.mockReturnValue([
+      {
+        id: "first-chat",
+        pluginId: "first-chat",
+        origin: "global",
+        channel: {
+          id: "first-chat",
+          aliases: ["shared"],
+          order: 10,
+          setup: {
+            fields: [
+              {
+                key: "firstKey",
+                kind: "string",
+                cli: { flags: "--first-key <key>", description: "First key" },
+              },
+            ],
+          },
+        },
+        meta: {
+          id: "first-chat",
+          label: "First Chat",
+          selectionLabel: "First Chat",
+          docsPath: "/channels/first-chat",
+          blurb: "First test channel.",
+        },
+        install: { npmSpec: "@openclaw/first-chat" },
+      },
+      {
+        id: "active-chat",
+        pluginId: "active-chat",
+        origin: "global",
+        channel: {
+          id: "active-chat",
+          aliases: ["shared"],
+          order: 20,
+          setup: {
+            fields: [
+              {
+                key: "activeKey",
+                kind: "string",
+                cli: { flags: "--active-key <key>", description: "Active key" },
+              },
+            ],
+          },
+        },
+        meta: {
+          id: "active-chat",
+          label: "Active Chat",
+          selectionLabel: "Active Chat",
+          docsPath: "/channels/active-chat",
+          blurb: "Active test channel.",
+        },
+        install: { npmSpec: "@openclaw/active-chat" },
+      },
+    ]);
+    const program = await runChannelsAddCli([
+      "channels",
+      "add",
+      "--channel",
+      "shared",
+      "--first-key",
+      "secret",
+    ]);
+
+    expect(getChannelAddOptionFlags(program)).toContain("--first-key <key>");
+    expect(getChannelAddOptionFlags(program)).not.toContain("--active-key <key>");
+    expect(channelsAddCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "first-chat", firstKey: "secret" }),
+      runtimeMock,
+      { hasFlags: true },
+    );
+  });
+
   it("projects channel-owned setup fields into Commander options", async () => {
     listBundledPackageChannelMetadataMock.mockReturnValueOnce([
       {

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -118,7 +118,7 @@ function shouldRegisterChannelSetupOptions(
 async function addChannelSetupOptions(
   command: Command,
   params: AddChannelSetupOptionsParams = {},
-): Promise<ChannelSetupOptionMode> {
+) {
   const { resolveChannelSetupCliOptionMetadata } = await loadChannelSetupCliOptions();
   const selected = params.channelId?.trim().toLowerCase();
   const { options, selectedChannel } = resolveChannelSetupCliOptionMetadata(selected, {
@@ -143,7 +143,7 @@ async function addChannelSetupOptions(
       addChannelSetupOption(command, option, seenFlags);
     }
   }
-  return mode;
+  return { mode, selectedChannelId: selectedChannel?.id };
 }
 
 export async function registerChannelsCli(
@@ -313,15 +313,18 @@ export async function registerChannelsCli(
     .option("--name <name>", "Display name for this account");
 
   let channelSetupOptionMode: ChannelSetupOptionMode = "none";
-  const selectedChannelId = await resolveChannelsAddChannelFromArgv(argv);
+  const selectedChannelInput = await resolveChannelsAddChannelFromArgv(argv);
+  let selectedChannelId = selectedChannelInput;
   if (
     shouldRegisterChannelSetupOptions(argv, options) &&
-    (selectedChannelId !== undefined || options.includeSetupOptions)
+    (selectedChannelInput !== undefined || options.includeSetupOptions)
   ) {
-    channelSetupOptionMode = await addChannelSetupOptions(addCommand, {
-      channelId: selectedChannelId,
+    const registration = await addChannelSetupOptions(addCommand, {
+      channelId: selectedChannelInput,
       includeAll: options.includeSetupOptions,
     });
+    channelSetupOptionMode = registration.mode;
+    selectedChannelId = registration.selectedChannelId ?? selectedChannelInput;
   }
 
   addCommand.action(async (channelArg: string | undefined, opts, command) => {
@@ -336,6 +339,7 @@ export async function registerChannelsCli(
           channelArg,
           opts,
           channelSetupOptionMode === "modern" ? command : undefined,
+          selectedChannelId,
         ),
         defaultRuntime,
         {

--- a/src/commands/channel-setup/channel-entry-resolution.test.ts
+++ b/src/commands/channel-setup/channel-entry-resolution.test.ts
@@ -1,0 +1,46 @@
+// Channel entry resolution tests preserve canonical-id and alias collision semantics.
+import { describe, expect, it } from "vitest";
+import { resolveChannelTarget } from "./channel-entry-resolution.js";
+
+const entries = [
+  { id: "feishu", meta: { aliases: ["lark", "telegram", "shared"] } },
+  { id: "telegram", meta: { aliases: ["tg", "shared"] } },
+] as const;
+
+describe("resolveChannelTarget", () => {
+  it("normalizes canonical ids and aliases", () => {
+    expect(resolveChannelTarget({ raw: " TELEGRAM ", entries })?.id).toBe("telegram");
+    expect(resolveChannelTarget({ raw: "Lark", entries })?.id).toBe("feishu");
+  });
+
+  it("prefers canonical ids over earlier aliases", () => {
+    expect(resolveChannelTarget({ raw: "telegram", entries })?.id).toBe("telegram");
+  });
+
+  it("keeps discovery order for duplicate aliases", () => {
+    expect(resolveChannelTarget({ raw: "shared", entries })?.id).toBe("feishu");
+  });
+
+  it("rejects blank and unknown targets", () => {
+    expect(resolveChannelTarget({ raw: " ", entries })).toBeUndefined();
+    expect(resolveChannelTarget({ raw: "unknown", entries })).toBeUndefined();
+  });
+
+  it("keeps an exact catalog id authoritative over a registered alias", () => {
+    expect(resolveChannelTarget({ raw: "telegram", entries, registeredId: "feishu" })).toEqual({
+      id: "telegram",
+      entry: entries[1],
+    });
+  });
+
+  it("keeps the active registry authoritative for aliases", () => {
+    expect(resolveChannelTarget({ raw: "shared", entries, registeredId: "telegram" })).toEqual({
+      id: "telegram",
+      entry: entries[1],
+    });
+    expect(resolveChannelTarget({ raw: "lark", entries })).toEqual({
+      id: "feishu",
+      entry: entries[0],
+    });
+  });
+});

--- a/src/commands/channel-setup/channel-entry-resolution.ts
+++ b/src/commands/channel-setup/channel-entry-resolution.ts
@@ -1,0 +1,52 @@
+// Canonical channel setup target resolution shared by CLI and interactive setup flows.
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+
+type ChannelEntry = {
+  id: string;
+  meta: { aliases?: readonly string[] };
+};
+
+function findExactChannelEntry<T extends ChannelEntry>(
+  raw: string,
+  entries: readonly T[],
+): T | undefined {
+  const normalized = normalizeOptionalLowercaseString(raw);
+  return normalized
+    ? entries.find((entry) => normalizeOptionalLowercaseString(entry.id) === normalized)
+    : undefined;
+}
+
+function findAliasChannelEntry<T extends ChannelEntry>(
+  raw: string,
+  entries: readonly T[],
+): T | undefined {
+  const normalized = normalizeOptionalLowercaseString(raw);
+  return normalized
+    ? entries.find((entry) =>
+        (entry.meta.aliases ?? []).some(
+          (candidate) => normalizeOptionalLowercaseString(candidate) === normalized,
+        ),
+      )
+    : undefined;
+}
+
+/** Resolve one coherent channel id/catalog fact from user input and the active registry. */
+export function resolveChannelTarget<T extends ChannelEntry>(params: {
+  raw: string;
+  entries: readonly T[];
+  registeredId?: string | null;
+}): { id: string; entry?: T } | undefined {
+  const exact = findExactChannelEntry(params.raw, params.entries);
+  if (exact) {
+    return { id: exact.id, entry: exact };
+  }
+  if (params.registeredId) {
+    const entry = findExactChannelEntry(params.registeredId, params.entries);
+    return {
+      id: params.registeredId,
+      ...(entry ? { entry } : {}),
+    };
+  }
+  const alias = findAliasChannelEntry(params.raw, params.entries);
+  return alias ? { id: alias.id, entry: alias } : undefined;
+}

--- a/src/commands/channel-setup/channel-plugin-resolution.test.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.test.ts
@@ -9,6 +9,9 @@ const mocks = vi.hoisted(() => ({
   listChannelPluginCatalogEntries: vi.fn(),
   getChannelPluginCatalogEntry: vi.fn(),
   getChannelPlugin: vi.fn(),
+  normalizeChannelId: vi.fn((value: unknown) =>
+    typeof value === "string" ? value.trim() || null : null,
+  ),
   loadChannelSetupPluginRegistrySnapshotForChannel: vi.fn(),
   ensureChannelSetupPluginInstalled: vi.fn(),
   createClackPrompter: vi.fn(() => ({}) as never),
@@ -26,7 +29,7 @@ vi.mock("../../channels/plugins/catalog.js", () => ({
 
 vi.mock("../../channels/plugins/index.js", () => ({
   getChannelPlugin: mocks.getChannelPlugin,
-  normalizeChannelId: (value: unknown) => (typeof value === "string" ? value.trim() || null : null),
+  normalizeChannelId: mocks.normalizeChannelId,
 }));
 
 vi.mock("./plugin-install.js", () => ({
@@ -78,6 +81,9 @@ function firstMockArg(mock: { mock: { calls: ReadonlyArray<ReadonlyArray<unknown
 describe("resolveInstallableChannelPlugin", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.normalizeChannelId.mockImplementation((value: unknown) =>
+      typeof value === "string" ? value.trim() || null : null,
+    );
     mocks.getChannelPlugin.mockReturnValue(undefined);
     mocks.getChannelPluginCatalogEntry.mockReturnValue(undefined);
     mocks.ensureChannelSetupPluginInstalled.mockResolvedValue({
@@ -168,6 +174,43 @@ describe("resolveInstallableChannelPlugin", () => {
     expect(snapshotRequest?.channel).toBe("telegram");
     expect(snapshotRequest?.pluginId).toBe("evil-telegram-shadow");
     expect(snapshotRequest?.workspaceDir).toBe("/tmp/workspace");
+  });
+
+  it("keeps an exact catalog id authoritative over an active plugin alias", async () => {
+    const catalogEntry = createCatalogEntry({
+      id: "exact-id",
+      pluginId: "exact-plugin",
+      origin: "bundled",
+    });
+    const aliasOwner = createPlugin("alias-owner");
+    const exactPlugin = createPlugin("exact-id");
+
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([catalogEntry]);
+    mocks.normalizeChannelId.mockImplementation((value: unknown) =>
+      value === "exact-id" ? "alias-owner" : null,
+    );
+    mocks.getChannelPlugin.mockImplementation((id: string) =>
+      id === "alias-owner" ? aliasOwner : undefined,
+    );
+    mocks.loadChannelSetupPluginRegistrySnapshotForChannel.mockImplementation(
+      ({ channel }: { channel: string }) => ({
+        channels: channel === "exact-id" ? [{ plugin: exactPlugin }] : [],
+        channelSetups: [],
+      }),
+    );
+
+    const result = await resolveInstallableChannelPlugin({
+      cfg: { plugins: { enabled: true } },
+      runtime: {} as never,
+      rawChannel: "exact-id",
+      allowInstall: false,
+    });
+
+    expect(result.channelId).toBe("exact-id");
+    expect(result.catalogEntry).toBe(catalogEntry);
+    expect(result.plugin).toBe(exactPlugin);
+    expect(mocks.getChannelPlugin).toHaveBeenCalledWith("exact-id");
+    expect(mocks.getChannelPlugin).not.toHaveBeenCalledWith("alias-owner");
   });
 
   it("returns an existing plugin that lacks the requested capability without reinstalling", async () => {

--- a/src/commands/channel-setup/channel-plugin-resolution.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.ts
@@ -1,5 +1,4 @@
 // Resolves or installs channel plugins needed by setup/onboarding flows.
-import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import {
   listRawChannelPluginCatalogEntries,
@@ -12,14 +11,12 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
+import { resolveChannelTarget } from "./channel-entry-resolution.js";
 import {
   ensureChannelSetupPluginInstalled,
   loadChannelSetupPluginRegistrySnapshotForChannel,
 } from "./plugin-install.js";
-import {
-  getTrustedChannelPluginCatalogEntry,
-  listTrustedChannelPluginCatalogEntries,
-} from "./trusted-catalog.js";
+import { listTrustedChannelPluginCatalogEntries } from "./trusted-catalog.js";
 
 type ChannelPluginSnapshot = {
   channels: Array<{ plugin: ChannelPlugin }>;
@@ -40,38 +37,21 @@ function resolveWorkspaceDir(cfg: OpenClawConfig) {
   return resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
 }
 
-function resolveResolvedChannelId(params: {
-  rawChannel?: string | null;
-  catalogEntry?: ChannelPluginCatalogEntry;
-}): ChannelId | undefined {
-  const normalized = normalizeChannelId(params.rawChannel);
-  if (normalized) {
-    return normalized;
-  }
-  if (!params.catalogEntry) {
-    return undefined;
-  }
-  return normalizeChannelId(params.catalogEntry.id) ?? (params.catalogEntry.id as ChannelId);
-}
-
-function resolveCatalogChannelEntry(raw: string, cfg: OpenClawConfig | null) {
-  const trimmed = normalizeOptionalLowercaseString(raw);
-  if (!trimmed) {
-    return undefined;
-  }
-  const entries = cfg
+function resolveCatalogChannelTarget(params: {
+  raw: string;
+  cfg: OpenClawConfig | null;
+  registeredId?: ChannelId | null;
+}) {
+  const entries = params.cfg
     ? listTrustedChannelPluginCatalogEntries({
-        cfg,
-        workspaceDir: resolveWorkspaceDir(cfg),
+        cfg: params.cfg,
+        workspaceDir: resolveWorkspaceDir(params.cfg),
       })
     : listRawChannelPluginCatalogEntries({ excludeWorkspace: true });
-  return entries.find((entry) => {
-    if (normalizeOptionalLowercaseString(entry.id) === trimmed) {
-      return true;
-    }
-    return (entry.meta.aliases ?? []).some(
-      (alias) => normalizeOptionalLowercaseString(alias) === trimmed,
-    );
+  return resolveChannelTarget({
+    raw: params.raw,
+    entries,
+    registeredId: params.registeredId,
   });
 }
 
@@ -111,7 +91,6 @@ export async function resolveInstallableChannelPlugin(params: {
   cfg: OpenClawConfig;
   runtime: RuntimeEnv;
   rawChannel?: string | null;
-  channelId?: ChannelId;
   allowInstall?: boolean;
   prompter?: WizardPrompter;
   supports?: (plugin: ChannelPlugin) => boolean;
@@ -119,20 +98,14 @@ export async function resolveInstallableChannelPlugin(params: {
   const supports = params.supports ?? (() => true);
   let nextCfg = params.cfg;
   const workspaceDir = resolveWorkspaceDir(nextCfg);
-  const catalogEntry =
-    (params.rawChannel ? resolveCatalogChannelEntry(params.rawChannel, nextCfg) : undefined) ??
-    (params.channelId
-      ? getTrustedChannelPluginCatalogEntry(params.channelId, {
-          cfg: nextCfg,
-          workspaceDir,
-        })
-      : undefined);
-  const channelId =
-    params.channelId ??
-    resolveResolvedChannelId({
-      rawChannel: params.rawChannel,
-      catalogEntry,
-    });
+  const rawChannel = params.rawChannel ?? "";
+  const target = resolveCatalogChannelTarget({
+    raw: rawChannel,
+    cfg: nextCfg,
+    registeredId: normalizeChannelId(rawChannel),
+  });
+  const channelId = target?.id;
+  const catalogEntry = target?.entry;
   if (!channelId) {
     return {
       cfg: nextCfg,

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -598,6 +598,123 @@ describe("channelsAddCommand", () => {
     expect(setupOptions().finishAfterInitialSelection).toBe(true);
   });
 
+  it("opens the active registry owner when catalog entries share an alias", async () => {
+    const config: OpenClawConfig = { channels: {} };
+    const activeOwner = createChannelTestPluginBase({
+      id: "active-chat",
+      label: "Active Chat",
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "active-chat",
+          plugin: {
+            ...activeOwner,
+            meta: { ...activeOwner.meta, aliases: ["shared"] },
+          },
+          source: "test",
+        },
+      ]),
+    );
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      sourceConfig: config,
+      config,
+    });
+    const catalogEntry = createExternalChatCatalogEntry();
+    catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        ...catalogEntry,
+        id: "first-chat",
+        pluginId: "first-chat",
+        meta: { ...catalogEntry.meta, id: "first-chat", aliases: ["shared"] },
+      },
+      {
+        ...catalogEntry,
+        id: "active-chat",
+        pluginId: "active-chat",
+        meta: { ...catalogEntry.meta, id: "active-chat", aliases: ["shared"] },
+      },
+    ]);
+
+    await channelsAddCommand({ channel: "shared" }, runtime, { hasFlags: false });
+
+    expect(setupOptions().initialSelection).toEqual(["active-chat"]);
+    expect(setupOptions().finishAfterInitialSelection).toBe(true);
+  });
+
+  it("configures an exact catalog id instead of an active plugin alias", async () => {
+    const config: OpenClawConfig = { channels: {} };
+    const aliasOwnerBase = createChannelTestPluginBase({
+      id: "alias-owner",
+      label: "Alias Owner",
+    });
+    const exactBase = createChannelTestPluginBase({
+      id: "exact-id",
+      label: "Exact ID",
+    });
+    const applyAccountConfig = vi.fn(({ cfg, input }: ApplyAccountConfigParams) => ({
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        "exact-id": { enabled: true, token: input.token },
+      },
+    }));
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "alias-owner",
+          plugin: {
+            ...aliasOwnerBase,
+            meta: { ...aliasOwnerBase.meta, aliases: ["exact-id"] },
+            setup: {
+              applyAccountConfig: vi.fn(({ cfg }: ApplyAccountConfigParams) => ({
+                ...cfg,
+                channels: { ...cfg.channels, "alias-owner": { enabled: true } },
+              })),
+            },
+          },
+          source: "test",
+        },
+      ]),
+    );
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      sourceConfig: config,
+      config,
+    });
+    const catalogEntry: ChannelPluginCatalogEntry = {
+      ...createExternalChatCatalogEntry(),
+      id: "exact-id",
+      pluginId: "exact-plugin",
+      meta: { ...createExternalChatCatalogEntry().meta, id: "exact-id", label: "Exact ID" },
+    };
+    catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([catalogEntry]);
+    vi.mocked(loadChannelSetupPluginRegistrySnapshotForChannel).mockReturnValue(
+      createTestRegistry([
+        {
+          pluginId: "exact-plugin",
+          plugin: { ...exactBase, setup: { applyAccountConfig } },
+          source: "test",
+        },
+      ]),
+    );
+
+    await channelsAddCommand(
+      { channel: "exact-id", account: "default", token: "exact-token" },
+      runtime,
+      { hasFlags: true },
+    );
+
+    expect(installCall().entry).toBe(catalogEntry);
+    expect(snapshotCall().channel).toBe("exact-id");
+    expect(applyAccountConfig).toHaveBeenCalledOnce();
+    expect(writtenChannel("exact-id").token).toBe("exact-token");
+    expect(
+      requireRecord(writtenConfig().channels, "written channels")["alias-owner"],
+    ).toBeUndefined();
+  });
+
   it("exits quietly when guided channel setup is cancelled", async () => {
     const { WizardCancelledError } = await import("../wizard/prompts.js");
     configMocks.readConfigFileSnapshot.mockResolvedValue({

--- a/src/commands/channels.remove.test.ts
+++ b/src/commands/channels.remove.test.ts
@@ -3,7 +3,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPluginCatalogEntry } from "../channels/plugins/catalog.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
-import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
   ensureChannelSetupPluginInstalled,
   loadChannelSetupPluginRegistrySnapshotForChannel,
@@ -27,6 +27,10 @@ const registryRefreshMocks = vi.hoisted(() => ({
 
 const gatewayMocks = vi.hoisted(() => ({
   callGateway: vi.fn(async () => ({ stopped: true })),
+}));
+
+const promptMocks = vi.hoisted(() => ({
+  confirm: vi.fn(async () => true),
 }));
 
 vi.mock("../channels/plugins/catalog.js", async () => {
@@ -62,6 +66,10 @@ vi.mock("../plugins/registry-refresh.js", () => registryRefreshMocks);
 
 vi.mock("../gateway/call.js", () => ({
   callGateway: gatewayMocks.callGateway,
+}));
+
+vi.mock("../wizard/clack-prompter.js", () => ({
+  createClackPrompter: () => ({ confirm: promptMocks.confirm }),
 }));
 
 const runtime = createTestRuntime();
@@ -104,7 +112,94 @@ describe("channelsRemoveCommand", () => {
     registryRefreshMocks.refreshPluginRegistryAfterConfigMutation.mockClear();
     gatewayMocks.callGateway.mockClear();
     gatewayMocks.callGateway.mockResolvedValue({ stopped: true });
+    promptMocks.confirm.mockClear();
+    promptMocks.confirm.mockResolvedValue(true);
     setActivePluginRegistry(createTestRegistry());
+  });
+
+  it("confirms and disables the exact catalog channel when its id is an active alias", async () => {
+    const setAccountEnabled = vi.fn<
+      NonNullable<ChannelPlugin["config"]["setAccountEnabled"]>
+    >(({ cfg, enabled }) => ({
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        "exact-id": { enabled },
+      },
+    }));
+    const exactPlugin = createChannelTestPluginBase({
+      id: "exact-id",
+      label: "Exact ID",
+      config: { setAccountEnabled },
+    }) as ChannelPlugin;
+    const aliasOwner = createChannelTestPluginBase({
+      id: "alias-owner",
+      label: "Alias Owner",
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "alias-owner",
+          plugin: {
+            ...aliasOwner,
+            meta: { ...aliasOwner.meta, aliases: ["exact-id"] },
+          },
+          source: "test",
+        },
+      ]),
+    );
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {
+        channels: {
+          "alias-owner": { enabled: true },
+          "exact-id": { enabled: true },
+        },
+      },
+    });
+    const catalogEntry = createExternalChatCatalogEntry();
+    catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        ...catalogEntry,
+        id: "exact-id",
+        pluginId: "exact-plugin",
+        meta: {
+          ...catalogEntry.meta,
+          id: "exact-id",
+          label: "Exact ID",
+          selectionLabel: "Exact ID",
+        },
+      },
+    ]);
+    vi.mocked(loadChannelSetupPluginRegistrySnapshotForChannel).mockReturnValue(
+      createTestRegistry([
+        {
+          pluginId: "exact-plugin",
+          plugin: exactPlugin,
+          source: "test",
+        },
+      ]),
+    );
+
+    await channelsRemoveCommand({ channel: "exact-id" }, runtime, { hasFlags: true });
+
+    expect(promptMocks.confirm).toHaveBeenCalledWith({
+      message: 'Disable Exact ID account "default"? (keeps config)',
+      initialValue: true,
+    });
+    expect(setAccountEnabled).toHaveBeenCalledWith({
+      cfg: {
+        channels: {
+          "alias-owner": { enabled: true },
+          "exact-id": { enabled: true },
+        },
+      },
+      accountId: "default",
+      enabled: false,
+    });
+    const writtenConfig = firstWrittenChannelsConfig();
+    expect(writtenConfig?.channels?.["alias-owner"]).toEqual({ enabled: true });
+    expect(writtenConfig?.channels?.["exact-id"]).toEqual({ enabled: false });
   });
 
   it("asks users to add an external channel plugin before removing its account", async () => {

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -1,9 +1,8 @@
 // Guided channel-setup wizard flow shared by `openclaw channels add` (clack
 // prompter) and the gateway `wizard.start {flow:"channels"}` RPC (session
 // prompter driving the Control UI / native clients).
-import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
-import { getLoadedChannelPlugin } from "../../channels/plugins/index.js";
+import { getLoadedChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import type { ChannelSetupPlugin } from "../../channels/plugins/setup-wizard-types.js";
 import { readConfigFileSnapshot, type OpenClawConfig } from "../../config/config.js";
 import { commitConfigWithPendingPluginInstalls } from "../../plugins/install-record-commit.js";
@@ -12,6 +11,7 @@ import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { applyAgentBindings, describeBinding } from "../agents.bindings.js";
+import { resolveChannelTarget } from "../channel-setup/channel-entry-resolution.js";
 import type { ChannelChoice } from "../onboard-types.js";
 import { applyAccountName } from "./add-mutators.js";
 
@@ -26,10 +26,6 @@ export async function resolveInitialWizardChannel(
   raw: string,
   cfg: OpenClawConfig,
 ): Promise<ChannelChoice | undefined> {
-  const normalized = normalizeOptionalLowercaseString(raw);
-  if (!normalized) {
-    return undefined;
-  }
   const [{ listActiveChannelSetupPlugins }, { resolveChannelSetupEntries }] = await Promise.all([
     import("../../channels/plugins/setup-registry.js"),
     import("../channel-setup/discovery.js"),
@@ -39,14 +35,11 @@ export async function resolveInitialWizardChannel(
     installedPlugins: listActiveChannelSetupPlugins(),
     workspaceDir: resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)),
   });
-  return (
-    resolved.entries.find((entry) => normalizeOptionalLowercaseString(entry.id) === normalized) ??
-    resolved.entries.find((entry) =>
-      (entry.meta.aliases ?? []).some(
-        (alias) => normalizeOptionalLowercaseString(alias) === normalized,
-      ),
-    )
-  )?.id;
+  return resolveChannelTarget({
+    raw,
+    entries: resolved.entries,
+    registeredId: normalizeChannelId(raw),
+  })?.entry?.id;
 }
 
 type ChannelsAddWizardFlowParams = {

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -1,5 +1,4 @@
 // Implements guided and non-interactive `openclaw channels add` account setup.
-import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import {
   applyPreparedChannelAccountConfiguration,
@@ -24,6 +23,7 @@ import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import { WizardCancelledError } from "../../wizard/prompts.js";
+import { resolveChannelTarget } from "../channel-setup/channel-entry-resolution.js";
 import { channelLabel } from "./runtime-label.js";
 import { requireValidConfigFileSnapshot, shouldUseWizard } from "./shared.js";
 
@@ -52,11 +52,7 @@ export type ChannelsAddOptions = {
 
 const CHANNEL_ADD_CONTROL_OPTION_KEYS = new Set(["channel", "account"]);
 
-async function resolveCatalogChannelEntry(raw: string, cfg: OpenClawConfig | null) {
-  const trimmed = normalizeOptionalLowercaseString(raw);
-  if (!trimmed) {
-    return undefined;
-  }
+async function resolveCatalogChannelTarget(raw: string, cfg: OpenClawConfig | null) {
   const entries = cfg
     ? await import("../channel-setup/trusted-catalog.js").then(
         ({ listTrustedChannelPluginCatalogEntries }) =>
@@ -69,13 +65,10 @@ async function resolveCatalogChannelEntry(raw: string, cfg: OpenClawConfig | nul
         ({ listRawChannelPluginCatalogEntries }) =>
           listRawChannelPluginCatalogEntries({ excludeWorkspace: true }),
       );
-  return entries.find((entry) => {
-    if (normalizeOptionalLowercaseString(entry.id) === trimmed) {
-      return true;
-    }
-    return (entry.meta.aliases ?? []).some(
-      (alias) => normalizeOptionalLowercaseString(alias) === trimmed,
-    );
+  return resolveChannelTarget({
+    raw,
+    entries,
+    registeredId: normalizeChannelId(raw),
   });
 }
 
@@ -170,8 +163,9 @@ async function channelsAddCommandImpl(
   }
 
   const rawChannel = opts.channel ?? "";
-  let channel = normalizeChannelId(rawChannel);
-  let catalogEntry = await resolveCatalogChannelEntry(rawChannel, nextConfig);
+  const target = await resolveCatalogChannelTarget(rawChannel, nextConfig);
+  const channel = target?.id as ChannelId | undefined;
+  let catalogEntry = target?.entry;
   const resolveWorkspaceDir = () =>
     resolveAgentWorkspaceDir(nextConfig, resolveDefaultAgentId(nextConfig));
   // May load a scoped plugin when the channel is not already registered.
@@ -238,7 +232,6 @@ async function channelsAddCommandImpl(
         ...(result.pluginId ? { pluginId: result.pluginId } : {}),
       };
     }
-    channel ??= normalizeChannelId(catalogEntry.id) ?? (catalogEntry.id as ChannelId);
   }
 
   if (!channel) {

--- a/src/commands/channels/remove.ts
+++ b/src/commands/channels/remove.ts
@@ -121,15 +121,6 @@ export async function channelsRemoveCommand(
       });
       return normalizeAccountId(choice);
     })();
-
-    const wantsDisable = await prompter.confirm({
-      message: `Disable ${channelLabel(selectedChannel)} account "${accountId}"? (keeps config)`,
-      initialValue: true,
-    });
-    if (!wantsDisable) {
-      await prompter.outro("Cancelled.");
-      return;
-    }
   } else {
     if (!rawChannel) {
       runtime.error(
@@ -137,17 +128,6 @@ export async function channelsRemoveCommand(
       );
       runtime.exit(1);
       return;
-    }
-    if (!deleteConfig) {
-      const confirm = createClackPrompter();
-      const channelPromptLabel = channel ? channelLabel(channel) : rawChannel;
-      const ok = await confirm.confirm({
-        message: `Disable ${channelPromptLabel} account "${accountId}"? (keeps config)`,
-        initialValue: true,
-      });
-      if (!ok) {
-        return;
-      }
     }
   }
 
@@ -193,6 +173,18 @@ export async function channelsRemoveCommand(
     accountId,
     action: deleteConfig ? "delete" : "disable",
   });
+
+  if (useWizard || !deleteConfig) {
+    const confirm = prompter ?? createClackPrompter();
+    const wantsDisable = await confirm.confirm({
+      message: `Disable ${plugin.meta.label} account "${preparedRemoval.accountKey}"? (keeps config)`,
+      initialValue: true,
+    });
+    if (!wantsDisable) {
+      await prompter?.outro("Cancelled.");
+      return;
+    }
+  }
 
   await stopGatewayRuntimeBeforeRemove({
     cfg,

--- a/src/flows/channel-setup.status.test.ts
+++ b/src/flows/channel-setup.status.test.ts
@@ -445,6 +445,24 @@ describe("resolveChannelSetupSelectionContributions", () => {
     );
   });
 
+  it("keeps safety guidance when the channel catalogue is omitted", async () => {
+    const note = vi.fn(async () => undefined);
+
+    await noteChannelPrimer({ note } as never, []);
+
+    expect(formatChannelPrimerLine).not.toHaveBeenCalled();
+    expect(note).toHaveBeenCalledWith(
+      [
+        "Inbound DM safety defaults to pairing: unknown senders get a pairing code first.",
+        "Approve with: openclaw pairing approve <channel> <code>",
+        'Open/public DMs require dmPolicy="open" plus allowFrom=["*"].',
+        'For multi-user DMs, isolate sessions with: openclaw config set session.dmScope "per-channel-peer" (or "per-account-channel-peer" for multi-account channels).',
+        "Docs: https://docs.openclaw.ai/channels/pairing",
+      ].join("\n"),
+      "How channels work",
+    );
+  });
+
   it("localizes built-in channel primer copy", async () => {
     const note = vi.fn(async () => undefined);
 

--- a/src/flows/channel-setup.status.ts
+++ b/src/flows/channel-setup.status.ts
@@ -491,22 +491,21 @@ export async function noteChannelPrimer(
       }),
     ),
   );
+  const safetyLines = [
+    t("wizard.channelsPrimer.inboundSafety"),
+    t("wizard.channelsPrimer.approveWith", {
+      command: formatCliCommand("openclaw pairing approve <channel> <code>"),
+    }),
+    t("wizard.channelsPrimer.openDm"),
+    t("wizard.channelsPrimer.multiUserDm", {
+      command: formatCliCommand('openclaw config set session.dmScope "per-channel-peer"'),
+    }),
+    t("wizard.channelsPrimer.docs", {
+      link: formatDocsLink("/channels/pairing", "channels/pairing"),
+    }),
+  ];
   await prompter.note(
-    [
-      t("wizard.channelsPrimer.inboundSafety"),
-      t("wizard.channelsPrimer.approveWith", {
-        command: formatCliCommand("openclaw pairing approve <channel> <code>"),
-      }),
-      t("wizard.channelsPrimer.openDm"),
-      t("wizard.channelsPrimer.multiUserDm", {
-        command: formatCliCommand('openclaw config set session.dmScope "per-channel-peer"'),
-      }),
-      t("wizard.channelsPrimer.docs", {
-        link: formatDocsLink("/channels/pairing", "channels/pairing"),
-      }),
-      "",
-      ...channelLines,
-    ].join("\n"),
+    [...safetyLines, ...(channelLines.length > 0 ? ["", ...channelLines] : [])].join("\n"),
     t("wizard.channelsPrimer.title"),
   );
 }

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -923,6 +923,7 @@ describe("setupChannels workspace shadow exclusion", () => {
     expect(noteChannelPrimer).toHaveBeenCalledTimes(1);
     expect(select).toHaveBeenCalledWith(
       expect.objectContaining({
+        initialValue: undefined,
         message: "Select a channel",
       }),
     );

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -893,6 +893,42 @@ describe("setupChannels workspace shadow exclusion", () => {
     });
   });
 
+  it("keeps an unknown targeted channel in the shared picker flow", async () => {
+    const externalChatPlugin = makeSetupPlugin({
+      id: "external-chat",
+      label: "External Chat",
+    });
+    resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
+    listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
+    const select = vi.fn(async () => "__done__");
+    const cfg = { channels: { telegram: { botToken: "keep" } } } as OpenClawConfig;
+
+    const result = await setupChannels(
+      cfg,
+      {} as never,
+      {
+        confirm: vi.fn(async () => true),
+        note: vi.fn(async () => undefined),
+        select,
+      } as never,
+      {
+        initialSelection: ["unknown-chat"],
+        finishAfterInitialSelection: true,
+        deferStatusUntilSelection: true,
+        skipConfirm: true,
+        skipDmPolicyPrompt: true,
+      },
+    );
+
+    expect(noteChannelPrimer).toHaveBeenCalledTimes(1);
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Select a channel",
+      }),
+    );
+    expect(result).toEqual(cfg);
+  });
+
   it("returns targeted channel setup Back navigation to the channel picker", async () => {
     const promptOrder: string[] = [];
     const configureInteractive = vi.fn(async ({ prompter }) => {

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -132,6 +132,7 @@ const collectChannelStatus = vi.hoisted(() =>
     statusLines: [],
   })),
 );
+const noteChannelPrimer = vi.hoisted(() => vi.fn(async () => undefined));
 const isChannelConfigured = vi.hoisted(() => vi.fn((_cfg?: unknown, _channel?: unknown) => true));
 
 vi.mock("../agents/agent-scope.js", () => ({
@@ -196,7 +197,7 @@ vi.mock("./channel-setup.status.js", () => ({
   collectChannelStatus: (params: Parameters<CollectChannelStatus>[0]) =>
     collectChannelStatus(params),
   findBundledSourceForCatalogChannel: vi.fn(() => undefined),
-  noteChannelPrimer: vi.fn(),
+  noteChannelPrimer,
   noteChannelStatus: vi.fn(),
   resolveCatalogChannelSelectionHint: vi.fn(() => "download from <npm>"),
   resolveChannelSelectionNoteLines: vi.fn(() => []),
@@ -866,7 +867,6 @@ describe("setupChannels workspace shadow exclusion", () => {
       promptOrder.push("channel picker");
       return "__done__";
     });
-
     const result = await setupChannels(
       {} as OpenClawConfig,
       {} as never,
@@ -885,6 +885,7 @@ describe("setupChannels workspace shadow exclusion", () => {
 
     expect(promptOrder).toEqual(["channel setup"]);
     expect(confirm).not.toHaveBeenCalled();
+    expect(noteChannelPrimer).not.toHaveBeenCalled();
     expect(configureInteractive).toHaveBeenCalledTimes(1);
     expect(result).toMatchObject({
       channels: { "external-chat": { token: "configured" } },

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -1514,6 +1514,8 @@ describe("setupChannels workspace shadow exclusion", () => {
         select,
       } as never,
       {
+        initialSelection: ["external-chat"],
+        finishAfterInitialSelection: true,
         deferStatusUntilSelection: true,
         skipConfirm: true,
         skipDmPolicyPrompt: true,
@@ -1526,6 +1528,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       initialValue: true,
     });
     expect(setupWizard.configure).not.toHaveBeenCalled();
+    expect(select).not.toHaveBeenCalled();
     expect(next).toEqual({
       channels: {
         "external-chat": { enabled: false, token: "secret" },

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -134,6 +134,7 @@ const collectChannelStatus = vi.hoisted(() =>
 );
 const noteChannelPrimer = vi.hoisted(() => vi.fn(async () => undefined));
 const isChannelConfigured = vi.hoisted(() => vi.fn((_cfg?: unknown, _channel?: unknown) => true));
+const normalizeChannelId = vi.hoisted(() => vi.fn((_raw?: unknown): string | null => null));
 
 vi.mock("../agents/agent-scope.js", () => ({
   resolveAgentWorkspaceDir: (cfg?: unknown, agentId?: unknown) =>
@@ -146,6 +147,13 @@ vi.mock("../channels/plugins/setup-registry.js", () => ({
   listActiveChannelSetupPlugins: () => listActiveChannelSetupPlugins(),
   listChannelSetupPlugins: () => listChannelSetupPlugins(),
 }));
+
+vi.mock("../channels/plugins/index.js", async () => {
+  const actual = await vi.importActual<typeof import("../channels/plugins/index.js")>(
+    "../channels/plugins/index.js",
+  );
+  return { ...actual, normalizeChannelId };
+});
 
 vi.mock("../channels/registry.js", () => ({
   getChatChannelMeta: (channelId: string) => ({ id: channelId, label: channelId }),
@@ -239,6 +247,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       statusLines: [],
     });
     isChannelConfigured.mockReturnValue(true);
+    normalizeChannelId.mockReturnValue(null);
   });
 
   it("preloads configured external plugins from the trusted catalog boundary", async () => {
@@ -831,66 +840,142 @@ describe("setupChannels workspace shadow exclusion", () => {
     },
   );
 
-  it("enters an explicitly targeted channel before the generic setup prompts", async () => {
-    const promptOrder: string[] = [];
-    const configureInteractive = vi.fn(async ({ cfg }) => {
-      promptOrder.push("channel setup");
-      return {
-        cfg: {
-          ...cfg,
-          channels: { ...cfg.channels, "external-chat": { token: "configured" } },
-        },
-        accountId: "external-account",
-      };
-    });
-    const externalChatPlugin = makeSetupPlugin({
-      id: "external-chat",
-      label: "External Chat",
-      setupWizard: {
-        channel: "external-chat",
-        getStatus: vi.fn(async () => ({
+  it.each(["external-chat", "external"])(
+    "enters an explicitly targeted channel before generic setup prompts for %s",
+    async (target) => {
+      const promptOrder: string[] = [];
+      const forceAllowValues: boolean[] = [];
+      const configureInteractive = vi.fn(async ({ cfg, forceAllowFrom }) => {
+        promptOrder.push("channel setup");
+        forceAllowValues.push(forceAllowFrom);
+        return {
+          cfg: {
+            ...cfg,
+            channels: { ...cfg.channels, "external-chat": { token: "configured" } },
+          },
+          accountId: "external-account",
+        };
+      });
+      const externalChatPlugin = makeSetupPlugin({
+        id: "external-chat",
+        label: "External Chat",
+        setupWizard: {
           channel: "external-chat",
-          configured: false,
-          statusLines: [],
-        })),
-        configure: vi.fn(),
-        configureInteractive,
-      } as ChannelSetupPlugin["setupWizard"],
-    });
-    resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
-    listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
-    const confirm = vi.fn(async () => {
-      promptOrder.push("setup confirmation");
-      return true;
-    });
-    const select = vi.fn(async () => {
-      promptOrder.push("channel picker");
-      return "__done__";
-    });
-    const result = await setupChannels(
+          getStatus: vi.fn(async () => ({
+            channel: "external-chat",
+            configured: false,
+            statusLines: [],
+          })),
+          configure: vi.fn(),
+          configureInteractive,
+        } as ChannelSetupPlugin["setupWizard"],
+      });
+      resolveChannelSetupEntries.mockReturnValue(
+        externalChatSetupEntries({
+          entries: [
+            {
+              id: "external-chat",
+              meta: makeMeta("external-chat", "External Chat", { aliases: ["external"] }),
+            },
+          ],
+        }),
+      );
+      listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
+      const confirm = vi.fn(async () => {
+        promptOrder.push("setup confirmation");
+        return true;
+      });
+      const select = vi.fn(async () => {
+        promptOrder.push("channel picker");
+        return "__done__";
+      });
+      const result = await setupChannels(
+        {} as OpenClawConfig,
+        {} as never,
+        {
+          confirm,
+          note: vi.fn(async () => undefined),
+          select,
+        } as never,
+        {
+          initialSelection: [target],
+          forceAllowFromChannels: [target],
+          finishAfterInitialSelection: true,
+          deferStatusUntilSelection: true,
+          skipDmPolicyPrompt: true,
+        },
+      );
+
+      expect(promptOrder).toEqual(["channel setup"]);
+      expect(confirm).not.toHaveBeenCalled();
+      expect(noteChannelPrimer).toHaveBeenCalledTimes(1);
+      expect(noteChannelPrimer).toHaveBeenCalledWith(expect.anything(), []);
+      expect(configureInteractive).toHaveBeenCalledTimes(1);
+      expect(forceAllowValues).toEqual([true]);
+      expect(result).toMatchObject({
+        channels: { "external-chat": { token: "configured" } },
+        plugins: { entries: { "external-chat": { enabled: true } } },
+      });
+    },
+  );
+
+  it("keeps active registry ownership authoritative for a targeted alias", async () => {
+    const configureFirst = vi.fn(async ({ cfg }: { cfg: OpenClawConfig }) => ({
+      cfg,
+      accountId: "first",
+    }));
+    const configureActive = vi.fn(async ({ cfg }: { cfg: OpenClawConfig }) => ({
+      cfg,
+      accountId: "active",
+    }));
+    const makeTargetPlugin = (
+      id: string,
+      configureInteractive: typeof configureFirst,
+    ): ChannelSetupPlugin =>
+      makeSetupPlugin({
+        id,
+        label: id,
+        setupWizard: {
+          channel: id,
+          getStatus: vi.fn(async () => ({ channel: id, configured: false, statusLines: [] })),
+          configure: vi.fn(),
+          configureInteractive,
+        } as ChannelSetupPlugin["setupWizard"],
+      });
+    resolveChannelSetupEntries.mockReturnValue(
+      externalChatSetupEntries({
+        entries: [
+          { id: "first-chat", meta: makeMeta("first-chat", "First", { aliases: ["shared"] }) },
+          {
+            id: "active-chat",
+            meta: makeMeta("active-chat", "Active", { aliases: ["shared"] }),
+          },
+        ],
+      }),
+    );
+    listActiveChannelSetupPlugins.mockReturnValue([
+      makeTargetPlugin("first-chat", configureFirst),
+      makeTargetPlugin("active-chat", configureActive),
+    ]);
+    normalizeChannelId.mockImplementation((raw) => (raw === "shared" ? "active-chat" : null));
+
+    await setupChannels(
       {} as OpenClawConfig,
       {} as never,
       {
-        confirm,
+        confirm: vi.fn(async () => true),
         note: vi.fn(async () => undefined),
-        select,
       } as never,
       {
-        initialSelection: ["external-chat"],
+        initialSelection: ["shared"],
         finishAfterInitialSelection: true,
         deferStatusUntilSelection: true,
         skipDmPolicyPrompt: true,
       },
     );
 
-    expect(promptOrder).toEqual(["channel setup"]);
-    expect(confirm).not.toHaveBeenCalled();
-    expect(noteChannelPrimer).not.toHaveBeenCalled();
-    expect(configureInteractive).toHaveBeenCalledTimes(1);
-    expect(result).toMatchObject({
-      channels: { "external-chat": { token: "configured" } },
-      plugins: { entries: { "external-chat": { enabled: true } } },
-    });
+    expect(configureActive).toHaveBeenCalledTimes(1);
+    expect(configureFirst).not.toHaveBeenCalled();
   });
 
   it("keeps an unknown targeted channel in the shared picker flow", async () => {
@@ -930,67 +1015,80 @@ describe("setupChannels workspace shadow exclusion", () => {
     expect(result).toEqual(cfg);
   });
 
-  it("returns targeted channel setup Back navigation to the channel picker", async () => {
-    const promptOrder: string[] = [];
-    const configureInteractive = vi.fn(async ({ prompter }) => {
-      promptOrder.push("channel setup");
-      await prompter.text({ message: "External Chat token" });
-      return {
-        cfg: {
-          channels: { "external-chat": { token: "should-not-apply" } },
-        } as OpenClawConfig,
-        accountId: "external-account",
-      };
-    });
-    const externalChatPlugin = makeSetupPlugin({
-      id: "external-chat",
-      label: "External Chat",
-      setupWizard: {
-        channel: "external-chat",
-        getStatus: vi.fn(async () => ({
+  it.each(["external-chat", "external"])(
+    "returns targeted channel setup Back navigation to the canonical picker option for %s",
+    async (target) => {
+      const promptOrder: string[] = [];
+      const configureInteractive = vi.fn(async ({ prompter }) => {
+        promptOrder.push("channel setup");
+        await prompter.text({ message: "External Chat token" });
+        return {
+          cfg: {
+            channels: { "external-chat": { token: "should-not-apply" } },
+          } as OpenClawConfig,
+          accountId: "external-account",
+        };
+      });
+      const externalChatPlugin = makeSetupPlugin({
+        id: "external-chat",
+        label: "External Chat",
+        setupWizard: {
           channel: "external-chat",
-          configured: false,
-          statusLines: [],
-        })),
-        configure: vi.fn(),
-        configureInteractive,
-      } as ChannelSetupPlugin["setupWizard"],
-    });
-    resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
-    listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
-    const select = vi.fn(async () => {
-      promptOrder.push("channel picker");
-      return "__done__";
-    });
-    const cfg = { channels: { telegram: { botToken: "keep" } } } as OpenClawConfig;
-
-    const result = await setupChannels(
-      cfg,
-      {} as never,
-      {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
-        select,
-        text: vi.fn(async () => {
-          throw new WizardNavigationError("back");
+          getStatus: vi.fn(async () => ({
+            channel: "external-chat",
+            configured: false,
+            statusLines: [],
+          })),
+          configure: vi.fn(),
+          configureInteractive,
+        } as ChannelSetupPlugin["setupWizard"],
+      });
+      resolveChannelSetupEntries.mockReturnValue(
+        externalChatSetupEntries({
+          entries: [
+            {
+              id: "external-chat",
+              meta: makeMeta("external-chat", "External Chat", { aliases: ["external"] }),
+            },
+          ],
         }),
-      } as never,
-      {
-        initialSelection: ["external-chat"],
-        finishAfterInitialSelection: true,
-        deferStatusUntilSelection: true,
-        skipDmPolicyPrompt: true,
-      },
-    );
+      );
+      listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
+      const select = vi.fn(async () => {
+        promptOrder.push("channel picker");
+        return "__done__";
+      });
+      const cfg = { channels: { telegram: { botToken: "keep" } } } as OpenClawConfig;
 
-    expect(promptOrder).toEqual(["channel setup", "channel picker"]);
-    expect(select).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: "Select a channel",
-      }),
-    );
-    expect(result).toEqual(cfg);
-  });
+      const result = await setupChannels(
+        cfg,
+        {} as never,
+        {
+          confirm: vi.fn(async () => true),
+          note: vi.fn(async () => undefined),
+          select,
+          text: vi.fn(async () => {
+            throw new WizardNavigationError("back");
+          }),
+        } as never,
+        {
+          initialSelection: [target],
+          finishAfterInitialSelection: true,
+          deferStatusUntilSelection: true,
+          skipDmPolicyPrompt: true,
+        },
+      );
+
+      expect(promptOrder).toEqual(["channel setup", "channel picker"]);
+      expect(select).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialValue: "external-chat",
+          message: "Select a channel",
+        }),
+      );
+      expect(result).toEqual(cfg);
+    },
+  );
 
   it("returns custom channel setup to channel selection when its first prompt goes back", async () => {
     const configureInteractive = vi.fn(async ({ prompter }) => {

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -250,6 +250,8 @@ export async function setupChannels(
     getVisibleChannelEntries().some((entry) => entry.id === requestedTargetedChannel)
       ? requestedTargetedChannel
       : undefined;
+  const pickerInitialSelection =
+    requestedTargetedChannel && !targetedChannel ? undefined : options?.initialSelection?.[0];
   const shouldConfigure =
     options?.skipConfirm || targetedChannel
       ? true
@@ -271,7 +273,7 @@ export async function setupChannels(
   }
 
   const quickstartDefault =
-    options?.initialSelection?.[0] ??
+    pickerInitialSelection ??
     (deferStatusUntilSelection ? undefined : resolveQuickstartDefault(statusByChannel));
 
   const shouldPromptAccountIds = options?.promptAccountIds === true;
@@ -913,7 +915,7 @@ export async function setupChannels(
 
   if (!targetedChannel && options?.quickstartDefaults) {
     const skipValue = "__skip__" as const;
-    const quickstartInitialValue = options?.initialSelection?.[0] ?? skipValue;
+    const quickstartInitialValue = pickerInitialSelection ?? skipValue;
     while (true) {
       const { entries, catalogById } = getChannelEntries();
       const choice = await prompter.select({
@@ -944,7 +946,7 @@ export async function setupChannels(
     }
   } else if (!targetedChannel || targetedSetupReturnedToPicker) {
     const doneValue = "__done__" as const;
-    const initialValue = options?.initialSelection?.[0] ?? quickstartDefault;
+    const initialValue = pickerInitialSelection ?? quickstartDefault;
     while (true) {
       const { entries, catalogById } = getChannelEntries();
       const choice = await prompter.select({

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -251,12 +251,14 @@ export async function setupChannels(
     return cfg;
   }
 
-  const primerChannels = resolveVisibleChannelEntries().entries.map((entry) => ({
-    id: entry.id,
-    label: entry.meta.label,
-    blurb: entry.meta.blurb,
-  }));
-  await noteChannelPrimer(prompter, primerChannels);
+  if (!targetedChannel) {
+    const primerChannels = resolveVisibleChannelEntries().entries.map((entry) => ({
+      id: entry.id,
+      label: entry.meta.label,
+      blurb: entry.meta.blurb,
+    }));
+    await noteChannelPrimer(prompter, primerChannels);
+  }
 
   const quickstartDefault =
     options?.initialSelection?.[0] ??

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -236,9 +236,19 @@ export async function setupChannels(
     await prompter.note(statusLines.join("\n"), t("wizard.channels.statusTitle"));
   }
 
-  const targetedChannel =
+  const requestedTargetedChannel =
     options?.finishAfterInitialSelection && options.initialSelection?.length === 1
       ? options.initialSelection[0]
+      : undefined;
+  let visibleChannelEntries: ReturnType<typeof resolveVisibleChannelEntries>["entries"] | undefined;
+  const getVisibleChannelEntries = () => {
+    visibleChannelEntries ??= resolveVisibleChannelEntries().entries;
+    return visibleChannelEntries;
+  };
+  const targetedChannel =
+    requestedTargetedChannel &&
+    getVisibleChannelEntries().some((entry) => entry.id === requestedTargetedChannel)
+      ? requestedTargetedChannel
       : undefined;
   const shouldConfigure =
     options?.skipConfirm || targetedChannel
@@ -252,7 +262,7 @@ export async function setupChannels(
   }
 
   if (!targetedChannel) {
-    const primerChannels = resolveVisibleChannelEntries().entries.map((entry) => ({
+    const primerChannels = getVisibleChannelEntries().map((entry) => ({
       id: entry.id,
       label: entry.meta.label,
       blurb: entry.meta.blurb,

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -653,13 +653,10 @@ export async function setupChannels(
     let resumingDisabledChannel = false;
     if (deferredDisabledHint) {
       if (deferredDisabledHint === "disabled") {
-        const resume =
-          channel === targetedChannel
-            ? true
-            : await prompter.confirm({
-                message: t("wizard.channels.resumeDisabledSetup", { channel }),
-                initialValue: true,
-              });
+        const resume = await prompter.confirm({
+          message: t("wizard.channels.resumeDisabledSetup", { channel }),
+          initialValue: true,
+        });
         if (!resume) {
           return "done";
         }
@@ -678,13 +675,10 @@ export async function setupChannels(
         } as OpenClawConfig;
         resumingDisabledChannel = true;
       } else if (deferredDisabledHint === "plugin disabled") {
-        const resume =
-          channel === targetedChannel
-            ? true
-            : await prompter.confirm({
-                message: t("wizard.channels.resumeDisabledPluginSetup", { channel }),
-                initialValue: true,
-              });
+        const resume = await prompter.confirm({
+          message: t("wizard.channels.resumeDisabledPluginSetup", { channel }),
+          initialValue: true,
+        });
         if (!resume) {
           return "done";
         }

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -2,6 +2,7 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getBundledChannelSetupPlugin } from "../channels/plugins/bundled.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
+import { normalizeChannelId } from "../channels/plugins/index.js";
 import { listActiveChannelSetupPlugins } from "../channels/plugins/setup-registry.js";
 import type {
   ChannelOnboardingPostWriteHook,
@@ -13,6 +14,7 @@ import type {
   SetupChannelsOptions,
 } from "../channels/plugins/setup-wizard-types.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import { resolveChannelTarget } from "../commands/channel-setup/channel-entry-resolution.js";
 import {
   resolveChannelSetupEntries,
   shouldShowChannelInSetup,
@@ -118,7 +120,6 @@ export async function setupChannels(
 ): Promise<OpenClawConfig> {
   let next = cfg;
   const deferStatusUntilSelection = options?.deferStatusUntilSelection === true;
-  const forceAllowFromChannels = new Set(options?.forceAllowFromChannels ?? []);
   const accountOverrides: Partial<Record<ChannelChoice, string>> = {
     ...options?.accountIds,
   };
@@ -245,13 +246,23 @@ export async function setupChannels(
     visibleChannelEntries ??= resolveVisibleChannelEntries().entries;
     return visibleChannelEntries;
   };
-  const targetedChannel =
-    requestedTargetedChannel &&
-    getVisibleChannelEntries().some((entry) => entry.id === requestedTargetedChannel)
-      ? requestedTargetedChannel
-      : undefined;
-  const pickerInitialSelection =
-    requestedTargetedChannel && !targetedChannel ? undefined : options?.initialSelection?.[0];
+  const resolveVisibleChannel = (raw: string) =>
+    resolveChannelTarget({
+      raw,
+      entries: getVisibleChannelEntries(),
+      registeredId: normalizeChannelId(raw),
+    })?.entry?.id;
+  const targetedChannel = requestedTargetedChannel
+    ? resolveVisibleChannel(requestedTargetedChannel)
+    : undefined;
+  const forceAllowFromChannels = new Set(
+    (options?.forceAllowFromChannels ?? []).map(
+      (channel) => resolveVisibleChannel(channel) ?? channel,
+    ),
+  );
+  const pickerInitialSelection = requestedTargetedChannel
+    ? targetedChannel
+    : options?.initialSelection?.[0];
   const shouldConfigure =
     options?.skipConfirm || targetedChannel
       ? true
@@ -263,14 +274,14 @@ export async function setupChannels(
     return cfg;
   }
 
-  if (!targetedChannel) {
-    const primerChannels = getVisibleChannelEntries().map((entry) => ({
-      id: entry.id,
-      label: entry.meta.label,
-      blurb: entry.meta.blurb,
-    }));
-    await noteChannelPrimer(prompter, primerChannels);
-  }
+  const primerChannels = targetedChannel
+    ? []
+    : getVisibleChannelEntries().map((entry) => ({
+        id: entry.id,
+        label: entry.meta.label,
+        blurb: entry.meta.blurb,
+      }));
+  await noteChannelPrimer(prompter, primerChannels);
 
   const quickstartDefault =
     pickerInitialSelection ??

--- a/src/system-agent/chat-engine.channel-hooks.test.ts
+++ b/src/system-agent/chat-engine.channel-hooks.test.ts
@@ -52,6 +52,7 @@ const mocks = vi.hoisted(() => {
     })),
     runCollectedChannelOnboardingPostWriteHooks: vi.fn(async () => {}),
     setupChannels: vi.fn(async (_cfg, _runtime, _prompter, options) => {
+      options?.onSelection?.(["matrix"]);
       options?.onPostWriteHook?.(hook);
       return { channels: { matrix: { enabled: true } } };
     }),

--- a/src/system-agent/chat-engine.channel-hooks.test.ts
+++ b/src/system-agent/chat-engine.channel-hooks.test.ts
@@ -146,7 +146,11 @@ describe("OpenClaw chat channel setup", () => {
       {},
       expect.any(Object),
       expect.any(Object),
-      expect.objectContaining({ beforePersistentEffect: expect.any(Function) }),
+      expect.objectContaining({
+        initialSelection: ["matrix"],
+        finishAfterInitialSelection: true,
+        beforePersistentEffect: expect.any(Function),
+      }),
     );
     expect(mocks.runCollectedChannelOnboardingPostWriteHooks).toHaveBeenCalledWith({
       hooks: [mocks.hook],

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -846,6 +846,41 @@ describe("SystemAgentChatEngine", () => {
     expect(wizardRuns).toEqual(["telegram", "token:123:abc", "mode:open"]);
   });
 
+  it("keeps an unknown channel request pending on the shared picker", async () => {
+    useTempStateDir();
+    const baseConfig = {} as OpenClawConfig;
+    mocks.readSetupConfigFileSnapshot.mockResolvedValue(configSnapshot(baseConfig) as never);
+    mocks.setupChannels.mockImplementation(
+      async (config: OpenClawConfig, _runtime: unknown, prompter: WizardPrompter) => {
+        await prompter.select({
+          message: "Select a channel",
+          options: [
+            { value: "telegram", label: "Telegram" },
+            { value: "discord", label: "Discord" },
+          ],
+        });
+        return config;
+      },
+    );
+    const engine = new SystemAgentChatEngine({
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+    });
+
+    const reply = await engine.handle("connect unknown-chat");
+
+    expect(reply.text).toContain("Select a channel");
+    expect(reply.text).not.toContain("is configured");
+    expect(reply.question).toEqual({
+      id: expect.any(String),
+      header: "Choose one",
+      question: "Select a channel",
+      options: [{ label: "Telegram" }, { label: "Discord" }],
+    });
+    expect(mocks.writeWizardConfigFile).not.toHaveBeenCalled();
+  });
+
   it("hosts the real skills setup flow and guards installs plus the final config write", async () => {
     const baseConfig: OpenClawConfig = {
       agents: { defaults: { workspace: "/tmp/skills-workspace" } },

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -851,14 +851,21 @@ describe("SystemAgentChatEngine", () => {
     const baseConfig = {} as OpenClawConfig;
     mocks.readSetupConfigFileSnapshot.mockResolvedValue(configSnapshot(baseConfig) as never);
     mocks.setupChannels.mockImplementation(
-      async (config: OpenClawConfig, _runtime: unknown, prompter: WizardPrompter) => {
+      async (
+        config: OpenClawConfig,
+        _runtime: unknown,
+        prompter: WizardPrompter,
+        options: { onSelection?: (selection: string[]) => void },
+      ) => {
         await prompter.select({
           message: "Select a channel",
           options: [
             { value: "telegram", label: "Telegram" },
             { value: "discord", label: "Discord" },
+            { value: "__done__", label: "Done" },
           ],
         });
+        options.onSelection?.([]);
         return config;
       },
     );
@@ -876,8 +883,14 @@ describe("SystemAgentChatEngine", () => {
       id: expect.any(String),
       header: "Choose one",
       question: "Select a channel",
-      options: [{ label: "Telegram" }, { label: "Discord" }],
+      options: [{ label: "Telegram" }, { label: "Discord" }, { label: "Done" }],
     });
+    expect(mocks.writeWizardConfigFile).not.toHaveBeenCalled();
+
+    const dismissed = await engine.handle("Done");
+
+    expect(dismissed.text).toContain("Nothing was changed");
+    expect(dismissed.text).not.toContain("is configured");
     expect(mocks.writeWizardConfigFile).not.toHaveBeenCalled();
   });
 

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -846,6 +846,32 @@ describe("SystemAgentChatEngine", () => {
     expect(wizardRuns).toEqual(["telegram", "token:123:abc", "mode:open"]);
   });
 
+  it("leaves channel-owned selections user-driven when an option matches the target", async () => {
+    useTempStateDir();
+    let selected: unknown;
+    const engine = new SystemAgentChatEngine({
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard: async (_channel, prompter) => {
+        selected = await prompter.select({
+          message: "Choose Feishu or Lark",
+          options: [
+            { value: "feishu", label: "Feishu" },
+            { value: "lark", label: "Lark" },
+          ],
+        });
+      },
+    });
+
+    const prompt = await engine.handle("connect feishu");
+
+    expect(prompt.text).toContain("Choose Feishu or Lark");
+    expect(selected).toBeUndefined();
+    await engine.handle("Lark");
+    expect(selected).toBe("lark");
+  });
+
   it("keeps an unknown channel request pending on the shared picker", async () => {
     useTempStateDir();
     const baseConfig = {} as OpenClawConfig;
@@ -892,6 +918,97 @@ describe("SystemAgentChatEngine", () => {
     expect(dismissed.text).toContain("Nothing was changed");
     expect(dismissed.text).not.toContain("is configured");
     expect(mocks.writeWizardConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("reports and audits the canonical channel selected by the fallback picker", async () => {
+    useTempStateDir();
+    const baseConfig = {} as OpenClawConfig;
+    const nextConfig = { channels: { telegram: { botToken: "configured" } } } as OpenClawConfig;
+    const appendAuditEntry = vi.fn(async () => "state/openclaw.sqlite");
+    mocks.readSetupConfigFileSnapshot.mockResolvedValue(configSnapshot(baseConfig) as never);
+    mocks.writeWizardConfigFile.mockResolvedValue(nextConfig as never);
+    mocks.setupChannels.mockImplementation(
+      async (
+        _config: OpenClawConfig,
+        _runtime: unknown,
+        prompter: WizardPrompter,
+        options: { onSelection?: (selection: string[]) => void },
+      ) => {
+        const selected = await prompter.select({
+          message: "Select a channel",
+          options: [
+            { value: "telegram", label: "Telegram" },
+            { value: "__done__", label: "Done" },
+          ],
+        });
+        options.onSelection?.([selected]);
+        return nextConfig;
+      },
+    );
+    const engine = new SystemAgentChatEngine({
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      appendAuditEntry,
+    });
+
+    const picker = await engine.handle("connect unknown-chat");
+    expect(picker.text).toContain("Select a channel");
+
+    const done = await engine.handle("Telegram");
+
+    expect(done.text).toContain("Done — telegram is configured.");
+    expect(done.text).not.toContain("unknown-chat is configured");
+    expect(appendAuditEntry).toHaveBeenCalledWith({
+      operation: "channels.setup",
+      summary: "Configured channel telegram via chat setup",
+      details: { channel: "telegram" },
+    });
+  });
+
+  it("reports and audits every channel configured after picker fallback", async () => {
+    useTempStateDir();
+    const baseConfig = {} as OpenClawConfig;
+    const nextConfig = {
+      channels: {
+        telegram: { botToken: "configured" },
+        discord: { token: "configured" },
+      },
+    } as OpenClawConfig;
+    const appendAuditEntry = vi.fn(async () => "state/openclaw.sqlite");
+    mocks.readSetupConfigFileSnapshot.mockResolvedValue(configSnapshot(baseConfig) as never);
+    mocks.writeWizardConfigFile.mockResolvedValue(nextConfig as never);
+    mocks.setupChannels.mockImplementation(
+      async (
+        _config: OpenClawConfig,
+        _runtime: unknown,
+        prompter: WizardPrompter,
+        options: { onSelection?: (selection: string[]) => void },
+      ) => {
+        await prompter.select({
+          message: "Select a channel",
+          options: [{ value: "telegram", label: "Telegram" }],
+        });
+        options.onSelection?.(["telegram", "discord"]);
+        return nextConfig;
+      },
+    );
+    const engine = new SystemAgentChatEngine({
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      appendAuditEntry,
+    });
+
+    await engine.handle("connect unknown-chat");
+    const done = await engine.handle("Telegram");
+
+    expect(done.text).toContain("Done — configured channels: telegram, discord.");
+    expect(appendAuditEntry).toHaveBeenCalledWith({
+      operation: "channels.setup",
+      summary: "Configured 2 channels via chat setup",
+      details: { channels: ["telegram", "discord"] },
+    });
   });
 
   it("hosts the real skills setup flow and guards installs plus the final config write", async () => {

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -271,6 +271,7 @@ async function defaultChannelSetupWizardRunner(
     run: async ({ baseConfig, runtime }) => ({
       nextConfig: await setupChannels(baseConfig, runtime, prompter, {
         initialSelection: [channel],
+        finishAfterInitialSelection: true,
         forceAllowFromChannels: [channel],
         allowIMessageInstall: true,
         allowSignalInstall: true,

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -1,4 +1,5 @@
 // OpenClaw chat engine: transport-agnostic conversation over typed operations.
+import { isDeepStrictEqual } from "node:util";
 import type {
   SystemAgentChatQuestion,
   SystemAgentWizardCancel,
@@ -268,8 +269,9 @@ async function defaultChannelSetupWizardRunner(
   return await runHostedConfigWizard({
     label: "Channel setup",
     beforePersistentApply,
-    run: async ({ baseConfig, runtime }) => ({
-      nextConfig: await setupChannels(baseConfig, runtime, prompter, {
+    run: async ({ baseConfig, runtime }) => {
+      let selection: string[] = [];
+      const nextConfig = await setupChannels(baseConfig, runtime, prompter, {
         initialSelection: [channel],
         finishAfterInitialSelection: true,
         forceAllowFromChannels: [channel],
@@ -280,17 +282,26 @@ async function defaultChannelSetupWizardRunner(
         skipDmPolicyPrompt: true,
         skipConfirm: true,
         beforePersistentEffect: async () => await beforePersistentApply(runtime),
+        onSelection: (selected) => {
+          selection = selected;
+        },
         onPostWriteHook: (hook) => postWriteHooks.collect(hook),
-      }),
-      afterWrite: async (committedConfig) => {
-        await runCollectedChannelOnboardingPostWriteHooks({
-          hooks: postWriteHooks.drain(),
-          cfg: committedConfig,
-          runtime,
-          beforePersistentEffect: async () => await beforePersistentApply(runtime),
-        });
-      },
-    }),
+      });
+      if (selection.length === 0 && isDeepStrictEqual(nextConfig, baseConfig)) {
+        return { keptCurrent: true };
+      }
+      return {
+        nextConfig,
+        afterWrite: async (committedConfig) => {
+          await runCollectedChannelOnboardingPostWriteHooks({
+            hooks: postWriteHooks.drain(),
+            cfg: committedConfig,
+            runtime,
+            beforePersistentEffect: async () => await beforePersistentApply(runtime),
+          });
+        },
+      };
+    },
   });
 }
 

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -95,7 +95,7 @@ export type SystemAgentChatEngineOptions = {
     channel: string,
     prompter: WizardPrompterLike,
     beforePersistentApply: (runtime: RuntimeEnv) => Promise<void>,
-  ) => Promise<void>;
+  ) => Promise<void | HostedChannelSetupOutcome>;
   /** Test seam for workspace-skill dependency setup hosted by the chat bridge. */
   runSkillsSetupWizard?: (
     prompter: WizardPrompterLike,
@@ -150,11 +150,21 @@ type WizardPrompterLike = import("../wizard/prompts.js").WizardPrompter;
 
 type HostedWizardCompletion = "applied" | "kept-current";
 
+type HostedChannelSetupOutcome = {
+  kind: "channel-setup";
+  status: HostedWizardCompletion;
+  configuredChannels?: string[];
+};
+
 type HostedMemoryImportOutcome =
   | SetupMemoryImportOutcome
   | { status: "workspace-missing"; providers: []; workspace: string };
 
-type HostedWizardRunResult = void | HostedWizardCompletion | HostedMemoryImportOutcome;
+type HostedWizardRunResult =
+  | void
+  | HostedWizardCompletion
+  | HostedChannelSetupOutcome
+  | HostedMemoryImportOutcome;
 
 type ActiveWizardBridge = {
   session: WizardSession;
@@ -163,11 +173,10 @@ type ActiveWizardBridge = {
   label: string;
   completion: {
     status: HostedWizardCompletion;
+    configuredChannels?: string[];
     memoryImport?: HostedMemoryImportOutcome;
     memoryImportProviders?: MemoryImportProviderOutcome[];
   };
-  /** Channel to auto-answer in the first selection step ("connect telegram"). */
-  autoSelectChannel?: string;
 };
 
 type CaptureRuntime = RuntimeEnv & {
@@ -259,18 +268,18 @@ async function defaultChannelSetupWizardRunner(
   channel: string,
   prompter: WizardPrompterLike,
   beforePersistentApply: (runtime: RuntimeEnv) => Promise<void>,
-): Promise<HostedWizardCompletion> {
+): Promise<HostedChannelSetupOutcome> {
   const {
     createChannelOnboardingPostWriteHookCollector,
     runCollectedChannelOnboardingPostWriteHooks,
     setupChannels,
   } = await import("../commands/onboard-channels.js");
   const postWriteHooks = createChannelOnboardingPostWriteHookCollector();
-  return await runHostedConfigWizard({
+  let selection: string[] = [];
+  const status = await runHostedConfigWizard({
     label: "Channel setup",
     beforePersistentApply,
     run: async ({ baseConfig, runtime }) => {
-      let selection: string[] = [];
       const nextConfig = await setupChannels(baseConfig, runtime, prompter, {
         initialSelection: [channel],
         finishAfterInitialSelection: true,
@@ -303,6 +312,11 @@ async function defaultChannelSetupWizardRunner(
       };
     },
   });
+  return {
+    kind: "channel-setup",
+    status,
+    ...(selection.length > 0 ? { configuredChannels: [...selection] } : {}),
+  };
 }
 
 async function defaultSkillsSetupWizardRunner(
@@ -1609,7 +1623,6 @@ export class SystemAgentChatEngine {
     return await this.startHostedWizard({
       kind: "channel",
       label: channel,
-      autoSelectChannel: channel,
       run: (prompter) => runWizard(channel, prompter, beforePersistentApply),
     });
   }
@@ -1682,13 +1695,13 @@ export class SystemAgentChatEngine {
   private async startHostedWizard(params: {
     kind: ActiveWizardBridge["kind"];
     label: string;
-    autoSelectChannel?: string;
     memoryImportProviders?: MemoryImportProviderOutcome[];
     run: (prompter: WizardPrompterLike) => Promise<HostedWizardRunResult>;
   }): Promise<string> {
     this.lastSensitiveChannel = undefined;
     const completion: ActiveWizardBridge["completion"] = {
       status: "applied",
+      ...(params.kind === "channel" ? { configuredChannels: [params.label] } : {}),
       ...(params.memoryImportProviders
         ? { memoryImportProviders: params.memoryImportProviders }
         : {}),
@@ -1698,7 +1711,16 @@ export class SystemAgentChatEngine {
       if (typeof result === "string") {
         completion.status = result;
       } else if (result) {
-        completion.memoryImport = result;
+        if ("kind" in result) {
+          completion.status = result.status;
+          if (result.configuredChannels?.length) {
+            completion.configuredChannels = [...result.configuredChannels];
+          } else {
+            delete completion.configuredChannels;
+          }
+        } else {
+          completion.memoryImport = result;
+        }
       }
     });
     this.wizardBridge = {
@@ -1707,7 +1729,6 @@ export class SystemAgentChatEngine {
       kind: params.kind,
       label: params.label,
       completion,
-      ...(params.autoSelectChannel ? { autoSelectChannel: params.autoSelectChannel } : {}),
     };
     return await this.pumpWizardBridge();
   }
@@ -1721,29 +1742,6 @@ export class SystemAgentChatEngine {
       ].join("\n"),
       action: "none",
     };
-  }
-
-  /**
-   * "connect telegram" already names the channel; answer the wizard's channel
-   * selection step automatically instead of echoing the full channel wall.
-   */
-  private tryAutoSelectChannel(step: WizardStep): { value: unknown } | null {
-    const bridge = this.wizardBridge;
-    const channel = bridge?.autoSelectChannel;
-    if (!bridge || !channel) {
-      return null;
-    }
-    if (step.type !== "select" && step.type !== "multiselect") {
-      return null;
-    }
-    const match = (step.options ?? []).find(
-      (option) => typeof option.value === "string" && option.value.toLowerCase() === channel,
-    );
-    if (!match) {
-      return null;
-    }
-    bridge.autoSelectChannel = undefined;
-    return { value: step.type === "multiselect" ? [match.value] : match.value };
   }
 
   /** Advance the hosted wizard to the next interactive step (or completion). */
@@ -1763,13 +1761,26 @@ export class SystemAgentChatEngine {
         if (bridge.completion.status === "kept-current") {
           return `${label[0]?.toUpperCase() ?? "S"}${label.slice(1)} setup kept the current configuration. Nothing was changed.`;
         }
+        const configuredChannels = bridge.completion.configuredChannels ?? [];
         const audit =
           bridge.kind === "channel"
-            ? {
-                operation: "channels.setup",
-                summary: `Configured channel ${label} via chat setup`,
-                details: { channel: label },
-              }
+            ? configuredChannels.length === 1
+              ? {
+                  operation: "channels.setup",
+                  summary: `Configured channel ${configuredChannels[0]} via chat setup`,
+                  details: { channel: configuredChannels[0] },
+                }
+              : configuredChannels.length > 1
+                ? {
+                    operation: "channels.setup",
+                    summary: `Configured ${configuredChannels.length} channels via chat setup`,
+                    details: { channels: configuredChannels },
+                  }
+                : {
+                    operation: "channels.setup",
+                    summary: "Saved channel setup changes via chat",
+                    details: { capability: "channels" },
+                  }
             : bridge.kind === "skills"
               ? {
                   operation: "skills.setup",
@@ -1802,7 +1813,11 @@ export class SystemAgentChatEngine {
         const success =
           bridge.kind === "channel"
             ? [
-                `Done — ${label} is configured.`,
+                configuredChannels.length === 1
+                  ? `Done — ${configuredChannels[0]} is configured.`
+                  : configuredChannels.length > 1
+                    ? `Done — configured channels: ${configuredChannels.join(", ")}.`
+                    : "Done — channel setup changes were saved.",
                 "Say `restart gateway` to apply channel changes, or `channels` to review.",
               ]
             : bridge.kind === "skills"
@@ -1828,13 +1843,6 @@ export class SystemAgentChatEngine {
     }
     bridge.step = result.step ?? null;
     if (bridge.step) {
-      const auto = this.tryAutoSelectChannel(bridge.step);
-      if (auto) {
-        const step = bridge.step;
-        bridge.step = null;
-        await bridge.session.answer(step.id, auto.value);
-        return await this.pumpWizardBridge();
-      }
       if (this.opts.surface === "cli" && bridge.step.sensitive === true) {
         bridge.session.cancel();
         this.wizardBridge = null;


### PR DESCRIPTION
## Outcome

Targeted channel setup now resolves one canonical channel owner and carries that decision through setup, CLI execution, completion receipts, audit records, and removal.

- Known chat targets enter the channel-owned setup flow directly. The generic channel catalogue is skipped, while pairing approval, open-DM, and per-peer session-safety guidance remains.
- Exact visible channel IDs take precedence over colliding aliases. Runtime-backed flows then use the active registry owner for aliases; cold `channels add` keeps its manifest-first contract and carries the selected catalog owner from option registration into execution.
- Unknown targets fall back to an answerable shared picker without an invalid default or a false success receipt.
- Back navigation returns to the picker with the canonical channel selected.
- Completion text and audit records name every channel actually configured.
- Removal resolves and prepares the canonical plugin before consent, then uses that same prepared fact for runtime stop and config mutation.

## Before / after

| Scenario | Before (`main` at the branch base) | After this PR |
|---|---|---|
| Chat: `connect slack` | Runs generic setup, including the all-channel catalogue, before auto-selecting Slack. | Starts Slack's channel-owned setup directly; the safety primer still appears. |
| Chat: `connect unknown-chat`, then dismiss | Seeds the picker with a value that is not an option and can later report the requested unknown name as configured. | Opens the shared picker with no invalid default; dismissal writes nothing and says nothing changed. |
| Chat: target an alias, then choose Back | Reopens the picker with the raw alias as its initial value. | Reopens it with the canonical channel option selected. |
| CLI: duplicate alias during `channels add` | Option registration can use one catalog entry while execution resolves another owner. | One manifest-first catalog selection owns both registered flags and execution. |
| CLI: remove an exact ID that is also an active alias | Consent can name the alias owner, then mutation disables the exact-ID owner. | Consent, runtime stop, and mutation use the same resolved exact-ID plugin. |
| Chat: fallback picker configures two channels | Completion and audit are derived from the original requested target. | Completion says `Done — configured channels: telegram, discord.` and the audit records both IDs. |

## UI proof

These captures render the real Control UI with official mocked Gateway output fixtures matching the focused engine tests. The full viewport is necessary to show the safety guidance and first credential card together.

### Before — direct base

<img width="1280" height="900" alt="Targeted Slack setup before this PR: safety guidance followed by the generic channel catalogue before the Slack credential card" src="https://github.com/user-attachments/assets/1fd24f27-7514-4890-82a9-6e880e9924ac" />

**What this shows:** `connect slack` still renders the generic channel catalogue before the Slack credential card.

**State:** `/custodian`, `connect slack` fixture, merge-base `4c951398`, 1280×900 viewport.

### After — exact PR head

<img width="1280" height="900" alt="Targeted Slack setup after this PR: safety guidance retained while setup proceeds directly to the Slack credential card" src="https://github.com/user-attachments/assets/a8444030-9f22-4287-b32c-855919c0da23" />

**What this shows:** The safety guidance remains, the generic catalogue is gone, and Slack setup starts directly.

**State:** `/custodian`, same fixture, exact head `282c2f50505d`, 1280×900 viewport.

## Compatibility decision

This deliberately standardizes precedence as **exact visible catalog ID → active registered owner → catalog alias**. The merge decision is whether to accept that an input matching both another plugin's alias and a real catalog ID now selects the real ID. Cold `channels add` remains manifest-first and does not load plugins or reread config during Commander option registration.

## Stack context

Standalone PR against `main`; it is independent of the Custodian cancellation/recovery stack. Exact head: `282c2f50505d`.

Direct-base net diff: 21 files, +1058/-292. Production is +251/-211 (net +40); tests are +807/-81 (net +726). The production growth is the shared canonical resolver, explicit configured-channel outcome, manifest-registration handoff, and prepared destructive-consent boundary.

## Verification

- Exact-head focused proof: 10 files across five Vitest shards, 272 tests passed. The covered scenarios include every A/B row above, exact-ID and alias collisions, disabled-channel consent, guarded config writes, and no-change dismissal.
- Exact-head `pnpm tsgo:core` passed.
- Exact-head formatting and `git diff --check` passed.
- [Remote ClawSweeper review](https://github.com/openclaw/openclaw/pull/120932#issuecomment-5230657971): no actionable findings on `282c2f50505d`; the remaining rank-up item is the compatibility decision above.

<details>
<summary>Focused test command</summary>

```sh
node scripts/run-vitest.mjs src/cli/channel-auth.test.ts src/cli/channels-cli.test.ts src/commands/channel-setup/channel-entry-resolution.test.ts src/commands/channel-setup/channel-plugin-resolution.test.ts src/commands/channels.add.test.ts src/commands/channels.remove.test.ts src/flows/channel-setup.status.test.ts src/flows/channel-setup.test.ts src/system-agent/chat-engine.channel-hooks.test.ts src/system-agent/chat-engine.test.ts
```

</details>
