### PR TITLE
fix(qqbot): keep connections alive after malformed gateway hello

### DIFF
--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -9,7 +9,7 @@ import { flushKnownUsers } from "../session/known-users.js";
 import { GatewayEvent, GatewayOp, MAX_RECONNECT_ATTEMPTS } from "./constants.js";
 import { GatewayConnection } from "./gateway-connection.js";
 import { QQBotIngressAdmissionError, type QQBotIngressMonitor } from "./ingress.js";
-import type { GatewayAccount, GatewayPluginRuntime } from "./types.js";
+import type { EngineLogger, GatewayAccount, GatewayPluginRuntime } from "./types.js";
 
 const createQQWSClientMock = vi.hoisted(() => vi.fn());
 
@@ -71,6 +71,7 @@ function makeAccount(): GatewayAccount {
 }
 
 async function startConnection(params: {
+  log?: EngineLogger;
   onDisconnected?: (info: unknown) => void;
   onError?: (error: Error) => void;
   createIngressMonitor?: () => QQBotIngressMonitor;
@@ -84,6 +85,7 @@ async function startConnection(params: {
     cfg: {},
     runtime: {} as GatewayPluginRuntime,
     adapters: {} as EngineAdapters,
+    log: params.log,
     handleMessage: async () => {},
     createIngressMonitor: createNoopIngressMonitor,
     ...(params.createIngressMonitor ? { createIngressMonitor: params.createIngressMonitor } : {}),
@@ -524,6 +526,42 @@ describe("GatewayConnection heartbeat liveness", () => {
     ws.emit("message", JSON.stringify({ op: GatewayOp.HEARTBEAT_ACK }));
     await vi.advanceTimersByTimeAsync(10_000); // tick 2: pre-send 0 < 2 → send (outstanding=1)
     await vi.advanceTimersByTimeAsync(10_000); // tick 3: pre-send 1 < 2 → send (outstanding=2)
+    expect(ws.terminate).not.toHaveBeenCalled();
+    controller.abort();
+    await started;
+  });
+
+  it.each([
+    ["missing", { op: GatewayOp.HELLO }],
+    ["null", { op: GatewayOp.HELLO, d: null }],
+    ["array", { op: GatewayOp.HELLO, d: [] }],
+    ["object", { op: GatewayOp.HELLO, d: {} }],
+    [
+      "non-stringifiable interval",
+      {
+        op: GatewayOp.HELLO,
+        d: { heartbeat_interval: { toString: null, valueOf: null } },
+      },
+    ],
+  ])("uses the fallback heartbeat for a %s HELLO body", async (_case, payload) => {
+    const error = vi.fn();
+    const { ws, controller, started } = await startConnection({
+      log: { info: vi.fn(), error },
+    });
+    ws.readyState = 1; // OPEN
+    ws.emit("open");
+
+    ws.emit("message", JSON.stringify(payload));
+    await vi.advanceTimersByTimeAsync(44_999);
+
+    expect(ws.send).not.toHaveBeenCalledWith(expect.stringContaining('"op":1'));
+    expect(ws.terminate).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledExactlyOnceWith(
+      "Invalid QQ gateway HELLO heartbeat interval; using default 45000ms",
+    );
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"op":1'));
     expect(ws.terminate).not.toHaveBeenCalled();
     controller.abort();
     await started;

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -1,4 +1,6 @@
 // Qqbot plugin module implements gateway connection behavior.
+import { asSafeIntegerInRange, MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import WebSocket from "ws";
 import type { EngineAdapters } from "../adapter/index.js";
 import {
@@ -38,6 +40,9 @@ import type {
   WSPayload,
 } from "./types.js";
 import { createQQWSClient } from "./ws-client.js";
+
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 45_000;
+const MIN_HEARTBEAT_INTERVAL_MS = 1_000;
 
 interface GatewayConnectionContext {
   account: GatewayAccount;
@@ -470,6 +475,20 @@ export class GatewayConnection {
   // ============ Protocol handlers ============
 
   private handleHello(ws: WebSocket, d: unknown, accessToken: string): void {
+    const hello = asOptionalRecord(d) ?? {};
+    const receivedInterval = asSafeIntegerInRange(hello.heartbeat_interval, {
+      min: MIN_HEARTBEAT_INTERVAL_MS,
+      max: MAX_TIMER_TIMEOUT_MS,
+    });
+    if (receivedInterval === undefined) {
+      // Do not interpolate hostile input here: diagnostics must not throw while
+      // recovering the heartbeat schedule from a malformed gateway frame.
+      this.ctx.log?.error(
+        `Invalid QQ gateway HELLO heartbeat interval; using default ${DEFAULT_HEARTBEAT_INTERVAL_MS}ms`,
+      );
+    }
+    const interval = receivedInterval ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+
     if (this.sessionId && this.lastSeq !== null) {
       ws.send(
         JSON.stringify({
@@ -494,7 +513,6 @@ export class GatewayConnection {
       );
     }
 
-    const interval = (d as { heartbeat_interval: number }).heartbeat_interval;
     if (this.heartbeatInterval) {
       clearInterval(this.heartbeatInterval);
     }


### PR DESCRIPTION
Supersedes #120279.

## What Problem This Solves

Fixes an issue where a malformed QQ gateway HELLO body could either throw before heartbeat recovery or schedule an invalid heartbeat interval. Missing, null, array, empty-object, and hostile interval values could leave the socket without a valid liveness schedule or trigger Node's 1 ms timer coercion.

## Why This Change Was Made

The QQ transport now normalizes HELLO data with the plugin SDK's canonical non-array record guard before reading `heartbeat_interval`, accepts only timer-safe integer intervals, and falls back to 45 seconds otherwise. The diagnostic is fixed text and never interpolates the hostile value, so reporting the recovery cannot itself throw.

This stays inside the QQ channel plugin and preserves the existing IDENTIFY/RESUME and heartbeat-ACK watchdog flow. It also removes the need for the exported test helper and Knip exception proposed in #120279. Contributor credit is preserved in the commit.

## User Impact

QQ connections receiving malformed HELLO frames keep a safe heartbeat schedule instead of silently stalling, busy-looping, or failing while formatting diagnostics. Valid gateway intervals remain unchanged.

## Evidence

- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/gateway/gateway-connection.test.ts` — 19/19 passed on the rebased head. The table-driven socket-message-path regression covers missing, null, array, empty-object, and non-stringifiable interval bodies.
- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check` — passed (`OK docs/.generated/plugin-sdk-api-baseline.sha256`).
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean, no accepted/actionable findings.
- Exact-head hosted CI — passed at https://github.com/openclaw/openclaw/actions/runs/31308522290 for `3e1c2137ab5b8cd919b0bc1fcfccfae7139e2975`.
- The changed gate passed conflict, format, contract, Plugin SDK baseline, boundary, dependency, patch, and dead-code checks. Its local fallback later reported an untouched `packages/terminal-core/src/ansi.ts` type error; an isolated current-main retry could not start before the shared heavy-check lock timed out. Exact-head hosted CI subsequently passed the full selected graph.

No live QQ credentials were available. This is not live-channel proof. Per the maintainer-authorized proof boundary for this transport parser repair, unit-level hostile-input coverage at the real socket message/HELLO scheduling seam is sufficient.

Production LOC: +19/-1 (net +18). Tests: +39/-1 (net +38). The production growth establishes the network-input validation and timer-safety ownership boundary.
