### PR TITLE
feat(android): support android 9 devices

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -611,7 +611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 216,
+      "line": 232,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt",
       "source": "Too many shares are waiting to be added.",
       "surface": "android",
@@ -619,7 +619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 383,
+      "line": 399,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt",
       "source": "OPENCLAW",
       "surface": "android",
@@ -651,7 +651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 48,
+      "line": 49,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "Starting…",
       "surface": "android",
@@ -659,7 +659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 135,
+      "line": 136,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "OpenClaw Node · Talk",
       "surface": "android",
@@ -667,7 +667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 136,
+      "line": 137,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "OpenClaw Node · Connected",
       "surface": "android",
@@ -675,7 +675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 141,
+      "line": 142,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "$status · $server",
       "surface": "android",
@@ -683,7 +683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 194,
+      "line": 195,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "OpenClaw Node",
       "surface": "android",
@@ -691,7 +691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 197,
+      "line": 198,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "Talk mode active",
       "surface": "android",
@@ -699,7 +699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 199,
+      "line": 200,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "Connected",
       "surface": "android",
@@ -707,7 +707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 230,
+      "line": 231,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "Connection",
       "surface": "android",
@@ -715,7 +715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 233,
+      "line": 234,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "OpenClaw node connection status",
       "surface": "android",
@@ -723,7 +723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 264,
+      "line": 265,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "Disconnect",
       "surface": "android",
@@ -731,7 +731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 389,
+      "line": 395,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": " · Location: Always",
       "surface": "android",
@@ -739,7 +739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 404,
+      "line": 410,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": " · Talk: Speaking",
       "surface": "android",
@@ -747,7 +747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 405,
+      "line": 411,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": " · Talk: Listening",
       "surface": "android",
@@ -755,7 +755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 406,
+      "line": 412,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": " · Talk: On",
       "surface": "android",
@@ -763,7 +763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 411,
+      "line": 417,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": " · Mic: Listening",
       "surface": "android",
@@ -771,7 +771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 413,
+      "line": 419,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": " · Mic: Pending",
       "surface": "android",
@@ -947,7 +947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2393,
+      "line": 2396,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation already has a queued run.",
       "surface": "android",
@@ -955,7 +955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2423,
+      "line": 2426,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation run queued.",
       "surface": "android",
@@ -963,7 +963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2423,
+      "line": 2426,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation started.",
       "surface": "android",
@@ -971,7 +971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2436,
+      "line": 2439,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway rejected the automation run.",
       "surface": "android",
@@ -979,7 +979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2467,
+      "line": 2470,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation enabled.",
       "surface": "android",
@@ -987,7 +987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2467,
+      "line": 2470,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation paused.",
       "surface": "android",
@@ -995,7 +995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2489,
+      "line": 2492,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation changed on the gateway. Review the latest version before saving again.",
       "surface": "android",
@@ -1003,7 +1003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2495,
+      "line": 2498,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation updated.",
       "surface": "android",
@@ -1011,7 +1011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2510,
+      "line": 2513,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation deleted.",
       "surface": "android",
@@ -1019,7 +1019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2725,
+      "line": 2728,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Node offline. Reconnect and retry.",
       "surface": "android",
@@ -1027,7 +1027,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 2736,
+      "line": 2739,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Restore canvas now for session=$sessionKey source=$source. If existing A2UI state exists, replay it immediately. If not, create and render a compact mobile-friendly dashboard in Canvas.",
       "surface": "android",
@@ -1035,7 +1035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2757,
+      "line": 2760,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed to request restore. Tap to retry.",
       "surface": "android",
@@ -1043,7 +1043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2768,
+      "line": 2771,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No canvas update yet. Tap to retry.",
       "surface": "android",
@@ -1051,7 +1051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3875,
+      "line": 3878,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -1059,7 +1059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3903,
+      "line": 3906,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Wake words saved",
       "surface": "android",
@@ -1067,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3912,
+      "line": 3915,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not save wake words",
       "surface": "android",
@@ -1075,7 +1075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4625,
+      "line": 4628,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -1083,7 +1083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4629,
+      "line": 4632,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -1091,7 +1091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4633,
+      "line": 4636,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -1099,7 +1099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4683,
+      "line": 4686,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -1107,7 +1107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4887,
+      "line": 4890,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -1115,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5741,
+      "line": 5744,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider catalog.",
       "surface": "android",
@@ -1123,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5772,
+      "line": 5775,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -1131,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5774,
+      "line": 5777,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",
@@ -1139,7 +1139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5790,
+      "line": 5793,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Provider models loaded, but readiness is unavailable.",
       "surface": "android",
@@ -1147,7 +1147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5877,
+      "line": 5880,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automations.",
       "surface": "android",
@@ -1155,7 +1155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5963,
+      "line": 5966,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -1163,7 +1163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5973,
+      "line": 5976,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned an invalid automation.",
       "surface": "android",
@@ -1171,7 +1171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5977,
+      "line": 5980,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation.",
       "surface": "android",
@@ -1179,7 +1179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5989,
+      "line": 5992,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automation run history.",
       "surface": "android",
@@ -1187,7 +1187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6020,
+      "line": 6023,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation run history.",
       "surface": "android",
@@ -1195,7 +1195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6037,
+      "line": 6040,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron changes require operator.admin access.",
       "surface": "android",
@@ -1203,7 +1203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6046,
+      "line": 6049,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to manage automations.",
       "surface": "android",
@@ -1211,7 +1211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6058,
+      "line": 6061,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Another cron action is still finishing.",
       "surface": "android",
@@ -1219,7 +1219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6105,
+      "line": 6108,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron action failed.",
       "surface": "android",
@@ -1227,7 +1227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6217,
+      "line": 6220,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load usage.",
       "surface": "android",
@@ -1235,7 +1235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6232,
+      "line": 6235,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load skills.",
       "surface": "android",
@@ -1243,7 +1243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6252,
+      "line": 6255,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update skills.",
       "surface": "android",
@@ -1251,7 +1251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6256,
+      "line": 6259,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to update skills.",
       "surface": "android",
@@ -1259,7 +1259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6271,
+      "line": 6274,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not disable skill.",
       "surface": "android",
@@ -1267,7 +1267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6271,
+      "line": 6274,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not enable skill.",
       "surface": "android",
@@ -1275,7 +1275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6289,
+      "line": 6292,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to search ClawHub skills.",
       "surface": "android",
@@ -1283,7 +1283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6335,
+      "line": 6338,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not search ClawHub skills.",
       "surface": "android",
@@ -1291,7 +1291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6348,
+      "line": 6351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect ClawHub skills.",
       "surface": "android",
@@ -1299,7 +1299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6381,
+      "line": 6384,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "ClawHub did not return an installable version for ${skill.slug}.",
       "surface": "android",
@@ -1307,7 +1307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6397,
+      "line": 6400,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load ClawHub details for ${skill.slug}.",
       "surface": "android",
@@ -1315,7 +1315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6413,
+      "line": 6416,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to install ClawHub skills.",
       "surface": "android",
@@ -1323,7 +1323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6429,
+      "line": 6432,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to install ClawHub skills.",
       "surface": "android",
@@ -1331,7 +1331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6519,
+      "line": 6522,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Installed $slug.",
       "surface": "android",
@@ -1339,7 +1339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6526,
+      "line": 6529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not install ${slug} from ClawHub.",
       "surface": "android",
@@ -1347,7 +1347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6566,
+      "line": 6569,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to load Skill Workshop proposals.",
       "surface": "android",
@@ -1355,7 +1355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6606,
+      "line": 6609,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load Skill Workshop proposals.",
       "surface": "android",
@@ -1363,7 +1363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6626,
+      "line": 6629,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect Skill Workshop proposals.",
       "surface": "android",
@@ -1371,7 +1371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6678,
+      "line": 6681,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not inspect Skill Workshop proposal.",
       "surface": "android",
@@ -1379,7 +1379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6698,
+      "line": 6701,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Skill Workshop proposal actions require operator.admin scope.",
       "surface": "android",
@@ -1387,7 +1387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6703,
+      "line": 6706,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update Skill Workshop proposals.",
       "surface": "android",
@@ -1395,7 +1395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6893,
+      "line": 6896,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not verify the device pairing change. Refresh and try again.",
       "surface": "android",
@@ -1403,7 +1403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 6975,
+      "line": 6978,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected",
       "surface": "android",
@@ -1411,7 +1411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7005,
+      "line": 7008,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load nodes and devices.",
       "surface": "android",
@@ -1419,7 +1419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7655,
+      "line": 7658,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load channels.",
       "surface": "android",
@@ -1427,7 +1427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7673,
+      "line": 7676,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load dreaming.",
       "surface": "android",
@@ -1435,7 +1435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7688,
+      "line": 7691,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load gateway logs.",
       "surface": "android",
@@ -1443,7 +1443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8171,
+      "line": 8174,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "One time",
       "surface": "android",
@@ -1451,7 +1451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8180,
+      "line": 8183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron",
       "surface": "android",
@@ -1459,7 +1459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8181,
+      "line": 8184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Scheduled",
       "surface": "android",
@@ -1467,7 +1467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8189,
+      "line": 8192,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${days}d",
       "surface": "android",
@@ -1475,7 +1475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8190,
+      "line": 8193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${hours}h",
       "surface": "android",
@@ -1483,7 +1483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8191,
+      "line": 8194,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${minutes}m",
       "surface": "android",
@@ -1491,7 +1491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8192,
+      "line": 8195,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Repeating",
       "surface": "android",
@@ -1499,7 +1499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8208,
+      "line": 8211,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No prompt",
       "surface": "android",
@@ -1507,7 +1507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8225,
+      "line": 8228,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway",
       "surface": "android",
@@ -1515,7 +1515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8233,
+      "line": 8236,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected to $gatewayLabel",
       "surface": "android",
@@ -1523,7 +1523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8234,
+      "line": 8237,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your agents are ready",
       "surface": "android",
@@ -1531,7 +1531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8236,
+      "line": 8239,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This phone stays dormant until the gateway needs it, then wakes, syncs, and goes back to sleep.",
       "surface": "android",
@@ -1539,7 +1539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8240,
+      "line": 8243,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Selected on this phone",
       "surface": "android",
@@ -1547,7 +1547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8243,
+      "line": 8246,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The overview refreshes on reconnect and when this screen opens.",
       "surface": "android",
@@ -1555,7 +1555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8248,
+      "line": 8251,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting",
       "surface": "android",
@@ -1563,7 +1563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8249,
+      "line": 8252,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "OpenClaw is syncing back up",
       "surface": "android",
@@ -1571,7 +1571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8251,
+      "line": 8254,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The gateway session is coming back online. Agent shortcuts should settle automatically in a moment.",
       "surface": "android",
@@ -1579,7 +1579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8255,
+      "line": 8258,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway session in progress",
       "surface": "android",
@@ -1587,7 +1587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8258,
+      "line": 8261,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "If the gateway is reachable, reconnect should complete without intervention.",
       "surface": "android",
@@ -1595,7 +1595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8263,
+      "line": 8266,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1603,7 +1603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8264,
+      "line": 8267,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your phone stays quiet until it is needed",
       "surface": "android",
@@ -1611,7 +1611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8266,
+      "line": 8269,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pair this device to your gateway to wake it only for real work, keep a live agent overview handy, and avoid battery-draining background loops.",
       "surface": "android",
@@ -1619,7 +1619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8270,
+      "line": 8273,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to load your agents",
       "surface": "android",
@@ -1627,7 +1627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8273,
+      "line": 8276,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session.",
       "surface": "android",
@@ -1635,7 +1635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8305,
+      "line": 8308,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Main",
       "surface": "android",
@@ -1643,7 +1643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8320,
+      "line": 8323,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Active on this phone",
       "surface": "android",
@@ -1651,7 +1651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8321,
+      "line": 8324,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Default agent",
       "surface": "android",
@@ -1659,7 +1659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8322,
+      "line": 8325,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Ready",
       "surface": "android",
@@ -1667,7 +1667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8977,
+      "line": 8980,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Dream",
       "surface": "android",
@@ -1955,7 +1955,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 106,
+      "line": 89,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt",
       "source": "Searching…",
       "surface": "android",
@@ -4507,7 +4507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 272,
+      "line": 274,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Enter the setup code from openclaw qr.",
       "surface": "android",
@@ -4515,7 +4515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 273,
+      "line": 275,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code was not accepted. Generate a fresh code with openclaw qr.",
       "surface": "android",
@@ -4523,7 +4523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 275,
+      "line": 277,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "That QR code is not an OpenClaw setup QR. Generate a fresh code with openclaw qr, then try again.",
       "surface": "android",
@@ -4531,7 +4531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 277,
+      "line": 279,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "That looks like a setup code. Go back and choose Setup Gateway, then Use setup code.",
       "surface": "android",
@@ -4539,7 +4539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 279,
+      "line": 281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not read that image. Choose a clear screenshot or image of the QR from openclaw qr.",
       "surface": "android",
@@ -4547,7 +4547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 281,
+      "line": 283,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "No setup QR code was found in that image. Choose the QR generated by openclaw qr, or enter the setup code manually.",
       "surface": "android",
@@ -4555,7 +4555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 283,
+      "line": 285,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not read a QR code from that image. Choose a clearer image or enter the setup code manually.",
       "surface": "android",
@@ -4563,7 +4563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 285,
+      "line": 287,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not start the camera. Choose a QR image from gallery or enter the setup code manually.",
       "surface": "android",
@@ -4571,7 +4571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 832,
+      "line": 834,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The gateway certificate could not be read automatically. Paste the SHA-256 fingerprint obtained on the gateway host.",
       "surface": "android",
@@ -4579,7 +4579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 852,
+      "line": 854,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "This gateway now presents a certificate trusted by this device.",
       "surface": "android",
@@ -4587,7 +4587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 862,
+      "line": 864,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "SHA-256 fingerprint",
       "surface": "android",
@@ -4595,7 +4595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 875,
+      "line": 877,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Trust",
       "surface": "android",
@@ -4603,7 +4603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 882,
+      "line": 884,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use system trust",
       "surface": "android",
@@ -4611,7 +4611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 886,
+      "line": 888,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Cancel",
       "surface": "android",
@@ -4619,7 +4619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1087,
+      "line": 1089,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -4627,7 +4627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1088,
+      "line": 1090,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Turn this device into a secure OpenClaw node for chat, voice, camera, and device tools.",
       "surface": "android",
@@ -4635,7 +4635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1120,
+      "line": 1122,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OpenClaw logo",
       "surface": "android",
@@ -4643,7 +4643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1179,
+      "line": 1181,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect to your Gateway",
       "surface": "android",
@@ -4651,7 +4651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1180,
+      "line": 1182,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose device permissions",
       "surface": "android",
@@ -4659,7 +4659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1181,
+      "line": 1183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use OpenClaw from your phone",
       "surface": "android",
@@ -4667,7 +4667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1203,
+      "line": 1205,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Security notice",
       "surface": "android",
@@ -4675,7 +4675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1205,
+      "line": 1207,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The connected OpenClaw agent can use device capabilities you enable. Continue only if you trust the Gateway and agent you connect to.",
       "surface": "android",
@@ -4683,7 +4683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1250,
+      "line": 1252,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect Gateway",
       "surface": "android",
@@ -4691,7 +4691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1251,
+      "line": 1253,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan a QR code or use the setup code from your OpenClaw Gateway.",
       "surface": "android",
@@ -4699,7 +4699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1260,
+      "line": 1262,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not open setup guide.",
       "surface": "android",
@@ -4707,7 +4707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1268,
+      "line": 1270,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan QR or setup code",
       "surface": "android",
@@ -4715,7 +4715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1274,
+      "line": 1276,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Set up manually",
       "surface": "android",
@@ -4723,7 +4723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1296,
+      "line": 1298,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Before you start",
       "surface": "android",
@@ -4731,7 +4731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1302,
+      "line": 1304,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Access to the Gateway device",
       "surface": "android",
@@ -4739,7 +4739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1303,
+      "line": 1305,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Have a terminal open on the device running OpenClaw.",
       "surface": "android",
@@ -4747,7 +4747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1306,
+      "line": 1308,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Phone can reach the Gateway",
       "surface": "android",
@@ -4755,7 +4755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1307,
+      "line": 1309,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the same network, or a secure remote Gateway URL.",
       "surface": "android",
@@ -4763,7 +4763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1313,
+      "line": 1315,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Android setup guide",
       "surface": "android",
@@ -4771,7 +4771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1356,
+      "line": 1358,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup Gateway",
       "surface": "android",
