### PR TITLE
fix(agents): pair reset tool results within retained session history

### DIFF
--- a/packages/agent-core/src/harness/session/session-context.test.ts
+++ b/packages/agent-core/src/harness/session/session-context.test.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage, ProviderReplayState } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
+import { convertToLlm } from "../messages.js";
 import type { SessionTreeEntry } from "../types.js";
 import { buildSessionContext } from "./session.js";
 
@@ -266,6 +267,90 @@ describe("buildSessionContext", () => {
     expect(JSON.stringify(context.messages)).toContain("first result");
     expect(JSON.stringify(context.messages)).toContain("second result");
     expect(JSON.stringify(context.messages)).not.toContain("orphan result");
+  });
+
+  it("pairs reset results only with calls inside the retained tail", () => {
+    const entries: SessionTreeEntry[] = [
+      userEntry("discarded-user", null, "discarded question"),
+      assistantToolEntry("discarded-assistant", "discarded-user", "call-shared"),
+      userEntry("kept", "discarded-assistant", "kept question"),
+      toolResultEntry("discarded-result", "kept", "call-shared", "discarded owner result"),
+      assistantToolEntry("kept-assistant", "discarded-result", "call-shared"),
+      toolResultEntry("kept-result", "kept-assistant", "call-shared", "kept owner result"),
+      {
+        type: "reset",
+        id: "reset",
+        parentId: "kept-result",
+        timestamp,
+        reason: "new",
+        firstKeptEntryId: "kept",
+      },
+      userEntry("new", "reset", "new turn"),
+    ];
+
+    const context = buildSessionContext(entries);
+    const providerMessages = convertToLlm(context.messages);
+
+    expect(providerMessages).toMatchObject([
+      { role: "user", content: "kept question" },
+      { role: "assistant", content: [{ id: "call-shared" }] },
+      { role: "toolResult", toolCallId: "call-shared", content: [{ text: "kept owner result" }] },
+      { role: "user", content: "new turn" },
+    ]);
+    expect(JSON.stringify(providerMessages)).not.toContain("discarded owner result");
+  });
+
+  it("keeps tool ownership within the latest reset when resets repeat", () => {
+    const entries: SessionTreeEntry[] = [
+      userEntry("first-user", null, "first conversation"),
+      assistantToolEntry("first-assistant", "first-user", "first-call"),
+      toolResultEntry("first-result", "first-assistant", "first-call", "first result"),
+      {
+        type: "reset",
+        id: "first-reset",
+        parentId: "first-result",
+        timestamp,
+        reason: "new",
+        firstKeptEntryId: "first-user",
+      },
+      assistantToolEntry("discarded-assistant", "first-reset", "discarded-call"),
+      userEntry("latest-kept", "discarded-assistant", "latest conversation"),
+      toolResultEntry(
+        "latest-orphan",
+        "latest-kept",
+        "discarded-call",
+        "result from discarded conversation",
+      ),
+      {
+        type: "thinking_level_change",
+        id: "thinking",
+        parentId: "latest-orphan",
+        timestamp,
+        thinkingLevel: "high",
+      },
+      assistantToolEntry("latest-assistant", "thinking", "latest-call"),
+      toolResultEntry("latest-result", "latest-assistant", "latest-call", "latest result"),
+      {
+        type: "reset",
+        id: "latest-reset",
+        parentId: "latest-result",
+        timestamp,
+        reason: "reset",
+        firstKeptEntryId: "latest-kept",
+      },
+      userEntry("new", "latest-reset", "new turn"),
+    ];
+
+    const context = buildSessionContext(entries);
+
+    expect(context.thinkingLevel).toBe("high");
+    expect(context.messages).toMatchObject([
+      { role: "user", content: "latest conversation" },
+      { role: "assistant", content: [{ id: "latest-call" }] },
+      { role: "toolResult", toolCallId: "latest-call" },
+      { role: "user", content: "new turn" },
+    ]);
+    expect(JSON.stringify(context.messages)).not.toContain("discarded conversation");
   });
 
   it("uses local frame ownership before unique displaced-result recovery", () => {

--- a/packages/agent-core/src/harness/session/session.ts
+++ b/packages/agent-core/src/harness/session/session.ts
@@ -106,24 +106,19 @@ export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionCon
       }
     }
     const boundaryIdx = pathEntries.findIndex((entry) => entry.id === boundary.id);
