### PR TITLE
fix(line): treat a non-positive mediaMaxMb as unset

### DIFF
--- a/extensions/line/src/bot.test.ts
+++ b/extensions/line/src/bot.test.ts
@@ -1,0 +1,107 @@
+// Line tests cover how the bot resolves the inbound media cap it hands to the handlers.
+import type { webhook } from "@line/bot-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type DeliverFn = (
+  event: webhook.Event,
+  destination: string,
+  control: Record<string, unknown>,
+) => Promise<void>;
+
+const { createLineWebhookSpoolMock, handleLineWebhookEventsMock } = vi.hoisted(() => ({
+  createLineWebhookSpoolMock: vi.fn(),
+  // Typed parameters so the recorded call can be read back as the handler context.
+  handleLineWebhookEventsMock: vi.fn(
+    async (_events: webhook.Event[], _context: { mediaMaxBytes: number }) => {},
+  ),
+}));
+
+vi.mock("./webhook-spool.js", () => ({
+  createLineWebhookSpool: createLineWebhookSpoolMock,
+}));
+vi.mock("./bot-handlers.js", () => ({
+  handleLineWebhookEvents: handleLineWebhookEventsMock,
+}));
+
+const { createLineBot } = await import("./bot.js");
+
+const MB = 1024 * 1024;
+
+function configWith(mediaMaxMb?: number): OpenClawConfig {
+  return {
+    channels: {
+      line: {
+        enabled: true,
+        channelAccessToken: "test-token",
+        channelSecret: "test-secret",
+        ...(mediaMaxMb === undefined ? {} : { mediaMaxMb }),
+      },
+    },
+  } as OpenClawConfig;
+}
+
+// The bot only reveals the resolved cap by handing it to the handlers, so drive
+// the spool's deliver callback once and read what the handlers were given.
+async function resolveMediaMaxBytes(opts: {
+  configuredMediaMaxMb?: number;
+  optionMediaMaxMb?: number;
+}): Promise<number> {
+  let deliver: DeliverFn | undefined;
+  createLineWebhookSpoolMock.mockImplementation((spoolOptions: { deliver: DeliverFn }) => {
+    deliver = spoolOptions.deliver;
+    return { accept: vi.fn(), start: vi.fn(), stop: vi.fn() };
+  });
+
+  createLineBot({
+    channelAccessToken: "test-token",
+    channelSecret: "test-secret",
+    config: configWith(opts.configuredMediaMaxMb),
+    ...(opts.optionMediaMaxMb === undefined ? {} : { mediaMaxMb: opts.optionMediaMaxMb }),
+  });
+
+  if (!deliver) {
+    throw new Error("createLineBot did not build a spool deliver callback");
+  }
+  await deliver({ type: "message" } as webhook.Event, "destination", {});
+
+  const context = handleLineWebhookEventsMock.mock.calls.at(-1)?.[1];
+  if (typeof context?.mediaMaxBytes !== "number") {
+    throw new Error("handleLineWebhookEvents was not given a mediaMaxBytes");
+  }
+  return context.mediaMaxBytes;
+}
+
+describe("createLineBot media cap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    { mediaMaxMb: 0, label: "zero" },
+    { mediaMaxMb: -5, label: "negative" },
+  ])("treats a $label mediaMaxMb as unset instead of a 0-byte cap", async ({ mediaMaxMb }) => {
+    // A non-positive cap would otherwise reject every non-empty inbound download.
+    await expect(resolveMediaMaxBytes({ configuredMediaMaxMb: mediaMaxMb })).resolves.toBe(10 * MB);
+  });
+
+  it("keeps the default when mediaMaxMb is unset", async () => {
+    await expect(resolveMediaMaxBytes({})).resolves.toBe(10 * MB);
+  });
+
+  it("still caps at a configured positive mediaMaxMb", async () => {
+    await expect(resolveMediaMaxBytes({ configuredMediaMaxMb: 2 })).resolves.toBe(2 * MB);
+  });
+
+  it("keeps the caller override ahead of account config", async () => {
+    await expect(
+      resolveMediaMaxBytes({ configuredMediaMaxMb: 2, optionMediaMaxMb: 3 }),
+    ).resolves.toBe(3 * MB);
+  });
+
+  it("falls through a non-positive caller override to the account config", async () => {
+    await expect(
+      resolveMediaMaxBytes({ configuredMediaMaxMb: 2, optionMediaMaxMb: 0 }),
+    ).resolves.toBe(2 * MB);
+  });
+});

