### PR TITLE
refactor(outbound): reuse prepared channel plugins

### DIFF
--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -23,7 +23,8 @@ import {
   type SerializedDurableMessagePayloadOutcome,
 } from "../../channels/message/runtime.js";
 import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
-import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
+import { normalizeChannelId } from "../../channels/plugins/index.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import { createReplyPrefixContext } from "../../channels/reply-prefix.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -462,6 +463,7 @@ function normalizeAgentCommandReplyPayloads(params: {
   payloads: RunResult["payloads"];
   result: RunResult;
   deliveryChannel?: string;
+  plugin?: ChannelPlugin;
   accountId?: string;
   applyChannelTransforms?: boolean;
   includeRunModelContext?: boolean;
@@ -478,7 +480,7 @@ function normalizeAgentCommandReplyPayloads(params: {
     return payloads as ReplyPayload[];
   }
   const applyChannelTransforms = params.applyChannelTransforms ?? true;
-  const deliveryPlugin = applyChannelTransforms ? getChannelPlugin(channel) : undefined;
+  const deliveryPlugin = applyChannelTransforms ? params.plugin : undefined;
 
   const sessionKey = params.outboundSession?.key ?? params.opts.sessionKey;
   const agentId =
@@ -576,11 +578,13 @@ export async function deliverAgentCommandResult(
     });
     params.assertDeliveryCurrent?.();
     let deliveryChannel = deliveryPlan.resolvedChannel;
+    let preparedPlugin = deliveryPlan.plugin;
     if (deliver && isInternalMessageChannel(deliveryChannel) && !explicitChannelHint) {
       try {
         const selection = await resolveMessageChannelSelection({ cfg });
         params.assertDeliveryCurrent?.();
         deliveryChannel = selection.channel;
+        preparedPlugin = selection.plugin;
       } catch {
         // Keep the internal channel marker; error handling below reports the failure.
       }
@@ -591,11 +595,11 @@ export async function deliverAgentCommandResult(
         : {
             ...deliveryPlan,
             resolvedChannel: deliveryChannel,
+            plugin: preparedPlugin,
           };
-    // Channel docking: delivery channels are resolved via plugin registry.
     const deliveryPlugin =
       deliver && !isInternalMessageChannel(deliveryChannel)
-        ? getChannelPlugin(normalizeChannelId(deliveryChannel) ?? deliveryChannel)
+        ? effectiveDeliveryPlan.plugin
         : undefined;
     const isDeliveryChannelKnown =
       isInternalMessageChannel(deliveryChannel) || Boolean(deliveryPlugin);
@@ -718,6 +722,7 @@ export async function deliverAgentCommandResult(
     deliveryTarget,
     resolvedReplyToId,
     resolvedThreadTarget,
+    deliveryPlugin,
   } = deliveryRouting;
 
   let deliveryLoggedError = false;
@@ -764,6 +769,7 @@ export async function deliverAgentCommandResult(
     payloads,
     result,
     deliveryChannel,
+    plugin: deliveryPlugin,
     accountId: resolvedAccountId,
     applyChannelTransforms: deliver,
   });
@@ -783,6 +789,7 @@ export async function deliverAgentCommandResult(
       payloads: sentTexts.map((text) => ({ text })),
       result,
       deliveryChannel,
+      plugin: deliveryPlugin,
       accountId: resolvedAccountId,
       applyChannelTransforms: deliver,
       includeRunModelContext: false,

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -23,7 +23,7 @@ import {
   type SerializedDurableMessagePayloadOutcome,
 } from "../../channels/message/runtime.js";
 import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
-import { normalizeChannelId } from "../../channels/plugins/index.js";
+import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import { createReplyPrefixContext } from "../../channels/reply-prefix.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
@@ -132,6 +132,8 @@ type DeliverAgentCommandResultParams = {
   sessionEntry: SessionEntry | undefined;
   result: RunResult;
   payloads: RunResult["payloads"];
+  /** Channel plugin already selected and bootstrapped by the caller. */
+  preparedPlugin?: ChannelPlugin;
   assertDeliveryCurrent?: () => void;
   onDeliveryResult?: (result: AgentCommandDeliveryResult) => void;
 } & FreshSessionDeliveryRefreshParams;
@@ -571,6 +573,7 @@ export async function deliverAgentCommandResult(
       explicitThreadId: opts.threadId,
       accountId: opts.replyAccountId ?? opts.accountId,
       wantsDelivery: deliver,
+      preparedPlugin: params.preparedPlugin,
       turnSourceChannel,
       turnSourceTo,
       turnSourceAccountId,
@@ -597,25 +600,32 @@ export async function deliverAgentCommandResult(
             resolvedChannel: deliveryChannel,
             plugin: preparedPlugin,
           };
+    // Bundled/setup channels may be dockable before they appear in the registered
+    // deliverable-id list. Resolve only when upstream planning prepared no plugin.
     const deliveryPlugin =
       deliver && !isInternalMessageChannel(deliveryChannel)
-        ? effectiveDeliveryPlan.plugin
+        ? (effectiveDeliveryPlan.plugin ??
+          getChannelPlugin(normalizeChannelId(deliveryChannel) ?? deliveryChannel))
         : undefined;
+    const pluginDeliveryPlan =
+      deliveryPlugin && deliveryPlugin !== effectiveDeliveryPlan.plugin
+        ? { ...effectiveDeliveryPlan, plugin: deliveryPlugin }
+        : effectiveDeliveryPlan;
     const isDeliveryChannelKnown =
       isInternalMessageChannel(deliveryChannel) || Boolean(deliveryPlugin);
     const targetMode =
       opts.deliveryTargetMode ??
-      effectiveDeliveryPlan.deliveryTargetMode ??
+      pluginDeliveryPlan.deliveryTargetMode ??
       (opts.to ? "explicit" : "implicit");
     const defaultAccountId =
-      !effectiveDeliveryPlan.resolvedAccountId && deliveryPlugin?.config?.listAccountIds
+      !pluginDeliveryPlan.resolvedAccountId && deliveryPlugin?.config?.listAccountIds
         ? resolveChannelDefaultAccountId({ plugin: deliveryPlugin, cfg })
         : undefined;
-    const resolvedAccountId = effectiveDeliveryPlan.resolvedAccountId ?? defaultAccountId;
+    const resolvedAccountId = pluginDeliveryPlan.resolvedAccountId ?? defaultAccountId;
     const resolvedDeliveryPlan =
-      resolvedAccountId === effectiveDeliveryPlan.resolvedAccountId
-        ? effectiveDeliveryPlan
-        : { ...effectiveDeliveryPlan, resolvedAccountId };
+      resolvedAccountId === pluginDeliveryPlan.resolvedAccountId
+        ? pluginDeliveryPlan
+        : { ...pluginDeliveryPlan, resolvedAccountId };
     const resolved =
       deliver && isDeliveryChannelKnown && deliveryChannel
         ? resolveAgentOutboundTarget({

--- a/src/agents/command/session-helpers.ts
+++ b/src/agents/command/session-helpers.ts
@@ -1,5 +1,8 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.public.js";
+import type {
+  ChannelOutboundTargetMode,
+  ChannelPlugin,
+} from "../../channels/plugins/types.public.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -63,7 +66,7 @@ export async function prepareCurrentRunDelivery(params: {
   if (opts.deliver !== true) {
     return undefined;
   }
-  const buildPlan = async (requestedChannel: string | undefined) =>
+  const buildPlan = async (requestedChannel: string | undefined, preparedPlugin?: ChannelPlugin) =>
     await resolveAgentDeliveryPlanWithSessionRoute({
       cfg,
       agentId: params.agentId,
@@ -78,6 +81,7 @@ export async function prepareCurrentRunDelivery(params: {
       turnSourceTo: opts.runContext?.currentChannelId ?? opts.to,
       turnSourceAccountId: opts.runContext?.accountId ?? opts.accountId,
       turnSourceThreadId: opts.runContext?.currentThreadTs ?? opts.threadId,
+      preparedPlugin,
     });
   let deliveryPlan = await buildPlan(opts.replyChannel ?? opts.channel);
   const explicitChannelHint = normalizeOptionalString(opts.replyChannel ?? opts.channel);
@@ -85,7 +89,7 @@ export async function prepareCurrentRunDelivery(params: {
     opts.threadId != null && opts.threadId !== "" ? opts.threadId : undefined;
   if (deliveryPlan.resolvedChannel === INTERNAL_MESSAGE_CHANNEL && !explicitChannelHint) {
     const selection = await resolveMessageChannelSelection({ cfg });
-    deliveryPlan = await buildPlan(selection.channel);
+    deliveryPlan = await buildPlan(selection.channel, selection.plugin);
   }
   if (deliveryPlan.targetResolutionError) {
     throw deliveryPlan.targetResolutionError;

--- a/src/cli/directory-cli.test.ts
+++ b/src/cli/directory-cli.test.ts
@@ -15,7 +15,6 @@ const mocks = vi.hoisted(() => ({
   replaceConfigFile: vi.fn(),
   resolveInstallableChannelPlugin: vi.fn(),
   resolveMessageChannelSelection: vi.fn(),
-  getChannelPlugin: vi.fn(),
   resolveChannelDefaultAccountId: vi.fn(),
 }));
 
@@ -36,10 +35,6 @@ vi.mock("../commands/channel-setup/channel-plugin-resolution.js", () => ({
 
 vi.mock("../infra/outbound/channel-selection.js", () => ({
   resolveMessageChannelSelection: mocks.resolveMessageChannelSelection,
-}));
-
-vi.mock("../channels/plugins/index.js", () => ({
-  getChannelPlugin: mocks.getChannelPlugin,
 }));
 
 vi.mock("../channels/plugins/helpers.js", () => ({
@@ -87,6 +82,7 @@ describe("registerDirectoryCli", () => {
     mocks.resolveChannelDefaultAccountId.mockReturnValue("default");
     mocks.resolveMessageChannelSelection.mockResolvedValue({
       channel: "demo-channel",
+      plugin: { id: "demo-channel" },
       configured: ["demo-channel"],
       source: "explicit",
     });
@@ -150,12 +146,12 @@ describe("registerDirectoryCli", () => {
     });
     mocks.resolveMessageChannelSelection.mockResolvedValue({
       channel: "whatsapp",
+      plugin: {
+        id: "whatsapp",
+        directory: { self },
+      },
       configured: ["whatsapp"],
       source: "single-configured",
-    });
-    mocks.getChannelPlugin.mockReturnValue({
-      id: "whatsapp",
-      directory: { self },
     });
 
     const program = new Command().name("openclaw");

--- a/src/cli/directory-cli.ts
+++ b/src/cli/directory-cli.ts
@@ -8,7 +8,6 @@ import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
-import { getChannelPlugin } from "../channels/plugins/index.js";
 import { resolveInstallableChannelPlugin } from "../commands/channel-setup/channel-plugin-resolution.js";
 import { getRuntimeConfig, readConfigFileSnapshot, replaceConfigFile } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
@@ -131,14 +130,14 @@ export function registerDirectoryCli(program: Command) {
     const selection = explicitChannel
       ? {
           channel: resolvedExplicit?.channelId,
+          plugin: resolvedExplicit?.plugin,
         }
       : await resolveMessageChannelSelection({
           cfg,
           channel: opts.channel ?? null,
         });
     const channelId = selection.channel;
-    const plugin =
-      resolvedExplicit?.plugin ?? (channelId ? getChannelPlugin(channelId) : undefined);
+    const plugin = selection.plugin;
     if (!plugin) {
       throw new Error(`Unsupported channel: ${String(channelId)}`);
     }

--- a/src/commands/agent.delivery.test.ts
+++ b/src/commands/agent.delivery.test.ts
@@ -11,7 +11,7 @@ import type { DeliveryContext } from "../utils/delivery-context.types.js";
 
 const mocks = vi.hoisted(() => ({
   deliverOutboundPayloads: vi.fn(async () => []),
-  getChannelPlugin: vi.fn(() => ({})),
+  getChannelPlugin: vi.fn(() => ({ outbound: { deliveryMode: "gateway" } })),
   resolveOutboundTarget: vi.fn(() => ({ ok: true as const, to: "+15551234567" })),
 }));
 

--- a/src/commands/channels.resolve.test.ts
+++ b/src/commands/channels.resolve.test.ts
@@ -13,7 +13,6 @@ const mocks = vi.hoisted(() => ({
   refreshPluginRegistryAfterConfigMutation: vi.fn(async () => undefined),
   resolveMessageChannelSelection: vi.fn(),
   resolveInstallableChannelPlugin: vi.fn(),
-  getChannelPlugin: vi.fn(),
 }));
 
 vi.mock("../cli/command-secret-gateway.js", () => ({
@@ -51,10 +50,6 @@ vi.mock("./channel-setup/channel-plugin-resolution.js", () => ({
   resolveInstallableChannelPlugin: mocks.resolveInstallableChannelPlugin,
 }));
 
-vi.mock("../channels/plugins/index.js", () => ({
-  getChannelPlugin: mocks.getChannelPlugin,
-}));
-
 const requireRecord = createRequireRecord("record", "expected-label");
 
 function requireFirstMockArg(
@@ -88,6 +83,7 @@ describe("channelsResolveCommand", () => {
     });
     mocks.resolveMessageChannelSelection.mockResolvedValue({
       channel: "telegram",
+      plugin: { id: "telegram" },
       configured: ["telegram"],
       source: "explicit",
     });
@@ -180,12 +176,12 @@ describe("channelsResolveCommand", () => {
     mocks.applyPluginAutoEnable.mockReturnValue({ config: autoEnabledConfig, changes: [] });
     mocks.resolveMessageChannelSelection.mockResolvedValue({
       channel: "whatsapp",
+      plugin: {
+        id: "whatsapp",
+        resolver: { resolveTargets },
+      },
       configured: ["whatsapp"],
       source: "single-configured",
-    });
-    mocks.getChannelPlugin.mockReturnValue({
-      id: "whatsapp",
-      resolver: { resolveTargets },
     });
 
     await channelsResolveCommand(

--- a/src/commands/channels/resolve.ts
+++ b/src/commands/channels/resolve.ts
@@ -4,7 +4,6 @@ import {
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
-import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type {
   ChannelResolveKind,
   ChannelResolveResult,
@@ -161,14 +160,13 @@ export async function channelsResolveCommand(opts: ChannelsResolveOptions, runti
   const selection = explicitChannel
     ? {
         channel: resolvedExplicit?.channelId,
+        plugin: resolvedExplicit?.plugin,
       }
     : await resolveMessageChannelSelection({
         cfg,
         channel: opts.channel ?? null,
       });
-  const plugin =
-    (explicitChannel ? resolvedExplicit?.plugin : undefined) ??
-    (selection.channel ? getChannelPlugin(selection.channel) : undefined);
+  const plugin = selection.plugin;
   if (!plugin?.resolver?.resolveTargets) {
     const channelText = selection.channel ?? explicitChannel ?? "";
     throw new Error(

--- a/src/gateway/server-methods/agent-delivery-phase.ts
+++ b/src/gateway/server-methods/agent-delivery-phase.ts
@@ -110,13 +110,15 @@ export async function resolveAgentDeliveryPhase(params: {
 
   if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
     try {
-      resolvedChannel = (
-        await resolveMessageChannelSelection({ cfg: params.cfgForAgent ?? params.cfg })
-      ).channel;
+      const selection = await resolveMessageChannelSelection({
+        cfg: params.cfgForAgent ?? params.cfg,
+      });
+      resolvedChannel = selection.channel;
       deliveryTargetMode = deliveryTargetMode ?? "implicit";
       effectivePlan = {
         ...deliveryPlan,
         resolvedChannel,
+        plugin: selection.plugin,
         deliveryTargetMode,
         resolvedAccountId,
       };
@@ -148,7 +150,8 @@ export async function resolveAgentDeliveryPhase(params: {
     resolvedChannel = INTERNAL_MESSAGE_CHANNEL;
     deliveryTargetMode = undefined;
     resolvedTo = undefined;
-    effectivePlan = { ...deliveryPlan, resolvedChannel, resolvedTo, deliveryTargetMode };
+    const { plugin: _plugin, ...pluginFreePlan } = deliveryPlan;
+    effectivePlan = { ...pluginFreePlan, resolvedChannel, resolvedTo, deliveryTargetMode };
   }
 
   if (!resolvedTo && isDeliverableMessageChannel(resolvedChannel)) {
@@ -220,7 +223,7 @@ export async function resolveAgentDeliveryPhase(params: {
       : undefined;
   return {
     activeSessionAgentId,
-    deliveryPlan,
+    deliveryPlan: effectivePlan,
     resolvedChannel,
     deliveryTargetMode,
     resolvedAccountId,

--- a/src/gateway/server-methods/agent-session-reset.ts
+++ b/src/gateway/server-methods/agent-session-reset.ts
@@ -1,6 +1,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import type { AgentCommandOpts } from "../../agents/command/types.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import { agentCommandFromIngress } from "../../commands/agent.js";
 import {
   resolveAgentIdFromSessionKey,
@@ -93,6 +94,7 @@ async function deliverBareSessionResetResult(params: {
   sessionKey: string;
   agentId?: string;
   sessionEntry?: SessionEntry;
+  preparedPlugin?: ChannelPlugin;
   request: {
     replyTo?: string;
     to?: string;
@@ -150,6 +152,7 @@ async function deliverBareSessionResetResult(params: {
     sessionEntry: params.sessionEntry,
     result: result as never,
     payloads: result.payloads as never,
+    preparedPlugin: params.preparedPlugin,
     assertDeliveryCurrent: params.assertCurrent,
   });
 }
@@ -226,6 +229,7 @@ export async function resolveBareSessionResetResult(params: {
     sessionKey: params.sessionKey,
     agentId: params.agentId,
     sessionEntry: params.sessionEntry,
+    preparedPlugin: deliveryPlan.plugin,
     request: {
       ...params.request,
       channel: deliveryPlan.resolvedChannel,

--- a/src/infra/outbound/agent-delivery.target-resolution.test.ts
+++ b/src/infra/outbound/agent-delivery.target-resolution.test.ts
@@ -41,9 +41,11 @@ vi.mock("../../utils/message-channel.js", () => ({
 import type { OpenClawConfig } from "../../config/config.js";
 
 let resolveAgentDeliveryPlanWithSessionRoute: typeof import("./agent-delivery.js").resolveAgentDeliveryPlanWithSessionRoute;
+let resolveAgentOutboundTarget: typeof import("./agent-delivery.js").resolveAgentOutboundTarget;
 
 beforeAll(async () => {
-  ({ resolveAgentDeliveryPlanWithSessionRoute } = await import("./agent-delivery.js"));
+  ({ resolveAgentDeliveryPlanWithSessionRoute, resolveAgentOutboundTarget } =
+    await import("./agent-delivery.js"));
 });
 
 beforeEach(() => {
@@ -172,6 +174,7 @@ describe("agent delivery target resolution", () => {
 
     expect(mocks.resolveOutboundTarget).toHaveBeenCalledWith({
       channel: "workspace",
+      plugin,
       to: undefined,
       cfg: {},
       accountId: undefined,
@@ -186,6 +189,24 @@ describe("agent delivery target resolution", () => {
       plugin,
     });
     expect(plan.resolvedTo).toBe("channel:1524410080953634830");
+    expect(plan.plugin).toBe(plugin);
+
+    mocks.resolveOutboundTarget.mockClear();
+    mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "channel:final" });
+    resolveAgentOutboundTarget({
+      cfg: {} as OpenClawConfig,
+      plan,
+      targetMode: "implicit",
+      validateExplicitTarget: true,
+    });
+    expect(mocks.resolveOutboundTarget).toHaveBeenCalledWith({
+      channel: "workspace",
+      plugin,
+      to: "channel:1524410080953634830",
+      cfg: {},
+      accountId: undefined,
+      mode: "implicit",
+    });
   });
 
   it("preserves normalized fallback for session-route-only plugins", async () => {

--- a/src/infra/outbound/agent-delivery.test.ts
+++ b/src/infra/outbound/agent-delivery.test.ts
@@ -723,6 +723,7 @@ describe("agent delivery helpers", () => {
 
     expect(mocks.resolveOutboundTarget).toHaveBeenCalledWith({
       channel: "whatsapp",
+      plugin,
       to: "+15551234567",
       cfg: {},
       accountId: "work",
@@ -963,6 +964,7 @@ describe("agent delivery helpers", () => {
     expect(mocks.resolveOutboundTarget).not.toHaveBeenCalled();
     expect(mocks.resolveOutboundSessionRoute).not.toHaveBeenCalled();
     expect(plan.resolvedTo).toBe("channel:C123");
+    expect(plan.plugin).toBeUndefined();
   });
 
   it("does not pass inherited session threads into explicit retarget routing", async () => {

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -2,8 +2,11 @@
 // options, session history, turn source, bindings, and channel route hooks.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
-import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.public.js";
-import type { ChannelId } from "../../channels/plugins/types.public.js";
+import type {
+  ChannelId,
+  ChannelOutboundTargetMode,
+  ChannelPlugin,
+} from "../../channels/plugins/types.public.js";
 import { listRouteBindings } from "../../config/bindings.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -30,6 +33,7 @@ import {
 type AgentDeliveryPlan = {
   baseDelivery: SessionDeliveryTarget;
   resolvedChannel: string;
+  plugin?: ChannelPlugin;
   resolvedTo?: string;
   resolvedAccountId?: string;
   resolvedThreadId?: string | number;
@@ -169,6 +173,8 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
     agentId: string;
     currentSessionKey?: string;
     sessionRouteMode?: "plugin-only" | "allow-fallback";
+    /** Channel plugin already selected and bootstrapped by the caller. */
+    preparedPlugin?: ChannelPlugin;
   },
 ): Promise<AgentDeliveryPlan> {
   const plan = resolveAgentDeliveryPlan(params);
@@ -176,14 +182,17 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
   if (!params.wantsDelivery || !isDeliverableMessageChannel(resolvedChannel)) {
     return plan;
   }
-  const plugin = resolveOutboundChannelPlugin({
-    channel: resolvedChannel,
-    cfg: params.cfg,
-    allowBootstrap: true,
-  });
+  const plugin =
+    params.preparedPlugin ??
+    resolveOutboundChannelPlugin({
+      channel: resolvedChannel,
+      cfg: params.cfg,
+      allowBootstrap: true,
+    });
   if (!plugin) {
     return plan;
   }
+  const pluginPlan = { ...plan, plugin };
   const hasPluginSessionRoute = Boolean(plugin?.messaging?.resolveOutboundSessionRoute);
   const hasPluginTargetResolver = Boolean(plugin?.messaging?.targetResolver);
   // Only concrete plugin resolution makes a directory miss authoritative.
@@ -194,17 +203,20 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
     !hasPluginTargetResolver &&
     params.sessionRouteMode !== "allow-fallback"
   ) {
-    return plan;
+    return pluginPlan;
   }
   const resolvedAccountId =
-    plan.resolvedAccountId ??
+    pluginPlan.resolvedAccountId ??
     (params.sessionRouteMode === "allow-fallback"
       ? resolveChannelDefaultAccountId({ plugin, cfg: params.cfg })
       : undefined);
   const routedPlan =
-    resolvedAccountId === plan.resolvedAccountId ? plan : { ...plan, resolvedAccountId };
+    resolvedAccountId === pluginPlan.resolvedAccountId
+      ? pluginPlan
+      : { ...pluginPlan, resolvedAccountId };
   const normalizedTarget = resolveOutboundTarget({
     channel: resolvedChannel,
+    plugin,
     to: routedPlan.resolvedTo,
     cfg: params.cfg,
     accountId: routedPlan.resolvedAccountId,
@@ -433,6 +445,7 @@ export function resolveAgentOutboundTarget(params: {
   }
   const resolvedTarget = resolveOutboundTarget({
     channel: params.plan.resolvedChannel,
+    ...(params.plan.plugin ? { plugin: params.plan.plugin } : {}),
     to: params.plan.resolvedTo,
     cfg: params.cfg,
     accountId: params.plan.resolvedAccountId,

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -294,27 +294,46 @@ describe("resolveMessageChannelSelection", () => {
     },
   ])("resolves message channel selection for %j", async ({ setup, params, expected, verify }) => {
     const setupResult = setup?.();
-    await expect(expectResolvedSelection(params)).resolves.toEqual(expected);
+    await expect(expectResolvedSelection(params)).resolves.toMatchObject(expected);
     verify?.(setupResult as never);
+  });
+
+  it("returns the exact bootstrapped plugin used to prove availability", async () => {
+    const plugin = { id: "alpha" };
+    mocks.resolveOutboundChannelPlugin.mockReturnValue(plugin);
+
+    const selection = await expectResolvedSelection({ cfg: {} as never, channel: "alpha" });
+
+    expect(selection.plugin).toBe(plugin);
+  });
+
+  it("returns the exact configured plugin used for single-channel selection", async () => {
+    const plugin = makePlugin({ id: "delta", isConfigured: async () => true });
+    mocks.listChannelPlugins.mockReturnValue([plugin]);
+
+    const selection = await expectResolvedSelection({ cfg: {} as never });
+
+    expect(selection.plugin).toBe(plugin);
   });
 
   it("allows bootstrap while checking explicit and fallback channels", async () => {
     const cfg = {} as never;
+    const fallbackPlugin = { id: "beta" };
     mocks.resolveOutboundChannelPlugin.mockImplementation(({ channel }: { channel: string }) =>
-      channel === "beta" ? { id: "beta" } : undefined,
+      channel === "beta" ? fallbackPlugin : undefined,
     );
 
-    await expect(
-      expectResolvedSelection({
-        cfg,
-        channel: "alpha",
-        fallbackChannel: "beta",
-      }),
-    ).resolves.toEqual({
+    const selection = await expectResolvedSelection({
+      cfg,
+      channel: "alpha",
+      fallbackChannel: "beta",
+    });
+    expect(selection).toMatchObject({
       channel: "beta",
       configured: [],
       source: "tool-context-fallback",
     });
+    expect(selection.plugin).toBe(fallbackPlugin);
 
     expect(mocks.resolveOutboundChannelPlugin).toHaveBeenNthCalledWith(1, {
       channel: "alpha",

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -28,7 +28,7 @@ type MessageChannelSelectionSource = "explicit" | "tool-context-fallback" | "sin
 function resolveAvailableKnownChannel(params: {
   cfg: OpenClawConfig;
   value?: string | null;
-}): string | undefined {
+}): { channel: string; plugin: ChannelPlugin } | undefined {
   const normalized = normalizeDeliverableOutboundChannel(params.value);
   if (!normalized) {
     return undefined;
@@ -42,13 +42,12 @@ function resolveAvailableKnownChannel(params: {
   // dispatches that the CLI send-path could deliver to.
   // Adjacent to #77254 (cron-announce / final-reply paths); this closes the
   // remaining in-agent caller in the same family.
-  return resolveOutboundChannelPlugin({
+  const plugin = resolveOutboundChannelPlugin({
     channel: normalized,
     cfg: params.cfg,
     allowBootstrap: true,
-  })
-    ? normalized
-    : undefined;
+  });
+  return plugin ? { channel: normalized, plugin } : undefined;
 }
 
 /** Checks whether a channel has a non-disabled config entry. */
@@ -178,18 +177,24 @@ async function isPluginConfigured(plugin: ChannelPlugin, cfg: OpenClawConfig): P
   return false;
 }
 
-/** Lists deliverable channels with at least one enabled, configured account. */
-export async function listConfiguredMessageChannels(cfg: OpenClawConfig): Promise<string[]> {
-  const channels: string[] = [];
+async function listConfiguredMessageChannelPlugins(cfg: OpenClawConfig): Promise<ChannelPlugin[]> {
+  const plugins: ChannelPlugin[] = [];
   for (const plugin of listChannelPlugins()) {
     if (!isDeliverableMessageChannel(plugin.id)) {
       continue;
     }
     if (await isPluginConfigured(plugin, cfg)) {
-      channels.push(plugin.id);
+      plugins.push(plugin);
     }
   }
-  return channels;
+  return plugins;
+}
+
+/** Lists deliverable channels with at least one enabled, configured account. */
+export async function listConfiguredMessageChannels(
+  cfg: OpenClawConfig,
+): Promise<string[]> {
+  return (await listConfiguredMessageChannelPlugins(cfg)).map((plugin) => plugin.id);
 }
 
 /** Resolves the message action channel from explicit input, context fallback, or config. */
@@ -199,6 +204,7 @@ export async function resolveMessageChannelSelection(params: {
   fallbackChannel?: string | null;
 }): Promise<{
   channel: string;
+  plugin: ChannelPlugin;
   configured: string[];
   source: MessageChannelSelectionSource;
 }> {
@@ -215,7 +221,8 @@ export async function resolveMessageChannelSelection(params: {
       });
       if (fallback) {
         return {
-          channel: fallback,
+          channel: fallback.channel,
+          plugin: fallback.plugin,
           configured: [],
           source: "tool-context-fallback",
         };
@@ -235,7 +242,8 @@ export async function resolveMessageChannelSelection(params: {
       throw new Error(`Channel is unavailable: ${normalized}`);
     }
     return {
-      channel: availableExplicit,
+      channel: availableExplicit.channel,
+      plugin: availableExplicit.plugin,
       configured: [],
       source: "explicit",
     };
@@ -247,16 +255,20 @@ export async function resolveMessageChannelSelection(params: {
   });
   if (fallback) {
     return {
-      channel: fallback,
+      channel: fallback.channel,
+      plugin: fallback.plugin,
       configured: [],
       source: "tool-context-fallback",
     };
   }
 
-  const configured = await listConfiguredMessageChannels(params.cfg);
-  if (configured.length === 1) {
+  const configuredPlugins = await listConfiguredMessageChannelPlugins(params.cfg);
+  const configured = configuredPlugins.map((plugin) => plugin.id);
+  if (configuredPlugins.length === 1) {
+    const plugin = expectDefined(configuredPlugins[0], "configured plugin at 0");
     return {
-      channel: expectDefined(configured[0], "configured entry at 0"),
+      channel: plugin.id,
+      plugin,
       configured,
       source: "single-configured",
     };

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -191,9 +191,7 @@ async function listConfiguredMessageChannelPlugins(cfg: OpenClawConfig): Promise
 }
 
 /** Lists deliverable channels with at least one enabled, configured account. */
-export async function listConfiguredMessageChannels(
-  cfg: OpenClawConfig,
-): Promise<string[]> {
+export async function listConfiguredMessageChannels(cfg: OpenClawConfig): Promise<string[]> {
   return (await listConfiguredMessageChannelPlugins(cfg)).map((plugin) => plugin.id);
 }
 

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -320,6 +320,8 @@ describe("runMessageAction media behavior", () => {
     expect(requireRecord(sendArgs.ctx).idempotencyKey).toBe(
       "run-1:message-tool:send-1:fingerprint",
     );
+    expect(requireRecord(sendArgs.ctx).plugin).toBe(workspacePlugin);
+    expect(channelResolutionMocks.resolveOutboundChannelPlugin).toHaveBeenCalledTimes(1);
   });
 
   it("rejects plugin-declined attachment actions before loading media", async () => {

--- a/src/infra/outbound/message-action-runner.poll.test.ts
+++ b/src/infra/outbound/message-action-runner.poll.test.ts
@@ -123,6 +123,7 @@ async function runPollAction(params: {
       threadId?: string;
     };
     ctx?: {
+      plugin?: ChannelPlugin;
       inboundEventKind?: string;
       idempotencyKey?: string;
       params?: Record<string, unknown>;
@@ -197,6 +198,8 @@ describe("runMessageAction poll handling", () => {
     expect(call?.durationHours).toBe(2);
     expect(call?.threadId).toBe("42");
     expect(call?.ctx?.params?.threadId).toBe("42");
+    expect(call?.ctx?.plugin).toBe(pollerTestPlugin);
+    expect(mocks.resolveOutboundChannelPlugin).toHaveBeenCalledTimes(1);
   });
 
   it.each([0, -1, 1.5, "1.5", "soon"])(

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -69,7 +69,6 @@ import {
 import { readTrimmedStringAlias } from "../../utils/string-readers.js";
 import { formatErrorMessage } from "../errors.js";
 import { throwIfAborted } from "./abort.js";
-import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import {
   listConfiguredMessageChannels,
   resolveMessageChannelSelection,
@@ -540,7 +539,7 @@ async function resolveChannel(
   if (selection.source === "tool-context-fallback") {
     params.channel = selection.channel;
   }
-  return selection.channel;
+  return selection;
 }
 
 function enforceCrossProviderEgressPolicyBeforeTargetResolution(params: {
@@ -713,7 +712,7 @@ type ResolvedActionContext = {
   params: Record<string, unknown>;
   idempotencyKey?: string;
   channel: ChannelId;
-  channelPlugin?: ChannelPlugin;
+  channelPlugin: ChannelPlugin;
   mediaAccess: OutboundMediaAccess;
   extraActionMediaSourceParamKeys?: readonly string[];
   accountId?: string | null;
@@ -1057,7 +1056,7 @@ async function handleBroadcastAction(
   }
   const targetChannels =
     channelHint && normalizeOptionalLowercaseString(channelHint) !== "all"
-      ? [await resolveChannel(input.cfg, { channel: channelHint }, input.toolContext)]
+      ? [(await resolveChannel(input.cfg, { channel: channelHint }, input.toolContext)).channel]
       : input.broadcastAccountPlan
         ? input.broadcastAccountPlan.candidateChannels
         : await (async () => {
@@ -1630,6 +1629,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     ctx: {
       cfg,
       channel,
+      plugin: channelPlugin,
       params,
       idempotencyKey: ctx.idempotencyKey,
       agentId,
@@ -1797,6 +1797,7 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
     ctx: {
       cfg,
       channel,
+      plugin: channelPlugin,
       params,
       idempotencyKey: ctx.idempotencyKey,
       accountId: accountId ?? undefined,
@@ -2041,9 +2042,9 @@ export async function runMessageAction(
   if (actionRequiresTarget(action) && !hasPotentialActionTargetInput(input, params)) {
     throw new Error(`Action ${action} requires a target.`);
   }
-  const channel = await resolveChannel(cfg, params, input.toolContext, action);
+  const selection = await resolveChannel(cfg, params, input.toolContext, action);
+  const { channel, plugin: channelPlugin } = selection;
   params.channel = channel;
-  const channelPlugin = resolveOutboundChannelPlugin({ channel, cfg });
   const explicitAccountId = validateExplicitMessageAccountSelection({
     cfg,
     channel,

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -2,6 +2,7 @@
 // capability checks, gateway fallback, dry runs, and payload planning.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 
 const mocks = vi.hoisted(() => ({
   getChannelPlugin: vi.fn(),
@@ -501,18 +502,33 @@ describe("sendMessage", () => {
     }
   });
 
-  it("does not load registries while resolving outbound plugins", async () => {
-    const forumPlugin = {
+  it("uses a prepared plugin for channel and target resolution without registry lookup", async () => {
+    const forumPlugin: ChannelPlugin = {
+      id: "forum",
+      meta: {
+        id: "forum",
+        label: "Forum",
+        selectionLabel: "Forum",
+        docsPath: "/channels/forum",
+        blurb: "Forum test plugin.",
+      },
+      capabilities: { chatTypes: ["channel"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
       outbound: { deliveryMode: "direct", sendText: vi.fn() },
     };
-    mocks.getChannelPlugin
-      .mockReturnValueOnce(undefined)
-      .mockReturnValueOnce(forumPlugin)
-      .mockReturnValue(forumPlugin);
+    mocks.getChannelPlugin.mockReturnValue(undefined);
+    mocks.resolveOutboundTarget.mockImplementation(({ plugin }: { plugin?: ChannelPlugin }) => ({
+      ok: true,
+      to: plugin === forumPlugin ? "prepared:123456" : "wrong-plugin",
+    }));
 
     const result = await sendMessage({
       cfg: { channels: { forum: { token: "test-token" } } },
       channel: "forum",
+      preparedPlugin: forumPlugin,
       to: "123456",
       content: "hi",
     });
@@ -527,7 +543,15 @@ describe("sendMessage", () => {
       "send message result",
     );
 
+    expect(mocks.getChannelPlugin).not.toHaveBeenCalled();
     expect(mocks.resolveRuntimePluginRegistry).not.toHaveBeenCalled();
+    expect(mocks.resolveOutboundTarget).toHaveBeenCalledTimes(1);
+    const targetParams = requireRecord(
+      getMockCallArg(mocks.resolveOutboundTarget, 0, 0, "outbound target"),
+      "outbound target params",
+    );
+    expect(targetParams.plugin).toBe(forumPlugin);
+    expectDeliveryCallFields({ to: "prepared:123456" });
   });
 
   it("preserves suppressed direct-send status", async () => {

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -9,6 +9,7 @@ import {
   type SerializedDurableMessagePayloadOutcome,
 } from "../../channels/message/runtime.js";
 import type { DurableMessageSendIntent } from "../../channels/message/types.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { OutboundMediaAccess } from "../../media/load-options.js";
 import type { PollInput } from "../../polls.js";
@@ -16,7 +17,6 @@ import { normalizePollInput } from "../../polls.js";
 import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import type { DeliveryQueueCompletionRetention } from "../delivery-queue-sqlite.js";
 import { formatErrorMessage } from "../errors.js";
-import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import { resolveMessageChannelSelection } from "./channel-selection.js";
 import {
   resolveOutboundDurableFinalDeliverySupport,
@@ -95,6 +95,8 @@ type MessageSendParams = {
   idempotencyKey?: string;
   /** @internal Channel-valid id reserved before a correlated conversation turn is sent. */
   preparedMessageId?: string;
+  /** @internal Channel plugin already selected and bootstrapped by the caller. */
+  preparedPlugin?: ChannelPlugin;
   /** @internal Use the active adapter directly when already executing inside the Gateway. */
   gatewayOwnedDelivery?: boolean;
   /** @internal Stable producer id for idempotent durable queue creation. */
@@ -150,6 +152,8 @@ type MessagePollParams = {
   cfg?: OpenClawConfig;
   gateway?: OutboundMessageGatewayOptionsInput;
   idempotencyKey?: string;
+  /** @internal Channel plugin already selected and bootstrapped by the caller. */
+  preparedPlugin?: ChannelPlugin;
 };
 
 export type MessagePollResult = {
@@ -200,7 +204,7 @@ function buildMessagePollResult(params: {
 
 function assertPollOptionSupport(params: {
   channel: string;
-  outbound: NonNullable<ReturnType<typeof resolveRequiredPlugin>["outbound"]>;
+  outbound: NonNullable<ChannelPlugin["outbound"]>;
   durationSeconds?: number;
   isAnonymous?: boolean;
 }): void {
@@ -218,20 +222,11 @@ function assertPollOptionSupport(params: {
 async function resolveRequiredChannel(params: {
   cfg: OpenClawConfig;
   channel?: string;
-}): Promise<string> {
-  const selection = await resolveMessageChannelSelection({
+}): Promise<{ channel: string; plugin: ChannelPlugin }> {
+  return await resolveMessageChannelSelection({
     cfg: params.cfg,
     channel: params.channel,
   });
-  return selection.channel;
-}
-
-function resolveRequiredPlugin(channel: string, cfg: OpenClawConfig) {
-  const plugin = resolveOutboundChannelPlugin({ channel, cfg });
-  if (!plugin) {
-    throw new Error(`Unknown channel: ${channel}`);
-  }
-  return plugin;
 }
 
 function deriveRequiredMessageSendCapabilities(params: {
@@ -313,8 +308,10 @@ async function resolveGatewayIdempotencyKey(idempotencyKey?: string): Promise<st
 
 export async function sendMessage(params: MessageSendParams): Promise<MessageSendResult> {
   const cfg = await resolveMessageConfig(params.cfg);
-  const channel = await resolveRequiredChannel({ cfg, channel: params.channel });
-  const plugin = resolveRequiredPlugin(channel, cfg);
+  const prepared = params.preparedPlugin
+    ? { channel: params.preparedPlugin.id, plugin: params.preparedPlugin }
+    : await resolveRequiredChannel({ cfg, channel: params.channel });
+  const { channel, plugin } = prepared;
   const deliveryMode = plugin.outbound?.deliveryMode ?? "direct";
   const mediaSources = [params.mediaUrl, ...(params.mediaUrls ?? [])].filter(
     (source): source is string => Boolean(source),
@@ -357,6 +354,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
     const outboundChannel = channel;
     const resolvedTarget = resolveOutboundTarget({
       channel: outboundChannel,
+      plugin,
       to: params.to,
       cfg,
       accountId: params.accountId,
@@ -489,7 +487,10 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
 
 export async function sendPoll(params: MessagePollParams): Promise<MessagePollResult> {
   const cfg = await resolveMessageConfig(params.cfg);
-  const channel = await resolveRequiredChannel({ cfg, channel: params.channel });
+  const prepared = params.preparedPlugin
+    ? { channel: params.preparedPlugin.id, plugin: params.preparedPlugin }
+    : await resolveRequiredChannel({ cfg, channel: params.channel });
+  const { channel, plugin } = prepared;
 
   const pollInput: PollInput = {
     question: params.question,
@@ -498,8 +499,7 @@ export async function sendPoll(params: MessagePollParams): Promise<MessagePollRe
     durationSeconds: params.durationSeconds,
     durationHours: params.durationHours,
   };
-  const plugin = resolveRequiredPlugin(channel, cfg);
-  const outbound = plugin?.outbound;
+  const outbound = plugin.outbound;
   if (!outbound?.sendPoll) {
     throw new Error(`Unsupported poll channel: ${channel}`);
   }
@@ -528,6 +528,7 @@ export async function sendPoll(params: MessagePollParams): Promise<MessagePollRe
   if (deliveryMode !== "gateway") {
     const resolvedTarget = resolveOutboundTarget({
       channel,
+      plugin,
       to: params.to,
       cfg,
       accountId: params.accountId,

--- a/src/infra/outbound/outbound-send-service.test.ts
+++ b/src/infra/outbound/outbound-send-service.test.ts
@@ -122,6 +122,7 @@ type MockCalls = {
 };
 
 const requireRecord = createRequireRecord("object", "expected-label");
+const defaultPlugin = createChannelTestPluginBase({ id: "demo-outbound" });
 
 function requireArray(value: unknown, label: string): unknown[] {
   expect(Array.isArray(value), label).toBe(true);
@@ -193,6 +194,7 @@ describe("executeSendAction", () => {
 
     await executeSendAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: { to: "channel:123", message: "hello" },
@@ -212,6 +214,7 @@ describe("executeSendAction", () => {
     overrides: Partial<ExecuteSendContext>,
   ): ExecuteSendContext {
     return {
+      plugin: defaultPlugin,
       cfg: {},
       channel: "demo-outbound",
       params: { media: "/tmp/host.png" },
@@ -258,6 +261,7 @@ describe("executeSendAction", () => {
 
     await executeSendAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: {},
@@ -297,6 +301,7 @@ describe("executeSendAction", () => {
 
     const result = await executeSendAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: { to: "channel:123", message: "hello" },
@@ -323,6 +328,7 @@ describe("executeSendAction", () => {
 
     await executeSendAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: { to: "channel:123", message: "hello" },
@@ -355,6 +361,7 @@ describe("executeSendAction", () => {
 
     await executeSendAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: {},
@@ -382,6 +389,7 @@ describe("executeSendAction", () => {
 
     await executeSendAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: {},
@@ -413,6 +421,7 @@ describe("executeSendAction", () => {
 
     await executeSendAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: {},
@@ -507,6 +516,7 @@ describe("executeSendAction", () => {
 
     await executeSendAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: {},
@@ -536,7 +546,6 @@ describe("executeSendAction", () => {
         sendText: async () => ({ channel: "discord", messageId: "msg-test" }),
       },
     };
-    setActivePluginRegistry(createTestRegistry([{ pluginId: "discord", plugin, source: "test" }]));
     mocks.dispatchChannelMessageAction.mockResolvedValue(pluginActionResult("msg-plugin"));
     mocks.sendMessage.mockResolvedValue({
       channel: "discord",
@@ -547,6 +556,7 @@ describe("executeSendAction", () => {
 
     const result = await executeSendAction({
       ctx: {
+        plugin,
         cfg: {},
         channel: "discord",
         params: { to: "channel:123", presentation },
@@ -592,7 +602,6 @@ describe("executeSendAction", () => {
         sendText: async () => ({ channel: "discord", messageId: "msg-test" }),
       },
     };
-    setActivePluginRegistry(createTestRegistry([{ pluginId: "discord", plugin, source: "test" }]));
     mocks.dispatchChannelMessageAction.mockResolvedValue(pluginActionResult("msg-plugin"));
     mocks.sendMessage.mockResolvedValue({
       channel: "discord",
@@ -603,6 +612,7 @@ describe("executeSendAction", () => {
 
     await executeSendAction({
       ctx: {
+        plugin,
         cfg: {},
         channel: "discord",
         params: { to: "channel:123", message: "Deployment trend", presentation },
@@ -638,11 +648,11 @@ describe("executeSendAction", () => {
         sendText: async () => ({ channel: "discord", messageId: "msg-test" }),
       },
     };
-    setActivePluginRegistry(createTestRegistry([{ pluginId: "discord", plugin, source: "test" }]));
     mocks.dispatchChannelMessageAction.mockResolvedValue(pluginActionResult("msg-plugin"));
 
     const result = await executeSendAction({
       ctx: {
+        plugin,
         cfg: {},
         channel: "discord",
         params: { to: "channel:123", components: nativeComponents, presentation },
@@ -698,7 +708,6 @@ describe("executeSendAction", () => {
         sendText: async () => ({ channel: "whatsapp", messageId: "msg-test" }),
       },
     };
-    setActivePluginRegistry(createTestRegistry([{ pluginId: "whatsapp", plugin, source: "test" }]));
     mocks.sendMessage.mockResolvedValue({
       channel: "whatsapp",
       to: "+15551234567",
@@ -708,6 +717,7 @@ describe("executeSendAction", () => {
 
     await executeSendAction({
       ctx: {
+        plugin,
         cfg: {},
         channel: "whatsapp",
         params: { to: "+15551234567", message: "Deployment trend", presentation },
@@ -746,11 +756,11 @@ describe("executeSendAction", () => {
         handleAction: async () => ({ content: [], details: { ok: true } }),
       },
     };
-    setActivePluginRegistry(createTestRegistry([{ pluginId: "discord", plugin, source: "test" }]));
     mocks.dispatchChannelMessageAction.mockResolvedValue(pluginActionResult("msg-plugin"));
 
     const result = await executeSendAction({
       ctx: {
+        plugin,
         cfg: {},
         channel: "discord",
         params: { to: "channel:123", presentation },
@@ -775,6 +785,7 @@ describe("executeSendAction", () => {
 
     const result = await executeSendAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: { to: "channel:123", message: "hello" },
@@ -796,6 +807,7 @@ describe("executeSendAction", () => {
 
     const result = await executePollAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: {},
@@ -821,6 +833,7 @@ describe("executeSendAction", () => {
 
     const result = await executePollAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: {
@@ -844,6 +857,7 @@ describe("executeSendAction", () => {
 
     await executeSendAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: { to: "channel:123", message: "hello" },
@@ -870,6 +884,7 @@ describe("executeSendAction", () => {
 
     await executeSendAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: {
@@ -897,6 +912,7 @@ describe("executeSendAction", () => {
 
     await executeSendAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: {
@@ -926,6 +942,7 @@ describe("executeSendAction", () => {
 
     await executeSendAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: {
@@ -1000,6 +1017,7 @@ describe("executeSendAction", () => {
 
     await executeSendAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: { to: "channel:123", message: "hello" },
@@ -1050,7 +1068,6 @@ describe("executeSendAction", () => {
       },
       outbound: { deliveryMode: "direct" },
     };
-    setActivePluginRegistry(createTestRegistry([{ pluginId: "discord", plugin, source: "test" }]));
     mocks.sendMessage.mockResolvedValue({
       channel: "discord",
       to: "channel:123",
@@ -1060,6 +1077,7 @@ describe("executeSendAction", () => {
 
     await executeSendAction({
       ctx: {
+        plugin,
         cfg: {},
         channel: "discord",
         params: { to: "channel:123", message: "hello" },
@@ -1093,6 +1111,7 @@ describe("executeSendAction", () => {
       threadId: "thread-1",
       conversationReadOrigin: "delegated",
     });
+    expect(sendArgs.preparedPlugin).toBe(plugin);
     const [payload] = requireArray(sendArgs.payloads, "send payloads");
     expectFields(requireRecord(payload, "prepared payload"), {
       channelData: { prepared: true },
@@ -1114,7 +1133,6 @@ describe("executeSendAction", () => {
       },
       outbound: { deliveryMode: "direct" },
     };
-    setActivePluginRegistry(createTestRegistry([{ pluginId: "discord", plugin, source: "test" }]));
     mocks.sendMessage.mockResolvedValue({
       channel: "discord",
       to: "channel:123",
@@ -1124,6 +1142,7 @@ describe("executeSendAction", () => {
 
     await executeSendAction({
       ctx: {
+        plugin,
         cfg: {},
         channel: "discord",
         params: { to: "channel:123", message: "hello" },
@@ -1155,6 +1174,7 @@ describe("executeSendAction", () => {
 
     await executePollAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: {},
@@ -1199,6 +1219,7 @@ describe("executeSendAction", () => {
 
     await executePollAction({
       ctx: {
+        plugin: defaultPlugin,
         cfg: {},
         channel: "demo-outbound",
         params: {},

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -11,6 +11,7 @@ import type {
   ChannelId,
   ChannelMessageActionContext,
   ChannelOutboundAdapter,
+  ChannelPlugin,
   ChannelThreadingToolContext,
 } from "../../channels/plugins/types.public.js";
 import { appendAssistantMessageToSessionTranscript } from "../../config/sessions.js";
@@ -26,7 +27,6 @@ import { extractToolPayload } from "../../plugin-sdk/tool-payload.js";
 import type { GatewayClientMode, GatewayClientName } from "../../utils/message-channel.js";
 import { formatErrorMessage } from "../errors.js";
 import { throwIfAborted } from "./abort.js";
-import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import type { OutboundDeliveryResult } from "./deliver-types.js";
 import type { NormalizedOutboundPayload, OutboundSendDeps } from "./deliver.js";
 import type { DurableDeliveryCompletion } from "./delivery-completion.js";
@@ -51,6 +51,7 @@ type OutboundGatewayContext = {
 type OutboundSendContext = {
   cfg: OpenClawConfig;
   channel: ChannelId;
+  plugin: ChannelPlugin;
   params: Record<string, unknown>;
   idempotencyKey?: string;
   /** Active agent id for per-agent outbound media root scoping. */
@@ -179,6 +180,7 @@ async function sendCoreMessage(params: {
     silent: params.ctx.silent,
     mediaAccess: params.ctx.mediaAccess,
     preparedMessageId: params.ctx.preparedMessageId,
+    preparedPlugin: params.ctx.plugin,
     gatewayOwnedDelivery: params.ctx.gatewayOwnedDelivery,
     deliveryIntentId: params.ctx.deliveryIntentId,
     deliveryCompletion: params.ctx.deliveryCompletion,
@@ -292,10 +294,7 @@ async function preparePluginSendPayload(params: {
   replyToIdSource?: "explicit" | "implicit";
   threadId?: string | number;
 }): Promise<PluginSendPayloadPreparation> {
-  const plugin = resolveOutboundChannelPlugin({
-    channel: params.ctx.channel,
-    cfg: params.ctx.cfg,
-  });
+  const plugin = params.ctx.plugin;
   if (!plugin?.outbound) {
     return { kind: "unavailable" };
   }
@@ -365,10 +364,7 @@ export async function executeSendAction(params: {
         replyToIdSource: params.replyToIdSource,
         threadId: params.threadId,
       });
-  const channelPlugin = resolveOutboundChannelPlugin({
-    channel: params.ctx.channel,
-    cfg: params.ctx.cfg,
-  });
+  const channelPlugin = params.ctx.plugin;
   const presentation = normalizeMessagePresentation(defaultPayload.presentation);
   const corePayload = requiresCoreDelivery
     ? defaultPayload
@@ -519,6 +515,7 @@ export async function executePollAction(params: {
     dryRun: params.ctx.dryRun,
     gateway: params.ctx.gateway,
     idempotencyKey: params.ctx.idempotencyKey,
+    preparedPlugin: params.ctx.plugin,
   });
 
   return {

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -57,6 +57,7 @@ import { resolveSessionDeliveryTarget, type SessionDeliveryTarget } from "./targ
 /** Resolves a user-supplied outbound destination through the channel plugin. */
 export function resolveOutboundTarget(params: {
   channel: string;
+  plugin?: ChannelPlugin;
   to?: string;
   allowFrom?: string[];
   allowBootstrap?: boolean;
@@ -66,11 +67,13 @@ export function resolveOutboundTarget(params: {
 }): OutboundTargetResolution {
   return (
     resolveOutboundTargetWithPlugin({
-      plugin: resolveOutboundChannelPlugin({
-        channel: params.channel,
-        cfg: params.cfg,
-        allowBootstrap: params.allowBootstrap,
-      }),
+      plugin:
+        params.plugin ??
+        resolveOutboundChannelPlugin({
+          channel: params.channel,
+          cfg: params.cfg,
+          allowBootstrap: params.allowBootstrap,
+        }),
       target: params,
       onMissingPlugin: () =>
         params.channel === INTERNAL_MESSAGE_CHANNEL


### PR DESCRIPTION
## What Problem This Solves

Resolves repeated outbound channel plugin discovery where selection or bootstrap proved a plugin usable, discarded that request-local fact, and downstream delivery immediately resolved registry state again. Isolated bootstrap registries could therefore produce redundant work or a different plugin view during one send.

## Why This Change Was Made

Channel selection now carries the exact prepared plugin through message actions, core send and poll delivery, target normalization, agent delivery planning, bare reset acknowledgments, and the immediate CLI and command consumers. Standalone entrypoints still resolve once at their boundary. Bundled/setup channels retain one docking lookup only when upstream planning produced no prepared plugin. No cache, persistence change, compatibility shim, or parallel resolution path was added.

## User Impact

Outbound sends and agent deliveries avoid repeated plugin bootstrap and registry lookup in the same request, while preserving existing routing, reset delivery, security gates, and channel behavior.

AI-assisted; the resulting code and ownership flow were reviewed and understood.

## Evidence

- Focused boundary proof: 12 test files, 262 tests passed, including message-action security coverage.
- Exact CI regression proof: the gateway bare-reset delivery test reproduced the legacy docking failure, then passed after forwarding the prepared plugin and retaining the no-plugin docking fallback.
- Focused follow-up proof: gateway reset plus command/agent delivery suites passed.
- Changed-file Testbox gate passed after the follow-up: formatting, core and test typechecks, lint, import cycles, plugin boundaries, dead exports, and repository guards.
- Testbox: tbx_01kzjkt72cjt12hy6g5a4ne6ch
- Run: https://github.com/openclaw/openclaw/actions/runs/31299277107
- Post-rebase selected channel-selection, reset, command-delivery, and agent-delivery tests passed.
- Two untouched CI failures passed on exact focused rerun and were classified as transient; the branch-owned formatting failure was corrected with the repository formatter.
- Fresh branch autoreview: clean, with no accepted or actionable findings.
- Production LOC: +138/-88 (net +50); tests: +126/-42 (net +84). The production delta is the typed plugin fact handoff across the full request boundary, including reset delivery and the named legacy docking contract.
