### PR TITLE
feat(memory): add session memory-subject lifecycle

### DIFF
--- a/src/agents/acp-spawn-runtime.ts
+++ b/src/agents/acp-spawn-runtime.ts
@@ -24,6 +24,8 @@ import {
   getSessionBindingService,
   type SessionBindingRecord,
 } from "../infra/outbound/session-binding-service.js";
+import { isIncognitoSessionKey } from "../routing/session-key.js";
+import { resolveIncognitoOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.js";
 import { persistAcpSpawnSessionFileBestEffort } from "./acp-spawn-requester.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 import {
@@ -151,7 +153,9 @@ export async function initializeAcpSpawnRuntime(params: {
   modelExplicit?: boolean;
   cwd?: string;
 }): Promise<AcpSpawnInitializedRuntime> {
-  const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.targetAgentId });
+  const storePath = isIncognitoSessionKey(params.sessionKey)
+    ? resolveIncognitoOpenClawAgentSqlitePath({ agentId: params.targetAgentId })
+    : resolveStorePath(params.cfg.session?.store, { agentId: params.targetAgentId });
   let sessionEntry = loadSessionEntry({
     storePath,
     sessionKey: params.sessionKey,

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -5,6 +5,12 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AcpInitializeSessionInput } from "../acp/control-plane/manager.types.js";
+import {
+  resolveSqliteScope,
+  toDatabaseOptions,
+} from "../config/sessions/session-accessor.sqlite-scope.js";
+import { readCurrentSessionMemorySubject } from "../config/sessions/session-memory-subject-access.js";
+import { prepareAutonomousAgentSessionMemorySubjectSeed } from "../config/sessions/session-memory-subject.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { CallGatewayOptions } from "../gateway/call.js";
@@ -17,6 +23,12 @@ import {
   type SessionBindingPlacement,
   type SessionBindingRecord,
 } from "../infra/outbound/session-binding-service.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+  resolveIncognitoOpenClawAgentSqlitePath,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.js";
 import type { AgentRunTerminalReplySnapshot } from "./agent-run-terminal-reply.js";
 import { reserveChildAdmissionSlot } from "./child-admission.js";
@@ -90,6 +102,7 @@ const hoisted = vi.hoisted(() => {
   const getSubagentRunByChildSessionKeyMock = vi.fn();
   const listTasksForOwnerKeyMock = vi.fn();
   const upsertSessionEntryMock = vi.fn();
+  const upsertSessionEntryWithTrustedMemorySubjectMock = vi.fn();
   const createSessionAccessorMock = () => {
     const resolveMockStorePath = (scope: {
       agentId?: string;
@@ -184,6 +197,7 @@ const hoisted = vi.hoisted(() => {
     getSubagentRunByChildSessionKeyMock,
     listTasksForOwnerKeyMock,
     upsertSessionEntryMock,
+    upsertSessionEntryWithTrustedMemorySubjectMock,
     createSessionAccessorMock,
     state,
   };
@@ -220,6 +234,12 @@ vi.mock("../config/sessions/paths.js", () => ({
 vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../config/sessions/session-accessor.js")>()),
   ...hoisted.createSessionAccessorMock(),
+}));
+
+vi.mock("../config/sessions/session-accessor.sqlite-entry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/sessions/session-accessor.sqlite-entry.js")>()),
+  upsertSqliteSessionEntryWithTrustedMemorySubject: async (...args: unknown[]) =>
+    await hoisted.upsertSessionEntryWithTrustedMemorySubjectMock(...args),
 }));
 
 vi.mock("../config/sessions.js", () => ({
@@ -784,6 +804,12 @@ describe("spawnAcpDirect", () => {
         sessionId: patch.sessionId ?? "sess-123",
         updatedAt: patch.updatedAt ?? Date.now(),
       }));
+    hoisted.upsertSessionEntryWithTrustedMemorySubjectMock
+      .mockReset()
+      .mockImplementation(
+        async (scope: unknown, patch: Partial<SessionEntry>) =>
+          await hoisted.upsertSessionEntryMock(scope, patch),
+      );
 
     hoisted.callGatewayMock.mockReset();
     hoisted.callGatewayMock.mockImplementation(async (argsUnknown: unknown) => {
@@ -917,7 +943,102 @@ describe("spawnAcpDirect", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     sessionBindingServiceTesting.resetSessionBindingAdaptersForTests();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("issues the durable ACP child subject for the target agent at its first write", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-memory-subject-"));
+    try {
+      vi.stubEnv("OPENCLAW_STATE_DIR", root);
+      const storePath = path.join(root, "agents", "codex", "sessions", "sessions.json");
+      const { upsertSqliteSessionEntryWithTrustedMemorySubject } = await vi.importActual<
+        typeof import("../config/sessions/session-accessor.sqlite-entry.js")
+      >("../config/sessions/session-accessor.sqlite-entry.js");
+      hoisted.upsertSessionEntryWithTrustedMemorySubjectMock.mockImplementation(
+        upsertSqliteSessionEntryWithTrustedMemorySubject,
+      );
+      hoisted.resolveStorePathMock.mockReturnValue(storePath);
+
+      const result = await spawnAcpDirect(
+        { task: "Persist the target-owned ACP subject", agentId: "codex" },
+        { agentSessionKey: "agent:main:main" },
+      );
+      const accepted = expectAcceptedSpawn(result);
+      const snapshot = readCurrentSessionMemorySubject({
+        agentId: "codex",
+        sessionKey: accepted.childSessionKey,
+        storePath,
+      });
+
+      expect(snapshot?.subject).toEqual(
+        prepareAutonomousAgentSessionMemorySubjectSeed("codex").subject,
+      );
+      expect(snapshot?.subject).not.toEqual(
+        prepareAutonomousAgentSessionMemorySubjectSeed("main").subject,
+      );
+    } finally {
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps an ACP child of an incognito requester unbound and out of the durable target store", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-incognito-memory-subject-"));
+    try {
+      vi.stubEnv("OPENCLAW_STATE_DIR", root);
+      const targetAgentId = "codex";
+      const durableStorePath = path.join(
+        root,
+        "agents",
+        targetAgentId,
+        "sessions",
+        "sessions.json",
+      );
+      const { upsertSqliteSessionEntry } = await vi.importActual<
+        typeof import("../config/sessions/session-accessor.sqlite-entry.js")
+      >("../config/sessions/session-accessor.sqlite-entry.js");
+      hoisted.upsertSessionEntryMock.mockImplementation(upsertSqliteSessionEntry);
+      hoisted.resolveStorePathMock.mockReturnValue(durableStorePath);
+
+      const result = await spawnAcpDirect(
+        { task: "Keep this ACP child incognito", agentId: targetAgentId },
+        { agentSessionKey: "agent:main:dashboard:incognito-parent" },
+      );
+      const accepted = expectAcceptedSpawn(result);
+      expect(accepted.childSessionKey).toMatch(/^agent:codex:acp:incognito-/u);
+      expect(hoisted.upsertSessionEntryWithTrustedMemorySubjectMock).not.toHaveBeenCalled();
+
+      expect(
+        readCurrentSessionMemorySubject({
+          agentId: targetAgentId,
+          sessionKey: accepted.childSessionKey,
+          storePath: resolveIncognitoOpenClawAgentSqlitePath({ agentId: targetAgentId }),
+        })?.subject,
+      ).toEqual({ version: 1, kind: "ambiguous", reason: "unbound" });
+
+      const durableDatabase = openOpenClawAgentDatabase(
+        toDatabaseOptions(
+          resolveSqliteScope({
+            agentId: targetAgentId,
+            sessionKey: "agent:codex:acp:durable-probe",
+            storePath: durableStorePath,
+          }),
+        ),
+      );
+      expect(
+        durableDatabase.db
+          .prepare("SELECT session_key FROM session_nodes WHERE session_key = ?")
+          .get(accepted.childSessionKey),
+      ).toBeUndefined();
+    } finally {
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 
   it("spawns ACP session, binds a new thread, and dispatches initial task", async () => {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -13,7 +13,12 @@ import {
   loadSessionEntryReadOnly,
   upsertSessionEntry,
 } from "../config/sessions/session-accessor.js";
+import { upsertSqliteSessionEntryWithTrustedMemorySubject as upsertSessionEntryWithTrustedMemorySubject } from "../config/sessions/session-accessor.sqlite-entry.js";
 import { buildSessionCreationStamp } from "../config/sessions/session-entry-provenance.js";
+import {
+  createTrustedSessionMemorySubjectIssuer,
+  prepareAutonomousAgentSessionMemorySubjectSeed,
+} from "../config/sessions/session-memory-subject.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
@@ -30,8 +35,10 @@ import {
   normalizeOptionalAgentId,
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
+  isIncognitoSessionKey,
 } from "../routing/session-key.js";
 import { recordSessionCreated, recordSubagentSpawned } from "../sessions/session-state-events.js";
+import { resolveIncognitoOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.js";
 import { deliveryContextFromSession } from "../utils/delivery-context.shared.js";
 import { countUntrackedActiveAcpRunsForOwner } from "./acp-spawn-admission.js";
 import {
@@ -405,7 +412,11 @@ export async function spawnAcpDirect(
     requester: requesterState,
   });
 
-  const sessionKey = mintSpawnSessionKey({ targetAgentId, backend: "acp" });
+  const incognito = isIncognitoSessionKey(requesterInternalKey);
+  const mintedSessionKey = mintSpawnSessionKey({ targetAgentId, backend: "acp" });
+  const sessionKey = incognito
+    ? mintedSessionKey.replace(":acp:", ":acp:incognito-")
+    : mintedSessionKey;
   const runtimeMode = resolveAcpSessionMode(spawnMode);
   const resolvedCwd = resolveSpawnedWorkspaceInheritance({
     config: cfg,
@@ -501,7 +512,9 @@ export async function spawnAcpDirect(
         via: "spawn",
         actor: { type: "agent", id: requesterInternalKey },
       });
-      const storePath = resolveStorePath(cfg.session?.store, { agentId: targetAgentId });
+      const storePath = incognito
+        ? resolveIncognitoOpenClawAgentSqlitePath({ agentId: targetAgentId })
+        : resolveStorePath(cfg.session?.store, { agentId: targetAgentId });
       const childSessionPatch = admission.childSessionPatch
         ? {
             spawnDepth: admission.childSessionPatch.spawnDepth,
@@ -511,23 +524,32 @@ export async function spawnAcpDirect(
             subagentControlScope: admission.childSessionPatch.subagentControlScope,
           }
         : {};
+      const childEntryPatch = {
+        ...creationStamp,
+        spawnedBy: requesterInternalKey,
+        completionOwnerSessionKey: ownership.completionRequesterSessionKey,
+        // Navigation parent is stamped at creation so the durable tree edge
+        // does not depend on the control-lineage field.
+        parentSessionKey: requesterInternalKey,
+        ...childSessionPatch,
+        inheritedToolPolicyVersion: 1,
+        ...inheritedToolAllowPatch(ctx.inheritedToolAllowlist),
+        ...inheritedToolDenyPatch(ctx.inheritedToolDenylist),
+        ...(params.label ? { label: params.label } : {}),
+        ...(incognito ? { incognito: true as const } : {}),
+      };
       childCreationEntry =
-        (await upsertSessionEntry(
-          { storePath, sessionKey },
-          {
-            ...creationStamp,
-            spawnedBy: requesterInternalKey,
-            completionOwnerSessionKey: ownership.completionRequesterSessionKey,
-            // Navigation parent is stamped at creation so the durable tree edge
-            // does not depend on the control-lineage field.
-            parentSessionKey: requesterInternalKey,
-            ...childSessionPatch,
-            inheritedToolPolicyVersion: 1,
-            ...inheritedToolAllowPatch(ctx.inheritedToolAllowlist),
-            ...inheritedToolDenyPatch(ctx.inheritedToolDenylist),
-            ...(params.label ? { label: params.label } : {}),
-          },
-        )) ?? undefined;
+        (incognito
+          ? await upsertSessionEntry({ storePath, sessionKey }, childEntryPatch)
+          : await upsertSessionEntryWithTrustedMemorySubject(
+              { storePath, sessionKey },
+              childEntryPatch,
+              // ACP has no requester-derived memory subject: the validated target
+              // agent owns its durable autonomous child from its first write.
+              createTrustedSessionMemorySubjectIssuer(() =>
+                prepareAutonomousAgentSessionMemorySubjectSeed(targetAgentId),
+              ),
+            )) ?? undefined;
       sessionCreated = true;
       const initializedSession = await initializeAcpSpawnRuntime({
         cfg,

--- a/src/agents/internal-session-effects.test.ts
+++ b/src/agents/internal-session-effects.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { createSessionEntryWithTrustedMemorySubject } from "../config/sessions/session-accessor.entry-mutation.js";
 import {
   appendTranscriptMessage,
   listSessionEntries,
@@ -10,9 +11,19 @@ import {
   upsertSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import {
+  readCurrentSessionMemorySubject,
+  readCurrentSessionMemorySubjectAuthority,
+} from "../config/sessions/session-memory-subject-access.js";
+import {
+  createTrustedSessionMemorySubjectIssuer,
+  prepareConversationSessionMemorySubjectSeed,
+  prepareExplicitSessionMemorySubjectSeed,
+} from "../config/sessions/session-memory-subject.js";
+import {
   closeOpenClawAgentDatabasesForTest,
   resolveIncognitoOpenClawAgentSqlitePath,
 } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
@@ -176,6 +187,175 @@ describe("internal session effects", () => {
       expect(listSessionEntries({ agentId: "main", storePath })).toEqual([
         expect.objectContaining({ sessionKey: source.sessionKey }),
       ]);
+    });
+  });
+
+  it.each([
+    {
+      label: "group",
+      chatType: "group" as const,
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "group-1",
+      canonicalConversationRef: "telegram:default:group:group-1",
+      sessionKey: "agent:main:telegram:group:group-1",
+    },
+    {
+      label: "channel",
+      chatType: "channel" as const,
+      channel: "discord",
+      accountId: "primary",
+      conversationId: "channel-1",
+      canonicalConversationRef: "discord:primary:channel:channel-1",
+      sessionKey: "agent:main:discord:channel:channel-1",
+    },
+  ])(
+    "preserves a $label conversation subject revision in a conversation-scoped internal-effects fork",
+    async ({
+      label,
+      chatType,
+      channel,
+      accountId,
+      conversationId,
+      canonicalConversationRef,
+      sessionKey,
+    }) => {
+      await withTempDir({ prefix: "openclaw-internal-session-effects-" }, async (dir) => {
+        const storePath = path.join(dir, "sessions.json");
+        const stateOptions = {
+          env: { ...process.env, OPENCLAW_STATE_DIR: path.join(dir, "state") },
+        };
+        const source = {
+          agentId: "main",
+          sessionId: `${label}-source-session`,
+          sessionKey,
+          storePath,
+        };
+        const seed = prepareConversationSessionMemorySubjectSeed({
+          channel,
+          accountId,
+          conversationId,
+          canonicalConversationRef,
+          now: 100,
+          options: stateOptions,
+        });
+
+        try {
+          const created = await createSessionEntryWithTrustedMemorySubject(
+            source,
+            () => ({
+              ok: true as const,
+              entry: { chatType, sessionId: source.sessionId, updatedAt: 100 },
+            }),
+            createTrustedSessionMemorySubjectIssuer(() => seed),
+          );
+          if (!created.ok) {
+            throw new Error(`failed to create the ${label} source session`);
+          }
+          await appendTranscriptMessage(source, {
+            message: { content: "stored", role: "assistant", timestamp: 101 },
+          });
+          const sourceSubject = readCurrentSessionMemorySubject(source);
+          if (!sourceSubject) {
+            throw new Error(`expected the ${label} source memory subject`);
+          }
+
+          const target = await prepareInternalSessionEffectsSession({
+            agentId: "main",
+            runId: `${label}-copy`,
+            source,
+            storePath,
+          });
+          const targetSubject = readCurrentSessionMemorySubject(target);
+
+          expect(sourceSubject).toMatchObject({
+            sessionScope: chatType,
+            subjectRevision: seed.subjectRevision,
+            subject: seed.subject,
+            canonicalConversationRef,
+          });
+          expect(targetSubject).toMatchObject({
+            sessionId: target.sessionId,
+            sessionScope: "conversation",
+            subjectRevision: sourceSubject.subjectRevision,
+            subject: sourceSubject.subject,
+            canonicalConversationRef: sourceSubject.canonicalConversationRef,
+          });
+        } finally {
+          closeOpenClawAgentDatabasesForTest();
+          closeOpenClawStateDatabaseForTest();
+        }
+      });
+    },
+  );
+
+  it("keeps a forced shared-main subject ambiguous and denied in an internal-effects fork", async () => {
+    await withTempDir({ prefix: "openclaw-internal-session-effects-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const stateOptions = {
+        env: { ...process.env, OPENCLAW_STATE_DIR: path.join(dir, "state") },
+      };
+      const source = {
+        agentId: "main",
+        sessionId: "shared-main-source-session",
+        sessionKey: "agent:main:main",
+        storePath,
+      };
+      const privateSeed = prepareExplicitSessionMemorySubjectSeed({
+        kind: "agent",
+        stableSubjectId: "main",
+        now: 100,
+        options: stateOptions,
+      });
+
+      try {
+        const created = await createSessionEntryWithTrustedMemorySubject(
+          source,
+          () => ({
+            ok: true as const,
+            entry: { chatType: "direct", sessionId: source.sessionId, updatedAt: 100 },
+          }),
+          createTrustedSessionMemorySubjectIssuer(() => privateSeed),
+        );
+        if (!created.ok) {
+          throw new Error("failed to create the shared-main source session");
+        }
+        await appendTranscriptMessage(source, {
+          message: { content: "stored", role: "assistant", timestamp: 101 },
+        });
+        const sourceSubject = readCurrentSessionMemorySubject(source);
+        if (!sourceSubject) {
+          throw new Error("expected the shared-main source memory subject");
+        }
+
+        const target = await prepareInternalSessionEffectsSession({
+          agentId: "main",
+          runId: "shared-main-copy",
+          source,
+          storePath,
+        });
+        const targetSubject = readCurrentSessionMemorySubject(target);
+
+        expect(sourceSubject).toMatchObject({
+          sessionScope: "shared-main",
+          subject: { version: 1, kind: "ambiguous", reason: "shared-main" },
+        });
+        expect(
+          readCurrentSessionMemorySubjectAuthority(source, stateOptions, 101)?.authority,
+        ).toEqual({ kind: "denied", reason: "ambiguous" });
+        expect(targetSubject).toMatchObject({
+          sessionId: target.sessionId,
+          sessionScope: "conversation",
+          subjectRevision: sourceSubject.subjectRevision,
+          subject: sourceSubject.subject,
+        });
+        expect(
+          readCurrentSessionMemorySubjectAuthority(target, stateOptions, 101)?.authority,
+        ).toEqual({ kind: "denied", reason: "ambiguous" });
+      } finally {
+        closeOpenClawAgentDatabasesForTest();
+        closeOpenClawStateDatabaseForTest();
+      }
     });
   });
 

--- a/src/agents/subagent-spawn-session-patch.test.ts
+++ b/src/agents/subagent-spawn-session-patch.test.ts
@@ -1,0 +1,139 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  upsertSqliteSessionEntry,
+  upsertSqliteSessionEntryWithTrustedMemorySubject,
+} from "../config/sessions/session-accessor.sqlite-entry.js";
+import {
+  resolveSqliteScope,
+  toDatabaseOptions,
+} from "../config/sessions/session-accessor.sqlite-scope.js";
+import { readCurrentSessionMemorySubject } from "../config/sessions/session-memory-subject-access.js";
+import { prepareAutonomousAgentSessionMemorySubjectSeed } from "../config/sessions/session-memory-subject.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+
+const tempDirectories = useAutoCleanupTempDirTracker(afterEach);
+
+async function loadCreateInitialSubagentSession(params: {
+  targetAgentId: string;
+  storePath: string;
+  canonicalKey: string;
+}) {
+  vi.resetModules();
+  vi.doMock("./subagent-spawn.runtime.js", () => ({
+    resolveGatewaySessionStoreTarget: () => ({
+      agentId: params.targetAgentId,
+      storePath: params.storePath,
+      canonicalKey: params.canonicalKey,
+      storeKeys: [params.canonicalKey],
+    }),
+    upsertSessionEntry: upsertSqliteSessionEntry,
+    upsertSessionEntryWithTrustedMemorySubject: upsertSqliteSessionEntryWithTrustedMemorySubject,
+  }));
+  return (await import("./subagent-spawn-session-patch.js")).createInitialSubagentSession;
+}
+
+function createParams(params: {
+  targetAgentId: string;
+  childSessionKey: string;
+  incognito: boolean;
+}) {
+  return {
+    cfg: {} as OpenClawConfig,
+    targetAgentId: params.targetAgentId,
+    childSessionKey: params.childSessionKey,
+    incognito: params.incognito,
+    requesterInternalKey: "agent:requester:main",
+    completionOwnerSessionKey: "agent:requester:main",
+    modelPatch: {},
+    collect: false,
+  };
+}
+
+afterEach(() => {
+  vi.doUnmock("./subagent-spawn.runtime.js");
+  vi.resetModules();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("createInitialSubagentSession memory subject issuance", () => {
+  it("assigns a durable native child to its target agent, not its requester lineage", async () => {
+    const root = tempDirectories.make("openclaw-subagent-memory-subject-");
+    const targetAgentId = "target";
+    const canonicalKey = "agent:target:subagent:canonical-child";
+    const storePath = path.join(root, "agents", targetAgentId, "sessions", "sessions.json");
+    const createInitialSubagentSession = await loadCreateInitialSubagentSession({
+      targetAgentId,
+      storePath,
+      canonicalKey,
+    });
+
+    const result = await createInitialSubagentSession(
+      createParams({
+        targetAgentId,
+        childSessionKey: "agent:target:subagent:requested-child",
+        incognito: false,
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    const snapshot = readCurrentSessionMemorySubject({
+      agentId: targetAgentId,
+      sessionKey: canonicalKey,
+      storePath,
+    });
+    expect(snapshot?.subject).toEqual(
+      prepareAutonomousAgentSessionMemorySubjectSeed(targetAgentId).subject,
+    );
+    expect(snapshot?.subject).not.toEqual(
+      prepareAutonomousAgentSessionMemorySubjectSeed("requester").subject,
+    );
+  });
+
+  it("keeps an incognito native child unbound and out of the durable target store", async () => {
+    const root = tempDirectories.make("openclaw-subagent-incognito-memory-subject-");
+    const targetAgentId = "target";
+    const childSessionKey = "agent:target:subagent:incognito-child";
+    const storePath = path.join(root, "agents", targetAgentId, "sessions", "sessions.json");
+    const createInitialSubagentSession = await loadCreateInitialSubagentSession({
+      targetAgentId,
+      storePath,
+      canonicalKey: childSessionKey,
+    });
+
+    const result = await createInitialSubagentSession(
+      createParams({ targetAgentId, childSessionKey, incognito: true }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(
+      readCurrentSessionMemorySubject({
+        agentId: targetAgentId,
+        sessionKey: childSessionKey,
+        storePath,
+      })?.subject,
+    ).toEqual({ version: 1, kind: "ambiguous", reason: "unbound" });
+
+    const durableDatabase = openOpenClawAgentDatabase(
+      toDatabaseOptions(
+        resolveSqliteScope({
+          agentId: targetAgentId,
+          sessionKey: "agent:target:subagent:durable-probe",
+          storePath,
+        }),
+      ),
+    );
+    expect(
+      durableDatabase.db
+        .prepare("SELECT session_key FROM session_nodes WHERE session_key = ?")
+        .get(childSessionKey),
+    ).toBeUndefined();
+  });
+});

--- a/src/agents/subagent-spawn-session-patch.ts
+++ b/src/agents/subagent-spawn-session-patch.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { buildSessionCreationStamp } from "../config/sessions/session-entry-provenance.js";
+import {
+  createTrustedSessionMemorySubjectIssuer,
+  prepareAutonomousAgentSessionMemorySubjectSeed,
+} from "../config/sessions/session-memory-subject.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveIncognitoOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.js";
@@ -12,7 +16,11 @@ import {
 } from "./inherited-tool-deny.js";
 import { getSubagentSpawnDeps } from "./subagent-spawn-deps.js";
 import { splitModelRef } from "./subagent-spawn-plan.js";
-import { resolveGatewaySessionStoreTarget, upsertSessionEntry } from "./subagent-spawn.runtime.js";
+import {
+  resolveGatewaySessionStoreTarget,
+  upsertSessionEntry,
+  upsertSessionEntryWithTrustedMemorySubject,
+} from "./subagent-spawn.runtime.js";
 
 function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<SessionEntry> {
   const entry: Partial<SessionEntry> = {};
@@ -154,20 +162,31 @@ export async function createInitialSubagentSession(params: {
           cfg: params.cfg,
           key: params.childSessionKey,
         });
-    const entry = await upsertSessionEntry(
-      {
-        storePath: target.storePath,
-        sessionKey: target.canonicalKey,
-      },
-      {
-        ...buildDirectChildSessionPatch(initialChildSessionPatch),
-        ...childSessionIdentity,
-        ...buildSessionCreationStamp({
-          via: "spawn",
-          actor: { type: "agent", id: params.requesterInternalKey },
-        }),
-      },
-    );
+    const initialEntryPatch = {
+      ...buildDirectChildSessionPatch(initialChildSessionPatch),
+      ...childSessionIdentity,
+      ...buildSessionCreationStamp({
+        via: "spawn",
+        actor: { type: "agent", id: params.requesterInternalKey },
+      }),
+    };
+    const scope = {
+      agentId: target.agentId,
+      storePath: target.storePath,
+      sessionKey: target.canonicalKey,
+    };
+    // This is the direct child row's first writer. The target agent is resolved
+    // by the validated spawn plan; requester/session fields describe lineage,
+    // never the child memory principal. Incognito remains deliberately unbound.
+    const entry = params.incognito
+      ? await upsertSessionEntry(scope, initialEntryPatch)
+      : await upsertSessionEntryWithTrustedMemorySubject(
+          scope,
+          initialEntryPatch,
+          createTrustedSessionMemorySubjectIssuer(() =>
+            prepareAutonomousAgentSessionMemorySubjectSeed(params.targetAgentId),
+          ),
+        );
     return { status: "ok", entry: entry ?? undefined };
   } catch (err) {
     const message = err instanceof Error ? err.message : typeof err === "string" ? err : "error";

--- a/src/agents/subagent-spawn.runtime.ts
+++ b/src/agents/subagent-spawn.runtime.ts
@@ -8,6 +8,7 @@ export {
   loadSessionEntryReadOnly as loadSessionEntry,
   upsertSessionEntry,
 } from "../config/sessions/session-accessor.js";
+export { upsertSqliteSessionEntryWithTrustedMemorySubject as upsertSessionEntryWithTrustedMemorySubject } from "../config/sessions/session-accessor.sqlite-entry.js";
 export { forkSessionEntryFromParent } from "../auto-reply/reply/session-fork.js";
 export { ensureContextEnginesInitialized } from "../context-engine/init.js";
 export { resolveContextEngine } from "../context-engine/registry.js";

--- a/src/agents/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagent-spawn.test-helpers.ts
@@ -335,6 +335,26 @@ export async function loadSubagentSpawnModuleForTest(params: {
       });
       return updated ?? null;
     },
+    upsertSessionEntryWithTrustedMemorySubject: async (
+      scope: { storePath?: string; sessionKey: string },
+      patch: Record<string, unknown>,
+    ) => {
+      const updateSessionStore =
+        params.updateSessionStoreMock ??
+        (async (_storePath: string, mutator: SessionStoreMutator) => {
+          const store: SessionStore = {};
+          await mutator(store);
+          return store;
+        });
+      let updated: Record<string, unknown> | undefined;
+      const storePath =
+        scope.storePath ?? params.sessionStorePath ?? "/tmp/subagent-spawn-model-session.json";
+      await updateSessionStore(storePath, (store: SessionStore) => {
+        updated = Object.assign({}, store[scope.sessionKey], patch);
+        store[scope.sessionKey] = updated;
+      });
+      return updated ?? null;
+    },
     getSessionBindingService:
       params.getSessionBindingService ??
       (() => ({

--- a/src/commands/doctor-security.test.ts
+++ b/src/commands/doctor-security.test.ts
@@ -271,13 +271,13 @@ describe("noteSecurityWarnings gateway exposure", () => {
     expect(note).not.toHaveBeenCalled();
   });
 
-  it("shows explicit dmScope config command for multi-user DMs", async () => {
+  function installMultiUserDmPlugin(accountIds: string[]) {
     pluginRegistry.list = [
       {
         id: "test-channel",
         meta: { label: "Test Channel" },
         config: {
-          listAccountIds: () => ["default"],
+          listAccountIds: () => accountIds,
           inspectAccount: () => ({ enabled: true, configured: true }),
           resolveAccount: () => ({}),
           isEnabled: () => true,
@@ -293,7 +293,13 @@ describe("noteSecurityWarnings gateway exposure", () => {
         },
       },
     ];
-    const cfg = { session: { dmScope: "main" } } as OpenClawConfig;
+  }
+
+  it("prescribes per-channel-peer for a single-account multi-user DM without rewriting dmScope", async () => {
+    installMultiUserDmPlugin(["default"]);
+    const cfg = Object.freeze({
+      session: Object.freeze({ dmScope: "main" as const }),
+    }) as OpenClawConfig;
     await noteSecurityWarnings(cfg);
     expect(listReadOnlyChannelPluginsForConfigMock).toHaveBeenCalledWith(cfg, {
       includePersistedAuthState: true,
@@ -301,6 +307,21 @@ describe("noteSecurityWarnings gateway exposure", () => {
     });
     const message = lastMessage();
     expect(message).toContain('config set session.dmScope "per-channel-peer"');
+    expect(message).not.toContain("per-account-channel-peer");
+    expect(cfg.session?.dmScope).toBe("main");
+  });
+
+  it("prescribes per-account-channel-peer for a multi-account multi-user DM without rewriting dmScope", async () => {
+    installMultiUserDmPlugin(["primary", "secondary"]);
+    const cfg = Object.freeze({
+      session: Object.freeze({ dmScope: "main" as const }),
+    }) as OpenClawConfig;
+    await noteSecurityWarnings(cfg);
+
+    const message = lastMessage();
+    expect(message).toContain('config set session.dmScope "per-account-channel-peer"');
+    expect(message).not.toContain('session.dmScope "per-channel-peer"');
+    expect(cfg.session?.dmScope).toBe("main");
   });
 
   it("clarifies approvals.exec forwarding-only behavior", async () => {

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -352,6 +352,7 @@ export async function collectSecurityWarnings(
     allowFromPath: string;
     approveHint: string;
     normalizeEntry?: (raw: string) => string;
+    dmScopeRemediation: "per-channel-peer" | "per-account-channel-peer";
   }) => {
     const dmPolicy = params.dmPolicy;
     const policyPath = params.policyPath ?? `${params.allowFromPath}policy`;
@@ -389,8 +390,8 @@ export async function collectSecurityWarnings(
     if (dmScope === "main" && isMultiUserDm) {
       warnings.push(
         `- ${params.label} DMs: multiple senders share the main session; run: ` +
-          formatCliCommand('openclaw config set session.dmScope "per-channel-peer"') +
-          ' (or "per-account-channel-peer" for multi-account channels) to isolate sessions.',
+          formatCliCommand(`openclaw config set session.dmScope "${params.dmScopeRemediation}"`) +
+          " to isolate sessions.",
       );
     }
   };
@@ -402,7 +403,7 @@ export async function collectSecurityWarnings(
     if (!plugin.security) {
       continue;
     }
-    const { defaultAccountId, account, enabled, configured, diagnostics } =
+    const { accountIds, defaultAccountId, account, enabled, configured, diagnostics } =
       await resolveDefaultChannelAccountContext(plugin, cfg, {
         mode: "read_only",
         commandName: "doctor",
@@ -432,6 +433,7 @@ export async function collectSecurityWarnings(
         allowFromPath: dmPolicy.allowFromPath,
         approveHint: dmPolicy.approveHint,
         normalizeEntry: dmPolicy.normalizeEntry,
+        dmScopeRemediation: accountIds.length > 1 ? "per-account-channel-peer" : "per-channel-peer",
       });
     }
     if (plugin.security.collectWarnings) {

--- a/src/commands/doctor-session-canonical-keys.ts
+++ b/src/commands/doctor-session-canonical-keys.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import { resolveAgentMainSessionKey } from "../config/sessions/main-session.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import {
-  applySessionEntryLifecycleMutation,
   copySessionOwnedStateForCanonicalRepair,
   listSessionEntriesForCanonicalRepair,
   listSessionGenerationIdsForCanonicalRepair,
@@ -16,6 +15,7 @@ import {
   copySessionNodeArtifactsForRepair,
   deleteSessionMembersForRepair,
 } from "../config/sessions/session-accessor.sqlite-node-artifacts.js";
+import { applySqliteSessionEntryLifecycleMutationWithTrustedMemorySubjects as applySessionEntryLifecycleMutation } from "../config/sessions/session-accessor.sqlite-projection.js";
 import { collectSqliteSessionStateIdsForEntry } from "../config/sessions/session-accessor.sqlite-references.js";
 import { resolveSqliteTranscriptArchiveDirectory } from "../config/sessions/session-accessor.sqlite-scope.js";
 import { setCanonicalSqliteSessionMainKey } from "../config/sessions/session-canonical-key.js";
@@ -597,7 +597,15 @@ async function repairCanonicalSessionGroup(
     removals: createCanonicalDestinationRemovals(destinationStore, selected),
     skipMaintenance: true,
     storePath: destination.storePath,
-    upserts: [{ entry: selected.entry, sessionKey: winner.canonicalKey }],
+    upserts: [
+      {
+        entry: selected.entry,
+        sessionKey: winner.canonicalKey,
+        ...(winner.sqlitePath !== destination.sqlitePath
+          ? { deferMemorySubjectPersistence: true as const }
+          : {}),
+      },
+    ],
   });
   const archivedDirectories = new Set([
     ...preArchivedDirectories,

--- a/src/commands/doctor-session-incognito-key-repair.test.ts
+++ b/src/commands/doctor-session-incognito-key-repair.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import { afterEach, describe, expect, it } from "vitest";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { listSessionEntries } from "../config/sessions/session-accessor.js";
+import { readCurrentSessionMemorySubject } from "../config/sessions/session-memory-subject-access.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -21,6 +22,136 @@ afterEach(() => {
 });
 
 describe("doctor reserved incognito session key repair", () => {
+  it("repairs an old database without lazily creating memory subject tables", () => {
+    const stateDir = fs.realpathSync(tempDirs.make("openclaw-doctor-incognito-old-schema-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const sqlitePath = resolveOpenClawAgentSqlitePath({ agentId: "main", env });
+    const database = openOpenClawAgentDatabase({ agentId: "main", env, path: sqlitePath });
+    const oldKey = "agent:main:dashboard:incognito-old-schema";
+    const newKey = "agent:main:dashboard:legacy-incognito-old-schema";
+    try {
+      database.db
+        .prepare(
+          "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at) VALUES (?, 'old-schema-session', ?, 1)",
+        )
+        .run(oldKey, JSON.stringify({ sessionId: "old-schema-session", updatedAt: 1 }));
+      database.db
+        .prepare(
+          "INSERT INTO session_windows (session_id, session_key, session_scope, created_at, updated_at) VALUES ('old-schema-session', ?, 'conversation', 1, 1)",
+        )
+        .run(oldKey);
+      database.db.exec(`
+        DROP TRIGGER IF EXISTS session_memory_subjects_reject_update;
+        DROP TABLE session_memory_subject_snapshots;
+        DROP TABLE session_memory_subjects;
+      `);
+      closeOpenClawAgentDatabasesForTest();
+
+      expect(repairReservedIncognitoSessionKeys({ apply: true, cfg: {}, env })).toEqual({
+        found: 1,
+        repaired: 1,
+      });
+
+      const reopened = openOpenClawAgentDatabase({ agentId: "main", env, path: sqlitePath });
+      expect(reopened.db.prepare("SELECT session_key FROM session_nodes").get()).toEqual({
+        session_key: newKey,
+      });
+      expect(
+        reopened.db
+          .prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?")
+          .get("session_memory_subjects"),
+      ).toBeUndefined();
+      expect(
+        reopened.db
+          .prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?")
+          .get("session_memory_subject_snapshots"),
+      ).toBeUndefined();
+    } finally {
+      closeOpenClawAgentDatabasesForTest();
+    }
+  });
+
+  it("rehomes immutable memory subject records with the renamed session", () => {
+    const stateDir = fs.realpathSync(tempDirs.make("openclaw-doctor-incognito-subject-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const sqlitePath = resolveOpenClawAgentSqlitePath({ agentId: "main", env });
+    const database = openOpenClawAgentDatabase({ agentId: "main", env, path: sqlitePath });
+    const oldKey = "agent:main:dashboard:incognito-subject";
+    const newKey = "agent:main:dashboard:legacy-incognito-subject";
+    const subjectRevision = "subject-revision";
+    const sessionIdentityRevision = "session-identity-revision";
+    try {
+      database.db
+        .prepare(
+          "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at) VALUES (?, 'subject-session', ?, 1)",
+        )
+        .run(oldKey, JSON.stringify({ sessionId: "subject-session", updatedAt: 1 }));
+      database.db
+        .prepare(
+          "INSERT INTO session_windows (session_id, session_key, session_scope, created_at, updated_at) VALUES ('subject-session', ?, 'conversation', 1, 1)",
+        )
+        .run(oldKey);
+      database.db
+        .prepare(
+          `INSERT INTO session_memory_subjects (
+            session_key, subject_revision, subject_kind, principal_id,
+            conversation_principal_id, channel, account_id, ambiguous_reason,
+            creation_evidence_kind, creation_evidence_revision, creation_binding_id,
+            canonical_conversation_ref, created_at
+          ) VALUES (?, ?, 'agent', 'agent:main', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 123)`,
+        )
+        .run(oldKey, subjectRevision);
+      database.db
+        .prepare(
+          "INSERT INTO session_memory_subject_snapshots (session_id, session_key, subject_revision, session_identity_revision, created_at) VALUES ('subject-session', ?, ?, ?, 456)",
+        )
+        .run(oldKey, subjectRevision, sessionIdentityRevision);
+
+      expect(repairReservedIncognitoSessionKeys({ apply: true, cfg: {}, env })).toEqual({
+        found: 1,
+        repaired: 1,
+      });
+      expect(
+        database.db
+          .prepare(
+            "SELECT session_key, subject_revision, subject_kind, principal_id, created_at FROM session_memory_subjects",
+          )
+          .get(),
+      ).toEqual({
+        session_key: newKey,
+        subject_revision: subjectRevision,
+        subject_kind: "agent",
+        principal_id: "agent:main",
+        created_at: 123,
+      });
+      expect(
+        database.db
+          .prepare(
+            "SELECT session_key, subject_revision, session_identity_revision, created_at FROM session_memory_subject_snapshots WHERE session_id = 'subject-session'",
+          )
+          .get(),
+      ).toEqual({
+        session_key: newKey,
+        subject_revision: subjectRevision,
+        session_identity_revision: sessionIdentityRevision,
+        created_at: 456,
+      });
+
+      closeOpenClawAgentDatabasesForTest();
+      expect(
+        readCurrentSessionMemorySubject({ agentId: "main", env, sessionKey: newKey }),
+      ).toMatchObject({
+        sessionId: "subject-session",
+        sessionKey: newKey,
+        subjectRevision,
+        sessionIdentityRevision,
+        subject: { version: 1, kind: "agent", principalId: "agent:main" },
+      });
+    } finally {
+      closeOpenClawAgentDatabasesForTest();
+    }
+  });
+
   it("renames durable collisions and every key-bearing linkage idempotently", () => {
     const stateDir = fs.realpathSync(tempDirs.make("openclaw-doctor-incognito-key-"));
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };

--- a/src/commands/doctor-session-incognito-key-repair.ts
+++ b/src/commands/doctor-session-incognito-key-repair.ts
@@ -12,6 +12,7 @@ import {
   type OpenClawAgentDatabase,
   runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
+import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -173,9 +174,74 @@ function applyReservedIncognitoKeyRenames(
   // Board widget foreign keys are immediate; defer them so every key-bearing row renames atomically.
   database.db.exec("PRAGMA defer_foreign_keys = ON;"); // sqlite-allow-raw -- transaction-local FK deferral.
   for (const rename of renames) {
+    rehomeSessionMemorySubjectForReservedKeyRename(database.db, rename);
     updateSessionKeyColumns(database.db, rename);
   }
   rewriteSessionEntryJsonReferences(database, new Map(renames.map((item) => [item.from, item.to])));
+}
+
+function rehomeSessionMemorySubjectForReservedKeyRename(
+  database: DatabaseSync,
+  rename: ReservedKeyRename,
+): void {
+  // Subjects are an additive lazy surface. Doctor must not create it while
+  // repairing an unrelated key in a valid older agent database.
+  if (!tableExists(database, "session_memory_subjects")) {
+    return;
+  }
+  const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database);
+  const subject = executeSqliteQuerySync(
+    database,
+    db.selectFrom("session_memory_subjects").selectAll().where("session_key", "=", rename.from),
+  ).rows[0];
+  if (!subject) {
+    return;
+  }
+  const target = executeSqliteQuerySync(
+    database,
+    db
+      .selectFrom("session_memory_subjects")
+      .select("session_key")
+      .where("session_key", "=", rename.to),
+  ).rows[0];
+  if (target) {
+    throw new Error(
+      `Cannot rehome immutable session memory subject because ${rename.to} already exists`,
+    );
+  }
+
+  // Subject rows reject updates. Copy the exact audit record before moving its
+  // snapshots, then delete the old row while this transaction defers foreign keys.
+  executeSqliteQuerySync(
+    database,
+    db.insertInto("session_memory_subjects").values({ ...subject, session_key: rename.to }),
+  );
+  const snapshots = tableExists(database, "session_memory_subject_snapshots")
+    ? executeSqliteQuerySync(
+        database,
+        db
+          .selectFrom("session_memory_subject_snapshots")
+          .selectAll()
+          .where("session_key", "=", rename.from),
+      ).rows
+    : [];
+  for (const snapshot of snapshots) {
+    if (snapshot.subject_revision !== subject.subject_revision) {
+      throw new Error(`Cannot rehome session memory subject snapshot for ${snapshot.session_id}`);
+    }
+    executeSqliteQuerySync(
+      database,
+      db
+        .updateTable("session_memory_subject_snapshots")
+        .set({ session_key: rename.to })
+        .where("session_id", "=", snapshot.session_id)
+        .where("session_key", "=", rename.from),
+    );
+  }
+  executeSqliteQuerySync(
+    database,
+    db.deleteFrom("session_memory_subjects").where("session_key", "=", rename.from),
+  );
 }
 
 function legacyIncognitoSessionKey(sessionKey: string): string {

--- a/src/config/sessions/inbound.runtime.ts
+++ b/src/config/sessions/inbound.runtime.ts
@@ -1,3 +1,4 @@
 // Runtime facade keeping inbound session persistence lazy behind the session accessor.
 export { resolveStorePath } from "./paths.js";
 export { recordInboundSessionMeta, updateSessionLastRoute } from "./session-accessor.js";
+export { recordInboundSessionMetaWithTrustedMemorySubject } from "./session-accessor.entry-mutation.js";

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -13,6 +13,7 @@ import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-age
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { appendSqliteTrajectoryRuntimeEvents } from "../../trajectory/runtime-store.sqlite.js";
@@ -45,6 +46,7 @@ import {
   type TranscriptMessageAppendResult,
   type TranscriptUpdatePayload,
 } from "./session-accessor.js";
+import { writeSessionEntry } from "./session-accessor.sqlite-entry-store.js";
 import {
   appendSqliteTranscriptEvent,
   appendSqliteTranscriptMessage,
@@ -66,6 +68,8 @@ import {
   upsertSqliteSessionEntry,
 } from "./session-accessor.sqlite.js";
 import { setCanonicalSqliteSessionMainKey } from "./session-canonical-key.js";
+import { readCurrentSessionMemorySubject } from "./session-memory-subject-access.js";
+import { createTrustedSessionMemorySubjectSeed } from "./session-memory-subject-trust.js";
 import type { InternalSessionEntry, SessionCompactionCheckpoint, SessionEntry } from "./types.js";
 
 // Keep accessor conformance independent of any real openclaw.json on the machine.
@@ -2079,11 +2083,12 @@ describe("sqlite session normalization", () => {
 
   it("branches a checkpoint by copying SQLite rows and creating the entry transactionally", async () => {
     const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    const sourceKey = "agent:main:checkpoint-source";
     const sourceScope = {
       agentId: "main",
       env,
       sessionId: "source-session",
-      sessionKey: "agent:main:main",
+      sessionKey: sourceKey,
       storePath: paths.sqlitePath,
     };
     const preCompactionScope = {
@@ -2093,7 +2098,7 @@ describe("sqlite session normalization", () => {
     const sourceEntryScope = {
       agentId: "main",
       env,
-      sessionKey: "agent:main:main",
+      sessionKey: sourceKey,
       storePath: paths.sqlitePath,
     };
     const branchKey = "agent:main:checkpoint-branch";
@@ -2116,6 +2121,32 @@ describe("sqlite session normalization", () => {
       },
     };
 
+    const sourceEntry: InternalSessionEntry = {
+      label: "Source",
+      lifecycleRunId: "source-run",
+      sessionId: "source-session",
+      updatedAt: 10,
+      compactionCheckpoints: [checkpoint],
+    };
+    const sourceSeed = createTrustedSessionMemorySubjectSeed({
+      subject: {
+        version: 1,
+        kind: "user",
+        principalId: "checkpoint-source-principal",
+        creationEvidence: { kind: "channel-binding", revision: "checkpoint-binding-revision" },
+      },
+      subjectRevision: "checkpoint-source-subject-revision",
+      creationBindingId: "checkpoint-source-binding-id",
+    });
+    runOpenClawAgentWriteTransaction(
+      (database) => {
+        writeSessionEntry(database, sourceEntryScope.sessionKey, sourceEntry, {
+          memorySubjectSeed: sourceSeed,
+        });
+      },
+      { agentId: "main", env, path: paths.sqlitePath },
+    );
+
     await replaceSqliteTranscriptEvents(preCompactionScope, [
       { type: "session", id: "pre-compaction-session", cwd: paths.tempDir },
       { type: "message", id: "pre-msg", parentId: null, message: { content: "pre" } },
@@ -2130,14 +2161,6 @@ describe("sqlite session normalization", () => {
         message: { content: "post-two" },
       },
     ]);
-    const sourceEntry: InternalSessionEntry = {
-      label: "Source",
-      lifecycleRunId: "source-run",
-      sessionId: "source-session",
-      updatedAt: 10,
-      compactionCheckpoints: [checkpoint],
-    };
-    await upsertSqliteSessionEntry(sourceEntryScope, sourceEntry);
 
     const notify = vi.fn();
     const unsubscribe = onSessionIdentityMutation(notify);
@@ -2177,6 +2200,16 @@ describe("sqlite session normalization", () => {
       }),
     );
     expect((result.entry as InternalSessionEntry).lifecycleRunId).toBeUndefined();
+    const sourceSubject = readCurrentSessionMemorySubject(sourceEntryScope);
+    if (!sourceSubject) {
+      throw new Error("expected source memory subject");
+    }
+    expect(
+      readCurrentSessionMemorySubject({ ...sourceEntryScope, sessionKey: branchKey }),
+    ).toMatchObject({
+      subjectRevision: sourceSubject.subjectRevision,
+      creationBindingId: sourceSubject.creationBindingId,
+    });
     await expect(loadSqliteTranscriptEvents(branchScope)).resolves.toEqual([
       expect.objectContaining({ type: "session", id: result.entry.sessionId }),
       expect.objectContaining({ id: "pre-msg", type: "message" }),
@@ -2257,11 +2290,12 @@ describe("sqlite session normalization", () => {
 
   it("restores a checkpoint by copying SQLite rows and replacing the entry transactionally", async () => {
     const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    const sourceKey = "agent:main:checkpoint-restore-source";
     const sourceScope = {
       agentId: "main",
       env,
       sessionId: "source-session",
-      sessionKey: "agent:main:main",
+      sessionKey: sourceKey,
       storePath: paths.sqlitePath,
     };
     const preCompactionScope = {
@@ -2271,7 +2305,7 @@ describe("sqlite session normalization", () => {
     const sourceEntryScope = {
       agentId: "main",
       env,
-      sessionKey: "agent:main:main",
+      sessionKey: sourceKey,
       storePath: paths.sqlitePath,
     };
     const checkpoint: SessionCompactionCheckpoint = {
@@ -2293,6 +2327,31 @@ describe("sqlite session normalization", () => {
       },
     };
 
+    const sourceEntry: InternalSessionEntry = {
+      label: "Current",
+      sessionId: "current-session",
+      updatedAt: 10,
+      compactionCheckpoints: [checkpoint],
+    };
+    const sourceSeed = createTrustedSessionMemorySubjectSeed({
+      subject: {
+        version: 1,
+        kind: "user",
+        principalId: "checkpoint-restore-principal",
+        creationEvidence: { kind: "channel-binding", revision: "checkpoint-restore-revision" },
+      },
+      subjectRevision: "checkpoint-restore-subject-revision",
+      creationBindingId: "checkpoint-restore-binding-id",
+    });
+    runOpenClawAgentWriteTransaction(
+      (database) => {
+        writeSessionEntry(database, sourceEntryScope.sessionKey, sourceEntry, {
+          memorySubjectSeed: sourceSeed,
+        });
+      },
+      { agentId: "main", env, path: paths.sqlitePath },
+    );
+
     await replaceSqliteTranscriptEvents(preCompactionScope, [
       { type: "session", id: "pre-compaction-session", cwd: paths.tempDir },
       { type: "message", id: "pre-msg", parentId: null, message: { content: "restore" } },
@@ -2302,12 +2361,6 @@ describe("sqlite session normalization", () => {
       { type: "message", id: "post-msg-1", parentId: null, message: { content: "skip" } },
       { type: "message", id: "post-msg-2", parentId: "post-msg-1", message: { content: "skip" } },
     ]);
-    await upsertSqliteSessionEntry(sourceEntryScope, {
-      label: "Current",
-      sessionId: "current-session",
-      updatedAt: 10,
-      compactionCheckpoints: [checkpoint],
-    });
 
     const result = await restoreSqliteCompactionCheckpointSession({
       agentId: "main",
@@ -2334,6 +2387,14 @@ describe("sqlite session normalization", () => {
         totalTokensVersion: 1,
       }),
     );
+    const sourceSubject = readCurrentSessionMemorySubject(sourceEntryScope);
+    if (!sourceSubject) {
+      throw new Error("expected restored source memory subject");
+    }
+    expect(sourceSubject).toMatchObject({
+      subjectRevision: sourceSeed.subjectRevision,
+      creationBindingId: sourceSeed.creationBindingId,
+    });
     await expect(loadSqliteTranscriptEvents(restoredScope)).resolves.toEqual([
       expect.objectContaining({ type: "session", id: result.entry.sessionId }),
       expect.objectContaining({ id: "pre-msg", type: "message" }),

--- a/src/config/sessions/session-accessor.entry-mutation.ts
+++ b/src/config/sessions/session-accessor.entry-mutation.ts
@@ -11,9 +11,11 @@ import {
   patchSessionEntry,
   resolveSessionEntryFromStore,
 } from "./session-accessor.entry.js";
-import { applySessionEntryLifecycleMutation } from "./session-accessor.lifecycle.js";
+import { recordSqliteInboundSessionMetaWithTrustedMemorySubject } from "./session-accessor.sqlite-entry.js";
+import { applySqliteSessionEntryLifecycleMutationWithTrustedMemorySubjects } from "./session-accessor.sqlite-projection.js";
+import { resolveSqliteScope } from "./session-accessor.sqlite-scope.js";
+import { appendTranscriptEventInTransaction } from "./session-accessor.sqlite-transcript-store.js";
 import {
-  appendSqliteTranscriptEvent,
   forkSqliteSessionEntryFromParentTarget,
   forkSqliteSessionTranscriptFromParent,
   recordSqliteInboundSessionMeta,
@@ -38,10 +40,18 @@ import type {
   SessionEntryCreateWithTranscriptPrepareResult,
   SessionEntryCreateWithTranscriptOptions,
 } from "./session-accessor.types.js";
+import type { TrustedSessionMemorySubjectIssuer } from "./session-memory-subject.js";
 import { projectSessionStoreForPersistence } from "./skill-prompt-blobs.js";
 import { normalizeStoreSessionKey } from "./store-entry.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import type { GroupKeyResolution, SessionEntry } from "./types.js";
+
+class SessionTranscriptInitializationError extends Error {
+  constructor(cause: unknown) {
+    super(formatErrorMessage(cause));
+    this.name = "SessionTranscriptInitializationError";
+  }
+}
 
 function projectSessionEntryForPersistenceRevision(params: {
   storePath: string;
@@ -100,6 +110,41 @@ export async function createSessionEntryWithTranscript<TError = string>(
     | SessionEntryCreateWithTranscriptPrepareResult<TError>,
   options: SessionEntryCreateWithTranscriptOptions = {},
 ): Promise<SessionEntryCreateWithTranscriptResult<TError>> {
+  return await createSessionEntryWithTranscriptInternal(scope, createEntry, options);
+}
+
+/**
+ * Core-only creation path. The issuer remains a branded in-memory capability
+ * until the entry transaction creates its immutable subject snapshot.
+ */
+export async function createSessionEntryWithTrustedMemorySubject<TError = string>(
+  scope: SessionAccessScope,
+  createEntry: (
+    context: SessionEntryCreateWithTranscriptContext,
+  ) =>
+    | Promise<SessionEntryCreateWithTranscriptPrepareResult<TError>>
+    | SessionEntryCreateWithTranscriptPrepareResult<TError>,
+  memorySubjectIssuer: TrustedSessionMemorySubjectIssuer,
+  options: SessionEntryCreateWithTranscriptOptions = {},
+): Promise<SessionEntryCreateWithTranscriptResult<TError>> {
+  return await createSessionEntryWithTranscriptInternal(
+    scope,
+    createEntry,
+    options,
+    memorySubjectIssuer,
+  );
+}
+
+async function createSessionEntryWithTranscriptInternal<TError>(
+  scope: SessionAccessScope,
+  createEntry: (
+    context: SessionEntryCreateWithTranscriptContext,
+  ) =>
+    | Promise<SessionEntryCreateWithTranscriptPrepareResult<TError>>
+    | SessionEntryCreateWithTranscriptPrepareResult<TError>,
+  options: SessionEntryCreateWithTranscriptOptions,
+  memorySubjectIssuer?: TrustedSessionMemorySubjectIssuer,
+): Promise<SessionEntryCreateWithTranscriptResult<TError>> {
   const storePath = resolveAccessStorePath(scope);
   const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
   const store = Object.fromEntries(
@@ -114,32 +159,56 @@ export async function createSessionEntryWithTranscript<TError = string>(
     return { ok: false, error: created.error, phase: "entry" };
   }
 
+  const entry = created.entry;
+  // Issuers attest the first logical owner only. An adopted legacy row must
+  // backfill ambiguous instead of binding its missing snapshot to this caller.
+  const firstWriteMemorySubjectIssuer = resolved.existing ? undefined : memorySubjectIssuer;
+  const transcriptScope = {
+    ...resolveSqliteScope({
+      agentId,
+      ...(scope.env ? { env: scope.env } : {}),
+      sessionKey: resolved.normalizedKey,
+      storePath,
+    }),
+    sessionId: entry.sessionId,
+  };
   try {
-    await appendSqliteTranscriptEvent(
-      {
-        agentId,
-        sessionId: created.entry.sessionId,
-        sessionKey: resolved.normalizedKey,
-        storePath,
+    await applySqliteSessionEntryLifecycleMutationWithTrustedMemorySubjects({
+      agentId,
+      storePath,
+      removals: resolved.legacyKeys.map((sessionKey) => ({ sessionKey })),
+      upserts: [
+        {
+          sessionKey: resolved.normalizedKey,
+          entry,
+          ...(firstWriteMemorySubjectIssuer
+            ? { memorySubjectIssuer: firstWriteMemorySubjectIssuer }
+            : {}),
+        },
+      ],
+      skipMaintenance: true,
+      afterUpsertsInTransaction: (database) => {
+        try {
+          appendTranscriptEventInTransaction(
+            database,
+            transcriptScope,
+            createSessionTranscriptHeader({ cwd: options.cwd, sessionId: entry.sessionId }),
+          );
+        } catch (error) {
+          throw new SessionTranscriptInitializationError(error);
+        }
       },
-      createSessionTranscriptHeader({ cwd: options.cwd, sessionId: created.entry.sessionId }),
-    );
+    });
   } catch (err) {
+    if (!(err instanceof SessionTranscriptInitializationError)) {
+      throw err;
+    }
     return {
       ok: false,
       error: formatErrorMessage(err),
       phase: "transcript",
     };
   }
-
-  const entry = created.entry;
-  await applySessionEntryLifecycleMutation({
-    agentId,
-    storePath,
-    removals: resolved.legacyKeys.map((sessionKey) => ({ sessionKey })),
-    upserts: [{ sessionKey: resolved.normalizedKey, entry }],
-    skipMaintenance: true,
-  });
   return { ok: true, entry, sessionFile: resolved.normalizedKey };
 }
 
@@ -323,6 +392,14 @@ export async function recordInboundSessionMeta(
   params: RecordInboundSessionMetaParams,
 ): Promise<SessionEntry | null> {
   return await recordSqliteInboundSessionMeta(params);
+}
+
+/** Core-only inbound metadata writer carrying a non-serializable subject issuer. */
+export async function recordInboundSessionMetaWithTrustedMemorySubject(
+  params: RecordInboundSessionMetaParams,
+  memorySubjectIssuer: TrustedSessionMemorySubjectIssuer,
+): Promise<SessionEntry | null> {
+  return await recordSqliteInboundSessionMetaWithTrustedMemorySubject(params, memorySubjectIssuer);
 }
 
 /**

--- a/src/config/sessions/session-accessor.parent-fork.test.ts
+++ b/src/config/sessions/session-accessor.parent-fork.test.ts
@@ -3,9 +3,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { SessionManager } from "../../agents/sessions/session-manager.js";
 import { parseSqliteSessionFileMarker } from "./legacy-sqlite-marker.js";
+import { createSessionEntryWithTrustedMemorySubject } from "./session-accessor.entry-mutation.js";
 import {
   forkSessionEntryFromParentTarget,
   forkSessionFromParentTranscript,
@@ -14,6 +15,33 @@ import {
   replaceSessionEntry,
   replaceTranscriptEvents,
 } from "./session-accessor.js";
+import { readCurrentSessionMemorySubject } from "./session-memory-subject-access.js";
+import {
+  createTrustedSessionMemorySubjectIssuer,
+  createTrustedSessionMemorySubjectSeed,
+} from "./session-memory-subject-trust.js";
+
+const sourceReadProbe = vi.hoisted(() => ({
+  active: false,
+  transactionStates: [] as boolean[],
+}));
+
+vi.mock("./session-accessor.sqlite-read.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./session-accessor.sqlite-read.js")>();
+  return {
+    ...actual,
+    loadSqliteTranscriptEventsFromDatabase: (
+      database: Parameters<typeof actual.loadSqliteTranscriptEventsFromDatabase>[0],
+      sessionId: Parameters<typeof actual.loadSqliteTranscriptEventsFromDatabase>[1],
+      beforeEventSeq?: Parameters<typeof actual.loadSqliteTranscriptEventsFromDatabase>[2],
+    ) => {
+      if (sourceReadProbe.active) {
+        sourceReadProbe.transactionStates.push(database.db.isTransaction);
+      }
+      return actual.loadSqliteTranscriptEventsFromDatabase(database, sessionId, beforeEventSeq);
+    },
+  };
+});
 
 const roots: string[] = [];
 
@@ -68,10 +96,81 @@ function openForkedChildSession(storePath: string, sessionId: string): SessionMa
 }
 
 afterEach(async () => {
+  sourceReadProbe.active = false;
+  sourceReadProbe.transactionStates.length = 0;
   await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
 });
 
 describe("forkSessionFromParentTranscript", () => {
+  it("captures a cross-store transcript and subject under one source transaction", async () => {
+    const root = await makeRoot("openclaw-parent-fork-cross-store-snapshot-");
+    const sourceStorePath = path.join(root, "main", "sessions.json");
+    const targetStorePath = path.join(root, "worker", "sessions.json");
+    await Promise.all([
+      fs.mkdir(path.dirname(sourceStorePath), { recursive: true }),
+      fs.mkdir(path.dirname(targetStorePath), { recursive: true }),
+    ]);
+    const parentSessionId = "cross-store-parent";
+    const parentSessionKey = "agent:main:main";
+    const childSessionKey = "agent:worker:child";
+    const seed = createTrustedSessionMemorySubjectSeed({
+      subject: { version: 1, kind: "service", principalId: "cross-store-source" },
+      subjectRevision: "cross-store-source-revision",
+    });
+    const createdParent = await createSessionEntryWithTrustedMemorySubject(
+      { agentId: "main", sessionKey: parentSessionKey, storePath: sourceStorePath },
+      () => ({ ok: true as const, entry: { sessionId: parentSessionId, updatedAt: 1 } }),
+      createTrustedSessionMemorySubjectIssuer(() => seed),
+    );
+    expect(createdParent.ok).toBe(true);
+    await seedParentTranscript({
+      storePath: sourceStorePath,
+      parentSessionId,
+      events: [
+        { type: "session", version: 3, id: parentSessionId, timestamp: "2026-08-09T00:00:00Z" },
+        {
+          type: "message",
+          id: "source-message",
+          parentId: null,
+          message: { role: "user", content: "copy this source snapshot" },
+        },
+      ],
+    });
+
+    sourceReadProbe.active = true;
+    let forked: Awaited<ReturnType<typeof forkSessionFromParentTranscript>> | undefined;
+    try {
+      forked = await forkSessionFromParentTranscript({
+        parentEntry: { sessionId: parentSessionId, updatedAt: 1 },
+        agentId: "main",
+        parentSessionKey,
+        sessionKey: childSessionKey,
+        storePath: sourceStorePath,
+        targetStorePath,
+      });
+    } finally {
+      sourceReadProbe.active = false;
+    }
+
+    expect(forked?.status).toBe("created");
+    // The pre-fix path read the transcript before entering the source transaction,
+    // allowing a reset/rebind to mix generations before it copied the subject.
+    expect(sourceReadProbe.transactionStates).toEqual([true]);
+    if (forked?.status !== "created") {
+      throw new Error("expected cross-store fork");
+    }
+    expect(
+      readCurrentSessionMemorySubject({
+        agentId: "worker",
+        sessionKey: childSessionKey,
+        storePath: targetStorePath,
+      }),
+    ).toMatchObject({
+      subject: seed.subject,
+      subjectRevision: seed.subjectRevision,
+    });
+  });
+
   it("forks the active branch without synchronously opening the session manager", async () => {
     const root = await makeRoot("openclaw-parent-fork-");
     const sessionsDir = path.join(root, "sessions");

--- a/src/config/sessions/session-accessor.sqlite-canonical-repair.ts
+++ b/src/config/sessions/session-accessor.sqlite-canonical-repair.ts
@@ -29,6 +29,7 @@ import { bindSqliteSessionWindowEntryProjection } from "./session-accessor.sqlit
 import { parseSqliteSessionEntryJson } from "./session-accessor.sqlite-status.js";
 import type { SessionEntryListScope } from "./session-accessor.types.js";
 import { canonicalSessionKeyMigrationRequiredError } from "./session-canonical-key.js";
+import { copySessionMemorySubjectStateForCanonicalRepair } from "./session-memory-subject-persistence.js";
 import {
   deleteSessionTranscriptIndexInTransaction,
   reconcileSessionTranscriptIndexInTransaction,
@@ -553,6 +554,17 @@ function copySqliteSessionOwnedStateForRepair(params: {
           conflict.column("session_id").doUpdateSet({ session_key: params.canonicalKey }),
         ),
     );
+  }
+  const sourceSubjectKey =
+    params.preferredSessionKey ?? (sourceKeys.length === 1 ? sourceKeys[0] : undefined);
+  if (sourceSubjectKey) {
+    copySessionMemorySubjectStateForCanonicalRepair({
+      canonicalKey: params.canonicalKey,
+      destination: params.destination,
+      sessionIds,
+      source: params.source,
+      sourceSessionKey: sourceSubjectKey,
+    });
   }
   for (const link of sessionLinks) {
     executeSqliteQuerySync(

--- a/src/config/sessions/session-accessor.sqlite-checkpoint.ts
+++ b/src/config/sessions/session-accessor.sqlite-checkpoint.ts
@@ -14,7 +14,6 @@ import {
 } from "./session-accessor.sqlite-entry-store.js";
 import { emitCommittedSessionIdentityDiff } from "./session-accessor.sqlite-identity.js";
 import {
-  formatSqliteSessionReferenceForScope,
   getSessionKysely,
   normalizeSqliteSessionKey,
   resolveSqliteScope,
@@ -26,6 +25,7 @@ import {
   appendTranscriptEventsInTransaction,
   readTranscriptIdentityByEventId,
 } from "./session-accessor.sqlite-transcript-store.js";
+import { prepareCurrentSessionMemorySubjectLineageSeedInTransaction } from "./session-memory-subject.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import {
   SESSION_TOTAL_TOKENS_VERSION,
@@ -46,6 +46,13 @@ type SqliteCompactionCheckpointLegacySource = {
   events: TranscriptEvent[];
   sessionFile: string;
   sourceLeafId?: string;
+  totalTokens?: number;
+};
+
+type SqliteCheckpointTranscriptFork = {
+  cwd?: string;
+  events: TranscriptEvent[];
+  sessionId: string;
   totalTokens?: number;
 };
 
@@ -183,15 +190,18 @@ function branchSqliteCompactionCheckpointSessionInTransaction(
   if (!checkpoint) {
     return { status: "missing-checkpoint" };
   }
-  const forked = forkSqliteCheckpointTranscriptInTransaction(database, params.resolved, {
+  const forked = prepareSqliteCheckpointTranscriptForkInTransaction(database, {
     checkpoint,
     legacySource: params.legacySource,
-    targetSessionKey: params.targetKey,
   });
   if (forked.status !== "created") {
     return forked;
   }
 
+  const lineageSeed = prepareCurrentSessionMemorySubjectLineageSeedInTransaction(
+    database,
+    params.sourceKey,
+  );
   const label = currentEntry.label?.trim()
     ? `${currentEntry.label.trim()} (checkpoint)`
     : "Checkpoint branch";
@@ -202,7 +212,17 @@ function branchSqliteCompactionCheckpointSessionInTransaction(
     parentSessionKey: params.parentSessionKey,
     totalTokens: forked.totalTokens,
   });
-  writeSessionEntry(database, params.targetKey, nextEntry);
+  // The child header materializes its root when no entry exists. Persist the
+  // lineage-seeded entry first so it cannot capture an unbound subject.
+  writeSessionEntry(database, params.targetKey, nextEntry, {
+    ...(lineageSeed ? { memorySubjectSeed: lineageSeed } : {}),
+  });
+  appendSqliteCheckpointTranscriptForkInTransaction(
+    database,
+    params.resolved,
+    params.targetKey,
+    forked,
+  );
   return {
     status: "created",
     key: params.targetKey,
@@ -232,22 +252,35 @@ function restoreSqliteCompactionCheckpointSessionInTransaction(
   if (!checkpoint) {
     return { status: "missing-checkpoint" };
   }
-  const restored = forkSqliteCheckpointTranscriptInTransaction(database, params.resolved, {
+  const restored = prepareSqliteCheckpointTranscriptForkInTransaction(database, {
     checkpoint,
     legacySource: params.legacySource,
-    targetSessionKey: params.targetKey,
   });
   if (restored.status !== "created") {
     return restored;
   }
 
+  const lineageSeed = prepareCurrentSessionMemorySubjectLineageSeedInTransaction(
+    database,
+    params.sourceKey,
+  );
   const nextEntry = cloneSqliteCheckpointSessionEntry({
     currentEntry,
     nextSessionId: restored.sessionId,
     preserveCompactionCheckpoints: true,
     totalTokens: restored.totalTokens,
   });
-  writeSessionEntry(database, params.targetKey, nextEntry);
+  // A restore replaces its source node, so capture lineage before the write and
+  // persist the child entry before its header establishes a transcript root.
+  writeSessionEntry(database, params.targetKey, nextEntry, {
+    ...(lineageSeed ? { memorySubjectSeed: lineageSeed } : {}),
+  });
+  appendSqliteCheckpointTranscriptForkInTransaction(
+    database,
+    params.resolved,
+    params.targetKey,
+    restored,
+  );
   return {
     status: "created",
     key: params.targetKey,
@@ -256,21 +289,14 @@ function restoreSqliteCompactionCheckpointSessionInTransaction(
   };
 }
 
-function forkSqliteCheckpointTranscriptInTransaction(
+function prepareSqliteCheckpointTranscriptForkInTransaction(
   database: OpenClawAgentDatabase,
-  resolved: ResolvedSqliteScope,
   params: {
     checkpoint: SessionCompactionCheckpoint;
     legacySource?: SqliteCompactionCheckpointLegacySource;
-    targetSessionKey: string;
   },
 ):
-  | {
-      status: "created";
-      sessionId: string;
-      sessionFile: string;
-      totalTokens?: number;
-    }
+  | ({ status: "created" } & SqliteCheckpointTranscriptFork)
   | { status: "missing-boundary" }
   | { status: "failed" } {
   const sources = resolveSqliteCheckpointTranscriptForkSources(params.checkpoint);
@@ -302,27 +328,35 @@ function forkSqliteCheckpointTranscriptInTransaction(
   }
 
   const sessionId = randomUUID();
-  const targetScope = {
-    ...resolved,
-    sessionId,
-    sessionKey: params.targetSessionKey,
-  };
-  const sessionFile = formatSqliteSessionReferenceForScope(targetScope);
   const selectedEvents = selected?.rows ?? legacySource?.events ?? [];
   const totalTokens = selected?.source.totalTokens ?? legacySource?.totalTokens;
-  appendTranscriptEventsInTransaction(database, targetScope, [
-    createSessionTranscriptHeader({
-      cwd: readTranscriptHeaderCwd(selectedEvents),
-      sessionId,
-    }),
-    ...selectedEvents.filter((event) => !isSessionTranscriptHeader(event)),
-  ]);
   return {
     status: "created",
+    cwd: readTranscriptHeaderCwd(selectedEvents),
+    events: selectedEvents.filter((event) => !isSessionTranscriptHeader(event)),
     sessionId,
-    sessionFile,
     ...(typeof totalTokens === "number" ? { totalTokens } : {}),
   };
+}
+
+function appendSqliteCheckpointTranscriptForkInTransaction(
+  database: OpenClawAgentDatabase,
+  resolved: ResolvedSqliteScope,
+  targetSessionKey: string,
+  forked: SqliteCheckpointTranscriptFork,
+): void {
+  appendTranscriptEventsInTransaction(
+    database,
+    {
+      ...resolved,
+      sessionId: forked.sessionId,
+      sessionKey: targetSessionKey,
+    },
+    [
+      createSessionTranscriptHeader({ cwd: forked.cwd, sessionId: forked.sessionId }),
+      ...forked.events,
+    ],
+  );
 }
 
 function resolvePreparedLegacyCheckpointSource(

--- a/src/config/sessions/session-accessor.sqlite-contract.ts
+++ b/src/config/sessions/session-accessor.sqlite-contract.ts
@@ -14,6 +14,8 @@ import type {
   SessionLifecycleArtifactCleanupResult,
   SessionLifecycleStoreTarget,
 } from "./session-accessor.lifecycle-types.js";
+import type { TranscriptMemorySubjectRootOptions } from "./session-accessor.sqlite-transcript-state.js";
+import type { TrustedSessionMemorySubjectSeed } from "./session-memory-subject-trust.js";
 import type { ResolvedSessionMaintenanceConfig } from "./store-maintenance.js";
 import type { TranscriptEntryAnchor } from "./transcript-entry-anchor.js";
 import type { SessionEntry } from "./types.js";
@@ -121,7 +123,7 @@ export type {
   SessionTranscriptVisibleMessageDeltaResult,
 } from "./session-accessor.types.js";
 
-export type TranscriptMessageAppendOptions<TMessage> = {
+export type TranscriptMessageAppendOptions<TMessage> = TranscriptMemorySubjectRootOptions & {
   appendIntent?: "active-branch";
   config?: OpenClawConfig;
   cwd?: string;
@@ -175,6 +177,8 @@ export type SessionEntryPatchOptions = {
   replaceEntry?: boolean;
   skipMaintenance?: boolean;
   takeCacheOwnership?: boolean;
+  /** Host-branded provenance used only when this mutation creates a logical session. */
+  memorySubjectSeed?: TrustedSessionMemorySubjectSeed;
 };
 
 export type SessionEntryPatchContext = {

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -42,6 +42,13 @@ import {
   canonicalSessionKeyMigrationRequiredError,
 } from "./session-canonical-key.js";
 import { parseSqliteSessionEntryRecord } from "./session-entry-json.js";
+import {
+  persistSessionMemorySubjectInTransaction,
+  rehomeSessionMemorySubjectAliases,
+  tryRehomeSessionMemorySubjectSnapshot,
+  type TrustedSessionMemorySubjectIssuer,
+  type TrustedSessionMemorySubjectSeed,
+} from "./session-memory-subject.js";
 import { projectCanonicalSessionEntryShape } from "./store-entry-shape.js";
 import {
   collectSessionEntryLookupKeys,
@@ -376,13 +383,25 @@ export function deleteSqliteSessionEntryRows(
         : false;
     });
     if (survivingNode) {
-      executeSqliteQuerySync(
-        database.db,
-        db
-          .updateTable("session_windows")
-          .set({ session_key: survivingNode.session_key })
-          .where("session_id", "=", window.session_id),
-      );
+      // A retained transcript window may only follow a new logical key when
+      // both immutable subjects match. Otherwise preserve its source tombstone
+      // rather than letting deletion turn a cross-key reference into lineage.
+      if (
+        tryRehomeSessionMemorySubjectSnapshot({
+          database,
+          sessionId: window.session_id,
+          sourceSessionKey: sessionKey,
+          targetSessionKey: survivingNode.session_key,
+        })
+      ) {
+        executeSqliteQuerySync(
+          database.db,
+          db
+            .updateTable("session_windows")
+            .set({ session_key: survivingNode.session_key })
+            .where("session_id", "=", window.session_id),
+        );
+      }
     }
   }
   if (options.deleteOwnedWindows) {
@@ -538,6 +557,9 @@ export function deleteLegacySessionEntryRows(
   if (legacyKeys.length === 0) {
     return;
   }
+  // Subject snapshots reference the logical key independently from transcript
+  // windows, so move immutable provenance before alias deletion can cascade it.
+  rehomeSessionMemorySubjectAliases(database, sessionKey, legacyKeys);
   const db = getSessionKysely(database.db);
   for (const legacyKey of legacyKeys) {
     if (legacyKey === sessionKey) {
@@ -575,13 +597,75 @@ export function rehomeSqliteSessionWindows(
   );
 }
 
+function hasExistingLogicalSessionIdentity(params: {
+  database: OpenClawAgentDatabase;
+  entry: SessionEntry;
+  sessionKey: string;
+  aliasSourceSessionKeys?: Iterable<string>;
+}): boolean {
+  const { database, entry, sessionKey } = params;
+  const db = getSessionKysely(database.db);
+  const sessionKeys = uniqueStrings(
+    [
+      ...collectSessionEntryLookupKeys(database, sessionKey),
+      ...(params.aliasSourceSessionKeys ?? []),
+    ].map((key) => key.trim()),
+  ).filter(Boolean);
+  const sessionIds = uniqueStrings(
+    [entry.sessionId, entry.previousSessionId]
+      .map((value) => value?.trim())
+      .filter((value): value is string => Boolean(value)),
+  );
+
+  // A node or window can outlive its parsed entry during repair, alias migration, or
+  // transcript adoption. An issuer may mint authority only for a truly new logical session.
+  return Boolean(
+    executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("session_nodes")
+        .select("session_key")
+        .where("session_key", "in", sessionKeys)
+        .limit(1),
+    ) ??
+    executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("session_nodes")
+        .select("session_key")
+        .where("current_session_id", "in", sessionIds)
+        .limit(1),
+    ) ??
+    executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("session_windows")
+        .select("session_id")
+        .where("session_key", "in", sessionKeys)
+        .limit(1),
+    ) ??
+    executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("session_windows")
+        .select("session_id")
+        .where("session_id", "in", sessionIds)
+        .limit(1),
+    ),
+  );
+}
+
 export function writeSessionEntry(
   database: OpenClawAgentDatabase,
   sessionKey: string,
   entry: SessionEntry,
   options: {
     allowStoredAliases?: boolean;
+    deferMemorySubjectPersistence?: true;
     preserveNodeSuggestions?: boolean;
+    memorySubjectIssuer?: TrustedSessionMemorySubjectIssuer;
+    memorySubjectSeed?: TrustedSessionMemorySubjectSeed;
+    memorySubjectAliasSourceKeys?: Iterable<string>;
     previousEntry?: SessionEntry | null;
   } = {},
 ): void {
@@ -642,6 +726,16 @@ export function writeSessionEntry(
     entry: normalizedEntry,
     sessionScope: boundSessionRoot.session_scope,
   });
+  const memorySubjectIssuer =
+    options.memorySubjectIssuer &&
+    !hasExistingLogicalSessionIdentity({
+      database,
+      entry: normalizedEntry,
+      sessionKey,
+      aliasSourceSessionKeys: options.memorySubjectAliasSourceKeys,
+    })
+      ? options.memorySubjectIssuer
+      : undefined;
   if (conversation) {
     upsertConversationIdentity(database, conversation.identity, updatedAt);
   }
@@ -738,6 +832,20 @@ export function writeSessionEntry(
       sessionId: sessionRow.session_id,
       conversation,
       updatedAt,
+    });
+  }
+  if (!options.deferMemorySubjectPersistence) {
+    persistSessionMemorySubjectInTransaction({
+      database,
+      sessionKey,
+      sessionId: sessionRow.session_id,
+      sessionScope: boundSessionRoot.session_scope,
+      ...(memorySubjectIssuer ? { issuer: memorySubjectIssuer } : {}),
+      ...(options.memorySubjectSeed ? { seed: options.memorySubjectSeed } : {}),
+      ...(options.memorySubjectAliasSourceKeys
+        ? { aliasSourceSessionKeys: options.memorySubjectAliasSourceKeys }
+        : {}),
+      now: updatedAt,
     });
   }
   publishSqliteSessionEntryCacheInvalidation(database, sessionNode);

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -73,6 +73,7 @@ import {
 import { preserveSqliteSameKeySessionRolloverLineage } from "./session-entry-lineage.js";
 import { buildSessionCreationStamp } from "./session-entry-provenance.js";
 import { kickSessionHistoryDiskBudgetMaintenance } from "./session-history-eviction.js";
+import type { TrustedSessionMemorySubjectIssuer } from "./session-memory-subject.js";
 import { resolveSessionStorePathForScope } from "./session-store-path.js";
 import { resolveDeliveryProvenCanonicalSessionKey } from "./store-entry.js";
 import type { GroupKeyResolution, SessionEntry } from "./types.js";
@@ -81,6 +82,7 @@ import { mergeSessionEntry, mergeSessionEntryPreserveActivity } from "./types.js
 // Public entry API. Async preparation precedes BEGIN; commit revalidates repository snapshots.
 
 type SqliteSessionEntryPatchOptions = SessionEntryPatchOptions & {
+  memorySubjectIssuer?: TrustedSessionMemorySubjectIssuer;
   skipMaintenance?: boolean;
 };
 
@@ -419,6 +421,18 @@ export async function upsertSqliteSessionEntry(
   });
 }
 
+/** Core-only first-writer path; the issuer is never part of stable accessor options. */
+export async function upsertSqliteSessionEntryWithTrustedMemorySubject(
+  scope: SessionAccessScope,
+  patch: Partial<SessionEntry>,
+  memorySubjectIssuer: TrustedSessionMemorySubjectIssuer,
+): Promise<SessionEntry | null> {
+  return await patchSqliteSessionEntryWithOptions(scope, () => patch, {
+    fallbackEntry: createFallbackSessionEntry(patch),
+    memorySubjectIssuer,
+  });
+}
+
 /** Replaces one entry in the additive SQLite session store. */
 export async function replaceSqliteSessionEntry(
   scope: SessionAccessScope,
@@ -484,6 +498,17 @@ export async function patchSqliteSessionEntry(
     entry: SessionEntry,
     context: SessionEntryPatchContext,
   ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryPatchOptions = {},
+): Promise<SessionEntry | null> {
+  return await patchSqliteSessionEntryWithOptions(scope, update, options);
+}
+
+async function patchSqliteSessionEntryWithOptions(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+    context: SessionEntryPatchContext,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
   options: SqliteSessionEntryPatchOptions = {},
 ): Promise<SessionEntry | null> {
   const resolved = resolveSqliteScope(scope);
@@ -512,6 +537,33 @@ export async function patchSqliteSessionEntry(
 
 /** Patches one logical entry selected from a canonical key and alias set. */
 export async function patchSqliteSessionEntryTarget(
+  scope: SessionEntryTargetPatchScope,
+  update: (
+    entry: SessionEntry,
+    context: SessionEntryPatchContext,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryPatchOptions = {},
+): Promise<SessionEntry | null> {
+  return await patchSqliteSessionEntryTargetWithOptions(scope, update, options);
+}
+
+/** Core-only target patch path; the issuer is intentionally separate from public options. */
+export async function patchSqliteSessionEntryTargetWithTrustedMemorySubject(
+  scope: SessionEntryTargetPatchScope,
+  update: (
+    entry: SessionEntry,
+    context: SessionEntryPatchContext,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  memorySubjectIssuer: TrustedSessionMemorySubjectIssuer,
+  options: SessionEntryPatchOptions = {},
+): Promise<SessionEntry | null> {
+  return await patchSqliteSessionEntryTargetWithOptions(scope, update, {
+    ...options,
+    memorySubjectIssuer,
+  });
+}
+
+async function patchSqliteSessionEntryTargetWithOptions(
   scope: SessionEntryTargetPatchScope,
   update: (
     entry: SessionEntry,
@@ -610,6 +662,10 @@ async function patchSqliteSessionEntrySnapshot<TSnapshot>(
       const selectedPreviousEntry = params.existingEntry(fresh) ?? writeBase;
       writeSessionEntry(writeDatabase, sessionKey, next, {
         previousEntry: selectedPreviousEntry,
+        ...(options.memorySubjectIssuer
+          ? { memorySubjectIssuer: options.memorySubjectIssuer }
+          : {}),
+        memorySubjectAliasSourceKeys: legacyKeys,
       });
       if (params.rehomeWindows) {
         rehomeSqliteSessionWindows(writeDatabase, sessionKey, legacyKeys);
@@ -655,8 +711,35 @@ export async function recordSqliteInboundSessionMeta(params: {
   groupResolution?: GroupKeyResolution | null;
   createIfMissing?: boolean;
 }): Promise<SessionEntry | null> {
+  return await recordSqliteInboundSessionMetaWithOptions(params);
+}
+
+/** Core-only inbound first-writer path; do not expose this issuer through accessor options. */
+export async function recordSqliteInboundSessionMetaWithTrustedMemorySubject(
+  params: {
+    storePath: string;
+    sessionKey: string;
+    ctx: MsgContext;
+    groupResolution?: GroupKeyResolution | null;
+    createIfMissing?: boolean;
+  },
+  memorySubjectIssuer: TrustedSessionMemorySubjectIssuer,
+): Promise<SessionEntry | null> {
+  return await recordSqliteInboundSessionMetaWithOptions(params, memorySubjectIssuer);
+}
+
+async function recordSqliteInboundSessionMetaWithOptions(
+  params: {
+    storePath: string;
+    sessionKey: string;
+    ctx: MsgContext;
+    groupResolution?: GroupKeyResolution | null;
+    createIfMissing?: boolean;
+  },
+  memorySubjectIssuer?: TrustedSessionMemorySubjectIssuer,
+): Promise<SessionEntry | null> {
   const createIfMissing = params.createIfMissing ?? true;
-  return await patchSqliteSessionEntry(
+  return await patchSqliteSessionEntryWithOptions(
     { sessionKey: params.sessionKey, storePath: params.storePath },
     (_entry, context) => {
       const metadataPatch = deriveSessionMetaPatch({
@@ -683,6 +766,7 @@ export async function recordSqliteInboundSessionMeta(params: {
       // Inbound metadata must not refresh activity timestamps; idle reset
       // evaluation relies on updatedAt from actual session turns.
       preserveActivity: true,
+      ...(memorySubjectIssuer ? { memorySubjectIssuer } : {}),
       ...(createIfMissing ? { fallbackEntry: mergeSessionEntry(undefined, {}) } : {}),
     },
   );

--- a/src/config/sessions/session-accessor.sqlite-import.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.ts
@@ -15,6 +15,7 @@ import {
   touchTranscriptMutationInTransaction,
 } from "./session-accessor.sqlite-transcript-state.js";
 import { appendTranscriptEventInTransaction } from "./session-accessor.sqlite-transcript-store.js";
+import type { TrustedSessionMemorySubjectSeed } from "./session-memory-subject-trust.js";
 import { reconcileSessionTranscriptIndexInTransaction } from "./session-transcript-index.js";
 import type { SessionEntry } from "./types.js";
 
@@ -27,6 +28,8 @@ type SqliteSessionImportRowsParams = {
   storePath?: string;
   sessionKey: string;
   entry: SessionEntry;
+  /** Exact host-trusted provenance for an import whose source lineage was confirmed. */
+  confirmedMemorySubjectLineage?: TrustedSessionMemorySubjectSeed;
   readTranscriptEvents?: (append: (event: TranscriptEvent) => void) => void;
   transcriptMtimeMs?: number;
 };
@@ -84,6 +87,9 @@ export async function importSqliteSessionRows(
       writeSessionEntry(database, resolved.sessionKey, importedEntry, {
         allowStoredAliases: true,
         previousEntry: currentEntry ?? null,
+        ...(params.confirmedMemorySubjectLineage
+          ? { memorySubjectSeed: params.confirmedMemorySubjectLineage }
+          : {}),
       });
       if (params.readTranscriptEvents) {
         const transcriptScope = {

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
@@ -15,7 +15,6 @@ import {
 } from "./session-accessor.sqlite-archive.js";
 import type {
   SessionEntryLifecycleRemoval,
-  SessionEntryLifecycleUpsert,
   SessionLifecycleArchivedTranscript,
 } from "./session-accessor.sqlite-contract.js";
 import { readSqliteSessionStateDeleteSnapshot } from "./session-accessor.sqlite-delete-snapshot.js";
@@ -30,6 +29,7 @@ import type {
   SqliteLifecycleArtifactCleanupPlan,
   SqliteProjectedLifecycleMutation,
   SqliteSessionEntryRemovalPlan,
+  TrustedSqliteSessionEntryLifecycleUpsert,
 } from "./session-accessor.sqlite-lifecycle-types.js";
 import { normalizeSqliteNumber } from "./session-accessor.sqlite-normalize.js";
 import { loadSqliteTranscriptEventsFromDatabase } from "./session-accessor.sqlite-read.js";
@@ -308,7 +308,7 @@ export async function projectSqliteSessionEntryLifecycleMutation(
     allowCanonicalRepair?: boolean;
     archiveDirectory: string;
     removals: readonly SessionEntryLifecycleRemoval[];
-    upserts: readonly SessionEntryLifecycleUpsert[];
+    upserts: readonly TrustedSqliteSessionEntryLifecycleUpsert[];
   },
 ): Promise<SqliteProjectedLifecycleMutation> {
   const store = readSqliteSessionEntryStore(database, {
@@ -385,6 +385,10 @@ export async function projectSqliteSessionEntryLifecycleMutation(
       expectedEntry,
       sessionKey,
       entry: cloned,
+      ...(upsert.deferMemorySubjectPersistence
+        ? { deferMemorySubjectPersistence: true as const }
+        : {}),
+      ...(upsert.memorySubjectIssuer ? { memorySubjectIssuer: upsert.memorySubjectIssuer } : {}),
       ...(resetBoundaryPlan ? { resetBoundaryPlan } : {}),
     });
   }

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-types.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-types.ts
@@ -1,5 +1,9 @@
 import type { SqliteSessionStateDeletePlan } from "./session-accessor.sqlite-archive.js";
-import type { SessionEntryLifecycleRemoval } from "./session-accessor.sqlite-contract.js";
+import type {
+  SessionEntryLifecycleRemoval,
+  SessionEntryLifecycleUpsert,
+} from "./session-accessor.sqlite-contract.js";
+import type { TrustedSessionMemorySubjectIssuer } from "./session-memory-subject-trust.js";
 import type { SessionResetBoundaryPlan } from "./session-reset-boundary-event.js";
 import type { SessionEntry } from "./types.js";
 
@@ -17,6 +21,14 @@ export type SqliteLifecycleArtifactCleanupPlan = {
   deletePlans: SqliteSessionStateDeletePlan[];
   entries: SqliteSessionEntryRemovalPlan[];
 };
+
+/** Internal-only trusted issuer retained until the synchronous SQLite commit. */
+export type TrustedSqliteSessionEntryLifecycleUpsert = SessionEntryLifecycleUpsert & {
+  /** Doctor-only: a selected cross-store subject is copied after its node/window rows exist. */
+  deferMemorySubjectPersistence?: true;
+  memorySubjectIssuer?: TrustedSessionMemorySubjectIssuer;
+};
+
 export type SqliteProjectedLifecycleMutation = {
   deletePlans: SqliteSessionStateDeletePlan[];
   removals: Array<{
@@ -25,8 +37,10 @@ export type SqliteProjectedLifecycleMutation = {
     sessionKey: string;
   }>;
   upsertedEntries: Array<{
+    deferMemorySubjectPersistence?: true;
     entry: SessionEntry;
     expectedEntry: SessionEntry | undefined;
+    memorySubjectIssuer?: TrustedSessionMemorySubjectIssuer;
     resetBoundaryPlan?: SessionResetBoundaryPlan;
     sessionKey: string;
   }>;

--- a/src/config/sessions/session-accessor.sqlite-message-cut.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.ts
@@ -38,6 +38,7 @@ import type {
 } from "./session-accessor.types.js";
 import { buildSessionCreationStamp } from "./session-entry-provenance.js";
 import { inheritSessionSelection } from "./session-entry-selection.js";
+import { prepareCurrentSessionMemorySubjectLineageSeedInTransaction } from "./session-memory-subject.js";
 import { reconcileSessionTranscriptIndexInTransaction } from "./session-transcript-index.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import {
@@ -257,6 +258,10 @@ function mutateSqliteSessionAtMessageInTransaction(
   if (!currentEntry?.sessionId) {
     return { status: "missing-session" };
   }
+  const lineageSeed = prepareCurrentSessionMemorySubjectLineageSeedInTransaction(
+    database,
+    params.sourceKey,
+  );
   const events = loadSqliteTranscriptEventsFromDatabase(database, currentEntry.sessionId);
   const cut = params.mode === "switch" ? undefined : resolveMessageCut(events, params.entryId);
   if (cut && "status" in cut) {
@@ -293,11 +298,6 @@ function mutateSqliteSessionAtMessageInTransaction(
             targetId: params.mode === "switch" ? params.entryId : (cut?.parentId ?? null),
           },
         ];
-  appendTranscriptEventsInTransaction(database, targetScope, nextEvents);
-  if (params.mode !== "fork") {
-    reconcileSessionTranscriptIndexInTransaction(database.db, nextSessionId);
-  }
-
   // Rotating transcript identity fences stale live managers: later snapshot-replace writes
   // target the old session and cannot erase this leaf repoint from the active session.
   const nextEntry = {
@@ -318,7 +318,15 @@ function mutateSqliteSessionAtMessageInTransaction(
       ? buildSessionCreationStamp(params.creation)
       : {}),
   };
-  writeSessionEntry(database, params.targetKey, nextEntry);
+  writeSessionEntry(database, params.targetKey, nextEntry, {
+    ...(lineageSeed ? { memorySubjectSeed: lineageSeed } : {}),
+  });
+  // The child/root entry owns the immutable subject before transcript rows can
+  // materialize a window, preserving exact same-database lineage.
+  appendTranscriptEventsInTransaction(database, targetScope, nextEvents);
+  if (params.mode !== "fork") {
+    reconcileSessionTranscriptIndexInTransaction(database.db, nextSessionId);
+  }
   return {
     status: "created",
     key: params.targetKey,

--- a/src/config/sessions/session-accessor.sqlite-parent-session.ts
+++ b/src/config/sessions/session-accessor.sqlite-parent-session.ts
@@ -48,6 +48,10 @@ import {
 } from "./session-accessor.sqlite-scope.js";
 import { appendTranscriptEventsInTransaction } from "./session-accessor.sqlite-transcript-store.js";
 import { preserveSqliteSameKeySessionRolloverLineage } from "./session-entry-lineage.js";
+import {
+  prepareCurrentSessionMemorySubjectLineageSeedInTransaction,
+  type SessionMemoryScope,
+} from "./session-memory-subject.js";
 import type { InternalSessionEntry, SessionEntry } from "./types.js";
 import { mergeSessionEntry, resolveFreshSessionTotalTokens } from "./types.js";
 
@@ -70,12 +74,25 @@ export async function forkSqliteSessionTranscriptFromParent(
     return await runExclusiveSqliteSessionWrite(resolved, async () => {
       let result: ForkSessionFromParentTranscriptResult = { status: "failed" };
       runOpenClawAgentWriteTransaction((database) => {
-        result = forkSqliteParentTranscriptInTransaction(database, resolved, {
+        const fork = prepareSqliteParentTranscriptForkInTransaction(database, resolved, {
           parentEntry: params.parentEntry,
           parentSessionKey: params.parentSessionKey,
           targetSessionId: params.targetSessionId,
           targetSessionKey: params.sessionKey,
         });
+        if (fork.status !== "created") {
+          result = fork;
+          return;
+        }
+        // The forked transcript materializes its root before the caller later
+        // writes the child entry. Carry the parent's immutable subject now, or
+        // that first root write permanently freezes the child as unbound.
+        const memorySubjectSeed = prepareCurrentSessionMemorySubjectLineageSeedInTransaction(
+          database,
+          params.parentSessionKey,
+        );
+        writeSqliteForkedChildTranscriptInTransaction(database, fork, memorySubjectSeed);
+        result = { status: "created", transcript: fork.transcript };
       }, toDatabaseOptions(resolved));
       return result;
     });
@@ -88,13 +105,28 @@ export async function forkSqliteSessionTranscriptFromParent(
   if (!params.parentEntry.sessionId) {
     return { status: "missing-parent" };
   }
-  const sourceDatabase = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-  const source = resolveSqliteParentForkSourceTranscript(
-    loadSqliteTranscriptEventsFromDatabase(sourceDatabase, params.parentEntry.sessionId),
-  );
-  if (!source) {
+  // Cross-store writes cannot commit atomically, but their source facts must
+  // still come from one source transaction. Otherwise a reset can pair an old
+  // transcript with a newer immutable subject before the child is written.
+  const sourceSnapshot = runOpenClawAgentWriteTransaction((database) => {
+    const source = resolveSqliteParentForkSourceTranscript(
+      loadSqliteTranscriptEventsFromDatabase(database, params.parentEntry.sessionId),
+    );
+    if (!source) {
+      return undefined;
+    }
+    return {
+      source,
+      memorySubjectSeed: prepareCurrentSessionMemorySubjectLineageSeedInTransaction(
+        database,
+        params.parentSessionKey,
+      ),
+    };
+  }, toDatabaseOptions(resolved));
+  if (!sourceSnapshot) {
     return { status: "failed" };
   }
+  const { source, memorySubjectSeed } = sourceSnapshot;
   const parentSessionFile = formatLegacySqliteSessionMarkerForScope({
     ...resolved,
     sessionId: params.parentEntry.sessionId,
@@ -109,10 +141,17 @@ export async function forkSqliteSessionTranscriptFromParent(
     };
     const sessionFile = formatSqliteSessionReferenceForScope(targetScope);
     runOpenClawAgentWriteTransaction((database) => {
-      writeSqliteForkedChildTranscriptInTransaction(database, targetScope, {
-        parentSessionFile,
-        source,
-      });
+      writeSqliteForkedChildTranscriptInTransaction(
+        database,
+        {
+          status: "created",
+          parentSessionFile,
+          source,
+          targetScope,
+          transcript: { sessionFile, sessionId },
+        },
+        memorySubjectSeed,
+      );
     }, toDatabaseOptions(target));
     return { status: "created", transcript: { sessionFile, sessionId } };
   });
@@ -191,20 +230,21 @@ export async function forkSqliteSessionEntryFromParentTarget(
     let previousIdentity = new Map<string, SessionEntry>();
     let currentIdentity = new Map<string, SessionEntry>();
     runOpenClawAgentWriteTransaction((writeDatabase) => {
-      const freshParent = resolveSqliteLifecyclePrimaryEntry(writeDatabase, parentTarget)?.entry;
-      if (!freshParent?.sessionId) {
+      const freshParentResult = resolveSqliteLifecyclePrimaryEntry(writeDatabase, parentTarget);
+      if (!freshParentResult?.entry.sessionId) {
         result = { status: "missing-parent" };
         return;
       }
+      const freshParent = freshParentResult.entry;
       const freshExisting = resolveSqliteLifecyclePrimaryEntry(writeDatabase, sessionTarget);
       const freshBase = freshExisting?.entry ?? params.fallbackEntry;
       if (!freshBase) {
         result = { status: "missing-entry" };
         return;
       }
-      const fork = forkSqliteParentTranscriptInTransaction(writeDatabase, resolved, {
+      const fork = prepareSqliteParentTranscriptForkInTransaction(writeDatabase, resolved, {
         parentEntry: freshParent,
-        parentSessionKey: parentTarget.canonicalKey,
+        parentSessionKey: freshParentResult.key,
         targetSessionKey: sessionTarget.canonicalKey,
       });
       if (fork.status !== "created") {
@@ -221,7 +261,7 @@ export async function forkSqliteSessionEntryFromParentTarget(
       const forkIdentityPatch: Partial<InternalSessionEntry> = {
         ...patch,
         forkSource: {
-          sessionKey: parentTarget.canonicalKey,
+          sessionKey: freshParentResult.key,
           sessionId: freshParent.sessionId,
         },
         forkedFromParent: true,
@@ -232,10 +272,18 @@ export async function forkSqliteSessionEntryFromParentTarget(
         totalTokensVersion: undefined,
       };
       const next = mergeSessionEntry(freshBase, forkIdentityPatch);
+      const lineageSeed = prepareCurrentSessionMemorySubjectLineageSeedInTransaction(
+        writeDatabase,
+        freshParentResult.key,
+      );
       previousIdentity = readSqliteSessionIdentitySnapshot(writeDatabase, sessionTarget.storeKeys);
       writeSessionEntry(writeDatabase, sessionTarget.canonicalKey, next, {
         previousEntry: freshBase,
+        ...(lineageSeed ? { memorySubjectSeed: lineageSeed } : {}),
       });
+      // A child transcript must observe the entry-owned immutable subject, not
+      // create its own unbound root before the lineage write becomes visible.
+      writeSqliteForkedChildTranscriptInTransaction(writeDatabase, fork);
       rehomeSqliteSessionWindows(
         writeDatabase,
         sessionTarget.canonicalKey,
@@ -344,7 +392,28 @@ export async function resolveSqliteSessionParentForkDecision(params: {
   );
 }
 
-function forkSqliteParentTranscriptInTransaction(
+type PreparedSqliteParentTranscriptFork =
+  | {
+      status: "created";
+      parentSessionFile: string;
+      source: SqliteParentForkSourceTranscript;
+      targetScope: ResolvedTranscriptScope;
+      transcript: { sessionFile: string; sessionId: string };
+    }
+  | { status: "missing-parent" }
+  | { status: "failed" };
+
+function resolveForkedTranscriptMemorySubjectScope(sessionKey: string): SessionMemoryScope {
+  const normalizedKey = sessionKey.trim().toLowerCase();
+  // Generic forks materialize a transcript before their caller owns an entry.
+  // A `main` target can later be a shared direct session, so quarantine it now
+  // instead of freezing copied private authority onto a shared root.
+  return normalizedKey === "main" || normalizedKey.endsWith(":main")
+    ? "shared-main"
+    : "conversation";
+}
+
+function prepareSqliteParentTranscriptForkInTransaction(
   database: OpenClawAgentDatabase,
   resolved: ResolvedSqliteScope,
   params: {
@@ -353,7 +422,7 @@ function forkSqliteParentTranscriptInTransaction(
     targetSessionId?: string;
     targetSessionKey: string;
   },
-): ForkSessionFromParentTranscriptResult {
+): PreparedSqliteParentTranscriptFork {
   if (!params.parentEntry.sessionId) {
     return { status: "missing-parent" };
   }
@@ -375,12 +444,11 @@ function forkSqliteParentTranscriptInTransaction(
     sessionKey: normalizeSqliteSessionKey(params.parentSessionKey),
   });
   const sessionFile = formatSqliteSessionReferenceForScope(targetScope);
-  writeSqliteForkedChildTranscriptInTransaction(database, targetScope, {
-    parentSessionFile,
-    source,
-  });
   return {
     status: "created",
+    parentSessionFile,
+    source,
+    targetScope,
     transcript: {
       sessionFile,
       sessionId,
@@ -390,19 +458,23 @@ function forkSqliteParentTranscriptInTransaction(
 
 function writeSqliteForkedChildTranscriptInTransaction(
   database: OpenClawAgentDatabase,
-  targetScope: ResolvedTranscriptScope,
-  params: {
-    parentSessionFile: string;
-    source: SqliteParentForkSourceTranscript;
-  },
+  fork: Extract<PreparedSqliteParentTranscriptFork, { status: "created" }>,
+  memorySubjectSeed?: ReturnType<typeof prepareCurrentSessionMemorySubjectLineageSeedInTransaction>,
 ): void {
+  const memorySubjectRoot = memorySubjectSeed
+    ? {
+        memorySubjectSeed,
+        memorySubjectScope: resolveForkedTranscriptMemorySubjectScope(fork.targetScope.sessionKey),
+      }
+    : {};
   appendTranscriptEventsInTransaction(
     database,
-    targetScope,
+    fork.targetScope,
     buildSqliteForkedChildTranscriptEvents({
-      parentSessionFile: params.parentSessionFile,
-      source: params.source,
-      targetSessionId: targetScope.sessionId,
+      parentSessionFile: fork.parentSessionFile,
+      source: fork.source,
+      targetSessionId: fork.targetScope.sessionId,
     }),
+    memorySubjectRoot,
   );
 }

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -55,6 +55,7 @@ import type {
   SqliteProjectedLifecycleMutation,
   SqliteSessionEntryMaintenancePlan,
   SqliteSessionEntryRemovalPlan,
+  TrustedSqliteSessionEntryLifecycleUpsert,
 } from "./session-accessor.sqlite-lifecycle-types.js";
 import {
   applySqliteSessionEntryMaintenance,
@@ -214,12 +215,11 @@ function readProjectedRemovalEntry(
   return projected.expectedEntry;
 }
 
-/** Applies exact lifecycle removals/upserts using SQLite session rows. */
-export async function applySqliteSessionEntryLifecycleMutation(params: {
+type SqliteSessionEntryLifecycleMutationParams<TUpsert extends SessionEntryLifecycleUpsert> = {
   agentId?: string;
   storePath: string;
   removals?: Iterable<SessionEntryLifecycleRemoval>;
-  upserts?: Iterable<SessionEntryLifecycleUpsert>;
+  upserts?: Iterable<TUpsert>;
   activeSessionKey?: string;
   maintenanceOverride?: Partial<ResolvedSessionMaintenanceConfig>;
   skipMaintenance?: boolean;
@@ -232,7 +232,22 @@ export async function applySqliteSessionEntryLifecycleMutation(params: {
   allowCanonicalRepair?: boolean;
   /** Doctor-only synchronous state transfer that commits with the destination entry. */
   afterUpsertsInTransaction?: (database: OpenClawAgentDatabase) => void;
-}): Promise<SessionEntryLifecycleMutationResult> {
+};
+
+/** Applies exact public lifecycle removals/upserts using SQLite session rows. */
+export async function applySqliteSessionEntryLifecycleMutation(
+  params: SqliteSessionEntryLifecycleMutationParams<SessionEntryLifecycleUpsert>,
+): Promise<SessionEntryLifecycleMutationResult> {
+  return await applySqliteSessionEntryLifecycleMutationWithTrustedMemorySubjects(params);
+}
+
+/**
+ * Core-only lifecycle writer. The branded issuer stays in process until the
+ * synchronous entry commit; it never crosses the public accessor contract.
+ */
+export async function applySqliteSessionEntryLifecycleMutationWithTrustedMemorySubjects(
+  params: SqliteSessionEntryLifecycleMutationParams<TrustedSqliteSessionEntryLifecycleUpsert>,
+): Promise<SessionEntryLifecycleMutationResult> {
   const resolved = resolveSqliteScope({
     ...(params.agentId ? { agentId: params.agentId } : {}),
     sessionKey: "",
@@ -308,9 +323,11 @@ export async function applySqliteSessionEntryLifecycleMutation(params: {
         { canonicalKey: string; rehomeMembers: boolean }
       >();
       for (const {
+        deferMemorySubjectPersistence,
         sessionKey,
         entry,
         expectedEntry,
+        memorySubjectIssuer,
         resetBoundaryPlan,
       } of projected.upsertedEntries) {
         const sameKeyRemoval = validatedRemovals.find(
@@ -348,17 +365,20 @@ export async function applySqliteSessionEntryLifecycleMutation(params: {
             throw new Error(`Failed to append reset boundary for ${sessionKey}`);
           }
         }
-        writeSessionEntry(transactionDb, sessionKey, entry, {
-          allowStoredAliases: params.allowCanonicalRepair === true,
-          preserveNodeSuggestions: params.allowCanonicalRepair === true,
-          previousEntry: expectedCurrentEntry ?? null,
-        });
         const relatedRemovalKeys = validatedRemovals.flatMap((removal) => {
           const removedSessionId = removal.expectedEntry.sessionId;
           return removal.sessionKey !== sessionKey &&
             (removedSessionId === entry.sessionId || removedSessionId === entry.previousSessionId)
             ? [removal.sessionKey]
             : [];
+        });
+        writeSessionEntry(transactionDb, sessionKey, entry, {
+          allowStoredAliases: params.allowCanonicalRepair === true,
+          ...(deferMemorySubjectPersistence ? { deferMemorySubjectPersistence } : {}),
+          preserveNodeSuggestions: params.allowCanonicalRepair === true,
+          previousEntry: expectedCurrentEntry ?? null,
+          ...(memorySubjectIssuer ? { memorySubjectIssuer } : {}),
+          memorySubjectAliasSourceKeys: relatedRemovalKeys,
         });
         rehomeSqliteSessionWindows(transactionDb, sessionKey, relatedRemovalKeys);
         for (const legacyKey of relatedRemovalKeys) {

--- a/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
@@ -10,6 +10,7 @@ import type {
 import type { ResolvedTranscriptScope } from "./session-accessor.sqlite-scope.js";
 import { readActiveTranscriptEntryAnchorInTransaction } from "./session-accessor.sqlite-transcript-anchor.js";
 import { resolveTranscriptMessageAppendParent } from "./session-accessor.sqlite-transcript-parent.js";
+import type { TranscriptMemorySubjectRootOptions } from "./session-accessor.sqlite-transcript-state.js";
 import {
   appendTranscriptEventInTransaction,
   ensureTranscriptHeader,
@@ -97,7 +98,8 @@ export function appendSqliteTranscriptMessageInTransaction<TMessage>(
   const messageId = options.eventId ?? randomUUID();
   const now = options.now ?? Date.now();
   const finalMessage = serializeForStorage(prepared);
-  ensureTranscriptHeader(database, resolved, options.cwd, now);
+  const rootOptions: TranscriptMemorySubjectRootOptions = options;
+  ensureTranscriptHeader(database, resolved, options.cwd, now, rootOptions);
   const parentId = resolveTranscriptMessageAppendParent(database, resolved.sessionId, options);
   const event = {
     type: "message",
@@ -107,6 +109,7 @@ export function appendSqliteTranscriptMessageInTransaction<TMessage>(
     message: finalMessage,
   };
   const appended = appendTranscriptEventInTransaction(database, resolved, event, {
+    ...rootOptions,
     dedupeByMessageIdempotency:
       options.idempotencyLookup !== "caller-checked" &&
       options.idempotencyLookup !== "scan-assistant",

--- a/src/config/sessions/session-accessor.sqlite-transcript-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-state.ts
@@ -14,6 +14,11 @@ import {
   assertCanonicalSessionKeyWriteMatchesDatabase,
   canonicalSessionKeyMigrationRequiredError,
 } from "./session-canonical-key.js";
+import {
+  persistSessionMemorySubjectInTransaction,
+  type SessionMemoryScope,
+  type TrustedSessionMemorySubjectSeed,
+} from "./session-memory-subject.js";
 import { deleteSessionTranscriptIndexInTransaction } from "./session-transcript-index.js";
 import {
   foldedSessionKeyAliasCandidates,
@@ -23,6 +28,42 @@ import {
 
 function createTranscriptGeneration(): string {
   return randomUUID().replaceAll("-", "");
+}
+
+export type TranscriptMemorySubjectRootOptions =
+  | {
+      /** No trusted provenance: the persistence owner materializes an ambiguous subject. */
+      memorySubjectSeed?: undefined;
+      /** Existing window scope remains authoritative on later writes. */
+      memorySubjectScope?: SessionMemoryScope;
+    }
+  | {
+      /** Host-trusted provenance for a newly materialized transcript root. */
+      memorySubjectSeed: TrustedSessionMemorySubjectSeed;
+      /** A seeded root must state its audience scope explicitly. */
+      memorySubjectScope: SessionMemoryScope;
+    };
+
+function resolveTranscriptMemorySubjectScope(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+): SessionMemoryScope {
+  const sessionScope = executeSqliteQueryTakeFirstSync(
+    database.db,
+    getSessionKysely(database.db)
+      .selectFrom("session_windows")
+      .select("session_scope")
+      .where("session_id", "=", sessionId),
+  )?.session_scope;
+  switch (sessionScope) {
+    case "conversation":
+    case "shared-main":
+    case "group":
+    case "channel":
+      return sessionScope;
+    default:
+      throw new Error(`missing or invalid transcript session scope for ${sessionId}`);
+  }
 }
 
 /** Read the current raw transcript generation inside the caller's transaction. */
@@ -80,8 +121,11 @@ export function ensureTranscriptSessionRoot(
   database: OpenClawAgentDatabase,
   scope: ResolvedTranscriptScope,
   updatedAt: number,
-  options: { allowStoredAlias?: boolean } = {},
+  options: TranscriptMemorySubjectRootOptions & { allowStoredAlias?: boolean } = {},
 ): void {
+  if (options.memorySubjectSeed && !options.memorySubjectScope) {
+    throw new Error("memorySubjectScope is required when creating a transcript root with a seed");
+  }
   if (!options.allowStoredAlias) {
     assertCanonicalSqliteSessionKeysCurrent(database);
     assertCanonicalSessionKeyWriteMatchesDatabase(database, scope.sessionKey);
@@ -148,6 +192,9 @@ export function ensureTranscriptSessionRoot(
     }
   }
   const db = getSessionKysely(database.db);
+  // Transcript-only legacy callers have no trusted subject or route classifier.
+  // Their root remains an ambiguous subject; this scope only preserves the legacy window shape.
+  const initialSessionScope = options.memorySubjectScope ?? "conversation";
   const insertedNode = executeSqliteQuerySync(
     database.db,
     db
@@ -180,7 +227,7 @@ export function ensureTranscriptSessionRoot(
         session_key: scope.sessionKey,
         previous_session_id: null,
         reason: null,
-        session_scope: "conversation",
+        session_scope: initialSessionScope,
         created_at: updatedAt,
         updated_at: updatedAt,
       })
@@ -191,6 +238,14 @@ export function ensureTranscriptSessionRoot(
         }),
       ),
   );
+  persistSessionMemorySubjectInTransaction({
+    database,
+    sessionKey: scope.sessionKey,
+    sessionId: scope.sessionId,
+    sessionScope: resolveTranscriptMemorySubjectScope(database, scope.sessionId),
+    ...(options.memorySubjectSeed ? { seed: options.memorySubjectSeed } : {}),
+    now: updatedAt,
+  });
 }
 
 export function readNextTranscriptSeq(database: OpenClawAgentDatabase, sessionId: string): number {

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -28,6 +28,7 @@ import {
   readNextTranscriptSeq,
   rotateTranscriptGenerationInTransaction,
   touchTranscriptMutationInTransaction,
+  type TranscriptMemorySubjectRootOptions,
 } from "./session-accessor.sqlite-transcript-state.js";
 import {
   deleteSessionTranscriptIndexInTransaction,
@@ -46,7 +47,7 @@ export function appendTranscriptEventInTransaction(
   database: OpenClawAgentDatabase,
   scope: ResolvedTranscriptScope,
   event: TranscriptEvent,
-  options: {
+  options: TranscriptMemorySubjectRootOptions & {
     allowStoredAlias?: boolean;
     dedupeByMessageIdempotency?: boolean;
     onProjectionReconcileNeeded?: () => void;
@@ -57,9 +58,7 @@ export function appendTranscriptEventInTransaction(
   const persistedEvent = canonicalizeTranscriptEventMedia(event);
   const db = getSessionKysely(database.db);
   const createdAt = readEventTimestamp(persistedEvent) ?? Date.now();
-  ensureTranscriptSessionRoot(database, scope, createdAt, {
-    allowStoredAlias: options.allowStoredAlias === true,
-  });
+  ensureTranscriptSessionRoot(database, scope, createdAt, options);
   ensureTranscriptGenerationInTransaction(database, scope.sessionId);
   const identity = readTranscriptEventIdentity(persistedEvent);
   if (identity && readTranscriptIdentityByEventId(database, scope.sessionId, identity.eventId)) {
@@ -156,12 +155,14 @@ export function appendTranscriptEventsInTransaction(
   database: OpenClawAgentDatabase,
   scope: ResolvedTranscriptScope,
   events: readonly TranscriptEvent[],
+  options: TranscriptMemorySubjectRootOptions = {},
 ): number {
   let appended = 0;
   let projectionNeedsRebuild = false;
   for (const event of events) {
     if (
       appendTranscriptEventInTransaction(database, scope, event, {
+        ...options,
         onProjectionReconcileNeeded: () => {
           projectionNeedsRebuild = true;
         },
@@ -242,6 +243,7 @@ export function ensureTranscriptHeader(
   scope: ResolvedTranscriptScope,
   cwd: string | undefined,
   now: number,
+  options: TranscriptMemorySubjectRootOptions = {},
 ): void {
   const db = getSessionKysely(database.db);
   const existing = executeSqliteQueryTakeFirstSync(
@@ -259,8 +261,9 @@ export function ensureTranscriptHeader(
     database,
     scope,
     createSessionTranscriptHeader({ cwd, sessionId: scope.sessionId }),
+    options,
   );
-  ensureTranscriptSessionRoot(database, scope, now);
+  ensureTranscriptSessionRoot(database, scope, now, options);
 }
 
 export function readActiveTranscriptAppendParentId(
@@ -323,7 +326,7 @@ export function replaceSqliteTranscriptEventsInTransaction(
   database: OpenClawAgentDatabase,
   resolved: ResolvedTranscriptScope,
   events: readonly TranscriptEvent[],
-  options: {
+  options: TranscriptMemorySubjectRootOptions & {
     createdAtByIndex?: readonly number[];
     /** Keep maintenance rewrites at their existing recency while invalidating stale projections. */
     preserveSessionWindowRecency?: boolean;
@@ -347,7 +350,12 @@ export function replaceSqliteTranscriptEventsInTransaction(
     return;
   }
   if (!deleted || options.preserveSessionWindowRecency !== true) {
-    ensureTranscriptSessionRoot(database, resolved, readEventTimestamp(events[0]) ?? Date.now());
+    ensureTranscriptSessionRoot(
+      database,
+      resolved,
+      readEventTimestamp(events[0]) ?? Date.now(),
+      options,
+    );
   }
   if (deleted || previousGeneration) {
     rotateTranscriptGenerationInTransaction(database, resolved.sessionId);

--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -47,7 +47,10 @@ import {
   readCommittedSqliteTranscriptMessageSequence,
   rememberCommittedSqliteTranscriptMessageSequencesInTransaction,
 } from "./session-accessor.sqlite-transcript-sequences.js";
-import { readTranscriptGenerationInTransaction } from "./session-accessor.sqlite-transcript-state.js";
+import {
+  readTranscriptGenerationInTransaction,
+  type TranscriptMemorySubjectRootOptions,
+} from "./session-accessor.sqlite-transcript-state.js";
 import {
   appendTranscriptEventInTransaction,
   replaceSqliteTranscriptEventsInTransaction,
@@ -109,11 +112,12 @@ type SqliteTranscriptSnapshotState =
 export async function replaceSqliteTranscriptEvents(
   scope: SessionTranscriptAccessScope,
   events: TranscriptEvent[],
+  options: TranscriptMemorySubjectRootOptions = {},
 ): Promise<void> {
   const resolved = resolveSqliteTranscriptScope(scope);
   await runExclusiveSqliteSessionWrite(resolved, async () => {
     runOpenClawAgentWriteTransaction((database) => {
-      replaceSqliteTranscriptEventsInTransaction(database, resolved, events);
+      replaceSqliteTranscriptEventsInTransaction(database, resolved, events, options);
     }, toDatabaseOptions(resolved));
   });
 }
@@ -155,6 +159,7 @@ export async function rewriteSqliteTranscriptEventRowsExact(
 export function replaceSqliteTranscriptEventsSync(
   scope: SessionTranscriptAccessScope,
   events: TranscriptEvent[],
+  options: TranscriptMemorySubjectRootOptions = {},
 ): boolean {
   const resolved = resolveSqliteTranscriptScope(scope);
   let replaced = false;
@@ -163,7 +168,7 @@ export function replaceSqliteTranscriptEventsSync(
     if (!fresh || fresh.entry.sessionId !== resolved.sessionId) {
       return;
     }
-    replaceSqliteTranscriptEventsInTransaction(database, resolved, events);
+    replaceSqliteTranscriptEventsInTransaction(database, resolved, events, options);
     replaced = true;
   }, toDatabaseOptions(resolved));
   return replaced;

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -196,6 +196,9 @@ export {
   persistSessionResetLifecycle,
   SessionInitializationAgentScopeMismatchError,
 } from "./session-accessor.reset.js";
+// Memory-subject issuance is deliberately absent from this stable accessor
+// barrel. Only core-owned ingress and lifecycle modules may import the
+// internal factories, so serializable/plugin-facing callers cannot mint provenance.
 export {
   appendTranscriptEvent,
   appendTranscriptEventSync,

--- a/src/config/sessions/session-memory-subject-access.test.ts
+++ b/src/config/sessions/session-memory-subject-access.test.ts
@@ -1,0 +1,98 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { replaceSessionEntrySync, upsertSessionEntry } from "./session-accessor.js";
+import {
+  readCurrentSessionMemorySubject,
+  readCurrentSessionMemorySubjectAuthority,
+} from "./session-memory-subject-access.js";
+import {
+  prepareExplicitSessionMemorySubjectSeed,
+  SessionMemorySubjectReboundError,
+} from "./session-memory-subject.js";
+import * as sessionMemorySubjectModule from "./session-memory-subject.js";
+
+const tempDirectories = useAutoCleanupTempDirTracker(afterEach);
+
+function createPaths() {
+  const directory = tempDirectories.make("openclaw-session-memory-subject-access-");
+  return {
+    stateOptions: { path: path.join(directory, "state.sqlite") },
+    storePath: path.join(directory, "sessions.json"),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("session memory subject access", () => {
+  it("returns the current persisted subject and authority", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const scope = { agentId: "main", sessionKey: "agent:main:service:task-1", storePath };
+    const seed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "service",
+      stableSubjectId: "task-service",
+      now: 100,
+      options: stateOptions,
+    });
+    await upsertSessionEntry(
+      scope,
+      { sessionId: "session-1", updatedAt: 100 },
+      { memorySubjectSeed: seed },
+    );
+
+    const snapshot = readCurrentSessionMemorySubject(scope);
+    const result = readCurrentSessionMemorySubjectAuthority(scope, stateOptions, 101);
+
+    expect(snapshot).toMatchObject({
+      sessionId: "session-1",
+      subject: { kind: "service" },
+    });
+    expect(result).toMatchObject({
+      snapshot,
+      authority: { kind: "current", assurance: "service" },
+    });
+  });
+
+  it("fails closed when the session is rebound between authority checks", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const scope = { agentId: "main", sessionKey: "agent:main:rebound-race", storePath };
+    const seed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "service",
+      stableSubjectId: "rebound-race-service",
+      now: 100,
+      options: stateOptions,
+    });
+    await upsertSessionEntry(
+      scope,
+      { sessionId: "rebound-race-before", updatedAt: 101 },
+      { memorySubjectSeed: seed },
+    );
+
+    const resolveAuthority = sessionMemorySubjectModule.resolveSessionMemorySubjectAuthority;
+    let replaced = false;
+    const resolveAuthoritySpy = vi
+      .spyOn(sessionMemorySubjectModule, "resolveSessionMemorySubjectAuthority")
+      .mockImplementation((snapshot, options, now) => {
+        const result = resolveAuthority(snapshot, options, now);
+        if (!replaced) {
+          replaced = true;
+          replaceSessionEntrySync(scope, {
+            sessionId: "rebound-race-after",
+            updatedAt: 102,
+          });
+        }
+        return result;
+      });
+
+    expect(() => readCurrentSessionMemorySubjectAuthority(scope, stateOptions, 103)).toThrow(
+      SessionMemorySubjectReboundError,
+    );
+    expect(resolveAuthoritySpy).toHaveBeenCalledOnce();
+  });
+});

--- a/src/config/sessions/session-memory-subject-access.ts
+++ b/src/config/sessions/session-memory-subject-access.ts
@@ -1,0 +1,67 @@
+import {
+  openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
+} from "../../state/openclaw-agent-db.js";
+import type { OpenClawStateDatabaseOptions } from "../../state/openclaw-state-db.js";
+import type { SessionAccessScope } from "./session-accessor.sqlite-contract.js";
+import { resolveSqliteScope, toDatabaseOptions } from "./session-accessor.sqlite-scope.js";
+import {
+  readOrCreateSessionMemorySubjectInTransaction,
+  readSessionMemorySubjectFromDatabase,
+  resolveSessionMemorySubjectAuthority,
+  SessionMemorySubjectReboundError,
+  type SessionMemorySubjectAuthority,
+  type TrustedSessionMemorySubjectSnapshot,
+} from "./session-memory-subject.js";
+
+/** Reads the canonical subject, lazily backfilling an explicit ambiguous row for old sessions. */
+export function readCurrentSessionMemorySubject(
+  scope: SessionAccessScope,
+): TrustedSessionMemorySubjectSnapshot | undefined {
+  const resolved = resolveSqliteScope(scope);
+  const options = toDatabaseOptions(resolved);
+  const database = openOpenClawAgentDatabase(options);
+  const existing = readSessionMemorySubjectFromDatabase(database, resolved.sessionKey);
+  if (existing) {
+    return existing;
+  }
+  return runOpenClawAgentWriteTransaction(
+    (transactionDb) =>
+      readOrCreateSessionMemorySubjectInTransaction(transactionDb, resolved.sessionKey),
+    options,
+    { operationLabel: "session.memory-subject.backfill" },
+  );
+}
+
+/**
+ * Rechecks shared identity evidence without holding an agent transaction, then
+ * rereads the agent mapping and identity authority so either database changing
+ * across the check fails closed.
+ */
+export function readCurrentSessionMemorySubjectAuthority(
+  scope: SessionAccessScope,
+  stateOptions: OpenClawStateDatabaseOptions = {},
+  now = Date.now(),
+):
+  | Readonly<{
+      snapshot: TrustedSessionMemorySubjectSnapshot;
+      authority: SessionMemorySubjectAuthority;
+    }>
+  | undefined {
+  const snapshot = readCurrentSessionMemorySubject(scope);
+  if (!snapshot) {
+    return undefined;
+  }
+  resolveSessionMemorySubjectAuthority(snapshot, stateOptions, now);
+  const current = readCurrentSessionMemorySubject(scope);
+  if (
+    !current ||
+    current.sessionId !== snapshot.sessionId ||
+    current.sessionIdentityRevision !== snapshot.sessionIdentityRevision ||
+    current.subjectRevision !== snapshot.subjectRevision
+  ) {
+    throw new SessionMemorySubjectReboundError(snapshot.sessionId);
+  }
+  const authority = resolveSessionMemorySubjectAuthority(current, stateOptions, now);
+  return { snapshot: current, authority };
+}

--- a/src/config/sessions/session-memory-subject-immutability.test.ts
+++ b/src/config/sessions/session-memory-subject-immutability.test.ts
@@ -1,0 +1,113 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { upsertSessionEntry } from "./session-accessor.js";
+import { resolveSqliteScope, toDatabaseOptions } from "./session-accessor.sqlite-scope.js";
+import { readCurrentSessionMemorySubject } from "./session-memory-subject-access.js";
+import { prepareExplicitSessionMemorySubjectSeed } from "./session-memory-subject.js";
+
+const tempDirectories = useAutoCleanupTempDirTracker(afterEach);
+
+function createScope() {
+  const directory = tempDirectories.make("openclaw-session-memory-subject-immutable-");
+  return {
+    agentId: "main",
+    sessionKey: "agent:main:immutable-subject",
+    storePath: path.join(directory, "sessions.json"),
+  };
+}
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("session memory subject immutability", () => {
+  it("lazily restores missing subject tables and trigger in a current agent database", async () => {
+    const scope = createScope();
+    const stateOptions = { path: path.join(path.dirname(scope.storePath), "state.sqlite") };
+    const seed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "service",
+      stableSubjectId: "lazy-schema-restore-service",
+      now: 100,
+      options: stateOptions,
+    });
+
+    await upsertSessionEntry(scope, { sessionId: "lazy-schema-session", updatedAt: 100 });
+
+    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolveSqliteScope(scope)));
+    database.db.exec(`
+      DROP TRIGGER IF EXISTS session_memory_subjects_reject_update;
+      DROP TABLE session_memory_subject_snapshots;
+      DROP TABLE session_memory_subjects;
+    `);
+    closeOpenClawAgentDatabasesForTest();
+
+    await upsertSessionEntry(
+      scope,
+      { sessionId: "lazy-schema-session", updatedAt: 101 },
+      { memorySubjectSeed: seed },
+    );
+
+    expect(readCurrentSessionMemorySubject(scope)?.subject).toEqual(seed.subject);
+
+    const reopened = openOpenClawAgentDatabase(toDatabaseOptions(resolveSqliteScope(scope)));
+    expect(
+      reopened.db
+        .prepare(
+          "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'session_memory_subjects'",
+        )
+        .get(),
+    ).toEqual({ name: "session_memory_subjects" });
+    expect(
+      reopened.db
+        .prepare(
+          "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'session_memory_subject_snapshots'",
+        )
+        .get(),
+    ).toEqual({ name: "session_memory_subject_snapshots" });
+    expect(
+      reopened.db
+        .prepare(
+          "SELECT name FROM sqlite_schema WHERE type = 'trigger' AND name = 'session_memory_subjects_reject_update'",
+        )
+        .get(),
+    ).toEqual({ name: "session_memory_subjects_reject_update" });
+  });
+
+  it("lazily installs the immutable-row trigger before accepting an existing subject", async () => {
+    const scope = createScope();
+    await upsertSessionEntry(scope, { sessionId: "immutable-session", updatedAt: 100 });
+
+    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolveSqliteScope(scope)));
+    database.db.exec("DROP TRIGGER session_memory_subjects_reject_update;");
+    closeOpenClawAgentDatabasesForTest();
+
+    expect(readCurrentSessionMemorySubject(scope)?.subject).toEqual({
+      version: 1,
+      kind: "ambiguous",
+      reason: "unbound",
+    });
+
+    const reopened = openOpenClawAgentDatabase(toDatabaseOptions(resolveSqliteScope(scope)));
+    expect(
+      reopened.db
+        .prepare(
+          "SELECT name FROM sqlite_schema WHERE type = 'trigger' AND name = 'session_memory_subjects_reject_update'",
+        )
+        .get(),
+    ).toEqual({ name: "session_memory_subjects_reject_update" });
+    expect(() =>
+      reopened.db
+        .prepare(
+          "UPDATE session_memory_subjects SET ambiguous_reason = 'shared-main' WHERE session_key = ?",
+        )
+        .run(scope.sessionKey),
+    ).toThrow("session memory subject is immutable");
+  });
+});

--- a/src/config/sessions/session-memory-subject-lifecycle.test.ts
+++ b/src/config/sessions/session-memory-subject-lifecycle.test.ts
@@ -1,0 +1,797 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { createMemoryIdentityBindingThroughApprovedPairing } from "../../pairing/memory-identity-approval.test-support.js";
+import { memoryIdentityLifecycle } from "../../state/memory-identity.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import {
+  appendTranscriptEvent,
+  appendTranscriptMessage,
+  copySessionOwnedStateForCanonicalRepair,
+  forkSessionAtMessage,
+  forkSessionFromParentTranscript,
+  loadSessionEntry,
+  resetSessionEntryLifecycle,
+  rewindSessionToMessage,
+  upsertSessionEntry,
+  type SessionAccessScope,
+} from "./session-accessor.js";
+import { importSqliteSessionRows } from "./session-accessor.sqlite.js";
+import {
+  readCurrentSessionMemorySubject,
+  readCurrentSessionMemorySubjectAuthority,
+} from "./session-memory-subject-access.js";
+import {
+  prepareChannelBindingSessionMemorySubjectSeed,
+  prepareExplicitSessionMemorySubjectSeed,
+  prepareSessionMemorySubjectLineageSeed,
+  SessionMemorySubjectReboundError,
+  type TrustedSessionMemorySubjectSnapshot,
+} from "./session-memory-subject.js";
+import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+
+const tempDirectories = useAutoCleanupTempDirTracker(afterEach);
+
+const { ensureEnterpriseMemoryPrincipal, revokeMemoryIdentityBinding } = memoryIdentityLifecycle;
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+function createPaths() {
+  const root = tempDirectories.make("openclaw-session-memory-subject-lifecycle-");
+  return {
+    stateOptions: { env: { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "state") } },
+    storePath: (agentId: string) => path.join(root, "agents", agentId, "sessions", "sessions.json"),
+  };
+}
+
+function readRequiredSubject(scope: SessionAccessScope): TrustedSessionMemorySubjectSnapshot {
+  const snapshot = readCurrentSessionMemorySubject(scope);
+  if (!snapshot) {
+    throw new Error(`expected a persisted memory subject for ${scope.sessionKey}`);
+  }
+  return snapshot;
+}
+
+function expectExactSubjectLineage(
+  source: TrustedSessionMemorySubjectSnapshot,
+  descendant: TrustedSessionMemorySubjectSnapshot,
+) {
+  expect(descendant.subjectRevision).toBe(source.subjectRevision);
+  expect(descendant.subject).toEqual(source.subject);
+  expect(descendant.creationBindingId).toBe(source.creationBindingId);
+  expect(descendant.canonicalConversationRef).toBe(source.canonicalConversationRef);
+}
+
+async function appendActiveMessagePath(params: {
+  scope: Required<Pick<SessionAccessScope, "agentId" | "sessionKey" | "storePath">> & {
+    sessionId: string;
+  };
+}) {
+  await appendTranscriptEvent(params.scope, {
+    type: "session",
+    id: params.scope.sessionId,
+    version: 3,
+    timestamp: "2026-08-09T00:00:00.000Z",
+  });
+  await appendTranscriptMessage(params.scope, {
+    eventId: "user-1",
+    message: { role: "user", content: "first prompt" },
+    now: Date.parse("2026-08-09T00:00:01.000Z"),
+    parentId: null,
+  });
+  await appendTranscriptMessage(params.scope, {
+    eventId: "assistant-1",
+    message: { role: "assistant", content: "first response" },
+    now: Date.parse("2026-08-09T00:00:02.000Z"),
+    parentId: "user-1",
+  });
+  await appendTranscriptMessage(params.scope, {
+    eventId: "user-2",
+    message: { role: "user", content: "second prompt" },
+    now: Date.parse("2026-08-09T00:00:03.000Z"),
+    parentId: "assistant-1",
+  });
+  await appendTranscriptMessage(params.scope, {
+    eventId: "assistant-2",
+    message: { role: "assistant", content: "second response" },
+    now: Date.parse("2026-08-09T00:00:04.000Z"),
+    parentId: "user-2",
+  });
+}
+
+async function createBoundUserSource(params: { name: string }) {
+  const paths = createPaths();
+  const agentId = "main";
+  const storePath = paths.storePath(agentId);
+  const stableSenderId = `${params.name}-sender`;
+  const principal = ensureEnterpriseMemoryPrincipal({
+    issuer: "session-memory-subject-lifecycle-test",
+    stableSubjectId: `${params.name}-principal`,
+    now: 100,
+    options: paths.stateOptions,
+  });
+  const binding = await createMemoryIdentityBindingThroughApprovedPairing({
+    channel: "telegram",
+    accountId: "default",
+    stableSenderId,
+    principalId: principal.principalId,
+    now: 100,
+    options: paths.stateOptions,
+  });
+  const scope = {
+    agentId,
+    sessionId: `${params.name}-source-session`,
+    sessionKey: `agent:${agentId}:${params.name}-source`,
+    storePath,
+  };
+  await upsertSessionEntry(
+    scope,
+    { sessionId: scope.sessionId, updatedAt: 101 },
+    {
+      memorySubjectSeed: prepareChannelBindingSessionMemorySubjectSeed({
+        channel: "telegram",
+        accountId: "default",
+        stableSenderId,
+        now: 101,
+        options: paths.stateOptions,
+      }),
+    },
+  );
+  return {
+    binding,
+    paths,
+    sourceScope: scope,
+    sourceSubject: readRequiredSubject(scope),
+  };
+}
+
+type BoundUserSource = Awaited<ReturnType<typeof createBoundUserSource>>;
+type BoundUserDescendant = Readonly<{ scope: SessionAccessScope }>;
+type BoundUserDescendantCase = Readonly<{
+  name: string;
+  derive: (source: BoundUserSource) => Promise<BoundUserDescendant>;
+}>;
+
+const boundUserDescendantCases: readonly BoundUserDescendantCase[] = [
+  {
+    name: "reset",
+    derive: async ({ sourceScope }) => {
+      await resetSessionEntryLifecycle({
+        buildNextEntry: () => ({ sessionId: "reset-descendant-session", updatedAt: 110 }),
+        storePath: sourceScope.storePath,
+        target: { canonicalKey: sourceScope.sessionKey, storeKeys: [sourceScope.sessionKey] },
+      });
+      return { scope: sourceScope };
+    },
+  },
+  {
+    name: "rollover",
+    derive: async ({ sourceScope }) => {
+      await upsertSessionEntry(sourceScope, {
+        sessionId: "rollover-descendant-session",
+        updatedAt: 110,
+      });
+      return { scope: sourceScope };
+    },
+  },
+  {
+    name: "fork",
+    derive: async ({ sourceScope }) => {
+      await appendActiveMessagePath({ scope: sourceScope });
+      const childSessionKey = "agent:main:fork-descendant";
+      const forked = await forkSessionFromParentTranscript({
+        agentId: sourceScope.agentId,
+        parentEntry: { sessionId: sourceScope.sessionId, updatedAt: 101 },
+        parentSessionKey: sourceScope.sessionKey,
+        sessionKey: childSessionKey,
+        storePath: sourceScope.storePath,
+      });
+      if (forked.status !== "created") {
+        throw new Error(`expected descendant fork, received ${forked.status}`);
+      }
+      const scope = {
+        agentId: sourceScope.agentId,
+        sessionKey: childSessionKey,
+        storePath: sourceScope.storePath,
+      };
+      await upsertSessionEntry(scope, {
+        sessionId: forked.transcript.sessionId,
+        updatedAt: 111,
+      });
+      return { scope };
+    },
+  },
+  {
+    name: "rewind",
+    derive: async ({ sourceScope }) => {
+      await appendActiveMessagePath({ scope: sourceScope });
+      const rewound = await rewindSessionToMessage({
+        agentId: sourceScope.agentId,
+        entryId: "user-2",
+        sessionKey: sourceScope.sessionKey,
+        storePath: sourceScope.storePath,
+      });
+      if (rewound.status !== "created") {
+        throw new Error(`expected descendant rewind, received ${rewound.status}`);
+      }
+      return { scope: sourceScope };
+    },
+  },
+  {
+    name: "recovery",
+    derive: async ({ sourceScope }) => {
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+      return { scope: sourceScope };
+    },
+  },
+  {
+    name: "confirmed import",
+    derive: async ({ paths, sourceScope, sourceSubject }) => {
+      const scope = {
+        agentId: sourceScope.agentId,
+        sessionKey: "agent:main:confirmed-import-descendant",
+        storePath: sourceScope.storePath,
+      };
+      await importSqliteSessionRows({
+        agentId: scope.agentId,
+        confirmedMemorySubjectLineage: prepareSessionMemorySubjectLineageSeed(sourceSubject),
+        entry: { sessionId: "confirmed-import-descendant-session", updatedAt: 110 },
+        sessionKey: scope.sessionKey,
+        storePath: scope.storePath,
+        // Keep the source's shared identity DB in scope for the subsequent
+        // authority recheck; imports only receive the already-issued lineage.
+        env: paths.stateOptions.env,
+      });
+      return { scope };
+    },
+  },
+];
+
+describe("session memory subject lifecycle provenance", () => {
+  it.each(boundUserDescendantCases)(
+    "keeps a channel-bound subject revoked after $name lineage",
+    async ({ name, derive }) => {
+      const source = await createBoundUserSource({ name: name.replace(/\s+/gu, "-") });
+      const descendant = await derive(source);
+      const descendantSubject = readRequiredSubject(descendant.scope);
+
+      expectExactSubjectLineage(source.sourceSubject, descendantSubject);
+      expect(
+        revokeMemoryIdentityBinding({
+          bindingId: source.binding.bindingId,
+          now: 150,
+          revokedBy: "lifecycle-test",
+          options: source.paths.stateOptions,
+        }),
+      ).toBe(true);
+      expect(
+        readCurrentSessionMemorySubjectAuthority(descendant.scope, source.paths.stateOptions, 151)
+          ?.authority,
+      ).toEqual({ kind: "denied", reason: "binding-revoked" });
+    },
+  );
+
+  it("keeps a reset descendant denied after its captured binding expires", async () => {
+    const source = await createBoundUserSource({ name: "expiry-reset" });
+    await resetSessionEntryLifecycle({
+      buildNextEntry: () => ({ sessionId: "expiry-reset-descendant-session", updatedAt: 110 }),
+      storePath: source.sourceScope.storePath,
+      target: {
+        canonicalKey: source.sourceScope.sessionKey,
+        storeKeys: [source.sourceScope.sessionKey],
+      },
+    });
+    const descendant = readRequiredSubject(source.sourceScope);
+    expectExactSubjectLineage(source.sourceSubject, descendant);
+
+    // Test-only direct expiry mutation proves authority consults the captured
+    // binding's current expiry rather than trusting the immutable subject row.
+    openOpenClawStateDatabase(source.paths.stateOptions)
+      .db.prepare("UPDATE memory_identity_bindings SET expires_at = ? WHERE binding_id = ?")
+      .run(150, source.binding.bindingId);
+
+    expect(
+      readCurrentSessionMemorySubjectAuthority(source.sourceScope, source.paths.stateOptions, 151)
+        ?.authority,
+    ).toEqual({ kind: "denied", reason: "binding-revoked" });
+  });
+
+  it("copies an exact subject revision through a generic parent transcript fork", async () => {
+    const paths = createPaths();
+    const storePath = paths.storePath("main");
+    const parentScope = {
+      agentId: "main",
+      sessionId: "generic-parent-session",
+      sessionKey: "agent:main:generic-parent",
+      storePath,
+    };
+    const seed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "service",
+      stableSubjectId: "generic-parent-service",
+      now: 100,
+      options: paths.stateOptions,
+    });
+    await upsertSessionEntry(
+      parentScope,
+      { sessionId: parentScope.sessionId, updatedAt: 100 },
+      { memorySubjectSeed: seed },
+    );
+    await appendActiveMessagePath({ scope: parentScope });
+    const parentSubject = readRequiredSubject(parentScope);
+
+    const forked = await forkSessionFromParentTranscript({
+      agentId: "main",
+      parentEntry: { sessionId: parentScope.sessionId, updatedAt: 100 },
+      parentSessionKey: parentScope.sessionKey,
+      sessionKey: "agent:main:generic-child",
+      storePath,
+    });
+    if (forked.status !== "created") {
+      throw new Error(`expected generic parent fork, received ${forked.status}`);
+    }
+    const childScope = {
+      agentId: "main",
+      sessionKey: "agent:main:generic-child",
+      storePath,
+    };
+    // The generic transcript fork intentionally returns before its caller owns
+    // the child entry. Materialize that entry before reading its logical subject.
+    await upsertSessionEntry(childScope, {
+      sessionId: forked.transcript.sessionId,
+      updatedAt: 101,
+    });
+    const childSubject = readRequiredSubject(childScope);
+
+    expect(childSubject.sessionId).toBe(forked.transcript.sessionId);
+    expect(childSubject.sessionIdentityRevision).not.toBe(parentSubject.sessionIdentityRevision);
+    expectExactSubjectLineage(parentSubject, childSubject);
+  });
+
+  it("quarantines private generic fork lineage when the target is shared main", async () => {
+    const paths = createPaths();
+    const storePath = paths.storePath("main");
+    const parentScope = {
+      agentId: "main",
+      sessionId: "shared-main-fork-parent",
+      sessionKey: "agent:main:private-parent",
+      storePath,
+    };
+    await upsertSessionEntry(
+      parentScope,
+      { sessionId: parentScope.sessionId, updatedAt: 100 },
+      {
+        memorySubjectSeed: prepareExplicitSessionMemorySubjectSeed({
+          kind: "service",
+          stableSubjectId: "private-parent-service",
+          now: 100,
+          options: paths.stateOptions,
+        }),
+      },
+    );
+    await appendActiveMessagePath({ scope: parentScope });
+
+    const forked = await forkSessionFromParentTranscript({
+      agentId: "main",
+      parentEntry: { sessionId: parentScope.sessionId, updatedAt: 100 },
+      parentSessionKey: parentScope.sessionKey,
+      sessionKey: "agent:main:main",
+      storePath,
+    });
+    if (forked.status !== "created") {
+      throw new Error(`expected shared-main fork, received ${forked.status}`);
+    }
+    const childScope = {
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    await upsertSessionEntry(childScope, {
+      chatType: "direct",
+      sessionId: forked.transcript.sessionId,
+      updatedAt: 101,
+    });
+
+    expect(readRequiredSubject(childScope)).toMatchObject({
+      sessionId: forked.transcript.sessionId,
+      sessionScope: "shared-main",
+      subject: { version: 1, kind: "ambiguous", reason: "shared-main" },
+    });
+  });
+
+  it("copies an exact subject revision into a cross-agent parent fork", async () => {
+    const paths = createPaths();
+    const sourceStorePath = paths.storePath("source");
+    const targetStorePath = paths.storePath("target");
+    const parentScope = {
+      agentId: "source",
+      sessionId: "cross-agent-parent-session",
+      sessionKey: "agent:source:cross-agent-parent",
+      storePath: sourceStorePath,
+    };
+    const seed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "service",
+      stableSubjectId: "cross-agent-parent-service",
+      now: 200,
+      options: paths.stateOptions,
+    });
+    await upsertSessionEntry(
+      parentScope,
+      { sessionId: parentScope.sessionId, updatedAt: 200 },
+      { memorySubjectSeed: seed },
+    );
+    await appendActiveMessagePath({ scope: parentScope });
+    const parentSubject = readRequiredSubject(parentScope);
+
+    const forked = await forkSessionFromParentTranscript({
+      agentId: "source",
+      parentEntry: { sessionId: parentScope.sessionId, updatedAt: 200 },
+      parentSessionKey: parentScope.sessionKey,
+      sessionKey: "agent:target:cross-agent-child",
+      storePath: sourceStorePath,
+      targetStorePath,
+    });
+    if (forked.status !== "created") {
+      throw new Error(`expected cross-agent parent fork, received ${forked.status}`);
+    }
+    const childScope = {
+      agentId: "target",
+      sessionKey: "agent:target:cross-agent-child",
+      storePath: targetStorePath,
+    };
+    await upsertSessionEntry(childScope, {
+      sessionId: forked.transcript.sessionId,
+      updatedAt: 201,
+    });
+    const childSubject = readRequiredSubject(childScope);
+
+    expect(childSubject.sessionId).toBe(forked.transcript.sessionId);
+    expectExactSubjectLineage(parentSubject, childSubject);
+  });
+
+  it("copies exact lineage through rewind and message-cut fork windows", async () => {
+    const paths = createPaths();
+    const storePath = paths.storePath("main");
+    const rewindScope = {
+      agentId: "main",
+      sessionId: "rewind-source-session",
+      sessionKey: "agent:main:rewind-source",
+      storePath,
+    };
+    const rewindSeed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "agent",
+      stableSubjectId: "rewind-agent",
+      now: 300,
+      options: paths.stateOptions,
+    });
+    await upsertSessionEntry(
+      rewindScope,
+      { sessionId: rewindScope.sessionId, updatedAt: 300 },
+      { memorySubjectSeed: rewindSeed },
+    );
+    await appendActiveMessagePath({ scope: rewindScope });
+    const rewindBefore = readRequiredSubject(rewindScope);
+
+    const rewound = await rewindSessionToMessage({
+      agentId: "main",
+      entryId: "user-2",
+      sessionKey: rewindScope.sessionKey,
+      storePath,
+    });
+    if (rewound.status !== "created") {
+      throw new Error(`expected rewind, received ${rewound.status}`);
+    }
+    const rewoundSubject = readRequiredSubject(rewindScope);
+    expect(rewoundSubject.sessionId).toBe(rewound.entry.sessionId);
+    expect(rewoundSubject.sessionIdentityRevision).not.toBe(rewindBefore.sessionIdentityRevision);
+    expectExactSubjectLineage(rewindBefore, rewoundSubject);
+
+    const forkSourceScope = {
+      agentId: "main",
+      sessionId: "message-cut-source-session",
+      sessionKey: "agent:main:message-cut-source",
+      storePath,
+    };
+    const forkSeed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "agent",
+      stableSubjectId: "message-cut-agent",
+      now: 400,
+      options: paths.stateOptions,
+    });
+    await upsertSessionEntry(
+      forkSourceScope,
+      { sessionId: forkSourceScope.sessionId, updatedAt: 400 },
+      { memorySubjectSeed: forkSeed },
+    );
+    await appendActiveMessagePath({ scope: forkSourceScope });
+    const forkSourceSubject = readRequiredSubject(forkSourceScope);
+
+    const forked = await forkSessionAtMessage({
+      agentId: "main",
+      entryId: "user-2",
+      sessionKey: forkSourceScope.sessionKey,
+      storePath,
+      targetKey: "agent:main:message-cut-child",
+    });
+    if (forked.status !== "created") {
+      throw new Error(`expected message-cut fork, received ${forked.status}`);
+    }
+    const forkedSubject = readRequiredSubject({
+      agentId: "main",
+      sessionKey: forked.key,
+      storePath,
+    });
+    expect(forkedSubject.sessionId).toBe(forked.entry.sessionId);
+    expectExactSubjectLineage(forkSourceSubject, forkedSubject);
+    expectExactSubjectLineage(forkSourceSubject, readRequiredSubject(forkSourceScope));
+  });
+
+  it("keeps the exact subject revision through rollover and reset", async () => {
+    const paths = createPaths();
+    const storePath = paths.storePath("main");
+    const scope = {
+      agentId: "main",
+      sessionKey: "agent:main:rollover-reset",
+      storePath,
+    };
+    const seed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "system",
+      stableSubjectId: "rollover-reset-system",
+      now: 500,
+      options: paths.stateOptions,
+    });
+    await upsertSessionEntry(
+      scope,
+      { sessionId: "rollover-before", updatedAt: 500 },
+      { memorySubjectSeed: seed },
+    );
+    const before = readRequiredSubject(scope);
+
+    await upsertSessionEntry(scope, { sessionId: "rollover-after", updatedAt: 501 });
+    const rolled = readRequiredSubject(scope);
+    expect(loadSessionEntry(scope)).toMatchObject({
+      previousSessionId: "rollover-before",
+      sessionId: "rollover-after",
+    });
+    expect(rolled.sessionIdentityRevision).not.toBe(before.sessionIdentityRevision);
+    expectExactSubjectLineage(before, rolled);
+
+    await resetSessionEntryLifecycle({
+      buildNextEntry: () => ({ sessionId: "reset-after", updatedAt: 502 }),
+      storePath,
+      target: { canonicalKey: scope.sessionKey, storeKeys: [scope.sessionKey] },
+    });
+    const reset = readRequiredSubject(scope);
+    expect(reset.sessionId).toBe("reset-after");
+    expect(reset.sessionIdentityRevision).not.toBe(rolled.sessionIdentityRevision);
+    expectExactSubjectLineage(before, reset);
+  });
+
+  it("recovers the persisted subject and revisions after an agent database reopen", async () => {
+    const paths = createPaths();
+    const storePath = paths.storePath("main");
+    const scope = {
+      agentId: "main",
+      sessionKey: "agent:main:recovered-session",
+      storePath,
+    };
+    const seed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "service",
+      stableSubjectId: "recovered-service",
+      now: 600,
+      options: paths.stateOptions,
+    });
+    await upsertSessionEntry(
+      scope,
+      { sessionId: "recovered-session-id", updatedAt: 600 },
+      { memorySubjectSeed: seed },
+    );
+    const before = readRequiredSubject(scope);
+
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    const recovered = readRequiredSubject(scope);
+    expect(recovered.sessionId).toBe(before.sessionId);
+    expect(recovered.sessionIdentityRevision).toBe(before.sessionIdentityRevision);
+    expectExactSubjectLineage(before, recovered);
+  });
+
+  it("copies immutable subject provenance exactly through cross-database canonical repair", async () => {
+    const paths = createPaths();
+    const sourceStorePath = paths.storePath("source");
+    const destinationStorePath = paths.storePath("destination");
+    const sourceScope = {
+      agentId: "source",
+      sessionKey: "agent:source:canonical-repair-source",
+      storePath: sourceStorePath,
+    };
+    const destinationScope = {
+      agentId: "destination",
+      sessionKey: "agent:destination:canonical-repair-target",
+      storePath: destinationStorePath,
+    };
+    const sourceEntry = { sessionId: "canonical-repair-session", updatedAt: 700 };
+    const destinationEntry = { ...sourceEntry, updatedAt: 701 };
+    const seed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "service",
+      stableSubjectId: "canonical-repair-service",
+      now: 700,
+      options: paths.stateOptions,
+    });
+    await upsertSessionEntry(sourceScope, sourceEntry, { memorySubjectSeed: seed });
+    const sourceSubject = readRequiredSubject(sourceScope);
+    const sourceDatabase = openOpenClawAgentDatabase({
+      agentId: sourceScope.agentId,
+      path: resolveSqliteTargetFromSessionStorePath(sourceStorePath, sourceScope).path,
+    });
+    const sourceRow = sourceDatabase.db
+      .prepare(
+        "SELECT created_at, subject_revision FROM session_memory_subjects WHERE session_key = ?",
+      )
+      .get(sourceScope.sessionKey) as { created_at: number; subject_revision: string } | undefined;
+    if (!sourceRow) {
+      throw new Error("expected source immutable memory subject row");
+    }
+
+    // Canonical repair creates its target entry before copying source-owned
+    // state. Remove its auto-backfill so the public helper must copy the source
+    // row and snapshot, rather than keeping a newly issued destination subject.
+    await upsertSessionEntry(destinationScope, destinationEntry);
+    const destinationDatabase = openOpenClawAgentDatabase({
+      agentId: destinationScope.agentId,
+      path: resolveSqliteTargetFromSessionStorePath(destinationStorePath, destinationScope).path,
+    });
+    destinationDatabase.db
+      .prepare("DELETE FROM session_memory_subject_snapshots WHERE session_id = ?")
+      .run(sourceEntry.sessionId);
+    destinationDatabase.db
+      .prepare("DELETE FROM session_memory_subjects WHERE session_key = ?")
+      .run(destinationScope.sessionKey);
+
+    copySessionOwnedStateForCanonicalRepair({
+      canonicalKey: destinationScope.sessionKey,
+      destinationDatabase,
+      preferredEntry: sourceEntry,
+      preferredSessionKey: sourceScope.sessionKey,
+      source: { agentId: sourceScope.agentId, storePath: sourceStorePath },
+      sourceEntries: [sourceEntry],
+      sourceKeys: [sourceScope.sessionKey],
+    });
+
+    const repaired = readRequiredSubject(destinationScope);
+    expect(repaired.sessionKey).toBe(destinationScope.sessionKey);
+    expect(repaired.sessionIdentityRevision).toBe(sourceSubject.sessionIdentityRevision);
+    expectExactSubjectLineage(sourceSubject, repaired);
+    expect(
+      destinationDatabase.db
+        .prepare(
+          "SELECT created_at, subject_revision FROM session_memory_subjects WHERE session_key = ?",
+        )
+        .get(destinationScope.sessionKey),
+    ).toEqual({
+      created_at: sourceRow.created_at,
+      subject_revision: sourceSubject.subjectRevision,
+    });
+    expect(
+      destinationDatabase.db
+        .prepare(
+          "SELECT session_key, subject_revision, session_identity_revision FROM session_memory_subject_snapshots WHERE session_id = ?",
+        )
+        .get(sourceEntry.sessionId),
+    ).toEqual({
+      session_key: destinationScope.sessionKey,
+      session_identity_revision: sourceSubject.sessionIdentityRevision,
+      subject_revision: sourceSubject.subjectRevision,
+    });
+  });
+
+  it("rejects a canonical repair when only immutable subject provenance time differs", async () => {
+    const paths = createPaths();
+    const sourceStorePath = paths.storePath("source");
+    const destinationStorePath = paths.storePath("destination");
+    const sourceScope = {
+      agentId: "source",
+      sessionKey: "agent:source:canonical-repair-created-at-source",
+      storePath: sourceStorePath,
+    };
+    const destinationScope = {
+      agentId: "destination",
+      sessionKey: "agent:destination:canonical-repair-created-at-target",
+      storePath: destinationStorePath,
+    };
+    const sourceEntry = { sessionId: "canonical-repair-created-at-session", updatedAt: 800 };
+    const destinationEntry = { ...sourceEntry, updatedAt: 801 };
+    const seed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "service",
+      stableSubjectId: "canonical-repair-created-at-service",
+      now: 800,
+      options: paths.stateOptions,
+    });
+    await upsertSessionEntry(sourceScope, sourceEntry, { memorySubjectSeed: seed });
+    await upsertSessionEntry(destinationScope, destinationEntry, { memorySubjectSeed: seed });
+
+    const sourceDatabase = openOpenClawAgentDatabase({
+      agentId: sourceScope.agentId,
+      path: resolveSqliteTargetFromSessionStorePath(sourceStorePath, sourceScope).path,
+    });
+    const destinationDatabase = openOpenClawAgentDatabase({
+      agentId: destinationScope.agentId,
+      path: resolveSqliteTargetFromSessionStorePath(destinationStorePath, destinationScope).path,
+    });
+    type SubjectProvenanceRow = {
+      subject_revision: string;
+      subject_kind: string;
+      principal_id: string | null;
+      conversation_principal_id: string | null;
+      channel: string | null;
+      account_id: string | null;
+      ambiguous_reason: string | null;
+      creation_evidence_kind: string | null;
+      creation_evidence_revision: string | null;
+      creation_binding_id: string | null;
+      canonical_conversation_ref: string | null;
+      created_at: number;
+    };
+    const selectSubjectProvenanceRow = (database: typeof sourceDatabase, sessionKey: string) =>
+      database.db
+        .prepare(
+          `
+            SELECT
+              subject_revision,
+              subject_kind,
+              principal_id,
+              conversation_principal_id,
+              channel,
+              account_id,
+              ambiguous_reason,
+              creation_evidence_kind,
+              creation_evidence_revision,
+              creation_binding_id,
+              canonical_conversation_ref,
+              created_at
+            FROM session_memory_subjects
+            WHERE session_key = ?
+          `,
+        )
+        .get(sessionKey) as SubjectProvenanceRow | undefined;
+    const sourceRow = selectSubjectProvenanceRow(sourceDatabase, sourceScope.sessionKey);
+    const destinationRow = selectSubjectProvenanceRow(
+      destinationDatabase,
+      destinationScope.sessionKey,
+    );
+    if (!sourceRow || !destinationRow) {
+      throw new Error("expected source and destination immutable memory subject rows");
+    }
+    expect(sourceRow.created_at).toBe(sourceEntry.updatedAt);
+    expect(destinationRow).toEqual({ ...sourceRow, created_at: destinationEntry.updatedAt });
+
+    // Keep the subject row but remove its independently generated snapshot, so
+    // the repair rejection can only be caused by its differing audit time.
+    destinationDatabase.db
+      .prepare("DELETE FROM session_memory_subject_snapshots WHERE session_id = ?")
+      .run(sourceEntry.sessionId);
+
+    expect(() =>
+      copySessionOwnedStateForCanonicalRepair({
+        canonicalKey: destinationScope.sessionKey,
+        destinationDatabase,
+        preferredEntry: sourceEntry,
+        preferredSessionKey: sourceScope.sessionKey,
+        source: { agentId: sourceScope.agentId, storePath: sourceStorePath },
+        sourceEntries: [sourceEntry],
+        sourceKeys: [sourceScope.sessionKey],
+      }),
+    ).toThrow(SessionMemorySubjectReboundError);
+  });
+});

--- a/src/config/sessions/session-memory-subject-persistence.ts
+++ b/src/config/sessions/session-memory-subject-persistence.ts
@@ -1,0 +1,694 @@
+import type { DatabaseSync } from "node:sqlite";
+import type { Selectable } from "kysely";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
+import { generateSecureUuid } from "../../infra/secure-random.js";
+import type { SessionMemorySubject } from "../../memory-host-sdk/host/authorization.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import { AGENT_SESSION_MEMORY_SCHEMA_SQL } from "../../state/openclaw-agent-session-memory-schema.js";
+import {
+  createTrustedSessionMemorySubjectSeed,
+  createTrustedSessionMemorySubjectSnapshot,
+  InvalidSessionMemorySubjectSeedError,
+  isTrustedSessionMemorySubjectIssuer,
+  isTrustedSessionMemorySubjectSeed,
+  issueTrustedSessionMemorySubject,
+  prepareSessionMemorySubjectLineageSeed,
+  requireSessionMemorySubjectText,
+  SessionMemorySubjectReboundError,
+  type SessionMemoryScope,
+  type TrustedSessionMemorySubjectIssuer,
+  type TrustedSessionMemorySubjectSeed,
+  type TrustedSessionMemorySubjectSnapshot,
+} from "./session-memory-subject-trust.js";
+
+type SessionMemoryDatabase = Pick<
+  OpenClawAgentKyselyDatabase,
+  | "session_memory_subject_snapshots"
+  | "session_memory_subjects"
+  | "session_nodes"
+  | "session_windows"
+>;
+type SessionMemorySubjectRow = Selectable<SessionMemoryDatabase["session_memory_subjects"]>;
+
+const ensuredDatabases = new WeakSet<DatabaseSync>();
+
+function sessionMemoryDb(db: DatabaseSync) {
+  return getNodeSqliteKysely<SessionMemoryDatabase>(db);
+}
+
+function ensureSessionMemorySubjectSchema(database: OpenClawAgentDatabase): void {
+  if (ensuredDatabases.has(database.db)) {
+    return;
+  }
+  // The schema includes its own idempotent tables, indexes, and immutable-row
+  // trigger. Execute it even when old additive tables already exist, or those
+  // rows could remain writable until the next schema-version migration.
+  database.db.exec(AGENT_SESSION_MEMORY_SCHEMA_SQL);
+  // DDL inside a larger session mutation rolls back with that mutation. Mark it
+  // only when this call owns an autocommit boundary; the next successful write
+  // observes both tables and then caches the committed ensure.
+  if (!database.db.isTransaction) {
+    ensuredDatabases.add(database.db);
+  }
+}
+
+function subjectFromRow(row: SessionMemorySubjectRow): SessionMemorySubject {
+  switch (row.subject_kind) {
+    case "user":
+      if (!row.principal_id || !row.creation_evidence_kind || !row.creation_evidence_revision) {
+        break;
+      }
+      return {
+        version: 1,
+        kind: "user",
+        principalId: row.principal_id,
+        creationEvidence: {
+          kind: row.creation_evidence_kind as Extract<
+            SessionMemorySubject,
+            { kind: "user" }
+          >["creationEvidence"]["kind"],
+          revision: row.creation_evidence_revision,
+        },
+      };
+    case "conversation":
+      if (!row.conversation_principal_id || !row.channel || !row.account_id) {
+        break;
+      }
+      return {
+        version: 1,
+        kind: "conversation",
+        conversationPrincipalId: row.conversation_principal_id,
+        channel: row.channel,
+        accountId: row.account_id,
+      };
+    case "service":
+    case "agent":
+    case "system":
+      if (!row.principal_id) {
+        break;
+      }
+      return { version: 1, kind: row.subject_kind, principalId: row.principal_id };
+    case "ambiguous":
+      if (!row.ambiguous_reason) {
+        break;
+      }
+      return {
+        version: 1,
+        kind: "ambiguous",
+        reason: row.ambiguous_reason as Extract<
+          SessionMemorySubject,
+          { kind: "ambiguous" }
+        >["reason"],
+      };
+  }
+  throw new Error(`corrupt session memory subject row: ${row.session_key}`);
+}
+
+function subjectValues(params: {
+  sessionKey: string;
+  seed: TrustedSessionMemorySubjectSeed;
+  createdAt: number;
+}): SessionMemoryDatabase["session_memory_subjects"] {
+  const { subject } = params.seed;
+  return {
+    session_key: params.sessionKey,
+    subject_revision: params.seed.subjectRevision,
+    subject_kind: subject.kind,
+    principal_id:
+      subject.kind === "user" ||
+      subject.kind === "service" ||
+      subject.kind === "agent" ||
+      subject.kind === "system"
+        ? subject.principalId
+        : null,
+    conversation_principal_id:
+      subject.kind === "conversation" ? subject.conversationPrincipalId : null,
+    channel: subject.kind === "conversation" ? subject.channel : null,
+    account_id: subject.kind === "conversation" ? subject.accountId : null,
+    ambiguous_reason: subject.kind === "ambiguous" ? subject.reason : null,
+    creation_evidence_kind: subject.kind === "user" ? subject.creationEvidence.kind : null,
+    creation_evidence_revision: subject.kind === "user" ? subject.creationEvidence.revision : null,
+    creation_binding_id: params.seed.creationBindingId ?? null,
+    canonical_conversation_ref: params.seed.canonicalConversationRef ?? null,
+    created_at: params.createdAt,
+  };
+}
+
+function readSubjectRow(
+  database: OpenClawAgentDatabase,
+  sessionKey: string,
+): SessionMemorySubjectRow | undefined {
+  ensureSessionMemorySubjectSchema(database);
+  return executeSqliteQueryTakeFirstSync(
+    database.db,
+    sessionMemoryDb(database.db)
+      .selectFrom("session_memory_subjects")
+      .selectAll()
+      .where("session_key", "=", sessionKey),
+  );
+}
+
+function assertEquivalentSubjectRows(
+  target: SessionMemorySubjectRow,
+  source: SessionMemorySubjectRow,
+): void {
+  if (!sessionMemorySubjectRowsEqual(target, source)) {
+    throw new Error("conflicting immutable session memory subjects during alias rehome");
+  }
+}
+
+function sessionMemorySubjectRowsEqual(
+  left: SessionMemorySubjectRow,
+  right: SessionMemorySubjectRow,
+): boolean {
+  const comparable = (row: SessionMemorySubjectRow) => ({
+    subject_revision: row.subject_revision,
+    subject_kind: row.subject_kind,
+    principal_id: row.principal_id,
+    conversation_principal_id: row.conversation_principal_id,
+    channel: row.channel,
+    account_id: row.account_id,
+    ambiguous_reason: row.ambiguous_reason,
+    creation_evidence_kind: row.creation_evidence_kind,
+    creation_evidence_revision: row.creation_evidence_revision,
+    creation_binding_id: row.creation_binding_id,
+    canonical_conversation_ref: row.canonical_conversation_ref,
+  });
+  return JSON.stringify(comparable(left)) === JSON.stringify(comparable(right));
+}
+
+function sessionMemorySubjectRowsExactlyEqual(
+  left: SessionMemorySubjectRow,
+  right: SessionMemorySubjectRow,
+): boolean {
+  return sessionMemorySubjectRowsEqual(left, right) && left.created_at === right.created_at;
+}
+
+/**
+ * Doctor moves a selected logical session between agent databases only after
+ * its destination node and windows exist. Copy the immutable pair exactly;
+ * a pre-existing different pair is evidence of an unsafe provenance merge.
+ */
+export function copySessionMemorySubjectStateForCanonicalRepair(params: {
+  canonicalKey: string;
+  destination: OpenClawAgentDatabase;
+  sessionIds: Iterable<string>;
+  source: OpenClawAgentDatabase;
+  sourceSessionKey: string;
+}): void {
+  ensureSessionMemorySubjectSchema(params.source);
+  ensureSessionMemorySubjectSchema(params.destination);
+  const sourceDb = sessionMemoryDb(params.source.db);
+  const destinationDb = sessionMemoryDb(params.destination.db);
+  const sourceSubject = executeSqliteQueryTakeFirstSync(
+    params.source.db,
+    sourceDb
+      .selectFrom("session_memory_subjects")
+      .selectAll()
+      .where("session_key", "=", params.sourceSessionKey),
+  );
+  if (!sourceSubject) {
+    // Legacy source rows have no provable immutable lineage. Leave the
+    // destination unbound so its normal lazy path quarantines it as ambiguous.
+    return;
+  }
+  const sessionIds = [...new Set([...params.sessionIds].filter(Boolean))];
+  const destinationSubject = readSubjectRow(params.destination, params.canonicalKey);
+  if (destinationSubject) {
+    // A repair must preserve the source audit record byte-for-byte (apart from
+    // its canonical key); accepting a reissued row loses its provenance time.
+    if (!sessionMemorySubjectRowsExactlyEqual(destinationSubject, sourceSubject)) {
+      throw new SessionMemorySubjectReboundError(sessionIds[0] ?? params.canonicalKey);
+    }
+  } else {
+    executeSqliteQuerySync(
+      params.destination.db,
+      destinationDb.insertInto("session_memory_subjects").values({
+        ...sourceSubject,
+        session_key: params.canonicalKey,
+      }),
+    );
+  }
+
+  if (sessionIds.length === 0) {
+    return;
+  }
+  const snapshots = executeSqliteQuerySync(
+    params.source.db,
+    sourceDb
+      .selectFrom("session_memory_subject_snapshots")
+      .selectAll()
+      .where("session_id", "in", sessionIds),
+  ).rows;
+  for (const snapshot of snapshots) {
+    if (
+      snapshot.session_key !== params.sourceSessionKey ||
+      snapshot.subject_revision !== sourceSubject.subject_revision
+    ) {
+      throw new SessionMemorySubjectReboundError(snapshot.session_id);
+    }
+    const destinationSnapshot = executeSqliteQueryTakeFirstSync(
+      params.destination.db,
+      destinationDb
+        .selectFrom("session_memory_subject_snapshots")
+        .selectAll()
+        .where("session_id", "=", snapshot.session_id),
+    );
+    if (destinationSnapshot) {
+      if (
+        destinationSnapshot.session_key !== params.canonicalKey ||
+        destinationSnapshot.subject_revision !== snapshot.subject_revision ||
+        destinationSnapshot.session_identity_revision !== snapshot.session_identity_revision
+      ) {
+        throw new SessionMemorySubjectReboundError(snapshot.session_id);
+      }
+      continue;
+    }
+    executeSqliteQuerySync(
+      params.destination.db,
+      destinationDb.insertInto("session_memory_subject_snapshots").values({
+        ...snapshot,
+        session_key: params.canonicalKey,
+      }),
+    );
+  }
+}
+
+/** Rehomes exact alias provenance after the canonical node exists and before its snapshot write. */
+export function rehomeSessionMemorySubjectAliases(
+  database: OpenClawAgentDatabase,
+  targetSessionKey: string,
+  sourceSessionKeys: Iterable<string>,
+): void {
+  ensureSessionMemorySubjectSchema(database);
+  const targetKey = requireSessionMemorySubjectText(targetSessionKey, "targetSessionKey");
+  const sourceKeys = [...new Set([...sourceSessionKeys].map((key) => key.trim()))].filter(
+    (key) => key && key !== targetKey,
+  );
+  if (sourceKeys.length === 0) {
+    return;
+  }
+  const db = sessionMemoryDb(database.db);
+  const sources = executeSqliteQuerySync(
+    database.db,
+    db.selectFrom("session_memory_subjects").selectAll().where("session_key", "in", sourceKeys),
+  ).rows;
+  if (sources.length === 0) {
+    return;
+  }
+  let target = readSubjectRow(database, targetKey);
+  const source = sources[0];
+  if (!source) {
+    return;
+  }
+  if (!target) {
+    executeSqliteQuerySync(
+      database.db,
+      db.insertInto("session_memory_subjects").values({
+        ...source,
+        session_key: targetKey,
+      }),
+    );
+    target = readSubjectRow(database, targetKey);
+  }
+  if (!target) {
+    throw new Error("canonical session memory subject could not be rehomed");
+  }
+  for (const candidate of sources) {
+    assertEquivalentSubjectRows(target, candidate);
+  }
+  const snapshots = executeSqliteQuerySync(
+    database.db,
+    db
+      .selectFrom("session_memory_subject_snapshots")
+      .select(["session_id", "session_key", "subject_revision"])
+      .where("session_key", "in", sourceKeys),
+  ).rows;
+  for (const snapshot of snapshots) {
+    if (snapshot.subject_revision !== target.subject_revision) {
+      throw new SessionMemorySubjectReboundError(snapshot.session_id);
+    }
+    executeSqliteQuerySync(
+      database.db,
+      db
+        .updateTable("session_memory_subject_snapshots")
+        .set({ session_key: targetKey })
+        .where("session_id", "=", snapshot.session_id)
+        .where("session_key", "=", snapshot.session_key),
+    );
+  }
+}
+
+/**
+ * Moves one retained window snapshot only when the destination logical session
+ * has the same immutable subject. A mismatch keeps the source tombstone alive.
+ */
+export function tryRehomeSessionMemorySubjectSnapshot(params: {
+  database: OpenClawAgentDatabase;
+  sessionId: string;
+  sourceSessionKey: string;
+  targetSessionKey: string;
+}): boolean {
+  const { database } = params;
+  ensureSessionMemorySubjectSchema(database);
+  const sessionId = requireSessionMemorySubjectText(params.sessionId, "sessionId");
+  const sourceSessionKey = requireSessionMemorySubjectText(
+    params.sourceSessionKey,
+    "sourceSessionKey",
+  );
+  const targetSessionKey = requireSessionMemorySubjectText(
+    params.targetSessionKey,
+    "targetSessionKey",
+  );
+  if (sourceSessionKey === targetSessionKey) {
+    return true;
+  }
+  const db = sessionMemoryDb(database.db);
+  const sourceWindow = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("session_windows")
+      .select(["session_key", "session_scope"])
+      .where("session_id", "=", sessionId),
+  );
+  if (!sourceWindow || sourceWindow.session_key !== sourceSessionKey) {
+    throw new SessionMemorySubjectReboundError(sessionId);
+  }
+  persistSessionMemorySubjectInTransaction({
+    database,
+    sessionKey: sourceSessionKey,
+    sessionId,
+    sessionScope: sourceWindow.session_scope as SessionMemoryScope,
+  });
+  const source = readSubjectRow(database, sourceSessionKey);
+  if (!source) {
+    throw new Error("retained session memory subject could not be materialized");
+  }
+  let target = readSubjectRow(database, targetSessionKey);
+  if (!target) {
+    // A cross-key reference alone is not proof of lineage. Legacy/imported
+    // destinations backfill as ambiguous instead of inheriting private authority.
+    readOrCreateSessionMemorySubjectInTransaction(database, targetSessionKey);
+    target = readSubjectRow(database, targetSessionKey);
+  }
+  if (!target) {
+    throw new Error("retained session memory subject destination could not be materialized");
+  }
+  if (!sessionMemorySubjectRowsEqual(target, source)) {
+    return false;
+  }
+  const snapshot = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("session_memory_subject_snapshots")
+      .select(["session_key", "subject_revision"])
+      .where("session_id", "=", sessionId),
+  );
+  if (
+    !snapshot ||
+    snapshot.session_key !== sourceSessionKey ||
+    snapshot.subject_revision !== source.subject_revision
+  ) {
+    throw new SessionMemorySubjectReboundError(sessionId);
+  }
+  executeSqliteQuerySync(
+    database.db,
+    db
+      .updateTable("session_memory_subject_snapshots")
+      .set({ session_key: targetSessionKey })
+      .where("session_id", "=", sessionId)
+      .where("session_key", "=", sourceSessionKey),
+  );
+  return true;
+}
+
+export function persistSessionMemorySubjectInTransaction(params: {
+  database: OpenClawAgentDatabase;
+  sessionKey: string;
+  sessionId: string;
+  sessionScope: SessionMemoryScope;
+  seed?: TrustedSessionMemorySubjectSeed;
+  issuer?: TrustedSessionMemorySubjectIssuer;
+  aliasSourceSessionKeys?: Iterable<string>;
+  now?: number;
+}): TrustedSessionMemorySubjectSnapshot | undefined {
+  const { database } = params;
+  ensureSessionMemorySubjectSchema(database);
+  if (params.seed !== undefined && !isTrustedSessionMemorySubjectSeed(params.seed)) {
+    throw new InvalidSessionMemorySubjectSeedError();
+  }
+  if (params.issuer !== undefined && !isTrustedSessionMemorySubjectIssuer(params.issuer)) {
+    throw new InvalidSessionMemorySubjectSeedError();
+  }
+  if (params.seed !== undefined && params.issuer !== undefined) {
+    throw new InvalidSessionMemorySubjectSeedError();
+  }
+  const requestedSessionKey = requireSessionMemorySubjectText(params.sessionKey, "sessionKey");
+  const sessionId = params.sessionId.trim();
+  const db = sessionMemoryDb(database.db);
+  const windowSessionKey = sessionId
+    ? executeSqliteQueryTakeFirstSync(
+        database.db,
+        db.selectFrom("session_windows").select("session_key").where("session_id", "=", sessionId),
+      )?.session_key
+    : undefined;
+  // Legacy aliases can retain separate nodes for one transcript. The window
+  // owns its immutable subject and snapshot, or direct reads lose the pair.
+  const sessionKey = windowSessionKey ?? requestedSessionKey;
+  if (params.aliasSourceSessionKeys) {
+    rehomeSessionMemorySubjectAliases(database, sessionKey, params.aliasSourceSessionKeys);
+  }
+  let snapshot = sessionId
+    ? executeSqliteQueryTakeFirstSync(
+        database.db,
+        db
+          .selectFrom("session_memory_subject_snapshots")
+          .selectAll()
+          .where("session_id", "=", sessionId),
+      )
+    : undefined;
+  let row = readSubjectRow(database, sessionKey);
+  if (!row) {
+    const aliasSubject = snapshot ? readSubjectRow(database, snapshot.session_key) : undefined;
+    const canPreserveAmbiguousAlias =
+      params.seed === undefined &&
+      aliasSubject?.subject_kind === "ambiguous" &&
+      (params.sessionScope !== "shared-main" || aliasSubject.ambiguous_reason === "shared-main");
+    if (canPreserveAmbiguousAlias) {
+      // Legacy aliases can share a transcript ID without proving private lineage.
+      // Preserve only an already-denied subject; never inherit user authority here.
+      executeSqliteQuerySync(
+        database.db,
+        db.insertInto("session_memory_subjects").values({
+          ...aliasSubject,
+          session_key: sessionKey,
+        }),
+      );
+    } else {
+      const seed =
+        params.sessionScope === "shared-main"
+          ? createTrustedSessionMemorySubjectSeed({
+              subject: { version: 1, kind: "ambiguous", reason: "shared-main" },
+            })
+          : (params.seed ??
+            // Issuers resolve only when this transaction creates the immutable
+            // row, so a revoked binding cannot be captured from stale ingress state.
+            (params.issuer ? issueTrustedSessionMemorySubject(params.issuer) : undefined) ??
+            createTrustedSessionMemorySubjectSeed({
+              subject: { version: 1, kind: "ambiguous", reason: "unbound" },
+            }));
+      executeSqliteQuerySync(
+        database.db,
+        db
+          .insertInto("session_memory_subjects")
+          .values(subjectValues({ sessionKey, seed, createdAt: params.now ?? Date.now() })),
+      );
+    }
+    row = readSubjectRow(database, sessionKey);
+  }
+  if (!row) {
+    throw new Error("session memory subject could not be persisted");
+  }
+  // Empty IDs are durable placeholder entries, not transcript windows. Keep
+  // their logical subject write-once, but deny access until an ID materializes.
+  if (!sessionId) {
+    return undefined;
+  }
+  if (snapshot) {
+    const snapshotSubject = readSubjectRow(database, snapshot.session_key);
+    if (
+      !snapshotSubject ||
+      snapshot.subject_revision !== row.subject_revision ||
+      !sessionMemorySubjectRowsEqual(snapshotSubject, row)
+    ) {
+      throw new SessionMemorySubjectReboundError(sessionId);
+    }
+    if (snapshot.session_key !== sessionKey) {
+      // session_windows already moved the canonical alias owner. Keep the
+      // audit snapshot attached to that owner without changing its identity.
+      executeSqliteQuerySync(
+        database.db,
+        db
+          .updateTable("session_memory_subject_snapshots")
+          .set({ session_key: sessionKey })
+          .where("session_id", "=", sessionId)
+          .where("session_key", "=", snapshot.session_key),
+      );
+      snapshot = { ...snapshot, session_key: sessionKey };
+    }
+  } else {
+    executeSqliteQuerySync(
+      database.db,
+      db.insertInto("session_memory_subject_snapshots").values({
+        session_id: sessionId,
+        session_key: sessionKey,
+        subject_revision: row.subject_revision,
+        session_identity_revision: generateSecureUuid(),
+        created_at: params.now ?? Date.now(),
+      }),
+    );
+    snapshot = executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("session_memory_subject_snapshots")
+        .selectAll()
+        .where("session_id", "=", sessionId),
+    );
+  }
+  if (!snapshot) {
+    throw new Error("session memory subject snapshot could not be persisted");
+  }
+  return createTrustedSessionMemorySubjectSnapshot({
+    sessionKey,
+    sessionId,
+    sessionScope: params.sessionScope,
+    sessionIdentityRevision: snapshot.session_identity_revision,
+    subjectRevision: row.subject_revision,
+    subject: subjectFromRow(row),
+    ...(row.creation_binding_id ? { creationBindingId: row.creation_binding_id } : {}),
+    ...(row.canonical_conversation_ref
+      ? { canonicalConversationRef: row.canonical_conversation_ref }
+      : {}),
+  });
+}
+
+export function readSessionMemorySubjectFromDatabase(
+  database: OpenClawAgentDatabase,
+  sessionKey: string,
+): TrustedSessionMemorySubjectSnapshot | undefined {
+  ensureSessionMemorySubjectSchema(database);
+  const key = requireSessionMemorySubjectText(sessionKey, "sessionKey");
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    sessionMemoryDb(database.db)
+      .selectFrom("session_nodes as node")
+      .innerJoin("session_windows as window", "window.session_id", "node.current_session_id")
+      .innerJoin("session_memory_subjects as subject", "subject.session_key", "window.session_key")
+      .innerJoin(
+        "session_memory_subject_snapshots as snapshot",
+        "snapshot.session_id",
+        "node.current_session_id",
+      )
+      .select([
+        "window.session_key as subject_session_key",
+        "node.session_key as session_key",
+        "node.current_session_id as session_id",
+        "window.session_scope as session_scope",
+        "snapshot.session_identity_revision as session_identity_revision",
+        "snapshot.subject_revision as snapshot_subject_revision",
+        "subject.subject_revision as subject_revision",
+        "subject.subject_kind as subject_kind",
+        "subject.principal_id as principal_id",
+        "subject.conversation_principal_id as conversation_principal_id",
+        "subject.channel as channel",
+        "subject.account_id as account_id",
+        "subject.ambiguous_reason as ambiguous_reason",
+        "subject.creation_evidence_kind as creation_evidence_kind",
+        "subject.creation_evidence_revision as creation_evidence_revision",
+        "subject.creation_binding_id as creation_binding_id",
+        "subject.canonical_conversation_ref as canonical_conversation_ref",
+        "subject.created_at as created_at",
+      ])
+      .where("node.session_key", "=", key)
+      // Alias nodes share one transcript window. Read both immutable records
+      // through its canonical owner, or a legacy alias can lose its subject.
+      .whereRef("snapshot.session_key", "=", "window.session_key"),
+  );
+  if (!row) {
+    return undefined;
+  }
+  if (row.snapshot_subject_revision !== row.subject_revision) {
+    throw new SessionMemorySubjectReboundError(row.session_id);
+  }
+  const subjectRow: SessionMemorySubjectRow = {
+    session_key: row.subject_session_key,
+    subject_revision: row.subject_revision,
+    subject_kind: row.subject_kind,
+    principal_id: row.principal_id,
+    conversation_principal_id: row.conversation_principal_id,
+    channel: row.channel,
+    account_id: row.account_id,
+    ambiguous_reason: row.ambiguous_reason,
+    creation_evidence_kind: row.creation_evidence_kind,
+    creation_evidence_revision: row.creation_evidence_revision,
+    creation_binding_id: row.creation_binding_id,
+    canonical_conversation_ref: row.canonical_conversation_ref,
+    created_at: row.created_at,
+  };
+  return createTrustedSessionMemorySubjectSnapshot({
+    sessionKey: row.session_key,
+    sessionId: row.session_id,
+    sessionScope: row.session_scope as SessionMemoryScope,
+    sessionIdentityRevision: row.session_identity_revision,
+    subjectRevision: row.subject_revision,
+    subject: subjectFromRow(subjectRow),
+    ...(row.creation_binding_id ? { creationBindingId: row.creation_binding_id } : {}),
+    ...(row.canonical_conversation_ref
+      ? { canonicalConversationRef: row.canonical_conversation_ref }
+      : {}),
+  });
+}
+
+export function readOrCreateSessionMemorySubjectInTransaction(
+  database: OpenClawAgentDatabase,
+  sessionKey: string,
+): TrustedSessionMemorySubjectSnapshot | undefined {
+  const current = readSessionMemorySubjectFromDatabase(database, sessionKey);
+  if (current) {
+    return current;
+  }
+  const identity = executeSqliteQueryTakeFirstSync(
+    database.db,
+    sessionMemoryDb(database.db)
+      .selectFrom("session_nodes as node")
+      .innerJoin("session_windows as window", "window.session_id", "node.current_session_id")
+      .select([
+        "window.session_key as session_key",
+        "node.current_session_id as session_id",
+        "window.session_scope as session_scope",
+      ])
+      .where("node.session_key", "=", requireSessionMemorySubjectText(sessionKey, "sessionKey")),
+  );
+  return identity
+    ? persistSessionMemorySubjectInTransaction({
+        database,
+        sessionKey: identity.session_key,
+        sessionId: identity.session_id,
+        sessionScope: identity.session_scope as SessionMemoryScope,
+      })
+    : undefined;
+}
+
+/** Captures exact persisted lineage while the caller owns the source agent transaction. */
+export function prepareCurrentSessionMemorySubjectLineageSeedInTransaction(
+  database: OpenClawAgentDatabase,
+  sessionKey: string,
+): TrustedSessionMemorySubjectSeed | undefined {
+  const snapshot = readOrCreateSessionMemorySubjectInTransaction(database, sessionKey);
+  return snapshot ? prepareSessionMemorySubjectLineageSeed(snapshot) : undefined;
+}

--- a/src/config/sessions/session-memory-subject-trust.ts
+++ b/src/config/sessions/session-memory-subject-trust.ts
@@ -1,0 +1,319 @@
+import { generateSecureUuid } from "../../infra/secure-random.js";
+import type { SessionMemorySubject } from "../../memory-host-sdk/host/authorization.js";
+
+const trustedSeedBrand: unique symbol = Symbol("openclaw.trusted-session-memory-subject-seed");
+const trustedIssuerBrand: unique symbol = Symbol("openclaw.trusted-session-memory-subject-issuer");
+const trustedSnapshotBrand: unique symbol = Symbol(
+  "openclaw.trusted-session-memory-subject-snapshot",
+);
+const trustedSeeds = new WeakSet<object>();
+const trustedIssuers = new WeakSet<object>();
+const trustedSnapshots = new WeakSet<object>();
+
+export type SessionMemoryScope = "conversation" | "shared-main" | "group" | "channel";
+
+export type TrustedSessionMemorySubjectSeed = Readonly<{
+  [trustedSeedBrand]: true;
+  subject: SessionMemorySubject;
+  subjectRevision: string;
+  creationBindingId?: string;
+  canonicalConversationRef?: string;
+}>;
+
+/**
+ * A core-only issuer defers identity resolution to the write transaction. Its
+ * closure is intentionally non-serializable so untrusted context cannot mint a subject.
+ */
+export type TrustedSessionMemorySubjectIssuer = Readonly<{
+  [trustedIssuerBrand]: true;
+  issue: () => TrustedSessionMemorySubjectSeed;
+}>;
+
+export type TrustedSessionMemorySubjectSnapshot = Readonly<{
+  [trustedSnapshotBrand]: true;
+  sessionKey: string;
+  sessionId: string;
+  sessionScope: SessionMemoryScope;
+  sessionIdentityRevision: string;
+  subjectRevision: string;
+  subject: SessionMemorySubject;
+  creationBindingId?: string;
+  canonicalConversationRef?: string;
+}>;
+
+export class SessionMemorySubjectReboundError extends Error {
+  readonly code = "SESSION_MEMORY_SUBJECT_REBOUND";
+
+  constructor(sessionId: string) {
+    super(`Session memory subject snapshot conflicts with reused session id: ${sessionId}`);
+    this.name = "SessionMemorySubjectReboundError";
+  }
+}
+
+export class InvalidSessionMemorySubjectSeedError extends Error {
+  readonly code = "INVALID_SESSION_MEMORY_SUBJECT_SEED";
+
+  constructor() {
+    super("Session memory subject seed is not host-trusted");
+    this.name = "InvalidSessionMemorySubjectSeedError";
+  }
+}
+
+export function requireSessionMemorySubjectText(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new TypeError(`${label} must not be empty`);
+  }
+  return normalized;
+}
+
+function assertSubjectEvidenceKind(
+  value: string,
+): asserts value is Extract<SessionMemorySubject, { kind: "user" }>["creationEvidence"]["kind"] {
+  if (
+    value !== "gateway-profile" &&
+    value !== "channel-binding" &&
+    value !== "adapter-attested" &&
+    value !== "explicit-service"
+  ) {
+    throw new TypeError("unsupported session memory subject evidence kind");
+  }
+}
+
+function assertAmbiguousReason(
+  value: string,
+): asserts value is Extract<SessionMemorySubject, { kind: "ambiguous" }>["reason"] {
+  if (value !== "shared-main" && value !== "unbound" && value !== "conflicting-bindings") {
+    throw new TypeError("unsupported ambiguous session memory subject reason");
+  }
+}
+
+function cloneSubject(subject: SessionMemorySubject): SessionMemorySubject {
+  if (subject.version !== 1) {
+    throw new TypeError("unsupported session memory subject version");
+  }
+  switch (subject.kind) {
+    case "user": {
+      assertSubjectEvidenceKind(subject.creationEvidence.kind);
+      return {
+        version: 1,
+        kind: "user",
+        principalId: requireSessionMemorySubjectText(subject.principalId, "principalId"),
+        creationEvidence: {
+          kind: subject.creationEvidence.kind,
+          revision: requireSessionMemorySubjectText(
+            subject.creationEvidence.revision,
+            "creation evidence revision",
+          ),
+        },
+      };
+    }
+    case "conversation":
+      return {
+        version: 1,
+        kind: "conversation",
+        conversationPrincipalId: requireSessionMemorySubjectText(
+          subject.conversationPrincipalId,
+          "conversationPrincipalId",
+        ),
+        channel: requireSessionMemorySubjectText(subject.channel, "channel").toLowerCase(),
+        accountId: requireSessionMemorySubjectText(subject.accountId, "accountId"),
+      };
+    case "service":
+    case "agent":
+    case "system":
+      return {
+        version: 1,
+        kind: subject.kind,
+        principalId: requireSessionMemorySubjectText(subject.principalId, "principalId"),
+      };
+    case "ambiguous":
+      assertAmbiguousReason(subject.reason);
+      return { version: 1, kind: "ambiguous", reason: subject.reason };
+  }
+  throw new TypeError("unsupported session memory subject kind");
+}
+
+function deepFreeze<T extends object>(value: T): T {
+  for (const nested of Object.values(value)) {
+    if (nested && typeof nested === "object" && !Object.isFrozen(nested)) {
+      deepFreeze(nested as object);
+    }
+  }
+  return Object.freeze(value);
+}
+
+export function createTrustedSessionMemorySubjectSeed(params: {
+  subject: SessionMemorySubject;
+  subjectRevision?: string;
+  creationBindingId?: string;
+  canonicalConversationRef?: string;
+}): TrustedSessionMemorySubjectSeed {
+  const subject = cloneSubject(params.subject);
+  const creationBindingId =
+    params.creationBindingId === undefined
+      ? undefined
+      : requireSessionMemorySubjectText(params.creationBindingId, "creationBindingId");
+  const requiresBindingId =
+    subject.kind === "user" && subject.creationEvidence.kind === "channel-binding";
+  if (requiresBindingId !== (creationBindingId !== undefined)) {
+    throw new TypeError("channel-binding subjects must carry exactly one creationBindingId");
+  }
+  const seed = {
+    subject,
+    subjectRevision: requireSessionMemorySubjectText(
+      params.subjectRevision ?? generateSecureUuid(),
+      "subjectRevision",
+    ),
+    ...(creationBindingId ? { creationBindingId } : {}),
+    ...(params.canonicalConversationRef
+      ? {
+          canonicalConversationRef: requireSessionMemorySubjectText(
+            params.canonicalConversationRef,
+            "canonicalConversationRef",
+          ),
+        }
+      : {}),
+  } as Omit<TrustedSessionMemorySubjectSeed, typeof trustedSeedBrand> & {
+    [trustedSeedBrand]?: true;
+  };
+  Object.defineProperty(seed, trustedSeedBrand, {
+    value: true,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  trustedSeeds.add(seed);
+  return deepFreeze(seed) as TrustedSessionMemorySubjectSeed;
+}
+
+export function isTrustedSessionMemorySubjectSeed(
+  value: unknown,
+): value is TrustedSessionMemorySubjectSeed {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    trustedSeeds.has(value) &&
+    (value as Record<symbol, unknown>)[trustedSeedBrand] === true &&
+    Object.isFrozen(value),
+  );
+}
+
+export function createTrustedSessionMemorySubjectIssuer(
+  issue: () => TrustedSessionMemorySubjectSeed,
+): TrustedSessionMemorySubjectIssuer {
+  const issuer = { issue } as Omit<TrustedSessionMemorySubjectIssuer, typeof trustedIssuerBrand> & {
+    [trustedIssuerBrand]?: true;
+  };
+  Object.defineProperty(issuer, trustedIssuerBrand, {
+    value: true,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  trustedIssuers.add(issuer);
+  return Object.freeze(issuer) as TrustedSessionMemorySubjectIssuer;
+}
+
+export function isTrustedSessionMemorySubjectIssuer(
+  value: unknown,
+): value is TrustedSessionMemorySubjectIssuer {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    trustedIssuers.has(value) &&
+    (value as Record<symbol, unknown>)[trustedIssuerBrand] === true &&
+    Object.isFrozen(value),
+  );
+}
+
+export function issueTrustedSessionMemorySubject(
+  issuer: TrustedSessionMemorySubjectIssuer,
+): TrustedSessionMemorySubjectSeed {
+  if (!isTrustedSessionMemorySubjectIssuer(issuer)) {
+    throw new InvalidSessionMemorySubjectSeedError();
+  }
+  const seed = issuer.issue();
+  if (!isTrustedSessionMemorySubjectSeed(seed)) {
+    throw new InvalidSessionMemorySubjectSeedError();
+  }
+  return seed;
+}
+
+export function createTrustedSessionMemorySubjectSnapshot(params: {
+  sessionKey: string;
+  sessionId: string;
+  sessionScope: SessionMemoryScope;
+  sessionIdentityRevision: string;
+  subjectRevision: string;
+  subject: SessionMemorySubject;
+  creationBindingId?: string;
+  canonicalConversationRef?: string;
+}): TrustedSessionMemorySubjectSnapshot {
+  const snapshot = {
+    sessionKey: requireSessionMemorySubjectText(params.sessionKey, "sessionKey"),
+    sessionId: requireSessionMemorySubjectText(params.sessionId, "sessionId"),
+    sessionScope: params.sessionScope,
+    sessionIdentityRevision: requireSessionMemorySubjectText(
+      params.sessionIdentityRevision,
+      "sessionIdentityRevision",
+    ),
+    subjectRevision: requireSessionMemorySubjectText(params.subjectRevision, "subjectRevision"),
+    subject: cloneSubject(params.subject),
+    ...(params.creationBindingId
+      ? {
+          creationBindingId: requireSessionMemorySubjectText(
+            params.creationBindingId,
+            "creationBindingId",
+          ),
+        }
+      : {}),
+    ...(params.canonicalConversationRef
+      ? {
+          canonicalConversationRef: requireSessionMemorySubjectText(
+            params.canonicalConversationRef,
+            "canonicalConversationRef",
+          ),
+        }
+      : {}),
+  } as Omit<TrustedSessionMemorySubjectSnapshot, typeof trustedSnapshotBrand> & {
+    [trustedSnapshotBrand]?: true;
+  };
+  Object.defineProperty(snapshot, trustedSnapshotBrand, {
+    value: true,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  trustedSnapshots.add(snapshot);
+  return deepFreeze(snapshot) as TrustedSessionMemorySubjectSnapshot;
+}
+
+export function isTrustedSessionMemorySubjectSnapshot(
+  value: unknown,
+): value is TrustedSessionMemorySubjectSnapshot {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    trustedSnapshots.has(value) &&
+    (value as Record<symbol, unknown>)[trustedSnapshotBrand] === true &&
+    Object.isFrozen(value),
+  );
+}
+
+/** Copies exact persisted provenance; snapshot-shaped caller data is not lineage proof. */
+export function prepareSessionMemorySubjectLineageSeed(
+  snapshot: TrustedSessionMemorySubjectSnapshot,
+): TrustedSessionMemorySubjectSeed {
+  if (!isTrustedSessionMemorySubjectSnapshot(snapshot)) {
+    throw new InvalidSessionMemorySubjectSeedError();
+  }
+  return createTrustedSessionMemorySubjectSeed({
+    subject: snapshot.subject,
+    subjectRevision: snapshot.subjectRevision,
+    ...(snapshot.creationBindingId ? { creationBindingId: snapshot.creationBindingId } : {}),
+    ...(snapshot.canonicalConversationRef
+      ? { canonicalConversationRef: snapshot.canonicalConversationRef }
+      : {}),
+  });
+}

--- a/src/config/sessions/session-memory-subject.test.ts
+++ b/src/config/sessions/session-memory-subject.test.ts
@@ -1,0 +1,925 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { createMemoryIdentityBindingThroughApprovedPairing } from "../../pairing/memory-identity-approval.test-support.js";
+import { memoryIdentityLifecycle } from "../../state/memory-identity.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import { ensureProfileForEmail, linkEmail } from "../../state/user-profiles.js";
+import { createSessionEntryWithTrustedMemorySubject } from "./session-accessor.entry-mutation.js";
+import {
+  recordInboundSessionMeta,
+  replaceSessionEntrySync,
+  resetSessionEntryLifecycle,
+  upsertSessionEntry,
+} from "./session-accessor.js";
+import * as sessionAccessorModule from "./session-accessor.js";
+import { resolveSqliteScope, toDatabaseOptions } from "./session-accessor.sqlite-scope.js";
+import {
+  appendSqliteTranscriptMessage,
+  importSqliteSessionRows,
+} from "./session-accessor.sqlite.js";
+import {
+  readCurrentSessionMemorySubject,
+  readCurrentSessionMemorySubjectAuthority,
+} from "./session-memory-subject-access.js";
+import {
+  createTrustedSessionMemorySubjectIssuer,
+  createTrustedSessionMemorySubjectSeed,
+} from "./session-memory-subject-trust.js";
+import {
+  prepareAmbiguousSessionMemorySubjectSeed,
+  prepareAutonomousAgentSessionMemorySubjectSeed,
+  prepareChannelBindingSessionMemorySubjectSeed,
+  prepareConversationSessionMemorySubjectSeed,
+  prepareExplicitSessionMemorySubjectSeed,
+  prepareGatewayProfileSessionMemorySubjectSeed,
+  prepareSessionMemorySubjectLineageSeed,
+  readSessionMemorySubjectFromDatabase,
+  SessionMemorySubjectReboundError,
+} from "./session-memory-subject.js";
+import * as sessionMemorySubjectModule from "./session-memory-subject.js";
+
+const {
+  ensureEnterpriseMemoryPrincipal,
+  ensureGatewayProfileMemoryPrincipal,
+  revokeMemoryIdentityBinding,
+  revokeMemoryPrincipal,
+} = memoryIdentityLifecycle;
+
+const tempDirectories = useAutoCleanupTempDirTracker(afterEach);
+
+function createPaths() {
+  const directory = tempDirectories.make("openclaw-session-memory-subject-");
+  return {
+    stateOptions: { env: { ...process.env, OPENCLAW_STATE_DIR: directory } },
+    storePath: path.join(directory, "sessions.json"),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("session memory subject", () => {
+  it("keeps subject issuance out of the stable session accessor barrel", () => {
+    expect(sessionAccessorModule).not.toHaveProperty("prepareExplicitSessionMemorySubjectSeed");
+    expect(sessionAccessorModule).not.toHaveProperty("prepareAmbiguousSessionMemorySubjectSeed");
+    expect(sessionAccessorModule).not.toHaveProperty(
+      "prepareAutonomousAgentSessionMemorySubjectSeed",
+    );
+    expect(sessionAccessorModule).not.toHaveProperty(
+      "prepareChannelBindingSessionMemorySubjectSeed",
+    );
+    expect(sessionAccessorModule).not.toHaveProperty("prepareConversationSessionMemorySubjectSeed");
+    expect(sessionAccessorModule).not.toHaveProperty(
+      "prepareGatewayProfileSessionMemorySubjectSeed",
+    );
+    expect(sessionAccessorModule).not.toHaveProperty("prepareSessionMemorySubjectLineageSeed");
+  });
+
+  it("keeps public inbound channel context unbound", async () => {
+    const { storePath } = createPaths();
+    const sessionKey = "agent:main:telegram:direct:constructed-user";
+
+    await recordInboundSessionMeta({
+      storePath,
+      sessionKey,
+      ctx: {
+        Provider: "telegram",
+        Surface: "telegram",
+        AccountId: "default",
+        ChatType: "direct",
+        From: "telegram:constructed-user",
+        To: "telegram:bot",
+        SessionKey: sessionKey,
+        OriginatingTo: "telegram:bot",
+        NativeChannelId: "dm-channel-1",
+        NativeDirectUserId: "constructed-user",
+        InboundAccessAuthorized: true,
+      },
+    });
+
+    expect(
+      readCurrentSessionMemorySubject({ agentId: "main", sessionKey, storePath })?.subject,
+    ).toEqual({
+      version: 1,
+      kind: "ambiguous",
+      reason: "unbound",
+    });
+  });
+
+  it("requires channel-binding provenance to retain its binding id", () => {
+    const subject = {
+      version: 1 as const,
+      kind: "user" as const,
+      principalId: "principal-1",
+      creationEvidence: { kind: "channel-binding" as const, revision: "evidence-1" },
+    };
+
+    expect(() => createTrustedSessionMemorySubjectSeed({ subject })).toThrow(
+      "channel-binding subjects must carry exactly one creationBindingId",
+    );
+    expect(() =>
+      createTrustedSessionMemorySubjectSeed({
+        subject: {
+          ...subject,
+          creationEvidence: { kind: "gateway-profile", revision: "evidence-1" },
+        },
+        creationBindingId: "binding-1",
+      }),
+    ).toThrow("channel-binding subjects must carry exactly one creationBindingId");
+  });
+
+  it("uses a trusted message-append seed before materializing its transcript header", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const scope = {
+      agentId: "main",
+      sessionId: "message-seed-session",
+      sessionKey: "agent:main:message-seed",
+      storePath,
+    };
+    const seed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "service",
+      stableSubjectId: "message-seed-service",
+      now: 100,
+      options: stateOptions,
+    });
+
+    await appendSqliteTranscriptMessage(scope, {
+      memorySubjectSeed: seed,
+      memorySubjectScope: "conversation",
+      message: { role: "user", content: "first message" },
+      now: 101,
+    });
+
+    expect(readCurrentSessionMemorySubject(scope)).toMatchObject({
+      sessionId: scope.sessionId,
+      sessionScope: "conversation",
+      subjectRevision: seed.subjectRevision,
+      subject: seed.subject,
+    });
+  });
+
+  it("keeps the first trusted subject immutable across later entry writes", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const scope = { agentId: "main", sessionKey: "agent:main:service:task-1", storePath };
+    const originalSeed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "service",
+      stableSubjectId: "task-service",
+      now: 100,
+      options: stateOptions,
+    });
+    const replacementSeed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "system",
+      stableSubjectId: "attempted-replacement",
+      now: 100,
+      options: stateOptions,
+    });
+
+    await upsertSessionEntry(
+      scope,
+      { sessionId: "session-1", updatedAt: 100 },
+      { memorySubjectSeed: originalSeed },
+    );
+    const first = readCurrentSessionMemorySubject(scope);
+    await upsertSessionEntry(
+      scope,
+      { label: "updated", updatedAt: 110 },
+      { memorySubjectSeed: replacementSeed },
+    );
+    const second = readCurrentSessionMemorySubject(scope);
+
+    expect(first?.subject).toMatchObject({ kind: "service" });
+    expect(second).toMatchObject({
+      sessionId: "session-1",
+      subjectRevision: first?.subjectRevision,
+      subject: first?.subject,
+    });
+  });
+
+  it("forces a shared-main direct session to an explicit ambiguous subject", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const scope = { agentId: "main", sessionKey: "agent:main:main", storePath };
+    const privateSeed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "agent",
+      stableSubjectId: "main",
+      now: 100,
+      options: stateOptions,
+    });
+
+    await upsertSessionEntry(
+      scope,
+      { chatType: "direct", sessionId: "shared-main", updatedAt: 100 },
+      { memorySubjectSeed: privateSeed },
+    );
+
+    expect(readCurrentSessionMemorySubject(scope)?.subject).toEqual({
+      version: 1,
+      kind: "ambiguous",
+      reason: "shared-main",
+    });
+  });
+
+  it("persists the isolated DM, group, and channel subject matrix", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const principal = ensureEnterpriseMemoryPrincipal({
+      issuer: "test-issuer",
+      stableSubjectId: "isolated-dm-user",
+      now: 100,
+      options: stateOptions,
+    });
+    await createMemoryIdentityBindingThroughApprovedPairing({
+      channel: "telegram",
+      accountId: "default",
+      stableSenderId: "telegram-dm-user",
+      principalId: principal.principalId,
+      now: 100,
+      options: stateOptions,
+    });
+    const cases = [
+      {
+        label: "isolated DM",
+        sessionKey: "agent:main:telegram:direct:telegram-dm-user",
+        chatType: "direct" as const,
+        sessionScope: "conversation",
+        seed: prepareChannelBindingSessionMemorySubjectSeed({
+          channel: "telegram",
+          accountId: "default",
+          stableSenderId: "telegram-dm-user",
+          now: 101,
+          options: stateOptions,
+        }),
+      },
+      {
+        label: "group",
+        sessionKey: "agent:main:telegram:group:group-1",
+        chatType: "group" as const,
+        sessionScope: "group",
+        seed: prepareConversationSessionMemorySubjectSeed({
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "group-1",
+          canonicalConversationRef: "telegram:default:group:group-1",
+          now: 101,
+          options: stateOptions,
+        }),
+      },
+      {
+        label: "channel",
+        sessionKey: "agent:main:discord:channel:channel-1",
+        chatType: "channel" as const,
+        sessionScope: "channel",
+        seed: prepareConversationSessionMemorySubjectSeed({
+          channel: "discord",
+          accountId: "primary",
+          conversationId: "channel-1",
+          canonicalConversationRef: "discord:primary:channel:channel-1",
+          now: 101,
+          options: stateOptions,
+        }),
+      },
+    ];
+
+    for (const testCase of cases) {
+      const scope = { agentId: "main", sessionKey: testCase.sessionKey, storePath };
+      await upsertSessionEntry(
+        scope,
+        {
+          chatType: testCase.chatType,
+          sessionId: `${testCase.label.replaceAll(" ", "-")}-session`,
+          updatedAt: 101,
+        },
+        { memorySubjectSeed: testCase.seed },
+      );
+      const snapshot = readCurrentSessionMemorySubject(scope);
+      if (!snapshot) {
+        throw new Error(`expected persisted ${testCase.label} memory subject`);
+      }
+      expect(snapshot.sessionScope).toBe(testCase.sessionScope);
+      expect(snapshot.subjectRevision).toBe(testCase.seed.subjectRevision);
+      expect(snapshot.subject).toEqual(testCase.seed.subject);
+    }
+  });
+
+  it("normalizes autonomous agent IDs before resolving their principal", () => {
+    const { stateOptions } = createPaths();
+    const autonomous = prepareAutonomousAgentSessionMemorySubjectSeed(
+      "  Research Agent  ",
+      stateOptions,
+    );
+    const canonical = prepareExplicitSessionMemorySubjectSeed({
+      kind: "agent",
+      stableSubjectId: "research-agent",
+      now: 100,
+      options: stateOptions,
+    });
+
+    expect(autonomous.subject).toEqual(canonical.subject);
+    expect(autonomous.subject).toMatchObject({ version: 1, kind: "agent" });
+  });
+
+  it("copies the exact subject revision into a reset window", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const sessionKey = "agent:main:service:reset";
+    const scope = { agentId: "main", sessionKey, storePath };
+    const seed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "service",
+      stableSubjectId: "reset-service",
+      now: 100,
+      options: stateOptions,
+    });
+    await upsertSessionEntry(
+      scope,
+      { sessionId: "before-reset", updatedAt: 100 },
+      { memorySubjectSeed: seed },
+    );
+    const before = readCurrentSessionMemorySubject(scope);
+    if (!before) {
+      throw new Error("expected pre-reset memory subject");
+    }
+
+    await resetSessionEntryLifecycle({
+      buildNextEntry: () => ({ sessionId: "after-reset", updatedAt: 200 }),
+      storePath,
+      target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+    });
+    const after = readCurrentSessionMemorySubject(scope);
+    if (!after) {
+      throw new Error("expected post-reset memory subject");
+    }
+
+    expect(after.sessionId).toBe("after-reset");
+    expect(after.subjectRevision).toBe(before.subjectRevision);
+    expect(after.subject).toEqual(before.subject);
+    expect(after.sessionIdentityRevision).not.toBe(before.sessionIdentityRevision);
+  });
+
+  it("preserves confirmed import lineage and quarantines unconfirmed imports", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const sourceScope = { agentId: "main", sessionKey: "agent:main:import-source", storePath };
+    const sourceSeed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "service",
+      stableSubjectId: "confirmed-import-source",
+      now: 100,
+      options: stateOptions,
+    });
+    await upsertSessionEntry(
+      sourceScope,
+      { sessionId: "import-source-session", updatedAt: 100 },
+      { memorySubjectSeed: sourceSeed },
+    );
+    const source = readCurrentSessionMemorySubject(sourceScope);
+    if (!source) {
+      throw new Error("expected source import memory subject");
+    }
+
+    const confirmedKey = "agent:main:confirmed-import";
+    await importSqliteSessionRows({
+      agentId: "main",
+      storePath,
+      sessionKey: confirmedKey,
+      entry: { sessionId: "confirmed-import-session", updatedAt: 110 },
+      confirmedMemorySubjectLineage: prepareSessionMemorySubjectLineageSeed(source),
+    });
+    const confirmed = readCurrentSessionMemorySubject({
+      agentId: "main",
+      sessionKey: confirmedKey,
+      storePath,
+    });
+    if (!confirmed) {
+      throw new Error("expected confirmed import memory subject");
+    }
+    expect(confirmed.subjectRevision).toBe(source.subjectRevision);
+    expect(confirmed.subject).toEqual(source.subject);
+
+    const unconfirmedKey = "agent:main:unconfirmed-import";
+    await importSqliteSessionRows({
+      agentId: "main",
+      storePath,
+      sessionKey: unconfirmedKey,
+      entry: { sessionId: "unconfirmed-import-session", updatedAt: 120 },
+    });
+    const unconfirmed = readCurrentSessionMemorySubject({
+      agentId: "main",
+      sessionKey: unconfirmedKey,
+      storePath,
+    });
+    if (!unconfirmed) {
+      throw new Error("expected unconfirmed import memory subject");
+    }
+    expect(unconfirmed.subject).toEqual({ version: 1, kind: "ambiguous", reason: "unbound" });
+    expect(unconfirmed.subjectRevision).not.toBe(source.subjectRevision);
+  });
+
+  it("rejects reuse of one transcript session id by another logical subject", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const firstScope = { agentId: "main", sessionKey: "agent:main:first", storePath };
+    const secondScope = { agentId: "main", sessionKey: "agent:main:second", storePath };
+    const firstSeed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "agent",
+      stableSubjectId: "first",
+      now: 100,
+      options: stateOptions,
+    });
+    const secondSeed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "agent",
+      stableSubjectId: "second",
+      now: 100,
+      options: stateOptions,
+    });
+    await upsertSessionEntry(
+      firstScope,
+      { sessionId: "reused-session-id", updatedAt: 100 },
+      { memorySubjectSeed: firstSeed },
+    );
+
+    await expect(
+      upsertSessionEntry(
+        secondScope,
+        { sessionId: "reused-session-id", updatedAt: 110 },
+        { memorySubjectSeed: secondSeed },
+      ),
+    ).rejects.toBeInstanceOf(SessionMemorySubjectReboundError);
+    expect(readCurrentSessionMemorySubject(firstScope)?.subject).toMatchObject({
+      kind: "agent",
+    });
+    expect(readCurrentSessionMemorySubject(secondScope)).toBeUndefined();
+  });
+
+  it("preserves denied subject identity across legacy aliases of one transcript", async () => {
+    const { storePath } = createPaths();
+    const firstScope = { agentId: "main", sessionKey: "legacy-alias", storePath };
+    const secondScope = { agentId: "main", sessionKey: "agent:main:legacy-alias", storePath };
+
+    await upsertSessionEntry(firstScope, { sessionId: "legacy-alias-session", updatedAt: 100 });
+    await upsertSessionEntry(secondScope, { sessionId: "legacy-alias-session", updatedAt: 110 });
+
+    const first = readCurrentSessionMemorySubject(firstScope);
+    const second = readCurrentSessionMemorySubject(secondScope);
+    expect(first?.subject).toEqual({ version: 1, kind: "ambiguous", reason: "unbound" });
+    expect(second).toMatchObject({
+      sessionIdentityRevision: first?.sessionIdentityRevision,
+      subjectRevision: first?.subjectRevision,
+      subject: first?.subject,
+    });
+  });
+
+  it("keeps an alias-first legacy backfill attached to its canonical transcript window", async () => {
+    const { storePath } = createPaths();
+    const sessionId = "legacy-alias-window";
+    const legacyKey = "agent:main:matrix:channel:!mixedcase:example.org";
+    const canonicalKey = "agent:main:matrix:channel:!MixedCase:example.org";
+    const legacyScope = { agentId: "main", sessionKey: legacyKey, storePath };
+    const canonicalScope = { agentId: "main", sessionKey: canonicalKey, storePath };
+
+    // Doctor import preserves two historical keys. The canonical import is the
+    // final writer, so the shared window belongs to the mixed-case key.
+    await importSqliteSessionRows({
+      agentId: "main",
+      preserveExactStoredKey: true,
+      storePath,
+      sessionKey: legacyKey,
+      entry: { sessionId, updatedAt: 100 },
+    });
+    await importSqliteSessionRows({
+      agentId: "main",
+      preserveExactStoredKey: true,
+      storePath,
+      sessionKey: canonicalKey,
+      entry: { sessionId, updatedAt: 101 },
+    });
+
+    const database = openOpenClawAgentDatabase(
+      toDatabaseOptions(resolveSqliteScope(canonicalScope)),
+    );
+    // Simulate an older SQLite file that predates subject persistence while
+    // retaining its legacy aliases and the canonical transcript window.
+    database.db.exec(`
+      DELETE FROM session_memory_subject_snapshots;
+      DELETE FROM session_memory_subjects;
+    `);
+
+    const aliasFirst = readCurrentSessionMemorySubject(legacyScope);
+    expect(aliasFirst).toMatchObject({
+      sessionId,
+      sessionKey: canonicalKey,
+      subject: { version: 1, kind: "ambiguous", reason: "unbound" },
+    });
+    expect(
+      database.db
+        .prepare("SELECT session_key FROM session_windows WHERE session_id = ?")
+        .get(sessionId),
+    ).toEqual({ session_key: canonicalKey });
+    expect(
+      database.db
+        .prepare("SELECT session_key FROM session_memory_subject_snapshots WHERE session_id = ?")
+        .get(sessionId),
+    ).toEqual({ session_key: canonicalKey });
+
+    // The next alias read is direct rather than another backfill. A mismatched
+    // snapshot would fail the reader's window-owner predicate.
+    expect(readCurrentSessionMemorySubject(legacyScope)).toMatchObject({
+      sessionId,
+      sessionKey: legacyKey,
+      subjectRevision: aliasFirst?.subjectRevision,
+    });
+    expect(readSessionMemorySubjectFromDatabase(database, legacyKey)).toMatchObject({
+      sessionId,
+      sessionKey: legacyKey,
+      subjectRevision: aliasFirst?.subjectRevision,
+    });
+    const canonical = readCurrentSessionMemorySubject(canonicalScope);
+    expect(canonical).toMatchObject({
+      sessionId,
+      sessionKey: canonicalKey,
+      subjectRevision: aliasFirst?.subjectRevision,
+    });
+    expect(readSessionMemorySubjectFromDatabase(database, canonicalKey)).toMatchObject({
+      sessionId,
+      sessionKey: canonicalKey,
+      subjectRevision: aliasFirst?.subjectRevision,
+    });
+  });
+
+  it("does not infer private lineage from an unseeded reused transcript id", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const firstScope = { agentId: "main", sessionKey: "agent:main:private", storePath };
+    const secondScope = { agentId: "main", sessionKey: "agent:main:untrusted-alias", storePath };
+    const privateSeed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "agent",
+      stableSubjectId: "private",
+      now: 100,
+      options: stateOptions,
+    });
+    await upsertSessionEntry(
+      firstScope,
+      { sessionId: "private-session-id", updatedAt: 100 },
+      { memorySubjectSeed: privateSeed },
+    );
+
+    await expect(
+      upsertSessionEntry(secondScope, { sessionId: "private-session-id", updatedAt: 110 }),
+    ).rejects.toBeInstanceOf(SessionMemorySubjectReboundError);
+    expect(readCurrentSessionMemorySubject(secondScope)).toBeUndefined();
+  });
+
+  it("lazily backfills old session rows as unbound instead of opening private authority", async () => {
+    const { storePath } = createPaths();
+    const scope = { agentId: "main", sessionKey: "agent:main:legacy", storePath };
+    await upsertSessionEntry(scope, { sessionId: "legacy-session", updatedAt: 100 });
+
+    expect(readCurrentSessionMemorySubject(scope)?.subject).toEqual(
+      prepareAmbiguousSessionMemorySubjectSeed("unbound").subject,
+    );
+  });
+
+  it("does not let an issuer bind an adopted legacy row", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const scope = { agentId: "main", sessionKey: "agent:main:adopted-legacy", storePath };
+    await upsertSessionEntry(scope, { sessionId: "adopted-legacy-session", updatedAt: 100 });
+
+    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolveSqliteScope(scope)));
+    // Simulate a pre-memory-schema row: the entry is durable, but no immutable
+    // subject/snapshot was ever written for it.
+    database.db.exec(`
+      DELETE FROM session_memory_subject_snapshots;
+      DELETE FROM session_memory_subjects;
+    `);
+    const issuerSeed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "agent",
+      stableSubjectId: "must-not-bind-adoption",
+      now: 101,
+      options: stateOptions,
+    });
+    const issue = vi.fn(() => issuerSeed);
+
+    await createSessionEntryWithTrustedMemorySubject(
+      scope,
+      ({ existingEntry }) => {
+        if (!existingEntry) {
+          throw new Error("expected adopted entry");
+        }
+        return {
+          ok: true,
+          entry: { ...existingEntry, label: "adopted", updatedAt: 101 },
+        };
+      },
+      createTrustedSessionMemorySubjectIssuer(issue),
+    );
+
+    expect(issue).not.toHaveBeenCalled();
+    expect(readCurrentSessionMemorySubject(scope)?.subject).toEqual(
+      prepareAmbiguousSessionMemorySubjectSeed("unbound").subject,
+    );
+  });
+
+  it("does not treat previousSessionId alone as private subject lineage", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const sourceScope = { agentId: "main", sessionKey: "agent:main:private-source", storePath };
+    const targetScope = { agentId: "main", sessionKey: "agent:main:unproven-target", storePath };
+    const sourceSeed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "service",
+      stableSubjectId: "private-source",
+      now: 100,
+      options: stateOptions,
+    });
+    await upsertSessionEntry(
+      sourceScope,
+      { sessionId: "private-source-session", updatedAt: 100 },
+      { memorySubjectSeed: sourceSeed },
+    );
+    const source = readCurrentSessionMemorySubject(sourceScope);
+
+    await upsertSessionEntry(targetScope, {
+      previousSessionId: "private-source-session",
+      sessionId: "unproven-target-session",
+      updatedAt: 110,
+    });
+    const target = readCurrentSessionMemorySubject(targetScope);
+
+    expect(target?.subject).toEqual({ version: 1, kind: "ambiguous", reason: "unbound" });
+    expect(target?.subjectRevision).not.toBe(source?.subjectRevision);
+  });
+
+  it("reports a revoked captured binding separately from its current principal", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const scope = { agentId: "main", sessionKey: "agent:main:bound-user", storePath };
+    const principal = ensureEnterpriseMemoryPrincipal({
+      issuer: "test-issuer",
+      stableSubjectId: "bound-user",
+      now: 100,
+      options: stateOptions,
+    });
+    const binding = await createMemoryIdentityBindingThroughApprovedPairing({
+      channel: "telegram",
+      accountId: "default",
+      stableSenderId: "telegram-user-1",
+      principalId: principal.principalId,
+      now: 100,
+      options: stateOptions,
+    });
+    const seed = prepareChannelBindingSessionMemorySubjectSeed({
+      channel: "telegram",
+      accountId: "default",
+      stableSenderId: "telegram-user-1",
+      now: 101,
+      options: stateOptions,
+    });
+    await upsertSessionEntry(
+      scope,
+      { sessionId: "bound-user-session", updatedAt: 101 },
+      { memorySubjectSeed: seed },
+    );
+
+    const revocationReason = "operator requested removal";
+    expect(
+      revokeMemoryIdentityBinding({
+        bindingId: binding.bindingId,
+        revokedBy: "operator-2",
+        reason: revocationReason,
+        now: 102,
+        options: stateOptions,
+      }),
+    ).toBe(true);
+    const revocation = openOpenClawStateDatabase(stateOptions)
+      .db.prepare(
+        "SELECT revoked_at, revoked_by, revocation_reason FROM memory_identity_bindings WHERE binding_id = ?",
+      )
+      .get(binding.bindingId) as
+      | { revoked_at: number; revoked_by: string; revocation_reason: string }
+      | undefined;
+    expect(revocation).toEqual({
+      revoked_at: 102,
+      revoked_by: "operator-2",
+      revocation_reason: revocationReason,
+    });
+    expect(readCurrentSessionMemorySubjectAuthority(scope, stateOptions, 103)?.authority).toEqual({
+      kind: "denied",
+      reason: "binding-revoked",
+    });
+  });
+
+  it("denies a persisted user subject when conflicting binding evidence appears", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const scope = { agentId: "main", sessionKey: "agent:main:binding-conflict", storePath };
+    const first = ensureEnterpriseMemoryPrincipal({
+      issuer: "test-issuer",
+      stableSubjectId: "binding-conflict-first",
+      now: 100,
+      options: stateOptions,
+    });
+    const second = ensureEnterpriseMemoryPrincipal({
+      issuer: "test-issuer",
+      stableSubjectId: "binding-conflict-second",
+      now: 100,
+      options: stateOptions,
+    });
+    await createMemoryIdentityBindingThroughApprovedPairing({
+      channel: "telegram",
+      accountId: "default",
+      stableSenderId: "binding-conflict-user",
+      principalId: first.principalId,
+      now: 100,
+      options: stateOptions,
+    });
+    const seed = prepareChannelBindingSessionMemorySubjectSeed({
+      channel: "telegram",
+      accountId: "default",
+      stableSenderId: "binding-conflict-user",
+      now: 101,
+      options: stateOptions,
+    });
+    await upsertSessionEntry(
+      scope,
+      { sessionId: "binding-conflict-session", updatedAt: 101 },
+      { memorySubjectSeed: seed },
+    );
+
+    await createMemoryIdentityBindingThroughApprovedPairing({
+      channel: "telegram",
+      accountId: "default",
+      stableSenderId: "binding-conflict-user",
+      principalId: second.principalId,
+      now: 102,
+      options: stateOptions,
+    });
+
+    expect(readCurrentSessionMemorySubjectAuthority(scope, stateOptions, 103)?.authority).toEqual({
+      kind: "denied",
+      reason: "binding-revoked",
+    });
+  });
+
+  it("reports principal revocation before a still-present captured binding", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const scope = { agentId: "main", sessionKey: "agent:main:revoked-user", storePath };
+    const principal = ensureEnterpriseMemoryPrincipal({
+      issuer: "test-issuer",
+      stableSubjectId: "revoked-user",
+      now: 100,
+      options: stateOptions,
+    });
+    await createMemoryIdentityBindingThroughApprovedPairing({
+      channel: "signal",
+      accountId: "primary",
+      stableSenderId: "signal-user-1",
+      principalId: principal.principalId,
+      now: 100,
+      options: stateOptions,
+    });
+    const seed = prepareChannelBindingSessionMemorySubjectSeed({
+      channel: "signal",
+      accountId: "primary",
+      stableSenderId: "signal-user-1",
+      now: 101,
+      options: stateOptions,
+    });
+    await upsertSessionEntry(
+      scope,
+      { sessionId: "revoked-user-session", updatedAt: 101 },
+      { memorySubjectSeed: seed },
+    );
+
+    expect(
+      revokeMemoryPrincipal({
+        principalId: principal.principalId,
+        now: 102,
+        options: stateOptions,
+      }),
+    ).toBe(true);
+    expect(readCurrentSessionMemorySubjectAuthority(scope, stateOptions, 103)?.authority).toEqual({
+      kind: "denied",
+      reason: "principal-revoked",
+    });
+  });
+
+  it("fails closed when a binding is revoked between authority checks", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const scope = { agentId: "main", sessionKey: "agent:main:binding-race", storePath };
+    const principal = ensureEnterpriseMemoryPrincipal({
+      issuer: "test-issuer",
+      stableSubjectId: "binding-race-user",
+      now: 100,
+      options: stateOptions,
+    });
+    const binding = await createMemoryIdentityBindingThroughApprovedPairing({
+      channel: "telegram",
+      accountId: "default",
+      stableSenderId: "binding-race-user",
+      principalId: principal.principalId,
+      now: 100,
+      options: stateOptions,
+    });
+    const seed = prepareChannelBindingSessionMemorySubjectSeed({
+      channel: "telegram",
+      accountId: "default",
+      stableSenderId: "binding-race-user",
+      now: 101,
+      options: stateOptions,
+    });
+    await upsertSessionEntry(
+      scope,
+      { sessionId: "binding-race-session", updatedAt: 101 },
+      { memorySubjectSeed: seed },
+    );
+
+    const resolveAuthority = sessionMemorySubjectModule.resolveSessionMemorySubjectAuthority;
+    let authorityChecks = 0;
+    const resolveAuthoritySpy = vi
+      .spyOn(sessionMemorySubjectModule, "resolveSessionMemorySubjectAuthority")
+      .mockImplementation((snapshot, options, now) => {
+        const result = resolveAuthority(snapshot, options, now);
+        authorityChecks += 1;
+        if (authorityChecks === 1) {
+          expect(result.kind).toBe("current");
+          revokeMemoryIdentityBinding({
+            bindingId: binding.bindingId,
+            revokedBy: "operator-2",
+            now: 102,
+            options: stateOptions,
+          });
+        }
+        return result;
+      });
+
+    expect(readCurrentSessionMemorySubjectAuthority(scope, stateOptions, 103)?.authority).toEqual({
+      kind: "denied",
+      reason: "binding-revoked",
+    });
+    expect(resolveAuthoritySpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a session window replaced between authority checks", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const scope = { agentId: "main", sessionKey: "agent:main:rebound-race", storePath };
+    const seed = prepareExplicitSessionMemorySubjectSeed({
+      kind: "service",
+      stableSubjectId: "rebound-race-service",
+      now: 100,
+      options: stateOptions,
+    });
+    await upsertSessionEntry(
+      scope,
+      { sessionId: "rebound-race-before", updatedAt: 101 },
+      { memorySubjectSeed: seed },
+    );
+
+    const resolveAuthority = sessionMemorySubjectModule.resolveSessionMemorySubjectAuthority;
+    let replaced = false;
+    const resolveAuthoritySpy = vi
+      .spyOn(sessionMemorySubjectModule, "resolveSessionMemorySubjectAuthority")
+      .mockImplementation((snapshot, options, now) => {
+        const result = resolveAuthority(snapshot, options, now);
+        if (!replaced) {
+          replaced = true;
+          replaceSessionEntrySync(scope, {
+            sessionId: "rebound-race-after",
+            updatedAt: 102,
+          });
+        }
+        return result;
+      });
+
+    expect(() => readCurrentSessionMemorySubjectAuthority(scope, stateOptions, 103)).toThrow(
+      SessionMemorySubjectReboundError,
+    );
+    expect(resolveAuthoritySpy).toHaveBeenCalledOnce();
+  });
+
+  it("reconciles an old Gateway-profile session after linkEmail merges its profile", async () => {
+    const { stateOptions, storePath } = createPaths();
+    const scope = { agentId: "main", sessionKey: "agent:main:gateway-profile", storePath };
+    const sourceProfile = ensureProfileForEmail("source@example.test", stateOptions);
+    const targetProfile = ensureProfileForEmail("target@example.test", stateOptions);
+    const sourcePrincipal = ensureGatewayProfileMemoryPrincipal(sourceProfile.id, stateOptions);
+    const targetPrincipal = ensureGatewayProfileMemoryPrincipal(targetProfile.id, stateOptions);
+    const seed = prepareGatewayProfileSessionMemorySubjectSeed(sourceProfile.id, stateOptions);
+    if (!sourcePrincipal || !targetPrincipal || !seed) {
+      throw new Error("expected Gateway profile memory principals");
+    }
+    await upsertSessionEntry(
+      scope,
+      { sessionId: "gateway-profile-session", updatedAt: 100 },
+      { memorySubjectSeed: seed },
+    );
+
+    linkEmail("source@example.test", targetProfile.id, stateOptions);
+
+    expect(readCurrentSessionMemorySubjectAuthority(scope, stateOptions)?.authority).toEqual({
+      kind: "current",
+      currentPrincipalId: targetPrincipal.principalId,
+      assurance: "gateway-profile",
+      evidenceRevision: targetPrincipal.evidenceRevision,
+    });
+    expect(sourcePrincipal.principalId).not.toBe(targetPrincipal.principalId);
+  });
+});

--- a/src/config/sessions/session-memory-subject.ts
+++ b/src/config/sessions/session-memory-subject.ts
@@ -1,0 +1,249 @@
+import { normalizeAgentId } from "@openclaw/normalization-core/agent-id";
+import type { SessionMemorySubject } from "../../memory-host-sdk/host/authorization.js";
+import {
+  memoryIdentityLifecycle,
+  type MemoryIdentityBindingAssurance,
+} from "../../state/memory-identity.js";
+import type { OpenClawStateDatabaseOptions } from "../../state/openclaw-state-db.js";
+import {
+  createTrustedSessionMemorySubjectSeed,
+  InvalidSessionMemorySubjectSeedError,
+  isTrustedSessionMemorySubjectSnapshot,
+  requireSessionMemorySubjectText,
+  type TrustedSessionMemorySubjectSeed,
+  type TrustedSessionMemorySubjectSnapshot,
+} from "./session-memory-subject-trust.js";
+
+export {
+  persistSessionMemorySubjectInTransaction,
+  prepareCurrentSessionMemorySubjectLineageSeedInTransaction,
+  readOrCreateSessionMemorySubjectInTransaction,
+  readSessionMemorySubjectFromDatabase,
+  rehomeSessionMemorySubjectAliases,
+  tryRehomeSessionMemorySubjectSnapshot,
+} from "./session-memory-subject-persistence.js";
+export {
+  createTrustedSessionMemorySubjectIssuer,
+  InvalidSessionMemorySubjectSeedError,
+  isTrustedSessionMemorySubjectIssuer,
+  prepareSessionMemorySubjectLineageSeed,
+  SessionMemorySubjectReboundError,
+} from "./session-memory-subject-trust.js";
+export type {
+  SessionMemoryScope,
+  TrustedSessionMemorySubjectIssuer,
+  TrustedSessionMemorySubjectSeed,
+  TrustedSessionMemorySubjectSnapshot,
+} from "./session-memory-subject-trust.js";
+
+const {
+  ensureConversationMemoryPrincipal,
+  ensureExplicitMemoryPrincipal,
+  ensureGatewayProfileMemoryPrincipal,
+  resolveCurrentMemoryIdentityBinding,
+  resolveMemoryIdentityBinding,
+  resolveMemoryPrincipal,
+} = memoryIdentityLifecycle;
+
+export type SessionMemorySubjectAuthority =
+  | Readonly<{
+      kind: "current";
+      currentPrincipalId?: string;
+      assurance?: "gateway-profile" | MemoryIdentityBindingAssurance | "service";
+      evidenceRevision?: string;
+      expiresAt?: number;
+    }>
+  | Readonly<{
+      kind: "denied";
+      reason: "ambiguous" | "binding-revoked" | "principal-revoked" | "shared-main-private-subject";
+    }>;
+
+export function prepareGatewayProfileSessionMemorySubjectSeed(
+  profileId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): TrustedSessionMemorySubjectSeed | undefined {
+  const principal = ensureGatewayProfileMemoryPrincipal(profileId, options);
+  return principal
+    ? createTrustedSessionMemorySubjectSeed({
+        subject: {
+          version: 1,
+          kind: "user",
+          principalId: principal.principalId,
+          creationEvidence: {
+            kind: "gateway-profile",
+            revision: principal.evidenceRevision,
+          },
+        },
+      })
+    : undefined;
+}
+
+export function prepareChannelBindingSessionMemorySubjectSeed(params: {
+  channel: string;
+  accountId: string;
+  stableSenderId: string;
+  now?: number;
+  options?: OpenClawStateDatabaseOptions;
+}): TrustedSessionMemorySubjectSeed {
+  const resolution = resolveMemoryIdentityBinding(params);
+  if (resolution.kind === "conflicting-bindings") {
+    return createTrustedSessionMemorySubjectSeed({
+      subject: { version: 1, kind: "ambiguous", reason: "conflicting-bindings" },
+    });
+  }
+  if (resolution.kind === "unbound") {
+    return createTrustedSessionMemorySubjectSeed({
+      subject: { version: 1, kind: "ambiguous", reason: "unbound" },
+    });
+  }
+  return createTrustedSessionMemorySubjectSeed({
+    subject: {
+      version: 1,
+      kind: "user",
+      principalId: resolution.principalId,
+      creationEvidence: {
+        kind: "channel-binding",
+        revision: resolution.evidenceRevision,
+      },
+    },
+    creationBindingId: resolution.bindingId,
+  });
+}
+
+export function prepareConversationSessionMemorySubjectSeed(params: {
+  channel: string;
+  accountId: string;
+  conversationId: string;
+  canonicalConversationRef?: string;
+  now?: number;
+  options?: OpenClawStateDatabaseOptions;
+}): TrustedSessionMemorySubjectSeed {
+  const channel = requireSessionMemorySubjectText(params.channel, "channel").toLowerCase();
+  const accountId = requireSessionMemorySubjectText(params.accountId, "accountId");
+  const principal = ensureConversationMemoryPrincipal({
+    channel,
+    accountId,
+    conversationId: params.conversationId,
+    now: params.now,
+    options: params.options,
+  });
+  return createTrustedSessionMemorySubjectSeed({
+    subject: {
+      version: 1,
+      kind: "conversation",
+      conversationPrincipalId: principal.principalId,
+      channel,
+      accountId,
+    },
+    canonicalConversationRef: params.canonicalConversationRef,
+  });
+}
+
+export function prepareExplicitSessionMemorySubjectSeed(params: {
+  kind: "service" | "agent" | "system";
+  stableSubjectId: string;
+  issuer?: string;
+  now?: number;
+  expiresAt?: number;
+  options?: OpenClawStateDatabaseOptions;
+}): TrustedSessionMemorySubjectSeed {
+  const principal = ensureExplicitMemoryPrincipal(params);
+  return createTrustedSessionMemorySubjectSeed({
+    subject: {
+      version: 1,
+      kind: params.kind,
+      principalId: principal.principalId,
+    },
+  });
+}
+
+/** Resolves autonomous work to the stable principal owned by one canonical agent. */
+export function prepareAutonomousAgentSessionMemorySubjectSeed(
+  agentId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): TrustedSessionMemorySubjectSeed {
+  const canonicalAgentId = normalizeAgentId(requireSessionMemorySubjectText(agentId, "agentId"));
+  return prepareExplicitSessionMemorySubjectSeed({
+    kind: "agent",
+    stableSubjectId: canonicalAgentId,
+    options,
+  });
+}
+
+export function prepareAmbiguousSessionMemorySubjectSeed(
+  reason: Extract<SessionMemorySubject, { kind: "ambiguous" }>["reason"],
+): TrustedSessionMemorySubjectSeed {
+  return createTrustedSessionMemorySubjectSeed({
+    subject: { version: 1, kind: "ambiguous", reason },
+  });
+}
+
+export function resolveSessionMemorySubjectAuthority(
+  snapshot: TrustedSessionMemorySubjectSnapshot,
+  options: OpenClawStateDatabaseOptions = {},
+  now = Date.now(),
+): SessionMemorySubjectAuthority {
+  if (!isTrustedSessionMemorySubjectSnapshot(snapshot)) {
+    throw new InvalidSessionMemorySubjectSeedError();
+  }
+  if (snapshot.sessionScope === "shared-main" && snapshot.subject.kind !== "ambiguous") {
+    return { kind: "denied", reason: "shared-main-private-subject" };
+  }
+  const subject = snapshot.subject;
+  if (subject.kind === "ambiguous") {
+    return { kind: "denied", reason: "ambiguous" };
+  }
+  const principalId =
+    subject.kind === "conversation" ? subject.conversationPrincipalId : subject.principalId;
+  const principal = resolveMemoryPrincipal(principalId, options, now);
+  if (principal.kind !== "current") {
+    return { kind: "denied", reason: "principal-revoked" };
+  }
+  let currentPrincipal = principal.principal;
+  if (currentPrincipal.kind === "gateway-profile") {
+    if (!currentPrincipal.userProfileId) {
+      return { kind: "denied", reason: "principal-revoked" };
+    }
+    const reconciled = ensureGatewayProfileMemoryPrincipal(currentPrincipal.userProfileId, options);
+    if (!reconciled) {
+      return { kind: "denied", reason: "principal-revoked" };
+    }
+    currentPrincipal = reconciled;
+  }
+  if (subject.kind === "user" && snapshot.creationBindingId) {
+    const binding = resolveCurrentMemoryIdentityBinding({
+      bindingId: snapshot.creationBindingId,
+      principalId: subject.principalId,
+      evidenceRevision: subject.creationEvidence.revision,
+      now,
+      options,
+    });
+    if (binding.kind !== "verified") {
+      // Distinguish a principal revoked between the first check and the binding
+      // recheck from a revoked binding while still failing both races closed.
+      const latestPrincipal = resolveMemoryPrincipal(subject.principalId, options, now);
+      return latestPrincipal.kind === "current"
+        ? { kind: "denied", reason: "binding-revoked" }
+        : { kind: "denied", reason: "principal-revoked" };
+    }
+    return {
+      kind: "current",
+      currentPrincipalId: binding.principalId,
+      assurance: binding.assurance,
+      evidenceRevision: binding.evidenceRevision,
+      ...(binding.expiresAt === undefined ? {} : { expiresAt: binding.expiresAt }),
+    };
+  }
+  return {
+    kind: "current",
+    currentPrincipalId: currentPrincipal.principalId,
+    assurance:
+      subject.kind === "user" && subject.creationEvidence.kind === "gateway-profile"
+        ? "gateway-profile"
+        : subject.kind === "service" || subject.kind === "agent" || subject.kind === "system"
+          ? "service"
+          : undefined,
+    evidenceRevision: currentPrincipal.evidenceRevision,
+    ...(currentPrincipal.expiresAt === undefined ? {} : { expiresAt: currentPrincipal.expiresAt }),
+  };
+}

--- a/src/cron/isolated-agent/run-prepare-runtime.ts
+++ b/src/cron/isolated-agent/run-prepare-runtime.ts
@@ -41,9 +41,22 @@ export type WithRunSession = (
   result: Omit<RunCronAgentTurnResult, "sessionId" | "sessionKey">,
 ) => RunCronAgentTurnResult;
 
-const sessionAccessorRuntimeLoader = createLazyImportLoader(
-  () => import("../../config/sessions/session-accessor.js"),
-);
+const cronSessionMemoryRuntimeLoader = createLazyImportLoader(async () => {
+  const [entry, projection, subject] = await Promise.all([
+    import("../../config/sessions/session-accessor.sqlite-entry.js"),
+    import("../../config/sessions/session-accessor.sqlite-projection.js"),
+    import("../../config/sessions/session-memory-subject.js"),
+  ]);
+  return {
+    applySqliteSessionEntryLifecycleMutationWithTrustedMemorySubjects:
+      projection.applySqliteSessionEntryLifecycleMutationWithTrustedMemorySubjects,
+    createTrustedSessionMemorySubjectIssuer: subject.createTrustedSessionMemorySubjectIssuer,
+    patchSqliteSessionEntryTargetWithTrustedMemorySubject:
+      entry.patchSqliteSessionEntryTargetWithTrustedMemorySubject,
+    prepareAutonomousAgentSessionMemorySubjectSeed:
+      subject.prepareAutonomousAgentSessionMemorySubjectSeed,
+  };
+});
 const cronExternalContentRuntimeLoader = createLazyImportLoader(
   () => import("./run-external-content.runtime.js"),
 );
@@ -53,8 +66,8 @@ const cronAuthProfileRuntimeLoader = createLazyImportLoader(
 const cronModelPreflightRuntimeLoader = createLazyImportLoader(
   () => import("./model-preflight.runtime.js"),
 );
-export async function loadSessionAccessorRuntime() {
-  return await sessionAccessorRuntimeLoader.load();
+export async function loadCronSessionMemoryRuntime() {
+  return await cronSessionMemoryRuntimeLoader.load();
 }
 
 export async function loadCronExternalContentRuntime() {

--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -48,7 +48,7 @@ import {
   loadCronAuthProfileRuntime,
   loadCronExternalContentRuntime,
   loadCronModelPreflightRuntime,
-  loadSessionAccessorRuntime,
+  loadCronSessionMemoryRuntime,
   resolveCronAgentTurnMessage,
   retireRolledCronSessionMcpRuntime,
   type RunCronAgentTurnParams,
@@ -272,6 +272,10 @@ export async function prepareCronRunContext(params: {
   });
 
   try {
+    const memoryRuntime = await loadCronSessionMemoryRuntime();
+    const memorySubjectIssuer = memoryRuntime.createTrustedSessionMemorySubjectIssuer(() =>
+      memoryRuntime.prepareAutonomousAgentSessionMemorySubjectSeed(agentId),
+    );
     const persistCronSessionRow = async ({
       storePath,
       sessionKey,
@@ -285,10 +289,8 @@ export async function prepareCronRunContext(params: {
       resetBoundaryReason?: "cron-stale";
       update: (entry: SessionEntry | undefined) => SessionEntry;
     }) => {
-      const { applySessionEntryLifecycleMutation, patchSessionEntry } =
-        await loadSessionAccessorRuntime();
       if (resetBoundaryReason) {
-        await applySessionEntryLifecycleMutation({
+        await memoryRuntime.applySqliteSessionEntryLifecycleMutationWithTrustedMemorySubjects({
           activeSessionKey: sessionKey,
           agentId,
           storePath,
@@ -296,6 +298,7 @@ export async function prepareCronRunContext(params: {
             {
               sessionKey,
               resetBoundaryReason,
+              memorySubjectIssuer,
               buildEntry: ({ currentEntry }) => update(currentEntry),
             },
           ],
@@ -304,9 +307,14 @@ export async function prepareCronRunContext(params: {
         return;
       }
       // Guarded replace reads the freshest row so lifecycle claims reject stale owners.
-      await patchSessionEntry(
-        { storePath, sessionKey, agentId },
+      await memoryRuntime.patchSqliteSessionEntryTargetWithTrustedMemorySubject(
+        {
+          agentId,
+          storePath,
+          target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+        },
         (_entry, context) => update(context.existingEntry),
+        memorySubjectIssuer,
         { fallbackEntry, replaceEntry: true },
       );
     };

--- a/src/cron/isolated-agent/run.session-lifecycle.test.ts
+++ b/src/cron/isolated-agent/run.session-lifecycle.test.ts
@@ -1,12 +1,19 @@
 // Persistent cron session tests cover lifecycle admission and mutation races.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { readCurrentSessionMemorySubject } from "../../config/sessions/session-memory-subject-access.js";
+import { prepareAutonomousAgentSessionMemorySubjectSeed } from "../../config/sessions/session-memory-subject.js";
 import {
   interruptSessionWorkAdmissions,
   isSessionWorkAdmissionActive,
   runExclusiveSessionLifecycleMutation,
 } from "../../sessions/session-lifecycle-admission.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { withEnvAsync } from "../../test-utils/env.js";
 import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
 import {
   dispatchCronDeliveryMock,
@@ -25,6 +32,12 @@ import {
 
 const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
 const inMemoryStorePath = "/tmp/store.json";
+const tempDirectories = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
 
 function makePersistentCronParams(sessionKey: string) {
   return makeIsolatedAgentParamsFixture({
@@ -164,6 +177,98 @@ describe("runCronIsolatedAgentTurn session lifecycle", () => {
         fallbackEntry: expect.objectContaining({ sessionId: "isolated-session" }),
       }),
     );
+  });
+
+  it("persists the autonomous subject for an isolated cron session", async () => {
+    const agentId = "worker";
+    const sessionKey = "cron:memory-subject";
+    const canonicalSessionKey = `agent:${agentId}:${sessionKey}`;
+    const stateDir = tempDirectories.make("openclaw-cron-memory-subject-");
+    const storePath = path.join(stateDir, "agents", agentId, "sessions", "sessions.json");
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      resolveCronSessionMock.mockReturnValue(
+        makeCronSession({
+          storePath,
+          initialSessionEntry: undefined,
+          isNewSession: true,
+          sessionEntry: makeCronSessionEntry({ sessionId: "cron-memory-subject-session" }),
+        }),
+      );
+
+      await expect(
+        runCronIsolatedAgentTurn(
+          makeIsolatedAgentParamsFixture({
+            agentId,
+            sessionKey,
+            job: makeIsolatedAgentJobFixture({
+              sessionTarget: "isolated",
+              delivery: { mode: "none" },
+            }),
+          }),
+        ),
+      ).resolves.toMatchObject({ status: "ok" });
+
+      expect(
+        readCurrentSessionMemorySubject({
+          agentId,
+          sessionKey: canonicalSessionKey,
+          storePath,
+        })?.subject,
+      ).toEqual(prepareAutonomousAgentSessionMemorySubjectSeed(agentId).subject);
+    });
+  });
+
+  it("persists the service subject for a webhook-shaped cron session", async () => {
+    const agentId = "worker";
+    const hookSessionKey = "hook:webhook:ticket-42";
+    const canonicalSessionKey = `agent:${agentId}:${hookSessionKey}`;
+    const stateDir = tempDirectories.make("openclaw-cron-webhook-memory-subject-");
+    const storePath = path.join(stateDir, "agents", agentId, "sessions", "sessions.json");
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      resolveCronSessionMock.mockReturnValue(
+        makeCronSession({
+          storePath,
+          initialSessionEntry: undefined,
+          isNewSession: true,
+          sessionEntry: makeCronSessionEntry({ sessionId: "webhook-memory-subject-session" }),
+        }),
+      );
+
+      await expect(
+        runCronIsolatedAgentTurn(
+          makeIsolatedAgentParamsFixture({
+            agentId,
+            sessionKey: hookSessionKey,
+            job: makeIsolatedAgentJobFixture({
+              sessionTarget: `session:${hookSessionKey}`,
+              payload: {
+                kind: "agentTurn",
+                message: "externally sourced hook payload",
+                externalContentSource: "webhook",
+              },
+              delivery: { mode: "none" },
+            }),
+          }),
+        ),
+      ).resolves.toMatchObject({ status: "ok" });
+
+      expect(resolveCronSessionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId,
+          sessionKey: canonicalSessionKey,
+          hookExternalContentSource: "webhook",
+        }),
+      );
+      expect(
+        readCurrentSessionMemorySubject({
+          agentId,
+          sessionKey: canonicalSessionKey,
+          storePath,
+        })?.subject,
+      ).toEqual(prepareAutonomousAgentSessionMemorySubjectSeed(agentId).subject);
+    });
   });
 
   it("does not recreate a persistent session deleted during async setup", async () => {

--- a/src/gateway/server-instance-runtime.ts
+++ b/src/gateway/server-instance-runtime.ts
@@ -70,7 +70,10 @@ export function createGatewayInstanceRuntime(
     });
   };
 
-  const recoveryClient = createSyntheticPluginRuntimeClient({ scopes: [WRITE_SCOPE] });
+  const recoveryClient = createSyntheticPluginRuntimeClient({
+    scopes: [WRITE_SCOPE],
+    autonomousMemorySubject: "gateway-recovery",
+  });
   const recoveryMethods = new Set(["agent", "agent.wait"]);
   const approvalClient = createSyntheticPluginRuntimeClient({ scopes: [APPROVALS_SCOPE] });
   const approvalMethods = new Set<GatewayNativeApprovalMethod>(GATEWAY_NATIVE_APPROVAL_METHODS);

--- a/src/gateway/server-methods/agent-run-handler.ts
+++ b/src/gateway/server-methods/agent-run-handler.ts
@@ -24,7 +24,10 @@ import { startAgentRunExecution } from "./agent-run-execution-phase.js";
 import { buildAgentSessionPatch } from "./agent-session-patch.js";
 import { persistAgentSessionPhase } from "./agent-session-persist.js";
 import { prepareAgentSession } from "./agent-session-prepare.js";
-import { resolveAgentRunSessionCreation } from "./session-creation-provenance.js";
+import {
+  createAgentRunSessionMemorySubjectIssuer,
+  resolveAgentRunSessionCreation,
+} from "./session-creation-provenance.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
 export const agentRunHandler: GatewayRequestHandlers["agent"] = async ({
@@ -336,6 +339,7 @@ export const agentRunHandler: GatewayRequestHandlers["agent"] = async ({
       const sessionAgentId = canonicalSessionAgentId;
       resolvedSessionAgentId = sessionAgentId;
       const mainSessionKey = mainSessionKeyForRequest;
+      const memorySubjectIssuer = createAgentRunSessionMemorySubjectIssuer(client);
       try {
         await acquireGatewayWorkAdmission(storePath ?? `agent:${sessionAgentId}`);
       } catch (err) {
@@ -355,6 +359,7 @@ export const agentRunHandler: GatewayRequestHandlers["agent"] = async ({
         sessionAgentId,
         mainSessionKey,
         creation: resolveAgentRunSessionCreation(client),
+        memorySubjectIssuer,
         lifecycleGeneration,
         isRestartRecoveryResumeRun,
         runId,

--- a/src/gateway/server-methods/agent-session-persist.test.ts
+++ b/src/gateway/server-methods/agent-session-persist.test.ts
@@ -1,0 +1,208 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { commitMainSessionRecovery } from "../../agents/main-session-recovery-store.js";
+import {
+  resolveSqliteScope,
+  toDatabaseOptions,
+} from "../../config/sessions/session-accessor.sqlite-scope.js";
+import { readCurrentSessionMemorySubject } from "../../config/sessions/session-memory-subject-access.js";
+import { prepareExplicitSessionMemorySubjectSeed } from "../../config/sessions/session-memory-subject.js";
+import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import type { AgentSessionPatchBuild } from "./agent-session-patch.js";
+import { persistAgentSessionPhase } from "./agent-session-persist.js";
+import { createAgentRunSessionMemorySubjectIssuer } from "./session-creation-provenance.js";
+
+const tempDirectories = useAutoCleanupTempDirTracker(afterEach);
+
+function createPatchBuild(sessionId: string, isNewSession = true): AgentSessionPatchBuild {
+  return {
+    patch: { sessionId, updatedAt: 100 },
+    spawnedBy: undefined,
+    groupId: undefined,
+    groupChannel: undefined,
+    groupSpace: undefined,
+    freshSessionRotatedSinceLoad: false,
+    isNewSession,
+    rotatedSessionId: false,
+    usableRequestedSessionId: undefined,
+    freshness: undefined,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("persistAgentSessionPhase memory subject issuance", () => {
+  it("persists a Gateway restart-recovery run with its closed system subject on the canonical key", async () => {
+    const root = tempDirectories.make("openclaw-gateway-recovery-memory-subject-");
+    const storePath = path.join(root, "agents", "target", "sessions", "sessions.json");
+    const canonicalSessionKey = "agent:target:recovery:canonical";
+    const requestAlias = "agent:target:recovery:requested";
+    const sessionId = "recovery-session";
+    const memorySubjectIssuer = createAgentRunSessionMemorySubjectIssuer({
+      internal: { autonomousMemorySubject: "gateway-recovery" },
+    });
+    if (!memorySubjectIssuer) {
+      throw new Error("expected a Gateway recovery subject issuer");
+    }
+    let admittedSessionId = "recovery-run";
+
+    const result = await persistAgentSessionPhase({
+      request: { message: "resume", idempotencyKey: "gateway-recovery-call" },
+      cfg: {},
+      storePath,
+      storeKeys: [requestAlias, canonicalSessionKey],
+      canonicalSessionKey,
+      sessionAgentId: "target",
+      mainSessionKey: "agent:target:main",
+      creation: { via: "run" },
+      memorySubjectIssuer,
+      lifecycleGeneration: getAgentEventLifecycleGeneration(),
+      isRestartRecoveryResumeRun: false,
+      runId: "recovery-run",
+      agentId: "target",
+      suppressVisibleSessionEffects: false,
+      initialPatchBuild: createPatchBuild(sessionId),
+      buildSessionPatch: () => createPatchBuild(sessionId),
+      initialSessionPersistedBeforeGatewayAdmission: false,
+      initialSupersededSessionId: undefined,
+      touchInteraction: false,
+      requestedBestEffortDeliver: undefined,
+      bestEffortDeliver: false,
+      expectedSession: undefined,
+      maintenanceConfig: undefined,
+      abortForLifecycleRotation: () => false,
+      assertGatewayWorkAdmissionAllowed: () => undefined,
+      respondToGatewayAdmissionOutcome: () => false,
+      updateAdmissionState: (state) => {
+        admittedSessionId = state.admittedSessionId;
+      },
+      getAdmittedSessionId: () => admittedSessionId,
+      setCronContinuationClaim: () => undefined,
+      setMainRestartRecoveryOwnerLease: () => undefined,
+      respond: vi.fn(),
+    });
+
+    expect(result?.sessionEntry?.sessionId).toBe(sessionId);
+    const snapshot = readCurrentSessionMemorySubject({
+      agentId: "target",
+      sessionKey: canonicalSessionKey,
+      storePath,
+    });
+    expect(snapshot?.subject).toEqual(
+      prepareExplicitSessionMemorySubjectSeed({
+        kind: "system",
+        stableSubjectId: "gateway-recovery",
+      }).subject,
+    );
+    if (!snapshot) {
+      throw new Error("expected the initial recovery session subject");
+    }
+
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const interrupted = await commitMainSessionRecovery({
+      command: { kind: "mark_interrupted", cycleId: "recovery-cycle", now: 200 },
+      requireWriteSuccess: true,
+      target: { sessionKey: canonicalSessionKey, storePath },
+    });
+    expect(interrupted.transition).toEqual({ kind: "applied" });
+    const reserved = await commitMainSessionRecovery({
+      command: {
+        kind: "prepare_attempt",
+        attempt: 1,
+        lifecycleGeneration,
+        now: 201,
+        observation: { sessionId, cycleId: "recovery-cycle", revision: 1 },
+        runId: "recovery-resume-run",
+        executionIdentity: { state: "disabled" },
+      },
+      requireWriteSuccess: true,
+      target: { sessionKey: canonicalSessionKey, storePath },
+    });
+    expect(reserved.transition).toMatchObject({ kind: "reserved" });
+    if (!reserved.entry) {
+      throw new Error("expected the reserved recovery session entry");
+    }
+
+    const resumed = await persistAgentSessionPhase({
+      request: {
+        message: "resume after Gateway restart",
+        idempotencyKey: "gateway-recovery-resume-call",
+        expectedExistingSessionId: sessionId,
+      },
+      cfg: {},
+      storePath,
+      storeKeys: [requestAlias, canonicalSessionKey],
+      entry: reserved.entry,
+      canonicalSessionKey,
+      sessionAgentId: "target",
+      mainSessionKey: "agent:target:main",
+      creation: { via: "run" },
+      memorySubjectIssuer,
+      lifecycleGeneration,
+      isRestartRecoveryResumeRun: true,
+      runId: "recovery-resume-run",
+      agentId: "target",
+      suppressVisibleSessionEffects: false,
+      initialPatchBuild: createPatchBuild(sessionId, false),
+      buildSessionPatch: () => createPatchBuild(sessionId, false),
+      initialSessionEntry: reserved.entry,
+      initialResolvedSessionId: sessionId,
+      initialSessionPersistedBeforeGatewayAdmission: true,
+      initialSupersededSessionId: undefined,
+      touchInteraction: false,
+      requestedBestEffortDeliver: undefined,
+      bestEffortDeliver: false,
+      expectedSession: { sessionId },
+      maintenanceConfig: undefined,
+      abortForLifecycleRotation: () => false,
+      assertGatewayWorkAdmissionAllowed: () => undefined,
+      respondToGatewayAdmissionOutcome: () => false,
+      updateAdmissionState: (state) => {
+        admittedSessionId = state.admittedSessionId;
+      },
+      getAdmittedSessionId: () => admittedSessionId,
+      setCronContinuationClaim: () => undefined,
+      setMainRestartRecoveryOwnerLease: () => undefined,
+      respond: vi.fn(),
+    });
+
+    expect(resumed?.sessionEntry?.sessionId).toBe(sessionId);
+    const resumedSnapshot = readCurrentSessionMemorySubject({
+      agentId: "target",
+      sessionKey: canonicalSessionKey,
+      storePath,
+    });
+    expect(resumedSnapshot).toMatchObject({
+      sessionId: snapshot.sessionId,
+      sessionIdentityRevision: snapshot.sessionIdentityRevision,
+      subjectRevision: snapshot.subjectRevision,
+      subject: snapshot.subject,
+    });
+
+    const database = openOpenClawAgentDatabase(
+      toDatabaseOptions(
+        resolveSqliteScope({
+          agentId: "target",
+          sessionKey: canonicalSessionKey,
+          storePath,
+        }),
+      ),
+    );
+    expect(
+      database.db
+        .prepare("SELECT session_key FROM session_nodes ORDER BY session_key")
+        .all()
+        .map((row) => (row as { session_key: string }).session_key),
+    ).toEqual([canonicalSessionKey]);
+  });
+});

--- a/src/gateway/server-methods/agent-session-persist.ts
+++ b/src/gateway/server-methods/agent-session-persist.ts
@@ -16,7 +16,9 @@ import {
   patchSessionEntryTarget,
   type SessionEntryPatchOptions,
 } from "../../config/sessions/session-accessor.js";
+import { patchSqliteSessionEntryTargetWithTrustedMemorySubject } from "../../config/sessions/session-accessor.sqlite-entry.js";
 import { buildSessionCreationStamp } from "../../config/sessions/session-entry-provenance.js";
+import type { TrustedSessionMemorySubjectIssuer } from "../../config/sessions/session-memory-subject.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeCronScheduledToolPolicy } from "../../cron/scheduled-tool-policy.js";
 import { assertAgentRunLifecycleGenerationCurrent } from "../../infra/agent-events.js";
@@ -79,6 +81,7 @@ export async function persistAgentSessionPhase(params: {
   sessionAgentId: string;
   mainSessionKey: string;
   creation: TrustedSessionCreation;
+  memorySubjectIssuer?: TrustedSessionMemorySubjectIssuer;
   lifecycleGeneration: string;
   isRestartRecoveryResumeRun: boolean;
   runId: string;
@@ -122,6 +125,19 @@ export async function persistAgentSessionPhase(params: {
   let mainRestartRecoveryOwnerLease: MainSessionRecoveryOwnerLease | undefined;
   let skipAgentInitialSessionTouch = false;
   let createdNewEntry = false;
+  const patchTarget = (
+    scope: Parameters<typeof patchSessionEntryTarget>[0],
+    update: Parameters<typeof patchSessionEntryTarget>[1],
+    options: SessionEntryPatchOptions,
+  ) =>
+    params.memorySubjectIssuer
+      ? patchSqliteSessionEntryTargetWithTrustedMemorySubject(
+          scope,
+          update,
+          params.memorySubjectIssuer,
+          options,
+        )
+      : patchSessionEntryTarget(scope, update, options);
   const recoveredSessionStartedAt =
     !patchBuild.isNewSession &&
     params.entry !== undefined &&
@@ -152,7 +168,7 @@ export async function persistAgentSessionPhase(params: {
     let restartRecoveryReservationConflict: string | undefined;
     try {
       persisted =
-        (await patchSessionEntryTarget(
+        (await patchTarget(
           {
             agentId: params.sessionAgentId,
             storePath: params.storePath,

--- a/src/gateway/server-methods/session-creation-provenance.ts
+++ b/src/gateway/server-methods/session-creation-provenance.ts
@@ -2,6 +2,14 @@ import type {
   SessionCreatedActor,
   SessionCreatedVia,
 } from "../../config/sessions/session-entry-provenance.js";
+import {
+  createTrustedSessionMemorySubjectIssuer,
+  prepareAutonomousAgentSessionMemorySubjectSeed,
+  prepareAmbiguousSessionMemorySubjectSeed,
+  prepareExplicitSessionMemorySubjectSeed,
+  prepareGatewayProfileSessionMemorySubjectSeed,
+  type TrustedSessionMemorySubjectIssuer,
+} from "../../config/sessions/session-memory-subject.js";
 import type { AgentRuntimeIdentity } from "../agent-runtime-identity-token.js";
 
 export type TrustedSessionCreation = {
@@ -27,8 +35,58 @@ type SessionCreationClient = {
     syntheticClient?: true;
     sessionCreation?: TrustedSessionCreation;
     agentRuntimeIdentity?: AgentRuntimeIdentity;
+    /** Closed server-only principal for Gateway restart recovery dispatch. */
+    autonomousMemorySubject?: "gateway-recovery";
   };
 };
+
+/**
+ * Gateway profile IDs are server-attested at connection time. Resolve the
+ * durable principal only in the entry transaction so stale profile state fails
+ * closed to an immutable ambiguous subject instead of being captured early.
+ */
+export function createGatewayProfileSessionMemorySubjectIssuer(
+  client: SessionCreationClient | null | undefined,
+): TrustedSessionMemorySubjectIssuer | undefined {
+  const profileId = client?.authenticatedUserProfile?.profileId;
+  if (!profileId) {
+    return undefined;
+  }
+  return createTrustedSessionMemorySubjectIssuer(
+    () =>
+      prepareGatewayProfileSessionMemorySubjectSeed(profileId) ??
+      prepareAmbiguousSessionMemorySubjectSeed("unbound"),
+  );
+}
+
+/**
+ * Selects only server-attested autonomous principals for Gateway agent runs.
+ * Request fields, session keys, and generic synthetic clients never influence
+ * the immutable subject issued by the first SQLite write.
+ */
+export function createAgentRunSessionMemorySubjectIssuer(
+  client: SessionCreationClient | null | undefined,
+): TrustedSessionMemorySubjectIssuer | undefined {
+  const profileIssuer = createGatewayProfileSessionMemorySubjectIssuer(client);
+  if (profileIssuer) {
+    return profileIssuer;
+  }
+  const agentId = client?.internal?.agentRuntimeIdentity?.agentId;
+  if (agentId) {
+    return createTrustedSessionMemorySubjectIssuer(() =>
+      prepareAutonomousAgentSessionMemorySubjectSeed(agentId),
+    );
+  }
+  if (client?.internal?.autonomousMemorySubject === "gateway-recovery") {
+    return createTrustedSessionMemorySubjectIssuer(() =>
+      prepareExplicitSessionMemorySubjectSeed({
+        kind: "system",
+        stableSubjectId: "gateway-recovery",
+      }),
+    );
+  }
+  return undefined;
+}
 
 export function resolveOperatorSessionCreation(
   client: SessionCreationClient | null | undefined,

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -41,7 +41,10 @@ import {
   resolveSessionCreateInitialTurn,
   shouldAttachPendingMessageSeq,
 } from "./session-create-initial-turn.js";
-import { resolveOperatorSessionCreation } from "./session-creation-provenance.js";
+import {
+  createGatewayProfileSessionMemorySubjectIssuer,
+  resolveOperatorSessionCreation,
+} from "./session-creation-provenance.js";
 import { sessionLog } from "./sessions-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
@@ -454,6 +457,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
         );
       }
     };
+    const memorySubjectIssuer = createGatewayProfileSessionMemorySubjectIssuer(client);
     const created = await createGatewaySession({
       cfg,
       key: sessionKey,
@@ -496,6 +500,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       resetMainWhenUnspecified: !hasInitialTurn,
       commandSource: "webchat",
       creation: sessionCreation,
+      ...(memorySubjectIssuer ? { memorySubjectIssuer } : {}),
       authorizedPluginId: normalizeOptionalString(client?.internal?.pluginRuntimeOwnerId),
       loadGatewayModelCatalog: () =>
         context.loadGatewayModelCatalog({ agentId: modelCatalogAgentId }),

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -105,6 +105,8 @@ export type GatewayClient = {
     approvalRuntime?: boolean;
     cronRunContinuation?: boolean;
     agentRuntimeIdentity?: AgentRuntimeIdentity;
+    /** Closed server-only marker used exclusively by Gateway recovery dispatch. */
+    autonomousMemorySubject?: "gateway-recovery";
     pluginRuntimeOwnerId?: string;
     agentRunTracking?: "plugin_subagent";
     /** Host-captured requester lineage for opt-in plugin subagent completion delivery. */

--- a/src/gateway/server-plugin-runtime-client.ts
+++ b/src/gateway/server-plugin-runtime-client.ts
@@ -24,6 +24,7 @@ export function createSyntheticPluginRuntimeClient(params?: {
   pluginSubagentRequester?: PluginSubagentRequesterContext;
   runtimePluginToolGrant?: RuntimePluginToolGrant;
   delegatedToolPolicyHandoffId?: string;
+  autonomousMemorySubject?: "gateway-recovery";
   sessionCreation?: TrustedSessionCreation;
   scopes?: string[];
 }): NonNullable<GatewayRequestOptions["client"]> {
@@ -50,6 +51,9 @@ export function createSyntheticPluginRuntimeClient(params?: {
       allowModelOverride: params?.allowModelOverride === true,
       ...(params?.agentRunTracking ? { agentRunTracking: params.agentRunTracking } : {}),
       ...(params?.cronRunContinuation === true ? { cronRunContinuation: true } : {}),
+      ...(params?.autonomousMemorySubject === "gateway-recovery"
+        ? { autonomousMemorySubject: "gateway-recovery" }
+        : {}),
       ...(params?.internalDeliveryMediaUrls
         ? { internalDeliveryMediaUrls: [...params.internalDeliveryMediaUrls] }
         : {}),

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -22,6 +22,7 @@ import {
   loadTranscriptEvents,
   upsertSessionEntry,
 } from "../config/sessions/session-accessor.js";
+import { readCurrentSessionMemorySubject } from "../config/sessions/session-memory-subject-access.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
@@ -34,6 +35,7 @@ import {
   resolveIncognitoOpenClawAgentSqlitePath,
 } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { ensureProfileForEmail } from "../state/user-profiles.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { resolveGatewaySessionStoreTarget } from "./session-utils.js";
@@ -2502,6 +2504,61 @@ test("sessions.create stamps trusted operator provenance and records created", a
     createdVia: "spawn",
     createdActor: { type: "agent", id: "agent:main:main" },
   });
+});
+
+test("sessions.create persists Gateway memory subjects only for durable authenticated sessions", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const profile = ensureProfileForEmail("memory-session-creator@example.test");
+  const authenticatedClient = {
+    connect: { scopes: ["operator.write"] },
+    authenticatedUserProfile: {
+      profileId: profile.id,
+      displayName: "Memory Session Creator",
+      hasAvatar: false,
+      updatedAt: 1,
+    },
+  };
+
+  const durable = await directSessionReq<{ key?: string }>(
+    "sessions.create",
+    { agentId: "main" },
+    { client: authenticatedClient as never },
+  );
+  expect(durable.ok).toBe(true);
+  const durableKey = requireNonEmptyString(durable.payload?.key, "durable session key");
+  expect(
+    readCurrentSessionMemorySubject({ agentId: "main", sessionKey: durableKey, storePath }),
+  ).toMatchObject({
+    subject: {
+      kind: "user",
+      creationEvidence: { kind: "gateway-profile" },
+    },
+  });
+
+  const profileless = await directSessionReq<{ key?: string }>("sessions.create", {
+    agentId: "main",
+  });
+  expect(profileless.ok).toBe(true);
+  const profilelessKey = requireNonEmptyString(profileless.payload?.key, "profileless session key");
+  expect(
+    readCurrentSessionMemorySubject({ agentId: "main", sessionKey: profilelessKey, storePath }),
+  ).toMatchObject({ subject: { kind: "ambiguous", reason: "unbound" } });
+
+  const incognito = await directSessionReq<{ key?: string }>(
+    "sessions.create",
+    { agentId: "main", incognito: true },
+    {
+      client: {
+        ...authenticatedClient,
+        connect: { scopes: ["operator.admin"] },
+      } as never,
+    },
+  );
+  expect(incognito.ok).toBe(true);
+  const incognitoKey = requireNonEmptyString(incognito.payload?.key, "incognito session key");
+  expect(
+    readCurrentSessionMemorySubject({ agentId: "main", sessionKey: incognitoKey, storePath }),
+  ).toMatchObject({ subject: { kind: "ambiguous", reason: "unbound" } });
 });
 
 test("sessions.create reset-in-place preserves the node creation stamp", async () => {

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -35,10 +35,13 @@ import {
 import type { SessionEntry } from "../config/sessions.js";
 import { resolveAgentMainSessionKey } from "../config/sessions/main-session.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
+import { createSessionEntryWithTrustedMemorySubject } from "../config/sessions/session-accessor.entry-mutation.js";
 import {
   createSessionEntryWithTranscript,
   listSessionEntriesReadOnly,
   resolveSessionEntryAccessTarget,
+  type SessionEntryCreateWithTranscriptContext,
+  type SessionEntryCreateWithTranscriptPrepareResult,
 } from "../config/sessions/session-accessor.js";
 import {
   buildSessionCreationStamp,
@@ -46,6 +49,7 @@ import {
   type SessionCreatedVia,
 } from "../config/sessions/session-entry-provenance.js";
 import { inheritSessionSelection } from "../config/sessions/session-entry-selection.js";
+import type { TrustedSessionMemorySubjectIssuer } from "../config/sessions/session-memory-subject.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   createInternalHookEvent,
@@ -276,6 +280,8 @@ export async function createGatewaySession(params: {
   requestingOperatorScopes?: readonly string[];
   /** Trusted in-process creation provenance; never populated from public Gateway params. */
   creation?: { via: SessionCreatedVia; actor?: SessionCreatedActor };
+  /** Core-only issuer for a durable first-write memory subject. */
+  memorySubjectIssuer?: TrustedSessionMemorySubjectIssuer;
   /** Exact harness namespace authorized by the scoped plugin runtime. */
   authorizedAgentHarnessId?: string;
   /** Exact plugin namespace authorized by the scoped plugin runtime. */
@@ -521,6 +527,9 @@ export async function createGatewaySession(params: {
   const parentIncognito =
     parentSessionEntry?.incognito === true || isIncognitoSessionKey(canonicalParentSessionKey);
   const incognito = params.incognito === true || parentIncognito;
+  // Incognito sessions deliberately have no durable identity. Do not allow a
+  // server-attested issuer to escape its storage boundary through this writer.
+  const memorySubjectIssuer = incognito ? undefined : params.memorySubjectIssuer;
   if (
     incognito &&
     params.requestingOperatorScopes !== undefined &&
@@ -775,348 +784,357 @@ export async function createGatewaySession(params: {
     }
 
     const target = creationTarget;
-    const created = await createSessionEntryWithTranscript<ErrorShape>(
-      {
-        agentId: target.agentId,
-        sessionKey: target.canonicalKey,
-        storePath: target.storePath,
-      },
-      async ({ existingEntry, sessionEntries }) => {
-        // This callback owns generated and explicit keys alike; no existing row
-        // is the canonical signal that this request will actually create one.
-        const existingOwnershipError = resolvePluginSessionOwnershipError({
-          action: "adopt",
-          entry: existingEntry,
-          key: target.canonicalKey,
-          pluginOwnerId: params.authorizedPluginId,
-        });
-        if (existingOwnershipError) {
-          return { ok: false, error: existingOwnershipError };
-        }
-        if (
-          isAgentHarnessSessionKey(target.canonicalKey) &&
-          !authorizedHarnessCreation &&
-          (!existingEntry || existingEntry.modelSelectionLocked === true)
-        ) {
-          return {
-            ok: false,
-            error: errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE,
-            ),
-          };
-        }
-        if (!params.initialEntry && existingEntry?.initializationPending === true) {
-          return {
-            ok: false,
-            error: errorShape(
-              ErrorCodes.UNAVAILABLE,
-              `Session ${target.canonicalKey} is still initializing; retry creation later.`,
-            ),
-          };
-        }
-        if (params.initialEntry && existingEntry !== undefined) {
-          return {
-            ok: false,
-            error: errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              "trusted initial session state requires a new session",
-            ),
-          };
-        }
-        if (params.catalogTarget && existingEntry !== undefined) {
-          return {
-            ok: false,
-            error: errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              "catalog session target requires a new session",
-            ),
-          };
-        }
-        if (spawnToolPolicy && existingEntry !== undefined) {
-          return {
-            ok: false,
-            error: errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              "spawn tool policy requires a new session",
-            ),
-          };
-        }
-        if (
-          params.visibility &&
-          existingEntry === undefined &&
-          !isSessionVisibilityAllowed(params.cfg, params.visibility)
-        ) {
-          return {
-            ok: false,
-            error: errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              `session visibility is disabled: ${params.visibility}`,
-              { details: { code: "SESSION_VISIBILITY_DISABLED", visibility: params.visibility } },
-            ),
-          };
-        }
-        if (
-          params.visibility &&
-          existingEntry !== undefined &&
-          resolveSessionVisibility(existingEntry) !== params.visibility
-        ) {
-          return {
-            ok: false,
-            error: errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              "sessions.create visibility requires a new session",
-            ),
-          };
-        }
-        // Adoption of an existing key must not stamp provenance or emit a
-        // `created` event; only a genuinely new row is a node creation.
-        createdNewEntry = existingEntry === undefined;
-        const requestedModel = normalizeOptionalString(params.model);
-        const requestedThinkingLevel = normalizeOptionalString(params.thinkingLevel);
-        if (existingEntry?.sessionId && params.allowExistingModelSelection !== true) {
-          const gateDefaultModel = resolveDefaultModelForAgent({
-            cfg: params.cfg,
-            agentId: target.agentId,
-          });
-          const modelSelectionWouldChange = await existingModelSelectionWouldChange({
-            agentId: target.agentId,
-            cfg: params.cfg,
-            catalogModel,
-            defaultModel: gateDefaultModel.model,
-            defaultProvider: gateDefaultModel.provider,
-            existingEntry,
-            loadGatewayModelCatalog: params.loadGatewayModelCatalog,
-            requestedModel,
-            requestedThinkingLevel,
-            subagentModelHint: isSubagentSessionKey(target.canonicalKey)
-              ? resolveSubagentConfiguredModelSelection({
-                  cfg: params.cfg,
-                  agentId: target.agentId,
-                })
-              : undefined,
-          });
-          if (modelSelectionWouldChange) {
-            return {
-              ok: false,
-              error: missingScopeErrorShape({
-                missingScope: ADMIN_SCOPE,
-                requiredScopes: [ADMIN_SCOPE],
-              }),
-            };
-          }
-        }
-        const patched = await projectSessionsPatchEntry({
-          cfg: params.cfg,
-          existingEntry: sessionEntries[target.canonicalKey],
-          isLabelInUse: (label) =>
-            Object.entries(sessionEntries).some(
-              ([sessionKey, entry]) => sessionKey !== target.canonicalKey && entry.label === label,
-            ),
-          storeKey: target.canonicalKey,
-          agentId: target.agentId,
-          patch: {
-            key: target.canonicalKey,
-            label: normalizeOptionalString(params.label),
-            model: catalogModel ?? requestedModel,
-            thinkingLevel: requestedThinkingLevel,
-          },
-          loadGatewayModelCatalog: params.loadGatewayModelCatalog,
-          authorizedAgentHarnessId: params.authorizedAgentHarnessId,
-        });
-        if (!patched.ok) {
-          return patched;
-        }
-        sessionEntries[target.canonicalKey] = patched.entry;
-        const spawnedCwd = normalizeOptionalString(params.spawnedCwd);
-        const execNode = normalizeOptionalString(params.execNode);
-        const execCwd = normalizeOptionalString(params.execCwd);
-        const initialAgentHarnessId = params.initialEntry
-          ? normalizeOptionalString(params.initialEntry.agentHarnessId)
-          : undefined;
-        if (params.initialEntry && !initialAgentHarnessId && !authorizedPluginCreation) {
-          return {
-            ok: false,
-            error: errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              params.initialEntry?.agentHarnessId !== undefined
-                ? "initial agentHarnessId must be non-empty"
-                : "trusted initial session state requires an authorized owner",
-            ),
-          };
-        }
-        if (
-          params.initialEntry?.modelSelectionLocked !== undefined &&
-          !params.initialEntry.modelSelectionLocked
-        ) {
-          return {
-            ok: false,
-            error: errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              "initial modelSelectionLocked must be true when provided",
-            ),
-          };
-        }
-        const catalogResolvedModel = params.catalogTarget
-          ? resolveSessionModelRef(params.cfg, patched.entry, target.agentId)
-          : undefined;
-        const initializedEntry: SessionEntry = {
-          ...patched.entry,
-          // New rows must expose the same canonical delivery shape to callbacks
-          // that the SQLite writer persists, or guarded finalization sees its own write as drift.
-          ...(existingEntry === undefined && patched.entry.delivery === undefined
-            ? { delivery: normalizeSessionDeliveryState() }
-            : {}),
-          // Stamp provenance only for genuinely new rows: adopting an existing key
-          // must not restamp write-once node facts (this direct store write bypasses
-          // the merge-level write-once guard), and legacy rows stay "unknown".
-          ...(params.creation && createdNewEntry ? buildSessionCreationStamp(params.creation) : {}),
-          ...(params.visibility && createdNewEntry ? { visibility: params.visibility } : {}),
-          ...(generatedDisplayName && createdNewEntry ? { displayName: generatedDisplayName } : {}),
-          ...(catalogResolvedModel && catalogAgentRuntime
-            ? {
-                providerOverride: catalogResolvedModel.provider,
-                modelOverride: catalogResolvedModel.model,
-                modelOverrideSource: "user" as const,
-                modelOverrideRouteResolution: "resolved" as const,
-                agentRuntimeOverride: catalogAgentRuntime,
-                modelSelectionLocked: true,
-                pluginOwnerId: catalogPluginOwnerId,
-              }
-            : {}),
-          // Session worktrees adopt cwd only during admin-gated creation; public patching stays
-          // restricted to spawned subagent and ACP lineage.
-          ...(spawnedCwd ? { spawnedCwd } : {}),
-          ...(params.worktree ? { worktree: params.worktree } : {}),
-          ...(execNode ? { execHost: "node", execNode, ...(execCwd ? { execCwd } : {}) } : {}),
-          ...(initialAgentHarnessId ? { agentHarnessId: initialAgentHarnessId } : {}),
-          ...(createdNewEntry && params.authorizedPluginId && !params.catalogTarget
-            ? { pluginOwnerId: params.authorizedPluginId }
-            : {}),
-          ...(authorizedPluginCreation && params.initialEntry?.providerOverride
-            ? { providerOverride: params.initialEntry.providerOverride }
-            : {}),
-          ...(authorizedPluginCreation && params.initialEntry?.modelOverride
-            ? { modelOverride: params.initialEntry.modelOverride }
-            : {}),
-          ...(authorizedPluginCreation && params.initialEntry?.modelOverrideRouteResolution
-            ? { modelOverrideRouteResolution: params.initialEntry.modelOverrideRouteResolution }
-            : {}),
-          // Seeded CLI bindings ride only the plugin-authorized creation path;
-          // harness creations must never smuggle pre-bound CLI session ids.
-          ...(authorizedPluginCreation && params.initialEntry?.cliSessionBindings
-            ? { cliSessionBindings: structuredClone(params.initialEntry.cliSessionBindings) }
-            : {}),
-          ...(params.initialEntry?.initializationPending === true
-            ? { initializationPending: true }
-            : {}),
-          ...(params.initialEntry?.modelSelectionLocked === true
-            ? { modelSelectionLocked: true }
-            : {}),
-          ...(params.initialEntry?.pluginExtensions !== undefined
-            ? { pluginExtensions: structuredClone(params.initialEntry.pluginExtensions) }
-            : {}),
-          // Spawn lineage is declared, never inferred: spawn-owned creations pass
-          // spawnDepth explicitly; everything else (operator chats, forks, harness
-          // and plugin sessions) persists as a depth-0 root. Reused entries keep
-          // their stored depth.
-          ...(existingEntry === undefined ? { spawnDepth: params.spawnDepth ?? 0 } : {}),
-          ...(existingEntry === undefined && spawnToolPolicy
-            ? {
-                spawnedBy: spawnToolPolicy.parentSessionKey,
-                ...(spawnToolPolicy.completionOwnerSessionKey
-                  ? { completionOwnerSessionKey: spawnToolPolicy.completionOwnerSessionKey }
-                  : {}),
-                inheritedToolPolicyVersion: 1 as const,
-                ...(spawnToolPolicy.allow.length > 0
-                  ? { inheritedToolAllow: spawnToolPolicy.allow }
-                  : {}),
-                ...(spawnToolPolicy.deny.length > 0
-                  ? { inheritedToolDeny: spawnToolPolicy.deny }
-                  : {}),
-              }
-            : {}),
-          ...(existingEntry === undefined && incognito ? { incognito: true as const } : {}),
-        };
-        sessionEntries[target.canonicalKey] = initializedEntry;
-        const initialized = { ...patched, entry: initializedEntry };
-        const explicitParentSessionKey =
-          canonicalParentSessionKey ?? normalizeOptionalString(initializedEntry.parentSessionKey);
-        const storedParentSessionKey = explicitParentSessionKey ?? dashboardParentSessionKey;
-        if (!storedParentSessionKey) {
-          return initialized;
-        }
-        const inheritedSelection =
-          !canonicalParentSessionKey || catalogModel || normalizeOptionalString(params.model)
-            ? {}
-            : inheritSessionSelection(currentParentSessionEntry);
-        const entry: SessionEntry = {
-          ...initializedEntry,
-          ...inheritedSelection,
-          parentSessionKey: storedParentSessionKey,
-        };
-        if (params.fork !== true) {
-          return { ...initialized, entry };
-        }
-        const forkParentSessionKey = canonicalParentSessionKey;
-        if (!forkParentSessionKey || !currentParentSessionEntry || !parentSessionTarget) {
-          return {
-            ok: false,
-            error: errorShape(ErrorCodes.UNAVAILABLE, "failed to resolve parent session for fork"),
-          };
-        }
-        // Operator forks honor the same oversized-parent cap as subagent forks;
-        // an explicit fork of an unusable parent fails loudly instead of
-        // silently producing an empty child.
-        const forkDecision = await resolveParentForkDecision({
-          parentEntry: currentParentSessionEntry,
-          agentId: parentSessionTarget.agentId,
-          storePath: parentSessionTarget.storePath,
-        });
-        if (forkDecision.status === "skip") {
-          return {
-            ok: false,
-            error: errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              `parent session is too large to fork (${forkDecision.parentTokens}/${forkDecision.maxTokens} tokens)`,
-            ),
-          };
-        }
-        const fork = await forkSessionFromParent({
-          parentEntry: currentParentSessionEntry,
-          agentId: parentSessionTarget.agentId,
-          parentSessionKey: forkParentSessionKey,
-          sessionKey: target.canonicalKey,
-          storePath: parentSessionTarget.storePath,
-          // Keep the fork transcript owned by the child store across agent boundaries.
-          targetStorePath: target.storePath,
-        });
-        if (!fork) {
-          return {
-            ok: false,
-            error: errorShape(ErrorCodes.UNAVAILABLE, "failed to fork parent session transcript"),
-          };
-        }
+    const sessionEntryScope = {
+      agentId: target.agentId,
+      sessionKey: target.canonicalKey,
+      storePath: target.storePath,
+    };
+    const prepareEntry = async ({
+      existingEntry,
+      sessionEntries,
+    }: SessionEntryCreateWithTranscriptContext): Promise<
+      SessionEntryCreateWithTranscriptPrepareResult<ErrorShape>
+    > => {
+      // This callback owns generated and explicit keys alike; no existing row
+      // is the canonical signal that this request will actually create one.
+      const existingOwnershipError = resolvePluginSessionOwnershipError({
+        action: "adopt",
+        entry: existingEntry,
+        key: target.canonicalKey,
+        pluginOwnerId: params.authorizedPluginId,
+      });
+      if (existingOwnershipError) {
+        return { ok: false, error: existingOwnershipError };
+      }
+      if (
+        isAgentHarnessSessionKey(target.canonicalKey) &&
+        !authorizedHarnessCreation &&
+        (!existingEntry || existingEntry.modelSelectionLocked === true)
+      ) {
         return {
-          ...initialized,
-          entry: buildForkedGatewaySessionEntry(
-            entry,
-            fork,
-            {
-              sessionKey: forkParentSessionKey,
-              sessionId: currentParentSessionEntry.sessionId,
-            },
-            existingEntry,
+          ok: false,
+          error: errorShape(ErrorCodes.INVALID_REQUEST, AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE),
+        };
+      }
+      if (!params.initialEntry && existingEntry?.initializationPending === true) {
+        return {
+          ok: false,
+          error: errorShape(
+            ErrorCodes.UNAVAILABLE,
+            `Session ${target.canonicalKey} is still initializing; retry creation later.`,
           ),
         };
-      },
-      params.initialEntry
-        ? {
-            activeSessionKey: target.canonicalKey,
-            requireWriteSuccess: true,
-          }
-        : undefined,
-    );
+      }
+      if (params.initialEntry && existingEntry !== undefined) {
+        return {
+          ok: false,
+          error: errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "trusted initial session state requires a new session",
+          ),
+        };
+      }
+      if (params.catalogTarget && existingEntry !== undefined) {
+        return {
+          ok: false,
+          error: errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "catalog session target requires a new session",
+          ),
+        };
+      }
+      if (spawnToolPolicy && existingEntry !== undefined) {
+        return {
+          ok: false,
+          error: errorShape(ErrorCodes.INVALID_REQUEST, "spawn tool policy requires a new session"),
+        };
+      }
+      if (
+        params.visibility &&
+        existingEntry === undefined &&
+        !isSessionVisibilityAllowed(params.cfg, params.visibility)
+      ) {
+        return {
+          ok: false,
+          error: errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `session visibility is disabled: ${params.visibility}`,
+            { details: { code: "SESSION_VISIBILITY_DISABLED", visibility: params.visibility } },
+          ),
+        };
+      }
+      if (
+        params.visibility &&
+        existingEntry !== undefined &&
+        resolveSessionVisibility(existingEntry) !== params.visibility
+      ) {
+        return {
+          ok: false,
+          error: errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "sessions.create visibility requires a new session",
+          ),
+        };
+      }
+      // Adoption of an existing key must not stamp provenance or emit a
+      // `created` event; only a genuinely new row is a node creation.
+      createdNewEntry = existingEntry === undefined;
+      const requestedModel = normalizeOptionalString(params.model);
+      const requestedThinkingLevel = normalizeOptionalString(params.thinkingLevel);
+      if (existingEntry?.sessionId && params.allowExistingModelSelection !== true) {
+        const gateDefaultModel = resolveDefaultModelForAgent({
+          cfg: params.cfg,
+          agentId: target.agentId,
+        });
+        const modelSelectionWouldChange = await existingModelSelectionWouldChange({
+          agentId: target.agentId,
+          cfg: params.cfg,
+          catalogModel,
+          defaultModel: gateDefaultModel.model,
+          defaultProvider: gateDefaultModel.provider,
+          existingEntry,
+          loadGatewayModelCatalog: params.loadGatewayModelCatalog,
+          requestedModel,
+          requestedThinkingLevel,
+          subagentModelHint: isSubagentSessionKey(target.canonicalKey)
+            ? resolveSubagentConfiguredModelSelection({
+                cfg: params.cfg,
+                agentId: target.agentId,
+              })
+            : undefined,
+        });
+        if (modelSelectionWouldChange) {
+          return {
+            ok: false,
+            error: missingScopeErrorShape({
+              missingScope: ADMIN_SCOPE,
+              requiredScopes: [ADMIN_SCOPE],
+            }),
+          };
+        }
+      }
+      const patched = await projectSessionsPatchEntry({
+        cfg: params.cfg,
+        existingEntry: sessionEntries[target.canonicalKey],
+        isLabelInUse: (label) =>
+          Object.entries(sessionEntries).some(
+            ([sessionKey, entry]) => sessionKey !== target.canonicalKey && entry.label === label,
+          ),
+        storeKey: target.canonicalKey,
+        agentId: target.agentId,
+        patch: {
+          key: target.canonicalKey,
+          label: normalizeOptionalString(params.label),
+          model: catalogModel ?? requestedModel,
+          thinkingLevel: requestedThinkingLevel,
+        },
+        loadGatewayModelCatalog: params.loadGatewayModelCatalog,
+        authorizedAgentHarnessId: params.authorizedAgentHarnessId,
+      });
+      if (!patched.ok) {
+        return patched;
+      }
+      sessionEntries[target.canonicalKey] = patched.entry;
+      const spawnedCwd = normalizeOptionalString(params.spawnedCwd);
+      const execNode = normalizeOptionalString(params.execNode);
+      const execCwd = normalizeOptionalString(params.execCwd);
+      const initialAgentHarnessId = params.initialEntry
+        ? normalizeOptionalString(params.initialEntry.agentHarnessId)
+        : undefined;
+      if (params.initialEntry && !initialAgentHarnessId && !authorizedPluginCreation) {
+        return {
+          ok: false,
+          error: errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            params.initialEntry?.agentHarnessId !== undefined
+              ? "initial agentHarnessId must be non-empty"
+              : "trusted initial session state requires an authorized owner",
+          ),
+        };
+      }
+      if (
+        params.initialEntry?.modelSelectionLocked !== undefined &&
+        !params.initialEntry.modelSelectionLocked
+      ) {
+        return {
+          ok: false,
+          error: errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "initial modelSelectionLocked must be true when provided",
+          ),
+        };
+      }
+      const catalogResolvedModel = params.catalogTarget
+        ? resolveSessionModelRef(params.cfg, patched.entry, target.agentId)
+        : undefined;
+      const initializedEntry: SessionEntry = {
+        ...patched.entry,
+        // New rows must expose the same canonical delivery shape to callbacks
+        // that the SQLite writer persists, or guarded finalization sees its own write as drift.
+        ...(existingEntry === undefined && patched.entry.delivery === undefined
+          ? { delivery: normalizeSessionDeliveryState() }
+          : {}),
+        // Stamp provenance only for genuinely new rows: adopting an existing key
+        // must not restamp write-once node facts (this direct store write bypasses
+        // the merge-level write-once guard), and legacy rows stay "unknown".
+        ...(params.creation && createdNewEntry ? buildSessionCreationStamp(params.creation) : {}),
+        ...(params.visibility && createdNewEntry ? { visibility: params.visibility } : {}),
+        ...(generatedDisplayName && createdNewEntry ? { displayName: generatedDisplayName } : {}),
+        ...(catalogResolvedModel && catalogAgentRuntime
+          ? {
+              providerOverride: catalogResolvedModel.provider,
+              modelOverride: catalogResolvedModel.model,
+              modelOverrideSource: "user" as const,
+              modelOverrideRouteResolution: "resolved" as const,
+              agentRuntimeOverride: catalogAgentRuntime,
+              modelSelectionLocked: true,
+              pluginOwnerId: catalogPluginOwnerId,
+            }
+          : {}),
+        // Session worktrees adopt cwd only during admin-gated creation; public patching stays
+        // restricted to spawned subagent and ACP lineage.
+        ...(spawnedCwd ? { spawnedCwd } : {}),
+        ...(params.worktree ? { worktree: params.worktree } : {}),
+        ...(execNode ? { execHost: "node", execNode, ...(execCwd ? { execCwd } : {}) } : {}),
+        ...(initialAgentHarnessId ? { agentHarnessId: initialAgentHarnessId } : {}),
+        ...(createdNewEntry && params.authorizedPluginId && !params.catalogTarget
+          ? { pluginOwnerId: params.authorizedPluginId }
+          : {}),
+        ...(authorizedPluginCreation && params.initialEntry?.providerOverride
+          ? { providerOverride: params.initialEntry.providerOverride }
+          : {}),
+        ...(authorizedPluginCreation && params.initialEntry?.modelOverride
+          ? { modelOverride: params.initialEntry.modelOverride }
+          : {}),
+        ...(authorizedPluginCreation && params.initialEntry?.modelOverrideRouteResolution
+          ? { modelOverrideRouteResolution: params.initialEntry.modelOverrideRouteResolution }
+          : {}),
+        // Seeded CLI bindings ride only the plugin-authorized creation path;
+        // harness creations must never smuggle pre-bound CLI session ids.
+        ...(authorizedPluginCreation && params.initialEntry?.cliSessionBindings
+          ? { cliSessionBindings: structuredClone(params.initialEntry.cliSessionBindings) }
+          : {}),
+        ...(params.initialEntry?.initializationPending === true
+          ? { initializationPending: true }
+          : {}),
+        ...(params.initialEntry?.modelSelectionLocked === true
+          ? { modelSelectionLocked: true }
+          : {}),
+        ...(params.initialEntry?.pluginExtensions !== undefined
+          ? { pluginExtensions: structuredClone(params.initialEntry.pluginExtensions) }
+          : {}),
+        // Spawn lineage is declared, never inferred: spawn-owned creations pass
+        // spawnDepth explicitly; everything else (operator chats, forks, harness
+        // and plugin sessions) persists as a depth-0 root. Reused entries keep
+        // their stored depth.
+        ...(existingEntry === undefined ? { spawnDepth: params.spawnDepth ?? 0 } : {}),
+        ...(existingEntry === undefined && spawnToolPolicy
+          ? {
+              spawnedBy: spawnToolPolicy.parentSessionKey,
+              ...(spawnToolPolicy.completionOwnerSessionKey
+                ? { completionOwnerSessionKey: spawnToolPolicy.completionOwnerSessionKey }
+                : {}),
+              inheritedToolPolicyVersion: 1 as const,
+              ...(spawnToolPolicy.allow.length > 0
+                ? { inheritedToolAllow: spawnToolPolicy.allow }
+                : {}),
+              ...(spawnToolPolicy.deny.length > 0
+                ? { inheritedToolDeny: spawnToolPolicy.deny }
+                : {}),
+            }
+          : {}),
+        ...(existingEntry === undefined && incognito ? { incognito: true as const } : {}),
+      };
+      sessionEntries[target.canonicalKey] = initializedEntry;
+      const initialized = { ...patched, entry: initializedEntry };
+      const explicitParentSessionKey =
+        canonicalParentSessionKey ?? normalizeOptionalString(initializedEntry.parentSessionKey);
+      const storedParentSessionKey = explicitParentSessionKey ?? dashboardParentSessionKey;
+      if (!storedParentSessionKey) {
+        return initialized;
+      }
+      const inheritedSelection =
+        !canonicalParentSessionKey || catalogModel || normalizeOptionalString(params.model)
+          ? {}
+          : inheritSessionSelection(currentParentSessionEntry);
+      const entry: SessionEntry = {
+        ...initializedEntry,
+        ...inheritedSelection,
+        parentSessionKey: storedParentSessionKey,
+      };
+      if (params.fork !== true) {
+        return { ...initialized, entry };
+      }
+      const forkParentSessionKey = canonicalParentSessionKey;
+      if (!forkParentSessionKey || !currentParentSessionEntry || !parentSessionTarget) {
+        return {
+          ok: false,
+          error: errorShape(ErrorCodes.UNAVAILABLE, "failed to resolve parent session for fork"),
+        };
+      }
+      // Operator forks honor the same oversized-parent cap as subagent forks;
+      // an explicit fork of an unusable parent fails loudly instead of
+      // silently producing an empty child.
+      const forkDecision = await resolveParentForkDecision({
+        parentEntry: currentParentSessionEntry,
+        agentId: parentSessionTarget.agentId,
+        storePath: parentSessionTarget.storePath,
+      });
+      if (forkDecision.status === "skip") {
+        return {
+          ok: false,
+          error: errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `parent session is too large to fork (${forkDecision.parentTokens}/${forkDecision.maxTokens} tokens)`,
+          ),
+        };
+      }
+      const fork = await forkSessionFromParent({
+        parentEntry: currentParentSessionEntry,
+        agentId: parentSessionTarget.agentId,
+        parentSessionKey: forkParentSessionKey,
+        sessionKey: target.canonicalKey,
+        storePath: parentSessionTarget.storePath,
+        // Keep the fork transcript owned by the child store across agent boundaries.
+        targetStorePath: target.storePath,
+      });
+      if (!fork) {
+        return {
+          ok: false,
+          error: errorShape(ErrorCodes.UNAVAILABLE, "failed to fork parent session transcript"),
+        };
+      }
+      return {
+        ...initialized,
+        entry: buildForkedGatewaySessionEntry(
+          entry,
+          fork,
+          {
+            sessionKey: forkParentSessionKey,
+            sessionId: currentParentSessionEntry.sessionId,
+          },
+          existingEntry,
+        ),
+      };
+    };
+    const createOptions = params.initialEntry
+      ? {
+          activeSessionKey: target.canonicalKey,
+          requireWriteSuccess: true,
+        }
+      : undefined;
+    const created = memorySubjectIssuer
+      ? await createSessionEntryWithTrustedMemorySubject<ErrorShape>(
+          sessionEntryScope,
+          prepareEntry,
+          memorySubjectIssuer,
+          createOptions,
+        )
+      : await createSessionEntryWithTranscript<ErrorShape>(
+          sessionEntryScope,
+          prepareEntry,
+          createOptions,
+        );
     if (!created.ok) {
       return {
         ok: false,

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -28,10 +28,14 @@ import { createReplyPrefixContext } from "../channels/reply-prefix.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import {
-  applySessionEntryLifecycleMutation,
   loadExactSessionEntry,
   type SessionEntryLifecycleRemoval,
 } from "../config/sessions/session-accessor.js";
+import { applySqliteSessionEntryLifecycleMutationWithTrustedMemorySubjects } from "../config/sessions/session-accessor.sqlite-projection.js";
+import {
+  createTrustedSessionMemorySubjectIssuer,
+  prepareAutonomousAgentSessionMemorySubjectSeed,
+} from "../config/sessions/session-memory-subject.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   hasActiveCronJobs,
@@ -572,33 +576,39 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
           },
         ]
       : [];
-    const lifecycleResult = await applySessionEntryLifecycleMutation({
-      activeSessionKey: isolatedSessionKey,
-      storePath: isolatedStorePath,
-      removals,
-      upserts: [
-        {
-          sessionKey: isolatedSessionKey,
-          buildEntry: ({ store }) => {
-            const cronSession = resolveCronSession({
-              cfg,
-              sessionKey: isolatedSessionKey,
-              agentId,
-              nowMs: startedAt,
-              forceNew: true,
-              store,
-            });
-            const nextEntry = {
-              ...cronSession.sessionEntry,
-              heartbeatIsolatedBaseSessionKey: isolatedBaseSessionKey,
-            };
-            runSessionEntry = nextEntry;
-            return nextEntry;
+    const memorySubjectIssuer = createTrustedSessionMemorySubjectIssuer(() =>
+      prepareAutonomousAgentSessionMemorySubjectSeed(agentId),
+    );
+    const lifecycleResult = await applySqliteSessionEntryLifecycleMutationWithTrustedMemorySubjects(
+      {
+        activeSessionKey: isolatedSessionKey,
+        storePath: isolatedStorePath,
+        removals,
+        upserts: [
+          {
+            sessionKey: isolatedSessionKey,
+            memorySubjectIssuer,
+            buildEntry: ({ store }) => {
+              const cronSession = resolveCronSession({
+                cfg,
+                sessionKey: isolatedSessionKey,
+                agentId,
+                nowMs: startedAt,
+                forceNew: true,
+                store,
+              });
+              const nextEntry = {
+                ...cronSession.sessionEntry,
+                heartbeatIsolatedBaseSessionKey: isolatedBaseSessionKey,
+              };
+              runSessionEntry = nextEntry;
+              return nextEntry;
+            },
           },
-        },
-      ],
-      captureArtifactCleanupError: true,
-    });
+        ],
+        captureArtifactCleanupError: true,
+      },
+    );
     if (lifecycleResult.artifactCleanupError) {
       log.warn("heartbeat: failed to archive stale isolated session transcript", {
         err: formatErrorMessage(lifecycleResult.artifactCleanupError),

--- a/src/infra/heartbeat-runner.isolated-key-stability.test.ts
+++ b/src/infra/heartbeat-runner.isolated-key-stability.test.ts
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import * as replyModule from "../auto-reply/reply.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
+import { readCurrentSessionMemorySubject } from "../config/sessions/session-memory-subject-access.js";
+import { prepareAutonomousAgentSessionMemorySubjectSeed } from "../config/sessions/session-memory-subject.js";
 import { runHeartbeatOnce } from "./heartbeat-runner.js";
 import {
   readSessionStoreForTest,
@@ -160,6 +162,13 @@ describe("runHeartbeatOnce – isolated session key stability (#59493)", () => {
       });
 
       expect(ctx?.SessionKey).toBe(`${baseSessionKey}:heartbeat`);
+      expect(
+        readCurrentSessionMemorySubject({
+          agentId: "main",
+          sessionKey: `${baseSessionKey}:heartbeat`,
+          storePath,
+        })?.subject,
+      ).toEqual(prepareAutonomousAgentSessionMemorySubjectSeed("main").subject);
     });
   });
 

--- a/src/routing/session-key.incognito.test.ts
+++ b/src/routing/session-key.incognito.test.ts
@@ -5,6 +5,7 @@ describe("isIncognitoSessionKey", () => {
   it.each([
     "agent:main:dashboard:incognito-1234",
     "agent:worker:subagent:incognito-5678",
+    "agent:worker:acp:incognito-5678",
     "agent:main:internal-session-effects:incognito-run-1",
   ])("recognizes %s", (sessionKey) => {
     expect(isIncognitoSessionKey(sessionKey)).toBe(true);

--- a/src/shared/incognito-session-key.test.ts
+++ b/src/shared/incognito-session-key.test.ts
@@ -5,6 +5,7 @@ describe("isIncognitoSessionKey", () => {
   it.each([
     "agent:main:dashboard:incognito-123",
     "AGENT:MAIN:SUBAGENT:INCOGNITO-123",
+    "agent:worker:acp:incognito-123",
     "agent:main:internal-session-effects:incognito-123",
   ])("recognizes %s", (sessionKey) => {
     expect(isIncognitoSessionKey(sessionKey)).toBe(true);

--- a/src/shared/incognito-session-key.ts
+++ b/src/shared/incognito-session-key.ts
@@ -1,4 +1,5 @@
-const INCOGNITO_SESSION_RE = /^(?:dashboard|subagent|internal-session-effects):incognito-[^:]+$/u;
+const INCOGNITO_SESSION_RE =
+  /^(?:acp|dashboard|subagent|internal-session-effects):incognito-[^:]+$/u;
 
 /** Classifies process-only agent session keys without consulting runtime registry state. */
 export function isIncognitoSessionKey(sessionKey: string | undefined | null): boolean {

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -49,6 +49,8 @@ const AGENT_SCHEMA_COMPATIBILITY = {
     MEMORY_INDEX_CHUNK_PROVENANCE_TABLE,
     MEMORY_INDEX_CHUNK_RECALL_METADATA_TABLE,
     CONTEXT_ENGINE_TURN_OUTBOX_TABLE,
+    "session_memory_subject_snapshots",
+    "session_memory_subjects",
     STANDING_INTENTS_TABLE,
     STANDING_INTENTS_FTS_TABLE,
     ...STANDING_INTENTS_FTS_SHADOW_TABLES,
@@ -58,6 +60,24 @@ const AGENT_SCHEMA_COMPATIBILITY = {
     "conversations.delivery_target": ["delivery_target TEXT NOT NULL DEFAULT ''"],
   },
   optionalCanonicalTriggerGroups: [
+    {
+      // Session-memory subjects are an additive lazy surface. Older current
+      // databases may lack this trigger until their first memory operation;
+      // the owner ensure installs it before any subject read or write.
+      tableName: "session_memory_subjects",
+      triggers: [
+        {
+          name: "session_memory_subjects_reject_update",
+          sql: `
+            CREATE TRIGGER session_memory_subjects_reject_update
+            BEFORE UPDATE ON session_memory_subjects
+            BEGIN
+              SELECT RAISE(ABORT, 'session memory subject is immutable');
+            END
+          `,
+        },
+      ],
+    },
     {
       tableName: MEMORY_INDEX_SOURCES_TABLE,
       triggers: MEMORY_PATH_FTS_TRIGGER_DEFINITIONS,

--- a/src/state/openclaw-agent-db.generated.d.ts
+++ b/src/state/openclaw-agent-db.generated.d.ts
@@ -225,6 +225,30 @@ export interface SessionMembers {
   session_key: string;
 }
 
+export interface SessionMemorySubjectSnapshots {
+  created_at: number;
+  session_id: string;
+  session_identity_revision: string;
+  session_key: string;
+  subject_revision: string;
+}
+
+export interface SessionMemorySubjects {
+  account_id: string | null;
+  ambiguous_reason: string | null;
+  canonical_conversation_ref: string | null;
+  channel: string | null;
+  conversation_principal_id: string | null;
+  created_at: number;
+  creation_binding_id: string | null;
+  creation_evidence_kind: string | null;
+  creation_evidence_revision: string | null;
+  principal_id: string | null;
+  session_key: string;
+  subject_kind: string;
+  subject_revision: string;
+}
+
 export interface SessionNodes {
   archived_at: number | null;
   category: string | null;
@@ -457,6 +481,8 @@ export interface DB {
   session_conversations: SessionConversations;
   session_key_contract: SessionKeyContract;
   session_members: SessionMembers;
+  session_memory_subject_snapshots: SessionMemorySubjectSnapshots;
+  session_memory_subjects: SessionMemorySubjects;
   session_nodes: SessionNodes;
   session_suggestions: SessionSuggestions;
   session_transcript_active_events: SessionTranscriptActiveEvents;

--- a/src/state/openclaw-agent-schema.sql
+++ b/src/state/openclaw-agent-schema.sql
@@ -247,6 +247,99 @@ CREATE TABLE IF NOT EXISTS session_members (
 CREATE INDEX IF NOT EXISTS idx_agent_session_members_identity
   ON session_members(identity_id, session_key);
 
+CREATE TABLE IF NOT EXISTS session_memory_subjects (
+  session_key TEXT NOT NULL PRIMARY KEY,
+  subject_revision TEXT NOT NULL,
+  subject_kind TEXT NOT NULL CHECK (
+    subject_kind IN ('user', 'conversation', 'service', 'agent', 'system', 'ambiguous')
+  ),
+  principal_id TEXT,
+  conversation_principal_id TEXT,
+  channel TEXT,
+  account_id TEXT,
+  ambiguous_reason TEXT CHECK (
+    ambiguous_reason IS NULL OR ambiguous_reason IN ('shared-main', 'unbound', 'conflicting-bindings')
+  ),
+  creation_evidence_kind TEXT CHECK (
+    creation_evidence_kind IS NULL OR creation_evidence_kind IN (
+      'gateway-profile', 'channel-binding', 'adapter-attested', 'explicit-service'
+    )
+  ),
+  creation_evidence_revision TEXT,
+  creation_binding_id TEXT,
+  canonical_conversation_ref TEXT,
+  created_at INTEGER NOT NULL,
+  CHECK (
+    (subject_kind = 'user'
+      AND principal_id IS NOT NULL
+      AND conversation_principal_id IS NULL
+      AND channel IS NULL
+      AND account_id IS NULL
+      AND ambiguous_reason IS NULL
+      AND creation_evidence_kind IS NOT NULL
+      AND creation_evidence_revision IS NOT NULL)
+    OR
+    (subject_kind = 'conversation'
+      AND principal_id IS NULL
+      AND conversation_principal_id IS NOT NULL
+      AND channel IS NOT NULL
+      AND account_id IS NOT NULL
+      AND ambiguous_reason IS NULL
+      AND creation_evidence_kind IS NULL
+      AND creation_evidence_revision IS NULL
+      AND creation_binding_id IS NULL)
+    OR
+    (subject_kind IN ('service', 'agent', 'system')
+      AND principal_id IS NOT NULL
+      AND conversation_principal_id IS NULL
+      AND channel IS NULL
+      AND account_id IS NULL
+      AND ambiguous_reason IS NULL
+      AND creation_evidence_kind IS NULL
+      AND creation_evidence_revision IS NULL
+      AND creation_binding_id IS NULL)
+    OR
+    (subject_kind = 'ambiguous'
+      AND principal_id IS NULL
+      AND conversation_principal_id IS NULL
+      AND channel IS NULL
+      AND account_id IS NULL
+      AND ambiguous_reason IS NOT NULL
+      AND creation_evidence_kind IS NULL
+      AND creation_evidence_revision IS NULL
+      AND creation_binding_id IS NULL
+      AND canonical_conversation_ref IS NULL)
+  ),
+  CHECK (
+    (creation_evidence_kind = 'channel-binding' AND creation_binding_id IS NOT NULL)
+    OR
+    (creation_evidence_kind IS NOT 'channel-binding' AND creation_binding_id IS NULL)
+  ),
+  FOREIGN KEY (session_key) REFERENCES session_nodes(session_key) ON DELETE CASCADE
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_session_memory_subjects_revision
+  ON session_memory_subjects(subject_revision, session_key);
+
+CREATE TRIGGER IF NOT EXISTS session_memory_subjects_reject_update
+BEFORE UPDATE ON session_memory_subjects
+BEGIN
+  SELECT RAISE(ABORT, 'session memory subject is immutable');
+END;
+
+CREATE TABLE IF NOT EXISTS session_memory_subject_snapshots (
+  session_id TEXT NOT NULL PRIMARY KEY,
+  session_key TEXT NOT NULL,
+  subject_revision TEXT NOT NULL,
+  session_identity_revision TEXT NOT NULL UNIQUE,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES session_windows(session_id) ON DELETE CASCADE,
+  FOREIGN KEY (session_key) REFERENCES session_memory_subjects(session_key) ON DELETE CASCADE
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_session_memory_subject_snapshots_session_key
+  ON session_memory_subject_snapshots(session_key, created_at DESC, session_id);
+
 CREATE TABLE IF NOT EXISTS session_suggestions (
   id TEXT PRIMARY KEY,
   session_key TEXT NOT NULL,

--- a/src/state/openclaw-agent-session-memory-schema.ts
+++ b/src/state/openclaw-agent-session-memory-schema.ts
@@ -1,0 +1,16 @@
+import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.js";
+
+const SESSION_MEMORY_SCHEMA_START = "CREATE TABLE IF NOT EXISTS session_memory_subjects (";
+const SESSION_MEMORY_SCHEMA_END = "CREATE TABLE IF NOT EXISTS session_suggestions (";
+
+function extractSessionMemorySchema(): string {
+  const start = OPENCLAW_AGENT_SCHEMA_SQL.indexOf(SESSION_MEMORY_SCHEMA_START);
+  const end = OPENCLAW_AGENT_SCHEMA_SQL.indexOf(SESSION_MEMORY_SCHEMA_END, start);
+  if (start < 0 || end <= start) {
+    throw new Error("canonical session memory schema markers are missing");
+  }
+  return OPENCLAW_AGENT_SCHEMA_SQL.slice(start, end).trim();
+}
+
+/** Canonical lazy schema for write-once logical-session memory subjects. */
+export const AGENT_SESSION_MEMORY_SCHEMA_SQL = extractSessionMemorySchema();


### PR DESCRIPTION
## What Problem This Solves

Later memory authorization needs a canonical, durable memory subject attached to the session lifecycle. Without it, session creation, forks, subagents, cron runs, and repair paths can derive inconsistent subject identity and make access decisions impossible to audit.

## Why This Change Was Made

This Phase 1A draft adds session memory-subject persistence, trust and immutability boundaries, SQLite lifecycle/schema support, and caller coverage across session creation, inbound routing, forks, subagents, cron, and doctor repair paths. It defines lifecycle facts only; it does not itself grant memory access or activate an enforcement mode.

## User Impact

This is an unreleased draft. Its intended future benefit is stable session-subject continuity across the supported lifecycle without changing current memory behavior or adding an operator setting today.

## Stack / Status

Depends on #121151’s identity/binding draft and is a historical parallel Phase 1A chain, not part of the current canonical #121421 → #121422 → #121423 stack. This description does not change its draft, base, or merge status.

## Evidence

- Exact head: `e0e9ab219b74b127ed57f11b0663af1b88711a93` (`feat(memory): add session subject lifecycle`).
- Current live GitHub rollup shows 10 successful and 73 skipped checks.
- The 63-file diff covers the session accessor/SQLite subject lifecycle, gateway session creation and persistence, agent and cron lifecycle callers, canonical repair/doctor paths, and focused tests.

## Remaining Evidence Gaps

This PR contains no named exact-head test command or remote proof artifact. The live rollup does not demonstrate a complete identity-to-subject-to-authorized-runtime flow, and no live channel/provider proof is claimed.
