### PR TITLE
fix(maintainers): prevent false PR closeout failures

### DIFF
--- a/scripts/pr-lib/merge.sh
+++ b/scripts/pr-lib/merge.sh
@@ -454,28 +454,8 @@ merge_run() {
   local repo_nwo
   repo_nwo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 
-  local landed_sha_url=""
-  if gh api repos/:owner/:repo/commits/"$landed_sha" >/dev/null 2>&1; then
-    landed_sha_url="https://github.com/$repo_nwo/commit/$landed_sha"
-  else
-    echo "Landed commit is not resolvable via repository commit endpoint: $landed_sha"
-    exit 1
-  fi
-
-  local prep_sha_url=""
-  if gh api repos/:owner/:repo/commits/"$PREP_HEAD_SHA" >/dev/null 2>&1; then
-    prep_sha_url="https://github.com/$repo_nwo/commit/$PREP_HEAD_SHA"
-  else
-    local pr_commit_count
-    pr_commit_count=$(gh pr view "$pr" --json commits --jq "[.commits[].oid | select(. == \"$PREP_HEAD_SHA\")] | length")
-    if [ "${pr_commit_count:-0}" -gt 0 ]; then
-      prep_sha_url="https://github.com/$repo_nwo/pull/$pr/commits/$PREP_HEAD_SHA"
-    fi
-  fi
-  if [ -z "$prep_sha_url" ]; then
-    echo "Prepared head SHA is not resolvable in repo commits or PR commit list: $PREP_HEAD_SHA"
-    exit 1
-  fi
+  local landed_sha_url="https://github.com/$repo_nwo/commit/$landed_sha"
+  local prep_sha_url="https://github.com/$repo_nwo/pull/$pr/commits/$PREP_HEAD_SHA"
 
   local ok=0
   local comment_body

--- a/test/scripts/pr-merge.test.ts
+++ b/test/scripts/pr-merge.test.ts
@@ -197,6 +197,15 @@ gh_route() {
       ;;
     "repo view") printf 'openclaw/openclaw\\n' ;;
     "api "*)
+      local api_arg
+      for api_arg in "$@"; do
+        case "$api_arg" in
+          repos/*/*/commits/*)
+            echo 'unexpected repository commit-resolution API probe' >&2
+            return 1
+            ;;
+        esac
+      done
       case "$*" in
         *"issues/123/comments"*)
           local arg
@@ -334,12 +343,14 @@ describePosix("scripts/pr merge-run", () => {
     expect(result.calls).toContain("path pr view 123 --json state,isDraft");
     expect(result.calls).not.toContain("--required --watch");
     expect(result.calls).not.toContain("--auto");
+    expect(result.calls).not.toMatch(/^(?:path|plain) api .*\/commits\//mu);
+    expect(result.calls).not.toContain("--json commits");
     expect(result.stdout).toContain("merge-run complete for PR #123");
     expect(result.stdout).toContain(
       "completion comment: https://github.com/openclaw/openclaw/pull/123#issuecomment-1",
     );
     expect(result.commentBody).toBe(
-      `Merged via squash.\n\n- Prepared head SHA: [${headSha}](https://github.com/openclaw/openclaw/commit/${headSha})\n- Landed commit: [${landedSha}](https://github.com/openclaw/openclaw/commit/${landedSha})`,
+      `Merged via squash.\n\n- Prepared head SHA: [${headSha}](https://github.com/openclaw/openclaw/pull/123/commits/${headSha})\n- Landed commit: [${landedSha}](https://github.com/openclaw/openclaw/commit/${landedSha})`,
     );
     expect(result.rgCalls).toBe("");
     expect(result.lifecycle).toBe(


### PR DESCRIPTION
Closes #121099

## What Problem This Solves

Fixes an issue where maintainers could merge a pull request successfully yet receive a false closeout error and retain the review worktree when REST fallback quota was unavailable.

## Why This Change Was Made

Closeout already has pinned-head verification, authoritative `MERGED` state, and the `mergeCommit` OID. It now constructs the landed link directly from that metadata and always uses the pull request-scoped prepared-head link, eliminating the redundant repository commit probes and PR commit-list fallback that were incompatible with the cached relay path.

## User Impact

Repo-native landing now reliably posts completion evidence and reaches cleanup without depending on a redundant REST lookup. There are no product or runtime behavior changes.

## Evidence

- Reproduced the exact route mismatch: `repos/openclaw/openclaw/commits/e40e352fe7fe0d1354bc62ad95a129d2bde6c59e` resolves, while the relay-only placeholder route `repos/:owner/:repo/commits/e40e352fe7fe0d1354bc62ad95a129d2bde6c59e` returns `route_denied` when fallback is unavailable.
- Live-checked pull request-scoped prepared-head URLs for same-repository PR #120945 and cross-repository merged PR #120988.
- Before commit, the exact intended diff passed 3 focused Vitest files with 38 tests, Bash syntax validation, and `git diff --check`.
- After the semantics-preserving rebase, exact head `c1f2b0c301aaf0b9587413fbc87ef59e36fd8d84` passed 3 focused Vitest files with 35 tests and `git diff --check`.
- Scoped changed-file validation passed on Blacksmith Testbox `tbx_01kzkj1jqggm29ptncj97tant9`; the command timing JSON reported `exitCode=0`. Actions: https://github.com/openclaw/openclaw/actions/runs/31321062337. A later portal-sync 401 occurred only after proof completion and runner shutdown.
- Codex autoreview completed with no accepted or actionable findings.
- Production LOC: +2/-22 (net -20). Tests: +12/-1 (net +11).

This change was AI-assisted. I reviewed the implementation and the proof above; no agent transcript is included.
