### PR TITLE
refactor(telegram): reuse outbound topic preparation

### DIFF
--- a/extensions/telegram/src/bot-handlers.callback-actions.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.runtime.ts
@@ -9,6 +9,11 @@ export type TelegramCallbackButton = {
   style?: "danger" | "success" | "primary";
 };
 
+type TelegramCallbackReplyParams = Omit<
+  NonNullable<Parameters<RegisterTelegramHandlerParams["bot"]["api"]["sendMessage"]>[2]>,
+  "direct_messages_topic_id" | "message_thread_id"
+>;
+
 export interface TelegramCallbackMessageActions {
   editCallbackMessage: (
     text: string,
@@ -25,14 +30,13 @@ export interface TelegramCallbackMessageActions {
   >;
   replyToCallbackChat: (
     text: string,
-    replyParams?: Parameters<RegisterTelegramHandlerParams["bot"]["api"]["sendMessage"]>[2],
+    replyParams?: TelegramCallbackReplyParams,
   ) => ReturnType<RegisterTelegramHandlerParams["bot"]["api"]["sendMessage"]>;
 }
 
 export function createTelegramCallbackMessageActions(params: {
   bot: RegisterTelegramHandlerParams["bot"];
   callbackMessage: Message;
-  isGroup: boolean;
   isForum: boolean;
 }): TelegramCallbackMessageActions {
   const { bot, callbackMessage, isForum } = params;
@@ -77,21 +81,13 @@ export function createTelegramCallbackMessageActions(params: {
     return await bot.api.deleteMessage(callbackMessage.chat.id, callbackMessage.message_id);
   };
 
-  const replyToCallbackChat = async (
-    text: string,
-    replyParams?: Parameters<typeof bot.api.sendMessage>[2],
-  ) => {
+  const replyToCallbackChat = async (text: string, replyParams?: TelegramCallbackReplyParams) => {
     const threadParams = buildTelegramThreadParams(
       resolveTelegramMessageThreadSpec(callbackMessage, isForum),
     );
-    const {
-      message_thread_id: _messageThreadId,
-      direct_messages_topic_id: _directMessagesTopicId,
-      ...ordinaryReplyParams
-    } = replyParams ?? {};
     const mergedParams =
       callbackBusinessParams || threadParams || replyParams
-        ? { ...ordinaryReplyParams, ...callbackBusinessParams, ...threadParams }
+        ? { ...replyParams, ...callbackBusinessParams, ...threadParams }
         : replyParams;
     return await bot.api.sendMessage(callbackMessage.chat.id, text, mergedParams);
   };

--- a/extensions/telegram/src/bot-handlers.callback.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.callback.runtime.ts
@@ -189,7 +189,6 @@ export function registerTelegramCallbackQueryHandler(
       const actions = createTelegramCallbackMessageActions({
         bot,
         callbackMessage,
-        isGroup,
         isForum,
       });
       const approvalRuntime = createTelegramCallbackApprovalRuntime({

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -102,7 +102,6 @@ const { clearTelegramRuntimeForTest, resetTelegramAccountThrottlersForTest } =
 const { setTelegramRuntime } = await import("./runtime.js");
 const {
   buildTelegramGroupFrom,
-  buildTelegramThreadParams,
   buildTypingThreadParams,
   resolveTelegramForumFlag,
   resetTelegramForumFlagCacheForTest,
@@ -4496,27 +4495,6 @@ describe("createTelegramBot", () => {
     );
     expect(buildTypingThreadParams(resolvedThreadId)).toEqual({ message_thread_id: 1 });
   });
-  it("threads forum replies only when a topic id exists", () => {
-    expect(
-      buildTelegramThreadParams(
-        resolveTelegramThreadSpec({
-          isGroup: true,
-          isForum: true,
-          messageThreadId: undefined,
-        }),
-      ),
-    ).toBeUndefined();
-    expect(
-      buildTelegramThreadParams(
-        resolveTelegramThreadSpec({
-          isGroup: true,
-          isForum: true,
-          messageThreadId: 99,
-        }),
-      ),
-    ).toEqual({ message_thread_id: 99 });
-  });
-
   const allowFromEdgeCases: MessagePolicyCase[] = [
     makeMessagePolicyCase({
       name: "allows direct messages regardless of groupPolicy",

--- a/extensions/telegram/src/send-context.ts
+++ b/extensions/telegram/src/send-context.ts
@@ -32,7 +32,6 @@ export type TelegramApi = Bot["api"];
 export type TelegramApiOverride = Partial<TelegramApi>;
 export type TelegramThreadScopedParams = {
   message_thread_id?: number;
-  direct_messages_topic_id?: number;
   reply_parameters?: { message_id?: number };
   reply_to_message_id?: number;
 };
@@ -105,12 +104,6 @@ export function toAcceptedThreadScopedParams(
   const scoped: TelegramThreadScopedParams = {};
   if (typeof params.message_thread_id === "number" && Number.isFinite(params.message_thread_id)) {
     scoped.message_thread_id = params.message_thread_id;
-  }
-  if (
-    typeof params.direct_messages_topic_id === "number" &&
-    Number.isFinite(params.direct_messages_topic_id)
-  ) {
-    scoped.direct_messages_topic_id = params.direct_messages_topic_id;
   }
   if (
     typeof params.reply_to_message_id === "number" &&

--- a/extensions/telegram/src/send-message.ts
+++ b/extensions/telegram/src/send-message.ts
@@ -17,17 +17,11 @@ import {
 } from "./outbound-media.js";
 import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import type { TelegramOutboundPromptContextMessage as TelegramMessageLike } from "./outbound-message-context.js";
-import {
-  buildTelegramThreadReplyParams,
-  resolveTelegramSendThreadSpec,
-} from "./reply-parameters.js";
+import { buildTelegramThreadReplyParams } from "./reply-parameters.js";
 import { isTelegramEmptyContentError } from "./rich-plain-fallback.js";
 import {
-  createRequestWithChatNotFound,
-  createTelegramNonIdempotentRequestWithDiag,
   logTelegramOutboundSendOk,
   resolveAcceptedReplyToMessageId,
-  resolveAndPersistChatId,
   resolveTelegramApiContext,
   resolveTelegramMessageIdOrThrow,
   sendLogger,
@@ -42,7 +36,7 @@ import {
 } from "./send-error-predicates.js";
 import { createTelegramTextSender } from "./send-message-text.js";
 import type { TelegramSendOpts, TelegramSendResult } from "./send-message-types.js";
-import { reportTelegramProviderDelivery } from "./send-outbound.js";
+import { prepareTelegramOutbound, reportTelegramProviderDelivery } from "./send-outbound.js";
 import {
   buildOutboundMediaLoadOptions,
   getImageMetadata,
@@ -51,7 +45,6 @@ import {
   resolveMarkdownTableMode,
 } from "./send.runtime.js";
 import { recordSentMessage } from "./sent-message-cache.js";
-import { parseTelegramTarget } from "./targets.js";
 import { resolveTelegramBotUserIdFromToken } from "./token-fingerprint.js";
 
 const MAX_TELEGRAM_PHOTO_DIMENSION_SUM = 10_000;
@@ -77,20 +70,16 @@ async function sendMessageTelegramWithContext(
 ): Promise<TelegramSendResult> {
   const { cfg, account, api } = apiContext;
   const botUserId = resolveTelegramBotUserIdFromToken(opts.token || account.token);
-  const target = parseTelegramTarget(to);
-  const chatId = await resolveAndPersistChatId({
-    cfg,
-    api,
-    lookupTarget: target.chatId,
-    persistTarget: to,
-    verbose: opts.verbose,
-    gatewayClientScopes: opts.gatewayClientScopes,
-  });
-  const threadSpec = resolveTelegramSendThreadSpec({
-    targetMessageThreadId: target.messageThreadId,
-    targetDirectMessagesTopicId: target.directMessagesTopicId,
-    messageThreadId: opts.messageThreadId,
-    chatType: target.chatType,
+  const {
+    chatId,
+    threadSpec,
+    request: requestWithChatNotFound,
+  } = await prepareTelegramOutbound({
+    to,
+    context: apiContext,
+    opts,
+    thread: { messageThreadId: opts.messageThreadId },
+    request: { kind: "nonIdempotent" },
   });
   const reportDelivery = async (
     messageId: string | number,
@@ -157,18 +146,6 @@ async function sendMessageTelegramWithContext(
           }
         : {}),
     });
-  const requestWithDiag = createTelegramNonIdempotentRequestWithDiag({
-    cfg,
-    account,
-    retry: opts.retry,
-    verbose: opts.verbose,
-  });
-  const requestWithChatNotFound = createRequestWithChatNotFound({
-    requestWithDiag,
-    chatId,
-    input: to,
-  });
-
   const textMode = opts.textMode ?? "markdown";
   // Caller-authored HTML keeps legacy parse_mode HTML semantics (literal
   // newlines, 4096 chunking) even on rich accounts; blocks are markdown-only.

--- a/extensions/telegram/src/targets.ts
+++ b/extensions/telegram/src/targets.ts
@@ -107,32 +107,23 @@ function resolveTelegramChatType(chatId: string): "direct" | "group" | "unknown"
 
 export function parseTelegramTarget(to: string): TelegramTarget {
   const normalized = stripTelegramInternalPrefixes(to);
-  const directMatch = /^(.+?):direct-topic:(\d+)$/.exec(normalized);
-  if (directMatch) {
-    const chatId = directMatch[1];
-    const topicIdText = directMatch[2];
-    if (chatId !== undefined && topicIdText !== undefined) {
-      const directMessagesTopicId = parseStrictPositiveInteger(topicIdText);
-      if (directMessagesTopicId !== undefined) {
-        return { chatId, directMessagesTopicId, chatType: resolveTelegramChatType(chatId) };
-      }
-    }
-    return { chatId: normalized, chatType: "unknown" };
-  }
-  const match = /^(.+?):topic:(\d+)$/.exec(normalized) ?? /^(.+):(\d+)$/.exec(normalized);
-  if (match) {
-    const chatId = match[1];
-    const threadIdText = match[2];
-    if (chatId !== undefined && threadIdText !== undefined) {
-      const messageThreadId = parseStrictNonNegativeInteger(threadIdText);
-      if (messageThreadId !== undefined) {
-        return { chatId, messageThreadId, chatType: resolveTelegramChatType(chatId) };
-      }
+  const match = /^(.+?):(?:(direct-topic|topic):)?(\d+)$/.exec(normalized);
+  const chatId = match?.[1];
+  const topicIdText = match?.[3];
+  if (chatId && topicIdText) {
+    const directTopic = match[2] === "direct-topic";
+    const topicId = directTopic
+      ? parseStrictPositiveInteger(topicIdText)
+      : parseStrictNonNegativeInteger(topicIdText);
+    if (topicId !== undefined) {
+      return directTopic
+        ? { chatId, directMessagesTopicId: topicId, chatType: resolveTelegramChatType(chatId) }
+        : { chatId, messageThreadId: topicId, chatType: resolveTelegramChatType(chatId) };
     }
   }
   return {
     chatId: normalized,
-    chatType: resolveTelegramChatType(normalized),
+    chatType: match ? "unknown" : resolveTelegramChatType(normalized),
   };
 }
 

--- a/extensions/telegram/src/transport-payload.test.ts
+++ b/extensions/telegram/src/transport-payload.test.ts
@@ -1,5 +1,4 @@
-import { createServer, type Server } from "node:http";
-import type { AddressInfo, Socket } from "node:net";
+import { buffer } from "node:stream/consumers";
 import { Bot } from "grammy";
 import type { Message } from "grammy/types";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -8,8 +7,9 @@ import {
   createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createTelegramCallbackMessageActions } from "./bot-handlers.callback-actions.runtime.js";
+import { asTelegramClientFetch } from "./client-fetch.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
 import { setTelegramRuntime } from "./runtime.js";
 import {
@@ -68,48 +68,47 @@ function hasMultipartField(request: CapturedRequest, name: string, value?: strin
 }
 
 describe("Telegram topic transport payloads", () => {
-  const liveSockets = new Set<Socket>();
   const requests: CapturedRequest[] = [];
-  let server: Server;
-  let bot: Bot;
   let nextMessageId = 100;
+  const fetch = asTelegramClientFetch(
+    async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init?: Parameters<typeof globalThis.fetch>[1],
+    ) => {
+      const rawBody = init?.body;
+      const body =
+        typeof rawBody === "string"
+          ? Buffer.from(rawBody)
+          : rawBody
+            ? await buffer(rawBody as unknown as NodeJS.ReadableStream)
+            : Buffer.alloc(0);
+      const method = new URL(input instanceof Request ? input.url : String(input)).pathname
+        .split("/")
+        .at(-1);
+      const captured = {
+        body,
+        contentType: new Headers(init?.headers).get("content-type") ?? "",
+        method: method ?? "unknown",
+      };
+      requests.push(captured);
 
-  beforeAll(async () => {
-    server = createServer((request, response) => {
-      const chunks: Buffer[] = [];
-      request.on("data", (chunk: Buffer) => chunks.push(chunk));
-      request.on("end", () => {
-        const body = Buffer.concat(chunks);
-        const method = request.url?.split("/").at(-1) ?? "unknown";
-        const captured = {
-          body,
-          contentType: request.headers["content-type"] ?? "",
-          method,
-        };
-        requests.push(captured);
-
-        let result: true | Record<string, unknown> = true;
-        if (method.startsWith("send")) {
-          const raw = body.toString("utf8");
-          const payload = captured.contentType.startsWith("application/json")
-            ? parseJsonBody(captured)
-            : undefined;
-          const directTopic =
-            payload?.direct_messages_topic_id ??
-            (hasMultipartField(captured, "direct_messages_topic_id", String(DIRECT_TOPIC_ID))
-              ? DIRECT_TOPIC_ID
-              : undefined);
-          const messageThread = payload?.message_thread_id;
-          result = {
+      const payload = captured.contentType.startsWith("application/json")
+        ? parseJsonBody(captured)
+        : undefined;
+      const directTopic =
+        payload?.direct_messages_topic_id ??
+        (hasMultipartField(captured, "direct_messages_topic_id", String(DIRECT_TOPIC_ID))
+          ? DIRECT_TOPIC_ID
+          : undefined);
+      const result = method?.startsWith("send")
+        ? {
             message_id: nextMessageId++,
             date: 1_700_000_000,
-            chat:
-              directTopic !== undefined
-                ? { id: DIRECT_CHAT_ID, type: "supergroup", is_direct_messages: true }
-                : {
-                    id: raw.includes('"chat_id":1234') ? 1234 : DIRECT_CHAT_ID,
-                    type: "supergroup",
-                  },
+            chat: {
+              id: DIRECT_CHAT_ID,
+              type: "supergroup",
+              ...(directTopic !== undefined ? { is_direct_messages: true } : {}),
+            },
             ...(directTopic !== undefined
               ? {
                   direct_messages_topic: {
@@ -117,26 +116,16 @@ describe("Telegram topic transport payloads", () => {
                     user: { id: 700, is_bot: false, first_name: "Subscriber" },
                   },
                 }
-              : typeof messageThread === "number"
-                ? { message_thread_id: messageThread }
-                : {}),
+              : {}),
             text: "accepted",
-          };
-        }
-        response.writeHead(200, { "content-type": "application/json" });
-        response.end(JSON.stringify({ ok: true, result }));
+          }
+        : true;
+      return new Response(JSON.stringify({ ok: true, result }), {
+        headers: { "content-type": "application/json" },
       });
-    });
-    server.on("connection", (socket) => {
-      liveSockets.add(socket);
-      socket.once("close", () => liveSockets.delete(socket));
-    });
-    await new Promise<void>((resolve) => {
-      server.listen(0, "127.0.0.1", resolve);
-    });
-    const apiRoot = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
-    bot = new Bot(TOKEN, { client: { apiRoot } });
-  });
+    },
+  );
+  const bot = new Bot(TOKEN, { client: { fetch } });
 
   beforeEach(() => {
     requests.length = 0;
@@ -149,15 +138,6 @@ describe("Telegram topic transport payloads", () => {
     clearTelegramRuntime();
     resetTelegramMessageCacheForTest();
     resetPluginStateStoreForTests();
-  });
-
-  afterAll(async () => {
-    for (const socket of liveSockets) {
-      socket.destroy();
-    }
-    await new Promise<void>((resolve) => {
-      server.close(() => resolve());
-    });
   });
 
   it("serializes direct draft destinations while keeping edits topic-free", async () => {
@@ -258,7 +238,6 @@ describe("Telegram topic transport payloads", () => {
     const actions = createTelegramCallbackMessageActions({
       bot,
       callbackMessage,
-      isGroup: true,
       isForum: false,
     });
 


### PR DESCRIPTION
Related: #120916

## What Problem This Solves

Resolves duplicate Telegram outbound preparation and transport-test infrastructure left adjacent to #120916, which made topic target changes require multiple coordinated edits.

## Why This Change Was Made

Routes main message sends through the existing `prepareTelegramOutbound`, unifies target suffix parsing, narrows callback topic ownership, removes unread accepted metadata, and uses grammY's injected fetch seam. This does not change routing behavior or a public contract.

## User Impact

None intended. Channel Direct Messages, forum, bot-private, replies, media, retries, diagnostics, and target writeback remain unchanged, with less duplicate code to maintain.

## Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/send.test.ts extensions/telegram/src/targets.test.ts extensions/telegram/src/transport-payload.test.ts extensions/telegram/src/thread-spec.test.ts extensions/telegram/src/reply-parameters.test.ts extensions/telegram/src/bot-native-commands.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts` — 7 files, 476 tests passed.
- Extension production and extension-test tsgo typechecks passed.
- Focused oxlint passed with 0 warnings and 0 errors on Blacksmith Testbox `tbx_01kzkjbfqm3zz0vtgcn057sxm9` ([run 31321304110](https://github.com/openclaw/openclaw/actions/runs/31321304110)).
- Focused oxfmt check and `git diff --check` passed.
- Production LOC: +33/-77 (net -44). Tests: +48/-91 (net -43).
- The focused transport suite captures grammY's actual post-serialization JSON and multipart payloads through its injected fetch seam.
- Final Codex autoreview reported no accepted/actionable findings.

No live Telegram probe was run; this is a behavior-neutral cleanup follow-up to #120916.

AI-assisted: yes; implementation and final diff reviewed by Peter.
