### PR TITLE
build(ui): pin @novnc/novnc to 1.7.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2408,7 +2408,7 @@ importers:
         specifier: 3.1.0
         version: 3.1.0
       '@novnc/novnc':
-        specifier: ^1.7.0
+        specifier: 1.7.0
         version: 1.7.0
       '@openclaw/gateway-client':
         specifier: workspace:*

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,7 +21,7 @@
     "@modelcontextprotocol/ext-apps": "1.7.5",
     "@modelcontextprotocol/sdk": "1.30.0",
     "@noble/ed25519": "3.1.0",
-    "@novnc/novnc": "^1.7.0",
+    "@novnc/novnc": "1.7.0",
     "@openclaw/gateway-client": "workspace:*",
     "@openclaw/gateway-protocol": "workspace:*",
     "@openclaw/libterminal": "0.3.2",


### PR DESCRIPTION
## What Problem This Solves

Resolves a changed-gate failure caused by `@novnc/novnc` being the sole caret-ranged external dependency in `ui/package.json`; every sibling external dependency in that manifest is exact-pinned.

## Why This Change Was Made

Commit `8fdf7570a17f` introduced `@novnc/novnc` as `^1.7.0`. This change exact-pins it to the already-resolved `1.7.0` and updates only the matching lockfile importer specifier. Peter approved this dependency change.

## User Impact

There is no runtime behavior or dependency-version change. The manifest now follows the repository's exact-pin policy and unblocks the changed gate for dependent PRs.

## Evidence

- `pnpm install --lockfile-only --offline --frozen-lockfile`
- `node --import tsx scripts/check-dependency-pins.mts` — 623 specs checked, 0 violations
- `git diff --check`
- Autoreview clean: no accepted/actionable findings
- Final diff: only `ui/package.json` and the corresponding `pnpm-lock.yaml` importer specifier; the resolved package remains `1.7.0`
