### PR TITLE
fix(qa): ignore unrelated Slack replies in MPIM dedupe proof

### DIFF
--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -302,6 +302,44 @@ describe("Slack live QA runtime helpers", () => {
     expect(recallText).not.toContain("TESTNONCE");
   });
 
+  it("scopes MPIM event dedupe proof to marker-bearing replies", () => {
+    const run = testing.findScenario(["slack-mpim-app-mention-dedupe"])[0]?.buildRun("U_SUT");
+    if (
+      !run ||
+      run.kind === "approval" ||
+      run.kind === "codex-approval" ||
+      run.kind === "direct-transport" ||
+      !run.verifyObserved
+    ) {
+      throw new Error("expected Slack MPIM message scenario with an observation verifier");
+    }
+    const seedMarker = /SLACK_QA_MPIM_SEED_[A-Z0-9]+/u.exec(run.input)?.[0];
+    if (!seedMarker) {
+      throw new Error("missing Slack MPIM seed marker");
+    }
+    const markerReply = {
+      channelId: "C_MPIM",
+      text: `${seedMarker}_BOT_TESTNONCE`,
+      ts: "2.000000",
+    };
+
+    expect(
+      run.verifyObserved({
+        finalMessage: markerReply,
+        messages: [
+          { channelId: "C_MPIM", text: "non-marker commentary", ts: "1.500000" },
+          markerReply,
+        ],
+      }),
+    ).toContain("one MPIM reply");
+    expect(() =>
+      run.verifyObserved?.({
+        finalMessage: markerReply,
+        messages: [markerReply, { ...markerReply, ts: "2.500000" }],
+      }),
+    ).toThrow("got 2 marker response(s)");
+  });
+
   it("rejects an MPIM seed reply without text before sending the recall turn", async () => {
     const run = testing.findScenario(["slack-mpim-app-mention-dedupe"])[0]?.buildRun("U_SUT");
     if (

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-implementations.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-implementations.ts
@@ -125,13 +125,14 @@ export const slackQaMpimAppMentionDedupeScenario: SlackQaScenarioImplementation 
         throw new Error("Slack QA channel has no human member yielding a C-prefixed MPIM");
       },
       verifyObserved: ({ messages }) => {
-        const uniqueReplies = new Map(messages.map((message) => [message.ts, message]));
-        const matchingReplies = [...uniqueReplies.values()].filter((message) =>
-          message.text.includes(seedMarker),
+        const matchingReplies = new Map(
+          messages
+            .filter((message) => message.text.includes(seedMarker))
+            .map((message) => [message.ts, message]),
         );
-        if (uniqueReplies.size !== 1 || matchingReplies.length !== 1) {
+        if (matchingReplies.size !== 1) {
           throw new Error(
-            `expected one MPIM response with the marker, got ${uniqueReplies.size} response(s) and ${matchingReplies.length} marker match(es)`,
+            `expected one MPIM response with the marker, got ${matchingReplies.size} marker response(s)`,
           );
         }
         return "one MPIM reply observed after message/app_mention twin delivery";


### PR DESCRIPTION
Related: #120588

## What Problem This Solves

Fixes an issue where Slack MPIM dedupe evidence could report a false duplicate when unrelated SUT commentary arrived alongside the one marker-bearing reply under test.

## Why This Change Was Made

The verifier now deduplicates and counts only replies correlated by the scenario marker, while still rejecting two distinct marker-bearing responses.

## User Impact

No Slack product behavior changes. MPIM maturity evidence now measures duplicate handling without being invalidated by unrelated assistant output.

## Evidence

- Linux Blacksmith Testbox: `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts` — 51 passed.
- Regression accepts unrelated commentary plus one marker reply and rejects two marker replies.
- Targeted oxfmt, oxlint, and `git diff --check` passed.
- QA harness LOC: +6/-5; tests: +38/-0 (net harness +1).
- Authenticated live Slack proof was not run; focused verifier proof covers the deterministic correlation boundary.
