### PR TITLE
fix(plugins): preserve unreadable retained npm markers during cleanup

### DIFF
--- a/src/commands/doctor-plugin-generations.ts
+++ b/src/commands/doctor-plugin-generations.ts
@@ -9,6 +9,7 @@ import {
   loadInstalledPluginIndexInstallRecords,
   type InstalledPluginIndexRecordStoreOptions,
 } from "../plugins/installed-plugin-index-records.js";
+import { RETAINED_MANAGED_NPM_DOCTOR_REPAIR_REASON } from "../plugins/managed-npm-retention-contract.js";
 import { markRetainedManagedNpmInstall } from "../plugins/managed-npm-retention.js";
 import { shortenHomePath } from "../utils.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
@@ -109,7 +110,7 @@ export async function maybeRepairStaleManagedNpmInstallGenerations(
       await markRetainedManagedNpmInstall({
         packageDir: generation.packageDir,
         pluginId: generation.pluginId,
-        reason: "doctor-repaired-stale-managed-npm-generation",
+        reason: RETAINED_MANAGED_NPM_DOCTOR_REPAIR_REASON,
       })
     ) {
       retired.push(generation);

--- a/src/gateway/server-retained-plugin-cleanup.test.ts
+++ b/src/gateway/server-retained-plugin-cleanup.test.ts
@@ -2,10 +2,15 @@ import fs from "node:fs";
 import path from "node:path";
 import { expect, it, vi } from "vitest";
 import { writePersistedInstalledPluginIndexInstallRecords } from "../plugins/installed-plugin-index-records.js";
-import { RETAINED_MANAGED_NPM_KEEP_FILES_REASON } from "../plugins/managed-npm-retention-contract.js";
+import {
+  RETAINED_MANAGED_NPM_GENERATION_UPDATE_REASON,
+  RETAINED_MANAGED_NPM_INFERENCE_ACTIVATION_REASON,
+  RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
+} from "../plugins/managed-npm-retention-contract.js";
 import {
   hasRetainedManagedNpmInstallMarker,
   markRetainedManagedNpmInstall,
+  resolveRetainedManagedNpmInstallMarkerPath,
 } from "../plugins/managed-npm-retention.js";
 import { writeManagedNpmPlugin } from "../plugins/test-helpers/managed-npm-plugin.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
@@ -65,7 +70,7 @@ it.each(["project", "legacy"] as const)(
         await markRetainedManagedNpmInstall({
           packageDir,
           pluginId: path.basename(packageDir),
-          reason: "replaced-plugin-generation",
+          reason: RETAINED_MANAGED_NPM_GENERATION_UPDATE_REASON,
         });
       }
       const log = { info: vi.fn(), warn: vi.fn() };
@@ -79,5 +84,87 @@ it.each(["project", "legacy"] as const)(
       expect(log.info).toHaveBeenCalledWith("cleaned 1 retained npm plugin generation(s)");
       expect(log.warn).not.toHaveBeenCalled();
     });
+  },
+);
+
+it("runs the Gateway cleanup owner across invalid and staged markers", async () => {
+  await withOpenClawTestState(
+    { label: "gateway-retained-plugin-cleanup-boundary" },
+    async (state) => {
+      const invalidPackageDir = writeManagedNpmPlugin({
+        stateDir: state.stateDir,
+        packageName: "@openclaw/invalid-plugin",
+        pluginId: "invalid-plugin",
+        version: "1.0.0",
+      });
+      await markRetainedManagedNpmInstall({
+        packageDir: invalidPackageDir,
+        pluginId: "invalid-plugin",
+        reason: RETAINED_MANAGED_NPM_GENERATION_UPDATE_REASON,
+      });
+      fs.writeFileSync(resolveRetainedManagedNpmInstallMarkerPath(invalidPackageDir), "{", "utf8");
+
+      const stagedPackageDir = writeManagedNpmPlugin({
+        stateDir: state.stateDir,
+        packageName: "@openclaw/codex",
+        pluginId: "codex",
+        version: "1.0.0",
+      });
+      await markRetainedManagedNpmInstall({
+        packageDir: stagedPackageDir,
+        pluginId: "codex",
+        reason: RETAINED_MANAGED_NPM_INFERENCE_ACTIVATION_REASON,
+      });
+      const log = { info: vi.fn(), warn: vi.fn() };
+
+      await cleanupRetainedPluginInstallGenerations({ log, startupInstallPaths: [] });
+
+      expect(fs.existsSync(invalidPackageDir)).toBe(true);
+      expect(hasRetainedManagedNpmInstallMarker(invalidPackageDir)).toBe(true);
+      expect(fs.existsSync(stagedPackageDir)).toBe(false);
+      expect(log.warn).toHaveBeenCalledOnce();
+      expect(log.info).toHaveBeenCalledWith("cleaned 1 retained npm plugin generation(s)");
+    },
+  );
+});
+
+it.runIf(process.platform !== "win32")(
+  "warns when a legacy retained marker cannot be read",
+  async () => {
+    await withOpenClawTestState(
+      { label: "gateway-retained-plugin-cleanup-access-error" },
+      async (state) => {
+        const packageDir = writeManagedNpmPlugin({
+          stateDir: state.stateDir,
+          packageName: "@openclaw/inaccessible-plugin",
+          pluginId: "inaccessible-plugin",
+          version: "1.0.0",
+          layout: "legacy",
+        });
+        await markRetainedManagedNpmInstall({
+          packageDir,
+          pluginId: "inaccessible-plugin",
+          reason: RETAINED_MANAGED_NPM_GENERATION_UPDATE_REASON,
+        });
+        const markerPath = resolveRetainedManagedNpmInstallMarkerPath(packageDir);
+        const markerDir = path.dirname(markerPath);
+        const log = { info: vi.fn(), warn: vi.fn() };
+        fs.chmodSync(markerDir, 0o000);
+
+        try {
+          await cleanupRetainedPluginInstallGenerations({ log, startupInstallPaths: [] });
+        } finally {
+          fs.chmodSync(markerDir, 0o700);
+        }
+
+        expect(fs.existsSync(packageDir)).toBe(true);
+        expect(fs.existsSync(markerPath)).toBe(true);
+        expect(log.info).not.toHaveBeenCalled();
+        expect(log.warn).toHaveBeenCalledOnce();
+        expect(log.warn).toHaveBeenCalledWith(
+          expect.stringContaining(`failed to clean retained npm generation ${packageDir}:`),
+        );
+      },
+    );
   },
 );

