### PR TITLE
fix(ci): recheck ClawSweeper PR ack marker before posting

### DIFF
--- a/.github/workflows/clawsweeper-dispatch.yml
+++ b/.github/workflows/clawsweeper-dispatch.yml
@@ -160,13 +160,27 @@ jobs:
             echo "::notice::Skipping ClawSweeper pull request acknowledgement because no target credential is configured."
             exit 0
           fi
+          has_ack_marker() {
+            jq -e \
+              --arg marker_prefix "clawsweeper-pr-ack:" \
+              --arg marker_suffix " item=$ITEM_NUMBER -->" \
+              'any(.[]; (.body // "") as $body | ($body | contains($marker_prefix)) and ($body | contains($marker_suffix)))' \
+              <<< "$1" >/dev/null
+          }
           comments="$(GH_TOKEN="$ACK_TOKEN" gh api \
             "repos/$TARGET_REPO/issues/$ITEM_NUMBER/comments?per_page=100")"
-          if jq -e \
-            --arg marker_prefix "clawsweeper-pr-ack:" \
-            --arg marker_suffix " item=$ITEM_NUMBER -->" \
-            'any(.[]; (.body // "") as $body | ($body | contains($marker_prefix)) and ($body | contains($marker_suffix)))' \
-            <<< "$comments" >/dev/null; then
+          if has_ack_marker "$comments"; then
+            echo "ClawSweeper pull request acknowledgement already exists."
+            exit 0
+          fi
+          # opened and ready_for_review can fire seconds apart for the same
+          # pull request, and both runs can list comments before either
+          # acknowledgement is visible. Wait, then recheck right before
+          # posting; a superseding run cancels this one while it sleeps.
+          sleep 15
+          comments="$(GH_TOKEN="$ACK_TOKEN" gh api \
+            "repos/$TARGET_REPO/issues/$ITEM_NUMBER/comments?per_page=100")"
+          if has_ack_marker "$comments"; then
             echo "ClawSweeper pull request acknowledgement already exists."
             exit 0
           fi


### PR DESCRIPTION
Propagates the canonical target-dispatcher fix from openclaw/clawsweeper#1083 (docs/target-dispatcher.md, "Acknowledge received pull request" step) byte-identically into this repository's customized dispatcher copy. Only that step changes; the rest of the file is untouched.

## Why

PR #120974 (created as draft, marked ready seconds later) received two clawsweeper[bot] receipt acks — `clawsweeper-pr-ack:opened` at 07:15:20Z and `clawsweeper-pr-ack:ready_for_review` at 07:15:29Z. Both event runs listed comments before either acknowledgement was visible, so the existing match-any-marker idempotency check passed in both.

## What changed

After a clean first marker check, the step now sleeps 15s, re-lists comments, and rechecks immediately before posting. A superseding `ready_for_review` event also cancels a still-sleeping `opened` run through the existing concurrency group, so exactly one ack survives. The step remains `continue-on-error` and the marker format is unchanged.

Verified: the previous step here was byte-identical to the pre-fix canonical step (propagated in #120934), and the new step is byte-identical to the fixed canonical step; `actionlint` and `bash -n` on the extracted step script are clean.
