### PR TITLE
fix(agents): start subagent retention after execution completes

### DIFF
--- a/src/agents/subagent-registry-helpers.test.ts
+++ b/src/agents/subagent-registry-helpers.test.ts
@@ -4,14 +4,13 @@ import { promises as fs } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { defaultRuntime } from "../runtime.js";
 import {
-  backfillCollectorArchiveAtMs,
   capFrozenResultText,
   logAnnounceGiveUp,
   reconcileOrphanedRestoredRuns,
   reconcileOrphanedRun,
   resolveAnnounceRetryDelayMs,
-  resolveSubagentArchiveAtMs,
   safeRemoveAttachmentsDir,
+  updateSubagentArchiveAtMs,
 } from "./subagent-registry-helpers.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 import { updateSwarmCollectorCompletion } from "./swarm-collector.js";
@@ -62,21 +61,32 @@ describe("capFrozenResultText", () => {
   });
 });
 
-describe("resolveSubagentArchiveAtMs", () => {
+describe("updateSubagentArchiveAtMs", () => {
   const cfg = { agents: { defaults: { subagents: { archiveAfterMinutes: 5 } } } };
 
-  it("defers collector retention until terminal completion", () => {
-    for (const cleanup of ["keep", "delete"] as const) {
-      expect(
-        resolveSubagentArchiveAtMs({
-          cfg,
-          now: 1_000,
-          spawnMode: "run",
-          cleanup,
-          collect: true,
-        }),
-      ).toBeUndefined();
+  it("defers delete-mode and collector retention until terminal completion", () => {
+    for (const overrides of [
+      { cleanup: "delete" as const },
+      { cleanup: "keep" as const, collect: true },
+      { cleanup: "delete" as const, collect: true },
+    ]) {
+      const entry = createRunEntry(overrides);
+      expect(updateSubagentArchiveAtMs(entry, cfg)).toBe(false);
+      expect(entry.archiveAtMs).toBeUndefined();
     }
+  });
+
+  it("starts ordinary delete-mode retention at execution completion", () => {
+    const entry = createRunEntry({
+      cleanup: "delete",
+      createdAt: 500,
+      execution: { status: "terminal", startedAt: 1_000, endedAt: 602_000 },
+      archiveAtMs: 300_500,
+    });
+
+    expect(updateSubagentArchiveAtMs(entry, cfg)).toBe(true);
+    expect(entry.archiveAtMs).toBe(902_000);
+    expect(updateSubagentArchiveAtMs(entry, cfg)).toBe(false);
   });
 
   it("starts collector retention when terminal completion is frozen", () => {
@@ -123,15 +133,29 @@ describe("resolveSubagentArchiveAtMs", () => {
       archiveAtMs: 10_000,
     });
 
-    expect(backfillCollectorArchiveAtMs(entry, cfg)).toBe(true);
+    expect(updateSubagentArchiveAtMs(entry, cfg)).toBe(true);
     expect(entry.archiveAtMs).toBe(302_000);
-    expect(backfillCollectorArchiveAtMs(entry, cfg)).toBe(false);
+    expect(updateSubagentArchiveAtMs(entry, cfg)).toBe(false);
   });
 
-  it("clears stale deadlines from active, persistent, or retention-disabled collectors", () => {
-    const active = createRunEntry({ collect: true, archiveAtMs: 10_000 });
-    expect(backfillCollectorArchiveAtMs(active, cfg)).toBe(true);
-    expect(active.archiveAtMs).toBeUndefined();
+  it("clears stale deadlines from active, paused, persistent, and retained runs", () => {
+    for (const overrides of [
+      { cleanup: "delete" as const },
+      { collect: true },
+      {
+        cleanup: "delete" as const,
+        pauseReason: "sessions_yield" as const,
+        execution: { status: "terminal" as const, startedAt: 1_000, endedAt: 2_000 },
+      },
+      {
+        cleanup: "keep" as const,
+        execution: { status: "terminal" as const, startedAt: 1_000, endedAt: 2_000 },
+      },
+    ]) {
+      const entry = createRunEntry({ ...overrides, archiveAtMs: 10_000 });
+      expect(updateSubagentArchiveAtMs(entry, cfg)).toBe(true);
+      expect(entry.archiveAtMs).toBeUndefined();
+    }
 
     const persistent = createRunEntry({
       collect: true,
@@ -139,40 +163,26 @@ describe("resolveSubagentArchiveAtMs", () => {
       execution: { status: "terminal", startedAt: 1_000, endedAt: 2_000 },
       archiveAtMs: 10_000,
     });
-    expect(backfillCollectorArchiveAtMs(persistent, cfg)).toBe(true);
+    expect(updateSubagentArchiveAtMs(persistent, cfg)).toBe(true);
     expect(persistent.archiveAtMs).toBeUndefined();
-
-    const completed = createRunEntry({
-      collect: true,
-      execution: { status: "terminal", startedAt: 1_000, endedAt: 2_000 },
-      archiveAtMs: 10_000,
-    });
-    expect(
-      backfillCollectorArchiveAtMs(completed, {
-        agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
-      }),
-    ).toBe(true);
-    expect(completed.archiveAtMs).toBeUndefined();
   });
 
-  it("preserves ordinary keep and persistent session semantics", () => {
-    expect(
-      resolveSubagentArchiveAtMs({
-        cfg,
-        now: 1_000,
-        spawnMode: "run",
-        cleanup: "keep",
-      }),
-    ).toBeUndefined();
-    expect(
-      resolveSubagentArchiveAtMs({
-        cfg,
-        now: 1_000,
-        spawnMode: "session",
+  it("never arms retention when archiveAfterMinutes is zero", () => {
+    for (const collect of [false, true]) {
+      const entry = createRunEntry({
         cleanup: "delete",
-        collect: true,
-      }),
-    ).toBeUndefined();
+        collect,
+        execution: { status: "terminal", startedAt: 1_000, endedAt: 2_000 },
+        archiveAtMs: 10_000,
+      });
+
+      expect(
+        updateSubagentArchiveAtMs(entry, {
+          agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
+        }),
+      ).toBe(true);
+      expect(entry.archiveAtMs).toBeUndefined();
+    }
   });
 });
 

--- a/src/agents/subagent-registry-helpers.ts
+++ b/src/agents/subagent-registry-helpers.ts
@@ -352,44 +352,29 @@ function resolveArchiveAfterMs(cfg?: OpenClawConfig) {
   return Math.max(1, Math.floor(minutes)) * 60_000;
 }
 
-/** Resolves the archive deadline for one newly registered run. */
-export function resolveSubagentArchiveAtMs(params: {
-  cfg?: OpenClawConfig;
-  now: number;
-  spawnMode: "run" | "session";
-  cleanup: "keep" | "delete";
-  collect?: boolean;
-}): number | undefined {
-  if (params.spawnMode === "session" || params.collect || params.cleanup === "keep") {
-    return undefined;
-  }
-  const archiveAfterMs = resolveArchiveAfterMs(params.cfg);
-  return archiveAfterMs ? params.now + archiveAfterMs : undefined;
-}
-
-/** Backfills the retention deadline added after collector groups first shipped. */
-export function backfillCollectorArchiveAtMs(
-  entry: SubagentRunRecord,
-  cfg?: OpenClawConfig,
-): boolean {
-  if (!entry.collect) {
-    return false;
-  }
+/** Arms retention only after the run or its waitable collector result has completed. */
+export function updateSubagentArchiveAtMs(entry: SubagentRunRecord, cfg?: OpenClawConfig): boolean {
   const endedAt =
     typeof entry.execution.endedAt === "number" && Number.isFinite(entry.execution.endedAt)
       ? entry.execution.endedAt
       : undefined;
-  const capturedAt =
-    endedAt === undefined && !entry.collectorCompletion
+  const completedAt = entry.collect
+    ? endedAt === undefined && !entry.collectorCompletion
       ? undefined
       : typeof entry.completion?.capturedAt === "number" &&
           Number.isFinite(entry.completion.capturedAt)
         ? entry.completion.capturedAt
-        : endedAt;
-  const archiveAfterMs = entry.spawnMode === "session" ? undefined : resolveArchiveAfterMs(cfg);
+        : endedAt
+    : entry.cleanup === "delete" && entry.pauseReason !== "sessions_yield"
+      ? endedAt
+      : undefined;
+  const archiveAfterMs =
+    entry.spawnMode === "session" || completedAt === undefined
+      ? undefined
+      : resolveArchiveAfterMs(cfg);
   const expectedArchiveAt =
-    capturedAt !== undefined && archiveAfterMs !== undefined
-      ? capturedAt + archiveAfterMs
+    completedAt !== undefined && archiveAfterMs !== undefined
+      ? completedAt + archiveAfterMs
       : undefined;
   if (entry.archiveAtMs === expectedArchiveAt) {
     return false;

--- a/src/agents/subagent-registry-lifecycle-completion.ts
+++ b/src/agents/subagent-registry-lifecycle-completion.ts
@@ -14,7 +14,10 @@ import {
 } from "./subagent-lifecycle-events.js";
 import { shouldSuppressSubagentRecoverySessionEffects } from "./subagent-recovery-state.js";
 import { resolveKilledSubagentTaskEndedAt } from "./subagent-registry-completion.js";
-import { persistSubagentSessionTiming } from "./subagent-registry-helpers.js";
+import {
+  persistSubagentSessionTiming,
+  updateSubagentArchiveAtMs,
+} from "./subagent-registry-helpers.js";
 import type { createSubagentRegistryLifecycleCleanupBase } from "./subagent-registry-lifecycle-cleanup-base.js";
 import type { createSubagentRegistryLifecycleCleanup } from "./subagent-registry-lifecycle-cleanup.js";
 import type { createSubagentRegistryLifecycleCommon } from "./subagent-registry-lifecycle-common.js";
@@ -461,7 +464,11 @@ export function createSubagentRegistryLifecycleCompletion(
           mutated = true;
         }
       }
-      if (updateSwarmCollectorCompletion(entry, params.getRuntimeConfig())) {
+      if (
+        entry.collect
+          ? updateSwarmCollectorCompletion(entry, params.getRuntimeConfig())
+          : updateSubagentArchiveAtMs(entry, params.getRuntimeConfig())
+      ) {
         mutated = true;
       }
       if (provisionalKillSnapshot) {

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -182,13 +182,13 @@ vi.mock("./subagent-registry-helpers.js", () => ({
   ANNOUNCE_EXPIRY_MS: 5 * 60_000,
   MIN_ANNOUNCE_RETRY_DELAY_MS: 1_000,
   PROVISIONAL_KILL_RECONCILIATION_MS: 5 * 60_000,
-  backfillCollectorArchiveAtMs: () => false,
   capFrozenResultText: (text: string) => text.trim(),
   logAnnounceGiveUp: helperMocks.logAnnounceGiveUp,
   persistSubagentSessionTiming: helperMocks.persistSubagentSessionTiming,
   resolveAnnounceRetryDelayMs: (retryCount: number) =>
     Math.min(1_000 * 2 ** Math.max(0, retryCount - 1), 8_000),
   safeRemoveAttachmentsDir: helperMocks.safeRemoveAttachmentsDir,
+  updateSubagentArchiveAtMs: () => false,
 }));
 
 type RunEntryOverrides = Omit<Partial<SubagentRunRecord>, "execution"> & {

--- a/src/agents/subagent-registry-restore.ts
+++ b/src/agents/subagent-registry-restore.ts
@@ -11,8 +11,8 @@ import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.
 import { applySubagentLaunchAuthorization } from "./subagent-launch-authorization.js";
 import type { SubagentRegistryDeps } from "./subagent-registry-deps.js";
 import {
-  backfillCollectorArchiveAtMs,
   reconcileOrphanedRestoredRuns,
+  updateSubagentArchiveAtMs,
 } from "./subagent-registry-helpers.js";
 import type { createSubagentRegistryLifecycleController } from "./subagent-registry-lifecycle.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
@@ -118,7 +118,7 @@ export function createSubagentRegistryRestorer(config: {
         resumedRuns,
       });
       for (const entry of runs.values()) {
-        if (backfillCollectorArchiveAtMs(entry, cfg)) {
+        if (updateSubagentArchiveAtMs(entry, cfg)) {
           restoredStateChanged = true;
         }
       }

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -48,8 +48,8 @@ import {
 } from "./subagent-registry-completion.js";
 import {
   persistSubagentSessionTiming,
-  resolveSubagentArchiveAtMs,
   safeRemoveAttachmentsDir,
+  updateSubagentArchiveAtMs,
 } from "./subagent-registry-helpers.js";
 import type {
   RequesterSettleWakeState,
@@ -191,6 +191,10 @@ export function markSubagentRunPausedAfterYield(params: {
   }
   if (entry.pauseReason !== "sessions_yield") {
     entry.pauseReason = "sessions_yield";
+    mutated = true;
+  }
+  if (entry.archiveAtMs !== undefined) {
+    delete entry.archiveAtMs;
     mutated = true;
   }
   if (entry.endedReason !== undefined) {
@@ -726,13 +730,6 @@ export function createSubagentRunManager(params: {
     );
     const cfg = params.getRuntimeConfig();
     const spawnMode = source.spawnMode === "session" ? "session" : "run";
-    const archiveAtMs = resolveSubagentArchiveAtMs({
-      cfg,
-      now,
-      spawnMode,
-      cleanup: source.cleanup,
-      collect: source.collect,
-    });
     const runTimeoutSeconds = replaceParams.runTimeoutSeconds ?? source.runTimeoutSeconds ?? 0;
     const waitTimeoutMs = params.resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
     const preserveFrozenResultFallback = replaceParams.preserveFrozenResultFallback === true;
@@ -821,7 +818,7 @@ export function createSubagentRunManager(params: {
         status: source.expectsCompletionMessage === false ? "not_required" : "pending",
       },
       spawnMode,
-      archiveAtMs,
+      archiveAtMs: undefined,
       runTimeoutSeconds,
     });
     clearDeliveryState(next);
@@ -1189,13 +1186,6 @@ export function createSubagentRunManager(params: {
     );
     const cfg = params.getRuntimeConfig();
     const spawnMode = registerParams.spawnMode === "session" ? "session" : "run";
-    const archiveAtMs = resolveSubagentArchiveAtMs({
-      cfg,
-      now,
-      spawnMode,
-      cleanup: registerParams.cleanup,
-      collect: registerParams.collect,
-    });
     const runTimeoutSeconds = registerParams.runTimeoutSeconds ?? 0;
     const waitTimeoutMs = params.resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
     const requesterOrigin = normalizeDeliveryContext(registerParams.requesterOrigin);
@@ -1256,7 +1246,6 @@ export function createSubagentRunManager(params: {
       },
       sessionStartedAt: queued ? undefined : now,
       accumulatedRuntimeMs: 0,
-      archiveAtMs,
       cleanupHandled: false,
       wakeOnDescendantSettle: undefined,
       requesterSettleWake: undefined,
@@ -1771,6 +1760,8 @@ export function createSubagentRunManager(params: {
       };
       if (wasQueuedCollector && !collectorLaunchInFlight) {
         updateSwarmCollectorCompletion(entry, params.getRuntimeConfig());
+      } else if (!entry.collect) {
+        updateSubagentArchiveAtMs(entry, params.getRuntimeConfig());
       }
       pendingTaskFinalizations.push({ entry, endedAt: taskEndedAt });
       if (!entriesByChildSessionKey.has(entry.childSessionKey)) {

--- a/src/agents/subagent-registry-sweeper.ts
+++ b/src/agents/subagent-registry-sweeper.ts
@@ -424,6 +424,9 @@ export function createSubagentRegistrySweeper(params: {
             );
             continue;
           }
+          // Retention starts after completion; a live run must never fall
+          // through to archival because an older persisted deadline expired.
+          continue;
         }
 
         if (entry.collect && entry.collectorCompletion) {
@@ -488,6 +491,17 @@ export function createSubagentRegistrySweeper(params: {
               groupId,
             });
           }
+          continue;
+        }
+        if (
+          entry.pauseReason === "sessions_yield" ||
+          entry.delivery?.status === "in_progress" ||
+          (entry.delivery?.status === "pending" &&
+            (entry.expectsCompletionMessage === true ||
+              entry.delivery.payload !== undefined ||
+              entry.delivery.disposition === "session_queued"))
+        ) {
+          // Queued or leased completion delivery owns this row until it settles.
           continue;
         }
         if (!entry.archiveAtMs && entry.cleanup === "keep" && entry.spawnMode !== "session") {

--- a/src/agents/subagent-registry.archive.e2e.test.ts
+++ b/src/agents/subagent-registry.archive.e2e.test.ts
@@ -5,6 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { callGateway } from "../gateway/call.js";
+import { onAgentEvent } from "../infra/agent-events.js";
+import { getAgentRunContext } from "../infra/agent-run-registry.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "../tasks/detached-task-runtime-contract.js";
 import { getDetachedTaskLifecycleRuntime } from "../tasks/detached-task-runtime.js";
 import {
@@ -149,6 +151,7 @@ describe("subagent registry archive behavior", () => {
       return {};
     });
     loadConfigMock.mockClear();
+    vi.mocked(getAgentRunContext).mockReset().mockReturnValue(undefined);
     taskRuntimeMocks.finalizeTaskRunByRunId.mockClear();
     taskStatusMocks.findTaskByRunIdForStatus.mockReset();
     taskStatusMocks.listTasksForSessionKeyForStatus.mockReset();
@@ -198,10 +201,11 @@ describe("subagent registry archive behavior", () => {
     expect(run?.archiveAtMs).toBeUndefined();
   });
 
-  it("sets archiveAtMs and sweeps delete-mode run subagents", async () => {
+  it("keeps live delete-mode subagents running beyond their archive retention window", async () => {
     currentConfig = {
       agents: { defaults: { subagents: { archiveAfterMinutes: 1 } } },
     };
+    vi.mocked(getAgentRunContext).mockReturnValue({} as never);
 
     mod.registerSubagentRun({
       runId: "run-delete-1",
@@ -213,12 +217,128 @@ describe("subagent registry archive behavior", () => {
     });
 
     const initialRun = mod.listSubagentRunsForRequester("agent:main:main")[0];
-    expect(initialRun?.archiveAtMs).toBe(Date.now() + 60_000);
+    expect(initialRun?.archiveAtMs).toBeUndefined();
 
-    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(120_000);
 
-    await waitForNoRequesterRuns();
+    expect(mod.listSubagentRunsForRequester("agent:main:main")).toEqual([initialRun]);
+    expect(initialRun?.execution.status).toBe("running");
+    expect(initialRun?.archiveAtMs).toBeUndefined();
+    expect(
+      vi
+        .mocked(callGateway)
+        .mock.calls.some(
+          ([request]) => (request as { method?: string }).method === "sessions.delete",
+        ),
+    ).toBe(false);
   });
+
+  it("starts delete-mode retention when its terminal lifecycle event completes", async () => {
+    currentConfig = {
+      agents: { defaults: { subagents: { archiveAfterMinutes: 1 } } },
+    };
+    vi.mocked(getAgentRunContext).mockReturnValue({} as never);
+    setRegistryTestDeps({
+      captureSubagentCompletionReply: vi.fn(async () => "completed result"),
+      runSubagentAnnounceFlow: vi.fn(async () => false),
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-delete-completed",
+      childSessionKey: "agent:main:subagent:delete-completed",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "finish after a long run",
+      cleanup: "delete",
+      expectsCompletionMessage: true,
+    });
+    await vi.advanceTimersByTimeAsync(90_000);
+
+    const endedAt = Date.now();
+    const lifecycleHandler = vi.mocked(onAgentEvent).mock.calls.at(-1)?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+    lifecycleHandler?.({
+      runId: "run-delete-completed",
+      stream: "lifecycle",
+      seq: 1,
+      ts: endedAt,
+      data: { phase: "end", endedAt, terminalReply: { disposition: "visible", text: "done" } },
+    });
+
+    await vi.waitFor(() => {
+      expect(mod.listSubagentRunsForRequester("agent:main:main")[0]).toMatchObject({
+        execution: { status: "terminal", endedAt },
+        archiveAtMs: endedAt + 60_000,
+      });
+    });
+  });
+
+  it("does not archive an active run carrying an obsolete persisted deadline", async () => {
+    vi.mocked(getAgentRunContext).mockReturnValue({} as never);
+    const now = Date.now();
+    addCanonicalSubagentRunForTests({
+      runId: "run-delete-stale-deadline",
+      childSessionKey: "agent:main:subagent:delete-stale-deadline",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "continue running after retention migration",
+      cleanup: "delete",
+      createdAt: now - 120_000,
+      startedAt: now - 120_000,
+      archiveAtMs: now - 60_000,
+    });
+
+    await mod.testing.sweepOnceForTests();
+
+    expect(mod.listSubagentRunsForRequester("agent:main:main")[0]).toMatchObject({
+      runId: "run-delete-stale-deadline",
+      execution: { status: "running" },
+    });
+    expect(
+      vi
+        .mocked(callGateway)
+        .mock.calls.some(
+          ([request]) => (request as { method?: string }).method === "sessions.delete",
+        ),
+    ).toBe(false);
+  });
+
+  it.each(["pending", "in_progress"] as const)(
+    "does not archive a completed delete-mode run while delivery is %s",
+    async (deliveryStatus) => {
+      const now = Date.now();
+      addCanonicalSubagentRunForTests({
+        runId: `run-delete-delivery-${deliveryStatus}`,
+        childSessionKey: `agent:main:subagent:delete-delivery-${deliveryStatus}`,
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "deliver completion before archival",
+        cleanup: "delete",
+        expectsCompletionMessage: true,
+        createdAt: now - 120_000,
+        endedAt: now - 60_000,
+        archiveAtMs: now - 1,
+        delivery: { status: deliveryStatus },
+      });
+
+      await mod.testing.sweepOnceForTests();
+
+      const entry = mod.listSubagentRunsForRequester("agent:main:main")[0];
+      expect(entry?.delivery?.status).toBe(deliveryStatus);
+      expect(
+        vi
+          .mocked(callGateway)
+          .mock.calls.some(
+            ([request]) => (request as { method?: string }).method === "sessions.delete",
+          ),
+      ).toBe(false);
+
+      entry!.delivery!.status = "delivered";
+      await mod.testing.sweepOnceForTests();
+
+      await waitForNoRequesterRuns();
+    },
+  );
 
   it("keeps archived delete-mode runs for retry when sessions.delete fails", async () => {
     currentConfig = {
@@ -851,7 +971,7 @@ describe("subagent registry archive behavior", () => {
     expect(run?.archiveAtMs).toBeUndefined();
   });
 
-  it("recomputes archiveAtMs when replacing a delete-mode run after steer restart", async () => {
+  it("keeps retention unarmed when replacing an active delete-mode run after steer restart", async () => {
     currentConfig = {
       agents: { defaults: { subagents: { archiveAfterMinutes: 1 } } },
     };
@@ -876,7 +996,7 @@ describe("subagent registry archive behavior", () => {
     const run = mod
       .listSubagentRunsForRequester("agent:main:main")
       .find((entry) => entry.runId === "run-delete-new");
-    expect(run?.archiveAtMs).toBe(Date.now() + 60_000);
+    expect(run?.archiveAtMs).toBeUndefined();
   });
 
   it("removes attachments for the replaced run after steer restart", async () => {

--- a/src/agents/swarm-collector.ts
+++ b/src/agents/swarm-collector.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { ensureCompletionState } from "./subagent-delivery-state.js";
 import { SUBAGENT_ENDED_REASON_KILLED } from "./subagent-lifecycle-events.js";
-import { backfillCollectorArchiveAtMs } from "./subagent-registry-helpers.js";
+import { updateSubagentArchiveAtMs } from "./subagent-registry-helpers.js";
 import type { SubagentRunRecord, SwarmCollectorStatus } from "./subagent-registry.types.js";
 import { loadSubagentSessionEntry } from "./subagent-session-reconciliation.js";
 import { consumeSwarmStructuredOutput } from "./tools/structured-output-tool.js";
@@ -37,7 +37,7 @@ export function updateSwarmCollectorCompletion(
   const completion = ensureCompletionState(entry);
   const capturedAtAdded = completion.capturedAt === undefined;
   completion.capturedAt ??= Date.now();
-  const archiveDeadlineAdded = backfillCollectorArchiveAtMs(entry, cfg);
+  const archiveDeadlineAdded = updateSubagentArchiveAtMs(entry, cfg);
   if (entry.collectorCompletion) {
     return clearedPendingLaunch || capturedAtAdded || archiveDeadlineAdded;
   }


### PR DESCRIPTION
## What Problem This Solves

Subagent archive deadlines were armed when a run was registered. A long-running, yielded, restored, or still-delivering child could therefore reach its retention deadline before execution and completion delivery had actually finished.

## Why This Change Was Made

One canonical `updateSubagentArchiveAtMs` owner now derives archive eligibility from terminal execution or finalized collector completion. Registration no longer creates retention policy, restore clears or recomputes stale deadlines, and the sweeper refuses to reclaim live, yielded, or completion-delivery-owned records.

This is the behavior already documented in `docs/gateway/config-tools.md` and `docs/gateway/config-agents.md`: `agents.defaults.subagents.archiveAfterMinutes` measures time after completed subagent state or session completion.

## User Impact

Long-running and yielded subagents remain available until their work finishes. Pending or in-progress completion delivery retains ownership of the row. After delivery settles and the completion-based retention window expires, the completed subagent can be archived normally.

## Evidence

- `node scripts/run-vitest.mjs src/agents/subagent-registry-helpers.test.ts src/agents/subagent-registry.archive.e2e.test.ts src/agents/subagent-registry-lifecycle.test.ts` — 185 tests passed on Blacksmith Testbox (`160` agents-core + `25` archive E2E), including a live run beyond the old registration deadline, terminal deadline arming, stale persisted-deadline protection, pending/in-progress delivery ownership, and post-delivery archival. Testbox hydration/run: https://github.com/openclaw/openclaw/actions/runs/31340823713
- `node scripts/check-changed.mjs -- src/agents/subagent-registry-helpers.ts src/agents/subagent-registry-lifecycle-completion.ts src/agents/subagent-registry-restore.ts src/agents/subagent-registry-run-manager.ts src/agents/subagent-registry-sweeper.ts src/agents/swarm-collector.ts` — classified `core, coreTests` and passed eight guards before stopping on the old branch baseline's unpinned `ui/package.json` noVNC range. This PR does not touch that file; current `origin/main` already pins `@novnc/novnc` to `1.7.0` in `5eaa99fe7d7`.
- `git diff --check` — passed.
- `AGENTS_HOME="$HOME/.claude" "$HOME/.claude/skills/autoreview/scripts/autoreview" --mode branch --base origin/main --max-priority P1` — clean; no accepted/actionable findings.
- Exact-head hosted CI for `c28d9f18928356db0bae68905ec603d109d974fd` completed green: https://github.com/openclaw/openclaw/actions/runs/31326868302
- Production code: `+49/-52` (net `-3`). Tests: `+187/-57` (net `+130`). No docs, config, schema, protocol, or changelog changes.
