### PR TITLE
fix: compaction leaves CLI-backed sessions resuming the pre-compaction history

### DIFF
--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -337,6 +337,9 @@ export const handleCompactCommand: CommandHandler = async (params) => {
       // Update token counts after compaction
       tokensAfter: result.result?.tokensAfter,
       newSessionId: result.result?.sessionId,
+      // The compacted transcript is the new starting point; resuming a CLI
+      // backend session would replay the pre-compaction history instead.
+      clearCliSessions: true,
     });
   }
   // Use the post-compaction token count for context summary if available

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -510,6 +510,53 @@ describe("incrementCompactionCount", () => {
     ).toBe(3);
   });
 
+  it("releases CLI backend session bindings when the caller compacted the transcript", async () => {
+    const entry = {
+      sessionId: "s1",
+      updatedAt: Date.now(),
+      compactionCount: 0,
+      cliSessionIds: { "claude-cli": "backend-session-1" },
+      cliSessionBindings: { "claude-cli": { sessionId: "backend-session-1" } },
+      claudeCliSessionId: "backend-session-1",
+    } as unknown as SessionEntry;
+    const { storePath, sessionKey, sessionStore } = await createCompactionSessionFixture(entry);
+
+    await incrementCompactionCount({
+      sessionEntry: entry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      clearCliSessions: true,
+    });
+
+    const stored = await loadStoredEntry(storePath, sessionKey);
+    expect(stored.compactionCount).toBe(1);
+    expect(stored.cliSessionIds).toBeUndefined();
+    expect(stored.cliSessionBindings).toBeUndefined();
+    expect(stored.claudeCliSessionId).toBeUndefined();
+  });
+
+  it("keeps CLI backend session bindings for callers that rebind them", async () => {
+    const entry = {
+      sessionId: "s1",
+      updatedAt: Date.now(),
+      compactionCount: 0,
+      cliSessionIds: { "claude-cli": "backend-session-1" },
+    } as unknown as SessionEntry;
+    const { storePath, sessionKey, sessionStore } = await createCompactionSessionFixture(entry);
+
+    await incrementCompactionCount({
+      sessionEntry: entry,
+      sessionStore,
+      sessionKey,
+      storePath,
+    });
+
+    const stored = await loadStoredEntry(storePath, sessionKey);
+    expect(stored.compactionCount).toBe(1);
+    expect(stored.cliSessionIds).toEqual({ "claude-cli": "backend-session-1" });
+  });
+
   it("persists incognito compaction metadata only in the scoped store", async () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-incognito-compact-"));
     tempDirs.push(tmp);

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -1,6 +1,7 @@
 /** Session update helpers for skill snapshots, compaction, and lifecycle hooks. */
 import crypto from "node:crypto";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { clearAllCliSessions } from "../../agents/cli-session.js";
 import {
   type ExecPolicyOverrides,
   resolveNodeExecEligibility,
@@ -322,6 +323,13 @@ export async function incrementCompactionCount(params: {
   tokensAfter?: number;
   /** Session id after compaction when a context engine changed identity. */
   newSessionId?: string;
+  /**
+   * Release every CLI backend session binding. Callers that compacted the
+   * OpenClaw transcript set this so the next turn reseeds from the compacted
+   * transcript instead of resuming the backend's uncompacted session. Callers
+   * that rebind to a new backend session themselves must leave it unset.
+   */
+  clearCliSessions?: boolean;
 }): Promise<number | undefined> {
   const {
     agentId,
@@ -334,6 +342,7 @@ export async function incrementCompactionCount(params: {
     amount = 1,
     tokensAfter,
     newSessionId,
+    clearCliSessions,
   } = params;
   if (!sessionStore || !sessionKey) {
     return undefined;
@@ -349,6 +358,9 @@ export async function incrementCompactionCount(params: {
     compactionCount: nextCount,
     updatedAt: now,
   };
+  if (clearCliSessions) {
+    clearAllCliSessions(updates);
+  }
   const sessionIdChanged = Boolean(newSessionId && newSessionId !== entry.sessionId);
   if (sessionIdChanged && newSessionId) {
     updates.sessionId = newSessionId;

--- a/src/gateway/server-methods/sessions-compact.ts
+++ b/src/gateway/server-methods/sessions-compact.ts
@@ -309,6 +309,29 @@ export const sessionCompactHandlers: GatewayRequestHandlers = {
               },
               { maxLines },
             );
+            if (trimResult.compacted) {
+              // Trimming rewrites the transcript, so a resumed CLI backend
+              // session would replay the history that was just removed.
+              await applySessionPatchProjection({
+                agentId: target.agentId,
+                storePath,
+                resolveTarget: () => ({ primaryKey: compactTarget.primaryKey }),
+                project: ({ existingEntry }) => {
+                  if (
+                    !existingEntry ||
+                    existingEntry.sessionId !== sessionId ||
+                    existingEntry.lifecycleRevision !== lifecycleRevision
+                  ) {
+                    // The row belongs to a session generation this trim no
+                    // longer owns; its bindings are not ours to release.
+                    return { ok: false };
+                  }
+                  existingEntry.updatedAt = Date.now();
+                  clearAllCliSessions(existingEntry);
+                  return { ok: true, entry: existingEntry };
+                },
+              });
+            }
             respond(
               true,
               {

--- a/src/gateway/server-methods/sessions-compact.ts
+++ b/src/gateway/server-methods/sessions-compact.ts
@@ -6,6 +6,7 @@ import {
   validateSessionsCompactParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { clearAllCliSessions } from "../../agents/cli-session.js";
 import { resolveEmbeddedSessionLane } from "../../agents/embedded-agent-runner/lanes.js";
 import { hasPendingFollowupQueueWork } from "../../auto-reply/reply/queue/state.js";
 import {
@@ -418,6 +419,11 @@ export const sessionCompactHandlers: GatewayRequestHandlers = {
                   entryToUpdate.updatedAt = Date.now();
                   entryToUpdate.compactionCount =
                     Math.max(0, entryToUpdate.compactionCount ?? 0) + 1;
+                  // Every CLI backend session predates the compacted transcript, so
+                  // none of them may be resumed. Bindings are keyed by backend id
+                  // (claude-cli), not by the session's resolved provider (anthropic),
+                  // so releasing them cannot be scoped to the compaction provider.
+                  clearAllCliSessions(entryToUpdate);
                   if (
                     result.result?.sessionId &&
                     result.result.sessionId !== entryToUpdate.sessionId

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -893,6 +893,50 @@ test("sessions.compact records terminal Codex native compaction", async () => {
   ws.close();
 });
 
+test("sessions.compact releases CLI backend session bindings", async () => {
+  const { storePath } = await createSessionStoreDir();
+  await seedSessionEntry({
+    entry: sessionStoreEntry("sess-cli-bound", {
+      agentHarnessId: "claude",
+      cliSessionIds: { "claude-cli": "backend-session-1" },
+      cliSessionBindings: { "claude-cli": { sessionId: "backend-session-1" } },
+      claudeCliSessionId: "backend-session-1",
+    }),
+    sessionKey: "agent:main:main",
+    storePath,
+  });
+  await seedTranscriptRows({
+    sessionId: "sess-cli-bound",
+    sessionKey: "agent:main:main",
+    storePath,
+    totalLines: 2,
+  });
+  embeddedRunMock.compactEmbeddedAgentSession.mockResolvedValueOnce({
+    ok: true,
+    compacted: true,
+    result: { summary: "summary", firstKeptEntryId: "entry-0", tokensBefore: 120, tokensAfter: 80 },
+  });
+
+  const { ws } = await openClient();
+  const compacted = await rpcReq<{ ok: true; key: string; compacted: boolean }>(
+    ws,
+    "sessions.compact",
+    { key: "main" },
+  );
+
+  expectMainCompactionResult(compacted, true);
+  // The bindings are keyed by backend id, so a compaction that summarizes the
+  // OpenClaw transcript must release them or the next turn resumes the
+  // backend's uncompacted session and the compaction is invisible to the model.
+  const boundEntry = loadSessionEntry({ sessionKey: "agent:main:main", storePath });
+  expect(boundEntry?.compactionCount).toBe(1);
+  expect(boundEntry?.cliSessionIds).toBeUndefined();
+  expect(boundEntry?.cliSessionBindings).toBeUndefined();
+  expect(boundEntry?.claudeCliSessionId).toBeUndefined();
+
+  ws.close();
+});
+
 test("sessions.compact emits a terminal operation event when persistence fails", async () => {
   const { storePath } = await createSessionStoreDir();
   const sessionId = "sess-compact-write-failure";

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -1689,6 +1689,43 @@ test("sessions.patch rejects archive while terminal compaction owns the session"
   ws.close();
 });
 
+test("sessions.compact maxLines releases CLI backend session bindings", async () => {
+  const { storePath } = await createSessionStoreDir();
+  await seedSessionEntry({
+    entry: sessionStoreEntry("sess-trim-bound", {
+      agentHarnessId: "claude",
+      cliSessionIds: { "claude-cli": "backend-session-1" },
+      cliSessionBindings: { "claude-cli": { sessionId: "backend-session-1" } },
+      claudeCliSessionId: "backend-session-1",
+    }),
+    sessionKey: "agent:main:main",
+    storePath,
+  });
+  await seedTranscriptRows({
+    sessionId: "sess-trim-bound",
+    sessionKey: "agent:main:main",
+    storePath,
+    totalLines: 200,
+  });
+
+  const { ws } = await openClient();
+  const compacted = await rpcReq<{ ok: true; compacted: boolean; kept?: number }>(
+    ws,
+    "sessions.compact",
+    { key: "main", maxLines: 20 },
+  );
+
+  expect(compacted.payload?.compacted).toBe(true);
+  // Trimming removes transcript rows the backend session still holds, so
+  // resuming that session would replay exactly what was just trimmed away.
+  const trimmedEntry = loadSessionEntry({ sessionKey: "agent:main:main", storePath });
+  expect(trimmedEntry?.cliSessionIds).toBeUndefined();
+  expect(trimmedEntry?.cliSessionBindings).toBeUndefined();
+  expect(trimmedEntry?.claudeCliSessionId).toBeUndefined();
+
+  ws.close();
+});
+
 test("sessions.compact maxLines trims SQLite transcript rows and archives the full pre-compaction transcript", async () => {
   const { dir, storePath } = await createSessionStoreDir();
   await seedSessionEntry({


### PR DESCRIPTION
Closes #121040

AI-assisted (Claude, via OpenClaw). I understand what the code does and validated it as described below.

## What Problem This Solves

Fixes an issue where users who compact a session that runs through a CLI backend (Claude Code via `claude-cli`) would see no reduction in the context that reaches the model. `/compact`, `openclaw sessions compact`, and the Control UI compaction action all report success and increment the compaction count, but the very next turn resumes the backend session that still holds the entire pre-compaction conversation.

Measured on two independent sessions: the bound `claude-cli` session id was unchanged across the compaction and the provider prompt grew straight through it — 190,240 → 248,847 → 249,777 tokens on one, 790,148 → 794,226 → 799,448 on the other. Across the same store, of 347 compacted sessions the 346 compacted by the automatic mid-turn path held no CLI binding; the ones still bound were exactly the manually compacted ones.

## Why This Change Was Made

The automatic mid-turn path finishes through `recordCliCompactionInStore`, which releases the binding. The `sessions.compact` RPC and the `/compact` command each perform their own post-compaction bookkeeping and did not. Both now release every CLI session binding on the persisted entry.

Two decisions worth flagging for review:

- **The release is not scoped to a provider id.** Bindings are keyed by backend id (`claude-cli`) while the session's model ref reports the model provider (`anthropic`). Replaying a provider-scoped release over the 81 stored entries that held a binding fired on 14 and silently did nothing on the other 67. After a compaction every backend session predates the new transcript, so none of them may be resumed.
- **`incrementCompactionCount` gained an opt-in flag rather than clearing unconditionally.** Its other callers (native-harness compaction) deliberately rebind to a new backend session and rely on it leaving bindings alone.

Non-goal: nothing changes for sessions with no CLI binding, and the automatic path is untouched.

## User Impact

Manual compaction now actually shrinks the model's context for CLI-backed sessions. The next turn after `/compact` or `sessions.compact` reseeds from the compacted transcript instead of resuming the uncompacted backend session, so token cost, latency, and context-limit pressure drop as users already expect them to.

## Evidence

Two focused regression tests, each verified red before the fix and green after:

- `src/gateway/server.sessions.compaction.test.ts` — `sessions.compact releases CLI backend session bindings`: seeds a session holding `cliSessionIds` / `cliSessionBindings` / `claudeCliSessionId`, drives the real RPC handler, and asserts the compaction count advanced and every binding is gone.
  - without the fix: `× sessions.compact releases CLI backend session bindings` (1 failed | 24 passed)
  - with the fix: `Test Files 1 passed (1) / Tests 25 passed (25)`
- `src/auto-reply/reply/reply-state.test.ts` — two cases: the opt-in clears all three binding fields from the persisted entry; the default leaves them untouched for the rebinding callers.
  - without the fix: `× releases CLI backend session bindings when the caller compacted the transcript` (1 failed | 38 passed)
  - with the fix: `Tests 39 passed (39)`

Wider lanes, all green:

```
node --import tsx scripts/test-projects.mts src/auto-reply/reply/commands-compact.test.ts \
  src/auto-reply/reply/session-updates.test.ts \
  src/auto-reply/reply/session-updates.lifecycle.test.ts \
  src/agents/embedded-agent-subscribe.handlers.compaction.test.ts \
  src/plugins/wired-hooks-compaction.test.ts
[test] passed 3 Vitest shards in 43.80s
```

`pnpm tsgo:core`, `pnpm tsgo:core:test`, `oxlint`, and `oxfmt --check` are clean on the changed files.

## Review follow-up (ac0fc02e)

Codex flagged that `sessions.compact` with `maxLines` returns on its own path before the compaction projection. Confirmed: the trimmed rows are exactly the history the bound backend session still holds, so that documented mode showed the same defect. The successful trim path now releases the bindings too, under the same session-id and lifecycle-revision ownership guard, before the response is sent.

Added `sessions.compact maxLines releases CLI backend session bindings`:

- without the trim fix: `× sessions.compact maxLines releases CLI backend session bindings` (1 failed | 25 passed)
- with it: `Test Files 1 passed (1) / Tests 26 passed (26)`

Wider re-run after the change:

```
node --import tsx scripts/test-projects.mts src/gateway/server.sessions.compaction.test.ts \
  src/gateway/server.sessions.store-rpc.test.ts src/gateway/server.sessions.list-changed.test.ts \
  src/commands/sessions-compact.test.ts src/auto-reply/reply/commands-compact.test.ts \
  src/auto-reply/reply/reply-state.test.ts
[test] passed 3 Vitest shards — 71 + 26 tests, all green
```

`pnpm tsgo:core`, `pnpm tsgo:core:test`, `oxlint` and `oxfmt --check` clean.


### Stored-data-model compatibility

The persisted change is subtractive: it removes `cliSessionIds`, `cliSessionBindings` and `claudeCliSessionId` from a session entry. All three are already optional, no field is added or retyped, and no migration is involved. An older build reading a post-compaction entry simply sees no CLI binding and starts a fresh backend session, which is the same state a session reset produces — so a downgrade is safe. `clearAllCliSessions` is the existing helper used by the reset and automatic-compaction paths; this PR adds callers, not a new representation.

### Live after-fix run

Observed on a restarted Gateway carrying the equivalent patch, on a disposable CLI-backed session (`claude-cli`, Opus 5) driven through three real turns.

Summary compaction, `sessions.compact` over the Gateway RPC:

```
=== BEFORE ===
{ "sessionId": "8e8ec554-...", "claudeCliSessionId": "ac96b92a-eb99-4beb-adba-bf9da73bde3b", "totalTokens": 39214 }

=== sessions.compact ===
{ "ok": true, "compacted": true, "result": { "sessionId": "c0ac10ec-...", ... } }

=== AFTER compaction, before the next turn ===
{ "sessionId": "c0ac10ec-...", "compactionCount": 1 }            # no CLI binding

=== AFTER one post-compaction turn ===
{ "sessionId": "c0ac10ec-...", "compactionCount": 1,
  "claudeCliSessionId": "4b0ae21b-9c39-4d86-9c6a-0d8f1a31d380" } # fresh backend session
```

The binding is gone the moment compaction persists, and the next turn opens a **different** backend session (`ac96b92a…` → `4b0ae21b…`) instead of resuming the pre-compaction one. That is the behavior the fix exists for.

The `maxLines` path, same build, separate disposable CLI-bound session:

```
before:  cliSessionIds { "claude-cli": "d38cd666-..." }, cliSessionBindings, claudeCliSessionId all present
run:     openclaw sessions compact <key> --max-lines 2  ->  { "ok": true, "compacted": true, "kept": 2 }
after:   { "sessionId": "3e7f30f9-..." }                     # all three binding fields gone
store:   entries holding a CLI binding 77 -> 76              # only the target session changed
```

One honest limit on this evidence: both probe sessions carry a small transcript against a ~39k-token system prompt, so the *prompt-size* signal is not meaningful at this scale (39,214 → 39,793 tokens, i.e. noise). The fresh-backend-session identity is the load-bearing observation; the large-session prompt growth quoted earlier is the pre-fix side of the same defect.


