### PR TITLE
refactor(gateway): carve agent turn principal and context types

### DIFF
--- a/src/gateway/agent-turn/types.ts
+++ b/src/gateway/agent-turn/types.ts
@@ -1,0 +1,27 @@
+import type { GatewayClient, GatewayRequestContext } from "../server-methods/shared-types.js";
+
+export type AgentTurnPrincipal = Pick<
+  GatewayClient,
+  | "authenticatedUserId"
+  | "authenticatedUserProfile"
+  | "connId"
+  | "connect"
+  | "internal"
+  | "isDeviceTokenAuth"
+>;
+
+export type AgentTurnContext = Pick<
+  GatewayRequestContext,
+  | "addChatRun"
+  | "broadcastToConnIds"
+  | "chatAbortControllers"
+  | "chatQueuedTurns"
+  | "dedupe"
+  | "deps"
+  | "getRuntimeConfig"
+  | "getSessionEventSubscriberConnIds"
+  | "loadGatewayModelCatalog"
+  | "loadGatewayModelCatalogSnapshot"
+  | "logGateway"
+  | "registerToolEventRecipient"
+>;

--- a/src/gateway/server-methods/agent-admission-controller.ts
+++ b/src/gateway/server-methods/agent-admission-controller.ts
@@ -11,6 +11,7 @@ import {
   beginSessionWorkAdmission,
   type SessionWorkAdmissionLease,
 } from "../../sessions/session-lifecycle-admission.js";
+import type { AgentTurnContext } from "../agent-turn/types.js";
 import { registerChatAbortController } from "../chat-abort.js";
 import { loadSessionEntry } from "../session-utils.js";
 import type { AgentDedupeLifecycle } from "./agent-dedupe-lifecycle.js";
