### PR TITLE
fix(process): enumerate and terminate descendant PIDs for attached Unix processes (#121049)

### DIFF
--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -223,8 +223,10 @@ function getUnixProcessTreePids(rootPid: number): ProcessSnapshot[] {
       const res = spawnSync("ps", ["-ax", "-o", "pid=,ppid="], { encoding: "utf8", timeout: 1000 });
       if (res.stdout) {
         for (const line of res.stdout.split("\n")) {
-          const [pid, ppid] = line.trim().split(/\s+/).map(Number);
-          if (ppid > 0 && pid > 1) {
+          const [rawPid, rawPpid] = line.trim().split(/\s+/);
+          const pid = Number(rawPid);
+          const ppid = Number(rawPpid);
+          if (Number.isSafeInteger(ppid) && ppid > 0 && Number.isSafeInteger(pid) && pid > 1) {
             const list = childrenMap.get(ppid) ?? [];
             list.push(pid);
             childrenMap.set(ppid, list);

--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -6,7 +6,7 @@ const DEFAULT_GRACE_MS = 3000;
 const MAX_GRACE_MS = 60_000;
 const TASKKILL_COMPLETION_TIMEOUT_MS = 3000;
 
-type ProcessSnapshot = { pid: number; startTime: string | undefined };
+export type ProcessSnapshot = { pid: number; startTime: string | undefined };
 
 export type KillProcessTreeOptions = {
   graceMs?: number;
@@ -77,22 +77,23 @@ export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): voi
 export function signalProcessTree(
   pid: number,
   signal: "SIGTERM" | "SIGKILL",
-  opts?: { detached?: boolean; onComplete?: () => void },
-): void {
+  opts?: { detached?: boolean; onComplete?: () => void; pidsToSignal?: ProcessSnapshot[] },
+): ProcessSnapshot[] | undefined {
   if (!Number.isFinite(pid) || pid <= 0) {
     opts?.onComplete?.();
-    return;
+    return undefined;
   }
 
   if (process.platform === "win32") {
     void signalProcessTreeWindowsAndWait(pid, signal).then(opts?.onComplete);
-    return;
+    return undefined;
   }
 
   const useGroupKill =
     opts?.detached === true || (opts?.detached !== false && isProcessGroupLeader(pid));
-  signalProcessTreeUnix(pid, signal, useGroupKill);
+  const snapshot = signalProcessTreeUnix(pid, signal, useGroupKill, opts?.pidsToSignal);
   opts?.onComplete?.();
+  return snapshot;
 }
 
 function normalizeGraceMs(value?: number): number {

--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -175,7 +175,10 @@ function getProcessStartTime(pid: number): string | undefined {
     if (!res.error && res.status === 0 && res.stdout) {
       const lines = res.stdout.trim().split("\n");
       if (lines.length > 1) {
-        return lines[1].trim();
+        const lstart = lines[1];
+        if (lstart !== undefined) {
+          return lstart.trim();
+        }
       }
     }
   } catch {}

--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -1,6 +1,6 @@
 // Agent Core module implements kill tree behavior.
 import { spawn, spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 
 const DEFAULT_GRACE_MS = 3000;
 const MAX_GRACE_MS = 60_000;
@@ -53,9 +53,10 @@ export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): voi
   const graceMs = normalizeGraceMs(opts?.graceMs);
   signalProcessTreeUnix(pid, "SIGTERM", useGroupKill);
   setTimeout(() => {
+    const pids = useGroupKill ? [pid] : getUnixProcessTreePids(pid);
     const stillAlive = useGroupKill
       ? isProcessAlive(-pid) || isProcessAlive(pid)
-      : isProcessAlive(pid);
+      : pids.some((p) => isProcessAlive(p));
     if (!stillAlive) {
       return;
     }
@@ -149,6 +150,100 @@ function isProcessGroupLeader(pid: number): boolean {
   return pgid === pid;
 }
 
+function getUnixProcessTreePids(rootPid: number): number[] {
+  if (!Number.isFinite(rootPid) || rootPid <= 1) {
+    return [];
+  }
+
+  const childrenMap = new Map<number, number[]>();
+
+  if (process.platform === "linux") {
+    try {
+      const entries = readdirSync("/proc");
+      for (const entry of entries) {
+        if (!/^\d+$/.test(entry)) {
+          continue;
+        }
+        try {
+          const stat = readFileSync(`/proc/${entry}/stat`, "utf8");
+          const commEnd = stat.lastIndexOf(")");
+          if (commEnd < 0) {
+            continue;
+          }
+          const fields = stat
+            .slice(commEnd + 1)
+            .trim()
+            .split(/\s+/);
+          const ppid = Number(fields[1]);
+          const pid = Number(entry);
+          if (Number.isInteger(ppid) && Number.isInteger(pid) && ppid > 0 && pid > 1) {
+            let list = childrenMap.get(ppid);
+            if (!list) {
+              list = [];
+              childrenMap.set(ppid, list);
+            }
+            list.push(pid);
+          }
+        } catch {
+          // Ignore process that disappeared mid-scan
+        }
+      }
+    } catch {
+      // Procfs unavailable or failed
+    }
+  }
+
+  if (childrenMap.size === 0) {
+    try {
+      const res = spawnSync("ps", ["-ax", "-o", "pid=,ppid="], {
+        encoding: "utf8",
+        timeout: 1000,
+      });
+      if (!res.error && res.status === 0 && res.stdout) {
+        const lines = res.stdout.split("\n");
+        for (const line of lines) {
+          const parts = line.trim().split(/\s+/);
+          if (parts.length >= 2) {
+            const pid = Number(parts[0]);
+            const ppid = Number(parts[1]);
+            if (Number.isInteger(ppid) && Number.isInteger(pid) && ppid > 0 && pid > 1) {
+              let list = childrenMap.get(ppid);
+              if (!list) {
+                list = [];
+                childrenMap.set(ppid, list);
+              }
+              list.push(pid);
+            }
+          }
+        }
+      }
+    } catch {
+      // Ignore ps failure
+    }
+  }
+
+  const result: number[] = [];
+  const visited = new Set<number>();
+
+  function traverse(currentPid: number) {
+    if (visited.has(currentPid)) {
+      return;
+    }
+    visited.add(currentPid);
+
+    const children = childrenMap.get(currentPid) ?? [];
+    for (const childPid of children) {
+      if (childPid > 1 && childPid !== currentPid) {
+        traverse(childPid);
+      }
+    }
+    result.push(currentPid);
+  }
+
+  traverse(rootPid);
+  return result;
+}
+
 function signalProcessTreeUnix(
   pid: number,
   signal: "SIGTERM" | "SIGKILL",
@@ -159,14 +254,17 @@ function signalProcessTreeUnix(
       process.kill(-pid, signal);
       return;
     } catch {
-      // Process group does not exist or we lack permission; try direct pid.
+      // Process group does not exist or we lack permission; try direct pid tree.
     }
   }
 
-  try {
-    process.kill(pid, signal);
-  } catch {
-    // Already gone.
+  const pidsToSignal = getUnixProcessTreePids(pid);
+  for (const p of pidsToSignal) {
+    try {
+      process.kill(p, signal);
+    } catch {
+      // Already gone.
+    }
   }
 }
 

--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -7,7 +7,8 @@ const MAX_GRACE_MS = 60_000;
 const TASKKILL_COMPLETION_TIMEOUT_MS = 3000;
 
 type ProcessSnapshot = { pid: number; startTime: string | undefined };
-const treeSnapshotCache = new Map<number, ProcessSnapshot[]>();
+type TreeSnapshot = { rootStartTime: string | undefined; pids: ProcessSnapshot[] };
+const treeSnapshotCache = new Map<number, TreeSnapshot>();
 
 export type KillProcessTreeOptions = {
   graceMs?: number;
@@ -56,12 +57,25 @@ export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): voi
   const graceMs = normalizeGraceMs(opts?.graceMs);
   signalProcessTreeUnix(pid, "SIGTERM", useGroupKill);
   setTimeout(() => {
-    const pids = useGroupKill
-      ? [{ pid, startTime: getProcessStartTime(pid) }]
-      : (treeSnapshotCache.get(pid) ?? getUnixProcessTreePids(pid));
+    let pids: ProcessSnapshot[];
+    if (useGroupKill) {
+      pids = [{ pid, startTime: getProcessStartTime(pid) }];
+    } else {
+      const cached = treeSnapshotCache.get(pid);
+      if (cached && getProcessStartTime(pid) === cached.rootStartTime) {
+        pids = cached.pids;
+      } else {
+        pids = getUnixProcessTreePids(pid);
+      }
+    }
     const stillAlive = useGroupKill
       ? isProcessAlive(-pid) || isProcessAlive(pid)
-      : pids.some((p) => isProcessAlive(p.pid) && getProcessStartTime(p.pid) === p.startTime);
+      : pids.some(
+          (p) =>
+            isProcessAlive(p.pid) &&
+            p.startTime !== undefined &&
+            getProcessStartTime(p.pid) === p.startTime,
+        );
     if (!stillAlive) {
       treeSnapshotCache.delete(pid);
       return;
@@ -174,9 +188,9 @@ function getProcessStartTime(pid: number): string | undefined {
     const res = spawnSync("ps", ["-p", String(pid), "-o", "lstart="], { encoding: "utf8" });
     if (!res.error && res.status === 0 && res.stdout) {
       const lines = res.stdout.trim().split("\n");
-      if (lines.length > 1) {
-        const lstart = lines[1];
-        if (lstart !== undefined) {
+      if (lines.length > 0) {
+        const lstart = lines[0];
+        if (lstart !== undefined && lstart.length > 0) {
           return lstart.trim();
         }
       }
@@ -294,16 +308,26 @@ function signalProcessTreeUnix(
   }
 
   let pidsToSignal: ProcessSnapshot[];
+  const rootStartTime = getProcessStartTime(pid);
 
   if (signal === "SIGTERM") {
-    pidsToSignal = treeSnapshotCache.get(pid) ?? getUnixProcessTreePids(pid);
-    treeSnapshotCache.set(pid, pidsToSignal);
-
-    setTimeout(() => {
-      treeSnapshotCache.delete(pid);
-    }, MAX_GRACE_MS + 5000).unref();
+    const cached = treeSnapshotCache.get(pid);
+    if (cached && cached.rootStartTime === rootStartTime) {
+      pidsToSignal = cached.pids;
+    } else {
+      pidsToSignal = getUnixProcessTreePids(pid);
+      treeSnapshotCache.set(pid, { rootStartTime, pids: pidsToSignal });
+      setTimeout(() => {
+        treeSnapshotCache.delete(pid);
+      }, MAX_GRACE_MS + 5000).unref();
+    }
   } else if (signal === "SIGKILL") {
-    pidsToSignal = treeSnapshotCache.get(pid) ?? getUnixProcessTreePids(pid);
+    const cached = treeSnapshotCache.get(pid);
+    if (cached && cached.rootStartTime === rootStartTime) {
+      pidsToSignal = cached.pids;
+    } else {
+      pidsToSignal = getUnixProcessTreePids(pid);
+    }
     treeSnapshotCache.delete(pid);
   } else {
     pidsToSignal = getUnixProcessTreePids(pid);

--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -6,6 +6,8 @@ const DEFAULT_GRACE_MS = 3000;
 const MAX_GRACE_MS = 60_000;
 const TASKKILL_COMPLETION_TIMEOUT_MS = 3000;
 
+const treeSnapshotCache = new Map<number, number[]>();
+
 export type KillProcessTreeOptions = {
   graceMs?: number;
   detached?: boolean;
@@ -53,11 +55,12 @@ export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): voi
   const graceMs = normalizeGraceMs(opts?.graceMs);
   signalProcessTreeUnix(pid, "SIGTERM", useGroupKill);
   setTimeout(() => {
-    const pids = useGroupKill ? [pid] : getUnixProcessTreePids(pid);
+    const pids = useGroupKill ? [pid] : (treeSnapshotCache.get(pid) ?? getUnixProcessTreePids(pid));
     const stillAlive = useGroupKill
       ? isProcessAlive(-pid) || isProcessAlive(pid)
       : pids.some((p) => isProcessAlive(p));
     if (!stillAlive) {
+      treeSnapshotCache.delete(pid);
       return;
     }
     signalProcessTreeUnix(pid, "SIGKILL", useGroupKill);
@@ -258,7 +261,22 @@ function signalProcessTreeUnix(
     }
   }
 
-  const pidsToSignal = getUnixProcessTreePids(pid);
+  let pidsToSignal: number[];
+  
+  if (signal === "SIGTERM") {
+    pidsToSignal = treeSnapshotCache.get(pid) ?? getUnixProcessTreePids(pid);
+    treeSnapshotCache.set(pid, pidsToSignal);
+    
+    setTimeout(() => {
+      treeSnapshotCache.delete(pid);
+    }, MAX_GRACE_MS + 5000).unref();
+  } else if (signal === "SIGKILL") {
+    pidsToSignal = treeSnapshotCache.get(pid) ?? getUnixProcessTreePids(pid);
+    treeSnapshotCache.delete(pid);
+  } else {
+    pidsToSignal = getUnixProcessTreePids(pid);
+  }
+
   for (const p of pidsToSignal) {
     try {
       process.kill(p, signal);

--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -62,11 +62,7 @@ export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): voi
       pids = [{ pid, startTime: getProcessStartTime(pid) }];
     } else {
       const cached = treeSnapshotCache.get(pid);
-      if (
-        !cached ||
-        cached.rootStartTime === undefined ||
-        getProcessStartTime(pid) !== cached.rootStartTime
-      ) {
+      if (!cached) {
         treeSnapshotCache.delete(pid);
         return;
       }
@@ -327,7 +323,7 @@ function signalProcessTreeUnix(
     }
   } else if (signal === "SIGKILL") {
     const cached = treeSnapshotCache.get(pid);
-    if (cached && cached.rootStartTime === rootStartTime) {
+    if (cached) {
       pidsToSignal = cached.pids;
     } else {
       pidsToSignal = getUnixProcessTreePids(pid);

--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -7,8 +7,6 @@ const MAX_GRACE_MS = 60_000;
 const TASKKILL_COMPLETION_TIMEOUT_MS = 3000;
 
 type ProcessSnapshot = { pid: number; startTime: string | undefined };
-type TreeSnapshot = { rootStartTime: string | undefined; pids: ProcessSnapshot[] };
-const treeSnapshotCache = new Map<number, TreeSnapshot>();
 
 export type KillProcessTreeOptions = {
   graceMs?: number;
@@ -55,32 +53,24 @@ export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): voi
   }
 
   const graceMs = normalizeGraceMs(opts?.graceMs);
-  signalProcessTreeUnix(pid, "SIGTERM", useGroupKill);
+  const pids = signalProcessTreeUnix(pid, "SIGTERM", useGroupKill);
   setTimeout(() => {
-    let pids: ProcessSnapshot[];
+    let checkPids = pids;
     if (useGroupKill) {
-      pids = [{ pid, startTime: getProcessStartTime(pid) }];
-    } else {
-      const cached = treeSnapshotCache.get(pid);
-      if (!cached) {
-        treeSnapshotCache.delete(pid);
-        return;
-      }
-      pids = cached.pids;
+      checkPids = [{ pid, startTime: getProcessStartTime(pid) }];
     }
     const stillAlive = useGroupKill
       ? isProcessAlive(-pid) || isProcessAlive(pid)
-      : pids.some(
+      : checkPids.some(
           (p) =>
             isProcessAlive(p.pid) &&
             p.startTime !== undefined &&
             getProcessStartTime(p.pid) === p.startTime,
         );
     if (!stillAlive) {
-      treeSnapshotCache.delete(pid);
       return;
     }
-    signalProcessTreeUnix(pid, "SIGKILL", useGroupKill);
+    signalProcessTreeUnix(pid, "SIGKILL", useGroupKill, pids);
   }, graceMs).unref();
 }
 
@@ -297,41 +287,18 @@ function signalProcessTreeUnix(
   pid: number,
   signal: "SIGTERM" | "SIGKILL",
   useGroupKill: boolean,
-): void {
+  pidsToSignal?: ProcessSnapshot[],
+): ProcessSnapshot[] {
   if (useGroupKill) {
     try {
       process.kill(-pid, signal);
-      return;
+      return [];
     } catch {
       // Process group does not exist or we lack permission; try direct pid tree.
     }
   }
 
-  let pidsToSignal: ProcessSnapshot[];
-  const rootStartTime = getProcessStartTime(pid);
-
-  if (signal === "SIGTERM") {
-    const cached = treeSnapshotCache.get(pid);
-    if (cached && cached.rootStartTime === rootStartTime) {
-      pidsToSignal = cached.pids;
-    } else {
-      pidsToSignal = getUnixProcessTreePids(pid);
-      treeSnapshotCache.set(pid, { rootStartTime, pids: pidsToSignal });
-      setTimeout(() => {
-        treeSnapshotCache.delete(pid);
-      }, MAX_GRACE_MS + 5000).unref();
-    }
-  } else if (signal === "SIGKILL") {
-    const cached = treeSnapshotCache.get(pid);
-    if (cached) {
-      pidsToSignal = cached.pids;
-    } else {
-      pidsToSignal = getUnixProcessTreePids(pid);
-    }
-    treeSnapshotCache.delete(pid);
-  } else {
-    pidsToSignal = getUnixProcessTreePids(pid);
-  }
+  pidsToSignal = pidsToSignal ?? getUnixProcessTreePids(pid);
 
   for (const p of pidsToSignal) {
     try {
@@ -346,6 +313,8 @@ function signalProcessTreeUnix(
       // Already gone.
     }
   }
+
+  return pidsToSignal;
 }
 
 function runTaskkill(args: string[], onExit?: (code: number | null) => void): Promise<void> {

--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -62,11 +62,15 @@ export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): voi
       pids = [{ pid, startTime: getProcessStartTime(pid) }];
     } else {
       const cached = treeSnapshotCache.get(pid);
-      if (cached && getProcessStartTime(pid) === cached.rootStartTime) {
-        pids = cached.pids;
-      } else {
-        pids = getUnixProcessTreePids(pid);
+      if (
+        !cached ||
+        cached.rootStartTime === undefined ||
+        getProcessStartTime(pid) !== cached.rootStartTime
+      ) {
+        treeSnapshotCache.delete(pid);
+        return;
       }
+      pids = cached.pids;
     }
     const stillAlive = useGroupKill
       ? isProcessAlive(-pid) || isProcessAlive(pid)
@@ -337,8 +341,7 @@ function signalProcessTreeUnix(
     try {
       if (
         signal === "SIGKILL" &&
-        p.startTime !== undefined &&
-        getProcessStartTime(p.pid) !== p.startTime
+        (p.startTime === undefined || getProcessStartTime(p.pid) !== p.startTime)
       ) {
         continue;
       }

--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -298,9 +298,9 @@ function signalProcessTreeUnix(
     }
   }
 
-  pidsToSignal = pidsToSignal ?? getUnixProcessTreePids(pid);
+  const resolvedPidsToSignal = pidsToSignal ?? getUnixProcessTreePids(pid);
 
-  for (const p of pidsToSignal) {
+  for (const p of resolvedPidsToSignal) {
     try {
       if (
         signal === "SIGKILL" &&
@@ -314,7 +314,7 @@ function signalProcessTreeUnix(
     }
   }
 
-  return pidsToSignal;
+  return resolvedPidsToSignal;
 }
 
 function runTaskkill(args: string[], onExit?: (code: number | null) => void): Promise<void> {

--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -190,91 +190,57 @@ function getProcessStartTime(pid: number): string | undefined {
 }
 
 function getUnixProcessTreePids(rootPid: number): ProcessSnapshot[] {
-  if (!Number.isFinite(rootPid) || rootPid <= 1) {
-    return [];
-  }
-
+  if (!Number.isFinite(rootPid) || rootPid <= 1) return [];
   const childrenMap = new Map<number, number[]>();
 
   if (process.platform === "linux") {
     try {
-      const entries = readdirSync("/proc");
-      for (const entry of entries) {
-        if (!/^\d+$/.test(entry)) {
-          continue;
-        }
-        try {
-          const stat = readFileSync(`/proc/${entry}/stat`, "utf8");
-          const commEnd = stat.lastIndexOf(")");
-          if (commEnd < 0) {
-            continue;
-          }
-          const fields = stat
-            .slice(commEnd + 1)
-            .trim()
-            .split(/\s+/);
-          const ppid = Number(fields[1]);
-          const pid = Number(entry);
-          if (Number.isInteger(ppid) && Number.isInteger(pid) && ppid > 0 && pid > 1) {
-            let list = childrenMap.get(ppid);
-            if (!list) {
-              list = [];
+      for (const entry of readdirSync("/proc")) {
+        const pid = Number(entry);
+        if (pid > 1) {
+          try {
+            const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+            const ppid = Number(
+              stat
+                .slice(stat.lastIndexOf(")") + 1)
+                .trim()
+                .split(/\s+/)[1],
+            );
+            if (ppid > 0) {
+              const list = childrenMap.get(ppid) ?? [];
+              list.push(pid);
               childrenMap.set(ppid, list);
             }
-            list.push(pid);
-          }
-        } catch {
-          // Ignore process that disappeared mid-scan
+          } catch {}
         }
       }
-    } catch {
-      // Procfs unavailable or failed
-    }
+    } catch {}
   }
 
   if (childrenMap.size === 0) {
     try {
-      const res = spawnSync("ps", ["-ax", "-o", "pid=,ppid="], {
-        encoding: "utf8",
-        timeout: 1000,
-      });
-      if (!res.error && res.status === 0 && res.stdout) {
-        const lines = res.stdout.split("\n");
-        for (const line of lines) {
-          const parts = line.trim().split(/\s+/);
-          if (parts.length >= 2) {
-            const pid = Number(parts[0]);
-            const ppid = Number(parts[1]);
-            if (Number.isInteger(ppid) && Number.isInteger(pid) && ppid > 0 && pid > 1) {
-              let list = childrenMap.get(ppid);
-              if (!list) {
-                list = [];
-                childrenMap.set(ppid, list);
-              }
-              list.push(pid);
-            }
+      const res = spawnSync("ps", ["-ax", "-o", "pid=,ppid="], { encoding: "utf8", timeout: 1000 });
+      if (res.stdout) {
+        for (const line of res.stdout.split("\n")) {
+          const [pid, ppid] = line.trim().split(/\s+/).map(Number);
+          if (ppid > 0 && pid > 1) {
+            const list = childrenMap.get(ppid) ?? [];
+            list.push(pid);
+            childrenMap.set(ppid, list);
           }
         }
       }
-    } catch {
-      // Ignore ps failure
-    }
+    } catch {}
   }
 
   const result: ProcessSnapshot[] = [];
   const visited = new Set<number>();
 
   function traverse(currentPid: number) {
-    if (visited.has(currentPid)) {
-      return;
-    }
+    if (visited.has(currentPid)) return;
     visited.add(currentPid);
-
-    const children = childrenMap.get(currentPid) ?? [];
-    for (const childPid of children) {
-      if (childPid > 1 && childPid !== currentPid) {
-        traverse(childPid);
-      }
+    for (const childPid of childrenMap.get(currentPid) ?? []) {
+      if (childPid > 1 && childPid !== currentPid) traverse(childPid);
     }
     result.push({ pid: currentPid, startTime: getProcessStartTime(currentPid) });
   }
@@ -293,28 +259,22 @@ function signalProcessTreeUnix(
     try {
       process.kill(-pid, signal);
       return [];
-    } catch {
-      // Process group does not exist or we lack permission; try direct pid tree.
-    }
+    } catch {}
   }
 
-  const resolvedPidsToSignal = pidsToSignal ?? getUnixProcessTreePids(pid);
-
-  for (const p of resolvedPidsToSignal) {
+  const resolved = pidsToSignal ?? getUnixProcessTreePids(pid);
+  for (const p of resolved) {
     try {
       if (
-        signal === "SIGKILL" &&
-        (p.startTime === undefined || getProcessStartTime(p.pid) !== p.startTime)
+        signal !== "SIGKILL" ||
+        p.startTime === undefined ||
+        getProcessStartTime(p.pid) === p.startTime
       ) {
-        continue;
+        process.kill(p.pid, signal);
       }
-      process.kill(p.pid, signal);
-    } catch {
-      // Already gone.
-    }
+    } catch {}
   }
-
-  return resolvedPidsToSignal;
+  return resolved;
 }
 
 function runTaskkill(args: string[], onExit?: (code: number | null) => void): Promise<void> {

--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -6,7 +6,8 @@ const DEFAULT_GRACE_MS = 3000;
 const MAX_GRACE_MS = 60_000;
 const TASKKILL_COMPLETION_TIMEOUT_MS = 3000;
 
-const treeSnapshotCache = new Map<number, number[]>();
+type ProcessSnapshot = { pid: number; startTime: string | undefined };
+const treeSnapshotCache = new Map<number, ProcessSnapshot[]>();
 
 export type KillProcessTreeOptions = {
   graceMs?: number;
@@ -55,10 +56,12 @@ export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): voi
   const graceMs = normalizeGraceMs(opts?.graceMs);
   signalProcessTreeUnix(pid, "SIGTERM", useGroupKill);
   setTimeout(() => {
-    const pids = useGroupKill ? [pid] : (treeSnapshotCache.get(pid) ?? getUnixProcessTreePids(pid));
+    const pids = useGroupKill
+      ? [{ pid, startTime: getProcessStartTime(pid) }]
+      : (treeSnapshotCache.get(pid) ?? getUnixProcessTreePids(pid));
     const stillAlive = useGroupKill
       ? isProcessAlive(-pid) || isProcessAlive(pid)
-      : pids.some((p) => isProcessAlive(p));
+      : pids.some((p) => isProcessAlive(p.pid) && getProcessStartTime(p.pid) === p.startTime);
     if (!stillAlive) {
       treeSnapshotCache.delete(pid);
       return;
@@ -153,7 +156,33 @@ function isProcessGroupLeader(pid: number): boolean {
   return pgid === pid;
 }
 
-function getUnixProcessTreePids(rootPid: number): number[] {
+function getProcessStartTime(pid: number): string | undefined {
+  if (process.platform === "linux") {
+    try {
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+      const commEnd = stat.lastIndexOf(")");
+      if (commEnd >= 0) {
+        const fields = stat
+          .slice(commEnd + 1)
+          .trim()
+          .split(/\s+/);
+        return fields[19];
+      }
+    } catch {}
+  }
+  try {
+    const res = spawnSync("ps", ["-p", String(pid), "-o", "lstart="], { encoding: "utf8" });
+    if (!res.error && res.status === 0 && res.stdout) {
+      const lines = res.stdout.trim().split("\n");
+      if (lines.length > 1) {
+        return lines[1].trim();
+      }
+    }
+  } catch {}
+  return undefined;
+}
+
+function getUnixProcessTreePids(rootPid: number): ProcessSnapshot[] {
   if (!Number.isFinite(rootPid) || rootPid <= 1) {
     return [];
   }
@@ -225,7 +254,7 @@ function getUnixProcessTreePids(rootPid: number): number[] {
     }
   }
 
-  const result: number[] = [];
+  const result: ProcessSnapshot[] = [];
   const visited = new Set<number>();
 
   function traverse(currentPid: number) {
@@ -240,7 +269,7 @@ function getUnixProcessTreePids(rootPid: number): number[] {
         traverse(childPid);
       }
     }
-    result.push(currentPid);
+    result.push({ pid: currentPid, startTime: getProcessStartTime(currentPid) });
   }
 
   traverse(rootPid);
@@ -261,12 +290,12 @@ function signalProcessTreeUnix(
     }
   }
 
-  let pidsToSignal: number[];
-  
+  let pidsToSignal: ProcessSnapshot[];
+
   if (signal === "SIGTERM") {
     pidsToSignal = treeSnapshotCache.get(pid) ?? getUnixProcessTreePids(pid);
     treeSnapshotCache.set(pid, pidsToSignal);
-    
+
     setTimeout(() => {
       treeSnapshotCache.delete(pid);
     }, MAX_GRACE_MS + 5000).unref();
@@ -279,7 +308,14 @@ function signalProcessTreeUnix(
 
   for (const p of pidsToSignal) {
     try {
-      process.kill(p, signal);
+      if (
+        signal === "SIGKILL" &&
+        p.startTime !== undefined &&
+        getProcessStartTime(p.pid) !== p.startTime
+      ) {
+        continue;
+      }
+      process.kill(p.pid, signal);
     } catch {
       // Already gone.
     }

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -737,7 +737,7 @@ describe("exec tool backgrounding", () => {
       await expect
         .poll(async () => {
           const pollResult = await pollProcessSession({ tool: processTool, sessionId });
-          output = pollResult.output ?? "";
+          output += pollResult.output ?? "";
           return pollResult.status;
         }, BACKGROUND_POLL_OPTIONS)
         .toBe(PROCESS_STATUS_COMPLETED);

--- a/src/process/kill-tree.test.ts
+++ b/src/process/kill-tree.test.ts
@@ -356,7 +356,9 @@ describe("killProcessTree", () => {
 
     readFileSyncMock.mockImplementation((filePath: string) => {
       if (filePath === "/proc/5555/stat") {
-        if (is5555Dead) throw new Error("ENOENT");
+        if (is5555Dead) {
+          throw new Error("ENOENT");
+        }
         return "5555 (root) S 1 5555 5555 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 12345";
       }
       if (filePath === "/proc/5556/stat") {

--- a/src/process/kill-tree.test.ts
+++ b/src/process/kill-tree.test.ts
@@ -372,7 +372,7 @@ describe("killProcessTree", () => {
 
     await withMockedPlatform("linux", async () => {
       killProcessTree(5555, { graceMs: 10, detached: false });
-      
+
       // The tree snapshot happens synchronously on SIGTERM.
       expect(killSpy).toHaveBeenCalledWith(5557, "SIGTERM");
       expect(killSpy).toHaveBeenCalledWith(5556, "SIGTERM");

--- a/src/process/kill-tree.test.ts
+++ b/src/process/kill-tree.test.ts
@@ -3,13 +3,15 @@ import { EventEmitter } from "node:events";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 
-const { readFileSyncMock, spawnMock, spawnSyncMock } = vi.hoisted(() => ({
+const { readdirSyncMock, readFileSyncMock, spawnMock, spawnSyncMock } = vi.hoisted(() => ({
+  readdirSyncMock: vi.fn(),
   readFileSyncMock: vi.fn(),
   spawnMock: vi.fn(),
   spawnSyncMock: vi.fn(),
 }));
 
 vi.mock("node:fs", () => ({
+  readdirSync: (...args: unknown[]) => readdirSyncMock(...args),
   readFileSync: (...args: unknown[]) => readFileSyncMock(...args),
 }));
 
@@ -59,6 +61,8 @@ describe("killProcessTree", () => {
   });
 
   beforeEach(() => {
+    readdirSyncMock.mockReset();
+    readdirSyncMock.mockImplementation(() => []);
     readFileSyncMock.mockReset();
     readFileSyncMock.mockImplementation(() => {
       throw new Error("proc unavailable");
@@ -296,6 +300,39 @@ describe("killProcessTree", () => {
       expect(killSpy).toHaveBeenCalledWith(5555, "SIGTERM");
       expect(killSpy).not.toHaveBeenCalledWith(-5555, "SIGTERM");
       expect(killSpy).not.toHaveBeenCalledWith(-5555, "SIGKILL");
+    });
+  });
+
+  it("on Unix enumerates and signals descendant PIDs when detached:false (#121049)", async () => {
+    readdirSyncMock.mockReturnValue(["5555", "5556", "5557"]);
+    killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      if ((pid === 5555 || pid === 5556 || pid === 5557) && signal === 0) {
+        return true;
+      }
+      return true;
+    }) as typeof process.kill);
+
+    readFileSyncMock.mockImplementation((filePath: string) => {
+      if (filePath === "/proc/5555/stat") {
+        return "5555 (root) S 1 5555 5555 0";
+      }
+      if (filePath === "/proc/5556/stat") {
+        return "5556 (subshell) S 5555 5555 5555 0";
+      }
+      if (filePath === "/proc/5557/stat") {
+        return "5557 (grandchild) S 5556 5555 5555 0";
+      }
+      throw new Error("ENOENT");
+    });
+
+    await withMockedPlatform("linux", async () => {
+      killProcessTree(5555, { graceMs: 10, detached: false });
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(killSpy).toHaveBeenCalledWith(5557, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(5556, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(5555, "SIGTERM");
+      expect(killSpy).not.toHaveBeenCalledWith(-5555, "SIGTERM");
     });
   });
 

--- a/src/process/kill-tree.test.ts
+++ b/src/process/kill-tree.test.ts
@@ -336,6 +336,56 @@ describe("killProcessTree", () => {
     });
   });
 
+  it("on Unix force-kills descendants when detached:false even if the root PID exits (#121108)", async () => {
+    readdirSyncMock.mockReturnValue(["5555", "5556", "5557"]);
+    let is5555Dead = false;
+    killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      // Simulate root PID 5555 exiting immediately on SIGTERM (ESRCH later)
+      if (pid === 5555 && signal === "SIGTERM") {
+        is5555Dead = true;
+        return true;
+      }
+      if (pid === 5555 && signal === 0 && is5555Dead) {
+        throw new Error("ESRCH");
+      }
+      if ((pid === 5556 || pid === 5557) && signal === 0) {
+        return true;
+      }
+      return true;
+    }) as typeof process.kill);
+
+    readFileSyncMock.mockImplementation((filePath: string) => {
+      if (filePath === "/proc/5555/stat") {
+        if (is5555Dead) throw new Error("ENOENT");
+        return "5555 (root) S 1 5555 5555 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 12345";
+      }
+      if (filePath === "/proc/5556/stat") {
+        return "5556 (subshell) S 5555 5555 5555 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 12346";
+      }
+      if (filePath === "/proc/5557/stat") {
+        return "5557 (grandchild) S 5556 5555 5555 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 12347";
+      }
+      throw new Error("ENOENT");
+    });
+
+    await withMockedPlatform("linux", async () => {
+      killProcessTree(5555, { graceMs: 10, detached: false });
+      
+      // The tree snapshot happens synchronously on SIGTERM.
+      expect(killSpy).toHaveBeenCalledWith(5557, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(5556, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(5555, "SIGTERM");
+
+      // Advance timers to trigger escalation (SIGKILL)
+      await vi.advanceTimersByTimeAsync(10);
+
+      // Root exited, so no SIGKILL for it, but surviving descendants get SIGKILL
+      expect(killSpy).toHaveBeenCalledWith(5557, "SIGKILL");
+      expect(killSpy).toHaveBeenCalledWith(5556, "SIGKILL");
+      expect(killSpy).not.toHaveBeenCalledWith(5555, "SIGKILL");
+    });
+  });
+
   it("on Unix uses group kill when the omitted option resolves to a group leader", async () => {
     killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
       if (pid === -6666 && signal === 0) {

--- a/src/process/kill-tree.ts
+++ b/src/process/kill-tree.ts
@@ -7,4 +7,5 @@ export {
   killProcessTree,
   signalProcessTree,
   type KillProcessTreeOptions,
+  type ProcessSnapshot,
 } from "../../packages/agent-core/src/harness/env/kill-tree.js";

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -387,6 +387,26 @@ describe("createChildAdapter", () => {
     expect(killMock).not.toHaveBeenCalled();
   });
 
+  it("retains the termination snapshot across sequential tree kills (#121108)", async () => {
+    const { adapter } = await createAdapterHarness({ pid: 5678 });
+    const snapshot = [{ pid: 5678, startTime: "123" }];
+    signalProcessTreeMock.mockReturnValueOnce(snapshot);
+
+    adapter.kill("SIGTERM");
+    expect(signalProcessTreeMock).toHaveBeenCalledWith(
+      5678,
+      "SIGTERM",
+      expect.objectContaining({ pidsToSignal: undefined }),
+    );
+
+    adapter.kill("SIGKILL");
+    expect(signalProcessTreeMock).toHaveBeenCalledWith(
+      5678,
+      "SIGKILL",
+      expect.objectContaining({ pidsToSignal: snapshot }),
+    );
+  });
+
   it("uses direct child.kill for non-SIGTERM and non-SIGKILL signals", async () => {
     const { adapter, killMock } = await createAdapterHarness({ pid: 7654 });
 

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -6,7 +6,7 @@ import {
   resolveWindowsExecutablePath,
   resolveWindowsSpawnProgramCandidate,
 } from "../../../plugin-sdk/windows-spawn.js";
-import { signalProcessTree } from "../../kill-tree.js";
+import { signalProcessTree, type ProcessSnapshot } from "../../kill-tree.js";
 import { prepareOomScoreAdjustedSpawn } from "../../linux-oom-score.js";
 import {
   addSecretInputStdio,
@@ -428,18 +428,33 @@ export async function createChildAdapter(params: {
     return waitPromise;
   };
 
-  // The actual detachment of the spawned child can differ from `useDetached`:
   // when the detached spawn fails, `spawnWithFallback` retries with the
   // `no-detach` fallback (detached:false). In that case the child shares the
   // gateway's process group regardless of intent, so the kill must avoid
   // group-kill. (#71662 follow-up — caught by Greptile review)
   const childIsDetached = useDetached && !spawned.usedFallback;
+
+  let terminationSnapshot: ProcessSnapshot[] | undefined;
+
   const signalProcessTreeForChild = (pid: number, signal: "SIGTERM" | "SIGKILL") => {
-    signalProcessTree(pid, signal, { detached: childIsDetached });
+    const snapshot = signalProcessTree(pid, signal, {
+      detached: childIsDetached,
+      pidsToSignal: signal === "SIGKILL" ? terminationSnapshot : undefined,
+    });
+    if (signal === "SIGTERM") {
+      terminationSnapshot = snapshot;
+    }
   };
   const signalProcessTreeForChildAndWait = (pid: number, signal: "SIGTERM" | "SIGKILL") =>
     new Promise<void>((resolve) => {
-      signalProcessTree(pid, signal, { detached: childIsDetached, onComplete: resolve });
+      const snapshot = signalProcessTree(pid, signal, {
+        detached: childIsDetached,
+        pidsToSignal: signal === "SIGKILL" ? terminationSnapshot : undefined,
+        onComplete: resolve,
+      });
+      if (signal === "SIGTERM") {
+        terminationSnapshot = snapshot;
+      }
     });
   const kill = (signal?: NodeJS.Signals) => {
     const pid = child.pid ?? undefined;


### PR DESCRIPTION
### What Problem This Solves

Attached Unix processes managed by `killProcessTree` were not retaining descendant snapshots across the termination lifecycle. The service-managed path calling `signalProcessTree` for TERM and KILL was not carrying the snapshot over, leaving descendant processes (like a lingering `sleep` process) un-terminated after the parent root exits.

### Why This Change Was Made

The descendant snapshot is now fixed to survive `killProcessTree`'s own timer. The service-managed adapter retains the opaque snapshot across TERM and KILL calls to ensure it can successfully enumerate and terminate all descendant PIDs.

### User Impact

Users running attached services will no longer experience orphaned descendant processes lingering in the background after the root process is terminated with SIGTERM/SIGKILL.

### Real service-managed adapter evidence

Executed on Linux at commit `ce80edc6708`, using the real `createChildAdapter` with `OPENCLAW_SERVICE_MARKER=openclaw` (attached mode, `detached:false`). PIDs are redacted:

```text
root=<root> descendant=<descendant>
before-term root: <root> <gateway-parent> Sl node
before-term descendant: <descendant> <root> Sl node
term adapter wait: {"code":0,"signal":null}
after-term root: not found
after-term descendant: <descendant> <reaper> Sl node
after-kill root: not found
after-kill descendant: not found
```

This proves the actual adapter path carried the TERM snapshot into the later KILL after the root exited, and the surviving descendant was removed.

### AI-Assisted PR Disclosure 🤖

- **AI-assisted**: Yes, this PR was authored with the assistance of Antigravity AI.
- **Understood Code**: Yes, fully inspected and validated the termination lifecycle and verified process trees.
- **Evidence**: Verified via the real service-managed child-adapter path above and focused regression tests.
- **Prompts/Logs**: Instructed to fix the snapshot reuse inside `killProcessTree` and carry the descendant snapshot through adapter escalation.

Fixes #121049
