### PR TITLE
fix(macos): localize remote Gateway status labels

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -33851,7 +33851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 760,
+      "line": 764,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Installed: \\(gatewayVersion) · Required: \\(required)",
       "surface": "apple",
@@ -33859,7 +33859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 764,
+      "line": 768,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway \\(gatewayVersion) detected",
       "surface": "apple",
@@ -33867,7 +33867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 770,
+      "line": 774,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Node \\(node)",
       "surface": "apple",
@@ -33875,7 +33875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 782,
+      "line": 786,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Last failure: \\(failure)",
       "surface": "apple",
@@ -33883,7 +33883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 787,
+      "line": 791,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Recheck",
       "surface": "apple",
@@ -33891,7 +33891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 790,
+      "line": 794,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway auto-starts in local mode via launchd (\\(gatewayLaunchdLabel)).",
       "surface": "apple",
@@ -33899,7 +33899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 843,
+      "line": 847,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Retry now",
       "surface": "apple",
@@ -33907,7 +33907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 848,
+      "line": 852,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Open logs",
       "surface": "apple",
@@ -34914,8 +34914,24 @@
       "id": "native.apple.e49b3d2d2cc77bd1"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 195,
+      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
+      "source": "Gateway authentication required",
+      "surface": "apple",
+      "id": "native.apple.4f86dd528b403cea"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 197,
+      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
+      "source": "Back to Gateway",
+      "surface": "apple",
+      "id": "native.apple.9e7e92ef3bc76528"
+    },
+    {
       "kind": "conditional-branch",
-      "line": 204,
+      "line": 231,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Waiting for the previous AI test to finish…",
       "surface": "apple",
@@ -34923,7 +34939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 205,
+      "line": 232,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Looking for AI you already use…",
       "surface": "apple",
@@ -34931,7 +34947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 208,
+      "line": 235,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "OpenClaw will check again before changing any inference settings.",
       "surface": "apple",
@@ -34939,7 +34955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 209,
+      "line": 236,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Checking CLI logins, saved API keys, and local model servers on the Gateway.",
       "surface": "apple",
@@ -34947,7 +34963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 257,
+      "line": 284,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Couldn’t check this Gateway for AI accounts",
       "surface": "apple",
@@ -34955,7 +34971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 258,
+      "line": 285,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Couldn’t check this Gateway for AI access",
       "surface": "apple",
@@ -34963,7 +34979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 274,
+      "line": 301,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Couldn’t load the full provider list",
       "surface": "apple",
@@ -34971,7 +34987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 277,
+      "line": 304,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Try again",
       "surface": "apple",
@@ -34979,7 +34995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 285,
+      "line": 312,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "None of the found options worked",
       "surface": "apple",
@@ -34987,7 +35003,7 @@
     },
     {
       "kind": "ui-named-argument-multiline",
-      "line": 286,
+      "line": 313,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
       "surface": "apple",
@@ -34995,7 +35011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 309,
+      "line": 336,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Need help? Chat with OpenClaw",
       "surface": "apple",
@@ -35003,7 +35019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 324,
+      "line": 351,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Your AI is ready",
       "surface": "apple",
@@ -35011,7 +35027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 335,
+      "line": 362,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Setup details",
       "surface": "apple",
@@ -35019,7 +35035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 349,
+      "line": 376,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Copy setup details",
       "surface": "apple",
@@ -35027,7 +35043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 358,
+      "line": 385,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Choose a different AI…",
       "surface": "apple",
@@ -35035,7 +35051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 372,
+      "line": 399,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "No usable AI access found on this Gateway",
       "surface": "apple",
@@ -35043,7 +35059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 375,
+      "line": 402,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect a provider below with an API key or token, then check again.",
       "surface": "apple",
@@ -35051,7 +35067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 376,
+      "line": 403,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Install one of these tools, then check again. You can also connect a provider below.",
       "surface": "apple",
@@ -35059,7 +35075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 381,
+      "line": 408,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Recommended installs",
       "surface": "apple",
@@ -35067,7 +35083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 404,
+      "line": 431,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Detected, but not auto-tested",
       "surface": "apple",
@@ -35075,7 +35091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 412,
+      "line": 439,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "\\(candidate.label) — \\(candidate.detail)",
       "surface": "apple",
@@ -35083,7 +35099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 531,
+      "line": 558,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "No key-based providers are available",
       "surface": "apple",
@@ -35091,7 +35107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 532,
+      "line": 559,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
       "surface": "apple",
@@ -35099,7 +35115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 534,
+      "line": 561,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Check again",
       "surface": "apple",
@@ -35107,7 +35123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 548,
+      "line": 575,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Set up a local model",
       "surface": "apple",
@@ -35115,7 +35131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 550,
+      "line": 577,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect a local model service, or prepare a model on this Gateway.",
       "surface": "apple",
@@ -35123,7 +35139,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 574,
+      "line": 601,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect / Set up",
       "surface": "apple",
@@ -35131,7 +35147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 596,
+      "line": 623,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Sign in with a provider",
       "surface": "apple",
@@ -35139,7 +35155,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 598,
+      "line": 625,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
       "surface": "apple",
@@ -35147,7 +35163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 613,
+      "line": 640,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "More sign-in options",
       "surface": "apple",
@@ -35155,7 +35171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 643,
+      "line": 670,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "API Keys",
       "surface": "apple",
@@ -35163,7 +35179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 683,
+      "line": 710,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Pair",
       "surface": "apple",
@@ -35171,7 +35187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 683,
+      "line": 710,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Sign in",
       "surface": "apple",
@@ -35179,7 +35195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 700,
+      "line": 727,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "OpenClaw will detect and verify the prepared model before using it.",
       "surface": "apple",
@@ -35187,7 +35203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 701,
+      "line": 728,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
       "surface": "apple",
@@ -35195,7 +35211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 730,
+      "line": 757,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Open sign-in page…",
       "surface": "apple",
@@ -35203,7 +35219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 738,
+      "line": 765,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Starting local model setup…",
       "surface": "apple",
@@ -35211,7 +35227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 739,
+      "line": 766,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Starting secure sign-in…",
       "surface": "apple",
@@ -35219,7 +35235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 746,
+      "line": 773,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Model setup didn’t complete",
       "surface": "apple",
@@ -35227,7 +35243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 747,
+      "line": 774,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Sign-in didn’t complete",
       "surface": "apple",
@@ -35235,7 +35251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 757,
+      "line": 784,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -35243,7 +35259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 780,
+      "line": 807,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Finish in your browser",
       "surface": "apple",
@@ -35251,7 +35267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 796,
+      "line": 823,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Copy",
       "surface": "apple",
@@ -35259,7 +35275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 807,
+      "line": 834,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Expires in \\(minutes) minutes",
       "surface": "apple",
@@ -35267,7 +35283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 814,
+      "line": 841,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Open sign-in page",
       "surface": "apple",
@@ -35275,7 +35291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 842,
+      "line": 869,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Option",
       "surface": "apple",
@@ -35283,7 +35299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 848,
+      "line": 875,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Confirm",
       "surface": "apple",
@@ -35291,7 +35307,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 857,
+      "line": 884,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "I've signed in",
       "surface": "apple",
@@ -35299,7 +35315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 859,
+      "line": 886,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Continue",
       "surface": "apple",
@@ -35307,7 +35323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 859,
+      "line": 886,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Submit",
       "surface": "apple",
@@ -35315,7 +35331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 864,
+      "line": 891,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect with an API key or token",
       "surface": "apple",
@@ -35323,7 +35339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 873,
+      "line": 900,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Provider",
       "surface": "apple",
@@ -35331,7 +35347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 881,
+      "line": 908,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "API key or token",
       "surface": "apple",
@@ -35339,7 +35355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 893,
+      "line": 920,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect",
       "surface": "apple",
@@ -35347,7 +35363,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 909,
+      "line": 936,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "That key didn’t work",
       "surface": "apple",
@@ -35355,7 +35371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 935,
+      "line": 962,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "OpenClaw — setup helper",
       "surface": "apple",
@@ -35363,7 +35379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 938,
+      "line": 965,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Done",
       "surface": "apple",
@@ -35371,7 +35387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1010,
+      "line": 1041,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Open help…",
       "surface": "apple",
@@ -35379,7 +35395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1049,
+      "line": 1080,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Hide details",
       "surface": "apple",
@@ -35387,7 +35403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1049,
+      "line": 1080,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Show details",
       "surface": "apple",
@@ -35395,7 +35411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1072,
+      "line": 1103,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Copy error",
       "surface": "apple",
@@ -35907,7 +35923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 751,
+      "line": 755,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": " · ssh \\(parsed.port)",
       "surface": "apple",
@@ -35915,7 +35931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 820,
+      "line": 824,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Grant permissions",
       "surface": "apple",
@@ -35923,7 +35939,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 827,
+      "line": 831,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "These macOS permissions let OpenClaw automate apps and capture context on this Mac. Status updates automatically.",
       "surface": "apple",
@@ -35931,7 +35947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 864,
+      "line": 868,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Getting things ready",
       "surface": "apple",
@@ -35939,7 +35955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 875,
+      "line": 879,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Install OpenClaw",
       "surface": "apple",
@@ -35947,7 +35963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 882,
+      "line": 886,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Prepare the Mac node",
       "surface": "apple",
@@ -35955,7 +35971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 882,
+      "line": 886,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Start the background service",
       "surface": "apple",
@@ -35963,7 +35979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 884,
+      "line": 888,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Runs inside the app and uses its macOS permissions.",
       "surface": "apple",
@@ -35971,7 +35987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 885,
+      "line": 889,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Runs quietly and starts again after a restart.",
       "surface": "apple",
@@ -35979,7 +35995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 888,
+      "line": 892,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Ready for the next step",
       "surface": "apple",
@@ -35987,7 +36003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 890,
+      "line": 894,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Once ready, this Mac connects to your selected Gateway.",
       "surface": "apple",
@@ -35995,7 +36011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 891,
+      "line": 895,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Once the service answers, you’ll connect your AI.",
       "surface": "apple",
@@ -36003,7 +36019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 897,
+      "line": 901,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "The Gateway didn’t start",
       "surface": "apple",
@@ -36011,7 +36027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 898,
+      "line": 902,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "OpenClaw installation failed",
       "surface": "apple",
@@ -36019,7 +36035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 901,
+      "line": 906,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Try again",
       "surface": "apple",
@@ -36027,7 +36043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 992,
+      "line": 997,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "You’re all set!",
       "surface": "apple",
@@ -36035,7 +36051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 995,
+      "line": 1000,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Finish opens the chat — say hi to your new agent.",
       "surface": "apple",
@@ -36043,7 +36059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1003,
+      "line": 1008,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Configure later",
       "surface": "apple",
@@ -36051,7 +36067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1004,
+      "line": 1009,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Pick Local or Remote in Settings → General whenever you’re ready.",
       "surface": "apple",
@@ -36059,7 +36075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1011,
+      "line": 1016,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Remote gateway checklist",
       "surface": "apple",
@@ -36067,7 +36083,7 @@
     },
     {
       "kind": "ui-named-argument-multiline",
-      "line": 1012,
+      "line": 1017,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "On your gateway host: install/update the `openclaw` package and make sure credentials exist\n(typically `~/.openclaw/credentials/oauth.json`). Then connect again if needed.",
       "surface": "apple",
@@ -36075,7 +36091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1021,
+      "line": 1026,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open the menu bar panel",
       "surface": "apple",
@@ -36083,7 +36099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1022,
+      "line": 1027,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
       "surface": "apple",
@@ -36091,7 +36107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1025,
+      "line": 1030,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Connect Discord, Slack, Telegram, WhatsApp, …",
       "surface": "apple",
@@ -36099,7 +36115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1026,
+      "line": 1031,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels to link channels and monitor status.",
       "surface": "apple",
@@ -36107,7 +36123,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1028,
+      "line": 1033,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels",
       "surface": "apple",
@@ -36115,7 +36131,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1033,
+      "line": 1038,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Try Voice Wake",
       "surface": "apple",
@@ -36123,7 +36139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1034,
+      "line": 1039,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable Voice Wake in Settings for hands-free commands with a live transcript overlay.",
       "surface": "apple",
@@ -36131,7 +36147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1037,
+      "line": 1042,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Use the panel + Canvas",
       "surface": "apple",
@@ -36139,7 +36155,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 1038,
+      "line": 1043,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
       "surface": "apple",
@@ -36147,7 +36163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1042,
+      "line": 1047,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Give your agent more powers",
       "surface": "apple",
@@ -36155,7 +36171,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1043,
+      "line": 1048,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable optional skills (Peekaboo, oracle, camsnap, …) from Settings → Skills.",
       "surface": "apple",
@@ -36163,7 +36179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1045,
+      "line": 1050,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Skills",
       "surface": "apple",
@@ -36171,7 +36187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1050,
+      "line": 1055,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Launch at login",
       "surface": "apple",
@@ -36179,7 +36195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1077,
+      "line": 1082,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Skills included",
       "surface": "apple",
@@ -36187,7 +36203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1084,
+      "line": 1089,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -36195,7 +36211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1093,
+      "line": 1098,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Couldn’t load skills from the Gateway.",
       "surface": "apple",
@@ -36203,7 +36219,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 1096,
+      "line": 1101,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Make sure the Gateway is running and connected, then hit Refresh (or open Settings → Skills).",
       "surface": "apple",
@@ -36211,7 +36227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1102,
+      "line": 1107,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Details: \\(error)",
       "surface": "apple",
@@ -36219,7 +36235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1108,
+      "line": 1113,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "No skills reported yet.",
       "surface": "apple",
@@ -37426,7 +37442,7 @@
       "id": "native.apple.6521871fc0ddc987"
     },
     {
-      "kind": "conditional-branch",
+      "kind": "ui-localized-call",
       "line": 55,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway requires an auth token",
@@ -37434,7 +37450,7 @@
       "id": "native.apple.1eeca02c45d3db5a"
     },
     {
-      "kind": "conditional-branch",
+      "kind": "ui-localized-call",
       "line": 57,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "That token did not match the gateway",
@@ -37442,7 +37458,7 @@
       "id": "native.apple.b45db388b1bd36bb"
     },
     {
-      "kind": "conditional-branch",
+      "kind": "ui-localized-call",
       "line": 59,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway host needs token setup",
@@ -37450,7 +37466,7 @@
       "id": "native.apple.199c0835c6de23e5"
     },
     {
-      "kind": "conditional-branch",
+      "kind": "ui-localized-call",
       "line": 61,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This setup code is no longer valid",
@@ -37458,7 +37474,7 @@
       "id": "native.apple.ff1cbf5fb69f6d53"
     },
     {
-      "kind": "conditional-branch",
+      "kind": "ui-localized-call",
       "line": 63,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway is using unsupported auth",
@@ -37466,7 +37482,7 @@
       "id": "native.apple.4f751db2308294e1"
     },
     {
-      "kind": "conditional-branch",
+      "kind": "ui-localized-call",
       "line": 65,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This device needs pairing approval",
@@ -37474,140 +37490,172 @@
       "id": "native.apple.2e5704a3b8fcc47f"
     },
     {
-      "kind": "conditional-branch",
-      "line": 72,
+      "kind": "ui-localized-call-multiline",
+      "line": 77,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw gateway auth-token --show` in an interactive terminal, then paste its output.",
       "surface": "apple",
       "id": "native.apple.90b00f3f5418b439"
     },
     {
-      "kind": "conditional-branch",
-      "line": 76,
+      "kind": "ui-localized-call-multiline",
+      "line": 84,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "On the gateway host, run `openclaw gateway auth-token --show` in an interactive terminal, then replace the token and try again.",
       "surface": "apple",
       "id": "native.apple.b79d3c42bd5438d5"
     },
     {
-      "kind": "conditional-branch",
-      "line": 79,
+      "kind": "ui-localized-call-multiline",
+      "line": 90,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
       "surface": "apple",
       "id": "native.apple.c26f61d639591f81"
     },
     {
-      "kind": "conditional-branch",
-      "line": 83,
+      "kind": "ui-localized-call",
+      "line": 97,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Scan or paste a fresh setup code from an already-paired OpenClaw client, then try again.",
       "surface": "apple",
       "id": "native.apple.83145f8f53d7be34"
     },
     {
-      "kind": "conditional-branch",
-      "line": 85,
+      "kind": "ui-localized-call-multiline",
+      "line": 100,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
       "surface": "apple",
       "id": "native.apple.a8bf4f7ab4a35dc0"
     },
     {
-      "kind": "conditional-branch",
-      "line": 88,
+      "kind": "ui-localized-call-multiline",
+      "line": 106,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
       "surface": "apple",
       "id": "native.apple.52c0f97f0b3bb792"
     },
     {
-      "kind": "conditional-branch",
-      "line": 111,
+      "kind": "ui-localized-call-multiline",
+      "line": 122,
+      "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
+      "source": "No token yet? Generate one on the gateway host with `openclaw doctor --generate-gateway-token`, then set it as `gateway.auth.token`.",
+      "surface": "apple",
+      "id": "native.apple.669cab82672e5b44"
+    },
+    {
+      "kind": "ui-localized-call-multiline",
+      "line": 131,
+      "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
+      "source": "If you do not have another paired OpenClaw client yet, approve the pending request on the gateway host with `openclaw devices approve`.",
+      "surface": "apple",
+      "id": "native.apple.b450aca58f210ab0"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 149,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway requires an auth token. Run openclaw gateway auth-token --show on the gateway host.",
       "surface": "apple",
       "id": "native.apple.a1cb5542806f0ec9"
     },
     {
-      "kind": "conditional-branch",
-      "line": 113,
+      "kind": "ui-localized-call",
+      "line": 152,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Gateway token mismatch. Run openclaw gateway auth-token --show on the gateway host.",
       "surface": "apple",
       "id": "native.apple.e12c96574b97ed4a"
     },
     {
-      "kind": "conditional-branch",
-      "line": 115,
+      "kind": "ui-localized-call",
+      "line": 155,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway has token auth enabled, but no gateway.auth.token is configured on the host.",
       "surface": "apple",
       "id": "native.apple.cd96754a96e5aa35"
     },
     {
-      "kind": "conditional-branch",
-      "line": 117,
+      "kind": "ui-localized-call",
+      "line": 158,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Setup code expired or already used. Scan a fresh setup code, then try again.",
       "surface": "apple",
       "id": "native.apple.b58556877f8eba24"
     },
     {
-      "kind": "conditional-branch",
-      "line": 119,
+      "kind": "ui-localized-call",
+      "line": 161,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway uses password auth. Remote onboarding on macOS cannot collect gateway passwords yet.",
       "surface": "apple",
       "id": "native.apple.49ea9045d0c7402d"
     },
     {
-      "kind": "conditional-branch",
-      "line": 121,
+      "kind": "ui-localized-call-multiline",
+      "line": 164,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
       "surface": "apple",
       "id": "native.apple.3e5a2b2a24f73418"
     },
     {
-      "kind": "conditional-branch",
-      "line": 139,
+      "kind": "ui-localized-call",
+      "line": 188,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Connected via paired device",
       "surface": "apple",
       "id": "native.apple.58e76e9c8b04290a"
     },
     {
-      "kind": "conditional-branch",
-      "line": 141,
+      "kind": "ui-localized-call",
+      "line": 190,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Connected with setup code",
       "surface": "apple",
       "id": "native.apple.dbe7f99297c2269d"
     },
     {
-      "kind": "conditional-branch",
-      "line": 143,
+      "kind": "ui-localized-call",
+      "line": 192,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Connected with gateway token",
       "surface": "apple",
       "id": "native.apple.a3c2651d36de9c7f"
     },
     {
-      "kind": "conditional-branch",
-      "line": 145,
+      "kind": "ui-localized-call",
+      "line": 194,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Connected with password",
       "surface": "apple",
       "id": "native.apple.f9df689f570952aa"
     },
     {
-      "kind": "conditional-branch",
-      "line": 147,
+      "kind": "ui-localized-call",
+      "line": 196,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Remote gateway ready",
       "surface": "apple",
       "id": "native.apple.ebfc72d56c8b3e3a"
+    },
+    {
+      "kind": "ui-localized-call-multiline",
+      "line": 208,
+      "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
+      "source": "This app used a stored device token. New or unpaired devices may still need the gateway token.",
+      "surface": "apple",
+      "id": "native.apple.afcb532f00f064a8"
+    },
+    {
+      "kind": "ui-localized-call-multiline",
+      "line": 214,
+      "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
+      "source": "This app is still using the temporary setup code. Approve pairing to finish provisioning device-scoped auth.",
+      "surface": "apple",
+      "id": "native.apple.0a9e9d0c6f5f61e1"
     },
     {
       "kind": "conditional-branch",

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -724,10 +724,14 @@ struct GeneralSettings: View {
                 .foregroundStyle(.secondary)
         case let .ok(success):
             VStack(alignment: .leading, spacing: 2) {
-                Label(success.title, systemImage: "checkmark.circle.fill")
-                    .font(.caption)
-                    .foregroundStyle(.green)
-                if let detail = success.detail {
+                Label {
+                    Text(success.titleResource)
+                } icon: {
+                    Image(systemName: "checkmark.circle.fill")
+                }
+                .font(.caption)
+                .foregroundStyle(.green)
+                if let detail = success.detailResource {
                     Text(detail)
                         .font(.caption)
                         .foregroundStyle(.secondary)

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
@@ -148,11 +148,38 @@ private struct OnboardingRecommendedInstallCard: View {
     }
 }
 
+enum OnboardingTextValue: Equatable, ExpressibleByStringLiteral {
+    case localized(LocalizedStringResource)
+    case verbatim(String)
+
+    init(stringLiteral value: String) {
+        self = .localized(LocalizedStringResource(stringLiteral: value))
+    }
+
+    var text: Text {
+        switch self {
+        case let .localized(resource):
+            Text(resource)
+        case let .verbatim(value):
+            Text(verbatim: value)
+        }
+    }
+
+    var resolvedString: String {
+        switch self {
+        case let .localized(resource):
+            String(localized: resource)
+        case let .verbatim(value):
+            value
+        }
+    }
+}
+
 struct GatewayAuthCard: Equatable {
-    let title: String
-    let message: String
-    let primaryTitle: String
-    let secondaryTitle: String
+    let title: OnboardingTextValue
+    let message: OnboardingTextValue
+    let primaryTitle: OnboardingTextValue
+    let secondaryTitle: OnboardingTextValue
 }
 
 struct OnboardingAISetupView: View {
@@ -165,10 +192,10 @@ struct OnboardingAISetupView: View {
 
     static func gatewayAuthCard(for issue: RemoteGatewayAuthIssue) -> GatewayAuthCard {
         GatewayAuthCard(
-            title: "Gateway authentication required",
-            message: issue.statusMessage,
-            primaryTitle: "Back to Gateway",
-            secondaryTitle: "Try again")
+            title: .localized("Gateway authentication required"),
+            message: .localized(issue.statusMessageResource),
+            primaryTitle: .localized("Back to Gateway"),
+            secondaryTitle: .localized("Try again"))
     }
 
     var body: some View {
@@ -256,7 +283,7 @@ struct OnboardingAISetupView: View {
                 title: self.model.configuredGatewayProbeUnavailable
                     ? "Couldn’t check this Gateway for AI accounts"
                     : "Couldn’t check this Gateway for AI access",
-                message: detectError.summary,
+                message: .verbatim(detectError.summary),
                 details: detectError.detail,
                 docsSlug: "start/onboarding",
                 retryTitle: "Try again")
@@ -272,7 +299,7 @@ struct OnboardingAISetupView: View {
         if let providerCatalogError = model.providerCatalogError {
             OnboardingErrorCard(
                 title: "Couldn’t load the full provider list",
-                message: providerCatalogError,
+                message: .verbatim(providerCatalogError),
                 docsSlug: "start/onboarding",
                 retryTitle: "Try again")
             {
@@ -745,7 +772,7 @@ struct OnboardingAISetupView: View {
                     title: self.model.isPreparingModel
                         ? "Model setup didn’t complete"
                         : "Sign-in didn’t complete",
-                    message: error.summary,
+                    message: .verbatim(error.summary),
                     details: error.detail,
                     docsSlug: "concepts/model-providers",
                     retryTitle: nil,
@@ -907,7 +934,7 @@ struct OnboardingAISetupView: View {
             if let manualError = model.manualError {
                 OnboardingErrorCard(
                     title: "That key didn’t work",
-                    message: manualError.summary,
+                    message: .verbatim(manualError.summary),
                     details: manualError.detail,
                     docsSlug: "concepts/model-providers",
                     retryTitle: nil,
@@ -951,22 +978,22 @@ struct OnboardingAISetupView: View {
 /// Every onboarding failure points at a docs.openclaw.ai page so people are
 /// never stuck staring at a raw error string.
 struct OnboardingErrorCard: View {
-    let title: String
-    let message: String
+    let title: OnboardingTextValue
+    let message: OnboardingTextValue
     var details: String?
     let docsSlug: String
-    var retryTitle: String?
+    var retryTitle: OnboardingTextValue?
     var retry: (() -> Void)?
-    var secondaryTitle: String?
+    var secondaryTitle: OnboardingTextValue?
     var secondary: (() -> Void)?
 
     init(
-        title: String,
-        message: String,
+        title: OnboardingTextValue,
+        message: OnboardingTextValue,
         details: String? = nil,
         docsSlug: String,
-        retryTitle: String? = nil,
-        secondaryTitle: String? = nil,
+        retryTitle: OnboardingTextValue? = nil,
+        secondaryTitle: OnboardingTextValue? = nil,
         secondary: (() -> Void)? = nil,
         retry: (() -> Void)? = nil)
     {
@@ -986,9 +1013,9 @@ struct OnboardingErrorCard: View {
                 .foregroundStyle(.orange)
                 .padding(.top, 1)
             VStack(alignment: .leading, spacing: 4) {
-                Text(self.title)
+                self.title.text
                     .font(.callout.weight(.semibold))
-                Text(self.message)
+                self.message.text
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .textSelection(.enabled)
@@ -998,14 +1025,18 @@ struct OnboardingErrorCard: View {
                 }
                 HStack(spacing: 14) {
                     if let retryTitle, let retry {
-                        Button(retryTitle, action: retry)
-                            .buttonStyle(.borderedProminent)
-                            .controlSize(.small)
+                        Button(action: retry) {
+                            retryTitle.text
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
                     }
                     if let secondaryTitle, let secondary {
-                        Button(secondaryTitle, action: secondary)
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
+                        Button(action: secondary) {
+                            secondaryTitle.text
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
                     }
                     Button("Open help…") {
                         if let url = URL(string: "https://docs.openclaw.ai/\(docsSlug)") {
@@ -1016,7 +1047,7 @@ struct OnboardingErrorCard: View {
                     .font(.caption)
                     if details == nil {
                         Button("Copy error") {
-                            OnboardingErrorDetails.copy(self.message)
+                            OnboardingErrorDetails.copy(self.message.resolvedString)
                         }
                         .buttonStyle(.link)
                         .font(.caption)
@@ -1054,7 +1085,7 @@ private struct OnboardingErrorDetails: View {
 
             if self.expanded {
                 ScrollView(.vertical) {
-                    Text(self.text)
+                    Text(verbatim: self.text)
                         .font(.system(.caption, design: .monospaced))
                         .foregroundStyle(.secondary)
                         .textSelection(.enabled)

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -563,10 +563,14 @@ extension OnboardingView {
                 .foregroundStyle(.secondary)
         case let .ok(_, success):
             VStack(alignment: .leading, spacing: 2) {
-                Label(success.title, systemImage: "checkmark.circle.fill")
-                    .font(.caption)
-                    .foregroundStyle(.green)
-                if let detail = success.detail {
+                Label {
+                    Text(success.titleResource)
+                } icon: {
+                    Image(systemName: "checkmark.circle.fill")
+                }
+                .font(.caption)
+                .foregroundStyle(.green)
+                if let detail = success.detailResource {
                     Text(detail)
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -592,14 +596,14 @@ extension OnboardingView {
                 .frame(width: 16, alignment: .center)
                 .padding(.top, 1)
             VStack(alignment: .leading, spacing: 4) {
-                Text(issue.title)
+                Text(issue.titleResource)
                     .font(.caption.weight(.semibold))
-                Text(.init(issue.body))
+                Text(issue.bodyResource)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
-                if let footnote = issue.footnote {
-                    Text(.init(footnote))
+                if let footnote = issue.footnoteResource {
+                    Text(footnote)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -896,7 +900,8 @@ extension OnboardingView {
                         title: self.cliExecutableReady
                             ? "The Gateway didn’t start"
                             : "OpenClaw installation failed",
-                        message: self.cliStatus ?? "The installer did not finish.",
+                        message: self.cliStatus?.nonEmpty.map(OnboardingTextValue.verbatim)
+                            ?? "The installer did not finish.",
                         docsSlug: "platforms/mac/bundled-gateway",
                         retryTitle: "Try again")
                     {
@@ -907,7 +912,7 @@ extension OnboardingView {
                         }
                     }
                 } else if let cliStatus, !self.cliInstalled {
-                    Text(cliStatus)
+                    Text(verbatim: cliStatus)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
@@ -49,78 +49,127 @@ enum RemoteGatewayAuthIssue: Equatable {
         }
     }
 
-    var title: String {
+    var titleResource: LocalizedStringResource {
         switch self {
         case .tokenRequired:
-            "This gateway requires an auth token"
+            LocalizedStringResource("This gateway requires an auth token")
         case .tokenMismatch:
-            "That token did not match the gateway"
+            LocalizedStringResource("That token did not match the gateway")
         case .gatewayTokenNotConfigured:
-            "This gateway host needs token setup"
+            LocalizedStringResource("This gateway host needs token setup")
         case .setupCodeExpired:
-            "This setup code is no longer valid"
+            LocalizedStringResource("This setup code is no longer valid")
         case .passwordRequired:
-            "This gateway is using unsupported auth"
+            LocalizedStringResource("This gateway is using unsupported auth")
         case .pairingRequired:
-            "This device needs pairing approval"
+            LocalizedStringResource("This device needs pairing approval")
+        }
+    }
+
+    var title: String {
+        String(localized: self.titleResource)
+    }
+
+    var bodyResource: LocalizedStringResource {
+        switch self {
+        case .tokenRequired:
+            LocalizedStringResource(
+                """
+                Paste the token configured on the gateway host. \
+                On the gateway host, run `openclaw gateway auth-token --show` \
+                in an interactive terminal, then paste its output.
+                """)
+        case .tokenMismatch:
+            LocalizedStringResource(
+                """
+                On the gateway host, run `openclaw gateway auth-token --show` \
+                in an interactive terminal, then replace the token and try again.
+                """)
+        case .gatewayTokenNotConfigured:
+            LocalizedStringResource(
+                """
+                This gateway is set to token auth, but no `gateway.auth.token` is configured \
+                on the gateway host. If the gateway uses an environment variable instead, \
+                set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.
+                """)
+        case .setupCodeExpired:
+            LocalizedStringResource(
+                "Scan or paste a fresh setup code from an already-paired OpenClaw client, then try again.")
+        case .passwordRequired:
+            LocalizedStringResource(
+                """
+                This onboarding flow does not support password auth yet. \
+                Reconfigure the gateway to use token auth, then retry.
+                """)
+        case .pairingRequired:
+            LocalizedStringResource(
+                """
+                Approve this device from an already-paired OpenClaw client. \
+                In your OpenClaw chat, run `/pair approve`, \
+                then click **Check connection** again.
+                """)
         }
     }
 
     var body: String {
-        switch self {
-        case .tokenRequired:
-            "Paste the token configured on the gateway host. "
-                + "On the gateway host, run `openclaw gateway auth-token --show` "
-                + "in an interactive terminal, then paste its output."
-        case .tokenMismatch:
-            "On the gateway host, run `openclaw gateway auth-token --show` "
-                + "in an interactive terminal, then replace the token and try again."
-        case .gatewayTokenNotConfigured:
-            "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. "
-                + "If the gateway uses an environment variable instead, "
-                + "set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
-        case .setupCodeExpired:
-            "Scan or paste a fresh setup code from an already-paired OpenClaw client, then try again."
-        case .passwordRequired:
-            "This onboarding flow does not support password auth yet. "
-                + "Reconfigure the gateway to use token auth, then retry."
-        case .pairingRequired:
-            "Approve this device from an already-paired OpenClaw client. "
-                + "In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
-        }
+        String(localized: self.bodyResource)
     }
 
-    var footnote: String? {
+    var footnoteResource: LocalizedStringResource? {
         switch self {
         case .tokenRequired, .gatewayTokenNotConfigured:
-            "No token yet? Generate one on the gateway host with "
-                + "`openclaw doctor --generate-gateway-token`, then set it as `gateway.auth.token`."
+            LocalizedStringResource(
+                """
+                No token yet? Generate one on the gateway host with \
+                `openclaw doctor --generate-gateway-token`, \
+                then set it as `gateway.auth.token`.
+                """)
         case .setupCodeExpired:
             nil
         case .pairingRequired:
-            "If you do not have another paired OpenClaw client yet, "
-                + "approve the pending request on the gateway host with `openclaw devices approve`."
+            LocalizedStringResource(
+                """
+                If you do not have another paired OpenClaw client yet, \
+                approve the pending request on the gateway host \
+                with `openclaw devices approve`.
+                """)
         case .tokenMismatch, .passwordRequired:
             nil
         }
     }
 
-    var statusMessage: String {
+    var footnote: String? {
+        self.footnoteResource.map { String(localized: $0) }
+    }
+
+    var statusMessageResource: LocalizedStringResource {
         switch self {
         case .tokenRequired:
-            "This gateway requires an auth token. Run openclaw gateway auth-token --show on the gateway host."
+            LocalizedStringResource(
+                "This gateway requires an auth token. Run openclaw gateway auth-token --show on the gateway host.")
         case .tokenMismatch:
-            "Gateway token mismatch. Run openclaw gateway auth-token --show on the gateway host."
+            LocalizedStringResource(
+                "Gateway token mismatch. Run openclaw gateway auth-token --show on the gateway host.")
         case .gatewayTokenNotConfigured:
-            "This gateway has token auth enabled, but no gateway.auth.token is configured on the host."
+            LocalizedStringResource(
+                "This gateway has token auth enabled, but no gateway.auth.token is configured on the host.")
         case .setupCodeExpired:
-            "Setup code expired or already used. Scan a fresh setup code, then try again."
+            LocalizedStringResource(
+                "Setup code expired or already used. Scan a fresh setup code, then try again.")
         case .passwordRequired:
-            "This gateway uses password auth. Remote onboarding on macOS cannot collect gateway passwords yet."
+            LocalizedStringResource(
+                "This gateway uses password auth. Remote onboarding on macOS cannot collect gateway passwords yet.")
         case .pairingRequired:
-            "Pairing required. In an already-paired OpenClaw client, "
-                + "run /pair approve, then check the connection again."
+            LocalizedStringResource(
+                """
+                Pairing required. In an already-paired OpenClaw client, \
+                run /pair approve, then check the connection again.
+                """)
         }
+    }
+
+    var statusMessage: String {
+        String(localized: self.statusMessageResource)
     }
 }
 
@@ -133,31 +182,46 @@ enum RemoteGatewayProbeResult: Equatable {
 struct RemoteGatewayProbeSuccess: Equatable {
     let authSource: GatewayAuthSource?
 
-    var title: String {
+    var titleResource: LocalizedStringResource {
         switch self.authSource {
         case .some(.deviceToken):
-            "Connected via paired device"
+            LocalizedStringResource("Connected via paired device")
         case .some(.bootstrapToken):
-            "Connected with setup code"
+            LocalizedStringResource("Connected with setup code")
         case .some(.sharedToken):
-            "Connected with gateway token"
+            LocalizedStringResource("Connected with gateway token")
         case .some(.password):
-            "Connected with password"
+            LocalizedStringResource("Connected with password")
         case .some(GatewayAuthSource.none), nil:
-            "Remote gateway ready"
+            LocalizedStringResource("Remote gateway ready")
+        }
+    }
+
+    var title: String {
+        String(localized: self.titleResource)
+    }
+
+    var detailResource: LocalizedStringResource? {
+        switch self.authSource {
+        case .some(.deviceToken):
+            LocalizedStringResource(
+                """
+                This app used a stored device token. \
+                New or unpaired devices may still need the gateway token.
+                """)
+        case .some(.bootstrapToken):
+            LocalizedStringResource(
+                """
+                This app is still using the temporary setup code. \
+                Approve pairing to finish provisioning device-scoped auth.
+                """)
+        case .some(.sharedToken), .some(.password), .some(GatewayAuthSource.none), nil:
+            nil
         }
     }
 
     var detail: String? {
-        switch self.authSource {
-        case .some(.deviceToken):
-            "This app used a stored device token. New or unpaired devices may still need the gateway token."
-        case .some(.bootstrapToken):
-            "This app is still using the temporary setup code. "
-                + "Approve pairing to finish provisioning device-scoped auth."
-        case .some(.sharedToken), .some(.password), .some(GatewayAuthSource.none), nil:
-            nil
-        }
+        self.detailResource.map { String(localized: $0) }
     }
 }
 

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -2108,7 +2108,7 @@ struct OnboardingAISetupTests {
         #expect(card.title == "Gateway authentication required")
         #expect(card.primaryTitle == "Back to Gateway")
         #expect(card.secondaryTitle == "Try again")
-        #expect(!card.title.localizedCaseInsensitiveContains("AI account"))
+        #expect(!card.title.resolvedString.localizedCaseInsensitiveContains("AI account"))
 
         let decision = try #require(OnboardingView.gatewayAuthenticationReturnDecision(
             connectionMode: appState.connectionMode,

--- a/scripts/apple-app-i18n.ts
+++ b/scripts/apple-app-i18n.ts
@@ -156,7 +156,53 @@ const APPLE_LOCALE_DIRECTORIES: Record<string, string> = {
   "zh-CN": "zh-Hans",
   "zh-TW": "zh-Hant",
 };
+const REMOTE_GATEWAY_SUCCESS_RESOURCE_CONTRACTS = [
+  "Text(success.titleResource)",
+  "if let detail = success.detailResource",
+] as const;
+const REMOTE_GATEWAY_SUCCESS_DYNAMIC_PROJECTIONS = [
+  "Label(success.title,",
+  "Text(success.title)",
+  "if let detail = success.detail {",
+  "Text(success.detail)",
+] as const;
 const LOCALIZED_WRAPPER_CONTRACTS: Record<string, readonly string[]> = {
+  "apps/macos/Sources/OpenClaw/GeneralSettings.swift": REMOTE_GATEWAY_SUCCESS_RESOURCE_CONTRACTS,
+  "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift": [
+    "enum OnboardingTextValue: Equatable, ExpressibleByStringLiteral",
+    "case localized(LocalizedStringResource)",
+    "case verbatim(String)",
+    "var resolvedString: String",
+    "struct OnboardingErrorCard: View {\n    let title: OnboardingTextValue\n    let message: OnboardingTextValue",
+    "message: .localized(issue.statusMessageResource)",
+    "message: .verbatim(detectError.summary)",
+    "message: .verbatim(providerCatalogError)",
+    "message: .verbatim(error.summary)",
+    "message: .verbatim(manualError.summary)",
+    "OnboardingErrorDetails.copy(self.message.resolvedString)",
+    "Text(verbatim: self.text)",
+  ],
+  "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift": [
+    "self.cliStatus?.nonEmpty.map(OnboardingTextValue.verbatim)",
+    "Text(verbatim: cliStatus)",
+    ...REMOTE_GATEWAY_SUCCESS_RESOURCE_CONTRACTS,
+    "Text(issue.titleResource)",
+    "Text(issue.bodyResource)",
+    "if let footnote = issue.footnoteResource",
+  ],
+  "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift": [
+    "var titleResource: LocalizedStringResource",
+    "var bodyResource: LocalizedStringResource",
+    "var footnoteResource: LocalizedStringResource?",
+    "var statusMessageResource: LocalizedStringResource",
+    "var detailResource: LocalizedStringResource?",
+    "String(localized: self.titleResource)",
+    "String(localized: self.bodyResource)",
+    "self.footnoteResource.map { String(localized: $0) }",
+    'LocalizedStringResource(\n                "This gateway requires an auth token.',
+    "String(localized: self.statusMessageResource)",
+    "self.detailResource.map { String(localized: $0) }",
+  ],
   "apps/macos/Sources/OpenClaw/SettingsComponents.swift": [
     "enum SettingsTextValue: ExpressibleByStringLiteral",
     "case localized(LocalizedStringKey)",
@@ -321,6 +367,33 @@ const LOCALIZED_WRAPPER_CONTRACTS: Record<string, readonly string[]> = {
   ],
 };
 const RAW_LOCALIZATION_BYPASSES: Record<string, readonly string[]> = {
+  "apps/macos/Sources/OpenClaw/GeneralSettings.swift": REMOTE_GATEWAY_SUCCESS_DYNAMIC_PROJECTIONS,
+  "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift": [
+    "struct OnboardingErrorCard: View {\n    let title: String",
+    "message: detectError.summary",
+    "message: providerCatalogError",
+    "message: error.summary",
+    "message: manualError.summary",
+    "OnboardingErrorDetails.copy(self.message)",
+    "Text(self.text)",
+  ],
+  "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift": [
+    "message: self.cliStatus ??",
+    "Text(cliStatus)",
+    ...REMOTE_GATEWAY_SUCCESS_DYNAMIC_PROJECTIONS,
+    "Text(issue.title)",
+    "Text(.init(issue.body))",
+    "if let footnote = issue.footnote {",
+    "Text(.init(footnote))",
+  ],
+  "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift": [
+    "var title: String {\n        switch self",
+    "var body: String {\n        switch self",
+    "var footnote: String? {\n        switch self",
+    "var statusMessage: String {\n        switch self {",
+    "var title: String {\n        switch self.authSource",
+    "var detail: String? {\n        switch self.authSource",
+  ],
   "apps/macos/Sources/OpenClaw/SettingsComponents.swift": [
     "let title: String",
     "let subtitle: String?",

--- a/test/scripts/apple-app-i18n.test.ts
+++ b/test/scripts/apple-app-i18n.test.ts
@@ -113,14 +113,22 @@ describe("Apple app i18n catalogs", () => {
     expect(keys.length).toBeGreaterThan(900);
     expect(keys).toEqual(
       expect.arrayContaining([
+        "Back to Gateway",
         "Browse ClawHub",
         "Done in %@",
         "Enable debug tools",
         "Everyday OpenClaw app behavior.",
+        "Gateway authentication required",
+        "Gateway token mismatch. Run openclaw gateway auth-token --show on the gateway host.",
         "General",
+        "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
         "Searching…",
+        "Setup code expired or already used. Scan a fresh setup code, then try again.",
         "Shelling",
         "Stopped",
+        "This gateway has token auth enabled, but no gateway.auth.token is configured on the host.",
+        "This gateway requires an auth token. Run openclaw gateway auth-token --show on the gateway host.",
+        "This gateway uses password auth. Remote onboarding on macOS cannot collect gateway passwords yet.",
         "Voice Wake requires macOS 26 or newer",
         "Waiting",
       ]),
@@ -186,6 +194,53 @@ describe("Apple app i18n catalogs", () => {
     expect(approvals).toContain("subtitle: .localized(self.model.security.policyDescription)");
     expect(approvals).toContain("subtitle: .localized(self.model.ask.policyDescription)");
     expect(voiceWake).toContain('format: String(localized: "Language %lld")');
+  });
+
+  it("keeps macOS probe labels localized and runtime failures verbatim", async () => {
+    const [aiSetup, general, pages, remoteProbe] = await Promise.all([
+      readFile("apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift", "utf8"),
+      readFile("apps/macos/Sources/OpenClaw/GeneralSettings.swift", "utf8"),
+      readFile("apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift", "utf8"),
+      readFile("apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift", "utf8"),
+    ]);
+
+    expect(aiSetup).toContain("enum OnboardingTextValue: Equatable, ExpressibleByStringLiteral");
+    expect(aiSetup).toContain("case localized(LocalizedStringResource)");
+    expect(aiSetup).toContain("message: .localized(issue.statusMessageResource)");
+    expect(aiSetup).toContain("message: .verbatim(detectError.summary)");
+    expect(aiSetup).toContain("message: .verbatim(providerCatalogError)");
+    expect(aiSetup).toContain("message: .verbatim(error.summary)");
+    expect(aiSetup).toContain("message: .verbatim(manualError.summary)");
+    expect(aiSetup).toContain("OnboardingErrorDetails.copy(self.message.resolvedString)");
+    expect(aiSetup).toContain("Text(verbatim: self.text)");
+    expect(pages).toContain("self.cliStatus?.nonEmpty.map(OnboardingTextValue.verbatim)");
+    expect(pages).toContain("Text(verbatim: cliStatus)");
+    for (const source of [general, pages]) {
+      expect(source).toContain("Text(success.titleResource)");
+      expect(source).toContain("if let detail = success.detailResource");
+      expect(source).not.toContain("Label(success.title,");
+      expect(source).not.toContain("Text(success.title)");
+      expect(source).not.toContain("if let detail = success.detail {");
+      expect(source).not.toContain("Text(success.detail)");
+    }
+    expect(pages).toContain("Text(issue.titleResource)");
+    expect(pages).toContain("Text(issue.bodyResource)");
+    expect(pages).toContain("if let footnote = issue.footnoteResource");
+    expect(pages).not.toContain("Text(issue.title)");
+    expect(pages).not.toContain("Text(.init(issue.body))");
+    expect(remoteProbe).toContain("var titleResource: LocalizedStringResource");
+    expect(remoteProbe).toContain("var bodyResource: LocalizedStringResource");
+    expect(remoteProbe).toContain("var footnoteResource: LocalizedStringResource?");
+    expect(remoteProbe).toContain("var statusMessageResource: LocalizedStringResource");
+    expect(remoteProbe).toContain("var detailResource: LocalizedStringResource?");
+    expect(remoteProbe).toContain("String(localized: self.titleResource)");
+    expect(remoteProbe).toContain("String(localized: self.bodyResource)");
+    expect(remoteProbe).toContain("self.footnoteResource.map { String(localized: $0) }");
+    expect(remoteProbe).toContain(
+      'LocalizedStringResource(\n                "This gateway requires an auth token.',
+    );
+    expect(remoteProbe).toContain("String(localized: self.statusMessageResource)");
+    expect(remoteProbe).toContain("self.detailResource.map { String(localized: $0) }");
   });
 
   it("selects duplicate-source translations deterministically while preserving shipped translations", () => {


### PR DESCRIPTION
Related: #120793

## What Problem This Solves

Fixes an issue where macOS users in non-English locales could still see onboarding, authentication, and remote Gateway success labels in English because static app-owned copy was converted to `String` before SwiftUI rendered it.

## Why This Change Was Made

The presentation owner now preserves static copy as `LocalizedStringResource` through the UI boundary and renders those resources directly. Resolved `String` projections remain only for non-UI status/control consumers and copy assertions.

The source repair covers:

- the onboarding error-card localized-versus-verbatim boundary;
- remote authentication title, body, footnote, and status resources;
- remote probe success title and detail resources;
- direct resource rendering in onboarding and General Settings;
- the canonical Apple i18n guard and focused negative regression for dynamic-string UI projections;
- the deterministic native source inventory.

This is the separate source repair requested by the review on #120793. It does not reopen that closed generated-locale PR. Native locale refresh automation owns catalog and locale regeneration after this source change lands.

LOC by ownership:

- Production Swift: `+192/-88` (net `+104`)
- Tooling guard: `+73/-0` (net `+73`)
- Tests: `+56/-1` (net `+55`)
- Source inventory: `+197/-149` (net `+48`)

No generated locale catalogs or generated locale translation files are included.

## User Impact

Static macOS onboarding and remote Gateway status copy now participates in native localization lookup, while runtime diagnostics remain verbatim and copyable.

There is no layout or styling change, so screenshots are not applicable.

## Evidence

- Independently reviewed and approved exact head: `31325796d4ca1dd4e8081aa72f3342452c8583e8`
- Commit signature verified; exactly one `Punchcard-Session` trailer
- General Settings status tests: 4 passed
- Remote onboarding/auth tests: 10 passed
- Apple i18n regression tests: 18 passed
- Native inventory verification: 5,380 entries; macOS source keys: 1,256
- Exact-main merge proof against `54ae94530cc8bd0dbe3b6fd6adbd9b784f26a991`: conflict-free tree `b781c0fffba5a9f4d373ceef44e14d8791abeb82`
- Merged inventory SHA-256: `7983dc19acb30f4084ec428887e678f3b851be0407361f9a0d29389da8dfd3fd`
- SwiftFormat, SwiftLint, Oxfmt, type-aware Oxlint, and `git diff --check`: passed
- Autoreview: no actionable findings
- AI-assisted implementation; exact head received independent review before publication

Punchcard-Session: amber-workshop-workshop-36


Punchcard-Receipt: pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaSkswNkRKTlo4RUE0OVlGQ1pIOEJTRwB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pGWE42TVBWRDRBMzM2VlZDWVdHUDQ1AGFtYmVyLXdvcmtzaG9wLXdvcmtzaG9wLTM2AG9wZW5jbGF3L29wZW5jbGF3AAAxMjA5NDcANDI5ZmYxMGUxYjM2ODNkYjMyZTE4MTVlYjRjMWY5MjExZGNiNTQ0Njk3MWJjNjY4MTU4NjdkZjhlMzA4ODZhNwBzaWduaW5nLXYxAHBXZVI1SjNNTDl2S2tzNHo4a1EzNmhmZmJNSDB1RlZqc2hCeHkxenNrX1p6NFkyRHdzeW5oaW5ISlRnNUp2dTBnQ2VzQ25jcXlTMEFsakNsYUc2SEFRADIwMjYtMDgtMDlUMDY6MjI6NDIuNjEwWgA.hcGR4TEfynr353JjM5afSfHdg9bFDy7YTZsekFSZTbYhOU_5_gJa9KajgaZixdPEoC6fax1_wZAtX5aEu57pCQ
