### PR TITLE
fix(sessions): preserve transcript ownership after key canonicalization

### DIFF
--- a/extensions/codex/src/app-server/transcript-mirror.test.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.test.ts
@@ -10,7 +10,7 @@ import {
   resetGlobalHookRunner,
 } from "openclaw/plugin-sdk/hook-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { getSessionEntry, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { readSessionTranscriptEvents } from "openclaw/plugin-sdk/session-transcript-runtime";
 import {
   castAgentMessage,
@@ -524,6 +524,38 @@ describe("importCodexThreadHistoryToTranscript", () => {
         stopReason: "stop",
         timestamp: expect.any(Number),
       },
+    ]);
+  });
+});
+
+describe("Codex transcript mirror session identity", () => {
+  it("uses the persisted session window owner instead of materializing a stale alias", async () => {
+    const target = await createSqliteMirrorTarget("openclaw-codex-mirror-canonical-owner-");
+    const staleAlias = "agent:main:telegram:default:direct:fixture-peer";
+
+    await mirrorCodexAppServerTranscript({
+      ...target,
+      sessionKey: staleAlias,
+      messages: [makeAgentUserMessage({ content: "canonical owner", timestamp: Date.now() })],
+      idempotencyScope: "codex-app-server:canonical-owner",
+    });
+
+    expect(
+      getSessionEntry({
+        agentId: target.agentId,
+        sessionKey: staleAlias,
+        storePath: target.storePath,
+      }),
+    ).toBeUndefined();
+    expect(
+      getSessionEntry({
+        agentId: target.agentId,
+        sessionKey: target.sessionKey,
+        storePath: target.storePath,
+      }),
+    ).toMatchObject({ sessionId: target.sessionId });
+    expect(await readMirrorMessages(target)).toEqual([
+      expect.objectContaining({ role: "user", text: "canonical owner" }),
     ]);
   });
 });

--- a/src/commands/doctor-session-canonical-keys.test.ts
+++ b/src/commands/doctor-session-canonical-keys.test.ts
@@ -224,6 +224,83 @@ describe("doctor canonical session-key repair", () => {
     });
   });
 
