### PR TITLE
refactor(acpx): complete lease ownership and remove legacy reaper heuristics

### DIFF
--- a/docs/refactor/acp.md
+++ b/docs/refactor/acp.md
@@ -1,5 +1,5 @@
 ---
-summary: "Migration plan for making ACP session and ACPX process ownership explicit"
+summary: "Current ACP session ownership and ACPX process-lease migration status"
 read_when:
   - Refactoring ACP session lifecycle or ACPX process cleanup
   - Debugging ACPX orphan processes, PID reuse, or multi-gateway cleanup safety
@@ -9,91 +9,33 @@ title: "ACP lifecycle refactor"
 sidebarTitle: "ACP lifecycle refactor"
 ---
 
-ACP lifecycle currently works, but too much of it is inferred after the fact.
-Process cleanup reconstructs ownership from PIDs, command strings, wrapper
-paths, and the live process table. Session visibility reconstructs ownership
-from session-key strings plus secondary `sessions.list({ spawnedBy })` lookups.
-That makes narrow fixes possible, but it also makes edge cases easy to miss:
-PID reuse, quoted commands, adapter grandchildren, multi-gateway state roots,
-`cancel` versus `close`, and `tree` versus `all` visibility all become separate
-places to rediscover the same ownership rules.
+ACP session ownership is now explicit in session rows, and generated ACPX
+wrapper launches are lease-backed. The remaining process-cleanup heuristics are
+not the target design: they are temporary coverage for launch paths that the
+published `acpx` runtime does not yet expose to OpenClaw.
 
-This refactor makes ownership first-class. The goal is not a new ACP product
-surface; it is a safer internal contract for the existing ACP and ACPX behavior.
+This page records the current boundary and the work that remains. It is not a
+proposal for a second lifecycle controller.
 
-## Goals
+## Invariants
 
-- Cleanup never signals a process unless current live evidence matches an
-  OpenClaw-owned lease.
-- `cancel`, `close`, and startup reaping have distinct lifecycle intents.
-- `sessions_list`, `sessions_history`, `sessions_send`, and status checks use
-  the same requester-owned session model.
-- Multi-gateway installs cannot reap each other's ACPX wrappers.
-- Old ACPX session records keep working during migration.
-- The runtime remains plugin-owned; core does not learn ACPX package details.
+- Lease-based cleanup signals a process only after current live evidence matches
+  the lease id, Gateway instance id, and expected wrapper path.
+- `cancel` stops the active turn without closing a reusable ACP session.
+- `close` owns terminal session cleanup.
+- Session visibility reads normalized ownership from session rows.
+- Core remains independent of ACPX package and adapter details.
 
-## Non-goals
+## Current ownership model
 
-- Replacing ACPX or changing the public `/acp` command surface.
-- Moving vendor-specific ACP adapter behavior into core.
-- Requiring users to manually clean state before upgrading.
-- Making `cancel` close reusable ACP sessions.
-
-## Target Model
-
-### Gateway Instance Identity
-
-Each Gateway process should have a stable runtime instance id:
-
-```ts
-type GatewayInstanceId = string;
-```
-
-It can be generated on Gateway startup and persisted in state for the life of
-that install. It is not a security secret; it is an ownership discriminator used
-to avoid confusing one Gateway's ACP processes with another Gateway's processes.
-
-### ACP Session Ownership
-
-Every spawned ACP session should have normalized ownership metadata:
-
-```ts
-type AcpSessionOwner = {
-  sessionKey: string;
-  spawnedBy?: string;
-  parentSessionKey?: string;
-  ownerSessionKey: string;
-  agentId: string;
-  backend: "acpx";
-  gatewayInstanceId: GatewayInstanceId;
-  createdAt: number;
-};
-```
-
-The Gateway should return these fields on session rows where they are known.
-Visibility filtering should be a pure check over row metadata:
-
-```ts
-canSeeSessionRow({
-  row,
-  requesterSessionKey,
-  visibility,
-  a2aPolicy,
-});
-```
-
-That removes hidden secondary `sessions.list({ spawnedBy })` calls from
-visibility checks. A spawned cross-agent ACP child is requester-owned because
-the row says so, not because a second query happens to find it.
-
-### ACPX Process Leases
-
-Every generated wrapper launch should create a lease record:
+The ACPX plugin persists a stable Gateway instance id and version 1 process
+leases in plugin SQLite state. The lease shape shipped in `v2026.7.2-beta.7` and
+remains compatible:
 
 ```ts
 type AcpxProcessLease = {
   leaseId: string;
-  gatewayInstanceId: GatewayInstanceId;
+  gatewayInstanceId: string;
   sessionKey: string;
   wrapperRoot: string;
   wrapperPath: string;
@@ -105,193 +47,129 @@ type AcpxProcessLease = {
 };
 ```
 
-The wrapper process receives the lease id and gateway instance id as portable
-arguments:
+Before entering an upstream launch that uses an OpenClaw-generated wrapper, the
+plugin writes a pending lease with `rootPid: 0`. The wrapper command receives
+the lease id and Gateway instance id as arguments:
 
 ```sh
---openclaw-acpx-lease-id ... --openclaw-gateway-instance-id ...
+--openclaw-acpx-lease-id <lease-id> \
+--openclaw-gateway-instance-id <gateway-instance-id>
 ```
 
-When the platform allows it, verification should prefer live process metadata
-that cannot be confused by command quoting:
+The ACPX session-store save promotes the pending lease with the wrapper PID.
+Generated-wrapper availability and doctor probes use the same lease-first
+ordering. Delegate fulfillment does not prove a probe wrapper exited: OpenClaw
+checks the exact live lease identity and reaps a surviving tree, but retains the
+lease even when the wrapper is absent. The wrapper strips lease arguments before
+spawning its detached adapter, so wrapper absence cannot prove reparented
+descendants are gone. The probe lease stays open until stable descendant identity
+can prove the whole tree absent. If delegate entry throws, OpenClaw likewise
+cannot distinguish a pre-spawn failure from a post-spawn failure.
 
-- root PID still exists
-- live wrapper path is under `wrapperRoot`
-- process group matches the lease when available
-- arguments contain the expected lease id
-- command hash or executable path matches the lease
+Direct agent commands are different. Published `acpx` resolves and spawns those
+processes internally and exposes neither a pre-spawn identity hook nor a
+post-spawn ownership callback. OpenClaw does not duplicate that launch policy;
+direct-agent sessions and direct-agent probes therefore remain outside complete
+lease coverage.
 
-If the live process cannot be verified, cleanup fails closed.
+## Startup recovery
 
-## Lifecycle Controller
+Startup first lists open leases owned by the current Gateway instance.
 
-Introduce one ACPX lifecycle controller that owns process leases and cleanup
-policy:
+- A lease with a recorded PID is reaped only when the live root command matches
+  its lease id, Gateway instance id, and wrapper root.
+- A pending `rootPid: 0` wrapper lease is recovered by enumerating live rows and
+  requiring exactly one process with the exact wrapper path, lease id, and
+  Gateway instance id. Foreign or missing matches are not signaled.
+- Ambiguous matches, unavailable process evidence, invalid wrapper paths, and
+  unsupported platforms leave the lease open for a later retry.
+- Missing generated-probe wrappers also leave their lease open because detached
+  descendants do not carry the lease identity.
+- Aggregate marker scanning is separate from lease retirement. Its result never
+  closes or loses a specific lease.
 
-```ts
-interface AcpxLifecycleController {
-  ensureSession(input: AcpRuntimeEnsureInput): Promise<AcpRuntimeHandle>;
-  cancelTurn(handle: AcpRuntimeHandle): Promise<void>;
-  closeSession(input: {
-    handle: AcpRuntimeHandle;
-    discardPersistentState?: boolean;
-    reason?: string;
-  }): Promise<void>;
-  reapStartupOrphans(): Promise<void>;
-  verifyOwnedTree(lease: AcpxProcessLease): Promise<OwnedProcessTree | null>;
-}
-```
+The legacy marker scan remains temporarily for unleased direct-agent processes
+and reparented descendants. It keeps its existing narrow trigger: startup saw a
+pending lease from an uncertain spawn. Lease-aware wrapper roots are excluded
+from that scan and are handled only by exact lease recovery.
 
-`cancelTurn` requests turn cancellation only. It must not reap reusable wrapper
-or adapter processes.
+## Session visibility
 
-`closeSession` is allowed to reap, but only after loading the session record,
-loading the lease, and verifying the live process tree still belongs to that
-lease.
+Session rows carry lineage such as `spawnedBy`, `parentSessionKey`, and
+`ownerSessionKey`. Visibility checks consume those row fields directly for
+`self`, `tree`, `agent`, and `all`; they no longer perform a secondary
+`sessions.list({ spawnedBy })` lookup per row. A requester-owned cross-agent ACP
+child remains visible whenever the configured visibility includes the
+requester's tree, and `all` is not less capable than `tree`.
 
-`reapStartupOrphans` starts from open leases in state. It may use the process
-table to find descendants, but it should not scan arbitrary ACP-looking
-commands first and then decide they are probably ours.
+## Migration status
 
