### PR TITLE
fix(slack): avoid duplicate commentary delivery

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -3851,6 +3851,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     );
 
     expect(capturedReplyOptions?.commentaryProgressEnabled).toBe(true);
+    expect(capturedReplyOptions?.commentaryPayloadsEnabled).toBeUndefined();
     expect(capturedReplyOptions?.suppressDefaultToolProgressMessages).toBe(true);
     expect(draftStream.update).toHaveBeenLastCalledWith("_Preparing the smallest fix_");
     expect(draftStream.update.mock.calls.flat().join("\n")).not.toContain("pnpm test");

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -392,7 +392,6 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         commentaryProgressEnabled: progress.commentaryProgressEnabled ? true : undefined,
         progressPreambleEnabled:
           progress.progressDraftActive && slackStreaming.mode === "progress" ? true : undefined,
-        commentaryPayloadsEnabled: progress.commentaryProgressEnabled ? true : undefined,
         onVerboseProgressVisibility: progress.commentaryProgressEnabled
           ? (isActive) => {
               progress.setShouldYieldDraftProgress(isActive);


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/120588

## What Problem This Solves

Fixes an issue where Slack users with progress commentary enabled could receive each commentary update twice: once in the editable progress draft and once through normal commentary payload delivery.

## Why This Change Was Made

Slack already owns commentary rendering in its progress-draft path. The dispatch call was also enabling `commentaryPayloadsEnabled`, which admitted the same commentary through the shared normal-payload route. This removes only that second route and asserts that it stays unset.

The change stays inside the Slack owner boundary: no core, sibling-channel, renderer, classifier, public SDK, timeout, fallback, config, docs, or changelog changes. This is the byte-identical Slack runtime/test slice from https://github.com/openclaw/openclaw/pull/120588, preserved as a focused fix. Dallin Romney (@RomneyDa) is credited as co-author in the signed commit.

## User Impact

Slack progress commentary is rendered once in the progress draft. Commentary-disabled and commentary-omitted behavior remains unchanged.

## Evidence

- Exact head: `5d8ec438c7f6f9e4982a71cf5e5742ea45cb4e6b`
- Independent exact-head review: approved with no findings
- Production LOC: `+0/-1`; tests: `+1/-0`
- Focused dispatch preview-fallback test: `140/140` passed
- Exact two-file formatting, direct oxlint, and `git diff --check`: passed
- Current `origin/main` at publication: `29c442d48389c834ebf4334e7246675e5f904ca7`
- Merge-tree against current `origin/main`: clean
- The exact two-file changed gate did not produce a green aggregate because hosted routing could not allocate a worker before execution, while trusted-source local fallback stopped at pre-existing Plugin SDK API manifest drift. The same manifest mismatch reproduced from an untouched archive of the exact base; no generated baseline was changed.

Remaining proof before review/landing:

- Hosted exact-head CI
- Redacted live Slack matrix:
  - `slack-progress-commentary-true`
  - `slack-progress-commentary-false`
  - `slack-progress-commentary-omitted`
  - `slack-progress-commentary-verbose-dedupe`

No live Slack claim is made yet.

<!-- punchcard-receipt: pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaSlRZUlFGTkFIWTFQQkoyRktIOE4zWQB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pGWE42TVBWRDRBMzM2VlZDWVdHUDQ1AGFtYmVyLXdvcmtzaG9wLXdvcmtzaG9wLTM2AG9wZW5jbGF3L29wZW5jbGF3AAAxMjEwMDQAN2EwYzg5NmI4MGRhOGMyNmE0YWRhMzVkNjZhNDdlMDk1NDNkY2EzODMxMDhkMmMyNTY4NGQzMzQ0ZGVmNmQxOQBzaWduaW5nLXYxAHNNdFZTT09tSEphcHgxNEZwYllsVnV5U2N3bVFhNXRPdUMxU2xwcXp5NnFMUGZzRTRUa3IxXzZxVkN6QmEyOU5CZkZDSF8zbFlBQ3JTY284c3M2LURRADIwMjYtMDgtMDlUMDg6NDE6NDQuNDMxWgA.DSrkgrwQ9EYbzzEnjDWuJq2vhEFwYNZkdGAdsQGrScApkS-y9YAJTN8d1Fv1NV_dcn4ZnAYrDyyDkilgMWRhDQ -->
