### PR TITLE
fix(gateway): keep models available after restart

### DIFF
--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -1,6 +1,6 @@
 // Startup config secret tests protect gateway token preparation, weak-secret
 // detection, auth profile loading, warning emission, and runtime activation.
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -11,6 +11,7 @@ import {
   getRuntimeAuthProfileStoreSnapshot,
   setRuntimeAuthProfileStoreSnapshot,
 } from "../agents/auth-profiles/runtime-snapshots.js";
+import { writePersistedAuthProfileStoreRaw } from "../agents/auth-profiles/sqlite.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
 import { measureDiagnosticsTimelineSpan } from "../infra/diagnostics-timeline.js";
 import { providerResolutionError, refResolutionError } from "../secrets/resolve-errors.js";
@@ -24,6 +25,7 @@ import {
   getActiveSecretsRuntimeSnapshotRevision,
 } from "../secrets/runtime-state.js";
 import type { PreparedSecretsRuntimeSnapshot, SecretResolverWarning } from "../secrets/runtime.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import {
   createRuntimeSecretsActivator,
   prepareGatewayStartupConfig,
@@ -354,6 +356,33 @@ async function activateImportedStartupConfig(config: OpenClawConfig) {
       reason: "startup",
       activate: true,
     },
+  );
+}
+
+async function activateStartupConfigWithEnv(config: OpenClawConfig, env: NodeJS.ProcessEnv) {
+  const activateRuntimeSecrets = createRuntimeSecretsActivator(
+    runtimeSecretsActivatorOptionsForTest(),
+  );
+  return await activateRuntimeSecrets(gatewayTokenConfig(config), {
+    reason: "startup",
+    activate: true,
+    env,
+  });
+}
+
+function writePersistedOpenAiProfile(agentDir: string, key: string): void {
+  writePersistedAuthProfileStoreRaw(
+    {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          key,
+        },
+      },
+    },
+    agentDir,
   );
 }
 
@@ -2876,6 +2905,94 @@ describe("gateway startup config secret preflight", () => {
           list: [{ id: "default", agentDir: harness.agentDir }],
         },
       }),
