### PR TITLE
fix(cli): reject blank configuration section filters

### DIFF
--- a/src/cli/program/register.configure.test.ts
+++ b/src/cli/program/register.configure.test.ts
@@ -44,6 +44,17 @@ describe("registerConfigureCommand", () => {
     expect(configureCommandFromSectionsArgMock).toHaveBeenCalledWith(["auth", "channels"], runtime);
   });
 
+  it.each([
+    ["an empty section", [""]],
+    ["a whitespace section", [" \t "]],
+    ["a valid and empty section", ["channels", ""]],
+    ["a valid and whitespace section", ["channels", "  "]],
+  ] as const)("preserves %s for shared section validation", async (_label, sections) => {
+    await runCli(["configure", ...sections.flatMap((section) => ["--section", section])]);
+
+    expect(configureCommandFromSectionsArgMock).toHaveBeenCalledWith([...sections], runtime);
+  });
+
   it("reports errors through runtime when configure command fails", async () => {
     configureCommandFromSectionsArgMock.mockRejectedValueOnce(new Error("configure failed"));
 

--- a/src/commands/configure.commands.test.ts
+++ b/src/commands/configure.commands.test.ts
@@ -59,20 +59,26 @@ describe("configureCommandFromSectionsArg", () => {
     expect(runConfigureWizardMock).not.toHaveBeenCalled();
   });
 
-  it("runs the wizard on an interactive terminal with no sections", async () => {
+  it.each([
+    ["omitted section values", undefined],
+    ["the Commander default", []],
+  ] as const)("runs the full wizard for %s", async (_label, sections) => {
     const runtime = makeRuntime();
 
-    await configureCommandFromSectionsArg(undefined, runtime, { interactive: true });
+    await configureCommandFromSectionsArg(sections, runtime, { interactive: true });
 
     expect(runtime.exit).not.toHaveBeenCalled();
     expect(runConfigureWizardMock).toHaveBeenCalledTimes(1);
     expect(runConfigureWizardMock).toHaveBeenCalledWith({ command: "configure" }, runtime);
   });
 
-  it("runs the wizard with sections on an interactive terminal", async () => {
+  it.each([
+    ["unchanged section names", ["channels", "plugins"]],
+    ["trimmed section names", ["  channels  ", "\tplugins\t"]],
+  ] as const)("runs only the requested wizard sections for %s", async (_label, sections) => {
     const runtime = makeRuntime();
 
-    await configureCommandFromSectionsArg(["channels", "plugins"], runtime, {
+    await configureCommandFromSectionsArg(sections, runtime, {
       interactive: true,
     });
 
@@ -82,6 +88,27 @@ describe("configureCommandFromSectionsArg", () => {
       runtime,
     );
   });
+
+  it.each([
+    ["an empty section", [""], true],
+    ["a whitespace section", [" \t "], true],
+    ["a valid section followed by an empty section", ["channels", ""], true],
+    ["a valid section followed by a whitespace section", ["channels", "  "], true],
+    ["a whitespace section before the non-interactive-terminal guard", ["  "], false],
+  ] as const)(
+    "rejects %s without opening the unrestricted wizard",
+    async (_label, sections, interactive) => {
+      const runtime = makeRuntime();
+
+      await expect(
+        configureCommandFromSectionsArg(sections, runtime, { interactive }),
+      ).rejects.toThrow("exit 1");
+
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(runtime.error.mock.calls[0]?.[0]).toContain('Invalid --section: "".');
+      expect(runConfigureWizardMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects a lone invalid section before unrestricted wizard dispatch", async () => {
     const runtime = makeRuntime();

--- a/src/commands/configure.commands.ts
+++ b/src/commands/configure.commands.ts
@@ -63,7 +63,7 @@ export async function configureCommandFromSectionsArg(
   const { sections, invalid } = parseConfigureWizardSections(rawSections);
   if (invalid.length > 0) {
     runtime.error(
-      `Invalid --section: ${invalid.join(", ")}. Expected one of: ${CONFIGURE_WIZARD_SECTIONS.join(", ")}. Run ${formatCliCommand("openclaw configure")} without --section to use the full wizard.`,
+      `Invalid --section: ${invalid.map((section) => section || '""').join(", ")}. Expected one of: ${CONFIGURE_WIZARD_SECTIONS.join(", ")}. Run ${formatCliCommand("openclaw configure")} without --section to use the full wizard.`,
     );
     runtime.exit(1);
     return;

--- a/src/commands/configure.shared.ts
+++ b/src/commands/configure.shared.ts
@@ -7,7 +7,6 @@ import {
   select as clackSelect,
   text as clackText,
 } from "@clack/prompts";
-import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { styleSelectParams } from "../../packages/terminal-core/src/prompt-select-styled-params.js";
 import {
   stylePromptMessage,
@@ -33,7 +32,7 @@ export function parseConfigureWizardSections(raw: unknown): {
   sections: WizardSection[];
   invalid: string[];
 } {
-  const sectionsRaw: string[] = Array.isArray(raw) ? normalizeStringEntries(raw) : [];
+  const sectionsRaw = Array.isArray(raw) ? raw.map((section) => String(section).trim()) : [];
   if (sectionsRaw.length === 0) {
     return { sections: [], invalid: [] };
   }


### PR DESCRIPTION
## What Problem This Solves

Explicit blank or whitespace-only `configure --section` values were silently discarded by generic normalization, causing a scoped configuration request to unexpectedly launch the full setup wizard.

## Why This Change Was Made

The configuration-section parser now retains explicitly supplied blank values long enough to classify and report them as invalid, while preserving existing trimming and accepted-section behavior. The invalid-section message displays empty values clearly. Omitted `--section` remains the only way to select the full wizard.

## User Impact

Operators who accidentally provide an empty section receive an actionable validation error instead of silently entering unrelated setup flows or changing the wrong configuration area.

## Evidence

Exact reviewed head: `5e6b5e1aab2a0c260b0297a2d60397399f357f58`

- `node scripts/run-vitest.mjs src/commands/configure.commands.test.ts` — 13/13 tests passed.
- `node scripts/run-vitest.mjs src/cli/program/register.configure.test.ts` — 6/6 tests passed.
- `git diff --check origin/main...HEAD` — passed.
- Blacksmith Testbox `tbx_01kzmac0dq3p0bdk7360ptrg4w` ([run 31339558396](https://github.com/openclaw/openclaw/actions/runs/31339558396)) — `pnpm build` passed; both `node dist/entry.js configure --section "   "` and `node dist/entry.js config --section "   "` exited 1 with `Invalid --section: ""` and did not display the wizard; omitting `--section` from both public spellings reached the `OpenClaw configure` wizard intro in a PTY before the proof interrupted setup.
- `AGENTS_HOME="$HOME/.claude" "$HOME/.claude/skills/autoreview/scripts/autoreview" --mode branch --base origin/main --max-priority P1` — clean; no accepted/actionable P0 or P1 findings.

Production code: +2/-3 (net -1). Tests: +42/-4 (net +38).
