### PR TITLE
fix(release): bootstrap typed Docker planner

### DIFF
--- a/.github/actions/setup-release-harness/action.yml
+++ b/.github/actions/setup-release-harness/action.yml
@@ -1,0 +1,23 @@
+name: Setup trusted release harness
+description: Prepare the trusted release harness package manager and dependencies.
+inputs:
+  node-version:
+    description: Node.js version required by the release harness.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Setup trusted release harness package manager
+      uses: ./.release-harness/.github/actions/setup-pnpm-store-cache
+      with:
+        node-version: ${{ inputs.node-version }}
+        package-manager-file: .release-harness/package.json
+        use-actions-cache: "false"
+
+    - name: Install trusted release harness dependencies
+      shell: bash
+      working-directory: .release-harness
+      env:
+        CI: "true"
+      # Corepack resolves packageManager from cwd before pnpm processes --dir.
+      run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -2141,6 +2141,12 @@ jobs:
           path: .release-harness
           persist-credentials: false
 
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          install-bun: "true"
+
       - name: Plan Docker E2E images
         id: plan
         shell: bash
@@ -2179,13 +2185,6 @@ jobs:
               }
           fi
           echo "plan_json=$plan_path" >> "$GITHUB_OUTPUT"
-
-      - name: Setup Node environment
-        if: (steps.plan.outputs.needs_package == '1' && inputs.package_artifact_name == '' && inputs.package_artifact_run_id == '') || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')
-        uses: ./.github/actions/setup-node-env
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          install-bun: "true"
 
       - name: Setup artifact package validation environment
         if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != ''

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -2141,11 +2141,21 @@ jobs:
           path: .release-harness
           persist-credentials: false
 
-      - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+      - name: Setup trusted release harness package manager
+        uses: ./.release-harness/.github/actions/setup-pnpm-store-cache
         with:
           node-version: ${{ env.NODE_VERSION }}
-          install-bun: "true"
+          package-manager-file: .release-harness/package.json
+          use-actions-cache: "false"
+
+      - name: Install trusted release harness dependencies
+        env:
+          CI: "true"
+        # Corepack resolves packageManager from the process cwd before pnpm can
+        # process --dir. Keep this in the trusted harness so a frozen candidate
+        # pin cannot select a different pnpm binary for its harness install.
+        working-directory: .release-harness
+        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
 
       - name: Plan Docker E2E images
         id: plan
@@ -2186,23 +2196,12 @@ jobs:
           fi
           echo "plan_json=$plan_path" >> "$GITHUB_OUTPUT"
 
-      - name: Setup artifact package validation environment
-        if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != ''
-        uses: ./.release-harness/.github/actions/setup-pnpm-store-cache
+      - name: Setup Node environment
+        if: (steps.plan.outputs.needs_package == '1' && inputs.package_artifact_name == '' && inputs.package_artifact_run_id == '') || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')
+        uses: ./.github/actions/setup-node-env
         with:
           node-version: ${{ env.NODE_VERSION }}
-          package-manager-file: .release-harness/package.json
-          use-actions-cache: "false"
-
-      - name: Install trusted package validation dependencies
-        if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != ''
-        env:
-          CI: "true"
-        # Corepack resolves packageManager from the process cwd before pnpm can
-        # process --dir. Keep this in the trusted harness so a frozen candidate
-        # pin cannot select a different pnpm binary for its harness install.
-        working-directory: .release-harness
-        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
+          install-bun: "true"
 
       - name: Validate OpenClaw package artifact identity
         id: input_package_artifact

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1256,23 +1256,11 @@ jobs:
           fetch-depth: 1
           path: .release-harness
 
-      - name: Setup trusted release harness package manager
+      - name: Setup trusted release harness
         if: contains(matrix.profiles, inputs.release_test_profile)
-        uses: ./.release-harness/.github/actions/setup-pnpm-store-cache
+        uses: ./.release-harness/.github/actions/setup-release-harness
         with:
           node-version: ${{ env.NODE_VERSION }}
-          package-manager-file: .release-harness/package.json
-          use-actions-cache: "false"
-
-      - name: Install trusted release harness dependencies
-        if: contains(matrix.profiles, inputs.release_test_profile)
-        env:
-          CI: "true"
-        # Corepack resolves packageManager from the process cwd before pnpm can
-        # process --dir. Keep this in the trusted harness so a frozen candidate
-        # pin cannot select a different pnpm binary for its harness install.
-        working-directory: .release-harness
-        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
 
       - name: Log in to GHCR for shared Docker E2E image
         if: contains(matrix.profiles, inputs.release_test_profile) && inputs.shared_image_policy != 'no-push-artifact'
@@ -1650,21 +1638,10 @@ jobs:
           fetch-depth: 1
           path: .release-harness
 
-      - name: Setup trusted release harness package manager
-        uses: ./.release-harness/.github/actions/setup-pnpm-store-cache
+      - name: Setup trusted release harness
+        uses: ./.release-harness/.github/actions/setup-release-harness
         with:
           node-version: ${{ env.NODE_VERSION }}
