### PR TITLE
fix(ui): prevent cloud draft recovery dead ends

### DIFF
--- a/src/gateway/server-methods/chat-metadata-runtime.test.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.test.ts
@@ -32,6 +32,10 @@ function createOwner(config: OpenClawConfig, id: string): PreparedModelRuntimeSn
 
 function createHarness(
   initialConfig: OpenClawConfig = { agents: { list: [{ id: "main", default: true }] } },
+  runtimeOptions: {
+    beforeRefresh?: () => Promise<void>;
+    refreshOnRead?: boolean;
+  } = {},
 ) {
   let config = initialConfig;
   let owner = createOwner(config, "first");
@@ -70,6 +74,7 @@ function createHarness(
     getConfig: () => config,
     getContext: () => context,
     log: context.logGateway,
+    ...runtimeOptions,
     deps: {
       getPreparedOwner,
       getPreparedAuthStore,
@@ -111,6 +116,19 @@ function createHarness(
 }
 
 describe("gateway chat metadata runtime", () => {
+  test("refreshes lazily on the first read when configured", async () => {
+    const beforeRefresh = vi.fn(async () => {});
+    const harness = createHarness(undefined, { beforeRefresh, refreshOnRead: true });
+
+    expect(harness.buildProjection).not.toHaveBeenCalled();
+    await expect(harness.runtime.read({ agentId: "main" })).resolves.toMatchObject({
+      models: [expect.objectContaining({ id: "first" })],
+    });
+
+    expect(beforeRefresh).toHaveBeenCalledOnce();
+    expect(harness.buildProjection).toHaveBeenCalledOnce();
+  });
+
   test("single-flights equivalent refreshes and reads", async () => {
     const harness = createHarness();
     const releaseModels = createDeferred();

--- a/ui/src/components/app-sidebar-session-narration.test.ts
+++ b/ui/src/components/app-sidebar-session-narration.test.ts
@@ -21,7 +21,7 @@ function runningRow(key: string): SidebarRecentSession {
     hasActiveRun: true,
     modelSelectionLocked: false,
     pinned: false,
-    cloudWorkerActive: false,
+    cloudWorkerStopAction: null,
     hasAutomation: false,
     unread: false,
     attention: { kind: "none" },

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -44,12 +44,12 @@ import {
   type SidebarSessionStatusFilter,
 } from "./app-sidebar-session-types.ts";
 import type { SidebarWorkboardBoard } from "./app-sidebar-workboard.ts";
+import { resolveCloudWorkerStopAction } from "./cloud-worker-stop.ts";
 import {
   listSessionCreators,
   type SessionCreatedActor,
   type SessionCreatorOption,
 } from "./session-owner-chip.ts";
-import { isStoppableCloudWorkerPlacement } from "./session-row-badges.ts";
 
 type SessionRow = SessionsListResult["sessions"][number];
 
@@ -164,7 +164,7 @@ export function buildSidebarSessionNavigationState(input: {
               row.placement.workspaceResultConflict?.totalCount ?? 0,
             ) || undefined
           : undefined,
-      cloudWorkerActive: isStoppableCloudWorkerPlacement(row.placement),
+      cloudWorkerStopAction: resolveCloudWorkerStopAction(row.placement),
       hasAutomation: row.hasAutomation === true,
       pullRequest: context?.sessions.pullRequestSummary(row.key),
       outboxCount: input.outboxCountForSessionKey(row.key),

--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -18,6 +18,7 @@ import {
 } from "../lib/sessions/grouping.ts";
 import type { SessionCapability } from "../lib/sessions/index.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
+import type { CloudWorkerStopAction } from "./cloud-worker-stop.ts";
 import type { SessionPlacementState } from "./session-row-badges.ts";
 
 export type SidebarSessionAttention =
@@ -83,7 +84,7 @@ export type SidebarRecentSession = {
   worktreeId?: string;
   placementState?: SessionPlacementState;
   workspaceConflictCount?: number;
-  cloudWorkerActive: boolean;
+  cloudWorkerStopAction: CloudWorkerStopAction | null;
   hasAutomation: boolean;
   pullRequest?: SessionCatalogPullRequestSummary;
   outboxCount?: number;

--- a/ui/src/components/cloud-worker-stop.ts
+++ b/ui/src/components/cloud-worker-stop.ts
@@ -1,0 +1,46 @@
+import type { EnvironmentsDestroyResult } from "../../../packages/gateway-protocol/src/schema/environments.ts";
+import { isCloudWorkerPlacementState } from "../../../packages/gateway-protocol/src/schema/session-placement-state.js";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import type { GatewaySessionRow } from "../api/types.ts";
+
+export type CloudWorkerStopAction =
+  | { method: "sessions.reclaim"; requiredScope: "operator.admin" }
+  | {
+      method: "environments.destroy";
+      params: { environmentId: string };
+      requiredScope: "operator.admin";
+    };
+
+export function resolveCloudWorkerStopAction(
+  placement: GatewaySessionRow["placement"],
+): CloudWorkerStopAction | null {
+  if (!placement || !isCloudWorkerPlacementState(placement.state)) {
+    return null;
+  }
+  if (placement.state === "active") {
+    return { method: "sessions.reclaim", requiredScope: "operator.admin" };
+  }
+  return "environmentId" in placement && placement.environmentId
+    ? {
+        method: "environments.destroy",
+        params: { environmentId: placement.environmentId },
+        requiredScope: "operator.admin",
+      }
+    : null;
+}
+
+export async function requestCloudWorkerStop(
+  client: GatewayBrowserClient,
+  action: CloudWorkerStopAction,
+  session: { key: string; agentId?: string },
+): Promise<EnvironmentsDestroyResult | null> {
+  if (action.method === "environments.destroy") {
+    return client.request<EnvironmentsDestroyResult>("environments.destroy", action.params);
+  }
+  await client.request(
+    "sessions.reclaim",
+    { key: session.key, ...(session.agentId ? { agentId: session.agentId } : {}) },
+    { timeoutMs: 10 * 60_000 },
+  );
+  return null;
+}

--- a/ui/src/components/session-organizer-operations.runtime.ts
+++ b/ui/src/components/session-organizer-operations.runtime.ts
@@ -14,6 +14,7 @@ import type {
   SidebarSessionMutationScope,
   SidebarSessionPatch,
 } from "./app-sidebar-session-types.ts";
+import { requestCloudWorkerStop } from "./cloud-worker-stop.ts";
 import type { SessionMenuAction } from "./session-menu.ts";
 import {
   patchSessionRows,
@@ -554,9 +555,10 @@ export async function stopCloudWorker(
   session: SidebarRecentSession,
   scope: SidebarSessionMutationScope,
 ) {
+  const stopAction = session.cloudWorkerStopAction;
   if (
-    !session.cloudWorkerActive ||
-    session.hasActiveRun ||
+    !stopAction ||
+    (stopAction.method === "sessions.reclaim" && session.hasActiveRun) ||
     !window.confirm(t("sessionsView.stopCloudWorkerConfirm", { session: session.label }))
   ) {
     return;
@@ -564,21 +566,23 @@ export async function stopCloudWorker(
   if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
     return;
   }
-  const agentId = parseAgentSessionKey(session.key)?.agentId ?? scope.selectedAgentId;
-  if (
-    !requireSessionMutationAccess(host, scope, {
-      method: "sessions.reclaim",
-      requiredScope: "operator.admin",
-    })
-  ) {
+  if (!requireSessionMutationAccess(host, scope, stopAction)) {
     return;
   }
   try {
-    await scope.client.request(
-      "sessions.reclaim",
-      { key: session.key, agentId },
-      { timeoutMs: 10 * 60_000 },
-    );
+    const agentId = parseAgentSessionKey(session.key)?.agentId ?? scope.selectedAgentId;
+    const result = await requestCloudWorkerStop(scope.client, stopAction, {
+      key: session.key,
+      agentId,
+    });
+    if (result && host.sessionData.isSessionMutationScopeCurrent(scope)) {
+      showToast({
+        message: t("sessionsView.cloudWorkerStopResult", {
+          session: session.label,
+          state: result.worker?.state ?? result.status,
+        }),
+      });
+    }
     if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
       return;
     }

--- a/ui/src/components/session-row-badges.ts
+++ b/ui/src/components/session-row-badges.ts
@@ -11,12 +11,6 @@ export type SessionPlacementState = NonNullable<GatewaySessionRow["placement"]>[
 
 export { isCloudWorkerPlacementState } from "../../../packages/gateway-protocol/src/schema/session-placement-state.js";
 
-export function isStoppableCloudWorkerPlacement(
-  placement: GatewaySessionRow["placement"],
-): boolean {
-  return placement?.state === "active";
-}
-
 function pullRequestStateLabel(state: SessionCatalogPullRequestSummary["state"]): string {
   switch (state) {
     case "open":

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -69,6 +69,9 @@ function sessionMenuActionDisabledReasons(
     requiredScope: "operator.write",
   });
   const deleteRows = batchRows ?? [session];
+  const cloudWorkerStopReason = session.cloudWorkerStopAction
+    ? reason(session.cloudWorkerStopAction)
+    : undefined;
   const deleteReason = deleteRows
     .map((row) =>
       reason({
@@ -104,14 +107,7 @@ function sessionMenuActionDisabledReasons(
                 }),
               }
             : {}),
-          ...(reason({ method: "sessions.reclaim", requiredScope: "operator.admin" })
-            ? {
-                "stop-cloud-worker": reason({
-                  method: "sessions.reclaim",
-                  requiredScope: "operator.admin",
-                }),
-              }
-            : {}),
+          ...(cloudWorkerStopReason ? { "stop-cloud-worker": cloudWorkerStopReason } : {}),
         }),
   };
 }
@@ -248,6 +244,14 @@ export function renderSidebarSessionMenuForController(controller: SidebarMenusCo
   const sharedCategory = rows.every((row) => (row.category ?? null) === (rows[0]?.category ?? null))
     ? (rows[0]?.category ?? null)
     : null;
+  const cloudWorkerStopAction = session.cloudWorkerStopAction;
+  const cloudWorkerStopAllowed = Boolean(
+    !batchRows &&
+    cloudWorkerStopAction &&
+    (cloudWorkerStopAction.method !== "sessions.reclaim" || !session.hasActiveRun) &&
+    context &&
+    isGatewayMethodAdvertised(context.gateway.snapshot, cloudWorkerStopAction.method) === true,
+  );
   return keyed(
     menu,
     html`
@@ -272,13 +276,7 @@ export function renderSidebarSessionMenuForController(controller: SidebarMenusCo
         )}
         .forkDisabled=${host.sessionData.sessionsLoading || session.modelSelectionLocked}
         .archiveAllowed=${archiveAllowed}
-        .cloudWorkerStopAllowed=${Boolean(
-          !batchRows &&
-          session.cloudWorkerActive &&
-          !session.hasActiveRun &&
-          context &&
-          isGatewayMethodAdvertised(context.gateway.snapshot, "sessions.reclaim") === true,
-        )}
+        .cloudWorkerStopAllowed=${cloudWorkerStopAllowed}
         .groups=${host.knownSessionGroups()}
         .canOpenChat=${true}
         .work=${batchRows ? null : controller.sessionMenuWork}

--- a/ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts
@@ -502,6 +502,9 @@ suite.define(() => {
       await expect
         .poll(() => page.locator(".new-session-page__message").inputValue())
         .toBe(message);
+      await pollLocatorText(page.locator(".new-session-page__error")).toContain(
+        "This cloud session's setup was interrupted. Check recent sessions before starting this task again.",
+      );
       await page.locator('.chat-attachment-thumb img[alt="Attachment preview"]').waitFor();
       await expect
         .poll(() => page.getByRole("button", { name: "Remove attachment" }).isDisabled())

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -702,9 +702,13 @@ export const en: TranslationMap = {
     start: "Start session",
     starting: "Starting…",
     createFailed: "Couldn't create the session.",
+    cloudOwnershipLost:
+      "Another window took over this cloud session. Check recent sessions before starting this task again.",
     createOutcomeUnknown:
       "The Gateway changed while this session was starting. Check recent sessions before starting this task again.",
     cliAgentsGroup: "CLI agents",
+    cloudSetupInterrupted:
+      "This cloud session's setup was interrupted. Check recent sessions before starting this task again.",
     catalogUnavailable: "This session target is unavailable.",
   },
   dashboardsPage: {
@@ -888,6 +892,7 @@ export const en: TranslationMap = {
     stopCloudWorker: "Stop cloud worker…",
     stopCloudWorkerConfirm: 'Stop the cloud worker for "{session}"?',
     stopCloudWorkerConfirmAction: "Stop worker",
+    cloudWorkerStopResult: 'Cloud worker for "{session}" is {state}.',
     deleteSessionMenu: "Delete…",
     deleteSessionCount: "Delete {count}…",
     deleteSessionConfirm: 'Delete "{session}" and its transcript?',

--- a/ui/src/pages/new-session/cloud-recovery-state.test.ts
+++ b/ui/src/pages/new-session/cloud-recovery-state.test.ts
@@ -1,9 +1,37 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { PendingCloudRecoveryState } from "./cloud-recovery-state.ts";
-import { readCloudSessionRecovery } from "./cloud-recovery.ts";
+import {
+  PendingCloudRecoveryState,
+  resolveSubmissionOutcomeReason,
+} from "./cloud-recovery-state.ts";
+import { readCloudSessionRecovery, writeCloudSessionRecovery } from "./cloud-recovery.ts";
 
 describe("pending cloud recovery state", () => {
   beforeEach(() => sessionStorage.clear());
+
+  it.each([
+    {
+      name: "a replacement Gateway",
+      gatewayIdentityChanged: true,
+      cloudDraftOwned: true,
+      expected: "gateway-changed",
+    },
+    {
+      name: "a normal local submission",
+      gatewayIdentityChanged: false,
+      cloudDraftOwned: false,
+      expected: "gateway-changed",
+    },
+    {
+      name: "an interrupted cloud draft",
+      gatewayIdentityChanged: false,
+      cloudDraftOwned: true,
+      expected: "cloud-interrupted",
+    },
+  ])("classifies $name accurately", ({ expected, gatewayIdentityChanged, cloudDraftOwned }) => {
+    expect(resolveSubmissionOutcomeReason({ gatewayIdentityChanged, cloudDraftOwned })).toBe(
+      expected,
+    );
+  });
 
   it("stages an idempotent create before the Gateway request", () => {
     const pending = new PendingCloudRecoveryState();
@@ -129,5 +157,36 @@ describe("pending cloud recovery state", () => {
     });
     expect(captured?.attachments).not.toBe(pending.attachments);
     expect(captured?.createParams).not.toBe(pending.createParams);
+  });
+
+  it("neutralizes a stale local owner without clearing newer durable recovery", () => {
+    const pending = new PendingCloudRecoveryState();
+    expect(
+      pending.stageCreate({
+        agentId: "cloud",
+        profileId: "aws",
+        message: "stale task",
+        gatewayUrl: "ws://gateway.example",
+        recoveryScope: "principal-a",
+        createParams: { agentId: "cloud", message: "", worktree: true },
+      }),
+    ).not.toBeNull();
+    const staleKey = pending.sessionKey;
+    const newerRecovery = {
+      sessionKey: "agent:cloud:newer",
+      messageId: "message-newer",
+      message: "newer task",
+      profileId: "aws",
+      agentId: "cloud",
+      gatewayUrl: "ws://gateway.example",
+      recoveryScope: "principal-a",
+      phase: "dispatching" as const,
+    };
+    expect(writeCloudSessionRecovery(newerRecovery)).toBe(true);
+
+    pending.clearFor("ws://gateway.example", "principal-a", staleKey);
+
+    expect(pending.sessionKey).toBe("");
+    expect(readCloudSessionRecovery("ws://gateway.example", "principal-a")).toEqual(newerRecovery);
   });
 });

--- a/ui/src/pages/new-session/cloud-recovery-state.ts
+++ b/ui/src/pages/new-session/cloud-recovery-state.ts
@@ -9,6 +9,17 @@ import {
   writeCloudSessionRecovery,
 } from "./cloud-recovery.ts";
 
+export type SubmissionOutcomeReason = "gateway-changed" | "cloud-interrupted";
+
+export function resolveSubmissionOutcomeReason(params: {
+  gatewayIdentityChanged: boolean;
+  cloudDraftOwned: boolean;
+}): SubmissionOutcomeReason {
+  return params.gatewayIdentityChanged || !params.cloudDraftOwned
+    ? "gateway-changed"
+    : "cloud-interrupted";
+}
+
 export function resolveScope(
   snapshot: {
     client: { recoveryScope?: string; recoveryScopeReady?: boolean } | null;

--- a/ui/src/pages/new-session/cloud-recovery-state.ts
+++ b/ui/src/pages/new-session/cloud-recovery-state.ts
@@ -65,6 +65,8 @@ export class PendingCloudRecoveryState {
     }
   }
 
+  // Concurrent same-key replacement pages may double-clear recovery; that rare multi-tab flow is
+  // accepted in favor of ownership based only on gateway URL, recovery scope, and session key.
   owns(gatewayUrl: string, recoveryScope: string, sessionKey: string): boolean {
     return (
       this.gatewayUrl === gatewayUrl &&

--- a/ui/src/pages/new-session/cloud-submit.test.ts
+++ b/ui/src/pages/new-session/cloud-submit.test.ts
@@ -54,7 +54,7 @@ describe("cloud draft advancement", () => {
         recoveryScope: "principal-a",
         recoveryPhase: "sending",
         recovering: true,
-        isCurrent: () => true,
+        isLifecycleCurrent: () => true,
         ownsRecovery: () => true,
         clearRecovery,
         setRecoveryPhase: vi.fn(),
@@ -97,7 +97,7 @@ describe("cloud draft advancement", () => {
         recoveryScope: "principal-a",
         recoveryPhase: "dispatching",
         recovering: false,
-        isCurrent: () => false,
+        isLifecycleCurrent: () => false,
         ownsRecovery: () => false,
         clearRecovery,
         setRecoveryPhase: vi.fn(),
@@ -116,18 +116,20 @@ describe("cloud draft advancement", () => {
   it.each([
     {
       name: "the page is interrupted after accepted delivery",
-      ownershipTaken: false,
+      lifecycleCurrent: false,
+      recoveryOwned: true,
       status: "interrupted",
       retirement: "interrupted",
     },
     {
       name: "a newer owner takes over",
-      ownershipTaken: true,
+      lifecycleCurrent: true,
+      recoveryOwned: false,
       status: "ownership-lost",
       retirement: "resolved",
     },
   ] as const)("retires only the completed submission when $name", async (testCase) => {
-    const { ownershipTaken, retirement, status } = testCase;
+    const { lifecycleCurrent, recoveryOwned, retirement, status } = testCase;
     const gatewayUrl = "ws://gateway.example";
     const recoveryScope = "principal-a";
     const sessionKey = "agent:cloud:stale";
@@ -145,12 +147,15 @@ describe("cloud draft advancement", () => {
       .fn()
       .mockResolvedValueOnce({ placement: { state: "active", environmentId: "environment-1" } })
       .mockImplementationOnce(async () => {
-        if (ownershipTaken) {
+        if (!recoveryOwned) {
           expect(writeCloudSessionRecovery(newerRecovery)).toBe(true);
         }
         return { runId: "run-stale", status: "started" };
       });
-    let currentChecks = 0;
+    // Both fences stay current through the helper's five safety checks. One
+    // independent fact changes before the caller classifies accepted delivery.
+    let lifecycleChecks = 0;
+    let ownershipChecks = 0;
     const clearRecovery = vi.fn(() =>
       clearCloudSessionRecovery(gatewayUrl, recoveryScope, sessionKey),
     );
@@ -167,23 +172,21 @@ describe("cloud draft advancement", () => {
         recoveryScope,
         recoveryPhase: "dispatching",
         recovering: false,
-        isCurrent: () => {
-          if (ownershipTaken) {
-            return true;
-          }
-          currentChecks += 1;
-          // The send helper accepts delivery on check five; its caller observes
-          // the tab invalidation immediately afterward.
-          return currentChecks < 6;
+        isLifecycleCurrent: () => {
+          lifecycleChecks += 1;
+          return lifecycleCurrent || lifecycleChecks < 6;
         },
-        ownsRecovery: () => !ownershipTaken,
+        ownsRecovery: () => {
+          ownershipChecks += 1;
+          return recoveryOwned || ownershipChecks < 6;
+        },
         clearRecovery,
         setRecoveryPhase: vi.fn(),
       }),
     ).resolves.toEqual({ status });
     expect(clearRecovery).toHaveBeenCalledWith(retirement);
     expect(readCloudSessionRecovery(gatewayUrl, recoveryScope)).toEqual(
-      ownershipTaken ? newerRecovery : null,
+      recoveryOwned ? null : newerRecovery,
     );
   });
 
@@ -203,7 +206,7 @@ describe("cloud draft advancement", () => {
         recoveryPhase: "dispatching",
         persistRecovery: false,
         recovering: false,
-        isCurrent: () => false,
+        isLifecycleCurrent: () => false,
         ownsRecovery: () => false,
         clearRecovery: vi.fn(),
         setRecoveryPhase: vi.fn(),
@@ -228,7 +231,7 @@ describe("cloud draft advancement", () => {
         recoveryScope: "principal-a",
         recoveryPhase: "dispatching",
         recovering: false,
-        isCurrent: () => false,
+        isLifecycleCurrent: () => false,
         ownsRecovery: () => false,
         clearRecovery,
         setRecoveryPhase: vi.fn(),
@@ -281,7 +284,7 @@ describe("cloud draft advancement", () => {
         recoveryScope: "principal-a",
         recoveryPhase: "sending",
         recovering: true,
-        isCurrent: () => true,
+        isLifecycleCurrent: () => true,
         ownsRecovery: () => true,
         clearRecovery,
         setRecoveryPhase: vi.fn(),
@@ -344,7 +347,7 @@ describe("cloud draft advancement", () => {
         recoveryScope: "principal-a",
         recoveryPhase: "sending",
         recovering: true,
-        isCurrent: () => true,
+        isLifecycleCurrent: () => true,
         ownsRecovery: () => true,
         clearRecovery,
         setRecoveryPhase: vi.fn(),
@@ -387,7 +390,7 @@ describe("cloud draft advancement", () => {
         recoveryScope: "principal-a",
         recoveryPhase: "sending",
         recovering: true,
-        isCurrent: () => true,
+        isLifecycleCurrent: () => true,
         ownsRecovery: () => true,
         clearRecovery,
         setRecoveryPhase: vi.fn(),
@@ -432,7 +435,7 @@ describe("cloud draft advancement", () => {
         recoveryScope: "principal-a",
         recoveryPhase: "dispatching",
         recovering: true,
-        isCurrent: () => true,
+        isLifecycleCurrent: () => true,
         ownsRecovery: () => true,
         clearRecovery,
         setRecoveryPhase: vi.fn(),

--- a/ui/src/pages/new-session/cloud-submit.test.ts
+++ b/ui/src/pages/new-session/cloud-submit.test.ts
@@ -114,9 +114,20 @@ describe("cloud draft advancement", () => {
   });
 
   it.each([
-    { name: "the page is interrupted after accepted delivery", ownershipTaken: false },
-    { name: "a newer owner takes over", ownershipTaken: true },
-  ])("retires only the completed submission when $name", async ({ ownershipTaken }) => {
+    {
+      name: "the page is interrupted after accepted delivery",
+      ownershipTaken: false,
+      status: "interrupted",
+      retirement: "interrupted",
+    },
+    {
+      name: "a newer owner takes over",
+      ownershipTaken: true,
+      status: "ownership-lost",
+      retirement: "resolved",
+    },
+  ] as const)("retires only the completed submission when $name", async (testCase) => {
+    const { ownershipTaken, retirement, status } = testCase;
     const gatewayUrl = "ws://gateway.example";
     const recoveryScope = "principal-a";
     const sessionKey = "agent:cloud:stale";
@@ -169,8 +180,8 @@ describe("cloud draft advancement", () => {
         clearRecovery,
         setRecoveryPhase: vi.fn(),
       }),
-    ).resolves.toEqual({ status: "ownership-lost" });
-    expect(clearRecovery).toHaveBeenCalledOnce();
+    ).resolves.toEqual({ status });
+    expect(clearRecovery).toHaveBeenCalledWith(retirement);
     expect(readCloudSessionRecovery(gatewayUrl, recoveryScope)).toEqual(
       ownershipTaken ? newerRecovery : null,
     );

--- a/ui/src/pages/new-session/cloud-submit.test.ts
+++ b/ui/src/pages/new-session/cloud-submit.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
+import {
+  clearCloudSessionRecovery,
+  readCloudSessionRecovery,
+  writeCloudSessionRecovery,
+} from "./cloud-recovery.ts";
 import { advanceCloudDraftSession } from "./cloud-submit.ts";
 
 function clientWith(request: ReturnType<typeof vi.fn>): Pick<GatewayBrowserClient, "request"> {
@@ -106,6 +111,69 @@ describe("cloud draft advancement", () => {
       ),
     ).toMatchObject({ sessionKey: "agent:cloud:newer" });
     expect(clearRecovery).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { name: "the page is interrupted after accepted delivery", ownershipTaken: false },
+    { name: "a newer owner takes over", ownershipTaken: true },
+  ])("retires only the completed submission when $name", async ({ ownershipTaken }) => {
+    const gatewayUrl = "ws://gateway.example";
+    const recoveryScope = "principal-a";
+    const sessionKey = "agent:cloud:stale";
+    const newerRecovery = {
+      sessionKey: "agent:cloud:newer",
+      messageId: "message-newer",
+      message: "newer task",
+      profileId: "aws",
+      agentId: "cloud",
+      gatewayUrl,
+      recoveryScope,
+      phase: "dispatching" as const,
+    };
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ placement: { state: "active", environmentId: "environment-1" } })
+      .mockImplementationOnce(async () => {
+        if (ownershipTaken) {
+          expect(writeCloudSessionRecovery(newerRecovery)).toBe(true);
+        }
+        return { runId: "run-stale", status: "started" };
+      });
+    let currentChecks = 0;
+    const clearRecovery = vi.fn(() =>
+      clearCloudSessionRecovery(gatewayUrl, recoveryScope, sessionKey),
+    );
+
+    await expect(
+      advanceCloudDraftSession({
+        client: clientWith(request),
+        key: sessionKey,
+        agentId: "cloud",
+        profileId: "aws",
+        message: "interrupted task",
+        messageId: "message-interrupted",
+        gatewayUrl,
+        recoveryScope,
+        recoveryPhase: "dispatching",
+        recovering: false,
+        isCurrent: () => {
+          if (ownershipTaken) {
+            return true;
+          }
+          currentChecks += 1;
+          // The send helper accepts delivery on check five; its caller observes
+          // the tab invalidation immediately afterward.
+          return currentChecks < 6;
+        },
+        ownsRecovery: () => !ownershipTaken,
+        clearRecovery,
+        setRecoveryPhase: vi.fn(),
+      }),
+    ).resolves.toEqual({ status: "ownership-lost" });
+    expect(clearRecovery).toHaveBeenCalledOnce();
+    expect(readCloudSessionRecovery(gatewayUrl, recoveryScope)).toEqual(
+      ownershipTaken ? newerRecovery : null,
+    );
   });
 
   it("does not persist volatile incognito recovery when submission is cancelled", async () => {

--- a/ui/src/pages/new-session/cloud-submit.ts
+++ b/ui/src/pages/new-session/cloud-submit.ts
@@ -17,7 +17,10 @@ type CloudDraftAdvanceResult =
   | { status: "cleanup-rejected"; error: string; messageId?: string }
   | { status: "dispatch-rejected"; error: string }
   | { status: "cancelled"; cleanupError?: string; recoveryPersisted: boolean }
+  | { status: "interrupted" }
   | { status: "ownership-lost" };
+
+export type CloudRecoveryRetirement = "resolved" | "interrupted";
 
 export async function advanceCloudDraftSession(params: {
   client: Pick<GatewayBrowserClient, "request">;
@@ -34,7 +37,7 @@ export async function advanceCloudDraftSession(params: {
   recovering: boolean;
   isCurrent: () => boolean;
   ownsRecovery: () => boolean;
-  clearRecovery: () => void;
+  clearRecovery: (retirement: CloudRecoveryRetirement) => void;
   setRecoveryPhase: (phase: CloudSessionRecovery["phase"]) => void;
 }): Promise<CloudDraftAdvanceResult> {
   const persistRecovery = params.persistRecovery !== false;
@@ -63,7 +66,7 @@ export async function advanceCloudDraftSession(params: {
       ? await deleteRecoveredCloudDraftSession(params.client, params.key, params.agentId)
       : await deleteCloudDraftSession(params.client, params.key, params.agentId);
     if (!cleanupError) {
-      params.clearRecovery();
+      params.clearRecovery("resolved");
     }
     return {
       status: "cancelled",
@@ -88,7 +91,7 @@ export async function advanceCloudDraftSession(params: {
       ? await deleteRecoveredCloudDraftSession(params.client, params.key, params.agentId)
       : await deleteCloudDraftSession(params.client, params.key, params.agentId);
     if (!cleanupError) {
-      params.clearRecovery();
+      params.clearRecovery("resolved");
     }
     return { status: "cancelled", cleanupError, recoveryPersisted };
   }
@@ -124,7 +127,7 @@ export async function advanceCloudDraftSession(params: {
   if (cloudStart.status === "cancelled") {
     const cleanupError = await deleteCloudDraftSession(params.client, params.key, params.agentId);
     if (!cleanupError) {
-      params.clearRecovery();
+      params.clearRecovery("resolved");
     }
     return { status: "cancelled", cleanupError, recoveryPersisted: persistRecovery };
   }
@@ -134,25 +137,25 @@ export async function advanceCloudDraftSession(params: {
   if (cloudStart.status === "send-not-started") {
     const cleanupError = await deleteCloudDraftSession(params.client, params.key, params.agentId);
     if (!cleanupError) {
-      params.clearRecovery();
+      params.clearRecovery("resolved");
     }
     return { status: "dispatch-rejected", error: cleanupError || cloudStart.error };
   }
   if (cloudStart.status === "send-definitive-rejected") {
     const cleanupError = await deleteCloudDraftSession(params.client, params.key, params.agentId);
     if (!cleanupError) {
-      params.clearRecovery();
+      params.clearRecovery("resolved");
     }
     return { status: "dispatch-rejected", error: cleanupError || cloudStart.error };
   }
   if (cloudStart.status === "session-missing") {
-    params.clearRecovery();
+    params.clearRecovery("resolved");
     return { status: "dispatch-rejected", error: cloudStart.error };
   }
   if (cloudStart.status === "dispatch-rejected") {
     const cleanupError = await deleteCloudDraftSession(params.client, params.key, params.agentId);
     if (!cleanupError) {
-      params.clearRecovery();
+      params.clearRecovery("resolved");
     }
     return {
       status: "dispatch-rejected",
@@ -162,12 +165,18 @@ export async function advanceCloudDraftSession(params: {
   if (cloudStart.status === "send-rejected") {
     return cloudStart;
   }
-  if (!params.isCurrent() || !params.ownsRecovery()) {
+  if (!params.ownsRecovery()) {
     // Delivery completed, so retire only this submission's recovery record.
     // The callback's expected-key guard preserves any newer owner.
-    params.clearRecovery();
+    params.clearRecovery("resolved");
     return { status: "ownership-lost" };
   }
-  params.clearRecovery();
+  if (!params.isCurrent()) {
+    // The page recorded why its lifecycle changed before this accepted send returned.
+    // Retire the delivered recovery without relabeling that interruption as a takeover.
+    params.clearRecovery("interrupted");
+    return { status: "interrupted" };
+  }
+  params.clearRecovery("resolved");
   return cloudStart;
 }

--- a/ui/src/pages/new-session/cloud-submit.ts
+++ b/ui/src/pages/new-session/cloud-submit.ts
@@ -163,8 +163,9 @@ export async function advanceCloudDraftSession(params: {
     return cloudStart;
   }
   if (!params.isCurrent() || !params.ownsRecovery()) {
-    // The worker is active, but ownership changed after the helper's final
-    // check. Keep recovery durable instead of orphaning it.
+    // Delivery completed, so retire only this submission's recovery record.
+    // The callback's expected-key guard preserves any newer owner.
+    params.clearRecovery();
     return { status: "ownership-lost" };
   }
   params.clearRecovery();

--- a/ui/src/pages/new-session/cloud-submit.ts
+++ b/ui/src/pages/new-session/cloud-submit.ts
@@ -35,12 +35,15 @@ export async function advanceCloudDraftSession(params: {
   recoveryPhase: CloudSessionRecovery["phase"];
   persistRecovery?: boolean;
   recovering: boolean;
-  isCurrent: () => boolean;
+  isLifecycleCurrent: () => boolean;
   ownsRecovery: () => boolean;
   clearRecovery: (retirement: CloudRecoveryRetirement) => void;
   setRecoveryPhase: (phase: CloudSessionRecovery["phase"]) => void;
 }): Promise<CloudDraftAdvanceResult> {
   const persistRecovery = params.persistRecovery !== false;
+  // Dispatch and send require both fences. After accepted delivery, inspect
+  // them separately so lifecycle interruption is not reported as takeover.
+  const isCurrentOwner = () => params.isLifecycleCurrent() && params.ownsRecovery();
   const recovery = {
     sessionKey: params.key,
     messageId: params.messageId,
@@ -56,7 +59,7 @@ export async function advanceCloudDraftSession(params: {
     params.recovering && persistRecovery
       ? readCloudSessionRecovery(params.gatewayUrl, params.recoveryScope)
       : null;
-  if (!params.isCurrent()) {
+  if (!isCurrentOwner()) {
     const recoveryPersisted = persistRecovery
       ? params.recovering
         ? existingRecovery?.sessionKey === params.key
@@ -79,7 +82,7 @@ export async function advanceCloudDraftSession(params: {
       ? existingRecovery?.sessionKey === params.key
       : writeCloudSessionRecovery(recovery)
     : true;
-  if (!params.isCurrent() || !recoveryPersisted) {
+  if (!isCurrentOwner() || !recoveryPersisted) {
     if (params.recovering && !recoveryPersisted) {
       return {
         status: "cancelled",
@@ -108,7 +111,7 @@ export async function advanceCloudDraftSession(params: {
       recovering: params.recovering,
       retryTerminalPlacement: params.recovering && params.recoveryPhase === "sending",
     },
-    params.isCurrent,
+    isCurrentOwner,
     () => {
       if (params.recoveryPhase === "sending") {
         return true;
@@ -165,17 +168,17 @@ export async function advanceCloudDraftSession(params: {
   if (cloudStart.status === "send-rejected") {
     return cloudStart;
   }
+  if (!params.isLifecycleCurrent()) {
+    // The page recorded why its lifecycle changed before this accepted send returned.
+    // Retire the delivered recovery without relabeling that interruption as a takeover.
+    params.clearRecovery("interrupted");
+    return { status: "interrupted" };
+  }
   if (!params.ownsRecovery()) {
     // Delivery completed, so retire only this submission's recovery record.
     // The callback's expected-key guard preserves any newer owner.
     params.clearRecovery("resolved");
     return { status: "ownership-lost" };
-  }
-  if (!params.isCurrent()) {
-    // The page recorded why its lifecycle changed before this accepted send returned.
-    // Retire the delivered recovery without relabeling that interruption as a takeover.
-    params.clearRecovery("interrupted");
-    return { status: "interrupted" };
   }
   params.clearRecovery("resolved");
   return cloudStart;

--- a/ui/src/pages/new-session/cloud-target.test.ts
+++ b/ui/src/pages/new-session/cloud-target.test.ts
@@ -235,6 +235,50 @@ describe("cloud session startup", () => {
     expect(request).toHaveBeenCalledTimes(5);
   });
 
+  it.each([
+    {
+      name: "destroys the last known worker",
+      cleanupError: undefined,
+      expectedError: "cloud worker placement could not be verified",
+    },
+    {
+      name: "reports a rejected worker cleanup",
+      cleanupError: "cleanup unavailable",
+      expectedError:
+        "cloud worker placement could not be verified; cleanup failed: cleanup unavailable",
+    },
+  ])("$name when placement lookups remain unavailable", async ({ cleanupError, expectedError }) => {
+    vi.useFakeTimers();
+    try {
+      const request = vi
+        .fn()
+        .mockResolvedValueOnce({
+          placement: { state: "provisioning", environmentId: "environment-unavailable" },
+        })
+        .mockRejectedValueOnce(new Error("lookup unavailable 1"))
+        .mockRejectedValueOnce(new Error("lookup unavailable 2"))
+        .mockRejectedValueOnce(new Error("lookup unavailable 3"))
+        .mockRejectedValueOnce(new Error("lookup unavailable 4"));
+      if (cleanupError) {
+        request.mockRejectedValueOnce(new Error(cleanupError));
+      } else {
+        request.mockResolvedValueOnce({ worker: { state: "destroyed" } });
+      }
+
+      const outcome = startCloudInitialTurn(clientWith(request), params, () => true);
+      await vi.runAllTimersAsync();
+
+      await expect(outcome).resolves.toEqual({ status: "cleanup-rejected", error: expectedError });
+      expect(request).toHaveBeenCalledTimes(6);
+      expect(request).toHaveBeenNthCalledWith(6, "environments.destroy", {
+        environmentId: "environment-unavailable",
+      });
+      expect(request).not.toHaveBeenCalledWith("sessions.abort", expect.anything());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps a still-provisioning placement recoverable after reconciliation times out", async () => {
     vi.useFakeTimers();
     try {

--- a/ui/src/pages/new-session/cloud-target.ts
+++ b/ui/src/pages/new-session/cloud-target.ts
@@ -122,17 +122,29 @@ async function resolveActivePlacement(
     }
     if (result.status === "unavailable") {
       lookupFailures += 1;
-      if (!isCurrent() || lookupFailures >= PLACEMENT_LOOKUP_FAILURE_LIMIT) {
-        if (!isCurrent() && lastKnownEnvironmentId) {
+      const submissionCancelled = !isCurrent();
+      if (submissionCancelled || lookupFailures >= PLACEMENT_LOOKUP_FAILURE_LIMIT) {
+        if (lastKnownEnvironmentId) {
+          // The last successful placement read still proves worker ownership.
+          // Destroy it before returning, or a lookup outage can orphan paid capacity.
           const cleanupError = await cancelActivePlacement(client, {
             key: params.key,
             agentId: params.agentId,
             environmentId: lastKnownEnvironmentId,
             abortRun: false,
           });
-          return cleanupError
-            ? { status: "cleanup-rejected", error: cleanupError }
-            : { status: "cancelled" };
+          if (submissionCancelled) {
+            return cleanupError
+              ? { status: "cleanup-rejected", error: cleanupError }
+              : { status: "cancelled" };
+          }
+          const placementError = "cloud worker placement could not be verified";
+          return {
+            status: "cleanup-rejected",
+            error: cleanupError
+              ? `${placementError}; cleanup failed: ${cleanupError}`
+              : placementError,
+          };
         }
         return {
           status: "cleanup-rejected",

--- a/ui/src/pages/new-session/new-session-page.test.ts
+++ b/ui/src/pages/new-session/new-session-page.test.ts
@@ -1,9 +1,19 @@
 import { render, type TemplateResult } from "lit";
 import { describe, expect, it } from "vitest";
+import type { PendingCloudRecoveryState, SubmissionOutcomeReason } from "./cloud-recovery-state.ts";
+import type { CloudRecoveryRetirement } from "./cloud-submit.ts";
 import "./new-session-page.ts";
 
 type TestNewSessionPage = {
+  pendingCloud: PendingCloudRecoveryState;
   renderDraftBlock(): TemplateResult;
+  submissionOutcomeUnknown: SubmissionOutcomeReason | null;
+  clearPendingCloudRecoveryFor(
+    gatewayUrl: string,
+    recoveryScope: string,
+    sessionKey: string,
+    retirement: CloudRecoveryRetirement,
+  ): void;
   showCloudDraftOwnershipLost(): void;
 };
 
@@ -19,6 +29,28 @@ describe("new session page outcomes", () => {
 
     expect(host.querySelector(".new-session-page__error")?.textContent).toContain(
       "Another window took over this cloud session. Check recent sessions before starting this task again.",
+    );
+  });
+
+  it("preserves an interrupted outcome when retiring accepted delivery", () => {
+    const page = document.createElement(
+      "openclaw-new-session-page",
+    ) as unknown as TestNewSessionPage;
+    const host = document.createElement("div");
+    const gatewayUrl = "ws://gateway.example";
+    const recoveryScope = "principal-a";
+    const sessionKey = "agent:cloud:interrupted";
+    page.pendingCloud.gatewayUrl = gatewayUrl;
+    page.pendingCloud.recoveryScope = recoveryScope;
+    page.pendingCloud.sessionKey = sessionKey;
+    page.submissionOutcomeUnknown = "cloud-interrupted";
+
+    page.clearPendingCloudRecoveryFor(gatewayUrl, recoveryScope, sessionKey, "interrupted");
+    render(page.renderDraftBlock(), host);
+
+    expect(page.pendingCloud.sessionKey).toBe("");
+    expect(host.querySelector(".new-session-page__error")?.textContent).toContain(
+      "This cloud session's setup was interrupted. Check recent sessions before starting this task again.",
     );
   });
 });

--- a/ui/src/pages/new-session/new-session-page.test.ts
+++ b/ui/src/pages/new-session/new-session-page.test.ts
@@ -1,0 +1,24 @@
+import { render, type TemplateResult } from "lit";
+import { describe, expect, it } from "vitest";
+import "./new-session-page.ts";
+
+type TestNewSessionPage = {
+  renderDraftBlock(): TemplateResult;
+  showCloudDraftOwnershipLost(): void;
+};
+
+describe("new session page outcomes", () => {
+  it("renders the ownership-lost cloud outcome", () => {
+    const page = document.createElement(
+      "openclaw-new-session-page",
+    ) as unknown as TestNewSessionPage;
+    const host = document.createElement("div");
+
+    page.showCloudDraftOwnershipLost();
+    render(page.renderDraftBlock(), host);
+
+    expect(host.querySelector(".new-session-page__error")?.textContent).toContain(
+      "Another window took over this cloud session. Check recent sessions before starting this task again.",
+    );
+  });
+});

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -39,7 +39,12 @@ import {
   discoverCloudProfiles,
   selectProfiles,
 } from "./cloud-profile-discovery.ts";
-import { PendingCloudRecoveryState, resolveScope } from "./cloud-recovery-state.ts";
+import {
+  PendingCloudRecoveryState,
+  resolveSubmissionOutcomeReason,
+  resolveScope,
+  type SubmissionOutcomeReason,
+} from "./cloud-recovery-state.ts";
 import { advanceCloudDraftSession } from "./cloud-submit.ts";
 import {
   NewSessionComposerTextareaController,
@@ -96,7 +101,7 @@ class NewSessionPage extends OpenClawLightDomElement {
   @state() private cloudProfileId = "";
   @state() private message = "";
   @state() private submitting = false;
-  @state() private submissionOutcomeUnknown = false;
+  @state() private submissionOutcomeUnknown: SubmissionOutcomeReason | null = null;
   @state() private error: string | null = null;
   @state() private catalogRetrying = false;
   @state() private browserLoading = false;
@@ -279,7 +284,14 @@ class NewSessionPage extends OpenClawLightDomElement {
       this.visibility = "normal";
     }
     if (gatewayUrlChanged || identityChanged || connectionChanged || recoveryScope.changed) {
-      this.invalidateGatewayDiscovery(gatewayUrlChanged || recoveryScope.changed);
+      const gatewayIdentityChanged = gatewayUrlChanged || recoveryScope.changed;
+      this.invalidateGatewayDiscovery(
+        gatewayIdentityChanged,
+        resolveSubmissionOutcomeReason({
+          gatewayIdentityChanged,
+          cloudDraftOwned: Boolean(this.pendingCloud.sessionKey),
+        }),
+      );
     }
     if (
       firstBind ||
@@ -294,7 +306,7 @@ class NewSessionPage extends OpenClawLightDomElement {
           this.pendingCloud.recoveryScope !== this.gatewayRecoveryScope)
       ) {
         this.pendingCloud.reset();
-        this.submissionOutcomeUnknown = false;
+        this.submissionOutcomeUnknown = null;
       }
       if (connected && snapshot.client?.recoveryScopeReady) {
         this.restorePendingCloudRecovery(this.gatewayUrl, this.gatewayRecoveryScope);
@@ -308,7 +320,10 @@ class NewSessionPage extends OpenClawLightDomElement {
     }
   }
 
-  private invalidateGatewayDiscovery(resetHostSelection: boolean) {
+  private invalidateGatewayDiscovery(
+    resetHostSelection: boolean,
+    submissionOutcome: SubmissionOutcomeReason,
+  ) {
     this.nodesRequestToken += 1;
     this.nodesHydrated = false;
     this.gatewayName = "";
@@ -323,14 +338,14 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.attachmentDraft.abortReads();
     this.closeBrowser();
     this.cancelRestoredFolderValidation();
-    this.invalidateSubmission(true); // Transport loss makes an in-flight create outcome unknowable.
+    this.invalidateSubmission(submissionOutcome);
     if (!resetHostSelection) {
       return;
     }
     if (this.pendingCloud.sessionKey) {
       // Keep the original Gateway identity so a failed teardown cannot hide a worker elsewhere.
       this.pendingCloud.retryAllowed = false;
-      this.submissionOutcomeUnknown = true;
+      this.submissionOutcomeUnknown = submissionOutcome;
     }
     // A replacement client may target another Gateway. Keep the user's task,
     // but retire every selection and discovery result owned by the old host.
@@ -446,7 +461,13 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.subscriptions.clear();
     // This invalidates submitRequestToken before payload release below, so a
     // late sessions.create result cannot navigate with attachments we no longer own.
-    this.invalidateGatewayDiscovery(true);
+    this.invalidateGatewayDiscovery(
+      true,
+      resolveSubmissionOutcomeReason({
+        gatewayIdentityChanged: false,
+        cloudDraftOwned: Boolean(this.pendingCloud.sessionKey),
+      }),
+    );
     this.gatewaySource = null;
     this.gatewayClient = null;
     this.gatewayConnected = false;
@@ -753,7 +774,9 @@ class NewSessionPage extends OpenClawLightDomElement {
   private resetDraft() {
     const preservePendingCloud = Boolean(this.pendingCloud.sessionKey);
     this.invalidateSubmission();
-    this.submissionOutcomeUnknown = preservePendingCloud;
+    this.submissionOutcomeUnknown = preservePendingCloud
+      ? (this.submissionOutcomeUnknown ?? "cloud-interrupted")
+      : null;
     this.agentSelectedByUser = false;
     this.folder = "";
     this.folderSelectedByUser = false;
@@ -796,17 +819,21 @@ class NewSessionPage extends OpenClawLightDomElement {
     });
   }
 
-  private invalidateSubmission(outcomeUnknown = false) {
+  private invalidateSubmission(outcomeUnknown: SubmissionOutcomeReason | null = null) {
     this.submitRequestToken += 1;
     if (outcomeUnknown && this.submitting) {
-      this.submissionOutcomeUnknown = true;
+      this.submissionOutcomeUnknown = outcomeUnknown;
     }
     this.submitting = false;
   }
 
   private clearPendingCloudRecovery() {
     this.pendingCloud.clear();
-    this.submissionOutcomeUnknown = false;
+    this.submissionOutcomeUnknown = null;
+  }
+
+  private showCloudDraftOwnershipLost() {
+    this.error = t("newSession.cloudOwnershipLost");
   }
 
   private clearPendingCloudRecoveryFor(
@@ -816,7 +843,7 @@ class NewSessionPage extends OpenClawLightDomElement {
   ) {
     this.pendingCloud.clearFor(gatewayUrl, recoveryScope, sessionKey);
     if (!this.pendingCloud.sessionKey) {
-      this.submissionOutcomeUnknown = false;
+      this.submissionOutcomeUnknown = null;
     }
   }
 
@@ -1271,7 +1298,9 @@ class NewSessionPage extends OpenClawLightDomElement {
           }
           if (cloudStart.cleanupError) {
             this.pendingCloud.retryAllowed = cloudStart.recoveryPersisted;
-            this.submissionOutcomeUnknown = !cloudStart.recoveryPersisted;
+            this.submissionOutcomeUnknown = cloudStart.recoveryPersisted
+              ? null
+              : "cloud-interrupted";
             this.error = t("newSession.cloudStartFailed", { error: cloudStart.cleanupError });
           } else if (!cloudStart.recoveryPersisted) {
             this.error = t("newSession.createFailed");
@@ -1289,7 +1318,7 @@ class NewSessionPage extends OpenClawLightDomElement {
           }
           const retryAllowed = requestId === this.submitRequestToken;
           this.pendingCloud.retryAllowed = retryAllowed;
-          this.submissionOutcomeUnknown = !retryAllowed;
+          this.submissionOutcomeUnknown = retryAllowed ? null : "cloud-interrupted";
           this.message = this.pendingCloud.message;
           this.error = t("newSession.cloudStartFailed", { error: cloudStart.error });
           return;
@@ -1301,6 +1330,7 @@ class NewSessionPage extends OpenClawLightDomElement {
           return;
         }
         if (cloudStart.status === "ownership-lost") {
+          this.showCloudDraftOwnershipLost();
           return;
         }
         if (cloudStart.status === "send-rejected") {
@@ -1767,7 +1797,13 @@ class NewSessionPage extends OpenClawLightDomElement {
         ${worktreeNameInvalid ? renderDraftError(t("newSession.worktreeNameInvalid")) : nothing}
         ${this.error ? renderDraftError(this.error) : nothing}
         ${this.submissionOutcomeUnknown
-          ? renderDraftError(t("newSession.createOutcomeUnknown"))
+          ? renderDraftError(
+              t(
+                this.submissionOutcomeUnknown === "gateway-changed"
+                  ? "newSession.createOutcomeUnknown"
+                  : "newSession.cloudSetupInterrupted",
+              ),
+            )
           : nothing}
         ${renderNewSessionDraftComposer({
           agent: this.selectedAgent(),

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -45,7 +45,7 @@ import {
   resolveScope,
   type SubmissionOutcomeReason,
 } from "./cloud-recovery-state.ts";
-import { advanceCloudDraftSession } from "./cloud-submit.ts";
+import { advanceCloudDraftSession, type CloudRecoveryRetirement } from "./cloud-submit.ts";
 import {
   NewSessionComposerTextareaController,
   renderDraftError,
@@ -840,10 +840,13 @@ class NewSessionPage extends OpenClawLightDomElement {
     gatewayUrl: string,
     recoveryScope: string,
     sessionKey: string,
+    retirement: CloudRecoveryRetirement,
   ) {
+    const submissionOutcome = this.submissionOutcomeUnknown;
     this.pendingCloud.clearFor(gatewayUrl, recoveryScope, sessionKey);
     if (!this.pendingCloud.sessionKey) {
-      this.submissionOutcomeUnknown = null;
+      this.submissionOutcomeUnknown =
+        retirement === "interrupted" ? (submissionOutcome ?? "cloud-interrupted") : null;
     }
   }
 
@@ -1280,11 +1283,12 @@ class NewSessionPage extends OpenClawLightDomElement {
           recovering: pendingCloud,
           isCurrent: isSubmissionCurrent,
           ownsRecovery: ownsSubmissionRecovery,
-          clearRecovery: () =>
+          clearRecovery: (retirement) =>
             this.clearPendingCloudRecoveryFor(
               submissionGatewayUrl,
               submissionRecoveryScope,
               result.key,
+              retirement,
             ),
           setRecoveryPhase: (phase) => {
             if (ownsSubmissionRecovery()) {
@@ -1327,6 +1331,9 @@ class NewSessionPage extends OpenClawLightDomElement {
           this.error = t("newSession.cloudStartFailed", {
             error: cloudStart.error || t("newSession.createFailed"),
           });
+          return;
+        }
+        if (cloudStart.status === "interrupted") {
           return;
         }
         if (cloudStart.status === "ownership-lost") {

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -1230,14 +1230,13 @@ class NewSessionPage extends OpenClawLightDomElement {
       let recoveryOwnerKey = submissionCloudRecovery?.sessionKey ?? "";
       const ownsSubmissionRecovery = () =>
         this.pendingCloud.owns(submissionGatewayUrl, submissionRecoveryScope, recoveryOwnerKey);
-      const isSubmissionCurrent = () =>
+      const isSubmissionLifecycleCurrent = () =>
         this.isConnected &&
         submissionClient.recoveryScopeReady &&
         requestId === this.submitRequestToken &&
         this.gatewayClient === submissionClient &&
         this.gatewayUrl === submissionGatewayUrl &&
-        this.gatewayRecoveryScope === submissionRecoveryScope &&
-        ownsSubmissionRecovery();
+        this.gatewayRecoveryScope === submissionRecoveryScope;
       const result =
         pendingCloud && this.pendingCloud.phase !== "creating"
           ? { key: this.pendingCloud.sessionKey, initialRun: { status: "idle" as const } }
@@ -1259,7 +1258,11 @@ class NewSessionPage extends OpenClawLightDomElement {
           submissionCloudRecovery.phase === "creating"
             ? "dispatching"
             : submissionCloudRecovery.phase;
-        if (submissionCloudRecovery.phase === "creating" && isSubmissionCurrent()) {
+        if (
+          submissionCloudRecovery.phase === "creating" &&
+          isSubmissionLifecycleCurrent() &&
+          ownsSubmissionRecovery()
+        ) {
           if (!this.pendingCloud.promoteToDispatching(result.key)) {
             this.error = t("newSession.cloudStartFailed", {
               error: "cloud recovery storage is unavailable",
@@ -1281,7 +1284,7 @@ class NewSessionPage extends OpenClawLightDomElement {
           recoveryPhase,
           persistRecovery: this.pendingCloud.persistent,
           recovering: pendingCloud,
-          isCurrent: isSubmissionCurrent,
+          isLifecycleCurrent: isSubmissionLifecycleCurrent,
           ownsRecovery: ownsSubmissionRecovery,
           clearRecovery: (retirement) =>
             this.clearPendingCloudRecoveryFor(

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -694,6 +694,49 @@ describe("sessions page lifecycle", () => {
     expect(page.sessionMutationPending).toBe(false);
   });
 
+  it("destroys a pending cloud worker and reports its terminal state", async () => {
+    const request = vi.fn(() =>
+      Promise.resolve({ status: "unavailable", worker: { state: "destroyed" } }),
+    );
+    const list = vi.fn(async () => ({ count: 0, sessions: [] }) as unknown as SessionsListResult);
+    const sessions = createSessions({ list });
+    const { gateway } = createGateway({ request } as unknown as GatewayBrowserClient);
+    const page = await createPage(createContext(gateway, sessions));
+    const toast = document.createElement("openclaw-toast-host");
+    document.body.append(toast);
+    await toast.updateComplete;
+    const row = {
+      key: "agent:main:cloud",
+      label: "Cloud task",
+      placement: {
+        state: "provisioning",
+        generation: 1,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+        stateChangedAtMs: 1,
+        environmentId: "environment-1",
+      },
+      hasActiveRun: true,
+    } as GatewaySessionRow;
+    vi.mocked(showConfirmDialog).mockResolvedValue(true);
+
+    await page.stopCloudWorker(row);
+
+    expect(showConfirmDialog).toHaveBeenCalledWith({
+      message: 'Stop the cloud worker for "Cloud task"?',
+      confirmLabel: "Stop worker",
+      danger: true,
+    });
+    expect(request).toHaveBeenCalledWith("environments.destroy", {
+      environmentId: "environment-1",
+    });
+    expect(list).toHaveBeenCalledOnce();
+    expect(toast.querySelector(".app-toast__message")?.textContent).toBe(
+      'Cloud worker for "Cloud task" is destroyed.',
+    );
+    expect(page.sessionMutationPending).toBe(false);
+  });
+
   it("surfaces a rejected custom-group creation on the Sessions page", async () => {
     const groupsPut = vi.fn(async () => {
       throw new Error("group name exceeds 512 characters");

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -13,6 +13,10 @@ import { selectApplicationSession } from "../../app/agent-selection.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { hasOperatorWriteAccess } from "../../app/operator-access.ts";
 import { renderAgentScopeControl } from "../../components/agent-scope-control.ts";
+import {
+  requestCloudWorkerStop,
+  resolveCloudWorkerStopAction,
+} from "../../components/cloud-worker-stop.ts";
 import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import { fetchSessionMenuWork } from "../../components/session-menu-work.ts";
 import type {
@@ -21,7 +25,6 @@ import type {
   SessionMenuWork,
 } from "../../components/session-menu.ts";
 import "../../components/session-menu.ts";
-import { isStoppableCloudWorkerPlacement } from "../../components/session-row-badges.ts";
 import { renderSessionsHubHeader } from "../../components/sessions-hub-header.ts";
 import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
@@ -461,10 +464,10 @@ class SessionsPage extends OpenClawLightDomElement {
       method: "sessions.create",
       params: { parentSessionKey: row.key, fork: true },
     });
-    const reclaimReason = this.mutationDisabledReason({
-      method: "sessions.reclaim",
-      requiredScope: "operator.admin",
-    });
+    const cloudWorkerStopAction = resolveCloudWorkerStopAction(row.placement);
+    const cloudWorkerStopReason = cloudWorkerStopAction
+      ? this.mutationDisabledReason(cloudWorkerStopAction)
+      : undefined;
     const deleteReason = this.mutationDisabledReason({
       method: "sessions.delete",
       params: { key: row.key, ...(row.archived === true ? { archivedOnly: true } : {}) },
@@ -482,7 +485,7 @@ class SessionsPage extends OpenClawLightDomElement {
         : {}),
       ...(groupReason || patchReason ? { "new-group": groupReason ?? patchReason } : {}),
       ...(forkReason ? { fork: forkReason } : {}),
-      ...(reclaimReason ? { "stop-cloud-worker": reclaimReason } : {}),
+      ...(cloudWorkerStopReason ? { "stop-cloud-worker": cloudWorkerStopReason } : {}),
       ...(deleteReason ? { delete: deleteReason } : {}),
     };
   }
@@ -967,7 +970,8 @@ class SessionsPage extends OpenClawLightDomElement {
 
   private async stopCloudWorker(row: GatewaySessionRow) {
     const label = normalizeOptionalString(row.label) ?? row.key;
-    if (!isStoppableCloudWorkerPlacement(row.placement) || row.hasActiveRun === true) {
+    const stopAction = resolveCloudWorkerStopAction(row.placement);
+    if (!stopAction || (stopAction.method === "sessions.reclaim" && row.hasActiveRun === true)) {
       return;
     }
     const scope = this.captureRequestScope();
@@ -979,24 +983,25 @@ class SessionsPage extends OpenClawLightDomElement {
         danger: true,
       })) ||
       !this.isRequestScopeCurrent(scope) ||
-      !this.requireMutationAccess(scope, {
-        method: "sessions.reclaim",
-        requiredScope: "operator.admin",
-      })
+      !this.requireMutationAccess(scope, stopAction)
     ) {
       return;
     }
-    const agentId = parseAgentSessionKey(row.key)?.agentId;
     this.sessionMutationPending = true;
     try {
-      await scope.client.request(
-        "sessions.reclaim",
-        {
-          key: row.key,
-          ...(agentId ? { agentId } : {}),
-        },
-        { timeoutMs: 10 * 60_000 },
-      );
+      const agentId = parseAgentSessionKey(row.key)?.agentId;
+      const result = await requestCloudWorkerStop(scope.client, stopAction, {
+        key: row.key,
+        ...(agentId ? { agentId } : {}),
+      });
+      if (result && this.isRequestScopeCurrent(scope)) {
+        showToast({
+          message: t("sessionsView.cloudWorkerStopResult", {
+            session: label,
+            state: result.worker?.state ?? result.status,
+          }),
+        });
+      }
       if (this.isRequestScopeCurrent(scope)) {
         await this.loadSessions();
       }
@@ -1404,6 +1409,12 @@ class SessionsPage extends OpenClawLightDomElement {
         hello: gateway.hello,
       }),
     );
+    const cloudWorkerStopAction = resolveCloudWorkerStopAction(row.placement);
+    const cloudWorkerStopAllowed = Boolean(
+      cloudWorkerStopAction &&
+      (cloudWorkerStopAction.method !== "sessions.reclaim" || row.hasActiveRun !== true) &&
+      isGatewayMethodAdvertised(gateway, cloudWorkerStopAction.method) === true,
+    );
     return html`
       <openclaw-session-menu
         .session=${{
@@ -1420,9 +1431,7 @@ class SessionsPage extends OpenClawLightDomElement {
         .actionDisabledReasons=${this.sessionMenuActionDisabledReasons(row)}
         .forkDisabled=${row.modelSelectionLocked === true}
         .archiveAllowed=${archiveAllowed}
-        .cloudWorkerStopAllowed=${isStoppableCloudWorkerPlacement(row.placement) &&
-        row.hasActiveRun !== true &&
-        isGatewayMethodAdvertised(gateway, "sessions.reclaim") === true}
+        .cloudWorkerStopAllowed=${cloudWorkerStopAllowed}
         .groups=${this.knownCategories()}
         .canOpenChat=${row.kind !== "global"}
         .work=${this.sessionMenuWork}

--- a/ui/src/test-helpers/app-sidebar-cases/sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sessions.ts
@@ -523,6 +523,53 @@ describe("AppSidebar session mutation feedback", () => {
     await waitForFast(() => expect(harness.refreshReplacement).toHaveBeenCalledWith("main"));
   });
 
+  it("destroys a pending cloud worker through its session", async () => {
+    const request = vi.fn(() =>
+      Promise.resolve({ status: "unavailable", worker: { state: "destroyed" } }),
+    );
+    const { gateway, harness, sidebar } = await mountMutationHarness({
+      request,
+    } as unknown as GatewayBrowserClient);
+    gateway.publish({
+      hello: {
+        features: { methods: ["environments.destroy"] },
+      } as ApplicationGatewaySnapshot["hello"],
+    });
+    const state = createSessionState("main", ["agent:main:main", "agent:main:a"]);
+    const row = state.result?.sessions.find((candidate) => candidate.key === "agent:main:a");
+    if (!row) {
+      throw new Error("expected cloud session row");
+    }
+    row.placement = {
+      state: "provisioning",
+      generation: 1,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      stateChangedAtMs: 1,
+      environmentId: "environment-1",
+    };
+    row.hasActiveRun = true;
+    harness.publishList({ result: state.result, agentId: state.agentId });
+    const toast = await mountToastHost();
+    await sidebar.updateComplete;
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    const menu = await openSessionMenu(sidebar, row.key);
+    menu.querySelector<HTMLElement>('[value="stop-cloud-worker"]')?.click();
+
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+    expect(confirm).toHaveBeenCalledWith('Stop the cloud worker for "a"?');
+    expect(request).toHaveBeenCalledWith("environments.destroy", {
+      environmentId: "environment-1",
+    });
+    await waitForFast(() => expect(harness.refreshReplacement).toHaveBeenCalledWith("main"));
+    await waitForFast(() =>
+      expect(toast.querySelector(".app-toast__message")?.textContent).toBe(
+        'Cloud worker for "a" is destroyed.',
+      ),
+    );
+  });
+
   it("shows and dismisses a fixed sidebar error when a session patch is rejected", async () => {
     const { harness, sidebar } = await mountMutationHarness();
     harness.patch.mockRejectedValueOnce(new Error("rename rejected by Gateway"));


### PR DESCRIPTION
Refs #120953

## What Problem This Solves

Fixes four dead ends in the Control UI cloud new-session flow: transient placement lookup failures could leave paid workers orphaned, recovery ownership changes could fail silently and replay a stale send, interrupted tab navigation could incorrectly blame a Gateway change, and pending cloud placements with a live environment had no stop-worker action.

## Why This Change Was Made

The UI now cleans up the last known environment before rejecting an ambiguous placement lookup, retires only the current submission's recovery state when another window takes ownership, records the actual interruption reason for recovery messaging, and routes stop-worker actions through the placement owner: active placements use `sessions.reclaim`, while pending placements with an environment use unforced `environments.destroy`.

This PR is limited to the Control UI. The two Gateway issues described in #120953 are intentionally excluded and remain owned by the sibling Gateway branch. AI-assisted; no agent transcript is included.

## User Impact

Cloud sessions now leave a visible, accurate outcome instead of silently replaying work or blaming an unrelated Gateway change. Users can also stop paid workers that are stuck before the active state, while active workers keep the existing reclaim behavior and confirmation flow.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/new-session/ ui/src/e2e/mcp-app-conformance.e2e.test.ts ui/src/e2e/control-ui-auth-transports.e2e.test.ts ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts src/gateway/server-chat-metadata-lifecycle.test.ts src/gateway/server-methods/chat-metadata-runtime.test.ts`: gateway 23 tests passed; UI 8,086 passed and 46 skipped; browser E2E 10 tests passed. The first broad UI pass exposed an order-sensitive `ui/src/app/overlays.test.ts` failure; its isolated rerun passed 47/47 and the required aggregate retry passed.
- Touched files passed `node scripts/run-oxlint.mjs` with no findings.
- `pnpm ui:i18n:baseline` verified 97 raw-copy baseline entries and 4,615 source keys with no baseline diff.
- `git diff --check` passed.
- Final autoreview reported one P2 request to retain same-key replacement recovery across remounts. That finding is consciously rejected under the named multi-tab tradeoff below because it requires restoring the removed lease/successor ownership design or adding a new persisted tombstone contract.

## Reduced ownership model and land-onto-red repair

The pre-existing `main` Control UI E2E breakage came from #120926 eagerly running the `chat.metadata` catch-up refresh during minimal Gateway startup. On that path, the roughly 120-second model-catalog build blocked startup. This PR includes the land-onto-red repair: minimal metadata startup stays lazy, so the catch-up refresh no longer blocks the startup path.

Cloud recovery now uses the simpler ownership identity of Gateway URL, recovery scope, and session key. The realm-local lease/successor-token design was removed after repeated reset/remount races. The accepted tradeoff is that concurrent same-key replacement pages may both clear recovery in the rare multi-tab flow; preserving that edge is not worth reintroducing the ownership machinery.
