### PR TITLE
fix(plugins): keep OpenCode Go bundled

### DIFF
--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-54 plugins
+55 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -131,6 +131,8 @@ Each entry lists the package, distribution route, and description.
 
 - **[openai](/plugins/reference/openai)** (`@openclaw/openai-provider`) - included in OpenClaw. Adds OpenAI model provider support to OpenClaw.
 
+- **[opencode-go](/plugins/reference/opencode-go)** (`@openclaw/opencode-go-provider`) - included in OpenClaw; npm; ClawHub: `clawhub:@openclaw/opencode-go-provider`. Adds OpenCode Go model provider support to OpenClaw.
+
 - **[openrouter](/plugins/reference/openrouter)** (`@openclaw/openrouter-provider`) - included in OpenClaw. Adds OpenRouter model provider support to OpenClaw.
 
 - **[policy](/plugins/reference/policy)** (`@openclaw/policy`) - included in OpenClaw. Adds policy-backed doctor checks for workspace conformance.
@@ -163,7 +165,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Official external packages
 
-91 plugins
+90 plugins
 
 - **[acpx](/plugins/reference/acpx)** (`@openclaw/acpx`) - npm; ClawHub. OpenClaw ACP runtime backend with plugin-owned session and transport management.
 
@@ -278,8 +280,6 @@ Each entry lists the package, distribution route, and description.
 - **[novita](/plugins/reference/novita)** (`@openclaw/novita-provider`) - npm; ClawHub: `clawhub:@openclaw/novita-provider`. Adds Novita, Novita AI, Novitaai model provider support to OpenClaw.
 
 - **[opencode](/plugins/reference/opencode)** (`@openclaw/opencode-provider`) - npm; ClawHub: `clawhub:@openclaw/opencode-provider`. Adds OpenCode model provider support to OpenClaw.
-
-- **[opencode-go](/plugins/reference/opencode-go)** (`@openclaw/opencode-go-provider`) - npm; ClawHub: `clawhub:@openclaw/opencode-go-provider`. Adds OpenCode Go model provider support to OpenClaw.
 
 - **[openshell](/plugins/reference/openshell)** (`@openclaw/openshell-sandbox`) - npm; ClawHub. OpenClaw sandbox backend for the NVIDIA OpenShell CLI with mirrored local workspaces and SSH command execution.
 

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -131,7 +131,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[openai](/plugins/reference/openai)** (`@openclaw/openai-provider`) - included in OpenClaw. Adds OpenAI model provider support to OpenClaw.
 
-- **[opencode-go](/plugins/reference/opencode-go)** (`@openclaw/opencode-go-provider`) - included in OpenClaw; npm; ClawHub: `clawhub:@openclaw/opencode-go-provider`. Adds OpenCode Go model provider support to OpenClaw.
+- **[opencode-go](/plugins/reference/opencode-go)** (`@openclaw/opencode-go-provider`) - included in OpenClaw. Adds OpenCode Go model provider support to OpenClaw.
 
 - **[openrouter](/plugins/reference/openrouter)** (`@openclaw/openrouter-provider`) - included in OpenClaw. Adds OpenRouter model provider support to OpenClaw.
 

--- a/docs/plugins/reference/opencode-go.md
+++ b/docs/plugins/reference/opencode-go.md
@@ -12,7 +12,7 @@ Adds OpenCode Go model provider support to OpenClaw.
 ## Distribution
 
 - Package: `@openclaw/opencode-go-provider`
-- Install route: npm; ClawHub: `clawhub:@openclaw/opencode-go-provider`
+- Install route: included in OpenClaw; npm; ClawHub: `clawhub:@openclaw/opencode-go-provider`
 
 ## Surface
 

--- a/docs/plugins/reference/opencode-go.md
+++ b/docs/plugins/reference/opencode-go.md
@@ -12,7 +12,7 @@ Adds OpenCode Go model provider support to OpenClaw.
 ## Distribution
 
 - Package: `@openclaw/opencode-go-provider`
-- Install route: included in OpenClaw; npm; ClawHub: `clawhub:@openclaw/opencode-go-provider`
+- Install route: included in OpenClaw
 
 ## Surface
 

