### PR TITLE
fix(opencode): migrate retired free model refs

### DIFF
--- a/extensions/opencode/doctor-contract-api.test.ts
+++ b/extensions/opencode/doctor-contract-api.test.ts
@@ -227,7 +227,9 @@ describe("OpenCode doctor compatibility normalization", () => {
     const input = {
       tools: {
         media: {
-          image: { preferredModel: "hy3-free" },
+          image: { preferredModel: "opencode/hy3-free" },
+          audio: { preferredModel: "hy3-free" },
+          video: { preferredModel: "OPENCODE/HY3-FREE@work" },
           models: [
             {
               provider: " OpenCode ",
@@ -260,9 +262,13 @@ describe("OpenCode doctor compatibility normalization", () => {
       capabilities: ["image"],
     });
     expect(migrated.tools.media.models.slice(1)).toEqual(input.tools.media.models.slice(1));
-    expect(migrated.tools.media.image.preferredModel).toBe("hy3-free");
+    expect(migrated.tools.media.image.preferredModel).toBe(REPLACEMENT);
+    expect(migrated.tools.media.audio.preferredModel).toBe("hy3-free");
+    expect(migrated.tools.media.video.preferredModel).toBe(`${REPLACEMENT}@work`);
     expect(result.changes).toEqual([
       "Updated tools.media.models.0 to the current OpenCode Zen model.",
+      `Updated tools.media.image.preferredModel from the retired OpenCode Zen model to ${REPLACEMENT}.`,
+      `Updated tools.media.video.preferredModel from the retired OpenCode Zen model to ${REPLACEMENT}.`,
     ]);
   });
 

--- a/extensions/opencode/doctor-contract-api.test.ts
+++ b/extensions/opencode/doctor-contract-api.test.ts
@@ -1,0 +1,300 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it } from "vitest";
+import { normalizeCompatibilityConfig } from "./doctor-contract-api.js";
+
+const RETIRED = "opencode/hy3-free";
+const REPLACEMENT = "opencode/laguna-s-2.1-free";
+
+describe("OpenCode doctor compatibility normalization", () => {
+  it("repairs every canonical model surface and removes retired catalog rows", () => {
+    const input = {
+      unrelated: { preserved: true, apiKey: "must-not-appear" },
+      agents: {
+        defaults: {
+          model: {
+            primary: "OpenCode/HY3-FREE",
+            fallbacks: [`${RETIRED}@secret-profile`, "other/model", 42],
+          },
+          utilityModel: RETIRED,
+          imageModel: { primary: RETIRED },
+          voiceModel: RETIRED,
+          pdfModel: RETIRED,
+          mediaModels: {
+            image: RETIRED,
+            video: { primary: RETIRED, fallbacks: [RETIRED] },
+            music: RETIRED,
+          },
+          heartbeat: { model: RETIRED },
+          subagents: { model: { primary: RETIRED, fallbacks: [RETIRED] } },
+          compaction: { model: RETIRED, memoryFlush: { model: RETIRED } },
+          models: {
+            [RETIRED]: { alias: "retired" },
+            [REPLACEMENT]: { alias: "canonical" },
+            "other/model": { alias: "other" },
+          },
+          modelPolicy: { allow: [RETIRED, "opencode/*", "alias"] },
+        },
+        entries: {
+          worker: {
+            model: RETIRED,
+            models: { [`${RETIRED}@work`]: { alias: "profiled" } },
+            modelPolicy: { allow: [`${RETIRED}@work`] },
+            tools: { exec: { reviewer: { model: RETIRED } } },
+            tts: { summaryModel: RETIRED },
+          },
+        },
+        list: [
+          {
+            id: "shadow",
+            model: RETIRED,
+            modelPolicy: { allow: [RETIRED] },
+            tools: { exec: { reviewer: { model: RETIRED } } },
+            tts: { summaryModel: RETIRED },
+          },
+        ],
+      },
+      tools: { exec: { reviewer: { model: RETIRED } } },
+      hooks: {
+        mappings: [{ model: RETIRED }],
+        gmail: { model: RETIRED },
+      },
+      tts: { summaryModel: RETIRED },
+      channels: {
+        modelByChannel: { discord: { guild: RETIRED } },
+        discord: {
+          voice: { model: RETIRED, tts: { summaryModel: RETIRED } },
+          accounts: {
+            work: { voice: { model: RETIRED, tts: { summaryModel: RETIRED } } },
+          },
+        },
+      },
+      models: {
+        providers: {
+          opencode: {
+            models: [
+              { id: "HY3-FREE", name: "retired" },
+              { id: "laguna-s-2.1-free", name: "canonical" },
+              { id: "custom", name: "custom" },
+              "malformed",
+            ],
+          },
+        },
+      },
+    };
+    const original = structuredClone(input);
+
+    const first = normalizeCompatibilityConfig({
+      cfg: input as unknown as OpenClawConfig,
+    });
+    const migrated = first.config as unknown as typeof input;
+
+    expect(input).toEqual(original);
+    expect(migrated.unrelated).toEqual(input.unrelated);
+    expect(migrated.agents.defaults.model).toEqual({
+      primary: REPLACEMENT,
+      fallbacks: [`${REPLACEMENT}@secret-profile`, "other/model", 42],
+    });
+    expect([
+      migrated.agents.defaults.utilityModel,
+      migrated.agents.defaults.imageModel.primary,
+      migrated.agents.defaults.voiceModel,
+      migrated.agents.defaults.pdfModel,
+      migrated.agents.defaults.mediaModels.image,
+      migrated.agents.defaults.mediaModels.video.primary,
+      migrated.agents.defaults.mediaModels.video.fallbacks[0],
+      migrated.agents.defaults.mediaModels.music,
+      migrated.agents.defaults.heartbeat.model,
+      migrated.agents.defaults.subagents.model.primary,
+      migrated.agents.defaults.subagents.model.fallbacks[0],
+      migrated.agents.defaults.compaction.model,
+      migrated.agents.defaults.compaction.memoryFlush.model,
+      migrated.agents.entries.worker.model,
+      migrated.hooks.mappings[0]?.model,
+      migrated.hooks.gmail.model,
+      migrated.tts.summaryModel,
+      migrated.channels.modelByChannel.discord.guild,
+      migrated.channels.discord.voice.model,
+      migrated.channels.discord.voice.tts.summaryModel,
+      migrated.channels.discord.accounts.work.voice.model,
+      migrated.channels.discord.accounts.work.voice.tts.summaryModel,
+      migrated.tools.exec.reviewer.model,
+      migrated.agents.entries.worker.tools.exec.reviewer.model,
+      migrated.agents.entries.worker.tts.summaryModel,
+    ]).toEqual(Array.from({ length: 25 }, () => REPLACEMENT));
+    expect(migrated.agents.defaults.models).toEqual({
+      [REPLACEMENT]: { alias: "canonical" },
+      "other/model": { alias: "other" },
+    });
+    expect(migrated.agents.defaults.modelPolicy.allow).toEqual([
+      REPLACEMENT,
+      "opencode/*",
+      "alias",
+    ]);
+    expect(migrated.agents.entries.worker.models).toEqual({
+      [`${REPLACEMENT}@work`]: { alias: "profiled" },
+    });
+    expect(migrated.agents.entries.worker.modelPolicy.allow).toEqual([`${REPLACEMENT}@work`]);
+    expect(migrated.agents.list).toEqual(input.agents.list);
+    expect(migrated.models.providers.opencode.models).toEqual([
+      { id: "laguna-s-2.1-free", name: "canonical" },
+      { id: "custom", name: "custom" },
+      "malformed",
+    ]);
+    expect(first.changes).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("agents.defaults.model.primary"),
+        expect.stringContaining("agents.defaults.modelPolicy.allow.0"),
+        expect.stringContaining("agents.entries.worker.models"),
+        expect.stringContaining("channels.discord.voice.model"),
+        expect.stringContaining("models.providers.opencode.models"),
+      ]),
+    );
+    expect(first.changes.join("\n")).not.toContain("secret-profile");
+    expect(first.changes.join("\n")).not.toContain("must-not-appear");
+
+    const second = normalizeCompatibilityConfig({ cfg: first.config });
+    expect(second).toEqual({ config: first.config, changes: [] });
+    expect(second.config).toBe(first.config);
+  });
+
+  it("uses the legacy list only when keyed entries are absent", () => {
+    const legacy = {
+      agents: {
+        list: [
+          {
+            id: "legacy",
+            model: RETIRED,
+            modelPolicy: { allow: [RETIRED] },
+            tools: { exec: { reviewer: { model: RETIRED } } },
+            tts: { summaryModel: RETIRED },
+          },
+        ],
+      },
+    };
+
+    const result = normalizeCompatibilityConfig({
+      cfg: legacy as unknown as OpenClawConfig,
+    }).config as unknown as typeof legacy;
+
+    expect(result.agents.list[0]).toEqual({
+      id: "legacy",
+      model: REPLACEMENT,
+      modelPolicy: { allow: [REPLACEMENT] },
+      tools: { exec: { reviewer: { model: REPLACEMENT } } },
+      tts: { summaryModel: REPLACEMENT },
+    });
+    expect(legacy.agents.list[0]?.model).toBe(RETIRED);
+  });
+
+  it("never rewrites a shadow list when entries exists", () => {
+    const input = {
+      agents: {
+        entries: {},
+        list: [{ id: "shadow", model: RETIRED, modelPolicy: { allow: [RETIRED] } }],
+      },
+    };
+
+    const result = normalizeCompatibilityConfig({
+      cfg: input as unknown as OpenClawConfig,
+    });
+
+    expect(result).toEqual({ config: input, changes: [] });
+    expect(result.config).toBe(input);
+  });
+
+  it("never rewrites a shadow list when entries is null", () => {
+    const input = {
+      agents: {
+        entries: null,
+        list: [
+          {
+            id: "shadow",
+            model: RETIRED,
+            tools: { exec: { reviewer: { model: RETIRED } } },
+            tts: { summaryModel: RETIRED },
+          },
+        ],
+      },
+    };
+
+    expect(normalizeCompatibilityConfig({ cfg: input as unknown as OpenClawConfig })).toEqual({
+      config: input,
+      changes: [],
+    });
+  });
+
+  it("repairs only structured OpenCode provider media entries", () => {
+    const input = {
+      tools: {
+        media: {
+          image: { preferredModel: "hy3-free" },
+          models: [
+            {
+              provider: " OpenCode ",
+              model: " HY3-FREE ",
+              profile: "work",
+              capabilities: ["image"],
+            },
+            { type: "cli", provider: "opencode", model: "hy3-free", command: "opencode" },
+            { provider: "opencode", model: "hy3-free", command: "opencode" },
+            { provider: "other", model: "hy3-free" },
+            { provider: "opencode", model: "opencode/hy3-free" },
+            { provider: "opencode", model: "hy3-free@work" },
+            "malformed",
+          ],
+        },
+      },
+    };
+    const original = structuredClone(input);
+
+    const result = normalizeCompatibilityConfig({
+      cfg: input as unknown as OpenClawConfig,
+    });
+    const migrated = result.config as unknown as typeof input;
+
+    expect(input).toEqual(original);
+    expect(migrated.tools.media.models[0]).toEqual({
+      provider: "opencode",
+      model: "laguna-s-2.1-free",
+      profile: "work",
+      capabilities: ["image"],
+    });
+    expect(migrated.tools.media.models.slice(1)).toEqual(input.tools.media.models.slice(1));
+    expect(migrated.tools.media.image.preferredModel).toBe("hy3-free");
+    expect(result.changes).toEqual([
+      "Updated tools.media.models.0 to the current OpenCode Zen model.",
+    ]);
+  });
+
+  it.each([
+    "hy3-free",
+    "opencode-go/hy3",
+    "opencode/*",
+    "prefix opencode/hy3-free suffix",
+    "opencode/hy3-free@",
+    "opencode/hy3-free@profile/with/slash",
+  ])("does not rewrite non-exact ref %s", (model) => {
+    const input = { agents: { defaults: { model } } };
+    const result = normalizeCompatibilityConfig({ cfg: input as OpenClawConfig });
+
+    expect(result).toEqual({ config: input, changes: [] });
+    expect(result.config).toBe(input);
+  });
+
+  it("ignores non-string and malformed selector values", () => {
+    const input = {
+      agents: {
+        defaults: {
+          model: { primary: 42, fallbacks: [null, { model: RETIRED }] },
+          modelPolicy: { allow: [42, null] },
+          models: [RETIRED],
+        },
+      },
+    };
+    const result = normalizeCompatibilityConfig({
+      cfg: input as unknown as OpenClawConfig,
+    });
+
+    expect(result).toEqual({ config: input, changes: [] });
+  });
+});

--- a/extensions/opencode/doctor-contract-api.ts
+++ b/extensions/opencode/doctor-contract-api.ts
@@ -1,0 +1,273 @@
+// OpenCode doctor contract repairs the retired Zen free-model reference shipped in beta.3.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { normalizeProviderId, parseModelRef } from "openclaw/plugin-sdk/model-ref-parse";
+import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor-migrations";
+
+const RETIRED_MODEL = "hy3-free";
+const REPLACEMENT_MODEL = "laguna-s-2.1-free";
+const REPLACEMENT_REF = `opencode/${REPLACEMENT_MODEL}`;
+const AGENT_MODEL_KEYS = ["model", "utilityModel", "imageModel", "voiceModel", "pdfModel"] as const;
+
+function replacementFor(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  const slash = trimmed.indexOf("/");
+  const suffixAt = trimmed.indexOf("@", slash + 1);
+  const suffix = suffixAt >= 0 ? trimmed.slice(suffixAt) : "";
+  if (suffix === "@" || suffix.includes("/")) {
+    return undefined;
+  }
+  const parsed = parseModelRef(suffixAt >= 0 ? trimmed.slice(0, suffixAt) : trimmed, "");
+  if (
+    parsed?.provider.toLowerCase() !== "opencode" ||
+    parsed.model.toLowerCase() !== RETIRED_MODEL
+  ) {
+    return undefined;
+  }
+  return `${REPLACEMENT_REF}${suffix}`;
+}
+
+function rewriteString(
+  owner: Record<string, unknown> | null,
+  key: string,
+  path: string,
+  changes: string[],
+): void {
+  if (!owner) {
+    return;
+  }
+  const replacement = replacementFor(owner[key]);
+  if (!replacement) {
+    return;
+  }
+  owner[key] = replacement;
+  changes.push(`Updated ${path} from the retired OpenCode Zen model to ${REPLACEMENT_REF}.`);
+}
+
+function rewriteSelector(
+  owner: Record<string, unknown> | null,
+  key: string,
+  path: string,
+  changes: string[],
+): void {
+  if (!owner) {
+    return;
+  }
+  if (typeof owner[key] === "string") {
+    rewriteString(owner, key, path, changes);
+    return;
+  }
+  const selector = asObjectRecord(owner[key]);
+  if (!selector) {
+    return;
+  }
+  rewriteString(selector, "primary", `${path}.primary`, changes);
+  if (!Array.isArray(selector.fallbacks)) {
+    return;
+  }
+  rewriteStringList(selector.fallbacks, `${path}.fallbacks`, changes);
+}
+
+function rewriteStringList(values: unknown[], path: string, changes: string[]): void {
+  for (const [index, value] of values.entries()) {
+    const replacement = replacementFor(value);
+    if (!replacement) {
+      continue;
+    }
+    values[index] = replacement;
+    changes.push(
+      `Updated ${path}.${index} from the retired OpenCode Zen model to ${REPLACEMENT_REF}.`,
+    );
+  }
+}
+
+function rewriteModelMap(agent: Record<string, unknown>, path: string, changes: string[]): void {
+  const models = asObjectRecord(agent.models);
+  if (!models) {
+    return;
+  }
+  for (const [modelRef, config] of Object.entries(models)) {
+    const replacement = replacementFor(modelRef);
+    if (!replacement) {
+      continue;
+    }
+    if (!Object.hasOwn(models, replacement)) {
+      models[replacement] = config;
+    }
+    delete models[modelRef];
+    changes.push(`Updated a retired OpenCode Zen model key in ${path} to ${REPLACEMENT_REF}.`);
+  }
+}
+
+function rewriteExecReviewer(
+  owner: Record<string, unknown>,
+  path: string,
+  changes: string[],
+): void {
+  const exec = asObjectRecord(asObjectRecord(owner.tools)?.exec);
+  rewriteSelector(asObjectRecord(exec?.reviewer), "model", path, changes);
+}
+
+function rewriteDiscordVoice(value: unknown, path: string, changes: string[]): void {
+  const voice = asObjectRecord(value);
+  rewriteString(voice, "model", `${path}.model`, changes);
+  rewriteString(asObjectRecord(voice?.tts), "summaryModel", `${path}.tts.summaryModel`, changes);
+}
+
+function rewriteStructuredMediaModels(root: Record<string, unknown>, changes: string[]): void {
+  const models = asObjectRecord(asObjectRecord(root.tools)?.media)?.models;
+  if (!Array.isArray(models)) {
+    return;
+  }
+  for (const [index, value] of models.entries()) {
+    const entry = asObjectRecord(value);
+    if (
+      !entry ||
+      entry.type === "cli" ||
+      (typeof entry.command === "string" && entry.command.trim()) ||
+      typeof entry.provider !== "string" ||
+      normalizeProviderId(entry.provider) !== "opencode" ||
+      typeof entry.model !== "string" ||
+      entry.model.trim().toLowerCase() !== RETIRED_MODEL
+    ) {
+      continue;
+    }
+    entry.provider = "opencode";
+    entry.model = REPLACEMENT_MODEL;
+    changes.push(`Updated tools.media.models.${index} to the current OpenCode Zen model.`);
+  }
+}
+
+function rewriteAgent(
+  value: unknown,
+  path: string,
+  changes: string[],
+  includeEntrySelectors = false,
+): void {
+  const agent = asObjectRecord(value);
+  if (!agent) {
+    return;
+  }
+  for (const key of AGENT_MODEL_KEYS) {
+    rewriteSelector(agent, key, `${path}.${key}`, changes);
+  }
+  const mediaModels = asObjectRecord(agent.mediaModels);
+  for (const capability of ["image", "video", "music"] as const) {
+    rewriteSelector(mediaModels, capability, `${path}.mediaModels.${capability}`, changes);
+  }
+  rewriteString(asObjectRecord(agent.heartbeat), "model", `${path}.heartbeat.model`, changes);
+  rewriteSelector(asObjectRecord(agent.subagents), "model", `${path}.subagents.model`, changes);
+  const compaction = asObjectRecord(agent.compaction);
+  rewriteString(compaction, "model", `${path}.compaction.model`, changes);
+  rewriteString(
+    asObjectRecord(compaction?.memoryFlush),
+    "model",
+    `${path}.compaction.memoryFlush.model`,
+    changes,
+  );
+  rewriteModelMap(agent, `${path}.models`, changes);
+  const allow = asObjectRecord(agent.modelPolicy)?.allow;
+  if (Array.isArray(allow)) {
+    rewriteStringList(allow, `${path}.modelPolicy.allow`, changes);
+  }
+  if (includeEntrySelectors) {
+    rewriteExecReviewer(agent, `${path}.tools.exec.reviewer.model`, changes);
+    rewriteString(asObjectRecord(agent.tts), "summaryModel", `${path}.tts.summaryModel`, changes);
+  }
+}
+
+function rewriteNonAgentRefs(root: Record<string, unknown>, changes: string[]): void {
+  rewriteExecReviewer(root, "tools.exec.reviewer.model", changes);
+  rewriteStructuredMediaModels(root, changes);
+  const channels = asObjectRecord(root.channels);
+  const modelByChannel = asObjectRecord(channels?.modelByChannel);
+  if (modelByChannel) {
+    for (const [channelId, targetsValue] of Object.entries(modelByChannel)) {
+      const targets = asObjectRecord(targetsValue);
+      if (!targets) {
+        continue;
+      }
+      for (const targetId of Object.keys(targets)) {
+        rewriteString(
+          targets,
+          targetId,
+          `channels.modelByChannel.${channelId}.${targetId}`,
+          changes,
+        );
+      }
+    }
+  }
+  const discord = asObjectRecord(channels?.discord);
+  rewriteDiscordVoice(discord?.voice, "channels.discord.voice", changes);
+  const accounts = asObjectRecord(discord?.accounts);
+  if (accounts) {
+    for (const [accountId, account] of Object.entries(accounts)) {
+      rewriteDiscordVoice(
+        asObjectRecord(account)?.voice,
+        `channels.discord.accounts.${accountId}.voice`,
+        changes,
+      );
+    }
+  }
+
+  const hooks = asObjectRecord(root.hooks);
+  if (Array.isArray(hooks?.mappings)) {
+    for (const [index, mapping] of hooks.mappings.entries()) {
+      rewriteString(asObjectRecord(mapping), "model", `hooks.mappings.${index}.model`, changes);
+    }
+  }
+  rewriteString(asObjectRecord(hooks?.gmail), "model", "hooks.gmail.model", changes);
+  rewriteString(asObjectRecord(root.tts), "summaryModel", "tts.summaryModel", changes);
+}
+
+function removeRetiredCatalogRows(root: Record<string, unknown>, changes: string[]): void {
+  const provider = asObjectRecord(asObjectRecord(asObjectRecord(root.models)?.providers)?.opencode);
+  if (!provider || !Array.isArray(provider.models)) {
+    return;
+  }
+  const retained = provider.models.filter((row) => {
+    const id = asObjectRecord(row)?.id;
+    return typeof id !== "string" || id.trim().toLowerCase() !== RETIRED_MODEL;
+  });
+  const removed = provider.models.length - retained.length;
+  if (removed > 0) {
+    provider.models = retained;
+    changes.push(
+      `Removed ${removed} retired OpenCode Zen model row(s) from models.providers.opencode.models.`,
+    );
+  }
+}
+
+export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): {
+  config: OpenClawConfig;
+  changes: string[];
+} {
+  const next = structuredClone(cfg);
+  const root = asObjectRecord(next);
+  if (!root) {
+    return { config: cfg, changes: [] };
+  }
+  const changes: string[] = [];
+  const agents = asObjectRecord(root.agents);
+  if (agents) {
+    rewriteAgent(agents.defaults, "agents.defaults", changes);
+    // Keyed entries own the roster whenever present; the legacy list is only a fallback.
+    if (Object.hasOwn(agents, "entries")) {
+      const entries = asObjectRecord(agents.entries);
+      if (entries) {
+        for (const [agentId, entry] of Object.entries(entries)) {
+          rewriteAgent(entry, `agents.entries.${agentId}`, changes, true);
+        }
+      }
+    } else if (Array.isArray(agents.list)) {
+      for (const [index, entry] of agents.list.entries()) {
+        rewriteAgent(entry, `agents.list.${index}`, changes, true);
+      }
+    }
+  }
+  rewriteNonAgentRefs(root, changes);
+  removeRetiredCatalogRows(root, changes);
+  return changes.length > 0 ? { config: next, changes } : { config: cfg, changes };
+}

