### PR TITLE
feat(memory): add identity protocol and binding registry

### DIFF
--- a/packages/gateway-protocol/src/schema-export-registry.ts
+++ b/packages/gateway-protocol/src/schema-export-registry.ts
@@ -389,6 +389,8 @@ export {
   ChannelsPairingApproveResultSchema,
   ChannelsPairingDismissParamsSchema,
   ChannelsPairingDismissResultSchema,
+  MemoryIdentityBindingRevokeParamsSchema,
+  MemoryIdentityBindingRevokeResultSchema,
   ChannelsStartParamsSchema,
   ChannelsStopParamsSchema,
   ChannelsLogoutParamsSchema,

--- a/packages/gateway-protocol/src/schema-modules.ts
+++ b/packages/gateway-protocol/src/schema-modules.ts
@@ -27,6 +27,7 @@ export * from "./schema/fs.js";
 export * from "./schema/gateway-suspend.js";
 export * from "./schema/hooks.js";
 export * from "./schema/logs-chat.js";
+export * from "./schema/memory-identity.js";
 export * from "./schema/migrations.js";
 export * from "./schema/nodes.js";
 export * from "./schema/push.js";

--- a/packages/gateway-protocol/src/schema/channel-pairing.ts
+++ b/packages/gateway-protocol/src/schema/channel-pairing.ts
@@ -50,6 +50,8 @@ export const ChannelsPairingApproveParamsSchema = closedObject({
   requestId: NonEmptyString,
   notify: Type.Optional(Type.Boolean()),
   bootstrapCommandOwner: Type.Optional(Type.Boolean()),
+  /** Explicit operator attestation; ordinary pairing never creates private-memory identity. */
+  linkMemoryProfileId: Type.Optional(NonEmptyString),
 });
 
 export const ChannelsPairingApproveResultSchema = closedObject({
@@ -59,6 +61,9 @@ export const ChannelsPairingApproveResultSchema = closedObject({
   commandOwnerBootstrap: Type.String({
     enum: ["not-requested", "configured", "already-configured", "unavailable"],
   }),
+  // Older Gateways do not return Phase 1A's optional identity-link result.
+  memoryBinding: Type.Optional(Type.String({ enum: ["not-requested", "created"] })),
+  memoryBindingId: Type.Optional(NonEmptyString),
 });
 
 /** Dismisses one pending request without permanently blocking the sender. */

--- a/packages/gateway-protocol/src/schema/memory-identity.ts
+++ b/packages/gateway-protocol/src/schema/memory-identity.ts
@@ -1,0 +1,25 @@
+// Gateway protocol schemas for durable memory-identity administration.
+import type { Static } from "typebox";
+import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
+
+const MemoryIdentityBindingIdSchema = Type.String({ minLength: 1, maxLength: 128 });
+const MemoryIdentityRevocationReasonSchema = Type.String({ maxLength: 1_024 });
+
+/** Revokes one durable identity binding while retaining its verification evidence. */
+export const MemoryIdentityBindingRevokeParamsSchema = closedObject({
+  bindingId: MemoryIdentityBindingIdSchema,
+  reason: Type.Optional(MemoryIdentityRevocationReasonSchema),
+});
+
+export const MemoryIdentityBindingRevokeResultSchema = closedObject({
+  bindingId: MemoryIdentityBindingIdSchema,
+  revoked: Type.Boolean(),
+});
+
+export type MemoryIdentityBindingRevokeParams = Static<
+  typeof MemoryIdentityBindingRevokeParamsSchema
+>;
+export type MemoryIdentityBindingRevokeResult = Static<
+  typeof MemoryIdentityBindingRevokeResultSchema
+>;

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-operations.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-operations.ts
@@ -2,6 +2,7 @@ import * as auditActivity from "./audit-activity.js";
 import * as auditRun from "./audit-run.js";
 import * as audit from "./audit.js";
 import * as config from "./config.js";
+import * as memoryIdentity from "./memory-identity.js";
 import * as openclaw from "./openclaw.js";
 import * as taskSuggestions from "./task-suggestions.js";
 import * as tasks from "./tasks.js";
@@ -55,6 +56,8 @@ export const OperationsProtocolSchemas = {
   ConfigSchemaLookupParams: config.ConfigSchemaLookupParamsSchema,
   ConfigSchemaResponse: config.ConfigSchemaResponseSchema,
   ConfigSchemaLookupResult: config.ConfigSchemaLookupResultSchema,
+  MemoryIdentityBindingRevokeParams: memoryIdentity.MemoryIdentityBindingRevokeParamsSchema,
+  MemoryIdentityBindingRevokeResult: memoryIdentity.MemoryIdentityBindingRevokeResultSchema,
   SystemAgentChatParams: openclaw.SystemAgentChatParamsSchema,
   SystemAgentChatResult: openclaw.SystemAgentChatResultSchema,
   SystemAgentChatHistoryParams: openclaw.SystemAgentChatHistoryParamsSchema,

--- a/packages/gateway-protocol/src/validator-registry.ts
+++ b/packages/gateway-protocol/src/validator-registry.ts
@@ -309,6 +309,12 @@ export const validateChannelsStatusParams = compile(S.ChannelsStatusParamsSchema
 export const validateChannelsPairingListParams = compile(S.ChannelsPairingListParamsSchema);
 export const validateChannelsPairingApproveParams = compile(S.ChannelsPairingApproveParamsSchema);
 export const validateChannelsPairingDismissParams = compile(S.ChannelsPairingDismissParamsSchema);
+export const validateMemoryIdentityBindingRevokeParams = compile(
+  S.MemoryIdentityBindingRevokeParamsSchema,
+);
+export const validateMemoryIdentityBindingRevokeResult = compile(
+  S.MemoryIdentityBindingRevokeResultSchema,
+);
 export const validateChannelsStartParams = compile(S.ChannelsStartParamsSchema);
 export const validateChannelsStopParams = compile(S.ChannelsStopParamsSchema);
 export const validateChannelsLogoutParams = compile(S.ChannelsLogoutParamsSchema);

--- a/scripts/check-protocol-registry.mts
+++ b/scripts/check-protocol-registry.mts
@@ -113,8 +113,8 @@ const ownerModules = [
   ...schemaModulesSource.matchAll(/^export \* from "\.\/schema\/([^"]+)\.js";$/gmu),
 ].map(([, moduleName = ""]) => moduleName);
 check(
-  ownerModules.length === 54 && new Set(ownerModules).size === ownerModules.length,
-  "schema-modules.ts must contain one unique 54-module owner list",
+  ownerModules.length === 55 && new Set(ownerModules).size === ownerModules.length,
+  "schema-modules.ts must contain one unique 55-module owner list",
 );
 check(
   schemaModulesSource.split("\n").filter(Boolean).length === ownerModules.length,

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -112,6 +112,7 @@ describe("method scope resolution", () => {
     ["talk.session.close", ["operator.talk"]],
     ["update.status", ["operator.admin"]],
     ["update.hold", ["operator.admin"]],
+    ["memory.identityBinding.revoke", ["operator.admin"]],
     ["config.schema", ["operator.admin"]],
     ["config.patch", ["operator.admin"]],
     ["nativeHook.invoke", ["operator.admin"]],
@@ -205,7 +206,7 @@ describe("method scope resolution", () => {
     });
   });
 
-  it("requires admin only when DM pairing approval bootstraps a command owner", () => {
+  it("requires admin when DM pairing approval bootstraps a command owner or links private memory", () => {
     expect(resolveLeastPrivilegeOperatorScopesForMethod("channels.pairing.approve", {})).toEqual([
       "operator.pairing",
     ]);
@@ -224,6 +225,23 @@ describe("method scope resolution", () => {
         "channels.pairing.approve",
         ["operator.pairing", "operator.admin"],
         { bootstrapCommandOwner: true },
+      ),
+    ).toEqual({ allowed: true });
+    expect(
+      resolveLeastPrivilegeOperatorScopesForMethod("channels.pairing.approve", {
+        linkMemoryProfileId: "profile-1",
+      }),
+    ).toEqual(["operator.pairing", "operator.admin"]);
+    expect(
+      authorizeOperatorScopesForMethod("channels.pairing.approve", ["operator.pairing"], {
+        linkMemoryProfileId: "profile-1",
+      }),
+    ).toEqual({ allowed: false, missingScope: "operator.admin" });
+    expect(
+      authorizeOperatorScopesForMethod(
+        "channels.pairing.approve",
+        ["operator.pairing", "operator.admin"],
+        { linkMemoryProfileId: "profile-1" },
       ),
     ).toEqual({ allowed: true });
   });

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -167,11 +167,13 @@ function resolveDynamicLeastPrivilegeOperatorScopesForMethod(
     return includeSecrets === true ? [READ_SCOPE, TALK_SECRETS_SCOPE] : [READ_SCOPE];
   }
   if (method === "channels.pairing.approve") {
-    const bootstrapCommandOwner =
+    const pairingApproval =
       params && typeof params === "object" && !Array.isArray(params)
-        ? (params as { bootstrapCommandOwner?: unknown }).bootstrapCommandOwner
+        ? (params as { bootstrapCommandOwner?: unknown; linkMemoryProfileId?: unknown })
         : undefined;
-    return bootstrapCommandOwner === true ? [PAIRING_SCOPE, ADMIN_SCOPE] : [PAIRING_SCOPE];
+    return pairingApproval?.bootstrapCommandOwner === true || pairingApproval?.linkMemoryProfileId
+      ? [PAIRING_SCOPE, ADMIN_SCOPE]
+      : [PAIRING_SCOPE];
   }
   if (method === "sessions.patch") {
     return [resolveDynamicSessionMutationRequiredScope(method, params) ?? WRITE_SCOPE];

--- a/src/gateway/methods/core-descriptors.since.test.ts
+++ b/src/gateway/methods/core-descriptors.since.test.ts
@@ -102,5 +102,8 @@ describe("core gateway method release trains", () => {
     expect(methods.find((method) => method.name === "worker.desktop.observe")?.since).toBe(
       "2026.8",
     );
+    expect(methods.find((method) => method.name === "memory.identityBinding.revoke")?.since).toBe(
+      "2026.8",
+    );
   });
 });

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -492,6 +492,9 @@ const CORE_GATEWAY_METHOD_SPECS = [
   // Additive catalog terminal start appends so older advertised indices stay stable.
   ["sessions.catalog.startTerminal", "session-catalog", "operator.admin", "2026.8"],
   ["worker.desktop.observe", "environments", "operator.admin", "2026.8", { startup: true }],
+  // Emergency privacy revocation stays admin-only but must not be throttled behind
+  // unrelated control-plane writes that could delay disabling a private-memory binding.
+  ["memory.identityBinding.revoke", "memory-identity", "operator.admin", "2026.8"],
 ] as const satisfies readonly CoreGatewayMethodSpecRow[];
 
 export type CoreGatewayHandlerFamily = Exclude<(typeof CORE_GATEWAY_METHOD_SPECS)[number][1], null>;

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -66,7 +66,7 @@ describe("listGatewayMethods", () => {
   });
 
   it("appends new methods after model probing without shifting older method indices", () => {
-    expect(listGatewayMethods().slice(-35)).toEqual([
+    expect(listGatewayMethods().slice(-36)).toEqual([
       "models.probe",
       "migrations.memory.plan",
       "migrations.memory.apply",
@@ -102,6 +102,7 @@ describe("listGatewayMethods", () => {
       "update.hold",
       "sessions.catalog.startTerminal",
       "worker.desktop.observe",
+      "memory.identityBinding.revoke",
     ]);
     const methods = listGatewayMethods();
     expect(methods.indexOf("node.pluginSurface.refresh")).toBe(
@@ -174,7 +175,7 @@ describe("listGatewayMethods", () => {
       "exec.approval.get",
     ]);
     expect(methods).toContain("tts.speak");
-    expect(coreMethods.slice(-42)).toEqual([
+    expect(coreMethods.slice(-43)).toEqual([
       "sessions.catalog.continue",
       "sessions.catalog.archive",
       "approval.get",
@@ -217,6 +218,7 @@ describe("listGatewayMethods", () => {
       "update.hold",
       "sessions.catalog.startTerminal",
       "worker.desktop.observe",
+      "memory.identityBinding.revoke",
     ]);
     expect(methods.indexOf("approval.get")).toBeGreaterThan(methods.indexOf("tts.speak"));
     expect(methods.indexOf("approval.resolve")).toBe(methods.indexOf("approval.get") + 1);

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -100,6 +100,8 @@ const CORE_GATEWAY_HANDLER_MODULES = {
   logs: () => import("./server-methods/logs.js").then((module) => module.logsHandlers),
   "memory-search": () =>
     import("./server-methods/memory-search.js").then((module) => module.memorySearchHandlers),
+  "memory-identity": () =>
+    import("./server-methods/memory-identity.js").then((module) => module.memoryIdentityHandlers),
   terminal: () => import("./server-methods/terminal.js").then((module) => module.terminalHandlers),
   "ui-command": () =>
     import("./server-methods/ui-command.js").then((module) => module.uiCommandHandlers),

--- a/src/gateway/server-methods/channel-pairing.test.ts
+++ b/src/gateway/server-methods/channel-pairing.test.ts
@@ -4,11 +4,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   approve: vi.fn(),
   bootstrapOwner: vi.fn(),
+  createMemoryBinding: vi.fn(),
   dismiss: vi.fn(),
+  ensureGatewayProfileMemoryPrincipalInTransaction: vi.fn(),
+  ensureMemoryIdentitySchema: vi.fn(),
   hasOwners: vi.fn(),
   listPlugins: vi.fn(),
   listRequests: vi.fn(),
   notify: vi.fn(),
+  resolveUserProfileId: vi.fn(),
 }));
 
 vi.mock("../../channels/plugins/index.js", () => ({
@@ -30,6 +34,17 @@ vi.mock("../../pairing/pairing-store.js", () => ({
   dismissChannelPairingRequest: mocks.dismiss,
   listChannelPairingRequests: mocks.listRequests,
   resolveChannelPairingRequestId: vi.fn(() => "opaque-request-id"),
+}));
+vi.mock("../../state/memory-identity.js", () => ({
+  ensureMemoryIdentitySchema: mocks.ensureMemoryIdentitySchema,
+  memoryIdentityLifecycle: {
+    createMemoryIdentityBindingFromApprovedChannelPairing: mocks.createMemoryBinding,
+    ensureGatewayProfileMemoryPrincipalInTransaction:
+      mocks.ensureGatewayProfileMemoryPrincipalInTransaction,
+  },
+}));
+vi.mock("../../state/user-profiles.js", () => ({
+  resolveUserProfileId: mocks.resolveUserProfileId,
 }));
 vi.mock("../runtime-plugin-config.js", () => ({
   resolveGatewayPluginConfig: ({ config }: { config: unknown }) => config,
@@ -74,6 +89,7 @@ function createContext() {
 async function invoke(
   method: keyof typeof channelPairingHandlers,
   params: Record<string, unknown>,
+  options: { client?: unknown } = {},
 ) {
   const respond = vi.fn();
   const handler = expectDefined(channelPairingHandlers[method], `${method} test invariant`);
@@ -81,8 +97,25 @@ async function invoke(
     params,
     respond,
     context: createContext(),
+    ...(options.client ? { client: options.client } : {}),
   } as unknown as Parameters<typeof handler>[0]);
   return respond;
+}
+
+function createAuthenticatedClient(params: { profileId?: string; scopes: string[] }) {
+  return {
+    connect: { scopes: params.scopes },
+    ...(params.profileId
+      ? {
+          authenticatedUserProfile: {
+            profileId: params.profileId,
+            displayName: null,
+            hasAvatar: false,
+            updatedAt: 1,
+          },
+        }
+      : {}),
+  };
 }
 
 beforeEach(() => {
@@ -91,6 +124,15 @@ beforeEach(() => {
   mocks.hasOwners.mockReturnValue(false);
   mocks.listRequests.mockResolvedValue([]);
   mocks.bootstrapOwner.mockResolvedValue({ ownerEntry: "whatsapp:+1555", status: "configured" });
+  mocks.resolveUserProfileId.mockReset();
+  mocks.resolveUserProfileId.mockImplementation((profileId: string) => profileId);
+  mocks.ensureMemoryIdentitySchema.mockReset();
+  mocks.ensureGatewayProfileMemoryPrincipalInTransaction.mockReset();
+  mocks.ensureGatewayProfileMemoryPrincipalInTransaction.mockReturnValue({
+    principalId: "memory-principal",
+  });
+  mocks.createMemoryBinding.mockReset();
+  mocks.createMemoryBinding.mockReturnValue({ bindingId: "memory-binding-id" });
 });
 
 describe("channel DM pairing gateway handlers", () => {
@@ -183,6 +225,7 @@ describe("channel DM pairing gateway handlers", () => {
         senderId: "+15551234567",
         notification: "failed",
         commandOwnerBootstrap: "configured",
+        memoryBinding: "not-requested",
       },
       undefined,
     );
@@ -214,8 +257,189 @@ describe("channel DM pairing gateway handlers", () => {
         senderId: "+15551234567",
         notification: "not-requested",
         commandOwnerBootstrap: "unavailable",
+        memoryBinding: "not-requested",
       },
       undefined,
+    );
+  });
+
+  it("requires an admin-scoped authenticated creator before linking private memory", async () => {
+    const params = {
+      channel: "whatsapp",
+      accountId: "personal",
+      requestId: "opaque-request-id",
+      linkMemoryProfileId: "target-profile",
+    };
+
+    const missingAdmin = await invoke("channels.pairing.approve", params, {
+      client: createAuthenticatedClient({
+        profileId: "creator-profile",
+        scopes: ["operator.pairing"],
+      }),
+    });
+    expect(missingAdmin).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: "linkMemoryProfileId requires gateway scope: operator.admin",
+      }),
+    );
+    expect(mocks.approve).not.toHaveBeenCalled();
+    expect(mocks.ensureGatewayProfileMemoryPrincipalInTransaction).not.toHaveBeenCalled();
+
+    const missingCreator = await invoke("channels.pairing.approve", params, {
+      client: createAuthenticatedClient({ scopes: ["operator.pairing", "operator.admin"] }),
+    });
+    expect(missingCreator).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: "linkMemoryProfileId requires an authenticated Gateway profile",
+      }),
+    );
+    expect(mocks.approve).not.toHaveBeenCalled();
+    expect(mocks.ensureGatewayProfileMemoryPrincipalInTransaction).not.toHaveBeenCalled();
+  });
+
+  it("binds the transaction-consumed pairing identity and returns the created binding", async () => {
+    const transactionDatabase = { transaction: "pairing-approval" };
+    const approval = Object.freeze({ consumed: "pairing-approval" });
+    mocks.resolveUserProfileId.mockImplementation((profileId: string) =>
+      profileId === "target-profile" ? "target-profile-current" : "creator-profile-current",
+    );
+    mocks.ensureGatewayProfileMemoryPrincipalInTransaction.mockReturnValue({
+      principalId: "target-memory-principal",
+    });
+    mocks.createMemoryBinding.mockReturnValue({ bindingId: "memory-binding-created" });
+    mocks.approve.mockImplementationOnce(
+      async (params: {
+        onApproved?: (approval: { database: unknown; approval: unknown }) => void;
+      }) => {
+        params.onApproved?.({
+          database: transactionDatabase,
+          approval,
+        });
+        return {
+          id: "+15559876543",
+          entry: {
+            id: "+15559876543",
+            code: "SECRET12",
+            createdAt: "2026-07-20T10:00:00.000Z",
+            lastSeenAt: "2026-07-20T10:00:00.000Z",
+          },
+        };
+      },
+    );
+
+    const respond = await invoke(
+      "channels.pairing.approve",
+      {
+        channel: "whatsapp",
+        accountId: "personal",
+        requestId: "caller-request-id",
+        linkMemoryProfileId: "target-profile",
+      },
+      {
+        client: createAuthenticatedClient({
+          profileId: "creator-profile",
+          scopes: ["operator.pairing", "operator.admin"],
+        }),
+      },
+    );
+
+    expect(mocks.ensureMemoryIdentitySchema).toHaveBeenCalledTimes(1);
+    expect(mocks.ensureGatewayProfileMemoryPrincipalInTransaction).toHaveBeenCalledWith({
+      database: transactionDatabase,
+      profileId: "target-profile",
+    });
+    expect(mocks.createMemoryBinding).toHaveBeenCalledWith({
+      database: transactionDatabase,
+      approval,
+      principalId: "target-memory-principal",
+      creatorProfileId: "creator-profile",
+    });
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      {
+        requestId: "caller-request-id",
+        senderId: "+15559876543",
+        notification: "not-requested",
+        commandOwnerBootstrap: "not-requested",
+        memoryBinding: "created",
+        memoryBindingId: "memory-binding-created",
+      },
+      undefined,
+    );
+  });
+
+  it("does not create a memory principal when the pairing request was already consumed", async () => {
+    mocks.approve.mockResolvedValueOnce(null);
+
+    const respond = await invoke(
+      "channels.pairing.approve",
+      {
+        channel: "whatsapp",
+        accountId: "personal",
+        requestId: "caller-request-id",
+        linkMemoryProfileId: "target-profile",
+      },
+      {
+        client: createAuthenticatedClient({
+          profileId: "creator-profile",
+          scopes: ["operator.pairing", "operator.admin"],
+        }),
+      },
+    );
+
+    expect(mocks.ensureMemoryIdentitySchema).toHaveBeenCalledTimes(1);
+    expect(mocks.ensureGatewayProfileMemoryPrincipalInTransaction).not.toHaveBeenCalled();
+    expect(mocks.createMemoryBinding).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "pending DM access request no longer exists" }),
+    );
+  });
+
+  it("returns the pairing failure path when the atomic memory-binding callback fails", async () => {
+    const transactionDatabase = { transaction: "pairing-approval" };
+    const approval = Object.freeze({ consumed: "pairing-approval" });
+    mocks.createMemoryBinding.mockImplementationOnce(() => {
+      throw new Error("memory binding write failed");
+    });
+    mocks.approve.mockImplementationOnce(
+      async (params: {
+        onApproved?: (approval: { database: unknown; approval: unknown }) => void;
+      }) => {
+        params.onApproved?.({
+          database: transactionDatabase,
+          approval,
+        });
+        return null;
+      },
+    );
+
+    const respond = await invoke(
+      "channels.pairing.approve",
+      {
+        channel: "whatsapp",
+        accountId: "personal",
+        requestId: "caller-request-id",
+        linkMemoryProfileId: "target-profile",
+      },
+      {
+        client: createAuthenticatedClient({
+          profileId: "creator-profile",
+          scopes: ["operator.pairing", "operator.admin"],
+        }),
+      },
+    );
+
+    expect(mocks.createMemoryBinding).toHaveBeenCalledTimes(1);
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("memory binding write failed") }),
     );
   });
 

--- a/src/gateway/server-methods/channel-pairing.ts
+++ b/src/gateway/server-methods/channel-pairing.ts
@@ -28,6 +28,12 @@ import {
   listChannelPairingRequests,
   resolveChannelPairingRequestId,
 } from "../../pairing/pairing-store.js";
+import {
+  ensureMemoryIdentitySchema,
+  memoryIdentityLifecycle,
+} from "../../state/memory-identity.js";
+import { resolveUserProfileId } from "../../state/user-profiles.js";
+import { ADMIN_SCOPE } from "../operator-scopes.js";
 import { resolveGatewayPluginConfig } from "../runtime-plugin-config.js";
 import { formatForLog } from "../ws-log.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
@@ -240,7 +246,7 @@ export const channelPairingHandlers: GatewayRequestHandlers = {
     }
   },
 
-  "channels.pairing.approve": async ({ params, respond, context }) => {
+  "channels.pairing.approve": async ({ params, respond, context, client }) => {
     if (
       !assertValidParams(
         params,
@@ -269,12 +275,110 @@ export const channelPairingHandlers: GatewayRequestHandlers = {
       invalidPairingAccount(respond, parsed.channel, parsed.accountId);
       return;
     }
+
+    let memoryLink:
+      | {
+          targetProfileId: string;
+          creatorProfileId: string;
+        }
+      | undefined;
+    if (parsed.linkMemoryProfileId) {
+      const scopes = Array.isArray(client?.connect.scopes) ? client.connect.scopes : [];
+      if (!scopes.includes(ADMIN_SCOPE)) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.FORBIDDEN,
+            `linkMemoryProfileId requires gateway scope: ${ADMIN_SCOPE}`,
+          ),
+        );
+        return;
+      }
+      const creatorProfileId = client?.authenticatedUserProfile?.profileId;
+      if (!creatorProfileId) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.FORBIDDEN,
+            "linkMemoryProfileId requires an authenticated Gateway profile",
+          ),
+        );
+        return;
+      }
+
+      try {
+        const targetProfileId = resolveUserProfileId(parsed.linkMemoryProfileId);
+        if (!targetProfileId) {
+          respond(
+            false,
+            undefined,
+            errorShape(
+              ErrorCodes.INVALID_REQUEST,
+              "linkMemoryProfileId references no Gateway profile",
+            ),
+          );
+          return;
+        }
+        const resolvedCreatorProfileId = resolveUserProfileId(creatorProfileId);
+        if (!resolvedCreatorProfileId) {
+          // The authenticated profile was removed or merged away after connection.
+          // Do not let a stale socket attribute durable verification evidence.
+          respond(
+            false,
+            undefined,
+            errorShape(
+              ErrorCodes.UNAVAILABLE,
+              "authenticated Gateway profile is no longer available",
+            ),
+          );
+          return;
+        }
+        // The schema is additive and can safely exist before approval. The
+        // principal and binding themselves are created only after consuming it.
+        ensureMemoryIdentitySchema();
+        memoryLink = {
+          targetProfileId: parsed.linkMemoryProfileId,
+          creatorProfileId,
+        };
+      } catch (error) {
+        respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(error)));
+        return;
+      }
+    }
     try {
+      const bindingLink = memoryLink;
+      let memoryBinding: ChannelsPairingApproveResult["memoryBinding"] = "not-requested";
+      let memoryBindingId: string | undefined;
       const approved = await approveChannelPairingRequest({
         channel: account.plugin.id,
         accountId: account.accountId,
         requestId: parsed.requestId,
         pairingAdapter: account.plugin.pairing,
+        ...(bindingLink
+          ? {
+              onApproved: ({ database, approval }) => {
+                const principal =
+                  memoryIdentityLifecycle.ensureGatewayProfileMemoryPrincipalInTransaction({
+                    database,
+                    profileId: bindingLink.targetProfileId,
+                  });
+                if (!principal) {
+                  throw new Error("linked Gateway profile is no longer available");
+                }
+                const binding =
+                  memoryIdentityLifecycle.createMemoryIdentityBindingFromApprovedChannelPairing({
+                    database,
+                    approval,
+                    principalId: principal.principalId,
+                    creatorProfileId: bindingLink.creatorProfileId,
+                  });
+                memoryBinding = "created";
+                memoryBindingId = binding.bindingId;
+              },
+            }
+          : {}),
       });
       if (!approved) {
         respond(
@@ -333,6 +437,8 @@ export const channelPairingHandlers: GatewayRequestHandlers = {
           senderId: approved.id,
           notification,
           commandOwnerBootstrap,
+          memoryBinding,
+          ...(memoryBindingId ? { memoryBindingId } : {}),
         },
         undefined,
       );

--- a/src/gateway/server-methods/memory-identity.test.ts
+++ b/src/gateway/server-methods/memory-identity.test.ts
@@ -1,0 +1,128 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { validateMemoryIdentityBindingRevokeResult } from "../../../packages/gateway-protocol/src/index.js";
+import { memoryIdentityHandlers } from "./memory-identity.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveUserProfileId: vi.fn(),
+  revokeMemoryIdentityBinding: vi.fn(),
+}));
+
+vi.mock("../../state/memory-identity.js", () => ({
+  memoryIdentityLifecycle: {
+    revokeMemoryIdentityBinding: mocks.revokeMemoryIdentityBinding,
+  },
+}));
+vi.mock("../../state/user-profiles.js", () => ({
+  resolveUserProfileId: mocks.resolveUserProfileId,
+}));
+
+async function invoke(params: object, client?: object) {
+  const respond = vi.fn();
+  await expectDefined(
+    memoryIdentityHandlers["memory.identityBinding.revoke"],
+    "memory.identityBinding.revoke test invariant",
+  )({ params, client, respond } as never);
+  return respond;
+}
+
+function adminClient(profileId = "admin-profile") {
+  return {
+    connect: { scopes: ["operator.admin"] },
+    authenticatedUserProfile: {
+      profileId,
+      displayName: null,
+      hasAvatar: false,
+      updatedAt: 1,
+    },
+  };
+}
+
+describe("memory identity gateway methods", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveUserProfileId.mockReturnValue("admin-profile-current");
+    mocks.revokeMemoryIdentityBinding.mockReturnValue(true);
+  });
+
+  it("requires operator.admin before it can revoke a durable binding", async () => {
+    const respond = await invoke(
+      { bindingId: "binding-1" },
+      {
+        connect: { scopes: ["operator.write"] },
+        authenticatedUserProfile: adminClient().authenticatedUserProfile,
+      },
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "FORBIDDEN",
+        message: "memory.identityBinding.revoke requires gateway scope: operator.admin",
+      }),
+    );
+    expect(mocks.revokeMemoryIdentityBinding).not.toHaveBeenCalled();
+  });
+
+  it("requires a durable authenticated Gateway profile for revocation attribution", async () => {
+    const respond = await invoke(
+      { bindingId: "binding-1" },
+      { connect: { scopes: ["operator.admin"] } },
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "FORBIDDEN",
+        message: "memory.identityBinding.revoke requires an authenticated Gateway profile",
+      }),
+    );
+    expect(mocks.revokeMemoryIdentityBinding).not.toHaveBeenCalled();
+  });
+
+  it("records the canonical admin profile and normalized optional reason", async () => {
+    const respond = await invoke(
+      { bindingId: " binding-1 ", reason: "  operator requested revocation  " },
+      adminClient("merged-admin-profile"),
+    );
+
+    expect(mocks.resolveUserProfileId).toHaveBeenCalledWith("merged-admin-profile");
+    expect(mocks.revokeMemoryIdentityBinding).toHaveBeenCalledWith({
+      bindingId: "binding-1",
+      revokedBy: "admin-profile-current",
+      reason: "operator requested revocation",
+    });
+    expect(respond).toHaveBeenCalledWith(true, { bindingId: "binding-1", revoked: true });
+    expect(validateMemoryIdentityBindingRevokeResult(respond.mock.calls[0]?.[1])).toBe(true);
+  });
+
+  it("reports an idempotent no-op without overwriting prior revocation evidence", async () => {
+    mocks.revokeMemoryIdentityBinding.mockReturnValue(false);
+
+    const respond = await invoke({ bindingId: "binding-1", reason: "   " }, adminClient());
+
+    expect(mocks.revokeMemoryIdentityBinding).toHaveBeenCalledWith({
+      bindingId: "binding-1",
+      revokedBy: "admin-profile-current",
+    });
+    expect(respond).toHaveBeenCalledWith(true, { bindingId: "binding-1", revoked: false });
+  });
+
+  it("fails closed when the connect-time profile no longer resolves", async () => {
+    mocks.resolveUserProfileId.mockReturnValue(undefined);
+
+    const respond = await invoke({ bindingId: "binding-1" }, adminClient());
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "UNAVAILABLE",
+        message: "authenticated Gateway profile is unavailable",
+      }),
+    );
+    expect(mocks.revokeMemoryIdentityBinding).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-methods/memory-identity.ts
+++ b/src/gateway/server-methods/memory-identity.ts
@@ -1,0 +1,102 @@
+// Gateway methods for durable memory-identity administration.
+import {
+  ErrorCodes,
+  errorShape,
+  validateMemoryIdentityBindingRevokeParams,
+} from "../../../packages/gateway-protocol/src/index.js";
+import { memoryIdentityLifecycle } from "../../state/memory-identity.js";
+import { resolveUserProfileId } from "../../state/user-profiles.js";
+import { ADMIN_SCOPE } from "../operator-scopes.js";
+import type { GatewayRequestHandlers } from "./types.js";
+import { assertValidParams } from "./validation.js";
+
+const { revokeMemoryIdentityBinding } = memoryIdentityLifecycle;
+
+/** Admin revocation is deliberately independent from channel ingress allowlists. */
+export const memoryIdentityHandlers: GatewayRequestHandlers = {
+  "memory.identityBinding.revoke": ({ client, params, respond }) => {
+    if (
+      !assertValidParams(
+        params,
+        validateMemoryIdentityBindingRevokeParams,
+        "memory.identityBinding.revoke",
+        respond,
+      )
+    ) {
+      return;
+    }
+    if (!client?.connect.scopes?.includes(ADMIN_SCOPE)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.FORBIDDEN,
+          `memory.identityBinding.revoke requires gateway scope: ${ADMIN_SCOPE}`,
+        ),
+      );
+      return;
+    }
+    const authenticatedProfileId = client.authenticatedUserProfile?.profileId;
+    if (!authenticatedProfileId) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.FORBIDDEN,
+          "memory.identityBinding.revoke requires an authenticated Gateway profile",
+        ),
+      );
+      return;
+    }
+
+    const bindingId = params.bindingId.trim();
+    if (!bindingId) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "bindingId must not be empty"),
+      );
+      return;
+    }
+
+    let revokedBy: string | undefined;
+    try {
+      revokedBy = resolveUserProfileId(authenticatedProfileId);
+    } catch {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.UNAVAILABLE, "authenticated Gateway profile is unavailable"),
+      );
+      return;
+    }
+    if (!revokedBy) {
+      // The connection's profile can be merged or removed after authentication.
+      // Never attribute a durable revocation to an identity that no longer resolves.
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.UNAVAILABLE, "authenticated Gateway profile is unavailable"),
+      );
+      return;
+    }
+
+    try {
+      const revoked = revokeMemoryIdentityBinding({
+        bindingId,
+        revokedBy,
+        ...(params.reason?.trim() ? { reason: params.reason.trim() } : {}),
+      });
+      respond(true, { bindingId, revoked });
+    } catch {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.UNAVAILABLE,
+          "memory identity binding revocation is temporarily unavailable",
+        ),
+      );
+    }
+  },
+};

