### PR TITLE
chore(gateway): add lightweight real-wire session boundary harness

### DIFF
--- a/src/cli/resume-cli.test.ts
+++ b/src/cli/resume-cli.test.ts
@@ -1,35 +1,33 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { parseAgentSessionKey } from "../routing/session-key.js";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectErrorDetailCodes } from "../../packages/gateway-protocol/src/connect-error-details.js";
+import { startMinimalRealGateway } from "../gateway/minimal-gateway.test-helpers.js";
 import type { TuiSessionList } from "../tui/tui-backend.js";
 import { resolveResumeSession } from "../tui/tui-session-picker.js";
 import { runResumeCommand } from "./resume-cli.runtime.js";
 
-const gatewayMocks = vi.hoisted(() => ({
+const mocks = vi.hoisted(() => ({
   connect: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(),
   runTui: vi.fn(),
   selectStyled: vi.fn(),
 }));
 
-const runtimeMocks = vi.hoisted(() => ({
-  error: vi.fn(),
-  exit: vi.fn(),
-}));
-
 vi.mock("../../packages/terminal-core/src/prompt-select-styled.js", () => ({
-  selectStyled: gatewayMocks.selectStyled,
+  selectStyled: mocks.selectStyled,
 }));
 
 vi.mock("../tui/gateway-chat.js", () => ({
-  GatewayChatClient: { connect: gatewayMocks.connect },
+  GatewayChatClient: { connect: mocks.connect },
 }));
 
 vi.mock("../tui/tui.js", () => ({
   resolveGatewayDisconnectState: vi.fn(),
-  runTui: gatewayMocks.runTui,
+  runTui: mocks.runTui,
 }));
 
 vi.mock("../runtime.js", () => ({
-  defaultRuntime: runtimeMocks,
+  defaultRuntime: mocks,
 }));
 
 type SessionRow = TuiSessionList["sessions"][number];
@@ -40,19 +38,9 @@ const sessions: SessionRow[] = [
   { key: "agent:work:gamma", displayName: "Gamma review", label: "checklist" },
 ];
 
-const stdinTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
-const stdoutTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
-
-function restoreTty(
-  stream: NodeJS.ReadStream | NodeJS.WriteStream,
-  descriptor: PropertyDescriptor | undefined,
-) {
-  if (descriptor) {
-    Object.defineProperty(stream, "isTTY", descriptor);
-  } else {
-    Reflect.deleteProperty(stream, "isTTY");
-  }
-}
+const ttyDescriptors = [process.stdin, process.stdout].map(
+  (stream) => [stream, Object.getOwnPropertyDescriptor(stream, "isTTY")] as const,
+);
 
 function createGatewayClient(rows: SessionRow[]) {
   const client = {
@@ -63,21 +51,26 @@ function createGatewayClient(rows: SessionRow[]) {
     start: vi.fn(() => client.onConnected?.()),
     stop: vi.fn().mockResolvedValue(undefined),
   };
-  gatewayMocks.connect.mockResolvedValue(client);
+  mocks.connect.mockResolvedValue(client);
   return client;
 }
 
 beforeEach(() => {
-  gatewayMocks.connect.mockReset();
-  gatewayMocks.runTui.mockReset().mockResolvedValue(undefined);
-  gatewayMocks.selectStyled.mockReset();
-  runtimeMocks.error.mockReset();
-  runtimeMocks.exit.mockReset();
+  Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+  Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+  mocks.connect.mockReset();
+  mocks.runTui.mockReset().mockResolvedValue(undefined);
+  mocks.selectStyled.mockReset();
+  mocks.error.mockReset();
+  mocks.exit.mockReset();
 });
 
 afterEach(() => {
-  restoreTty(process.stdin, stdinTtyDescriptor);
-  restoreTty(process.stdout, stdoutTtyDescriptor);
+  for (const [stream, descriptor] of ttyDescriptors) {
+    void (descriptor
+      ? Object.defineProperty(stream, "isTTY", descriptor)
+      : Reflect.deleteProperty(stream, "isTTY"));
+  }
 });
 
 describe("resolveResumeSession", () => {
@@ -140,8 +133,6 @@ describe("resolveResumeSession", () => {
 
 describe("runResumeCommand", () => {
   it("excludes the bare global session from query resolution", async () => {
-    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
-    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
     const client = createGatewayClient([]);
 
     await runResumeCommand("global", {});
@@ -149,56 +140,32 @@ describe("runResumeCommand", () => {
     expect(client.listSessions).toHaveBeenCalledWith(
       expect.objectContaining({ includeGlobal: false }),
     );
-    expect(runtimeMocks.exit).toHaveBeenCalledWith(1);
-    expect(gatewayMocks.runTui).not.toHaveBeenCalled();
+    expect(mocks.exit).toHaveBeenCalledWith(1);
+    expect(mocks.runTui).not.toHaveBeenCalled();
   });
 
   it("omits the bare global session from the interactive picker", async () => {
-    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
-    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
     const client = createGatewayClient([
       { key: "agent:main:alpha", displayName: "Alpha planning", label: "roadmap" },
     ]);
-    gatewayMocks.selectStyled.mockResolvedValue("agent:main:alpha");
+    mocks.selectStyled.mockResolvedValue("agent:main:alpha");
 
     await runResumeCommand(undefined, {});
 
     expect(client.listSessions).toHaveBeenCalledWith(
       expect.objectContaining({ includeGlobal: false }),
     );
-    expect(gatewayMocks.selectStyled).toHaveBeenCalledWith(
+    expect(mocks.selectStyled).toHaveBeenCalledWith(
       expect.objectContaining({
         options: [expect.objectContaining({ value: "agent:main:alpha" })],
       }),
     );
-    expect(gatewayMocks.runTui).toHaveBeenCalledWith(
+    expect(mocks.runTui).toHaveBeenCalledWith(
       expect.objectContaining({
         session: "agent:main:alpha",
         forceProcessExitOnReturn: true,
       }),
     );
-  });
-
-  it("preserves an explicitly agent-qualified global session", async () => {
-    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
-    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
-    const client = createGatewayClient([{ key: "global", displayName: "global" }]);
-
-    await runResumeCommand("agent:work:global", {});
-
-    expect(client.listSessions).toHaveBeenCalledWith(
-      expect.objectContaining({ agentId: "work", includeGlobal: true }),
-    );
-    expect(gatewayMocks.runTui).toHaveBeenCalledWith(
-      expect.objectContaining({
-        session: "agent:work:global",
-        forceProcessExitOnReturn: true,
-      }),
-    );
-    expect(parseAgentSessionKey(gatewayMocks.runTui.mock.lastCall?.[0]?.session)).toEqual({
-      agentId: "work",
-      rest: "global",
-    });
   });
 
   it("rejects a non-interactive queried resume before connecting or launching the TUI", async () => {
@@ -208,7 +175,47 @@ describe("runResumeCommand", () => {
     await expect(runResumeCommand("global", {})).rejects.toThrow(
       "Attaching to a session requires an interactive terminal. Re-run `openclaw resume [query]` from an interactive terminal.",
     );
-    expect(gatewayMocks.connect).not.toHaveBeenCalled();
-    expect(gatewayMocks.runTui).not.toHaveBeenCalled();
+    expect(mocks.connect).not.toHaveBeenCalled();
+    expect(mocks.runTui).not.toHaveBeenCalled();
+  });
+});
+
+describe("real Gateway session boundary", () => {
+  let harness: Awaited<ReturnType<typeof startMinimalRealGateway>>;
+
+  beforeAll(async () => {
+    harness = await startMinimalRealGateway([
+      { agentId: "work", key: "agent:work:global", visibility: "shared" },
+    ]);
+  });
+
+  afterAll(() => harness.close());
+
+  it("preserves an agent-qualified global session through the TUI handoff", async () => {
+    const { GatewayChatClient } =
+      await vi.importActual<typeof import("../tui/gateway-chat.js")>("../tui/gateway-chat.js");
+    mocks.connect.mockImplementation((options) => GatewayChatClient.connect(options));
+    await runResumeCommand("agent:work:global", { url: harness.url, token: harness.token });
+
+    expect(harness.sessionListRequests).toContainEqual(
+      expect.objectContaining({ agentId: "work", includeGlobal: true }),
+    );
+    expect(mocks.runTui).toHaveBeenCalledWith(
+      expect.objectContaining({ session: "agent:work:global", forceProcessExitOnReturn: true }),
+    );
+  });
+
+  it("accepts a bootstrap-signed identity and rejects a mismatched signature", async () => {
+    await expect(harness.connectBootstrap()).resolves.toMatchObject({ ok: true });
+    expect(harness.hellos).toContainEqual(expect.objectContaining({ type: "hello-ok" }));
+
+    await harness.connectBootstrap(true);
+    expect(harness.connectFailures).toContainEqual(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          code: ConnectErrorDetailCodes.DEVICE_AUTH_SIGNATURE_INVALID,
+        }),
+      }),
+    );
   });
 });

--- a/src/gateway/minimal-gateway.test-helpers.ts
+++ b/src/gateway/minimal-gateway.test-helpers.ts
@@ -1,9 +1,11 @@
 // Minimal Gateway websocket test helpers.
-// Provides small fake-server frames for client/backend tests.
-import type WebSocket from "ws";
-import type { WebSocketServer } from "ws";
+// Provides small fake-server frames plus an isolated real-Gateway boundary harness.
+import path from "node:path";
+import { WebSocket, type WebSocketServer } from "ws";
 import { PROTOCOL_VERSION } from "../../packages/gateway-protocol/src/index.js";
 import { rawDataToString } from "../infra/ws.js";
+import { toAgentRequestSessionKey } from "../routing/session-key.js";
+import { getFreePort } from "../test-utils/ports.js";
 
 type MinimalGatewayRequestFrame = {
   type?: string;
@@ -73,4 +75,113 @@ export async function closeMinimalGatewayServer(wss: WebSocketServer): Promise<v
   await new Promise<void>((resolve, reject) => {
     wss.close((error) => (error ? reject(error) : resolve()));
   });
+}
+
+export async function startMinimalRealGateway(
+  sessions: Array<{
+    agentId: string;
+    key: string;
+    visibility?: import("../config/sessions.js").SessionEntry["visibility"];
+  }> = [],
+) {
+  const [bootstrap, profiles, sessionStore, testState] = await Promise.all([
+    import("../infra/device-bootstrap.js"),
+    import("../shared/device-bootstrap-profile.js"),
+    import("../config/sessions/session-accessor.sqlite-entry.js"),
+    import("../test-utils/openclaw-test-state.js"),
+  ]);
+  const token = "minimal-real-gateway-token";
+  const state = await testState.createOpenClawTestState({
+    env: {
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+      OPENCLAW_SKIP_CANVAS_HOST: "1",
+      OPENCLAW_SKIP_CHANNELS: "1",
+      OPENCLAW_SKIP_CRON: "1",
+      OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+      OPENCLAW_SKIP_PROVIDERS: "1",
+      OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+    },
+  });
+  const sessionListRequests: Record<string, unknown>[] = [];
+  const hellos: unknown[] = [];
+  const connectFailures: unknown[] = [];
+  const clients: WebSocket[] = [];
+  let server: Awaited<ReturnType<(typeof import("./server.js"))["startGatewayServer"]>> | undefined;
+  let port = await getFreePort();
+  while (port === 18789) {
+    port = await getFreePort();
+  }
+  try {
+    for (const session of sessions) {
+      await sessionStore.upsertSqliteSessionEntry(
+        {
+          agentId: session.agentId,
+          sessionKey: toAgentRequestSessionKey(session.key)!,
+          storePath: path.join(state.agentDir(session.agentId), "openclaw-agent.sqlite"),
+        },
+        { sessionId: session.key, updatedAt: Date.now(), visibility: session.visibility },
+      );
+    }
+    const methods = await import("./server-methods.js");
+    const original = methods.coreGatewayHandlers["sessions.list"]!;
+    methods.coreGatewayHandlers["sessions.list"] = async (options) => {
+      sessionListRequests.push(options.params as Record<string, unknown>);
+      return await original(options);
+    };
+    const gateway = await import("./server.js");
+    server = await gateway
+      .startGatewayServer(port, {
+        auth: { mode: "token", token },
+        bind: "loopback",
+        controlUiEnabled: false,
+        sidecarStartup: "defer",
+      })
+      .finally(() => (methods.coreGatewayHandlers["sessions.list"] = original));
+  } catch (error) {
+    await state.cleanup();
+    throw error;
+  }
+  const dropConnections = () => clients.forEach((client) => client.terminate());
+  return {
+    url: `ws://127.0.0.1:${port}`,
+    token,
+    sessionListRequests,
+    hellos,
+    connectFailures,
+    connectBootstrap: async (mismatched = false) => {
+      const helpers = await import("./test-helpers.js");
+      const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+      clients.push(ws);
+      const bootstrapToken = (
+        await bootstrap.issueDeviceBootstrapToken({
+          baseDir: state.stateDir,
+          profile: profiles.NODE_PAIRING_SETUP_BOOTSTRAP_PROFILE,
+        })
+      ).token;
+      const response = await helpers.connectReq(ws, {
+        bootstrapToken,
+        ...(mismatched ? { deviceToken: "mismatched-device-token" } : {}),
+        skipDefaultAuth: true,
+        role: "node",
+        scopes: [],
+        client: { id: "node-host", version: "test", platform: "test", mode: "node" },
+        deviceIdentityPath: state.statePath(`device-${mismatched ? "bad" : "ok"}.sqlite`),
+        timeoutMs: 2_000,
+      });
+      (response.ok ? hellos : connectFailures).push(
+        response.ok ? response.payload : response.error,
+      );
+      return response;
+    },
+    dropConnections,
+    close: async () => {
+      dropConnections();
+      try {
+        await server!.close();
+      } finally {
+        await state.cleanup();
+      }
+    },
+  };
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The runners plan calls for a fast boundary regression before device-runner work begins. The qualified-global resume path and bootstrap-signature handshake were covered by unit-level mocks or broad Gateway suites, leaving no cheap proof that the actual CLI client, WebSocket protocol, session store, and Gateway handshake agree at their boundaries.

## Why This Change Was Made

This adds a narrowly scoped real-wire Gateway harness to the existing minimal test helper. It uses an OS-assigned loopback port, isolated OpenClaw state and SQLite stores, disables plugins and background work, seeds agent-scoped sessions, records sanitized `sessions.list` requests and connect outcomes, issues real bootstrap tokens, and tears down sockets, server state, databases, and temp directories deterministically.

The regression reuses the existing resume test surface while delegating to the real `GatewayChatClient`; only the final `runTui` handoff remains behavior-mocked. It proves that `agent:work:global` reaches `sessions.list` with `agentId: work` and `includeGlobal: true`, then reaches the TUI unchanged. The pairing case proves a bootstrap-signed identity reaches `hello-ok`, while a deliberately mismatched signature is rejected with `DEVICE_AUTH_SIGNATURE_INVALID`.

This is test infrastructure only: no production, config, schema, protocol, public API, or changelog changes.

## User Impact

There is no direct user-visible behavior change. Maintainers now have a sub-second-per-case boundary regression for the session and pairing invariants that M5 device-runner work depends on.

## Evidence

- Focused verbose run: `node scripts/run-vitest.mjs src/cli/resume-cli.test.ts --reporter=verbose`
  - 11/11 tests passed.
  - Resume real-Gateway case: 121 ms.
  - Bootstrap accept/reject case: 222 ms.
  - Vitest duration: 7.65 s; wrapper wall time: 10.45 s.
- Bounded three-run loop: all three runs passed.
  - Vitest durations: 6.28 s, 6.17 s, 6.10 s.
  - Wrapper wall times: 8.96 s, 8.83 s, 8.76 s.
- `pnpm check:test-types`: passed.
- Targeted oxlint, oxfmt check, and `git diff --check`: passed.
- Project autoreview, dirty/local mode: clean; no accepted/actionable findings.
- LOC: 185 additions, 67 deletions, net +118 test-infrastructure lines across two files; production LOC delta is 0.

Remote changed-gate delegation was unavailable because the configured backend was not authenticated, so the requested test-type gate ran through the trusted-source local fallback. The broader local changed gate reached a pre-existing default-branch dependency-pin failure for `ui/package.json` (`@novnc/novnc` uses `^1.7.0`); this PR does not touch that file or dependency.
