### PR TITLE
fix(ui): show concrete defaults in new sessions

### DIFF
--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -63,10 +63,16 @@ function renderControl(
   control: NewSessionModelControl,
   context: ApplicationContext,
   agentId = "main",
+  agent: GatewayAgentRow | null = {
+    id: "main",
+    model: { primary: "openai/gpt-5.6-luna" },
+    thinkingDefault: "medium",
+  },
 ) {
   const container = document.createElement("div");
   render(
     control.render({
+      ...(agent ? { agent } : {}),
       agentId,
       context,
       sending: false,
@@ -219,6 +225,96 @@ describe("new-session model runtime", () => {
     ).toBe("true");
     expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
     pending.resolve({ models: [] });
+  });
+
+  it("waits for selected-agent defaults after chat metadata resolves", async () => {
+    const { context, request } = contextWith([
+      { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai", reasoning: true },
+      { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai", reasoning: true },
+    ]);
+    const notify = vi.fn();
+    const control = new NewSessionModelControl(notify);
+
+    control.load(context, "main", true);
+    await vi.waitFor(() => {
+      expect(request).toHaveBeenCalledOnce();
+      expect(notify).toHaveBeenCalledTimes(2);
+    });
+
+    let container = renderControl(control, context, "main", null);
+    const loadingModelTrigger = container.querySelector('[data-chat-model-select="true"]');
+    expect(loadingModelTrigger?.textContent).toContain("Loading models");
+    expect(loadingModelTrigger?.textContent).not.toContain("Default model");
+    expect(container.querySelector('[data-chat-thinking-select="true"]')?.textContent).toContain(
+      "Medium",
+    );
+    expect(control.selected).toBe("");
+    expect(control.thinkingLevel).toBe("");
+
+    container = renderControl(control, context, "main", {
+      id: "main",
+      model: { primary: "openai/gpt-5.6-sol" },
+      thinkingDefault: "high",
+    });
+    expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
+      "GPT-5.6 Sol",
+    );
+    expect(container.querySelector('[data-chat-thinking-select="true"]')?.textContent).toContain(
+      "High",
+    );
+    expect(control.selected).toBe("");
+    expect(control.thinkingLevel).toBe("");
+  });
+
+  it("shows Medium for a hydrated agent without a projected thinking default", async () => {
+    const { context, request } = contextWith([
+      { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai", reasoning: true },
+    ]);
+    const notify = vi.fn();
+    const control = new NewSessionModelControl(notify);
+
+    control.load(context, "main", true);
+    await vi.waitFor(() => {
+      expect(request).toHaveBeenCalledOnce();
+      expect(notify).toHaveBeenCalledTimes(2);
+    });
+
+    const container = renderControl(control, context, "main", {
+      id: "main",
+      model: { primary: "openai/gpt-5.6-sol" },
+    });
+    expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
+      "GPT-5.6 Sol",
+    );
+    expect(container.querySelector('[data-chat-thinking-select="true"]')?.textContent).toContain(
+      "Medium",
+    );
+    expect(control.selected).toBe("");
+    expect(control.thinkingLevel).toBe("");
+  });
+
+  it("preserves an explicitly remembered Off effort", async () => {
+    const agent = {
+      id: "main",
+      model: { primary: "openai/gpt-5.6-sol" },
+      thinkingDefault: "high",
+    } satisfies GatewayAgentRow;
+    const { context } = contextWith([
+      { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai", reasoning: true },
+    ]);
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true, {
+      agent,
+      preference: { thinkingLevel: "off" },
+    });
+
+    await vi.waitFor(() => expect(control.thinkingLevel).toBe("off"));
+    const container = renderControl(control, context, "main", agent);
+    expect(container.querySelector('[data-chat-thinking-select="true"]')?.textContent).toContain(
+      "Off",
+    );
+    expect(control.selected).toBe("");
   });
 
   it.each([

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -577,6 +577,7 @@ export class NewSessionModelControl {
     const snapshot = options.context?.gateway.snapshot;
     const sessionKey = `new-session:${normalizeAgentId(options.agentId)}`;
     const sourceResult = options.context?.sessions.state.result ?? null;
+    const agentDefaultsAvailable = options.agent !== undefined;
     const agentDefaultModel = options.agent?.model?.primary;
     const defaultTarget = resolveDraftModelTarget(
       agentDefaultModel ?? sourceResult?.defaults.model,
@@ -601,7 +602,8 @@ export class NewSessionModelControl {
       agentRuntime: options.agent?.agentRuntime ?? sourceResult?.defaults.agentRuntime,
       thinkingLevels: options.agent?.thinkingLevels ?? sourceResult?.defaults.thinkingLevels,
       thinkingOptions: options.agent?.thinkingOptions ?? sourceResult?.defaults.thinkingOptions,
-      thinkingDefault: options.agent?.thinkingDefault ?? sourceResult?.defaults.thinkingDefault,
+      thinkingDefault:
+        options.agent?.thinkingDefault ?? sourceResult?.defaults.thinkingDefault ?? "medium",
     };
     return renderChatModelControls({
       activeRunId: null,
@@ -611,9 +613,14 @@ export class NewSessionModelControl {
       loading: false,
       modelCatalog: this.catalog,
       modelCatalogState: {
-        hasSnapshot: this.metadataState.hasSnapshot,
+        // chat.metadata and agents.list hydrate independently. Do not expose a
+        // ready catalog until the selected agent can supply its concrete defaults.
+        hasSnapshot: agentDefaultsAvailable && this.metadataState.hasSnapshot,
         ...(this.metadataState.status === "error" ? { onRetry: this.retryMetadata } : {}),
-        status: this.metadataState.status,
+        status:
+          !agentDefaultsAvailable && this.metadataState.status !== "error"
+            ? "loading"
+            : this.metadataState.status,
       },
       modelOverrides: { [sessionKey]: this.selected },
       modelPickerTargetGroups:


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a new session could see the generic `Default model` label and an `Off` thinking level while the model catalog finished loading before the selected agent and session defaults. The composer could therefore present defaults that did not match the session the Gateway would actually create.

## Why This Change Was Made

The new-session model control now treats the selected agent projection as part of readiness: it keeps the model control in its loading presentation until the concrete agent default is available. Missing thinking metadata uses `Medium` as the new-session presentation fallback, while authoritative agent/session values—including legitimate `Off`—still win. Both draft overrides remain empty, so the Gateway continues to own inherited defaults.

This change is AI-assisted and was reviewed with the repository autoreview workflow.

## User Impact

New sessions no longer flash or remain on `Default model · Off`. Users see `Loading models… · Medium` during the cold hydration window, then the concrete selected model and effective thinking level. Explicit model or thinking choices still create overrides normally.

## Evidence

### Before

![New session showing Default model and Off](https://github.com/user-attachments/assets/bf1e6124-ef66-4b05-8787-0e5be3762b12)

### After

![New session showing Loading models and Medium](https://github.com/user-attachments/assets/e2298880-57b6-418a-a34f-400ace77d670)

- Source-backed Control UI mock, with both `agents.list` and `sessions.list` delayed:
  - before: `Default model`, `Off`, empty model/thinking overrides
  - after: `Loading models…`, `Medium`, empty model/thinking overrides
- Hydrated browser state: concrete `gpt-5.5 · openai`, `Medium`, empty model/thinking overrides.
- User interaction proof: selecting GPT-5.6 Sol set the model override; moving the thinking slider to High set the thinking override; resetting returned to inheritance.
- `node scripts/run-vitest.mjs ui/src/pages/new-session/model-control.test.ts` — 31 tests passed.
- `pnpm check:test-types` — passed all test typecheck lanes.
- Classified changed-file checks passed locally, including UI/core test typechecks, UI i18n verification, formatting, dead-export checks, dependency guards, and targeted oxlint. The first delegated run could not acquire any Crabbox provider, so the same classified commands were run locally per fallback policy.
- Exact-head CI run [31326298778](https://github.com/openclaw/openclaw/actions/runs/31326298778) — green with no pending or failed checks.
- Codex autoreview: clean, no accepted/actionable findings.
- Source-blind behavior validation: pass for the complete cold → hydrated → explicit-selection contract.