+  it("removes a stale placeholder alias owned by an existing canonical session window", async () => {
+    await withStateDirEnv("openclaw-doctor-canonical-placeholder-alias-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const storeTemplate = path.join(stateDir, "agents", "{agentId}", "sessions.json");
+      const storePath = resolveStorePath(storeTemplate, { agentId: "main", env });
+      const cfg = {
+        agents: { list: [{ id: "main", default: true }] },
+        session: { store: storeTemplate },
+      } as OpenClawConfig;
+      const canonicalKey = "agent:main:main";
+      const staleAlias = "agent:main:telegram:default:direct:fixture-peer";
+      const sessionId = "shared-canonical-session";
+      insertLegacySession({
+        agentId: "main",
+        entry: {
+          sessionId,
+          updatedAt: 20,
+          label: "preserved canonical label",
+          model: "preserved-model",
+          modelProvider: "preserved-provider",
+        },
+        env,
+        eventText: "preserved canonical transcript",
+        sessionKey: canonicalKey,
+        storePath,
+      });
+      const database = openOpenClawAgentDatabase({
+        agentId: "main",
+        env,
+        path: resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main", env }).path,
+      });
+      database.db
+        .prepare(
+          `INSERT INTO session_nodes
+             (session_key, current_session_id, entry_json, entry_valid, updated_at)
+           VALUES (?, ?, '{}', -1, ?)`,
+        )
+        .run(staleAlias, sessionId, 30);
+
+      expect(await repairCanonicalSessionKeys({ apply: true, cfg, env })).toMatchObject({
+        foundGroups: 1,
+        removedRows: 1,
+        repairedGroups: 1,
+      });
+      expect(
+        loadExactSessionEntryReadOnly({ agentId: "main", env, sessionKey: staleAlias, storePath }),
+      ).toBeUndefined();
+      expect(
+        loadExactSessionEntryReadOnly({ agentId: "main", env, sessionKey: canonicalKey, storePath })
+          ?.entry,
+      ).toMatchObject({
+        label: "preserved canonical label",
+        model: "preserved-model",
+        modelProvider: "preserved-provider",
+        sessionId,
+        updatedAt: 20,
+      });
+      await expect(
+        loadTranscriptEvents({
+          agentId: "main",
+          env,
+          sessionId,
+          sessionKey: canonicalKey,
+          storePath,
+        }),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          message: expect.objectContaining({ content: "preserved canonical transcript" }),
+        }),
+      ]);
+      expect(await repairCanonicalSessionKeys({ apply: true, cfg, env })).toMatchObject({
+        foundGroups: 0,
+        repairedGroups: 0,
+      });
+    });
+  });
+
   it("moves a legacy global heartbeat sibling to its agent-qualified key", async () => {
     await withStateDirEnv("openclaw-doctor-canonical-global-heartbeat-", async ({ stateDir }) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };

--- a/src/commands/doctor-session-canonical-keys.ts
+++ b/src/commands/doctor-session-canonical-keys.ts
@@ -45,6 +45,7 @@ type CanonicalSessionCandidate = {
   sessionKey: string;
   sqlitePath: string;
   storePath: string;
+  windowOwnerEvidenceOnly: boolean;
 };
 
 function createCanonicalRepairRemoval(
@@ -116,21 +117,30 @@ function collectCanonicalSessionCandidates(
       agentId: target.agentId,
       clone: false,
       storePath: target.storePath,
-    }).map(({ entry, rawEntryJson, sessionKey }) => {
+    }).map(({ currentWindowOwnerSessionKey, entry, rawEntryJson, sessionKey }) => {
       const storedKey = resolveStoredSessionKeyForAgentStore({
         cfg: params.cfg,
         agentId: target.agentId,
         sessionKey,
       });
       return {
-        canonicalKey: storedKey
-          ? resolveDeliveryProvenCanonicalSessionKey(storedKey, entry)
-          : resolveAgentMainSessionKey({ cfg: params.cfg, agentId: target.agentId }),
+        // A malformed/placeholder node can share its current session id with a window already
+        // owned by the canonical node. That unique window is stronger identity evidence than
+        // the stale key itself, whose `{}` payload carries no delivery provenance.
+        canonicalKey:
+          rawEntryJson !== undefined && currentWindowOwnerSessionKey
+            ? currentWindowOwnerSessionKey
+            : storedKey
+              ? resolveDeliveryProvenCanonicalSessionKey(storedKey, entry)
+              : resolveAgentMainSessionKey({ cfg: params.cfg, agentId: target.agentId }),
         entry,
         rawEntryJson,
         sessionKey,
         storedKey,
         target,
+        windowOwnerEvidenceOnly: Boolean(
+          rawEntryJson !== undefined && currentWindowOwnerSessionKey,
+        ),
       };
     }),
   );
@@ -149,7 +159,8 @@ function collectCanonicalSessionCandidates(
       addCanonicalMapping(`*\0${ownerAgentId}\0${key}`, item.canonicalKey);
     }
   }
