### PR TITLE
fix(gateway): audio history exposes raw data and local paths

### DIFF
--- a/src/gateway/chat-display-projection.sanitize.ts
+++ b/src/gateway/chat-display-projection.sanitize.ts
@@ -30,6 +30,56 @@ import {
   WORKSPACE_CONFLICT_TRANSCRIPT_TYPE,
 } from "./worker-environments/workspace-conflicts.js";
 
+const AUDIO_LOCAL_PATH_FIELDS = ["path", "file", "filePath", "localPath"] as const;
+
+function isInlineOrLocalAudioReference(value: unknown): boolean {
+  if (typeof value !== "string") {
+    return false;
+  }
+  const reference = value.trim();
+  const isManagedRoute = /^\/(?:api\/chat\/media\/outgoing|media|__openclaw__)\//u.test(reference);
+  return (
+    /^data:audio\//iu.test(reference) ||
+    /^file:/iu.test(reference) ||
+    /^~[\\/]/u.test(reference) ||
+    (!isManagedRoute &&
+      (reference.startsWith("/") ||
+        /^[A-Za-z]:[\\/]/u.test(reference) ||
+        reference.startsWith("\\\\")))
+  );
+}
+
+function omitAudioHistoryContent(
+  entry: Record<string, unknown>,
+  referenceFields: readonly string[],
+): boolean {
+  let removed = false;
+  if (Object.hasOwn(entry, "data")) {
+    const data = entry.data;
+    delete entry.data;
+    if (typeof data === "string") {
+      entry.bytes = estimateBase64DecodedBytes(data);
+    }
+    removed = true;
+  }
+  for (const field of AUDIO_LOCAL_PATH_FIELDS) {
+    if (Object.hasOwn(entry, field)) {
+      delete entry[field];
+      removed = true;
+    }
+  }
+  for (const field of referenceFields) {
+    if (isInlineOrLocalAudioReference(entry[field])) {
+      delete entry[field];
+      removed = true;
+    }
+  }
+  if (removed) {
+    entry.omitted = true;
+  }
+  return removed;
+}
+
 export function sanitizeChatHistoryContentBlock(
   block: unknown,
   opts?: { preserveExactToolPayload?: boolean; maxChars?: number },
@@ -113,15 +163,18 @@ export function sanitizeChatHistoryContentBlock(
       changed = true;
     }
   }
