### PR TITLE
feat(ui): start CLI agent sessions in the terminal from the new-session page

### DIFF
--- a/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
@@ -33,6 +33,33 @@ function requestHasParam(request: { params?: unknown }, key: string, value: unkn
   );
 }
 
+const TERMINAL_START_FEATURE_METHODS = [
+  "chat.metadata",
+  "chat.startup",
+  "sessions.catalog.list",
+  "sessions.catalog.startTerminal",
+  "sessions.create",
+  "sessions.dispatch",
+  "terminal.open",
+  "worktrees.create",
+] as const;
+
+function cliAgentCatalog(startTerminal: boolean) {
+  return {
+    id: "claude",
+    label: "Claude Code",
+    capabilities: {
+      continueSession: true,
+      archive: false,
+      createSession: {
+        model: "anthropic/claude-opus-4-8",
+        ...(startTerminal ? { startTerminal: true } : {}),
+      },
+    },
+    hosts: [],
+  };
+}
+
 suite.define(() => {
   it("routes a Labs-enabled CLI agent picker row through catalog-target mode", async () => {
     if (captureCliAgentsProof) {
@@ -122,6 +149,265 @@ suite.define(() => {
           path: path.join(cliAgentsProofDir, "catalog-target.png"),
         });
       }
+    } finally {
+      await context.close();
+    }
+  });
+
+  it.each([
+    {
+      label: "CLI agents gate is off",
+      cliAgentsEnabled: false,
+      terminalEnabled: true,
+      startTerminal: true,
+    },
+    {
+      label: "terminal gate is off",
+      cliAgentsEnabled: true,
+      terminalEnabled: false,
+      startTerminal: true,
+    },
+    {
+      label: "catalog capability is absent",
+      cliAgentsEnabled: true,
+      terminalEnabled: true,
+      startTerminal: false,
+    },
+  ])("keeps the plain Start control when $label", async (testCase) => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      cliAgentsEnabled: testCase.cliAgentsEnabled,
+      terminalEnabled: testCase.terminalEnabled,
+      workspace: WORKSPACE,
+      workspaceGit: true,
+      featureMethods: [...TERMINAL_START_FEATURE_METHODS],
+      methodResponses: {
+        "sessions.catalog.list": {
+          catalogs: [cliAgentCatalog(testCase.startTerminal)],
+        },
+        "worktrees.branches": {
+          branches: [{ kind: "local", name: "main" }],
+          defaultBranch: "main",
+          repositoryStatus: "git",
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}new?catalog=claude`);
+      await pollLocatorText(page.locator(".new-session-page__runtime")).toContain("Claude Code");
+
+      expect(await page.locator(".new-session-page__start-split").count()).toBe(0);
+      await page.locator(".new-session-page__message").fill("keep the normal path");
+      await expect
+        .poll(() => page.getByRole("button", { name: "Start session" }).isEnabled())
+        .toBe(true);
+      expect(await page.locator(".chat-send-btn").count()).toBe(1);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("creates a worktree, starts the catalog session, and opens its terminal", async () => {
+    if (captureCliAgentsProof) {
+      await mkdir(cliAgentsProofDir, { recursive: true });
+    }
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+      ...(captureCliAgentsProof
+        ? { recordVideo: { dir: cliAgentsProofDir, size: { height: 900, width: 1280 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    await page.addInitScript(() => {
+      const proofWindow = window as typeof window & { terminalToggleProof?: unknown[] };
+      proofWindow.terminalToggleProof = [];
+      window.addEventListener("openclaw:terminal-toggle", (event) => {
+        proofWindow.terminalToggleProof?.push((event as CustomEvent).detail);
+      });
+    });
+    const worktreePath = "/home/peter/.openclaw/worktrees/terminal-e2e";
+    const gateway = await installMockGateway(page, {
+      cliAgentsEnabled: true,
+      terminalEnabled: true,
+      workspace: WORKSPACE,
+      workspaceGit: true,
+      featureMethods: [...TERMINAL_START_FEATURE_METHODS],
+      methodResponses: {
+        "agents.list": {
+          agents: [
+            {
+              id: "main",
+              identity: { name: "Main" },
+              name: "Main",
+              workspace: WORKSPACE,
+              workspaceGit: true,
+            },
+            {
+              id: "research",
+              identity: { name: "Research" },
+              name: "Research",
+              workspace: WORKSPACE,
+              workspaceGit: true,
+            },
+          ],
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+        },
+        "sessions.catalog.list": { catalogs: [cliAgentCatalog(true)] },
+        "worktrees.branches": {
+          branches: [{ kind: "local", name: "main" }],
+          defaultBranch: "main",
+          repositoryStatus: "git",
+        },
+        "worktrees.create": {
+          id: "terminal-e2e",
+          name: "terminal-task",
+          repoFingerprint: "0123456789abcdef",
+          repoRoot: WORKSPACE,
+          path: worktreePath,
+          branch: "openclaw/terminal-task",
+          baseRef: "main",
+          ownerKind: "manual",
+          createdAt: 1,
+          lastActiveAt: 1,
+        },
+        "sessions.catalog.startTerminal": {
+          sessionId: "terminal-cli-1",
+          agentId: "research",
+          shell: "/bin/zsh",
+          cwd: worktreePath,
+          confined: false,
+          title: "Claude Code",
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}new?agent=research&catalog=claude`);
+      await pollLocatorText(page.locator(".new-session-page__runtime")).toContain("Claude Code");
+      await expect.poll(() => page.locator(".new-session-page__start-split").count()).toBe(1);
+
+      await page.locator("#new-session-place-trigger").click();
+      const placePopover = page.locator("wa-popover.new-session-page__place-popover");
+      await placePopover.getByRole("button", { name: "Worktree" }).click();
+      await placePopover.getByLabel("Base branch").fill("main");
+      await placePopover.getByLabel("Worktree name").fill("terminal-task");
+      await page.locator("#new-session-place-trigger").click();
+      await page.locator(".new-session-page__message").fill("  inspect the checkout  ");
+
+      if (captureCliAgentsProof) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(cliAgentsProofDir, "terminal-split.png"),
+        });
+      }
+
+      await page.getByRole("button", { name: "Start in terminal" }).click();
+      await page.getByRole("menuitem", { name: "Start in terminal" }).click();
+
+      const worktreeRequest = await gateway.waitForRequest("worktrees.create");
+      expect(worktreeRequest.params).toEqual({
+        repoRoot: WORKSPACE,
+        name: "terminal-task",
+        baseRef: "main",
+      });
+      const terminalRequest = await gateway.waitForRequest("sessions.catalog.startTerminal");
+      expect(terminalRequest.params).toEqual({
+        catalogId: "claude",
+        agentId: "research",
+        cwd: worktreePath,
+        initialMessage: "inspect the checkout",
+      });
+      const requests = await gateway.getRequests();
+      const methods = requests.map((request) => request.method);
+      expect(methods.indexOf("worktrees.create")).toBeLessThan(
+        methods.indexOf("sessions.catalog.startTerminal"),
+      );
+      await expect.poll(() => page.locator(".new-session-page__message").inputValue()).toBe("");
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const proofWindow = window as typeof window & { terminalToggleProof?: unknown[] };
+            return proofWindow.terminalToggleProof;
+          }),
+        )
+        .toContainEqual({ open: true, terminalSessionId: "terminal-cli-1" });
+
+      await expect
+        .poll(() => page.getByRole("button", { name: "Start in terminal" }).isEnabled())
+        .toBe(true);
+      await page.getByRole("button", { name: "Start in terminal" }).click();
+      await page.getByRole("menuitem", { name: "Start in terminal" }).click();
+      await expect
+        .poll(async () => {
+          const currentRequests = await gateway.getRequests();
+          return currentRequests.filter(
+            (request) => request.method === "sessions.catalog.startTerminal",
+          ).length;
+        })
+        .toBe(2);
+      const repeatedRequests = await gateway.getRequests();
+      const emptyMessageRequest = repeatedRequests.findLast(
+        (request) => request.method === "sessions.catalog.startTerminal",
+      );
+      expect(emptyMessageRequest?.params).toEqual({
+        catalogId: "claude",
+        agentId: "research",
+        cwd: worktreePath,
+      });
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("shows the terminal-start server error without rewriting it", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const serverMessage = "cwd is no longer available; choose another folder and retry";
+    await installMockGateway(page, {
+      cliAgentsEnabled: true,
+      terminalEnabled: true,
+      workspace: WORKSPACE,
+      workspaceGit: true,
+      featureMethods: [...TERMINAL_START_FEATURE_METHODS],
+      methodResponses: {
+        "sessions.catalog.list": { catalogs: [cliAgentCatalog(true)] },
+        "worktrees.branches": {
+          branches: [{ kind: "local", name: "main" }],
+          defaultBranch: "main",
+          repositoryStatus: "git",
+        },
+        "sessions.catalog.startTerminal": {
+          __mockError: { code: "INVALID_REQUEST", message: serverMessage },
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}new?catalog=claude`);
+      await pollLocatorText(page.locator(".new-session-page__runtime")).toContain("Claude Code");
+      await page.locator(".new-session-page__message").fill("keep this draft");
+      await page.getByRole("button", { name: "Start in terminal" }).click();
+      await page.getByRole("menuitem", { name: "Start in terminal" }).click();
+
+      await expect
+        .poll(() => page.locator(".new-session-page__alert-message").textContent())
+        .toBe(serverMessage);
+      expect(await page.locator(".new-session-page__message").inputValue()).toBe("keep this draft");
     } finally {
       await context.close();
     }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -700,6 +700,7 @@ export const en: TranslationMap = {
     messagePlaceholder: "What should this session work on?",
     readingAttachment: "Reading attachment",
     start: "Start session",
+    startInTerminal: "Start in terminal",
     starting: "Starting…",
     createFailed: "Couldn't create the session.",
     cloudOwnershipLost:

--- a/ui/src/lib/sessions/catalog-terminal.ts
+++ b/ui/src/lib/sessions/catalog-terminal.ts
@@ -4,10 +4,16 @@ import {
 } from "../../components/panel-toggle-contract.ts";
 import type { CatalogSessionKey } from "./catalog-key.ts";
 
-export function openCatalogSessionInTerminal(key: CatalogSessionKey): void {
+function openTerminal(detail: TerminalPanelToggleDetail): void {
   window.dispatchEvent(
-    new CustomEvent<TerminalPanelToggleDetail>(TERMINAL_PANEL_TOGGLE_EVENT, {
-      detail: { open: true, catalog: key },
-    }),
+    new CustomEvent<TerminalPanelToggleDetail>(TERMINAL_PANEL_TOGGLE_EVENT, { detail }),
   );
+}
+
+export function openCatalogSessionInTerminal(key: CatalogSessionKey): void {
+  openTerminal({ open: true, catalog: key });
+}
+
+export function openTerminalSessionInTerminal(terminalSessionId: string): void {
+  openTerminal({ open: true, terminalSessionId });
 }

--- a/ui/src/lib/worktrees/create-worktree.ts
+++ b/ui/src/lib/worktrees/create-worktree.ts
@@ -1,0 +1,15 @@
+import type { WorktreeRecord } from "../../../../packages/gateway-protocol/src/index.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+
+export async function createManagedWorktree(
+  client: Pick<GatewayBrowserClient, "request">,
+  params: { repoRoot: string; name?: string; baseRef?: string },
+): Promise<WorktreeRecord> {
+  const name = params.name?.trim();
+  const baseRef = params.baseRef?.trim();
+  return client.request<WorktreeRecord>("worktrees.create", {
+    repoRoot: params.repoRoot.trim(),
+    ...(name ? { name } : {}),
+    ...(baseRef ? { baseRef } : {}),
+  });
+}

--- a/ui/src/pages/labs/labs-page.test.ts
+++ b/ui/src/pages/labs/labs-page.test.ts
@@ -60,18 +60,6 @@ async function mountPage(sourceConfig: Record<string, unknown>): Promise<{
   return { page, provider, runtimeConfig };
 }
 
-function labToggle(page: LabsPageElement, index: number, label: string) {
-  const toggle = page.querySelectorAll<HTMLElement & { checked: boolean }>("wa-switch").item(index);
-  if (!toggle) {
-    throw new Error(`${label} toggle not rendered`);
-  }
-  return toggle;
-}
-
-function codeModeToggle(page: LabsPageElement) {
-  return labToggle(page, 0, "Code Mode");
-}
-
 function labRow(page: LabsPageElement, title: string) {
   const row = [...page.querySelectorAll<HTMLElement>(".settings-row")].find(
     (candidate) => candidate.querySelector(".settings-row__title")?.textContent?.trim() === title,
@@ -80,6 +68,26 @@ function labRow(page: LabsPageElement, title: string) {
     throw new Error(`${title} row not rendered`);
   }
   return row;
+}
+
+function labToggle(page: LabsPageElement, title: string) {
+  const toggle = labRow(page, title).querySelector<HTMLElement & { checked: boolean }>("wa-switch");
+  if (!toggle) {
+    throw new Error(`${title} toggle not rendered`);
+  }
+  return toggle;
+}
+
+function labDocsLink(page: LabsPageElement, title: string) {
+  const link = labRow(page, title).querySelector<HTMLAnchorElement>(".settings-row__desc a");
+  if (!link) {
+    throw new Error(`${title} documentation link not rendered`);
+  }
+  return link;
+}
+
+function codeModeToggle(page: LabsPageElement) {
+  return labToggle(page, "Code Mode");
 }
 
 describe("LabsPage", () => {
@@ -107,7 +115,7 @@ describe("LabsPage", () => {
     expect(page.textContent).toContain("Cloud Worker Desktop");
     expect(codeModeToggle(page).checked).toBe(true);
 
-    const docs = [...page.querySelectorAll<HTMLAnchorElement>(".settings-row__desc a")];
+    const docs = LAB_FEATURES.map((feature) => labDocsLink(page, feature.title()));
     expect(docs.map((link) => link.href)).toEqual(LAB_FEATURES.map((feature) => feature.docsUrl));
     expect(docs.every((link) => link.target === "_blank")).toBe(true);
     expect(docs.every((link) => link.rel.includes("noopener"))).toBe(true);
@@ -147,14 +155,12 @@ describe("LabsPage", () => {
       // The on position restores the shipped "auto" tier, never `true`: Labs
       // offers Auto/Off, and force-on stays a config-only power-user state.
       label: "Code Mode",
-      id: "codeMode",
       sourceConfig: { tools: { codeMode: { enabled: false } } },
       expectedPatch: { tools: { codeMode: { enabled: null } } },
       note: "labs: update codeMode",
     },
     {
       label: "Swarm",
-      id: "swarm",
       sourceConfig: { tools: { swarm: { enabled: false } } },
       expectedPatch: { tools: { swarm: { enabled: true } } },
       note: "labs: update swarm",
@@ -164,28 +170,24 @@ describe("LabsPage", () => {
       // mode to "code", so a bare `enabled: true` would select the surface with
       // the weakest recall rather than the one this row advertises.
       label: "Tool Search",
-      id: "toolSearch",
       sourceConfig: { tools: { toolSearch: { enabled: false } } },
       expectedPatch: { tools: { toolSearch: { enabled: true, mode: "directory" } } },
       note: "labs: update toolSearch",
     },
     {
       label: "Tool-loop detection",
-      id: "loopDetection",
       sourceConfig: { tools: { loopDetection: { enabled: false } } },
       expectedPatch: { tools: { loopDetection: { enabled: true } } },
       note: "labs: update loopDetection",
     },
     {
       label: "Lean tools for local models",
-      id: "localModelLean",
       sourceConfig: {},
       expectedPatch: { agents: { defaults: { experimental: { localModelLean: true } } } },
       note: "labs: update localModelLean",
     },
     {
       label: "CLI agents",
-      id: "cliAgents",
       sourceConfig: {},
       expectedPatch: { gateway: { cliAgents: { enabled: true } } },
       note: "labs: update cliAgents",
@@ -194,24 +196,19 @@ describe("LabsPage", () => {
       // Not a boolean gate: the on state is the conservative `direct` mode, so
       // enabling here cannot start recording group or unknown conversations.
       label: "Message audit metadata",
-      id: "auditMessages",
       sourceConfig: { logging: { audit: { messages: "off" } } },
       expectedPatch: { logging: { audit: { messages: "direct" } } },
       note: "labs: update auditMessages",
     },
     {
       label: "Cloud Worker Desktop",
-      id: "workerDesktop",
       sourceConfig: { cloudWorkers: { desktop: false } },
       expectedPatch: { cloudWorkers: { desktop: true } },
       note: "labs: update workerDesktop",
     },
   ])("writes the on value at the registered config path when enabling $label", async (testCase) => {
-    // Resolve the row from the registry: hardcoded indices rot when a new lab
-    // entry lands and silently toggle a neighboring row instead.
-    const rowIndex = LAB_FEATURES.findIndex((feature) => feature.id === testCase.id);
     const { page, runtimeConfig } = await mountPage(testCase.sourceConfig);
-    const toggle = labToggle(page, rowIndex, testCase.label);
+    const toggle = labToggle(page, testCase.label);
 
     toggle.checked = true;
     toggle.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
@@ -224,29 +221,26 @@ describe("LabsPage", () => {
   });
 
   it("reads a mode-valued gate as on only for the mode this row offers", async () => {
-    const auditIndex = LAB_FEATURES.findIndex((feature) => feature.id === "auditMessages");
-
     const off = await mountPage({ logging: { audit: { messages: "off" } } });
-    expect(labToggle(off.page, auditIndex, "audit").checked).toBe(false);
+    expect(labToggle(off.page, "Message audit metadata").checked).toBe(false);
     off.provider.remove();
 
     const direct = await mountPage({ logging: { audit: { messages: "direct" } } });
-    expect(labToggle(direct.page, auditIndex, "audit").checked).toBe(true);
+    expect(labToggle(direct.page, "Message audit metadata").checked).toBe(true);
     direct.provider.remove();
 
     // `all` is broader than the mode this row offers, but it is still on. Showing
     // it as off would make the switch look available and quietly narrow a choice
     // the operator made deliberately somewhere else.
     const all = await mountPage({ logging: { audit: { messages: "all" } } });
-    expect(labToggle(all.page, auditIndex, "audit").checked).toBe(true);
+    expect(labToggle(all.page, "Message audit metadata").checked).toBe(true);
   });
 
   it("restores the default off mode from a broader audit mode", async () => {
-    const auditIndex = LAB_FEATURES.findIndex((feature) => feature.id === "auditMessages");
     const { page, runtimeConfig } = await mountPage({
       logging: { audit: { messages: "all" } },
     });
-    const toggle = labToggle(page, auditIndex, "audit");
+    const toggle = labToggle(page, "Message audit metadata");
 
     toggle.checked = false;
     toggle.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
@@ -323,10 +317,7 @@ describe("LabsPage", () => {
         },
       },
     });
-    const localModelLeanIndex = LAB_FEATURES.findIndex(
-      (feature) => feature.id === "localModelLean",
-    );
-    const toggle = labToggle(page, localModelLeanIndex, "local model lean");
+    const toggle = labToggle(page, "Lean tools for local models");
 
     toggle.checked = false;
     toggle.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
@@ -455,8 +446,6 @@ describe("LabsPage code mode enablement", () => {
 });
 
 describe("LabsPage tool search enablement", () => {
-  const toolSearchIndex = LAB_FEATURES.findIndex((feature) => feature.id === "toolSearch");
-
   // readToolSearchConfig + readBoolean(raw.enabled, configured): an object that
   // configures anything besides `enabled` is already on at runtime.
   it.each([
@@ -481,7 +470,7 @@ describe("LabsPage tool search enablement", () => {
   ])("reads $label as $expected", async ({ config, expected }) => {
     const { page, provider } = await mountPage(config);
 
-    expect(labToggle(page, toolSearchIndex, "Tool Search").checked).toBe(expected);
+    expect(labToggle(page, "Tool Search").checked).toBe(expected);
     provider.remove();
   });
 
@@ -489,7 +478,7 @@ describe("LabsPage tool search enablement", () => {
     const { page, runtimeConfig } = await mountPage({
       tools: { toolSearch: { mode: "tools" } },
     });
-    const toggle = labToggle(page, toolSearchIndex, "Tool Search");
+    const toggle = labToggle(page, "Tool Search");
 
     expect(toggle.checked).toBe(true);
     expect(labRow(page, "Tool Search").textContent).toContain("Default: Disabled");
@@ -507,7 +496,7 @@ describe("LabsPage tool search enablement", () => {
     const { page, runtimeConfig } = await mountPage({
       tools: { toolSearch: { enabled: false, mode: "tools" } },
     });
-    const toggle = labToggle(page, toolSearchIndex, "Tool Search");
+    const toggle = labToggle(page, "Tool Search");
 
     toggle.checked = true;
     toggle.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
@@ -537,8 +526,6 @@ describe("LabsPage tool search enablement", () => {
 });
 
 describe("LabsPage tool loop detection enablement", () => {
-  const loopDetectionIndex = LAB_FEATURES.findIndex((feature) => feature.id === "loopDetection");
-
   // Mirrors resolveToolLoopDetectionConfig and the detector default: only an
   // explicit true enables the rolling-history detectors.
   it.each([
@@ -556,7 +543,7 @@ describe("LabsPage tool loop detection enablement", () => {
   ])("reads $label as $expected", async ({ config, expected }) => {
     const { page, provider } = await mountPage(config);
 
-    expect(labToggle(page, loopDetectionIndex, "Tool-loop detection").checked).toBe(expected);
+    expect(labToggle(page, "Tool-loop detection").checked).toBe(expected);
     provider.remove();
   });
 
@@ -564,7 +551,7 @@ describe("LabsPage tool loop detection enablement", () => {
     const { page, runtimeConfig } = await mountPage({
       tools: { loopDetection: { enabled: false, warningThreshold: 12 } },
     });
-    const toggle = labToggle(page, loopDetectionIndex, "Tool-loop detection");
+    const toggle = labToggle(page, "Tool-loop detection");
 
     toggle.checked = true;
     toggle.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
@@ -580,7 +567,7 @@ describe("LabsPage tool loop detection enablement", () => {
     const { page, runtimeConfig } = await mountPage({
       tools: { loopDetection: { enabled: true, warningThreshold: 12 } },
     });
-    const toggle = labToggle(page, loopDetectionIndex, "Tool-loop detection");
+    const toggle = labToggle(page, "Tool-loop detection");
 
     toggle.checked = false;
     toggle.dispatchEvent(new Event("change", { bubbles: true, composed: true }));

--- a/ui/src/pages/new-session/catalog-target.test.ts
+++ b/ui/src/pages/new-session/catalog-target.test.ts
@@ -17,6 +17,7 @@ describe("new-session catalog target", () => {
       catalogId: "claude",
       model: "",
       catalogLabel: "",
+      startTerminal: false,
     };
     const ready = {
       ...pending,
@@ -35,6 +36,7 @@ describe("new-session catalog target", () => {
       catalogId: "claude",
       model: "",
       catalogLabel: "",
+      startTerminal: false,
     };
     const unresolved = { ...requested, agentId: "" };
     const resolved = { ...requested, agentId: "research" };
@@ -64,6 +66,34 @@ describe("new-session catalog target", () => {
       agentId: "research",
       catalogId: "claude",
       limitPerHost: 1,
+    });
+  });
+
+  it("preserves the catalog terminal-start capability with the resolved target", async () => {
+    const request = vi.fn(async () => ({
+      catalogs: [
+        {
+          id: "claude",
+          label: "Claude Code",
+          capabilities: {
+            continueSession: true,
+            archive: false,
+            createSession: {
+              model: "anthropic/claude-opus-4-8",
+              startTerminal: true,
+            },
+          },
+          hosts: [],
+        },
+      ],
+    }));
+
+    await expect(
+      resolveCreateTarget({ request } as unknown as GatewayBrowserClient, "claude", "research"),
+    ).resolves.toEqual({
+      model: "anthropic/claude-opus-4-8",
+      catalogLabel: "Claude Code",
+      startTerminal: true,
     });
   });
 

--- a/ui/src/pages/new-session/catalog-target.ts
+++ b/ui/src/pages/new-session/catalog-target.ts
@@ -50,7 +50,7 @@ export async function resolveCreateTarget(
   client: GatewayBrowserClient,
   catalogId: string,
   agentId?: string,
-): Promise<Pick<NewSessionRouteData, "model" | "catalogLabel"> | undefined> {
+): Promise<Pick<NewSessionRouteData, "model" | "catalogLabel" | "startTerminal"> | undefined> {
   try {
     const result = await client.request<SessionsCatalogListResult>("sessions.catalog.list", {
       ...(agentId ? { agentId } : {}),
@@ -59,7 +59,13 @@ export async function resolveCreateTarget(
     });
     const catalog = result.catalogs.find((candidate) => candidate.id === catalogId);
     const model = catalog?.capabilities.createSession?.model.trim();
-    return catalog && model ? { model, catalogLabel: catalog.label } : undefined;
+    return catalog && model
+      ? {
+          model,
+          catalogLabel: catalog.label,
+          startTerminal: catalog.capabilities.createSession?.startTerminal === true,
+        }
+      : undefined;
   } catch {
     return undefined;
   }

--- a/ui/src/pages/new-session/composer.test.ts
+++ b/ui/src/pages/new-session/composer.test.ts
@@ -17,6 +17,11 @@ function renderComposer(
     canSubmit?: boolean;
     requiresModifier?: boolean;
     submitDisabledReason?: string;
+    terminalAction?: {
+      canStart: boolean;
+      disabledReason?: string;
+      onStart: () => void;
+    };
     submitting?: boolean;
     messageLocked?: boolean;
     incognitoDisabledReason?: string;
@@ -50,6 +55,7 @@ function renderComposer(
       modelControl: new NewSessionModelControl(() => undefined),
       requiresModifier: overrides.requiresModifier ?? false,
       submitDisabledReason: overrides.submitDisabledReason,
+      terminalAction: overrides.terminalAction,
       submitting: overrides.submitting ?? false,
       textareaController,
       messageLocked: overrides.messageLocked,
@@ -145,6 +151,53 @@ describe("new-session composer keyboard submission", () => {
 
     expect(event.defaultPrevented).toBe(true);
     expect(onSubmit).toHaveBeenCalledOnce();
+  });
+});
+
+describe("new-session composer start control", () => {
+  it("keeps the plain Start button unchanged when the terminal action is hidden", () => {
+    const { composer } = renderComposer();
+
+    expect(composer.querySelectorAll(".chat-send-btn")).toHaveLength(1);
+    expect(composer.querySelector(".new-session-page__start-split")).toBeNull();
+    expect(composer.querySelector("wa-dropdown-item[value='start-terminal']")).toBeNull();
+  });
+
+  it("renders the terminal action as a secondary split-button menu item", () => {
+    const onStart = vi.fn();
+    const { composer } = renderComposer({
+      terminalAction: { canStart: true, onStart },
+    });
+    const trigger = composer.querySelector<HTMLButtonElement>(
+      ".new-session-page__start-menu-trigger",
+    );
+    const item = composer.querySelector<HTMLElement>("wa-dropdown-item[value='start-terminal']");
+
+    expect(composer.querySelector(".new-session-page__start-split")).not.toBeNull();
+    expect(trigger?.disabled).toBe(false);
+    expect(trigger?.getAttribute("aria-label")).toBe("Start in terminal");
+    expect(item?.textContent?.trim()).toBe("Start in terminal");
+    item?.click();
+    expect(onStart).toHaveBeenCalledOnce();
+  });
+
+  it("disables the terminal action with its existing tooltip reason pattern", () => {
+    const onStart = vi.fn();
+    const reason = "This Gateway does not support this session action.";
+    const { composer } = renderComposer({
+      terminalAction: { canStart: false, disabledReason: reason, onStart },
+    });
+    const trigger = composer.querySelector<HTMLButtonElement>(
+      ".new-session-page__start-menu-trigger",
+    );
+    const item = composer.querySelector<HTMLElement>("wa-dropdown-item[value='start-terminal']");
+    const tooltips = composer.querySelectorAll<HTMLElement>("openclaw-tooltip");
+
+    expect(trigger?.disabled).toBe(true);
+    expect(item?.hasAttribute("disabled")).toBe(true);
+    expect((tooltips[1] as HTMLElement & { content?: string })?.content).toBe(reason);
+    item?.click();
+    expect(onStart).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -31,6 +31,11 @@ type NewSessionComposerOptions = {
   readSignal: AbortSignal;
   requiresModifier: boolean;
   submitDisabledReason?: string;
+  terminalAction?: {
+    canStart: boolean;
+    disabledReason?: string;
+    onStart: () => void;
+  };
   submitting: boolean;
   textareaController: NewSessionComposerTextareaController;
   messageLocked?: boolean;
@@ -43,6 +48,65 @@ type NewSessionComposerOptions = {
   onVisibilityChange?: (visibility: NewSessionVisibility) => void;
   onSubmit: () => void;
 };
+
+function renderStartControl(options: NewSessionComposerOptions) {
+  const startLabel = options.submitting ? t("newSession.starting") : t("newSession.start");
+  if (!options.terminalAction) {
+    return html`
+      <openclaw-tooltip content=${options.submitDisabledReason ?? t("newSession.start")}>
+        <button
+          type="button"
+          class="chat-send-btn"
+          ?disabled=${!options.canSubmit}
+          aria-label=${startLabel}
+          @click=${options.onSubmit}
+        >
+          ${options.submitting ? icons.loader : icons.arrowUp}
+        </button>
+      </openclaw-tooltip>
+    `;
+  }
+  const terminalLabel = t("newSession.startInTerminal");
+  return html`
+    <div class="new-session-page__start-split">
+      <openclaw-tooltip content=${options.submitDisabledReason ?? t("newSession.start")}>
+        <button
+          type="button"
+          class="chat-send-btn new-session-page__start-primary"
+          ?disabled=${!options.canSubmit}
+          aria-label=${startLabel}
+          @click=${options.onSubmit}
+        >
+          ${options.submitting ? icons.loader : icons.arrowUp}
+        </button>
+      </openclaw-tooltip>
+      <openclaw-tooltip content=${options.terminalAction.disabledReason ?? terminalLabel}>
+        <wa-dropdown class="new-session-page__start-menu" placement="top-end">
+          <button
+            slot="trigger"
+            type="button"
+            class="chat-send-btn new-session-page__start-menu-trigger"
+            ?disabled=${!options.terminalAction.canStart}
+            aria-label=${terminalLabel}
+          >
+            ${icons.chevronUp}
+          </button>
+          <wa-dropdown-item
+            value="start-terminal"
+            ?disabled=${!options.terminalAction.canStart}
+            @click=${() => {
+              if (options.terminalAction?.canStart) {
+                options.terminalAction.onStart();
+              }
+            }}
+          >
+            ${terminalLabel}
+          </wa-dropdown-item>
+        </wa-dropdown>
+      </openclaw-tooltip>
+    </div>
+  `;
+}
 
 export class NewSessionComposerTextareaController {
   private textarea: HTMLTextAreaElement | null = null;
@@ -130,7 +194,6 @@ function handleComposerKeydown(event: KeyboardEvent, options: NewSessionComposer
 
 /** Draft message box styled as the chat composer shell so both pickers match. */
 function renderNewSessionComposer(options: NewSessionComposerOptions) {
-  const startLabel = options.submitting ? t("newSession.starting") : t("newSession.start");
   const attachmentProps = {
     attachments: options.attachments,
     disabled: options.submitting || options.messageLocked,
@@ -180,19 +243,7 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
               }}
             ></textarea>
           </div>
-          <div class="agent-chat__composer-actions">
-            <openclaw-tooltip content=${options.submitDisabledReason ?? t("newSession.start")}>
-              <button
-                type="button"
-                class="chat-send-btn"
-                ?disabled=${!options.canSubmit}
-                aria-label=${startLabel}
-                @click=${options.onSubmit}
-              >
-                ${options.submitting ? icons.loader : icons.arrowUp}
-              </button>
-            </openclaw-tooltip>
-          </div>
+          <div class="agent-chat__composer-actions">${renderStartControl(options)}</div>
         </div>
         <div class="agent-chat__composer-footer">
           <div class="agent-chat__composer-controls">
@@ -242,6 +293,11 @@ export function renderNewSessionDraftComposer(options: {
   textareaController: NewSessionComposerTextareaController;
   requiresModifier: boolean;
   submitDisabledReason?: string;
+  terminalAction?: {
+    canStart: boolean;
+    disabledReason?: string;
+    onStart: () => void;
+  };
   submitting: boolean;
   messageLocked?: boolean;
   incognitoDisabledReason?: string;
@@ -269,6 +325,7 @@ export function renderNewSessionDraftComposer(options: {
     readSignal,
     requiresModifier: options.requiresModifier,
     submitDisabledReason: options.submitDisabledReason,
+    terminalAction: options.terminalAction,
     submitting: options.submitting,
     textareaController: options.textareaController,
     messageLocked: options.messageLocked,

--- a/ui/src/pages/new-session/location.ts
+++ b/ui/src/pages/new-session/location.ts
@@ -6,6 +6,7 @@ export type NewSessionRouteData = {
   catalogId: string;
   model: string;
   catalogLabel: string;
+  startTerminal: boolean;
 };
 
 export type NewSessionTarget = { catalogId: string };

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -4,6 +4,7 @@ import { html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import type {
   FsListDirResult,
+  SessionsCatalogStartTerminalResult,
   WorktreesBranchesResult,
 } from "../../../../packages/gateway-protocol/src/index.js";
 import { selectApplicationSession } from "../../app/agent-selection.ts";
@@ -20,9 +21,12 @@ import {
   readSessionMethodAccess,
   type SessionMethodAccess,
 } from "../../lib/session-method-access.ts";
+import { openTerminalSessionInTerminal } from "../../lib/sessions/catalog-terminal.ts";
 import { sessionNavigationTarget } from "../../lib/sessions/route-navigation.ts";
 import { buildAgentMainSessionKey, normalizeAgentId } from "../../lib/sessions/session-key.ts";
 import { normalizeOptionalString } from "../../lib/string-coerce.ts";
+import { isTerminalAvailable } from "../../lib/terminal-availability.ts";
+import { createManagedWorktree } from "../../lib/worktrees/create-worktree.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import "../../styles/chat.css";
@@ -565,6 +569,20 @@ class NewSessionPage extends OpenClawLightDomElement {
     return hasOperatorAdminAccess(this.context?.gateway.snapshot.hello?.auth ?? null);
   }
 
+  private showStartInTerminal(): boolean {
+    const context = this.context;
+    return Boolean(
+      context &&
+      catalog.isTarget(this.data) &&
+      this.data?.startTerminal &&
+      context.config.current.cliAgentsEnabled === true &&
+      isTerminalAvailable(
+        context.gateway.snapshot,
+        context.config.current.terminalEnabled ?? false,
+      ),
+    );
+  }
+
   private canStartAsDraft(): boolean {
     return canStartSessionAsDraft({
       allowedVisibilities: this.context?.gateway.snapshot.hello?.policy?.allowedSessionVisibilities,
@@ -624,6 +642,26 @@ class NewSessionPage extends OpenClawLightDomElement {
 
   private submitDisabledReason(): string | undefined {
     const access = this.submissionAccess();
+    return access.allowed ? undefined : access.reason;
+  }
+
+  private terminalStartAccess(): SessionMethodAccess {
+    const gateway = this.context?.gateway.snapshot;
+    const terminalAccess = readSessionMethodAccess(gateway, {
+      method: "sessions.catalog.startTerminal",
+      requiredScope: "operator.admin",
+    });
+    if (!terminalAccess.allowed || !this.worktree) {
+      return terminalAccess;
+    }
+    return readSessionMethodAccess(gateway, {
+      method: "worktrees.create",
+      requiredScope: "operator.admin",
+    });
+  }
+
+  private terminalStartDisabledReason(): string | undefined {
+    const access = this.terminalStartAccess();
     return access.allowed ? undefined : access.reason;
   }
 
@@ -1043,7 +1081,7 @@ class NewSessionPage extends OpenClawLightDomElement {
     return this.worktreeAvailable() ? undefined : t("newSession.cloudRequiresWorktree");
   }
 
-  private canSubmit(): boolean {
+  private canSubmit(kind: "session" | "terminal" = "session"): boolean {
     const pendingCloud = Boolean(this.pendingCloud.sessionKey);
     const cloudProfileId = this.cloudProfileForSubmission();
     const message = pendingCloud ? this.pendingCloud.message : this.message.trim();
@@ -1056,13 +1094,14 @@ class NewSessionPage extends OpenClawLightDomElement {
       this.requiresModelSetup() ||
       this.attachmentDraft.pendingReads > 0 ||
       (!pendingCloud && this.submissionOutcomeUnknown) ||
-      (!message && !hasAttachments) ||
+      (kind === "session" && !message && !hasAttachments) ||
       gateway?.snapshot.phase !== "connected" ||
       !gateway.snapshot.client
     ) {
       return false;
     }
-    if (!this.submissionAccess().allowed) {
+    const access = kind === "terminal" ? this.terminalStartAccess() : this.submissionAccess();
+    if (!access.allowed) {
       return false;
     }
     if (this.restoredFolderValidation !== "none") {
@@ -1124,6 +1163,9 @@ class NewSessionPage extends OpenClawLightDomElement {
     if (this.worktree && !isWorktreeNameValid(this.worktreeName)) {
       return false;
     }
+    if (kind === "terminal" && !(this.folder.trim() || this.workspacePath())) {
+      return false;
+    }
     return true;
   }
 
@@ -1139,6 +1181,14 @@ class NewSessionPage extends OpenClawLightDomElement {
       selectedAgentFound: selectedAgent !== undefined,
       agentModel: selectedAgent?.model?.primary,
     });
+  }
+
+  private closeOpenDropdowns() {
+    for (const dropdown of this.querySelectorAll<HTMLElement & { open: boolean }>(
+      "wa-dropdown[open]",
+    )) {
+      dropdown.open = false;
+    }
   }
 
   private async submit() {
@@ -1171,11 +1221,7 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.error = null;
     // Retire hidden pickers before their late requests can mutate this submitted draft.
     this.closeBrowser();
-    for (const dropdown of this.querySelectorAll<HTMLElement & { open: boolean }>(
-      "wa-dropdown[open]",
-    )) {
-      dropdown.open = false;
-    }
+    this.closeOpenDropdowns();
     try {
       const cloudProfileId = this.cloudProfileForSubmission();
       // Draft mode can go stale if sharing policy changed since it was selected.
@@ -1417,6 +1463,59 @@ class NewSessionPage extends OpenClawLightDomElement {
           agentId: this.agentId,
         }).options,
       );
+    } finally {
+      if (requestId === this.submitRequestToken) {
+        this.submitting = false;
+      }
+    }
+  }
+
+  private async startInTerminal() {
+    const context = this.context;
+    const client = context?.gateway.snapshot.client;
+    const catalogId = this.data?.catalogId.trim() ?? "";
+    const agentId = normalizeAgentId(this.agentId);
+    if (!context || !client || !catalogId || !agentId || !this.canSubmit("terminal")) {
+      return;
+    }
+    const requestId = ++this.submitRequestToken;
+    const initialMessage = this.message.trim();
+    this.submitting = true;
+    this.error = null;
+    this.closeBrowser();
+    this.closeOpenDropdowns();
+    try {
+      let cwd = this.folder.trim() || this.workspacePath();
+      if (this.worktree) {
+        const created = await createManagedWorktree(client, {
+          repoRoot: cwd,
+          name: this.worktreeName,
+          baseRef: this.baseRef,
+        });
+        if (requestId !== this.submitRequestToken || this.gatewayClient !== client) {
+          return;
+        }
+        cwd = created.path;
+      }
+      const result = await client.request<SessionsCatalogStartTerminalResult>(
+        "sessions.catalog.startTerminal",
+        {
+          catalogId,
+          ...(this.execNode ? { hostId: `node:${this.execNode}` } : {}),
+          agentId,
+          cwd,
+          ...(initialMessage ? { initialMessage } : {}),
+        },
+      );
+      if (requestId !== this.submitRequestToken || this.gatewayClient !== client) {
+        return;
+      }
+      this.message = "";
+      openTerminalSessionInTerminal(result.sessionId);
+    } catch (error) {
+      if (requestId === this.submitRequestToken && this.gatewayClient === client) {
+        this.error = error instanceof Error ? error.message : String(error);
+      }
     } finally {
       if (requestId === this.submitRequestToken) {
         this.submitting = false;
@@ -1832,6 +1931,13 @@ class NewSessionPage extends OpenClawLightDomElement {
           textareaController: this.composerTextarea,
           messageLocked: Boolean(this.pendingCloud.sessionKey),
           incognitoDisabledReason: this.incognitoDisabledReason(),
+          terminalAction: this.showStartInTerminal()
+            ? {
+                canStart: this.canSubmit("terminal"),
+                disabledReason: this.terminalStartDisabledReason(),
+                onStart: () => void this.startInTerminal(),
+              }
+            : undefined,
           onInput: (message) => {
             if (!this.submitting && !this.pendingCloud.sessionKey) {
               this.message = message;

--- a/ui/src/pages/new-session/route.ts
+++ b/ui/src/pages/new-session/route.ts
@@ -14,7 +14,13 @@ async function loadNewSessionData(
   const requestedLocation = newSessionLocationFromSearch(search);
   const requestedAgentId = requestedLocation.agentId.trim();
   if (!requestedLocation.catalogId) {
-    return { ...requestedLocation, requestedAgentId, model: "", catalogLabel: "" };
+    return {
+      ...requestedLocation,
+      requestedAgentId,
+      model: "",
+      catalogLabel: "",
+      startTerminal: false,
+    };
   }
   const { resolveAgentId, resolveCreateTarget } = await import("./catalog-target.ts");
   const unresolved = (agentId = ""): NewSessionRouteData => ({
@@ -23,6 +29,7 @@ async function loadNewSessionData(
     requestedAgentId,
     model: "",
     catalogLabel: "",
+    startTerminal: false,
   });
   const initialGateway = context.gateway.snapshot;
   const initialAgentsState = context.agents.state;

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -24,6 +24,7 @@ import {
   resolveSessionPreferredFaceForKey,
   sessionNavigationTarget,
 } from "../../lib/sessions/route-navigation.ts";
+import { createManagedWorktree } from "../../lib/worktrees/create-worktree.ts";
 import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 
@@ -279,10 +280,10 @@ class WorktreesPage extends OpenClawLightDomElement {
     this.creating = true;
     this.error = null;
     try {
-      await scope.client.request("worktrees.create", {
+      await createManagedWorktree(scope.client, {
         repoRoot,
-        ...(this.createName.trim() ? { name: this.createName.trim() } : {}),
-        ...(this.createBaseRef.trim() ? { baseRef: this.createBaseRef.trim() } : {}),
+        name: this.createName,
+        baseRef: this.createBaseRef,
       });
       if (this.gateway.isCurrent(scope)) {
         this.createOpen = false;

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -338,6 +338,35 @@ wa-popover.new-session-page__place-popover::part(body) {
   border-radius: var(--radius-md);
 }
 
+.new-session-page__start-split {
+  display: inline-flex;
+  align-items: center;
+}
+
+.new-session-page__start-primary {
+  width: 34px;
+  min-width: 34px;
+  border-radius: var(--radius-full) 0 0 var(--radius-full);
+}
+
+wa-dropdown.new-session-page__start-menu {
+  display: inline-flex;
+}
+
+.new-session-page__start-menu-trigger {
+  width: 22px;
+  min-width: 22px;
+  height: 36px;
+  padding: 0 4px 0 2px;
+  border-left: 1px solid color-mix(in srgb, var(--primary-foreground) 28%, transparent);
+  border-radius: 0 var(--radius-full) var(--radius-full) 0;
+}
+
+.new-session-page__start-menu-trigger svg {
+  width: 13px;
+  height: 13px;
+}
+
 /* Keep a long first prompt visible before scrolling. The shared auto-height
    controller measures content; this surface owns its ten-line visual cap. */
 .new-session-page__composer .new-session-page__message {


### PR DESCRIPTION
## What Problem This Solves

Labs users who select a CLI agent catalog target from the new-session page could only start the existing OpenClaw session flow, even when the selected catalog can create a terminal-backed session. Starting that CLI agent in the terminal therefore required leaving the page and manually recreating the same folder, agent, and worktree choices elsewhere.

Builds on #120949 and #121020.

## Why This Change Was Made

This adds a capability-gated split action beside the existing Start control. The secondary “Start in terminal” action appears only when the CLI-agents Labs gate, terminal availability gate, and resolved catalog capability all allow it. It reuses the existing worktree creation contract when requested, calls the catalog terminal-start method with the selected agent/folder/node and trimmed prompt, then opens the returned server session through the terminal panel’s established attach event. The plain Start path remains unchanged.

## User Impact

Labs users can now launch a supported CLI agent directly into the embedded terminal from the new-session page, including optional managed-worktree provisioning. Empty prompts are supported, actionable gateway errors remain visible in the page, and unsupported catalogs keep the original single Start button pixel-identical.

Release-note context: CLI-agent catalog targets in Labs now offer “Start in terminal” when the Gateway and catalog advertise the capability. No `CHANGELOG.md` edit is included because release generation owns that file.

Production LOC: +261/-32 (net +229) | Tests: +402/-43

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/new-session` — 16 files, 159 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts` — 12 tests passed on the rebased head.
- Browser coverage proves all three visibility gates, plain Start preservation, worktree-before-terminal request order, trimmed and empty prompt contracts, returned-session toggle dispatch, and exact server error preservation.
- `pnpm ui:i18n:baseline` and `pnpm ui:i18n:verify` — passed; the rebased-head verify reports 98 raw-copy baseline entries and 4,646 source keys.
- Targeted `node scripts/run-oxlint.mjs ...` — passed.
- `node scripts/check-changed.mjs` — passed on patch-equivalent source in Blacksmith Testbox `tbx_01kzkmcdhyk0tzhgdc7w1g5s4c`, [Actions run 31322896739](https://github.com/openclaw/openclaw/actions/runs/31322896739).
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean; no accepted/actionable findings.
- Deterministic red-main repair: current `origin/main` reproduced `ui/src/pages/labs/labs-page.test.ts` at 43 passed / 1 failed because the positional “Cloud Worker Desktop” selection clicked “Message audit metadata” after #120949 inserted the CLI-agents row alongside #120727.
- The Labs test now selects every feature row by stable title instead of registry position; the isolated suite passes 44/44 after the repair.
- AI-assisted implementation; the complete diff and relevant route, page, worktree, terminal attach, protocol, and test-owner paths were reviewed before publication.

### ClawSweeper findings

- Attachment-draft gating is intentionally skipped in this PR. The A3 contract starts terminal sessions with an optional trimmed `initialMessage` and the requested red-main follow-up is test-only; changing the composer’s production behavior here would exceed that scope. Attachment support or an explicit attachment guard needs its own product-contract follow-up.
- Selected-node gating is intentionally skipped because A3 explicitly requires forwarding the selected node as `hostId: node:<id>` and preserving the Gateway’s actionable error. Encoding today’s provider-specific node-start limitations in this generic UI would contradict that contract.

### Visual proof

Before — catalog-target mode with the unchanged plain Start control:

![Before: plain Start control](https://github.com/user-attachments/assets/4bf2677e-226f-492d-af89-8d230b2f800e)

After — supported CLI agent target with the terminal split action:

![After: Start in terminal split control](https://github.com/user-attachments/assets/7f974d5d-5350-4984-9b9c-e665599dd1af)
