### PR TITLE
fix(gateway): recover cloud worker placement state

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1802,6 +1802,7 @@ public struct WorkerEnvironmentMetadata: Codable, Sendable {
     public let idlems: Int?
     public let attachedsessionids: [String]
     public let tunnelstatus: WorkerTunnelStatus
+    public let error: String?
 
     public init(
         providerid: String,
@@ -1810,7 +1811,8 @@ public struct WorkerEnvironmentMetadata: Codable, Sendable {
         agems: Int,
         idlems: Int? = nil,
         attachedsessionids: [String],
-        tunnelstatus: WorkerTunnelStatus)
+        tunnelstatus: WorkerTunnelStatus,
+        error: String? = nil)
     {
         self.providerid = providerid
         self.leaseid = leaseid
@@ -1819,6 +1821,7 @@ public struct WorkerEnvironmentMetadata: Codable, Sendable {
         self.idlems = idlems
         self.attachedsessionids = attachedsessionids
         self.tunnelstatus = tunnelstatus
+        self.error = error
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -1829,6 +1832,7 @@ public struct WorkerEnvironmentMetadata: Codable, Sendable {
         case idlems = "idleMs"
         case attachedsessionids = "attachedSessionIds"
         case tunnelstatus = "tunnelStatus"
+        case error
     }
 }
 

--- a/packages/gateway-protocol/src/schema/environments.test.ts
+++ b/packages/gateway-protocol/src/schema/environments.test.ts
@@ -88,6 +88,7 @@ describe("worker environment protocol schemas", () => {
         ...destroyedBase.worker,
         leaseId: "lease-1",
         idleMs: 50,
+        error: "provider teardown failed",
       },
     };
 
@@ -132,6 +133,12 @@ describe("worker environment protocol schemas", () => {
           ...workerSummary("attached", "available").worker,
           attachedSessionIds: [""],
         },
+      }),
+    ).toBe(false);
+    expect(
+      Value.Check(EnvironmentSummarySchema, {
+        ...workerSummary("failed"),
+        worker: { ...workerSummary("failed").worker, error: "" },
       }),
     ).toBe(false);
   });

