### PR TITLE
fix: keep SecretRef-backed models available in chat

### DIFF
--- a/src/agents/model-auth-availability.test.ts
+++ b/src/agents/model-auth-availability.test.ts
@@ -56,6 +56,7 @@ function evaluate(params: {
   ref?: ModelAuthAvailabilityRef;
   resolution?: ProviderModelRouteResolution | null;
   store?: AuthProfileStore;
+  preparedRuntimeAuthStore?: AuthProfileStore;
   syntheticAuthProviderRefs?: readonly string[];
   preparedRuntimeAuthModes?: PreparedAgentCredentialModes;
 }) {
@@ -66,6 +67,7 @@ function evaluate(params: {
     routeResolverFactory: routeResolverFactory(params.resolution ?? dualRoutes),
     syntheticAuthProviderRefs: params.syntheticAuthProviderRefs,
     preparedRuntimeAuthModes: params.preparedRuntimeAuthModes,
+    preparedRuntimeAuthStore: params.preparedRuntimeAuthStore,
   }).evaluateModelAuth("openai", params.ref);
 }
 
@@ -155,6 +157,43 @@ describe("createModelAuthAvailabilityResolver", () => {
       });
     },
   );
+
+  it.each([
+    { label: "resolved", key: "runtime-key", availability: true },
+    { label: "unresolved", key: undefined, availability: undefined },
+  ])("uses an exact $label prepared SecretRef profile", ({ key, availability }) => {
+    const keyRef = { source: "file" as const, provider: "vault", id: "value" };
+    const persisted = authStore({
+      "openai:default": { type: "api_key", provider: "openai", keyRef },
+    });
+    const preparedRuntimeAuthStore = authStore({
+      "openai:default": {
+        type: "api_key",
+        provider: "openai",
+        keyRef,
+        ...(key ? { key } : {}),
+      },
+    });
+
+    expect(
+      evaluate({
+        cfg: {
+          secrets: {
+            providers: {
+              vault: { source: "file", path: "/tmp/test-secret", mode: "singleValue" },
+            },
+          },
+        },
+        store: persisted,
+        preparedRuntimeAuthStore,
+      }),
+    ).toMatchObject({
+      availability,
+      evidence: "profile",
+      selectedProfileId: "openai:default",
+      selectedRoute: platformRoute,
+    });
+  });
 
   it("keeps a selected profile with missing credential material unavailable", () => {
     expect(

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -120,6 +120,7 @@ type CreateModelAuthAvailabilityResolverParams = {
   externalCliProviderIds?: readonly string[];
   routeResolverFactory?: typeof createOpenAIModelRoutesResolver;
   allowPreparedRuntimeAuth?: boolean;
+  preparedRuntimeAuthStore?: AuthProfileStore;
   preparedRuntimeAuthModes?: PreparedAgentCredentialModes;
 };
 
@@ -177,9 +178,10 @@ export function createModelAuthAvailabilityResolver(
       }
     : params.authStore;
   const runtimeStore =
-    params.allowPreparedRuntimeAuth !== false
+    params.preparedRuntimeAuthStore ??
+    (params.allowPreparedRuntimeAuth !== false
       ? getRuntimeAuthProfileStoreSnapshot(params.agentDir)
-      : undefined;
+      : undefined);
   const hydratedProfileIds = new Set<string>();
   const sameSecretRef = (
     left: ReturnType<typeof coerceSecretRef>,

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -11,6 +11,7 @@ type CreateStaticCatalogResolver =
 type StaticCatalogResolver = ReturnType<CreateStaticCatalogResolver>;
 
 const preparedModelRuntimeMocks = vi.hoisted(() => ({
+  preparedAuthStore: undefined as import("./auth-profiles/types.js").AuthProfileStore | undefined,
   authStorage: {
     getAll: vi.fn<() => AuthStorageData>(() => ({
       custom: { type: "api_key", key: "test-key" },
@@ -108,7 +109,8 @@ vi.mock("./agent-scope.js", () => ({
 }));
 
 vi.mock("./auth-profiles/runtime-snapshots.js", () => ({
-  getPreparedRuntimeAuthProfileStoreSnapshot: () => undefined,
+  getPreparedRuntimeAuthProfileStoreSnapshot: () => preparedModelRuntimeMocks.preparedAuthStore,
+  getRuntimeAuthProfileStoreSnapshot: () => preparedModelRuntimeMocks.preparedAuthStore,
   getRuntimeAuthProfileStoreSnapshotRevision: () => 0,
   registerRuntimeAuthProfileStoreMutationListener: (
     listener: (event: { agentDir?: string; affectsInheritedStores: boolean }) => void,
@@ -116,6 +118,10 @@ vi.mock("./auth-profiles/runtime-snapshots.js", () => ({
     preparedModelRuntimeMocks.mutationListener = listener;
     return () => {};
   },
+}));
+
+vi.mock("./auth-profiles/external-cli-sync.js", () => ({
+  resolveExternalCliAuthProfiles: () => [],
 }));
 
 vi.mock("./model-discovery-context.js", () => ({
@@ -172,6 +178,7 @@ export function resetPreparedModelRuntimeHarness(): void {
     custom: { type: "api_key", key: "test-key" },
   });
   preparedModelRuntimeMocks.authStorage.getOAuthProviders.mockReset().mockReturnValue([]);
+  preparedModelRuntimeMocks.preparedAuthStore = undefined;
   preparedModelRuntimeMocks.modelRegistry.fork
     .mockReset()
     .mockImplementation((authStorage: unknown) => ({ authStorage }));

--- a/src/gateway/server-chat-metadata-lifecycle.integration.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.integration.test.ts
@@ -39,6 +39,7 @@ const context = {
 let sidecars: GatewayPostReadySidecarHandle[] = [];
 
 beforeEach(() => {
+  vi.stubEnv("OPENAI_API_KEY", "");
   resetPreparedModelRuntimeHarness();
   mocks.configuredAgentIds = ["main"];
   mocks.authStorage.getAll.mockReturnValue({
@@ -56,7 +57,33 @@ beforeEach(() => {
   sidecars = [];
 });
 
+function configureAuthFixture(kind: "secret-ref" | "external-oauth" | "unresolved-secret-ref") {
+  if (kind === "external-oauth") {
+    return;
+  }
+  const apiKeyModel = { ...model, api: "openai-responses" as const };
+  mocks.buildPreparedModelCatalogSnapshot.mockResolvedValue({
+    entries: [apiKeyModel],
+    routeVariants: [apiKeyModel],
+  });
+  mocks.authStorage.getAll.mockReturnValue({
+    openai: { type: "api_key", key: "openclaw-secret-ref-configured" },
+  });
+  mocks.preparedAuthStore = {
+    version: 1,
+    profiles: {
+      "openai:default": {
+        type: "api_key",
+        provider: "openai",
+        keyRef: { source: "file", provider: "round4-file", id: "value" },
+        ...(kind === "secret-ref" ? { key: "resolved-at-runtime" } : {}),
+      },
+    },
+  };
+}
+
 afterEach(async () => {
+  vi.unstubAllEnvs();
   for (const sidecar of sidecars) {
     await sidecar.stop();
   }
@@ -73,13 +100,14 @@ async function createLifecycle() {
 async function publishOwner(): Promise<void> {
   await refreshPreparedModelRuntimeSnapshots(config, {
     gatewayLifecycle: true,
-    catalogMode: "static",
+    catalogMode: "live",
     allowGatewaySubagentBinding: true,
   });
 }
 
 async function expectAvailable(
   lifecycle: Awaited<ReturnType<typeof createGatewayChatMetadataLifecycle>>,
+  expectedAvailable = true,
 ): Promise<void> {
   const owner = getPreparedModelCatalogOwnerSnapshot({
     agentId: "main",
@@ -95,7 +123,7 @@ async function expectAvailable(
     agentId: "main",
     snapshot: owner.modelCatalog,
     metadataSnapshot: owner.metadataSnapshot,
-    preparedAuthStore: { version: 1, profiles: {} },
+    preparedAuthStore: mocks.preparedAuthStore ?? { version: 1, profiles: {} },
     preparedRuntimeAuthModes: owner.authModes,
   });
   const [metadata, modelsList] = await Promise.all([
@@ -122,11 +150,29 @@ async function expectAvailable(
   const listedModel = modelsList.models.find(
     (candidate) => candidate.id === "gpt-5.4" && candidate.provider === "openai",
   );
-  expect(metadataModel?.available).toBe(listedModel?.available);
-  expect(listedModel?.available).toBe(true);
+  expect({
+    chatMetadata: metadataModel?.available,
+    modelsList: listedModel?.available,
+  }).toEqual({
+    chatMetadata: expectedAvailable,
+    modelsList: expectedAvailable,
+  });
 }
 
 describe("gateway chat metadata lifecycle composition", () => {
+  it.each([
+    ["SecretRef-only runtime auth", "secret-ref", true],
+    ["external CLI OAuth bootstrap", "external-oauth", true],
+    ["unresolved SecretRef", "unresolved-secret-ref", false],
+  ] as const)("converges chat metadata and models.list for %s", async (_, kind, available) => {
+    configureAuthFixture(kind);
+    await publishOwner();
+    const lifecycle = await createLifecycle();
+    await lifecycle.attachContext(context, sidecars);
+
+    await expectAvailable(lifecycle, available);
+  });
+
   it("catches up when the prepared owner publishes before attachment", async () => {
     await publishOwner();
     const lifecycle = await createLifecycle();

--- a/src/gateway/server-methods/models-list-auth-resolver.ts
+++ b/src/gateway/server-methods/models-list-auth-resolver.ts
@@ -52,6 +52,9 @@ export function createModelsListAuthResolver(params: {
     loadAuthProfileStoreWithoutExternalProfiles(agentDir, {
       allowKeychainPrompt: false,
     });
+  // A prepared projection must hydrate from its own auth-store generation. Reading the global
+  // snapshot can mix generations; treating this store as persisted loses resolved SecretRefs.
+  const preparedRuntimeAuthStore = params.preparedAuthStore;
   return createModelAuthAvailabilityResolver({
     cfg: params.cfg,
     authStore,
@@ -64,7 +67,7 @@ export function createModelsListAuthResolver(params: {
     syntheticAuthProviderRefs: listEnabledSyntheticAuthProviderRefs(params),
     externalCliProviderIds:
       !params.preparedAuthStore && params.includeOpenAIExternalProfiles ? ["openai"] : [],
-    ...(params.preparedAuthStore ? { allowPreparedRuntimeAuth: false } : {}),
+    ...(preparedRuntimeAuthStore ? { preparedRuntimeAuthStore } : {}),
     routeResolverFactory: params.routeResolverFactory,
   });
 }

--- a/src/secrets/runtime-auth-store-inline-refs.test.ts
+++ b/src/secrets/runtime-auth-store-inline-refs.test.ts
@@ -174,6 +174,7 @@ describe("secrets runtime snapshot inline auth-store refs", () => {
         ownerKind: "account",
         ownerId: resolveAuthProfileSecretOwnerId({ agentDir, profileId: coldProfileId }),
         state: "unavailable",
+        degradationState: "cold",
       },
     ]);
     const profiles = snapshot.authStores[0]?.store.profiles;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where chat model metadata permanently reported a SecretRef-backed model as unavailable even though the Gateway's model list reported the same model as available. This happened when the only usable credential was an API-key auth profile resolved through the secrets runtime and no external CLI OAuth credential masked the divergence.

## Why This Change Was Made

Prepared chat projections now use their own lifecycle-prepared auth store as both the profile source and the exact runtime hydration source. That reuses the existing same-profile, provider, type, and SecretRef identity checks without reading a newer global auth generation, storing another secret value, or treating unresolved placeholders as usable.

This repairs the policy split introduced by #121057's round-1 prepared-auth ownership work: prepared projections previously disabled runtime hydration entirely, so an already-resolved `keyRef` was reclassified as an unresolved read-only ref. Direct `models.list` kept the exact-profile hydration path and therefore disagreed.

Production LOC: +8/-3 (net +5) | Tests: +98/-5

## User Impact

The model picker and chat startup metadata now agree with `models.list` for SecretRef-only credentials. External CLI OAuth bootstrap remains available when appropriate, while a genuinely unresolved SecretRef remains configured-unavailable and retains its cold account-owner diagnostic.

## Evidence

Environment-independent pre-fix reproduction on current `main`, using a canonical per-agent SQLite auth profile with only a matching file SecretRef, an empty auth-state table, isolated `HOME`/`USERPROFILE`/`CODEX_HOME`, and no ambient provider credential:

```json
{"surface":"chat.metadata","model":{"id":"gpt-5.4","provider":"openai","available":false}}
{"surface":"models.list","model":{"id":"gpt-5.4","provider":"openai","available":true}}
```

Post-fix, using the same synthetic config, auth profile, and secret without a config touch:

```json
{"surface":"chat.metadata","model":{"id":"gpt-5.4","provider":"openai","available":true}}
{"surface":"models.list","model":{"id":"gpt-5.4","provider":"openai","available":true}}
```

An independent rerun on the preserved fixture also produced `true/true`, logged zero external-CLI bootstrap uses, and verified that SQLite still stored only the file `keyRef`, not a literal key.

Focused proof:

- `node scripts/run-vitest.mjs src/agents/model-auth-availability.test.ts src/gateway/server-chat-metadata-lifecycle.integration.test.ts src/gateway/server-methods/models.test.ts src/secrets/runtime-auth-store-inline-refs.test.ts` — 77 tests passed across the selected shards.
- Affected final rerun — lifecycle 5/5 and evaluator 39/39 passed.
- Targeted `scripts/run-oxlint.mjs` — passed.
- `git diff --check` — passed.
- Autoreview (`gpt-5.6-sol`, xhigh) — clean, no actionable findings.

Provenance: clear regression from #121057, authored and merged by @steipete on 2026-08-09 (squash `4fec5242439d420af838d9a8f76ae9f0b94fb88a`); direct merge, no automation trigger found.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":3,"user":1,"assistant":1,"toolCalls":44,"toolOutputsDropped":44,"web":0,"redactions":1,"omittedUnsafe":0,"rawEntries":13}

[user]
[instructions recap omitted; policy/config text, not task dialogue]

[assistant]
I’ll use the OpenClaw debugging, testing, PR-maintainer, autoreview, and agent-transcript skills because this is a provider-generic runtime repair that must be reproduced, proven live, reviewed, and landed with transcript provenance. I’m starting with the exact SecretRef/bootstrap mechanism, the repository rules, and the prior-round memory; after that I’ll create only the requested isolated worktree and reproduce before editing.

The PR-maintainer workflow makes this a worker-executed repair: I’ll keep the parent lane as coordinator, while one execution worker owns the requested worktree through merge and independent workers challenge the owner boundary, sibling convergence, and #121057 provenance. The skill also routes historical PR evidence through Gitcrawl, so I’m adding that read-only archive workflow before delegating.

I’m taking the full Round 4 execution lane in the requested isolated worktree. I’ll first validate canonical `main`, read the governing guides and test/review/PR/transcript workflows, then reproduce the SecretRef-only divergence before touching code.

The canonical checkout is clean and exactly at `origin/main` (`fc9905ed…`); the requested branch/worktree do not exist. Memory only confirms this is the same chat-metadata problem family, so I’m treating the live mechanism and current source as authoritative. The OpenClaw testing, debugging, PR-maintainer, autoreview, and explicit transcript workflows apply here; I’m loading those before creating the requested branch.

The owner split is now visible in current source: snapshot construction deliberately inserts a secret-free configured marker for a read-only SecretRef profile, but `resolveUsableAgentCredentialModes` rejects that marker, while the model-list path independently evaluates the auth profile store. I’m now recreating that exact source shape with an isolated `HOME` so external Codex CLI bootstrap cannot mask it, and I will capture the before-fix RPC divergence before editing.

The isolated worktree has no dependency link, and the source-backed gateway cannot start because the build cannot resolve a UI workspace dependency. Per the repo’s missing-dependency rule, I’m doing the single permitted `pnpm install` retry in this task-owned worktree; after that I’ll rerun the exact gateway probe and stop treating build failures as product evidence.

The required pre-fix divergence is now stable on current `main` with external bootstrap neutralized: the same synthetic canonical SecretRef profile reports `chat.metadata.available=false` and `models.list.available=true`.

The decisive repair is now in the shared evaluator rather than the provider-level mode fallback: when chat supplies its exact lifecycle-prepared auth store, the existing same-profile/type/provider/ref hydrator uses that store as the runtime proof source. This preserves profile ordering and locks, makes the resolved ref true, and leaves the unresolved twin false. The focused evaluator and lifecycle suites are green; I’m rerunning the exact live state now.

The reduced patch is fully green: focused Vitest passed 32 gateway/model tests, 6 secrets tests, and 39 evaluator tests; the final affected rerun passed 5 lifecycle + 39 evaluator tests. Targeted oxlint and `git diff --check` pass. Production is `+8/-3` (net +5), justified by the exact lifecycle hydration-store ownership seam and its invariant comment. I’m starting the required autoreview now with the scope fixed to this SecretRef/profile-generation invariant.

Autoreview returned clean on the first cycle with no actionable findings. The patch is committed as `e8c7c9a7878`; Git author and GitHub writer are both `steipete`. I’m now rebasing once onto current `origin/main`, then I’ll push and open the PR with the sanitized proof and requested transcript.

[tool summary]
44 other; raw tool outputs dropped: 44
````

</details>
<!-- agent-transcript:end -->