@@ -4779,7 +4779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1361,
+      "line": 1363,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Step 1",
       "surface": "android",
@@ -4787,7 +4787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1362,
+      "line": 1364,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Start your Gateway.",
       "surface": "android",
@@ -4795,7 +4795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1363,
+      "line": 1365,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw gateway",
       "surface": "android",
@@ -4803,7 +4803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1367,
+      "line": 1369,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Step 2",
       "surface": "android",
@@ -4811,7 +4811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1368,
+      "line": 1370,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Generate a QR code.",
       "surface": "android",
@@ -4819,7 +4819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1369,
+      "line": 1371,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw qr",
       "surface": "android",
@@ -4827,7 +4827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1392,
+      "line": 1394,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose from gallery",
       "surface": "android",
@@ -4835,7 +4835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1447,
+      "line": 1449,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "QR code not accepted",
       "surface": "android",
@@ -4843,7 +4843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1466,
+      "line": 1468,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose another image",
       "surface": "android",
@@ -4851,7 +4851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1519,
+      "line": 1521,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan QR code",
       "surface": "android",
@@ -4859,7 +4859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1521,
+      "line": 1523,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Open the camera and frame the code from openclaw qr.",
       "surface": "android",
@@ -4867,7 +4867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1555,
+      "line": 1557,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Align the QR code inside the square.",
       "surface": "android",
@@ -4875,7 +4875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1573,
+      "line": 1575,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Camera access is needed to scan the setup QR.",
       "surface": "android",
@@ -4883,7 +4883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1578,
+      "line": 1580,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Allow camera",
       "surface": "android",
@@ -4891,7 +4891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1599,
+      "line": 1601,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Close scanner",
       "surface": "android",
@@ -4899,7 +4899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1762,
+      "line": 1764,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Enter setup code",
       "surface": "android",
@@ -4907,7 +4907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1768,
+      "line": 1770,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code",
       "surface": "android",
@@ -4915,7 +4915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1772,
+      "line": 1774,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste setup code",
       "surface": "android",
@@ -4923,7 +4923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1780,
+      "line": 1782,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use setup code",
       "surface": "android",
@@ -4931,7 +4931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1820,
+      "line": 1822,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Manual setup",
       "surface": "android",
@@ -4939,7 +4939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1823,
+      "line": 1825,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway URL",
       "surface": "android",
@@ -4947,7 +4947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1832,
+      "line": 1834,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Host",
       "surface": "android",
@@ -4955,7 +4955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1833,
+      "line": 1835,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Port",
       "surface": "android",
@@ -4963,7 +4963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1838,
+      "line": 1840,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the Gateway computer's LAN address or secure remote hostname.",
       "surface": "android",
@@ -4971,7 +4971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1845,
+      "line": 1847,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Token",
       "surface": "android",
@@ -4979,7 +4979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1846,
+      "line": 1848,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste token",
       "surface": "android",
@@ -4987,7 +4987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1848,
+      "line": 1850,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste a shared Gateway token or operator-issued token.",
       "surface": "android",
@@ -4995,7 +4995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1855,
+      "line": 1857,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password",
       "surface": "android",
@@ -5003,7 +5003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1856,
+      "line": 1858,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password optional",
       "surface": "android",
@@ -5011,7 +5011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1860,
+      "line": 1862,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connection security",
       "surface": "android",
@@ -5019,7 +5019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1882,
+      "line": 1884,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Unencrypted",
       "surface": "android",
@@ -5027,7 +5027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1888,
+      "line": 1890,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Secure (TLS)",
       "surface": "android",
@@ -5035,7 +5035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1911,
+      "line": 1913,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not test connection",
       "surface": "android",
@@ -5043,7 +5043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1916,
+      "line": 1918,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Test connection",
       "surface": "android",
@@ -5051,7 +5051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2003,
+      "line": 2005,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code was not accepted",
       "surface": "android",
@@ -5059,7 +5059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2009,
+      "line": 2011,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Your phone is paired with ${recoveryGatewayName(serverName = serverName, attemptedGatewayName = attemptedGatewayName)}. Continue to finish node access.",
       "surface": "android",
@@ -5067,7 +5067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2061,
+      "line": 2063,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway paired",
       "surface": "android",
@@ -5075,7 +5075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2062,
+      "line": 2064,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Pair Gateway",
       "surface": "android",
@@ -5083,7 +5083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2114,
+      "line": 2116,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "View details",
       "surface": "android",
@@ -5091,7 +5091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2147,
+      "line": 2149,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connection details",
       "surface": "android",
@@ -5099,7 +5099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2159,
+      "line": 2161,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy",
       "surface": "android",
@@ -5107,7 +5107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2164,
+      "line": 2166,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Close",
       "surface": "android",
@@ -5115,7 +5115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2176,
+      "line": 2178,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Details copied",
       "surface": "android",
@@ -5123,7 +5123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2221,
+      "line": 2223,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approve node access",
       "surface": "android",
@@ -5131,7 +5131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2228,
+      "line": 2230,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway pairing is complete. Approve this phone as a node so OpenClaw can use the device capabilities you enable.",
       "surface": "android",
@@ -5139,7 +5139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2236,
+      "line": 2238,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "On the Gateway computer, run:",
       "surface": "android",
@@ -5147,7 +5147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2245,
+      "line": 2247,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the requestId from the pending command in the approve command.",
       "surface": "android",
@@ -5155,7 +5155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2256,
+      "line": 2258,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "I have approved",
       "surface": "android",
@@ -5163,7 +5163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2257,
+      "line": 2259,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Checking approval…",
       "surface": "android",
@@ -5171,7 +5171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2269,
+      "line": 2271,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Still waiting for approval",
       "surface": "android",
@@ -5179,7 +5179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2272,
+      "line": 2274,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Run the approve command on the Gateway computer, then check again.",
       "surface": "android",
@@ -5187,7 +5187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2279,
+      "line": 2281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OK",
       "surface": "android",
@@ -5195,7 +5195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2429,
+      "line": 2431,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy approval command",
       "surface": "android",
@@ -5203,7 +5203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2460,
+      "line": 2462,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Only enable access you are comfortable letting OpenClaw use while this phone is connected. You can change these later in Android Settings.",
       "surface": "android",
@@ -5211,7 +5211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2499,
+      "line": 2501,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Back",
       "surface": "android",
@@ -5219,7 +5219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2550,
+      "line": 2552,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Permissions",
       "surface": "android",
@@ -5227,7 +5227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2611,
+      "line": 2613,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connected",
       "surface": "android",
@@ -5235,7 +5235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2612,
+      "line": 2614,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Your Gateway is ready.",
       "surface": "android",
@@ -5243,7 +5243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2616,
+      "line": 2618,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approve this phone on the gateway.\nThen retry the connection.",
       "surface": "android",
@@ -5251,7 +5251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2619,
+      "line": 2621,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Node Approval Pending",
       "surface": "android",
@@ -5259,7 +5259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2620,
+      "line": 2622,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway pairing worked.\nApprove this phone's node capabilities from an operator UI.",
       "surface": "android",
@@ -5267,7 +5267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2623,
+      "line": 2625,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Pairing Gateway",
       "surface": "android",
@@ -5275,7 +5275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2624,
+      "line": 2626,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approval is in progress.\nOpenClaw will reconnect automatically.",
       "surface": "android",
@@ -5283,7 +5283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2627,
+      "line": 2629,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connecting Gateway",
       "surface": "android",
@@ -5291,7 +5291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2628,
+      "line": 2630,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OpenClaw is checking gateway and node access.",
       "surface": "android",
@@ -5299,7 +5299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2631,
+      "line": 2633,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Still connecting",
       "surface": "android",
@@ -5307,7 +5307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2632,
+      "line": 2634,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "This is taking longer than expected.\nCheck that the Gateway is running and reachable.",
       "surface": "android",
@@ -5315,7 +5315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2635,
+      "line": 2637,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connection issue",
       "surface": "android",
@@ -5323,7 +5323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2636,
+      "line": 2638,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "We could not reach your Gateway.\nLet's fix this.",
       "surface": "android",
@@ -5331,7 +5331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2644,
+      "line": 2646,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Continue",
       "surface": "android",
@@ -5339,7 +5339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2645,
+      "line": 2647,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Retry connection",
       "surface": "android",
@@ -5347,7 +5347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2646,
+      "line": 2648,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Go back",
       "surface": "android",
@@ -5355,7 +5355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2742,
+      "line": 2744,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway received this phone",
       "surface": "android",
@@ -5363,7 +5363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2743,
+      "line": 2745,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Waiting for device approval",
       "surface": "android",
@@ -5371,7 +5371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2744,
+      "line": 2746,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Retrying automatically",
       "surface": "android",
@@ -5379,7 +5379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2748,
+      "line": 2750,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway needs device approval",
       "surface": "android",
@@ -5387,7 +5387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2749,
+      "line": 2751,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Run the approval command on the Gateway",
       "surface": "android",
@@ -5395,7 +5395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2765,
+      "line": 2767,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Opening Gateway connection",
       "surface": "android",
@@ -5403,7 +5403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2774,
+      "line": 2776,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Checking pairing access",
       "surface": "android",
@@ -5411,7 +5411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2782,
+      "line": 2784,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Checking node access",
       "surface": "android",
@@ -5419,7 +5419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2851,
+      "line": 2853,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Ready for chat and voice",
       "surface": "android",
@@ -5427,7 +5427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2853,
+      "line": 2855,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway paired. Waiting for node capability approval.",
       "surface": "android",
@@ -5435,7 +5435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2856,
+      "line": 2858,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway approval is pending. Run this on the gateway host:",
       "surface": "android",
@@ -5443,7 +5443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2857,
+      "line": 2859,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway approval is pending. Run openclaw devices list on the gateway host, approve this phone, then retry.",
       "surface": "android",
@@ -5451,7 +5451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2865,
+      "line": 2867,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway paired. Checking node capability approval.",
       "surface": "android",
@@ -5459,7 +5459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2867,
+      "line": 2869,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway paired. Waiting for operator access.",
       "surface": "android",
@@ -5467,7 +5467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2869,
+      "line": 2871,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
       "surface": "android",
@@ -5475,7 +5475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2871,
+      "line": 2873,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway unreachable",
       "surface": "android",
@@ -5483,7 +5483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2877,
+      "line": 2879,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The code may have expired or been generated for another Gateway.",
       "surface": "android",
@@ -5491,7 +5491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2881,
+      "line": 2883,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -5499,7 +5499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2882,
+      "line": 2884,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is invalid. Re-enter it or reset this gateway connection.",
       "surface": "android",
@@ -5507,7 +5507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2883,
+      "line": 2885,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway token is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -5515,7 +5515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2886,
+      "line": 2888,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway requires this device identity. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -5523,7 +5523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2889,
+      "line": 2891,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Saved authentication is invalid. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -5531,7 +5531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2890,
+      "line": 2892,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication is not configured. Edit this connection and try again.",
       "surface": "android",
@@ -5539,7 +5539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2891,
+      "line": 2893,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication needs review. Check gateway settings, then retry.",
       "surface": "android",
@@ -5547,7 +5547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2892,
+      "line": 2894,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication needs attention.",
       "surface": "android",
@@ -5555,7 +5555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2903,
+      "line": 2905,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "This app is older than the Gateway. Update OpenClaw on this device, then retry.",
       "surface": "android",
@@ -5563,7 +5563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2905,
+      "line": 2907,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The Gateway is older than this app. Update OpenClaw on the Gateway host, then retry.",
       "surface": "android",
@@ -5571,7 +5571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2906,
+      "line": 2908,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The app and Gateway use incompatible protocol versions. Update OpenClaw on both, then retry.",
       "surface": "android",
@@ -5579,7 +5579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2908,
+      "line": 2910,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "$summary $details",
       "surface": "android",
@@ -5587,7 +5587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2943,
+      "line": 2945,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw devices approve $requestId",
       "surface": "android",
@@ -5595,7 +5595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2945,
+      "line": 2947,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw devices list",
       "surface": "android",
@@ -5603,7 +5603,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2952,
+      "line": 2954,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw nodes approve $requestId",
       "surface": "android",
@@ -5611,7 +5611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2954,
+      "line": 2956,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw nodes approve REQUEST_ID",
       "surface": "android",
@@ -5619,7 +5619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3039,
+      "line": 3041,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approval command copied",
       "surface": "android",
@@ -5627,7 +5627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3048,
+      "line": 3050,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Command copied",
       "surface": "android",
@@ -5635,7 +5635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3115,
+      "line": 3117,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Enabled",
       "surface": "android",
@@ -5643,7 +5643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3116,
+      "line": 3118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Off",
       "surface": "android",
@@ -5651,7 +5651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3117,
+      "line": 3119,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Not allowed",
       "surface": "android",
@@ -5659,7 +5659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3125,
+      "line": 3127,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Granted",
       "surface": "android",
@@ -5667,7 +5667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3125,
+      "line": 3127,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Not granted",
       "surface": "android",
@@ -5675,7 +5675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3251,
+      "line": 3257,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Transcribe voice prompts",
       "surface": "android",
@@ -5683,7 +5683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3251,
+      "line": 3257,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Voice",
       "surface": "android",
@@ -5691,7 +5691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3256,
+      "line": 3262,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Camera",
       "surface": "android",
@@ -5699,7 +5699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3257,
+      "line": 3263,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Capture photos and clips from this phone",
       "surface": "android",
@@ -5707,7 +5707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3266,
+      "line": 3272,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Location",
       "surface": "android",
@@ -5715,7 +5715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3266,
+      "line": 3272,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Read this phone's location",
       "surface": "android",
@@ -5723,7 +5723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3270,
+      "line": 3276,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Photos",
       "surface": "android",
@@ -5731,7 +5731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3270,
+      "line": 3276,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Read recent photos and media",
       "surface": "android",
@@ -5739,7 +5739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3276,
+      "line": 3282,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Contacts",
       "surface": "android",
@@ -5747,7 +5747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3276,
+      "line": 3282,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Find people and contact details",
       "surface": "android",
@@ -5755,7 +5755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3279,
+      "line": 3285,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Calendar",
       "surface": "android",
@@ -5763,7 +5763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3279,
+      "line": 3285,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Read and update events",
       "surface": "android",
@@ -5771,7 +5771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3282,
+      "line": 3288,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Notifications",
       "surface": "android",
@@ -5779,7 +5779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3282,
+      "line": 3288,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Show OpenClaw alerts",
       "surface": "android",
@@ -5787,7 +5787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3285,
+      "line": 3291,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Notification listener",
       "surface": "android",
@@ -5795,7 +5795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3285,
+      "line": 3291,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Read selected app notifications",
       "surface": "android",
@@ -5803,7 +5803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3289,
+      "line": 3295,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Motion",
       "surface": "android",
@@ -5811,7 +5811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3289,
+      "line": 3295,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Share steps and activity",
       "surface": "android",
@@ -5819,7 +5819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3296,
+      "line": 3304,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Device access; Gateway opt-in still required",
       "surface": "android",
@@ -5827,7 +5827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3296,
+      "line": 3304,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "SMS",
       "surface": "android",
@@ -5835,7 +5835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3303,
+      "line": 3311,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Call Log",
       "surface": "android",
@@ -5843,7 +5843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3303,
+      "line": 3311,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Show recent call history",
       "surface": "android",
@@ -6643,7 +6643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 255,
+      "line": 256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits and quota health.",
       "surface": "android",
@@ -6651,7 +6651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 255,
+      "line": 256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Usage",
       "surface": "android",
@@ -6659,7 +6659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 259,
+      "line": 260,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Providers",
       "surface": "android",
@@ -6667,7 +6667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 275,
+      "line": 276,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load usage.",
       "surface": "android",
@@ -6675,7 +6675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 280,
+      "line": 281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No usage data yet.",
       "surface": "android",
@@ -6683,7 +6683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 281,
+      "line": 282,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits will appear here when your gateway reports them.",
       "surface": "android",
@@ -6691,7 +6691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 320,
+      "line": 321,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled OpenClaw work from your gateway.",
       "surface": "android",
@@ -6699,7 +6699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 325,
+      "line": 326,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Automations",
       "surface": "android",
@@ -6707,7 +6707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 333,
+      "line": 334,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search automations",
       "surface": "android",
@@ -6715,7 +6715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 334,
+      "line": 335,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search",
       "surface": "android",
@@ -6723,7 +6723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 350,
+      "line": 351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open an automation to inspect its configuration and run history. Admin-scoped connections can also run, edit, enable, disable, or delete it.",
       "surface": "android",
