### PR TITLE
fix(agents): exclude private shell output from context compaction

### DIFF
--- a/extensions/codex/src/app-server/session-history.test.ts
+++ b/extensions/codex/src/app-server/session-history.test.ts
@@ -56,6 +56,30 @@ function messageEntry(params: {
   };
 }
 
+function bashEntry(params: {
+  id: string;
+  parentId: string;
+  output: string;
+  excludeFromContext: boolean;
+}) {
+  return {
+    type: "message",
+    id: params.id,
+    parentId: params.parentId,
+    timestamp: "2026-06-15T00:00:00.000Z",
+    message: {
+      role: "bashExecution",
+      command: `print ${params.output}`,
+      output: params.output,
+      exitCode: 0,
+      cancelled: false,
+      truncated: false,
+      timestamp: 1,
+      excludeFromContext: params.excludeFromContext,
+    },
+  };
+}
+
 function mirroredTarget(sessionFile: string) {
   return {
     sessionFile,
@@ -363,6 +387,42 @@ describe("readCodexMirroredSessionHistoryMessages", () => {
       { role: "user", content: "root prompt" },
       { role: "assistant", content: [{ type: "text", text: "active answer" }] },
     ]);
+  });
+
+  it("projects private shell rows out of mirrored history without rewriting persisted bytes", async () => {
+    const sessionFile = await writeSession([
+      messageEntry({ id: "root", parentId: null, role: "user", content: "root prompt" }),
+      bashEntry({
+        id: "private-shell",
+        parentId: "root",
+        output: "private shell output",
+        excludeFromContext: true,
+      }),
+      bashEntry({
+        id: "visible-shell",
+        parentId: "private-shell",
+        output: "visible shell output",
+        excludeFromContext: false,
+      }),
+      messageEntry({
+        id: "continued",
+        parentId: "visible-shell",
+        role: "user",
+        content: "continue prompt",
+      }),
+    ]);
+    const persistedBefore = await fs.readFile(sessionFile, "utf8");
+
+    const messages = await readCodexMirroredSessionHistoryMessages(mirroredTarget(sessionFile));
+
+    expect(messages).toMatchObject([
+      { role: "user", content: "root prompt" },
+      { role: "bashExecution", output: "visible shell output" },
+      { role: "user", content: "continue prompt" },
+    ]);
+    expect(JSON.stringify(messages)).not.toContain("private shell output");
+    expect(await fs.readFile(sessionFile, "utf8")).toBe(persistedBefore);
+    expect(persistedBefore).toContain("private shell output");
   });
 
   it("honors explicit navigation to an empty branch", async () => {

--- a/packages/agent-core/src/harness/compaction/branch-summarization.test.ts
+++ b/packages/agent-core/src/harness/compaction/branch-summarization.test.ts
@@ -198,6 +198,56 @@ src/write.ts
     expect(preparation.messages.map((message) => message.role)).toEqual(["user", "toolResult"]);
   });
 
