### PR TITLE
fix(system-agent): prevent roster rejection before inference

### DIFF
--- a/src/system-agent/agent-turn.test.ts
+++ b/src/system-agent/agent-turn.test.ts
@@ -333,6 +333,10 @@ describe("runSystemAgentTurn", () => {
       native: [],
       openClaw: ["openclaw"],
     });
+    expect(listAgentEntries(call.config ?? {}).filter((agent) => agent.id === "openclaw")).toEqual([
+      { id: "openclaw" },
+    ]);
+    expect(listAgentEntries(call.config ?? {}).find((agent) => agent.id === "ops")).toBeDefined();
     expect(call.toolsAllow).toBeUndefined();
     expect(requireValue(call.systemAgentTool, "missing CLI OpenClaw tool").proposalRef).toBe(
       session.proposalRef,

--- a/src/system-agent/inference-route.ts
+++ b/src/system-agent/inference-route.ts
@@ -87,25 +87,13 @@ function projectSystemAgentExecutionConfig(
   const retainedAgents = agents.filter(
     (agent) => normalizeAgentId(agent.id) !== SYSTEM_AGENT_EXECUTION_AGENT_ID,
   );
-  const hasProjectedSettings = routeAgent?.params !== undefined || routeAgent?.tools !== undefined;
-  if (retainedAgents.length === agents.length && !hasProjectedSettings) {
-    return config;
-  }
   const projectedAgents = [
     ...retainedAgents,
-    ...(hasProjectedSettings
-      ? [
-          {
-            id: SYSTEM_AGENT_EXECUTION_AGENT_ID,
-            ...(routeAgent?.params !== undefined
-              ? { params: structuredClone(routeAgent.params) }
-              : {}),
-            ...(routeAgent?.tools !== undefined
-              ? { tools: structuredClone(routeAgent.tools) }
-              : {}),
-          },
-        ]
-      : []),
+    {
+      id: SYSTEM_AGENT_EXECUTION_AGENT_ID,
+      ...(routeAgent?.params !== undefined ? { params: structuredClone(routeAgent.params) } : {}),
+      ...(routeAgent?.tools !== undefined ? { tools: structuredClone(routeAgent.tools) } : {}),
+    },
   ];
   const { list: _legacyList, ...agentsConfig } = config.agents ?? {};
   return {


### PR DESCRIPTION
Closes #121039

## What Problem This Solves

Fixes an issue where Crestodian/system-agent turns could fail before inference when the selected agent had no custom params or tools. The projected execution roster omitted the reserved `openclaw` identity even though the turn executes under that identity and strict workspace validation requires it to be present.

## Why This Change Was Made

The projection boundary now always replaces any authored reserved entry with exactly one ephemeral `openclaw` execution entry whenever an explicit roster exists. Selected-agent params and tools are copied only when defined; non-reserved agents remain intact, and strict workspace isolation is unchanged.

## User Impact

System-agent turns now reach their configured inference route for the default no-custom-settings roster shape instead of failing workspace preparation. Existing custom params/tools continue to be projected onto the reserved execution identity.

## Evidence

- Red phase: the existing no-params/no-tools CLI route test produced no reserved execution entry (`[]` instead of `[{ id: "openclaw" }]`).
- Green phase: `node scripts/run-vitest.mjs src/system-agent/agent-turn.test.ts src/agents/workspace-run.test.ts` — 27 tests passed across both shards.
- Exact-head runtime proof on `765449c2cf0ae348cdf6125421571c5b8c3ac499`: started the repository's QA HTTP inference provider, wrote an isolated config whose only persisted agent was `ops` (with no per-agent params or tools), completed bound setup verification, and ran `runSystemAgentTurn` through the real embedded runner.
  - verified execution owner/runner: `ops` / `embedded`
  - projected agent IDs: `ops`, `openclaw`; projected reserved entry: `{ "id": "openclaw" }`
  - tool-policy trace confirmed the runtime restricted the turn to the `openclaw` tool
  - reserved workspace admission succeeded (`$OPENCLAW_STATE_DIR/openclaw/workspace` was created)
  - provider reply: `SYSTEM-AGENT-INFERENCE-OK`
  - persisted agent IDs after the turn: `ops`; `reservedEntryPersisted: false`
- Existing system-agent coverage continues to prove params/tools copying; the new assertion also proves exactly one reserved entry and retention of the selected non-reserved agent.
- `pnpm exec oxfmt`, `pnpm exec oxlint`, and `git diff --check` passed.
- `node scripts/check-changed.mjs -- ...` could not run its delegated analysis because the selected Crabbox binary failed its own sanity check; direct focused suites and static checks were run instead.

## AI Assistance

This PR was implemented with AI assistance. The projection producer, execution identity, strict workspace consumer, sibling tests, and current issue/PR state were inspected; the regression was observed failing before the minimal projection change and passing afterward. The post-fix runtime proof used the repository's deterministic QA HTTP provider, not a hosted production credential; the workspace admission and embedded agent loop were real.