--- a/docs/providers/opencode-go.md
+++ b/docs/providers/opencode-go.md
@@ -9,24 +9,21 @@ title: "OpenCode Go"
 OpenCode Go is the Go catalog inside [OpenCode](/providers/opencode). It shares
 the `OPENCODE_API_KEY` credential with the Zen catalog, but keeps its own
 runtime provider id (`opencode-go`) so upstream per-model routing stays
-correct. OpenClaw provides it as the official external
-`@openclaw/opencode-go-provider` plugin.
+correct. OpenCode Go is bundled in the OpenClaw package for this release, so
+onboarding and configuration are sufficient; no separate plugin install is
+required.
 
 | Property         | Value                                              |
 | ---------------- | -------------------------------------------------- |
 | Runtime provider | `opencode-go`                                      |
-| Plugin           | `@openclaw/opencode-go-provider`                   |
+| Plugin           | Bundled (`opencode-go`)                            |
 | Auth             | `OPENCODE_API_KEY` (alias: `OPENCODE_ZEN_API_KEY`) |
 | Parent setup     | [OpenCode](/providers/opencode)                    |
 
 ## Getting started
 
-Install the official plugin and restart the Gateway:
-
-```bash
-openclaw plugins install @openclaw/opencode-go-provider
-openclaw gateway restart
-```
+OpenCode Go is already included with OpenClaw for this release. Continue with
+interactive onboarding or pass the shared OpenCode API key directly.
 
 <Tabs>
   <Tab title="Interactive">

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -55,11 +55,9 @@ one OpenCode setup.
     **Best for:** the OpenCode-hosted Kimi, GLM, MiniMax, Qwen, and DeepSeek lineup.
 
     <Steps>
