### PR TITLE
docs(memory): add multiplayer memory design

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1696,6 +1696,22 @@
     "target": "多用户模式"
   },
   {
+    "source": "Multiplayer memory design",
+    "target": "多人记忆设计"
+  },
+  {
+    "source": "Memory architecture",
+    "target": "记忆架构"
+  },
+  {
+    "source": "Context engine",
+    "target": "上下文引擎"
+  },
+  {
+    "source": "Access groups",
+    "target": "访问组"
+  },
+  {
     "source": "The main session",
     "target": "主会话"
   },

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1700,6 +1700,10 @@
     "target": "多人记忆设计"
   },
   {
+    "source": "Multiplayer memory implementation plan",
+    "target": "多人记忆实施计划"
+  },
+  {
     "source": "Memory architecture",
     "target": "记忆架构"
   },

--- a/docs/concepts/2026-07-29-memory-impl-plan.md
+++ b/docs/concepts/2026-07-29-memory-impl-plan.md
@@ -264,12 +264,13 @@ Phase 3 and Phase 4 can proceed independently after Phase 2C. Phase 5 is
 required only for a process-adversarial claim, but its interfaces must be
 preserved from Phase 0.
 
-## 6. Phase 0: contracts and shadow decisions
+## 6. Phase 0: contracts and shadow surface inspection
 
 ### Goal
 
 Create the generic core/SDK/plugin contract, inventory all memory paths, and
-evaluate decisions in shadow mode without moving content or changing results.
+evaluate selected-runtime authorization-surface compatibility in shadow mode
+without moving content or changing results.
 
 ### Deliverables
 
@@ -305,14 +306,25 @@ Required invariants:
 Extend the selected memory runtime with a versioned authorized surface:
 
 ```ts
+type AuthorizedMemoryPlanForContext<Context extends MemoryAccessContext> =
+  Context extends MemoryAccessContext & { operation: infer Operation extends MemoryOperation }
+    ? Operation extends MemoryContentAccessOperation
+      ? AuthorizedMemoryContentPlan<Operation>
+      : AuthorizedMemoryPlan & { operation: Operation }
+    : never;
+
 interface AuthorizedMemoryRuntime {
   authorization: MemoryAuthorizationCapabilities;
-  authorize(context: MemoryAccessContext): Promise<AuthorizedMemoryPlan>;
-  searchAuthorized(...): Promise<AuthorizedMemoryResultEnvelope<MemorySearchResult>>;
+  authorize<Context extends MemoryAccessContext>(
+    context: Context,
+  ): Promise<AuthorizedMemoryPlanForContext<Context>>;
+  searchAuthorized(...): Promise<AuthorizedMemoryResultEnvelope<readonly AuthorizedMemorySearchResult[]>>;
   readAuthorized(...): Promise<AuthorizedMemoryResultEnvelope<MemoryReadResult>>;
   writeAuthorized(...): Promise<MemoryWriteResult>;
+  importAuthorized(...): Promise<MemoryWriteResult>;
   syncAuthorized(...): Promise<AuthorizedMemoryResultEnvelope<MemorySyncResult>>;
   exportAuthorized(...): Promise<AuthorizedMemoryResultEnvelope<MemoryExportResult>>;
+  statusAuthorized(...): Promise<AuthorizedMemoryResultEnvelope<MemoryProviderStatus>>;
 }
 ```
 
@@ -320,28 +332,26 @@ Legacy agents may continue to use the existing manager path. An enforced agent
 must reject a runtime without the new capability. Do not silently wrap a
 context-free backend and call it conforming.
 
-#### 6.3 Core context factory
+The declaration and the conformance suite describe plugin behavior only; they
+do not construct a trusted context or make an authorization decision. Phase 0
+does not enforce this surface. A later core-owned enforcement path must consume
+the trusted context and admitted capability at selected-runtime acquisition,
+rather than treating the current narrow search-hit filter as whole-runtime
+enforcement.
 
-Add a single core factory that receives only trusted runtime facts:
+#### 6.3 Trusted-context issuance boundary
 
-- request and run IDs;
-- agent, session key, and current session ID;
-- persisted session subject and revision;
-- actor evidence;
-- verified principals and memberships;
-- collaboration decision and revision;
-- delivery audiences, sink, and route revision;
-- delegation snapshot;
-- requested operation;
-- host-facts revision.
+Phase 0 deliberately does not expose a core context factory or an admission
+path. `MemoryAccessContext` is a serializable SDK DTO in this phase, not a
+trusted in-process object. A factory that accepts a caller-assembled bag of
+facts would manufacture authority before Phase 1A has durable principal,
+session-subject, and verified ingress evidence.
 
-The factory must:
-
-- reread the current session-key-to-session-ID mapping;
-- reject a stale mapping as `session-rebound`;
-- freeze and brand the in-process object;
-- exclude model-authored JSON and extensible message extras;
-- produce a stable context fingerprint.
+Phase 1A owns the core-only factory. It will receive trusted runtime facts,
+reread the current session-key-to-session-ID mapping, reject
+`session-rebound`, freeze and brand the in-process object, exclude
+model-authored JSON and extensible extras, and produce the stable context
+fingerprint consumed by a later enforced path.
 
 #### 6.4 Pure policy conformance harness
 
@@ -403,15 +413,15 @@ until the stable identifiers are decided.
 ### Suggested PR slices
 
 1. Serializable types, capability declaration, and SDK conformance harness.
-2. Core context factory with fake/persisted subject adapters.
-3. Shadow wiring at selected runtime acquisition and path-inventory tests.
+2. Shadow wiring at selected runtime acquisition and path-inventory tests.
+3. Phase 1A core context factory with durable subject and trusted-ingress
+   adapters.
 
 ### Tests
 
 - SDK export and API baseline checks.
 - `src/plugins/memory-state.test.ts`
 - `src/plugins/contracts/*`
-- new context branding/fingerprint tests;
 - new generated policy evaluator tests;
 - new "no context-free enforced backend" contract test.
 
@@ -422,15 +432,18 @@ current implementation head:
 
 - [ ] Every memory ingress and egress path has a recorded owner and one explicit
       disposition: authorized, blocked in enforced mode, or legacy-only.
-- [ ] Tool JSON, prompt text, plugin extras, and caller-assembled objects cannot
-      construct or modify a trusted access context or authorization plan.
+- [ ] Phase 0 exposes no trusted-context factory or enforcement admission path;
+      tool JSON, prompt text, plugin extras, and caller-assembled objects
+      therefore cannot opt into or modify an enforced authorization plan.
 - [ ] Every selected backend must declare authorization capabilities, and the
       conformance suite rejects a context-free backend in enforced mode.
-- [ ] Shadow evaluation emits only bounded decision metadata; it never logs
-      memory content, prompts, queries, snippets, or raw principal identifiers.
+- [ ] Shadow evaluation emits only bounded selected-runtime surface metadata;
+      it never logs memory content, prompts, queries, snippets, or raw
+      principal identifiers, and does not claim to evaluate context-free policy
+      decisions.
 - [ ] Existing single-user results, configured corpora, and measured hot-path
       latency remain unchanged.
-- [ ] SDK exports, API baselines, contract tests, focused context tests, and any
+- [ ] SDK exports, API baselines, contract and runtime-inspection tests, and any
       required build/lazy-import gates pass.
 - [ ] Product and security documentation still describes the feature as
       shadow-only, with no public isolation claim or public configuration.
@@ -515,6 +528,28 @@ Keep:
 
 Steering may change actor evidence but never the session subject.
 
+#### 7.6 Core trusted access-context factory
+
+Build the single core-owned factory deferred from Phase 0. It receives only
+trusted runtime facts:
+
+- request and run IDs;
+- agent, session key, and current session ID;
+- persisted session subject and revision;
+- actor evidence;
+- verified principals and memberships;
+- collaboration decision and revision;
+- delivery audiences, sink, and route revision;
+- delegation snapshot;
+- requested operation; and
+- host-facts revision.
+
+The factory rereads the current session-key-to-session-ID mapping, rejects a
+stale mapping as `session-rebound`, freezes and brands the in-process object,
+excludes model-authored JSON and extensible message extras, and produces the
+stable context fingerprint. It is not an SDK entrypoint and no plugin can mint
+or modify its output.
+
 ### Data changes
 
 Shared state:
@@ -551,6 +586,8 @@ Use additive lazy ensures. Fold into the next natural schema-version bump.
 - reset/fork/rewind copies provenance but rechecks current authority;
 - session-rebound race denies;
 - profile-less compatibility does not open private memory.
+- trusted-context branding, fingerprint, trusted-fact provenance, and
+  caller-assembled lookalike rejection.
 
 Reuse and extend:
 
@@ -576,6 +613,10 @@ Phase 1A is complete only when all of the following are demonstrated:
       that subject provenance is copied exactly while current authority is
       rechecked.
 - [ ] Session-rebound and revoke-between-check-and-use races fail closed.
+- [ ] The core-only trusted context factory rejects caller-assembled facts,
+      stale session mappings, model/plugin extras, and lookalikes; its branded,
+      frozen result binds the current subject, identity, delivery, delegation,
+      and host-fact revisions into a stable fingerprint.
 - [ ] Additive schema compatibility and identity/session lifecycle tests pass
       for existing and newly created agent databases.
 
@@ -1831,8 +1872,8 @@ Phase 6 is complete only when all of the following are demonstrated:
 Keep each PR independently safe and feature-gated.
 
 1. SDK authorization types and conformance harness.
-2. Core branded context factory and shadow decisions.
-3. Session subject/binding additive schema and lifecycle.
+2. Shadow selected-runtime inspection and complete path inventory.
+3. Session subject/binding additive schema, lifecycle, and core branded context factory.
 4. Builtin scoped store/resource/policy schema.
 5. Builtin authorized search/read contract.
 6. Doctor dry-run migration and backend admission.

