### PR TITLE
fix: restore session transcript test type-checking

### DIFF
--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -545,7 +545,7 @@ describe("user turn transcript persistence", () => {
     });
 
     it("waits for a deferred projection rebuild before returning admission identity", async () => {
-      const dir = createTempDir("openclaw-user-turn-recorder-projection-");
+      const dir = tempDirs.make("openclaw-user-turn-recorder-projection-");
       const target = createSqliteTranscriptTarget({ dir });
       await replaceSessionEntry(
         { storePath: target.storePath, sessionKey: target.sessionKey },


### PR DESCRIPTION
## What Problem This Solves

Restores exact-head main CI after the session transcript test retained one call to a temp-directory helper removed by the shared test-helper migration. The stale reference failed both test type-checking and the compact Node test shard.

## Why This Change Was Made

The remaining transcript projection test now allocates its temporary directory through the file's existing auto-cleanup tracker, matching every sibling test and preserving after-each cleanup ownership.

## User Impact

No runtime behavior changes. This restores CI compilation and execution for the session transcript regression suite.

## Evidence

- Blacksmith Testbox: [run 31315591890](https://github.com/openclaw/openclaw/actions/runs/31315591890)
- Focused test: `src/sessions/user-turn-transcript.test.ts` — 40/40 passed, including the deferred projection rebuild case
- Test type-check: core, extensions, and root test TypeScript projects passed
- `git diff --check` passed
- Autoreview: clean, with no accepted/actionable findings
- Production LOC: +0/-0; tests: +1/-1