@@ -6731,7 +6731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 360,
+      "line": 361,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load automations.",
       "surface": "android",
@@ -6739,7 +6739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 365,
+      "line": 366,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No automations yet.",
       "surface": "android",
@@ -6747,7 +6747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 366,
+      "line": 367,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled work created on the gateway will appear here.",
       "surface": "android",
@@ -6755,7 +6755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 371,
+      "line": 372,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching automations.",
       "surface": "android",
@@ -6763,7 +6763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 470,
+      "line": 471,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Automation",
       "surface": "android",
@@ -6771,7 +6771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 471,
+      "line": 472,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Inspect and manage scheduled gateway work.",
       "surface": "android",
@@ -6779,7 +6779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 492,
+      "line": 493,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -6787,7 +6787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 500,
+      "line": 501,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Automation not loaded.",
       "surface": "android",
@@ -6795,7 +6795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 500,
+      "line": 501,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Loading automation…",
       "surface": "android",
@@ -6803,7 +6803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 551,
+      "line": 552,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose and inspect the assistants available on this gateway.",
       "surface": "android",
@@ -6811,7 +6811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 555,
+      "line": 556,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Available",
       "surface": "android",
@@ -6819,7 +6819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 562,
+      "line": 563,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load agents.",
       "surface": "android",
@@ -6827,7 +6827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 566,
+      "line": 567,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No agents loaded yet.",
       "surface": "android",
@@ -6835,7 +6835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 593,
+      "line": 594,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approvals",
       "surface": "android",
@@ -6843,7 +6843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 593,
+      "line": 594,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review actions that need your attention.",
       "surface": "android",
@@ -6851,7 +6851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 597,
+      "line": 598,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway Pending",
       "surface": "android",
@@ -6859,7 +6859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 598,
+      "line": 599,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Thread Activity",
       "surface": "android",
@@ -6867,7 +6867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 599,
+      "line": 600,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issues",
       "surface": "android",
@@ -6875,7 +6875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 600,
+      "line": 601,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Active Runs",
       "surface": "android",
@@ -6883,7 +6883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 604,
+      "line": 605,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refresh",
       "surface": "android",
@@ -6891,7 +6891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 604,
+      "line": 605,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -6899,7 +6899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 622,
+      "line": 623,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway disconnected.",
       "surface": "android",
@@ -6907,7 +6907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 623,
+      "line": 624,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load approval requests in the app.",
       "surface": "android",
@@ -6915,7 +6915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 629,
+      "line": 630,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateway approvals.",
       "surface": "android",
@@ -6923,7 +6923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 630,
+      "line": 631,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Exec approval requests will appear here while this phone is connected.",
       "surface": "android",
@@ -6931,7 +6931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 640,
+      "line": 641,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Thread activity",
       "surface": "android",
@@ -6939,7 +6939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 641,
+      "line": 642,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Chat tool calls waiting in the active thread remain visible here.",
       "surface": "android",
@@ -6947,7 +6947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 655,
+      "line": 656,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "How this phone appears to OpenClaw.",
       "surface": "android",
@@ -6955,7 +6955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 655,
+      "line": 656,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Profile",
       "surface": "android",
@@ -6963,7 +6963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 658,
+      "line": 659,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Device name",
       "surface": "android",
@@ -6971,7 +6971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 659,
+      "line": 660,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save Profile",
       "surface": "android",
@@ -6979,7 +6979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 718,
+      "line": 719,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Configure wake words, talk, and playback.",
       "surface": "android",
@@ -6987,7 +6987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 718,
+      "line": 719,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Voice",
       "surface": "android",
@@ -6995,7 +6995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 720,
+      "line": 721,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Voice Wake",
       "surface": "android",
@@ -7003,7 +7003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 725,
+      "line": 726,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Listen for wake words",
       "surface": "android",
@@ -7011,7 +7011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 728,
+      "line": 729,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runs on-device while OpenClaw is visible.",
       "surface": "android",
@@ -7019,7 +7019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 730,
+      "line": 731,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On-device speech recognition is unavailable.",
       "surface": "android",
@@ -7027,7 +7027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 740,
+      "line": 741,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake listener",
       "surface": "android",
@@ -7035,7 +7035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 742,
+      "line": 743,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last command: $command",
       "surface": "android",
@@ -7043,7 +7043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 743,
+      "line": 744,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Pauses during other voice activity.",
       "surface": "android",
@@ -7051,7 +7051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 750,
+      "line": 751,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake words",
       "surface": "android",
@@ -7059,7 +7059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 752,
+      "line": 753,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add one wake word or phrase per field. Then say one before your command.",
       "surface": "android",
@@ -7067,7 +7067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 767,
+      "line": 768,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake word or phrase",
       "surface": "android",
@@ -7075,7 +7075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 774,
+      "line": 775,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Remove wake phrase",
       "surface": "android",
@@ -7083,7 +7083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 783,
+      "line": 784,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add wake phrase",
       "surface": "android",
@@ -7091,7 +7091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 790,
+      "line": 791,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save wake words",
       "surface": "android",
@@ -7099,7 +7099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 790,
+      "line": 791,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Saving…",
       "surface": "android",
@@ -7107,7 +7107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 795,
+      "line": 796,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -7115,7 +7115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 800,
+      "line": 801,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Talk Provider Setup",
       "surface": "android",
@@ -7123,7 +7123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 802,
+      "line": 803,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Microphone",
       "surface": "android",
@@ -7131,7 +7131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 809,
+      "line": 810,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Audio Test",
       "surface": "android",
@@ -7139,7 +7139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 810,
+      "line": 811,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check that OpenClaw can speak clearly on this phone.",
       "surface": "android",
@@ -7147,7 +7147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 813,
+      "line": 814,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enable speaker",
       "surface": "android",
@@ -7155,7 +7155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 813,
+      "line": 814,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Mute speaker",
       "surface": "android",
@@ -7163,7 +7163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 814,
+      "line": 815,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Assistant speech muted",
       "surface": "android",
@@ -7171,7 +7171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 814,
+      "line": 815,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replies play aloud",
       "surface": "android",
@@ -7179,7 +7179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 816,
+      "line": 817,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Muted",
       "surface": "android",
@@ -7187,7 +7187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 816,
+      "line": 817,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On",
       "surface": "android",
@@ -7195,7 +7195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 820,
+      "line": 821,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Done",
       "surface": "android",
@@ -7203,7 +7203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 838,
+      "line": 839,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Automatic",
       "surface": "android",
@@ -7211,7 +7211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 841,
+      "line": 842,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Preferred microphone unavailable; using automatic routing.",
       "surface": "android",