+    );
+  });
+
+  it("publishes persisted relocated shared-main auth at startup", async () => {
+    const root = autoCleanupTempDirs.make("openclaw-startup-relocated-main-auth-");
+    const processHome = path.join(root, "process-home");
+    const activationHome = path.join(root, "activation-home");
+    const relocatedMainAgentDir = path.join(root, "relocated-main-agent");
+    mkdirSync(processHome, { recursive: true });
+    mkdirSync(activationHome, { recursive: true });
+    mkdirSync(relocatedMainAgentDir, { recursive: true });
+
+    await withEnvAsync(
+      {
+        HOME: processHome,
+        OPENCLAW_STATE_DIR: path.join(processHome, "state"),
+        OPENCLAW_AGENT_DIR: relocatedMainAgentDir,
+      },
+      async () => {
+        writePersistedOpenAiProfile(relocatedMainAgentDir, "fake-persisted-key");
+        const secretsRuntime = await import("../secrets/runtime.js");
+        const activationEnv = {
+          ...process.env,
+          HOME: activationHome,
+          OPENCLAW_STATE_DIR: path.join(activationHome, "state"),
+          OPENCLAW_AGENT_DIR: relocatedMainAgentDir,
+        };
+
+        try {
+          await activateStartupConfigWithEnv(
+            { agents: { list: [{ id: "default", default: true }] } },
+            activationEnv,
+          );
+
+          expect(
+            secretsRuntime.getActiveSecretsRuntimeSnapshot()?.authStores[0]?.store.profiles[
+              "openai:default"
+            ],
+          ).toMatchObject({ key: "fake-persisted-key" });
+        } finally {
+          secretsRuntime.clearSecretsRuntimeSnapshot();
+        }
+      },
+    );
+  });
+
+  it("uses the activation env when publishing persisted startup auth", async () => {
+    const root = autoCleanupTempDirs.make("openclaw-startup-activation-env-auth-");
+    const processHome = path.join(root, "process-home");
+    const activationHome = path.join(root, "activation-home");
+    const activationAgentDir = path.join(activationHome, "configured-agent");
+    mkdirSync(processHome, { recursive: true });
+    mkdirSync(activationAgentDir, { recursive: true });
+
+    await withEnvAsync(
+      {
+        HOME: processHome,
+        OPENCLAW_STATE_DIR: path.join(processHome, "state"),
+        OPENCLAW_AGENT_DIR: undefined,
+      },
+      async () => {
+        writePersistedOpenAiProfile(activationAgentDir, "fake-activation-env-key");
+        const secretsRuntime = await import("../secrets/runtime.js");
+        const activationEnv = {
+          ...process.env,
+          HOME: activationHome,
+          OPENCLAW_STATE_DIR: path.join(activationHome, "state"),
+        };
+
+        try {
+          await activateStartupConfigWithEnv(
+            {
+              agents: {
+                list: [{ id: "default", default: true, agentDir: "~/configured-agent" }],
+              },
+            },
+            activationEnv,
+          );
+
+          const activeStore = secretsRuntime.getActiveSecretsRuntimeSnapshot()?.authStores[0];
+          expect(activeStore?.agentDir).toBe(activationAgentDir);
+          expect(activeStore?.store.profiles["openai:default"]).toMatchObject({
+            key: "fake-activation-env-key",
+          });
+        } finally {
+          secretsRuntime.clearSecretsRuntimeSnapshot();
+        }
+      },
     );
   });
 });

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -378,6 +378,7 @@ export function createRuntimeSecretsActivator(params: {
             ? null
             : prepareSecretsRuntimeFastPathSnapshot({
                 config: sourceConfig,
+                env: startupEnv,
                 ...(startupManifestRegistry ? { manifestRegistry: startupManifestRegistry } : {}),
               });
           if (fastPath) {

--- a/src/secrets/runtime-fast-path.ts
+++ b/src/secrets/runtime-fast-path.ts
@@ -1,6 +1,5 @@
 /** Detects when secrets runtime preparation can safely use a fast path. */
 import { existsSync } from "node:fs";
-import path from "node:path";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import {
   listAgentIds,
@@ -8,9 +7,9 @@ import {
   resolveDefaultAgentDir,
 } from "../agents/agent-scope-config.js";
 import { getRuntimeAuthProfileStoreCredentialsRevision } from "../agents/auth-profiles/runtime-snapshots.js";
+import { resolveSharedMainAuthAgentDir } from "../agents/auth-profiles/shared-main-dir.js";
 import { resolveAuthProfileDatabasePath } from "../agents/auth-profiles/sqlite.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
-import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
@@ -106,14 +105,7 @@ function hasCandidateAuthProfileStoreSources(params: {
   agentDirs?: string[];
 }): boolean {
   const candidateDirs = resolveCandidateAgentDirs(params);
-  // The shipped no-argument auth store is fixed at agents/main/agent even when
-  // another roster entry is default, so the fast path must probe it separately.
-  const mainAgentDir = path.join(
-    resolveStateDir(params.env as NodeJS.ProcessEnv),
-    "agents",
-    "main",
-    "agent",
-  );
+  const mainAgentDir = resolveSharedMainAuthAgentDir(params.env as NodeJS.ProcessEnv);
   return (
     candidateDirs.some((agentDir) => hasCandidateAuthProfileStoreSource(agentDir)) ||
     hasCandidateAuthProfileStoreSource(mainAgentDir)


### PR DESCRIPTION
Refs #120951

## What Problem This Solves

Fixes an issue where operators restarting the Gateway could see every model reported as unavailable in the Control UI even though the persisted agent auth profile was valid. `models.list` and `chat.metadata` disagreed until an unrelated config edit refreshed the prepared runtime.

## Why This Change Was Made

The root cause was category (c): the startup-only secrets fast path selected auth state using a different environment and a stale hardcoded shared-main directory instead of the canonical auth-store owner. Startup now forwards its activation environment and probes the shared-main store through the canonical relocated-directory resolver, so an existing SQLite store sends preparation through the loader that publishes its persisted profiles.

Genuine `AuthProfileMigrationRequiredError` cases keep their existing cold degraded-owner reporting. This does not add a request-path fallback or a second source of truth; `chat.metadata` remains snapshot-only.

Production LOC: +3/-10 (net -7) | Tests: +118/-1

## User Impact

At Gateway-ready time after a restart, the Control UI can use the agent's persisted credentials immediately and reports the same model availability as `models.list`. Operators no longer need to touch config to make models appear.

## Evidence

- Before the repair, focused regressions reproduced both failures: the relocated persisted profile was `undefined`, and the activation-env agent directory resolved under `process-home` instead of `activation-home`.
- After the repair, focused Vitest passed 82/82 tests across startup secrets, secrets fast-path behavior, auth migration isolation, and `chat.metadata` runtime projection:
  - Gateway shard: 69 passed
  - Secrets shard: 13 passed
- `node scripts/run-oxlint.mjs` passed for all three touched files.
- `git diff --check` passed.
- Codex autoreview completed cleanly with no accepted or actionable findings.
- Source-blind Gateway smoke was blocked before readiness by plugin migration convergence, so this PR does not claim live Gateway proof from that lane.
