### PR TITLE
fix(gateway): reject stale worker bundles before tunnel start

### DIFF
--- a/src/gateway/worker-environments/environment-access.test.ts
+++ b/src/gateway/worker-environments/environment-access.test.ts
@@ -69,6 +69,42 @@ describe("worker environment service", () => {
     });
   });
 
+  it.each([
+    ["stale receipt", { ...support.BOOTSTRAP_RECEIPT, bundleHash: "c".repeat(64) }, undefined],
+    ["unavailable current bundle", support.BOOTSTRAP_RECEIPT, new Error("bundle unavailable")],
+  ] as const)("rejects SSH tunnel startup with %s", async (_name, receipt, prepareError) => {
+    const environmentId = "worker-tunnel-current-bundle";
+    const bootstrapping = support.seedBootstrapping(environmentId, undefined, true);
+    support.testState.store.transition({
+      environmentId,
+      from: bootstrapping.state,
+      to: "ready",
+      patch: support.readyPatch(environmentId, receipt),
+    });
+    if (prepareError) {
+      support.testState.prepareInstallation = vi.fn(async () => {
+        throw prepareError;
+      });
+    }
+    const tunnelManager = {
+      status: () => "stopped" as const,
+      start: vi.fn(),
+      stop: vi.fn(async () => {}),
+      stopAll: vi.fn(async () => {}),
+    } as unknown as WorkerTunnelManager;
+    const workerService = support.createService(support.createProvider(), { tunnelManager });
+
+    await expect(workerService.startTunnel({ environmentId, ownerEpoch: 1 })).rejects.toMatchObject(
+      {
+        code: "invalid_state",
+        message: prepareError
+          ? "Current worker build identity is unavailable"
+          : "Worker must bootstrap the current build before continuing",
+      } satisfies Partial<WorkerEnvironmentServiceError>,
+    );
+    expect(tunnelManager.start).not.toHaveBeenCalled();
+  });
+
   it("starts a local-install node tunnel without entering SSH", async () => {
     const tunnelManager = {
       status: () => "stopped" as const,
@@ -125,6 +161,8 @@ describe("worker environment service", () => {
       ownerEpoch: environment.ownerEpoch,
       sessionId: "session-device",
     });
+    const prepareInstallation = vi.mocked(support.testState.prepareInstallation);
+    const prepareCallsBeforeTunnel = prepareInstallation.mock.calls.length;
 
     await expect(
       workerService.startTunnel({
@@ -133,6 +171,7 @@ describe("worker environment service", () => {
       }),
     ).resolves.toMatchObject({ environmentId: environment.environmentId });
     expect(tunnelManager.start).not.toHaveBeenCalled();
+    expect(prepareInstallation).toHaveBeenCalledTimes(prepareCallsBeforeTunnel);
     expect(nodeTunnelManager.start).toHaveBeenCalledWith(
       expect.objectContaining({
         deviceId: "device-1",

--- a/src/gateway/worker-environments/environment-access.ts
+++ b/src/gateway/worker-environments/environment-access.ts
@@ -2,6 +2,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { OpenClawConfig } from "../../config/types.js";
 import { withTimeout } from "../../infra/fs-safe.js";
 import type { WorkerProvider } from "../../plugins/types.js";
+import { verifyWorkerAdmissionHandshake, type ExpectedWorkerBuild } from "./admission.js";
 import { DEVICE_WORKER_PROVIDER_ID } from "./device-provider.js";
 import type { NodeWorkerTunnelManager } from "./node-worker-tunnel.js";
 import type { WorkerDesktopLaunchResult, WorkerDesktopObserveResult } from "./service-contract.js";
@@ -16,6 +17,7 @@ const TUNNEL_START_TIMEOUT_MS = 3 * 60_000;
 type WorkerEnvironmentAccessOptions = {
   store: WorkerEnvironmentStore;
   getConfig: () => OpenClawConfig;
+  prepareCurrentBundle: () => Promise<ExpectedWorkerBuild>;
   tunnelManager?: WorkerTunnelManager;
   nodeTunnelManager?: NodeWorkerTunnelManager;
   resolveWorkerGateway?: () => { host: "127.0.0.1" | "::1"; port: number } | undefined;
@@ -153,12 +155,24 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
       if (!gateway) {
         throw serviceError("invalid_state", "Worker gateway ingress is unavailable");
       }
+      let currentBundle: ExpectedWorkerBuild;
+      try {
+        currentBundle = await options.prepareCurrentBundle();
+      } catch {
+        throw serviceError("invalid_state", "Current worker build identity is unavailable");
+      }
+      if (!verifyWorkerAdmissionHandshake(record.bootstrapReceipt, currentBundle)) {
+        throw serviceError(
+          "invalid_state",
+          "Worker must bootstrap the current build before continuing",
+        );
+      }
       const provider = providerFor(record.providerId);
       // Tunnel ownership is registered synchronously by the manager. Release the durable-state
       // lock while SSH connects so drain/destroy can fence an indefinitely reconnecting start.
       startup = tunnels.start({
         ...request,
-        bundleHash: record.bootstrapReceipt.bundleHash,
+        bundleHash: currentBundle.bundleHash,
         gateway,
         ssh: record.sshEndpoint,
         sharedHost: record.sharedHost,

--- a/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import type { WorkerInstallationArtifact } from "./bundle.js";
+import { seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
+import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
+import { createWorkerSessionPlacementStore } from "./placement-store.js";
+import * as support from "./service.test-support.js";
+import type { WorkerTunnelManager } from "./tunnel.js";
+import { createWorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
+
+describe("worker placement restart recovery", () => {
+  support.setupWorkerEnvironmentServiceSuite();
+
+  it.each(["bundle", "provider"] as const)(
+    "keeps stale pending recovery fenced when %s recovery is unavailable",
+    async (failure) => {
+      let currentBundle: WorkerInstallationArtifact = support.BUNDLE_ARTIFACT;
+      const recoveryState = { started: false };
+      support.testState.prepareInstallation = vi.fn(async (install) => {
+        if (install === "bundle" && recoveryState.started && failure === "bundle") {
+          throw new Error("bundle unavailable");
+        }
+        return install === "bundle" ? currentBundle : support.NPM_ARTIFACT;
+      });
+      const tunnelManager = {
+        status: () => "stopped" as const,
+        start: vi.fn(),
+        stop: vi.fn(async () => {}),
+        stopAll: vi.fn(async () => {}),
+      } as unknown as WorkerTunnelManager;
+      const provider = support.createProvider({
+        inspect: async () => {
+          if (recoveryState.started && failure === "provider") {
+            throw new Error("provider unavailable");
+          }
+          return { status: "active" };
+        },
+      });
+      const workerService = support.createService(provider, { tunnelManager });
+      const placements = createWorkerSessionPlacementStore({
+        database: support.testState.stateDb,
+        now: () => support.testState.nowMs,
+      });
+      const recovery = createWorkerPlacementDispatchService({
+        placements,
+        environments: workerService,
+        workspaceOperations: createWorkerWorkspaceOperationCoordinator(),
+        runLocalBarrier: async ({ startDispatch }) => startDispatch(),
+        runActivationBarrier: async ({ activate }) => activate(),
+        runReclaimBarrier: async ({ reclaim }) => await reclaim("/gateway/workspace"),
+        resolveWorkspacePath: async () => "/gateway/workspace",
+        reportWorkspaceResultConflict: async () => {},
+        resolveWorkspaceResultConflict: async () => undefined,
+      });
+      const environmentId = "worker-stale-recovery";
+      support.seedReady(environmentId);
+      const attached = await workerService.attachSession({
+        environmentId,
+        ownerEpoch: 1,
+        sessionId: "session-1",
+      });
+      const active = seedActivePlacement(placements, {
+        environmentId,
+        ownerEpoch: attached.ownerEpoch,
+      });
+      if (active.state !== "active") {
+        throw new Error("active placement fixture was not active");
+      }
+      const claim = placements.claimTurn({
+        sessionId: active.sessionId,
+        sessionKey: active.sessionKey,
+        agentId: active.agentId,
+        claimId: "claim-stale-recovery",
+        runId: "run-stale-recovery",
+        owner: {
+          kind: "worker",
+          environmentId: active.environmentId,
+          ownerEpoch: active.activeOwnerEpoch,
+        },
+      });
+      placements.markWorkspaceResultPending(claim);
+      placements.handoffWorkspaceResultRecovery(claim);
+      currentBundle = { ...support.BUNDLE_ARTIFACT, bundleHash: "c".repeat(64) };
+      recoveryState.started = true;
+
+      await recovery.reconcile();
+
+      expect(placements.get(active.sessionId)).toMatchObject({
+        state: "active",
+        turnClaim: { claimId: claim.claimId, runId: claim.runId },
+      });
+      expect(placements.listPendingWorkspaceResults()).toHaveLength(1);
+      expect(workerService.get(active.environmentId)).toMatchObject({
+        state: "attached",
+        destroyRequestedAtMs: null,
+      });
+      expect(tunnelManager.start).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -293,6 +293,7 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
   const environmentAccess = createWorkerEnvironmentAccess({
     store,
     getConfig: options.getConfig,
+    prepareCurrentBundle: async () => await options.prepareInstallation("bundle"),
     tunnelManager: options.tunnelManager,
     nodeTunnelManager: options.nodeTunnelManager,
     resolveWorkerGateway: options.resolveWorkerGateway,


### PR DESCRIPTION
Closes #121036

## What Problem This Solves

Gateway restart recovery could register an SSH tunnel for an attached worker whose persisted bootstrap receipt belonged to an older worker bundle. If current-bundle preparation or provider inspection failed during reconciliation, the attached record intentionally remained retryable, but pending workspace-result recovery could then reach tunnel startup and trust the stale persisted hash.

## Why This Change Was Made

Tunnel registration is the final ownership boundary before SSH workspace operations begin. `environment-access.ts` now prepares the current Gateway bundle under the existing environment lock, verifies the persisted receipt with the canonical worker-admission verifier, and passes the freshly verified hash into the tunnel manager.

Paired-device workers retain their separate local-install contract: the node path returns before Gateway bundle preparation and the node tunnel manager continues validating the connected node against its exact advertised build.

The original pre-service-split patch was rewritten onto the current owners rather than mechanically rebased. No recovery-caller workaround, fallback, compatibility shim, config, protocol, storage, or schema-version change was added.

## User Impact

Recovery fails closed before tunnel ownership when the current SSH worker build is unavailable or mismatched. The pending result, turn claim, and attached environment remain fenced and retryable for the next recovery sweep. Valid paired-device workers continue unchanged.

## Evidence

- Pre-fix reproduction: `node scripts/run-vitest.mjs src/gateway/worker-environments/environment-access.test.ts src/gateway/worker-environments/placement-dispatch-recovery.test.ts` failed four regressions. Both direct SSH cases reached `Worker tunnel failed to start`; both restart-recovery cases invoked the stale tunnel manager.
- Fixed owner and sibling proof: five files, 64 tests passed across environment access, restart recovery, credential attachment, provider reconciliation, and worker RPC admission.
- Direct regressions cover stale SSH receipts and unavailable current-bundle preparation; both return typed `invalid_state` errors and leave `tunnelManager.start` untouched.
- Restart regressions cover unavailable bundle preparation and unavailable provider inspection in the original execution order; the pending result and claim remain fenced, the environment remains attached, and no tunnel owner is registered.
- The paired-device regression proves node tunnel startup performs no Gateway bundle preparation and still receives the exact local build.
- `node scripts/check-changed.mjs` passed through the documented trusted-source local fallback after the remote backend was unavailable.
- Fresh `autoreview --mode uncommitted` completed clean with no accepted/actionable findings.
- `git diff --check` passed.
- Production `+16/-1` (net `+15`); tests `+138`. The production growth is the SSH tunnel admission security/availability invariant at its owning boundary.
- Commit preserves the original author with `Co-authored-by: Vincent Koc <vincentkoc@ieee.org>`.