--- a/docs/concepts/2026-07-29-memory-impl-plan.md
+++ b/docs/concepts/2026-07-29-memory-impl-plan.md
@@ -1,0 +1,1996 @@
+# OpenClaw Multiplayer Memory Implementation Plan
+
+Date: 2026-07-29
+
+Status: planning document; no behavior described here is shipped
+
+Canonical design: `docs/concepts/memory-multiplayer.md`
+
+## 1. Outcome
+
+Implement identity-aware private, channel, role, shared, projection, agent, and
+quarantine memory without turning prompts into an authorization boundary.
+
+The completed system must:
+
+- resolve a durable session subject before memory access;
+- expose only a selected memory plugin's authorized virtual view;
+- apply the same policy to bootstrap, search, exact reads, prompt supplements,
+  automatic recall, files, transcripts, compaction, dreaming, delegation,
+  writes, sync, import, export, and public artifacts;
+- keep direct user-to-user private-store reads unavailable;
+- preserve existing single-user behavior until explicit migration;
+- fail closed for memory without taking unrelated conversation paths down;
+- distinguish cooperative, model-adversarial, process-adversarial, and
+  hostile-tenant claims.
+
+This plan splits the design's large security stages into smaller, independently
+reviewable milestones. The numbering maps back to the canonical design:
+
+- Design Stage 0 -> implementation Phase 0.
+- Design Stage 1 -> implementation Phases 1A through 1D.
+- Design Stage 2 -> implementation Phases 2A through 2C.
+- Design Stage 3 -> implementation Phase 3.
+- Design Stage 4 -> implementation Phase 4.
+- Design Stage 5 -> implementation Phase 5.
+- Phase 6 is rollout, migration completion, and cleanup.
+
+## 2. Non-negotiable architecture boundaries
+
+### 2.1 Core ownership
+
+Core owns facts and confinement whose absence could widen access:
+
+- canonical principal and identity-binding resolution;
+- write-once session memory subjects;
+- actor, collaboration, delivery, route, and session-instance revisions;
+- creation and validation of the branded memory access context;
+- selected-memory-capability admission;
+- generic prompt, filesystem, sandbox, and egress enforcement;
+- fail-closed behavior when memory is unavailable or nonconforming.
+- atomic persistence of session-subject and transcript-policy companion rows
+  in the core-owned transcript transaction.
+
+Likely owner surfaces:
+
+- `src/routing/session-key.ts:216-259`
+- `src/channels/message-access/types.ts:15-35`
+- `src/config/sessions/session-entry-provenance.ts:4-38`
+- `src/config/sessions/session-sharing-store.ts:104-213`
+- `src/gateway/session-reset-service.ts`
+- `src/plugins/memory-runtime.ts:10-79`
+- `src/plugins/memory-state.ts:8-195`
+- `src/agents/tool-fs-policy.ts:15-63`
+- `src/agents/sandbox/workspace-mounts.ts:39-181`
+
+### 2.2 Plugin SDK ownership
+
+The SDK owns a small, versioned contract between core and the selected memory
+plugin:
+
+- serializable access facts;
+- plugin-issued authorization plans and opaque handles;
+- authorized read, write, sync, import, export, and status operations;
+- exposure and egress receipts;
+- backend capability declaration;
+- a reusable conformance suite.
+
+Prefer one narrow memory-authorization subpath. Do not add a broad convenience
+barrel or expose core implementation details.
+
+Likely contract surfaces:
+
+- `packages/memory-host-sdk/src/host/types.ts:1-168`
+- a new focused file under `packages/memory-host-sdk/src/host/`
+- a narrow facade under `src/plugin-sdk/`
+- `scripts/lib/plugin-sdk-entrypoints.json`
+- `src/plugin-sdk/entrypoints.ts`
+- `src/plugin-sdk/api-baseline.ts`
+- package exports and SDK contract tests
+
+### 2.3 Selected memory plugin ownership
+
+The selected memory plugin owns:
+
+- logical stores and physical/backend namespaces;
+- resource and immutable revision catalogs;
+- policy revisions, entries, evaluation, and decision traces;
+- view construction from core-supplied verified facts;
+- candidate prefilter and authoritative postfilter;
+- content reads and writes;
+- lineage, projections, postbox, exposure records, repair, and sync;
+- backend-specific crash recovery.
+
+For transcript policy persistence, the selected plugin computes opaque
+policy-set contents, stable policy IDs, and receipts before the SQLite commit.
+Core persists those opaque records atomically beside transcript events. Core
+does not interpret plugin policy semantics, and no plugin call occurs inside a
+SQLite transaction.
+
+Core must not import deep `extensions/memory-core/src/**` internals. Bundled
+plugins use the same public contract as external plugins.
+
+Current selected-runtime seam:
+
+- `src/plugins/memory-runtime.ts:10-79`
+- `src/plugins/memory-state.ts:144-195`
+- `packages/memory-host-sdk/src/host/types.ts:120-168`
+
+### 2.4 Identity plugin ownership
+
+Identity plugins may provide raw verification material, registered adapter
+attestations, group snapshots, and refresh support. They do not return final
+principals or final memory decisions.
+
+Core validates protocol-appropriate issuer, audience, signature or registered
+adapter identity, tenant binding, expiry, and snapshot freshness before adding
+facts to the access context.
+
+### 2.5 Storage and migration rules
+
+- Runtime reads only one canonical layout after migration.
+- No dual-read, lazy import, read-through fallback, or dual-write.
+- Ambiguous legacy data enters quarantine, not shared memory.
+- Provider, tenant, channel, and user identifiers do not appear in storage
+  paths or backend locator tokens.
+- Runtime SQLite access uses Kysely helpers except schema DDL, migrations, FTS,
+  vector primitives, and narrowly justified transaction-time rereads.
+- No asynchronous work or filesystem access occurs inside SQLite transaction
+  callbacks.
+- Additive tables use canonical schema declarations plus idempotent lazy
+  ensures. Shared-state tables must be listed in
+  `LAZY_ADDITIVE_STATE_TABLES`. Per-agent tables/columns must also be registered
+  in `AGENT_SCHEMA_COMPATIBILITY.allowedMissingTables` /
+  `allowedMissingColumns`; optional scoped FTS/vector trigger groups must be
+  represented in `optionalCanonicalTriggerGroups`. Otherwise current-version
+  existing agent databases fail schema assertion before the lazy ensure runs.
+  Do not bump a SQLite schema version without explicit maintainer discussion
+  and approval.
+- Postbox defaults to `off`; review-required is the first enabled posture.
+- Direct private-store grants between users remain deferred.
+
+## 3. Current implementation anchors
+
+| Area                       | Current source of truth                                                                                                       | Planning implication                                                                                                                          |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Memory slot                | `src/plugins/memory-runtime.ts:10-79`                                                                                         | Exactly one selected memory plugin supplies the runtime. Authorization must be backend-neutral.                                               |
+| Memory capability registry | `src/plugins/memory-state.ts:8-195,230-424`                                                                                   | Prompt builders, preparations, supplements, flush planning, runtime, and public artifacts are separate paths that all need access context.    |
+| Host manager contract      | `packages/memory-host-sdk/src/host/types.ts:1-168`                                                                            | Current search, read, sync, status, and probe methods carry no authorization plan or resource revision.                                       |
+| DM routing                 | `src/routing/session-key.ts:216-259`                                                                                          | Default `dmScope: main` cannot receive a private memory subject.                                                                              |
+| Session identity           | `src/state/openclaw-agent-schema.sql:34-112`                                                                                  | `session_nodes` owns the logical key and current window; `session_windows` owns generations and already records a coarse session scope.       |
+| Session sharing            | `src/config/sessions/session-sharing-store.ts:104-213`                                                                        | Existing Gateway collaboration membership is authoritative only for Gateway collaborative sessions and includes a session-rebound guard.      |
+| Transcript persistence     | `src/config/sessions/session-accessor.sqlite-transcript-write.ts:333-748`                                                     | Message and non-message transcript writes already converge on synchronous SQLite commit sections and can receive companion policy writes.     |
+| Current memory index       | `src/state/openclaw-agent-schema.sql:400-454`                                                                                 | Existing chunks contain plaintext text and embeddings and are agent-scoped legacy state. Scoped content must use new tables.                  |
+| Builtin memory schema      | `packages/memory-host-sdk/src/host/memory-schema-base.ts:7-61`                                                                | Existing source/chunk tables are content-bearing derived state, not authorization objects.                                                    |
+| Memory search tools        | `extensions/memory-core/src/tools.ts:465-980`                                                                                 | `memory_search`, `memory_get`, session recall, and corpus merging must use authorized handles and receipts.                                   |
+| Corpus supplements         | `extensions/memory-core/src/tools.shared.ts:163-212`                                                                          | Supplemental corpora are currently context-free registration surfaces.                                                                        |
+| Prompt supplements         | `src/plugins/memory-state.ts:263-408`                                                                                         | Synchronous and prepared prompt sections are run-scoped but not authorization-scoped.                                                         |
+| LanceDB                    | `extensions/memory-lancedb/index.ts:493-637`                                                                                  | `before_prompt_build` recall and `agent_end` auto-capture bypass the selected authorized runtime contract today.                              |
+| Memory wiki                | `extensions/memory-wiki/index.ts:82-162`                                                                                      | Prompt preparation, prompt supplementation, corpus search, and Gateway/CLI surfaces need the same authorized plan.                            |
+| Memory flush               | `src/auto-reply/reply/agent-runner-memory.ts:756-1665` and `extensions/memory-core/src/flush-plan.ts`                         | The model currently receives a filesystem target such as `memory/YYYY-MM-DD.md`; enforced mode must replace this with an authorized mutation. |
+| Compaction                 | `src/agents/embedded-agent-runner/compaction-checkpoint.ts:17-65` and `src/gateway/session-compaction-checkpoints.ts:574-760` | Summary/checkpoint persistence needs source-policy sets and immutable audience metadata.                                                      |
+| Dreaming                   | `extensions/memory-core/src/dreaming-phases.ts:1142-2030`                                                                     | Session and daily ingestion currently span workspace files and transcripts; enforced mode must run one authorized store at a time.            |
+| Filesystem policy          | `src/agents/tool-fs-policy.ts:15-63`                                                                                          | Current policy is a single `workspaceOnly` boolean, not a per-session memory view.                                                            |
+| Sandbox mounts             | `src/agents/sandbox/workspace-mounts.ts:135-181`                                                                              | Current mounts expose whole workspaces as `none`, `ro`, or `rw`; model-adversarial isolation requires mount-level narrowing.                  |
+| Doctor memory repair       | `src/commands/doctor-agent-memory-schema.ts:61-149`                                                                           | Doctor already owns offline per-agent memory schema convergence and handle closure.                                                           |
+| Additive shared tables     | `src/state/openclaw-state-db-contract.ts:7-17`                                                                                | `LAZY_ADDITIVE_STATE_TABLES` establishes the shared no-bump additive-table pattern.                                                           |
+| Additive per-agent tables  | `src/state/openclaw-agent-db-schema-helpers.ts:46-83`                                                                         | New canonical tables/columns and optional trigger groups must be accepted by `AGENT_SCHEMA_COMPATIBILITY` until their lazy ensure runs.       |
+
+## 4. Decisions required before implementation
+
+These are owner decisions. Record them in the tracking issue before merging
+the phase that consumes them.
+
+1. **Enablement surface**
+   - Recommended: one durable agent-level policy state managed by CLI/Doctor,
+     rather than several public config flags.
+   - Stage 0 remains internal shadow-only.
+   - Do not expose the final mode until migration and conformance checks exist.
+
+2. **Canonical storage root**
+   - Choose the controlled per-agent artifact root.
+   - Define backup ownership, filesystem permissions, path-key versioning, and
+     cross-platform behavior.
+   - Keep the selected plugin's catalog authoritative for opaque path keys.
+
+3. **Local identity binding**
+   - Define how a channel sender proves ownership of a Gateway profile.
+   - Define account merge, recovery, revocation, and audit behavior.
+   - Never bind by display name, email equality, username equality, phone
+     equality, session key, or `identityLinks`.
+
+4. **Membership staleness**
+   - Define provider-specific expiry and outage behavior.
+   - Expired evidence removes the affected role/channel mount.
+
+5. **Incognito**
+   - Recommended initial rule: no durable memory, transcript-derived memory,
+     flush, dreaming, projection, or postbox writes.
+
+6. **Audit retention and admin inspection**
+   - Define retention, export, deletion, and which admins may inspect resource
+     existence versus only redacted decision metadata.
+
+7. **Egress registry scope**
+   - Approve whether the run-exposure audience gate lands in Stage 1 or is
+     split into a separate security RFC.
+   - If deferred, pilot scope must disable or narrowly allow outbound
+     capabilities after scoped exposure and must not claim complete audience
+     confinement.
+
+8. **Process boundary**
+   - Decide whether Stage 5 uses a broker child process, a separate local
+     service, or separate Gateway cells.
+
+9. **Shared publishing**
+   - Decide which local roles may receive publisher authority for role and
+     agent-shared stores.
+   - Decide whether every update requires review.
+
+10. **Projection experience**
+    - Approve selection, preview, expiry, refresh, and revocation-residual
+      behavior before Phase 3.
+    - Do not allow broad "share everywhere" defaults.
+
+## 5. Phase dependency graph
+
+```text
+Phase 0: contract + shadow
+  |
+  +--> Phase 1A: identity + session subject
+  |      |
+  |      +--> Phase 1B: scoped store + migration foundation
+  |               |
+  |               +--> Phase 1C: authorized reads + minimum transcript labels
+  |                        |
+  |                        +--> Phase 1D: filesystem + egress confinement
+  |                                  |
+  |                                  +--> Phase 2A: authorized writes
+  |                                           |
+  |                                           +--> Phase 2B: full transcript policy
+  |                                                    |
+  |                                                    +--> Phase 2C: derivation lifecycle
+  |                                                              |
+  |                                                              +--> Phase 3: projections + postbox
+  |                                                              |
+  |                                                              +--> Phase 4: enterprise identity
+  |                                                              |
+  |                                                              +--> Phase 5: process isolation
+  |
+  +--> Phase 6: pilot, migration rollout, cleanup
+```
+
+Phase 3 and Phase 4 can proceed independently after Phase 2C. Phase 5 is
+required only for a process-adversarial claim, but its interfaces must be
+preserved from Phase 0.
+
+## 6. Phase 0: contracts and shadow decisions
+
+### Goal
+
+Create the generic core/SDK/plugin contract, inventory all memory paths, and
+evaluate decisions in shadow mode without moving content or changing results.
+
+### Deliverables
+
+#### 6.1 Serializable contract
+
+Define versioned serializable types for:
+
+- `SessionMemorySubject`
+- `MemoryOperation`
+- `MemoryAccessContext`
+- `MemoryAuthorizationCapabilities`
+- `AuthorizedMemoryPlan`
+- `AuthorizedResourceHandle`
+- `AuthorizedMemoryMutation`
+- `MemoryExposureReceipt`
+- `MemoryEgressAuthorizationReceipt`
+- `AuthorizedMemoryResultEnvelope<T>`
+
+Keep core-only brands and freeze logic outside the serializable SDK shape.
+Brands are an in-process anti-forgery mechanism, not an IPC credential.
+
+Required invariants:
+
+- Callers cannot name a raw store, owner, audience, or principal.
+- Plans bind context fingerprint, agent, session/window identity, subject
+  revision, operation, delivery revision, policy revision, and expiry.
+- Handles are revision-bound references, not bearer grants.
+- Content-bearing methods return both exposure and egress receipts.
+- A selected backend advertises exact supported capabilities.
+
+#### 6.2 Runtime capability extension
+
+Extend the selected memory runtime with a versioned authorized surface:
+
+```ts
+interface AuthorizedMemoryRuntime {
+  authorization: MemoryAuthorizationCapabilities;
+  authorize(context: MemoryAccessContext): Promise<AuthorizedMemoryPlan>;
+  searchAuthorized(...): Promise<AuthorizedMemoryResultEnvelope<MemorySearchResult>>;
+  readAuthorized(...): Promise<AuthorizedMemoryResultEnvelope<MemoryReadResult>>;
+  writeAuthorized(...): Promise<MemoryWriteResult>;
+  syncAuthorized(...): Promise<AuthorizedMemoryResultEnvelope<MemorySyncResult>>;
+  exportAuthorized(...): Promise<AuthorizedMemoryResultEnvelope<MemoryExportResult>>;
+}
+```
+
+Legacy agents may continue to use the existing manager path. An enforced agent
+must reject a runtime without the new capability. Do not silently wrap a
+context-free backend and call it conforming.
+
+#### 6.3 Core context factory
+
+Add a single core factory that receives only trusted runtime facts:
+
+- request and run IDs;
+- agent, session key, and current session ID;
+- persisted session subject and revision;
+- actor evidence;
+- verified principals and memberships;
+- collaboration decision and revision;
+- delivery audiences, sink, and route revision;
+- delegation snapshot;
+- requested operation;
+- host-facts revision.
+
+The factory must:
+
+- reread the current session-key-to-session-ID mapping;
+- reject a stale mapping as `session-rebound`;
+- freeze and brand the in-process object;
+- exclude model-authored JSON and extensible message extras;
+- produce a stable context fingerprint.
+
+#### 6.4 Pure policy conformance harness
+
+Create a reusable test harness that can generate:
+
+- principal sets;
+- stores and views;
+- policy entries and explicit denies;
+- expiry and revisions;
+- delivery audiences;
+- delegation intersections;
+- lineage requirements.
+
+The harness must assert:
+
+- deny precedence;
+- permission implication;
+- no cross-agent cell access;
+- no plan reuse across context revisions;
+- candidate prefilter superset property;
+- no unauthorized count, score, path, title, citation, cursor, or denial detail.
+
+#### 6.5 Complete path inventory
+
+Classify every current path as:
+
+- converted through authorized capability;
+- blocked in enforced mode;
+- legacy-only for unmigrated agents;
+- operator-only with explicit authenticated context.
+
+Minimum inventory:
+
+- selected runtime manager acquisition;
+- bootstrap and recent-memory startup context;
+- `memory_search` and `memory_get`;
+- session transcript recall;
+- active-memory trigger recall;
+- memory-wiki prompt/corpus/Gateway/CLI;
+- LanceDB tool recall, auto-recall, store, forget, and auto-capture;
+- memory prompt supplements and preparations;
+- corpus supplements;
+- Talk fast context and project bootstrap;
+- status, sync, CLI, import, export, and public artifacts;
+- generic file tools;
+- memory flush;
+- transcript writes and replay;
+- compaction and checkpoints;
+- dreaming and profile promotion;
+- child agents and completion handoff;
+- cron, heartbeat, webhook, and system runs.
+
+### Data changes
+
+None required for the first contract PR. Shadow traces may use bounded
+structured logs or test-only fixtures. Do not create a permanent audit schema
+until the stable identifiers are decided.
+
+### Suggested PR slices
+
+1. Serializable types, capability declaration, and SDK conformance harness.
+2. Core context factory with fake/persisted subject adapters.
+3. Shadow wiring at selected runtime acquisition and path-inventory tests.
+
+### Tests
+
+- SDK export and API baseline checks.
+- `src/plugins/memory-state.test.ts`
+- `src/plugins/contracts/*`
+- new context branding/fingerprint tests;
+- new generated policy evaluator tests;
+- new "no context-free enforced backend" contract test.
+
+### Definition of done
+
+Phase 0 is complete only when all of the following are demonstrated on the
+current implementation head:
+
+- [ ] Every memory ingress and egress path has a recorded owner and one explicit
+      disposition: authorized, blocked in enforced mode, or legacy-only.
+- [ ] Tool JSON, prompt text, plugin extras, and caller-assembled objects cannot
+      construct or modify a trusted access context or authorization plan.
+- [ ] Every selected backend must declare authorization capabilities, and the
+      conformance suite rejects a context-free backend in enforced mode.
+- [ ] Shadow evaluation emits only bounded decision metadata; it never logs
+      memory content, prompts, queries, snippets, or raw principal identifiers.
+- [ ] Existing single-user results, configured corpora, and measured hot-path
+      latency remain unchanged.
+- [ ] SDK exports, API baselines, contract tests, focused context tests, and any
+      required build/lazy-import gates pass.
+- [ ] Product and security documentation still describes the feature as
+      shadow-only, with no public isolation claim or public configuration.
+
+### Rollback
+
+Remove shadow invocation and ignore the new capability when the agent is not
+enforced. No content or schema rollback is required.
+
+## 7. Phase 1A: identity and write-once session subject
+
+### Goal
+
+Resolve one immutable memory subject for every logical session before any
+private store can open.
+
+### Deliverables
+
+#### 7.1 Principal model
+
+Add canonical principals for:
+
+- existing durable Gateway profiles;
+- verified enterprise subjects;
+- service agents;
+- system actors;
+- conversation principals.
+
+Store raw provider identifiers only where an explicitly protected operational
+workflow needs them. Ordinary binding lookup should use a keyed-HMAC over:
+
+```text
+(channel, account, normalized stable sender ID)
+```
+
+#### 7.2 Identity binding
+
+Create a core-owned binding lifecycle:
+
+- create through pairing/OAuth/admin-link only;
+- record adapter, assurance, evidence revision, creator, and timestamp;
+- revoke without deleting history;
+- resolve current merge head before each operation;
+- never derive a principal from `identityLinks`, display fields, route keys, or
+  message text.
+
+Ingress integration starts from authenticated or trusted-adapter sender facts.
+The current `stable-id` material in
+`src/channels/message-access/types.ts:15-35` is input evidence, not the final
+principal.
+
+#### 7.3 Session memory subject
+
+Persist a write-once subject against the logical `session_nodes` row:
+
+- verified user for an isolated DM;
+- conversation principal for group/channel sessions;
+- explicit service/agent/system principal for autonomous runs;
+- `ambiguous` for shared-main/unbound/conflicting DM identity.
+
+The subject is immutable provenance. Current binding, membership, collaboration,
+and revocation state is rechecked separately and may deny all operations.
+
+Reset, rollover, fork, rewind, and recovery windows copy the exact subject and
+subject revision. Imports without provable lineage become quarantined imports,
+not subject successors.
+
+#### 7.4 DM precondition
+
+- `dmScope: main` never receives a user-private subject.
+- Doctor reports the exact `per-channel-peer` or
+  `per-account-channel-peer` remediation.
+- Do not silently rewrite `session.dmScope`.
+
+#### 7.5 Actor separation
+
+Keep:
+
+- session subject for default audience and write target;
+- actor for audit and collaboration;
+- source message/sender evidence for postbox targeting.
+
+Steering may change actor evidence but never the session subject.
+
+### Data changes
+
+Shared state:
+
+- `memory_principals`
+- `memory_identity_bindings`
+
+Per-agent:
+
+- `session_memory_subjects`
+- `session_memory_subject_snapshots`
+
+Use additive lazy ensures. Fold into the next natural schema-version bump.
+
+### Likely files
+
+- `src/routing/session-key.ts`
+- `src/routing/resolve-route.ts`
+- `src/channels/message-access/*`
+- `src/config/sessions/session-entry-provenance.ts`
+- `src/config/sessions/session-accessor*`
+- `src/gateway/session-create-service.ts`
+- `src/gateway/session-reset-service.ts`
+- `src/gateway/server-methods/sessions-create.ts`
+- `src/state/openclaw-agent-schema.sql`
+- shared state schema/contract files
+
+### Tests
+
+- isolated DM, shared-main DM, group, channel, cron, heartbeat, webhook,
+  subagent, system, and incognito subject matrix;
+- stable sender ID cannot become a principal without a binding;
+- revoked or conflicting binding produces no private subject;
+- reset/fork/rewind copies provenance but rechecks current authority;
+- session-rebound race denies;
+- profile-less compatibility does not open private memory.
+
+Reuse and extend:
+
+- `src/routing/resolve-route.test.ts`
+- `src/gateway/session-sharing.test.ts`
+- `src/config/sessions/session-accessor.conformance.test.ts`
+- `src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts`
+- Gateway session create/reset tests
+
+### Definition of done
+
+Phase 1A is complete only when all of the following are demonstrated:
+
+- [ ] Every logical session kind resolves to a persisted write-once subject or
+      an explicit ambiguous state.
+- [ ] Raw sender fields, display names, aliases, `identityLinks`, route keys,
+      and model-visible context cannot grant or replace a principal.
+- [ ] Revoked, expired, unbound, or conflicting identity evidence prevents a
+      private subject from being issued.
+- [ ] A shared-main DM cannot mount private memory, and Doctor reports the exact
+      isolating `dmScope` remediation without rewriting configuration.
+- [ ] Reset, rollover, fork, rewind, recovery, and confirmed import tests prove
+      that subject provenance is copied exactly while current authority is
+      rechecked.
+- [ ] Session-rebound and revoke-between-check-and-use races fail closed.
+- [ ] Additive schema compatibility and identity/session lifecycle tests pass
+      for existing and newly created agent databases.
+
+### Rollback
+
+Keep the new subject rows unused while current memory remains legacy-only.
+Bindings may remain as inert identity metadata.
+
+## 8. Phase 1B: scoped store, policy, and migration foundation
+
+### Goal
+
+Give the builtin selected memory plugin isolated logical stores and immutable
+resource/policy revisions without changing legacy agents.
+
+### Deliverables
+
+#### 8.1 Root and store registry
+
+Create opaque IDs and path keys:
+
+- `storage_root_id`
+- `store_id`
+- random path key generated with a CSPRNG;
+- `path_key_version`;
+- authority kind and owner;
+- backend kind and opaque locator;
+- lifecycle state.
+
+Create directories with exclusive `mkdir`; retry collisions with a fresh key.
+Never place provider/user/channel IDs in the path.
+
+#### 8.2 Resource revision model
+
+Builtin resources use:
+
+- stable `resource_id`;
+- immutable `revision_id`;
+- stable logical locator inside a store;
+- exactly one active revision;
+- content hash;
+- actor and timestamps;
+- lifecycle state (`pending`, `active`, `quarantined`, `tombstoned`).
+
+The catalog stores pointers and policy metadata. Markdown remains canonical
+content for builtin memory. Scoped index chunks are content-bearing derived
+state inside the same trusted plugin/broker boundary.
+
+#### 8.3 Policy model
+
+Create stable policies and immutable policy revisions:
+
+- placement authority for common user/channel/agent stores;
+- explicit allow/deny entries for exceptional narrowing and publishing;
+- requested-operation implication;
+- expiry;
+- grantor/actor/reason;
+- delivery-audience coverage;
+- current revision/revocation epoch.
+
+The initial product exposes no direct private user-to-user allow.
+
+#### 8.4 Builtin authorized runtime
+
+Implement the Phase 0 contract for builtin memory:
+
+- resolve authorized view;
+- issue opaque mount handles;
+- query only stores in the view;
+- prefilter candidates;
+- authoritative postfilter;
+- read immutable active revisions only;
+- record exposure before returning content.
+
+Do not insert scoped content into `memory_index_sources`,
+`memory_index_chunks`, or legacy FTS/vector tables.
+
+#### 8.5 QMD and alternate backend admission
+
+Define conformance requirements for:
+
+- isolated collections/namespaces;
+- authorized exact reads;
+- candidate over-fetch/filter behavior;
+- revision/hash checks;
+- status and export;
+- no silent fallback to a broader backend.
+
+If QMD cannot meet the contract in the first release, enforced agents use the
+builtin backend or memory remains unavailable. QMD failure must not fall back to
+legacy broad builtin search.
+
+#### 8.6 Doctor migration scaffold
+
+Implement dry-run only first:
+
+1. scan legacy files and transcripts;
+2. classify from trusted structural evidence;
+3. preview owner/admin choices;
+4. place ambiguous data in quarantine;
+5. estimate copy/index/backup work;
+6. report `dmScope`, backend, filesystem, and sandbox blockers.
+
+No runtime cutover in the dry-run PR.
+
+### Data changes
+
+Per-agent plugin tables:
+
+- `memory_storage_roots`
+- `memory_stores`
+- `memory_resources`
+- `memory_resource_revisions`
+- `memory_resource_subjects`
+- `memory_policies`
+- `memory_policy_revisions`
+- `memory_policy_entries`
+- `memory_scoped_chunks` plus scoped FTS/vector tables
+- `memory_migrations`
+
+Register every additive per-agent table in
+`AGENT_SCHEMA_COMPATIBILITY.allowedMissingTables`. Register scoped FTS/vector
+shadow tables and triggers in the corresponding optional canonical trigger
+groups. Add any lazily ensured columns to `allowedMissingColumns`.
+
+### Likely files
+
+- `packages/memory-host-sdk/src/host/memory-schema*.ts`
+- `src/state/openclaw-agent-schema.sql`
+- `extensions/memory-core/src/memory/*`
+- `extensions/memory-core/runtime-api.ts`
+- `extensions/memory-core/api.ts`
+- `src/plugin-sdk/memory-core-*`
+- `src/commands/doctor-agent-memory-schema.ts`
+- new memory-core doctor/migration modules
+
+### Tests
+
+- opaque path collision/retry and path traversal;
+- no provider identity in path or locator;
+- active/pending/quarantined/tombstoned revision visibility;
+- policy deny precedence and expiry;
+- candidate-superset property for FTS, vector scan, sqlite-vec, and exact read;
+- QMD nonconformance rejects enforced mode;
+- dry-run migration is deterministic and content-free in logs;
+- existing legacy agent remains byte-for-byte on the old path.
+
+### Definition of done
+
+Phase 1B is complete only when all of the following are demonstrated:
+
+- [ ] Builtin memory passes the full authorized-backend conformance suite for
+      store isolation, immutable revisions, policy evaluation, search, and
+      exact reads.
+- [ ] Pending, quarantined, expired, stale-hash, and tombstoned revisions cannot
+      be returned.
+- [ ] Scoped resources and chunks never enter legacy
+      `memory_index_sources`/`memory_index_chunks` or legacy FTS/vector tables.
+- [ ] Every additive per-agent table, column, and trigger group is registered
+      in schema compatibility so an existing current-version database opens
+      before feature-local lazy ensure.
+- [ ] A nonconforming or failed QMD/alternate backend becomes unavailable in
+      enforced mode and never falls back to broader legacy search.
+- [ ] Doctor dry-run produces a deterministic, content-redacted classification,
+      backup, copy, reindex, verification, and cutover plan without modifying
+      files or database state.
+- [ ] Legacy single-user agents remain on the existing runtime path with no
+      user-visible behavior change or runtime cutover.
+
+### Rollback
+
+Drop or ignore empty additive tables and remove dry-run state. Legacy content
+was never moved.
+
+## 9. Phase 1C: private and channel read isolation
+
+### Goal
+
+Convert every content-bearing read lane to the authorized runtime and enable a
+single-subject/shadow read-only pilot. A pilot with two distinct verified
+subjects is gated on Phase 1D filesystem and exec confinement.
+
+### Deliverables
+
+#### 9.1 Core access host
+
+For each read operation:
+
+1. build and revalidate `MemoryAccessContext`;
+2. call selected plugin `authorize`;
+3. invoke the authorized method;
+4. validate plan/context binding;
+5. reject missing or stale receipts;
+6. merge exposure into the run exposure set;
+7. return only safe unavailable/not-found details to model-facing callers.
+
+#### 9.2 Search and exact read
+
+Convert:
+
+- `memory_search`;
+- `memory_get`;
+- transcript recall;
+- `corpus=memory`, `sessions`, `wiki`, and `all`;
+- citations and continuation behavior.
+
+Search returns opaque revision-bound handles. Human-friendly virtual paths are
+display only and resolve inside the current view.
+
+The postfilter runs before final result count, ranking, pagination, snippet
+rendering, path exposure, or citation generation.
+
+#### 9.3 Bootstrap and automatic recall
+
+Convert:
+
+- curated/front-card bootstrap;
+- startup recent-memory context;
+- trigger injection;
+- active-memory recall;
+- Talk fast context;
+- project bootstrap;
+- prompt supplements and preparations.
+
+`MemoryPromptSectionParams` and corpus supplement inputs must carry a trusted
+host invocation/context handle, not only `agentId` and `agentSessionKey`.
+
+#### 9.4 Supplemental plugin paths
+
+Memory wiki:
+
+- prompt builder;
+- prompt preparation;
+- corpus search/get;
+- Gateway methods;
+- CLI and public artifacts.
+
+LanceDB:
+
+- `memory_recall`;
+- `before_prompt_build` auto-recall;
+- status/CLI reads.
+
+Any supplemental plugin that cannot route through the selected capability is
+blocked in enforced mode. Supplemental plugins do not become independent
+policy engines.
+
+#### 9.5 Operator surfaces
+
+Status, CLI, sync inspection, and export must authenticate explicitly and use
+an operator/admin access context. A purpose string such as `"status"` or
+`"cli"` is not authorization.
+
+#### 9.6 Minimum transcript policy labeling
+
+Before any scoped resource enters a run, persist enough metadata to prevent the
+next durable turn from becoming an unlabeled copy:
+
+- source-policy-set ID;
+- exposed resource revisions;
+- delivery audience;
+- session identity and subject revision;
+- run exposure-set ID/revision.
+
+Write the companion policy row in the same per-agent SQLite transaction as the
+transcript event. If that is not possible, mark the event
+authorization-pending and exclude it from replay, search, compaction, export,
+and derivation.
+
+At this phase, durable memory writes remain disabled for enforced agents.
+
+#### 9.7 Minimum transcript policy storage
+
+Create the minimum additive forms of:
+
+- `transcript_event_memory_policies`;
+- `memory_policy_sets`;
+- `memory_run_exposures`.
+
+The selected plugin produces opaque policy-set contents/IDs and receipts before
+the transcript transaction. Core writes the policy-set row, run exposure
+reference, and event companion row atomically with the transcript event. There
+is no plugin callback inside the transaction.
+
+### Likely files
+
+- `src/plugins/memory-runtime.ts`
+- `src/plugins/memory-state.ts`
+- `packages/memory-host-sdk/src/host/types.ts`
+- `extensions/memory-core/src/tools.ts`
+- `extensions/memory-core/src/tools.shared.ts`
+- `extensions/memory-core/src/session-search-visibility.ts`
+- `extensions/memory-core/src/prompt-section.ts`
+- `extensions/active-memory/*`
+- `extensions/memory-wiki/*`
+- `extensions/memory-lancedb/index.ts`
+- `src/auto-reply/reply/startup-context*`
+- `src/auto-reply/reply/agent-runner-memory.ts`
+- `src/config/sessions/session-accessor.sqlite-transcript-write.ts`
+
+### Tests
+
+Read-lane matrix:
+
+- bootstrap;
+- search;
+- exact get;
+- session recall;
+- trigger recall;
+- active recall;
+- wiki supplement;
+- LanceDB auto-recall;
+- status;
+- CLI;
+- public artifact inspection.
+
+Leak assertions:
+
+- no denied path/title/snippet/score/count/citation/cursor;
+- denied nearest neighbors do not crowd out an allowed top K;
+- no private store in a channel view;
+- no role store in a group because the latest actor has that role;
+- memory plugin crash/disable/nonconformance never re-enables legacy reads;
+- missing transcript policy companion row denies replay and derivation.
+
+Focused existing tests:
+
+- `extensions/memory-core/src/tools.test.ts`
+- `extensions/memory-core/src/tools.citations.test.ts`
+- `extensions/memory-core/src/session-search-visibility.test.ts`
+- `extensions/memory-lancedb/index.test.ts`
+- `extensions/memory-wiki/index.test.ts`
+- `src/auto-reply/reply/startup-context.test.ts`
+- `src/auto-reply/reply/agent-runner-memory.test.ts`
+- transcript accessor and projection tests
+
+### Definition of done
+
+Phase 1C is complete only when all of the following are demonstrated:
+
+- [ ] Every content-bearing read lane is either converted to the authorized
+      runtime or explicitly unavailable in enforced mode.
+- [ ] Through every converted lane, two verified users cannot observe one
+      another's private existence bits, paths, titles, snippets, scores,
+      counts, citations, cursors, or content.
+- [ ] A group view contains only its channel store, eligible shared content,
+      and projections explicitly addressed to that audience.
+- [ ] Bootstrap, automatic recall, Active Memory, Memory Wiki, LanceDB, CLI,
+      status, session recall, and corpus supplements pass the same context and
+      receipt checks or are blocked.
+- [ ] Every scoped exposure is recorded before content leaves the selected
+      plugin, and missing/stale exposure or egress receipts are rejected.
+- [ ] The minimum transcript policy-set, run-exposure, and event-companion rows
+      commit atomically with each durable event after scoped exposure.
+- [ ] Enforced agents remain read-only; every ordinary, watcher, plugin,
+      import, sync, and generic-file durable write path is disabled until Phase
+      2A.
+- [ ] The read-lane, top-K crowd-out, plugin-failure, missing-label, and
+      transcript-visibility test matrix passes.
+- [ ] No two-subject pilot or stronger isolation claim is enabled before Phase
+      1D closes raw file and exec bypasses.
+
+### Rollback
+
+Disable enforced mode for agents not yet cut over. Migrated agents remain
+read-only until restored through the documented pre-write rollback path; never
+fall back to broad legacy reads.
+
+## 10. Phase 1D: filesystem and egress confinement
+
+### Goal
+
+Prevent model-facing file and delivery surfaces from bypassing an authorized
+memory view.
+
+### Deliverables
+
+#### 10.1 Virtual filesystem view
+
+Replace raw host memory paths with:
+
+- virtual roots such as `private/`, `channel/`, `shared/`, `projections/`, and
+  `postbox-review/` only when authorized;
+- plugin-issued mount handles;
+- symlink-safe resolution inside one authorized store root;
+- no model-visible controlled artifact root.
+
+Generic `read`, `write`, `edit`, and `apply_patch` calls against virtual memory
+paths delegate to the broker/capability. Direct host paths into controlled
+memory storage are rejected.
+
+#### 10.2 Tool filesystem policy
+
+Extend the closed policy shape beyond a parallel nullable boolean. Prefer a
+discriminated result that represents:
+
+- normal workspace view;
+- authorized memory virtual view;
+- sandbox mount plan;
+- blocked/unavailable memory.
+
+Keep routing and mount preparation deterministic and runtime-light.
+
+#### 10.3 Sandbox
+
+For model-adversarial mode:
+
+- mount only authorized virtual roots;
+- do not mount the real artifact root;
+- make read-only roots physically read-only;
+- ensure a writable channel/private root cannot reach siblings;
+- reject dangerous and reserved mount targets;
+- include mount view identity in sandbox config hashes.
+
+#### 10.4 Exec behavior
+
+Choose one:
+
+- hide/deny `exec` for an enforced run without a scoped sandbox; or
+- allow it only under the cooperative-isolation claim with an explicit Doctor
+  security finding.
+
+Never claim model-adversarial isolation while unsandboxed `exec` can open the
+workspace/state tree.
+
+#### 10.5 Run exposure and egress
+
+If approved for this stage:
+
+- register stable egress capability IDs for message, session-send, network,
+  process, browser, webhook, upload/export, plugin, MCP, file delivery, fanout,
+  and final reply surfaces;
+- deny unclassified side-effect tools after scoped exposure;
+- intersect every exposed resource audience into the run exposure set;
+- invalidate receipts after a later read or route/delivery/registry revision;
+- deny delivery or rerun without ineligible content after route changes.
+
+If the registry is deferred, document and enforce a narrower pilot profile that
+disables unclassified egress after scoped exposure.
+
+### Likely files
+
+- `src/agents/tool-fs-policy.ts`
+- `src/agents/tool-fs-policy.types.ts`
+- `src/agents/agent-tools.ts`
+- `src/agents/agent-tools.read.ts`
+- `src/agents/sandbox/*`
+- `src/agents/tool-policy-*`
+- requester/delivery policy files
+- message/session-send/browser/webhook/plugin/MCP tool registration surfaces
+- final reply route and outbound delivery paths
+
+### Tests
+
+- traversal, symlink, case, Unicode, hard-link where relevant, stale handle, and
+  virtual-to-host confusion;
+- sandbox gets only authorized roots;
+- direct controlled-root host paths fail;
+- route/sink revision change invalidates egress receipt;
+- later exposure invalidates an older receipt;
+- every unregistered side-effect tool is denied;
+- unsandboxed `exec` cannot be used in a model-adversarial profile.
+
+Focused existing tests:
+
+- `src/agents/tool-fs-policy.test.ts`
+- `src/agents/agent-tools.workspace-paths.test.ts`
+- `src/agents/sandbox/validate-sandbox-security.test.ts`
+- `src/agents/sandbox/workspace-mounts.test.ts`
+- `src/agents/requester-tool-policy.test.ts`
+- delivery and message-tool tests
+
+### Definition of done
+
+Phase 1D is complete only when all of the following are demonstrated:
+
+- [ ] Model-facing `read`, `write`, `edit`, and `apply_patch` cannot resolve a
+      raw controlled-memory path or an unmounted store.
+- [ ] Traversal, symlink, case-normalization, Unicode, stale-handle,
+      virtual-to-host, and relevant hard-link tests fail closed.
+- [ ] Sandboxed runs receive only their authorized virtual roots, with physical
+      read-only enforcement where required and no real artifact-root mount.
+- [ ] Unsandboxed `exec` is denied/hidden for model-adversarial mode, or the
+      deployment is explicitly limited to cooperative isolation with a Doctor
+      security finding.
+- [ ] Every enabled side-effect path after scoped exposure is classified in the
+      egress registry or denied by the approved constrained-pilot policy.
+- [ ] A later exposure, route change, sink change, delivery revision, or
+      registry revision invalidates older egress authorization.
+- [ ] Scoped content cannot reach an audience outside the run exposure set.
+- [ ] Filesystem, sandbox, exec, route-rebound, and egress-registry tests pass
+      on the required local and remote/cross-platform lanes.
+- [ ] Only after all prior items pass may a two-subject read-only pilot begin,
+      and its documented isolation claim matches the tested profile.
+
+### Rollback
+
+Withdraw the stronger isolation claim and disable enforced memory for profiles
+that cannot provide the required filesystem/egress boundary. Do not restore raw
+path access.
+
+## 11. Phase 2A: authorized writes and crash-consistent resources
+
+### Goal
+
+Route every durable memory mutation through the selected plugin's authorized
+resource lifecycle.
+
+### Deliverables
+
+#### 11.1 Closed mutation model
+
+Define a discriminated mutation union for:
+
+- remember/append;
+- replace;
+- delete/tombstone;
+- derive;
+- deposit;
+- project/publish;
+- import;
+- sync;
+- admin reclassification.
+
+The runtime chooses the default target from the session subject. Model JSON may
+select content or narrow an operation but cannot name another owner, store,
+root, or broader audience.
+
+#### 11.2 Builtin write state machine
+
+1. Complete identity, membership, policy, filesystem preparation, and plugin
+   hooks before opening a transaction.
+2. Stage a revision file with restrictive permissions and fsync it.
+3. In one short synchronous transaction, reread authoritative rows, insert a
+   pending immutable revision/write intent, and enqueue the audit outbox row.
+4. Commit.
+5. Rename the staged file to the revision-scoped locator and fsync.
+6. Compute finalized hash outside a transaction.
+7. In a second synchronous transaction, compare prepared facts, activate the
+   revision, repoint current resource revision, and finalize policy/lineage/
+   outbox state.
+8. Index only active revisions.
+
+Startup recovery completes valid pending intents or quarantines orphans. A
+pending file is never readable.
+
+#### 11.3 Convert write paths
+
+Convert or block:
+
+- explicit remember;
+- generic file writes to virtual memory;
+- human/operator edits and watcher ingestion;
+- delete/forget;
+- sync;
+- imports;
+- exports that create durable artifacts;
+- public artifact publication;
+- LanceDB store, forget, and auto-capture;
+- memory wiki write/import flows;
+- memory-core short-term promotion.
+
+New files without a valid catalog mapping enter quarantine.
+
+#### 11.4 Audit outbox
+
+Commit write/exposure decision records locally with plugin state, then drain
+idempotently to the shared redacted audit table. Audit delivery never becomes
+an allow dependency.
+
+### Data changes
+
+Per-agent:
+
+- `memory_write_intents`
+- `memory_audit_outbox`
+- lifecycle/index state extensions needed by active revisions
+
+Shared:
+
+- `memory_access_audit`
+
+### Tests
+
+- reject model-supplied store, owner, and audience;
+- every interruption boundary in stage/pending/rename/activate/index/outbox;
+- duplicate/retry/idempotency;
+- watcher edits without mapping quarantine;
+- delete removes current read eligibility immediately;
+- plugin crash cannot expose pending content;
+- LanceDB auto-capture uses session subject and policy;
+- sync/import/export cannot bypass authorization.
+
+### Definition of done
+
+Phase 2A is complete only when all of the following are demonstrated:
+
+- [ ] Every durable mutation path for an enforced agent routes through
+      `writeAuthorized`; no remember, file, watcher, import, export, sync,
+      plugin, LanceDB, or Memory Wiki bypass remains.
+- [ ] The runtime, not model arguments, selects the target store, owner, and
+      maximum audience.
+- [ ] Pending, orphaned, ambiguous, and quarantined revisions are never
+      readable or indexed as active.
+- [ ] The stage -> pending commit -> rename/fsync -> activation commit -> index
+      -> audit-outbox state machine survives interruption at every boundary.
+- [ ] Retries, duplicate requests, and recovery are idempotent and do not
+      create two active revisions.
+- [ ] Delete/tombstone removes read eligibility immediately and cannot leave a
+      readable FTS/vector/file artifact.
+- [ ] SQLite transaction callbacks perform no async work, filesystem access,
+      network access, plugin calls, or model calls.
+- [ ] Legacy/context-free writers remain blocked for enforced agents.
+- [ ] Focused write, crash-recovery, watcher, import/export, sync, and plugin
+      mutation tests pass.
+
+### Rollback
+
+Disable new writes while preserving scoped data. Resume only after repair.
+Never dual-write to legacy files/tables.
+
+## 12. Phase 2B: complete transcript policy lifecycle
+
+### Goal
+
+Make every transcript event and session transition carry durable authorization
+metadata for its full retention lifetime.
+
+### Deliverables
+
+#### 12.1 Policy companion rows
+
+Every assistant, user, tool-result, summary, checkpoint, and system event
+records:
+
+- source-policy-set ID;
+- normalized audience intersection;
+- finalized delivery and egress audiences;
+- actor evidence;
+- session identity and subject revisions;
+- delegation snapshot;
+- run exposure-set ID/revision;
+- exposed resource revisions;
+- expected current policy revision/revocation epoch.
+
+Append the event and companion row in one per-agent SQLite transaction.
+The selected plugin must finish policy evaluation and return the opaque
+policy-set payload before this transaction begins. Core persists it without
+understanding store kinds or ACL semantics.
+
+#### 12.2 Policy sets
+
+Store immutable policy sets for transcript and derivation retention:
+
+- member stable policy IDs;
+- captured revisions;
+- expected active revisions/revocation epochs;
+- normalized audience intersection;
+- retention state.
+
+Captured revisions preserve history, not permanent allow. Each read/derivation
+resolves the stable policy against its current active revision.
+
+#### 12.3 Session transitions
+
+Reset, fork, rewind, branch, checkpoint restore, archive, and export preserve:
+
+- source subject provenance;
+- policy-set references;
+- session identity revision;
+- event lineage.
+
+An import that cannot prove lineage remains quarantine and receives no normal
+memory view.
+
+#### 12.4 Missing-label behavior
+
+Missing or invalid companion metadata is pending/denied. Never reconstruct
+authorization from event JSON, prompt text, session key shape, or
+`InputProvenance`.
+
+### Data changes
+
+Extend the Phase 1C minimum tables with full lineage-retention and transition
+fields:
+
+- `transcript_event_memory_policies`
+- `memory_policy_sets`
+- `memory_run_exposures`
+
+Add:
+
+- `memory_compaction_policies`
+
+### Likely files
+
+- `src/config/sessions/session-accessor.sqlite-transcript-write.ts`
+- `src/config/sessions/session-accessor.sqlite-transcript-store.ts`
+- `src/config/sessions/session-accessor.sqlite-contract.ts`
+- `src/config/sessions/session-accessor.types.ts`
+- `src/config/sessions/session-transcript-*`
+- `src/gateway/session-reset-service.ts`
+- `src/gateway/server-methods/sessions-rewind.ts`
+- transcript export/import/archive paths
+
+### Tests
+
+- atomic event + policy companion write;
+- authorization-pending exclusion;
+- reset/fork/rewind/archive/export preservation;
+- current-policy revision invalidates old captured allow;
+- revoke-between-check-and-commit;
+- session-rebound during transcript append;
+- legacy unlabeled transcript remains unavailable unless migration confirms it.
+
+### Definition of done
+
+Phase 2B is complete only when all of the following are demonstrated:
+
+- [ ] Every readable user, assistant, tool-result, summary, checkpoint, and
+      system event has an atomic, evaluable policy companion row.
+- [ ] Every scoped exposure can be mapped to the durable events, policy-set
+      revision, delivery audience, and run exposure revision it influenced.
+- [ ] Stable policy IDs are revalidated against current active revisions and
+      revocation epochs; captured historical allows are not permanent grants.
+- [ ] Reset, rollover, fork, rewind, checkpoint restore, archive, export, and
+      confirmed import preserve subject and policy lineage exactly.
+- [ ] Missing, invalid, stale, or authorization-pending labels exclude events
+      from replay, search, compaction, export, and derivation.
+- [ ] Authorization is never reconstructed from session-key shape, transcript
+      JSON, rendered prompt text, or `InputProvenance`.
+- [ ] No plugin call or async work occurs inside the transcript commit
+      transaction.
+- [ ] Atomic-write, transition, policy-revision, revoke-race, session-rebound,
+      and legacy-unlabeled transcript tests pass.
+
+### Rollback
+
+Disable transcript recall, compaction, flush, dreaming, and derivation for the
+affected enforced agent. Keep ordinary conversation available with memory
+unavailable.
+
+## 13. Phase 2C: compaction, flush, dreaming, and delegation
+
+### Goal
+
+Prevent durable derived artifacts from laundering scoped content into a broader
+audience.
+
+### Deliverables
+
+#### 13.1 Derivation requirements
+
+Every derivation:
+
+- identifies immutable parent revisions or transcript policy sets;
+- checks `derive` authority before the model sees source content;
+- computes the intersection of all source audiences and requested target;
+- partitions or quarantines when no representable common audience exists;
+- records lineage;
+- preserves current stable policy requirements;
+- creates a new immutable revision.
+
+#### 13.2 Compaction
+
+Before summarization:
+
+- collect every compacted event, prior summary, preserved turn, and injected
+  memory revision;
+- compute one source-policy set;
+- ensure the summarizer receives only authorized content.
+
+After summarization:
+
+- derive output policy deterministically;
+- reject unrepresentable audience;
+- persist summary, checkpoint, policy metadata, and lineage together;
+- preserve through all session transitions.
+
+Integration anchors:
+
+- `src/agents/embedded-agent-runner/compaction-checkpoint.ts:17-65`
+- `src/gateway/session-compaction-checkpoints.ts:574-760`
+- embedded compaction execution and queued compaction paths
+
+Any provider/harness adapter, including Codex-specific integration, must inspect
+the exact upstream dependency/runtime contract before implementation. Do not
+infer native compaction behavior from OpenClaw wrappers.
+
+#### 13.3 Memory flush
+
+Replace the current model-directed raw filesystem target with an authorized
+mutation:
+
+- private DM -> user episodic store;
+- channel/group -> conversation store;
+- service/agent -> agent store or no write;
+- ambiguous/incognito -> no durable write.
+
+Extend provenance with resource/store/audience/source-event revisions.
+
+#### 13.4 Dreaming and promotion
+
+Run one authorized store at a time:
+
+- session ingestion;
+- daily ingestion;
+- Light/REM phases;
+- `DREAMS.md`;
+- profile/front-card promotion;
+- consolidation and repair.
+
+Never combine unrelated stores in one model context. Postbox and quarantine are
+ineligible until review changes their state.
+
+#### 13.5 Tombstones and descendants
+
+- materialize source policy requirements on derived revisions;
+- tombstone/revoke invalidates descendants immediately;
+- background jobs may recompute utility but do not restore access
+  automatically;
+- reclassification requires explicit declassification authority and a new
+  reviewed revision.
+
+#### 13.6 Delegation and autonomous runs
+
+Child view:
+
+```text
+parent authorized view
+intersect child capability snapshot
+intersect child session/collaboration visibility
+intersect current revocation and membership
+```
+
+Children receive minimal explicit excerpts or opaque plugin capabilities, never
+raw DB handles, credentials, or an unbounded parent view.
+
+Cron, heartbeat, webhook, and system runs use explicit service identities and
+cannot acquire private user memory from an old session key.
+
+### Data changes
+
+- `memory_revision_policy_requirements`
+- `memory_lineage_edges`
+- descendant invalidation/repair state as needed
+
+### Tests
+
+- mixed private/channel/shared/projected compaction;
+- summary policy intersection;
+- tombstoned/revoked ancestor denial;
+- compaction policy survives reset/fork/rewind/archive/export;
+- flush target matrix;
+- dreaming one-store-at-a-time and no postbox promotion;
+- child cannot widen parent view;
+- autonomous run cannot mount private store;
+- crash recovery around summary/checkpoint/resource activation.
+
+Focused existing tests:
+
+- `src/gateway/session-compaction-checkpoints.test.ts`
+- `src/agents/agent-hooks/compaction-safeguard.test.ts`
+- embedded compaction/checkpoint tests
+- `extensions/memory-core/src/flush-plan.test.ts`
+- `extensions/memory-core/src/dreaming-phases.test.ts`
+- memory-core dreaming consolidation/repair tests
+- subagent requester and completion-handoff tests
+
+### Definition of done
+
+Phase 2C is complete only when all of the following are demonstrated:
+
+- [ ] Every compaction, checkpoint, memory flush, dreaming output, promotion,
+      export, and child-produced durable artifact identifies immutable parents
+      and records lineage.
+- [ ] `derive` authority is checked before source content enters a model
+      context.
+- [ ] No unlabeled or policy-unrepresentable derived artifact is readable.
+- [ ] Group compaction and flush remain channel-scoped; private compaction and
+      flush remain user-scoped; autonomous work remains agent-scoped or writes
+      nothing.
+- [ ] Mixed audiences are partitioned or denied and can never be widened by
+      model wording.
+- [ ] Tombstoning/revoking an ancestor denies descendants immediately; any
+      recomputation creates a new reviewed immutable revision.
+- [ ] Dreaming and promotion run one authorized store at a time, and postbox or
+      quarantine content cannot auto-promote.
+- [ ] Child agents receive only the intersection of parent view, task
+      capability, session visibility, and current authority; cron, heartbeat,
+      webhook, and system runs cannot recover private access from a session key.
+- [ ] Compaction, flush, dreaming, lineage, revocation, delegation, and
+      interruption tests pass, including any dependency-specific contract
+      checks required by the selected harness.
+
+### Rollback
+
+Disable derivation and background memory jobs while preserving scoped resources.
+Do not restore context-free compaction or flush.
+
+## 14. Phase 3: explicit sharing and postbox
+
+### Goal
+
+Add deliberate sharing without introducing direct private-store reads.
+
+### Deliverables
+
+#### 14.1 Publisher operations
+
+Agent-shared and role stores require explicit publisher authority independent
+of read authority. Ordinary memory capture cannot write them.
+
+#### 14.2 Projections
+
+A projection is a reviewed copy with:
+
+- one target channel, role, or agent-shared audience;
+- purpose and human-readable preview;
+- source immutable revision;
+- publisher;
+- required expiry or explicit audited `no_expiry`;
+- revocation behavior;
+- lineage to the source.
+
+Source edits do not auto-republish. A refreshed projection is a new reviewed
+revision.
+
+#### 14.3 Postbox
+
+Initial modes:
+
+- `off` by default;
+- `review-required` when explicitly enabled.
+
+Do not ship labeled automatic use in the first rollout.
+
+Deposit requirements:
+
+- model names a server-issued source-message handle, not a user/store ID;
+- core resolves current verified sender evidence;
+- selected plugin resolves the target quarantine;
+- channel receives success or generic refusal only;
+- channel cannot search/list/read/exact-get the item;
+- persistent per-source-channel/target rate limits;
+- owner provenance label, approve/edit/reject/purge controls;
+- no bootstrap, trigger injection, dreaming, or promotion before review.
+
+#### 14.4 Owner/admin surfaces
+
+Add authenticated CLI/UI/API workflows for:
+
+- store inspection;
+- projection preview/create/revoke/refresh;
+- postbox review and purge;
+- safe deletion;
+- revocation impact.
+
+Do not add direct user-to-user private-store grant APIs.
+
+### Data changes
+
+- `memory_projections`
+- `memory_postbox_items`
+- persisted rate-limit/review state
+
+### Tests
+
+- target sees projection copy but never source;
+- unrelated/newly joined channel cannot see projection;
+- expiry/revoke removes all new reads;
+- prior exposure impact is enumerable;
+- forged/stale/cross-channel source-message handle denied;
+- channel cannot read deposited item back;
+- postbox never auto-promotes;
+- no direct private grant through tool, SDK, API, CLI, UI, or raw DB helper.
+
+### Definition of done
+
+Phase 3 is complete only when all of the following are demonstrated:
+
+- [ ] Agent-shared and role writes require explicit publisher authority
+      independent of read authority.
+- [ ] Every projection names one audience, purpose, source revision, publisher,
+      expiry/no-expiry decision, and revocation behavior.
+- [ ] A projection exposes only its reviewed copy; the target cannot read or
+      mutate the private source.
+- [ ] Projection refresh creates a new reviewed revision, while expiry or
+      revocation removes all new reads and enumerates affected prior exposures.
+- [ ] Postbox remains `off` by default and supports review-required mode before
+      any labeled automatic-use mode.
+- [ ] A source session can deposit only through a current server-issued source
+      message handle and receives no list/read/exact-get capability over the
+      result.
+- [ ] Postbox rate limits, provenance, review, purge, and no-auto-promotion
+      behavior are persisted and tested.
+- [ ] Owner/admin CLI, API, and UI operations authenticate and use authorized
+      plans.
+- [ ] No tool, SDK, API, CLI, UI, plugin, or raw argument can create direct
+      private user-to-user store access.
+- [ ] Projection, publisher, postbox, expiry, revocation, forged-handle, and
+      prior-exposure tests pass.
+
+### Rollback
+
+Disable new projection/deposit operations. Tombstone projection reads and keep
+postbox items quarantined for review or purge.
+
+## 15. Phase 4: enterprise identity and operations
+
+### Goal
+
+Add revisioned enterprise identity evidence and operational access review
+without moving policy authority out of the selected memory plugin.
+
+### Deliverables
+
+#### 15.1 Generic adapter registry
+
+- manifest-declared provider capability;
+- operator allowlist;
+- duplicate registration refusal;
+- startup-only sealing;
+- core constructs canonical principals;
+- adapter can deny service but cannot forge another provider's principal.
+
+#### 15.2 Provider adapters
+
+Implement alphabetically:
+
+- Entra ID;
+- Google Workspace;
+- Okta.
+
+Each adapter provides protocol-appropriate verification material and group
+snapshots. Core validates before adding facts to the context.
+
+#### 15.3 Membership snapshots
+
+- revisioned evidence;
+- observed and expiry times;
+- provider/tenant binding;
+- bounded staleness;
+- outage expiry removes access;
+- refresh/removal and audit.
+
+Use existing `session_members` only for Gateway collaborative-session
+membership. Native channel and enterprise group membership remains separate
+provider evidence.
+
+#### 15.4 Operations
+
+- redacted access explanation;
+- audit query/export/retention;
+- policy drift alerts;
+- revocation impact;
+- periodic access review;
+- load tests for hundreds/thousands of stores, roles, and channels.
+
+If this introduces a new plugin, update `.github/labeler.yml` and create the
+matching GitHub labels as part of the plugin PR.
+
+### Tests
+
+- wrong issuer/audience/signature/tenant;
+- expired, revoked, and unbound identity;
+- duplicate/unlisted provider registration;
+- role removal within documented bound;
+- provider outage does not extend membership indefinitely;
+- audit explanation reveals no unauthorized resource title/existence;
+- collection/mount fan-out benchmarks for builtin and QMD.
+
+### Definition of done
+
+Phase 4 is complete only when all of the following are demonstrated:
+
+- [ ] Every enabled enterprise adapter is operator-allowlisted, manifest
+      declared, unique for its provider prefix, and registered before the
+      registry seals.
+- [ ] Core, not the adapter, validates issuer/audience/signature or registered
+      attestation, tenant binding, assurance, expiry, and snapshot freshness
+      before constructing principals.
+- [ ] Private stores never open for forged, wrong-issuer, wrong-audience,
+      expired, revoked, conflicting, or unbound identities.
+- [ ] Role and native-channel evidence is revisioned, bounded by documented
+      staleness, and removed fail-closed during expiry or provider outage.
+- [ ] Existing `session_members` remains authoritative only for Gateway
+      collaborative sessions; provider membership does not create a competing
+      session-sharing store.
+- [ ] Operators can explain allow/deny decisions from redacted revisions,
+      subject/store kinds, collaboration roles, evidence, and rules without
+      storing or revealing unauthorized memory content.
+- [ ] Audit retention/export and periodic access-review behavior are approved
+      and implemented.
+- [ ] Provider verification, outage/expiry, group removal, registry sealing,
+      audit explanation, and scale/fan-out tests pass, including required live
+      official-provider proof.
+- [ ] Any new plugin surface has matching labeler paths, GitHub labels, SDK
+      contracts, docs, and package ownership metadata.
+
+### Rollback
+
+Disable adapters and allow evidence to expire. Local verified user/channel
+stores continue under Stage 2 rules. Stale role evidence never becomes a local
+allow.
+
+## 16. Phase 5: process-adversarial isolation
+
+### Goal
+
+Prevent a compromised non-broker agent/tool process from crossing its issued
+memory view.
+
+### Deliverables
+
+- move selected memory plugin, content-bearing indexes, and controlled artifact
+  roots behind authenticated local IPC;
+- keep broker DB handles, filesystem roots, and keys out of agent processes;
+- bind IPC to Gateway-issued subject, capability snapshot, agent, session,
+  policy revision, and request nonce;
+- reject client-supplied principals and replay;
+- run agents in per-session sandboxes with only virtual mounts;
+- define bounded queues, cancellation, timeouts, and denial-of-service limits;
+- define broker startup, health, upgrade, backup, and recovery;
+- document the trusted computing base: Gateway, broker backend, selected memory
+  plugin, and operator.
+
+If at-rest application encryption is added, do it only after process separation
+creates real key isolation. Do not add SQLCipher merely to protect an
+in-process key from the same process.
+
+### Tests
+
+- compromised agent opens another store;
+- raw artifact path and DB handle probing;
+- IPC replay across session/actor/agent/revision;
+- confused deputy;
+- stale/revoked capability;
+- malicious model-facing plugin inside constrained process;
+- broker crash/restart and backpressure;
+- OS permissions and credential separation;
+- separate-cell hostile-tenant scenario.
+
+### Definition of done
+
+Phase 5 is complete only when all of the following are demonstrated:
+
+- [ ] The selected memory plugin, content-bearing indexes, and controlled
+      artifact roots execute behind authenticated IPC outside the agent/tool
+      process.
+- [ ] Agent processes receive no broker database handle, raw artifact root,
+      encryption key, or reusable broker credential.
+- [ ] IPC binds requests to agent, session, subject, actor/capability snapshot,
+      policy revision, request nonce, and expiry; cross-context replay fails.
+- [ ] Per-session sandboxes expose only the issued virtual mounts.
+- [ ] Compromised non-broker agent/tool code cannot read, write, enumerate, or
+      infer a store outside its issued view.
+- [ ] Broker cancellation, timeout, queue bounds, restart, upgrade, backup,
+      repair, and denial-of-service behavior are defined and tested.
+- [ ] OS-permission, raw-path, DB-handle, replay, confused-deputy,
+      stale-capability, malicious-tool, crash/restart, and separate-cell tests
+      pass in a real process-isolated environment.
+- [ ] Documentation states the exact tested process-adversarial boundary and
+      names the trusted Gateway, broker backend, selected memory plugin, and
+      operator.
+- [ ] Hostile tenants continue to require separate
+      Gateway/process/credential/storage cells.
+
+### Rollback
+
+Explicitly withdraw the process-adversarial claim. Either return to cooperative
+Stage 2 after a verified export/cutover or split trust domains into separate
+cells. Never replace a failed broker with raw filesystem/database access.
+
+## 17. Phase 6: migration, pilot, and cleanup
+
+### Goal
+
+Cut over selected agents safely, prove real behavior, and remove temporary
+shadow/legacy paths.
+
+### Deliverables
+
+#### 17.1 Migration
+
+1. Doctor dry-run and owner decisions.
+2. Verified backup.
+3. Copy to opaque scoped stores.
+4. Commit catalog, policy, subjects, and lineage.
+5. Build scoped index.
+6. Verify hashes, mounts, bootstrap, denial matrix, and backend conformance.
+7. Write one atomic cutover marker.
+8. Start enforced runtime.
+9. Archive/remove legacy files and legacy index rows only after verification.
+
+Rollback is available before cutover, or before any new scoped writes after
+cutover. Once new scoped writes exist, downgrade requires an explicit export
+that warns about lost audience metadata.
+
+#### 17.2 Pilot matrix
+
+Minimum end-to-end scenario:
+
+1. Alice and Bob create verified isolated DMs.
+2. Both store distinct private facts using colliding names/keywords.
+3. Both join one group and create a channel fact.
+4. Private recall returns only the current user's fact.
+5. Group recall returns only channel/shared/addressed projection content.
+6. Run child agent, compaction, flush, and dreaming in every context.
+7. Bob leaves, a projection is revoked, and a binding is revoked.
+8. New reads deny immediately or within the documented evidence bound.
+9. Audit proves decisions/exposures without storing the facts.
+
+#### 17.3 Cleanup
+
+- remove shadow-only adapters and temporary metrics;
+- remove context-free overloads from the enforced path;
+- remove legacy scoped-data import helpers after migration window;
+- update architecture, plugin SDK, security, multi-user, memory, compaction,
+  sandbox, Doctor, CLI, backup, and testing docs;
+- retain only explicit public API compatibility with a removal plan.
+
+### Definition of done
+
+Phase 6 is complete only when all of the following are demonstrated:
+
+- [ ] Doctor dry-run, verified backup, scoped copy, catalog/policy commit,
+      reindex, hash/mount/denial verification, and atomic cutover complete for
+      every pilot agent.
+- [ ] Ambiguous legacy files and transcripts are quarantined; no migration
+      decision is inferred from prose, filenames, route shape, or the launching
+      sender.
+- [ ] Each migrated agent has exactly one canonical runtime path with no
+      dual-read, dual-write, lazy import, or legacy fallback.
+- [ ] Every selected and supplemental backend is conforming or explicitly
+      unavailable in enforced mode.
+- [ ] The two-user/group pilot proves private, channel, shared, projection,
+      child, compaction, flush, dreaming, leave/revoke, binding-revoke, and
+      redacted-audit behavior.
+- [ ] New scoped writes make downgrade possible only through the documented
+      explicit export path; pre-write rollback is verified separately.
+- [ ] Shadow-only adapters, temporary metrics, context-free enforced overloads,
+      and migrated legacy index rows/files are removed according to the
+      approved retention window.
+- [ ] Architecture, memory, multi-user, compaction, sandbox, Doctor, CLI,
+      backup, plugin SDK, security, migration, and testing documentation matches
+      current behavior.
+- [ ] Exact-head focused and broad risk-appropriate validation is green, and
+      the recorded deployment claim matches the controls actually tested.
+
+## 18. Recommended PR sequence
+
+Keep each PR independently safe and feature-gated.
+
+1. SDK authorization types and conformance harness.
+2. Core branded context factory and shadow decisions.
+3. Session subject/binding additive schema and lifecycle.
+4. Builtin scoped store/resource/policy schema.
+5. Builtin authorized search/read contract.
+6. Doctor dry-run migration and backend admission.
+7. `memory_search`/`memory_get`/session recall conversion.
+8. Bootstrap, prompt supplements, active recall, wiki, and LanceDB read
+   conversion.
+9. Minimum transcript policy companion rows and exposure receipts.
+10. Virtual memory filesystem and file-tool confinement.
+11. Run exposure/egress registry, or approved constrained pilot alternative.
+12. Authorized write state machine and recovery.
+13. Convert remember/file/watcher/import/export/sync/plugin write paths.
+14. Complete transcript policy sets and transition preservation.
+15. Compaction/checkpoint derivation.
+16. Flush, dreaming, promotion, child, and autonomous derivation.
+17. Projections and publisher operations.
+18. Postbox off/review-required workflow.
+19. Enterprise adapter registry and provider plugins.
+20. Out-of-process broker and sandbox hardening.
+21. Pilot migration, evidence, and legacy cleanup.
+
+Public SDK PRs must update exports, baselines, docs, and bundled consumers in
+the same change. Schema PRs must state explicitly whether they are additive and
+why no version bump is required.
+
+## 19. Validation strategy
+
+### 19.1 Test layers
+
+| Layer                | Proof                                                                                                 |
+| -------------------- | ----------------------------------------------------------------------------------------------------- |
+| Pure types/evaluator | Property tests for implication, deny precedence, revision, audience, delegation, and lineage.         |
+| SQL/backend          | Candidate superset, top-K crowd-out, immutable revision, pending/quarantine denial, hash/path checks. |
+| Core context         | Identity, session-rebound, subject revision, actor separation, delivery revision.                     |
+| Plugin contract      | Builtin/QMD/LanceDB/wiki/active-memory conformance or enforced unavailability.                        |
+| Filesystem/sandbox   | Virtual mount, traversal/symlink/case/Unicode, direct host-path denial, exec profile.                 |
+| Transcript           | Atomic companion labels, reset/fork/rewind/archive/export, missing-label denial.                      |
+| Derivation           | Compaction/flush/dreaming/delegation audience intersection and ancestor revocation.                   |
+| Sharing              | Projection copy, postbox one-way behavior, expiry/revocation impact.                                  |
+| Enterprise           | Verification, expiry, group snapshot, outage, registry sealing.                                       |
+| Process              | IPC auth/replay, OS separation, compromised agent/tool process.                                       |
+| End to end           | Two-user/group/pilot matrix with revocation and audit.                                                |
+
+### 19.2 Repository commands
+
+For trusted source and one/few focused files with ready dependencies:
+
+```bash
+node scripts/run-vitest.mjs <path-or-filter>
+git diff --check
+```
+
+For changed-path classification in a linked/Codex worktree:
+
+```bash
+node scripts/check-changed.mjs -- <changed-files...>
+```
+
+Use Testbox/Crabbox for:
+
+- SDK surface checks;
+- changed typecheck/lint fan-out;
+- builds;
+- broad plugin suites;
+- sandbox/Docker/E2E;
+- cross-platform;
+- live enterprise provider proof;
+- package/install/upgrade proof.
+
+Required gates by risk:
+
+- SDK change: `pnpm plugin-sdk:surface:check`, export/baseline tests, bundled
+  plugin contract tests, build.
+- SQLite schema: focused schema/maintenance/Doctor tests plus migration
+  interruption cases.
+- Plugin runtime loading: build and isolated extension import profiling.
+- Sandbox/filesystem: focused policy tests plus Docker/Testbox scenario.
+- User-visible migration: Doctor live-copy scenario against an isolated state
+  directory.
+- Enterprise API: official contract/source verification plus live test.
+- Process isolation: real remote scenario, not only unit mocks.
+
+Do not run independent Vitest commands concurrently in one worktree.
+
+## 20. Observability
+
+Expose only bounded, redacted signals:
+
+- decision counts by operation and stable reason;
+- postfilter denial after prefilter pass;
+- backend capability/conformance failures;
+- subject/binding/membership revision age;
+- exposed resource count and bytes by scope kind;
+- quarantine/postbox/projection backlog;
+- projection expiry/revocation backlog;
+- search/policy/write/repair latency;
+- pending write intents and hash mismatches;
+- audit outbox backlog;
+- egress denial by capability class.
+
+Do not label metrics with query text, prompt text, memory content, raw provider
+IDs, or unbounded principal/resource identifiers.
+
+Stable denial reasons should include:
+
+- `invalid-context`
+- `session-rebound`
+- `delivery-rebound`
+- `plan-expired`
+- `identity-revoked`
+- `membership-stale`
+- `outside-view`
+- `revision-stale`
+- `explicit-deny`
+- `default-deny`
+- `lineage-deny`
+- `backend-nonconforming`
+
+## 21. Main risks and mitigations
+
+| Risk                                             | Mitigation                                                                                                           |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| Scope grows into a second memory architecture    | Keep selected plugin ownership; add generic contracts only; no core deep imports into bundled memory implementation. |
+| Stage 1 is too large to land                     | Use Phases 1A-1D with read-only enforced state and explicit exit gates.                                              |
+| Legacy backend silently widens access            | Reject nonconforming backend; never fallback from authorized QMD/external backend to broad legacy builtin.           |
+| Transcript or compaction launders content        | Require atomic policy companion rows before scoped exposure; compaction is derivation.                               |
+| File tools bypass memory policy                  | Controlled artifact roots are never model-visible; virtual memory paths delegate to authorized operations.           |
+| Unsandboxed exec defeats model isolation         | Hide/deny or restrict claim to cooperative isolation with Doctor finding.                                            |
+| Write crash exposes orphan/pending content       | Two-transaction pending-to-active state machine plus startup repair.                                                 |
+| Policy revisions leave descendants readable      | Store stable policy requirements and revalidate current revisions/epochs.                                            |
+| Migration publishes personal legacy data         | Structural classification and owner confirmation; ambiguous data goes to quarantine.                                 |
+| Too many public config knobs                     | One enablement surface; staged features unavailable until implemented.                                               |
+| Audit becomes a second sensitive corpus          | Store IDs, revisions, decisions, hashes, and timestamps only; explicit retention/access policy.                      |
+| Egress registry becomes unbounded project scope  | Owner decision before Phase 1D; constrained pilot if deferred, with no broad claim.                                  |
+| Enterprise plugin can forge identity             | Adapters provide evidence; core validates and constructs principals; allowlisted sealed registry.                    |
+| Direct grant complexity leaks into first release | Keep direct user-to-user private reads structurally absent.                                                          |
+
+## 22. Completion checklist
+
+- [ ] One trusted, write-once subject or explicit ambiguous/service state exists
+      for every session.
+- [ ] Every selected memory backend uses the versioned authorized contract.
+- [ ] Every supplemental memory path routes through the selected capability or
+      is unavailable.
+- [ ] Every content-bearing result has valid exposure and egress receipts.
+- [ ] Every durable memory resource has store, audience, authority, origin,
+      revision, and lifecycle state.
+- [ ] Every transcript event after scoped exposure has an evaluable policy
+      companion row.
+- [ ] Every write uses the authorized crash-consistent lifecycle.
+- [ ] Every derivation records source revisions and audience intersection.
+- [ ] Bootstrap, search, exact read, automatic recall, files, transcripts,
+      compaction, dreaming, delegation, sync, import, export, and public
+      artifacts have no unscoped fallback.
+- [ ] Existing session collaboration and provider membership are consumed only
+      at their owning boundaries.
+- [ ] Migration is explicit, idempotent, verified, and single-path at runtime.
+- [ ] Ambiguous legacy data is quarantined.
+- [ ] Postbox defaults off and remains write-only from source sessions.
+- [ ] No direct private user-to-user read path exists.
+- [ ] The tested isolation claim and trusted computing base are documented.
+- [ ] Stronger hostile-tenant guidance still requires separate cells.

