### PR TITLE
feat(zai-search): add Z.AI MCP web search provider plugin

### DIFF
--- a/extensions/zai-search/README.md
+++ b/extensions/zai-search/README.md
@@ -1,0 +1,73 @@
+# @openclaw/zai-search-plugin
+
+Official Z.AI Web Search provider plugin for Assistant.
+
+## Overview
+
+This plugin adds Z.AI as a `web_search` provider in Assistant. It uses the
+[MCP web search endpoint](https://docs.z.ai/api-reference/tools/web-search)
+at `https://api.z.ai/api/mcp/web_search_prime/mcp`, which is **included in the
+GLM Coding Plan** — no separate billing or credits required beyond the coding
+plan.
+
+### How it works
+
+The Z.AI MCP protocol requires two HTTP requests:
+
+1. **Initialize** — `POST {baseUrl}` with `method: "initialize"` → returns a
+   `Mcp-Session-Id` header
+2. **Call tool** — `POST {baseUrl}` with `method: "tools/call"`,
+   `name: "web_search_prime"`, and the session header → returns SSE-encoded
+   JSON-RPC results
+
+Each result contains `{ title, link, content, refer }`.
+
+### Supported parameters
+
+| Parameter  | Z.AI mapping                        |
+|------------|-------------------------------------|
+| `query`    | `search_query`                      |
+| `count`    | Slices result array (1–10)          |
+| `country`  | `location` (`cn` or `us`)           |
+| `freshness`| `search_recency_filter` (oneDay/Week/Month/Year) |
+
+## Install
+
+```bash
+openclaw plugins install @openclaw/zai-search-plugin
+```
+
+## Configuration
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "zai-search": {
+        "enabled": true,
+        "config": {
+          "webSearch": {
+            "apiKey": "***"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The API key is the same Z.AI key used for model inference. It also falls back
+to the `ZAI_API_KEY` / `Z_AI_API_KEY` environment variables.
+
+### Selecting Z.AI as the search provider
+
+```bash
+openclaw config set tools.web.search.provider zai-search
+```
+
+Provider-specific options live under `plugins.entries.zai-search.config.webSearch.*`.
+
+## Docs
+
+- [Z.AI Web Search API](https://docs.z.ai/api-reference/tools/web-search)
+- [Assistant Web Search](https://docs.openclaw.ai/tools/web-search)

--- a/extensions/zai-search/index.ts
+++ b/extensions/zai-search/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Z.AI Web Search plugin entry. Registers the Z.AI web-search provider which
+ * uses the MCP `web_search_prime` endpoint included in the GLM Coding Plan.
+ */
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createZaiWebSearchProvider } from "./src/zai-web-search-provider.js";
+
+/** Plugin entry for Z.AI Web Search. */
+export default definePluginEntry({
+  id: "zai-search",
+  name: "Z.AI Web Search Plugin",
+  description: "Z.AI Web Search provider using MCP web_search_prime",
+  register(api) {
+    api.registerWebSearchProvider(createZaiWebSearchProvider());
+  },
+});

--- a/extensions/zai-search/openclaw.plugin.json
+++ b/extensions/zai-search/openclaw.plugin.json
@@ -1,0 +1,54 @@
+{
+  "id": "zai-search",
+  "name": "Z.AI Web Search",
+  "description": "Assistant Z.AI Web Search provider plugin using the MCP web_search_prime endpoint.",
+  "icon": "https://cdn.simpleicons.org/zai",
+  "activation": {
+    "onStartup": false
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "zai-search",
+        "authMethods": ["api-key"],
+        "envVars": ["ZAI_API_KEY", "Z_AI_API_KEY"]
+      }
+    ]
+  },
+  "uiHints": {
+    "webSearch.apiKey": {
+      "label": "Z.AI API Key",
+      "help": "Z.AI API key (same key used for models). Falls back to ZAI_API_KEY env var.",
+      "sensitive": true,
+      "placeholder": "zai-..."
+    },
+    "webSearch.baseUrl": {
+      "label": "Z.AI MCP Base URL",
+      "help": "Override Z.AI MCP web search endpoint. Defaults to https://api.z.ai/api/mcp/web_search_prime/mcp."
+    }
+  },
+  "contracts": {
+    "webSearchProviders": ["zai-search"]
+  },
+  "configContracts": {
+    "compatibilityRuntimePaths": ["tools.web.search.apiKey"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "webSearch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "apiKey": {
+            "type": ["string", "object"]
+          },
+          "baseUrl": {
+            "type": ["string", "object"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/zai-search/package.json
+++ b/extensions/zai-search/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@openclaw/zai-search-plugin",
+  "version": "2026.8.1",
+  "description": "Assistant Z.AI Web Search provider plugin using the MCP web_search_prime endpoint.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "install": {
+      "npmSpec": "@openclaw/zai-search-plugin",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.6.9",
+      "allowInvalidConfigRecovery": true
+    },
+    "compat": {
+      "pluginApi": ">=2026.8.1"
+    },
+    "build": {
+      "openclawVersion": "2026.8.1"
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
+  }
+}

--- a/extensions/zai-search/src/zai-web-search-provider.runtime.ts
+++ b/extensions/zai-search/src/zai-web-search-provider.runtime.ts
@@ -1,0 +1,364 @@
+/**
+ * Z.AI Web Search MCP HTTP runtime. Handles:
+ *
+ * 1. Credential resolution (config → env var fallback)
+ * 2. MCP session initialization (POST initialize → capture Mcp-Session-Id)
+ * 3. Tool call (POST tools/call web_search_prime)
+ * 4. SSE response parsing with doubly-encoded JSON unwrapping
+ * 5. Result mapping, caching, and SSRF safety
+ */
+import type { SearchConfigRecord } from "openclaw/plugin-sdk/provider-web-search";
+import {
+  buildSearchCacheKey,
+  DEFAULT_SEARCH_COUNT,
+  formatCliCommand,
+  MAX_SEARCH_COUNT,
+  readCachedSearchPayload,
+  readConfiguredSecretString,
+  readPositiveIntegerParam,
+  readProviderEnvValue,
+  readStringParam,
+  resolveSearchCacheTtlMs,
+  resolveSearchCount,
+  resolveSearchTimeoutSeconds,
+  resolveSiteName,
+  wrapWebContent,
+  writeCachedSearchPayload,
+} from "openclaw/plugin-sdk/provider-web-search";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import { ZAI_CREDENTIAL_PATH } from "../web-search-shared.js";
+
+const ZAI_MCP_DEFAULT_URL = "https://api.z.ai/api/mcp/web_search_prime/mcp";
+const zaiSearchLogger = createSubsystemLogger("zai-search");
+
+//#region Config resolution
+
+function resolveZaiApiKey(
+  searchConfig?: SearchConfigRecord,
+): string | undefined {
+  return (
+    readConfiguredSecretString(searchConfig?.apiKey, ZAI_CREDENTIAL_PATH) ??
+    readProviderEnvValue(["ZAI_API_KEY", "Z_AI_API_KEY"])
+  );
+}
+
+function resolveZaiBaseUrl(searchConfig?: SearchConfigRecord): string {
+  const configured = readConfiguredSecretString(
+    searchConfig?.baseUrl,
+    "plugins.entries.zai-search.config.webSearch.baseUrl",
+  );
+  return configured?.replace(/\/+$/u, "") || ZAI_MCP_DEFAULT_URL;
+}
+
+//#endregion
+
+//#region MCP protocol helpers
+
+/** Parse SSE response text, returning the last JSON-RPC data payload. */
+function parseMcpSseResponse(text: string): Record<string, unknown> | null {
+  const lines = text.split("\n");
+  let lastData: Record<string, unknown> | null = null;
+  for (const line of lines) {
+    if (line.startsWith("data:")) {
+      const jsonStr = line.slice(5).trim();
+      try {
+        lastData = JSON.parse(jsonStr) as Record<string, unknown>;
+      } catch {
+        // skip non-JSON lines
+      }
+    }
+  }
+  return lastData;
+}
+
+type ZaiSearchResult = {
+  title?: string;
+  link?: string;
+  url?: string;
+  content?: string;
+  snippet?: string;
+  refer?: string;
+};
+
+/**
+ * Extract search results from an MCP tool-call response.
+ *
+ * The MCP `text` field contains a JSON-encoded string which itself wraps a
+ * JSON array — i.e. doubly escaped. We parse up to twice to unwrap both
+ * layers.
+ */
+function extractSearchResults(
+  mcpResult: Record<string, unknown> | null,
+): Array<{
+  title: string;
+  url: string;
+  description: string;
+  siteName: string | undefined;
+}> {
+  const result = mcpResult?.result as Record<string, unknown> | undefined;
+  const content = result?.content;
+  if (!Array.isArray(content)) return [];
+
+  for (const item of content) {
+    if (
+      typeof item !== "object" ||
+      item === null ||
+      (item as { type?: string }).type !== "text"
+    ) {
+      continue;
+    }
+    const text = (item as { text?: unknown }).text;
+    if (typeof text !== "string") continue;
+
+    let parsed: unknown = text;
+    // May need up to 2 JSON.parse calls to unwrap the double encoding.
+    for (let depth = 0; depth < 2; depth++) {
+      if (typeof parsed !== "string") break;
+      try {
+        parsed = JSON.parse(parsed);
+      } catch {
+        break;
+      }
+    }
+
+    if (Array.isArray(parsed)) {
+      return parsed
+        .filter((r): r is Record<string, unknown> => typeof r === "object" && r !== null)
+        .map((r) => {
+          const entry = r as ZaiSearchResult;
+          const url = entry.link || entry.url || "";
+          return {
+            title: entry.title || "",
+            url,
+            description: entry.content || entry.snippet || "",
+            siteName: resolveSiteName(url) || undefined,
+          };
+        });
+    }
+  }
+  return [];
+}
+
+/** Map shared freshness values to Z.AI recency filter values. */
+function resolveRecencyFilter(
+  args: Record<string, unknown>,
+): string | undefined {
+  const freshness = args.freshness;
+  if (typeof freshness !== "string") return undefined;
+  const map: Record<string, string> = {
+    day: "oneDay",
+    week: "oneWeek",
+    month: "oneMonth",
+    year: "oneYear",
+  };
+  return map[freshness] ?? undefined;
+}
+
+/** Map country code to Z.AI location. */
+function resolveLocation(country: string | undefined): string | undefined {
+  if (!country) return undefined;
+  if (country.toUpperCase() === "CN") return "cn";
+  return "us";
+}
+
+//#endregion
+
+//#region Search execution
+
+/**
+ * Execute Z.AI web search via the MCP protocol:
+ * 1. Initialize session → capture Mcp-Session-Id
+ * 2. Call web_search_prime tool
+ */
+export async function executeZaiSearch(
+  args: Record<string, unknown>,
+  searchConfig: SearchConfigRecord | undefined,
+  options: { signal?: AbortSignal },
+): Promise<Record<string, unknown>> {
+  const apiKey = resolveZaiApiKey(searchConfig);
+  if (!apiKey) {
+    return {
+      error: "missing_zai_api_key",
+      message: `web_search (zai-search) needs a Z.AI API key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set ZAI_API_KEY in the Gateway environment.`,
+      docs: "https://docs.z.ai/api-reference/tools/web-search",
+    };
+  }
+
+  const baseUrl = resolveZaiBaseUrl(searchConfig);
+  const query = readStringParam(args, "query", { required: true });
+  if (!query) {
+    return {
+      error: "missing_query",
+      message: "query is required for web search.",
+    };
+  }
+
+  const count = readPositiveIntegerParam(args, "count", {
+    max: MAX_SEARCH_COUNT,
+    message: `count must be an integer from 1 to ${MAX_SEARCH_COUNT}.`,
+  });
+  const resolvedCount = resolveSearchCount(count, DEFAULT_SEARCH_COUNT);
+  const country = readStringParam(args, "country");
+  const location = resolveLocation(country) ?? "us";
+  const recency = resolveRecencyFilter(args);
+  const contentSize = resolvedCount <= 3 ? "medium" : "high";
+  const timeoutSeconds = resolveSearchTimeoutSeconds(searchConfig);
+  const cacheTtlMs = resolveSearchCacheTtlMs(searchConfig);
+
+  // Build cache key
+  const cacheKey = buildSearchCacheKey([
+    "zai-search",
+    baseUrl,
+    query,
+    resolvedCount,
+    location,
+    recency,
+    contentSize,
+  ]);
+  const cached = readCachedSearchPayload(cacheKey);
+  if (cached) return cached;
+
+  const start = Date.now();
+
+  // Build MCP search arguments
+  const searchArgs: Record<string, unknown> = {
+    search_query: query,
+    location,
+    content_size: contentSize,
+  };
+  if (recency) searchArgs.search_recency_filter = recency;
+
+  try {
+    // Step 1: Initialize MCP session
+    const initResponse = await fetch(baseUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "openclaw-zai-search", version: "0.1.0" },
+        },
+        id: 1,
+      }),
+      signal: options.signal ?? AbortSignal.timeout(timeoutSeconds * 1000),
+    });
+
+    if (!initResponse.ok) {
+      const errBody = await initResponse.text().catch(() => "");
+      zaiSearchLogger.error(
+        `MCP initialize failed: ${initResponse.status} ${errBody.slice(0, 200)}`,
+      );
+      return {
+        error: "zai_mcp_init_failed",
+        message: `Z.AI MCP initialize failed (HTTP ${initResponse.status}). ${errBody.slice(0, 300)}`,
+      };
+    }
+
+    const sessionId = initResponse.headers.get("mcp-session-id");
+    if (!sessionId) {
+      zaiSearchLogger.error("MCP did not return session ID");
+      return {
+        error: "zai_mcp_no_session",
+        message: "Z.AI MCP did not return a session ID.",
+      };
+    }
+
+    // Step 2: Call web_search_prime tool
+    const callResponse = await fetch(baseUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "Mcp-Session-Id": sessionId,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: {
+          name: "web_search_prime",
+          arguments: searchArgs,
+        },
+        id: 2,
+      }),
+      signal: options.signal ?? AbortSignal.timeout(timeoutSeconds * 1000),
+    });
+
+    if (!callResponse.ok) {
+      const errBody = await callResponse.text().catch(() => "");
+      zaiSearchLogger.error(`MCP search call failed: ${callResponse.status}`);
+      return {
+        error: "zai_mcp_call_failed",
+        message: `Z.AI MCP search call failed (HTTP ${callResponse.status}). ${errBody.slice(0, 300)}`,
+      };
+    }
+
+    const responseText = await callResponse.text();
+    const mcpResult = parseMcpSseResponse(responseText);
+
+    if (mcpResult?.error) {
+      zaiSearchLogger.error(
+        `MCP RPC error: ${JSON.stringify(mcpResult.error)}`,
+      );
+      return {
+        error: "zai_search_rpc_error",
+        message: `Z.AI search RPC error: ${(mcpResult.error as { message?: string })?.message || JSON.stringify(mcpResult.error)}`,
+      };
+    }
+
+    const result = mcpResult?.result as Record<string, unknown> | undefined;
+    if (result?.isError) {
+      const content = result.content;
+      const errorText =
+        (Array.isArray(content) && content[0] && typeof content[0] === "object" &&
+          (content[0] as { text?: string }).text) ||
+        "Unknown error";
+      return {
+        error: "zai_search_error",
+        message: `Z.AI search error: ${errorText}`,
+      };
+    }
+
+    const results = extractSearchResults(mcpResult).slice(0, resolvedCount);
+
+    const payload = {
+      query,
+      provider: "zai-search",
+      count: results.length,
+      tookMs: Date.now() - start,
+      externalContent: {
+        untrusted: true,
+        source: "web_search",
+        provider: "zai-search",
+        wrapped: true,
+      },
+      results: results.map((entry) => ({
+        title: entry.title ? wrapWebContent(entry.title, "web_search") : "",
+        url: entry.url,
+        description: entry.description
+          ? wrapWebContent(entry.description, "web_search")
+          : "",
+        siteName: entry.siteName,
+      })),
+    };
+
+    writeCachedSearchPayload(cacheKey, payload, cacheTtlMs);
+    return payload;
+  } catch (err) {
+    const msg = (err as Error)?.message || String(err);
+    zaiSearchLogger.error(`zai-search failed: ${msg}`);
+    return {
+      error: "zai_search_exception",
+      message: `Z.AI web search failed: ${msg}`,
+    };
+  }
+}
+
+//#endregion

