### PR TITLE
ci: acknowledge pull request receipts in clawsweeper dispatch

### DIFF
--- a/.github/workflows/clawsweeper-dispatch.yml
+++ b/.github/workflows/clawsweeper-dispatch.yml
@@ -118,6 +118,70 @@ jobs:
           permission-issues: write
           permission-pull-requests: read
 
+      - name: Create target PR acknowledgement token
+        id: pr_ack_token
+        if: >-
+          ${{
+            github.event_name == 'pull_request_target' &&
+            (
+              github.event.action == 'ready_for_review' ||
+              (github.event.action == 'opened' && github.event.pull_request.draft == false)
+            ) &&
+            env.HAS_CLAWSWEEPER_APP_PRIVATE_KEY == 'true'
+          }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+
+      - name: Acknowledge received pull request
+        if: >-
+          ${{
+            github.event_name == 'pull_request_target' &&
+            (
+              github.event.action == 'ready_for_review' ||
+              (github.event.action == 'opened' && github.event.pull_request.draft == false)
+            ) &&
+            env.HAS_CLAWSWEEPER_APP_PRIVATE_KEY == 'true'
+          }}
+        continue-on-error: true
+        env:
+          ACK_TOKEN: ${{ steps.pr_ack_token.outputs.token }}
+          TARGET_REPO: ${{ github.repository }}
+          ITEM_NUMBER: ${{ github.event.pull_request.number }}
+          SOURCE_ACTION: ${{ github.event.action }}
+        run: |
+          set -euo pipefail
+          if [ -z "$ACK_TOKEN" ]; then
+            echo "::notice::Skipping ClawSweeper pull request acknowledgement because no target credential is configured."
+            exit 0
+          fi
+          comments="$(GH_TOKEN="$ACK_TOKEN" gh api \
+            "repos/$TARGET_REPO/issues/$ITEM_NUMBER/comments?per_page=100")"
+          if jq -e \
+            --arg marker_prefix "clawsweeper-pr-ack:" \
+            --arg marker_suffix " item=$ITEM_NUMBER -->" \
+            'any(.[]; (.body // "") as $body | ($body | contains($marker_prefix)) and ($body | contains($marker_suffix)))' \
+            <<< "$comments" >/dev/null; then
+            echo "ClawSweeper pull request acknowledgement already exists."
+            exit 0
+          fi
+          ack_body="$(printf '%s\n' \
+            "<!-- clawsweeper-pr-ack:$SOURCE_ACTION item=$ITEM_NUMBER -->" \
+            "🦞👀" \
+            "ClawSweeper picked this up." \
+            "" \
+            "Pull request received. I will update this pull request when review starts.")"
+          ack_payload="$(jq -nc --arg body "$ack_body" '{body:$body}')"
+          GH_TOKEN="$ACK_TOKEN" gh api \
+            "repos/$TARGET_REPO/issues/$ITEM_NUMBER/comments" \
+            --method POST \
+            --input - <<< "$ack_payload"
+
       - name: Dispatch GitHub activity to ClawSweeper
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}

--- a/docs/reference/pull-request-review-flow.md
+++ b/docs/reference/pull-request-review-flow.md
@@ -45,7 +45,9 @@ and help maintainers with guarded repair or automerge flows.
 A positive ClawSweeper result is supporting evidence, not maintainer approval.
 Maintainers still decide whether and when a PR is ready to merge.
 
-ClawSweeper is queue-based. Do not expect an immediate response after opening a
+ClawSweeper is queue-based. When you open a non-draft PR or mark a draft ready
+for review, it posts a short receipt comment right away, but the review itself
+still waits for a queue slot. Do not expect an immediate review after opening a
 PR, pushing a commit, or adding a review request. Label updates after a
 ClawSweeper run can also take time.
 


### PR DESCRIPTION
## What Problem This Solves

ClawSweeper review is queue-based, so contributors who open a PR against openclaw/openclaw get no signal that the bot saw it until a review slot frees up. openclaw/clawsweeper#1080 added an immediate receipt-acknowledgment step to the canonical dispatch workflow template; this repo's copy of `clawsweeper-dispatch.yml` had not picked it up yet.

## Why This Change Was Made

Propagates the canonical template change so openclaw/openclaw PRs get the same immediate "received" feedback as other ClawSweeper-managed repos. The inserted 64-line block (the `Create target PR acknowledgement token` and `Acknowledge received pull request` steps) is byte-identical to the canonical copy in openclaw/clawsweeper `.github/workflows/clawsweeper-dispatch.yml`, placed at the same structural position: after `Create target comment token`, before the dispatch steps. This repo's intentional local divergences (push/review triggers, `gh_api_with_retry` backoff helper) are untouched; the ack step uses plain `gh api` exactly as the template does, and stays template-identical for future propagation diffs.

Step behavior, as designed in the template:

- Gated to `pull_request_target` with action `ready_for_review` or non-draft `opened`.
- Mints a minimal ClawSweeper App token scoped to this repository with `permission-issues: write` only.
- Posts "Pull request received. I will update this pull request when review starts." with the hidden `clawsweeper-pr-ack:<action>` marker; checks existing comments for the marker first so re-runs and reopen events stay idempotent.
- Both steps are `continue-on-error: true`, so acknowledgment failures never block review dispatch.

## User Impact

Contributors opening a non-draft PR (or marking a draft ready for review) see a ClawSweeper receipt comment within seconds instead of silence until review starts. No change to review dispatch, issue handling, comment commands, or push/activity mirroring. `docs/reference/pull-request-review-flow.md` now mentions the receipt comment so its "do not expect an immediate response" guidance stays accurate.

## Evidence

- `diff` of the inserted block against canonical openclaw/clawsweeper `main` lines 72–135: byte-identical.
- `actionlint .github/workflows/clawsweeper-dispatch.yml`: clean.
- YAML parse (`ruby -ryaml`): OK.
- Same step is already live in openclaw/clawsweeper (landed there via openclaw/clawsweeper#1080 / #1079) and passes that repo's zizmor gate with the identical `pull_request_target` trigger comment.