--- a/docs/concepts/2026-07-29-memory-impl-plan.md
+++ b/docs/concepts/2026-07-29-memory-impl-plan.md
@@ -266,13 +266,13 @@ preserved from Phase 0.
 
 ## 6. Phase 0: contracts and shadow surface inspection
 
-### Goal
+### Phase 0 goal
 
 Create the generic core/SDK/plugin contract, inventory all memory paths, and
 evaluate selected-runtime authorization-surface compatibility in shadow mode
 without moving content or changing results.
 
-### Deliverables
+### Phase 0 deliverables
 
 #### 6.1 Serializable contract
 
@@ -410,20 +410,20 @@ Minimum inventory:
 - child agents and completion handoff;
 - cron, heartbeat, webhook, and system runs.
 
-### Data changes
+### Phase 0 data changes
 
 None required for the first contract PR. Shadow traces may use bounded
 structured logs or test-only fixtures. Do not create a permanent audit schema
 until the stable identifiers are decided.
 
-### Suggested PR slices
+### Phase 0 suggested PR slices
 
 1. Serializable types, capability declaration, and SDK conformance harness.
 2. Shadow wiring at selected runtime acquisition and path-inventory tests.
 3. Phase 1A core context factory with durable subject and trusted-ingress
    adapters.
 
