### PR TITLE
refactor(plugin-sdk): unify lazy channel config schemas

### DIFF
--- a/src/plugin-sdk/channel-entry-contract.test.ts
+++ b/src/plugin-sdk/channel-entry-contract.test.ts
@@ -120,6 +120,26 @@ function createBundledChannelEntry(params: {
 }
 
 describe("defineBundledChannelEntry", () => {
+  it("defers and memoizes config schema factories", () => {
+    const configSchema = {
+      schema: { type: "object" as const, additionalProperties: false },
+    };
+    const createConfigSchema = vi.fn(() => configSchema);
+    const entry = defineBundledChannelEntry({
+      id: "lazy-config-schema",
+      name: "Lazy Config Schema",
+      description: "lazy config schema test",
+      importMetaUrl: import.meta.url,
+      plugin: { specifier: "./unused.js" },
+      configSchema: createConfigSchema,
+    });
+
+    expect(createConfigSchema).not.toHaveBeenCalled();
+    expect(entry.configSchema).toBe(configSchema);
+    expect(entry.configSchema).toBe(configSchema);
+    expect(createConfigSchema).toHaveBeenCalledTimes(1);
+  });
+
   it("runs tool registrations without channel sidecar hydration during tool discovery", () => {
     const tempRoot = tempDirs.make("openclaw-bundled-entry-tools-");
     const runtimeMarker = path.join(tempRoot, "runtime-loaded");

--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -24,6 +24,7 @@ import type {
   BundledChannelLegacyStateMigrationDetector,
   BundledEntryModuleLoadOptions,
 } from "./channel-entry-contract.types.js";
+import { createCachedLazyValueGetter } from "./lazy-value.js";
 
 export type AnyAgentTool = import("../plugins/types.js").AnyAgentTool;
 export type OpenClawPluginApi = import("../plugins/types.js").OpenClawPluginApi;
@@ -497,10 +498,7 @@ export function defineBundledChannelEntry<TPlugin = ChannelPlugin>({
   registerFull,
   registerCapabilities,
 }: DefineBundledChannelEntryOptions<TPlugin>): BundledChannelEntryContract<TPlugin> {
-  const resolvedConfigSchema: ChannelEntryConfigSchema<TPlugin> =
-    typeof configSchema === "function"
-      ? configSchema()
-      : ((configSchema ?? emptyChannelConfigSchema()) as ChannelEntryConfigSchema<TPlugin>);
+  const getConfigSchema = createCachedLazyValueGetter(configSchema ?? emptyChannelConfigSchema);
   const loadChannelPlugin = (options?: BundledEntryModuleLoadOptions) =>
     loadBundledEntryExportSync<TPlugin>(importMetaUrl, plugin, options);
   const loadChannelOutbound = outbound
@@ -542,7 +540,9 @@ export function defineBundledChannelEntry<TPlugin = ChannelPlugin>({
     id,
     name,
     description,
-    configSchema: resolvedConfigSchema,
+    get configSchema() {
+      return getConfigSchema();
+    },
     ...(features || accountInspect
       ? { features: { ...features, ...(accountInspect ? { accountInspect: true } : {}) } }
       : {}),

--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -103,7 +103,7 @@ export type BundledChannelEntryContract<TPlugin = ChannelPlugin> = {
   id: string;
   name: string;
   description: string;
-  configSchema: ChannelEntryConfigSchema<TPlugin>;
+  configSchema: ChannelConfigSchema;
   features?: BundledChannelEntryFeatures;
   register: (api: OpenClawPluginApi) => void;
   loadChannelPlugin: (options?: BundledEntryModuleLoadOptions) => TPlugin;

--- a/src/plugin-sdk/core.test.ts
+++ b/src/plugin-sdk/core.test.ts
@@ -40,6 +40,25 @@ function createApi(registrationMode: PluginRegistrationMode): OpenClawPluginApi 
 }
 
 describe("defineChannelPluginEntry", () => {
+  it("defers and memoizes config schema factories", () => {
+    const configSchema = {
+      schema: { type: "object" as const, additionalProperties: false },
+    };
+    const createConfigSchema = vi.fn(() => configSchema);
+    const entry = defineChannelPluginEntry({
+      id: "lazy-config-schema",
+      name: "Lazy Config Schema",
+      description: "lazy config schema test",
+      plugin: createChannelPlugin("lazy-config-schema"),
+      configSchema: createConfigSchema,
+    });
+
+    expect(createConfigSchema).not.toHaveBeenCalled();
+    expect(entry.configSchema).toBe(configSchema);
+    expect(entry.configSchema).toBe(configSchema);
+    expect(createConfigSchema).toHaveBeenCalledTimes(1);
+  });
+
   it("runs tool registrations without channel runtime wiring during tool discovery", () => {
     const setRuntime = vi.fn<(runtime: PluginRuntime) => void>();
     const registerCliMetadata = vi.fn<(api: OpenClawPluginApi) => void>();

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -36,6 +36,7 @@ import {
   normalizeSessionKeyPreservingOpaquePeerIds,
   parseThreadSessionSuffix,
 } from "../sessions/session-key-utils.js";
+import { createCachedLazyValueGetter } from "./lazy-value.js";
 export type {
   AgentPromptGuidance,
   AgentPromptGuidanceEntry,
@@ -563,9 +564,9 @@ type CreatedChannelPluginBase<TResolvedAccount> = Pick<
 /**
  * Canonical entry helper for channel plugins.
  *
- * This wraps `definePluginEntry(...)`, registers the channel capability, and
- * optionally exposes extra full-runtime registration such as tools or gateway
- * handlers that only make sense outside setup-only registration modes.
+ * This shares `definePluginEntry(...)`'s lazy schema primitive, registers the
+ * channel capability, and optionally exposes extra full-runtime registration
+ * such as tools or gateway handlers outside setup-only registration modes.
  */
 export function defineChannelPluginEntry<TPlugin>({
   id,
@@ -578,15 +579,14 @@ export function defineChannelPluginEntry<TPlugin>({
   registerFull,
   registerCapabilities,
 }: DefineChannelPluginEntryOptions<TPlugin>): DefinedChannelPluginEntry<TPlugin> {
-  const resolvedConfigSchema: ChannelEntryConfigSchema<TPlugin> =
-    typeof configSchema === "function"
-      ? configSchema()
-      : ((configSchema ?? emptyChannelConfigSchema()) as ChannelEntryConfigSchema<TPlugin>);
-  const entry = {
+  const getConfigSchema = createCachedLazyValueGetter(configSchema ?? emptyChannelConfigSchema);
+  return {
     id,
     name,
     description,
-    configSchema: resolvedConfigSchema,
+    get configSchema() {
+      return getConfigSchema();
+    },
     register(api: OpenClawPluginApi) {
       if (api.registrationMode === "cli-metadata") {
         registerCliMetadata?.(api);
@@ -611,9 +611,6 @@ export function defineChannelPluginEntry<TPlugin>({
       registerFull?.(api);
       registerCapabilities?.(api);
     },
-  };
-  return {
-    ...entry,
     channelPlugin: plugin,
     ...(setRuntime ? { setChannelRuntime: setRuntime } : {}),
   };

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -510,7 +510,7 @@ type DefinedChannelPluginEntry<TPlugin> = {
   id: string;
   name: string;
   description: string;
-  configSchema: ChannelEntryConfigSchema<TPlugin>;
+  configSchema: ChannelConfigSchema;
   register: (api: OpenClawPluginApi) => void;
   channelPlugin: TPlugin;
   setChannelRuntime?: (runtime: PluginRuntime) => void;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Channel plugin entry helpers resolved config schema factories during entry construction, even though schema consumers may never inspect the schema. This made the channel entry path eager while the generic plugin entry path already supported deferred, memoized schema construction.

## Why This Change Was Made

Generic plugin schemas and channel schemas intentionally have different public types, so the two channel helpers now share the narrow cached-lazy value primitive rather than forcing one public schema type through a cast. Both helpers expose the existing `configSchema` property while deferring a factory until its first read and caching that result.

## User Impact

There is no user-visible behavior or configuration change. Plugin entry construction avoids unnecessary schema work, and channel config schema factories remain stable after their first access.

## Evidence

- `node scripts/run-vitest.mjs src/plugin-sdk/core.test.ts src/plugin-sdk/channel-entry-contract.test.ts` — 2 files, 21 tests passed.
- `oxfmt` check and `git diff --check` passed.
- Blacksmith Testbox `pnpm build` passed on lease `tbx_01kzjh2fwdtdzntfjgkgtcbc1k`; all 151 public SDK subpaths verified: https://github.com/openclaw/openclaw/actions/runs/31297506761
- Scoped Blacksmith Testbox changed gate passed on lease `tbx_01kzjjgthvrm5ec20yxdpnkgxe`, covering production, test, and plugin typechecks plus lint and SDK boundary guards: https://github.com/openclaw/openclaw/actions/runs/31298430551
- Production LOC: +16/-19 (net -3). Tests: +39/-0.
- Fresh `autoreview --mode uncommitted` completed clean with no accepted/actionable findings.
