### PR TITLE
fix(telegram): preserve context for animated and video stickers

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-media.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-media.ts
@@ -111,6 +111,7 @@ export function createTelegramInboundMedia({
   const {
     resolveMediaRuntime,
     recordMessageResolvedMedia,
+    recordMessageMediaUnavailableReason,
     promptContextBoundaryOptions,
     latestPromptContextMinTimestampMs,
     latestPromptContextAmbientWatermark,
@@ -362,6 +363,12 @@ export function createTelegramInboundMedia({
         if (media) {
           if (media.path) {
             await recordMessageResolvedMedia({ msg, media, botUserId: ctx.me?.id });
+          } else if (media.unavailableReason) {
+            await recordMessageMediaUnavailableReason({
+              msg,
+              reason: media.unavailableReason,
+              botUserId: ctx.me?.id,
+            });
           }
           allMedia.push({
             ...(media.path ? { path: media.path } : {}),

--- a/extensions/telegram/src/bot-handlers.inbound-media.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-media.ts
@@ -360,16 +360,24 @@ export function createTelegramInboundMedia({
           continue;
         }
         if (media) {
-          await recordMessageResolvedMedia({ msg, media, botUserId: ctx.me?.id });
+          if (media.path) {
+            await recordMessageResolvedMedia({ msg, media, botUserId: ctx.me?.id });
+          }
           allMedia.push({
-            path: media.path,
+            ...(media.path ? { path: media.path } : {}),
             contentType: media.contentType,
             kind: media.kind,
             stickerMetadata: media.stickerMetadata,
+            unavailableReason: media.unavailableReason,
             sourceMessageId,
           });
-          materializedCount++;
-          selection.set(sourceMessageId, "include");
+          if (media.path) {
+            materializedCount++;
+            selection.set(sourceMessageId, "include");
+          } else {
+            skippedCount++;
+            selection.set(sourceMessageId, "exclude");
+          }
         } else {
           allMedia.push({ kind: nativeKind, sourceMessageId });
           selection.set(sourceMessageId, "exclude");

--- a/extensions/telegram/src/bot-handlers.inbound-processing.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-processing.ts
@@ -316,7 +316,7 @@ export function createTelegramInboundProcessing({
       ? [
           media
             ? {
-                path: media.path,
+                ...(media.path ? { path: media.path } : {}),
                 contentType: media.contentType,
                 kind: media.kind,
                 stickerMetadata: media.stickerMetadata,

--- a/extensions/telegram/src/bot-handlers.inbound-processing.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-processing.ts
@@ -320,6 +320,8 @@ export function createTelegramInboundProcessing({
                 contentType: media.contentType,
                 kind: media.kind,
                 stickerMetadata: media.stickerMetadata,
+                unavailableReason: media.unavailableReason,
+                sourceMessageId: String(msg.message_id),
               }
             : { kind: nativeMedia.kind },
         ]

--- a/extensions/telegram/src/bot-handlers.inbound-processing.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-processing.ts
@@ -93,6 +93,7 @@ export function createTelegramInboundProcessing({
   const {
     resolveMediaRuntime,
     recordMessageResolvedMedia,
+    recordMessageMediaUnavailableReason,
     promptContextBoundaryOptions,
     releaseDispatchDedupeClaims,
     createSpooledReplayParticipantForBufferedWork,
@@ -253,8 +254,14 @@ export function createTelegramInboundProcessing({
         releaseDispatchDedupeClaims(dispatchDedupeClaims, abortError);
         return { kind: "ignored" };
       }
-      if (media) {
+      if (media?.path) {
         await recordMessageResolvedMedia({ msg, media, botUserId: ctx.me?.id });
+      } else if (media?.unavailableReason) {
+        await recordMessageMediaUnavailableReason({
+          msg,
+          reason: media.unavailableReason,
+          botUserId: ctx.me?.id,
+        });
       }
     } catch (mediaErr) {
       const replayingSpooledUpdate = isTelegramSpooledReplayUpdate(ctx.update);

--- a/extensions/telegram/src/bot-handlers.message-context.ts
+++ b/extensions/telegram/src/bot-handlers.message-context.ts
@@ -344,6 +344,19 @@ export function createTelegramMessageContextRuntime({
       ...(params.botUserId !== undefined ? { botUserId: params.botUserId } : {}),
     });
 
+  const recordMessageMediaUnavailableReason = (params: {
+    msg: Message;
+    reason: NonNullable<TelegramMediaRef["unavailableReason"]>;
+    botUserId?: number;
+  }) =>
+    messageCache.recordMediaUnavailableReason({
+      accountId,
+      chatId: params.msg.chat.id,
+      messageId: String(params.msg.message_id),
+      reason: params.reason,
+      ...(params.botUserId !== undefined ? { botUserId: params.botUserId } : {}),
+    });
+
   const recordReplyMessageResolvedMedia = async (params: {
     chatId: string | number;
     messageId: string;
@@ -366,6 +379,17 @@ export function createTelegramMessageContextRuntime({
       ...(params.botUserId !== undefined ? { botUserId: params.botUserId } : {}),
     });
   };
+
+  const recordReplyMessageMediaUnavailableReason = (params: {
+    chatId: string | number;
+    messageId: string;
+    reason: NonNullable<TelegramMediaRef["unavailableReason"]>;
+    botUserId?: number;
+  }) =>
+    messageCache.recordMediaUnavailableReason({
+      accountId,
+      ...params,
+    });
 
   // `MessageReactionUpdated` carries no `message_thread_id`, so the reaction handler
   // recovers the originating topic from the same bounded cache that records inbound
@@ -399,16 +423,17 @@ export function createTelegramMessageContextRuntime({
       ...entry
     } = node;
     const projectedEntry = { ...entry, sender: resolvePromptSender(node, ctx) };
-    if (!media?.path && !media?.unavailableReason) {
+    const unavailableReason = media?.unavailableReason ?? node.mediaUnavailableReason;
+    if (!media?.path && !unavailableReason) {
       return projectedEntry;
     }
     const { mediaRef: _mediaRef, ...entryWithoutProviderMediaRef } = projectedEntry;
     return {
       ...entryWithoutProviderMediaRef,
-      ...(media.path ? { mediaPath: media.path } : {}),
-      mediaKind: media.kind,
-      ...(media.contentType ? { mediaType: media.contentType } : {}),
-      ...(media.unavailableReason ? { mediaUnavailableReason: media.unavailableReason } : {}),
+      ...(media?.path ? { mediaPath: media.path } : {}),
+      mediaKind: media?.kind ?? "sticker",
+      ...(media?.contentType ? { mediaType: media.contentType } : {}),
+      ...(unavailableReason ? { mediaUnavailableReason: unavailableReason } : {}),
     };
   };
 
@@ -418,8 +443,9 @@ export function createTelegramMessageContextRuntime({
     flags?: { replyTarget?: boolean },
     media?: TelegramMediaRef,
   ) => {
-    const unavailableNotice = media?.unavailableReason
-      ? formatTelegramUnavailableStickerNotice(media.unavailableReason)
+    const unavailableReason = media?.unavailableReason ?? node.mediaUnavailableReason;
+    const unavailableNotice = unavailableReason
+      ? formatTelegramUnavailableStickerNotice(unavailableReason)
       : undefined;
     const body = [node.body, unavailableNotice].filter(Boolean).join("\n");
     return {
@@ -430,9 +456,10 @@ export function createTelegramMessageContextRuntime({
       sender_username: node.senderUsername,
       timestamp_ms: node.timestamp,
       body: body || undefined,
-      media_type: media?.contentType ?? media?.kind ?? node.mediaType,
+      media_type:
+        media?.contentType ?? media?.kind ?? (unavailableReason ? "sticker" : node.mediaType),
       media_path: media?.path,
-      media_ref: media?.path || media?.unavailableReason ? undefined : node.mediaRef,
+      media_ref: media?.path || unavailableReason ? undefined : node.mediaRef,
       reply_to_id: node.replyToId,
       is_reply_target: flags?.replyTarget === true ? true : undefined,
     };
@@ -555,7 +582,9 @@ export function createTelegramMessageContextRuntime({
   return {
     recordMessageForReplyChain,
     recordMessageResolvedMedia,
+    recordMessageMediaUnavailableReason,
     recordReplyMessageResolvedMedia,
+    recordReplyMessageMediaUnavailableReason,
     resolveCachedMessageThreadSpec,
     buildReplyChainForMessage,
     toReplyChainEntry,

--- a/extensions/telegram/src/bot-handlers.message-context.ts
+++ b/extensions/telegram/src/bot-handlers.message-context.ts
@@ -19,6 +19,7 @@ import type {
   TelegramMessageContextOptions,
   TelegramPromptContextEntry,
 } from "./bot-message-context.types.js";
+import { formatTelegramUnavailableStickerNotice } from "./bot-message-context.body.js";
 import {
   buildSenderName,
   getTelegramTextParts,
@@ -398,15 +399,16 @@ export function createTelegramMessageContextRuntime({
       ...entry
     } = node;
     const projectedEntry = { ...entry, sender: resolvePromptSender(node, ctx) };
-    if (!media?.path) {
+    if (!media?.path && !media?.unavailableReason) {
       return projectedEntry;
     }
     const { mediaRef: _mediaRef, ...entryWithoutProviderMediaRef } = projectedEntry;
     return {
       ...entryWithoutProviderMediaRef,
-      mediaPath: media.path,
+      ...(media.path ? { mediaPath: media.path } : {}),
       mediaKind: media.kind,
       ...(media.contentType ? { mediaType: media.contentType } : {}),
+      ...(media.unavailableReason ? { mediaUnavailableReason: media.unavailableReason } : {}),
     };
   };
 
@@ -415,20 +417,26 @@ export function createTelegramMessageContextRuntime({
     ctx: TelegramContext,
     flags?: { replyTarget?: boolean },
     media?: TelegramMediaRef,
-  ) => ({
-    message_id: node.messageId,
-    thread_id: node.threadId,
-    sender: resolvePromptSender(node, ctx),
-    sender_id: node.senderId,
-    sender_username: node.senderUsername,
-    timestamp_ms: node.timestamp,
-    body: node.body,
-    media_type: media?.contentType ?? media?.kind ?? node.mediaType,
-    media_path: media?.path,
-    media_ref: media?.path ? undefined : node.mediaRef,
-    reply_to_id: node.replyToId,
-    is_reply_target: flags?.replyTarget === true ? true : undefined,
-  });
+  ) => {
+    const unavailableNotice = media?.unavailableReason
+      ? formatTelegramUnavailableStickerNotice(media.unavailableReason)
+      : undefined;
+    const body = [node.body, unavailableNotice].filter(Boolean).join("\n");
+    return {
+      message_id: node.messageId,
+      thread_id: node.threadId,
+      sender: resolvePromptSender(node, ctx),
+      sender_id: node.senderId,
+      sender_username: node.senderUsername,
+      timestamp_ms: node.timestamp,
+      body: body || undefined,
+      media_type: media?.contentType ?? media?.kind ?? node.mediaType,
+      media_path: media?.path,
+      media_ref: media?.path || media?.unavailableReason ? undefined : node.mediaRef,
+      reply_to_id: node.replyToId,
+      is_reply_target: flags?.replyTarget === true ? true : undefined,
+    };
+  };
 
   const buildPromptContextForMessage = async (
     ctx: TelegramContext,

--- a/extensions/telegram/src/bot-handlers.message-context.ts
+++ b/extensions/telegram/src/bot-handlers.message-context.ts
@@ -13,13 +13,13 @@ import { asFiniteNumber } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
 import { resolveDefaultModelForAgent } from "./bot-handlers.agent.runtime.js";
 import type { RegisterTelegramHandlerParams } from "./bot-handlers.types.js";
+import { formatTelegramUnavailableStickerNotice } from "./bot-message-context.body.js";
 import type { TelegramMediaRef } from "./bot-message-context.js";
 import type {
   TelegramAmbientTranscriptWatermark,
   TelegramMessageContextOptions,
   TelegramPromptContextEntry,
 } from "./bot-message-context.types.js";
-import { formatTelegramUnavailableStickerNotice } from "./bot-message-context.body.js";
 import {
   buildSenderName,
   getTelegramTextParts,

--- a/extensions/telegram/src/bot-handlers.message-pipeline.ts
+++ b/extensions/telegram/src/bot-handlers.message-pipeline.ts
@@ -335,17 +335,20 @@ export function createTelegramMessagePipeline({
             });
             if (media) {
               mediaRef = {
-                path: media.path,
+                ...(media.path ? { path: media.path } : {}),
                 kind: media.kind,
                 ...(media.contentType ? { contentType: media.contentType } : {}),
                 ...(media.stickerMetadata ? { stickerMetadata: media.stickerMetadata } : {}),
+                ...(media.unavailableReason ? { unavailableReason: media.unavailableReason } : {}),
               };
-              await recordReplyMessageResolvedMedia({
-                chatId: ctx.message.chat.id,
-                messageId: node.messageId,
-                media,
-                botUserId: ctx.me?.id,
-              });
+              if (media.path) {
+                await recordReplyMessageResolvedMedia({
+                  chatId: ctx.message.chat.id,
+                  messageId: node.messageId,
+                  media,
+                  botUserId: ctx.me?.id,
+                });
+              }
             }
           }
         } catch (err) {

--- a/extensions/telegram/src/bot-handlers.message-pipeline.ts
+++ b/extensions/telegram/src/bot-handlers.message-pipeline.ts
@@ -124,6 +124,11 @@ export interface TelegramMessagePipeline {
     media: TelegramResolvedMedia;
     botUserId?: number;
   }) => Promise<void>;
+  recordMessageMediaUnavailableReason: (params: {
+    msg: Message;
+    reason: NonNullable<TelegramMediaRef["unavailableReason"]>;
+    botUserId?: number;
+  }) => Promise<void>;
   resolveCachedMessageThreadSpec: (params: {
     chatId: number | string;
     messageId: number | string;

--- a/extensions/telegram/src/bot-handlers.message-pipeline.ts
+++ b/extensions/telegram/src/bot-handlers.message-pipeline.ts
@@ -203,7 +203,9 @@ export function createTelegramMessagePipeline({
   const {
     recordMessageForReplyChain,
     recordMessageResolvedMedia,
+    recordMessageMediaUnavailableReason,
     recordReplyMessageResolvedMedia,
+    recordReplyMessageMediaUnavailableReason,
     resolveCachedMessageThreadSpec,
     buildReplyChainForMessage,
     toReplyChainEntry,
@@ -309,9 +311,15 @@ export function createTelegramMessagePipeline({
     const replyMedia: TelegramMediaRef[] = [];
     const replyChain: TelegramReplyChainEntry[] = [];
     for (const [index, node] of chain.entries()) {
-      let mediaRef: TelegramMediaRef | undefined;
+      let mediaRef: TelegramMediaRef | undefined = node.mediaUnavailableReason
+        ? {
+            kind: "sticker",
+            unavailableReason: node.mediaUnavailableReason,
+          }
+        : undefined;
       const replyFileId = resolveInboundMediaFileId(node.sourceMessage);
       if (
+        !mediaRef &&
         replyFileId &&
         hasInboundMedia(node.sourceMessage) &&
         (await shouldHydrateMedia(node, index))
@@ -346,6 +354,13 @@ export function createTelegramMessagePipeline({
                   chatId: ctx.message.chat.id,
                   messageId: node.messageId,
                   media,
+                  botUserId: ctx.me?.id,
+                });
+              } else if (media.unavailableReason) {
+                await recordReplyMessageMediaUnavailableReason({
+                  chatId: ctx.message.chat.id,
+                  messageId: node.messageId,
+                  reason: media.unavailableReason,
                   botUserId: ctx.me?.id,
                 });
               }
@@ -539,10 +554,10 @@ export function createTelegramMessagePipeline({
       for (const [index, media] of params.allMedia.entries()) {
         const messageId = media.sourceMessageId ?? (index === 0 ? currentMessageId : undefined);
         const promptMediaPath = media.path ? resolveTelegramPromptMediaPath(media.path) : undefined;
-        if (messageId && promptMediaPath) {
+        if (messageId && (promptMediaPath || media.unavailableReason)) {
           promptContextMediaByMessageId.set(messageId, {
             ...media,
-            path: promptMediaPath,
+            ...(promptMediaPath ? { path: promptMediaPath } : {}),
           });
         }
       }
@@ -556,11 +571,17 @@ export function createTelegramMessagePipeline({
         const mediaKind =
           entry.mediaKind ??
           (inferredKind && inferredKind !== "unknown" ? inferredKind : "document");
-        if (entry.messageId && entry.mediaPath && promptMediaPath) {
+        if (
+          entry.messageId &&
+          ((entry.mediaPath && promptMediaPath) || entry.mediaUnavailableReason)
+        ) {
           promptContextMediaByMessageId.set(entry.messageId, {
-            path: promptMediaPath,
+            ...(promptMediaPath ? { path: promptMediaPath } : {}),
             kind: mediaKind,
             ...(entry.mediaType ? { contentType: entry.mediaType } : {}),
+            ...(entry.mediaUnavailableReason
+              ? { unavailableReason: entry.mediaUnavailableReason }
+              : {}),
           });
         }
       }
@@ -639,6 +660,7 @@ export function createTelegramMessagePipeline({
     resolvePromptContextAmbientWatermark,
     recordMessageForReplyChain,
     recordMessageResolvedMedia,
+    recordMessageMediaUnavailableReason,
     resolveCachedMessageThreadSpec,
     processMessageWithReplyChain,
   };

--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -58,7 +58,7 @@ import {
   type TelegramThreadSpec,
 } from "./bot/helpers.js";
 import { renderTelegramTextEntities } from "./bot/inbound-text-entities.js";
-import type { TelegramContext } from "./bot/types.js";
+import type { TelegramContext, TelegramMediaUnavailableReason } from "./bot/types.js";
 import { isTelegramForumServiceMessage } from "./forum-service-message.js";
 import { resolveTelegramGroupIngestEnabled } from "./group-config-helpers.js";
 import { recordTelegramGroupHistoryEntry } from "./group-history-window.js";
@@ -132,6 +132,13 @@ async function resolveStickerVisionSupport(params: {
   } catch {
     return false;
   }
+}
+
+export function formatTelegramUnavailableStickerNotice(
+  reason: TelegramMediaUnavailableReason,
+): string {
+  const format = reason === "video-sticker" ? "video" : "animated";
+  return `[Sticker unavailable: OpenClaw did not stage or analyze this ${format} Telegram sticker.]`;
 }
 
 export async function resolveTelegramInboundBody(params: {
@@ -247,6 +254,15 @@ export async function resolveTelegramInboundBody(params: {
     const stickerContext = [emoji, setName ? `from "${setName}"` : null].filter(Boolean).join(" ");
     formattedStickerDescription = `[Sticker${stickerContext ? ` ${stickerContext}` : ""}] ${cachedStickerDescription}`;
   }
+  const unavailableStickerNotices = [
+    ...new Set(
+      allMedia.flatMap((media) =>
+        media.unavailableReason
+          ? [formatTelegramUnavailableStickerNotice(media.unavailableReason)]
+          : [],
+      ),
+    ),
+  ].join("\n");
 
   const locationData = extractTelegramLocation(msg);
   const locationText = locationData ? formatLocationText(locationData) : undefined;
@@ -265,8 +281,10 @@ export async function resolveTelegramInboundBody(params: {
   }
 
   let bodyText = rawBody;
-  if (formattedStickerDescription) {
-    bodyText = [formattedStickerDescription, rawBody].filter(Boolean).join("\n");
+  if (formattedStickerDescription || unavailableStickerNotices) {
+    bodyText = [formattedStickerDescription, unavailableStickerNotices, rawBody]
+      .filter(Boolean)
+      .join("\n");
   }
   const isAudioMedia = (media: TelegramMediaRef) =>
     media.kind === "audio" || media.contentType?.startsWith("audio/") === true;
@@ -320,7 +338,10 @@ export async function resolveTelegramInboundBody(params: {
     bodyText = formatAudioTranscriptForAgent(preflightTranscript);
   }
   const historyBody =
-    rawBody || formattedStickerDescription || formatMediaPlaceholderText(nativeMediaFacts);
+    rawBody ||
+    formattedStickerDescription ||
+    unavailableStickerNotices ||
+    formatMediaPlaceholderText(nativeMediaFacts);
 
   const hasAnyMention = messageTextParts.entities.some((ent) => ent.type === "mention");
   const explicitlyMentioned = botUsername

--- a/extensions/telegram/src/bot-message-context.forwarded-batch.test.ts
+++ b/extensions/telegram/src/bot-message-context.forwarded-batch.test.ts
@@ -200,4 +200,60 @@ describe("buildTelegramMessageContext forwarded debounce batches", () => {
     expect(context?.ctxPayload.BodyForAgent).toMatch(expectedBody);
     expect(context?.ctxPayload.CommandBody).toBe("ordinary note");
   });
+
+  it("keeps unavailable sticker notices in forwarded media batches", async () => {
+    const chat = { id: 999, type: "private" as const, first_name: "Alice" };
+    const sender = { id: 42, first_name: "Alice", is_bot: false };
+    const context = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 2,
+        chat,
+        from: sender,
+        text: "ordinary note",
+      },
+      allMedia: [
+        {
+          kind: "sticker",
+          unavailableReason: "animated-sticker",
+          sourceMessageId: "2",
+        },
+      ],
+      options: {
+        inboundDebounceMessages: [
+          {
+            message_id: 1,
+            date: 1_700_000_000,
+            chat,
+            from: sender,
+            text: "ordinary note",
+          },
+          {
+            message_id: 2,
+            date: 1_700_000_001,
+            chat,
+            from: sender,
+            sticker: {
+              file_id: "animated-sticker",
+              file_unique_id: "animated-sticker-unique",
+              type: "regular",
+              width: 1,
+              height: 1,
+              is_animated: true,
+              is_video: false,
+            },
+            forward_origin: {
+              type: "hidden_user",
+              sender_user_name: "Original B",
+              date: 500,
+            },
+          },
+        ],
+      },
+    });
+
+    expect(context?.ctxPayload.BodyForAgent).toMatch(
+      /ordinary note\n\[Forwarded from Original B[^\]]*\]\n\[Sticker unavailable: OpenClaw did not stage or analyze this animated Telegram sticker\.\]/,
+    );
+    expect(context?.ctxPayload.BodyForAgent).not.toContain("<media:sticker>");
+  });
 });

--- a/extensions/telegram/src/bot-message-context.forwarded-batch.test.ts
+++ b/extensions/telegram/src/bot-message-context.forwarded-batch.test.ts
@@ -232,6 +232,7 @@ describe("buildTelegramMessageContext forwarded debounce batches", () => {
             date: 1_700_000_001,
             chat,
             from: sender,
+            caption: "captioned sticker",
             sticker: {
               file_id: "animated-sticker",
               file_unique_id: "animated-sticker-unique",
@@ -252,7 +253,7 @@ describe("buildTelegramMessageContext forwarded debounce batches", () => {
     });
 
     expect(context?.ctxPayload.BodyForAgent).toMatch(
-      /ordinary note\n\[Forwarded from Original B[^\]]*\]\n\[Sticker unavailable: OpenClaw did not stage or analyze this animated Telegram sticker\.\]/,
+      /ordinary note\n\[Forwarded from Original B[^\]]*\]\ncaptioned sticker\n\[Sticker unavailable: OpenClaw did not stage or analyze this animated Telegram sticker\.\]/,
     );
     expect(context?.ctxPayload.BodyForAgent).not.toContain("<media:sticker>");
   });

--- a/extensions/telegram/src/bot-message-context.forwarded-batch.test.ts
+++ b/extensions/telegram/src/bot-message-context.forwarded-batch.test.ts
@@ -219,7 +219,7 @@ describe("buildTelegramMessageContext forwarded debounce batches", () => {
         },
       ],
       options: {
-        inboundDebounceMessages: [
+        bufferedMessages: [
           {
             message_id: 1,
             date: 1_700_000_000,

--- a/extensions/telegram/src/bot-message-context.media-carriers.test.ts
+++ b/extensions/telegram/src/bot-message-context.media-carriers.test.ts
@@ -196,6 +196,80 @@ describe("buildTelegramMessageContext media carriers", () => {
     expect(context?.ctxPayload.StickerMediaIncluded).toBeUndefined();
   });
 
+  it("explains unavailable hydrated reply stickers in reply context", async () => {
+    const context = await buildTelegramMessageContextForTest({
+      message: {
+        chat: { id: 42, type: "private", first_name: "Ada" },
+        text: "What was that?",
+      },
+      replyChain: [
+        {
+          messageId: "10",
+          sender: "Pat",
+          mediaKind: "sticker",
+          mediaUnavailableReason: "video-sticker",
+        },
+      ],
+    });
+
+    expect(context?.ctxPayload.ReplyToBody).toContain(
+      "OpenClaw did not stage or analyze this video Telegram sticker",
+    );
+  });
+
+  it("explains unavailable ancestor stickers in the rendered reply chain", async () => {
+    const context = await buildTelegramMessageContextForTest({
+      message: {
+        chat: { id: 42, type: "private", first_name: "Ada" },
+        text: "What was that?",
+      },
+      replyChain: [
+        {
+          messageId: "11",
+          replyToId: "10",
+          sender: "Pat",
+          body: "The sticker above",
+        },
+        {
+          messageId: "10",
+          sender: "Lee",
+          mediaKind: "sticker",
+          mediaUnavailableReason: "animated-sticker",
+        },
+      ],
+    });
+
+    expect(context?.ctxPayload.ReplyToBody).toBe("The sticker above");
+    expect(context?.ctxPayload.Body).toContain(
+      "OpenClaw did not stage or analyze this animated Telegram sticker",
+    );
+  });
+
+  it("preserves unavailable sticker notices in accepted group history", async () => {
+    const groupHistories = new Map();
+    await buildTelegramMessageContextForTest({
+      message: {
+        chat: { id: -1003, type: "supergroup", title: "Stickers" },
+        text: undefined,
+        sticker: {
+          file_id: "sticker-3",
+          file_unique_id: "sticker-u3",
+          type: "regular",
+          width: 1,
+          height: 1,
+          is_animated: false,
+          is_video: true,
+        },
+      },
+      allMedia: [{ kind: "sticker", unavailableReason: "video-sticker" }],
+      groupHistories,
+      historyLimit: 5,
+    });
+
+    const historyBody = [...groupHistories.values()].flat().at(-1)?.body;
+    expect(historyBody).toContain("OpenClaw did not stage or analyze this video Telegram sticker");
+  });
+
   it("preserves cached sticker descriptions in group history", async () => {
     const groupHistories = new Map();
     await buildTelegramMessageContextForTest({

--- a/extensions/telegram/src/bot-message-context.media-carriers.test.ts
+++ b/extensions/telegram/src/bot-message-context.media-carriers.test.ts
@@ -172,7 +172,7 @@ describe("buildTelegramMessageContext media carriers", () => {
     expect([...groupHistories.values()].flat().at(-1)?.body).toBe("<media:image>");
   });
 
-  it("admits an unavailable native sticker as a type-only fact", async () => {
+  it("explains an unavailable animated sticker without inventing a staged path", async () => {
     const context = await buildTelegramMessageContextForTest({
       message: {
         chat: { id: 42, type: "private", first_name: "Ada" },
@@ -187,12 +187,15 @@ describe("buildTelegramMessageContext media carriers", () => {
           is_video: false,
         },
       },
-      allMedia: [{ kind: "sticker" }],
+      allMedia: [{ kind: "sticker", unavailableReason: "animated-sticker" }],
     });
 
     expect(context?.ctxPayload.RawBody).toBe("");
-    expect(context?.ctxPayload.BodyForAgent).toBe("");
+    expect(context?.ctxPayload.BodyForAgent).toContain(
+      "OpenClaw did not stage or analyze this animated Telegram sticker",
+    );
     expect(context?.ctxPayload.media?.map((fact) => fact.kind)).toEqual(["sticker"]);
+    expect(context?.ctxPayload.media?.[0]?.path).toBeUndefined();
     expect(context?.ctxPayload.StickerMediaIncluded).toBeUndefined();
   });
 

--- a/extensions/telegram/src/bot-message-context.prompt-context.test.ts
+++ b/extensions/telegram/src/bot-message-context.prompt-context.test.ts
@@ -305,21 +305,24 @@ describe("buildTelegramMessageContext prompt context", () => {
       telegramCfg,
       undefined,
       new Map([
-        [
-          "10",
-          { kind: "sticker" as const, unavailableReason: "animated-sticker" as const },
-        ],
+        ["10", { kind: "sticker" as const, unavailableReason: "animated-sticker" as const }],
       ]),
     );
 
-    expect(promptContext[0]?.payload.messages).toEqual([
+    expect(promptContext).toEqual([
       expect.objectContaining({
-        message_id: "10",
-        body: expect.stringContaining(
-          "OpenClaw did not stage or analyze this animated Telegram sticker",
-        ),
-        media_type: "sticker",
-        media_ref: undefined,
+        payload: expect.objectContaining({
+          messages: [
+            expect.objectContaining({
+              message_id: "10",
+              body: expect.stringContaining(
+                "OpenClaw did not stage or analyze this animated Telegram sticker",
+              ),
+              media_type: "sticker",
+              media_ref: undefined,
+            }),
+          ],
+        }),
       }),
     ]);
     expect(JSON.stringify(promptContext)).not.toContain("telegram:file/animated-sticker-1");

--- a/extensions/telegram/src/bot-message-context.prompt-context.test.ts
+++ b/extensions/telegram/src/bot-message-context.prompt-context.test.ts
@@ -254,6 +254,77 @@ describe("buildTelegramMessageContext prompt context", () => {
     expect(JSON.stringify(promptContext)).not.toContain("older DM");
   });
 
+  it("preserves unavailable sticker state in chat-window context", async () => {
+    const cfg = {
+      agents: { defaults: {} },
+      channels: { telegram: { dmPolicy: "open", dmHistoryLimit: 1 } },
+    } as never;
+    const telegramCfg = { dmPolicy: "open", dmHistoryLimit: 1 } as never;
+    const messageContextRuntime = createTelegramMessageContextRuntime({
+      cfg,
+      accountId: "default",
+      opts: {
+        token: "test-token",
+        botInfo: { id: 7, username: "bot", first_name: "Bot" },
+      } as never,
+      telegramCfg,
+      telegramDeps: {
+        resolveStorePath: () => createTempSessionStorePath(),
+      } as never,
+    });
+    const chat = { id: 1234, type: "private", first_name: "Pat" } as const;
+    await messageContextRuntime.recordMessageForReplyChain({
+      chat,
+      message_id: 10,
+      date: 1_700_000_000,
+      from: { id: 1234, is_bot: false, first_name: "Pat" },
+      sticker: {
+        file_id: "animated-sticker-1",
+        file_unique_id: "animated-sticker-u1",
+        type: "regular",
+        width: 1,
+        height: 1,
+        is_animated: true,
+        is_video: false,
+      },
+    } as never);
+    const currentMessage = {
+      chat,
+      message_id: 11,
+      date: 1_700_000_010,
+      text: "What was that?",
+      from: { id: 1234, is_bot: false, first_name: "Pat" },
+    } as never;
+    await messageContextRuntime.recordMessageForReplyChain(currentMessage);
+
+    const promptContext = await messageContextRuntime.buildPromptContextForMessage(
+      { me: { id: 7, username: "bot", first_name: "Bot" } } as never,
+      currentMessage,
+      [],
+      cfg,
+      telegramCfg,
+      undefined,
+      new Map([
+        [
+          "10",
+          { kind: "sticker" as const, unavailableReason: "animated-sticker" as const },
+        ],
+      ]),
+    );
+
+    expect(promptContext[0]?.payload.messages).toEqual([
+      expect.objectContaining({
+        message_id: "10",
+        body: expect.stringContaining(
+          "OpenClaw did not stage or analyze this animated Telegram sticker",
+        ),
+        media_type: "sticker",
+        media_ref: undefined,
+      }),
+    ]);
+    expect(JSON.stringify(promptContext)).not.toContain("telegram:file/animated-sticker-1");
+  });
+
   it("disables persisted DM transcript injection when the effective limit is zero", async () => {
     const ctx = await buildTelegramMessageContextForTest({
       message: {

--- a/extensions/telegram/src/bot-message-context.prompt-context.test.ts
+++ b/extensions/telegram/src/bot-message-context.prompt-context.test.ts
@@ -143,7 +143,6 @@ describe("buildTelegramMessageContext prompt context", () => {
       text: "older unrelated DM",
       from: { id: 1234, is_bot: false, first_name: "Pat" },
     } as never);
-
     const currentMessage = {
       chat,
       message_id: 12,
@@ -288,6 +287,13 @@ describe("buildTelegramMessageContext prompt context", () => {
         is_video: false,
       },
     } as never);
+    await messageContextRuntime.recordMessageMediaUnavailableReason({
+      msg: {
+        chat,
+        message_id: 10,
+      } as never,
+      reason: "animated-sticker",
+    });
     const currentMessage = {
       chat,
       message_id: 11,
@@ -304,9 +310,6 @@ describe("buildTelegramMessageContext prompt context", () => {
       cfg,
       telegramCfg,
       undefined,
-      new Map([
-        ["10", { kind: "sticker" as const, unavailableReason: "animated-sticker" as const }],
-      ]),
     );
 
     expect(promptContext).toEqual([

--- a/extensions/telegram/src/bot-message-context.prompt-context.test.ts
+++ b/extensions/telegram/src/bot-message-context.prompt-context.test.ts
@@ -262,6 +262,7 @@ describe("buildTelegramMessageContext prompt context", () => {
     const messageContextRuntime = createTelegramMessageContextRuntime({
       cfg,
       accountId: "default",
+      ownerAgentId: "main",
       opts: {
         token: "test-token",
         botInfo: { id: 7, username: "bot", first_name: "Bot" },

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -454,11 +454,13 @@ export async function buildTelegramInboundContextPayload(params: {
           (media) => media.sourceMessageId === String(bufferedMessage.message_id),
         )?.unavailableReason;
         const textParts = getTelegramTextParts(bufferedMessage);
-        const segmentBody =
-          renderTelegramTextEntities(textParts.text, textParts.entities) ||
-          (unavailableReason
-            ? formatTelegramUnavailableStickerNotice(unavailableReason)
-            : formatMediaPlaceholderText(bufferedMedia ? [{ kind: bufferedMedia.kind }] : []));
+        const renderedText = renderTelegramTextEntities(textParts.text, textParts.entities);
+        const mediaContext = unavailableReason
+          ? formatTelegramUnavailableStickerNotice(unavailableReason)
+          : renderedText
+            ? undefined
+            : formatMediaPlaceholderText(bufferedMedia ? [{ kind: bufferedMedia.kind }] : []);
+        const segmentBody = [renderedText, mediaContext].filter(Boolean).join("\n");
         if (!segmentBody) {
           return [];
         }

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -188,15 +188,17 @@ function formatReplyChainEntry(entry: TelegramReplyChainEntry, index: number): s
       forwardedFrom: entry.forwardedFrom,
       forwardedDate: entry.forwardedDate,
     }),
-    entry.mediaKind || entry.mediaType
-      ? formatMediaPlaceholderText([
-          entry.mediaKind
-            ? { kind: entry.mediaKind }
-            : isTelegramMediaKind(entry.mediaType ?? "")
-              ? { kind: entry.mediaType as TelegramMediaKind }
-              : { contentType: entry.mediaType },
-        ])
-      : undefined,
+    entry.mediaUnavailableReason
+      ? formatTelegramUnavailableStickerNotice(entry.mediaUnavailableReason)
+      : entry.mediaKind || entry.mediaType
+        ? formatMediaPlaceholderText([
+            entry.mediaKind
+              ? { kind: entry.mediaKind }
+              : isTelegramMediaKind(entry.mediaType ?? "")
+                ? { kind: entry.mediaType as TelegramMediaKind }
+                : { contentType: entry.mediaType },
+          ])
+        : undefined,
     mediaPath ? `[media_path:${mediaPath}]` : undefined,
     entry.mediaRef ? `[media_ref:${entry.mediaRef}]` : undefined,
   ].filter(Boolean);
@@ -447,10 +449,15 @@ export async function buildTelegramInboundContextPayload(params: {
   const bufferedBodySegments = shouldRenderBufferedBody
     ? bufferedMessages.flatMap((bufferedMessage) => {
         const bufferedMedia = resolveTelegramPrimaryMedia(bufferedMessage);
+        const unavailableReason = allMedia.find(
+          (media) => media.sourceMessageId === String(bufferedMessage.message_id),
+        )?.unavailableReason;
         const textParts = getTelegramTextParts(bufferedMessage);
         const segmentBody =
           renderTelegramTextEntities(textParts.text, textParts.entities) ||
-          formatMediaPlaceholderText(bufferedMedia ? [{ kind: bufferedMedia.kind }] : []);
+          (unavailableReason
+            ? formatTelegramUnavailableStickerNotice(unavailableReason)
+            : formatMediaPlaceholderText(bufferedMedia ? [{ kind: bufferedMedia.kind }] : []));
         if (!segmentBody) {
           return [];
         }
@@ -831,6 +838,7 @@ export async function buildTelegramInboundContextPayload(params: {
     },
   } satisfies BuildChannelInboundEventContextAsyncParams);
   if (isGroup && historyKey) {
+    const hasUnavailableSticker = allMedia.some((media) => media.unavailableReason);
     recordTelegramGroupHistoryEntry({
       historyMap: groupHistories,
       historyKey,
@@ -838,7 +846,7 @@ export async function buildTelegramInboundContextPayload(params: {
       entry: {
         sender: buildSenderLabel(msg, senderId || chatId),
         body:
-          rawBody ||
+          (hasUnavailableSticker ? bodyText : rawBody) ||
           (stickerCacheHit ? bodyText : undefined) ||
           formatMediaPlaceholderText(currentMediaFacts),
         timestamp: msg.date ? msg.date * 1000 : undefined,

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -27,6 +27,7 @@ import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coe
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { NormalizedAllowFrom } from "./bot-access.js";
 import { isSenderAllowed, normalizeAllowFrom } from "./bot-access.js";
+import { formatTelegramUnavailableStickerNotice } from "./bot-message-context.body.js";
 import type {
   TelegramMediaRef,
   TelegramMessageContextOptions,
@@ -627,10 +628,22 @@ export async function buildTelegramInboundContextPayload(params: {
   const replyTargetMedia =
     replyHeadMedia ??
     (visibleReplyTarget?.mediaType ? { kind: visibleReplyTarget.mediaType } : undefined);
-  const replyBody =
+  const replyBodyBase =
     replyHead?.body ??
     visibleReplyTarget?.body ??
     (replyTargetMedia ? formatMediaPlaceholderText([replyTargetMedia]) : undefined);
+  const replyUnavailableReason =
+    replyHead?.mediaUnavailableReason ??
+    (visibleReplyChain.length === 0
+      ? replyMedia.find((media) => media.unavailableReason)?.unavailableReason
+      : undefined);
+  const replyUnavailableNotice = replyUnavailableReason
+    ? formatTelegramUnavailableStickerNotice(replyUnavailableReason)
+    : undefined;
+  const replyBody =
+    replyUnavailableNotice || replyBodyBase
+      ? [replyBodyBase, replyUnavailableNotice].filter(Boolean).join("\n")
+      : undefined;
   const telegramFrom = isGroup ? buildTelegramGroupFrom(chatId, threadSpec) : `telegram:${chatId}`;
   const telegramTo = buildTelegramInboundOriginTarget(chatId, threadSpec);
   const locationContext = locationData ? toLocationContext(locationData) : undefined;

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -16,7 +16,11 @@ import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import type { TelegramMediaKind } from "./bot/body-helpers.js";
 import type { TelegramThreadSpec } from "./bot/helpers.js";
-import type { StickerMetadata, TelegramContext } from "./bot/types.js";
+import type {
+  StickerMetadata,
+  TelegramContext,
+  TelegramMediaUnavailableReason,
+} from "./bot/types.js";
 import type { TelegramReplyChainEntry } from "./message-cache.js";
 import type { TelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
 
@@ -25,6 +29,7 @@ export type TelegramMediaRef = {
   path?: string;
   contentType?: string;
   stickerMetadata?: StickerMetadata;
+  unavailableReason?: TelegramMediaUnavailableReason;
   sourceMessageId?: string;
 };
 

--- a/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
@@ -172,6 +172,7 @@ describe("telegram stickers", () => {
         {
           messageId: 101,
           filePath: "stickers/animated.tgs",
+          unavailableReason: "animated-sticker",
           sticker: {
             file_id: "animated_sticker_id",
             file_unique_id: "animated_unique",
@@ -187,6 +188,7 @@ describe("telegram stickers", () => {
         {
           messageId: 102,
           filePath: "stickers/video.webm",
+          unavailableReason: "video-sticker",
           sticker: {
             file_id: "video_sticker_id",
             file_unique_id: "video_unique",
@@ -223,7 +225,10 @@ describe("telegram stickers", () => {
           } as unknown as TelegramContext,
         });
 
-        expect(media).toBeNull();
+        expect(media).toEqual({
+          kind: "sticker",
+          unavailableReason: scenario.unavailableReason,
+        });
         expect(getFile).not.toHaveBeenCalled();
         expect(proxyFetch).not.toHaveBeenCalled();
       }

--- a/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
@@ -235,6 +235,75 @@ describe("telegram stickers", () => {
     },
     STICKER_TEST_TIMEOUT_MS,
   );
+
+  it(
+    "retains an unavailable sticker notice in later group chat-window context",
+    async () => {
+      const originalLoadConfig = telegramBotDepsForTest.getRuntimeConfig;
+      telegramBotDepsForTest.getRuntimeConfig = (() => ({
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            groupAllowFrom: ["777"],
+            groupPolicy: "open",
+            groups: {
+              "-10042": { allowFrom: ["777"], groupPolicy: "open", requireMention: false },
+            },
+          },
+        },
+      })) as typeof telegramBotDepsForTest.getRuntimeConfig;
+
+      const getFile = vi.fn(async () => ({ file_path: "stickers/animated.tgs" }));
+      try {
+        const { handler, replySpy } = await createBotHandlerWithOptions({});
+        const chat = { id: -10042, type: "supergroup", title: "Sticker QA" } as const;
+        const from = { id: 777, is_bot: false, first_name: "Ada" } as const;
+
+        await handler({
+          message: {
+            chat,
+            from,
+            message_id: 201,
+            date: 1736380800,
+            sticker: {
+              file_id: "animated_sticker_id",
+              file_unique_id: "animated_unique",
+              type: "regular",
+              width: 512,
+              height: 512,
+              is_animated: true,
+              is_video: false,
+            },
+          },
+          me: { id: 999, username: "openclaw_bot", first_name: "OpenClaw" },
+          getFile,
+        });
+        await handler({
+          message: {
+            chat,
+            from,
+            message_id: 202,
+            date: 1736380801,
+            text: "What was that?",
+          },
+          me: { id: 999, username: "openclaw_bot", first_name: "OpenClaw" },
+          getFile,
+        });
+
+        await vi.waitFor(() => expect(replySpy).toHaveBeenCalledTimes(2));
+        const laterContext = JSON.stringify(replySpy.mock.calls.at(1)?.[0]);
+        expect(laterContext).toContain(
+          "OpenClaw did not stage or analyze this animated Telegram sticker",
+        );
+        expect(laterContext).not.toContain("telegram:file/animated_sticker_id");
+        expect(getFile).not.toHaveBeenCalled();
+      } finally {
+        telegramBotDepsForTest.getRuntimeConfig = originalLoadConfig;
+      }
+    },
+    STICKER_TEST_TIMEOUT_MS,
+  );
 });
 
 describe("telegram local Bot API media", () => {

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -18,11 +18,21 @@ import {
   sleepWithAbort,
 } from "./delivery.resolve-media.runtime.js";
 import { resolveTelegramPrimaryMedia } from "./helpers.js";
-import type { TelegramContext } from "./types.js";
+import type { TelegramContext, TelegramMediaUnavailableReason } from "./types.js";
 
 const FILE_TOO_BIG_RE = /file is too big/i;
 const TELEGRAM_GET_FILE_RETRY_DEADLINE_MS = 20 * 60_000;
 const TELEGRAM_GET_FILE_RETRY_ATTEMPTS = 3;
+
+type TelegramMediaResolution =
+  | (TelegramResolvedMedia & { path: string; unavailableReason?: undefined })
+  | {
+      path?: undefined;
+      contentType?: undefined;
+      kind: "sticker";
+      stickerMetadata?: undefined;
+      unavailableReason: TelegramMediaUnavailableReason;
+    };
 const GrammyErrorCtor: typeof GrammyError | undefined =
   typeof GrammyError === "function" ? GrammyError : undefined;
 
@@ -376,16 +386,19 @@ async function resolveStickerMedia(params: {
   trustedLocalFileRoots?: readonly string[];
   dangerouslyAllowPrivateNetwork?: boolean;
   abortSignal?: AbortSignal;
-}): Promise<(TelegramResolvedMedia & { path: string }) | null | undefined> {
+}): Promise<TelegramMediaResolution | null | undefined> {
   const { msg, ctx, maxBytes, token, transport, abortSignal } = params;
   if (!msg.sticker) {
     return undefined;
   }
   const sticker = msg.sticker;
-  // Skip animated (TGS) and video (WEBM) stickers - only static WEBP supported
+  // Preserve a model-visible outcome for formats OpenClaw does not analyze.
   if (sticker.is_animated || sticker.is_video) {
     logVerbose("telegram: skipping animated/video sticker (only static stickers supported)");
-    return null;
+    return {
+      kind: "sticker",
+      unavailableReason: sticker.is_video ? "video-sticker" : "animated-sticker",
+    };
   }
   if (!sticker.file_id) {
     return null;
@@ -467,7 +480,7 @@ export async function resolveMedia(params: {
   trustedLocalFileRoots?: readonly string[];
   dangerouslyAllowPrivateNetwork?: boolean;
   abortSignal?: AbortSignal;
-}): Promise<(TelegramResolvedMedia & { path: string }) | null> {
+}): Promise<TelegramMediaResolution | null> {
   const {
     ctx,
     maxBytes,

--- a/extensions/telegram/src/bot/types.ts
+++ b/extensions/telegram/src/bot/types.ts
@@ -38,3 +38,5 @@ export interface StickerMetadata {
   /** Cached description from previous vision processing (skip re-processing if present). */
   cachedDescription?: string;
 }
+
+export type TelegramMediaUnavailableReason = "animated-sticker" | "video-sticker";

--- a/extensions/telegram/src/message-cache-persistence.ts
+++ b/extensions/telegram/src/message-cache-persistence.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import type { Message } from "grammy/types";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { TelegramMediaKind } from "./bot/body-helpers.js";
-import type { StickerMetadata } from "./bot/types.js";
+import type { StickerMetadata, TelegramMediaUnavailableReason } from "./bot/types.js";
 import type {
   TelegramPromptContextProjection,
   TelegramPromptContextSource,
@@ -39,9 +39,16 @@ export type PersistedTelegramMessageCacheValue = {
   botUserId?: number;
   promptContextProjection?: TelegramPromptContextProjection | TelegramPromptContextSource;
   resolvedMedia?: TelegramResolvedMedia;
+  mediaUnavailableReason?: TelegramMediaUnavailableReason;
   threadBinding?: TelegramMessageThreadBinding;
   threadId?: string;
 };
+
+export function parseTelegramMediaUnavailableReason(
+  value: unknown,
+): TelegramMediaUnavailableReason | undefined {
+  return value === "animated-sticker" || value === "video-sticker" ? value : undefined;
+}
 
 const TELEGRAM_MEDIA_KINDS = new Set<string>(["audio", "document", "image", "sticker", "video"]);
 

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -25,6 +25,7 @@ type PersistedValue = {
   botUserId?: number;
   promptContextProjection?: unknown;
   resolvedMedia?: TelegramResolvedMedia;
+  mediaUnavailableReason?: "animated-sticker" | "video-sticker";
   threadBinding?: {
     kind: "provider-observed-v1";
     threadSpec: { scope: "direct-messages" | "dm" | "forum"; id: number };
@@ -175,6 +176,34 @@ describe("telegram message cache", () => {
     const reloadedCache = cacheFor(bucketKey, store);
     await record(reloadedCache, message(9000, "Kesava", { photo: photo("photo-2") }));
     expect((await get(reloadedCache, "9000"))?.resolvedMedia).toBeUndefined();
+  });
+
+  it("persists unavailable sticker outcomes and drops them when the media changes", async () => {
+    const { bucketKey, entries, store } = createMemoryStore();
+    const cache = cacheFor(bucketKey, store);
+    const animatedSticker = {
+      file_id: "animated-1",
+      file_unique_id: "animated-1-unique",
+      width: 1,
+      height: 1,
+      is_animated: true,
+      is_video: false,
+    };
+    await record(cache, message(9001, "Kesava", { sticker: animatedSticker }));
+    await cache.recordMediaUnavailableReason({
+      accountId: "default",
+      chatId: 7,
+      messageId: "9001",
+      reason: "animated-sticker",
+    });
+
+    expect(onlyEntry(entries)[1].mediaUnavailableReason).toBe("animated-sticker");
+    const reloaded = await reloadGet(bucketKey, store, "9001");
+    expect(reloaded?.mediaUnavailableReason).toBe("animated-sticker");
+
+    const reloadedCache = cacheFor(bucketKey, store);
+    await record(reloadedCache, message(9001, "Kesava", { photo: photo("photo-2") }));
+    expect((await get(reloadedCache, "9001"))?.mediaUnavailableReason).toBeUndefined();
   });
 
   it("persists provider-observed topic bindings for messages and same-topic replies", async () => {

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -20,6 +20,7 @@ import {
 import type { TelegramMediaUnavailableReason } from "./bot/types.js";
 import {
   isTelegramMessageCacheSourceMessage,
+  parseTelegramMediaUnavailableReason,
   parseTelegramResolvedMedia,
   type PersistedTelegramMessageCacheValue,
   type TelegramResolvedMedia,
@@ -72,6 +73,13 @@ type TelegramMessageCache = {
     chatId: string | number;
     messageId: string;
     media: TelegramResolvedMedia;
+  }) => Promise<void>;
+  recordMediaUnavailableReason: (params: {
+    accountId: string;
+    botUserId?: number;
+    chatId: string | number;
+    messageId: string;
+    reason: TelegramMediaUnavailableReason;
   }) => Promise<void>;
   get: (params: {
     accountId: string;
@@ -209,6 +217,7 @@ function normalizeMessageNode(
     threadId?: number;
     promptContextProjectionMarker?: TelegramPromptContextProjectionMarker;
     resolvedMedia?: TelegramResolvedMedia;
+    mediaUnavailableReason?: TelegramMediaUnavailableReason;
     threadBinding?: TelegramMessageThreadBinding;
   },
 ): TelegramCachedMessageNode {
@@ -240,6 +249,9 @@ function normalizeMessageNode(
       ? { promptContextProjectionMarker: params.promptContextProjectionMarker }
       : {}),
     ...(params.resolvedMedia ? { resolvedMedia: params.resolvedMedia } : {}),
+    ...(params.mediaUnavailableReason
+      ? { mediaUnavailableReason: params.mediaUnavailableReason }
+      : {}),
     ...(threadBinding ? { threadBinding } : {}),
   };
 }
@@ -295,6 +307,7 @@ function normalizeMessageNodes(
     threadId?: number;
     promptContextProjectionMarker?: TelegramPromptContextProjectionMarker;
     resolvedMedia?: TelegramResolvedMedia;
+    mediaUnavailableReason?: TelegramMediaUnavailableReason;
     threadBinding?: TelegramMessageThreadBinding;
   },
 ): TelegramCachedMessageObservation[] {
@@ -309,6 +322,7 @@ function normalizeMessageNodes(
     promptContextProjectionMarker?: TelegramPromptContextProjectionMarker,
     threadBinding?: TelegramMessageThreadBinding,
     resolvedMedia?: TelegramResolvedMedia,
+    mediaUnavailableReason?: TelegramMediaUnavailableReason,
   ) => {
     const embeddedThreadId = parseTelegramMessageThreadId(
       (message as { message_thread_id?: unknown }).message_thread_id,
@@ -325,6 +339,7 @@ function normalizeMessageNodes(
       ...(threadId !== undefined ? { threadId } : {}),
       ...(promptContextProjectionMarker ? { promptContextProjectionMarker } : {}),
       ...(resolvedMedia ? { resolvedMedia } : {}),
+      ...(mediaUnavailableReason ? { mediaUnavailableReason } : {}),
       ...(matchingBinding ? { threadBinding: matchingBinding } : {}),
     });
     if (visited.has(node.messageId)) {
@@ -351,6 +366,7 @@ function normalizeMessageNodes(
     params.promptContextProjectionMarker,
     params.threadBinding,
     params.resolvedMedia,
+    params.mediaUnavailableReason,
   );
   return observations;
 }
@@ -382,11 +398,16 @@ function parsePersistedCacheValue(key: string, value: unknown) {
       ? normalizeTelegramMessageThreadBinding(value.threadBinding)
       : undefined;
   const resolvedMedia = parseTelegramResolvedMedia(value.resolvedMedia);
+  const mediaUnavailableReason =
+    value.version === TELEGRAM_MESSAGE_CACHE_PERSISTED_VERSION
+      ? parseTelegramMediaUnavailableReason(value.mediaUnavailableReason)
+      : undefined;
   return normalizeMessageNodes(value.sourceMessage, {
     ...(threadId !== undefined ? { threadId } : {}),
     ...(promptContextProjectionMarker ? { promptContextProjectionMarker } : {}),
     ...(threadBinding ? { threadBinding } : {}),
     ...(resolvedMedia ? { resolvedMedia } : {}),
+    ...(mediaUnavailableReason ? { mediaUnavailableReason } : {}),
   }).map(({ node, mode }) => ({
     key: `${key.slice(0, separatorIndex + 1)}${node.messageId}`,
     node,
@@ -458,15 +479,22 @@ function mergeCachedMessageNode(
     threadBinding?.threadSpec.id ?? incoming.threadId ?? existing.threadId,
   );
   const primaryMedia = resolveTelegramPrimaryMedia(sourceMessage);
+  const existingPrimaryMedia = resolveTelegramPrimaryMedia(existing.sourceMessage);
   const resolvedMedia =
     existing.resolvedMedia?.fileUniqueId === primaryMedia?.fileRef.file_unique_id
       ? existing.resolvedMedia
+      : undefined;
+  const mediaUnavailableReason =
+    existing.mediaUnavailableReason &&
+    existingPrimaryMedia?.fileRef.file_unique_id === primaryMedia?.fileRef.file_unique_id
+      ? existing.mediaUnavailableReason
       : undefined;
   return normalizeMessageNode(sourceMessage, {
     ...(threadId !== undefined ? { threadId } : {}),
     ...(promptContextProjectionMarker ? { promptContextProjectionMarker } : {}),
     ...(threadBinding ? { threadBinding } : {}),
     ...(resolvedMedia ? { resolvedMedia } : {}),
+    ...(mediaUnavailableReason ? { mediaUnavailableReason } : {}),
   });
 }
 
@@ -590,6 +618,9 @@ async function persistCachedNode(params: {
       ...(params.botUserId !== undefined ? { botUserId: params.botUserId } : {}),
       ...(promptContextProjection ? { promptContextProjection } : {}),
       ...(params.node.resolvedMedia ? { resolvedMedia: params.node.resolvedMedia } : {}),
+      ...(params.node.mediaUnavailableReason
+        ? { mediaUnavailableReason: params.node.mediaUnavailableReason }
+        : {}),
       ...(params.node.threadBinding ? { threadBinding: params.node.threadBinding } : {}),
       ...(params.node.threadId ? { threadId: params.node.threadId } : {}),
     });
@@ -722,7 +753,27 @@ export function createTelegramMessageCache(params?: {
       if (fileUniqueId !== media.fileUniqueId) {
         throw new Error(`Telegram message ${messageId} media changed during resolution`);
       }
-      const resolvedNode = { ...node, resolvedMedia: media };
+      const resolvedNode = { ...node, resolvedMedia: media, mediaUnavailableReason: undefined };
+      messages.delete(key);
+      messages.set(key, resolvedNode);
+      await persistCachedNode({
+        bucket,
+        key,
+        node: resolvedNode,
+        ...(botUserId !== undefined ? { botUserId } : {}),
+      });
+    },
+    recordMediaUnavailableReason: async ({ accountId, botUserId, chatId, messageId, reason }) => {
+      await hydrateMessageCacheBucket(bucket, maxMessages, scopeKey);
+      const key = telegramMessageCacheKey({ scopeKey, accountId, chatId, messageId });
+      const node = messages.get(key);
+      if (!node) {
+        throw new Error(`Telegram message ${messageId} was not recorded before media resolution`);
+      }
+      if (resolveTelegramPrimaryMedia(node.sourceMessage)?.kind !== "sticker") {
+        throw new Error(`Telegram message ${messageId} unavailable media is not a sticker`);
+      }
+      const resolvedNode = { ...node, resolvedMedia: undefined, mediaUnavailableReason: reason };
       messages.delete(key);
       messages.set(key, resolvedNode);
       await persistCachedNode({

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -17,6 +17,7 @@ import {
   normalizeForwardedContext,
   type TelegramThreadSpec,
 } from "./bot/helpers.js";
+import type { TelegramMediaUnavailableReason } from "./bot/types.js";
 import {
   isTelegramMessageCacheSourceMessage,
   parseTelegramResolvedMedia,
@@ -38,6 +39,7 @@ import { getOptionalTelegramRuntime } from "./runtime.js";
 
 export type TelegramReplyChainEntry = NonNullable<MsgContext["ReplyChain"]>[number] & {
   mediaKind?: TelegramMediaKind;
+  mediaUnavailableReason?: TelegramMediaUnavailableReason;
 };
 
 export type TelegramCachedMessageNode = Omit<TelegramReplyChainEntry, "messageId"> & {


### PR DESCRIPTION
Closes #120735

## What Problem This Solves

Telegram animated TGS and video WebM stickers are intentionally not staged for analysis. Previously, that no-media outcome could leave the agent with an empty message or later expose an opaque `telegram:file/...` placeholder instead of useful context.

## Why This Change Was Made

The Telegram pipeline now carries a typed unavailable-media reason without downloading, converting, or persisting unsupported sticker bytes. It survives the same context paths as ordinary message metadata: direct and group messages, albums, accepted group history, nested and hydrated replies, forwarded/debounced batches, cache reloads, and later chat-window context.

Each context sink renders an accurate notice that OpenClaw did not stage or analyze the sticker. Static WEBP sticker handling is unchanged, and captions remain intact when messages are combined.

## User Impact

Agents can acknowledge that an animated or video sticker was sent and explain the limitation instead of receiving a blank message or raw media reference. This does not claim Telegram cannot provide the file and does not add a conversion dependency.

## Evidence

- Focused Telegram context/cache suite: 5 files, 55 tests passed.
- Current production and extension-test TypeScript programs passed after aligning the consolidated `TelegramMessagePipeline` contract and updated test fixture with upstream.
- Resolver E2E: 1 passed, 8 skipped after the TypeScript and bundled-plugin build; asserts that neither Telegram `getFile` nor the proxy fetch runs for animated/video stickers.
- Later group chat-window handler E2E: 1 passed, 8 skipped; sends an animated sticker followed by another group message and asserts that the retained context contains the unavailable notice, omits the raw `telegram:file/...` reference, and never calls `getFile`.
- That handler E2E initially failed after the rebase because the persistence branch accepted any media object instead of only a staged media path. Restricting it to `media?.path` restored the unavailable-reason path, after which the regression passed.
- `oxfmt --check` and `oxlint` passed across all 16 changed TypeScript files; `git diff --check` passed.
- Repository autoreview against `upstream/main` passed after a clean TruffleHog scan: no accepted/actionable findings; correctness confidence 0.96.
- A synthetic secretless Codex tool-registration proof is not relevant to this Telegram-only change; product-path verification here is the checked-in resolver and handler E2E coverage. No live Telegram credential was available.

## AI Assistance

This PR was implemented with AI assistance. The issue path, current upstream Telegram media/cache/context pipeline, regression failures, rebase adaptation, focused tests, E2E paths, type checks, formatting, lint, and repository autoreview were inspected and run manually. The verified head is `037cc36d94e88301fd8a0730894053a019490dbc`.
