### PR TITLE
fix(agents): agent turns fail when workspace templates are unavailable

### DIFF
--- a/src/agents/workspace.missing-templates.test.ts
+++ b/src/agents/workspace.missing-templates.test.ts
@@ -1,0 +1,55 @@
+// A packaged install whose workspace templates are absent must still serve
+// agent turns. Templates are required to *create* bootstrap files, but the
+// per-turn checks only compare existing files against them, and a missing
+// template there used to throw and fail every turn on a provisioned workspace.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const templateSearchDirs = vi.hoisted(() => ({ dirs: [] as string[] }));
+
+vi.mock("./workspace-templates.js", () => ({
+  resolveWorkspaceTemplateSearchDirs: async () => templateSearchDirs.dirs,
+}));
+
+async function makeProvisionedWorkspace(): Promise<string> {
+  // Resolve the temp root: macOS reports /var, while path guards canonicalize
+  // to /private/var, and the mismatch trips workspace boundary checks.
+  const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "oc-ws-tpl-")));
+  for (const name of ["AGENTS.md", "SOUL.md", "IDENTITY.md", "USER.md"]) {
+    await fs.writeFile(path.join(root, name), `# ${name}\n\nreal user content\n`, "utf-8");
+  }
+  return root;
+}
+
+describe("workspace bootstrap status without packaged templates", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("resolves instead of throwing when no template directory exists", async () => {
+    templateSearchDirs.dirs = [];
+    const dir = await makeProvisionedWorkspace();
+    const { resolveWorkspaceBootstrapStatus } = await import("./workspace.js");
+
+    await expect(resolveWorkspaceBootstrapStatus(dir)).resolves.toMatch(/^(pending|complete)$/);
+  });
+
+  it("treats existing bootstrap files as user content when templates are unavailable", async () => {
+    // An empty (but present) template dir is the packaged-install failure mode:
+    // the directory resolves, every individual template read misses.
+    templateSearchDirs.dirs = [
+      await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "oc-tpl-empty-"))),
+    ];
+    const dir = await makeProvisionedWorkspace();
+    const { resolveWorkspaceBootstrapStatus } = await import("./workspace.js");
+
+    // Unknown-template content must never be mistaken for regenerable
+    // boilerplate; the call completes and the files stay untouched.
+    await expect(resolveWorkspaceBootstrapStatus(dir)).resolves.toMatch(/^(pending|complete)$/);
+    await expect(fs.readFile(path.join(dir, "SOUL.md"), "utf-8")).resolves.toContain(
+      "real user content",
+    );
+  });
+});

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -233,6 +233,23 @@ async function loadTemplate(name: string): Promise<string> {
 }
 
 /**
+ * Template lookup for comparison-only checks ("is this file still pristine?").
+ * Provisioning must keep using loadTemplate() and fail loudly, because it
+ * cannot write a file it has no template for. Comparison callers only ask
+ * whether existing content still matches, so an unavailable template makes the
+ * answer unknown, never fatal: an install missing its packaged templates would
+ * otherwise turn every agent turn into a hard error on a fully provisioned
+ * workspace.
+ */
+async function loadTemplateForComparison(name: string): Promise<string | undefined> {
+  try {
+    return await loadTemplate(name);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Canonical bootstrap filenames in prompt order. Single source for the runtime
  * validation set, the name union, and the Control UI core-files list; a private
  * copy anywhere else silently drifts when a file is retired.
@@ -337,15 +354,24 @@ function isTransientWorkspaceReadError(error: unknown): boolean {
 
 async function fileContentDiffersFromTemplate(
   filePath: string,
-  template: string,
+  // Undefined when the template is unavailable: existing content cannot be
+  // attested as pristine, so it counts as user content (the safe answer, since
+  // callers use this to decide whether regenerating would destroy real work).
+  template: string | undefined,
 ): Promise<boolean> {
   try {
-    return await retryAsync(async () => (await fs.readFile(filePath, "utf-8")) !== template, {
-      attempts: 3,
-      minDelayMs: 50,
-      maxDelayMs: 50,
-      shouldRetry: (err) => isTransientWorkspaceReadError(err),
-    });
+    return await retryAsync(
+      async () => {
+        const content = await fs.readFile(filePath, "utf-8");
+        return template === undefined || content !== template;
+      },
+      {
+        attempts: 3,
+        minDelayMs: 50,
+        maxDelayMs: 50,
+        shouldRetry: (err) => isTransientWorkspaceReadError(err),
+      },
+    );
   } catch (err) {
     const anyErr = err as { code?: string };
     if (anyErr.code === "ENOENT") {
@@ -430,7 +456,10 @@ async function workspaceProfileLooksConfigured(params: {
 }): Promise<boolean> {
   const profileFileDiffs = await Promise.all(
     WORKSPACE_ONBOARDING_PROFILE_FILENAMES.map(async (fileName) =>
-      fileContentDiffersFromTemplate(path.join(params.dir, fileName), await loadTemplate(fileName)),
+      fileContentDiffersFromTemplate(
+        path.join(params.dir, fileName),
+        await loadTemplateForComparison(fileName),
+      ),
     ),
   );
   return (
@@ -454,7 +483,8 @@ async function workspaceRequiredBootstrapLooksCustomized(
       try {
         const content = await fs.readFile(filePath, "utf-8");
         const contentHash = createHash("sha256").update(content).digest("hex");
-        if (contentHash !== generatedHash && content !== (await loadTemplate(fileName))) {
+        const template = await loadTemplateForComparison(fileName);
+        if (contentHash !== generatedHash && (template === undefined || content !== template)) {
           return true;
         }
       } catch {
@@ -465,7 +495,10 @@ async function workspaceRequiredBootstrapLooksCustomized(
   }
   const fileDiffs = await Promise.all(
     fileNames.map(async (fileName) =>
-      fileContentDiffersFromTemplate(path.join(dir, fileName), await loadTemplate(fileName)),
+      fileContentDiffersFromTemplate(
+        path.join(dir, fileName),
+        await loadTemplateForComparison(fileName),
+      ),
     ),
   );
   return fileDiffs.some(Boolean);
@@ -560,7 +593,7 @@ async function collectGeneratedBootstrapHashes(dir: string): Promise<Map<string,
   for (const fileName of GENERATED_WORKSPACE_BOOTSTRAP_FILENAMES) {
     try {
       const content = await fs.readFile(path.join(dir, fileName), "utf-8");
-      if (content === (await loadTemplate(fileName))) {
+      if (content === (await loadTemplateForComparison(fileName))) {
         hashes.set(fileName, createHash("sha256").update(content).digest("hex"));
       }
     } catch {


### PR DESCRIPTION
## What Problem This Solves

On an install whose workspace templates are not present on disk, **every agent turn fails** — even when the agent's workspace is fully provisioned and the template is only wanted for a comparison:

```
Missing workspace template: SOUL.md (<root>/src/agents/templates/SOUL.md). Ensure workspace templates are packaged.
```

Observed live on a self-hosted gateway: a healthy install with a complete workspace (`SOUL.md`, `AGENTS.md`, … all present and user-authored) could not run a single turn on **any** agent. `main` failed on `SOUL.md`, a second agent on `AGENTS.md`. The gateway was otherwise fine — nodes connected, CLI worked — so the assistant simply stopped answering with a packaging error that pointed nowhere useful.

The trigger is that templates serve two different jobs:

- **Provisioning** — creating a bootstrap file that does not exist yet. Genuinely impossible without the template; must fail loudly.
- **Comparison** — deciding whether an *existing* file is still pristine or has been edited by the user (`workspaceProfileLooksConfigured`, `workspaceRequiredBootstrapLooksCustomized`, `collectGeneratedBootstrapHashes`).

Both went through `loadTemplate()`, which throws. So a missing template turned a purely informational question into a fatal one on the hot path every turn takes.

Note the pre-existing asymmetry this fixes: `fileContentDiffersFromTemplate` already tolerated a **missing workspace file** (returns `false` on `ENOENT`), but a **missing template** was fatal. Both are "cannot compare" — only one degraded.

## Why This Change Was Made

Comparison callers ask "is this still the pristine template?". When the template is unavailable the honest answer is *unknown*, and the safe interpretation is **user content**, because every caller uses the result to decide whether regenerating would destroy real work. Treating unknown as "customized / configured" preserves user files and keeps the turn alive.

Provisioning deliberately keeps the strict loader — writing a bootstrap file with no template is a real error and should still surface.

## User Impact

An install missing packaged templates degrades instead of hard-failing: agents keep answering, existing workspace files are never mistaken for regenerable boilerplate, and setup/provisioning still reports a clear error when it truly cannot proceed. No behavior change when templates are present.

## Evidence

- **Production trace (negative case):** the live outage above produced this exact error on two different agents against a fully provisioned workspace — that is the real-world reproduction of the failing path this patch removes.
- **Regression test:** `src/agents/workspace.missing-templates.test.ts` covers both packaged-install failure shapes — no template directory at all, and a directory that resolves but is empty — asserting the status call resolves and that existing user content is left untouched.
- **Test run:** `node scripts/run-vitest.mjs src/agents/workspace.missing-templates.test.ts` → **2 passed**.
- **Formatting:** `oxfmt` clean on both files.
- **Autoreview** (gpt-5.6-sol, high): clean — *"patch is correct (0.98)… comparison-only fallback conservatively treats content as customized when templates are unavailable, while provisioning continues to use the strict template loader."*

Scope is deliberately narrow: no change to template resolution, packaging, or the provisioning contract.
