### PR TITLE
fix(cli): preserve Windows user arguments named node.exe

### DIFF
--- a/src/cli/channels-cli.test.ts
+++ b/src/cli/channels-cli.test.ts
@@ -528,8 +528,8 @@ describe("registerChannelsCli", () => {
     mockProcessPlatform("win32");
     process.argv = [
       "C:\\Program Files\\nodejs\\node.exe",
-      "C:\\repo\\openclaw.js",
       "C:\\Program Files\\nodejs\\node.exe",
+      "C:\\repo\\openclaw.js",
       "channels",
       "add",
       "--channel",

--- a/src/cli/windows-argv.test.ts
+++ b/src/cli/windows-argv.test.ts
@@ -83,4 +83,52 @@ describe("normalizeWindowsArgv", () => {
       platform.mockRestore();
     }
   });
+
+  it("preserves node.exe as the first user argument after the script entry", () => {
+    const platform = mockProcessPlatform("win32");
+    try {
+      expect(
+        normalizeWindowsArgv([
+          "C:\\Program Files\\nodejs\\node.exe",
+          "C:\\pkg\\openclaw.mjs",
+          "node.exe",
+          "--help",
+        ]),
+      ).toEqual([
+        "C:\\Program Files\\nodejs\\node.exe",
+        "C:\\pkg\\openclaw.mjs",
+        "node.exe",
+        "--help",
+      ]);
+    } finally {
+      platform.mockRestore();
+    }
+  });
+
+  it("preserves a post-script node.exe argument after normalizing a duplicated prefix", () => {
+    const platform = mockProcessPlatform("win32");
+    try {
+      expect(
+        normalizeWindowsArgv([
+          "C:\\Program Files\\nodejs\\node.exe",
+          "C:\\Program Files\\nodejs\\node.exe",
+          "C:\\pkg\\openclaw.mjs",
+          "node.exe",
+          "--help",
+        ]),
+      ).toEqual([
+        "C:\\Program Files\\nodejs\\node.exe",
+        "C:\\pkg\\openclaw.mjs",
+        "node.exe",
+        "--help",
+      ]);
+    } finally {
+      platform.mockRestore();
+    }
+  });
+
+  it("does not normalize POSIX argv", () => {
+    const argv = ["/usr/bin/node", "/opt/openclaw/openclaw.mjs", "node.exe", "--help"];
+    expect(normalizeWindowsArgv(argv, { platform: "linux" })).toBe(argv);
+  });
 });

--- a/src/cli/windows-argv.ts
+++ b/src/cli/windows-argv.ts
@@ -58,31 +58,13 @@ export function normalizeWindowsArgv(
     );
   };
 
-  const argv0IsExecPath = isExecPath(argv[0]);
   const next = [...argv];
-  let removedLauncherPrefix = false;
   for (const i = 1; i < next.length;) {
     if (isExecPath(next[i])) {
       next.splice(i, 1);
-      removedLauncherPrefix = true;
       continue;
     }
     break;
   }
-  if (next.length < 3 || (!argv0IsExecPath && !removedLauncherPrefix)) {
-    return next;
-  }
-  const cleaned = [...next];
-  for (const i = 2; i < cleaned.length;) {
-    const arg = cleaned[i];
-    if (!arg || arg.startsWith("-")) {
-      break;
-    }
-    if (isExecPath(arg)) {
-      cleaned.splice(i, 1);
-      continue;
-    }
-    break;
-  }
-  return cleaned;
+  return next;
 }

--- a/src/entry.respawn.test.ts
+++ b/src/entry.respawn.test.ts
@@ -216,7 +216,7 @@ describe("buildCliRespawnPlan", () => {
     expect(respawnPlan.detachForProcessTree).toBe(false);
   });
 
