### PR TITLE
fix: legacy WhatsApp/Feishu/Telegram plugin builds crash on every inbound message after runDispatchLifecycle guard

### DIFF
--- a/src/channels/turn/kernel.test.ts
+++ b/src/channels/turn/kernel.test.ts
@@ -2424,7 +2424,36 @@ describe("channel turn kernel", () => {
     expect(result.dispatchResult.queuedFinal).toBe(true);
   });
 
-  it("rejects prepared turns that omit dispatch lifecycle ownership", async () => {
+  it("runs a legacy prepared turn that omits dispatch lifecycle ownership when no adoption lifecycle is in play", async () => {
+    // Released plugin builds predating the runDispatchLifecycle contract (e.g.
+    // @openclaw/whatsapp@2026.7.1) never adopt a durable ingress claim, so
+    // there is nothing to leak here -- see openclaw/openclaw#114020, #116453.
+    const recordInboundSession = createRecordInboundSession();
+    const runDispatch = vi.fn(async () => ({ visibleReplySent: true }));
+
+    const result = await runChannelInboundEvent({
+      channel: "test",
+      raw: { id: "msg-1", text: "hello" },
+      adapter: {
+        ingest: () => ({ id: "msg-1", rawText: "hello" }),
+        resolveTurn: () =>
+          ({
+            channel: "test",
+            routeSessionKey: "agent:main:test:peer",
+            storePath: "/tmp/sessions.json",
+            ctxPayload: createCtx(),
+            recordInboundSession,
+            runDispatch,
+          }) as unknown as ChannelTurnResolved,
+      },
+    });
+
+    expect(recordInboundSession).toHaveBeenCalled();
+    expect(runDispatch).toHaveBeenCalled();
+    expect(result.dispatched).toBe(true);
+  });
+
+  it("rejects prepared turns that omit dispatch lifecycle ownership when the caller adopts a durable ingress claim", async () => {
     const recordInboundSession = createRecordInboundSession();
     const runDispatch = vi.fn(async () => ({ visibleReplySent: true }));
     const onFinalize = vi.fn();
@@ -2433,6 +2462,7 @@ describe("channel turn kernel", () => {
       runChannelInboundEvent({
         channel: "test",
         raw: { id: "msg-1", text: "hello" },
+        turnAdoptionLifecycle: { onAdopted: vi.fn(async () => undefined) },
         adapter: {
           ingest: () => ({ id: "msg-1", rawText: "hello" }),
           resolveTurn: () =>

--- a/src/channels/turn/kernel.ts
+++ b/src/channels/turn/kernel.ts
@@ -92,13 +92,23 @@ function assertPreparedDispatchLifecycle<TDispatchResult>(
   turn: PreparedChannelTurn<TDispatchResult>,
   turnAdoptionLifecycle: RunChannelTurnParams<unknown>["turnAdoptionLifecycle"],
 ): void {
+  // This guard exists to stop a durable ingress claim from stalling unadopted
+  // (see #110981) -- that risk only exists when the caller actually hands in
+  // a turnAdoptionLifecycle to adopt. Without one, there is no durable claim
+  // for a prepared turn to leak, so legacy adapters built against the older,
+  // lifecycle-less PreparedChannelTurn contract (e.g. released plugin builds
+  // that predate this field) keep working instead of crashing every inbound
+  // event. See openclaw/openclaw#114020 and #116453.
+  if (!turnAdoptionLifecycle) {
+    return;
+  }
   const lifecycle = turn.runDispatchLifecycle;
   if (!lifecycle) {
     throw new Error(
       "runChannelInboundEvent prepared turns must declare runDispatchLifecycle when creating runDispatch",
     );
   }
-  if (turnAdoptionLifecycle && lifecycle.turnAdoptionLifecycle !== turnAdoptionLifecycle) {
+  if (lifecycle.turnAdoptionLifecycle !== turnAdoptionLifecycle) {
     throw new Error(
       "runChannelInboundEvent prepared turn runDispatchLifecycle must own the top-level turnAdoptionLifecycle",
     );


### PR DESCRIPTION
Related: #114020
Related: #116453

## What Problem This Solves

Fixes an issue where released channel plugin builds that predate the
`runDispatchLifecycle` contract (e.g. `@openclaw/whatsapp@2026.7.1`, and the
Feishu/Telegram adapters described in #114020) have **every inbound message
dispatch fail** with:

```
runChannelInboundEvent prepared turns must declare runDispatchLifecycle when creating runDispatch
```

immediately after upgrading core past the turn-lifecycle hardening in
#110981. The channel connects and receives messages fine, but every dispatch
throws, so passive/idle listening breaks completely and no replies are ever
sent — users only notice when they realize the assistant has gone silent on
that channel.

## Why This Change Was Made

`assertPreparedDispatchLifecycle()` in the channel turn kernel throws
whenever a prepared turn's `runDispatchLifecycle` is missing, regardless of
whether the caller ever passed a `turnAdoptionLifecycle` to adopt in the
first place. That check exists to stop a durable ingress claim from stalling
unadopted (#110981) — but that risk only exists when the caller actually
hands in a `turnAdoptionLifecycle`. Without one, there is no durable claim
for a prepared turn to leak, so this change short-circuits the guard in that
case instead of throwing, letting legacy adapters built against the older,
lifecycle-less `PreparedChannelTurn` contract keep working.

## User Impact

Channels running plugin builds that predate the `runDispatchLifecycle`
field (currently affects WhatsApp, and per #114020 also Feishu and
Telegram) go back to dispatching inbound messages normally instead of
crashing on every single one. No plugin update is required to unblock this
— core stays backward compatible with the older prepared-turn contract.

## Evidence

- Focused test run: `node scripts/run-vitest.mjs src/channels/turn/kernel.test.ts`
  → 50 passed, including a new regression test
  (`runs a legacy prepared turn that omits dispatch lifecycle ownership when
  no adoption lifecycle is in play`).
- Live verification: rebuilt a local gateway image with this fix, running
  against an installed `@openclaw/whatsapp@2026.7.1` plugin on a
  `2026.7.2`-versioned core build. Before the fix, the WhatsApp connection
  went completely silent during idle periods (zero reconnect attempts logged
  for 51+ hours, no established WhatsApp socket). After rebuilding with this
  fix and restarting, the WhatsApp connection stayed established through
  30+ minutes of idle time with zero watchdog/reconnect churn.
