### PR TITLE
fix(acpx): start Claude sessions with Bedrock model IDs

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -617,7 +617,10 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     });
   });
 
-  it("strips the OpenClaw Anthropic provider prefix for Claude ACP startup", async () => {
+  it.each([
+    ["anthropic/claude-sonnet-4-6", "claude-sonnet-4-6"],
+    ["amazon-bedrock/us.anthropic.claude-sonnet-4-6-v1:0", "us.anthropic.claude-sonnet-4-6-v1:0"],
+  ])("strips the OpenClaw provider prefix for Claude ACP startup", async (model, expected) => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => undefined),
       save: vi.fn(async () => {}),
@@ -639,15 +642,15 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       sessionKey: "agent:claude:acp:test",
       agent: "claude",
       mode: "persistent",
-      model: "anthropic/claude-sonnet-4-6",
+      model,
     });
 
     expect(readFirstEnsureSessionInput(ensure)).toEqual({
       sessionKey: "agent:claude:acp:test",
       agent: "claude",
       mode: "persistent",
-      model: "claude-sonnet-4-6",
-      sessionOptions: { model: "claude-sonnet-4-6" },
+      model: expected,
+      sessionOptions: { model: expected },
     });
   });
 
@@ -665,6 +668,12 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       "claude-sonnet-4-6-1m",
     );
     expect(testing.normalizeClaudeAcpModelOverride("custom-model")).toBe("custom-model");
+    expect(
+      testing.normalizeClaudeAcpModelOverride("Amazon-Bedrock/us.anthropic.claude-sonnet-4-6-v1:0"),
+    ).toBe("us.anthropic.claude-sonnet-4-6-v1:0");
+    const inferenceProfileArn =
+      "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-4-6-v1:0";
+    expect(testing.normalizeClaudeAcpModelOverride(inferenceProfileArn)).toBe(inferenceProfileArn);
   });
 
   it("leaves Codex ACP startup defaults alone when no model or thinking is provided", async () => {
@@ -1821,7 +1830,10 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(setConfigOption).not.toHaveBeenCalled();
   });
 
-  it("normalizes model config controls for claude-agent-acp", async () => {
+  it.each([
+    ["anthropic/claude-sonnet-4-6", "claude-sonnet-4-6"],
+    ["amazon-bedrock/us.anthropic.claude-sonnet-4-6-v1:0", "us.anthropic.claude-sonnet-4-6-v1:0"],
+  ])("normalizes model config controls for claude-agent-acp", async (value, expected) => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({
         acpxRecordId: "agent:claude:acp:test",
@@ -1841,14 +1853,14 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     await runtime.setConfigOption({
       handle,
       key: "model",
-      value: "anthropic/claude-sonnet-4-6",
+      value,
     });
 
     expect(setConfigOption).toHaveBeenCalledOnce();
     expect(setConfigOption).toHaveBeenCalledWith({
       handle,
       key: "model",
-      value: "claude-sonnet-4-6",
+      value: expected,
     });
   });
 

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -380,7 +380,7 @@ const OPENCLAW_BRIDGE_EXECUTABLE = "openclaw";
 const OPENCLAW_BRIDGE_SUBCOMMAND = "acp";
 const CODEX_ACP_AGENT_ID = "codex";
 const CODEX_ACP_OPENCLAW_PREFIX = "openai/";
-const CLAUDE_ACP_OPENCLAW_PREFIX = "anthropic/";
+const CLAUDE_ACP_OPENCLAW_PREFIXES = ["anthropic/", "amazon-bedrock/"] as const;
 const CODEX_ACP_THINKING_ALIASES = new Map<string, string | undefined>([
   ["off", undefined],
   ["minimal", "low"],
@@ -648,10 +648,13 @@ function normalizeClaudeAcpModelOverride(rawModel: string | undefined): string |
   if (!raw) {
     return undefined;
   }
-  if (!raw.toLowerCase().startsWith(CLAUDE_ACP_OPENCLAW_PREFIX)) {
+  const prefix = CLAUDE_ACP_OPENCLAW_PREFIXES.find((candidate) =>
+    raw.toLowerCase().startsWith(candidate),
+  );
+  if (!prefix) {
     return raw;
   }
-  return raw.slice(CLAUDE_ACP_OPENCLAW_PREFIX.length).trim() || undefined;
+  return raw.slice(prefix.length).trim() || undefined;
 }
 
 function withAcpxSessionOptions(input: OpenClawRuntimeEnsureInput): AcpxDelegateEnsureInput {


### PR DESCRIPTION
Closes #121034

## What Problem This Solves

Fixes an issue where users selecting a Claude model through Amazon Bedrock could not start or switch a Claude ACP session. OpenClaw’s canonical `amazon-bedrock/<model>` reference was forwarded to the native Claude/Bedrock client instead of the bare Bedrock model ID it expects.

## Why This Change Was Made

The Claude ACP adapter now removes only the two known OpenClaw provider qualifiers, `anthropic/` and `amazon-bedrock/`, using the existing case-insensitive prefix behavior. Bare model IDs and full Bedrock inference-profile ARNs remain byte-for-byte unchanged; the core model-selection path and generic ACPX behavior are untouched.

## User Impact

Claude ACP sessions configured through Amazon Bedrock receive the native model ID at startup and through model controls, while existing Anthropic, bare-ID, and ARN configurations keep their current behavior.

## Evidence

- Red phase: Bedrock startup, direct normalization, and model-control assertions all failed with the `amazon-bedrock/` prefix still present.
- Rebased focused proof: `node scripts/run-vitest.mjs extensions/acpx/src/runtime.test.ts` — 111 tests passed.
- Extension proof: `pnpm test:extension acpx` — 19 files / 260 tests passed after rebasing.
- Cross-boundary proof before rebase: `src/agents/acp-spawn.test.ts` — 75 tests passed; the rebased core rerun was blocked only after generated build artifacts were intentionally cleaned for disk space, while the changed adapter suite remained green.
- Repository build compiled plugin assets plus all AI/package/unified TypeScript bundles, passed CLI bootstrap and plugin SDK export checks, and the separately rerun Control UI build plus precompressed/performance checks passed after sparse checkout paths were restored.
- `pnpm exec oxfmt`, `pnpm exec oxlint`, and `git diff --check` passed.

No AWS/Bedrock credentials are available in this environment, so a real one-shot with `CLAUDE_CODE_USE_BEDROCK=1` was not fabricated; CI/maintainer Testbox validation is still requested for that external provider proof.

## AI Assistance

This PR was implemented with AI assistance. The OpenClaw adapter, core spawn caller, pinned `acpx` and Claude ACP pass-through contracts, canonical Bedrock documentation, issue/PR state, and regression history were inspected before the focused change. Tests were observed failing before implementation and passing afterward.
