### PR TITLE
feat(trajectory): add on-demand debug capture for the untruncated prompt

### DIFF
--- a/docs/tools/trajectory.md
+++ b/docs/tools/trajectory.md
@@ -150,6 +150,27 @@ continues; it does not change the trajectory size caps. To tune all agent
 cleanup steps that do not pass an explicit timeout, set
 `OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS`.
 
+## Debug-capture the full prompt for one turn
+
+Stored `context.compiled` trajectory rows bound each string field to 32,768
+characters, so a long system prompt or tool list reads back truncated. To
+audit the exact prompt a run submitted, capture it unbounded, one turn at a
+time, without changing default storage:
+
+```bash
+export OPENCLAW_TRAJECTORY_DEBUG_CAPTURE=1
+```
+
+While set, the next `context.compiled` event on each new recorder (one per
+run/attempt, i.e. one turn) is also written, secrets redacted but otherwise
+untruncated, as its own JSON file under `$TMPDIR/openclaw-trajectory-debug/`
+(override with `OPENCLAW_TRAJECTORY_DEBUG_CAPTURE_DIR`). The file name and its
+`sessionId`/`sessionKey`/`runId` fields identify which session and turn
+produced it. Unset the variable to go back to the default, always-bounded
+behavior; the stored trajectory row is unaffected either way. This applies to
+every agent runtime that goes through the embedded run attempt path,
+including `claude-cli`/CLI-backed sessions.
+
 ## Privacy and limits
 
 Trajectory bundles are for support and debugging, not public posting. OpenClaw

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -82,6 +82,78 @@ describe("trajectory runtime", () => {
     expect(JSON.stringify(parsed.data)).not.toContain("abcd-efgh-ijkl-mnop");
   });
 
