### PR TITLE
fix(gateway): keep listener live when restart state is invalid

### DIFF
--- a/src/gateway/server-import-boundary.test.ts
+++ b/src/gateway/server-import-boundary.test.ts
@@ -78,6 +78,9 @@ describe("gateway startup import boundaries", () => {
       expect(workerStartup).toContain(`import("./worker-environments/${workerModule}.js")`);
     }
     expect(serverImpl).not.toContain('from "../plugins/worker-provider-registry.js"');
+    expect(readSource("src/gateway/server-restart-readiness.ts")).toContain(
+      'import("../state/openclaw-database-preflight.js")',
+    );
     expect(workerStartup).toContain('import("../plugins/worker-provider-registry.js")');
     expect(serverImpl).not.toContain(
       'from "../../packages/gateway-protocol/src/schema/worker-admission.js"',

--- a/src/gateway/server-reload-contracts.ts
+++ b/src/gateway/server-reload-contracts.ts
@@ -170,6 +170,8 @@ export type GatewayReloadHandlerParams = {
   onCronRestart?: () => void;
   requestRecoveryRestart?: GatewayRestartEmitter;
   restartRecoveryAvailable?: boolean;
+  /** Revalidate successor-owned startup state before the current listener is closed. */
+  assertRestartReady?: () => Promise<void> | void;
 };
 
 export type ManagedGatewayConfigReloaderParams = Omit<

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -760,6 +760,7 @@ function createManagedRestartSequenceHarness(
   const requestRecoveryRestart = vi.fn<NonNullable<ReloadHandlerParams["requestRecoveryRestart"]>>(
     () => ({ status: "emitted" }),
   );
+  const assertRestartReady = vi.fn(async () => {});
   const sharedGatewaySessionGenerationState = { current: undefined, required: null };
   let generationInvalidated = false;
   const reloader = startManagedGatewayConfigReloader({
@@ -789,6 +790,7 @@ function createManagedRestartSequenceHarness(
     acceptTerminalConfig: terminalPolicy.acceptConfig,
     sharedGatewaySessionGenerationState,
     requestRecoveryRestart,
+    assertRestartReady,
   });
   const writeConfig = (
     config: OpenClawConfig,
@@ -811,6 +813,7 @@ function createManagedRestartSequenceHarness(
 
   return {
     activateRuntimeSecrets,
+    assertRestartReady,
     deferredConfig,
     initialConfig,
     invalidConfig,
@@ -4329,6 +4332,7 @@ describe("gateway Gmail hot reload handlers", () => {
       hoisted.activeTaskBlockers.length = 0;
       await vi.advanceTimersByTimeAsync(500);
       expect(harness.requestRecoveryRestart).not.toHaveBeenCalled();
+      expect(harness.assertRestartReady).toHaveBeenCalledOnce();
       expect(harness.logReload.warn).toHaveBeenCalledWith(
         expect.stringContaining("gateway restart preflight failed"),
       );
@@ -4336,6 +4340,7 @@ describe("gateway Gmail hot reload handlers", () => {
       harness.setSecretAvailable("RESTART_A_TOKEN");
       await vi.advanceTimersByTimeAsync(1_000);
       expect(harness.requestRecoveryRestart).toHaveBeenCalledOnce();
+      expect(harness.assertRestartReady).toHaveBeenCalledTimes(2);
       expect(harness.activateRuntimeSecrets).toHaveBeenCalledTimes(3);
     } finally {
       hoisted.activeTaskBlockers.length = 0;

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -4330,7 +4330,7 @@ describe("gateway Gmail hot reload handlers", () => {
       await vi.advanceTimersByTimeAsync(500);
       expect(harness.requestRecoveryRestart).not.toHaveBeenCalled();
       expect(harness.logReload.warn).toHaveBeenCalledWith(
-        expect.stringContaining("gateway restart secrets preflight failed"),
+        expect.stringContaining("gateway restart preflight failed"),
       );
 
       harness.setSecretAvailable("RESTART_A_TOKEN");

--- a/src/gateway/server-reload-managed.ts
+++ b/src/gateway/server-reload-managed.ts
@@ -147,6 +147,7 @@ export function startManagedGatewayConfigReloader(
     ...(params.requestRecoveryRestart
       ? { requestRecoveryRestart: params.requestRecoveryRestart }
       : {}),
+    ...(params.assertRestartReady ? { assertRestartReady: params.assertRestartReady } : {}),
     restartRecoveryAvailable,
     createHealthMonitor: (config) =>
       startGatewayChannelHealthMonitor({

--- a/src/gateway/server-reload-restart.test.ts
+++ b/src/gateway/server-reload-restart.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { GatewayReloadPlan } from "./config-reload.js";
+import { nextGatewayReloadGeneration } from "./server-reload-contracts.js";
+import { createGatewayRestartCoordinator } from "./server-reload-restart.js";
+
+const zeroActiveCounts = {
+  queueSize: 0,
+  pendingReplies: 0,
+  embeddedRuns: 0,
+  backgroundExecSessions: 0,
+  rootRequests: 0,
+  activeTasks: 0,
+  totalActive: 0,
+};
+
+const restartPlan = {
+  changedPaths: ["gateway.port"],
+  restartGateway: true,
+  restartReasons: ["gateway.port"],
+  hotReasons: [],
+  reloadHooks: false,
+  restartGmailWatcher: false,
+  restartCron: false,
+  restartHeartbeat: false,
+  restartHealthMonitor: false,
+  reloadPlugins: false,
+  restartChannels: new Set(),
+  disposeMcpRuntimes: false,
+  noopPaths: [],
+} satisfies GatewayReloadPlan;
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("gateway restart readiness preflight", () => {
+  it("keeps the current lifecycle serving until successor state is restart-ready", async () => {
+    const requestRecoveryRestart = vi.fn(() => ({ status: "emitted" as const }));
+    const assertRestartReady = vi
+      .fn<() => Promise<void> | void>()
+      .mockRejectedValueOnce(new Error("state schema is noncanonical"))
+      .mockResolvedValue(undefined);
+    const prepareRuntimeConfig = vi.fn(async () => ({}) as OpenClawConfig);
+    const logReload = { info: vi.fn(), warn: vi.fn() };
+    const params = { assertRestartReady, logReload, requestRecoveryRestart };
+    const coordinator = createGatewayRestartCoordinator({
+      params,
+      myGeneration: nextGatewayReloadGeneration(),
+      restartRecoveryAvailable: true,
+      getActiveCounts: () => zeroActiveCounts,
+      formatActiveDetails: () => [],
+      formatDeferredWorkStatus: () => "no active work",
+      formatTaskBlockers: () => null,
+    });
+    vi.useFakeTimers();
+
+    try {
+      expect(
+        coordinator.requestGatewayRestart(restartPlan, {} as OpenClawConfig, {
+          prepareRuntimeConfig,
+        }).status,
+      ).toBe("accepted");
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(assertRestartReady).toHaveBeenCalledOnce();
+      expect(prepareRuntimeConfig).not.toHaveBeenCalled();
+      expect(requestRecoveryRestart).not.toHaveBeenCalled();
+      expect(logReload.warn).toHaveBeenCalledWith(
+        "gateway restart preflight failed: Error: state schema is noncanonical",
+      );
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(assertRestartReady).toHaveBeenCalledTimes(2);
+      expect(prepareRuntimeConfig).toHaveBeenCalledOnce();
+      expect(requestRecoveryRestart).toHaveBeenCalledOnce();
+    } finally {
+      coordinator.stopRestartRetries();
+    }
+  });
+});

--- a/src/gateway/server-reload-restart.ts
+++ b/src/gateway/server-reload-restart.ts
@@ -69,8 +69,13 @@ type AcceptedRestartTargetState =
       target: AcceptedRestartTarget;
     };
 
+type GatewayRestartCoordinatorParams = Pick<
+  GatewayReloadHandlerParams,
+  "assertRestartReady" | "logReload" | "requestRecoveryRestart"
+>;
+
 type GatewayRestartCoordinatorOptions = {
-  params: GatewayReloadHandlerParams;
+  params: GatewayRestartCoordinatorParams;
   myGeneration: number;
   restartRecoveryAvailable: boolean;
   getActiveCounts: () => GatewayActiveCounts;
@@ -409,6 +414,10 @@ class GatewayRestartTransaction {
     let emissionPrepared = true;
     const prepareForEmit = async () => {
       try {
+        await params.assertRestartReady?.();
+        if (!this.isCurrentRequest(requestGeneration)) {
+          return false;
+        }
         const preparedConfig = options?.prepareRuntimeConfig
           ? await options.prepareRuntimeConfig()
           : nextConfig;
@@ -420,14 +429,14 @@ class GatewayRestartTransaction {
         return this.isCurrentRequest(requestGeneration);
       } catch (err) {
         emissionPrepared = false;
-        params.logReload.warn(`gateway restart secrets preflight failed: ${String(err)}`);
+        params.logReload.warn(`gateway restart preflight failed: ${String(err)}`);
         return false;
       }
     };
 
     const active = this.options.getActiveCounts();
 
-    if (active.totalActive > 0 || options?.prepareRuntimeConfig) {
+    if (active.totalActive > 0 || options?.prepareRuntimeConfig || params.assertRestartReady) {
       // Avoid spinning up duplicate polling loops from repeated config changes.
       if (this.restartPending) {
         params.logReload.info(

--- a/src/gateway/server-restart-readiness.ts
+++ b/src/gateway/server-restart-readiness.ts
@@ -1,0 +1,6 @@
+/** Revalidate fresh database ownership before a config restart closes the listener. */
+export async function assertGatewayRestartDatabaseReadiness(): Promise<void> {
+  const { assertOpenClawDatabasesReadyForRestart } =
+    await import("../state/openclaw-database-preflight.js");
+  assertOpenClawDatabasesReadyForRestart({ env: process.env });
+}

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -23,6 +23,7 @@ import {
 } from "./server-lifetime-sidecars.js";
 import { GATEWAY_EVENTS } from "./server-methods-list.js";
 import { setFallbackGatewayContextResolver } from "./server-plugins.js";
+import { assertGatewayRestartDatabaseReadiness } from "./server-restart-readiness.js";
 import {
   enforceSharedGatewaySessionGenerationForConfigWrite,
   getRequiredSharedGatewaySessionGeneration,
@@ -631,6 +632,7 @@ export async function finishGatewayStartup(params: {
     resolveSharedGatewaySessionGenerationForConfig,
     sharedGatewaySessionGenerationState,
     clients,
+    ...(!minimalTestGateway ? { assertRestartReady: assertGatewayRestartDatabaseReadiness } : {}),
     ...(opts.hotReloadRecovery ? { requestRecoveryRestart: opts.hotReloadRecovery } : {}),
     restartRecoveryAvailable: opts.hotReloadRecovery !== undefined,
   });

--- a/src/state/openclaw-database-preflight.test.ts
+++ b/src/state/openclaw-database-preflight.test.ts
@@ -7,7 +7,10 @@ import {
   OPENCLAW_AGENT_SCHEMA_VERSION,
   openOpenClawAgentDatabase,
 } from "./openclaw-agent-db.js";
-import { preflightOpenClawDatabaseSchemas } from "./openclaw-database-preflight.js";
+import {
+  assertOpenClawDatabasesReadyForRestart,
+  preflightOpenClawDatabaseSchemas,
+} from "./openclaw-database-preflight.js";
 import {
   closeOpenClawStateDatabaseForTest,
   OPENCLAW_STATE_SCHEMA_VERSION,
@@ -40,12 +43,55 @@ describe("OpenClaw database schema preflight", () => {
     expect(
       preflightOpenClawDatabaseSchemas({
         env,
+        verifyCurrentSchemaShape: true,
         supportedVersions: {
           state: OPENCLAW_STATE_SCHEMA_VERSION,
           agent: OPENCLAW_AGENT_SCHEMA_VERSION,
         },
       }),
     ).toEqual({ incompatible: [], indeterminate: [] });
+    expect(() => assertOpenClawDatabasesReadyForRestart({ env })).not.toThrow();
+  });
+
+  it("reports a current but noncanonical state schema as indeterminate", () => {
+    const stateDir = makeTempDir(tempDirs, "openclaw-database-preflight-noncanonical-state-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const statePath = openOpenClawStateDatabase({ env }).path;
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const state = new DatabaseSync(statePath);
+    try {
+      state.exec(
+        "ALTER TABLE worktrees DROP COLUMN run_end_cleanup_json; " +
+          "ALTER TABLE worktrees ADD COLUMN run_end_cleanup_json INTEGER;",
+      );
+    } finally {
+      state.close();
+    }
+
+    expect(
+      preflightOpenClawDatabaseSchemas({
+        env,
+        verifyCurrentSchemaShape: true,
+        supportedVersions: {
+          state: OPENCLAW_STATE_SCHEMA_VERSION,
+          agent: OPENCLAW_AGENT_SCHEMA_VERSION,
+        },
+      }),
+    ).toEqual({
+      incompatible: [],
+      indeterminate: [
+        {
+          kind: "state",
+          path: statePath,
+          reason: expect.stringContaining("column definitions differ for worktrees"),
+        },
+      ],
+    });
+    expect(() => assertOpenClawDatabasesReadyForRestart({ env })).toThrow(
+      /Gateway refused restart.*column definitions differ for worktrees/u,
+    );
   });
 
   it("collects newer state and registered agent schemas with writer builds", () => {
@@ -103,6 +149,42 @@ describe("OpenClaw database schema preflight", () => {
         },
       ],
       indeterminate: [],
+    });
+  });
+
+  it("reports a current but noncanonical registered agent schema as indeterminate", () => {
+    const stateDir = makeTempDir(tempDirs, "openclaw-database-preflight-noncanonical-agent-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const agentPath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const agent = new DatabaseSync(agentPath);
+    try {
+      agent.exec("ALTER TABLE schema_meta ADD COLUMN unexpected TEXT;");
+    } finally {
+      agent.close();
+    }
+
+    expect(
+      preflightOpenClawDatabaseSchemas({
+        env,
+        verifyCurrentSchemaShape: true,
+        supportedVersions: {
+          state: OPENCLAW_STATE_SCHEMA_VERSION,
+          agent: OPENCLAW_AGENT_SCHEMA_VERSION,
+        },
+      }),
+    ).toEqual({
+      incompatible: [],
+      indeterminate: [
+        {
+          kind: "agent",
+          path: agentPath,
+          reason: expect.stringContaining("column definitions differ for schema_meta"),
+        },
+      ],
     });
   });
 

--- a/src/state/openclaw-database-preflight.test.ts
+++ b/src/state/openclaw-database-preflight.test.ts
@@ -1,6 +1,6 @@
-import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import packageJson from "../../package.json" with { type: "json" };
-import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -17,14 +17,12 @@ import {
   openOpenClawStateDatabase,
 } from "./openclaw-state-db.js";
 
-const tempDirs: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
 });
-
-afterAll(() => cleanupTempDirs(tempDirs));
 
 describe("OpenClaw database schema preflight", () => {
   it("keeps package schema support metadata aligned", () => {
@@ -35,7 +33,7 @@ describe("OpenClaw database schema preflight", () => {
   });
 
   it("accepts a supported state schema", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-preflight-supported-");
+    const stateDir = tempDirs.make("openclaw-database-preflight-supported-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     openOpenClawStateDatabase({ env });
     closeOpenClawStateDatabaseForTest();
@@ -54,7 +52,7 @@ describe("OpenClaw database schema preflight", () => {
   });
 
   it("reports a current but noncanonical state schema as indeterminate", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-preflight-noncanonical-state-");
+    const stateDir = tempDirs.make("openclaw-database-preflight-noncanonical-state-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const statePath = openOpenClawStateDatabase({ env }).path;
     closeOpenClawStateDatabaseForTest();
@@ -95,7 +93,7 @@ describe("OpenClaw database schema preflight", () => {
   });
 
   it("collects newer state and registered agent schemas with writer builds", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-preflight-");
+    const stateDir = tempDirs.make("openclaw-database-preflight-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const statePath = openOpenClawStateDatabase({ env }).path;
     const agentPath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
@@ -153,7 +151,7 @@ describe("OpenClaw database schema preflight", () => {
   });
 
   it("reports a current but noncanonical registered agent schema as indeterminate", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-preflight-noncanonical-agent-");
+    const stateDir = tempDirs.make("openclaw-database-preflight-noncanonical-agent-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentPath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
     closeOpenClawAgentDatabasesForTest();
@@ -189,7 +187,7 @@ describe("OpenClaw database schema preflight", () => {
   });
 
   it("reports an existing unreadable state database as indeterminate", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-preflight-unreadable-state-");
+    const stateDir = tempDirs.make("openclaw-database-preflight-unreadable-state-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const statePath = openOpenClawStateDatabase({ env }).path;
     closeOpenClawStateDatabaseForTest();
@@ -212,7 +210,7 @@ describe("OpenClaw database schema preflight", () => {
   });
 
   it("reports a failed agent registry query as indeterminate", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-preflight-registry-");
+    const stateDir = tempDirs.make("openclaw-database-preflight-registry-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const statePath = openOpenClawStateDatabase({ env }).path;
     closeOpenClawStateDatabaseForTest();
@@ -245,7 +243,7 @@ describe("OpenClaw database schema preflight", () => {
   });
 
   it("reports an existing unreadable registered agent database as indeterminate", () => {
-    const stateDir = makeTempDir(tempDirs, "openclaw-database-preflight-unreadable-agent-");
+    const stateDir = tempDirs.make("openclaw-database-preflight-unreadable-agent-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentPath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
     closeOpenClawAgentDatabasesForTest();

--- a/src/state/openclaw-database-preflight.ts
+++ b/src/state/openclaw-database-preflight.ts
@@ -12,12 +12,16 @@ import {
   describeRunningOpenClawBuild,
   readSqliteUserVersion,
 } from "../infra/sqlite-user-version.js";
+import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
+import { assertOpenClawAgentDatabaseForMaintenance } from "./openclaw-agent-db-maintenance.js";
 import type { OpenClawSchemaVersions } from "./openclaw-schema-versions.js";
-import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
   OPENCLAW_DATABASE_SCHEMA_DOCS_URL,
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
-} from "./openclaw-state-db.js";
+  OPENCLAW_STATE_SCHEMA_VERSION,
+} from "./openclaw-state-db-contract.js";
+import { assertOpenClawStateDatabaseForMaintenance } from "./openclaw-state-db-maintenance.js";
+import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
 export { OPENCLAW_DATABASE_SCHEMA_DOCS_URL } from "./openclaw-state-db.js";
@@ -44,7 +48,7 @@ export type OpenClawDatabaseSchemaPreflight = {
 
 type AgentRegistryDatabase = Pick<OpenClawStateKyselyDatabase, "agent_databases">;
 
-type OpenClawDatabaseSchemaPreflightOperation = "doctor" | "gateway-startup";
+type OpenClawDatabaseSchemaPreflightOperation = "doctor" | "gateway-restart" | "gateway-startup";
 
 function formatDoctorIncompatibleDatabase(database: IncompatibleOpenClawDatabase): string {
   const agent = database.agentId ? ` for agent ${database.agentId}` : "";
@@ -60,7 +64,11 @@ export class OpenClawDatabaseSchemaPreflightError extends Error {
   ) {
     const operation = options.operation ?? "gateway-startup";
     const prefix =
-      operation === "doctor" ? "Doctor refused to continue" : "Gateway refused startup";
+      operation === "doctor"
+        ? "Doctor refused to continue"
+        : operation === "gateway-restart"
+          ? "Gateway refused restart"
+          : "Gateway refused startup";
     const doctorGuidance =
       operation === "doctor"
         ? ` ${incompatibleDatabases.map(formatDoctorIncompatibleDatabase).join(" ")} Run Doctor with the OpenClaw install that wrote this state (typically the active Gateway install), or another build that supports these schemas.`
@@ -71,6 +79,33 @@ export class OpenClawDatabaseSchemaPreflightError extends Error {
     );
     this.name = "OpenClawDatabaseSchemaPreflightError";
   }
+}
+
+/** Refuse a restart that would reopen the current persisted databases unsuccessfully. */
+export function assertOpenClawDatabasesReadyForRestart(options: { env: NodeJS.ProcessEnv }): void {
+  const schemas = preflightOpenClawDatabaseSchemas({
+    env: options.env,
+    supportedVersions: {
+      state: OPENCLAW_STATE_SCHEMA_VERSION,
+      agent: OPENCLAW_AGENT_SCHEMA_VERSION,
+    },
+    verifyCurrentSchemaShape: true,
+  });
+  if (schemas.incompatible.length > 0) {
+    throw new OpenClawDatabaseSchemaPreflightError(schemas.incompatible, {
+      operation: "gateway-restart",
+    });
+  }
+  if (schemas.indeterminate.length === 0) {
+    return;
+  }
+  const shown = schemas.indeterminate
+    .slice(0, 3)
+    .map((database) => `${database.kind} ${database.path}: ${database.reason}`);
+  const omitted = schemas.indeterminate.length - shown.length;
+  throw new Error(
+    `Gateway refused restart because persisted database readiness could not be verified: ${shown.join("; ")}${omitted > 0 ? `; +${omitted} more` : ""}. Run openclaw doctor --fix, then retry the restart.`,
+  );
 }
 
 function readWriterAppVersion(database: DatabaseSync): string | undefined {
@@ -107,10 +142,11 @@ function readRegisteredAgentDatabases(database: DatabaseSync): Array<{
   );
 }
 
-/** Read schema headers; report unreadable existing files without diagnosing or repairing them. */
+/** Read schema headers and optionally verify current schema shape without repairing it. */
 export function preflightOpenClawDatabaseSchemas(options: {
   env: NodeJS.ProcessEnv;
   supportedVersions: OpenClawSchemaVersions;
+  verifyCurrentSchemaShape?: boolean;
 }): OpenClawDatabaseSchemaPreflight {
   const result: OpenClawDatabaseSchemaPreflight = { incompatible: [], indeterminate: [] };
   const statePath = path.resolve(resolveOpenClawStateSqlitePath(options.env));
@@ -134,6 +170,20 @@ export function preflightOpenClawDatabaseSchemas(options: {
         supportedVersion: options.supportedVersions.state,
         ...(writerAppVersion ? { writerAppVersion } : {}),
       });
+    }
+    if (
+      options.verifyCurrentSchemaShape === true &&
+      stateVersion === OPENCLAW_STATE_SCHEMA_VERSION
+    ) {
+      try {
+        assertOpenClawStateDatabaseForMaintenance(stateDatabase, { pathname: statePath });
+      } catch (error) {
+        result.indeterminate.push({
+          kind: "state",
+          path: statePath,
+          reason: formatErrorMessage(error),
+        });
+      }
     }
 
     let registeredDatabases: ReturnType<typeof readRegisteredAgentDatabases>;
@@ -161,6 +211,14 @@ export function preflightOpenClawDatabaseSchemas(options: {
         agentDatabase.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
         const agentVersion = readSqliteUserVersion(agentDatabase);
         if (agentVersion <= options.supportedVersions.agent) {
+          if (options.verifyCurrentSchemaShape === true) {
+            // Existing agent databases require Doctor-owned migration before
+            // startup; a successor cannot safely repair them after close.
+            assertOpenClawAgentDatabaseForMaintenance(agentDatabase, {
+              agentId: row.agentId,
+              pathname: agentPath,
+            });
+          }
           continue;
         }
         const writerAppVersion = readWriterAppVersion(agentDatabase);


### PR DESCRIPTION
Related: #35862

## What Problem This Solves

Fixes an issue where a config write that required a Gateway restart could close a healthy listener even when the persisted SQLite state could not be reopened by the successor lifecycle. The restart then failed before returning a server handle, leaving the process alive without a listener and preventing an external supervisor from restoring service cleanly.

## Why This Change Was Made

Config-reload restart admission now performs a fresh, read-only database readiness check before resolving config secrets or emitting the restart signal. It verifies the canonical shared-state schema and every registered agent database with the same maintenance-owned contracts startup relies on. If readiness fails, the existing bounded retry owner keeps the current lifecycle serving, logs Doctor guidance, and retries without signaling, resetting task registries, writing a supervisor handoff, or starting a duplicate listener.

The readiness loader stays behind a lazy runtime boundary so this safety check does not expand the cold Gateway startup import graph. This is AI-assisted work; the implementation and owner boundaries were inspected directly.

## User Impact

Operators keep a reachable Gateway when a restart-required config change coincides with noncanonical persisted database state. After `openclaw doctor --fix` repairs the state, the already-owned retry can proceed normally.

## Evidence

- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31299235406
- Focused Vitest: 223 assertions passed across database readiness, restart ordering/retry, existing managed reload behavior, and startup import boundaries.
- Remote `check:changed`: formatting, max-lines, dependency/architecture guards, dead-code scans, production/test typechecks, lint, database-first guards, and import cycles passed.
- Ordered regression proves an unhealthy database check runs before secrets preparation and restart signal delivery, then emits exactly once after readiness recovers.
- State and registered-agent SQLite regressions use fresh read-only handles and prove noncanonical current schemas are rejected without mutation.
- Source-blind isolated process proof first failed and exposed a missing managed-reloader handoff; after that wiring repair, the same contract passed with the original PID and old port healthy, the configured replacement port unbound, persisted config confirmed, and explicit restart-preflight/Doctor guidance in logs.
- Autoreview: clean before the initial commit (confidence 0.93) and after the behavior-driven wiring repair (confidence 0.99), with no accepted/actionable findings.
- Production LOC: +86/-8 (net +78), justified by the new restart safety/ownership boundary and shared state + agent schema contract coverage. Tests: +182/-12.
