### PR TITLE
fix: preserve tool results across session reset

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -432,6 +432,56 @@ describe("session-entry compaction budgeting", () => {
     expect(["entry-5", "entry-6"]).toContain(result.value.firstKeptEntryId);
   });
 
+  it("retains only occurrence-paired reset tool results in compaction input", () => {
+    const assistantToolCall = (timestamp: number): AssistantMessage => ({
+      ...createAssistant("", createUsage(2), timestamp),
+      content: [{ type: "toolCall", id: "call-1", name: "read", arguments: {} }],
+      stopReason: "toolUse",
+    });
+    const toolResult = (timestamp: number, text: string): AgentMessage => ({
+      role: "toolResult",
+      toolCallId: "call-1",
+      toolName: "read",
+      content: [{ type: "text", text }],
+      isError: false,
+      timestamp,
+    });
+    const entries: SessionTreeEntry[] = [
+      createMessageEntry({ role: "user", content: "discarded", timestamp: 1 }, 0),
+      createMessageEntry({ role: "user", content: "kept", timestamp: 2 }, 1),
+      createMessageEntry(assistantToolCall(3), 2),
+      createMessageEntry(toolResult(4, "first result"), 3),
+      createMessageEntry(assistantToolCall(5), 4),
+      createMessageEntry(toolResult(6, "second result"), 5),
+      createMessageEntry(toolResult(7, "orphan result"), 6),
+      {
+        type: "reset",
+        id: "entry-7",
+        parentId: "entry-6",
+        timestamp: new Date(8).toISOString(),
+        reason: "new",
+        firstKeptEntryId: "entry-1",
+      },
+      createMessageEntry({ role: "user", content: "post reset", timestamp: 9 }, 8),
+      createMessageEntry(createAssistant("new answer", createUsage(2), 10), 9),
+    ];
+
+    const result = prepareCompaction(entries, {
+      enabled: true,
+      reserveTokens: 0,
+      keepRecentTokens: 1,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok || !result.value) {
+      throw new Error("expected reset transcript to be compactable");
+    }
+    const summarized = JSON.stringify(result.value.messagesToSummarize);
+    expect(summarized).toContain("first result");
+    expect(summarized).toContain("second result");
+    expect(summarized).not.toContain("orphan result");
+  });
+
   it("moves the cut earlier when a reset kept-tail prelude consumes the compaction budget", () => {
     const largePrelude = "kept context ".repeat(4_000);
     const postResetEntries: SessionTreeEntry[] = [

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -17,7 +17,11 @@ import {
 } from "../../runtime-deps.js";
 import type { AgentMessage, ThinkingLevel } from "../../types.js";
 import { convertToLlm, type HarnessMessage } from "../messages.js";
-import { buildSessionContext, projectSessionEntryMessage } from "../session/session.js";
+import {
+  buildSessionContext,
+  projectSessionEntryMessage,
+  selectResetKeptEntries,
+} from "../session/session.js";
 import {
   type CompactionEntry,
   CompactionError,
@@ -70,13 +74,6 @@ function getMessageFromEntryForCompaction(entry: SessionTreeEntry): AgentMessage
     return undefined;
   }
   return projectSessionEntryMessage(entry);
-}
-
-function isResetReplayableEntry(entry: SessionTreeEntry): boolean {
-  return (
-    entry.type === "message" &&
-    (entry.message.role === "user" || entry.message.role === "assistant")
-  );
 }
 
 /** Generated compaction data ready to be persisted as a compaction entry. */
@@ -714,7 +711,7 @@ export function prepareCompaction(
     if (prevBoundary?.type === "reset") {
       const keptEntries =
         firstKeptEntryIndex >= 0
-          ? pathEntries.slice(firstKeptEntryIndex, prevBoundaryIndex).filter(isResetReplayableEntry)
+          ? selectResetKeptEntries(pathEntries.slice(firstKeptEntryIndex, prevBoundaryIndex))
           : [];
       resetPreludeMessages = keptEntries.flatMap((entry) => {
         const message = getMessageFromEntryForCompaction(entry);

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -17,11 +17,8 @@ import {
 } from "../../runtime-deps.js";
 import type { AgentMessage, ThinkingLevel } from "../../types.js";
 import { convertToLlm, type HarnessMessage } from "../messages.js";
-import {
-  buildSessionContext,
-  projectSessionEntryMessage,
-  selectResetKeptEntries,
-} from "../session/session.js";
+import { buildSessionContext, projectSessionEntryMessage } from "../session/session.js";
+import { selectResetKeptEntries } from "../session/tool-result-pairing.js";
 import {
   type CompactionEntry,
   CompactionError,

--- a/packages/agent-core/src/harness/session/session-context.test.ts
+++ b/packages/agent-core/src/harness/session/session-context.test.ts
@@ -59,6 +59,54 @@ function replayState(type: string, data: string): ProviderReplayState {
   };
 }
 
+function assistantToolEntry(id: string, parentId: string, toolCallId: string): SessionTreeEntry {
+  return {
+    type: "message",
+    id,
+    parentId,
+    timestamp,
+    message: {
+      role: "assistant",
+      api: "openai-responses",
+      content: [{ type: "toolCall", id: toolCallId, name: "read", arguments: {} }],
+      provider: "test-provider",
+      model: "test-model",
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "toolUse",
+      timestamp: Date.parse(timestamp),
+    },
+  };
+}
+
+function toolResultEntry(
+  id: string,
+  parentId: string,
+  toolCallId: string,
+  content: string,
+): SessionTreeEntry {
+  return {
+    type: "message",
+    id,
+    parentId,
+    timestamp,
+    message: {
+      role: "toolResult",
+      toolCallId,
+      toolName: "read",
+      content: [{ type: "text", text: content }],
+      isError: false,
+      timestamp: Date.parse(timestamp),
+    },
+  };
+}
+
 describe("buildSessionContext", () => {
   it("replays only the retained tail and newer entries after compaction", () => {
     const retainedCheckpoint = replayState("openai-responses-compaction", "retained-checkpoint");
@@ -183,6 +231,110 @@ describe("buildSessionContext", () => {
         }
       )[Symbol.for("openclaw.sessionHistoryPrelude")],
     ).toBe(true);
+  });
+
+  it("retains reset tool results by call occurrence while excluding an orphan", () => {
+    const entries: SessionTreeEntry[] = [
+      userEntry("discarded", null, "discarded"),
+      userEntry("kept", "discarded", "kept"),
+      assistantToolEntry("assistant-1", "kept", "call-1"),
+      toolResultEntry("result-1", "assistant-1", "call-1", "first result"),
+      assistantToolEntry("assistant-2", "result-1", "call-1"),
+      toolResultEntry("result-2", "assistant-2", "call-1", "second result"),
+      toolResultEntry("orphan", "result-2", "call-1", "orphan result"),
+      {
+        type: "reset",
+        id: "reset",
+        parentId: "orphan",
+        timestamp,
+        reason: "new",
+        firstKeptEntryId: "kept",
+      },
+      userEntry("new", "reset", "new turn"),
+    ];
+
+    const context = buildSessionContext(entries);
+
+    expect(context.messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "assistant",
+      "toolResult",
+      "user",
+    ]);
+    expect(JSON.stringify(context.messages)).toContain("first result");
+    expect(JSON.stringify(context.messages)).toContain("second result");
+    expect(JSON.stringify(context.messages)).not.toContain("orphan result");
+  });
+
+  it("uses local frame ownership before unique displaced-result recovery", () => {
+    const localResult = toolResultEntry("local-result", "assistant-2", "call-1", "local result");
+    const entries: SessionTreeEntry[] = [
+      userEntry("kept", null, "kept"),
+      assistantToolEntry("assistant-1", "kept", "call-1"),
+      assistantToolEntry("assistant-2", "assistant-1", "call-1"),
+      localResult,
+      toolResultEntry("ambiguous-extra", "local-result", "call-1", "ambiguous extra"),
+      {
+        type: "reset",
+        id: "reset",
+        parentId: "ambiguous-extra",
+        timestamp,
+        reason: "new",
+        firstKeptEntryId: "kept",
+      },
+      userEntry("new", "reset", "new turn"),
+    ];
+
+    const messages = buildSessionContext(entries).messages;
+
+    expect(messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "assistant",
+      "toolResult",
+      "user",
+    ]);
+    expect(messages[3]).toBe(localResult.type === "message" ? localResult.message : undefined);
+    expect(JSON.stringify(messages)).not.toContain("ambiguous extra");
+  });
+
+  it("retains a uniquely displaced result in its original branch position", () => {
+    const displacedResult = toolResultEntry(
+      "displaced-result",
+      "intervening-user",
+      "call-1",
+      "displaced result",
+    );
+    const entries: SessionTreeEntry[] = [
+      userEntry("kept", null, "kept"),
+      assistantToolEntry("assistant", "kept", "call-1"),
+      userEntry("intervening-user", "assistant", "intervening"),
+      displacedResult,
+      {
+        type: "reset",
+        id: "reset",
+        parentId: "displaced-result",
+        timestamp,
+        reason: "new",
+        firstKeptEntryId: "kept",
+      },
+      userEntry("new", "reset", "new turn"),
+    ];
+
+    const messages = buildSessionContext(entries).messages;
+
+    expect(messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "toolResult",
+      "user",
+    ]);
+    expect(messages[3]).toBe(
+      displacedResult.type === "message" ? displacedResult.message : undefined,
+    );
   });
 
   it("lets the latest compaction shadow an earlier reset boundary", () => {

--- a/packages/agent-core/src/harness/session/session.ts
+++ b/packages/agent-core/src/harness/session/session.ts
@@ -7,6 +7,7 @@ import {
   createCustomMessage,
 } from "../messages.js";
 import type { CompactionEntry, ResetEntry, SessionContext, SessionTreeEntry } from "../types.js";
+import { classifyToolUseResultPairing } from "./tool-result-pairing.js";
 
 type ContextBoundary = CompactionEntry | ResetEntry;
 const SESSION_HISTORY_PRELUDE = Symbol.for("openclaw.sessionHistoryPrelude");
@@ -60,10 +61,10 @@ function appendContextMessage(
 }
 
 function appendResetKeptMessage(messages: AgentMessage[], entry: SessionTreeEntry): void {
-  if (
-    entry.type === "message" &&
-    (entry.message.role === "user" || entry.message.role === "assistant")
-  ) {
+  if (entry.type !== "message") {
+    return;
+  }
+  if (entry.message.role === "user" || entry.message.role === "assistant") {
     const message = { ...stripStalePrefixReplay(entry.message) } as AgentMessage & {
       [SESSION_HISTORY_PRELUDE]?: true;
     };
@@ -73,7 +74,29 @@ function appendResetKeptMessage(messages: AgentMessage[], entry: SessionTreeEntr
       value: true,
     });
     messages.push(message);
+  } else if (entry.message.role === "toolResult") {
+    messages.push(entry.message);
   }
+}
+
+/** Select reset-tail model context without changing persisted entry bytes or order. */
+export function selectResetKeptEntries(entries: readonly SessionTreeEntry[]): SessionTreeEntry[] {
+  const messages = entries.flatMap((entry) => (entry.type === "message" ? [entry.message] : []));
+  const pairing = classifyToolUseResultPairing(messages);
+  const pairedResults = new Set(
+    pairing.frames.flatMap((frame) =>
+      frame.occurrences.flatMap((occurrence) =>
+        occurrence.sourceResult ? [occurrence.sourceResult] : [],
+      ),
+    ),
+  );
+  return entries.filter(
+    (entry) =>
+      entry.type === "message" &&
+      (entry.message.role === "user" ||
+        entry.message.role === "assistant" ||
+        (entry.message.role === "toolResult" && pairedResults.has(entry.message))),
+  );
 }
 
 /** Build model context from an ordered session branch and its latest state markers. */
@@ -103,9 +126,11 @@ export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionCon
       }
     }
     const boundaryIdx = pathEntries.findIndex((entry) => entry.id === boundary.id);
-    // A reset kept tail mirrors the old cross-log replay contract: only user/assistant
-    // rows survive. Both retained-tail forms now follow rewritten prefixes, so
-    // prefix-bound checkpoints are stale.
+    const resetKeptEntries =
+      boundary.type === "reset"
+        ? new Set(selectResetKeptEntries(pathEntries.slice(0, boundaryIdx)))
+        : undefined;
+    // Both retained-tail forms follow rewritten prefixes, so prefix-bound checkpoints are stale.
     let foundFirstKept = false;
     for (const entry of pathEntries.slice(0, boundaryIdx)) {
       if (entry.id === boundary.firstKeptEntryId) {
@@ -113,7 +138,9 @@ export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionCon
       }
       if (foundFirstKept) {
         if (boundary.type === "reset") {
-          appendResetKeptMessage(messages, entry);
+          if (resetKeptEntries?.has(entry)) {
+            appendResetKeptMessage(messages, entry);
+          }
         } else {
           appendContextMessage(messages, entry, { prefixWasRewritten: true });
         }

--- a/packages/agent-core/src/harness/session/session.ts
+++ b/packages/agent-core/src/harness/session/session.ts
@@ -7,7 +7,7 @@ import {
   createCustomMessage,
 } from "../messages.js";
 import type { CompactionEntry, ResetEntry, SessionContext, SessionTreeEntry } from "../types.js";
-import { classifyToolUseResultPairing } from "./tool-result-pairing.js";
+import { selectResetKeptEntries } from "./tool-result-pairing.js";
 
 type ContextBoundary = CompactionEntry | ResetEntry;
 const SESSION_HISTORY_PRELUDE = Symbol.for("openclaw.sessionHistoryPrelude");
@@ -77,26 +77,6 @@ function appendResetKeptMessage(messages: AgentMessage[], entry: SessionTreeEntr
   } else if (entry.message.role === "toolResult") {
     messages.push(entry.message);
   }
-}
-
-/** Select reset-tail model context without changing persisted entry bytes or order. */
-export function selectResetKeptEntries(entries: readonly SessionTreeEntry[]): SessionTreeEntry[] {
-  const messages = entries.flatMap((entry) => (entry.type === "message" ? [entry.message] : []));
-  const pairing = classifyToolUseResultPairing(messages);
-  const pairedResults = new Set(
-    pairing.frames.flatMap((frame) =>
-      frame.occurrences.flatMap((occurrence) =>
-        occurrence.sourceResult ? [occurrence.sourceResult] : [],
-      ),
-    ),
-  );
-  return entries.filter(
-    (entry) =>
-      entry.type === "message" &&
-      (entry.message.role === "user" ||
-        entry.message.role === "assistant" ||
-        (entry.message.role === "toolResult" && pairedResults.has(entry.message))),
-  );
 }
 
 /** Build model context from an ordered session branch and its latest state markers. */

--- a/packages/agent-core/src/harness/session/tool-result-pairing.ts
+++ b/packages/agent-core/src/harness/session/tool-result-pairing.ts
@@ -6,12 +6,12 @@ const SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY = "openclawSyntheticMissingToolRe
 const DEFAULT_MISSING_TOOL_RESULT_TEXT =
   "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
 
-export type ToolCallLike = {
+type ToolCallLike = {
   id: string;
   name?: string;
 };
 
-export type ToolCallOccurrence = {
+type ToolCallOccurrence = {
   id: string;
   name?: string;
   result?: ToolResultMessage;
@@ -26,7 +26,7 @@ type ToolResultRecord = {
   id?: string;
 };
 
-export type ToolUsePairingFrame = {
+type ToolUsePairingFrame = {
   startIndex: number;
   endIndex: number;
   assistant: Extract<AgentMessage, { role: "assistant" }>;
@@ -35,13 +35,13 @@ export type ToolUsePairingFrame = {
   failed: boolean;
 };
 
-export type ToolUsePairingClassification = {
+type ToolUsePairingClassification = {
   frames: ToolUsePairingFrame[];
   droppedDuplicateCount: number;
   droppedOrphanCount: number;
 };
 
-export type ToolCallOccurrenceQueue<T> = {
+type ToolCallOccurrenceQueue<T> = {
   add: (id: string, occurrence: T) => void;
   claim: (id: string) => T | undefined;
   clear: () => void;
@@ -327,7 +327,10 @@ export function classifyToolUseResultPairing(
         droppedOrphanCount += preserveUnframed ? 0 : 1;
         continue;
       }
-      const candidate = candidates[0]!;
+      const candidate = candidates[0];
+      if (!candidate) {
+        continue;
+      }
       droppedDuplicateCount += candidate.result ? 1 : 0;
       candidate.result = normalizeToolResultName(record.result, candidate.name);
       candidate.sourceResult = record.sourceResult;

--- a/packages/agent-core/src/harness/session/tool-result-pairing.ts
+++ b/packages/agent-core/src/harness/session/tool-result-pairing.ts
@@ -1,0 +1,341 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { AgentMessage } from "../../types.js";
+
+const TOOL_CALL_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
+const SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY = "openclawSyntheticMissingToolResult";
+const DEFAULT_MISSING_TOOL_RESULT_TEXT =
+  "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
+
+export type ToolCallLike = {
+  id: string;
+  name?: string;
+};
+
+export type ToolCallOccurrence = {
+  id: string;
+  name?: string;
+  result?: ToolResultMessage;
+  sourceResult?: ToolResultMessage;
+};
+
+type ToolResultMessage = Extract<AgentMessage, { role: "toolResult" }>;
+
+type ToolResultRecord = {
+  result: ToolResultMessage;
+  sourceResult: ToolResultMessage;
+  id?: string;
+};
+
+export type ToolUsePairingFrame = {
+  startIndex: number;
+  endIndex: number;
+  assistant: Extract<AgentMessage, { role: "assistant" }>;
+  remainder: AgentMessage[];
+  occurrences: ToolCallOccurrence[];
+  failed: boolean;
+};
+
+export type ToolUsePairingClassification = {
+  frames: ToolUsePairingFrame[];
+  droppedDuplicateCount: number;
+  droppedOrphanCount: number;
+};
+
+export type ToolCallOccurrenceQueue<T> = {
+  add: (id: string, occurrence: T) => void;
+  claim: (id: string) => T | undefined;
+  clear: () => void;
+  readonly size: number;
+};
+
+/** Tracks repeated provider ids by occurrence instead of collapsing them into a set. */
+export function createToolCallOccurrenceQueue<T>(): ToolCallOccurrenceQueue<T> {
+  const pendingById = new Map<string, T[]>();
+  let pendingCount = 0;
+  return {
+    add(id, occurrence) {
+      const pending = pendingById.get(id);
+      if (pending) {
+        pending.push(occurrence);
+      } else {
+        pendingById.set(id, [occurrence]);
+      }
+      pendingCount += 1;
+    },
+    claim(id) {
+      const pending = pendingById.get(id);
+      const occurrence = pending?.shift();
+      if (!occurrence) {
+        return undefined;
+      }
+      pendingCount -= 1;
+      if (pending?.length === 0) {
+        pendingById.delete(id);
+      }
+      return occurrence;
+    },
+    clear() {
+      pendingById.clear();
+      pendingCount = 0;
+    },
+    get size() {
+      return pendingCount;
+    },
+  };
+}
+
+export function extractToolCallsFromAssistant(
+  message: Extract<AgentMessage, { role: "assistant" }>,
+): ToolCallLike[] {
+  if (!Array.isArray(message.content)) {
+    return [];
+  }
+  return message.content.flatMap((block) => {
+    if (!block || typeof block !== "object") {
+      return [];
+    }
+    const record = block as { type?: unknown; id?: unknown; name?: unknown };
+    if (
+      typeof record.type !== "string" ||
+      !TOOL_CALL_TYPES.has(record.type) ||
+      typeof record.id !== "string" ||
+      !record.id
+    ) {
+      return [];
+    }
+    return [{ id: record.id, name: typeof record.name === "string" ? record.name : undefined }];
+  });
+}
+
+export function extractToolResultIds(message: ToolResultMessage): string[] {
+  const record = message as {
+    toolCallId?: unknown;
+    toolUseId?: unknown;
+    tool_call_id?: unknown;
+    tool_use_id?: unknown;
+    callId?: unknown;
+    call_id?: unknown;
+  };
+  const ids: string[] = [];
+  for (const value of [
+    record.toolCallId,
+    record.toolUseId,
+    record.tool_call_id,
+    record.tool_use_id,
+    record.callId,
+    record.call_id,
+  ]) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const id = value.trim();
+    if (id && !ids.includes(id)) {
+      ids.push(id);
+    }
+  }
+  return ids;
+}
+
+export function extractToolResultId(message: ToolResultMessage): string | null {
+  return extractToolResultIds(message)[0] ?? null;
+}
+
+export function makeMissingToolResult(params: {
+  toolCallId: string;
+  toolName?: string;
+  text?: string;
+}): ToolResultMessage {
+  return {
+    role: "toolResult",
+    toolCallId: params.toolCallId,
+    toolName: params.toolName ?? "unknown",
+    content: [{ type: "text", text: params.text ?? DEFAULT_MISSING_TOOL_RESULT_TEXT }],
+    details: { [SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY]: true },
+    isError: true,
+    timestamp: Date.now(),
+  } as ToolResultMessage;
+}
+
+function isSyntheticMissingToolResult(message: ToolResultMessage): boolean {
+  if (!(message as { isError?: unknown }).isError) {
+    return false;
+  }
+  const details = (message as { details?: unknown }).details;
+  if (
+    details &&
+    typeof details === "object" &&
+    (details as Record<string, unknown>)[SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY] === true
+  ) {
+    return true;
+  }
+  const content = (message as { content?: unknown }).content;
+  return (
+    Array.isArray(content) &&
+    content.some(
+      (block) =>
+        typeof block === "object" &&
+        block !== null &&
+        (block as { type?: string }).type === "text" &&
+        (block as { text?: string }).text === DEFAULT_MISSING_TOOL_RESULT_TEXT,
+    )
+  );
+}
+
+function normalizeToolResultName(
+  message: ToolResultMessage,
+  fallbackName?: string,
+): ToolResultMessage {
+  const rawToolName = (message as { toolName?: unknown }).toolName;
+  const normalizedToolName = normalizeOptionalString(rawToolName);
+  if (normalizedToolName) {
+    return rawToolName === normalizedToolName
+      ? message
+      : ({ ...message, toolName: normalizedToolName } as ToolResultMessage);
+  }
+  const normalizedFallback = normalizeOptionalString(fallbackName);
+  if (normalizedFallback) {
+    return { ...message, toolName: normalizedFallback } as ToolResultMessage;
+  }
+  return typeof rawToolName === "string"
+    ? ({ ...message, toolName: "unknown" } as ToolResultMessage)
+    : message;
+}
+
+export function normalizeLegacyToolResultId(
+  message: ToolResultMessage,
+  toolCalls: ToolCallLike[],
+): ToolResultMessage {
+  if (extractToolResultId(message) || toolCalls.length !== 1) {
+    return message;
+  }
+  const toolCall = toolCalls[0];
+  if (!toolCall) {
+    return message;
+  }
+  const resultName = normalizeOptionalString((message as { toolName?: unknown }).toolName);
+  const callName = normalizeOptionalString(toolCall.name);
+  if (resultName && callName && resultName !== callName) {
+    return message;
+  }
+  return { ...message, toolCallId: toolCall.id, isError: true } as ToolResultMessage;
+}
+
+/** Classifies call/result ownership without reordering or synthesizing transcript messages. */
+export function classifyToolUseResultPairing(
+  messages: readonly AgentMessage[],
+  options?: { preserveUnframedToolResults?: boolean },
+): ToolUsePairingClassification {
+  const frameStartIndexes = messages.flatMap((message, index) =>
+    message?.role === "assistant" && extractToolCallsFromAssistant(message).length > 0
+      ? [index]
+      : [],
+  );
+  let droppedDuplicateCount = 0;
+  let droppedOrphanCount = 0;
+  const preserveUnframed = options?.preserveUnframedToolResults === true;
+  const frameRecords: Array<ToolUsePairingFrame & { unclaimedResults: ToolResultRecord[] }> =
+    frameStartIndexes.map((startIndex, frameIndex) => {
+      const assistant = messages[startIndex] as Extract<AgentMessage, { role: "assistant" }>;
+      const toolCalls = extractToolCallsFromAssistant(assistant);
+      const occurrences: ToolCallOccurrence[] = [];
+      const pending = createToolCallOccurrenceQueue<ToolCallOccurrence>();
+      const syntheticById = new Map<string, ToolCallOccurrence[]>();
+      for (const toolCall of toolCalls) {
+        const occurrence = { id: toolCall.id, name: toolCall.name };
+        occurrences.push(occurrence);
+        pending.add(toolCall.id, occurrence);
+      }
+      const endIndex = frameStartIndexes[frameIndex + 1] ?? messages.length;
+      const remainder: AgentMessage[] = [];
+      const unclaimedResults: ToolResultRecord[] = [];
+      for (let index = startIndex + 1; index < endIndex; index += 1) {
+        const message = messages[index];
+        if (!message || typeof message !== "object") {
+          continue;
+        }
+        if (message.role !== "toolResult") {
+          remainder.push(message);
+          continue;
+        }
+        const normalized = normalizeLegacyToolResultId(message, toolCalls);
+        const id = extractToolResultId(normalized);
+        const occurrence = id ? pending.claim(id) : undefined;
+        if (occurrence) {
+          occurrence.result = normalizeToolResultName(normalized, occurrence.name);
+          occurrence.sourceResult = message;
+          if (isSyntheticMissingToolResult(occurrence.result)) {
+            const synthetic = syntheticById.get(occurrence.id);
+            if (synthetic) {
+              synthetic.push(occurrence);
+            } else {
+              syntheticById.set(occurrence.id, [occurrence]);
+            }
+          }
+          continue;
+        }
+        if (!id || !occurrences.some((candidate) => candidate.id === id)) {
+          unclaimedResults.push({ result: normalized, sourceResult: message, id: id ?? undefined });
+          if (preserveUnframed) {
+            remainder.push(normalized);
+          }
+          continue;
+        }
+        droppedDuplicateCount += 1;
+        if (!isSyntheticMissingToolResult(normalized)) {
+          const replaceable = syntheticById.get(id)?.shift();
+          if (replaceable) {
+            replaceable.result = normalizeToolResultName(normalized, replaceable.name);
+            replaceable.sourceResult = message;
+          }
+        }
+      }
+      const stopReason = (assistant as { stopReason?: string }).stopReason;
+      return {
+        startIndex,
+        endIndex,
+        assistant,
+        remainder,
+        unclaimedResults,
+        occurrences,
+        failed: stopReason === "error" || stopReason === "aborted",
+      };
+    });
+
+  // Displaced results cross a frame only when one unresolved occurrence can own them.
+  const unresolvedById = new Map<string, ToolCallOccurrence[]>();
+  for (const frame of frameRecords) {
+    for (const occurrence of frame.occurrences) {
+      if (!occurrence.result || isSyntheticMissingToolResult(occurrence.result)) {
+        const unresolved = unresolvedById.get(occurrence.id);
+        if (unresolved) {
+          unresolved.push(occurrence);
+        } else {
+          unresolvedById.set(occurrence.id, [occurrence]);
+        }
+      }
+    }
+    for (const record of frame.unclaimedResults) {
+      const candidates = record.id
+        ? (unresolvedById.get(record.id) ?? []).filter(
+            (candidate) =>
+              !candidate.result ||
+              (isSyntheticMissingToolResult(candidate.result) &&
+                !isSyntheticMissingToolResult(record.result)),
+          )
+        : [];
+      if (candidates.length !== 1) {
+        droppedOrphanCount += preserveUnframed ? 0 : 1;
+        continue;
+      }
+      const candidate = candidates[0]!;
+      droppedDuplicateCount += candidate.result ? 1 : 0;
+      candidate.result = normalizeToolResultName(record.result, candidate.name);
+      candidate.sourceResult = record.sourceResult;
+      if (preserveUnframed) {
+        frame.remainder = frame.remainder.filter((message) => message !== record.result);
+      }
+    }
+  }
+
+  return { frames: frameRecords, droppedDuplicateCount, droppedOrphanCount };
+}

--- a/packages/agent-core/src/harness/session/tool-result-pairing.ts
+++ b/packages/agent-core/src/harness/session/tool-result-pairing.ts
@@ -1,5 +1,6 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { AgentMessage } from "../../types.js";
+import type { SessionTreeEntry } from "../types.js";
 
 const TOOL_CALL_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
 const SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY = "openclawSyntheticMissingToolResult";
@@ -341,4 +342,24 @@ export function classifyToolUseResultPairing(
   }
 
   return { frames: frameRecords, droppedDuplicateCount, droppedOrphanCount };
+}
+
+/** Select reset-tail model context without changing persisted entry bytes or order. */
+export function selectResetKeptEntries(entries: readonly SessionTreeEntry[]): SessionTreeEntry[] {
+  const messages = entries.flatMap((entry) => (entry.type === "message" ? [entry.message] : []));
+  const pairing = classifyToolUseResultPairing(messages);
+  const pairedResults = new Set(
+    pairing.frames.flatMap((frame) =>
+      frame.occurrences.flatMap((occurrence) =>
+        occurrence.sourceResult ? [occurrence.sourceResult] : [],
+      ),
+    ),
+  );
+  return entries.filter(
+    (entry) =>
+      entry.type === "message" &&
+      (entry.message.role === "user" ||
+        entry.message.role === "assistant" ||
+        (entry.message.role === "toolResult" && pairedResults.has(entry.message))),
+  );
 }

--- a/src/agents/compaction-planning.ts
+++ b/src/agents/compaction-planning.ts
@@ -3,6 +3,7 @@
  * token usage, chooses chunking strategy, and preserves active tool-use pairs
  * while splitting history for summaries.
  */
+import { createToolCallOccurrenceQueue } from "../../packages/agent-core/src/harness/session/tool-result-pairing.js";
 import {
   projectCompactionPlanningMessages,
   readCompactionPlanningOmittedChars,
@@ -109,7 +110,7 @@ function groupCompactionMessages(
   const groups: CompactionMessageGroup[] = [];
   let current: AgentMessage[] = [];
   let currentTokens = 0;
-  let pendingToolCallIds = new Set<string>();
+  let pendingToolCalls = createToolCallOccurrenceQueue<true>();
 
   for (const [index, message] of messages.entries()) {
     current.push(message);
@@ -121,19 +122,22 @@ function groupCompactionMessages(
         stopReason === "aborted" || stopReason === "error"
           ? []
           : extractToolCallsFromAssistant(message);
-      pendingToolCallIds = new Set(toolCalls.map((toolCall) => toolCall.id));
-    } else if (message.role === "toolResult" && pendingToolCallIds.size > 0) {
+      pendingToolCalls = createToolCallOccurrenceQueue();
+      for (const toolCall of toolCalls) {
+        pendingToolCalls.add(toolCall.id, true);
+      }
+    } else if (message.role === "toolResult" && pendingToolCalls.size > 0) {
       const resultId = extractToolResultId(message);
       if (resultId) {
-        pendingToolCallIds.delete(resultId);
+        pendingToolCalls.claim(resultId);
       } else {
-        pendingToolCallIds.clear();
+        pendingToolCalls.clear();
       }
     }
 
     // A displaced user turn still belongs to an unfinished call/result batch;
     // splitting it would make one of the resulting provider transcripts invalid.
-    if (pendingToolCallIds.size === 0) {
+    if (pendingToolCalls.size === 0) {
       groups.push({ messages: current, tokens: currentTokens });
       current = [];
       currentTokens = 0;

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -192,6 +192,31 @@ describe("splitMessagesByTokenShare", () => {
     expect(parts.flat().length).toBe(messages.length);
   });
 
+  it("keeps repeated-id tool results with their assistant by occurrence", () => {
+    const assistant = makeAgentAssistantMessage({
+      content: [
+        { type: "toolCall", id: "call_reused", name: "first", arguments: {} },
+        { type: "toolCall", id: "call_reused", name: "second", arguments: {} },
+      ],
+      model: "gpt-5.6-luna",
+      stopReason: "toolUse",
+      timestamp: 2,
+    });
+    const messages: AgentMessage[] = [
+      makeMessage(1, 4000),
+      assistant,
+      makeToolResult(3, "call_reused", "first".repeat(400)),
+      makeToolResult(4, "call_reused", "second".repeat(400)),
+      makeMessage(5, 4000),
+    ];
+
+    const parts = splitMessagesByTokenShare(messages, 2);
+
+    const toolChunk = requireChunkContainingTimestamp(parts, "assistant", 2);
+    expect(requireChunkContainingTimestamp(parts, "toolResult", 3)).toBe(toolChunk);
+    expect(requireChunkContainingTimestamp(parts, "toolResult", 4)).toBe(toolChunk);
+  });
+
   it("keeps displaced toolResults with their assistant chunk", () => {
     const messages: AgentMessage[] = [
       makeMessage(1, 4000),

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -15,10 +15,7 @@ import {
   normalizeLegacyToolResultId,
 } from "../../packages/agent-core/src/harness/session/tool-result-pairing.js";
 import { isThinkingLikeBlock } from "./thinking-block.js";
-import {
-  extractToolCallsFromAssistant,
-  extractToolResultIds,
-} from "./tool-call-id.js";
+import { extractToolCallsFromAssistant, extractToolResultIds } from "./tool-call-id.js";
 import { isAllowedToolCallName, normalizeAllowedToolNames } from "./tool-call-shared.js";
 
 type RawToolCallBlock = {

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -7,13 +7,16 @@ import type { AgentMessage } from "@openclaw/agent-core";
 import {
   hasNonEmptyString as hasNonEmptyStringField,
   normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
+import {
+  classifyToolUseResultPairing,
+  makeMissingToolResult,
+  normalizeLegacyToolResultId,
+} from "../../packages/agent-core/src/harness/session/tool-result-pairing.js";
 import { isThinkingLikeBlock } from "./thinking-block.js";
 import {
   extractToolCallsFromAssistant,
-  extractToolResultId,
   extractToolResultIds,
 } from "./tool-call-id.js";
 import { isAllowedToolCallName, normalizeAllowedToolNames } from "./tool-call-shared.js";
@@ -182,104 +185,6 @@ function hasSessionsSpawnAttachmentToolCall(content: unknown[]): boolean {
   return false;
 }
 
-const DEFAULT_MISSING_TOOL_RESULT_TEXT =
-  "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
-const SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY = "openclawSyntheticMissingToolResult";
-
-function makeMissingToolResult(params: {
-  toolCallId: string;
-  toolName?: string;
-  // OpenAI Responses/Codex replay should match upstream Codex's "aborted"
-  // function_call_output normalization; live coverage in
-  // openai-reasoning-compat.live.test.ts and tool-replay-repair.live.test.ts
-  // sends this repaired history to real models. Other providers keep the older,
-  // explicit OpenClaw diagnostic text unless the caller opts in.
-  text?: string;
-}): Extract<AgentMessage, { role: "toolResult" }> {
-  return {
-    role: "toolResult",
-    toolCallId: params.toolCallId,
-    toolName: params.toolName ?? "unknown",
-    content: [
-      {
-        type: "text",
-        text: params.text ?? DEFAULT_MISSING_TOOL_RESULT_TEXT,
-      },
-    ],
-    details: { [SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY]: true },
-    isError: true,
-    timestamp: Date.now(),
-  } as Extract<AgentMessage, { role: "toolResult" }>;
-}
-
-function isSyntheticMissingToolResult(msg: Extract<AgentMessage, { role: "toolResult" }>): boolean {
-  if (!(msg as { isError?: unknown }).isError) {
-    return false;
-  }
-  const details = (msg as { details?: unknown }).details;
-  if (
-    details &&
-    typeof details === "object" &&
-    (details as Record<string, unknown>)[SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY] === true
-  ) {
-    return true;
-  }
-  const content = (msg as { content?: unknown }).content;
-  if (!Array.isArray(content)) {
-    return false;
-  }
-  return content.some(
-    (block: unknown) =>
-      typeof block === "object" &&
-      block !== null &&
-      (block as { type?: string }).type === "text" &&
-      (block as { text?: string }).text === DEFAULT_MISSING_TOOL_RESULT_TEXT,
-  );
-}
-
-function normalizeToolResultName(
-  message: Extract<AgentMessage, { role: "toolResult" }>,
-  fallbackName?: string,
-): Extract<AgentMessage, { role: "toolResult" }> {
-  const rawToolName = (message as { toolName?: unknown }).toolName;
-  const normalizedToolName = normalizeOptionalString(rawToolName);
-  if (normalizedToolName) {
-    if (rawToolName === normalizedToolName) {
-      return message;
-    }
-    return { ...message, toolName: normalizedToolName };
-  }
-
-  const normalizedFallback = normalizeOptionalString(fallbackName);
-  if (normalizedFallback) {
-    return { ...message, toolName: normalizedFallback };
-  }
-
-  if (typeof rawToolName === "string") {
-    return { ...message, toolName: "unknown" };
-  }
-  return message;
-}
-
-function normalizeLegacyToolResultId(
-  message: Extract<AgentMessage, { role: "toolResult" }>,
-  toolCalls: Array<{ id: string; name?: string }>,
-): Extract<AgentMessage, { role: "toolResult" }> {
-  if (extractToolResultId(message) || toolCalls.length !== 1) {
-    return message;
-  }
-  const [toolCall] = toolCalls;
-  if (!toolCall) {
-    return message;
-  }
-  const toolResultName = normalizeOptionalString((message as { toolName?: unknown }).toolName);
-  const toolCallName = normalizeOptionalString(toolCall.name);
-  if (toolResultName && toolCallName && toolResultName !== toolCallName) {
-    return message;
-  }
-  return { ...message, toolCallId: toolCall.id, isError: true };
-}
-
 export { makeMissingToolResult };
 
 type ToolCallInputRepairReport = {
@@ -341,7 +246,7 @@ function collectFollowingToolResults(
       sawNonToolResult = true;
       continue;
     }
-    if (message.role === "assistant" && assistantHasToolCalls(message)) {
+    if (message.role === "assistant" && extractToolCallsFromAssistant(message).length > 0) {
       break;
     }
     if (message.role === "toolResult") {
@@ -552,143 +457,6 @@ function shouldDropErroredAssistantResults(options?: ToolUseResultPairingOptions
   return options?.erroredAssistantResultPolicy === "drop";
 }
 
-function assistantHasToolCalls(message: AgentMessage): boolean {
-  if (!message || typeof message !== "object" || message.role !== "assistant") {
-    return false;
-  }
-  return extractToolCallsFromAssistant(message).length > 0;
-}
-
-type ToolResultMessage = Extract<AgentMessage, { role: "toolResult" }>;
-
-type ToolResultRecord = {
-  result: ToolResultMessage;
-  id?: string;
-};
-
-type ToolCallOccurrence = {
-  id: string;
-  name?: string;
-  result?: ToolResultMessage;
-};
-
-type SameIdOccurrenceGroup = {
-  occurrences: ToolCallOccurrence[];
-  nextUnfilledIndex: number;
-  syntheticOccurrences: ToolCallOccurrence[];
-  nextSyntheticIndex: number;
-};
-
-type ToolUseFrame = {
-  startIndex: number;
-  endIndex: number;
-  assistant: Extract<AgentMessage, { role: "assistant" }>;
-  remainder: AgentMessage[];
-  unclaimedResults: ToolResultRecord[];
-  occurrences: ToolCallOccurrence[];
-  failed: boolean;
-};
-
-function buildToolUseFrames(
-  messages: AgentMessage[],
-  onDuplicate: () => void,
-  preserveUnframed: boolean,
-): ToolUseFrame[] {
-  const frameStartIndexes: number[] = [];
-  for (const [index, message] of messages.entries()) {
-    if (message && typeof message === "object" && assistantHasToolCalls(message)) {
-      frameStartIndexes.push(index);
-    }
-  }
-
-  return frameStartIndexes.map((startIndex, frameIndex) => {
-    const assistant = messages[startIndex] as Extract<AgentMessage, { role: "assistant" }>;
-    const toolCalls = extractToolCallsFromAssistant(assistant);
-    const occurrences: ToolCallOccurrence[] = [];
-    const occurrencesById = new Map<string, SameIdOccurrenceGroup>();
-    for (const toolCall of toolCalls) {
-      const occurrence: ToolCallOccurrence = { id: toolCall.id, name: toolCall.name };
-      occurrences.push(occurrence);
-      const sameIdGroup = occurrencesById.get(toolCall.id);
-      if (sameIdGroup) {
-        sameIdGroup.occurrences.push(occurrence);
-      } else {
-        occurrencesById.set(toolCall.id, {
-          occurrences: [occurrence],
-          nextUnfilledIndex: 0,
-          syntheticOccurrences: [],
-          nextSyntheticIndex: 0,
-        });
-      }
-    }
-
-    const endIndex = frameStartIndexes[frameIndex + 1] ?? messages.length;
-    const remainder: AgentMessage[] = [];
-    const unclaimedResults: ToolResultRecord[] = [];
-
-    for (let index = startIndex + 1; index < endIndex; index += 1) {
-      const message = messages[index];
-      if (!message || typeof message !== "object") {
-        continue;
-      }
-      if (message.role !== "toolResult") {
-        remainder.push(message);
-        continue;
-      }
-
-      const legacyNormalized = normalizeLegacyToolResultId(message, toolCalls);
-      const id = extractToolResultId(legacyNormalized);
-      const sameIdGroup = id ? occurrencesById.get(id) : undefined;
-      if (!id || !sameIdGroup) {
-        unclaimedResults.push({ result: legacyNormalized, id: id ?? undefined });
-        if (preserveUnframed) {
-          remainder.push(legacyNormalized);
-        }
-        continue;
-      }
-
-      const unfilledOccurrence = sameIdGroup.occurrences[sameIdGroup.nextUnfilledIndex];
-      if (unfilledOccurrence) {
-        unfilledOccurrence.result = normalizeToolResultName(
-          legacyNormalized,
-          unfilledOccurrence.name,
-        );
-        sameIdGroup.nextUnfilledIndex += 1;
-        if (isSyntheticMissingToolResult(unfilledOccurrence.result)) {
-          sameIdGroup.syntheticOccurrences.push(unfilledOccurrence);
-        }
-        continue;
-      }
-
-      onDuplicate();
-      if (!isSyntheticMissingToolResult(legacyNormalized)) {
-        const replaceableOccurrence =
-          sameIdGroup.syntheticOccurrences[sameIdGroup.nextSyntheticIndex];
-        if (replaceableOccurrence) {
-          sameIdGroup.nextSyntheticIndex += 1;
-          replaceableOccurrence.result = normalizeToolResultName(
-            legacyNormalized,
-            replaceableOccurrence.name,
-          );
-        }
-      }
-    }
-
-    const stopReason = (assistant as { stopReason?: string }).stopReason;
-    const failed = stopReason === "error" || stopReason === "aborted";
-
-    return {
-      startIndex,
-      endIndex,
-      assistant,
-      remainder,
-      unclaimedResults,
-      occurrences,
-      failed,
-    };
-  });
-}
-
 export function repairToolUseResultPairing(
   messages: AgentMessage[],
   options?: ToolUseResultPairingOptions,
@@ -701,49 +469,13 @@ export function repairToolUseResultPairing(
   // - dropping duplicate toolResults for the same tool-call occurrence
   // Provider ids are opaque and can legitimately repeat on later assistant turns.
   const added: Array<Extract<AgentMessage, { role: "toolResult" }>> = [];
-  let droppedDuplicateCount = 0;
-  let droppedOrphanCount = 0;
   const preserveUnframed = options?.preserveUnframedToolResults === true;
-  const frames = buildToolUseFrames(messages, () => (droppedDuplicateCount += 1), preserveUnframed);
-
-  // Cross-frame recovery is intentionally conservative. A displaced result is moved only
-  // when exactly one still-unresolved call occurrence can own it; repeated ids otherwise
-  // make attribution unknowable, and guessing would feed the model the wrong tool output.
-  const unresolvedById = new Map<string, ToolCallOccurrence[]>();
-  for (const frame of frames) {
-    for (const occurrence of frame.occurrences) {
-      if (!occurrence.result || isSyntheticMissingToolResult(occurrence.result)) {
-        const unresolved = unresolvedById.get(occurrence.id);
-        if (unresolved) {
-          unresolved.push(occurrence);
-        } else {
-          unresolvedById.set(occurrence.id, [occurrence]);
-        }
-      }
-    }
-
-    for (const record of frame.unclaimedResults) {
-      const candidates = record.id
-        ? (unresolvedById.get(record.id) ?? []).filter(
-            (candidate) =>
-              !candidate.result ||
-              (isSyntheticMissingToolResult(candidate.result) &&
-                !isSyntheticMissingToolResult(record.result)),
-          )
-        : [];
-      if (candidates.length !== 1) {
-        droppedOrphanCount += preserveUnframed ? 0 : 1;
-        continue;
-      }
-
-      const candidate = candidates[0]!;
-      droppedDuplicateCount += candidate.result ? 1 : 0;
-      candidate.result = normalizeToolResultName(record.result, candidate.name);
-      if (preserveUnframed) {
-        frame.remainder = frame.remainder.filter((message) => message !== record.result);
-      }
-    }
-  }
+  const pairing = classifyToolUseResultPairing(messages, {
+    preserveUnframedToolResults: preserveUnframed,
+  });
+  const { frames } = pairing;
+  const droppedDuplicateCount = pairing.droppedDuplicateCount;
+  let droppedOrphanCount = pairing.droppedOrphanCount;
 
   const out: AgentMessage[] = [];
   let cursor = 0;

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -11,7 +11,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import {
   classifyToolUseResultPairing,
-  makeMissingToolResult,
+  makeMissingToolResult as makePairingMissingToolResult,
   normalizeLegacyToolResultId,
 } from "../../packages/agent-core/src/harness/session/tool-result-pairing.js";
 import { isThinkingLikeBlock } from "./thinking-block.js";
@@ -180,6 +180,14 @@ function hasSessionsSpawnAttachmentToolCall(content: unknown[]): boolean {
     }
   }
   return false;
+}
+
+function makeMissingToolResult(params: {
+  toolCallId: string;
+  toolName?: string;
+  text?: string;
+}): Extract<AgentMessage, { role: "toolResult" }> {
+  return makePairingMissingToolResult(params);
 }
 
 export { makeMissingToolResult };

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -1,8 +1,8 @@
 import type { AgentMessage } from "@openclaw/agent-core";
 import {
-  extractToolCallsFromAssistant,
-  extractToolResultId,
-  extractToolResultIds,
+  extractToolCallsFromAssistant as extractPairingToolCalls,
+  extractToolResultId as extractPairingToolResultId,
+  extractToolResultIds as extractPairingToolResultIds,
 } from "../../packages/agent-core/src/harness/session/tool-result-pairing.js";
 /**
  * Tool call id normalization and extraction helpers.
@@ -20,6 +20,11 @@ const OPENAI_TOOL_CALL_ID_RE = /^call_[A-Za-z0-9_-]+$/;
 
 const STRICT9_LEN = 9;
 const TOOL_CALL_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
+
+type ToolCallLike = {
+  id: string;
+  name?: string;
+};
 
 type ReplaySafeToolCallBlock = {
   type?: unknown;
@@ -63,7 +68,21 @@ function sanitizeToolCallId(id: string, mode: ToolCallIdMode = "strict"): string
   return alphanumericOnly.length > 0 ? alphanumericOnly : "sanitizedtoolid";
 }
 
-export { extractToolCallsFromAssistant, extractToolResultId, extractToolResultIds };
+export function extractToolCallsFromAssistant(
+  msg: Extract<AgentMessage, { role: "assistant" }>,
+): ToolCallLike[] {
+  return extractPairingToolCalls(msg);
+}
+
+export function extractToolResultId(
+  msg: Extract<AgentMessage, { role: "toolResult" }>,
+): string | null {
+  return extractPairingToolResultId(msg);
+}
+
+export function extractToolResultIds(msg: Extract<AgentMessage, { role: "toolResult" }>): string[] {
+  return extractPairingToolResultIds(msg);
+}
 
 function hasToolCallInput(block: ReplaySafeToolCallBlock): boolean {
   const hasInput = "input" in block ? block.input !== undefined && block.input !== null : false;

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -1,4 +1,9 @@
 import type { AgentMessage } from "@openclaw/agent-core";
+import {
+  extractToolCallsFromAssistant,
+  extractToolResultId,
+  extractToolResultIds,
+} from "../../packages/agent-core/src/harness/session/tool-result-pairing.js";
 /**
  * Tool call id normalization and extraction helpers.
  *
@@ -15,11 +20,6 @@ const OPENAI_TOOL_CALL_ID_RE = /^call_[A-Za-z0-9_-]+$/;
 
 const STRICT9_LEN = 9;
 const TOOL_CALL_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
-
-type ToolCallLike = {
-  id: string;
-  name?: string;
-};
 
 type ReplaySafeToolCallBlock = {
   type?: unknown;
@@ -63,67 +63,7 @@ function sanitizeToolCallId(id: string, mode: ToolCallIdMode = "strict"): string
   return alphanumericOnly.length > 0 ? alphanumericOnly : "sanitizedtoolid";
 }
 
-export function extractToolCallsFromAssistant(
-  msg: Extract<AgentMessage, { role: "assistant" }>,
-): ToolCallLike[] {
-  const content = msg.content;
-  if (!Array.isArray(content)) {
-    return [];
-  }
-
-  const toolCalls: ToolCallLike[] = [];
-  for (const block of content) {
-    if (!block || typeof block !== "object") {
-      continue;
-    }
-    const rec = block as { type?: unknown; id?: unknown; name?: unknown };
-    if (typeof rec.id !== "string" || !rec.id) {
-      continue;
-    }
-    if (typeof rec.type === "string" && TOOL_CALL_TYPES.has(rec.type)) {
-      toolCalls.push({
-        id: rec.id,
-        name: typeof rec.name === "string" ? rec.name : undefined,
-      });
-    }
-  }
-  return toolCalls;
-}
-
-export function extractToolResultId(
-  msg: Extract<AgentMessage, { role: "toolResult" }>,
-): string | null {
-  return extractToolResultIds(msg)[0] ?? null;
-}
-
-export function extractToolResultIds(msg: Extract<AgentMessage, { role: "toolResult" }>): string[] {
-  const ids: string[] = [];
-  const record = msg as {
-    toolCallId?: unknown;
-    toolUseId?: unknown;
-    tool_call_id?: unknown;
-    tool_use_id?: unknown;
-    callId?: unknown;
-    call_id?: unknown;
-  };
-  for (const value of [
-    record.toolCallId,
-    record.toolUseId,
-    record.tool_call_id,
-    record.tool_use_id,
-    record.callId,
-    record.call_id,
-  ]) {
-    if (typeof value !== "string") {
-      continue;
-    }
-    const id = value.trim();
-    if (id && !ids.includes(id)) {
-      ids.push(id);
-    }
-  }
-  return ids;
-}
+export { extractToolCallsFromAssistant, extractToolResultId, extractToolResultIds };
 
 function hasToolCallInput(block: ReplaySafeToolCallBlock): boolean {
   const hasInput = "input" in block ? block.input !== undefined && block.input !== null : false;


### PR DESCRIPTION
Closes #116588
Supersedes #119943 while preserving the original contribution and author credit.

## What Problem This Solves

Fixes an issue where sessions reset with a retained assistant tool call would silently lose its real tool result from the next model turn and later compaction. The resulting incomplete history could cause OpenClaw to fabricate a missing-result error even though the original output remained persisted.

## Why This Change Was Made

Reset replay, compaction, and transcript repair now share one occurrence-aware call/result classifier. It keeps locally paired results, accepts a displaced result only when exactly one unresolved call can own it, and drops ambiguous extras instead of guessing. Compaction chunking uses the same occurrence queue so repeated provider IDs remain atomic.

The projection retains original result objects in deterministic branch order. It does not rewrite SQLite rows, serialized transcript shapes, IDs, or existing session bytes; UI/history projections remain unchanged.

Root cause: the user/assistant-only cross-log reset filter introduced in #112988 was later reused for model-context replay, where tool results are required. The canonical occurrence behavior introduced in #110518 remained correct but ran after the real results had already been dropped.

## User Impact

After a session reset, real tool outputs remain available to the model and to later compaction. Sessions with repeated provider-generated call IDs no longer lose outputs or summarize an ambiguous extra result.

## Evidence

- Before fix: the focused reset replay regression returned `user, assistant, assistant, user`, dropping both real results.
- After fix: reset replay retains both results by occurrence, excludes the third same-ID orphan, preserves original result identity/order, and accepts only uniquely attributable displaced results.
- Focused exact-head proof: 4 Vitest shards, 6 files, 154 tests passed.
- `oxfmt --check` passed for all 9 changed files.
- Fresh branch autoreview: clean, no accepted/actionable findings.
- Hosted changed-check attempts did not execute repository checks: the Daytona fallback failed during sync finalization, then all backends were temporarily unavailable. Exact-head pull-request CI is the authoritative heavy gate.
- Plugin SDK API baseline check passes with the generated manifest unchanged; typed wrappers preserve the historical public declarations.
- Production LOC: +414/-348 (net +66), justified by moving canonical occurrence pairing into the agent-core owner and deleting duplicate repair/extraction policy. Tests: +227/-0.

Dependency contract checked directly: Codex history normalization requires a matching output for every call and removes orphan outputs (`codex-rs/core/src/context_manager/history.rs`, `codex-rs/core/src/context_manager/normalize.rs`); OpenClaw retains its stricter occurrence-aware handling for provider IDs that may repeat across turns.
