### PR TITLE
fix(workboard): truncate oversized notification messages instead of crashing dispatch

### DIFF
--- a/extensions/workboard/src/store-card-helpers.ts
+++ b/extensions/workboard/src/store-card-helpers.ts
@@ -16,7 +16,6 @@ import {
 } from "@openclaw/workboard-contract";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   BLOCKED_TOO_LONG_MS,
   MAX_CARD_ATTEMPTS,
@@ -26,6 +25,7 @@ import {
 } from "./store-constants.js";
 import type { WorkboardMutationScope } from "./store-inputs.js";
 import {
+  capText,
   metadataIsEmpty,
   normalizeEvents,
   normalizeTimestamp,
@@ -520,13 +520,6 @@ export function computeCardDiagnostics(card: WorkboardCard, now: number): Workbo
     );
   }
   return diagnostics;
-}
-
-export function capText(value: string | undefined, max: number): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-  return value.length <= max ? value : `${truncateUtf16Safe(value, Math.max(0, max - 1))}…`;
 }
 
 export function cardBoardId(card: WorkboardCard): string {

--- a/extensions/workboard/src/store-enrichment.ts
+++ b/extensions/workboard/src/store-enrichment.ts
@@ -8,7 +8,6 @@ import type {
 import type { PersistedWorkboardAttachment } from "./persistence-types.js";
 import {
   assertCanMutateClaimedCard,
-  capText,
   cardRunId,
   cardSessionKey,
   closeRunningAttempts,
@@ -30,6 +29,7 @@ import type {
   WorkboardWorkerLogInput,
 } from "./store-inputs.js";
 import {
+  capText,
   clearDiagnostics,
   normalizeArtifact,
   normalizeAttachmentInput,

--- a/extensions/workboard/src/store-normalizers.ts
+++ b/extensions/workboard/src/store-normalizers.ts
@@ -44,6 +44,7 @@ import {
 } from "@openclaw/workboard-contract";
 import { resolveNonNegativeIntegerOption } from "openclaw/plugin-sdk/number-runtime";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   MAX_ATTACHMENT_BYTES,
   MAX_CARD_ARTIFACTS,
@@ -276,6 +277,13 @@ export function normalizeBoundedString(
     );
   }
   return normalized;
+}
+
+export function capText(value: string | undefined, max: number): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return value.length <= max ? value : `${truncateUtf16Safe(value, Math.max(0, max - 1))}…`;
 }
 
 export function normalizeStatus(value: unknown, fallback: WorkboardStatus): WorkboardStatus {
@@ -941,7 +949,7 @@ function normalizeNotification(value: unknown): WorkboardNotification | null {
   const kind = normalizeEnumValue(record.kind, WORKBOARD_NOTIFICATION_KINDS, undefined);
   const createdAt = normalizeTimestamp(record.createdAt, Date.now());
   const sequence = normalizeTimestamp(record.sequence, 0) || undefined;
-  const message = normalizeBoundedString(record.message, undefined, 240, "notification message");
+  const message = capText(normalizeOptionalString(record.message), 240);
   if (!kind || !message) {
     return null;
   }

--- a/extensions/workboard/src/store-workflow.ts
+++ b/extensions/workboard/src/store-workflow.ts
@@ -13,7 +13,6 @@ import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   assertCanMutateClaimedCard,
-  capText,
   cardBoardId,
   cardChildIds,
   cardParentIds,
@@ -48,6 +47,7 @@ import type {
 } from "./store-inputs.js";
 import {
   appendCompletionProof,
+  capText,
   clearDiagnostics,
   deriveChildIdempotencyKey,
   normalizeArtifact,

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -2748,6 +2748,50 @@ describe("WorkboardStore", () => {
     expect(blocked.metadata?.notifications?.[0]?.message.length).toBeLessThanOrEqual(240);
   });
 
+  it("heals oversized persisted notifications and keeps dispatching sibling cards", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-notification-"));
+    const dbPath = path.join(dir, "workboard.sqlite");
+    const stores = createWorkboardSqliteStores({ dbPath });
+    try {
+      const store = new WorkboardStore(stores.cards);
+      const poisoned = await store.create({ title: "Oversized notification", status: "ready" });
+      const sibling = await store.create({ title: "Unaffected sibling", status: "ready" });
+      const oversized = `${"x".repeat(238)}🦞${" tail".repeat(60)}`;
+      const rawDb = new DatabaseSync(dbPath);
+      try {
+        rawDb
+          .prepare(
+            "INSERT INTO workboard_card_notifications (id, card_id, ordinal, kind, message, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+          )
+          .run("oversized", poisoned.id, 0, "failed", oversized, Date.now());
+      } finally {
+        rawDb.close();
+      }
+
+      expect((await store.get(poisoned.id))?.metadata?.notifications?.[0]?.message).toBe(oversized);
+      await expect(store.dispatch()).resolves.toBeDefined();
+
+      const repaired = await store.get(poisoned.id);
+      expect(repaired?.metadata?.notifications?.[0]?.message).toBe(`${"x".repeat(238)}…`);
+      expect(repaired?.metadata?.automation?.dispatchCount).toBe(1);
+      expect((await store.get(sibling.id))?.metadata?.automation?.dispatchCount).toBe(1);
+
+      const verifyDb = new DatabaseSync(dbPath, { readOnly: true });
+      try {
+        expect(
+          verifyDb
+            .prepare("SELECT message FROM workboard_card_notifications WHERE id = ?")
+            .get("oversized"),
+        ).toEqual({ message: `${"x".repeat(238)}…` });
+      } finally {
+        verifyDb.close();
+      }
+    } finally {
+      stores.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("dispatches ready cards and blocks expired or timed-out work", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -21,7 +21,6 @@ import { createWorkboardSqliteStores } from "./sqlite-store.js";
 import {
   buildWorkerContext,
   assertCanMutateClaimedCard,
-  capText,
   cardBoardId,
   cardRunId,
   cardSessionKey,
@@ -49,7 +48,7 @@ import type {
   WorkboardDispatchResult,
   WorkboardMutationScope,
 } from "./store-inputs.js";
-import { normalizeBoardId, normalizeTimestamp } from "./store-normalizers.js";
+import { capText, normalizeBoardId, normalizeTimestamp } from "./store-normalizers.js";
 import { WorkboardNotificationStore } from "./store-notifications.js";
 
 export type { WorkboardDispatchResult } from "./store-inputs.js";


### PR DESCRIPTION
## What Problem This Solves

Fixes #120956. A legacy Workboard notification longer than its existing 240-character limit makes the next dispatch tick throw during card metadata normalization. That poisons the whole tick, so unrelated ready cards stop dispatching until an operator repairs SQLite manually.

## Why This Change Was Made

The completion, blocking, and worker-protocol notification producers already use Workboard's existing UTF-16-safe `capText` helper. Persisted rows can predate those producer-side caps, and SQLite correctly materializes their existing text without rewriting data on read. The common card metadata normalization boundary incorrectly rejected those legacy notifications instead of applying the very same existing cap before a legitimate card update.

Move the existing `capText` helper into its canonical normalization owner and migrate all four existing local consumers to their already-present normalizer imports. Normalize notifications with that same helper before persistence. This removes the duplicate truncation policy in the original patch, avoids an import cycle or new helper module, preserves valid notification text and surrogate pairs, and makes the next legitimate dispatch update heal only the affected notification row. No database schema, migration, public API, provider contract, or Gateway protocol changes.

Production LOC: +13/-13 (net zero). Regression coverage: +44 lines. Original contribution and primary commit authorship: @licheer-zte.

## User Impact

Workboard dispatch automatically recovers from an existing oversized notification; unrelated ready cards continue dispatching. The repaired notification is persisted at 240 UTF-16 code units or fewer with the established ellipsis behavior, without splitting an astral Unicode character.

## Evidence

- Before the repair, a real SQLite-backed regression inserts a 540-code-unit legacy notification directly into `workboard_card_notifications`, then calls the real `WorkboardStore.dispatch()` flow. It fails at `normalizeBoundedString -> normalizeNotification -> normalizeMetadata -> updateCard -> recordDispatch` with `notification message must be 240 characters or fewer (got 540)`.
- After the repair, the same real dispatch tick succeeds, stores the healed notification in the actual SQLite row, preserves the astral-character boundary, and dispatches an independent ready sibling card.
- Focused proof: `node scripts/run-vitest.mjs extensions/workboard/src/store.test.ts -t 'heals oversized persisted notifications'` — **1 passed**.
- Full owner and sibling surface: `node scripts/run-vitest.mjs extensions/workboard` — **18 files, 338 tests passed**.
- A separate independent verifier reran the real SQLite regression successfully.
- Mandatory structured autoreview: clean, no accepted or actionable findings.
- `git diff --check` and targeted formatting checks pass.
- The 240-character limit is the existing Workboard notification-normalization policy; this change does not claim or modify an independent Gateway transport limit.

[AI-assisted]
