### PR TITLE
fix(channels): route commentary through one progress owner

### DIFF
--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -92,6 +92,8 @@ Channels that normally render commentary in one evolving progress draft can also
 `shouldDeliverCommentaryPayloads`. Core freezes verbose visibility for the turn, registers that
 getter through `onVerboseProgressVisibility`, evaluates the delivery callback once before
 dispatch, and snapshots that result for the whole turn. Session changes apply on the next turn.
+The callback is inert unless `commentaryPayloadsEnabled` is also `true`; without that static
+opt-in, core neither evaluates the callback nor freezes the registered visibility getter.
 
 Return `false` while the draft owns normal progress and `true` when verbose progress makes that
 draft yield to durable commentary. Keep the callback synchronous and read only channel-owned,

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -85,6 +85,20 @@ update occurred. Existing synchronous and asynchronous callbacks that return `vo
 backward-compatible and are treated as visible; new acceptance-aware implementations should use
 an explicit boolean.
 
+### Commentary delivery ownership
+
+Set `commentaryPayloadsEnabled: true` when the channel supports durable commentary messages.
+Channels that normally render commentary in one evolving progress draft can also provide
+`shouldDeliverCommentaryPayloads`. Core freezes verbose visibility for the turn, registers that
+getter through `onVerboseProgressVisibility`, evaluates the delivery callback once before
+dispatch, and snapshots that result for the whole turn. Session changes apply on the next turn.
+
+Return `false` while the draft owns normal progress and `true` when verbose progress makes that
+draft yield to durable commentary. Keep the callback synchronous and read only channel-owned,
+already prepared state. Omitting it preserves durable delivery for existing plugins that use the
+static opt-in. The callback does not control reasoning, partial replies, tool progress, or final
+answers.
+
 Inbound receivers that defer platform acknowledgements should declare
 `message.receive.defaultAckPolicy` and `supportedAckPolicies` instead of hiding
 ack timing in monitor-local state. Cover every declared policy with

--- a/extensions/discord/src/monitor/message-handler.process-progress.ts
+++ b/extensions/discord/src/monitor/message-handler.process-progress.ts
@@ -125,6 +125,10 @@ export function createDiscordMessageProgressRuntime(params: {
     commentaryPayloadsEnabled: draftPreview.isProgressMode
       ? draftPreview.commentaryProgressEnabled
       : undefined,
+    shouldDeliverCommentaryPayloads:
+      draftPreview.isProgressMode && draftPreview.commentaryProgressEnabled
+        ? () => shouldYieldDraftCommentary()
+        : undefined,
     reasoningPayloadsEnabled: reasoningDurableEnabled,
     onVerboseProgressVisibility: (isActive) => {
       shouldYieldDraftCommentary = isActive;

--- a/extensions/discord/src/monitor/message-handler.process.draft-progress.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.draft-progress.test.ts
@@ -338,7 +338,7 @@ describe("processDiscordMessage draft streaming progress", () => {
       return createNoQueuedDispatchResult();
     });
 
-    const ctx = await createAutomaticSourceDeliveryContext({
+    const ctx = await createAutomaticDraftContext({
       discordConfig: {
         streaming: {
           mode: "progress",

--- a/extensions/discord/src/monitor/message-handler.process.draft-progress.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.draft-progress.test.ts
@@ -293,7 +293,10 @@ describe("processDiscordMessage draft streaming progress", () => {
       const draftStream = createMockDraftStreamForTest();
 
       dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+        expect(params?.replyOptions?.commentaryPayloadsEnabled).toBe(true);
+        expect(params?.replyOptions?.shouldDeliverCommentaryPayloads?.()).toBe(false);
         params?.replyOptions?.onVerboseProgressVisibility?.(() => durableLaneActive);
+        expect(params?.replyOptions?.shouldDeliverCommentaryPayloads?.()).toBe(durableLaneActive);
         await params?.replyOptions?.onItemEvent?.({
           itemId: "preamble-1",
           kind: "preamble",
@@ -327,6 +330,25 @@ describe("processDiscordMessage draft streaming progress", () => {
       }
     },
   );
+
+  it("omits the durable commentary owner when Discord commentary progress is disabled", async () => {
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      expect(params?.replyOptions?.commentaryPayloadsEnabled).toBe(false);
+      expect(params?.replyOptions?.shouldDeliverCommentaryPayloads).toBeUndefined();
+      return createNoQueuedDispatchResult();
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: {
+        streaming: {
+          mode: "progress",
+          progress: { commentary: false },
+        },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+  });
 
   it.each([
     ["active", true],

--- a/extensions/discord/src/monitor/message-handler.process.test-harness.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test-harness.ts
@@ -184,6 +184,8 @@ export type DispatchInboundParams = {
     isProgressDraftVisible?: () => boolean;
     progressPreambleEnabled?: boolean;
     narrationHideCommandText?: boolean;
+    commentaryPayloadsEnabled?: boolean;
+    shouldDeliverCommentaryPayloads?: () => boolean;
     onVerboseProgressVisibility?: (isActive: () => boolean) => void;
     onPlanUpdate?: (payload: {
       phase?: string;

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -4092,6 +4092,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     );
 
     expect(capturedReplyOptions?.commentaryProgressEnabled).toBe(true);
+    expect(capturedReplyOptions?.commentaryPayloadsEnabled).toBeUndefined();
     expect(capturedReplyOptions?.suppressDefaultToolProgressMessages).toBe(true);
     expectLastDraftUpdateText(draftStream, "_Preparing the smallest fix_");
     expect(draftUpdateTexts(draftStream).join("\n")).not.toContain("pnpm test");

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -4092,13 +4092,15 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     );
 
     expect(capturedReplyOptions?.commentaryProgressEnabled).toBe(true);
-    expect(capturedReplyOptions?.commentaryPayloadsEnabled).toBeUndefined();
+    expect(capturedReplyOptions?.commentaryPayloadsEnabled).toBe(true);
+    expect(capturedReplyOptions?.shouldDeliverCommentaryPayloads?.()).toBe(false);
     expect(capturedReplyOptions?.suppressDefaultToolProgressMessages).toBe(true);
     expectLastDraftUpdateText(draftStream, "_Preparing the smallest fix_");
     expect(draftUpdateTexts(draftStream).join("\n")).not.toContain("pnpm test");
 
     const updateCount = draftStream.update.mock.calls.length;
     capturedReplyOptions?.onVerboseProgressVisibility?.(() => true);
+    expect(capturedReplyOptions?.shouldDeliverCommentaryPayloads?.()).toBe(true);
     await requireCapturedItemEventHandler()({
       kind: "preamble",
       itemId: "preamble-3",
@@ -4306,6 +4308,8 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     );
 
     expect(capturedReplyOptions?.commentaryProgressEnabled).toBeUndefined();
+    expect(capturedReplyOptions?.commentaryPayloadsEnabled).toBeUndefined();
+    expect(capturedReplyOptions?.shouldDeliverCommentaryPayloads).toBeUndefined();
     expect(capturedReplyOptions?.onVerboseProgressVisibility).toBeUndefined();
     expect(capturedReplyOptions?.progressPreambleEnabled).toBe(true);
     expectLastDraftUpdateText(draftStream, "Keeping the released behavior\n\n• pnpm test");

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -495,7 +495,6 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         commentaryProgressEnabled: progress.commentaryProgressEnabled ? true : undefined,
         progressPreambleEnabled:
           progress.progressDraftActive && slackStreaming.mode === "progress" ? true : undefined,
-        commentaryPayloadsEnabled: progress.commentaryProgressEnabled ? true : undefined,
         onVerboseProgressVisibility: progress.commentaryProgressEnabled
           ? (isActive) => {
               progress.setShouldYieldDraftProgress(isActive);

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -495,6 +495,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         commentaryProgressEnabled: progress.commentaryProgressEnabled ? true : undefined,
         progressPreambleEnabled:
           progress.progressDraftActive && slackStreaming.mode === "progress" ? true : undefined,
+        commentaryPayloadsEnabled: progress.commentaryProgressEnabled ? true : undefined,
+        shouldDeliverCommentaryPayloads: progress.commentaryProgressEnabled
+          ? progress.shouldYieldDraftProgress
+          : undefined,
         onVerboseProgressVisibility: progress.commentaryProgressEnabled
           ? (isActive) => {
               progress.setShouldYieldDraftProgress(isActive);

--- a/extensions/telegram/src/bot-message-dispatch.progress-summary.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-summary.test.ts
@@ -320,6 +320,7 @@ describeTelegramDispatch("dispatchTelegramMessage progress-summary", () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
         expect(replyOptions?.commentaryPayloadsEnabled).toBe(true);
+        expect(replyOptions?.shouldDeliverCommentaryPayloads).toBeUndefined();
         await replyOptions?.onItemEvent?.({
           kind: "preamble",
           itemId: "commentary-1",

--- a/extensions/telegram/src/progress-draft-preview.test.ts
+++ b/extensions/telegram/src/progress-draft-preview.test.ts
@@ -26,7 +26,6 @@ describe("renderTelegramProgressDraftPreview", () => {
     for (const name of ["Bash", "bash", "exec"]) {
       const rendered = renderToolLine(name);
       expect(rendered.match(/🛠️/gu) ?? []).toHaveLength(1);
-      expect(rendered).toContain("print text");
     }
   });
 

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -398,6 +398,10 @@ describe("getTelegramSequentialKey", () => {
   ])("resolves key %#", (input, expected) => {
     expect(getTelegramSequentialKey(input)).toEqual(expected);
   });
+
+  it("keeps malformed message updates on the unknown lane", () => {
+    expect(getTelegramSequentialKey({ message: {} as Message })).toBe("telegram:unknown");
+  });
 });
 
 describe("getTelegramSequentialConstraints", () => {

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -265,8 +265,8 @@ export type GetReplyOptions = {
   reasoningPayloadsEnabled?: boolean;
   /** Deliver durable commentary (💬) payloads to channels that own a separate commentary lane. */
   commentaryPayloadsEnabled?: boolean;
-  /** With the static opt-in, evaluated once after frozen verbose visibility registers.
-   * Omit to retain durable delivery; the result is snapshotted for the turn. */
+  /** Optional turn-frozen commentary owner; visibility is live by default.
+   * With the static opt-in and this callback, core freezes, evaluates once, and snapshots. */
   shouldDeliverCommentaryPayloads?: () => boolean;
   /** Called when the agent emits a structured plan update. */
   onPlanUpdate?: (payload: {

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -265,6 +265,9 @@ export type GetReplyOptions = {
   reasoningPayloadsEnabled?: boolean;
   /** Deliver durable commentary (💬) payloads to channels that own a separate commentary lane. */
   commentaryPayloadsEnabled?: boolean;
+  /** With the static opt-in, evaluated once after frozen verbose visibility registers.
+   * Omit to retain durable delivery; the result is snapshotted for the turn. */
+  shouldDeliverCommentaryPayloads?: () => boolean;
   /** Called when the agent emits a structured plan update. */
   onPlanUpdate?: (payload: {
     phase?: string;

--- a/src/auto-reply/reply/agent-runner-result-accounting.test.ts
+++ b/src/auto-reply/reply/agent-runner-result-accounting.test.ts
@@ -128,6 +128,7 @@ function createParams(
     sessionKey: "main",
   } satisfies FollowupRunnerParams;
   const execution = {
+    commentaryPayloadsEnabled: false,
     execution: {
       runId: "run-1",
       outcome: {

--- a/src/auto-reply/reply/commentary-progress-owner.test.ts
+++ b/src/auto-reply/reply/commentary-progress-owner.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveTurnCommentaryPayloadsEnabled } from "./commentary-progress-owner.js";
+
+describe("resolveTurnCommentaryPayloadsEnabled", () => {
+  it("keeps visibility live and ignores the owner callback without the static opt-in", () => {
+    let verboseProgressVisible = true;
+    let registeredVisibility = () => false;
+    const shouldDeliverCommentaryPayloads = vi.fn(() => true);
+
+    expect(
+      resolveTurnCommentaryPayloadsEnabled({
+        commentaryPayloadsEnabled: false,
+        options: {
+          shouldDeliverCommentaryPayloads,
+          onVerboseProgressVisibility: (getter) => {
+            registeredVisibility = getter;
+          },
+        },
+        resolveVerboseProgressVisibility: () => verboseProgressVisible,
+      }),
+    ).toBe(false);
+
+    expect(shouldDeliverCommentaryPayloads).not.toHaveBeenCalled();
+    expect(registeredVisibility()).toBe(true);
+    verboseProgressVisible = false;
+    expect(registeredVisibility()).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/commentary-progress-owner.test.ts
+++ b/src/auto-reply/reply/commentary-progress-owner.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
-import { resolveTurnCommentaryPayloadsEnabled } from "./commentary-progress-owner.js";
+import { resolveTurnCommentaryProgressOwner } from "./commentary-progress-owner.js";
 
-describe("resolveTurnCommentaryPayloadsEnabled", () => {
+describe("resolveTurnCommentaryProgressOwner", () => {
   it("keeps visibility live and ignores the owner callback without the static opt-in", () => {
     let verboseProgressVisible = true;
     let registeredVisibility = () => false;
     const shouldDeliverCommentaryPayloads = vi.fn(() => true);
 
     expect(
-      resolveTurnCommentaryPayloadsEnabled({
+      resolveTurnCommentaryProgressOwner({
         commentaryPayloadsEnabled: false,
         options: {
           shouldDeliverCommentaryPayloads,
@@ -18,11 +18,39 @@ describe("resolveTurnCommentaryPayloadsEnabled", () => {
         },
         resolveVerboseProgressVisibility: () => verboseProgressVisible,
       }),
-    ).toBe(false);
+    ).toEqual({ commentaryPayloadsEnabled: false, draftOwnsCommentaryProgress: false });
 
     expect(shouldDeliverCommentaryPayloads).not.toHaveBeenCalled();
     expect(registeredVisibility()).toBe(true);
     verboseProgressVisible = false;
     expect(registeredVisibility()).toBe(false);
+  });
+
+  it.each([
+    {
+      owner: "static opt-in without a callback",
+      shouldDeliverCommentaryPayloads: undefined,
+      expected: { commentaryPayloadsEnabled: true, draftOwnsCommentaryProgress: false },
+    },
+    {
+      owner: "draft callback",
+      shouldDeliverCommentaryPayloads: () => false,
+      expected: { commentaryPayloadsEnabled: false, draftOwnsCommentaryProgress: true },
+    },
+    {
+      owner: "durable callback",
+      shouldDeliverCommentaryPayloads: () => true,
+      expected: { commentaryPayloadsEnabled: true, draftOwnsCommentaryProgress: false },
+    },
+  ])("records $owner ownership", ({ shouldDeliverCommentaryPayloads, expected }) => {
+    expect(
+      resolveTurnCommentaryProgressOwner({
+        commentaryPayloadsEnabled: true,
+        options: {
+          shouldDeliverCommentaryPayloads,
+        },
+        resolveVerboseProgressVisibility: () => false,
+      }),
+    ).toEqual(expected);
   });
 });

--- a/src/auto-reply/reply/commentary-progress-owner.ts
+++ b/src/auto-reply/reply/commentary-progress-owner.ts
@@ -1,0 +1,26 @@
+import type { GetReplyOptions } from "../get-reply-options.types.js";
+
+type CommentaryProgressOwnerOptions = Pick<
+  GetReplyOptions,
+  "onVerboseProgressVisibility" | "shouldDeliverCommentaryPayloads"
+>;
+
+/** Freezes and registers one commentary owner for the current agent turn. */
+export function resolveTurnCommentaryPayloadsEnabled(params: {
+  commentaryPayloadsEnabled: boolean;
+  options?: CommentaryProgressOwnerOptions;
+  resolveVerboseProgressVisibility: () => boolean;
+}): boolean {
+  const shouldDeliverCommentaryPayloads = params.commentaryPayloadsEnabled
+    ? params.options?.shouldDeliverCommentaryPayloads
+    : undefined;
+  const frozenVerboseProgressVisibility = shouldDeliverCommentaryPayloads
+    ? params.resolveVerboseProgressVisibility()
+    : undefined;
+  params.options?.onVerboseProgressVisibility?.(
+    frozenVerboseProgressVisibility === undefined
+      ? params.resolveVerboseProgressVisibility
+      : () => frozenVerboseProgressVisibility,
+  );
+  return params.commentaryPayloadsEnabled && (shouldDeliverCommentaryPayloads?.() ?? true);
+}

--- a/src/auto-reply/reply/commentary-progress-owner.ts
+++ b/src/auto-reply/reply/commentary-progress-owner.ts
@@ -6,11 +6,14 @@ type CommentaryProgressOwnerOptions = Pick<
 >;
 
 /** Freezes and registers one commentary owner for the current agent turn. */
-export function resolveTurnCommentaryPayloadsEnabled(params: {
+export function resolveTurnCommentaryProgressOwner(params: {
   commentaryPayloadsEnabled: boolean;
   options?: CommentaryProgressOwnerOptions;
   resolveVerboseProgressVisibility: () => boolean;
-}): boolean {
+}): {
+  commentaryPayloadsEnabled: boolean;
+  draftOwnsCommentaryProgress: boolean;
+} {
   const shouldDeliverCommentaryPayloads = params.commentaryPayloadsEnabled
     ? params.options?.shouldDeliverCommentaryPayloads
     : undefined;
@@ -22,5 +25,13 @@ export function resolveTurnCommentaryPayloadsEnabled(params: {
       ? params.resolveVerboseProgressVisibility
       : () => frozenVerboseProgressVisibility,
   );
-  return params.commentaryPayloadsEnabled && (shouldDeliverCommentaryPayloads?.() ?? true);
+  const commentaryPayloadsEnabled =
+    params.commentaryPayloadsEnabled && (shouldDeliverCommentaryPayloads?.() ?? true);
+  return {
+    commentaryPayloadsEnabled,
+    draftOwnsCommentaryProgress:
+      params.commentaryPayloadsEnabled &&
+      shouldDeliverCommentaryPayloads !== undefined &&
+      !commentaryPayloadsEnabled,
+  };
 }

--- a/src/auto-reply/reply/dispatch-from-config.prepare-execution.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-execution.ts
@@ -363,13 +363,20 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
         return await forwardItemEvent?.(payload);
       }
     : undefined;
-  // Let draft-rendering channels yield their ephemeral commentary lines while
-  // the durable verbose commentary lane is delivering the same content.
+  const resolveVerboseProgressVisibility = () =>
+    deliverStandaloneCommentaryProgress &&
+    shouldSendVerboseProgressMessages() &&
+    !shouldSuppressProgressDelivery();
+  const shouldDeliverCommentaryPayloads = params.replyOptions?.shouldDeliverCommentaryPayloads;
+  // New commentary-owner consumers share one per-turn decision between the
+  // draft and durable lanes. Legacy visibility listeners remain live.
+  const frozenCommentaryProgressVisibility = shouldDeliverCommentaryPayloads
+    ? resolveVerboseProgressVisibility()
+    : undefined;
   params.replyOptions?.onVerboseProgressVisibility?.(
-    () =>
-      deliverStandaloneCommentaryProgress &&
-      shouldSendVerboseProgressMessages() &&
-      !shouldSuppressProgressDelivery(),
+    frozenCommentaryProgressVisibility === undefined
+      ? resolveVerboseProgressVisibility
+      : () => frozenCommentaryProgressVisibility,
   );
 
   const replyResolver =
@@ -407,6 +414,8 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
     deliverStandaloneCommentaryProgress,
     canForwardSuppressedSourceItemEvents,
     onItemEvent,
+    commentaryPayloadsEnabled:
+      state.commentaryPayloadsEnabled && (shouldDeliverCommentaryPayloads?.() ?? true),
     replyResolver,
     replyConfig,
     progressState,

--- a/src/auto-reply/reply/dispatch-from-config.prepare-execution.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-execution.ts
@@ -12,7 +12,7 @@ import { shouldCleanTtsDirectiveText } from "../../tts/tts-config.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import type { GetReplyOptions } from "../get-reply-options.types.js";
 import type { ReplyPayload } from "../reply-payload.js";
-import { resolveTurnCommentaryPayloadsEnabled } from "./commentary-progress-owner.js";
+import { resolveTurnCommentaryProgressOwner } from "./commentary-progress-owner.js";
 import type { ChooseDispatchRouteReadyState } from "./dispatch-from-config.choose-route.js";
 import {
   hasAskUserPayload,
@@ -368,7 +368,7 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
     deliverStandaloneCommentaryProgress &&
     shouldSendVerboseProgressMessages() &&
     !shouldSuppressProgressDelivery();
-  const commentaryPayloadsEnabled = resolveTurnCommentaryPayloadsEnabled({
+  const { commentaryPayloadsEnabled } = resolveTurnCommentaryProgressOwner({
     commentaryPayloadsEnabled: state.commentaryPayloadsEnabled,
     options: params.replyOptions,
     resolveVerboseProgressVisibility,

--- a/src/auto-reply/reply/dispatch-from-config.prepare-execution.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-execution.ts
@@ -12,6 +12,7 @@ import { shouldCleanTtsDirectiveText } from "../../tts/tts-config.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import type { GetReplyOptions } from "../get-reply-options.types.js";
 import type { ReplyPayload } from "../reply-payload.js";
+import { resolveTurnCommentaryPayloadsEnabled } from "./commentary-progress-owner.js";
 import type { ChooseDispatchRouteReadyState } from "./dispatch-from-config.choose-route.js";
 import {
   hasAskUserPayload,
@@ -367,17 +368,11 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
     deliverStandaloneCommentaryProgress &&
     shouldSendVerboseProgressMessages() &&
     !shouldSuppressProgressDelivery();
-  const shouldDeliverCommentaryPayloads = params.replyOptions?.shouldDeliverCommentaryPayloads;
-  // New commentary-owner consumers share one per-turn decision between the
-  // draft and durable lanes. Legacy visibility listeners remain live.
-  const frozenCommentaryProgressVisibility = shouldDeliverCommentaryPayloads
-    ? resolveVerboseProgressVisibility()
-    : undefined;
-  params.replyOptions?.onVerboseProgressVisibility?.(
-    frozenCommentaryProgressVisibility === undefined
-      ? resolveVerboseProgressVisibility
-      : () => frozenCommentaryProgressVisibility,
-  );
+  const commentaryPayloadsEnabled = resolveTurnCommentaryPayloadsEnabled({
+    commentaryPayloadsEnabled: state.commentaryPayloadsEnabled,
+    options: params.replyOptions,
+    resolveVerboseProgressVisibility,
+  });
 
   const replyResolver =
     params.replyResolver ??
@@ -414,8 +409,7 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
     deliverStandaloneCommentaryProgress,
     canForwardSuppressedSourceItemEvents,
     onItemEvent,
-    commentaryPayloadsEnabled:
-      state.commentaryPayloadsEnabled && (shouldDeliverCommentaryPayloads?.() ?? true),
+    commentaryPayloadsEnabled,
     replyResolver,
     replyConfig,
     progressState,

--- a/src/auto-reply/reply/dispatch-from-config.progress.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.progress.test-utils.ts
@@ -46,12 +46,17 @@ describe("dispatchReplyFromConfig", () => {
 
     let isActive: (() => boolean) | undefined;
     let activeDuringRun: boolean | undefined;
+    let activeAfterLevelChange: boolean | undefined;
     const replyResolver = async (
       _ctx: MsgContext,
       _opts?: GetReplyOptions,
       _cfg?: OpenClawConfig,
     ) => {
       activeDuringRun = isActive?.();
+      sessionStoreMocks.currentEntry = {
+        verboseLevel: "off",
+      };
+      activeAfterLevelChange = isActive?.();
       return { text: "done" } satisfies ReplyPayload;
     };
 
@@ -68,6 +73,7 @@ describe("dispatchReplyFromConfig", () => {
     });
 
     expect(activeDuringRun).toBe(true);
+    expect(activeAfterLevelChange).toBe(false);
 
     sessionStoreMocks.currentEntry = {
       verboseLevel: "off",
@@ -92,60 +98,88 @@ describe("dispatchReplyFromConfig", () => {
     expect(activeDuringOffRun).toBe(false);
   });
 
-  it("keeps block-owned commentary out of the standalone durable progress lane", async () => {
-    setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      verboseLevel: "on",
-    };
-    const dispatcher = createDispatcher();
-    const ctx = buildTestCtx({
-      Provider: "discord",
-      Surface: "discord",
-      ChatType: "direct",
-    });
-    const onItemEvent = vi.fn();
+  it.each([
+    { surface: "slack", verboseLevel: "on", nextVerboseLevel: "off", durableCommentary: true },
+    { surface: "slack", verboseLevel: "off", nextVerboseLevel: "on", durableCommentary: false },
+    { surface: "discord", verboseLevel: "on", nextVerboseLevel: "off", durableCommentary: true },
+    { surface: "discord", verboseLevel: "off", nextVerboseLevel: "on", durableCommentary: false },
+  ] as const)(
+    "routes $surface commentary through one owner with verbose $verboseLevel",
+    async ({ surface, verboseLevel, nextVerboseLevel, durableCommentary }) => {
+      setNoAbort();
+      sessionStoreMocks.currentEntry = {
+        verboseLevel,
+      };
+      const dispatcher = createDispatcher();
+      const ctx = buildTestCtx({
+        Provider: surface,
+        Surface: surface,
+        ChatType: "group",
+        From: `${surface}:channel:C123`,
+        SessionKey: `agent:main:${surface}:channel:C123`,
+      });
+      const onItemEvent = vi.fn();
+      let isVerboseProgressActive = () => false;
 
-    const replyResolver = async (
-      _ctx: MsgContext,
-      opts?: GetReplyOptions,
-      _cfg?: OpenClawConfig,
-    ) => {
-      await opts?.onItemEvent?.({
+      const replyResolver = async (
+        _ctx: MsgContext,
+        opts?: GetReplyOptions,
+        _cfg?: OpenClawConfig,
+      ) => {
+        sessionStoreMocks.currentEntry = {
+          verboseLevel: nextVerboseLevel,
+        };
+        expect(isVerboseProgressActive()).toBe(durableCommentary);
+        expect(opts?.commentaryPayloadsEnabled).toBe(durableCommentary);
+        await opts?.onItemEvent?.({
+          itemId: "commentary-1",
+          kind: "preamble",
+          progressText: "Inspecting the dispatch path.",
+          ...(durableCommentary ? { suppressDurableProgress: true } : {}),
+        });
+        await opts?.onBlockReply?.({
+          text: "Inspecting the dispatch path.",
+          isCommentary: true,
+        });
+        return { text: "Done." } satisfies ReplyPayload;
+      };
+
+      await dispatchReplyFromConfig({
+        ctx,
+        cfg: automaticGroupReplyConfig,
+        dispatcher,
+        replyResolver,
+        replyOptions: {
+          suppressDefaultToolProgressMessages: true,
+          commentaryProgressEnabled: true,
+          progressPreambleEnabled: true,
+          commentaryPayloadsEnabled: true,
+          shouldDeliverCommentaryPayloads: () => isVerboseProgressActive(),
+          onVerboseProgressVisibility: (getter) => {
+            isVerboseProgressActive = getter;
+          },
+          onItemEvent,
+        },
+      });
+
+      expect(onItemEvent).toHaveBeenCalledExactlyOnceWith({
         itemId: "commentary-1",
         kind: "preamble",
         progressText: "Inspecting the dispatch path.",
-        suppressDurableProgress: true,
+        ...(durableCommentary ? { suppressDurableProgress: true } : {}),
       });
-      await opts?.onBlockReply?.({ text: "Inspecting the dispatch path." });
-      return { text: "Done." } satisfies ReplyPayload;
-    };
-
-    await dispatchReplyFromConfig({
-      ctx,
-      cfg: emptyConfig,
-      dispatcher,
-      replyResolver,
-      replyOptions: {
-        suppressDefaultToolProgressMessages: true,
-        commentaryProgressEnabled: true,
-        progressPreambleEnabled: true,
-        commentaryPayloadsEnabled: true,
-        onItemEvent,
-      },
-    });
-
-    expect(onItemEvent).toHaveBeenCalledExactlyOnceWith({
-      itemId: "commentary-1",
-      kind: "preamble",
-      progressText: "Inspecting the dispatch path.",
-      suppressDurableProgress: true,
-    });
-    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
-    expect(dispatcher.sendBlockReply).toHaveBeenCalledExactlyOnceWith({
-      text: "Inspecting the dispatch path.",
-    });
-    expect(dispatcher.sendFinalReply).toHaveBeenCalledExactlyOnceWith({ text: "Done." });
-  });
+      expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+      if (durableCommentary) {
+        expect(dispatcher.sendBlockReply).toHaveBeenCalledExactlyOnceWith({
+          text: "Inspecting the dispatch path.",
+          isCommentary: true,
+        });
+      } else {
+        expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+      }
+      expect(dispatcher.sendFinalReply).toHaveBeenCalledExactlyOnceWith({ text: "Done." });
+    },
+  );
 
   it("forwards channel-owned group progress callbacks while source delivery is suppressed", async () => {
     setNoAbort();

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -118,6 +118,7 @@ function createTurn(
 
 function createRejectedExecution(order: string[] = []): FollowupExecutionResult {
   return {
+    commentaryPayloadsEnabled: false,
     execution: {
       runId: "run-1",
       outcome: { kind: "rejected", payload: { text: "failed" } },
@@ -282,6 +283,34 @@ describe("createFollowupRunner", () => {
     ]);
     expect(state.clearRunContext).toHaveBeenCalledWith("run-1");
   });
+
+  it.each([true, false])(
+    "projects queued commentary with the refreshed durable owner when enabled is %s",
+    async (commentaryPayloadsEnabled) => {
+      const typing = createTypingController();
+      const turn = createTurn();
+      const execution = Object.assign(createRejectedExecution(), {
+        commentaryPayloadsEnabled,
+      });
+      state.admit.mockResolvedValue({ kind: "admitted", turn });
+      state.execute.mockResolvedValue(execution);
+      state.account.mockResolvedValue(undefined);
+      state.deliver.mockResolvedValue(undefined);
+
+      await createFollowupRunner({
+        typing,
+        typingMode: "instant",
+        defaultModel: "claude",
+        opts: { commentaryPayloadsEnabled: !commentaryPayloadsEnabled },
+      })(turn.queued);
+
+      expect(state.resolveDecision).toHaveBeenCalledWith(
+        expect.objectContaining({
+          opts: expect.objectContaining({ commentaryPayloadsEnabled }),
+        }),
+      );
+    },
+  );
 
   it("does not replay a settled turn when progress presentation fails", async () => {
     const typing = createTypingController();

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -119,11 +119,15 @@ export function createFollowupRunner(
         await defaults.opts?.onObservedReplyDelivery?.();
       }
       const accounting = await accountFollowupTurn({ turn, defaults, execution });
+      const deliveryOpts = {
+        ...defaults.opts,
+        commentaryPayloadsEnabled: execution.commentaryPayloadsEnabled,
+      };
       const decision = resolveFollowupDeliveryDecision({
         turn,
         execution: execution.execution,
         accounting,
-        opts: defaults.opts,
+        opts: deliveryOpts,
       });
       await deliverFollowupDecision({
         decision,

--- a/src/auto-reply/reply/followup-turn-execution.test.ts
+++ b/src/auto-reply/reply/followup-turn-execution.test.ts
@@ -323,6 +323,44 @@ describe("executeFollowupTurn", () => {
     });
   });
 
+  it("suppresses queued verbose-off preambles without an explicit commentary owner", async () => {
+    const onItemEvent = vi.fn(async () => true as const);
+    let preambleVisible: boolean | void = true;
+    const turn = createTurn({
+      session: {
+        kind: "session",
+        key: "main",
+        current: () => ({ sessionId: "session", updatedAt: 1, verboseLevel: "off" }),
+        publish: () => undefined,
+        adopt: () => undefined,
+      },
+    });
+    state.execute.mockImplementation(async (params: AgentTurnParams) => {
+      preambleVisible = await params.opts?.onItemEvent?.({
+        kind: "preamble",
+        progressText: "Checking the queued request",
+      });
+      return { runId: "run-1", outcome: { kind: "rejected", payload: { text: "done" } } };
+    });
+
+    const result = await executeFollowupTurn({
+      turn,
+      defaults: {
+        typing: createTypingController(),
+        typingMode: "never",
+        defaultModel: "claude",
+        opts: { onItemEvent },
+      },
+      onToolResult: vi.fn(async () => {}),
+      onCompactionNoticePayload: vi.fn(async () => {}),
+    });
+    await result.progress.drain();
+
+    expect(result.commentaryPayloadsEnabled).toBe(false);
+    expect(preambleVisible).toBe(false);
+    expect(onItemEvent).not.toHaveBeenCalled();
+  });
+
   it("keeps room-event progress, tool summaries, and typing silent", async () => {
     const turn = createTurn({
       queued: { ...createTurn().queued, currentInboundEventKind: "room_event" },

--- a/src/auto-reply/reply/followup-turn-execution.test.ts
+++ b/src/auto-reply/reply/followup-turn-execution.test.ts
@@ -323,43 +323,65 @@ describe("executeFollowupTurn", () => {
     });
   });
 
-  it("suppresses queued verbose-off preambles without an explicit commentary owner", async () => {
-    const onItemEvent = vi.fn(async () => true as const);
-    let preambleVisible: boolean | void = true;
-    const turn = createTurn({
-      session: {
-        kind: "session",
-        key: "main",
-        current: () => ({ sessionId: "session", updatedAt: 1, verboseLevel: "off" }),
-        publish: () => undefined,
-        adopt: () => undefined,
+  it.each([
+    {
+      owner: "without a static opt-in",
+      ownerOptions: {},
+      expectedDurableCommentary: false,
+    },
+    {
+      owner: "with only a static opt-in",
+      ownerOptions: { commentaryPayloadsEnabled: true },
+      expectedDurableCommentary: true,
+    },
+    {
+      owner: "with the durable callback owner",
+      ownerOptions: {
+        commentaryPayloadsEnabled: true,
+        shouldDeliverCommentaryPayloads: () => true,
       },
-    });
-    state.execute.mockImplementation(async (params: AgentTurnParams) => {
-      preambleVisible = await params.opts?.onItemEvent?.({
-        kind: "preamble",
-        progressText: "Checking the queued request",
+      expectedDurableCommentary: true,
+    },
+  ] as const)(
+    "suppresses queued verbose-off preambles $owner",
+    async ({ ownerOptions, expectedDurableCommentary }) => {
+      const onItemEvent = vi.fn(async () => true as const);
+      let preambleVisible: boolean | void = true;
+      const turn = createTurn({
+        session: {
+          kind: "session",
+          key: "main",
+          current: () => ({ sessionId: "session", updatedAt: 1, verboseLevel: "off" }),
+          publish: () => undefined,
+          adopt: () => undefined,
+        },
       });
-      return { runId: "run-1", outcome: { kind: "rejected", payload: { text: "done" } } };
-    });
+      state.execute.mockImplementation(async (params: AgentTurnParams) => {
+        preambleVisible = await params.opts?.onItemEvent?.({
+          kind: "preamble",
+          progressText: "Checking the queued request",
+        });
+        return { runId: "run-1", outcome: { kind: "rejected", payload: { text: "done" } } };
+      });
 
-    const result = await executeFollowupTurn({
-      turn,
-      defaults: {
-        typing: createTypingController(),
-        typingMode: "never",
-        defaultModel: "claude",
-        opts: { onItemEvent },
-      },
-      onToolResult: vi.fn(async () => {}),
-      onCompactionNoticePayload: vi.fn(async () => {}),
-    });
-    await result.progress.drain();
+      const result = await executeFollowupTurn({
+        turn,
+        defaults: {
+          typing: createTypingController(),
+          typingMode: "never",
+          defaultModel: "claude",
+          opts: { onItemEvent, ...ownerOptions },
+        },
+        onToolResult: vi.fn(async () => {}),
+        onCompactionNoticePayload: vi.fn(async () => {}),
+      });
+      await result.progress.drain();
 
-    expect(result.commentaryPayloadsEnabled).toBe(false);
-    expect(preambleVisible).toBe(false);
-    expect(onItemEvent).not.toHaveBeenCalled();
-  });
+      expect(result.commentaryPayloadsEnabled).toBe(expectedDurableCommentary);
+      expect(preambleVisible).toBe(false);
+      expect(onItemEvent).not.toHaveBeenCalled();
+    },
+  );
 
   it("keeps room-event progress, tool summaries, and typing silent", async () => {
     const turn = createTurn({

--- a/src/auto-reply/reply/followup-turn-execution.test.ts
+++ b/src/auto-reply/reply/followup-turn-execution.test.ts
@@ -270,6 +270,59 @@ describe("executeFollowupTurn", () => {
     },
   );
 
+  it("routes a queued verbose-off preamble to the draft commentary owner", async () => {
+    const onItemEvent = vi.fn(async () => true as const);
+    let preambleVisible: boolean | void = false;
+    let toolVisible: boolean | void = true;
+    const turn = createTurn({
+      session: {
+        kind: "session",
+        key: "main",
+        current: () => ({ sessionId: "session", updatedAt: 1, verboseLevel: "off" }),
+        publish: () => undefined,
+        adopt: () => undefined,
+      },
+    });
+    state.execute.mockImplementation(async (params: AgentTurnParams) => {
+      expect(params.opts?.commentaryPayloadsEnabled).toBe(false);
+      preambleVisible = await params.opts?.onItemEvent?.({
+        kind: "preamble",
+        progressText: "Checking the queued request",
+      });
+      toolVisible = await params.opts?.onItemEvent?.({
+        kind: "tool",
+        progressText: "running exec",
+      });
+      return { runId: "run-1", outcome: { kind: "rejected", payload: { text: "done" } } };
+    });
+
+    const result = await executeFollowupTurn({
+      turn,
+      defaults: {
+        typing: createTypingController(),
+        typingMode: "never",
+        defaultModel: "claude",
+        opts: {
+          commentaryPayloadsEnabled: true,
+          shouldDeliverCommentaryPayloads: () => false,
+          onItemEvent,
+        },
+      },
+      onToolResult: vi.fn(async () => {}),
+      onCompactionNoticePayload: vi.fn(async () => {}),
+    });
+    await result.progress.drain();
+
+    expect(result.commentaryPayloadsEnabled).toBe(false);
+    expect(preambleVisible).toBe(true);
+    expect(toolVisible).toBe(false);
+    expect(onItemEvent).toHaveBeenCalledOnce();
+    expect(onItemEvent).toHaveBeenCalledWith({
+      kind: "preamble",
+      progressText: "Checking the queued request",
+    });
+  });
+
   it("keeps room-event progress, tool summaries, and typing silent", async () => {
     const turn = createTurn({
       queued: { ...createTurn().queued, currentInboundEventKind: "room_event" },

--- a/src/auto-reply/reply/followup-turn-execution.test.ts
+++ b/src/auto-reply/reply/followup-turn-execution.test.ts
@@ -215,6 +215,61 @@ describe("executeFollowupTurn", () => {
     expect(call.resolvedVerboseLevel).toBe("off");
   });
 
+  it.each([
+    {
+      initialLevel: "off",
+      queuedLevel: "on",
+      expectedDurableCommentary: true,
+    },
+    {
+      initialLevel: "on",
+      queuedLevel: "off",
+      expectedDurableCommentary: false,
+    },
+  ] as const)(
+    "refreshes commentary ownership for a queued $initialLevel-to-$queuedLevel transition",
+    async ({ initialLevel, queuedLevel, expectedDurableCommentary }) => {
+      let verboseLevel = queuedLevel;
+      let isVerboseProgressActive = () => initialLevel !== "off";
+      const turn = createTurn({
+        session: {
+          kind: "session",
+          key: "main",
+          current: () => ({ sessionId: "session", updatedAt: 1, verboseLevel }),
+          publish: () => undefined,
+          adopt: () => undefined,
+        },
+      });
+      state.execute.mockImplementation(async (params: AgentTurnParams) => {
+        expect(params.resolvedVerboseLevel).toBe(queuedLevel);
+        expect(params.opts?.commentaryPayloadsEnabled).toBe(expectedDurableCommentary);
+        verboseLevel = queuedLevel === "off" ? "on" : "off";
+        expect(isVerboseProgressActive()).toBe(queuedLevel !== "off");
+        return { runId: "run-1", outcome: { kind: "rejected", payload: { text: "done" } } };
+      });
+
+      const result = await executeFollowupTurn({
+        turn,
+        defaults: {
+          typing: createTypingController(),
+          typingMode: "never",
+          defaultModel: "claude",
+          opts: {
+            commentaryPayloadsEnabled: true,
+            shouldDeliverCommentaryPayloads: () => isVerboseProgressActive(),
+            onVerboseProgressVisibility: (getter) => {
+              isVerboseProgressActive = getter;
+            },
+          },
+        },
+        onToolResult: vi.fn(async () => {}),
+        onCompactionNoticePayload: vi.fn(async () => {}),
+      });
+
+      expect(result.commentaryPayloadsEnabled).toBe(expectedDurableCommentary);
+    },
+  );
+
   it("keeps room-event progress, tool summaries, and typing silent", async () => {
     const turn = createTurn({
       queued: { ...createTurn().queued, currentInboundEventKind: "room_event" },

--- a/src/auto-reply/reply/followup-turn-execution.ts
+++ b/src/auto-reply/reply/followup-turn-execution.ts
@@ -7,7 +7,7 @@ import type { ReplyPayload } from "../types.js";
 import { executeAgentTurn } from "./agent-runner-execution.js";
 import type { AgentTurnExecutionResult } from "./agent-runner-execution.types.js";
 import { resetReplyRunSession } from "./agent-runner-session-reset.js";
-import { resolveTurnCommentaryPayloadsEnabled } from "./commentary-progress-owner.js";
+import { resolveTurnCommentaryProgressOwner } from "./commentary-progress-owner.js";
 import { requiresDurableToolResultDelivery } from "./dispatch-from-config.payloads.js";
 import type { AdmittedFollowupTurn, FollowupRunnerParams } from "./followup-turn-admission.js";
 import type { InternalGetReplyOptions } from "./get-reply.types.js";
@@ -115,15 +115,12 @@ export async function executeFollowupTurn(params: {
   const shouldEmitToolLifecycle = () =>
     progressAllowed() &&
     (shouldEmitToolResult() || defaults.opts?.allowToolLifecycleWhenProgressHidden === true);
-  const commentaryPayloadsEnabled = resolveTurnCommentaryPayloadsEnabled({
-    commentaryPayloadsEnabled: sourceOpts?.commentaryPayloadsEnabled === true,
-    options: sourceOpts,
-    resolveVerboseProgressVisibility: () => progressAllowed() && shouldEmitVerboseToolResult(),
-  });
-  const draftOwnsCommentaryProgress =
-    sourceOpts?.commentaryPayloadsEnabled === true &&
-    sourceOpts.shouldDeliverCommentaryPayloads !== undefined &&
-    !commentaryPayloadsEnabled;
+  const { commentaryPayloadsEnabled, draftOwnsCommentaryProgress } =
+    resolveTurnCommentaryProgressOwner({
+      commentaryPayloadsEnabled: sourceOpts?.commentaryPayloadsEnabled === true,
+      options: sourceOpts,
+      resolveVerboseProgressVisibility: () => progressAllowed() && shouldEmitVerboseToolResult(),
+    });
   let visibleToolError = false;
   let progressChain: Promise<void> = Promise.resolve();
   let pendingProgressTaskFailure: unknown;

--- a/src/auto-reply/reply/followup-turn-execution.ts
+++ b/src/auto-reply/reply/followup-turn-execution.ts
@@ -120,6 +120,10 @@ export async function executeFollowupTurn(params: {
     options: sourceOpts,
     resolveVerboseProgressVisibility: () => progressAllowed() && shouldEmitVerboseToolResult(),
   });
+  const draftOwnsCommentaryProgress =
+    sourceOpts?.commentaryPayloadsEnabled === true &&
+    sourceOpts.shouldDeliverCommentaryPayloads !== undefined &&
+    !commentaryPayloadsEnabled;
   let visibleToolError = false;
   let progressChain: Promise<void> = Promise.resolve();
   let pendingProgressTaskFailure: unknown;
@@ -225,9 +229,10 @@ export async function executeFollowupTurn(params: {
     onItemEvent: sourceOpts?.onItemEvent
       ? (item) =>
           enqueueProgressResult(async () => {
-            // When durable commentary yields, the channel draft owns queued preambles.
+            // Only an explicit draft-vs-durable owner contract may bypass hidden
+            // tool-progress filtering for queued preambles.
             const draftOwnsPreamble =
-              progressAllowed() && item.kind === "preamble" && !commentaryPayloadsEnabled;
+              progressAllowed() && item.kind === "preamble" && draftOwnsCommentaryProgress;
             if (!draftOwnsPreamble && !shouldEmitToolResult()) {
               return false;
             }

--- a/src/auto-reply/reply/followup-turn-execution.ts
+++ b/src/auto-reply/reply/followup-turn-execution.ts
@@ -225,7 +225,10 @@ export async function executeFollowupTurn(params: {
     onItemEvent: sourceOpts?.onItemEvent
       ? (item) =>
           enqueueProgressResult(async () => {
-            if (!shouldEmitToolResult()) {
+            // When durable commentary yields, the channel draft owns queued preambles.
+            const draftOwnsPreamble =
+              progressAllowed() && item.kind === "preamble" && !commentaryPayloadsEnabled;
+            if (!draftOwnsPreamble && !shouldEmitToolResult()) {
               return false;
             }
             const visible = (

--- a/src/auto-reply/reply/followup-turn-execution.ts
+++ b/src/auto-reply/reply/followup-turn-execution.ts
@@ -7,12 +7,14 @@ import type { ReplyPayload } from "../types.js";
 import { executeAgentTurn } from "./agent-runner-execution.js";
 import type { AgentTurnExecutionResult } from "./agent-runner-execution.types.js";
 import { resetReplyRunSession } from "./agent-runner-session-reset.js";
+import { resolveTurnCommentaryPayloadsEnabled } from "./commentary-progress-owner.js";
 import { requiresDurableToolResultDelivery } from "./dispatch-from-config.payloads.js";
 import type { AdmittedFollowupTurn, FollowupRunnerParams } from "./followup-turn-admission.js";
 import type { InternalGetReplyOptions } from "./get-reply.types.js";
 import { createTypingSignaler, type TypingSignaler } from "./typing-mode.js";
 
 export type FollowupExecutionResult = {
+  commentaryPayloadsEnabled: boolean;
   execution: AgentTurnExecutionResult;
   runStartedAt: number;
   sessionCtx: TemplateContext;
@@ -113,6 +115,11 @@ export async function executeFollowupTurn(params: {
   const shouldEmitToolLifecycle = () =>
     progressAllowed() &&
     (shouldEmitToolResult() || defaults.opts?.allowToolLifecycleWhenProgressHidden === true);
+  const commentaryPayloadsEnabled = resolveTurnCommentaryPayloadsEnabled({
+    commentaryPayloadsEnabled: sourceOpts?.commentaryPayloadsEnabled === true,
+    options: sourceOpts,
+    resolveVerboseProgressVisibility: () => progressAllowed() && shouldEmitVerboseToolResult(),
+  });
   let visibleToolError = false;
   let progressChain: Promise<void> = Promise.resolve();
   let pendingProgressTaskFailure: unknown;
@@ -185,6 +192,7 @@ export async function executeFollowupTurn(params: {
     // queued turn. Never let a later callback widen or narrow an older item.
     toolsAllow: turn.queued.toolsAllow,
     disableTools: turn.queued.disableTools,
+    commentaryPayloadsEnabled,
     runId: turn.runId,
     onAgentRunStart: (runId) => {
       params.onExecutionStarted?.();
@@ -409,6 +417,7 @@ export async function executeFollowupTurn(params: {
     }
   }
   return {
+    commentaryPayloadsEnabled,
     execution,
     runStartedAt,
     sessionCtx,

--- a/src/plugin-sdk/reply-runtime.contract.test.ts
+++ b/src/plugin-sdk/reply-runtime.contract.test.ts
@@ -32,4 +32,13 @@ describe("reply runtime public progress contracts", () => {
       Promise<ProgressResult> | ProgressResult
     >();
   });
+
+  it("exports the snapshotted commentary delivery gate", () => {
+    expectTypeOf<GetReplyOptions["commentaryPayloadsEnabled"]>().toEqualTypeOf<
+      boolean | undefined
+    >();
+    expectTypeOf<
+      Exclude<GetReplyOptions["shouldDeliverCommentaryPayloads"], undefined>
+    >().returns.toEqualTypeOf<boolean>();
+  });
 });


### PR DESCRIPTION
Related: #120588

## What Problem This Solves

Slack and Discord can show model commentary in either one evolving progress draft or separate durable messages. OpenClaw must choose exactly one owner per turn. Previously Slack disabled durable commentary unconditionally, which could drop commentary when its draft yielded. A later queued-path repair exposed the inverse bug: “durable commentary is false” was treated as “the draft owns commentary,” even for channels that never opted into this contract.

This PR records one explicit commentary owner when a turn starts and re-evaluates it for each admitted follow-up. Normal progress stays in the channel draft; verbose progress yields commentary to durable delivery. Ordinary tool events remain behind the existing progress gate.

## Root Cause And Architectural Owner

Static support and the turn-frozen delivery decision were represented by one ambiguous boolean. Shared initial/queued reply execution owns the per-turn decision; Slack and Discord own when their draft yields; the Plugin SDK owns the optional callback contract.

The canonical resolver now records two facts: whether durable commentary is enabled for the turn, and whether an explicitly opted-in draft owns commentary instead. Draft ownership requires static opt-in, a callback, and a frozen callback result selecting the draft. Matrix/Mattermost do not opt in; Telegram has only the static durable path.

## Fix

- Add the optional, synchronous `shouldDeliverCommentaryPayloads` SDK callback and document that it is inert without static `commentaryPayloadsEnabled: true`.
- Snapshot the callback once per admitted turn and use the same result for initial and queued execution.
- Let only an explicitly draft-owned queued `kind: "preamble"` bypass hidden tool-progress filtering; do not leak tool or room events.
- Wire Slack and Discord to the same prepared verbose-visibility getter that makes their drafts yield.
- Preserve current main's queued tool-policy snapshot, consolidated Discord draft fixture, and on-demand Plugin SDK API-diff contract.

## CI And Rebase

An earlier exact-head run exposed a Telegram native-command import stall that disjoint PR #123528 reproduced. #123607 fixed that architectural owner on main: an empty loaded registry no longer falls through to bundled-plugin source loading during Telegram native-name lookup. Exact #123607 and downstream #123528 CI both pass the formerly stalled shard; the previous #121009 head inherited that repair and passed those exact Telegram jobs.

The next exact-head run's only real red was unrelated Control UI budget saturation: startup JS measured 330511 B against a 330507 B ratchet. Current-main push CI independently failed at 330512 B with no #121009 UI changes. Main's canonical `ad400d810b3` repair records the CI-measured startup baseline; this head rebases onto that commit instead of copying UI-owner work into this PR.

All nine logical commits are patch-identical after rebase. #123036's on-demand Plugin SDK API-diff contract and #123022's consolidated Discord draft fixture remain intact. No timeout was increased and no cleanup, lifecycle, visibility, or watchdog assertion was weakened.

## Exact Proof

Current head `bdaedb9f1188`, local Node 26.3:

- core commentary-owner and queued-turn suites: 38/38 passed;
- Slack dispatch suite: 149/149 passed;
- Discord draft-progress suite: 26/26 passed;
- Telegram progress-summary suite: 18/18 passed;
- focused total: 231/231 passed across four repository Vitest shards;
- range-diff: all nine commits unchanged;
- `git diff --check`: passed;
- prior head proof: channel regressions, SDK contract/surface/API diff, oxlint, and oxfmt passed.

[Fresh exact-head CI run 31799402437](https://github.com/openclaw/openclaw/actions/runs/31799402437) is active. [#123607 exact-head run 31793124921](https://github.com/openclaw/openclaw/actions/runs/31793124921) and [downstream #123528 run 31793773495](https://github.com/openclaw/openclaw/actions/runs/31793773495) prove the inherited Telegram owner fix on Node 24.

The latest durable [ClawSweeper review](https://github.com/openclaw/openclaw/pull/121009#issuecomment-5230893777) found no remaining behavior defect and confirmed the queued-owner P1 was fixed. This push is a mechanical rebase onto the canonical main repair; exact-head dispatch ran automatically, so no duplicate mention was posted.

## Remaining Risk

Authenticated Slack and Discord live rendering was not run. Remaining product risk is transport rendering outside deterministic shared-dispatch and channel-owner tests. Fresh exact-head CI must pass before landing.

## Scope And LOC

- Production: +78/-10, net +68. This is the public callback contract and one canonical initial/queued ownership lifecycle shared by Slack and Discord.
- Tests and test support: +380/-50, net +330.
- Public docs: +16/-0.
- Generated Plugin SDK baselines: none; current main uses on-demand API diffs.
- Total: +474/-60 across 20 files.

## Credit

Dallin Romney remains author of the original Slack commit and co-author of the shared owner repair.