--- a/src/gateway/server-retained-plugin-cleanup.test.ts
+++ b/src/gateway/server-retained-plugin-cleanup.test.ts
@@ -128,7 +128,8 @@ it("runs the Gateway cleanup owner across invalid and staged markers", async () 
   );
 });
 
-it.runIf(process.platform !== "win32")(
+// Root bypasses mode bits, so chmod cannot model an unreadable marker there.
+it.runIf(process.platform !== "win32" && process.getuid?.() !== 0)(
   "warns when a legacy retained marker cannot be read",
   async () => {
     await withOpenClawTestState(

--- a/src/plugins/install-record-commit.retention.test.ts
+++ b/src/plugins/install-record-commit.retention.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { resolvePluginNpmGenerationProjectDir } from "./install-paths.js";
 import { commitPluginInstallRecordsWithConfig } from "./install-record-commit.js";
 import { listRecoveredManagedNpmInstallCandidates } from "./installed-plugin-index-record-reader.js";
 import {
@@ -137,6 +138,46 @@ describe("retained managed npm record commits", () => {
       ).resolves.toBe(1);
       expect(fs.existsSync(installPath)).toBe(false);
       expect(fs.existsSync(localInstallPath)).toBe(true);
+    });
+  });
+
+  it("keeps npm generation replacements cleanup-eligible", async () => {
+    await withOpenClawTestState({ label: "retained-generation-update" }, async (state) => {
+      const packageName = "@openclaw/updated-plugin";
+      const npmDir = state.statePath("npm");
+      const previousInstallPath = path.join(
+        resolvePluginNpmGenerationProjectDir({ npmDir, packageName, generationKey: "v1" }),
+        "node_modules",
+        "@openclaw",
+        "updated-plugin",
+      );
+      const nextInstallPath = path.join(
+        resolvePluginNpmGenerationProjectDir({ npmDir, packageName, generationKey: "v2" }),
+        "node_modules",
+        "@openclaw",
+        "updated-plugin",
+      );
+      fs.mkdirSync(previousInstallPath, { recursive: true });
+      fs.mkdirSync(nextInstallPath, { recursive: true });
+
+      await commitPluginInstallRecordsWithConfig({
+        previousInstallRecords: {
+          "updated-plugin": npmRecord(packageName, previousInstallPath),
+        },
+        nextInstallRecords: {
+          "updated-plugin": npmRecord(packageName, nextInstallPath),
+        },
+        nextConfig: {},
+      });
+
+      expect(hasRetainedManagedNpmInstallMarker(previousInstallPath)).toBe(true);
+      await expect(
+        cleanupRetainedManagedNpmInstallGenerations({
+          activeInstallPaths: [nextInstallPath],
+        }),
+      ).resolves.toBe(1);
+      expect(fs.existsSync(previousInstallPath)).toBe(false);
+      expect(fs.existsSync(nextInstallPath)).toBe(true);
     });
   });
 });

--- a/src/plugins/install-record-commit.ts
+++ b/src/plugins/install-record-commit.ts
@@ -38,7 +38,11 @@ import {
   type InstalledPluginIndexWriteReceipt,
 } from "./installed-plugin-index-store-write.js";
 import { readPersistedInstalledPluginIndex } from "./installed-plugin-index-store.js";
