### PR TITLE
fix(gateway): preserve terminal task run identity

### DIFF
--- a/src/agents/tools/terminal-tool.test.ts
+++ b/src/agents/tools/terminal-tool.test.ts
@@ -168,7 +168,7 @@ describe("terminal tool", () => {
       spawn: async () => backends.shift() ?? makeBackend(),
     });
     const agentSessionKey = "agent:main:shared-task-session";
-    const lookupTaskByRunId = vi.fn(async (runId: string) =>
+    const lookupTaskByRunIdForChildSession = vi.fn(async (runId: string) =>
       runId === "conversation-run"
         ? undefined
         : {
@@ -182,7 +182,7 @@ describe("terminal tool", () => {
         agentId: "main",
         agentSessionKey,
         runId,
-        lookupTaskByRunId,
+        lookupTaskByRunIdForChildSession,
         getGatewayContext: () => makeContext(manager),
       });
 
@@ -190,12 +190,52 @@ describe("terminal tool", () => {
     await createTaskTool("run-2").execute("open", { action: "open", show: false });
     await createTaskTool("conversation-run").execute("open", { action: "open", show: false });
 
-    expect(lookupTaskByRunId.mock.calls).toEqual([["run-1"], ["run-2"], ["conversation-run"]]);
+    expect(lookupTaskByRunIdForChildSession.mock.calls).toEqual([
+      ["run-1", agentSessionKey],
+      ["run-2", agentSessionKey],
+      ["conversation-run", agentSessionKey],
+    ]);
     expect(manager.closeAgentSessions("task-1")).toBe(1);
     expect(firstBackend.killed).toBe(true);
     expect(secondBackend.killed).toBe(false);
     expect(persistentBackend.killed).toBe(false);
     expect(manager.listAgent(agentSessionKey, "main")).toHaveLength(2);
+  });
+
+  it("binds the matching child session when task run ids collide", async () => {
+    const backend = makeBackend();
+    const manager = new TerminalSessionManager({ emit: vi.fn(), spawn: async () => backend });
+    const agentSessionKey = "agent:main:shared-run-task-2";
+    const tasks = [
+      {
+        taskId: "task-1",
+        status: "running" as const,
+        childSessionKey: "agent:main:shared-run-task-1",
+      },
+      {
+        taskId: "task-2",
+        status: "running" as const,
+        childSessionKey: agentSessionKey,
+      },
+    ];
+    const lookupTaskByRunIdForChildSession = vi.fn(
+      async (_runId: string, childSessionKey: string) =>
+        tasks.find((task) => task.childSessionKey === childSessionKey),
+    );
+    const tool = createTerminalTool({
+      agentId: "main",
+      agentSessionKey,
+      runId: "shared-run",
+      lookupTaskByRunIdForChildSession,
+      getGatewayContext: () => makeContext(manager),
+    });
+
+    await tool.execute("open", { action: "open", show: false });
+
+    expect(lookupTaskByRunIdForChildSession).toHaveBeenCalledWith("shared-run", agentSessionKey);
+    expect(manager.closeAgentSessions("task-2")).toBe(1);
+    expect(manager.closeAgentSessions("task-1")).toBe(0);
+    expect(backend.killed).toBe(true);
   });
 
   it("maps a cron agent run to its detached task before terminal lookup", async () => {
@@ -212,7 +252,7 @@ describe("terminal tool", () => {
       throw new Error("expected cron agent run claim");
     }
     expect(bindAgentRunTaskRunId("cron-agent-run", claimId, "detached-task-run")).toBe(true);
-    const lookupTaskByRunId = vi.fn(async () => ({
+    const lookupTaskByRunIdForChildSession = vi.fn(async () => ({
       taskId: "cron-task",
       status: "running" as const,
       childSessionKey: agentSessionKey,
@@ -221,14 +261,17 @@ describe("terminal tool", () => {
       agentId: "main",
       agentSessionKey,
       runId: "cron-agent-run",
-      lookupTaskByRunId,
+      lookupTaskByRunIdForChildSession,
       getGatewayContext: () => makeContext(manager),
     });
 
     try {
       await tool.execute("open", { action: "open", show: false });
 
-      expect(lookupTaskByRunId).toHaveBeenCalledWith("detached-task-run");
+      expect(lookupTaskByRunIdForChildSession).toHaveBeenCalledWith(
+        "detached-task-run",
+        agentSessionKey,
+      );
       expect(manager.closeAgentSessions("cron-task")).toBe(1);
       expect(backend.killed).toBe(true);
     } finally {
@@ -246,7 +289,7 @@ describe("terminal tool", () => {
       agentId: "main",
       agentSessionKey: "agent:main:completed-task",
       runId: "completed-run",
-      lookupTaskByRunId: vi.fn(async () => ({
+      lookupTaskByRunIdForChildSession: vi.fn(async () => ({
         taskId: "task-completed",
         status: "succeeded" as const,
         childSessionKey: "agent:main:completed-task",

--- a/src/agents/tools/terminal-tool.ts
+++ b/src/agents/tools/terminal-tool.ts
@@ -82,18 +82,21 @@ type TerminalToolOptions = {
   agentId?: string;
   agentSessionKey?: string;
   runId?: string;
-  lookupTaskByRunId?: (
+  lookupTaskByRunIdForChildSession?: (
     runId: string,
+    childSessionKey: string,
   ) => Promise<Pick<TaskRecord, "taskId" | "status" | "childSessionKey"> | undefined>;
   callGateway?: InProcessGatewayCaller;
   getGatewayContext?: () => TerminalToolGatewayContext | undefined;
 };
 
-async function lookupTaskByRunId(
+async function lookupTaskByRunIdForChildSession(
   runId: string,
+  childSessionKey: string,
 ): Promise<Pick<TaskRecord, "taskId" | "status" | "childSessionKey"> | undefined> {
-  const { findTaskByRunIdForStatus } = await import("../../tasks/task-status-access.js");
-  return findTaskByRunIdForStatus(runId);
+  const { findTaskByRunIdForChildSessionForStatus } =
+    await import("../../tasks/task-status-access.js");
+  return findTaskByRunIdForChildSessionForStatus(runId, childSessionKey);
 }
 
 function readDimension(
@@ -161,7 +164,7 @@ function launchBlockMessage(
 export function createTerminalTool(opts: TerminalToolOptions = {}): AnyAgentTool {
   const gatewayCall = opts.callGateway ?? callInProcessGatewayTool;
   const getContext = opts.getGatewayContext ?? getInProcessGatewayToolContext;
-  const findOwnerTask = opts.lookupTaskByRunId ?? lookupTaskByRunId;
+  const findOwnerTask = opts.lookupTaskByRunIdForChildSession ?? lookupTaskByRunIdForChildSession;
   return {
     label: "Terminal",
     name: "terminal",
@@ -206,9 +209,7 @@ export function createTerminalTool(opts: TerminalToolOptions = {}): AnyAgentTool
         });
         const runId = opts.runId?.trim();
         const taskLookupId = runId ? (getAgentRunTaskRunId(runId) ?? runId) : undefined;
-        const candidateTask = taskLookupId ? await findOwnerTask(taskLookupId) : undefined;
-        const task =
-          candidateTask?.childSessionKey?.trim() === agentSessionKey ? candidateTask : undefined;
+        const task = taskLookupId ? await findOwnerTask(taskLookupId, agentSessionKey) : undefined;
         if (task && isTerminalTaskStatus(task.status)) {
           throw new ToolInputError("terminal task already ended");
         }

--- a/src/gateway/tool-resolution.terminal.test.ts
+++ b/src/gateway/tool-resolution.terminal.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { GatewayRequestContext } from "./server-methods/types.js";
+import { setFallbackGatewayContext } from "./server-plugin-fallback-context.js";
+import { TerminalSessionManager } from "./terminal/session-manager.js";
+import { makeFakePty } from "./terminal/session-manager.test-helpers.js";
+import { resolveGatewayScopedTools } from "./tool-resolution.js";
+
+type TaskLookupRecord = {
+  taskId: string;
+  runId: string;
+  childSessionKey: string;
+  status: "running";
+};
+
+const taskStatusMocks = vi.hoisted(() => ({
+  findTaskByRunIdForChildSessionForStatus: vi.fn(
+    (_runId: string, _childSessionKey: string): TaskLookupRecord | undefined => undefined,
+  ),
+  findTaskByRunIdForStatus: vi.fn((_runId: string): TaskLookupRecord | undefined => undefined),
+}));
+
+vi.mock("../tasks/task-status-access.js", () => taskStatusMocks);
+
+describe("resolveGatewayScopedTools terminal ownership", () => {
+  it("binds a loopback terminal to the matching child when run ids collide", async () => {
+    const backend = makeFakePty();
+    const manager = new TerminalSessionManager({ emit: vi.fn(), spawn: async () => backend });
+    const childSessionKey = "agent:main:loopback-task-2";
+    const tasks: TaskLookupRecord[] = [
+      {
+        taskId: "task-1",
+        runId: "shared-run",
+        childSessionKey: "agent:main:loopback-task-1",
+        status: "running",
+      },
+      { taskId: "task-2", runId: "shared-run", childSessionKey, status: "running" },
+    ];
+    taskStatusMocks.findTaskByRunIdForChildSessionForStatus.mockImplementation(
+      (runId, sessionKey) =>
+        tasks.find((task) => task.runId === runId && task.childSessionKey === sessionKey),
+    );
+    const clearContext = setFallbackGatewayContext({
+      terminalSessions: manager,
+      isTerminalEnabled: () => true,
+      resolveTerminalLaunchPolicy: () => ({
+        ok: true,
+        plan: { agentId: "main", cwd: "/tmp", shell: "/bin/sh", args: [] },
+      }),
+    } as unknown as GatewayRequestContext);
+
+    try {
+      const result = resolveGatewayScopedTools({
+        cfg: { tools: { allow: ["terminal"] } } as OpenClawConfig,
+        sessionKey: childSessionKey,
+        runId: "shared-run",
+        senderIsOwner: true,
+        surface: "loopback",
+      });
+      const terminal = result.tools.find((tool) => tool.name === "terminal");
+      if (!terminal?.execute) {
+        throw new Error("expected loopback terminal tool");
+      }
+
+      await terminal.execute("terminal-open", { action: "open", show: false });
+
+      expect(taskStatusMocks.findTaskByRunIdForChildSessionForStatus).toHaveBeenCalledWith(
+        "shared-run",
+        childSessionKey,
+      );
+      expect(manager.closeAgentSessions("task-2")).toBe(1);
+      expect(manager.closeAgentSessions("task-1")).toBe(0);
+      expect(backend.killed).toBe(true);
+    } finally {
+      clearContext();
+      manager.disposeAll();
+      taskStatusMocks.findTaskByRunIdForChildSessionForStatus.mockReset();
+      taskStatusMocks.findTaskByRunIdForStatus.mockReset();
+    }
+  });
+});

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -272,6 +272,7 @@ export function resolveGatewayScopedTools(params: {
 
   const openClawTools = createOpenClawTools({
     agentSessionKey: params.sessionKey,
+    runId: params.runId,
     requesterAgentIdOverride: sessionAgentId,
     agentChannel: params.messageProvider ?? undefined,
     agentAccountId: params.accountId,

--- a/src/tasks/task-status-access.ts
+++ b/src/tasks/task-status-access.ts
@@ -5,6 +5,7 @@ import {
   listActiveGeneratedMediaTaskIdsForSessionKey,
 } from "./generated-media-task-activity.js";
 import { isTerminalTaskStatus } from "./task-executor-policy.js";
+import { getTasksByRunScope, pickPreferredRunIdTask } from "./task-registry-state.js";
 // Filters task status visibility by requester, owner, and flow scope.
 import {
   findTaskByRunId,
@@ -56,6 +57,30 @@ export function listTasksForAgentIdForStatus(agentId: string): TaskRecord[] {
 
 export function findTaskByRunIdForStatus(runId: string): TaskRecord | undefined {
   return findTaskByRunId(runId);
+}
+
+export function findTaskByRunIdForChildSessionForStatus(
+  runId: string,
+  childSessionKey: string,
+): Pick<TaskRecord, "taskId" | "status" | "childSessionKey"> | undefined {
+  const normalizedChildSessionKey = childSessionKey.trim();
+  if (!normalizedChildSessionKey) {
+    return undefined;
+  }
+  // A run id can span multiple task scopes. Terminal ownership must stay on
+  // the exact child session instead of adopting the registry's global preference.
+  const task = pickPreferredRunIdTask(
+    getTasksByRunScope({ runId, sessionKey: normalizedChildSessionKey }).filter(
+      (candidate) => candidate.childSessionKey?.trim() === normalizedChildSessionKey,
+    ),
+  );
+  return task
+    ? {
+        taskId: task.taskId,
+        status: task.status,
+        childSessionKey: task.childSessionKey,
+      }
+    : undefined;
 }
 
 /** Snapshots generated-media task ids so replay guards stay attempt-local. */


### PR DESCRIPTION
Related: #121070

## What Problem This Solves

Fixes an issue where a terminal opened through the Gateway MCP loopback could survive its task's completion when another child session had a task with the same run ID.

Gateway tool resolution dropped the prepared run ID. Forwarding it exposed a second issue: terminal ownership used the registry's global preferred run-ID match, then discarded a mismatched child session without searching the correct scope.

## Why This Change Was Made

The Gateway now forwards its existing prepared `runId`. Terminal ownership resolves the task through the canonical task-registry scope `{ runId, childSessionKey }`, then records the exact private task ID used by lifecycle cleanup.

This is the complete owner-boundary repair. It adds no config, protocol, SDK, migration, persistence, identity, fallback, or cache surface. The detached-task runtime retains its existing global lookup because it has a different ownership contract.

This change was developed with AI assistance and rewritten by a maintainer after ClawSweeper found the cross-child collision.

## User Impact

Completing one Gateway/loopback task now closes that task's PTY even when another child session reuses the same run ID. The sibling task's terminal remains live and writable.

## Evidence

- **Red/green collision regression:** before the rewrite, the terminal lookup received only `shared-run`; the new duplicate-run-ID test failed because the child session was absent. After the rewrite, both terminal and Gateway regressions pass and assert lookup by `("shared-run", childSessionKey)`.
- **Focused tests:** 86 assertions passed across `terminal-tool`, Gateway resolver/exclusion, terminal session lifecycle, runtime subscriptions, task status access, and the two registry cross-scope collision cases.
- **Changed gate:** Blacksmith Testbox `tbx_01kzwqhv8vfftahjzk8tj8thq4`, run https://github.com/openclaw/openclaw/actions/runs/31668517679, completed with exit 0. Core production/test typechecks, changed-file lint/format, import-cycle, dead-code, database-first, SDK, and repository guards passed.
- **Autoreview:** `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --engine codex --model gpt-5.6-sol --thinking high --stream-engine-output` reported no accepted/actionable findings; overall correctness 0.98.
- **Static:** `git diff --check` passed.

### Exact-head MCP-to-real-PTY collision proof

Exact commit: `ae68f2d4e2f8b659af6c7754aa74eed1fced3246`

The transient harness traversed real loopback HTTP `/mcp` -> bound shared-run grant -> production Gateway resolver -> production terminal tool -> real `@lydell/node-pty` -> production task-registry observer cleanup.

It deliberately created two tasks with the same run ID in different child sessions. Task 1 was the registry's global preferred match, so the pre-rewrite lookup would leave task 2's terminal unbound. On the rewritten head, terminalizing task 2 reduced live PTYs from two to one; task 1 stayed writable and emitted output after cleanup.

Harness SHA-256: `fc8842e6788a2ee81a9f148f1eb218395927f2917ad05e46a2231fc14aad03d6`

Verdict SHA-256: `49aafa97112e9d068de81f70fee9697342318ff8e56b9b3c761bebc8c74bc752`

```json
{
  "schemaVersion": 1,
  "verdict": "pass",
  "targetSha": "ae68f2d4e2f8b659af6c7754aa74eed1fced3246",
  "boundary": [
    "real-loopback-http-/mcp",
    "bound-runId-grant",
    "production-gateway-tool-resolver",
    "production-terminal-tool",
    "real-node-pty",
    "production-task-registry-observer-cleanup"
  ],
  "assertions": {
    "exactGrantPublishedOnlyTerminal": true,
    "duplicateRunIdAcrossChildSessions": true,
    "globalPreferredTaskBelongsToOtherChild": true,
    "distinctRealPtyProcesses": true,
    "completedTaskTerminalClosed": true,
    "siblingTerminalRemainedWritable": true,
    "siblingOutputObservedAfterCleanup": true
  },
  "observations": {
    "httpStatus": 200,
    "taskCount": 2,
    "ptyProcessCount": 2,
    "sessionCountBeforeCleanup": 2,
    "sessionCountAfterCleanup": 1,
    "capturedTerminalCalls": 7,
    "emittedTerminalEvents": 0
  },
  "redaction": {
    "bearerTokensIncluded": false,
    "filesystemPathsIncluded": false,
    "terminalOutputIncluded": false
  }
}
```

The earlier Linux public proof remains available at https://github.com/Alix-007/openclaw/actions/runs/31376607923 and establishes the same production MCP-to-PTY boundary on the contributor branch before the collision rewrite.

### Dependency contract

Direct sibling Codex inspection on commit `414782450952a196bbb64b1605a458c2531c47b6`:

- `codex-rs/core/src/session/mcp.rs:292-303` forwards server, tool, arguments, and request metadata into the MCP manager.
- `codex-rs/core/src/mcp_tool_call.rs:576-607` adds Codex thread/sandbox/trace metadata, but carries no OpenClaw task-row identity.
- `codex-rs/core/src/session/mod.rs:3267-3276` shows the same MCP call contract.

Therefore OpenClaw must preserve the prepared run ID at tool construction and resolve its own exact child-session task scope.

### Scope

- Production: **+35/-8**
- Tests: **+131/-7**
- Config/default surfaces: **0**

The positive production delta is the canonical scoped status projection needed to enforce the task-ownership boundary. No changelog entry is included because contributor PRs leave changelog updates to the landing workflow.

Punchcard-Session: calm-workshop-cedar-hx