--- a/packages/gateway-protocol/src/schema/environments.ts
+++ b/packages/gateway-protocol/src/schema/environments.ts
@@ -46,6 +46,7 @@ export const WorkerEnvironmentMetadataSchema = closedObject({
   idleMs: Type.Optional(Type.Integer({ minimum: 0 })),
   attachedSessionIds: Type.Array(NonEmptyString),
   tunnelStatus: WorkerTunnelStatusSchema,
+  error: Type.Optional(NonEmptyString),
 });
 
 function createEnvironmentSummarySchema() {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -71,6 +71,7 @@ export type WorkerEnvironmentMetadata = {
   idleMs?: number;
   attachedSessionIds: string[];
   tunnelStatus: WorkerTunnelStatus;
+  error?: string;
 };
 
 export type EnvironmentSummary = {

--- a/src/gateway/server-methods/environments.test.ts
+++ b/src/gateway/server-methods/environments.test.ts
@@ -20,7 +20,10 @@ vi.mock("../../infra/device-pairing-node.js", () => ({
 
 const NOW = 10_000;
 
-type TestWorkerRecord = WorkerEnvironmentRecord & { tunnelStatus: WorkerTunnelStatus };
+type TestWorkerRecord = WorkerEnvironmentRecord & {
+  tunnelStatus: WorkerTunnelStatus;
+  error?: string;
+};
 
 type TestWorkerService = {
   list: () => TestWorkerRecord[];
@@ -256,6 +259,21 @@ describe("environment gateway methods", () => {
     ["orphaned", "error"],
   ] as const)("maps worker state %s to %s", (state, status) => {
     expect(summarizeWorkerEnvironment(workerRecord({ state }), NOW).status).toBe(status);
+  });
+
+  it("projects recorded errors only for terminal error states", () => {
+    expect(
+      summarizeWorkerEnvironment(
+        workerRecord({ state: "failed", error: "provider teardown failed" }),
+        NOW,
+      ).worker,
+    ).toMatchObject({ error: "provider teardown failed" });
+    expect(
+      summarizeWorkerEnvironment(
+        workerRecord({ state: "ready", error: "stale transient error" }),
+        NOW,
+      ).worker,
+    ).not.toHaveProperty("error");
   });
 
   it("returns status for one node environment", async () => {

--- a/src/gateway/server-methods/environments.ts
+++ b/src/gateway/server-methods/environments.ts
@@ -79,6 +79,9 @@ export function summarizeWorkerEnvironment(
         : {}),
       attachedSessionIds: uniqueSortedStrings(record.attachedSessionIds),
       tunnelStatus: record.tunnelStatus,
+      ...((record.state === "failed" || record.state === "orphaned") && record.error
+        ? { error: record.error }
+        : {}),
     },
   };
 }

--- a/src/gateway/server-methods/sessions-dispatch.ts
+++ b/src/gateway/server-methods/sessions-dispatch.ts
@@ -15,6 +15,7 @@ import {
   isWorkerPlacementSessionRuntimeSupported,
   resolveWorkerPlacementSessionRuntime,
 } from "../worker-environments/placement-session-runtime.js";
+import { isFailedWorkerPlacementEnvironmentGone } from "../worker-environments/session-placement-lifecycle.js";
 import {
   isWorkerDispatchInputError,
   loadAccessorSessionEntryForGatewayTarget,
@@ -164,9 +165,23 @@ export const sessionDispatchHandlers: GatewayRequestHandlers = {
     }
     const existingPlacement = placementReader.getMany([sessionId]).get(sessionId);
     if (
+      existingPlacement?.state === "failed" &&
+      !isFailedWorkerPlacementEnvironmentGone({
+        environmentService: context.workerEnvironmentService,
+        placement: existingPlacement,
+      })
+    ) {
+      respondInvalidWorkerSession(
+        respond,
+        "cloud worker environment must be stopped before redispatch; use Stop cloud worker",
+      );
+      return;
+    }
+    if (
       existingPlacement &&
       existingPlacement.state !== "local" &&
-      existingPlacement.state !== "reclaimed"
+      existingPlacement.state !== "reclaimed" &&
+      existingPlacement.state !== "failed"
     ) {
       respondInvalidWorkerSession(
         respond,

--- a/src/gateway/server-methods/sessions.dispatch.test.ts
+++ b/src/gateway/server-methods/sessions.dispatch.test.ts
@@ -50,6 +50,14 @@ function reclaimedPlacementRecord(): WorkerSessionPlacementRecord {
   };
 }
 
+function failedPlacementRecord(): WorkerSessionPlacementRecord {
+  return {
+    ...reclaimedPlacementRecord(),
+    state: "failed",
+    recoveryError: "gateway restarted during worker dispatch",
+  };
+}
+
 function targetWithEntry(entry?: {
   sessionId: string;
   worktree?: { id: string; branch: string; repoRoot: string };
@@ -308,6 +316,101 @@ describe("sessions.dispatch", () => {
         }),
       }),
       undefined,
+    );
+  });
+
+  it("allows a failed placement to redispatch after its environment is proven gone", async () => {
+    mocks.resolveTarget.mockReturnValue(
+      targetWithEntry({
+        sessionId,
+        worktree: { id: "worktree-1", branch: "openclaw/cloud-test", repoRoot: "/repo" },
+      }),
+    );
+    mocks.findLiveByOwner.mockReturnValue({
+      id: "worktree-1",
+      ownerKind: "session",
+      ownerId: sessionKey,
+    });
+    const dispatch = vi.fn().mockResolvedValue({
+      ...reclaimedPlacementRecord(),
+      state: "active",
+      environmentId: "environment-next",
+      generation: 6,
+      activeOwnerEpoch: 2,
+      recoveryError: null,
+    });
+    const getEnvironment = vi.fn(() => undefined);
+
+    const respond = await invoke(
+      makeContext({
+        workerEnvironmentService: { get: getEnvironment } as never,
+        workerPlacementDispatchService: { dispatch },
+        workerSessionPlacementService: {
+          getMany: () => new Map([[sessionId, failedPlacementRecord()]]),
+        },
+      }),
+    );
+
+    expect(getEnvironment).toHaveBeenCalledWith("environment-previous");
+    expect(dispatch).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ placement: expect.objectContaining({ state: "active" }) }),
+      undefined,
+    );
+  });
+
+  it("rejects failed-placement redispatch while its environment remains live", async () => {
+    mocks.resolveTarget.mockReturnValue(targetWithEntry({ sessionId }));
+    const dispatch = vi.fn();
+
+    const respond = await invoke(
+      makeContext({
+        workerEnvironmentService: {
+          get: vi.fn(() => ({ state: "failed", leaseId: "lease-previous" })),
+        } as never,
+        workerPlacementDispatchService: { dispatch },
+        workerSessionPlacementService: {
+          getMany: () => new Map([[sessionId, failedPlacementRecord()]]),
+        },
+      }),
+    );
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: ErrorCodes.INVALID_REQUEST,
+        message:
+          "cloud worker environment must be stopped before redispatch; use Stop cloud worker",
+      }),
+    );
+  });
+
+  it("rejects failed-placement redispatch when environment proof is unavailable", async () => {
+    mocks.resolveTarget.mockReturnValue(targetWithEntry({ sessionId }));
+    const dispatch = vi.fn();
+
+    const respond = await invoke(
+      makeContext({
+        workerPlacementDispatchService: { dispatch },
+        workerSessionPlacementService: {
+          getMany: () => new Map([[sessionId, failedPlacementRecord()]]),
+        },
+      }),
+    );
+
+    expect(failedPlacementRecord().environmentId).not.toBeNull();
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: ErrorCodes.INVALID_REQUEST,
+        message:
+          "cloud worker environment must be stopped before redispatch; use Stop cloud worker",
+      }),
     );
   });
 

