### PR TITLE
fix(telegram): record undeliverable failure notices instead of discarding them

### DIFF
--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -855,26 +855,33 @@ describe("telegram bot message processor", () => {
     );
   });
 
-  it("swallows fallback delivery failures after dispatch throws", async () => {
+  it("records an undeliverable fallback notice after dispatch throws", async () => {
     const sendMessage = vi.fn().mockRejectedValue(new Error("blocked by user"));
     const { processMessage, runtimeError, dispatchError } = createDispatchFailureHarness(
       {
         chatId: 123,
+        threadSpec: { id: 456, scope: "forum" },
         route: { sessionKey: "agent:main:main" },
       },
       sendMessage,
     );
     const result = await processSampleMessage(processMessage);
 
+    // A failed notice must not propagate: the turn still settles as retryable.
     expect(result).toEqual({ kind: "failed-retryable", error: dispatchError });
 
     expect(sendMessage).toHaveBeenCalledWith(
       123,
       "Something went wrong while processing your request. Please try again.",
-      undefined,
+      { message_thread_id: 456 },
     );
     expect(runtimeError).toHaveBeenCalledWith(
       "telegram message processing failed: Error: dispatch exploded",
+    );
+    // The notice inherits the thread that just failed, so its own failure is the
+    // only signal that the turn reached the user with nothing at all.
+    expect(runtimeError).toHaveBeenCalledWith(
+      "telegram failure notice undeliverable chat=123 thread=456: Error: blocked by user",
     );
   });
 });

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -322,7 +322,16 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
               "Something went wrong while processing your request. Please try again.",
               buildTelegramThreadParams(context.threadSpec),
             );
-          } catch {}
+          } catch (notifyErr) {
+            // This notice inherits the thread binding that just failed, so a dead
+            // topic silences it too. Record the miss: it is the only signal that
+            // the turn ended with nothing visible to the user at all.
+            runtime.error?.(
+              danger(
+                `telegram failure notice undeliverable chat=${context.chatId} thread=${context.threadSpec.id ?? "none"}: ${String(notifyErr)}`,
+              ),
+            );
+          }
         }
         const result: TelegramMessageProcessingResult = {
           kind: "failed-retryable",


### PR DESCRIPTION
Related: #121092

## What Problem This Solves

Fixes an issue where a Telegram turn that fails while its topic is unreachable leaves no record that the user was told nothing at all.

When a turn fails, the processor sends a "Something went wrong while processing your request. Please try again." notice. That notice is addressed with the same thread binding the turn just failed on, so when Telegram rejects the topic with `400 Bad Request: message thread not found`, the notice is rejected too. Its rejection was discarded by a bare `catch {}`.

The result is a turn that ends with nothing visible in Telegram and no operator-facing statement of that fact. The dispatch error is logged, but nothing says the last-resort notice also never landed, or which thread it tried.

## Why This Change Was Made

The notice's own failure is the only signal that a turn reached the user with nothing at all. Every other log line on this path describes why the turn failed, not whether the user was reachable, so discarding it removes the one fact an operator needs to tell "the turn broke" apart from "the turn broke and the user never heard about it".

The record names the chat and the thread it targeted, because the actionable detail is which binding is unreachable.

Scope is deliberately narrow. This does not change routing, does not retry, and does not reintroduce the threadless fallback removed in #83381 — a rejected topic send still fails closed, per `extensions/telegram/AGENTS.md`. The notice still does not propagate, so the turn settles as `failed-retryable` exactly as before. The remaining questions raised in #121092 (failure alerts inheriting a dead `delivery.threadId`, cron recording a definitive rejection as `unknown`, and the drain retry budget for non-transient failures) are product decisions and are intentionally left out of this PR.

## User Impact

Operators debugging a silent Telegram turn now get an explicit line naming the chat and thread whose failure notice could not be delivered, instead of a gap in the log. There is no user-visible change in Telegram itself: the notice still cannot reach an unreachable topic, and that is the intended fail-closed behavior.

## Evidence

Focused tests, `extensions/telegram/src/bot-message.test.ts` (25 tests):

```
 Test Files  1 passed (1)
      Tests  25 passed (25)
```

Red/green proof — reverting only the production change fails exactly the new assertion:

```
 × records an undeliverable fallback notice after dispatch throws
AssertionError: expected "vi.fn()" to be called with arguments: [ Array(1) ]
-   "telegram failure notice undeliverable chat=123 thread=456: Error: blocked by user",
      Tests  1 failed | 24 passed (25)
```

The existing `swallows fallback delivery failures after dispatch throws` case was extended rather than duplicated, and renamed to match the new contract. Its original guarantee — a failed notice must not propagate — is still asserted.

Sibling surface: `extensions/telegram/src/bot-message-dispatch*` (17 files, 235 tests) reports 4 failures. The identical 4 failures reproduce on a clean checkout with no changes applied, so they are pre-existing on `main` and untouched here:

```
 FAIL  bot-message-dispatch.context-recovery.test.ts > does not recover forum thread context from a different group session key
 FAIL  bot-message-dispatch.delivery-basics.test.ts > queues final Telegram replies through outbound delivery when available
 FAIL  bot-message-dispatch.draft-failures-progress.test.ts > finalizes the default streamed draft in place after an unexpected reply failure in a 'direct chat'
 FAIL  bot-message-dispatch.draft-failures-progress.test.ts > finalizes the default streamed draft in place after an unexpected reply failure in a 'group chat'
```

`oxfmt` and `scripts/run-oxlint.mjs` are clean on both touched files. Production delta is +9/-1; the rest is test.

Proof was run locally. The Crabbox/Testbox wrappers need an installed dependency tree to start, and this checkout had none, so the remote lane was unavailable and validation fell back to local focused runs on the rebased head (`origin/main` at `d60a5f7dd41`).

Field evidence for the underlying problem, including live `cron_run_logs` rows for three consecutive days of silently dropped deliveries, is in #121092.
