### PR TITLE
fix(ai): retain Responses request ownership through response hooks

### DIFF
--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -51,7 +51,11 @@ import {
   type ResponsesEncryptedContentAttempt,
 } from "../transports/openai-responses-replay-internal.js";
 import { processResponsesStream } from "../transports/openai-responses-stream-internal.js";
-import { transportAbortError } from "../transports/transport-stream-shared.js";
+import { createOpenAIResponseHook } from "../transports/openai-transport-shared.js";
+import {
+  transportAbortError,
+  withProviderResponseHook,
+} from "../transports/transport-stream-shared.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../transports/transport-utils.js";
 import type {
   AssistantMessage,
@@ -73,6 +77,7 @@ import {
   createFirstStreamEventAbortController,
   getFirstStreamEventTimeoutHandler,
   getFirstStreamEventTimeoutMs,
+  withFirstStreamEventTimeout,
 } from "../utils/stream-first-event-timeout.js";
 import { createSseByteGuard } from "../utils/streaming-byte-guard.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
@@ -507,14 +512,29 @@ export const streamOpenAICodexResponses: StreamFunction<
           }
 
           response = attemptResponse;
-          await options?.onResponse?.(
-            { status: attemptResponse.status, headers: headersToRecord(attemptResponse.headers) },
-            model,
-          );
           if (attemptResponse.ok) {
             break;
           }
-          const errorText = await readChatGptResponsesErrorTextLimited(attemptResponse);
+          const hookStream = withFirstStreamEventTimeout(
+            withProviderResponseHook({
+              signal: firstEventAbort.signal,
+              abort: firstEventAbort.abort,
+              hook: createOpenAIResponseHook(options?.onResponse, attemptResponse, model),
+            }),
+            {
+              provider: model.provider,
+              api: model.api,
+              model: model.id,
+              timeoutMs: getFirstStreamEventTimeoutMs(options) ?? 0,
+              stage: "responses",
+              abort: firstEventAbort.abort,
+              onTimeout: getFirstStreamEventTimeoutHandler(options),
+            },
+          );
+          const [errorText] = await Promise.all([
+            readChatGptResponsesErrorTextLimited(attemptResponse, activeSignal),
+            hookStream[Symbol.asyncIterator]().next(),
+          ]);
           if (attempt < maxRetries && isRetryableError(attemptResponse.status, errorText)) {
             await sleepWithAbort(resolveHttpRetryDelayMs(attemptResponse, attempt), activeSignal);
             continue;
@@ -562,8 +582,27 @@ export const streamOpenAICodexResponses: StreamFunction<
         semanticAttempt = nextSemanticAttempt;
       }
 