--- a/extensions/zai-search/src/zai-web-search-provider.ts
+++ b/extensions/zai-search/src/zai-web-search-provider.ts
@@ -1,0 +1,77 @@
+/**
+ * Z.AI web-search provider factory. Builds the agent tool definition and
+ * lazy-loads MCP execution only when a search is run.
+ */
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import {
+  mergeScopedSearchConfig,
+  resolveProviderWebSearchPluginConfig,
+} from "openclaw/plugin-sdk/provider-web-search-config-contract";
+import type {
+  SearchConfigRecord,
+  WebSearchProviderPlugin,
+  WebSearchProviderToolDefinition,
+} from "openclaw/plugin-sdk/provider-web-search";
+import { buildZaiWebSearchProviderBase } from "../web-search-shared.js";
+
+const loadZaiWebSearchRuntime = createLazyRuntimeModule(
+  () => import("./zai-web-search-provider.runtime.js"),
+);
+
+const ZaiSearchSchema = {
+  type: "object",
+  properties: {
+    query: {
+      type: "string",
+      description: "Search query string.",
+    },
+    count: {
+      type: "integer",
+      description: "Number of results to return (1-10).",
+      minimum: 1,
+      maximum: 10,
+    },
+    country: {
+      type: "string",
+      description:
+        "2-letter country code for region-specific results (e.g., 'US', 'CN', 'AU'). Affects result localization.",
+    },
+    freshness: {
+      type: "string",
+      description: "Filter by time: 'day' (24h), 'week', 'month', or 'year'.",
+    },
+  },
+} satisfies Record<string, unknown>;
+
+function createZaiToolDefinition(
+  searchConfig?: SearchConfigRecord,
+): WebSearchProviderToolDefinition {
+  return {
+    description:
+      "Search the web using Z.AI Web Search (MCP web_search_prime, included in the GLM Coding Plan). Returns titles, URLs, and content summaries optimized for LLM processing.",
+    parameters: ZaiSearchSchema,
+    execute: async (args, context) => {
+      context?.signal?.throwIfAborted();
+      const { executeZaiSearch } = await loadZaiWebSearchRuntime();
+      return await executeZaiSearch(args, searchConfig, {
+        signal: context?.signal,
+      });
+    },
+  };
+}
+
+/** Create the runtime Z.AI Search provider descriptor. */
+export function createZaiWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    ...buildZaiWebSearchProviderBase(),
+    createTool: (ctx) =>
+      createZaiToolDefinition(
+        mergeScopedSearchConfig(
+          ctx.searchConfig,
+          "zai-search",
+          resolveProviderWebSearchPluginConfig(ctx.config, "zai-search"),
+          { mirrorApiKeyToTopLevel: true },
+        ),
+      ),
+  };
+}

