### PR TITLE
fix(qa): reject stale Matrix readiness after state restart

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts
@@ -523,4 +523,105 @@ describe("matrix scenario environment", () => {
     expect(waitForConfigRestartSettle).not.toHaveBeenCalled();
     expect(gateway.call.mock.calls.filter(([method]) => method === "config.patch")).toHaveLength(1);
   });
+
+  it("requires a fresh account start when the pre-restart status read fails", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    let configReadCount = 0;
+    let statusReadCount = 0;
+    const mutateState = vi.fn(async () => undefined);
+    const gateway = {
+      baseUrl: "http://127.0.0.1:12345",
+      runtimeEnv: {},
+      tempRoot: "/tmp/matrix-qa",
+      workspaceDir: "/tmp/matrix-qa/workspace",
+      restartAfterStateMutation: vi.fn(
+        async (
+          mutate: (context: {
+            configPath: string;
+            runtimeEnv: NodeJS.ProcessEnv;
+            stateDir: string;
+            tempRoot: string;
+          }) => Promise<void>,
+        ) => {
+          await mutate({
+            configPath: "/tmp/matrix-qa/config.json",
+            runtimeEnv: {},
+            stateDir: "/tmp/matrix-qa/state",
+            tempRoot: "/tmp/matrix-qa",
+          });
+        },
+      ),
+      call: vi.fn(async (method: string) => {
+        if (method === "config.get") {
+          configReadCount += 1;
+          if (configReadCount === 1) {
+            return { config: {} };
+          }
+          if (configReadCount === 2) {
+            return { hash: "config-hash" };
+          }
+          return {
+            appliedConfigHash: "config-hash",
+            configRevisionHash: "config-hash",
+            hash: "config-hash",
+          };
+        }
+        if (method === "config.patch") {
+          return { hash: "config-hash", noop: true, ok: true };
+        }
+        if (method === "channels.status") {
+          statusReadCount += 1;
+          if (statusReadCount === 3) {
+            throw new Error("status temporarily unavailable");
+          }
+          return {
+            channelAccounts: {
+              matrix: [
+                {
+                  accountId: "sut",
+                  connected: true,
+                  healthState: "healthy",
+                  lastStartAt: statusReadCount === 4 ? 900 : 1_100,
+                  restartPending: false,
+                  running: true,
+                },
+              ],
+            },
+          };
+        }
+        throw new Error(`unexpected gateway method ${method}`);
+      }),
+    };
+    const environment = createMatrixQaScenarioEnvironment({
+      accountId: "sut",
+      harness: { baseUrl: "http://127.0.0.1:8008", recording: {} } as never,
+      observedEvents: [],
+      provisioning: {
+        driver: { accessToken: "fixture", userId: "@driver:test" },
+        observer: { accessToken: "fixture", userId: "@observer:test" },
+        roomId: "!room:test",
+        sut: { accessToken: "fixture", userId: "@sut:test" },
+        topology: { rooms: [] },
+      } as never,
+    });
+    const prepared = await environment.prepareFlow({
+      config: {},
+      gateway,
+      outputDir: "/tmp/matrix-qa/output",
+      scenarioId: "matrix-state-restart",
+      scenarioTitle: "Matrix state restart",
+      timeoutMs: 2_000,
+      waitForConfigRestartSettle: vi.fn(),
+    });
+
+    const restarting = prepared.scenarioContext.restartGatewayAfterStateMutation?.(mutateState, {
+      timeoutMs: 2_000,
+    });
+    await vi.runAllTimersAsync();
+    await restarting;
+
+    expect(mutateState).toHaveBeenCalledOnce();
+    expect(statusReadCount).toBe(5);
+  });
 });

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
@@ -355,9 +355,15 @@ export function createMatrixQaScenarioEnvironment(params: MatrixQaScenarioEnviro
         if (!restart) {
           throw new Error("Matrix persisted-state scenario requires Gateway restart support");
         }
+        const waitAccountId = opts?.waitAccountId ?? params.accountId;
+        const restartStartedAt = Date.now();
+        const beforeRestartAt = (
+          await readMatrixAccountStatuses(input.gateway).catch(() => [])
+        ).find((account) => account.accountId === waitAccountId)?.lastStartAt;
         await restart(async ({ stateDir }) => await mutateState({ stateDir }));
         await waitForMatrixAccountReady({
-          accountId: opts?.waitAccountId ?? params.accountId,
+          afterStartAt: beforeRestartAt ?? restartStartedAt - 1,
+          accountId: waitAccountId,
           deadline: Date.now() + (opts?.timeoutMs ?? input.timeoutMs),
           gateway: input.gateway,
         });


### PR DESCRIPTION
Related: #120588

## What Problem This Solves

Fixes an issue where destructive Matrix QA restarts could accept a healthy account snapshot from before the restart when the pre-restart status read was temporarily unavailable.

## Why This Change Was Made

The scenario environment records the account start boundary before mutation when available and otherwise uses the restart start time, then requires readiness to report a newer `lastStartAt`.

## User Impact

No product behavior changes. Matrix restart evidence now proves that the restarted account actually came back instead of accepting stale readiness.

## Evidence

- Linux Blacksmith Testbox: `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts` — 6 passed.
- Regression covers a failed pre-restart status read followed by stale then fresh account timestamps.
- Targeted oxfmt, oxlint, and `git diff --check` passed.
- QA harness LOC: +7/-1; tests: +101/-0. The added harness state enforces restart freshness at its owner.
- Authenticated live Matrix proof was not run; focused scenario-environment proof covers the deterministic boundary.
