### PR TITLE
feat(memory): add trusted channel ingress context

### DIFF
--- a/src/channels/direct-dm.test.ts
+++ b/src/channels/direct-dm.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { dispatchInboundDirectDm } from "./direct-dm.js";
+import type { PluginRuntime } from "../plugins/runtime/types.js";
+import { dispatchInboundDirectDm, dispatchInboundDirectDmWithRuntime } from "./direct-dm.js";
+
+type RuntimeInboundRunInput = Parameters<PluginRuntime["channel"]["inbound"]["run"]>[0];
 
 const mocks = vi.hoisted(() => ({
   dispatchChannelInboundTurn: vi.fn(async () => undefined),
   onModelSelected: vi.fn(),
+  runtimeBuildContext: vi.fn(),
+  runtimeRun: vi.fn(async () => undefined),
 }));
 
 vi.mock("./inbound-event/context.js", () => ({
@@ -19,6 +24,14 @@ vi.mock("./inbound-event/envelope.js", () => ({
       sessionKey: "agent:agent-1:nostr:direct:peer-1",
     },
     buildEnvelope: vi.fn(() => "envelope:hello"),
+  })),
+  resolveInboundRouteEnvelopeBuilderWithRuntime: vi.fn(() => ({
+    route: {
+      agentId: "agent-1",
+      accountId: "account-1",
+      sessionKey: "agent:agent-1:nostr:direct:peer-1",
+    },
+    buildEnvelope: vi.fn(() => ({ storePath: "/tmp/nostr-session-store", body: "envelope:hello" })),
   })),
 }));
 
@@ -93,5 +106,60 @@ describe("dispatchInboundDirectDm", () => {
         replyOptions: expect.objectContaining({ turnAdoptionLifecycle }),
       }),
     );
+  });
+
+  it("pairs the trusted runtime builder with its inbound runner", async () => {
+    const ctxPayload = { Body: "trusted:hello", SessionKey: "agent:agent-1:nostr:direct:peer-1" };
+    mocks.runtimeBuildContext.mockReturnValueOnce(ctxPayload);
+    mocks.runtimeRun.mockImplementationOnce(async (input: RuntimeInboundRunInput) => {
+      expect(input.raw).toBe(ctxPayload);
+      const ingested = await input.adapter.ingest(input.raw);
+      if (!ingested) {
+        throw new Error("expected direct DM ingress to produce an input");
+      }
+      const plan = await input.adapter.resolveTurn(ingested, {
+        kind: "message",
+        canStartAgentTurn: true,
+      });
+      if (!("ctxPayload" in plan)) {
+        throw new Error("expected direct DM ingress to produce a turn plan");
+      }
+      expect(plan.ctxPayload).toBe(ctxPayload);
+    });
+
+    await dispatchInboundDirectDmWithRuntime({
+      runtime: {
+        channel: {
+          inbound: {
+            buildContext: mocks.runtimeBuildContext,
+            run: mocks.runtimeRun,
+          },
+        },
+      } as never,
+      cfg: {} as OpenClawConfig,
+      channel: "nostr",
+      channelLabel: "Nostr",
+      accountId: "account-1",
+      peer: { kind: "direct", id: "peer-1" },
+      senderId: "peer-1",
+      senderAddress: "nostr:peer-1",
+      recipientAddress: "nostr:bot-1",
+      conversationLabel: "peer-1",
+      rawBody: "hello",
+      messageId: "event-1",
+      inboundAccessAuthorized: true,
+      deliver: async () => undefined,
+      onRecordError: vi.fn(),
+      onDispatchError: vi.fn(),
+    });
+
+    expect(mocks.runtimeBuildContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "nostr",
+        route: expect.objectContaining({ dispatchSessionKey: "agent:agent-1:nostr:direct:peer-1" }),
+        extra: expect.objectContaining({ InboundAccessAuthorized: true }),
+      }),
+    );
+    expect(mocks.runtimeRun).toHaveBeenCalledOnce();
   });
 });

