### PR TITLE
refactor(plugin-sdk): remove unused lazy fallback

### DIFF
--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -564,8 +564,7 @@ type CreatedChannelPluginBase<TResolvedAccount> = Pick<
 /**
  * Canonical entry helper for channel plugins.
  *
- * This shares `definePluginEntry(...)`'s lazy schema primitive, registers the
- * channel capability, and optionally exposes extra full-runtime registration
+ * Registers the channel capability and optionally exposes full-runtime hooks
  * such as tools or gateway handlers outside setup-only registration modes.
  */
 export function defineChannelPluginEntry<TPlugin>({

--- a/src/plugin-sdk/lazy-value.test.ts
+++ b/src/plugin-sdk/lazy-value.test.ts
@@ -1,6 +1,4 @@
-/**
- * Tests cached lazy value getter behavior and fallback handling.
- */
+/** Tests cached lazy value getter memoization. */
 import { describe, expect, it, vi } from "vitest";
 import { createCachedLazyValueGetter } from "./lazy-value.js";
 
@@ -12,13 +10,5 @@ describe("createCachedLazyValueGetter", () => {
     expect(getSchema()).toEqual({ type: "object" });
     expect(getSchema()).toEqual({ type: "object" });
     expect(resolveSchema).toHaveBeenCalledTimes(1);
-  });
-
-  it("uses the fallback when the lazy value resolves nullish", () => {
-    const fallback = { type: "object" as const, properties: {} };
-    const resolveSchema = (): typeof fallback | undefined => undefined;
-    const getSchema = createCachedLazyValueGetter(resolveSchema, fallback);
-
-    expect(getSchema()).toBe(fallback);
   });
 });

--- a/src/plugin-sdk/lazy-value.ts
+++ b/src/plugin-sdk/lazy-value.ts
@@ -4,24 +4,13 @@
 type LazyValue<T> = T | (() => T);
 
 /** Returns a getter that resolves the supplied value at most once. */
-export function createCachedLazyValueGetter<T>(value: LazyValue<T>): () => T;
-/** Returns a getter that resolves once and substitutes a fallback for nullish values. */
-export function createCachedLazyValueGetter<T>(
-  value: LazyValue<T | null | undefined>,
-  fallback: T,
-): () => T;
-export function createCachedLazyValueGetter<T>(
-  value: LazyValue<T | null | undefined>,
-  fallback?: T,
-): () => T | undefined {
+export function createCachedLazyValueGetter<T>(value: LazyValue<T>): () => T {
   let resolved = false;
-  let cached: T | undefined;
+  let cached!: T;
 
   return () => {
     if (!resolved) {
-      const nextValue =
-        typeof value === "function" ? (value as () => T | null | undefined)() : value;
-      cached = nextValue ?? fallback;
+      cached = typeof value === "function" ? (value as () => T)() : value;
       resolved = true;
     }
     return cached;


### PR DESCRIPTION
Related: #120938

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The lazy-value primitive added for #120938 retained a two-argument nullish-fallback mode even though no production caller uses it. That left an unnecessary overload, implementation branch, and dedicated test in an internal helper whose callers already supply one non-nullish value or factory.

## Why This Change Was Made

Remove the unused fallback overload and implementation so the helper has one memoization contract. Keep the plugin and channel entry constructors, their public types, and their boundary tests unchanged; also clarify the channel entry comment so it describes that constructor's responsibility directly.

## User Impact

There is no user-visible behavior, configuration, or public SDK contract change. This is an AI-assisted maintainer simplification follow-up that removes an unused internal mode.

## Evidence

- `node scripts/run-vitest.mjs src/plugin-sdk/lazy-value.test.ts src/plugin-sdk/core.test.ts src/plugin-sdk/channel-entry-contract.test.ts` — 3 files, 22 tests passed.
- Targeted `oxfmt` and `git diff --check` passed.
- Blacksmith Testbox changed gate passed, including SDK guards, production and test typechecks, and lint.
- Full `pnpm build` passed on Blacksmith Testbox lease `tbx_01kzjnf1rhasn6zwdrg00ptj77`: https://github.com/openclaw/openclaw/actions/runs/31300364065 (lease stopped successfully).
- Fresh `autoreview --mode uncommitted` completed clean with no accepted/actionable findings.
- Production LOC: +4/-16 (net -12). Tests: +1/-11 (net -10). Total: net -22.
