### PR TITLE
fix(state): let upgraded gateways restart after additive schema changes

### DIFF
--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1956,39 +1956,50 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     ).toEqual([{ task_id: "task-index-repair" }]);
   });
 
-  it("repairs the same-version worktree cleanup column with physical index drift", () => {
-    const stateDir = createTempStateDir();
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
+  it.each([
+    { columnName: "run_end_cleanup_json", tableName: "worktrees" },
+    { columnName: "shared_host", tableName: "worker_environments" },
+  ])(
+    "appends same-version $columnName to $tableName before schema validation",
+    ({ columnName, tableName }) => {
+      const stateDir = createTempStateDir();
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      const databasePath = materializeCurrentStateDatabase(stateDir);
 
-    const { DatabaseSync } = requireNodeSqlite();
-    const shippedSchema = new DatabaseSync(databasePath);
-    try {
-      shippedSchema.exec("ALTER TABLE worktrees DROP COLUMN run_end_cleanup_json;");
-      expect(readSqliteNumberPragma(shippedSchema, "user_version")).toBe(
-        OPENCLAW_STATE_SCHEMA_VERSION,
-      );
-    } finally {
-      shippedSchema.close();
-    }
-    createTaskRunStatusIndexPhysicalDrift(databasePath);
+      const { DatabaseSync } = requireNodeSqlite();
+      const shippedSchema = new DatabaseSync(databasePath);
+      let canonicalColumnOrder: string[];
+      try {
+        canonicalColumnOrder = (
+          shippedSchema.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>
+        ).map((column) => column.name);
+        shippedSchema.exec(`ALTER TABLE ${tableName} DROP COLUMN ${columnName};`);
+        expect(readSqliteNumberPragma(shippedSchema, "user_version")).toBe(
+          OPENCLAW_STATE_SCHEMA_VERSION,
+        );
+      } finally {
+        shippedSchema.close();
+      }
+      createTaskRunStatusIndexPhysicalDrift(databasePath);
 
-    const reopened = openOpenClawStateDatabase({ env });
-    const columns = reopened.db.prepare("PRAGMA table_info(worktrees)").all() as Array<{
-      name: string;
-    }>;
-    expect(columns.map((column) => column.name)).toContain("run_end_cleanup_json");
-    expect(reopened.db.prepare("PRAGMA integrity_check").get()).toEqual({
-      integrity_check: "ok",
-    });
-    expect(
-      reopened.db
-        .prepare(
-          "SELECT task_id FROM task_runs INDEXED BY idx_task_runs_status WHERE status = 'running'",
-        )
-        .all(),
-    ).toEqual([{ task_id: "task-index-repair" }]);
-  });
+      const reopened = openOpenClawStateDatabase({ env });
+      const columns = reopened.db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{
+        name: string;
+      }>;
+      expect(columns.map((column) => column.name)).toEqual(canonicalColumnOrder);
+      expect(canonicalColumnOrder.at(-1)).toBe(columnName);
+      expect(reopened.db.prepare("PRAGMA integrity_check").get()).toEqual({
+        integrity_check: "ok",
+      });
+      expect(
+        reopened.db
+          .prepare(
+            "SELECT task_id FROM task_runs INDEXED BY idx_task_runs_status WHERE status = 'running'",
+          )
+          .all(),
+      ).toEqual([{ task_id: "task-index-repair" }]);
+    },
+  );
 
   it("does not add Claw bootstrap columns before rejecting unrelated index corruption", () => {
     const stateDir = createTempStateDir();

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -1801,10 +1801,10 @@ CREATE TABLE IF NOT EXISTS worktrees (
   owner_id TEXT,
   snapshot_ref TEXT,
   provisioned_paths_json TEXT,
-  run_end_cleanup_json TEXT,
   created_at INTEGER NOT NULL,
   last_active_at INTEGER NOT NULL,
-  removed_at INTEGER
+  removed_at INTEGER,
+  run_end_cleanup_json TEXT
 ) STRICT;
 
 CREATE INDEX IF NOT EXISTS idx_worktrees_repo_fingerprint
@@ -1846,7 +1846,6 @@ CREATE TABLE IF NOT EXISTS worker_environments (
   profile_snapshot_json TEXT NOT NULL,
   provision_operation_id TEXT NOT NULL UNIQUE,
   lease_id TEXT,
-  shared_host INTEGER CHECK (shared_host IN (0, 1)),
   ssh_host TEXT,
   ssh_port INTEGER CHECK (ssh_port IS NULL OR (ssh_port >= 1 AND ssh_port <= 65535)),
   ssh_user TEXT,
@@ -1878,7 +1877,8 @@ CREATE TABLE IF NOT EXISTS worker_environments (
   state_changed_at_ms INTEGER NOT NULL,
   idle_since_at_ms INTEGER,
   destroy_requested_at_ms INTEGER,
-  last_error TEXT
+  last_error TEXT,
+  shared_host INTEGER CHECK (shared_host IN (0, 1))
 ) STRICT;
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_worker_environments_provider_lease


### PR DESCRIPTION
Closes #121061

AI-assisted implementation; I reviewed the schema ownership boundary, regression coverage, production failure, and focused proof.

## What Problem This Solves

Fixes an issue where operators restarting after a supported same-version SQLite additive-column repair could lose the entire Gateway because the integrity-clean shared state database was rejected as noncanonical.

SQLite appends new columns, but fresh database definitions placed `worktrees.run_end_cleanup_json` and `worker_environments.shared_host` earlier in their tables. Upgraded databases therefore had equivalent data and constraints in a different ordinal order, causing deterministic startup failure and managed-service restart loops.

## Why This Change Was Made

The canonical fresh-schema definitions now use the same append order that SQLite necessarily produces during `ALTER TABLE ... ADD COLUMN`. Existing additive repair remains the sole owner; there is no schema-version bump, data rewrite, compatibility branch, or runtime fallback.

Regression coverage opens current-version databases missing each affected column through the real shared-state owner and proves the repaired column order exactly matches a fresh canonical database.

## User Impact

Gateways with either affected upgraded table shape can restart normally without manual SQLite repair. Fresh and upgraded databases now converge on one canonical schema shape.

## Evidence

- Production reproduction: immutable Gateway activation failed with `column definitions differ for worktrees` and then `column definitions differ for worker_environments`; the same database passed `PRAGMA integrity_check` and `PRAGMA foreign_key_check`.
- `node scripts/run-vitest.mjs src/state/openclaw-state-db.test.ts`: 113 passed, 1 skipped.
- `node scripts/check-native-state-schema-version.mjs`: passed at schema v6; no bump required.
- Targeted `oxfmt --check`: passed.
- `git diff --check`: passed.
- Native uncommitted autoreview: clean, no accepted/actionable findings; TruffleHog clean.
- Live production recovery at exact head `d3da11786b82b9dc9cf389601c220276bb0eaf7f`: the integrity-clean existing database opened without a rewrite, admin RPC became healthy, and Telegram, WhatsApp, and SSH-backed iMessage all reached ready/healthy state.
- Live iMessage behavior at the same head: provider-accepted outbound arrived in receiver history; a fresh paired inbound message produced the exact requested automatic acknowledgement through the remote Mini.
- Production LOC: +4 / -4, net zero.
- Test LOC: +42 / -31, net +11.
