### PR TITLE
fix(feishu): stop repeated doc child pagination

### DIFF
--- a/extensions/feishu/src/docx-create-loopback.test.ts
+++ b/extensions/feishu/src/docx-create-loopback.test.ts
@@ -26,7 +26,7 @@ vi.spyOn(toolAccountModule, "resolveFeishuToolAccount").mockReturnValue({
 
 const { registerFeishuDocTools } = await import("./docx.js");
 
-describe("feishu_doc create contract over the real Lark SDK", () => {
+describe("feishu_doc contract over the real Lark SDK", () => {
   afterAll(() => {
     vi.restoreAllMocks();
     vi.resetModules();
@@ -182,6 +182,107 @@ describe("feishu_doc create contract over the real Lark SDK", () => {
           body: expect.objectContaining({ children_id: ["body_loopback"] }),
         },
       ]);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("stops insert pagination when the SDK returns a repeated page token", async () => {
+    const pageTokens: Array<string | null> = [];
+    const server = createServer((request, response) => {
+      const url = new URL(request.url ?? "/", "http://127.0.0.1");
+      const sendJson = (body: unknown) => {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify(body));
+      };
+
+      if (
+        request.method === "GET" &&
+        url.pathname === "/open-apis/docx/v1/documents/doc_loopback/blocks/after_loopback"
+      ) {
+        sendJson({
+          code: 0,
+          data: {
+            block: { block_id: "after_loopback", parent_id: "parent_loopback", block_type: 2 },
+          },
+        });
+        return;
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/open-apis/docx/v1/documents/doc_loopback/blocks/parent_loopback/children"
+      ) {
+        pageTokens.push(url.searchParams.get("page_token"));
+        if (pageTokens.length > 2) {
+          sendJson({ code: 1, msg: "unexpected third pagination request" });
+          return;
+        }
+        sendJson({
+          code: 0,
+          data: {
+            items: [{ block_id: "after_loopback", parent_id: "parent_loopback", block_type: 2 }],
+            has_more: true,
+            page_token: "repeated-token",
+          },
+        });
+        return;
+      }
+      response.writeHead(404).end();
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const address = server.address() as AddressInfo;
+      const loopbackHttp = Object.create(Lark.defaultHttpInstance) as Lark.HttpInstance;
+      loopbackHttp.request = async (options) => {
+        const upstream = new URL(options.url ?? "");
+        const target = new URL(
+          `${upstream.pathname}${upstream.search}`,
+          `http://127.0.0.1:${address.port}`,
+        );
+        for (const [key, value] of Object.entries(options.params ?? {})) {
+          if (value !== undefined && value !== null) {
+            target.searchParams.set(key, String(value));
+          }
+        }
+        const response = await fetch(target, { method: options.method ?? "GET" });
+        return response.json();
+      };
+      createFeishuClientMock.mockReturnValue(
+        new Lark.Client({
+          appId: "loopback-test-app",
+          appSecret: "loopback-test-placeholder", // pragma: allowlist secret
+          domain: Lark.Domain.Feishu,
+          loggerLevel: Lark.LoggerLevel.error,
+          disableTokenCache: true,
+          httpInstance: loopbackHttp,
+        }),
+      );
+
+      const harness = createToolFactoryHarness({
+        channels: {
+          feishu: { enabled: true, appId: "app_id", appSecret: "app_secret" },
+        },
+      });
+      registerFeishuDocTools(harness.api);
+
+      const result = await harness.resolveTool("feishu_doc").execute("insert-document", {
+        action: "insert",
+        doc_token: "doc_loopback",
+        after_block_id: "after_loopback",
+        content: "Body content",
+      });
+
+      expect(result.details.error).toContain(
+        'Feishu document children pagination repeated token for parent block "parent_loopback"',
+      );
+      expect(pageTokens).toEqual([null, "repeated-token"]);
     } finally {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));

--- a/extensions/feishu/src/docx-create-loopback.test.ts
+++ b/extensions/feishu/src/docx-create-loopback.test.ts
@@ -189,104 +189,121 @@ describe("feishu_doc contract over the real Lark SDK", () => {
     }
   });
 
-  it("stops insert pagination when the SDK returns a repeated page token", async () => {
-    const pageTokens: Array<string | null> = [];
-    const server = createServer((request, response) => {
-      const url = new URL(request.url ?? "/", "http://127.0.0.1");
-      const sendJson = (body: unknown) => {
-        response.writeHead(200, { "content-type": "application/json" });
-        response.end(JSON.stringify(body));
-      };
+  it.each([
+    {
+      description: "a repeated page token",
+      pageToken: "repeated-token",
+      expectedPageTokens: [null, "repeated-token"],
+      expectedError:
+        'Feishu document children pagination repeated token for parent block "parent_loopback"',
+    },
+    {
+      description: "no next page token",
+      pageToken: undefined,
+      expectedPageTokens: [null],
+      expectedError:
+        'Feishu document children pagination is missing its next page token for parent block "parent_loopback"',
+    },
+  ])(
+    "stops insert pagination when the SDK returns $description",
+    async ({ pageToken, expectedPageTokens, expectedError }) => {
+      const pageTokens: Array<string | null> = [];
+      const server = createServer((request, response) => {
+        const url = new URL(request.url ?? "/", "http://127.0.0.1");
+        const sendJson = (body: unknown) => {
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end(JSON.stringify(body));
+        };
 
-      if (
-        request.method === "GET" &&
-        url.pathname === "/open-apis/docx/v1/documents/doc_loopback/blocks/after_loopback"
-      ) {
-        sendJson({
-          code: 0,
-          data: {
-            block: { block_id: "after_loopback", parent_id: "parent_loopback", block_type: 2 },
-          },
-        });
-        return;
-      }
-      if (
-        request.method === "GET" &&
-        url.pathname === "/open-apis/docx/v1/documents/doc_loopback/blocks/parent_loopback/children"
-      ) {
-        pageTokens.push(url.searchParams.get("page_token"));
-        if (pageTokens.length > 2) {
-          sendJson({ code: 1, msg: "unexpected third pagination request" });
+        if (
+          request.method === "GET" &&
+          url.pathname === "/open-apis/docx/v1/documents/doc_loopback/blocks/after_loopback"
+        ) {
+          sendJson({
+            code: 0,
+            data: {
+              block: { block_id: "after_loopback", parent_id: "parent_loopback", block_type: 2 },
+            },
+          });
           return;
         }
-        sendJson({
-          code: 0,
-          data: {
-            items: [{ block_id: "after_loopback", parent_id: "parent_loopback", block_type: 2 }],
-            has_more: true,
-            page_token: "repeated-token",
+        if (
+          request.method === "GET" &&
+          url.pathname ===
+            "/open-apis/docx/v1/documents/doc_loopback/blocks/parent_loopback/children"
+        ) {
+          pageTokens.push(url.searchParams.get("page_token"));
+          if (pageTokens.length > 2) {
+            sendJson({ code: 1, msg: "unexpected third pagination request" });
+            return;
+          }
+          sendJson({
+            code: 0,
+            data: {
+              items: [{ block_id: "after_loopback", parent_id: "parent_loopback", block_type: 2 }],
+              has_more: true,
+              ...(pageToken ? { page_token: pageToken } : {}),
+            },
+          });
+          return;
+        }
+        response.writeHead(404).end();
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+      });
+
+      try {
+        const address = server.address() as AddressInfo;
+        const loopbackHttp = Object.create(Lark.defaultHttpInstance) as Lark.HttpInstance;
+        loopbackHttp.request = async (options) => {
+          const upstream = new URL(options.url ?? "");
+          const target = new URL(
+            `${upstream.pathname}${upstream.search}`,
+            `http://127.0.0.1:${address.port}`,
+          );
+          for (const [key, value] of Object.entries(options.params ?? {})) {
+            if (value !== undefined && value !== null) {
+              target.searchParams.set(key, String(value));
+            }
+          }
+          const response = await fetch(target, { method: options.method ?? "GET" });
+          return response.json();
+        };
+        createFeishuClientMock.mockReturnValue(
+          new Lark.Client({
+            appId: "loopback-test-app",
+            appSecret: "loopback-test-placeholder", // pragma: allowlist secret
+            domain: Lark.Domain.Feishu,
+            loggerLevel: Lark.LoggerLevel.error,
+            disableTokenCache: true,
+            httpInstance: loopbackHttp,
+          }),
+        );
+
+        const harness = createToolFactoryHarness({
+          channels: {
+            feishu: { enabled: true, appId: "app_id", appSecret: "app_secret" },
           },
         });
-        return;
+        registerFeishuDocTools(harness.api);
+
+        const result = await harness.resolveTool("feishu_doc").execute("insert-document", {
+          action: "insert",
+          doc_token: "doc_loopback",
+          after_block_id: "after_loopback",
+          content: "Body content",
+        });
+
+        expect(result.details.error).toContain(expectedError);
+        expect(pageTokens).toEqual(expectedPageTokens);
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
       }
-      response.writeHead(404).end();
-    });
-
-    await new Promise<void>((resolve, reject) => {
-      server.once("error", reject);
-      server.listen(0, "127.0.0.1", resolve);
-    });
-
-    try {
-      const address = server.address() as AddressInfo;
-      const loopbackHttp = Object.create(Lark.defaultHttpInstance) as Lark.HttpInstance;
-      loopbackHttp.request = async (options) => {
-        const upstream = new URL(options.url ?? "");
-        const target = new URL(
-          `${upstream.pathname}${upstream.search}`,
-          `http://127.0.0.1:${address.port}`,
-        );
-        for (const [key, value] of Object.entries(options.params ?? {})) {
-          if (value !== undefined && value !== null) {
-            target.searchParams.set(key, String(value));
-          }
-        }
-        const response = await fetch(target, { method: options.method ?? "GET" });
-        return response.json();
-      };
-      createFeishuClientMock.mockReturnValue(
-        new Lark.Client({
-          appId: "loopback-test-app",
-          appSecret: "loopback-test-placeholder", // pragma: allowlist secret
-          domain: Lark.Domain.Feishu,
-          loggerLevel: Lark.LoggerLevel.error,
-          disableTokenCache: true,
-          httpInstance: loopbackHttp,
-        }),
-      );
-
-      const harness = createToolFactoryHarness({
-        channels: {
-          feishu: { enabled: true, appId: "app_id", appSecret: "app_secret" },
-        },
-      });
-      registerFeishuDocTools(harness.api);
-
-      const result = await harness.resolveTool("feishu_doc").execute("insert-document", {
-        action: "insert",
-        doc_token: "doc_loopback",
-        after_block_id: "after_loopback",
-        content: "Body content",
-      });
-
-      expect(result.details.error).toContain(
-        'Feishu document children pagination repeated token for parent block "parent_loopback"',
-      );
-      expect(pageTokens).toEqual([null, "repeated-token"]);
-    } finally {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
-  });
+    },
+  );
 });

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -884,9 +884,14 @@ async function insertDoc(
       throw new Error(childrenRes.msg);
     }
     items.push(...(childrenRes.data?.items ?? []));
-    const nextPageToken = childrenRes.data?.has_more ? childrenRes.data.page_token : undefined;
-    if (!nextPageToken) {
+    if (childrenRes.data?.has_more !== true) {
       break;
+    }
+    const nextPageToken = childrenRes.data.page_token?.trim();
+    if (!nextPageToken) {
+      throw new Error(
+        `Feishu document children pagination is missing its next page token for parent block "${parentId}"`,
+      );
     }
     if (seenPageTokens.has(nextPageToken)) {
       throw new Error(

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -874,7 +874,8 @@ async function insertDoc(
   // parents require multiple requests.
   const items: FeishuDocxBlock[] = [];
   let pageToken: string | undefined;
-  do {
+  const seenPageTokens = new Set<string>();
+  while (true) {
     const childrenRes = await client.docx.documentBlockChildren.get({
       path: { document_id: docToken, block_id: parentId },
       params: pageToken ? { page_token: pageToken } : {},
@@ -883,8 +884,18 @@ async function insertDoc(
       throw new Error(childrenRes.msg);
     }
     items.push(...(childrenRes.data?.items ?? []));
-    pageToken = childrenRes.data?.page_token ?? undefined;
-  } while (pageToken);
+    const nextPageToken = childrenRes.data?.has_more ? childrenRes.data.page_token : undefined;
+    if (!nextPageToken) {
+      break;
+    }
+    if (seenPageTokens.has(nextPageToken)) {
+      throw new Error(
+        `Feishu document children pagination repeated token for parent block "${parentId}"`,
+      );
+    }
+    seenPageTokens.add(nextPageToken);
+    pageToken = nextPageToken;
+  }
 
   const blockIndex = items.findIndex((item) => item.block_id === afterBlockId);
   if (blockIndex === -1) {


### PR DESCRIPTION
## What Problem This Solves

- Problem: `feishu_doc insert` followed document child `page_token` values without checking `has_more` or whether the continuation advanced. A repeated token could keep requesting and appending the same page indefinitely; `has_more: true` without a token could leave an incomplete sibling list.
- Why it matters: the insert action could hang or compute an insertion point from incomplete data instead of returning a visible failure when Feishu returned malformed pagination state.
- What changed: follow the documented `has_more` contract, require a nonempty continuation, track continuation tokens at the insert pagination owner, and fail before conversion or insertion on missing or repeated cursors.
- What did not change: document conversion, insertion ordering, and other Feishu document actions are unchanged.

Official contract: https://open.feishu.cn/document/ukTMukTMukTM/uUDN04SN0QjL1QDN/document-docx/docx-v1/document-block-children/get

## Evidence

Authoritative current exact head: \`29f797d2661a48cf188b1deafbb294f04de9c442\`.

- Parent-failure proof: the new real SDK + loopback regression failed before the fix after issuing a third request with the repeated cursor.
- Node v24.15.0: `node scripts/run-vitest.mjs extensions/feishu/src/docx-create-loopback.test.ts --reporter=verbose` (3 tests passed).
- The parameterized real-SDK loopback proof covers both a repeated cursor and `has_more: true` without a next cursor; neither reaches conversion or insertion.
- Targeted oxfmt, `git diff --check`, and type-aware oxlint passed.

## Repair doctrine

- Root cause: the document insert paginator treated any `page_token` as progress and did not enforce the `has_more` continuation contract.
- Architectural owner: `insertDoc` owns the complete sibling enumeration needed to calculate the insertion index.
- Canonical fix: require a nonempty trimmed continuation and enforce forward-only progress at that owner, matching the existing Feishu reaction pagination invariant.
- Removed paths: none.
- Production LOC delta: +19/-3; the growth records the pagination ownership invariant and returns operator-visible errors. Tests: +119/-1.
- Sibling coverage: Feishu reaction pagination already rejects missing and repeated tokens; the document insertion path now has equivalent protection.
- Observed behavior: a repeated cursor stops after two child-list requests, and a missing next cursor stops after one; neither reaches conversion or insertion.

## AI assistance

AI-assisted implementation and test authoring; all listed verification was run on the exact submitted tree.