### PR TITLE
fix(qa): activate Telegram plugin in bot-token startup proof

### DIFF
--- a/test/e2e/qa-lab/runtime/telegram-bot-token-runtime.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-bot-token-runtime.test.ts
@@ -101,6 +101,10 @@ describe("telegram bot token runtime evidence", () => {
             accounts: { "qa-live": { botToken: leasedToken } },
           },
         },
+        plugins: {
+          allow: ["telegram"],
+          entries: { telegram: { enabled: true } },
+        },
       },
       env: {
         OPENCLAW_SKIP_CHANNELS: undefined,

--- a/test/e2e/qa-lab/runtime/telegram-bot-token-runtime.ts
+++ b/test/e2e/qa-lab/runtime/telegram-bot-token-runtime.ts
@@ -230,6 +230,12 @@ export async function runTelegramBotTokenRuntime(
             },
           },
         },
+        // The isolated Gateway inherits VITEST, where bundled plugins are not
+        // implicitly enabled. Activate the product plugin this proof exercises.
+        plugins: {
+          allow: ["telegram"],
+          entries: { telegram: { enabled: true } },
+        },
       },
       env: {
         OPENCLAW_SKIP_CHANNELS: undefined,


### PR DESCRIPTION
## Summary

- Explicitly enable the Telegram plugin in the isolated bot-token startup Gateway.
- Assert the isolated runtime receives the matching plugin allowlist and enabled entry.

Related: extracted from #120588 at source head `2d0fdeb61fa06f9fa97b9626bb5a2f9016e45202` as an independent failure cluster.

## Root cause

The startup proof inherits `VITEST`, where bundled plugins are not implicitly enabled. Telegram channel configuration therefore existed without activating the Telegram plugin, so product polling never began and the proof timed out.

The owning boundary is `test/e2e/qa-lab/runtime/telegram-bot-token-runtime.ts`: the isolated Gateway fixture must explicitly activate the product plugin it exercises.

## Proof

- Blacksmith Testbox `tbx_01kzjtjq1563b6eagxpv2vpjf9`: [run 31303873503](https://github.com/openclaw/openclaw/actions/runs/31303873503)
- `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/telegram-bot-token-runtime.test.ts`: 6/6 passed
- Targeted oxfmt: passed
- Targeted oxlint: 0 warnings, 0 errors
- `pnpm tsgo:test:root`: passed
- `git diff --check`: passed
- Exact touched-file parity with the extracted #120588 source hunks: passed

## Scope

- Production LOC: `0`
- QA LOC: `+10/-0`
- No changelog: this only repairs QA fixture activation and assertions.
