### PR TITLE
fix(memory): decay dated notes in nested folders

### DIFF
--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -139,7 +139,8 @@ Two optional features help with a large note history.
 Old notes gradually lose ranking weight so recent information surfaces first.
 With the default 30-day half-life, a note from last month scores at 50% of its
 original weight. `MEMORY.md` and other non-dated files under `memory/` are
-evergreen and never decayed; only dated `memory/YYYY-MM-DD.md` files decay.
+evergreen and never decayed; dated `YYYY-MM-DD.md` files anywhere under
+`memory/` decay.
 
 ### MMR (diversity)
 

--- a/extensions/memory-core/src/memory/temporal-decay.test.ts
+++ b/extensions/memory-core/src/memory/temporal-decay.test.ts
@@ -122,6 +122,24 @@ describe("temporal decay", () => {
     expect(byPath.get("memory/2000-01-01.md")?.score ?? 1).toBeLessThan(0.001);
   });
 
+  it("decays valid dated files nested under memory while keeping other nested notes evergreen", async () => {
+    const decayed = await applyTemporalDecayToHybridResults({
+      results: [
+        { path: "memory/dreaming/light/2026-01-11.md", score: 1, source: "memory" },
+        { path: "memory\\dreaming\\deep\\2026-01-11.md", score: 0.8, source: "memory" },
+        { path: "memory/dreaming/light/notes.md", score: 0.7, source: "memory" },
+        { path: "memory/dreaming/light/2026-02-30.md", score: 0.6, source: "memory" },
+      ],
+      temporalDecay: { enabled: true, halfLifeDays: 30 },
+      nowMs: NOW_MS,
+    });
+
+    expect(decayed[0]?.score).toBeCloseTo(0.5, 2);
+    expect(decayed[1]?.score).toBeCloseTo(0.4, 2);
+    expect(decayed[2]?.score).toBeCloseTo(0.7);
+    expect(decayed[3]?.score).toBeCloseTo(0.6);
+  });
+
   it("uses file mtime fallback for non-memory sources", async () => {
     const dir = await createTempWorkspace("openclaw-temporal-decay-");
     const sessionPath = path.join(dir, "sessions", "thread.jsonl");

--- a/extensions/memory-core/src/memory/temporal-decay.ts
+++ b/extensions/memory-core/src/memory/temporal-decay.ts
@@ -13,7 +13,7 @@ export const DEFAULT_TEMPORAL_DECAY_CONFIG: TemporalDecayConfig = {
 };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const DATED_MEMORY_PATH_RE = /(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})\.md$/;
+const DATED_MEMORY_PATH_RE = /(?:^|\/)memory\/(?:[^/]+\/)*(\d{4})-(\d{2})-(\d{2})\.md$/;
 
 function toDecayLambda(halfLifeDays: number): number {
   if (!Number.isFinite(halfLifeDays) || halfLifeDays <= 0) {
@@ -77,7 +77,7 @@ function isEvergreenMemoryPath(filePath: string): boolean {
   if (!normalized.startsWith("memory/")) {
     return false;
   }
-  return !DATED_MEMORY_PATH_RE.test(normalized);
+  return parseMemoryDateFromPath(normalized) === null;
 }
 
 async function extractTimestamp(params: {


### PR DESCRIPTION
Closes #121046

## What Problem This Solves

Fixes an issue where dated memory files written below nested directories such as `memory/dreaming/light/` were treated as evergreen. Those old reports kept their full ranking weight even with temporal decay enabled, allowing stale generated memories to outrank recent notes.

## Why This Change Was Made

Temporal decay now recognizes a valid date-only Markdown basename at any depth below `memory/`, at the shared timestamp-classification boundary used by both vector and keyword results. Undated files and invalid calendar dates remain evergreen; no dreaming-specific special case or persistent-data migration was added.

## User Impact

Users with nested memory producers such as dreaming reports get the same recency ranking behavior as root daily notes. Existing `MEMORY.md`, topic notes, and other non-dated knowledge remain stable.

## Evidence

- Red phase: the nested POSIX case retained score `1` instead of decaying to `0.5` after one half-life.
- Rebased focused proof: `node scripts/run-vitest.mjs extensions/memory-core/src/memory/temporal-decay.test.ts` — 5 tests passed.
- Real-workspace production CLI proof at head `36340572d7`:
  1. Created an isolated workspace with `memory/dreaming/light/notes.md` and `memory/dreaming/light/2026-01-11.md`, both containing the same `violet lighthouse calibration evidence` text.
  2. Configured deliberate FTS-only retrieval with `memory.search.provider: "none"` and ran `pnpm openclaw memory index --force --agent main --verbose`; the production CLI loaded `memory-core` and completed the index.
  3. Ran `pnpm openclaw memory search 'violet lighthouse calibration' --agent main --max-results 10 --min-score 0 --json`.
  4. Both results had the identical lexical `textScore` (`0.000002999991000027`). The evergreen nested `notes.md` result scored `0.7157172857`; the nested dated `2026-01-11.md` result scored `0.0054972910`, demonstrating temporal decay through actual indexing and search rather than a helper-only call.
- Regression coverage includes nested POSIX and Windows paths, an undated nested note, and an invalid date.
- `pnpm docs:check-mdx` — 770 documentation files passed.
- `pnpm exec oxfmt`, `pnpm exec oxlint`, and `git diff --check` passed.
- Rebased onto upstream `ad1a2cd7e7`, where the formerly failing Labs test passes 44/44; a fresh exact-head CI run was triggered.
- `node scripts/check-changed.mjs -- ...` could not run delegated analysis because the selected Crabbox binary failed its own sanity check; focused tests, docs, and the real production CLI trajectory were run directly.

The proof used an isolated state directory/workspace and FTS-only mode, so it required no hosted provider credentials and did not touch user memory or external services.

## AI Assistance

This PR was implemented with AI assistance. The nested dreaming producer, recursive memory indexer, shared hybrid ranking owner, evergreen rules, documentation, issue/PR state, and existing tests were inspected. The regression failed before implementation; focused tests and an isolated production `memory index`/`memory search` trajectory passed afterward on the rebased head.
