### PR TITLE
feat(pairing): offer Tailscale in the Control UI pairing wizard

### DIFF
--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -151,6 +151,13 @@ Use an already connected Control UI session with `operator.admin` access:
      address issues Limited access, and this is not exposure to the public
      internet. Confirming applies the Gateway's own configuration change, so the
      Gateway restarts and this page reconnects on its own.
+   - **Tailscale** — optional, for phones signed in to the same tailnet. It uses
+     an existing Tailscale Serve route that already reaches this Gateway.
+     OpenClaw never creates, changes, or removes Tailscale routes, so when
+     Tailscale is absent, signed out, still starting, missing a Serve route, or
+     waiting on Service approval, the wizard names that one step, leaves the
+     other options untouched, and offers **Retry** once you have finished it on
+     the Gateway host.
    - **Public address** — advanced. Enter a `wss://` address that already routes
      to this Gateway. It is used once for this pairing and never stored, and
      OpenClaw does not create a tunnel for you.

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -56,8 +56,9 @@ creation has a token or password auth path.
    **Pair mobile device** on the **Devices** page. Full access is recommended
    and selected by default; choose Limited access only when you want to omit
    administrative Gateway controls. Then pick how the phone should reach the
-   Gateway — the current address, the local network, or a public `wss://`
-   address you already route here. The setup code appears once your browser has
+   Gateway — the current address, the local network, an existing Tailscale Serve
+   route, or a public `wss://` address you already route here. The setup code
+   appears once your browser has
    confirmed that address answers. See
    [Pairing](/channels/pairing#pair-from-the-control-ui-recommended) for what
    the local-network option changes.

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -108,7 +108,7 @@ An already paired administrator can create the iOS/Android connection QR without
   </Step>
 </Steps>
 
-Pairing requires `operator.admin`; a pairing-only session opens the dialog on its review path instead. The dialog first inspects how a phone can reach the Gateway and offers the current address, the local network, or an operator-supplied public `wss://` address; it issues a setup code only after your browser confirms the chosen address answers the Gateway challenge. A setup code contains a short-lived bootstrap credential, so treat the QR and copied code like a password while they are valid. For remote pairing, the Gateway must resolve to `wss://` (for example, through Tailscale Serve/Funnel); plain `ws://` is limited to loopback and private LAN addresses. See [Pairing](/channels/pairing#pair-from-the-control-ui-recommended) for the full security and fallback details.
+Pairing requires `operator.admin`; a pairing-only session opens the dialog on its review path instead. The dialog first inspects how a phone can reach the Gateway and offers the current address, the local network, an existing Tailscale Serve route, or an operator-supplied public `wss://` address; it issues a setup code only after your browser confirms the chosen address answers the Gateway challenge. A setup code contains a short-lived bootstrap credential, so treat the QR and copied code like a password while they are valid. For remote pairing, the Gateway must resolve to `wss://` (for example, through Tailscale Serve/Funnel); plain `ws://` is limited to loopback and private LAN addresses. See [Pairing](/channels/pairing#pair-from-the-control-ui-recommended) for the full security and fallback details.
 
 ## Personal identity (browser-local)
 

--- a/ui/src/e2e/mobile-pairing.e2e.test.ts
+++ b/ui/src/e2e/mobile-pairing.e2e.test.ts
@@ -56,6 +56,36 @@ const appliedLanPlan = {
   configWrite: undefined,
 };
 
+const TAILNET_URL = "wss://gateway.tail1a2b.ts.net";
+const TAILSCALE_UNAVAILABLE_COPY = "To use Tailscale, install it on the Gateway host.";
+
+/** Every unhealthy Tailscale state is a manual, resumable Gateway-host step. */
+const blockedTailscalePlan = {
+  status: "blocked",
+  mode: "tailscale",
+  configHash: BASE_CONFIG_HASH,
+  configState: "applied",
+  auth: "token",
+  blocker: "tailscale-unavailable",
+  changes: [],
+  action: { kind: "retry", target: "gateway-host", execution: "manual", resumable: true },
+};
+
+const tailscalePlan = {
+  status: "confirmation-required",
+  mode: "tailscale",
+  configHash: BASE_CONFIG_HASH,
+  configState: "applied",
+  urls: [TAILNET_URL],
+  exposure: "tailnet",
+  auth: "token",
+  access: "full",
+  accessDowngraded: false,
+  changes: [],
+  restartRequired: false,
+  preservesCurrentRoute: true,
+};
+
 /**
  * Restarts the application connection the way a `gateway.*` change does, and
  * proves the app socket really dropped and was replaced. Counting sockets for
@@ -300,6 +330,93 @@ suite.define(() => {
     );
   });
 
+  it("keeps an unavailable Tailscale option local, recoverable, and link-free", async () => {
+    const setupCode = Buffer.from(
+      JSON.stringify({ url: TAILNET_URL, bootstrapToken: "e2e-bootstrap-token" }),
+      "utf8",
+    ).toString("base64url");
+    const qrDataUrl = await qrcode.toDataURL(setupCode, { margin: 2, width: 360 });
+    mkdirSync(artifactDir, { recursive: true });
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const pageErrors: string[] = [];
+        page.on("pageerror", (error) => pageErrors.push(String(error)));
+        const gateway = await installMockGateway(page, {
+          presenceUsers: [{ self: true, id: "operator", name: "Operator" }],
+          methodResponses: {
+            "device.pair.list": { paired: [], pending: [] },
+            "device.pair.connectivity.inspect": loopbackInspection,
+            "device.pair.connectivity.plan": blockedTailscalePlan,
+            "device.pair.setupCode": {
+              access: "full",
+              auth: "token",
+              gatewayUrl: TAILNET_URL,
+              qrDataUrl,
+              setupCode,
+              urlSource: "gateway.tailscale.mode=serve",
+            },
+            "node.list": { nodes: [] },
+          },
+        });
+
+        await page.goto(`${suite.server.baseUrl}settings/security`);
+        await page
+          .locator(".security-page")
+          .getByRole("button", { name: "Pair mobile device" })
+          .click();
+        await page.getByRole("dialog", { name: "OpenClaw mobile" }).waitFor();
+        await page.getByText("How should this phone reach the Gateway?").waitFor();
+
+        await page.getByRole("button", { name: /^Tailscale/ }).click();
+        await page.getByText(TAILSCALE_UNAVAILABLE_COPY).waitFor();
+        expect((await gateway.getRequests("device.pair.connectivity.plan")).at(-1)?.params).toEqual(
+          {
+            mode: "tailscale",
+          },
+        );
+        // The unavailable branch states the requirement and offers recovery and
+        // nothing else: no link, download, or install action of any kind.
+        const branch = page.locator(".device-pair-setup__body");
+        expect(await branch.locator("a").count()).toBe(0);
+        expect(await branch.locator("button").allInnerTexts()).toEqual(["Retry", "Back"]);
+        expect(await gateway.getRequests("device.pair.setupCode")).toEqual([]);
+        expect(await gateway.getRequests("config.patch")).toEqual([]);
+        await settleDialog(page);
+        await page.screenshot({ path: path.join(artifactDir, "07-tailscale-unavailable.png") });
+
+        // Back leaves the sibling routes exactly as they were.
+        await page.getByRole("button", { name: "Back", exact: true }).click();
+        await page.getByText("How should this phone reach the Gateway?").waitFor();
+        expect(await page.getByRole("button", { name: /^Local network/ }).isEnabled()).toBe(true);
+        expect(await page.getByRole("button", { name: /^Public address/ }).isEnabled()).toBe(true);
+
+        // Retry re-plans from authoritative Gateway state after the host step.
+        await page.getByRole("button", { name: /^Tailscale/ }).click();
+        await page.getByText(TAILSCALE_UNAVAILABLE_COPY).waitFor();
+        await gateway.setMethodResponse("device.pair.connectivity.plan", tailscalePlan);
+        await page.getByRole("button", { name: "Retry" }).click();
+
+        const qr = page.getByAltText("OpenClaw mobile pairing QR code");
+        await qr.waitFor();
+        // The tailnet candidate answered the challenge in this browser first.
+        expect(await gateway.getSocketUrls()).toContain(TAILNET_URL);
+        expect((await gateway.getRequests("device.pair.setupCode")).map((r) => r.params)).toEqual([
+          { mode: "tailscale" },
+        ]);
+        expect(await page.getByText(TAILNET_URL, { exact: true }).isVisible()).toBe(true);
+        expect(await gateway.getRequests("config.patch")).toEqual([]);
+        await settleDialog(page);
+        await page.screenshot({ path: path.join(artifactDir, "08-tailscale-code.png") });
+        expect(pageErrors).toEqual([]);
+      },
+    );
+  });
+
   it.each(PAIRING_VIEWPORTS)(
     "renders the chooser and LAN review at $name width in both themes",
     async (viewport) => {
@@ -315,7 +432,7 @@ suite.define(() => {
             viewport: { height: viewport.height, width: viewport.width },
           },
           async ({ page }) => {
-            await installMockGateway(page, {
+            const gateway = await installMockGateway(page, {
               presenceUsers: [{ self: true, id: "operator", name: "Operator" }],
               methodResponses: {
                 "device.pair.list": { paired: [], pending: [] },
@@ -344,6 +461,19 @@ suite.define(() => {
             await settleDialog(page);
             await page.screenshot({
               path: path.join(artifactDir, `lan-review-${viewport.name}-${colorScheme}.png`),
+            });
+
+            await page.getByRole("button", { name: "Back", exact: true }).click();
+            await page.getByText("How should this phone reach the Gateway?").waitFor();
+            await gateway.setMethodResponse("device.pair.connectivity.plan", blockedTailscalePlan);
+            await page.getByRole("button", { name: /^Tailscale/ }).click();
+            await page.getByText(TAILSCALE_UNAVAILABLE_COPY).waitFor();
+            await settleDialog(page);
+            await page.screenshot({
+              path: path.join(
+                artifactDir,
+                `tailscale-unavailable-${viewport.name}-${colorScheme}.png`,
+              ),
             });
           },
         );

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -499,6 +499,8 @@ export const en: TranslationMap = {
       routeLanHint: "Phones on the same network as this computer.",
       routeLanInsecurePage:
         "Unavailable from this secure page: the browser cannot check a plaintext local address.",
+      routeTailscale: "Tailscale",
+      routeTailscaleHint: "Phones signed in to the same tailnet as this Gateway.",
       routePublic: "Public address",
       routePublicHint: "You already route a secure wss:// address to this Gateway.",
       noticeReverted: "The previous network setting was restored.",
@@ -553,7 +555,20 @@ export const en: TranslationMap = {
       blockedPublicRequired: "Enter the address that reaches this Gateway.",
       blockedPublicInvalid: "Enter a plain wss:// host, with no path, query, or credentials.",
       blockedPublicInsecure: "Public pairing requires a secure wss:// address.",
-      blockedGatewayHost: "Finish this step on the Gateway host, then try again.",
+      blockedTailscaleUnavailable: "To use Tailscale, install it on the Gateway host.",
+      blockedTailscaleLoginRequired:
+        "Sign in to Tailscale on the Gateway host. A new machine may also need approval in your tailnet.",
+      blockedTailscaleNotRunning: "Tailscale is installed on the Gateway host but not running.",
+      blockedTailscaleStarting: "Tailscale is still starting on the Gateway host.",
+      blockedTailscaleStatusError: "Tailscale status could not be read on the Gateway host.",
+      blockedTailscaleServeRequired:
+        "No Tailscale Serve route reaches this Gateway. Set one up on the Gateway host.",
+      blockedTailscaleServeConflict:
+        "Another Tailscale Serve route already uses this address. OpenClaw leaves existing routes as they are.",
+      blockedTailscaleApprovalRequired:
+        "This Tailscale service is waiting for approval in your tailnet.",
+      blockedTailscaleApprovalUnknown:
+        "The approval state of this Tailscale service could not be read.",
       generateCode: "Create setup code",
       transportLimitedTitle: "Limited for network safety",
       transportLimitedHint:

--- a/ui/src/lib/pairing/wizard.test.ts
+++ b/ui/src/lib/pairing/wizard.test.ts
@@ -54,6 +54,43 @@ const appliedLanPlan = {
   configWrite: undefined,
 };
 
+const TAILNET_URL = "wss://gateway.tail1a2b.ts.net";
+
+const tailscalePlan = {
+  status: "confirmation-required",
+  mode: "tailscale",
+  configHash: CONFIG_HASH,
+  configState: "applied",
+  urls: [TAILNET_URL],
+  exposure: "tailnet",
+  auth: "token",
+  access: "full",
+  accessDowngraded: false,
+  changes: [],
+  restartRequired: false,
+  preservesCurrentRoute: true,
+};
+
+const blockedTailscalePlan = {
+  status: "blocked",
+  mode: "tailscale",
+  configHash: CONFIG_HASH,
+  configState: "applied",
+  auth: "token",
+  blocker: "tailscale-serve-required",
+  changes: [],
+  action: { kind: "retry", target: "gateway-host", execution: "manual", resumable: true },
+};
+
+const tailnetSetupCode = {
+  setupCode: "SETUP-CODE",
+  gatewayUrl: TAILNET_URL,
+  auth: "token",
+  urlSource: "gateway.tailscale.mode=serve",
+  access: "full",
+  accessDowngraded: false,
+};
+
 function setupCodeFor(gatewayUrl: string) {
   return {
     setupCode: "SETUP-CODE",
@@ -560,5 +597,78 @@ describe("pairing wizard", () => {
 
     expect(harness.wizard.snapshot.open).toBe(false);
     expect(stepKind(harness.wizard.snapshot.step)).toBe("inspecting");
+  });
+
+  it("proves the tailnet route before minting and pins issuance to it", async () => {
+    const harness = createHarness({
+      responses: {
+        "device.pair.connectivity.plan": tailscalePlan,
+        "device.pair.setupCode": tailnetSetupCode,
+      },
+    });
+    await harness.wizard.open({ canAdmin: true });
+    await harness.wizard.chooseRoute("tailscale");
+
+    expect(harness.wizard.snapshot.step).toEqual({ kind: "code", setup: tailnetSetupCode });
+    expect(harness.methods()).toEqual([
+      "device.pair.connectivity.inspect",
+      "device.pair.connectivity.plan",
+      "device.pair.setupCode",
+    ]);
+    expect(harness.paramsOf("device.pair.connectivity.plan")).toEqual([{ mode: "tailscale" }]);
+    expect(harness.paramsOf("device.pair.setupCode")).toEqual([{ mode: "tailscale" }]);
+    // An externally owned route is read, never written or restarted.
+    expect(harness.config.patch).not.toHaveBeenCalled();
+  });
+
+  it("withholds a setup code when the tailnet route does not answer", async () => {
+    const harness = createHarness({
+      responses: { "device.pair.connectivity.plan": tailscalePlan },
+      probe: async () => ({ status: "unreachable" }),
+    });
+    await harness.wizard.open({ canAdmin: true });
+    await harness.wizard.chooseRoute("tailscale");
+
+    expect(harness.wizard.snapshot.step).toEqual({ kind: "recovery", reason: "endpoint-unproven" });
+    expect(harness.methods()).not.toContain("device.pair.setupCode");
+    expect(harness.config.patch).not.toHaveBeenCalled();
+  });
+
+  it("re-plans from authoritative state once the host step is finished", async () => {
+    const harness = createHarness({
+      responses: { "device.pair.connectivity.plan": blockedTailscalePlan },
+    });
+    await harness.wizard.open({ canAdmin: true });
+    await harness.wizard.chooseRoute("tailscale");
+
+    expect(harness.wizard.snapshot.step).toEqual({ kind: "blocked", plan: blockedTailscalePlan });
+    expect(harness.methods()).not.toContain("device.pair.setupCode");
+
+    harness.setResponse("device.pair.connectivity.plan", tailscalePlan);
+    harness.setResponse("device.pair.setupCode", tailnetSetupCode);
+    await harness.wizard.chooseRoute("tailscale");
+
+    expect(harness.wizard.snapshot.step).toEqual({ kind: "code", setup: tailnetSetupCode });
+    expect(harness.paramsOf("device.pair.connectivity.plan")).toEqual([
+      { mode: "tailscale" },
+      { mode: "tailscale" },
+    ]);
+  });
+
+  it("keeps the other routes usable while Tailscale is blocked", async () => {
+    const harness = createHarness({
+      responses: { "device.pair.connectivity.plan": blockedTailscalePlan },
+    });
+    await harness.wizard.open({ canAdmin: true });
+    await harness.wizard.chooseRoute("tailscale");
+    expect(stepKind(harness.wizard.snapshot.step)).toBe("blocked");
+
+    await harness.wizard.back();
+    expect(stepKind(harness.wizard.snapshot.step)).toBe("chooser");
+
+    harness.setResponse("device.pair.connectivity.plan", lanPlan);
+    await harness.wizard.chooseRoute("lan");
+
+    expect(harness.wizard.snapshot.step).toEqual({ kind: "lan-review", plan: lanPlan });
   });
 });

--- a/ui/src/lib/pairing/wizard.ts
+++ b/ui/src/lib/pairing/wizard.ts
@@ -13,7 +13,7 @@ import {
 } from "./endpoint-probe.ts";
 
 export type PairingWizardAccess = "full" | "limited";
-type PairingWizardRoute = "current" | "lan" | "public";
+type PairingWizardRoute = "current" | "lan" | "public" | "tailscale";
 
 type BlockedPlan = Extract<DevicePairConnectivityPlanResult, { status: "blocked" }>;
 type ConfirmedPlan = Extract<DevicePairConnectivityPlanResult, { status: "confirmation-required" }>;
@@ -159,7 +159,8 @@ export function createPairingWizard(deps: PairingWizardDeps) {
     return isCurrent(owned) ? result : null;
   };
 
-  const planRoute = async (owned: number, mode: "lan" | "public") => {
+  // `current` needs no plan: inspection already resolved the route it names.
+  const planRoute = async (owned: number, mode: Exclude<PairingWizardRoute, "current">) => {
     const result = await request<DevicePairConnectivityPlanResult>(
       "device.pair.connectivity.plan",
       { mode, ...(mode === "public" ? { publicUrl } : {}) },
@@ -184,9 +185,10 @@ export function createPairingWizard(deps: PairingWizardDeps) {
     setStep({ kind: "issuing" });
     const setup = await request<DevicePairSetupCodeResult>("device.pair.setupCode", {
       ...(snapshot.access === "limited" ? { bootstrapProfile: "limited" as const } : {}),
-      // Pin the planned route so a persisted public URL cannot replace it.
-      ...(route === "public" ? { mode: "public" as const, publicUrl } : {}),
-      ...(route === "lan" ? { mode: "lan" as const } : {}),
+      // Pin the planned route so no configured public, remote, or Tailscale
+      // address can outrank the one this browser just proved.
+      ...(route === "current" ? {} : { mode: route }),
+      ...(route === "public" ? { publicUrl } : {}),
     });
     if (!isCurrent(owned) || !setup) {
       return;
@@ -345,12 +347,18 @@ export function createPairingWizard(deps: PairingWizardDeps) {
     }
     setStep({ kind: "inspecting" });
     try {
-      const planned = await planRoute(owned, "lan");
+      const planned = await planRoute(owned, next);
       if (!planned) {
         return;
       }
       if (planned.status === "blocked") {
         setStep({ kind: "blocked", plan: planned });
+        return;
+      }
+      if (next === "tailscale") {
+        // The Serve route is the operator's, not OpenClaw's: nothing is written
+        // and nothing can be undone, so proof is all that stands before issuance.
+        await proveThenIssue(owned, planned.urls);
         return;
       }
       if (!planned.urls.every((url) => canProve(url))) {

--- a/ui/src/pages/devices/view-pairing.ts
+++ b/ui/src/pages/devices/view-pairing.ts
@@ -22,8 +22,6 @@ const PAIRING_DOCS_URL =
 
 type PairingBlocker = Extract<DevicePairConnectivityPlanResult, { status: "blocked" }>["blocker"];
 
-// Tailscale routes are not offered here; their blockers can only arrive as an
-// already-configured current route, so they share the Gateway-host message.
 const BLOCKER_COPY: Record<PairingBlocker, string> = {
   "gateway-auth-required": "devices.pairing.blockedAuthRequired",
   "gateway-auth-unavailable": "devices.pairing.blockedAuthUnavailable",
@@ -35,15 +33,15 @@ const BLOCKER_COPY: Record<PairingBlocker, string> = {
   "public-url-required": "devices.pairing.blockedPublicRequired",
   "public-url-invalid": "devices.pairing.blockedPublicInvalid",
   "public-url-insecure": "devices.pairing.blockedPublicInsecure",
-  "tailscale-unavailable": "devices.pairing.blockedGatewayHost",
-  "tailscale-login-required": "devices.pairing.blockedGatewayHost",
-  "tailscale-not-running": "devices.pairing.blockedGatewayHost",
-  "tailscale-starting": "devices.pairing.blockedGatewayHost",
-  "tailscale-status-error": "devices.pairing.blockedGatewayHost",
-  "tailscale-serve-required": "devices.pairing.blockedGatewayHost",
-  "tailscale-serve-conflict": "devices.pairing.blockedGatewayHost",
-  "tailscale-service-approval-required": "devices.pairing.blockedGatewayHost",
-  "tailscale-service-approval-unknown": "devices.pairing.blockedGatewayHost",
+  "tailscale-unavailable": "devices.pairing.blockedTailscaleUnavailable",
+  "tailscale-login-required": "devices.pairing.blockedTailscaleLoginRequired",
+  "tailscale-not-running": "devices.pairing.blockedTailscaleNotRunning",
+  "tailscale-starting": "devices.pairing.blockedTailscaleStarting",
+  "tailscale-status-error": "devices.pairing.blockedTailscaleStatusError",
+  "tailscale-serve-required": "devices.pairing.blockedTailscaleServeRequired",
+  "tailscale-serve-conflict": "devices.pairing.blockedTailscaleServeConflict",
+  "tailscale-service-approval-required": "devices.pairing.blockedTailscaleApprovalRequired",
+  "tailscale-service-approval-unknown": "devices.pairing.blockedTailscaleApprovalUnknown",
 };
 
 const RECOVERY_COPY: Record<PairingWizardRecovery, string> = {
@@ -163,6 +161,9 @@ function renderChooser(
   // A secure page cannot open the plaintext LAN candidate, so it cannot verify it.
   const lanProvable =
     inspection.lan.status === "available" && canProvePairingEndpoint(inspection.lan.url);
+  // Tailscale ignores `inspection.tailscale` and stays selectable: every unhealthy
+  // state is a Gateway-host step the operator can finish and retry, so only the
+  // branch it leads to says what is missing.
   return html`
     ${renderAccess(props, false)}
     ${props.wizard.notice === "route-reverted"
@@ -193,6 +194,11 @@ function renderChooser(
         ...(inspection.lan.status === "available" ? { detail: inspection.lan.url } : {}),
         disabled: inspection.lan.status !== "available" || !lanProvable,
         onSelect: () => void props.actions.chooseRoute("lan"),
+      })}
+      ${renderRoute({
+        label: t("devices.pairing.routeTailscale"),
+        hint: t("devices.pairing.routeTailscaleHint"),
+        onSelect: () => void props.actions.chooseRoute("tailscale"),
       })}
       ${renderRoute({
         label: t("devices.pairing.routePublic"),
@@ -270,13 +276,23 @@ function renderLanReview(
   `;
 }
 
-function renderMessage(props: DevicePairSetupProps, params: { title?: string; body: string }) {
+function renderMessage(
+  props: DevicePairSetupProps,
+  params: { title?: string; body: string; onRetry?: () => void },
+) {
   return html`
     <div class="callout warn device-pair-setup__error" role="alert">
       ${params.title ? html`<strong>${params.title}</strong>` : nothing}
       <span>${params.body}</span>
     </div>
-    <div class="device-pair-setup__actions">${renderBack(props.actions)}</div>
+    <div class="device-pair-setup__actions">
+      ${params.onRetry
+        ? html`<button class="btn primary" type="button" @click=${params.onRetry}>
+            ${icons.refresh} ${t("common.retry")}
+          </button>`
+        : nothing}
+      ${renderBack(props.actions)}
+    </div>
   `;
 }
 
@@ -388,7 +404,15 @@ function renderStep(props: DevicePairSetupProps): TemplateResult {
     case "lan-review":
       return renderLanReview(props, step);
     case "blocked":
-      return renderMessage(props, { body: t(BLOCKER_COPY[step.plan.blocker]) });
+      return renderMessage(props, {
+        body: t(BLOCKER_COPY[step.plan.blocker]),
+        // Retry re-plans from authoritative Gateway state. It is offered only
+        // when the plan itself declares a resumable manual step, so the UI never
+        // invents recovery the connectivity owner did not report.
+        ...(step.plan.action
+          ? { onRetry: () => void props.actions.chooseRoute(step.plan.mode) }
+          : {}),
+      });
     case "applying":
       return renderStatus(t("devices.pairing.applying"));
     case "awaiting-restart":


### PR DESCRIPTION
Closes #120766

Related: #120762

Depends on #121032 (#120764), #120890, #120825

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Operators who reach their Gateway over Tailscale have no way to pair a phone from the Control UI. The guided pairing wizard offers Local network and Public address, so a tailnet operator has to leave the dialog and configure pairing by hand, even when a Tailscale Serve route already points at the Gateway.

The Gateway already reports precise Tailscale state — not installed, signed out, not running, starting, unreadable status, no matching Serve route, a conflicting route, or a service waiting for tailnet approval — but nothing in the Control UI consumes it, so none of those situations reach the operator.

## Why This Change Was Made

Tailscale becomes a third route in the existing chooser. Choosing it plans against authoritative Gateway state, and the wizard renders one concise sentence for each typed host state plus Back and the retry the plan itself declares. Retry re-plans from scratch, so an operator can finish the step on the Gateway host and resume without reopening the dialog.

The option is deliberately never disabled from the inspection: every unhealthy Tailscale state is something an operator can fix and retry, so the choice stays open and only the branch it leads to reports what is missing. An unavailable Tailscale is local to that option — Local network and Public address stay selectable and plan-able, and no top-level error appears.

The Serve route is treated as the operator's, not OpenClaw's. This flow writes no configuration, restarts nothing, removes no route, and has nothing to undo. It also adds no install link, download action, App Store link, or command preview: the unavailable branch states the requirement in one sentence and stops there.

A setup code is issued only after the tailnet candidate answers the OpenClaw Gateway challenge in this browser, and issuance is pinned to `mode: "tailscale"` so a persisted public URL cannot outrank the route that was just proven. Missing, conflicting, unreadable, or unproven routes issue nothing.

No Gateway, protocol, config, or CLI change is included. This layer consumes the contracts landed by #120825 and #120890 and composes with the wizard lifecycle from #121032.

**Also in this PR:** the inherited `settleDialog` E2E helper tripped `no-promise-executor-return`, so lint was already red on the branch point. Fixed here rather than left for the next author.

## User Impact

Operators on a tailnet can pair a phone without leaving the Control UI. When Tailscale is not ready, they get one clear sentence naming the step to finish on the Gateway host and a Retry that resumes the flow, instead of a generic pairing failure or an unexplained dead end. Operators who do not use Tailscale see one extra option and no change to the Local network or Public address paths.

| Tailscale state on the Gateway host | What the operator sees |
| --- | --- |
| Not installed | "To use Tailscale, install it on the Gateway host." |
| Signed out or machine not approved | Sign-in prompt naming possible tailnet approval |
| Not running / still starting | The exact daemon state |
| Status unreadable | That the status could not be read |
| No matching Serve route | That no Serve route reaches this Gateway |
| Conflicting Serve route | That another route owns the address and OpenClaw leaves it alone |
| Service approval required or unknown | The tailnet approval state |
| Ready | Browser challenge, then the QR and setup code |

## Evidence

Head: `ccebb11b4bcd8c53c9a8bc1ea53c3b9f438e507d`, based on #121032 `244f2e205fa`.

**Product contract, re-verified on this head.** Tailscale is one optional route among four, and its failure stays local to that option:

- The chooser never disables the Tailscale button. Every unhealthy state is a Gateway-host step, so the branch it leads to names the missing step instead of hiding the option.
- Each blocker gets its own message; none links anywhere. `blockedTailscaleUnavailable` reads "To use Tailscale, install it on the Gateway host." — a statement of the missing precondition, with **no URL, no download link, no install button, and no automation**. `grep` over the full stack diff finds no `tailscale.com`, no download/install action, and no `sudo`, `serve reset/off/clear`, `--bg` or `--service`.
- Recovery is typed, manual and resumable: **Retry** renders only when the plan itself carries `action: { kind: "retry", target: "gateway-host", execution: "manual", resumable: true }`, so the UI never invents recovery the connectivity owner did not report.
- The Tailscale branch writes nothing and restarts nothing — the Serve route is the operator's — so it goes straight from plan to browser proof to issuance, with no config patch and no revert path to strand.

**Docs added on this head.** `docs/channels/pairing.md` now documents the Tailscale option, that OpenClaw never creates, changes or removes Tailscale routes, and that an absent/signed-out/starting/route-less/approval-pending Tailscale names that one step and offers Retry. `docs/web/control-ui.md` and `docs/platforms/ios.md` list the route alongside the others.

**Proof**

- Browser E2E on Blacksmith Testbox `tbx_01kzm2epywsh2fr5w6yaf6evgy` (Chromium, mocked Gateway): `ui/src/e2e/mobile-pairing.e2e.test.ts` — 5/5 green, including **"keeps an unavailable Tailscale option local, recoverable, and link-free"**, which asserts the other routes stay usable, the message is Tailscale-specific, Retry is offered, and no link is rendered.
- Focused suites (local): `ui/src/lib/pairing/wizard.test.ts` (Tailscale route cases), `ui/src/lib/pairing/endpoint-probe.test.ts`, `ui/src/app/*` overlay suites — all green.
- `pnpm plugin-sdk:api:check` green on a pristine clone of this exact head.
- Fresh `$autoreview --mode branch --base 244f2e205fa` on this head: TruffleHog clean, **no accepted/actionable findings**, `patch is correct (0.99)`.
- LOC vs base: production `+68/-21` (net `+47`), tests `+241/-1`, docs `+11/-3`. The production delta is the route entry, its nine blocker messages replacing one generic string, and the plan-declared Retry action.
