### PR TITLE
feat(memory): bind channel ingress to trusted subjects

### DIFF
--- a/extensions/buzz/src/inbound.ts
+++ b/extensions/buzz/src/inbound.ts
@@ -1,7 +1,4 @@
-import {
-  buildChannelInboundEventContext,
-  resolveChannelInboundRouteEnvelope,
-} from "openclaw/plugin-sdk/channel-inbound";
+import { resolveChannelInboundRouteEnvelope } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveStableChannelMessageIngress } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/logging-core";
@@ -87,7 +84,7 @@ export async function handleBuzzInbound(params: {
     timestamp: new Date(message.createdAt * 1000),
     body: textForAgent,
   });
-  const ctxPayload = buildChannelInboundEventContext({
+  const ctxPayload = runtime.channel.inbound.buildContext({
     channel: "buzz",
     accountId: route.accountId ?? account.accountId,
     messageId: message.id,

--- a/extensions/discord/src/monitor/agent-components.dispatch.ts
+++ b/extensions/discord/src/monitor/agent-components.dispatch.ts
@@ -3,7 +3,6 @@ import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import {
   formatInboundEnvelope,
   resolveEnvelopeFormatOptions,
-  runChannelInboundEvent,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
@@ -93,6 +92,10 @@ export async function dispatchDiscordComponentEvent(params: {
 }): Promise<void> {
   const { ctx, interaction, interactionCtx, channelCtx, guildInfo, eventText } = params;
   const runtime = ctx.runtime ?? createNonExitingRuntime();
+  const inbound = ctx.inbound?.();
+  if (!inbound) {
+    throw new Error("Discord component ingress requires the paired inbound runtime facade.");
+  }
   const route = resolveAgentComponentRoute({
     ctx,
     rawGuildId: interactionCtx.rawGuildId,
@@ -176,62 +179,87 @@ export async function dispatchDiscordComponentEvent(params: {
     envelope: envelopeOptions,
   });
 
-  const {
-    createReplyReferencePlanner,
-    finalizeInboundContext,
-    resolveChunkMode,
-    resolveTextChunkLimit,
-  } = await (async () => {
-    const conversationRuntime = await loadConversationRuntime();
-    return {
-      ...conversationRuntime,
-    };
-  })();
+  const { createReplyReferencePlanner, resolveChunkMode, resolveTextChunkLimit } =
+    await (async () => {
+      const conversationRuntime = await loadConversationRuntime();
+      return {
+        ...conversationRuntime,
+      };
+    })();
 
-  const ctxPayload = finalizeInboundContext({
-    Body: combinedBody,
-    BodyForAgent: eventText,
-    RawBody: eventText,
-    CommandBody: eventText,
-    From: interactionCtx.isDirectMessage
-      ? `discord:${interactionCtx.userId}`
-      : interactionCtx.isGroupDm
-        ? `discord:group:${interactionCtx.channelId}`
-        : `discord:channel:${interactionCtx.channelId}`,
-    To: `channel:${interactionCtx.channelId}`,
-    SessionKey: sessionKey,
-    AccountId: accountId,
-    ChatType: chatType,
-    ConversationLabel: fromLabel,
-    SenderName: senderName,
-    SenderId: interactionCtx.userId,
-    SenderUsername: senderUsername,
-    SenderTag: senderTag,
-    GroupSubject: groupSubject,
-    GroupChannel: groupChannel,
-    MemberRoleIds: interactionCtx.memberRoleIds,
-    GroupSystemPrompt: interactionCtx.isDirectMessage ? undefined : groupSystemPrompt,
-    GroupSpace: guildInfo?.id ?? guildInfo?.slug ?? interactionCtx.rawGuildId ?? undefined,
-    OwnerAllowFrom: ownerAllowFrom,
-    Provider: "discord" as const,
-    Surface: "discord" as const,
-    WasMentioned: true,
-    CommandAuthorized: commandAuthorized,
-    CommandTurn: {
+  const deliverTarget = `channel:${interactionCtx.channelId}`;
+  const from = interactionCtx.isDirectMessage
+    ? `discord:${interactionCtx.userId}`
+    : interactionCtx.isGroupDm
+      ? `discord:group:${interactionCtx.channelId}`
+      : `discord:channel:${interactionCtx.channelId}`;
+  const ctxPayload = await inbound.buildContext({
+    channel: "discord",
+    accountId,
+    messageId: interaction.rawData.id,
+    timestamp,
+    from,
+    sender: {
+      id: interactionCtx.userId,
+      name: senderName,
+      username: senderUsername,
+      tag: senderTag,
+      roles: interactionCtx.memberRoleIds,
+    },
+    conversation: {
+      kind: chatType,
+      id: interactionCtx.channelId,
+      label: fromLabel,
+      spaceId: guildInfo?.id ?? guildInfo?.slug ?? interactionCtx.rawGuildId ?? undefined,
+      parentId: channelCtx.parentId,
+      threadId: channelCtx.isThread ? interactionCtx.channelId : undefined,
+      nativeChannelId: interactionCtx.channelId,
+    },
+    route: {
+      agentId,
+      dmScope: route.dmScope,
+      accountId,
+      routeSessionKey: route.sessionKey,
+      dispatchSessionKey: sessionKey,
+    },
+    reply: {
+      to: deliverTarget,
+      originatingTo:
+        resolveDiscordComponentOriginatingTo(interactionCtx) ??
+        `channel:${interactionCtx.channelId}`,
+      nativeChannelId: interactionCtx.channelId,
+      messageThreadId: channelCtx.isThread ? interactionCtx.channelId : undefined,
+      threadParentId: channelCtx.parentId,
+    },
+    message: {
+      body: combinedBody,
+      bodyForAgent: eventText,
+      rawBody: eventText,
+      commandBody: eventText,
+    },
+    access: {
+      mentions: {
+        canDetectMention: !interactionCtx.isDirectMessage,
+        wasMentioned: true,
+      },
+      commands: { authorized: commandAuthorized },
+    },
+    commandTurn: {
       kind: "text-slash" as const,
       source: "text" as const,
       authorized: commandAuthorized,
       body: eventText,
     },
-    CommandSource: "text" as const,
-    MessageSid: interaction.rawData.id,
-    Timestamp: timestamp,
-    OriginatingChannel: "discord" as const,
-    OriginatingTo:
-      resolveDiscordComponentOriginatingTo(interactionCtx) ?? `channel:${interactionCtx.channelId}`,
+    supplemental: {
+      groupSystemPrompt: interactionCtx.isDirectMessage ? undefined : groupSystemPrompt,
+    },
+    extra: {
+      GroupSubject: groupSubject,
+      GroupChannel: groupChannel,
+      OwnerAllowFrom: ownerAllowFrom,
+    },
   });
 
-  const deliverTarget = `channel:${interactionCtx.channelId}`;
   const typingChannelId = interactionCtx.channelId;
   const tableMode = resolveMarkdownTableMode({
     cfg: ctx.cfg,
@@ -255,7 +283,7 @@ export async function dispatchDiscordComponentEvent(params: {
     startId: params.replyToId,
   });
 
-  await runChannelInboundEvent({
+  await inbound.run({
     channel: "discord",
     accountId,
     raw: interaction,

--- a/extensions/discord/src/monitor/agent-components.modal-presentation-failure.test.ts
+++ b/extensions/discord/src/monitor/agent-components.modal-presentation-failure.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../internal/test-builders.test-support.js";
 import { resetDiscordComponentRuntimeMocks } from "../test-support/component-runtime.js";
 import { createDiscordComponentControls } from "./agent-components.js";
+import { createDiscordTestInboundRuntimeResolver } from "./inbound-runtime.test-support.js";
 
 describe("Discord modal presentation failures", () => {
   beforeEach(() => {
@@ -73,6 +74,7 @@ describe("Discord modal presentation failures", () => {
         allowFrom: ["123456789"],
         discordConfig: { replyToMode: "first" },
         token: "token",
+        inbound: createDiscordTestInboundRuntimeResolver(),
       });
       const post = vi.fn().mockRejectedValueOnce(new Error("Discord rejected the modal"));
       if (replyRejects) {

--- a/extensions/discord/src/monitor/agent-components.types.ts
+++ b/extensions/discord/src/monitor/agent-components.types.ts
@@ -11,6 +11,7 @@ import type {
 } from "../internal/discord.js";
 import type { DiscordGuildEntryResolved } from "./allow-list.js";
 import type { formatDiscordUserTag } from "./format.js";
+import type { DiscordInboundRuntimeResolver } from "./inbound-runtime.js";
 
 export type DiscordUser = Parameters<typeof formatDiscordUserTag>[0];
 
@@ -44,6 +45,8 @@ export type AgentComponentContext = {
   guildEntries?: Record<string, DiscordGuildEntryResolved>;
   allowFrom?: string[];
   dmPolicy?: "open" | "pairing" | "allowlist" | "disabled";
+  /** Present for live controls; detached authorization-only tests do not need ingress. */
+  inbound?: DiscordInboundRuntimeResolver;
 };
 
 export type ComponentInteractionContext = {

--- a/extensions/discord/src/monitor/inbound-runtime.test-support.ts
+++ b/extensions/discord/src/monitor/inbound-runtime.test-support.ts
@@ -1,0 +1,28 @@
+// Discord test helper builds the deliberately unprivileged inbound facade.
+import {
+  buildChannelInboundEventContext,
+  dispatchChannelInboundTurn,
+  runChannelInboundEvent,
+} from "openclaw/plugin-sdk/channel-inbound";
+import type { DiscordInboundRuntime, DiscordInboundRuntimeResolver } from "./inbound-runtime.js";
+
+/**
+ * Test-only facade backed by the public SDK entrypoints. It is deliberately
+ * unprivileged: production ingress must receive the gateway-owned facade.
+ */
+export function createDiscordTestInboundRuntime(
+  overrides: Partial<DiscordInboundRuntime> = {},
+): DiscordInboundRuntime {
+  return {
+    buildContext: overrides.buildContext ?? buildChannelInboundEventContext,
+    run: overrides.run ?? runChannelInboundEvent,
+    dispatch: overrides.dispatch ?? dispatchChannelInboundTurn,
+  };
+}
+
+export function createDiscordTestInboundRuntimeResolver(
+  overrides: Partial<DiscordInboundRuntime> = {},
+): DiscordInboundRuntimeResolver {
+  const inbound = createDiscordTestInboundRuntime(overrides);
+  return () => inbound;
+}

--- a/extensions/discord/src/monitor/inbound-runtime.test.ts
+++ b/extensions/discord/src/monitor/inbound-runtime.test.ts
@@ -1,0 +1,37 @@
+// Discord inbound runtime tests protect the live gateway capability boundary.
+import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
+import { describe, expect, it, vi } from "vitest";
+import { type DiscordInboundRuntime, resolveDiscordInboundRuntime } from "./inbound-runtime.js";
+
+const LIVE_INGRESS_ERROR = "Discord inbound runtime is unavailable for a live ingress event.";
+
+function withInboundRuntime(inbound: unknown): ChannelRuntimeSurface {
+  return { inbound } as ChannelRuntimeSurface;
+}
+
+describe("resolveDiscordInboundRuntime", () => {
+  it("rejects a missing gateway-owned facade when live ingress resolves it", () => {
+    expect(() => resolveDiscordInboundRuntime(undefined)).toThrow(LIVE_INGRESS_ERROR);
+  });
+
+  it("rejects an incomplete gateway-owned facade when live ingress resolves it", () => {
+    const incompleteInbound = {
+      buildContext: vi.fn(),
+      run: vi.fn(),
+    };
+
+    expect(() => resolveDiscordInboundRuntime(withInboundRuntime(incompleteInbound))).toThrow(
+      LIVE_INGRESS_ERROR,
+    );
+  });
+
+  it("returns the exact complete gateway-owned facade", () => {
+    const inbound = {
+      buildContext: vi.fn(),
+      run: vi.fn(),
+      dispatch: vi.fn(),
+    } as unknown as DiscordInboundRuntime;
+
+    expect(resolveDiscordInboundRuntime(withInboundRuntime(inbound))).toBe(inbound);
+  });
+});

--- a/extensions/discord/src/monitor/inbound-runtime.ts
+++ b/extensions/discord/src/monitor/inbound-runtime.ts
@@ -1,0 +1,38 @@
+// Discord plugin module defines the trusted inbound runtime boundary.
+import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+
+/** Paired context construction and execution capability for one Discord ingress event. */
+export type DiscordInboundRuntime = Pick<
+  PluginRuntime["channel"]["inbound"],
+  "buildContext" | "run" | "dispatch"
+>;
+
+export type DiscordInboundRuntimeResolver = () => DiscordInboundRuntime;
+
+function isDiscordInboundRuntime(value: unknown): value is DiscordInboundRuntime {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const inbound = value as Partial<DiscordInboundRuntime>;
+  return (
+    typeof inbound.buildContext === "function" &&
+    typeof inbound.run === "function" &&
+    typeof inbound.dispatch === "function"
+  );
+}
+
+/**
+ * Resolve the gateway-owned facade lazily, so startup-only test paths do not
+ * need an inbound runtime. Real ingress must fail closed instead of downgrading
+ * to the public unprivileged helpers.
+ */
+export function resolveDiscordInboundRuntime(
+  channelRuntime: ChannelRuntimeSurface | undefined,
+): DiscordInboundRuntime {
+  const inbound = channelRuntime?.["inbound"];
+  if (!isDiscordInboundRuntime(inbound)) {
+    throw new Error("Discord inbound runtime is unavailable for a live ingress event.");
+  }
+  return inbound;
+}

--- a/extensions/discord/src/monitor/message-dispatcher.ts
+++ b/extensions/discord/src/monitor/message-dispatcher.ts
@@ -9,6 +9,7 @@ import { danger } from "openclaw/plugin-sdk/runtime-env";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import type { Client } from "../internal/discord.js";
 import { buildDiscordInboundJob } from "./inbound-job.js";
+import type { DiscordInboundRuntime } from "./inbound-runtime.js";
 import type {
   createDiscordIngressMonitor,
   DiscordIngressDispatchResult,
@@ -33,8 +34,9 @@ type PreflightDiscordMessage =
 
 type DiscordMessageHandlerParams = Omit<
   DiscordMessagePreflightParams,
-  "ackReactionScope" | "groupPolicy" | "data" | "client"
+  "ackReactionScope" | "groupPolicy" | "inbound" | "data" | "client"
 > & {
+  inbound: () => DiscordInboundRuntime;
   setStatus?: DiscordMonitorStatusSink;
   abortSignal?: AbortSignal;
   testing?: DiscordMessageHandlerTestingHooks;
@@ -87,6 +89,7 @@ export function createDiscordMessageDispatcher(
   type DiscordDebounceEntry = {
     data: DiscordMessageEvent;
     client: Client;
+    inbound: DiscordInboundRuntime;
     abortSignal?: AbortSignal;
     turnAdoptionLifecycle?: DiscordIngressLifecycle;
     debounceKey?: string;
@@ -154,6 +157,7 @@ export function createDiscordMessageDispatcher(
                 abortSignal,
                 data: last.data,
                 client: last.client,
+                inbound: last.inbound,
                 turnAdoptionLifecycle: admissionLifecycle,
               });
               if (abortSignal?.aborted) {
@@ -208,6 +212,7 @@ export function createDiscordMessageDispatcher(
               abortSignal,
               data: syntheticData,
               client: last.client,
+              inbound: last.inbound,
               turnAdoptionLifecycle: admissionLifecycle,
             });
             if (abortSignal?.aborted) {
@@ -285,9 +290,13 @@ export function createDiscordMessageDispatcher(
       const abortSignal = options?.abortSignal
         ? AbortSignal.any([options.abortSignal, dispatcherShutdown.signal])
         : dispatcherShutdown.signal;
+      // Capture the paired facade once while receiving this event. A delayed
+      // debounce flush must not construct with one facade and dispatch with another.
+      const inbound = params.inbound();
       const entry: DiscordDebounceEntry = {
         data,
         client,
+        inbound,
         abortSignal,
         turnAdoptionLifecycle: options?.turnAdoptionLifecycle,
       };

--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -360,7 +360,10 @@ export async function buildDiscordMessageProcessContext(params: {
           sessionKey: effectiveSessionKey,
         });
 
-  const ctxPayload = await buildChannelInboundEventContext({
+  // Direct context tests intentionally have no trusted facade. Live messages
+  // always carry the receipt-time facade captured by the dispatcher above.
+  const buildContext = ctx.inbound?.buildContext ?? buildChannelInboundEventContext;
+  const ctxPayload = await buildContext({
     channel: "discord",
     resolveSupplementalMedia: true,
     contextVisibility: contextVisibilityMode,

--- a/extensions/discord/src/monitor/message-handler.preflight-context.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight-context.ts
@@ -19,6 +19,7 @@ type SharedPreflightFields =
   | "replyToMode"
   | "ackReactionScope"
   | "groupPolicy"
+  | "inbound"
   | "turnAdoptionLifecycle"
   | "threadBindings"
   | "discordRestFetch";
@@ -49,6 +50,7 @@ export function buildDiscordMessagePreflightContext({
     replyToMode: preflightParams.replyToMode,
     ackReactionScope: preflightParams.ackReactionScope,
     groupPolicy: preflightParams.groupPolicy,
+    inbound: preflightParams.inbound,
     turnAdoptionLifecycle: preflightParams.turnAdoptionLifecycle,
     ...fields,
     threadBindings: preflightParams.threadBindings,

--- a/extensions/discord/src/monitor/message-handler.preflight.types.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.types.ts
@@ -5,6 +5,7 @@ import type { SessionBindingRecord } from "openclaw/plugin-sdk/conversation-runt
 import type { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import type { ChannelType, Client, User } from "../internal/discord.js";
 import type { DiscordChannelConfigResolved, DiscordGuildEntryResolved } from "./allow-list.js";
+import type { DiscordInboundRuntime } from "./inbound-runtime.js";
 import type { DiscordIngressLifecycle } from "./ingress.js";
 import type { DiscordHistoryEntry } from "./message-handler.history.js";
 import type { DiscordChannelInfo, DiscordMediaInfo } from "./message-utils.js";
@@ -36,6 +37,8 @@ type DiscordMessagePreflightSharedFields = {
   replyToMode: ReplyToMode;
   ackReactionScope: "all" | "direct" | "group-all" | "group-mentions" | "off" | "none";
   groupPolicy: "open" | "disabled" | "allowlist";
+  /** Captured at receipt time so builder and dispatcher retain one paired facade. */
+  inbound?: DiscordInboundRuntime;
   turnAdoptionLifecycle?: DiscordIngressLifecycle;
 };
 

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -1,10 +1,7 @@
 // Discord plugin module implements message handler.process behavior.
 import type { APIAllowedMentions } from "discord-api-types/v10";
 import { resolveAgentConfig, resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
-import {
-  dispatchChannelInboundTurn,
-  hasFinalInboundReplyDispatch,
-} from "openclaw/plugin-sdk/channel-inbound";
+import { hasFinalInboundReplyDispatch } from "openclaw/plugin-sdk/channel-inbound";
 import {
   bindIngressLifecycleToReplyOptions,
   defineFinalizableLivePreviewAdapter,
@@ -111,6 +108,10 @@ async function processDiscordMessageInner(
   } = ctx;
   if (isProcessAborted(abortSignal)) {
     return;
+  }
+  const inbound = ctx.inbound;
+  if (!inbound) {
+    throw new Error("Discord inbound context was not built by the paired runtime facade.");
   }
   const text = messageText;
   if (!text && mediaList.length === 0) {
@@ -608,7 +609,7 @@ async function processDiscordMessageInner(
       dispatchAborted = true;
       return;
     }
-    const preparedResult = await dispatchChannelInboundTurn({
+    const preparedResult = await inbound.dispatch({
       cfg,
       channel: "discord",
       accountId: route.accountId,

--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -3,6 +3,7 @@ import { getEventListeners } from "node:events";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DiscordInboundRuntime } from "./inbound-runtime.js";
 import type { DiscordIngressLifecycle } from "./ingress.js";
 import { createDiscordMessageHandler as createDurableDiscordMessageHandler } from "./message-handler.js";
 import {
@@ -257,6 +258,60 @@ describe("createDiscordMessageHandler queue behavior", () => {
     await vi.waitFor(() => expect(processDiscordMessageMock).toHaveBeenCalledTimes(1));
     expect(first.onAdopted).toHaveBeenCalledTimes(1);
     expect(second.onAdopted).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains the receipt-time facade through a delayed message build and dispatch", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+
+    const builtByFirstFacade = { marker: "first-facade" };
+    const firstBuildContext = vi.fn().mockResolvedValue(builtByFirstFacade);
+    const firstDispatch = vi.fn().mockResolvedValue({});
+    const secondBuildContext = vi.fn().mockResolvedValue({ marker: "second-facade" });
+    const secondDispatch = vi.fn().mockResolvedValue({});
+    const firstFacade = {
+      buildContext: firstBuildContext,
+      run: vi.fn(),
+      dispatch: firstDispatch,
+    } as unknown as DiscordInboundRuntime;
+    const secondFacade = {
+      buildContext: secondBuildContext,
+      run: vi.fn(),
+      dispatch: secondDispatch,
+    } as unknown as DiscordInboundRuntime;
+    let resolvedFacade = firstFacade;
+    const params = createDiscordHandlerParams();
+    params.cfg.messages = { inbound: { debounceMs: 20 } };
+    params.inbound = vi.fn(() => resolvedFacade);
+    preflightDiscordMessageMock.mockImplementation(
+      async (preflightParams: {
+        data: { channel_id: string };
+        inbound?: DiscordInboundRuntime;
+      }) => ({
+        ...createPreflightContext(preflightParams.data.channel_id),
+        inbound: preflightParams.inbound,
+      }),
+    );
+    processDiscordMessageMock.mockImplementation(
+      async (ctx: { inbound?: DiscordInboundRuntime }) => {
+        if (!ctx.inbound) {
+          throw new Error("expected the receipt-time inbound facade");
+        }
+        const ctxPayload = await ctx.inbound.buildContext({} as never);
+        await ctx.inbound.dispatch({ ctxPayload } as never);
+      },
+    );
+    const handler = createDiscordMessageHandler(params);
+
+    await handler(createTextMessageData("m-facade") as never, {} as never);
+    resolvedFacade = secondFacade;
+
+    await vi.waitFor(() => expect(processDiscordMessageMock).toHaveBeenCalledTimes(1));
+    expect(params.inbound).toHaveBeenCalledTimes(1);
+    expect(firstBuildContext).toHaveBeenCalledTimes(1);
+    expect(firstDispatch).toHaveBeenCalledWith({ ctxPayload: builtByFirstFacade });
+    expect(secondBuildContext).not.toHaveBeenCalled();
+    expect(secondDispatch).not.toHaveBeenCalled();
   });
 
   it("completes every debounced ingress claim when preflight gates the merged turn", async () => {

--- a/extensions/discord/src/monitor/message-handler.test-harness.ts
+++ b/extensions/discord/src/monitor/message-handler.test-harness.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { createDiscordTestInboundRuntime } from "./inbound-runtime.test-support.js";
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
 import { createNoopThreadBindingManager } from "./thread-bindings.js";
 
@@ -25,6 +26,7 @@ export async function createBaseDiscordMessageContext(
     replyToMode: "off",
     ackReactionScope: "group-mentions",
     groupPolicy: "open",
+    inbound: createDiscordTestInboundRuntime(),
     data: { guild: { id: "g1", name: "Guild" } },
     client: { rest: {} },
     message: {

--- a/extensions/discord/src/monitor/message-handler.test-helpers.ts
+++ b/extensions/discord/src/monitor/message-handler.test-helpers.ts
@@ -1,6 +1,7 @@
 // Discord helper module supports message handler helpers behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { vi } from "vitest";
+import { createDiscordTestInboundRuntimeResolver } from "./inbound-runtime.test-support.js";
 import type { createDiscordMessageDispatcher } from "./message-dispatcher.js";
 import { createNoopThreadBindingManager } from "./thread-bindings.js";
 
@@ -38,6 +39,7 @@ export function createDiscordHandlerParams(overrides?: {
       },
     },
     botUserId: overrides?.botUserId ?? DEFAULT_DISCORD_BOT_USER_ID,
+    inbound: createDiscordTestInboundRuntimeResolver(),
     guildHistories: new Map(),
     historyLimit: 0,
     mediaMaxBytes: 10_000,

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -31,6 +31,8 @@ import {
   resolveStorePathMock,
 } from "../test-support/component-runtime.js";
 import type { DiscordGuildEntryResolved } from "./allow-list.js";
+import type { DiscordInboundRuntime } from "./inbound-runtime.js";
+import { createDiscordTestInboundRuntimeResolver } from "./inbound-runtime.test-support.js";
 
 type CreateDiscordComponentButton =
   (typeof import("./agent-components.js").createDiscordComponentControls)[number];
@@ -139,6 +141,7 @@ describe("discord component interactions", () => {
       allowFrom: ["123456789"],
       discordConfig: createDiscordConfig(),
       token: "token",
+      inbound: createDiscordTestInboundRuntimeResolver(),
       ...overrides,
     }) as ComponentContext;
 
@@ -423,6 +426,98 @@ describe("discord component interactions", () => {
     expect(typeof dispatchParams?.dispatcherOptions.responsePrefixContextProvider).toBe("function");
     expect(typeof dispatchParams?.replyOptions?.onModelSelected).toBe("function");
     await expect(resolveDiscordComponentEntryWithPersistence({ id: "btn_1" })).resolves.toBeNull();
+  });
+
+  it("uses the receipt-time facade for component context construction and execution", async () => {
+    registerDiscordComponentEntries({
+      entries: [createButtonEntry()],
+      modals: [],
+    });
+    const builtByFirstFacade = {
+      SessionKey: "agent:agent-1:discord:component:btn_1",
+      RawBody: "clicked",
+      BodyForAgent: "clicked",
+      CommandBody: "clicked",
+    };
+    const firstBuildContext = vi.fn().mockResolvedValue(builtByFirstFacade);
+    const firstRun = vi.fn(
+      async (params: { adapter: { resolveTurn: () => { ctxPayload: unknown } } }) => {
+        expect(params.adapter.resolveTurn().ctxPayload).toBe(builtByFirstFacade);
+      },
+    );
+    const secondBuildContext = vi.fn();
+    const secondRun = vi.fn();
+    const firstFacade = {
+      buildContext: firstBuildContext,
+      run: firstRun,
+      dispatch: vi.fn(),
+    } as unknown as DiscordInboundRuntime;
+    const secondFacade = {
+      buildContext: secondBuildContext,
+      run: secondRun,
+      dispatch: vi.fn(),
+    } as unknown as DiscordInboundRuntime;
+    const inbound = vi
+      .fn<() => DiscordInboundRuntime>()
+      .mockReturnValueOnce(firstFacade)
+      .mockReturnValue(secondFacade);
+    const button = createDiscordComponentButton(createComponentContext({ inbound }));
+    const { interaction } = createComponentButtonInteraction();
+
+    await button.run(interaction, { cid: "btn_1" } as ComponentData);
+
+    expect(inbound).toHaveBeenCalledTimes(1);
+    expect(firstBuildContext).toHaveBeenCalledTimes(1);
+    expect(firstRun).toHaveBeenCalledTimes(1);
+    expect(secondBuildContext).not.toHaveBeenCalled();
+    expect(secondRun).not.toHaveBeenCalled();
+    expect(dispatchReplyMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the receipt-time facade for modal context construction and execution", async () => {
+    registerDiscordComponentEntries({
+      entries: [],
+      modals: [createModalEntry()],
+    });
+    const builtByFirstFacade = {
+      SessionKey: "agent:agent-2:discord:modal:mdl_1",
+      RawBody: "submitted",
+      BodyForAgent: "submitted",
+      CommandBody: "submitted",
+    };
+    const firstBuildContext = vi.fn().mockResolvedValue(builtByFirstFacade);
+    const firstRun = vi.fn(
+      async (params: { adapter: { resolveTurn: () => { ctxPayload: unknown } } }) => {
+        expect(params.adapter.resolveTurn().ctxPayload).toBe(builtByFirstFacade);
+      },
+    );
+    const secondBuildContext = vi.fn();
+    const secondRun = vi.fn();
+    const firstFacade = {
+      buildContext: firstBuildContext,
+      run: firstRun,
+      dispatch: vi.fn(),
+    } as unknown as DiscordInboundRuntime;
+    const secondFacade = {
+      buildContext: secondBuildContext,
+      run: secondRun,
+      dispatch: vi.fn(),
+    } as unknown as DiscordInboundRuntime;
+    const inbound = vi
+      .fn<() => DiscordInboundRuntime>()
+      .mockReturnValueOnce(firstFacade)
+      .mockReturnValue(secondFacade);
+    const modal = createDiscordComponentModal(createComponentContext({ inbound }));
+    const { interaction } = createModalInteraction();
+
+    await modal.run(interaction, { mid: "mdl_1" } as ComponentData);
+
+    expect(inbound).toHaveBeenCalledTimes(1);
+    expect(firstBuildContext).toHaveBeenCalledTimes(1);
+    expect(firstRun).toHaveBeenCalledTimes(1);
+    expect(secondBuildContext).not.toHaveBeenCalled();
+    expect(secondRun).not.toHaveBeenCalled();
+    expect(dispatchReplyMock).not.toHaveBeenCalled();
   });
 
   it("records DM component interactions with user originating targets", async () => {

--- a/extensions/discord/src/monitor/native-command-agent-reply.ts
+++ b/extensions/discord/src/monitor/native-command-agent-reply.ts
@@ -18,6 +18,7 @@ import type {
   StringSelectMenuInteraction,
 } from "../internal/discord.js";
 import type { DiscordChannelConfigResolved } from "./allow-list.js";
+import type { DiscordInboundRuntime } from "./inbound-runtime.js";
 import type { buildDiscordNativeCommandContext } from "./native-command-context.js";
 import {
   DISCORD_EMPTY_VISIBLE_REPLY_WARNING,
@@ -25,7 +26,6 @@ import {
   safeDiscordInteractionCall,
   settleDiscordInteractionWithoutVisibleReply,
 } from "./native-command-reply.js";
-import { nativeCommandRuntime } from "./native-command.runtime.js";
 import type { DiscordConfig } from "./native-command.types.js";
 
 type NativeCommandEffectiveRoute = {
@@ -44,7 +44,8 @@ export async function dispatchDiscordNativeAgentReply(params: {
   discordConfig: DiscordConfig;
   accountId: string;
   interaction: CommandInteraction | ButtonInteraction | StringSelectMenuInteraction;
-  ctxPayload: ReturnType<typeof buildDiscordNativeCommandContext>;
+  ctxPayload: Awaited<ReturnType<typeof buildDiscordNativeCommandContext>>;
+  dispatch: DiscordInboundRuntime["dispatch"];
   effectiveRoute: NativeCommandEffectiveRoute;
   channelConfig: DiscordChannelConfigResolved | null;
   mediaLocalRoots: ReturnType<typeof getAgentScopedMediaLocalRoots>;
@@ -58,7 +59,7 @@ export async function dispatchDiscordNativeAgentReply(params: {
   let didReply = false;
   let finalReplyOutcome: "accepted" | "failed" | "suppressed" | undefined;
   let hiddenFinalReply: ReplyPayload | undefined;
-  const turnResult = await nativeCommandRuntime.dispatchChannelInboundTurn({
+  const turnResult = await params.dispatch({
     cfg: params.cfg,
     channel: "discord",
     accountId: params.effectiveRoute.accountId,

--- a/extensions/discord/src/monitor/native-command-context.test.ts
+++ b/extensions/discord/src/monitor/native-command-context.test.ts
@@ -3,10 +3,11 @@ import { describe, expect, it } from "vitest";
 import { buildDiscordNativeCommandContext } from "./native-command-context.js";
 
 describe("buildDiscordNativeCommandContext", () => {
-  it("builds direct-message slash command context", () => {
-    const ctx = buildDiscordNativeCommandContext({
+  it("builds direct-message slash command context", async () => {
+    const ctx = await buildDiscordNativeCommandContext({
       prompt: "/status",
       commandArgs: {},
+      agentId: "codex",
       sessionKey: "agent:codex:discord:slash:user-1",
       commandTargetSessionKey: "agent:codex:discord:direct:user-1",
       accountId: "default",
@@ -42,10 +43,11 @@ describe("buildDiscordNativeCommandContext", () => {
     expect(ctx.Timestamp).toBe(123);
   });
 
-  it("builds guild slash command context with owner allowlist and channel metadata", () => {
-    const ctx = buildDiscordNativeCommandContext({
+  it("builds guild slash command context with owner allowlist and channel metadata", async () => {
+    const ctx = await buildDiscordNativeCommandContext({
       prompt: "/status",
       commandArgs: { values: { model: "gpt-5.2" } },
+      agentId: "codex",
       sessionKey: "agent:codex:discord:slash:user-1",
       commandTargetSessionKey: "agent:codex:discord:channel:chan-1",
       accountId: "default",

--- a/extensions/discord/src/monitor/native-command-context.ts
+++ b/extensions/discord/src/monitor/native-command-context.ts
@@ -1,13 +1,15 @@
+import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
 // Discord plugin module implements native command context behavior.
 import type { CommandArgs } from "openclaw/plugin-sdk/command-auth-native";
-import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { resolveDiscordConversationIdentity } from "../conversation-identity.js";
 import type { DiscordChannelConfigResolved, DiscordGuildEntryResolved } from "./allow-list.js";
 import { buildDiscordInboundAccessContext } from "./inbound-context.js";
+import type { DiscordInboundRuntime } from "./inbound-runtime.js";
 
 type BuildDiscordNativeCommandContextParams = {
   prompt: string;
   commandArgs: CommandArgs;
+  agentId: string;
   sessionKey: string;
   commandTargetSessionKey: string;
   accountId?: string | null;
@@ -37,9 +39,13 @@ type BuildDiscordNativeCommandContextParams = {
     tag?: string;
   };
   timestampMs?: number;
+  /** Supplied by live native ingress; omitted only by detached context tests. */
+  inbound?: DiscordInboundRuntime;
 };
 
-export function buildDiscordNativeCommandContext(params: BuildDiscordNativeCommandContextParams) {
+export async function buildDiscordNativeCommandContext(
+  params: BuildDiscordNativeCommandContextParams,
+) {
   const conversationLabel = params.isDirectMessage
     ? (params.user.globalName ?? params.user.username)
     : params.channelId;
@@ -53,59 +59,79 @@ export function buildDiscordNativeCommandContext(params: BuildDiscordNativeComma
       channelTopic: params.channelTopic,
     });
 
-  return finalizeInboundContext({
-    Body: params.prompt,
-    BodyForAgent: params.prompt,
-    RawBody: params.prompt,
-    CommandBody: params.prompt,
-    CommandArgs: params.commandArgs,
-    From: params.isDirectMessage
-      ? `discord:${params.user.id}`
-      : params.isGroupDm
-        ? `discord:group:${params.channelId}`
-        : `discord:channel:${params.channelId}`,
-    To: `slash:${params.user.id}`,
-    SessionKey: params.sessionKey,
-    CommandTargetSessionKey: params.commandTargetSessionKey,
-    AccountId: params.accountId ?? undefined,
-    ChatType: params.isDirectMessage ? "direct" : params.isGroupDm ? "group" : "channel",
-    ConversationLabel: conversationLabel,
-    GroupSubject: params.isGuild ? params.guildName : undefined,
-    GroupSpace: params.isGuild
-      ? (params.guildInfo?.id ?? params.guildInfo?.slug ?? params.guildId)
-      : undefined,
-    MemberRoleIds: params.memberRoleIds,
-    GroupSystemPrompt: groupSystemPrompt,
-    ChannelStructuredContext: channelStructuredContext,
-    OwnerAllowFrom: ownerAllowFrom,
-    SenderName: params.user.globalName ?? params.user.username,
-    SenderId: params.user.id,
-    SenderUsername: params.user.username,
-    SenderTag: params.sender.tag,
-    Provider: "discord" as const,
-    Surface: "discord" as const,
-    WasMentioned: true,
-    MessageSid: params.interactionId,
-    MessageThreadId: params.isThreadChannel ? params.channelId : undefined,
-    Timestamp: params.timestampMs ?? Date.now(),
-    CommandAuthorized: params.commandAuthorized,
-    CommandTurn: {
-      kind: "native" as const,
-      source: "native" as const,
-      authorized: params.commandAuthorized,
-      body: params.prompt,
+  const chatType = params.isDirectMessage ? "direct" : params.isGroupDm ? "group" : "channel";
+  const from = params.isDirectMessage
+    ? `discord:${params.user.id}`
+    : params.isGroupDm
+      ? `discord:group:${params.channelId}`
+      : `discord:channel:${params.channelId}`;
+  // Detached unit callers keep the public builder only to exercise context
+  // projection. Live slash ingress receives the paired facade from its command.
+  const buildContext = params.inbound?.buildContext ?? buildChannelInboundEventContext;
+  return await buildContext({
+    channel: "discord",
+    accountId: params.accountId ?? undefined,
+    messageId: params.interactionId,
+    timestamp: params.timestampMs ?? Date.now(),
+    from,
+    sender: {
+      id: params.user.id,
+      name: params.user.globalName ?? params.user.username,
+      username: params.user.username,
+      tag: params.sender.tag,
+      roles: params.memberRoleIds,
     },
-    CommandSource: "native" as const,
-    // Native slash contexts use To=slash:<user> for interaction routing.
-    // For follow-up delivery (for example subagent completion announces),
-    // preserve the real Discord target separately.
-    OriginatingChannel: "discord" as const,
-    OriginatingTo:
-      resolveDiscordConversationIdentity({
-        isDirectMessage: params.isDirectMessage,
-        userId: params.user.id,
-        channelId: params.channelId,
-      }) ?? (params.isDirectMessage ? `user:${params.user.id}` : `channel:${params.channelId}`),
-    ThreadParentId: params.isThreadChannel ? params.threadParentId : undefined,
+    conversation: {
+      kind: chatType,
+      id: params.channelId,
+      label: conversationLabel,
+      spaceId: params.isGuild
+        ? (params.guildInfo?.id ?? params.guildInfo?.slug ?? params.guildId)
+        : undefined,
+      parentId: params.isThreadChannel ? params.threadParentId : undefined,
+      threadId: params.isThreadChannel ? params.channelId : undefined,
+      nativeChannelId: params.channelId,
+    },
+    route: {
+      agentId: params.agentId,
+      accountId: params.accountId ?? undefined,
+      routeSessionKey: params.sessionKey,
+      dispatchSessionKey: params.sessionKey,
+    },
+    reply: {
+      to: `slash:${params.user.id}`,
+      originatingTo:
+        resolveDiscordConversationIdentity({
+          isDirectMessage: params.isDirectMessage,
+          userId: params.user.id,
+          channelId: params.channelId,
+        }) ?? (params.isDirectMessage ? `user:${params.user.id}` : `channel:${params.channelId}`),
+      nativeChannelId: params.channelId,
+      messageThreadId: params.isThreadChannel ? params.channelId : undefined,
+      threadParentId: params.isThreadChannel ? params.threadParentId : undefined,
+    },
+    message: {
+      body: params.prompt,
+      bodyForAgent: params.prompt,
+      rawBody: params.prompt,
+      commandBody: params.prompt,
+    },
+    access: {
+      mentions: { canDetectMention: true, wasMentioned: true },
+      commands: { authorized: params.commandAuthorized },
+    },
+    command: {
+      kind: "native",
+      body: params.prompt,
+      authorized: params.commandAuthorized,
+    },
+    supplemental: { groupSystemPrompt },
+    extra: {
+      CommandArgs: params.commandArgs,
+      CommandTargetSessionKey: params.commandTargetSessionKey,
+      GroupSubject: params.isGuild ? params.guildName : undefined,
+      ChannelStructuredContext: channelStructuredContext,
+      OwnerAllowFrom: ownerAllowFrom,
+    },
   });
 }

--- a/extensions/discord/src/monitor/native-command-ui.types.ts
+++ b/extensions/discord/src/monitor/native-command-ui.types.ts
@@ -1,5 +1,6 @@
 // Discord type declarations define plugin contracts.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { DiscordInboundRuntimeResolver } from "./inbound-runtime.js";
 import type { ThreadBindingManager } from "./thread-bindings.js";
 
 type DiscordConfig = NonNullable<OpenClawConfig["channels"]>["discord"];
@@ -10,6 +11,8 @@ export type DiscordCommandArgContext = {
   accountId: string;
   sessionPrefix: string;
   threadBindings: ThreadBindingManager;
+  /** Each deferred control resolves its own facade when the user clicks it. */
+  inbound: DiscordInboundRuntimeResolver;
   postApplySettleMs?: number;
 };
 

--- a/extensions/discord/src/monitor/native-command.command-arg.test.ts
+++ b/extensions/discord/src/monitor/native-command.command-arg.test.ts
@@ -3,6 +3,7 @@ import type { ChatCommandDefinition } from "openclaw/plugin-sdk/command-auth-nat
 import * as commandRegistryModule from "openclaw/plugin-sdk/command-auth-native";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDiscordTestInboundRuntimeResolver } from "./inbound-runtime.test-support.js";
 import type { DispatchDiscordCommandInteraction } from "./native-command-dispatch.js";
 import { createDiscordCommandArgFallbackButton } from "./native-command-ui.js";
 import { createNoopThreadBindingManager } from "./thread-bindings.js";
@@ -46,6 +47,7 @@ function createContext(
     accountId: "default",
     sessionPrefix: "discord:slash",
     threadBindings: createNoopThreadBindingManager("default"),
+    inbound: createDiscordTestInboundRuntimeResolver(),
   };
 }
 

--- a/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
+++ b/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
@@ -11,7 +11,7 @@ import { defineThrowingDiscordChannelGetter } from "../test-support/partial-chan
 import { createDiscordNativeCommand } from "./native-command.js";
 
 vi.mock("openclaw/plugin-sdk/plugin-runtime", { spy: true });
-import { nativeCommandRuntime } from "./native-command.runtime.js";
+import { createDiscordTestInboundRuntime } from "./inbound-runtime.test-support.js";
 import {
   createMockCommandInteraction,
   type MockCommandInteraction,
@@ -70,6 +70,7 @@ function createCommand(cfg: OpenClawConfig, discordConfig?: DiscordAccountConfig
     sessionPrefix: "discord:slash",
     ephemeralDefault: true,
     threadBindings: createNoopThreadBindingManager("default"),
+    inbound: resolveTestInbound,
   });
 }
 
@@ -81,7 +82,7 @@ function createDispatchSpy() {
       tool: 0,
     },
   } as never);
-  nativeCommandRuntime.dispatchChannelInboundTurn = dispatchChannelInboundTurnForTest;
+  dispatchInboundForTest = dispatchChannelInboundTurnForTest;
   return dispatchSpy;
 }
 
@@ -109,6 +110,10 @@ const dispatchChannelInboundTurnForTest: typeof dispatchChannelInboundTurn = asy
     dispatchResult,
   };
 };
+
+let dispatchInboundForTest: typeof dispatchChannelInboundTurn = dispatchChannelInboundTurnForTest;
+const resolveTestInbound = () =>
+  createDiscordTestInboundRuntime({ dispatch: dispatchInboundForTest });
 
 function firstDispatchReplyCall(): Parameters<
   typeof dispatcherModule.dispatchReplyWithDispatcher
@@ -167,7 +172,7 @@ function expectChannelNotAllowedReply(interaction: MockCommandInteraction) {
 describe("Discord native slash commands with commands.allowFrom", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    nativeCommandRuntime.dispatchChannelInboundTurn = dispatchChannelInboundTurnForTest;
+    dispatchInboundForTest = dispatchChannelInboundTurnForTest;
   });
 
   it("authorizes guild slash commands when commands.allowFrom.discord matches the sender", async () => {

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -16,6 +16,7 @@ import * as commandTextModule from "openclaw/plugin-sdk/text-utility-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { defineThrowingDiscordChannelGetter } from "../test-support/partial-channel.js";
 import { resolveDiscordChannelContext } from "./agent-components-context.js";
+import { createDiscordTestInboundRuntimeResolver } from "./inbound-runtime.test-support.js";
 import * as modelPickerPreferencesModule from "./model-picker-preferences.js";
 import * as modelPickerModule from "./model-picker.state.js";
 import { createModelsProviderData as createBaseModelsProviderData } from "./model-picker.test-utils.js";
@@ -93,6 +94,7 @@ function createModelPickerContext(): ModelPickerContext {
     accountId: "default",
     sessionPrefix: "discord:slash",
     threadBindings: createNoopThreadBindingManager("default"),
+    inbound: createDiscordTestInboundRuntimeResolver(),
     postApplySettleMs: 0,
   };
 }

--- a/extensions/discord/src/monitor/native-command.options.test.ts
+++ b/extensions/discord/src/monitor/native-command.options.test.ts
@@ -7,6 +7,7 @@ import {
   setRuntimeConfigSnapshot,
 } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDiscordTestInboundRuntimeResolver } from "./inbound-runtime.test-support.js";
 import { nativeCommandRuntime } from "./native-command.runtime.js";
 
 const { loadModelCatalogMock, logVerboseMock } = vi.hoisted(() => ({
@@ -81,6 +82,7 @@ function createNativeCommand(
     sessionPrefix: "discord:slash",
     ephemeralDefault: true,
     threadBindings: createNoopThreadBindingManager("default"),
+    inbound: createDiscordTestInboundRuntimeResolver(),
   });
 }
 
@@ -477,6 +479,7 @@ describe("createDiscordNativeCommand option wiring", () => {
         sessionPrefix: "discord:slash",
         ephemeralDefault: true,
         threadBindings: createNoopThreadBindingManager("default"),
+        inbound: createDiscordTestInboundRuntimeResolver(),
       });
       const mode = requireOption(command, "mode");
       const autocomplete = requireAutocomplete(
@@ -551,6 +554,7 @@ describe("createDiscordNativeCommand option wiring", () => {
         sessionPrefix: "discord:slash",
         ephemeralDefault: true,
         threadBindings: createNoopThreadBindingManager("default"),
+        inbound: createDiscordTestInboundRuntimeResolver(),
       });
       const value = requireOption(command, "value");
       const autocomplete = requireAutocomplete(
@@ -675,6 +679,7 @@ describe("createDiscordNativeCommand option wiring", () => {
       sessionPrefix: "discord:slash",
       ephemeralDefault: true,
       threadBindings: createNoopThreadBindingManager("default"),
+      inbound: createDiscordTestInboundRuntimeResolver(),
     });
 
     expect(command.description).toBe("x".repeat(99));
@@ -699,6 +704,7 @@ describe("createDiscordNativeCommand option wiring", () => {
       sessionPrefix: "discord:slash",
       ephemeralDefault: true,
       threadBindings: createNoopThreadBindingManager("default"),
+      inbound: createDiscordTestInboundRuntimeResolver(),
     });
 
     expect(command.descriptionLocalizations).toEqual({

--- a/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
+++ b/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
@@ -1,6 +1,6 @@
 // Discord tests cover native command.plugin dispatch plugin behavior.
 import { ChannelType } from "discord-api-types/v10";
-import { dispatchChannelInboundTurn } from "openclaw/plugin-sdk/channel-inbound";
+import type { dispatchChannelInboundTurn } from "openclaw/plugin-sdk/channel-inbound";
 import type { NativeCommandSpec } from "openclaw/plugin-sdk/command-auth-native";
 import { resolveDirectStatusReplyForSession } from "openclaw/plugin-sdk/command-status-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -23,6 +23,8 @@ import {
 import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { defineThrowingDiscordChannelGetter } from "../test-support/partial-channel.js";
+import type { DiscordInboundRuntime } from "./inbound-runtime.js";
+import { createDiscordTestInboundRuntime } from "./inbound-runtime.test-support.js";
 import { dispatchDiscordNativeAgentReply } from "./native-command-agent-reply.js";
 import { resolveDiscordNativeInteractionRouteState } from "./native-command-route.js";
 import { nativeCommandRuntime } from "./native-command.runtime.js";
@@ -60,6 +62,10 @@ const dispatchChannelInboundTurnForTest: typeof dispatchChannelInboundTurn = asy
     dispatchResult,
   };
 };
+
+let dispatchInboundForTest: typeof dispatchChannelInboundTurn = dispatchChannelInboundTurnForTest;
+const resolveTestInbound = () =>
+  createDiscordTestInboundRuntime({ dispatch: dispatchInboundForTest });
 
 function createConfig(): OpenClawConfig {
   return {
@@ -156,6 +162,7 @@ async function createNativeCommand(cfg: OpenClawConfig, commandSpec: NativeComma
     sessionPrefix: "discord:slash",
     ephemeralDefault: true,
     threadBindings: createNoopThreadBindingManager("default"),
+    inbound: resolveTestInbound,
   });
 }
 
@@ -310,6 +317,7 @@ async function createPluginCommand(params: { cfg: OpenClawConfig; name: string }
     sessionPrefix: "discord:slash",
     ephemeralDefault: true,
     threadBindings: createNoopThreadBindingManager("default"),
+    inbound: resolveTestInbound,
   });
 }
 
@@ -433,7 +441,6 @@ describe("Discord native plugin command dispatch", () => {
     setActivePluginRegistry(createTestRegistry());
     nativeCommandRuntime.matchPluginCommand = matchPluginCommand;
     nativeCommandRuntime.executePluginCommand = executePluginCommand;
-    nativeCommandRuntime.dispatchChannelInboundTurn = dispatchChannelInboundTurn;
     nativeCommandRuntime.resolveDirectStatusReplyForSession = resolveDirectStatusReplyForSession;
     nativeCommandRuntime.resolveDiscordNativeInteractionRouteState =
       resolveDiscordNativeInteractionRouteState;
@@ -467,7 +474,7 @@ describe("Discord native plugin command dispatch", () => {
       runtimeModuleMocks.matchPluginCommand as typeof import("openclaw/plugin-sdk/plugin-runtime").matchPluginCommand;
     nativeCommandRuntime.executePluginCommand =
       runtimeModuleMocks.executePluginCommand as typeof import("openclaw/plugin-sdk/plugin-runtime").executePluginCommand;
-    nativeCommandRuntime.dispatchChannelInboundTurn = dispatchChannelInboundTurnForTest;
+    dispatchInboundForTest = dispatchChannelInboundTurnForTest;
     nativeCommandRuntime.resolveDirectStatusReplyForSession =
       runtimeModuleMocks.resolveDirectStatusReplyForSession as typeof resolveDirectStatusReplyForSession;
     nativeCommandRuntime.resolveDiscordNativeInteractionRouteState = async (params) =>
@@ -994,6 +1001,70 @@ describe("Discord native plugin command dispatch", () => {
     expect(interaction.deleteReply).not.toHaveBeenCalled();
   });
 
+  it("uses one captured facade to build and dispatch a native slash command", async () => {
+    const cfg = createConfig();
+    const interaction = createInteraction();
+    const builtByInboundFacade = {
+      SessionKey: "agent:main:discord:slash:owner",
+      CommandTargetSessionKey: "agent:main:discord:direct:owner",
+    };
+    const buildContext = vi.fn().mockResolvedValue(builtByInboundFacade);
+    const dispatch = vi.fn(async (plan: Parameters<typeof dispatchChannelInboundTurn>[0]) => {
+      expect(plan.ctxPayload).toBe(builtByInboundFacade);
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: plan.ctxPayload,
+        routeSessionKey: plan.route.sessionKey,
+        dispatchResult: {
+          counts: { final: 1, block: 0, tool: 0 },
+          queuedFinal: false,
+        },
+      } as never;
+    });
+    const firstFacade = {
+      buildContext,
+      run: vi.fn(),
+      dispatch,
+    } as unknown as DiscordInboundRuntime;
+    const secondBuildContext = vi.fn();
+    const secondDispatch = vi.fn();
+    const secondFacade = {
+      buildContext: secondBuildContext,
+      run: vi.fn(),
+      dispatch: secondDispatch,
+    } as unknown as DiscordInboundRuntime;
+    const inbound = vi
+      .fn<() => DiscordInboundRuntime>()
+      .mockReturnValueOnce(firstFacade)
+      .mockReturnValue(secondFacade);
+    const command = await createDiscordNativeCommand({
+      command: {
+        name: "new",
+        description: "Start a new session.",
+        acceptsArgs: true,
+      },
+      cfg,
+      discordConfig: cfg.channels?.discord ?? {},
+      accountId: "default",
+      sessionPrefix: "discord:slash",
+      ephemeralDefault: true,
+      threadBindings: createNoopThreadBindingManager("default"),
+      inbound,
+    });
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(inbound).toHaveBeenCalledTimes(1);
+    expect(buildContext).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(secondBuildContext).not.toHaveBeenCalled();
+    expect(secondDispatch).not.toHaveBeenCalled();
+    expect(interaction.followUp).not.toHaveBeenCalledWith(
+      expect.objectContaining({ content: "⚠️ Command produced no visible reply." }),
+    );
+  });
+
   it("returns an explicit warning instead of success when dispatch produces zero visible replies", async () => {
     const cfg = createConfig();
     const interaction = createInteraction();
@@ -1021,7 +1092,7 @@ describe("Discord native plugin command dispatch", () => {
   it("warns when the inbound turn is dropped before dispatch", async () => {
     const cfg = createConfig();
     const interaction = createInteraction();
-    nativeCommandRuntime.dispatchChannelInboundTurn = async () => ({
+    dispatchInboundForTest = async () => ({
       admission: { kind: "drop", reason: "ingest-null" },
       dispatched: false,
     });
@@ -1032,6 +1103,7 @@ describe("Discord native plugin command dispatch", () => {
       accountId: "default",
       interaction: interaction as never,
       ctxPayload: { SessionKey: "agent:main:discord:dm:owner" } as never,
+      dispatch: dispatchInboundForTest,
       effectiveRoute: {
         accountId: "default",
         agentId: "main",
@@ -1078,7 +1150,7 @@ describe("Discord native plugin command dispatch", () => {
     const cfg = createConfig();
     const interaction = createInteraction();
     runtimeModuleMocks.matchPluginCommand.mockReturnValue(null);
-    nativeCommandRuntime.dispatchChannelInboundTurn = async (plan) => {
+    dispatchInboundForTest = async (plan) => {
       await plan.delivery.onDelivered?.({ text: "unreported" }, { kind: "final" }, undefined);
       return {
         admission: { kind: "dispatch" },
@@ -1111,7 +1183,7 @@ describe("Discord native plugin command dispatch", () => {
     const cfg = createConfig();
     const interaction = createInteraction();
     runtimeModuleMocks.matchPluginCommand.mockReturnValue(null);
-    nativeCommandRuntime.dispatchChannelInboundTurn = async (plan) => {
+    dispatchInboundForTest = async (plan) => {
       for (let index = 0; index < count; index += 1) {
         await plan.delivery.onDelivered?.(
           { text: "cancelled" },
@@ -1154,7 +1226,7 @@ describe("Discord native plugin command dispatch", () => {
       { text: "scope-aware model selection result", isError: true },
       { assistantMessageIndex: 3 },
     );
-    nativeCommandRuntime.dispatchChannelInboundTurn = async (plan) => {
+    dispatchInboundForTest = async (plan) => {
       if (!("deliver" in plan.delivery) || !plan.delivery.deliver) {
         throw new Error("expected direct deliverer");
       }
@@ -1179,6 +1251,7 @@ describe("Discord native plugin command dispatch", () => {
       accountId: "default",
       interaction: interaction as never,
       ctxPayload: { SessionKey: "agent:main:discord:dm:owner" } as never,
+      dispatch: dispatchInboundForTest,
       effectiveRoute: {
         accountId: "default",
         agentId: "main",
@@ -1213,7 +1286,7 @@ describe("Discord native plugin command dispatch", () => {
     const cfg = createConfig();
     const interaction = createInteraction();
     interaction.responseState = "deferred";
-    nativeCommandRuntime.dispatchChannelInboundTurn = async (plan) => {
+    dispatchInboundForTest = async (plan) => {
       await plan.delivery.onDelivered?.(
         payload,
         { kind: "final" },
@@ -1240,6 +1313,7 @@ describe("Discord native plugin command dispatch", () => {
       accountId: "default",
       interaction: interaction as never,
       ctxPayload: { SessionKey: "agent:main:discord:dm:owner" } as never,
+      dispatch: dispatchInboundForTest,
       effectiveRoute: {
         accountId: "default",
         agentId: "main",
@@ -1316,7 +1390,7 @@ describe("Discord native plugin command dispatch", () => {
       message: "Unknown interaction",
     });
     runtimeModuleMocks.matchPluginCommand.mockReturnValue(null);
-    nativeCommandRuntime.dispatchChannelInboundTurn = async (plan) => {
+    dispatchInboundForTest = async (plan) => {
       const reportSuppressed = (suppressedKind: "block" | "final" | "tool") =>
         plan.delivery.onDelivered?.(
           { text: "cancelled intermediate reply" },
@@ -1394,7 +1468,7 @@ describe("Discord native plugin command dispatch", () => {
         interaction.followUp.mockRejectedValueOnce(new Error("provider connection failed"));
       }
     }
-    nativeCommandRuntime.dispatchChannelInboundTurn = async (plan) => {
+    dispatchInboundForTest = async (plan) => {
       if (!("deliver" in plan.delivery) || !plan.delivery.deliver) {
         throw new Error("expected direct delivery adapter");
       }

--- a/extensions/discord/src/monitor/native-command.runtime.ts
+++ b/extensions/discord/src/monitor/native-command.runtime.ts
@@ -1,4 +1,3 @@
-import { dispatchChannelInboundTurn } from "openclaw/plugin-sdk/channel-inbound";
 // Discord plugin module implements native command behavior.
 import { resolveDirectStatusReplyForSession } from "openclaw/plugin-sdk/command-status-runtime";
 import * as pluginRuntime from "openclaw/plugin-sdk/plugin-runtime";
@@ -8,7 +7,6 @@ import { resolveDiscordNativeInteractionRouteState } from "./native-command-rout
 export const nativeCommandRuntime = {
   matchPluginCommand: pluginRuntime.matchPluginCommand,
   executePluginCommand: pluginRuntime.executePluginCommand,
-  dispatchChannelInboundTurn,
   resolveDirectStatusReplyForSession,
   resolveDiscordNativeInteractionRouteState,
   getSessionEntry,

--- a/extensions/discord/src/monitor/native-command.status-direct.test.ts
+++ b/extensions/discord/src/monitor/native-command.status-direct.test.ts
@@ -3,6 +3,7 @@ import { ChannelType } from "discord-api-types/v10";
 import type { dispatchChannelInboundTurn } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDiscordTestInboundRuntimeResolver } from "./inbound-runtime.test-support.js";
 import { nativeCommandRuntime } from "./native-command.runtime.js";
 import { createMockCommandInteraction as createInteraction } from "./native-command.test-helpers.js";
 import { createNoopThreadBindingManager } from "./thread-bindings.js";
@@ -95,6 +96,9 @@ async function createStatusCommand(cfg: OpenClawConfig) {
     sessionPrefix: "discord:slash",
     ephemeralDefault: true,
     threadBindings: createNoopThreadBindingManager("default"),
+    inbound: createDiscordTestInboundRuntimeResolver({
+      dispatch: dispatchChannelInboundTurnForTest,
+    }),
   });
 }
 
@@ -181,7 +185,6 @@ describe("discord native /status", () => {
       buffer: Buffer.from("image"),
       fileName: "status.png",
     });
-    nativeCommandRuntime.dispatchChannelInboundTurn = dispatchChannelInboundTurnForTest;
     nativeCommandRuntime.matchPluginCommand = (() =>
       null) as typeof import("openclaw/plugin-sdk/plugin-runtime").matchPluginCommand;
     setDefaultRouteState();

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -41,6 +41,7 @@ import {
 import { resolveDiscordChannelTopicSafe } from "./channel-access.js";
 import { resolveDiscordDmCommandAccess } from "./dm-command-auth.js";
 import { handleDiscordDmCommandDecision } from "./dm-command-decision.js";
+import type { DiscordInboundRuntimeResolver } from "./inbound-runtime.js";
 import { dispatchDiscordNativeAgentReply } from "./native-command-agent-reply.js";
 import {
   resolveDiscordGuildNativeCommandAuthorized,
@@ -95,6 +96,7 @@ export function createDiscordNativeCommand(params: {
   sessionPrefix: string;
   ephemeralDefault: boolean;
   threadBindings: ThreadBindingManager;
+  inbound: DiscordInboundRuntimeResolver;
 }): Command {
   const {
     command,
@@ -104,6 +106,7 @@ export function createDiscordNativeCommand(params: {
     sessionPrefix,
     ephemeralDefault,
     threadBindings,
+    inbound,
   } = params;
   const fallbackCommandDefinition = createNativeCommandDefinition(command);
   const pluginCommandMatch = nativeCommandRuntime.matchPluginCommand(`/${command.name}`);
@@ -194,6 +197,7 @@ export function createDiscordNativeCommand(params: {
         // follow-up/edit semantics instead of the initial reply endpoint.
         preferFollowUp: true,
         threadBindings,
+        inbound,
         responseEphemeral: ephemeralDefault,
       });
     }
@@ -211,6 +215,7 @@ async function dispatchDiscordCommandInteraction(params: {
   sessionPrefix: string;
   preferFollowUp: boolean;
   threadBindings: ThreadBindingManager;
+  inbound: DiscordInboundRuntimeResolver;
   responseEphemeral?: boolean;
   suppressReplies?: boolean;
 }): Promise<DispatchDiscordCommandInteractionResult> {
@@ -225,10 +230,14 @@ async function dispatchDiscordCommandInteraction(params: {
     sessionPrefix,
     preferFollowUp,
     threadBindings,
+    inbound: inboundResolver,
     responseEphemeral,
     suppressReplies,
   } = params;
   const cfg = getRuntimeConfigSnapshot() ?? inputConfig;
+  // Pair the builder and dispatcher for this exact native interaction. Follow-up
+  // controls keep the resolver and capture their own facade when clicked.
+  const inbound = inboundResolver();
   const commandName = command.nativeName ?? command.key;
   const respond = async (content: string, options?: { ephemeral?: boolean }) => {
     const ephemeral = options?.ephemeral ?? responseEphemeral;
@@ -521,9 +530,11 @@ async function dispatchDiscordCommandInteraction(params: {
         accountId,
         sessionPrefix,
         threadBindings,
+        inbound: inboundResolver,
       },
       safeInteractionCall: safeDiscordInteractionCall,
-      dispatchCommandInteraction: dispatchDiscordCommandInteraction,
+      dispatchCommandInteraction: (nextParams) =>
+        dispatchDiscordCommandInteraction({ ...nextParams, inbound: inboundResolver }),
     });
     if (preferFollowUp) {
       await safeDiscordInteractionCall("interaction follow-up", () =>
@@ -647,9 +658,10 @@ async function dispatchDiscordCommandInteraction(params: {
     boundSessionKey,
   });
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, effectiveRoute.agentId);
-  const ctxPayload = buildDiscordNativeCommandContext({
+  const ctxPayload = await buildDiscordNativeCommandContext({
     prompt,
     commandArgs: commandArgs ?? {},
+    agentId: effectiveRoute.agentId,
     sessionKey,
     commandTargetSessionKey,
     accountId: effectiveRoute.accountId,
@@ -674,6 +686,7 @@ async function dispatchDiscordCommandInteraction(params: {
       globalName: user.globalName,
     },
     sender: { id: sender.id, name: sender.name, tag: sender.tag },
+    inbound,
   });
 
   const directStatusResult = await maybeDeliverDiscordDirectStatus({
@@ -709,6 +722,7 @@ async function dispatchDiscordCommandInteraction(params: {
     accountId,
     interaction,
     ctxPayload,
+    dispatch: inbound.dispatch,
     effectiveRoute,
     channelConfig,
     mediaLocalRoots,
@@ -725,7 +739,8 @@ export function createDiscordCommandArgFallbackButton(params: DiscordCommandArgC
   return createDiscordCommandArgFallbackButtonUi({
     ctx: params,
     safeInteractionCall: safeDiscordInteractionCall,
-    dispatchCommandInteraction: dispatchDiscordCommandInteraction,
+    dispatchCommandInteraction: (nextParams) =>
+      dispatchDiscordCommandInteraction({ ...nextParams, inbound: params.inbound }),
   });
 }
 
@@ -733,7 +748,8 @@ export function createDiscordModelPickerFallbackButton(params: DiscordModelPicke
   return createDiscordModelPickerFallbackButtonUi({
     ctx: params,
     safeInteractionCall: safeDiscordInteractionCall,
-    dispatchCommandInteraction: dispatchDiscordCommandInteraction,
+    dispatchCommandInteraction: (nextParams) =>
+      dispatchDiscordCommandInteraction({ ...nextParams, inbound: params.inbound }),
   });
 }
 
@@ -743,7 +759,8 @@ export function createDiscordModelPickerFallbackSelect(
   return createDiscordModelPickerFallbackSelectUi({
     ctx: params,
     safeInteractionCall: safeDiscordInteractionCall,
-    dispatchCommandInteraction: dispatchDiscordCommandInteraction,
+    dispatchCommandInteraction: (nextParams) =>
+      dispatchDiscordCommandInteraction({ ...nextParams, inbound: params.inbound }),
   });
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/discord/src/monitor/provider.interactions.ts
+++ b/extensions/discord/src/monitor/provider.interactions.ts
@@ -21,6 +21,7 @@ import {
   createDiscordExecApprovalButtonContext,
   createExecApprovalButton,
 } from "./exec-approvals.js";
+import type { DiscordInboundRuntimeResolver } from "./inbound-runtime.js";
 import {
   createDiscordCommandArgFallbackButton,
   createDiscordModelPickerFallbackButton,
@@ -52,6 +53,7 @@ export function createDiscordProviderInteractionSurface(params: {
   dmPolicy: NonNullable<DiscordAccountConfig["dmPolicy"]>;
   runtime: RuntimeEnv;
   channelRuntime?: ChannelRuntimeSurface;
+  inbound: DiscordInboundRuntimeResolver;
   abortSignal?: AbortSignal;
   createNativeCommand?: typeof createDiscordNativeCommand;
 }): {
@@ -69,6 +71,7 @@ export function createDiscordProviderInteractionSurface(params: {
       sessionPrefix: params.sessionPrefix,
       ephemeralDefault: params.ephemeralDefault,
       threadBindings: params.threadBindings,
+      inbound: params.inbound,
     }),
   );
   if (params.nativeEnabled && params.voiceEnabled) {
@@ -132,6 +135,7 @@ export function createDiscordProviderInteractionSurface(params: {
       accountId: params.accountId,
       sessionPrefix: params.sessionPrefix,
       threadBindings: params.threadBindings,
+      inbound: params.inbound,
     }),
     createDiscordModelPickerFallbackButton({
       cfg: params.cfg,
@@ -139,6 +143,7 @@ export function createDiscordProviderInteractionSurface(params: {
       accountId: params.accountId,
       sessionPrefix: params.sessionPrefix,
       threadBindings: params.threadBindings,
+      inbound: params.inbound,
     }),
     createDiscordModelPickerFallbackSelect({
       cfg: params.cfg,
@@ -146,6 +151,7 @@ export function createDiscordProviderInteractionSurface(params: {
       accountId: params.accountId,
       sessionPrefix: params.sessionPrefix,
       threadBindings: params.threadBindings,
+      inbound: params.inbound,
     }),
   ];
   const activityButton = createDiscordActivityButton(
@@ -189,6 +195,7 @@ export function createDiscordProviderInteractionSurface(params: {
       dmPolicy: params.dmPolicy,
       runtime: params.runtime,
       token: params.token,
+      inbound: params.inbound,
     };
     components.push(...createAgentComponentControls.map((create) => create(componentContext)));
     components.push(...createDiscordComponentControls.map((create) => create(componentContext)));

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -379,6 +379,47 @@ describe("monitorDiscordProvider", () => {
     ).not.toThrow();
   });
 
+  it("defers a missing inbound runtime failure until message ingress resolves it", async () => {
+    await monitorDiscordProvider({
+      config: baseConfig(),
+      runtime: baseRuntime(),
+    });
+
+    expect(monitorLifecycleMock).toHaveBeenCalledTimes(1);
+    const params = getFirstDiscordMessageHandlerParams<{ inbound?: () => unknown }>();
+    if (typeof params?.inbound !== "function") {
+      throw new Error("message handler did not receive an inbound runtime resolver");
+    }
+
+    expect(() => params.inbound()).toThrow(
+      "Discord inbound runtime is unavailable for a live ingress event.",
+    );
+  });
+
+  it("defers an incomplete inbound runtime failure until message ingress resolves it", async () => {
+    const channelRuntime = createTestChannelRuntime();
+    channelRuntime.inbound = {
+      buildContext: vi.fn(),
+      run: vi.fn(),
+    };
+
+    await monitorDiscordProvider({
+      config: baseConfig(),
+      runtime: baseRuntime(),
+      channelRuntime,
+    });
+
+    expect(monitorLifecycleMock).toHaveBeenCalledTimes(1);
+    const params = getFirstDiscordMessageHandlerParams<{ inbound?: () => unknown }>();
+    if (typeof params?.inbound !== "function") {
+      throw new Error("message handler did not receive an inbound runtime resolver");
+    }
+
+    expect(() => params.inbound()).toThrow(
+      "Discord inbound runtime is unavailable for a live ingress event.",
+    );
+  });
+
   it("fails closed before lifecycle when Discord bot identity fetch rejects", async () => {
     const runtime = baseRuntime();
     clientFetchUserMock.mockRejectedValueOnce(new Error("identity offline"));

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -24,6 +24,7 @@ import { resolveDiscordSlashCommandConfig } from "./commands.js";
 import type { MutableDiscordGateway } from "./gateway-handle.js";
 import { createDiscordGatewayPlugin } from "./gateway-plugin.js";
 import { createDiscordGatewaySupervisor } from "./gateway-supervisor.js";
+import { resolveDiscordInboundRuntime } from "./inbound-runtime.js";
 import { registerDiscordListener } from "./listeners.js";
 import { discordProviderRuntime } from "./provider-runtime.js";
 import { probeDiscordAcpBindingHealth } from "./provider.acp.js";
@@ -83,6 +84,9 @@ function isDiscordDisallowedIntentsError(err: unknown): boolean {
 export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   const startupStartedAt = Date.now();
   const cfg = opts.config ?? getRuntimeConfig();
+  // Resolve only at event ingress. Startup probes and component registration
+  // intentionally remain usable in tests that provide no channel runtime.
+  const inbound = () => resolveDiscordInboundRuntime(opts.channelRuntime);
   const account = discordProviderRuntime.resolveDiscordAccount({
     cfg,
     accountId: opts.accountId,
@@ -324,6 +328,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       dmPolicy,
       runtime,
       channelRuntime: opts.channelRuntime,
+      inbound,
       abortSignal: opts.abortSignal,
       createNativeCommand: discordProviderRuntime.createDiscordNativeCommand,
     });
@@ -453,6 +458,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       guildEntries,
       threadBindings,
       discordRestFetch,
+      inbound,
     });
     deactivateMessageHandler = messageHandler.deactivate;
     const trackInboundEvent = opts.setStatus

--- a/extensions/feishu/src/bot.broadcast.test.ts
+++ b/extensions/feishu/src/bot.broadcast.test.ts
@@ -1,4 +1,5 @@
 // Feishu tests cover bot.broadcast plugin behavior.
+import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
 import { feishuGroupNameCache } from "./bot-group-name-state.js";
@@ -134,6 +135,7 @@ describe("broadcast dispatch", () => {
         saveMediaBuffer: mockSaveMediaBuffer,
       },
       inbound: {
+        buildContext: buildChannelInboundEventContext,
         run: vi.fn(async (params: Parameters<PluginRuntime["channel"]["inbound"]["run"]>[0]) => {
           const input = await params.adapter.ingest(params.raw);
           if (!input) {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1,3 +1,4 @@
+import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
 import { createTestInboundDebounceFlush } from "openclaw/plugin-sdk/channel-test-helpers";
 // Feishu tests cover bot plugin behavior.
 import type {
@@ -184,6 +185,7 @@ function createFeishuBotRuntime(overrides: DeepPartial<PluginRuntime> = {}): Plu
         buildPairingReply: vi.fn(),
       },
       inbound: {
+        buildContext: buildChannelInboundEventContext,
         run: vi.fn(async (params) => {
           const input = await params.adapter.ingest(params.raw);
           if (!input) {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1,5 +1,4 @@
 import {
-  buildChannelInboundEventContext,
   formatAgentEnvelope,
   formatInboundMediaUnavailableText,
   recordChannelBotPairLoopAndCheckSuppression,
@@ -1368,7 +1367,7 @@ export async function handleFeishuMessage(params: {
     ) => {
       const groupName = await resolveGroupNameForLabel();
       const threadContext = await resolveThreadContextForAgent(agentId, agentSessionKey, groupName);
-      return buildChannelInboundEventContext({
+      return core.channel.inbound.buildContext({
         channel: "feishu",
         supplemental: {
           quote: quotedContent ? { id: ctx.parentId, body: quotedContent } : undefined,

--- a/extensions/feishu/src/comment-handler.test.ts
+++ b/extensions/feishu/src/comment-handler.test.ts
@@ -1,4 +1,5 @@
 // Feishu tests cover comment handler plugin behavior.
+import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
 import { handleFeishuCommentEvent } from "./comment-handler.js";
@@ -147,6 +148,7 @@ function createTestRuntime(overrides?: {
         recordInboundSession,
       },
       inbound: {
+        buildContext: buildChannelInboundEventContext,
         run: vi.fn(async (params: Parameters<PluginRuntime["channel"]["inbound"]["run"]>[0]) => {
           const input = await params.adapter.ingest(params.raw);
           if (!input) {

--- a/extensions/feishu/src/comment-handler.ts
+++ b/extensions/feishu/src/comment-handler.ts
@@ -1,5 +1,4 @@
 // Feishu plugin module implements comment handler behavior.
-import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
 import { bindIngressLifecycleToReplyOptions } from "openclaw/plugin-sdk/channel-outbound";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
@@ -222,7 +221,7 @@ export async function handleFeishuCommentEvent(
   const conversationLabel = turn.documentTitle
     ? `Feishu comment · ${turn.documentTitle}`
     : "Feishu comment";
-  const ctxPayload = buildChannelInboundEventContext({
+  const ctxPayload = core.channel.inbound.buildContext({
     channel: "feishu",
     accountId: route.accountId,
     surface: "feishu-comment",

--- a/extensions/imessage/src/monitor.plugin-payload.test.ts
+++ b/extensions/imessage/src/monitor.plugin-payload.test.ts
@@ -16,7 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { createIMessageRpcClient } from "./client.js";
 import { monitorIMessageProvider } from "./monitor.js";
 import { setCachedIMessagePrivateApiStatus } from "./private-api-status.js";
-import { getIMessageRuntime } from "./runtime.js";
+import { getIMessageRuntime, setIMessageRuntime } from "./runtime.js";
 import { installIMessageStateRuntimeForTest } from "./test-support/runtime.js";
 
 const waitForTransportReadyMock = vi.hoisted(() =>
@@ -199,6 +199,17 @@ describe("iMessage plugin payload attachments", () => {
           },
         }),
       );
+      const pluginRuntime = getIMessageRuntime();
+      const inbound = pluginRuntime.channel.inbound;
+      const buildContext = vi.fn(inbound.buildContext);
+      const run = vi.fn(inbound.run);
+      setIMessageRuntime({
+        ...pluginRuntime,
+        channel: {
+          ...pluginRuntime.channel,
+          inbound: { ...inbound, buildContext, run },
+        },
+      });
 
       const nativeClient = {
         request: vi.fn(async (method: string) => {
@@ -255,6 +266,14 @@ describe("iMessage plugin payload attachments", () => {
         } as never,
         runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
       });
+
+      expect(buildContext).toHaveBeenCalledWith(expect.objectContaining({ channel: "imessage" }));
+      expect(run).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: "imessage",
+          raw: expect.objectContaining({ kind: "dispatch" }),
+        }),
+      );
 
       if (!visible) {
         expect(nativeClient.request).not.toHaveBeenCalled();

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -882,6 +882,8 @@ export async function buildIMessageInboundContext(params: {
   cfg: OpenClawConfig;
   decision: IMessageInboundDispatchDecision;
   message: IMessagePayload;
+  /** Trusted monitor ingress supplies its paired runtime builder. */
+  buildContext?: typeof buildChannelInboundEventContext;
   envelopeOptions?: EnvelopeFormatOptions;
   previousTimestamp?: number;
   remoteHost?: string;
@@ -996,7 +998,7 @@ export async function buildIMessageInboundContext(params: {
   const media = await toInboundMediaFactsWithMetadata(
     params.media?.facts?.map((entry) => ({ ...entry, url: entry.url ?? entry.path })),
   );
-  const ctxPayload = buildChannelInboundEventContext({
+  const ctxPayload = (params.buildContext ?? buildChannelInboundEventContext)({
     channel: "imessage",
     supplemental: {
       quote: decision.replyContext

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -6,7 +6,6 @@ import {
   createChannelInboundDebouncer,
   formatInboundMediaUnavailableText,
   resolveEnvelopeFormatOptions,
-  runChannelInboundEvent,
   shouldDebounceTextInbound,
   type ChannelInboundTurnPlan,
   type ChannelInboundMediaInput,
@@ -72,6 +71,7 @@ import {
   maybeResolveIMessageQuestionReaction,
 } from "../question-reactions.js";
 import { resolveIMessageRemoteHost } from "../remote-host.js";
+import { getIMessageRuntime } from "../runtime.js";
 import { sendMessageIMessage } from "../send.js";
 import { normalizeIMessageHandle } from "../targets.js";
 import { attachIMessageMonitorAbortHandler } from "./abort-handler.js";
@@ -349,6 +349,8 @@ async function waitForWatchSubscribeRetryDelay(params: {
 export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): Promise<void> {
   const runtime = resolveRuntime(opts);
   const cfg = opts.config ?? getRuntimeConfig();
+  // Capture one trusted facade so the builder and runner carry the same ingress capability.
+  const inbound = getIMessageRuntime().channel.inbound;
   const accountInfo = resolveIMessageAccount({
     cfg,
     accountId: opts.accountId,
@@ -1049,6 +1051,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       cfg,
       decision: contextDecision,
       message,
+      buildContext: inbound.buildContext,
       previousTimestamp,
       remoteHost,
       historyLimit,
@@ -1226,7 +1229,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       sessionKey: decision.route.sessionKey,
     });
 
-    await runChannelInboundEvent({
+    await inbound.run({
       channel: "imessage",
       accountId: decision.route.accountId,
       raw: decision,

--- a/extensions/imessage/src/test-support/runtime.ts
+++ b/extensions/imessage/src/test-support/runtime.ts
@@ -1,6 +1,7 @@
 // Imessage plugin module implements runtime behavior.
 import fs from "node:fs";
 import path from "node:path";
+import * as channelInbound from "openclaw/plugin-sdk/channel-inbound";
 import type {
   OpenKeyedStoreOptions,
   PluginStateSyncKeyedStore,
@@ -25,6 +26,15 @@ function createIMessageTestEnv(): NodeJS.ProcessEnv & { OPENCLAW_STATE_DIR: stri
 }
 
 let imessageTestEnv = createIMessageTestEnv();
+
+function createIMessageInboundRuntimeForTest() {
+  return {
+    buildContext: (...args: Parameters<PluginRuntime["channel"]["inbound"]["buildContext"]>) =>
+      channelInbound.buildChannelInboundEventContext(...args),
+    run: (...args: Parameters<PluginRuntime["channel"]["inbound"]["run"]>) =>
+      channelInbound.runChannelInboundEvent(...args),
+  };
+}
 
 export function createIMessagePluginStateSyncStoreForTest<T>(
   options: OpenKeyedStoreOptions,
@@ -60,7 +70,7 @@ export function installIMessageStateRuntimeForTest(): void {
           options,
         )) as PluginRuntime["state"]["openSyncKeyedStore"],
     },
-    channel: {},
+    channel: { inbound: createIMessageInboundRuntimeForTest() },
   } as PluginRuntime);
   createIMessagePluginStateSyncStoreForTest({
     namespace: "imessage.reply-cache",
@@ -103,7 +113,7 @@ export async function loadFreshIMessageReplyCacheForTest(options?: {
           storeOptions,
         )) as PluginRuntime["state"]["openSyncKeyedStore"],
     },
-    channel: {},
+    channel: { inbound: createIMessageInboundRuntimeForTest() },
   } as PluginRuntime);
   createIMessagePluginStateSyncStoreForTest({
     namespace: "imessage.reply-cache",
@@ -137,6 +147,6 @@ export function installIMessageFailingStateRuntimeForTest(): void {
         throw new Error("test plugin-state failure");
       }) as PluginRuntime["state"]["openSyncKeyedStore"],
     },
-    channel: {},
+    channel: { inbound: createIMessageInboundRuntimeForTest() },
   } as PluginRuntime);
 }

--- a/extensions/irc/src/inbound.ts
+++ b/extensions/irc/src/inbound.ts
@@ -1,6 +1,5 @@
 // Irc plugin module implements inbound behavior.
 import {
-  buildChannelInboundEventContext,
   logInboundDrop,
   resolveChannelInboundRouteEnvelope,
 } from "openclaw/plugin-sdk/channel-inbound";
@@ -442,7 +441,7 @@ export async function handleIrcInbound(params: {
   const groupSystemPrompt = normalizeOptionalString(groupMatch.groupConfig?.systemPrompt);
   const blockStreamingEnabled = resolveChannelStreamingBlockEnabled(account.config);
 
-  const ctxPayload = buildChannelInboundEventContext({
+  const ctxPayload = core.channel.inbound.buildContext({
     channel: CHANNEL_ID,
     accountId: route.accountId,
     messageId: message.messageId,

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -245,6 +245,7 @@ function createTestMessageEvent(params: {
 
 function createLineWebhookTestContext(params: {
   processMessage: LineWebhookContext["processMessage"];
+  inbound?: LineWebhookContext["inbound"];
   groupPolicy?: LineAccountConfig["groupPolicy"];
   dmPolicy?: LineAccountConfig["dmPolicy"];
   allowFrom?: LineAccountConfig["allowFrom"];
@@ -281,6 +282,7 @@ function createLineWebhookTestContext(params: {
     runtime: createRuntime(),
     mediaMaxBytes: 1,
     processMessage: params.processMessage,
+    ...(params.inbound ? { inbound: params.inbound } : {}),
     ...(params.groupHistories ? { groupHistories: params.groupHistories } : {}),
   };
 }
@@ -352,6 +354,53 @@ describe("handleLineWebhookEvents", () => {
       throw new Error("downloadLineMedia should not be called from bot-handlers tests");
     });
   });
+
+  it("threads one supplied facade into both message and postback context builders", async () => {
+    const processMessage = vi.fn();
+    const inbound = {
+      buildContext: vi.fn(),
+      run: vi.fn(),
+    } as LineWebhookContext["inbound"];
+    const context = createLineWebhookTestContext({
+      processMessage,
+      inbound,
+      groupPolicy: "open",
+      requireMention: false,
+    });
+    const postback = {
+      type: "postback",
+      postback: { data: "action=select" },
+      replyToken: "postback-token",
+      timestamp: Date.now(),
+      source: { type: "group", groupId: "group-1", userId: "user-1" },
+      mode: "active",
+      webhookEventId: "postback-facade",
+      deliveryContext: { isRedelivery: false },
+    } as webhook.PostbackEvent;
+    buildLinePostbackContextMock.mockResolvedValueOnce({
+      ctxPayload: { From: "line:group:group-1" },
+      replyToken: "postback-token",
+      route: { agentId: "default" },
+      isGroup: true,
+      accountId: "default",
+    });
+
+    await handleLineWebhookEvents(
+      [
+        createTestMessageEvent({
+          message: { id: "facade-message", type: "text", text: "hi", quoteToken: "q" },
+          source: { type: "group", groupId: "group-1", userId: "user-1" },
+          webhookEventId: "message-facade",
+        }),
+        postback,
+      ],
+      context,
+    );
+
+    expect(buildLineMessageContextMock).toHaveBeenCalledWith(expect.objectContaining({ inbound }));
+    expect(buildLinePostbackContextMock).toHaveBeenCalledWith(expect.objectContaining({ inbound }));
+  });
+
   it("blocks group messages when groupPolicy is disabled", async () => {
     const processMessage = vi.fn();
     const event = {

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -38,6 +38,7 @@ import {
   buildLinePostbackContext,
   getLineSourceInfo,
   type LineInboundContext,
+  type LineInboundRuntime,
 } from "./bot-message-context.js";
 import { downloadLineMedia, isRetryableLineInboundMediaError } from "./download.js";
 import { reserveLineGroupHistory } from "./group-history.js";
@@ -77,6 +78,7 @@ interface LineHandlerContext {
   account: ResolvedLineAccount;
   runtime: RuntimeEnv;
   mediaMaxBytes: number;
+  inbound?: LineInboundRuntime;
   processMessage: (
     ctx: LineInboundContext,
     control: { turnAdoptionLifecycle?: LineWebhookTurnAdoptionLifecycle },
@@ -448,6 +450,7 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
       account,
       commandAuthorized: decision.commandAccess.authorized,
       inboundHistory: historyReservation.inboundHistory,
+      ...(context.inbound ? { inbound: context.inbound } : {}),
     });
 
     if (!messageContext) {
@@ -505,6 +508,7 @@ async function handlePostbackEvent(
     cfg: context.cfg,
     account: context.account,
     commandAuthorized: decision.commandAccess.authorized,
+    ...(context.inbound ? { inbound: context.inbound } : {}),
   });
   if (!postbackContext) {
     return;

--- a/extensions/line/src/bot-message-context.test.ts
+++ b/extensions/line/src/bot-message-context.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { webhook } from "@line/bot-sdk";
+import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { getSessionBindingService } from "openclaw/plugin-sdk/conversation-runtime";
 import { testing as sessionBindingTesting } from "openclaw/plugin-sdk/conversation-runtime";
@@ -12,7 +13,11 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { lineBindingsAdapter } from "./bindings.js";
-import { buildLineMessageContext, buildLinePostbackContext } from "./bot-message-context.js";
+import {
+  buildLineMessageContext,
+  buildLinePostbackContext,
+  type LineInboundRuntime,
+} from "./bot-message-context.js";
 import type { ResolvedLineAccount } from "./types.js";
 
 const logVerboseMock = vi.hoisted(() => vi.fn());
@@ -125,6 +130,26 @@ describe("buildLineMessageContext", () => {
 
     expect(context?.ctxPayload.OriginatingTo).toBe("line:group:group-1");
     expect(context?.ctxPayload.To).toBe("line:group:group-1");
+  });
+
+  it("uses and preserves the injected inbound facade for a message", async () => {
+    const inbound = {
+      buildContext: vi.fn(buildChannelInboundEventContext),
+      run: vi.fn(),
+    } as unknown as LineInboundRuntime;
+    const context = await buildLineMessageContext({
+      event: createMessageEvent({ type: "user", userId: "user-facade" }),
+      allMedia: [],
+      cfg,
+      account,
+      commandAuthorized: true,
+      inbound,
+    });
+
+    expect(inbound.buildContext).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "line", messageId: "1" }),
+    );
+    expect(context?.inbound).toBe(inbound);
   });
 
   it("passes the caller-provided inbound history through to the context payload", async () => {
@@ -251,6 +276,25 @@ describe("buildLineMessageContext", () => {
 
     expect(context?.ctxPayload.OriginatingTo).toBe("line:group:group-2");
     expect(context?.ctxPayload.To).toBe("line:group:group-2");
+  });
+
+  it("uses and preserves the injected inbound facade for a postback", async () => {
+    const inbound = {
+      buildContext: vi.fn(buildChannelInboundEventContext),
+      run: vi.fn(),
+    } as unknown as LineInboundRuntime;
+    const context = await buildLinePostbackContext({
+      event: createPostbackEvent({ type: "user", userId: "user-facade" }),
+      cfg,
+      account,
+      commandAuthorized: true,
+      inbound,
+    });
+
+    expect(inbound.buildContext).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "line", messageId: "postback:reply-token" }),
+    );
+    expect(context?.inbound).toBe(inbound);
   });
 
   it("routes room postback replies to the room id", async () => {

--- a/extensions/line/src/bot-message-context.ts
+++ b/extensions/line/src/bot-message-context.ts
@@ -18,6 +18,7 @@ import {
   resolveConfiguredBindingRoute,
   resolveRuntimeConversationBindingRoute,
 } from "openclaw/plugin-sdk/conversation-runtime";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { resolveAgentRoute, resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -37,6 +38,8 @@ interface MediaRef {
   contentType?: string;
 }
 
+export type LineInboundRuntime = Pick<PluginRuntime["channel"]["inbound"], "buildContext" | "run">;
+
 interface BuildLineMessageContextParams {
   event: MessageEvent;
   allMedia: MediaRef[];
@@ -45,6 +48,8 @@ interface BuildLineMessageContextParams {
   account: ResolvedLineAccount;
   commandAuthorized: boolean;
   inboundHistory?: HistoryEntry[];
+  /** The plugin-scoped paired facade for a real webhook ingress turn. */
+  inbound?: LineInboundRuntime;
 }
 
 type LineSourceInfo = {
@@ -262,6 +267,7 @@ async function finalizeLineInboundContext(params: {
   locationContext?: ReturnType<typeof toLocationContext>;
   verboseLog: { kind: "inbound" | "postback"; mediaCount?: number };
   inboundHistory?: Pick<HistoryEntry, "sender" | "body" | "timestamp">[];
+  inbound?: LineInboundRuntime;
 }) {
   const senderId = params.source.userId ?? "unknown";
   const senderLabel = params.source.userId ? `user:${params.source.userId}` : "unknown";
@@ -299,7 +305,9 @@ async function finalizeLineInboundContext(params: {
     envelope: envelopeOptions,
   });
 
-  const ctxPayload = buildChannelInboundEventContext({
+  // Unit callers without the runtime facade deliberately use the public builder,
+  // which remains unprivileged. A live webhook receives its paired facade below.
+  const ctxPayload = (params.inbound?.buildContext ?? buildChannelInboundEventContext)({
     channel: "line",
     accountId: params.route.accountId,
     messageId: params.messageSid,
@@ -409,8 +417,16 @@ async function finalizeLineInboundContext(params: {
 }
 
 export async function buildLineMessageContext(params: BuildLineMessageContextParams) {
-  const { event, allMedia, mediaUnavailable, cfg, account, commandAuthorized, inboundHistory } =
-    params;
+  const {
+    event,
+    allMedia,
+    mediaUnavailable,
+    cfg,
+    account,
+    commandAuthorized,
+    inboundHistory,
+    inbound,
+  } = params;
 
   const source = event.source;
   const { userId, groupId, roomId, isGroup, peerId, route } = await resolveLineInboundRoute({
@@ -469,6 +485,7 @@ export async function buildLineMessageContext(params: BuildLineMessageContextPar
     locationContext,
     verboseLog: { kind: "inbound", mediaCount: allMedia.length },
     inboundHistory,
+    inbound,
   });
 
   return {
@@ -482,6 +499,7 @@ export async function buildLineMessageContext(params: BuildLineMessageContextPar
     route,
     replyToken: event.replyToken,
     accountId: account.accountId,
+    ...(inbound ? { inbound } : {}),
   };
 }
 
@@ -490,8 +508,9 @@ export async function buildLinePostbackContext(params: {
   cfg: OpenClawConfig;
   account: ResolvedLineAccount;
   commandAuthorized: boolean;
+  inbound?: LineInboundRuntime;
 }) {
-  const { event, cfg, account, commandAuthorized } = params;
+  const { event, cfg, account, commandAuthorized, inbound } = params;
 
   const source = event.source;
   const { userId, groupId, roomId, isGroup, peerId, route } = await resolveLineInboundRoute({
@@ -526,6 +545,7 @@ export async function buildLinePostbackContext(params: {
     commandAuthorized,
     media: [],
     verboseLog: { kind: "postback" },
+    inbound,
   });
 
   return {
@@ -539,6 +559,7 @@ export async function buildLinePostbackContext(params: {
     route,
     replyToken: event.replyToken,
     accountId: account.accountId,
+    ...(inbound ? { inbound } : {}),
   };
 }
 

--- a/extensions/line/src/bot.ts
+++ b/extensions/line/src/bot.ts
@@ -10,7 +10,7 @@ import {
 } from "openclaw/plugin-sdk/runtime-env";
 import { resolveLineAccount } from "./accounts.js";
 import { handleLineWebhookEvents } from "./bot-handlers.js";
-import type { LineInboundContext } from "./bot-message-context.js";
+import type { LineInboundContext, LineInboundRuntime } from "./bot-message-context.js";
 import type { ResolvedLineAccount } from "./types.js";
 import { createLineWebhookSpool, type LineWebhookTurnAdoptionLifecycle } from "./webhook-spool.js";
 
@@ -21,6 +21,8 @@ interface LineBotOptions {
   runtime?: RuntimeEnv;
   config?: OpenClawConfig;
   mediaMaxMb?: number;
+  /** Resolves the plugin-scoped facade only while processing a durable webhook event. */
+  inbound: () => LineInboundRuntime;
   onMessage?: (
     ctx: LineInboundContext,
     control: { turnAdoptionLifecycle?: LineWebhookTurnAdoptionLifecycle },
@@ -53,19 +55,22 @@ export function createLineBot(opts: LineBotOptions): LineBot {
   const spool = createLineWebhookSpool({
     accountId: account.accountId,
     runtime,
-    deliver: async (event, _destination, control) =>
+    deliver: async (event, _destination, control) => {
+      const inbound = opts.inbound();
       await handleLineWebhookEvents([event], {
         cfg,
         account,
         runtime,
         mediaMaxBytes,
+        inbound,
         processMessage,
         ...(control.turnAdoptionLifecycle
           ? { turnAdoptionLifecycle: control.turnAdoptionLifecycle }
           : {}),
         groupHistories,
         historyLimit: cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
-      }),
+      });
+    },
   });
   spool.start();
 

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -155,6 +155,7 @@ export async function monitorLineProvider(
     accountId,
     runtime,
     config,
+    inbound: () => getLineRuntime().channel.inbound,
     onMessage: async (ctx, deliveryControl) => {
       if (!ctx) {
         return;
@@ -184,8 +185,11 @@ export async function monitorLineProvider(
 
       try {
         const textLimit = 5000;
-        const core = getLineRuntime();
-        const turnResult = await core.channel.inbound.run({
+        const inbound = ctx.inbound;
+        if (!inbound) {
+          throw new Error("LINE inbound context was not built by the plugin-scoped facade.");
+        }
+        const turnResult = await inbound.run({
           channel: "line",
           accountId: route.accountId,
           raw: ctx,

--- a/extensions/matrix/src/matrix/monitor/handler-context.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-context.ts
@@ -1,5 +1,4 @@
 import {
-  buildChannelInboundEventContext,
   createChannelInboundEnvelopeBuilder,
   toInboundMediaFactsWithMetadata,
 } from "openclaw/plugin-sdk/channel-inbound";
@@ -219,7 +218,7 @@ export async function resolveMatrixInboundContext(config: {
       senderAllowed: replySenderAllowed,
     }).include,
   );
-  const ctxPayload = buildChannelInboundEventContext({
+  const ctxPayload = core.channel.inbound.buildContext({
     channel: "matrix",
     contextVisibility: contextVisibilityMode,
     finalize: finalizeInboundContext,

--- a/extensions/msteams/src/monitor-handler/inbound-dispatch.ts
+++ b/extensions/msteams/src/monitor-handler/inbound-dispatch.ts
@@ -1,6 +1,5 @@
 // Msteams plugin module dispatches prepared inbound turns and owns reply lifecycle handling.
 import {
-  buildChannelInboundEventContext,
   createChannelInboundEnvelopeBuilder,
   hasFinalInboundReplyDispatch,
   resolveInboundReplyDispatchCounts,
@@ -145,7 +144,7 @@ export async function dispatchMSTeamsInboundTurn(params: {
   // Teams channel actions need both the AAD group and Graph channel ids.
   const nativeChannelId =
     isChannel && teamAadGroupId ? `${teamAadGroupId}/${graphChannelId}` : undefined;
-  const ctxPayload = buildChannelInboundEventContext({
+  const ctxPayload = core.channel.inbound.buildContext({
     channel: "msteams",
     contextVisibility: contextVisibilityMode,
     supplemental: {

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -1,7 +1,4 @@
-import {
-  buildChannelInboundEventContext,
-  resolveChannelInboundRouteEnvelope,
-} from "openclaw/plugin-sdk/channel-inbound";
+import { resolveChannelInboundRouteEnvelope } from "openclaw/plugin-sdk/channel-inbound";
 // Nextcloud Talk plugin module implements inbound behavior.
 import {
   channelIngressRoutes,
@@ -332,7 +329,7 @@ export async function handleNextcloudTalkInbound(params: {
   const groupSystemPrompt = normalizeOptionalString(roomConfig?.systemPrompt);
   const blockStreamingEnabled = resolveChannelStreamingBlockEnabled(account.config);
 
-  const ctxPayload = buildChannelInboundEventContext({
+  const ctxPayload = core.channel.inbound.buildContext({
     channel: CHANNEL_ID,
     accountId: route.accountId,
     messageId: message.messageId,

--- a/extensions/nostr/src/channel.inbound.test.ts
+++ b/extensions/nostr/src/channel.inbound.test.ts
@@ -1,4 +1,4 @@
-import type { dispatchInboundDirectDm as DispatchInboundDirectDm } from "openclaw/plugin-sdk/channel-inbound";
+import type { dispatchInboundDirectDmWithRuntime as DispatchInboundDirectDmWithRuntime } from "openclaw/plugin-sdk/channel-inbound";
 // Nostr tests cover channel.inbound plugin behavior.
 import { createStartAccountContext } from "openclaw/plugin-sdk/channel-test-helpers";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -9,7 +9,7 @@ import { setNostrRuntime } from "./runtime.js";
 import { buildResolvedNostrAccount } from "./test-fixtures.js";
 
 const mocks = vi.hoisted(() => ({
-  dispatchInboundDirectDm: vi.fn(),
+  dispatchInboundDirectDmWithRuntime: vi.fn(),
   normalizePubkey: vi.fn((value: string) =>
     value
       .trim()
@@ -21,7 +21,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>()),
-  dispatchInboundDirectDm: mocks.dispatchInboundDirectDm,
+  dispatchInboundDirectDmWithRuntime: mocks.dispatchInboundDirectDmWithRuntime,
 }));
 vi.mock("./nostr-bus.js", () => ({
   DEFAULT_RELAYS: ["wss://relay.example.com"],
@@ -136,7 +136,7 @@ function mockCallArg(mock: ReturnType<typeof vi.fn>, callIndex = 0, argIndex = 0
 
 describe("nostr inbound gateway path", () => {
   afterEach(() => {
-    mocks.dispatchInboundDirectDm.mockReset();
+    mocks.dispatchInboundDirectDmWithRuntime.mockReset();
     mocks.normalizePubkey.mockClear();
     mocks.startNostrBus.mockReset();
   });
@@ -169,8 +169,8 @@ describe("nostr inbound gateway path", () => {
   });
 
   it("routes allowed DMs through the standard reply pipeline", async () => {
-    mocks.dispatchInboundDirectDm.mockImplementationOnce(
-      async (params: Parameters<typeof DispatchInboundDirectDm>[0]) => {
+    mocks.dispatchInboundDirectDmWithRuntime.mockImplementationOnce(
+      async (params: Parameters<typeof DispatchInboundDirectDmWithRuntime>[0]) => {
         await params.deliver({ text: "**Table:** [docs](https://example.com)" });
         await params.deliver({ text: "***" });
       },
@@ -212,8 +212,9 @@ describe("nostr inbound gateway path", () => {
       lifecycle,
     );
 
-    expect(mocks.dispatchInboundDirectDm).toHaveBeenCalledWith(
+    expect(mocks.dispatchInboundDirectDmWithRuntime).toHaveBeenCalledWith(
       expect.objectContaining({
+        runtime: harness.runtime,
         channel: "nostr",
         accountId: "default",
         peer: { kind: "direct", id: "sender-pubkey" },
@@ -263,8 +264,8 @@ describe("nostr inbound gateway path", () => {
       expected: "The relay has two active subscriptions.",
     },
   ])("$name before sending an inbound Nostr DM reply", async ({ text, expected }) => {
-    mocks.dispatchInboundDirectDm.mockImplementationOnce(
-      async (params: Parameters<typeof DispatchInboundDirectDm>[0]) => {
+    mocks.dispatchInboundDirectDmWithRuntime.mockImplementationOnce(
+      async (params: Parameters<typeof DispatchInboundDirectDmWithRuntime>[0]) => {
         await params.deliver({ text });
       },
     );

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -179,8 +179,10 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
             return;
           }
 
-          const { dispatchInboundDirectDm } = await import("./inbound-direct-dm-runtime.js");
-          await dispatchInboundDirectDm({
+          const { dispatchInboundDirectDmWithRuntime } =
+            await import("./inbound-direct-dm-runtime.js");
+          await dispatchInboundDirectDmWithRuntime({
+            runtime,
             cfg: ctx.cfg,
             channel: "nostr",
             channelLabel: "Nostr",

--- a/extensions/nostr/src/inbound-direct-dm-runtime.ts
+++ b/extensions/nostr/src/inbound-direct-dm-runtime.ts
@@ -1,2 +1,2 @@
-// Nostr plugin module implements inbound direct dm runtime behavior.
-export { dispatchInboundDirectDm } from "openclaw/plugin-sdk/channel-inbound";
+// Nostr plugin module implements trusted inbound direct-DM runtime behavior.
+export { dispatchInboundDirectDmWithRuntime } from "openclaw/plugin-sdk/channel-inbound";

--- a/extensions/qa-channel/src/inbound.test.ts
+++ b/extensions/qa-channel/src/inbound.test.ts
@@ -463,8 +463,10 @@ describe("handleQaInbound", () => {
       }),
     );
 
+    expect(runtime.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
     expect(runtime.channel.inbound.dispatch).toHaveBeenCalledTimes(1);
     const ctxPayload = firstRunAssembledParams(runtime).ctxPayload;
+    expect(ctxPayload).toBe(vi.mocked(runtime.channel.inbound.buildContext).mock.results[0]?.value);
     expect(ctxPayload?.CommandAuthorized).toBe(true);
     expect(ctxPayload?.SenderId).toBe("alice");
   });

--- a/extensions/qa-channel/src/inbound.ts
+++ b/extensions/qa-channel/src/inbound.ts
@@ -1,5 +1,4 @@
 import {
-  buildChannelInboundEventContext,
   resolveChannelInboundRouteEnvelope,
   toInboundMediaFactsWithMetadata,
 } from "openclaw/plugin-sdk/channel-inbound";
@@ -357,7 +356,7 @@ export async function handleQaInbound(params: {
       })
     : undefined;
   const sessionKey = commandTargets?.sessionKey ?? route.sessionKey;
-  const ctxPayload = buildChannelInboundEventContext({
+  const ctxPayload = runtime.channel.inbound.buildContext({
     channel: params.channelId,
     accountId: route.accountId ?? params.account.accountId,
     messageId: inbound.id,

--- a/extensions/qqbot/src/engine/gateway/inbound-pipeline.self-echo.test.ts
+++ b/extensions/qqbot/src/engine/gateway/inbound-pipeline.self-echo.test.ts
@@ -173,6 +173,7 @@ function makeRuntime(): GatewayPluginRuntime {
         recordInboundSession: vi.fn(async () => undefined),
       },
       inbound: {
+        buildContext: vi.fn(),
         run: vi.fn(async (rawParams: unknown) => {
           const params = rawParams as {
             raw: unknown;

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -121,6 +121,41 @@ function makeInboundRuntime(
   onResolvedTurn?: (turn: Record<string, unknown>) => void,
 ): GatewayPluginRuntime["channel"]["inbound"] {
   return {
+    buildContext: vi.fn((rawParams: unknown) => {
+      const params = rawParams as {
+        channel: string;
+        accountId?: string;
+        from: string;
+        sender: { id: string; name?: string };
+        conversation: { kind: string };
+        route: { accountId?: string; dispatchSessionKey?: string; routeSessionKey?: string };
+        reply: { to: string };
+        message: { body?: string; bodyForAgent?: string; rawBody: string; commandBody?: string };
+        access?: { commands?: { authorized?: boolean } };
+        command?: { kind: string };
+        media?: unknown;
+        extra?: Record<string, unknown>;
+      };
+      return {
+        Body: params.message.body ?? params.message.rawBody,
+        BodyForAgent: params.message.bodyForAgent ?? params.message.rawBody,
+        RawBody: params.message.rawBody,
+        CommandBody: params.message.commandBody ?? params.message.rawBody,
+        From: params.from,
+        To: params.reply.to,
+        SessionKey: params.route.dispatchSessionKey ?? params.route.routeSessionKey,
+        AccountId: params.route.accountId ?? params.accountId,
+        ChatType: params.conversation.kind,
+        SenderId: params.sender.id,
+        SenderName: params.sender.name,
+        Provider: params.channel,
+        Surface: params.channel,
+        CommandAuthorized: params.access?.commands?.authorized ?? false,
+        ...(params.command?.kind === "text-slash" ? { CommandSource: "text" } : {}),
+        ...(params.media ? { media: params.media } : {}),
+        ...params.extra,
+      };
+    }) as GatewayPluginRuntime["channel"]["inbound"]["buildContext"],
     run: vi.fn(async (rawParams: unknown) => {
       const params = rawParams as {
         raw: unknown;
@@ -1017,6 +1052,7 @@ describe("dispatchOutbound", () => {
       { runtime, cfg: { commands: { text: true } }, account },
     );
 
+    expect(runtime.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
     expect(finalized?.CommandBody).toBe("/models");
     expect(finalized?.CommandAuthorized).toBe(true);
     expect(finalized?.CommandSource).toBe("text");

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -11,7 +11,6 @@
  */
 
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
-import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
 import { bindIngressLifecycleToReplyOptions } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "openclaw/plugin-sdk/reply-chunking";
@@ -794,7 +793,7 @@ async function buildCtxPayload(
     })),
     ...inbound.remoteMediaUrls.map((url) => ({ url, kind: "image" as const })),
   ];
-  return buildChannelInboundEventContext({
+  return runtime.channel.inbound.buildContext({
     channel: "qqbot",
     accountId: inbound.route.accountId,
     messageId: event.messageId,

--- a/extensions/qqbot/src/engine/gateway/stages/access-stage.test.ts
+++ b/extensions/qqbot/src/engine/gateway/stages/access-stage.test.ts
@@ -71,7 +71,7 @@ function buildRuntime(
         resolveStorePath: vi.fn(() => ""),
         recordInboundSession: vi.fn(async () => undefined),
       },
-      inbound: { run: vi.fn(async () => undefined) },
+      inbound: { buildContext: vi.fn(), run: vi.fn(async () => undefined) },
       text: { chunkMarkdownText: vi.fn(() => []) },
     },
     tts: { textToSpeech: vi.fn() },

--- a/extensions/qqbot/src/engine/gateway/types.ts
+++ b/extensions/qqbot/src/engine/gateway/types.ts
@@ -1,3 +1,7 @@
+import type {
+  BuildChannelInboundEventContextParams,
+  BuiltChannelInboundEventContext,
+} from "openclaw/plugin-sdk/channel-inbound";
 import type { ChannelIngressQueue } from "openclaw/plugin-sdk/channel-outbound";
 // Qqbot type declarations define plugin contracts.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
@@ -52,6 +56,9 @@ export interface GatewayPluginRuntime {
       recordInboundSession: (params: unknown) => Promise<unknown>;
     };
     inbound: {
+      buildContext: (
+        params: BuildChannelInboundEventContextParams,
+      ) => BuiltChannelInboundEventContext;
       run: (params: unknown) => Promise<unknown>;
     };
     text: {

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -54,6 +54,7 @@ import { isSignalSenderAllowed, type resolveSignalSender } from "./identity.js";
 import { createSignalEventHandler } from "./monitor/event-handler.js";
 import type {
   SignalAttachment,
+  SignalInboundCore,
   SignalNativeReplyContext,
   SignalReactionMessage,
   SignalReactionTarget,
@@ -93,6 +94,27 @@ export type MonitorSignalOpts = {
   waitForTransportReady?: typeof waitForTransportReady;
   statusSink?: SignalStatusSink;
 };
+
+function hasSignalInboundCoreFacade(
+  value: unknown,
+): value is SignalInboundCore["channel"]["inbound"] {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { buildContext?: unknown }).buildContext === "function" &&
+    typeof (value as { run?: unknown }).run === "function"
+  );
+}
+
+function resolveSignalInboundCore(
+  channelRuntime: ChannelRuntimeSurface | undefined,
+): SignalInboundCore | undefined {
+  // Gateway startup supplies the full plugin channel runtime, while this public
+  // option intentionally exposes only its compatibility surface. Keep just the
+  // paired ingress capability; direct monitor callers retain unprivileged helpers.
+  const inbound = (channelRuntime as { inbound?: unknown } | undefined)?.inbound;
+  return hasSignalInboundCoreFacade(inbound) ? { channel: { inbound } } : undefined;
+}
 
 function createSignalMonitorTaskRunner(runtime: RuntimeEnv) {
   const inFlight = new Set<Promise<void>>();
@@ -501,6 +523,7 @@ function createSignalNativeReplyResolver(params: {
 
 export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promise<void> {
   const runtime = opts.runtime ?? createNonExitingRuntime();
+  const core = resolveSignalInboundCore(opts.channelRuntime);
   const cfg = opts.config ?? getRuntimeConfig();
   const accountInfo = resolveSignalAccount({
     cfg,
@@ -623,6 +646,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
     });
 
     const handleEvent = createSignalEventHandler({
+      ...(core ? { core } : {}),
       runtime,
       abortSignal: daemonLifecycle.abortSignal,
       runTrackedTask: (task) => {

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -414,6 +414,27 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(contextWithBody.Body ?? "").not.toContain("[from:");
   });
 
+  it("uses one injected core facade to build and run a normal inbound turn", async () => {
+    const inbound = await import("openclaw/plugin-sdk/channel-inbound");
+    const buildContext = vi.fn(inbound.buildChannelInboundEventContext);
+    const run = vi.fn(inbound.runChannelInboundEvent);
+    const handler = createTestHandler({
+      core: {
+        channel: {
+          inbound: {
+            buildContext: buildContext as typeof inbound.buildChannelInboundEventContext,
+            run: run as typeof inbound.runChannelInboundEvent,
+          },
+        },
+      },
+    });
+
+    await receiveDirectMessage(handler, { dataMessage: { message: "paired ingress" } });
+
+    expect(buildContext).toHaveBeenCalledOnce();
+    expect(run).toHaveBeenCalledOnce();
+  });
+
   it("normalizes direct chat To/OriginatingTo targets to canonical Signal ids", async () => {
     const handler = createTestHandler({
       cfg: { messages: { inbound: { debounceMs: 0 } } } as OpenClawConfig,

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -181,6 +181,10 @@ async function finalizeSignalStatusReaction(params: {
 export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   const statusReactionTiming = deps.statusReactionTiming ?? DEFAULT_TIMING;
   const activeEnqueueEntries = new WeakSet<SignalInboundEntry>();
+  // The opaque core capability recognizes the exact context object it built.
+  // Keep this builder and runner from one injected facade or fall back to public,
+  // unprivileged helpers.
+  const inbound = deps.core?.channel.inbound;
 
   async function handleSignalInboundMessage(entry: SignalInboundEntry) {
     const fromLabel = formatInboundFromLabel({
@@ -259,7 +263,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       entry.isBatched === true,
     );
     const media = await toInboundMediaFactsWithMetadata(entry.media);
-    const ctxPayload = buildChannelInboundEventContext({
+    const ctxPayload = (inbound?.buildContext ?? buildChannelInboundEventContext)({
       channel: "signal",
       supplemental: {
         quote: entry.replyToBody
@@ -466,7 +470,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       sessionKey: route.sessionKey,
     });
 
-    await runChannelInboundEvent({
+    await (inbound?.run ?? runChannelInboundEvent)({
       channel: "signal",
       accountId: route.accountId,
       raw: entry,

--- a/extensions/signal/src/monitor/event-handler.types.ts
+++ b/extensions/signal/src/monitor/event-handler.types.ts
@@ -6,6 +6,7 @@ import type {
   GroupPolicy,
   SignalReactionNotificationMode,
 } from "openclaw/plugin-sdk/config-contracts";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -90,7 +91,15 @@ export type SignalNativeReplyContext = {
   };
 };
 
+/** The gateway injects this paired capability for Signal's trusted inbound path. */
+export type SignalInboundCore = {
+  channel: {
+    inbound: Pick<PluginRuntime["channel"]["inbound"], "buildContext" | "run">;
+  };
+};
+
 export type SignalEventHandlerDeps = {
+  core?: SignalInboundCore;
   runtime: RuntimeEnv;
   statusReactionTiming?: Required<StatusReactionTiming>;
   abortSignal?: AbortSignal;

--- a/extensions/slack/src/delivery-trace.test.ts
+++ b/extensions/slack/src/delivery-trace.test.ts
@@ -20,10 +20,12 @@ import {
   type TraceNormalizer,
 } from "openclaw/plugin-sdk/channel-contract-testing";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { afterAll, afterEach, describe, it, vi } from "vitest";
 import type { PreparedSlackMessage } from "./monitor/message-handler/types.js";
+import { setSlackRuntime } from "./runtime.js";
 
 type RecordedWireCall = {
   method: string;
@@ -79,38 +81,40 @@ const traceState = vi.hoisted(
   }),
 );
 
-// Replace only the core agent turn. Everything downstream of the captured
-// deliver/typing/replyOptions wiring (dedupe, thread plan, native stream ladder,
-// draft preview, preview finalize, deliverReplies chunking, sendMessageSlack)
-// stays the real production code.
-vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>();
-  type DispatchParams = Parameters<typeof actual.dispatchChannelInboundTurn>[0];
-  return {
-    ...actual,
-    dispatchChannelInboundTurn: async (params: DispatchParams) => {
-      traceState.turn = {
-        options: {
-          ...params.dispatcherOptions,
-          deliver: params.delivery.deliver,
-          onError: params.delivery.onError,
-        } as CapturedDispatcherOptions,
-        replyOptions: (params.replyOptions ?? {}) as CapturedReplyOptions,
-      };
-      traceState.turnStarted?.resolve();
-      if (!traceState.turnOutcome) {
-        throw new Error("trace turn outcome gate not initialized");
-      }
-      return {
-        admission: { kind: "dispatch" },
-        dispatched: true,
-        ctxPayload: params.ctxPayload,
-        routeSessionKey: params.route.sessionKey,
-        dispatchResult: await traceState.turnOutcome.promise,
-      };
+type InboundDispatchPlan = Parameters<PluginRuntime["channel"]["inbound"]["dispatch"]>[0];
+
+// Replace only the core agent turn through the injected inbound facade.
+// Everything downstream of the captured deliver/typing/replyOptions wiring
+// stays real production code.
+function installSlackTraceInboundFacade() {
+  setSlackRuntime({
+    channel: {
+      inbound: {
+        dispatch: async (params: InboundDispatchPlan) => {
+          traceState.turn = {
+            options: {
+              ...params.dispatcherOptions,
+              deliver: params.delivery.deliver,
+              onError: params.delivery.onError,
+            } as CapturedDispatcherOptions,
+            replyOptions: (params.replyOptions ?? {}) as CapturedReplyOptions,
+          };
+          traceState.turnStarted?.resolve();
+          if (!traceState.turnOutcome) {
+            throw new Error("trace turn outcome gate not initialized");
+          }
+          return {
+            admission: { kind: "dispatch" },
+            dispatched: true,
+            ctxPayload: params.ctxPayload,
+            routeSessionKey: params.route.sessionKey,
+            dispatchResult: await traceState.turnOutcome.promise,
+          };
+        },
+      },
     },
-  };
-});
+  } as unknown as PluginRuntime);
+}
 
 // send.ts/actions.ts build their own WebClient from tokens; route every client
 // resolution to the scenario's recording client so all wire calls are captured.
@@ -134,7 +138,6 @@ vi.mock("./client.js", async (importOriginal) => {
 import { dispatchPreparedSlackMessage } from "./monitor/message-handler/dispatch.js";
 
 afterAll(() => {
-  vi.doUnmock("openclaw/plugin-sdk/channel-inbound");
   vi.doUnmock("./client.js");
   vi.resetModules();
 });
@@ -522,6 +525,7 @@ async function setupSlackTrace(
       ? "method_not_supported_for_channel_type"
       : undefined;
   traceState.client = createRecordingSlackClient();
+  installSlackTraceInboundFacade();
 
   const dispatchDone = dispatchPreparedSlackMessage(createPreparedTraceMessage(scenario));
   traceState.dispatchDone = dispatchDone;

--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -1,12 +1,17 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
+import {
+  buildChannelInboundEventContext,
+  dispatchChannelInboundTurn,
+} from "openclaw/plugin-sdk/channel-inbound";
 // Slack helper module supports monitor helpers behavior.
 import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { vi } from "vitest";
@@ -33,6 +38,9 @@ type SlackRunOnceOptions = {
   appToken?: string;
   awaitDispatch?: boolean;
 };
+
+type InboundDispatchPlan = Parameters<PluginRuntime["channel"]["inbound"]["dispatch"]>[0];
+type ReplyResolver = NonNullable<InboundDispatchPlan["replyResolver"]>;
 
 function withSlackDispatchLifecycle(args: unknown): Record<string, unknown> {
   if (!args || typeof args !== "object" || Array.isArray(args)) {
@@ -236,7 +244,7 @@ export function startSlackMonitor(
     appToken: opts?.appToken ?? "app-token",
     abortSignal: controller.signal,
     config: slackTestState.config,
-    channelRuntime: opts?.channelRuntime,
+    channelRuntime: opts?.channelRuntime ?? slackTestChannelRuntime,
     runtime: opts?.runtime,
     setStatus: opts?.setStatus,
   });
@@ -307,6 +315,39 @@ export const defaultSlackTestConfig = () => ({
 });
 
 let lastSlackTestStateDir: string | undefined;
+let slackTestChannelRuntime: PluginRuntime["channel"] | undefined;
+
+function resetSlackTestRuntime(stateDir: string): void {
+  const runtime = createPluginRuntimeMock();
+  const replyResolver: ReplyResolver = (...args) =>
+    slackTestState.replyMock(...args) as ReturnType<ReplyResolver>;
+  const channel = {
+    ...runtime.channel,
+    inbound: {
+      ...runtime.channel.inbound,
+      buildContext: buildChannelInboundEventContext,
+      dispatch: (params: InboundDispatchPlan) =>
+        dispatchChannelInboundTurn({ ...params, replyResolver }),
+    },
+  } satisfies PluginRuntime["channel"];
+  slackTestChannelRuntime = channel;
+  setSlackRuntime({
+    ...runtime,
+    channel,
+    state: {
+      ...runtime.state,
+      openChannelIngressQueue: (
+        options?: Omit<Parameters<typeof createChannelIngressQueueForTests>[0], "channelId">,
+      ) =>
+        createChannelIngressQueueForTests({
+          ...options,
+          channelId: "slack",
+          stateDir: options?.stateDir ?? stateDir,
+        }),
+      resolveStateDir: () => stateDir,
+    },
+  });
+}
 
 export function resetSlackTestState(config: Record<string, unknown> = defaultSlackTestConfig()) {
   // Fresh persistent state per test: the dispatch-dedupe guard writes logical
@@ -327,19 +368,7 @@ export function resetSlackTestState(config: Record<string, unknown> = defaultSla
   );
   lastSlackTestStateDir = stateDir;
   process.env.OPENCLAW_STATE_DIR = stateDir;
-  setSlackRuntime({
-    state: {
-      openChannelIngressQueue: (
-        options?: Omit<Parameters<typeof createChannelIngressQueueForTests>[0], "channelId">,
-      ) =>
-        createChannelIngressQueueForTests({
-          ...options,
-          channelId: "slack",
-          stateDir: options?.stateDir ?? stateDir,
-        }),
-      resolveStateDir: () => stateDir,
-    },
-  } as unknown as PluginRuntime);
+  resetSlackTestRuntime(stateDir);
   slackTestState.config = config;
   slackTestState.appConstructorArgs = undefined;
   slackTestState.socketModeLogger = undefined;
@@ -395,19 +424,6 @@ vi.mock("./monitor/config.runtime.js", async () => {
     recordSessionMetaFromInbound: vi.fn().mockResolvedValue(undefined),
     resolveStorePath: vi.fn(() => "/tmp/openclaw-sessions.json"),
     updateLastRoute: (...args: unknown[]) => slackTestState.updateLastRouteMock(...args),
-  };
-});
-
-vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>();
-  type DispatchParams = Parameters<typeof actual.dispatchChannelInboundTurn>[0];
-  type ReplyResolver = NonNullable<DispatchParams["replyResolver"]>;
-  const replyResolver: ReplyResolver = (...args) =>
-    slackTestState.replyMock(...args) as ReturnType<ReplyResolver>;
-  return {
-    ...actual,
-    dispatchChannelInboundTurn: (params: DispatchParams) =>
-      actual.dispatchChannelInboundTurn({ ...params, replyResolver }),
   };
 });
 

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1,7 +1,9 @@
-import type { GetReplyOptions, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 // Slack tests cover dispatch.preview fallback plugin behavior.
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import type { GetReplyOptions, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { setSlackRuntime } from "../../runtime.js";
 
 const FINAL_REPLY_TEXT = "final answer";
 const THREAD_TS = "thread-1";
@@ -947,134 +949,137 @@ vi.mock("../replies.js", () => ({
   resolveSlackThreadTs: () => mockedReplyThreadTs,
 }));
 
-vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>();
-  type DispatchParams = Parameters<typeof actual.dispatchChannelInboundTurn>[0];
-  return {
-    ...actual,
-    dispatchChannelInboundTurn: async (params: DispatchParams) => {
-      capturedReplyOptions = params.replyOptions as typeof capturedReplyOptions;
-      if (mockedReplyOptionEvents.length > 0) {
-        for (const entry of mockedReplyOptionEvents) {
-          if (entry.kind === "item") {
-            await params.replyOptions?.onItemEvent?.({
-              kind: entry.itemKind,
-              itemId: entry.itemId,
-              toolCallId: entry.toolCallId,
-              progressText: entry.progressText,
-              summary: entry.summary,
-              title: entry.title,
-              name: entry.name,
-              phase: entry.phase,
-              status: entry.status,
-              meta: entry.meta,
-            });
-          } else if (entry.kind === "command_output") {
-            await params.replyOptions?.onCommandOutput?.({
-              itemId: entry.itemId,
-              toolCallId: entry.toolCallId,
-              phase: entry.phase,
-              title: entry.title,
-              name: entry.name,
-              status: entry.status,
-              exitCode: entry.exitCode,
-            });
-          } else if (entry.kind === "tool_start") {
-            await params.replyOptions?.onToolStart?.({
-              itemId: entry.itemId,
-              toolCallId: entry.toolCallId,
-              name: entry.name,
-              phase: entry.phase,
-              args: entry.args,
-              detailMode: entry.detailMode,
-            });
-          } else if (entry.kind === "patch") {
-            await params.replyOptions?.onPatchSummary?.({
-              itemId: entry.itemId,
-              toolCallId: entry.toolCallId,
-              phase: entry.phase,
-              title: entry.title,
-              name: entry.name,
-              added: entry.added,
-              modified: entry.modified,
-              deleted: entry.deleted,
-              summary: entry.summary,
-            });
-          } else if (entry.kind === "plan") {
-            await params.replyOptions?.onPlanUpdate?.({
-              phase: entry.phase,
-              explanation: entry.explanation,
-              steps: entry.steps,
-            });
-          } else if (entry.kind === "concurrent_items") {
-            await Promise.all(
-              entry.progressTexts.map((progressText) =>
-                Promise.resolve(params.replyOptions?.onItemEvent?.({ progressText })),
-              ),
-            );
-          } else if (entry.kind === "assistant_start") {
-            await params.replyOptions?.onAssistantMessageStart?.();
-          } else if (entry.kind === "reasoning") {
-            await params.replyOptions?.onReasoningStream?.({
-              text: entry.text,
-              isReasoningSnapshot: entry.isReasoningSnapshot,
-            });
-          } else if (entry.kind === "reasoning_end") {
-            await params.replyOptions?.onReasoningEnd?.();
+type InboundDispatchPlan = Parameters<PluginRuntime["channel"]["inbound"]["dispatch"]>[0];
+
+function installSlackInboundDispatchFixture() {
+  setSlackRuntime({
+    channel: {
+      inbound: {
+        dispatch: async (params: InboundDispatchPlan) => {
+          capturedReplyOptions = params.replyOptions as typeof capturedReplyOptions;
+          if (mockedReplyOptionEvents.length > 0) {
+            for (const entry of mockedReplyOptionEvents) {
+              if (entry.kind === "item") {
+                await params.replyOptions?.onItemEvent?.({
+                  kind: entry.itemKind,
+                  itemId: entry.itemId,
+                  toolCallId: entry.toolCallId,
+                  progressText: entry.progressText,
+                  summary: entry.summary,
+                  title: entry.title,
+                  name: entry.name,
+                  phase: entry.phase,
+                  status: entry.status,
+                  meta: entry.meta,
+                });
+              } else if (entry.kind === "command_output") {
+                await params.replyOptions?.onCommandOutput?.({
+                  itemId: entry.itemId,
+                  toolCallId: entry.toolCallId,
+                  phase: entry.phase,
+                  title: entry.title,
+                  name: entry.name,
+                  status: entry.status,
+                  exitCode: entry.exitCode,
+                });
+              } else if (entry.kind === "tool_start") {
+                await params.replyOptions?.onToolStart?.({
+                  itemId: entry.itemId,
+                  toolCallId: entry.toolCallId,
+                  name: entry.name,
+                  phase: entry.phase,
+                  args: entry.args,
+                  detailMode: entry.detailMode,
+                });
+              } else if (entry.kind === "patch") {
+                await params.replyOptions?.onPatchSummary?.({
+                  itemId: entry.itemId,
+                  toolCallId: entry.toolCallId,
+                  phase: entry.phase,
+                  title: entry.title,
+                  name: entry.name,
+                  added: entry.added,
+                  modified: entry.modified,
+                  deleted: entry.deleted,
+                  summary: entry.summary,
+                });
+              } else if (entry.kind === "plan") {
+                await params.replyOptions?.onPlanUpdate?.({
+                  phase: entry.phase,
+                  explanation: entry.explanation,
+                  steps: entry.steps,
+                });
+              } else if (entry.kind === "concurrent_items") {
+                await Promise.all(
+                  entry.progressTexts.map((progressText) =>
+                    Promise.resolve(params.replyOptions?.onItemEvent?.({ progressText })),
+                  ),
+                );
+              } else if (entry.kind === "assistant_start") {
+                await params.replyOptions?.onAssistantMessageStart?.();
+              } else if (entry.kind === "reasoning") {
+                await params.replyOptions?.onReasoningStream?.({
+                  text: entry.text,
+                  isReasoningSnapshot: entry.isReasoningSnapshot,
+                });
+              } else if (entry.kind === "reasoning_end") {
+                await params.replyOptions?.onReasoningEnd?.();
+              } else {
+                await params.replyOptions?.onPartialReply?.({ text: entry.text });
+              }
+            }
           } else {
-            await params.replyOptions?.onPartialReply?.({ text: entry.text });
+            for (const progressText of mockedProgressEvents) {
+              await params.replyOptions?.onItemEvent?.({ progressText });
+            }
           }
-        }
-      } else {
-        for (const progressText of mockedProgressEvents) {
-          await params.replyOptions?.onItemEvent?.({ progressText });
-        }
-      }
-      for (const entry of mockedDispatchSequence) {
-        if (entry.kind === "queued_followup") {
-          await params.replyOptions?.onQueuedFollowupAdmitted?.();
-          continue;
-        }
-        if (entry.kind === "item") {
-          await params.replyOptions?.onItemEvent?.({ progressText: entry.progressText });
-          continue;
-        }
-        const payload = entry.payload as ReplyPayload;
-        const transformed = params.dispatcherOptions?.transformReplyPayload
-          ? params.dispatcherOptions.transformReplyPayload(payload)
-          : payload;
-        if (!transformed) {
-          continue;
-        }
-        const deliverPayload = params.dispatcherOptions?.beforeDeliver
-          ? await params.dispatcherOptions.beforeDeliver(transformed, { kind: entry.kind })
-          : transformed;
-        if (!deliverPayload) {
-          continue;
-        }
-        mockedQueuedDispatchCounts[entry.kind] += 1;
-        try {
-          await params.delivery.deliver(deliverPayload, { kind: entry.kind });
-        } catch (error) {
-          if (!mockedDispatcherCapturesDeliveryErrors) {
-            throw error;
+          for (const entry of mockedDispatchSequence) {
+            if (entry.kind === "queued_followup") {
+              await params.replyOptions?.onQueuedFollowupAdmitted?.();
+              continue;
+            }
+            if (entry.kind === "item") {
+              await params.replyOptions?.onItemEvent?.({ progressText: entry.progressText });
+              continue;
+            }
+            const payload = entry.payload as ReplyPayload;
+            const transformed = params.dispatcherOptions?.transformReplyPayload
+              ? params.dispatcherOptions.transformReplyPayload(payload)
+              : payload;
+            if (!transformed) {
+              continue;
+            }
+            const deliverPayload = params.dispatcherOptions?.beforeDeliver
+              ? await params.dispatcherOptions.beforeDeliver(transformed, { kind: entry.kind })
+              : transformed;
+            if (!deliverPayload) {
+              continue;
+            }
+            mockedQueuedDispatchCounts[entry.kind] += 1;
+            try {
+              await params.delivery.deliver(deliverPayload, { kind: entry.kind });
+            } catch (error) {
+              if (!mockedDispatcherCapturesDeliveryErrors) {
+                throw error;
+              }
+              mockedQueuedDispatchCounts[entry.kind] -= 1;
+            }
           }
-          mockedQueuedDispatchCounts[entry.kind] -= 1;
-        }
-      }
-      return {
-        admission: { kind: "dispatch" } as const,
-        dispatched: true as const,
-        ctxPayload: params.ctxPayload,
-        routeSessionKey: params.route.sessionKey,
-        dispatchResult: {
-          queuedFinal: false,
-          counts: { ...mockedQueuedDispatchCounts },
+          return {
+            admission: { kind: "dispatch" } as const,
+            dispatched: true as const,
+            ctxPayload: params.ctxPayload,
+            routeSessionKey: params.route.sessionKey,
+            dispatchResult: {
+              queuedFinal: false,
+              counts: { ...mockedQueuedDispatchCounts },
+            },
+          };
         },
-      };
+      },
     },
-  };
-});
+  } as unknown as PluginRuntime);
+}
 
 vi.mock("./preview-finalize.js", () => ({
   finalizeSlackPreviewEdit: finalizeSlackPreviewEditMock,
@@ -1137,6 +1142,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     appendSlackStreamMock.mockResolvedValue(undefined);
     stopSlackStreamMock.mockResolvedValue({});
     emitSlackMessageSentHooksMock.mockClear();
+    installSlackInboundDispatchFixture();
   });
 
   it("forwards durable ingress ownership into reply options", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -1,10 +1,9 @@
 // Slack plugin module implements dispatch behavior.
 import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import {
-  dispatchChannelInboundTurn,
+  hasVisibleInboundReplyDispatch,
   type InboundReplyRecordOptions,
 } from "openclaw/plugin-sdk/channel-inbound";
-import { hasVisibleInboundReplyDispatch } from "openclaw/plugin-sdk/channel-inbound";
 import {
   defineFinalizableLivePreviewAdapter,
   deliverWithFinalizableLivePreviewAdapter,
@@ -23,6 +22,7 @@ import { normalizeSlackOutboundText } from "../../format.js";
 import { SLACK_EDIT_TEXT_MAX_BYTES } from "../../limits.js";
 import { emitSlackMessageSentHooks } from "../../message-sent-hook.js";
 import { resolveSlackReplyRenderPlan } from "../../reply-blocks.js";
+import { getSlackRuntime } from "../../runtime.js";
 import { recordSlackThreadParticipation } from "../../sent-thread-cache.js";
 import {
   SlackStreamNotDeliveredError,
@@ -357,7 +357,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let queuedFinal = false;
   let counts: Partial<Record<ReplyDispatchKind, number>> = {};
   try {
-    const turnResult = await dispatchChannelInboundTurn({
+    const turnResult = await getSlackRuntime().channel.inbound.dispatch({
       cfg,
       channel: "slack",
       accountId: route.accountId,

--- a/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
@@ -4,10 +4,12 @@ import path from "node:path";
 import type { App } from "@slack/bolt";
 import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import type { ResolvedSlackAccount } from "../../accounts.js";
+import { setSlackRuntime } from "../../runtime.js";
 import type { SlackChannelConfigEntries } from "../channel-config.js";
 import { createSlackMonitorContext } from "../context.js";
 
@@ -23,13 +25,27 @@ export function createInboundSlackTestContext(params: {
   groupPolicy?: "open" | "disabled" | "allowlist";
   channelRuntime?: ChannelRuntimeSurface;
 }) {
+  const runtime = createPluginRuntimeMock();
+  const suppliedChannelRuntime = params.channelRuntime as
+    | Partial<PluginRuntime["channel"]>
+    | undefined;
+  const channelRuntime = {
+    ...runtime.channel,
+    ...suppliedChannelRuntime,
+    inbound: {
+      ...runtime.channel.inbound,
+      ...suppliedChannelRuntime?.inbound,
+    },
+  } satisfies PluginRuntime["channel"];
+  setSlackRuntime({ ...runtime, channel: channelRuntime });
+
   return createSlackMonitorContext({
     cfg: params.cfg,
     accountId: "default",
     botToken: "token",
     app: params.app ?? ({ client: params.appClient ?? {} } as App),
     runtime: {} as RuntimeEnv,
-    channelRuntime: params.channelRuntime ?? createPluginRuntimeMock().channel,
+    channelRuntime,
     botUserId: "B1",
     botId: "B1",
     identityHealth: { lifecycle: "ready", lastError: null },

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -10,6 +10,7 @@ import {
   type SessionBindingAdapter,
   type SessionBindingRecord,
 } from "openclaw/plugin-sdk/conversation-runtime";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { upsertSessionEntry, type SessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
@@ -166,6 +167,30 @@ describe("slack prepareSlackMessage inbound contract", () => {
       ...overrides,
     } as SlackMessageEvent;
   }
+
+  it("builds ordinary inbound context through the injected runtime facade", async () => {
+    const runtime = createPluginRuntimeMock();
+    const buildContext = vi.mocked(runtime.channel.inbound.buildContext);
+    const ctx = createInboundSlackCtx({
+      cfg: { channels: { slack: { enabled: true } } } as OpenClawConfig,
+      channelRuntime: runtime.channel,
+    });
+    ctx.resolveUserName = async () => ({ name: "Alice" });
+
+    const prepared = await prepareSlackMessage({
+      ctx,
+      account: defaultAccount,
+      message: createSlackMessage({}),
+      opts: { source: "message" },
+    });
+
+    assertPrepared(prepared);
+    expect(buildContext).toHaveBeenCalledOnce();
+    expect(buildContext.mock.results[0]?.value).toBe(prepared.ctxPayload);
+    expect(buildContext.mock.calls[0]?.[0]?.route.routeSessionKey).toBe(
+      prepared.ctxPayload.SessionKey,
+    );
+  });
 
   function createBotRoomMessage(overrides: Partial<SlackMessageEvent> = {}): SlackMessageEvent {
     return createSlackMessage({
@@ -3142,7 +3167,10 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       messages: [{ text: "starter", user: "U2", ts: "250.000" }],
     });
     const slackCtx = createThreadSlackCtx({ cfg, replies });
-    slackCtx.channelRuntime = undefined;
+    slackCtx.channelRuntime = {
+      ...slackCtx.channelRuntime,
+      session: undefined,
+    };
     slackCtx.resolveUserName = async () => ({ name: "Alice" });
     slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
 

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -5,7 +5,6 @@ import {
   type AckReactionScope,
 } from "openclaw/plugin-sdk/channel-feedback";
 import {
-  buildChannelInboundEventContext,
   buildMentionRegexes,
   classifyChannelInboundEvent,
   formatInboundEnvelope,
@@ -44,6 +43,7 @@ import { reactSlackMessage } from "../../actions.js";
 import { normalizeSlackAppContextEntities, isSlackAppContext } from "../../agent-context.js";
 import { formatSlackError } from "../../errors.js";
 import { formatSlackFileReference } from "../../file-reference.js";
+import { getSlackRuntime } from "../../runtime.js";
 import type { SlackSendIdentity } from "../../send.js";
 import { hasSlackThreadParticipationWithPersistence } from "../../sent-thread-cache.js";
 import { formatSlackTarget } from "../../target-parsing.js";
@@ -1639,7 +1639,7 @@ export async function prepareSlackMessage(params: {
     ? normalizeSlackAppContextEntities(message.app_context)
     : [];
 
-  const ctxPayload = buildChannelInboundEventContext({
+  const ctxPayload = getSlackRuntime().channel.inbound.buildContext({
     channel: "slack",
     accountId: route.accountId,
     messageId: threadContext.messageTs,

--- a/extensions/slack/src/monitor/slash-dispatch.runtime.ts
+++ b/extensions/slack/src/monitor/slash-dispatch.runtime.ts
@@ -1,22 +1,12 @@
 // Slack plugin module implements slash dispatch behavior.
-import {
-  dispatchChannelInboundTurn as dispatchChannelInboundTurnImpl,
-  isChannelPartialDeliveryError as isChannelPartialDeliveryErrorImpl,
-} from "openclaw/plugin-sdk/channel-inbound";
+import { isChannelPartialDeliveryError as isChannelPartialDeliveryErrorImpl } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveConversationLabel as resolveConversationLabelImpl } from "openclaw/plugin-sdk/conversation-runtime";
 import { resolveMarkdownTableMode as resolveMarkdownTableModeImpl } from "openclaw/plugin-sdk/markdown-table-runtime";
-import {
-  finalizeInboundContext as finalizeInboundContextImpl,
-  resolveChunkMode as resolveChunkModeImpl,
-} from "openclaw/plugin-sdk/reply-runtime";
+import { resolveChunkMode as resolveChunkModeImpl } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveAgentRoute as resolveAgentRouteImpl } from "openclaw/plugin-sdk/routing";
 import { deliverSlackSlashReplies as deliverSlackSlashRepliesImpl } from "./replies.js";
 
 type ResolveChunkMode = typeof import("openclaw/plugin-sdk/reply-runtime").resolveChunkMode;
-type FinalizeInboundContext =
-  typeof import("openclaw/plugin-sdk/reply-runtime").finalizeInboundContext;
-type DispatchChannelInboundTurn =
-  typeof import("openclaw/plugin-sdk/channel-inbound").dispatchChannelInboundTurn;
 type IsChannelPartialDeliveryError =
   typeof import("openclaw/plugin-sdk/channel-inbound").isChannelPartialDeliveryError;
 type ResolveConversationLabel =
@@ -30,18 +20,6 @@ export function resolveChunkMode(
   ...args: Parameters<ResolveChunkMode>
 ): ReturnType<ResolveChunkMode> {
   return resolveChunkModeImpl(...args);
-}
-
-export function finalizeInboundContext(
-  ...args: Parameters<FinalizeInboundContext>
-): ReturnType<FinalizeInboundContext> {
-  return finalizeInboundContextImpl(...args);
-}
-
-export function dispatchChannelInboundTurn(
-  ...args: Parameters<DispatchChannelInboundTurn>
-): ReturnType<DispatchChannelInboundTurn> {
-  return dispatchChannelInboundTurnImpl(...args);
 }
 
 export function isChannelPartialDeliveryError(

--- a/extensions/slack/src/monitor/slash.test-harness.ts
+++ b/extensions/slack/src/monitor/slash.test-harness.ts
@@ -1,5 +1,9 @@
 // Slack plugin module implements slash harness behavior.
+import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { vi } from "vitest";
+import { setSlackRuntime } from "../runtime.js";
 
 type AsyncMock = ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<unknown>>>;
 
@@ -9,7 +13,8 @@ const mocks = vi.hoisted(() => ({
   readAllowFromStoreMock: vi.fn(),
   upsertPairingRequestMock: vi.fn(),
   resolveAgentRouteMock: vi.fn(),
-  finalizeInboundContextMock: vi.fn(),
+  buildContextMock: vi.fn(),
+  inboundDispatchMock: vi.fn(),
   resolveConversationLabelMock: vi.fn(),
   recordSessionMetaFromInboundMock: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
   resolveStorePathMock: vi.fn(),
@@ -27,55 +32,6 @@ const mocks = vi.hoisted(() => ({
 vi.mock("./slash-dispatch.runtime.js", () => {
   return {
     deliverSlackSlashReplies: (params: unknown) => mocks.deliverSlackSlashRepliesMock(params),
-    dispatchChannelInboundTurn: async (plan: {
-      cfg: unknown;
-      ctxPayload: unknown;
-      route: { sessionKey: string };
-      dispatcherOptions?: { onSettled?: () => unknown };
-      delivery: { deliver?: unknown; onError?: unknown };
-      replyOptions?: unknown;
-    }) => {
-      mocks.turnPlanMock(plan);
-      void mocks.recordSessionMetaFromInboundMock({
-        sessionKey:
-          (plan.ctxPayload as { SessionKey?: string }).SessionKey ?? plan.route.sessionKey,
-        ctx: plan.ctxPayload,
-      });
-      let dispatchResult: unknown;
-      try {
-        const deliver = async (...args: unknown[]) => {
-          const result = await (
-            plan.delivery.deliver as (...deliveryArgs: unknown[]) => Promise<{
-              finalization?: Promise<unknown>;
-            } | void>
-          )(...args);
-          // Routed core observes deferred rejection immediately, then awaits the same
-          // finalization during settlement. Mirror that ownership in this legacy-shaped shim.
-          void result?.finalization?.catch(() => undefined);
-          return result;
-        };
-        dispatchResult = await mocks.dispatchMock({
-          ctx: plan.ctxPayload,
-          cfg: plan.cfg,
-          dispatcherOptions: {
-            ...plan.dispatcherOptions,
-            deliver,
-            onError: plan.delivery.onError,
-          },
-          replyOptions: plan.replyOptions,
-        });
-      } finally {
-        await plan.dispatcherOptions?.onSettled?.();
-      }
-      return {
-        admission: { kind: "dispatch" },
-        dispatched: true,
-        ctxPayload: plan.ctxPayload,
-        routeSessionKey: plan.route.sessionKey,
-        dispatchResult,
-      };
-    },
-    finalizeInboundContext: (...args: unknown[]) => mocks.finalizeInboundContextMock(...args),
     isChannelPartialDeliveryError: (error: unknown) =>
       Boolean(
         error &&
@@ -95,7 +51,8 @@ type SlashHarnessMocks = {
   readAllowFromStoreMock: ReturnType<typeof vi.fn>;
   upsertPairingRequestMock: ReturnType<typeof vi.fn>;
   resolveAgentRouteMock: ReturnType<typeof vi.fn>;
-  finalizeInboundContextMock: ReturnType<typeof vi.fn>;
+  buildContextMock: ReturnType<typeof vi.fn>;
+  inboundDispatchMock: ReturnType<typeof vi.fn>;
   resolveConversationLabelMock: ReturnType<typeof vi.fn>;
   recordSessionMetaFromInboundMock: AsyncMock;
   resolveStorePathMock: ReturnType<typeof vi.fn>;
@@ -116,7 +73,71 @@ export function resetSlackSlashMocks() {
     sessionKey: "session:1",
     accountId: "acct",
   });
-  mocks.finalizeInboundContextMock.mockReset().mockImplementation((ctx: unknown) => ctx);
+  mocks.buildContextMock
+    .mockReset()
+    .mockImplementation((params: unknown) => buildChannelInboundEventContext(params as never));
+  mocks.inboundDispatchMock.mockReset().mockImplementation(async (plan: unknown) => {
+    const inboundPlan = plan as {
+      cfg: unknown;
+      ctxPayload: unknown;
+      route: { sessionKey: string };
+      dispatcherOptions?: { onSettled?: () => unknown };
+      delivery: { deliver?: unknown; onError?: unknown };
+      replyOptions?: unknown;
+    };
+    mocks.turnPlanMock(inboundPlan);
+    void mocks.recordSessionMetaFromInboundMock({
+      sessionKey:
+        (inboundPlan.ctxPayload as { SessionKey?: string }).SessionKey ??
+        inboundPlan.route.sessionKey,
+      ctx: inboundPlan.ctxPayload,
+    });
+    let dispatchResult: unknown;
+    try {
+      const deliver = async (...args: unknown[]) => {
+        const result = await (
+          inboundPlan.delivery.deliver as (...deliveryArgs: unknown[]) => Promise<{
+            finalization?: Promise<unknown>;
+          } | void>
+        )(...args);
+        // Routed core observes deferred rejection immediately, then awaits the same
+        // finalization during settlement. Mirror that ownership in this facade shim.
+        void result?.finalization?.catch(() => undefined);
+        return result;
+      };
+      dispatchResult = await mocks.dispatchMock({
+        ctx: inboundPlan.ctxPayload,
+        cfg: inboundPlan.cfg,
+        dispatcherOptions: {
+          ...inboundPlan.dispatcherOptions,
+          deliver,
+          onError: inboundPlan.delivery.onError,
+        },
+        replyOptions: inboundPlan.replyOptions,
+      });
+    } finally {
+      await inboundPlan.dispatcherOptions?.onSettled?.();
+    }
+    return {
+      admission: { kind: "dispatch" },
+      dispatched: true,
+      ctxPayload: inboundPlan.ctxPayload,
+      routeSessionKey: inboundPlan.route.sessionKey,
+      dispatchResult,
+    };
+  });
+  const runtime = createPluginRuntimeMock();
+  setSlackRuntime({
+    ...runtime,
+    channel: {
+      ...runtime.channel,
+      inbound: {
+        ...runtime.channel.inbound,
+        buildContext: mocks.buildContextMock as PluginRuntime["channel"]["inbound"]["buildContext"],
+        dispatch: mocks.inboundDispatchMock as PluginRuntime["channel"]["inbound"]["dispatch"],
+      },
+    },
+  });
   mocks.resolveConversationLabelMock.mockReset().mockReturnValue(undefined);
   mocks.recordSessionMetaFromInboundMock.mockReset().mockResolvedValue(undefined);
   mocks.resolveStorePathMock.mockReset().mockReturnValue("/tmp/openclaw-sessions.json");

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -905,6 +905,18 @@ describe("Slack native command argument menus", () => {
     expect(dispatchMock).toHaveBeenCalledTimes(1);
     const call = firstDispatchArg() as { ctx?: { Body?: string } };
     expect(call.ctx?.Body).toBe("/tools compact");
+    const { buildContextMock, inboundDispatchMock } = getSlackSlashMocks();
+    const builderInput = buildContextMock.mock.calls[0]?.[0] as
+      | { route?: { routeSessionKey?: string } }
+      | undefined;
+    const built = buildContextMock.mock.results[0]?.value as { SessionKey?: string } | undefined;
+    const inboundPlan = inboundDispatchMock.mock.calls[0]?.[0] as
+      | { ctxPayload?: unknown; route?: { sessionKey?: string } }
+      | undefined;
+    expect(built).toBeDefined();
+    expect(inboundPlan?.ctxPayload).toBe(built);
+    expect(builderInput?.route?.routeSessionKey).toBe(built?.SessionKey);
+    expect(inboundPlan?.route?.sessionKey).toBe(built?.SessionKey);
   });
 
   it("does not apply the response_url call cap to Web API action replies", async () => {

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -36,6 +36,7 @@ import { chunkItems } from "openclaw/plugin-sdk/text-chunking";
 import type { ResolvedSlackAccount } from "../accounts.js";
 import { SLACK_MAX_BLOCKS } from "../blocks-input.js";
 import { formatSlackError } from "../errors.js";
+import { getSlackRuntime } from "../runtime.js";
 import { truncateSlackText } from "../truncate.js";
 import { resolveSlackCommandIngress, resolveSlackEffectiveAllowFrom } from "./auth.js";
 import { resolveSlackChannelConfig, type SlackChannelConfigResolved } from "./channel-config.js";
@@ -667,8 +668,6 @@ export async function registerSlackMonitorSlashCommands(params: {
       const roomLabel = channelName ? `#${channelName}` : `#${command.channel_id}`;
       const {
         deliverSlackSlashReplies,
-        dispatchChannelInboundTurn,
-        finalizeInboundContext,
         isChannelPartialDeliveryError,
         resolveAgentRoute,
         resolveChunkMode,
@@ -706,48 +705,72 @@ export async function registerSlackMonitorSlashCommands(params: {
         !slashCommand.ephemeral && isRoomish
           ? `channel:${command.channel_id}`
           : `user:${command.user_id}`;
-      const ctxPayload = finalizeInboundContext({
-        Body: prompt,
-        BodyForAgent: prompt,
-        RawBody: prompt,
-        CommandBody: prompt,
-        CommandArgs: commandArgs,
-        From: isDirectMessage
-          ? `slack:${command.user_id}`
-          : isRoom
-            ? `slack:channel:${command.channel_id}`
-            : `slack:group:${command.channel_id}`,
-        To: `slash:${command.user_id}`,
-        ChatType: chatType,
-        ConversationLabel:
-          resolveConversationLabel({
-            ChatType: chatType,
-            SenderName: senderName,
-            GroupSubject: isRoomish ? roomLabel : undefined,
-            From: isDirectMessage
-              ? `slack:${command.user_id}`
-              : isRoom
-                ? `slack:channel:${command.channel_id}`
-                : `slack:group:${command.channel_id}`,
-          }) ?? (isDirectMessage ? senderName : roomLabel),
-        GroupSubject: isRoomish ? roomLabel : undefined,
-        GroupSpace: ctx.teamId || undefined,
-        GroupSystemPrompt: groupSystemPrompt,
-        ChannelPromptContext: channelMetadata ? [channelMetadata] : undefined,
-        SenderName: senderName,
-        SenderId: command.user_id,
-        Provider: "slack" as const,
-        Surface: "slack" as const,
-        WasMentioned: true,
-        MessageSid: command.trigger_id,
-        Timestamp: Date.now(),
-        SessionKey: sessionKey,
-        CommandTargetSessionKey: commandTargetSessionKey,
-        AccountId: route.accountId,
-        CommandSource: "native" as const,
-        CommandAuthorized: commandAuthorized,
-        OriginatingChannel: "slack" as const,
-        OriginatingTo: slashReplyTarget,
+      const slackFrom = isDirectMessage
+        ? `slack:${command.user_id}`
+        : isRoom
+          ? `slack:channel:${command.channel_id}`
+          : `slack:group:${command.channel_id}`;
+      const conversationLabel =
+        resolveConversationLabel({
+          ChatType: chatType,
+          SenderName: senderName,
+          GroupSubject: isRoomish ? roomLabel : undefined,
+          From: slackFrom,
+        }) ?? (isDirectMessage ? senderName : roomLabel);
+      const ctxPayload = getSlackRuntime().channel.inbound.buildContext({
+        channel: "slack",
+        accountId: route.accountId,
+        messageId: command.trigger_id,
+        timestamp: Date.now(),
+        from: slackFrom,
+        sender: {
+          id: command.user_id,
+          name: senderName,
+          displayLabel: senderName,
+        },
+        conversation: {
+          kind: chatType,
+          id: command.channel_id,
+          label: conversationLabel,
+          spaceId: ctx.teamId || undefined,
+          nativeChannelId: command.channel_id,
+        },
+        route: {
+          agentId: route.agentId,
+          dmScope: route.dmScope,
+          accountId: route.accountId,
+          routeSessionKey: sessionKey,
+        },
+        reply: {
+          to: `slash:${command.user_id}`,
+          originatingTo: slashReplyTarget,
+          nativeChannelId: command.channel_id,
+        },
+        message: {
+          body: prompt,
+          bodyForAgent: prompt,
+          rawBody: prompt,
+          commandBody: prompt,
+        },
+        access: {
+          mentions: { canDetectMention: isRoomish, wasMentioned: true },
+          commands: { authorized: commandAuthorized },
+        },
+        command: {
+          kind: "native",
+          body: prompt,
+          name: commandDefinition?.key,
+          authorized: commandAuthorized,
+        },
+        supplemental: {
+          groupSystemPrompt,
+        },
+        extra: {
+          CommandArgs: commandArgs,
+          CommandTargetSessionKey: commandTargetSessionKey,
+          GroupSubject: isRoomish ? roomLabel : undefined,
+          ChannelPromptContext: channelMetadata ? [channelMetadata] : undefined,
+        },
       });
 
       const messageSentHookTarget = ctxPayload.OriginatingTo ?? ctxPayload.To ?? slashReplyTarget;
@@ -762,7 +785,7 @@ export async function registerSlackMonitorSlashCommands(params: {
           textLimit: ctx.textLimit,
           messageSentHookTarget,
           accountId: route.accountId,
-          sessionKeyForInternalHooks: ctxPayload.SessionKey ?? route.sessionKey,
+          sessionKeyForInternalHooks: sessionKey,
           isGroup: isRoomish,
           groupId: isRoomish ? command.channel_id : undefined,
           chunkMode: resolveChunkMode(cfg, "slack", route.accountId),
@@ -781,13 +804,13 @@ export async function registerSlackMonitorSlashCommands(params: {
       }> = [];
       const shouldDeliverBlockImmediately = commandDefinition?.key === "login";
 
-      await dispatchChannelInboundTurn({
+      await getSlackRuntime().channel.inbound.dispatch({
         cfg,
         channel: "slack",
         accountId: route.accountId,
         route: {
           agentId: route.agentId,
-          sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+          sessionKey,
         },
         ctxPayload,
         replyPipeline: {

--- a/extensions/telegram/src/bot-deps.inbound-facade.test.ts
+++ b/extensions/telegram/src/bot-deps.inbound-facade.test.ts
@@ -1,0 +1,237 @@
+import path from "node:path";
+import {
+  buildChannelInboundEventContext,
+  runChannelInboundEvent,
+} from "openclaw/plugin-sdk/channel-inbound";
+import { recordInboundSession } from "openclaw/plugin-sdk/conversation-runtime";
+import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";
+import { afterEach, expect, it, vi } from "vitest";
+import type { FinalizedMsgContext } from "../../../src/auto-reply/templating.js";
+import { createCoreChannelInboundEventFacade } from "../../../src/channels/inbound-event/core-ingress.js";
+import { readCurrentSessionMemorySubject } from "../../../src/config/sessions/session-memory-subject-access.js";
+import { createMemoryIdentityBindingThroughApprovedPairing } from "../../../src/pairing/memory-identity-approval.test-support.js";
+import { memoryIdentityLifecycle } from "../../../src/state/memory-identity.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../../src/state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../../src/state/openclaw-state-db.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { defaultTelegramBotDeps } from "./bot-deps.js";
+import { setTelegramRuntime } from "./runtime.js";
+import { clearTelegramRuntimeForTest } from "./runtime.test-support.js";
+import type { TelegramRuntime } from "./runtime.types.js";
+
+const SESSION_KEY = "agent:main:telegram:direct:telegram-user-42";
+const COMMAND_SESSION_KEY = "agent:main:telegram:slash:telegram-user-42";
+const COMMAND_TARGET_SESSION_KEY = "agent:main:telegram:direct:telegram-user-42";
+const tempDirectories = useAutoCleanupTempDirTracker(afterEach);
+const { ensureEnterpriseMemoryPrincipal } = memoryIdentityLifecycle;
+
+afterEach(() => {
+  clearTelegramRuntimeForTest();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  vi.unstubAllEnvs();
+});
+
+it("falls back to the SDK ingress functions when a partial runtime has no inbound facade", () => {
+  setTelegramRuntime({ channel: {} } as TelegramRuntime);
+
+  expect(defaultTelegramBotDeps.buildChannelInboundEventContext).toBe(
+    buildChannelInboundEventContext,
+  );
+  expect(defaultTelegramBotDeps.runChannelInboundEvent).toBe(runChannelInboundEvent);
+});
+
+it("uses the trusted Telegram inbound facade to persist an approved direct-message subject", async () => {
+  const stateDir = tempDirectories.make("openclaw-telegram-inbound-facade-state-");
+  const storePath = path.join(
+    tempDirectories.make("openclaw-telegram-inbound-facade-store-"),
+    "sessions.json",
+  );
+  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  closeOpenClawStateDatabaseForTest();
+  const principal = ensureEnterpriseMemoryPrincipal({
+    issuer: "telegram-inbound-facade-test",
+    stableSubjectId: "telegram-user-42",
+    now: 100,
+  });
+  await createMemoryIdentityBindingThroughApprovedPairing({
+    channel: "telegram",
+    accountId: "acct",
+    stableSenderId: "telegram-user-42",
+    principalId: principal.principalId,
+    now: 100,
+    options: { env: process.env },
+  });
+  const inbound = createCoreChannelInboundEventFacade({
+    ownsChannel: (channel) => channel === "telegram",
+  });
+  setTelegramRuntime({ channel: { inbound } } as TelegramRuntime);
+
+  expect(defaultTelegramBotDeps.buildChannelInboundEventContext).toBe(inbound.buildContext);
+  expect(defaultTelegramBotDeps.runChannelInboundEvent).toBe(inbound.run);
+
+  const ctx = await defaultTelegramBotDeps.buildChannelInboundEventContext!({
+    channel: "telegram",
+    accountId: "acct",
+    from: "telegram:telegram-user-42",
+    sender: { id: "telegram-user-42" },
+    conversation: { kind: "direct", id: "telegram-user-42" },
+    route: {
+      agentId: "main",
+      accountId: "acct",
+      dmScope: "per-channel-peer",
+      routeSessionKey: SESSION_KEY,
+    },
+    reply: { to: "telegram:telegram-user-42" },
+    message: { rawBody: "hello" },
+  });
+  const metadataTasks: Promise<unknown>[] = [];
+  const recordErrors: unknown[] = [];
+
+  await defaultTelegramBotDeps.runChannelInboundEvent({
+    channel: "telegram",
+    accountId: "acct",
+    raw: {},
+    adapter: {
+      ingest: () => ({ id: "telegram-message-1", rawText: "hello" }),
+      resolveTurn: () => ({
+        channel: "telegram",
+        accountId: "acct",
+        routeSessionKey: SESSION_KEY,
+        storePath,
+        ctxPayload: ctx as FinalizedMsgContext,
+        recordInboundSession,
+        record: {
+          sessionKey: SESSION_KEY,
+          onRecordError: (error) => {
+            recordErrors.push(error);
+          },
+          trackSessionMetaTask: (task) => {
+            metadataTasks.push(task);
+          },
+        },
+        runDispatch: async () => ({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } }),
+        runDispatchLifecycle: {
+          turnAdoptionLifecycle: undefined,
+          onDispatchSkipped: async () => undefined,
+        },
+      }),
+    },
+  });
+
+  await Promise.all(metadataTasks);
+
+  expect(recordErrors).toEqual([]);
+  expect(metadataTasks).toHaveLength(1);
+  expect(
+    readCurrentSessionMemorySubject({ agentId: "main", sessionKey: SESSION_KEY, storePath })
+      ?.subject,
+  ).toMatchObject({ kind: "user", principalId: principal.principalId });
+});
+
+it("keeps a split-key native-command target unbound through public ingress", async () => {
+  const stateDir = tempDirectories.make("openclaw-telegram-native-command-state-");
+  const storePath = path.join(
+    tempDirectories.make("openclaw-telegram-native-command-store-"),
+    "sessions.json",
+  );
+  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  closeOpenClawStateDatabaseForTest();
+  const principal = ensureEnterpriseMemoryPrincipal({
+    issuer: "telegram-native-command-test",
+    stableSubjectId: "telegram-user-42",
+    now: 100,
+  });
+  await createMemoryIdentityBindingThroughApprovedPairing({
+    channel: "telegram",
+    accountId: "acct",
+    stableSenderId: "telegram-user-42",
+    principalId: principal.principalId,
+    now: 100,
+    options: { env: process.env },
+  });
+  const ctx = finalizeInboundContext({
+    Body: "/status",
+    BodyForAgent: "/status",
+    RawBody: "/status",
+    CommandBody: "/status",
+    From: "telegram:telegram-user-42",
+    To: "slash:telegram-user-42",
+    ChatType: "direct",
+    SenderId: "telegram-user-42",
+    Surface: "telegram",
+    Provider: "telegram",
+    OriginatingChannel: "telegram",
+    AccountId: "acct",
+    AgentId: "main",
+    SessionKey: COMMAND_SESSION_KEY,
+    CommandTargetSessionKey: COMMAND_TARGET_SESSION_KEY,
+    CommandAuthorized: true,
+    CommandTurn: {
+      kind: "native",
+      source: "native",
+      authorized: true,
+      body: "/status",
+    },
+    CommandSource: "native",
+  });
+  const metadataTasks: Promise<unknown>[] = [];
+  const recordErrors: unknown[] = [];
+  const recordedSessionKeys: string[] = [];
+  const recordNativeCommandSession = async (
+    params: Parameters<typeof recordInboundSession>[0],
+  ): Promise<void> => {
+    recordedSessionKeys.push(params.sessionKey);
+    await recordInboundSession(params);
+  };
+
+  const result = await runChannelInboundEvent({
+    channel: "telegram",
+    accountId: "acct",
+    raw: {},
+    adapter: {
+      ingest: () => ({ id: "telegram-native-command-1", rawText: "/status" }),
+      resolveTurn: () => ({
+        channel: "telegram",
+        accountId: "acct",
+        routeSessionKey: COMMAND_SESSION_KEY,
+        storePath,
+        ctxPayload: ctx as FinalizedMsgContext,
+        recordInboundSession: recordNativeCommandSession,
+        record: {
+          sessionKey: COMMAND_TARGET_SESSION_KEY,
+          onRecordError: (error) => {
+            recordErrors.push(error);
+          },
+          trackSessionMetaTask: (task) => {
+            metadataTasks.push(task);
+          },
+        },
+        runDispatch: async () => ({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } }),
+        runDispatchLifecycle: {
+          turnAdoptionLifecycle: undefined,
+          onDispatchSkipped: async () => undefined,
+        },
+      }),
+    },
+  });
+
+  await Promise.all(metadataTasks);
+
+  expect(result).toMatchObject({ dispatched: true, routeSessionKey: COMMAND_SESSION_KEY });
+  expect(ctx).toMatchObject({
+    SessionKey: COMMAND_SESSION_KEY,
+    CommandTargetSessionKey: COMMAND_TARGET_SESSION_KEY,
+    CommandTurn: { kind: "native", source: "native", authorized: true },
+  });
+  expect(recordedSessionKeys).toEqual([COMMAND_TARGET_SESSION_KEY]);
+  expect(recordErrors).toEqual([]);
+  expect(metadataTasks).toHaveLength(1);
+  expect(
+    readCurrentSessionMemorySubject({
+      agentId: "main",
+      sessionKey: COMMAND_TARGET_SESSION_KEY,
+      storePath,
+    })?.subject,
+  ).toEqual({ version: 1, kind: "ambiguous", reason: "unbound" });
+});

--- a/extensions/telegram/src/bot-deps.ts
+++ b/extensions/telegram/src/bot-deps.ts
@@ -5,7 +5,10 @@ import {
 } from "openclaw/plugin-sdk/approval-gateway-runtime";
 import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
-import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  buildChannelInboundEventContext,
+  runChannelInboundEvent,
+} from "openclaw/plugin-sdk/channel-inbound";
 import {
   createChannelMessageReplyPipeline,
   deliverInboundReplyWithMessageSendContext,
@@ -35,6 +38,7 @@ import { syncTelegramMenuCommands } from "./bot-native-command-menu.js";
 import { deliverReplies, emitTelegramMessageSentHooks } from "./bot/delivery.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
 import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
+import { getOptionalTelegramRuntime } from "./runtime.js";
 import { editMessageTelegram } from "./send.js";
 import { wasSentByBot } from "./sent-message-cache.js";
 
@@ -66,6 +70,7 @@ export type TelegramBotDeps = {
   resolveInboundLastRouteSessionKey?: typeof resolveInboundLastRouteSessionKey;
   resolvePinnedMainDmOwnerFromAllowlist?: typeof resolvePinnedMainDmOwnerFromAllowlist;
   buildChannelInboundEventContext?: typeof buildChannelInboundEventContext;
+  runChannelInboundEvent?: typeof runChannelInboundEvent;
   readChannelAllowFromStore: typeof readChannelAllowFromStore;
   upsertChannelPairingRequest: typeof upsertChannelPairingRequest;
   enqueueSystemEvent: typeof enqueueSystemEvent;
@@ -85,7 +90,9 @@ export type TelegramBotDeps = {
   createChannelMessageReplyPipeline?: typeof createChannelMessageReplyPipeline;
 };
 
-export const defaultTelegramBotDeps: TelegramBotDeps = {
+export const defaultTelegramBotDeps: TelegramBotDeps & {
+  runChannelInboundEvent: typeof runChannelInboundEvent;
+} = {
   get getRuntimeConfig() {
     return getRuntimeConfig;
   },
@@ -120,7 +127,13 @@ export const defaultTelegramBotDeps: TelegramBotDeps = {
     return resolvePinnedMainDmOwnerFromAllowlist;
   },
   get buildChannelInboundEventContext() {
-    return buildChannelInboundEventContext;
+    return (
+      getOptionalTelegramRuntime()?.channel?.inbound?.buildContext ??
+      buildChannelInboundEventContext
+    );
+  },
+  get runChannelInboundEvent() {
+    return getOptionalTelegramRuntime()?.channel?.inbound?.run ?? runChannelInboundEvent;
   },
   get upsertChannelPairingRequest() {
     return upsertChannelPairingRequest;

--- a/extensions/telegram/src/bot-message-dispatch-turn.ts
+++ b/extensions/telegram/src/bot-message-dispatch-turn.ts
@@ -1,8 +1,5 @@
 import { logTypingFailure } from "openclaw/plugin-sdk/channel-feedback";
-import {
-  runChannelInboundEvent,
-  type ChannelInboundTurnPlan,
-} from "openclaw/plugin-sdk/channel-inbound";
+import type { ChannelInboundTurnPlan } from "openclaw/plugin-sdk/channel-inbound";
 // Telegram plugin module wires inbound turn execution to Telegram delivery controllers.
 import {
   createChannelMessageReplyPipeline,
@@ -11,7 +8,7 @@ import {
 import type { OpenClawConfig, TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isFastModeAutoProgressPayload } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import type { TelegramBotDeps } from "./bot-deps.js";
+import { defaultTelegramBotDeps, type TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
 import type { TelegramDeliveryController } from "./bot-message-dispatch-delivery.js";
 import type { TelegramDraftController } from "./bot-message-dispatch-draft.js";
@@ -93,6 +90,8 @@ export async function runTelegramDispatchTurn(params: {
         logVerbose(`telegram reply error callback failed: ${String(callbackError)}`);
       });
     };
+    const runChannelInboundEvent =
+      params.telegramDeps.runChannelInboundEvent ?? defaultTelegramBotDeps.runChannelInboundEvent;
     const turnResult = await runChannelInboundEvent({
       channel: "telegram",
       accountId: context.route.accountId,

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -1,3 +1,4 @@
+import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
 // Whatsapp tests cover inbound dispatch plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi, beforeEach } from "vitest";
@@ -211,6 +212,7 @@ function collectNonPortablePaths(
 }
 
 type PrepareWhatsAppInboundParams = Parameters<typeof prepareWhatsAppInboundContext>[0];
+const testInboundContextBuilder = buildChannelInboundEventContext;
 type LegacyTestCommand = Omit<
   NonNullable<PrepareWhatsAppInboundParams["command"]>,
   "authorization"
@@ -220,7 +222,7 @@ type LegacyTestCommand = Omit<
 };
 
 async function buildWhatsAppInboundContext(
-  params: Omit<PrepareWhatsAppInboundParams, "command"> & {
+  params: Omit<PrepareWhatsAppInboundParams, "buildContext" | "command"> & {
     command?: LegacyTestCommand;
   },
 ) {
@@ -238,11 +240,17 @@ async function buildWhatsAppInboundContext(
       }
     : undefined;
   if (!command) {
-    return (await prepareWhatsAppInboundContext(preparedParams)).ctxPayload;
+    return (
+      await prepareWhatsAppInboundContext({
+        buildContext: testInboundContextBuilder,
+        ...preparedParams,
+      })
+    ).ctxPayload;
   }
   const { authorized: _legacyAuthorized, ...preparedCommand } = command;
   return (
     await prepareWhatsAppInboundContext({
+      buildContext: testInboundContextBuilder,
       ...preparedParams,
       command: preparedCommand,
     })
@@ -297,6 +305,7 @@ describe("prepared WhatsApp inbound boundary", () => {
       },
     });
     const prepared = await prepareWhatsAppInboundContext({
+      buildContext: testInboundContextBuilder,
       bodyForAgent: "agent body",
       combinedBody: "formatted agent body",
       command: {
@@ -392,6 +401,7 @@ describe("prepared WhatsApp inbound boundary", () => {
       event: { id: undefined, timestamp: 1_710_000_000 },
     });
     const params = {
+      buildContext: testInboundContextBuilder,
       combinedBody: "hi",
       msg,
       route: makeRoute(),

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -381,6 +381,7 @@ export function buildWhatsAppInboundTransportContext(
 }
 
 export async function prepareWhatsAppInboundContext(params: {
+  buildContext: Parameters<typeof projectPreparedChannelInbound>[0]["buildContext"];
   bodyForAgent?: string;
   combinedBody: string;
   command?: NonNullable<PreparedChannelInbound["command"]>;
@@ -511,7 +512,11 @@ export async function prepareWhatsAppInboundContext(params: {
       location: params.msg.payload.location,
     },
   };
-  const projected = projectPreparedChannelInbound({ inbound, control });
+  const projected = projectPreparedChannelInbound({
+    buildContext: params.buildContext,
+    inbound,
+    control,
+  });
   return {
     inbound,
     control,

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-helpers.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-helpers.test.ts
@@ -1,3 +1,4 @@
+import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
 // Whatsapp tests cover inbound context plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTestWebInboundMessage } from "../../inbound/test-message.test-helper.js";
@@ -297,6 +298,7 @@ describe("WhatsApp prepared inbound", () => {
     } satisfies PreparedChannelInbound;
 
     const projected = projectPreparedChannelInbound({
+      buildContext: buildChannelInboundEventContext,
       inbound,
       control: { messageReceivedHooks: "core" },
     });

--- a/extensions/whatsapp/src/auto-reply/monitor/prepared-inbound.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/prepared-inbound.ts
@@ -1,5 +1,4 @@
 import {
-  buildChannelInboundEventContext,
   toLocationContext,
   type BuildChannelInboundEventContextParams,
   type BuiltChannelInboundEventContext,
@@ -8,6 +7,7 @@ import {
   type SupplementalContextFacts,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveChannelMessageSourceReplyDeliveryMode } from "openclaw/plugin-sdk/channel-outbound";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import type { ReplyThreadingPolicy } from "openclaw/plugin-sdk/reply-reference";
 
 type PreparedChannelInboundCommandAuthorization =
@@ -60,6 +60,8 @@ type PreparedChannelInboundControl = {
   messageReceivedHooks: "channel" | "core";
 };
 
+type ChannelInboundContextBuilder = PluginRuntime["channel"]["inbound"]["buildContext"];
+
 function resolvePreparedCommandFacts(
   command: PreparedChannelInboundCommand | undefined,
 ): CommandFacts | undefined {
@@ -76,6 +78,7 @@ function resolvePreparedCommandFacts(
 }
 
 export function projectPreparedChannelInbound(params: {
+  buildContext: ChannelInboundContextBuilder;
   inbound: PreparedChannelInbound;
   control: PreparedChannelInboundControl;
 }): {
@@ -105,7 +108,7 @@ export function projectPreparedChannelInbound(params: {
       textForCommands: inbound.message.commandBody,
       raw: inbound,
     },
-    context: buildChannelInboundEventContext({
+    context: params.buildContext({
       ...inbound,
       messageId: inbound.event.id,
       messageIdFull: inbound.event.fullId,

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.audio-preflight.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.audio-preflight.test.ts
@@ -1,10 +1,17 @@
+import {
+  buildChannelInboundEventContext,
+  runChannelInboundEvent,
+} from "openclaw/plugin-sdk/channel-inbound";
 // Whatsapp tests cover process message.audio preflight plugin behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestWebAudioInboundMessage } from "../../inbound/test-message.test-helper.js";
+import { setWhatsAppRuntime } from "../../runtime.js";
 
 // Mock the lazy-loaded audio preflight runtime boundary
 const transcribeFirstAudioMock = vi.fn();
 const maybeSendAckReactionMock = vi.fn();
+const runtimeInboundBuildContextMock = vi.fn();
+const runtimeInboundRunMock = vi.fn();
 
 vi.mock("./audio-preflight.runtime.js", () => ({
   transcribeFirstAudio: (...args: unknown[]) => transcribeFirstAudioMock(...args),
@@ -265,6 +272,24 @@ describe("processMessage audio preflight transcription", () => {
     shouldComputeCommandResult = false;
     shouldComputeCommandBodies = [];
     vi.mocked(createWhatsAppReplyPlan).mockClear();
+    runtimeInboundBuildContextMock.mockReset();
+    runtimeInboundBuildContextMock.mockImplementation(
+      (params: Parameters<typeof buildChannelInboundEventContext>[0]) =>
+        buildChannelInboundEventContext(params),
+    );
+    runtimeInboundRunMock.mockReset();
+    runtimeInboundRunMock.mockImplementation(
+      async (params: Parameters<typeof runChannelInboundEvent>[0]) =>
+        await runChannelInboundEvent(params),
+    );
+    setWhatsAppRuntime({
+      channel: {
+        inbound: {
+          buildContext: runtimeInboundBuildContextMock as never,
+          run: runtimeInboundRunMock as never,
+        },
+      },
+    } as never);
   });
 
   it("replaces an empty audio caption with the transcript when transcription succeeds", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
@@ -1,7 +1,12 @@
+import {
+  buildChannelInboundEventContext,
+  runChannelInboundEvent,
+} from "openclaw/plugin-sdk/channel-inbound";
 // Whatsapp tests cover process message plugin behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createAcceptedWhatsAppSendResult } from "../../inbound/send-result.test-helper.js";
 import { createTestWebInboundMessage } from "../../inbound/test-message.test-helper.js";
+import { setWhatsAppRuntime } from "../../runtime.js";
 
 // Hoisted mocks used across tests so vi.mock factories can reference them.
 const {
@@ -10,7 +15,8 @@ const {
   isControlCommandMessageMock,
   dispatchBufferedReplyMock,
   replyPlanParamsMock,
-  runChannelInboundEventParamsMock,
+  runtimeInboundBuildContextMock,
+  runtimeInboundRunMock,
   runMessageReceivedMock,
   shouldComputeCommandAuthorizedMock,
   trackBackgroundTaskMock,
@@ -23,22 +29,12 @@ const {
     counts: { tool: 0, block: 0, final: 0 },
   })),
   replyPlanParamsMock: vi.fn(),
-  runChannelInboundEventParamsMock: vi.fn(),
+  runtimeInboundBuildContextMock: vi.fn(),
+  runtimeInboundRunMock: vi.fn(),
   runMessageReceivedMock: vi.fn(async () => undefined),
   shouldComputeCommandAuthorizedMock: vi.fn(() => false),
   trackBackgroundTaskMock: vi.fn(),
 }));
-
-vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>();
-  return {
-    ...actual,
-    runChannelInboundEvent: async (params: Parameters<typeof actual.runChannelInboundEvent>[0]) => {
-      runChannelInboundEventParamsMock(params);
-      return await actual.runChannelInboundEvent(params);
-    },
-  };
-});
 
 vi.mock("../../inbound-policy.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../inbound-policy.js")>();
@@ -308,7 +304,24 @@ describe("processMessage group system prompt wiring", () => {
     isControlCommandMessageMock.mockReturnValue(false);
     resolvePolicyMock.mockReset();
     replyPlanParamsMock.mockClear();
-    runChannelInboundEventParamsMock.mockClear();
+    runtimeInboundBuildContextMock.mockReset();
+    runtimeInboundBuildContextMock.mockImplementation(
+      (params: Parameters<typeof buildChannelInboundEventContext>[0]) =>
+        buildChannelInboundEventContext(params),
+    );
+    runtimeInboundRunMock.mockReset();
+    runtimeInboundRunMock.mockImplementation(
+      async (params: Parameters<typeof runChannelInboundEvent>[0]) =>
+        await runChannelInboundEvent(params),
+    );
+    setWhatsAppRuntime({
+      channel: {
+        inbound: {
+          buildContext: runtimeInboundBuildContextMock as never,
+          run: runtimeInboundRunMock as never,
+        },
+      },
+    } as never);
     runMessageReceivedMock.mockClear();
     shouldComputeCommandAuthorizedMock.mockReset();
     shouldComputeCommandAuthorizedMock.mockReturnValue(false);
@@ -600,7 +613,7 @@ describe("processMessage group system prompt wiring", () => {
 
     await callProcessMessage({ msg });
 
-    const runParams = mockCallArg(runChannelInboundEventParamsMock, "runChannelInboundEvent") as {
+    const runParams = mockCallArg(runtimeInboundRunMock, "runtime inbound run") as {
       raw?: unknown;
       turnAdoptionLifecycle?: unknown;
     };
@@ -608,6 +621,8 @@ describe("processMessage group system prompt wiring", () => {
       turnAdoptionLifecycle?: unknown;
     };
     expect(runParams.turnAdoptionLifecycle).toBe(replyPlanParams.turnAdoptionLifecycle);
+    expect(runtimeInboundBuildContextMock).toHaveBeenCalledOnce();
+    expect(runtimeInboundRunMock).toHaveBeenCalledOnce();
     expect(runParams.raw).not.toHaveProperty("platform");
     expect(runParams.raw).not.toHaveProperty("admission");
   });

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -4,10 +4,7 @@ import {
   removeAckReactionHandleAfterReply,
   type AckReactionHandle,
 } from "openclaw/plugin-sdk/channel-feedback";
-import {
-  formatMediaPlaceholderText,
-  runChannelInboundEvent,
-} from "openclaw/plugin-sdk/channel-inbound";
+import { formatMediaPlaceholderText } from "openclaw/plugin-sdk/channel-inbound";
 import { bindIngressLifecycleToReplyOptions } from "openclaw/plugin-sdk/channel-outbound";
 import {
   createInternalHookEvent,
@@ -29,6 +26,7 @@ import { requireWhatsAppInboundAdmission } from "../../inbound/admission.js";
 import { resolveWhatsAppIngressLifecycle } from "../../inbound/ingress-lifecycle.js";
 import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
 import { newConnectionId } from "../../reconnect.js";
+import { getWhatsAppRuntime } from "../../runtime.js";
 import { formatError } from "../../session.js";
 import {
   resolveWhatsAppDirectSystemPrompt,
@@ -221,6 +219,7 @@ export async function processMessage(params: {
   if (admission.ingress.admission !== "dispatch" && admission.ingress.admission !== "observe") {
     return false;
   }
+  const inboundFacade = getWhatsAppRuntime().channel.inbound;
   const conversationId = admission.conversation.id;
   const conversationKind = admission.conversation.kind;
   const self = getSelfIdentity(params.msg);
@@ -480,6 +479,7 @@ export async function processMessage(params: {
         ? ({ kind: "authorized" } as const)
         : ({ kind: "denied" } as const);
   const prepared = await prepareWhatsAppInboundContext({
+    buildContext: inboundFacade.buildContext,
     bodyForAgent: msgForAgent.payload.body,
     combinedBody,
     command: {
@@ -534,7 +534,7 @@ export async function processMessage(params: {
   });
   let finalizeReply: ReturnType<typeof createWhatsAppReplyPlan>["finalize"] | undefined;
 
-  const turnResult = await runChannelInboundEvent({
+  const turnResult = await inboundFacade.run({
     channel: "whatsapp",
     accountId: params.route.accountId,
     raw: inbound,


### PR DESCRIPTION
## What Problem This Solves

Core ingress facts are insufficient unless channel adapters preserve them at their native inbound boundaries. Later memory authorization needs channel-delivery context to stay bound to the trusted subject instead of being reconstructed after transport-specific processing.

## Why This Change Was Made

This Phase 1A draft applies trusted subject/inbound-context plumbing across bundled channel adapters and their test harnesses. It extends the proposed ingress context through transport handling; it does not define authorization policy, expose a new operator control, or enforce memory access.

## User Impact

This remains an unreleased draft. It is intended to support consistent future identity propagation across channel implementations while leaving current memory behavior unchanged.

## Stack / Status

Depends on #121153’s core trusted-ingress draft. It is the historical channel-adapter tail of that parallel Phase 1A chain, not part of the current canonical #121421 → #121422 → #121423 stack. This update does not change its draft/base/head state.

## Evidence

- Exact head: `3504f0e01741f852908c5881aa3c7b785f835fa3` (channel-ingress binding plus Feishu inbound-context facade coverage).
- Current live GitHub rollup shows 9 successful and 65 skipped checks.
- The 85-file diff touches inbound contexts and tests across Discord, Feishu, iMessage, IRC, Line, Matrix, MS Teams, Nextcloud Talk, Nostr, QA Channel, QQBot, Signal, Slack, Telegram, WhatsApp, and other bundled channel adapters.

## Remaining Evidence Gaps

No exact-head channel-by-channel focused test transcript, remote artifact, or live-channel proof is attached. The successful workflow count is not a substitute for later end-to-end authorization enforcement proof.