-### Tests
+### Phase 0 tests
 
 - SDK export and API baseline checks.
 - `src/plugins/memory-state.test.ts`
@@ -431,7 +431,7 @@ until the stable identifiers are decided.
 - new generated policy evaluator tests;
 - new "no context-free enforced backend" contract test.
 
-### Definition of done
+### Phase 0 definition of done
 
 Phase 0 is complete only when all of the following are demonstrated on the
 current implementation head:
@@ -454,19 +454,19 @@ current implementation head:
 - [ ] Product and security documentation still describes the feature as
       shadow-only, with no public isolation claim or public configuration.
 
-### Rollback
+### Phase 0 rollback
 
 Remove shadow invocation and ignore the new capability when the agent is not
 enforced. No content or schema rollback is required.
 
 ## 7. Phase 1A: identity and write-once session subject
 
-### Goal
+### Phase 1A goal
 
 Resolve one immutable memory subject for every logical session before any
 private store can open.
 
-### Deliverables
+### Phase 1A deliverables
 
 #### 7.1 Principal model
 
@@ -556,7 +556,7 @@ excludes model-authored JSON and extensible message extras, and produces the
 stable context fingerprint. It is not an SDK entrypoint and no plugin can mint
 or modify its output.
 
-### Data changes
+### Phase 1A data changes
 
 Shared state:
 
@@ -570,7 +570,7 @@ Per-agent:
 
 Use additive lazy ensures. Fold into the next natural schema-version bump.
 
-### Likely files
+### Phase 1A likely files
 
 - `src/routing/session-key.ts`
 - `src/routing/resolve-route.ts`
@@ -583,7 +583,7 @@ Use additive lazy ensures. Fold into the next natural schema-version bump.
 - `src/state/openclaw-agent-schema.sql`
 - shared state schema/contract files
 
-### Tests
+### Phase 1A tests
 
 - isolated DM, shared-main DM, group, channel, cron, heartbeat, webhook,
   subagent, system, and incognito subject matrix;
@@ -603,7 +603,7 @@ Reuse and extend:
 - `src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts`
 - Gateway session create/reset tests
 
-### Definition of done
+### Phase 1A definition of done
 
 Phase 1A is complete only when all of the following are demonstrated:
 
@@ -626,19 +626,19 @@ Phase 1A is complete only when all of the following are demonstrated:
 - [ ] Additive schema compatibility and identity/session lifecycle tests pass
       for existing and newly created agent databases.
 
-### Rollback
+### Phase 1A rollback
 
 Keep the new subject rows unused while current memory remains legacy-only.
 Bindings may remain as inert identity metadata.
 
 ## 8. Phase 1B: scoped store, policy, and migration foundation
 
-### Goal
+### Phase 1B goal
 
 Give the builtin selected memory plugin isolated logical stores and immutable
 resource/policy revisions without changing legacy agents.
 
-### Deliverables
+### Phase 1B deliverables
 
 #### 8.1 Root and store registry
 
@@ -728,7 +728,7 @@ Implement dry-run only first:
 
 No runtime cutover in the dry-run PR.
 
-### Data changes
+### Phase 1B data changes
 
 Per-agent plugin tables:
 
@@ -748,7 +748,7 @@ Register every additive per-agent table in
 shadow tables and triggers in the corresponding optional canonical trigger
 groups. Add any lazily ensured columns to `allowedMissingColumns`.
 
-### Likely files
+### Phase 1B likely files
 
 - `packages/memory-host-sdk/src/host/memory-schema*.ts`
 - `src/state/openclaw-agent-schema.sql`
@@ -759,7 +759,7 @@ groups. Add any lazily ensured columns to `allowedMissingColumns`.
 - `src/commands/doctor-agent-memory-schema.ts`
 - new memory-core doctor/migration modules
 
-### Tests
+### Phase 1B tests
 
 - opaque path collision/retry and path traversal;
 - no provider identity in path or locator;
@@ -770,7 +770,7 @@ groups. Add any lazily ensured columns to `allowedMissingColumns`.
 - dry-run migration is deterministic and content-free in logs;
 - existing legacy agent remains byte-for-byte on the old path.
 
-### Definition of done
+### Phase 1B definition of done
 
 Phase 1B is complete only when all of the following are demonstrated:
 
@@ -792,20 +792,20 @@ Phase 1B is complete only when all of the following are demonstrated:
 - [ ] Legacy single-user agents remain on the existing runtime path with no
       user-visible behavior change or runtime cutover.
 
-### Rollback
+### Phase 1B rollback
 
 Drop or ignore empty additive tables and remove dry-run state. Legacy content
 was never moved.
 
 ## 9. Phase 1C: private and channel read isolation
 
-### Goal
+### Phase 1C goal
 
 Convert every content-bearing read lane to the authorized runtime and enable a
 single-subject/shadow read-only pilot. A pilot with two distinct verified
 subjects is gated on Phase 1D filesystem and exec confinement.
 
-### Deliverables
+### Phase 1C deliverables
 
 #### 9.1 Core access host
 
@@ -907,7 +907,7 @@ the transcript transaction. Core writes the policy-set row, run exposure
 reference, and event companion row atomically with the transcript event. There
 is no plugin callback inside the transaction.
 
-### Likely files
+### Phase 1C likely files
 
 - `src/plugins/memory-runtime.ts`
 - `src/plugins/memory-state.ts`
@@ -923,7 +923,7 @@ is no plugin callback inside the transaction.
 - `src/auto-reply/reply/agent-runner-memory.ts`
 - `src/config/sessions/session-accessor.sqlite-transcript-write.ts`
 
-### Tests
+### Phase 1C tests
 
 Read-lane matrix:
 
@@ -959,7 +959,7 @@ Focused existing tests:
 - `src/auto-reply/reply/agent-runner-memory.test.ts`
 - transcript accessor and projection tests
 
-### Definition of done
+### Phase 1C definition of done
 
 Phase 1C is complete only when all of the following are demonstrated:
 
@@ -985,7 +985,7 @@ Phase 1C is complete only when all of the following are demonstrated:
 - [ ] No two-subject pilot or stronger isolation claim is enabled before Phase
       1D closes raw file and exec bypasses.
 
-### Rollback
+### Phase 1C rollback
 
 Disable enforced mode for agents not yet cut over. Migrated agents remain
 read-only until restored through the documented pre-write rollback path; never
@@ -993,12 +993,12 @@ fall back to broad legacy reads.
 
 ## 10. Phase 1D: filesystem and egress confinement
 
-### Goal
+### Phase 1D goal
 
 Prevent model-facing file and delivery surfaces from bypassing an authorized
 memory view.
 
-### Deliverables
+### Phase 1D deliverables
 
 #### 10.1 Virtual filesystem view
 
@@ -1063,7 +1063,7 @@ If approved for this stage:
 If the registry is deferred, document and enforce a narrower pilot profile that
 disables unclassified egress after scoped exposure.
 
-### Likely files
+### Phase 1D likely files
 
 - `src/agents/tool-fs-policy.ts`
 - `src/agents/tool-fs-policy.types.ts`
@@ -1075,7 +1075,7 @@ disables unclassified egress after scoped exposure.
 - message/session-send/browser/webhook/plugin/MCP tool registration surfaces
 - final reply route and outbound delivery paths
 
-### Tests
+### Phase 1D tests
 
 - traversal, symlink, case, Unicode, hard-link where relevant, stale handle, and
   virtual-to-host confusion;
@@ -1095,7 +1095,7 @@ Focused existing tests:
 - `src/agents/requester-tool-policy.test.ts`
 - delivery and message-tool tests
 
-### Definition of done
+### Phase 1D definition of done
 
 Phase 1D is complete only when all of the following are demonstrated:
 
@@ -1118,7 +1118,7 @@ Phase 1D is complete only when all of the following are demonstrated:
 - [ ] Only after all prior items pass may a two-subject read-only pilot begin,
       and its documented isolation claim matches the tested profile.
 
-### Rollback
+### Phase 1D rollback
 
 Withdraw the stronger isolation claim and disable enforced memory for profiles
 that cannot provide the required filesystem/egress boundary. Do not restore raw
@@ -1126,12 +1126,12 @@ path access.
 
 ## 11. Phase 2A: authorized writes and crash-consistent resources
 
-### Goal
+### Phase 2A goal
 
 Route every durable memory mutation through the selected plugin's authorized
 resource lifecycle.
 
-### Deliverables
+### Phase 2A deliverables
 
 #### 11.1 Closed mutation model
 
@@ -1193,7 +1193,7 @@ Commit write/exposure decision records locally with plugin state, then drain
 idempotently to the shared redacted audit table. Audit delivery never becomes
 an allow dependency.
 
-### Data changes
+### Phase 2A data changes
 
 Per-agent:
 
@@ -1205,7 +1205,7 @@ Shared:
 
 - `memory_access_audit`
 
-### Tests
+### Phase 2A tests
 
 - reject model-supplied store, owner, and audience;
 - every interruption boundary in stage/pending/rename/activate/index/outbox;
@@ -1216,7 +1216,7 @@ Shared:
 - LanceDB auto-capture uses session subject and policy;
 - sync/import/export cannot bypass authorization.
 
-### Definition of done
+### Phase 2A definition of done
 
 Phase 2A is complete only when all of the following are demonstrated:
 
@@ -1239,19 +1239,19 @@ Phase 2A is complete only when all of the following are demonstrated:
 - [ ] Focused write, crash-recovery, watcher, import/export, sync, and plugin
       mutation tests pass.
 
-### Rollback
+### Phase 2A rollback
 
 Disable new writes while preserving scoped data. Resume only after repair.
 Never dual-write to legacy files/tables.
 
 ## 12. Phase 2B: complete transcript policy lifecycle
 
-### Goal
+### Phase 2B goal
 
 Make every transcript event and session transition carry durable authorization
 metadata for its full retention lifetime.
 
-### Deliverables
+### Phase 2B deliverables
 
 #### 12.1 Policy companion rows
 
@@ -1304,7 +1304,7 @@ Missing or invalid companion metadata is pending/denied. Never reconstruct
 authorization from event JSON, prompt text, session key shape, or
 `InputProvenance`.
 
-### Data changes
+### Phase 2B data changes
 
 Extend the Phase 1C minimum tables with full lineage-retention and transition
 fields:
@@ -1317,7 +1317,7 @@ Add:
 
 - `memory_compaction_policies`
 
-### Likely files
+### Phase 2B likely files
 
 - `src/config/sessions/session-accessor.sqlite-transcript-write.ts`
 - `src/config/sessions/session-accessor.sqlite-transcript-store.ts`
@@ -1328,7 +1328,7 @@ Add:
 - `src/gateway/server-methods/sessions-rewind.ts`
 - transcript export/import/archive paths
 
-### Tests
+### Phase 2B tests
 
 - atomic event + policy companion write;
 - authorization-pending exclusion;
@@ -1338,7 +1338,7 @@ Add:
 - session-rebound during transcript append;
 - legacy unlabeled transcript remains unavailable unless migration confirms it.
 
-### Definition of done
+### Phase 2B definition of done
 
 Phase 2B is complete only when all of the following are demonstrated:
 
@@ -1359,7 +1359,7 @@ Phase 2B is complete only when all of the following are demonstrated:
 - [ ] Atomic-write, transition, policy-revision, revoke-race, session-rebound,
       and legacy-unlabeled transcript tests pass.
 
-### Rollback
+### Phase 2B rollback
 
 Disable transcript recall, compaction, flush, dreaming, and derivation for the
 affected enforced agent. Keep ordinary conversation available with memory
@@ -1367,12 +1367,12 @@ unavailable.
 
 ## 13. Phase 2C: compaction, flush, dreaming, and delegation
 
-### Goal
+### Phase 2C goal
 
 Prevent durable derived artifacts from laundering scoped content into a broader
 audience.
 
-### Deliverables
+### Phase 2C deliverables
 
 #### 13.1 Derivation requirements
 
@@ -1464,13 +1464,13 @@ raw DB handles, credentials, or an unbounded parent view.
 Cron, heartbeat, webhook, and system runs use explicit service identities and
 cannot acquire private user memory from an old session key.
 
-### Data changes
+### Phase 2C data changes
 
 - `memory_revision_policy_requirements`
 - `memory_lineage_edges`
 - descendant invalidation/repair state as needed
 
-### Tests
+### Phase 2C tests
 
 - mixed private/channel/shared/projected compaction;
 - summary policy intersection;
@@ -1492,7 +1492,7 @@ Focused existing tests:
 - memory-core dreaming consolidation/repair tests
 - subagent requester and completion-handoff tests
 
-### Definition of done
+### Phase 2C definition of done
 
 Phase 2C is complete only when all of the following are demonstrated:
 
@@ -1518,18 +1518,18 @@ Phase 2C is complete only when all of the following are demonstrated:
       interruption tests pass, including any dependency-specific contract
       checks required by the selected harness.
 
-### Rollback
+### Phase 2C rollback
 
 Disable derivation and background memory jobs while preserving scoped resources.
 Do not restore context-free compaction or flush.
 
 ## 14. Phase 3: explicit sharing and postbox
 
-### Goal
+### Phase 3 goal
 
 Add deliberate sharing without introducing direct private-store reads.
 
-### Deliverables
+### Phase 3 deliverables
 
 #### 14.1 Publisher operations
 
@@ -1583,13 +1583,13 @@ Add authenticated CLI/UI/API workflows for:
 
 Do not add direct user-to-user private-store grant APIs.
 
-### Data changes
+### Phase 3 data changes
 
 - `memory_projections`
 - `memory_postbox_items`
 - persisted rate-limit/review state
 
-### Tests
+### Phase 3 tests
 
 - target sees projection copy but never source;
 - unrelated/newly joined channel cannot see projection;
@@ -1600,7 +1600,7 @@ Do not add direct user-to-user private-store grant APIs.
 - postbox never auto-promotes;
 - no direct private grant through tool, SDK, API, CLI, UI, or raw DB helper.
 
-### Definition of done
+### Phase 3 definition of done
 
 Phase 3 is complete only when all of the following are demonstrated:
 
@@ -1626,19 +1626,19 @@ Phase 3 is complete only when all of the following are demonstrated:
 - [ ] Projection, publisher, postbox, expiry, revocation, forged-handle, and
       prior-exposure tests pass.
 
-### Rollback
+### Phase 3 rollback
 
 Disable new projection/deposit operations. Tombstone projection reads and keep
 postbox items quarantined for review or purge.
 
 ## 15. Phase 4: enterprise identity and operations
 
-### Goal
+### Phase 4 goal
 
 Add revisioned enterprise identity evidence and operational access review
 without moving policy authority out of the selected memory plugin.
 
-### Deliverables
+### Phase 4 deliverables
 
 #### 15.1 Generic adapter registry
 
@@ -1685,7 +1685,7 @@ provider evidence.
 If this introduces a new plugin, update `.github/labeler.yml` and create the
 matching GitHub labels as part of the plugin PR.
 
-### Tests
+### Phase 4 tests
 
 - wrong issuer/audience/signature/tenant;
 - expired, revoked, and unbound identity;
@@ -1695,7 +1695,7 @@ matching GitHub labels as part of the plugin PR.
 - audit explanation reveals no unauthorized resource title/existence;
 - collection/mount fan-out benchmarks for builtin and alternate backends.
 
-### Definition of done
+### Phase 4 definition of done
 
 Phase 4 is complete only when all of the following are demonstrated:
 
@@ -1723,7 +1723,7 @@ Phase 4 is complete only when all of the following are demonstrated:
 - [ ] Any new plugin surface has matching labeler paths, GitHub labels, SDK
       contracts, docs, and package ownership metadata.
 
-### Rollback
+### Phase 4 rollback
 
 Disable adapters and allow evidence to expire. Local verified user/channel
 stores continue under Stage 2 rules. Stale role evidence never becomes a local
@@ -1731,12 +1731,12 @@ allow.
 
 ## 16. Phase 5: process-adversarial isolation
 
-### Goal
+### Phase 5 goal
 
 Prevent a compromised non-broker agent/tool process from crossing its issued
 memory view.
 
-### Deliverables
+### Phase 5 deliverables
 
 - move selected memory plugin, content-bearing indexes, and controlled artifact
   roots behind authenticated local IPC;
@@ -1754,7 +1754,7 @@ If at-rest application encryption is added, do it only after process separation
 creates real key isolation. Do not add SQLCipher merely to protect an
 in-process key from the same process.
 
-### Tests
+### Phase 5 tests
 
 - compromised agent opens another store;
 - raw artifact path and DB handle probing;
@@ -1766,7 +1766,7 @@ in-process key from the same process.
 - OS permissions and credential separation;
 - separate-cell hostile-tenant scenario.
 
-### Definition of done
+### Phase 5 definition of done
 
 Phase 5 is complete only when all of the following are demonstrated:
 
@@ -1791,7 +1791,7 @@ Phase 5 is complete only when all of the following are demonstrated:
 - [ ] Hostile tenants continue to require separate
       Gateway/process/credential/storage cells.
 
-### Rollback
+### Phase 5 rollback
 
 Explicitly withdraw the process-adversarial claim. Either return to cooperative
 Stage 2 after a verified export/cutover or split trust domains into separate
@@ -1799,12 +1799,12 @@ cells. Never replace a failed broker with raw filesystem/database access.
 
 ## 17. Phase 6: migration, pilot, and cleanup
 
-### Goal
+### Phase 6 goal
 
 Cut over selected agents safely, prove real behavior, and remove temporary
 shadow/legacy paths.
 
-### Deliverables
+### Phase 6 deliverables
 
 #### 17.1 Migration
 
@@ -1845,7 +1845,7 @@ Minimum end-to-end scenario:
   sandbox, Doctor, CLI, backup, and testing docs;
 - retain only explicit public API compatibility with a removal plan.
 
-### Definition of done
+### Phase 6 definition of done
 
 Phase 6 is complete only when all of the following are demonstrated:
 

--- a/docs/concepts/2026-07-29-memory-impl-plan.md
+++ b/docs/concepts/2026-07-29-memory-impl-plan.md
@@ -303,7 +303,8 @@ Required invariants:
 
 #### 6.2 Runtime capability extension
 
-Extend the selected memory runtime with a versioned authorized surface:
+Extend the selected memory capability with a versioned authorization declaration
+and its optional runtime with the authorized surface:
 
 ```ts
 type AuthorizedMemoryPlanForContext<Context extends MemoryAccessContext> =
@@ -313,8 +314,12 @@ type AuthorizedMemoryPlanForContext<Context extends MemoryAccessContext> =
       : AuthorizedMemoryPlan & { operation: Operation }
     : never;
 
+type MemoryPluginCapability = Readonly<{
+  authorization?: MemoryAuthorizationCapabilities;
+  runtime?: MemoryPluginRuntime;
+}>;
+
 interface AuthorizedMemoryRuntime {
-  authorization: MemoryAuthorizationCapabilities;
   authorize<Context extends MemoryAccessContext>(
     context: Context,
   ): Promise<AuthorizedMemoryPlanForContext<Context>>;
@@ -328,9 +333,10 @@ interface AuthorizedMemoryRuntime {
 }
 ```
 
-Legacy agents may continue to use the existing manager path. An enforced agent
-must reject a runtime without the new capability. Do not silently wrap a
-context-free backend and call it conforming.
+The selected `MemoryPluginCapability`, rather than its optional `runtime`,
+declares `authorization`. Legacy agents may continue to use the existing manager
+path. An enforced agent must reject a selected capability without the new
+declaration. Do not silently wrap a context-free backend and call it conforming.
 
 The declaration and the conformance suite describe plugin behavior only; they
 do not construct a trusted context or make an authorization decision. Phase 0

--- a/docs/concepts/2026-07-29-memory-impl-plan.md
+++ b/docs/concepts/2026-07-29-memory-impl-plan.md
@@ -653,7 +653,7 @@ Implement the Phase 0 contract for builtin memory:
 Do not insert scoped content into `memory_index_sources`,
 `memory_index_chunks`, or legacy FTS/vector tables.
 
-#### 8.5 QMD and alternate backend admission
+#### 8.5 Alternate backend admission
 
 Define conformance requirements for:
 
@@ -664,9 +664,9 @@ Define conformance requirements for:
 - status and export;
 - no silent fallback to a broader backend.
 
-If QMD cannot meet the contract in the first release, enforced agents use the
-builtin backend or memory remains unavailable. QMD failure must not fall back to
-legacy broad builtin search.
+If a selected alternate backend cannot meet the contract in the first release,
+enforced agents use the builtin backend or memory remains unavailable. A failed
+alternate backend must not fall back to legacy broad builtin search.
 
 #### 8.6 Doctor migration scaffold
 
@@ -719,7 +719,7 @@ groups. Add any lazily ensured columns to `allowedMissingColumns`.
 - active/pending/quarantined/tombstoned revision visibility;
 - policy deny precedence and expiry;
 - candidate-superset property for FTS, vector scan, sqlite-vec, and exact read;
-- QMD nonconformance rejects enforced mode;
+- alternate-backend nonconformance rejects enforced mode;
 - dry-run migration is deterministic and content-free in logs;
 - existing legacy agent remains byte-for-byte on the old path.
 
@@ -737,7 +737,7 @@ Phase 1B is complete only when all of the following are demonstrated:
 - [ ] Every additive per-agent table, column, and trigger group is registered
       in schema compatibility so an existing current-version database opens
       before feature-local lazy ensure.
-- [ ] A nonconforming or failed QMD/alternate backend becomes unavailable in
+- [ ] A nonconforming or failed alternate backend becomes unavailable in
       enforced mode and never falls back to broader legacy search.
 - [ ] Doctor dry-run produces a deterministic, content-redacted classification,
       backup, copy, reindex, verification, and cutover plan without modifying
@@ -1646,7 +1646,7 @@ matching GitHub labels as part of the plugin PR.
 - role removal within documented bound;
 - provider outage does not extend membership indefinitely;
 - audit explanation reveals no unauthorized resource title/existence;
-- collection/mount fan-out benchmarks for builtin and QMD.
+- collection/mount fan-out benchmarks for builtin and alternate backends.
 
 ### Definition of done
 
@@ -1866,7 +1866,7 @@ why no version bump is required.
 | Pure types/evaluator | Property tests for implication, deny precedence, revision, audience, delegation, and lineage.         |
 | SQL/backend          | Candidate superset, top-K crowd-out, immutable revision, pending/quarantine denial, hash/path checks. |
 | Core context         | Identity, session-rebound, subject revision, actor separation, delivery revision.                     |
-| Plugin contract      | Builtin/QMD/LanceDB/wiki/active-memory conformance or enforced unavailability.                        |
+| Plugin contract      | Builtin, LanceDB, wiki, active-memory, and alternate-backend conformance or enforced unavailability.  |
 | Filesystem/sandbox   | Virtual mount, traversal/symlink/case/Unicode, direct host-path denial, exec profile.                 |
 | Transcript           | Atomic companion labels, reset/fork/rewind/archive/export, missing-label denial.                      |
 | Derivation           | Compaction/flush/dreaming/delegation audience intersection and ancestor revocation.                   |
@@ -1956,7 +1956,7 @@ Stable denial reasons should include:
 | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
 | Scope grows into a second memory architecture    | Keep selected plugin ownership; add generic contracts only; no core deep imports into bundled memory implementation. |
 | Stage 1 is too large to land                     | Use Phases 1A-1D with read-only enforced state and explicit exit gates.                                              |
-| Legacy backend silently widens access            | Reject nonconforming backend; never fallback from authorized QMD/external backend to broad legacy builtin.           |
+| Legacy backend silently widens access            | Reject nonconforming backend; never fall back from an authorized alternate backend to broad legacy builtin.          |
 | Transcript or compaction launders content        | Require atomic policy companion rows before scoped exposure; compaction is derivation.                               |
 | File tools bypass memory policy                  | Controlled artifact roots are never model-visible; virtual memory paths delegate to authorized operations.           |
 | Unsandboxed exec defeats model isolation         | Hide/deny or restrict claim to cooperative isolation with Doctor finding.                                            |

--- a/docs/concepts/2026-07-29-memory-impl-plan.md
+++ b/docs/concepts/2026-07-29-memory-impl-plan.md
@@ -1,3 +1,14 @@
+---
+doc-schema-version: 1
+summary: "Phased implementation plan for identity-aware multiplayer memory"
+title: "Multiplayer memory implementation plan"
+sidebarTitle: "Memory implementation plan"
+read_when:
+  - You are implementing identity-aware memory authorization in phases
+  - You need the definition of done for multiplayer memory milestones
+  - You are reviewing the rollout or security boundaries for multiplayer memory
+---
+
 # OpenClaw Multiplayer Memory Implementation Plan
 
 Date: 2026-07-29

--- a/docs/concepts/memory-multiplayer.md
+++ b/docs/concepts/memory-multiplayer.md
@@ -957,8 +957,13 @@ type MemoryAuthorizationCapabilities = Readonly<{
   egressReceipts: true;
 }>;
 
