### PR TITLE
fix(zalo): treat a non-positive mediaMaxMb as unset, not a 0-byte cap

### DIFF
--- a/extensions/zalo/src/monitor.image.polling.test-support.ts
+++ b/extensions/zalo/src/monitor.image.polling.test-support.ts
@@ -320,4 +320,44 @@ describe("Zalo polling image handling", () => {
       server.close(() => resolve());
     });
   });
+
+  it.each([
+    { mediaMaxMb: 0, expectedMaxBytes: 5 * 1024 * 1024 },
+    { mediaMaxMb: -5, expectedMaxBytes: 5 * 1024 * 1024 },
+    { mediaMaxMb: 2, expectedMaxBytes: 2 * 1024 * 1024 },
+  ])(
+    "caps inbound image downloads at $expectedMaxBytes bytes when mediaMaxMb is $mediaMaxMb",
+    async ({ mediaMaxMb, expectedMaxBytes }) => {
+      getUpdatesMock
+        .mockResolvedValueOnce({
+          ok: true,
+          result: createImageUpdate({ messageId: `zalo-image-cap-${mediaMaxMb}` }),
+        })
+        .mockImplementation(() => new Promise(() => {}));
+
+      const { monitorZaloProvider } = await loadCachedLifecycleMonitorModule("zalo-image-polling");
+      const abort = new AbortController();
+      const runtime = createRuntimeEnv();
+      const { account, config } = createLifecycleMonitorSetup({
+        accountId: "default",
+        dmPolicy: "open",
+        mediaMaxMb,
+      });
+      const run = monitorZaloProvider({
+        token: "zalo-token", // pragma: allowlist secret
+        account,
+        config,
+        runtime,
+        abortSignal: abort.signal,
+      });
+
+      await settleAsyncWork();
+      expect(saveRemoteMediaMock).toHaveBeenCalledWith(
+        expect.objectContaining({ maxBytes: expectedMaxBytes }),
+      );
+
+      abort.abort();
+      await run;
+    },
+  );
 });

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -869,7 +869,14 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
   } = options;
 
   const core = getZaloRuntime();
-  const effectiveMediaMaxMb = account.config.mediaMaxMb ?? DEFAULT_MEDIA_MAX_MB;
+  // A non-positive cap cannot bound a transfer, so treat it as unset: `??` alone
+  // keeps 0/negatives and turns every inbound download and hosted outbound send
+  // into a 0-byte limit the media core rejects.
+  const configuredMediaMaxMb = account.config.mediaMaxMb;
+  const effectiveMediaMaxMb =
+    typeof configuredMediaMaxMb === "number" && configuredMediaMaxMb > 0
+      ? configuredMediaMaxMb
+      : DEFAULT_MEDIA_MAX_MB;
   const fetcher = fetcherOverride ?? resolveZaloProxyFetch(account.config.proxy);
   const mode = useWebhook ? "webhook" : "polling";
   const effectiveWebhookUrl = normalizeWebhookUrl(webhookUrl ?? account.config.webhookUrl);

--- a/extensions/zalo/src/test-support/lifecycle-test-support.ts
+++ b/extensions/zalo/src/test-support/lifecycle-test-support.ts
@@ -8,6 +8,15 @@ import { expect, vi } from "vitest";
 import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
 import type { ResolvedZaloAccount } from "../types.js";
 
