### PR TITLE
fix: exact dated models work after gateway ready

### DIFF
--- a/extensions/anthropic/forward-compat-generation.test.ts
+++ b/extensions/anthropic/forward-compat-generation.test.ts
@@ -40,11 +40,31 @@ describe("unreleased Claude generations", () => {
     expect(resolveModel("claude-opus-4-8")?.params?.canonicalModelId).toBeUndefined();
   });
 
-  it("leaves pre-4.6 and snapshot-dated ids alone", () => {
+  it("does not mistake snapshot dates for minor versions", () => {
     // claude-opus-4-20250514 is 4.0; a naive parse reads 4.20 and would treat it
     // as newer than every released generation.
     expect(resolveModel("claude-opus-4-20250514")?.params?.canonicalModelId).toBeUndefined();
     expect(supportsClaudeAdaptiveThinking({ id: "claude-haiku-4-5-20251001" })).toBe(false);
+  });
+
+  it("clones released snapshot ids from their dateless manifest template", () => {
+    expect(resolveModel("claude-haiku-4-5-20251001")).toEqual({
+      id: "claude-haiku-4-5-20251001",
+      name: "claude-haiku-4-5-20251001",
+      provider: "anthropic",
+      api: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com",
+      reasoning: true,
+      input: ["text", "image"],
+      mediaInput: {
+        image: { maxSidePx: 1568, preferredSidePx: 1568, tokenMode: "provider" },
+      },
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200_000,
+      maxTokens: 64_000,
+      compat: { codeMode: "preferred" },
+    });
+    expect(resolveModel("claude-haiku-4-9-20251001")).toBeUndefined();
   });
 
   it("carries manifest catalog compat onto hand-built modern rows", () => {

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -477,6 +477,9 @@ function resolveAnthropicManifestModel(modelId: string): ProviderRuntimeModel | 
       if (api && baseUrl) {
         anthropicManifestModelIndex.set(model.id, {
           ...model,
+          input: model.input.filter(
+            (item): item is "text" | "image" => item === "text" || item === "image",
+          ),
           provider: PROVIDER_ID,
           api,
           baseUrl,

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -384,6 +384,33 @@ function resolveAnthropic46ForwardCompatModel(params: {
   });
 }
 
+function resolveAnthropicSnapshotModel(
+  ctx: ProviderResolveDynamicModelContext,
+): ProviderRuntimeModel | undefined {
+  const modelId = ctx.modelId.trim();
+  const normalizedModelId = normalizeLowercaseStringOrEmpty(modelId);
+  const match = /^(claude-[a-z0-9]+(?:-[a-z0-9]+)*)-\d{8}$/.exec(normalizedModelId);
+  if (
+    modelId !== normalizedModelId ||
+    normalizeLowercaseStringOrEmpty(ctx.provider) !== PROVIDER_ID ||
+    !match
+  ) {
+    return undefined;
+  }
+  const templateId = match[1]!;
+  const captured = cloneFirstTemplateModel({
+    providerId: PROVIDER_ID,
+    modelId,
+    templateIds: [templateId],
+    ctx,
+  });
+  if (captured) {
+    return captured;
+  }
+  const template = resolveAnthropicManifestModel(templateId);
+  return template ? { ...template, id: modelId, name: modelId } : undefined;
+}
+
 /** Newest Claude generation whose request contract this plugin encodes. */
 const ANTHROPIC_NEWEST_KNOWN_GENERATION = { major: 5, minor: 0 } as const;
 
@@ -436,28 +463,37 @@ function resolveAnthropicUnreleasedCanonicalModelId(modelId: string): string {
   return /(?:^|-)claude-sonnet-/.test(modelId) ? "claude-sonnet-5" : "claude-opus-5";
 }
 
-// Lazily indexed manifest compat per provider so hand-built dynamic rows keep
-// catalog capability metadata even when the run's model registry is empty
-// (for example env-key-only runs without a generated models.json).
-let anthropicManifestCompatIndex: Map<string, ModelCompatConfig> | undefined;
+// Dynamic rows use the manifest as the provider-owned offline contract when a lifecycle registry
+// has no template yet. Keeping one normalized index avoids reparsing catalog metadata per run.
+let anthropicManifestModelIndex: Map<string, ProviderRuntimeModel> | undefined;
+
+function resolveAnthropicManifestModel(modelId: string): ProviderRuntimeModel | undefined {
+  if (!anthropicManifestModelIndex) {
+    anthropicManifestModelIndex = new Map();
+    const catalog = buildAnthropicCatalogProvider();
+    for (const model of catalog.models ?? []) {
+      const api = model.api ?? catalog.api;
+      const baseUrl = model.baseUrl ?? catalog.baseUrl;
+      if (api && baseUrl) {
+        anthropicManifestModelIndex.set(model.id, {
+          ...model,
+          provider: PROVIDER_ID,
+          api,
+          baseUrl,
+        });
+      }
+    }
+  }
+  return anthropicManifestModelIndex.get(modelId);
+}
 
 function resolveAnthropicManifestCompat(
   provider: string,
   modelId: string,
 ): ModelCompatConfig | undefined {
-  if (!anthropicManifestCompatIndex) {
-    anthropicManifestCompatIndex = new Map();
-    const providers = manifest.modelCatalog?.providers ?? {};
-    for (const [providerId, catalog] of Object.entries(providers)) {
-      for (const model of catalog.models ?? []) {
-        const compat = (model as { compat?: ModelCompatConfig }).compat;
-        if (compat) {
-          anthropicManifestCompatIndex.set(`${providerId}/${model.id}`, compat);
-        }
-      }
-    }
-  }
-  return anthropicManifestCompatIndex.get(`${provider}/${modelId}`);
+  return normalizeLowercaseStringOrEmpty(provider) === PROVIDER_ID
+    ? resolveAnthropicManifestModel(modelId)?.compat
+    : undefined;
 }
 
 function buildAnthropicForwardCompatModel(
@@ -528,6 +564,7 @@ function resolveAnthropicForwardCompatModel(
   ctx: ProviderResolveDynamicModelContext,
 ): ProviderRuntimeModel | undefined {
   return (
+    resolveAnthropicSnapshotModel(ctx) ??
     resolveAnthropic46ForwardCompatModel({
       ctx,
       dashModelId: ANTHROPIC_OPUS_48_MODEL_ID,

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -363,7 +363,7 @@ async function buildSnapshotBatch(
   }
   const registryMs = performance.now() - registryStartedAt;
   const preparedAgentFacts = [...preparedInputs.values()];
-  const configuredRuntimeModelCount = preparedAgentFacts.reduce(
+  const configuredRuntimeModelCount = [...preparedCatalogs.values()].reduce(
     (count, facts) => count + facts.configuredRuntimeModels.length,
     0,
   );

--- a/src/agents/prepared-model-runtime.configured-catalog.ts
+++ b/src/agents/prepared-model-runtime.configured-catalog.ts
@@ -1,24 +1,37 @@
+import type { ConfiguredModelRef } from "@openclaw/model-catalog-core/configured-model-refs";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import type { InlineModelEntry } from "./embedded-agent-runner/model.inline-provider.js";
 import type { ModelCatalogEntry } from "./model-catalog.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import {
   toStaticCatalogEntry,
   type PreparedConfiguredRuntimeModel,
 } from "./prepared-model-runtime.configured.js";
-import type {
-  PreparedModelRuntimeAgentFacts,
-  PreparedModelRuntimeCatalogFacts,
-  PreparedModelRuntimeWorkspaceFacts,
-} from "./prepared-model-runtime.facts.js";
 import type { ModelRegistry } from "./sessions/model-registry.js";
+
+type ConfiguredCatalogAgentFacts = {
+  configuredModelRefs: readonly ConfiguredModelRef[];
+};
+
+type ConfiguredCatalogWorkspaceFacts = {
+  configuredCatalogEntries: readonly ModelCatalogEntry[];
+  inlineProviderModels: readonly InlineModelEntry[];
+};
+
+type ConfiguredRuntimeFacts = {
+  templateModelRegistry: ModelRegistry;
+  modelCatalog: ModelCatalogSnapshot;
+  configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
+  inlineProviderModels: readonly InlineModelEntry[];
+};
 
 export function modelCatalogEntryKey(entry: Pick<ModelCatalogEntry, "id" | "provider">): string {
   return `${normalizeProviderId(entry.provider)}\0${entry.id.trim().toLowerCase()}`;
 }
 
 function createConfiguredModelCatalogSnapshot(params: {
-  agentFacts: PreparedModelRuntimeAgentFacts;
-  workspaceFacts: PreparedModelRuntimeWorkspaceFacts;
+  agentFacts: ConfiguredCatalogAgentFacts;
+  workspaceFacts: ConfiguredCatalogWorkspaceFacts;
   templateModelRegistry: ModelRegistry;
   configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
 }): ModelCatalogSnapshot {
@@ -62,11 +75,11 @@ function createConfiguredModelCatalogSnapshot(params: {
 }
 
 export function prepareConfiguredRuntimeFacts(params: {
-  agentFacts: PreparedModelRuntimeAgentFacts;
-  workspaceFacts: PreparedModelRuntimeWorkspaceFacts;
+  agentFacts: ConfiguredCatalogAgentFacts;
+  workspaceFacts: ConfiguredCatalogWorkspaceFacts;
   templateModelRegistry: ModelRegistry;
   configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
-}): PreparedModelRuntimeCatalogFacts {
+}): ConfiguredRuntimeFacts {
   return {
     templateModelRegistry: params.templateModelRegistry,
     modelCatalog: createConfiguredModelCatalogSnapshot(params),

--- a/src/agents/prepared-model-runtime.configured-catalog.ts
+++ b/src/agents/prepared-model-runtime.configured-catalog.ts
@@ -1,0 +1,76 @@
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import type { ModelCatalogEntry } from "./model-catalog.js";
+import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
+import {
+  toStaticCatalogEntry,
+  type PreparedConfiguredRuntimeModel,
+} from "./prepared-model-runtime.configured.js";
+import type {
+  PreparedModelRuntimeAgentFacts,
+  PreparedModelRuntimeCatalogFacts,
+  PreparedModelRuntimeWorkspaceFacts,
+} from "./prepared-model-runtime.facts.js";
+import type { ModelRegistry } from "./sessions/model-registry.js";
+
+export function modelCatalogEntryKey(entry: Pick<ModelCatalogEntry, "id" | "provider">): string {
+  return `${normalizeProviderId(entry.provider)}\0${entry.id.trim().toLowerCase()}`;
+}
+
+function createConfiguredModelCatalogSnapshot(params: {
+  agentFacts: PreparedModelRuntimeAgentFacts;
+  workspaceFacts: PreparedModelRuntimeWorkspaceFacts;
+  templateModelRegistry: ModelRegistry;
+  configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
+}): ModelCatalogSnapshot {
+  const entries = new Map<string, ModelCatalogEntry>();
+  const addEntry = (entry: ModelCatalogEntry) => {
+    const key = modelCatalogEntryKey(entry);
+    if (!entries.has(key)) {
+      entries.set(key, entry);
+    }
+  };
+  for (const entry of params.workspaceFacts.configuredCatalogEntries) {
+    addEntry(entry);
+  }
+  for (const configured of params.configuredRuntimeModels) {
+    addEntry(toStaticCatalogEntry(configured.model));
+  }
+  for (const { value } of params.agentFacts.configuredModelRefs) {
+    const separator = value.indexOf("/");
+    if (separator <= 0 || separator >= value.length - 1) {
+      continue;
+    }
+    const provider = normalizeProviderId(value.slice(0, separator));
+    const modelId = value.slice(separator + 1).trim();
+    if (!provider || !modelId) {
+      continue;
+    }
+    const model = params.templateModelRegistry.find(provider, modelId);
+    if (model) {
+      addEntry(toStaticCatalogEntry(model));
+    }
+  }
+  const configuredEntries = [...entries.values()];
+  const staticEntries = params.configuredRuntimeModels.map(({ model }) =>
+    toStaticCatalogEntry(model),
+  );
+  return {
+    entries: configuredEntries,
+    routeVariants: configuredEntries,
+    ...(staticEntries.length > 0 ? { staticEntries } : {}),
+  };
+}
+
+export function prepareConfiguredRuntimeFacts(params: {
+  agentFacts: PreparedModelRuntimeAgentFacts;
+  workspaceFacts: PreparedModelRuntimeWorkspaceFacts;
+  templateModelRegistry: ModelRegistry;
+  configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
+}): PreparedModelRuntimeCatalogFacts {
+  return {
+    templateModelRegistry: params.templateModelRegistry,
+    modelCatalog: createConfiguredModelCatalogSnapshot(params),
+    configuredRuntimeModels: params.configuredRuntimeModels,
+    inlineProviderModels: params.workspaceFacts.inlineProviderModels,
+  };
+}

--- a/src/agents/prepared-model-runtime.configured-completion.ts
+++ b/src/agents/prepared-model-runtime.configured-completion.ts
@@ -1,0 +1,42 @@
+import type { ConfiguredModelRef } from "@openclaw/model-catalog-core/configured-model-refs";
+import {
+  buildModelCatalogMergeKey,
+  parseModelCatalogRef,
+} from "@openclaw/model-catalog-core/model-catalog-refs";
+import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
+import type { PreparedConfiguredRuntimeModel } from "./prepared-model-runtime.configured.js";
+
+export function completeConfiguredRuntimeModels(params: {
+  configuredModelRefs: readonly ConfiguredModelRef[];
+  configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
+  resolveDynamicModel: (lookup: {
+    provider: string;
+    modelId: string;
+  }) => ProviderRuntimeModel | undefined;
+}): PreparedConfiguredRuntimeModel[] {
+  const existing = new Map(
+    params.configuredRuntimeModels.map((configured) => [
+      buildModelCatalogMergeKey(configured.provider, configured.modelId),
+      configured,
+    ]),
+  );
+  const completed: PreparedConfiguredRuntimeModel[] = [];
+  const seen = new Set<string>();
+  for (const { value } of params.configuredModelRefs) {
+    const parsed = parseModelCatalogRef(value);
+    if (!parsed) {
+      continue;
+    }
+    const key = buildModelCatalogMergeKey(parsed.provider, parsed.modelId);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    const prepared = existing.get(key);
+    const model = prepared?.model ?? params.resolveDynamicModel(parsed);
+    if (model) {
+      completed.push({ provider: parsed.provider, modelId: parsed.modelId, model });
+    }
+  }
+  return completed;
+}

--- a/src/agents/prepared-model-runtime.configured.ts
+++ b/src/agents/prepared-model-runtime.configured.ts
@@ -201,41 +201,6 @@ export function prepareConfiguredRuntimeModels(params: {
   return prepared;
 }
 
-export function completeConfiguredRuntimeModels(params: {
-  configuredModelRefs: readonly ConfiguredModelRef[];
-  configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
-  resolveDynamicModel: (lookup: {
-    provider: string;
-    modelId: string;
-  }) => ProviderRuntimeModel | undefined;
-}): PreparedConfiguredRuntimeModel[] {
-  const existing = new Map(
-    params.configuredRuntimeModels.map((configured) => [
-      buildModelCatalogMergeKey(configured.provider, configured.modelId),
-      configured,
-    ]),
-  );
-  const completed: PreparedConfiguredRuntimeModel[] = [];
-  const seen = new Set<string>();
-  for (const { value } of params.configuredModelRefs) {
-    const parsed = parseModelCatalogRef(value);
-    if (!parsed) {
-      continue;
-    }
-    const key = buildModelCatalogMergeKey(parsed.provider, parsed.modelId);
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    const prepared = existing.get(key);
-    const model = prepared?.model ?? params.resolveDynamicModel(parsed);
-    if (model) {
-      completed.push({ provider: parsed.provider, modelId: parsed.modelId, model });
-    }
-  }
-  return completed;
-}
-
 function findPreparedProviderStaticCatalogModel(params: {
   prepared: PreparedProviderStaticCatalog | undefined;
   metadataSnapshot: PluginMetadataSnapshot;

--- a/src/agents/prepared-model-runtime.configured.ts
+++ b/src/agents/prepared-model-runtime.configured.ts
@@ -2,6 +2,10 @@ import {
   collectConfiguredModelRefs,
   type ConfiguredModelRef,
 } from "@openclaw/model-catalog-core/configured-model-refs";
+import {
+  buildModelCatalogMergeKey,
+  parseModelCatalogRef,
+} from "@openclaw/model-catalog-core/model-catalog-refs";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { MODEL_APIS } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -125,15 +129,12 @@ export function collectConfiguredProviderIdsNeedingStaticCatalog(params: {
 }): string[] {
   const providerIds = new Set<string>();
   for (const { value } of params.configuredModelRefs ?? collectConfiguredModelRefs(params.config)) {
-    const separator = value.indexOf("/");
-    if (separator <= 0 || separator >= value.length - 1) {
+    const parsed = parseModelCatalogRef(value);
+    if (!parsed) {
       continue;
     }
-    const provider = normalizeProviderId(value.slice(0, separator));
-    const modelId = value.slice(separator + 1).trim();
+    const { provider, modelId } = parsed;
     if (
-      !provider ||
-      !modelId ||
       hasConfiguredInlineProviderModel(
         params.config,
         provider,
@@ -164,16 +165,12 @@ export function prepareConfiguredRuntimeModels(params: {
   const prepared: PreparedConfiguredRuntimeModel[] = [];
   const seen = new Set<string>();
   for (const { value } of params.configuredModelRefs ?? collectConfiguredModelRefs(params.config)) {
-    const separator = value.indexOf("/");
-    if (separator <= 0 || separator >= value.length - 1) {
+    const parsed = parseModelCatalogRef(value);
+    if (!parsed) {
       continue;
     }
-    const provider = normalizeProviderId(value.slice(0, separator));
-    const modelId = value.slice(separator + 1).trim();
-    if (!provider || !modelId) {
-      continue;
-    }
-    const key = `${provider}\0${modelId.toLowerCase()}`;
+    const { modelId, provider } = parsed;
+    const key = buildModelCatalogMergeKey(provider, modelId);
     if (seen.has(key)) {
       continue;
     }
@@ -202,6 +199,41 @@ export function prepareConfiguredRuntimeModels(params: {
     }
   }
   return prepared;
+}
+
+export function completeConfiguredRuntimeModels(params: {
+  configuredModelRefs: readonly ConfiguredModelRef[];
+  configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
+  resolveDynamicModel: (lookup: {
+    provider: string;
+    modelId: string;
+  }) => ProviderRuntimeModel | undefined;
+}): PreparedConfiguredRuntimeModel[] {
+  const existing = new Map(
+    params.configuredRuntimeModels.map((configured) => [
+      buildModelCatalogMergeKey(configured.provider, configured.modelId),
+      configured,
+    ]),
+  );
+  const completed: PreparedConfiguredRuntimeModel[] = [];
+  const seen = new Set<string>();
+  for (const { value } of params.configuredModelRefs) {
+    const parsed = parseModelCatalogRef(value);
+    if (!parsed) {
+      continue;
+    }
+    const key = buildModelCatalogMergeKey(parsed.provider, parsed.modelId);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    const prepared = existing.get(key);
+    const model = prepared?.model ?? params.resolveDynamicModel(parsed);
+    if (model) {
+      completed.push({ provider: parsed.provider, modelId: parsed.modelId, model });
+    }
+  }
+  return completed;
 }
 
 function findPreparedProviderStaticCatalogModel(params: {

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -20,8 +20,8 @@ import {
   getPreparedMessageToolCatalogForRegistry,
 } from "../plugins/prepared-message-tool-catalog.js";
 import type { PreparedProviderStaticCatalog } from "../plugins/provider-discovery.js";
+import { resolveLoadedProviderRuntimePlugin } from "../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
-import { runProviderDynamicModel } from "../plugins/provider-runtime.js";
 import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../plugins/synthetic-auth.runtime.js";
 import type { AgentCredentialMap } from "./agent-auth-credentials.js";
@@ -697,20 +697,20 @@ export function prepareConfiguredRuntimeFactsBatch(params: {
                 const providerConfig =
                   input.config.models?.providers?.[provider] ??
                   findNormalizedProviderValue(input.config.models?.providers, provider);
-                return runProviderDynamicModel({
+                return resolveLoadedProviderRuntimePlugin({
                   provider,
+                  modelId,
                   config: input.config,
                   workspaceDir: input.workspaceDir,
                   env: facts.env,
-                  context: {
-                    config: input.config,
-                    agentDir: input.agentDir,
-                    workspaceDir: input.workspaceDir,
-                    provider,
-                    modelId,
-                    modelRegistry: templateModelRegistry,
-                    providerConfig,
-                  },
+                })?.resolveDynamicModel?.({
+                  config: input.config,
+                  agentDir: input.agentDir,
+                  workspaceDir: input.workspaceDir,
+                  provider,
+                  modelId,
+                  modelRegistry: templateModelRegistry,
+                  providerConfig,
                 });
               },
             })

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -3,10 +3,6 @@ import path from "node:path";
 import { performance } from "node:perf_hooks";
 import type { ConfiguredModelRef } from "@openclaw/model-catalog-core/configured-model-refs";
 import {
-  buildModelCatalogMergeKey,
-  parseModelCatalogRef,
-} from "@openclaw/model-catalog-core/model-catalog-refs";
-import {
   findNormalizedProviderValue,
   normalizeProviderId,
 } from "@openclaw/model-catalog-core/provider-id";
@@ -50,6 +46,11 @@ import {
   resolvePluginModelCatalogOwnerPluginId,
   type PersistedPluginModelCatalog,
 } from "./plugin-model-catalog.js";
+import {
+  modelCatalogEntryKey,
+  prepareConfiguredRuntimeFacts,
+} from "./prepared-model-runtime.configured-catalog.js";
+import { completeConfiguredRuntimeModels } from "./prepared-model-runtime.configured-completion.js";
 import {
   collectPreparedModelRuntimeConfiguredRefs,
   collectConfiguredProviderIdsNeedingStaticCatalog,
@@ -473,76 +474,6 @@ export function isPreparedModelCatalogFull(snapshot: ModelCatalogSnapshot): bool
   return fullModelCatalogSnapshots.has(snapshot);
 }
 
-function modelCatalogEntryKey(entry: Pick<ModelCatalogEntry, "id" | "provider">): string {
-  return `${normalizeProviderId(entry.provider)}\0${entry.id.trim().toLowerCase()}`;
-}
-
-function createConfiguredModelCatalogSnapshot(params: {
-  agentFacts: PreparedModelRuntimeAgentFacts;
-  workspaceFacts: PreparedModelRuntimeWorkspaceFacts;
-  templateModelRegistry: ModelRegistry;
-  configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
-}): ModelCatalogSnapshot {
-  const entries = new Map<string, ModelCatalogEntry>();
-  const addEntry = (entry: ModelCatalogEntry) => {
-    const key = modelCatalogEntryKey(entry);
-    if (!entries.has(key)) {
-      entries.set(key, entry);
-    }
-  };
-  for (const entry of params.workspaceFacts.configuredCatalogEntries) {
-    addEntry(entry);
-  }
-  for (const configured of params.configuredRuntimeModels) {
-    addEntry(toStaticCatalogEntry(configured.model));
-  }
-  for (const { value } of params.agentFacts.configuredModelRefs) {
-    const separator = value.indexOf("/");
-    if (separator <= 0 || separator >= value.length - 1) {
-      continue;
-    }
-    const provider = normalizeProviderId(value.slice(0, separator));
-    const modelId = value.slice(separator + 1).trim();
-    if (!provider || !modelId) {
-      continue;
-    }
-    const model = params.templateModelRegistry.find(provider, modelId);
-    if (model) {
-      addEntry(toStaticCatalogEntry(model));
-    }
-  }
-  const configuredEntries = [...entries.values()];
-  const staticEntries = params.configuredRuntimeModels.map(({ model }) =>
-    toStaticCatalogEntry(model),
-  );
-  return {
-    entries: configuredEntries,
-    routeVariants: configuredEntries,
-    ...(staticEntries.length > 0 ? { staticEntries } : {}),
-  };
-}
-
-function prepareConfiguredRuntimeFacts(
-  agentFacts: PreparedModelRuntimeAgentFacts,
-  workspaceFacts: PreparedModelRuntimeWorkspaceFacts,
-  sharedTemplateModelRegistry: ModelRegistry,
-  configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[],
-): PreparedModelRuntimeCatalogFacts {
-  const { inlineProviderModels } = workspaceFacts;
-  const templateModelRegistry = sharedTemplateModelRegistry;
-  return {
-    templateModelRegistry,
-    modelCatalog: createConfiguredModelCatalogSnapshot({
-      agentFacts,
-      workspaceFacts,
-      templateModelRegistry,
-      configuredRuntimeModels,
-    }),
-    configuredRuntimeModels,
-    inlineProviderModels,
-  };
-}
-
 function captureModelsJsonContents(agentDir: string): string | null {
   try {
     return fs.readFileSync(path.join(agentDir, "models.json"), "utf8");
@@ -619,41 +550,6 @@ function groupConfiguredRegistrySources(
   return [...groups.values()].flat();
 }
 
-function completeConfiguredRuntimeModels(params: {
-  configuredModelRefs: readonly ConfiguredModelRef[];
-  configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
-  resolveDynamicModel: (lookup: {
-    provider: string;
-    modelId: string;
-  }) => ProviderRuntimeModel | undefined;
-}): PreparedConfiguredRuntimeModel[] {
-  const existing = new Map(
-    params.configuredRuntimeModels.map((configured) => [
-      buildModelCatalogMergeKey(configured.provider, configured.modelId),
-      configured,
-    ]),
-  );
-  const completed: PreparedConfiguredRuntimeModel[] = [];
-  const seen = new Set<string>();
-  for (const { value } of params.configuredModelRefs) {
-    const parsed = parseModelCatalogRef(value);
-    if (!parsed) {
-      continue;
-    }
-    const key = buildModelCatalogMergeKey(parsed.provider, parsed.modelId);
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    const prepared = existing.get(key);
-    const model = prepared?.model ?? params.resolveDynamicModel(parsed);
-    if (model) {
-      completed.push({ provider: parsed.provider, modelId: parsed.modelId, model });
-    }
-  }
-  return completed;
-}
-
 export function prepareConfiguredRuntimeFactsBatch(params: {
   agentFacts: readonly PreparedModelRuntimeAgentFacts[];
   workspaceFacts: PreparedModelRuntimeWorkspaceFacts;
@@ -697,32 +593,34 @@ export function prepareConfiguredRuntimeFactsBatch(params: {
                 const providerConfig =
                   input.config.models?.providers?.[provider] ??
                   findNormalizedProviderValue(input.config.models?.providers, provider);
-                return resolveLoadedProviderRuntimePlugin({
-                  provider,
-                  modelId,
-                  config: input.config,
-                  workspaceDir: input.workspaceDir,
-                  env: facts.env,
-                })?.resolveDynamicModel?.({
-                  config: input.config,
-                  agentDir: input.agentDir,
-                  workspaceDir: input.workspaceDir,
-                  provider,
-                  modelId,
-                  modelRegistry: templateModelRegistry,
-                  providerConfig,
-                });
+                return (
+                  resolveLoadedProviderRuntimePlugin({
+                    provider,
+                    modelId,
+                    config: input.config,
+                    workspaceDir: input.workspaceDir,
+                    env: facts.env,
+                  })?.resolveDynamicModel?.({
+                    config: input.config,
+                    agentDir: input.agentDir,
+                    workspaceDir: input.workspaceDir,
+                    provider,
+                    modelId,
+                    modelRegistry: templateModelRegistry,
+                    providerConfig,
+                  }) ?? undefined
+                );
               },
             })
           : facts.configuredRuntimeModels;
         catalogs.set(
           input,
-          prepareConfiguredRuntimeFacts(
-            facts,
-            params.workspaceFacts,
+          prepareConfiguredRuntimeFacts({
+            agentFacts: facts,
+            workspaceFacts: params.workspaceFacts,
             templateModelRegistry,
             configuredRuntimeModels,
-          ),
+          }),
         );
       }
     });

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -2,7 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import type { ConfiguredModelRef } from "@openclaw/model-catalog-core/configured-model-refs";
-import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import {
+  findNormalizedProviderValue,
+  normalizeProviderId,
+} from "@openclaw/model-catalog-core/provider-id";
 import { stableStringify } from "@openclaw/normalization-core";
 import type { PreparedMessageToolCatalog } from "../channels/plugins/message-action-discovery.js";
 import { sha256Base64Url } from "../infra/crypto-digest.js";
@@ -14,6 +17,7 @@ import {
 } from "../plugins/prepared-message-tool-catalog.js";
 import type { PreparedProviderStaticCatalog } from "../plugins/provider-discovery.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
+import { runProviderDynamicModel } from "../plugins/provider-runtime.js";
 import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../plugins/synthetic-auth.runtime.js";
 import type { AgentCredentialMap } from "./agent-auth-credentials.js";
@@ -43,6 +47,7 @@ import {
   type PersistedPluginModelCatalog,
 } from "./plugin-model-catalog.js";
 import {
+  completeConfiguredRuntimeModels,
   collectPreparedModelRuntimeConfiguredRefs,
   collectConfiguredProviderIdsNeedingStaticCatalog,
   collectPreparedModelRuntimeProviderIds,
@@ -518,8 +523,8 @@ function prepareConfiguredRuntimeFacts(
   agentFacts: PreparedModelRuntimeAgentFacts,
   workspaceFacts: PreparedModelRuntimeWorkspaceFacts,
   sharedTemplateModelRegistry: ModelRegistry,
+  configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[],
 ): PreparedModelRuntimeCatalogFacts {
-  const { configuredRuntimeModels } = agentFacts;
   const { inlineProviderModels } = workspaceFacts;
   const templateModelRegistry = sharedTemplateModelRegistry;
   return {
@@ -641,12 +646,48 @@ export function prepareConfiguredRuntimeFactsBatch(params: {
       },
     );
     registryCount += 1;
-    for (const facts of group.agentFacts) {
-      catalogs.set(
-        facts.input,
-        prepareConfiguredRuntimeFacts(facts, params.workspaceFacts, templateModelRegistry),
-      );
-    }
+    // The captured registry exists only after agent-owned catalog parsing. Complete static misses
+    // here so turn facts stay within this lifecycle generation without starting live discovery.
+    withPluginRuntimeRegistryScope(params.workspaceFacts.pluginRegistry, () => {
+      for (const facts of group.agentFacts) {
+        const { input } = facts;
+        const configuredRuntimeModels = params.workspaceFacts.pluginRegistry
+          ? completeConfiguredRuntimeModels({
+              configuredModelRefs: facts.configuredModelRefs,
+              configuredRuntimeModels: facts.configuredRuntimeModels,
+              resolveDynamicModel: ({ provider, modelId }) => {
+                const providerConfig =
+                  input.config.models?.providers?.[provider] ??
+                  findNormalizedProviderValue(input.config.models?.providers, provider);
+                return runProviderDynamicModel({
+                  provider,
+                  config: input.config,
+                  workspaceDir: input.workspaceDir,
+                  env: facts.env,
+                  context: {
+                    config: input.config,
+                    agentDir: input.agentDir,
+                    workspaceDir: input.workspaceDir,
+                    provider,
+                    modelId,
+                    modelRegistry: templateModelRegistry,
+                    providerConfig,
+                  },
+                });
+              },
+            })
+          : facts.configuredRuntimeModels;
+        catalogs.set(
+          input,
+          prepareConfiguredRuntimeFacts(
+            facts,
+            params.workspaceFacts,
+            templateModelRegistry,
+            configuredRuntimeModels,
+          ),
+        );
+      }
+    });
   }
   return { catalogs, registryCount };
 }

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -3,6 +3,10 @@ import path from "node:path";
 import { performance } from "node:perf_hooks";
 import type { ConfiguredModelRef } from "@openclaw/model-catalog-core/configured-model-refs";
 import {
+  buildModelCatalogMergeKey,
+  parseModelCatalogRef,
+} from "@openclaw/model-catalog-core/model-catalog-refs";
+import {
   findNormalizedProviderValue,
   normalizeProviderId,
 } from "@openclaw/model-catalog-core/provider-id";
@@ -47,7 +51,6 @@ import {
   type PersistedPluginModelCatalog,
 } from "./plugin-model-catalog.js";
 import {
-  completeConfiguredRuntimeModels,
   collectPreparedModelRuntimeConfiguredRefs,
   collectConfiguredProviderIdsNeedingStaticCatalog,
   collectPreparedModelRuntimeProviderIds,
@@ -614,6 +617,41 @@ function groupConfiguredRegistrySources(
     }
   }
   return [...groups.values()].flat();
+}
+
+function completeConfiguredRuntimeModels(params: {
+  configuredModelRefs: readonly ConfiguredModelRef[];
+  configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
+  resolveDynamicModel: (lookup: {
+    provider: string;
+    modelId: string;
+  }) => ProviderRuntimeModel | undefined;
+}): PreparedConfiguredRuntimeModel[] {
+  const existing = new Map(
+    params.configuredRuntimeModels.map((configured) => [
+      buildModelCatalogMergeKey(configured.provider, configured.modelId),
+      configured,
+    ]),
+  );
+  const completed: PreparedConfiguredRuntimeModel[] = [];
+  const seen = new Set<string>();
+  for (const { value } of params.configuredModelRefs) {
+    const parsed = parseModelCatalogRef(value);
+    if (!parsed) {
+      continue;
+    }
+    const key = buildModelCatalogMergeKey(parsed.provider, parsed.modelId);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    const prepared = existing.get(key);
+    const model = prepared?.model ?? params.resolveDynamicModel(parsed);
+    if (model) {
+      completed.push({ provider: parsed.provider, modelId: parsed.modelId, model });
+    }
+  }
+  return completed;
 }
 
 export function prepareConfiguredRuntimeFactsBatch(params: {

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -409,6 +409,107 @@ describe("prepared model runtime Gateway catalog mode", () => {
     expect(mocks.discoverModels).toHaveBeenCalledTimes(3);
   });
 
+  it("publishes exact dynamic configured models without building a live catalog", async () => {
+    const provider = "fixture-provider";
+    const modelId = "fixture-model-2026-08-09";
+    const registry = createEmptyPluginRegistry();
+    const resolveDynamicModel = vi.fn(
+      (context: { provider: string; modelId: string; modelRegistry: unknown }) => ({
+        id: context.modelId,
+        name: "Fixture dated model",
+        provider: context.provider,
+        api: "openai-responses" as const,
+        baseUrl: "https://fixture.invalid/v1",
+        reasoning: false,
+        input: ["text" as const],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 64_000,
+        maxTokens: 8_192,
+      }),
+    );
+    registry.providers.push({
+      pluginId: provider,
+      provider: { id: provider, label: "Fixture provider", auth: [], resolveDynamicModel },
+      source: "test",
+    });
+    mocks.loadAgentRuntimePluginRegistryHandle.mockReturnValue(registry);
+    const providerConfig = {
+      api: "openai-responses" as const,
+      baseUrl: "https://configured.fixture.invalid/v1",
+      models: [],
+    };
+    const config = {
+      models: { providers: { [provider]: providerConfig } },
+      agents: {
+        defaults: {
+          model: {
+            primary: `${provider}/${modelId}`,
+            fallbacks: ["openai/gpt-5.5", `${provider}/${modelId}`],
+          },
+        },
+      },
+    };
+
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+
+    expect(resolveDynamicModel).toHaveBeenCalledOnce();
+    expect(mocks.discoverModels.mock.invocationCallOrder[0]).toBeLessThan(
+      resolveDynamicModel.mock.invocationCallOrder[0]!,
+    );
+    expect(resolveDynamicModel).toHaveBeenCalledWith({
+      config,
+      agentDir: "/tmp/prepared-static-agent",
+      workspaceDir: "/tmp/prepared-static-workspace",
+      provider,
+      modelId,
+      modelRegistry: mocks.modelRegistry,
+      providerConfig,
+    });
+    const snapshot = getPreparedModelRuntimeSnapshot({
+      agentId: "default",
+      config,
+      agentDir: "/tmp/prepared-static-agent",
+      inheritedAuthDir: "/tmp/prepared-static-agent",
+      workspaceDir: "/tmp/prepared-static-workspace",
+    });
+    expect(
+      snapshot?.configuredRuntimeModels.map(
+        (configured) => `${configured.provider}/${configured.modelId}`,
+      ),
+    ).toEqual([`${provider}/${modelId}`, "openai/gpt-5.5"]);
+    expect(snapshot?.configuredRuntimeModels[0]?.model).toMatchObject({
+      provider,
+      id: modelId,
+      name: "Fixture dated model",
+      api: "openai-responses",
+      baseUrl: "https://fixture.invalid/v1",
+    });
+    for (const entries of [
+      snapshot?.modelCatalog.entries,
+      snapshot?.modelCatalog.routeVariants,
+      snapshot?.modelCatalog.staticEntries,
+    ]) {
+      expect(entries?.map((entry) => `${entry.provider}/${entry.id}`)).toEqual([
+        `${provider}/${modelId}`,
+        "openai/gpt-5.5",
+      ]);
+    }
+    expect(mocks.prepareStaticCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerDiscoveryProviderIds: [provider, "openai"],
+        staticCatalogProviderIds: [provider, "openai"],
+      }),
+    );
+    expect(mocks.discoverModels).toHaveBeenCalledOnce();
+    expect(mocks.buildPreparedModelCatalogSnapshot).not.toHaveBeenCalled();
+    expect(mocks.loadStaticCatalog).not.toHaveBeenCalled();
+    expect(mocks.planOpenClawModelsJsonSource).not.toHaveBeenCalled();
+    expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
+  });
+
   it("does not request a static provider hook when manifest facts resolve the configured model", async () => {
     mocks.resolveStaticCatalogModel.mockReturnValue({
       id: "gpt-5.5",


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where the gateway's static prepared runtime could publish before an exact configured provider model became executable. The main session and scheduled heartbeat lane could then repeatedly report `Unknown model` even while `models.list` and live discovery said that exact model was available.

## Why This Change Was Made

The prepared model-runtime owner is the authoritative completion boundary. Once the captured `ModelRegistry` exists, it now completes unresolved configured refs through the selected provider's synchronous, side-effect-free resolver under the owned plugin registry and publishes that exact model in `configuredRuntimeModels` and the static catalog.

Anthropic now clones snapshot-dated IDs from a matching dateless manifest template while preserving the exact configured ID. This avoids both live startup network catalog work and rolling-alias rewrites.

## User Impact

Operators can pin an exact dated provider model and use it immediately after gateway readiness. The same pin remains executable across scheduled heartbeat and main-session turns instead of degrading into repeated `Unknown model` failures.

Release-note context: exact dated model pins now become executable before the gateway publishes its prepared static runtime and remain stable across heartbeat and main-session turns.

## Evidence

- Focused regression tests: `node scripts/run-vitest.mjs src/agents/prepared-model-runtime.startup-static.test.ts extensions/anthropic/forward-compat-generation.test.ts` passed 6 agent tests and 10 Anthropic tests across 2 shards.
- `git diff --check` passed.
- Two fresh Codex autoreview runs passed. The final review had no accepted or actionable findings and rated the change correct with 0.98 confidence.
- The first exact-head CI run, [31323720693](https://github.com/openclaw/openclaw/actions/runs/31323720693), failed only on the compile and API-surface fallout from the initial refactor: Anthropic manifest input capabilities were wider than `ProviderRuntimeModel`, and the prepared completion helper had accidentally become exported from the configured-runtime module, drifting the plugin SDK baseline.
- The follow-up narrows manifest model input to the supported `text`/`image` contract and keeps the completion helper private to its sole prepared-facts lifecycle owner. Post-fix proof passed all 16 focused tests across 2 shards, `pnpm plugin-sdk:surface:check`, `pnpm plugin-sdk:api:check` with the baseline unchanged, and `git diff --check`. A fresh Codex autoreview found no accepted or actionable findings and rated the fix correct with 0.99 confidence.
- The second exact-head CI run, [31324357867](https://github.com/openclaw/openclaw/actions/runs/31324357867), exposed that prepared completion used `runProviderDynamicModel`, whose scoped-registry miss may broad-load plugins. Prepared completion now resolves only from its owned already-loaded scoped provider registry and cleanly leaves a missing hook unresolved. Owner-selection, startup-static, and Anthropic focused tests passed 36/36 across 2 shards; plugin SDK surface/API gates, baseline verification, `git diff --check`, and fresh Codex autoreview are clean.
- The third exact-head CI run, [31324849078](https://github.com/openclaw/openclaw/actions/runs/31324849078), found that the loaded provider resolver can return `ProviderRuntimeModel | null | undefined` while configured completion accepts `ProviderRuntimeModel | undefined`. The final cleanup normalizes resolver `null` to `undefined`, keeps resolution exclusively under `resolveLoadedProviderRuntimePlugin` and the owned registry, and splits configured completion/catalog projection into focused modules after the remote changed gate correctly rejected the original file for exceeding the 700-line limit. No max-lines suppression or test-only workaround was added.
- The fourth exact-head CI run, [31327206712](https://github.com/openclaw/openclaw/actions/runs/31327206712), isolated one Madge cycle: the extracted configured-catalog helper type-imported `prepared-model-runtime.facts.ts`, while that facts owner imported the helper. The repair removes that back-import and declares narrow local structural types for only the configured refs, catalog entries, inline models, registry, and output facts the helper consumes, restoring one-way ownership without changing runtime behavior.
- Final focused proof on the exact cleanup patch: `node scripts/run-vitest.mjs src/agents/prepared-model-runtime.owner-selection.test.ts src/agents/prepared-model-runtime.startup-static.test.ts extensions/anthropic/forward-compat-generation.test.ts` passed 36/36 tests. `pnpm plugin-sdk:surface:check` passed. `pnpm plugin-sdk:api:check` passed with the baseline unchanged. `git diff --check` passed.
- Final remote changed gate: Blacksmith Testbox `tbx_01kzkrzczgkkjk9qhmzcwe6gy9`, [Actions run 31326394329](https://github.com/openclaw/openclaw/actions/runs/31326394329), exited 0 with core/test typechecks, lint, import cycles, SDK manifest, and guards green.
- Exact post-cycle-fix changed gate: Blacksmith Testbox `tbx_01kzktbq8rb0n47w5ej217bqke`, [Actions run 31327469596](https://github.com/openclaw/openclaw/actions/runs/31327469596), exited 0 with typechecks, lint, SDK checks, boundaries, and import cycles green.
- Exact architecture proof: Blacksmith Testbox `tbx_01kzkv0qa9psp8xwmvxs2d9rwk`, [Actions run 31327975641](https://github.com/openclaw/openclaw/actions/runs/31327975641), exited 0 for `pnpm check:architecture`, with runtime cycles 0, Madge cycles 0, and every architecture subcheck green.
- ClawSweeper Rank-up disposition: the reported failed architecture lane was investigated and repaired above, and exact-head pull-request CI [31328438649](https://github.com/openclaw/openclaw/actions/runs/31328438649) is green. The optional rebase was intentionally skipped because the repository-native landing policy treats conflict-free behind-main drift as advisory and this PR does not overlap current main; no unnecessary rebase was introduced.
- Final remote full build: Blacksmith Testbox `tbx_01kzksh5xvk8dr2n4p3tzzwbk2`, [Actions run 31326831736](https://github.com/openclaw/openclaw/actions/runs/31326831736), completed `pnpm build` successfully in 5m54s.
- Fresh final Codex autoreview found no accepted or actionable findings and rated the exact cleanup patch correct with 0.99 confidence.
- Live source-built proof used a fresh isolated `OPENCLAW_STATE_DIR` and a free loopback port with exact public model `anthropic/claude-haiku-4-5-20251001`. The first main-session `chat.send` completed through `agent.wait` with `FIXED_IMMEDIATE_OK`; two scheduled heartbeat runs on `agent:main:main` reached Anthropic and completed; a second `chat.send` after more than two minutes completed with `FIXED_AFTER_HEARTBEAT_OK`. Every provider request kept the exact dated model and returned HTTP 200. `models.list` and `chat.metadata` both reported the same exact model. There were zero `Unknown model` errors and zero `model_not_found` candidate failures. The isolated gateway was stopped; no operator gateway was touched.
- Production LOC: +254/-109 (net +145). The growth is the canonical prepared-owner completion boundary, its focused completion/catalog ownership split, and the Anthropic provider-owned exact snapshot contract. Tests: +122/-1.
- No `CHANGELOG.md` edit: release generation owns the changelog; the release-note context is recorded above.

AI-assisted: yes. The changes were understood, directly tested, live-proven, and independently autoreviewed before opening this PR.
