### PR TITLE
fix(matrix): keep durable delivery identity across payload fanout

### DIFF
--- a/extensions/matrix/src/outbound.test.ts
+++ b/extensions/matrix/src/outbound.test.ts
@@ -529,6 +529,38 @@ describe("matrixOutbound cfg threading", () => {
     expect(mockOptions(mocks.sendMessageMatrix, "sendMessageMatrix", 1).threadId).toBe("$thread");
   });
 
+  it("preserves durable dispatch ownership across sendPayload media fanout", async () => {
+    const onPlatformSendDispatch = vi.fn();
+
+    await matrixOutbound.sendPayload!({
+      cfg: {} as OpenClawConfig,
+      to: "room:!room:example",
+      text: "caption",
+      payload: {
+        text: "caption",
+        mediaUrls: ["", "file:///tmp/a.png", "   ", "file:///tmp/b.png"],
+      },
+      deliveryQueueId: "queue-1",
+      onPlatformSendDispatch,
+    });
+
+    expect(mocks.sendMessageMatrix).toHaveBeenCalledTimes(2);
+    expect(mockOptions(mocks.sendMessageMatrix, "first media", 0)).toMatchObject({
+      mediaUrl: "file:///tmp/a.png",
+      deliveryQueueId: "queue-1",
+      deliveryPartIndex: 0,
+      deliveryPartCount: 2,
+      onPlatformSendDispatch,
+    });
+    expect(mockOptions(mocks.sendMessageMatrix, "second media", 1)).toMatchObject({
+      mediaUrl: "file:///tmp/b.png",
+      deliveryQueueId: "queue-1",
+      deliveryPartIndex: 1,
+      deliveryPartCount: 2,
+      onPlatformSendDispatch,
+    });
+  });
+
   it("combines media payload receipts without inventing replies on later events", async () => {
     const firstReceipt = createMatrixReceipt([
       { messageId: "$image", kind: "media", replyToId: "$reply" },

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -9,7 +9,7 @@ import {
   type MessagePresentation,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import {
-  resolvePayloadMediaUrls,
+  resolveSendableOutboundReplyParts,
   sendPayloadMediaSequence,
 } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
@@ -147,6 +147,8 @@ export const matrixOutbound: ChannelOutboundAdapter = {
     threadId,
     accountId,
     audioAsVoice,
+    deliveryQueueId,
+    onPlatformSendDispatch,
     onDeliveryResult,
   }) => {
     const send =
@@ -158,14 +160,14 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       ...(replyToIdSource !== undefined ? { replyToIdSource } : {}),
       ...(replyToMode !== undefined ? { replyToMode } : {}),
     });
-    const urls = resolvePayloadMediaUrls(payload);
+    const urls = resolveSendableOutboundReplyParts(payload).mediaUrls;
     const payloadText = resolveMatrixPayloadText(payload);
     if (urls.length > 0) {
       const sentResults: Awaited<ReturnType<typeof sendMessageMatrix>>[] = [];
       const lastResult = await sendPayloadMediaSequence({
         text: payloadText,
         mediaUrls: urls,
-        send: async ({ text, mediaUrl, isFirst }) =>
+        send: async ({ text, mediaUrl, index, isFirst }) =>
           await send(to, text, {
             cfg,
             mediaUrl,
@@ -176,6 +178,10 @@ export const matrixOutbound: ChannelOutboundAdapter = {
             threadId: resolvedThreadId,
             accountId: accountId ?? undefined,
             audioAsVoice: payload.audioAsVoice ?? audioAsVoice,
+            deliveryQueueId,
+            deliveryPartIndex: index,
+            deliveryPartCount: urls.length,
+            onPlatformSendDispatch,
             extraContent: isFirst ? resolveMatrixExtraContent(payload) : undefined,
             onDeliveryResult: resolveMatrixDeliveryProgress(onDeliveryResult),
           }),
@@ -204,6 +210,10 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       threadId: resolvedThreadId,
       accountId: accountId ?? undefined,
       audioAsVoice: payload.audioAsVoice ?? audioAsVoice,
+      deliveryQueueId,
+      deliveryPartIndex: 0,
+      deliveryPartCount: 1,
+      onPlatformSendDispatch,
       extraContent: resolveMatrixExtraContent(payload),
       onDeliveryResult: resolveMatrixDeliveryProgress(onDeliveryResult),
     });


### PR DESCRIPTION
Related: #120588

## What Problem This Solves

Fixes an issue where durable Matrix payload deliveries could lose their queue identity when a structured payload fanned out across media parts. Empty media entries could also distort part numbering, leaving platform dispatch ownership incomplete.

## Why This Change Was Made

Matrix now resolves the canonical sendable media list and carries the delivery queue id, part index/count, and platform-dispatch callback into every payload send, matching its existing text/media delivery boundary.

## User Impact

Queued Matrix payloads remain attributable to the correct durable delivery across attachment fanout, so retries and settlement observe one coherent delivery.

## Evidence

- Linux Blacksmith Testbox: `node scripts/run-vitest.mjs extensions/matrix/src/outbound.test.ts` — 22 passed.
- Targeted oxfmt, oxlint, and `git diff --check` passed.
- Production LOC: +13/-3; tests: +32/-0. Positive production LOC carries the existing durable ownership contract through `sendPayload`.
- Authenticated live Matrix proof was not run; focused adapter proof covers the deterministic boundary.