--- a/src/gateway/server-methods/sessions.dispatch.test.ts
+++ b/src/gateway/server-methods/sessions.dispatch.test.ts
@@ -55,6 +55,7 @@ function failedPlacementRecord(): WorkerSessionPlacementRecord {
     ...reclaimedPlacementRecord(),
     state: "failed",
     recoveryError: "gateway restarted during worker dispatch",
+    turnClaim: null,
   };
 }
 

--- a/src/gateway/server-worker-placement-startup.test.ts
+++ b/src/gateway/server-worker-placement-startup.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../shared/deferred.js";
+import {
+  coordinateWorkerPlacementDispatch,
+  type GatewayWorkerPlacementRuntime,
+} from "./server-worker-placement-startup.js";
+
+type DispatchService = GatewayWorkerPlacementRuntime["dispatchService"];
+
+describe("worker placement dispatch coordinator", () => {
+  it("coalesces full sweeps but runs a fresh targeted pass with its environment id", async () => {
+    const fullSweepStarted = createDeferred();
+    const releaseFullSweep = createDeferred();
+    const reconcileActive = vi.fn(async (environmentId?: string) => {
+      if (environmentId === undefined) {
+        fullSweepStarted.resolve();
+        await releaseFullSweep.promise;
+      }
+    });
+    const service = {
+      dispatch: vi.fn(),
+      forceDestroyEnvironment: vi.fn(),
+      reclaim: vi.fn(),
+      reconcile: vi.fn(),
+      reconcileActive,
+    } as unknown as DispatchService;
+    const coordinated = coordinateWorkerPlacementDispatch(service);
+
+    const firstFullSweep = coordinated.reconcileActive();
+    const secondFullSweep = coordinated.reconcileActive();
+    await fullSweepStarted.promise;
+    const targetedSweep = coordinated.reconcileActive("worker-target");
+
+    expect(reconcileActive).toHaveBeenCalledTimes(1);
+    releaseFullSweep.resolve();
+    await Promise.all([firstFullSweep, secondFullSweep, targetedSweep]);
+
+    expect(reconcileActive.mock.calls).toEqual([[], ["worker-target"]]);
+  });
+});

