### PR TITLE
fix(qa): record structured SSH blocked evidence

### DIFF
--- a/qa/scenarios/runtime/gateway-ssh-tunnels.yaml
+++ b/qa/scenarios/runtime/gateway-ssh-tunnels.yaml
@@ -24,6 +24,7 @@ scenario:
     - src/commands/gateway-status/probe-run.ts
     - test/e2e/qa-lab/runtime/gateway-ssh-tunnels.ts
   execution:
+    allowBlockedEvidence: true
     kind: script
     path: test/e2e/qa-lab/runtime/gateway-ssh-tunnels.ts
     summary: Starts an isolated real sshd and loopback Gateway with scenario-owned host trust, then exercises success, cleanup, host-key rejection, unreachable-daemon diagnostics, overlap, and forced termination.

--- a/test/e2e/qa-lab/runtime/gateway-ssh-tunnels.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-ssh-tunnels.test.ts
@@ -46,6 +46,20 @@ const evidence = await runGatewaySshTunnels({
 process.exitCode = evidence.entries[0]?.result.status === "pass" ? 0 : 1;
 `;
 
+describe("Gateway SSH tunnel QA preflight", () => {
+  it("records blocked evidence outside Testbox without privileged setup", async () => {
+    const artifactBase = tempDirs.make("openclaw-gateway-ssh-guard-");
+    const evidence = await withEnvAsync({ OPENCLAW_TESTBOX: undefined }, async () =>
+      runGatewaySshTunnels({ artifactBase, repoRoot: process.cwd() }),
+    );
+
+    expect(evidence.entries[0]?.result).toMatchObject({ status: "blocked" });
+    await expect(fs.access(path.join(artifactBase, ".ssh-namespace"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+});
+
 async function terminateChild(child: ChildProcessWithoutNullStreams) {
   if (child.exitCode !== null || child.signalCode !== null) {
     return;
@@ -155,21 +169,6 @@ async function readOptionalFile(filePath: string) {
 }
 
 describeOnTestbox("Gateway SSH tunnel QA producer", () => {
-  it("rejects privileged setup outside Testbox", async () => {
-    const artifactBase = tempDirs.make("openclaw-gateway-ssh-guard-");
-    await withEnvAsync({ OPENCLAW_TESTBOX: undefined }, async () => {
-      await expect(
-        runGatewaySshTunnels({
-          artifactBase,
-          repoRoot: process.cwd(),
-        }),
-      ).rejects.toThrow("requires OPENCLAW_TESTBOX=1 before privileged setup");
-    });
-    await expect(fs.access(path.join(artifactBase, ".ssh-namespace"))).rejects.toMatchObject({
-      code: "ENOENT",
-    });
-  });
-
   it("proves real forwarding, cleanup, and operator diagnostics", async () => {
     const artifactBase = tempDirs.make("openclaw-gateway-ssh-evidence-");
     const gatewayStartupEnv = snapshotGatewayStartupEnv();

--- a/test/e2e/qa-lab/runtime/gateway-ssh-tunnels.ts
+++ b/test/e2e/qa-lab/runtime/gateway-ssh-tunnels.ts
@@ -514,12 +514,6 @@ function sanitizeDiagnostic(text: string, roots: readonly string[]) {
 export async function runGatewaySshTunnels(
   options: ProducerOptions,
 ): Promise<QaEvidenceSummaryJson> {
-  if (process.env.OPENCLAW_TESTBOX !== "1") {
-    throw new Error("Gateway SSH tunnel QA requires OPENCLAW_TESTBOX=1 before privileged setup");
-  }
-  if (process.env[SSH_NAMESPACE_MARKER] !== "1") {
-    return await runInSshNamespace(options);
-  }
   await fs.mkdir(options.artifactBase, { recursive: true });
   const writer = createQaScriptEvidenceWriter({
     artifactBase: options.artifactBase,
@@ -539,6 +533,16 @@ export async function runGatewaySshTunnels(
       ],
     },
   });
+  if (process.env.OPENCLAW_TESTBOX !== "1") {
+    return await writer.write({
+      details: "Gateway SSH tunnel QA requires OPENCLAW_TESTBOX=1 before privileged setup",
+      durationMs: 1,
+      status: "blocked",
+    });
+  }
+  if (process.env[SSH_NAMESPACE_MARKER] !== "1") {
+    return await runInSshNamespace(options);
+  }
   const startedAt = Date.now();
   // openclaw-temp-dir: normal runs remove the fixture root; the SIGKILL test tracks its injected root
   const root =
@@ -714,7 +718,7 @@ async function main(argv: readonly string[]) {
   const status = evidence.entries[0]?.result.status;
   process.stdout.write(`Gateway SSH tunnel evidence: ${QA_EVIDENCE_FILENAME}\n`);
   process.stdout.write(`Gateway SSH tunnel status: ${status}\n`);
-  return status === "pass" ? 0 : 1;
+  return status === "pass" || status === "blocked" ? 0 : 1;
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {


### PR DESCRIPTION
## Summary

- Create the SSH scenario evidence writer before checking Testbox availability.
- Record a structured `blocked` result outside Testbox without attempting privileged namespace setup.
- Allow blocked evidence for the scenario and make the standalone producer treat that intentional result as successful settlement.

Related: extracted from #120588 at source head `2d0fdeb61fa06f9fa97b9626bb5a2f9016e45202` as an independent failure cluster.

## Root cause

The environment preflight threw before the evidence writer existed, so QA reported a producer failure instead of preserving the intentional environmental block. The scenario also lacked permission to accept blocked evidence.

The owning boundary is `test/e2e/qa-lab/runtime/gateway-ssh-tunnels.ts`: environment eligibility must be represented through the same structured evidence contract as the executable scenario.

## Proof

- Blacksmith Testbox `tbx_01kzjtwkn7y5v1qen4w3pjkcma`: [run 31304083193](https://github.com/openclaw/openclaw/actions/runs/31304083193)
- `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/gateway-ssh-tunnels.test.ts`: 3/3 passed
- Linux proof included real isolated `sshd` forwarding, cleanup and operator diagnostics, plus overlap and forced-termination isolation
- Targeted oxfmt: passed
- Targeted oxlint: 0 warnings, 0 errors
- `pnpm tsgo:test:root`: passed
- `git diff --check`: passed
- Exact touched-file parity with the extracted #120588 source hunks: passed

## Coordination

#120816 independently adds `parallelSafe: true` beside this scenario's execution policy. A merge-tree proof against its exact head `e3941fc` succeeds and preserves both `parallelSafe: true` and `allowBlockedEvidence: true`; this PR has no semantic dependency on #120816.

## Scope

- Production LOC: `0`
- QA/policy LOC: `+26/-22`
- No changelog: this only repairs QA evidence ownership and scenario policy.
