### PR TITLE
refactor(agents): simplify prepared registry dispatch

### DIFF
--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -193,12 +193,7 @@ export async function prepareWorkspaceBuildGroup(
   const runtimePluginMs = performance.now() - runtimePluginStartedAt;
   return await withPluginRuntimeRegistryScope(runtimePluginRegistry, async () => {
     const pluginMetadataStartedAt = performance.now();
-    const pluginMetadataSnapshot = prepareOwnedPluginLoadContext(
-      input,
-      env,
-      runtimePluginRegistry,
-      inboundPluginRegistry,
-    );
+    const pluginMetadataSnapshot = prepareOwnedPluginLoadContext(input, env, runtimePluginRegistry);
     const pluginMetadataMs = performance.now() - pluginMetadataStartedAt;
     const matchesStaticModelId = createStaticModelIdMatcher({
       manifestPlugins: pluginMetadataSnapshot.plugins,

--- a/src/agents/prepared-model-runtime.inbound-registry.test.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.test.ts
@@ -1,6 +1,7 @@
 import "./prepared-model-runtime.test-harness.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { createDeferred } from "../test-utils/deferred.js";
 import {
   acquireAgentRunPreparedModelRuntime,
   getPreparedModelRuntimeSnapshot,
@@ -50,13 +51,8 @@ describe("prepared model runtime inbound registry", () => {
       firstRegistry,
     );
 
-    let finishReplacement!: () => void;
-    mocks.prepareStaticCatalog.mockImplementationOnce(
-      async () =>
-        await new Promise<{ entries: [] }>((resolve) => {
-          finishReplacement = () => resolve({ entries: [] });
-        }),
-    );
+    const replacementCatalog = createDeferred<{ entries: [] }>();
+    mocks.prepareStaticCatalog.mockImplementationOnce(async () => await replacementCatalog.promise);
     const refresh = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
       catalogMode: "static",
       allowGatewaySubagentBinding: true,
@@ -75,7 +71,7 @@ describe("prepared model runtime inbound registry", () => {
     await Promise.resolve();
     expect(resolvedRegistry).toBeUndefined();
 
-    finishReplacement();
+    replacementCatalog.resolve({ entries: [] });
     await expect(refresh).resolves.toBeUndefined();
     await expect(read).resolves.toBe(replacementRegistry);
     expect(replacementRegistry).not.toBe(firstRegistry);
@@ -127,17 +123,15 @@ describe("prepared model runtime inbound registry", () => {
     expect(dynamicLease.snapshot.inboundPluginRegistry).toBeUndefined();
     dynamicLease.release();
     const callsBeforeAuthRefresh = mocks.loadAgentRuntimePluginRegistryHandle.mock.calls.length;
-    let unregister = () => {};
-    const published = new Promise<void>((resolve) => {
-      unregister = registerPreparedModelRuntimePublicationListener((event) => {
-        if (event.phase === "published") {
-          resolve();
-        }
-      });
+    const published = createDeferred();
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      if (event.phase === "published") {
+        published.resolve();
+      }
     });
 
     mocks.mutationListener?.({ affectsInheritedStores: true });
-    await published;
+    await published.promise;
     unregister();
 
     const authRefreshCalls =

--- a/src/agents/prepared-model-runtime.owner-selection.test.ts
+++ b/src/agents/prepared-model-runtime.owner-selection.test.ts
@@ -12,7 +12,6 @@ import {
   publishPreparedModelRuntimeSnapshot,
   refreshPreparedModelRuntimeSnapshots,
 } from "./prepared-model-runtime.js";
-import { getPreparedPluginRuntimeLoadContext } from "./prepared-model-runtime.plugin-context.js";
 import {
   getPreparedModelRuntimeMocks,
   getPreparedModelRuntimeTestApi,
@@ -167,10 +166,6 @@ describe("prepared model runtime owner selection", () => {
     });
     expect(configured?.inboundPluginRegistry).toBeDefined();
     expect(configured?.pluginRegistry).not.toBe(configured?.inboundPluginRegistry);
-    expect(getPreparedPluginRuntimeLoadContext(configured?.inboundPluginRegistry)).toMatchObject({
-      rawConfig: config,
-      workspaceDir: "/tmp/unused-workspace",
-    });
     expect(mocks.prepareStaticCatalog).toHaveBeenCalledOnce();
     expect(mocks.discoverModels).toHaveBeenCalledOnce();
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();

--- a/src/agents/prepared-model-runtime.plugin-context.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.ts
@@ -58,19 +58,13 @@ export function prepareOwnedPluginLoadContext(
   input: PreparedModelRuntimeInput,
   env: NodeJS.ProcessEnv,
   registry: PluginRegistry | undefined,
-  additionalRegistry?: PluginRegistry,
 ): PluginMetadataSnapshot {
   const metadataSnapshot = resolvePluginMetadataSnapshot({
     config: input.config,
     env,
     ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
   });
-  const context = preparePluginLoadContext(input, env, registry, metadataSnapshot);
-  if (additionalRegistry && additionalRegistry !== registry) {
-    // Generic inbound and model-selected registries keep distinct activation scopes while sharing
-    // the exact lifecycle-owned config, metadata, and install generation.
-    setPreparedPluginRuntimeLoadContext(additionalRegistry, context);
-  }
+  preparePluginLoadContext(input, env, registry, metadataSnapshot);
   return metadataSnapshot;
 }
 

--- a/src/auto-reply/reply/dispatch-from-config.base.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.base.test-utils.ts
@@ -119,52 +119,29 @@ describe("dispatchReplyFromConfig", () => {
     );
   });
 
-  it("uses zero per-turn registry loads after Gateway publication and preserves cold fallback", async () => {
+  it("uses zero fallback registry loads for a published Gateway dispatch", async () => {
     setNoAbort();
     const cfg = emptyConfig;
     const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
-    for (let index = 0; index < 3; index += 1) {
-      await dispatchReplyFromConfig({
-        ctx: buildTestCtx({
-          Provider: "whatsapp",
-          SessionKey: "agent:main:main",
-          MessageSid: `cold-${index}`,
-        }),
-        cfg,
-        dispatcher: createDispatcher(),
-        replyResolver,
-      });
-    }
-    expect(runtimePluginMocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(3);
-
     const preparedRegistry = createTestRegistry([]);
     const preparedRuntime = await import("../../agents/prepared-model-runtime.js");
     const preparedLookup = vi
       .spyOn(preparedRuntime, "loadPublishedGatewayInboundPluginRegistry")
       .mockResolvedValue(preparedRegistry);
-    runtimePluginMocks.loadAgentRuntimePluginRegistryHandle.mockClear();
     try {
-      for (let index = 0; index < 3; index += 1) {
-        await dispatchReplyFromConfig({
-          ctx: buildTestCtx({
-            Provider: "whatsapp",
-            SessionKey: "agent:main:main",
-            MessageSid: `prepared-${index}`,
-          }),
-          cfg,
-          dispatcher: createDispatcher(),
-          replyResolver,
-          usePublishedModelRuntime: true,
-        });
-      }
-      expect(preparedLookup).toHaveBeenCalledTimes(3);
-      expect(
-        preparedLookup.mock.calls.every(
-          ([input]) =>
-            Object.keys(input as object).length === 1 &&
-            (input as { agentId?: string }).agentId === "main",
-        ),
-      ).toBe(true);
+      await dispatchReplyFromConfig({
+        ctx: buildTestCtx({
+          Provider: "whatsapp",
+          SessionKey: "agent:main:main",
+          MessageSid: "prepared",
+        }),
+        cfg,
+        dispatcher: createDispatcher(),
+        replyResolver,
+        usePublishedModelRuntime: true,
+      });
+      expect(preparedLookup).toHaveBeenCalledOnce();
+      expect(preparedLookup).toHaveBeenCalledWith({ agentId: "main" });
       expect(runtimePluginMocks.loadAgentRuntimePluginRegistryHandle).not.toHaveBeenCalled();
     } finally {
       preparedLookup.mockRestore();

--- a/src/auto-reply/reply/dispatch-from-config.gather.ts
+++ b/src/auto-reply/reply/dispatch-from-config.gather.ts
@@ -22,7 +22,6 @@ import {
 import { createDiagnosticMessageLifecycle } from "../../logging/message-lifecycle.js";
 import { stripLegacyMediaContextFields } from "../../media/media-facts.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { normalizeTtsAutoMode } from "../../tts/tts-config.js";
 import type { FinalizedRuntimeMsgContext as FinalizedMsgContext } from "../templating.js";
 import { normalizeVerboseLevel } from "../thinking.js";
@@ -383,139 +382,135 @@ export async function gatherDispatchRequest(
         allowGatewaySubagentBinding: true,
       });
     }));
-  return await withPluginRuntimeRegistryScope(pluginRegistry, async () => {
-    const hookRunner = getGlobalHookRunner();
-    // Extract message context for hooks (plugin and internal)
-    const timestamp =
-      typeof ctx.Timestamp === "number" && Number.isFinite(ctx.Timestamp)
-        ? ctx.Timestamp
-        : undefined;
-    const messageIdForHook =
-      ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
-    const hookCtx = { ...ctx };
-    const buildHookState = (sourceCtx: FinalizedMsgContext) => {
-      const nextHookContext = deriveInboundMessageHookContext(sourceCtx, {
-        messageId: messageIdForHook,
-      });
-      const inboundClaim = toPluginInboundClaimPair(nextHookContext, {
-        commandAuthorized:
-          typeof ctx.CommandAuthorized === "boolean" ? ctx.CommandAuthorized : undefined,
-        wasMentioned: typeof ctx.WasMentioned === "boolean" ? ctx.WasMentioned : undefined,
-      });
-      return {
-        hookContext: nextHookContext,
-        inboundClaimContext: inboundClaim.context,
-        inboundClaimEvent: inboundClaim.event,
-      };
-    };
-    const hookState = buildHookState(hookCtx);
-    const { isGroup, groupId } = hookState.hookContext;
-    let hookMediaPrepared = false;
-    let hookMediaMetadataStaged = false;
-    const prepareHookMediaMetadata = async () => {
-      if (hookMediaPrepared) {
-        return;
-      }
-      hookMediaPrepared = true;
-      // Plugin hooks may run in a different Codex cwd from core dispatch, so
-      // only actual hook/plugin-claim consumers get remote-cache media paths.
-      // Keep ctx unstaged for the normal get-reply single-stage path.
-      const staged = await traceReplyPhase("reply.stage_remote_media_for_dispatch", () =>
-        stageRemoteInboundMediaIfNeeded({
-          ctx: hookCtx,
-          cfg,
-          sessionKey: acpDispatchSessionKey,
-          workspaceDir,
-          remoteMediaMode: "cache",
-        }),
-      );
-      if (staged) {
-        hookMediaMetadataStaged = true;
-        Object.assign(hookState, buildHookState(hookCtx));
-      }
-    };
-    const buildMessageReceivedHookContext = () => {
-      const mediaRemoteHost = normalizeOptionalString(ctx.MediaRemoteHost);
-      const { hookContext } = hookState;
-      const hasUnstagedRemoteMediaMetadata = Boolean(hookContext.media?.length);
-      if (hookMediaMetadataStaged || !mediaRemoteHost || !hasUnstagedRemoteMediaMetadata) {
-        return hookContext;
-      }
-      const messageReceivedCtx = { ...hookCtx };
-      // message_received hooks run before normal get-reply staging, so remote
-      // host paths are not safe as live media. Keep originals as debug metadata.
-      stripLegacyMediaContextFields(messageReceivedCtx);
-      delete messageReceivedCtx.media;
-      return {
-        ...buildHookState(messageReceivedCtx).hookContext,
-        mediaRemoteHost,
-        mediaStagingPending: true,
-        originalMedia: hookContext.media?.map((entry) => ({ ...entry })),
-        originalMediaPath: hookContext.mediaPath,
-        originalMediaUrl: hookContext.mediaUrl,
-        originalMediaType: hookContext.mediaType,
-        originalMediaPaths: hookContext.mediaPaths,
-        originalMediaUrls: hookContext.mediaUrls,
-        originalMediaTypes: hookContext.mediaTypes,
-      };
-    };
-    const nextState = extendPreparedDispatchState(state, {
-      ctx,
-      cfg,
-      dispatcher,
-      sessionKey,
-      traceReplyPhase,
-      recordProcessed,
-      recordAgentDispatchStarted,
-      recordAgentDispatchCompleted,
-      markProcessing,
-      markIdle,
-      markInboundDedupeReplayUnsafe,
-      acpDispatchSessionKey,
-      markProgress,
-      sessionStoreEntry,
-      notePreparedSession,
-      resolvePreparedTranscriptBinding,
-      sessionAgentId,
-      shouldEmitVerboseProgress,
-      shouldEmitFullVerboseProgress,
-      replyRoute,
-      routeReplyThreadId,
-      inboundAudio,
-      sessionTtsAuto,
-      workspaceDir,
-      pluginRegistry,
-      replyOperationRunState,
-      completeDispatchReplyOperation,
-      dispatchHookDispatcher,
-      ensureDispatchReplyOperation,
-      failDispatchReplyOperation,
-      getDispatchAbortOperation,
-      getDispatchAbortSignal,
-      getDispatchReplyOperation,
-      getObservedReplyDelivery,
-      getPreDispatchAbortSignal,
-      getReplyOptions,
-      isDispatchOperationAborted,
-      isPreDispatchOperationAborted,
-      markObservedReplyDelivery,
-      releasePreDispatchLifecycleAdmission,
-      runWithDispatchLifecycleAdmission,
-      throwIfDispatchOperationAborted,
-      trackDispatchLifecycleWork,
-      turnLedger,
-      maybeApplyTtsWithFinalizationLease,
-      hookRunner,
-      timestamp,
-      messageIdForHook,
-      isGroup,
-      groupId,
-      hookState,
-      prepareHookMediaMetadata,
-      buildMessageReceivedHookContext,
+  const hookRunner = getGlobalHookRunner();
+  // Extract message context for hooks (plugin and internal)
+  const timestamp =
+    typeof ctx.Timestamp === "number" && Number.isFinite(ctx.Timestamp) ? ctx.Timestamp : undefined;
+  const messageIdForHook =
+    ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
+  const hookCtx = { ...ctx };
+  const buildHookState = (sourceCtx: FinalizedMsgContext) => {
+    const nextHookContext = deriveInboundMessageHookContext(sourceCtx, {
+      messageId: messageIdForHook,
     });
-    return { status: "ready" as const, state: nextState };
+    const inboundClaim = toPluginInboundClaimPair(nextHookContext, {
+      commandAuthorized:
+        typeof ctx.CommandAuthorized === "boolean" ? ctx.CommandAuthorized : undefined,
+      wasMentioned: typeof ctx.WasMentioned === "boolean" ? ctx.WasMentioned : undefined,
+    });
+    return {
+      hookContext: nextHookContext,
+      inboundClaimContext: inboundClaim.context,
+      inboundClaimEvent: inboundClaim.event,
+    };
+  };
+  const hookState = buildHookState(hookCtx);
+  const { isGroup, groupId } = hookState.hookContext;
+  let hookMediaPrepared = false;
+  let hookMediaMetadataStaged = false;
+  const prepareHookMediaMetadata = async () => {
+    if (hookMediaPrepared) {
+      return;
+    }
+    hookMediaPrepared = true;
+    // Plugin hooks may run in a different Codex cwd from core dispatch, so
+    // only actual hook/plugin-claim consumers get remote-cache media paths.
+    // Keep ctx unstaged for the normal get-reply single-stage path.
+    const staged = await traceReplyPhase("reply.stage_remote_media_for_dispatch", () =>
+      stageRemoteInboundMediaIfNeeded({
+        ctx: hookCtx,
+        cfg,
+        sessionKey: acpDispatchSessionKey,
+        workspaceDir,
+        remoteMediaMode: "cache",
+      }),
+    );
+    if (staged) {
+      hookMediaMetadataStaged = true;
+      Object.assign(hookState, buildHookState(hookCtx));
+    }
+  };
+  const buildMessageReceivedHookContext = () => {
+    const mediaRemoteHost = normalizeOptionalString(ctx.MediaRemoteHost);
+    const { hookContext } = hookState;
+    const hasUnstagedRemoteMediaMetadata = Boolean(hookContext.media?.length);
+    if (hookMediaMetadataStaged || !mediaRemoteHost || !hasUnstagedRemoteMediaMetadata) {
+      return hookContext;
+    }
+    const messageReceivedCtx = { ...hookCtx };
+    // message_received hooks run before normal get-reply staging, so remote
+    // host paths are not safe as live media. Keep originals as debug metadata.
+    stripLegacyMediaContextFields(messageReceivedCtx);
+    delete messageReceivedCtx.media;
+    return {
+      ...buildHookState(messageReceivedCtx).hookContext,
+      mediaRemoteHost,
+      mediaStagingPending: true,
+      originalMedia: hookContext.media?.map((entry) => ({ ...entry })),
+      originalMediaPath: hookContext.mediaPath,
+      originalMediaUrl: hookContext.mediaUrl,
+      originalMediaType: hookContext.mediaType,
+      originalMediaPaths: hookContext.mediaPaths,
+      originalMediaUrls: hookContext.mediaUrls,
+      originalMediaTypes: hookContext.mediaTypes,
+    };
+  };
+  const nextState = extendPreparedDispatchState(state, {
+    ctx,
+    cfg,
+    dispatcher,
+    sessionKey,
+    traceReplyPhase,
+    recordProcessed,
+    recordAgentDispatchStarted,
+    recordAgentDispatchCompleted,
+    markProcessing,
+    markIdle,
+    markInboundDedupeReplayUnsafe,
+    acpDispatchSessionKey,
+    markProgress,
+    sessionStoreEntry,
+    notePreparedSession,
+    resolvePreparedTranscriptBinding,
+    sessionAgentId,
+    shouldEmitVerboseProgress,
+    shouldEmitFullVerboseProgress,
+    replyRoute,
+    routeReplyThreadId,
+    inboundAudio,
+    sessionTtsAuto,
+    workspaceDir,
+    pluginRegistry,
+    replyOperationRunState,
+    completeDispatchReplyOperation,
+    dispatchHookDispatcher,
+    ensureDispatchReplyOperation,
+    failDispatchReplyOperation,
+    getDispatchAbortOperation,
+    getDispatchAbortSignal,
+    getDispatchReplyOperation,
+    getObservedReplyDelivery,
+    getPreDispatchAbortSignal,
+    getReplyOptions,
+    isDispatchOperationAborted,
+    isPreDispatchOperationAborted,
+    markObservedReplyDelivery,
+    releasePreDispatchLifecycleAdmission,
+    runWithDispatchLifecycleAdmission,
+    throwIfDispatchOperationAborted,
+    trackDispatchLifecycleWork,
+    turnLedger,
+    maybeApplyTtsWithFinalizationLease,
+    hookRunner,
+    timestamp,
+    messageIdForHook,
+    isGroup,
+    groupId,
+    hookState,
+    prepareHookMediaMetadata,
+    buildMessageReceivedHookContext,
   });
+  return { status: "ready" as const, state: nextState };
 }
 
 type GatherDispatchRequestResult = Awaited<ReturnType<typeof gatherDispatchRequest>>;

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -160,7 +160,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     resetPluginTtsAndThreadMocks();
   });
 
-  it("returns handled dispatch results from plugins", async () => {
+  it("runs a handled plugin reply hook in the registry scope", async () => {
     hookMocks.runner.runReplyDispatch.mockImplementation(async () => {
       expect(getPluginRuntimeGatewayRequestScope()?.pluginRegistry).toBe(
         runtimePluginMocks.pluginRegistry,


### PR DESCRIPTION
## What Problem This Solves

This is a bounded maintainer-requested follow-up to #120879. Prepared inbound dispatch retained a redundant gather-time plugin-registry scope and attached a prepared load context to the generic inbound registry even though that attachment was never read.

## Why This Change Was Made

The cleanup removes the redundant scope and write-only context attachment, then simplifies the overlapping tests and deferred setup. Atomic configured publication, generic-versus-model-specific registry separation, direct fallback, and reply-hook registry scope behavior remain owned by their existing canonical paths.

The result removes one `AsyncLocalStorage.run` from each ready inbound dispatch and one hidden context-property write when registries differ. Production changes are +128/-144 (net -16); tests are +22/-56 (net -34); the seven-file change is net -50 lines overall.

## User Impact

There is no user-visible behavior change. Published Gateway dispatch continues to perform zero fallback registry loads, while cold/direct fallback and hook scope behavior remain unchanged.

## Evidence

- 95 prepared-runtime tests passed.
- Two focused dispatch cases passed; the reply-hook registry-scope and published zero-fallback cases were also verified individually.
- Blacksmith Testbox `tbx_01kzjhqq4n9dm3nrkbj9yre0hj`: `pnpm check:changed` passed in 8m14s, including typecheck, lint, import cycles, boundaries, and format: https://github.com/openclaw/openclaw/actions/runs/31297927069
- Automated autoreview was clean with no accepted or actionable findings.
- `git diff --check` passed.

No issue is required for this bounded maintainer refactor. No changelog edit is needed. A full build was not required because module/lazy import boundaries and bundled plugin import fanout are unchanged.