--- a/src/pairing/memory-identity-approval.test-support.ts
+++ b/src/pairing/memory-identity-approval.test-support.ts
@@ -1,0 +1,58 @@
+// Test-only helpers that exercise the same consumed-pairing proof as production.
+import type { MemoryIdentityBinding } from "../state/memory-identity.js";
+import { memoryIdentityLifecycle } from "../state/memory-identity.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
+import { ensureProfileForEmail } from "../state/user-profiles.js";
+import {
+  approveChannelPairingRequest,
+  listChannelPairingRequests,
+  resolveChannelPairingRequestId,
+  upsertChannelPairingRequest,
+} from "./pairing-store.js";
+import type { PairingChannel } from "./pairing-store.types.js";
+
+/** Creates test bindings only by consuming a real pending channel-pairing request. */
+export async function createMemoryIdentityBindingThroughApprovedPairing(params: {
+  accountId: string;
+  channel: PairingChannel;
+  now?: number;
+  options: OpenClawStateDatabaseOptions;
+  principalId: string;
+  stableSenderId: string;
+}): Promise<MemoryIdentityBinding> {
+  const env = params.options.env ?? process.env;
+  const creator = ensureProfileForEmail("memory-pairing-test-owner@example.test", params.options);
+  await upsertChannelPairingRequest({
+    channel: params.channel,
+    accountId: params.accountId,
+    id: params.stableSenderId,
+    env,
+  });
+  const request = (await listChannelPairingRequests(params.channel, env, params.accountId)).find(
+    (candidate) => candidate.id === params.stableSenderId,
+  );
+  if (!request) {
+    throw new Error("test pairing request was not persisted");
+  }
+  let binding: MemoryIdentityBinding | undefined;
+  const approved = await approveChannelPairingRequest({
+    channel: params.channel,
+    accountId: params.accountId,
+    requestId: resolveChannelPairingRequestId(params.channel, request),
+    env,
+    pairingAdapter: { idLabel: "Test sender" },
+    onApproved: ({ database, approval }) => {
+      binding = memoryIdentityLifecycle.createMemoryIdentityBindingFromApprovedChannelPairing({
+        database,
+        approval,
+        principalId: params.principalId,
+        creatorProfileId: creator.id,
+        now: params.now,
+      });
+    },
+  });
+  if (!approved || !binding) {
+    throw new Error("test pairing approval did not create a memory identity binding");
+  }
+  return binding;
+}

