### PR TITLE
fix(release): mount trusted survivor assertions

### DIFF
--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -181,6 +181,7 @@ if [ "${OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE:-0}" = "1" ]; then
     -v "$ARTIFACT_DIR:/tmp/openclaw-upgrade-survivor-artifacts" \
     -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/clawhub-fixture-server.cjs:/tmp/openclaw-clawhub-fixture-server.cjs:ro" \
     -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/run.sh:/tmp/openclaw-upgrade-survivor-run.sh:ro" \
+    -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/assertions.mjs:/app/scripts/e2e/lib/upgrade-survivor/assertions.mjs:ro" \
     "${PREPUBLISH_PLUGIN_REGISTRY_ARGS[@]}" \
     "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
     "${DOCKER_RUN_USER_ARGS[@]}" \

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2598,7 +2598,7 @@ docker_e2e_docker_run_cmd run demo
     }
   });
 
-  it("kills timed Docker scenario runners after the grace period", () => {
+  it("pins the trusted upgrade survivor harness and kills timed Docker runners", () => {
     const multiNode = readFileSync(MULTI_NODE_UPDATE_DOCKER_E2E_PATH, "utf8");
     const upgradeSurvivor = readFileSync(UPGRADE_SURVIVOR_DOCKER_E2E_PATH, "utf8");
 
@@ -2609,6 +2609,9 @@ docker_e2e_docker_run_cmd run demo
     expect(upgradeSurvivor).toContain('DOCKER_E2E_HARNESS_ROOT_DIR="$HARNESS_ROOT_DIR"');
     expect(upgradeSurvivor).toContain(
       '-v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/run.sh:/tmp/openclaw-upgrade-survivor-run.sh:ro"',
+    );
+    expect(upgradeSurvivor).toContain(
+      '-v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/assertions.mjs:/app/scripts/e2e/lib/upgrade-survivor/assertions.mjs:ro"',
     );
     expect(upgradeSurvivor).toContain(
       'timeout --kill-after=30s "$DOCKER_RUN_TIMEOUT" bash /tmp/openclaw-upgrade-survivor-run.sh',


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where published-baseline upgrade validation could execute a stale or missing candidate-image assertions helper even though the release runner itself was pinned to trusted harness code.

## Why This Change Was Made

Mount the trusted `assertions.mjs` read-only at the exact `/app` path used by the pinned upgrade-survivor runner. The existing Docker helper contract test now covers both trusted harness mounts.

## User Impact

No direct product behavior changes. Release package acceptance now evaluates upgrades with the intended assertions implementation instead of candidate-image drift.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts` (`189/189`)
- Blacksmith Testbox `node scripts/check-changed.mjs -- scripts/e2e/upgrade-survivor-docker.sh test/scripts/docker-build-helper.test.ts`
  - lease `tbx_01kzjk7b6qd720h79f6r41jvyh`
  - https://github.com/openclaw/openclaw/actions/runs/31298890310
- Autoreview: clean, no accepted/actionable findings

AI-assisted: yes