+  it("preserves earlier branch context while excluding private shell output", async () => {
+    const model = createModel(8192);
+    const capture = createCapturingStream(model);
+    const shellMessage: AgentMessage = {
+      role: "bashExecution",
+      command: "private command",
+      output: `private output marker ${"x".repeat(80_000)}`,
+      exitCode: 0,
+      cancelled: false,
+      truncated: false,
+      timestamp: 2,
+      excludeFromContext: true,
+    };
+    const entries: SessionTreeEntry[] = [
+      createMessageEntry({ role: "user", content: "important original request", timestamp: 1 }, 0),
+      createMessageEntry(shellMessage, 1),
+      createMessageEntry({ role: "user", content: "continue branch", timestamp: 3 }, 2),
+    ];
+
+    const preparation = prepareBranchEntries(entries, 100);
+    expect(preparation.messages).toMatchObject([
+      { role: "user", content: "important original request" },
+      { role: "user", content: "continue branch" },
+    ]);
+    expect(preparation.totalTokens).toBeLessThan(100);
+
+    const visibleEntries = entries.map((entry, index) =>
+      index === 1
+        ? createMessageEntry({ ...shellMessage, excludeFromContext: false }, index)
+        : entry,
+    );
+    expect(prepareBranchEntries(visibleEntries, 100).messages).toMatchObject([
+      { role: "user", content: "continue branch" },
+    ]);
+
+    const result = await generateBranchSummary(entries, {
+      model,
+      apiKey: "test-key",
+      signal: new AbortController().signal,
+      streamFn: capture.streamFn,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(capture.readCapture().prompt).toContain("important original request");
+    expect(capture.readCapture().prompt).toContain("continue branch");
+    expect(capture.readCapture().prompt).not.toContain("private command");
+    expect(capture.readCapture().prompt).not.toContain("private output marker");
+    expect(JSON.stringify(entries)).toContain("private output marker");
+  });
+
   it("summarizes tool failures without exposing private result details", async () => {
     const model = createModel(128_000);
     const capture = createCapturingStream(model);

--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -40,6 +40,23 @@ function createAssistant(text: string, usage: Usage, timestamp: number): Assista
   };
 }
 
+function createBashMessage(
+  output: string,
+  timestamp: number,
+  excludeFromContext: boolean,
+): AgentMessage {
+  return {
+    role: "bashExecution",
+    command: "print output",
+    output,
+    exitCode: 0,
+    cancelled: false,
+    truncated: false,
+    timestamp,
+    excludeFromContext,
+  };
+}
+
 function createMessageEntry(message: AgentMessage, index: number): SessionTreeEntry {
   return {
     type: "message",
@@ -229,6 +246,95 @@ describe("calculateContextTokens", () => {
 });
 
 describe("session-entry compaction budgeting", () => {
+  it("counts visible shell output while ignoring private output after provider usage", () => {
+    const hidden = createBashMessage("x".repeat(80_000), 2, true);
+    const visible = createBashMessage("x".repeat(80_000), 2, false);
+    const assistant = createAssistant("done", createUsage(42), 1);
+    const latest: AgentMessage = { role: "user", content: "continue", timestamp: 3 };
+
+    expect(estimateTokens(hidden)).toBe(0);
+    expect(estimateTokens(visible)).toBeGreaterThan(20_000);
+    expect(estimateContextTokens([assistant, hidden, latest])).toMatchObject({
+      tokens: 44,
+      usageTokens: 42,
+      trailingTokens: 2,
+      lastUsageIndex: 0,
+    });
+    expect(estimateContextTokens([assistant, visible, latest]).trailingTokens).toBeGreaterThan(
+      20_000,
+    );
+  });
+
+  it("never rewinds a retained visible turn onto an excluded shell-history row", () => {
+    const entries: SessionTreeEntry[] = [
+      createMessageEntry({ role: "user", content: "original request", timestamp: 1 }, 0),
+      createMessageEntry(createAssistant("earlier", createUsage(10), 2), 1),
+      createMessageEntry(createBashMessage("x".repeat(80_000), 3, true), 2),
+      createMessageEntry({ role: "user", content: "recent turn", timestamp: 4 }, 3),
+      createMessageEntry(createAssistant("ok", createUsage(10), 5), 4),
+    ];
+
+    expect(findCutPoint(entries, 0, entries.length, 2)).toEqual({
+      firstKeptEntryIndex: 3,
+      turnStartIndex: -1,
+      isSplitTurn: false,
+    });
+  });
+
+  it("omits private shell history from a genuine split-turn summary prefix", () => {
+    const entries: SessionTreeEntry[] = [
+      createMessageEntry({ role: "user", content: "original request", timestamp: 1 }, 0),
+      createMessageEntry(createAssistant("earlier work", createUsage(10), 2), 1),
+      createMessageEntry(createBashMessage("private output ".repeat(6_000), 3, true), 2),
+      createMessageEntry(createAssistant("latest", createUsage(10), 4), 3),
+    ];
+
+    expect(findCutPoint(entries, 0, entries.length, 1)).toEqual({
+      firstKeptEntryIndex: 3,
+      turnStartIndex: 0,
+      isSplitTurn: true,
+    });
+
+    const preparation = prepareCompaction(entries, {
+      enabled: true,
+      reserveTokens: 0,
+      keepRecentTokens: 1,
+    });
+
+    expect(preparation.ok).toBe(true);
+    if (!preparation.ok || !preparation.value) {
+      throw new Error("expected a genuine split turn to remain compactable");
+    }
+    expect(preparation.value).toMatchObject({
+      firstKeptEntryId: "entry-3",
+      isSplitTurn: true,
+      tokensBefore: 10,
+      turnPrefixMessages: [{ role: "user" }, { role: "assistant" }],
+    });
+    expect(JSON.stringify(preparation.value)).not.toContain("private output");
+    expect(JSON.stringify(entries)).toContain("private output");
+  });
+
+  it("does not compact private output while retaining ordinary shell-output budgeting", () => {
+    const buildEntries = (excludeFromContext: boolean): SessionTreeEntry[] => [
+      createMessageEntry({ role: "user", content: "original request", timestamp: 1 }, 0),
+      createMessageEntry(createBashMessage("x".repeat(80_000), 2, excludeFromContext), 1),
+      createMessageEntry(createAssistant("done", createUsage(10), 3), 2),
+    ];
+    const settings = { enabled: true, reserveTokens: 0, keepRecentTokens: 10_000 };
+
+    expect(prepareCompaction(buildEntries(true), settings)).toEqual({
+      ok: true,
+      value: undefined,
+    });
+
+    const visiblePreparation = prepareCompaction(buildEntries(false), settings);
+    expect(visiblePreparation.ok && visiblePreparation.value).toMatchObject({
+      firstKeptEntryId: "entry-1",
+      messagesToSummarize: [{ role: "user", content: "original request" }],
+    });
+  });
+
   it("applies the shared common-CJK budget heuristic", () => {
     expect(estimateTokens({ role: "user", content: "hello world", timestamp: 1 })).toBe(3);
     expect(estimateTokens({ role: "user", content: "你好世界", timestamp: 1 })).toBe(4);

--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -315,26 +315,6 @@ describe("session-entry compaction budgeting", () => {
     expect(JSON.stringify(entries)).toContain("private output");
   });
 
-  it("does not compact private output while retaining ordinary shell-output budgeting", () => {
-    const buildEntries = (excludeFromContext: boolean): SessionTreeEntry[] => [
-      createMessageEntry({ role: "user", content: "original request", timestamp: 1 }, 0),
-      createMessageEntry(createBashMessage("x".repeat(80_000), 2, excludeFromContext), 1),
-      createMessageEntry(createAssistant("done", createUsage(10), 3), 2),
-    ];
-    const settings = { enabled: true, reserveTokens: 0, keepRecentTokens: 10_000 };
-
-    expect(prepareCompaction(buildEntries(true), settings)).toEqual({
-      ok: true,
-      value: undefined,
-    });
-
-    const visiblePreparation = prepareCompaction(buildEntries(false), settings);
-    expect(visiblePreparation.ok && visiblePreparation.value).toMatchObject({
-      firstKeptEntryId: "entry-1",
-      messagesToSummarize: [{ role: "user", content: "original request" }],
-    });
-  });
-
   it("applies the shared common-CJK budget heuristic", () => {
     expect(estimateTokens({ role: "user", content: "hello world", timestamp: 1 })).toBe(3);
     expect(estimateTokens({ role: "user", content: "你好世界", timestamp: 1 })).toBe(4);

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -287,6 +287,9 @@ export function estimateTokens(message: AgentMessage): number {
       return Math.ceil(chars / CHARS_PER_TOKEN_ESTIMATE);
     }
     case "bashExecution": {
+      if (harnessMessage.excludeFromContext === true) {
+        return 0;
+      }
       chars =
         estimateStringChars(harnessMessage.command) + estimateStringChars(harnessMessage.output);
       return Math.ceil(chars / CHARS_PER_TOKEN_ESTIMATE);
@@ -437,7 +440,8 @@ export function findCutPoint(
     if (prevEntry.type === "compaction" || prevEntry.type === "reset") {
       break;
     }
-    if (getMessageFromEntryForCompaction(prevEntry)) {
+    // Metadata can follow the cut, but private persisted messages cannot become its boundary.
+    if (prevEntry.type === "message" || getMessageFromEntryForCompaction(prevEntry)) {
       break;
     }
     cutIndex--;

--- a/packages/agent-core/src/harness/session/session-context.test.ts
+++ b/packages/agent-core/src/harness/session/session-context.test.ts
@@ -2,7 +2,7 @@ import type { AssistantMessage, ProviderReplayState } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
 import { convertToLlm } from "../messages.js";
 import type { SessionTreeEntry } from "../types.js";
-import { buildSessionContext } from "./session.js";
+import { buildSessionContext, projectSessionEntryMessage } from "./session.js";
 
 const timestamp = "2026-07-17T00:00:00.000Z";
 
@@ -13,6 +13,30 @@ function userEntry(id: string, parentId: string | null, content: string): Sessio
     parentId,
     timestamp,
     message: { role: "user", content, timestamp: Date.parse(timestamp) },
+  };
+}
+
+function bashEntry(
+  id: string,
+  parentId: string,
+  output: string,
+  excludeFromContext: boolean,
+): SessionTreeEntry {
+  return {
+    type: "message",
+    id,
+    parentId,
+    timestamp,
+    message: {
+      role: "bashExecution",
+      command: `print ${output}`,
+      output,
+      exitCode: 0,
+      cancelled: false,
+      truncated: false,
+      timestamp: Date.parse(timestamp),
+      excludeFromContext,
+    },
   };
 }
 
@@ -109,6 +133,28 @@ function toolResultEntry(
 }
 
 describe("buildSessionContext", () => {
+  it("keeps private shell executions in history without projecting them into context", () => {
+    const hiddenEntry = bashEntry("hidden", "initial", "private shell output", true);
+    const visibleEntry = bashEntry("visible", "hidden", "visible shell output", false);
+    const entries = [
+      userEntry("initial", null, "original request"),
+      hiddenEntry,
+      visibleEntry,
+      userEntry("latest", "visible", "continue"),
+    ];
+
+    const messages = buildSessionContext(entries).messages;
+
+    expect(projectSessionEntryMessage(hiddenEntry)).toBeUndefined();
+    expect(projectSessionEntryMessage(visibleEntry)).toBe(
+      visibleEntry.type === "message" ? visibleEntry.message : undefined,
+    );
+    expect(messages.map((message) => message.role)).toEqual(["user", "bashExecution", "user"]);
+    expect(JSON.stringify(messages)).toContain("visible shell output");
+    expect(JSON.stringify(messages)).not.toContain("private shell output");
+    expect(JSON.stringify(entries)).toContain("private shell output");
+  });
+
   it("replays only the retained tail and newer entries after compaction", () => {
     const retainedCheckpoint = replayState("openai-responses-compaction", "retained-checkpoint");
     const retainedSuppression = replayState("openai-responses-compaction-suppression", "rejected");

--- a/packages/agent-core/src/harness/session/session.ts
+++ b/packages/agent-core/src/harness/session/session.ts
@@ -16,7 +16,10 @@ const SESSION_HISTORY_PRELUDE = Symbol.for("openclaw.sessionHistoryPrelude");
 export function projectSessionEntryMessage(entry: SessionTreeEntry): AgentMessage | undefined {
   switch (entry.type) {
     case "message":
-      return entry.message;
+      // Private shell history stays persisted but never enters replay or summarization.
+      return entry.message.role === "bashExecution" && entry.message.excludeFromContext === true
+        ? undefined
+        : entry.message;
     case "custom_message":
       return asAgentMessage(
         createCustomMessage(


### PR DESCRIPTION
## What Problem This Solves

`bashExecution` messages marked `excludeFromContext: true` are private persisted history. Provider conversion already filtered them from some final request paths, but shared pre-provider consumers could still replay them, include them in compaction or branch-summary prompts, charge their output against token budgets, select them as retained cut boundaries, or mirror them into Codex session history.

## Why This Change Was Made

The shared session projection owner now omits only private `bashExecution` rows. Compaction gives those rows zero token cost and prevents a private persisted row from becoming a retained-history boundary. This composes after #121146's canonical retained-tail selection and tool-call/result pairing: the correct retained slice is selected first, then private messages are removed from model-visible projection.

Raw session entries and persisted bytes are unchanged. Ordinary visible shell output follows the existing replay, budgeting, summarization, and Codex mirroring paths.

This matches Codex's upstream ownership split at canonical `openai/codex@c9c6c0daa994109cec50fddcb57d076fdf9e738c`:

- [`History::for_prompt` normalizes model-visible input while raw access remains separate](https://github.com/openai/codex/blob/c9c6c0daa994109cec50fddcb57d076fdf9e738c/codex-rs/core/src/context_manager/history.rs#L142-L157)
- [local compaction builds its prompt from `for_prompt`](https://github.com/openai/codex/blob/c9c6c0daa994109cec50fddcb57d076fdf9e738c/codex-rs/core/src/compact.rs#L247-L274)
- [remote compaction preserves raw trace history separately before projecting prompt input](https://github.com/openai/codex/blob/c9c6c0daa994109cec50fddcb57d076fdf9e738c/codex-rs/core/src/compact_remote_request.rs#L58-L65)

## User Impact

Private shell output remains durably available to its owner without entering replay, compaction prompts, branch summaries, Codex mirrored history, token estimates, or retained cut boundaries. Visible shell transcripts behave exactly as before.

## Evidence

- `node scripts/run-vitest.mjs packages/agent-core/src/harness/session/session-context.test.ts` — 9 passed
- `node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/compaction.test.ts` — 31 passed
- `node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/branch-summarization.test.ts` — 10 passed
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/session-history.test.ts` — 20 passed
- `node scripts/run-vitest.mjs src/gateway/worker-environments/worker-turn-launcher.test.ts` — 37 passed (#121146 retained-pair worker regression)
- `node scripts/check-changed.mjs -- packages/agent-core/src/harness/compaction/branch-summarization.test.ts packages/agent-core/src/harness/compaction/compaction.test.ts packages/agent-core/src/harness/compaction/compaction.ts packages/agent-core/src/harness/session/session-context.test.ts packages/agent-core/src/harness/session/session.ts extensions/codex/src/app-server/session-history.test.ts` — passed on Blacksmith Testbox `tbx_01kzmqpw5kk8svvv445vv4x4de` ([run 31349663178](https://github.com/openclaw/openclaw/actions/runs/31349663178))
- `git diff --check` — passed
- `AGENTS_HOME="$HOME/.claude" "$HOME/.claude/skills/autoreview/scripts/autoreview" --mode branch --base origin/main --max-priority P1` — clean; no accepted/actionable findings