-## Wrapper Contract
+| Phase                          | Status                          | Current result                                                                                                                                                                           |
+| ------------------------------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Identity and leases         | Complete for generated wrappers | Stable Gateway identity, SQLite lease store, lease-first generated session/probe launch, and session-record lease identity are live. Direct upstream spawns are blocked on `acpx` hooks. |
+| 2. Lease-first close cleanup   | Complete                        | Close loads the lease first and verifies current process evidence. Shipped legacy session records retain fail-closed PID/command cleanup.                                                |
+| 3. Lease-first startup reaping | Partial                         | PID and `rootPid: 0` wrapper leases use exact live evidence. Process-group coverage, reparented descendants, direct agents, and Windows reaping remain blocked.                          |
+| 4. Session ownership rows      | Complete                        | Writers persist lineage and visibility reads normalized row metadata without secondary list lookups.                                                                                     |
+| 5. Remove legacy heuristics    | Blocked                         | Visibility fallbacks are gone. Command-marker reaping must remain until the process-ownership blockers below are closed and proven.                                                      |
 
-Generated wrappers should stay small. They should:
+## Remaining blockers
 
-- start the adapter in a process group where supported
-- forward normal termination signals to the process group
-- detect parent death
-- on parent death, send SIGTERM, then keep the wrapper alive until the SIGKILL
-  fallback runs
-- report root PID and process group id back to the lifecycle controller when
-  that is available
+### Upstream launch ownership
 
-Wrappers should not decide session policy. They only enforce local process-tree
-cleanup for their own adapter group.
+`acpx` owns probe, initial session, reconnect, and control-operation process
+creation. OpenClaw needs upstream pre-spawn identity injection plus a post-spawn
+callback that reports the root PID or an equivalent launch primitive. Without
+that contract, locally wrapping direct launches would duplicate `acpx` command
+resolution and platform behavior.
 
-## Session Visibility Contract
+### Stable descendant identity
 
-Visibility should use normalized row ownership:
+Generated wrappers create a detached adapter process group on Unix, but the
+group id is not reported back into the lease. The reaper currently discovers
+descendants from PPID rows, so a reparented grandchild can escape the recorded
+tree. Removing its marker fallback requires upstream or wrapper-owned reporting
+of a stable process-group identity and reaper support that verifies that identity
+against the lease.
 
-```ts
-type SessionVisibilityInput = {
-  requesterSessionKey: string;
-  row: {
-    key: string;
-    agentId: string;
-    ownerSessionKey?: string;
-    spawnedBy?: string;
-    parentSessionKey?: string;
-  };
-  visibility: "self" | "tree" | "agent" | "all";
-  a2aPolicy: AgentToAgentPolicy;
-};
-```
+### Windows cleanup
 
-Rules:
+The ACPX reaper does not yet enumerate and terminate Windows process trees with
+the same live command-line evidence used on Unix. Windows cleanup therefore
+fails closed and leaves leases open. Marker removal requires a tested Windows
+process-list and tree-termination implementation, not a platform skip.
 
-- `self`: only the requester session.
-- `tree`: requester session plus rows owned by or spawned from the requester.
-- `all`: all same-agent rows, a2a-allowed cross-agent rows, and requester-owned
-  spawned cross-agent rows even when general a2a is disabled.
-- `agent`: same agent only, unless an explicit owner relationship says the row
-  belongs to the requester.
+## Compatibility
 
-This makes `tree` and `all` monotonic: `all` must not hide an owned child that
-`tree` would show.
-
-## Migration Plan
-
-### Phase 1: Add Identity And Leases
-
-- Add `gatewayInstanceId` to Gateway state.
-- Add an ACPX lease store under the ACPX state directory.
-- Write a lease before spawning a generated wrapper.
-- Store `leaseId` on new ACPX session records.
-- Keep existing PID and command fields for old records.
-
-### Phase 2: Lease-First Cleanup
-
-- Change close cleanup to load `leaseId` first.
-- Verify live process ownership against the lease before signaling.
-- Keep the current root PID and wrapper-root fallback only for legacy records.
-- Mark leases `closed` after verified cleanup.
-- Mark leases `lost` when the process is gone before cleanup.
-
-### Phase 3: Lease-First Startup Reaping
-
-- Startup reaping scans open leases.
-- For each lease, verify the root process and collect descendants.
-- Reap verified trees children-first.
-- Expire old `closed` and `lost` leases with a bounded retention window.
-- Keep command-marker scanning only as a temporary legacy fallback, guarded by
-  wrapper root and Gateway instance where possible.
-
-### Phase 4: Session Ownership Rows
-
-- Add ownership metadata to Gateway session rows.
-- Teach ACPX, subagent, background-task, and session-store writers to populate
-  `ownerSessionKey` or `spawnedBy`.
-- Convert session visibility checks to use row metadata.
-- Remove visibility-time secondary `sessions.list({ spawnedBy })` lookups.
-
-### Phase 5: Remove Legacy Heuristics
-
-After one release window:
-
-- stop relying on stored root command strings for non-legacy ACPX cleanup
-- remove command-marker startup scans
-- remove visibility fallback list lookups
-- keep defensive fail-closed behavior for missing or unverifiable leases
-
-## Tests
-
-Add two table-driven suites.
-
-Process lifecycle simulator:
-
-- PID reused by unrelated process
-- PID reused by another Gateway's wrapper root
-- stored wrapper command is shell-quoted, live `ps` command is not
-- adapter child exits, grandchild remains in the process group
-- parent death SIGTERM fallback reaches SIGKILL
-- process listing unavailable
-- stale lease with missing process
-- startup orphan with wrapper, adapter child, and grandchild
-
-Session visibility matrix:
-
-- `self`, `tree`, `agent`, `all`
-- a2a enabled and disabled
-- same-agent row
-- cross-agent row
-- requester-owned spawned cross-agent ACP row
-- sandboxed requester clamped to `tree`
-- list, history, send, and status actions
-
-The important invariant: a requester-owned spawned child is visible wherever
-the configured visibility includes the requester session tree, and `all` is not
-less capable than `tree`.
-
-## Compatibility Notes
-
-Old session records may not have `leaseId`. They should use the legacy
-fail-closed cleanup path:
+The lease schema is unchanged from the latest shipped release, so no doctor
+migration is required for this work. Old session records without `leaseId` keep
+the legacy fail-closed cleanup path:
 
 - require a live root process
-- require wrapper-root ownership when a generated wrapper is expected
-- require command agreement for non-wrapper roots
-- never signal based only on stale stored PID metadata
+- require wrapper-root ownership for generated wrappers
+- require stored/live command agreement for non-wrapper roots
+- never signal from stale PID metadata alone
 
-If a legacy record cannot be verified, leave it alone. Startup lease cleanup and
-the next release window should eventually retire the fallback.
+If a legacy record cannot be verified, cleanup leaves it alone.
 
-## Success Criteria
+## Proof expectations
 
-- Closing an old or stale ACPX session cannot kill another Gateway's process.
-- Parent death does not leave stubborn adapter grandchildren running.
-- `cancel` aborts the active turn without closing reusable sessions.
-- `sessions_list` can show requester-owned cross-agent ACP children under both
-  `tree` and `all`.
-- Startup cleanup is driven by leases, not broad command-string scans.
-- The focused process and visibility matrix tests cover every edge case that
-  previously required one-off review fixes.
+Process lifecycle coverage must include:
+
+- generated probe lease persistence before upstream entry
+- completed probe exact-wrapper inspection and conservative lease retention
+- PID reuse by an unrelated process or another Gateway instance
+- exact `rootPid: 0` own-versus-foreign recovery
+- ambiguous, unavailable, and Windows evidence failing closed
+- adapter children reaped in child-first order
+- a reparented descendant test before claiming marker removal
+
+Session visibility coverage must retain the `self`, `tree`, `agent`, and `all`
+matrix across same-agent, cross-agent, a2a-disabled, and requester-owned spawned
+rows.
+
+## Completion criteria
+
+The refactor is complete only when upstream launch hooks cover every direct
+spawn, leases carry stable process-tree identity across reparenting, Windows has
+equivalent verified cleanup, and the marker scan plus its package/path literals
+can be deleted without reducing orphan cleanup coverage.

--- a/extensions/acpx/src/process-lease.test.ts
+++ b/extensions/acpx/src/process-lease.test.ts
@@ -16,6 +16,7 @@ import {
   withAcpxLeaseEnvironment,
   type AcpxProcessLease,
 } from "./process-lease.js";
