### PR TITLE
fix(release): accept repeated PR title suffixes

### DIFF
--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -684,7 +684,7 @@ export function contributionRecordTarget(section) {
 }
 
 export function pullRequestTitleFromCommitSubject(subject, number) {
-  const match = subject.match(/^(?<title>\S(?:.*\S)?) \(#(?<number>[1-9]\d*)\)$/u);
+  const match = subject.match(/^(?<title>\S(?:.*?\S)?)(?<pr> \(#(?<number>[1-9]\d*)\))\k<pr>*$/u);
   return match?.groups?.number === String(number) ? match.groups.title : undefined;
 }
 

--- a/test/scripts/verify-release-notes.test.ts
+++ b/test/scripts/verify-release-notes.test.ts
@@ -59,8 +59,12 @@ describe("release-note verification", () => {
 
   it("accepts only canonical commit PR suffixes", () => {
     expect(pullRequestTitleFromCommitSubject("Fix status (#102147)", 102147)).toBe("Fix status");
+    expect(pullRequestTitleFromCommitSubject("Fix status (#102147) (#102147)", 102147)).toBe(
+      "Fix status",
+    );
     expect(pullRequestTitleFromCommitSubject("Fix status(#102147)", 102147)).toBeUndefined();
     expect(pullRequestTitleFromCommitSubject("Fix status (#0102147)", 102147)).toBeUndefined();
+    expect(pullRequestTitleFromCommitSubject("Fix status (#0)", 0)).toBeUndefined();
     expect(pullRequestTitleFromCommitSubject(" Fix status (#102147)", 102147)).toBeUndefined();
     expect(pullRequestTitleFromCommitSubject("Fix status (#102147) ", 102147)).toBeUndefined();
     expect(pullRequestTitleFromCommitSubject("Fix status (#102148)", 102147)).toBeUndefined();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release-note verification preserved a duplicated terminal PR suffix in a recovered commit title when the same canonical `(#PR)` suffix appeared more than once.

## Why This Change Was Made

The verifier now captures the complete canonical suffix and accepts exact repetitions of that suffix. Existing positive-number, spacing, and target-number validation remains unchanged.

## User Impact

Release maintainers can verify contribution records for squash commits with repeated terminal PR suffixes without manually repairing the recovered title.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/verify-release-notes.test.ts` (32/32)
- `pnpm format .agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs test/scripts/verify-release-notes.test.ts`
- `git diff --check`
- independent exact-diff review: no findings
- production delta: `+1/-1`; tests: `+4/-0`
