### PR TITLE
fix: a timed-out exec leaves its child's forked processes running forever

### DIFF
--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -6,8 +6,6 @@ const DEFAULT_GRACE_MS = 3000;
 const MAX_GRACE_MS = 60_000;
 const TASKKILL_COMPLETION_TIMEOUT_MS = 3000;
 const PS_TIMEOUT_MS = 500;
-/** Long enough to cover the longest grace period, short enough to forget stale trees. */
-const TRACKED_DESCENDANT_TTL_MS = MAX_GRACE_MS * 2;
 
 export type KillProcessTreeOptions = {
   graceMs?: number;
@@ -55,7 +53,7 @@ export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): voi
   }
 
   const graceMs = normalizeGraceMs(opts?.graceMs);
-  signalProcessTreeUnix(pid, "SIGTERM", useGroupKill);
+  const tracked = signalProcessTreeUnix(pid, "SIGTERM", useGroupKill);
   setTimeout(() => {
     if (useGroupKill) {
       if (isProcessAlive(-pid) || isProcessAlive(pid)) {
@@ -65,7 +63,7 @@ export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): voi
     }
     // A descendant that ignored SIGTERM outlives a root that did not, so the
     // root's own liveness cannot decide whether the tree still needs killing.
-    const { tableAvailable, descendants, rootIdentity } = resolveTrackedUnixTree(pid);
+    const { tableAvailable, descendants, rootIdentity } = resolveUnixTree(pid, tracked);
     if (!tableAvailable) {
       // Nothing can be enumerated on this host; degrade to the direct-PID
       // escalation this function performed before descendants were tracked.
@@ -301,28 +299,19 @@ function collectDescendants(
 }
 
 /**
- * Descendants seen for a root PID during its termination sequence. SIGTERM can
- * end the root while a descendant ignores it; that descendant is reparented to
- * init and can no longer be found from the root, so the force phase would have
- * nothing to signal without this.
+ * What one termination sequence remembers about the tree it signaled. SIGTERM
+ * can end the root while a descendant ignores it; that descendant is reparented
+ * to init and can no longer be found from the root, so the force phase would
+ * have nothing to signal without this. It belongs to the sequence and dies with
+ * it: a PID the kernel hands to an unrelated process later carries no memory of
+ * the tree that used it before.
  */
-const trackedTreeDescendants = new Map<
-  number,
-  { rootStartToken: string; entries: Array<{ pid: number; startToken: string }>; atMs: number }
->();
-
-function pruneTrackedTreeDescendants(nowMs: number): void {
-  for (const [root, tracked] of trackedTreeDescendants) {
-    if (nowMs - tracked.atMs > TRACKED_DESCENDANT_TTL_MS) {
-      trackedTreeDescendants.delete(root);
-    }
-  }
-}
+type TrackedTree = { rootStartToken: string; entries: Array<{ pid: number; startToken: string }> };
 
 /**
  * Live descendants of a PID that does not lead its own process group: the ones
- * visible now, plus the ones seen earlier in this termination sequence that are
- * still provably the same process.
+ * visible now, plus the ones this sequence signaled earlier that are still
+ * provably the same process.
  *
  * `tableAvailable` distinguishes "this host cannot enumerate processes" from
  * "the tree is empty"; the caller must not read the latter into the former, or
@@ -332,18 +321,19 @@ function pruneTrackedTreeDescendants(nowMs: number): void {
  * and treating two empty tokens as a match would let a recycled PID inherit a
  * pending SIGKILL.
  */
-function resolveTrackedUnixTree(pid: number): {
+function resolveUnixTree(
+  pid: number,
+  tracked: TrackedTree | undefined,
+): {
   tableAvailable: boolean;
   descendants: number[];
   rootIdentity: "same" | "changed" | "unknown";
+  tracked: TrackedTree | undefined;
 } {
-  const nowMs = Date.now();
-  pruneTrackedTreeDescendants(nowMs);
   const table = readProcessTable();
   if (!table) {
-    return { tableAvailable: false, descendants: [], rootIdentity: "unknown" };
+    return { tableAvailable: false, descendants: [], rootIdentity: "unknown", tracked };
   }
-  const tracked = trackedTreeDescendants.get(pid);
   const rootStartToken = table.get(pid)?.startToken;
   const trackedRootToken = tracked?.rootStartToken ?? "";
   const rootIdentity: "same" | "changed" | "unknown" =
@@ -354,6 +344,8 @@ function resolveTrackedUnixTree(pid: number): {
         : trackedRootToken === rootStartToken
           ? "same"
           : "changed";
+  // A root that is no longer the process this sequence signaled must not have
+  // its tree traversed: those descendants belong to whoever holds the PID now.
   const discovered = rootIdentity === "changed" ? [] : collectDescendants(pid, table);
   const merged = new Map(discovered.map((entry) => [entry.pid, entry] as const));
   for (const entry of tracked?.entries ?? []) {
@@ -368,19 +360,17 @@ function resolveTrackedUnixTree(pid: number): {
     merged.set(entry.pid, entry);
   }
   const entries = [...merged.values()];
-  // Only identifiable entries are worth remembering: an unidentifiable one
-  // could not be safely signaled later anyway.
-  const retained = entries.filter((entry) => entry.startToken !== "");
-  if (retained.length > 0) {
-    trackedTreeDescendants.set(pid, {
+  return {
+    tableAvailable: true,
+    descendants: entries.map((entry) => entry.pid),
+    rootIdentity,
+    tracked: {
       rootStartToken: tracked?.rootStartToken || (rootStartToken ?? ""),
-      entries: retained,
-      atMs: nowMs,
-    });
-  } else {
-    trackedTreeDescendants.delete(pid);
-  }
-  return { tableAvailable: true, descendants: entries.map((entry) => entry.pid), rootIdentity };
+      // Only identifiable entries are worth remembering: an unidentifiable one
+      // could not be safely signaled later anyway.
+      entries: entries.filter((entry) => entry.startToken !== ""),
+    },
+  };
 }
 
 function signalUnixTargets(pid: number, signal: "SIGTERM" | "SIGKILL", targets: number[]): void {
@@ -399,15 +389,16 @@ function signalUnixTargets(pid: number, signal: "SIGTERM" | "SIGKILL", targets: 
   }
 }
 
+/** Returns what the caller must remember to escalate this same tree later. */
 function signalProcessTreeUnix(
   pid: number,
   signal: "SIGTERM" | "SIGKILL",
   useGroupKill: boolean,
-): void {
+): TrackedTree | undefined {
   if (useGroupKill) {
     try {
       process.kill(-pid, signal);
-      return;
+      return undefined;
     } catch {
       // Process group does not exist or we lack permission; try direct pid.
     }
@@ -417,7 +408,9 @@ function signalProcessTreeUnix(
   // the direct PID alone leaves everything the child forked running, reparented
   // to init with its output already closed, so a timed-out run keeps consuming
   // the machine and can never deliver a result.
-  signalUnixTargets(pid, signal, resolveTrackedUnixTree(pid).descendants);
+  const resolved = resolveUnixTree(pid, undefined);
+  signalUnixTargets(pid, signal, resolved.descendants);
+  return resolved.tracked;
 }
 
 function runTaskkill(args: string[], onExit?: (code: number | null) => void): Promise<void> {

--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -63,7 +63,7 @@ export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): voi
     }
     // A descendant that ignored SIGTERM outlives a root that did not, so the
     // root's own liveness cannot decide whether the tree still needs killing.
-    const { tableAvailable, descendants, rootIdentity } = resolveUnixTree(pid, tracked);
+    const { tableAvailable, descendants, rootIdentity } = resolveUnixTree(pid, tracked, "force");
     if (!tableAvailable) {
       // Nothing can be enumerated on this host; degrade to the direct-PID
       // escalation this function performed before descendants were tracked.
@@ -324,6 +324,7 @@ type TrackedTree = { rootStartToken: string; entries: Array<{ pid: number; start
 function resolveUnixTree(
   pid: number,
   tracked: TrackedTree | undefined,
+  phase: "initial" | "force",
 ): {
   tableAvailable: boolean;
   descendants: number[];
@@ -344,9 +345,13 @@ function resolveUnixTree(
         : trackedRootToken === rootStartToken
           ? "same"
           : "changed";
-  // A root that is no longer the process this sequence signaled must not have
-  // its tree traversed: those descendants belong to whoever holds the PID now.
-  const discovered = rootIdentity === "changed" ? [] : collectDescendants(pid, table);
+  // The tree may only be walked from a root this sequence can vouch for. On the
+  // first pass that is the PID just handed to us; afterwards it must still be
+  // provably the same process. An identity that was never established is not a
+  // licence to traverse — the PID may since have gone to a stranger, and its
+  // children are not ours to kill.
+  const mayTraverseRoot = phase === "initial" || rootIdentity === "same";
+  const discovered = mayTraverseRoot ? collectDescendants(pid, table) : [];
   const merged = new Map(discovered.map((entry) => [entry.pid, entry] as const));
   for (const entry of tracked?.entries ?? []) {
     if (merged.has(entry.pid)) {
@@ -358,6 +363,14 @@ function resolveUnixTree(
       continue;
     }
     merged.set(entry.pid, entry);
+    // A descendant that outlived SIGTERM keeps forking. Those children appear
+    // in no earlier snapshot and cannot be reached from a root that has since
+    // died, so the only way to them is a rescan from the survivor itself.
+    for (const late of collectDescendants(entry.pid, table)) {
+      if (!merged.has(late.pid)) {
+        merged.set(late.pid, late);
+      }
+    }
   }
   const entries = [...merged.values()];
   return {
@@ -408,7 +421,7 @@ function signalProcessTreeUnix(
   // the direct PID alone leaves everything the child forked running, reparented
   // to init with its output already closed, so a timed-out run keeps consuming
   // the machine and can never deliver a result.
-  const resolved = resolveUnixTree(pid, undefined);
+  const resolved = resolveUnixTree(pid, undefined, "initial");
   signalUnixTargets(pid, signal, resolved.descendants);
   return resolved.tracked;
 }

--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -65,10 +65,21 @@ export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): voi
     }
     // A descendant that ignored SIGTERM outlives a root that did not, so the
     // root's own liveness cannot decide whether the tree still needs killing.
-    // The root is signaled again only when it is provably the same process, so
-    // a PID reused during the grace period is never force-killed.
-    const { descendants, rootIsSameProcess } = resolveTrackedUnixTree(pid);
-    if (descendants.length === 0 && !rootIsSameProcess) {
+    const { tableAvailable, descendants, rootIdentity } = resolveTrackedUnixTree(pid);
+    if (!tableAvailable) {
+      // Nothing can be enumerated on this host; degrade to the direct-PID
+      // escalation this function performed before descendants were tracked.
+      if (isProcessAlive(pid)) {
+        signalUnixTargets(pid, "SIGKILL", []);
+      }
+      return;
+    }
+    // The root is re-signaled only when it is provably the same process, or
+    // when no start time is available at all and liveness is the best evidence
+    // there is — never when its identity provably changed.
+    const shouldKillRoot =
+      rootIdentity === "same" || (rootIdentity === "unknown" && isProcessAlive(pid));
+    if (descendants.length === 0 && !shouldKillRoot) {
       return;
     }
     for (const target of descendants) {
@@ -78,7 +89,7 @@ export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): voi
         // Already gone, or not ours to signal.
       }
     }
-    if (rootIsSameProcess) {
+    if (shouldKillRoot) {
       try {
         process.kill(pid, "SIGKILL");
       } catch {
@@ -311,48 +322,65 @@ function pruneTrackedTreeDescendants(nowMs: number): void {
 /**
  * Live descendants of a PID that does not lead its own process group: the ones
  * visible now, plus the ones seen earlier in this termination sequence that are
- * still the same process. A remembered PID whose start token changed has been
- * reused by something unrelated and is never signaled.
+ * still provably the same process.
+ *
+ * `tableAvailable` distinguishes "this host cannot enumerate processes" from
+ * "the tree is empty"; the caller must not read the latter into the former, or
+ * a child that ignored SIGTERM never gets its SIGKILL. Identity is carried by a
+ * start token, and a PID is only re-signaled across the grace window when that
+ * token is non-empty on both sides: some `ps` builds cannot report a start time,
+ * and treating two empty tokens as a match would let a recycled PID inherit a
+ * pending SIGKILL.
  */
 function resolveTrackedUnixTree(pid: number): {
+  tableAvailable: boolean;
   descendants: number[];
-  rootIsSameProcess: boolean;
+  rootIdentity: "same" | "changed" | "unknown";
 } {
   const nowMs = Date.now();
   pruneTrackedTreeDescendants(nowMs);
   const table = readProcessTable();
   if (!table) {
-    return { descendants: [], rootIsSameProcess: false };
+    return { tableAvailable: false, descendants: [], rootIdentity: "unknown" };
   }
   const tracked = trackedTreeDescendants.get(pid);
   const rootStartToken = table.get(pid)?.startToken;
-  const rootIsSameProcess =
-    rootStartToken !== undefined &&
-    (tracked === undefined || tracked.rootStartToken === rootStartToken);
-  const discovered = rootIsSameProcess ? collectDescendants(pid, table) : [];
+  const trackedRootToken = tracked?.rootStartToken ?? "";
+  const rootIdentity: "same" | "changed" | "unknown" =
+    rootStartToken === undefined
+      ? "changed"
+      : rootStartToken === "" || trackedRootToken === ""
+        ? "unknown"
+        : trackedRootToken === rootStartToken
+          ? "same"
+          : "changed";
+  const discovered = rootIdentity === "changed" ? [] : collectDescendants(pid, table);
   const merged = new Map(discovered.map((entry) => [entry.pid, entry] as const));
   for (const entry of tracked?.entries ?? []) {
     if (merged.has(entry.pid)) {
       continue;
     }
     const current = table.get(entry.pid);
-    if (!current || current.startToken !== entry.startToken) {
-      // The PID is gone, or now belongs to an unrelated process.
+    if (!current || !entry.startToken || current.startToken !== entry.startToken) {
+      // Gone, unidentifiable, or now an unrelated process.
       continue;
     }
     merged.set(entry.pid, entry);
   }
   const entries = [...merged.values()];
-  if (entries.length > 0) {
+  // Only identifiable entries are worth remembering: an unidentifiable one
+  // could not be safely signaled later anyway.
+  const retained = entries.filter((entry) => entry.startToken !== "");
+  if (retained.length > 0) {
     trackedTreeDescendants.set(pid, {
-      rootStartToken: tracked?.rootStartToken ?? rootStartToken ?? "",
-      entries,
+      rootStartToken: tracked?.rootStartToken || (rootStartToken ?? ""),
+      entries: retained,
       atMs: nowMs,
     });
   } else {
     trackedTreeDescendants.delete(pid);
   }
-  return { descendants: entries.map((entry) => entry.pid), rootIsSameProcess };
+  return { tableAvailable: true, descendants: entries.map((entry) => entry.pid), rootIdentity };
 }
 
 function signalUnixTargets(pid: number, signal: "SIGTERM" | "SIGKILL", targets: number[]): void {

--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -5,6 +5,9 @@ import { readdirSync, readFileSync } from "node:fs";
 const DEFAULT_GRACE_MS = 3000;
 const MAX_GRACE_MS = 60_000;
 const TASKKILL_COMPLETION_TIMEOUT_MS = 3000;
+const PS_TIMEOUT_MS = 500;
+/** Long enough to cover the longest grace period, short enough to forget stale trees. */
+const TRACKED_DESCENDANT_TTL_MS = MAX_GRACE_MS * 2;
 
 export type KillProcessTreeOptions = {
   graceMs?: number;
@@ -54,13 +57,34 @@ export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): voi
   const graceMs = normalizeGraceMs(opts?.graceMs);
   signalProcessTreeUnix(pid, "SIGTERM", useGroupKill);
   setTimeout(() => {
-    const stillAlive = useGroupKill
-      ? isProcessAlive(-pid) || isProcessAlive(pid)
-      : isProcessAlive(pid);
-    if (!stillAlive) {
+    if (useGroupKill) {
+      if (isProcessAlive(-pid) || isProcessAlive(pid)) {
+        signalProcessTreeUnix(pid, "SIGKILL", useGroupKill);
+      }
       return;
     }
-    signalProcessTreeUnix(pid, "SIGKILL", useGroupKill);
+    // A descendant that ignored SIGTERM outlives a root that did not, so the
+    // root's own liveness cannot decide whether the tree still needs killing.
+    // The root is signaled again only when it is provably the same process, so
+    // a PID reused during the grace period is never force-killed.
+    const { descendants, rootIsSameProcess } = resolveTrackedUnixTree(pid);
+    if (descendants.length === 0 && !rootIsSameProcess) {
+      return;
+    }
+    for (const target of descendants) {
+      try {
+        process.kill(target, "SIGKILL");
+      } catch {
+        // Already gone, or not ours to signal.
+      }
+    }
+    if (rootIsSameProcess) {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // Already gone.
+      }
+    }
   }, graceMs).unref();
 }
 
@@ -150,26 +174,29 @@ function isProcessGroupLeader(pid: number): boolean {
   return pgid === pid;
 }
 
-function parseProcessParentTable(text: string): Map<number, number[]> {
-  const children = new Map<number, number[]>();
-  for (const line of text.split("\n")) {
-    const [pidText, ppidText] = line.trim().split(/\s+/);
-    const pid = Number(pidText);
-    const ppid = Number(ppidText);
-    if (!Number.isSafeInteger(pid) || pid <= 0 || !Number.isSafeInteger(ppid) || ppid <= 0) {
+/** One process, with a start token that distinguishes it from a later PID reuse. */
+type ProcessTableEntry = { ppid: number; startToken: string };
+
+function parseProcessTable(lines: Iterable<string>): Map<number, ProcessTableEntry> {
+  const table = new Map<number, ProcessTableEntry>();
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) {
       continue;
     }
-    const siblings = children.get(ppid);
-    if (siblings) {
-      siblings.push(pid);
-    } else {
-      children.set(ppid, [pid]);
+    const separator = /\s+/;
+    const [pidText, ppidText, ...rest] = trimmed.split(separator);
+    const pid = Number(pidText);
+    const ppid = Number(ppidText);
+    if (!Number.isSafeInteger(pid) || pid <= 0 || !Number.isSafeInteger(ppid) || ppid < 0) {
+      continue;
     }
+    table.set(pid, { ppid, startToken: rest.join(" ") });
   }
-  return children;
+  return table;
 }
 
-function readProcessParentTableFromProc(): Map<number, number[]> | undefined {
+function readProcessTableFromProc(): Map<number, ProcessTableEntry> | undefined {
   try {
     const lines: string[] = [];
     for (const entry of readdirSync("/proc")) {
@@ -182,57 +209,166 @@ function readProcessParentTableFromProc(): Map<number, number[]> | undefined {
         if (commEnd < 0) {
           continue;
         }
-        // After comm: state, ppid. The command name may contain spaces or ')'.
+        // After comm the fields are positional: state, ppid, ... starttime.
+        // The command name may itself contain spaces or ')'.
         const fields = stat
           .slice(commEnd + 1)
           .trim()
           .split(/\s+/);
-        lines.push(`${entry} ${fields[1] ?? ""}`);
+        lines.push(`${entry} ${fields[1] ?? ""} ${fields[19] ?? ""}`);
       } catch {
         // The process exited while the snapshot was being taken.
       }
     }
-    return parseProcessParentTable(lines.join("\n"));
+    return parseProcessTable(lines);
   } catch {
     return undefined;
   }
 }
 
-function readProcessParentTableFromPs(): Map<number, number[]> | undefined {
+function readProcessTableFromPs(): Map<number, ProcessTableEntry> | undefined {
+  // `timeout` alone only signals the child and keeps waiting for it, so a `ps`
+  // that ignores SIGTERM would block this synchronous call indefinitely.
+  const runPs = (format: string) =>
+    spawnSync("ps", ["-eo", format], {
+      encoding: "utf8",
+      killSignal: "SIGKILL",
+      timeout: PS_TIMEOUT_MS,
+    });
   try {
-    const res = spawnSync("ps", ["-eo", "pid=,ppid="], { encoding: "utf8", timeout: 500 });
+    const withStart = runPs("pid=,ppid=,lstart=");
+    const res =
+      !withStart.error && withStart.status === 0 && typeof withStart.stdout === "string"
+        ? withStart
+        : runPs("pid=,ppid=");
     if (res.error || res.status !== 0 || typeof res.stdout !== "string") {
       return undefined;
     }
-    return parseProcessParentTable(res.stdout);
+    return parseProcessTable(res.stdout.split("\n"));
   } catch {
     return undefined;
   }
 }
 
-/** Best-effort descendant snapshot for a PID that does not lead its own group. */
-function collectDescendantPids(pid: number): number[] {
-  const children =
-    (process.platform === "linux" ? readProcessParentTableFromProc() : undefined) ??
-    readProcessParentTableFromPs();
-  if (!children) {
-    return [];
+function readProcessTable(): Map<number, ProcessTableEntry> | undefined {
+  return (
+    (process.platform === "linux" ? readProcessTableFromProc() : undefined) ??
+    readProcessTableFromPs()
+  );
+}
+
+function collectDescendants(
+  pid: number,
+  table: Map<number, ProcessTableEntry>,
+): Array<{ pid: number; startToken: string }> {
+  const children = new Map<number, number[]>();
+  for (const [candidate, entry] of table) {
+    const siblings = children.get(entry.ppid);
+    if (siblings) {
+      siblings.push(candidate);
+    } else {
+      children.set(entry.ppid, [candidate]);
+    }
   }
-  const descendants: number[] = [];
+  const descendants: Array<{ pid: number; startToken: string }> = [];
   const seen = new Set<number>([pid]);
+  // The array iterator walks entries appended during the loop, which keeps this
+  // linear; shift() would make a runaway high-fanout tree quadratic and stall
+  // the caller's event loop while it is being cleaned up.
   const queue = [pid];
-  while (queue.length > 0) {
-    const current = queue.shift() as number;
+  for (const current of queue) {
     for (const child of children.get(current) ?? []) {
       if (seen.has(child)) {
         continue;
       }
       seen.add(child);
-      descendants.push(child);
+      descendants.push({ pid: child, startToken: table.get(child)?.startToken ?? "" });
       queue.push(child);
     }
   }
   return descendants;
+}
+
+/**
+ * Descendants seen for a root PID during its termination sequence. SIGTERM can
+ * end the root while a descendant ignores it; that descendant is reparented to
+ * init and can no longer be found from the root, so the force phase would have
+ * nothing to signal without this.
+ */
+const trackedTreeDescendants = new Map<
+  number,
+  { rootStartToken: string; entries: Array<{ pid: number; startToken: string }>; atMs: number }
+>();
+
+function pruneTrackedTreeDescendants(nowMs: number): void {
+  for (const [root, tracked] of trackedTreeDescendants) {
+    if (nowMs - tracked.atMs > TRACKED_DESCENDANT_TTL_MS) {
+      trackedTreeDescendants.delete(root);
+    }
+  }
+}
+
+/**
+ * Live descendants of a PID that does not lead its own process group: the ones
+ * visible now, plus the ones seen earlier in this termination sequence that are
+ * still the same process. A remembered PID whose start token changed has been
+ * reused by something unrelated and is never signaled.
+ */
+function resolveTrackedUnixTree(pid: number): {
+  descendants: number[];
+  rootIsSameProcess: boolean;
+} {
+  const nowMs = Date.now();
+  pruneTrackedTreeDescendants(nowMs);
+  const table = readProcessTable();
+  if (!table) {
+    return { descendants: [], rootIsSameProcess: false };
+  }
+  const tracked = trackedTreeDescendants.get(pid);
+  const rootStartToken = table.get(pid)?.startToken;
+  const rootIsSameProcess =
+    rootStartToken !== undefined &&
+    (tracked === undefined || tracked.rootStartToken === rootStartToken);
+  const discovered = rootIsSameProcess ? collectDescendants(pid, table) : [];
+  const merged = new Map(discovered.map((entry) => [entry.pid, entry] as const));
+  for (const entry of tracked?.entries ?? []) {
+    if (merged.has(entry.pid)) {
+      continue;
+    }
+    const current = table.get(entry.pid);
+    if (!current || current.startToken !== entry.startToken) {
+      // The PID is gone, or now belongs to an unrelated process.
+      continue;
+    }
+    merged.set(entry.pid, entry);
+  }
+  const entries = [...merged.values()];
+  if (entries.length > 0) {
+    trackedTreeDescendants.set(pid, {
+      rootStartToken: tracked?.rootStartToken ?? rootStartToken ?? "",
+      entries,
+      atMs: nowMs,
+    });
+  } else {
+    trackedTreeDescendants.delete(pid);
+  }
+  return { descendants: entries.map((entry) => entry.pid), rootIsSameProcess };
+}
+
+function signalUnixTargets(pid: number, signal: "SIGTERM" | "SIGKILL", targets: number[]): void {
+  for (const target of targets) {
+    try {
+      process.kill(target, signal);
+    } catch {
+      // Already gone, or not ours to signal.
+    }
+  }
+
+  try {
+    process.kill(pid, signal);
+  } catch {
+    // Already gone.
+  }
 }
 
 function signalProcessTreeUnix(
@@ -253,19 +389,7 @@ function signalProcessTreeUnix(
   // the direct PID alone leaves everything the child forked running, reparented
   // to init with its output already closed, so a timed-out run keeps consuming
   // the machine and can never deliver a result.
-  for (const descendant of collectDescendantPids(pid)) {
-    try {
-      process.kill(descendant, signal);
-    } catch {
-      // Already gone, or not ours to signal.
-    }
-  }
-
-  try {
-    process.kill(pid, signal);
-  } catch {
-    // Already gone.
-  }
+  signalUnixTargets(pid, signal, resolveTrackedUnixTree(pid).descendants);
 }
 
 function runTaskkill(args: string[], onExit?: (code: number | null) => void): Promise<void> {

--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -1,6 +1,6 @@
 // Agent Core module implements kill tree behavior.
 import { spawn, spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 
 const DEFAULT_GRACE_MS = 3000;
 const MAX_GRACE_MS = 60_000;
@@ -24,7 +24,8 @@ export type KillProcessTreeOptions = {
  * This prevents accidentally signaling the gateway's process group when the
  * child shares its parent's group.
  *
- * - `detached: false`: skip group kill unconditionally.
+ * - `detached: false`: skip group kill unconditionally and signal the PID plus
+ *   its descendants individually instead.
  * - `detached: true`: use group kill unconditionally (trust caller).
  * - `detached` omitted: use group kill only when PID is the group leader.
  */
@@ -149,6 +150,91 @@ function isProcessGroupLeader(pid: number): boolean {
   return pgid === pid;
 }
 
+function parseProcessParentTable(text: string): Map<number, number[]> {
+  const children = new Map<number, number[]>();
+  for (const line of text.split("\n")) {
+    const [pidText, ppidText] = line.trim().split(/\s+/);
+    const pid = Number(pidText);
+    const ppid = Number(ppidText);
+    if (!Number.isSafeInteger(pid) || pid <= 0 || !Number.isSafeInteger(ppid) || ppid <= 0) {
+      continue;
+    }
+    const siblings = children.get(ppid);
+    if (siblings) {
+      siblings.push(pid);
+    } else {
+      children.set(ppid, [pid]);
+    }
+  }
+  return children;
+}
+
+function readProcessParentTableFromProc(): Map<number, number[]> | undefined {
+  try {
+    const lines: string[] = [];
+    for (const entry of readdirSync("/proc")) {
+      if (!/^\d+$/.test(entry)) {
+        continue;
+      }
+      try {
+        const stat = readFileSync(`/proc/${entry}/stat`, "utf8");
+        const commEnd = stat.lastIndexOf(")");
+        if (commEnd < 0) {
+          continue;
+        }
+        // After comm: state, ppid. The command name may contain spaces or ')'.
+        const fields = stat
+          .slice(commEnd + 1)
+          .trim()
+          .split(/\s+/);
+        lines.push(`${entry} ${fields[1] ?? ""}`);
+      } catch {
+        // The process exited while the snapshot was being taken.
+      }
+    }
+    return parseProcessParentTable(lines.join("\n"));
+  } catch {
+    return undefined;
+  }
+}
+
+function readProcessParentTableFromPs(): Map<number, number[]> | undefined {
+  try {
+    const res = spawnSync("ps", ["-eo", "pid=,ppid="], { encoding: "utf8", timeout: 500 });
+    if (res.error || res.status !== 0 || typeof res.stdout !== "string") {
+      return undefined;
+    }
+    return parseProcessParentTable(res.stdout);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Best-effort descendant snapshot for a PID that does not lead its own group. */
+function collectDescendantPids(pid: number): number[] {
+  const children =
+    (process.platform === "linux" ? readProcessParentTableFromProc() : undefined) ??
+    readProcessParentTableFromPs();
+  if (!children) {
+    return [];
+  }
+  const descendants: number[] = [];
+  const seen = new Set<number>([pid]);
+  const queue = [pid];
+  while (queue.length > 0) {
+    const current = queue.shift() as number;
+    for (const child of children.get(current) ?? []) {
+      if (seen.has(child)) {
+        continue;
+      }
+      seen.add(child);
+      descendants.push(child);
+      queue.push(child);
+    }
+  }
+  return descendants;
+}
+
 function signalProcessTreeUnix(
   pid: number,
   signal: "SIGTERM" | "SIGKILL",
@@ -160,6 +246,18 @@ function signalProcessTreeUnix(
       return;
     } catch {
       // Process group does not exist or we lack permission; try direct pid.
+    }
+  }
+
+  // Without group kill this is the only way descendants are reached. Signaling
+  // the direct PID alone leaves everything the child forked running, reparented
+  // to init with its output already closed, so a timed-out run keeps consuming
+  // the machine and can never deliver a result.
+  for (const descendant of collectDescendantPids(pid)) {
+    try {
+      process.kill(descendant, signal);
+    } catch {
+      // Already gone, or not ours to signal.
     }
   }
 

--- a/src/process/kill-tree.test.ts
+++ b/src/process/kill-tree.test.ts
@@ -427,6 +427,59 @@ describe("killProcessTree", () => {
     });
   });
 
+  it("on Unix still force-kills a live root when process discovery is unavailable", async () => {
+    // Neither procfs nor ps can enumerate here. Losing the escalation would
+    // leave a child that ignored SIGTERM running for good.
+    readdirSyncMock.mockImplementation(() => {
+      throw new Error("proc unavailable");
+    });
+    spawnSyncMock.mockReturnValue({ status: 1, stdout: "" });
+    killSpy.mockImplementation((() => true) as typeof process.kill);
+
+    await withMockedPlatform("linux", async () => {
+      killProcessTree(7040, { graceMs: 10, detached: false });
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(killSpy).toHaveBeenCalledWith(7040, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(7040, "SIGKILL");
+      expect(killSpy).not.toHaveBeenCalledWith(-7040, "SIGKILL");
+    });
+  });
+
+  it("on Unix never re-signals a remembered descendant that has no start time", async () => {
+    // `ps -eo pid=,ppid=` carries no start time. Two empty tokens must not
+    // compare equal, or a PID reused during the grace window inherits the kill.
+    let rootAlive = true;
+    spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+      if (command !== "ps" || args[0] !== "-eo") {
+        return { status: 1, stdout: "" };
+      }
+      if (args[1] === "pid=,ppid=,lstart=") {
+        return { status: 1, stdout: "" };
+      }
+      return {
+        status: 0,
+        stdout: rootAlive ? "7050 1\n7051 7050\n" : "7051 1\n",
+      };
+    });
+    killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      if (signal === 0 && pid === 7050 && !rootAlive) {
+        throw new Error("ESRCH");
+      }
+      return true;
+    }) as typeof process.kill);
+
+    await withMockedPlatform("darwin", async () => {
+      killProcessTree(7050, { graceMs: 10, detached: false });
+      expect(killSpy).toHaveBeenCalledWith(7051, "SIGTERM");
+
+      rootAlive = false;
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(killSpy).not.toHaveBeenCalledWith(7051, "SIGKILL");
+    });
+  });
+
   it("on Unix bounds the ps descendant probe with a signal the target cannot ignore", async () => {
     spawnSyncMock.mockReturnValue({ status: 0, stdout: "" });
     killSpy.mockImplementation((() => true) as typeof process.kill);

--- a/src/process/kill-tree.test.ts
+++ b/src/process/kill-tree.test.ts
@@ -427,6 +427,51 @@ describe("killProcessTree", () => {
     });
   });
 
+  it("on Unix signals the descendants of a root whose PID a previous termination also used", async () => {
+    // The first tree leaves a TERM-resistant child behind, so its root PID is
+    // still remembered when an unrelated process reuses that PID. Reading the
+    // stale memory as "this tree is already known" would skip discovery and
+    // leak the new tree's own children, which is the bug this file exists for.
+    let reused = false;
+    const mockProcessTable = () => {
+      const table = reused
+        ? [
+            mockProcStat({ pid: 7031, ppid: 1, startToken: "200" }),
+            mockProcStat({ pid: 7030, ppid: 1, startToken: "555" }),
+            mockProcStat({ pid: 7032, ppid: 7030, startToken: "300" }),
+          ]
+        : [
+            mockProcStat({ pid: 7030, ppid: 1, startToken: "100" }),
+            mockProcStat({ pid: 7031, ppid: 7030, startToken: "200" }),
+          ];
+      readdirSyncMock.mockReturnValue(table.map((entry) => String(entry.pid)));
+      readFileSyncMock.mockImplementation((filePath: unknown) => {
+        const pid = Number(String(filePath).replace("/proc/", "").replace("/stat", ""));
+        const found = table.find((entry) => entry.pid === pid);
+        if (!found) {
+          throw new Error("proc unavailable");
+        }
+        return found.stat;
+      });
+    };
+    mockProcessTable();
+    killSpy.mockImplementation((() => true) as typeof process.kill);
+
+    await withMockedPlatform("linux", async () => {
+      killProcessTree(7030, { graceMs: 10, detached: false });
+      await vi.advanceTimersByTimeAsync(10);
+
+      reused = true;
+      mockProcessTable();
+      killSpy.mockClear();
+      killProcessTree(7030, { graceMs: 10, detached: false });
+
+      expect(killSpy).toHaveBeenCalledWith(7032, "SIGTERM");
+      await vi.advanceTimersByTimeAsync(10);
+      expect(killSpy).toHaveBeenCalledWith(7032, "SIGKILL");
+    });
+  });
+
   it("on Unix still force-kills a live root when process discovery is unavailable", async () => {
     // Neither procfs nor ps can enumerate here. Losing the escalation would
     // leave a child that ignored SIGTERM running for good.

--- a/src/process/kill-tree.test.ts
+++ b/src/process/kill-tree.test.ts
@@ -3,13 +3,15 @@ import { EventEmitter } from "node:events";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 
-const { readFileSyncMock, spawnMock, spawnSyncMock } = vi.hoisted(() => ({
+const { readdirSyncMock, readFileSyncMock, spawnMock, spawnSyncMock } = vi.hoisted(() => ({
+  readdirSyncMock: vi.fn((..._args: unknown[]) => [] as string[]),
   readFileSyncMock: vi.fn(),
   spawnMock: vi.fn(),
   spawnSyncMock: vi.fn(),
 }));
 
 vi.mock("node:fs", () => ({
+  readdirSync: (...args: unknown[]) => readdirSyncMock(...args),
   readFileSync: (...args: unknown[]) => readFileSyncMock(...args),
 }));
 
@@ -59,6 +61,8 @@ describe("killProcessTree", () => {
   });
 
   beforeEach(() => {
+    readdirSyncMock.mockReset();
+    readdirSyncMock.mockReturnValue([]);
     readFileSyncMock.mockReset();
     readFileSyncMock.mockImplementation(() => {
       throw new Error("proc unavailable");
@@ -296,6 +300,40 @@ describe("killProcessTree", () => {
       expect(killSpy).toHaveBeenCalledWith(5555, "SIGTERM");
       expect(killSpy).not.toHaveBeenCalledWith(-5555, "SIGTERM");
       expect(killSpy).not.toHaveBeenCalledWith(-5555, "SIGKILL");
+    });
+  });
+
+  it("on Unix signals descendants explicitly when detached:false rules out group kill", async () => {
+    // 5555 is the shell the supervisor spawned; 5556 is what the shell forked
+    // and 5557 is that process's own child. Without group kill they are only
+    // reachable one PID at a time.
+    const parents = new Map([
+      [5555, 1],
+      [5556, 5555],
+      [5557, 5556],
+      [6001, 1],
+    ]);
+    readdirSyncMock.mockReturnValue([...parents.keys()].map(String));
+    readFileSyncMock.mockImplementation((filePath: unknown) => {
+      const pid = Number(String(filePath).replace("/proc/", "").replace("/stat", ""));
+      const ppid = parents.get(pid);
+      if (ppid === undefined) {
+        throw new Error("proc unavailable");
+      }
+      return `${pid} (bash cmd) S ${ppid} ${pid} ${pid} 0`;
+    });
+    killSpy.mockImplementation((() => true) as typeof process.kill);
+
+    await withMockedPlatform("linux", async () => {
+      signalProcessTree(5555, "SIGKILL", { detached: false });
+
+      expect(killSpy).toHaveBeenCalledWith(5556, "SIGKILL");
+      expect(killSpy).toHaveBeenCalledWith(5557, "SIGKILL");
+      expect(killSpy).toHaveBeenCalledWith(5555, "SIGKILL");
+      // Group kill stays forbidden: the child shares the gateway's group.
+      expect(killSpy).not.toHaveBeenCalledWith(-5555, "SIGKILL");
+      // An unrelated process must not be signaled.
+      expect(killSpy).not.toHaveBeenCalledWith(6001, "SIGKILL");
     });
   });
 

--- a/src/process/kill-tree.test.ts
+++ b/src/process/kill-tree.test.ts
@@ -491,6 +491,94 @@ describe("killProcessTree", () => {
     });
   });
 
+  it("on Unix does not traverse a PID whose identity this sequence never established", async () => {
+    // Discovery was unavailable when SIGTERM went out, so nothing is known
+    // about the root. If the PID is recycled before the force phase, the tree
+    // visible then belongs to a stranger and must not be signaled.
+    let discoveryAvailable = false;
+    const strangerTable = [
+      mockProcStat({ pid: 7060, ppid: 1, startToken: "900" }),
+      mockProcStat({ pid: 7061, ppid: 7060, startToken: "901" }),
+    ];
+    readdirSyncMock.mockImplementation(() => {
+      if (!discoveryAvailable) {
+        throw new Error("proc unavailable");
+      }
+      return strangerTable.map((entry) => String(entry.pid));
+    });
+    readFileSyncMock.mockImplementation((filePath: unknown) => {
+      if (!discoveryAvailable) {
+        throw new Error("proc unavailable");
+      }
+      const pid = Number(String(filePath).replace("/proc/", "").replace("/stat", ""));
+      const found = strangerTable.find((entry) => entry.pid === pid);
+      if (!found) {
+        throw new Error("proc unavailable");
+      }
+      return found.stat;
+    });
+    spawnSyncMock.mockReturnValue({ status: 1, stdout: "" });
+    killSpy.mockImplementation((() => true) as typeof process.kill);
+
+    await withMockedPlatform("linux", async () => {
+      killProcessTree(7060, { graceMs: 10, detached: false });
+
+      discoveryAvailable = true;
+      await vi.advanceTimersByTimeAsync(10);
+
+      // The legacy direct-PID escalation is kept: liveness is all the evidence
+      // there is, and dropping it would resurrect the orphan this fix closes.
+      expect(killSpy).toHaveBeenCalledWith(7060, "SIGKILL");
+      expect(killSpy).not.toHaveBeenCalledWith(7061, "SIGKILL");
+    });
+  });
+
+  it("on Unix force-kills a descendant forked during the grace window by a survivor", async () => {
+    // The root dies on SIGTERM, so the tree can no longer be walked from it.
+    // A descendant that ignored SIGTERM keeps forking, and those children are
+    // in no snapshot: they must be reached from the survivor itself.
+    let rootAlive = true;
+    const mockProcessTable = () => {
+      const table = rootAlive
+        ? [
+            mockProcStat({ pid: 7070, ppid: 1, startToken: "100" }),
+            mockProcStat({ pid: 7071, ppid: 7070, startToken: "200" }),
+          ]
+        : [
+            mockProcStat({ pid: 7071, ppid: 1, startToken: "200" }),
+            mockProcStat({ pid: 7072, ppid: 7071, startToken: "300" }),
+          ];
+      readdirSyncMock.mockReturnValue(table.map((entry) => String(entry.pid)));
+      readFileSyncMock.mockImplementation((filePath: unknown) => {
+        const pid = Number(String(filePath).replace("/proc/", "").replace("/stat", ""));
+        const found = table.find((entry) => entry.pid === pid);
+        if (!found) {
+          throw new Error("proc unavailable");
+        }
+        return found.stat;
+      });
+    };
+    mockProcessTable();
+    killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      if (signal === 0 && pid === 7070 && !rootAlive) {
+        throw new Error("ESRCH");
+      }
+      return true;
+    }) as typeof process.kill);
+
+    await withMockedPlatform("linux", async () => {
+      killProcessTree(7070, { graceMs: 10, detached: false });
+      expect(killSpy).toHaveBeenCalledWith(7071, "SIGTERM");
+
+      rootAlive = false;
+      mockProcessTable();
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(killSpy).toHaveBeenCalledWith(7071, "SIGKILL");
+      expect(killSpy).toHaveBeenCalledWith(7072, "SIGKILL");
+    });
+  });
+
   it("on Unix never re-signals a remembered descendant that has no start time", async () => {
     // `ps -eo pid=,ppid=` carries no start time. Two empty tokens must not
     // compare equal, or a PID reused during the grace window inherits the kill.

--- a/src/process/kill-tree.test.ts
+++ b/src/process/kill-tree.test.ts
@@ -41,6 +41,15 @@ function expectTaskkillCall(index: number, args: string[]) {
   ]);
 }
 
+/** A `/proc/<pid>/stat` line whose positional fields carry ppid and start time. */
+function mockProcStat(params: { pid: number; ppid: number; startToken: string }) {
+  const betweenPpidAndStartTime = Array.from({ length: 17 }, () => "0").join(" ");
+  return {
+    pid: params.pid,
+    stat: `${params.pid} (bash cmd) S ${params.ppid} ${betweenPpidAndStartTime} ${params.startToken}`,
+  };
+}
+
 function mockIsProcessGroupLeader(...pids: number[]) {
   spawnSyncMock.mockImplementation((command: string, args: string[]) => {
     if (command === "ps" && args[0] === "-p" && args[2] === "-o" && args[3] === "pgid=") {
@@ -335,6 +344,103 @@ describe("killProcessTree", () => {
       // An unrelated process must not be signaled.
       expect(killSpy).not.toHaveBeenCalledWith(6001, "SIGKILL");
     });
+  });
+
+  it("on Unix force-kills a descendant that outlived the root it was signaled with", async () => {
+    // SIGTERM ends the shell but not the process it forked. That process is
+    // reparented to init, so it can no longer be found from the root PID and
+    // only the remembered identity keeps it reachable for the force phase.
+    let rootAlive = true;
+    const mockProcessTable = () => {
+      const table = rootAlive
+        ? [
+            mockProcStat({ pid: 7010, ppid: 1, startToken: "100" }),
+            mockProcStat({ pid: 7011, ppid: 7010, startToken: "200" }),
+          ]
+        : [mockProcStat({ pid: 7011, ppid: 1, startToken: "200" })];
+      readdirSyncMock.mockReturnValue(table.map((entry) => String(entry.pid)));
+      readFileSyncMock.mockImplementation((filePath: unknown) => {
+        const pid = Number(String(filePath).replace("/proc/", "").replace("/stat", ""));
+        const found = table.find((entry) => entry.pid === pid);
+        if (!found) {
+          throw new Error("proc unavailable");
+        }
+        return found.stat;
+      });
+    };
+    mockProcessTable();
+    killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      if (signal === 0 && pid === 7010 && !rootAlive) {
+        throw new Error("ESRCH");
+      }
+      return true;
+    }) as typeof process.kill);
+
+    await withMockedPlatform("linux", async () => {
+      killProcessTree(7010, { graceMs: 10, detached: false });
+      expect(killSpy).toHaveBeenCalledWith(7011, "SIGTERM");
+
+      // The shell exits on SIGTERM; its TERM-resistant child is reparented.
+      rootAlive = false;
+      mockProcessTable();
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(killSpy).toHaveBeenCalledWith(7011, "SIGKILL");
+    });
+  });
+
+  it("on Unix never force-kills a remembered PID that another process has reused", async () => {
+    let rootAlive = true;
+    const mockProcessTable = () => {
+      const table = rootAlive
+        ? [
+            mockProcStat({ pid: 7020, ppid: 1, startToken: "100" }),
+            mockProcStat({ pid: 7021, ppid: 7020, startToken: "200" }),
+          ]
+        : // Same PID, different process: the original descendant is gone.
+          [mockProcStat({ pid: 7021, ppid: 1, startToken: "999" })];
+      readdirSyncMock.mockReturnValue(table.map((entry) => String(entry.pid)));
+      readFileSyncMock.mockImplementation((filePath: unknown) => {
+        const pid = Number(String(filePath).replace("/proc/", "").replace("/stat", ""));
+        const found = table.find((entry) => entry.pid === pid);
+        if (!found) {
+          throw new Error("proc unavailable");
+        }
+        return found.stat;
+      });
+    };
+    mockProcessTable();
+    killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      if (signal === 0 && pid === 7020 && !rootAlive) {
+        throw new Error("ESRCH");
+      }
+      return true;
+    }) as typeof process.kill);
+
+    await withMockedPlatform("linux", async () => {
+      killProcessTree(7020, { graceMs: 10, detached: false });
+      rootAlive = false;
+      mockProcessTable();
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(killSpy).not.toHaveBeenCalledWith(7021, "SIGKILL");
+    });
+  });
+
+  it("on Unix bounds the ps descendant probe with a signal the target cannot ignore", async () => {
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: "" });
+    killSpy.mockImplementation((() => true) as typeof process.kill);
+
+    await withMockedPlatform("darwin", async () => {
+      signalProcessTree(7030, "SIGKILL", { detached: false });
+    });
+
+    // `timeout` alone only signals the child and keeps waiting for it to exit.
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      "ps",
+      ["-eo", "pid=,ppid=,lstart="],
+      expect.objectContaining({ killSignal: "SIGKILL", timeout: 500 }),
+    );
   });
 
   it("on Unix uses group kill when the omitted option resolves to a group leader", async () => {

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -13,20 +13,24 @@ import {
   mockLinuxOomWrapperShell,
 } from "./test-support.js";
 
-const { spawnWithFallbackMock, signalProcessTreeMock, createWindowsOutputDecoderMock } = vi.hoisted(
-  () => ({
-    spawnWithFallbackMock: vi.fn(),
-    signalProcessTreeMock: vi.fn(
-      (_pid: number, _signal: string, opts?: { onComplete?: () => void }) => {
-        opts?.onComplete?.();
-      },
-    ),
-    createWindowsOutputDecoderMock: vi.fn(() => ({
-      decode: (chunk: Buffer | string) => (Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk),
-      flush: () => "",
-    })),
-  }),
-);
+const {
+  spawnWithFallbackMock,
+  signalProcessTreeMock,
+  killProcessTreeMock,
+  createWindowsOutputDecoderMock,
+} = vi.hoisted(() => ({
+  spawnWithFallbackMock: vi.fn(),
+  killProcessTreeMock: vi.fn(),
+  signalProcessTreeMock: vi.fn(
+    (_pid: number, _signal: string, opts?: { onComplete?: () => void }) => {
+      opts?.onComplete?.();
+    },
+  ),
+  createWindowsOutputDecoderMock: vi.fn(() => ({
+    decode: (chunk: Buffer | string) => (Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk),
+    flush: () => "",
+  })),
+}));
 
 vi.mock("../../spawn-utils.js", () => ({
   spawnWithFallback: spawnWithFallbackMock,
@@ -34,6 +38,7 @@ vi.mock("../../spawn-utils.js", () => ({
 
 vi.mock("../../kill-tree.js", () => ({
   signalProcessTree: signalProcessTreeMock,
+  killProcessTree: killProcessTreeMock,
 }));
 
 vi.mock("../../../infra/windows-encoding.js", () => ({
@@ -152,6 +157,7 @@ describe("createChildAdapter", () => {
     ({ createChildAdapter } = await import("./child.js"));
     spawnWithFallbackMock.mockClear();
     signalProcessTreeMock.mockClear();
+    killProcessTreeMock.mockClear();
     createWindowsOutputDecoderMock.mockClear();
     createWindowsOutputDecoderMock.mockImplementation(() => ({
       decode: (chunk: Buffer | string) => (Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk),
@@ -361,8 +367,12 @@ describe("createChildAdapter", () => {
     adapter.kill("SIGTERM");
 
     const expectedDetached = process.platform !== "win32" && !process.env.OPENCLAW_SERVICE_MARKER;
-    expect(signalProcessTreeMock).toHaveBeenCalledWith(7654, "SIGTERM", {
+    // Graceful cancellation owns its own escalation: the supervisor stops
+    // watching once the direct child settles, but a descendant that ignored
+    // SIGTERM outlives it.
+    expect(killProcessTreeMock).toHaveBeenCalledWith(7654, {
       detached: expectedDetached,
+      graceMs: 5000,
     });
     expect(killMock).not.toHaveBeenCalled();
   });
@@ -381,8 +391,9 @@ describe("createChildAdapter", () => {
 
     adapter.kill("SIGTERM");
 
-    expect(signalProcessTreeMock).toHaveBeenCalledWith(8765, "SIGTERM", {
+    expect(killProcessTreeMock).toHaveBeenCalledWith(8765, {
       detached: false,
+      graceMs: 5000,
     });
     expect(killMock).not.toHaveBeenCalled();
   });

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -6,7 +6,7 @@ import {
   resolveWindowsExecutablePath,
   resolveWindowsSpawnProgramCandidate,
 } from "../../../plugin-sdk/windows-spawn.js";
-import { signalProcessTree } from "../../kill-tree.js";
+import { killProcessTree, signalProcessTree } from "../../kill-tree.js";
 import { prepareOomScoreAdjustedSpawn } from "../../linux-oom-score.js";
 import {
   addSecretInputStdio,
@@ -71,6 +71,9 @@ function resolveChildInvocation(params: {
 }
 
 type ChildAdapter = SpawnProcessAdapter<NodeJS.Signals | null>;
+
+/** Mirrors the supervisor's graceful cancel window before forced termination. */
+const SIGTERM_TREE_ESCALATION_MS = 5000;
 
 function isServiceManagedRuntime(): boolean {
   return Boolean(process.env.OPENCLAW_SERVICE_MARKER?.trim());
@@ -434,9 +437,6 @@ export async function createChildAdapter(params: {
   // gateway's process group regardless of intent, so the kill must avoid
   // group-kill. (#71662 follow-up — caught by Greptile review)
   const childIsDetached = useDetached && !spawned.usedFallback;
-  const signalProcessTreeForChild = (pid: number, signal: "SIGTERM" | "SIGKILL") => {
-    signalProcessTree(pid, signal, { detached: childIsDetached });
-  };
   const signalProcessTreeForChildAndWait = (pid: number, signal: "SIGTERM" | "SIGKILL") =>
     new Promise<void>((resolve) => {
       signalProcessTree(pid, signal, { detached: childIsDetached, onComplete: resolve });
@@ -476,7 +476,14 @@ export async function createChildAdapter(params: {
       return;
     }
     if (signal === "SIGTERM" && pid) {
-      signalProcessTreeForChild(pid, "SIGTERM");
+      // The supervisor's own force phase is skipped once the direct child
+      // settles, so a descendant that ignores SIGTERM would outlive the run.
+      // Let the tree own its escalation: SIGTERM now, SIGKILL after the same
+      // graceful window for whatever is provably still the original tree.
+      killProcessTree(pid, {
+        detached: childIsDetached,
+        graceMs: SIGTERM_TREE_ESCALATION_MS,
+      });
       return;
     }
     try {


### PR DESCRIPTION
Closes #121049

AI-assisted (Claude, via OpenClaw). I understand what the code does and validated it as described below.

## What Problem This Solves

Fixes an issue where users whose exec run hits `overall-timeout` or `no-output-timeout` would be left with orphaned processes burning CPU on the machine running the gateway. Only the direct child was signaled, so anything that child had forked kept running — reparented to `init`, with its output pipe already closed, so its work could never be collected and nothing would stop it.

Measured twice on a service-managed gateway on 2026-08-05: a `python3` heredoc forked by an already-killed shell held one core for 51 minutes in one case and 123 minutes in the other.

## Why This Change Was Made

The kill path was never broken; it was unreachable. Children are deliberately spawned attached under a service manager so systemd/launchd can stop the full tree, so `{ detached: false }` reaches `kill-tree`, which correctly refuses `kill(-pid, signal)` — the child shares the gateway's own process group, and a group kill would signal the gateway. That refusal left signaling the lone PID as the only remaining action.

This change keeps both of those decisions and adds the missing path: when group kill is ruled out, snapshot the descendants and signal each one before the direct PID. Discovery uses procfs on Linux and `ps -eo pid=,ppid=` elsewhere — the same procfs-first, `ps`-fallback shape this module already uses to resolve a process group id — and a failed snapshot degrades to exactly the previous direct-PID behavior.

Non-goals: the spawn shape is unchanged (no new detaching), Windows still goes through `taskkill /T`, and the group-kill path for genuinely detached children is untouched.

## User Impact

A timed-out exec now leaves nothing running. Operators stop finding stray CPU-pinning processes that outlive the run that started them.

## Evidence

**Real-process reproduction** against the module itself — a non-detached `bash` with one forked descendant, signaled with `{ detached: false }`:

```
# before
child=3399375 descendants=3399376
ORPHAN SURVIVED: 3399376

# after
child=3399450 descendants=3399451
no orphan: child tree fully reaped
```

**Focused regression test** in `src/process/kill-tree.test.ts` — `on Unix signals descendants explicitly when detached:false rules out group kill` — builds a 3-deep tree plus one unrelated process and asserts that every descendant and the root are signaled, that `-pid` is never signaled, and that the unrelated process is left alone.

- without the fix: `× on Unix signals descendants explicitly when detached:false rules out group kill` (1 failed | 25 passed)
- with the fix: `Test Files 1 passed (1) / Tests 26 passed (26)`

Wider lane (kill-tree, supervisor, child adapter, pty, respawn runner):

```
node --import tsx scripts/test-projects.mts src/process/kill-tree.test.ts \
  src/process/supervisor/supervisor.test.ts \
  src/process/supervisor/adapters/child.test.ts \
  src/process/terminal-pty.test.ts src/process/respawn-child-runner.test.ts
Test Files  5 passed (5) / Tests  100 passed (100)
```

`pnpm tsgo:core`, `pnpm tsgo:core:test`, `oxlint`, and `oxfmt --check` are clean on the changed files.

## Review follow-up (2e7f248d)

Three findings, each reproduced before being changed.

**The force phase had nothing to signal, and on the real path never ran (P1).** SIGTERM ends the shell but not a descendant that ignores it; that descendant is reparented to init and a fresh lookup from the root PID no longer finds it. Worse, `cancelAdapter` arms its force timer behind `!settled`, so a root that dies on SIGTERM cancels the escalation its own descendant needed.

Reproduced through the **real supervisor** with `timeoutMs`, shell exits on SIGTERM, child ignores it:

```
# before
root=3417818 term-resistant descendants=3417819
exit reason: overall-timeout
ORPHAN SURVIVED: 3417819

# after
root=3420295 term-resistant descendants=3420296
exit reason: overall-timeout
no orphan: child tree fully reaped
```

Fix: descendants seen during a termination sequence are remembered with a start token (procfs field 22, or `lstart` via `ps`), and a remembered PID is force-killed only while that token still matches — a PID recycled during the grace window is never signaled. The root is re-signaled under the same proof rather than a bare liveness check. Graceful cancellation in the child adapter now terminates through `killProcessTree`, so the tree owns its SIGTERM-then-SIGKILL window regardless of whether the direct child settled.

**Linear-time traversal (P2).** The queue is walked with the array iterator, which visits entries appended during the loop, instead of `shift()` on a growing array.

**Bounded `ps` (P2).** The descendant probe passes `killSignal: "SIGKILL"` with its 500 ms timeout, matching the contract `src/infra/spawn-ps.ts` documents. (`packages/agent-core` cannot import that helper; the pre-existing `readProcessGroupIdFromPs` in the same file has the same exposure and was left alone to keep this PR to one concern.)

New tests: `on Unix force-kills a descendant that outlived the root it was signaled with`, `on Unix never force-kills a remembered PID that another process has reused`, `on Unix bounds the ps descendant probe with a signal the target cannot ignore`. The first and third are red on the previous commit. The two existing child-adapter tests that pinned the bare-SIGTERM contract were updated to the tree contract.

```
node --import tsx scripts/test-projects.mts src/process/kill-tree.test.ts \
  src/process/supervisor/supervisor.test.ts src/process/supervisor/adapters/child.test.ts \
  src/process/supervisor/adapters/pty.test.ts src/process/terminal-pty.test.ts \
  src/process/respawn-child-runner.test.ts src/process/supervisor/supervisor.cancellation-reason.test.ts \
  src/process/supervisor/supervisor.queued-cancellation.test.ts \
  src/process/supervisor/supervisor.timeout-overflow.test.ts
Test Files  9 passed (9) / Tests  165 passed (165)
```

`pnpm tsgo:core`, `pnpm tsgo:core:test`, `oxlint`, `oxfmt --check` clean.


### On the requested supervisor-path regression

The supervisor suite drives stub adapters rather than real processes, so a root-exits/descendant-survives-TERM case cannot be expressed there without spawning real children in a unit test. It is covered from both sides instead: `src/process/supervisor/adapters/child.test.ts` pins the contract that graceful cancellation now terminates the tree with its own escalation window (the two tests that previously pinned a bare SIGTERM were updated), and the real-supervisor before/after trace above exercises the actual `overall-timeout` sequence with a TERM-ignoring descendant. Happy to add a real-process test to the supervisor suite if that is wanted there.


## Second review follow-up (`e55d83e7`)

Both P1s were real and both were mine.

**Force escalation was lost when process discovery failed.** The resolver returned an empty tree when neither procfs nor `ps` could enumerate, and the force callback read that as "nothing to kill" and returned — so a child that ignored SIGTERM was never SIGKILLed, which is worse than the direct-PID escalation this function performed before descendants were tracked. Table availability is now distinct from an empty tree, and an unavailable table degrades to exactly that older behavior.

**Tokenless identities compared equal.** The `ps -eo pid=,ppid=` fallback carries no start time, so remembered entries could hold an empty token and `"" === ""` passed the identity check — a PID reused during the grace window could inherit a pending SIGKILL. Unidentifiable entries are no longer retained or re-signaled across the window. The root is re-signaled only when its identity is proven, or when no start time exists at all and liveness is the only evidence available (which is what `main` does today); never when its identity provably changed.

Two regression tests, both red on the previous commit:

- `on Unix still force-kills a live root when process discovery is unavailable`
- `on Unix never re-signals a remembered descendant that has no start time`

```
node --import tsx scripts/test-projects.mts src/process/kill-tree.test.ts
Test Files  1 passed (1) / Tests  31 passed (31)

# full process lane
Test Files  9 passed (9) / Tests  167 passed (167)
```

Real-supervisor probe re-run after the change: `exit reason: overall-timeout` then `no orphan: child tree fully reaped`.

`pnpm tsgo:core`, `pnpm tsgo:core:test`, `oxlint` and `oxfmt --check` clean. Branch rebased onto `main` (`409fb7ab`) to refresh merge and CI state.



## Review follow-up (c357b31a)

**A recycled root PID hid the new tree's descendants (P1).** Descendant memory lived in a module-level map keyed by root PID with a 120 s TTL. When the kernel handed that PID to an unrelated process while an entry was still live, the root read as "identity changed" — a branch that skips discovery. The new tree's own children were then never signaled and only the direct PID was killed, which is the leak this PR exists to close.

Reproduced before changing anything, with two `killProcessTree` operations on one PID (the first leaves a TERM-resistant child, so the entry is retained):

```
# before, on e55d83e7
expected: kill(7032, "SIGTERM")   # child of the new root
received: kill(7030, "SIGTERM")   # the recycled root, alone

# after
7032 SIGTERM, then 7032 SIGKILL
```

Fix: the memory belongs to one termination sequence, so that sequence now owns it. `killProcessTree` keeps the snapshot its SIGTERM produced and passes it to its own force phase; nothing is stored across calls, so the TTL and its prune pass are deleted and a reused PID starts clean by construction. Identity rules across the grace window are unchanged — a root that is provably no longer ours has neither its tree traversed nor itself signaled, and a remembered descendant is re-signaled only while its start token matches. Source: 35 added, 42 removed.

New regression test, red on `e55d83e7`: `on Unix signals the descendants of a root whose PID a previous termination also used`.

```
src/process/kill-tree.test.ts                     32 passed (32)
src/process/supervisor/adapters/child.test.ts     28 passed (28)
process lane                                      313 passed | 3 skipped (316)
```

Real-process escalation probe re-run on this head: `root=3608628 term-resistant descendants=3608629` then `no orphan: descendant reaped by the force phase`. `tsgo -p tsconfig.json`, `oxlint` and `oxfmt --check` clean.

The PID-reuse case is proven by the deterministic test rather than on live processes: forcing a real PID recycle needs `kernel/ns_last_pid` and root, which this host does not grant.


## Review follow-up (e636a7b3)

Two P1s, both real and both mine. Reproduced as failing tests on `c357b31a` before anything was changed.

**Traversing a PID whose identity this sequence never established.** Traversal was gated on the root not being provably *changed*, which also admits the case where no identity was ever recorded — discovery unavailable when SIGTERM went out, so `tracked` is undefined. If the PID is recycled before the force phase, the tree visible then belongs to a stranger, and its children were signalled.

```
# before, on c357b31a — table unavailable at SIGTERM, PID recycled by force time
expected: no signal to 7061        # the stranger's child
received: kill(7061, "SIGKILL")
```

Traversal now requires either the initial pass, where the PID is the one just handed to us, or a root still provably the same process. The direct-PID escalation for an unidentifiable-but-live root is untouched, so the "discovery unavailable" case still loses nothing.

**Descendants forked during the grace window.** The force phase re-signalled only what it remembered. A descendant that ignores SIGTERM keeps forking, and those children are in no snapshot and unreachable from a root that has already died — exactly the orphan class this branch exists to close. Each remembered descendant still provably the same process is now rescanned and its current children join the targets.

Real processes, root dying on SIGTERM with its child forking a grandchild inside the grace window:

```
# before, on c357b31a
after SIGTERM:      root alive=false survivor alive=true late=3772667 alive=true
after force phase:  survivor alive=false late alive=true      -> ORPHAN SURVIVED

# after, on e636a7b3
after SIGTERM:      root alive=false survivor alive=true late=3772352 alive=true
after force phase:  survivor alive=false late alive=false     -> whole tree reaped
```

Two new regression tests, both red on `c357b31a`: `on Unix does not traverse a PID whose identity this sequence never established` and `on Unix force-kills a descendant forked during the grace window by a survivor`.

```
src/process/kill-tree.test.ts                     34 passed (34)
src/process/supervisor/adapters/child.test.ts     28 passed (28)
src/process/supervisor/supervisor.queued-cancellation.test.ts   3 passed (3)
```

`pnpm tsgo:core`, `pnpm tsgo:core:test`, `oxlint` and `oxfmt --check` clean. Source: +18/-5.

The whole-lane `pnpm vitest run src/process/` run is not quotable from this host: it fails under file parallelism on the unmodified branch too (42 tests on `c357b31a`, 2 on this head, different files each run), and a serial re-run exceeds 20 minutes here. Every file the change touches passes individually on both heads, and exact-head CI covers the lane.