--- a/src/gateway/server-worker-placement-startup.ts
+++ b/src/gateway/server-worker-placement-startup.ts
@@ -51,7 +51,7 @@ class WorkerDispatchTargetChangedError extends Error {
 
 /** Serializes reconciliation sweeps against in-flight dispatches so a sweep never
  * observes a placement mid-transition. Dispatches wait out any pending sweep. */
-function coordinateWorkerPlacementDispatch(
+export function coordinateWorkerPlacementDispatch(
   service: WorkerPlacementDispatchService,
 ): WorkerPlacementDispatchService {
   let activeDispatchCount = 0;
@@ -132,7 +132,10 @@ function coordinateWorkerPlacementDispatch(
       ),
     reclaim: async (request) => await runPlacementOperation(() => service.reclaim(request)),
     reconcile: () => runReconciliation(service.reconcile),
-    reconcileActive: () => runReconciliation(service.reconcileActive),
+    reconcileActive: (environmentId) =>
+      environmentId === undefined
+        ? runReconciliation(() => service.reconcileActive())
+        : runExclusivePlacementOperation(() => service.reconcileActive(environmentId)),
   };
 }
 

--- a/src/gateway/server.sessions.worker-placement-lifecycle.test.ts
+++ b/src/gateway/server.sessions.worker-placement-lifecycle.test.ts
@@ -320,6 +320,10 @@ test.each([
     state: "failed" as const,
     withoutEnvironment: true,
   },
+  {
+    name: "failed after missing durable environment",
+    state: "failed" as const,
+  },
 ])("sessions.delete retires a $name placement before deleting its session", async (testCase) => {
   await createSessionStoreDir();
   const caseId = testCase.name.replaceAll(" ", "-");

--- a/src/gateway/worker-environments/placement-dispatch-test-fixtures.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-fixtures.ts
@@ -81,9 +81,9 @@ export function seedActivePlacement(
   });
 }
 