--- a/src/channels/direct-dm.ts
+++ b/src/channels/direct-dm.ts
@@ -63,9 +63,10 @@ function buildDirectDmContext(
   params: DispatchInboundDirectDmParams,
   route: DirectDmRoute,
   body: string,
-): FinalizedMsgContext {
+  buildContext: typeof buildChannelInboundEventContext = buildChannelInboundEventContext,
+): FinalizedMsgContext | Promise<FinalizedMsgContext> {
   const accountId = route.accountId ?? params.accountId;
-  return buildChannelInboundEventContext({
+  return buildContext({
     channel: params.channel,
     accountId,
     provider: params.provider,
@@ -96,6 +97,7 @@ function buildDirectDmContext(
     extra: {
       NativeDirectUserId: params.peer.id,
       OriginatingChannel: params.originatingChannel ?? params.channel,
+      ...(params.inboundAccessAuthorized === true ? { InboundAccessAuthorized: true } : {}),
       ...params.extraContext,
     },
   });
@@ -111,7 +113,7 @@ export async function dispatchInboundDirectDm(params: DispatchInboundDirectDmPar
     accountId: params.accountId,
     peer: params.peer,
   });
-  const ctxPayload = buildDirectDmContext(
+  const ctxPayload = await buildDirectDmContext(
     params,
     route,
     buildEnvelope({
@@ -182,30 +184,12 @@ export async function dispatchInboundDirectDmWithRuntime(
     body: params.rawBody,
     timestamp: params.timestamp,
   });
-  const ctxPayload = params.runtime.channel.reply.finalizeInboundContext({
-    Body: body,
-    BodyForAgent: params.bodyForAgent ?? params.rawBody,
-    RawBody: params.rawBody,
-    CommandBody: params.commandBody ?? params.rawBody,
-    From: params.senderAddress,
-    To: params.recipientAddress,
-    SessionKey: route.sessionKey,
-    AccountId: route.accountId ?? params.accountId,
-    ChatType: "direct",
-    ConversationLabel: params.conversationLabel,
-    SenderId: params.senderId,
-    Provider: params.provider ?? params.channel,
-    Surface: params.surface ?? params.channel,
-    MessageSid: params.messageId,
-    MessageSidFull: params.messageId,
-    Timestamp: params.timestamp,
-    CommandAuthorized: params.commandAuthorized,
-    ...(params.inboundAccessAuthorized === true ? { InboundAccessAuthorized: true } : {}),
-    OriginatingChannel: params.originatingChannel ?? params.channel,
-    OriginatingTo: params.originatingTo ?? params.recipientAddress,
-    NativeDirectUserId: params.peer.id,
-    ...params.extraContext,
-  });
+  const ctxPayload = await buildDirectDmContext(
+    params,
+    route,
+    body,
+    params.runtime.channel.inbound.buildContext,
+  );
   const plan = buildDirectDmTurnPlan(params, route, ctxPayload);
   await params.runtime.channel.inbound.run({
     channel: params.channel,

--- a/src/channels/inbound-event/core-ingress.runtime.test.ts
+++ b/src/channels/inbound-event/core-ingress.runtime.test.ts
@@ -1,0 +1,216 @@
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type { FinalizedMsgContext } from "../../auto-reply/templating.js";
+import { readCurrentSessionMemorySubject } from "../../config/sessions/session-memory-subject-access.js";
+import { createMemoryIdentityBindingThroughApprovedPairing } from "../../pairing/memory-identity-approval.test-support.js";
+import { buildAgentSessionKey } from "../../routing/resolve-route.js";
+import { memoryIdentityLifecycle } from "../../state/memory-identity.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { recordInboundSession } from "../session.js";
+import { createCoreChannelInboundEventFacade } from "./core-ingress.js";
+
+const SESSION_KEY = "agent:main:test:direct:sender-1";
+const CANONICAL_EQUIVALENT_SESSION_KEY = "Agent:Main:Test:Direct:Sender-1";
+const tempDirectories = useAutoCleanupTempDirTracker(afterEach);
+const { ensureEnterpriseMemoryPrincipal } = memoryIdentityLifecycle;
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  vi.unstubAllEnvs();
+});
+
+it("persists a private subject through the facade with a canonical-equivalent record key", async () => {
+  const stateDir = tempDirectories.make("openclaw-core-ingress-runtime-state-");
+  const storePath = path.join(
+    tempDirectories.make("openclaw-core-ingress-runtime-store-"),
+    "sessions.json",
+  );
+  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  closeOpenClawStateDatabaseForTest();
+  const principal = ensureEnterpriseMemoryPrincipal({
+    issuer: "core-ingress-runtime-test",
+    stableSubjectId: "sender-1",
+    now: 100,
+  });
+  await createMemoryIdentityBindingThroughApprovedPairing({
+    channel: "test",
+    accountId: "acct",
+    stableSenderId: "sender-1",
+    principalId: principal.principalId,
+    now: 100,
+    options: { env: process.env },
+  });
+  const facade = createCoreChannelInboundEventFacade({
+    ownsChannel: (channel) => channel === "test",
+  });
+  const ctx = facade.buildContext({
+    channel: "test",
+    accountId: "acct",
+    from: "test:sender-1",
+    sender: { id: "sender-1" },
+    conversation: { kind: "direct", id: "sender-1" },
+    route: {
+      agentId: "main",
+      accountId: "acct",
+      dmScope: "per-channel-peer",
+      routeSessionKey: SESSION_KEY,
+    },
+    reply: { to: "test:sender-1" },
+    message: { rawBody: "hello" },
+  });
+  const metadataTasks: Promise<unknown>[] = [];
+  const recordErrors: unknown[] = [];
+
+  await facade.run({
+    channel: "test",
+    accountId: "acct",
+    raw: {},
+    adapter: {
+      ingest: () => ({ id: "message-1", rawText: "hello" }),
+      resolveTurn: () => ({
+        channel: "test",
+        accountId: "acct",
+        routeSessionKey: SESSION_KEY,
+        storePath,
+        ctxPayload: ctx as FinalizedMsgContext,
+        recordInboundSession,
+        record: {
+          sessionKey: CANONICAL_EQUIVALENT_SESSION_KEY,
+          onRecordError: (error) => {
+            recordErrors.push(error);
+          },
+          trackSessionMetaTask: (task) => {
+            metadataTasks.push(task);
+          },
+        },
+        runDispatch: async () => ({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } }),
+        runDispatchLifecycle: {
+          turnAdoptionLifecycle: undefined,
+          onDispatchSkipped: async () => undefined,
+        },
+      }),
+    },
+  });
+
+  await Promise.all(metadataTasks);
+
+  expect(recordErrors).toEqual([]);
+  expect(metadataTasks).toHaveLength(1);
+  expect(
+    readCurrentSessionMemorySubject({ agentId: "main", sessionKey: SESSION_KEY, storePath })
+      ?.subject,
+  ).toMatchObject({ kind: "user", principalId: principal.principalId });
+});
+
+it("keeps hostile sender and alias extras from becoming a private subject", async () => {
+  const stateDir = tempDirectories.make("openclaw-core-ingress-hostile-state-");
+  const storePath = path.join(
+    tempDirectories.make("openclaw-core-ingress-hostile-store-"),
+    "sessions.json",
+  );
+  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  closeOpenClawStateDatabaseForTest();
+  const victim = ensureEnterpriseMemoryPrincipal({
+    issuer: "core-ingress-hostile-test",
+    stableSubjectId: "victim-sender",
+    now: 100,
+  });
+  await createMemoryIdentityBindingThroughApprovedPairing({
+    channel: "test",
+    accountId: "acct",
+    stableSenderId: "victim-sender",
+    principalId: victim.principalId,
+    now: 100,
+    options: { env: process.env },
+  });
+  const identityLinks = { "victim-alias": ["test:unbound-sender"] };
+  const sessionKey = buildAgentSessionKey({
+    agentId: "main",
+    channel: "test",
+    accountId: "acct",
+    peer: { kind: "direct", id: "unbound-sender" },
+    dmScope: "per-channel-peer",
+    identityLinks,
+  });
+  expect(sessionKey).toBe("agent:main:test:direct:victim-alias");
+  const facade = createCoreChannelInboundEventFacade({
+    ownsChannel: (channel) => channel === "test",
+  });
+  const ctx = facade.buildContext({
+    channel: "test",
+    accountId: "acct",
+    from: "test:unbound-sender",
+    sender: {
+      id: "unbound-sender",
+      name: "Unbound Sender",
+      displayLabel: "Unbound Sender",
+      username: "unbound",
+      tag: "unbound",
+    },
+    conversation: { kind: "direct", id: "unbound-sender" },
+    route: {
+      agentId: "main",
+      accountId: "acct",
+      dmScope: "per-channel-peer",
+      routeSessionKey: sessionKey,
+    },
+    reply: { to: "test:unbound-sender" },
+    message: { rawBody: "hello" },
+    extra: {
+      From: "test:victim-sender",
+      SenderId: "victim-sender",
+      SenderName: "Victim Name",
+      SenderUsername: "victim",
+      SenderTag: "victim",
+      identityLinks,
+      IdentityLinks: identityLinks,
+      Model: "openai/victim-model",
+      ParentSessionKey: "agent:main:test:direct:victim-sender",
+      ModelParentSessionKey: "agent:main:test:direct:victim-sender",
+    },
+  });
+  const metadataTasks: Promise<unknown>[] = [];
+  const recordErrors: unknown[] = [];
+
+  await facade.run({
+    channel: "test",
+    accountId: "acct",
+    raw: {},
+    adapter: {
+      ingest: () => ({ id: "message-hostile", rawText: "hello" }),
+      resolveTurn: () => ({
+        channel: "test",
+        accountId: "acct",
+        routeSessionKey: sessionKey,
+        storePath,
+        ctxPayload: ctx as FinalizedMsgContext,
+        recordInboundSession,
+        record: {
+          sessionKey,
+          onRecordError: (error) => {
+            recordErrors.push(error);
+          },
+          trackSessionMetaTask: (task) => {
+            metadataTasks.push(task);
+          },
+        },
+        runDispatch: async () => ({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } }),
+        runDispatchLifecycle: {
+          turnAdoptionLifecycle: undefined,
+          onDispatchSkipped: async () => undefined,
+        },
+      }),
+    },
+  });
+
+  await Promise.all(metadataTasks);
+
+  expect(recordErrors).toEqual([]);
+  expect(metadataTasks).toHaveLength(1);
+  expect(
+    readCurrentSessionMemorySubject({ agentId: "main", sessionKey, storePath })?.subject,
+  ).toEqual({ version: 1, kind: "ambiguous", reason: "unbound" });
+});

--- a/src/channels/inbound-event/core-ingress.test.ts
+++ b/src/channels/inbound-event/core-ingress.test.ts
@@ -1,0 +1,583 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type { FinalizedMsgContext } from "../../auto-reply/templating.js";
+import { recordInboundSessionMetaWithTrustedMemorySubject } from "../../config/sessions/session-accessor.entry-mutation.js";
+import { readCurrentSessionMemorySubject } from "../../config/sessions/session-memory-subject-access.js";
+import type { TrustedSessionMemorySubjectIssuer } from "../../config/sessions/session-memory-subject.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createMemoryIdentityBindingThroughApprovedPairing } from "../../pairing/memory-identity-approval.test-support.js";
+import {
+  buildChannelInboundEventContext,
+  runChannelInboundEvent,
+} from "../../plugin-sdk/channel-inbound.js";
+import { memoryIdentityLifecycle } from "../../state/memory-identity.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import type { RecordInboundSession } from "../session.types.js";
+import { dispatchChannelInboundTurn, runPreparedInboundReply } from "../turn/kernel.js";
+import { createCoreChannelInboundEventFacade } from "./core-ingress.js";
+import {
+  attestCoreChannelInboundMemorySubjectContext,
+  bindAttestedChannelInboundMemorySubject,
+  getBoundChannelInboundMemorySubjectIssuer,
+} from "./memory-subject-attestation.js";
+
+const recordInboundSession = vi.hoisted(() => vi.fn<RecordInboundSession>(async () => undefined));
+const dispatchRouted = vi.hoisted(() => vi.fn());
+
+vi.mock("../session.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../session.js")>();
+  return { ...actual, recordInboundSession };
+});
+
+vi.mock("../../auto-reply/dispatch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../auto-reply/dispatch.js")>();
+  return { ...actual, dispatchInboundMessageWithRoutedChannelDispatcher: dispatchRouted };
+});
+
+const SESSION_KEY = "agent:main:test:direct:sender-1";
+const OTHER_SESSION_KEY = "agent:main:test:direct:sender-2";
+const CANONICAL_EQUIVALENT_SESSION_KEY = "Agent:Main:Test:Direct:Sender-1";
+const tempDirectories = useAutoCleanupTempDirTracker(afterEach);
+const { ensureEnterpriseMemoryPrincipal } = memoryIdentityLifecycle;
+
+function createContextParams(overrides: Record<string, unknown> = {}) {
+  return {
+    channel: "test",
+    accountId: "acct",
+    from: "test:sender-1",
+    sender: { id: "sender-1" },
+    conversation: { kind: "direct" as const, id: "sender-1" },
+    route: {
+      agentId: "main",
+      accountId: "acct",
+      dmScope: "per-channel-peer" as const,
+      routeSessionKey: SESSION_KEY,
+    },
+    reply: { to: "test:sender-1" },
+    message: { rawBody: "hello" },
+    ...overrides,
+  };
+}
+
+function createPreparedTurn(
+  ctxPayload: FinalizedMsgContext,
+  options?: { recordSessionKey?: string; useSessionRecorder?: boolean },
+) {
+  return {
+    channel: "test",
+    accountId: "acct",
+    routeSessionKey: SESSION_KEY,
+    storePath: "/tmp/openclaw-core-ingress-test",
+    ctxPayload,
+    recordInboundSession: options?.useSessionRecorder
+      ? recordInboundSession
+      : async () => undefined,
+    ...(options?.recordSessionKey ? { record: { sessionKey: options.recordSessionKey } } : {}),
+    runDispatch: async () => ({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } }),
+    runDispatchLifecycle: {
+      turnAdoptionLifecycle: undefined,
+      onDispatchSkipped: async () => undefined,
+    },
+  };
+}
+
+function createRoutedTurn(ctxPayload: FinalizedMsgContext) {
+  return {
+    cfg: {} as OpenClawConfig,
+    channel: "test",
+    accountId: "acct",
+    route: {
+      agentId: "main",
+      dmScope: "per-channel-peer" as const,
+      sessionKey: SESSION_KEY,
+    },
+    ctxPayload,
+    delivery: { deliver: async () => ({ visibleReplySent: false }) },
+  };
+}
+
+async function runPrepared(params: {
+  ctxPayload: FinalizedMsgContext;
+  run: (input: Parameters<typeof runChannelInboundEvent>[0]) => Promise<unknown>;
+  recordSessionKey?: string;
+  useSessionRecorder?: boolean;
+}) {
+  await params.run({
+    channel: "test",
+    accountId: "acct",
+    raw: {},
+    adapter: {
+      ingest: () => ({ id: "message-1", rawText: "hello" }),
+      resolveTurn: () =>
+        createPreparedTurn(params.ctxPayload, {
+          recordSessionKey: params.recordSessionKey,
+          useSessionRecorder: params.useSessionRecorder,
+        }),
+    },
+  });
+}
+
+describe("core channel inbound memory-subject ingress", () => {
+  beforeEach(() => {
+    recordInboundSession.mockReset();
+    recordInboundSession.mockResolvedValue(undefined);
+    dispatchRouted.mockReset();
+    dispatchRouted.mockResolvedValue({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    vi.unstubAllEnvs();
+  });
+
+  it("keeps public SDK builder and runner calls unbound", async () => {
+    const ctx = buildChannelInboundEventContext(createContextParams());
+
+    await runPrepared({ ctxPayload: ctx, run: runChannelInboundEvent });
+
+    expect(getBoundChannelInboundMemorySubjectIssuer(ctx, SESSION_KEY)).toBeUndefined();
+  });
+
+  it("keeps the public runtime-style builder unbound even when a trusted runner is used", async () => {
+    const facade = createCoreChannelInboundEventFacade({
+      ownsChannel: (channel) => channel === "test",
+    });
+    const ctx = buildChannelInboundEventContext(createContextParams());
+
+    await runPrepared({ ctxPayload: ctx, run: facade.run });
+
+    expect(getBoundChannelInboundMemorySubjectIssuer(ctx, SESSION_KEY)).toBeUndefined();
+  });
+
+  it("keeps a trusted builder unbound when it runs through the public SDK runner", async () => {
+    const facade = createCoreChannelInboundEventFacade({
+      ownsChannel: (channel) => channel === "test",
+    });
+    const ctx = facade.buildContext(createContextParams());
+
+    await runPrepared({ ctxPayload: ctx, run: runChannelInboundEvent });
+
+    expect(getBoundChannelInboundMemorySubjectIssuer(ctx, SESSION_KEY)).toBeUndefined();
+  });
+
+  it("issues only through the matching paired trusted facade", async () => {
+    const facade = createCoreChannelInboundEventFacade({
+      ownsChannel: (channel) => channel === "test",
+    });
+    const ctx = facade.buildContext(createContextParams());
+    let issuer: TrustedSessionMemorySubjectIssuer | undefined;
+    recordInboundSession.mockImplementation(async (params) => {
+      issuer = getBoundChannelInboundMemorySubjectIssuer(
+        params.ctx as FinalizedMsgContext,
+        params.sessionKey,
+      );
+    });
+
+    await runPrepared({ ctxPayload: ctx, run: facade.run, useSessionRecorder: true });
+
+    expect(issuer).toBeDefined();
+    expect(getBoundChannelInboundMemorySubjectIssuer(ctx, SESSION_KEY)).toBeUndefined();
+  });
+
+  it("pairs facade-built contexts with facade dispatch without promoting public dispatch", async () => {
+    const facade = createCoreChannelInboundEventFacade({
+      ownsChannel: (channel) => channel === "test",
+    });
+    const paired = facade.buildContext(createContextParams());
+    const publicContext = buildChannelInboundEventContext(createContextParams());
+    const directDispatchContext = facade.buildContext(createContextParams());
+    const cloned = { ...facade.buildContext(createContextParams()) } as FinalizedMsgContext;
+    const issuers: TrustedSessionMemorySubjectIssuer[] = [];
+    recordInboundSession.mockImplementation(async (params) => {
+      const issuer = getBoundChannelInboundMemorySubjectIssuer(
+        params.ctx as FinalizedMsgContext,
+        params.sessionKey,
+      );
+      if (issuer) {
+        issuers.push(issuer);
+      }
+    });
+
+    await facade.dispatch(createRoutedTurn(paired));
+    await facade.dispatch(createRoutedTurn(publicContext));
+    await dispatchChannelInboundTurn(createRoutedTurn(directDispatchContext));
+    await facade.dispatch(createRoutedTurn(cloned));
+
+    expect(issuers).toHaveLength(1);
+    expect(getBoundChannelInboundMemorySubjectIssuer(paired, SESSION_KEY)).toBeUndefined();
+    expect(getBoundChannelInboundMemorySubjectIssuer(publicContext, SESSION_KEY)).toBeUndefined();
+    expect(
+      getBoundChannelInboundMemorySubjectIssuer(directDispatchContext, SESSION_KEY),
+    ).toBeUndefined();
+    expect(getBoundChannelInboundMemorySubjectIssuer(cloned, SESSION_KEY)).toBeUndefined();
+  });
+
+  it("rejects a different facade, cloned context, and lookalike ingress", async () => {
+    const first = createCoreChannelInboundEventFacade({
+      ownsChannel: (channel) => channel === "test",
+    });
+    const second = createCoreChannelInboundEventFacade({
+      ownsChannel: (channel) => channel === "test",
+    });
+    const firstContext = first.buildContext(createContextParams());
+    const clonedContext = { ...firstContext } as FinalizedMsgContext;
+
+    await runPrepared({ ctxPayload: firstContext, run: second.run });
+    await runPrepared({ ctxPayload: clonedContext, run: first.run });
+    attestCoreChannelInboundMemorySubjectContext({
+      ctx: firstContext,
+      ingress: Object.freeze({}),
+      runChannel: "test",
+    });
+    await bindAttestedChannelInboundMemorySubject(firstContext, SESSION_KEY);
+
+    expect(getBoundChannelInboundMemorySubjectIssuer(firstContext, SESSION_KEY)).toBeUndefined();
+    expect(getBoundChannelInboundMemorySubjectIssuer(clonedContext, SESSION_KEY)).toBeUndefined();
+  });
+
+  it("rejects untrusted or wrong-channel facades", async () => {
+    const untrusted = createCoreChannelInboundEventFacade({ ownsChannel: () => false });
+    const wrongChannel = createCoreChannelInboundEventFacade({
+      ownsChannel: (channel) => channel === "other",
+    });
+    const untrustedContext = untrusted.buildContext(createContextParams());
+    const wrongChannelContext = wrongChannel.buildContext(createContextParams());
+
+    await runPrepared({ ctxPayload: untrustedContext, run: untrusted.run });
+    await runPrepared({ ctxPayload: wrongChannelContext, run: wrongChannel.run });
+
+    expect(
+      getBoundChannelInboundMemorySubjectIssuer(untrustedContext, SESSION_KEY),
+    ).toBeUndefined();
+    expect(
+      getBoundChannelInboundMemorySubjectIssuer(wrongChannelContext, SESSION_KEY),
+    ).toBeUndefined();
+  });
+
+  it("accepts a canonical record key but rejects a different final identity", async () => {
+    const facade = createCoreChannelInboundEventFacade({
+      ownsChannel: (channel) => channel === "test",
+    });
+    const equivalentKey = facade.buildContext(createContextParams());
+    const changedAccount = facade.buildContext(
+      createContextParams({ extra: { AccountId: "different-account" } }),
+    );
+    const changedScope = facade.buildContext(
+      createContextParams({ extra: { DmScope: "per-peer" } }),
+    );
+    const changedKey = facade.buildContext(createContextParams());
+
+    const issuers: TrustedSessionMemorySubjectIssuer[] = [];
+    recordInboundSession.mockImplementation(async (params) => {
+      const issuer = getBoundChannelInboundMemorySubjectIssuer(
+        params.ctx as FinalizedMsgContext,
+        params.sessionKey,
+      );
+      if (issuer) {
+        issuers.push(issuer);
+      }
+    });
+
+    await runPrepared({
+      ctxPayload: equivalentKey,
+      run: facade.run,
+      recordSessionKey: CANONICAL_EQUIVALENT_SESSION_KEY,
+      useSessionRecorder: true,
+    });
+    await runPrepared({ ctxPayload: changedAccount, run: facade.run, useSessionRecorder: true });
+    await runPrepared({ ctxPayload: changedScope, run: facade.run, useSessionRecorder: true });
+    await runPrepared({
+      ctxPayload: changedKey,
+      run: facade.run,
+      recordSessionKey: OTHER_SESSION_KEY,
+      useSessionRecorder: true,
+    });
+
+    expect(issuers).toHaveLength(1);
+    expect(getBoundChannelInboundMemorySubjectIssuer(changedAccount, SESSION_KEY)).toBeUndefined();
+    expect(getBoundChannelInboundMemorySubjectIssuer(changedScope, SESSION_KEY)).toBeUndefined();
+    expect(getBoundChannelInboundMemorySubjectIssuer(changedKey, SESSION_KEY)).toBeUndefined();
+  });
+
+  it("maps either captured or finalized main DM scope to an ambiguous issuer", async () => {
+    const facade = createCoreChannelInboundEventFacade({
+      ownsChannel: (channel) => channel === "test",
+    });
+    const capturedMain = facade.buildContext(
+      createContextParams({
+        route: {
+          agentId: "main",
+          accountId: "acct",
+          dmScope: "main",
+          routeSessionKey: SESSION_KEY,
+        },
+      }),
+    );
+    const finalizedMain = facade.buildContext(createContextParams({ extra: { DmScope: "main" } }));
+    const issuers: TrustedSessionMemorySubjectIssuer[] = [];
+    recordInboundSession.mockImplementation(async (params) => {
+      const issuer = getBoundChannelInboundMemorySubjectIssuer(
+        params.ctx as FinalizedMsgContext,
+        params.sessionKey,
+      );
+      if (issuer) {
+        issuers.push(issuer);
+      }
+    });
+
+    await runPrepared({ ctxPayload: capturedMain, run: facade.run, useSessionRecorder: true });
+    await runPrepared({ ctxPayload: finalizedMain, run: facade.run, useSessionRecorder: true });
+
+    expect(issuers).toHaveLength(2);
+    expect(issuers.map((issuer) => issuer.issue().subject)).toEqual([
+      { version: 1, kind: "ambiguous", reason: "shared-main" },
+      { version: 1, kind: "ambiguous", reason: "shared-main" },
+    ]);
+  });
+
+  it("rechecks facade liveness inside the real first-write transaction", async () => {
+    const stateDir = tempDirectories.make("openclaw-core-ingress-state-");
+    const storePath = path.join(
+      tempDirectories.make("openclaw-core-ingress-store-"),
+      "sessions.json",
+    );
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    closeOpenClawStateDatabaseForTest();
+    const principal = ensureEnterpriseMemoryPrincipal({
+      issuer: "core-ingress-test",
+      stableSubjectId: "sender-1",
+      now: 100,
+    });
+    await createMemoryIdentityBindingThroughApprovedPairing({
+      channel: "test",
+      accountId: "acct",
+      stableSenderId: "sender-1",
+      principalId: principal.principalId,
+      now: 100,
+      options: { env: process.env },
+    });
+    let ownsChannel = true;
+    const facade = createCoreChannelInboundEventFacade({
+      ownsChannel: (channel) => ownsChannel && channel === "test",
+    });
+    const activeContext = facade.buildContext(createContextParams());
+    const revokedSessionKey = "agent:main:test:direct:sender-2";
+    const revokedContext = facade.buildContext(
+      createContextParams({
+        from: "test:sender-2",
+        sender: { id: "sender-2" },
+        conversation: { kind: "direct", id: "sender-2" },
+        route: {
+          agentId: "main",
+          accountId: "acct",
+          dmScope: "per-channel-peer",
+          routeSessionKey: revokedSessionKey,
+        },
+        reply: { to: "test:sender-2" },
+      }),
+    );
+    const issuers: TrustedSessionMemorySubjectIssuer[] = [];
+    recordInboundSession.mockImplementation(async (params) => {
+      const issuer = getBoundChannelInboundMemorySubjectIssuer(
+        params.ctx as FinalizedMsgContext,
+        params.sessionKey,
+      );
+      if (issuer) {
+        issuers.push(issuer);
+      }
+    });
+
+    await runPrepared({ ctxPayload: activeContext, run: facade.run, useSessionRecorder: true });
+    const activeIssuer = issuers.at(0);
+    if (!activeIssuer) {
+      throw new Error("expected active facade issuer");
+    }
+    await recordInboundSessionMetaWithTrustedMemorySubject(
+      { storePath, sessionKey: SESSION_KEY, ctx: activeContext },
+      activeIssuer,
+    );
+    expect(
+      readCurrentSessionMemorySubject({ agentId: "main", sessionKey: SESSION_KEY, storePath })
+        ?.subject,
+    ).toMatchObject({ kind: "user", principalId: principal.principalId });
+
+    await runPrepared({ ctxPayload: revokedContext, run: facade.run, useSessionRecorder: true });
+    const revokedIssuer = issuers.at(1);
+    if (!revokedIssuer) {
+      throw new Error("expected issuer before liveness revocation");
+    }
+    ownsChannel = false;
+    await recordInboundSessionMetaWithTrustedMemorySubject(
+      { storePath, sessionKey: revokedSessionKey, ctx: revokedContext },
+      revokedIssuer,
+    );
+    expect(
+      readCurrentSessionMemorySubject({
+        agentId: "main",
+        sessionKey: revokedSessionKey,
+        storePath,
+      })?.subject,
+    ).toEqual({ version: 1, kind: "ambiguous", reason: "unbound" });
+  });
+
+  it("does not promote a facade-built context through direct prepared dispatch", async () => {
+    const facade = createCoreChannelInboundEventFacade({
+      ownsChannel: (channel) => channel === "test",
+    });
+    const ctx = facade.buildContext(createContextParams());
+    const issuers: TrustedSessionMemorySubjectIssuer[] = [];
+    recordInboundSession.mockImplementation(async (params) => {
+      const issuer = getBoundChannelInboundMemorySubjectIssuer(
+        params.ctx as FinalizedMsgContext,
+        params.sessionKey,
+      );
+      if (issuer) {
+        issuers.push(issuer);
+      }
+    });
+
+    await runPrepared({ ctxPayload: ctx, run: facade.run, useSessionRecorder: true });
+    await runPrepared({ ctxPayload: ctx, run: runChannelInboundEvent, useSessionRecorder: true });
+    await runPreparedInboundReply(createPreparedTurn(ctx));
+
+    expect(issuers).toHaveLength(1);
+    expect(getBoundChannelInboundMemorySubjectIssuer(ctx, SESSION_KEY)).toBeUndefined();
+  });
+
+  it("rejects authority when routed execution changes the owning agent", async () => {
+    const facade = createCoreChannelInboundEventFacade({
+      ownsChannel: (channel) => channel === "test",
+    });
+    const ctx = facade.buildContext(createContextParams());
+    let issuer: TrustedSessionMemorySubjectIssuer | undefined;
+    recordInboundSession.mockImplementation(async (params) => {
+      issuer = getBoundChannelInboundMemorySubjectIssuer(
+        params.ctx as FinalizedMsgContext,
+        params.sessionKey,
+      );
+    });
+
+    await facade.run({
+      channel: "test",
+      accountId: "acct",
+      raw: {},
+      adapter: {
+        ingest: () => ({ id: "message-1", rawText: "hello" }),
+        resolveTurn: () => ({
+          cfg: {} as OpenClawConfig,
+          channel: "test",
+          accountId: "acct",
+          route: {
+            agentId: "other-agent",
+            dmScope: "per-channel-peer",
+            sessionKey: SESSION_KEY,
+          },
+          ctxPayload: ctx,
+          delivery: { deliver: async () => ({ visibleReplySent: false }) },
+        }),
+      },
+    });
+
+    expect(issuer).toBeUndefined();
+    expect(getBoundChannelInboundMemorySubjectIssuer(ctx, SESSION_KEY)).toBeUndefined();
+  });
+
+  it("clears a bound issuer after a bot-loop terminal path", async () => {
+    const facade = createCoreChannelInboundEventFacade({
+      ownsChannel: (channel) => channel === "test",
+    });
+    const ctx = facade.buildContext(createContextParams());
+    const botLoopProtection = {
+      scopeId: "core-ingress-terminal-cleanup",
+      conversationId: "sender-1",
+      senderId: "bot-a",
+      receiverId: "bot-b",
+      config: { maxEventsPerWindow: 1, windowSeconds: 60, cooldownSeconds: 60 },
+      defaultEnabled: true,
+    };
+    await runPreparedInboundReply({
+      ...createPreparedTurn(ctx),
+      botLoopProtection: { ...botLoopProtection, nowMs: 1_000 },
+    });
+    let issuerDuringSkip: TrustedSessionMemorySubjectIssuer | undefined;
+
+    await facade.run({
+      channel: "test",
+      accountId: "acct",
+      raw: {},
+      adapter: {
+        ingest: () => ({ id: "message-1", rawText: "hello" }),
+        resolveTurn: () => ({
+          ...createPreparedTurn(ctx),
+          botLoopProtection: { ...botLoopProtection, nowMs: 1_001 },
+          runDispatchLifecycle: {
+            turnAdoptionLifecycle: undefined,
+            onDispatchSkipped: async () => {
+              issuerDuringSkip = getBoundChannelInboundMemorySubjectIssuer(ctx, SESSION_KEY);
+            },
+          },
+        }),
+      },
+    });
+
+    expect(issuerDuringSkip).toBeDefined();
+    expect(getBoundChannelInboundMemorySubjectIssuer(ctx, SESSION_KEY)).toBeUndefined();
+  });
+
+  it("preserves a valid issuer only on the final routed dmScope context clone", async () => {
+    const facade = createCoreChannelInboundEventFacade({
+      ownsChannel: (channel) => channel === "test",
+    });
+    const ctx = facade.buildContext(createContextParams());
+    let recordedContext: FinalizedMsgContext | undefined;
+    let issuer: TrustedSessionMemorySubjectIssuer | undefined;
+    recordInboundSession.mockImplementation(async (params) => {
+      recordedContext = params.ctx as FinalizedMsgContext;
+      issuer = getBoundChannelInboundMemorySubjectIssuer(recordedContext, params.sessionKey);
+    });
+    const result = await facade.run({
+      channel: "test",
+      accountId: "acct",
+      raw: {},
+      adapter: {
+        ingest: () => ({ id: "message-1", rawText: "hello" }),
+        resolveTurn: () => ({
+          cfg: {} as OpenClawConfig,
+          channel: "test",
+          accountId: "acct",
+          route: {
+            agentId: "main",
+            dmScope: "per-channel-peer",
+            sessionKey: SESSION_KEY,
+          },
+          ctxPayload: ctx,
+          delivery: { deliver: async () => ({ visibleReplySent: false }) },
+        }),
+      },
+    });
+
+    expect(result.dispatched).toBe(true);
+    if (!result.dispatched) {
+      throw new Error("expected a dispatched routed turn");
+    }
+    expect(result.ctxPayload).not.toBe(ctx);
+    expect(getBoundChannelInboundMemorySubjectIssuer(ctx, SESSION_KEY)).toBeUndefined();
+    expect(recordedContext).toBe(result.ctxPayload);
+    expect(issuer).toBeDefined();
+    expect(
+      getBoundChannelInboundMemorySubjectIssuer(
+        result.ctxPayload as FinalizedMsgContext,
+        SESSION_KEY,
+      ),
+    ).toBeUndefined();
+    expect(recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({ ctx: result.ctxPayload, sessionKey: SESSION_KEY }),
+    );
+  });
+});

--- a/src/channels/inbound-event/core-ingress.ts
+++ b/src/channels/inbound-event/core-ingress.ts
@@ -1,0 +1,81 @@
+import {
+  dispatchChannelInboundTurnWithCoreIngress,
+  runChannelInboundEventWithCoreIngress,
+} from "../turn/kernel.js";
+/**
+ * Internal paired facade for trusted channel runtime ingress.
+ *
+ * This is intentionally not an SDK entrypoint: public context construction and
+ * public event runners stay unprivileged and therefore resolve an ambiguous subject.
+ */
+import {
+  buildChannelInboundEventContext,
+  type BuildChannelInboundEventContextParams,
+  type BuiltChannelInboundEventContext,
+  type ChannelInboundSupplementalResolutionOptions,
+} from "./context.js";
+import {
+  createCoreChannelInboundMemorySubjectIngress,
+  registerCoreChannelInboundMemorySubjectFacts,
+} from "./memory-subject-attestation.js";
+
+type MaybePromise<T> = T | Promise<T>;
+type CoreInboundContextParams = BuildChannelInboundEventContextParams &
+  Partial<ChannelInboundSupplementalResolutionOptions>;
+
+export type CoreChannelInboundEventFacade = Readonly<{
+  buildContext: typeof buildChannelInboundEventContext;
+  run: typeof import("../turn/kernel.js").runChannelInboundEvent;
+  dispatch: typeof import("../turn/kernel.js").dispatchChannelInboundTurn;
+}>;
+
+function isPromiseLike<T>(value: MaybePromise<T>): value is Promise<T> {
+  return typeof (value as Promise<T> | undefined)?.then === "function";
+}
+
+/**
+ * Captures structured adapter facts before `extra` can replace finalized fields, then pairs
+ * that exact built context with the matching core runner via an opaque ingress capability.
+ */
+export function createCoreChannelInboundEventFacade(params: {
+  ownsChannel: (channel: unknown) => boolean;
+}): CoreChannelInboundEventFacade {
+  const ingress = createCoreChannelInboundMemorySubjectIngress({
+    ownsChannel: params.ownsChannel,
+  });
+  const buildContext = ((
+    input: CoreInboundContextParams,
+  ): MaybePromise<BuiltChannelInboundEventContext> => {
+    const facts = {
+      agentId: input.route.agentId,
+      accountId: input.route.accountId ?? input.accountId,
+      channel: input.channel,
+      conversationId: input.conversation.id,
+      conversationKind: input.conversation.kind,
+      dmScope: input.route.dmScope,
+      nativeChannelId: input.conversation.nativeChannelId,
+      senderId: input.sender.id,
+      sessionKey: input.route.dispatchSessionKey ?? input.route.routeSessionKey,
+    };
+    const result = buildChannelInboundEventContext(
+      input as never,
+    ) as MaybePromise<BuiltChannelInboundEventContext>;
+    const register = (ctx: BuiltChannelInboundEventContext): BuiltChannelInboundEventContext => {
+      registerCoreChannelInboundMemorySubjectFacts(ctx, ingress, facts);
+      return ctx;
+    };
+    return isPromiseLike(result) ? result.then(register) : register(result);
+  }) as typeof buildChannelInboundEventContext;
+  const run = ((input: unknown) =>
+    runChannelInboundEventWithCoreIngress(
+      input as never,
+      ingress,
+    )) as CoreChannelInboundEventFacade["run"];
+  const dispatch = ((input: unknown) =>
+    dispatchChannelInboundTurnWithCoreIngress(
+      input as never,
+      ingress,
+    )) as CoreChannelInboundEventFacade["dispatch"];
+
+  return Object.freeze({ buildContext, run, dispatch });
+}

--- a/src/channels/inbound-event/memory-subject-attestation.ts
+++ b/src/channels/inbound-event/memory-subject-attestation.ts
@@ -1,0 +1,365 @@
+/**
+ * Core-owned attestation for the subject used to initialize an inbound channel session.
+ *
+ * Public SDK context/runner helpers remain deliberately unprivileged. Only the paired,
+ * per-plugin core facade holds an opaque ingress object that this module recognizes.
+ */
+import type { FinalizedMsgContext } from "../../auto-reply/templating.js";
+import type { TrustedSessionMemorySubjectIssuer } from "../../config/sessions/session-memory-subject.js";
+import type { DmScope } from "../../config/types.base.js";
+import { normalizeSessionKeyPreservingOpaquePeerIds } from "../../sessions/session-key-utils.js";
+
+export type ChannelInboundMemorySubjectFacts = Readonly<{
+  agentId: unknown;
+  accountId: unknown;
+  channel: unknown;
+  conversationId: unknown;
+  conversationKind: unknown;
+  dmScope: unknown;
+  nativeChannelId: unknown;
+  senderId: unknown;
+  sessionKey: unknown;
+}>;
+
+type CoreChannelInboundMemorySubjectIngressRecord = Readonly<{
+  ownsChannel: (channel: unknown) => boolean;
+}>;
+
+type RegisteredChannelInboundMemorySubjectFacts = Readonly<{
+  facts: ChannelInboundMemorySubjectFacts;
+  ingress: object;
+}>;
+
+type ChannelInboundMemorySubjectMarker = Readonly<{
+  facts: ChannelInboundMemorySubjectFacts;
+  ingress: object;
+}>;
+
+type BoundChannelInboundMemorySubjectIssuer = Readonly<{
+  finalChannel: string;
+  ingress: object;
+  issuer: TrustedSessionMemorySubjectIssuer;
+  sessionKey: string;
+}>;
+
+// Ingress authority is identity-only: serialization or a structural lookalike cannot recreate
+// the private WeakSet membership. The callback also rechecks live channel ownership at use time.
+const trustedIngresses = new WeakSet<object>();
+const ingressRecords = new WeakMap<object, CoreChannelInboundMemorySubjectIngressRecord>();
+const registeredFacts = new WeakMap<object, RegisteredChannelInboundMemorySubjectFacts>();
+const attestedMarkers = new WeakMap<object, ChannelInboundMemorySubjectMarker>();
+const boundIssuers = new WeakMap<object, BoundChannelInboundMemorySubjectIssuer>();
+
+function isNonEmptyText(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function normalizeRequiredText(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function normalizeChannel(value: unknown): string | undefined {
+  return normalizeRequiredText(value)?.toLowerCase();
+}
+
+function normalizeAccountId(value: unknown): string | undefined {
+  return normalizeRequiredText(value);
+}
+
+function normalizeAgentId(value: unknown): string | undefined {
+  return normalizeRequiredText(value);
+}
+
+function normalizeDmScope(value: unknown): DmScope | undefined {
+  const normalized = normalizeRequiredText(value)?.toLowerCase();
+  return normalized === "main" ||
+    normalized === "per-peer" ||
+    normalized === "per-channel-peer" ||
+    normalized === "per-account-channel-peer"
+    ? normalized
+    : undefined;
+}
+
+function normalizeBoundSessionKey(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.trim() !== value || !value) {
+    return undefined;
+  }
+  return normalizeSessionKeyPreservingOpaquePeerIds(value) || undefined;
+}
+
+function getTrustedIngressRecord(
+  ingress: unknown,
+): CoreChannelInboundMemorySubjectIngressRecord | undefined {
+  if (!ingress || typeof ingress !== "object" || !trustedIngresses.has(ingress)) {
+    return undefined;
+  }
+  return ingressRecords.get(ingress);
+}
+
+function hasLiveIngressChannel(ingress: unknown, channel: unknown): boolean {
+  const record = getTrustedIngressRecord(ingress);
+  return Boolean(record && normalizeChannel(channel) && record.ownsChannel(channel));
+}
+
+function createFacts(params: ChannelInboundMemorySubjectFacts): ChannelInboundMemorySubjectFacts {
+  return Object.freeze({ ...params });
+}
+
+/** Creates the non-SDK ingress capability held only by a core-injected paired facade. */
+export function createCoreChannelInboundMemorySubjectIngress(params: {
+  ownsChannel: (channel: unknown) => boolean;
+}): object {
+  const ingress = Object.freeze(Object.create(null)) as object;
+  trustedIngresses.add(ingress);
+  ingressRecords.set(
+    ingress,
+    Object.freeze({
+      ownsChannel: params.ownsChannel,
+    }),
+  );
+  return ingress;
+}
+
+/** Registers pre-extra structured facts only for a live, trusted core ingress facade. */
+export function registerCoreChannelInboundMemorySubjectFacts(
+  ctx: object,
+  ingress: unknown,
+  params: ChannelInboundMemorySubjectFacts,
+): void {
+  const record = getTrustedIngressRecord(ingress);
+  if (!record || !record.ownsChannel(params.channel)) {
+    return;
+  }
+  registeredFacts.set(
+    ctx,
+    Object.freeze({
+      facts: createFacts(params),
+      ingress,
+    }),
+  );
+}
+
+/** Marks an exact facade-built context only when its paired ingress runs the matching channel. */
+export function attestCoreChannelInboundMemorySubjectContext(params: {
+  ctx: object;
+  ingress: unknown;
+  runChannel: unknown;
+}): void {
+  const record = getTrustedIngressRecord(params.ingress);
+  const registered = registeredFacts.get(params.ctx);
+  if (
+    !record ||
+    !registered ||
+    registered.ingress !== params.ingress ||
+    !record.ownsChannel(params.runChannel) ||
+    !hasLiveIngressChannel(params.ingress, params.runChannel) ||
+    normalizeChannel(registered.facts.channel) !== normalizeChannel(params.runChannel)
+  ) {
+    // A public runner may see a previously facade-built object. Do not leave an
+    // old attestation available for its later bind step.
+    attestedMarkers.delete(params.ctx);
+    boundIssuers.delete(params.ctx);
+    registeredFacts.delete(params.ctx);
+    return;
+  }
+  attestedMarkers.set(
+    params.ctx,
+    Object.freeze({ facts: registered.facts, ingress: params.ingress as object }),
+  );
+}
+
+/**
+ * Only core assembly may transfer an already-attested marker to its finalized context clone.
+ * The builder registry and any session-bound issuer remain identity-bound to their original ctx.
+ */
+export function transferChannelInboundMemorySubjectMarker(source: object, target: object): void {
+  const marker = attestedMarkers.get(source);
+  if (marker) {
+    attestedMarkers.set(target, marker);
+    // A routed clone is the sole final context. Retaining the source marker
+    // would let a later public runner bind the same facade-built object.
+    attestedMarkers.delete(source);
+    registeredFacts.delete(source);
+  }
+}
+
+async function createIssuer(params: {
+  facts: ChannelInboundMemorySubjectFacts;
+  finalChannel: string;
+  ingress: object;
+}): Promise<TrustedSessionMemorySubjectIssuer> {
+  const {
+    createTrustedSessionMemorySubjectIssuer,
+    prepareAmbiguousSessionMemorySubjectSeed,
+    prepareChannelBindingSessionMemorySubjectSeed,
+    prepareConversationSessionMemorySubjectSeed,
+  } = await import("../../config/sessions/session-memory-subject.js");
+
+  let issued = false;
+  return createTrustedSessionMemorySubjectIssuer(() => {
+    // This runs only inside the writer transaction. Rechecking here closes the
+    // gap between facade attestation and a detached metadata write after unload.
+    if (issued || !hasLiveIngressChannel(params.ingress, params.finalChannel)) {
+      issued = true;
+      return prepareAmbiguousSessionMemorySubjectSeed("unbound");
+    }
+    issued = true;
+    const { facts } = params;
+    if (facts.conversationKind === "direct") {
+      if (facts.dmScope === "main") {
+        return prepareAmbiguousSessionMemorySubjectSeed("shared-main");
+      }
+      if (
+        !isNonEmptyText(facts.channel) ||
+        !isNonEmptyText(facts.accountId) ||
+        !isNonEmptyText(facts.senderId)
+      ) {
+        return prepareAmbiguousSessionMemorySubjectSeed("unbound");
+      }
+      return prepareChannelBindingSessionMemorySubjectSeed({
+        channel: facts.channel,
+        accountId: facts.accountId,
+        stableSenderId: facts.senderId,
+      });
+    }
+
+    if (facts.conversationKind === "group" || facts.conversationKind === "channel") {
+      const conversationId = facts.nativeChannelId ?? facts.conversationId;
+      if (
+        !isNonEmptyText(facts.channel) ||
+        !isNonEmptyText(facts.accountId) ||
+        !isNonEmptyText(conversationId)
+      ) {
+        return prepareAmbiguousSessionMemorySubjectSeed("unbound");
+      }
+      return prepareConversationSessionMemorySubjectSeed({
+        channel: facts.channel,
+        accountId: facts.accountId,
+        conversationId,
+      });
+    }
+
+    return prepareAmbiguousSessionMemorySubjectSeed("unbound");
+  });
+}
+
+function resolveFinalizedTargetFacts(params: {
+  ctx: FinalizedMsgContext;
+  facts: ChannelInboundMemorySubjectFacts;
+  sessionKey: string;
+}):
+  | { facts: ChannelInboundMemorySubjectFacts; finalChannel: string; sessionKey: string }
+  | undefined {
+  const { ctx, facts, sessionKey } = params;
+  const factsChannel = normalizeChannel(facts.channel);
+  const finalChannel = normalizeChannel(ctx.OriginatingChannel);
+  const factsAccountId = normalizeAccountId(facts.accountId);
+  const finalAccountId = normalizeAccountId(ctx.AccountId);
+  const factsAgentId = normalizeAgentId(facts.agentId);
+  const finalAgentId = normalizeAgentId(ctx.AgentId);
+  const factsSessionKey = normalizeBoundSessionKey(facts.sessionKey);
+  const contextSessionKey = normalizeBoundSessionKey(ctx.SessionKey);
+  const finalSessionKey = normalizeBoundSessionKey(sessionKey);
+  const factsDmScope = normalizeDmScope(facts.dmScope);
+  const finalDmScope = normalizeDmScope(ctx.DmScope);
+  if (
+    !factsChannel ||
+    !finalChannel ||
+    factsChannel !== finalChannel ||
+    factsAccountId !== finalAccountId ||
+    !factsAgentId ||
+    !finalAgentId ||
+    factsAgentId !== finalAgentId ||
+    !factsSessionKey ||
+    !contextSessionKey ||
+    !finalSessionKey ||
+    factsSessionKey !== contextSessionKey ||
+    factsSessionKey !== finalSessionKey ||
+    (facts.accountId !== undefined && !factsAccountId) ||
+    (ctx.AccountId !== undefined && !finalAccountId) ||
+    (facts.dmScope !== undefined && !factsDmScope) ||
+    (ctx.DmScope !== undefined && !finalDmScope)
+  ) {
+    return undefined;
+  }
+  const sharedMain = factsDmScope === "main" || finalDmScope === "main";
+  if (!sharedMain && factsDmScope !== finalDmScope) {
+    return undefined;
+  }
+  return {
+    facts: createFacts({
+      ...facts,
+      agentId: factsAgentId,
+      accountId: factsAccountId,
+      channel: factsChannel,
+      dmScope: sharedMain ? "main" : factsDmScope,
+      sessionKey: factsSessionKey,
+    }),
+    finalChannel,
+    sessionKey: finalSessionKey,
+  };
+}
+
+/** Binds an attested marker to the exact final metadata key selected by the core turn. */
+export async function bindAttestedChannelInboundMemorySubject(
+  ctx: FinalizedMsgContext,
+  sessionKey: string,
+): Promise<void> {
+  const marker = attestedMarkers.get(ctx);
+  if (!marker || boundIssuers.has(ctx)) {
+    return;
+  }
+  // Consume the ephemeral marker before the dynamic import below. A public
+  // runner cannot turn a facade-built context into authority while it awaits.
+  attestedMarkers.delete(ctx);
+  registeredFacts.delete(ctx);
+  const target = resolveFinalizedTargetFacts({ ctx, facts: marker.facts, sessionKey });
+  if (!target || !hasLiveIngressChannel(marker.ingress, target.finalChannel)) {
+    return;
+  }
+  const issuer = await createIssuer({
+    facts: target.facts,
+    finalChannel: target.finalChannel,
+    ingress: marker.ingress,
+  });
+  if (!hasLiveIngressChannel(marker.ingress, target.finalChannel)) {
+    return;
+  }
+  boundIssuers.set(
+    ctx,
+    Object.freeze({
+      finalChannel: target.finalChannel,
+      ingress: marker.ingress,
+      issuer,
+      sessionKey: target.sessionKey,
+    }),
+  );
+}
+
+/** Returns an issuer only for the exact context identity and canonical record key. */
+export function getBoundChannelInboundMemorySubjectIssuer(
+  ctx: FinalizedMsgContext,
+  sessionKey: string,
+): TrustedSessionMemorySubjectIssuer | undefined {
+  const bound = boundIssuers.get(ctx);
+  const normalizedSessionKey = normalizeBoundSessionKey(sessionKey);
+  if (
+    !bound ||
+    !normalizedSessionKey ||
+    bound.sessionKey !== normalizedSessionKey ||
+    !hasLiveIngressChannel(bound.ingress, bound.finalChannel)
+  ) {
+    if (bound) {
+      boundIssuers.delete(ctx);
+    }
+    return undefined;
+  }
+  return bound.issuer;
+}
+
+/** Clears the exact-turn capability after dispatch, including no-record terminal paths. */
+export function clearBoundChannelInboundMemorySubject(ctx: object): void {
+  boundIssuers.delete(ctx);
+  attestedMarkers.delete(ctx);
+  registeredFacts.delete(ctx);
+}

--- a/src/channels/session.ts
+++ b/src/channels/session.ts
@@ -4,6 +4,7 @@ import type { MsgContext } from "../auto-reply/templating.js";
 import type { GroupKeyResolution } from "../config/sessions/types.js";
 import { normalizeSessionKeyPreservingOpaquePeerIds } from "../sessions/session-key-utils.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
+import { getBoundChannelInboundMemorySubjectIssuer } from "./inbound-event/memory-subject-attestation.js";
 import type { InboundLastRouteUpdate } from "./session.types.js";
 
 // Keep session persistence lazy so channel SDK type paths do not load disk writers.
@@ -40,21 +41,32 @@ export async function recordInboundSession(params: {
   const { storePath, sessionKey, ctx, groupResolution, createIfMissing } = params;
   const canonicalSessionKey = normalizeSessionKeyPreservingOpaquePeerIds(sessionKey);
   const runtime = await loadInboundSessionRuntime();
-  const metaTask = runtime
-    .recordInboundSessionMeta({
-      storePath,
-      sessionKey: canonicalSessionKey,
-      ctx,
-      groupResolution,
-      createIfMissing,
-    })
-    .catch(async (err: unknown) => {
-      try {
-        await Promise.resolve(params.onRecordError(err));
-      } catch {
-        // Error reporting must not reject the detached metadata task.
-      }
-    });
+  const memorySubjectIssuer = getBoundChannelInboundMemorySubjectIssuer(ctx, canonicalSessionKey);
+  const metadataTask = memorySubjectIssuer
+    ? runtime.recordInboundSessionMetaWithTrustedMemorySubject(
+        {
+          storePath,
+          sessionKey: canonicalSessionKey,
+          ctx,
+          groupResolution,
+          createIfMissing,
+        },
+        memorySubjectIssuer,
+      )
+    : runtime.recordInboundSessionMeta({
+        storePath,
+        sessionKey: canonicalSessionKey,
+        ctx,
+        groupResolution,
+        createIfMissing,
+      });
+  const metaTask = metadataTask.catch(async (err: unknown) => {
+    try {
+      await Promise.resolve(params.onRecordError(err));
+    } catch {
+      // Error reporting must not reject the detached metadata task.
+    }
+  });
   params.trackSessionMetaTask?.(metaTask);
   void metaTask;
 

--- a/src/channels/turn/execution.ts
+++ b/src/channels/turn/execution.ts
@@ -13,6 +13,7 @@ import {
   type ChannelTurnDispatchResultLike,
   type ChannelTurnVisibleDeliverySignals,
 } from "./dispatch-result.js";
+import { resolveRecordSessionKey } from "./record-session-key.js";
 import type {
   ChannelTurnAdmission,
   ChannelTurnHistoryFinalizeOptions,
@@ -62,23 +63,6 @@ function isSystemChannelTurn(ctx: FinalizedMsgContext): boolean {
   return (
     ctx.Provider === "heartbeat" || ctx.Provider === "cron-event" || ctx.Provider === "exec-event"
   );
-}
-
-function resolveRecordSessionKey<TDispatchResult>(
-  params: PreparedChannelTurn<TDispatchResult>,
-): string {
-  const explicitSessionKey = params.record?.sessionKey;
-  if (explicitSessionKey === undefined) {
-    return params.ctxPayload.SessionKey ?? params.routeSessionKey;
-  }
-  const normalizedSessionKey = explicitSessionKey.trim();
-  if (!normalizedSessionKey) {
-    throw new Error("Channel turn record.sessionKey must be non-empty.");
-  }
-  if (normalizedSessionKey !== explicitSessionKey) {
-    throw new Error("Channel turn record.sessionKey must not include surrounding whitespace.");
-  }
-  return explicitSessionKey;
 }
 
 function maybeWarnZeroCountVisibleDispatch<TDispatchResult>(

--- a/src/channels/turn/kernel.ts
+++ b/src/channels/turn/kernel.ts
@@ -1,11 +1,18 @@
 import { recordChannelHistoryEntryWithMedia } from "../../auto-reply/reply/history.js";
 import { toHistoryMediaEntries } from "../inbound-event/media.js";
 import {
+  attestCoreChannelInboundMemorySubjectContext,
+  bindAttestedChannelInboundMemorySubject,
+  clearBoundChannelInboundMemorySubject,
+} from "../inbound-event/memory-subject-attestation.js";
+import {
   assembleResolvedChannelTurn,
   dispatchAssembledChannelTurn as dispatchAssembledChannelTurnImpl,
+  dispatchAssembledRoutedChannelTurn as dispatchAssembledRoutedChannelTurnImpl,
   dispatchRoutedChannelTurn as dispatchRoutedChannelTurnImpl,
   runPreparedInboundReply as runPreparedInboundReplyImpl,
 } from "./lifecycle.js";
+import { resolveRecordSessionKey } from "./record-session-key.js";
 
 export { recordChannelBotPairLoopAndCheckSuppression } from "./bot-loop-protection.js";
 
@@ -59,6 +66,38 @@ export function dispatchChannelInboundTurn(
   plan: ChannelTurnPlan<ChannelTurnDeliveryAdapter>,
 ): Promise<ChannelTurnResult> {
   return dispatchRoutedChannelTurnImpl(plan);
+}
+
+/**
+ * Internal-only paired dispatch entrypoint for a facade-built context.
+ *
+ * Direct `dispatch` users arrive after adapter resolution, so they bypass the
+ * raw-event runner that normally attests, assembles, and binds the issuer.
+ * Keep that lifecycle here rather than granting authority to public dispatch.
+ */
+export async function dispatchChannelInboundTurnWithCoreIngress(
+  plan: ChannelTurnPlan<ChannelTurnDeliveryAdapter>,
+  coreIngress: object,
+): Promise<ChannelTurnResult> {
+  attestCoreChannelInboundMemorySubjectContext({
+    ctx: plan.ctxPayload,
+    ingress: coreIngress,
+    runChannel: plan.channel,
+  });
+  const assembled = assembleResolvedChannelTurn(plan);
+  try {
+    await bindAttestedChannelInboundMemorySubject(
+      assembled.ctxPayload,
+      resolveRecordSessionKey(assembled),
+    );
+    return await dispatchAssembledRoutedChannelTurnImpl(
+      assembled as Parameters<typeof dispatchAssembledRoutedChannelTurnImpl>[0],
+    );
+  } finally {
+    // An exact context/issuer pair is single-turn authority even when dispatch
+    // exits before session recording. Never leave it reusable by a later call.
+    clearBoundChannelInboundMemorySubject(assembled.ctxPayload);
+  }
 }
 
 export const runPreparedInboundReply = runPreparedInboundReplyImpl;
@@ -202,6 +241,14 @@ async function runChannelTurn<
   TDispatchResult = DispatchedChannelTurnResult["dispatchResult"],
 >(
   params: RunChannelTurnParams<TRaw, TDispatchResult, ChannelTurnDeliveryAdapter>,
+  coreIngress?: object,
+): Promise<ChannelTurnResult<TDispatchResult>>;
+async function runChannelTurn<
+  TRaw,
+  TDispatchResult = DispatchedChannelTurnResult["dispatchResult"],
+>(
+  params: RunChannelTurnParams<TRaw, TDispatchResult, ChannelTurnDeliveryAdapter>,
+  coreIngress?: object,
 ): Promise<ChannelTurnResult<TDispatchResult>> {
   emit({
     ...params,
@@ -271,111 +318,178 @@ async function runChannelTurn<
   }
 
   const unresolved = await params.adapter.resolveTurn(input, eventClass, preflight);
+  // Public runner calls have no ingress token. A core-injected paired facade must provide the
+  // exact opaque capability that registered this context before any facts become authority.
+  attestCoreChannelInboundMemorySubjectContext({
+    ctx: unresolved.ctxPayload,
+    ingress: coreIngress,
+    runChannel: params.channel,
+  });
   const isRoutedTurn = "route" in unresolved && !("runDispatch" in unresolved);
   const resolved = assembleResolvedChannelTurn(unresolved);
-  emit({
-    ...params,
-    accountId: resolved.accountId ?? params.accountId,
-    event: {
-      stage: "assemble",
-      event: "done",
-      messageId: input.id,
-      sessionKey: resolved.routeSessionKey,
-      admission: resolved.admission?.kind ?? "dispatch",
-    },
-  });
-
-  const admission = resolved.admission ?? preflightAdmission ?? ({ kind: "dispatch" } as const);
-  let result: ChannelTurnResult<TDispatchResult>;
   try {
-    if ("runDispatch" in resolved) {
-      assertPreparedDispatchLifecycle(resolved, params.turnAdoptionLifecycle);
-    }
-    const dispatchResult = (
-      "runDispatch" in resolved
-        ? await runPreparedInboundReply({
-            ...resolved,
-            admission,
-            log: params.log,
-            messageId: input.id,
-          })
-        : isRoutedTurn
-          ? await dispatchRoutedChannelTurnImpl({
-              ...(unresolved as ChannelTurnPlan<ChannelTurnDeliveryAdapter>),
-              admission,
-              log: params.log,
-              messageId: input.id,
-              ...(params.turnAdoptionLifecycle
-                ? { turnAdoptionLifecycle: params.turnAdoptionLifecycle }
-                : {}),
-            })
-          : await dispatchAssembledChannelTurn({
-              ...(resolved as AssembledChannelTurn),
-              admission,
-              log: params.log,
-              messageId: input.id,
-              ...(params.turnAdoptionLifecycle
-                ? { turnAdoptionLifecycle: params.turnAdoptionLifecycle }
-                : {}),
-            })
-    ) as ChannelTurnResult<TDispatchResult>;
-    result = dispatchResult.dispatched ? { ...dispatchResult, admission } : dispatchResult;
-  } catch (err) {
-    const failedResult: ChannelTurnResult<TDispatchResult> = {
-      admission,
-      dispatched: false,
-      ctxPayload: resolved.ctxPayload,
-      routeSessionKey: resolved.routeSessionKey,
-    };
+    await bindAttestedChannelInboundMemorySubject(
+      resolved.ctxPayload,
+      resolveRecordSessionKey(resolved),
+    );
+    emit({
+      ...params,
+      accountId: resolved.accountId ?? params.accountId,
+      event: {
+        stage: "assemble",
+        event: "done",
+        messageId: input.id,
+        sessionKey: resolved.routeSessionKey,
+        admission: resolved.admission?.kind ?? "dispatch",
+      },
+    });
+
+    const admission = resolved.admission ?? preflightAdmission ?? ({ kind: "dispatch" } as const);
+    let result: ChannelTurnResult<TDispatchResult>;
     try {
-      await params.adapter.onFinalize?.(failedResult);
-    } catch {
-      // Preserve the original dispatch error.
+      if ("runDispatch" in resolved) {
+        assertPreparedDispatchLifecycle(resolved, params.turnAdoptionLifecycle);
+      }
+      const dispatchResult = (
+        "runDispatch" in resolved
+          ? await runPreparedInboundReply({
+              ...resolved,
+              admission,
+              log: params.log,
+              messageId: input.id,
+            })
+          : isRoutedTurn
+            ? await dispatchAssembledRoutedChannelTurnImpl({
+                ...(resolved as Parameters<typeof dispatchAssembledRoutedChannelTurnImpl>[0]),
+                admission,
+                log: params.log,
+                messageId: input.id,
+                ...(params.turnAdoptionLifecycle
+                  ? { turnAdoptionLifecycle: params.turnAdoptionLifecycle }
+                  : {}),
+              })
+            : await dispatchAssembledChannelTurn({
+                ...(resolved as AssembledChannelTurn),
+                admission,
+                log: params.log,
+                messageId: input.id,
+                ...(params.turnAdoptionLifecycle
+                  ? { turnAdoptionLifecycle: params.turnAdoptionLifecycle }
+                  : {}),
+              })
+      ) as ChannelTurnResult<TDispatchResult>;
+      result = dispatchResult.dispatched ? { ...dispatchResult, admission } : dispatchResult;
+    } catch (err) {
+      const failedResult: ChannelTurnResult<TDispatchResult> = {
+        admission,
+        dispatched: false,
+        ctxPayload: resolved.ctxPayload,
+        routeSessionKey: resolved.routeSessionKey,
+      };
+      try {
+        await params.adapter.onFinalize?.(failedResult);
+      } catch {
+        // Preserve the original dispatch error.
+      }
+      emit({
+        ...params,
+        accountId: resolved.accountId ?? params.accountId,
+        event: {
+          stage: "finalize",
+          event: "done",
+          messageId: input.id,
+          sessionKey: resolved.routeSessionKey,
+          admission: admission.kind,
+        },
+      });
+      throw err;
     }
-    emit({
-      ...params,
-      accountId: resolved.accountId ?? params.accountId,
-      event: {
-        stage: "finalize",
-        event: "done",
-        messageId: input.id,
-        sessionKey: resolved.routeSessionKey,
-        admission: admission.kind,
-      },
-    });
-    throw err;
-  }
 
-  try {
-    await params.adapter.onFinalize?.(result);
-    emit({
-      ...params,
-      accountId: resolved.accountId ?? params.accountId,
-      event: {
-        stage: "finalize",
-        event: "done",
-        messageId: input.id,
-        sessionKey: resolved.routeSessionKey,
-        admission: admission.kind,
-      },
-    });
-  } catch (err) {
-    emit({
-      ...params,
-      accountId: resolved.accountId ?? params.accountId,
-      event: {
-        stage: "finalize",
-        event: "error",
-        messageId: input.id,
-        sessionKey: resolved.routeSessionKey,
-        admission: admission.kind,
-        error: err,
-      },
-    });
-    throw err;
-  }
+    try {
+      await params.adapter.onFinalize?.(result);
+      emit({
+        ...params,
+        accountId: resolved.accountId ?? params.accountId,
+        event: {
+          stage: "finalize",
+          event: "done",
+          messageId: input.id,
+          sessionKey: resolved.routeSessionKey,
+          admission: admission.kind,
+        },
+      });
+    } catch (err) {
+      emit({
+        ...params,
+        accountId: resolved.accountId ?? params.accountId,
+        event: {
+          stage: "finalize",
+          event: "error",
+          messageId: input.id,
+          sessionKey: resolved.routeSessionKey,
+          admission: admission.kind,
+          error: err,
+        },
+      });
+      throw err;
+    }
 
-  return result;
+    return result;
+  } finally {
+    // A bound issuer is exact-turn authority. Clear it even when dispatch
+    // short-circuits before session recording, so a context cannot be replayed.
+    clearBoundChannelInboundMemorySubject(resolved.ctxPayload);
+  }
 }
 
-export const runChannelInboundEvent = runChannelTurn;
+export function runChannelInboundEvent<
+  TRaw,
+  TDispatchResult = DispatchedChannelTurnResult["dispatchResult"],
+>(
+  params: RunChannelTurnParams<
+    TRaw,
+    TDispatchResult,
+    ChannelProviderOwnedMessageSendingDeliveryAdapter
+  >,
+): Promise<ChannelTurnResult<TDispatchResult>>;
+export function runChannelInboundEvent<
+  TRaw,
+  TDispatchResult = DispatchedChannelTurnResult["dispatchResult"],
+>(params: RunChannelTurnParams<TRaw, TDispatchResult>): Promise<ChannelTurnResult<TDispatchResult>>;
+export function runChannelInboundEvent<
+  TRaw,
+  TDispatchResult = DispatchedChannelTurnResult["dispatchResult"],
+>(
+  params: RunChannelTurnParams<TRaw, TDispatchResult, ChannelTurnDeliveryAdapter>,
+): Promise<ChannelTurnResult<TDispatchResult>> {
+  return runChannelTurn(params);
+}
+
+/** Internal-only entrypoint used by the trusted paired runtime facade. */
+export function runChannelInboundEventWithCoreIngress<
+  TRaw,
+  TDispatchResult = DispatchedChannelTurnResult["dispatchResult"],
+>(
+  params: RunChannelTurnParams<
+    TRaw,
+    TDispatchResult,
+    ChannelProviderOwnedMessageSendingDeliveryAdapter
+  >,
+  coreIngress: object,
+): Promise<ChannelTurnResult<TDispatchResult>>;
+export function runChannelInboundEventWithCoreIngress<
+  TRaw,
+  TDispatchResult = DispatchedChannelTurnResult["dispatchResult"],
+>(
+  params: RunChannelTurnParams<TRaw, TDispatchResult>,
+  coreIngress: object,
+): Promise<ChannelTurnResult<TDispatchResult>>;
+export function runChannelInboundEventWithCoreIngress<
+  TRaw,
+  TDispatchResult = DispatchedChannelTurnResult["dispatchResult"],
+>(
+  params: RunChannelTurnParams<TRaw, TDispatchResult, ChannelTurnDeliveryAdapter>,
+  coreIngress: object,
+): Promise<ChannelTurnResult<TDispatchResult>> {
+  return runChannelTurn(params, coreIngress);
+}

--- a/src/channels/turn/lifecycle.ts
+++ b/src/channels/turn/lifecycle.ts
@@ -15,6 +15,7 @@ import { isPlatformMessageNotDispatchedError } from "../../infra/outbound/delive
 import { createMessageSentEmitter } from "../../infra/outbound/message-sent-hook.js";
 import { summarizeOutboundPayloadForTransport } from "../../infra/outbound/payloads.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { transferChannelInboundMemorySubjectMarker } from "../inbound-event/memory-subject-attestation.js";
 import { resolveMessageReceiptPrimaryId } from "../message/receipt.js";
 import { createChannelReplyPipeline } from "../message/reply-pipeline.js";
 import { recordInboundSession } from "../session.js";
@@ -55,6 +56,24 @@ type PendingChannelDeliveryAttempt = {
   error?: unknown;
 };
 
+function applyRouteContext<T extends AssembledChannelTurn["ctxPayload"]>(
+  ctxPayload: T,
+  route: { agentId: string; dmScope: string | undefined },
+): T {
+  if (!route.dmScope && ctxPayload.AgentId === route.agentId) {
+    return ctxPayload;
+  }
+  // The routed agent owns the store path. Keep the final context aligned so
+  // attested first-write authority cannot cross an agent boundary in transit.
+  const routedContext = {
+    ...ctxPayload,
+    ...(route.dmScope ? { DmScope: route.dmScope } : {}),
+    AgentId: route.agentId,
+  } as T;
+  transferChannelInboundMemorySubjectMarker(ctxPayload, routedContext);
+  return routedContext;
+}
+
 function resolvePartialChannelDeliveryResult(
   error: unknown,
 ): (ChannelDeliveryOutcome & { visibleReplySent: true }) | undefined {
@@ -74,7 +93,7 @@ export function assembleResolvedChannelTurn<
     const { cfg, route, ...turn } = value;
     return {
       ...turn,
-      ctxPayload: route.dmScope ? { ...turn.ctxPayload, DmScope: route.dmScope } : turn.ctxPayload,
+      ctxPayload: applyRouteContext(turn.ctxPayload, route),
       routeSessionKey: route.sessionKey,
       storePath: resolveStorePath(cfg.session?.store, { agentId: route.agentId }),
       recordInboundSession,
@@ -83,7 +102,7 @@ export function assembleResolvedChannelTurn<
   const { cfg, route, ...turn } = value;
   const assembled: RoutedAssembledChannelTurn = {
     ...turn,
-    ctxPayload: route.dmScope ? { ...turn.ctxPayload, DmScope: route.dmScope } : turn.ctxPayload,
+    ctxPayload: applyRouteContext(turn.ctxPayload, route),
     cfg,
     agentId: route.agentId,
     routeSessionKey: route.sessionKey,
@@ -647,6 +666,13 @@ export async function dispatchAssembledChannelTurn(
   params: AssembledChannelTurn,
 ): Promise<ChannelTurnResult> {
   return await dispatchChannelTurnWithDeliveryOwner(params, "legacy-dispatcher");
+}
+
+/** Keeps the exact assembled context that the kernel attested through routed dispatch. */
+export async function dispatchAssembledRoutedChannelTurn(
+  params: RoutedAssembledChannelTurn,
+): Promise<ChannelTurnResult> {
+  return await dispatchChannelTurnWithDeliveryOwner(params, "routed-delivery");
 }
 
 export async function dispatchRoutedChannelTurn(

--- a/src/channels/turn/record-session-key.ts
+++ b/src/channels/turn/record-session-key.ts
@@ -1,0 +1,24 @@
+import type { FinalizedMsgContext } from "../../auto-reply/templating.js";
+import type { ChannelTurnRecordOptions } from "./types.js";
+
+type RecordableChannelTurn = {
+  ctxPayload: FinalizedMsgContext;
+  record?: ChannelTurnRecordOptions;
+  routeSessionKey: string;
+};
+
+/** Resolves the one key used for both session metadata and transcript context. */
+export function resolveRecordSessionKey(params: RecordableChannelTurn): string {
+  const explicitSessionKey = params.record?.sessionKey;
+  if (explicitSessionKey === undefined) {
+    return params.ctxPayload.SessionKey ?? params.routeSessionKey;
+  }
+  const normalizedSessionKey = explicitSessionKey.trim();
+  if (!normalizedSessionKey) {
+    throw new Error("Channel turn record.sessionKey must be non-empty.");
+  }
+  if (normalizedSessionKey !== explicitSessionKey) {
+    throw new Error("Channel turn record.sessionKey must not include surrounding whitespace.");
+  }
+  return explicitSessionKey;
+}

--- a/src/config/sessions/session-memory-access-context.test.ts
+++ b/src/config/sessions/session-memory-access-context.test.ts
@@ -1,0 +1,463 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { createMemoryIdentityBindingThroughApprovedPairing } from "../../pairing/memory-identity-approval.test-support.js";
+import { memoryIdentityLifecycle } from "../../state/memory-identity.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { replaceSessionEntrySync, upsertSessionEntry } from "./session-accessor.js";
+import {
+  createTrustedSessionMemoryAccessContext,
+  isTrustedSessionMemoryAccessContext,
+  readTrustedSessionMemoryAccessContext,
+} from "./session-memory-access-context.js";
+import {
+  isTrustedMemoryAccessHostFacts,
+  issueTrustedMemoryAccessHostFactsFromCore,
+  type TrustedMemoryAccessHostFacts,
+} from "./session-memory-access-host-facts.js";
+import { readCurrentSessionMemorySubjectAuthority } from "./session-memory-subject-access.js";
+import * as sessionMemorySubjectAccessModule from "./session-memory-subject-access.js";
+import {
+  prepareChannelBindingSessionMemorySubjectSeed,
+  prepareExplicitSessionMemorySubjectSeed,
+  prepareConversationSessionMemorySubjectSeed,
+} from "./session-memory-subject.js";
+
+const tempDirectories = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+function createPaths() {
+  const directory = tempDirectories.make("openclaw-session-memory-context-");
+  return {
+    stateOptions: { path: path.join(directory, "state.sqlite") },
+    storePath: path.join(directory, "sessions.json"),
+  };
+}
+
+async function createServiceSession(options: { expiresAt?: number; now?: number } = {}) {
+  const { stateOptions, storePath } = createPaths();
+  const scope = { agentId: "main", sessionKey: "agent:main:service:context", storePath };
+  const now = options.now ?? 100;
+  const seed = prepareExplicitSessionMemorySubjectSeed({
+    kind: "service",
+    stableSubjectId: "memory-context-service",
+    now,
+    ...(options.expiresAt === undefined ? {} : { expiresAt: options.expiresAt }),
+    options: stateOptions,
+  });
+  await upsertSessionEntry(
+    scope,
+    { sessionId: "memory-context-session", updatedAt: now },
+    { memorySubjectSeed: seed },
+  );
+  const authority = readCurrentSessionMemorySubjectAuthority(scope, stateOptions, now + 1);
+  if (
+    !authority ||
+    authority.authority.kind !== "current" ||
+    !authority.authority.currentPrincipalId
+  ) {
+    throw new Error("expected current service authority");
+  }
+  return { authority: authority.authority, scope, stateOptions };
+}
+
+async function createChannelBoundSession() {
+  const { storePath } = createPaths();
+  const stateOptions = {
+    env: { ...process.env, OPENCLAW_STATE_DIR: path.dirname(storePath) },
+  };
+  const principal = memoryIdentityLifecycle.ensureEnterpriseMemoryPrincipal({
+    issuer: "session-memory-access-context-test",
+    stableSubjectId: "binding-race-user",
+    now: 100,
+    options: stateOptions,
+  });
+  const binding = await createMemoryIdentityBindingThroughApprovedPairing({
+    channel: "telegram",
+    accountId: "default",
+    stableSenderId: "binding-race-user",
+    principalId: principal.principalId,
+    now: 100,
+    options: stateOptions,
+  });
+  const scope = { agentId: "main", sessionKey: "agent:main:binding-race", storePath };
+  await upsertSessionEntry(
+    scope,
+    { sessionId: "binding-race-session", updatedAt: 101 },
+    {
+      memorySubjectSeed: prepareChannelBindingSessionMemorySubjectSeed({
+        channel: "telegram",
+        accountId: "default",
+        stableSenderId: "binding-race-user",
+        now: 101,
+        options: stateOptions,
+      }),
+    },
+  );
+  const authority = readCurrentSessionMemorySubjectAuthority(scope, stateOptions, 102);
+  if (
+    !authority ||
+    authority.authority.kind !== "current" ||
+    !authority.authority.currentPrincipalId ||
+    !authority.authority.assurance ||
+    !authority.authority.evidenceRevision
+  ) {
+    throw new Error("expected current channel-bound authority");
+  }
+  return { authority: authority.authority, binding, scope, stateOptions };
+}
+
+function createHostFacts(
+  params: Pick<Awaited<ReturnType<typeof createServiceSession>>, "authority" | "scope">,
+  extra: Record<string, unknown> = {},
+) {
+  const expiresAt = params.authority.expiresAt;
+  return {
+    contextId: "context-1",
+    requestId: "request-1",
+    runId: "run-1",
+    agentId: "main",
+    sessionKey: params.scope.sessionKey,
+    actor: {
+      kind: "principal",
+      actorKind: "service",
+      principalId: params.authority.currentPrincipalId,
+      assurance: "service",
+      evidenceRevision: params.authority.evidenceRevision,
+      ...(expiresAt === undefined ? {} : { expiresAt: new Date(expiresAt).toISOString() }),
+    },
+    verifiedPrincipals: [
+      {
+        principalId: params.authority.currentPrincipalId,
+        assurance: "service",
+        evidenceRevision: params.authority.evidenceRevision,
+        ...(expiresAt === undefined ? {} : { expiresAt: new Date(expiresAt).toISOString() }),
+      },
+    ],
+    delivery: {
+      sinkKind: "internal",
+      audiences: [{ kind: "agent", id: "main" }],
+      egressCapabilityIds: ["memory-egress"],
+      egressRegistryRevision: "egress-r1",
+      deliveryRevision: "delivery-r1",
+    },
+    collaboration: { kind: "not-applicable" },
+    verifiedMemberships: [],
+    operation: "read",
+    hostFactsRevision: "host-facts-r1",
+    ...extra,
+  };
+}
+
+describe("session memory access context", () => {
+  it("binds frozen host facts to the current persisted subject and hides the DTO behind an opaque handle", async () => {
+    const params = await createServiceSession();
+    const hostFacts = issueTrustedMemoryAccessHostFactsFromCore({
+      facts: createHostFacts(params),
+      scope: params.scope,
+      stateOptions: params.stateOptions,
+    });
+
+    const result = createTrustedSessionMemoryAccessContext({ hostFacts });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(isTrustedSessionMemoryAccessContext(result.value)).toBe(true);
+    expect(Object.isFrozen(result.value)).toBe(true);
+    expect(result.value.contextFingerprint).toMatch(/^sha256:[a-f0-9]{64}$/u);
+    expect(JSON.stringify(result.value)).not.toContain(params.authority.currentPrincipalId);
+    expect(isTrustedSessionMemoryAccessContext({ ...result.value })).toBe(false);
+    expect(readTrustedSessionMemoryAccessContext(result.value)).toMatchObject({
+      sessionId: "memory-context-session",
+      subject: { kind: "service", principalId: params.authority.currentPrincipalId },
+      subjectRevision: expect.any(String),
+    });
+  });
+
+  it("accepts only an opaque core-issued host-facts handle", async () => {
+    const params = await createServiceSession();
+    const callerAssembledFacts = createHostFacts(params);
+    const modelAuthoredJson = JSON.parse(JSON.stringify(callerAssembledFacts)) as unknown;
+    const pluginExtras = {
+      ...callerAssembledFacts,
+      extra: {
+        identityLinks: [{ principalId: params.authority.currentPrincipalId }],
+        memoryAccess: callerAssembledFacts,
+      },
+    };
+
+    for (const candidate of [callerAssembledFacts, modelAuthoredJson, pluginExtras]) {
+      expect(isTrustedMemoryAccessHostFacts(candidate)).toBe(false);
+      expect(
+        createTrustedSessionMemoryAccessContext({
+          hostFacts: candidate as TrustedMemoryAccessHostFacts,
+        }),
+      ).toEqual({ ok: false, error: "invalid-context" });
+    }
+
+    const coreIssued = issueTrustedMemoryAccessHostFactsFromCore({
+      facts: callerAssembledFacts,
+      scope: params.scope,
+      stateOptions: params.stateOptions,
+    });
+    expect(isTrustedMemoryAccessHostFacts(coreIssued)).toBe(true);
+    expect(createTrustedSessionMemoryAccessContext({ hostFacts: coreIssued })).toMatchObject({
+      ok: true,
+    });
+  });
+
+  it("uses the host clock even when untyped callers attach a backdated now", async () => {
+    const beforeExpiry = 1_000;
+    const expiresAt = 2_000;
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(beforeExpiry);
+    const params = await createServiceSession({ now: beforeExpiry, expiresAt });
+    const hostFacts = issueTrustedMemoryAccessHostFactsFromCore({
+      facts: createHostFacts(params),
+      scope: params.scope,
+      stateOptions: params.stateOptions,
+    });
+
+    expect(createTrustedSessionMemoryAccessContext({ hostFacts })).toMatchObject({ ok: true });
+
+    dateNow.mockReturnValue(expiresAt + 1);
+    const backdatedHostFactsParams = {
+      facts: createHostFacts(params),
+      scope: params.scope,
+      stateOptions: params.stateOptions,
+      now: beforeExpiry,
+    } as unknown as Parameters<typeof issueTrustedMemoryAccessHostFactsFromCore>[0];
+    expect(() => issueTrustedMemoryAccessHostFactsFromCore(backdatedHostFactsParams)).toThrow(
+      "identity-revoked",
+    );
+    const backdatedContextParams = {
+      hostFacts,
+      now: beforeExpiry,
+    } as unknown as Parameters<typeof createTrustedSessionMemoryAccessContext>[0];
+    expect(createTrustedSessionMemoryAccessContext(backdatedContextParams)).toEqual({
+      ok: false,
+      error: "identity-revoked",
+    });
+  });
+
+  it("normalizes unordered facts into a stable fingerprint and rejects copied or extra host facts", async () => {
+    const params = await createServiceSession();
+    const base = createHostFacts(params, {
+      verifiedPrincipals: [
+        ...createHostFacts(params).verifiedPrincipals,
+        {
+          principalId: "other-principal",
+          assurance: "service",
+          evidenceRevision: "other-evidence",
+        },
+      ],
+      delivery: {
+        ...createHostFacts(params).delivery,
+        audiences: [
+          { kind: "internal", id: "memory" },
+          { kind: "agent", id: "main" },
+        ],
+        egressCapabilityIds: ["z-cap", "a-cap"],
+      },
+    });
+    const reordered = {
+      ...base,
+      verifiedPrincipals: [...base.verifiedPrincipals].toReversed(),
+      delivery: {
+        ...base.delivery,
+        audiences: [...base.delivery.audiences].toReversed(),
+        egressCapabilityIds: [...base.delivery.egressCapabilityIds].toReversed(),
+      },
+    };
+    const first = issueTrustedMemoryAccessHostFactsFromCore({
+      facts: base,
+      scope: params.scope,
+      stateOptions: params.stateOptions,
+    });
+    const second = issueTrustedMemoryAccessHostFactsFromCore({
+      facts: reordered,
+      scope: params.scope,
+      stateOptions: params.stateOptions,
+    });
+    const firstContext = createTrustedSessionMemoryAccessContext({ hostFacts: first });
+    const secondContext = createTrustedSessionMemoryAccessContext({ hostFacts: second });
+
+    expect(firstContext).toMatchObject({ ok: true });
+    expect(secondContext).toMatchObject({ ok: true });
+    if (!firstContext.ok || !secondContext.ok) {
+      return;
+    }
+    expect(secondContext.value.contextFingerprint).toBe(firstContext.value.contextFingerprint);
+    expect(
+      createTrustedSessionMemoryAccessContext({
+        hostFacts: { ...first } as TrustedMemoryAccessHostFacts,
+      }),
+    ).toEqual({
+      ok: false,
+      error: "invalid-context",
+    });
+    expect(() =>
+      issueTrustedMemoryAccessHostFactsFromCore({
+        facts: { ...base, rawSenderId: "forged" },
+        scope: params.scope,
+        stateOptions: params.stateOptions,
+      }),
+    ).toThrow("invalid-context");
+  });
+
+  it("rejects a revoked principal and a mismatched conversation host fact", async () => {
+    const params = await createServiceSession();
+    const hostFacts = issueTrustedMemoryAccessHostFactsFromCore({
+      facts: createHostFacts(params),
+      scope: params.scope,
+      stateOptions: params.stateOptions,
+    });
+    expect(
+      memoryIdentityLifecycle.revokeMemoryPrincipal({
+        principalId: params.authority.currentPrincipalId,
+        now: 102,
+        options: params.stateOptions,
+      }),
+    ).toBe(true);
+    expect(createTrustedSessionMemoryAccessContext({ hostFacts })).toEqual({
+      ok: false,
+      error: "identity-revoked",
+    });
+
+    const { stateOptions, storePath } = createPaths();
+    const scope = { agentId: "main", sessionKey: "agent:main:group:context", storePath };
+    const seed = prepareConversationSessionMemorySubjectSeed({
+      channel: "discord",
+      accountId: "primary",
+      conversationId: "room-1",
+      now: 100,
+      options: stateOptions,
+    });
+    await upsertSessionEntry(
+      scope,
+      { sessionId: "conversation-context-session", updatedAt: 100 },
+      { memorySubjectSeed: seed },
+    );
+    const conversationFacts = issueTrustedMemoryAccessHostFactsFromCore({
+      facts: {
+        contextId: "conversation-context",
+        requestId: "request-1",
+        runId: "run-1",
+        agentId: "main",
+        sessionKey: scope.sessionKey,
+        actor: { kind: "unattributed", transportAuditRef: "audit-1", evidenceRevision: "audit-r1" },
+        verifiedPrincipals: [],
+        conversation: {
+          conversationPrincipalId: "wrong-conversation",
+          channel: "discord",
+          accountId: "primary",
+          evidenceRevision: "conversation-r1",
+        },
+        delivery: {
+          sinkKind: "channel",
+          audiences: [{ kind: "conversation", id: "room-1" }],
+          egressCapabilityIds: [],
+          egressRegistryRevision: "egress-r1",
+          deliveryRevision: "delivery-r1",
+        },
+        collaboration: { kind: "not-applicable" },
+        verifiedMemberships: [],
+        operation: "read",
+        hostFactsRevision: "host-facts-r1",
+      },
+      scope,
+      stateOptions,
+    });
+    expect(createTrustedSessionMemoryAccessContext({ hostFacts: conversationFacts })).toEqual({
+      ok: false,
+      error: "outside-view",
+    });
+  });
+
+  it("fails closed when the session is rebound while constructing the context", async () => {
+    const params = await createServiceSession();
+    const hostFacts = issueTrustedMemoryAccessHostFactsFromCore({
+      facts: createHostFacts(params),
+      scope: params.scope,
+      stateOptions: params.stateOptions,
+    });
+    const readAuthority = sessionMemorySubjectAccessModule.readCurrentSessionMemorySubjectAuthority;
+    let rebound = false;
+    vi.spyOn(
+      sessionMemorySubjectAccessModule,
+      "readCurrentSessionMemorySubjectAuthority",
+    ).mockImplementation((scope, stateOptions, now) => {
+      const result = readAuthority(scope, stateOptions, now);
+      if (!rebound) {
+        rebound = true;
+        replaceSessionEntrySync(scope, {
+          sessionId: "memory-context-session-rebound",
+          updatedAt: 102,
+        });
+      }
+      return result;
+    });
+
+    expect(createTrustedSessionMemoryAccessContext({ hostFacts })).toEqual({
+      ok: false,
+      error: "session-rebound",
+    });
+  });
+
+  it("fails closed when a channel binding is revoked between context authority reads", async () => {
+    const params = await createChannelBoundSession();
+    const hostFacts = issueTrustedMemoryAccessHostFactsFromCore({
+      facts: createHostFacts(params, {
+        actor: {
+          kind: "principal",
+          actorKind: "human",
+          principalId: params.authority.currentPrincipalId,
+          assurance: params.authority.assurance,
+          evidenceRevision: params.authority.evidenceRevision,
+        },
+        verifiedPrincipals: [
+          {
+            principalId: params.authority.currentPrincipalId,
+            assurance: params.authority.assurance,
+            evidenceRevision: params.authority.evidenceRevision,
+          },
+        ],
+      }),
+      scope: params.scope,
+      stateOptions: params.stateOptions,
+    });
+    const readAuthority = sessionMemorySubjectAccessModule.readCurrentSessionMemorySubjectAuthority;
+    let authorityReads = 0;
+    const authoritySpy = vi
+      .spyOn(sessionMemorySubjectAccessModule, "readCurrentSessionMemorySubjectAuthority")
+      .mockImplementation((scope, stateOptions, now) => {
+        const result = readAuthority(scope, stateOptions, now);
+        authorityReads += 1;
+        if (authorityReads === 1) {
+          expect(result?.authority.kind).toBe("current");
+          expect(
+            memoryIdentityLifecycle.revokeMemoryIdentityBinding({
+              bindingId: params.binding.bindingId,
+              revokedBy: "context-race-test",
+              now: Date.now(),
+              options: params.stateOptions,
+            }),
+          ).toBe(true);
+        }
+        return result;
+      });
+
+    expect(createTrustedSessionMemoryAccessContext({ hostFacts })).toEqual({
+      ok: false,
+      error: "identity-revoked",
+    });
+    expect(authoritySpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/config/sessions/session-memory-access-context.ts
+++ b/src/config/sessions/session-memory-access-context.ts
@@ -1,0 +1,230 @@
+/** Core-only construction of a memory authorization context from persisted session provenance. */
+import { stableStringify } from "@openclaw/normalization-core";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
+import { sha256Hex } from "../../infra/crypto-digest.js";
+import type {
+  MemoryAccessContext,
+  MemoryOperation,
+} from "../../memory-host-sdk/host/authorization.js";
+import {
+  failSessionMemoryAccessContext,
+  readTrustedMemoryAccessHostFacts,
+  sessionMemoryAccessContextFailureCode,
+  type SessionMemoryAccessContextFailureCode,
+  type SessionMemoryAccessHostFacts,
+  type TrustedMemoryAccessHostFacts,
+} from "./session-memory-access-host-facts.js";
+import {
+  readCurrentSessionMemorySubjectAuthority,
+  type SessionMemorySubjectAuthority,
+} from "./session-memory-subject-access.js";
+import {
+  SessionMemorySubjectReboundError,
+  type TrustedSessionMemorySubjectSnapshot,
+} from "./session-memory-subject.js";
+
+const trustedAccessContextBrand: unique symbol = Symbol(
+  "openclaw.trusted-session-memory-access-context",
+);
+const trustedAccessContexts = new WeakSet<object>();
+const accessContextSnapshots = new WeakMap<
+  TrustedSessionMemoryAccessContext,
+  MemoryAccessContext
+>();
+
+/** Opaque in-process handle; the serializable DTO remains in this module's private WeakMap. */
+export type TrustedSessionMemoryAccessContext = Readonly<{
+  version: 1;
+  operation: MemoryOperation;
+  contextFingerprint: string;
+}>;
+
+export type { SessionMemoryAccessContextFailureCode, TrustedMemoryAccessHostFacts };
+
+function fail(code: SessionMemoryAccessContextFailureCode = "invalid-context"): never {
+  return failSessionMemoryAccessContext(code);
+}
+
+function failureCode(error: unknown): SessionMemoryAccessContextFailureCode {
+  if (error instanceof SessionMemorySubjectReboundError) {
+    return "session-rebound";
+  }
+  return sessionMemoryAccessContextFailureCode(error);
+}
+
+function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
+  if (typeof value !== "object" || value === null || seen.has(value)) {
+    return value;
+  }
+  seen.add(value);
+  for (const nested of Object.values(value)) {
+    deepFreeze(nested, seen);
+  }
+  return Object.freeze(value);
+}
+
+function brandAndFreeze<T extends object>(value: T): T {
+  Object.defineProperty(value, trustedAccessContextBrand, {
+    value: true,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  trustedAccessContexts.add(value);
+  return deepFreeze(value);
+}
+
+function isTrustedSessionMemoryAccessContextHandle(
+  value: unknown,
+): value is TrustedSessionMemoryAccessContext {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    trustedAccessContexts.has(value) &&
+    (value as Record<PropertyKey, unknown>)[trustedAccessContextBrand] === true &&
+    Object.isFrozen(value),
+  );
+}
+
+function authorityFailure(
+  authority: SessionMemorySubjectAuthority,
+): SessionMemoryAccessContextFailureCode {
+  return authority.kind === "denied" && authority.reason === "shared-main-private-subject"
+    ? "outside-view"
+    : authority.kind === "denied" && authority.reason === "ambiguous"
+      ? "invalid-context"
+      : "identity-revoked";
+}
+
+function snapshotMatches(
+  left: TrustedSessionMemorySubjectSnapshot,
+  right: TrustedSessionMemorySubjectSnapshot,
+): boolean {
+  return (
+    left.sessionKey === right.sessionKey &&
+    left.sessionId === right.sessionId &&
+    left.sessionIdentityRevision === right.sessionIdentityRevision &&
+    left.subjectRevision === right.subjectRevision &&
+    stableStringify(left.subject) === stableStringify(right.subject) &&
+    left.creationBindingId === right.creationBindingId &&
+    left.canonicalConversationRef === right.canonicalConversationRef
+  );
+}
+
+function authorityMatches(
+  left: SessionMemorySubjectAuthority,
+  right: SessionMemorySubjectAuthority,
+): boolean {
+  return stableStringify(left) === stableStringify(right);
+}
+
+function assertHostFactsMatchCurrentIdentity(
+  facts: SessionMemoryAccessHostFacts,
+  snapshot: TrustedSessionMemorySubjectSnapshot,
+  authority: SessionMemorySubjectAuthority,
+): void {
+  if (authority.kind !== "current") {
+    fail(authorityFailure(authority));
+  }
+  if (snapshot.subject.kind === "conversation") {
+    const conversation = facts.conversation;
+    if (
+      !conversation ||
+      conversation.conversationPrincipalId !== snapshot.subject.conversationPrincipalId ||
+      conversation.channel !== snapshot.subject.channel ||
+      conversation.accountId !== snapshot.subject.accountId
+    ) {
+      fail("outside-view");
+    }
+    return;
+  }
+  const principalId = authority.currentPrincipalId;
+  const assurance = authority.assurance;
+  const evidenceRevision = authority.evidenceRevision;
+  if (!principalId || !assurance || !evidenceRevision) {
+    fail("identity-revoked");
+  }
+  const principal = facts.verifiedPrincipals.find((entry) => entry.principalId === principalId);
+  if (
+    !principal ||
+    principal.assurance !== assurance ||
+    principal.evidenceRevision !== evidenceRevision ||
+    (authority.expiresAt === undefined
+      ? principal.expiresAt !== undefined
+      : principal.expiresAt !== new Date(authority.expiresAt).toISOString())
+  ) {
+    fail("identity-revoked");
+  }
+}
+
+function resolveHostFactsSnapshot(value: unknown) {
+  const snapshot = readTrustedMemoryAccessHostFacts(value);
+  if (!snapshot) {
+    fail();
+  }
+  return snapshot;
+}
+
+/** Creates a context only from an exact core-issued host-facts handle and a fresh subject read. */
+export function createTrustedSessionMemoryAccessContext(params: {
+  hostFacts: TrustedMemoryAccessHostFacts;
+}): Result<TrustedSessionMemoryAccessContext, SessionMemoryAccessContextFailureCode> {
+  try {
+    // Recheck identity authority against the host-owned current time, not a
+    // time supplied by the context caller.
+    const now = Date.now();
+    const host = resolveHostFactsSnapshot(params.hostFacts);
+    const current = readCurrentSessionMemorySubjectAuthority(host.scope, host.stateOptions, now);
+    if (!current) {
+      fail("session-rebound");
+    }
+    assertHostFactsMatchCurrentIdentity(host.facts, current.snapshot, current.authority);
+    const dtoWithoutFingerprint = {
+      version: 1 as const,
+      ...host.facts,
+      sessionKey: current.snapshot.sessionKey,
+      sessionId: current.snapshot.sessionId,
+      sessionIdentityRevision: current.snapshot.sessionIdentityRevision,
+      subjectRevision: current.snapshot.subjectRevision,
+      subject: current.snapshot.subject,
+    } satisfies Omit<MemoryAccessContext, "contextFingerprint">;
+    const contextFingerprint = `sha256:${sha256Hex(stableStringify(dtoWithoutFingerprint))}`;
+    // Recheck after all host facts have been bound. Any reset, rehome, revoke,
+    // or binding merge between reads makes the context unusable rather than stale.
+    const rechecked = readCurrentSessionMemorySubjectAuthority(host.scope, host.stateOptions, now);
+    if (!rechecked || !snapshotMatches(current.snapshot, rechecked.snapshot)) {
+      fail("session-rebound");
+    }
+    if (!authorityMatches(current.authority, rechecked.authority)) {
+      fail(authorityFailure(rechecked.authority));
+    }
+    assertHostFactsMatchCurrentIdentity(host.facts, rechecked.snapshot, rechecked.authority);
+    const dto = deepFreeze({
+      ...dtoWithoutFingerprint,
+      contextFingerprint,
+    } satisfies MemoryAccessContext);
+    const context = brandAndFreeze({
+      version: 1 as const,
+      operation: dto.operation,
+      contextFingerprint,
+    }) as TrustedSessionMemoryAccessContext;
+    accessContextSnapshots.set(context, dto);
+    return ok(context);
+  } catch (error) {
+    return err(failureCode(error));
+  }
+}
+
+/** True only for an exact opaque context minted by this module in this process. */
+export function isTrustedSessionMemoryAccessContext(
+  value: unknown,
+): value is TrustedSessionMemoryAccessContext {
+  return isTrustedSessionMemoryAccessContextHandle(value);
+}
+
+/** Core-only bridge to the frozen serializable DTO passed to the selected memory plugin. */
+export function readTrustedSessionMemoryAccessContext(
+  value: unknown,
+): MemoryAccessContext | undefined {
+  return isTrustedSessionMemoryAccessContext(value) ? accessContextSnapshots.get(value) : undefined;
+}

--- a/src/config/sessions/session-memory-access-host-facts.ts
+++ b/src/config/sessions/session-memory-access-host-facts.ts
@@ -1,0 +1,524 @@
+/** Core-internal capture of trusted runtime facts for session-memory authorization. */
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type {
+  AudienceRef,
+  MemoryAccessContext,
+  MemoryActorEvidence,
+  MemoryOperation,
+  MemoryVerifiedMembership,
+  VerifiedPrincipalRef,
+} from "../../memory-host-sdk/host/authorization.js";
+import type { OpenClawStateDatabaseOptions } from "../../state/openclaw-state-db.js";
+import type { SessionAccessScope } from "./session-accessor.sqlite-contract.js";
+import { resolveSqliteScope } from "./session-accessor.sqlite-scope.js";
+
+const trustedHostFactsBrand: unique symbol = Symbol("openclaw.trusted-memory-access-host-facts");
+const trustedHostFacts = new WeakSet<object>();
+const hostFactSnapshots = new WeakMap<
+  TrustedMemoryAccessHostFacts,
+  TrustedMemoryAccessHostFactsSnapshot
+>();
+
+const AUDIENCE_KINDS = [
+  "user",
+  "conversation",
+  "role",
+  "agent-shared",
+  "agent",
+  "internal",
+] as const;
+const ACTOR_KINDS = ["human", "agent", "service", "system"] as const;
+const ASSURANCE_KINDS = ["gateway-profile", "adapter-attested", "oidc", "service"] as const;
+const COLLABORATION_MODES = ["shared", "read-only", "suggest", "draft"] as const;
+const COLLABORATION_ROLES = ["admin", "owner", "member", "viewer"] as const;
+const DELIVERY_SINK_KINDS = ["private", "channel", "session", "internal"] as const;
+const MEMORY_OPERATIONS = [
+  "retrieve",
+  "read",
+  "append",
+  "replace",
+  "derive",
+  "deposit",
+  "project",
+  "publish",
+  "import",
+  "export",
+  "delete",
+  "sync",
+  "status",
+  "policy-admin",
+] as const satisfies readonly MemoryOperation[];
+
+export type SessionMemoryAccessContextFailureCode =
+  | "identity-revoked"
+  | "invalid-context"
+  | "outside-view"
+  | "session-rebound";
+
+export type SessionMemoryAccessHostFacts = Omit<
+  MemoryAccessContext,
+  | "contextFingerprint"
+  | "sessionId"
+  | "sessionIdentityRevision"
+  | "subject"
+  | "subjectRevision"
+  | "version"
+>;
+
+export type TrustedMemoryAccessHostFacts = Readonly<{
+  version: 1;
+  operation: MemoryOperation;
+  hostFactsRevision: string;
+}>;
+
+export type TrustedMemoryAccessHostFactsSnapshot = Readonly<{
+  facts: SessionMemoryAccessHostFacts;
+  scope: SessionAccessScope;
+  stateOptions: OpenClawStateDatabaseOptions;
+}>;
+
+export class SessionMemoryAccessContextError extends Error {
+  constructor(readonly code: SessionMemoryAccessContextFailureCode) {
+    super(code);
+    this.name = "SessionMemoryAccessContextError";
+  }
+}
+
+export function failSessionMemoryAccessContext(
+  code: SessionMemoryAccessContextFailureCode = "invalid-context",
+): never {
+  throw new SessionMemoryAccessContextError(code);
+}
+
+export function sessionMemoryAccessContextFailureCode(
+  error: unknown,
+): SessionMemoryAccessContextFailureCode {
+  return error instanceof SessionMemoryAccessContextError ? error.code : "invalid-context";
+}
+
+function requireText(value: unknown): string {
+  if (typeof value !== "string" || !value.trim()) {
+    failSessionMemoryAccessContext();
+  }
+  return value;
+}
+
+function requireEnum<T extends string>(value: unknown, allowed: readonly T[]): T {
+  if (typeof value !== "string" || !allowed.includes(value as T)) {
+    failSessionMemoryAccessContext();
+  }
+  return value as T;
+}
+
+function ownDataRecord(
+  value: unknown,
+  required: readonly string[],
+  optional: readonly string[] = [],
+): Record<string, unknown> {
+  if (!isRecord(value) || Array.isArray(value)) {
+    failSessionMemoryAccessContext();
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    failSessionMemoryAccessContext();
+  }
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  const allowed = new Set([...required, ...optional]);
+  if (
+    Object.getOwnPropertySymbols(value).length > 0 ||
+    Object.keys(descriptors).length !==
+      required.length + optional.filter((key) => key in descriptors).length ||
+    !required.every((key) => key in descriptors) ||
+    !Object.keys(descriptors).every((key) => allowed.has(key))
+  ) {
+    failSessionMemoryAccessContext();
+  }
+  const output: Record<string, unknown> = {};
+  for (const key of [...required, ...optional]) {
+    const descriptor = descriptors[key];
+    if (!descriptor) {
+      continue;
+    }
+    if (descriptor.enumerable !== true || !("value" in descriptor)) {
+      failSessionMemoryAccessContext();
+    }
+    output[key] = descriptor.value;
+  }
+  return output;
+}
+
+function normalizeTimestamp(
+  value: unknown,
+  now: number,
+  staleCode: SessionMemoryAccessContextFailureCode,
+): string {
+  const timestamp = requireText(value);
+  const milliseconds = Date.parse(timestamp);
+  if (!Number.isFinite(milliseconds) || milliseconds <= now) {
+    failSessionMemoryAccessContext(staleCode);
+  }
+  return new Date(milliseconds).toISOString();
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function normalizeSet<T>(
+  values: readonly T[],
+  key: (value: T) => string,
+  rejectDuplicates = false,
+): T[] {
+  const entries = new Map<string, T>();
+  for (const value of values) {
+    const entryKey = key(value);
+    if (rejectDuplicates && entries.has(entryKey)) {
+      failSessionMemoryAccessContext();
+    }
+    entries.set(entryKey, value);
+  }
+  return [...entries.entries()]
+    .toSorted(([left], [right]) => compareText(left, right))
+    .map(([, value]) => value);
+}
+
+function normalizeAudience(value: unknown): AudienceRef {
+  const record = ownDataRecord(value, ["kind", "id"]);
+  return {
+    kind: requireEnum(record.kind, AUDIENCE_KINDS),
+    id: requireText(record.id),
+  };
+}
+
+function normalizeAudiences(value: unknown): AudienceRef[] {
+  if (!Array.isArray(value)) {
+    failSessionMemoryAccessContext();
+  }
+  return normalizeSet(value.map(normalizeAudience), (entry) => `${entry.kind}\0${entry.id}`);
+}
+
+function normalizeStringSet(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    failSessionMemoryAccessContext();
+  }
+  return normalizeSet(value.map(requireText), (entry) => entry);
+}
+
+function normalizeOperationSet(value: unknown): MemoryOperation[] {
+  if (!Array.isArray(value)) {
+    failSessionMemoryAccessContext();
+  }
+  return normalizeSet(
+    value.map((entry) => requireEnum(entry, MEMORY_OPERATIONS)),
+    (entry) => entry,
+  );
+}
+
+function normalizeActor(value: unknown, now: number): MemoryActorEvidence {
+  const record = ownDataRecord(
+    value,
+    ["kind"],
+    ["actorKind", "assurance", "evidenceRevision", "expiresAt", "principalId", "transportAuditRef"],
+  );
+  if (record.kind === "unattributed") {
+    if (
+      record.actorKind !== undefined ||
+      record.assurance !== undefined ||
+      record.expiresAt !== undefined ||
+      record.principalId !== undefined ||
+      record.transportAuditRef === undefined ||
+      record.evidenceRevision === undefined
+    ) {
+      failSessionMemoryAccessContext();
+    }
+    return {
+      kind: "unattributed",
+      transportAuditRef: requireText(record.transportAuditRef),
+      evidenceRevision: requireText(record.evidenceRevision),
+    };
+  }
+  if (
+    record.kind !== "principal" ||
+    record.actorKind === undefined ||
+    record.assurance === undefined ||
+    record.evidenceRevision === undefined ||
+    record.principalId === undefined ||
+    record.transportAuditRef !== undefined
+  ) {
+    failSessionMemoryAccessContext();
+  }
+  return {
+    kind: "principal",
+    actorKind: requireEnum(record.actorKind, ACTOR_KINDS),
+    principalId: requireText(record.principalId),
+    assurance: requireEnum(record.assurance, ASSURANCE_KINDS),
+    evidenceRevision: requireText(record.evidenceRevision),
+    ...(record.expiresAt === undefined
+      ? {}
+      : { expiresAt: normalizeTimestamp(record.expiresAt, now, "identity-revoked") }),
+  };
+}
+
+function normalizeVerifiedPrincipals(value: unknown, now: number): VerifiedPrincipalRef[] {
+  if (!Array.isArray(value)) {
+    failSessionMemoryAccessContext();
+  }
+  return normalizeSet(
+    value.map((entry) => {
+      const record = ownDataRecord(
+        entry,
+        ["assurance", "evidenceRevision", "principalId"],
+        ["expiresAt"],
+      );
+      return {
+        principalId: requireText(record.principalId),
+        assurance: requireEnum(record.assurance, ASSURANCE_KINDS),
+        evidenceRevision: requireText(record.evidenceRevision),
+        ...(record.expiresAt === undefined
+          ? {}
+          : { expiresAt: normalizeTimestamp(record.expiresAt, now, "identity-revoked") }),
+      } satisfies VerifiedPrincipalRef;
+    }),
+    (entry) => entry.principalId,
+    true,
+  );
+}
+
+function normalizeConversation(value: unknown): MemoryAccessContext["conversation"] {
+  if (value === undefined) {
+    return undefined;
+  }
+  const record = ownDataRecord(value, [
+    "accountId",
+    "channel",
+    "conversationPrincipalId",
+    "evidenceRevision",
+  ]);
+  return {
+    conversationPrincipalId: requireText(record.conversationPrincipalId),
+    channel: requireText(record.channel),
+    accountId: requireText(record.accountId),
+    evidenceRevision: requireText(record.evidenceRevision),
+  };
+}
+
+function normalizeDelivery(value: unknown): MemoryAccessContext["delivery"] {
+  const record = ownDataRecord(value, [
+    "audiences",
+    "deliveryRevision",
+    "egressCapabilityIds",
+    "egressRegistryRevision",
+    "sinkKind",
+  ]);
+  return {
+    sinkKind: requireEnum(record.sinkKind, DELIVERY_SINK_KINDS),
+    audiences: normalizeAudiences(record.audiences),
+    egressCapabilityIds: normalizeStringSet(record.egressCapabilityIds),
+    egressRegistryRevision: requireText(record.egressRegistryRevision),
+    deliveryRevision: requireText(record.deliveryRevision),
+  };
+}
+
+function normalizeCollaboration(value: unknown): MemoryAccessContext["collaboration"] {
+  const record = ownDataRecord(value, ["kind"], ["decisionRevision", "mode", "role"]);
+  if (record.kind === "not-applicable") {
+    if (
+      record.decisionRevision !== undefined ||
+      record.mode !== undefined ||
+      record.role !== undefined
+    ) {
+      failSessionMemoryAccessContext();
+    }
+    return { kind: "not-applicable" };
+  }
+  if (
+    record.kind !== "gateway-session" ||
+    record.decisionRevision === undefined ||
+    record.mode === undefined ||
+    record.role === undefined
+  ) {
+    failSessionMemoryAccessContext();
+  }
+  return {
+    kind: "gateway-session",
+    mode: requireEnum(record.mode, COLLABORATION_MODES),
+    role: requireEnum(record.role, COLLABORATION_ROLES),
+    decisionRevision: requireText(record.decisionRevision),
+  };
+}
+
+function normalizeMemberships(value: unknown, now: number): MemoryVerifiedMembership[] {
+  if (!Array.isArray(value)) {
+    failSessionMemoryAccessContext();
+  }
+  return normalizeSet(
+    value.map((entry) => {
+      const record = ownDataRecord(entry, [
+        "evidenceRevision",
+        "expiresAt",
+        "groupId",
+        "observedAt",
+        "principalId",
+        "provider",
+      ]);
+      return {
+        principalId: requireText(record.principalId),
+        groupId: requireText(record.groupId),
+        provider: requireText(record.provider),
+        evidenceRevision: requireText(record.evidenceRevision),
+        observedAt: requireText(record.observedAt),
+        expiresAt: normalizeTimestamp(record.expiresAt, now, "identity-revoked"),
+      } satisfies MemoryVerifiedMembership;
+    }),
+    (entry) => `${entry.principalId}\0${entry.groupId}\0${entry.provider}`,
+    true,
+  );
+}
+
+function normalizeDelegation(value: unknown): MemoryAccessContext["delegation"] {
+  if (value === undefined) {
+    return undefined;
+  }
+  const record = ownDataRecord(value, [
+    "allowedOperations",
+    "capabilitySnapshotId",
+    "depth",
+    "maximumAudiences",
+    "parentContextId",
+    "parentMemoryPlanId",
+    "rootContextId",
+    "rootPrincipalId",
+    "storeCapToken",
+  ]);
+  if (!Number.isInteger(record.depth) || (record.depth as number) < 1) {
+    failSessionMemoryAccessContext();
+  }
+  return {
+    rootPrincipalId: requireText(record.rootPrincipalId),
+    rootContextId: requireText(record.rootContextId),
+    parentContextId: requireText(record.parentContextId),
+    parentMemoryPlanId: requireText(record.parentMemoryPlanId),
+    capabilitySnapshotId: requireText(record.capabilitySnapshotId),
+    allowedOperations: normalizeOperationSet(record.allowedOperations),
+    maximumAudiences: normalizeAudiences(record.maximumAudiences),
+    storeCapToken: requireText(record.storeCapToken),
+    depth: record.depth as number,
+  };
+}
+
+function normalizeHostFacts(value: unknown, now: number): SessionMemoryAccessHostFacts {
+  const record = ownDataRecord(
+    value,
+    [
+      "actor",
+      "agentId",
+      "collaboration",
+      "contextId",
+      "delivery",
+      "hostFactsRevision",
+      "operation",
+      "requestId",
+      "runId",
+      "sessionKey",
+      "verifiedMemberships",
+      "verifiedPrincipals",
+    ],
+    ["conversation", "delegation"],
+  );
+  const conversation = normalizeConversation(record.conversation);
+  const delegation = normalizeDelegation(record.delegation);
+  return {
+    contextId: requireText(record.contextId),
+    requestId: requireText(record.requestId),
+    runId: requireText(record.runId),
+    agentId: requireText(record.agentId),
+    sessionKey: requireText(record.sessionKey),
+    actor: normalizeActor(record.actor, now),
+    verifiedPrincipals: normalizeVerifiedPrincipals(record.verifiedPrincipals, now),
+    ...(conversation === undefined ? {} : { conversation }),
+    delivery: normalizeDelivery(record.delivery),
+    collaboration: normalizeCollaboration(record.collaboration),
+    verifiedMemberships: normalizeMemberships(record.verifiedMemberships, now),
+    ...(delegation === undefined ? {} : { delegation }),
+    operation: requireEnum(record.operation, MEMORY_OPERATIONS),
+    hostFactsRevision: requireText(record.hostFactsRevision),
+  };
+}
+
+function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
+  if (typeof value !== "object" || value === null || seen.has(value)) {
+    return value;
+  }
+  seen.add(value);
+  for (const nested of Object.values(value)) {
+    deepFreeze(nested, seen);
+  }
+  return Object.freeze(value);
+}
+
+function brandAndFreeze<T extends object>(value: T): T {
+  Object.defineProperty(value, trustedHostFactsBrand, {
+    value: true,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  trustedHostFacts.add(value);
+  return deepFreeze(value);
+}
+
+export function isTrustedMemoryAccessHostFacts(
+  value: unknown,
+): value is TrustedMemoryAccessHostFacts {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    trustedHostFacts.has(value) &&
+    (value as Record<PropertyKey, unknown>)[trustedHostFactsBrand] === true &&
+    Object.isFrozen(value),
+  );
+}
+
+/**
+ * Core-internal ingress bridge. Only authenticated runtime code may capture a
+ * raw facts bag here; the context factory accepts the opaque handle only.
+ * Keep this module out of session-accessor and plugin-SDK barrels.
+ */
+export function issueTrustedMemoryAccessHostFactsFromCore(params: {
+  facts: unknown;
+  scope: SessionAccessScope;
+  stateOptions?: OpenClawStateDatabaseOptions;
+}): TrustedMemoryAccessHostFacts {
+  // Expiry checks belong to the host clock. Accepting a caller-provided time
+  // lets untrusted callers backdate expired evidence into a current context.
+  const now = Date.now();
+  const facts = normalizeHostFacts(params.facts, now);
+  const resolvedScope = resolveSqliteScope(params.scope);
+  if (facts.agentId !== resolvedScope.agentId || facts.sessionKey !== resolvedScope.sessionKey) {
+    failSessionMemoryAccessContext("outside-view");
+  }
+  const scope: SessionAccessScope = {
+    agentId: resolvedScope.agentId,
+    sessionKey: resolvedScope.sessionKey,
+    ...(params.scope.defaultAgentId ? { defaultAgentId: params.scope.defaultAgentId } : {}),
+    ...(params.scope.env ? { env: params.scope.env } : {}),
+    ...(params.scope.storePath ? { storePath: params.scope.storePath } : {}),
+  };
+  const hostFacts = brandAndFreeze({
+    version: 1 as const,
+    operation: facts.operation,
+    hostFactsRevision: facts.hostFactsRevision,
+  }) as TrustedMemoryAccessHostFacts;
+  hostFactSnapshots.set(
+    hostFacts,
+    deepFreeze({ facts, scope, stateOptions: { ...(params.stateOptions ?? {}) } }),
+  );
+  return hostFacts;
+}
+
+/** Returns the private runtime snapshot for an exact handle minted in this process. */
+export function readTrustedMemoryAccessHostFacts(
+  value: unknown,
+): TrustedMemoryAccessHostFactsSnapshot | undefined {
+  return isTrustedMemoryAccessHostFacts(value) ? hostFactSnapshots.get(value) : undefined;
+}

--- a/src/plugins/registry-runtime.inbound-liveness.test.ts
+++ b/src/plugins/registry-runtime.inbound-liveness.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest";
+import type { FinalizedMsgContext } from "../auto-reply/templating.js";
+import { getBoundChannelInboundMemorySubjectIssuer } from "../channels/inbound-event/memory-subject-attestation.js";
+import type { RecordInboundSession } from "../channels/session.types.js";
+import { markPluginRegistryActive, markPluginRegistryRetired } from "./registry-lifecycle.js";
+import { createPluginRuntimeResolver } from "./registry-runtime.js";
+import { createPluginRegistryState } from "./registry-state.js";
+import type { PluginRecord } from "./registry-types.js";
+import { createPluginRuntime } from "./runtime/index.js";
+import type { PluginRuntime } from "./runtime/types.js";
+
+const PLUGIN_ID = "test-channel-owner";
+const CHANNEL_ID = "test";
+const SESSION_KEY = "agent:main:test:direct:sender-1";
+
+function createPluginRecord(): PluginRecord {
+  return {
+    id: PLUGIN_ID,
+    name: "Test Channel Owner",
+    source: "test",
+    origin: "bundled",
+    enabled: true,
+    status: "loaded",
+    toolNames: [],
+    hookNames: [],
+    channelIds: [CHANNEL_ID],
+    cliBackendIds: [],
+    providerIds: [],
+    embeddingProviderIds: [],
+    speechProviderIds: [],
+    realtimeTranscriptionProviderIds: [],
+    realtimeVoiceProviderIds: [],
+    mediaUnderstandingProviderIds: [],
+    transcriptSourceProviderIds: [],
+    imageGenerationProviderIds: [],
+    videoGenerationProviderIds: [],
+    musicGenerationProviderIds: [],
+    webFetchProviderIds: [],
+    webSearchProviderIds: [],
+    migrationProviderIds: [],
+    memoryEmbeddingProviderIds: [],
+    agentHarnessIds: [],
+    cliCommands: [],
+    services: [],
+    gatewayDiscoveryServiceIds: [],
+    commands: [],
+    httpRoutes: 0,
+    hookCount: 0,
+    configSchema: false,
+  };
+}
+
+function createFixture(params: { activate?: boolean } = {}) {
+  const runtime = createPluginRuntime();
+  const state = createPluginRegistryState({
+    logger: { info: () => undefined, warn: () => undefined, error: () => undefined },
+    runtime,
+  });
+  const record = createPluginRecord();
+  state.registry.plugins.push(record);
+  state.registry.channels.push({
+    pluginId: PLUGIN_ID,
+    source: "test",
+    plugin: { id: CHANNEL_ID },
+  } as never);
+  if (params.activate !== false) {
+    markPluginRegistryActive(state.registry);
+  }
+  const resolver = createPluginRuntimeResolver(state);
+  resolver.setPluginRuntimeRecord(record);
+  return {
+    record,
+    registry: state.registry,
+    inbound: resolver.resolvePluginRuntime(PLUGIN_ID).channel.inbound,
+  };
+}
+
+function buildContext(inbound: PluginRuntime["channel"]["inbound"]): FinalizedMsgContext {
+  return inbound.buildContext({
+    channel: CHANNEL_ID,
+    accountId: "acct",
+    from: "test:sender-1",
+    sender: { id: "sender-1" },
+    conversation: { kind: "direct", id: "sender-1" },
+    route: {
+      agentId: "main",
+      accountId: "acct",
+      dmScope: "per-channel-peer",
+      routeSessionKey: SESSION_KEY,
+    },
+    reply: { to: "test:sender-1" },
+    message: { rawBody: "hello" },
+  });
+}
+
+async function observeIssuer(params: {
+  ctx: FinalizedMsgContext;
+  inbound: PluginRuntime["channel"]["inbound"];
+}): Promise<unknown> {
+  let issuer: unknown;
+  const recordInboundSession = vi.fn<RecordInboundSession>(async (record) => {
+    issuer = getBoundChannelInboundMemorySubjectIssuer(
+      record.ctx as FinalizedMsgContext,
+      record.sessionKey,
+    );
+  });
+  await params.inbound.run({
+    channel: CHANNEL_ID,
+    accountId: "acct",
+    raw: {},
+    adapter: {
+      ingest: () => ({ id: "message-1", rawText: "hello" }),
+      resolveTurn: () => ({
+        channel: CHANNEL_ID,
+        accountId: "acct",
+        routeSessionKey: SESSION_KEY,
+        storePath: "/tmp/openclaw-registry-runtime-inbound-liveness",
+        ctxPayload: params.ctx,
+        recordInboundSession,
+        runDispatch: async () => ({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } }),
+        runDispatchLifecycle: {
+          turnAdoptionLifecycle: undefined,
+          onDispatchSkipped: async () => undefined,
+        },
+      }),
+    },
+  } as never);
+  return issuer;
+}
+
+describe("plugin runtime inbound facade liveness", () => {
+  it("issues only while the live registry owns an activated, loaded, enabled channel", async () => {
+    const active = createFixture();
+
+    expect(
+      await observeIssuer({ ctx: buildContext(active.inbound), inbound: active.inbound }),
+    ).toBeDefined();
+  });
+
+  it.each([
+    ["disabled", (fixture: ReturnType<typeof createFixture>) => (fixture.record.enabled = false)],
+    [
+      "unloaded",
+      (fixture: ReturnType<typeof createFixture>) => (fixture.record.status = "disabled"),
+    ],
+    [
+      "removed",
+      (fixture: ReturnType<typeof createFixture>) => fixture.registry.plugins.splice(0, 1),
+    ],
+    [
+      "retired",
+      (fixture: ReturnType<typeof createFixture>) => markPluginRegistryRetired(fixture.registry),
+    ],
+    [
+      "without its registered channel",
+      (fixture: ReturnType<typeof createFixture>) => fixture.registry.channels.splice(0, 1),
+    ],
+  ])("revokes authority when the plugin is %s", async (_label, revoke) => {
+    const fixture = createFixture();
+    const ctx = buildContext(fixture.inbound);
+    revoke(fixture);
+
+    expect(await observeIssuer({ ctx, inbound: fixture.inbound })).toBeUndefined();
+  });
+
+  it("rejects a registry that was never activated", async () => {
+    const fixture = createFixture({ activate: false });
+
+    expect(
+      await observeIssuer({ ctx: buildContext(fixture.inbound), inbound: fixture.inbound }),
+    ).toBeUndefined();
+  });
+});

--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -1,6 +1,10 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
 import { normalizeOptionalAgentRuntimeId } from "../agents/agent-runtime-id.js";
+import { createCoreChannelInboundEventFacade } from "../channels/inbound-event/core-ingress.js";
 import { createChannelIngressDrain } from "../channels/message/ingress-drain.js";
 import { createChannelIngressQueue } from "../channels/message/ingress-queue.js";
 import {
@@ -31,6 +35,7 @@ import {
   isAgentHarnessSessionKey,
   isAgentHarnessSessionKeyOwnedBy,
 } from "../sessions/agent-harness-session-key.js";
+import { isPluginRegistryActivated, isPluginRegistryRetired } from "./registry-lifecycle.js";
 import type { PluginRegistryState } from "./registry-state.js";
 import type { PluginRecord } from "./registry-types.js";
 import {
@@ -544,6 +549,7 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
       }
     };
     let scopedAgentRuntime: PluginRuntime["agent"] | undefined;
+    let scopedChannelRuntime: PluginRuntime["channel"] | undefined;
     const runtime = new Proxy(registryParams.runtime, {
       get(target, prop, receiver) {
         const runWithPluginScope = <T>(run: () => T): T => {
@@ -699,6 +705,45 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
             list: (params) => runWithPluginScope(() => nodes.list(params)),
             invoke: (params) => runWithPluginScope(() => nodes.invoke(params)),
           } satisfies PluginRuntime["nodes"];
+        }
+        if (prop === "channel") {
+          if (scopedChannelRuntime) {
+            return scopedChannelRuntime;
+          }
+          const channel: PluginRuntime["channel"] = getRuntimeProperty();
+          const isLiveTrustedOwnedChannel = (channelId: unknown): boolean => {
+            // The facade can outlive a plugin runtime object. Consult the live
+            // registry record so disable, unload, or removal revokes ingress.
+            const record = registry.plugins.find((entry) => entry.id === pluginId);
+            const normalizedChannelId = normalizeOptionalLowercaseString(channelId);
+            if (
+              !isPluginRegistryActivated(registry) ||
+              isPluginRegistryRetired(registry) ||
+              !record ||
+              record.enabled !== true ||
+              record.status !== "loaded" ||
+              !normalizedChannelId ||
+              (record.origin !== "bundled" && record.trustedOfficialInstall !== true)
+            ) {
+              return false;
+            }
+            return registry.channels.some(
+              (entry) =>
+                entry.pluginId === pluginId &&
+                normalizeOptionalLowercaseString(entry.plugin.id) === normalizedChannelId,
+            );
+          };
+          const inbound = createCoreChannelInboundEventFacade({
+            ownsChannel: isLiveTrustedOwnedChannel,
+          });
+          scopedChannelRuntime = {
+            ...channel,
+            inbound: {
+              ...channel.inbound,
+              ...inbound,
+            },
+          } satisfies PluginRuntime["channel"];
+          return scopedChannelRuntime;
         }
         if (prop === "agent") {
           if (scopedAgentRuntime) {


### PR DESCRIPTION
## What Problem This Solves

A later memory authorization boundary needs trusted ingress facts from the core channel path rather than reconstructed identity from downstream message data. Without an ingress context, a session’s memory subject could be attached inconsistently across direct messages and channel delivery.

## Why This Change Was Made

This Phase 1A draft adds core inbound-event handling for trusted channel ingress context, direct-message classification, session-memory access context and host facts, and registry/runtime liveness coverage. It carries authenticated ingress facts forward; it does not add a policy decision, backend admission, or enforced memory read/write behavior.

## User Impact

This is an unreleased draft with no new user-facing setting. Its intended future effect is to make identity-bearing channel ingress available to later memory phases without changing the current legacy memory experience.

## Stack / Status

Depends on #121152’s session-subject lifecycle draft. It remains a historical parallel Phase 1A draft, outside the current canonical #121421 → #121422 → #121423 stack; this body update does not alter its status or dependency branch.

## Evidence

- Exact head: `c73a0077fc31257f07f992cf33a25945518a72b7` (`feat(memory): add trusted channel ingress context`).
- Current live GitHub rollup shows 10 successful and 77 skipped checks.
- The 16-file diff contains core channel ingress/runtime paths, direct-DM classification, session-memory access-context and host-fact modules, and focused tests.

## Remaining Evidence Gaps

No named exact-head focused test command, remote artifact, or end-to-end channel proof is attached to this draft. The live check rollup is not evidence of the complete later authorization chain.
