### PR TITLE
fix(replies): keep approval-unavailable notices durable

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -2672,6 +2672,15 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       },
     },
     {
+      label: "unavailable exec approvals",
+      payload: {
+        text: "Exec approval is unavailable.",
+        channelData: {
+          execApprovalUnavailable: { reason: "no-approval-route" },
+        },
+      },
+    },
+    {
       label: "ask-user prompts",
       payload: {
         text: "Question for you: Where should this deploy?",

--- a/src/auto-reply/reply/dispatch-from-config.payloads.ts
+++ b/src/auto-reply/reply/dispatch-from-config.payloads.ts
@@ -51,6 +51,10 @@ export function hasExecApprovalPayload(payload: ReplyPayload): boolean {
   return isRecord(payload.channelData?.execApproval);
 }
 
+export function hasExecApprovalUnavailablePayload(payload: ReplyPayload): boolean {
+  return isRecord(payload.channelData?.execApprovalUnavailable);
+}
+
 export function hasAskUserPayload(payload: ReplyPayload): boolean {
   return isRecord(payload.channelData?.askUser);
 }
@@ -59,6 +63,7 @@ export function requiresDurableToolResultDelivery(payload: ReplyPayload): boolea
   return (
     resolveSendableOutboundReplyParts(payload).hasMedia ||
     hasExecApprovalPayload(payload) ||
+    hasExecApprovalUnavailablePayload(payload) ||
     hasAskUserPayload(payload)
   );
 }

--- a/src/auto-reply/reply/dispatch-from-config.prepare-execution.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-execution.ts
@@ -13,7 +13,11 @@ import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import type { GetReplyOptions } from "../get-reply-options.types.js";
 import type { ReplyPayload } from "../reply-payload.js";
 import type { ChooseDispatchRouteReadyState } from "./dispatch-from-config.choose-route.js";
-import { hasAskUserPayload, hasExecApprovalPayload } from "./dispatch-from-config.payloads.js";
+import {
+  hasAskUserPayload,
+  hasExecApprovalPayload,
+  hasExecApprovalUnavailablePayload,
+} from "./dispatch-from-config.payloads.js";
 import { extendPreparedDispatchState } from "./dispatch-from-config.phase-state.js";
 import { loadGetReplyFromConfigRuntime } from "./dispatch-from-config.runtime-loaders.js";
 import { withFullRuntimeReplyConfig } from "./get-reply-fast-path.js";
@@ -121,7 +125,7 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
     if (shouldSendToolSummaries()) {
       return payload;
     }
-    if (hasExecApprovalPayload(payload)) {
+    if (hasExecApprovalPayload(payload) || hasExecApprovalUnavailablePayload(payload)) {
       return payload;
     }
     if (hasAskUserPayload(payload)) {

--- a/src/auto-reply/reply/dispatch-from-config.routing.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.routing.test-utils.ts
@@ -427,6 +427,31 @@ describe("dispatchReplyFromConfig", () => {
     ).toBe(true);
   });
 
+  it("delivers approval-unavailable notices when verbose tool progress is disabled", async () => {
+    setNoAbort();
+    const payload = {
+      text: "Exec approval is unavailable.",
+      channelData: {
+        execApprovalUnavailable: { reason: "no-approval-route" },
+      },
+    } satisfies ReplyPayload;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", ChatType: "direct" });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await requireToolResultHandler(opts?.onToolResult)(payload);
+      return undefined;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+
+    expect(dispatcher.sendToolResult).toHaveBeenCalledWith(payload);
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
   it("drops ask_user prompts that terminalize before dispatcher delivery", async () => {
     setNoAbort();
     askUserMocks.isAskUserPromptPending.mockResolvedValue(false);

--- a/src/auto-reply/reply/followup-turn-execution.test.ts
+++ b/src/auto-reply/reply/followup-turn-execution.test.ts
@@ -330,6 +330,15 @@ describe("executeFollowupTurn", () => {
       },
     },
     {
+      label: "unavailable exec approvals",
+      payload: {
+        text: "Exec approval is unavailable.",
+        channelData: {
+          execApprovalUnavailable: { reason: "no-approval-route" },
+        },
+      },
+    },
+    {
       label: "ask-user prompts",
       payload: {
         text: "Question for you: Where should this deploy?",

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -688,18 +688,23 @@ describe("exec approval reply helpers", () => {
       }),
     ).toEqual({
       text: "Careful.\n\nApproval required. I sent approval DMs to the approvers for this account.",
+      channelData: {
+        execApprovalUnavailable: {
+          reason: "no-approval-route",
+        },
+      },
     });
   });
 
   it.each(unavailableReasonCases)(
     "builds unavailable payload for reason $reason",
     ({ reason, channelLabel, expected }) => {
-      expect(
-        buildExecApprovalUnavailableReplyPayload({
-          reason,
-          channelLabel,
-        }).text,
-      ).toContain(expected);
+      const payload = buildExecApprovalUnavailableReplyPayload({
+        reason,
+        channelLabel,
+      });
+      expect(payload.text).toContain(expected);
+      expect(payload.channelData).toEqual({ execApprovalUnavailable: { reason } });
     },
   );
 });

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -475,6 +475,11 @@ export function buildExecApprovalUnavailableReplyPayload(
   params: ExecApprovalUnavailableReplyParams,
 ): ReplyPayload {
   const lines: string[] = [];
+  const channelData = {
+    execApprovalUnavailable: {
+      reason: params.reason,
+    },
+  };
   const warningText = params.warningText?.trim();
   if (warningText) {
     lines.push(warningText);
@@ -484,6 +489,7 @@ export function buildExecApprovalUnavailableReplyPayload(
     lines.push(getExecApprovalApproverDmNoticeText());
     return {
       text: lines.join("\n\n"),
+      channelData,
     };
   }
 
@@ -535,5 +541,6 @@ export function buildExecApprovalUnavailableReplyPayload(
 
   return {
     text: lines.join("\n\n"),
+    channelData,
   };
 }


### PR DESCRIPTION
Fixes #121127

Related: #60445, #121048

## What Problem This Solves

Fixes an issue where users whose exec command could not enter the interactive approval flow could miss the actionable unavailable notice when transient progress delivery was active.

## Why This Change Was Made

Approval-unavailable replies now carry a typed channel-data marker on both builder return paths. The existing shared delivery classifier recognizes that marker, and the quiet direct resolver preserves the same marker beside pending approvals. Direct, queued, and non-forced quiet flows therefore route the notice through durable tool-result delivery without changing ordinary progress messages.

## User Impact

Users reliably receive the explanation and recovery guidance when an exec approval route is unavailable, including when a channel progress callback is active or verbose tool summaries are disabled.

## Evidence

- Added builder regressions for both unavailable reasons and both payload return shapes.
- Added direct and queued dispatcher-policy regressions proving the unavailable marker bypasses transient callbacks.
- Added a non-forced, verbose-off direct-dispatch regression proving the quiet resolver reaches durable `sendToolResult` delivery.
- Targeted `oxfmt`, `oxlint`, and `git diff --check` pass on the changed files.
- Controlled red proof restored the three production files to main while retaining the new tests: all four new producer assertions failed because `channelData` was undefined, then the approved patch was restored byte-for-byte.
- Exact head `c68595480345d68519a4834553ec52c84a727ea0` passed 41 producer tests, 351 direct-dispatch tests, and 28 queued follow-up tests.
- Blacksmith Testbox passed the full changed gate against the exact seven-file diff: https://github.com/openclaw/openclaw/actions/runs/31667726128
- Fresh exact-head autoreview is clean with 0.99 confidence and no actionable finding.
- A fresh secretless production-boundary proof entered through `qaChannelPlugin.gateway.startAccount`, used `channelRuntime.inbound.dispatch` plus the production durable classifier, and produced exactly one outbound QA channel API send.
- The proof mocked only the provider reply resolver and loopback channel API. It asserted the production approval-unavailable payload, target, reply id, one provider call, and one durable send without credentials or private output. This is a focused Gateway/channel boundary proof, not a full QA E2E.

## Focused Runtime Transcript

```text
PR121179_EPHEMERAL_GATEWAY_DURABLE_SEND_PROOF {"head":"c68595480345d68519a4834553ec52c84a727ea0","gatewayOwner":"qaChannelPlugin.gateway.startAccount","runtimeOwner":"createRuntimeChannel","dispatchOwner":"channelRuntime.inbound.dispatch","providerEdge":"mock-replyResolver","channelApiEdge":"loopback-http","inboundEvents":1,"providerCalls":1,"durableChannelSends":1,"target":"dm:[redacted]","replyTo":"[redacted]","reason":"no-approval-route","privateDataPrinted":false}
```

## Current-Main Refresh (2026-08-13)

- The contributor branch was rewritten from current main after `e4e558df215a009fb24faa4471c4ee8dc7730151` repaired the unrelated env-var ratchet failure; exact PR head is `c68595480345d68519a4834553ec52c84a727ea0`.
- The PR diff remains the same seven approval-delivery files at +72/-8; both rebases applied without conflict or integration edits.
- Native `scripts/pr` review initialization and guard passed against current main `64e8791601b`.
- Native review artifacts validate as `READY FOR /prepare-pr` with zero findings, behavioral sweep pass, and no silent-drop risk.
- Official exact-head CI completed with 82 successful and 42 skipped checks, zero pending, and zero failures; the final lint shard passed in https://github.com/openclaw/openclaw/actions/runs/31668801488

Punchcard-Session: clear-lantern-summit-v2