-export function createDispatchEnvironmentFixtures() {
+export function createDispatchEnvironmentFixtures(generation = 1) {
   const environmentId = workerEnvironmentIdForIdempotencyKey(
-    `session-dispatch:${REQUEST.sessionId}:1`,
+    `session-dispatch:${REQUEST.sessionId}:${generation}`,
   );
   const profileSnapshot: WorkerProfile = { settings: { region: "test" } };
   const bootstrapReceipt: WorkerAdmissionHandshake = {

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -46,6 +46,7 @@ export function createHarness(
     destroyFailureState?: "draining" | "destroying";
     terminalizeReclaimOnTunnelDrop?: boolean;
     terminalizedReclaimError?: Error;
+    environmentGeneration?: number;
   } = {},
 ) {
   const reconciledManifestRef = MANIFEST_REF.replaceAll("b", "c");
@@ -156,7 +157,7 @@ export function createHarness(
     },
   };
   const { attached, destroyedEnvironment, environmentId, ready } =
-    createDispatchEnvironmentFixtures();
+    createDispatchEnvironmentFixtures(options.environmentGeneration);
   let currentEnvironment: ReturnType<WorkerDispatchEnvironmentService["get"]> = ready;
   const tunnelHandle = (ownerEpoch: number): WorkerTunnelHandle => ({
     environmentId: ready.environmentId,

--- a/src/gateway/worker-environments/placement-dispatch.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch.test.ts
@@ -15,6 +15,7 @@ import {
 } from "./placement-dispatch-test-fixtures.js";
 import { createHarness } from "./placement-dispatch-test-harness.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
+import { workerEnvironmentIdForIdempotencyKey } from "./service.js";
 
 describe("worker placement dispatch", () => {
   let root: string;
@@ -410,6 +411,65 @@ describe("worker placement dispatch", () => {
       expect(failedAt).toBeGreaterThan(harness.log.indexOf("teardown:destroy"));
     }
   });
+
+  it.each(["requested", "provisioning", "syncing"] as const)(
+    "allows explicit redispatch after restart recovery fails an interrupted %s placement",
+    async (interruptedState) => {
+      let interrupted = placementStore.startDispatch(REQUEST);
+      if (interruptedState !== "requested") {
+        interrupted = placementStore.transition({
+          sessionId: REQUEST.sessionId,
+          from: "requested",
+          to: "provisioning",
+          expectedGeneration: interrupted.generation,
+          patch: {
+            environmentId: workerEnvironmentIdForIdempotencyKey(
+              `session-dispatch:${REQUEST.sessionId}:${interrupted.generation}`,
+            ),
+          },
+        });
+      }
+      if (interruptedState === "syncing") {
+        interrupted = placementStore.transition({
+          sessionId: REQUEST.sessionId,
+          from: "provisioning",
+          to: "syncing",
+          expectedGeneration: interrupted.generation,
+          patch: { workerBundleHash: "a".repeat(64) },
+        });
+      }
+      const interruptedEnvironmentId = interrupted.environmentId;
+      const restartedHarness = createHarness(placementStore);
+
+      await restartedHarness.service.reconcile();
+      const failed = restartedHarness.placements.current();
+      expect(failed).toMatchObject({
+        state: "failed",
+        recoveryError: `Worker dispatch interrupted in ${interruptedState}`,
+      });
+      if (failed?.state !== "failed") {
+        throw new Error("restart recovery did not fail the interrupted placement");
+      }
+      const environmentOwned = interruptedState !== "requested";
+      expect(restartedHarness.environments.stopTunnel).toHaveBeenCalledTimes(
+        environmentOwned ? 1 : 0,
+      );
+      expect(restartedHarness.environments.destroy).toHaveBeenCalledTimes(environmentOwned ? 1 : 0);
+      const redispatchHarness = createHarness(placementStore, {
+        environmentGeneration: failed.generation + 1,
+      });
+
+      const active = await redispatchHarness.service.dispatch(REQUEST);
+
+      expect(active).toMatchObject({
+        state: "active",
+        environmentId: redispatchHarness.ready.environmentId,
+      });
+      expect(active.generation).toBeGreaterThan(failed.generation);
+      expect(active.environmentId).not.toBe(interruptedEnvironmentId);
+      expect(redispatchHarness.log).toContain("placement:requested");
+    },
+  );
 
   it("does not fail or tear down a dispatch owned by another invocation", async () => {
     placementStore.startDispatch(REQUEST);

--- a/src/gateway/worker-environments/placement-state.ts
+++ b/src/gateway/worker-environments/placement-state.ts
@@ -27,7 +27,7 @@ const WORKER_SESSION_PLACEMENT_TRANSITIONS = {
   draining: ["reconciling"],
   reconciling: ["local", "reclaimed", "failed"],
   reclaimed: ["requested"],
-  failed: [],
+  failed: ["requested"],
 } as const satisfies WorkerSessionPlacementTransition;
 
 export function parseWorkerSessionPlacementState(value: string): WorkerSessionPlacementState {

--- a/src/gateway/worker-environments/placement-store.redispatch.test.ts
+++ b/src/gateway/worker-environments/placement-store.redispatch.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+  type OpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import type { WorkerSessionPlacementIdentity } from "./placement-record.js";
+import {
+  createWorkerSessionPlacementStore,
+  type WorkerSessionPlacementStore,
+} from "./placement-store.js";
+
+const SESSION: WorkerSessionPlacementIdentity = {
+  sessionId: "session-failed-redispatch",
+  agentId: "main",
+  sessionKey: "agent:main:failed-redispatch",
+};
+
+describe("failed worker placement redispatch", () => {
+  let root: string;
+  let database: OpenClawStateDatabase;
+  let store: WorkerSessionPlacementStore;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-redispatch-"));
+    database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
+    store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
+  });
+
+  afterEach(async () => {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("uses the canonical generation and identity reset", () => {
+    let placement = store.startDispatch(SESSION);
+    placement = store.transition({
+      sessionId: SESSION.sessionId,
+      from: "requested",
+      to: "provisioning",
+      expectedGeneration: placement.generation,
+      patch: { environmentId: "environment-failed-dispatch" },
+    });
+    placement = store.transition({
+      sessionId: SESSION.sessionId,
+      from: "provisioning",
+      to: "syncing",
+      expectedGeneration: placement.generation,
+      patch: { workerBundleHash: "a".repeat(64) },
+    });
+    placement = store.transition({
+      sessionId: SESSION.sessionId,
+      from: "syncing",
+      to: "starting",
+      expectedGeneration: placement.generation,
+      patch: {
+        workspaceBaseManifestRef: "manifest-failed-dispatch",
+        remoteWorkspaceDir: "/workspace/failed-dispatch",
+      },
+    });
+    const failed = store.fail({
+      sessionId: SESSION.sessionId,
+      expectedGeneration: placement.generation,
+      recoveryError: "gateway restarted during activation",
+    });
+
+    expect(store.startDispatch(SESSION)).toMatchObject({
+      state: "requested",
+      generation: failed.generation + 1,
+      environmentId: null,
+      activeOwnerEpoch: null,
+      workspaceBaseManifestRef: null,
+      remoteWorkspaceDir: null,
+      workerBundleHash: null,
+      lastTranscriptAckCursor: null,
+      lastLiveEventAckCursor: null,
+      recoveryError: null,
+    });
+  });
+});

--- a/src/gateway/worker-environments/placement-store.ts
+++ b/src/gateway/worker-environments/placement-store.ts
@@ -209,14 +209,18 @@ export function createWorkerSessionPlacementStore(
       const identity = normalizeIdentity(input);
       return write((db) => {
         const current = ensureLocal(db, identity, now());
-        if (current.state !== "local" && current.state !== "reclaimed") {
+        if (
+          current.state !== "local" &&
+          current.state !== "reclaimed" &&
+          current.state !== "failed"
+        ) {
           throw new Error(
             `Cannot dispatch session ${identity.sessionId} from placement ${current.state}`,
           );
         }
         const updatedAtMs = now();
         // Preserve an in-flight local claim while closing admission. Reclaimed
-        // placement has no live owner and starts a fresh worker generation.
+        // and failed placements have no live worker owner and start a fresh generation.
         const result = executeSqliteQuerySync(
           db,
           query(db)

--- a/src/gateway/worker-environments/service-contract.ts
+++ b/src/gateway/worker-environments/service-contract.ts
@@ -17,6 +17,7 @@ export type WorkerEnvironmentServiceRecord = {
   idleSinceAtMs: number | null;
   attachedSessionIds: readonly string[];
   tunnelStatus: WorkerTunnelStatus;
+  error?: string;
 };
 
 /** Request-facing lifecycle methods, kept separate from persistence and provider internals. */

--- a/src/gateway/worker-environments/service.test.ts
+++ b/src/gateway/worker-environments/service.test.ts
@@ -1173,6 +1173,10 @@ describe("worker environment service", () => {
       leaseId: null,
       lastError: "npm install requires a released gateway package",
     });
+    expect(workerService.list()[0]).toMatchObject({
+      state: "failed",
+      error: "npm install requires a released gateway package",
+    });
   });
 
   it("keeps a remotely bootstrapped lease retryable when receipt persistence fails", async () => {

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -321,6 +321,9 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
 
   const project = (record: WorkerEnvironmentRecord) => ({
     ...record,
+    ...((record.state === "failed" || record.state === "orphaned") && record.lastError
+      ? { error: boundedError(record.lastError) }
+      : {}),
     tunnelStatus: tunnels?.status(record.environmentId) ?? ("stopped" as const),
   });
 

--- a/src/gateway/worker-environments/session-placement-lifecycle.ts
+++ b/src/gateway/worker-environments/session-placement-lifecycle.ts
@@ -34,6 +34,31 @@ type SessionWorkerPlacementMutationParams = {
 };
 
 type RetirablePlacement = Extract<Placement, { state: "local" | "reclaimed" | "failed" }>;
+type FailedPlacement = Extract<Placement, { state: "failed" }>;
+
+export function isFailedWorkerPlacementEnvironmentGone(params: {
+  environmentService: SessionWorkerPlacementContext["workerEnvironmentService"];
+  placement: FailedPlacement;
+}): boolean {
+  if (params.placement.environmentId === null) {
+    return true;
+  }
+  // Provisioning persists deterministic allocation intent first; only the configured service
+  // can prove that the corresponding durable environment row was never created or is gone.
+  if (!params.environmentService) {
+    return false;
+  }
+  try {
+    const environment = params.environmentService.get(params.placement.environmentId);
+    return (
+      environment === undefined ||
+      environment.state === "destroyed" ||
+      (environment.state === "failed" && environment.leaseId === null)
+    );
+  } catch {
+    return false;
+  }
+}
 
 function retirementGuard(placement: RetirablePlacement): SessionWorkerPlacementMutationGuard {
   return {
@@ -65,15 +90,13 @@ function resolveSessionWorkerPlacementMutationGuard(
     return retirementGuard(placement);
   }
   if (params.action === "delete" && placement.state === "failed") {
-    const environment = placement.environmentId
-      ? params.context.workerEnvironmentService?.get(placement.environmentId)
-      : undefined;
     // Failed environments retain their lease until teardown is proven, so they stay fenced.
-    const failedPlacementCanDelete =
-      placement.environmentId === null ||
-      environment?.state === "destroyed" ||
-      (environment?.state === "failed" && environment.leaseId === null);
-    if (failedPlacementCanDelete) {
+    if (
+      isFailedWorkerPlacementEnvironmentGone({
+        environmentService: params.context.workerEnvironmentService,
+        placement,
+      })
+    ) {
       return retirementGuard(placement);
     }
   }

--- a/src/gateway/worker-environments/tunnel.test.ts
+++ b/src/gateway/worker-environments/tunnel.test.ts
@@ -93,6 +93,22 @@ describe("worker tunnel manager", () => {
     await handle.stop();
   });
 
+  it("reports stopped when the reconnect loop settles without removing its entry", async () => {
+    const fake = fakeRunner();
+    const { manager, handle } = await startConnectedTunnel(fake, "worker:settled-loop", 1, {
+      manager: {
+        sleep: async () => {
+          throw new Error("retry scheduler stopped");
+        },
+      },
+    });
+
+    fake.starts[0]?.process.exit();
+    await waitForFast(() => expect(manager.status("worker:settled-loop")).toBe("stopped"));
+
+    await handle.stop();
+  });
+
   it("times out a marker-less SSH child and retries", async () => {
     vi.useFakeTimers();
     const fake = fakeRunner();

--- a/src/gateway/worker-environments/tunnel.ts
+++ b/src/gateway/worker-environments/tunnel.ts
@@ -94,6 +94,7 @@ type TunnelEntry = {
   process?: WorkerSshProcess;
   initialization?: Promise<void>;
   loop?: Promise<void>;
+  loopSettled: boolean;
   stopPromise?: Promise<void>;
   readiness: Deferred<WorkerTunnelHandle>;
   workspaceTasks: Set<Promise<unknown>>;
@@ -418,6 +419,7 @@ export function createWorkerTunnelManager(options: WorkerTunnelManagerOptions = 
       remoteSocketPath: `${remoteDirectory}/${REMOTE_SOCKET_NAME}`,
       abortController: new AbortController(),
       status: "connecting",
+      loopSettled: false,
       readiness,
       workspaceTasks: new Set(),
     };
@@ -442,7 +444,9 @@ export function createWorkerTunnelManager(options: WorkerTunnelManagerOptions = 
         entry.prepared = undefined;
         return;
       }
-      entry.loop = reconnectLoop(entry);
+      entry.loop = reconnectLoop(entry).finally(() => {
+        entry.loopSettled = true;
+      });
       void entry.loop.catch((error: unknown) => {
         entry.readiness.reject(error instanceof Error ? error : new Error("Worker tunnel failed"));
       });
@@ -476,7 +480,8 @@ export function createWorkerTunnelManager(options: WorkerTunnelManagerOptions = 
     stop,
     stopAll,
     status(environmentId: string): WorkerTunnelStatus {
-      return entries.get(environmentId)?.status ?? "stopped";
+      const entry = entries.get(environmentId);
+      return !entry || entry.loopSettled ? "stopped" : entry.status;
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Cloud worker lifecycle state could become stale or permanently terminal in four gateway paths:

- post-destroy placement reconciliation dropped the environment ID and could collapse into an older full sweep;
- failed worker details were hidden from environment inventory responses;
- a settled tunnel reconnect loop could remain reported as reconnecting;
- dispatches interrupted during requested, provisioning, or syncing became permanently failed even after their environment was proven gone.

## Why This Change Was Made

The gateway now keeps periodic full reconciliation coalesced while serializing each targeted reconciliation as a fresh pass. Failed placement redispatch reuses the existing generation bump and identity reset, but is admitted only through the same fail-closed environment-gone proof used by session deletion. Worker failure details are redacted and bounded at the service projection, and tunnel liveness tracks actual loop settlement.

## User Impact

Operators can explicitly redispatch a failed cloud placement after teardown is proven, while a still-live or unprovable environment remains safely fenced with an actionable Stop cloud worker message. Environment listings expose bounded terminal failure context, and tunnel status no longer claims an abandoned reconnect loop is live.

This PR is gateway-only and makes no Control UI changes.

## Evidence

- Focused gateway and protocol suite: 212 tests passed.
- Dispatch-abort and SDK coverage: 42 tests passed.
- Follow-up requested/provisioning/syncing recovery coverage: 79 tests passed.
- Tunnel settlement regression: 12 tests passed.
- Touched TypeScript files pass `node scripts/run-oxlint.mjs`.
- Protocol registry, TypeScript generation, Swift generation check, Kotlin generation, and protocol-since guard pass.
- `git diff --check` passes.
- Codex autoreview: no accepted or actionable findings.

Related: #120953