--- a/src/pairing/memory-identity-approval.ts
+++ b/src/pairing/memory-identity-approval.ts
@@ -1,0 +1,94 @@
+// Opaque capability exchanged between the pairing owner and memory identity persistence.
+import type { OpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import type { PairingChannel } from "./pairing-store.types.js";
+
+const channelPairingMemoryIdentityApprovalBrand: unique symbol = Symbol(
+  "openclaw.channel-pairing-memory-identity-approval",
+);
+const approvals = new WeakMap<object, ChannelPairingMemoryIdentityApprovalRecord>();
+
+export type ConsumedChannelPairingMemoryIdentityApproval = Readonly<{
+  [channelPairingMemoryIdentityApprovalBrand]: true;
+}>;
+
+type ChannelPairingMemoryIdentityApprovalRecord = Readonly<{
+  database: OpenClawStateDatabase;
+  channel: PairingChannel;
+  accountId: string;
+  requestId: string;
+  stableSenderId: string;
+}>;
+
+export type ConsumedChannelPairingMemoryIdentityFacts = Omit<
+  ChannelPairingMemoryIdentityApprovalRecord,
+  "database"
+>;
+
+function requireText(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new TypeError(`${label} must not be empty`);
+  }
+  return normalized;
+}
+
+/**
+ * Pairing-store-only mint: the request has already been selected for removal
+ * in this exact transaction, so shaped caller data cannot recreate this proof.
+ */
+export function mintConsumedChannelPairingMemoryIdentityApproval(params: {
+  database: OpenClawStateDatabase;
+  channel: PairingChannel;
+  accountId: string;
+  requestId: string;
+  stableSenderId: string;
+}): ConsumedChannelPairingMemoryIdentityApproval {
+  const approval = Object.create(null) as Omit<
+    ConsumedChannelPairingMemoryIdentityApproval,
+    typeof channelPairingMemoryIdentityApprovalBrand
+  > & {
+    [channelPairingMemoryIdentityApprovalBrand]?: true;
+  };
+  Object.defineProperty(approval, channelPairingMemoryIdentityApprovalBrand, {
+    value: true,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  approvals.set(
+    approval,
+    Object.freeze({
+      database: params.database,
+      channel: requireText(params.channel, "channel") as PairingChannel,
+      accountId: requireText(params.accountId, "accountId"),
+      requestId: requireText(params.requestId, "requestId"),
+      stableSenderId: requireText(params.stableSenderId, "stableSenderId"),
+    }),
+  );
+  return Object.freeze(approval) as ConsumedChannelPairingMemoryIdentityApproval;
+}
+
+/** Consumes one proof only inside the transaction that removed its pending request. */
+export function consumeChannelPairingMemoryIdentityApproval(params: {
+  approval: unknown;
+  database: OpenClawStateDatabase;
+}): ConsumedChannelPairingMemoryIdentityFacts | undefined {
+  if (
+    !params.approval ||
+    typeof params.approval !== "object" ||
+    !params.database.db.isTransaction
+  ) {
+    return undefined;
+  }
+  const record = approvals.get(params.approval);
+  if (!record || record.database !== params.database) {
+    return undefined;
+  }
+  approvals.delete(params.approval);
+  return {
+    channel: record.channel,
+    accountId: record.accountId,
+    requestId: record.requestId,
+    stableSenderId: record.stableSenderId,
+  };
+}

--- a/src/pairing/pairing-store.test.ts
+++ b/src/pairing/pairing-store.test.ts
@@ -6,11 +6,13 @@ import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
+import { ensureMemoryIdentitySchema, memoryIdentityLifecycle } from "../state/memory-identity.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
+import { ensureProfileForEmail } from "../state/user-profiles.js";
 
 const pairingMocks = vi.hoisted(() => ({
   getPairingAdapter: vi.fn<
@@ -28,6 +30,7 @@ import {
 } from "./pairing-store-sqlite.test-helpers.js";
 import {
   addChannelAllowFromStoreEntry,
+  CHANNEL_PAIRING_PENDING_TTL_MS,
   approveChannelPairingCode,
   approveChannelPairingRequest,
   dismissChannelPairingRequest,
@@ -248,6 +251,42 @@ describe("pairing store", () => {
     ).resolves.toEqual({ code: "", created: false });
   });
 
+  it("does not invoke the binding owner for an expired pending request", async () => {
+    const { env } = createTestEnv();
+    await upsertChannelPairingRequest({
+      channel: "telegram",
+      accountId: "primary",
+      id: "expired-sender",
+      env,
+    });
+    const request = requireFirstPairingRequest(
+      await listChannelPairingRequests("telegram", env, "primary"),
+    );
+    const requestId = resolveChannelPairingRequestId("telegram", request);
+    const state = readChannelPairingStateSnapshot("telegram", env);
+    const expiredAt = new Date(Date.now() - CHANNEL_PAIRING_PENDING_TTL_MS - 1).toISOString();
+    state.requests = state.requests.map((entry) => ({
+      ...entry,
+      createdAt: expiredAt,
+      lastSeenAt: expiredAt,
+    }));
+    writeChannelPairingStateSnapshot("telegram", state, env);
+
+    const onApproved = vi.fn();
+    await expect(
+      approveChannelPairingRequest({
+        channel: "telegram",
+        accountId: "primary",
+        requestId,
+        env,
+        onApproved,
+      }),
+    ).resolves.toBeNull();
+
+    expect(onApproved).not.toHaveBeenCalled();
+    await expect(listChannelPairingRequests("telegram", env, "primary")).resolves.toEqual([]);
+  });
+
   it("persists a channel-derived approval entry from request metadata", async () => {
     const { env } = createTestEnv();
     const request = await upsertChannelPairingRequest({
@@ -330,6 +369,112 @@ describe("pairing store", () => {
     ).resolves.toMatchObject({ id: "shared-sender" });
     await expect(readChannelAllowFromStore("telegram", env, "beta")).resolves.toEqual([]);
     await expect(listChannelPairingRequests("telegram", env)).resolves.toEqual([]);
+  });
+
+  it("rolls back the consumed request, principal, and binding when an approval callback fails", async () => {
+    const { env } = createTestEnv();
+    const options = { env };
+    const target = ensureProfileForEmail("target@example.test", options);
+    const creator = ensureProfileForEmail("creator@example.test", options);
+    ensureMemoryIdentitySchema(options);
+    await upsertChannelPairingRequest({
+      channel: "telegram",
+      accountId: "primary",
+      id: "sender-1",
+      env,
+    });
+    const request = requireFirstPairingRequest(
+      await listChannelPairingRequests("telegram", env, "primary"),
+    );
+    const requestId = resolveChannelPairingRequestId("telegram", request);
+    let principalId: string | undefined;
+    let bindingId: string | undefined;
+
+    await expect(
+      approveChannelPairingRequest({
+        channel: "telegram",
+        accountId: "primary",
+        requestId,
+        env,
+        onApproved: ({ database, approval }) => {
+          const principal =
+            memoryIdentityLifecycle.ensureGatewayProfileMemoryPrincipalInTransaction({
+              database,
+              profileId: target.id,
+              now: 100,
+            });
+          expect(principal).toBeDefined();
+          if (!principal) {
+            throw new Error("test invariant: profile principal must exist");
+          }
+          principalId = principal.principalId;
+          const binding =
+            memoryIdentityLifecycle.createMemoryIdentityBindingFromApprovedChannelPairing({
+              database,
+              approval,
+              principalId: principal.principalId,
+              creatorProfileId: creator.id,
+              now: 100,
+            });
+          bindingId = binding.bindingId;
+          throw new Error("forced approval callback failure");
+        },
+      }),
+    ).rejects.toThrow("forced approval callback failure");
+
+    expect(principalId).toBeDefined();
+    expect(bindingId).toBeDefined();
+    expect(memoryIdentityLifecycle.resolveMemoryPrincipal(principalId!, options)).toEqual({
+      kind: "missing",
+    });
+    expect(
+      memoryIdentityLifecycle.resolveMemoryIdentityBinding({
+        channel: "telegram",
+        accountId: "primary",
+        stableSenderId: "sender-1",
+        options,
+      }),
+    ).toEqual({ kind: "unbound" });
+    await expect(readChannelAllowFromStore("telegram", env, "primary")).resolves.toEqual([]);
+    await expect(listChannelPairingRequests("telegram", env, "primary")).resolves.toEqual([
+      request,
+    ]);
+
+    const retried = await approveChannelPairingRequest({
+      channel: "telegram",
+      accountId: "primary",
+      requestId,
+      env,
+      onApproved: ({ database, approval }) => {
+        const principal = memoryIdentityLifecycle.ensureGatewayProfileMemoryPrincipalInTransaction({
+          database,
+          profileId: target.id,
+          now: 101,
+        });
+        if (!principal) {
+          throw new Error("test invariant: profile principal must exist");
+        }
+        memoryIdentityLifecycle.createMemoryIdentityBindingFromApprovedChannelPairing({
+          database,
+          approval,
+          principalId: principal.principalId,
+          creatorProfileId: creator.id,
+          now: 101,
+        });
+      },
+    });
+    expect(retried).toMatchObject({ id: "sender-1" });
+
+    // A new database handle must derive the same lookup key from persisted state.
+    closeOpenClawStateDatabaseForTest();
+    expect(
+      memoryIdentityLifecycle.resolveMemoryIdentityBinding({
+        channel: "telegram",
+        accountId: "primary",
+        stableSenderId: "sender-1",
+        options,
+      }),
+    ).toMatchObject({ kind: "verified" });
   });
 
   it("regenerates colliding codes and reports exhaustion without leaking codes", async () => {

--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -6,10 +6,18 @@ import {
   normalizeOptionalString,
   normalizeStringifiedOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { clearAuditIdentityKeyCacheForDatabase } from "../audit/audit-identity.js";
 import { getPairingAdapter } from "../channels/plugins/pairing.js";
 import type { ChannelPairingAdapter } from "../channels/plugins/pairing.types.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
-import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
+import {
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import {
+  mintConsumedChannelPairingMemoryIdentityApproval,
+  type ConsumedChannelPairingMemoryIdentityApproval,
+} from "./memory-identity-approval.js";
 import { resolveAllowFromAccountId } from "./pairing-store-keys.js";
 import {
   readChannelPairingState,
@@ -354,60 +362,97 @@ type ResolvePairingRequestParams = {
   pairingAdapter?: ChannelPairingAdapter;
   matches: (request: PairingRequest) => boolean;
   approve: boolean;
+  /**
+   * Commits owner-bound side effects with the consumed request and allowlist
+   * update. Throwing rolls every approval side effect back so an operator can retry.
+   */
+  onApproved?: (params: {
+    database: OpenClawStateDatabase;
+    approval: ConsumedChannelPairingMemoryIdentityApproval;
+  }) => void;
 };
 
 async function resolveChannelPairingRequest(
   params: ResolvePairingRequestParams,
 ): Promise<{ id: string; entry: PairingRequest } | null> {
   const env = params.env ?? process.env;
-  return runOpenClawStateWriteTransaction((database) => {
-    const state = readChannelPairingStateFromDatabase(database, params.channel);
-    const pruned = pruneExpiredRequests(state.requests, Date.now());
-    const accountId = normalizePairingAccountId(params.accountId);
-    const index = pruned.requests.findIndex(
-      (request) => requestMatchesAccountId(request, accountId) && params.matches(request),
-    );
-    if (index < 0) {
-      if (pruned.removed) {
-        state.requests = pruned.requests;
-        writeChannelPairingStateToDatabase(database, params.channel, state);
-      }
-      return null;
-    }
-    const entry = pruned.requests[index];
-    if (!entry) {
-      return null;
-    }
-    pruned.requests.splice(index, 1);
-    state.requests = pruned.requests;
-
-    if (params.approve) {
-      const allowAccountId = resolveAllowFromAccountId(
-        normalizeOptionalString(params.accountId) ?? normalizeOptionalString(entry.meta?.accountId),
+  let transactionDatabase: OpenClawStateDatabase | undefined;
+  try {
+    return runOpenClawStateWriteTransaction((database) => {
+      transactionDatabase = database;
+      const state = readChannelPairingStateFromDatabase(database, params.channel);
+      const pruned = pruneExpiredRequests(state.requests, Date.now());
+      const accountId = normalizePairingAccountId(params.accountId);
+      const index = pruned.requests.findIndex(
+        (request) => requestMatchesAccountId(request, accountId) && params.matches(request),
       );
-      const currentAllow = state.allowFrom?.[allowAccountId] ?? [];
-      const adapter = resolvePairingAdapter(params.channel, params.pairingAdapter);
-      // Channels with key-bound handoffs can persist an opaque approval token
-      // derived from request metadata instead of a durable sender allowlist id.
-      const approvalEntry = adapter?.resolveApprovalStoreEntry
-        ? adapter.resolveApprovalStoreEntry({
-            id: entry.id,
-            ...(entry.meta ? { meta: entry.meta } : {}),
-          })
-        : entry.id;
-      const normalizedAllow =
-        approvalEntry == null
-          ? ""
-          : normalizeAllowFromInput(params.channel, approvalEntry, adapter);
-      if (normalizedAllow && !currentAllow.includes(normalizedAllow)) {
-        state.allowFrom ??= {};
-        state.allowFrom[allowAccountId] = [...currentAllow, normalizedAllow];
+      if (index < 0) {
+        if (pruned.removed) {
+          state.requests = pruned.requests;
+          writeChannelPairingStateToDatabase(database, params.channel, state);
+        }
+        return null;
       }
-    }
+      const entry = pruned.requests[index];
+      if (!entry) {
+        return null;
+      }
+      pruned.requests.splice(index, 1);
+      state.requests = pruned.requests;
 
-    writeChannelPairingStateToDatabase(database, params.channel, state);
-    return { id: entry.id, entry };
-  }, sqliteOptionsForEnv(env));
+      if (params.approve) {
+        const allowAccountId = resolveAllowFromAccountId(
+          normalizeOptionalString(params.accountId) ??
+            normalizeOptionalString(entry.meta?.accountId),
+        );
+        const currentAllow = state.allowFrom?.[allowAccountId] ?? [];
+        const adapter = resolvePairingAdapter(params.channel, params.pairingAdapter);
+        // Channels with key-bound handoffs can persist an opaque approval token
+        // derived from request metadata instead of a durable sender allowlist id.
+        const approvalEntry = adapter?.resolveApprovalStoreEntry
+          ? adapter.resolveApprovalStoreEntry({
+              id: entry.id,
+              ...(entry.meta ? { meta: entry.meta } : {}),
+            })
+          : entry.id;
+        const normalizedAllow =
+          approvalEntry == null
+            ? ""
+            : normalizeAllowFromInput(params.channel, approvalEntry, adapter);
+        if (normalizedAllow && !currentAllow.includes(normalizedAllow)) {
+          state.allowFrom ??= {};
+          state.allowFrom[allowAccountId] = [...currentAllow, normalizedAllow];
+        }
+        // Persist the consumed request before minting the one-shot proof. A
+        // binding write therefore cannot observe or reuse pending evidence.
+        writeChannelPairingStateToDatabase(database, params.channel, state);
+        if (params.onApproved) {
+          params.onApproved({
+            database,
+            approval: mintConsumedChannelPairingMemoryIdentityApproval({
+              database,
+              channel: params.channel,
+              accountId: resolvePairingRequestAccountId(entry),
+              // Recompute from the consumed row, never from a caller-supplied id.
+              requestId: resolveChannelPairingRequestId(params.channel, entry),
+              stableSenderId: entry.id,
+            }),
+          });
+        }
+        return { id: entry.id, entry };
+      }
+
+      writeChannelPairingStateToDatabase(database, params.channel, state);
+      return { id: entry.id, entry };
+    }, sqliteOptionsForEnv(env));
+  } catch (error) {
+    // An approval hook may create the audit HMAC inside this transaction. Do not
+    // retain that key if a later pairing write or commit rolls the transaction back.
+    if (transactionDatabase) {
+      clearAuditIdentityKeyCacheForDatabase(transactionDatabase.db);
+    }
+    throw error;
+  }
 }
 
 export async function approveChannelPairingCode(params: {
@@ -435,6 +480,7 @@ export async function approveChannelPairingRequest(params: {
   accountId: string;
   env?: NodeJS.ProcessEnv;
   pairingAdapter?: ChannelPairingAdapter;
+  onApproved?: ResolvePairingRequestParams["onApproved"];
 }): Promise<{ id: string; entry: PairingRequest } | null> {
   const requestId = normalizeOptionalString(params.requestId);
   if (!requestId) {

--- a/src/state/memory-identity-schema.ts
+++ b/src/state/memory-identity-schema.ts
@@ -1,0 +1,16 @@
+import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
+
+const MEMORY_IDENTITY_SCHEMA_START = "CREATE TABLE IF NOT EXISTS memory_principals (";
+const MEMORY_IDENTITY_SCHEMA_END = "CREATE TABLE IF NOT EXISTS session_state_events (";
+
+function extractMemoryIdentitySchema(): string {
+  const start = OPENCLAW_STATE_SCHEMA_SQL.indexOf(MEMORY_IDENTITY_SCHEMA_START);
+  const end = OPENCLAW_STATE_SCHEMA_SQL.indexOf(MEMORY_IDENTITY_SCHEMA_END, start);
+  if (start < 0 || end <= start) {
+    throw new Error("canonical memory identity schema markers are missing");
+  }
+  return OPENCLAW_STATE_SCHEMA_SQL.slice(start, end).trim();
+}
+
+/** Canonical lazy schema for shared multiplayer-memory identity metadata. */
+export const MEMORY_IDENTITY_SCHEMA_SQL = extractMemoryIdentitySchema();

--- a/src/state/memory-identity.test.ts
+++ b/src/state/memory-identity.test.ts
@@ -1,0 +1,367 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createMemoryIdentityBindingThroughApprovedPairing } from "../pairing/memory-identity-approval.test-support.js";
+import { memoryIdentityLifecycle } from "./memory-identity.js";
+import { tableExists } from "./openclaw-state-db-schema-helpers.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "./openclaw-state-db.js";
+import { ensureProfileForEmail } from "./user-profiles.js";
+
+const {
+  ensureEnterpriseMemoryPrincipal,
+  ensureExplicitMemoryPrincipal,
+  ensureGatewayProfileMemoryPrincipal,
+  mergeMemoryPrincipals,
+  resolveCurrentMemoryIdentityBinding,
+  resolveMemoryIdentityBinding,
+  resolveMemoryPrincipal,
+  revokeMemoryIdentityBinding,
+  revokeMemoryPrincipal,
+} = memoryIdentityLifecycle;
+
+const tempDirectories = useAutoCleanupTempDirTracker(afterEach);
+
+function createStateOptions() {
+  const directory = tempDirectories.make("openclaw-memory-identity-");
+  return { env: { ...process.env, OPENCLAW_STATE_DIR: directory } };
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("memory identity", () => {
+  it("maps one durable Gateway profile to an idempotent canonical principal", () => {
+    const options = createStateOptions();
+    const profile = ensureProfileForEmail("owner@example.test", options);
+
+    const first = ensureGatewayProfileMemoryPrincipal(profile.id, options);
+    const second = ensureGatewayProfileMemoryPrincipal(profile.id, options);
+
+    expect(first).toMatchObject({
+      kind: "gateway-profile",
+      state: "active",
+      userProfileId: profile.id,
+    });
+    expect(second).toEqual(first);
+  });
+
+  it("stores only a keyed sender lookup token and resolves verified evidence", async () => {
+    const options = createStateOptions();
+    const principal = ensureEnterpriseMemoryPrincipal({
+      issuer: "example-idp",
+      stableSubjectId: "verified-owner",
+      now: 100,
+      options,
+    });
+    const stableSenderId = "provider-user-raw-123";
+    const binding = await createMemoryIdentityBindingThroughApprovedPairing({
+      channel: "telegram",
+      accountId: "default",
+      stableSenderId,
+      principalId: principal.principalId,
+      now: 100,
+      options,
+    });
+
+    expect(
+      resolveMemoryIdentityBinding({
+        channel: "telegram",
+        accountId: "default",
+        stableSenderId,
+        now: 101,
+        options,
+      }),
+    ).toEqual({
+      kind: "verified",
+      bindingId: binding.bindingId,
+      principalId: principal.principalId,
+      assurance: "adapter-attested",
+      evidenceRevision: binding.evidenceRevision,
+    });
+    const row = openOpenClawStateDatabase(options)
+      .db.prepare(
+        "SELECT channel, account_id, sender_lookup_hmac FROM memory_identity_bindings WHERE binding_id = ?",
+      )
+      .get(binding.bindingId) as
+      | { channel: string; account_id: string; sender_lookup_hmac: string }
+      | undefined;
+    expect(row).toMatchObject({ channel: "telegram", account_id: "default" });
+    expect(row?.sender_lookup_hmac).not.toBe(stableSenderId);
+    expect(JSON.stringify(row)).not.toContain(stableSenderId);
+  });
+
+  it("fails closed for unbound, conflicting, expired, and revoked evidence", async () => {
+    const options = createStateOptions();
+    const first = ensureEnterpriseMemoryPrincipal({
+      issuer: "example-idp",
+      stableSubjectId: "first-owner",
+      now: 100,
+      options,
+    });
+    const second = ensureEnterpriseMemoryPrincipal({
+      issuer: "example-idp",
+      stableSubjectId: "second-owner",
+      now: 100,
+      options,
+    });
+    const base = {
+      channel: "signal",
+      accountId: "primary",
+      stableSenderId: "sender-1",
+      options,
+    };
+
+    expect(resolveMemoryIdentityBinding({ ...base, now: 101 })).toEqual({ kind: "unbound" });
+
+    const firstBinding = await createMemoryIdentityBindingThroughApprovedPairing({
+      ...base,
+      principalId: first.principalId,
+      now: 100,
+    });
+    await createMemoryIdentityBindingThroughApprovedPairing({
+      ...base,
+      principalId: second.principalId,
+      now: 100,
+    });
+    expect(resolveMemoryIdentityBinding({ ...base, now: 101 })).toEqual({
+      kind: "conflicting-bindings",
+    });
+
+    expect(
+      revokeMemoryIdentityBinding({
+        bindingId: firstBinding.bindingId,
+        revokedBy: "operator-2",
+        now: 102,
+        options,
+      }),
+    ).toBe(true);
+    expect(revokeMemoryPrincipal({ principalId: second.principalId, now: 102, options })).toBe(
+      true,
+    );
+    expect(resolveMemoryIdentityBinding({ ...base, now: 103 })).toEqual({ kind: "unbound" });
+
+    const expired = ensureEnterpriseMemoryPrincipal({
+      issuer: "example-idp",
+      stableSubjectId: "expired-owner",
+      expiresAt: 201,
+      now: 200,
+      options,
+    });
+    expect(resolveMemoryPrincipal(expired.principalId, options, 201)).toEqual({ kind: "expired" });
+  });
+
+  it("treats expired channel bindings as unbound for sender and captured-binding lookups", async () => {
+    const options = createStateOptions();
+    const principal = ensureEnterpriseMemoryPrincipal({
+      issuer: "example-idp",
+      stableSubjectId: "expiry-owner",
+      now: 100,
+      options,
+    });
+    const binding = await createMemoryIdentityBindingThroughApprovedPairing({
+      channel: "telegram",
+      accountId: "default",
+      stableSenderId: "sender-1",
+      principalId: principal.principalId,
+      now: 100,
+      options,
+    });
+    const lookup = {
+      channel: "telegram",
+      accountId: "default",
+      stableSenderId: "sender-1",
+      options,
+    };
+
+    const captured = resolveMemoryIdentityBinding({ ...lookup, now: 101 });
+    expect(captured).toMatchObject({
+      kind: "verified",
+      bindingId: binding.bindingId,
+      principalId: principal.principalId,
+    });
+    if (captured.kind !== "verified") {
+      throw new Error("test setup must resolve a verified binding");
+    }
+
+    openOpenClawStateDatabase(options)
+      .db.prepare("UPDATE memory_identity_bindings SET expires_at = ? WHERE binding_id = ?")
+      .run(102, binding.bindingId);
+
+    expect(resolveMemoryIdentityBinding({ ...lookup, now: 102 })).toEqual({ kind: "unbound" });
+    expect(
+      resolveCurrentMemoryIdentityBinding({
+        bindingId: captured.bindingId,
+        principalId: captured.principalId,
+        evidenceRevision: captured.evidenceRevision,
+        now: 102,
+        options,
+      }),
+    ).toEqual({ kind: "unbound" });
+  });
+
+  it("rechecks a captured binding against current merge and revocation state", async () => {
+    const options = createStateOptions();
+    const source = ensureEnterpriseMemoryPrincipal({
+      issuer: "example-idp",
+      stableSubjectId: "source-owner",
+      now: 100,
+      options,
+    });
+    const target = ensureEnterpriseMemoryPrincipal({
+      issuer: "example-idp",
+      stableSubjectId: "target-owner",
+      now: 100,
+      options,
+    });
+    const binding = await createMemoryIdentityBindingThroughApprovedPairing({
+      channel: "discord",
+      accountId: "primary",
+      stableSenderId: "sender-1",
+      principalId: source.principalId,
+      now: 100,
+      options,
+    });
+
+    mergeMemoryPrincipals({
+      sourcePrincipalId: source.principalId,
+      targetPrincipalId: target.principalId,
+      now: 101,
+      options,
+    });
+    expect(
+      resolveCurrentMemoryIdentityBinding({
+        bindingId: binding.bindingId,
+        principalId: source.principalId,
+        evidenceRevision: binding.evidenceRevision,
+        now: 102,
+        options,
+      }),
+    ).toMatchObject({ kind: "verified", principalId: target.principalId });
+
+    revokeMemoryIdentityBinding({
+      bindingId: binding.bindingId,
+      revokedBy: "operator-2",
+      now: 103,
+      options,
+    });
+    expect(
+      resolveCurrentMemoryIdentityBinding({
+        bindingId: binding.bindingId,
+        principalId: source.principalId,
+        evidenceRevision: binding.evidenceRevision,
+        now: 104,
+        options,
+      }),
+    ).toEqual({ kind: "unbound" });
+  });
+
+  it("does not allow service or agent principals to be bound as human identity", async () => {
+    const options = createStateOptions();
+    const service = ensureExplicitMemoryPrincipal({
+      kind: "service",
+      stableSubjectId: "cron",
+      now: 100,
+      options,
+    });
+
+    await expect(
+      createMemoryIdentityBindingThroughApprovedPairing({
+        channel: "telegram",
+        accountId: "default",
+        stableSenderId: "sender-1",
+        principalId: service.principalId,
+        now: 101,
+        options,
+      }),
+    ).rejects.toThrow("verified user");
+  });
+
+  it("keeps identity tables absent until the first identity operation", () => {
+    const options = createStateOptions();
+    const database = openOpenClawStateDatabase(options).db;
+
+    expect(tableExists(database, "memory_principals")).toBe(false);
+    expect(tableExists(database, "memory_identity_bindings")).toBe(false);
+
+    ensureEnterpriseMemoryPrincipal({
+      issuer: "lazy-schema-test",
+      stableSubjectId: "first-owner",
+      now: 100,
+      options,
+    });
+
+    expect(tableExists(database, "memory_principals")).toBe(true);
+    expect(tableExists(database, "memory_identity_bindings")).toBe(true);
+  });
+
+  it("rejects caller-assembled pairing approval facts and exposes no raw mint", () => {
+    const options = createStateOptions();
+    const principal = ensureEnterpriseMemoryPrincipal({
+      issuer: "approval-abuse-test",
+      stableSubjectId: "owner",
+      now: 100,
+      options,
+    });
+
+    expect(() =>
+      runOpenClawStateWriteTransaction(
+        (database) =>
+          memoryIdentityLifecycle.createMemoryIdentityBindingFromApprovedChannelPairing({
+            database,
+            approval: {
+              accountId: "default",
+              channel: "telegram",
+              requestId: "caller-forged-request",
+              stableSenderId: "caller-forged-sender",
+            },
+            principalId: principal.principalId,
+            creatorProfileId: "caller-forged-creator",
+            now: 101,
+          }),
+        options,
+      ),
+    ).toThrow("requires a consumed channel pairing approval");
+    expect(
+      Object.keys(memoryIdentityLifecycle).filter((method) => method.startsWith("create")),
+    ).toEqual(["createMemoryIdentityBindingFromApprovedChannelPairing"]);
+    expect(
+      resolveMemoryIdentityBinding({
+        channel: "telegram",
+        accountId: "default",
+        stableSenderId: "caller-forged-sender",
+        now: 101,
+        options,
+      }),
+    ).toEqual({ kind: "unbound" });
+  });
+
+  it("does not merge verified users into autonomous principals", () => {
+    const options = createStateOptions();
+    const user = ensureEnterpriseMemoryPrincipal({
+      issuer: "example-idp",
+      stableSubjectId: "human-owner",
+      now: 100,
+      options,
+    });
+    const service = ensureExplicitMemoryPrincipal({
+      kind: "service",
+      stableSubjectId: "scheduled-task",
+      now: 100,
+      options,
+    });
+
+    expect(() =>
+      mergeMemoryPrincipals({
+        sourcePrincipalId: user.principalId,
+        targetPrincipalId: service.principalId,
+        now: 101,
+        options,
+      }),
+    ).toThrow("compatible principal kinds");
+  });
+});

--- a/src/state/memory-identity.ts
+++ b/src/state/memory-identity.ts
@@ -1,0 +1,889 @@
+import type { DatabaseSync } from "node:sqlite";
+import type { Selectable } from "kysely";
+import {
+  clearAuditIdentityKeyCacheForDatabase,
+  pseudonymizeExecutionIdentityRef,
+} from "../audit/audit-identity.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import { generateSecureUuid } from "../infra/secure-random.js";
+import { consumeChannelPairingMemoryIdentityApproval } from "../pairing/memory-identity-approval.js";
+import { MEMORY_IDENTITY_SCHEMA_SQL } from "./memory-identity-schema.js";
+import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabase,
+  type OpenClawStateDatabaseOptions,
+} from "./openclaw-state-db.js";
+import { resolveUserProfileId, resolveUserProfileIdInTransaction } from "./user-profiles.js";
+
+export type MemoryPrincipalKind =
+  | "gateway-profile"
+  | "enterprise"
+  | "service"
+  | "agent"
+  | "system"
+  | "conversation";
+
+export type MemoryPrincipal = Readonly<{
+  principalId: string;
+  kind: MemoryPrincipalKind;
+  userProfileId?: string;
+  issuer?: string;
+  state: "active" | "revoked" | "merged";
+  evidenceRevision: string;
+  mergedInto?: string;
+  expiresAt?: number;
+  revokedAt?: number;
+  createdAt: number;
+  updatedAt: number;
+}>;
+
+export type MemoryIdentityBindingAssurance = "adapter-attested" | "oidc";
+export type MemoryIdentityVerificationMethod = "pairing" | "oauth" | "admin-link";
+
+export type MemoryIdentityBinding = Readonly<{
+  bindingId: string;
+  channel: string;
+  accountId: string;
+  principalId: string;
+  adapterId: string;
+  assurance: MemoryIdentityBindingAssurance;
+  verificationMethod: MemoryIdentityVerificationMethod;
+  evidenceRevision: string;
+  createdBy: string;
+  createdAt: number;
+  expiresAt?: number;
+  revokedAt?: number;
+}>;
+
+export type MemoryIdentityBindingResolution =
+  | Readonly<{
+      kind: "verified";
+      bindingId: string;
+      principalId: string;
+      assurance: MemoryIdentityBindingAssurance;
+      evidenceRevision: string;
+      expiresAt?: number;
+    }>
+  | Readonly<{ kind: "unbound" }>
+  | Readonly<{ kind: "conflicting-bindings" }>;
+
+export type MemoryPrincipalResolution =
+  | Readonly<{ kind: "current"; principal: MemoryPrincipal }>
+  | Readonly<{ kind: "missing" | "revoked" | "expired" | "merge-cycle" }>;
+
+type MemoryIdentityDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  "memory_identity_bindings" | "memory_principals"
+>;
+type MemoryPrincipalRow = Selectable<MemoryIdentityDatabase["memory_principals"]>;
+type MemoryIdentityBindingRow = Selectable<MemoryIdentityDatabase["memory_identity_bindings"]>;
+
+const ensuredDatabases = new WeakSet<DatabaseSync>();
+const MAX_PRINCIPAL_MERGE_DEPTH = 64;
+
+function memoryIdentityDb(db: DatabaseSync) {
+  return getNodeSqliteKysely<MemoryIdentityDatabase>(db);
+}
+
+function requireText(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new TypeError(`${label} must not be empty`);
+  }
+  return normalized;
+}
+
+function normalizeChannel(value: string): string {
+  return requireText(value, "channel").toLowerCase();
+}
+
+function requireVerificationMethod(value: string): MemoryIdentityVerificationMethod {
+  const normalized = requireText(value, "verificationMethod");
+  if (normalized === "pairing" || normalized === "oauth" || normalized === "admin-link") {
+    return normalized;
+  }
+  throw new TypeError("verificationMethod must be pairing, oauth, or admin-link");
+}
+
+function optionalNumber(value: number | null): number | undefined {
+  return value === null ? undefined : value;
+}
+
+function toMemoryPrincipal(row: MemoryPrincipalRow): MemoryPrincipal {
+  return {
+    principalId: row.principal_id,
+    kind: row.kind as MemoryPrincipalKind,
+    ...(row.user_profile_id ? { userProfileId: row.user_profile_id } : {}),
+    ...(row.issuer ? { issuer: row.issuer } : {}),
+    state: row.state as MemoryPrincipal["state"],
+    evidenceRevision: row.evidence_revision,
+    ...(row.merged_into ? { mergedInto: row.merged_into } : {}),
+    ...(row.expires_at === null ? {} : { expiresAt: row.expires_at }),
+    ...(row.revoked_at === null ? {} : { revokedAt: row.revoked_at }),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function toMemoryIdentityBinding(row: MemoryIdentityBindingRow): MemoryIdentityBinding {
+  return {
+    bindingId: row.binding_id,
+    channel: row.channel,
+    accountId: row.account_id,
+    principalId: row.principal_id,
+    adapterId: row.adapter_id,
+    assurance: row.assurance as MemoryIdentityBindingAssurance,
+    verificationMethod: requireVerificationMethod(row.verification_method),
+    evidenceRevision: row.evidence_revision,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+    ...(row.expires_at === null ? {} : { expiresAt: row.expires_at }),
+    ...(row.revoked_at === null ? {} : { revokedAt: row.revoked_at }),
+  };
+}
+
+function isVerifiedMemoryUserPrincipal(principal: MemoryPrincipal): boolean {
+  return principal.kind === "gateway-profile" || principal.kind === "enterprise";
+}
+
+function memoryPrincipalMergeClass(kind: MemoryPrincipalKind): string {
+  switch (kind) {
+    case "gateway-profile":
+    case "enterprise":
+      return "verified-user";
+    default:
+      return kind;
+  }
+}
+
+/** Creates the additive shared tables only on the first identity operation. */
+export function ensureMemoryIdentitySchema(options: OpenClawStateDatabaseOptions = {}): void {
+  const database = openOpenClawStateDatabase(options);
+  if (ensuredDatabases.has(database.db)) {
+    return;
+  }
+  runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      db.exec(MEMORY_IDENTITY_SCHEMA_SQL); // sqlite-allow-raw -- Canonical additive lazy schema.
+    },
+    options,
+    { operationLabel: "memory-identity.schema.ensure" },
+  );
+  // Only cache after commit; a rollback must retry the schema creation.
+  ensuredDatabases.add(database.db);
+}
+
+function readPrincipalRow(db: DatabaseSync, principalId: string): MemoryPrincipalRow | undefined {
+  return executeSqliteQueryTakeFirstSync(
+    db,
+    memoryIdentityDb(db)
+      .selectFrom("memory_principals")
+      .selectAll()
+      .where("principal_id", "=", principalId),
+  );
+}
+
+function resolvePrincipalInDatabase(
+  db: DatabaseSync,
+  principalId: string,
+  now: number,
+): MemoryPrincipalResolution {
+  let currentId = principalId;
+  const visited = new Set<string>();
+  for (let depth = 0; depth < MAX_PRINCIPAL_MERGE_DEPTH; depth += 1) {
+    if (visited.has(currentId)) {
+      return { kind: "merge-cycle" };
+    }
+    visited.add(currentId);
+    const row = readPrincipalRow(db, currentId);
+    if (!row) {
+      return { kind: "missing" };
+    }
+    if (row.state === "merged") {
+      if (!row.merged_into) {
+        return { kind: "missing" };
+      }
+      currentId = row.merged_into;
+      continue;
+    }
+    if (row.state === "revoked") {
+      return { kind: "revoked" };
+    }
+    if (row.expires_at !== null && row.expires_at <= now) {
+      return { kind: "expired" };
+    }
+    return { kind: "current", principal: toMemoryPrincipal(row) };
+  }
+  return { kind: "merge-cycle" };
+}
+
+function identityLookupHmac(params: { db: DatabaseSync; scope: string; value: string }): string {
+  // This domain is distinct from audit pseudonyms. The database stores only
+  // this keyed lookup token, never the provider's raw sender/subject value.
+  return pseudonymizeExecutionIdentityRef({
+    db: params.db,
+    kind: "principal",
+    scope: params.scope,
+    value: params.value,
+  });
+}
+
+function bindingLookupScope(channel: string, accountId: string): string {
+  return `memory-identity-binding:v1:${channel}\u0000${accountId}`;
+}
+
+function principalLookupScope(kind: MemoryPrincipalKind, issuer: string): string {
+  return `memory-principal:v1:${kind}\u0000${issuer}`;
+}
+
+function runMemoryIdentityTransaction<T>(
+  options: OpenClawStateDatabaseOptions,
+  operationLabel: string,
+  operation: (db: DatabaseSync) => T,
+): T {
+  ensureMemoryIdentitySchema(options);
+  let database: DatabaseSync | undefined;
+  try {
+    return runOpenClawStateWriteTransaction(
+      ({ db }) => {
+        database = db;
+        return operation(db);
+      },
+      options,
+      { operationLabel },
+    );
+  } catch (error) {
+    // The keyed HMAC helper may create its key in this transaction. Never keep
+    // a cache entry for a key whose outer transaction rolled back.
+    if (database) {
+      clearAuditIdentityKeyCacheForDatabase(database);
+    }
+    throw error;
+  }
+}
+
+function ensureOpaquePrincipal(params: {
+  kind: Exclude<MemoryPrincipalKind, "gateway-profile">;
+  issuer: string;
+  stableSubjectId: string;
+  expiresAt?: number;
+  now?: number;
+  options?: OpenClawStateDatabaseOptions;
+}): MemoryPrincipal {
+  const issuer = requireText(params.issuer, "issuer");
+  const stableSubjectId = requireText(params.stableSubjectId, "stableSubjectId");
+  const now = params.now ?? Date.now();
+  if (params.expiresAt !== undefined && params.expiresAt <= now) {
+    throw new TypeError("expiresAt must be in the future");
+  }
+  return runMemoryIdentityTransaction(params.options ?? {}, "memory-principal.ensure", (db) => {
+    const subjectKey = identityLookupHmac({
+      db,
+      scope: principalLookupScope(params.kind, issuer),
+      value: stableSubjectId,
+    });
+    const kysely = memoryIdentityDb(db);
+    let row = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("memory_principals")
+        .selectAll()
+        .where("kind", "=", params.kind)
+        .where("issuer", "=", issuer)
+        .where("subject_key", "=", subjectKey),
+    );
+    if (!row) {
+      const principalId = generateSecureUuid();
+      executeSqliteQuerySync(
+        db,
+        kysely
+          .insertInto("memory_principals")
+          .values({
+            principal_id: principalId,
+            kind: params.kind,
+            user_profile_id: null,
+            issuer,
+            subject_key: subjectKey,
+            state: "active",
+            evidence_revision: generateSecureUuid(),
+            merged_into: null,
+            expires_at: params.expiresAt ?? null,
+            revoked_at: null,
+            created_at: now,
+            updated_at: now,
+          })
+          .onConflict((conflict) => conflict.doNothing()),
+      );
+      row = executeSqliteQueryTakeFirstSync(
+        db,
+        kysely
+          .selectFrom("memory_principals")
+          .selectAll()
+          .where("kind", "=", params.kind)
+          .where("issuer", "=", issuer)
+          .where("subject_key", "=", subjectKey),
+      );
+    }
+    if (!row) {
+      throw new Error("memory principal could not be created");
+    }
+    const resolved = resolvePrincipalInDatabase(db, row.principal_id, now);
+    if (resolved.kind !== "current") {
+      throw new Error(`memory principal is not current: ${resolved.kind}`);
+    }
+    return resolved.principal;
+  });
+}
+
+function ensureGatewayProfileMemoryPrincipalInDatabase(params: {
+  db: DatabaseSync;
+  requestedProfileId: string;
+  resolvedProfileId: string;
+  now: number;
+}): MemoryPrincipal | undefined {
+  const kysely = memoryIdentityDb(params.db);
+  let head = executeSqliteQueryTakeFirstSync(
+    params.db,
+    kysely
+      .selectFrom("memory_principals")
+      .selectAll()
+      .where("user_profile_id", "=", params.resolvedProfileId),
+  );
+  if (!head) {
+    const principalId = generateSecureUuid();
+    executeSqliteQuerySync(
+      params.db,
+      kysely
+        .insertInto("memory_principals")
+        .values({
+          principal_id: principalId,
+          kind: "gateway-profile",
+          user_profile_id: params.resolvedProfileId,
+          issuer: null,
+          subject_key: null,
+          state: "active",
+          evidence_revision: generateSecureUuid(),
+          merged_into: null,
+          expires_at: null,
+          revoked_at: null,
+          created_at: params.now,
+          updated_at: params.now,
+        })
+        .onConflict((conflict) => conflict.doNothing()),
+    );
+    head = executeSqliteQueryTakeFirstSync(
+      params.db,
+      kysely
+        .selectFrom("memory_principals")
+        .selectAll()
+        .where("user_profile_id", "=", params.resolvedProfileId),
+    );
+  }
+  if (!head) {
+    throw new Error("Gateway profile memory principal could not be created");
+  }
+  if (params.requestedProfileId !== params.resolvedProfileId) {
+    const source = executeSqliteQueryTakeFirstSync(
+      params.db,
+      kysely
+        .selectFrom("memory_principals")
+        .selectAll()
+        .where("user_profile_id", "=", params.requestedProfileId),
+    );
+    if (source && source.principal_id !== head.principal_id && source.state !== "revoked") {
+      executeSqliteQuerySync(
+        params.db,
+        kysely
+          .updateTable("memory_principals")
+          .set({ state: "merged", merged_into: head.principal_id, updated_at: params.now })
+          .where("principal_id", "=", source.principal_id),
+      );
+    }
+  }
+  const resolved = resolvePrincipalInDatabase(params.db, head.principal_id, params.now);
+  return resolved.kind === "current" ? resolved.principal : undefined;
+}
+
+/** Resolves one authenticated durable Gateway profile into its canonical principal. */
+function ensureGatewayProfileMemoryPrincipal(
+  profileId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): MemoryPrincipal | undefined {
+  const requestedProfileId = requireText(profileId, "profileId");
+  const resolvedProfileId = resolveUserProfileId(requestedProfileId, options);
+  if (!resolvedProfileId) {
+    return undefined;
+  }
+  const now = Date.now();
+  return runMemoryIdentityTransaction(options, "memory-principal.gateway-profile.ensure", (db) =>
+    ensureGatewayProfileMemoryPrincipalInDatabase({
+      db,
+      requestedProfileId,
+      resolvedProfileId,
+      now,
+    }),
+  );
+}
+
+/**
+ * Ensures a profile principal inside the caller's approval transaction.
+ * The caller must ensure the additive identity schema before opening it.
+ */
+function ensureGatewayProfileMemoryPrincipalInTransaction(params: {
+  database: OpenClawStateDatabase;
+  profileId: string;
+  now?: number;
+}): MemoryPrincipal | undefined {
+  const requestedProfileId = requireText(params.profileId, "profileId");
+  const resolvedProfileId = resolveUserProfileIdInTransaction({
+    database: params.database,
+    profileId: requestedProfileId,
+  });
+  if (!resolvedProfileId) {
+    return undefined;
+  }
+  return ensureGatewayProfileMemoryPrincipalInDatabase({
+    db: params.database.db,
+    requestedProfileId,
+    resolvedProfileId,
+    now: params.now ?? Date.now(),
+  });
+}
+
+function ensureEnterpriseMemoryPrincipal(params: {
+  issuer: string;
+  stableSubjectId: string;
+  expiresAt?: number;
+  now?: number;
+  options?: OpenClawStateDatabaseOptions;
+}): MemoryPrincipal {
+  return ensureOpaquePrincipal({ ...params, kind: "enterprise" });
+}
+
+function ensureExplicitMemoryPrincipal(params: {
+  kind: "service" | "agent" | "system";
+  issuer?: string;
+  stableSubjectId: string;
+  expiresAt?: number;
+  now?: number;
+  options?: OpenClawStateDatabaseOptions;
+}): MemoryPrincipal {
+  return ensureOpaquePrincipal({
+    ...params,
+    issuer: params.issuer ?? "openclaw",
+  });
+}
+
+function ensureConversationMemoryPrincipal(params: {
+  channel: string;
+  accountId: string;
+  conversationId: string;
+  now?: number;
+  options?: OpenClawStateDatabaseOptions;
+}): MemoryPrincipal {
+  const channel = normalizeChannel(params.channel);
+  const accountId = requireText(params.accountId, "accountId");
+  return ensureOpaquePrincipal({
+    kind: "conversation",
+    issuer: channel,
+    stableSubjectId: JSON.stringify([
+      accountId,
+      requireText(params.conversationId, "conversationId"),
+    ]),
+    now: params.now,
+    options: params.options,
+  });
+}
+
+type MemoryIdentityBindingRecordParams = {
+  channel: string;
+  accountId: string;
+  stableSenderId: string;
+  principalId: string;
+  adapterId: string;
+  assurance: MemoryIdentityBindingAssurance;
+  verificationMethod: MemoryIdentityVerificationMethod;
+  evidenceRevision: string;
+  createdBy: string;
+  expiresAt?: number;
+  now?: number;
+};
+
+/** Records verified channel-to-principal evidence without retaining the raw sender identifier. */
+function createMemoryIdentityBindingInDatabase(
+  params: MemoryIdentityBindingRecordParams,
+  db: DatabaseSync,
+): MemoryIdentityBinding {
+  const channel = normalizeChannel(params.channel);
+  const accountId = requireText(params.accountId, "accountId");
+  const stableSenderId = requireText(params.stableSenderId, "stableSenderId");
+  const principalId = requireText(params.principalId, "principalId");
+  const adapterId = requireText(params.adapterId, "adapterId");
+  const verificationMethod = requireVerificationMethod(params.verificationMethod);
+  const evidenceRevision = requireText(params.evidenceRevision, "evidenceRevision");
+  const createdBy = requireText(params.createdBy, "createdBy");
+  const now = params.now ?? Date.now();
+  if (params.expiresAt !== undefined && params.expiresAt <= now) {
+    throw new TypeError("expiresAt must be in the future");
+  }
+  const principal = resolvePrincipalInDatabase(db, principalId, now);
+  if (principal.kind !== "current") {
+    throw new Error(`memory binding principal is not current: ${principal.kind}`);
+  }
+  if (principal.principal.kind !== "gateway-profile" && principal.principal.kind !== "enterprise") {
+    throw new Error(
+      `memory binding principal must be a verified user: ${principal.principal.kind}`,
+    );
+  }
+  const bindingId = generateSecureUuid();
+  const senderLookupHmac = identityLookupHmac({
+    db,
+    scope: bindingLookupScope(channel, accountId),
+    value: stableSenderId,
+  });
+  const dbQuery = memoryIdentityDb(db);
+  executeSqliteQuerySync(
+    db,
+    dbQuery.insertInto("memory_identity_bindings").values({
+      binding_id: bindingId,
+      channel,
+      account_id: accountId,
+      sender_lookup_hmac: senderLookupHmac,
+      principal_id: principal.principal.principalId,
+      adapter_id: adapterId,
+      assurance: params.assurance,
+      verification_method: verificationMethod,
+      evidence_revision: evidenceRevision,
+      created_by: createdBy,
+      created_at: now,
+      expires_at: params.expiresAt ?? null,
+      revoked_at: null,
+      revoked_by: null,
+      revocation_reason: null,
+    }),
+  );
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    dbQuery.selectFrom("memory_identity_bindings").selectAll().where("binding_id", "=", bindingId),
+  );
+  if (!row) {
+    throw new Error("memory identity binding could not be created");
+  }
+  return toMemoryIdentityBinding(row);
+}
+
+/**
+ * Writes an admin link only from a one-shot pairing proof minted while its
+ * request was consumed. OAuth gets its own verifier rather than widening this
+ * pairing-only owner boundary.
+ */
+function createMemoryIdentityBindingFromApprovedChannelPairing(params: {
+  database: OpenClawStateDatabase;
+  approval: unknown;
+  principalId: string;
+  creatorProfileId: string;
+  now?: number;
+}): MemoryIdentityBinding {
+  try {
+    const approval = consumeChannelPairingMemoryIdentityApproval({
+      approval: params.approval,
+      database: params.database,
+    });
+    if (!approval) {
+      throw new TypeError("memory identity binding requires a consumed channel pairing approval");
+    }
+    const createdBy = resolveUserProfileIdInTransaction({
+      database: params.database,
+      profileId: requireText(params.creatorProfileId, "creatorProfileId"),
+    });
+    if (!createdBy) {
+      throw new Error("memory identity binding creator is not current");
+    }
+    return createMemoryIdentityBindingInDatabase(
+      {
+        channel: approval.channel,
+        accountId: approval.accountId,
+        stableSenderId: approval.stableSenderId,
+        principalId: params.principalId,
+        adapterId: approval.channel,
+        assurance: "adapter-attested",
+        verificationMethod: "admin-link",
+        evidenceRevision: `pairing-request:${approval.requestId}`,
+        createdBy,
+        now: params.now,
+      },
+      params.database.db,
+    );
+  } catch (error) {
+    // The keyed HMAC helper may have created its key in the surrounding
+    // transaction. Let the retry reconstruct it after that transaction rolls back.
+    clearAuditIdentityKeyCacheForDatabase(params.database.db);
+    throw error;
+  }
+}
+
+/** Revokes a binding while retaining its verification history. */
+function revokeMemoryIdentityBinding(params: {
+  bindingId: string;
+  revokedBy: string;
+  reason?: string;
+  now?: number;
+  options?: OpenClawStateDatabaseOptions;
+}): boolean {
+  const bindingId = requireText(params.bindingId, "bindingId");
+  const revokedBy = requireText(params.revokedBy, "revokedBy");
+  const reason = params.reason?.trim() || null;
+  const now = params.now ?? Date.now();
+  return runMemoryIdentityTransaction(
+    params.options ?? {},
+    "memory-identity-binding.revoke",
+    (db) => {
+      const result = executeSqliteQuerySync(
+        db,
+        memoryIdentityDb(db)
+          .updateTable("memory_identity_bindings")
+          .set({ revoked_at: now, revoked_by: revokedBy, revocation_reason: reason })
+          .where("binding_id", "=", bindingId)
+          .where("revoked_at", "is", null),
+      );
+      return Number(result.numAffectedRows ?? 0n) > 0;
+    },
+  );
+}
+
+/** Resolves active evidence to exactly one current merge head; ambiguity fails closed. */
+function resolveMemoryIdentityBinding(params: {
+  channel: string;
+  accountId: string;
+  stableSenderId: string;
+  now?: number;
+  options?: OpenClawStateDatabaseOptions;
+}): MemoryIdentityBindingResolution {
+  const channel = normalizeChannel(params.channel);
+  const accountId = requireText(params.accountId, "accountId");
+  const stableSenderId = requireText(params.stableSenderId, "stableSenderId");
+  const options = params.options ?? {};
+  const now = params.now ?? Date.now();
+  ensureMemoryIdentitySchema(options);
+  const { db } = openOpenClawStateDatabase(options);
+  const senderLookupHmac = identityLookupHmac({
+    db,
+    scope: bindingLookupScope(channel, accountId),
+    value: stableSenderId,
+  });
+  const active = resolveCurrentMemoryIdentityBindingsByLookup({
+    db,
+    channel,
+    accountId,
+    senderLookupHmac,
+    now,
+  });
+  if (active.length === 0) {
+    return { kind: "unbound" };
+  }
+  // More than one active record is operationally ambiguous. A renewal must
+  // revoke the superseded evidence rather than leave issuance nondeterministic.
+  if (active.length !== 1) {
+    return { kind: "conflicting-bindings" };
+  }
+  const activeBinding = active[0];
+  if (!activeBinding) {
+    return { kind: "conflicting-bindings" };
+  }
+  const { row, principal } = activeBinding;
+  return {
+    kind: "verified",
+    bindingId: row.binding_id,
+    principalId: principal.principalId,
+    assurance: row.assurance as MemoryIdentityBindingAssurance,
+    evidenceRevision: row.evidence_revision,
+    ...(optionalNumber(row.expires_at) === undefined
+      ? {}
+      : { expiresAt: row.expires_at ?? undefined }),
+  };
+}
+
+function resolveCurrentMemoryIdentityBindingsByLookup(params: {
+  db: DatabaseSync;
+  channel: string;
+  accountId: string;
+  senderLookupHmac: string;
+  now: number;
+}): Array<{ row: MemoryIdentityBindingRow; principal: MemoryPrincipal }> {
+  const rows = executeSqliteQuerySync(
+    params.db,
+    memoryIdentityDb(params.db)
+      .selectFrom("memory_identity_bindings")
+      .selectAll()
+      .where("channel", "=", params.channel)
+      .where("account_id", "=", params.accountId)
+      .where("sender_lookup_hmac", "=", params.senderLookupHmac)
+      .orderBy("created_at", "asc")
+      .orderBy("binding_id", "asc"),
+  ).rows;
+  const active: Array<{ row: MemoryIdentityBindingRow; principal: MemoryPrincipal }> = [];
+  for (const row of rows) {
+    if (row.revoked_at !== null || (row.expires_at !== null && row.expires_at <= params.now)) {
+      continue;
+    }
+    const principal = resolvePrincipalInDatabase(params.db, row.principal_id, params.now);
+    if (principal.kind === "current" && isVerifiedMemoryUserPrincipal(principal.principal)) {
+      active.push({ row, principal: principal.principal });
+    }
+  }
+  return active;
+}
+
+/** Rechecks one captured binding and its current principal merge head. */
+function resolveCurrentMemoryIdentityBinding(params: {
+  bindingId: string;
+  principalId: string;
+  evidenceRevision: string;
+  now?: number;
+  options?: OpenClawStateDatabaseOptions;
+}): MemoryIdentityBindingResolution {
+  const options = params.options ?? {};
+  const now = params.now ?? Date.now();
+  ensureMemoryIdentitySchema(options);
+  const { db } = openOpenClawStateDatabase(options);
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    memoryIdentityDb(db)
+      .selectFrom("memory_identity_bindings")
+      .selectAll()
+      .where("binding_id", "=", requireText(params.bindingId, "bindingId")),
+  );
+  if (
+    !row ||
+    row.evidence_revision !== requireText(params.evidenceRevision, "evidenceRevision") ||
+    row.revoked_at !== null ||
+    (row.expires_at !== null && row.expires_at <= now)
+  ) {
+    return { kind: "unbound" };
+  }
+  const active = resolveCurrentMemoryIdentityBindingsByLookup({
+    db,
+    channel: row.channel,
+    accountId: row.account_id,
+    senderLookupHmac: row.sender_lookup_hmac,
+    now,
+  });
+  if (active.length !== 1 || active[0]?.row.binding_id !== row.binding_id) {
+    return { kind: "unbound" };
+  }
+  const bindingPrincipal = active[0].principal;
+  const capturedPrincipal = resolvePrincipalInDatabase(
+    db,
+    requireText(params.principalId, "principalId"),
+    now,
+  );
+  if (
+    capturedPrincipal.kind !== "current" ||
+    !isVerifiedMemoryUserPrincipal(capturedPrincipal.principal) ||
+    bindingPrincipal.principalId !== capturedPrincipal.principal.principalId
+  ) {
+    return { kind: "unbound" };
+  }
+  return {
+    kind: "verified",
+    bindingId: row.binding_id,
+    principalId: bindingPrincipal.principalId,
+    assurance: row.assurance as MemoryIdentityBindingAssurance,
+    evidenceRevision: row.evidence_revision,
+    ...(row.expires_at === null ? {} : { expiresAt: row.expires_at }),
+  };
+}
+
+function resolveMemoryPrincipal(
+  principalId: string,
+  options: OpenClawStateDatabaseOptions = {},
+  now = Date.now(),
+): MemoryPrincipalResolution {
+  ensureMemoryIdentitySchema(options);
+  return resolvePrincipalInDatabase(
+    openOpenClawStateDatabase(options).db,
+    requireText(principalId, "principalId"),
+    now,
+  );
+}
+
+/** Leaves a durable tombstone that redirects future authority checks to one head. */
+function mergeMemoryPrincipals(params: {
+  sourcePrincipalId: string;
+  targetPrincipalId: string;
+  now?: number;
+  options?: OpenClawStateDatabaseOptions;
+}): MemoryPrincipal {
+  const sourcePrincipalId = requireText(params.sourcePrincipalId, "sourcePrincipalId");
+  const targetPrincipalId = requireText(params.targetPrincipalId, "targetPrincipalId");
+  if (sourcePrincipalId === targetPrincipalId) {
+    throw new TypeError("memory principal cannot merge into itself");
+  }
+  const now = params.now ?? Date.now();
+  return runMemoryIdentityTransaction(params.options ?? {}, "memory-principal.merge", (db) => {
+    const source = resolvePrincipalInDatabase(db, sourcePrincipalId, now);
+    const target = resolvePrincipalInDatabase(db, targetPrincipalId, now);
+    if (source.kind !== "current" || target.kind !== "current") {
+      throw new Error("memory principal merge requires two current principals");
+    }
+    if (source.principal.principalId === target.principal.principalId) {
+      return target.principal;
+    }
+    if (
+      memoryPrincipalMergeClass(source.principal.kind) !==
+      memoryPrincipalMergeClass(target.principal.kind)
+    ) {
+      throw new Error("memory principal merge requires compatible principal kinds");
+    }
+    executeSqliteQuerySync(
+      db,
+      memoryIdentityDb(db)
+        .updateTable("memory_principals")
+        .set({ state: "merged", merged_into: target.principal.principalId, updated_at: now })
+        .where("principal_id", "=", source.principal.principalId),
+    );
+    return target.principal;
+  });
+}
+
+function revokeMemoryPrincipal(params: {
+  principalId: string;
+  now?: number;
+  options?: OpenClawStateDatabaseOptions;
+}): boolean {
+  const principalId = requireText(params.principalId, "principalId");
+  const now = params.now ?? Date.now();
+  return runMemoryIdentityTransaction(params.options ?? {}, "memory-principal.revoke", (db) => {
+    const result = executeSqliteQuerySync(
+      db,
+      memoryIdentityDb(db)
+        .updateTable("memory_principals")
+        .set({ state: "revoked", revoked_at: now, updated_at: now })
+        .where("principal_id", "=", principalId)
+        .where("state", "=", "active"),
+    );
+    return Number(result.numAffectedRows ?? 0n) > 0;
+  });
+}
+
+/** Core-owned lifecycle for canonical principals and verified transport bindings. */
+export const memoryIdentityLifecycle = Object.freeze({
+  createMemoryIdentityBindingFromApprovedChannelPairing,
+  ensureConversationMemoryPrincipal,
+  ensureEnterpriseMemoryPrincipal,
+  ensureExplicitMemoryPrincipal,
+  ensureGatewayProfileMemoryPrincipal,
+  ensureGatewayProfileMemoryPrincipalInTransaction,
+  mergeMemoryPrincipals,
+  resolveCurrentMemoryIdentityBinding,
+  resolveMemoryIdentityBinding,
+  resolveMemoryPrincipal,
+  revokeMemoryIdentityBinding,
+  revokeMemoryPrincipal,
+});

--- a/src/state/openclaw-state-db-contract.ts
+++ b/src/state/openclaw-state-db-contract.ts
@@ -7,8 +7,19 @@ export const OPENCLAW_STATE_SCHEMA_VERSION = 6;
 export const OPENCLAW_STATE_STRICT_SCHEMA_VERSION = 3;
 // Privacy-sensitive feature tables remain absent even in fresh databases until
 // their feature-local first write. The canonical SQL still owns their shape.
-export const FIRST_USE_STATE_TABLES = ["execution_identity_contexts"] as const;
-export const FIRST_USE_STATE_INDEXES = ["execution_identity_contexts_run_created_idx"] as const;
+export const FIRST_USE_STATE_TABLES = [
+  "execution_identity_contexts",
+  "memory_principals",
+  "memory_identity_bindings",
+] as const;
+export const FIRST_USE_STATE_INDEXES = [
+  "execution_identity_contexts_run_created_idx",
+  "idx_memory_principals_user_profile",
+  "idx_memory_principals_opaque_subject",
+  "idx_memory_principals_merge_head",
+  "idx_memory_identity_bindings_lookup",
+  "idx_memory_identity_bindings_principal",
+] as const;
 // Added after v6 shipped. These tables stay optional until their feature-local
 // lazy ensures run; fold them into the next natural schema-version bump.
 export const LAZY_ADDITIVE_STATE_TABLES = [

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -860,6 +860,39 @@ export interface MeetingTranscriptUtterances {
   utterance_id: string | null;
 }
 
+export interface MemoryIdentityBindings {
+  account_id: string;
+  adapter_id: string;
+  assurance: string;
+  binding_id: string;
+  channel: string;
+  created_at: number;
+  created_by: string;
+  evidence_revision: string;
+  expires_at: number | null;
+  principal_id: string;
+  revocation_reason: string | null;
+  revoked_at: number | null;
+  revoked_by: string | null;
+  sender_lookup_hmac: string;
+  verification_method: string;
+}
+
+export interface MemoryPrincipals {
+  created_at: number;
+  evidence_revision: string;
+  expires_at: number | null;
+  issuer: string | null;
+  kind: string;
+  merged_into: string | null;
+  principal_id: string;
+  revoked_at: number | null;
+  state: string;
+  subject_key: string | null;
+  updated_at: number;
+  user_profile_id: string | null;
+}
+
 export interface MigrationRuns {
   finished_at: number | null;
   id: string;
@@ -1640,6 +1673,8 @@ export interface DB {
   meeting_transcript_sessions: MeetingTranscriptSessions;
   meeting_transcript_summaries: MeetingTranscriptSummaries;
   meeting_transcript_utterances: MeetingTranscriptUtterances;
+  memory_identity_bindings: MemoryIdentityBindings;
+  memory_principals: MemoryPrincipals;
   migration_runs: MigrationRuns;
   migration_sources: MigrationSources;
   model_capability_cache: ModelCapabilityCache;

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1135,6 +1135,40 @@ describe("openclaw state database", () => {
     ).toThrow();
   });
 
+  it("opens a v6 database without materializing lazy memory identity schema", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+    const { DatabaseSync } = requireNodeSqlite();
+    const listMemoryIdentitySchemaObjects = (database: DatabaseSync) =>
+      database
+        .prepare(
+          `SELECT name
+             FROM sqlite_schema
+            WHERE name IN (
+              'memory_principals',
+              'memory_identity_bindings',
+              'idx_memory_principals_user_profile',
+              'idx_memory_principals_opaque_subject',
+              'idx_memory_principals_merge_head',
+              'idx_memory_identity_bindings_lookup',
+              'idx_memory_identity_bindings_principal'
+            )`,
+        )
+        .all();
+
+    const shipped = new DatabaseSync(databasePath);
+    try {
+      expect(readSqliteNumberPragma(shipped, "user_version")).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
+      expect(listMemoryIdentitySchemaObjects(shipped)).toEqual([]);
+    } finally {
+      shipped.close();
+    }
+
+    const reopened = openOpenClawStateDatabase(options);
+    expect(listMemoryIdentitySchemaObjects(reopened.db)).toEqual([]);
+  });
+
   it("keeps the additive worker SSH fallback table compatible with older v6 containment", () => {
     const database = openMaterializedCurrentStateDatabase();
     try {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -224,8 +224,10 @@ function canonicalStateSchemaForRuntime(options: {
     eagerSchema = `${eagerSchema.slice(0, start)}${eagerSchema.slice(end + endMarker.length)}`;
   }
   for (const indexName of omittedIndexes) {
-    const startMarker = `CREATE INDEX IF NOT EXISTS ${indexName}`;
-    const start = eagerSchema.indexOf(startMarker);
+    const start =
+      [`CREATE INDEX IF NOT EXISTS ${indexName}`, `CREATE UNIQUE INDEX IF NOT EXISTS ${indexName}`]
+        .map((marker) => eagerSchema.indexOf(marker))
+        .find((index) => index >= 0) ?? -1;
     const end = start >= 0 ? eagerSchema.indexOf(";", start) : -1;
     if (start < 0 || end < 0) {
       throw new Error(`lazy additive state schema index is missing for ${indexName}`);

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -211,6 +211,78 @@ CREATE TABLE IF NOT EXISTS execution_identity_contexts (
 CREATE INDEX IF NOT EXISTS execution_identity_contexts_run_created_idx
   ON execution_identity_contexts (run_id, created_at, execution_id);
 
+CREATE TABLE IF NOT EXISTS memory_principals (
+  principal_id TEXT NOT NULL PRIMARY KEY,
+  kind TEXT NOT NULL CHECK (
+    kind IN ('gateway-profile', 'enterprise', 'service', 'agent', 'system', 'conversation')
+  ),
+  user_profile_id TEXT,
+  issuer TEXT,
+  subject_key TEXT,
+  state TEXT NOT NULL CHECK (state IN ('active', 'revoked', 'merged')),
+  evidence_revision TEXT NOT NULL,
+  merged_into TEXT,
+  expires_at INTEGER,
+  revoked_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  CHECK (
+    (kind = 'gateway-profile' AND user_profile_id IS NOT NULL AND issuer IS NULL AND subject_key IS NULL)
+    OR
+    (kind != 'gateway-profile' AND user_profile_id IS NULL AND issuer IS NOT NULL AND subject_key IS NOT NULL)
+  ),
+  CHECK (
+    (state = 'active' AND merged_into IS NULL AND revoked_at IS NULL)
+    OR
+    (state = 'revoked' AND merged_into IS NULL AND revoked_at IS NOT NULL)
+    OR
+    (state = 'merged' AND merged_into IS NOT NULL AND revoked_at IS NULL)
+  ),
+  FOREIGN KEY (merged_into) REFERENCES memory_principals(principal_id)
+) STRICT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_principals_user_profile
+  ON memory_principals(user_profile_id)
+  WHERE user_profile_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_principals_opaque_subject
+  ON memory_principals(kind, issuer, subject_key)
+  WHERE subject_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_memory_principals_merge_head
+  ON memory_principals(merged_into)
+  WHERE merged_into IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS memory_identity_bindings (
+  binding_id TEXT NOT NULL PRIMARY KEY,
+  channel TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  sender_lookup_hmac TEXT NOT NULL,
+  principal_id TEXT NOT NULL,
+  adapter_id TEXT NOT NULL,
+  assurance TEXT NOT NULL CHECK (assurance IN ('adapter-attested', 'oidc')),
+  verification_method TEXT NOT NULL,
+  evidence_revision TEXT NOT NULL,
+  created_by TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER,
+  revoked_at INTEGER,
+  revoked_by TEXT,
+  revocation_reason TEXT,
+  CHECK (
+    (revoked_at IS NULL AND revoked_by IS NULL AND revocation_reason IS NULL)
+    OR
+    (revoked_at IS NOT NULL AND revoked_by IS NOT NULL)
+  ),
+  FOREIGN KEY (principal_id) REFERENCES memory_principals(principal_id)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_memory_identity_bindings_lookup
+  ON memory_identity_bindings(channel, account_id, sender_lookup_hmac, revoked_at, expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_memory_identity_bindings_principal
+  ON memory_identity_bindings(principal_id, revoked_at);
+
 CREATE TABLE IF NOT EXISTS session_state_events (
   sequence INTEGER PRIMARY KEY AUTOINCREMENT,
   dedupe_key TEXT UNIQUE,

--- a/src/state/user-profiles.ts
+++ b/src/state/user-profiles.ts
@@ -13,6 +13,7 @@ import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabase,
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db.js";
 import { USER_PROFILES_SCHEMA_SQL } from "./user-profiles-schema.js";
@@ -244,6 +245,17 @@ export function resolveUserProfileId(
   ensureUserProfilesSchema(options);
   const { db } = openOpenClawStateDatabase(options);
   return selectResolvedProfileById(db, profileId)?.id;
+}
+
+/** Resolves a durable profile reference through the caller's active state transaction. */
+export function resolveUserProfileIdInTransaction(params: {
+  database: OpenClawStateDatabase;
+  profileId: string;
+}): string | undefined {
+  if (!params.database.db.isTransaction) {
+    throw new Error("user profile resolution requires an active state transaction");
+  }
+  return selectResolvedProfileById(params.database.db, params.profileId)?.id;
 }
 
 /** Reads a profile's protocol-facing representation through its merge head. */


### PR DESCRIPTION
## What Problem This Solves

Identity-aware memory needs a durable, protocol-visible identity and binding record before a later phase can decide which memory audiences a session may access. Without that record, channel pairing and gateway callers cannot carry one auditable identity fact into later memory work.

## Why This Change Was Made

This Phase 1A draft adds memory-identity protocol schemas, gateway methods and method scopes, pairing approval and binding storage, plus shared-state schema and validation coverage. It establishes identity and binding data only; it does not by itself authorize memory reads or writes, create a role policy, or turn on enforcement.

## User Impact

This remains a draft with no released operator workflow. Its intended future benefit is a stable identity/binding foundation for later memory authorization phases, without changing today’s memory behavior.

## Stack / Status

This historical Phase 1A draft is based on the earlier P0B runtime branch (`0443dd4695a9af24222356cf4ac169912041948b`). It is not part of the current canonical #121421 → #121422 → #121423 stack. This metadata clarification does not close, rebase, or otherwise change the draft’s GitHub status.

## Evidence

- Exact head: `2358bda1c3c0a2c86bb679025292dc78c14aac09` (`feat(memory): add identity protocol and binding registry`).
- Current live GitHub rollup shows 10 successful and 73 skipped checks for this draft.
- The changed surface includes gateway-protocol memory-identity schemas, pairing identity approval/storage, gateway memory-identity methods, state schema, and their focused test files.

## Remaining Evidence Gaps

No named exact-head focused test command, Testbox/Crabbox artifact, composed stack proof, or live channel/provider result is recorded in this PR. The successful live check count alone is not treated as proof that later authorization policy or enforcement works.