@@ -7219,7 +7219,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 843,
+      "line": 844,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Uses the system-selected microphone.",
+      "surface": "android",
+      "id": "native.android.122bc72e47efbc5c"
+    },
+    {
+      "kind": "ui-call",
+      "line": 846,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Prioritizes connected Bluetooth microphones.",
       "surface": "android",
@@ -7227,7 +7235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 852,
+      "line": 855,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Preferred microphone",
       "surface": "android",
@@ -7235,7 +7243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 853,
+      "line": 856,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unavailable",
       "surface": "android",
@@ -7243,7 +7251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 885,
+      "line": 888,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Next session",
       "surface": "android",
@@ -7251,7 +7259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 907,
+      "line": 910,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Built-in microphone",
       "surface": "android",
@@ -7259,7 +7267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 908,
+      "line": 911,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bluetooth microphone",
       "surface": "android",
@@ -7267,7 +7275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 909,
+      "line": 912,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bluetooth LE microphone",
       "surface": "android",
@@ -7275,7 +7283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 910,
+      "line": 913,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wired headset microphone",
       "surface": "android",
@@ -7283,7 +7291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 914,
+      "line": 917,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "USB microphone",
       "surface": "android",
@@ -7291,7 +7299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 915,
+      "line": 918,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "External microphone",
       "surface": "android",
@@ -7299,7 +7307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 923,
+      "line": 926,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Realtime Talk",
       "surface": "android",
@@ -7307,7 +7315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 924,
+      "line": 927,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dictation",
       "surface": "android",
@@ -7315,7 +7323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1094,
+      "line": 1097,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what reaches OpenClaw.",
       "surface": "android",
@@ -7323,7 +7331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1094,
+      "line": 1097,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Notifications",
       "surface": "android",
@@ -7331,7 +7339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1098,
+      "line": 1101,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Alerts stay on this phone.",
       "surface": "android",
@@ -7339,7 +7347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1098,
+      "line": 1101,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forward Notifications",
       "surface": "android",
@@ -7347,7 +7355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1098,
+      "line": 1101,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can receive selected alerts.",
       "surface": "android",
@@ -7355,7 +7363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1100,
+      "line": 1103,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Quiet Hours",
       "surface": "android",
@@ -7363,7 +7371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1101,
+      "line": 1104,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$quietStart to $quietEnd",
       "surface": "android",
@@ -7371,7 +7379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1113,
+      "line": 1116,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Policy",
       "surface": "android",
@@ -7379,7 +7387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1114,
+      "line": 1117,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected Apps",
       "surface": "android",
@@ -7387,7 +7395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1115,
+      "line": 1118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Rate Limit",
       "surface": "android",
@@ -7395,7 +7403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1116,
+      "line": 1119,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Granted",
       "surface": "android",
@@ -7403,7 +7411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1116,
+      "line": 1119,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup",
       "surface": "android",
@@ -7411,7 +7419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1121,
+      "line": 1124,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check Access",
       "surface": "android",
@@ -7419,7 +7427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1121,
+      "line": 1124,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open System Access",
       "surface": "android",
@@ -7427,7 +7435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1130,
+      "line": 1133,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forwarding Mode",
       "surface": "android",
@@ -7435,7 +7443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1132,
+      "line": 1135,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Blocklist",
       "surface": "android",
@@ -7443,7 +7451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1136,
+      "line": 1139,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowlist",
       "surface": "android",
@@ -7451,7 +7459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1185,
+      "line": 1188,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App Filter",
       "surface": "android",
@@ -7459,7 +7467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1192,
+      "line": 1195,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Close App Picker",
       "surface": "android",
@@ -7467,7 +7475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1192,
+      "line": 1195,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open App Picker",
       "surface": "android",
@@ -7475,7 +7483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1197,
+      "line": 1200,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search apps",
       "surface": "android",
@@ -7483,7 +7491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1200,
+      "line": 1203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show System Apps",
       "surface": "android",
@@ -7491,7 +7499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1201,
+      "line": 1204,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Include Android and background packages.",
       "surface": "android",
@@ -7499,7 +7507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1208,
+      "line": 1211,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching apps.",
       "surface": "android",
@@ -7507,7 +7515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1219,
+      "line": 1222,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Showing ${visibleApps.size} of ${apps.size}. Refine search for more.",
       "surface": "android",
@@ -7515,7 +7523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1466,
+      "line": 1477,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what this phone can share.",
       "surface": "android",
@@ -7523,7 +7531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1466,
+      "line": 1477,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Phone Capabilities",
       "surface": "android",
@@ -7531,7 +7539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1470,
+      "line": 1481,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow camera tools when requested.",
       "surface": "android",
@@ -7539,7 +7547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1470,
+      "line": 1481,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Camera",
       "surface": "android",
@@ -7547,7 +7555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1471,
+      "line": 1482,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Precise Location",
       "surface": "android",
@@ -7555,7 +7563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1471,
+      "line": 1482,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Share precise location while location is enabled.",
       "surface": "android",
@@ -7563,7 +7571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1474,
+      "line": 1485,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Photos",
       "surface": "android",
@@ -7571,7 +7579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1475,
+      "line": 1486,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow photo library access.",
       "surface": "android",
@@ -7579,7 +7587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1475,
+      "line": 1486,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected or full photo access granted.",
       "surface": "android",
@@ -7587,7 +7595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1484,
+      "line": 1495,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Installed Apps",
       "surface": "android",
@@ -7595,7 +7603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1485,
+      "line": 1496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App list stays on this phone.",
       "surface": "android",
@@ -7603,7 +7611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1485,
+      "line": 1496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can list launcher-visible apps.",
       "surface": "android",
@@ -7611,7 +7619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1490,
+      "line": 1501,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Keep Awake",
       "surface": "android",
@@ -7619,7 +7627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1490,
+      "line": 1501,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Keep the node available during active work.",
       "surface": "android",
@@ -7627,7 +7635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1491,
+      "line": 1502,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Canvas Status",
       "surface": "android",
@@ -7635,7 +7643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1491,
+      "line": 1502,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show screen-sharing debug state.",
       "surface": "android",
@@ -7643,7 +7651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1499,
+      "line": 1510,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Location",
       "surface": "android",
@@ -7651,7 +7659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1507,
+      "line": 1518,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always allows requested location checks while OpenClaw is in the background; Android shows this in the persistent node notification.",
       "surface": "android",
@@ -7659,7 +7667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1542,
+      "line": 1553,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow background location?",
       "surface": "android",
@@ -7667,7 +7675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1545,
+      "line": 1556,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
       "surface": "android",
@@ -7675,7 +7683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1559,
+      "line": 1570,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open Settings",
       "surface": "android",
@@ -7683,7 +7691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1578,
+      "line": 1589,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Share installed app information?",
       "surface": "android",
@@ -7691,7 +7699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1582,
+      "line": 1593,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
       "surface": "android",
@@ -7699,7 +7707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1585,
+      "line": 1596,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
       "surface": "android",
@@ -7707,7 +7715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1591,
+      "line": 1602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agree and Enable",
       "surface": "android",
@@ -7715,7 +7723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1596,
+      "line": 1607,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not Now",
       "surface": "android",
@@ -7723,7 +7731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1650,
+      "line": 1661,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace gateway setup?",
       "surface": "android",
@@ -7731,7 +7739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1665,
+      "line": 1676,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace setup",
       "surface": "android",
@@ -7739,7 +7747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1679,
+      "line": 1690,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "this gateway",
       "surface": "android",
@@ -7747,7 +7755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1682,
+      "line": 1693,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget gateway?",
       "surface": "android",
@@ -7755,7 +7763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1685,
+      "line": 1696,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Remove $gatewayName and its saved credentials from this phone?",
       "surface": "android",
@@ -7763,7 +7771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1702,
+      "line": 1713,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cancel",
       "surface": "android",
@@ -7771,7 +7779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1740,
+      "line": 1751,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection between this phone and OpenClaw.",
       "surface": "android",
@@ -7779,7 +7787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1754,
+      "line": 1765,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connected",
       "surface": "android",
@@ -7787,7 +7795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1754,
+      "line": 1765,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection",
       "surface": "android",
@@ -7795,7 +7803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1754,
+      "line": 1765,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Offline",
       "surface": "android",
@@ -7803,7 +7811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1755,
+      "line": 1766,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not paired",
       "surface": "android",
@@ -7811,7 +7819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1755,
+      "line": 1766,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Online",
       "surface": "android",
@@ -7819,7 +7827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1757,
+      "line": 1768,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Access",
       "surface": "android",
@@ -7827,7 +7835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1764,
+      "line": 1775,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Address",
       "surface": "android",
@@ -7835,7 +7843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1769,
+      "line": 1780,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Discovered",
       "surface": "android",
@@ -7843,7 +7851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1770,
+      "line": 1781,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default Agent",
       "surface": "android",
@@ -7851,7 +7859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1771,
+      "line": 1782,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agents",
       "surface": "android",
@@ -7859,7 +7867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1772,
+      "line": 1783,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Instance ID",
       "surface": "android",
@@ -7867,7 +7875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1778,
+      "line": 1789,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan QR to Pair",
       "surface": "android",
@@ -7875,7 +7883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1788,
+      "line": 1799,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Limited Gateway access",
       "surface": "android",
@@ -7883,7 +7891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1801,
+      "line": 1812,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Reconnect",
       "surface": "android",
@@ -7891,7 +7899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1802,
+      "line": 1813,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Disconnect",
       "surface": "android",
@@ -7899,7 +7907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1805,
+      "line": 1816,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Diagnose",
       "surface": "android",
@@ -7907,7 +7915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1818,
+      "line": 1829,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add Gateway",
       "surface": "android",
@@ -7915,7 +7923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1820,
+      "line": 1831,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan or paste a setup code to add another gateway.",
       "surface": "android",
@@ -7923,7 +7931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1826,
+      "line": 1837,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan QR",
       "surface": "android",
@@ -7931,7 +7939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1827,
+      "line": 1838,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup code",
       "surface": "android",
@@ -7939,7 +7947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1830,
+      "line": 1841,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Where do I get a setup code?",
       "surface": "android",
@@ -7947,7 +7955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1834,
+      "line": 1845,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android can scan or paste an existing setup code, but this gateway does not expose setup-code generation to the app yet. Generate the QR/code on the gateway host with openclaw qr, then scan it here or paste the setup code below.",
       "surface": "android",
@@ -7955,7 +7963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1841,
+      "line": 1852,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateways found yet. Use manual setup if discovery is blocked.",
       "surface": "android",
@@ -7963,7 +7971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1854,
+      "line": 1865,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect",
       "surface": "android",
@@ -7971,7 +7979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1865,
+      "line": 1876,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateways",
       "surface": "android",
@@ -7979,7 +7987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1867,
+      "line": 1878,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No paired gateways.",
       "surface": "android",
@@ -7987,7 +7995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1895,
+      "line": 1906,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget",
       "surface": "android",
@@ -7995,7 +8003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1912,
+      "line": 1923,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Manual Gateway",
       "surface": "android",
@@ -8003,7 +8011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1914,
+      "line": 1925,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Host",
       "surface": "android",
@@ -8011,7 +8019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1915,
+      "line": 1926,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Port",
       "surface": "android",
@@ -8019,7 +8027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1917,
+      "line": 1928,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection security",
       "surface": "android",
@@ -8027,7 +8035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1921,
+      "line": 1932,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unencrypted",
       "surface": "android",
@@ -8035,7 +8043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1925,
+      "line": 1936,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Secure (TLS)",
       "surface": "android",
@@ -8043,7 +8051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1938,
+      "line": 1949,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Token",
       "surface": "android",
@@ -8051,7 +8059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1939,
+      "line": 1950,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bootstrap",
       "surface": "android",
@@ -8059,7 +8067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1941,
+      "line": 1952,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Password",
       "surface": "android",
@@ -8067,7 +8075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1946,
+      "line": 1957,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save & Connect",
       "surface": "android",
@@ -8075,7 +8083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1963,
+      "line": 1974,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enter a valid setup code or gateway address.",
       "surface": "android",
@@ -8083,7 +8091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1984,
+      "line": 1995,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not available",
       "surface": "android",
@@ -8091,7 +8099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1985,
+      "line": 1996,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Full",
       "surface": "android",
@@ -8099,7 +8107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1986,
+      "line": 1997,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Limited",
       "surface": "android",
@@ -8107,7 +8115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1990,
+      "line": 2001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Use a secure wss:// or Tailscale Serve Gateway, generate a full-access setup code in the Control UI or with openclaw qr, then scan or paste it below and reconnect to enable settings and upgrades.",
       "surface": "android",
@@ -8115,7 +8123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2004,
+      "line": 2015,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
       "surface": "android",
@@ -8123,7 +8131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2004,
+      "line": 2015,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme and translated Android text.",
       "surface": "android",
@@ -8131,7 +8139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2009,
+      "line": 2020,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Language",
       "surface": "android",
@@ -8139,7 +8147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2010,
+      "line": 2021,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Contrast",
       "surface": "android",
@@ -8147,7 +8155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2010,
+      "line": 2021,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "High",
       "surface": "android",
@@ -8155,7 +8163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2011,
+      "line": 2022,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Readable",
       "surface": "android",
@@ -8163,7 +8171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2011,
+      "line": 2022,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Typography",
       "surface": "android",
@@ -8171,7 +8179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2016,
+      "line": 2027,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme",
       "surface": "android",
@@ -8179,7 +8187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2026,
+      "line": 2037,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App language",
       "surface": "android",
@@ -8187,7 +8195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2060,
+      "line": 2071,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected",
       "surface": "android",
@@ -8195,7 +8203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2072,
+      "line": 2083,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System",
       "surface": "android",
@@ -8203,7 +8211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2100,
+      "line": 2111,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "While Using",
       "surface": "android",
@@ -8211,7 +8219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2101,
+      "line": 2112,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always",
       "surface": "android",
@@ -8219,7 +8227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2117,
+      "line": 2128,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "About",
       "surface": "android",
@@ -8227,7 +8235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2117,
+      "line": 2128,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw for Android.",
       "surface": "android",
@@ -8235,7 +8243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2129,
+      "line": 2140,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Channel",
       "surface": "android",
@@ -8243,7 +8251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2130,
+      "line": 2141,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not connected",
       "surface": "android",
@@ -8251,7 +8259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2135,
+      "line": 2146,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Home Gateway",
       "surface": "android",
@@ -8259,7 +8267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2137,
+      "line": 2148,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runtime",
       "surface": "android",
@@ -8267,7 +8275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2137,
+      "line": 2148,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting",
       "surface": "android",
@@ -8275,7 +8283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2140,
+      "line": 2151,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Update",
       "surface": "android",
@@ -8283,7 +8291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2141,
+      "line": 2152,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Up to date",
       "surface": "android",
@@ -8291,7 +8299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2141,
+      "line": 2152,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "v$it available",
       "surface": "android",
@@ -8299,7 +8307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2151,
+      "line": 2162,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "© 2026 OpenClaw Foundation — MIT License.",
       "surface": "android",
@@ -8307,7 +8315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2168,
+      "line": 2179,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw logo",
       "surface": "android",
@@ -8315,7 +8323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2170,
+      "line": 2181,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -8323,7 +8331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2171,
+      "line": 2182,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Personal AI on your devices",
       "surface": "android",
@@ -8331,7 +8339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2230,
+      "line": 2241,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Licenses",
       "surface": "android",
@@ -8339,7 +8347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2231,
+      "line": 2242,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "android",
@@ -8347,7 +8355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2240,
+      "line": 2251,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No license notices are packaged in this build.",
       "surface": "android",
@@ -8355,7 +8363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2266,
+      "line": 2277,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open ${license.title}",
       "surface": "android",
@@ -8363,7 +8371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2277,
+      "line": 2288,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Third-party",
       "surface": "android",
@@ -8371,7 +8379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2278,
+      "line": 2289,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unknown",
       "surface": "android",
@@ -8379,7 +8387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2284,
+      "line": 2295,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Website",
       "surface": "android",
@@ -8387,7 +8395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2285,
+      "line": 2296,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Docs",
       "surface": "android",
@@ -8395,7 +8403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2289,
+      "line": 2300,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow all the time",
       "surface": "android",
@@ -8403,7 +8411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2292,
+      "line": 2303,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
       "surface": "android",
@@ -8411,7 +8419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2311,
+      "line": 2322,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
@@ -8419,7 +8427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2318,
+      "line": 2329,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
       "surface": "android",
@@ -8427,7 +8435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2320,
+      "line": 2331,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
       "surface": "android",
@@ -8435,7 +8443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2345,
+      "line": 2356,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Back",
       "surface": "android",
@@ -8443,7 +8451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2419,
+      "line": 2430,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command approval",
       "surface": "android",
@@ -8451,7 +8459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2424,
+      "line": 2435,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Sending",
       "surface": "android",
@@ -8459,7 +8467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2484,
+      "line": 2495,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Once",
       "surface": "android",
@@ -8467,7 +8475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2485,
+      "line": 2496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Always",
       "surface": "android",
@@ -8475,7 +8483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2486,
+      "line": 2497,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Deny",
       "surface": "android",
@@ -8483,7 +8491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2507,
+      "line": 2518,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approval ${notice.approvalId}",
       "surface": "android",
@@ -8491,7 +8499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2514,
+      "line": 2525,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dismiss approval notice",
       "surface": "android",
@@ -8499,7 +8507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2533,
+      "line": 2544,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review",
       "surface": "android",
@@ -8507,7 +8515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2573,
+      "line": 2584,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open automation detail",
       "surface": "android",
@@ -8515,7 +8523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2616,
+      "line": 2627,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enabled",
       "surface": "android",
@@ -8523,7 +8531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2616,
+      "line": 2627,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Status",
       "surface": "android",
@@ -8531,7 +8539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2617,
+      "line": 2628,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Schedule",
       "surface": "android",
@@ -8539,7 +8547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2618,
+      "line": 2629,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Next Wake",
       "surface": "android",
@@ -8547,7 +8555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2619,
+      "line": 2630,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Run",
       "surface": "android",
@@ -8555,7 +8563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2626,
+      "line": 2637,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Description",
       "surface": "android",
@@ -8563,7 +8571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2627,
+      "line": 2638,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Schedule Detail",
       "surface": "android",
@@ -8571,7 +8579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2628,
+      "line": 2639,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Session Target",
       "surface": "android",
@@ -8579,7 +8587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2629,
+      "line": 2640,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake Mode",
       "surface": "android",
@@ -8587,7 +8595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2630,
+      "line": 2641,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delete After Run",
       "surface": "android",
@@ -8595,7 +8603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2630,
+      "line": 2641,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No",
       "surface": "android",
@@ -8603,7 +8611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2630,
+      "line": 2641,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Yes",
       "surface": "android",
@@ -8611,7 +8619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2631,
+      "line": 2642,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload",
       "surface": "android",
@@ -8619,7 +8627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2632,
+      "line": 2643,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery",
       "surface": "android",
@@ -8627,7 +8635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2633,
+      "line": 2644,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Failure Alert",
       "surface": "android",
@@ -8635,7 +8643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2634,
+      "line": 2645,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Created",
       "surface": "android",
@@ -8643,7 +8651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2635,
+      "line": 2646,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Updated",
       "surface": "android",
@@ -8651,7 +8659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2636,
+      "line": 2647,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Running Since",
       "surface": "android",
@@ -8659,7 +8667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2637,
+      "line": 2648,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Status",
       "surface": "android",
@@ -8667,7 +8675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2639,
+      "line": 2650,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Duration",
       "surface": "android",
@@ -8675,7 +8683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2640,
+      "line": 2651,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${durationMs}ms",
       "surface": "android",
@@ -8683,7 +8691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2642,
+      "line": 2653,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Consecutive Errors",
       "surface": "android",
@@ -8691,7 +8699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2643,
+      "line": 2654,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Consecutive Skips",
       "surface": "android",
@@ -8699,7 +8707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2644,
+      "line": 2655,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Status",
       "surface": "android",
@@ -8707,7 +8715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2651,
+      "line": 2662,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Error",
       "surface": "android",
@@ -8715,7 +8723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2654,
+      "line": 2665,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Error",
       "surface": "android",
@@ -8723,7 +8731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2670,
+      "line": 2681,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Copy ${row.title}",
       "surface": "android",
@@ -8731,7 +8739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2695,
+      "line": 2706,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Tap to copy",
       "surface": "android",
@@ -8739,7 +8747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2710,
+      "line": 2721,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$title copied",
       "surface": "android",
@@ -8747,7 +8755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2748,
+      "line": 2759,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default assistant",
       "surface": "android",
@@ -8755,7 +8763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2754,
+      "line": 2765,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default",
       "surface": "android",
@@ -8763,7 +8771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2762,
+      "line": 2773,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${endpoint.host}:${endpoint.port}",
       "surface": "android",
@@ -8771,7 +8779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2808,
+      "line": 2819,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Action Request",
       "surface": "android",
@@ -8779,7 +8787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2816,
+      "line": 2827,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -8787,7 +8795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2819,
+      "line": 2830,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${minutes}m",
       "surface": "android",
@@ -8795,7 +8803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2819,
+      "line": 2830,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting for review",
       "surface": "android",
@@ -8803,7 +8811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2830,
+      "line": 2841,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Node ${nodeId}",
       "surface": "android",
@@ -8811,7 +8819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2832,
+      "line": 2843,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Node",
       "surface": "android",
@@ -8819,7 +8827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2835,
+      "line": 2846,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway",
       "surface": "android",
@@ -8827,7 +8835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2840,
+      "line": 2851,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent ${agentId}",
       "surface": "android",
@@ -8835,7 +8843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2845,
+      "line": 2856,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${duration}",
       "surface": "android",
@@ -8843,7 +8851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2850,
+      "line": 2861,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Expires ${duration}",
       "surface": "android",
@@ -8851,7 +8859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2860,
+      "line": 2871,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "soon",
       "surface": "android",
@@ -8859,7 +8867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2868,
+      "line": 2879,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Main",
       "surface": "android",
@@ -8867,7 +8875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2869,
+      "line": 2880,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Isolated",
       "surface": "android",
@@ -8875,7 +8883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2870,
+      "line": 2881,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Current",
       "surface": "android",
@@ -8883,7 +8891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2876,
+      "line": 2887,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}",
       "surface": "android",
@@ -8891,7 +8899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2892,
+      "line": 2903,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "All",
       "surface": "android",
@@ -8899,7 +8907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2893,
+      "line": 2904,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Active",
       "surface": "android",
@@ -8907,7 +8915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2894,
+      "line": 2905,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Paused",
       "surface": "android",
@@ -8915,7 +8923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2927,
+      "line": 2938,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${remaining}% left ${label}",
       "surface": "android",
@@ -8923,7 +8931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2930,
+      "line": 2941,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No limits reported",
       "surface": "android",
@@ -8931,7 +8939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2941,
+      "line": 2952,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Never",
       "surface": "android",
@@ -8939,7 +8947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2946,
+      "line": 2957,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Now",
       "surface": "android",
@@ -8947,7 +8955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2968,
+      "line": 2979,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
       "surface": "android",
@@ -8955,7 +8963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2970,
+      "line": 2981,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issue",
       "surface": "android",
@@ -8963,7 +8971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2972,
+      "line": 2983,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Skipped",
       "surface": "android",
@@ -8971,7 +8979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2973,
+      "line": 2984,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Ready",
       "surface": "android",
@@ -8979,7 +8987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2989,
+      "line": 3000,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System Event Text",
       "surface": "android",
@@ -8987,7 +8995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2990,
+      "line": 3001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent Prompt",
       "surface": "android",
@@ -8995,7 +9003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2991,
+      "line": 3002,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command",
       "surface": "android",
@@ -9003,7 +9011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2992,
+      "line": 3003,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Script",
       "surface": "android",
@@ -9011,7 +9019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2993,
+      "line": 3004,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload Text",
       "surface": "android",
@@ -9019,7 +9027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3023,
+      "line": 3034,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No apps selected. Nothing forwards until you add apps.",
       "surface": "android",
@@ -9027,7 +9035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3025,
+      "line": 3036,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount app allowed to forward.",
       "surface": "android",
@@ -9035,7 +9043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3027,
+      "line": 3038,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount apps allowed to forward.",
       "surface": "android",
@@ -9043,7 +9051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3031,
+      "line": 3042,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No apps blocked. Apps can forward unless you add blocks.",
       "surface": "android",
@@ -9051,7 +9059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3033,
+      "line": 3044,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount app blocked from forwarding.",
       "surface": "android",
@@ -9059,7 +9067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3035,
+      "line": 3046,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount apps blocked from forwarding.",
       "surface": "android",
@@ -9067,7 +9075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3061,
+      "line": 3072,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Due",
       "surface": "android",
@@ -9075,7 +9083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3066,
+      "line": 3077,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${days}d",
       "surface": "android",
@@ -9083,7 +9091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3067,
+      "line": 3078,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${hours}h",
       "surface": "android",
@@ -9091,7 +9099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3068,
+      "line": 3079,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${minutes}m",
       "surface": "android",
@@ -9099,7 +9107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3069,
+      "line": 3080,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Soon",
       "surface": "android",
@@ -9107,7 +9115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3074,
+      "line": 3085,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "None",
       "surface": "android",
@@ -12259,7 +12267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 413,
+      "line": 428,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatDictation.kt",
       "source": "Stop Dictation",
       "surface": "android",
@@ -12267,7 +12275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 415,
+      "line": 430,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatDictation.kt",
       "source": "Dictation",
       "surface": "android",
@@ -12275,7 +12283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 456,
+      "line": 471,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatDictation.kt",
       "source": "On-device speech recognition is unavailable.",
       "surface": "android",
@@ -12283,7 +12291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 457,
+      "line": 472,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatDictation.kt",
       "source": "Microphone permission is required.",
       "surface": "android",
@@ -12291,7 +12299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 458,
+      "line": 473,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatDictation.kt",
       "source": "Recognizer busy",
       "surface": "android",
@@ -12299,7 +12307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 459,
+      "line": 474,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatDictation.kt",
       "source": "Network error",
       "surface": "android",
@@ -12307,7 +12315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 460,
+      "line": 475,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatDictation.kt",
       "source": "No matches",
       "surface": "android",
@@ -12315,7 +12323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 461,
+      "line": 476,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatDictation.kt",
       "source": "Speech recognition",
       "surface": "android",
