### PR TITLE
test(gateway): boot a minimal test gateway in the gateway lane

### DIFF
--- a/src/gateway/server-startup-minimal-boot.test.ts
+++ b/src/gateway/server-startup-minimal-boot.test.ts
@@ -1,0 +1,57 @@
+// Minimal-gateway boot smoke: guards the startup path the Control UI e2e suites
+// depend on. Bundled plugins stay enabled on purpose — disabling them (as other
+// gateway boot tests do) hides startup work that materializes plugin runtime,
+// which is exactly how a startup stall shipped green while hanging every
+// ui-e2e suite that boots a minimal test gateway.
+import { describe, expect, it } from "vitest";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { getFreePort } from "../test-utils/ports.js";
+
+// Local boot completes in ~10s; the budget only buys headroom for loaded CI
+// runners. A stall exhausts it and fails in the gateway lane instead of first
+// surfacing on unrelated UI PRs.
+const BOOT_BUDGET_MS = 90_000;
+
+describe("gateway minimal boot smoke", () => {
+  it("boots a minimal test gateway within budget", { timeout: BOOT_BUDGET_MS }, async () => {
+    const port = await getFreePort();
+    const state = await createOpenClawTestState({
+      label: "gateway-minimal-boot-smoke",
+      layout: "home",
+      env: {
+        OPENCLAW_GATEWAY_PASSWORD: undefined,
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_PROVIDERS: "1",
+        OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+        VITEST: "1",
+      },
+    });
+    const token = "gateway-minimal-boot-smoke-token";
+    await state.writeConfig({
+      gateway: {
+        auth: { mode: "token", token },
+        controlUi: { enabled: false },
+        port,
+      },
+    });
+    state.applyEnv();
+    try {
+      const { startGatewayServer } = await import("./server.js");
+      const server = await startGatewayServer(port, {
+        auth: { mode: "token", token },
+        bind: "loopback",
+        controlUiEnabled: false,
+        sidecarStartup: "defer",
+      });
+      expect(server).toBeTruthy();
+      await server.close({ reason: "minimal boot smoke complete" });
+    } finally {
+      await state.cleanup();
+    }
+  });
+});

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -8,7 +8,9 @@ import {
   hasPromptSnapshotAffectingChange,
   hasQaSmokeAffectingChange,
 } from "../../scripts/lib/ci-changed-node-test-plan.mts";
+import { hasImportGraphImpactOnTargets } from "../../scripts/test-projects.test-support.mts";
 import { listGitTrackedFiles } from "../../src/test-utils/repo-files.js";
