### PR TITLE
fix(gateway): skip startup chat-metadata refresh on minimal test gateways

### DIFF
--- a/src/gateway/server-chat-metadata-lifecycle.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createGatewayChatMetadataLifecycle } from "./server-chat-metadata-lifecycle.js";
+import type { GatewayRequestContext } from "./server-methods/types.js";
+import type { GatewayPostReadySidecarHandle } from "./server-startup-post-attach.js";
+
+const refreshPreparedModelRuntimeSnapshots = vi.hoisted(() =>
+  vi.fn(() => new Promise<void>(() => {})),
+);
+
+vi.mock("../agents/prepared-model-runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../agents/prepared-model-runtime.js")>()),
+  refreshPreparedModelRuntimeSnapshots,
+}));
+
+describe("gateway chat metadata lifecycle", () => {
+  test("minimal test gateway attach skips the startup runtime build", async () => {
+    const lifecycle = await createGatewayChatMetadataLifecycle({
+      getConfig: () => ({}) as OpenClawConfig,
+      minimalTestGateway: true,
+      log: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() } as never,
+    });
+    const sidecars: GatewayPostReadySidecarHandle[] = [];
+    // Minimal gateways register no refresh listeners, so there is no listener-registration
+    // race for a catch-up refresh to close. Awaiting one would force the full prepared
+    // model runtime build at startup, which the never-resolving mock turns into a hang.
+    await expect(
+      Promise.race([
+        lifecycle.attachContext({} as GatewayRequestContext, sidecars).then(() => "attached"),
+        new Promise((resolve) => setTimeout(() => resolve("timed out"), 2_000)),
+      ]),
+    ).resolves.toBe("attached");
+    expect(refreshPreparedModelRuntimeSnapshots).not.toHaveBeenCalled();
+    expect(sidecars).toHaveLength(0);
+  });
+});

--- a/src/gateway/server-chat-metadata-lifecycle.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.ts
@@ -92,9 +92,13 @@ export async function createGatewayChatMetadataLifecycle(params: {
     ) => {
       context = next;
       const sidecar = await registerRefreshListeners();
-      if (sidecar) {
-        sidecars.push(sidecar);
+      if (!sidecar) {
+        // Minimal test gateways register no listeners and self-heal via refreshOnRead; an
+        // awaited startup refresh would force the full prepared-model-runtime build the
+        // minimal path exists to avoid, stalling startup past test hook budgets.
+        return;
       }
+      sidecars.push(sidecar);
       // Auth/model snapshots published before listener registration are otherwise never
       // observed; one awaited catch-up refresh reconciles facts (revision-aware, no-op when
       // fresh) so post-attach reads cannot serve a pre-publication generation. Failures are


### PR DESCRIPTION
## What Problem This Solves

#120926 broke the `checks-ui-e2e` lane on `main`: every ui-e2e suite that starts a minimal test gateway (`OPENCLAW_TEST_MINIMAL_GATEWAY=1`) hangs in `startGatewayServer` until the 120s hook timeout. The lane only runs on ui-touching PRs (changed-scope gating), so #120926 landed green and the breakage first surfaced on unrelated UI PRs (e.g. #120960, four consecutive red runs plus a fresh-run repro).

Bisect proof (clean-room isolated HOME/state, `ui/src/e2e/mcp-app-conformance.e2e.test.ts`):
- `bb799aec0fd` (parent) exit 0
- `3bfe82180e1` (#120926) exit 124 (timeout)

## Why This Change Was Made

#120926 added an awaited catch-up refresh in `createGatewayChatMetadataLifecycle.attachContext` so auth/model snapshots published before listener registration are still observed. That refresh is correct for full gateways, but it ran for minimal test gateways too. On the minimal path `beforeRefresh` calls `refreshPreparedModelRuntimeSnapshots(...)`, which forces the full prepared-model-runtime build (plugins + catalog materialization) during startup — exactly the work the minimal gateway path exists to avoid (`src/gateway/CLAUDE.md`). File-instrumented tracing pinned the stall inside `buildSnapshotBatch` via `startSerializedSnapshotBuildBatch`, entered from the startup-awaited refresh; startup trace stops after `gateway.handlers`.

Minimal gateways register no refresh listeners (`registerRefreshListeners` returns `undefined`), so there is no listener-registration race for a catch-up refresh to close, and `refreshOnRead: true` already self-heals reads. The fix skips the awaited startup refresh exactly when no listener sidecar was registered. Full-gateway behavior (the actual #120926 fix for stale "No models available" metadata) is unchanged.

## User Impact

- `main` ui-e2e lane is green again; UI PRs are no longer blocked by unrelated 120s hook timeouts.
- No production behavior change: the skipped refresh only ever ran under `OPENCLAW_TEST_MINIMAL_GATEWAY=1`.

## Evidence

- Repro before fix (this checkout, `main`): `HOME=<iso> OPENCLAW_STATE_DIR=<iso>/state node scripts/run-vitest.mjs --config test/vitest/vitest.ui-e2e.config.ts ui/src/e2e/mcp-app-conformance.e2e.test.ts` → exit 124 (killed at 150s, gateway startup never completes).
- Same command with fix → passes in 36s (matches parent-commit behavior).
- New regression test `src/gateway/server-chat-metadata-lifecycle.test.ts`: minimal-gateway `attachContext` resolves without invoking `refreshPreparedModelRuntimeSnapshots` (never-resolving mock would hang otherwise) — passes.
- `src/gateway/server-methods/chat-metadata-runtime.test.ts` (19 tests, includes #120926's additions) — passes.
- Autoreview (Codex gpt-5.6-sol, xhigh): clean, "patch is correct (0.94)".

Production LOC delta: +6/-2 in `server-chat-metadata-lifecycle.ts` (guard + comment); tests +34.