-  if (type === "audio" && entry.source && typeof entry.source === "object") {
-    const source = { ...(entry.source as Record<string, unknown>) };
-    if (source.type === "base64" && typeof source.data === "string") {
-      const bytes = estimateBase64DecodedBytes(source.data);
-      delete source.data;
-      source.omitted = true;
-      source.bytes = bytes;
-      entry.source = source;
-      changed = true;
+  if (type === "audio") {
+    // Audio transcripts can retain model-input bytes and host-local references.
+    // Strip them at the shared display boundary while preserving safe metadata.
+    const blockChanged = omitAudioHistoryContent(entry, ["url", "openUrl", "audio_url"]);
+    changed ||= blockChanged;
+    const source = readRecord(entry.source);
+    if (source) {
+      const projectedSource = { ...source };
+      if (omitAudioHistoryContent(projectedSource, ["url"])) {
+        entry.source = projectedSource;
+        changed = true;
+      }
     }
   }
   return { block: changed ? entry : block, changed };

--- a/src/gateway/chat-display-projection.test.ts
+++ b/src/gateway/chat-display-projection.test.ts
@@ -9,7 +9,16 @@ import {
   CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
   replaceOversizedChatHistoryMessages,
 } from "./server-methods/chat-history-budget.js";
-import { buildSessionHistorySnapshot } from "./session-history-state.js";
+import { buildSessionHistorySnapshot, SessionHistorySseState } from "./session-history-state.js";
+
+function projectHistoryTransports(message: Record<string, unknown>) {
+  const websocket = replaceOversizedChatHistoryMessages({
+    messages: projectChatDisplayMessages([message]),
+    maxSingleMessageBytes: CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
+  }).messages;
+  const sse = buildSessionHistorySnapshot({ rawMessages: [message], limit: 5 }).history.messages;
+  return [websocket, sse];
+}
 
 describe("oversized multimodal chat history", () => {
   it.each([
@@ -35,14 +44,7 @@ describe("oversized multimodal chat history", () => {
         { type: "text", text: "keep suffix text" },
       ],
     };
-    const projected = projectChatDisplayMessages([message]);
-    const websocket = replaceOversizedChatHistoryMessages({
-      messages: projected,
-      maxSingleMessageBytes: CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
-    }).messages;
-    const sse = buildSessionHistorySnapshot({ rawMessages: [message], limit: 5 }).history.messages;
-
-    for (const messages of [websocket, sse]) {
+    for (const messages of projectHistoryTransports(message)) {
       expect(messages).toMatchObject([
         {
           role: "user",
@@ -66,6 +68,129 @@ describe("oversized multimodal chat history", () => {
       projectChatDisplayMessages([{ role: "user", content: [{ type: "image", source }] }]),
     ).toEqual([{ role: "user", content: [{ type: "image", source }] }]);
   });
+
+  it("omits persisted top-level audio data from WebSocket and SSE history", () => {
+    const audio = Buffer.from("persisted audio bytes");
+    const encoded = audio.toString("base64");
+    const message = {
+      role: "user",
+      content: [
+        { type: "text", text: "keep prefix text" },
+        { type: "audio", mimeType: "audio/wav", data: encoded },
+        { type: "text", text: "keep suffix text" },
+      ],
+    };
+
+    for (const messages of projectHistoryTransports(message)) {
+      expect(messages).toEqual([
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "keep prefix text" },
+            { type: "audio", mimeType: "audio/wav", omitted: true, bytes: audio.length },
+            { type: "text", text: "keep suffix text" },
+          ],
+        },
+      ]);
+      expect(JSON.stringify(messages)).not.toContain(encoded);
+    }
+  });
+
+  it("removes private audio payloads and local references while preserving safe refs", () => {
+    const privateMarker = "private-audio-reference";
+    const safeAudio = [
+      {
+        type: "audio",
+        url: "https://example.invalid/audio.wav",
+        openUrl: "http://example.invalid/audio.wav",
+        audio_url: "media://inbound/audio.wav",
+        source: { type: "url", url: "/api/chat/media/outgoing/audio.wav" },
+      },
+      { type: "audio", url: "/media/audio.wav", openUrl: "/__openclaw__/audio/clip.wav" },
+    ];
+    const message = {
+      role: "user",
+      content: [
+        {
+          type: "audio",
+          data: { rawSecret: privateMarker },
+          url: `data:audio/wav;base64,${privateMarker}`,
+          openUrl: `file:///tmp/${privateMarker}.wav`,
+          audio_url: `~/${privateMarker}.wav`,
+          path: `/tmp/${privateMarker}.wav`,
+          file: privateMarker,
+          filePath: String.raw`C:\private-audio-reference.wav`,
+          localPath: String.raw`\\server\share\private-audio-reference.wav`,
+          source: {
+            type: "opaque",
+            codec: "pcm",
+            data: new Uint8Array([111, 112, 113]),
+            url: `/tmp/${privateMarker}-source.wav`,
+            path: `/tmp/${privateMarker}-source.wav`,
+            file: privateMarker,
+            filePath: String.raw`D:\private-audio-reference.wav`,
+            localPath: String.raw`\\server\share\private-audio-reference-source.wav`,
+          },
+        },
+        { type: "audio", url: String.raw`C:\a.wav`, source: { url: String.raw`\\s\a.wav` } },
+        ...safeAudio,
+      ],
+    };
+    const original = structuredClone(message);
+
+    for (const messages of projectHistoryTransports(message)) {
+      expect(messages).toEqual([
+        {
+          role: "user",
+          content: [
+            {
+              type: "audio",
+              omitted: true,
+              source: { type: "opaque", codec: "pcm", omitted: true },
+            },
+            { type: "audio", omitted: true, source: { omitted: true } },
+            ...safeAudio,
+          ],
+        },
+      ]);
+      expect(JSON.stringify(messages)).not.toContain(privateMarker);
+      expect(JSON.stringify(messages)).not.toContain('"0":111');
+    }
+    expect(message).toEqual(original);
+  });
+
+  it("sanitizes newly appended audio before returning an incremental SSE message", () => {
+    const encoded = Buffer.from("incremental SSE audio").toString("base64");
+    const state = SessionHistorySseState.fromRawSnapshot({
+      target: { sessionId: "audio-session", sessionKey: "agent:main:audio-session" },
+      rawMessages: [],
+    });
+
+    const appended = state.appendInlineMessage({
+      message: {
+        role: "user",
+        content: [
+          { type: "text", text: "keep incremental text" },
+          { type: "audio", mimeType: "audio/ogg", data: encoded },
+        ],
+      },
+      messageId: "audio-message",
+    });
+
+    expect(appended?.message).toMatchObject({
+      role: "user",
+      content: [
+        { type: "text", text: "keep incremental text" },
+        {
+          type: "audio",
+          mimeType: "audio/ogg",
+          omitted: true,
+          bytes: Buffer.from("incremental SSE audio").length,
+        },
+      ],
+    });
+    expect(JSON.stringify(appended?.message)).not.toContain(encoded);
+  });
 });
 
 describe("private transcript metadata projection", () => {
@@ -79,14 +204,7 @@ describe("private transcript metadata projection", () => {
         upstreamUserText: "private decorated prompt ".repeat(12_000),
       },
     };
-    const projected = projectChatDisplayMessages([message]);
-    const websocket = replaceOversizedChatHistoryMessages({
-      messages: projected,
-      maxSingleMessageBytes: CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
-    }).messages;
-    const sse = buildSessionHistorySnapshot({ rawMessages: [message], limit: 5 }).history.messages;
-
-    for (const messages of [websocket, sse]) {
+    for (const messages of projectHistoryTransports(message)) {
       expect(messages).toEqual([
         {
           role: "user",


### PR DESCRIPTION
Related: #120499

## What Problem This Solves

Fixes an issue where authenticated WebSocket and HTTP/SSE history clients could receive raw audio bytes or host-local audio references when persisted transcript blocks used top-level `data`, non-string `source.data`, or filesystem-backed URL/path forms.

## Why This Change Was Made

The shared chat display projector now removes audio payload bytes and local filesystem references at the single boundary used by `chat.history`, `chat.startup`, JSON history, and SSE history. Remote HTTP(S), inbound media references, and gateway-managed media routes remain intact. This is intentionally separate from the native-video capability work in #120499.

## User Impact

History reloads and incremental SSE updates no longer expose raw audio payloads or machine-local audio paths. Visible surrounding text and safe remote/managed audio references continue to work.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/chat-display-projection.test.ts` — 13 tests passed, covering WebSocket projection, initial SSE snapshots, incremental SSE messages, raw/non-string data, local references, safe references, and input immutability.
- `node scripts/run-oxlint.mjs src/gateway/chat-display-projection.sanitize.ts src/gateway/chat-display-projection.test.ts` — passed.
- `./node_modules/.bin/oxfmt --check src/gateway/chat-display-projection.sanitize.ts src/gateway/chat-display-projection.test.ts` — passed.
- `git diff --check` — passed.
- Hosted PR CI [run 31322722723](https://github.com/openclaw/openclaw/actions/runs/31322722723) — green on exact head `39e408016f24a32352908b0d3c9cc805bb407733`.
- Testbox changed-surface [run 31322110395](https://github.com/openclaw/openclaw/actions/runs/31322110395) passed core/core-test typechecks, dead-export, dependency, plugin-boundary, format, and repository ratchet checks; its single lint finding was fixed and the targeted lint rerun passed.
- Codex autoreview — clean, no accepted/actionable findings.

AI-assisted: implementation and review used coding agents; the final diff and proof were verified by the maintainer.