+import { isGatewayServerTestFile } from "../vitest/vitest.gateway-server-paths.mjs";
 
 describe("CI changed Node test plan", () => {
   it("routes a focused source change into one targeted job", () => {
@@ -114,6 +116,22 @@ describe("CI changed Node test plan", () => {
 
   it("fails safe to the full plan for broad changes", () => {
     expect(createChangedNodeTestShards(["package.json"])).toBeNull();
+  });
+
+  it("keeps minimal-gateway boot coverage reachable from gateway startup changes", () => {
+    // A gateway startup stall must fail in the gateway lane; the boot smoke is
+    // selected purely through the import graph, so a rename or an import shape
+    // the graph walker cannot see would silently drop it from targeted plans
+    // and the stall would first surface on unrelated ui-e2e PRs again.
+    const bootSmoke = "src/gateway/server-startup-minimal-boot.test.ts";
+    expect(isGatewayServerTestFile(bootSmoke)).toBe(true);
+    expect(
+      hasImportGraphImpactOnTargets(
+        ["src/gateway/server-startup-bootstrap.ts"],
+        [bootSmoke],
+        process.cwd(),
+      ),
+    ).toBe(true);
   });
 
   it("fails safe whenever a diff deletes source files", () => {

--- a/ui/src/pages/labs/labs-page.test.ts
+++ b/ui/src/pages/labs/labs-page.test.ts
@@ -147,14 +147,14 @@ describe("LabsPage", () => {
       // The on position restores the shipped "auto" tier, never `true`: Labs
       // offers Auto/Off, and force-on stays a config-only power-user state.
       label: "Code Mode",
-      index: 0,
+      id: "codeMode",
       sourceConfig: { tools: { codeMode: { enabled: false } } },
       expectedPatch: { tools: { codeMode: { enabled: null } } },
       note: "labs: update codeMode",
     },
     {
       label: "Swarm",
-      index: 1,
+      id: "swarm",
       sourceConfig: { tools: { swarm: { enabled: false } } },
       expectedPatch: { tools: { swarm: { enabled: true } } },
       note: "labs: update swarm",
@@ -164,28 +164,28 @@ describe("LabsPage", () => {
       // mode to "code", so a bare `enabled: true` would select the surface with
       // the weakest recall rather than the one this row advertises.
       label: "Tool Search",
-      index: 2,
+      id: "toolSearch",
       sourceConfig: { tools: { toolSearch: { enabled: false } } },
       expectedPatch: { tools: { toolSearch: { enabled: true, mode: "directory" } } },
       note: "labs: update toolSearch",
     },
     {
       label: "Tool-loop detection",
-      index: 3,
+      id: "loopDetection",
       sourceConfig: { tools: { loopDetection: { enabled: false } } },
       expectedPatch: { tools: { loopDetection: { enabled: true } } },
       note: "labs: update loopDetection",
     },
     {
       label: "Lean tools for local models",
-      index: 4,
+      id: "localModelLean",
       sourceConfig: {},
       expectedPatch: { agents: { defaults: { experimental: { localModelLean: true } } } },
       note: "labs: update localModelLean",
     },
     {
       label: "CLI agents",
-      index: 5,
+      id: "cliAgents",
       sourceConfig: {},
       expectedPatch: { gateway: { cliAgents: { enabled: true } } },
       note: "labs: update cliAgents",
@@ -194,21 +194,24 @@ describe("LabsPage", () => {
       // Not a boolean gate: the on state is the conservative `direct` mode, so
       // enabling here cannot start recording group or unknown conversations.
       label: "Message audit metadata",
-      index: 6,
+      id: "auditMessages",
       sourceConfig: { logging: { audit: { messages: "off" } } },
       expectedPatch: { logging: { audit: { messages: "direct" } } },
       note: "labs: update auditMessages",
     },
     {
       label: "Cloud Worker Desktop",
-      index: 7,
+      id: "workerDesktop",
       sourceConfig: { cloudWorkers: { desktop: false } },
       expectedPatch: { cloudWorkers: { desktop: true } },
       note: "labs: update workerDesktop",
     },
   ])("writes the on value at the registered config path when enabling $label", async (testCase) => {
+    // Resolve the row from the registry: hardcoded indices rot when a new lab
+    // entry lands and silently toggle a neighboring row instead.
+    const rowIndex = LAB_FEATURES.findIndex((feature) => feature.id === testCase.id);
     const { page, runtimeConfig } = await mountPage(testCase.sourceConfig);
-    const toggle = labToggle(page, testCase.index, testCase.label);
+    const toggle = labToggle(page, rowIndex, testCase.label);
 
     toggle.checked = true;
     toggle.dispatchEvent(new Event("change", { bubbles: true, composed: true }));


### PR DESCRIPTION
## What Problem This Solves

PR #120926 (3bfe82180e1) changed `src/gateway/server-chat-metadata-lifecycle.ts` and hung every `checks-ui-e2e` suite that boots a minimal test gateway — yet its own CI was green. The breakage first surfaced on unrelated UI PRs, because no test owned by the gateway lane boots a minimal test gateway the way the ui-e2e suites do.

The existing gateway boot coverage (`src/gateway/gateway.test.ts`) disables bundled plugins and boots from an empty plugin dir. That masks exactly the startup work that hung: the regressed `await runtime.refresh()` materializes plugin/model runtime during minimal-mode startup, which only stalls when bundled plugins are enabled — the environment the ui-e2e suites use. The changed-scope classifier correctly selects the ui-e2e lane only for ui-touching diffs, so gateway PRs never ran the one suite that held this invariant. Per AGENTS.md: a test asserting an invariant owned by lane X belongs in lane X's suite.

## Why This Change Was Made

Two options were considered:

- (a) make `src/gateway/**` diffs select the `checks-ui-e2e` lane — runs the full Chromium lane (UI build + browser + all suites, many minutes) on every gateway PR;
- (b) a fast gateway-lane boot smoke — one ~15s test in an existing gateway shard.

This PR implements (b). `src/gateway/server-startup-minimal-boot.test.ts` boots a minimal test gateway in-process with the ui-e2e environment (bundled plugins enabled, same `OPENCLAW_SKIP_*` set, `sidecarStartup: "defer"`) under a strict time budget.

Selection needs no planner changes: the smoke imports `./server.js`, so `createChangedNodeTestShards` reaches it through the import graph for any diff that can affect gateway startup (verified for `server-chat-metadata-lifecycle.ts`, `server-startup-post-attach.ts`, and `src/agents/auth-profiles/store.ts`), and full-suite plans run it in the existing `agentic-control-plane-startup-core` shard (`requiresDist: false`, no dist/build cost). A planner regression test in `test/scripts/ci-changed-node-test-plan.test.ts` keeps the smoke classified as a gateway-server test file and import-graph-reachable from `src/gateway/server-startup-bootstrap.ts`, so a rename or a graph-invisible import shape cannot silently drop the coverage.

## User Impact

None at runtime — the diff is test-only (0 production LOC). For maintainers: a gateway startup stall now fails in the gateway lane on the PR that introduces it, instead of shipping green and hanging unrelated UI PRs.

## Evidence

- Bug reproduction: reintroducing the #120926 hunk (hoisting the awaited catch-up refresh out of the sidecar guard) makes the new smoke hang and fail via the vitest wrapper watchdog (`[test] FAILED (exit 143)`); the existing `gateway.test.ts` minimal-boot test still passes with the bug present (37s, green), proving the masking.
- Healthy code: smoke passes under both the local `test/vitest/vitest.gateway.config.ts` (~21s wall, ~14s test) and the CI shard config `test/vitest/vitest.gateway-server.config.ts` (~20s wall).
- Planner suite: `node scripts/run-vitest.mjs test/scripts/ci-changed-node-test-plan.test.ts` — 21/21 passed.
- Shard placement: `createNodeTestShards` places the smoke in `agentic-control-plane-startup-core` (requiresDist false, blacksmith-8vcpu-ubuntu-2404).
- oxfmt, oxlint (core tsconfig), and `pnpm tsgo:core:test` clean; Codex autoreview (`gpt-5.6-sol`) on the diff: no accepted/actionable findings.

## Red-main fix included

The first CI run on this PR failed on `ui/src/pages/labs/labs-page.test.ts` — a breakage on current `main`, not this diff: 8fdf7570a17 (#120727) added the Cloud Worker Desktop labs entry with a hardcoded row index colliding with Message audit metadata, so its table case toggled the neighboring row. It only surfaces on PRs that run the compact full suite (exactly the lane this PR's gateway diff selects). Per AGENTS.md ("Landing PR onto red main: fix the breakage in the same landing PR"), the second commit derives each table case's row index from `LAB_FEATURES` by feature id — the idiom the rest of the suite already uses — killing the stale-index class. Local proof: 44/44 pass on `origin/main` + this branch.