@@ -12363,7 +12371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 220,
+      "line": 221,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
       "source": "Save image",
       "surface": "android",
@@ -12371,7 +12379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 230,
+      "line": 232,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
       "source": "Widget unavailable",
       "surface": "android",
@@ -14411,7 +14419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 375,
+      "line": 378,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/VoiceWakeManager.kt",
       "source": "Off",
       "surface": "android",
@@ -14419,7 +14427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 376,
+      "line": 379,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/VoiceWakeManager.kt",
       "source": "On-device speech recognition unavailable",
       "surface": "android",
@@ -14427,7 +14435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 378,
+      "line": 381,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/VoiceWakeManager.kt",
       "source": "Paused",
       "surface": "android",
@@ -14435,7 +14443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 401,
+      "line": 404,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/VoiceWakeManager.kt",
       "source": "Listening",
       "surface": "android",
@@ -14443,7 +14451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 420,
+      "line": 423,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/VoiceWakeManager.kt",
       "source": "Microphone permission required",
       "surface": "android",
@@ -14451,7 +14459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 422,
+      "line": 425,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/VoiceWakeManager.kt",
       "source": "Device language not supported",
       "surface": "android",
@@ -14459,7 +14467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 424,
+      "line": 427,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/VoiceWakeManager.kt",
       "source": "On-device language model unavailable",
       "surface": "android",
@@ -14467,7 +14475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 444,
+      "line": 447,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/VoiceWakeManager.kt",
       "source": "Triggered",
       "surface": "android",
@@ -14475,7 +14483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 457,
+      "line": 460,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/VoiceWakeManager.kt",
       "source": "Gateway unavailable",
       "surface": "android",
@@ -14483,7 +14491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 472,
+      "line": 475,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/VoiceWakeManager.kt",
       "source": "Starting…",
       "surface": "android",

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -18,7 +18,8 @@ OpenClaw Android is the officially released Google Play app. It connects to an O
 - [x] Security hardening (biometric lock, token handling, safer defaults)
 - [x] Authenticated background presence beacons
 - [x] Voice tab full functionality
-- [x] Foreground on-device Voice Wake with Gateway-synced wake words
+- [x] Foreground on-device Voice Wake with Gateway-synced wake words on
+  Android 12 and newer
 - [x] Screen tab full functionality
 - [x] Skill Workshop settings can filter proposals, inspect proposal content, and apply/reject/quarantine drafts through Gateway RPCs
 - [x] Skills settings can search installed skills, enable or disable them, and install Gateway-verified ClawHub releases
@@ -30,6 +31,13 @@ OpenClaw Android is the officially released Google Play app. It connects to an O
 
 - Run `pnpm install` from the repository root so native Canvas resources can be generated.
 - Open the folder `apps/android`.
+
+The phone app supports Android 9 (API 28) and newer. The Wear OS app still
+requires API 31. On Android 9 through 11, on-device Voice Wake and Chat
+dictation are unavailable because Android does not expose the guaranteed
+on-device recognizer API. Copying a widget image remains available on Android
+9; saving it directly to Downloads requires Android 10.
+Automatic Bluetooth microphone routing requires Android 12.
 
 ## Wear OS companion
 
@@ -245,7 +253,9 @@ Then in app **Connect → Manual**:
 
 This app is native Kotlin + Jetpack Compose.
 