-import { RETAINED_MANAGED_NPM_KEEP_FILES_REASON } from "./managed-npm-retention-contract.js";
+import {
+  RETAINED_MANAGED_NPM_GENERATION_UPDATE_REASON,
+  RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
+  RETAINED_MANAGED_NPM_PLUGIN_SOURCE_CHANGE_REASON,
+} from "./managed-npm-retention-contract.js";
 import {
   clearRetainedManagedNpmInstallMarker,
   markRetainedManagedNpmInstall,
@@ -304,9 +308,9 @@ async function markRetiredManagedNpmInstallRecords(params: {
       pluginId,
       reason:
         nextRecord?.source === "npm"
-          ? "replaced-by-managed-npm-generation-update"
+          ? RETAINED_MANAGED_NPM_GENERATION_UPDATE_REASON
           : nextRecord
-            ? "replaced-by-plugin-source-change"
+            ? RETAINED_MANAGED_NPM_PLUGIN_SOURCE_CHANGE_REASON
             : RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
     });
     if (marked && !markerAlreadyExisted) {

--- a/src/plugins/managed-npm-retention-contract.ts
+++ b/src/plugins/managed-npm-retention-contract.ts
@@ -1,2 +1,28 @@
 /** Marker reason for packages preserved by an explicit `plugins uninstall --keep-files`. */
 export const RETAINED_MANAGED_NPM_KEEP_FILES_REASON = "removed-managed-npm-install-retained";
+
+/** Marker reason for stale generations retired by `openclaw doctor --fix`. */
+export const RETAINED_MANAGED_NPM_DOCTOR_REPAIR_REASON =
+  "doctor-repaired-stale-managed-npm-generation";
+
+/** Marker reason for a generation superseded by a managed npm update. */
+export const RETAINED_MANAGED_NPM_GENERATION_UPDATE_REASON =
+  "replaced-by-managed-npm-generation-update";
+
+/** Marker reason for a managed npm install superseded by another plugin source. */
+export const RETAINED_MANAGED_NPM_PLUGIN_SOURCE_CHANGE_REASON = "replaced-by-plugin-source-change";
+
+/** Marker reason for an uncommitted Codex inference activation kept for later GC. */
+export const RETAINED_MANAGED_NPM_INFERENCE_ACTIVATION_REASON =
+  "openclaw-inference-activation-not-committed";
+
+const RETAINED_MANAGED_NPM_CLEANUP_ELIGIBLE_REASONS = new Set<string>([
+  RETAINED_MANAGED_NPM_DOCTOR_REPAIR_REASON,
+  RETAINED_MANAGED_NPM_GENERATION_UPDATE_REASON,
+  RETAINED_MANAGED_NPM_PLUGIN_SOURCE_CHANGE_REASON,
+  RETAINED_MANAGED_NPM_INFERENCE_ACTIVATION_REASON,
+]);
+
+export function isRetainedManagedNpmCleanupEligibleReason(reason: string): boolean {
+  return RETAINED_MANAGED_NPM_CLEANUP_ELIGIBLE_REASONS.has(reason);
+}

--- a/src/plugins/managed-npm-retention.test.ts
+++ b/src/plugins/managed-npm-retention.test.ts
@@ -1,16 +1,23 @@
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   resolvePluginNpmGenerationProjectDir,
   resolvePluginNpmProjectDir,
 } from "./install-paths.js";
-import { RETAINED_MANAGED_NPM_KEEP_FILES_REASON } from "./managed-npm-retention-contract.js";
+import {
+  RETAINED_MANAGED_NPM_DOCTOR_REPAIR_REASON,
+  RETAINED_MANAGED_NPM_GENERATION_UPDATE_REASON,
+  RETAINED_MANAGED_NPM_INFERENCE_ACTIVATION_REASON,
+  RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
+  RETAINED_MANAGED_NPM_PLUGIN_SOURCE_CHANGE_REASON,
+} from "./managed-npm-retention-contract.js";
 import {
   cleanupRetainedManagedNpmInstallGenerations,
   hasRetainedManagedNpmInstallMarker,
   markRetainedManagedNpmInstall,
+  resolveRetainedManagedNpmInstallMarkerPath,
 } from "./managed-npm-retention.js";
 
 const retentionTempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -42,7 +49,7 @@ describe("managed npm retention", () => {
       await markRetainedManagedNpmInstall({
         packageDir: oldPackageDir,
         pluginId: "codex",
-        reason: "test-retired-generation",
+        reason: RETAINED_MANAGED_NPM_GENERATION_UPDATE_REASON,
       });
 
       await expect(
@@ -65,7 +72,7 @@ describe("managed npm retention", () => {
     await markRetainedManagedNpmInstall({
       packageDir,
       pluginId: "codex",
-      reason: "test-legacy-generation",
+      reason: RETAINED_MANAGED_NPM_DOCTOR_REPAIR_REASON,
     });
 
     await expect(
@@ -88,7 +95,7 @@ describe("managed npm retention", () => {
     await markRetainedManagedNpmInstall({
       packageDir,
       pluginId: "codex",
-      reason: "test-retired-generation",
+      reason: RETAINED_MANAGED_NPM_GENERATION_UPDATE_REASON,
     });
 
     await expect(cleanupRetainedManagedNpmInstallGenerations({ npmDir })).resolves.toBe(0);
@@ -112,11 +119,24 @@ describe("managed npm retention", () => {
     await markRetainedManagedNpmInstall({
       packageDir,
       pluginId: "codex",
-      reason: "test-retired-generation",
+      reason: RETAINED_MANAGED_NPM_GENERATION_UPDATE_REASON,
     });
 
     await expect(cleanupRetainedManagedNpmInstallGenerations({ npmDir })).resolves.toBe(0);
     expect(fs.readFileSync(sentinel, "utf8")).toBe("preserve me");
+  });
+
+  it("ignores unmarked legacy packages without reporting an error", async () => {
+    const stateDir = retentionTempDirs.make("openclaw-retention-");
+    const npmDir = path.join(stateDir, "npm");
+    const packageDir = path.join(npmDir, "node_modules", "@openclaw", "active-plugin");
+    fs.mkdirSync(packageDir, { recursive: true });
+    const onError = vi.fn();
+
+    await expect(cleanupRetainedManagedNpmInstallGenerations({ npmDir, onError })).resolves.toBe(0);
+
+    expect(fs.existsSync(packageDir)).toBe(true);
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it.each(["project", "legacy"] as const)(
@@ -145,4 +165,127 @@ describe("managed npm retention", () => {
       expect(hasRetainedManagedNpmInstallMarker(packageDir)).toBe(true);
     },
   );
+
+  it.each([
+    { layout: "project" as const, markerState: "corrupt" as const },
+    { layout: "legacy" as const, markerState: "corrupt" as const },
+    { layout: "project" as const, markerState: "unknown" as const },
+    { layout: "legacy" as const, markerState: "unknown" as const },
+  ])(
+    "preserves $layout package files for a $markerState marker",
+    async ({ layout, markerState }) => {
+      const stateDir = retentionTempDirs.make("openclaw-retention-");
+      const npmDir = path.join(stateDir, "npm");
+      const projectRoot =
+        layout === "legacy"
+          ? npmDir
+          : resolvePluginNpmGenerationProjectDir({
+              npmDir,
+              packageName: "@openclaw/kept-plugin",
+              generationKey: "kept-plugin-v1",
+            });
+      const packageDir = path.join(projectRoot, "node_modules", "@openclaw", "kept-plugin");
+      fs.mkdirSync(packageDir, { recursive: true });
+      await markRetainedManagedNpmInstall({
+        packageDir,
+        pluginId: "kept-plugin",
+        reason:
+          markerState === "unknown"
+            ? "future-retention-policy"
+            : RETAINED_MANAGED_NPM_GENERATION_UPDATE_REASON,
+      });
+      if (markerState === "corrupt") {
+        fs.writeFileSync(resolveRetainedManagedNpmInstallMarkerPath(packageDir), "{", "utf8");
+      }
+      const onError = vi.fn();
+
+      await expect(cleanupRetainedManagedNpmInstallGenerations({ npmDir, onError })).resolves.toBe(
+        0,
+      );
+
+      expect(fs.existsSync(packageDir)).toBe(true);
+      expect(hasRetainedManagedNpmInstallMarker(packageDir)).toBe(true);
+      expect(onError).toHaveBeenCalledOnce();
+      expect(onError).toHaveBeenCalledWith(
+        expect.any(Error),
+        layout === "legacy" ? packageDir : projectRoot,
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "reports inaccessible legacy markers while preserving package files",
+    async () => {
+      const stateDir = retentionTempDirs.make("openclaw-retention-");
+      const npmDir = path.join(stateDir, "npm");
+      const packageDir = path.join(npmDir, "node_modules", "@openclaw", "kept-plugin");
+      fs.mkdirSync(packageDir, { recursive: true });
+      await markRetainedManagedNpmInstall({
+        packageDir,
+        pluginId: "kept-plugin",
+        reason: RETAINED_MANAGED_NPM_GENERATION_UPDATE_REASON,
+      });
+      const markerPath = resolveRetainedManagedNpmInstallMarkerPath(packageDir);
+      const markerDir = path.dirname(markerPath);
+      const onError = vi.fn();
+      fs.chmodSync(markerDir, 0o000);
+
+      try {
+        expect(hasRetainedManagedNpmInstallMarker(packageDir)).toBe(true);
+        await expect(
+          cleanupRetainedManagedNpmInstallGenerations({ npmDir, onError }),
+        ).resolves.toBe(0);
+      } finally {
+        fs.chmodSync(markerDir, 0o700);
+      }
+
+      expect(fs.existsSync(packageDir)).toBe(true);
+      expect(fs.existsSync(markerPath)).toBe(true);
+      expect(onError).toHaveBeenCalledOnce();
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ code: expect.stringMatching(/^(?:EACCES|EPERM)$/u) }),
+        packageDir,
+      );
+    },
+  );
+
+  it("cleans staged Codex inference activation markers", async () => {
+    const stateDir = retentionTempDirs.make("openclaw-retention-");
+    const npmDir = path.join(stateDir, "npm");
+    const projectRoot = resolvePluginNpmGenerationProjectDir({
+      npmDir,
+      packageName: "@openclaw/codex",
+      generationKey: "inference-v1",
+    });
+    const packageDir = path.join(projectRoot, "node_modules", "@openclaw", "codex");
+    fs.mkdirSync(packageDir, { recursive: true });
+    await markRetainedManagedNpmInstall({
+      packageDir,
+      pluginId: "codex",
+      reason: RETAINED_MANAGED_NPM_INFERENCE_ACTIVATION_REASON,
+    });
+
+    await expect(cleanupRetainedManagedNpmInstallGenerations({ npmDir })).resolves.toBe(1);
+    expect(fs.existsSync(packageDir)).toBe(false);
+  });
+
+  it.each([
+    RETAINED_MANAGED_NPM_DOCTOR_REPAIR_REASON,
+    RETAINED_MANAGED_NPM_GENERATION_UPDATE_REASON,
+    RETAINED_MANAGED_NPM_PLUGIN_SOURCE_CHANGE_REASON,
+    RETAINED_MANAGED_NPM_INFERENCE_ACTIVATION_REASON,
+  ])("cleans the canonical cleanup-eligible reason %s", async (reason) => {
+    const stateDir = retentionTempDirs.make("openclaw-retention-contract-");
+    const npmDir = path.join(stateDir, "npm");
+    const packageDir = path.join(npmDir, "node_modules", "@openclaw", "retired-plugin");
+    fs.mkdirSync(packageDir, { recursive: true });
+    await markRetainedManagedNpmInstall({
+      packageDir,
+      pluginId: "retired-plugin",
+      reason,
+    });
+
+    await expect(cleanupRetainedManagedNpmInstallGenerations({ npmDir })).resolves.toBe(1);
+    expect(fs.existsSync(packageDir)).toBe(false);
+  });
 });

--- a/src/plugins/managed-npm-retention.test.ts
+++ b/src/plugins/managed-npm-retention.test.ts
@@ -213,7 +213,8 @@ describe("managed npm retention", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  // Root bypasses mode bits, so chmod cannot model an unreadable marker there.
+  it.runIf(process.platform !== "win32" && process.getuid?.() !== 0)(
     "reports inaccessible legacy markers while preserving package files",
     async () => {
       const stateDir = retentionTempDirs.make("openclaw-retention-");

--- a/src/plugins/managed-npm-retention.ts
+++ b/src/plugins/managed-npm-retention.ts
@@ -3,23 +3,61 @@ import fs from "node:fs";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { safePathSegmentHashed } from "../infra/install-safe-path.js";
-import { isPathInside } from "../infra/path-guards.js";
+import { isNotFoundPathError, isPathInside } from "../infra/path-guards.js";
 import {
   isPluginNpmProjectDir,
   resolveDefaultPluginNpmDir,
   resolvePluginNpmProjectsDir,
 } from "./install-paths.js";
-import { RETAINED_MANAGED_NPM_KEEP_FILES_REASON } from "./managed-npm-retention-contract.js";
+import {
+  isRetainedManagedNpmCleanupEligibleReason,
+  RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
+} from "./managed-npm-retention-contract.js";
 import { listManagedPluginNpmRootsSync } from "./npm-project-roots.js";
 
 const RETAINED_MANAGED_NPM_INSTALL_MARKER_DIR = ".openclaw-retained-npm-installs";
+const RETAINED_MANAGED_NPM_INSTALL_MARKER_VERSION = 1;
 
-function markerPreservesPackageFiles(markerPath: string): boolean {
+type MarkerCleanupDisposition =
+  | { kind: "absent" }
+  | { kind: "cleanup" }
+  | { kind: "preserve" }
+  | { kind: "invalid"; error: unknown };
+
+function classifyMarkerForCleanup(markerPath: string): MarkerCleanupDisposition {
   try {
     const marker: unknown = JSON.parse(fs.readFileSync(markerPath, "utf8"));
-    return isRecord(marker) && marker.reason === RETAINED_MANAGED_NPM_KEEP_FILES_REASON;
-  } catch {
-    return false;
+    if (
+      !isRecord(marker) ||
+      marker.version !== RETAINED_MANAGED_NPM_INSTALL_MARKER_VERSION ||
+      typeof marker.pluginId !== "string" ||
+      marker.pluginId.trim().length === 0 ||
+      typeof marker.retainedAt !== "string" ||
+      marker.retainedAt.trim().length === 0 ||
+      typeof marker.reason !== "string"
+    ) {
+      return {
+        kind: "invalid",
+        error: new Error(`Invalid retained managed npm marker: ${markerPath}`),
+      };
+    }
+    if (marker.reason === RETAINED_MANAGED_NPM_KEEP_FILES_REASON) {
+      return { kind: "preserve" };
+    }
+    if (isRetainedManagedNpmCleanupEligibleReason(marker.reason)) {
+      return { kind: "cleanup" };
+    }
+    return {
+      kind: "invalid",
+      error: new Error(`Unknown retained managed npm marker reason: ${markerPath}`),
+    };
+  } catch (error) {
+    if (isNotFoundPathError(error)) {
+      return { kind: "absent" };
+    }
+    // Cleanup requires positive proof that the marker is disposable. A damaged marker may be
+    // the only remaining record that package files were intentionally retained.
+    return { kind: "invalid", error };
   }
 }
 
@@ -63,7 +101,16 @@ export function resolveRetainedManagedNpmInstallMarkerPath(packageDir: string): 
 
 export function hasRetainedManagedNpmInstallMarker(packageDir: string): boolean {
   const info = resolveRetainedManagedNpmInstallPackageInfo(packageDir);
-  return info ? fs.existsSync(info.markerPath) : false;
+  if (!info) {
+    return false;
+  }
+  try {
+    fs.lstatSync(info.markerPath);
+    return true;
+  } catch (error) {
+    // Discovery must fail closed: an inaccessible marker cannot make retained files recoverable.
+    return !isNotFoundPathError(error);
+  }
 }
 
 export async function clearRetainedManagedNpmInstallMarker(packageDir: string): Promise<boolean> {
@@ -114,7 +161,7 @@ export async function markRetainedManagedNpmInstall(params: {
     info.markerPath,
     `${JSON.stringify(
       {
-        version: 1,
+        version: RETAINED_MANAGED_NPM_INSTALL_MARKER_VERSION,
         pluginId: params.pluginId,
         retainedAt: params.retainedAt ?? new Date().toISOString(),
         reason: params.reason,
@@ -178,11 +225,17 @@ async function cleanupRetainedLegacyNpmPackages(params: {
 }): Promise<number> {
   let removed = 0;
   for (const packageDir of listManagedNpmPackageDirs(params.npmRoot)) {
-    if (
-      !hasRetainedManagedNpmInstallMarker(packageDir) ||
-      markerPreservesPackageFiles(resolveRetainedManagedNpmInstallMarkerPath(packageDir)) ||
-      params.activeInstallPaths.some((installPath) => isPathInside(packageDir, installPath))
-    ) {
+    if (params.activeInstallPaths.some((installPath) => isPathInside(packageDir, installPath))) {
+      continue;
+    }
+    // Classify in one read so access failures cannot masquerade as a missing marker.
+    const disposition = classifyMarkerForCleanup(
+      resolveRetainedManagedNpmInstallMarkerPath(packageDir),
+    );
+    if (disposition.kind !== "cleanup") {
+      if (disposition.kind === "invalid") {
+        params.onError?.(disposition.error, packageDir);
+      }
       continue;
     }
     try {
@@ -236,9 +289,6 @@ export async function cleanupRetainedManagedNpmInstallGenerations(
     }
     if (
       markerEntries.length === 0 ||
-      markerEntries.some((entry) =>
-        markerPreservesPackageFiles(path.join(markerDir, entry.name)),
-      ) ||
       !isPathInside(projectsDir, projectRoot) ||
       !isOwnedManagedNpmProject({
         markerNames: new Set(markerEntries.map((entry) => entry.name)),
@@ -247,6 +297,19 @@ export async function cleanupRetainedManagedNpmInstallGenerations(
       }) ||
       activeInstallPaths.some((installPath) => isPathInside(projectRoot, installPath))
     ) {
+      continue;
+    }
+    let cleanupEligible = true;
+    for (const entry of markerEntries) {
+      const disposition = classifyMarkerForCleanup(path.join(markerDir, entry.name));
+      if (disposition.kind !== "cleanup") {
+        cleanupEligible = false;
+        if (disposition.kind === "invalid") {
+          params.onError?.(disposition.error, projectRoot);
+        }
+      }
+    }
+    if (!cleanupEligible) {
       continue;
     }
     try {

--- a/src/system-agent/setup-inference-persist.ts
+++ b/src/system-agent/setup-inference-persist.ts
@@ -12,6 +12,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
+import { RETAINED_MANAGED_NPM_INFERENCE_ACTIVATION_REASON } from "../plugins/managed-npm-retention-contract.js";
 import {
   stageProviderAuthProfilesForPersistence,
   type ProviderAuthProtectedProfilesReceipt,
@@ -87,7 +88,7 @@ export async function retainUnownedCodexInstall(params: {
     const marked = await markRetained({
       packageDir: params.record.installPath,
       pluginId: "codex",
-      reason: "openclaw-inference-activation-not-committed",
+      reason: RETAINED_MANAGED_NPM_INFERENCE_ACTIVATION_REASON,
     });
     if (!marked) {
       setupInferenceLog.warn("Could not retain the uncommitted Codex runtime package generation.");

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -30,6 +30,7 @@ import {
 import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-state.js";
 import * as pluginEnable from "../plugins/enable.js";
 import { withoutPluginInstallRecords } from "../plugins/installed-plugin-index-records.js";
+import { RETAINED_MANAGED_NPM_INFERENCE_ACTIVATION_REASON } from "../plugins/managed-npm-retention-contract.js";
 import { hasRetainedManagedNpmInstallMarker } from "../plugins/managed-npm-retention.js";
 import {
   rebasePluginMetadataSnapshotManifestRegistry,
@@ -5929,17 +5930,17 @@ describe("activateSetupInference", () => {
     expect(markRetained).toHaveBeenNthCalledWith(1, {
       packageDir: expectDefined(installRecords[0], "installRecords[0] test invariant").installPath,
       pluginId: "codex",
-      reason: "openclaw-inference-activation-not-committed",
+      reason: RETAINED_MANAGED_NPM_INFERENCE_ACTIVATION_REASON,
     });
     expect(markRetained).toHaveBeenNthCalledWith(2, {
       packageDir: expectDefined(installRecords[0], "installRecords[0] test invariant").installPath,
       pluginId: "codex",
-      reason: "openclaw-inference-activation-not-committed",
+      reason: RETAINED_MANAGED_NPM_INFERENCE_ACTIVATION_REASON,
     });
     expect(markRetained).toHaveBeenNthCalledWith(3, {
       packageDir: expectDefined(installRecords[1], "installRecords[1] test invariant").installPath,
       pluginId: "codex",
-      reason: "openclaw-inference-activation-not-committed",
+      reason: RETAINED_MANAGED_NPM_INFERENCE_ACTIVATION_REASON,
     });
     expect(clearInstallRecords).toHaveBeenCalledTimes(3);
     expect(clearMetadata).toHaveBeenCalledTimes(3);


### PR DESCRIPTION
Closes #121131

Follow-up to merged PR #113902.

## What Problem This Solves

Users who retained managed npm plugin files could lose those files during Gateway cleanup when the retention marker was truncated, malformed, unreadable, or used an unrecognized reason.

## Why This Change Was Made

Cleanup now classifies markers as absent, cleanup-eligible, preserved, or invalid. It removes package data only when the marker has the current version, complete metadata, and a canonical production cleanup reason. Explicit keep markers and invalid markers preserve the package, while invalid markers also flow through the existing `onError` callback.

Legacy cleanup no longer uses an `existsSync` preflight that can collapse marker access failures into absence. The shared existence helper treats non-missing filesystem errors as retained, so install-record recovery cannot make an inaccessible retained package active before Gateway cleanup reports the error.

The cleanup-eligible reason contract is exported from `src/plugins/managed-npm-retention-contract.ts`. The install-record, doctor, and staged inference producers import the same constants consumed by the cleanup classifier, preventing producer/consumer reason drift.

## User Impact

Managed npm plugin files requested with `plugins uninstall --keep-files` remain intact when their retention marker cannot be safely classified. Existing valid retired-generation markers remain cleanup-eligible. Inaccessible legacy markers are preserved and produce an operator-visible Gateway warning.

## Evidence

### Maintenance validation — 2026-09-09

I rebased this PR onto upstream main `338a53fbde2cd2668e987156a22b4383b4207bdc`. The current contributor head is `edaaff249310325859d55f47bc6106201f6de798`.

Resolved the setup-inference import conflict, preserving the current protected-auth-profile receipt contract. Also excluded root from the two chmod-based access-denied tests: UID 0 bypasses the mode bits, so those scenarios only apply to unprivileged Unix users.

Validation on Linux with Node 24.16.0 and the repository-pinned pnpm 12.3.4 / Vitest 5:
- `node scripts/run-vitest.mjs run src/gateway/server-retained-plugin-cleanup.test.ts src/plugins/managed-npm-retention.test.ts src/plugins/install-record-commit.retention.test.ts --reporter=dot`: 29 passed.
- `node scripts/run-vitest.mjs run src/system-agent/setup-inference.test.ts --reporter=dot`: 165 passed.
- Fresh structured autoreview covered actionable priorities P0–P3; no remaining accepted findings.
- `git diff --check` passed. Contributor author/committer identities and maintainer edit permission were verified before the exact-lease push.

These are focused regression checks, not a new live behavior proof. The earlier runtime/media/transcript receipts below belong to their stated historical heads and were not rerun on this rebased head. Upstream CI for the new head is reported by the checks attached to this PR; I am not claiming it green before completion.

### Earlier validation receipts (historical heads)

- Focused generated/legacy regressions cover malformed and unknown markers, real POSIX `EACCES`, a normal absent marker, all canonical cleanup reasons, and the staged Codex inference reason.
- Install-record recovery and Gateway-owner regressions prove an inaccessible legacy marker remains retained, reaches `onError`, becomes a Gateway warning, and leaves package and marker files on disk.
- Producer regressions prove real install-record, doctor, and inference paths write the canonical reasons accepted by cleanup.
- Fresh whole-branch autoreview at the current head reports no accepted/actionable P0-P2 findings (`patch is correct`, confidence 0.93). Fresh proof-workflow autoreview is also clean (`patch is correct`, confidence 0.92).
- `git diff --check` and TruffleHog pass. No config, protocol, SDK, database, or migration surface changes.

## Current Exact Head (2026-08-10)

- Exact head: `ae89b01edf9dee0aa18597dd6b5aecfbb4a95d79`.
- The six-commit branch was rebased without conflicts onto `46e941c3036d8e8f59a71ce3b6664b29487e0616`; the official PR run used base `c3f4d5ee601ad6f3753daf72b0deac2ed171a286` after two unrelated main commits.
- [Exact-head upstream CI run 31384301911](https://github.com/openclaw/openclaw/actions/runs/31384301911) completed. Build artifacts, lint, production checks, plugin contract shards, the three-test Gateway cleanup-owner file, and the 127-test inference file passed.
- The run's five root failures are inherited from current `main`: `check-test-types`, `checks-node-compact-large-2`, and compact small shards 7, 9, and 11 fail in auto-reply/outbound/Telegram/Discord `onPlatformSendDispatch` work outside this PR. The aggregate `openclaw/ci-gate` then fails. [Current-main run 31383550120](https://github.com/openclaw/openclaw/actions/runs/31383550120) at the exact PR base SHA has the identical five root failures and aggregate gate; none of the failing files is touched here.

## Codex Dependency Contract Check (2026-08-10)

- Inspected sibling OpenAI Codex source at `315195492c80fdade38e917c18f9584efd599304`: `codex-rs/cli/src/plugin_cmd.rs:585-618` resolves `CODEX_HOME` and CLI auth; `codex-rs/cli/src/doctor/updates.rs:50-78` treats `CODEX_MANAGED_PACKAGE_ROOT` as the npm-managed install-root contract; `sdk/typescript/src/codex.ts:15-27`, `sdk/typescript/src/thread.ts:70-113`, and `sdk/typescript/src/exec.ts:86-184` show the TypeScript SDK delegates to `codex exec --experimental-json` while preserving the configured environment.
- This PR does not change Codex protocol, SDK, auth, or package resolution. The retention marker is an OpenClaw-owned cleanup contract produced by `src/system-agent/setup-inference-persist.ts` and consumed by Gateway cleanup.
- The exact-head Gateway boundary proof exercises the OpenClaw owner boundary without credentials; it does not infer or reimplement Codex runtime behavior.

## Standalone Runtime Owner Proof (2026-08-10)

- [Fork proof run 31384914581](https://github.com/Leon-SK668/openclaw/actions/runs/31384914581) and its [runtime-proof job](https://github.com/Leon-SK668/openclaw/actions/runs/31384914581/job/93443061455) completed successfully after anonymously checking out and asserting exact PR head `ae89b01edf9dee0aa18597dd6b5aecfbb4a95d79`.
- The workflow has `permissions: {}`, uses no secrets, and does not substitute an existing Vitest for runtime evidence. One standalone TypeScript process creates real managed-npm filesystem state under an isolated temporary `OPENCLAW_STATE_DIR`, imports production `cleanupRetainedPluginInstallGenerations`, and invokes the cleanup owner used by Gateway idle maintenance. It does not start a full Gateway, QA/E2E lane, or full build.
- It proves simultaneously that a malformed generated marker is preserved and warned, an inaccessible legacy marker produces `EACCES` and is preserved and warned, all three canonical retired-generation reasons are removed, and the staged Codex inference marker is removed.
- Redacted owner log marker: `PR121156_CLEANUP_OWNER_RUNTIME_LOG {"info":["cleaned 4 retained npm plugin generation(s)"],"warn":["failed to clean retained npm generation $STATE/npm/node_modules/@openclaw/inaccessible-proof-plugin: Error: EACCES: permission denied, open '$STATE/...'","failed to clean retained npm generation $STATE/npm/projects/...: SyntaxError: ..."]}`.
- Result marker: `PR121156_RETAINED_NPM_PROOF {"head":"ae89b01edf9dee0aa18597dd6b5aecfbb4a95d79","invalidPackagePreserved":true,"invalidMarkerPreserved":true,"inaccessibleLegacyPackagePreserved":true,"inaccessibleLegacyMarkerPreserved":true,"inaccessibleLegacyWarned":true,"warningCount":2,"canonicalCleanupReasons":["doctor-repaired-stale-managed-npm-generation","replaced-by-managed-npm-generation-update","replaced-by-plugin-source-change"],"canonicalRetiredProjectsRemoved":true,"stagedCodexReason":"openclaw-inference-activation-not-committed","stagedCodexProjectRemoved":true,"cleanedGenerationCount":4}`.

## Current-Main Refresh (2026-08-17)

- Ordinary merge of frozen `main@fc8ee406a24031038dd9014d1e853f2b37687f7a`; exact head is `d3777158b11788f445e91ab1e0f0c060eeb10a04`. The PR is now mergeable; no force push was used.
- The two conflicts were reconciled by retaining both safety layers: only structurally valid markers with a canonical cleanup-eligible reason may delete data, and only canonical OpenClaw-owned project/generation roots that pass the current symlink/path checks may be removed.
- The generation-replacement proof now uses production `resolvePluginNpmGenerationProjectDir` instead of a hand-written noncanonical directory. Business scope remains nine files at `+399/-31`.
- Node 24.15.0 exact focused proof: 129 setup-inference tests, 3 Gateway cleanup-owner tests, and 24 retention/install-record tests passed (156 total). The initial merged run exposed the noncanonical fixture; after correcting it, the affected two-file plugin shard passed 24/24.
- Exact nine-file `oxfmt --check`, `oxlint --deny-warnings`, staged/worktree diff checks: passed.
- Fresh exact-result Codex autoreview (`gpt-5.6-sol`, high): clean, no P0/P1 findings; TruffleHog clean; correctness 0.91.
- Exact-head CI started in run 31991859861: https://github.com/openclaw/openclaw/actions/runs/31991859861 (pending at evidence update; no green claim).

### Current Codex Dependency Contract

- Personally inspected sibling OpenAI Codex source at `279b93242cfef379e65da97e87e44b83c5934fd7`: `codex-cli/bin/codex.js:179-198` injects `CODEX_MANAGED_PACKAGE_ROOT` plus the detected package-manager marker; `codex-rs/install-context/src/lib.rs:119-136` maps those markers into install ownership; `codex-rs/cli/src/doctor.rs:777-808,993-1023` and `codex-rs/cli/src/doctor/updates.rs:50-85` consume the managed install context for diagnostics and update targeting.
- `sdk/typescript/src/codex.ts:15-27`, `sdk/typescript/src/thread.ts:70-113`, and `sdk/typescript/src/exec.ts:86-184` confirm the SDK passes configured environment into `codex exec --experimental-json`. This PR does not change Codex protocol, SDK, authentication, or update behavior; its marker lifecycle remains OpenClaw-owned cleanup state.\n\n### Identity refresh (2026-08-20)\n\n- Metadata-only history rewrite: new head `83d6082b29aeb1c5e7d4bfabeed57db5669096df`; all rewritten commits now use `Leon-SK668 <0668001470@xydigit.com>` for both author and committer. Commit trees, messages, timestamps, parent structure, and the PR business diff are unchanged.\n- No product code or proof claim changed in this refresh. Existing focused tests/CI/review evidence remains behaviorally applicable to the unchanged tree; this new head is available for the normal exact-head checks.\n

### Missing-Path Dependency Verification

September 5, 2026; unchanged product head `b94cbb54666cd6fe578e43cba90d3e77b33e59cd`. Personally inspected the complete cleanup/classification owner and its `src/infra/path-guards.ts` re-export, then the installed pinned `@openclaw/fs-safe@0.7.2/dist/path.js` implementation and types. `isNotFoundPathError` accepts only string codes in `{ENOENT, ENOTDIR}`; it does not collapse access errors, I/O errors, symlink loops, or malformed JSON into missing paths.

Executed the actual pinned helper under Linux/Node 24 with error objects carrying `ENOENT`, `ENOTDIR`, `EACCES`, `EPERM`, `ELOOP`, `EIO`, plus a JSON `SyntaxError`. Result: `true,true,false,false,false,false,false`, all assertions passed. This is a direct dependency contract probe, not a new Gateway cleanup or OS-permission live run. It supplements, rather than relabels, the earlier filesystem cleanup evidence.

The maintainer decision is still open: uncertain durable retention markers preserve files, and inaccessible markers exclude packages from automatic recovery until repaired. This update verifies the missing-path predicate only; it does not claim owner acceptance of that upgrade/recovery policy. No source, config, dependency pin, or branch head changed.