-          package-manager-file: .release-harness/package.json
-          use-actions-cache: "false"
-
-      - name: Install trusted release harness dependencies
-        env:
-          CI: "true"
-        # Corepack resolves packageManager from the process cwd before pnpm can
-        # process --dir. Keep this in the trusted harness so a frozen candidate
-        # pin cannot select a different pnpm binary for its harness install.
-        working-directory: .release-harness
-        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
 
       - name: Log in to GHCR for shared Docker E2E image
         if: inputs.shared_image_policy != 'no-push-artifact'
@@ -1953,21 +1930,10 @@ jobs:
           path: .release-harness
           persist-credentials: false
 
-      - name: Setup trusted release harness package manager
-        uses: ./.release-harness/.github/actions/setup-pnpm-store-cache
+      - name: Setup trusted release harness
+        uses: ./.release-harness/.github/actions/setup-release-harness
         with:
           node-version: ${{ env.NODE_VERSION }}
-          package-manager-file: .release-harness/package.json
-          use-actions-cache: "false"
-
-      - name: Install trusted release harness dependencies
-        env:
-          CI: "true"
-        # Corepack resolves packageManager from the process cwd before pnpm can
-        # process --dir. Keep this in the trusted harness so a frozen candidate
-        # pin cannot select a different pnpm binary for its harness install.
-        working-directory: .release-harness
-        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
 
       - name: Log in to GHCR for shared Docker E2E image
         if: inputs.shared_image_policy != 'no-push-artifact'
@@ -2191,21 +2157,10 @@ jobs:
           path: .release-harness
           persist-credentials: false
 
-      - name: Setup trusted release harness package manager
-        uses: ./.release-harness/.github/actions/setup-pnpm-store-cache
+      - name: Setup trusted release harness
+        uses: ./.release-harness/.github/actions/setup-release-harness
         with:
           node-version: ${{ env.NODE_VERSION }}
-          package-manager-file: .release-harness/package.json
-          use-actions-cache: "false"
-
-      - name: Install trusted release harness dependencies
-        env:
-          CI: "true"
-        # Corepack resolves packageManager from the process cwd before pnpm can
-        # process --dir. Keep this in the trusted harness so a frozen candidate
-        # pin cannot select a different pnpm binary for its harness install.
-        working-directory: .release-harness
-        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
 
       - name: Plan Docker E2E images
         id: plan

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1256,6 +1256,24 @@ jobs:
           fetch-depth: 1
           path: .release-harness
 
+      - name: Setup trusted release harness package manager
+        if: contains(matrix.profiles, inputs.release_test_profile)
+        uses: ./.release-harness/.github/actions/setup-pnpm-store-cache
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          package-manager-file: .release-harness/package.json
+          use-actions-cache: "false"
+
+      - name: Install trusted release harness dependencies
+        if: contains(matrix.profiles, inputs.release_test_profile)
+        env:
+          CI: "true"
+        # Corepack resolves packageManager from the process cwd before pnpm can
+        # process --dir. Keep this in the trusted harness so a frozen candidate
+        # pin cannot select a different pnpm binary for its harness install.
+        working-directory: .release-harness
+        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
+
       - name: Log in to GHCR for shared Docker E2E image
         if: contains(matrix.profiles, inputs.release_test_profile) && inputs.shared_image_policy != 'no-push-artifact'
         run: bash .release-harness/scripts/ci-docker-login-ghcr.sh
@@ -1632,6 +1650,22 @@ jobs:
           fetch-depth: 1
           path: .release-harness
 
+      - name: Setup trusted release harness package manager
+        uses: ./.release-harness/.github/actions/setup-pnpm-store-cache
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          package-manager-file: .release-harness/package.json
+          use-actions-cache: "false"
+
+      - name: Install trusted release harness dependencies
+        env:
+          CI: "true"
+        # Corepack resolves packageManager from the process cwd before pnpm can
+        # process --dir. Keep this in the trusted harness so a frozen candidate
+        # pin cannot select a different pnpm binary for its harness install.
+        working-directory: .release-harness
+        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
+
       - name: Log in to GHCR for shared Docker E2E image
         if: inputs.shared_image_policy != 'no-push-artifact'
         run: bash .release-harness/scripts/ci-docker-login-ghcr.sh
@@ -1918,6 +1952,22 @@ jobs:
           fetch-depth: 1
           path: .release-harness
           persist-credentials: false
