### PR TITLE
fix(memory): apply temporal decay to dated files in memory subdirectories

### DIFF
--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -145,10 +145,9 @@ Two deterministic ranking passes are enabled by default for hybrid search.
 
 Old notes gradually lose ranking weight so recent information surfaces first.
 With the default 30-day half-life, a note from last month scores at 50% of its
-original weight. `MEMORY.md` and other non-dated files under `memory/` are
-evergreen and never decayed; any dated `YYYY-MM-DD.md` file under `memory/`
-decays by its embedded date, including dated files in subdirectories such as
-`memory/dreaming/light/`.
+original weight. `MEMORY.md`, `USER.md`, and undated files under `memory/`
+remain evergreen. Dated `YYYY-MM-DD.md` and `YYYY-MM-DD-<slug>.md` files decay
+at any depth, including session-memory notes and nested dreaming reports.
 
 ### MMR (diversity)
 

--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -146,7 +146,9 @@ Two deterministic ranking passes are enabled by default for hybrid search.
 Old notes gradually lose ranking weight so recent information surfaces first.
 With the default 30-day half-life, a note from last month scores at 50% of its
 original weight. `MEMORY.md` and other non-dated files under `memory/` are
-evergreen and never decayed; only dated `memory/YYYY-MM-DD.md` files decay.
+evergreen and never decayed; any dated `YYYY-MM-DD.md` file under `memory/`
+decays by its embedded date, including dated files in subdirectories such as
+`memory/dreaming/light/`.
 
 ### MMR (diversity)
 

--- a/extensions/memory-core/src/memory/temporal-decay.test.ts
+++ b/extensions/memory-core/src/memory/temporal-decay.test.ts
@@ -94,7 +94,7 @@ describe("temporal decay", () => {
     expect(merged[0]?.score ?? 0).toBeGreaterThan(merged[1]?.score ?? 0);
   });
 
