### PR TITLE
fix(beam): complete only sessions confirmed inactive

### DIFF
--- a/extensions/beam/src/mirror-inactive.test.ts
+++ b/extensions/beam/src/mirror-inactive.test.ts
@@ -133,6 +133,7 @@ describe("Beam mirror inactive completion", () => {
       pluginId: "claude",
       id: "claude",
       label: "Claude",
+      processHomeFallbackAllowed: true,
       list: () => list(),
       read: async ({ threadId }) => ({
         hostId: "gateway:local",

--- a/extensions/beam/src/mirror-inactive.test.ts
+++ b/extensions/beam/src/mirror-inactive.test.ts
@@ -45,8 +45,13 @@ function memoryStore(): BeamStore & { values: Map<string, BeamStoredSession> } {
   const values = new Map<string, BeamStoredSession>();
   return {
     values,
-    put: async (entry) => {
-      values.set(entry.beamId, entry);
+    update: async (beamId, updateValue) => {
+      const next = updateValue(values.get(beamId));
+      if (!next) {
+        return false;
+      }
+      values.set(beamId, next);
+      return true;
     },
     get: async (beamId) => values.get(beamId),
     list: async () => [...values.values()],
@@ -69,7 +74,7 @@ async function serve(store: BeamStore): Promise<string> {
   const handler = createBeamRequestHandler({
     store,
     resolveClient: () => ({ clientIp: "127.0.0.1", scopes: ["operator.write"] }),
-    resolveControlUiTarget: () => ({ agentId: "main" }),
+    resolveControlUiBasePath: () => "",
   });
   const server = http.createServer((req, res) => {
     void handler(req, res);

--- a/extensions/beam/src/mirror-inactive.test.ts
+++ b/extensions/beam/src/mirror-inactive.test.ts
@@ -145,7 +145,7 @@ describe("Beam mirror inactive completion", () => {
           },
         }),
       },
-    } as PluginRuntime;
+    } as unknown as PluginRuntime;
     const runner = createBeamMirrorRunner({
       runtime,
       logger: { warn: () => {}, info: () => {} },

--- a/extensions/beam/src/mirror-inactive.test.ts
+++ b/extensions/beam/src/mirror-inactive.test.ts
@@ -1,0 +1,168 @@
+import http from "node:http";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import type {
+  SessionCatalogHost,
+  SessionCatalogSession,
+} from "openclaw/plugin-sdk/session-catalog";
+import type { ActiveSessionCatalog } from "openclaw/plugin-sdk/session-catalog-runtime";
+import { afterEach, describe, expect, it } from "vitest";
+import { createBeamRequestHandler } from "./http.js";
+import { beamMirrorId, createBeamMirrorRunner } from "./mirror.js";
+import type { BeamStore } from "./store.js";
+import type { BeamStoredSession } from "./types.js";
+
+const NOW = Date.parse("2026-08-24T00:00:00.000Z");
+const TRACKED_THREAD_ID = "tracked-session";
+
+function session(threadId: string, recencyAt: number): SessionCatalogSession {
+  return {
+    threadId,
+    name: threadId,
+    status: "live",
+    createdAt: recencyAt,
+    recencyAt,
+    archived: false,
+    canContinue: false,
+    canArchive: false,
+  };
+}
+
+function gatewayHost(
+  sessions: SessionCatalogSession[],
+  state: Partial<Pick<SessionCatalogHost, "connected" | "error" | "nextCursor">> = {},
+): SessionCatalogHost {
+  return {
+    hostId: "gateway:local",
+    label: "Local",
+    kind: "gateway",
+    connected: true,
+    sessions,
+    ...state,
+  };
+}
+
+function memoryStore(): BeamStore & { values: Map<string, BeamStoredSession> } {
+  const values = new Map<string, BeamStoredSession>();
+  return {
+    values,
+    put: async (entry) => {
+      values.set(entry.beamId, entry);
+    },
+    get: async (beamId) => values.get(beamId),
+    list: async () => [...values.values()],
+  };
+}
+
+const servers: http.Server[] = [];
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        }),
+    ),
+  );
+});
+
+async function serve(store: BeamStore): Promise<string> {
+  const handler = createBeamRequestHandler({
+    store,
+    resolveClient: () => ({ clientIp: "127.0.0.1", scopes: ["operator.write"] }),
+    resolveControlUiTarget: () => ({ agentId: "main" }),
+  });
+  const server = http.createServer((req, res) => {
+    void handler(req, res);
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Beam receiver did not expose a TCP address");
+  }
+  return `http://127.0.0.1:${address.port}/api/v1/beam/sessions`;
+}
+
+const overflowSessions = Array.from({ length: 32 }, (_, index) =>
+  session(`newer-${index}`, NOW + index + 1),
+);
+
+describe("Beam mirror inactive completion", () => {
+  it.each([
+    {
+      observation: "upload selection is capped",
+      incomplete: async () => [gatewayHost([...overflowSessions, session(TRACKED_THREAD_ID, NOW)])],
+      complete: async () => [gatewayHost(overflowSessions)],
+    },
+    {
+      observation: "catalog listing throws",
+      incomplete: async (): Promise<SessionCatalogHost[]> => {
+        throw new Error("catalog unavailable");
+      },
+      complete: async () => [gatewayHost([])],
+    },
+    {
+      observation: "host reports an error",
+      incomplete: async () => [
+        gatewayHost([], { error: { code: "unavailable", message: "try again" } }),
+      ],
+      complete: async () => [gatewayHost([])],
+    },
+    {
+      observation: "host is paginated",
+      incomplete: async () => [gatewayHost([], { nextCursor: "page-2" })],
+      complete: async () => [gatewayHost([])],
+    },
+    {
+      observation: "host is disconnected",
+      incomplete: async () => [gatewayHost([], { connected: false })],
+      complete: async () => [gatewayHost([])],
+    },
+  ])("waits when $observation", async ({ incomplete, complete }) => {
+    const store = memoryStore();
+    const endpoint = await serve(store);
+    let list = async () => [gatewayHost([session(TRACKED_THREAD_ID, NOW)])];
+    const catalog: ActiveSessionCatalog = {
+      pluginId: "claude",
+      id: "claude",
+      label: "Claude",
+      list: () => list(),
+      read: async ({ threadId }) => ({
+        hostId: "gateway:local",
+        threadId,
+        items: [{ type: "agentMessage", text: "Still working" }],
+      }),
+    };
+    const runtime = {
+      config: {
+        current: () => ({
+          plugins: {
+            entries: {
+              beam: { config: { mirror: { endpoint, catalogs: ["claude"] } } },
+            },
+          },
+        }),
+      },
+    } as PluginRuntime;
+    const runner = createBeamMirrorRunner({
+      runtime,
+      logger: { warn: () => {}, info: () => {} },
+      now: () => NOW,
+      listCatalogs: () => [catalog],
+    });
+
+    await runner.tick();
+    const trackedId = beamMirrorId("claude", "gateway:local", TRACKED_THREAD_ID);
+    expect(store.values.get(trackedId)?.completed).toBe(false);
+
+    list = incomplete;
+    await runner.tick();
+    expect(store.values.get(trackedId)?.completed).toBe(false);
+
+    list = complete;
+    await runner.tick();
+    expect(store.values.get(trackedId)?.completed).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #121132.

## What Problem This Solves

Incomplete catalog observations must not mark an active Beam session completed. This PR now contributes regression coverage only: current main already contains the production lifecycle guards, while this five-case real-receiver matrix remains distinct from the merged retry work.

## Why This Change Was Made

The test drives the existing Beam mirror through real Node fetch to the production HTTP request handler on loopback. It covers the newest-32 upload cap, catalog listing exceptions, structured host errors, pagination, and disconnection. Each case reads the receiver store after initial publication, uncertain observation, and confirmed absence.

The canonical mirror owner remains responsible for observing all active rows before upload selection and requiring an authoritative complete observation before absence-based completion. No duplicate production policy, external service, or new dependency is introduced.

## User Impact

Regression protection for Beam session lifecycle accuracy. The current diff changes no production behavior, configuration, authentication, protocol, persistence schema, or defaults. Scope: one test file, +174/-0; production LOC: 0.

## Evidence

- Tested PR head: `196b56e12cae3506487f1923bbafde6af902f5cf`.
- The isolated source archive came directly from this head. It includes the current BeamStore.update, resolveControlUiBasePath, and processHomeFallbackAllowed fixture contracts.
- Node 24.15.0; one worker; real local TCP receiver and production Node fetch. Catalog observations and the in-memory BeamStore implementation are deterministic injected fixtures. This does not claim a deployed Gateway, persistent database, live coding-agent catalog, or third-party service run.

```text
OPENCLAW_VITEST_MAX_WORKERS=1
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=<isolated-cache>
OPENCLAW_FS_SAFE_NATIVE_MODE=off
node scripts/run-vitest.mjs extensions/beam/src/mirror-inactive.test.ts --maxWorkers=1

PASS waits when 'upload selection is capped'
PASS waits when 'catalog listing throws'
PASS waits when 'host reports an error'
PASS waits when 'host is paginated'
PASS waits when 'host is disconnected'

Test Files  1 passed (1)
Tests       5 passed (5)
```

Run September 5, 2026, 04:16 UTC; 108.46 seconds in Vitest, 123.50 seconds including wrapper preparation. Each passing case asserts completed=false after publication and after uncertainty, followed by completed=true after a complete observation confirms inactivity. These assertions read the store populated by the real HTTP receiver, not a stubbed upload result.

The local run used the available current dependency tree with package-local dependency links and disabled the optional native fs-safe acceleration as shown. No credentials or real user data were supplied. The HTTP servers are stopped by afterEach. No proof files were added to the product branch.

- Current-head [CI run 33935713452](https://github.com/openclaw/openclaw/actions/runs/33935713452) passed the applicable checks, including production types, test types, lint, dependencies, changed plugin bundles, source contracts, and CI gate.
- The latest durable review found no code findings and requested exactly this refreshed five-case boundary run. This body provides that result; external re-review and rating are not assumed complete.
- Historical red/green receipts and the August 16 five-case proof remain attached to their older revisions; no current-main failure is claimed because this is now regression-only coverage. AI assistance was used for implementation and verification.