-      <Step title="Install the Go catalog plugin">
-        ```bash
-        openclaw plugins install @openclaw/opencode-go-provider
-        openclaw gateway restart
-        ```
+      <Step title="Use the bundled Go catalog">
+        OpenCode Go is included with OpenClaw for this release, so no separate
+        plugin installation or Gateway restart is required.
       </Step>
       <Step title="Run onboarding">
         ```bash

--- a/extensions/opencode-go/README.md
+++ b/extensions/opencode-go/README.md
@@ -2,12 +2,8 @@
 
 Official OpenClaw provider plugin for the OpenCode Go model catalog.
 
-Install from OpenClaw:
-
-```bash
-openclaw plugins install @openclaw/opencode-go-provider
-openclaw gateway restart
-```
+OpenCode Go is bundled with OpenClaw for this release; no separate plugin
+installation is required.
 
 Configure `OPENCODE_API_KEY` or `OPENCODE_ZEN_API_KEY`, then select an
 `opencode-go/...` model.

--- a/extensions/opencode-go/package.json
+++ b/extensions/opencode-go/package.json
@@ -24,7 +24,8 @@
       "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.8.1"
+      "openclawVersion": "2026.8.1",
+      "bundledDist": true
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/opencode-go/package.json
+++ b/extensions/opencode-go/package.json
@@ -24,8 +24,7 @@
       "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.8.1",
-      "bundledDist": false
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/package.json
+++ b/package.json
@@ -307,7 +307,6 @@
     "!dist/extensions/nostr/**",
     "!dist/extensions/novita/**",
     "!dist/extensions/opencode/**",
-    "!dist/extensions/opencode-go/**",
     "!dist/extensions/parallel/**",
     "!dist/extensions/perplexity/**",
     "!dist/extensions/qianfan/**",

--- a/scripts/generate-plugin-inventory-doc.mjs
+++ b/scripts/generate-plugin-inventory-doc.mjs
@@ -334,6 +334,10 @@ function resolveInstallRoute(packageJson, status) {
     return "source checkout only";
   }
   if (status === "core") {
+    // Explicit bundle ownership describes the current install surface; release flags may stage future publication.
+    if (packageJson.openclaw?.build?.bundledDist === true) {
+      return "included in OpenClaw";
+    }
     const release = packageJson.openclaw?.release;
     if (release?.publishToClawHub === true || release?.publishToNpm === true) {
       return `included in OpenClaw; ${resolveInstallRoute(packageJson, "external")}`;

--- a/scripts/lib/plugin-clawhub-release.ts
+++ b/scripts/lib/plugin-clawhub-release.ts
@@ -13,6 +13,7 @@ import {
   collectChangedExtensionIdsFromPaths,
   collectPublishablePluginPackageErrors,
   collectRequiredLatestDependencies,
+  isPluginExternalPublicationDeferred,
   assertPluginReleaseVersionFloors,
   parsePluginReleaseArgs,
   resolvePublishablePluginVersion,
@@ -45,6 +46,7 @@ type PluginPackageJson = {
       minGatewayVersion?: string;
     };
     build?: {
+      bundledDist?: boolean;
       openclawVersion?: string;
       pluginSdkVersion?: string;
     };
@@ -281,6 +283,9 @@ export function collectClawHubPublishablePluginPackages(
     }
     const packageName = packageJson.name?.trim() ?? "";
     if (hasSelectedPackageNames && !selectedPackageNames.has(packageName)) {
+      continue;
+    }
+    if (isPluginExternalPublicationDeferred(packageJson)) {
       continue;
     }
     if (packageJson.openclaw?.release?.publishToClawHub !== true) {

--- a/scripts/lib/plugin-npm-release.ts
+++ b/scripts/lib/plugin-npm-release.ts
@@ -34,6 +34,7 @@ type PluginPackageJson = {
       minGatewayVersion?: string;
     };
     build?: {
+      bundledDist?: boolean;
       openclawVersion?: string;
       pluginSdkVersion?: string;
     };
@@ -44,6 +45,13 @@ type PluginPackageJson = {
     };
   };
 };
+
+/** Explicit core ownership defers staged external publication until the plugin is externalized. */
+export function isPluginExternalPublicationDeferred(packageJson: {
+  openclaw?: { build?: { bundledDist?: unknown } };
+}): boolean {
+  return packageJson.openclaw?.build?.bundledDist === true;
+}
 
 export type RequiredLatestDependency = {
   packageName: string;
@@ -428,6 +436,9 @@ export function collectPublishablePluginPackages(
     }
     const packageName = packageJson.name?.trim() ?? "";
     if (hasSelectedPackageNames && !selectedPackageNames.has(packageName)) {
+      continue;
+    }
+    if (isPluginExternalPublicationDeferred(packageJson)) {
       continue;
     }
     if (packageJson.openclaw?.release?.publishToNpm !== true) {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.load-path.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.load-path.test.ts
@@ -45,6 +45,41 @@ function writeProviderPlugin(rootDir: string): void {
   );
 }
 
+function writeBundledOpenCodeGoPlugin(bundledPluginsDir: string): void {
+  const pluginDir = path.join(bundledPluginsDir, "opencode-go");
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(path.join(pluginDir, "index.js"), "export default {};\n", "utf8");
+  fs.writeFileSync(
+    path.join(pluginDir, "package.json"),
+    JSON.stringify({
+      name: "@openclaw/opencode-go-provider",
+      version: "2026.8.1",
+      openclaw: {
+        extensions: ["./index.js"],
+        install: {
+          clawhubSpec: "clawhub:@openclaw/opencode-go-provider",
+          npmSpec: "@openclaw/opencode-go-provider",
+          defaultChoice: "npm",
+        },
+        build: { openclawVersion: "2026.8.1" },
+        release: { publishToClawHub: true, publishToNpm: true },
+      },
+    }),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(pluginDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: "opencode-go",
+      activation: { onStartup: false },
+      enabledByDefault: true,
+      providers: ["opencode-go"],
+      configSchema: { type: "object", additionalProperties: false, properties: {} },
+    }),
+    "utf8",
+  );
+}
+
 describe("configured plugin install health for explicit load paths", () => {
   it("does not install a provider plugin already present at a configured load path", async () => {
     const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-load-path-provider-"));
@@ -75,6 +110,55 @@ describe("configured plugin install health for explicit load paths", () => {
 
     const repair = await repairMissingConfiguredPluginInstalls({ cfg, env });
     expect(repair).toMatchObject({
+      changes: [],
+      records: {},
+      warnings: [],
+    });
+  });
+
+  it("discovers packaged OpenCode Go before configured-plugin repair", async () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-opencode-go-"));
+    tempDirs.push(rootDir);
+    const homeDir = path.join(rootDir, "home");
+    const stateDir = path.join(rootDir, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const bundledPluginsDir = path.join(rootDir, "dist", "extensions");
+    fs.mkdirSync(homeDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+    writeBundledOpenCodeGoPlugin(bundledPluginsDir);
+
+    const cfg = {
+      auth: {
+        profiles: {
+          "opencode-go:default": { provider: "opencode-go", mode: "api_key" as const },
+        },
+      },
+    };
+    fs.writeFileSync(configPath, `${JSON.stringify(cfg)}\n`, "utf8");
+    const env = {
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      OPENCLAW_HOME: homeDir,
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPluginsDir,
+      OPENCLAW_DISABLE_BUNDLED_SOURCE_OVERLAYS: "1",
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      NPM_CONFIG_REGISTRY: "http://127.0.0.1:9",
+      npm_config_registry: "http://127.0.0.1:9",
+      XDG_CONFIG_HOME: path.join(rootDir, "xdg-config"),
+      VITEST: "true",
+    };
+    const snapshot = loadManifestMetadataSnapshot({ config: cfg, env });
+    expect(snapshot.plugins).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "opencode-go", origin: "bundled" })]),
+    );
+
+    const issues = await detectConfiguredPluginInstallHealthIssues({ cfg, env });
+    expect(issues).toStrictEqual([]);
+
+    const repair = await repairMissingConfiguredPluginInstalls({ cfg, env });
+    expect(repair).toStrictEqual({
       changes: [],
       records: {},
       warnings: [],

--- a/test/plugin-npm-release.test.ts
+++ b/test/plugin-npm-release.test.ts
@@ -540,6 +540,28 @@ describe("collectPluginReleasePlan", () => {
 });
 
 describe("collectPublishablePluginPackages", () => {
+  it("defers explicitly bundled plugins from npm and ClawHub release plans", () => {
+    const repoDir = makeTempRepoRoot(tempDirs, "openclaw-plugin-npm-release-");
+    mkdirSync(join(repoDir, "extensions", "demo-plugin"), { recursive: true });
+    writePluginReadme(repoDir, "demo-plugin");
+    writeJsonFile(join(repoDir, "extensions", "demo-plugin", "package.json"), {
+      name: "@openclaw/demo-plugin",
+      version: "2026.4.10",
+      type: "module",
+      repository: { type: "git", url: OPENCLAW_PLUGIN_NPM_REPOSITORY_URL },
+      openclaw: {
+        extensions: ["./index.ts"],
+        ...externalPluginContract("2026.4.10"),
+        build: { openclawVersion: "2026.4.10", bundledDist: true },
+        install: { npmSpec: "@openclaw/demo-plugin" },
+        release: { publishToClawHub: true, publishToNpm: true },
+      },
+    });
+
+    expect(collectPublishablePluginPackages(repoDir)).toStrictEqual([]);
+    expect(collectClawHubPublishablePluginPackages(repoDir)).toStrictEqual([]);
+  });
+
   it("keeps publishable plugin dist trees out of the core npm package unless bundled", () => {
     const corePackageRuntimePluginIds = new Set(["discord"]);
     const rootPackage = JSON.parse(readFileSync("package.json", "utf8")) as {

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -356,13 +356,24 @@ describe("bundled plugin build entries", () => {
       "mistral",
       "novita",
       "opencode",
-      "opencode-go",
       "xiaomi",
     ]) {
       expect(artifacts).not.toContain(`dist/extensions/${pluginId}/index.js`);
       expect(artifacts).not.toContain(`dist/extensions/${pluginId}/openclaw.plugin.json`);
       expect(artifacts).not.toContain(`dist/extensions/${pluginId}/package.json`);
     }
+  });
+
+  it("keeps OpenCode Go bundled until its companion artifact is available", () => {
+    const artifacts = listBundledPluginPackArtifacts();
+
+    expect(artifacts).toEqual(
+      expect.arrayContaining([
+        "dist/extensions/opencode-go/index.js",
+        "dist/extensions/opencode-go/openclaw.plugin.json",
+        "dist/extensions/opencode-go/package.json",
+      ]),
+    );
   });
 
   it("excludes the externalized Vydra provider from bundled artifacts", () => {


### PR DESCRIPTION
Related: #117064

## What Problem This Solves

Fixes an issue where users with a configured `opencode-go:default` profile could be sent through configured-plugin repair even though OpenCode Go was expected to remain available with OpenClaw. PR #117064 excluded OpenCode Go from the core package before a usable companion artifact was published: npm currently has only a manifestless `0.0.0` placeholder, and ClawHub has no usable companion artifact. Repair therefore correctly rejected the placeholder with `plugin id mismatch: expected opencode-go, got @openclaw/opencode-go-provider` because it lacks `openclaw.plugin.json`.

## Why This Change Was Made

OpenCode Go is restored to the core distribution by marking `bundledDist: true` and removing its root package exclusion. Explicit bundled ownership makes generated and provider documentation expose only the currently usable bundled route and defers both npm and ClawHub publication plans, while official release metadata remains staged for a later externalization after publication is verified. Installer identity validation is intentionally unchanged: rejecting a manifestless or mismatched package remains the correct safety boundary.

## User Impact

OpenCode Go is bundled for this release. Existing configured profiles are discovered from the packaged plugin before Doctor considers install repair, so onboarding, model listing, and `openclaw doctor --fix` work without reaching npm or requiring a separate plugin install. Normal release automation also leaves the staged companion unpublished until the plugin is explicitly externalized.

No CHANGELOG change; release generation owns it.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/bundled-plugin-build-entries.test.ts src/commands/doctor/shared/missing-configured-plugin-install.load-path.test.ts`: 35 tests passed.
- After CI and ClawSweeper findings, the focused command was expanded across npm and ClawHub release planning, inventory, bundled artifacts, Doctor repair, and the Plugin SDK baseline: 143 tests passed.
- Hardened real-path regression on Blacksmith Testbox lease `tbx_01kzjmgqm9a4scnrp320c43e05`: 2 tests passed.
- `pnpm build` passed on the same Testbox lease.
- Curated `node scripts/package-openclaw-for-docker.mjs --skip-build --allow-unreleased-changelog ...` package integrity passed and included `dist/extensions/opencode-go/index.js`, `openclaw.plugin.json`, and `package.json`.
- A fresh tarball installation with npm forced to `http://127.0.0.1:9` reported OpenCode Go as bundled, loaded, and enabled; `doctor --fix --non-interactive --yes` exited 0 without install messages.
- Source-blind validation passed all six clauses. Artifact SHA-256: `641be04111585129b9bf5b42bae60a7c6ab2339c2ed5cbcddca7f43eea5326a9`.
- Testbox-backed Actions evidence: https://github.com/openclaw/openclaw/actions/runs/31299731327
- The initial plain `npm pack` probe on that run failed after the build because this repository requires the curated package builder. The corrected package and install commands passed on the same retained lease.
- `node scripts/generate-plugin-inventory-doc.mjs --check` and `git diff --check` passed.
- Current `main` was independently red in `check-plugin-sdk-api-baseline` (https://github.com/openclaw/openclaw/actions/runs/31305384952). A later main commit refreshed the same generated hash; after rebasing onto it, `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check` passes and this PR carries no Plugin SDK baseline diff.
- Exact-head CI passed for `534a6f019d3a00a44253fffd2933e7640d2c09bf`: https://github.com/openclaw/openclaw/actions/runs/31307062008
- Final post-fix structured autoreview was clean with no accepted or actionable findings.
- ClawSweeper's exact-head findings and Rank-up moves were addressed: both external publication planners defer explicit bundles, and every provider/reference/extension guide exposes only the bundled route.
- Runtime/tooling/package metadata: +21/-2. Tests: +118/-1. Docs/generated: +16/-25.