--- a/extensions/line/src/bot.ts
+++ b/extensions/line/src/bot.ts
@@ -14,6 +14,8 @@ import type { LineInboundContext } from "./bot-message-context.js";
 import type { ResolvedLineAccount } from "./types.js";
 import { createLineWebhookSpool, type LineWebhookTurnAdoptionLifecycle } from "./webhook-spool.js";
 
+const DEFAULT_MEDIA_MAX_MB = 10;
+
 interface LineBotOptions {
   channelAccessToken: string;
   channelSecret: string;
@@ -42,7 +44,15 @@ export function createLineBot(opts: LineBotOptions): LineBot {
     accountId: opts.accountId,
   });
 
-  const mediaMaxBytes = (opts.mediaMaxMb ?? account.config.mediaMaxMb ?? 10) * 1024 * 1024;
+  // A non-positive cap cannot bound a transfer, so treat it as unset at every
+  // link. `??` alone keeps a configured 0 or negative and turns every inbound
+  // media download into a 0-byte budget the media core rejects, which degrades
+  // the attachment to an unavailable notice without naming the setting.
+  const effectiveMediaMaxMb =
+    [opts.mediaMaxMb, account.config.mediaMaxMb].find(
+      (value) => typeof value === "number" && value > 0,
+    ) ?? DEFAULT_MEDIA_MAX_MB;
+  const mediaMaxBytes = effectiveMediaMaxMb * 1024 * 1024;
 
   const processMessage =
     opts.onMessage ??


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who set `channels.line.mediaMaxMb` to `0` — or to a
negative value — silently lose non-empty inbound LINE attachments on that account: the
agent is handed `[line attachment unavailable]` in place of the media. The rejection is a
byte-count comparison that does not look at the media kind, so it applies to every
downloadable LINE message type — image, video, audio and file — though the capture below
exercises an image.

The value is accepted by config validation: LINE declares its own `mediaMaxMb` with no
range (`extensions/line/src/config-schema.ts:36`, `z.number().optional()`), so nothing
rejects it at load time. `createLineBot` then resolved the cap with `??`, which only
replaces `null`/`undefined`, so `0` survived into `mediaMaxBytes = 0 * 1024 * 1024` and
reached the media core as a byte budget no payload can satisfy. The first non-empty chunk
trips `src/media/store.ts:481-483`:

```
Media exceeds 0MB limit
```

Nothing surfaces that. The thrown value is a plain `Error`, not a `MediaFetchError`, so
`isRetryableLineInboundMediaError` (`extensions/line/src/download.ts:141-157`) returns
false and the event is not retried; `extensions/line/src/bot-handlers.ts:433-437` then
sets `mediaUnavailable` and — because the message contains both `exceeds` and `limit` —
routes it to `logVerbose` rather than `runtime.error`. The turn still reaches the agent,
just without the attachment. In the captured runs below the runtime error channel stays
empty and no line emitted on this path names `mediaMaxMb`, so an operator sees a verbose
line about a size limit they did not knowingly set.

The shared contract other channels use forbids non-positive values:
`CommonMediaMaxMbSchema = z.number().positive()`
(`src/config/zod-schema.channel-messaging-common.ts`). Channels that reuse it publish
`exclusiveMinimum: 0` in the generated config metadata, so the value can never reach their
resolvers. LINE does not use it, so the raw value survives validation and lands on the
resolver.

Resolvers that have to cope with a raw number already agree on what a non-positive value
means — all of them fall back to a default rather than treating it as a cap:

- `src/gateway/chat-attachment-policy.ts` — `typeof configured === "number" && Number.isFinite(configured) && configured > 0`
- `src/media/configured-max-bytes.ts` — the same predicate
- `extensions/whatsapp/src/accounts.ts` — `resolveWhatsAppMediaMaxBytes`, already shipped

LINE's resolver was the outlier: it turned the value into a literal byte budget.

## Why This Change Was Made

`createLineBot` (`extensions/line/src/bot.ts`) owns what an account's media cap means, and
it resolved that cap with `??`. That is the whole production change:

