### PR TITLE
fix(release): verify SHA-pinned validation evidence

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1626,7 +1626,7 @@ jobs:
       - name: Write release validation manifest
         if: ${{ success() }}
         env:
-          TARGET_REF: ${{ inputs.ref }}
+          TARGET_REF: ${{ startsWith(github.ref, 'refs/heads/release-ci/') && needs.resolve_target.outputs.sha || inputs.ref }}
           TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
           RELEASE_PROFILE: ${{ inputs.release_profile }}
           RERUN_GROUP: ${{ inputs.rerun_group }}

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -4242,6 +4242,8 @@ describe("package artifact reuse", () => {
     expect(manifestStep.env).toMatchObject({
       ALLOW_UNRELEASED_CHANGELOG:
         "${{ inputs.allow_unreleased_changelog || (inputs.target_context_ref == '' && (inputs.ref == 'main' || inputs.ref == 'refs/heads/main')) }}",
+      TARGET_REF:
+        "${{ startsWith(github.ref, 'refs/heads/release-ci/') && needs.resolve_target.outputs.sha || inputs.ref }}",
       NPM_TELEGRAM_PACKAGE_SPEC: "${{ inputs.npm_telegram_package_spec }}",
       NPM_TELEGRAM_PROVIDER_MODE: "${{ inputs.npm_telegram_provider_mode }}",
       NPM_TELEGRAM_SCENARIO: "${{ inputs.npm_telegram_scenario }}",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a fully green SHA-pinned Full Release Validation run could not pass its final evidence verification. Run https://github.com/openclaw/openclaw/actions/runs/31314622572 completed successfully, but the verifier rejected its manifest because the workflow persisted the temporary `validation/target-*` transport branch as durable `targetRef` evidence instead of the resolved candidate SHA.

## Why This Change Was Made

For trusted `release-ci/*` workflow runs, the manifest producer now records `needs.resolve_target.outputs.sha` as `targetRef`. Normal branch and tag dispatches continue recording `inputs.ref`, and canonical release context remains in `validationInputs.targetContextRef`.

The temporary target branch remains unchanged as a Git transport mechanism, while evidence schema v3 and its strict `targetRef === targetSha` verifier invariant remain unchanged.

AI-assisted implementation and review.

## User Impact

Release operators can verify and reuse green SHA-pinned Full Release Validation evidence instead of receiving a false evidence-identity failure after all product and release lanes pass.

## Evidence

- Green run with malformed producer output: https://github.com/openclaw/openclaw/actions/runs/31314622572
- Release checks child: https://github.com/openclaw/openclaw/actions/runs/31315230688 — success
- Focused workflow/helper/verifier tests: 241/241 passed
- `actionlint .github/workflows/full-release-validation.yml`: passed
- Formatting and `git diff --check`: passed
- Codex autoreview: clean, no accepted/actionable findings
- Workflow/config LOC: `+1/-1`; tests: `+2/-0`