--- a/extensions/zai-search/test-api.ts
+++ b/extensions/zai-search/test-api.ts
@@ -1,0 +1,11 @@
+/**
+ * Z.AI Search test API barrel. Tests import normalized helpers through this
+ * path instead of deep runtime modules.
+ */
+import { resolveRecencyFilter, resolveLocation } from "./src/zai-web-search-provider.runtime.js";
+
+/** Test-only Z.AI search normalization helpers. */
+export const testing = {
+  resolveRecencyFilter,
+  resolveLocation,
+} as const;

--- a/extensions/zai-search/tsconfig.json
+++ b/extensions/zai-search/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json"
+}

--- a/extensions/zai-search/web-search-contract-api.ts
+++ b/extensions/zai-search/web-search-contract-api.ts
@@ -1,0 +1,14 @@
+/**
+ * Z.AI Search contract provider. Exposes provider metadata without creating
+ * the runtime search tool.
+ */
+import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-config-contract";
+import { buildZaiWebSearchProviderBase } from "./web-search-shared.js";
+
+/** Create the Z.AI provider descriptor for contract checks. */
+export function createZaiWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    ...buildZaiWebSearchProviderBase(),
+    createTool: () => null,
+  };
+}

--- a/extensions/zai-search/web-search-provider.ts
+++ b/extensions/zai-search/web-search-provider.ts
@@ -1,0 +1,5 @@
+/**
+ * Public Z.AI web-search provider barrel. Runtime consumers import this
+ * lightweight path for the provider factory.
+ */
+export { createZaiWebSearchProvider } from "./src/zai-web-search-provider.js";