-      stream.push({ type: "start", partial: output });
-      await processStream(response, output, stream, model, options, firstEventAbort.abort);
+      const hookedResponseStream = withProviderResponseHook({
+        stream: mapCodexEvents(parseSSE(response)),
+        signal: firstEventAbort.signal,
+        abort: firstEventAbort.abort,
+        hook: createOpenAIResponseHook(options?.onResponse, response, model),
+        onReady: () => stream.push({ type: "start", partial: output }),
+      });
+      await processResponsesStream(hookedResponseStream, output, stream, model, {
+        serviceTier: options?.serviceTier,
+        firstEventTimeoutMs: getFirstStreamEventTimeoutMs(options),
+        abortFirstEventStream: firstEventAbort.abort,
+        onFirstEventTimeout: getFirstStreamEventTimeoutHandler(options),
+        signal: options?.signal,
+        reasoningReplayMetadata: buildOpenAIResponsesReasoningReplayMetadata(model, {
+          sessionId: options?.sessionId,
+          authProfileId: options?.authProfileId,
+        }),
+        resolveServiceTier: resolveCodexServiceTier,
+        applyServiceTierPricing: (usage, serviceTier) =>
+          applyResponsesServiceTierPricing(usage, serviceTier, model),
+      });
 
       if (activeSignal?.aborted) {
         throw transportAbortError(activeSignal);
@@ -725,30 +764,6 @@ function resolveCodexWebSocketUrl(baseUrl?: string): string {
 // ============================================================================
 // Response Processing
 // ============================================================================
-
-async function processStream(
-  response: Response,
-  output: AssistantMessage,
-  stream: AssistantMessageEventStream,
-  model: Model<"openai-chatgpt-responses">,
-  options?: OpenAICodexResponsesOptions,
-  abortFirstEventStream?: (reason: Error) => void,
-): Promise<void> {
-  await processResponsesStream(mapCodexEvents(parseSSE(response)), output, stream, model, {
-    serviceTier: options?.serviceTier,
-    firstEventTimeoutMs: getFirstStreamEventTimeoutMs(options),
-    abortFirstEventStream,
-    onFirstEventTimeout: getFirstStreamEventTimeoutHandler(options),
-    signal: options?.signal,
-    reasoningReplayMetadata: buildOpenAIResponsesReasoningReplayMetadata(model, {
-      sessionId: options?.sessionId,
-      authProfileId: options?.authProfileId,
-    }),
-    resolveServiceTier: resolveCodexServiceTier,
-    applyServiceTierPricing: (usage, serviceTier) =>
-      applyResponsesServiceTierPricing(usage, serviceTier, model),
-  });
-}
 
 class CodexApiError extends Error {
   readonly code?: string;
@@ -1654,7 +1669,10 @@ async function processWebSocketStream(
 // Error Handling
 // ============================================================================
 
-async function readChatGptResponsesErrorTextLimited(response: Response): Promise<string> {
+async function readChatGptResponsesErrorTextLimited(
+  response: Response,
+  signal?: AbortSignal,
+): Promise<string> {
   const reader = response.body?.getReader();
   if (!reader) {
     return "";
@@ -1664,11 +1682,26 @@ async function readChatGptResponsesErrorTextLimited(response: Response): Promise
   let total = 0;
   let text = "";
   let reachedLimit = false;
+  let completed = false;
+  let cancelPromise: Promise<void> | undefined;
+  const cancel = () => {
+    cancelPromise ??= reader.cancel(signal?.reason).catch(() => {});
+    return cancelPromise;
+  };
+  const onAbort = () => {
+    void cancel();
+  };
+  if (signal?.aborted) {
+    onAbort();
+  } else {
+    signal?.addEventListener("abort", onAbort, { once: true });
+  }
 
   try {
     while (true) {
       const { value, done } = await reader.read();
       if (done) {
+        completed = true;
         break;
       }
       if (!value || value.byteLength === 0) {
@@ -1693,9 +1726,10 @@ async function readChatGptResponsesErrorTextLimited(response: Response): Promise
       text += decoder.decode();
     }
   } finally {
-    if (reachedLimit) {
-      // This provider module is browser-safe, so keep error-body capping on Web APIs.
-      await reader.cancel().catch(() => {});
+    signal?.removeEventListener("abort", onAbort);
+    if (!completed) {
+      // This provider module is browser-safe, so keep error-body cleanup on Web APIs.
+      await cancel();
     }
     try {
       reader.releaseLock();

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -28,7 +28,11 @@ import {
   readOpenAIResponsesReasoningReplayBlockMetadata,
 } from "../transports/openai-responses-replay-internal.js";
 import { processResponsesStream } from "../transports/openai-responses-stream-internal.js";
-import { transportAbortError } from "../transports/transport-stream-shared.js";
+import { createOpenAIResponseHook } from "../transports/openai-transport-shared.js";
+import {
+  transportAbortError,
+  withProviderResponseHook,
+} from "../transports/transport-stream-shared.js";
 import type {
   Api,
   AssistantMessage,
@@ -41,7 +45,6 @@ import type {
 } from "../types.js";
 import type { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { shortHash } from "../utils/hash.js";
-import { headersToRecord } from "../utils/headers.js";
 import { projectProviderError } from "../utils/provider-error.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import {
@@ -637,11 +640,13 @@ export async function runResponsesStreamLifecycle<TApi extends Api>(params: {
           }),
       },
     );
-    await options?.onResponse?.(
-      { status: response.status, headers: headersToRecord(response.headers) },
-      model,
-    );
-    stream.push({ type: "start", partial: output });
+    const hookedOpenAIStream = withProviderResponseHook({
+      stream: openaiStream,
+      signal: firstEventAbort.signal,
+      abort: firstEventAbort.abort,
+      hook: createOpenAIResponseHook(options?.onResponse, response, model),
+      onReady: () => stream.push({ type: "start", partial: output }),
+    });
 
     const firstEventTimeoutMs = getFirstStreamEventTimeoutMs(options);
     const onFirstEventTimeout = getFirstStreamEventTimeoutHandler(options);
@@ -660,7 +665,7 @@ export async function runResponsesStreamLifecycle<TApi extends Api>(params: {
             signal: params.processStreamOptions?.signal ?? options?.signal,
           }
         : undefined;
-    await processResponsesStream(openaiStream, output, stream, model, {
+    await processResponsesStream(hookedOpenAIStream, output, stream, model, {
       ...processStreamOptions,
       reasoningReplayMetadata: buildOpenAIResponsesReasoningReplayMetadata(model, {
         sessionId: options?.sessionId,

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -6,7 +6,6 @@ import { getAiTransportHost } from "../host.js";
 import { resolveAzureDeploymentNameFromMap } from "../providers/azure-deployment-map.js";
 import { isOpenAICompatibleAzureResponsesBaseUrl } from "../providers/azure-openai-responses-client-compat.js";
 import { createAssistantMessageEventStream } from "../utils/event-stream.js";
-import { headersToRecord } from "../utils/headers.js";
 import { projectProviderError } from "../utils/provider-error.js";
 import {
   createFirstStreamEventAbortController,
@@ -59,9 +58,13 @@ import {
   isOpenAICodexResponsesModel,
   resolveCodeModeResponsesVisibleToolNames,
 } from "./openai-transport-params.js";
-import { log } from "./openai-transport-shared.js";
+import { createOpenAIResponseHook, log } from "./openai-transport-shared.js";
 import { sanitizeResponsesImagePayload } from "./responses-image-payload-sanitizer.js";
-import { mergeTransportMetadata, transportAbortError } from "./transport-stream-shared.js";
+import {
+  mergeTransportMetadata,
+  transportAbortError,
+  withProviderResponseHook,
+} from "./transport-stream-shared.js";
 import { redactIdentifier } from "./transport-utils.js";
 
 function resolveNativeOpenAIResponsesWebSocketMode(
@@ -267,14 +270,22 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
           context.systemPrompt,
         );
         const requestStartedAt = Date.now();
-        firstEventAbort = createFirstStreamEventAbortController(options?.signal);
-        const requestOptions = buildOpenAISdkRequestOptions(model, firstEventAbort.signal, {
+        let started = false;
+        const startStream = () => {
+          if (!started) {
+            started = true;
+            stream.push({ type: "start", partial: output as never });
+          }
+        };
+        const firstEvent = createFirstStreamEventAbortController(options?.signal);
+        firstEventAbort = firstEvent;
+        const requestOptions = buildOpenAISdkRequestOptions(model, firstEvent.signal, {
           stream: config.streamRequest,
           timeoutMs: options?.timeoutMs,
           maxRetries: options?.maxRetries,
         });
         const websocketSignal = combineWebSocketTimeoutSignal(
-          firstEventAbort.signal,
+          firstEvent.signal,
           model,
           requestOptions?.timeout,
         );
@@ -299,16 +310,20 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
                 authProfileId: responsesOptions?.authProfileId,
               }),
           });
-          await options?.onResponse?.(
-            { status: response.status, headers: headersToRecord(response.headers) },
-            model,
-          );
-          emitModelTransportDebug(
-            log,
-            `[responses] headers provider=${model.provider} api=${model.api} model=${model.id} ` +
-              `transport=sse elapsedMs=${Date.now() - requestStartedAt}`,
-          );
-          return responseStream;
+          return withProviderResponseHook({
+            stream: observeResponsesStream(responseStream, model, requestStartedAt),
+            signal: firstEvent.signal,
+            abort: firstEvent.abort,
+            hook: createOpenAIResponseHook(options?.onResponse, response, model),
+            onReady: () => {
+              emitModelTransportDebug(
+                log,
+                `[responses] headers provider=${model.provider} api=${model.api} model=${model.id} ` +
+                  `transport=sse elapsedMs=${Date.now() - requestStartedAt}`,
+              );
+              startStream();
+            },
+          });
         };
 
         let responseStream: AsyncIterable<unknown>;
@@ -349,7 +364,10 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
             responseStream = {
               async *[Symbol.asyncIterator]() {
                 try {
-                  yield* websocket.stream;
+                  for await (const event of websocket.stream) {
+                    startStream();
+                    yield event;
+                  }
                 } catch (error) {
                   if (
                     websocketSignal.aborted ||
@@ -372,26 +390,19 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
         } else {
           responseStream = await createSseStream();
         }
-        stream.push({ type: "start", partial: output as never });
         try {
-          await processResponsesStream(
-            observeResponsesStream(responseStream, model, requestStartedAt),
-            output,
-            stream,
-            model,
-            {
-              ...config.pricingOptions?.(responsesOptions),
-              firstEventTimeoutMs:
-                getFirstStreamEventTimeoutMs(options) ?? config.firstEventTimeoutMs,
-              abortFirstEventStream: firstEventAbort.abort,
-              onFirstEventTimeout: getFirstStreamEventTimeoutHandler(options),
-              signal: options?.signal,
-              reasoningReplayMetadata: buildOpenAIResponsesReasoningReplayMetadata(model, {
-                authProfileId: responsesOptions?.authProfileId,
-                sessionId: options?.sessionId,
-              }),
-            },
-          );
+          await processResponsesStream(responseStream, output, stream, model, {
+            ...config.pricingOptions?.(responsesOptions),
+            firstEventTimeoutMs:
+              getFirstStreamEventTimeoutMs(options) ?? config.firstEventTimeoutMs,
+            abortFirstEventStream: firstEvent.abort,
+            onFirstEventTimeout: getFirstStreamEventTimeoutHandler(options),
+            signal: options?.signal,
+            reasoningReplayMetadata: buildOpenAIResponsesReasoningReplayMetadata(model, {
+              authProfileId: responsesOptions?.authProfileId,
+              sessionId: options?.sessionId,
+            }),
+          });
           finishWebSocket?.();
         } catch (error) {
           finishWebSocket?.({ keep: false });

--- a/packages/ai/src/transports/openai-responses-transport.response-hook.test.ts
+++ b/packages/ai/src/transports/openai-responses-transport.response-hook.test.ts
@@ -1,0 +1,455 @@
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+import { configureAiTransportHost, getAiTransportHost } from "../host.js";
+import type { BaseOpenAIStreamOptions } from "../provider-options.js";
+import {
+  closeOpenAICodexWebSocketSessions,
+  resetOpenAICodexWebSocketStateForTest,
+  streamOpenAICodexResponses,
+} from "../providers/openai-chatgpt-responses.js";
+import { streamOpenAIResponses } from "../providers/openai-responses.js";
+import type { AssistantMessageEventStreamLike, Context, Model, StreamFn } from "../types.js";
+import {
+  createAzureOpenAIResponsesTransportStreamFn,
+  createOpenAIResponsesTransportStreamFn,
+} from "./openai-responses-client.js";
+
+const openAIModel = {
+  id: "gpt-5.6-luna",
+  name: "Responses hook lifecycle",
+  api: "openai-responses",
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 4_096,
+} satisfies Model<"openai-responses">;
+
+const azureModel = {
+  ...openAIModel,
+  api: "azure-openai-responses",
+  provider: "azure-openai-responses",
+  baseUrl: "https://project.services.ai.azure.com/openai/v1",
+} satisfies Model<"azure-openai-responses">;
+
+const chatGptModel = {
+  ...openAIModel,
+  api: "openai-chatgpt-responses",
+  baseUrl: "https://chatgpt.test/backend-api",
+  reasoning: true,
+} satisfies Model<"openai-chatgpt-responses">;
+
+const context = {
+  messages: [{ role: "user", content: "hello", timestamp: 1 }],
+} satisfies Context;
+
+const chatGptToken = (() => {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(
+    JSON.stringify({
+      "https://api.openai.com/auth": { chatgpt_account_id: "acct-response-hook" },
+    }),
+  ).toString("base64url");
+  return `${header}.${body}.signature`;
+})();
+
+type RequestLifecycle = {
+  requestAborted: ReturnType<typeof vi.fn>;
+  assertListenersRemoved(): void;
+};
+
+function completedResponse(init?: ResponseInit): Response {
+  const response = {
+    id: "resp_response_hook",
+    object: "response",
+    status: "completed",
+    model: openAIModel.id,
+    output: [
+      {
+        id: "msg_response_hook",
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: "hello", annotations: [] }],
+      },
+    ],
+    usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+  };
+  const events = [
+    { type: "response.created", response: { ...response, output: [], status: "in_progress" } },
+    { type: "response.completed", response },
+  ];
+  const body = `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`;
+  return new Response(body, {
+    status: 202,
+    headers: {
+      "content-type": "text/event-stream",
+      "x-ratelimit-remaining-requests": "42",
+      "x-request-id": "req_observable",
+    },
+    ...init,
+  });
+}
+
+function trackedFetch(responseFactory: () => Response): {
+  fetch: typeof fetch;
+  lifecycle: RequestLifecycle;
+} {
+  let addAbortListener: MockInstance<AbortSignal["addEventListener"]> | undefined;
+  let removeAbortListener: MockInstance<AbortSignal["removeEventListener"]> | undefined;
+  const requestAborted = vi.fn();
+  const fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+    const signal = init?.signal;
+    if (signal) {
+      signal.addEventListener("abort", requestAborted, { once: true });
+      addAbortListener = vi.spyOn(signal, "addEventListener");
+      removeAbortListener = vi.spyOn(signal, "removeEventListener");
+    }
+    return responseFactory();
+  });
+  return {
+    fetch: fetchMock,
+    lifecycle: {
+      requestAborted,
+      assertListenersRemoved() {
+        for (const [event, listener] of addAbortListener?.mock.calls ?? []) {
+          if (event === "abort") {
+            expect(removeAbortListener).toHaveBeenCalledWith("abort", listener);
+          }
+        }
+      },
+    },
+  };
+}
+
+function installSdkResponse(): RequestLifecycle {
+  const tracked = trackedFetch(completedResponse);
+  configureAiTransportHost({ buildModelFetch: () => tracked.fetch });
+  return tracked.lifecycle;
+}
+
+function installChatGptResponse(): RequestLifecycle {
+  const tracked = trackedFetch(completedResponse);
+  vi.stubGlobal("fetch", tracked.fetch);
+  return tracked.lifecycle;
+}
+
+function createManagedFixtureStream(
+  createStream: StreamFn,
+  model: Model,
+  options?: BaseOpenAIStreamOptions,
+): AssistantMessageEventStreamLike {
+  const result = createStream(model, context, { apiKey: "fixture-token", ...options });
+  if (result instanceof Promise) {
+    throw new Error("OpenAI Responses transport must return its event stream synchronously");
+  }
+  return result;
+}
+
+const managedOpenAIStream = createOpenAIResponsesTransportStreamFn();
+const managedAzureStream = createAzureOpenAIResponsesTransportStreamFn();
+
+const fixtures = [
+  {
+    name: "SDK OpenAI",
+    model: openAIModel,
+    installResponse: installSdkResponse,
+    createStream: (options?: BaseOpenAIStreamOptions) =>
+      createManagedFixtureStream(managedOpenAIStream, openAIModel, options),
+  },
+  {
+    name: "SDK Azure",
+    model: azureModel,
+    installResponse: installSdkResponse,
+    createStream: (options?: BaseOpenAIStreamOptions) =>
+      createManagedFixtureStream(managedAzureStream, azureModel, options),
+  },
+  {
+    name: "shared Responses provider",
+    model: openAIModel,
+    installResponse: installSdkResponse,
+    createStream: (options?: BaseOpenAIStreamOptions) =>
+      streamOpenAIResponses(openAIModel, context, { apiKey: "fixture-token", ...options }),
+  },
+  {
+    name: "native ChatGPT SSE",
+    model: chatGptModel,
+    installResponse: installChatGptResponse,
+    createStream: (options?: BaseOpenAIStreamOptions) =>
+      streamOpenAICodexResponses(chatGptModel, context, {
+        apiKey: chatGptToken,
+        transport: "sse",
+        ...options,
+      }),
+  },
+];
+
+async function settleWithin<T>(promise: Promise<T>, timeoutMs = 500): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error("response hook lifecycle timed out")), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+let previousHost: ReturnType<typeof getAiTransportHost>;
+
+beforeEach(() => {
+  previousHost = getAiTransportHost();
+});
+
+afterEach(() => {
+  closeOpenAICodexWebSocketSessions();
+  resetOpenAICodexWebSocketStateForTest();
+  configureAiTransportHost(previousHost);
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe.each(fixtures)("$name response hook", ({ createStream, installResponse, model }) => {
+  it("awaits response metadata before exposing the first stream event", async () => {
+    installResponse();
+    const order: string[] = [];
+    let continueHook!: () => void;
+    const hookCompleted = new Promise<void>((resolve) => {
+      continueHook = resolve;
+    });
+    const onResponse = vi.fn(async () => {
+      order.push("hook:start");
+      await hookCompleted;
+      order.push("hook:end");
+    });
+    const stream = createStream({ onResponse });
+    const consume = (async () => {
+      for await (const event of stream) {
+        order.push(event.type);
+      }
+    })();
+
+    await vi.waitFor(() => expect(onResponse).toHaveBeenCalledOnce());
+    expect(order).toEqual(["hook:start"]);
+    expect(onResponse).toHaveBeenCalledWith(
+      {
+        status: 202,
+        headers: {
+          "content-type": "text/event-stream",
+          "x-ratelimit-remaining-requests": "42",
+          "x-request-id": "req_observable",
+        },
+      },
+      model,
+    );
+
+    continueHook();
+    await consume;
+    expect((await stream.result()).stopReason).toBe("stop");
+    expect(order.slice(0, 3)).toEqual(["hook:start", "hook:end", "start"]);
+  });
+
+  it.each(["throw", "reject"] as const)(
+    "preserves a hook %s and aborts the unread request",
+    async (failure) => {
+      const lifecycle = installResponse();
+      const hookError = new Error("after_provider_response hook failed");
+      const onResponse = vi.fn(() => {
+        if (failure === "throw") {
+          throw hookError;
+        }
+        return Promise.reject(hookError);
+      });
+      const stream = createStream({ onResponse });
+      const eventTypes: string[] = [];
+      for await (const event of stream) {
+        eventTypes.push(event.type);
+      }
+      const result = await stream.result();
+
+      expect(onResponse).toHaveBeenCalledOnce();
+      expect(result).toMatchObject({
+        stopReason: "error",
+        errorMessage: "after_provider_response hook failed",
+      });
+      expect(eventTypes).toEqual(["error"]);
+      expect(lifecycle.requestAborted).toHaveBeenCalledOnce();
+      lifecycle.assertListenersRemoved();
+    },
+  );
+
+  it("applies the first-event timeout while the hook is pending", async () => {
+    const lifecycle = installResponse();
+    const onFirstEventTimeout = vi.fn();
+    const onResponse = vi.fn(() => new Promise<void>(() => {}));
+    const stream = createStream({
+      firstEventTimeoutMs: 20,
+      onFirstEventTimeout,
+      onResponse,
+    });
+    const eventTypes: string[] = [];
+    const consume = (async () => {
+      for await (const event of stream) {
+        eventTypes.push(event.type);
+      }
+    })();
+    const result = await settleWithin(stream.result());
+    await consume;
+
+    expect(onResponse).toHaveBeenCalledOnce();
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toMatch(
+      /responses HTTP stream opened but did not deliver a first SSE event within 20ms/,
+    );
+    expect(onFirstEventTimeout).toHaveBeenCalledWith(expect.any(Error));
+    expect(eventTypes).toEqual(["error"]);
+    expect(lifecycle.requestAborted).toHaveBeenCalledOnce();
+    lifecycle.assertListenersRemoved();
+  });
+
+  it.each(["resolve", "reject"] as const)(
+    "keeps caller cancellation terminal after a late hook %s",
+    async (settlement) => {
+      const lifecycle = installResponse();
+      const controller = new AbortController();
+      let settleHook!: () => void;
+      const pendingHook = new Promise<void>((resolve, reject) => {
+        settleHook = () => {
+          if (settlement === "resolve") {
+            resolve();
+          } else {
+            reject(new Error("late response hook rejection"));
+          }
+        };
+      });
+      const onResponse = vi.fn(() => pendingHook);
+      const stream = createStream({ signal: controller.signal, onResponse });
+      const eventTypes: string[] = [];
+      const consume = (async () => {
+        for await (const event of stream) {
+          eventTypes.push(event.type);
+        }
+      })();
+
+      await vi.waitFor(() => expect(onResponse).toHaveBeenCalledOnce());
+      const abortReason = Object.assign(new Error("caller canceled the provider response"), {
+        code: "CALLER_ABORTED",
+      });
+      controller.abort(abortReason);
+      const result = await settleWithin(stream.result());
+      await consume;
+      expect(result).toMatchObject({
+        stopReason: "aborted",
+        errorCode: "CALLER_ABORTED",
+        errorMessage: "caller canceled the provider response",
+      });
+      expect(eventTypes).toEqual(["error"]);
+      expect(lifecycle.requestAborted).toHaveBeenCalledOnce();
+
+      settleHook();
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(eventTypes).toEqual(["error"]);
+      lifecycle.assertListenersRemoved();
+    },
+  );
+});
+
+describe("native ChatGPT SSE non-success response hooks", () => {
+  it("runs the hook for every retry response before the successful SSE stream", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response("overloaded", { status: 503, headers: { "retry-after-ms": "0" } }),
+      )
+      .mockResolvedValueOnce(completedResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    const onResponse = vi.fn();
+
+    const result = await streamOpenAICodexResponses(chatGptModel, context, {
+      apiKey: chatGptToken,
+      transport: "sse",
+      maxRetries: 1,
+      onResponse,
+    }).result();
+
+    expect(result.stopReason).toBe("stop");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(onResponse.mock.calls.map(([response]) => response.status)).toEqual([503, 202]);
+  });
+
+  it("cancels a terminal non-success body when its hook rejects", async () => {
+    const bodyCancelled = vi.fn();
+    let sentBody = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (!sentBody) {
+          sentBody = true;
+          controller.enqueue(new TextEncoder().encode('{"error":{"message":"bad request"}}'));
+        }
+      },
+      cancel: bodyCancelled,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          new Response(body, { status: 400, headers: { "content-type": "application/json" } }),
+        ),
+    );
+
+    const result = await settleWithin(
+      streamOpenAICodexResponses(chatGptModel, context, {
+        apiKey: chatGptToken,
+        transport: "sse",
+        maxRetries: 0,
+        onResponse: async () => {
+          throw new Error("non-success response hook failed");
+        },
+      }).result(),
+    );
+
+    expect(result).toMatchObject({
+      stopReason: "error",
+      errorMessage: "non-success response hook failed",
+    });
+    expect(bodyCancelled).toHaveBeenCalledOnce();
+  });
+
+  it("times out a stalled non-success hook and cancels its body", async () => {
+    const bodyCancelled = vi.fn();
+    const body = new ReadableStream<Uint8Array>({
+      pull() {},
+      cancel: bodyCancelled,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(new Response(body, { status: 503 })),
+    );
+    const onFirstEventTimeout = vi.fn();
+
+    const result = await settleWithin(
+      streamOpenAICodexResponses(chatGptModel, context, {
+        apiKey: chatGptToken,
+        transport: "sse",
+        maxRetries: 0,
+        firstEventTimeoutMs: 20,
+        onFirstEventTimeout,
+        onResponse: () => new Promise<void>(() => {}),
+      }).result(),
+    );
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toMatch(
+      /responses HTTP stream opened but did not deliver a first SSE event within 20ms/,
+    );
+    expect(onFirstEventTimeout).toHaveBeenCalledWith(expect.any(Error));
+    expect(bodyCancelled).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ai/src/transports/openai-responses-websocket-client.test.ts
+++ b/packages/ai/src/transports/openai-responses-websocket-client.test.ts
@@ -377,6 +377,44 @@ describe("native OpenAI Responses WebSocket client integration", () => {
     expect(transportState.sdkRequests).toHaveLength(1);
   });
 
+  it("awaits the SSE response hook before start after a WebSocket fallback", async () => {
+    transportState.handshakeMessages.push({ type: "error", error: new Error("connect failed") });
+    transportState.sdkOutcomes.push(sdkCompletion("resp_sse"));
+    const order: string[] = [];
+    let releaseHook!: () => void;
+    const hookPending = new Promise<void>((resolve) => {
+      releaseHook = resolve;
+    });
+    const onResponse = vi.fn(async () => {
+      order.push("hook:start");
+      await hookPending;
+      order.push("hook:end");
+    });
+    const responseStream = await createOpenAIResponsesTransportStreamFn()(
+      model,
+      { messages: [userMessage("hello", 1)], tools: [] },
+      {
+        apiKey: "test-key",
+        sessionId: "session-1",
+        transport: "auto",
+        onResponse,
+      },
+    );
+    const consume = (async () => {
+      for await (const event of responseStream) {
+        order.push(event.type);
+      }
+    })();
+
+    await vi.waitFor(() => expect(onResponse).toHaveBeenCalledOnce());
+    expect(order).toEqual(["hook:start"]);
+
+    releaseHook();
+    await consume;
+    expect((await responseStream.result()).stopReason).toBe("stop");
+    expect(order.slice(0, 3)).toEqual(["hook:start", "hook:end", "start"]);
+  });
+
   it("skips repeated WebSocket setup during the provider degradation cooldown", async () => {
     transportState.handshakeMessages.push({ type: "error", error: new Error("connect failed") });
     transportState.sdkOutcomes.push(sdkCompletion("resp_sse_1"), sdkCompletion("resp_sse_2"));

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -132,12 +132,12 @@ export function transportAbortError(signal?: AbortSignal): Error {
 }
 
 /** Run a provider-response hook before start/body consumption inside the first-event deadline. */
-export function withProviderResponseHook<T>(params: {
-  stream: AsyncIterable<T>;
+export function withProviderResponseHook<T = never>(params: {
+  stream?: AsyncIterable<T>;
   signal: AbortSignal;
   abort: (reason: Error) => void;
   hook?: () => void | Promise<void>;
-  onReady: () => void;
+  onReady?: () => void;
 }): AsyncIterable<T> {
   return {
     async *[Symbol.asyncIterator]() {
@@ -166,8 +166,10 @@ export function withProviderResponseHook<T>(params: {
       if (params.signal.aborted) {
         throw transportAbortError(params.signal);
       }
-      params.onReady();
-      yield* params.stream;
+      params.onReady?.();
+      if (params.stream) {
+        yield* params.stream;
+      }
     },
   };
 }

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -738,6 +738,41 @@ describe("createAgentSession tool defaults", () => {
     expect(sessionManager.getEntries().some((entry) => entry.type === "message")).toBe(true);
   });
 
+  it("runs provider response hooks under the configured write settlement", async () => {
+    const events: string[] = [];
+    const handlers = new Map<string, Array<(...args: unknown[]) => Promise<unknown>>>([
+      [
+        "after_provider_response",
+        [
+          async () => {
+            events.push("hook");
+            return undefined;
+          },
+        ],
+      ],
+    ]);
+
+    const { session } = await createAgentSession({
+      model: testModel,
+      resourceLoader: createResourceLoaderWithHandlers(handlers),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+      withSessionWriteSettlement: async (run) => {
+        events.push("settlement:start");
+        try {
+          return await run();
+        } finally {
+          events.push("settlement:end");
+        }
+      },
+    });
+
+    await session.agent.onResponse?.({ status: 200, headers: {} }, testModel);
+
+    expect(events).toEqual(["settlement:start", "hook", "settlement:end"]);
+  });
+
   it("runs write-capable tool hooks under the configured write settlement", async () => {
     const events: string[] = [];
     const handlers = new Map<string, Array<(...args: unknown[]) => Promise<unknown>>>([


### PR DESCRIPTION
## What Problem This Solves

OpenAI Responses HTTP transports invoked `after_provider_response` after response headers arrived but before the stream lifecycle owned the wait. A stalled hook therefore sat outside the first-event deadline, while hook rejection or caller cancellation could leave a successful SSE request or a non-success response body unread. This was missing lifecycle ownership in OpenClaw, not speculative provider behavior.

Affected owners were the SDK OpenAI/Azure transport, the shared Responses provider lifecycle, and native ChatGPT/Codex SSE retries. Responses WebSocket events have no HTTP `Response` or header hook and remain a separate path.

## Why This Change Was Made

- Successful SDK, shared-provider, and native ChatGPT SSE streams now enter the existing cancellation-aware response-hook wrapper as their first iterator work. The first-event deadline includes the hook, and `start` is emitted only after it succeeds.
- Native ChatGPT non-success attempts run each hook under the same deadline while the bounded error body is consumed. Rejection, caller abort, or timeout aborts the request and explicitly cancels a partially read body before retry/terminal handling continues.
- SDK WebSocket events are not passed through the HTTP hook wrapper. A WebSocket attempt now emits `start` on its first actual event, so a pre-dispatch SSE fallback can await its HTTP hook without producing a duplicate or premature start.
- The shared session SDK proof confirms `after_provider_response` still executes inside the configured transcript write-settlement boundary.

Encrypted-content recovery, hosted tool state, metadata, pricing, diagnostics, native WebSocket reuse, and retry classification remain on their existing owners. Anthropic has a different response/body lifecycle and is intentionally unchanged.

## User Impact

Stalled response hooks now time out with the stream they gate, coded caller abort reasons remain authoritative, hook failures close owned requests, and native retry responses cannot strand their bodies. Successful streams still deliver the same Responses events and usage data.

## Evidence

### Reproduction and regression proof

- Pre-fix Blacksmith Testbox: `tbx_01kzrmjk5g9zjv9g08wdqchm93`, [Actions run 31503311696](https://github.com/openclaw/openclaw/actions/runs/31503311696). The new owner-boundary matrix failed 21/26 cases: pending hooks escaped the deadline, hook failures did not abort unread requests, caller abort could not settle, and terminal non-success rejection did not cancel its body.
- Repaired patch-identical Testbox: `tbx_01kzrnnr98mx2tfvyk7xy1ky6g`, [Actions run 31505092591](https://github.com/openclaw/openclaw/actions/runs/31505092591). Serialized focused proof passed 223/223 tests across the hook matrix, managed WebSocket fallback, shared Responses lifecycle, native ChatGPT streaming/encrypted retry, and session SDK ownership.
- `pnpm check:changed` passed on the final patch tree in the same Testbox, including production/test typechecks, changed-file lint/format, dependency/API/boundary/dead-export guards, and import-cycle checks.
- Exact-head hosted CI passed at `0a45508085daa8a47f6074b4c9bd896c9d3cf1c6`: [run 31507902028](https://github.com/openclaw/openclaw/actions/runs/31507902028), required `openclaw/ci-gate` success.
- Authenticated OpenAI Responses live proof passed from isolated state: real `gpt-5.6-luna` stream reached a terminal event with usage accounting (1 passed, 3 unrelated cases skipped; 3.8 s provider test).
- Azure live proof was not run because no approved endpoint/credential pair was available. Native ChatGPT live proof was not run because no isolated OAuth profile was available; both paths have deterministic owner-boundary coverage above.
- P1 autoreview found and prompted the WebSocket-fallback ordering repair; the full rerun and final mechanical-controller rerun were clean with no accepted/actionable findings.

### Dependency/source contracts

- Pinned `openai@6.49.0`: `src/internal/parse.ts:18-45` constructs the SDK SSE stream with the request controller; `src/core/streaming.ts:21-101` exposes that controller and aborts unfinished iteration; `core/streaming.d.ts:8-30` confirms the public stream/controller/iterator shape; `src/client.ts:999-1032` connects caller abort and timeout to the fetch controller.
- Current Codex source at `279b93242cfef379e65da97e87e44b83c5934fd7`: `codex-rs/core/src/client_common.rs:105-123` cancels when `ResponseStream` is dropped; `codex-rs/core/src/client.rs:2004-2044` selects consumer cancellation against upstream iteration; `codex-rs/codex-api/src/endpoint/responses.rs:140-162` constructs the HTTP SSE stream from the owned response.

### Surface

- Production: +137/-85 (net +52). The net growth is the cross-attempt deadline/body-cancellation owner and current WebSocket/SSE fallback sequencing; duplicate direct awaits and the obsolete native response-processing wrapper were removed.
- Tests: +528/-0.
- No config, protocol, Plugin SDK public surface, SQLite schema, dependency, docs, or changelog changes.

ClawSweeper rank-up moves are addressed: the repair is rebased through the current WebSocket/SSE flow, the focused Responses hook matrix is green on the rebased tree, and exact-head hosted CI is green.
