### PR TITLE
fix(codex): preserve operator request ownership through steering

### DIFF
--- a/extensions/codex/src/app-server/attempt-steering.test.ts
+++ b/extensions/codex/src/app-server/attempt-steering.test.ts
@@ -387,7 +387,7 @@ describe("Codex app-server steering queue", () => {
     await vi.advanceTimersByTimeAsync(0);
   });
 
-  it("answers pending user input without steering", async () => {
+  it("answers pending user input only for an inbound user message", async () => {
     const request = vi.fn(async () => ({ turnId: "turn-1" }));
     const answerPendingUserInput = vi.fn(() => true);
     const queue = createQueue(request, {
@@ -398,9 +398,59 @@ describe("Codex app-server steering queue", () => {
     });
     const onQueueAccepted = vi.fn();
 
-    await queue.queue("answer locally", { debounceMs: 0, onQueueAccepted });
+    await queue.queue("answer locally", {
+      debounceMs: 0,
+      isInboundUserMessage: true,
+      onQueueAccepted,
+    });
     expect(answerPendingUserInput).toHaveBeenCalledWith("answer locally");
     expect(onQueueAccepted).toHaveBeenCalledWith(true);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("steers internal completion messages without claiming pending user input", async () => {
+    const request = vi.fn(async () => ({ turnId: "turn-1" }));
+    const claimPendingUserInput = vi.fn(() => ({
+      answer: vi.fn(() => true),
+      cancel: vi.fn(() => true),
+    }));
+    const queue = createQueue(request, { claimPendingUserInput });
+
+    const queued = queue.queue("subagent completed", { debounceMs: 0 });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(claimPendingUserInput).not.toHaveBeenCalled();
+    expect(request).toHaveBeenCalledWith(
+      "turn/steer",
+      expect.objectContaining({
+        input: [{ type: "text", text: "subagent completed", text_elements: [] }],
+      }),
+      steerRequestOptions,
+    );
+    expect(queue.confirmConsumed("openclaw:turn-1:steer:1")).toBe(true);
+    await queued;
+  });
+
+  it("rejects sealed inbound admission before claiming pending user input", async () => {
+    const request = vi.fn(async () => ({ turnId: "turn-1" }));
+    const claimPendingUserInput = vi.fn(() => ({
+      answer: vi.fn(() => true),
+      cancel: vi.fn(() => true),
+    }));
+    const queue = createQueue(request, { claimPendingUserInput });
+    const onQueueAccepted = vi.fn();
+
+    queue.sealAdmission();
+    await expect(
+      queue.queue("too late", {
+        debounceMs: 0,
+        isInboundUserMessage: true,
+        onQueueAccepted,
+      }),
+    ).rejects.toThrow("queue admission sealed");
+
+    expect(claimPendingUserInput).not.toHaveBeenCalled();
+    expect(onQueueAccepted).toHaveBeenCalledWith(false);
     expect(request).not.toHaveBeenCalled();
   });
 
@@ -416,6 +466,7 @@ describe("Codex app-server steering queue", () => {
     });
 
     const queued = queue.queue("compare these", {
+      isInboundUserMessage: true,
       images: [
         { type: "image", data: PNG_1X1, mimeType: "image/png" },
         { type: "image", data: PNG_1X1, mimeType: "image/png" },
@@ -470,6 +521,7 @@ describe("Codex app-server steering queue", () => {
     });
 
     const imageQueued = queue.queue("image reply", {
+      isInboundUserMessage: true,
       images: [{ type: "image", data: PNG_1X1, mimeType: "image/png" }],
     });
     await vi.advanceTimersByTimeAsync(0);
@@ -509,6 +561,7 @@ describe("Codex app-server steering queue", () => {
     });
 
     const queued = queue.queue("compare this", {
+      isInboundUserMessage: true,
       images: [{ type: "image", data: PNG_1X1, mimeType: "image/png" }],
     });
     const rejected = expect(queued).rejects.toThrow("cannot steer this turn");

--- a/extensions/codex/src/app-server/attempt-steering.ts
+++ b/extensions/codex/src/app-server/attempt-steering.ts
@@ -272,7 +272,9 @@ export function createCodexSteeringQueue(params: {
         options?.onQueueAccepted?.(false);
         throw unavailableError;
       }
-      const pendingUserInput = params.claimPendingUserInput();
+      // Only operator ingress can answer a pending prompt; internal steering stays transcript input.
+      const pendingUserInput =
+        options?.isInboundUserMessage === true ? params.claimPendingUserInput() : undefined;
       if (pendingUserInput) {
         if (!options?.images?.length) {
           const answered = pendingUserInput.answer(text);

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -114,7 +114,7 @@ export function createCodexAttemptServerRequestController(
           armCompletionWatchOnResponse = true;
           markCurrentTurnRequestProgress();
         }
-        return userInputBridgeRef.current?.handleRequest({
+        return await userInputBridgeRef.current?.handleRequest({
           id: request.id,
           params: request.params,
         });
@@ -125,7 +125,7 @@ export function createCodexAttemptServerRequestController(
             armCompletionWatchOnResponse = true;
             markCurrentTurnRequestProgress();
           }
-          return handleCodexAppServerApprovalRequest({
+          return await handleCodexAppServerApprovalRequest({
             method: request.method,
             requestParams: request.params,
             paramsForRun: params,

--- a/extensions/codex/src/app-server/run-attempt.steering.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.steering.test.ts
@@ -495,7 +495,10 @@ describe("runCodexAppServerAttempt steering", () => {
     expect(onLateAccepted).toHaveBeenCalledWith(false);
   });
 
-  it("routes request_user_input prompts through the active run follow-up queue", async () => {
+  it.each([
+    { name: "gateway-backed", isSecret: false },
+    { name: "secret", isSecret: true },
+  ])("routes $name user prompts without consuming internal steering", async ({ isSecret }) => {
     let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
     let handleRequest:
       | ((request: { id: string; method: string; params?: unknown }) => Promise<unknown>)
@@ -533,6 +536,8 @@ describe("runCodexAppServerAttempt steering", () => {
 
     const params = createSteeringParams();
     params.onBlockReply = vi.fn();
+    const onRunProgress = vi.fn();
+    params.onRunProgress = onRunProgress;
     const run = runCodexAppServerAttempt(params);
     await vi.waitFor(
       () => expect(request.mock.calls.map(([method]) => method)).toContain("turn/start"),
@@ -547,13 +552,14 @@ describe("runCodexAppServerAttempt steering", () => {
         threadId: "thread-1",
         turnId: "turn-1",
         itemId: "ask-1",
+        isBlocking: true,
         questions: [
           {
             id: "mode",
             header: "Mode",
             question: "Pick a mode",
             isOther: false,
-            isSecret: false,
+            isSecret,
             options: [
               { label: "Fast", description: "Use less reasoning" },
               { label: "Deep", description: "Use more reasoning" },
@@ -583,6 +589,12 @@ describe("runCodexAppServerAttempt steering", () => {
         item: { id: "source-message", type: "userMessage", clientId: sourceMessageId },
       },
     });
+    expect(
+      onRunProgress.mock.calls.some(
+        ([event]) =>
+          (event as { reason?: string }).reason === "request:item/tool/requestUserInput:response",
+      ),
+    ).toBe(false);
     const onQuestionAccepted = vi.fn();
     await waitAndQueueActiveRunMessage(params.sessionId, "2", {
       isInboundUserMessage: true,
@@ -591,6 +603,9 @@ describe("runCodexAppServerAttempt steering", () => {
     await expect(response).resolves.toEqual({
       answers: { mode: { answers: ["Deep"] } },
     });
+    expect(onRunProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "request:item/tool/requestUserInput:response" }),
+    );
     expect(onQuestionAccepted).toHaveBeenCalledWith(true);
     expect(request.mock.calls.filter(([method]) => method === "turn/steer")).toHaveLength(1);
 

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -12,6 +12,7 @@ import {
 } from "openclaw/plugin-sdk/diagnostic-runtime";
 import * as mediaStore from "openclaw/plugin-sdk/media-store";
 import { describe, expect, it, vi } from "vitest";
+import * as approvalBridge from "./approval-bridge.js";
 import { buildCodexAppServerPromptTimeoutOutcome } from "./attempt-results.js";
 import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
 import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
@@ -1146,6 +1147,71 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
   });
 
+  it("keeps turn request activity active until command approval resolves", async () => {
+    const harness = createStartedThreadHarness();
+    const approvalResponse = { decision: "accept" } as const;
+    let resolveApproval!: (value: typeof approvalResponse) => void;
+    const approval = new Promise<typeof approvalResponse>((resolve) => {
+      resolveApproval = resolve;
+    });
+    vi.spyOn(approvalBridge, "handleCodexAppServerApprovalRequest").mockImplementation(
+      async () => await approval,
+    );
+    const params = makeTestParams({ timeoutMs: 500 });
+    const onRunProgress = vi.fn();
+    params.onRunProgress = onRunProgress;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 1_000,
+      turnAssistantCompletionIdleTimeoutMs: 1_000,
+      turnTerminalIdleTimeoutMs: 1_000,
+    });
+    await harness.waitForMethod("turn/start");
+
+    const response = harness.handleServerRequest({
+      id: "request-pending-approval",
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "command-1",
+        command: "echo approved",
+        cwd: "/workspace",
+      },
+    });
+    await vi.waitFor(
+      () =>
+        expect(onRunProgress).toHaveBeenCalledWith(
+          expect.objectContaining({
+            reason: "request:item/commandExecution/requestApproval:start",
+          }),
+        ),
+      fastWait,
+    );
+    expect(
+      onRunProgress.mock.calls.some(
+        ([event]) =>
+          (event as { reason?: string }).reason ===
+          "request:item/commandExecution/requestApproval:response",
+      ),
+    ).toBe(false);
+
+    resolveApproval(approvalResponse);
+    await expect(response).resolves.toEqual(approvalResponse);
+    expect(onRunProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "request:item/commandExecution/requestApproval:response",
+      }),
+    );
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+
+    expect(readAttemptTerminal(await run)).toMatchObject({
+      aborted: false,
+      timedOut: false,
+      promptError: null,
+    });
+  });
+
   it("keeps an eliciting MCP tool active past the completion timeout", async () => {
     const harness = createStartedThreadHarness();
     const bridgedResponse = {
@@ -1225,16 +1291,11 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
   });
 
-  it("counts pending secret user input requests as turn attempt progress", async () => {
-    // `item/tool/requestUserInput` records attempt progress but never suppresses
-    // the attempt watch while pending, so this proves the turn outlives the
+  it("keeps secret user input request activity active until the answer arrives", async () => {
+    // Pending user input must keep the active request open and outlive the
     // deadline `turn:start` alone would have set. That needs
     // preRequestIdleMs + pendingHoldMs > attemptIdleTimeoutMs > pendingHoldMs;
     // both bounds are asserted below so load can never make it vacuous.
-    // The two request resets in run-attempt-server-requests.ts land ~20ms apart
-    // (`finally` runs at `return`, not when the bridge promise settles), so this
-    // cannot attribute survival to `:start` over `:response` — it guards the
-    // pair. Mutating either one alone still passes; mutating both fails.
     const attemptIdleTimeoutMs = 1_000;
     const preRequestIdleMs = 500;
     const pendingHoldMs = 700;
@@ -1271,6 +1332,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
         threadId: "thread-1",
         turnId: "turn-1",
         itemId: "input-1",
+        isBlocking: true,
         questions: [
           {
             id: "mode",
@@ -1300,10 +1362,21 @@ describe("runCodexAppServerAttempt turn watches", () => {
     // Lower bound: the turn has now outlived the deadline turn:start alone set,
     // so surviving proves the pending request moved it.
     expect(Date.now() - turnObservedAt).toBeGreaterThan(attemptIdleTimeoutMs);
-    expect(queueActiveRunMessageForTest("session-1", "2")).toBe(true);
+    expect(
+      onRunProgress.mock.calls.some(
+        ([event]) =>
+          (event as { reason?: string }).reason === "request:item/tool/requestUserInput:response",
+      ),
+    ).toBe(false);
+    expect(queueActiveRunMessageForTest("session-1", "2", { isInboundUserMessage: true })).toBe(
+      true,
+    );
     await expect(response).resolves.toEqual({
       answers: { mode: { answers: ["Deep"] } },
     });
+    expect(onRunProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "request:item/tool/requestUserInput:response" }),
+    );
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
 
     const result = await run;

--- a/extensions/codex/src/app-server/user-input-bridge.test.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.test.ts
@@ -77,6 +77,22 @@ function requestParams(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function secretRequestParams(overrides: Record<string, unknown> = {}) {
+  return requestParams({
+    questions: [
+      {
+        id: "token",
+        header: "Secret",
+        question: "Enter token",
+        isOther: true,
+        isSecret: true,
+        options: null,
+      },
+    ],
+    ...overrides,
+  });
+}
+
 describe("Codex app-server user input bridge", () => {
   it("registers, presents, claims, and returns gateway answers", async () => {
     const params = createParams();
@@ -178,18 +194,7 @@ describe("Codex app-server user input bridge", () => {
     });
     const response = bridge.handleRequest({
       id: "input-secret",
-      params: requestParams({
-        questions: [
-          {
-            id: "token",
-            header: "Secret",
-            question: "Enter token",
-            isOther: true,
-            isSecret: true,
-            options: null,
-          },
-        ],
-      }),
+      params: secretRequestParams(),
     });
     await vi.waitFor(() => expect(params.onBlockReply).toHaveBeenCalledOnce());
 
@@ -199,6 +204,55 @@ describe("Codex app-server user input bridge", () => {
     expect(gateway.calls).toHaveLength(0);
     expect(bridge.claimPendingRequest()?.answer("private")).toBe(true);
     await expect(response).resolves.toEqual({ answers: { token: { answers: ["private"] } } });
+  });
+
+  it("clears an unanswered secret request when prompt delivery fails", async () => {
+    const params = createParams();
+    params.onBlockReply = vi.fn().mockRejectedValue(new Error("channel unavailable"));
+    const bridge = createCodexUserInputBridge({
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    await expect(
+      bridge.handleRequest({ id: "input-secret-undelivered", params: secretRequestParams() }),
+    ).resolves.toEqual({ answers: {} });
+    expect(bridge.claimPendingRequest()).toBeUndefined();
+  });
+
+  it("keeps a replacement secret request when an earlier prompt later fails", async () => {
+    let rejectFirstDelivery!: (error: Error) => void;
+    const firstDelivery = new Promise<void>((_resolve, reject) => {
+      rejectFirstDelivery = reject;
+    });
+    const params = createParams();
+    params.onBlockReply = vi.fn().mockReturnValueOnce(firstDelivery).mockResolvedValue(undefined);
+    const bridge = createCodexUserInputBridge({
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    const first = bridge.handleRequest({
+      id: "input-secret-replaced",
+      params: secretRequestParams(),
+    });
+    const replacement = bridge.handleRequest({
+      id: "input-secret-current",
+      params: secretRequestParams(),
+    });
+    await expect(first).resolves.toEqual({ answers: {} });
+
+    rejectFirstDelivery(new Error("previous prompt delivery failed"));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(bridge.claimPendingRequest()?.answer("replacement secret")).toBe(true);
+    await expect(replacement).resolves.toEqual({
+      answers: { token: { answers: ["replacement secret"] } },
+    });
   });
 
   it("cancels the matching gateway record on serverRequest/resolved", async () => {
@@ -319,19 +373,9 @@ describe("Codex app-server user input bridge", () => {
     });
     const response = bridge.handleRequest({
       id: "input-secret-nonblocking",
-      params: requestParams({
+      params: secretRequestParams({
         isBlocking: false,
         autoResolutionMs: 60_000,
-        questions: [
-          {
-            id: "token",
-            header: "Secret",
-            question: "Enter token",
-            isOther: true,
-            isSecret: true,
-            options: null,
-          },
-        ],
       }),
     });
 

--- a/extensions/codex/src/app-server/user-input-bridge.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.ts
@@ -138,6 +138,7 @@ export function createCodexUserInputBridge(params: {
             intro: "Codex needs input:",
           }).catch((error: unknown) => {
             embeddedAgentLog.warn("failed to deliver secret codex user input prompt", { error });
+            resolveSecretIfCurrent(current, emptyUserInputResponse());
           });
         });
       }

--- a/src/talk/agent-run-control.test.ts
+++ b/src/talk/agent-run-control.test.ts
@@ -23,7 +23,11 @@ function createDeps(options: {
       async (
         sessionId: string,
         _text: string,
-        _options?: { steeringMode?: "all"; taskSuggestionDeliveryMode?: undefined },
+        _options?: {
+          steeringMode?: "all";
+          isInboundUserMessage?: boolean;
+          taskSuggestionDeliveryMode?: undefined;
+        },
       ) =>
         options.queued === false
           ? {
@@ -147,7 +151,12 @@ describe("controlRealtimeVoiceAgentRun", () => {
     expect(deps.queueEmbeddedAgentMessageWithOutcomeAsync).toHaveBeenCalledWith(
       "session-active",
       "use the safer path",
-      { steeringMode: "all", debounceMs: 0, taskSuggestionDeliveryMode: undefined },
+      {
+        steeringMode: "all",
+        debounceMs: 0,
+        isInboundUserMessage: true,
+        taskSuggestionDeliveryMode: undefined,
+      },
     );
   });
 

--- a/src/talk/agent-run-control.ts
+++ b/src/talk/agent-run-control.ts
@@ -47,6 +47,7 @@ type RealtimeVoiceAgentControlDeps = {
     options?: {
       steeringMode?: "all";
       debounceMs?: number;
+      isInboundUserMessage?: boolean;
       taskSuggestionDeliveryMode?: undefined;
     },
   ) => Promise<EmbeddedAgentQueueMessageOutcome>;
@@ -160,6 +161,7 @@ export async function controlRealtimeVoiceAgentRun(
   const outcome = await deps.queueEmbeddedAgentMessageWithOutcomeAsync(sessionId, steerText, {
     steeringMode: "all",
     debounceMs: 0,
+    isInboundUserMessage: true,
     // Talk cannot present task suggestions, so spoken user input must not inherit
     // a capable TUI run's model-facing task tools.
     taskSuggestionDeliveryMode: undefined,

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1851,7 +1851,7 @@ describe("EmbeddedTuiBackend", () => {
     expect(queueEmbeddedAgentMessageWithOutcomeAsyncMock).toHaveBeenCalledWith(
       "active-session",
       "steer this turn",
-      { steeringMode: "all", debounceMs: 500 },
+      { steeringMode: "all", debounceMs: 500, isInboundUserMessage: true },
     );
     expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
 

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -508,6 +508,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
             {
               steeringMode: "all",
               debounceMs: queueSettings.debounceMs ?? DEFAULT_QUEUE_DEBOUNCE_MS,
+              isInboundUserMessage: true,
             },
           ).catch(() => undefined);
           if (outcome?.queued) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an internal Codex completion or continuation message could answer an outstanding operator input request. The same lifecycle path could also advance completion watches before asynchronous input or approval handling settled, while a failed stale secret prompt could clear a newer operator request.

## Why This Change Was Made

Only explicitly marked operator ingress may claim a request-ID-owned `item/tool/requestUserInput`; internal completion and continuation messages remain distinct `turn/steer` transcript input. TUI and Talk mark genuine operator ingress at their source, request and approval handlers stay awaited until settlement, and failed secret-prompt cleanup is scoped to the exact current request. Queue sealing, `onQueueAccepted`, accepted-unconfirmed steering, request-watch lifetime, and image-reply behavior remain intact. This adds no config, protocol, schema, changelog, or permanent proof-harness surface.

## User Impact

Pending Codex questions remain assigned to the operator who must answer them. Internal steering cannot silently satisfy a secret or interactive prompt, and the run does not move past an unresolved input or approval request.

## Evidence

- **Exact upstream contract (`@openai/codex@0.147.0`):** Codex defines [`turn/steer` as a distinct client request](https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/app-server-protocol/src/protocol/common.rs#L861-L866) and [`item/tool/requestUserInput` as a typed server request/response](https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/app-server-protocol/src/protocol/common.rs#L1545-L1549). The request carries authoritative blocking state, defaulting legacy omissions to blocking ([`item.rs:1637-1674`](https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L1637-L1674)); Codex stores the pending answer by the active turn sub-ID and awaits that exact response ([`session/mod.rs:2628-2664`](https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/core/src/session/mod.rs#L2628-L2664), [`state/turn.rs:150-163`](https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/core/src/state/turn.rs#L150-L163)). The app-server keeps its request watcher alive until the client response settles ([`bespoke_event_handling.rs:1631-1644`](https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/app-server/src/bespoke_event_handling.rs#L1631-L1644)).
- **Focused regression proof:** `node scripts/run-vitest.mjs extensions/codex/src/app-server/attempt-steering.test.ts extensions/codex/src/app-server/run-attempt.steering.test.ts extensions/codex/src/app-server/run-attempt.turn-watches.test.ts extensions/codex/src/app-server/user-input-bridge.test.ts src/talk/agent-run-control.test.ts src/tui/embedded-backend.test.ts` passed **239/239** tests (134 Codex, 11 Talk, 94 TUI).
- **Changed gate:** `node scripts/check-changed.mjs -- <all 11 touched files>` passed on Blacksmith Testbox [`tbx_01kznekywtpyjehm52zmy3zc94`](https://github.com/openclaw/openclaw/actions/runs/31372860407), including touched-file formatting, ratchet/dependency guards, 5 doctor contract tests, the Plugin SDK API manifest, plugin/storage/runtime boundaries, dead exports, import cycles, all four core/extension production/test typecheck lanes, and core/extension lint.
- **Exact-head hosted CI:** [run `31374159660`](https://github.com/openclaw/openclaw/actions/runs/31374159660) completed green for `fe1890d36cfe7180f3eebf744473f1ae2ecbff46`.
- **Installed behavior proof:** Blacksmith Testbox [`tbx_01kzmsz1n82gjskvjzepjy1jkp`](https://github.com/openclaw/openclaw/actions/runs/31351468747), command `pnpm test:docker:live-codex-npm-plugin`. Redacted observed sequence: pending request observed → internal `turn/steer` accepted but unsettled → explicit operator answer resolved the exact request → visible terminal marker. The temporary proof branch and harness commits were not pushed or merged into this PR.
- **Review and hygiene:** final fresh P1 autoreview on the owner-fixed base reported no accepted/actionable findings; `git diff --check` passed. Stable patch ID after rebase: `045c34615fb41631aacd69930e65c12ced709d62`.
- **Surface:** production **+9/-3**; tests **+232/-38** across exactly 11 files.
