### PR TITLE
fix(release): repair .35 validation backports

### DIFF
--- a/extensions/llama-cpp/npm-shrinkwrap.json
+++ b/extensions/llama-cpp/npm-shrinkwrap.json
@@ -1144,9 +1144,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
-      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",

--- a/extensions/memory-core/src/memory/qmd-manager.slugified-paths.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.slugified-paths.test.ts
@@ -12,16 +12,18 @@ const { logWarnMock, logDebugMock, logInfoMock } = vi.hoisted(() => ({
   logInfoMock: vi.fn(),
 }));
 
+type MockStream = EventEmitter & { setEncoding: ReturnType<typeof vi.fn> };
+
 interface MockChild extends EventEmitter {
-  stdout: EventEmitter;
-  stderr: EventEmitter;
+  stdout: MockStream;
+  stderr: MockStream;
   kill: (signal?: NodeJS.Signals) => void;
   closeWith: (code?: number | null) => void;
 }
 
 function createMockChild(params?: { autoClose?: boolean }): MockChild {
-  const stdout = new EventEmitter();
-  const stderr = new EventEmitter();
+  const stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+  const stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
   const child = new EventEmitter() as unknown as MockChild;
   child.stdout = stdout;
   child.stderr = stderr;

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -1,6 +1,9 @@
 // Memory Core plugin module implements tools behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import type {
+  MemoryReadResult,
+  MemorySource,
+} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import {
   asToolParamsRecord,
   jsonResult,
@@ -342,8 +345,12 @@ async function resolveMemoryReadFailureResult(params: {
   return jsonResult({ path: params.relPath, text: "", disabled: true, error: message });
 }
 
-async function executeMemoryReadResult<T>(params: {
-  read: () => Promise<T>;
+function isMissingMemoryReadResult(result: MemoryReadResult, relPath: string): boolean {
+  return result.path === relPath && result.text === "" && result.from === undefined;
+}
+
+async function executeMemoryReadResult(params: {
+  read: () => Promise<MemoryReadResult>;
   requestedCorpus?: "memory" | "wiki" | "all";
   relPath: string;
   from?: number;
@@ -351,7 +358,20 @@ async function executeMemoryReadResult<T>(params: {
   agentSessionKey?: string;
 }) {
   try {
-    return jsonResult(await params.read());
+    const result = await params.read();
+    if (params.requestedCorpus === "all" && isMissingMemoryReadResult(result, params.relPath)) {
+      const supplement = await getSupplementMemoryReadResult({
+        relPath: params.relPath,
+        from: params.from,
+        lines: params.lines,
+        agentSessionKey: params.agentSessionKey,
+        corpus: params.requestedCorpus,
+      });
+      if (supplement) {
+        return jsonResult(supplement);
+      }
+    }
+    return jsonResult(result);
   } catch (error) {
     return await resolveMemoryReadFailureResult({
       error,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6387,8 +6387,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.11:
-    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -12735,7 +12735,7 @@ snapshots:
 
   nanoid@3.3.18: {}
 
-  nanoid@5.1.11:
+  nanoid@5.1.16:
     optional: true
 
   negotiator@1.0.0: {}
@@ -12786,7 +12786,7 @@ snapshots:
       is-unicode-supported: 2.1.0
       lifecycle-utils: 3.1.1
       log-symbols: 7.0.1
-      nanoid: 5.1.11
+      nanoid: 5.1.16
       node-addon-api: 8.8.0
       ora: 9.4.0
       pretty-ms: 9.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6382,8 +6382,8 @@ packages:
     resolution: {integrity: sha512-n6hSTZkuD59qWgHh6IP5dtDlDZQXoxk/bcA85Jywg8Z1iFrlNgl2+GTFgjZyn52W5UgQpV42V4XqrQZZAMbZTQ==}
     engines: {node: '>=18'}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -12733,7 +12733,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   nanoid@5.1.11:
     optional: true
@@ -13101,7 +13101,7 @@ snapshots:
 
   postcss@8.5.21:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,7 @@ minimumReleaseAgeExclude:
   - "hono"
   - "libopus-wasm@0.2.0"
   - "libsignal@6.0.0"
+  - "nanoid@3.3.18"
   - "openclaw"
   - "protobufjs"
   - "vite"

--- a/test/scripts/bundled-plugin-install-uninstall-probe.test.ts
+++ b/test/scripts/bundled-plugin-install-uninstall-probe.test.ts
@@ -1117,7 +1117,7 @@ describe("bundled plugin install/uninstall probe", () => {
 
   it("allows degraded runtime readiness only for expected channel failures", async () => {
     const runtimeSmoke = await importRuntimeSmokeWithEnv({
-      OPENCLAW_BUNDLED_PLUGIN_RUNTIME_HTTP_MS: "100",
+      OPENCLAW_BUNDLED_PLUGIN_RUNTIME_HTTP_MS: "1000",
       OPENCLAW_BUNDLED_PLUGIN_RUNTIME_RPC_READY_MS: "50",
     });
     const server = createHttpServer((_request, response) => {
@@ -1142,7 +1142,7 @@ describe("bundled plugin install/uninstall probe", () => {
 
   it("rejects degraded runtime readiness for unexpected channel failures", async () => {
     const runtimeSmoke = await importRuntimeSmokeWithEnv({
-      OPENCLAW_BUNDLED_PLUGIN_RUNTIME_HTTP_MS: "100",
+      OPENCLAW_BUNDLED_PLUGIN_RUNTIME_HTTP_MS: "1000",
       OPENCLAW_BUNDLED_PLUGIN_RUNTIME_RPC_READY_MS: "50",
     });
     const server = createHttpServer((_request, response) => {
@@ -1167,7 +1167,7 @@ describe("bundled plugin install/uninstall probe", () => {
 
   it("rejects generic readyz server errors in degraded runtime mode", async () => {
     const runtimeSmoke = await importRuntimeSmokeWithEnv({
-      OPENCLAW_BUNDLED_PLUGIN_RUNTIME_HTTP_MS: "100",
+      OPENCLAW_BUNDLED_PLUGIN_RUNTIME_HTTP_MS: "1000",
       OPENCLAW_BUNDLED_PLUGIN_RUNTIME_RPC_READY_MS: "50",
     });
     const server = createHttpServer((_request, response) => {
@@ -1192,7 +1192,7 @@ describe("bundled plugin install/uninstall probe", () => {
 
   it("keeps readyz HTTP status diagnostics when the body is malformed", async () => {
     const runtimeSmoke = await importRuntimeSmokeWithEnv({
-      OPENCLAW_BUNDLED_PLUGIN_RUNTIME_HTTP_MS: "100",
+      OPENCLAW_BUNDLED_PLUGIN_RUNTIME_HTTP_MS: "1000",
       OPENCLAW_BUNDLED_PLUGIN_RUNTIME_RPC_READY_MS: "50",
     });
     const server = createHttpServer((_request, response) => {
@@ -1217,7 +1217,7 @@ describe("bundled plugin install/uninstall probe", () => {
 
   it("bounds readyz diagnostic response bodies", async () => {
     const runtimeSmoke = await importRuntimeSmokeWithEnv({
-      OPENCLAW_BUNDLED_PLUGIN_RUNTIME_HTTP_MS: "100",
+      OPENCLAW_BUNDLED_PLUGIN_RUNTIME_HTTP_MS: "1000",
       OPENCLAW_BUNDLED_PLUGIN_RUNTIME_RPC_READY_MS: "50",
     });
     const server = createHttpServer((_request, response) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes release validation blockers for the unpublished 2026.6.35 extended-stable candidate: a production NanoID advisory, a missing memory `corpus=all` wiki fallback, and QMD test mocks that no longer implement the real child-stream contract.

## Why This Change Was Made

This ports the smallest verified upstream repairs onto the frozen extended-stable candidate. The memory fallback restores the production branch already covered by the candidate regression test; the QMD change updates only its test double; the lockfile update replaces the vulnerable resolved NanoID 3.x package and keeps the package-manager release-age exception explicit.

## User Impact

The candidate avoids two high-severity NanoID infinite-loop advisories and correctly returns a wiki supplement when a non-throwing all-corpus memory read misses. It also lets the release plugin validation test the real QMD stream behavior.

## Evidence

- Failed validation: https://github.com/openclaw/openclaw/actions/runs/31299294641
- Failed NPM preflight: https://github.com/openclaw/openclaw/actions/runs/31299267079
- Upstream source repairs: 9042e8020f387334448dc74c9981f0fda36f833e, 4a2c381a3a6ada0c117c93d6c1038361a3ba0e82, 3641b8271dc97cdaa86780d4ad28c7c15682cdf2
- `git diff --check` passed.
- Focused remote test was attempted but is blocked in this session: delegated Testbox requires Blacksmith authentication; the configured Azure path lacks a subscription; brokered AWS requires Crabbox login. GitHub release CI is the authoritative package/Docker proof.
- Structured autoreview completed before commit with no actionable output.