```ts
// before
const mediaMaxBytes = (opts.mediaMaxMb ?? account.config.mediaMaxMb ?? 10) * 1024 * 1024;

// after
const effectiveMediaMaxMb =
  [opts.mediaMaxMb, account.config.mediaMaxMb].find(
    (value) => typeof value === "number" && value > 0,
  ) ?? DEFAULT_MEDIA_MAX_MB;
const mediaMaxBytes = effectiveMediaMaxMb * 1024 * 1024;
```

Nothing upstream of that line normalizes the value. `resolveLineAccount`
(`extensions/line/src/accounts.ts`) never touches the field, and `mergeAccountConfig`
(`src/channels/plugins/account-helpers.ts`) is a plain spread that keeps `0`. The only
caller in the plugin, `extensions/line/src/monitor.ts:152` (the only `createLineBot(` call
outside tests), passes no `mediaMaxMb` override, so `account.config.mediaMaxMb` arrives raw. The default parameter in
`downloadLineMedia` (`extensions/line/src/download.ts:162`, `maxBytes = 10 * 1024 * 1024`)
cannot rescue it either: it fires only on `undefined`, and `bot.ts` always passes a
computed number.

The guard applies "non-positive means unset" at **every link** of the chain rather than
after collapsing it. That matters for the caller override: folding first
(`opts.mediaMaxMb ?? account.config.mediaMaxMb`, then guarding the result) would let a
non-positive `opts.mediaMaxMb` discard a perfectly valid `account.config` value. Applying
the predicate per link keeps the existing precedence — a positive override still wins —
without introducing that second silent drop. That arm is not observable today: no caller in
the plugin passes `mediaMaxMb`, so `opts.mediaMaxMb` is always `undefined` in production.
It is written this way so the resolver means one thing for both of its inputs rather than
two, not to fix a reported symptom on the override path.

The reachable inputs are `0` and negatives: `z.number()` already rejects `NaN` and
non-finite values, so those never reach this resolver and the guard does not try to model
them. `value > 0` is the same predicate the canonical `CommonMediaMaxMbSchema`
(`z.number().positive()`) applies to the channels that use it.

This patch changes that one resolver and nothing else in production code. It reuses the
existing fallback; no new fallback path is added. The unset-to-`10` fallback already lived
on this line, and the guard widens the condition that triggers it from "unset" to "unset or
not a usable cap". The inline `10` in that expression becomes a module-private
`DEFAULT_MEDIA_MAX_MB` so the value the fallback lands on is named where it is chosen. The
separate default parameter in `downloadLineMedia` is untouched.

**Design note.** This is the third and last bundled channel with this defect. The set was
determined from `src/config/bundled-channel-config-metadata.generated.ts`: every
`mediaMaxMb` entry in that catalog publishes `exclusiveMinimum: 0` except the ones owned by
LINE, Matrix and Zalo, so a non-positive value cannot reach any other channel's resolver.
#120466 fixed Matrix and landed the semantics as "non-positive = uncapped", because
Matrix's `loadWebMedia` reads `undefined` as no cap. #120988 fixed Zalo, where the resolver
already defined "unset" as the channel default, so it landed as that default instead. LINE
matches Zalo: "unset" here already means 10 MB, so that is where a non-positive value lands.

The resolver is the durable place for this. It owns the meaning of the account's cap and
has to be total over whatever the schema lets through, so the guard is not a stopgap for a
missing constraint — a resolver has to be total over whatever reaches it even after a
schema is tightened. Tightening `extensions/line/src/config-schema.ts` with `.positive()`
is worth doing and belongs in its own PR: it turns a config that loads today into one that
fails validation, which is a compatibility decision rather than a bug fix, and it forces a
regeneration of `src/config/bundled-channel-config-metadata.generated.ts` — a cross-channel
generated artifact, not a LINE-local one. Landing the resolver first means the invalid value
stops causing harm immediately, without coupling that to a breaking-change decision.

## User Impact

Operators who set `mediaMaxMb: 0`, or who typo a negative, now get the channel default
(10 MB) instead of an account whose inbound media silently stops working. A configured
positive limit is unchanged, and so is the unset case.