+
+      - name: Setup trusted release harness package manager
+        uses: ./.release-harness/.github/actions/setup-pnpm-store-cache
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          package-manager-file: .release-harness/package.json
+          use-actions-cache: "false"
+
+      - name: Install trusted release harness dependencies
+        env:
+          CI: "true"
+        # Corepack resolves packageManager from the process cwd before pnpm can
+        # process --dir. Keep this in the trusted harness so a frozen candidate
+        # pin cannot select a different pnpm binary for its harness install.
+        working-directory: .release-harness
+        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
 
       - name: Log in to GHCR for shared Docker E2E image
         if: inputs.shared_image_policy != 'no-push-artifact'

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2496,6 +2496,11 @@ describe("package artifact reuse", () => {
     ).toContain("inputs.enable_prepublish_plugin_registry");
     expect(workflow).toContain("bash .release-harness/scripts/ci-docker-pull-retry.sh");
     const prepareDockerImage = workflowJob(LIVE_E2E_WORKFLOW, "prepare_docker_e2e_image");
+    const prepareDockerImageStepNames = prepareDockerImage.steps.map((step) => step.name);
+    expect(prepareDockerImageStepNames.indexOf("Setup Node environment")).toBeLessThan(
+      prepareDockerImageStepNames.indexOf("Plan Docker E2E images"),
+    );
+    expect(workflowStep(prepareDockerImage, "Setup Node environment").if).toBeUndefined();
     expect(workflowStep(prepareDockerImage, "Plan Docker E2E images").env).toEqual({
       INCLUDE_OPENWEBUI: "${{ inputs.include_openwebui }}",
       INCLUDE_RELEASE_PATH_SUITES: "${{ inputs.include_release_path_suites }}",

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -118,6 +118,7 @@ type WorkflowStep = {
   shell?: string;
   uses?: string;
   with?: Record<string, string>;
+  "working-directory"?: string;
 };
 
 type WorkflowMatrixEntry = {
@@ -2497,11 +2498,46 @@ describe("package artifact reuse", () => {
     expect(workflow).toContain("bash .release-harness/scripts/ci-docker-pull-retry.sh");
     const prepareDockerImage = workflowJob(LIVE_E2E_WORKFLOW, "prepare_docker_e2e_image");
     const prepareDockerImageStepNames = (prepareDockerImage.steps ?? []).map((step) => step.name);
-    expect(prepareDockerImageStepNames.indexOf("Setup Node environment")).toBeLessThan(
-      prepareDockerImageStepNames.indexOf("Plan Docker E2E images"),
+    const setupHarnessStepName = "Setup trusted release harness package manager";
+    const installHarnessStepName = "Install trusted release harness dependencies";
+    const planStepName = "Plan Docker E2E images";
+    const setupCandidateStepName = "Setup Node environment";
+    expect(
+      prepareDockerImageStepNames.filter((name) => name === setupHarnessStepName),
+    ).toHaveLength(1);
+    expect(
+      prepareDockerImageStepNames.filter((name) => name === installHarnessStepName),
+    ).toHaveLength(1);
+    expect(
+      prepareDockerImageStepNames.filter((name) => name === setupCandidateStepName),
+    ).toHaveLength(1);
+    expect(prepareDockerImageStepNames.indexOf(setupHarnessStepName)).toBeLessThan(
+      prepareDockerImageStepNames.indexOf(planStepName),
     );
-    expect(workflowStep(prepareDockerImage, "Setup Node environment").if).toBeUndefined();
-    expect(workflowStep(prepareDockerImage, "Plan Docker E2E images").env).toEqual({
+    expect(prepareDockerImageStepNames.indexOf(installHarnessStepName)).toBeLessThan(
+      prepareDockerImageStepNames.indexOf(planStepName),
+    );
+    expect(prepareDockerImageStepNames.indexOf(setupCandidateStepName)).toBeGreaterThan(
+      prepareDockerImageStepNames.indexOf(planStepName),
+    );
+    expect(workflowStep(prepareDockerImage, setupHarnessStepName)).toMatchObject({
+      uses: "./.release-harness/.github/actions/setup-pnpm-store-cache",
+      with: {
+        "package-manager-file": ".release-harness/package.json",
+        "use-actions-cache": "false",
+      },
+    });
+    expect(workflowStep(prepareDockerImage, setupHarnessStepName).if).toBeUndefined();
+    expect(workflowStep(prepareDockerImage, installHarnessStepName)).toMatchObject({
+      run: "pnpm install --frozen-lockfile --prefer-offline --ignore-scripts",
+      "working-directory": ".release-harness",
+    });
+    expect(workflowStep(prepareDockerImage, installHarnessStepName).if).toBeUndefined();
+    expect(workflowStep(prepareDockerImage, setupCandidateStepName)).toMatchObject({
+      if: "(steps.plan.outputs.needs_package == '1' && inputs.package_artifact_name == '' && inputs.package_artifact_run_id == '') || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')",
+      uses: "./.github/actions/setup-node-env",
+    });
+    expect(workflowStep(prepareDockerImage, planStepName).env).toEqual({
       INCLUDE_OPENWEBUI: "${{ inputs.include_openwebui }}",
       INCLUDE_RELEASE_PATH_SUITES: "${{ inputs.include_release_path_suites }}",
       LANES: "${{ inputs.docker_lanes }}",

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2496,7 +2496,7 @@ describe("package artifact reuse", () => {
     ).toContain("inputs.enable_prepublish_plugin_registry");
     expect(workflow).toContain("bash .release-harness/scripts/ci-docker-pull-retry.sh");
     const prepareDockerImage = workflowJob(LIVE_E2E_WORKFLOW, "prepare_docker_e2e_image");
-    const prepareDockerImageStepNames = prepareDockerImage.steps.map((step) => step.name);
+    const prepareDockerImageStepNames = (prepareDockerImage.steps ?? []).map((step) => step.name);
     expect(prepareDockerImageStepNames.indexOf("Setup Node environment")).toBeLessThan(
       prepareDockerImageStepNames.indexOf("Plan Docker E2E images"),
     );

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2408,9 +2408,7 @@ describe("package artifact reuse", () => {
 
   it("lets reusable Docker E2E consume an already resolved package artifact", () => {
     const workflow = readFileSync(LIVE_E2E_WORKFLOW, "utf8");
-    const parsedWorkflow = parse(workflow) as {
-      on?: { workflow_call?: { inputs?: Record<string, unknown> } };
-    };
+    const parsedWorkflow = parse(workflow) as Workflow;
     const packageJson = readFileSync(PACKAGE_JSON, "utf8");
     const scheduler = readFileSync("scripts/test-docker-all.mts", "utf8");
     const publishedUpgradeSurvivor = readFileSync(UPGRADE_SURVIVOR_RUN_SCRIPT, "utf8");
@@ -2496,47 +2494,95 @@ describe("package artifact reuse", () => {
         ?.prepublish_plugin_registry_artifact_id,
     ).toContain("inputs.enable_prepublish_plugin_registry");
     expect(workflow).toContain("bash .release-harness/scripts/ci-docker-pull-retry.sh");
-    const prepareDockerImage = workflowJob(LIVE_E2E_WORKFLOW, "prepare_docker_e2e_image");
-    const prepareDockerImageStepNames = (prepareDockerImage.steps ?? []).map((step) => step.name);
     const setupHarnessStepName = "Setup trusted release harness package manager";
     const installHarnessStepName = "Install trusted release harness dependencies";
-    const planStepName = "Plan Docker E2E images";
     const setupCandidateStepName = "Setup Node environment";
-    expect(
-      prepareDockerImageStepNames.filter((name) => name === setupHarnessStepName),
-    ).toHaveLength(1);
-    expect(
-      prepareDockerImageStepNames.filter((name) => name === installHarnessStepName),
-    ).toHaveLength(1);
-    expect(
-      prepareDockerImageStepNames.filter((name) => name === setupCandidateStepName),
-    ).toHaveLength(1);
-    expect(prepareDockerImageStepNames.indexOf(setupHarnessStepName)).toBeLessThan(
-      prepareDockerImageStepNames.indexOf(planStepName),
-    );
-    expect(prepareDockerImageStepNames.indexOf(installHarnessStepName)).toBeLessThan(
-      prepareDockerImageStepNames.indexOf(planStepName),
-    );
-    expect(prepareDockerImageStepNames.indexOf(setupCandidateStepName)).toBeGreaterThan(
-      prepareDockerImageStepNames.indexOf(planStepName),
-    );
-    expect(workflowStep(prepareDockerImage, setupHarnessStepName)).toMatchObject({
-      uses: "./.release-harness/.github/actions/setup-pnpm-store-cache",
-      with: {
-        "package-manager-file": ".release-harness/package.json",
-        "use-actions-cache": "false",
+    const releaseChunkCondition = "contains(matrix.profiles, inputs.release_test_profile)";
+    const plannerConsumers = [
+      {
+        candidatePosition: "before",
+        condition: releaseChunkCondition,
+        jobName: "validate_docker_e2e",
+        planStepName: "Plan Docker E2E chunk",
       },
-    });
-    expect(workflowStep(prepareDockerImage, setupHarnessStepName).if).toBeUndefined();
-    expect(workflowStep(prepareDockerImage, installHarnessStepName)).toMatchObject({
-      run: "pnpm install --frozen-lockfile --prefer-offline --ignore-scripts",
-      "working-directory": ".release-harness",
-    });
-    expect(workflowStep(prepareDockerImage, installHarnessStepName).if).toBeUndefined();
-    expect(workflowStep(prepareDockerImage, setupCandidateStepName)).toMatchObject({
-      if: "(steps.plan.outputs.needs_package == '1' && inputs.package_artifact_name == '' && inputs.package_artifact_run_id == '') || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')",
-      uses: "./.github/actions/setup-node-env",
-    });
+      {
+        candidatePosition: "before",
+        condition: undefined,
+        jobName: "validate_docker_lanes",
+        planStepName: "Plan targeted Docker E2E lanes",
+      },
+      {
+        candidatePosition: "before",
+        condition: undefined,
+        jobName: "validate_docker_openwebui",
+        planStepName: "Plan Open WebUI Docker E2E chunk",
+      },
+      {
+        candidatePosition: "after",
+        condition: undefined,
+        jobName: "prepare_docker_e2e_image",
+        planStepName: "Plan Docker E2E images",
+      },
+    ] as const;
+    const discoveredPlannerConsumers = Object.entries(parsedWorkflow.jobs ?? {})
+      .filter(([, job]) =>
+        job.steps?.some((step) =>
+          step.run?.includes("node .release-harness/scripts/test-docker-all.mjs --plan-json"),
+        ),
+      )
+      .map(([jobName]) => jobName)
+      .sort();
+    expect(discoveredPlannerConsumers).toEqual(
+      plannerConsumers.map(({ jobName }) => jobName).sort(),
+    );
+
+    for (const consumer of plannerConsumers) {
+      const job = workflowJob(LIVE_E2E_WORKFLOW, consumer.jobName);
+      const stepNames = (job.steps ?? []).map((step) => step.name);
+      const planStep = workflowStep(job, consumer.planStepName);
+      const setupHarnessStep = workflowStep(job, setupHarnessStepName);
+      const installHarnessStep = workflowStep(job, installHarnessStepName);
+      const setupCandidateStep = workflowStep(job, setupCandidateStepName);
+      const planIndex = stepNames.indexOf(consumer.planStepName);
+
+      expect(stepNames.filter((name) => name === setupHarnessStepName)).toHaveLength(1);
+      expect(stepNames.filter((name) => name === installHarnessStepName)).toHaveLength(1);
+      expect(stepNames.filter((name) => name === setupCandidateStepName)).toHaveLength(1);
+      expect(stepNames.indexOf(setupHarnessStepName)).toBeLessThan(planIndex);
+      expect(stepNames.indexOf(installHarnessStepName)).toBeLessThan(planIndex);
+      expect(
+        consumer.candidatePosition === "before"
+          ? stepNames.indexOf(setupCandidateStepName) < planIndex
+          : stepNames.indexOf(setupCandidateStepName) > planIndex,
+      ).toBe(true);
+      expect(setupHarnessStep).toMatchObject({
+        uses: "./.release-harness/.github/actions/setup-pnpm-store-cache",
+        with: {
+          "package-manager-file": ".release-harness/package.json",
+          "use-actions-cache": "false",
+        },
+      });
+      expect(setupHarnessStep.if).toBe(consumer.condition);
+      expect(installHarnessStep).toMatchObject({
+        env: { CI: "true" },
+        run: "pnpm install --frozen-lockfile --prefer-offline --ignore-scripts",
+        "working-directory": ".release-harness",
+      });
+      expect(installHarnessStep.if).toBe(consumer.condition);
+      expect(planStep.if).toBe(consumer.condition);
+      expect(planStep.run).toContain(
+        "node .release-harness/scripts/test-docker-all.mjs --plan-json",
+      );
+      expect(setupCandidateStep.uses).toBe("./.github/actions/setup-node-env");
+      expect(setupCandidateStep.if).toBe(
+        consumer.jobName === "prepare_docker_e2e_image"
+          ? "(steps.plan.outputs.needs_package == '1' && inputs.package_artifact_name == '' && inputs.package_artifact_run_id == '') || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')"
+          : consumer.condition,
+      );
+    }
+
+    const prepareDockerImage = workflowJob(LIVE_E2E_WORKFLOW, "prepare_docker_e2e_image");
+    const planStepName = "Plan Docker E2E images";
     expect(workflowStep(prepareDockerImage, planStepName).env).toEqual({
       INCLUDE_OPENWEBUI: "${{ inputs.include_openwebui }}",
       INCLUDE_RELEASE_PATH_SUITES: "${{ inputs.include_release_path_suites }}",

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -31,6 +31,7 @@ const MANTIS_TELEGRAM_LIVE_WORKFLOW = ".github/workflows/mantis-telegram-live.ym
 const MANTIS_WEB_UI_CHAT_PROOF_WORKFLOW = ".github/workflows/mantis-web-ui-chat-proof.yml";
 const PACKAGE_JSON = "package.json";
 const SETUP_PNPM_STORE_CACHE_ACTION = ".github/actions/setup-pnpm-store-cache/action.yml";
+const SETUP_RELEASE_HARNESS_ACTION = ".github/actions/setup-release-harness/action.yml";
 const RELEASE_CHECKS_WORKFLOW = ".github/workflows/openclaw-release-checks.yml";
 const RELEASE_TELEGRAM_QA_WORKFLOW = ".github/workflows/openclaw-release-telegram-qa.yml";
 const RELEASE_PUBLISH_WORKFLOW = ".github/workflows/openclaw-release-publish.yml";
@@ -1351,6 +1352,26 @@ describe("package acceptance workflow", () => {
     expect(setupPnpmAction).toContain('corepack enable --install-directory "$PNPM_HOME"');
     expect(setupPnpmAction).toContain('echo "PNPM_HOME=$PNPM_HOME" >> "$GITHUB_ENV"');
 
+    const setupReleaseHarnessAction = readFileSync(SETUP_RELEASE_HARNESS_ACTION, "utf8");
+    const setupHarnessPackageManagerIndex = setupReleaseHarnessAction.indexOf(
+      "Setup trusted release harness package manager",
+    );
+    const installHarnessDependenciesIndex = setupReleaseHarnessAction.indexOf(
+      "Install trusted release harness dependencies",
+    );
+    expect(setupHarnessPackageManagerIndex).toBeGreaterThan(-1);
+    expect(installHarnessDependenciesIndex).toBeGreaterThan(setupHarnessPackageManagerIndex);
+    expect(setupReleaseHarnessAction).toContain(
+      "uses: ./.release-harness/.github/actions/setup-pnpm-store-cache",
+    );
+    expect(setupReleaseHarnessAction).toContain(
+      "package-manager-file: .release-harness/package.json",
+    );
+    expect(setupReleaseHarnessAction).toContain("working-directory: .release-harness");
+    expect(setupReleaseHarnessAction).toContain(
+      "pnpm install --frozen-lockfile --prefer-offline --ignore-scripts",
+    );
+
     const setupNodeAction = readFileSync(".github/actions/setup-node-env/action.yml", "utf8");
     expect(setupNodeAction).toContain("Normalize container toolcache");
     expect(setupNodeAction).toContain("ln -s /__t /opt/hostedtoolcache");
@@ -2408,7 +2429,10 @@ describe("package artifact reuse", () => {
 
   it("lets reusable Docker E2E consume an already resolved package artifact", () => {
     const workflow = readFileSync(LIVE_E2E_WORKFLOW, "utf8");
-    const parsedWorkflow = parse(workflow) as Workflow;
+    const parsedWorkflow = parse(workflow) as {
+      jobs?: Record<string, WorkflowJob>;
+      on?: { workflow_call?: { inputs?: Record<string, unknown> } };
+    };
     const packageJson = readFileSync(PACKAGE_JSON, "utf8");
     const scheduler = readFileSync("scripts/test-docker-all.mts", "utf8");
     const publishedUpgradeSurvivor = readFileSync(UPGRADE_SURVIVOR_RUN_SCRIPT, "utf8");
@@ -2494,95 +2518,79 @@ describe("package artifact reuse", () => {
         ?.prepublish_plugin_registry_artifact_id,
     ).toContain("inputs.enable_prepublish_plugin_registry");
     expect(workflow).toContain("bash .release-harness/scripts/ci-docker-pull-retry.sh");
-    const setupHarnessStepName = "Setup trusted release harness package manager";
-    const installHarnessStepName = "Install trusted release harness dependencies";
-    const setupCandidateStepName = "Setup Node environment";
-    const releaseChunkCondition = "contains(matrix.profiles, inputs.release_test_profile)";
-    const plannerConsumers = [
+    const setupHarnessStepName = "Setup trusted release harness";
+    const harnessJobCases = [
       {
-        candidatePosition: "before",
-        condition: releaseChunkCondition,
-        jobName: "validate_docker_e2e",
+        jobId: "validate_docker_e2e",
         planStepName: "Plan Docker E2E chunk",
+        setupIf: "contains(matrix.profiles, inputs.release_test_profile)",
       },
       {
-        candidatePosition: "before",
-        condition: undefined,
-        jobName: "validate_docker_lanes",
+        jobId: "validate_docker_lanes",
         planStepName: "Plan targeted Docker E2E lanes",
+        setupIf: undefined,
       },
       {
-        candidatePosition: "before",
-        condition: undefined,
-        jobName: "validate_docker_openwebui",
+        jobId: "validate_docker_openwebui",
         planStepName: "Plan Open WebUI Docker E2E chunk",
+        setupIf: undefined,
       },
       {
-        candidatePosition: "after",
-        condition: undefined,
-        jobName: "prepare_docker_e2e_image",
+        jobId: "prepare_docker_e2e_image",
         planStepName: "Plan Docker E2E images",
+        setupIf: undefined,
       },
     ] as const;
-    const discoveredPlannerConsumers = Object.entries(parsedWorkflow.jobs ?? {})
+    const typedHarnessJobIds = Object.entries(parsedWorkflow.jobs ?? {})
       .filter(([, job]) =>
-        job.steps?.some((step) =>
-          step.run?.includes("node .release-harness/scripts/test-docker-all.mjs --plan-json"),
+        (job.steps ?? []).some(
+          (step) =>
+            step.run?.includes("node .release-harness/scripts/test-docker-all.mjs") ||
+            step.run?.includes("node .release-harness/scripts/docker-e2e.mjs"),
         ),
       )
-      .map(([jobName]) => jobName)
+      .map(([jobId]) => jobId)
       .sort();
-    expect(discoveredPlannerConsumers).toEqual(
-      plannerConsumers.map(({ jobName }) => jobName).sort(),
-    );
+    expect(typedHarnessJobIds).toEqual(harnessJobCases.map(({ jobId }) => jobId).sort());
 
-    for (const consumer of plannerConsumers) {
-      const job = workflowJob(LIVE_E2E_WORKFLOW, consumer.jobName);
-      const stepNames = (job.steps ?? []).map((step) => step.name);
-      const planStep = workflowStep(job, consumer.planStepName);
-      const setupHarnessStep = workflowStep(job, setupHarnessStepName);
-      const installHarnessStep = workflowStep(job, installHarnessStepName);
-      const setupCandidateStep = workflowStep(job, setupCandidateStepName);
-      const planIndex = stepNames.indexOf(consumer.planStepName);
-
-      expect(stepNames.filter((name) => name === setupHarnessStepName)).toHaveLength(1);
-      expect(stepNames.filter((name) => name === installHarnessStepName)).toHaveLength(1);
-      expect(stepNames.filter((name) => name === setupCandidateStepName)).toHaveLength(1);
-      expect(stepNames.indexOf(setupHarnessStepName)).toBeLessThan(planIndex);
-      expect(stepNames.indexOf(installHarnessStepName)).toBeLessThan(planIndex);
-      expect(
-        consumer.candidatePosition === "before"
-          ? stepNames.indexOf(setupCandidateStepName) < planIndex
-          : stepNames.indexOf(setupCandidateStepName) > planIndex,
-      ).toBe(true);
+    for (const { jobId, planStepName, setupIf } of harnessJobCases) {
+      const harnessJob = workflowJob(LIVE_E2E_WORKFLOW, jobId);
+      const harnessJobSteps = harnessJob.steps ?? [];
+      const harnessJobStepNames = harnessJobSteps.map((step) => step.name);
+      const checkoutIndex = harnessJobStepNames.indexOf("Checkout trusted release harness");
+      const setupIndex = harnessJobStepNames.indexOf(setupHarnessStepName);
+      const typedHarnessIndex = harnessJobSteps.findIndex(
+        (step) =>
+          step.run?.includes("node .release-harness/scripts/test-docker-all.mjs") ||
+          step.run?.includes("node .release-harness/scripts/docker-e2e.mjs"),
+      );
+      expect(harnessJobStepNames.filter((name) => name === setupHarnessStepName)).toHaveLength(1);
+      expect(checkoutIndex).toBeGreaterThan(-1);
+      expect(setupIndex).toBeGreaterThan(checkoutIndex);
+      expect(typedHarnessIndex).toBeGreaterThan(setupIndex);
+      expect(workflowStep(harnessJob, planStepName)).toBeDefined();
+      const setupHarnessStep = workflowStep(harnessJob, setupHarnessStepName);
       expect(setupHarnessStep).toMatchObject({
-        uses: "./.release-harness/.github/actions/setup-pnpm-store-cache",
-        with: {
-          "package-manager-file": ".release-harness/package.json",
-          "use-actions-cache": "false",
-        },
+        uses: "./.release-harness/.github/actions/setup-release-harness",
+        with: { "node-version": "${{ env.NODE_VERSION }}" },
       });
-      expect(setupHarnessStep.if).toBe(consumer.condition);
-      expect(installHarnessStep).toMatchObject({
-        env: { CI: "true" },
-        run: "pnpm install --frozen-lockfile --prefer-offline --ignore-scripts",
-        "working-directory": ".release-harness",
-      });
-      expect(installHarnessStep.if).toBe(consumer.condition);
-      expect(planStep.if).toBe(consumer.condition);
-      expect(planStep.run).toContain(
-        "node .release-harness/scripts/test-docker-all.mjs --plan-json",
-      );
-      expect(setupCandidateStep.uses).toBe("./.github/actions/setup-node-env");
-      expect(setupCandidateStep.if).toBe(
-        consumer.jobName === "prepare_docker_e2e_image"
-          ? "(steps.plan.outputs.needs_package == '1' && inputs.package_artifact_name == '' && inputs.package_artifact_run_id == '') || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')"
-          : consumer.condition,
-      );
+      expect(setupHarnessStep.if).toBe(setupIf);
     }
 
     const prepareDockerImage = workflowJob(LIVE_E2E_WORKFLOW, "prepare_docker_e2e_image");
+    const prepareDockerImageStepNames = (prepareDockerImage.steps ?? []).map((step) => step.name);
     const planStepName = "Plan Docker E2E images";
+    const setupCandidateStepName = "Setup Node environment";
+    expect(
+      prepareDockerImageStepNames.filter((name) => name === setupCandidateStepName),
+    ).toHaveLength(1);
+    expect(prepareDockerImageStepNames.indexOf(setupCandidateStepName)).toBeGreaterThan(
+      prepareDockerImageStepNames.indexOf(planStepName),
+    );
+    expect(workflowStep(prepareDockerImage, setupCandidateStepName)).toMatchObject({
+      if: "(steps.plan.outputs.needs_package == '1' && inputs.package_artifact_name == '' && inputs.package_artifact_run_id == '') || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')",
+      uses: "./.github/actions/setup-node-env",
+    });
     expect(workflowStep(prepareDockerImage, planStepName).env).toEqual({
       INCLUDE_OPENWEBUI: "${{ inputs.include_openwebui }}",
       INCLUDE_RELEASE_PATH_SUITES: "${{ inputs.include_release_path_suites }}",

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -693,21 +693,11 @@ describe("release validation no-push transport", () => {
     );
     expect(packDockerArtifact.run).toContain("archive_sha256=");
     const validatePackage = step(dockerProducer, "Validate OpenClaw Docker E2E package");
-    expect(step(dockerProducer, "Setup trusted release harness package manager")).toMatchObject({
-      uses: "./.release-harness/.github/actions/setup-pnpm-store-cache",
-      with: {
-        "package-manager-file": ".release-harness/package.json",
-        "use-actions-cache": "false",
-      },
+    expect(step(dockerProducer, "Setup trusted release harness")).toMatchObject({
+      uses: "./.release-harness/.github/actions/setup-release-harness",
+      with: { "node-version": "${{ env.NODE_VERSION }}" },
     });
-    expect(
-      step(dockerProducer, "Setup trusted release harness package manager").if,
-    ).toBeUndefined();
-    expect(step(dockerProducer, "Install trusted release harness dependencies")).toMatchObject({
-      "working-directory": ".release-harness",
-      run: "pnpm install --frozen-lockfile --prefer-offline --ignore-scripts",
-    });
-    expect(step(dockerProducer, "Install trusted release harness dependencies").if).toBeUndefined();
+    expect(step(dockerProducer, "Setup trusted release harness").if).toBeUndefined();
     expect(validatePackage.env).toMatchObject({
       EXPECTED_PACKAGE_FILE_NAME: "${{ inputs.package_file_name }}",
       EXPECTED_PACKAGE_SHA256: "${{ inputs.package_sha256 }}",

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -693,19 +693,21 @@ describe("release validation no-push transport", () => {
     );
     expect(packDockerArtifact.run).toContain("archive_sha256=");
     const validatePackage = step(dockerProducer, "Validate OpenClaw Docker E2E package");
-    expect(step(dockerProducer, "Setup artifact package validation environment")).toMatchObject({
-      if: "steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != ''",
+    expect(step(dockerProducer, "Setup trusted release harness package manager")).toMatchObject({
       uses: "./.release-harness/.github/actions/setup-pnpm-store-cache",
       with: {
         "package-manager-file": ".release-harness/package.json",
         "use-actions-cache": "false",
       },
     });
-    expect(step(dockerProducer, "Install trusted package validation dependencies")).toMatchObject({
-      if: "steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != ''",
+    expect(
+      step(dockerProducer, "Setup trusted release harness package manager").if,
+    ).toBeUndefined();
+    expect(step(dockerProducer, "Install trusted release harness dependencies")).toMatchObject({
       "working-directory": ".release-harness",
       run: "pnpm install --frozen-lockfile --prefer-offline --ignore-scripts",
     });
+    expect(step(dockerProducer, "Install trusted release harness dependencies").if).toBeUndefined();
     expect(validatePackage.env).toMatchObject({
       EXPECTED_PACKAGE_FILE_NAME: "${{ inputs.package_file_name }}",
       EXPECTED_PACKAGE_SHA256: "${{ inputs.package_sha256 }}",


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation failed after the Docker planner migrated to TypeScript. The trusted `.release-harness` invoked `scripts/test-docker-all.mjs`, whose `tsx-cli-shim.mjs` resolves `tsx` from the harness repository root, but independent workflow jobs relied on the selected candidate/root dependency install instead of installing the trusted harness dependency graph.

The first observed failure was https://github.com/openclaw/openclaw/actions/runs/31319885372/job/93261415297. The same ownership violation also existed in the fresh jobs that plan release chunks, targeted Docker lanes, and Open WebUI.

## Why This Change Was Made

Every job that invokes the trusted Docker planner now bootstraps the trusted harness before its `Plan ...` step:

- `validate_docker_e2e` / `Plan Docker E2E chunk`
- `validate_docker_lanes` / `Plan targeted Docker E2E lanes`
- `validate_docker_openwebui` / `Plan Open WebUI Docker E2E chunk`
- `prepare_docker_e2e_image` / `Plan Docker E2E images`

Each job uses the trusted harness `setup-pnpm-store-cache` action with `.release-harness/package.json`, then installs from `.release-harness` with a frozen lockfile, `--prefer-offline`, and `--ignore-scripts`. The release-chunk bootstrap follows the planner's existing profile condition; the other planner bootstraps are unconditional within their jobs.

Selected-candidate setup remains where later runtime paths need it. The three consumer jobs keep their existing candidate setup before planning, while `prepare_docker_e2e_image` keeps the original conditional candidate setup after planning for source-package and prerelease-registry work. The redundant later artifact-only harness install remains removed.

The contract test now discovers every workflow job that invokes `test-docker-all.mjs --plan-json`, compares that set with the four expected planner owners, and verifies one trusted setup/install before each plan plus the preserved candidate setup ordering and conditions. A newly added planner consumer cannot silently omit its own harness bootstrap.

This preserves the frozen-target ownership boundary established by:

- https://github.com/openclaw/openclaw/pull/113907
- https://github.com/openclaw/openclaw/pull/114106
- https://github.com/openclaw/openclaw/pull/115172

The frozen candidate cannot select the trusted harness dependency set or package-manager contract.

AI-assisted implementation and review.

## User Impact

Release-only Docker planning is dependency-independent from the selected candidate, including frozen historical candidates. Validation no longer fails before planning or silently runs trusted harness code on candidate-owned dependencies.

## Evidence

- Exact PR head: `c180e4f62def885dc0786b716d5b62de715ab04b`
- Focused workflow contracts: `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts test/scripts/release-no-push-workflow.test.ts` - 191/191 passed
- `actionlint .github/workflows/openclaw-live-and-e2e-checks-reusable.yml` - passed
- `pnpm format` on the two repaired files and `git diff --check` - passed
- Exact branch Codex autoreview against current `origin/main` - clean, no accepted/actionable findings, confidence 0.99
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/31324377618 - running
- Exact-head Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31324377586 - running
- Exact-head Workflow Sanity: https://github.com/openclaw/openclaw/actions/runs/31324377594 - running
- Current merge-tree against `origin/main` `01cf584d2a83cacdfaa3048cd4509f75a01b4e33`: clean, tree `423b12617dd2f8964967a89f5414492f22ccde05`
- Production runtime LOC: `0`; workflow/config LOC: `+66/-18`; tests: `+97/-8`; config/default surfaces: `0`

The reusable workflow's bounded `prepare_only` route is exposed through `workflow_call`, not manual dispatch. Starting a separate heavy release campaign would duplicate the exact-head hosted matrix, so this PR uses source/history proof, exhaustive workflow contracts, and exact-head CI; final campaign release validation remains with the release coordinator.
