### PR TITLE
fix(ci): sparse-checkout the renamed local-heavy-check-runtime.mts on the frozen shard lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2095,7 +2095,7 @@ jobs:
           sparse-checkout: |
             scripts/ci-run-node-test-shard.mts
             scripts/lib/direct-run.mjs
-            scripts/lib/local-heavy-check-runtime.mjs
+            scripts/lib/local-heavy-check-runtime.mts
           sparse-checkout-cone-mode: false
           persist-credentials: false
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -5503,7 +5503,17 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
         "persist-credentials": false,
       },
     });
-    expect(existsSync("scripts/ci-run-node-test-shard.mts")).toBe(true);
+    // Non-cone sparse-checkout ignores missing paths silently, so a renamed
+    // script would surface only as a runtime module-not-found on the frozen
+    // lane. Require every listed path to exist at this revision.
+    const sparseCheckoutPaths = String(trustedRunnerStep?.with?.["sparse-checkout"] ?? "")
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    expect(sparseCheckoutPaths).toContain("scripts/ci-run-node-test-shard.mts");
+    for (const sparsePath of sparseCheckoutPaths) {
+      expect({ sparsePath, exists: existsSync(sparsePath) }).toEqual({ sparsePath, exists: true });
+    }
   });
 
   it("emits one final CI gate after every selected lane", () => {


### PR DESCRIPTION
## What Problem This Solves

Today's scripts TypeScript migration (#121005) renamed `scripts/lib/local-heavy-check-runtime.mjs` to `.mts` but left the old `.mjs` path in the "Checkout trusted Node shard runner" sparse-checkout list in `.github/workflows/ci.yml`. Non-cone sparse-checkout ignores missing paths silently, so the frozen-target Node shard lane (the compatibility path used for release-candidate and historical-target runs) would fetch the shard runner but not its dependency, then die at import time with `ERR_MODULE_NOT_FOUND` — looking like an unrelated infra flake at the worst possible moment.

## Why This Change Was Made

The guard test `ci-workflow-guards.test.ts` only asserted existence for one of the three sparse-checkout paths, so this rename drift passed CI. This PR fixes the stale path and closes the guard gap: the test now splits the sparse-checkout block and requires every listed path to exist at the current revision, making this whole class of rename drift a red test instead of a dormant lane break.

## User Impact

None at runtime. CI-only: the frozen-target shard lane keeps working after script renames, and future renames that miss a workflow reference fail fast in the guard suite.

## Evidence

- On disk: `scripts/lib/local-heavy-check-runtime.mts` exists; the `.mjs` variant does not. `scripts/ci-run-node-test-shard.mts:22` imports `./lib/local-heavy-check-runtime.mts`.
- `scripts/lib/direct-run.mjs` is genuinely still `.mjs` and its sparse-checkout line is unchanged.
- Focused proof: `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 108 passed, 2 skipped.
- Codex autoreview (gpt-5.6-sol, local mode): clean, no accepted findings, "patch is correct (0.99)".