-  it("normalizes duplicated Windows node.exe argv before respawning", () => {
+  it("normalizes a duplicated Windows node.exe launcher prefix before respawning", () => {
     const scriptPath =
       "C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\openclaw\\openclaw.mjs";
     const plan = buildCliRespawnPlan({
@@ -224,7 +224,6 @@ describe("buildCliRespawnPlan", () => {
         "C:\\Program Files\\nodejs\\node.exe",
         "C:\\Program Files\\nodejs\\node.exe",
         scriptPath,
-        "node.exe",
         "dashboard",
         "--no-open",
       ],
@@ -236,6 +235,27 @@ describe("buildCliRespawnPlan", () => {
 
     const respawnPlan = expectCliRespawnPlan(plan);
     expect(respawnPlan.argv).toEqual(["--stack-size=8192", scriptPath, "dashboard", "--no-open"]);
+  });
+
+  it("preserves post-script node.exe arguments after normalizing the launcher prefix", () => {
+    const scriptPath =
+      "C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\openclaw\\openclaw.mjs";
+    const plan = buildCliRespawnPlan({
+      argv: [
+        "C:\\Program Files\\nodejs\\node.exe",
+        "C:\\Program Files\\nodejs\\node.exe",
+        scriptPath,
+        "node.exe",
+        "status",
+      ],
+      env: {},
+      execArgv: [],
+      execPath: "C:\\Program Files\\nodejs\\node.exe",
+      platform: "win32",
+    });
+
+    const respawnPlan = expectCliRespawnPlan(plan);
+    expect(respawnPlan.argv).toEqual(["--stack-size=8192", scriptPath, "node.exe", "status"]);
   });
 
   it("does not respawn on Windows when stack size is already configured", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows users passing a command token named `node.exe` could receive unrelated root help instead of a visible unknown-command result. The Windows argv normalizer treated a legitimate post-script user argument as another launcher artifact and silently deleted it.

## Why This Change Was Made

Windows launcher normalization now removes duplicate Node executable tokens only from the launcher prefix before the entry script. It no longer scans into user-owned argv after the entry boundary. This keeps the existing npm/pnpm wrapper repair while removing an inference that conflicts with Node's argv contract.

Node 24 defines `argv[0]` as the executable, `argv[1]` as the program entry point, and all remaining elements as additional command-line arguments. The repo-pinned pnpm 11.15.1 bundles `@zkochan/cmd-shim` 9.0.6, whose CMD, PowerShell, and shell generators place the interpreter and target script before `%*`, `$args`, or `$@`. Therefore a `node.exe` after the script is user input, not a launcher duplicate.

Production delta is `+1/-19` (net `-18`); tests are `+70/-2` (net `+68`). No config, schema, dependency, protocol, security policy, fallback, or public SDK surface changes.

## User Impact

Windows CLI invocations preserve every user argument after the script entry. Invalid commands named `node.exe` now produce the normal actionable unknown-command diagnostic instead of silently turning into root help.

## Evidence

- Native Windows red proof on exact current main `1471881af7aaff047c605dce08caa9a86f0de316`:
  - `corepack pnpm openclaw node.exe --help`
  - exit `0`; printed root help because `node.exe` was deleted.
- Native Windows green proof on exact head `14a8afbad4a03e2e0b8cac7cb81bfef889866439`:
  - identical command
  - exit `1`; visibly reported `Unknown command: openclaw node.exe` plus doctor/help next steps.
- Focused one-worker tests: `src/cli/windows-argv.test.ts` and `src/entry.respawn.test.ts`, `29/29` passed.
- Exact three-path formatting and `git diff --check` passed.
- Fresh-current-main audit: all three owner/test blobs were unchanged from candidate parent through `4ade409cf2fd17b8dcddf05486e125dfac29536a`; merge-tree was clean and bounded live duplicate searches found no matching PR.
- Structured exact-commit review passed TruffleHog. Its sole P1 was rejected after direct dependency inspection because it assumed a post-script `node.exe` could be a launcher token, contrary to Node and pnpm shim contracts.
- Independent exact-commit P0/P1 review re-read all callers, history, Node 24.18.0, pnpm 11.15.1, and bundled cmd-shim 9.0.6; it returned clean and judged prefix-only normalization the best fix.

Original candidate and current-main rebuild authored by Peter Steinberger with autonomous Windows QA verification.