The inbound download path is the only place this setting is wired to: the resolved budget
travels from `extensions/line/src/bot.ts:71` to `extensions/line/src/bot-handlers.ts:418`,
which hands it to `downloadLineMedia`, and no other call site in the plugin reads it. So
outbound sending is unaffected in both directions.

## Evidence

### Real behavior proof

Behavior addressed: a non-positive `channels.line.mediaMaxMb` reaching the media core as a
byte budget, so inbound LINE attachments are rejected before the agent ever sees them.

Real environment tested: Linux x86_64, node v24.18.0. Baseline `be6f4c3d6a82`
(upstream/main), candidate `d5da1d29087d` (this PR's head).

Exact steps or command run after this patch: a before/after harness is kept outside the
repository and invoked as `node --import tsx <harness>` from two worktrees — one checked out
at the baseline, one at this patch. Both runs execute the same bytes of the harness against
the same fixture bytes, so the only variable is the source under test; the captures below
are its stdout. That harness is not reviewable from a checkout, and the reproducible claim
is the regression suite, which needs nothing but this repository:

```sh
node scripts/run-vitest.mjs extensions/line/src/bot.test.ts
node scripts/run-vitest.mjs extensions/line
```

The harness drives the real `createLineBot`. It hands one `image` webhook event to the real
`handleWebhook`, which admits it through the real durable webhook spool and its SQLite
ingress queue, downloads the content through the real `downloadLineMedia`, and persists it
through the real `saveMediaStream`. Cap resolution and limit enforcement are production
code throughout; the harness supplies config and records what that code did.

Three substitutions, all outside the behaviour under test: `globalThis.fetch` is replaced
with a passthrough that rewrites `api-data.line.me` to a loopback HTTP server and calls the
real `fetch` (bytes still cross a real socket and are still streamed in 64 KiB chunks — the
production adapter `fetchWithRuntimeDispatcherOrMockedGlobal` already honours this seam);
`onMessage` — the same callback the production monitor passes at
`extensions/line/src/monitor.ts:152-158` — records the context the bot built instead of
running an agent; and `state.openChannelIngressQueue` is supplied directly, making the same
call the plugin-registry proxy makes for a bundled plugin, rather than booting the registry.

Each case serves the same 1,572,864-byte JPEG. The resolver multiplies the configured
number by `1024 * 1024`, so that payload sits under the default budget (10,485,760 bytes),
over the `1` control budget (1,048,576 bytes), and is non-empty so a 0-byte budget must
reject it (`src/media/store.ts:478-479` skips zero-length chunks, so a genuinely empty
stream would survive one).

Before (pre-fix, `be6f4c3d6a82`) — the run covers all four cases; the `0` case is quoted in
full and the per-case outcomes are excerpted after it:

```text
===== BEFORE (baseline be6f4c3d6a82, unfixed source) =====
      "agentBody": "[line attachment unavailable]",
          "contentType": "image",
          "hasPath": false
      "savedMediaBytes": null,
        "line: media exceeds size limit for message proof-message-0",
        "line inbound: from=line:user-proof len=92 preview=\"[LINE user:user-proof Sat 2026-03-21 18:40:23 GMT+9] (sender): [line attachment unavailable]\""

      "case": "mediaMaxMb=-5 (defect case, negative)",
      "agentBody": "[line attachment unavailable]",
      "savedMediaBytes": null,
      "case": "mediaMaxMb unset (control)",
      "agentBody": "",
      "savedMediaBytes": 1572864,
      "case": "mediaMaxMb=1 (control, positive cap still enforced)",
      "agentBody": "[line attachment unavailable]",
      "savedMediaBytes": null,
```

The runtime error channel stayed empty in every case on both sides, so in these runs the
verbose line above is the whole trace a dropped attachment leaves.

Evidence after fix: same harness, same fixture, candidate `d5da1d29087d`.

```text
===== AFTER (candidate d5da1d29087d, fix applied) =====
      "agentBody": "",
          "contentType": "image/jpeg",
          "hasPath": true
      "savedMediaBytes": 1572864,
        "line: persisted media proof-message-0 to <state dir>/media/inbound/<id>.jpg (1572864 bytes)",
        "line inbound: from=line:user-proof len=63 preview=\"[LINE user:user-proof Sat 2026-03-21 18:40:23 GMT+9] (sender): \""

      "case": "mediaMaxMb=-5 (defect case, negative)",
      "agentBody": "",
      "savedMediaBytes": 1572864,
      "case": "mediaMaxMb unset (control)",
      "agentBody": "",
      "savedMediaBytes": 1572864,
      "case": "mediaMaxMb=1 (control, positive cap still enforced)",
      "agentBody": "[line attachment unavailable]",
      "savedMediaBytes": null,
```

Observed result after fix: the two defect cases resolve to the 10 MB default and the saved
image reaches the agent context; both controls are untouched — in particular the `1` case
still rejects the 1,572,864-byte payload, so the budget was not widened. Every row of the table below
is read from those two captures, not from the tests.

| configured `mediaMaxMb` (MB) | attachment saved | bytes persisted | agent body |
|---|---|---|---|
| `0` | no → **yes** | none → **1572864** | notice → **empty (media attached)** |
| `-5` | no → **yes** | none → **1572864** | notice → **empty (media attached)** |
| unset (control) | yes (unchanged) | 1572864 (unchanged) | unchanged |
| `1` (control) | no (unchanged) | none (unchanged) | notice (unchanged) |

What was not tested: only the inbound download leg is exercised, on both sides — in the
current production wiring that is the only leg that reads this budget (see User Impact).
The capture is one 1,572,864-byte JPEG per case, not a corpus; it generalizes because the rejected comparison is a size check against
a non-positive bound, which no non-empty payload can pass. No live LINE account is
involved: the content endpoint is a loopback fixture, and the harness records the context
the bot built for the agent rather than running an agent, so "the image reaches the agent"
means "the saved media is present in that context".

### Regression tests

`extensions/line/src/bot.test.ts` is new: `extensions/line/src/bot.ts` had no suite that
owned this decision. `extensions/line/src/monitor.lifecycle.test.ts` mocks `createLineBot`
away, and `extensions/line/src/bot-handlers.test.ts` injects `mediaMaxBytes` directly, so
neither can observe how the cap is resolved. It drives the real
`createLineBot`, captures the spool's `deliver` callback, and asserts the `mediaMaxBytes`
the bot hands to the handlers, over `0`, `-5`, unset, a positive value, and both caller
override cases — six in all.

```
node scripts/run-vitest.mjs extensions/line/src/bot.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Reverting only the guard fails exactly the three non-positive rows and leaves the
positive-value controls green, so the assertions have teeth:

```
 × treats a 'zero' mediaMaxMb as unset instead of a 0-byte cap
 × treats a 'negative' mediaMaxMb as unset instead of a 0-byte cap
 × falls through a non-positive caller override to the account config
AssertionError: expected +0 to be 10485760 // Object.is equality
AssertionError: expected -5242880 to be 10485760 // Object.is equality
AssertionError: expected +0 to be 2097152 // Object.is equality
 Test Files  1 failed (1)
      Tests  3 failed | 3 passed (6)
```

The full LINE lane is green on this head:

```
node scripts/run-vitest.mjs extensions/line
 Test Files  34 passed (34)
      Tests  530 passed (530)
```

The before/after harness lives outside the repository, so only the Vitest commands above
are reproducible from a checkout alone.

### Scope and state

- **Root cause:** the media-cap resolver in `createLineBot` used `??`, which keeps `0` and
  negatives because it only replaces `null`/`undefined`.
- **Fix:** one resolver change — widen the existing unset-to-default condition so a
  non-positive value also falls back to the default, at every link of the chain.
  Production diff is one file, +11/-1 lines, of which four are the explanatory comment and
  two are the named constant. No new export, parameter, returned field, persisted state,
  config key, or additional fallback branch.
- **Tests:** one new file, 107 lines, six cases.
- **Non-Scope:** four things are deliberately out of scope here — `.positive()` on the LINE
  config schema; the `LineGroupConfigSchema` fields, which belong to the open PR at
  https://github.com/openclaw/openclaw/pull/103761; anything under `src/media/**`; and
  outbound media, which never reads this budget.
- **Head / proof freshness:** head `d5da1d29087d4202089ef2abf957479f473a337e` on
  upstream/main `be6f4c3d6a8272566c25f04af08907b51f913ffe`. The capture above was taken on
  exactly that pair.
