### PR TITLE
fix(release): build frozen artifacts through package script

### DIFF
--- a/scripts/package-openclaw-for-docker.mts
+++ b/scripts/package-openclaw-for-docker.mts
@@ -450,11 +450,10 @@ function run(command: string, args: string[], cwd: string, options: RunOptions =
 const PACKAGE_ARTIFACT_BUILD_STEPS = [
   {
     label: "Building OpenClaw package artifacts",
-    command: "node",
-    // The full profile keeps canonical declaration emission; ciArtifacts is a
-    // PR-CI-only profile whose step env forces dts off and would clobber the
-    // OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=0 this packaging path requires.
-    args: ["--import", "tsx", "scripts/build-all.mts", "full"],
+    command: "pnpm",
+    // Let the frozen source own its build entrypoint while the packaging env
+    // keeps canonical declaration emission enabled.
+    args: ["run", "build"],
   },
 ];
 

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -354,7 +354,7 @@ describe("package-openclaw-for-docker", () => {
     );
   });
 
-  it("uses build-all with declaration generation for package artifacts", async () => {
+  it("uses the source package build entrypoint with declaration generation", async () => {
     const calls: Array<{
       command: string;
       args: string[];
@@ -429,8 +429,8 @@ describe("package-openclaw-for-docker", () => {
 
     expect(calls).toEqual([
       {
-        command: "node",
-        args: ["--import", "tsx", "scripts/build-all.mts", "full"],
+        command: "pnpm",
+        args: ["run", "build"],
         cwd: "/repo",
         dockerBuildExtensions: undefined,
         internalDockerBuildPluginIds: undefined,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where frozen-source Docker package validation failed when the current release harness invoked a build script path that did not exist in the frozen checkout.

## Why This Change Was Made

The trusted harness now runs the frozen source package's canonical `pnpm run build` entrypoint. This lets each validated ref own its `.mjs` or `.mts` build implementation without probing or fallback behavior, while preserving the existing environment scrub, declaration generation, timeout, and process-group controls.

## User Impact

No runtime behavior changes. Release validation can build older frozen source refs using the build contract declared by that ref.

## Evidence

- Exact argv: `pnpm`, `["run", "build"]`
- Frozen `da4e341b` declares `build: node scripts/build-all.mjs`; current main declares `build: node --import tsx scripts/build-all.mts`
- Both build parsers default an empty argument list to the full profile
- Focused assertion retains coverage for source cwd, plugin-selection env scrubbing, `OPENCLAW_BUILD_ALL_NO_PNPM=1`, `OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=0`, and the package-build timeout
- `pnpm format scripts/package-openclaw-for-docker.mts test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts` passed
- `git diff --check` passed
- Independent autoreview found no issues and judged this the canonical owner-boundary fix
- Local focused E2E startup was stopped after it entered another session's long-running shared TypeScript build; exact-head CI/Testbox is the authoritative test proof

Production LOC: +4/-5 (net -1) | Tests: +3/-3.
