### PR TITLE
fix(ui): clear sidebar hover controls after pointer leaves

### DIFF
--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -294,12 +294,14 @@ suite.define(() => {
         await expect
           .poll(() =>
             header.evaluate((element) => {
-              const toggle = element.querySelector<HTMLElement>(".sidebar-session-group-toggle");
+              const focusedToggle = element.querySelector<HTMLElement>(
+                ".sidebar-session-group-toggle",
+              );
               return {
                 focusWithin: element.matches(":focus-within"),
                 hovered: element.matches(":hover"),
-                toggleFocusVisible: toggle?.matches(":focus-visible") ?? false,
-                toggleFocused: document.activeElement === toggle,
+                toggleFocusVisible: focusedToggle?.matches(":focus-visible") ?? false,
+                toggleFocused: document.activeElement === focusedToggle,
               };
             }),
           )

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -198,6 +198,36 @@ function hostGroupedNativeCatalogs() {
   return { catalogs: [catalog("claude", "Claude Code"), catalog("codex", "Codex")] };
 }
 
+async function catalogHeaderAffordances(header: Locator) {
+  return header.evaluate((element) => {
+    const toggle = element.querySelector<HTMLElement>(".sidebar-session-group-toggle");
+    const providerIcon = element.querySelector<HTMLElement>(
+      ".sidebar-session-catalog-provider-icon",
+    );
+    const chevron = element.querySelector<HTMLElement>(".sidebar-session-group-toggle__icon");
+    const grip = element.querySelector<HTMLElement>(".sidebar-session-group-drag-handle");
+    const actions = element.querySelector<HTMLElement>(".sidebar-session-group-actions");
+    if (!toggle || !providerIcon || !chevron || !grip || !actions) {
+      throw new Error("expected complete branded catalog header affordances");
+    }
+    return {
+      actionFocusVisible: actions.matches(":focus-visible"),
+      actionFocused: document.activeElement === actions,
+      actionsOpacity: getComputedStyle(actions).opacity,
+      actionsPointerEvents: getComputedStyle(actions).pointerEvents,
+      chevronOpacity: getComputedStyle(chevron).opacity,
+      finePointer: matchMedia("(pointer: fine)").matches,
+      focusWithin: element.matches(":focus-within"),
+      gripOpacity: getComputedStyle(grip).opacity,
+      hoverCapable: matchMedia("(hover: hover)").matches,
+      hovered: element.matches(":hover"),
+      providerOpacity: getComputedStyle(providerIcon).opacity,
+      toggleFocusVisible: toggle.matches(":focus-visible"),
+      toggleFocused: document.activeElement === toggle,
+    };
+  });
+}
+
 async function expandCodingSection(page: Page) {
   const toggle = page.locator('[data-session-section="work"] .sidebar-session-group-toggle');
   await page.waitForFunction(() =>
@@ -225,6 +255,102 @@ async function openClaudeCatalogTerminal(page: Page) {
 }
 
 suite.define(() => {
+  it("shows catalog header affordances only for hover or keyboard-visible focus", async () => {
+    await suite.withPage(
+      { hasTouch: false, viewport: { width: 1440, height: 900 } },
+      async ({ page }) => {
+        await installMockGateway(page, {
+          featureMethods: [
+            "chat.metadata",
+            "chat.startup",
+            "sessions.catalog.list",
+            "sessions.groups.put",
+          ],
+          methodResponses: { "sessions.catalog.list": hostGroupedNativeCatalogs() },
+        });
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await expandCodingSection(page);
+
+        const header = page.locator(
+          '[data-session-section="catalog:claude"] .sidebar-recent-sessions__head',
+        );
+        const toggle = header.locator(".sidebar-session-group-toggle");
+        await header.hover();
+        await expect
+          .poll(() => catalogHeaderAffordances(header))
+          .toMatchObject({
+            actionsOpacity: "1",
+            actionsPointerEvents: "auto",
+            chevronOpacity: "0.75",
+            finePointer: true,
+            gripOpacity: "0.55",
+            hoverCapable: true,
+            hovered: true,
+            providerOpacity: "0",
+          });
+
+        await toggle.click();
+        await page.locator(".chat-main__conversation").hover({ position: { x: 40, y: 40 } });
+        await expect
+          .poll(() =>
+            header.evaluate((element) => {
+              const toggle = element.querySelector<HTMLElement>(".sidebar-session-group-toggle");
+              return {
+                focusWithin: element.matches(":focus-within"),
+                hovered: element.matches(":hover"),
+                toggleFocusVisible: toggle?.matches(":focus-visible") ?? false,
+                toggleFocused: document.activeElement === toggle,
+              };
+            }),
+          )
+          .toEqual({
+            focusWithin: true,
+            hovered: false,
+            toggleFocusVisible: false,
+            toggleFocused: true,
+          });
+
+        const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+        if (artifactDir) {
+          await fs.mkdir(artifactDir, { recursive: true });
+          await header.screenshot({
+            animations: "disabled",
+            path: path.join(artifactDir, "catalog-header-pointer-away.png"),
+          });
+        }
+
+        await expect
+          .poll(() => catalogHeaderAffordances(header))
+          .toMatchObject({
+            actionsOpacity: "0",
+            actionsPointerEvents: "none",
+            chevronOpacity: "0",
+            focusWithin: true,
+            gripOpacity: "0",
+            hovered: false,
+            providerOpacity: "1",
+            toggleFocusVisible: false,
+            toggleFocused: true,
+          });
+
+        await page.keyboard.press("Tab");
+        await expect
+          .poll(() => catalogHeaderAffordances(header))
+          .toMatchObject({
+            actionFocusVisible: true,
+            actionFocused: true,
+            actionsOpacity: "1",
+            actionsPointerEvents: "auto",
+            chevronOpacity: "0.75",
+            focusWithin: true,
+            gripOpacity: "0.55",
+            hovered: false,
+            providerOpacity: "0",
+          });
+      },
+    );
+  });
+
   it("groups Claude and Codex sessions by Gateway and paired-node host", async () => {
     const page = await suite.browser.newPage({
       hasTouch: true,

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1491,7 +1491,7 @@ html.openclaw-native-macos
 .sidebar-recent-sessions__head:hover
   .sidebar-session-group-toggle__lead--branded
   .sidebar-session-catalog-provider-icon,
-.sidebar-recent-sessions__head:focus-within
+.sidebar-recent-sessions__head:has(:focus-visible)
   .sidebar-session-group-toggle__lead--branded
   .sidebar-session-catalog-provider-icon {
   opacity: 0;
@@ -1500,7 +1500,7 @@ html.openclaw-native-macos
 .sidebar-recent-sessions__head:hover
   .sidebar-session-group-toggle__lead--branded
   .sidebar-session-group-toggle__icon,
-.sidebar-recent-sessions__head:focus-within
+.sidebar-recent-sessions__head:has(:focus-visible)
   .sidebar-session-group-toggle__lead--branded
   .sidebar-session-group-toggle__icon {
   opacity: 0.75;
@@ -1596,7 +1596,7 @@ html.openclaw-native-macos
 }
 
 .sidebar-recent-sessions__head--draggable:hover .sidebar-session-group-drag-handle,
-.sidebar-recent-sessions__head--draggable:focus-within .sidebar-session-group-drag-handle {
+.sidebar-recent-sessions__head--draggable:has(:focus-visible) .sidebar-session-group-drag-handle {
   opacity: 0.55;
 }
 
@@ -1650,7 +1650,7 @@ html.openclaw-native-macos
   stroke-linejoin: round;
 }
 
-/* Group header kebab: hidden until hover/focus like row actions, but always
+/* Group header kebab: hidden until hover/keyboard focus like row actions, but always
    reachable on touch pointers where hover does not exist. */
 .sidebar-session-group-actions {
   display: inline-flex;
@@ -1672,7 +1672,7 @@ html.openclaw-native-macos
 }
 
 .sidebar-recent-sessions__head:hover .sidebar-session-group-actions,
-.sidebar-recent-sessions__head:focus-within .sidebar-session-group-actions,
+.sidebar-recent-sessions__head:has(:focus-visible) .sidebar-session-group-actions,
 .sidebar-session-group-actions[aria-expanded="true"],
 .sidebar-session-group-actions.sidebar-session-sort--filtered {
   opacity: 1;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who clicked a Claude Code, Codex, OpenCode, or other sidebar session-group header would see its drag grip, disclosure chevron, and trailing action remain visible after moving the pointer away.

## Why This Change Was Made

The shared sidebar header now distinguishes ordinary pointer focus from keyboard-visible focus. Hover affordances clear when mouse hover ends, while touch fallbacks, open-menu visibility, filtered state, and keyboard Tab access remain intact.

## User Impact

Sidebar group controls no longer look stuck after expanding or collapsing a group with the mouse. Keyboard users can still Tab into the hidden header action and have the controls reveal normally.

## Evidence

Before — mouse click focus kept the hover affordances visible after pointer-away:

![Sidebar header before: drag grip, chevron, and action remain visible](https://github.com/user-attachments/assets/610e4f47-e593-4874-bb2f-303e5057b12c)

After — pointer-away restores the provider icon and hides the hover affordances:

![Sidebar header after: provider icon restored and hover controls hidden](https://github.com/user-attachments/assets/a8433ca2-d8ee-429d-ac7d-3ac56ed0989e)

Focused validation:

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/claude-sessions.e2e.test.ts -t 'shows catalog header affordances only for hover or keyboard-visible focus'` — 1 passed, 6 skipped.
- Source-blind browser validation — 4/4 clauses passed: hover reveal, mouse click plus pointer-away reset, keyboard Tab reveal, and fine-pointer mode.
- `./node_modules/.bin/oxfmt --check ui/src/styles/layout.css ui/src/e2e/claude-sessions.e2e.test.ts` — passed.
- `./node_modules/.bin/stylelint --config config/stylelint.config.mjs ui/src/styles/layout.css` — passed.
- `pnpm ui:build` — passed.
- `git diff --check` — passed.
- Codex autoreview — clean, no accepted/actionable findings.

The changed-file remote orchestrator could not acquire a ready Crabbox/Testbox provider, so the relevant browser, style, formatting, production-build, and source-blind checks were run locally as the trusted-source fallback.

AI-assisted: implementation and review used coding agents; the final diff and behavior were independently verified.