+import { ACPX_PROCESS_LEASE_MAX_ENTRIES } from "./state.js";
 
 function makeLease(index: number): AcpxProcessLease {
   return {
@@ -74,6 +75,23 @@ describe("createAcpxProcessLeaseStore", () => {
 
     await expect(store.load(closedLease.leaseId)).resolves.toBeUndefined();
     await expect(store.listOpen("gateway-test")).resolves.toEqual([openLease]);
+  });
+
+  it("rejects capacity overflow without evicting existing process ownership", async () => {
+    const store = createStore();
+    await Promise.all(
+      Array.from({ length: ACPX_PROCESS_LEASE_MAX_ENTRIES }, (_, index) =>
+        store.save(makeLease(index)),
+      ),
+    );
+
+    await expect(store.save(makeLease(ACPX_PROCESS_LEASE_MAX_ENTRIES))).rejects.toMatchObject({
+      code: "PLUGIN_STATE_LIMIT_EXCEEDED",
+    });
+    await expect(store.load("lease-0")).resolves.toEqual(makeLease(0));
+    await expect(store.listOpen("gateway-test")).resolves.toHaveLength(
+      ACPX_PROCESS_LEASE_MAX_ENTRIES,
+    );
   });
 });
 

--- a/extensions/acpx/src/process-lease.ts
+++ b/extensions/acpx/src/process-lease.ts
@@ -14,6 +14,8 @@ import { ACPX_PROCESS_LEASE_MAX_ENTRIES, ACPX_PROCESS_LEASE_NAMESPACE } from "./
 export const OPENCLAW_ACPX_LEASE_ID_ARG = "--openclaw-acpx-lease-id";
 /** CLI argument carrying the owning gateway instance id. */
 export const OPENCLAW_GATEWAY_INSTANCE_ID_ARG = "--openclaw-gateway-instance-id";