--- a/extensions/zai-search/web-search-shared.ts
+++ b/extensions/zai-search/web-search-shared.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared Z.AI Web Search provider metadata and credential lookup. Contract
+ * tests and runtime provider creation both use this lightweight descriptor.
+ */
+import {
+  createWebSearchProviderContractFields,
+  type WebSearchProviderPlugin,
+} from "openclaw/plugin-sdk/provider-web-search-config-contract";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+/** Canonical config path for the Z.AI API key. */
+const ZAI_CREDENTIAL_PATH = "plugins.entries.zai-search.config.webSearch.apiKey";
+
+function resolveZaiWebSearchPluginConfig(
+  config: unknown,
+): Record<string, unknown> | undefined {
+  if (!isRecord(config)) {
+    return undefined;
+  }
+  const plugins = isRecord(config.plugins) ? config.plugins : undefined;
+  const entries = isRecord(plugins?.entries) ? plugins.entries : undefined;
+  const entry = isRecord(entries?.["zai-search"]) ? entries["zai-search"] : undefined;
+  const pluginConfig = isRecord(entry?.config) ? entry.config : undefined;
+  return isRecord(pluginConfig?.webSearch) ? pluginConfig.webSearch : undefined;
+}
+
+/** Resolve Z.AI credentials from current plugin config. */
+function resolveConfiguredZaiCredential(config: unknown): unknown {
+  return resolveZaiWebSearchPluginConfig(config)?.apiKey;
+}
+
+/** Build the common Z.AI provider metadata without the runtime tool executor. */
+export function buildZaiWebSearchProviderBase(): Omit<
+  WebSearchProviderPlugin,
+  "createTool"
+> {
+  return {
+    id: "zai-search",
+    label: "Z.AI Web Search",
+    hint: "MCP web_search_prime · GLM Coding Plan included",
+    onboardingScopes: ["text-inference"],
+    credentialLabel: "Z.AI API key",
+    envVars: ["ZAI_API_KEY", "Z_AI_API_KEY"],
+    placeholder: "zai-...",
+    signupUrl: "https://z.ai/",
+    docsUrl: "https://docs.z.ai/api-reference/tools/web-search",
+    autoDetectOrder: 20,
+    credentialPath: ZAI_CREDENTIAL_PATH,
+    ...createWebSearchProviderContractFields({
+      credentialPath: ZAI_CREDENTIAL_PATH,
+      searchCredential: { type: "top-level" },
+      configuredCredential: { pluginId: "zai-search" },
+    }),
+    getConfiguredCredentialValue: resolveConfiguredZaiCredential,
+  };
+}
+
+export { ZAI_CREDENTIAL_PATH };


