### PR TITLE
fix(tests): verify workspace reset process-group liveness

### DIFF
--- a/src/gateway/worker-environments/workspace-sync-tunnel.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-tunnel.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { waitForChildClose, waitForFile } from "../../../test/helpers/process-wait.js";
+import { waitForChildClose, waitForPidFile } from "../../../test/helpers/process-wait.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { createWorkerTunnelManager } from "./tunnel.js";
@@ -290,7 +290,7 @@ describe("worker tunnel manager", () => {
       const fakeRsync = path.join(bin, "rsync");
       await fs.writeFile(
         fakeRsync,
-        '#!/bin/sh\nset -eu\n: > "$OPENCLAW_TEST_RECEIVER_MARKER"\nread -r _ < "$OPENCLAW_TEST_RECEIVER_GATE"\nprintf \'late stale write\\n\' > "$OPENCLAW_TEST_RECEIVER_WORKSPACE/stale-late.txt"\n',
+        '#!/bin/sh\nset -eu\nprintf \'%s\\n\' "$$" > "$OPENCLAW_TEST_RECEIVER_MARKER"\nread -r _ < "$OPENCLAW_TEST_RECEIVER_GATE"\nprintf \'late stale write\\n\' > "$OPENCLAW_TEST_RECEIVER_WORKSPACE/stale-late.txt"\n',
         { mode: 0o755 },
       );
 
@@ -301,8 +301,24 @@ describe("worker tunnel manager", () => {
         | undefined;
       let receiverWorkspace: string | undefined;
       let receiverRelative: string | undefined;
+      let receiverGroupPid: number | undefined;
       let receiverStderr = "";
-      const lifecycle: string[] = [];
+      let resetAcknowledgement: { nonce: string; groupAlive: boolean } | undefined;
+      const processGroupIsAlive = (pid: number): boolean => {
+        try {
+          process.kill(-pid, 0);
+          return true;
+        } catch (error) {
+          const code = (error as NodeJS.ErrnoException).code;
+          if (code === "EPERM") {
+            return true;
+          }
+          if (code === "ESRCH") {
+            return false;
+          }
+          throw error;
+        }
+      };
       const fake = localWorkspaceRunner(
         remoteHome,
         async (argv, localArgv, options, receiverTarget) => {
@@ -347,12 +363,9 @@ describe("worker tunnel manager", () => {
           receiverChild.stderr?.on("data", (chunk: string) => {
             receiverStderr += chunk;
           });
-          receiverChild.once("close", () => {
-            lifecycle.push("receiver-exit");
-          });
           receiverExited = waitForChildClose(receiverChild, 10_000);
-          await Promise.race([
-            waitForFile(receiverMarker, 10_000),
+          receiverGroupPid = await Promise.race([
+            waitForPidFile(receiverMarker, 10_000),
             receiverExited.then(() => {
               throw new Error(receiverStderr || "test receiver exited before its marker");
             }),
@@ -362,7 +375,13 @@ describe("worker tunnel manager", () => {
         (argv, result) => {
           const acknowledged = /^reset ([a-f0-9]{32})\n$/u.exec(result.stdout)?.[1];
           if (acknowledged) {
-            lifecycle.push(`reset-complete:${acknowledged}`);
+            if (receiverGroupPid === undefined) {
+              throw new Error("test receiver process group was not captured");
+            }
+            resetAcknowledgement = {
+              nonce: acknowledged,
+              groupAlive: processGroupIsAlive(receiverGroupPid),
+            };
           }
         },
       );
@@ -438,7 +457,9 @@ describe("worker tunnel manager", () => {
         });
         expect(resetCommands).toHaveLength(1);
         expect(sshArgvPort(resetCommands[0]!.argv)).toBe(22);
-        expect(lifecycle).not.toContain(`reset-complete:${resetCommands[0]!.nonce}`);
+        expect(receiverGroupPid).toBeDefined();
+        expect(processGroupIsAlive(receiverGroupPid!)).toBe(true);
+        expect(resetAcknowledgement).toBeUndefined();
         await expect(fs.readFile(path.join(receiverWorkspace!, "stale.txt"), "utf8")).resolves.toBe(
           "remove before fallback\n",
         );
@@ -464,7 +485,10 @@ describe("worker tunnel manager", () => {
         expect(receiverExit.signal).toBeNull();
         expect(receiverExit.code).not.toBe(0);
         const result = await syncing;
-        expect(lifecycle).toEqual(["receiver-exit", `reset-complete:${resetCommands[0]!.nonce}`]);
+        expect(resetAcknowledgement).toEqual({
+          nonce: resetCommands[0]!.nonce,
+          groupAlive: false,
+        });
         expect(result.mode).toBe("git");
         await expect(
           fs.readFile(path.join(result.remoteWorkspaceDir, "current.txt"), "utf8"),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Cloud Worker workspace fallback test could fail nondeterministically even though production correctly serialized reset behind the remote receiver's process-group liveness and workspace mutation lock.

The old assertion compared callback order from independent local child processes. That is not the production ownership contract, so `[reset-complete, receiver-exit]` could be observed without a reset/receiver race.

## Why This Change Was Made

The test now records the fake receiver's process-group PID, proves the negative-PID group is alive while reset is gated, and probes the same group when the matching reset acknowledgement is emitted. `ESRCH` means dead, `EPERM` means alive, and other errors fail the test.

The unsupported local `receiver-exit` callback-order assertion is removed. Existing stale-write, current-source, `.git`, derived-cache, manifest, accepted-transaction, and lock-residue assertions remain unchanged. Production code is untouched.

History:

- #120715 introduced the remote receiver process-group and shared mutation-lock/reset proof.
- #121027 changed receiver invocation while retaining the local callback-order assumption.
- Historical CI evidence for #121182 observed `[reset-complete, receiver-exit]`; its unchanged rerun passed. #121088 also passed the same test blob.
- Live source verification confirms the merged #121182 and #121088 heads both carried test blob `a5ce3a82b695fcf65cf5b9e32b12c62f481e2c4c`.

## User Impact

No runtime behavior changes. Maintainers get a deterministic regression test for the production process-group ownership invariant.

## Evidence

- Focused named test: 3/3 project variants passed.
- Relevant three-file suite: 51/51 tests passed.
- Bounded stress: 100/100 single-worker iterations passed with no retries.
- Direct probe: receiver group alive before gate release; matching reset acknowledgement observed `groupAlive: false`.
- `pnpm format src/gateway/worker-environments/workspace-sync-tunnel.test.ts`: passed.
- `git diff --check`: passed.
- Changed classifier: `coreTests`.
- `$autoreview --mode local`: clean; patch correct at 0.99 confidence; TruffleHog clean.
- Signed exact head: `4a83a924717f363b0139046df2e94c8e2bbf6938`.
- Exact-head hosted CI: run `31330662325` passed, including `checks-node-changed` job `93288386195` and `openclaw/ci-gate` job `93289061266`.
- Current-main merge tree against `96798953b2207e8eed6ca275b066a8393433b6af`: clean tree `c4e0a7a33af9a5ef71988ca435fb3b743ab4fa1e`, one test file only.
- Production LOC: 0. Tests: +35/-11.
- Live `ghx` duplicate search found no older open PR or issue. `gitcrawl` was unavailable because its token is expired, so duplicate/history proof uses live `ghx`, source blobs, and Git history.
- No changelog entry: pure test-oracle repair.

Punchcard-Session: amber-workshop-workshop-36
