### PR TITLE
fix(telegram): preserve unsent media while deduplicating streamed replies

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
@@ -1,3 +1,7 @@
+import {
+  createOutboundPayloadPlan,
+  projectOutboundPayloadPlanForDelivery,
+} from "openclaw/plugin-sdk/channel-outbound";
 import { describe, expect, it, vi } from "vitest";
 import {
   describeTelegramDispatch,
@@ -294,6 +298,45 @@ describeTelegramDispatch("dispatchTelegramMessage fallback-topic-media", () => {
       });
 
       expect(finalDeliveryPayload().mediaUrls).toEqual([]);
+    });
+
+    it("does not restore block-sent legacy media when the final includes another attachment", async () => {
+      const sentMediaUrl = "/tmp/cat.jpg";
+      const remainingMediaUrl = "/tmp/dog.jpg";
+      deliverReplies.mockResolvedValue({ delivered: true });
+      deliverInboundReplyWithMessageSendContext.mockResolvedValue({
+        status: "handled_visible",
+        delivery: { messageIds: ["101"], visibleReplySent: true },
+      });
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ mediaUrl: sentMediaUrl }, { kind: "block" });
+        await dispatcherOptions.deliver(
+          {
+            text: "Here are the images",
+            mediaUrls: [remainingMediaUrl],
+            mediaUrl: sentMediaUrl,
+          },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      });
+
+      await dispatchWithContext({
+        context: createContext(),
+        streamMode: "off",
+        telegramDeps: telegramDepsForTest,
+      });
+
+      const finalPayload = finalDeliveryPayload();
+      expect(finalPayload).toMatchObject({
+        text: "Here are the images",
+        mediaUrl: undefined,
+        mediaUrls: [remainingMediaUrl],
+      });
+      expect(
+        projectOutboundPayloadPlanForDelivery(createOutboundPayloadPlan([finalPayload]))[0]
+          ?.mediaUrls,
+      ).toEqual([remainingMediaUrl]);
     });
 
     it("preserves final media when block delivery reports no visible send", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.media-dedup.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.media-dedup.test.ts
@@ -55,7 +55,7 @@ describe("deduplicateBlockSentMedia", () => {
     expect(result).toEqual({ text: "captioned", mediaUrl: undefined, mediaUrls: [] });
   });
 
-  it("preserves legacy mediaUrl when some mediaUrls remain", () => {
+  it("clears already-sent legacy mediaUrl when other mediaUrls remain", () => {
     const payload = {
       text: "hey",
       mediaUrl: "/tmp/a.jpg",
@@ -63,6 +63,42 @@ describe("deduplicateBlockSentMedia", () => {
     };
     const sent = new Set(["/tmp/a.jpg"]);
     const result = deduplicateBlockSentMedia(payload, sent);
-    expect(result).toEqual({ text: "hey", mediaUrl: "/tmp/a.jpg", mediaUrls: ["/tmp/b.jpg"] });
+    expect(result).toEqual({ text: "hey", mediaUrl: undefined, mediaUrls: ["/tmp/b.jpg"] });
+  });
+
+  it("preserves legacy mediaUrl when its attachment remains unsent", () => {
+    const payload = {
+      text: "hey",
+      mediaUrl: "/tmp/b.jpg",
+      mediaUrls: ["/tmp/a.jpg", "/tmp/b.jpg"],
+    };
+    const sent = new Set(["/tmp/a.jpg"]);
+    const result = deduplicateBlockSentMedia(payload, sent);
+    expect(result).toEqual({ text: "hey", mediaUrl: "/tmp/b.jpg", mediaUrls: ["/tmp/b.jpg"] });
+  });
+
+  it.each(["/tmp/dog.jpg", " /tmp/dog.jpg "])(
+    "preserves unsent legacy mediaUrl outside the remaining mediaUrls (%s)",
+    (mediaUrl) => {
+      const payload = {
+        text: "hey",
+        mediaUrl,
+        mediaUrls: ["/tmp/cat.jpg", "/tmp/bird.jpg"],
+      };
+      const sent = new Set(["/tmp/cat.jpg"]);
+      const result = deduplicateBlockSentMedia(payload, sent);
+      expect(result).toEqual({ text: "hey", mediaUrl, mediaUrls: ["/tmp/bird.jpg"] });
+    },
+  );
+
+  it("clears whitespace-padded legacy mediaUrl after its normalized attachment was sent", () => {
+    const payload = {
+      text: "hey",
+      mediaUrl: " /tmp/a.jpg ",
+      mediaUrls: ["/tmp/a.jpg", "/tmp/b.jpg"],
+    };
+    const sent = new Set(["/tmp/a.jpg"]);
+    const result = deduplicateBlockSentMedia(payload, sent);
+    expect(result).toEqual({ text: "hey", mediaUrl: undefined, mediaUrls: ["/tmp/b.jpg"] });
   });
 });

--- a/extensions/telegram/src/bot-message-dispatch.media-dedup.ts
+++ b/extensions/telegram/src/bot-message-dispatch.media-dedup.ts
@@ -12,10 +12,9 @@ export function deduplicateBlockSentMedia<
   if (remainingMedia.length === 0 && !payload.text) {
     return undefined;
   }
-  const mediaUrl = payload.mediaUrl;
   return {
     ...payload,
     mediaUrls: remainingMedia,
-    mediaUrl: mediaUrl && sentBlockMediaUrls.has(mediaUrl.trim()) ? undefined : mediaUrl,
+    mediaUrl: sentBlockMediaUrls.has(payload.mediaUrl?.trim() ?? "") ? undefined : payload.mediaUrl,
   };
 }

--- a/extensions/telegram/src/bot-message-dispatch.media-dedup.ts
+++ b/extensions/telegram/src/bot-message-dispatch.media-dedup.ts
@@ -1,4 +1,4 @@
-// Telegram plugin module implements bot message dispatch.media dedup behavior.
+// Keep sent-block media out of both delivery fields so outbound planning cannot restore it.
 export function deduplicateBlockSentMedia<
   T extends { mediaUrl?: string; mediaUrls?: string[]; text?: string },
 >(payload: T, sentBlockMediaUrls: ReadonlySet<string>): T | undefined {
@@ -12,9 +12,10 @@ export function deduplicateBlockSentMedia<
   if (remainingMedia.length === 0 && !payload.text) {
     return undefined;
   }
+  const mediaUrl = payload.mediaUrl;
   return {
     ...payload,
     mediaUrls: remainingMedia,
-    mediaUrl: remainingMedia.length === 0 ? undefined : payload.mediaUrl,
+    mediaUrl: mediaUrl && sentBlockMediaUrls.has(mediaUrl.trim()) ? undefined : mediaUrl,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram users could receive the same attachment twice when a streamed block had already delivered attachment A, but a later final reply carried distinct attachment B while the legacy `mediaUrl` still referenced A.

## Why This Change Was Made

Telegram's media-deduplication owner now normalizes the legacy value and clears it only when that attachment is in the visibly successful block-send set. Every distinct unsent `mediaUrls` or legacy attachment remains available to final delivery. Shared outbound planning is unchanged; there is no config, schema, protocol, changelog, or cross-channel behavior change.

## User Impact

Telegram mixed streamed/final replies deliver each successful attachment once. If a block send fails or produces no visible delivery, its attachment is preserved for the final send instead of being dropped.

## Evidence

### Mock-Gateway real-behavior proof

The real Telegram plugin ran through a Crabline mock Telegram Bot API, deterministic mock provider, and ephemeral Gateway on Blacksmith Testbox `tbx_01kzmzafz6kp59jkr3dferwt5w`: [Actions run 31356022924](https://github.com/openclaw/openclaw/actions/runs/31356022924). A temporary proof-only scenario created workspace PNGs, emitted streamed A before a tool call, emitted distinct final B afterward, and derived the verdict from the native Bot API recorder. The proof-only scenario was removed before push. This was the explicitly selected maintainer proof path for this landing; no external live Telegram service call was required.

```json
{
  "verdict": "PASS",
  "pr": 121141,
  "harness": "Crabline Telegram mock API + mock-openai + ephemeral Gateway",
  "qaScenarioPassed": true,
  "streamedAttachmentA": { "sends": 1, "exactlyOnce": true },
  "distinctFinalAttachmentB": { "sends": 1, "exactlyOnce": true },
  "finalPlannerRestoredA": false,
  "failedOrNonVisibleBlockPreservesA": {
    "passed": true,
    "proof": "bot-message-dispatch.fallback-topic-media.test.ts"
  },
  "focusedOwnerAndDispatchTestsPassed": true
}
```

The patch-identical pre-rebase proof passed both focused suites:

- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.media-dedup.test.ts` — 13/13
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts` — 13/13, including failed and non-visible block preservation

The exact rebased head reran both suites and all changed gates on Testbox `tbx_01kzmzpe2zxygnw6swsyfa6cap`: [Actions run 31356367570](https://github.com/openclaw/openclaw/actions/runs/31356367570).

### Dependency contract

Direct inspection of grammY 1.45.1 confirmed the generated type `sendPhoto(...): Promise<Message.PhotoMessage>` (`grammy@1.45.1/out/core/api.d.ts:226`). The pinned source documents that a successful send returns the sent `Message` and delegates directly to the raw call ([`src/core/api.ts:385-402`](https://github.com/grammyjs/grammY/blob/v1.45.1/src/core/api.ts#L385-L402)); the client returns `data.result` only for an `ok` response and throws otherwise ([`src/core/client.ts:339-347`](https://github.com/grammyjs/grammY/blob/v1.45.1/src/core/client.ts#L339-L347)). This makes the awaited successful-send boundary the authoritative point for recording sent media.

### Static and review gates

- `node scripts/check-changed.mjs -- extensions/telegram/src/bot-message-dispatch.media-dedup.ts extensions/telegram/src/bot-message-dispatch.media-dedup.test.ts extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts` — passed on the exact rebased head
- `git diff --check origin/main...HEAD` — passed
- `AGENTS_HOME="$HOME/.claude" "$HOME/.claude/skills/autoreview/scripts/autoreview" --mode branch --base origin/main --max-priority P1` — clean, no accepted/actionable findings

Production LOC: +2/-2 (net 0) | Tests: +81/-2 (net +79)
