### PR TITLE
perf(gateway): per-transcript broadcast lanes

### DIFF
--- a/src/gateway/server-session-events.test.ts
+++ b/src/gateway/server-session-events.test.ts
@@ -14,6 +14,7 @@ const sessionRow = vi.hoisted(() => ({
   agentRuntime: { id: "openclaw", source: "model" },
 }));
 const isEmbeddedAgentRunInProgressMock = vi.hoisted(() => vi.fn());
+const loadGatewaySessionRowMock = vi.hoisted(() => vi.fn());
 const projectChatDisplayMessageMock = vi.hoisted(() => vi.fn((message: unknown) => message));
 const loadAccessorSessionEntryReadOnlyMock = vi.hoisted(() => vi.fn());
 const loadGatewaySessionEntryReadOnlyMock = vi.hoisted(() => vi.fn());
@@ -32,7 +33,7 @@ vi.mock("./chat-display-projection.js", () => ({
 }));
 vi.mock("./session-utils.js", () => ({
   attachOpenClawTranscriptMeta: (message: unknown) => message,
-  loadGatewaySessionRow: () => sessionRow,
+  loadGatewaySessionRow: loadGatewaySessionRowMock,
   loadSessionEntry: () => ({ entry: undefined, storePath: "" }),
   loadSessionEntryReadOnly: loadGatewaySessionEntryReadOnlyMock,
 }));
@@ -102,6 +103,7 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
     isEmbeddedAgentRunInProgressMock.mockReturnValue(false);
     loadAccessorSessionEntryReadOnlyMock.mockReturnValue(undefined);
     loadGatewaySessionEntryReadOnlyMock.mockReturnValue({ entry: undefined, storePath: "" });
+    loadGatewaySessionRowMock.mockReturnValue(sessionRow);
     readSessionMessageCountAsyncMock.mockResolvedValue(undefined);
     sessionRow.thinkingLevel = "ultra";
   });
@@ -550,9 +552,95 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
     });
     expect(broadcastToConnIds.mock.calls[0]?.[1]).toMatchObject({ messageSeq: 7 });
   });