-  return inventory.map(({ canonicalKey, entry, rawEntryJson, sessionKey, target }) => {
+  return inventory.map((item) => {
+    const { canonicalKey, entry, rawEntryJson, sessionKey, target, windowOwnerEvidenceOnly } = item;
     const canonicalAgentId =
       canonicalKey === "global" || canonicalKey === "unknown"
         ? target.agentId
@@ -218,6 +229,7 @@ function collectCanonicalSessionCandidates(
       sessionKey,
       sqlitePath: target.sqlitePath,
       storePath: target.storePath,
+      windowOwnerEvidenceOnly,
     };
     if (rawEntryJson !== undefined) {
       candidate.rawEntryJson = rawEntryJson;
@@ -295,8 +307,9 @@ function selectCanonicalSessionCandidate(
     env: params.env,
     sourceAgentId: first.agentId,
   });
+  const metadataCandidates = candidates.filter((candidate) => !candidate.windowOwnerEvidenceOnly);
   const selected = mergeCanonicalSessionEntryCandidates(
-    candidates
+    (metadataCandidates.length > 0 ? metadataCandidates : candidates)
       .toSorted((left, right) =>
         Buffer.compare(
           Buffer.from(`${left.sqlitePath}\0${left.sessionKey}`, "utf8"),

--- a/src/config/sessions/session-accessor.sqlite-canonical-repair.ts
+++ b/src/config/sessions/session-accessor.sqlite-canonical-repair.ts
@@ -209,6 +209,7 @@ type CanonicalRepairRow = Selectable<OpenClawAgentKyselyDatabase["session_nodes"
   current_previous_session_id: string | null;
   current_started_at: number | null;
   current_window_id: string | null;
+  current_window_owner_session_key: string | null;
   delivery_account_id: string | null;
   delivery_channel: string | null;
   delivery_target: string | null;
@@ -290,7 +291,7 @@ function hydrateCanonicalRepairEntry(row: CanonicalRepairRow): SessionEntry {
 
 export function listSqliteSessionEntriesForCanonicalRepair(
   scope: SessionEntryListScope = {},
-): Array<SessionEntrySummary & { rawEntryJson?: string }> {
+): Array<SessionEntrySummary & { currentWindowOwnerSessionKey?: string; rawEntryJson?: string }> {
   const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
   const databaseOptions = toDatabaseOptions(resolved);
   const result = withOpenClawAgentDatabaseReadOnly((database) => {
@@ -305,6 +306,11 @@ export function listSqliteSessionEntriesForCanonicalRepair(
             .onRef("current_window.session_key", "=", "session_nodes.session_key"),
         )
         .leftJoin(
+          "session_windows as current_window_owner",
+          "current_window_owner.session_id",
+          "session_nodes.current_session_id",
+        )
+        .leftJoin(
           "conversations as current_conversation",
           "current_conversation.conversation_id",
           "current_window.primary_conversation_id",
@@ -312,6 +318,7 @@ export function listSqliteSessionEntriesForCanonicalRepair(
         .selectAll("session_nodes")
         .select([
           "current_window.session_id as current_window_id",
+          "current_window_owner.session_key as current_window_owner_session_key",
           "current_window.started_at as current_started_at",
           "current_window.ended_at as current_ended_at",
           "current_window.chat_type as current_chat_type",
@@ -345,6 +352,11 @@ export function listSqliteSessionEntriesForCanonicalRepair(
         {
           sessionKey: row.session_key,
           entry,
+          ...(row.entry_json === "{}" &&
+          row.current_window_id === null &&
+          row.current_window_owner_session_key
+            ? { currentWindowOwnerSessionKey: row.current_window_owner_session_key }
+            : {}),
           ...(rawCompareRequired ? { rawEntryJson: row.entry_json } : {}),
         },
       ];

--- a/src/config/sessions/session-accessor.sqlite-data-version.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-data-version.test.ts
@@ -574,6 +574,44 @@ describe("SQLite session entry cache", () => {
     ]);
   });
 
+  it("rejects a stale transcript key without materializing a second physical owner", async () => {
+    const scope = createSessionScope("transcript-owner-conflict");
+    const sessionId = "owned-transcript-session";
+    const staleAlias = "agent:main:transport:default:direct:fixture-peer";
+    await upsertSessionEntry(scope, { sessionId, updatedAt: 1 });
+    const database = openOpenClawAgentDatabase(scope);
+
+    expect(() =>
+      runOpenClawAgentWriteTransaction((transactionDatabase) => {
+        ensureTranscriptSessionRoot(
+          transactionDatabase,
+          {
+            agentId: scope.agentId,
+            env: scope.env,
+            sessionId,
+            sessionKey: staleAlias,
+          },
+          2,
+        );
+      }, scope),
+    ).toThrow(
+      expect.objectContaining({
+        name: "SqliteTranscriptSessionOwnerConflictError",
+      }),
+    );
+
+    expect(
+      database.db
+        .prepare("SELECT session_key, entry_valid FROM session_nodes ORDER BY session_key")
+        .all(),
+    ).toEqual([{ session_key: scope.sessionKey, entry_valid: 1 }]);
+    expect(
+      database.db
+        .prepare("SELECT session_key FROM session_windows WHERE session_id = ?")
+        .get(sessionId),
+    ).toEqual({ session_key: scope.sessionKey });
+  });
+
   it("bypasses the cache in a transaction and reuses the persisted snapshot after rollback", async () => {
     const scope = createSessionScope("transaction-rollback");
     await upsertSessionEntry(scope, { label: "before", sessionId: "rollback", updatedAt: 1 });

--- a/src/config/sessions/session-accessor.sqlite-transcript-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-state.ts
@@ -82,10 +82,24 @@ export function ensureTranscriptSessionRoot(
   updatedAt: number,
   options: { allowStoredAlias?: boolean } = {},
 ): void {
+  const db = getSessionKysely(database.db);
+  const persistedOwner = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("session_windows")
+      .select("session_key")
+      .where("session_id", "=", scope.sessionId),
+  )?.session_key;
+  if (persistedOwner && persistedOwner !== scope.sessionKey) {
+    const error = new Error(
+      `Transcript session ${scope.sessionId} is owned by ${persistedOwner}, not ${scope.sessionKey}`,
+    );
+    error.name = "SqliteTranscriptSessionOwnerConflictError";
+    throw error;
+  }
   if (!options.allowStoredAlias) {
     assertCanonicalSqliteSessionKeysCurrent(database);
     assertCanonicalSessionKeyWriteMatchesDatabase(database, scope.sessionKey);
-    const db = getSessionKysely(database.db);
     const lookupKeys = uniqueStrings([
       scope.sessionKey,
       ...foldedSessionKeyAliasCandidates(normalizeStoreSessionKey(scope.sessionKey)),
@@ -147,7 +161,6 @@ export function ensureTranscriptSessionRoot(
       }
     }
   }
-  const db = getSessionKysely(database.db);
   const insertedNode = executeSqliteQuerySync(
     database.db,
     db

--- a/src/config/sessions/session-accessor.transcript-target.ts
+++ b/src/config/sessions/session-accessor.transcript-target.ts
@@ -2,6 +2,7 @@ import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { getRuntimeConfig } from "../io.js";
 import { resolveStorePath } from "./paths.js";
 import { resolveSessionEntrySelection } from "./session-accessor.entry.js";
+import { resolveSqliteSessionKeyBySessionId } from "./session-accessor.sqlite-entry.js";
 import type {
   SessionTranscriptReadScope,
   SessionTranscriptReadTarget,
@@ -17,7 +18,10 @@ type SessionTranscriptRuntimeContext = {
 };
 
 function resolveRuntimeContext(
-  scope: Pick<SessionTranscriptRuntimeScope, "agentId" | "env" | "sessionKey" | "storePath">,
+  scope: Pick<
+    SessionTranscriptRuntimeScope,
+    "agentId" | "env" | "sessionId" | "sessionKey" | "storePath"
+  >,
 ): SessionTranscriptRuntimeContext {
   const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
   if (!agentId) {
@@ -38,9 +42,15 @@ function resolveRuntimeContext(
     sessionKey: scope.sessionKey,
     storePath,
   });
+  const persistedOwner = resolveSqliteSessionKeyBySessionId({
+    agentId,
+    ...(scope.env ? { env: scope.env } : {}),
+    sessionId: scope.sessionId,
+    storePath,
+  });
   return {
     agentId,
-    sessionKey: resolved?.normalizedKey ?? scope.sessionKey,
+    sessionKey: persistedOwner ?? resolved?.normalizedKey ?? scope.sessionKey,
     storePath,
   };
 }


### PR DESCRIPTION
Closes #120980

## What Problem This Solves

A transcript writer can retain a stale transport-specific session key after the stable session ID has already moved to its canonical `session_windows` owner. The SQLite transcript-root path could then create a second empty `session_nodes` placeholder with `entry_valid = -1`.

That placeholder causes canonical-key validation to block gateway startup, `doctor --fix`, and session cleanup.

## Why This Change Was Made

- Resolve the unique persisted transcript owner by `sessionId` in the shared transcript-target layer instead of fixing only the Codex consumer.
- Add a transaction-local ownership invariant so a concurrent migration cannot materialize a second physical owner.
- Let Doctor use an existing window owner as identity evidence for an orphaned empty placeholder.
- Exclude that evidence-only placeholder from metadata winner selection, even when its timestamp is newer, so valid canonical metadata cannot be overwritten.

The Codex app-server protocol provides stable opaque thread/session identity but no OpenClaw transport key; canonical session-key ownership therefore belongs in OpenClaw core.

## User Impact

- Gateway restarts no longer recreate this stale alias through transcript mirroring.
- Existing empty alias placeholders can be repaired without deleting conversations or transcript events.
- Canonical labels, model/provider metadata, and window ownership are preserved.
- All transcript writers using the shared runtime target receive the protection, including future plugin consumers.

## Evidence

Focused regression suites on current `main`:

- `src/commands/doctor-session-canonical-keys.test.ts`: 16/16 passing
- `src/config/sessions/session-accessor.sqlite-data-version.test.ts`: 17/17 passing
- `extensions/codex/src/app-server/transcript-mirror.test.ts`: 36/36 passing
- `pnpm build`: passing
- `git diff --check`: passing

The tests verify that:

- a stale runtime key resolves to the persisted window owner;
- no second physical `session_nodes` row is created;
- `session_windows` ownership remains unchanged;
- a newer invalid placeholder cannot replace valid canonical metadata;
- Doctor removes only the alias and remains idempotent;
- canonical transcript content remains available.

The full extension-wide native TypeScript check exceeded the available RAM/swap on the local 5 GB VM and was stopped without a TypeScript diagnostic. Focused Codex tests and the full production build pass; the repository CI can run the complete extension check on the submitted head.

## AI Assistance

AI-assisted investigation, implementation, and test design. The final diff was manually reviewed against current `main`, related session-repair history, and the Codex app-server protocol. All reproduction identifiers are synthetic.