### PR TITLE
fix(memory): avoid repeating recall from supplied context

### DIFF
--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -129,6 +129,8 @@ describe("buildPromptSection", () => {
     expect(result[1]).toContain("run memory_search");
     expect(result[1]).toContain("then use memory_get");
     expect(result[1]).toContain("indexed session transcripts");
+    expect(result[1]).toContain("not already present in the current turn");
+    expect(result[1]).toContain("Do not repeat memory retrieval");
     expect(result).toContain(
       "Citations: include Source: <path#line> when it helps the user verify memory snippets.",
     );
@@ -143,6 +145,8 @@ describe("buildPromptSection", () => {
     expect(result[0]).toBe("## Memory Recall");
     expect(result[1]).toContain("run memory_search");
     expect(result[1]).toContain("indexed session transcripts");
+    expect(result[1]).toContain("not already present in the current turn");
+    expect(result[1]).toContain("Do not repeat memory retrieval");
     expect(result[1]).not.toContain("then use memory_get");
   });
 
@@ -154,6 +158,8 @@ describe("buildPromptSection", () => {
     expect(result[0]).toBe("## Memory Recall");
     expect(result[1]).toContain("run memory_get");
     expect(result[1]).not.toContain("run memory_search");
+    expect(result[1]).toContain("not already present in the current turn");
+    expect(result[1]).toContain("Do not repeat memory retrieval");
   });
 
   it("includes citations-off instruction when citationsMode is off", () => {

--- a/extensions/memory-core/src/memory-tool-contract.ts
+++ b/extensions/memory-core/src/memory-tool-contract.ts
@@ -87,7 +87,7 @@ export const MEMORY_SEARCH_TOOL_CONTRACT = {
   name: "memory_search",
   parameters: MemorySearchSchema,
   describe: ({ search }: MemorySourceContract) =>
-    `Mandatory recall step: semantically search ${search} before answering questions about prior work, decisions, dates, people, preferences, or todos. Optional \`corpus=wiki\` or \`corpus=all\` also searches registered compiled-wiki supplements. \`corpus=memory\` restricts hits to indexed memory files (excludes session transcript chunks from ranking). \`corpus=sessions\` restricts hits to the session corpus under the same visibility rules as session history tools. ${SEARCH_CORPUS_OUTCOME_GUIDANCE} If response has disabled=true or stale=true, tell the user and include the warning/action guidance.`,
+    `Semantically search ${search} when an answer depends on prior work, decisions, dates, people, preferences, or todos not already present in the current turn. Do not repeat memory retrieval when supplied context already answers the question. Optional \`corpus=wiki\` or \`corpus=all\` also searches registered compiled-wiki supplements. \`corpus=memory\` restricts hits to indexed memory files (excludes session transcript chunks from ranking). \`corpus=sessions\` restricts hits to the session corpus under the same visibility rules as session history tools. ${SEARCH_CORPUS_OUTCOME_GUIDANCE} If response has disabled=true or stale=true, tell the user and include the warning/action guidance.`,
 } as const;
 
 export const MEMORY_GET_TOOL_CONTRACT = {
@@ -114,12 +114,12 @@ export function buildMemoryPromptSection({
   }
 
   const guidance = hasMemorySearch
-    ? `Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on ${sources.search}${
+    ? `When an answer depends on prior work, decisions, dates, people, preferences, or todos not already present in the current turn, run memory_search on ${sources.search}${
         hasMemoryGet ? "; then use memory_get to pull only the needed lines" : ""
-      }. ${SEARCH_CORPUS_OUTCOME_GUIDANCE}${
+      }. Do not repeat memory retrieval when supplied context already answers the question. ${SEARCH_CORPUS_OUTCOME_GUIDANCE}${
         hasMemoryGet ? ` For memory_get, ${GET_READ_OUTCOME_GUIDANCE}` : ""
       } If low confidence after search, say you checked.`
-    : `Before answering anything about prior work, decisions, dates, people, preferences, or todos that point to a specific source in ${sources.files}: run memory_get to pull only the needed lines. ${GET_READ_OUTCOME_GUIDANCE} ${SEARCH_CORPUS_OUTCOME_GUIDANCE} If low confidence after reading, say you checked.`;
+    : `When an answer depends on prior work, decisions, dates, people, preferences, or todos not already present in the current turn and points to a specific source in ${sources.files}, run memory_get to pull only the needed lines. Do not repeat memory retrieval when supplied context already answers the question. ${GET_READ_OUTCOME_GUIDANCE} ${SEARCH_CORPUS_OUTCOME_GUIDANCE} If low confidence after reading, say you checked.`;
   const citationGuidance =
     citationsMode === "off"
       ? "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks."

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -64,6 +64,14 @@ describe("memory tool schemas", () => {
       enum: ["memory", "wiki", "all"],
     });
   });
+
+  it("describes search as evidence-driven without repeating supplied recall", () => {
+    const description = createMemorySearchToolOrThrow().description;
+
+    expect(description).toContain("not already present in the current turn");
+    expect(description).toContain("Do not repeat memory retrieval");
+    expect(description).not.toContain("Mandatory recall step");
+  });
 });
 
 describe("memory_search unavailable payloads", () => {


### PR DESCRIPTION
Closes #120968

## What Problem This Solves

Memory Core categorically instructs the main agent to call `memory_search` for people, preferences, and other historical topics even when Active Memory has already injected the relevant recalled context into the same turn. A successful pre-prompt recall can therefore trigger a redundant second retrieval, adding latency and another model/tool round trip.

## Why This Change Was Made

Memory Core’s canonical model contract now makes retrieval depend on missing evidence: search or read memory when the answer depends on history not already present in the current turn, and do not repeat retrieval when supplied context already answers the question.

The change is centralized in `memory-tool-contract.ts`, the current owner of prompt, lazy-tool, and eager-tool wording. Search remains explicitly expected for unresolved historical questions; no cross-plugin state API, configuration toggle, or duplicate policy surface was added.

## User Impact

Active Memory users can receive direct answers from already-injected recall instead of paying for a duplicate search. Users without relevant supplied context keep the existing historical recall workflow.

## Evidence

- Red phase: the three existing branch regressions failed against current main because prompt/tool descriptions lacked the supplied-context exception and still called search a mandatory category step.
- Focused unit proof: `node scripts/run-vitest.mjs extensions/memory-core/index.test.ts extensions/memory-core/src/tools.test.ts extensions/active-memory/index.test.ts` — 264 tests passed across both shards (199 Active Memory plus 65 Memory Core tests).
- Contract coverage: prompt assertions cover search+get, search-only, and get-only configurations; the production tool assertion confirms the search description is evidence-driven and no longer says `Mandatory recall step`.
- Real-provider behavior proof: a synthetic, secretless `codex-cli 0.146.0` app-server turn used the exact production `MEMORY_SEARCH_TOOL_CONTRACT`, exact `buildMemoryPromptSection` output, and an `openclaw.memory_search` dynamic tool. Given injected context `Alice’s preferred editor is Neovim` and the corresponding user question, the real OpenAI-backed turn completed with `toolCalls=0` and answered `Alice prefers Neovim.` No tool execution was possible or attempted.
- The provider proof used an ephemeral thread, synthetic data only, and no Gateway mutation. It validates the after-fix model trajectory requested in the latest review rather than only mock-provider prompt assembly.
- Required sibling Codex source gate at `openai/codex@50ef7395faee`: the dynamic-tool handler [parses function arguments and passes the resulting JSON value](https://github.com/openai/codex/blob/50ef7395faee1d0e2d01730f9636aa06091c7be3/codex-rs/core/src/tools/handlers/dynamic.rs#L126-L143), then [emits and returns that same value](https://github.com/openai/codex/blob/50ef7395faee1d0e2d01730f9636aa06091c7be3/codex-rs/core/src/tools/handlers/dynamic.rs#L196-L236); the observed absence of a dynamic call therefore reflects model planning, not wrapper filtering.
- Repository-required structured autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` passed after a clean TruffleHog scan with no accepted/actionable findings; overall correctness was `patch is correct` at 0.99 confidence.
- `git diff upstream/main...HEAD --check` passed.

## AI Assistance

This PR was implemented with AI assistance. Memory Core’s current canonical contract, Active Memory injection boundary, prompt assembly, existing QA contract, current issue/review state, and sibling Codex dynamic-tool path were inspected directly. The focused red/green suite, real-provider trajectory, and repository-required structured autoreview were run against the rebased change.