### PR DESCRIPTION
## What Problem This Solves

Z.AI (GLM) offers a web search API via the MCP `web_search_prime` endpoint, which is **included in the GLM Coding Plan** at no extra cost. However, Assistant currently has no plugin to use it — Z.AI users need a separate Brave API key or another search provider just to get `web_search` functionality.

This plugin lets Z.AI Coding Plan subscribers use `web_search` with zero additional cost or API keys beyond what they already have.

## Why This Change Was Made

The existing `zai` extension only provides LLM inference models and media understanding — no web search. A separate provider (following the brave-plugin pattern) is the right architecture:

- **Separate provider ID** (`zai-search`) — doesn't conflict with the existing `zai` model provider
- **MCP protocol** — Z.AI exposes search via Model Context Protocol, not a REST API like Brave
- **Auto-detect order 20** — lower priority than Brave (10) so Brave stays preferred when both are configured

## How It Works

The MCP protocol requires a two-step flow:

1. **Initialize** — `POST {baseUrl}` with JSON-RPC `initialize` → captures `Mcp-Session-Id` header
2. **Call tool** — `POST {baseUrl}` with `tools/call`, `name: "web_search_prime"`, and the session header → returns SSE-encoded JSON-RPC results

### Parameter mapping

| openclaw param | Z.AI MCP param                |
|----------------|-------------------------------|
| `query`       | `search_query`              |
| `count`       | Slices result array (1–10)    |
| `country`     | `location` (`cn` or `us`) |
| `freshness`   | `search_recency_filter`     |

