### PR TITLE
fix(qa): keep live alternate model distinct

### DIFF
--- a/extensions/qa-lab/src/model-selection.runtime.test.ts
+++ b/extensions/qa-lab/src/model-selection.runtime.test.ts
@@ -19,6 +19,18 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
 }));
 
 import { defaultQaRuntimeModelForMode } from "./model-selection.runtime.js";
+import { QA_FRONTIER_CATALOG_ALTERNATE_MODEL } from "./providers/live-frontier/catalog.js";
+
+function expectLiveFrontierModelPair(primaryModel: string) {
+  const primary = defaultQaRuntimeModelForMode("live-frontier");
+  const alternate = defaultQaRuntimeModelForMode("live-frontier", { alternate: true });
+
+  expect({ primary, alternate }).toEqual({
+    primary: primaryModel,
+    alternate: QA_FRONTIER_CATALOG_ALTERNATE_MODEL,
+  });
+  expect(alternate).not.toBe(primary);
+}
 
 describe("qa model selection runtime", () => {
   beforeEach(() => {
@@ -33,27 +45,30 @@ describe("qa model selection runtime", () => {
   it("keeps the OpenAI live default when an API key is configured", () => {
     resolveEnvApiKey.mockReturnValue({ apiKey: "sk-test" });
 
-    expect(defaultQaRuntimeModelForMode("live-frontier")).toBe("openai/gpt-5.6");
+    expectLiveFrontierModelPair("openai/gpt-5.6");
     expect(loadAuthProfileStoreForRuntime).not.toHaveBeenCalled();
   });
 
-  it("prefers the Codex OAuth live default when only Codex auth profiles are available", () => {
-    loadAuthProfileStoreForRuntime.mockReturnValue({
-      profiles: {
-        "openai:user@example.com": {
-          provider: "openai",
-          type: "oauth",
+  it.each(["oauth", "token"] as const)(
+    "prefers the Codex live default for a stored %s profile",
+    (type) => {
+      loadAuthProfileStoreForRuntime.mockReturnValue({
+        profiles: {
+          "openai:user@example.com": {
+            provider: "openai",
+            type,
+          },
         },
-      },
-    });
+      });
 
-    expect(defaultQaRuntimeModelForMode("live-frontier")).toBe("openai/gpt-5.6-luna");
-    expect(loadAuthProfileStoreForRuntime).toHaveBeenCalledWith(undefined, {
-      readOnly: true,
-      allowKeychainPrompt: false,
-      externalCliProviderIds: ["openai"],
-    });
-  });
+      expectLiveFrontierModelPair("openai/gpt-5.6-luna");
+      expect(loadAuthProfileStoreForRuntime).toHaveBeenCalledWith(undefined, {
+        readOnly: true,
+        allowKeychainPrompt: false,
+        externalCliProviderIds: ["openai"],
+      });
+    },
+  );
 
   it("keeps the OpenAI live default when stored OpenAI profiles are available", () => {
     loadAuthProfileStoreForRuntime.mockReturnValue({
@@ -65,7 +80,7 @@ describe("qa model selection runtime", () => {
       },
     });
 
-    expect(defaultQaRuntimeModelForMode("live-frontier")).toBe("openai/gpt-5.6");
+    expectLiveFrontierModelPair("openai/gpt-5.6");
   });
 
   it("leaves mock defaults unchanged", () => {

--- a/extensions/qa-lab/src/providers/live-frontier/index.ts
+++ b/extensions/qa-lab/src/providers/live-frontier/index.ts
@@ -1,5 +1,6 @@
 // Qa Lab plugin entrypoint registers its OpenClaw integration.
 import type { QaProviderDefinition } from "../shared/types.js";
+import { QA_FRONTIER_CATALOG_ALTERNATE_MODEL } from "./catalog.js";
 
 function isOpenAiModel(modelRef: string) {
   return modelRef.startsWith("openai/");
@@ -31,7 +32,10 @@ function isClaudeOpusModel(modelRef: string) {
 export const liveFrontierProviderDefinition: QaProviderDefinition = {
   mode: "live-frontier",
   kind: "live",
-  defaultModel: (options) => options?.preferredLiveModel ?? "openai/gpt-5.6",
+  defaultModel: (options) =>
+    options?.alternate
+      ? QA_FRONTIER_CATALOG_ALTERNATE_MODEL
+      : (options?.preferredLiveModel ?? "openai/gpt-5.6"),
   defaultImageGenerationProviderIds: ["openai"],
   defaultImageGenerationModel: ({ modelProviderIds }) =>
     modelProviderIds.includes("openai") ? "openai/gpt-image-1" : null,

--- a/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
@@ -23,6 +23,7 @@ function normalizeModelRef(raw: string) {
 async function runToolContinuity(
   alternateTools: string[],
   params?: {
+    alternateModel?: string;
     primaryOutboundText?: string;
     primaryDelivery?: { status: string; resultCount: number } | null;
     alternateReplyText?: string;
@@ -30,12 +31,14 @@ async function runToolContinuity(
     alternateDelivery?: { status: string; resultCount: number } | null;
     unrelatedPrimaryOutboundText?: string;
     unrelatedLaterOutboundText?: string;
+    onRun?: () => void;
   },
 ) {
   const state = createQaBusState();
   let call = 0;
   const runAgentPrompt = vi.fn(
     async (_env: unknown, prompt: { provider?: string; model?: string }) => {
+      params?.onRun?.();
       call += 1;
       const runId = `run-${call}`;
       const provider = prompt.provider ?? "openai";
@@ -98,7 +101,7 @@ async function runToolContinuity(
       env: {
         providerMode: "mock-openai",
         primaryModel: "openai/primary-model",
-        alternateModel: "OPENAI/alternate-alias",
+        alternateModel: params?.alternateModel ?? "OPENAI/alternate-alias",
         gateway: {},
       },
       splitModelRef,
@@ -145,6 +148,14 @@ describe("model-switch tool continuity terminal evidence", () => {
     await expect(runToolContinuity([])).rejects.toThrow(
       "alternate-model run did not return exact owned successful read evidence",
     );
+  });
+
+  it("rejects normalized-identical refs before starting an agent run", async () => {
+    const onRun = vi.fn();
+    await expect(
+      runToolContinuity(["read"], { alternateModel: "OPENAI/primary-model", onRun }),
+    ).rejects.toThrow("primary and alternate models must normalize to different refs");
+    expect(onRun).not.toHaveBeenCalled();
   });
 
   it("rejects unrelated later continuity text when the alternate reply lacks it", async () => {

--- a/extensions/qa-lab/src/suite-provider-selection.test.ts
+++ b/extensions/qa-lab/src/suite-provider-selection.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { QA_FRONTIER_CATALOG_ALTERNATE_MODEL } from "./providers/live-frontier/catalog.js";
 import type { QaTransportAdapterFactory } from "./qa-transport-registry.js";
 import { requireFlowScenario } from "./scenario-catalog.test-utils.js";
 import { runQaSuite } from "./suite-launch.runtime.js";
@@ -140,9 +141,10 @@ describe("qa suite provider selection", () => {
       };
       expect(summary.run).toMatchObject({
         providerMode: "live-frontier",
-        primaryModel: expect.stringMatching(/^openai\//),
-        alternateModel: expect.stringMatching(/^openai\//),
+        primaryModel: "openai/gpt-5.6",
+        alternateModel: QA_FRONTIER_CATALOG_ALTERNATE_MODEL,
       });
+      expect(summary.run.alternateModel).not.toBe(summary.run.primaryModel);
     } finally {
       await rm(repoRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/120588

## What Problem This Solves

Fixes an issue where live-frontier QA could select the same normalized model for both primary and alternate runs when OAuth-preferred OpenAI was active.

## Why This Change Was Made

`defaultModel` ignored `options.alternate`, so the OAuth-preferred OpenAI primary and alternate collapsed to the same normalized ref. The alternate path now returns `QA_FRONTIER_CATALOG_ALTERNATE_MODEL` (`anthropic/claude-sonnet-4-6`) before `preferredLiveModel`; the primary preference remains intact.

This publishes and credits only the alternate-model slice from https://github.com/openclaw/openclaw/pull/120588. That broader PR remains open and is not closed or superseded wholesale.

## User Impact

Live-frontier QA now exercises a distinct alternate provider/model while preserving the existing primary-model preference.

## Evidence

- Exact commit: `c4369d8bf74e0c3d14ae4ecfbd7dce8e9f0ea15d`
- Independent exact-commit approval completed
- Focused proof: 34/34 across model-selection, suite-provider selection, model-switch follow-up, and model-switch tool continuity
- Targeted format, oxlint, and `git diff --check` proof passed
- Production LOC: +5/-1
- Tests: +48/-20
- Current `origin/main`: `7af8e129d6852a16f191b21872892e88112b482e`
- `git merge-tree --write-tree origin/main HEAD` exited cleanly with tree `46a42a37c2a931faaec325b43e9565988d3b498a`
- Remaining risk: no live authenticated OpenAI + Anthropic model-switch run was performed
- AI-assisted; no agent transcript included

Punchcard-Session: amber-workshop-workshop-36
