### PR TITLE
fix(release): normalize backport PR suffixes

### DIFF
--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -684,7 +684,7 @@ export function contributionRecordTarget(section) {
 }
 
 export function pullRequestTitleFromCommitSubject(subject, number) {
-  const match = subject.match(/^(?<title>\S(?:.*?\S)?)(?<pr> \(#(?<number>[1-9]\d*)\))\k<pr>*$/u);
+  const match = subject.match(/^(?<title>\S(?:.*\S)?)(?<! \(#\d+\)) \(#(?<number>[1-9]\d*)\)$/u);
   return match?.groups?.number === String(number) ? match.groups.title : undefined;
 }
 
@@ -839,7 +839,7 @@ function appendReferences(references, additions) {
 
 function normalizedCommitSubject(subject) {
   return subject
-    .replace(/\s+\(#\d+\)\s*$/, "")
+    .replace(/(?:\s+\(#\d+\))+\s*$/, "")
     .replace(/\s+/g, " ")
     .trim()
     .toLowerCase();

--- a/test/scripts/verify-release-notes.test.ts
+++ b/test/scripts/verify-release-notes.test.ts
@@ -58,13 +58,13 @@ describe("release-note verification", () => {
   });
 
   it("accepts only canonical commit PR suffixes", () => {
+    const repeated = "Fix status (#102147) (#102147)";
+    const distinct = "Fix status (#120582) (#120584)";
     expect(pullRequestTitleFromCommitSubject("Fix status (#102147)", 102147)).toBe("Fix status");
-    expect(pullRequestTitleFromCommitSubject("Fix status (#102147) (#102147)", 102147)).toBe(
-      "Fix status",
-    );
+    expect(pullRequestTitleFromCommitSubject(repeated, 102147)).toBeUndefined();
+    expect(pullRequestTitleFromCommitSubject(distinct, 120584)).toBeUndefined();
     expect(pullRequestTitleFromCommitSubject("Fix status(#102147)", 102147)).toBeUndefined();
     expect(pullRequestTitleFromCommitSubject("Fix status (#0102147)", 102147)).toBeUndefined();
-    expect(pullRequestTitleFromCommitSubject("Fix status (#0)", 0)).toBeUndefined();
     expect(pullRequestTitleFromCommitSubject(" Fix status (#102147)", 102147)).toBeUndefined();
     expect(pullRequestTitleFromCommitSubject("Fix status (#102147) ", 102147)).toBeUndefined();
     expect(pullRequestTitleFromCommitSubject("Fix status (#102148)", 102147)).toBeUndefined();
@@ -481,6 +481,12 @@ describe("release-note verification", () => {
         },
       ]),
     ).toEqual([mainCommit.hash]);
+    const backportSubject = "fix(gateway): retain work admission across hosted wizard steps";
+    mainCommit.subject = `${backportSubject} (#120582)`;
+    integratedBackport.subject = `${mainCommit.subject} (#120584)`;
+    expect(canonicalMainCommitMatches(integratedBackport, [mainCommit])).toEqual([mainCommit.hash]);
+    const malformed = { ...integratedBackport, subject: `${backportSubject}(#120582) (#120584)` };
+    expect(canonicalMainCommitMatches(malformed, [mainCommit])).toEqual([]);
     expect(canonicalPullRequests([456], [123])).toEqual([123]);
   });
 


### PR DESCRIPTION
Related: #120948

## What Problem This Solves

Fixes an issue where release-note verification could not match a canonical main commit to its release backport after GitHub appended both the original and release PR suffixes to the backport merge subject.

The concrete beta history is main PR #120582 (`... (#120582)`) and release PR #120584 (`... (#120582) (#120584)`).

## Why This Change Was Made

Canonical commit comparison now strips one or more whitespace-delimited terminal PR suffixes. Vanished-PR title recovery remains deliberately stricter and rejects stacked suffixes instead of treating an earlier PR suffix as part of the title.

## User Impact

Release maintainers can verify canonical main/backport provenance for stacked GitHub PR suffixes without weakening title recovery or adding manual provenance for this deterministic case.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/verify-release-notes.test.ts` (32/32, including post-rebase exact head)
- `pnpm format .agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs test/scripts/verify-release-notes.test.ts`
- `git diff --check origin/main...HEAD`
- independent exact-diff review: no findings; best-fix verdict
- production delta: `+2/-2` (net 0); tests: `+10/-4`
