### PR TITLE
fix(qa): enforce fresh Matrix state restarts

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts
@@ -523,4 +523,107 @@ describe("matrix scenario environment", () => {
     expect(waitForConfigRestartSettle).not.toHaveBeenCalled();
     expect(gateway.call.mock.calls.filter(([method]) => method === "config.patch")).toHaveLength(1);
   });
+
+  it("rejects a stale account start after a delayed failed pre-restart status read", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    let configReadCount = 0;
+    let statusReadCount = 0;
+    const mutateState = vi.fn(async () => undefined);
+    const gateway = {
+      baseUrl: "http://127.0.0.1:12345",
+      runtimeEnv: {},
+      tempRoot: "/tmp/matrix-qa",
+      workspaceDir: "/tmp/matrix-qa/workspace",
+      restartAfterStateMutation: vi.fn(
+        async (
+          mutate: (context: {
+            configPath: string;
+            runtimeEnv: NodeJS.ProcessEnv;
+            stateDir: string;
+            tempRoot: string;
+          }) => Promise<void>,
+        ) => {
+          await mutate({
+            configPath: "/tmp/matrix-qa/config.json",
+            runtimeEnv: {},
+            stateDir: "/tmp/matrix-qa/state",
+            tempRoot: "/tmp/matrix-qa",
+          });
+        },
+      ),
+      call: vi.fn(async (method: string) => {
+        if (method === "config.get") {
+          configReadCount += 1;
+          if (configReadCount === 1) {
+            return { config: {} };
+          }
+          if (configReadCount === 2) {
+            return { hash: "config-hash" };
+          }
+          return {
+            appliedConfigHash: "config-hash",
+            configRevisionHash: "config-hash",
+            hash: "config-hash",
+          };
+        }
+        if (method === "config.patch") {
+          return { hash: "config-hash", noop: true, ok: true };
+        }
+        if (method === "channels.status") {
+          statusReadCount += 1;
+          if (statusReadCount === 3) {
+            vi.setSystemTime(1_500);
+            throw new Error("status temporarily unavailable");
+          }
+          return {
+            channelAccounts: {
+              matrix: [
+                {
+                  accountId: "sut",
+                  connected: true,
+                  healthState: "healthy",
+                  lastStartAt:
+                    statusReadCount === 4 ? 1_200 : statusReadCount === 5 ? 1_500 : 1_600,
+                  restartPending: false,
+                  running: true,
+                },
+              ],
+            },
+          };
+        }
+        throw new Error(`unexpected gateway method ${method}`);
+      }),
+    };
+    const environment = createMatrixQaScenarioEnvironment({
+      accountId: "sut",
+      harness: { baseUrl: "http://127.0.0.1:8008", recording: {} } as never,
+      observedEvents: [],
+      provisioning: {
+        driver: { accessToken: "fixture", userId: "@driver:test" },
+        observer: { accessToken: "fixture", userId: "@observer:test" },
+        roomId: "!room:test",
+        sut: { accessToken: "fixture", userId: "@sut:test" },
+        topology: { rooms: [] },
+      } as never,
+    });
+    const prepared = await environment.prepareFlow({
+      config: {},
+      gateway,
+      outputDir: "/tmp/matrix-qa/output",
+      scenarioId: "matrix-state-restart",
+      scenarioTitle: "Matrix state restart",
+      timeoutMs: 2_000,
+      waitForConfigRestartSettle: vi.fn(),
+    });
+
+    const restarting = prepared.scenarioContext.restartGatewayAfterStateMutation?.(mutateState, {
+      timeoutMs: 2_000,
+    });
+    await vi.runAllTimersAsync();
+    await restarting;
+
+    expect(mutateState).toHaveBeenCalledOnce();
+    expect(statusReadCount).toBe(6);
+  });
 });

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
@@ -355,9 +355,15 @@ export function createMatrixQaScenarioEnvironment(params: MatrixQaScenarioEnviro
         if (!restart) {
           throw new Error("Matrix persisted-state scenario requires Gateway restart support");
         }
+        const waitAccountId = opts?.waitAccountId ?? params.accountId;
+        const beforeRestartAt = (
+          await readMatrixAccountStatuses(input.gateway).catch(() => [])
+        ).find((account) => account.accountId === waitAccountId)?.lastStartAt;
+        const restartStartedAt = Date.now();
         await restart(async ({ stateDir }) => await mutateState({ stateDir }));
         await waitForMatrixAccountReady({
-          accountId: opts?.waitAccountId ?? params.accountId,
+          afterStartAt: beforeRestartAt ?? restartStartedAt,
+          accountId: waitAccountId,
           deadline: Date.now() + (opts?.timeoutMs ?? input.timeoutMs),
           gateway: input.gateway,
         });


### PR DESCRIPTION
Replaces #121007
Related: #120588

## What Problem This Solves

Fixes an issue where destructive Matrix QA restarts could accept a healthy account snapshot from before the restart when the pre-restart `channels.status` read failed after a delay.

## Why This Change Was Made

The scenario environment now finishes the pre-restart status read first, captures the fallback boundary immediately before `restart()`, and requires readiness after `beforeRestartAt ?? restartStartedAt`.

This clean replacement is required because #121007 is uneditable (`maintainerCanModify=false`) and its fallback timestamp is captured before the potentially delayed status read. The materially corrected timing diff remains in the same Matrix QA scenario owner boundary. Dallin Romney's original repair and regression design are preserved through the commit's co-author trailer.

## User Impact

No production Matrix behavior changes. Matrix QA restart evidence now rejects account status that became stale during a delayed failed pre-restart read.

## Evidence

- Source PR #121007 remains open at exact head `c8c4bdc641c79bf969153b92986d2f32e64a858c`.
- The focused regression advances fake time during the failed pre-read, then rejects both an older stale post-restart sample and a sample exactly equal to `restartStartedAt` before accepting a strictly newer start timestamp. Six status reads prove both stale samples were rejected.
- Focused branch proof: `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts` - 6 passed.
- Current-main combined proof: the focused scenario and Matrix config tests passed 21/21 with `git diff --check` clean on tree `f4e9bf08051bda977df179acf08ec112a9061df2`. Live `origin/main` then advanced only through unrelated Android notification work to `d506f604d69295ef69f291c5715effb82929b98e`; exact head `021072bd06eb1f17aa0f943ddfc2283e8abf1f05` still merges conflict-free as tree `13a3a43e3606c28366cad82e9c14d57c2a99b1d8`, with no post-proof changed-file intersection.
- The combined tree preserves #120017's Matrix config baseline/patch restoration and this PR's separate `restartGatewayAfterStateMutation` freshness boundary without semantic collision.
- Targeted `pnpm format`, focused oxlint, and `git diff --check` passed.
- Autoreview: Codex `gpt-5.6-sol`, high reasoning, clean with no actionable findings; patch correctness 0.99.
- The latest durable exact-head ClawSweeper review found no code findings. Its Rank-up moves are satisfied: the old `check-test-types` failure was traced to the stale synthetic base's removed `createTempDir` declaration, and fresh exact-head CI completed successfully.
- Pull-request CI run `31320324487` tested exact head `021072bd06eb1f17aa0f943ddfc2283e8abf1f05`. Attempt 2 completed successfully after the one authorized failed-job rerun: `checks-node-compact-large-5` job `93263913146`, `checks-node-compact-large-8` job `93263913121`, and `openclaw/ci-gate` job `93264724836` all passed.
- Production/QA harness: `+7/-1`. Tests: `+103/-0`.
- Authenticated live Matrix proof was not run; this deterministic owner-boundary repair requires no live credentials.