-- For Compose UI edits: use Android Studio **Live Edit** on a debug build (works on physical devices; project `minSdk=31` already meets API requirement).
+- For Compose UI edits: use Android Studio **Live Edit** on a compatible debug
+  device. Live Edit itself requires API 30 even though the phone app supports
+  API 28.
 - For many non-structural code/resource changes: use Android Studio **Apply Changes**.
 - For structural/native/manifest/Gradle changes: do full reinstall (`pnpm android:run`).
 - Canvas web content already supports live reload when loaded from Gateway `__openclaw__/canvas/` (see `docs/platforms/android.md`).

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -215,7 +215,7 @@ android {
 
   defaultConfig {
     applicationId = "ai.openclaw.app"
-    minSdk = 31
+    minSdk = 28
     targetSdk = 36
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     versionCode = openClawAndroidVersionCode

--- a/apps/android/app/src/androidTest/java/ai/openclaw/app/ui/CanvasHostLifecycleTest.kt
+++ b/apps/android/app/src/androidTest/java/ai/openclaw/app/ui/CanvasHostLifecycleTest.kt
@@ -8,6 +8,7 @@ import android.content.ClipboardManager
 import android.content.ContentUris
 import android.content.pm.ActivityInfo
 import android.graphics.BitmapFactory
+import android.os.Build
 import android.os.SystemClock
 import android.provider.MediaStore
 import android.view.View
@@ -107,6 +108,7 @@ class CanvasHostLifecycleTest {
 
   @Test
   fun rendererTerminationForgetsFailedPageAndNextShowRecreatesIt() {
+    org.junit.Assume.assumeTrue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
     activityRule.scenario.onActivity { activity -> activity.presentFastPage() }
     assertTrue("initial page never finished", activityRule.scenario.waitForPageFinished())
 
@@ -164,6 +166,7 @@ class CanvasHostLifecycleTest {
 
   @Test
   fun renderedWebViewExportsPngToClipboardAndDownloads() {
+    org.junit.Assume.assumeTrue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
     activityRule.scenario.onActivity { activity -> activity.presentFastPage() }
     assertTrue("widget proof page never finished", activityRule.scenario.waitForPageFinished())
     val activity = activityRule.scenario.readActivity { it }

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission
         android:name="android.permission.NEARBY_WIFI_DEVICES"
-        android:usesPermissionFlags="neverForLocation" />
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="s" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.CAMERA" />

--- a/apps/android/app/src/main/java/ai/openclaw/app/AndroidPermissionPolicy.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/AndroidPermissionPolicy.kt
@@ -1,0 +1,22 @@
+package ai.openclaw.app
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+/** Android runtime-permission behavior shared across UI, services, and node handlers. */
+internal object AndroidPermissionPolicy {
+  fun hasBackgroundLocation(context: Context): Boolean =
+    Build.VERSION.SDK_INT < Build.VERSION_CODES.Q ||
+      ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
+      PackageManager.PERMISSION_GRANTED
+
+  fun hasActivityRecognition(context: Context): Boolean =
+    Build.VERSION.SDK_INT < Build.VERSION_CODES.Q ||
+      ContextCompat.checkSelfPermission(context, Manifest.permission.ACTIVITY_RECOGNITION) ==
+      PackageManager.PERMISSION_GRANTED
+}
+
+internal fun hasTelephonyCapability(context: Context): Boolean = context.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
@@ -4,6 +4,7 @@ import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.ui.OpenClawTheme
 import ai.openclaw.app.ui.RootScreen
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.view.WindowManager
 import android.widget.Toast
@@ -106,13 +107,28 @@ class MainActivity : AppCompatActivity() {
 
   override fun onTopResumedActivityChanged(isTopResumedActivity: Boolean) {
     super.onTopResumedActivityChanged(isTopResumedActivity)
-    // minSdk 31 guarantees this callback and lets multi-resume select the actually interactive task.
+    // Multi-resume selects the actually interactive task on Android 10 and newer.
     updateTopResumedPermissionHost(
       isTopResumedActivity = isTopResumedActivity,
       activate = { permissionRequester.activate(this) },
       deactivate = { permissionRequester.deactivate(this) },
       refreshPermissionSurface = { initializedViewModel?.refreshNodePermissionSurface() },
     )
+  }
+
+  override fun onResume() {
+    super.onResume()
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      permissionRequester.activate(this)
+      initializedViewModel?.refreshNodePermissionSurface()
+    }
+  }
+
+  override fun onPause() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      permissionRequester.deactivate(this)
+    }
+    super.onPause()
   }
 
   override fun onStop() {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
@@ -12,6 +12,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
+import android.os.Build
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
@@ -284,8 +285,7 @@ class NodeForegroundService : Service() {
       ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) ==
         PackageManager.PERMISSION_GRANTED
     val backgroundGranted =
-      ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
-        PackageManager.PERMISSION_GRANTED
+      AndroidPermissionPolicy.hasBackgroundLocation(this)
     return (fineGranted || coarseGranted) && backgroundGranted
   }
 
@@ -369,13 +369,19 @@ internal fun foregroundServiceTypes(
   voiceMode: VoiceCaptureMode,
   backgroundLocationActive: Boolean,
 ): Int {
+  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return 0
   val base = ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
   val voiceTypes =
     when (voiceMode) {
       VoiceCaptureMode.Off -> base
       VoiceCaptureMode.ManualMic,
       VoiceCaptureMode.TalkMode,
-      -> base or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+      ->
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+          base or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+        } else {
+          base
+        }
     }
   return if (backgroundLocationActive) {
     voiceTypes or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -940,11 +940,14 @@ class NodeRuntime private constructor(
       locationPreciseEnabled = { locationPreciseEnabled.value },
     )
 
+  private val callLogAvailable =
+    SensitiveFeatureConfig.callLogEnabled && hasTelephonyCapability(appContext)
+
   private val permissionSnapshot = {
     readAndroidPermissionSnapshot(
       context = appContext,
       smsEnabled = SensitiveFeatureConfig.smsEnabled,
-      callLogEnabled = SensitiveFeatureConfig.callLogEnabled,
+      callLogEnabled = callLogAvailable,
       photosEnabled = SensitiveFeatureConfig.photosEnabled,
       backgroundLocationEnabled = SensitiveFeatureConfig.backgroundLocationEnabled,
     )
@@ -954,7 +957,7 @@ class NodeRuntime private constructor(
     DeviceHandler.withPermissionSnapshot(
       appContext = appContext,
       smsEnabled = SensitiveFeatureConfig.smsEnabled,
-      callLogEnabled = SensitiveFeatureConfig.callLogEnabled,
+      callLogEnabled = callLogAvailable,
       photosEnabled = SensitiveFeatureConfig.photosEnabled,
       permissionSnapshot = permissionSnapshot,
     )
@@ -1018,7 +1021,7 @@ class NodeRuntime private constructor(
       sendSmsAvailable = { SensitiveFeatureConfig.smsEnabled && sms.canSendSms() },
       readSmsAvailable = { SensitiveFeatureConfig.smsEnabled && sms.canReadSms() },
       smsSearchPossible = { SensitiveFeatureConfig.smsEnabled && sms.hasTelephonyFeature() },
-      callLogAvailable = { SensitiveFeatureConfig.callLogEnabled },
+      callLogAvailable = { callLogAvailable },
       photosAvailable = { SensitiveFeatureConfig.photosEnabled },
       installedAppsSharingEnabled = { installedAppsSharingEnabled.value },
       voiceWakeAvailable = {
@@ -1074,7 +1077,7 @@ class NodeRuntime private constructor(
       readSmsAvailable = { SensitiveFeatureConfig.smsEnabled && sms.canReadSms() },
       smsFeatureEnabled = { SensitiveFeatureConfig.smsEnabled },
       smsTelephonyAvailable = { sms.hasTelephonyFeature() },
-      callLogAvailable = { SensitiveFeatureConfig.callLogEnabled },
+      callLogAvailable = { callLogAvailable },
       photosAvailable = { SensitiveFeatureConfig.photosEnabled },
       installedAppsSharingEnabled = { installedAppsSharingEnabled.value },
       debugBuild = { BuildConfig.DEBUG },

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/VoiceNoteRecorderController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/VoiceNoteRecorderController.kt
@@ -3,6 +3,7 @@ package ai.openclaw.app.chat
 import ai.openclaw.app.voice.TalkAudioLevel
 import android.content.Context
 import android.media.MediaRecorder
+import android.os.Build
 import android.os.SystemClock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -274,7 +275,7 @@ internal class AndroidVoiceNoteRecordingEngine(
 
   override fun start(outputFile: File) {
     check(recorder == null)
-    val next = MediaRecorder(context)
+    val next = createMediaRecorder(context)
     try {
       next.setAudioSource(MediaRecorder.AudioSource.MIC)
       next.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
@@ -315,3 +316,11 @@ internal class AndroidVoiceNoteRecordingEngine(
   // killing the recording.
   override fun pollAmplitude(): Int = recorder?.let { active -> runCatching { active.maxAmplitude }.getOrDefault(0) } ?: 0
 }
+
+@Suppress("DEPRECATION")
+private fun createMediaRecorder(context: Context): MediaRecorder =
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+    MediaRecorder(context)
+  } else {
+    MediaRecorder()
+  }

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
@@ -2,14 +2,12 @@ package ai.openclaw.app.gateway
 
 import android.content.Context
 import android.net.ConnectivityManager
-import android.net.DnsResolver
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.os.Build
-import android.os.CancellationSignal
 import android.util.Log
 import androidx.annotation.RequiresApi
 import kotlinx.coroutines.CoroutineScope
@@ -20,7 +18,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
 import org.xbill.DNS.AAAARecord
 import org.xbill.DNS.ARecord
 import org.xbill.DNS.DClass
@@ -46,21 +43,6 @@ import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-
-private fun createDnsResolver(context: Context): DnsResolver =
-  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN) {
-    createContextDnsResolver(context)
-  } else {
-    createLegacyDnsResolver()
-  }
-
-@RequiresApi(Build.VERSION_CODES.CINNAMON_BUN)
-private fun createContextDnsResolver(context: Context): DnsResolver = DnsResolver(context, null)
-
-@Suppress("DEPRECATION")
-private fun createLegacyDnsResolver(): DnsResolver = DnsResolver.getInstance()
 
 internal fun gatewayDiscoveryStatusText(
   localCount: Int,
@@ -91,7 +73,8 @@ class GatewayDiscovery(
 ) {
   private val nsd = context.getSystemService(NsdManager::class.java)
   private val connectivity = context.getSystemService(ConnectivityManager::class.java)
-  private val dns = createDnsResolver(context)
+  private val serviceInfoExecutor: Executor = Executors.newCachedThreadPool()
+  private val systemDns = createGatewaySystemDns(context, serviceInfoExecutor)
   private val serviceType = "_openclaw-gw._tcp."
   private val wideAreaDomain = System.getenv("OPENCLAW_WIDE_AREA_DOMAIN")
   private val logTag = "OpenClaw/GatewayDiscovery"
@@ -109,7 +92,6 @@ class GatewayDiscovery(
   val statusText: StateFlow<String> = _statusText.asStateFlow()
 
   private var unicastJob: Job? = null
-  private val dnsExecutor: Executor = Executors.newCachedThreadPool()
   private val availableNetworks = ConcurrentHashMap.newKeySet<Network>()
   private val serviceInfoCallbacks = ConcurrentHashMap<String, Any>()
 
@@ -237,7 +219,7 @@ class GatewayDiscovery(
 
     serviceInfoCallbacks[id] = callback
     try {
-      nsd.registerServiceInfoCallback(serviceInfo, dnsExecutor, callback)
+      nsd.registerServiceInfoCallback(serviceInfo, serviceInfoExecutor, callback)
     } catch (_: Throwable) {
       serviceInfoCallbacks.remove(id, callback)
     }
@@ -488,10 +470,11 @@ class GatewayDiscovery(
   }
 
   private suspend fun queryViaSystemDns(query: Message): Message? {
+    val dns = systemDns ?: return null
     val network = preferredDnsNetwork()
     val bytes =
       try {
-        rawQuery(network, query.toWire())
+        dns.rawQuery(network, query.toWire())
       } catch (_: Throwable) {
         return null
       }
@@ -608,35 +591,6 @@ class GatewayDiscovery(
       null
     }
   }
-
-  private suspend fun rawQuery(
-    network: android.net.Network?,
-    wireQuery: ByteArray,
-  ): ByteArray =
-    suspendCancellableCoroutine { cont ->
-      val signal = CancellationSignal()
-      cont.invokeOnCancellation { signal.cancel() }
-
-      dns.rawQuery(
-        network,
-        wireQuery,
-        DnsResolver.FLAG_EMPTY,
-        dnsExecutor,
-        signal,
-        object : DnsResolver.Callback<ByteArray> {
-          override fun onAnswer(
-            answer: ByteArray,
-            rcode: Int,
-          ) {
-            cont.resume(answer)
-          }
-
-          override fun onError(error: DnsResolver.DnsException) {
-            cont.resumeWithException(error)
-          }
-        },
-      )
-    }
 
   private fun txtValue(
     records: List<TXTRecord>,

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySystemDns.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySystemDns.kt
@@ -1,0 +1,24 @@
+package ai.openclaw.app.gateway
+
+import android.content.Context
+import android.net.Network
+import android.os.Build
+import java.util.concurrent.Executor
+
+/** API-neutral system DNS seam; API 28 falls through to dnsjava resolution. */
+internal interface GatewaySystemDns {
+  suspend fun rawQuery(
+    network: Network?,
+    wireQuery: ByteArray,
+  ): ByteArray
+}
+
+internal fun createGatewaySystemDns(
+  context: Context,
+  executor: Executor,
+): GatewaySystemDns? =
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+    GatewaySystemDnsApi29(context, executor)
+  } else {
+    null
+  }

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySystemDnsApi29.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySystemDnsApi29.kt
@@ -1,0 +1,63 @@
+package ai.openclaw.app.gateway
+
+import android.content.Context
+import android.net.DnsResolver
+import android.net.Network
+import android.os.Build
+import android.os.CancellationSignal
+import androidx.annotation.RequiresApi
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.util.concurrent.Executor
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+@RequiresApi(Build.VERSION_CODES.Q)
+internal class GatewaySystemDnsApi29(
+  context: Context,
+  private val executor: Executor,
+) : GatewaySystemDns {
+  private val resolver = createDnsResolver(context)
+
+  override suspend fun rawQuery(
+    network: Network?,
+    wireQuery: ByteArray,
+  ): ByteArray =
+    suspendCancellableCoroutine { cont ->
+      val signal = CancellationSignal()
+      cont.invokeOnCancellation { signal.cancel() }
+      resolver.rawQuery(
+        network,
+        wireQuery,
+        DnsResolver.FLAG_EMPTY,
+        executor,
+        signal,
+        object : DnsResolver.Callback<ByteArray> {
+          override fun onAnswer(
+            answer: ByteArray,
+            rcode: Int,
+          ) {
+            cont.resume(answer)
+          }
+
+          override fun onError(error: DnsResolver.DnsException) {
+            cont.resumeWithException(error)
+          }
+        },
+      )
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.Q)
+private fun createDnsResolver(context: Context): DnsResolver =
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN) {
+    createContextDnsResolver(context)
+  } else {
+    createLegacyDnsResolver()
+  }
+
+@RequiresApi(Build.VERSION_CODES.CINNAMON_BUN)
+private fun createContextDnsResolver(context: Context): DnsResolver = DnsResolver(context, null)
+
+@Suppress("DEPRECATION")
+@RequiresApi(Build.VERSION_CODES.Q)
+private fun createLegacyDnsResolver(): DnsResolver = DnsResolver.getInstance()

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/AndroidPermissionSnapshot.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/AndroidPermissionSnapshot.kt
@@ -1,6 +1,8 @@
 package ai.openclaw.app.node
 
+import ai.openclaw.app.AndroidPermissionPolicy
 import ai.openclaw.app.hasPhotoReadPermission
+import ai.openclaw.app.hasTelephonyCapability
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
@@ -63,7 +65,7 @@ internal fun readAndroidPermissionSnapshot(
 
   val locationFine = hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)
   val locationCoarse = hasPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
-  val telephonyAvailable = context.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)
+  val telephonyAvailable = hasTelephonyCapability(context)
 
   return AndroidPermissionSnapshot(
     camera = hasPermission(Manifest.permission.CAMERA),
@@ -73,7 +75,7 @@ internal fun readAndroidPermissionSnapshot(
     locationBackground =
       backgroundLocationEnabled &&
         (locationFine || locationCoarse) &&
-        hasPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION),
+        AndroidPermissionPolicy.hasBackgroundLocation(context),
     smsSend = smsEnabled && telephonyAvailable && hasPermission(Manifest.permission.SEND_SMS),
     smsRead = smsEnabled && telephonyAvailable && hasPermission(Manifest.permission.READ_SMS),
     notificationListener = DeviceNotificationListenerService.isAccessEnabled(context),
@@ -85,7 +87,7 @@ internal fun readAndroidPermissionSnapshot(
     contactsWrite = hasPermission(Manifest.permission.WRITE_CONTACTS),
     calendarRead = hasPermission(Manifest.permission.READ_CALENDAR),
     calendarWrite = hasPermission(Manifest.permission.WRITE_CALENDAR),
-    callLog = callLogEnabled && hasPermission(Manifest.permission.READ_CALL_LOG),
-    motion = hasPermission(Manifest.permission.ACTIVITY_RECOGNITION),
+    callLog = callLogEnabled && telephonyAvailable && hasPermission(Manifest.permission.READ_CALL_LOG),
+    motion = AndroidPermissionPolicy.hasActivityRecognition(context),
   )
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/DeviceHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/DeviceHandler.kt
@@ -3,6 +3,7 @@ package ai.openclaw.app.node
 import ai.openclaw.app.BuildConfig
 import ai.openclaw.app.SensitiveFeatureConfig
 import ai.openclaw.app.gateway.GatewaySession
+import ai.openclaw.app.hasTelephonyCapability
 import android.annotation.SuppressLint
 import android.app.ActivityManager
 import android.content.Context
@@ -353,7 +354,7 @@ class DeviceHandler private constructor(
 
   private fun permissionsPayloadJson(): String {
     val snapshot = permissionSnapshot()
-    val canSendSms = appContext.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)
+    val telephonyAvailable = hasTelephonyCapability(appContext)
     return buildJsonObject {
       put(
         "permissions",
@@ -387,7 +388,7 @@ class DeviceHandler private constructor(
                 JsonPrimitive(
                   if (hasAnySmsCapability(
                       smsEnabled,
-                      canSendSms,
+                      telephonyAvailable,
                       snapshot.smsSend,
                       snapshot.smsRead,
                     )
@@ -403,7 +404,7 @@ class DeviceHandler private constructor(
                 JsonPrimitive(
                   isSmsPromptable(
                     smsEnabled,
-                    canSendSms,
+                    telephonyAvailable,
                     snapshot.smsSend,
                     snapshot.smsRead,
                   ),
@@ -416,14 +417,14 @@ class DeviceHandler private constructor(
                     "send",
                     permissionStateJson(
                       granted = snapshot.smsSend,
-                      promptableWhenDenied = smsEnabled && canSendSms,
+                      promptableWhenDenied = smsEnabled && telephonyAvailable,
                     ),
                   )
                   put(
                     "read",
                     permissionStateJson(
                       granted = snapshot.smsRead,
-                      promptableWhenDenied = smsEnabled && canSendSms,
+                      promptableWhenDenied = smsEnabled && telephonyAvailable,
                     ),
                   )
                 },
@@ -469,7 +470,7 @@ class DeviceHandler private constructor(
             "callLog",
             permissionStateJson(
               granted = snapshot.callLog,
-              promptableWhenDenied = callLogEnabled,
+              promptableWhenDenied = callLogEnabled && telephonyAvailable,
             ),
           )
           put(
@@ -610,7 +611,8 @@ class DeviceHandler private constructor(
     }
 
   private fun mapThermalState(powerManager: PowerManager?): String {
-    val thermal = powerManager?.currentThermalStatus ?: return "nominal"
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return "unknown"
+    val thermal = powerManager?.currentThermalStatus ?: return "unknown"
     return when (thermal) {
       PowerManager.THERMAL_STATUS_NONE, PowerManager.THERMAL_STATUS_LIGHT -> "nominal"
       PowerManager.THERMAL_STATUS_MODERATE -> "fair"

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/LocationCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/LocationCaptureManager.kt
@@ -7,6 +7,7 @@ import android.location.Location
 import android.location.LocationManager
 import android.os.CancellationSignal
 import androidx.core.content.ContextCompat
+import androidx.core.location.LocationManagerCompat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
@@ -113,7 +114,7 @@ class LocationCaptureManager(
         suspendCancellableCoroutine<Location?> { cont ->
           val signal = CancellationSignal()
           cont.invokeOnCancellation { signal.cancel() }
-          manager.getCurrentLocation(resolved, signal, context.mainExecutor) { location ->
+          LocationManagerCompat.getCurrentLocation(manager, resolved, signal, context.mainExecutor) { location ->
             cont.resume(location) { _, _, _ -> }
           }
         }

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/LocationHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/LocationHandler.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.node
 
+import ai.openclaw.app.AndroidPermissionPolicy
 import ai.openclaw.app.LocationMode
 import ai.openclaw.app.gateway.GatewaySession
 import android.Manifest
@@ -41,9 +42,7 @@ private class DefaultLocationDataSource(
     ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) ==
       PackageManager.PERMISSION_GRANTED
 
-  override fun hasBackgroundPermission(context: Context): Boolean =
-    ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
-      PackageManager.PERMISSION_GRANTED
+  override fun hasBackgroundPermission(context: Context): Boolean = AndroidPermissionPolicy.hasBackgroundLocation(context)
 
   override suspend fun fetchLocation(
     desiredProviders: List<String>,

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
@@ -1,14 +1,13 @@
 package ai.openclaw.app.node
 
+import ai.openclaw.app.AndroidPermissionPolicy
 import ai.openclaw.app.gateway.GatewaySession
-import android.Manifest
 import android.content.Context
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.os.SystemClock
-import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -94,9 +93,7 @@ private object SystemMotionDataSource : MotionDataSource {
     return sensorManager?.getDefaultSensor(Sensor.TYPE_STEP_COUNTER) != null
   }
 
-  override fun hasPermission(context: Context): Boolean =
-    ContextCompat.checkSelfPermission(context, Manifest.permission.ACTIVITY_RECOGNITION) ==
-      android.content.pm.PackageManager.PERMISSION_GRANTED
+  override fun hasPermission(context: Context): Boolean = AndroidPermissionPolicy.hasActivityRecognition(context)
 
   override suspend fun activity(
     context: Context,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.ui
 
+import ai.openclaw.app.AndroidPermissionPolicy
 import ai.openclaw.app.GatewayConnectionProblem
 import ai.openclaw.app.GatewayNodeCapabilityApproval
 import ai.openclaw.app.LocationMode
@@ -10,6 +11,7 @@ import ai.openclaw.app.gateway.GatewayEndpoint
 import ai.openclaw.app.gateway.isLocalCleartextGatewayHost
 import ai.openclaw.app.gateway.normalizeGatewayTlsFingerprintInput
 import ai.openclaw.app.hasPhotoReadPermission
+import ai.openclaw.app.hasTelephonyCapability
 import ai.openclaw.app.i18n.NativeText
 import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.i18n.nativeText
@@ -3164,19 +3166,18 @@ private fun rememberPermissionState(
   var notificationListenerGranted by rememberSaveable { mutableStateOf(DeviceNotificationListenerService.isAccessEnabled(context)) }
   val photosAvailable = SensitiveFeatureConfig.photosEnabled
   val motionAvailable = remember(context) { hasMotionCapabilities(context) }
-  val smsAvailable =
-    remember(context) {
-      SensitiveFeatureConfig.smsEnabled &&
-        context.packageManager?.hasSystemFeature(PackageManager.FEATURE_TELEPHONY) == true
-    }
+  val telephonyAvailable = remember(context) { hasTelephonyCapability(context) }
+  val smsAvailable = SensitiveFeatureConfig.smsEnabled && telephonyAvailable
   val currentSmsGranted =
     !smsAvailable ||
       (
         hasPermission(context, Manifest.permission.SEND_SMS) &&
           hasPermission(context, Manifest.permission.READ_SMS)
       )
-  val callLogAvailable = SensitiveFeatureConfig.callLogEnabled
-  var motionGranted by rememberSaveable { mutableStateOf(!motionAvailable || hasPermission(context, Manifest.permission.ACTIVITY_RECOGNITION)) }
+  val callLogAvailable = SensitiveFeatureConfig.callLogEnabled && telephonyAvailable
+  var motionGranted by rememberSaveable {
+    mutableStateOf(!motionAvailable || AndroidPermissionPolicy.hasActivityRecognition(context))
+  }
   var smsGranted by rememberSaveable { mutableStateOf(currentSmsGranted) }
   var callLogGranted by rememberSaveable { mutableStateOf(!callLogAvailable || hasPermission(context, Manifest.permission.READ_CALL_LOG)) }
   val lifecycleOwner = LocalLifecycleOwner.current
@@ -3219,7 +3220,12 @@ private fun rememberPermissionState(
         } else {
           true
         }
-      motionGranted = permissions[Manifest.permission.ACTIVITY_RECOGNITION] ?: motionGranted
+      motionGranted =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+          permissions[Manifest.permission.ACTIVITY_RECOGNITION] ?: motionGranted
+        } else {
+          true
+        }
       smsGranted =
         mergedRequiredPermissionGrantState(
           permissions = permissions,
@@ -3287,7 +3293,9 @@ private fun rememberPermissionState(
       },
       if (motionAvailable) {
         PermissionRowModel(PermissionRowId.Motion, nativeText("Motion"), nativeText("Share steps and activity"), Icons.Default.Sensors, motionGranted) {
-          request(Manifest.permission.ACTIVITY_RECOGNITION)
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            request(Manifest.permission.ACTIVITY_RECOGNITION)
+          }
         }
       } else {
         null

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OpenClawTheme.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OpenClawTheme.kt
@@ -2,10 +2,13 @@ package ai.openclaw.app.ui
 
 import ai.openclaw.app.AppearanceThemeMode
 import android.app.Activity
+import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
@@ -23,7 +26,12 @@ fun OpenClawTheme(
 ) {
   val context = LocalContext.current
   val isDark = themeMode.isDark(systemDark = isSystemInDarkTheme())
-  val colorScheme = if (isDark) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+  val colorScheme =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      if (isDark) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+    } else {
+      if (isDark) darkColorScheme() else lightColorScheme()
+    }
   val mobileColors = if (isDark) darkMobileColors() else lightMobileColors()
 
   OpenClawSystemBarAppearance(lightAppearance = !isDark)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.ui
 
 import ai.openclaw.app.AndroidLicenseNotice
+import ai.openclaw.app.AndroidPermissionPolicy
 import ai.openclaw.app.AppLanguage
 import ai.openclaw.app.AppearanceThemeMode
 import ai.openclaw.app.BuildConfig
@@ -839,6 +840,8 @@ private fun AudioInputDevicePanel(
         subtitle =
           if (preferredDeviceKey != null && !preferredAvailable) {
             nativeString("Preferred microphone unavailable; using automatic routing.")
+          } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            nativeString("Uses the system-selected microphone.")
           } else {
             nativeString("Prioritizes connected Bluetooth microphones.")
           },
@@ -1289,7 +1292,11 @@ private fun PhoneCapabilitiesScreen(
   var pendingPreciseLocation by rememberSaveable { mutableStateOf(false) }
   val platformBackgroundPermissionLabel =
     remember(context) {
-      context.packageManager.backgroundPermissionOptionLabel.toString()
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        context.packageManager.backgroundPermissionOptionLabel.toString()
+      } else {
+        ""
+      }
     }
   val backgroundPermissionLabel = resolvedBackgroundPermissionLabel(platformBackgroundPermissionLabel)
   val cameraPermissionLauncher =
@@ -1318,8 +1325,12 @@ private fun PhoneCapabilitiesScreen(
           )
         LocationMode.Always -> {
           if (foregroundGranted) {
-            viewModel.setLocationMode(LocationMode.WhileUsing)
-            showBackgroundLocationExplanation = true
+            if (hasBackgroundLocationPermission(context)) {
+              viewModel.setLocationMode(LocationMode.Always)
+            } else {
+              viewModel.setLocationMode(LocationMode.WhileUsing)
+              showBackgroundLocationExplanation = true
+            }
           } else {
             viewModel.setLocationMode(LocationMode.Off)
             pendingAlwaysPreviousModeRaw = null
@@ -3163,7 +3174,7 @@ private fun hasLocationPermission(context: Context): Boolean =
   hasPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ||
     hasPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION)
 
-private fun hasBackgroundLocationPermission(context: Context): Boolean = hasPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+private fun hasBackgroundLocationPermission(context: Context): Boolean = AndroidPermissionPolicy.hasBackgroundLocation(context)
 
 private fun openNotificationListenerSettings(context: Context) {
   val intent = Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatDictation.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatDictation.kt
@@ -5,10 +5,12 @@ import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.ui.design.ClawTheme
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.speech.RecognitionListener
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
@@ -90,7 +92,7 @@ internal class AndroidChatDictationRecognizer(
 ) : ChatDictationRecognizer {
   private val appContext = context.applicationContext
   override val isAvailable: Boolean =
-    runCatching { SpeechRecognizer.isOnDeviceRecognitionAvailable(appContext) }.getOrDefault(false)
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && isOnDeviceRecognitionAvailable(appContext)
   private var generation = 0L
   private var recognizer: SpeechRecognizer? = null
 
@@ -98,11 +100,11 @@ internal class AndroidChatDictationRecognizer(
     generation += 1
     val operation = generation
     retireRecognizer()
-    if (!isAvailable) {
-      onEvent(ChatDictationRecognitionEvent.Error(SpeechRecognizer.ERROR_SERVER_DISCONNECTED))
+    if (!isAvailable || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+      onEvent(ChatDictationRecognitionEvent.Error(SpeechRecognizer.ERROR_CLIENT))
       return
     }
-    val active = SpeechRecognizer.createOnDeviceSpeechRecognizer(appContext)
+    val active = createOnDeviceSpeechRecognizer(appContext)
     active.setRecognitionListener(
       object : RecognitionListener {
         override fun onReadyForSpeech(params: Bundle?) {
@@ -192,6 +194,12 @@ internal class AndroidChatDictationRecognizer(
     runCatching { active?.destroy() }
   }
 }
+
+@RequiresApi(Build.VERSION_CODES.S)
+private fun isOnDeviceRecognitionAvailable(context: Context): Boolean = runCatching { SpeechRecognizer.isOnDeviceRecognitionAvailable(context) }.getOrDefault(false)
+
+@RequiresApi(Build.VERSION_CODES.S)
+private fun createOnDeviceSpeechRecognizer(context: Context): SpeechRecognizer = SpeechRecognizer.createOnDeviceSpeechRecognizer(context)
 
 internal class ChatDictationController(
   private val recognizer: ChatDictationRecognizer,
@@ -354,12 +362,19 @@ internal fun dictationFailureForError(code: Int): ChatDictationFailure =
     SpeechRecognizer.ERROR_NO_MATCH,
     SpeechRecognizer.ERROR_SPEECH_TIMEOUT,
     -> ChatDictationFailure.NoSpeech
-    SpeechRecognizer.ERROR_SERVER_DISCONNECTED,
-    SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED,
-    SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE,
-    -> ChatDictationFailure.Unavailable
-    else -> ChatDictationFailure.Generic
+    else ->
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && isOnDeviceRecognitionUnavailableError(code)) {
+        ChatDictationFailure.Unavailable
+      } else {
+        ChatDictationFailure.Generic
+      }
   }
+
+@RequiresApi(Build.VERSION_CODES.S)
+private fun isOnDeviceRecognitionUnavailableError(code: Int): Boolean =
+  code == SpeechRecognizer.ERROR_SERVER_DISCONNECTED ||
+    code == SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED ||
+    code == SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE
 
 @Composable
 internal fun rememberChatDictationController(viewModel: MainViewModel): ChatDictationController {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt
@@ -216,11 +216,13 @@ internal fun ChatInlineWidget(
                 leadingIcon = { Icon(Icons.Default.ContentCopy, contentDescription = null) },
                 onClick = { export(ChatWidgetExportDestination.Clipboard) },
               )
-              DropdownMenuItem(
-                text = { Text(nativeString("Save image")) },
-                leadingIcon = { Icon(Icons.Default.Download, contentDescription = null) },
-                onClick = { export(ChatWidgetExportDestination.Downloads) },
-              )
+              if (canSaveChatWidgetToDownloads()) {
+                DropdownMenuItem(
+                  text = { Text(nativeString("Save image")) },
+                  leadingIcon = { Icon(Icons.Default.Download, contentDescription = null) },
+                  onClick = { export(ChatWidgetExportDestination.Downloads) },
+                )
+              }
             }
           }
         }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWidgetExport.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWidgetExport.kt
@@ -10,12 +10,14 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Rect
+import android.os.Build
 import android.os.Environment
 import android.os.Handler
 import android.os.Looper
 import android.provider.MediaStore
 import android.view.PixelCopy
 import android.webkit.WebView
+import androidx.annotation.RequiresApi
 import androidx.core.content.FileProvider
 import androidx.core.graphics.createBitmap
 import kotlinx.coroutines.Dispatchers
@@ -65,7 +67,13 @@ internal suspend fun exportChatWidgetImage(
     val fileName = widgetExportFileName(title)
     when (destination) {
       ChatWidgetExportDestination.Clipboard -> copyChatWidgetImage(context, bitmap, fileName)
-      ChatWidgetExportDestination.Downloads -> saveChatWidgetImage(context, bitmap, fileName)
+      ChatWidgetExportDestination.Downloads -> {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+          saveChatWidgetImage(context, bitmap, fileName)
+        } else {
+          error("saving widget images requires Android 10")
+        }
+      }
     }
   } finally {
     bitmap.recycle()
@@ -208,6 +216,9 @@ private fun pruneExpiredWidgetExportDirectories(
     }.forEach(File::deleteRecursively)
 }
 
+internal fun canSaveChatWidgetToDownloads(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+
+@RequiresApi(Build.VERSION_CODES.Q)
 private suspend fun saveChatWidgetImage(
   context: Context,
   bitmap: Bitmap,

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
@@ -9,9 +9,11 @@ import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.AudioRouting
 import android.media.MediaRecorder
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import androidx.annotation.RequiresApi
 import java.net.URLDecoder
 import java.net.URLEncoder
 
@@ -84,6 +86,7 @@ internal class AndroidAudioInputSession private constructor(
       val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
       return audioManager
         .getDevices(AudioManager.GET_DEVICES_INPUTS)
+        .filter { device -> isSupportedAudioInput(device.type) }
         .map { device ->
           AudioInputDeviceOption(
             key = audioInputDeviceKey(device),
@@ -201,9 +204,9 @@ internal class AndroidAudioInputSession private constructor(
   ): Boolean {
     val communicationDevice =
       if (preferredInput == null) {
-        selectBluetoothDevice(audioManager.availableCommunicationDevices, requestedCommunicationDevice)
+        selectBluetoothDevice(availableCommunicationDevices(audioManager), requestedCommunicationDevice)
       } else {
-        selectCommunicationDevice(audioManager.availableCommunicationDevices, preferredInput)
+        selectCommunicationDevice(availableCommunicationDevices(audioManager), preferredInput)
       }
     val communicationSelected = bluetoothCommunicationRoute.update(audioManager, communicationRouteOwner, communicationDevice)
     requestedCommunicationDevice = communicationDevice.takeIf { communicationSelected }
@@ -302,6 +305,16 @@ private class BluetoothCommunicationRoute {
   ): Boolean {
     if (owner < latestOwner) return false
     latestOwner = owner
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return false
+    return updateApi31(audioManager, owner, device)
+  }
+
+  @RequiresApi(Build.VERSION_CODES.S)
+  private fun updateApi31(
+    audioManager: AudioManager,
+    owner: Long,
+    device: AudioDeviceInfo?,
+  ): Boolean {
     if (device == null) {
       if (activeOwner != null) audioManager.clearCommunicationDevice()
       activeOwner = null
@@ -322,12 +335,21 @@ private class BluetoothCommunicationRoute {
     owner: Long,
   ) {
     if (activeOwner != owner || owner < latestOwner) return
-    audioManager.clearCommunicationDevice()
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      audioManager.clearCommunicationDevice()
+    }
     activeOwner = null
   }
 }
 
 private val bluetoothCommunicationRoute = BluetoothCommunicationRoute()
+
+private fun availableCommunicationDevices(audioManager: AudioManager): List<AudioDeviceInfo> =
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+    audioManager.availableCommunicationDevices
+  } else {
+    emptyList()
+  }
 
 /** Converts AudioRecord's negative return codes into capture-session failures. */
 internal fun checkAudioRecordReadResult(result: Int): Int {
@@ -389,7 +411,12 @@ internal fun audioInputDeviceKey(device: AudioDeviceInfo): String = audioInputDe
 internal fun resolvePreferredAudioInput(
   devices: List<AudioDeviceInfo>,
   preferredDeviceKey: String?,
-): AudioDeviceInfo? = preferredDeviceKey?.let { key -> devices.firstOrNull { audioInputDeviceKey(it) == key } }
+): AudioDeviceInfo? =
+  preferredDeviceKey?.let { key ->
+    devices.firstOrNull { device ->
+      isSupportedAudioInput(device.type) && audioInputDeviceKey(device) == key
+    }
+  }
 
 internal fun audioInputDeviceKey(
   type: Int,
@@ -412,12 +439,18 @@ internal fun audioInputDeviceOptionFromKey(key: String): AudioInputDeviceOption?
   )
 }
 
-private fun bluetoothPriority(type: Int): Int? =
-  when (type) {
+private fun bluetoothPriority(type: Int): Int? {
+  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return null
+  return when (type) {
     AudioDeviceInfo.TYPE_BLE_HEADSET -> 0
     AudioDeviceInfo.TYPE_BLUETOOTH_SCO -> 1
     else -> null
   }
+}
+
+private fun isSupportedAudioInput(type: Int): Boolean =
+  Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ||
+    type != AudioDeviceInfo.TYPE_BLUETOOTH_SCO
 
 private fun sameDevice(
   left: AudioDeviceInfo?,

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/VoiceWakeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/VoiceWakeManager.kt
@@ -7,12 +7,14 @@ import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.speech.RecognitionListener
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
+import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -73,7 +75,7 @@ internal class AndroidOnDeviceVoiceWakeRecognizer(
   private val appContext = context.applicationContext
   private val mainHandler = Handler(Looper.getMainLooper())
   override val isAvailable: Boolean =
-    runCatching { SpeechRecognizer.isOnDeviceRecognitionAvailable(appContext) }.getOrDefault(false)
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && isOnDeviceRecognitionAvailable(appContext)
   private val latestOperationId = AtomicLong(0)
   private val platformOwnerOperationId = AtomicLong(0)
   private var recognizer: SpeechRecognizer? = null
@@ -96,9 +98,9 @@ internal class AndroidOnDeviceVoiceWakeRecognizer(
       }
       retireRecognizer()
       platformOwnerOperationId.set(operationId)
-      if (!isAvailable) {
+      if (!isAvailable || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
         platformOwnerOperationId.compareAndSet(operationId, 0)
-        onEvent(VoiceWakeRecognitionEvent.Error(SpeechRecognizer.ERROR_SERVER_DISCONNECTED))
+        onEvent(VoiceWakeRecognitionEvent.Error(SpeechRecognizer.ERROR_CLIENT))
         return@runOnMain
       }
       val session = VoiceWakeRecognitionSession(onEvent)
@@ -141,6 +143,7 @@ internal class AndroidOnDeviceVoiceWakeRecognizer(
     }
   }
 
+  @RequiresApi(Build.VERSION_CODES.S)
   private fun createRecognizer(session: VoiceWakeRecognitionSession): SpeechRecognizer =
     SpeechRecognizer.createOnDeviceSpeechRecognizer(appContext).also { active ->
       active.setRecognitionListener(
@@ -418,9 +421,9 @@ internal class VoiceWakeManager(
             _isListening.value = false
             if (event.code == SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS) {
               _statusText.value = nativeText("Microphone permission required")
-            } else if (event.code == SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED) {
+            } else if (isLanguageNotSupportedError(event.code)) {
               _statusText.value = nativeText("Device language not supported")
-            } else if (event.code == SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE) {
+            } else if (isLanguageUnavailableError(event.code)) {
               _statusText.value = nativeText("On-device language model unavailable")
             } else {
               scheduleRestartLocked(delayMs = retryDelayMs(event.code))
@@ -483,15 +486,18 @@ internal class VoiceWakeManager(
   }
 
   private fun retryDelayMs(errorCode: Int): Long =
-    when (errorCode) {
-      SpeechRecognizer.ERROR_TOO_MANY_REQUESTS -> 15_000L
-      SpeechRecognizer.ERROR_RECOGNIZER_BUSY,
-      SpeechRecognizer.ERROR_SERVER,
-      SpeechRecognizer.ERROR_SERVER_DISCONNECTED,
-      SpeechRecognizer.ERROR_AUDIO,
-      SpeechRecognizer.ERROR_CLIENT,
-      -> 1_500L
-      else -> restartDelayMs
+    when {
+      isTooManyRequestsError(errorCode) -> 15_000L
+      isServerDisconnectedError(errorCode) -> 1_500L
+      else ->
+        when (errorCode) {
+          SpeechRecognizer.ERROR_RECOGNIZER_BUSY,
+          SpeechRecognizer.ERROR_SERVER,
+          SpeechRecognizer.ERROR_AUDIO,
+          SpeechRecognizer.ERROR_CLIENT,
+          -> 1_500L
+          else -> restartDelayMs
+        }
     }
 
   private fun stopSessionLocked(destroy: Boolean): RecognizerAction? {
@@ -528,6 +534,17 @@ internal class VoiceWakeManager(
     }
   }
 }
+
+@RequiresApi(Build.VERSION_CODES.S)
+private fun isOnDeviceRecognitionAvailable(context: Context): Boolean = runCatching { SpeechRecognizer.isOnDeviceRecognitionAvailable(context) }.getOrDefault(false)
+
+private fun isLanguageNotSupportedError(code: Int): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && code == SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED
+
+private fun isLanguageUnavailableError(code: Int): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && code == SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE
+
+private fun isTooManyRequestsError(code: Int): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && code == SpeechRecognizer.ERROR_TOO_MANY_REQUESTS
+
+private fun isServerDisconnectedError(code: Int): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && code == SpeechRecognizer.ERROR_SERVER_DISCONNECTED
 
 internal class PreviewVoiceWakeRecognizer : VoiceWakeRecognizer {
   override val isAvailable: Boolean = true

--- a/apps/android/app/src/test/java/ai/openclaw/app/AndroidApiCompatibilityTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/AndroidApiCompatibilityTest.kt
@@ -1,0 +1,178 @@
+package ai.openclaw.app
+
+import ai.openclaw.app.gateway.GatewayDiscovery
+import ai.openclaw.app.gateway.createGatewaySystemDns
+import ai.openclaw.app.node.DeviceHandler
+import ai.openclaw.app.node.readAndroidPermissionSnapshot
+import ai.openclaw.app.ui.chat.AndroidChatDictationRecognizer
+import ai.openclaw.app.ui.chat.ChatDictationFailure
+import ai.openclaw.app.ui.chat.canSaveChatWidgetToDownloads
+import ai.openclaw.app.ui.chat.dictationFailureForError
+import ai.openclaw.app.voice.AndroidOnDeviceVoiceWakeRecognizer
+import android.Manifest
+import android.app.Application
+import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo
+import android.speech.SpeechRecognizer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.util.concurrent.Executor
+
+@RunWith(RobolectricTestRunner::class)
+class AndroidApiCompatibilityTest {
+  @Test
+  @Config(sdk = [28])
+  fun api28UsesLegacyPermissionSemanticsWithoutNewerServices() {
+    val app = appContext()
+    shadowOf(app).grantPermissions(
+      Manifest.permission.ACCESS_COARSE_LOCATION,
+      Manifest.permission.READ_CALL_LOG,
+    )
+
+    val snapshot =
+      readAndroidPermissionSnapshot(
+        context = app,
+        smsEnabled = true,
+        callLogEnabled = true,
+        photosEnabled = false,
+        backgroundLocationEnabled = true,
+      )
+
+    assertTrue(snapshot.locationBackground)
+    assertTrue(snapshot.motion)
+    assertFalse(snapshot.callLog)
+    shadowOf(app.packageManager).setSystemFeature(PackageManager.FEATURE_TELEPHONY, true)
+    assertTrue(
+      readAndroidPermissionSnapshot(
+        context = app,
+        smsEnabled = true,
+        callLogEnabled = true,
+        photosEnabled = false,
+        backgroundLocationEnabled = true,
+      ).callLog,
+    )
+    assertTrue(AndroidPermissionPolicy.hasBackgroundLocation(app))
+    assertTrue(AndroidPermissionPolicy.hasActivityRecognition(app))
+    assertNull(createGatewaySystemDns(app, directExecutor))
+    assertFalse(AndroidChatDictationRecognizer(app).isAvailable)
+    assertFalse(AndroidOnDeviceVoiceWakeRecognizer(app).isAvailable)
+    assertFalse(canSaveChatWidgetToDownloads())
+  }
+
+  @Test
+  @Config(sdk = [28])
+  fun api28ConstructsDiscoveryAndReportsUnknownThermalState() {
+    val app = appContext()
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    try {
+      GatewayDiscovery(app, scope)
+    } finally {
+      scope.cancel()
+    }
+
+    val result = DeviceHandler(app).handleDeviceStatus(null)
+    val payload = Json.parseToJsonElement(result.payloadJson.orEmpty()).jsonObject
+    assertEquals(
+      "unknown",
+      payload
+        .getValue("thermal")
+        .jsonObject
+        .getValue("state")
+        .jsonPrimitive.content,
+    )
+  }
+
+  @Test
+  @Config(sdk = [28])
+  fun api28ForegroundServiceTypesAreIgnored() {
+    val controller = Robolectric.buildService(NodeForegroundService::class.java).create()
+    try {
+      assertEquals(0, foregroundServiceTypes(VoiceCaptureMode.TalkMode, backgroundLocationActive = true))
+    } finally {
+      controller.destroy()
+    }
+  }
+
+  @Test
+  @Config(sdk = [29])
+  fun api29RequiresNewRuntimePermissionsAndOmitsMicrophoneServiceType() {
+    val app = appContext()
+    assertFalse(AndroidPermissionPolicy.hasBackgroundLocation(app))
+    assertFalse(AndroidPermissionPolicy.hasActivityRecognition(app))
+    assertTrue(canSaveChatWidgetToDownloads())
+    assertEquals(
+      ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE or
+        ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION,
+      foregroundServiceTypes(VoiceCaptureMode.TalkMode, backgroundLocationActive = true),
+    )
+  }
+
+  @Test
+  @Config(sdk = [30])
+  fun api30AddsMicrophoneForegroundServiceType() {
+    assertEquals(
+      ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE or
+        ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE,
+      foregroundServiceTypes(VoiceCaptureMode.ManualMic, backgroundLocationActive = false),
+    )
+  }
+
+  @Test
+  @Config(sdk = [31])
+  fun api31ActivatesModernSpeechAndCommunicationContracts() {
+    val app = appContext()
+
+    assertNotNull(createGatewaySystemDns(app, directExecutor))
+    assertEquals(
+      ChatDictationFailure.Unavailable,
+      dictationFailureForError(SpeechRecognizer.ERROR_SERVER_DISCONNECTED),
+    )
+    assertEquals(
+      ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE or
+        ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE,
+      foregroundServiceTypes(VoiceCaptureMode.TalkMode, backgroundLocationActive = false),
+    )
+    // These calls cross the API 31 speech boundary even when Robolectric has no
+    // installed on-device recognition service.
+    AndroidChatDictationRecognizer(app).isAvailable
+    AndroidOnDeviceVoiceWakeRecognizer(app).isAvailable
+  }
+
+  @Test
+  @Config(sdk = [36])
+  fun currentApiRetainsModernPermissionAndServiceContracts() {
+    val app = appContext()
+
+    assertFalse(AndroidPermissionPolicy.hasBackgroundLocation(app))
+    assertFalse(AndroidPermissionPolicy.hasActivityRecognition(app))
+    assertTrue(canSaveChatWidgetToDownloads())
+    assertNotNull(createGatewaySystemDns(app, directExecutor))
+    assertEquals(
+      ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE or
+        ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE or
+        ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION,
+      foregroundServiceTypes(VoiceCaptureMode.ManualMic, backgroundLocationActive = true),
+    )
+  }
+
+  private fun appContext(): Application = RuntimeEnvironment.getApplication()
+
+  private val directExecutor = Executor(Runnable::run)
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/MainActivityLifecycleTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/MainActivityLifecycleTest.kt
@@ -8,6 +8,7 @@ import android.database.Cursor
 import android.net.Uri
 import android.os.Looper
 import androidx.lifecycle.SavedStateHandle
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -20,6 +21,7 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowContentResolver
+import org.robolectric.util.ReflectionHelpers
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -27,6 +29,27 @@ import java.util.concurrent.TimeUnit
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class MainActivityLifecycleTest {
+  @Test
+  @Config(sdk = [28])
+  fun api28ResumeOwnsPermissionRequestsUntilPause() {
+    val controller =
+      Robolectric
+        .buildActivity(MainActivity::class.java)
+        .create()
+        .start()
+        .resume()
+    val requester = (RuntimeEnvironment.getApplication() as NodeApp).permissionRequester
+    val activeHost = ReflectionHelpers.getField<MutableStateFlow<*>>(requester, "activeActivityHost")
+
+    try {
+      assertTrue(activeHost.value != null)
+      controller.pause()
+      assertNull(activeHost.value)
+    } finally {
+      controller.stop().destroy()
+    }
+  }
+
   @Test
   fun pendingIntentRouterUsesLatestIntentBeforeActivation() {
     val router = MainActivityPendingIntentRouter()

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/DeviceHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/DeviceHandlerTest.kt
@@ -12,12 +12,14 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 class DeviceHandlerTest {
@@ -109,7 +111,7 @@ class DeviceHandlerTest {
     assertEquals((totalBytes - freeBytes).coerceAtLeast(0L), usedBytes)
 
     val thermalState = thermal.getValue("state").jsonPrimitive.content
-    assertTrue(thermalState in setOf("nominal", "fair", "serious", "critical"))
+    assertTrue(thermalState in setOf("unknown", "nominal", "fair", "serious", "critical"))
 
     val networkStatus = network.getValue("status").jsonPrimitive.content
     assertTrue(networkStatus in setOf("satisfied", "unsatisfied", "requiresConnection"))
@@ -328,6 +330,18 @@ class DeviceHandlerTest {
   }
 
   @Test
+  @Config(sdk = [28])
+  fun handleDevicePermissions_marksCallLogPromptableOnlyWithTelephony() {
+    val app = appContext()
+    val handler = DeviceHandler(app, callLogEnabled = true)
+
+    assertFalse(permissionPromptable(handler.handleDevicePermissions(null).payloadJson, "callLog"))
+
+    shadowOf(app.packageManager).setSystemFeature(PackageManager.FEATURE_TELEPHONY, true)
+    assertTrue(permissionPromptable(handler.handleDevicePermissions(null).payloadJson, "callLog"))
+  }
+
+  @Test
   fun handleDevicePermissions_requiresReadAndWritePermissionPairs() {
     val app = appContext()
     val handler = DeviceHandler(app)
@@ -540,6 +554,19 @@ class DeviceHandlerTest {
       .getValue("status")
       .jsonPrimitive
       .content
+
+  private fun permissionPromptable(
+    payloadJson: String?,
+    key: String,
+  ): Boolean =
+    parsePayload(payloadJson)
+      .getValue("permissions")
+      .jsonObject
+      .getValue(key)
+      .jsonObject
+      .getValue("promptable")
+      .jsonPrimitive
+      .boolean
 }
 
 private class FakeDeviceAppSource(

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/AndroidAudioInputSessionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/AndroidAudioInputSessionTest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.media.AudioDeviceInfo
 import android.media.AudioManager
 import android.media.AudioRecord
+import android.os.Build
 import android.os.Looper
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -37,8 +38,43 @@ class AndroidAudioInputSessionTest {
   @After
   fun tearDown() {
     shadowAudioManager.setInputDevices(emptyList())
-    shadowAudioManager.setAvailableCommunicationDevices(emptyList())
-    audioManager.clearCommunicationDevice()
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      shadowAudioManager.setAvailableCommunicationDevices(emptyList())
+      audioManager.clearCommunicationDevice()
+    }
+  }
+
+  @Test
+  @Config(sdk = [28])
+  fun api28OpensAndClosesWithoutCommunicationDeviceApis() {
+    val builtIn = audioDevice(AudioDeviceInfo.TYPE_BUILTIN_MIC)
+    val bluetooth = audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+    shadowAudioManager.setInputDevices(listOf(bluetooth, builtIn))
+
+    val session = AndroidAudioInputSession.open(context, sampleRateHz = 24_000, frameBytes = 4_800)
+
+    assertNull(session.requestedInputType)
+    assertEquals(
+      listOf(AudioDeviceInfo.TYPE_BUILTIN_MIC),
+      AndroidAudioInputSession.listAvailableDevices(context).map(AudioInputDeviceOption::type),
+    )
+    assertNull(resolvePreferredAudioInput(listOf(bluetooth, builtIn), audioInputDeviceKey(bluetooth)))
+    session.close()
+  }
+
+  @Test
+  @Config(sdk = [31])
+  fun api31RoutesClassicBluetoothThroughCommunicationDevice() {
+    val scoInput = audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+    val scoOutput = audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+    shadowAudioManager.setInputDevices(listOf(scoInput))
+    shadowAudioManager.setAvailableCommunicationDevices(listOf(scoOutput))
+
+    val session = AndroidAudioInputSession.open(context, sampleRateHz = 24_000, frameBytes = 4_800)
+
+    assertEquals(AudioDeviceInfo.TYPE_BLUETOOTH_SCO, session.requestedInputType)
+    assertEquals(AudioDeviceInfo.TYPE_BLUETOOTH_SCO, audioManager.communicationDevice?.type)
+    session.close()
   }
 
   @Test
@@ -239,6 +275,7 @@ class AndroidAudioInputSessionTest {
         .setType(type)
         .build()
     val port = ReflectionHelpers.getField<Any>(device, "mPort")
+    ReflectionHelpers.setField(port, "mName", "Test microphone")
     val handle = ReflectionHelpers.getField<Any>(port, "mHandle")
     ReflectionHelpers.setField(handle, "mId", nextDeviceId++)
     return device

--- a/apps/android/wear-shared/build.gradle.kts
+++ b/apps/android/wear-shared/build.gradle.kts
@@ -9,7 +9,7 @@ android {
   compileSdk = 37
 
   defaultConfig {
-    minSdk = 31
+    minSdk = 28
   }
 
   compileOptions {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceCommands.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceCommands.swift
@@ -13,6 +13,7 @@ public enum OpenClawBatteryState: String, Codable, Sendable {
 }
 
 public enum OpenClawThermalState: String, Codable, Sendable {
+    case unknown
     case nominal
     case fair
     case serious

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -337,11 +337,13 @@ Camera commands (foreground only; permission-gated): `camera.snap` (jpg), `camer
 
 - Android's shell navigation is **Home**, **Chat**, and **Settings**. Voice input
   belongs to the Chat composer; there is no separate Voice tab.
-- Tap the composer microphone for on-device speech recognition that inserts a
-  transcript into the draft. Long-press the microphone to record a voice-note
-  attachment. The UI reports unavailable recognition, missing permission,
-  busy/network failures, and no-speech outcomes instead of silently dropping
-  the attempt.
+- On Android 12 and newer, tap the composer microphone for on-device speech
+  recognition that inserts a transcript into the draft. On Android 9 through
+  11, Chat dictation and Voice Wake remain unavailable because the platform
+  cannot guarantee on-device recognition. Long-press the microphone to record
+  a voice-note attachment. The UI reports unavailable recognition, missing
+  permission, busy/network failures, and no-speech outcomes instead of
+  silently dropping the attempt.
 - Start continuous **Talk** from the Chat waveform. Dictation, voice-note
   recording, and Talk are mutually exclusive microphone paths.
 - Talk Mode promotes the existing foreground service from `connectedDevice` to `connectedDevice|microphone` before capture starts, then demotes it when Talk Mode stops. The node service declares `FOREGROUND_SERVICE_CONNECTED_DEVICE` with `CHANGE_NETWORK_STATE`; Android 14+ also requires the `FOREGROUND_SERVICE_MICROPHONE` declaration, the `RECORD_AUDIO` runtime grant, and the microphone service type at runtime.

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -346,7 +346,13 @@ Camera commands (foreground only; permission-gated): `camera.snap` (jpg), `camer
   silently dropping the attempt.
 - Start continuous **Talk** from the Chat waveform. Dictation, voice-note
   recording, and Talk are mutually exclusive microphone paths.
-- Talk Mode promotes the existing foreground service from `connectedDevice` to `connectedDevice|microphone` before capture starts, then demotes it when Talk Mode stops. The node service declares `FOREGROUND_SERVICE_CONNECTED_DEVICE` with `CHANGE_NETWORK_STATE`; Android 14+ also requires the `FOREGROUND_SERVICE_MICROPHONE` declaration, the `RECORD_AUDIO` runtime grant, and the microphone service type at runtime.
+- Talk Mode updates the existing foreground service before capture starts. On
+  Android 9, the service uses the legacy untyped foreground-service path. On
+  Android 10, it uses `connectedDevice`; Android 11 and newer add `microphone`
+  while capture is active and remove it when Talk stops. The node service
+  declares `FOREGROUND_SERVICE_CONNECTED_DEVICE` with `CHANGE_NETWORK_STATE`;
+  Android 14+ also requires the `FOREGROUND_SERVICE_MICROPHONE` declaration,
+  the `RECORD_AUDIO` runtime grant, and the microphone service type at runtime.
 - By default, Android Talk uses native speech recognition, Gateway chat, and `talk.speak` through the configured gateway Talk provider. Local system TTS is used only when `talk.speak` is unavailable.
 - Android Talk uses realtime Gateway relay only when `talk.realtime.mode` is `realtime` and `talk.realtime.transport` is `gateway-relay`.
 - Android does not advertise the `voiceWake` capability. Use Chat dictation,


### PR DESCRIPTION
## What Problem This Solves

The Android phone app currently requires Android 12, preventing users with
otherwise capable Android 9 through 11 devices from installing and running the
OpenClaw companion app.

Older-device support has been requested repeatedly. This is the third direct
public PR attempt identified for lowering the Android app's minimum version,
following #48929 and #49488.

This PR deliberately stops at Android 9 rather than claiming support for every
older release at once. If this change is accepted, I plan to use it as the
tested baseline for evaluating a further reduction on physical hardware in a
separate PR.

For comparison, OpenAI documents Android 7.0 as the minimum for its
[ChatGPT Android app](https://help.openai.com/en/articles/8167614-minimum-requirements-for-the-chatgpt-android-app)
on devices with Google Play. That suggests a lower floor may be practical for
this class of companion app, but it does not prove that OpenClaw's current
device capabilities are safe on API 24 through 27.

## Why This Change Was Made

The previous attempts established the demand and some useful compatibility
patterns, but neither reached a mergeable state:

- #48929 targeted Android 11. It also included a bootstrap-token pairing fix
  that had become stale because the pairing path was fixed separately on
  `main`. The maintainer closed it and requested a dedicated Android 11
  compatibility PR.
- #49488 targeted Android 8. Review found that lowering directly to API 26
  exposed additional platform assumptions that the patch did not fully cover.
  It also became stale relative to current foreground-service, theme, backup,
  and other application behavior. Changes were requested and it was later
  closed without merging.

This attempt keeps the effort dedicated to compatibility and chooses Android 9
(API 28) as a narrower support floor. It audits the current application rather
than reviving either older patch, preserves current Android 12+ behavior, and
tests the relevant boundaries across API 28, 29, 30, 31, and the current SDK.

Features that cannot retain their existing security or privacy guarantees fail
closed on older Android releases rather than using weaker substitutes. The
Wear OS app remains on API 31.

Support below API 28 is explicitly outside this PR. After the API 28 work has
landed, a follow-up can test Android 7 and 8 on physical hardware, audit the
additional API boundaries, and propose a further reduction with its own
evidence. This staged approach keeps the present change reviewable and avoids
repeating the broader compatibility jump that blocked #49488.

## User Impact

Users can install and use the OpenClaw phone app on Android 9 and newer,
including gateway connectivity, chat, voice-note recording, and device
capabilities supported by their hardware.

On Android 9 through 11:

- Chat dictation and Voice Wake remain unavailable because guaranteed
  on-device speech recognition requires Android 12.
- Widget images can be copied, while direct saving to Downloads requires
  Android 10.
- Automatic Bluetooth microphone routing requires Android 12.

Behavior on Android 12 and newer remains unchanged.

## Evidence

Automated compatibility coverage exercises API 28, 29, 30, 31, and 36.

The following completed successfully:

- `pnpm android:lint`
- `pnpm android:lint:android`
- `pnpm android:test`
- `pnpm android:test:third-party`
- `pnpm android:assemble`
- `pnpm android:assemble:third-party`
- Play, third-party, and Wear AAR metadata checks

The generated phone APK declares API 28 as its minimum SDK and contains both
`armeabi-v7a` and `arm64-v8a` native libraries.

The exact rebuilt APK was installed in place on a Fire HD 10 (7th generation,
`suez`) running LineageOS 16 / Android 9. Physical-device validation confirmed:

- application launch without a crash
- connection to the Gateway through Tailscale
- successful agent chat round trip
- built-in voice-note recording and cancellation
- continued node connectivity while the app was backgrounded

**SCREENSHOT**: of my running fire tablet of the pushed checkout, it has the LineageOS16/An
<img width="3000" height="4000" alt="PXL_20260809_184110350" src="https://github.com/user-attachments/assets/a6ed8ead-fd4c-4f03-9a3f-b80c4470890e" />
droid 9 running atm; 