### Double JSON encoding

The MCP `text` content field contains a JSON string which itself wraps a JSON array (doubly escaped). The parser unwraps via iterative `JSON.parse` (up to 2 passes).

## User Impact

- Z.AI Coding Plan users get `web_search` with no extra API key or cost
- Falls back automatically if Brave is unavailable (autoDetectOrder: 20)
- Same `web_search` tool interface — transparent to agents

## Evidence

Tested locally with openclaw 2026.7.1:

```
web_search(query="best pizza recipe 2026", count=2)
→ provider: zai-search, count: 2, tookMs: 2451
→ results: [{title: "It's Perfect": I Tried King Arthur's 2026 Recipe...", url: thekitchn.com, ...}, ...]
```

```
web_search(query="latest technology news August 2026", count=3)
→ provider: zai-search, count: 3
→ results: [Reuters Tech, GeekWire, TechCrunch, ...]
```

## Structure

Follows the `extensions/brave/` pattern exactly:

```
extensions/zai-search/
├── index.ts                           # Plugin entry
├── openclaw.plugin.json               # Plugin manifest
├── package.json                       # npm package
├── tsconfig.json                      # TS config
├── README.md                          # Docs
├── web-search-provider.ts             # Public barrel
├── web-search-shared.ts               # Shared metadata
├── web-search-contract-api.ts         # Contract test API
├── test-api.ts                        # Test helpers barrel
└── src/
    ├── zai-web-search-provider.ts     # Provider factory (lazy runtime)
    └── zai-web-search-provider.runtime.ts  # MCP execution
```

## Notes

- The plugin reuses the same Z.AI API key as the existing `zai` model provider (via `ZAI_API_KEY` env var or plugin config)
- Credential path: `plugins.entries.zai-search.config.webSearch.apiKey`
- No SSRF checks needed — the endpoint is a fixed Z.AI URL (not user-configurable to internal addresses like Brave's self-hosted mode)