### PR TITLE
fix(npm-lock): generated package locks install both glibc and musl builds

### DIFF
--- a/scripts/generate-npm-package-lock.mts
+++ b/scripts/generate-npm-package-lock.mts
@@ -175,6 +175,36 @@ function readPnpmLockPackages() {
   return lockPackages;
 }
 
+/**
+ * Reads `libc` constraints from pnpm-lock.yaml keyed by `name@version`.
+ * npm only emits `libc` in package-lock.json from npm 11 onward, so the pnpm
+ * lock is the version-independent source of truth for this field.
+ */
+function readPnpmLockPackageLibc() {
+  const lockfile = readPnpmLock();
+  const packages = recordAt(lockfile, "packages") ?? {};
+  const libcByPackageKey = new Map<string, string[]>();
+  for (const [packageKey, metadata] of Object.entries(packages)) {
+    const parsed = parsePnpmPackageKey(packageKey);
+    const libc = isPlainObject(metadata) ? metadata.libc : undefined;
+    if (!parsed || !Array.isArray(libc)) {
+      continue;
+    }
+    const values = libc.filter((entry): entry is string => typeof entry === "string");
+    if (values.length === 0) {
+      continue;
+    }
+    const versions = new Set([parsed.version]);
+    if (isPlainObject(metadata) && typeof metadata.version === "string") {
+      versions.add(metadata.version);
+    }
+    for (const version of versions) {
+      libcByPackageKey.set(`${parsed.name}@${version}`, [...values]);
+    }
+  }
+  return libcByPackageKey;
+}
+
 function readPnpmLockPackageIntegrities() {
   const lockfile = readPnpmLock();
   const packages = recordAt(lockfile, "packages") ?? {};
@@ -906,21 +936,43 @@ function normalizeNpmLockOverrides(
   }
 }
 
