### PR TITLE
fix(ci): full heartbeat admission proof no longer times out

### DIFF
--- a/src/infra/heartbeat-runner.reply-admission.test.ts
+++ b/src/infra/heartbeat-runner.reply-admission.test.ts
@@ -35,6 +35,9 @@ const heartbeatDeps = {
   getReplyFromConfig,
 } satisfies HeartbeatDeps;
 
+// This case cold-loads the full reply stack to verify production admission and registry cleanup.
+const FULL_REPLY_ADMISSION_TEST_TIMEOUT_MS = 240_000;
+
 function modelPrompt(index: number): string {
   const prompt = runEmbeddedAgentMock.mock.calls[index]?.[0]?.prompt;
   if (typeof prompt !== "string") {
@@ -64,81 +67,85 @@ describe("heartbeat reply admission", () => {
     vi.unstubAllEnvs();
   });
 
-  it("keeps global events isolated through production reply admission", async () => {
-    await withTempHeartbeatSandbox(async ({ tmpDir }) => {
-      const storeTemplate = path.join(tmpDir, "agents", "{agentId}", "sessions", "sessions.json");
-      const cfg = markCompleteReplyConfig(
-        {
-          agents: {
-            defaults: {
-              model: "anthropic/claude-opus-4-6",
-              workspace: tmpDir,
+  it(
+    "keeps global events isolated through production reply admission",
+    async () => {
+      await withTempHeartbeatSandbox(async ({ tmpDir }) => {
+        const storeTemplate = path.join(tmpDir, "agents", "{agentId}", "sessions", "sessions.json");
+        const cfg = markCompleteReplyConfig(
+          {
+            agents: {
+              defaults: {
+                model: "anthropic/claude-opus-4-6",
+                workspace: tmpDir,
+              },
+              entries: { main: { default: true }, alpha: {}, beta: {} },
             },
-            entries: { main: { default: true }, alpha: {}, beta: {} },
-          },
-          models: {
-            providers: {
-              anthropic: {
-                baseUrl: "https://api.anthropic.test",
-                apiKey: "test-key",
-                models: [
-                  {
-                    id: "claude-opus-4-6",
-                    name: "Claude Opus 4.6",
-                    reasoning: true,
-                    input: ["text"],
-                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                    contextWindow: 200_000,
-                    maxTokens: 8192,
-                  },
-                ],
+            models: {
+              providers: {
+                anthropic: {
+                  baseUrl: "https://api.anthropic.test",
+                  apiKey: "test-key",
+                  models: [
+                    {
+                      id: "claude-opus-4-6",
+                      name: "Claude Opus 4.6",
+                      reasoning: true,
+                      input: ["text"],
+                      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                      contextWindow: 200_000,
+                      maxTokens: 8192,
+                    },
+                  ],
+                },
               },
             },
+            session: { scope: "global", store: storeTemplate },
           },
-          session: { scope: "global", store: storeTemplate },
-        },
-        { runtimeMode: "full" },
-      ) as OpenClawConfig;
-      await seedSessionStore(resolveStorePath(storeTemplate, { agentId: "alpha" }), "global", {});
-      await seedSessionStore(resolveStorePath(storeTemplate, { agentId: "beta" }), "global", {});
-      enqueueSystemEvent(
-        "Alpha hook finished",
-        withSystemEventOwner({ sessionKey: "global" }, "alpha"),
-      );
-      enqueueSystemEvent(
-        "Beta hook finished",
-        withSystemEventOwner({ sessionKey: "global" }, "beta"),
-      );
+          { runtimeMode: "full" },
+        ) as OpenClawConfig;
+        await seedSessionStore(resolveStorePath(storeTemplate, { agentId: "alpha" }), "global", {});
+        await seedSessionStore(resolveStorePath(storeTemplate, { agentId: "beta" }), "global", {});
+        enqueueSystemEvent(
+          "Alpha hook finished",
+          withSystemEventOwner({ sessionKey: "global" }, "alpha"),
+        );
+        enqueueSystemEvent(
+          "Beta hook finished",
+          withSystemEventOwner({ sessionKey: "global" }, "beta"),
+        );
 
-      const alphaResult = await runHeartbeatOnce({
-        cfg,
-        agentId: "alpha",
-        source: "hook",
-        intent: "immediate",
-        reason: "hook:wake",
-        deps: heartbeatDeps,
+        const alphaResult = await runHeartbeatOnce({
+          cfg,
+          agentId: "alpha",
+          source: "hook",
+          intent: "immediate",
+          reason: "hook:wake",
+          deps: heartbeatDeps,
+        });
+
+        expect(alphaResult.status).toBe("ran");
+        expect(modelPrompt(0)).toContain("Alpha hook finished");
+        expect(modelPrompt(0)).not.toContain("Beta hook finished");
+        expect(peekSystemEventEntries("global").map((event) => event.text)).toEqual([
+          "Beta hook finished",
+        ]);
+
+        const betaResult = await runHeartbeatOnce({
+          cfg,
+          agentId: "beta",
+          source: "hook",
+          intent: "immediate",
+          reason: "hook:wake",
+          deps: heartbeatDeps,
+        });
+
+        expect(betaResult.status).toBe("ran");
+        expect(modelPrompt(1)).toContain("Beta hook finished");
+        expect(modelPrompt(1)).not.toContain("Alpha hook finished");
+        expect(peekSystemEventEntries("global")).toEqual([]);
       });
-
-      expect(alphaResult.status).toBe("ran");
-      expect(modelPrompt(0)).toContain("Alpha hook finished");
-      expect(modelPrompt(0)).not.toContain("Beta hook finished");
-      expect(peekSystemEventEntries("global").map((event) => event.text)).toEqual([
-        "Beta hook finished",
-      ]);
-
-      const betaResult = await runHeartbeatOnce({
-        cfg,
-        agentId: "beta",
-        source: "hook",
-        intent: "immediate",
-        reason: "hook:wake",
-        deps: heartbeatDeps,
-      });
-
-      expect(betaResult.status).toBe("ran");
-      expect(modelPrompt(1)).toContain("Beta hook finished");
-      expect(modelPrompt(1)).not.toContain("Alpha hook finished");
-      expect(peekSystemEventEntries("global")).toEqual([]);
-    });
-  });
+    },
+    FULL_REPLY_ADMISSION_TEST_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the full-runtime heartbeat reply-admission regression could hit Vitest's generic 120-second case ceiling while it was still actively progressing through the production reply stack. This failed otherwise healthy Node CI and blocked unrelated pull requests.

## Why This Change Was Made

The test intentionally keeps the real heartbeat, `getReplyFromConfig`, reply-agent, admission, and registry-cleanup wiring. It now uses a named 240-second budget scoped only to this one cold full-stack case; no product timeout or runtime behavior changes.

The regression was introduced with the test in #119817 (authored by @licheer-zte, merged by @sallyom). Replacing the runtime seam with a faster mock would weaken the integration contract, so the production path remains unchanged.

## User Impact

No user-visible product change. Maintainers get reliable CI coverage for global heartbeat event ownership without false timeouts on cold or loaded runners.

## Evidence

- Reproduced on current-main lineage: the unchanged case ran at roughly 108–119 seconds against a 120-second default and timed out under contention.
- After: unchanged semantic case passed repeatedly under the scoped budget:
  - 102.58-second test body; 122.01-second Vitest total; 134.73-second wrapper total.
  - 100.43-second test body; 113.35-second Vitest total; 118.87-second wrapper total after rebase.
  - 123.63-second test body; 133.53-second Vitest total; 137.98-second wrapper total after inlining the per-case timeout, directly proving the old 120-second ceiling was insufficient.
- `git diff --check` passed.
- `oxfmt --check src/infra/heartbeat-runner.reply-admission.test.ts` passed.
- Codex autoreview: clean, no accepted/actionable findings (0.99).
- Production LOC: +0/-0. Tests: +76/-69; 68 additions/deletions are formatter-required reindentation from Vitest's direct three-argument per-case form.

Local `check:changed` guards all passed through the core-test typecheck. The typecheck then hit two unrelated stale-worktree dependency errors (`packages/terminal-core/src/ansi.ts` arity and missing `@openclaw/session-url-contract/parse`); exact-head CI uses a fresh dependency snapshot and is the authoritative type gate.
