### PR TITLE
fix(telegram): keep reactions and poll answers in their original topics

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -748,7 +748,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     `own` means user reactions to bot-sent messages only (best-effort via a sent-message cache). Reaction events still respect Telegram access controls (`dmPolicy`, `allowFrom`, `groupPolicy`, `groupAllowFrom`); unauthorized senders are dropped.
 
-    Telegram does not provide thread IDs in reaction updates. Non-forum groups route to the group chat session. Forum groups recover the originating topic from OpenClaw's bounded message cache (keyed by account, chat, and message ID), so the reaction routes to that topic's session, including its topic agent and conversation bindings. When the reacted-to message is no longer cached the topic is unknown, so OpenClaw skips the reaction notification and logs a warning instead of attributing it to General (`:topic:1`).
+    Telegram does not provide topic metadata in reaction updates. Ordinary non-forum groups remain chat-scoped. Forum and channel Direct Messages reactions recover the originating topic from OpenClaw's bounded message cache (keyed by account, chat, and message ID), so topic config, topic agents, and conversation bindings still apply. If the cached topic is missing or belongs to the wrong scope, OpenClaw skips the reaction notification and logs a warning instead of falling back to General or the base chat.
 
     `allowed_updates` for polling/webhook include `message_reaction` automatically.
 

--- a/extensions/telegram/src/bot-handlers.message-context.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.message-context.runtime.test.ts
@@ -40,18 +40,21 @@ function forumMessage(messageId: number, threadId?: number): Message {
   } as Message;
 }
 
