### PR TITLE
fix(release): prefer SQLite upgrade survivor state

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -823,13 +823,12 @@ function assertSessionMetadataMigrated(stateDir) {
   const legacyStorePath = path.join(stateDir, "sessions", "sessions.json");
   const agentSessionsDir = path.join(stateDir, "agents", "main", "sessions");
   const targetStorePath = path.join(agentSessionsDir, "sessions.json");
-  const dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
   assert(
     !fs.existsSync(legacyStorePath),
     `legacy sessions.json survived migration: ${legacyStorePath}`,
   );
 
-  const store = readMigratedSessionStore(stateDir, targetStorePath);
+  const { source, store } = readMigratedSessionStore(stateDir, targetStorePath);
   const main = store["agent:main:main"];
   const direct = store["agent:main:+15551234567"];
   const group = store["agent:main:slack:channel:cupgrade"];
@@ -841,7 +840,8 @@ function assertSessionMetadataMigrated(stateDir) {
     LEGACY_SESSION_DIRECT_ID,
     LEGACY_SESSION_GROUP_ID,
   ];
-  if (fs.existsSync(dbPath)) {
+  if (source !== "file") {
+    const dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
     const db = new DatabaseSync(dbPath, { readOnly: true });
     try {
       const count = db.prepare(
@@ -885,42 +885,71 @@ function assertSessionMetadataMigrated(stateDir) {
 }
 
 function readMigratedSessionStore(stateDir, targetStorePath) {
-  if (fs.existsSync(targetStorePath)) {
-    return readJson(targetStorePath);
-  }
-
   const dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
-  assert(fs.existsSync(dbPath), `agent session store missing: ${targetStorePath} or ${dbPath}`);
-
-  let db;
-  try {
-    db = new DatabaseSync(dbPath, { readOnly: true });
-    const hasSessionEntries = db
-      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'session_nodes'")
-      .get();
-    const rows = hasSessionEntries
-      ? db
+  if (fs.existsSync(dbPath)) {
+    let db;
+    try {
+      db = new DatabaseSync(dbPath, { readOnly: true });
+      const tables = new Set(
+        db
           .prepare(
-            `SELECT session_key AS key, current_session_id AS session_id, entry_json AS value_json
-             FROM session_nodes`,
+            `SELECT name
+             FROM sqlite_master
+             WHERE type = 'table'
+               AND name IN ('session_nodes', 'session_entries', 'cache_entries')`,
           )
           .all()
-      : db
-          .prepare("SELECT key, value_json FROM cache_entries WHERE scope = ?")
-          .all("session_entries");
-    const store = {};
-    for (const row of rows) {
-      if (typeof row?.key !== "string" || typeof row?.value_json !== "string") {
-        continue;
+          .map((row) => row.name),
+      );
+      // SQLite is authoritative once it owns a supported session table. A stale
+      // sessions.json must not hide missing, malformed, or unreadable database state.
+      const source = tables.has("session_nodes")
+        ? "session_nodes"
+        : tables.has("session_entries")
+          ? "session_entries"
+          : tables.has("cache_entries")
+            ? "cache_entries"
+            : null;
+      if (source) {
+        const rows =
+          source === "session_nodes"
+            ? db
+                .prepare(
+                  `SELECT session_key AS key, current_session_id AS session_id, entry_json AS value_json
+                   FROM session_nodes`,
+                )
+                .all()
+            : source === "session_entries"
+              ? db
+                  .prepare(
+                    `SELECT session_key AS key, session_id, entry_json AS value_json
+                     FROM session_entries`,
+                  )
+                  .all()
+              : db
+                  .prepare("SELECT key, value_json FROM cache_entries WHERE scope = ?")
+                  .all("session_entries");
+        const store = {};
+        for (const row of rows) {
+          if (typeof row?.key !== "string" || typeof row?.value_json !== "string") {
+            continue;
+          }
+          const entry = JSON.parse(row.value_json);
+          store[row.key] =
+            typeof row.session_id === "string" ? { ...entry, sessionId: row.session_id } : entry;
+        }
+        return { source, store };
       }
-      const entry = JSON.parse(row.value_json);
-      store[row.key] =
-        typeof row.session_id === "string" ? { ...entry, sessionId: row.session_id } : entry;
+    } finally {
+      db?.close();
     }
-    return store;
-  } finally {
-    db?.close();
   }
+
+  assert(
+    fs.existsSync(targetStorePath),
+    `agent session store missing: ${targetStorePath} or ${dbPath}`,
+  );
+  return { source: "file", store: readJson(targetStorePath) };
 }
 
 function readInstalledPluginIndex() {

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -90,6 +90,142 @@ function writeMigratedSessionState(stateDir: string): void {
   }
 }
 
+function createMigratedSessionFileStore(
+  stateDir: string,
+  options: { includePrompt?: boolean } = {},
+): Record<string, Record<string, unknown>> {
+  const agentSessionsDir = join(stateDir, "agents", "main", "sessions");
+  const main: Record<string, unknown> = {
+    sessionId: "upgrade-main-session",
+    sessionFile: join(agentSessionsDir, "upgrade-main-session.jsonl"),
+  };
+  if (options.includePrompt !== false) {
+    main.skillsSnapshot = {
+      prompt: "legacy prompt survives as metadata",
+    };
+  }
+  return {
+    "agent:main:main": main,
+    "agent:main:+15551234567": {
+      sessionId: "upgrade-direct-session",
+      sessionFile: join(agentSessionsDir, "upgrade-direct-session.jsonl"),
+    },
+    "agent:main:slack:channel:cupgrade": {
+      sessionId: "upgrade-group-session",
+      sessionFile: join(agentSessionsDir, "upgrade-group-session.jsonl"),
+    },
+  };
+}
+
+function writeMigratedSessionFiles(
+  stateDir: string,
+  options: { includePrompt?: boolean } = {},
+): void {
+  const agentSessionsDir = join(stateDir, "agents", "main", "sessions");
+  mkdirSync(agentSessionsDir, { recursive: true });
+  writeJson(
+    join(agentSessionsDir, "sessions.json"),
+    createMigratedSessionFileStore(stateDir, options),
+  );
+  for (const sessionId of [
+    "upgrade-main-session",
+    "upgrade-direct-session",
+    "upgrade-group-session",
+  ]) {
+    writeFileSync(
+      join(agentSessionsDir, `${sessionId}.jsonl`),
+      `${JSON.stringify({ type: "session", id: sessionId })}\n`,
+    );
+  }
+}
+
+function writeLegacyCacheSessionState(
+  stateDir: string,
+  options: { empty?: boolean; includePrompt?: boolean; replaceNodes?: boolean } = {},
+) {
+  const dbPath = join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+  const db = new DatabaseSync(dbPath);
+  try {
+    if (options.replaceNodes) {
+      db.exec("DROP TABLE session_nodes;");
+    }
+    db.exec(`
+      CREATE TABLE cache_entries (
+        scope TEXT NOT NULL,
+        key TEXT NOT NULL,
+        value_json TEXT NOT NULL
+      );
+    `);
+    if (options.empty) {
+      return;
+    }
+    const insert = db.prepare(
+      "INSERT INTO cache_entries (scope, key, value_json) VALUES (?, ?, ?)",
+    );
+    for (const [key, entry] of Object.entries(createMigratedSessionFileStore(stateDir, options))) {
+      insert.run("session_entries", key, JSON.stringify(entry));
+    }
+  } finally {
+    db.close();
+  }
+}
+
+function writeLegacySessionEntriesState(stateDir: string): void {
+  const dbPath = join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec(`
+      DROP TABLE session_nodes;
+      CREATE TABLE session_entries (
+        session_key TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        entry_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+    `);
+    const insert = db.prepare(`
+      INSERT INTO session_entries (session_key, session_id, entry_json, updated_at)
+      VALUES (?, ?, ?, ?)
+    `);
+    for (const [key, entry] of Object.entries(createMigratedSessionFileStore(stateDir))) {
+      const sessionId = entry.sessionId;
+      if (typeof sessionId !== "string") {
+        throw new TypeError(`missing fixture session id for ${key}`);
+      }
+      insert.run(key, sessionId, JSON.stringify(entry), 1710000000000);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+function runSessionStateAssertion(setup: (stateDir: string) => void): void {
+  const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-session-state-"));
+  try {
+    const stateDir = join(root, "state");
+    const workspace = join(root, "workspace");
+    mkdirSync(join(stateDir, "agents", "main", "sessions"), { recursive: true });
+    mkdirSync(workspace, { recursive: true });
+    writeFileSync(join(workspace, "IDENTITY.md"), "# survivor\n");
+    writeJson(join(stateDir, "agents", "main", "sessions", "legacy-session.json"), {
+      id: "legacy-session",
+    });
+    setup(stateDir);
+
+    execFileSync(process.execPath, [ASSERTIONS_PATH, "assert-state"], {
+      env: {
+        ...process.env,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_TEST_WORKSPACE_DIR: workspace,
+        OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: "base",
+      },
+      stdio: "pipe",
+    });
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+}
+
 function assertConfiguredPluginState(params: { installPath?: string } = {}): void {
   const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-"));
   try {
@@ -374,6 +510,88 @@ describe("upgrade survivor assertions", () => {
 
   it("accepts official ClawHub npm-pack installs for configured external plugins", () => {
     expect(() => assertConfiguredPluginState()).not.toThrow();
+  });
+
+  it("prefers session_nodes over stale file and cache session stores", () => {
+    expect(() =>
+      runSessionStateAssertion((stateDir) => {
+        writeMigratedSessionState(stateDir);
+        writeMigratedSessionFiles(stateDir, { includePrompt: false });
+        writeLegacyCacheSessionState(stateDir, { includePrompt: false });
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not mask missing session_nodes rows with a valid file store", () => {
+    expect(() =>
+      runSessionStateAssertion((stateDir) => {
+        writeMigratedSessionState(stateDir);
+        const db = new DatabaseSync(
+          join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite"),
+        );
+        try {
+          db.exec("DELETE FROM session_nodes;");
+        } finally {
+          db.close();
+        }
+        writeMigratedSessionFiles(stateDir);
+      }),
+    ).toThrow(/main legacy session row missing/);
+  });
+
+  it("does not mask empty legacy cache_entries with a valid file store", () => {
+    expect(() =>
+      runSessionStateAssertion((stateDir) => {
+        writeMigratedSessionState(stateDir);
+        writeLegacyCacheSessionState(stateDir, { empty: true, replaceNodes: true });
+        writeMigratedSessionFiles(stateDir);
+      }),
+    ).toThrow(/main legacy session row missing/);
+  });
+
+  it("prefers legacy cache_entries over a stale file session store", () => {
+    expect(() =>
+      runSessionStateAssertion((stateDir) => {
+        writeMigratedSessionState(stateDir);
+        writeLegacyCacheSessionState(stateDir, { replaceNodes: true });
+        writeMigratedSessionFiles(stateDir, { includePrompt: false });
+      }),
+    ).not.toThrow();
+  });
+
+  it("prefers legacy session_entries over stale file and cache session stores", () => {
+    expect(() =>
+      runSessionStateAssertion((stateDir) => {
+        writeMigratedSessionState(stateDir);
+        writeLegacySessionEntriesState(stateDir);
+        writeLegacyCacheSessionState(stateDir, { includePrompt: false });
+        writeMigratedSessionFiles(stateDir, { includePrompt: false });
+      }),
+    ).not.toThrow();
+  });
+
+  it("uses the file session store when SQLite has no supported session table", () => {
+    expect(() =>
+      runSessionStateAssertion((stateDir) => {
+        const agentDbDir = join(stateDir, "agents", "main", "agent");
+        mkdirSync(agentDbDir, { recursive: true });
+        const db = new DatabaseSync(join(agentDbDir, "openclaw-agent.sqlite"));
+        try {
+          db.exec("CREATE TABLE unrelated_state (key TEXT PRIMARY KEY);");
+        } finally {
+          db.close();
+        }
+        writeMigratedSessionFiles(stateDir);
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts a SQLite-only migrated session store", () => {
+    expect(() =>
+      runSessionStateAssertion((stateDir) => {
+        writeMigratedSessionState(stateDir);
+      }),
+    ).not.toThrow();
   });
 
   it("rejects ClawHub npm-pack installs outside the managed extensions root", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the upgrade-survivor release check could report lost session metadata when a stale per-agent `sessions.json` coexisted with the authoritative SQLite session store.

## Why This Change Was Made

The assertion now prefers `session_nodes`, then the shipped `session_entries` predecessor, then the older `cache_entries` session scope, and uses the JSON file only when SQLite has no supported table. Transcript verification follows the selected store instead of merely checking whether a database file exists. This changes only the release-test harness; runtime storage, migrations, release branches, and package code are untouched.

Root cause: the assertion read the migrated JSON file before opening the agent database, so stale compatibility debris could shadow correct SQLite state.

## User Impact

No runtime behavior changes. Maintainers get accurate upgrade-survivor results instead of a false package-acceptance failure for preserved session metadata.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/upgrade-survivor-assertions.test.ts` - 20/20 passed
- `pnpm format scripts/e2e/lib/upgrade-survivor/assertions.mjs test/scripts/upgrade-survivor-assertions.test.ts` - passed
- `git diff --check` - passed
- project autoreview - clean, no accepted/actionable findings
- Regression coverage proves `session_nodes` wins over conflicting file/cache state, `session_entries` wins over stale file/cache state, empty supported SQLite stores cannot be masked by valid JSON, legacy `cache_entries` wins over stale JSON, and file fallback still works when SQLite has no supported session table.
- The v13 fixture validates its session ID before binding it to SQLite, covering the exact `check-test-types` failure from the previous head.
- The targeted oxlint wrapper stopped in pre-lint boundary artifact generation on an unrelated existing `packages/terminal-core/src/ansi.ts:194` `TS2554`.

Production LOC: +61/-32 (net +29) | Tests: +218/-0. The production growth records and enforces the authoritative-store ownership boundary across shipped SQLite generations and routes transcript proof through that selected source.