+type LifecycleMonitorSetupParams = {
+  accountId: string;
+  dmPolicy: "open" | "pairing";
+  allowFrom?: string[];
+  webhookUrl?: string;
+  webhookSecret?: string;
+  mediaMaxMb?: number;
+};
+
 function resolveLifecycleAllowFrom(params: {
   dmPolicy: "open" | "pairing";
   allowFrom?: string[];
@@ -15,65 +24,43 @@ function resolveLifecycleAllowFrom(params: {
   return params.allowFrom ?? (params.dmPolicy === "open" ? ["*"] : undefined);
 }
 
-function createLifecycleConfig(params: {
-  accountId: string;
-  dmPolicy: "open" | "pairing";
-  allowFrom?: string[];
-  webhookUrl?: string;
-  webhookSecret?: string;
-}): OpenClawConfig {
-  const webhookUrl = params.webhookUrl ?? "https://example.com/hooks/zalo";
-  const webhookSecret = params.webhookSecret ?? "supersecret";
+function createLifecycleAccountConfig(params: LifecycleMonitorSetupParams) {
   const allowFrom = resolveLifecycleAllowFrom(params);
+  return {
+    webhookUrl: params.webhookUrl ?? "https://example.com/hooks/zalo",
+    webhookSecret: params.webhookSecret ?? "supersecret", // pragma: allowlist secret
+    dmPolicy: params.dmPolicy,
+    ...(allowFrom ? { allowFrom } : {}),
+    // Kept undefined-free so cases can assert on an account config that never
+    // declared the key, which is what the resolver's unset branch expects.
+    ...(params.mediaMaxMb === undefined ? {} : { mediaMaxMb: params.mediaMaxMb }),
+  };
+}
+
+function createLifecycleConfig(params: LifecycleMonitorSetupParams): OpenClawConfig {
   return {
     channels: {
       zalo: {
         enabled: true,
         accounts: {
-          [params.accountId]: {
-            enabled: true,
-            webhookUrl,
-            webhookSecret, // pragma: allowlist secret
-            dmPolicy: params.dmPolicy,
-            ...(allowFrom ? { allowFrom } : {}),
-          },
+          [params.accountId]: { enabled: true, ...createLifecycleAccountConfig(params) },
         },
       },
     },
   } as OpenClawConfig;
 }
 
-function createLifecycleAccount(params: {
-  accountId: string;
-  dmPolicy: "open" | "pairing";
-  allowFrom?: string[];
-  webhookUrl?: string;
-  webhookSecret?: string;
-}): ResolvedZaloAccount {
-  const webhookUrl = params.webhookUrl ?? "https://example.com/hooks/zalo";
-  const webhookSecret = params.webhookSecret ?? "supersecret";
-  const allowFrom = resolveLifecycleAllowFrom(params);
+function createLifecycleAccount(params: LifecycleMonitorSetupParams): ResolvedZaloAccount {
   return {
     accountId: params.accountId,
     enabled: true,
     token: "zalo-token",
     tokenSource: "config",
-    config: {
-      webhookUrl,
-      webhookSecret, // pragma: allowlist secret
-      dmPolicy: params.dmPolicy,
-      ...(allowFrom ? { allowFrom } : {}),
-    },
+    config: createLifecycleAccountConfig(params),
   } as ResolvedZaloAccount;
 }
 
-export function createLifecycleMonitorSetup(params: {
-  accountId: string;
-  dmPolicy: "open" | "pairing";
-  allowFrom?: string[];
-  webhookUrl?: string;
-  webhookSecret?: string;
-}) {
+export function createLifecycleMonitorSetup(params: LifecycleMonitorSetupParams) {
   return {
     account: createLifecycleAccount(params),
     config: createLifecycleConfig(params),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who set `channels.zalo.mediaMaxMb` to `0` — or to a
negative value — silently lose inbound Zalo media on that account. Every non-empty image
payload is dropped and the agent is handed `[zalo image attachment unavailable]` instead: a
response that declares `content-length` is rejected by `src/media/fetch.ts:436`
(`length > params.maxBytes`), and one that does not is rejected by
`src/media/store.ts:481-483` on its first non-empty chunk (`total > params.maxBytes`).
The value is accepted by config validation — Zalo's own schema declares `mediaMaxMb` with
no range — so nothing rejects it at load time. The startup log does echo it back
(`Zalo provider init mode=polling mediaMaxMb=0`), but the failure itself never connects to
it — each dropped image only produces:

```
[default] Failed to download Zalo image: MediaFetchError: Failed to fetch media from
  <photo_url>: content length 3072 exceeds maxBytes 0
```

The shared contract other channels use forbids non-positive values:
`CommonMediaMaxMbSchema = z.number().positive()`
(`src/config/zod-schema.channel-messaging-common.ts`). Channels that reuse it publish
`exclusiveMinimum: 0` in the generated config metadata, so the value can never reach their
resolvers. **Zalo does not use it** — it declares its own `mediaMaxMb` without a range, so
the raw value survives validation and lands on the resolver.

Resolvers that have to cope with a raw number already agree on what a non-positive value
means. Their predicates are not identical — the two core ones also require
`Number.isFinite`, so they reject `Infinity` where the WhatsApp one accepts it — but all
three fall back to a default rather than treating a non-positive value as a cap:

- `src/gateway/chat-attachment-policy.ts:14-17` — `typeof configured === "number" && Number.isFinite(configured) && configured > 0`
- `src/media/configured-max-bytes.ts:11-12` and `:60-61` — the same predicate
- `extensions/whatsapp/src/accounts.ts:157-164` — `resolveWhatsAppMediaMaxBytes` is this
  patch's predicate, already shipped: `typeof account.mediaMaxMb === "number" && account.mediaMaxMb > 0 ? account.mediaMaxMb : DEFAULT_WHATSAPP_MEDIA_MAX_MB`

Zalo's resolver is the outlier: it turns the value into a literal byte budget instead.

## Why This Change Was Made

`monitorZaloProvider` (`extensions/zalo/src/monitor.ts`) owns what an account's media cap
means, and it resolved that cap with `??`. That one line is the whole production change:

```ts
// before
const effectiveMediaMaxMb = account.config.mediaMaxMb ?? DEFAULT_MEDIA_MAX_MB;

// after
const configuredMediaMaxMb = account.config.mediaMaxMb;
const effectiveMediaMaxMb =
  typeof configuredMediaMaxMb === "number" && configuredMediaMaxMb > 0
    ? configuredMediaMaxMb
    : DEFAULT_MEDIA_MAX_MB;
```

The harness that produced the captures below is pinned beside this work item and is
byte-identical across the two runs; ClawProof checks out the baseline and the candidate
into two worktrees from one clone and runs it in each, so the only variable is the source.

`??` only replaces `null`/`undefined`, so `0` and negatives survive into
`mediaMaxMb * 1024 * 1024`. On the inbound leg that budget goes straight to
`saveRemoteMedia`, whose content-length check rejects any non-empty payload. Nothing
upstream normalizes the value: the zalo config schema declares `mediaMaxMb` with no range,
and `mergeAccountConfig` (`src/channels/plugins/account-helpers.ts`) is a plain spread
that keeps `0`.

This patch changes that one resolver and nothing else in production code. It reuses the
existing fallback; no new fallback path is added. The unset-to-`DEFAULT_MEDIA_MAX_MB`
fallback already lives on this line, and the guard widens the condition that triggers it
from "unset" to "unset or not a usable cap". The hosted outbound leg reads the same
resolved constant, so the guard reaches it as well (see User Impact and the limitations
note). The existing startup log then reports the effective cap (`mediaMaxMb=5`) instead of
the unusable one.

**Design note.** #120466 made the same fix for Matrix and landed the semantics as
"non-positive = uncapped", because Matrix's `loadWebMedia` reads `undefined` as no cap.
Zalo's resolver already defines "unset" as `DEFAULT_MEDIA_MAX_MB`, so the same invariant
lands as the channel's own default rather than as uncapped.

The resolver is the durable place for this. It owns the meaning of the account's cap and
has to be total over whatever the schema lets through, so the guard is not a stopgap for a
missing constraint. Tightening `extensions/zalo/src/config-schema.ts` with `.positive()`
would be additive on top of it, and is left out here for two reasons that hold on their
own: it changes load-time behaviour for configs that parse today, and it forces a
regeneration of `src/config/bundled-channel-config-metadata.generated.ts`, which is a
cross-channel artifact rather than a zalo-local one.
`extensions/line/src/bot.ts` has the same resolver defect and belongs in its own PR, since
it is a different owner module.

## User Impact

Operators who set `mediaMaxMb: 0`, or who typo a negative, now get the channel default
(5 MB) instead of an account whose inbound media silently stops working. A configured
positive limit is unchanged, and so is the unset case.

Because the resolver feeds both media legs, hosted outbound sends
(`deliverZaloReply({ mediaMaxBytes })` → `prepareHostedZaloMediaUrl`) on such an account
also start using the 5 MB default instead of the unusable budget. **That is a code-level
inference, not a captured one** — it follows from both legs reading one resolved constant,
and only the inbound leg is captured below. It is intentional and in scope: the invariant
being repaired is what the account's cap *means*, and splitting it per leg would leave the
same setting meaning two different things.

## Evidence

### Real behavior proof

Behavior addressed: a non-positive `channels.zalo.mediaMaxMb` reaching the media core as a
byte budget, so inbound Zalo images are rejected before the agent ever sees them.

Real environment tested: Linux x86_64, node v24.18.0. Baseline `c5bdad48defb`
(upstream/main), candidate `c755e31d54e0` (this PR's head).

Exact steps or command run after this patch:

The first two commands are the same command run twice — once against the baseline
checkout and once against this patch — which is what makes the two captures comparable.

```sh
# A before/after harness, kept outside the repository. Both sides run the same
# bytes of it against the same fixture bytes; only the checked-out source differs.
HARNESS="$HOME/.clawproof/work-items/zalo-media-cap-nonpositive/proof/harness/harness.mjs"

# run from the baseline worktree, checked out at c5bdad48defb
node --import tsx "$HARNESS"

# run from the candidate worktree, checked out at c755e31d54e0
node --import tsx "$HARNESS"

# the regression tests, which need nothing but this repository
node scripts/run-vitest.mjs extensions/zalo/src/monitor.polling-lifecycle.test.ts
```

The harness drives the real `monitorZaloProvider`. It polls a loopback Zalo Bot API
fixture (through the supported `ZALO_API_URL` override), receives one
`message.image.received` update, and downloads the photo through the **real**
`saveRemoteMedia` against a loopback media host serving a 3072-byte JPEG with
`content-length`. Cap resolution and limit enforcement are production code throughout; the
harness supplies config and records what that code did. Three substitutions, all outside
the behaviour under test: `ZALO_API_URL` points at the loopback fixture;
`saveRemoteMedia` is wrapped to record its arguments and to add
`ssrfPolicy.allowPrivateNetwork` for the loopback host, passing `maxBytes` through
untouched; and `channel.inbound.dispatch` records the context the monitor built for the
agent instead of running one.

Before (pre-fix, `c5bdad48defb`) — the `0` case; `-5` behaves the same way and both
controls are in the table below:

```text
===== BEFORE (baseline c5bdad48defb, unfixed source) =====
--- harness.stderr ---
[harness: running mediaMaxMb=0 (defect case)]
[harness:   download attempted=true saved=false]
[harness: running mediaMaxMb=-5 (defect case, negative)]
[harness:   download attempted=true saved=false]
[harness: running mediaMaxMb unset (control)]
[harness:   download attempted=true saved=true]
[harness: running mediaMaxMb=2 (control, positive honored)]
[harness:   download attempted=true saved=true]
--- harness.stdout ---
      "case": "mediaMaxMb=0 (defect case)",
      "configuredMediaMaxMb": 0,
      "servedPayloadBytes": 3072,
      "downloadAttempted": true,
      "maxBytesPassedToMediaCore": 0,
      "mediaSaved": false,
      "savedBytes": null,
      "savedContentType": null,
      "mediaCoreError": "Failed to fetch media from http://127.0.0.1:36011/inbound/photo.jpg: content length 3072 exceeds maxBytes 0",
      "agentBodyForAgent": "[zalo image attachment unavailable]",
      "agentMedia": [
        {
          "kind": "image",
          "contentType": "image",
          "hasPath": false
        }
      ],
      "zaloLogLines": [
        "log: [default] Zalo provider init mode=polling mediaMaxMb=0",
        "error: [default] Failed to download Zalo image: MediaFetchError: Failed to fetch media from http://127.0.0.1:36011/inbound/photo.jpg: content length 3072 exceeds maxBytes 0"
      ],
```

Evidence after fix: same harness, same fixture, candidate `c755e31d54e0`.

```text
===== AFTER (candidate c755e31d54e0, fix applied) =====
--- harness.stderr ---
[harness: running mediaMaxMb=0 (defect case)]
[harness:   download attempted=true saved=true]
[harness: running mediaMaxMb=-5 (defect case, negative)]
[harness:   download attempted=true saved=true]
[harness: running mediaMaxMb unset (control)]
[harness:   download attempted=true saved=true]
[harness: running mediaMaxMb=2 (control, positive honored)]
[harness:   download attempted=true saved=true]
--- harness.stdout ---
      "case": "mediaMaxMb=0 (defect case)",
      "configuredMediaMaxMb": 0,
      "servedPayloadBytes": 3072,
      "downloadAttempted": true,
      "maxBytesPassedToMediaCore": 5242880,
      "mediaSaved": true,
      "savedBytes": 3072,
      "savedContentType": "image/jpeg",
      "mediaCoreError": null,
      "agentBodyForAgent": "",
      "agentMedia": [
        {
          "kind": "image",
          "contentType": "image/jpeg",
          "hasPath": true
        }
      ],
      "zaloLogLines": [
        "log: [default] Zalo provider init mode=polling mediaMaxMb=5"
      ],
```

Observed result after fix: the two defect cases resolve to the 5 MB default and the saved
image reaches the dispatch context; both controls are untouched.

| configured `mediaMaxMb` (MB) | `maxBytes` reaching the media core (bytes) | image saved | dispatch context carries |
|---|---|---|---|
| `0` | `0` → **`5242880`** | no → **yes** | notice → **`image/jpeg`, 3072 B, path set** |
| `-5` | `-5242880` → **`5242880`** | no → **yes** | notice → **`image/jpeg`, 3072 B, path set** |
| unset (control) | `5242880` (unchanged) | yes (unchanged) | unchanged |
| `2` (control) | `2097152` (unchanged) | yes (unchanged) | unchanged |

What was not tested: only the inbound download leg is captured, on both sides. For the
hosted outbound leg **neither the baseline behaviour nor the post-fix behaviour is captured
here** (see User Impact for why the guard still reaches it), and its baseline
failure mode is not the one shown above: for optimizable images `loadWebMedia`
(`src/media/web-media.ts:1135-1141`) widens the *source read* cap to
`Math.max(maxBytes, defaultSourceReadCap)`, so a non-positive budget is rejected by the
later delivery-cap check rather than by the content-length check. The direct (non-hosted) outbound path is
unaffected: in `deliverZaloReply`'s `sendMedia`, the cap is only passed on the
`canHostMedia && webhookUrl && webhookPath` branch, and the other branch forwards
`mediaUrl` untouched.

The capture is one 3072-byte JPEG per case, not a corpus; it generalizes because the
rejected comparison is a size check against a non-positive bound, which no non-empty
payload can pass. No live Zalo account is involved: the Bot API and the photo host are
loopback fixtures, and the harness records the dispatch context the monitor built for the
agent rather than running an agent, so "the image reaches the agent" means "the saved
media is present in that context".

### Regression tests

`extensions/zalo/src/monitor.image.polling.test-support.ts` adds a table-driven case over
`0`, `-5`, and `2`, asserting the `maxBytes` the monitor hands to the inbound download.
The unset case is already pinned by an existing test in the same file.

```
node scripts/run-vitest.mjs extensions/zalo/src/monitor.polling-lifecycle.test.ts
 Test Files  1 passed (1)
      Tests  29 passed (29)
```

Reverting only the guard fails exactly the two defect rows and leaves the positive-value
control row green, so the assertions have teeth:

```
 × caps inbound image downloads at 5242880 bytes when mediaMaxMb is +0
 × caps inbound image downloads at 5242880 bytes when mediaMaxMb is -5
AssertionError: expected "vi.fn()" to be called with arguments: [ ObjectContaining{…} ]
-     "maxBytes": 5242880,
+     "maxBytes": 0,
AssertionError: expected "vi.fn()" to be called with arguments: [ ObjectContaining{…} ]
-     "maxBytes": 5242880,
+     "maxBytes": -5242880,
 Test Files  1 failed (1)
      Tests  2 failed | 27 passed (29)
```

The full zalo lane is green on this head:

```
node scripts/run-vitest.mjs extensions/zalo
 Test Files  8 passed (8)
      Tests  59 passed (59)
```

The before/after harness lives outside the repository, so only the Vitest commands above
are reproducible from a checkout alone.

### Scope and state

- **Root cause:** the media-cap resolver in `monitorZaloProvider` used `??`, which keeps
  `0` and negatives because it only replaces `null`/`undefined`.
- **Fix:** one resolver change — widen the existing unset-to-default condition so a
  non-positive value also falls back to `DEFAULT_MEDIA_MAX_MB`. Production diff is one
  file, +8/-1 lines, of which three are the explanatory comment. No new export, parameter, returned field,
  persisted state, config key, or additional fallback branch.
- **Tests:** 3 table-driven cases added to the existing zalo polling-image suite. The other
  changed file, `extensions/zalo/src/test-support/lifecycle-test-support.ts`, is a test-only
  helper. It gains one `mediaMaxMb` input; because three functions had that parameter shape
  written out inline, the shape is named once instead of the new field being pasted three
  times. No production behaviour changes.
- **Non-Scope:** four things are deliberately out of scope here — `.positive()` on the zalo
  config schema; `extensions/line/src/bot.ts`, which has the same defect in a different
  owner module; anything under `src/media/**`; and the direct (non-hosted) outbound path,
  which never applies the cap.
- **Head / proof freshness:** head `c755e31d54e0477d7c7c122cd8e408495caca8c2`, rebased onto
  upstream/main `c5bdad48defb3c7eb1d95936c2730f63fbfc432f`. The capture above was taken on
  exactly that pair, after the rebase.