-describe("resolveCachedMessageThreadId", () => {
+describe("resolveCachedMessageThreadSpec", () => {
   beforeEach(() => {
     resetTelegramMessageCacheForTest();
   });
 
   it("recovers the topic of a recorded forum message", async () => {
     const runtime = createRuntime();
-    await runtime.recordMessageForReplyChain(forumMessage(100, TOPIC_ID), TOPIC_ID);
+    await runtime.recordMessageForReplyChain(forumMessage(100, TOPIC_ID), {
+      scope: "forum",
+      id: TOPIC_ID,
+    });
 
     await expect(
-      runtime.resolveCachedMessageThreadId({ chatId: CHAT_ID, messageId: 100 }),
-    ).resolves.toBe(TOPIC_ID);
+      runtime.resolveCachedMessageThreadSpec({ chatId: CHAT_ID, messageId: 100 }),
+    ).resolves.toEqual({ scope: "forum", id: TOPIC_ID });
   });
 
   it("returns undefined for a message that is not in the cache", async () => {
@@ -60,7 +63,7 @@ describe("resolveCachedMessageThreadId", () => {
     // Cache miss must stay unknown; the reaction handler drops rather than
     // attributing the reaction to the General topic.
     await expect(
-      runtime.resolveCachedMessageThreadId({ chatId: CHAT_ID, messageId: 404 }),
+      runtime.resolveCachedMessageThreadSpec({ chatId: CHAT_ID, messageId: 404 }),
     ).resolves.toBeUndefined();
   });
 
@@ -69,7 +72,29 @@ describe("resolveCachedMessageThreadId", () => {
     await runtime.recordMessageForReplyChain(forumMessage(101));
 
     await expect(
-      runtime.resolveCachedMessageThreadId({ chatId: CHAT_ID, messageId: 101 }),
+      runtime.resolveCachedMessageThreadSpec({ chatId: CHAT_ID, messageId: 101 }),
     ).resolves.toBeUndefined();
+  });
+
+  it("recovers a channel Direct Messages scope without reusing raw message_thread_id", async () => {
+    const runtime = createRuntime();
+    const msg = {
+      ...forumMessage(102, 999),
+      chat: {
+        id: CHAT_ID,
+        type: "supergroup",
+        title: "Channel replies",
+        is_direct_messages: true,
+      },
+      direct_messages_topic: { topic_id: TOPIC_ID },
+    } as Message;
+    await runtime.recordMessageForReplyChain(msg, {
+      scope: "direct-messages",
+      id: TOPIC_ID,
+    });
+
+    await expect(
+      runtime.resolveCachedMessageThreadSpec({ chatId: CHAT_ID, messageId: 102 }),
+    ).resolves.toEqual({ scope: "direct-messages", id: TOPIC_ID });
   });
 });

--- a/extensions/telegram/src/bot-handlers.message-context.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-context.runtime.ts
@@ -10,6 +10,7 @@ import type {
   TelegramPromptContextEntry,
 } from "./bot-message-context.types.js";
 import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
+import type { TelegramThreadSpec } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import { resolveTelegramDmHistoryLimit } from "./dm-history.js";
 import {
@@ -26,7 +27,7 @@ import {
   buildTelegramReplyChain,
   createTelegramMessageCache,
   isTelegramMessageFromCurrentBot,
-  resolveProviderObservedTelegramThreadId,
+  resolveProviderObservedTelegramThreadSpec,
   type TelegramCachedMessageNode,
   type TelegramReplyChainEntry,
 } from "./message-cache.js";
@@ -86,14 +87,18 @@ export function createTelegramMessageContextRuntime({
     return isTelegramSelfSenderName(node.sender) ? `${node.sender} (Telegram sender)` : node.sender;
   };
 
-  const recordMessageForReplyChain = (msg: Message, threadId?: number, botUserId?: number) =>
+  const recordMessageForReplyChain = (
+    msg: Message,
+    providerObservedThread?: TelegramThreadSpec,
+    botUserId?: number,
+  ) =>
     messageCache.record({
       accountId,
       chatId: msg.chat.id,
       msg,
       ...(botUserId !== undefined ? { botUserId } : {}),
-      ...(threadId != null ? { providerObservedThreadId: threadId } : {}),
-      ...(threadId != null ? { threadId } : {}),
+      ...(providerObservedThread ? { providerObservedThread } : {}),
+      ...(providerObservedThread?.id != null ? { threadId: providerObservedThread.id } : {}),
     });
 
   const recordMessageResolvedMedia = (params: {
@@ -136,16 +141,16 @@ export function createTelegramMessageContextRuntime({
   // recovers the originating topic from the same bounded cache that records inbound
   // and outbound messages. `undefined` means "thread unknown", never "General": the
   // caller must not substitute a topic id.
-  const resolveCachedMessageThreadId = async (params: {
+  const resolveCachedMessageThreadSpec = async (params: {
     chatId: number | string;
     messageId: number | string;
-  }): Promise<number | undefined> => {
+  }): Promise<TelegramThreadSpec | undefined> => {
     const node = await messageCache.get({
       accountId,
       chatId: params.chatId,
       messageId: String(params.messageId),
     });
-    return resolveProviderObservedTelegramThreadId(node);
+    return resolveProviderObservedTelegramThreadSpec(node);
   };
 
   const buildReplyChainForMessage = (msg: Message) =>
@@ -314,7 +319,7 @@ export function createTelegramMessageContextRuntime({
     recordMessageForReplyChain,
     recordMessageResolvedMedia,
     recordReplyMessageResolvedMedia,
-    resolveCachedMessageThreadId,
+    resolveCachedMessageThreadSpec,
     buildReplyChainForMessage,
     toReplyChainEntry,
     buildPromptContextForMessage,

--- a/extensions/telegram/src/bot-handlers.message-events.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-events.runtime.ts
@@ -144,12 +144,7 @@ export function registerTelegramMessageHandlers(
     if (!gate.allowed) {
       return;
     }
-    const { resolvedThreadId, dmThreadId } = gate.context;
-    await recordMessageForReplyChain(
-      normalizedMsg,
-      resolvedThreadId ?? dmThreadId,
-      params.botUserId,
-    );
+    await recordMessageForReplyChain(normalizedMsg, gate.context.threadSpec, params.botUserId);
   };
 
   const handleInboundMessageLike = async (event: InboundTelegramEvent) => {
@@ -208,7 +203,7 @@ export function registerTelegramMessageHandlers(
         return;
       }
       dispatchDedupeClaims = dispatchDedupe.claims;
-      await recordMessageForReplyChain(event.msg, resolvedThreadId ?? dmThreadId, event.botUserId);
+      await recordMessageForReplyChain(event.msg, gate.context.threadSpec, event.botUserId);
       await processInboundMessage({
         authorizationCfg: gate.context.cfg,
         ctx: event.ctx,

--- a/extensions/telegram/src/bot-handlers.message.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message.runtime.ts
@@ -110,7 +110,7 @@ export function createTelegramHandlerMessageRuntime({
     recordMessageForReplyChain,
     recordMessageResolvedMedia,
     recordReplyMessageResolvedMedia,
-    resolveCachedMessageThreadId,
+    resolveCachedMessageThreadSpec,
     buildReplyChainForMessage,
     toReplyChainEntry,
     buildPromptContextForMessage,
@@ -478,7 +478,7 @@ export function createTelegramHandlerMessageRuntime({
     resolvePromptContextAmbientWatermark,
     recordMessageForReplyChain,
     recordMessageResolvedMedia,
-    resolveCachedMessageThreadId,
+    resolveCachedMessageThreadSpec,
     processMessageWithReplyChain,
   };
 }

--- a/extensions/telegram/src/bot-handlers.poll-answer.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.poll-answer.runtime.ts
@@ -8,7 +8,6 @@ import {
   isTelegramSpooledReplayUpdate,
   recordTelegramMessageProcessingResult,
 } from "./bot-processing-outcome.js";
-import { resolveTelegramThreadSpec } from "./bot/helpers.js";
 import { getPreparedTelegramPollAnswer } from "./poll-answer-context.js";
 import { findTelegramPollRegistryEntry, retireTelegramPollRegistryEntry } from "./poll-registry.js";
 
@@ -78,7 +77,6 @@ export function registerTelegramPollHandlers(
 
       const chatId = entry.chat.id;
       const isGroup = entry.chat.type === "group" || entry.chat.type === "supergroup";
-      const isForum = entry.chat.type === "supergroup" && entry.chat.is_forum === true;
       const senderId = user?.id != null ? String(user.id) : "";
       const senderUsername = user?.username ?? "";
       if (!isGroup && user.id !== chatId) {
@@ -97,11 +95,7 @@ export function registerTelegramPollHandlers(
         chatId,
         isGroup,
         senderId,
-        threadSpec: resolveTelegramThreadSpec({
-          isGroup,
-          isForum,
-          messageThreadId: entry.messageThreadId,
-        }),
+        threadSpec: entry.threadSpec,
       });
       const senderAuthorization = await authorizeTelegramEventSender({
         chatId,
@@ -134,15 +128,17 @@ export function registerTelegramPollHandlers(
 
       const optionLabels = optionIds.map((index) => entry.options[index] ?? `option ${index}`);
       const text = `Poll response to "${entry.question}": ${optionLabels.join(", ")}`;
+      const messageThreadId = "id" in entry.threadSpec ? entry.threadSpec.id : undefined;
       const syntheticMessage = buildSyntheticTextMessage({
         base: {
           message_id: entry.messageId,
           date: Math.floor(Date.now() / 1000),
           chat: entry.chat,
-          ...(entry.messageThreadId == null
+          ...(messageThreadId == null
             ? {}
             : {
-                message_thread_id: entry.messageThreadId,
+                message_thread_id: messageThreadId,
+                is_topic_message: true,
               }),
         },
         from: user,

--- a/extensions/telegram/src/bot-handlers.reaction.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.reaction.runtime.test.ts
@@ -6,6 +6,7 @@ import { defaultTelegramBotDeps } from "./bot-deps.js";
 import { createTelegramHandlerAuthorizationRuntime } from "./bot-handlers.authorization.runtime.js";
 import { registerTelegramReactionHandler } from "./bot-handlers.reaction.runtime.js";
 import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
+import type { TelegramThreadSpec } from "./bot/helpers.js";
 
 const FIRE_EMOJI = "\u{1F525}";
 const FORUM_CHAT_ID = 5678;
@@ -17,8 +18,11 @@ type ReactionHandler = (ctx: Record<string, unknown>) => Promise<void>;
 const enqueueSystemEvent = vi.fn();
 const runtimeLog = vi.fn();
 const runtimeError = vi.fn();
-const resolveCachedMessageThreadId = vi.fn<
-  (params: { chatId: number | string; messageId: number | string }) => Promise<number | undefined>
+const resolveCachedMessageThreadSpec = vi.fn<
+  (params: {
+    chatId: number | string;
+    messageId: number | string;
+  }) => Promise<TelegramThreadSpec | undefined>
 >(async () => undefined);
 
 function buildTelegramConfig(overrides?: {
@@ -104,7 +108,7 @@ function registerHandler(cfg: OpenClawConfig): ReactionHandler {
 
   registerTelegramReactionHandler(
     params,
-    { resolveCachedMessageThreadId },
+    { resolveCachedMessageThreadSpec },
     createTelegramHandlerAuthorizationRuntime(params),
   );
   const handler = handlers.get("message_reaction");
@@ -118,6 +122,7 @@ function forumReactionContext(overrides?: {
   oldReaction?: Array<{ type: string; emoji: string }>;
   newReaction?: Array<{ type: string; emoji: string }>;
   isForum?: boolean;
+  isDirectMessages?: boolean;
   chatType?: string;
 }) {
   return {
@@ -127,6 +132,7 @@ function forumReactionContext(overrides?: {
         id: FORUM_CHAT_ID,
         type: overrides?.chatType ?? "supergroup",
         ...(overrides?.isForum === false ? {} : { is_forum: true }),
+        ...(overrides?.isDirectMessages ? { is_direct_messages: true } : {}),
       },
       message_id: REACTED_MESSAGE_ID,
       user: { id: 10, first_name: "Bob", username: "bob_user" },
@@ -149,19 +155,19 @@ describe("registerTelegramReactionHandler forum topic recovery", () => {
     enqueueSystemEvent.mockClear();
     runtimeLog.mockClear();
     runtimeError.mockClear();
-    resolveCachedMessageThreadId.mockReset();
-    resolveCachedMessageThreadId.mockResolvedValue(undefined);
+    resolveCachedMessageThreadSpec.mockReset();
+    resolveCachedMessageThreadSpec.mockResolvedValue(undefined);
   });
 
   it("recovers the cached topic before authorization and routes to that topic", async () => {
-    resolveCachedMessageThreadId.mockResolvedValue(FORUM_TOPIC_ID);
+    resolveCachedMessageThreadSpec.mockResolvedValue({ scope: "forum", id: FORUM_TOPIC_ID });
     const handler = registerHandler(
       buildTelegramConfig({ topics: { [String(FORUM_TOPIC_ID)]: { enabled: true } } }),
     );
 
     await handler(forumReactionContext());
 
-    expect(resolveCachedMessageThreadId).toHaveBeenCalledWith({
+    expect(resolveCachedMessageThreadSpec).toHaveBeenCalledWith({
       chatId: FORUM_CHAT_ID,
       messageId: REACTED_MESSAGE_ID,
     });
@@ -172,7 +178,7 @@ describe("registerTelegramReactionHandler forum topic recovery", () => {
   });
 
   it("routes a recovered topic through its configured topic agent", async () => {
-    resolveCachedMessageThreadId.mockResolvedValue(FORUM_TOPIC_ID);
+    resolveCachedMessageThreadSpec.mockResolvedValue({ scope: "forum", id: FORUM_TOPIC_ID });
     const handler = registerHandler(
       buildTelegramConfig({
         topics: { [String(FORUM_TOPIC_ID)]: { enabled: true, agentId: "topicbot" } },
@@ -186,7 +192,7 @@ describe("registerTelegramReactionHandler forum topic recovery", () => {
   });
 
   it("applies the recovered topic's disabled config instead of the General topic's", async () => {
-    resolveCachedMessageThreadId.mockResolvedValue(FORUM_TOPIC_ID);
+    resolveCachedMessageThreadSpec.mockResolvedValue({ scope: "forum", id: FORUM_TOPIC_ID });
     const handler = registerHandler(
       buildTelegramConfig({
         topics: { "1": { enabled: true }, [String(FORUM_TOPIC_ID)]: { enabled: false } },
@@ -199,7 +205,7 @@ describe("registerTelegramReactionHandler forum topic recovery", () => {
   });
 
   it("drops a forum reaction with an unknown topic instead of guessing General", async () => {
-    resolveCachedMessageThreadId.mockResolvedValue(undefined);
+    resolveCachedMessageThreadSpec.mockResolvedValue(undefined);
     const handler = registerHandler(buildTelegramConfig({ topics: { "1": { enabled: true } } }));
 
     await handler(forumReactionContext());
@@ -215,12 +221,46 @@ describe("registerTelegramReactionHandler forum topic recovery", () => {
     expect(logged).not.toContain(FIRE_EMOJI);
   });
 
+  it("routes channel Direct Messages reactions through topic config and agent", async () => {
+    resolveCachedMessageThreadSpec.mockResolvedValue({
+      scope: "direct-messages",
+      id: FORUM_TOPIC_ID,
+    });
+    const handler = registerHandler(
+      buildTelegramConfig({
+        topics: { [String(FORUM_TOPIC_ID)]: { enabled: true, agentId: "direct-topic-agent" } },
+      }),
+    );
+
+    await handler(forumReactionContext({ isForum: false, isDirectMessages: true }));
+
+    expect(enqueueSystemEvent).toHaveBeenCalledTimes(1);
+    expect(String(systemEventOptions().sessionKey)).toContain("direct-topic-agent");
+    expect(String(systemEventOptions().sessionKey)).toContain(
+      `telegram:group:${FORUM_CHAT_ID}:topic:${FORUM_TOPIC_ID}`,
+    );
+  });
+
+  it.each([
+    { name: "cache miss", recovered: undefined },
+    { name: "scope mismatch", recovered: { scope: "forum" as const, id: FORUM_TOPIC_ID } },
+  ])("drops a channel Direct Messages reaction on $name", async ({ recovered }) => {
+    resolveCachedMessageThreadSpec.mockResolvedValue(recovered);
+    const handler = registerHandler(buildTelegramConfig());
+
+    await handler(forumReactionContext({ isForum: false, isDirectMessages: true }));
+
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(runtimeLog).toHaveBeenCalledTimes(1);
+    expect(String(runtimeLog.mock.calls[0]?.[0])).toContain("thread-context-unavailable");
+  });
+
   it("never consults the message cache for non-forum groups", async () => {
     const handler = registerHandler(buildTelegramConfig());
 
     await handler(forumReactionContext({ isForum: false }));
 
-    expect(resolveCachedMessageThreadId).not.toHaveBeenCalled();
+    expect(resolveCachedMessageThreadSpec).not.toHaveBeenCalled();
     expect(enqueueSystemEvent).toHaveBeenCalledTimes(1);
     expect(String(systemEventOptions().sessionKey)).not.toContain(":topic:");
   });
@@ -230,7 +270,7 @@ describe("registerTelegramReactionHandler forum topic recovery", () => {
 
     await handler(forumReactionContext({ isForum: false, chatType: "private" }));
 
-    expect(resolveCachedMessageThreadId).not.toHaveBeenCalled();
+    expect(resolveCachedMessageThreadSpec).not.toHaveBeenCalled();
     expect(enqueueSystemEvent).toHaveBeenCalledTimes(1);
     expect(String(systemEventOptions().sessionKey)).not.toContain(":topic:");
     expect(String(systemEventOptions().sessionKey)).not.toContain(":group:");
@@ -250,7 +290,7 @@ describe("registerTelegramReactionHandler forum topic recovery", () => {
       }),
     );
 
-    expect(resolveCachedMessageThreadId).not.toHaveBeenCalled();
+    expect(resolveCachedMessageThreadSpec).not.toHaveBeenCalled();
     expect(enqueueSystemEvent).not.toHaveBeenCalled();
     expect(runtimeLog).not.toHaveBeenCalled();
   });

--- a/extensions/telegram/src/bot-handlers.reaction.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.reaction.runtime.ts
@@ -10,16 +10,17 @@ import {
   buildTelegramGroupPeerId,
   buildTelegramParentPeer,
   resolveTelegramThreadSpec,
+  type TelegramThreadSpec,
 } from "./bot/helpers.js";
 import { resolveTelegramConversationRoute } from "./conversation-route.js";
 
-/** Stable operator-facing reason for a forum reaction dropped without a known topic. */
+/** Stable operator-facing reason for a scoped reaction dropped without a known topic. */
 const TELEGRAM_REACTION_THREAD_UNRESOLVED_REASON = "thread-context-unavailable";
 
 /** Only the message-cache lookup this handler needs, so tests can supply it directly. */
 type TelegramReactionThreadRecovery = Pick<
   TelegramHandlerMessageRuntime,
-  "resolveCachedMessageThreadId"
+  "resolveCachedMessageThreadSpec"
 >;
 
 export function registerTelegramReactionHandler(
@@ -46,7 +47,8 @@ export function registerTelegramReactionHandler(
       const senderId = user?.id != null ? String(user.id) : "";
       const senderUsername = user?.username ?? "";
       const isGroup = reaction.chat.type === "group" || reaction.chat.type === "supergroup";
-      const isForum = reaction.chat.is_forum === true;
+      const isDirectMessagesChat = reaction.chat.is_direct_messages === true;
+      const isForum = !isDirectMessagesChat && reaction.chat.is_forum === true;
       const authorizationCfg = telegramDeps.getRuntimeConfig();
       const authorizationTelegramCfg = resolveTelegramAccount({
         cfg: authorizationCfg,
@@ -85,23 +87,23 @@ export function registerTelegramReactionHandler(
         return;
       }
 
-      // `MessageReactionUpdated` omits `message_thread_id`, so a forum reaction only has a
-      // topic if the reacted-to message is still in the bounded message cache. Recover it
-      // before authorization: topic allowlists and topic agents are both keyed by thread
-      // id, so an assumed thread here authorizes and routes the wrong topic.
-      let cachedForumThreadId: number | undefined;
-      if (isForum) {
-        cachedForumThreadId = await threadRecovery.resolveCachedMessageThreadId({
+      // `MessageReactionUpdated` omits every topic field. Scoped reactions only have a
+      // route if the reacted-to message is still in the bounded message cache.
+      let recoveredThreadSpec: TelegramThreadSpec | undefined;
+      const requiredScope = isDirectMessagesChat
+        ? "direct-messages"
+        : isForum
+          ? "forum"
+          : undefined;
+      if (requiredScope) {
+        recoveredThreadSpec = await threadRecovery.resolveCachedMessageThreadSpec({
           chatId,
           messageId,
         });
-        if (cachedForumThreadId === undefined) {
-          // Never fall back to General: that would authorize and enqueue this reaction
-          // against a topic the user did not react in. Degrade to one bounded warning
-          // carrying route ids only.
+        if (recoveredThreadSpec?.scope !== requiredScope || recoveredThreadSpec.id === undefined) {
           runtime.log?.(
             warn(
-              `telegram: skipped forum reaction account=${accountId} chat=${chatId} message=${messageId} reason=${TELEGRAM_REACTION_THREAD_UNRESOLVED_REASON}`,
+              `telegram: skipped scoped reaction account=${accountId} chat=${chatId} message=${messageId} reason=${TELEGRAM_REACTION_THREAD_UNRESOLVED_REASON}`,
             ),
           );
           return;
@@ -113,11 +115,12 @@ export function registerTelegramReactionHandler(
         chatId,
         isGroup,
         senderId,
-        threadSpec: resolveTelegramThreadSpec({
-          isGroup,
-          isForum,
-          messageThreadId: cachedForumThreadId,
-        }),
+        threadSpec:
+          recoveredThreadSpec ??
+          resolveTelegramThreadSpec({
+            isGroup,
+            isForum,
+          }),
       });
       const senderAuthorization = await authorizeTelegramEventSender({
         chatId,
@@ -149,16 +152,16 @@ export function registerTelegramReactionHandler(
 
       const resolvedThreadId = eventAuthContext.resolvedThreadId;
       let sessionKey: string;
-      if (isForum) {
-        // Forum topics carry topic agents and conversation bindings, so the recovered
-        // topic goes through the canonical route resolver instead of a bare peer route.
+      if (recoveredThreadSpec) {
+        // Scoped topics carry topic agents and conversation bindings, so the recovered
+        // spec goes through the canonical route resolver instead of a bare peer route.
         sessionKey = resolveTelegramConversationRoute({
           cfg: eventAuthContext.cfg,
           accountId,
           chatId,
           isGroup,
           resolvedThreadId,
-          replyThreadId: resolvedThreadId,
+          replyThreadId: recoveredThreadSpec.id,
           senderId,
           topicAgentId: eventAuthContext.topicConfig?.agentId,
         }).route.sessionKey;

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -410,7 +410,9 @@ export const buildTelegramMessageContext = async ({
   });
   const useDmThreadSession = shouldUseTelegramDmThreadSession({
     dmThreadId,
-    botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(primaryCtx.me),
+    botHasTopicsEnabled:
+      (threadSpec.scope === "dm" && msg.is_topic_message === true) ||
+      resolveTelegramBotHasTopicsEnabled(primaryCtx.me),
   });
   const threadKeys =
     useDmThreadSession && dmThreadId != null

--- a/extensions/telegram/src/bot-message-dispatch.delivery-transcript.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.delivery-transcript.test.ts
@@ -300,7 +300,7 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-transcript", () => {
     });
     expect(streamedReply?.node.threadBinding).toEqual({
       kind: "provider-observed-v1",
-      threadId: "777",
+      threadSpec: { scope: "dm", id: 777 },
     });
   });
 

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -605,9 +605,9 @@ describe("createTelegramBot", () => {
     });
     await store.register("default:poll-topic", {
       pollId: "poll-topic",
-      chat: { id: -1001, type: "supergroup", title: "Reviewers", is_forum: true },
+      chat: { id: -1001, type: "supergroup", title: "Reviewers" },
       messageId: 7,
-      messageThreadId: 9,
+      threadSpec: { scope: "forum", id: 9 },
       question: "Ready?",
       options: ["Yes", "No"],
     });

--- a/extensions/telegram/src/bot.forum-ingress.response-body-timeout.integration.test.ts
+++ b/extensions/telegram/src/bot.forum-ingress.response-body-timeout.integration.test.ts
@@ -82,7 +82,9 @@ describe("Telegram supergroup ingress with a stalled Bot API response body", () 
       invalidEntries: [],
     };
     const authorization = {
-      authorizeInboundMessage: vi.fn(async () => ({
+      authorizeInboundMessage: vi.fn<
+        Parameters<typeof registerTelegramMessageHandlers>[2]["authorizeInboundMessage"]
+      >(async (params) => ({
         allowed: true as const,
         effectiveDmAllow: emptyAllow,
         context: {
@@ -90,6 +92,7 @@ describe("Telegram supergroup ingress with a stalled Bot API response body", () 
           telegramCfg: {},
           allowFrom: [],
           dmPolicy: "open" as const,
+          threadSpec: params.isGroup ? ({ scope: "none" } as const) : ({ scope: "dm" } as const),
           storeAllowFrom: [],
           effectiveGroupAllow: emptyAllow,
           hasGroupAllowOverride: false,

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -201,6 +201,7 @@ function makeTelegramPollRegistryEntry(
 ): Omit<TelegramPollRegistryEntry, "createdAt"> {
   return {
     chat: { id: 9876, type: "private", first_name: "Ada" },
+    threadSpec: { scope: "dm" },
     question: "Ready?",
     options: ["Yes", "No"],
     ...overrides,
@@ -934,10 +935,9 @@ describe("createTelegramBot", () => {
           id: -1001234567890,
           type: "supergroup",
           title: "Reviewers",
-          is_forum: true,
         },
         messageId: 321,
-        messageThreadId: 99,
+        threadSpec: { scope: "forum", id: 99 },
         question: "Escalate?",
       }),
     );
@@ -995,7 +995,7 @@ describe("createTelegramBot", () => {
           is_forum: true,
         },
         messageId: 324,
-        messageThreadId: 99,
+        threadSpec: { scope: "forum", id: 99 },
         question: "Escalate?",
       }),
     );
@@ -1091,7 +1091,7 @@ describe("createTelegramBot", () => {
       makeTelegramPollRegistryEntry({
         pollId: "poll-dm-topic",
         messageId: 323,
-        messageThreadId: 42,
+        threadSpec: { scope: "dm", id: 42 },
       }),
     );
 
@@ -1100,7 +1100,7 @@ describe("createTelegramBot", () => {
 
       await getTelegramPollAnswerHandlerForTests()({
         update: { update_id: 9002 },
-        me: { id: 999, username: "openclaw_bot", has_topics_enabled: true },
+        me: { id: 999, username: "openclaw_bot", has_topics_enabled: false },
         getFile: getEmptyTelegramFile,
         pollAnswer: {
           poll_id: "poll-dm-topic",

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -237,6 +237,7 @@ export async function resolveTelegramGroupAllowFromContext(params: {
     topicConfig?: TelegramTopicConfig;
   };
 }): Promise<{
+  threadSpec: TelegramThreadSpec;
   resolvedThreadId?: number;
   dmThreadId?: number;
   storeAllowFrom: string[];
@@ -293,6 +294,7 @@ export async function resolveTelegramGroupAllowFromContext(params: {
   const effectiveGroupAllow = normalizeAllowFrom(expandedGroupAllowFrom);
   const hasGroupAllowOverride = groupAllowOverride !== undefined;
   return {
+    threadSpec,
     resolvedThreadId,
     dmThreadId,
     storeAllowFrom,

--- a/extensions/telegram/src/message-cache-persistence.ts
+++ b/extensions/telegram/src/message-cache-persistence.ts
@@ -17,7 +17,10 @@ export const TELEGRAM_MESSAGE_CACHE_PERSISTED_VERSION = 1;
 
 export type TelegramMessageThreadBinding = {
   kind: "provider-observed-v1";
-  threadId: string;
+  threadSpec:
+    | { scope: "direct-messages"; id: number }
+    | { scope: "dm"; id: number }
+    | { scope: "forum"; id: number };
 };
 
 export type TelegramResolvedMedia = {

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -10,7 +10,7 @@ import {
   buildTelegramReplyChain,
   createTelegramMessageCache,
   hasProviderObservedTelegramThreadBinding,
-  resolveProviderObservedTelegramThreadId,
+  resolveProviderObservedTelegramThreadSpec,
 } from "./message-cache.js";
 import { resetTelegramMessageCacheForTest as resetCache } from "./runtime.test-support.js";
 
@@ -25,7 +25,10 @@ type PersistedValue = {
   botUserId?: number;
   promptContextProjection?: unknown;
   resolvedMedia?: TelegramResolvedMedia;
-  threadBinding?: { kind: "provider-observed-v1"; threadId: string };
+  threadBinding?: {
+    kind: "provider-observed-v1";
+    threadSpec: { scope: "direct-messages" | "dm" | "forum"; id: number };
+  };
   threadId?: string;
 };
 
@@ -195,7 +198,11 @@ describe("telegram message cache", () => {
         is_topic_message: true,
         reply_to_message: parent,
       }),
-      { chatId: -1001, threadId: 77, providerObservedThreadId: 77 },
+      {
+        chatId: -1001,
+        threadId: 77,
+        providerObservedThread: { scope: "forum", id: 77 },
+      },
     );
 
     expect(entries.size).toBe(2);
@@ -203,7 +210,8 @@ describe("telegram message cache", () => {
       Array.from(entries.values()).every(
         (value) =>
           value.threadBinding?.kind === "provider-observed-v1" &&
-          value.threadBinding.threadId === "77",
+          value.threadBinding.threadSpec.scope === "forum" &&
+          value.threadBinding.threadSpec.id === 77,
       ),
     ).toBe(true);
 
@@ -212,7 +220,7 @@ describe("telegram message cache", () => {
     for (const messageId of ["901", "902"]) {
       const node = await get(reloaded, messageId, { chatId: -1001 });
       expect(hasProviderObservedTelegramThreadBinding(node, 77)).toBe(true);
-      expect(resolveProviderObservedTelegramThreadId(node)).toBe(77);
+      expect(resolveProviderObservedTelegramThreadSpec(node)).toEqual({ scope: "forum", id: 77 });
     }
   });
 
@@ -240,17 +248,52 @@ describe("telegram message cache", () => {
     const recorded = await record(cache, root, {
       chatId: -1001,
       threadId: 77,
-      providerObservedThreadId: 77,
+      providerObservedThread: { scope: "forum", id: 77 },
     });
 
     expect(recorded.threadId).toBe("77");
-    expect(resolveProviderObservedTelegramThreadId(recorded)).toBe(77);
+    expect(resolveProviderObservedTelegramThreadSpec(recorded)).toEqual({
+      scope: "forum",
+      id: 77,
+    });
     expect((await get(cache, "905", { chatId: -1001 }))?.threadId).toBe("88");
     expect((await get(cache, "904", { chatId: -1001 }))?.threadId).toBe("88");
     const persistedRoot = Array.from(entries.values()).find(
       (entry) => entry.sourceMessage.message_id === 906,
     );
     expect(persistedRoot?.threadId).toBe("77");
+  });
+
+  it("persists a channel Direct Messages binding ahead of conflicting raw thread metadata", async () => {
+    const { bucketKey, store } = createMemoryStore();
+    const cache = cacheFor(bucketKey, store);
+    await record(
+      cache,
+      message(904, "Ada", {
+        chat: {
+          id: -1002,
+          type: "supergroup",
+          title: "Channel replies",
+          is_direct_messages: true,
+        },
+        direct_messages_topic: { topic_id: 77 },
+        message_thread_id: 999,
+        is_topic_message: true,
+      }),
+      {
+        chatId: -1002,
+        threadId: 999,
+        providerObservedThread: { scope: "direct-messages", id: 77 },
+      },
+    );
+
+    resetCache();
+    const reloaded = await get(cacheFor(bucketKey, store), "904", { chatId: -1002 });
+    expect(reloaded?.threadId).toBe("77");
+    expect(resolveProviderObservedTelegramThreadSpec(reloaded)).toEqual({
+      scope: "direct-messages",
+      id: 77,
+    });
   });
 
   it("does not resolve caller-only topic metadata as a provider-observed binding", async () => {
@@ -266,7 +309,7 @@ describe("telegram message cache", () => {
     );
 
     const node = await get(cache, "903", { chatId: -1001 });
-    expect(resolveProviderObservedTelegramThreadId(node)).toBeUndefined();
+    expect(resolveProviderObservedTelegramThreadSpec(node)).toBeUndefined();
   });
 
   it("hydrates reply chains from persisted cached messages", async () => {
@@ -634,7 +677,6 @@ describe("telegram message cache", () => {
     });
     expect(reloaded?.promptContextProjectionMarker).toBeUndefined();
     expect(hasProviderObservedTelegramThreadBinding(reloaded, 77)).toBe(false);
-    expect(resolveProviderObservedTelegramThreadId(reloaded)).toBeUndefined();
   });
 
   it("rejects unknown future persisted cache versions", async () => {

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -15,6 +15,7 @@ import {
   extractTelegramLocation,
   getTelegramTextParts,
   normalizeForwardedContext,
+  type TelegramThreadSpec,
 } from "./bot/helpers.js";
 import {
   isTelegramMessageCacheSourceMessage,
@@ -60,7 +61,7 @@ type TelegramMessageCache = {
     botUserId?: number;
     promptContextProjection?: TelegramPromptContextProjection;
     /** Set only while recording an authenticated provider event or response. */
-    providerObservedThreadId?: number;
+    providerObservedThread?: TelegramThreadSpec;
     threadId?: number;
   }) => Promise<TelegramCachedMessageNode>;
   recordResolvedMedia: (params: {
@@ -214,8 +215,8 @@ function normalizeMessageNode(
   const forwardedFrom = normalizeForwardedContext(msg);
   const replyMessage = resolveReplyMessage(msg);
   const body = resolveMessageBody(msg, params.promptContextProjectionMarker !== undefined);
-  const threadId = parseTelegramMessageThreadId(params.threadId);
-  const threadBinding = normalizeTelegramMessageThreadBinding(params.threadBinding, threadId);
+  const threadBinding = normalizeTelegramMessageThreadBinding(params.threadBinding);
+  const threadId = parseTelegramMessageThreadId(threadBinding?.threadSpec.id ?? params.threadId);
   const timestamp = resolveMessageTimestamp(msg);
   return {
     sourceMessage: msg,
@@ -243,40 +244,47 @@ function normalizeMessageNode(
 
 function normalizeTelegramMessageThreadBinding(
   value: unknown,
-  threadId: unknown,
 ): TelegramMessageThreadBinding | undefined {
   if (!isRecord(value) || value.kind !== "provider-observed-v1") {
     return undefined;
   }
-  const normalizedThreadId = parseTelegramMessageThreadId(threadId);
-  const observedThreadId = parseTelegramMessageThreadId(value.threadId);
-  if (normalizedThreadId === undefined || observedThreadId !== normalizedThreadId) {
+  const threadSpec = value.threadSpec;
+  if (!isRecord(threadSpec)) {
     return undefined;
   }
-  return { kind: "provider-observed-v1", threadId: String(normalizedThreadId) };
+  const id = parseTelegramMessageThreadId(threadSpec.id);
+  if (
+    id === undefined ||
+    (threadSpec.scope !== "direct-messages" &&
+      threadSpec.scope !== "dm" &&
+      threadSpec.scope !== "forum")
+  ) {
+    return undefined;
+  }
+  return { kind: "provider-observed-v1", threadSpec: { scope: threadSpec.scope, id } };
 }
 
 function createTelegramMessageThreadBinding(
-  threadId: unknown,
+  threadSpec: TelegramThreadSpec | undefined,
 ): TelegramMessageThreadBinding | undefined {
-  const normalizedThreadId = parseTelegramMessageThreadId(threadId);
-  return normalizedThreadId === undefined
-    ? undefined
-    : { kind: "provider-observed-v1", threadId: String(normalizedThreadId) };
+  return normalizeTelegramMessageThreadBinding({ kind: "provider-observed-v1", threadSpec });
 }
 
 export function hasProviderObservedTelegramThreadBinding(
   node: TelegramCachedMessageNode | null | undefined,
   threadId: unknown,
 ): boolean {
-  return normalizeTelegramMessageThreadBinding(node?.threadBinding, threadId) !== undefined;
+  const normalizedThreadId = parseTelegramMessageThreadId(threadId);
+  return (
+    normalizedThreadId !== undefined &&
+    resolveProviderObservedTelegramThreadSpec(node)?.id === normalizedThreadId
+  );
 }
 
-export function resolveProviderObservedTelegramThreadId(
+export function resolveProviderObservedTelegramThreadSpec(
   node: TelegramCachedMessageNode | null | undefined,
-): number | undefined {
-  const threadId = parseTelegramMessageThreadId(node?.threadId);
-  return hasProviderObservedTelegramThreadBinding(node, threadId) ? threadId : undefined;
+): TelegramMessageThreadBinding["threadSpec"] | undefined {
+  return normalizeTelegramMessageThreadBinding(node?.threadBinding)?.threadSpec;
 }
 
 function normalizeMessageNodes(
@@ -304,14 +312,18 @@ function normalizeMessageNodes(
       (message as { message_thread_id?: unknown }).message_thread_id,
     );
     const inheritedThread = parseTelegramMessageThreadId(inheritedThreadId);
+    const observedBinding = normalizeTelegramMessageThreadBinding(threadBinding);
+    const threadId =
+      mode === "authoritative"
+        ? (observedBinding?.threadSpec.id ?? inheritedThread ?? embeddedThreadId)
+        : (embeddedThreadId ?? inheritedThread);
+    const matchingBinding =
+      observedBinding?.threadSpec.id === threadId ? observedBinding : undefined;
     const node = normalizeMessageNode(message, {
-      threadId:
-        mode === "authoritative"
-          ? (inheritedThread ?? embeddedThreadId)
-          : (embeddedThreadId ?? inheritedThread),
+      ...(threadId !== undefined ? { threadId } : {}),
       ...(promptContextProjectionMarker ? { promptContextProjectionMarker } : {}),
       ...(resolvedMedia ? { resolvedMedia } : {}),
-      ...(threadBinding ? { threadBinding } : {}),
+      ...(matchingBinding ? { threadBinding: matchingBinding } : {}),
     });
     if (visited.has(node.messageId)) {
       return;
@@ -365,7 +377,7 @@ function parsePersistedCacheValue(key: string, value: unknown) {
       : undefined;
   const threadBinding =
     value.version === TELEGRAM_MESSAGE_CACHE_PERSISTED_VERSION
-      ? normalizeTelegramMessageThreadBinding(value.threadBinding, threadId)
+      ? normalizeTelegramMessageThreadBinding(value.threadBinding)
       : undefined;
   const resolvedMedia = parseTelegramResolvedMedia(value.resolvedMedia);
   return normalizeMessageNodes(value.sourceMessage, {
@@ -423,7 +435,6 @@ function mergeCachedMessageNode(
   incoming: TelegramCachedMessageNode,
   mode: TelegramMessageObservationMode,
 ): TelegramCachedMessageNode {
-  const threadId = parseTelegramMessageThreadId(incoming.threadId ?? existing.threadId);
   const mergedSourceMessage =
     mode === "authoritative"
       ? mergeAuthoritativeTelegramSourceMessage(existing.sourceMessage, incoming.sourceMessage)
@@ -439,8 +450,11 @@ function mergeCachedMessageNode(
   const promptContextProjectionMarker =
     incoming.promptContextProjectionMarker ?? existing.promptContextProjectionMarker;
   const threadBinding =
-    normalizeTelegramMessageThreadBinding(incoming.threadBinding, threadId) ??
-    normalizeTelegramMessageThreadBinding(existing.threadBinding, threadId);
+    normalizeTelegramMessageThreadBinding(incoming.threadBinding) ??
+    normalizeTelegramMessageThreadBinding(existing.threadBinding);
+  const threadId = parseTelegramMessageThreadId(
+    threadBinding?.threadSpec.id ?? incoming.threadId ?? existing.threadId,
+  );
   const primaryMedia = resolveTelegramPrimaryMedia(sourceMessage);
   const resolvedMedia =
     existing.resolvedMedia?.fileUniqueId === primaryMedia?.fileRef.file_unique_id
@@ -659,11 +673,11 @@ export function createTelegramMessageCache(params?: {
       chatId,
       msg,
       promptContextProjection,
-      providerObservedThreadId,
+      providerObservedThread,
       threadId,
     }) => {
       await hydrateMessageCacheBucket(bucket, maxMessages, scopeKey);
-      const threadBinding = createTelegramMessageThreadBinding(providerObservedThreadId);
+      const threadBinding = createTelegramMessageThreadBinding(providerObservedThread);
       const observations = normalizeMessageNodes(msg, {
         threadId,
         ...(promptContextProjection && isTelegramMessageFromCurrentBot(msg, botUserId)

--- a/extensions/telegram/src/message-topic-binding.test.ts
+++ b/extensions/telegram/src/message-topic-binding.test.ts
@@ -77,7 +77,9 @@ async function recordMessage(params: {
     chatId: -1001,
     msg: topicMessage(params.messageId, params.threadId),
     threadId: params.threadId,
-    ...(params.providerObserved ? { providerObservedThreadId: params.threadId } : {}),
+    ...(params.providerObserved
+      ? { providerObservedThread: { scope: "forum" as const, id: params.threadId } }
+      : {}),
   });
 }
 

--- a/extensions/telegram/src/outbound-message-context.test.ts
+++ b/extensions/telegram/src/outbound-message-context.test.ts
@@ -133,6 +133,7 @@ describe("recordOutboundMessageForPromptContext", () => {
     const providerThread = await recordAndRead({
       ...common,
       messageId: 701,
+      successfulSendThread: { id: 77, scope: "forum" },
       message: {
         chat: { id: -1001, type: "supergroup", title: "QA" },
         date: 1_736_380_701,
@@ -143,6 +144,32 @@ describe("recordOutboundMessageForPromptContext", () => {
       },
     });
     expect(hasProviderObservedTelegramThreadBinding(providerThread, 77)).toBe(true);
+  });
+
+  it("records the successful channel Direct Messages spec ahead of raw message_thread_id", async () => {
+    const cached = await recordAndRead({
+      account: { accountId: "default", name: "Configured Agent" },
+      chatId: -1002,
+      messageId: 704,
+      messageThreadId: 999,
+      successfulSendThread: { id: 77, scope: "direct-messages" },
+      message: {
+        chat: {
+          id: -1002,
+          type: "supergroup",
+          title: "Channel replies",
+        },
+        date: 1_736_380_704,
+        from: { id: 999, is_bot: true, first_name: "OpenClaw" },
+        message_id: 704,
+        message_thread_id: 999,
+        direct_messages_topic: { topic_id: 77 },
+        text: "Bot replied in channel Direct Messages",
+      },
+    });
+
+    expect(cached?.threadId).toBe("77");
+    expect(cached?.threadBinding?.threadSpec).toEqual({ scope: "direct-messages", id: 77 });
   });
 
   it("binds a successful General-topic response from trusted send context", async () => {

--- a/extensions/telegram/src/outbound-message-context.ts
+++ b/extensions/telegram/src/outbound-message-context.ts
@@ -9,7 +9,7 @@ import { buildTelegramSelfSenderName } from "./group-history-window.js";
 import { resolveTelegramMessageCacheScope } from "./message-cache-persistence.js";
 import { createTelegramMessageCache } from "./message-cache.js";
 import type { TelegramPromptContextProjection } from "./prompt-context-projection.js";
-import { resolveTelegramProviderObservedThreadId } from "./provider-thread-proof.js";
+import { resolveTelegramProviderObservedThreadSpec } from "./provider-thread-proof.js";
 
 type TelegramOutboundPromptContextUser = {
   id?: number;
@@ -30,6 +30,7 @@ export type TelegramOutboundPromptContextMessage = {
   text?: string;
   caption?: string;
   message_thread_id?: number;
+  direct_messages_topic?: { topic_id?: number };
 };
 
 type TelegramOutboundPromptContextAccount = {
@@ -142,11 +143,11 @@ export async function recordOutboundMessageForPromptContext(params: {
   recordGroupHistory?: boolean;
 }): Promise<boolean> {
   try {
-    const providerObservedThreadId = resolveTelegramProviderObservedThreadId({
+    const providerObservedThread = resolveTelegramProviderObservedThreadSpec({
       message: params.message,
       successfulSendThread: params.successfulSendThread,
     });
-    const messageThreadId = params.messageThreadId ?? providerObservedThreadId;
+    const messageThreadId = providerObservedThread?.id ?? params.messageThreadId;
     const cacheMessage = buildOutboundCacheMessage({
       ...params,
       ...(messageThreadId !== undefined ? { messageThreadId } : {}),
@@ -166,7 +167,7 @@ export async function recordOutboundMessageForPromptContext(params: {
       ...(params.promptContextProjection
         ? { promptContextProjection: params.promptContextProjection }
         : {}),
-      ...(providerObservedThreadId !== undefined ? { providerObservedThreadId } : {}),
+      ...(providerObservedThread ? { providerObservedThread } : {}),
       ...(messageThreadId !== undefined ? { threadId: messageThreadId } : {}),
     });
     if (params.recordGroupHistory !== false) {

--- a/extensions/telegram/src/poll-registry.test.ts
+++ b/extensions/telegram/src/poll-registry.test.ts
@@ -9,6 +9,7 @@ import {
   findTelegramPollRegistryEntry,
   recordTelegramPollRegistryEntry,
   retireTelegramPollRegistryEntry,
+  type TelegramPollRegistryEntry,
 } from "./poll-registry.js";
 import { setTelegramRuntime } from "./runtime.js";
 import { clearTelegramRuntimeForTest } from "./runtime.test-support.js";
@@ -16,15 +17,6 @@ import type { TelegramRuntime } from "./runtime.types.js";
 
 const TELEGRAM_POLL_REGISTRY_NAMESPACE = "telegram.poll-registry";
 const TELEGRAM_POLL_REGISTRY_MAX_ENTRIES = 10_000;
-
-type TelegramPollRegistryEntry = {
-  pollId: string;
-  chat: { id: number; type: "private"; first_name: string };
-  messageId: number;
-  messageThreadId?: number;
-  question: string;
-  options: string[];
-};
 
 function installTelegramStateRuntime(
   openKeyedStore: TelegramRuntime["state"]["openKeyedStore"],
@@ -56,22 +48,44 @@ describe("telegram poll registry", () => {
     resetPluginStateStoreForTests();
   });
 
-  it("stores and retrieves poll registry entries", async () => {
+  it.each([
+    {
+      name: "base private chat",
+      chat: { id: 123, type: "private" as const, first_name: "Ada" },
+      threadSpec: { scope: "dm" as const },
+    },
+    {
+      name: "bot-private topic",
+      chat: { id: 123, type: "private" as const, first_name: "Ada" },
+      threadSpec: { scope: "dm" as const, id: 77 },
+    },
+    {
+      name: "regular group",
+      chat: { id: -123, type: "group" as const, title: "Reviewers" },
+      threadSpec: { scope: "none" as const },
+    },
+    {
+      name: "forum topic without redundant chat metadata",
+      chat: { id: -124, type: "supergroup" as const, title: "Reviewers" },
+      threadSpec: { scope: "forum" as const, id: 88 },
+    },
+  ])("stores and retrieves $name thread specs", async ({ chat, threadSpec }) => {
+    const threadId = "id" in threadSpec ? threadSpec.id : undefined;
+    const pollId = `poll-${threadSpec.scope}-${threadId ?? "base"}`;
     await recordTelegramPollRegistryEntry({
-      pollId: "poll-1",
-      chat: { id: 123, type: "private", first_name: "Ada" },
+      pollId,
+      chat,
       messageId: 44,
-      messageThreadId: 77,
+      threadSpec,
       question: "Ready?",
       options: ["Yes", "No"],
     });
 
-    await expect(findTelegramPollRegistryEntry({ pollId: "poll-1" })).resolves.toEqual(
+    await expect(findTelegramPollRegistryEntry({ pollId })).resolves.toEqual(
       expect.objectContaining({
-        pollId: "poll-1",
-        chat: { id: 123, type: "private", first_name: "Ada" },
+        chat,
         messageId: 44,
-        messageThreadId: 77,
+        threadSpec,
         question: "Ready?",
         options: ["Yes", "No"],
       }),
@@ -89,6 +103,7 @@ describe("telegram poll registry", () => {
       pollId: "poll-closed",
       chat: { id: 123, type: "private", first_name: "Ada" },
       messageId: 44,
+      threadSpec: { scope: "dm" },
       question: "Ready?",
       options: ["Yes", "No"],
     });
@@ -104,12 +119,63 @@ describe("telegram poll registry", () => {
     await expect(retireTelegramPollRegistryEntry({ pollId: "missing" })).resolves.toBeUndefined();
   });
 
-  it("rejects malformed stored origin data", async () => {
+  it.each([
+    {
+      name: "invalid chat id",
+      chat: { id: "not-a-chat", type: "private", first_name: "Ada" },
+      threadSpec: { scope: "dm" },
+    },
+    {
+      name: "old numeric-only shape",
+      chat: { id: 123, type: "private", first_name: "Ada" },
+      threadSpec: undefined,
+      messageThreadId: 77,
+    },
+    {
+      name: "direct messages scope",
+      chat: { id: -123, type: "supergroup", title: "Channel replies" },
+      threadSpec: { scope: "direct-messages", id: 77 },
+    },
+    {
+      name: "direct messages chat",
+      chat: {
+        id: -123,
+        type: "supergroup",
+        title: "Channel replies",
+        is_direct_messages: true,
+      },
+      threadSpec: { scope: "forum", id: 77 },
+    },
+    {
+      name: "forum without id",
+      chat: { id: -123, type: "supergroup", title: "Forum" },
+      threadSpec: { scope: "forum" },
+    },
+    {
+      name: "none with id",
+      chat: { id: -123, type: "group", title: "Reviewers" },
+      threadSpec: { scope: "none", id: 77 },
+    },
+    {
+      name: "dm scope on a group",
+      chat: { id: -123, type: "group", title: "Reviewers" },
+      threadSpec: { scope: "dm", id: 77 },
+    },
+    {
+      name: "forum scope on a private chat",
+      chat: { id: 123, type: "private", first_name: "Ada" },
+      threadSpec: { scope: "forum", id: 77 },
+    },
+  ])("rejects malformed stored origin data: $name", async (invalid) => {
     installTelegramStateRuntime((() => ({
       lookup: async () => ({
         pollId: "poll-invalid-chat",
-        chat: { id: "not-a-chat", type: "private", first_name: "Ada" },
+        chat: invalid.chat,
         messageId: 44,
+        ...(invalid.threadSpec === undefined ? {} : { threadSpec: invalid.threadSpec }),
+        ...(invalid.messageThreadId === undefined
+          ? {}
+          : { messageThreadId: invalid.messageThreadId }),
         question: "Ready?",
         options: ["Yes", "No"],
       }),

--- a/extensions/telegram/src/poll-registry.ts
+++ b/extensions/telegram/src/poll-registry.ts
@@ -4,7 +4,7 @@
 // updates do not carry the originating chat/thread. Persist the authoritative route
 // returned by sendPoll so a later vote can enter the normal inbound turn pipeline.
 import type { Chat } from "grammy/types";
-import { parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
+import { parseStrictInteger, parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import type {
   PluginStateKeyedStore,
   PluginStateSyncKeyedStore,
@@ -23,7 +23,7 @@ export type TelegramPollRegistryEntry = {
   pollId: string;
   chat: TelegramPollRouteChat;
   messageId: number;
-  messageThreadId?: number;
+  threadSpec: { scope: "none" } | { scope: "dm"; id?: number } | { scope: "forum"; id: number };
   question: string;
   options: string[];
 };
@@ -57,7 +57,7 @@ export function telegramPollRegistryKey(accountId: string | undefined, pollId: s
 }
 
 function normalizePollChat(raw: unknown): TelegramPollRouteChat | null {
-  if (!isRecord(raw)) {
+  if (!isRecord(raw) || raw.is_direct_messages === true) {
     return null;
   }
   const id = parseStrictInteger(raw.id);
@@ -81,21 +81,45 @@ function normalizePollChat(raw: unknown): TelegramPollRouteChat | null {
   return null;
 }
 
+function normalizePollThreadSpec(
+  raw: unknown,
+  chat: TelegramPollRouteChat,
+): TelegramPollRegistryEntry["threadSpec"] | null {
+  if (!isRecord(raw)) {
+    return null;
+  }
+  const id = parseStrictPositiveInteger(raw.id);
+  if (raw.scope === "none") {
+    return raw.id === undefined && chat.type !== "private" && chat.is_forum !== true
+      ? { scope: "none" }
+      : null;
+  }
+  if (raw.scope === "dm") {
+    if (chat.type !== "private" || (raw.id !== undefined && id === undefined)) {
+      return null;
+    }
+    return id === undefined ? { scope: "dm" } : { scope: "dm", id };
+  }
+  return raw.scope === "forum" && chat.type === "supergroup" && id !== undefined
+    ? { scope: "forum", id }
+    : null;
+}
+
 function normalizePollRegistryEntry(raw: unknown): TelegramPollRegistryEntry | null {
   if (!isRecord(raw)) {
     return null;
   }
   const chat = normalizePollChat(raw.chat);
   const messageId = parseStrictInteger(raw.messageId);
-  const messageThreadId = parseStrictInteger(raw.messageThreadId);
+  const threadSpec = chat ? normalizePollThreadSpec(raw.threadSpec, chat) : null;
   if (
     typeof raw.pollId !== "string" ||
     !chat ||
+    !threadSpec ||
     messageId === undefined ||
     typeof raw.question !== "string" ||
     !Array.isArray(raw.options) ||
-    !raw.options.every((option) => typeof option === "string") ||
-    (raw.messageThreadId != null && messageThreadId === undefined)
+    !raw.options.every((option) => typeof option === "string")
   ) {
     return null;
   }
@@ -103,7 +127,7 @@ function normalizePollRegistryEntry(raw: unknown): TelegramPollRegistryEntry | n
     pollId: raw.pollId,
     chat,
     messageId,
-    ...(messageThreadId === undefined ? {} : { messageThreadId }),
+    threadSpec,
     question: raw.question,
     options: raw.options,
   };
@@ -114,7 +138,7 @@ export async function recordTelegramPollRegistryEntry(params: {
   pollId: string;
   chat: TelegramPollRouteChat;
   messageId: number;
-  messageThreadId?: number;
+  threadSpec: TelegramPollRegistryEntry["threadSpec"];
   question: string;
   options: string[];
   env?: NodeJS.ProcessEnv;
@@ -131,22 +155,22 @@ export function createTelegramPollRegistryEntry(params: {
   pollId: string;
   chat: TelegramPollRouteChat;
   messageId: number;
-  messageThreadId?: number;
+  threadSpec: TelegramPollRegistryEntry["threadSpec"];
   question: string;
   options: string[];
 }): TelegramPollRegistryEntry {
-  // The keyed store persists JSON and rejects explicit `undefined`, so only include the
-  // optional thread id when it is actually present.
-  return {
+  const entry = normalizePollRegistryEntry({
     pollId: params.pollId,
     chat: params.chat,
     messageId: params.messageId,
+    threadSpec: params.threadSpec,
     question: params.question,
     options: [...params.options],
-    ...(typeof params.messageThreadId === "number"
-      ? { messageThreadId: Math.floor(params.messageThreadId) }
-      : {}),
-  };
+  });
+  if (!entry) {
+    throw new Error("Invalid Telegram poll registry route");
+  }
+  return entry;
 }
 
 export async function findTelegramPollRegistryEntry(params: {

--- a/extensions/telegram/src/provider-thread-proof.ts
+++ b/extensions/telegram/src/provider-thread-proof.ts
@@ -24,6 +24,22 @@ export function resolveTelegramProviderObservedThreadId(params: {
     : undefined;
 }
 
+export function resolveTelegramProviderObservedThreadSpec(params: {
+  message: TelegramThreadMessage;
+  successfulSendThread?: TelegramThreadSpec;
+}): TelegramThreadSpec | undefined {
+  const providerThreadId = resolveTelegramProviderObservedThreadId(params);
+  const successfulSendThread = params.successfulSendThread;
+  if (
+    providerThreadId === undefined ||
+    successfulSendThread?.id !== providerThreadId ||
+    successfulSendThread.scope === "none"
+  ) {
+    return undefined;
+  }
+  return { scope: successfulSendThread.scope, id: providerThreadId };
+}
+
 export function assertTelegramProviderThread(params: {
   message: TelegramThreadMessage;
   successfulSendThread?: TelegramThreadSpec;

--- a/extensions/telegram/src/send-edit.ts
+++ b/extensions/telegram/src/send-edit.ts
@@ -1,4 +1,6 @@
+import type { Message } from "grammy/types";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { resolveTelegramMessageThreadSpec } from "./bot/helpers.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { renderTelegramHtmlText, telegramHtmlToPlainTextFallback } from "./format.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
@@ -296,6 +298,7 @@ async function editMessageTelegramWithContext(
 
   if (editedMessage && editedMessage !== true && typeof editedMessage.message_id === "number") {
     const botUserId = resolveTelegramBotUserIdFromToken(opts.token || account.token);
+    const successfulSendThread = resolveTelegramMessageThreadSpec(editedMessage as Message);
     await recordOutboundMessageForPromptContext({
       cfg,
       account,
@@ -303,6 +306,7 @@ async function editMessageTelegramWithContext(
       message: editedMessage,
       messageId: editedMessage.message_id,
       recordGroupHistory: false,
+      successfulSendThread,
       ...(botUserId !== undefined ? { botUserId } : {}),
       ...(editedMessage.message_thread_id !== undefined
         ? { messageThreadId: editedMessage.message_thread_id }

--- a/extensions/telegram/src/send-special.ts
+++ b/extensions/telegram/src/send-special.ts
@@ -1,10 +1,12 @@
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { resolveTelegramMessageThreadSpec, type TelegramThreadSpec } from "./bot/helpers.js";
 import { resolveTelegramEffectiveGroupPolicy } from "./group-access.js";
 import { resolveTelegramScopedGroupConfig } from "./group-config-helpers.js";
 import { beginTelegramPollRegistration } from "./poll-answer-context.js";
 import {
   createTelegramPollRegistryEntry,
   recordTelegramPollRegistryEntry,
+  type TelegramPollRegistryEntry,
 } from "./poll-registry.js";
 import {
   resolveTelegramApiContext,
@@ -30,6 +32,20 @@ type TelegramPollSendResult = {
   pollAnswerRouting?: "enabled" | "unavailable";
   warning?: string;
 };
+
+function resolveTelegramPollThreadSpec(
+  threadSpec: TelegramThreadSpec,
+): TelegramPollRegistryEntry["threadSpec"] | undefined {
+  if (threadSpec.scope === "none") {
+    return { scope: "none" };
+  }
+  if (threadSpec.scope === "dm") {
+    return threadSpec.id === undefined ? { scope: "dm" } : { scope: "dm", id: threadSpec.id };
+  }
+  return threadSpec.scope === "forum" && threadSpec.id !== undefined
+    ? { scope: "forum", id: threadSpec.id }
+    : undefined;
+}
 
 /**
  * Send a sticker to a Telegram chat by file_id.
@@ -154,14 +170,27 @@ async function sendPollTelegramWithContext(
   );
   const pollId = result.poll.id;
   const routeChat = result.chat.type === "channel" ? undefined : result.chat;
-  const messageThreadId = result.message_thread_id ?? prepared.threadSpec?.id;
+  const routeMessage =
+    result.message_thread_id === undefined && prepared.threadSpec?.id !== undefined
+      ? { ...result, message_thread_id: prepared.threadSpec.id }
+      : result;
+  const resolvedThreadSpec = routeChat
+    ? resolveTelegramMessageThreadSpec(
+        routeMessage,
+        prepared.threadSpec?.scope === "forum" || result.chat.is_forum === true,
+      )
+    : undefined;
+  const threadSpec = resolvedThreadSpec
+    ? resolveTelegramPollThreadSpec(resolvedThreadSpec)
+    : undefined;
+  const messageThreadId = threadSpec && "id" in threadSpec ? threadSpec.id : undefined;
   const provisionalEntry =
-    opts.isAnonymous === false && routeChat
+    opts.isAnonymous === false && routeChat && threadSpec
       ? createTelegramPollRegistryEntry({
           pollId,
           chat: routeChat,
           messageId: result.message_id,
-          messageThreadId,
+          threadSpec,
           question: normalizedPoll.question,
           options: normalizedPoll.options,
         })

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -5465,7 +5465,12 @@ describe("editMessageTelegram", () => {
   ])("refreshes cached $name from Telegram's authoritative edit response", async (testCase) => {
     const storePath = `/tmp/openclaw-telegram-edited-context-${process.pid}-${Date.now()}-${testCase.name}.json`;
     const cfg = { session: { store: storePath } };
-    const chat = { id: -100123, type: "supergroup" as const, title: "Ops" };
+    const chat = {
+      id: -100123,
+      type: "supergroup" as const,
+      title: "Ops",
+      is_forum: true as const,
+    };
     const cache = createTelegramMessageCache({
       scope: resolveTelegramMessageCacheScope(storePath),
     });
@@ -5733,10 +5738,79 @@ describe("sendPollTelegram", () => {
             is_forum: true,
           },
           messageId: 123,
-          messageThreadId: 99,
+          threadSpec: { scope: "forum", id: 99 },
           question: "Ready?",
           options: ["Yes", "No"],
         }),
+      }),
+    ]);
+  });
+
+  it.each([
+    {
+      name: "base private chat",
+      to: "555",
+      chat: { id: 555, type: "private" as const, first_name: "Ada" },
+      expected: { scope: "dm" as const },
+    },
+    {
+      name: "bot-private topic",
+      to: "555:topic:42",
+      chat: { id: 555, type: "private" as const, first_name: "Ada" },
+      messageThreadId: 42,
+      expected: { scope: "dm" as const, id: 42 },
+    },
+    {
+      name: "regular group",
+      to: "-100555",
+      chat: { id: -100555, type: "supergroup" as const, title: "Reviewers" },
+      expected: { scope: "none" as const },
+    },
+  ])("records the canonical $name poll scope", async (testCase) => {
+    const store = await installPollRegistryStore();
+    botApi.getChatMember.mockResolvedValue({ status: "administrator" });
+    botApi.sendPoll.mockResolvedValue({
+      message_id: 126,
+      ...(testCase.messageThreadId === undefined
+        ? {}
+        : { message_thread_id: testCase.messageThreadId }),
+      chat: testCase.chat,
+      poll: { id: `poll-${testCase.expected.scope}` },
+    });
+
+    await expect(
+      sendPollTelegram(
+        testCase.to,
+        { question: "Ready?", options: ["Yes", "No"] },
+        { cfg: TELEGRAM_TEST_CFG, token: "999:token", isAnonymous: false },
+      ),
+    ).resolves.toMatchObject({ pollAnswerRouting: "enabled" });
+    expect(await store.entries()).toEqual([
+      expect.objectContaining({
+        value: expect.objectContaining({ threadSpec: testCase.expected }),
+      }),
+    ]);
+  });
+
+  it("preserves the accepted General forum scope when Telegram omits its thread id", async () => {
+    const store = await installPollRegistryStore();
+    botApi.getChatMember.mockResolvedValue({ status: "administrator" });
+    botApi.sendPoll.mockResolvedValue({
+      message_id: 127,
+      chat: { id: -100556, type: "supergroup", title: "Forum", is_forum: true },
+      poll: { id: "poll-general" },
+    });
+
+    await expect(
+      sendPollTelegram(
+        "-100556:topic:1",
+        { question: "Ready?", options: ["Yes", "No"] },
+        { cfg: TELEGRAM_TEST_CFG, token: "999:token", isAnonymous: false },
+      ),
+    ).resolves.toMatchObject({ pollAnswerRouting: "enabled" });
+    expect(await store.entries()).toEqual([
+      expect.objectContaining({
+        value: expect.objectContaining({ threadSpec: { scope: "forum", id: 1 } }),
       }),
     ]);
   });
@@ -5901,6 +5975,7 @@ describe("sendPollTelegram", () => {
       pollId: "poll-fast-answer",
       chat: { id: -1001234567890, type: "supergroup" as const, title: "Reviewers" },
       messageId: 125,
+      threadSpec: { scope: "none" as const },
       question: "Ready?",
       options: ["Yes", "No"],
     };
@@ -5967,7 +6042,7 @@ describe("sendPollTelegram", () => {
     const api = {
       sendPoll: vi.fn(async () => ({
         message_id: 123,
-        chat: { id: 555, type: "private" },
+        chat: { id: 555, type: "private", first_name: "Ada" },
         poll: { id: "poll-anonymous" },
       })),
     };
@@ -6010,7 +6085,7 @@ describe("sendPollTelegram", () => {
     const api = {
       sendPoll: vi.fn(async () => ({
         message_id: 123,
-        chat: { id: 555, type: "private" },
+        chat: { id: 555, type: "private", first_name: "Ada" },
         poll: { id: "poll-write-error" },
       })),
     };

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -422,7 +422,46 @@ describe("getTelegramSequentialConstraints", () => {
       "telegram:-1001:topic:9",
       expected,
     ]);
-    expect(getTelegramSequentialConstraints(reaction)).toEqual(["telegram:-1001", expected]);
+    expect(getTelegramSequentialConstraints(reaction)).toBe(expected);
+  });
+
+  it("bridges a channel Direct Messages message with its reaction without coupling topics", () => {
+    const message = mockMessage({
+      chat: mockChat({
+        id: -1002,
+        type: "supergroup",
+        is_direct_messages: true,
+      } as Chat),
+      message_id: 77,
+      message_thread_id: 999,
+      direct_messages_topic: { topic_id: 9, user: { id: 1 } as never },
+      is_topic_message: true,
+    });
+    const expected = "telegram:-1002:message:77";
+    const reaction = {
+      update: {
+        message_reaction: {
+          chat: { id: -1002, type: "supergroup", is_direct_messages: true },
+          message_id: 77,
+        },
+      },
+    };
+
+    expect(getTelegramSequentialConstraints({ message })).toEqual([
+      "telegram:-1002:topic:9",
+      expected,
+    ]);
+    expect(getTelegramSequentialConstraints(reaction)).toBe(expected);
+    expect(
+      getTelegramSequentialConstraints({
+        update: {
+          message_reaction: {
+            chat: { id: -1002, type: "supergroup", is_direct_messages: true },
+            message_id: 78,
+          },
+        },
+      }),
+    ).toBe("telegram:-1002:message:78");
   });
 
   it("does not add a bridge lane outside forum chats", () => {

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -13,7 +13,6 @@ import {
 import { hasTelegramApprovalCallbackPrefix } from "./approval-callback-data.js";
 import {
   resolveTelegramBotHasTopicsEnabled,
-  resolveTelegramForumThreadId,
   resolveTelegramMessageForumFlagHint,
   resolveTelegramMessageThreadSpec,
   shouldUseTelegramDmThreadSession,
@@ -48,7 +47,7 @@ type TelegramSequentialKeyContext = {
     edited_channel_post?: Message;
     callback_query?: { message?: Message; data?: string };
     message_reaction?: {
-      chat?: { id?: number; type?: string; is_forum?: boolean };
+      chat?: { id?: number; type?: string; is_forum?: boolean; is_direct_messages?: boolean };
       message_id?: number;
     };
     poll_answer?: { poll_id?: string };
@@ -60,7 +59,7 @@ function getTelegramMessageReactionSequentialKey(
 ): string | undefined {
   const reaction = ctx.update?.message_reaction;
   if (
-    reaction?.chat?.is_forum === true &&
+    (reaction?.chat?.is_forum === true || reaction?.chat?.is_direct_messages === true) &&
     typeof reaction.chat.id === "number" &&
     typeof reaction.message_id === "number"
   ) {
@@ -80,7 +79,8 @@ function getTelegramMessageReactionSequentialKey(
     isForum: msg?.chat?.is_forum,
     isTopicMessage: msg?.is_topic_message,
   });
-  return isForum && typeof msg?.chat.id === "number" && typeof msg.message_id === "number"
+  const isScopedMessage = isForum || msg?.chat.is_direct_messages === true;
+  return isScopedMessage && typeof msg?.chat.id === "number" && typeof msg.message_id === "number"
     ? `telegram:${msg.chat.id}:message:${msg.message_id}`
     : undefined;
 }
@@ -196,7 +196,7 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
     const prepared = getPreparedTelegramPollAnswer(update);
     const entry = prepared?.entry;
     if (entry) {
-      return getTelegramPollAnswerSequentialKey(entry, ctx.me);
+      return getTelegramPollAnswerSequentialKey(entry);
     }
     // Missing historical registry entries do no work, but keep duplicate answers
     // for the same unknown poll together while the handler records the miss.
@@ -263,20 +263,8 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
   return "telegram:unknown";
 }
 
-function getTelegramPollAnswerSequentialKey(
-  entry: TelegramPollRegistryEntry,
-  botUser?: UserFromGetMe,
-): string {
-  const isGroup = entry.chat.type === "group" || entry.chat.type === "supergroup";
-  const isForum = entry.chat.type === "supergroup" && entry.chat.is_forum === true;
-  const threadId = isGroup
-    ? resolveTelegramForumThreadId({ isForum, messageThreadId: entry.messageThreadId })
-    : shouldUseTelegramDmThreadSession({
-          dmThreadId: entry.messageThreadId,
-          botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(botUser),
-        })
-      ? entry.messageThreadId
-      : undefined;
+function getTelegramPollAnswerSequentialKey(entry: TelegramPollRegistryEntry): string {
+  const threadId = "id" in entry.threadSpec ? entry.threadSpec.id : undefined;
   return threadId == null
     ? `telegram:${entry.chat.id}`
     : `telegram:${entry.chat.id}:topic:${threadId}`;
@@ -287,7 +275,10 @@ export function getTelegramSequentialConstraints(
 ): string | string[] {
   const key = getTelegramSequentialKey(ctx);
   const messageKey = getTelegramMessageReactionSequentialKey(ctx);
-  // A forum reaction reads the topic fact recorded by the message update it targets.
-  // Bridge that exact message without serializing unrelated forum topics.
+  if (ctx.update?.message_reaction && messageKey) {
+    return messageKey;
+  }
+  // Scoped reactions read the topic fact recorded by the message update they target.
+  // Bridge that exact message without serializing unrelated topics.
   return messageKey ? [key, messageKey] : key;
 }

--- a/extensions/telegram/src/telegram-ingress-spool.test.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.test.ts
@@ -118,7 +118,7 @@ describe("telegram ingress spool mapping", () => {
         pollId: "poll-topic-order",
         chat: { id: -100123, type: "supergroup", title: "Reviewers", is_forum: true },
         messageId: 40,
-        messageThreadId: 99,
+        threadSpec: { scope: "forum", id: 99 },
         question: "Ready?",
         options: ["Yes", "No"],
       });
@@ -182,7 +182,7 @@ describe("telegram ingress spool mapping", () => {
           id: telegramQueueEventId(9),
           payload: expect.objectContaining({
             preparedPollAnswer: {
-              entry: expect.objectContaining({ messageThreadId: 99 }),
+              entry: expect.objectContaining({ threadSpec: { scope: "forum", id: 99 } }),
             },
           }),
         }),
@@ -215,7 +215,7 @@ describe("telegram ingress spool mapping", () => {
           is_forum: true as const,
         },
         messageId: 40,
-        messageThreadId: 99,
+        threadSpec: { scope: "forum" as const, id: 99 },
         question: "Ready?",
         options: ["Yes", "No"],
       };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram reactions and poll answers could be routed to the wrong OpenClaw session or topic when Telegram omitted topic metadata from those updates. In scoped chats, that could apply the wrong authorization, topic agent, conversation binding, or sequencing lane.

## Why This Change Was Made

Telegram's persistent message cache now owns the scoped provider-observed topic fact used to correlate reactions, while the poll registry owns a closed none/DM/forum route for poll answers. Consumers use those stored authoritative facts directly; scoped reactions with missing or mismatched correlation are dropped instead of falling back to another topic, and channel Direct Messages polls remain rejected as required by the Bot API.

This PR is AI-assisted with Codex.

## User Impact

Reactions and poll answers remain attached to the Telegram topic where the original message or poll was sent, so they reach the correct session and retain the correct topic-specific routing and authorization. Unresolvable scoped reactions now fail safely instead of being attributed to General or the base chat.

## Evidence

- Initial focused Telegram proof: 13 test files, 676 tests passed; additional affected reruns passed.
- Post-rebase focused Telegram proof: 13 test files, 683 tests passed on Blacksmith Testbox `tbx_01kzm5702aphh8jw4pkyy51xxy`; backing run: https://github.com/openclaw/openclaw/actions/runs/31335695758.
- Real forum ingress socket integration passed.
- Telegram extension production and extension-test typechecks passed; targeted lint, formatting, and diff hygiene passed.
- Final changed-surface Blacksmith Testbox gate passed: `tbx_01kzkvkepzxhftyqp3wttkry8h`; backing run: https://github.com/openclaw/openclaw/actions/runs/31328420629. The backing run may show a cancelled Testbox lifecycle after the delegated proof completed successfully.
- Fresh post-rebase autoreview completed with no accepted or actionable findings.
- Proof gap: no live Telegram channel test was run.
