### PR TITLE
fix: close task terminals after completion

### DIFF
--- a/src/agents/tools/terminal-tool.test.ts
+++ b/src/agents/tools/terminal-tool.test.ts
@@ -145,6 +145,24 @@ describe("terminal tool", () => {
     expect(backend.killed).toBe(true);
   });
 
+  it("binds a uniquely active task to terminals opened from its child session", async () => {
+    const backend = makeBackend();
+    const manager = new TerminalSessionManager({ emit: vi.fn(), spawn: async () => backend });
+    const resolveTaskOwnerId = vi.fn(async () => "task-1");
+    const tool = createTerminalTool({
+      agentId: "main",
+      agentSessionKey: "agent:main:task-run",
+      resolveTaskOwnerId,
+      getGatewayContext: () => makeContext(manager),
+    });
+
+    await tool.execute("open", { action: "open", show: false });
+
+    expect(resolveTaskOwnerId).toHaveBeenCalledWith("agent:main:task-run");
+    expect(manager.closeTaskSessions("task-1")).toBe(1);
+    expect(backend.killed).toBe(true);
+  });
+
   it("fails closed when launch policy blocks the agent", async () => {
     const spawn = vi.fn(async () => makeBackend());
     const manager = new TerminalSessionManager({ emit: vi.fn(), spawn });

--- a/src/agents/tools/terminal-tool.test.ts
+++ b/src/agents/tools/terminal-tool.test.ts
@@ -159,7 +159,7 @@ describe("terminal tool", () => {
     await tool.execute("open", { action: "open", show: false });
 
     expect(resolveTaskOwnerId).toHaveBeenCalledWith("agent:main:task-run");
-    expect(manager.closeTaskSessions("task-1")).toBe(1);
+    expect(manager.closeAgentSessions("task-1")).toBe(1);
     expect(backend.killed).toBe(true);
   });
 

--- a/src/agents/tools/terminal-tool.ts
+++ b/src/agents/tools/terminal-tool.ts
@@ -79,8 +79,8 @@ type TerminalToolOptions = {
 };
 
 async function resolveTaskOwnerId(agentSessionKey: string): Promise<string | undefined> {
-  const { listTasksForSessionKey } = await import("../../tasks/task-registry.js");
-  const tasks = listTasksForSessionKey(agentSessionKey).filter(
+  const { listTasksForSessionKeyForStatus } = await import("../../tasks/task-status-access.js");
+  const tasks = listTasksForSessionKeyForStatus(agentSessionKey).filter(
     (task) =>
       (task.status === "queued" || task.status === "running") &&
       task.childSessionKey?.trim() === agentSessionKey,

--- a/src/agents/tools/terminal-tool.ts
+++ b/src/agents/tools/terminal-tool.ts
@@ -73,9 +73,22 @@ type TerminalToolGatewayContext = Pick<
 type TerminalToolOptions = {
   agentId?: string;
   agentSessionKey?: string;
+  resolveTaskOwnerId?: (agentSessionKey: string) => Promise<string | undefined>;
   callGateway?: InProcessGatewayCaller;
   getGatewayContext?: () => TerminalToolGatewayContext | undefined;
 };
+
+async function resolveTaskOwnerId(agentSessionKey: string): Promise<string | undefined> {
+  const { listTasksForSessionKey } = await import("../../tasks/task-registry.js");
+  const tasks = listTasksForSessionKey(agentSessionKey).filter(
+    (task) =>
+      (task.status === "queued" || task.status === "running") &&
+      task.childSessionKey?.trim() === agentSessionKey,
+  );
+  // Shared persistent sessions can host more than one task. Without a unique
+  // owner, keep the terminal conversation-scoped instead of guessing.
+  return tasks.length === 1 ? tasks[0]?.taskId : undefined;
+}
 
 function readDimension(
   params: Record<string, unknown>,
@@ -142,6 +155,7 @@ function launchBlockMessage(
 export function createTerminalTool(opts: TerminalToolOptions = {}): AnyAgentTool {
   const gatewayCall = opts.callGateway ?? callInProcessGatewayTool;
   const getContext = opts.getGatewayContext ?? getInProcessGatewayToolContext;
+  const resolveOwnerTaskId = opts.resolveTaskOwnerId ?? resolveTaskOwnerId;
   return {
     label: "Terminal",
     name: "terminal",
@@ -184,6 +198,7 @@ export function createTerminalTool(opts: TerminalToolOptions = {}): AnyAgentTool
           ...launch.plan,
           ...(cwd ? { cwdOverride: cwd } : {}),
         });
+        const taskId = await resolveOwnerTaskId(agentSessionKey);
         const deadline = createTerminalOpenDeadline();
         const cancelOpen = () => {
           if (!deadline.controller.signal.aborted) {
@@ -200,7 +215,7 @@ export function createTerminalTool(opts: TerminalToolOptions = {}): AnyAgentTool
         try {
           outcome = await waitForTerminalOpenDeadline(() => {
             openingTerminal = manager.open({
-              owner: { kind: "agent", agentSessionKey },
+              owner: { kind: "agent", agentSessionKey, ...(taskId ? { taskId } : {}) },
               agentId: spawnPlan.agentId,
               cwd: spawnPlan.cwd,
               shell: spawnPlan.shell,

--- a/src/agents/tools/terminal-tool.ts
+++ b/src/agents/tools/terminal-tool.ts
@@ -199,6 +199,7 @@ export function createTerminalTool(opts: TerminalToolOptions = {}): AnyAgentTool
           ...(cwd ? { cwdOverride: cwd } : {}),
         });
         const taskId = await resolveOwnerTaskId(agentSessionKey);
+        const owner = { kind: "agent", agentSessionKey, ...(taskId ? { taskId } : {}) } as const;
         const deadline = createTerminalOpenDeadline();
         const cancelOpen = () => {
           if (!deadline.controller.signal.aborted) {
@@ -215,7 +216,7 @@ export function createTerminalTool(opts: TerminalToolOptions = {}): AnyAgentTool
         try {
           outcome = await waitForTerminalOpenDeadline(() => {
             openingTerminal = manager.open({
-              owner: { kind: "agent", agentSessionKey, ...(taskId ? { taskId } : {}) },
+              owner,
               agentId: spawnPlan.agentId,
               cwd: spawnPlan.cwd,
               shell: spawnPlan.shell,

--- a/src/gateway/server-runtime-subscriptions.test.ts
+++ b/src/gateway/server-runtime-subscriptions.test.ts
@@ -142,7 +142,7 @@ function createParams(): SubscriptionParams {
     sessionMessageSubscribers: createSessionMessageSubscriberRegistry(),
     chatAbortControllers: new Map(),
     restartRecoveryCandidates: new Map(),
-    terminalSessions: { closeTaskSessions: vi.fn() },
+    terminalSessions: { closeAgentSessions: vi.fn() },
   };
 }
 
@@ -402,7 +402,7 @@ describe("startGatewayEventSubscriptions", () => {
 
   it("closes task-run terminals only after the authoritative task becomes terminal", async () => {
     const events: string[] = [];
-    const closeTaskSessions = vi.fn((taskId: string) => {
+    const closeAgentSessions = vi.fn((taskId: string) => {
       events.push(`terminal:${taskId}`);
       return 1;
     });
@@ -415,7 +415,7 @@ describe("startGatewayEventSubscriptions", () => {
     unsubs = startGatewayEventSubscriptions({
       ...createParams(),
       broadcast,
-      terminalSessions: { closeTaskSessions },
+      terminalSessions: { closeAgentSessions },
     });
     await waitForFast(() => expect(getTaskRegistryObservers()).not.toBeNull());
 
@@ -434,17 +434,17 @@ describe("startGatewayEventSubscriptions", () => {
     if (!task) {
       throw new Error("expected task record");
     }
-    expect(closeTaskSessions).not.toHaveBeenCalled();
+    expect(closeAgentSessions).not.toHaveBeenCalled();
     expect(events).toEqual(["task:running"]);
 
     markTaskTerminalById({ taskId: task.taskId, status: "succeeded", endedAt: 2_000 });
-    expect(closeTaskSessions).toHaveBeenCalledOnce();
-    expect(closeTaskSessions).toHaveBeenCalledWith(task.taskId);
+    expect(closeAgentSessions).toHaveBeenCalledOnce();
+    expect(closeAgentSessions).toHaveBeenCalledWith(task.taskId);
     expect(events).toEqual(["task:running", "task:completed", `terminal:${task.taskId}`]);
 
     // Later terminal-row updates cannot close terminals opened by a newer owner.
     markTaskTerminalById({ taskId: task.taskId, status: "succeeded", endedAt: 2_001 });
-    expect(closeTaskSessions).toHaveBeenCalledOnce();
+    expect(closeAgentSessions).toHaveBeenCalledOnce();
   });
 
   it("keeps a replacement gateway's task observer when a stale unsub runs late", async () => {

--- a/src/gateway/server-runtime-subscriptions.test.ts
+++ b/src/gateway/server-runtime-subscriptions.test.ts
@@ -142,7 +142,7 @@ function createParams(): SubscriptionParams {
     sessionMessageSubscribers: createSessionMessageSubscriberRegistry(),
     chatAbortControllers: new Map(),
     restartRecoveryCandidates: new Map(),
-    terminalSessions: { closeAgentSessions: vi.fn() },
+    terminalSessions: { closeTaskSessions: vi.fn() },
   };
 }
 
@@ -402,8 +402,8 @@ describe("startGatewayEventSubscriptions", () => {
 
   it("closes task-run terminals only after the authoritative task becomes terminal", async () => {
     const events: string[] = [];
-    const closeAgentSessions = vi.fn((sessionKey: string) => {
-      events.push(`terminal:${sessionKey}`);
+    const closeTaskSessions = vi.fn((taskId: string) => {
+      events.push(`terminal:${taskId}`);
       return 1;
     });
     const broadcast = vi.fn<SubscriptionParams["broadcast"]>((event, payload) => {
@@ -415,7 +415,7 @@ describe("startGatewayEventSubscriptions", () => {
     unsubs = startGatewayEventSubscriptions({
       ...createParams(),
       broadcast,
-      terminalSessions: { closeAgentSessions },
+      terminalSessions: { closeTaskSessions },
     });
     await waitForFast(() => expect(getTaskRegistryObservers()).not.toBeNull());
 
@@ -434,38 +434,17 @@ describe("startGatewayEventSubscriptions", () => {
     if (!task) {
       throw new Error("expected task record");
     }
-    expect(closeAgentSessions).not.toHaveBeenCalled();
+    expect(closeTaskSessions).not.toHaveBeenCalled();
     expect(events).toEqual(["task:running"]);
 
     markTaskTerminalById({ taskId: task.taskId, status: "succeeded", endedAt: 2_000 });
-    expect(closeAgentSessions).toHaveBeenCalledOnce();
-    expect(closeAgentSessions).toHaveBeenCalledWith(runSessionKey);
-    expect(events).toEqual(["task:running", "task:completed", `terminal:${runSessionKey}`]);
+    expect(closeTaskSessions).toHaveBeenCalledOnce();
+    expect(closeTaskSessions).toHaveBeenCalledWith(task.taskId);
+    expect(events).toEqual(["task:running", "task:completed", `terminal:${task.taskId}`]);
 
     // Later terminal-row updates cannot close terminals opened by a newer owner.
     markTaskTerminalById({ taskId: task.taskId, status: "succeeded", endedAt: 2_001 });
-    expect(closeAgentSessions).toHaveBeenCalledOnce();
-
-    const persistentTask = createTaskRecord({
-      runtime: "cron",
-      requesterSessionKey: "agent:main:main",
-      ownerKey: "",
-      scopeKind: "system",
-      childSessionKey: "agent:main:main",
-      task: "Persistent conversation task",
-      status: "running",
-      deliveryStatus: "not_applicable",
-      notifyPolicy: "silent",
-    });
-    if (!persistentTask) {
-      throw new Error("expected persistent task record");
-    }
-    markTaskTerminalById({
-      taskId: persistentTask.taskId,
-      status: "succeeded",
-      endedAt: 3_000,
-    });
-    expect(closeAgentSessions).toHaveBeenCalledOnce();
+    expect(closeTaskSessions).toHaveBeenCalledOnce();
   });
 
   it("keeps a replacement gateway's task observer when a stale unsub runs late", async () => {

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -10,11 +10,6 @@ import { clearAgentRunContext } from "../infra/agent-run-registry.js";
 import { onTrustedToolExecutionEvent } from "../infra/diagnostic-events.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import type { SubsystemLogger } from "../logging/subsystem.js";
-import {
-  isAcpSessionKey,
-  isCronRunSessionKey,
-  isSubagentSessionKey,
-} from "../sessions/session-key-utils.js";
 import { onSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { onInternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { createLazyPromise, createLazyPromiseLoader } from "../shared/lazy-runtime.js";
@@ -52,24 +47,14 @@ function dispatchEventHandler<TEvent>(params: {
     });
 }
 
-function terminalTaskSessionKey(event: TaskRegistryObserverEvent): string | undefined {
+function terminalTaskId(event: TaskRegistryObserverEvent): string | undefined {
   if (event.kind !== "upserted" || !isTerminalTaskStatus(event.task.status)) {
     return undefined;
   }
   if (event.previous && isTerminalTaskStatus(event.previous.status)) {
     return undefined;
   }
-  const sessionKey = event.task.childSessionKey?.trim();
-  if (!sessionKey) {
-    return undefined;
-  }
-  // Persistent conversation targets intentionally retain their terminals.
-  // Only task-run identities end when their authoritative task row terminalizes.
-  const taskRunScoped =
-    isCronRunSessionKey(sessionKey) ||
-    isSubagentSessionKey(sessionKey) ||
-    isAcpSessionKey(sessionKey);
-  return taskRunScoped ? sessionKey : undefined;
+  return event.task.taskId;
 }
 
 /** Register gateway runtime event subscriptions and return unsubscribe handles. */
@@ -90,7 +75,7 @@ export function startGatewayEventSubscriptions(params: {
   sessionMessageSubscribers: SessionMessageSubscriberRegistry;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   restartRecoveryCandidates: Map<string, RestartRecoveryCandidate>;
-  terminalSessions: Pick<TerminalSessionManager, "closeAgentSessions">;
+  terminalSessions: Pick<TerminalSessionManager, "closeTaskSessions">;
 }) {
   // The worker always runs retention maintenance. audit.enabled only controls
   // producer subscriptions, so disabling collection cannot strand expired rows.
@@ -402,9 +387,9 @@ export function startGatewayEventSubscriptions(params: {
           break;
       }
       params.broadcast("task", payload, { dropIfSlow: true });
-      const sessionKey = terminalTaskSessionKey(event);
-      if (sessionKey) {
-        params.terminalSessions.closeAgentSessions(sessionKey);
+      const taskId = terminalTaskId(event);
+      if (taskId) {
+        params.terminalSessions.closeTaskSessions(taskId);
       }
     },
   };

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -75,7 +75,7 @@ export function startGatewayEventSubscriptions(params: {
   sessionMessageSubscribers: SessionMessageSubscriberRegistry;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   restartRecoveryCandidates: Map<string, RestartRecoveryCandidate>;
-  terminalSessions: Pick<TerminalSessionManager, "closeTaskSessions">;
+  terminalSessions: Pick<TerminalSessionManager, "closeAgentSessions">;
 }) {
   // The worker always runs retention maintenance. audit.enabled only controls
   // producer subscriptions, so disabling collection cannot strand expired rows.
@@ -389,7 +389,7 @@ export function startGatewayEventSubscriptions(params: {
       params.broadcast("task", payload, { dropIfSlow: true });
       const taskId = terminalTaskId(event);
       if (taskId) {
-        params.terminalSessions.closeTaskSessions(taskId);
+        params.terminalSessions.closeAgentSessions(taskId);
       }
     },
   };

--- a/src/gateway/terminal/session-manager.task-lifecycle.test.ts
+++ b/src/gateway/terminal/session-manager.task-lifecycle.test.ts
@@ -20,6 +20,7 @@ describe("TerminalSessionManager task lifecycle", () => {
     const runOwner = {
       kind: "agent",
       agentSessionKey: "agent:main:cron:job-1:run:run-1",
+      taskId: "task-1",
     } as const;
     const persistentOwner = { kind: "agent", agentSessionKey: "agent:main:main" } as const;
     const first = await manager.open(baseOpenRequest({ owner: runOwner }));
@@ -35,7 +36,7 @@ describe("TerminalSessionManager task lifecycle", () => {
     manager.attach("viewer-2", second.sessionId);
     emit.mockClear();
 
-    expect(manager.closeAgentSessions(runOwner.agentSessionKey)).toBe(2);
+    expect(manager.closeTaskSessions(runOwner.taskId)).toBe(2);
     expect(runPtys.every((pty) => pty.killed)).toBe(true);
     expect(persistentPty.killed).toBe(false);
     expect(connectionPty.killed).toBe(false);

--- a/src/gateway/terminal/session-manager.task-lifecycle.test.ts
+++ b/src/gateway/terminal/session-manager.task-lifecycle.test.ts
@@ -36,7 +36,7 @@ describe("TerminalSessionManager task lifecycle", () => {
     manager.attach("viewer-2", second.sessionId);
     emit.mockClear();
 
-    expect(manager.closeTaskSessions(runOwner.taskId)).toBe(2);
+    expect(manager.closeAgentSessions(runOwner.taskId)).toBe(2);
     expect(runPtys.every((pty) => pty.killed)).toBe(true);
     expect(persistentPty.killed).toBe(false);
     expect(connectionPty.killed).toBe(false);

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -39,8 +39,11 @@ const log = createSubsystemLogger("gateway/terminal");
 // conversation-scoped while lifecycle cleanup can target the exact producer.
 type TaskBoundAgentOwner = Extract<TerminalOwner, { kind: "agent" }> & { taskId?: string };
 
-function terminalOwnerTaskId(owner: TerminalOwner | null): string | undefined {
-  return owner?.kind === "agent" ? (owner as TaskBoundAgentOwner).taskId : undefined;
+function terminalOwnerMatches(owner: TerminalOwner | null, ownerKey: string): boolean {
+  if (owner?.kind !== "agent") {
+    return false;
+  }
+  return owner.agentSessionKey === ownerKey || (owner as TaskBoundAgentOwner).taskId === ownerKey;
 }
 
 /**
@@ -389,10 +392,10 @@ export class TerminalSessionManager {
     return true;
   }
 
-  /** Closes every PTY whose agent owner was bound to one exact task. */
-  closeTaskSessions(taskId: string): number {
+  /** Closes every PTY owned by one exact agent session. */
+  closeAgentSessions(agentSessionKey: string): number {
     const owned = [...this.sessions.values()].filter(
-      (session) => !session.closed && terminalOwnerTaskId(session.owner) === taskId,
+      (session) => !session.closed && terminalOwnerMatches(session.owner, agentSessionKey),
     );
     for (const session of owned) {
       this.finalize(session, "closed", {});

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -35,6 +35,14 @@ import type {
 
 const log = createSubsystemLogger("gateway/terminal");
 
+// Task binding is manager-private metadata: public terminal ownership stays
+// conversation-scoped while lifecycle cleanup can target the exact producer.
+type TaskBoundAgentOwner = Extract<TerminalOwner, { kind: "agent" }> & { taskId?: string };
+
+function terminalOwnerTaskId(owner: TerminalOwner | null): string | undefined {
+  return owner?.kind === "agent" ? (owner as TaskBoundAgentOwner).taskId : undefined;
+}
+
 /**
  * Tracks live PTY sessions keyed by session id, with a reverse index for
  * connection owners and viewers so disconnect cleanup stays bounded.
@@ -384,8 +392,7 @@ export class TerminalSessionManager {
   /** Closes every PTY whose agent owner was bound to one exact task. */
   closeTaskSessions(taskId: string): number {
     const owned = [...this.sessions.values()].filter(
-      (session) =>
-        !session.closed && session.owner?.kind === "agent" && session.owner.taskId === taskId,
+      (session) => !session.closed && terminalOwnerTaskId(session.owner) === taskId,
     );
     for (const session of owned) {
       this.finalize(session, "closed", {});

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -381,13 +381,11 @@ export class TerminalSessionManager {
     return true;
   }
 
-  /** Closes every PTY owned by one exact agent session. */
-  closeAgentSessions(agentSessionKey: string): number {
+  /** Closes every PTY whose agent owner was bound to one exact task. */
+  closeTaskSessions(taskId: string): number {
     const owned = [...this.sessions.values()].filter(
       (session) =>
-        !session.closed &&
-        session.owner?.kind === "agent" &&
-        session.owner.agentSessionKey === agentSessionKey,
+        !session.closed && session.owner?.kind === "agent" && session.owner.taskId === taskId,
     );
     for (const session of owned) {
       this.finalize(session, "closed", {});

--- a/src/gateway/terminal/session-manager.types.ts
+++ b/src/gateway/terminal/session-manager.types.ts
@@ -9,7 +9,7 @@ export type TerminalExitReason = "process_exit" | "closed" | "disconnected" | "d
 
 export type TerminalOwner =
   | { kind: "conn"; connId: string }
-  | { kind: "agent"; agentSessionKey: string };
+  | { kind: "agent"; agentSessionKey: string; taskId?: string };
 
 export type TerminalSession = {
   id: string;

--- a/src/gateway/terminal/session-manager.types.ts
+++ b/src/gateway/terminal/session-manager.types.ts
@@ -9,7 +9,7 @@ export type TerminalExitReason = "process_exit" | "closed" | "disconnected" | "d
 
 export type TerminalOwner =
   | { kind: "conn"; connId: string }
-  | { kind: "agent"; agentSessionKey: string; taskId?: string };
+  | { kind: "agent"; agentSessionKey: string };
 
 export type TerminalSession = {
   id: string;


### PR DESCRIPTION
Related: #121055

## What Problem This Solves

Fixes an issue where terminals opened by a task could remain alive after that task completed when its agent session key did not use a recognized cron, subagent, or ACP naming pattern. Those leaked PTYs kept the Gateway's active-work blocker set non-empty after otherwise successful tasks.

This follows #121055 after independent source-blind validation found that a generic CLI task still leaked both of its terminals.

## Why This Change Was Made

Terminal ownership now records the exact active task ID at creation time. Task lifecycle cleanup closes only terminals carrying that task ID, while normal conversation terminals and connection-owned terminals remain persistent. Ambiguous shared-session cases stay conversation-scoped rather than guessing ownership.

The repair replaces session-key syntax inference with the task registry's authoritative ownership relationship. Production code is +34/-25 (net +9); the added lines keep task binding private while preserving the existing public terminal-manager contract.

## User Impact

When a terminal task finishes, all terminals that task opened are closed and attached viewers receive `terminal.exit`. Unrelated normal-chat and browser-attached terminals continue running.

## Evidence

- Source-blind AWS behavior validation: 5/5 clauses passed at implementation commit `de5ada41e23b` (implementation rebased as `6a3faee59616`): running-task retention, exact task-owned cleanup, normal-chat persistence, connection-owned persistence, viewer exit delivery, and PTY drain.
- Focused Testbox proof: 19/19 tests passed across `terminal-tool`, Gateway task subscriptions, and terminal task lifecycle (`tbx_01kzk9b03srt4t78d3ehrhqw40`; [run 31314398390](https://github.com/openclaw/openclaw/actions/runs/31314398390)).
- Task access-boundary follow-up: 13/13 focused tests passed after routing the lookup through the approved task read seam (`tbx_01kzkcfpte5rp4fk3kwkwpeyxq`; [run 31316755916](https://github.com/openclaw/openclaw/actions/runs/31316755916)).
- Final compatibility-preserving shape: Plugin SDK baseline and 16/16 task-boundary/Gateway lifecycle tests passed in [run 31318374042](https://github.com/openclaw/openclaw/actions/runs/31318374042); the updated terminal-tool caller passed 8/8 in [run 31318564503](https://github.com/openclaw/openclaw/actions/runs/31318564503), and targeted formatting passed in [run 31318739874](https://github.com/openclaw/openclaw/actions/runs/31318739874).
- The full changed gate, core/core-test typechecks, lint, and architecture guards passed before the final private-only refactor; targeted formatting and `git diff --check` passed on the current shape.
- Final Codex autoreview: clean, no accepted/actionable findings, confidence 0.98.
