### PR TITLE
fix(acpx): strip amazon-bedrock provider prefix from Claude ACP model refs

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -691,6 +691,30 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       model: "custom-model",
       expectedModel: "custom-model",
     },
+    {
+      // Issue #121034: Bedrock rejects provider-qualified refs.
+      name: "strips the OpenClaw Bedrock provider prefix for Claude ACP startup",
+      model: "amazon-bedrock/global.anthropic.claude-sonnet-5",
+      expectedModel: "global.anthropic.claude-sonnet-5",
+    },
+    {
+      name: "matches the Bedrock provider prefix case-insensitively",
+      model: "Amazon-Bedrock/us.anthropic.claude-opus-4-6-v1",
+      expectedModel: "us.anthropic.claude-opus-4-6-v1",
+    },
+    {
+      // Bare inference-profile ids and ARNs are native Bedrock values the SDK
+      // accepts as-is; only the documented OpenClaw prefixes may be stripped.
+      name: "preserves native Bedrock inference-profile ids",
+      model: "global.anthropic.claude-sonnet-5",
+      expectedModel: "global.anthropic.claude-sonnet-5",
+    },
+    {
+      name: "preserves Bedrock inference-profile ARNs",
+      model: "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-5",
+      expectedModel:
+        "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-5",
+    },
   ])("$name", async ({ model, expectedModel }) => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => undefined),
@@ -1912,13 +1936,23 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       key: "model",
       value: "anthropic/claude-sonnet-4-6",
     });
+    await runtime.setConfigOption({
+      handle,
+      key: "model",
+      value: "amazon-bedrock/global.anthropic.claude-sonnet-5",
+    });
 
-    expect(setConfigOption).toHaveBeenCalledOnce();
-    expect(setConfigOption).toHaveBeenCalledWith({
+    expect(setConfigOption).toHaveBeenNthCalledWith(1, {
       handle,
       key: "model",
       value: "claude-sonnet-4-6",
     });
+    expect(setConfigOption).toHaveBeenNthCalledWith(2, {
+      handle,
+      key: "model",
+      value: "global.anthropic.claude-sonnet-5",
+    });
+    expect(setConfigOption).toHaveBeenCalledTimes(2);
   });
 
   it("recognizes claude-agent-acp commands", () => {

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -711,7 +711,8 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     },
     {
       name: "preserves Bedrock inference-profile ARNs",
-      model: "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-5",
+      model:
+        "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-5",
       expectedModel:
         "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-5",
     },

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -380,7 +380,10 @@ const OPENCLAW_BRIDGE_EXECUTABLE = "openclaw";
 const OPENCLAW_BRIDGE_SUBCOMMAND = "acp";
 const CODEX_ACP_AGENT_ID = "codex";
 const CODEX_ACP_OPENCLAW_PREFIX = "openai/";
-const CLAUDE_ACP_OPENCLAW_PREFIX = "anthropic/";
+// Documented OpenClaw provider prefixes the Claude Agent SDK does not understand.
+// Strip only these; a generic first-slash split would corrupt native Bedrock
+// inference-profile ids and ARNs the SDK accepts as-is.
+const CLAUDE_ACP_OPENCLAW_PREFIX = /^(?:anthropic|amazon-bedrock)\//i;
 const CODEX_ACP_THINKING_ALIASES = new Map<string, string | undefined>([
   ["off", undefined],
   ["minimal", "low"],
@@ -648,10 +651,11 @@ function normalizeClaudeAcpModelOverride(rawModel: string | undefined): string |
   if (!raw) {
     return undefined;
   }
-  if (!raw.toLowerCase().startsWith(CLAUDE_ACP_OPENCLAW_PREFIX)) {
+  const prefix = raw.match(CLAUDE_ACP_OPENCLAW_PREFIX);
+  if (!prefix) {
     return raw;
   }
-  return raw.slice(CLAUDE_ACP_OPENCLAW_PREFIX.length).trim() || undefined;
+  return raw.slice(prefix[0].length).trim() || undefined;
 }
 
 function withAcpxSessionOptions(input: OpenClawRuntimeEnsureInput): AcpxDelegateEnsureInput {


### PR DESCRIPTION
## What Problem This Solves

Fixes #121034.

OpenClaw stores a Bedrock model as `amazon-bedrock/<model-id>`. The Claude ACP adapter forwarded that full value to the Claude Agent SDK. Bedrock expects the bare model or inference-profile ID, so the ACP session failed with an invalid model identifier.

## Root Cause

The adapter removed the `anthropic/` qualifier but did not remove `amazon-bedrock/`. Startup and model-control both use this adapter-owned normalizer.

## Fix

The Claude ACP adapter now removes either documented OpenClaw qualifier with one anchored, case-insensitive match:

- `anthropic/`
- `amazon-bedrock/`

Bare Bedrock IDs and inference-profile ARNs stay unchanged. Core model selection stays canonical.

## Evidence

The same real ACP child-wire contract ran against current main at the red run, `b6aff3ef0e16a47f10b82bf6223598326d632705`, and the rebased exact head `c4e4ddc5f8009082766b879bcc5865961cc77165`.

| ACP boundary | Current main | This head |
| --- | --- | --- |
| `session/new` model | `amazon-bedrock/global.anthropic.claude-sonnet-5` | `global.anthropic.claude-sonnet-5` |
| `session/set_config_option` model | `amazon-bedrock/us.anthropic.claude-opus-4-6-v1` | `us.anthropic.claude-opus-4-6-v1` |

The capture used the production `AcpxRuntime`, the real pinned `acpx` delegate, and a spawned ACP child that recorded the raw requests. Distinct child process IDs and revision-bound session keys proved that each run reached a new child process.

## Validation

- Pre-fix regression: 3 intended Bedrock assertions failed; 99 existing tests passed.
- Focused runtime: 102/102 tests passed.
- Rebased ACPX extension: 259/259 tests passed across 22 files.
- Extension production and test type-check lanes passed.
- Focused format and lint checks passed.
- `git diff --check` passed.
- Production: +7/-3 lines, net +4.
- Tests: +37/-2 lines, net +35.

## Contract Checks

- Head-pinned `acpx` 0.13.1 copies `sessionOptions.model` unchanged into `_meta.claudeCode.options.model`.
- Head-pinned Claude ACP 0.70.0 copies that model unchanged into Claude Agent SDK options and forwards model-control values to `query.setModel`.
- Codex keeps model and provider as separate protocol fields at `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:62` and forwards model updates as model strings at `codex-rs/app-server/src/request_processors/turn_processor.rs:219`.

## AI Assistance

AI assisted with repository inspection and validation. The contributor patch was retained unchanged after source, history, dependency, sibling-runtime, test, and live-wire review.