+  it("does not write a debug capture file by default", () => {
+    const captureDir = tempDirs.make("openclaw-trajectory-debug-off-");
+    const writes: string[] = [];
+    const recorder = createTrajectoryRuntimeRecorder({
+      sessionId: "session-1",
+      sessionFile: "/tmp/session.jsonl",
+      env: { ...process.env, OPENCLAW_TRAJECTORY_DEBUG_CAPTURE_DIR: captureDir },
+      writer: {
+        filePath: "/tmp/session.trajectory.jsonl",
+        write: (line) => {
+          writes.push(line);
+        },
+        flush: async () => undefined,
+      },
+    });
+
+    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    runtimeRecorder.recordEvent("context.compiled", {
+      systemPrompt: "x".repeat(32_768 + 1),
+    });
+
+    expect(writes).toHaveLength(1);
+    expect(fs.existsSync(captureDir) ? fs.readdirSync(captureDir) : []).toEqual([]);
+  });
+
+  it("writes the untruncated prompt to a debug capture file when enabled", () => {
+    const captureDir = tempDirs.make("openclaw-trajectory-debug-on-");
+    const writes: string[] = [];
+    const oversizedSystemPrompt = "x".repeat(32_768 + 1);
+    const recorder = createTrajectoryRuntimeRecorder({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+      sessionFile: "/tmp/session.jsonl",
+      env: {
+        ...process.env,
+        OPENCLAW_TRAJECTORY_DEBUG_CAPTURE: "1",
+        OPENCLAW_TRAJECTORY_DEBUG_CAPTURE_DIR: captureDir,
+      },
+      writer: {
+        filePath: "/tmp/session.trajectory.jsonl",
+        write: (line) => {
+          writes.push(line);
+        },
+        flush: async () => undefined,
+      },
+    });
+
+    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    // The stored trajectory row still truncates the oversized field.
+    runtimeRecorder.recordEvent("context.compiled", { systemPrompt: oversizedSystemPrompt });
+    // Non-prompt events are not captured.
+    runtimeRecorder.recordEvent("model.completed", { usage: { input: 1, output: 2, total: 3 } });
+
+    const stored = JSON.parse(expectDefined(writes[0], "writes[0] test invariant"));
+    expect(stored.data.systemPrompt.truncated).toBe(true);
+
+    const captureFiles = fs.readdirSync(captureDir);
+    expect(captureFiles).toHaveLength(1);
+    const capture = JSON.parse(
+      fs.readFileSync(
+        path.join(captureDir, expectDefined(captureFiles[0], "capture file")),
+        "utf8",
+      ),
+    );
+    expect(capture.sessionId).toBe("session-1");
+    expect(capture.sessionKey).toBe("agent:main:session-1");
+    expect(capture.runId).toBe("run-1");
+    expect(capture.type).toBe("context.compiled");
+    expect(capture.data.systemPrompt).toBe(oversizedSystemPrompt);
+  });
+
   it("records SQLite marker runtime events without active JSONL sidecars", async () => {
     const tempDir = tempDirs.make("openclaw-trajectory-runtime-");
     const storePath = path.join(tempDir, "agents", "main", "sessions", "sessions.json");

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -1,4 +1,6 @@
 // Trajectory runtime records bounded session events into SQLite-backed storage.
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeDiagnosticPayload } from "../agents/payload-redaction.js";
@@ -10,7 +12,9 @@ import { parseSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-m
 import { loadSessionEntry } from "../config/sessions/session-accessor.js";
 import type { SessionTranscriptRuntimeTarget } from "../config/sessions/session-accessor.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveHomeRelativePath } from "../infra/home-dir.js";
 import { redactSecrets } from "../logging/redact.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { parseBooleanValue } from "../utils/boolean.js";
 import { safeJsonStringify } from "../utils/safe-json.js";
@@ -18,9 +22,12 @@ import { truncateUtf8Prefix } from "../utils/utf8-truncate.js";
 import {
   TRAJECTORY_RUNTIME_CAPTURE_MAX_BYTES,
   TRAJECTORY_RUNTIME_EVENT_MAX_BYTES,
+  safeTrajectorySessionFileName,
 } from "./paths.js";
 import { appendSqliteTrajectoryRuntimeEvents } from "./runtime-store.sqlite.js";
 import type { TrajectoryEvent, TrajectoryToolDefinition } from "./types.js";
+
+const log = createSubsystemLogger("trajectory/runtime");
 
 type TrajectoryRuntimeInit = {
   cfg?: OpenClawConfig;
@@ -60,6 +67,65 @@ const TRAJECTORY_RUNTIME_OVERSIZE_DROP_FIRST_DATA_KEYS = [
   "systemPrompt",
 ] as const;
 const OVERSIZE_PRESERVED_DATA_KEYS = ["stopReason", "usage", "promptCache", "prompt"] as const;
+
+// On-demand debug capture: OPENCLAW_TRAJECTORY_DEBUG_CAPTURE writes the fully
+// assembled prompt for one "context.compiled" event per recorder (i.e. one
+// turn) to a side JSON file, unaffected by the 32,768-char field limit above.
+// Off by default; does not change stored trajectory rows or their size caps.
+const TRAJECTORY_DEBUG_CAPTURE_EVENT_TYPE = "context.compiled";
+const TRAJECTORY_DEBUG_CAPTURE_DEFAULT_DIR = path.join(os.tmpdir(), "openclaw-trajectory-debug");
+
+function resolveTrajectoryDebugCaptureDir(env: NodeJS.ProcessEnv): string {
+  const override = env.OPENCLAW_TRAJECTORY_DEBUG_CAPTURE_DIR?.trim();
+  return override
+    ? resolveHomeRelativePath(override, { env })
+    : TRAJECTORY_DEBUG_CAPTURE_DEFAULT_DIR;
+}
+
+function writeTrajectoryDebugCapture(params: {
+  data: Record<string, unknown>;
+  env: NodeJS.ProcessEnv;
+  runId?: string;
+  seq: number;
+  sessionId: string;
+  sessionKey?: string;
+  type: string;
+}): void {
+  if (
+    params.type !== TRAJECTORY_DEBUG_CAPTURE_EVENT_TYPE ||
+    !parseBooleanValue(params.env.OPENCLAW_TRAJECTORY_DEBUG_CAPTURE)
+  ) {
+    return;
+  }
+  try {
+    const dir = resolveTrajectoryDebugCaptureDir(params.env);
+    fs.mkdirSync(dir, { recursive: true });
+    const fileName = `${safeTrajectorySessionFileName(params.sessionId)}-${params.runId ?? "no-run"}-${params.seq}.json`;
+    const filePath = path.join(dir, fileName);
+    // Secrets are still redacted; only the field/array/depth truncation from
+    // limitTrajectoryPayloadValue is skipped so the capture stays complete.
+    const capturedData = redactSecrets(sanitizeDiagnosticPayload(params.data));
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify(
+        {
+          capturedAt: new Date().toISOString(),
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          runId: params.runId,
+          seq: params.seq,
+          type: params.type,
+          data: capturedData,
+        },
+        null,
+        2,
+      ),
+    );
+    log.warn(`trajectory debug capture written: ${filePath}`);
+  } catch (err) {
+    log.warn(`trajectory debug capture failed: ${String(err)}`);
+  }
+}
 
 type TrajectoryRuntimeWriterDiagnostics = QueuedFileWriterDiagnostics;
 
@@ -442,6 +508,17 @@ export function createTrajectoryRuntimeRecorder(
   ): { event: TrajectoryEvent; line: string } | undefined => {
     const nextSeq = seq + 1;
     const sourceSeq = sink.nextSourceSeq?.() ?? nextSeq;
+    if (data) {
+      writeTrajectoryDebugCapture({
+        data,
+        env,
+        runId: params.runId,
+        seq: nextSeq,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        type,
+      });
+    }
     const event: TrajectoryEvent = {
       traceSchema: "openclaw-trajectory",
       schemaVersion: 1,


### PR DESCRIPTION
Fixes #121217

## What changed

`context.compiled` trajectory rows bound `systemPrompt`/`prompt`/`messages`
string fields to 32,768 chars via `limitTrajectoryPayloadValue`, so there is
no way to read the full prompt an agent actually received once it exceeds
that size.

Adds `OPENCLAW_TRAJECTORY_DEBUG_CAPTURE`: when set, the next
`context.compiled` event on each trajectory recorder (one per run/attempt,
i.e. one turn) is additionally written unbounded — secrets still redacted via
the existing `redactSecrets`/`sanitizeDiagnosticPayload` pipeline, only the
char/array/depth truncation is skipped — to its own JSON file under
`$TMPDIR/openclaw-trajectory-debug/` (override the directory with
`OPENCLAW_TRAJECTORY_DEBUG_CAPTURE_DIR`). The artifact records
`sessionId`/`sessionKey`/`runId`/`type`/`seq` so it is traceable to the exact
session and turn that produced it.

- Default behavior is unchanged when the flag is unset: the 32,768-char cap
  on stored trajectory rows still applies.
- Applies to every agent runtime that goes through the embedded run attempt
  path (`observeEmbeddedAttemptPrompt` → `context.compiled`), including
  `claude-cli`/CLI-backed sessions — the motivating case.
- Docs: added a "Debug-capture the full prompt for one turn" section to
  `docs/tools/trajectory.md`.

## Validation run

- `node scripts/run-vitest.mjs src/trajectory/runtime.test.ts` — 23 passed,
  including 2 new tests (`does not write a debug capture file by default`,
  `writes the untruncated prompt to a debug capture file when enabled`).
- `pnpm tsgo:core` — clean.
- `pnpm tsgo:core:test` — clean.
- `node scripts/run-oxlint.mjs src/trajectory/runtime.ts src/trajectory/runtime.test.ts` — clean.
- `pnpm format src/trajectory/runtime.ts src/trajectory/runtime.test.ts` — no diff beyond authored changes.

## Trade-offs / residual risks

- Capture is scoped to the `context.compiled` event only (the one carrying
  the full assembled prompt/system prompt/tools); other event types are
  unaffected and not captured, by design — this stays a prompt-observability
  tool, not a general trajectory-truncation bypass.
- No built-in auto-off after one turn: the flag is a plain env var, so "one
  turn" is achieved operationally (set it for a single run/restart, then
  unset it) rather than via internal state — this matches how
  `OPENCLAW_TRAJECTORY=0` and other trajectory env toggles already work in
  this file.
- The debug file location defaults to the OS temp dir and is not itself
  redacted-then-deleted; it is meant for short-lived, operator-initiated
  audits, not long-term storage.