### PR TITLE
fix(cron): deliver final descendant results for threaded jobs

### DIFF
--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -313,7 +313,7 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.deliveryPayload).toEqual({ text: "section 2" });
   });
 
-  it("keeps structured-content detection scoped to the last delivery payload", () => {
+  it("detects structured content anywhere in the selected delivery batch", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [{ mediaUrl: "https://example.com/report.png" }, { text: "final text" }],
       finalAssistantVisibleText: "full final report",
@@ -326,7 +326,7 @@ describe("resolveCronPayloadOutcome", () => {
     ]);
     expect(result.outputText).toBe("final text");
     expect(result.synthesizedText).toBe("final text");
-    expect(result.deliveryPayloadHasStructuredContent).toBe(false);
+    expect(result.deliveryPayloadHasStructuredContent).toBe(true);
   });
 
   it("keeps presentation-only delivery payloads instead of collapsing to final text", () => {

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -14,6 +14,16 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import * as deliveryQueueSqlite from "../../infra/delivery-queue-sqlite.js";
+import {
+  captureActivePluginRegistrySnapshot,
+  restoreActivePluginRegistrySnapshot,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
+import {
+  createDirectOutboundTestAdapter,
+  createOutboundTestPlugin,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 
 const directCronCompletionRetention = {
   idPrefix: "cron-direct-delivery:v1:",
@@ -1172,6 +1182,130 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     },
   );
 
+  it.each([
+    {
+      name: "active Telegram topic",
+      channel: "telegram",
+      to: "123456",
+      threadId: 42,
+      activeDescendants: true,
+      deliveryBestEffort: false,
+    },
+    {
+      name: "completed Telegram topic",
+      channel: "telegram",
+      to: "123456",
+      threadId: "42",
+      activeDescendants: false,
+      deliveryBestEffort: false,
+    },
+    {
+      name: "active Discord thread",
+      channel: "discord",
+      to: "123456789012345678",
+      threadId: "123456789012345679",
+      activeDescendants: true,
+      deliveryBestEffort: false,
+    },
+    {
+      name: "completed Slack thread",
+      channel: "slack",
+      to: "C1234567890",
+      threadId: "1712345678.123456",
+      activeDescendants: false,
+      deliveryBestEffort: false,
+    },
+    {
+      name: "active Matrix thread",
+      channel: "matrix",
+      to: "!room:example.org",
+      threadId: "$event:example.org",
+      activeDescendants: true,
+      deliveryBestEffort: false,
+    },
+    {
+      name: "completed Microsoft Teams thread",
+      channel: "msteams",
+      to: "19:team-channel@thread.tacv2",
+      threadId: "1712345678901",
+      activeDescendants: false,
+      deliveryBestEffort: false,
+    },
+    {
+      name: "active best-effort Slack thread",
+      channel: "slack",
+      to: "C1234567890",
+      threadId: "1712345678.654321",
+      activeDescendants: true,
+      deliveryBestEffort: true,
+    },
+  ])(
+    "delivers the child result instead of an interim parent reply to an $name",
+    async ({ activeDescendants, channel, deliveryBestEffort, threadId, to }) => {
+      const parentReply = "on it, pulling everything together";
+      const childReply = "Completed child result visible to the user.";
+      vi.mocked(isLikelyInterimCronMessage).mockImplementation((text) => text === parentReply);
+      if (activeDescendants) {
+        vi.mocked(countActiveDescendantRuns).mockReturnValueOnce(1).mockReturnValueOnce(0);
+        vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(childReply);
+      } else {
+        vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+        vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(childReply);
+      }
+
+      const params = makeBaseParams({
+        spawnOnlyHandoff: true,
+        synthesizedText: parentReply,
+        deliveryBestEffort,
+      });
+      params.agentSessionKey = "agent:main:cron:test-job";
+      params.runSessionKey = "agent:main:cron:test-job:run:test-session-id";
+      params.job.deleteAfterRun = true;
+      params.resolvedDelivery = makeResolvedDelivery({ channel, to, threadId });
+      const normalizeTarget = vi.fn((raw: string) => raw.trim());
+      const previousPluginRegistry = captureActivePluginRegistrySnapshot();
+      let state: Awaited<ReturnType<typeof dispatchCronDelivery>>;
+      try {
+        setActivePluginRegistry(
+          createTestRegistry([
+            {
+              pluginId: channel,
+              source: "test",
+              plugin: createOutboundTestPlugin({
+                id: channel,
+                outbound: createDirectOutboundTestAdapter({ channel }),
+                messaging: { normalizeTarget },
+              }),
+            },
+          ]),
+        );
+        state = await dispatchCronDelivery(params);
+      } finally {
+        restoreActivePluginRegistrySnapshot(previousPluginRegistry);
+      }
+
+      expect(waitForDescendantSubagentSummary).toHaveBeenCalledTimes(activeDescendants ? 1 : 0);
+      if (activeDescendants) {
+        expect(waitForDescendantSubagentSummary).toHaveBeenCalledWith(
+          expect.objectContaining({ initialReply: parentReply }),
+        );
+      }
+      expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+      expectDeliveryCall(0, {
+        channel,
+        to,
+        threadId,
+        payloads: [{ text: childReply }],
+      });
+      expect(normalizeTarget).toHaveBeenCalledWith(to);
+      expect(state.delivered).toBe(true);
+      expect(state.cronRunSessionCleanupAttempted).toBe(true);
+      expect(callGateway).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "sessions.delete" }),
+      );
+    },
+  );
+
   it("preserves a substantive parent synthesis after an accepted child has completed", async () => {
     const parentReply = "Combined parent summary already includes every child result.";
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
@@ -1199,35 +1333,88 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(state.delivered).toBe(true);
   });
 
-  it.each([
-    {
-      name: "active child times out",
-      activeDescendants: 1,
-      error: "cron child-session handoff timed out before producing a final assistant payload",
-    },
-    {
-      name: "completed child has no output",
-      activeDescendants: 0,
-      error: "cron child-session handoff completed without a final assistant payload",
-    },
-  ])("fails an accepted spawn-only handoff when $name", async ({ activeDescendants, error }) => {
-    vi.mocked(countActiveDescendantRuns).mockReturnValue(activeDescendants);
-    const params = makeBaseParams({ spawnOnlyHandoff: true, synthesizedText: "" });
-    params.synthesizedText = undefined;
-    params.deliveryPayloads = [];
-    params.summary = undefined;
-    params.outputText = undefined;
+  it("preserves structured parent output followed by an interim threaded reply", async () => {
+    const mediaPayload = { mediaUrl: "https://example.invalid/chart.png" };
+    const interimPayload = { text: "on it, pulling everything together" };
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(1);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(true);
+    const params = makeBaseParams({
+      spawnOnlyHandoff: false,
+      synthesizedText: interimPayload.text,
+    });
+    params.deliveryPayloadHasStructuredContent = true;
+    params.deliveryPayloads = [mediaPayload, interimPayload];
+    params.resolvedDelivery = makeResolvedDelivery({ threadId: "42" });
 
     const state = await dispatchCronDelivery(params);
 
-    expectResultFields(state.result, {
-      status: "error",
-      error,
-      delivered: false,
-      deliveryAttempted: true,
+    expect(waitForDescendantSubagentSummary).not.toHaveBeenCalled();
+    expect(deliverOutboundPayloads).toHaveBeenCalledOnce();
+    expectDeliveryCall(0, {
+      threadId: "42",
+      payloads: [mediaPayload, interimPayload],
     });
-    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+    expect(state.delivered).toBe(true);
   });
+
+  it.each([
+    {
+      name: "active child with no parent text times out",
+      activeDescendants: 1,
+      parentReply: undefined,
+      error: "cron child-session handoff timed out before producing a final assistant payload",
+    },
+    {
+      name: "completed child with no parent text has no output",
+      activeDescendants: 0,
+      parentReply: undefined,
+      error: "cron child-session handoff completed without a final assistant payload",
+    },
+    {
+      name: "active child leaves only the interim parent reply",
+      activeDescendants: 1,
+      parentReply: "on it, pulling everything together",
+      error: "cron child-session handoff timed out before producing a final assistant payload",
+    },
+    {
+      name: "completed child leaves only the interim parent reply",
+      activeDescendants: 0,
+      parentReply: "on it, pulling everything together",
+      error: "cron child-session handoff completed without a final assistant payload",
+    },
+  ])(
+    "keeps a one-shot child-owned handoff when $name",
+    async ({ activeDescendants, error, parentReply }) => {
+      vi.mocked(countActiveDescendantRuns).mockReturnValue(activeDescendants);
+      vi.mocked(isLikelyInterimCronMessage).mockImplementation((text) => text === parentReply);
+      const params = makeBaseParams({
+        spawnOnlyHandoff: true,
+        synthesizedText: parentReply ?? "",
+      });
+      params.agentSessionKey = "agent:main:cron:test-job";
+      params.job.deleteAfterRun = true;
+      params.resolvedDelivery = makeResolvedDelivery({ threadId: "42" });
+      if (!parentReply) {
+        params.synthesizedText = undefined;
+        params.deliveryPayloads = [];
+        params.summary = undefined;
+        params.outputText = undefined;
+      }
+
+      const state = await dispatchCronDelivery(params);
+
+      expectResultFields(state.result, {
+        status: "error",
+        error,
+        delivered: false,
+        deliveryAttempted: true,
+      });
+      expect(state.synthesizedText).toBeUndefined();
+      expect(state.deliveryPayloads).toEqual([]);
+      expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+      expect(callGateway).not.toHaveBeenCalled();
+    },
+  );
 
   it("preserves abort precedence when an accepted child handoff is interrupted", async () => {
     const abortReason = "scheduled run aborted while waiting for its child";

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -70,17 +70,6 @@ const deliveryOutboundRuntimeLoader = createLazyImportLoader(
 const subagentFollowupRuntimeLoader = createLazyImportLoader(
   () => import("./subagent-followup.runtime.js"),
 );
-async function loadDeliveryOutboundRuntime(): Promise<
-  typeof import("./delivery-outbound.runtime.js")
-> {
-  return await deliveryOutboundRuntimeLoader.load();
-}
-
-async function loadSubagentFollowupRuntime(): Promise<
-  typeof import("./subagent-followup.runtime.js")
-> {
-  return await subagentFollowupRuntimeLoader.load();
-}
 
 export {
   cleanupDirectCronSession,
@@ -201,7 +190,7 @@ export async function dispatchCronDelivery(
       createOutboundSendDeps,
       resolveAgentOutboundIdentity,
       sendDurableMessageBatch,
-    } = await loadDeliveryOutboundRuntime();
+    } = await deliveryOutboundRuntimeLoader.load();
     const identity = resolveAgentOutboundIdentity(params.cfgWithAgentDefaults, params.agentId);
     try {
       const summaryFallbackText = resolveDirectCronSummaryFallbackText({
@@ -590,7 +579,7 @@ export async function dispatchCronDelivery(
     const needsSubagentFollowupRuntime =
       shouldCheckCompletedDescendants || activeSubagentRuns > 0 || expectedSubagentFollowup;
     const subagentFollowupRuntime = needsSubagentFollowupRuntime
-      ? await loadSubagentFollowupRuntime()
+      ? await subagentFollowupRuntimeLoader.load()
       : undefined;
     // Also check for already-completed descendants. If the subagent finished
     // before delivery-dispatch runs, activeSubagentRuns is 0 and
@@ -604,11 +593,13 @@ export async function dispatchCronDelivery(
         })
       : undefined;
     const hadDescendants = activeSubagentRuns > 0 || Boolean(completedDescendantReply);
+    // Already-finished and awaited children share the same final-output owner.
+    let finalReply = completedDescendantReply;
     if (
       (!params.deliveryBestEffort || spawnOnlyHandoff) &&
       (activeSubagentRuns > 0 || expectedSubagentFollowup)
     ) {
-      let finalReply = await subagentFollowupRuntime?.waitForDescendantSubagentSummary({
+      finalReply = await subagentFollowupRuntime?.waitForDescendantSubagentSummary({
         sessionKey: subagentFollowupSessionKey,
         initialReply: initialSynthesizedText,
         timeoutMs: params.timeoutMs,
@@ -623,23 +614,23 @@ export async function dispatchCronDelivery(
           runStartedAt: params.runStartedAt,
         });
       }
-      if (finalReply && activeSubagentRuns === 0) {
-        outputText = finalReply;
-        summary = pickSummaryFromOutput(finalReply) ?? summary;
-        synthesizedText = finalReply;
-        deliveryPayloads = [{ text: finalReply }];
-      }
-    } else if (completedDescendantReply) {
-      // Descendants already finished before we got here. Use their output
-      // directly instead of the cron agent's interim text.
-      outputText = completedDescendantReply;
-      summary = pickSummaryFromOutput(completedDescendantReply) ?? summary;
-      synthesizedText = completedDescendantReply;
-      deliveryPayloads = [{ text: completedDescendantReply }];
     }
-    if (spawnOnlyHandoff && !synthesizedText?.trim()) {
+    if (finalReply && activeSubagentRuns === 0) {
+      outputText = finalReply;
+      summary = pickSummaryFromOutput(finalReply) ?? summary;
+      synthesizedText = finalReply;
+      deliveryPayloads = [{ text: finalReply }];
+    }
+    const unchangedInterimHandoff =
+      synthesizedText?.trim() === initialSynthesizedText &&
+      isLikelyInterimCronMessage(initialSynthesizedText);
+    if (spawnOnlyHandoff && (!synthesizedText?.trim() || unchangedInterimHandoff)) {
       // An accepted spawn is the turn's only completion; retiring it without
       // child output permanently loses one-shot scheduled work.
+      synthesizedText = undefined;
+      outputText = undefined;
+      summary = undefined;
+      deliveryPayloads = [];
       const error = params.isAborted()
         ? params.abortReason()
         : activeSubagentRuns > 0
@@ -669,8 +660,7 @@ export async function dispatchCronDelivery(
     }
     if (
       hadDescendants &&
-      synthesizedText?.trim() === initialSynthesizedText &&
-      isLikelyInterimCronMessage(initialSynthesizedText) &&
+      unchangedInterimHandoff &&
       !isSilentReplyText(initialSynthesizedText, SILENT_REPLY_TOKEN)
     ) {
       // Descendants existed but no post-orchestration synthesis arrived AND
@@ -739,16 +729,11 @@ export async function dispatchCronDelivery(
     const useDirectDelivery =
       params.deliveryPayloadHasStructuredContent ||
       (params.resolvedDelivery.threadId != null && !params.spawnOnlyHandoff);
-    if (useDirectDelivery) {
-      const directResult = await deliverViaDirectAndCleanup(params.resolvedDelivery);
-      if (directResult) {
-        return buildDeliveryState(directResult);
-      }
-    } else {
-      const finalizedTextResult = await finalizeTextDelivery(params.resolvedDelivery);
-      if (finalizedTextResult) {
-        return buildDeliveryState(finalizedTextResult);
-      }
+    const deliveryResult = useDirectDelivery
+      ? await deliverViaDirectAndCleanup(params.resolvedDelivery)
+      : await finalizeTextDelivery(params.resolvedDelivery);
+    if (deliveryResult) {
+      return buildDeliveryState(deliveryResult);
     }
   }
 

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -283,7 +283,6 @@ export function resolveCronPayloadOutcome(params: {
   const fallbackOutputText = pickLastNonEmptyTextFromPayloads(params.payloads);
   const deliveryPayload = pickLastDeliverablePayload(params.payloads);
   const selectedDeliveryPayloads = pickDeliverablePayloads(params.payloads);
-  const deliveryPayloadHasStructuredContent = payloadHasStructuredDeliveryContent(deliveryPayload);
   const hasErrorPayload = params.payloads.some((payload) => payload?.isError === true);
   const lastErrorPayloadIndex = params.payloads.findLastIndex(
     (payload) => payload?.isError === true,
@@ -398,9 +397,7 @@ export function resolveCronPayloadOutcome(params: {
     deliveryPayload: fatalDeliveryPayload ?? deliveryPayload,
     deliveryPayloads: delivery.deliveryPayloads,
     deliveryDisposition: delivery.deliveryDisposition,
-    deliveryPayloadHasStructuredContent: fatalDeliveryPayload
-      ? false
-      : deliveryPayloadHasStructuredContent,
+    deliveryPayloadHasStructuredContent: !fatalDeliveryPayload && hasStructuredDeliveryPayloads,
     hasFatalErrorPayload,
     hasFatalStructuredErrorPayload,
     embeddedRunError: structuredErrorText

--- a/src/cron/isolated-agent/run-finalize.ts
+++ b/src/cron/isolated-agent/run-finalize.ts
@@ -32,6 +32,7 @@ import {
   setSessionRuntimeModel,
 } from "./run.runtime.js";
 import type { RunCronAgentTurnResult } from "./run.types.js";
+import { isLikelyInterimCronMessage } from "./subagent-followup-hints.js";
 
 type CronExecutionRuntime = typeof import("./run-executor.runtime.js");
 type CronExecutionResult = Awaited<ReturnType<CronExecutionRuntime["executeCronRun"]>>;
@@ -356,9 +357,14 @@ export async function finalizeCronRun(params: {
     heartbeatOnlyResponse &&
     (deliveryDisposition.kind === "empty" ||
       (deliveryDisposition.kind === "heartbeat" && deliveryDisposition.controlOnly));
+  const interimOnlyResponse =
+    !deliveryPayloadHasStructuredContent &&
+    isLikelyInterimCronMessage(synthesizedText ?? "") &&
+    deliveryPayloads.every((payload) => isLikelyInterimCronMessage(payload.text ?? ""));
   const spawnOnlyHandoff =
     acceptedSessionSpawn &&
     (heartbeatControlOnlyResponse ||
+      interimOnlyResponse ||
       (deliveryPayloads.length === 0 && normalizeOptionalString(synthesizedText) === undefined));
   if (spawnOnlyHandoff && heartbeatControlOnlyResponse) {
     // Parent heartbeat acknowledgments cannot fulfill child delivery; one-shot

--- a/src/cron/isolated-agent/run.meta-error-status.test.ts
+++ b/src/cron/isolated-agent/run.meta-error-status.test.ts
@@ -1,9 +1,10 @@
 // Run meta error tests cover status reporting when cron run metadata fails.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
 import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
 import {
   cleanupDirectCronSessionMock,
+  countActiveDescendantRunsMock,
   dispatchCronDeliveryMock,
   loadRunCronIsolatedAgentTurn,
   resolveCronDeliveryPlanMock,
@@ -245,6 +246,94 @@ describe("runCronIsolatedAgentTurn - meta.error status propagation", () => {
     expect(result.delivered).toBe(false);
   });
 
+  it.each(["on it", "pulling everything together", "working on it, give me a few minutes"])(
+    "hands interim parent reply %s to the accepted child without erasing its original text",
+    async (parentReply) => {
+      const interimPayload = { text: parentReply };
+      countActiveDescendantRunsMock.mockReturnValue(1);
+      mockAgentRun({
+        payloads: [interimPayload],
+        usage: { input: 10, output: 1 },
+        acceptedSessionSpawns: [{ runId: "run-child", childSessionKey: "agent:default:child" }],
+      });
+      mockAnnounceOutcome({
+        summary: parentReply,
+        outputText: parentReply,
+        synthesizedText: parentReply,
+        deliveryPayload: interimPayload,
+        deliveryPayloads: [interimPayload],
+      });
+
+      const result = await runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture());
+
+      expect(dispatchCronDeliveryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          spawnOnlyHandoff: true,
+          skipHeartbeatDelivery: false,
+          deliveryPayloads: [interimPayload],
+          synthesizedText: parentReply,
+        }),
+      );
+      expect(result.status).toBe("ok");
+    },
+  );
+
+  it("preserves an interim-only accepted child handoff failure as a cron error", async () => {
+    const parentReply = "on it, pulling everything together";
+    const interimPayload = { text: parentReply };
+    const error = "cron child-session handoff timed out before producing a final assistant payload";
+    countActiveDescendantRunsMock.mockReturnValue(1);
+    mockAgentRun({
+      payloads: [interimPayload],
+      acceptedSessionSpawns: [{ runId: "run-child", childSessionKey: "agent:default:child" }],
+    });
+    mockAnnounceOutcome({
+      summary: parentReply,
+      outputText: parentReply,
+      synthesizedText: parentReply,
+      deliveryPayload: interimPayload,
+      deliveryPayloads: [interimPayload],
+    });
+    mockDeliveryFailure(error);
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        job: makeIsolatedAgentJobFixture({ deleteAfterRun: true }),
+      }),
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toBe(error);
+    expect(result.delivered).toBe(false);
+  });
+
+  it("preserves a substantive parent payload before an interim sibling", async () => {
+    const substantivePayload = { text: "Completed the report and attached the source data." };
+    const interimPayload = { text: "on it, pulling everything together" };
+    countActiveDescendantRunsMock.mockReturnValue(1);
+    mockAgentRun({
+      payloads: [substantivePayload, interimPayload],
+      acceptedSessionSpawns: [{ runId: "run-child", childSessionKey: "agent:default:child" }],
+    });
+    mockAnnounceOutcome({
+      summary: interimPayload.text,
+      outputText: interimPayload.text,
+      synthesizedText: interimPayload.text,
+      deliveryPayload: interimPayload,
+      deliveryPayloads: [substantivePayload, interimPayload],
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture());
+
+    expect(dispatchCronDeliveryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spawnOnlyHandoff: false,
+        deliveryPayloads: [substantivePayload, interimPayload],
+      }),
+    );
+    expect(result.status).toBe("ok");
+  });
+
   it.each([
     "HEARTBEAT_OK",
     "**HEARTBEAT_OK**",
@@ -383,6 +472,31 @@ describe("runCronIsolatedAgentTurn - meta.error status propagation", () => {
     );
     expect(result.status).toBe("ok");
     expect(result.deliveryError).toBe(error);
+  });
+
+  it("preserves a structured parent batch when its final sibling is an interim reply", async () => {
+    const mediaPayload = { mediaUrl: "https://example.invalid/chart.png" };
+    const interimPayload = { text: "on it, pulling everything together" };
+    mockAgentRun({
+      payloads: [mediaPayload, interimPayload],
+      usage: { input: 10, output: 1 },
+      acceptedSessionSpawns: [{ runId: "run-child", childSessionKey: "agent:default:child" }],
+    });
+    mockAnnounceOutcome();
+    const { resolveCronPayloadOutcome } =
+      await vi.importActual<typeof import("./helpers.js")>("./helpers.js");
+    resolveCronPayloadOutcomeMock.mockImplementation(resolveCronPayloadOutcome);
+
+    const result = await runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture());
+
+    expect(dispatchCronDeliveryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spawnOnlyHandoff: false,
+        deliveryPayloadHasStructuredContent: true,
+        deliveryPayloads: [mediaPayload, interimPayload],
+      }),
+    );
+    expect(result.status).toBe("ok");
   });
 
   it("does not mark empty successful cron-add completions as cron errors", async () => {


### PR DESCRIPTION
## What Problem This Solves
Scheduled jobs that handed work to child agents could publish interim orchestration text, lose the final descendant result, or misroute structured threaded output across channel-specific delivery targets.

## Why This Change Was Made
The cron delivery owner now treats completed and awaited child results through one canonical final-output flow, recognizes interim-only spawn handoffs, preserves structured payload classification, and chooses threaded direct versus normal delivery from the prepared target contract.

## User Impact
Scheduled Telegram, Discord, Slack, Matrix, and Teams jobs deliver their actual final child response to the intended thread instead of leaking placeholder text, dropping completed work, or emitting duplicate announcements.

## Context
Exact final-source trusted remote proof passed 259 tests across seven focused files, including actual channel target normalization and all five channel delivery families. The previously failing core and plugin-boundary type-aware lint gate passed after correcting the implementation; all six changed files pass formatting. Production code decreases by 12 lines.