-  it("decays dated files in memory subdirectories by their embedded date", async () => {
+  it("decays dated and slugged memory files at any depth by their embedded date", async () => {
     const merged = await mergeVectorResultsWithTemporalDecay([
       createVectorMemoryEntry({
         id: "nested-old",
@@ -109,6 +109,24 @@ describe("temporal decay", () => {
         vectorScore: 0.95,
       }),
       createVectorMemoryEntry({
+        id: "root-timestamp",
+        path: "memory/2025-01-01-1430.md",
+        snippet: "stale session memory",
+        vectorScore: 0.95,
+      }),
+      createVectorMemoryEntry({
+        id: "root-collision",
+        path: "memory/2025-01-01-1430-2.md",
+        snippet: "stale colliding session memory",
+        vectorScore: 0.95,
+      }),
+      createVectorMemoryEntry({
+        id: "nested-slug",
+        path: "memory/dreaming/light/2025-01-01-vendor-pitch.md",
+        snippet: "stale named dreaming report",
+        vectorScore: 0.95,
+      }),
+      createVectorMemoryEntry({
         id: "nested-undated",
         path: "memory/dreaming/light/report.md",
         snippet: "undated evergreen",
@@ -119,19 +137,28 @@ describe("temporal decay", () => {
     const byPath = new Map(merged.map((entry) => [entry.path, entry]));
     const nestedOld = byPath.get("memory/dreaming/light/2025-01-01.md");
     const rootOld = byPath.get("memory/2025-01-01.md");
-    // A date-only basename at any depth below memory/ decays exactly like a
-    // root daily note with the same date.
     expect(nestedOld?.score).toBeCloseTo(rootOld?.score ?? 0);
     expect(nestedOld?.score ?? 1).toBeLessThan(0.5);
+    expect(byPath.get("memory/2025-01-01-1430.md")?.score).toBeCloseTo(rootOld?.score ?? 0);
+    expect(byPath.get("memory/2025-01-01-1430-2.md")?.score).toBeCloseTo(rootOld?.score ?? 0);
+    expect(byPath.get("memory/dreaming/light/2025-01-01-vendor-pitch.md")?.score).toBeCloseTo(
+      rootOld?.score ?? 0,
+    );
     expect(byPath.get("memory/dreaming/light/report.md")?.score).toBeCloseTo(0.7);
   });
 
-  it("decays nested dated memory files with Windows-style separators", async () => {
+  it("decays nested dated and slugged memory files with Windows-style separators", async () => {
     const merged = await mergeVectorResultsWithTemporalDecay([
       createVectorMemoryEntry({
         id: "win-nested-old",
         path: "memory\\dreaming\\light\\2025-01-01.md",
         snippet: "stale dreaming report",
+        vectorScore: 0.95,
+      }),
+      createVectorMemoryEntry({
+        id: "win-nested-slug",
+        path: "memory\\dreaming\\light\\2025-01-01-1430.md",
+        snippet: "stale session memory",
         vectorScore: 0.95,
       }),
       createVectorMemoryEntry({
@@ -144,6 +171,7 @@ describe("temporal decay", () => {
 
     const byPath = new Map(merged.map((entry) => [entry.path, entry]));
     expect(byPath.get("memory\\dreaming\\light\\2025-01-01.md")?.score ?? 1).toBeLessThan(0.5);
+    expect(byPath.get("memory\\dreaming\\light\\2025-01-01-1430.md")?.score ?? 1).toBeLessThan(0.5);
     expect(byPath.get("memory\\dreaming\\light\\report.md")?.score).toBeCloseTo(0.7);
   });
 

--- a/extensions/memory-core/src/memory/temporal-decay.test.ts
+++ b/extensions/memory-core/src/memory/temporal-decay.test.ts
@@ -120,7 +120,7 @@ describe("temporal decay", () => {
     const nestedOld = byPath.get("memory/dreaming/light/2025-01-01.md");
     const rootOld = byPath.get("memory/2025-01-01.md");
     // A date-only basename at any depth below memory/ decays exactly like a
-    // root daily note with the same date (#121046).
+    // root daily note with the same date.
     expect(nestedOld?.score).toBeCloseTo(rootOld?.score ?? 0);
     expect(nestedOld?.score ?? 1).toBeLessThan(0.5);
     expect(byPath.get("memory/dreaming/light/report.md")?.score).toBeCloseTo(0.7);

--- a/extensions/memory-core/src/memory/temporal-decay.test.ts
+++ b/extensions/memory-core/src/memory/temporal-decay.test.ts
@@ -94,6 +94,59 @@ describe("temporal decay", () => {
     expect(merged[0]?.score ?? 0).toBeGreaterThan(merged[1]?.score ?? 0);
   });
 
+  it("decays dated files in memory subdirectories by their embedded date", async () => {
+    const merged = await mergeVectorResultsWithTemporalDecay([
+      createVectorMemoryEntry({
+        id: "nested-old",
+        path: "memory/dreaming/light/2025-01-01.md",
+        snippet: "stale dreaming report",
+        vectorScore: 0.95,
+      }),
+      createVectorMemoryEntry({
+        id: "root-old",
+        path: "memory/2025-01-01.md",
+        snippet: "stale daily note",
+        vectorScore: 0.95,
+      }),
+      createVectorMemoryEntry({
+        id: "nested-undated",
+        path: "memory/dreaming/light/report.md",
+        snippet: "undated evergreen",
+        vectorScore: 0.7,
+      }),
+    ]);
+
+    const byPath = new Map(merged.map((entry) => [entry.path, entry]));
+    const nestedOld = byPath.get("memory/dreaming/light/2025-01-01.md");
+    const rootOld = byPath.get("memory/2025-01-01.md");
+    // A date-only basename at any depth below memory/ decays exactly like a
+    // root daily note with the same date (#121046).
+    expect(nestedOld?.score).toBeCloseTo(rootOld?.score ?? 0);
+    expect(nestedOld?.score ?? 1).toBeLessThan(0.5);
+    expect(byPath.get("memory/dreaming/light/report.md")?.score).toBeCloseTo(0.7);
+  });
+
+  it("decays nested dated memory files with Windows-style separators", async () => {
+    const merged = await mergeVectorResultsWithTemporalDecay([
+      createVectorMemoryEntry({
+        id: "win-nested-old",
+        path: "memory\\dreaming\\light\\2025-01-01.md",
+        snippet: "stale dreaming report",
+        vectorScore: 0.95,
+      }),
+      createVectorMemoryEntry({
+        id: "win-nested-undated",
+        path: "memory\\dreaming\\light\\report.md",
+        snippet: "undated evergreen",
+        vectorScore: 0.7,
+      }),
+    ]);
+
+    const byPath = new Map(merged.map((entry) => [entry.path, entry]));
+    expect(byPath.get("memory\\dreaming\\light\\2025-01-01.md")?.score ?? 1).toBeLessThan(0.5);
+    expect(byPath.get("memory\\dreaming\\light\\report.md")?.score).toBeCloseTo(0.7);
+  });
+
   it("handles future dates, zero age, and very old memories", async () => {
     const merged = await mergeVectorResultsWithTemporalDecay([
       createVectorMemoryEntry({

--- a/extensions/memory-core/src/memory/temporal-decay.ts
+++ b/extensions/memory-core/src/memory/temporal-decay.ts
@@ -13,8 +13,7 @@ export const DEFAULT_TEMPORAL_DECAY_CONFIG: TemporalDecayConfig = {
 };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-// A date-only basename anywhere below memory/ counts as dated and must decay.
-const DATED_MEMORY_PATH_RE = /(?:^|\/)memory\/(?:[^/]+\/)*(\d{4})-(\d{2})-(\d{2})\.md$/;
+const DATED_MEMORY_PATH_RE = /(?:^|\/)memory\/(?:[^/]+\/)*(\d{4})-(\d{2})-(\d{2})(?:-[^/]+)?\.md$/;
 
 function toDecayLambda(halfLifeDays: number): number {
   if (!Number.isFinite(halfLifeDays) || halfLifeDays <= 0) {

--- a/extensions/memory-core/src/memory/temporal-decay.ts
+++ b/extensions/memory-core/src/memory/temporal-decay.ts
@@ -13,7 +13,11 @@ export const DEFAULT_TEMPORAL_DECAY_CONFIG: TemporalDecayConfig = {
 };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const DATED_MEMORY_PATH_RE = /(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})\.md$/;
+// Dated daily notes also live in subdirectories (e.g. dreaming phase reports at
+// memory/dreaming/light/2026-05-14.md); a date-only basename anywhere below
+// memory/ must decay, otherwise nested reports stay evergreen forever (#121046).
+// Matches the nested-path shape short-term promotion already recognizes.
+const DATED_MEMORY_PATH_RE = /(?:^|\/)memory\/(?:[^/]+\/)*(\d{4})-(\d{2})-(\d{2})\.md$/;
 
 function toDecayLambda(halfLifeDays: number): number {
   if (!Number.isFinite(halfLifeDays) || halfLifeDays <= 0) {

--- a/extensions/memory-core/src/memory/temporal-decay.ts
+++ b/extensions/memory-core/src/memory/temporal-decay.ts
@@ -13,10 +13,7 @@ export const DEFAULT_TEMPORAL_DECAY_CONFIG: TemporalDecayConfig = {
 };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-// Dated daily notes also live in subdirectories (e.g. dreaming phase reports at
-// memory/dreaming/light/2026-05-14.md); a date-only basename anywhere below
-// memory/ must decay, otherwise nested reports stay evergreen forever (#121046).
-// Matches the nested-path shape short-term promotion already recognizes.
+// A date-only basename anywhere below memory/ counts as dated and must decay.
 const DATED_MEMORY_PATH_RE = /(?:^|\/)memory\/(?:[^/]+\/)*(\d{4})-(\d{2})-(\d{2})\.md$/;
 
 function toDecayLambda(halfLifeDays: number): number {


### PR DESCRIPTION
## What Problem This Solves

Fixes #121046.

OpenClaw enables memory recency decay by default, but its dated-memory classifier recognized only root-level `memory/YYYY-MM-DD.md` files. Nested dreaming reports and the bundled session-memory hook's default `memory/YYYY-MM-DD-HHMM.md` snapshots were incorrectly treated as evergreen, allowing old context to outrank recent memories indefinitely.

The original contributor patch repaired nested date-only reports. Maintainer review found that the same invariant also covers timestamp, descriptive, and collision-suffixed session-memory files, which onboarding enables by default.

## Why This Change Was Made

`extensions/memory-core/src/memory/temporal-decay.ts` owns date classification before hybrid, keyword-only, and vector-only retrieval apply ranking. Its matcher now uses the exact dated-file shape already established by `SHORT_TERM_PATH_RE` in `extensions/memory-core/src/short-term-promotion-utils.ts`: a `YYYY-MM-DD` basename at any depth under `memory/`, with an optional nonempty suffix before `.md`.

Examples that now decay consistently by their embedded date:

- `memory/2025-01-01.md`
- `memory/2025-01-01-1430.md`
- `memory/2025-01-01-1430-2.md`
- `memory/dreaming/light/2025-01-01.md`
- `memory/dreaming/light/2025-01-01-vendor-pitch.md`
- Equivalent Windows-separated paths.

`MEMORY.md`, `USER.md`, undated root or nested memory files, non-memory modification-time handling, and existing future-date behavior remain unchanged. This is a search-ranking classifier repair only: there are no database, schema, indexing, retention, persistence, configuration, or migration changes. Production source delta is `+1/-1`.

## User Impact

Default memory search stops giving stale dreaming reports and session-reset snapshots permanent full ranking weight. Root daily notes, nested daily notes, timestamped reset snapshots, descriptive slugs, and same-minute collision suffixes now decay identically, while deliberately evergreen knowledge remains evergreen. Operators do not need to enable or configure anything.

## Evidence

New regression cases first failed against the unchanged contributor classifier:

```text
Test Files  1 failed (1)
Tests       2 failed | 4 passed (6)
default timestamped session memory: score 0.95, expected 0.00008200090846279555
nested Windows timestamped session memory: score 0.95, expected less than 0.5
```

After repairing the shared classifier, focused owner and sibling proof passed:

```text
node scripts/run-vitest.mjs extensions/memory-core/src/memory/temporal-decay.test.ts extensions/memory-core/src/memory/hybrid.test.ts
Test Files  2 passed (2)
Tests       32 passed (32)
```

Formatting and `git diff --check` passed. Fresh independent structured code review and a separate owner-boundary review reported no actionable findings.