-function normalizeNpmVersionDrift<T>(lockfile: T): T {
+function normalizeNpmVersionDrift<T>(
+  lockfile: T,
+  libcByPackageKey?: ReadonlyMap<string, readonly string[]>,
+): T {
   const packages = recordAt(lockfile, "packages");
   if (!packages) {
     return lockfile;
   }
-  for (const metadata of Object.values(packages)) {
+  const libcConstraints = libcByPackageKey ?? readPnpmLockPackageLibc();
+  for (const [lockPath, metadata] of Object.entries(packages)) {
     if (!isPlainObject(metadata)) {
       continue;
     }
     // npm versions and mutable registry metadata disagree on these package-lock
-    // fields. None affect resolution, so keep generated npm locks stable.
+    // fields. Neither affects resolution, so drop them to keep generated npm
+    // locks stable.
     delete metadata.deprecated;
-    delete metadata.libc;
     if (metadata.peer === true) {
       delete metadata.peer;
+    }
+    // `libc` DOES affect resolution: npm uses it alongside `os`/`cpu` to pick
+    // between glibc and musl builds, which are otherwise indistinguishable.
+    // Only npm 11+ emits it, so pin it from the pnpm lock rather than trusting
+    // whichever npm generated this file. Dropping it instead would make every
+    // consumer of the generated lock install both variants of every
+    // libc-specific package.
+    const packageName = metadata.name ?? parseLockPackagePath(lockPath).at(-1)?.name;
+    const libc =
+      typeof packageName === "string" && typeof metadata.version === "string"
+        ? libcConstraints.get(`${packageName}@${metadata.version}`)
+        : undefined;
+    // Delete before assigning so a backfilled `libc` lands in the same key
+    // position as one npm 11 emitted, keeping generated locks byte-identical
+    // across npm versions.
+    delete metadata.libc;
+    if (libc) {
+      metadata.libc = [...libc];
     }
   }
   return lockfile;

--- a/test/scripts/generate-npm-package-lock.test.ts
+++ b/test/scripts/generate-npm-package-lock.test.ts
@@ -313,33 +313,38 @@ describe("generate-npm-package-lock", () => {
     ]);
   });
 
-  it("normalizes npm patch-version metadata drift", () => {
+  it("normalizes npm patch-version metadata drift while keeping libc", () => {
+    const libcByPackageKey = new Map([["@rollup/rollup-linux-x64-gnu@4.53.5", ["glibc"]]]);
     expect(
-      normalizeNpmVersionDrift({
-        packages: {
-          "node_modules/@rollup/rollup-linux-x64-gnu": {
-            version: "4.53.5",
-            cpu: ["x64"],
-            libc: ["glibc"],
-            optional: true,
-            os: ["linux"],
-          },
-          "node_modules/zod": {
-            version: "4.4.3",
-            deprecated: "Use another package",
-            peer: true,
-          },
-          "node_modules/keeps-peer-false": {
-            version: "1.0.0",
-            peer: false,
+      normalizeNpmVersionDrift(
+        {
+          packages: {
+            "node_modules/@rollup/rollup-linux-x64-gnu": {
+              version: "4.53.5",
+              cpu: ["x64"],
+              libc: ["glibc"],
+              optional: true,
+              os: ["linux"],
+            },
+            "node_modules/zod": {
+              version: "4.4.3",
+              deprecated: "Use another package",
+              peer: true,
+            },
+            "node_modules/keeps-peer-false": {
+              version: "1.0.0",
+              peer: false,
+            },
           },
         },
-      }),
+        libcByPackageKey,
+      ),
     ).toEqual({
       packages: {
         "node_modules/@rollup/rollup-linux-x64-gnu": {
           version: "4.53.5",
           cpu: ["x64"],
+          libc: ["glibc"],
           optional: true,
           os: ["linux"],
         },
@@ -352,6 +357,70 @@ describe("generate-npm-package-lock", () => {
         },
       },
     });
+  });
+
+  it("backfills libc from the pnpm lock when npm omits it", () => {
+    // npm 10 emits no `libc` at all; npm 11 does. Backfilling from the pnpm
+    // lock keeps generated locks byte-identical across both while preserving
+    // the field npm needs to tell glibc and musl builds apart.
+    const libcByPackageKey = new Map([
+      ["@rollup/rollup-linux-x64-gnu@4.53.5", ["glibc"]],
+      ["@rollup/rollup-linux-x64-musl@4.53.5", ["musl"]],
+    ]);
+    expect(
+      normalizeNpmVersionDrift(
+        {
+          packages: {
+            "node_modules/@rollup/rollup-linux-x64-gnu": {
+              version: "4.53.5",
+              cpu: ["x64"],
+              optional: true,
+              os: ["linux"],
+            },
+            "node_modules/@rollup/rollup-linux-x64-musl": {
+              version: "4.53.5",
+              cpu: ["x64"],
+              optional: true,
+              os: ["linux"],
+            },
+          },
+        },
+        libcByPackageKey,
+      ),
+    ).toEqual({
+      packages: {
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+          version: "4.53.5",
+          cpu: ["x64"],
+          optional: true,
+          os: ["linux"],
+          libc: ["glibc"],
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+          version: "4.53.5",
+          cpu: ["x64"],
+          optional: true,
+          os: ["linux"],
+          libc: ["musl"],
+        },
+      },
+    });
+  });
+
+  it("drops libc that the pnpm lock does not constrain", () => {
+    expect(
+      normalizeNpmVersionDrift(
+        {
+          packages: {
+            "node_modules/portable": {
+              version: "1.0.0",
+              libc: ["glibc"],
+            },
+          },
+        },
+        new Map(),
+      ),
+    ).toEqual({ packages: { "node_modules/portable": { version: "1.0.0" } } });
   });
 
   it("uses legacy peer resolution when package extensions mark dependency peers optional", () => {


### PR DESCRIPTION
Related: #111745
Closes #121059

> **AI-assisted.** Investigated and patched with Claude. I reproduced the
> behaviour myself before and after the change, and can explain each edit.

## What Problem This Solves

`normalizeNpmVersionDrift()` in `scripts/generate-npm-package-lock.mts` strips
`libc` from every entry of the generated `package-lock.json`. The comment says
why:

```ts
// npm versions and mutable registry metadata disagree on these package-lock
// fields. None affect resolution, so keep generated npm locks stable.
delete metadata.deprecated;
delete metadata.libc;
```

That holds for `deprecated` and `peer`. It does not hold for `libc`. npm reads
`libc` alongside `os`/`cpu` to choose between glibc and musl builds, and for
packages that ship both, the two variants are identical in `os` and `cpu`. `libc`
is the only thing telling them apart. Delete it and npm has no basis to choose,
so it installs both.

This is live in our own dependency tree. From `pnpm-lock.yaml`:

```yaml
'@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.219':
  cpu: [arm64]
  os: [linux]
  libc: [musl]

'@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.219':
  cpu: [arm64]
  os: [linux]
  libc: [glibc]
```

84 packages in `pnpm-lock.yaml` carry a `libc` constraint. Any consumer
installing from a generated lock gets both variants of all of them.

## Why This Change Was Made

The original intent was keeping generated locks byte-stable across npm versions,
which is a real concern, not a hypothetical one. npm 10 emits no `libc` at all.
npm 11 emits it. `createNpmLockCommand()` resolves whatever npm sits beside the
running node, and our supported Node floors straddle the change: Node 22.22.3
ships npm 10.9.x, Node 24.15 ships npm 11.x.

So deleting the line and stopping there would fix correctness and reintroduce the
churn. This change backfills `libc` from `pnpm-lock.yaml` instead. That file is
already the source of truth for versions and integrities here, via
`assertNpmLockMatchesPnpmLock` and `readPnpmLockPackageIntegrities`, and the new
`readPnpmLockPackageLibc()` mirrors the latter.

The output ends up both correct and stable, and stable for a better reason than
before: the value comes from a file in the repo rather than from whichever npm
happened to run. `deprecated` and `peer` are still dropped, since those really
don't affect resolution. Entries the pnpm lock doesn't constrain still have
`libc` removed, so npm 11's output keeps converging with npm 10's. The field is
deleted before being reassigned, so a backfilled `libc` occupies the same key
position as one npm 11 emitted, keeping output byte-identical either way.

Worth noting the two npm versions only disagree about *writing* the field. Both
read it: npm 10.9.7 running `npm ci` against a lockfile containing `libc`
installed only the glibc variant. So pinning npm to 11 would also fix this, but
it would force the toolchain on every contributor and break the Node 22 floor.
Reading from a committed file constrains nobody.

This was originally written against `scripts/generate-npm-package-lock.mjs` and
`.d.mts`. It is now retargeted to `scripts/generate-npm-package-lock.mts` after
the generator was migrated to TypeScript upstream — the `.mjs` is a tsx shim now,
the `.d.mts` is gone, and the `delete metadata.libc` had carried over unchanged
into the new file.

## User Impact

Anyone installing from a generated lock stops receiving the wrong-libc copy of
every libc-discriminated package. On a glibc host each one drops from two
installed copies to one.

The wasted copies are native binaries. For `@anthropic-ai/claude-agent-sdk` the
duplicate measures 258 MB.

## Evidence

### End-to-end proof: patched generator to installed tree

Measured at exact head `6133f6038a`, against base `f806abf43b`, on Node 24.19.0 /
npm 11.17.0, Ubuntu 24.04 (WSL2), glibc 2.39.

`extensions/acpx` depends transitively on `@anthropic-ai/claude-agent-sdk`, whose
Linux builds are the glibc/musl pair. Generating that package's lock with each
version of the generator, then installing from it:

```
# main (current behaviour)
lock for extensions/acpx: 185 entries
entries carrying libc: 0

$ npm ci --ignore-scripts --no-audit --no-fund
added 147 packages
$ ls node_modules/@anthropic-ai/
claude-agent-sdk  claude-agent-sdk-linux-x64  claude-agent-sdk-linux-x64-musl  sdk
$ du -sh node_modules
889M

# patched
lock for extensions/acpx: 185 entries
entries carrying libc: 4
  @anthropic-ai/claude-agent-sdk-linux-arm64        libc=glibc
  @anthropic-ai/claude-agent-sdk-linux-arm64-musl   libc=musl
  @anthropic-ai/claude-agent-sdk-linux-x64          libc=glibc
  @anthropic-ai/claude-agent-sdk-linux-x64-musl     libc=musl

$ npm ci --ignore-scripts --no-audit --no-fund
added 146 packages
$ ls node_modules/@anthropic-ai/
claude-agent-sdk  claude-agent-sdk-linux-x64  sdk
$ du -sh node_modules
632M
```

Same 185 lock entries either way. On a glibc host main's lock installs the musl
binary as well; the patched lock does not. That duplicate is 258 MB of native
binary that cannot execute on the host:

```
$ du -sh node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl
258M
```

Reproduced by calling the generator's exported `generateNpmPackageLock` and
writing the result alongside `packageJsonForNpmLock(...)`, then `npm ci` from it.
Switch between the two behaviours with
`git checkout f806abf43b -- scripts/generate-npm-package-lock.mts`.

### npm's libc behaviour, measured directly

`rollup@4.53.5`'s linux-x64 variants differ only in `libc`:

```
rollup-linux-x64-gnu    os: ['linux'] cpu: ['x64'] libc: ['glibc']
rollup-linux-x64-musl   os: ['linux'] cpu: ['x64'] libc: ['musl']
```

`npm ci` from the same lockfile, before and after stripping `libc`:

```
A: libc intact    -> rollup-linux-x64-gnu                          (1)
B: libc deleted   -> rollup-linux-x64-gnu, rollup-linux-x64-musl   (2)
```

The version disagreement that motivated the original delete, same `package.json`
both times, each run in a clean directory:

```
npm 10.9.7  -> libc emitted on 0 entries
npm 11.17.0 -> libc emitted on 11 entries
```

Corroborated upstream by npm/cli#8514: npm emits `libc` in package-lock.json only
from npm 11 onward, and inconsistently.

And the asymmetry, npm 10.9.7 running `npm ci` against a lockfile that has `libc`:

```
rollup-linux-x64-gnu    (1)
```

### Local validation

```
pnpm check   passed — typecheck core / ui / extensions / scripts / test-root,
             oxlint 0 warnings 0 errors across 15886 + 8307 + 687 files,
             oxfmt --check clean, npm package-lock guard revalidated all 95
             locks with the patched generator
pnpm vitest run test/scripts/generate-npm-package-lock.test.ts  -> 28 passed
```

The package-lock guard is the useful one: it runs
`node scripts/generate-npm-package-lock.mjs --all` and revalidated every lock in
the repo against the patched generator, with no drift. `pnpm test` in full was
not run locally; relying on CI for that.

I updated the existing `normalizes npm patch-version metadata drift` case to
assert `libc` survives, and added two cases: backfill when npm omits the field,
and removal when the pnpm lock does not constrain it.

### autoreview

Branch mode, base `f806abf43b`, engine claude:

```
trufflehog: clean
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.90)
```

No P0 defects. The review independently checked the `name@version` map
construction including alias handling, the `metadata.name` lookup precedence over
the path-derived name, the root `""` entry, and the backward-compatible optional
parameter. An earlier run flagged a key-ordering asymmetry between backfilled and
npm-11-emitted `libc`; that is addressed by deleting before reassigning, and the
current run confirms output is byte-identical regardless of which npm generated
the input.

## Notes

I found this while investigating #111745, so to be clear: this is not a fix for
that issue. #111745 concerns `os`/`cpu` filtering on `@openai/codex`; this is the
same bug class on a different field, found separately. The two do not share a
root cause as far as I can tell, and this patch stands on its own.

## AI-assisted checklist

- [x] Marked as AI-assisted
- [x] Evidence section included
- [x] I understand what the code does and can explain each change
- [ ] Session log attached
- [x] `autoreview` skill run — clean, no accepted/actionable findings reported