### PR TITLE
feat(memory): supplement thin strict recall with bounded lexical expansion

### DIFF
--- a/docs/concepts/memory-builtin.md
+++ b/docs/concepts/memory-builtin.md
@@ -121,8 +121,8 @@ The builtin engine is the right choice for most users:
 - Hybrid search combines the best of both retrieval approaches.
 
 The builtin engine can index directories outside the workspace with
-`memory.search.extraPaths`, but it does not provide query expansion or a
-separate reranking stage.
+`memory.search.extraPaths`. It uses bounded lexical query expansion to improve
+conversational recall, but it does not provide a separate reranking stage.
 
 Consider [Honcho](/concepts/memory-honcho) if you want cross-session memory
 with automatic user modeling.

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2973,6 +2973,49 @@ describe("memory index", () => {
     );
   });
 
+  it("supplements thin strict FTS results for conversational queries", async () => {
+    const cases = [
+      {
+        query: "that thing we discussed about the API",
+        strictFile: "strict-english.md",
+        strictText: "That thing we discussed about the API belongs in the first draft.",
+        recallFile: "recall-english.md",
+        recallText: "API authentication uses short-lived OAuth tokens.",
+      },
+      {
+        query: "ayer hablamos sobre estrategia de despliegue",
+        strictFile: "strict-spanish.md",
+        strictText: "Ayer hablamos sobre estrategia de despliegue para la primera region.",
+        recallFile: "recall-spanish.md",
+        recallText: "La estrategia de despliegue requiere una ventana de mantenimiento.",
+      },
+    ] as const;
+    for (const entry of cases) {
+      await fs.writeFile(path.join(memoryDir, entry.strictFile), entry.strictText);
+      await fs.writeFile(path.join(memoryDir, entry.recallFile), entry.recallText);
+    }
+
+    const manager = await getPersistentManager(
+      createCfg({
+        minScore: 0,
+        hybrid: { enabled: true, vectorWeight: 0.7, textWeight: 0.3 },
+      }),
+    );
+    await manager.sync({ reason: "test" });
+    const provider = Reflect.get(manager, "provider") as {
+      embedQuery: (text: string) => Promise<number[]>;
+    };
+    const embedQuerySpy = vi.spyOn(provider, "embedQuery");
+
+    for (const entry of cases) {
+      const results = await manager.search(entry.query, { maxResults: 6 });
+      expect(results.some((result) => result.path.endsWith(`memory/${entry.recallFile}`))).toBe(
+        true,
+      );
+    }
+    expect(embedQuerySpy).toHaveBeenCalledTimes(cases.length);
+  });
+
   it("bounds per-keyword FTS fallback in provider-backed hybrid search", async () => {
     const cfg = createCfg({
       minScore: 0.35,

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -654,6 +654,7 @@ export async function searchKeyword(params: {
   buildFtsQuery: (raw: string) => string | null;
   bm25RankToScore: (rank: number) => number;
   boostFallbackRanking?: boolean;
+  rankingQuery?: string;
 }): Promise<Array<SearchRowResult & { textScore: number }>> {
   if (params.limit <= 0) {
     return [];
@@ -738,7 +739,7 @@ export async function searchKeyword(params: {
     const textScore = usedMatch ? params.bm25RankToScore(row.rank) : 1;
     const score = params.boostFallbackRanking
       ? scoreFallbackKeywordResult({
-          query: params.query,
+          query: params.rankingQuery ?? params.query,
           path: row.path,
           text: row.text,
           ftsScore: textScore,

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1655,7 +1655,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private async searchKeyword(
     query: string,
     limit: number,
-    options?: { boostFallbackRanking?: boolean; exactPathQuery?: string },
+    options?: {
+      boostFallbackRanking?: boolean;
+      exactPathQuery?: string;
+      rankingQuery?: string;
+    },
     sourceFilterList?: MemorySource[],
   ): Promise<KeywordSearchHit[]> {
     if (!this.fts.enabled || !this.fts.available) {
@@ -1672,6 +1676,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       buildFtsQuery: (raw) => this.buildFtsQuery(raw),
       bm25RankToScore,
       boostFallbackRanking: options?.boostFallbackRanking,
+      rankingQuery: options?.rankingQuery,
     }).catch((err: unknown) => {
       log.warn(`memory search: body keyword query failed: ${formatErrorMessage(err)}`);
       return [];
@@ -1721,16 +1726,23 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       options,
       sourceFilterList,
     ).catch(() => []);
-    if (fullQueryResults.length > 0) {
+    const nonExactResults = fullQueryResults.filter((result) => result.exactPathSpecificity === 0);
+    if (nonExactResults.length >= limit) {
       return fullQueryResults;
     }
 
-    // Broaden recall for conversational queries when the exact AND query is too
-    // strict, but cap the number of extra FTS probes so long prompts cannot fan
-    // out into unbounded sqlite work.
+    // Supplement thin candidate pools for conversational queries, but cap the
+    // extra FTS probes so long prompts cannot fan out into unbounded sqlite work.
     const fallbackTerms = this.resolveKeywordFallbackTerms(query);
     if (fallbackTerms.length === 0) {
-      return [];
+      return fullQueryResults;
+    }
+    const strictFtsQuery = this.buildFtsQuery(query)?.toLowerCase();
+    const keywordFtsQuery = this.buildFtsQuery(fallbackTerms.join(" "))?.toLowerCase();
+    if (fullQueryResults.length > 0 && strictFtsQuery === keywordFtsQuery) {
+      // Expansion did not normalize this already-matching keyword query; OR
+      // probes can only weaken its strict relevance before importance ranking.
+      return fullQueryResults;
     }
 
     const resultSets = await Promise.all(
@@ -1738,18 +1750,22 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         this.searchKeyword(
           term,
           limit,
-          { ...options, exactPathQuery: query },
+          { ...options, exactPathQuery: query, rankingQuery: query },
           sourceFilterList,
         ).catch(() => []),
       ),
     );
-    return this.limitKeywordSearchHits(this.mergeKeywordSearchHits(resultSets, query), limit);
+    return this.limitKeywordSearchHits(
+      this.mergeKeywordSearchHits([fullQueryResults, ...resultSets], query),
+      limit,
+    );
   }
 
   private resolveKeywordFallbackTerms(query: string): string[] {
+    const normalizedQuery = query.trim().toLowerCase();
     const keywords = extractKeywords(query, {
       ftsTokenizer: this.settings.store.fts.tokenizer,
-    }).filter((term) => term !== query);
+    }).filter((term) => term !== normalizedQuery);
     return keywords.slice(0, KEYWORD_FALLBACK_SEARCH_TERM_LIMIT);
   }
 

--- a/packages/memory-host-sdk/src/host/query-expansion.ts
+++ b/packages/memory-host-sdk/src/host/query-expansion.ts
@@ -2,11 +2,11 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
 /**
- * Query expansion for FTS-only search mode.
+ * Query expansion for lexical FTS search.
  *
- * When no embedding provider is available, we fall back to FTS (full-text search).
  * FTS works best with specific keywords, but users often ask conversational queries
- * like "that thing we discussed yesterday" or "之前讨论的那个方案".
+ * like "that thing we discussed yesterday" or "之前讨论的那个方案". This helps both
+ * hybrid retrieval and FTS-only fallback mode find those keywords.
  *
  * This module extracts meaningful keywords from such queries to improve FTS results.
  */


### PR DESCRIPTION
## What Problem This Solves

Builtin memory's strict AND FTS query only fell back to keyword expansion when it returned ZERO hits — a natural-language query yielding one weak strict hit got no supplementation, hurting recall for conversational queries. With QMD removed (#120936), builtin's default-path recall quality is the product.

## Why This Change Was Made

Thin strict pools (below the candidate target) now receive bounded lexical supplementation via the existing `extractKeywords` machinery; strict hits are retained and merged by id; exactly one embedding call as before; no new config keys, no new dependencies, no added provider calls (expansion is lexical).

## User Impact

Better recall on natural-language memory queries on the default path.

## Evidence

Memory-core 1,063 tests; host SDK 709; changed gate; codex autoreview clean (0.98). Production net +17, tests +43. Part of the post-QMD builtin upgrade series (with extraPaths globs and MMR-default following).