+
+  it("does not stall one session's broadcasts behind another session's pending seq read", async () => {
+    let releaseSlowCount: (value: number | undefined) => void = () => undefined;
+    readSessionMessageCountAsyncMock.mockImplementation((params: { sessionKey?: string }) =>
+      params.sessionKey === "agent:main:slow"
+        ? new Promise<number | undefined>((resolve) => {
+            releaseSlowCount = resolve;
+          })
+        : Promise.resolve(3),
+    );
+    loadAccessorSessionEntryReadOnlyMock.mockReturnValue({ sessionId: "sess-main" });
+    const { broadcastToConnIds, handler } = createHandler(false);
+
+    // No messageSeq: the slow lane blocks on its async transcript count.
+    const slowTask = handler({
+      message: { role: "assistant", content: [{ type: "text", text: "slow" }] },
+      messageId: "slow-1",
+      target: {
+        agentId: "main",
+        sessionId: "sess-slow",
+        sessionKey: "agent:main:slow",
+        storePath: "/tmp/slow-sessions.json",
+      },
+    });
+
+    await handler({
+      sessionFile: "/tmp/sess-main.jsonl",
+      sessionKey: "agent:main:main",
+      message: { role: "assistant", content: [{ type: "text", text: "fast" }] },
+      messageId: "fast-1",
+      messageSeq: 1,
+    });
+
+    // The independent lane broadcast completed while the slow lane is parked.
+    expect(broadcastToConnIds).toHaveBeenCalledTimes(1);
+    expect(broadcastToConnIds.mock.calls[0]?.[1]).toMatchObject({ messageId: "fast-1" });
+
+    releaseSlowCount(5);
+    await slowTask;
+    expect(broadcastToConnIds).toHaveBeenCalledTimes(2);
+    expect(broadcastToConnIds.mock.calls[1]?.[1]).toMatchObject({ messageId: "slow-1" });
+  });
+
+  it("preserves message order within one session lane", async () => {
+    let releaseFirstCount: (value: number | undefined) => void = () => undefined;
+    readSessionMessageCountAsyncMock.mockImplementationOnce(
+      () =>
+        new Promise<number | undefined>((resolve) => {
+          releaseFirstCount = resolve;
+        }),
+    );
+    loadAccessorSessionEntryReadOnlyMock.mockReturnValue({ sessionId: "sess-main" });
+    const { broadcastToConnIds, handler } = createHandler(false);
+
+    const firstTask = handler({
+      message: { role: "assistant", content: [{ type: "text", text: "first" }] },
+      messageId: "ordered-1",
+      target: {
+        agentId: "main",
+        sessionId: "sess-main",
+        sessionKey: "agent:main:main",
+        storePath: "/tmp/explicit-sessions.json",
+      },
+    });
+    const secondTask = handler({
+      sessionFile: "/tmp/sess-main.jsonl",
+      sessionKey: "agent:main:main",
+      message: { role: "assistant", content: [{ type: "text", text: "second" }] },
+      messageId: "ordered-2",
+      messageSeq: 2,
+    });
+
+    await Promise.resolve();
+    expect(broadcastToConnIds).not.toHaveBeenCalled();
+
+    releaseFirstCount(1);
+    await Promise.all([firstTask, secondTask]);
+    expect(broadcastToConnIds.mock.calls.map((call) => call[1]?.messageId)).toEqual([
+      "ordered-1",
+      "ordered-2",
+    ]);
+  });
 });
 
 describe("createLifecycleEventBroadcastHandler", () => {
+  beforeEach(() => {
+    loadGatewaySessionRowMock.mockReturnValue(sessionRow);
+  });
+
   it("projects swarm phase and log payload fields", () => {
     const broadcastToConnIds = vi.fn();
     const handler = createLifecycleEventBroadcastHandler({

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -164,7 +164,10 @@ export function createTranscriptUpdateBroadcastHandler(params: {
   sessionMessageSubscribers: SessionMessageSubscribers;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
 }) {
-  let broadcastQueue = Promise.resolve();
+  // Ordering is a per-transcript contract: subscribers merge each session's
+  // updates independently, so lanes keyed by transcript identity keep message
+  // order without one session's async seq reads stalling every other session.
+  const broadcastQueues = new Map<string, Promise<void>>();
   return (update: InternalSessionTranscriptUpdate): Promise<void> => {
     // Capture legacy ownership before the async queue can cross a same-id reset;
     // committed producer ownership always wins over a later session-store read.
@@ -174,10 +177,26 @@ export function createTranscriptUpdateBroadcastHandler(params: {
         ? readTranscriptUpdateLifecycleOwner(update)?.lifecycleRevision
         : undefined);
     const queuedUpdate = lifecycleRevision ? { ...update, lifecycleRevision } : update;
-    // Preserve transcript update order even when counting messages requires an
-    // async read from the session file.
-    const task = broadcastQueue.then(() => handleTranscriptUpdateBroadcast(params, queuedUpdate));
-    broadcastQueue = task.catch(() => undefined);
+    const laneKey =
+      normalizeOptionalString(update.target?.sessionKey) ??
+      normalizeOptionalString(update.sessionKey) ??
+      normalizeOptionalString(update.sessionFile) ??
+      "";
+    // Preserve transcript update order within the lane even when counting
+    // messages requires an async read from the session file.
+    const tail = broadcastQueues.get(laneKey) ?? Promise.resolve();
+    const task = tail.then(() => handleTranscriptUpdateBroadcast(params, queuedUpdate));
+    const settled = task.then(
+      () => undefined,
+      () => undefined,
+    );
+    broadcastQueues.set(laneKey, settled);
+    void settled.then(() => {
+      // Drop drained lanes so idle sessions do not accumulate map entries.
+      if (broadcastQueues.get(laneKey) === settled) {
+        broadcastQueues.delete(laneKey);
+      }
+    });
     return task;
   };
 }
@@ -320,6 +339,8 @@ async function handleTranscriptUpdateBroadcast(
       return;
     }
   }
+  // Message frames must keep transcript-derived live usage (dashboard API
+  // contract from #50101); the 64KB cap bounds the per-message tail read.
   const sessionRow = loadGatewaySessionRow(sessionKey, {
     agentId: routingAgentId,
     transcriptUsageMaxBytes: 64 * 1024,

--- a/ui/src/pages/labs/labs-page.test.ts
+++ b/ui/src/pages/labs/labs-page.test.ts
@@ -201,7 +201,7 @@ describe("LabsPage", () => {
     },
     {
       label: "Cloud Worker Desktop",
-      index: 6,
+      index: 7,
       sourceConfig: { cloudWorkers: { desktop: false } },
       expectedPatch: { cloudWorkers: { desktop: true } },
       note: "labs: update workerDesktop",


### PR DESCRIPTION
## What Problem This Solves

`createTranscriptUpdateBroadcastHandler` serialized every transcript-update broadcast behind one process-wide promise queue. Ordering only matters within a transcript, but the single queue made it global: one session's pending async seq read (`readSessionMessageCountAsync`, taken whenever an update arrives without a committed `messageSeq`) head-of-line blocked `session.message` and `sessions.changed` delivery for every other session. Each queued update also does a full gateway session-row build, so a busy session's per-message broadcasts stalled unrelated sessions on multi-agent installs and subagent swarms.

## Why This Change Was Made

Ordering is a per-transcript contract — subscribers merge each session's updates independently and no consumer depends on cross-session broadcast order. The queue is now a `Map` of lanes keyed by the update's transcript identity (`target.sessionKey` → `sessionKey` → `sessionFile`), so independent sessions proceed concurrently while order within one transcript is preserved. Drained lanes are deleted so idle sessions do not accumulate map entries.

Scope note: an earlier revision of this PR also skipped the per-message transcript-usage re-derivation. CI caught that as a regression — `session.message` payloads carry live `totalTokens` / `estimatedCostUsd` derived from the transcript as a dashboard API contract (#50101), proven by `src/gateway/session-message-events.test.ts`. That part is reverted; per-message usage stays derived under its existing bounded 64KB cap. Reducing that remaining per-message read needs a different fix (recording usage at its producer rather than re-deriving it downstream) and is left as a follow-up.

## User Impact

A busy session can no longer stall transcript and message updates for other connected sessions. No payload or ordering contract changes.

## Evidence

- New boundary tests: one session's broadcast completes while another session's lane is parked on a pending seq read; message order within one lane is preserved when the first update blocks.
- `node scripts/run-vitest.mjs run src/gateway/server-session-events.test.ts src/gateway/session-message-events.test.ts` — 52 passed (includes the usage-metadata contract test that caught the reverted change).
- `node scripts/run-vitest.mjs run src/gateway/server-runtime-subscriptions.test.ts` — 10 passed; earlier full run with `session-utils.test.ts` — 169 passed.
- tsgo core test lane clean; oxfmt/oxlint clean.
- Codex autoreview (gpt-5.6-sol, xhigh) clean on the change bundle.

Production LOC delta: +21 (lane map). Tests +88. Growth justification: the per-transcript ordering fact is now recorded at the boundary that enforces it.

Found by a full syncing-logic audit; separate follow-ups tracked for cloud-worker workspace-sync repeated full-tree hashing and its 25ms directory-walk poll, auth-profile throwaway SQLite handles, per-turn sandbox skill wipe/recopy, and `sessions.patch` key scoping.

## Unrelated main breakage fixed here

`main` is red on `checks-node-compact-large-6` independently of this PR (its own run on `5b6c19d9` fails the same job). Cause: `ui/src/pages/labs/labs-page.test.ts` gives the "Cloud Worker Desktop" case `index: 6`, which is the "Message audit metadata" row — the row added in #120727 reused the previous index instead of taking the next one. Labs rows render in `LAB_FEATURES` registry order and `workerDesktop` is the eighth entry, so the case toggled the audit row and asserted the audit patch. Reproduced locally on an unmodified UI tree before the fix and green after (`node scripts/run-vitest.mjs run ui/src/pages/labs/labs-page.test.ts` — 44 passed). Per repo policy the merge gate is not bypassed; the smallest correct fix rides in this landing PR as a separate commit.