+/** Synthetic session identity for generated-wrapper health probes. */
+export const ACPX_PROBE_LEASE_SESSION_KEY = "openclaw:acpx:probe";
 
 export type AcpxProcessLeaseIdentity = {
   leaseId: string;

--- a/extensions/acpx/src/process-lease.ts
+++ b/extensions/acpx/src/process-lease.ts
@@ -116,6 +116,7 @@ export function openAcpxProcessLeaseStateStore(
   return openKeyedStore<AcpxProcessLease>({
     namespace: ACPX_PROCESS_LEASE_NAMESPACE,
     maxEntries: ACPX_PROCESS_LEASE_MAX_ENTRIES,
+    overflowPolicy: "reject-new",
   });
 }
 

--- a/extensions/acpx/src/process-reaper.test.ts
+++ b/extensions/acpx/src/process-reaper.test.ts
@@ -11,6 +11,7 @@ vi.mock("openclaw/plugin-sdk/process-runtime", async (importOriginal) => ({
 }));
 
 import {
+  cleanupOpenClawOwnedAcpxPendingLease,
   cleanupOpenClawOwnedAcpxProcessTree,
   isOpenClawLeaseAwareAcpxProcessCommand,
   reapStaleOpenClawOwnedAcpxOrphans,
@@ -194,6 +195,118 @@ describe("process reaper", () => {
     expect(killed).toStrictEqual([]);
   });
 
+  it("recovers a pending lease only from its exact wrapper and gateway identity", async () => {
+    const { deps, killed } = cleanupDeps([
+      { pid: 120, ppid: 1, command: CODEX_WRAPPER_COMMAND_WITH_LEASE },
+      {
+        pid: 121,
+        ppid: 1,
+        command: `${CODEX_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-1 ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-foreign`,
+      },
+      { pid: 122, ppid: 120, command: "node adapter-child.js" },
+    ]);
+
+    const result = await cleanupOpenClawOwnedAcpxPendingLease({
+      leaseId: "lease-1",
+      gatewayInstanceId: "gateway-1",
+      wrapperRoot: WRAPPER_ROOT,
+      wrapperPath: `${WRAPPER_ROOT}/codex-acp-wrapper.mjs`,
+      deps,
+    });
+
+    expect(result).toMatchObject({ inspectedPids: [120, 122] });
+    expect(killed.slice(0, 2)).toEqual([
+      { pid: 122, signal: "SIGTERM" },
+      { pid: 120, signal: "SIGTERM" },
+    ]);
+    expect(killed.some((entry) => entry.pid === 121)).toBe(false);
+  });
+
+  it("fails closed when pending lease evidence is ambiguous or unavailable", async () => {
+    const duplicateCommand = CODEX_WRAPPER_COMMAND_WITH_LEASE;
+    const { deps, killed } = cleanupDeps([
+      { pid: 130, ppid: 1, command: duplicateCommand },
+      { pid: 131, ppid: 1, command: duplicateCommand },
+    ]);
+
+    await expect(
+      cleanupOpenClawOwnedAcpxPendingLease({
+        leaseId: "lease-1",
+        gatewayInstanceId: "gateway-1",
+        wrapperRoot: WRAPPER_ROOT,
+        wrapperPath: `${WRAPPER_ROOT}/codex-acp-wrapper.mjs`,
+        deps,
+      }),
+    ).resolves.toEqual({
+      inspectedPids: [130, 131],
+      terminatedPids: [],
+      skippedReason: "ambiguous-root",
+    });
+    expect(killed).toEqual([]);
+
+    await expect(
+      cleanupOpenClawOwnedAcpxPendingLease({
+        leaseId: "lease-1",
+        gatewayInstanceId: "gateway-1",
+        wrapperRoot: WRAPPER_ROOT,
+        wrapperPath: `${WRAPPER_ROOT}/codex-acp-wrapper.mjs`,
+        deps: {
+          listProcesses: vi.fn(async () => {
+            throw new Error("ps unavailable");
+          }),
+        },
+      }),
+    ).resolves.toMatchObject({ skippedReason: "process-list-unavailable" });
+  });
+
+  it("does not claim a pending wrapper leased by another gateway", async () => {
+    const { deps, killed } = cleanupDeps([
+      {
+        pid: 135,
+        ppid: 1,
+        command: `${CODEX_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-1 ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-foreign`,
+      },
+    ]);
+
+    await expect(
+      cleanupOpenClawOwnedAcpxPendingLease({
+        leaseId: "lease-1",
+        gatewayInstanceId: "gateway-1",
+        wrapperRoot: WRAPPER_ROOT,
+        wrapperPath: `${WRAPPER_ROOT}/codex-acp-wrapper.mjs`,
+        deps,
+      }),
+    ).resolves.toEqual({
+      inspectedPids: [],
+      terminatedPids: [],
+      skippedReason: "missing-root",
+    });
+    expect(killed).toEqual([]);
+  });
+
+  it("keeps pending leases untouched when process evidence is unsupported", async () => {
+    const listProcesses = vi.fn(async () => [
+      { pid: 140, ppid: 1, command: CODEX_WRAPPER_COMMAND_WITH_LEASE },
+    ]);
+    const killProcess = vi.fn();
+
+    await expect(
+      cleanupOpenClawOwnedAcpxPendingLease({
+        leaseId: "lease-1",
+        gatewayInstanceId: "gateway-1",
+        wrapperRoot: WRAPPER_ROOT,
+        wrapperPath: `${WRAPPER_ROOT}/codex-acp-wrapper.mjs`,
+        deps: { platform: "win32", listProcesses, killProcess },
+      }),
+    ).resolves.toEqual({
+      inspectedPids: [],
+      terminatedPids: [],
+      skippedReason: "unsupported-platform",
+    });
+    expect(listProcesses).not.toHaveBeenCalled();
+    expect(killProcess).not.toHaveBeenCalled();
+  });
+
   it("skips recorded pid cleanup when process listing is unavailable", async () => {
     const killed: Array<{ pid: number; signal: NodeJS.Signals }> = [];
     const result = await cleanupOpenClawOwnedAcpxProcessTree({
@@ -284,6 +397,7 @@ describe("process reaper", () => {
       { pid: 404, ppid: 403, command: "node claude-child.js" },
       { pid: 405, ppid: 1, command: PLUGIN_DEPS_CODEX_COMMAND },
       { pid: 406, ppid: 1, command: "node /tmp/other/codex-acp-wrapper.mjs" },
+      { pid: 407, ppid: 1, command: CODEX_WRAPPER_COMMAND_WITH_LEASE },
     ]);
 
     const result = await reapStaleOpenClawOwnedAcpxOrphans({

--- a/extensions/acpx/src/process-reaper.ts
+++ b/extensions/acpx/src/process-reaper.ts
@@ -8,7 +8,11 @@ import { runExec } from "openclaw/plugin-sdk/process-runtime";
 import { CODEX_ACP_PACKAGE, LEGACY_CODEX_ACP_PACKAGE } from "./codex-adapter.js";
 import { splitCommandParts } from "./command-line.js";
 import { resolveAcpxPluginRoot } from "./config.js";
-import { OPENCLAW_ACPX_LEASE_ID_ARG, OPENCLAW_GATEWAY_INSTANCE_ID_ARG } from "./process-lease.js";
+import {
+  OPENCLAW_ACPX_LEASE_ID_ARG,
+  OPENCLAW_GATEWAY_INSTANCE_ID_ARG,
+  readAcpxProcessLeaseIdentity,
+} from "./process-lease.js";
 
 const requireFromHere = createRequire(import.meta.url);
 const GENERATED_WRAPPER_BASENAMES = new Set([
@@ -59,6 +63,7 @@ type AcpxProcessInfo = {
 export type AcpxProcessCleanupDeps = {
   listProcesses?: () => Promise<AcpxProcessInfo[]>;
   killProcess?: (pid: number, signal: NodeJS.Signals) => void;
+  platform?: NodeJS.Platform;
   sleep?: (ms: number) => Promise<void>;
 };
 
@@ -68,8 +73,10 @@ type AcpxProcessCleanupResult = {
   terminatedPids: number[];
   skippedReason?:
     | "missing-root"
+    | "ambiguous-root"
     | "not-openclaw-owned"
     | "process-list-unavailable"
+    | "unsupported-platform"
     | "unverified-root";
 };
 
@@ -133,6 +140,20 @@ function commandWrapperBelongsToRoot(command: string, wrapperRoot: string | unde
   const normalizedRoot = normalizePathLike(wrapperRoot).replace(/\/+$/, "");
   return Array.from(GENERATED_WRAPPER_BASENAMES).some((basename) =>
     normalizedCommand.includes(`${normalizedRoot}/${basename}`),
+  );
+}
+
+function commandContainsExactWrapperPath(command: string, wrapperPath: string): boolean {
+  const expectedPath = normalizePathLike(wrapperPath);
+  return splitCommandParts(command).some((part) => normalizePathLike(part) === expectedPath);
+}
+
+function wrapperPathBelongsToRoot(wrapperPath: string, wrapperRoot: string): boolean {
+  const normalizedPath = normalizePathLike(wrapperPath);
+  const normalizedRoot = normalizePathLike(wrapperRoot).replace(/\/+$/, "");
+  return (
+    GENERATED_WRAPPER_BASENAMES.has(path.posix.basename(normalizedPath)) &&
+    normalizedPath.startsWith(`${normalizedRoot}/`)
   );
 }
 
@@ -342,6 +363,9 @@ export async function cleanupOpenClawOwnedAcpxProcessTree(params: {
   if (!rootPid || rootPid <= 0 || rootPid === process.pid) {
     return { inspectedPids: [], terminatedPids: [], skippedReason: "missing-root" };
   }
+  if ((params.deps?.platform ?? process.platform) === "win32") {
+    return { inspectedPids: [], terminatedPids: [], skippedReason: "unsupported-platform" };
+  }
 
   let processes: AcpxProcessInfo[];
   try {
@@ -418,12 +442,66 @@ export async function cleanupOpenClawOwnedAcpxProcessTree(params: {
   };
 }
 
+/** Recover a pending lease by matching its exact live wrapper identity. */
+export async function cleanupOpenClawOwnedAcpxPendingLease(params: {
+  leaseId: string;
+  gatewayInstanceId: string;
+  wrapperRoot: string;
+  wrapperPath: string;
+  deps?: AcpxProcessCleanupDeps;
+}): Promise<AcpxProcessCleanupResult> {
+  if ((params.deps?.platform ?? process.platform) === "win32") {
+    return { inspectedPids: [], terminatedPids: [], skippedReason: "unsupported-platform" };
+  }
+  if (!params.wrapperPath || !wrapperPathBelongsToRoot(params.wrapperPath, params.wrapperRoot)) {
+    return { inspectedPids: [], terminatedPids: [], skippedReason: "unverified-root" };
+  }
+
+  let processes: AcpxProcessInfo[];
+  try {
+    processes = await (params.deps?.listProcesses ?? listPlatformProcesses)();
+  } catch {
+    return {
+      inspectedPids: [],
+      terminatedPids: [],
+      skippedReason: "process-list-unavailable",
+    };
+  }
+
+  const matchingRoots = processes.filter(
+    (processInfo) =>
+      commandContainsExactWrapperPath(processInfo.command, params.wrapperPath) &&
+      liveCommandMatchesLeaseIdentity({
+        command: processInfo.command,
+        expectedLeaseId: params.leaseId,
+        expectedGatewayInstanceId: params.gatewayInstanceId,
+      }),
+  );
+  if (matchingRoots.length === 0) {
+    return { inspectedPids: [], terminatedPids: [], skippedReason: "missing-root" };
+  }
+  if (matchingRoots.length > 1) {
+    return {
+      inspectedPids: uniquePids(matchingRoots),
+      terminatedPids: [],
+      skippedReason: "ambiguous-root",
+    };
+  }
+
+  const listedTree = collectProcessTree(processes, matchingRoots[0]!.pid);
+  const pids = uniquePids(listedTree.toReversed());
+  return {
+    inspectedPids: uniquePids(listedTree),
+    terminatedPids: await terminatePids(pids, params.deps),
+  };
+}
+
 /** Reap orphaned OpenClaw-owned ACPX wrapper trees during runtime startup. */
 export async function reapStaleOpenClawOwnedAcpxOrphans(params: {
   wrapperRoot: string;
   deps?: AcpxProcessCleanupDeps;
 }): Promise<AcpxStartupReapResult> {
-  if (process.platform === "win32") {
+  if ((params.deps?.platform ?? process.platform) === "win32") {
     return { inspectedPids: [], terminatedPids: [], skippedReason: "unsupported-platform" };
   }
 
@@ -437,6 +515,10 @@ export async function reapStaleOpenClawOwnedAcpxOrphans(params: {
   const orphans = processes.filter(
     (processInfo) =>
       processInfo.ppid === 1 &&
+      // Lease-aware wrapper roots are recovered one lease at a time. This
+      // temporary marker fallback remains only for direct agents and
+      // reparented descendants that upstream acpx cannot identify yet.
+      !readAcpxProcessLeaseIdentity(processInfo.command) &&
       isOpenClawOwnedAcpxProcessCommand({
         command: processInfo.command,
         wrapperRoot: params.wrapperRoot,

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -48,6 +48,7 @@ function makeRuntime(
     setConfigOption: NonNullable<AcpRuntime["setConfigOption"]>;
     isHealthy(): boolean;
     probeAvailability(): Promise<void>;
+    doctor(): Promise<{ ok: boolean; message: string; details?: string[] }>;
   };
   bridgeSafeDelegate: {
     close: AcpRuntime["close"];
@@ -56,6 +57,7 @@ function makeRuntime(
     setConfigOption: NonNullable<AcpRuntime["setConfigOption"]>;
     isHealthy(): boolean;
     probeAvailability(): Promise<void>;
+    doctor(): Promise<{ ok: boolean; message: string; details?: string[] }>;
   };
 } {
   const runtime = new AcpxRuntime(
@@ -93,6 +95,7 @@ function makeRuntime(
           setConfigOption: NonNullable<AcpRuntime["setConfigOption"]>;
           isHealthy(): boolean;
           probeAvailability(): Promise<void>;
+          doctor(): Promise<{ ok: boolean; message: string; details?: string[] }>;
         };
       }
     ).delegate,
@@ -105,6 +108,7 @@ function makeRuntime(
           setConfigOption: NonNullable<AcpRuntime["setConfigOption"]>;
           isHealthy(): boolean;
           probeAvailability(): Promise<void>;
+          doctor(): Promise<{ ok: boolean; message: string; details?: string[] }>;
         };
       }
     ).bridgeSafeDelegate,
@@ -305,6 +309,179 @@ describe("AcpxRuntime fresh reset wrapper", () => {
 
     expect(safeProbe).toHaveBeenCalledTimes(1);
     expect(defaultProbe).not.toHaveBeenCalled();
+  });
+
+  it("leases generated-wrapper probes before delegate entry and retains absent wrappers", async () => {
+    const events: string[] = [];
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    leaseStore.store.save.mockImplementation(async (lease: Record<string, unknown>) => {
+      events.push("lease-saved");
+      leaseStore.leases.set(String(lease.leaseId), lease);
+    });
+    const { runtime, delegate } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+        agentRegistry: {
+          resolve: (agentName: string) =>
+            agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+          list: () => ["codex"],
+        },
+      },
+      {
+        openclawProcessCleanup: {
+          listProcesses: vi.fn(async () => {
+            events.push("process-inspected");
+            return [];
+          }),
+        },
+      },
+    );
+    let launchedCommand = "";
+    vi.spyOn(delegate, "probeAvailability").mockImplementation(async () => {
+      events.push("probe-entered");
+      launchedCommand = (
+        runtime as unknown as { scopedAgentRegistry: { resolve(agent: string): string } }
+      ).scopedAgentRegistry.resolve("codex");
+    });
+
+    await runtime.probeAvailability();
+
+    expect(events).toEqual(["lease-saved", "probe-entered", "process-inspected"]);
+    expect(launchedCommand).toContain(OPENCLAW_ACPX_LEASE_ID_ARG);
+    expect(launchedCommand).toContain(`${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`);
+    expect(Array.from(leaseStore.leases.values())).toEqual([
+      expect.objectContaining({ rootPid: 0, state: "open" }),
+    ]);
+    expect(leaseStore.store.markState).not.toHaveBeenCalledWith(expect.any(String), "lost");
+  });
+
+  it("reaps a fulfilled probe wrapper that exact live evidence still finds", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    let launchedCommand = "";
+    const killed: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    const { runtime, delegate } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+        agentRegistry: {
+          resolve: (agentName: string) =>
+            agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+          list: () => ["codex"],
+        },
+      },
+      {
+        openclawProcessCleanup: {
+          listProcesses: vi.fn(async () => [
+            { pid: 710, ppid: 1, command: launchedCommand },
+            { pid: 711, ppid: 710, command: "node adapter-child.js" },
+          ]),
+          killProcess: vi.fn((pid, signal) => {
+            killed.push({ pid, signal });
+          }),
+          sleep: vi.fn(async () => {}),
+        },
+      },
+    );
+    vi.spyOn(delegate, "probeAvailability").mockImplementation(async () => {
+      launchedCommand = (
+        runtime as unknown as { scopedAgentRegistry: { resolve(agent: string): string } }
+      ).scopedAgentRegistry.resolve("codex");
+    });
+
+    await runtime.probeAvailability();
+
+    expect(killed.slice(0, 2)).toEqual([
+      { pid: 711, signal: "SIGTERM" },
+      { pid: 710, signal: "SIGTERM" },
+    ]);
+    expect(Array.from(leaseStore.leases.values())).toEqual([
+      expect.objectContaining({ rootPid: 0, state: "open" }),
+    ]);
+  });
+
+  it("retains a fulfilled probe lease when live evidence is unavailable", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+        agentRegistry: {
+          resolve: (agentName: string) =>
+            agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+          list: () => ["codex"],
+        },
+      },
+      {
+        openclawProcessCleanup: {
+          listProcesses: vi.fn(async () => {
+            throw new Error("process evidence unavailable");
+          }),
+        },
+      },
+    );
+    vi.spyOn(delegate, "probeAvailability").mockResolvedValue(undefined);
+
+    await runtime.probeAvailability();
+
+    expect(Array.from(leaseStore.leases.values())).toEqual([
+      expect.objectContaining({ rootPid: 0, state: "open" }),
+    ]);
+  });
+
+  it("leases generated-wrapper doctor probes and keeps uncertain failures open", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+      agentRegistry: {
+        resolve: (agentName: string) =>
+          agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+        list: () => ["codex"],
+      },
+    });
+    vi.spyOn(delegate, "doctor").mockImplementation(async () => {
+      const command = (
+        runtime as unknown as { scopedAgentRegistry: { resolve(agent: string): string } }
+      ).scopedAgentRegistry.resolve("codex");
+      expect(command).toContain(OPENCLAW_ACPX_LEASE_ID_ARG);
+      throw new Error("probe launch state unknown");
+    });
+
+    await expect(runtime.doctor()).rejects.toThrow("probe launch state unknown");
+
+    expect(Array.from(leaseStore.leases.values())).toEqual([
+      expect.objectContaining({
+        gatewayInstanceId: "gateway-test",
+        rootPid: 0,
+        sessionKey: "openclaw:acpx:probe",
+        state: "open",
+      }),
+    ]);
+    expect(leaseStore.store.markState).not.toHaveBeenCalledWith(expect.any(String), "lost");
   });
 
   it("normalizes OpenClaw Codex model ids for ACP startup", async () => {
@@ -2203,7 +2380,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(lease?.rootPid).toBe(888);
   });
 
-  it("removes pending process leases when a fresh launch fails", async () => {
+  it("keeps pending process leases when a fresh launch fails after spawn may have occurred", async () => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => undefined),
       save: vi.fn(async () => {}),
@@ -2229,8 +2406,10 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       }),
     ).rejects.toThrow("launch failed");
 
-    expect(leaseStore.leases.size).toBe(0);
-    expect(leaseStore.store.markState).toHaveBeenCalledWith(expect.any(String), "lost");
+    expect(Array.from(leaseStore.leases.values())).toEqual([
+      expect.objectContaining({ rootPid: 0, state: "open" }),
+    ]);
+    expect(leaseStore.store.markState).not.toHaveBeenCalledWith(expect.any(String), "lost");
   });
 
   it("preserves promoted process leases when session setup later fails", async () => {
@@ -2735,7 +2914,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     });
     releaseControl();
     await control;
-    expect(leaseStore.leases.size).toBe(0);
+    expect(leaseStore.leases.get(leaseId)).toMatchObject({ rootPid: 0, state: "open" });
   });
 
   it("serializes last-owner retirement with the next lease acquisition", async () => {
@@ -2898,7 +3077,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(leaseStore.leases.size).toBe(0);
   });
 
-  it("retires close pending leases when cleanup fails", async () => {
+  it("keeps close pending leases when cleanup fails", async () => {
     const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-close-failure ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({
@@ -2932,7 +3111,10 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       }),
     ).rejects.toThrow("cleanup failed");
 
-    expect(leaseStore.leases.size).toBe(0);
+    expect(leaseStore.leases.get("lease-close-failure")).toMatchObject({
+      rootPid: 0,
+      state: "open",
+    });
   });
 
   it("preserves PID-bearing close leases when cleanup fails", async () => {
@@ -2987,7 +3169,23 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     });
   });
 
-  it("keeps close leases retryable when process listing is unavailable", async () => {
+  it.each([
+    {
+      evidence: "process listing is unavailable",
+      processCleanup: {
+        listProcesses: vi.fn(async () => {
+          throw new Error("process listing unavailable");
+        }),
+      },
+    },
+    {
+      evidence: "Windows process evidence is unsupported",
+      processCleanup: {
+        platform: "win32" as const,
+        listProcesses: vi.fn(async () => []),
+      },
+    },
+  ])("keeps close leases retryable when $evidence", async ({ processCleanup }) => {
     const leasedCommand = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-close-process-list ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({
@@ -3018,9 +3216,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       },
       {
         openclawProcessCleanup: {
-          listProcesses: vi.fn(async () => {
-            throw new Error("process listing unavailable");
-          }),
+          ...processCleanup,
           sleep: vi.fn(async () => {}),
         },
       },
@@ -3040,6 +3236,9 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       rootPid: 777,
       state: "open",
     });
+    if ("platform" in processCleanup && processCleanup.platform === "win32") {
+      expect(processCleanup.listProcesses).not.toHaveBeenCalled();
+    }
   });
 
   it("merges sidecar lease ids into loaded ACPX session records", async () => {

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -12,8 +12,13 @@ import {
   type AcpRuntimeTurn,
 } from "../runtime-api.js";
 import { OPENCLAW_CODEX_CONFIG_ARG } from "./codex-adapter.js";
-import { OPENCLAW_ACPX_LEASE_ID_ARG, OPENCLAW_GATEWAY_INSTANCE_ID_ARG } from "./process-lease.js";
+import {
+  OPENCLAW_ACPX_LEASE_ID_ARG,
+  OPENCLAW_GATEWAY_INSTANCE_ID_ARG,
+  readAcpxProcessLeaseIdentity,
+} from "./process-lease.js";
 import { AcpxRuntime, testing, type AcpSessionStore } from "./runtime.js";
+import { ACPX_PROCESS_LEASE_MAX_ENTRIES } from "./state.js";
 
 type TestSessionStore = {
   load(sessionId: string): Promise<Record<string, unknown> | undefined>;
@@ -445,6 +450,101 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(Array.from(leaseStore.leases.values())).toEqual([
       expect.objectContaining({ rootPid: 0, state: "open" }),
     ]);
+  });
+
+  it("coalesces repeated probe uncertainty before it can evict a live lease", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    leaseStore.leases.set("lease-live", {
+      leaseId: "lease-live",
+      gatewayInstanceId: "gateway-test",
+      sessionKey: "agent:codex:acp:live",
+      wrapperRoot: "/tmp/openclaw/acpx",
+      wrapperPath: "/tmp/openclaw/acpx/codex-acp-wrapper.mjs",
+      rootPid: 700,
+      commandHash: "hash-live",
+      startedAt: 1,
+      state: "open",
+    });
+    leaseStore.store.save.mockImplementation(async (lease: Record<string, unknown>) => {
+      const leaseId = String(lease.leaseId);
+      leaseStore.leases.delete(leaseId);
+      leaseStore.leases.set(leaseId, lease);
+      if (leaseStore.leases.size > ACPX_PROCESS_LEASE_MAX_ENTRIES) {
+        const oldestLeaseId = leaseStore.leases.keys().next().value;
+        if (oldestLeaseId) {
+          leaseStore.leases.delete(oldestLeaseId);
+        }
+      }
+    });
+    const { runtime, delegate } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+        agentRegistry: {
+          resolve: (agentName: string) =>
+            agentName === "codex" ? CODEX_ACP_WRAPPER_COMMAND : agentName,
+          list: () => ["codex"],
+        },
+      },
+      {
+        openclawProcessCleanup: {
+          listProcesses: vi.fn(async () => []),
+        },
+      },
+    );
+    const probeLeaseIds = new Set<string>();
+    vi.spyOn(delegate, "probeAvailability").mockImplementation(async () => {
+      const command = (
+        runtime as unknown as { scopedAgentRegistry: { resolve(agent: string): string } }
+      ).scopedAgentRegistry.resolve("codex");
+      const identity = readAcpxProcessLeaseIdentity(command);
+      expect(identity).toBeDefined();
+      probeLeaseIds.add(String(identity?.leaseId));
+    });
+
+    for (let index = 0; index <= ACPX_PROCESS_LEASE_MAX_ENTRIES; index += 1) {
+      await runtime.probeAvailability();
+    }
+
+    const { runtime: updatedRuntime, delegate: updatedDelegate } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+        agentRegistry: {
+          resolve: (agentName: string) =>
+            agentName === "codex" ? `${CODEX_ACP_WRAPPER_COMMAND} --updated` : agentName,
+          list: () => ["codex"],
+        },
+      },
+      {
+        openclawProcessCleanup: {
+          listProcesses: vi.fn(async () => []),
+        },
+      },
+    );
+    vi.spyOn(updatedDelegate, "probeAvailability").mockImplementation(async () => {
+      const command = (
+        updatedRuntime as unknown as {
+          scopedAgentRegistry: { resolve(agent: string): string };
+        }
+      ).scopedAgentRegistry.resolve("codex");
+      const identity = readAcpxProcessLeaseIdentity(command);
+      expect(identity).toBeDefined();
+      probeLeaseIds.add(String(identity?.leaseId));
+    });
+    await updatedRuntime.probeAvailability();
+
+    expect(leaseStore.leases.has("lease-live")).toBe(true);
+    expect(leaseStore.leases.size).toBe(2);
+    expect(probeLeaseIds.size).toBe(1);
   });
 
   it("leases generated-wrapper doctor probes and keeps uncertain failures open", async () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -1034,7 +1034,15 @@ export class AcpxRuntime implements AcpRuntime {
     const processLeaseStore = this.processLeaseStore;
     const reusableIdentity = readAcpxProcessLeaseIdentity(params.reusableCommand);
     const canReuseLeaseIdentity = reusableIdentity?.gatewayInstanceId === this.gatewayInstanceId;
-    const leaseId = canReuseLeaseIdentity ? reusableIdentity.leaseId : createAcpxProcessLeaseId();
+    // Repeated probes share one uncertainty row per Gateway and wrapper. Unique probe rows could
+    // otherwise evict live session ownership from the bounded lease namespace.
+    const leaseId = canReuseLeaseIdentity
+      ? reusableIdentity.leaseId
+      : params.finalizeCompletedProbe
+        ? `probe-${hashAcpxProcessCommand(
+            `${this.gatewayInstanceId}\0${extractGeneratedWrapperPath(params.command)}`,
+          )}`
+        : createAcpxProcessLeaseId();
     const leasedCommand = withAcpxLeaseEnvironment({
       command: params.command,
       leaseId,

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -32,6 +32,7 @@ import { AcpRuntimeError, type AcpRuntime, type AcpRuntimeErrorCode } from "../r
 import { CODEX_ACP_PACKAGE, OPENCLAW_CODEX_CONFIG_ARG } from "./codex-adapter.js";
 import { splitCommandParts } from "./command-line.js";
 import {
+  ACPX_PROBE_LEASE_SESSION_KEY,
   createAcpxProcessLeaseId,
   hashAcpxProcessCommand,
   readAcpxProcessLeaseIdentity,
@@ -41,6 +42,7 @@ import {
   type AcpxProcessLeaseStore,
 } from "./process-lease.js";
 import {
+  cleanupOpenClawOwnedAcpxPendingLease,
   cleanupOpenClawOwnedAcpxProcessTree,
   isOpenClawLeaseAwareAcpxProcessCommand,
   type AcpxProcessCleanupDeps,
@@ -69,7 +71,6 @@ type AcpxMcpServer = NonNullable<AcpRuntimeOptions["mcpServers"]>[number];
 const ACPX_PLUGIN_TOOLS_MCP_SERVER_NAME = "openclaw-plugin-tools";
 const ACPX_OPENCLAW_TOOLS_MCP_SERVER_NAME = "openclaw-tools";
 const OPENCLAW_TOOLS_MCP_AGENT_SESSION_KEY_ENV = "OPENCLAW_TOOLS_MCP_AGENT_SESSION_KEY";
-
 type ResetAwareSessionStore = AcpSessionStore & {
   markFresh: (sessionKey: string) => void;
 };
@@ -795,6 +796,7 @@ export class AcpxRuntime implements AcpRuntime {
   private readonly delegate: BaseAcpxRuntime;
   private readonly bridgeSafeDelegate: BaseAcpxRuntime;
   private readonly probeDelegate: BaseAcpxRuntime;
+  private readonly probeCommand: string | undefined;
   private readonly delegateOptions: AcpRuntimeOptions;
   private readonly delegateTestOptions: BaseAcpxRuntimeTestOptions;
   private readonly pluginToolsMcpBridgeEnabled: boolean;
@@ -809,6 +811,7 @@ export class AcpxRuntime implements AcpRuntime {
   private readonly ensureSessionTails = new Map<string, Promise<void>>();
   private readonly processLeaseTransitionTails = new Map<string, Promise<void>>();
   private readonly processLeaseOperationCounts = new Map<string, number>();
+  private readonly uncertainProcessLeaseIds = new Set<string>();
   private readonly cwd: string;
 
   constructor(options: OpenClawAcpxRuntimeOptions, testOptions?: AcpxRuntimeTestOptions) {
@@ -855,6 +858,7 @@ export class AcpxRuntime implements AcpRuntime {
       agentName: normalizeAgentName(options.probeAgent) ?? "codex",
       agentRegistry: this.agentRegistry,
     });
+    this.probeCommand = probeCommand;
     const useBridgeSafeProbe =
       this.managedToolsMcpBridgeEnabled || shouldUseBridgeSafeDelegateForCommand(probeCommand);
     this.probeDelegate = useBridgeSafeProbe ? this.bridgeSafeDelegate : this.delegate;
@@ -1012,6 +1016,7 @@ export class AcpxRuntime implements AcpRuntime {
     sessionKey: string;
     command: string | undefined;
     reusableCommand?: string;
+    finalizeCompletedProbe?: boolean;
     run: () => Promise<T>;
   }): Promise<T> {
     if (
@@ -1068,7 +1073,7 @@ export class AcpxRuntime implements AcpRuntime {
         return;
       }
       // The pending lease is written before acpx can spawn. The session-store
-      // save fills in the PID, or the last owner deletes it on launch failure.
+      // save fills in the PID; uncertain launch failures leave it for recovery.
       await processLeaseStore.save({
         leaseId: launch.leaseId,
         gatewayInstanceId: launch.gatewayInstanceId,
@@ -1083,10 +1088,14 @@ export class AcpxRuntime implements AcpRuntime {
     });
     try {
       const result = await this.launchLeaseScope.run(launch, params.run);
-      await this.finalizeProcessLeaseForSession(params.sessionKey, launch);
+      if (params.finalizeCompletedProbe) {
+        await this.finalizeCompletedProbeLease(launch);
+      } else {
+        await this.finalizeProcessLeaseForSession(params.sessionKey, launch);
+      }
       return result;
     } catch (error) {
-      await this.retirePendingProcessLease(launch);
+      await this.releaseProcessLeaseAfterUncertainFailure(launch);
       throw error;
     }
   }
@@ -1232,9 +1241,13 @@ export class AcpxRuntime implements AcpRuntime {
         return;
       }
       if (lease.rootPid <= 0) {
+        if (this.uncertainProcessLeaseIds.has(identity.leaseId)) {
+          return;
+        }
         await processLeaseStore.markState(identity.leaseId, "lost");
         return;
       }
+      this.uncertainProcessLeaseIds.delete(identity.leaseId);
       try {
         const record = await this.sessionStore.load(sessionId);
         const recordIdentity = readAcpxProcessLeaseIdentity(readAgentCommandFromRecord(record));
@@ -1251,17 +1264,45 @@ export class AcpxRuntime implements AcpRuntime {
     });
   }
 
-  private async retirePendingProcessLease(
-    identity: AcpxProcessLeaseIdentity | undefined,
-  ): Promise<void> {
-    if (!identity || !this.processLeaseStore) {
+  private async finalizeCompletedProbeLease(identity: AcpxLaunchLeaseContext): Promise<void> {
+    if (!this.processLeaseStore) {
       return;
     }
     const processLeaseStore = this.processLeaseStore;
     await this.releaseProcessLeaseOperation(identity, async () => {
       const lease = await processLeaseStore.load(identity.leaseId);
-      if (lease?.gatewayInstanceId === identity.gatewayInstanceId && lease.rootPid <= 0) {
-        await processLeaseStore.markState(identity.leaseId, "lost");
+      if (!lease || lease.gatewayInstanceId !== identity.gatewayInstanceId) {
+        return;
+      }
+      // Upstream probe close is bounded and best-effort. Delegate fulfillment
+      // does not prove the wrapper exited, so verify the exact pending identity.
+      // Keep the lease even when the wrapper is absent: its detached adapter
+      // descendants do not carry lease args and may already be reparented.
+      if (lease.rootPid > 0) {
+        return;
+      }
+      await cleanupOpenClawOwnedAcpxPendingLease({
+        leaseId: lease.leaseId,
+        gatewayInstanceId: lease.gatewayInstanceId,
+        wrapperRoot: lease.wrapperRoot,
+        wrapperPath: lease.wrapperPath,
+        deps: this.processCleanupDeps,
+      });
+    });
+  }
+
+  private async releaseProcessLeaseAfterUncertainFailure(
+    identity: AcpxProcessLeaseIdentity | undefined,
+  ): Promise<void> {
+    if (!identity || !this.processLeaseStore) {
+      return;
+    }
+    this.uncertainProcessLeaseIds.add(identity.leaseId);
+    const processLeaseStore = this.processLeaseStore;
+    await this.releaseProcessLeaseOperation(identity, async () => {
+      const lease = await processLeaseStore.load(identity.leaseId);
+      if (!lease || lease.gatewayInstanceId !== identity.gatewayInstanceId || lease.rootPid > 0) {
+        this.uncertainProcessLeaseIds.delete(identity.leaseId);
       }
     });
   }
@@ -1384,7 +1425,8 @@ export class AcpxRuntime implements AcpRuntime {
       });
       await this.processLeaseStore?.markState(
         lease.leaseId,
-        result.skippedReason === "process-list-unavailable"
+        result.skippedReason === "process-list-unavailable" ||
+          result.skippedReason === "unsupported-platform"
           ? "open"
           : result.terminatedPids.length > 0 || result.skippedReason === "missing-root"
             ? "closed"
@@ -1417,12 +1459,22 @@ export class AcpxRuntime implements AcpRuntime {
     return this.probeDelegate.isHealthy();
   }
 
-  probeAvailability(): Promise<void> {
-    return this.probeDelegate.probeAvailability();
+  async probeAvailability(): Promise<void> {
+    await this.runWithLaunchLease({
+      sessionKey: ACPX_PROBE_LEASE_SESSION_KEY,
+      command: this.probeCommand,
+      finalizeCompletedProbe: true,
+      run: () => this.probeDelegate.probeAvailability(),
+    });
   }
 
-  doctor(): Promise<AcpRuntimeDoctorReport> {
-    return this.probeDelegate.doctor();
+  async doctor(): Promise<AcpRuntimeDoctorReport> {
+    return await this.runWithLaunchLease({
+      sessionKey: ACPX_PROBE_LEASE_SESSION_KEY,
+      command: this.probeCommand,
+      finalizeCompletedProbe: true,
+      run: () => this.probeDelegate.doctor(),
+    });
   }
 
   async ensureSession(
@@ -1798,7 +1850,7 @@ export class AcpxRuntime implements AcpRuntime {
       if (cleanupSucceeded) {
         await this.finalizeProcessLeaseForOperation(input.handle, closeLease);
       } else {
-        await this.retirePendingProcessLease(closeLease);
+        await this.releaseProcessLeaseAfterUncertainFailure(closeLease);
       }
     }
   }

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -30,6 +30,19 @@ const { cleanupOpenClawOwnedAcpxProcessTreeMock } = vi.hoisted(() => ({
     }),
   ),
 }));
+const { cleanupOpenClawOwnedAcpxPendingLeaseMock } = vi.hoisted(() => ({
+  cleanupOpenClawOwnedAcpxPendingLeaseMock: vi.fn(
+    async (): Promise<{
+      inspectedPids: number[];
+      terminatedPids: number[];
+      skippedReason?: string;
+    }> => ({
+      inspectedPids: [],
+      terminatedPids: [],
+      skippedReason: "missing-root",
+    }),
+  ),
+}));
 const { reapStaleOpenClawOwnedAcpxOrphansMock } = vi.hoisted(() => ({
   reapStaleOpenClawOwnedAcpxOrphansMock: vi.fn(
     async (): Promise<{
@@ -85,13 +98,18 @@ vi.mock("./codex-auth-bridge.js", () => ({
 }));
 
 vi.mock("./process-reaper.js", () => ({
+  cleanupOpenClawOwnedAcpxPendingLease: cleanupOpenClawOwnedAcpxPendingLeaseMock,
   cleanupOpenClawOwnedAcpxProcessTree: cleanupOpenClawOwnedAcpxProcessTreeMock,
   reapStaleOpenClawOwnedAcpxOrphans: reapStaleOpenClawOwnedAcpxOrphansMock,
 }));
 
 import { getAcpRuntimeBackend } from "../runtime-api.js";
 import type { OpenClawPluginServiceContext } from "../runtime-api.js";
-import { openAcpxProcessLeaseStateStore, type AcpxProcessLease } from "./process-lease.js";
+import {
+  ACPX_PROBE_LEASE_SESSION_KEY,
+  openAcpxProcessLeaseStateStore,
+  type AcpxProcessLease,
+} from "./process-lease.js";
 import {
   createAcpxRuntimeService as createRealAcpxRuntimeService,
   resolveAcpxTimerTimeoutMs,
@@ -130,6 +148,7 @@ afterEach(async () => {
   runtimeRegistry.clear();
   prepareAcpxCodexAuthConfigMock.mockClear();
   cleanupOpenClawOwnedAcpxProcessTreeMock.mockClear();
+  cleanupOpenClawOwnedAcpxPendingLeaseMock.mockClear();
   reapStaleOpenClawOwnedAcpxOrphansMock.mockClear();
   acpxRuntimeConstructorMock.mockClear();
   createAgentRegistryMock.mockClear();
@@ -519,7 +538,7 @@ describe("createAcpxRuntimeService", () => {
     await service.stop?.(ctx);
   });
 
-  it("runs wrapper-root orphan cleanup before dropping pending ACPX leases", async () => {
+  it("recovers a pending ACPX lease from exact wrapper identity before retiring it", async () => {
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
     const runtime = createMockRuntime();
@@ -542,7 +561,7 @@ describe("createAcpxRuntimeService", () => {
       state: "open",
     };
     await openProcessLeaseStore(ctx).register(lease.leaseId, lease);
-    reapStaleOpenClawOwnedAcpxOrphansMock.mockResolvedValueOnce({
+    cleanupOpenClawOwnedAcpxPendingLeaseMock.mockResolvedValueOnce({
       inspectedPids: [201, 202],
       terminatedPids: [201, 202],
     });
@@ -553,7 +572,13 @@ describe("createAcpxRuntimeService", () => {
 
     await service.start(ctx);
 
-    expect(cleanupOpenClawOwnedAcpxProcessTreeMock).not.toHaveBeenCalled();
+    expect(cleanupOpenClawOwnedAcpxPendingLeaseMock).toHaveBeenCalledWith({
+      leaseId: "lease-pending",
+      gatewayInstanceId: "gw-test",
+      wrapperRoot,
+      wrapperPath: path.join(wrapperRoot, "codex-acp-wrapper.mjs"),
+      deps: processCleanupDeps,
+    });
     expect(reapStaleOpenClawOwnedAcpxOrphansMock).toHaveBeenCalledWith({
       wrapperRoot,
       deps: processCleanupDeps,
@@ -561,6 +586,85 @@ describe("createAcpxRuntimeService", () => {
     expect(ctx.logger.info).toHaveBeenCalledWith("reaped 2 stale OpenClaw-owned ACPX processes");
     await expect(openProcessLeaseStore(ctx).lookup("lease-pending")).resolves.toBeUndefined();
 
+    await service.stop?.(ctx);
+  });
+
+  it("keeps pending leases open when exact process evidence is ambiguous", async () => {
+    const workspaceDir = await makeTempDir();
+    const ctx = createServiceContext(workspaceDir);
+    const runtime = createMockRuntime();
+    const wrapperRoot = path.join(ctx.stateDir, "acpx");
+    await openGatewayInstanceStore(ctx).register(ACPX_GATEWAY_INSTANCE_KEY, {
+      instanceId: "gw-test",
+      createdAt: 1,
+    });
+    const lease: AcpxProcessLease = {
+      leaseId: "lease-ambiguous",
+      gatewayInstanceId: "gw-test",
+      sessionKey: "agent:codex:acp:test",
+      wrapperRoot,
+      wrapperPath: path.join(wrapperRoot, "codex-acp-wrapper.mjs"),
+      rootPid: 0,
+      commandHash: "hash",
+      startedAt: 1,
+      state: "open",
+    };
+    await openProcessLeaseStore(ctx).register(lease.leaseId, lease);
+    cleanupOpenClawOwnedAcpxPendingLeaseMock.mockResolvedValueOnce({
+      inspectedPids: [201, 202],
+      terminatedPids: [],
+      skippedReason: "ambiguous-root",
+    });
+    reapStaleOpenClawOwnedAcpxOrphansMock.mockResolvedValueOnce({
+      inspectedPids: [301],
+      terminatedPids: [301],
+    });
+    const service = createAcpxRuntimeService(ctx, {
+      runtimeFactory: () => runtime as never,
+    });
+
+    await service.start(ctx);
+
+    await expect(openProcessLeaseStore(ctx).lookup(lease.leaseId)).resolves.toMatchObject({
+      leaseId: lease.leaseId,
+      rootPid: 0,
+      state: "open",
+    });
+    await service.stop?.(ctx);
+  });
+
+  it("keeps an absent pending probe lease open for unidentifiable descendants", async () => {
+    const workspaceDir = await makeTempDir();
+    const ctx = createServiceContext(workspaceDir);
+    const runtime = createMockRuntime();
+    const wrapperRoot = path.join(ctx.stateDir, "acpx");
+    await openGatewayInstanceStore(ctx).register(ACPX_GATEWAY_INSTANCE_KEY, {
+      instanceId: "gw-test",
+      createdAt: 1,
+    });
+    const lease: AcpxProcessLease = {
+      leaseId: "lease-probe-missing",
+      gatewayInstanceId: "gw-test",
+      sessionKey: ACPX_PROBE_LEASE_SESSION_KEY,
+      wrapperRoot,
+      wrapperPath: path.join(wrapperRoot, "codex-acp-wrapper.mjs"),
+      rootPid: 0,
+      commandHash: "hash",
+      startedAt: 1,
+      state: "open",
+    };
+    await openProcessLeaseStore(ctx).register(lease.leaseId, lease);
+    const service = createAcpxRuntimeService(ctx, {
+      runtimeFactory: () => runtime as never,
+    });
+
+    await service.start(ctx);
+
+    await expect(openProcessLeaseStore(ctx).lookup(lease.leaseId)).resolves.toMatchObject({
+      leaseId: lease.leaseId,
+      rootPid: 0,
+      state: "open",
+    });
     await service.stop?.(ctx);
   });
 

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -28,11 +28,13 @@ import {
   type ResolvedAcpxPluginConfig,
 } from "./config.js";
 import {
+  ACPX_PROBE_LEASE_SESSION_KEY,
   createAcpxProcessLeaseStore,
   openAcpxProcessLeaseStateStore,
   type AcpxProcessLeaseStore,
 } from "./process-lease.js";
 import {
+  cleanupOpenClawOwnedAcpxPendingLease,
   cleanupOpenClawOwnedAcpxProcessTree,
   reapStaleOpenClawOwnedAcpxOrphans,
   type AcpxProcessCleanupDeps,
@@ -262,26 +264,32 @@ async function reapOpenAcpxProcessLeases(params: {
   const leases = await params.leaseStore.listOpen(params.gatewayInstanceId);
   const inspectedPids: number[] = [];
   const terminatedPids: number[] = [];
-  const pendingLeaseRootResults = new Map<
-    string,
-    { inspectedPids: number[]; terminatedPids: number[] }
-  >();
+  const legacyWrapperRoots = new Set<string>();
   for (const lease of leases) {
     if (lease.rootPid <= 0) {
+      legacyWrapperRoots.add(lease.wrapperRoot);
       await params.leaseStore.markState(lease.leaseId, "closing");
-      let result = pendingLeaseRootResults.get(lease.wrapperRoot);
-      if (!result) {
-        result = await reapStaleOpenClawOwnedAcpxOrphans({
-          wrapperRoot: lease.wrapperRoot,
-          deps: params.deps,
-        });
-        pendingLeaseRootResults.set(lease.wrapperRoot, result);
-        inspectedPids.push(...result.inspectedPids);
-        terminatedPids.push(...result.terminatedPids);
-      }
+      const result = await cleanupOpenClawOwnedAcpxPendingLease({
+        leaseId: lease.leaseId,
+        gatewayInstanceId: lease.gatewayInstanceId,
+        wrapperRoot: lease.wrapperRoot,
+        wrapperPath: lease.wrapperPath,
+        deps: params.deps,
+      });
+      inspectedPids.push(...result.inspectedPids);
+      terminatedPids.push(...result.terminatedPids);
+      // A missing probe wrapper cannot prove its detached adapter descendants
+      // exited because those descendants do not carry the lease arguments.
+      const retryableEvidenceFailure =
+        result.skippedReason === "ambiguous-root" ||
+        result.skippedReason === "process-list-unavailable" ||
+        result.skippedReason === "unsupported-platform" ||
+        result.skippedReason === "unverified-root" ||
+        (lease.sessionKey === ACPX_PROBE_LEASE_SESSION_KEY &&
+          result.skippedReason === "missing-root");
       await params.leaseStore.markState(
         lease.leaseId,
-        result.terminatedPids.length > 0 ? "closed" : "lost",
+        retryableEvidenceFailure ? "open" : result.terminatedPids.length > 0 ? "closed" : "lost",
       );
       continue;
     }
@@ -297,12 +305,24 @@ async function reapOpenAcpxProcessLeases(params: {
     terminatedPids.push(...result.terminatedPids);
     await params.leaseStore.markState(
       lease.leaseId,
-      result.skippedReason === "process-list-unavailable"
+      result.skippedReason === "process-list-unavailable" ||
+        result.skippedReason === "unsupported-platform"
         ? "open"
         : result.terminatedPids.length > 0
           ? "closed"
           : "lost",
     );
+  }
+  // Preserve the previous narrow trigger for marker cleanup: a pending lease
+  // proves this Gateway had an uncertain spawn. Keep aggregate results wholly
+  // separate from the state transition of any specific lease.
+  for (const wrapperRoot of legacyWrapperRoots) {
+    const legacyResult = await reapStaleOpenClawOwnedAcpxOrphans({
+      wrapperRoot,
+      deps: params.deps,
+    });
+    inspectedPids.push(...legacyResult.inspectedPids);
+    terminatedPids.push(...legacyResult.terminatedPids);
   }
   return { inspectedPids, terminatedPids };
 }


### PR DESCRIPTION
Related: #120937

## What Problem This Solves

ACPX startup cleanup could not safely resolve generated-wrapper launches whose lease was persisted before spawn but whose PID was never recorded. Generated availability and doctor probes also entered upstream launch code without first persisting an OpenClaw ownership lease. That left cleanup dependent on aggregate command-marker scanning and made a specific pending lease vulnerable to being retired from evidence that did not identify that lease.

## Why This Change Was Made

Generated-wrapper probes now use the same lease-first launch scope as sessions: OpenClaw persists an open `rootPid: 0` lease before entering upstream code, then promotes it when the session-store callback records a PID. Startup recovery matches a pending lease only when the live process command contains the exact wrapper path, lease id, and Gateway instance id; ambiguous, unavailable, foreign-instance, and Windows evidence fails closed. Aggregate marker cleanup is kept separate from individual lease state transitions, and lease-aware wrapper roots are excluded from that fallback.

This is an intentional partial completion of the work order. The PR title reflects the requested end state, but deleting the legacy marker heuristics is blocked by the order's escape hatch:

- Generated wrapper probes: confirmed gap, fixed with pre-spawn lease persistence and exact post-probe inspection.
- `rootPid: 0` crash windows: confirmed gap, fixed for generated wrappers. An uncertain launch leaves an open lease; recovery signals only one exact same-instance wrapper match.
- Direct agent spawns: confirmed gap, not fixed. Published `acpx` owns command resolution and process creation without pre-spawn identity injection or a post-spawn PID callback.
- Reparented descendants: confirmed gap, not fixed. Detached adapter descendants do not retain the lease arguments and the wrapper does not report a stable process-group identity.
- Windows containment: not proven and intentionally fails closed because equivalent live process enumeration and tree termination are unavailable here.

The `@zed-industries/codex-acp-*` and `/acpx/dist/` marker matching therefore remains narrowly enabled for unleased direct-agent processes and reparented descendants after an uncertain spawn. It cannot retire any specific lease. Removing it now would reduce orphan coverage and violate the safety invariant.

The version 1 lease shape is unchanged from the latest shipped tag checked for this work, `v2026.7.2-beta.7`; no plugin doctor migration is required. Legacy session records without a lease id retain their existing fail-closed cleanup path.

## User Impact

Operators get safer ACPX restart cleanup for generated wrapper probes and pending launches: OpenClaw can recover an exact same-Gateway orphan without risking another Gateway instance's process. There is no new configuration or user-visible command change. Direct-agent, reparented-descendant, and Windows cleanup remain conservative until upstream ownership hooks and stable tree identity exist.

## Evidence

- `node scripts/run-vitest.mjs extensions/acpx` — 19 files, 256 tests passed on final head.
- `node scripts/check-changed.mjs` — passed before the final base refresh on Blacksmith Testbox `tbx_01kzjwahypjvw1g4gsh1jf7v7g`; run `31305084480`.
- `node scripts/check-docs-mdx.mjs docs/refactor/acp.md` — passed.
- `node scripts/check-docs-i18n-glossary.mjs` — passed.
- `node scripts/docs-link-audit.mjs` — 6,411 internal links checked, 0 broken.
- `git diff --check origin/main...HEAD` — passed on final head.
- Final structured autoreview before commit: clean, exit 0, confidence 0.98.
- Exact-head CI rerun `31305893627` failed `check-plugin-sdk-api-baseline`. The same `generate-plugin-sdk-api-baseline.ts --check` command fails with the identical manifest mismatch on a clean archive of current `origin/main` (`7d4066639ef008c122c8243ce08d834227a494f3`), so the work order's one unrelated-failure rerun was exhausted and no out-of-scope Plugin SDK/generated-baseline change was added here.
- LOC: production `+190/-34` (net `+156`); tests `+431/-14` (net `+417`); docs `+118/-240` (net `-122`). The production growth establishes the missing ownership boundary and exact live-evidence recovery while retaining the upstream-blocked safety fallback.