-    const resetKeptEntries =
-      boundary.type === "reset"
-        ? new Set(selectResetKeptEntries(pathEntries.slice(0, boundaryIdx)))
-        : undefined;
+    const firstKeptIdx = pathEntries.findIndex((entry) => entry.id === boundary.firstKeptEntryId);
+    const keptEntries =
+      firstKeptIdx >= 0 && firstKeptIdx < boundaryIdx
+        ? pathEntries.slice(firstKeptIdx, boundaryIdx)
+        : [];
+    const replayEntries =
+      boundary.type === "reset" ? selectResetKeptEntries(keptEntries) : keptEntries;
     // Both retained-tail forms follow rewritten prefixes, so prefix-bound checkpoints are stale.
-    let foundFirstKept = false;
-    for (const entry of pathEntries.slice(0, boundaryIdx)) {
-      if (entry.id === boundary.firstKeptEntryId) {
-        foundFirstKept = true;
-      }
-      if (foundFirstKept) {
-        if (boundary.type === "reset") {
-          if (resetKeptEntries?.has(entry)) {
-            appendResetKeptMessage(messages, entry);
-          }
-        } else {
-          appendContextMessage(messages, entry, { prefixWasRewritten: true });
-        }
+    for (const entry of replayEntries) {
+      if (boundary.type === "reset") {
+        appendResetKeptMessage(messages, entry);
+      } else {
+        appendContextMessage(messages, entry, { prefixWasRewritten: true });
       }
     }
     for (const entry of pathEntries.slice(boundaryIdx + 1)) {

--- a/src/gateway/worker-environments/worker-turn-launcher.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.test.ts
@@ -822,7 +822,7 @@ describe("worker turn launcher", () => {
     const manager = openSessionManager();
     manager.appendMessage(
       makeAgentAssistantMessage({
-        content: [{ type: "toolCall", id: "discarded-call", name: "read", arguments: {} }],
+        content: [{ type: "toolCall", id: "shared-call", name: "read", arguments: {} }],
         stopReason: "toolUse",
         timestamp: 16,
       }),
@@ -832,7 +832,7 @@ describe("worker turn launcher", () => {
     );
     manager.appendMessage({
       role: "toolResult",
-      toolCallId: "discarded-call",
+      toolCallId: "shared-call",
       toolName: "read",
       content: [{ type: "text", text: "Discarded owner result" }],
       isError: false,
@@ -840,14 +840,14 @@ describe("worker turn launcher", () => {
     });
     manager.appendMessage(
       makeAgentAssistantMessage({
-        content: [{ type: "toolCall", id: "kept-call", name: "read", arguments: {} }],
+        content: [{ type: "toolCall", id: "shared-call", name: "read", arguments: {} }],
         stopReason: "toolUse",
         timestamp: 19,
       }),
     );
     manager.appendMessage({
       role: "toolResult",
-      toolCallId: "kept-call",
+      toolCallId: "shared-call",
       toolName: "read",
       content: [{ type: "text", text: "Kept owner result" }],
       isError: false,
@@ -943,11 +943,13 @@ describe("worker turn launcher", () => {
     expect(descriptor?.assignment.prompt).toBe("Inspect this workspace");
     expect(descriptor?.assignment.initialMessages).toMatchObject([
       { role: "user" },
-      { role: "assistant", content: [{ id: "kept-call" }] },
-      { role: "toolResult", toolCallId: "kept-call" },
+      { role: "assistant", content: [{ id: "shared-call" }] },
+      { role: "toolResult", toolCallId: "shared-call" },
       { role: "assistant" },
     ]);
-    expect(JSON.stringify(descriptor?.assignment.initialMessages)).not.toContain("discarded-call");
+    expect(JSON.stringify(descriptor?.assignment.initialMessages)).not.toContain(
+      "Discarded owner result",
+    );
     const persistedEntries = openSessionManager().getEntries();
     const persistedCurrentUsers = persistedEntries.filter((entry) => {
       if (typeof entry !== "object" || entry === null || !("message" in entry)) {

--- a/src/gateway/worker-environments/worker-turn-launcher.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.test.ts
@@ -817,18 +817,51 @@ describe("worker turn launcher", () => {
     ).toContainEqual([{ type: "text", text: "Canonical transcript request" }]);
   });
 
-  it("does not replay an already-persisted current user message into worker history", async () => {
+  it("keeps reset tool pairs valid without replaying the already-persisted current user", async () => {
     seedActivePlacement();
     const manager = openSessionManager();
-    manager.appendMessage(makeAgentUserMessage({ content: "Earlier request", timestamp: 18 }));
     manager.appendMessage(
       makeAgentAssistantMessage({
-        content: [{ type: "text", text: "Earlier reply" }],
+        content: [{ type: "toolCall", id: "discarded-call", name: "read", arguments: {} }],
+        stopReason: "toolUse",
+        timestamp: 16,
+      }),
+    );
+    const firstKeptEntryId = manager.appendMessage(
+      makeAgentUserMessage({ content: "Earlier request", timestamp: 17 }),
+    );
+    manager.appendMessage({
+      role: "toolResult",
+      toolCallId: "discarded-call",
+      toolName: "read",
+      content: [{ type: "text", text: "Discarded owner result" }],
+      isError: false,
+      timestamp: 18,
+    });
+    manager.appendMessage(
+      makeAgentAssistantMessage({
+        content: [{ type: "toolCall", id: "kept-call", name: "read", arguments: {} }],
+        stopReason: "toolUse",
         timestamp: 19,
       }),
     );
+    manager.appendMessage({
+      role: "toolResult",
+      toolCallId: "kept-call",
+      toolName: "read",
+      content: [{ type: "text", text: "Kept owner result" }],
+      isError: false,
+      timestamp: 20,
+    });
     manager.appendMessage(
-      makeAgentUserMessage({ content: "Inspect this workspace", timestamp: 20 }),
+      makeAgentAssistantMessage({
+        content: [{ type: "text", text: "Earlier reply" }],
+        timestamp: 21,
+      }),
+    );
+    manager.appendResetBoundary("new", firstKeptEntryId);
+    manager.appendMessage(
+      makeAgentUserMessage({ content: "Inspect this workspace", timestamp: 22 }),
     );
     let descriptor: WorkerLaunchDescriptor | undefined;
     const tunnel: WorkerTunnelHandle = {
@@ -910,8 +943,11 @@ describe("worker turn launcher", () => {
     expect(descriptor?.assignment.prompt).toBe("Inspect this workspace");
     expect(descriptor?.assignment.initialMessages).toMatchObject([
       { role: "user" },
+      { role: "assistant", content: [{ id: "kept-call" }] },
+      { role: "toolResult", toolCallId: "kept-call" },
       { role: "assistant" },
     ]);
+    expect(JSON.stringify(descriptor?.assignment.initialMessages)).not.toContain("discarded-call");
     const persistedEntries = openSessionManager().getEntries();
     const persistedCurrentUsers = persistedEntries.filter((entry) => {
       if (typeof entry !== "object" || entry === null || !("message" in entry)) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where resetting an agent session could attach a retained tool result to a discarded tool call when the provider reused the same call ID across the reset boundary. That produced incoherent replay context for later turns and cloud workers.

## Why This Change Was Made

The session-context owner now defines the retained tail before occurrence-aware tool call/result pairing. Reset and compaction replay use the same bounded history slice, the prior membership scan is gone, persisted session entries remain byte-for-byte unchanged, and the existing provider-replay checkpoint stripping behavior is preserved. This is an AI-assisted maintainer bug fix.

## User Impact

Reset sessions now replay only legitimate in-window tool exchanges. Repeated resets remain isolated, discarded calls cannot claim retained results even when call IDs are reused, and cloud-worker launch receives the current user message exactly once.

## Evidence

- `node scripts/run-vitest.mjs packages/agent-core/src/harness/session/session-context.test.ts` — 8/8 passed.
- `node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/compaction.test.ts` — 28/28 passed.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/worker-turn-launcher.test.ts` — 37/37 passed. The worker regression executes discarded reused-ID call -> retained boundary -> in-window call/result -> reset replay -> worker launch, retains only the in-window occurrence, and verifies the current user message is persisted once.
- `node scripts/check-changed.mjs -- packages/agent-core/src/harness/session/session-context.test.ts packages/agent-core/src/harness/session/session.ts src/gateway/worker-environments/worker-turn-launcher.test.ts` — Blacksmith Testbox `tbx_01kzmp6e9an3tankmkkmy2gvhd`, run `31348445986`; scoped guards passed through duplicate coverage, then the raw stale PR head hit the already-fixed `@novnc/novnc` direct-pin baseline (`^1.7.0` on the head, `1.7.0` on current `origin/main`). Native prepare reconciliation owns that mainline update.
- `node_modules/.bin/oxfmt --check src/gateway/worker-environments/worker-turn-launcher.test.ts` — passed.
- `git diff --check` — passed.
- `AGENTS_HOME="$HOME/.claude" "$HOME/.claude/skills/autoreview/scripts/autoreview" --mode branch --base origin/main --max-priority P1` — clean; no accepted/actionable findings.
- Exact-head hosted CI — run `31348702056` passed for `f4e4dc2a0f4b0e4642e6b03bb7ba91e1260ae514`.

Production LOC: +12/-17 (net -5). Tests: +127/-4 (net +123).