--- a/extensions/opencode/doctor-contract-api.ts
+++ b/extensions/opencode/doctor-contract-api.ts
@@ -181,6 +181,15 @@ function rewriteAgent(
 function rewriteNonAgentRefs(root: Record<string, unknown>, changes: string[]): void {
   rewriteExecReviewer(root, "tools.exec.reviewer.model", changes);
   rewriteStructuredMediaModels(root, changes);
+  const media = asObjectRecord(asObjectRecord(root.tools)?.media);
+  for (const capability of ["image", "audio", "video"] as const) {
+    rewriteString(
+      asObjectRecord(media?.[capability]),
+      "preferredModel",
+      `tools.media.${capability}.preferredModel`,
+      changes,
+    );
+  }
   const channels = asObjectRecord(root.channels);
   const modelByChannel = asObjectRecord(channels?.modelByChannel);
   if (modelByChannel) {

--- a/extensions/opencode/openclaw.plugin.json
+++ b/extensions/opencode/openclaw.plugin.json
@@ -1,6 +1,9 @@
 {
   "id": "opencode",
   "icon": "https://cdn.simpleicons.org/opencode",
+  "doctorContract": {
+    "configRepair": true
+  },
   "activation": {
     "onStartup": true
   },

--- a/packages/model-catalog-core/src/configured-model-refs.test.ts
+++ b/packages/model-catalog-core/src/configured-model-refs.test.ts
@@ -130,6 +130,32 @@ describe("configured model refs", () => {
       ],
     },
     {
+      name: "media preferences",
+      config: {
+        tools: {
+          media: {
+            image: { preferredModel: "image-provider/model" },
+            audio: { preferredModel: "audio-provider/model" },
+            video: { preferredModel: "video-provider/model" },
+          },
+        },
+      },
+      expected: [
+        {
+          path: "tools.media.image.preferredModel",
+          value: "image-provider/model",
+        },
+        {
+          path: "tools.media.audio.preferredModel",
+          value: "audio-provider/model",
+        },
+        {
+          path: "tools.media.video.preferredModel",
+          value: "video-provider/model",
+        },
+      ],
+    },
+    {
       name: "keyed agent exec reviewer",
       config: {
         agents: {

--- a/packages/model-catalog-core/src/configured-model-refs.test.ts
+++ b/packages/model-catalog-core/src/configured-model-refs.test.ts
@@ -70,11 +70,14 @@ describe("configured model refs", () => {
       collectConfiguredModelRefValues(
         {
           agents: { defaults: { model: "openai/gpt-5.5" } },
-          channels: { modelByChannel: { discord: { guild: "anthropic/claude-sonnet-4-6" } } },
+          channels: {
+            modelByChannel: { discord: { guild: "anthropic/claude-sonnet-4-6" } },
+            discord: { voice: { tts: { summaryModel: "discord-tts/model" } } },
+          },
         },
         { includeChannelModelOverrides: false },
       ),
-    ).toEqual(["openai/gpt-5.5"]);
+    ).toEqual(["openai/gpt-5.5", "discord-tts/model"]);
   });
 
   it("preserves legacy list indices when collecting agent model refs", () => {
@@ -102,6 +105,128 @@ describe("configured model refs", () => {
         },
       }),
     ).toEqual([{ path: "agents.entries.ops.model", value: "openai/gpt-5.6" }]);
+  });
+
+  it.each([
+    {
+      name: "global exec reviewer string",
+      config: { tools: { exec: { reviewer: { model: "global-review/model" } } } },
+      expected: [{ path: "tools.exec.reviewer.model", value: "global-review/model" }],
+    },
+    {
+      name: "global exec reviewer selector",
+      config: {
+        tools: {
+          exec: {
+            reviewer: {
+              model: { primary: "global-primary/model", fallbacks: ["global-fallback/model"] },
+            },
+          },
+        },
+      },
+      expected: [
+        { path: "tools.exec.reviewer.model.primary", value: "global-primary/model" },
+        { path: "tools.exec.reviewer.model.fallbacks.0", value: "global-fallback/model" },
+      ],
+    },
+    {
+      name: "keyed agent exec reviewer",
+      config: {
+        agents: {
+          entries: {
+            worker: {
+              tools: {
+                exec: {
+                  reviewer: {
+                    model: {
+                      primary: "entry-review-primary/model",
+                      fallbacks: ["entry-review-fallback/model"],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      expected: [
+        {
+          path: "agents.entries.worker.tools.exec.reviewer.model.primary",
+          value: "entry-review-primary/model",
+        },
+        {
+          path: "agents.entries.worker.tools.exec.reviewer.model.fallbacks.0",
+          value: "entry-review-fallback/model",
+        },
+      ],
+    },
+    {
+      name: "legacy agent exec reviewer",
+      config: {
+        agents: {
+          list: [{ id: "worker", tools: { exec: { reviewer: { model: "list-review/model" } } } }],
+        },
+      },
+      expected: [{ path: "agents.list.0.tools.exec.reviewer.model", value: "list-review/model" }],
+    },
+    {
+      name: "keyed agent TTS summary",
+      config: { agents: { entries: { worker: { tts: { summaryModel: "entry-tts/model" } } } } },
+      expected: [{ path: "agents.entries.worker.tts.summaryModel", value: "entry-tts/model" }],
+    },
+    {
+      name: "legacy agent TTS summary",
+      config: { agents: { list: [{ id: "worker", tts: { summaryModel: "list-tts/model" } }] } },
+      expected: [{ path: "agents.list.0.tts.summaryModel", value: "list-tts/model" }],
+    },
+    {
+      name: "Discord root voice model",
+      config: { channels: { discord: { voice: { model: "discord-voice/model" } } } },
+      expected: [{ path: "channels.discord.voice.model", value: "discord-voice/model" }],
+    },
+    {
+      name: "Discord root voice TTS summary",
+      config: { channels: { discord: { voice: { tts: { summaryModel: "discord-tts/model" } } } } },
+      expected: [{ path: "channels.discord.voice.tts.summaryModel", value: "discord-tts/model" }],
+    },
+    {
+      name: "Discord account voice model",
+      config: {
+        channels: { discord: { accounts: { work: { voice: { model: "account-voice/model" } } } } },
+      },
+      expected: [
+        { path: "channels.discord.accounts.work.voice.model", value: "account-voice/model" },
+      ],
+    },
+    {
+      name: "Discord account voice TTS summary",
+      config: {
+        channels: {
+          discord: {
+            accounts: { work: { voice: { tts: { summaryModel: "account-tts/model" } } } },
+          },
+        },
+      },
+      expected: [
+        {
+          path: "channels.discord.accounts.work.voice.tts.summaryModel",
+          value: "account-tts/model",
+        },
+      ],
+    },
+  ])("collects $name", ({ config, expected }) => {
+    expect(collectConfiguredModelRefs(config)).toEqual(expected);
+  });
+
+  it.each([{}, null])("does not inspect a shadow list when entries is %j", (entries) => {
+    expect(
+      collectConfiguredModelRefs({
+        agents: {
+          entries,
+          list: [{ id: "shadow", tools: { exec: { reviewer: { model: "shadow/model" } } } }],
+        },
+      }),
+    ).toEqual([]);
   });
 
   it("ignores array-shaped malformed records", () => {

--- a/packages/model-catalog-core/src/configured-model-refs.ts
+++ b/packages/model-catalog-core/src/configured-model-refs.ts
@@ -38,7 +38,7 @@ export function listModelRefsFromConfigValue(value: unknown): string[] {
   return refs;
 }
 
-/** Collect configured model references from agents, channels, hooks, and message config. */
+/** Collect configured model references from agents, tools, channels, hooks, and message config. */
 export function collectConfiguredModelRefs(
   config: unknown,
   options: { includeChannelModelOverrides?: boolean } = {},
@@ -64,7 +64,7 @@ export function collectConfiguredModelRefs(
       }
     }
   };
-  const collectFromAgent = (path: string, agent: unknown) => {
+  const collectFromAgent = (path: string, agent: unknown, includeEntrySelectors = false) => {
     if (!isRecord(agent)) {
       return;
     }
@@ -95,18 +95,38 @@ export function collectConfiguredModelRefs(
         pushModelRef(`${path}.models.${modelRef}`, modelRef);
       }
     }
+    if (includeEntrySelectors) {
+      const tools = isRecord(agent.tools) ? agent.tools : {};
+      const exec = isRecord(tools.exec) ? tools.exec : {};
+      collectModelConfig(
+        `${path}.tools.exec.reviewer.model`,
+        isRecord(exec.reviewer) ? exec.reviewer.model : undefined,
+      );
+      pushModelRef(
+        `${path}.tts.summaryModel`,
+        isRecord(agent.tts) ? agent.tts.summaryModel : undefined,
+      );
+    }
   };
 
   const root = isRecord(config) ? config : {};
+  const tools = isRecord(root.tools) ? root.tools : {};
+  const exec = isRecord(tools.exec) ? tools.exec : {};
+  collectModelConfig(
+    "tools.exec.reviewer.model",
+    isRecord(exec.reviewer) ? exec.reviewer.model : undefined,
+  );
   const agents = isRecord(root.agents) ? root.agents : {};
   collectFromAgent("agents.defaults", agents.defaults);
-  if (isRecord(agents.entries)) {
-    for (const [agentId, entry] of Object.entries(agents.entries)) {
-      collectFromAgent(`agents.entries.${agentId}`, entry);
+  if (Object.hasOwn(agents, "entries")) {
+    if (isRecord(agents.entries)) {
+      for (const [agentId, entry] of Object.entries(agents.entries)) {
+        collectFromAgent(`agents.entries.${agentId}`, entry, true);
+      }
     }
   } else if (Array.isArray(agents.list)) {
     for (const [index, entry] of agents.list.entries()) {
-      collectFromAgent(`agents.list.${index}`, entry);
+      collectFromAgent(`agents.list.${index}`, entry, true);
     }
   }
   if (options.includeChannelModelOverrides !== false) {
@@ -129,14 +149,25 @@ export function collectConfiguredModelRefs(
   }
   pushModelRef("hooks.gmail.model", isRecord(hooks.gmail) ? hooks.gmail.model : undefined);
   pushModelRef("tts.summaryModel", isRecord(root.tts) ? root.tts.summaryModel : undefined);
-  pushModelRef(
-    "channels.discord.voice.model",
-    isRecord(root.channels) &&
-      isRecord(root.channels.discord) &&
-      isRecord(root.channels.discord.voice)
-      ? root.channels.discord.voice.model
-      : undefined,
-  );
+  const discord =
+    isRecord(root.channels) && isRecord(root.channels.discord) ? root.channels.discord : {};
+  const collectDiscordVoice = (path: string, value: unknown) => {
+    const voice = isRecord(value) ? value : {};
+    pushModelRef(`${path}.model`, voice.model);
+    pushModelRef(
+      `${path}.tts.summaryModel`,
+      isRecord(voice.tts) ? voice.tts.summaryModel : undefined,
+    );
+  };
+  collectDiscordVoice("channels.discord.voice", discord.voice);
+  if (isRecord(discord.accounts)) {
+    for (const [accountId, account] of Object.entries(discord.accounts)) {
+      collectDiscordVoice(
+        `channels.discord.accounts.${accountId}.voice`,
+        isRecord(account) ? account.voice : undefined,
+      );
+    }
+  }
   return refs;
 }
 

--- a/packages/model-catalog-core/src/configured-model-refs.ts
+++ b/packages/model-catalog-core/src/configured-model-refs.ts
@@ -116,6 +116,13 @@ export function collectConfiguredModelRefs(
     "tools.exec.reviewer.model",
     isRecord(exec.reviewer) ? exec.reviewer.model : undefined,
   );
+  const media = isRecord(tools.media) ? tools.media : {};
+  for (const capability of ["image", "audio", "video"] as const) {
+    pushModelRef(
+      `tools.media.${capability}.preferredModel`,
+      isRecord(media[capability]) ? media[capability].preferredModel : undefined,
+    );
+  }
   const agents = isRecord(root.agents) ? root.agents : {};
   collectFromAgent("agents.defaults", agents.defaults);
   if (Object.hasOwn(agents, "entries")) {

--- a/src/commands/doctor/shared/legacy-config-migrate.e2e.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.e2e.test.ts
@@ -195,4 +195,34 @@ describe("legacy config migration end to end", () => {
     expect(validateConfigObjectRaw(result.config).ok).toBe(true);
     expect(applyLegacyDoctorMigrations(result.config)).toEqual({ next: null, changes: [] });
   });
+
+  it("loads the OpenCode doctor contract from an exec reviewer fallback", () => {
+    const raw = {
+      tools: {
+        exec: {
+          reviewer: { model: { fallbacks: ["opencode/hy3-free@work"] } },
+        },
+      },
+    };
+    const applied = applyLegacyDoctorMigrations(raw);
+
+    expect(applied.next?.tools).toEqual({
+      exec: {
+        reviewer: { model: { fallbacks: ["opencode/laguna-s-2.1-free@work"] } },
+      },
+    });
+    const result = migrateLegacyConfig(raw);
+
+    expect(result.partiallyValid).toBeUndefined();
+    expect(result.config?.tools?.exec?.reviewer?.model).toEqual({
+      fallbacks: ["opencode/laguna-s-2.1-free@work"],
+    });
+    expect(result.changes).toContain(
+      "Updated tools.exec.reviewer.model.fallbacks.0 from the retired OpenCode Zen model to opencode/laguna-s-2.1-free.",
+    );
+    const validation = validateConfigObjectRaw(result.config);
+    expect(validation.ok, validation.ok ? undefined : JSON.stringify(validation.issues)).toBe(true);
+    expect(applyLegacyDoctorMigrations(result.config)).toEqual({ next: null, changes: [] });
+    expect(migrateLegacyConfig(result.config)).toEqual({ config: null, changes: [] });
+  });
 });

--- a/src/commands/doctor/shared/legacy-config-migrate.e2e.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.e2e.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { validateConfigObjectRaw } from "../../../config/validation.js";
+import { resolveModelEntries } from "../../../media-understanding/resolve.js";
 import { applyLegacyDoctorMigrations } from "./legacy-config-compat.js";
 import { migrateLegacyConfig } from "./legacy-config-migrate.js";
 
@@ -223,6 +224,37 @@ describe("legacy config migration end to end", () => {
     const validation = validateConfigObjectRaw(result.config);
     expect(validation.ok, validation.ok ? undefined : JSON.stringify(validation.issues)).toBe(true);
     expect(applyLegacyDoctorMigrations(result.config)).toEqual({ next: null, changes: [] });
+    expect(migrateLegacyConfig(result.config)).toEqual({ config: null, changes: [] });
+  });
+
+  it("keeps a repaired OpenCode media preference selected", () => {
+    const result = migrateLegacyConfig({
+      tools: {
+        media: {
+          image: { preferredModel: "opencode/hy3-free" },
+          models: [
+            { provider: "other", model: "alternative", capabilities: ["image"] },
+            { provider: "opencode", model: "hy3-free", capabilities: ["image"] },
+          ],
+        },
+      },
+    });
+
+    expect(result.config?.tools?.media?.image?.preferredModel).toBe("opencode/laguna-s-2.1-free");
+    const entries = resolveModelEntries({
+      cfg: result.config ?? {},
+      capability: "image",
+      config: result.config?.tools?.media?.image,
+      providerRegistry: new Map([
+        ["opencode", { capabilities: ["image"] }],
+        ["other", { capabilities: ["image"] }],
+      ]),
+    });
+    expect(entries[0]?.entry).toMatchObject({
+      provider: "opencode",
+      model: "laguna-s-2.1-free",
+    });
+    expect(validateConfigObjectRaw(result.config).ok).toBe(true);
     expect(migrateLegacyConfig(result.config)).toEqual({ config: null, changes: [] });
   });
 });

--- a/src/plugins/doctor-contract-registry.test.ts
+++ b/src/plugins/doctor-contract-registry.test.ts
@@ -814,7 +814,7 @@ describe("doctor-contract-registry module loader", () => {
     });
   });
 
-  it("loads a provider doctor contract when a configured model ref is its only activation", () => {
+  it("loads a provider doctor contract when a media preference is its only activation", () => {
     const pluginRoot = makeTempDir();
     fs.writeFileSync(path.join(pluginRoot, "doctor-contract-api.ts"), "export {};\n", "utf-8");
     mocks.createJiti.mockImplementation(() => () => ({
@@ -835,7 +835,9 @@ describe("doctor-contract-registry module loader", () => {
       ],
       diagnostics: [],
     });
-    const config = { agents: { defaults: { model: "opencode/hy3-free" } } };
+    const config = {
+      tools: { media: { image: { preferredModel: "opencode/hy3-free" } } },
+    };
     const pluginIds = collectRelevantDoctorPluginIds(config);
 
     expect(pluginIds).toEqual(["opencode"]);

--- a/src/plugins/doctor-contract-registry.test.ts
+++ b/src/plugins/doctor-contract-registry.test.ts
@@ -569,26 +569,165 @@ describe("doctor-contract-registry module loader", () => {
     ).toEqual(["ollama-cloud"]);
   });
 
+  it("collects distinct provider ids from every canonical model selector and model policy", () => {
+    const providerIds = collectRelevantDoctorPluginIds({
+      agents: {
+        defaults: {
+          model: {
+            primary: "default-primary/model",
+            fallbacks: ["default-fallback/model", 42],
+          },
+          utilityModel: "default-utility/model",
+          imageModel: "default-image/model",
+          voiceModel: "default-voice/model",
+          pdfModel: "default-pdf/model",
+          mediaModels: {
+            image: "media-image/model",
+            video: "media-video/model",
+            music: "media-music/model",
+          },
+          heartbeat: { model: "heartbeat/model" },
+          subagents: {
+            model: { primary: "subagent-primary/model", fallbacks: ["subagent-fallback/model"] },
+          },
+          compaction: {
+            model: "compaction/model",
+            memoryFlush: { model: "memory-flush/model" },
+          },
+          models: {
+            "default-map/model": {},
+            bare: {},
+          },
+          modelPolicy: { allow: ["default-policy/*", 42, "bare"] },
+        },
+        entries: {
+          worker: {
+            model: "entry-model/model",
+            models: { "entry-map/model": {} },
+            modelPolicy: { allow: ["entry-policy/model", null] },
+            tools: { exec: { reviewer: { model: "entry-reviewer/model" } } },
+            tts: { summaryModel: "entry-tts/model" },
+          },
+        },
+        list: [
+          {
+            id: "shadow",
+            model: "shadow-model/model",
+            modelPolicy: { allow: ["shadow-policy/model"] },
+          },
+        ],
+      },
+      tools: { exec: { reviewer: { model: "global-reviewer/model" } } },
+      hooks: {
+        mappings: [{ model: "hook-mapping/model" }, { model: 42 }],
+        gmail: { model: "hook-gmail/model" },
+      },
+      tts: { summaryModel: "tts-summary/model" },
+      channels: {
+        modelByChannel: { discord: { guild: "channel-override/model" } },
+        discord: {
+          voice: {
+            model: "discord-voice/model",
+            tts: { summaryModel: "discord-voice-tts/model" },
+          },
+          accounts: {
+            work: {
+              voice: {
+                model: "discord-account-voice/model",
+                tts: { summaryModel: "discord-account-tts/model" },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(providerIds).toEqual(
+      [
+        "channel-override",
+        "compaction",
+        "default-fallback",
+        "default-image",
+        "default-map",
+        "default-pdf",
+        "default-policy",
+        "default-primary",
+        "default-utility",
+        "default-voice",
+        "discord",
+        "discord-account-tts",
+        "discord-account-voice",
+        "discord-voice",
+        "discord-voice-tts",
+        "entry-map",
+        "entry-model",
+        "entry-policy",
+        "entry-reviewer",
+        "entry-tts",
+        "global-reviewer",
+        "heartbeat",
+        "hook-gmail",
+        "hook-mapping",
+        "media-image",
+        "media-music",
+        "media-video",
+        "memory-flush",
+        "subagent-fallback",
+        "subagent-primary",
+        "tts-summary",
+      ].toSorted(),
+    );
+    expect(providerIds).not.toContain("shadow-model");
+    expect(providerIds).not.toContain("shadow-policy");
+  });
+
+  it("collects model and policy providers from the legacy list when entries is absent", () => {
+    expect(
+      collectRelevantDoctorPluginIds({
+        agents: {
+          list: [
+            {
+              id: "legacy",
+              model: "legacy-model/model",
+              modelPolicy: { allow: ["legacy-policy/*"] },
+            },
+          ],
+        },
+      }),
+    ).toEqual(["legacy-model", "legacy-policy"]);
+  });
+
+  it("does not collect shadow-list policy providers when entries is null", () => {
+    expect(
+      collectRelevantDoctorPluginIds({
+        agents: {
+          entries: null,
+          list: [{ id: "shadow", modelPolicy: { allow: ["shadow-policy/*"] } }],
+        },
+      }),
+    ).toEqual([]);
+  });
+
   it("excludes channel metadata and blank ids from full and touched doctor scans", () => {
     const raw = {
       channels: {
         defaults: {},
-        modelByChannel: { discord: "openai/gpt-5.6-luna" },
+        modelByChannel: { discord: { guild: "openai/gpt-5.6-luna" } },
         " ": {},
         discord: {},
       },
     };
 
-    expect(collectRelevantDoctorPluginIds(raw)).toEqual(["discord"]);
+    expect(collectRelevantDoctorPluginIds(raw)).toEqual(["discord", "openai"]);
     expect(
       collectRelevantDoctorPluginIdsForTouchedPaths({
         raw,
-        touchedPaths: [["channels", "modelByChannel", "discord"]],
+        touchedPaths: [["channels", "modelByChannel", "discord", "guild"]],
       }),
-    ).toStrictEqual([]);
+    ).toStrictEqual(["openai"]);
     expect(
       collectRelevantDoctorPluginIdsForTouchedPaths({ raw, touchedPaths: [["channels"]] }),
-    ).toEqual(["discord"]);
+    ).toEqual(["discord", "openai"]);
   });
 
   it("collects provider ids from media model entries", () => {
@@ -675,6 +814,40 @@ describe("doctor-contract-registry module loader", () => {
     });
   });
 
+  it("loads a provider doctor contract when a configured model ref is its only activation", () => {
+    const pluginRoot = makeTempDir();
+    fs.writeFileSync(path.join(pluginRoot, "doctor-contract-api.ts"), "export {};\n", "utf-8");
+    mocks.createJiti.mockImplementation(() => () => ({
+      normalizeCompatibilityConfig: ({ cfg }: { cfg: Record<string, unknown> }) => ({
+        config: { ...cfg, repaired: true },
+        changes: ["repaired configured provider model"],
+      }),
+    }));
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "opencode",
+          rootDir: pluginRoot,
+          channels: [],
+          providers: ["opencode"],
+          doctorContract: { configRepair: true },
+        },
+      ],
+      diagnostics: [],
+    });
+    const config = { agents: { defaults: { model: "opencode/hy3-free" } } };
+    const pluginIds = collectRelevantDoctorPluginIds(config);
+
+    expect(pluginIds).toEqual(["opencode"]);
+    expect(
+      applyPluginDoctorCompatibilityMigrations(config, { config, env: {}, pluginIds }),
+    ).toEqual({
+      config: { ...config, repaired: true },
+      changes: ["repaired configured provider model"],
+    });
+    expect(mocks.createJiti).toHaveBeenCalledTimes(1);
+  });
+
   it("narrows touched-path doctor ids for scoped dry-run validation", () => {
     expect(
       collectRelevantDoctorPluginIdsForTouchedPaths({
@@ -705,6 +878,55 @@ describe("doctor-contract-registry module loader", () => {
         ],
       }),
     ).toEqual(["discord", "elevenlabs", "memory-wiki", "ollama-cloud"]);
+  });
+
+  it("keeps all configured model and policy providers active during touched scans", () => {
+    expect(
+      collectRelevantDoctorPluginIdsForTouchedPaths({
+        raw: {
+          agents: {
+            defaults: {
+              model: { primary: "agent-primary/model", fallbacks: ["agent-fallback/model"] },
+            },
+            entries: {
+              worker: { modelPolicy: { allow: ["worker-policy/*"] } },
+            },
+          },
+          hooks: { gmail: { model: "gmail-model/model" } },
+          tts: { summaryModel: "untouched-tts/model" },
+          channels: {
+            modelByChannel: { slack: { room: "channel-model/model" } },
+            discord: { voice: { model: "untouched-voice/model" } },
+          },
+        },
+        touchedPaths: [
+          ["agents", "defaults", "model"],
+          ["agents", "entries", "worker", "modelPolicy", "allow", "0"],
+          ["hooks", "gmail", "model"],
+          ["channels", "modelByChannel", "slack", "room"],
+        ],
+      }),
+    ).toEqual([
+      "agent-fallback",
+      "agent-primary",
+      "channel-model",
+      "gmail-model",
+      "untouched-tts",
+      "untouched-voice",
+      "worker-policy",
+    ]);
+  });
+
+  it("does not infer touched-path ownership from dotted configured ids", () => {
+    expect(
+      collectRelevantDoctorPluginIdsForTouchedPaths({
+        raw: {
+          agents: { entries: { "worker.blue": { model: "provider.with.dots/model" } } },
+          plugins: { entries: { other: {} } },
+        },
+        touchedPaths: [["plugins", "entries", "other", "enabled"]],
+      }),
+    ).toEqual(["other", "provider.with.dots"]);
   });
 
   it("falls back to the full doctor-id set when touched paths are too broad", () => {

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -1,4 +1,6 @@
 // Loads plugin doctor contracts from manifest-owned metadata.
+import { collectConfiguredModelRefs } from "@openclaw/model-catalog-core/configured-model-refs";
+import { parseProviderModelRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
@@ -108,6 +110,37 @@ function collectMediaProviderIds(root: Record<string, unknown>, ids: Set<string>
   }
 }
 
+function collectConfiguredModelProviderIds(params: {
+  root: Record<string, unknown>;
+  ids: Set<string>;
+}): void {
+  const addRef = (value: unknown) => {
+    const parsed = typeof value === "string" ? parseProviderModelRef(value) : null;
+    if (parsed) {
+      params.ids.add(normalizeProviderId(parsed.provider));
+    }
+  };
+  for (const ref of collectConfiguredModelRefs(params.root)) {
+    addRef(ref.value);
+  }
+  const collectAgentPolicy = (value: unknown) => {
+    const allow = asNullableRecord(asNullableRecord(value)?.modelPolicy)?.allow;
+    if (Array.isArray(allow)) {
+      allow.forEach(addRef);
+    }
+  };
+  const agents = asNullableRecord(params.root.agents) ?? {};
+  collectAgentPolicy(agents.defaults);
+  if (Object.hasOwn(agents, "entries")) {
+    const entries = asNullableRecord(agents.entries);
+    if (entries) {
+      Object.values(entries).forEach(collectAgentPolicy);
+    }
+  } else if (Array.isArray(agents.list)) {
+    agents.list.forEach(collectAgentPolicy);
+  }
+}
+
 export function collectRelevantDoctorPluginIds(raw: unknown): string[] {
   const ids = new Set<string>();
   const root = asNullableRecord(raw);
@@ -140,6 +173,7 @@ export function collectRelevantDoctorPluginIds(raw: unknown): string[] {
   }
 
   collectMediaProviderIds(root, ids);
+  collectConfiguredModelProviderIds({ root, ids });
 
   if (hasLegacyElevenLabsTalkFields(root)) {
     ids.add("elevenlabs");
@@ -158,6 +192,7 @@ export function collectRelevantDoctorPluginIdsForTouchedPaths(params: {
   }
 
   const ids = new Set<string>();
+  collectConfiguredModelProviderIds({ root, ids });
   for (const touchedPath of params.touchedPaths) {
     const [first, second, third] = touchedPath;
     if (first === "channels") {


### PR DESCRIPTION
Related: #113549

Supersedes the focused Doctor portion of #113561. The static catalog refresh already landed via #121030; catalog synchronization, models.dev refresh, and hybrid catalog work remain out of scope here.

## What Problem This Solves

Fixes an issue where users upgrading from the v2026.7.2 beta releases could retain a saved `opencode/hy3-free` selection after that free model was retired and replaced by the active `opencode/laguna-s-2.1-free` route. Without an upgrade migration, the saved selection remained unknown until users edited every affected selector manually.

Credit to @samson1357924 for the original Doctor investigation in #113561.

## Why This Change Was Made

The repair lives in the OpenCode plugin's Doctor contract, where provider-owned compatibility belongs. It rewrites only the exact retired ref to the active free successor, preserves `@profile` suffixes, and activates through the canonical configured-model-ref inventory so every supported selector is covered without maintaining a second traversal in core.

The migration covers active agent selectors, `modelPolicy.allow`, safe structured `tools.media` entries, and explicitly configured stale catalog rows. `agents.entries` remains authoritative over the legacy `agents.list` projection. Runtime behavior remains fail-closed until `openclaw doctor --fix` runs; there is no request-time alias, network lookup, live-state mutation, or provider call.

Fully qualified `tools.media.{image,audio,video}.preferredModel` references are repaired with their matching structured media rows so Doctor preserves the operator's resolver ordering. Bare model ids and provider/CLI selectors remain unchanged.

## User Impact

Operators upgrading from the affected beta releases can run `openclaw doctor --fix` to repair saved references to the retired free OpenCode model across the supported configuration surfaces. Profiles are preserved, unrelated model references are untouched, and the migration does not contact the network or alter live provider state.

## Evidence

- Rebased head: `7d27838686868d9bf7445e74fd468ebe0a9c7810` on the latest `origin/main` at publication time.
- Focused rebased-head proof: 115 tests passed across `packages/model-catalog-core/src/configured-model-refs.test.ts`, `extensions/opencode/doctor-contract-api.test.ts`, `src/plugins/doctor-contract-registry.test.ts`, `src/media-understanding/resolve.test.ts`, `src/commands/doctor/shared/legacy-config-migrate.e2e.test.ts`, and `ui/src/pages/labs/labs-page.test.ts`. The E2E shard rebuilt stale dist and verified that the repaired fully qualified media preference still selects the replacement row.
- Red-main recovery proof: the first exact-head CI run and its failed-job retry both exposed the same newly landed Labs test regression as current `main` run https://github.com/openclaw/openclaw/actions/runs/31324435770. Current `main` now carries the canonical registry-ID correction, so the temporary branch-local index fix was dropped during rebase. The focused Labs test passes 44/44 on the final base.
- Formatting: targeted `oxfmt --check` clean; `git diff --check origin/main...HEAD` clean.
- Repository changed gate: Blacksmith Testbox lease `tbx_01kzkk8jc2q5p74q1sep4rrhsd`, Actions run https://github.com/openclaw/openclaw/actions/runs/31322015204. This included Doctor declaration/closure guards, four typecheck lanes, core and extension lint, deadcode, boundaries, cycles, metadata/API baselines, and storage guards.
- ClawSweeper P1 addressed: fully qualified media preferences now activate and migrate with their structured rows, with resolver-level E2E coverage. Bare `hy3-free` remains unchanged because it is not provider-qualified.
- Mandatory post-repair uncommitted autoreview completed clean with no accepted/actionable findings (`gpt-5.6-sol`, high reasoning; overall correct 0.99). The final branch autoreview against current `origin/main` also completed clean with no accepted/actionable findings (overall correct 0.98).
- Production LOC: +372/-14 (net +358), justified by the provider-owned upgrade boundary, canonical activation seam, and preference-selection invariant. Tests: +750/-7.
- Migration boundary: deterministic local config normalization only; no live user state was used, no network request occurs, and no external API behavior is involved.

AI-assisted: yes. The implementation and proof were reviewed before publication.
