### PR TITLE
fix(plugins): canonicalize ids during forced activation

### DIFF
--- a/src/plugins/activation-context.test.ts
+++ b/src/plugins/activation-context.test.ts
@@ -40,6 +40,56 @@ afterEach(() => {
 });
 
 describe("withActivatedPluginIds", () => {
+  it("canonicalizes allowed aliases and requested plugin ids", () => {
+    expect(
+      withActivatedPluginIds({
+        config: {
+          plugins: {
+            allow: [" GOOGLE-GEMINI-CLI ", "minimax"],
+          },
+        },
+        pluginIds: ["google", "MINIMAX-PORTAL"],
+      }),
+    ).toEqual({
+      plugins: {
+        allow: ["google", "minimax"],
+        entries: {
+          google: { enabled: true },
+          minimax: { enabled: true },
+        },
+      },
+    });
+  });
+
+  it("preserves explicit disables stored under an alias", () => {
+    expect(
+      withActivatedPluginIds({
+        config: {
+          plugins: {
+            allow: ["google-gemini-cli"],
+            entries: {
+              "GOOGLE-GEMINI-CLI": {
+                enabled: false,
+                config: { projectId: "example" },
+              },
+            },
+          },
+        },
+        pluginIds: ["google"],
+      }),
+    ).toEqual({
+      plugins: {
+        allow: ["google"],
+        entries: {
+          google: {
+            enabled: false,
+            config: { projectId: "example" },
+          },
+        },
+      },
+    });
+  });
+
   it("keeps omitted plugin ids outside restrictive allowlists", () => {
     expect(
       withActivatedPluginIds({

--- a/src/plugins/activation-context.test.ts
+++ b/src/plugins/activation-context.test.ts
@@ -89,6 +89,30 @@ describe("withActivatedPluginIds", () => {
     });
   });
 
+  it("preserves empty model policy arrays through repeated alias normalization", () => {
+    const config = {
+      plugins: {
+        entries: {
+          "GOOGLE-GEMINI-CLI": {
+            subagent: { allowedModels: [] },
+            llm: { allowedModels: [], allowedCompletionModels: [] },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const first = withActivatedPluginIds({ config, pluginIds: ["google"] });
+    const second = withActivatedPluginIds({
+      config: first,
+      pluginIds: ["GOOGLE-GEMINI-CLI"],
+    });
+
+    const entry = second?.plugins?.entries?.google;
+    expect(entry?.subagent?.allowedModels).toEqual([]);
+    expect(entry?.llm?.allowedModels).toEqual([]);
+    expect(entry?.llm?.allowedCompletionModels).toEqual([]);
+  });
+
   it("keeps omitted plugin ids outside restrictive allowlists", () => {
     expect(
       withActivatedPluginIds({

--- a/src/plugins/activation-context.test.ts
+++ b/src/plugins/activation-context.test.ts
@@ -39,6 +39,56 @@ afterEach(() => {
 });
 
 describe("withActivatedPluginIds", () => {
+  it("canonicalizes allowed aliases and requested plugin ids", () => {
+    expect(
+      withActivatedPluginIds({
+        config: {
+          plugins: {
+            allow: [" GOOGLE-GEMINI-CLI ", "minimax"],
+          },
+        },
+        pluginIds: ["google", "MINIMAX-PORTAL"],
+      }),
+    ).toEqual({
+      plugins: {
+        allow: ["google", "minimax"],
+        entries: {
+          google: { enabled: true },
+          minimax: { enabled: true },
+        },
+      },
+    });
+  });
+
+  it("preserves explicit disables stored under an alias", () => {
+    expect(
+      withActivatedPluginIds({
+        config: {
+          plugins: {
+            allow: ["google-gemini-cli"],
+            entries: {
+              "GOOGLE-GEMINI-CLI": {
+                enabled: false,
+                config: { projectId: "example" },
+              },
+            },
+          },
+        },
+        pluginIds: ["google"],
+      }),
+    ).toEqual({
+      plugins: {
+        allow: ["google"],
+        entries: {
+          google: {
+            enabled: false,
+            config: { projectId: "example" },
+          },
+        },
+      },
+    });
+  });
+
   it("keeps omitted plugin ids outside restrictive allowlists", () => {
     expect(
       withActivatedPluginIds({

--- a/src/plugins/activation-context.ts
+++ b/src/plugins/activation-context.ts
@@ -4,7 +4,9 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withBundledPluginEnablementCompat } from "./bundled-compat.js";
 import {
   createPluginActivationSource,
+  normalizePluginId,
   normalizePluginsConfig,
+  normalizePluginTargetConfig,
   type NormalizedPluginsConfig,
   type PluginActivationConfigSource,
 } from "./config-state.js";
@@ -55,22 +57,28 @@ export function withActivatedPluginIds(params: {
   }
   const originalAllow = params.config?.plugins?.allow ?? [];
   const useAllowlistDiscovery = originalAllow.length > 0;
-  const originalAllowSet = useAllowlistDiscovery ? new Set(originalAllow) : undefined;
-  const allow = new Set(originalAllow);
+  const originalAllowSet = useAllowlistDiscovery
+    ? new Set(originalAllow.map((pluginId) => normalizePluginId(pluginId)).filter(Boolean))
+    : undefined;
+  const activatedPluginIds = new Set(
+    params.pluginIds.map((pluginId) => normalizePluginId(pluginId)).filter(Boolean),
+  );
+  let config = params.config ?? {};
+  for (const pluginId of activatedPluginIds) {
+    if (originalAllowSet && !originalAllowSet.has(pluginId)) {
+      activatedPluginIds.delete(pluginId);
+      continue;
+    }
+    config = normalizePluginTargetConfig(config, pluginId);
+  }
+  const allow = new Set(config.plugins?.allow ?? []);
   const entries = {
-    ...params.config?.plugins?.entries,
+    ...config.plugins?.entries,
   };
-  for (const pluginId of params.pluginIds) {
-    const normalized = pluginId.trim();
-    if (!normalized) {
-      continue;
-    }
-    if (originalAllowSet && !originalAllowSet.has(normalized)) {
-      continue;
-    }
-    allow.add(normalized);
-    const existingEntry = entries[normalized];
-    entries[normalized] = {
+  for (const pluginId of activatedPluginIds) {
+    allow.add(pluginId);
+    const existingEntry = entries[pluginId];
+    entries[pluginId] = {
       ...existingEntry,
       enabled: existingEntry?.enabled !== false || params.overrideExplicitDisable === true,
     };
@@ -78,9 +86,9 @@ export function withActivatedPluginIds(params: {
   const forcePluginsEnabled =
     params.overrideGlobalDisable === true && params.config?.plugins?.enabled === false;
   return {
-    ...params.config,
+    ...config,
     plugins: {
-      ...params.config?.plugins,
+      ...config.plugins,
       ...(forcePluginsEnabled ? { enabled: true } : {}),
       ...(allow.size > 0 ? { allow: [...allow] } : {}),
       entries,

--- a/src/plugins/activation-context.ts
+++ b/src/plugins/activation-context.ts
@@ -4,7 +4,9 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withBundledPluginEnablementCompat } from "./bundled-compat.js";
 import {
   createPluginActivationSource,
+  normalizePluginId,
   normalizePluginsConfig,
+  normalizePluginTargetConfig,
   type NormalizedPluginsConfig,
   type PluginActivationConfigSource,
 } from "./config-state.js";
@@ -53,22 +55,28 @@ export function withActivatedPluginIds(params: {
   }
   const originalAllow = params.config?.plugins?.allow ?? [];
   const useAllowlistDiscovery = originalAllow.length > 0;
-  const originalAllowSet = useAllowlistDiscovery ? new Set(originalAllow) : undefined;
-  const allow = new Set(originalAllow);
+  const originalAllowSet = useAllowlistDiscovery
+    ? new Set(originalAllow.map((pluginId) => normalizePluginId(pluginId)).filter(Boolean))
+    : undefined;
+  const activatedPluginIds = new Set(
+    params.pluginIds.map((pluginId) => normalizePluginId(pluginId)).filter(Boolean),
+  );
+  let config = params.config ?? {};
+  for (const pluginId of activatedPluginIds) {
+    if (originalAllowSet && !originalAllowSet.has(pluginId)) {
+      activatedPluginIds.delete(pluginId);
+      continue;
+    }
+    config = normalizePluginTargetConfig(config, pluginId);
+  }
+  const allow = new Set(config.plugins?.allow ?? []);
   const entries = {
-    ...params.config?.plugins?.entries,
+    ...config.plugins?.entries,
   };
-  for (const pluginId of params.pluginIds) {
-    const normalized = pluginId.trim();
-    if (!normalized) {
-      continue;
-    }
-    if (originalAllowSet && !originalAllowSet.has(normalized)) {
-      continue;
-    }
-    allow.add(normalized);
-    const existingEntry = entries[normalized];
-    entries[normalized] = {
+  for (const pluginId of activatedPluginIds) {
+    allow.add(pluginId);
+    const existingEntry = entries[pluginId];
+    entries[pluginId] = {
       ...existingEntry,
       enabled: existingEntry?.enabled !== false || params.overrideExplicitDisable === true,
     };
@@ -76,9 +84,9 @@ export function withActivatedPluginIds(params: {
   const forcePluginsEnabled =
     params.overrideGlobalDisable === true && params.config?.plugins?.enabled === false;
   return {
-    ...params.config,
+    ...config,
     plugins: {
-      ...params.config?.plugins,
+      ...config.plugins,
       ...(forcePluginsEnabled ? { enabled: true } : {}),
       ...(allow.size > 0 ? { allow: [...allow] } : {}),
       entries,

--- a/src/plugins/bundled-compat.test.ts
+++ b/src/plugins/bundled-compat.test.ts
@@ -75,4 +75,59 @@ describe("withBundledPluginEnablementCompat", () => {
       })?.plugins?.allow,
     ).toEqual(["openai", "deepseek"]);
   });
+
+  it("preserves explicit alias disables for canonical bundled plugin ids", () => {
+    const config = {
+      plugins: {
+        entries: {
+          "GOOGLE-GEMINI-CLI": {
+            enabled: false,
+            config: { projectId: "example" },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(
+      withBundledPluginEnablementCompat({
+        config,
+        pluginIds: ["google"],
+      }),
+    ).toEqual({
+      plugins: {
+        entries: {
+          google: {
+            enabled: false,
+            config: { projectId: "example" },
+          },
+        },
+      },
+    });
+  });
+
+  it("canonicalizes compat aliases before extending the allowlist", () => {
+    readBundledDiscoveryMode.mockReturnValue("compat");
+    const config = {
+      plugins: {
+        allow: ["MINIMAX-PORTAL"],
+        entries: {
+          "MiNiMaX-PoRtAl-AuTh": { enabled: false },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(
+      withBundledPluginEnablementCompat({
+        config,
+        pluginIds: [" MINIMAX-PORTAL-AUTH "],
+      }),
+    ).toEqual({
+      plugins: {
+        allow: ["minimax"],
+        entries: {
+          minimax: { enabled: false },
+        },
+      },
+    });
+  });
 });

--- a/src/plugins/bundled-compat.test.ts
+++ b/src/plugins/bundled-compat.test.ts
@@ -130,4 +130,28 @@ describe("withBundledPluginEnablementCompat", () => {
       },
     });
   });
+
+  it("preserves empty model policy arrays through repeated alias normalization", () => {
+    const config = {
+      plugins: {
+        entries: {
+          "GOOGLE-GEMINI-CLI": {
+            subagent: { allowedModels: [] },
+            llm: { allowedModels: [], allowedCompletionModels: [] },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const first = withBundledPluginEnablementCompat({ config, pluginIds: ["google"] });
+    const second = withBundledPluginEnablementCompat({
+      config: first,
+      pluginIds: ["GOOGLE-GEMINI-CLI"],
+    });
+
+    const entry = second?.plugins?.entries?.google;
+    expect(entry?.subagent?.allowedModels).toEqual([]);
+    expect(entry?.llm?.allowedModels).toEqual([]);
+    expect(entry?.llm?.allowedCompletionModels).toEqual([]);
+  });
 });

--- a/src/plugins/bundled-compat.test.ts
+++ b/src/plugins/bundled-compat.test.ts
@@ -75,4 +75,59 @@ describe("withBundledPluginEnablementCompat", () => {
       })?.plugins?.allow,
     ).toEqual(["openai", "deepseek"]);
   });
+
+  it("preserves explicit alias disables for canonical bundled plugin ids", () => {
+    const config = {
+      plugins: {
+        entries: {
+          "GOOGLE-GEMINI-CLI": {
+            enabled: false,
+            config: { projectId: "example" },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(
+      withBundledPluginEnablementCompat({
+        config,
+        pluginIds: ["google"],
+      }),
+    ).toEqual({
+      plugins: {
+        entries: {
+          google: {
+            enabled: false,
+            config: { projectId: "example" },
+          },
+        },
+      },
+    });
+  });
+
+  it("canonicalizes compat aliases before extending the allowlist", () => {
+    readBundledDiscoveryModeMemoized.mockReturnValue("compat");
+    const config = {
+      plugins: {
+        allow: ["MINIMAX-PORTAL"],
+        entries: {
+          "MiNiMaX-PoRtAl-AuTh": { enabled: false },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(
+      withBundledPluginEnablementCompat({
+        config,
+        pluginIds: [" MINIMAX-PORTAL-AUTH "],
+      }),
+    ).toEqual({
+      plugins: {
+        allow: ["minimax"],
+        entries: {
+          minimax: { enabled: false },
+        },
+      },
+    });
+  });
 });

--- a/src/plugins/bundled-compat.ts
+++ b/src/plugins/bundled-compat.ts
@@ -2,7 +2,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginEntryConfig } from "../config/types.plugins.js";
 import { readBundledDiscoveryMode } from "./bundled-discovery-state.js";
-import { normalizePluginId } from "./config-state.js";
+import { normalizePluginId, normalizePluginTargetConfig } from "./config-state.js";
 
 /** Returns config with selected bundled plugins explicitly enabled when compat rules require it. */
 export function withBundledPluginEnablementCompat(params: {
@@ -12,7 +12,6 @@ export function withBundledPluginEnablementCompat(params: {
   if (params.pluginIds.length === 0) {
     return params.config;
   }
-  const existingEntries = params.config?.plugins?.entries ?? {};
   const forcePluginsEnabled = params.config?.plugins?.enabled === false;
   const allow = params.config?.plugins?.allow;
   const bypassAllowlist = readBundledDiscoveryMode() === "compat";
@@ -20,16 +19,27 @@ export function withBundledPluginEnablementCompat(params: {
     !bypassAllowlist && Array.isArray(allow) && allow.length > 0
       ? new Set(allow.map((pluginId) => normalizePluginId(pluginId)).filter(Boolean))
       : undefined;
-  let hasEligiblePlugin = false;
+  const eligiblePluginIds = [
+    ...new Set(params.pluginIds.map((pluginId) => normalizePluginId(pluginId)).filter(Boolean)),
+  ].filter((pluginId) => !allowSet || allowSet.has(pluginId));
+  if (eligiblePluginIds.length === 0) {
+    return params.config;
+  }
+
+  let config = params.config ?? {};
+  for (const pluginId of eligiblePluginIds) {
+    config = normalizePluginTargetConfig(config, pluginId);
+  }
+
+  const existingEntries = config.plugins?.entries ?? {};
   let changed = false;
   const nextEntries: Record<string, PluginEntryConfig> = { ...existingEntries };
-  const nextAllow = bypassAllowlist && Array.isArray(allow) ? new Set(allow) : undefined;
+  const nextAllow =
+    bypassAllowlist && Array.isArray(config.plugins?.allow)
+      ? new Set(config.plugins.allow)
+      : undefined;
 
-  for (const pluginId of params.pluginIds) {
-    if (allowSet && !allowSet.has(pluginId)) {
-      continue;
-    }
-    hasEligiblePlugin = true;
+  for (const pluginId of eligiblePluginIds) {
     const beforeAllowSize = nextAllow?.size;
     nextAllow?.add(pluginId);
     if (nextAllow && nextAllow.size !== beforeAllowSize) {
@@ -43,15 +53,15 @@ export function withBundledPluginEnablementCompat(params: {
   }
 
   if (!changed) {
-    if (!forcePluginsEnabled || !hasEligiblePlugin) {
-      return params.config;
+    if (!forcePluginsEnabled) {
+      return config;
     }
   }
 
   return {
-    ...params.config,
+    ...config,
     plugins: {
-      ...params.config?.plugins,
+      ...config.plugins,
       ...(forcePluginsEnabled ? { enabled: true } : {}),
       ...(nextAllow ? { allow: [...nextAllow] } : {}),
       entries: nextEntries,

--- a/src/plugins/bundled-compat.ts
+++ b/src/plugins/bundled-compat.ts
@@ -2,7 +2,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginEntryConfig } from "../config/types.plugins.js";
 import { readBundledDiscoveryModeMemoized } from "./bundled-discovery-state.js";
-import { normalizePluginId } from "./config-state.js";
+import { normalizePluginId, normalizePluginTargetConfig } from "./config-state.js";
 
 /** Returns config with selected bundled plugins explicitly enabled when compat rules require it. */
 export function withBundledPluginEnablementCompat(params: {
@@ -14,7 +14,6 @@ export function withBundledPluginEnablementCompat(params: {
   if (params.pluginIds.length === 0) {
     return params.config;
   }
-  const existingEntries = params.config?.plugins?.entries ?? {};
   const selectPlugins = params.activation !== "defaults";
   const forcePluginsEnabled = selectPlugins && params.config?.plugins?.enabled === false;
   const allow = params.config?.plugins?.allow;
@@ -23,16 +22,27 @@ export function withBundledPluginEnablementCompat(params: {
     !bypassAllowlist && Array.isArray(allow) && allow.length > 0
       ? new Set(allow.map((pluginId) => normalizePluginId(pluginId)).filter(Boolean))
       : undefined;
-  let hasEligiblePlugin = false;
+  const eligiblePluginIds = [
+    ...new Set(params.pluginIds.map((pluginId) => normalizePluginId(pluginId)).filter(Boolean)),
+  ].filter((pluginId) => !allowSet || allowSet.has(pluginId));
+  if (eligiblePluginIds.length === 0) {
+    return params.config;
+  }
+
+  let config = params.config ?? {};
+  for (const pluginId of eligiblePluginIds) {
+    config = normalizePluginTargetConfig(config, pluginId);
+  }
+
+  const existingEntries = config.plugins?.entries ?? {};
   let changed = false;
   const nextEntries: Record<string, PluginEntryConfig> = { ...existingEntries };
-  const nextAllow = bypassAllowlist && Array.isArray(allow) ? new Set(allow) : undefined;
+  const nextAllow =
+    bypassAllowlist && Array.isArray(config.plugins?.allow)
+      ? new Set(config.plugins.allow)
+      : undefined;
 
-  for (const pluginId of params.pluginIds) {
-    if (allowSet && !allowSet.has(pluginId)) {
-      continue;
-    }
-    hasEligiblePlugin = true;
+  for (const pluginId of eligiblePluginIds) {
     const beforeAllowSize = nextAllow?.size;
     nextAllow?.add(pluginId);
     if (nextAllow && nextAllow.size !== beforeAllowSize) {
@@ -46,15 +56,15 @@ export function withBundledPluginEnablementCompat(params: {
   }
 
   if (!changed) {
-    if (!forcePluginsEnabled || !hasEligiblePlugin) {
-      return params.config;
+    if (!forcePluginsEnabled) {
+      return config;
     }
   }
 
   return {
-    ...params.config,
+    ...config,
     plugins: {
-      ...params.config?.plugins,
+      ...config.plugins,
       ...(forcePluginsEnabled ? { enabled: true } : {}),
       ...(nextAllow ? { allow: [...nextAllow] } : {}),
       ...(selectPlugins ? { entries: nextEntries } : {}),

--- a/src/plugins/config-normalization-shared.ts
+++ b/src/plugins/config-normalization-shared.ts
@@ -159,9 +159,7 @@ function normalizePluginEntries(
               ? { allowModelOverride: subagent.allowModelOverride }
               : {}),
             ...(subagent.hasAllowedModelsConfig ? { hasAllowedModelsConfig: true } : {}),
-            ...(Array.isArray(subagent.allowedModels) && subagent.allowedModels.length > 0
-              ? { allowedModels: subagent.allowedModels }
-              : {}),
+            ...(subagent.hasAllowedModelsConfig ? { allowedModels: subagent.allowedModels } : {}),
           }
         : undefined;
     const llmRaw = entry.llm;
@@ -207,13 +205,11 @@ function normalizePluginEntries(
               ? { allowModelOverride: llm.allowModelOverride }
               : {}),
             ...(llm.hasAllowedModelsConfig ? { hasAllowedModelsConfig: true } : {}),
-            ...(Array.isArray(llm.allowedModels) && llm.allowedModels.length > 0
-              ? { allowedModels: llm.allowedModels }
-              : {}),
+            ...(llm.hasAllowedModelsConfig ? { allowedModels: llm.allowedModels } : {}),
             ...(llm.hasAllowedCompletionModelsConfig
               ? { hasAllowedCompletionModelsConfig: true }
               : {}),
-            ...(Array.isArray(llm.allowedCompletionModels) && llm.allowedCompletionModels.length > 0
+            ...(llm.hasAllowedCompletionModelsConfig
               ? { allowedCompletionModels: llm.allowedCompletionModels }
               : {}),
             ...(typeof llm.allowAuthProfileOverride === "boolean"

--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -158,6 +158,7 @@ describe("normalizePluginsConfig", () => {
       } as unknown as { allowModelOverride: boolean; allowedModels: string[] },
       expected: {
         hasAllowedModelsConfig: true,
+        allowedModels: [],
       },
     },
   ] as const)("$name", ({ subagent, expected }) => {


### PR DESCRIPTION
Closes #121128

Source context: #120928 and #77194

## What Problem This Solves

Fixes an issue where provider-driven plugin activation could skip an allowed plugin when either the allowlist or requested plugin ID used a supported alias or different casing. The same mismatch could also create a canonical enabled entry beside an explicitly disabled alias entry, including in bundled compatibility activation paths.

## Why This Change Was Made

Forced activation now applies the existing plugin ID normalization contract to the original allowlist, requested IDs, and targeted config entry before changing enablement. Bundled compatibility activation uses the same targeted canonicalization helper before deciding whether an entry already exists. This keeps both activation paths aligned with the canonical config contract introduced in #77194 while preserving explicit disables unless the caller opts into overriding them.

## User Impact

Users can use supported Google and MiniMax plugin aliases consistently in plugin allowlists and provider activation flows. Explicitly disabled aliased entries remain disabled instead of being bypassed by a second canonical entry.

## Evidence

- Historical proof head: `098b423d836e49a2004bf8e18386eeee8afbad18`.
- Added focused activation-context coverage for Google alias/case normalization, MiniMax alias normalization, and preservation of explicitly disabled alias entries.
- Added focused bundled-compat coverage for a canonical Google target with an uppercase legacy disabled entry and for mixed-case MiniMax aliases in compatibility mode.
- `git diff --check` passes.
- Fresh repo-native autoreview on the final patch: clean, no accepted/actionable findings; correctness confidence `0.9`.
- Exact-head secretless fork [bundled compatibility proof run 31381592358](https://github.com/Leon-SK668/openclaw/actions/runs/31381592358) passed with `permissions: {}` on Node `24.15.0`. It verified the full SHA, checked formatting for both changed files, and ran `src/plugins/bundled-compat.test.ts`: 1 file and 6 tests passed.
- The same exact-head proof called the production `resolvePluginWebSearchProviders` owner boundary. Its positive control resolved `google:gemini`; a `GOOGLE-GEMINI-CLI` entry with `enabled: false` and plugin config was canonicalized to `google`, retained both the disable and config, and resolved zero disabled providers.
- Redacted marker: `BUNDLED_COMPAT_ALIAS_DISABLE_PROOF_121150 {"head":"098b423d836e49a2004bf8e18386eeee8afbad18","boundary":"resolvePluginWebSearchProviders","canonicalEntry":{"enabled":false,"config":{"webSearch":{"model":"gemini-3-flash-preview"}}},"positiveControl":"google:gemini","disabledAliasProviderCount":0,"credentials":"none"}`.
- Parent-head [production provider-owner proof run 31363982676](https://github.com/Leon-SK668/openclaw/actions/runs/31363982676) also passed without credentials. It exercised provider-driven canonical activation through setup and runtime hooks and confirmed that an explicitly disabled Google alias stayed disabled.

AI-assisted: yes. No agent transcript is included.

### Rebase reconciliation (September 5, 2026)

- Rebase head before the policy repair: `ebc335e25560ef9bac1ab1ffd52033a5f3988400`
- Rebased onto frozen `upstream/main` at `c4052ca628ac0e1026b82c10d7d80a5ebd8aaff9`; upstream `main` advanced after this batch, so no later baseline is claimed here.
- The owner-level production/test change described above is preserved; this note records the new head after rebase and does not replace the original proof receipts.
- Current-head CI audit: no completed PR-owned failure was found at this rebase head.
- No new live proof is claimed by this reconciliation note.

### Empty Policy Repair, September 5

- Production repair head: `fd14979877f033e78fd94214b3d9888eaaac1197`, based directly on `ebc335e25560ef9bac1ab1ffd52033a5f3988400`.
- Targeted alias activation was dropping explicitly empty subagent/LLM model allowlists. A later normalization pass then treated those restrictions as absent. The shared normalization owner now retains all three explicitly configured arrays, including empty arrays, without adding a configuration surface.
- Acceptance-red on the prior head: the repeated-normalization regression failed with expected undefined to deeply equal []. After repair, bundled-compat passed 7/7 and activation-context plus runtime-llm passed 39/39, under Node 24.15.0.
- Commands: node scripts/run-vitest.mjs src/plugins/bundled-compat.test.ts; node scripts/run-vitest.mjs src/plugins/activation-context.test.ts src/plugins/runtime/runtime-llm.runtime.test.ts --run.
- A direct two-pass production normalizePluginTargetConfig probe also read back all three empty arrays. This is a local owner-contract probe, not a live provider run. Historical provider-owner proof above remains tied to its recorded older SHA.
- Scoped oxfmt, oxlint --deny-warnings, and git diff --check passed. Fresh autoreview --mode local --max-priority P3 was scoped-clean with no accepted/actionable findings.
- Repair-only size: 3 files; production +3/-7, tests +48/-0. No generated, lockfile, protocol, schema, or new default/config changes.
- The final commit author and committer are both Leon-SK668; the reviewed and tested code tree is unchanged. CI passed at that production-repair head; the subsequent review found the outdated sibling assertion addressed below.

### Normalization Sibling Test Follow-up, September 5

- Current head: `01f6dbfdd70a6f2d4fd8ce9829ddd632cdcae79b`, parent `fd14979877f033e78fd94214b3d9888eaaac1197`. This follow-up changes one existing test expectation, +1/-0 test LOC and zero production LOC.
- The invalid-only subagent allowlist case must retain `allowedModels: []` alongside `hasAllowedModelsConfig: true`, matching the repaired canonical normalization contract. The old assertion omitted the explicit empty array.
- Acceptance-red: `src/plugins/config-state.test.ts` had 1 failure and 61 passing cases. After the expectation repair, config-state, activation-context, and bundled-compat passed together: 3 files, 76 tests under Node 24.15.0.
- Command: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/config-state.test.ts src/plugins/activation-context.test.ts src/plugins/bundled-compat.test.ts`. Scoped type-aware Oxlint, formatting, and `git diff --check` passed.
- Fresh `autoreview --mode local --max-priority P3`: scoped-clean, no findings for this test-only repair. Exact-head [CI run 33946887802](https://github.com/openclaw/openclaw/actions/runs/33946887802) passed, including openclaw/ci-gate. External re-review is pending; historical production-owner proof remains tied to its recorded SHA.