+type MemoryPluginCapability = Readonly<{
+  authorization?: MemoryAuthorizationCapabilities;
+  runtime?: MemoryPluginRuntime;
+  // Other memory-plugin contributions are omitted.
+}>;
+
 interface AuthorizedMemoryRuntime {
-  authorization: MemoryAuthorizationCapabilities;
   authorize(context: MemoryAccessContext): Promise<AuthorizedMemoryPlan>;
   searchAuthorized(params: {
     context: MemoryAccessContext;
@@ -993,6 +998,15 @@ interface AuthorizedMemoryRuntime {
 }
 ```
 
+The selected `MemoryPluginCapability`, rather than its optional runtime alone,
+declares `authorization`. The declaration is additive during Phase 0 and must
+be complete before a later enforced path can select the backend. Keeping
+`runtime` optional lets Phase 0 inventory a selected runtime-less or legacy
+registration, including a LanceDB-style registration, without pretending that
+it implements `AuthorizedMemoryRuntime`. The declaration and a conformance
+result describe plugin surface shape only; neither can admit a capability,
+construct a trusted context, or make an authorization decision.
+
 The plan is plugin-issued and bound to the context fingerprint, session and
 subject revisions, operation, mounts, policy revision, delivery revision,
 egress audiences, and expiry. No selected or supplemental backend exposes a
@@ -1002,10 +1016,11 @@ plan and resource revision. A returned handle is not a bearer grant.
 
 Every search or exact-read result that exposes content uses the mandatory
 result envelope with both branded receipts, recorded before the content leaves
-the plugin. The capability flags make that requirement discoverable during
-backend admission. Core rejects a missing or invalid exposure receipt before
-prompt assembly, and rejects an egress receipt whose context, delivery,
-registry, policy-set, or `runExposureRevision` no longer matches.
+the plugin. In a later enforced path, the capability flags make that
+requirement discoverable during backend admission. That path rejects a missing
+or invalid exposure receipt before prompt assembly, and rejects an egress
+receipt whose context, delivery, registry, policy-set, or `runExposureRevision`
+no longer matches.
 Sync, export, public-artifact reads, and any future method that emits content
 use the same envelope; a plain content-bearing return type is nonconforming.
 
@@ -1363,12 +1378,13 @@ flowchart TB
   IDP -->|verification material, never final policy| ID
 ```
 
-Core constructs and brands immutable verified access facts, gates every memory-
-capability invocation, enforces generic prompt, egress, and filesystem
-confinement, and rejects missing or nonconforming capabilities. It owns durable
-principal resolution, the write-once session subject, current session mapping,
-Gateway collaboration decisions, and delivery revisions. Core never branches
-on store kinds, ACL schemas, search algorithms, or bundled plugin IDs.
+In the enforced target state, core constructs and brands immutable verified
+access facts, gates every memory-capability invocation, enforces generic prompt,
+egress, and filesystem confinement, and rejects missing or nonconforming
+capabilities. It owns durable principal resolution, the write-once session
+subject, current session mapping, Gateway collaboration decisions, and delivery
+revisions. Core never branches on store kinds, ACL schemas, search algorithms,
+or bundled plugin IDs.
 
 The selected memory plugin owns its logical-store catalog, memory policy,
 resource revisions, lineage, view construction, candidate prefilter,
@@ -1376,6 +1392,14 @@ authoritative postfilter, content reads and writes, exposure records, sync, and
 backend-specific recovery. Its policy evaluator is pure and reusable by its
 conformance tests. Core treats the returned plan, handles, mounts, policy
 receipt, and exposure receipt as versioned opaque capability data.
+
+Phase 0 does not activate this enforcement architecture. It has no trusted-
+context factory, capability-admission path, or policy decision. Its shadow
+surface inspection records only bounded selected-capability and method-shape
+metadata: no memory content, prompts, queries, snippets, paths, or principal
+identifiers. Phase 1A or a later phase must establish trusted-context issuance
+and selected-capability admission before any enforced memory ingress or egress
+can rely on this contract.
 
 `session_members` and the current sharing evaluator remain authoritative only
 for Gateway collaborative-session membership and mode. Native channel and
@@ -1567,20 +1591,22 @@ warns about lost audience metadata, not an automatic fallback.
 Stages are security boundaries, not calendar estimates. A stage is complete
 only when all listed read and write surfaces use the new invariant.
 
-### Stage 0: contracts and shadow decisions
+### Stage 0: contracts and shadow surface inspection
 
 **Deliverables**
 
-- Define core-owned principals, session subjects, delivery facts, and the
-  branded access context; define plugin-owned operations, decisions, plans,
-  mounts, and the pure memory evaluator behind the SDK contract.
+- Define serializable principal, session-subject, delivery, context, operation,
+  plan, mount, and evaluator contract shapes. Stage 0 does not mint a trusted
+  context from caller-provided facts; that core-only issuance path follows the
+  durable identity and subject work in Phase 1A.
 - Add the versioned plugin SDK authorization contract and a reusable backend
   conformance suite.
-- Add lazy additive tables and read-only decision tracing. Do not move content
-  or alter current results.
-- Build core-only context factories for authenticated Gateway calls, channel
-  ingress, autonomous runs, and delegation. Prove that plugin extras and tool
-  JSON cannot override them.
+- Add bounded, content-free, read-only selected-runtime surface inspection. Do
+  not move content, alter current results, create a permanent audit schema, or
+  make a policy decision.
+- Keep the serializable context DTO distinct from a future trusted context:
+  plugin extras, tool JSON, prompt text, and caller-assembled objects cannot
+  opt into an enforced path during Stage 0 because no such path exists yet.
 - Inventory every memory ingress and egress path and fail the stage if any
   context-free manager call remains unclassified.
 
@@ -1588,11 +1614,15 @@ only when all listed read and write surfaces use the new invariant.
 
 - Property tests cover deny precedence, permission implication, view
   intersection, expiry, revision, and lineage.
-- Shadow decisions can be compared with current reads without logging content.
+- Shadow surface metadata is bounded and content-free. It is not a policy
+  decision or a comparison against current reads until Phase 1A supplies a
+  trusted context and a later phase supplies a selected policy backend and
+  admission path.
 - Single-user behavior and latency stay unchanged.
 - No public isolation claim and no public configuration change.
 
-**Rollback:** stop shadow evaluation and ignore the additive tables.
+**Rollback:** remove the shadow invocation and ignore the additive capability
+declaration while the agent remains unenforced.
 
 ### Stage 1: private and channel read isolation
 
@@ -1789,7 +1819,7 @@ Never replace a failed broker with unscoped filesystem or database access.
 
 ```mermaid
 flowchart LR
-  S0[Stage 0: contracts and shadow] --> S1[Stage 1: scoped reads]
+  S0[Stage 0: contracts and shadow surface] --> S1[Stage 1: scoped reads]
   S1 --> S2[Stage 2: writes and derivations]
   S2 --> S3[Stage 3: projections and postbox]
   S2 --> S4[Stage 4: enterprise operations]

--- a/docs/concepts/memory-multiplayer.md
+++ b/docs/concepts/memory-multiplayer.md
@@ -719,9 +719,9 @@ any path-key migration. This avoids leaking provider IDs through paths, path
 instability after an account rename, and path injection from external
 identifiers.
 
-For builtin memory and QMD, Markdown remains the content source of truth and
-stays inspectable through operator UI, CLI export, backups, and an authorized
-virtual filesystem view. A conforming external backend may instead use an
+For builtin memory, Markdown remains the content source of truth and stays
+inspectable through operator UI, CLI export, backups, and an authorized virtual
+filesystem view. A future conforming external backend may use Markdown or an
 isolated namespace or collection, but must provide equivalent inspection,
 export, backup, deletion, revision, and recovery behavior. SQLite stores the
 builtin plugin's identity references, policy, lifecycle, lineage, index, and
@@ -1023,12 +1023,12 @@ Core supplies verified principal facts; the selected plugin may turn those
 facts or server-issued mention/message references into subject handles. Free-
 form model text cannot create them.
 
-Builtin memory should implement the contract first. QMD and other selected
-memory plugins need conformance adapters that use separate authorized
-collections or an equivalent native scope. A backend returning already
-rendered snippets can be supported only when its process is inside the trusted
-broker boundary and its native filter has passed conformance tests. Enforced
-mode rejects a legacy backend instead of falling back to broad search.
+Builtin memory should implement the contract first. Any future selected memory
+plugin needs a conformance adapter that uses separate authorized collections or
+an equivalent native scope. A backend returning already rendered snippets can
+be supported only when its process is inside the trusted broker boundary and
+its native filter has passed conformance tests. Enforced mode rejects a legacy
+backend instead of falling back to broad search.
 
 ### Every read lane uses the same view
 
@@ -1053,8 +1053,9 @@ mode rejects a legacy backend instead of falling back to broad search.
 - **Supplements and preparations:** `MemoryPromptSupplement`,
   `MemoryPromptPreparation`, and `MemoryCorpusSupplement` registrations must
   declare an authorized store or route through the selected capability. This
-  includes memory wiki Gateway/CLI paths, public artifacts, QMD extra
-  collections and session artifacts, and project bootstrap supplements.
+  includes memory wiki Gateway/CLI paths, public artifacts, future
+  alternate-backend collections and session artifacts, and project bootstrap
+  supplements.
 - **Import and export:** Codex, Claude, Hermes, and other import targets enter
   the scoped write lifecycle; exports require an authorized plan and preserve
   or explicitly warn about audience metadata.
@@ -1609,8 +1610,8 @@ only when all listed read and write surfaces use the new invariant.
   injection, active recall, project bootstrap, Talk fast context, transcript
   recall, supplements, status, and CLI.
 - Convert or block LanceDB raw tools and prompt hooks, memory prompt/corpus
-  registries, QMD extra collections and session artifacts, memory wiki, and
-  every other context-free prompt or public-artifact read.
+  registries, alternate-backend collections and session artifacts, memory wiki,
+  and every other context-free prompt or public-artifact read.
 - Extend filesystem policy and sandbox mounts so model-facing tools see only
   the virtual view. Hide or deny `exec` and file tools that cannot honor it.
 - Merge every exposure receipt into the run exposure set and recheck it for
@@ -1728,8 +1729,8 @@ with direct access to its private source.
   policy instead of a parallel `channel_member` authority.
 - Add audit query, retention, export, access explanation, policy drift alerts,
   revocation impact, and periodic access review.
-- Load-test hundreds of principals, stores, roles, and channels; benchmark QMD
-  or other backend collection fan-out.
+- Load-test hundreds of principals, stores, roles, and channels; benchmark
+  alternate-backend collection fan-out.
 
 **Exit gates**
 
@@ -1930,16 +1931,16 @@ policy; logical denial does not wait for deletion.
 
 No existing OpenClaw feature provides this entire boundary:
 
-| Existing option                          | What it already solves                                                          | Why it is not the complete design                                                                                                                                                                                                         |
-| ---------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Separate agents or Gateway cells         | Strongest current separation of sessions, files, tools, credentials, and memory | Operationally heavier, but remains the correct option for mutually untrusted people and hostile tenants                                                                                                                                   |
-| `session.dmScope`                        | Separates DM conversation routing                                               | All sessions of an agent can still use the same memory files and index                                                                                                                                                                    |
-| Session sharing policy                   | Human session visibility and mutation roles                                     | Does not label or authorize memory resources; should be reused as one input                                                                                                                                                               |
-| Ingress access groups                    | Static and provider-backed admission checks                                     | They are allowlist expansion, not durable identity, audience, lineage, or memory policy                                                                                                                                                   |
-| `memory-core` and QMD                    | Markdown memory, indexing, provenance, and transcript visibility filters        | They need the versioned scoped backend contract and complete read/write lifecycle                                                                                                                                                         |
-| Honcho, LanceDB, and memory wiki plugins | Alternative recall or supplemental knowledge                                    | A selected or supplemental plugin cannot define the Gateway-wide identity and filesystem boundary                                                                                                                                         |
-| PostgreSQL RLS or vector namespaces      | Mature data-layer row or collection isolation                                   | Useful backend techniques, but they do not solve OpenClaw session identity, bootstrap files, tool mounts, compaction, dreaming, or delegation by themselves                                                                               |
-| Cedar or Zanzibar-style policy engines   | General policy evaluation models                                                | They do not provide identity proof, physical storage authority, lineage, or sandboxing. A small typed evaluator inside the selected builtin plugin fits the first local SQLite implementation; keep its inputs and traces engine-neutral. |
+| Existing option                             | What it already solves                                                          | Why it is not the complete design                                                                                                                                                                                                         |
+| ------------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Separate agents or Gateway cells            | Strongest current separation of sessions, files, tools, credentials, and memory | Operationally heavier, but remains the correct option for mutually untrusted people and hostile tenants                                                                                                                                   |
+| `session.dmScope`                           | Separates DM conversation routing                                               | All sessions of an agent can still use the same memory files and index                                                                                                                                                                    |
+| Session sharing policy                      | Human session visibility and mutation roles                                     | Does not label or authorize memory resources; should be reused as one input                                                                                                                                                               |
+| Ingress access groups                       | Static and provider-backed admission checks                                     | They are allowlist expansion, not durable identity, audience, lineage, or memory policy                                                                                                                                                   |
+| `memory-core` and future alternate backends | Markdown memory, indexing, provenance, and transcript visibility filters        | They need the versioned scoped backend contract and complete read/write lifecycle                                                                                                                                                         |
+| Honcho, LanceDB, and memory wiki plugins    | Alternative recall or supplemental knowledge                                    | A selected or supplemental plugin cannot define the Gateway-wide identity and filesystem boundary                                                                                                                                         |
+| PostgreSQL RLS or vector namespaces         | Mature data-layer row or collection isolation                                   | Useful backend techniques, but they do not solve OpenClaw session identity, bootstrap files, tool mounts, compaction, dreaming, or delegation by themselves                                                                               |
+| Cedar or Zanzibar-style policy engines      | General policy evaluation models                                                | They do not provide identity proof, physical storage authority, lineage, or sandboxing. A small typed evaluator inside the selected builtin plugin fits the first local SQLite implementation; keep its inputs and traces engine-neutral. |
 
 The custom work is justified by the integration boundary, not by a need to
 invent another vector store or IAM language. Reuse current storage, session,
@@ -1963,7 +1964,8 @@ These choices require owner agreement before their implementation stage:
 6. **Postbox posture:** whether any non-enterprise deployment should support
    labeled automatic use without explicit review.
 7. **Backend scaling:** collection and mount fan-out at hundreds or thousands
-   of stores, especially for QMD and remote memory plugins.
+   of stores, especially for future alternate backends and remote memory
+   plugins.
 8. **Artifact location and backup:** the exact controlled state path, ownership
    permissions, cross-platform virtual mount, and consistent backup boundary.
 9. **Audit retention:** defaults, export permissions, and compliance deletion

--- a/docs/concepts/memory-multiplayer.md
+++ b/docs/concepts/memory-multiplayer.md
@@ -952,7 +952,9 @@ type MemoryAuthorizationCapabilities = Readonly<{
   exactReadByAuthorizedHandle: true;
   scopedSync: true;
   scopedWrite: true;
+  scopedImport: true;
   scopedExport: true;
+  scopedStatus: true;
   exposureReceipts: true;
   egressReceipts: true;
 }>;
@@ -986,6 +988,11 @@ interface AuthorizedMemoryRuntime {
     plan: AuthorizedMemoryPlan;
     mutation: AuthorizedMemoryMutation;
   }): Promise<MemoryWriteResult>;
+  importAuthorized(params: {
+    context: MemoryAccessContext;
+    plan: AuthorizedMemoryPlan;
+    mutation: AuthorizedMemoryMutation;
+  }): Promise<MemoryWriteResult>;
   syncAuthorized(params: {
     context: MemoryAccessContext;
     plan: AuthorizedMemoryPlan;
@@ -995,6 +1002,10 @@ interface AuthorizedMemoryRuntime {
     plan: AuthorizedMemoryPlan;
     handles: readonly AuthorizedResourceHandle[];
   }): Promise<AuthorizedMemoryResultEnvelope<MemoryExportResult>>;
+  statusAuthorized(params: {
+    context: MemoryAccessContext;
+    plan: AuthorizedMemoryPlan;
+  }): Promise<AuthorizedMemoryResultEnvelope<MemoryProviderStatus>>;
 }
 ```
 

--- a/docs/concepts/memory-multiplayer.md
+++ b/docs/concepts/memory-multiplayer.md
@@ -1,0 +1,2007 @@
+---
+doc-schema-version: 1
+summary: "Staged design for identity-aware, private, and shared memory in multi-user OpenClaw agents"
+title: "Multiplayer memory design"
+sidebarTitle: "Multiplayer memory design"
+read_when:
+  - You are designing memory for an agent used by more than one person
+  - You are implementing identity-aware memory authorization
+  - You need the rollout, migration, and verification plan for multiplayer memory
+---
+
+<Warning>
+This page is an implementation design, not shipped behavior. OpenClaw does not
+currently use memory ACLs as a security boundary. After Stage 2, a deployment
+may claim only the cooperative-isolation boundary it has tested. Stage 5 is
+required for a tested model/process-adversarial claim. Mutually untrusted or
+hostile tenants still require separate agents or separate Gateway, credential,
+and storage cells. See [Multi-user mode](/concepts/multi-user).
+</Warning>
+
+OpenClaw memory was designed for a personal agent. Its Markdown files,
+per-agent index, bootstrap context, transcript recall, and background
+consolidation all assume that the agent's audience is one trust domain. A
+shared DM inbox or group channel breaks that assumption: routing may separate
+conversations, but every conversation can still reach the same agent memory.
+
+This design adds identity-aware memory without turning model instructions into
+an authorization mechanism. It uses verified principals, isolated logical
+stores, a core-issued access context, plugin-owned policy evaluation, and an
+authoritative postfilter before content reaches a prompt. The builtin backend
+maps stores to opaque Markdown roots; other conforming backends may use
+isolated collections or namespaces. The design also covers writes, session
+transcripts, compaction, dreaming, delegation, sharing, revocation, migration,
+and audit.
+
+## Why multiplayer memory fails
+
+Current memory records what was learned and where it came from, but not who may
+receive it later. That missing audience dimension produces three recurring
+failures.
+
+**Cross-participant leakage.** A fact learned from one person can be retrieved
+for another person when both conversations use the same agent-level files and
+index. Separating route keys does not help if every route still reaches the same
+memory.
+
+**The implicit-subject problem.** Personal memory can safely record "prefers
+short replies" only while there is one implicit person. In a group, the subject
+disappears. Similarity search can find every passage about "Mike," but it cannot
+decide which Mike a fact describes or whether that fact is still current.
+Identity must narrow the store before lexical or semantic ranking begins.
+
+**Compaction as a laundering channel.** Transcripts, summaries, memory flushes,
+and dreaming outputs are durable derived artifacts. If any of them drops its
+source audience, scoped content becomes a clean, unscoped copy. A design that
+protects search but not derivation still has a direct disclosure path.
+
+## Design principles
+
+1. **Resolve identity before retrieval.** Determine the session subject and
+   current verified evidence before opening a store or issuing a candidate
+   query. Search ranks facts only after authorization establishes whose view is
+   being searched.
+2. **Isolation comes from placement, not predicates.** Personal, channel, role,
+   shared, projection, and quarantine content live in separate logical stores.
+   Policy rows may narrow a mounted view; they never compensate for attaching
+   the wrong store.
+3. **Deny by default.** A resource is unavailable unless the current memory
+   view and policy permit the requested operation. Backend failure never falls
+   back to an unscoped store.
+4. **The session subject is not the latest actor.** Steering changes who caused
+   an operation, not the audience boundary of the shared context.
+5. **Derived artifacts keep their source restrictions.** Compaction,
+   transcripts, dreaming, exports, and projections use the same policy
+   lifecycle as direct memory reads and writes.
+6. **State the isolation strength honestly.** In-process authorization can
+   constrain cooperative and model-facing access, but process-adversarial
+   claims require a broker and sandbox boundary that the deployment has
+   actually tested.
+
+## Decision summary
+
+- Preserve today's single-user behavior until an operator explicitly migrates
+  an agent. Do not reinterpret existing files at runtime.
+- Resolve a durable principal after authentication and ingress admission. A
+  sender label, session key, static `identityLinks` entry, or prompt field is
+  never an ACL principal.
+- Stamp each session with one immutable memory subject: verified user for an
+  isolated DM, channel for a group, or service agent for an autonomous run.
+  The verified or unattributed actor evidence may change, but steering never
+  changes the session's retrieval subject. Reset, fork, and import paths must
+  preserve or explicitly quarantine that subject rather than infer a
+  replacement from routing text.
+- Keep personal, channel, role, agent-shared, projection, and quarantine
+  content in separate logical stores under opaque IDs. Expose only an
+  authorized virtual view to a session.
+- Reuse `session_members` and the existing Gateway session-sharing evaluator
+  for Gateway collaborative-session audiences only. Native channel and
+  enterprise-role membership remains separately verified, revisioned,
+  expiring provider evidence. Do not confuse ingress access groups with memory
+  ACL groups.
+- Make a generic, versioned authorization contract part of core and the plugin
+  SDK. Core supplies verified access facts and generic confinement; the
+  selected memory plugin owns its stores, policy, lineage, search, postfilter,
+  and exposure records. Enforced mode rejects a backend that cannot honor the
+  contract.
+- Apply the same policy to bootstrap files, `memory_search`, `memory_get`,
+  trigger injection, active recall, generic file tools, memory flush, dreaming,
+  transcripts, compaction, child agents, and every alternate memory backend.
+- Implement controlled sharing as an explicit projection into a named
+  audience. Keep direct user-to-user grants deferred.
+- Treat in-process enforcement as protection against accidental and
+  model-driven disclosure inside one trusted Gateway. A process-adversarial
+  claim requires sandboxed agents and an out-of-process broker. Hostile tenants
+  require separate Gateway, process, credential, and storage cells.
+
+## Isolation model at a glance
+
+**Channel memory is the group default.** Content learned in a group session is
+written to that conversation's store. The conversation remains the session
+subject even when another member steers the run, so changing the latest actor
+does not change the audience.
+
+**Private stores never mount into group sessions.** A group query about one of
+its members may use channel memory, agent-shared memory, and projections
+addressed to that channel. It cannot search, exact-read, or otherwise reach the
+member's private or role stores.
+
+**The postbox is a one-way deposit valve.** A group may file an observation
+from a verified source message into one participant's quarantine. The group
+receives only a generic outcome and cannot list, search, or read the deposited
+item back.
+
+**Projections are explicit declassified copies.** A projection names one
+audience, source revision, purpose, publisher, and lifetime. It is never
+inferred by the model, and a later source edit does not silently republish it.
+
+## Design inputs
+
+This plan combines three sources with the current OpenClaw implementation:
+
+- [RFC 0010 draft](https://github.com/openclaw/rfcs/pull/30), reviewed at head
+  `a925820bd766f6a5df79d44323db0e8eb55649ac`, contributes the session subject,
+  structural mount, deny-by-default evaluator, authoritative postfilter,
+  postbox, projection, lineage, and exposure-audit ideas. Its three changed
+  files are the proposal, implementation plan, and broker design. The RFC is a
+  draft, and some implementation assumptions predate the current codebase.
+- [Shared vs private AI agent memory](https://www.mindstudio.ai/blog/shared-vs-private-ai-agent-memory-team-access-control)
+  separates global, role, and user tiers; enforces permissions below the
+  prompt; applies least privilege independently at each agent hop; and treats
+  writes, audit, revocation, and retention as first-class controls.
+- [Designing agent memory for multiplayer](https://bloome.im/blog/designing-agent-memory-for-multiplayer)
+  makes identity structural: first answer "who is this for?" and only then
+  search. It also separates a very small, always-loaded profile card from
+  larger notes that are searched on demand.
+
+The resulting design deliberately changes several RFC details. It reuses
+OpenClaw's existing session collaboration policy, does not treat current
+access groups as general ACL groups, stores opaque IDs rather than provider
+identifiers in paths, quarantines ambiguous legacy content instead of making
+it shared, and requires projections to name their audience.
+
+## Current state and gaps
+
+The following seams already exist. They are foundations, not multiplayer
+memory enforcement.
+
+| Surface                | Current behavior                                                                                                                                                                                                                    | Gap this design closes                                                                                                                                    |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Routing                | `src/routing/session-key.ts` can collapse DMs into `main` or separate them by peer. Group keys identify a conversation, not a sender.                                                                                               | A route key is not a verified person or an authorization decision.                                                                                        |
+| Gateway identity       | Durable Gateway user profiles and write-once `createdActor` provenance exist. Channel senders are not bound to those profiles.                                                                                                      | Add an explicit, verified channel identity binding; keep creation attribution separate from memory authority.                                             |
+| Session collaboration  | `src/gateway/session-sharing.ts` and `src/config/sessions/session-sharing-store.ts` already centralize owner, member, viewer, admin, draft, read-only, and suggest decisions.                                                       | Feed these decisions into memory authorization instead of inventing parallel membership rules.                                                            |
+| Ingress access groups  | `src/channels/message-access/` controls whether a transport event may enter the system. Dynamic provider failures fail closed.                                                                                                      | Ingress admission does not grant durable memory access. Role and group principals need verified, revisioned identity evidence.                            |
+| Memory plugin boundary | `src/plugins/memory-state.ts`, `src/plugins/memory-runtime.ts`, and `packages/memory-host-sdk/src/host/types.ts` expose one selected memory runtime and a `MemorySearchManager`.                                                    | The contract carries agent and session IDs, but no canonical principal, authorized view, resource revision, or policy decision.                           |
+| Markdown and index     | `memory-core` indexes `MEMORY.md`, `USER.md`, `memory/`, and optional session sources into the per-agent SQLite database. Chunk rows contain full text and serialized embeddings; provenance records trust origin and session kind. | Provenance answers "where did this come from?", not "who may receive it?" The content-bearing derived index is agent-scoped, not user- or channel-scoped. |
+| Search and exact read  | `extensions/memory-core/src/tools.ts` filters transcript hits and lets the trusted runtime narrow the requested corpus. `packages/memory-host-sdk/src/host/read-file.ts` prevents path traversal and symlink escape.                | Ordinary memory hits and exact reads can still reach every allowed memory path in the agent workspace.                                                    |
+| Transcript recall      | `extensions/memory-core/src/session-search-visibility.ts` already excludes group and channel aliases from private cross-conversation recall and fails closed on conflicting aliases.                                                | Visibility is inferred from session shape and current policy, not a persisted canonical audience label.                                                   |
+| Bootstrap and dreaming | The curated tier is loaded or referenced at session start, and dreaming promotes eligible evidence with trust provenance.                                                                                                           | A single `MEMORY.md` and `USER.md` have no human audience. Flush and dreaming can copy scoped content into a broader file.                                |
+| Compaction             | Compaction persists a plain-text summary and transcript checkpoint.                                                                                                                                                                 | Current summaries and preserved-turn rendering drop authorization labels, so audience cannot safely be reconstructed later.                               |
+| Files and sandbox      | `ToolFsPolicy` currently expresses `workspaceOnly`; sandbox workspace mounts are whole-workspace `none`, `ro`, or `rw`.                                                                                                             | There is no session-specific allowlist of memory roots. Unsandboxed `exec` can bypass model-facing file guards.                                           |
+
+Two current protections remain useful after this design lands:
+
+1. The runtime, not model-authored tool arguments, chooses whether transcript
+   recall is available and which corpus may be searched.
+2. Memory path readers already reject traversal, unexpected file types, and
+   symlink escapes. Scoped readers should build on those checks rather than
+   replacing them.
+
+The initial bypass inventory must also include non-tool callers. Active Memory
+trigger recall, project bootstrap, Talk fast context, memory wiki supplements,
+and the LanceDB plugin's prompt hook all reach memory through independent
+paths today. A scoped `memory_search` implementation is not complete while any
+of those paths remains context-free.
+
+## Goals
+
+1. A private DM can remember facts for its verified user without exposing them
+   to another user, a group, an autonomous run, or an unrelated agent.
+2. A group remembers what happened in that group without silently learning a
+   readable copy of each participant's private profile.
+3. Shared and role memory has explicit read and write authority. A group does
+   not gain role memory merely because one participant has that role.
+4. Identity is decided before retrieval. Semantic similarity is never used to
+   decide which person a fact belongs to.
+5. Every path that can put memory into a model prompt or durable derived
+   artifact uses the same policy context and decision semantics.
+6. Every write has an owner, audience, trust origin, resource revision, and
+   audit actor. An unlabeled write fails closed or enters quarantine.
+7. Revocation stops future reads and derivations, and exposure records make
+   residual copies enumerable.
+8. Single-user installs keep their current files and behavior until an explicit
+   migration, with no required enterprise identity provider.
+
+## Non-goals
+
+- This does not make one Gateway a hostile multi-tenant boundary. The host
+  operator, admins, installed in-process plugins, and processes with direct
+  state-directory access remain trusted.
+- This cannot make a model forget content already placed in its context. It can
+  prevent new retrieval, track exposure, and restrict derived writes, but it
+  cannot prevent semantic rephrasing of already-seen information.
+- This does not infer sensitivity from prose or add a general DLP classifier.
+- This does not use display names, usernames, email strings, embeddings, or
+  model judgment to merge identities.
+- This does not add cross-instance federation.
+- This does not ship direct private-store grants from one user to another.
+- This does not move plugin KV or arbitrary workspace files into the memory
+  authorization system.
+
+## Threat model
+
+Authorization controls which durable content may enter a run; it cannot make a
+model forget content already exposed in that run. The model may paraphrase or
+be influenced by authorized content without preserving token-level lineage.
+Exposure records and anomaly checks can detect suspicious follow-on writes,
+but they cannot prevent this semantic laundering.
+
+The rollout has three explicitly different claims.
+
+| Level                         | Claim                                                                                                         | Required controls                                                                                                                                                                                                     |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cooperative isolation         | Prevent ordinary cross-user mistakes and make policy decisions observable.                                    | Core identity context, scoped backend contract, authoritative postfilter, guarded bootstrap and writes.                                                                                                               |
+| Model-adversarial isolation   | A prompt-injected model cannot use available tools to open an unmounted memory store.                         | All cooperative controls plus session-specific file policy, no unguarded host file tools, and a sandbox that exposes only the virtual memory view.                                                                    |
+| Process-adversarial isolation | Compromise of a non-broker agent or tool process cannot cross its issued view.                                | All model controls plus an out-of-process broker with authenticated IPC, no broker credentials in the agent process, and OS separation. Gateway, broker backend, selected memory plugin, and operator remain trusted. |
+| Hostile-tenant isolation      | Mutually untrusted tenants do not share a trusted Gateway, plugin host, credential set, or storage authority. | Separate Gateway, process, credential, and storage cells for each trust domain.                                                                                                                                       |
+
+Enforced multiplayer mode must not claim a stronger level than the deployment
+provides. In particular, unsandboxed `exec` over the host workspace is
+incompatible with model-adversarial isolation. Memory failure should fail
+closed for memory while leaving the conversation available: the reply may
+continue with an explicit "memory unavailable" result, but it must never fall
+back to an unscoped store.
+
+## Vocabulary and invariants
+
+**Principal** is a durable, canonical identity such as a Gateway profile, a
+verified enterprise subject, a service agent, or a system actor. Provider
+display fields are aliases or evidence, not principals.
+
+**Session subject** is the audience identity stamped once when a session is
+created: one user, one channel, or one service agent. It controls retrieval and
+the default write target. It is not necessarily the actor sending the current
+message.
+
+**Actor** is the authenticated human, agent, or system process causing one
+operation. Actors are used for audit, collaboration roles, and postbox source
+attribution. In a group session, changing actors does not change the channel
+subject.
+
+**Store** is one logical storage and policy boundary with exactly one base
+scope, one agent cell, one authority owner, and an opaque `store_id`. Builtin
+memory maps it to a physical Markdown root. An external backend may map it to
+an isolated collection or namespace if it supplies equivalent inspection,
+export, lifecycle, and conformance behavior. Provider, tenant, channel, and
+user IDs never appear in filesystem paths or backend locator tokens.
+
+**Resource** is one versioned logical artifact or stable record registered in
+the selected plugin's policy catalog. A builtin resource is usually Markdown.
+Index chunks point to an immutable resource revision; they are not
+authorization objects themselves.
+
+Each resource keeps four independent dimensions:
+
+- **Subject:** who or what the fact describes. A channel note can be about
+  Alice while remaining channel-audience data. Subject supports exact person
+  lookup; it never grants access.
+- **Origin:** where and from whom the evidence came, including trust class and
+  source event. Origin affects promotion and review; it does not by itself set
+  the audience.
+- **Audience:** which user, channel, role, agent, or agent-shared scope may
+  receive the content.
+- **Authority:** which actors may append, replace, derive, project, delete, or
+  administer the resource.
+
+Conflating any two recreates a leak. In particular, a note about Alice is not
+automatically private to Alice, and a note written by Alice is not
+automatically readable only by Alice.
+
+**Memory view** is the immutable set of store mounts and per-mount capabilities
+computed by the selected plugin for one operation from the session subject,
+actor, collaboration policy, delegation, current memberships, revocations,
+physical authority, and backend capability.
+
+The implementation must maintain these invariants:
+
+1. No model argument can add a principal, store, audience, or permission.
+2. A session subject is persisted write-once on the logical session node.
+   Reset successors, transcript branches, forks, checkpoint restores, and
+   rewinds copy the exact source subject and source-policy set as immutable
+   provenance. Current binding, membership, and revocation state is rechecked
+   separately and may deny every operation without rewriting that provenance.
+   A flow that cannot prove source lineage is not a successor; it is a
+   quarantined import with no memory view. Import into a differently scoped
+   session requires a reviewed projection or quarantine, and choosing another
+   session key is never a transfer.
+3. Every readable resource belongs to the same hard `agent_id` cell and to a
+   store mount in the plugin-computed memory view.
+4. The candidate prefilter may over-include, but it must never exclude a
+   resource the canonical evaluator would allow. The postfilter is always
+   authoritative.
+5. No snippet, path, count, rank, cursor, or denial detail for an unauthorized
+   resource reaches a model-facing response.
+6. A derived resource is never readable by a broader audience than every
+   source resource. Mixed audiences are partitioned or quarantined.
+7. A write target comes from trusted runtime context. A model may narrow an
+   operation or choose content, but it cannot name another user's store.
+8. Disabling or failing a memory plugin makes memory unavailable. It never
+   disables core path, bootstrap, or identity enforcement.
+9. Runtime reads only the new canonical layout after migration. There is no
+   dual-read, lazy import, or unscoped fallback.
+
+## Identity and session subject
+
+### Resolution flow
+
+```mermaid
+flowchart LR
+  GP[Authenticated Gateway profile] --> PR[Core principal resolver]
+  CI[Admitted event with authenticated or adapter-attested sender fact] --> VB[Verified identity binding]
+  VB --> PR
+  SI[Explicit service or system identity] --> PR
+
+  PR --> SS[Write-once session memory subject]
+  SS --> AC[Immutable access context for one operation]
+
+  HM[Existing session collaboration decision] --> MV[Selected plugin computes memory view]
+  GM[Verified group and channel membership] --> MV
+  DL[Delegation capability intersection] --> MV
+  AC --> MV
+  RV[Revocation and policy revision] --> MV
+```
+
+Channel resolution happens after transport authentication or trusted-adapter
+attestation and shared ingress admission, before route dispatch. Core verifies
+issuer, signature, and audience where the protocol supports them; otherwise it
+records the registered adapter and assurance level. The trusted carrier must
+not live in model-visible message text or in an extensible `MsgContext` extras
+bag. Gateway UI calls resolve from the authenticated durable user profile.
+Cron, webhook, heartbeat, and child-agent runs receive explicit service or
+delegated identities; they never synthesize an owner from a session key.
+
+The logical binding key is the tuple `(channel, account, normalized stable
+sender ID)`. Persist an opaque keyed-HMAC lookup key for that tuple, not the raw
+provider ID, unless a protected operational workflow explicitly needs the raw
+value. A binding records the canonical principal, adapter and assurance,
+verification method, evidence revision, creation actor, creation time, and
+revocation time. Raw provider identifiers stay out of paths, logs, and audit.
+Usernames, display names, phone numbers, and email aliases may assist a human
+linking flow, but they cannot create or update a binding by equality alone.
+
+Existing `identityLinks` continue to affect DM route grouping only. Existing
+access groups continue to decide ingress admission only. Neither surface is
+silently promoted into memory authority.
+
+The current collaboration fallback that treats a profile-less client as an
+owner in a trusted deployment remains a chat-control compatibility rule only.
+It never creates a memory principal, private subject, or personal-store grant.
+Without a durable authenticated principal, the memory subject is `ambiguous`
+and private memory is unavailable.
+
+### Trusted types
+
+The exact names may change during implementation, but the separation should
+remain:
+
+```ts
+declare const memoryContextBrand: unique symbol;
+declare const memoryPlanBrand: unique symbol;
+declare const memoryExposureReceiptBrand: unique symbol;
+declare const memoryEgressReceiptBrand: unique symbol;
+
+type DeepReadonly<T> = T extends readonly (infer U)[]
+  ? readonly DeepReadonly<U>[]
+  : T extends object
+    ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+    : T;
+
+type SubjectEvidenceRef = Readonly<{
+  kind: "gateway-profile" | "channel-binding" | "adapter-attested" | "explicit-service";
+  revision: string;
+}>;
+
+type AudienceRef = Readonly<{
+  kind: "user" | "conversation" | "role" | "agent-shared" | "agent" | "internal";
+  id: string;
+}>;
+
+type VerifiedPrincipalRef = Readonly<{
+  principalId: string;
+  assurance: "gateway-profile" | "adapter-attested" | "oidc" | "service";
+  evidenceRevision: string;
+  expiresAt?: string;
+}>;
+
+type SessionMemorySubject =
+  | {
+      kind: "user";
+      principalId: string;
+      creationEvidence: SubjectEvidenceRef;
+    }
+  | {
+      kind: "conversation";
+      conversationPrincipalId: string;
+      channel: string;
+      accountId: string;
+    }
+  | { kind: "service" | "agent" | "system"; principalId: string }
+  | {
+      kind: "ambiguous";
+      reason: "shared-main" | "unbound" | "conflicting-bindings";
+    };
+
+type MemoryOperation =
+  | "retrieve"
+  | "read"
+  | "append"
+  | "replace"
+  | "derive"
+  | "deposit"
+  | "project"
+  | "publish"
+  | "import"
+  | "export"
+  | "delete"
+  | "sync"
+  | "policy-admin";
+
+type MemoryAccessContext = DeepReadonly<{
+  readonly [memoryContextBrand]: true;
+  version: 1;
+  contextId: string;
+  requestId: string;
+  runId: string;
+  agentId: string;
+  sessionKey: string;
+  sessionId: string;
+  sessionIdentityRevision: string;
+  subjectRevision: string;
+  subject: SessionMemorySubject;
+  actor:
+    | {
+        kind: "principal";
+        actorKind: "human" | "agent" | "service" | "system";
+        principalId: string;
+        assurance: VerifiedPrincipalRef["assurance"];
+        evidenceRevision: string;
+        expiresAt?: string;
+      }
+    | {
+        kind: "unattributed";
+        transportAuditRef: string;
+        evidenceRevision: string;
+      };
+  verifiedPrincipals: readonly VerifiedPrincipalRef[];
+  conversation?: {
+    conversationPrincipalId: string;
+    channel: string;
+    accountId: string;
+    evidenceRevision: string;
+  };
+  delivery: {
+    sinkKind: "private" | "channel" | "session" | "internal";
+    audiences: readonly AudienceRef[];
+    egressCapabilityIds: readonly string[];
+    egressRegistryRevision: string;
+    deliveryRevision: string;
+  };
+  collaboration:
+    | {
+        kind: "gateway-session";
+        mode: "shared" | "read-only" | "suggest" | "draft";
+        role: "admin" | "owner" | "member" | "viewer";
+        decisionRevision: string;
+      }
+    | { kind: "not-applicable" };
+  verifiedMemberships: readonly {
+    principalId: string;
+    groupId: string;
+    provider: string;
+    evidenceRevision: string;
+    observedAt: string;
+    expiresAt: string;
+  }[];
+  delegation?: {
+    rootPrincipalId: string;
+    rootContextId: string;
+    parentContextId: string;
+    parentMemoryPlanId: string;
+    capabilitySnapshotId: string;
+    allowedOperations: readonly MemoryOperation[];
+    maximumAudiences: readonly AudienceRef[];
+    storeCapToken: string;
+    depth: number;
+  };
+  operation: MemoryOperation;
+  hostFactsRevision: string;
+}>;
+
+type MemoryMount = DeepReadonly<{
+  agentId: string;
+  storeId: string;
+  mountHandle: string;
+  capabilities: readonly MemoryOperation[];
+  audienceRevision: string;
+}>;
+
+type AuthorizedMemoryPlan = DeepReadonly<{
+  readonly [memoryPlanBrand]: true;
+  version: 1;
+  planId: string;
+  contextFingerprint: string;
+  sessionIdentityRevision: string;
+  subjectRevision: string;
+  memoryPolicyRevision: string;
+  deliveryRevision: string;
+  operation: MemoryOperation;
+  mounts: readonly MemoryMount[];
+  bootstrapResourceHandles: readonly string[];
+  allowedEgressAudiences: readonly AudienceRef[];
+  expiresAt: string;
+}>;
+
+type MemoryExposureReceipt = DeepReadonly<{
+  readonly [memoryExposureReceiptBrand]: true;
+  version: 1;
+  receiptId: string;
+  contextFingerprint: string;
+  planId: string;
+  runId: string;
+  runExposureRevision: string;
+  sourcePolicySetId: string;
+  exposedRevisionHandles: readonly string[];
+  recordedAt: string;
+}>;
+
+type MemoryEgressAuthorizationReceipt = DeepReadonly<{
+  readonly [memoryEgressReceiptBrand]: true;
+  version: 1;
+  receiptId: string;
+  contextFingerprint: string;
+  planId: string;
+  runId: string;
+  runExposureRevision: string;
+  sourcePolicySetId: string;
+  allowedAudiences: readonly AudienceRef[];
+  deliveryRevision: string;
+  egressRegistryRevision: string;
+  expiresAt: string;
+}>;
+
+type AuthorizedMemoryResultEnvelope<T> = DeepReadonly<{
+  value: T;
+  exposureReceipt: MemoryExposureReceipt;
+  egressReceipt: MemoryEgressAuthorizationReceipt;
+}>;
+```
+
+`MemoryAccessContext` is created by core for each operation from the persisted
+session subject and the current verified or unattributed actor. Its in-process
+form is deep-frozen and host-branded; plugins receive it as a trusted host
+parameter, never as tool JSON. Across Stage 5 IPC, the symbol brand becomes a
+broker-authenticated envelope over the same serializable fields. The selected
+memory plugin consumes those facts and returns an opaque
+`AuthorizedMemoryPlan`; no caller may assemble mounts or raw store IDs. Read
+authorization covers every possible delivery audience, not merely the actor
+who triggered the run. This prevents a private fact from entering a group
+response just because its owner spoke last.
+
+Creation evidence is immutable provenance, not part of a principal's identity.
+Every operation resolves the principal's current merge head, binding state,
+membership evidence, and subject revision. Raw roles reported by a plugin are
+not authoritative until core validates them; expired membership evidence
+fails closed.
+
+An admitted event without a durable principal uses the `unattributed` actor
+variant. Its protected transport reference is audit provenance only and grants
+no actor-based memory authority. It never causes core or a plugin to synthesize
+a principal. `verifiedPrincipals` contains no actor-derived principal, but it
+retains independently verified subject or collaboration principals. An
+unattributed event cannot turn an ambiguous session into a private subject or
+erase a valid conversation subject.
+
+Core allocates a run/exposure ID for every content-bearing operation, including
+operator CLI, status, sync, and export paths. A runtime cannot omit `runId` and
+then return a receipt-producing result.
+
+`session_nodes.session_key` names the logical session node, while its current
+window mapping can change. Neither string is a human authorization identity.
+Before exposure and before every mutation, core rereads the authoritative
+session-key-to-current-session-ID mapping and the write-once subject row. A
+stale context fails with `session-rebound`; it never follows a changed mapping
+to a replacement window or conversation.
+
+Once a run receives scoped content, its run exposure set constrains every
+egress. Final replies, message and session-send tools, plugin or MCP outbound
+actions, and fanout must all remain within the intersection of every exposed
+resource audience. A route, sink, or delivery revision change invalidates the
+authorization plan and egress receipt: deny delivery or rerun without the now-
+ineligible content. An audit entry alone cannot make an unsafe delivery
+acceptable.
+
+Egress uses a mandatory capability registry, not a closed list of transports.
+Every enabled tool capable of network, process, upload/export, browser, node,
+webhook, plugin, MCP, file-delivery, or message side effects declares a stable
+egress capability ID and passes the audience gate after a scoped exposure.
+Unclassified egress is denied. Each authorization receipt binds the current
+`runExposureRevision`, delivery revision, and registry revision; a receipt
+issued before a later read is stale. Unsandboxed, network-capable `exec` is
+incompatible with model-adversarial isolation even when its filesystem view is
+scoped.
+
+### Session mapping
+
+| Session                                                   | Subject                                                    | Default readable stores                                                                          | Default write store                                                                                                                                  |
+| --------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Isolated DM with verified binding                         | User                                                       | That user's private store, the agent-shared store, and currently verified role stores            | That user's private store                                                                                                                            |
+| Group, room, or channel                                   | Conversation                                               | That channel's store, the agent-shared store, and explicit projections addressed to that channel | That channel's store                                                                                                                                 |
+| Gateway collaborative session                             | Stored session subject plus current collaboration decision | Intersection of subject view and existing session visibility decision                            | Only when the collaboration mode and role permit mutation                                                                                            |
+| Cron, heartbeat, webhook, or autonomous run               | Service agent                                              | Agent store and the agent-shared store                                                           | Agent store                                                                                                                                          |
+| Child agent                                               | Delegated subject                                          | Intersection of parent view, child task capability, and child session visibility                 | Explicit child target inside that intersection                                                                                                       |
+| Shared-DM `main` session with more than one possible user | Ambiguous                                                  | Agent-shared resources explicitly classified safe for anonymous or local-cell use only           | No durable write                                                                                                                                     |
+| Incognito session                                         | Existing subject, with an incognito visibility attribute   | Explicitly allowed agent-shared or ephemeral context only                                        | No durable memory, transcript-derived memory, flush, dream, or projection until a future explicit product/config contract is implemented and enabled |
+
+OpenClaw currently defaults `session.dmScope` to `main`, which routes direct
+messages through the shared main session (`src/routing/session-key.ts:229`). A
+`main` session with more than one possible sender has no coherent private
+subject, so it must never mount a user store.
+
+The existing security checks already recommend `per-channel-peer`, or
+`per-account-channel-peer` for multi-account channels, when multiple DM senders
+share that session (`src/commands/doctor-security.ts:389`,
+`src/security/audit-channel.ts:256`). Enforced mode promotes that advice to a
+precondition for private memory. It reports the exact remediation through
+`openclaw doctor` and refuses the private mount; it does not silently rewrite
+the operator's session configuration.
+
+A group never automatically mounts role memory based on the current sender.
+Other participants share the same model context, so sender-specific role
+memory would immediately become channel memory. A role fact must be explicitly
+projected into the channel first.
+
+Incognito is a session visibility attribute, not a memory audience grant. It
+never widens a view. The conservative row above remains the enforced behavior
+until the product explicitly defines a different durable-memory contract.
+
+## Scope and storage model
+
+### Scope kinds
+
+| Scope          | Purpose                                                                              | Read rule                                                       | Write rule                                                 |
+| -------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------- | ---------------------------------------------------------- |
+| `user`         | Private profile and durable notes for one verified person                            | Only that user's isolated subject, plus trusted admin workflows | That user's authorized DM workflows                        |
+| `channel`      | Facts said or produced in one group conversation                                     | That channel subject while collaboration and membership permit  | Runs in that channel                                       |
+| `role`         | Team or department memory                                                            | Verified role principal in a private or service context         | Named role publishers or admins                            |
+| `agent-shared` | Reference material shared by scoped sessions of one agent                            | Every eligible subject in that agent cell                       | Explicit publisher only                                    |
+| `agent`        | Autonomous operational memory                                                        | That service agent and trusted admin workflows                  | That service agent                                         |
+| `projection`   | Deliberately declassified copy for one named channel, role, or agent-shared audience | The named target audience while the projection is live          | The projection publisher; no implicit source write-through |
+| `quarantine`   | Ambiguous migration data, pending postbox deposits, and invalid policy state         | Admin review, or owner review for their own postbox             | Migration and deposit paths only                           |
+
+Cross-agent, instance-wide shared or role memory is deferred. It needs a
+separate canonical owner, database, lifecycle, and multi-agent authorization
+design; a row in one agent's database must not silently become global.
+
+### Storage roots and backend namespaces
+
+Do not place every multiplayer store below one model-editable workspace tree.
+The selected backend keeps a root registry that makes physical authority
+explicit. For the local builtin backend, user stores are logically owned by a
+principal, channel stores by a conversation or workspace, and agent-shared
+stores by the agent's administrative owner. The broker process owns the host
+files at Stage 5; logical owner authority still controls which operations it
+may perform.
+
+The local builtin default uses a controlled, versioned artifact area for each
+agent, conceptually:
+
+```text
+{agent-state}/memory-scopes/v1/
+  s1_7K4M.../
+    PROFILE.md
+    MEMORY.md
+    notes/
+  s1_B2PF.../
+    CHANNEL.md
+    notes/
+  s1_N9TR.../
+    postbox/
+  s1_Q5DC.../
+    projections/
+```
+
+The opaque directory key is generated with a CSPRNG and created with exclusive
+`mkdir`; a collision retries with a new key. Its user, channel, role, or
+agent-shared meaning exists only in the policy catalog. Store IDs and path keys
+are distinct so doctor can rotate a path key without changing resource
+identity. The catalog records `path_key_version`; `openclaw doctor --fix` owns
+any path-key migration. This avoids leaking provider IDs through paths, path
+instability after an account rename, and path injection from external
+identifiers.
+
+For builtin memory and QMD, Markdown remains the content source of truth and
+stays inspectable through operator UI, CLI export, backups, and an authorized
+virtual filesystem view. A conforming external backend may instead use an
+isolated namespace or collection, but must provide equivalent inspection,
+export, backup, deletion, revision, and recovery behavior. SQLite stores the
+builtin plugin's identity references, policy, lifecycle, lineage, index, and
+audit metadata; it is not a second canonical copy of a Markdown artifact. A
+search index is content-bearing derived state because it contains chunk text
+or embeddings, so it must sit inside the same trusted broker boundary.
+
+### Catalog rows and derived indexes
+
+The resource catalog stores authority metadata and artifact pointers, not a
+second canonical copy of Markdown. For the builtin backend, an active resource
+revision points to an immutable artifact locator and content hash. Scoped FTS
+and vector chunks are content-bearing derived state inside the broker boundary.
+
+After the policy postfilter authorizes a read, the backend resolves the active
+revision and verifies its artifact hash before returning content. A missing
+artifact, hash mismatch, or orphaned index row produces `revision-stale` or an
+unavailable result; the backend never serves chunk text as a fallback copy.
+Repair or reindexing must restore agreement before the revision becomes
+readable again.
+
+Deletion is symmetric across every access path. A tombstone or revocation makes
+exact reads, candidate queries, exports, and derivations reject the revision
+immediately. The plugin-owned lifecycle then retires its FTS, vector, and
+fallback-search rows and removes the artifact through the recoverable write
+state machine. A lagging index row remains denied, and an orphaned file never
+becomes readable merely because it exists under a storage root.
+
+### Front card and searchable notes
+
+Each personal store has two intentionally different layers:
+
+- `PROFILE.md` is the tiny front card: stable communication preferences,
+  identity facts, and safety-critical context worth loading whenever that user
+  has a private session. It has a hard character and entry budget.
+- `MEMORY.md` and `notes/` hold detailed durable and episodic facts. They are
+  available only through authorized retrieval unless a consolidation process
+  promotes a bounded entry to the front card.
+
+Channel, role, and agent-shared stores use the same pattern only when useful. A
+channel may have a small `CHANNEL.md`; shared reference material is usually
+search-only. No front card from one scope is concatenated into another scope.
+
+### Subject lookup
+
+Bloome's identity lesson applies inside every authorized store. Person
+references use canonical subject IDs recorded in policy metadata, not names
+recovered by similarity search. A channel resource about a participant stays
+in the channel store but may carry that verified participant as its subject.
+Two people named Mike remain two IDs even when their note text is similar.
+
+Only trusted identity resolution may attach a canonical human subject. A model
+may create an ordinary topic label or select a server-issued mention/message
+handle, but it cannot assert that an arbitrary string is a verified person.
+Subject lookup first narrows to the resolved ID inside the current memory view;
+semantic or lexical ranking then finds relevant facts. Expiry and
+supersession answer the second multiplayer question: whether the fact is still
+current.
+
+### Virtual mount topology
+
+```mermaid
+flowchart TB
+  subgraph P[Private session for user A]
+    PV[Authorized memory view]
+  end
+
+  subgraph G[Group session for channel C]
+    GV[Authorized memory view]
+  end
+
+  UA[User A private store]
+  CC[Channel C store]
+  SH[Agent-shared read-only store]
+  RP[Verified role stores]
+  PJ[Projections addressed to channel C]
+  PB[User A postbox quarantine]
+
+  PV -->|read and authorized write| UA
+  PV -->|read| SH
+  PV -->|read while membership is current| RP
+  PV -->|owner review only| PB
+
+  GV -->|read and authorized write| CC
+  GV -->|read| SH
+  GV -->|read| PJ
+  GV -. deposit only .-> PB
+  GV -. never mounted .-> UA
+  GV -. never mounted .-> RP
+```
+
+For filesystem-backed plugins, the virtual view is also the authority for
+model-facing tools. A group sees virtual `channel/`, `agent-shared/`, and
+`projections/` roots, not the real artifact area. Exact reads resolve through
+the plugin catalog and a symlink-safe reader. A sandbox receives only those
+roots. External backends expose opaque handles rather than fake host paths. In
+enforced mode, a tool that cannot honor the view is hidden or denied.
+
+## Authorization model
+
+### Permission lattice
+
+The RFC's retrieval lattice is useful but incomplete without write controls.
+Use these implications:
+
+```text
+derive -> read -> retrieve
+replace -> append
+
+project, deposit, sync, destructive delete, publish, and policy-admin
+are independent capabilities and never imply one another
+```
+
+| Requested operation                                                            | Required capabilities                     |
+| ------------------------------------------------------------------------------ | ----------------------------------------- |
+| `retrieve`                                                                     | `{retrieve}`                              |
+| `read`                                                                         | `{retrieve, read}`                        |
+| `derive`                                                                       | `{retrieve, read, derive}`                |
+| `append`                                                                       | `{append}`                                |
+| `replace`                                                                      | `{append, replace}`                       |
+| `project`, `deposit`, `sync`, destructive delete, `publish`, or `policy-admin` | The requested independent capability only |
+
+`retrieve` permits a candidate to exist inside the trusted broker. It does not
+permit a snippet, path, title, score, or existence bit to leave the broker.
+`read` permits content exposure. `derive` permits content to become an input to
+a new durable resource. `project` is explicit declassification into a named
+audience. `deposit` is the write-only postbox valve. `sync`, destructive
+deletion, and publisher authority are independent. A policy administrator may
+grant or revoke a capability but does not thereby exercise it: ambient admin
+authority must never silently declassify private content.
+
+Most resources need no explicit allow row. Placement in a store plus a valid
+memory view supplies the common allow. ACL rows handle explicit denies,
+publisher roles, expiry, and future exceptional sharing. No application path
+creates a direct cross-user private-store allow in the initial design.
+
+### Evaluation order
+
+For requested permission `P`, evaluate in this order:
+
+1. Core validates the context brand and version, request binding, current
+   session-window mapping, subject revision, actor, delivery audience,
+   delegation cap, and evidence expiry before invoking the memory capability.
+2. The selected memory plugin validates that its plan is bound to that exact
+   context fingerprint, operation, delivery revision, agent cell, and current
+   memory-policy revision.
+3. The plugin resolves the current memory view. A revoked identity, stale
+   required group snapshot, or failed membership lookup removes the affected
+   store.
+4. Enforce the hard cell, agent, store, and virtual-mount boundary. An ACL can
+   narrow this boundary but cannot override it.
+5. Validate resource state: active immutable revision, matching content hash,
+   non-expired, non-tombstoned, and a canonical path inside its store root.
+6. Apply the core-validated Gateway session collaboration decision for
+   session-backed content and mutation. Reissue or revalidate those host facts
+   at exposure and commit time to avoid a revoke race.
+7. Expand the permissions implied by `P`. Any matching deny on any required
+   permission denies the operation.
+8. Require placement authority or a matching, unexpired allow for every
+   required permission.
+9. Require the resource audience to cover every output audience in the
+   operation context. Actor read authority alone is insufficient.
+10. For a derived resource, require every inherited source-policy requirement
+    plus any narrowing output policy; do not infer a broader policy from the
+    current ancestor text.
+11. Record a bounded decision trace and return either an opaque allowed handle
+    or a stable denial reason.
+
+Stable reason codes include `invalid-context`, `session-rebound`,
+`delivery-rebound`, `plan-expired`, `identity-revoked`, `membership-stale`,
+`outside-view`, `revision-stale`, `explicit-deny`, `default-deny`,
+`lineage-deny`, and `backend-nonconforming`. Model-facing tools receive only a
+safe unavailable or not-found result where detail could reveal another scope.
+
+## Read and prompt path
+
+### Authoritative pipeline
+
+```mermaid
+sequenceDiagram
+  participant T as Model-facing tool or prompt builder
+  participant H as Core access host
+  participant M as Selected memory plugin
+  participant B as Plugin-owned isolated backend
+
+  T->>H: query plus host-only invocation metadata
+  H->>H: build and revalidate branded access context
+  H->>M: invoke memory capability with context
+  M->>M: derive context-bound authorization plan
+  M->>B: candidate query with pre-limit policy predicate
+  B-->>M: opaque candidates and immutable revisions
+  M->>M: authoritative policy postfilter
+  M->>B: read only allowed active revisions
+  B-->>M: verified content
+  M->>M: rank, trim, render, and record exposure
+  M-->>H: safe result plus exposure and egress receipt
+  H->>H: merge run exposure set and gate all egress
+  H-->>T: scoped result or unavailable response
+```
+
+The order matters. Authorization occurs before result count, final ranking,
+pagination, or rendering. An unauthorized nearest neighbor must not displace
+an authorized result and thereby leak information through result shape.
+Adaptive over-fetch may fill the requested number of allowed results, but
+denial counts stay internal.
+
+The prefilter is an optimization with one required property:
+
+> Every resource the canonical evaluator would allow is included in the
+> prefilter candidate superset.
+
+The selected plugin's postfilter is the memory security boundary. A prefilter
+false positive is safe but observable as policy drift; a false negative is a
+correctness bug. Use property tests to compare generated policy states against
+the plugin's pure evaluator. In practical terms, the prefilter may be loose;
+confidentiality never depends on it. Core never interprets store kinds, ACL
+rows, or bundled backend IDs.
+
+### Authorized runtime contract
+
+The current `MemorySearchManager` accepts an optional session key and returns
+content-bearing hits. Enforced mode needs a versioned contract such as:
+
+```ts
+type MemoryAuthorizationCapabilities = Readonly<{
+  version: 1;
+  scopedCandidates: true;
+  exactReadByAuthorizedHandle: true;
+  scopedSync: true;
+  scopedWrite: true;
+  scopedExport: true;
+  exposureReceipts: true;
+  egressReceipts: true;
+}>;
+
+interface AuthorizedMemoryRuntime {
+  authorization: MemoryAuthorizationCapabilities;
+  authorize(context: MemoryAccessContext): Promise<AuthorizedMemoryPlan>;
+  searchAuthorized(params: {
+    context: MemoryAccessContext;
+    plan: AuthorizedMemoryPlan;
+    query: string;
+    subjectHandles?: readonly string[];
+    sources?: readonly ("memory" | "sessions")[];
+    limit: number;
+    signal?: AbortSignal;
+  }): Promise<AuthorizedMemoryResultEnvelope<MemorySearchResult>>;
+  readAuthorized(params: {
+    context: MemoryAccessContext;
+    plan: AuthorizedMemoryPlan;
+    handle: AuthorizedResourceHandle;
+    from?: number;
+    lines?: number;
+  }): Promise<AuthorizedMemoryResultEnvelope<MemoryReadResult>>;
+  writeAuthorized(params: {
+    context: MemoryAccessContext;
+    plan: AuthorizedMemoryPlan;
+    mutation: AuthorizedMemoryMutation;
+  }): Promise<MemoryWriteResult>;
+  syncAuthorized(params: {
+    context: MemoryAccessContext;
+    plan: AuthorizedMemoryPlan;
+  }): Promise<AuthorizedMemoryResultEnvelope<MemorySyncResult>>;
+  exportAuthorized(params: {
+    context: MemoryAccessContext;
+    plan: AuthorizedMemoryPlan;
+    handles: readonly AuthorizedResourceHandle[];
+  }): Promise<AuthorizedMemoryResultEnvelope<MemoryExportResult>>;
+}
+```
+
+The plan is plugin-issued and bound to the context fingerprint, session and
+subject revisions, operation, mounts, policy revision, delivery revision,
+egress audiences, and expiry. No selected or supplemental backend exposes a
+context-free overload or one that accepts caller-assembled store IDs. Exact
+reads, writes, deletes, imports, sync, and every candidate branch revalidate the
+plan and resource revision. A returned handle is not a bearer grant.
+
+Every search or exact-read result that exposes content uses the mandatory
+result envelope with both branded receipts, recorded before the content leaves
+the plugin. The capability flags make that requirement discoverable during
+backend admission. Core rejects a missing or invalid exposure receipt before
+prompt assembly, and rejects an egress receipt whose context, delivery,
+registry, policy-set, or `runExposureRevision` no longer matches.
+Sync, export, public-artifact reads, and any future method that emits content
+use the same envelope; a plain content-bearing return type is nonconforming.
+
+Before each branch's final limit, the backend applies a full over-approximating
+resource-policy predicate, not only a store-placement filter. Continuation or
+adaptive widening continues until it has the authorized top K or exhausts the
+eligible corpus. The authoritative plugin postfilter runs immediately before
+any snippet, content, score, path, or existence bit leaves the plugin. The
+conformance suite exercises the current sqlite-vec KNN, vector-scan fallback,
+FTS/LIKE, and exact-path branches independently.
+
+Candidate rows carry stable resource ID, immutable revision ID, store ID,
+source, and score, but no content until the plugin evaluator allows `read`.
+Core supplies verified principal facts; the selected plugin may turn those
+facts or server-issued mention/message references into subject handles. Free-
+form model text cannot create them.
+
+Builtin memory should implement the contract first. QMD and other selected
+memory plugins need conformance adapters that use separate authorized
+collections or an equivalent native scope. A backend returning already
+rendered snippets can be supported only when its process is inside the trusted
+broker boundary and its native filter has passed conformance tests. Enforced
+mode rejects a legacy backend instead of falling back to broad search.
+
+### Every read lane uses the same view
+
+- **Bootstrap:** prompt assembly invokes the selected capability for authorized
+  front-card resources. It never reads root `MEMORY.md` or `USER.md` directly
+  in multiplayer mode.
+- **Memory prompt guidance:** guidance may direct the model to memory tools, but
+  those tools receive the same view. Disabling the tool does not restore raw
+  file injection.
+- **Search:** model-selected `corpus` can narrow the trusted runtime's source
+  set but cannot add sessions, stores, or supplements.
+- **Exact get:** search returns an opaque, revision-bound resource handle.
+  Human-friendly virtual paths may be displayed, but a raw path is resolved
+  only inside the current view.
+- **Trigger and active recall:** automatic injection is more sensitive than an
+  explicit tool call, so it uses the same `read` decision and only authorized
+  curated resources.
+- **Plugin tools and hooks:** `memory-lancedb` recall, store, and forget tools,
+  its `before_prompt_build` auto-recall and auto-capture, and any future raw
+  `registerTool` or prompt hook must invoke the selected memory capability with
+  the host context. Enforced mode rejects direct memory-content injection.
+- **Supplements and preparations:** `MemoryPromptSupplement`,
+  `MemoryPromptPreparation`, and `MemoryCorpusSupplement` registrations must
+  declare an authorized store or route through the selected capability. This
+  includes memory wiki Gateway/CLI paths, public artifacts, QMD extra
+  collections and session artifacts, and project bootstrap supplements.
+- **Import and export:** Codex, Claude, Hermes, and other import targets enter
+  the scoped write lifecycle; exports require an authorized plan and preserve
+  or explicitly warn about audience metadata.
+- **Session history:** current session visibility remains a necessary check.
+  The persisted transcript audience becomes an additional mandatory check.
+- **Status and CLI:** operator commands authenticate explicitly. They do not
+  call a context-free manager method that happens to bypass session policy.
+
+## Write, derive, and share path
+
+### Write flow
+
+```mermaid
+flowchart LR
+  EV[Authenticated event or lifecycle hook] --> CTX[Core access context]
+  CTX --> PL[Selected plugin authorization plan]
+  PL --> OP{Operation}
+
+  OP -->|remember| WT[Choose session default write store]
+  OP -->|deposit| PB[Core resolves source handle to verified principal evidence]
+  PB --> PT[Plugin selects authorized deposit quarantine]
+  OP -->|project| PJ[Require target, purpose, lifetime, and preview]
+  OP -->|derive| DR[Load authorized parent revisions]
+
+  DR --> IN[Intersect source audiences]
+  IN -->|representable| WR[Stage backend revision]
+  IN -->|mixed or missing labels| Q[Quarantine or partition]
+  WT --> WR
+  PT --> Q
+  PJ --> WR
+
+  WR --> DB[Commit pending revision and audit outbox]
+  DB --> FN[Finalize backend artifact]
+  FN --> AC[Activate revision, policy, provenance, and lineage]
+  AC --> IX[Index authorized revision]
+```
+
+The content-producing model never chooses `store_id`, owner principal, or raw
+artifact root. A private session writes to its user store, a group session to
+its channel store, and an autonomous session to its agent store. Agent-shared
+and role writes require an explicit publisher operation outside ordinary memory
+capture.
+
+Model-facing generic `write`, `edit`, and `apply_patch` calls against a virtual
+memory path must delegate to the same broker write transaction. A direct host
+path into the controlled artifact area is not a valid model tool target.
+
+Human or administrator edits remain supported. The operator opens an
+authorized store through CLI or UI; the watcher validates the store root,
+records an admin actor, bumps the resource revision, and reindexes. A new file
+with no valid catalog mapping enters quarantine rather than becoming shared.
+
+### Crash consistency
+
+Markdown and SQLite cannot share one atomic transaction. Use a recoverable
+state machine for the builtin filesystem backend:
+
+1. Validate the expected active revision and policy, then stage the new file
+   with restrictive permissions and fsync it. Finish all filesystem work for
+   this phase before opening a transaction.
+2. In one short synchronous SQLite transaction, reread authority and revisions,
+   insert an immutable `pending` revision and write intent, and enqueue the
+   corresponding local audit/outbox record. Commit without touching the
+   filesystem.
+3. Atomically rename the staged file to its revision-scoped final locator,
+   fsync it, and compute its finalized hash outside any database transaction.
+   Revision files are broker-owned and immutable after this point.
+4. In a second short synchronous transaction, compare the pending row with the
+   already prepared finalized-hash fact, mark that revision `active`, repoint
+   the resource's current revision, and finalize lineage and audit-outbox
+   state. The callback performs no `stat`, open, read, or hash operation.
+5. Readers resolve only active revisions. Startup recovery completes a valid
+   pending intent or quarantines orphan files and rolls back invalid pending
+   rows. Reads and recovery verify the immutable file hash again, so a changed
+   live-looking filename never grants readability by itself.
+
+No SQLite transaction callback performs filesystem access or awaits plugin,
+model, membership, or network work. External backends must document and test an
+equivalent pending-to-active protocol using their own atomic primitives.
+
+### Derived content
+
+Compaction summaries, dreaming output, memory flushes, profile promotion,
+session exports, and projection copies are derivations, not ordinary new
+facts. Every derivation records parent resource or transcript-event revisions.
+
+The effective audience is the intersection of all parent audiences and the
+requested target. An agent-shared source plus a user-private source produces
+user-private output. Sources from two unrelated private users have no
+representable common audience; the derivation must be split or quarantined.
+The model cannot widen the result by describing it as public.
+
+Tombstoning or revoking a parent invalidates cached effective policy for its
+descendants. Every old derived revision remains denied. Reclassification as
+independent requires explicit declassification authority and creates a new,
+reviewed immutable revision with fresh policy while preserving the original
+lineage and audit trail. This is stricter than deleting an FTS row while
+leaving an old summary readable.
+
+### Postbox
+
+The postbox is a deposit-only path from a group or collaborative session to one
+participant's quarantine. It is not a mounted personal store.
+
+Within the broker boundary, a hostile channel can attempt to pollute that
+quarantine, but it cannot read the participant's private store or retrieve a
+deposited item back into the channel.
+
+- A deposit names a server-issued source message handle, not a user ID. Core
+  resolves that message to a currently verified sender principal and evidence;
+  the selected memory plugin resolves the current deposit target and quarantine
+  store under its own catalog and policy.
+- The channel session receives only success or a generic refusal. It cannot
+  search, read, list, or exact-get the deposited item.
+- The item records the channel, source message, actor, trust origin, creation
+  time, and expiry. It never enters `PROFILE.md`, bootstrap, trigger injection,
+  or dreaming promotion automatically.
+- The owner sees a provenance label and may approve, edit, reject, bulk-purge
+  by source channel, or disable deposits.
+- The first accepted deposit from a previously unseen source channel queues an
+  owner notification. Rate limits are per source channel and target store,
+  persisted in SQLite; over-cap deposits are dropped and audited.
+
+Initial rollout defaults postbox to `off`. A review-required mode may be
+enabled after Stage 3. A labeled-without-review mode remains a later product
+choice; it should not be the enterprise default.
+
+If labeled-without-review is added later, an unreviewed item must render as
+untrusted data with its provenance. It remains ineligible for `PROFILE.md`,
+bootstrap, trigger injection, automatic promotion, and dreaming, and it is
+never presented as an instruction source.
+
+### Projections
+
+A projection is an explicit declassified copy, not a live read grant against a
+private store. It must name:
+
+- one target channel, role, or agent-shared audience;
+- a purpose and human-readable preview;
+- the source resource revision and publisher;
+- either a required `expires_at` or an explicit, audited `no_expiry` decision;
+- revocation behavior.
+
+Membership can narrow access to that named audience but never create or widen
+it. For example, "all channels I might join" is not an acceptable implicit
+target. A new channel needs a new projection decision.
+
+The copy lives in the target audience's projection store and has lineage back
+to the private source. Source edits do not silently republish; the owner
+reviews a new projection revision. Revocation tombstones future retrieval of
+the copy and queues impact analysis for sessions where it was already exposed.
+
+Direct private-store access from user A to user B remains deferred. It needs a
+separate design for invitation, acceptance, delegation, admin override,
+expiry, revocation residuals, and user experience.
+
+## Transcripts, compaction, and dreaming
+
+Memory files are only one durable representation of a conversation. The
+transcript path must carry the same audience or it becomes a bypass.
+
+Canonical sessions, transcript events, windows, and conversation identity
+remain in the per-agent SQLite database. Do not relocate transcripts into
+per-user Markdown directories. Add authorization companion records keyed by
+the canonical session and event identities, then project those labels into
+scoped transcript search.
+
+Revocation is forward-looking. Content already exposed may persist in affected
+transcript events or external deliveries after a member leaves or a projection
+is revoked. Exposure records make the affected resource revisions and sessions
+enumerable, so a revocation-triggered impact report or scrub is a defined
+operational job. That cleanup is best effort, not a retroactive guarantee that
+the model or a recipient has forgotten the content.
+
+### Transcript labels
+
+Persist non-model metadata beside each transcript event:
+
+- session subject and store scope;
+- verified or unattributed actor evidence, with a binding revision when
+  present;
+- source trust provenance;
+- immutable effective source-policy-set ID, referencing every stable policy
+  ID, captured revision, expected active revision/revocation epoch, and a
+  cached normalized audience intersection;
+- finalized delivery and egress audiences;
+- session identity revision and subject revision;
+- delegation snapshot, when present;
+- run exposure-set ID and immutable revisions of memory resources exposed into
+  that turn.
+
+Every derived assistant, tool-result, summary, and checkpoint event carries
+these labels because it may depend on the whole prompt rather than only its
+immediate parent event. Actor and binding remain origin and audit facts; they
+never substitute for effective audience. Policy-set records remain evaluable
+for the full lineage-retention period even after a source resource is deleted.
+
+`InputProvenance` remains useful trust metadata, but it is not authority: its
+current shape has no canonical principal or audience and can be reconstructed
+from ordinary event JSON. Authorization metadata must be written by the
+trusted transcript writer and never recovered from rendered prompt text.
+
+Append a transcript event and its authorization companion row in the same per-
+agent SQLite transaction. If a runtime cannot do so, persist the event as
+authorization-pending and exclude it from replay, search, compaction, export,
+and derivation until the label commits. Summary and checkpoint text and their
+policy rows obey the same atomic visibility rule. In enforced mode, a missing
+companion row means pending/denied; it is never reconstructed from legacy event
+content.
+
+No scoped resource may enter an enforced run until this minimum labeling path
+exists. If a deployment cannot persist the turn's effective source-policy set,
+exposed revisions, delivery audience, and session identity revision, it must
+disable transcript recall, compaction, memory flush, dreaming, and every other
+durable derived write for that agent rather than create an unlabeled copy.
+
+### Compaction
+
+Before summarization, compute the source policy set over every compacted event,
+previous summary, injected memory resource, and preserved turn. Store that set
+as non-model metadata on the compaction entry and checkpoint. The summary
+model receives only content already authorized for the current subject.
+
+After summarization:
+
+1. Derive the output policy deterministically from the source policy set.
+2. Reject a summary that has no representable audience.
+3. Persist summary text and policy metadata together.
+4. Preserve the metadata through reset, branch, fork, rewind, checkpoint,
+   archive, export, and transcript search.
+
+Never infer an audience from the summary's words or from a session key. The
+current compaction path renders preserved turns as plain role text, so adding
+authorization metadata after the model call would be too late.
+
+### Memory flush and dreaming
+
+The pre-compaction flush chooses its target from the session subject. A private
+DM flush writes the user's episodic store; a group flush writes the channel
+store; an autonomous flush writes the agent store or nothing. The existing
+write-provenance callback is extended with resource, store, audience, and
+source-event revisions.
+
+Dreaming operates one authorized store at a time. Candidate queries, phase
+artifacts, `DREAMS.md`, profile promotion, and consolidation never combine
+unrelated stores in one model context. Trust provenance still controls whether
+content is eligible for promotion; audience authorization is a separate,
+additional gate. Postbox and quarantine resources are ineligible until an
+authorized review changes their state.
+
+### Delegation and autonomous runs
+
+Each child authenticates independently. Its view is:
+
+```text
+parent authorized view
+intersect child task capability snapshot
+intersect child session visibility and collaboration decision
+intersect current revocation and membership state
+```
+
+A parent may pass a minimal, explicit context excerpt to a child and record
+that exposure. It does not pass a database handle, raw credential, or
+unbounded parent view. Agent-tree visibility and human session membership are
+separate checks; both apply. `parentMemoryPlanId` and `storeCapToken` are opaque
+artifacts issued and checked by the selected memory plugin; core carries them
+without interpreting store identity.
+
+Cron, heartbeat, webhook, and system runs use explicit service identities.
+They can read agent-shared and their own agent store by default. They cannot
+acquire a human private store merely because they target that human's old
+session key.
+
+## Core and plugin ownership
+
+```mermaid
+flowchart TB
+  subgraph CORE[Core access host]
+    ID[Principal and binding resolver]
+    SS[Session subject and collaboration adapter]
+    CT[Branded access facts and capability gate]
+    PM[Generic prompt, egress, and filesystem confinement]
+  end
+
+  subgraph SDK[Versioned plugin SDK]
+    AC[Authorized memory capability contract]
+    CF[Backend conformance suite]
+  end
+
+  subgraph MEM[Selected memory plugin]
+    EV[Policy evaluator and memory view]
+    ST[Logical stores and isolated backend]
+    IX[Prefilter, postfilter, and scoped reads]
+    WR[Writes, lineage, exposure, sync, and lifecycle]
+  end
+
+  subgraph IDP[Optional identity plugins]
+    OI[Identity evidence and group adapters]
+  end
+
+  ID --> SS --> CT --> AC
+  AC --> MEM
+  MEM --> PM
+  CF --> MEM
+  IDP -->|verification material, never final policy| ID
+```
+
+Core constructs and brands immutable verified access facts, gates every memory-
+capability invocation, enforces generic prompt, egress, and filesystem
+confinement, and rejects missing or nonconforming capabilities. It owns durable
+principal resolution, the write-once session subject, current session mapping,
+Gateway collaboration decisions, and delivery revisions. Core never branches
+on store kinds, ACL schemas, search algorithms, or bundled plugin IDs.
+
+The selected memory plugin owns its logical-store catalog, memory policy,
+resource revisions, lineage, view construction, candidate prefilter,
+authoritative postfilter, content reads and writes, exposure records, sync, and
+backend-specific recovery. Its policy evaluator is pure and reusable by its
+conformance tests. Core treats the returned plan, handles, mounts, policy
+receipt, and exposure receipt as versioned opaque capability data.
+
+`session_members` and the current sharing evaluator remain authoritative only
+for Gateway collaborative-session membership and mode. Native channel and
+enterprise role membership is separate provider evidence consumed by the same
+plugin evaluator; it is never mirrored into or inferred from
+`session_members`.
+
+Identity plugins may supply issuer metadata, signed claims when the transport
+supports them, trusted-adapter attestations otherwise, group snapshots, and
+refresh support. Core validates the protocol-appropriate issuer, audience,
+signature or adapter registration, assurance, expiry, tenant binding, and
+snapshot freshness before constructing principal facts. Missing or stale
+evidence removes access; it cannot produce a permissive fallback. Installed
+in-process plugins remain inside the current trusted-process boundary.
+
+Each identity adapter may register only provider and issuer namespaces allowed
+by operator-owned configuration. Duplicate authority registrations are
+rejected, and the registry seals before the first session routes. Changing the
+registry requires an explicit owner reload or restart flow that advances the
+relevant host-fact and evidence revisions; a late plugin cannot replace an
+active identity authority in place.
+
+## Proposed builtin data model
+
+Use additive SQLite tables and idempotent lazy ensure. Do not alter strict
+existing tables or bump a schema version without explicit maintainer
+discussion. Application state belongs in SQLite; do not add JSON policy,
+cursor, audit, or migration sidecars. This is the concrete builtin-plugin
+layout, not a requirement that external memory plugins use SQLite or Markdown;
+their implementation must provide equivalent contract behavior.
+
+### Shared state database
+
+Global identity coordination and redacted audit belong in
+`state/openclaw.sqlite`.
+Human principals reference the existing durable Gateway user profiles rather
+than duplicating them:
+
+| Table                      | Key fields                                                                                                 | Purpose                                                                                  |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `memory_principals`        | `principal_id`, optional user-profile ID, kind, issuer, subject, state                                     | Canonical references for existing profiles plus enterprise, agent, and system identities |
+| `memory_identity_bindings` | channel, account, keyed-HMAC sender lookup, principal, adapter, assurance, evidence revision, revoked time | Verified transport-to-principal mapping without raw provider IDs in ordinary lookups     |
+| `memory_group_snapshots`   | provider, group, principal, revision, observed and expiry times                                            | Bounded-staleness role evidence                                                          |
+| `memory_access_audit`      | batch, request, actor, subject, operation, decision, reason, resource revision, time                       | Redacted decision and exposure history                                                   |
+
+The audit table stores identifiers, revisions, decisions, and hashes, not
+memory text, queries, prompts, or snippets. Retention and export are explicit
+operator policies.
+
+### Per-agent database
+
+The builtin selected plugin keeps resource, policy, session-label, and derived-
+index metadata in the existing per-agent database:
+
+| Table                                             | Key fields                                                                                                                                                  | Purpose                                                                                      |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `memory_storage_roots`                            | `storage_root_id`, backend kind, opaque locator token, path-key version/key, authority kind/owner, default capabilities, state                              | Physical or backend namespace registry; filesystem path keys exist only for filesystem roots |
+| `memory_stores`                                   | `store_id`, `agent_id`, storage root, scope kind, audience reference, state                                                                                 | One logical store and hard agent-cell boundary                                               |
+| `memory_resources`                                | `resource_id`, `agent_id`, store ID, stable logical locator, created time                                                                                   | Stable resource identity independent of revisions                                            |
+| `memory_resource_revisions`                       | `revision_id`, resource ID, revision number, content hash, lifecycle state, actor, time                                                                     | Immutable, addressable revisions; at most one is active per resource                         |
+| `memory_resource_subjects`                        | revision ID, subject kind and ID, evidence revision, current or superseded state                                                                            | Exact person, project, channel, and topic identity independent of audience                   |
+| `memory_scoped_chunks` plus FTS and vector tables | chunk ID, revision ID, text, embedding metadata                                                                                                             | Content-bearing index used only by the authorized backend                                    |
+| `memory_policies` and `memory_policy_revisions`   | policy ID, agent ID, revision ID, state, actor, reason                                                                                                      | Stable policies and immutable policy revisions                                               |
+| `memory_policy_entries`                           | policy revision, audience, effect, capability, grantor, expiry                                                                                              | Denies, placement authority, publisher authority, and exceptional allows                     |
+| `memory_revision_policy_requirements`             | resource revision, stable policy ID, captured source revision, expected active revision/revocation epoch, own/inherited relation                            | Materialized policy intersection for derivations without an unbounded lineage walk           |
+| `memory_lineage_edges`                            | child revision, parent revision or transcript event, relation                                                                                               | Derivation and revocation graph                                                              |
+| `memory_projections`                              | projection revision, source revision, target audience, purpose, expiry mode/time, revoked time                                                              | Explicit sharing lifecycle                                                                   |
+| `memory_postbox_items`                            | revision, source channel and event, target user store, review state, expiry                                                                                 | Deposit quarantine and review                                                                |
+| `session_memory_subjects`                         | session key, subject revision, subject and canonical conversation reference, creation evidence, created time                                                | Write-once subject on the logical `session_nodes` node                                       |
+| `session_memory_subject_snapshots`                | session ID, session key, subject revision, session-identity revision                                                                                        | Per-window audit snapshot; detects reset/rebind races                                        |
+| `transcript_event_memory_policies`                | session ID and event sequence, source-policy-set ID, finalized delivery/egress audience, actor, session-identity revision, exposure-set ID/revision         | Companion authorization labels for every transcript event                                    |
+| `memory_policy_sets`                              | policy-set ID, normalized audience intersection, member stable policy IDs, captured revisions, expected active revisions/revocation epochs, retention state | Immutable effective source-policy sets used by transcript and derivation labels              |
+| `memory_run_exposures`                            | exposure-set ID and revision, run, resource revision, policy revision, time                                                                                 | Exact scoped revisions exposed to one run; each addition invalidates older egress receipts   |
+| `memory_compaction_policies`                      | session ID, checkpoint/summary event, source-policy-set ID, output-policy-set ID                                                                            | Policy preservation through compaction and checkpoints                                       |
+| `memory_write_intents`                            | token, pending revision, staged/final locator hash, state                                                                                                   | Crash-recovery state machine; pending rows are never readable                                |
+| `memory_audit_outbox`                             | event ID, request, opaque audit payload, state                                                                                                              | Idempotent per-agent outbox committed with writes and drained to shared audit                |
+| `memory_migrations`                               | migration ID, source hash, phase, verification, cutover time                                                                                                | Idempotent migration and recovery state                                                      |
+
+Chunks, lineage, projections, policy requirements, and exposures always
+reference immutable `revision_id`, never a mutable "current revision" field.
+Every store and resource query also constrains `agent_id`; an ACL or locator
+cannot cross that hard cell boundary.
+
+Captured policy revisions preserve audit history; they are never permanent
+allow snapshots. On every read or derivation, the plugin resolves each stable
+`policy_id` against its current active revision and revocation epoch. A missing,
+revoked, or mismatched requirement denies the dependent revision or transcript
+set until an authorized recomputation records new expectations. A later deny
+therefore cannot be bypassed through a descendant that captured an older allow.
+
+Existing `memory_index_sources`, chunks, FTS, vectors, and provenance remain
+legacy search state for unmigrated personal mode only. Do not insert scoped
+content into those legacy tables: an older runtime knows how to query them but
+does not know how to apply audience policy. Enforced mode uses new additive
+scoped index tables keyed to immutable revision ID. After migration and cutover,
+doctor removes the agent's legacy index rows; a full scoped reindex rebuilds
+only from the resource catalog and never invents policy from content or
+filename text.
+
+Declare additive tables in the canonical schema and use a one-time idempotent
+lazy ensure. Use the repository's Kysely helpers for runtime reads and writes;
+reserve raw SQL for schema DDL, migrations, FTS/vector primitives, and narrowly
+justified low-level bootstrap. All transaction callbacks remain synchronous.
+
+SQLite cannot enforce foreign keys or atomic commits across the shared and per-
+agent databases. Core validates referenced principal and host-fact revisions
+before issuing the access context; the selected plugin revalidates them before
+exposure and commit. The local `memory_audit_outbox` commits with plugin state
+and drains idempotently to `memory_access_audit`; audit delivery is never part
+of the authorization decision. A missing or revoked shared identity fact fails
+closed.
+
+## Migration and compatibility
+
+### Enablement
+
+Do not add several public knobs at the start. Stage 0 uses an internal shadow
+gate. Before enforcement reaches users, justify one explicit mode surface that
+distinguishes the current personal layout from the canonical scoped layout.
+Postbox, projection, and enterprise membership policy can remain unavailable
+until their stages rather than accumulating permissive defaults.
+
+An agent enters enforced mode only after `openclaw doctor --fix` completes and
+records a verified cutover. Runtime does not inspect both layouts to guess
+which one to use.
+
+### Classification rules
+
+Migration assigns legacy content from trusted structural evidence, never from
+semantic analysis:
+
+1. If exactly one verified owner principal exists, the preview may recommend
+   assigning legacy `USER.md`, `MEMORY.md`, daily notes, and dreams to that
+   user's private store. The owner or admin confirms the assignment; the
+   migrator does not claim files for whichever sender happened to launch it.
+2. Only transcripts written after trusted audience labeling, or legacy
+   transcripts with a separately proven one-to-one binding plus explicit
+   owner/admin confirmation, may enter a matching user or channel store.
+   Session-key shape, route metadata, and a recorded sender alone are
+   insufficient; every other transcript-derived artifact enters quarantine.
+3. Files explicitly marked and confirmed by an admin may enter role or
+   agent-shared stores.
+4. Anything ambiguous enters a quarantine store that no ordinary session
+   mounts.
+
+Do not default legacy content to agent-shared. The old audience may have been
+one person even if the old agent technically exposed it broadly; enabling a
+team must not turn that technical possibility into intentional publication.
+
+### Migration transaction
+
+```mermaid
+flowchart LR
+  L[Legacy personal layout] --> SC[Scan and structural classification]
+  SC --> PV[Dry-run preview and owner decisions]
+  PV --> BK[Verified backup]
+  BK --> CP[Copy into opaque scoped stores]
+  CP --> MD[Commit catalog, policy, and lineage metadata]
+  MD --> RI[Rebuild scoped index]
+  RI --> VF[Verify hashes, mounts, bootstrap, and denial matrix]
+  VF --> CO[Atomic cutover marker]
+  CO --> EN[Enforced runtime]
+  SC -->|ambiguous| Q[Quarantine]
+```
+
+The process is idempotent and records every source hash and destination
+resource. It copies and verifies before removing or archiving legacy files.
+Rollback is supported before cutover, or before any new scoped writes after
+cutover. After new scoped data exists, downgrade is an explicit export that
+warns about lost audience metadata, not an automatic fallback.
+
+### Compatibility rules
+
+- Existing personal agents remain on the current layout until migrated.
+- A migrated agent never reads root legacy memory at runtime.
+- Scoped content and full-text chunks never enter legacy index tables, so an
+  older runtime cannot discover them after downgrade.
+- A nonconforming selected memory backend blocks enforced memory, not the
+  conversation and not startup for unrelated agents.
+- A shared `main` DM never gets a private mount. Doctor explains the necessary
+  `dmScope` or separate-agent choice.
+- Backups include the scoped backend roots, shared identity/audit tables, and
+  per-agent resource catalog consistently.
+- Restoring a backup validates catalog hashes and policy revisions before
+  making any store readable.
+
+## Staged implementation plan
+
+Stages are security boundaries, not calendar estimates. A stage is complete
+only when all listed read and write surfaces use the new invariant.
+
+### Stage 0: contracts and shadow decisions
+
+**Deliverables**
+
+- Define core-owned principals, session subjects, delivery facts, and the
+  branded access context; define plugin-owned operations, decisions, plans,
+  mounts, and the pure memory evaluator behind the SDK contract.
+- Add the versioned plugin SDK authorization contract and a reusable backend
+  conformance suite.
+- Add lazy additive tables and read-only decision tracing. Do not move content
+  or alter current results.
+- Build core-only context factories for authenticated Gateway calls, channel
+  ingress, autonomous runs, and delegation. Prove that plugin extras and tool
+  JSON cannot override them.
+- Inventory every memory ingress and egress path and fail the stage if any
+  context-free manager call remains unclassified.
+
+**Exit gates**
+
+- Property tests cover deny precedence, permission implication, view
+  intersection, expiry, revision, and lineage.
+- Shadow decisions can be compared with current reads without logging content.
+- Single-user behavior and latency stay unchanged.
+- No public isolation claim and no public configuration change.
+
+**Rollback:** stop shadow evaluation and ignore the additive tables.
+
+### Stage 1: private and channel read isolation
+
+**Deliverables**
+
+- Persist verified identity bindings and write-once logical-session subjects.
+- Create isolated personal, channel, agent-shared, agent, and quarantine stores
+  in the builtin plugin; require equivalent isolated namespaces from other
+  selected backends.
+- Have the selected plugin compute an `AuthorizedMemoryPlan` from current host
+  collaboration facts, identity revocation state, provider evidence, and
+  plugin policy.
+- Convert builtin search to scoped candidates plus authoritative postfilter.
+- Convert exact read, bootstrap, startup recent-memory context, trigger
+  injection, active recall, project bootstrap, Talk fast context, transcript
+  recall, supplements, status, and CLI.
+- Convert or block LanceDB raw tools and prompt hooks, memory prompt/corpus
+  registries, QMD extra collections and session artifacts, memory wiki, and
+  every other context-free prompt or public-artifact read.
+- Extend filesystem policy and sandbox mounts so model-facing tools see only
+  the virtual view. Hide or deny `exec` and file tools that cannot honor it.
+- Merge every exposure receipt into the run exposure set and recheck it for
+  every registered egress capability and any route, sink, registry, or
+  exposure revision change. Deny every unclassified side-effect tool.
+- Make backend nonconformance and stale identity fail closed for memory.
+- Keep enforced agents read-only for durable memory until each write path passes
+  the Stage 2 scoped lifecycle. Deny legacy store/forget/auto-capture,
+  remember, sync, human-watcher ingestion, and generic file mutation; no
+  context-free write remains enabled merely because transcript labels exist.
+- Before exposing any scoped resource, persist the turn's effective source-
+  policy set, exposed resource revisions, delivery audience, session-identity
+  revision, and run exposure-set ID/revision on transcript output; preserve
+  that policy through compaction and checkpoints. If this minimum path is unavailable,
+  disable transcript recall, compaction, memory flush, dreaming, and all
+  durable derived writes for the enforced agent until Stage 2.
+- Exclude unlabeled legacy transcript events from enforced recall unless the
+  migration rules prove and confirm their audience; quarantine every ambiguous
+  transcript-derived artifact.
+
+**Exit gates**
+
+- Two verified users cannot observe each other's private paths, snippets,
+  counts, scores, citations, or timing-dependent result shape through any read
+  lane.
+- A group can read its channel store but cannot read a participant's personal
+  or role store.
+- A shared-DM session refuses a private mount.
+- Profile-less owner compatibility never opens private memory, and incognito
+  sessions obey the conservative no-durable-write rule.
+- No ordinary, derived, watcher, plugin, sync, import, or generic-file path can
+  create or change durable memory before Stage 2 authorizes it.
+- Symlink, traversal, stale-handle, and raw-host-path tests pass.
+- Disabled or failed memory plugins do not re-enable legacy bootstrap or files.
+- Every assistant, tool-result, summary, and checkpoint event produced after a
+  scoped exposure carries an evaluable source-policy-set label.
+
+**Rollback:** enforcement remains opt-in; unmigrated personal agents stay on
+the legacy path. Migrated agents require the migration rollback rules above.
+
+### Stage 2: scoped writes and derived lifecycle
+
+**Deliverables**
+
+- Route model-facing memory file writes, explicit remember operations, human
+  edits, delete, import, public-artifact publication, and sync through the
+  selected plugin's authorized lifecycle.
+- Scope memory flush by session subject and extend provenance with resource and
+  source-event revisions.
+- Run dreaming and profile promotion one store at a time.
+- Complete transcript-event labels, exposure lineage, compaction policy sets,
+  audit outbox draining, retention, and repair beyond the Stage 1 minimum.
+- Enforce audience intersection for compaction, summaries, session export,
+  recall artifacts, and every other derivation.
+- Apply per-hop capability intersection to child agents, completion handoff,
+  cron, heartbeat, and webhook flows.
+- Add tombstone, descendant invalidation, retention, and repair jobs.
+
+**Exit gates**
+
+- No unlabeled durable write is readable outside quarantine.
+- Group flush and compaction stay channel-scoped; private flush stays
+  user-scoped.
+- Mixed-audience compaction partitions or refuses output instead of widening.
+- A child cannot widen its parent's view or regain revoked access through a
+  stored session key.
+- Crash-recovery tests cover every file/SQLite interruption boundary.
+
+**Rollback:** disable new derivations, preserve scoped data, and require an
+explicit export for legacy operation. Never dual-write.
+
+### Stage 3: explicit sharing and postbox
+
+**Deliverables**
+
+- Add agent-shared and role publisher workflows with preview and audit.
+- Add projections with one named audience, purpose, source revision, an
+  explicit expiry or audited `no_expiry` choice, refresh, and revocation impact
+  analysis.
+- Add postbox in `off` and review-required modes with source-message handles,
+  first-source owner notifications, rate limits, owner review, provenance
+  labels, and bulk purge.
+- Add owner/admin UI and CLI for store inspection, projection review,
+  postbox review, and safe deletion.
+
+**Exit gates**
+
+- Projection tests prove the target cannot read the private source and receives
+  only the reviewed copy.
+- Revoking or expiring a projection removes it from all new reads and lists
+  affected prior exposures.
+- A group can deposit but cannot list or read back a postbox item.
+- The first accepted deposit from a new source channel notifies the owner once;
+  over-cap deposits are dropped and audited.
+- Postbox content never auto-promotes or auto-injects.
+- No direct user-to-user private-store allow can be created through API, CLI,
+  UI, plugin, or raw tool arguments.
+
+**Rollback:** disable new deposits, projections, and publisher workflows; deny
+or tombstone existing projection reads and keep postbox items quarantined for
+review or purge. Preserve lineage and audit, and never replace a projection
+with direct access to its private source.
+
+### Stage 4: enterprise identity and operations
+
+**Deliverables**
+
+- Add allowlisted Entra ID, Google Workspace, and Okta verification adapters
+  as plugins using the generic core verification contract.
+- Refuse duplicate provider or issuer authorities and seal the allowlisted
+  adapter registry before the first session routes.
+- Add revisioned role and group membership snapshots with bounded staleness,
+  refresh, removal, and fail-closed behavior.
+- Integrate provider channel membership with existing session collaboration
+  policy instead of a parallel `channel_member` authority.
+- Add audit query, retention, export, access explanation, policy drift alerts,
+  revocation impact, and periodic access review.
+- Load-test hundreds of principals, stores, roles, and channels; benchmark QMD
+  or other backend collection fan-out.
+
+**Exit gates**
+
+- Forged, wrong-issuer, wrong-audience, expired, revoked, and unbound identities
+  fail before a private store opens.
+- An unlisted or duplicate adapter cannot register, and a late plugin cannot
+  replace a sealed identity authority.
+- Role removal denies new reads inside the documented staleness bound.
+- Provider outage removes role access when the bound expires; it never extends
+  membership indefinitely.
+- Operators can answer who exposed or changed a resource without reading audit
+  log content.
+
+**Rollback:** disable the enterprise adapters and let their evidence expire,
+which removes affected role and channel mounts. Local verified user and channel
+stores continue under Stage 2 rules; no stale provider role becomes a local
+allow.
+
+### Stage 5: adversarial isolation
+
+**Deliverables**
+
+- Move the broker and content-bearing index behind authenticated local IPC in a
+  separately permissioned process, or deploy separate Gateway cells.
+- Run agent processes in per-session sandboxes with only authorized virtual
+  mounts. The agent never receives the broker database handle or real artifact
+  root.
+- Bind IPC requests to the Gateway-issued session subject and capability
+  snapshot; reject client-supplied principals.
+- Add OS permission, compromised non-broker agent/tool plugin, IPC replay,
+  confused deputy, and denial-of-service tests. The selected memory plugin,
+  broker backend, Gateway, and operator remain in the trusted computing base.
+
+A "compromised plugin" test at this stage means model-facing plugin or tool
+code running inside the constrained agent process. A malicious Gateway-hosted
+in-process plugin can use Gateway authority and remains trusted at this level.
+Protecting against that plugin requires moving it behind a process boundary
+whose broker credentials are unavailable to the Gateway plugin host, or using
+separate Gateway cells.
+
+**Exit gates**
+
+- A compromised agent process cannot open a store outside its issued view.
+- IPC replay under another session, actor, agent, or policy revision fails.
+- Documentation may claim only the exact tested boundary, for example that
+  compromise of a non-broker agent process cannot cross its issued view. It
+  must name the trusted Gateway, broker backend, selected memory plugin, and
+  operator. Separate Gateway cells satisfy this stage only when each mutually
+  untrusted audience receives its own process, credential, and storage cell;
+  hostile tenants still require those separate cells.
+
+**Rollback:** explicitly withdraw the process-adversarial claim. Either return
+to Stage 2 cooperative isolation under its trusted-Gateway assumptions after a
+verified broker export/cutover, or move each trust domain to a separate cell.
+Never replace a failed broker with unscoped filesystem or database access.
+
+```mermaid
+flowchart LR
+  S0[Stage 0: contracts and shadow] --> S1[Stage 1: scoped reads]
+  S1 --> S2[Stage 2: writes and derivations]
+  S2 --> S3[Stage 3: projections and postbox]
+  S2 --> S4[Stage 4: enterprise operations]
+  S2 --> S5[Stage 5: process isolation]
+  S3 -. optional enterprise sharing integration .-> S4
+  S3 -. deferred .-> DG[Direct cross-user grants]
+  S5 -. future RFC .-> FD[Cross-instance federation]
+```
+
+## Verification strategy
+
+### Policy and identity tests
+
+- Property-generate principals, stores, ACL rows, operations, expiry, denies,
+  lineage, and membership revisions. Compare the SQL prefilter with the pure
+  evaluator and assert the candidate-superset invariant.
+- Prove display names, usernames, email aliases, raw sender fields,
+  `identityLinks`, `InputProvenance`, transcript JSON, plugin context extras,
+  and model tool arguments cannot change a principal or memory view.
+- Exercise user, conversation, service, agent, system, ambiguous DM, profile-
+  less owner compatibility, incognito, reset successor, fork, steering, and
+  reused-session-key matrices.
+- Exercise existing session roles and modes: admin, owner, member, viewer by
+  shared, read-only, suggest, and draft, including revoke-between-check-and-
+  commit races.
+
+### Read non-leakage tests
+
+- Search a mixed batch of allowed and denied nearest neighbors. Assert denied
+  rows affect neither rendered result count, rank, pagination, citations, nor
+  continuation handles.
+- Test bootstrap, recent-note startup context, memory tools, active recall,
+  trigger injection, wiki supplements, transcript recall, status, CLI, and
+  every registered memory plugin.
+- Test path traversal, case normalization, Unicode, symlinks, hard links where
+  relevant, deleted files, replaced hashes, stale handles, and virtual-to-host
+  path confusion.
+- Leave a catalog revision with a missing artifact, mismatched hash, or orphaned
+  index chunks. Assert reads fail unavailable and never return the indexed text
+  as fallback content.
+- Run the same tests with the memory plugin disabled, crashed, slow, and
+  nonconforming.
+- Run sqlite-vec KNN, vector-scan fallback, FTS/LIKE, and exact-path branches
+  with enough denied nearest neighbors to crowd out an allowed top-K result.
+- Change a reply route or run exposure revision after recall and attempt
+  message-tool, session-send, `exec` network/process, browser/HTTP, node,
+  webhook, upload/export, plugin, MCP, fanout, and final-reply egress outside
+  the run exposure set. Verify an unregistered side-effect tool is denied.
+
+### Write and derivation tests
+
+- Verify default targets for private, channel, agent, ambiguous, and delegated
+  sessions. Reject a model-supplied store or owner.
+- Verify generic file writes, LanceDB store/forget and auto-capture, imports,
+  public artifacts, deletes, and sync cannot bypass resource revision, policy,
+  provenance, or audit.
+- Tombstone a revision and verify exact read, sqlite-vec KNN, vector-scan,
+  FTS/LIKE, export, and derivation all deny it before physical cleanup finishes.
+- Compact mixed private, channel, agent-shared, projected, tool-derived, and recalled
+  content. Assert output policy is the intersection and survives checkpoint,
+  reset, branch, rewind, archive, and export.
+- Revoke and tombstone ancestors; verify descendants disappear until reviewed
+  or re-derived.
+- Interrupt every step between staged write, pending-intent commit, rename,
+  activation commit, index update, local audit outbox, and shared-audit drain;
+  verify repair never exposes a pending or ambiguous file.
+
+### Sharing and membership tests
+
+- Project one reviewed revision to one channel. Verify another channel, a newly
+  joined channel, and another user cannot access it.
+- Leave, rejoin, remove a role, expire a snapshot, revoke a binding, and revoke
+  a projection during active and idle sessions.
+- Deposit from a group using a valid source-message handle; try forged,
+  cross-channel, stale, and another-member handles. Verify write-only behavior.
+- Verify the first accepted deposit from a new source channel notifies the
+  owner once, and over-cap deposits are dropped and audited without exposing a
+  target-store detail to the channel.
+- Confirm agent-shared and role writes require publisher authority independently of
+  read authority.
+
+### End-to-end proof
+
+Use at least this scenario before enabling a pilot:
+
+1. Alice and Bob each establish verified private DMs with one agent.
+2. Each stores a distinct private fact with the same noun and a deliberately
+   colliding display name.
+3. Both join one group and add a channel fact.
+4. Private recall returns only the current user's fact; group recall returns
+   only the channel fact and explicit channel projections.
+5. A child agent, compaction, memory flush, and dreaming run in every context.
+6. Bob leaves the group, Alice revokes a projection, and an identity binding is
+   revoked. New reads deny immediately or within the documented membership
+   bound.
+7. Audit shows authorized exposures and decisions without storing the facts.
+
+Adjacent focused test owners include:
+
+- `src/channels/turn/kernel.test.ts`
+- `src/gateway/session-sharing.test.ts`
+- `src/config/sessions/session-accessor.conformance.test.ts`
+- `src/agents/requester-tool-policy.test.ts`
+- `src/auto-reply/reply/startup-context.test.ts`
+- `src/auto-reply/reply/agent-runner-memory.test.ts`
+- `extensions/memory-core/src/tools.test.ts`
+- `extensions/memory-core/src/session-search-visibility.test.ts`
+- `extensions/memory-core/src/memory/manager-search.test.ts`
+- `extensions/memory-core/src/flush-plan.test.ts`
+- `extensions/memory-core/src/dreaming-phases.test.ts`
+- `src/gateway/session-compaction-checkpoints.test.ts`
+- `src/agents/agent-hooks/compaction-safeguard.test.ts`
+
+## Observability and operations
+
+Expose safe operational metrics:
+
+- decisions by operation and stable reason code;
+- postfilter denials after prefilter success;
+- backend conformance and capability failures;
+- policy and membership snapshot age;
+- exposed resource count and bytes by scope kind;
+- quarantined migration and postbox counts;
+- projection expiry, revocation impact, and scrub backlog;
+- search and policy latency without query or principal labels;
+- repair jobs and hash mismatches.
+
+Admin explanation should answer "why was this allowed or denied?" with policy
+revision, subject kind, store kind, collaboration role, membership evidence,
+and matching rule. It must not reveal the title or existence of a resource the
+admin is not authorized to inspect under the deployment's own admin model.
+
+Retention applies independently to memory content, transcripts, postbox,
+projection copies, lineage, and audit. Expiry is enforced on reads even if
+cleanup is late. Physical cleanup follows a grace period and verified backup
+policy; logical denial does not wait for deletion.
+
+## Existing solutions preflight
+
+No existing OpenClaw feature provides this entire boundary:
+
+| Existing option                          | What it already solves                                                          | Why it is not the complete design                                                                                                                                                                                                         |
+| ---------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Separate agents or Gateway cells         | Strongest current separation of sessions, files, tools, credentials, and memory | Operationally heavier, but remains the correct option for mutually untrusted people and hostile tenants                                                                                                                                   |
+| `session.dmScope`                        | Separates DM conversation routing                                               | All sessions of an agent can still use the same memory files and index                                                                                                                                                                    |
+| Session sharing policy                   | Human session visibility and mutation roles                                     | Does not label or authorize memory resources; should be reused as one input                                                                                                                                                               |
+| Ingress access groups                    | Static and provider-backed admission checks                                     | They are allowlist expansion, not durable identity, audience, lineage, or memory policy                                                                                                                                                   |
+| `memory-core` and QMD                    | Markdown memory, indexing, provenance, and transcript visibility filters        | They need the versioned scoped backend contract and complete read/write lifecycle                                                                                                                                                         |
+| Honcho, LanceDB, and memory wiki plugins | Alternative recall or supplemental knowledge                                    | A selected or supplemental plugin cannot define the Gateway-wide identity and filesystem boundary                                                                                                                                         |
+| PostgreSQL RLS or vector namespaces      | Mature data-layer row or collection isolation                                   | Useful backend techniques, but they do not solve OpenClaw session identity, bootstrap files, tool mounts, compaction, dreaming, or delegation by themselves                                                                               |
+| Cedar or Zanzibar-style policy engines   | General policy evaluation models                                                | They do not provide identity proof, physical storage authority, lineage, or sandboxing. A small typed evaluator inside the selected builtin plugin fits the first local SQLite implementation; keep its inputs and traces engine-neutral. |
+
+The custom work is justified by the integration boundary, not by a need to
+invent another vector store or IAM language. Reuse current storage, session,
+identity, and sandbox seams wherever they already own the invariant.
+
+## Open decisions
+
+These choices require owner agreement before their implementation stage:
+
+1. **Enablement surface:** one durable config key versus a CLI-managed policy
+   state. Avoid a temporary matrix of public flags.
+2. **Local binding flow:** how a channel sender proves ownership of a Gateway
+   profile, and how account merges and recovery are approved and audited.
+3. **Shared publishing:** which local roles may receive the explicit publisher
+   capability for agent-shared or role memory, and whether every update
+   requires review.
+4. **Projection experience:** item selection, preview, refresh, expiry, and
+   revocation residuals without encouraging broad "share everywhere" actions.
+5. **Membership bound:** provider-specific freshness guarantees and behavior
+   during an outage.
+6. **Postbox posture:** whether any non-enterprise deployment should support
+   labeled automatic use without explicit review.
+7. **Backend scaling:** collection and mount fan-out at hundreds or thousands
+   of stores, especially for QMD and remote memory plugins.
+8. **Artifact location and backup:** the exact controlled state path, ownership
+   permissions, cross-platform virtual mount, and consistent backup boundary.
+9. **Audit retention:** defaults, export permissions, and compliance deletion
+   behavior.
+10. **Process boundary:** whether Stage 5 uses a Gateway-hosted broker with
+    child agents, a separate broker service, or separate Gateway cells only.
+11. **Incognito durability:** whether any future incognito mode may opt into a
+    private durable store; until that decision, enforced mode uses the
+    conservative no-durable-write rule above.
+
+## Completion criteria
+
+Multiplayer memory is complete only when all of these statements are true:
+
+- Every durable memory resource has one structural store, audience, revision,
+  trust provenance, and lifecycle state.
+- Every session has a trusted, write-once memory subject or an explicit
+  ambiguous/service state.
+- Every read and write lane requires a core-issued context and current memory
+  view.
+- Every selected or supplemental backend passes the same authorization
+  conformance suite or is unavailable in enforced mode.
+- Bootstrap, exact read, search, automatic recall, files, transcripts,
+  compaction, dreaming, delegation, and sync have no unscoped fallback.
+- Existing session collaboration and provider membership decisions are
+  consumed once at their owner boundaries and rechecked before mutation.
+- Migration is explicit, idempotent, verified, and single-path at runtime.
+- Documentation states the tested isolation level and keeps separate-agent or
+  separate-Gateway guidance for stronger trust boundaries.
+
+## Related
+
+- [Memory overview](/concepts/memory)
+- [Memory architecture](/concepts/memory-architecture)
+- [Multi-user mode](/concepts/multi-user)
+- [The main session](/concepts/main-session)
+- [Session management](/concepts/session)
+- [Compaction](/concepts/compaction)
+- [Context engine](/concepts/context-engine)
+- [Access groups](/channels/access-groups)
+- [Sandboxing](/gateway/sandboxing)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1257,6 +1257,7 @@
                     "pages": [
                       "concepts/memory",
                       "concepts/memory-architecture",
+                      "concepts/memory-multiplayer",
                       "concepts/user-model",
                       "concepts/standing-intents",
                       "concepts/memory-builtin",

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -374,7 +374,6 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
   <Accordion title="Memory subpaths">
     | Subpath | Key exports |
     | --- | --- |
-    | `plugin-sdk/memory-authorization` | Versioned serializable memory-authorization contracts, selected-capability declarations, and pure conformance helpers. This contract alone does not enable isolation, capability admission, or an authorization mode. |
     | `plugin-sdk/memory-core-host-embedding-registry` | Private-local after July 2026; Lightweight memory embedding provider registry helpers |
     | `plugin-sdk/memory-core-host-engine-curated` | Private-local focused curated-memory annotation parsing for doctor and promotion paths |
     | `plugin-sdk/memory-core-host-engine-foundation` | Memory host foundation engine exports |

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -374,6 +374,7 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
   <Accordion title="Memory subpaths">
     | Subpath | Key exports |
     | --- | --- |
+    | `plugin-sdk/memory-authorization` | Versioned serializable memory-authorization contracts, selected-capability declarations, and pure conformance helpers. This contract alone does not enable isolation, capability admission, or an authorization mode. |
     | `plugin-sdk/memory-core-host-embedding-registry` | Private-local after July 2026; Lightweight memory embedding provider registry helpers |
     | `plugin-sdk/memory-core-host-engine-curated` | Private-local focused curated-memory annotation parsing for doctor and promotion paths |
     | `plugin-sdk/memory-core-host-engine-foundation` | Memory host foundation engine exports |


### PR DESCRIPTION
## What Problem This Solves

OpenClaw has no single source of truth for how a shared agent could keep private, channel, role, shared, projection, and quarantine memory separate. Operators and plugin authors need an explicit design that distinguishes planning from shipped isolation behavior.

## Why This Change Was Made

This adds the canonical multiplayer-memory design and its phased implementation plan. The design preserves the current single-user behavior until an explicit migration, names the core/plugin boundary, and keeps Phase 0 explicitly shadow-only. It reserves the planned authorization contract; the child SDK PR supplies the importable SDK surface.

## User Impact

Operators and plugin authors can now find the proposed memory-isolation model, its constraints, and the staged path toward it. No runtime behavior, configuration, or isolation claim changes in this PR.

## Evidence

- `pnpm docs:list`
- `tsx scripts/format-docs.mts --check` — 756 docs files clean
- `node scripts/check-docs-mdx.mjs docs/concepts/memory-multiplayer.md docs/concepts/2026-07-29-memory-impl-plan.md docs/docs.json` — passed (2 files)
- `node --import tsx scripts/check-docs-i18n-glossary.mts` — passed
- `node scripts/docs-link-audit.mjs` — 6,420 internal links checked; 0 broken
- `git diff --check origin/main...HEAD`