@@ -34,7 +35,7 @@ export function createAgentAdmissionController(params: {
   agentDedupeKeys: string[];
   preAcceptedReservedSessionKey?: string;
   expectedSession?: ExpectedExistingSessionConstraint;
-  context: GatewayRequestHandlerOptions["context"];
+  context: AgentTurnContext;
   respond: GatewayRequestHandlerOptions["respond"];
   dedupeLifecycle: AgentDedupeLifecycle;
   getRequestedSessionKey: () => string | undefined;

--- a/src/gateway/server-methods/agent-content-phase.ts
+++ b/src/gateway/server-methods/agent-content-phase.ts
@@ -29,6 +29,7 @@ import {
   isInternalNonDeliveryChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
+import type { AgentTurnContext } from "../agent-turn/types.js";
 import { resolveChatAttachmentMaxBytes } from "../chat-attachment-policy.js";
 import {
   MediaOffloadError,
@@ -69,7 +70,7 @@ type AgentContentPhaseResult = {
 export async function prepareAgentContentPhase(params: {
   request: AgentRunRequest;
   cfg: OpenClawConfig;
-  context: GatewayRequestHandlerOptions["context"];
+  context: AgentTurnContext;
   respond: GatewayRequestHandlerOptions["respond"];
   isRawModelRun: boolean;
   inputProvenance?: InputProvenance;

--- a/src/gateway/server-methods/agent-dedupe-lifecycle.ts
+++ b/src/gateway/server-methods/agent-dedupe-lifecycle.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { AGENT_RUN_RESTART_ABORT_STOP_REASON } from "../../agents/run-termination.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
+import type { AgentTurnContext } from "../agent-turn/types.js";
 import { resolveAgentRunExpiresAtMs } from "../chat-abort.js";
 import { resolveSessionStoreKey } from "../session-utils.js";
 import {
@@ -25,7 +26,7 @@ import type { GatewayRequestHandlerOptions } from "./types.js";
 export type AgentDedupeLifecycle = ReturnType<typeof createAgentDedupeLifecycle>;
 
 export function createAgentDedupeLifecycle(params: {
-  cfg: ReturnType<GatewayRequestHandlerOptions["context"]["getRuntimeConfig"]>;
+  cfg: ReturnType<AgentTurnContext["getRuntimeConfig"]>;
   request: AgentRunRequest;
   runId: string;
   lifecycleGeneration: string;
@@ -33,7 +34,7 @@ export function createAgentDedupeLifecycle(params: {
   suppressVisibleSessionEffects: boolean;
   ownerConnId?: string;
   ownerDeviceId?: string;
-  context: GatewayRequestHandlerOptions["context"];
+  context: AgentTurnContext;
   respond: GatewayRequestHandlerOptions["respond"];
 }) {
   let reserved = false;

--- a/src/gateway/server-methods/agent-delivery-phase.ts
+++ b/src/gateway/server-methods/agent-delivery-phase.ts
@@ -20,6 +20,7 @@ import {
   isInternalNonDeliveryChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
+import type { AgentTurnContext, AgentTurnPrincipal } from "../agent-turn/types.js";
 import { formatForLog } from "../ws-log.js";
 import type { AgentRunRequest } from "./agent-request-types.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
@@ -53,8 +54,8 @@ export async function resolveAgentDeliveryPhase(params: {
   recipientThreadId?: string | number;
   bestEffortDeliver: boolean;
   runId: string;
-  client: GatewayRequestHandlerOptions["client"];
-  context: GatewayRequestHandlerOptions["context"];
+  client: AgentTurnPrincipal | null;
+  context: AgentTurnContext;
   respond: GatewayRequestHandlerOptions["respond"];
   isWebchatConnect: GatewayRequestHandlerOptions["isWebchatConnect"];
 }): Promise<AgentDeliveryPhaseResult | undefined> {

--- a/src/gateway/server-methods/agent-request-preflight.ts
+++ b/src/gateway/server-methods/agent-request-preflight.ts
@@ -23,6 +23,7 @@ import {
   shouldPreserveUserFacingSessionStateForInputProvenance,
 } from "../../sessions/input-provenance.js";
 import { isSubagentSessionKey } from "../../sessions/session-key-utils.js";
+import type { AgentTurnContext, AgentTurnPrincipal } from "../agent-turn/types.js";
 import {
   isAcceptedAgentDedupePayload,
   readGatewayDedupeEntry,
@@ -43,7 +44,7 @@ import { assertValidParams } from "./validation.js";
 
 type AgentRequestPreflight = {
   request: AgentRunRequest;
-  cfg: ReturnType<GatewayRequestHandlerOptions["context"]["getRuntimeConfig"]>;
+  cfg: ReturnType<AgentTurnContext["getRuntimeConfig"]>;
   runId: string;
   lifecycleGeneration: string;
   allowModelOverride: boolean;
@@ -67,7 +68,10 @@ type AgentRequestPreflight = {
 };
 
 export function prepareAgentRequestPreflight(
-  params: Pick<GatewayRequestHandlerOptions, "params" | "respond" | "context" | "client">,
+  params: Pick<GatewayRequestHandlerOptions, "params" | "respond"> & {
+    context: AgentTurnContext;
+    client: AgentTurnPrincipal | null;
+  },
 ): AgentRequestPreflight | undefined {
   if (!assertValidParams(params.params, validateAgentParams, "agent", params.respond)) {
     return undefined;

--- a/src/gateway/server-methods/agent-request-routing.ts
+++ b/src/gateway/server-methods/agent-request-routing.ts
@@ -18,6 +18,7 @@ import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
+import type { AgentTurnContext } from "../agent-turn/types.js";
 import { loadSessionEntry, resolveSessionStoreKey } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
 import { setGatewayDedupeEntries } from "./agent-dedupe.js";
@@ -55,7 +56,7 @@ export async function prepareAgentRequestRouting(params: {
   execApprovalFollowupApprovalId?: string;
   runId: string;
   agentDedupeKeys: string[];
-  context: GatewayRequestHandlerOptions["context"];
+  context: AgentTurnContext;
   respond: GatewayRequestHandlerOptions["respond"];
   reserveDedupe: (sessionKey?: string, agentId?: string) => void;
   clearDedupe: () => void;
@@ -268,7 +269,7 @@ function dropReboundExecApprovalFollowup(params: {
   execApprovalFollowupApprovalId?: string;
   runId: string;
   agentDedupeKeys: string[];
-  context: GatewayRequestHandlerOptions["context"];
+  context: AgentTurnContext;
   respond: GatewayRequestHandlerOptions["respond"];
 }): boolean {
   if (!params.execApprovalFollowupApprovalId || !params.requestedSessionKeyRaw) {

--- a/src/gateway/server-methods/agent-run-admission-phase.ts
+++ b/src/gateway/server-methods/agent-run-admission-phase.ts
@@ -22,6 +22,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { claimAgentRunContext } from "../../infra/agent-run-registry.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
 import type { SessionWorkAdmissionLease } from "../../sessions/session-lifecycle-admission.js";
+import type { AgentTurnContext, AgentTurnPrincipal } from "../agent-turn/types.js";
 import { registerChatAbortController, resolveAgentRunExpiresAtMs } from "../chat-abort.js";
 import { loadSessionEntry, resolveSessionModelRef } from "../session-utils.js";
 import { consumeSubagentCompletionToolHandoff } from "../subagent-completion-tool-handoff.js";
@@ -93,8 +94,8 @@ export async function prepareAgentRunDispatch(params: {
   isRestartRecoveryResumeRun: boolean;
   runId: string;
   agentDedupeKeys: readonly string[];
-  context: GatewayRequestHandlerOptions["context"];
-  client: GatewayRequestHandlerOptions["client"];
+  context: AgentTurnContext;
+  client: AgentTurnPrincipal | null;
   respond: GatewayRequestHandlerOptions["respond"];
   abortForLifecycleRotation: (target?: { sessionKey?: string; agentId?: string }) => boolean;
   acquireGatewayWorkAdmission: (scope: string) => Promise<void>;

--- a/src/gateway/server-methods/agent-run-dispatch.ts
+++ b/src/gateway/server-methods/agent-run-dispatch.ts
@@ -17,6 +17,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { createRunningTaskRun } from "../../tasks/detached-task-runtime.js";
 import { mapAgentRunTerminalOutcomeToTaskStatus } from "../../tasks/task-registry-common.js";
 import { normalizeDeliveryContext } from "../../utils/delivery-context.shared.js";
+import type { AgentTurnContext } from "../agent-turn/types.js";
 import type { ChatAbortControllerEntry } from "../chat-abort.js";
 import { formatForLog } from "../ws-log.js";
 import { setGatewayDedupeEntries } from "./agent-dedupe.js";
@@ -25,7 +26,7 @@ import {
   type GatewayAgentTaskTrackingMode,
 } from "./agent-task-tracking.js";
 import type { GatewayCronCreatorAuthorityAdmission } from "./cron-creator-authority-admission.js";
-import type { GatewayRequestContext, GatewayRequestHandlerOptions } from "./types.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
 
 function resolveResolvedAgentTimeoutStopReason(
   meta: unknown,
@@ -95,7 +96,7 @@ export function resolveAbortedAgentStopReason(entry?: ChatAbortControllerEntry):
 }
 
 export function deleteGatewayDedupeEntries(params: {
-  dedupe: GatewayRequestContext["dedupe"];
+  dedupe: AgentTurnContext["dedupe"];
   keys: readonly string[];
 }) {
   for (const key of params.keys) {
@@ -116,7 +117,7 @@ export function dispatchAgentRunFromGateway(params: {
   abortController: AbortController;
   cleanupAbortController: () => void;
   respond: GatewayRequestHandlerOptions["respond"];
-  context: GatewayRequestHandlerOptions["context"];
+  context: AgentTurnContext;
   taskTrackingMode: Exclude<GatewayAgentTaskTrackingMode, "plugin_subagent">;
   restoreAdmittedRecovery?: () => Promise<MainSessionRecoveryPendingTarget | undefined>;
   onSettled?: (outcome: {

--- a/src/gateway/server-methods/agent-run-execution-phase.ts
+++ b/src/gateway/server-methods/agent-run-execution-phase.ts
@@ -40,6 +40,7 @@ import {
   buildRunUserTurnIdempotencyKey,
   createUserTurnTranscriptRecorder,
 } from "../../sessions/user-turn-transcript.js";
+import type { AgentTurnContext, AgentTurnPrincipal } from "../agent-turn/types.js";
 import { reactivateCompletedSubagentSession } from "../session-subagent-reactivation.js";
 import { loadSessionEntry } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
@@ -109,8 +110,8 @@ export function startAgentRunExecution(params: {
   restoredCronContinuation?: RestoredCronContinuation;
   canUseInternalRuntimeHandoff: boolean;
   execApprovalFollowupApprovalId?: string;
-  client: GatewayRequestHandlerOptions["client"];
-  context: GatewayRequestHandlerOptions["context"];
+  client: AgentTurnPrincipal | null;
+  context: AgentTurnContext;
   respond: GatewayRequestHandlerOptions["respond"];
   releaseCronContinuationClaimWithRecovery: (
     outcome?: { terminalOutcome: AgentRunTerminalOutcome },

--- a/src/gateway/server-methods/agent-run-model-selection.ts
+++ b/src/gateway/server-methods/agent-run-model-selection.ts
@@ -3,11 +3,11 @@ import { isCliProvider } from "../../agents/model-selection.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { applySessionEntryReplacements } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { AgentTurnContext } from "../agent-turn/types.js";
 import { updateChatRunProvider } from "../chat-abort.js";
-import type { GatewayRequestHandlerOptions } from "./types.js";
 
 export function createAgentRunModelSelectionHandler(params: {
-  context: GatewayRequestHandlerOptions["context"];
+  context: Pick<AgentTurnContext, "chatAbortControllers">;
   runId: string;
   cfg: OpenClawConfig;
   cfgForAgent?: OpenClawConfig;


### PR DESCRIPTION
## What Problem This Solves

The gateway agent phases consume the full `GatewayClient` and `GatewayRequestContext`, hiding which capabilities the turn pipeline actually needs and blocking a transport-free `AgentTurnService` extraction.

## Why This Change Was Made

Phase 1 of the `AgentTurnService`/`GatewayKernel` split — introduce `AgentTurnPrincipal` and `AgentTurnContext` (the verified minimal member sets, trusted `client.internal.*` flags carried verbatim) and narrow the phase signatures. Zero runtime change; the handler still passes the full objects via structural typing. Follow-up PRs: respond-sink narrowing, service extraction, typed internal principal path.

## User Impact

None (types only).

## Evidence

- tsgo core + core:test lanes
- agent umbrella: 278 tests
- gateway agent A: 24 tests; B: 12 tests
- in-process abort: 4 tests
- instance runtime: 6 tests
- formatting, lint, and diff check
- Codex autoreview clean
- Exact-head PR CI: run 31326429493 passed
- Net +39 production LOC (two type definitions)
- Local `check-changed` fallback stopped on a pre-existing unrelated `ui/package.json` `@novnc/novnc` pin complaint; this branch does not touch that file. The complaint did not appear in exact-head PR CI. It does reproduce on current `origin/main`: the relevant files match `origin/main`, and `node --import tsx scripts/check-dependency-pins.mts` reports only `ui/package.json:dependencies:@novnc/novnc -> "^1.7.0"`.
