### PR TITLE
fix(ui): confirm disruptive Control UI updates before they start

### DIFF
--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -319,6 +319,13 @@ The Control UI sidebar update card shows **Update Gateway** when it will start
 this `update.run` flow directly. This covers browser-hosted Control UI, remote
 Gateways, and manually managed local Gateways.
 
+Manual updates started from the Control UI always ask first. The first click on
+the sidebar update card or on **Settings → Updates → Update now** opens a
+confirmation naming the target, the installed and available versions when known,
+and the restart impact; it sends nothing until you choose **Update and restart**.
+Cancel, Escape, and dismissing the dialog leave the Gateway untouched. Automatic
+campaigns, the CLI, and `update.run` API clients are unaffected.
+
 In the signed macOS app, a local app-owned Gateway changes that card to
 **Update Mac app + Gateway**. Sparkle updates the app first; after relaunch, the
 app runs `openclaw update --tag <app-version> --json`, restarts its Gateway,

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -66,6 +66,10 @@ The dashboard update card names what the app will update:
   managed local Gateway, or another install the app does not own. The button
   runs that Gateway's normal update flow instead of changing the Mac app.
 
+Either button asks for confirmation first. The card hands the update to the app
+only after you choose **Update Mac app and restart**, so a misclick never starts
+Sparkle.
+
 A failed coordinated update stays in its setup-style window with retry,
 [update guide](/install/updating), and Discord actions. Automatic repair never
 downgrades a newer Gateway or overrides an `extended-stable` channel pin.

--- a/ui/src/app/app-host-native-shell.test.ts
+++ b/ui/src/app/app-host-native-shell.test.ts
@@ -3,6 +3,11 @@
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "./app-host.ts";
+import {
+  installDialogPolyfill,
+  nextFrame,
+  waitForRenderedModalDialog,
+} from "../test-helpers/modal-dialog.ts";
 import { resetAppHostTestGlobals, type ShellKeyboardState } from "./app-host.test-support.ts";
 import type { ApplicationContext } from "./context.ts";
 import { navigationSurfaceIsHidden, renderFloatingUpdateCard } from "./navigation-surface.ts";
@@ -416,7 +421,14 @@ describe("OpenClaw shell update affordance", () => {
     expect(card).not.toBeNull();
     await card?.updateComplete;
     expect(card?.canUpdate).toBe(true);
+    const restoreDialogPolyfill = installDialogPolyfill();
     card?.querySelector<HTMLButtonElement>(".sidebar-update-card__action")?.click();
+    const { modal } = await waitForRenderedModalDialog(document.body);
+    [...modal.querySelectorAll("button")]
+      .find((button) => button.textContent?.trim() === "Update and restart")
+      ?.click();
+    await nextFrame();
+    restoreDialogPolyfill();
     expect(shared.onUpdate).toHaveBeenCalledOnce();
 
     render(

--- a/ui/src/app/update-confirmation.runtime.test.ts
+++ b/ui/src/app/update-confirmation.runtime.test.ts
@@ -3,7 +3,7 @@
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import type { UpdateAvailable, UpdateScheduleState } from "../api/types.ts";
 import { getRenderedModalDialog, installDialogPolyfill } from "../test-helpers/modal-dialog.ts";
-import { confirmAndStartUpdate } from "./update-confirmation.ts";
+import { confirmAndStartUpdateRuntime } from "./update-confirmation.runtime.ts";
 
 const UPDATE_AVAILABLE: UpdateAvailable = {
   channel: "stable",
@@ -42,7 +42,7 @@ function startUpdate(
   } = {},
 ) {
   const startGatewayUpdate = vi.fn();
-  const settled = confirmAndStartUpdate({
+  const settled = confirmAndStartUpdateRuntime({
     startGatewayUpdate: overrides.startGatewayUpdate ?? startGatewayUpdate,
     updateAvailable:
       overrides.updateAvailable === undefined ? UPDATE_AVAILABLE : overrides.updateAvailable,
@@ -74,7 +74,7 @@ it("states the target, restart impact, and both versions without starting the up
 
   expect(dialog.getAttribute("aria-label")).toBe("Update Gateway");
   expect(modal.textContent).toContain(
-    "This installs the available update on the connected Gateway and restarts it.",
+    "Installs the available update on the connected Gateway and restarts it.",
   );
   expect(modal.textContent).toContain("this Control UI disconnects until the Gateway is back");
   expect(modal.textContent).toContain("Installed v1.0.0 · Available v2.0.0");

--- a/ui/src/app/update-confirmation.runtime.ts
+++ b/ui/src/app/update-confirmation.runtime.ts
@@ -5,8 +5,8 @@
 import type { UpdateAvailable, UpdateScheduleState } from "../api/types.ts";
 import { showConfirmDialog } from "../components/confirm-dialog.ts";
 import { t } from "../i18n/index.ts";
-import type { ConfirmAndStartUpdateParams } from "./update-confirmation.ts";
 import { postNativeUpdate } from "./native-link-routing.ts";
+import type { ConfirmAndStartUpdateParams } from "./update-confirmation.ts";
 import { formatUpdateTargetLabel } from "./update-overlay-helpers.ts";
 
 function formatInstalledAndAvailable(

--- a/ui/src/app/update-confirmation.runtime.ts
+++ b/ui/src/app/update-confirmation.runtime.ts
@@ -1,0 +1,55 @@
+// Implementation of the Control UI's disruptive-update confirmation gate. It
+// stays behind the `update-confirmation.ts` lazy boundary because nothing here
+// runs until an operator clicks an update affordance, and the startup bundle
+// has no room for a dialog nobody has opened yet.
+import type { UpdateAvailable, UpdateScheduleState } from "../api/types.ts";
+import { showConfirmDialog } from "../components/confirm-dialog.ts";
+import { t } from "../i18n/index.ts";
+import type { ConfirmAndStartUpdateParams } from "./update-confirmation.ts";
+import { postNativeUpdate } from "./native-link-routing.ts";
+import { formatUpdateTargetLabel } from "./update-overlay-helpers.ts";
+
+function formatInstalledAndAvailable(
+  updateAvailable: UpdateAvailable | null,
+  updateSchedule: UpdateScheduleState | null,
+): string | undefined {
+  const currentVersion = updateAvailable?.currentVersion?.trim();
+  const installed = currentVersion
+    ? t("updates.target.version", { version: currentVersion })
+    : null;
+  const available = formatUpdateTargetLabel(updateSchedule, updateAvailable);
+  if (installed && available) {
+    return t("updates.confirm.versions", { available, installed });
+  }
+  return installed ?? available ?? undefined;
+}
+
+export async function confirmAndStartUpdateRuntime(
+  params: ConfirmAndStartUpdateParams,
+): Promise<void> {
+  const route = params.viaNativeApp
+    ? {
+        confirmLabel: t("updates.confirm.macAction"),
+        message: t("updates.confirm.macMessage"),
+        title: t("chat.sidebar.updateMacAndGateway"),
+      }
+    : {
+        confirmLabel: t("updates.confirm.action"),
+        message: t("updates.confirm.message"),
+        title: t("chat.sidebar.updateGateway"),
+      };
+  const confirmed = await showConfirmDialog({
+    title: route.title,
+    // The impact sentence is shared so both routes state the same consequence.
+    message: `${route.message} ${t("updates.confirm.impact")}`,
+    details: formatInstalledAndAvailable(params.updateAvailable, params.updateSchedule),
+    confirmLabel: route.confirmLabel,
+  });
+  if (!confirmed) {
+    return;
+  }
+  if (params.viaNativeApp && postNativeUpdate()) {
+    return;
+  }
+  params.startGatewayUpdate();
+}

--- a/ui/src/app/update-confirmation.test.ts
+++ b/ui/src/app/update-confirmation.test.ts
@@ -1,0 +1,174 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import type { UpdateAvailable, UpdateScheduleState } from "../api/types.ts";
+import { getRenderedModalDialog, installDialogPolyfill } from "../test-helpers/modal-dialog.ts";
+import { confirmAndStartUpdate } from "./update-confirmation.ts";
+
+const UPDATE_AVAILABLE: UpdateAvailable = {
+  channel: "stable",
+  currentVersion: "1.0.0",
+  latestVersion: "2.0.0",
+};
+
+let restoreDialogPolyfill: () => void;
+let originalWebkit: PropertyDescriptor | undefined;
+
+function findButton(label: string): HTMLButtonElement {
+  const button = [...document.body.querySelectorAll("button")].find(
+    (candidate) => candidate.textContent?.trim() === label,
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Expected ${label} button`);
+  }
+  return button;
+}
+
+function installNativeBridge(): ReturnType<typeof vi.fn> {
+  const postMessage = vi.fn();
+  Object.defineProperty(window, "webkit", {
+    configurable: true,
+    value: { messageHandlers: { openclawUpdate: { postMessage } } },
+  });
+  return postMessage;
+}
+
+function startUpdate(
+  overrides: {
+    startGatewayUpdate?: () => void;
+    updateAvailable?: UpdateAvailable | null;
+    updateSchedule?: UpdateScheduleState | null;
+    viaNativeApp?: boolean;
+  } = {},
+) {
+  const startGatewayUpdate = vi.fn();
+  const settled = confirmAndStartUpdate({
+    startGatewayUpdate: overrides.startGatewayUpdate ?? startGatewayUpdate,
+    updateAvailable:
+      overrides.updateAvailable === undefined ? UPDATE_AVAILABLE : overrides.updateAvailable,
+    updateSchedule: overrides.updateSchedule ?? null,
+    viaNativeApp: overrides.viaNativeApp ?? false,
+  });
+  return { settled, startGatewayUpdate };
+}
+
+beforeEach(() => {
+  restoreDialogPolyfill = installDialogPolyfill();
+  originalWebkit = Object.getOwnPropertyDescriptor(window, "webkit");
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+  restoreDialogPolyfill();
+  if (originalWebkit) {
+    Object.defineProperty(window, "webkit", originalWebkit);
+  } else {
+    Reflect.deleteProperty(window, "webkit");
+  }
+});
+
+it("states the target, restart impact, and both versions without starting the update", async () => {
+  const postMessage = installNativeBridge();
+  const { settled, startGatewayUpdate } = startUpdate();
+  const { modal, dialog } = await getRenderedModalDialog(document.body);
+
+  expect(dialog.getAttribute("aria-label")).toBe("Update Gateway");
+  expect(modal.textContent).toContain(
+    "This installs the available update on the connected Gateway and restarts it.",
+  );
+  expect(modal.textContent).toContain("this Control UI disconnects until the Gateway is back");
+  expect(modal.textContent).toContain("Installed v1.0.0 · Available v2.0.0");
+  // The confirm action names the operation; a generic "Yes" would not.
+  expect(findButton("Update and restart")).toBeInstanceOf(HTMLButtonElement);
+  expect(findButton("Cancel").hasAttribute("autofocus")).toBe(true);
+  expect(startGatewayUpdate).not.toHaveBeenCalled();
+  expect(postMessage).not.toHaveBeenCalled();
+
+  findButton("Cancel").click();
+  await settled;
+});
+
+it.each([
+  { dismiss: () => findButton("Cancel").click(), name: "Cancel" },
+  {
+    dismiss: () => {
+      const modal = document.body.querySelector("openclaw-modal-dialog");
+      modal?.dispatchEvent(new CustomEvent("modal-cancel", { bubbles: true, composed: true }));
+    },
+    name: "Escape or modal dismissal",
+  },
+])("sends nothing when the operator chooses $name", async ({ dismiss }) => {
+  const postMessage = installNativeBridge();
+  const { settled, startGatewayUpdate } = startUpdate({ viaNativeApp: true });
+  await getRenderedModalDialog(document.body);
+
+  dismiss();
+  await settled;
+
+  expect(startGatewayUpdate).not.toHaveBeenCalled();
+  expect(postMessage).not.toHaveBeenCalled();
+});
+
+it("starts exactly one Gateway update after an explicit confirmation", async () => {
+  const { settled, startGatewayUpdate } = startUpdate();
+  await getRenderedModalDialog(document.body);
+
+  findButton("Update and restart").click();
+  await settled;
+
+  expect(startGatewayUpdate).toHaveBeenCalledOnce();
+});
+
+it("hands a confirmed update to the Mac app instead of the Gateway", async () => {
+  const postMessage = installNativeBridge();
+  const { settled, startGatewayUpdate } = startUpdate({ viaNativeApp: true });
+  const { dialog } = await getRenderedModalDialog(document.body);
+
+  expect(dialog.getAttribute("aria-label")).toBe("Update Mac app + Gateway");
+  findButton("Update Mac app and restart").click();
+  await settled;
+
+  expect(postMessage).toHaveBeenCalledExactlyOnceWith({ type: "start-update" });
+  expect(startGatewayUpdate).not.toHaveBeenCalled();
+});
+
+it("falls back to the Gateway when the Mac bridge disappears during confirmation", async () => {
+  installNativeBridge();
+  const { settled, startGatewayUpdate } = startUpdate({ viaNativeApp: true });
+  await getRenderedModalDialog(document.body);
+
+  Reflect.deleteProperty(window, "webkit");
+  findButton("Update Mac app and restart").click();
+  await settled;
+
+  expect(startGatewayUpdate).toHaveBeenCalledOnce();
+});
+
+it("shows the git target when no package version is available", async () => {
+  const { settled } = startUpdate({
+    updateAvailable: null,
+    updateSchedule: {
+      target: { commitsBehind: 3, kind: "git" },
+    } as unknown as UpdateScheduleState,
+  });
+  const { modal } = await getRenderedModalDialog(document.body);
+
+  expect(modal.textContent).toContain("3 commits behind");
+
+  findButton("Cancel").click();
+  await settled;
+});
+
+it("keeps a repeated request from stacking a second confirmation or update", async () => {
+  const first = startUpdate();
+  const second = startUpdate();
+  await getRenderedModalDialog(document.body);
+
+  await second.settled;
+  expect(document.body.querySelectorAll("openclaw-modal-dialog")).toHaveLength(1);
+  expect(second.startGatewayUpdate).not.toHaveBeenCalled();
+
+  findButton("Update and restart").click();
+  await first.settled;
+  expect(first.startGatewayUpdate).toHaveBeenCalledOnce();
+});

--- a/ui/src/app/update-confirmation.ts
+++ b/ui/src/app/update-confirmation.ts
@@ -1,0 +1,53 @@
+// Canonical confirmation gate for the Control UI's disruptive update action.
+// Every affordance that can start an update routes its first click here: the
+// dialog owns the copy, the safe-cancel default, and the choice between the
+// macOS bridge and `update.run`, so no surface can dispatch an unconfirmed
+// update or drift from the shared policy.
+import type { UpdateAvailable, UpdateScheduleState } from "../api/types.ts";
+import { showConfirmDialog } from "../components/confirm-dialog.ts";
+import { t } from "../i18n/index.ts";
+import { postNativeUpdate } from "./native-link-routing.ts";
+import { formatUpdateTargetLabel } from "./update-overlay-helpers.ts";
+
+function formatInstalledAndAvailable(
+  updateAvailable: UpdateAvailable | null,
+  updateSchedule: UpdateScheduleState | null,
+): string | undefined {
+  const currentVersion = updateAvailable?.currentVersion?.trim();
+  const installed = currentVersion ? t("updates.target.version", { version: currentVersion }) : null;
+  const available = formatUpdateTargetLabel(updateSchedule, updateAvailable);
+  if (installed && available) {
+    return t("updates.confirm.versions", { available, installed });
+  }
+  return installed ?? available ?? undefined;
+}
+
+export async function confirmAndStartUpdate(params: {
+  updateAvailable: UpdateAvailable | null;
+  updateSchedule: UpdateScheduleState | null;
+  /**
+   * True only where the surface can hand a confirmed update to the macOS app
+   * and recover from its decline event. Surfaces without that listener stay on
+   * the Gateway route so a declined handoff cannot end in silence.
+   */
+  viaNativeApp: boolean;
+  startGatewayUpdate: () => void;
+}): Promise<void> {
+  const confirmed = await showConfirmDialog({
+    title: params.viaNativeApp
+      ? t("chat.sidebar.updateMacAndGateway")
+      : t("chat.sidebar.updateGateway"),
+    message: params.viaNativeApp ? t("updates.confirm.macMessage") : t("updates.confirm.message"),
+    details: formatInstalledAndAvailable(params.updateAvailable, params.updateSchedule),
+    confirmLabel: params.viaNativeApp
+      ? t("updates.confirm.macAction")
+      : t("updates.confirm.action"),
+  });
+  if (!confirmed) {
+    return;
+  }
+  if (params.viaNativeApp && postNativeUpdate()) {
+    return;
+  }
+  params.startGatewayUpdate();
+}

--- a/ui/src/app/update-confirmation.ts
+++ b/ui/src/app/update-confirmation.ts
@@ -14,7 +14,9 @@ function formatInstalledAndAvailable(
   updateSchedule: UpdateScheduleState | null,
 ): string | undefined {
   const currentVersion = updateAvailable?.currentVersion?.trim();
-  const installed = currentVersion ? t("updates.target.version", { version: currentVersion }) : null;
+  const installed = currentVersion
+    ? t("updates.target.version", { version: currentVersion })
+    : null;
   const available = formatUpdateTargetLabel(updateSchedule, updateAvailable);
   if (installed && available) {
     return t("updates.confirm.versions", { available, installed });

--- a/ui/src/app/update-confirmation.ts
+++ b/ui/src/app/update-confirmation.ts
@@ -1,30 +1,11 @@
 // Canonical confirmation gate for the Control UI's disruptive update action.
-// Every affordance that can start an update routes its first click here: the
-// dialog owns the copy, the safe-cancel default, and the choice between the
-// macOS bridge and `update.run`, so no surface can dispatch an unconfirmed
-// update or drift from the shared policy.
+// Every affordance that can start an update routes its first click here, so no
+// surface dispatches an unconfirmed update or drifts from the shared policy.
+// The dialog itself loads lazily: startup pays nothing for a confirmation the
+// operator has not opened.
 import type { UpdateAvailable, UpdateScheduleState } from "../api/types.ts";
-import { showConfirmDialog } from "../components/confirm-dialog.ts";
-import { t } from "../i18n/index.ts";
-import { postNativeUpdate } from "./native-link-routing.ts";
-import { formatUpdateTargetLabel } from "./update-overlay-helpers.ts";
 
-function formatInstalledAndAvailable(
-  updateAvailable: UpdateAvailable | null,
-  updateSchedule: UpdateScheduleState | null,
-): string | undefined {
-  const currentVersion = updateAvailable?.currentVersion?.trim();
-  const installed = currentVersion
-    ? t("updates.target.version", { version: currentVersion })
-    : null;
-  const available = formatUpdateTargetLabel(updateSchedule, updateAvailable);
-  if (installed && available) {
-    return t("updates.confirm.versions", { available, installed });
-  }
-  return installed ?? available ?? undefined;
-}
-
-export async function confirmAndStartUpdate(params: {
+export type ConfirmAndStartUpdateParams = {
   updateAvailable: UpdateAvailable | null;
   updateSchedule: UpdateScheduleState | null;
   /**
@@ -34,22 +15,9 @@ export async function confirmAndStartUpdate(params: {
    */
   viaNativeApp: boolean;
   startGatewayUpdate: () => void;
-}): Promise<void> {
-  const confirmed = await showConfirmDialog({
-    title: params.viaNativeApp
-      ? t("chat.sidebar.updateMacAndGateway")
-      : t("chat.sidebar.updateGateway"),
-    message: params.viaNativeApp ? t("updates.confirm.macMessage") : t("updates.confirm.message"),
-    details: formatInstalledAndAvailable(params.updateAvailable, params.updateSchedule),
-    confirmLabel: params.viaNativeApp
-      ? t("updates.confirm.macAction")
-      : t("updates.confirm.action"),
-  });
-  if (!confirmed) {
-    return;
-  }
-  if (params.viaNativeApp && postNativeUpdate()) {
-    return;
-  }
-  params.startGatewayUpdate();
+};
+
+export async function confirmAndStartUpdate(params: ConfirmAndStartUpdateParams): Promise<void> {
+  const { confirmAndStartUpdateRuntime } = await import("./update-confirmation.runtime.ts");
+  await confirmAndStartUpdateRuntime(params);
 }

--- a/ui/src/components/sidebar-update-card.test.ts
+++ b/ui/src/components/sidebar-update-card.test.ts
@@ -7,9 +7,9 @@ import {
   NATIVE_UPDATE_DECLINED_EVENT,
 } from "../app/native-link-routing.ts";
 import {
-  getRenderedModalDialog,
   installDialogPolyfill,
   nextFrame,
+  waitForRenderedModalDialog,
 } from "../test-helpers/modal-dialog.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import "./sidebar-update-card.ts";
@@ -20,7 +20,7 @@ const DISMISS_KEY = "openclaw:control-ui:update-banner-dismissed:v1";
 async function resolveUpdateConfirmation(
   label: "Cancel" | "Update and restart" | "Update Mac app and restart",
 ) {
-  const { modal } = await getRenderedModalDialog(document.body);
+  const { modal } = await waitForRenderedModalDialog(document.body);
   const button = [...modal.querySelectorAll("button")].find(
     (candidate) => candidate.textContent?.trim() === label,
   );

--- a/ui/src/components/sidebar-update-card.test.ts
+++ b/ui/src/components/sidebar-update-card.test.ts
@@ -6,10 +6,28 @@ import {
   NATIVE_UPDATE_AVAILABILITY_CHANGED_EVENT,
   NATIVE_UPDATE_DECLINED_EVENT,
 } from "../app/native-link-routing.ts";
+import {
+  getRenderedModalDialog,
+  installDialogPolyfill,
+  nextFrame,
+} from "../test-helpers/modal-dialog.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import "./sidebar-update-card.ts";
 
 const DISMISS_KEY = "openclaw:control-ui:update-banner-dismissed:v1";
+
+/** Resolve the update confirmation the card opens, then let its dispatch settle. */
+async function resolveUpdateConfirmation(label: "Cancel" | "Update and restart" | "Update Mac app and restart") {
+  const { modal } = await getRenderedModalDialog(document.body);
+  const button = [...modal.querySelectorAll("button")].find(
+    (candidate) => candidate.textContent?.trim() === label,
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Expected ${label} button in the update confirmation`);
+  }
+  button.click();
+  await nextFrame();
+}
 
 type SidebarUpdateCardElement = HTMLElement & {
   updateAvailable: UpdateAvailable | null;
@@ -27,6 +45,7 @@ type SidebarUpdateCardElement = HTMLElement & {
 
 let originalWebkit: PropertyDescriptor | undefined;
 let originalLocalStorage: PropertyDescriptor | undefined;
+let restoreDialogPolyfill: () => void;
 
 async function mount(
   update: UpdateAvailable | null,
@@ -47,6 +66,7 @@ async function mount(
 }
 
 beforeEach(() => {
+  restoreDialogPolyfill = installDialogPolyfill();
   originalWebkit = Object.getOwnPropertyDescriptor(window, "webkit");
   originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
   Object.defineProperty(globalThis, "localStorage", {
@@ -58,6 +78,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
   document.body.replaceChildren();
+  restoreDialogPolyfill();
   if (originalLocalStorage) {
     Object.defineProperty(globalThis, "localStorage", originalLocalStorage);
   } else {
@@ -122,7 +143,7 @@ describe("SidebarUpdateCard", () => {
     expect(element.querySelector(".sidebar-update-card__dismiss")).toBeNull();
   });
 
-  it("labels a direct Gateway update and invokes its action", async () => {
+  it("labels a direct Gateway update and confirms before invoking its action", async () => {
     const element = await mount({
       currentVersion: "1.0.0",
       latestVersion: "2.0.0",
@@ -140,8 +161,26 @@ describe("SidebarUpdateCard", () => {
     expect(element.querySelector(".sidebar-update-card__subtitle")).toBeNull();
     expect(element.querySelector(".sidebar-update-card__arrow")).toBeNull();
     action?.click();
+    await nextFrame();
 
+    expect(onUpdate).not.toHaveBeenCalled();
+    await resolveUpdateConfirmation("Update and restart");
     expect(onUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("leaves the Gateway untouched when the operator cancels the confirmation", async () => {
+    const element = await mount({
+      currentVersion: "1.0.0",
+      latestVersion: "2.0.0",
+      channel: "stable",
+    });
+    const onUpdate = vi.fn();
+    element.onUpdate = onUpdate;
+
+    element.querySelector<HTMLButtonElement>(".sidebar-update-card__action")?.click();
+    await resolveUpdateConfirmation("Cancel");
+
+    expect(onUpdate).not.toHaveBeenCalled();
   });
 
   it.each(["2026.7.2", "2026.7.2-beta.5"])(
@@ -198,8 +237,11 @@ describe("SidebarUpdateCard", () => {
     expect(action?.textContent).toContain("Update Mac app + Gateway");
     expect(action?.textContent).toContain("v2.0.0");
     action?.click();
+    await nextFrame();
 
-    expect(postMessage).toHaveBeenCalledWith({ type: "start-update" });
+    expect(postMessage).not.toHaveBeenCalled();
+    await resolveUpdateConfirmation("Update Mac app and restart");
+    expect(postMessage).toHaveBeenCalledExactlyOnceWith({ type: "start-update" });
     expect(onUpdate).not.toHaveBeenCalled();
   });
 
@@ -241,8 +283,9 @@ describe("SidebarUpdateCard", () => {
       value: { messageHandlers: { openclawUpdate: { postMessage } } },
     });
     element.querySelector<HTMLButtonElement>(".sidebar-update-card__action")?.click();
+    await resolveUpdateConfirmation("Update Mac app and restart");
 
-    expect(postMessage).toHaveBeenCalledWith({ type: "start-update" });
+    expect(postMessage).toHaveBeenCalledExactlyOnceWith({ type: "start-update" });
     expect(onUpdate).not.toHaveBeenCalled();
   });
 
@@ -291,6 +334,7 @@ describe("SidebarUpdateCard", () => {
     expect(element.textContent).toContain("Update Gateway");
 
     element.querySelector<HTMLButtonElement>(".sidebar-update-card__action")?.click();
+    await resolveUpdateConfirmation("Update and restart");
     expect(onUpdate).toHaveBeenCalledTimes(2);
     expect(postMessage).not.toHaveBeenCalled();
 
@@ -298,7 +342,8 @@ describe("SidebarUpdateCard", () => {
     await element.updateComplete;
     expect(element.textContent).toContain("Update Mac app + Gateway");
     element.querySelector<HTMLButtonElement>(".sidebar-update-card__action")?.click();
-    expect(postMessage).toHaveBeenCalledWith({ type: "start-update" });
+    await resolveUpdateConfirmation("Update Mac app and restart");
+    expect(postMessage).toHaveBeenCalledExactlyOnceWith({ type: "start-update" });
     expect(onUpdate).toHaveBeenCalledTimes(2);
   });
 
@@ -324,6 +369,7 @@ describe("SidebarUpdateCard", () => {
 
     expect(element.textContent).toContain("Update Gateway");
     element.querySelector<HTMLButtonElement>(".sidebar-update-card__action")?.click();
+    await resolveUpdateConfirmation("Update and restart");
     expect(onUpdate).toHaveBeenCalledTimes(2);
     expect(postMessage).not.toHaveBeenCalled();
   });

--- a/ui/src/components/sidebar-update-card.test.ts
+++ b/ui/src/components/sidebar-update-card.test.ts
@@ -17,7 +17,9 @@ import "./sidebar-update-card.ts";
 const DISMISS_KEY = "openclaw:control-ui:update-banner-dismissed:v1";
 
 /** Resolve the update confirmation the card opens, then let its dispatch settle. */
-async function resolveUpdateConfirmation(label: "Cancel" | "Update and restart" | "Update Mac app and restart") {
+async function resolveUpdateConfirmation(
+  label: "Cancel" | "Update and restart" | "Update Mac app and restart",
+) {
   const { modal } = await getRenderedModalDialog(document.body);
   const button = [...modal.querySelectorAll("button")].find(
     (candidate) => candidate.textContent?.trim() === label,

--- a/ui/src/components/sidebar-update-card.ts
+++ b/ui/src/components/sidebar-update-card.ts
@@ -5,8 +5,8 @@ import {
   hasNativeUpdateBridge,
   NATIVE_UPDATE_AVAILABILITY_CHANGED_EVENT,
   NATIVE_UPDATE_DECLINED_EVENT,
-  postNativeUpdate,
 } from "../app/native-link-routing.ts";
+import { confirmAndStartUpdate } from "../app/update-confirmation.ts";
 import {
   formatUpdateCampaignLabel,
   formatUpdateTargetLabel,
@@ -84,6 +84,8 @@ class SidebarUpdateCard extends OpenClawLightDomContentsElement {
     this.nativeUpdateAvailable = hasNativeUpdateBridge();
   };
 
+  // The Mac app only declines an update it was already handed, so this is the
+  // tail of a confirmed click. Re-confirming here would ask twice for one action.
   private readonly handleNativeUpdateDeclined = () => {
     this.nativeUpdateDeclined = true;
     this.nativeUpdateAvailable = false;
@@ -208,9 +210,14 @@ class SidebarUpdateCard extends OpenClawLightDomContentsElement {
               if (busy || !this.canUpdate) {
                 return;
               }
-              if (this.nativeUpdateDeclined || !postNativeUpdate()) {
-                this.onUpdate();
-              }
+              void confirmAndStartUpdate({
+                startGatewayUpdate: () => this.onUpdate(),
+                updateAvailable: this.updateAvailable,
+                updateSchedule: this.updateSchedule,
+                // Read the bridge at click time: a Mac app that installed it
+                // after the last availability event still owns this update.
+                viaNativeApp: !this.nativeUpdateDeclined && hasNativeUpdateBridge(),
+              });
             }}
           >
             <span class="sidebar-update-card__icon" aria-hidden="true">${icons.download}</span>

--- a/ui/src/e2e/update-coalesced.e2e.test.ts
+++ b/ui/src/e2e/update-coalesced.e2e.test.ts
@@ -82,6 +82,7 @@ suite.define(() => {
         });
 
         await page.getByRole("button", { name: /Update Gateway/ }).click();
+        await page.getByRole("button", { name: "Update and restart", exact: true }).click();
         await page
           .getByText(
             "Update error: global-install-failed. The global package install did not verify on disk. Retry or reinstall from the CLI.",
@@ -130,6 +131,7 @@ suite.define(() => {
         });
 
         await page.getByRole("button", { name: /Update Gateway/ }).click();
+        await page.getByRole("button", { name: "Update and restart", exact: true }).click();
         await page
           .getByText(
             "Update installed. A gateway restart is already in progress; status will refresh after it reconnects.",
@@ -212,6 +214,7 @@ suite.define(() => {
           });
 
           await page.getByRole("button", { name: /Update Gateway/ }).click();
+          await page.getByRole("button", { name: "Update and restart", exact: true }).click();
           await gateway.waitForRequest("update.run");
           if (responseFirst) {
             await gateway.resolveDeferred("update.run", MANAGED_UPDATE_HANDOFF_RESPONSE);
@@ -281,6 +284,7 @@ suite.define(() => {
       });
 
       await page.getByRole("button", { name: /Update Mac app \+ Gateway/ }).click();
+      await page.getByRole("button", { name: "Update Mac app and restart", exact: true }).click();
       expect(
         await page.evaluate(
           () => (window as unknown as { openClawUpdateMessages: unknown[] }).openClawUpdateMessages,
@@ -293,6 +297,7 @@ suite.define(() => {
         window.dispatchEvent(new CustomEvent(eventName));
       }, NATIVE_UPDATE_AVAILABILITY_CHANGED_EVENT);
       await page.getByRole("button", { name: /Update Gateway/ }).click();
+      await page.getByRole("button", { name: "Update and restart", exact: true }).click();
 
       expect(await gateway.getRequests("update.run")).toHaveLength(1);
       expect(pageErrors).toEqual([]);

--- a/ui/src/e2e/update-confirmation.e2e.test.ts
+++ b/ui/src/e2e/update-confirmation.e2e.test.ts
@@ -22,6 +22,11 @@ const UPDATE_RUN_RESPONSE = {
 } as const;
 const PROOF_DIR = path.resolve(".artifacts/control-ui-e2e/update-confirmation");
 
+/** The dialog element lives in a shadow root; its visible copy is slotted light DOM. */
+function confirmationCopy(page: Page) {
+  return page.locator("openclaw-modal-dialog");
+}
+
 async function openUpdateCard(page: Page, baseUrl: string) {
   const gateway = await installMockGateway(page, {
     methodResponses: { "update.run": UPDATE_RUN_RESPONSE },
@@ -50,7 +55,7 @@ suite.define(() => {
         const dialog = page.getByRole("dialog");
         await dialog.waitFor();
         expect(await dialog.getAttribute("aria-label")).toBe("Update Gateway");
-        const dialogText = await dialog.textContent();
+        const dialogText = await confirmationCopy(page).textContent();
         expect(dialogText).toContain(
           "This installs the available update on the connected Gateway and restarts it.",
         );
@@ -69,7 +74,11 @@ suite.define(() => {
   it("renders the same confirmation in dark mode and on a compact viewport", async () => {
     for (const variant of [
       { colorScheme: "dark", name: "03-confirmation-dark", viewport: { height: 720, width: 1280 } },
-      { colorScheme: "light", name: "04-confirmation-compact", viewport: { height: 780, width: 420 } },
+      {
+        colorScheme: "light",
+        name: "04-confirmation-compact",
+        viewport: { height: 780, width: 420 },
+      },
     ] as const) {
       await suite.withPage(
         {
@@ -203,7 +212,9 @@ suite.define(() => {
 
         const dialog = page.getByRole("dialog");
         await dialog.waitFor();
-        expect(await dialog.textContent()).toContain("Installed v1.0.0 · Available v2.0.0");
+        expect(await confirmationCopy(page).textContent()).toContain(
+          "Installed v1.0.0 · Available v2.0.0",
+        );
         expect(await gateway.getRequests("update.run")).toHaveLength(0);
         await page.screenshot({
           animations: "disabled",

--- a/ui/src/e2e/update-confirmation.e2e.test.ts
+++ b/ui/src/e2e/update-confirmation.e2e.test.ts
@@ -57,7 +57,7 @@ suite.define(() => {
         expect(await dialog.getAttribute("aria-label")).toBe("Update Gateway");
         const dialogText = await confirmationCopy(page).textContent();
         expect(dialogText).toContain(
-          "This installs the available update on the connected Gateway and restarts it.",
+          "Installs the available update on the connected Gateway and restarts it.",
         );
         expect(dialogText).toContain("this Control UI disconnects until the Gateway is back");
         expect(dialogText).toContain("Installed v1.0.0 · Available v2.0.0");

--- a/ui/src/e2e/update-confirmation.e2e.test.ts
+++ b/ui/src/e2e/update-confirmation.e2e.test.ts
@@ -1,0 +1,219 @@
+import path from "node:path";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI update confirmation E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
+const UPDATE_AVAILABLE = {
+  channel: "stable",
+  currentVersion: "1.0.0",
+  latestVersion: "2.0.0",
+} as const;
+const UPDATE_RUN_RESPONSE = {
+  ok: true,
+  restart: null,
+  result: { after: { version: "2.0.0" }, status: "ok" },
+} as const;
+const PROOF_DIR = path.resolve(".artifacts/control-ui-e2e/update-confirmation");
+
+async function openUpdateCard(page: Page, baseUrl: string) {
+  const gateway = await installMockGateway(page, {
+    methodResponses: { "update.run": UPDATE_RUN_RESPONSE },
+  });
+  expect((await page.goto(`${baseUrl}chat`))?.status()).toBe(200);
+  await gateway.waitForRequest("chat.startup");
+  await gateway.emitGatewayEvent("update.available", { updateAvailable: UPDATE_AVAILABLE });
+  const updateButton = page.getByRole("button", { name: /Update Gateway/ });
+  await updateButton.waitFor({ timeout: 10_000 });
+  return { gateway, updateButton };
+}
+
+suite.define(() => {
+  it("opens a confirmation that states the action, target, versions, and restart impact", async () => {
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block", viewport: { height: 720, width: 1280 } },
+      async ({ page }) => {
+        const { gateway, updateButton } = await openUpdateCard(page, suite.server.baseUrl);
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(PROOF_DIR, "01-update-affordance-light.png"),
+        });
+
+        await updateButton.click();
+
+        const dialog = page.getByRole("dialog");
+        await dialog.waitFor();
+        expect(await dialog.getAttribute("aria-label")).toBe("Update Gateway");
+        const dialogText = await dialog.textContent();
+        expect(dialogText).toContain(
+          "This installs the available update on the connected Gateway and restarts it.",
+        );
+        expect(dialogText).toContain("this Control UI disconnects until the Gateway is back");
+        expect(dialogText).toContain("Installed v1.0.0 · Available v2.0.0");
+        // The first click must not reach the Gateway.
+        expect(await gateway.getRequests("update.run")).toHaveLength(0);
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(PROOF_DIR, "02-confirmation-light.png"),
+        });
+      },
+    );
+  });
+
+  it("renders the same confirmation in dark mode and on a compact viewport", async () => {
+    for (const variant of [
+      { colorScheme: "dark", name: "03-confirmation-dark", viewport: { height: 720, width: 1280 } },
+      { colorScheme: "light", name: "04-confirmation-compact", viewport: { height: 780, width: 420 } },
+    ] as const) {
+      await suite.withPage(
+        {
+          colorScheme: variant.colorScheme,
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: variant.viewport,
+        },
+        async ({ page }) => {
+          const { gateway, updateButton } = await openUpdateCard(page, suite.server.baseUrl);
+          await updateButton.click();
+          await page.getByRole("dialog").waitFor();
+          expect(
+            await page.getByRole("button", { name: "Update and restart", exact: true }).isVisible(),
+          ).toBe(true);
+          expect(await gateway.getRequests("update.run")).toHaveLength(0);
+          await page.screenshot({
+            animations: "disabled",
+            path: path.join(PROOF_DIR, `${variant.name}.png`),
+          });
+        },
+      );
+    }
+  });
+
+  it.each([
+    { dismiss: "Escape" as const, name: "Escape" },
+    { dismiss: "cancel" as const, name: "Cancel" },
+  ])("makes no update request when the operator dismisses with $name", async ({ dismiss }) => {
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block", viewport: { height: 720, width: 1280 } },
+      async ({ page }) => {
+        const { gateway, updateButton } = await openUpdateCard(page, suite.server.baseUrl);
+        await updateButton.click();
+        await page.getByRole("dialog").waitFor();
+
+        if (dismiss === "Escape") {
+          await page.keyboard.press("Escape");
+        } else {
+          await page.getByRole("button", { name: "Cancel", exact: true }).click();
+        }
+        await page.getByRole("dialog").waitFor({ state: "detached" });
+
+        expect(await gateway.getRequests("update.run")).toHaveLength(0);
+        expect(await updateButton.isEnabled()).toBe(true);
+      },
+    );
+  });
+
+  it("keeps the update-opening keypress from confirming and lets a later Return confirm once", async () => {
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block", viewport: { height: 720, width: 1280 } },
+      async ({ page }) => {
+        const { gateway, updateButton } = await openUpdateCard(page, suite.server.baseUrl);
+
+        await updateButton.focus();
+        await page.keyboard.press("Enter");
+        const dialog = page.getByRole("dialog");
+        await dialog.waitFor();
+
+        // The keypress that opened the dialog lands on Cancel, never on the confirm action.
+        const cancelFocused = await page.evaluate(
+          () => document.activeElement?.textContent?.trim() ?? "",
+        );
+        expect(cancelFocused).toBe("Cancel");
+        expect(await gateway.getRequests("update.run")).toHaveLength(0);
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(PROOF_DIR, "05-confirmation-initial-focus.png"),
+        });
+
+        const confirm = page.getByRole("button", { name: "Update and restart", exact: true });
+        await confirm.focus();
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(PROOF_DIR, "06-confirmation-confirm-focus.png"),
+        });
+        await page.keyboard.press("Enter");
+
+        await gateway.waitForRequest("update.run");
+        expect(await gateway.getRequests("update.run")).toHaveLength(1);
+      },
+    );
+  });
+
+  it("sends exactly one update request when the confirm action is clicked", async () => {
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block", viewport: { height: 720, width: 1280 } },
+      async ({ page }) => {
+        const { gateway, updateButton } = await openUpdateCard(page, suite.server.baseUrl);
+        await updateButton.click();
+        await page.getByRole("dialog").waitFor();
+
+        await page.getByRole("button", { name: "Update and restart", exact: true }).click();
+        await gateway.waitForRequest("update.run");
+        await page.getByRole("dialog").waitFor({ state: "detached" });
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(PROOF_DIR, "07-update-running.png"),
+        });
+
+        expect(await gateway.getRequests("update.run")).toHaveLength(1);
+      },
+    );
+  });
+
+  it("applies the same confirmation to the Settings update row", async () => {
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block", viewport: { height: 900, width: 1280 } },
+      async ({ page }) => {
+        const config = { update: { auto: { enabled: false }, channel: "stable" } };
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["config.get", "config.set", "update.run"],
+          methodResponses: {
+            "config.get": {
+              config,
+              hash: "update-confirmation-1",
+              issues: [],
+              raw: JSON.stringify(config),
+              runtimeConfig: config,
+              valid: true,
+            },
+            "update.run": UPDATE_RUN_RESPONSE,
+          },
+        });
+
+        expect((await page.goto(`${suite.server.baseUrl}settings/updates`))?.status()).toBe(200);
+        await gateway.waitForRequest("config.get");
+        await gateway.emitGatewayEvent("update.available", { updateAvailable: UPDATE_AVAILABLE });
+        await page.getByRole("button", { name: "Update now", exact: true }).click();
+
+        const dialog = page.getByRole("dialog");
+        await dialog.waitFor();
+        expect(await dialog.textContent()).toContain("Installed v1.0.0 · Available v2.0.0");
+        expect(await gateway.getRequests("update.run")).toHaveLength(0);
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(PROOF_DIR, "08-settings-confirmation.png"),
+        });
+
+        await page.getByRole("button", { name: "Update and restart", exact: true }).click();
+        await gateway.waitForRequest("update.run");
+        expect(await gateway.getRequests("update.run")).toHaveLength(1);
+      },
+    );
+  });
+});

--- a/ui/src/e2e/updates-settings.e2e.test.ts
+++ b/ui/src/e2e/updates-settings.e2e.test.ts
@@ -102,6 +102,7 @@ suite.define(() => {
         expect(JSON.parse(String(raw))).toMatchObject({ update: { channel: "beta" } });
 
         await content.getByRole("button", { name: "Update now", exact: true }).click();
+        await page.getByRole("button", { name: "Update and restart", exact: true }).click();
         await gateway.waitForRequest("update.run");
       },
     );

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -371,6 +371,15 @@ export const en: TranslationMap = {
       applying: "Applying update…",
     },
     holdOneHour: "Hold 1 h",
+    confirm: {
+      message:
+        "This installs the available update on the connected Gateway and restarts it. Running sessions are interrupted and this Control UI disconnects until the Gateway is back.",
+      macMessage:
+        "This hands the update to the OpenClaw Mac app, which installs it and relaunches the Gateway it manages. Running sessions are interrupted and this Control UI disconnects until the Gateway is back.",
+      versions: "Installed {installed} · Available {available}",
+      action: "Update and restart",
+      macAction: "Update Mac app and restart",
+    },
     target: {
       version: "v{version}",
       commitBehind: "{count} commit behind",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -375,7 +375,8 @@ export const en: TranslationMap = {
       message: "Installs the available update on the connected Gateway and restarts it.",
       macMessage:
         "Hands this update to the OpenClaw Mac app, which installs it and restarts the Gateway it manages.",
-      impact: "Running sessions are interrupted and this Control UI disconnects until the Gateway is back.",
+      impact:
+        "Running sessions are interrupted and this Control UI disconnects until the Gateway is back.",
       versions: "Installed {installed} · Available {available}",
       action: "Update and restart",
       macAction: "Update Mac app and restart",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -372,10 +372,10 @@ export const en: TranslationMap = {
     },
     holdOneHour: "Hold 1 h",
     confirm: {
-      message:
-        "This installs the available update on the connected Gateway and restarts it. Running sessions are interrupted and this Control UI disconnects until the Gateway is back.",
+      message: "Installs the available update on the connected Gateway and restarts it.",
       macMessage:
-        "This hands the update to the OpenClaw Mac app, which installs it and relaunches the Gateway it manages. Running sessions are interrupted and this Control UI disconnects until the Gateway is back.",
+        "Hands this update to the OpenClaw Mac app, which installs it and restarts the Gateway it manages.",
+      impact: "Running sessions are interrupted and this Control UI disconnects until the Gateway is back.",
       versions: "Installed {installed} · Available {available}",
       action: "Update and restart",
       macAction: "Update Mac app and restart",

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -11,6 +11,11 @@ import type {
 } from "../../app/context.ts";
 import { changedServerUiPrefs, resetServerUiPrefsSync } from "../../app/server-prefs.ts";
 import { loadSettings } from "../../app/settings.ts";
+import {
+  getRenderedModalDialog,
+  installDialogPolyfill,
+  nextFrame,
+} from "../../test-helpers/modal-dialog.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import * as chatModels from "../chat/models.ts";
 import * as realtimeTalk from "../chat/realtime-talk.ts";
@@ -567,7 +572,7 @@ describe("ConfigPage Updates integration", () => {
     expect(refreshUpdateStatus).toHaveBeenCalledTimes(2);
   });
 
-  it("stages policy changes through patchForm and delegates Update now to overlays", () => {
+  it("stages policy changes through patchForm and confirms Update now before overlays", async () => {
     const patchForm = vi.fn();
     const runUpdate = vi.fn();
     const page = new ConfigPage();
@@ -611,6 +616,8 @@ describe("ConfigPage Updates integration", () => {
       },
     } as unknown as ApplicationContext;
     const container = document.createElement("div");
+    document.body.append(container);
+    const restoreDialogPolyfill = installDialogPolyfill();
 
     render(page.render(), container);
 
@@ -629,10 +636,22 @@ describe("ConfigPage Updates integration", () => {
     [...container.querySelectorAll<HTMLButtonElement>("button")]
       .find((button) => button.textContent?.includes("Update now"))
       ?.click();
+    await nextFrame();
 
     expect(patchForm).toHaveBeenCalledWith(["update", "channel"], "beta");
     expect(patchForm).toHaveBeenCalledWith(["update", "auto", "enabled"], true);
+    // Settings shares the sidebar card's confirmation gate: nothing runs on the click itself.
+    expect(runUpdate).not.toHaveBeenCalled();
+
+    const { modal } = await getRenderedModalDialog(document.body);
+    [...modal.querySelectorAll("button")]
+      .find((button) => button.textContent?.trim() === "Update and restart")
+      ?.click();
+    await nextFrame();
+
     expect(runUpdate).toHaveBeenCalledOnce();
+    restoreDialogPolyfill();
+    container.remove();
   });
 });
 

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -12,9 +12,9 @@ import type {
 import { changedServerUiPrefs, resetServerUiPrefsSync } from "../../app/server-prefs.ts";
 import { loadSettings } from "../../app/settings.ts";
 import {
-  getRenderedModalDialog,
   installDialogPolyfill,
   nextFrame,
+  waitForRenderedModalDialog,
 } from "../../test-helpers/modal-dialog.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import * as chatModels from "../chat/models.ts";
@@ -643,7 +643,7 @@ describe("ConfigPage Updates integration", () => {
     // Settings shares the sidebar card's confirmation gate: nothing runs on the click itself.
     expect(runUpdate).not.toHaveBeenCalled();
 
-    const { modal } = await getRenderedModalDialog(document.body);
+    const { modal } = await waitForRenderedModalDialog(document.body);
     [...modal.querySelectorAll("button")]
       .find((button) => button.textContent?.trim() === "Update and restart")
       ?.click();

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -34,6 +34,7 @@ import {
 } from "../../app/settings.ts";
 import { startThemeTransition } from "../../app/theme-transition.ts";
 import { resolveTheme, type ThemeMode, type ThemeName } from "../../app/theme.ts";
+import { confirmAndStartUpdate } from "../../app/update-confirmation.ts";
 import { CONTROL_UI_BUILD_INFO } from "../../build-info.ts";
 import {
   loadStoredHiddenSessionCatalogIds,
@@ -1005,7 +1006,15 @@ export class ConfigPage extends OpenClawLightDomElement {
         onChannelChange: (channel) => runtimeConfig.patchForm(["update", "channel"], channel),
         onAutomaticUpdatesChange: (enabled) =>
           runtimeConfig.patchForm(["update", "auto", "enabled"], enabled),
-        onUpdateNow: () => void this.context.overlays.runUpdate(),
+        onUpdateNow: () =>
+          void confirmAndStartUpdate({
+            startGatewayUpdate: () => void this.context.overlays.runUpdate(),
+            updateAvailable: overlaySnapshot.updateAvailable,
+            updateSchedule: overlaySnapshot.updateSchedule,
+            // This row has no native-decline listener, so a handoff the Mac app
+            // refuses would end in silence. Keep it on the Gateway route.
+            viaNativeApp: false,
+          }),
         onHoldUpdate: () => this.context.overlays.holdUpdate(),
       });
     }

--- a/ui/src/test-helpers/app-sidebar-cases/basics.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/basics.ts
@@ -18,6 +18,7 @@ import {
   mountSidebar,
   TWO_AGENTS,
 } from "../app-sidebar.ts";
+import { installDialogPolyfill, nextFrame, waitForRenderedModalDialog } from "../modal-dialog.ts";
 import "../../components/app-sidebar.ts";
 
 await import("../../components/viewer-facepile.ts");
@@ -50,7 +51,14 @@ describe("AppSidebar update card wiring", () => {
     expect(footer?.firstElementChild?.localName).toBe("openclaw-sidebar-attention");
     const card = footer?.querySelector("openclaw-sidebar-update-card");
     expect(card).not.toBeNull();
+    const restoreDialogPolyfill = installDialogPolyfill();
     card?.querySelector<HTMLButtonElement>(".sidebar-update-card__action")?.click();
+    const { modal } = await waitForRenderedModalDialog(document.body);
+    [...modal.querySelectorAll("button")]
+      .find((button) => button.textContent?.trim() === "Update and restart")
+      ?.click();
+    await nextFrame();
+    restoreDialogPolyfill();
     expect(onUpdate).toHaveBeenCalledOnce();
 
     sidebar.refreshRequired = true;

--- a/ui/src/test-helpers/modal-dialog.ts
+++ b/ui/src/test-helpers/modal-dialog.ts
@@ -1,6 +1,6 @@
 import type WaDialog from "@awesome.me/webawesome/dist/components/dialog/dialog.js";
 // Control UI test helper supports modal dialog setup.
-import { expect } from "vitest";
+import { expect, vi } from "vitest";
 import type { OpenClawModalDialog } from "../components/modal-dialog.ts";
 
 type DialogMethodName = "showModal" | "close";
@@ -41,6 +41,16 @@ export function installDialogPolyfill(): () => void {
     restoreDescriptor("showModal", snapshot.showModal);
     restoreDescriptor("close", snapshot.close);
   };
+}
+
+/** Await a dialog whose owner loads it behind a lazy import, then read it. */
+export async function waitForRenderedModalDialog(container: HTMLElement) {
+  await vi.waitFor(() => {
+    if (!container.querySelector("openclaw-modal-dialog")) {
+      throw new Error("Expected openclaw-modal-dialog");
+    }
+  });
+  return getRenderedModalDialog(container);
 }
 
 export async function getRenderedModalDialog(container: HTMLElement) {


### PR DESCRIPTION
Related: #117178

## What Problem This Solves

Resolves a problem where a single misclick in the Control UI immediately started an
OpenClaw update. Every update affordance the Control UI exposes — the sidebar update
card, the same card inside Settings, the floating card shown when the nav surface is
hidden, and **Settings → Updates → Update now** — dispatched the `update.run` RPC (or,
inside the signed macOS app, posted the `start-update` bridge message) on the first
click. Nothing between the click and the operation told the operator that new code was
about to be installed, that the Gateway would restart, that running sessions would be
interrupted, or which version they were moving to.

## Why This Change Was Made

The Control UI now has one canonical confirmation gate (`ui/src/app/update-confirmation.ts`,
implementation behind its `.runtime.ts` lazy boundary) and every update affordance routes its
first click through it. The gate owns the whole
policy: the exact action and target, the restart/disconnect consequence, the installed and
available versions when known, an action-specific confirm label, Cancel as the safe
default, and the choice between the macOS bridge and `update.run`.

Because the bridge-versus-Gateway fork moved out of the sidebar card and into the gate,
there is no second place a surface could dispatch an unconfirmed update from. The existing
`showConfirmDialog` primitive is reused rather than duplicated, so focus handling, Escape,
backdrop dismissal, and its reentrancy guard come along unchanged.

Deliberate non-goals: this changes no backend contract. The `update.run` RPC, the CLI, the
API, automation clients, agent-driven paths, and automatic update campaigns are untouched —
they are intentionally noninteractive and must stay that way. A native decline from the Mac
app still falls through to the Gateway route without asking twice, because that is the tail
of an already-confirmed click, not a new one.

## Scope

This PR covers the **Control UI web surface** and the **macOS bridge route triggered by
that same web control** (the update card hands a confirmed update to the Mac app).

- ✅ Control UI web: sidebar card, Settings sidebar card, floating card, Settings → Updates row
- ✅ macOS bridge, where the Control UI card delegates the update to the Mac app
- ❌ **Android app: NOT covered**
- ❌ **iOS app: NOT covered**

Issue #117178 asks for the same rule across first-party graphical surfaces, so it
**stays open** for the remaining native surfaces. This PR intentionally addresses only the
Control UI portion.

Inventory note: `update.run` is the only disruptive lifecycle action the Control UI exposes
on current `main`. There is no Control UI affordance for gateway restart, stop, shutdown, or
host reboot, so none was invented here; when one is added it should call the same gate.

## User Impact

Operators can no longer start an update by accident. The first click opens a dialog naming
the target ("Update Gateway" or "Update Mac app + Gateway"), stating that the Gateway
restarts and the Control UI disconnects, and showing `Installed v1.0.0 · Available v2.0.0`
when those versions are known. Confirming requires the explicit **Update and restart**
action — never a generic "Yes". Cancel, Escape, and dismissing the dialog all leave the
Gateway untouched. Initial focus sits on Cancel, and the keypress that opens the dialog
cannot also confirm it. Nothing is remembered or bypassed: the confirmation appears every
time.

## Evidence

### Before → after (same deterministic mock-Gateway fixture, viewport, and theme)

Both columns run the identical fixture (`updateAvailable: 1.0.0 → 2.0.0`, mock Gateway,
`en-US`); only the production code differs. The "before" column was captured with the
production files reverted to the base commit `690f7d77786`.

**Desktop 1280×720, light — one click on the sidebar update card**

| Before (`main`): update already running, no confirmation | After: confirmation, nothing sent |
| --- | --- |
| <img width="640" src="https://github.com/user-attachments/assets/5df5685f-9baa-4db8-8328-e13356e3f569" /> | <img width="640" src="https://github.com/user-attachments/assets/b4df8c92-1321-426b-baf0-eb5327516f38" /> |

In the before shot the card already reads `Updating… · v2.0.0`; the E2E capture asserts
`update.run` was called once from that single click. In the after shot `update.run` has been
called zero times.

**Desktop 1280×720, dark**

| Before | After |
| --- | --- |
| <img width="640" src="https://github.com/user-attachments/assets/083fbf54-ceed-461d-bbca-2a0a8b4220a0" /> | <img width="640" src="https://github.com/user-attachments/assets/cc87b59c-d158-4fd6-9ab5-50cde1b88342" /> |

**Compact 420×780 (floating update card)**

| Before | After |
| --- | --- |
| <img width="320" src="https://github.com/user-attachments/assets/0b22c88e-24fe-4fe6-9472-19a57c546f9c" /> | <img width="320" src="https://github.com/user-attachments/assets/a33f111b-193c-4f8a-b2d0-8868c9827c79" /> |

**Settings → Updates → Update now (1280×900)** — the same gate, not a second implementation

| Before | After |
| --- | --- |
| <img width="640" src="https://github.com/user-attachments/assets/6c6a62f5-bde8-439f-b722-dc9c463e1239" /> | <img width="640" src="https://github.com/user-attachments/assets/28c9c25c-41c6-4799-93ea-7fab7a164a79" /> |

### Keyboard and focus

Opening the dialog with <kbd>Enter</kbd> on the update button leaves focus on **Cancel**, so
the same keypress cannot confirm. A later, explicit <kbd>Enter</kbd> on the focused confirm
action does confirm, exactly once.

| Initial focus after opening (Cancel) | Focus moved to the confirm action |
| --- | --- |
| <img width="640" src="https://github.com/user-attachments/assets/180733df-2a91-46a3-9ac0-3e0716f21e62" /> | <img width="640" src="https://github.com/user-attachments/assets/fc6df8ff-c9ea-43f8-8ef9-4011a953f4b1" /> |

And the confirmed result — one request, card switches to `Updating…`:

<img width="640" src="https://github.com/user-attachments/assets/b0a95259-e14e-43ad-998d-fa8b7a55a8fa" />

### Tests

New deterministic E2E against the mocked Gateway/bridge, `ui/src/e2e/update-confirmation.e2e.test.ts`
(7 tests), proving the full contract:

- first click opens the confirmation and issues **zero** `update.run` requests
- **Cancel** issues no request; **Escape** issues no request; the affordance stays enabled
- the opening keypress lands on Cancel; a later explicit <kbd>Enter</kbd> confirms
- clicking the confirm action sends **exactly one** request
- the dialog states action, target, restart consequence, and both versions
- the Settings row uses the same confirmation and the same single-request behavior
- the dialog renders correctly in dark mode and on a compact viewport

New unit coverage for the gate itself, `ui/src/app/update-confirmation.runtime.test.ts` (8 tests):
copy/labels/autofocus, Cancel and modal-dismissal paths, single Gateway dispatch, macOS
bridge handoff, fallback to the Gateway when the bridge disappears mid-confirmation, the
git-target (`3 commits behind`) label, and no double-submit from a repeated request.

Existing suites updated to the new contract rather than duplicated:
`ui/src/components/sidebar-update-card.test.ts`, `ui/src/pages/config/config-page.test.ts`,
`ui/src/app/app-host-native-shell.test.ts`, `ui/src/test-helpers/app-sidebar-cases/basics.ts`,
`ui/src/e2e/update-coalesced.e2e.test.ts`, `ui/src/e2e/updates-settings.e2e.test.ts`. A shared
`waitForRenderedModalDialog` helper was added next to the existing modal-dialog test helpers,
since the dialog now arrives behind a lazy import.

Red/green: the existing card, config-page, and update E2E tests asserted a dispatch on the
bare click and fail against this change until they drive the confirmation, which is the
regression the issue reports.

### Commands (Blacksmith Testbox, Linux, Node 24)

```
pnpm format:check ui/src docs                                  FORMAT_OK
pnpm tsgo:ui                                                   TSGO_UI_OK
pnpm ui:i18n:verify                                            I18N_OK  (raw-copy baseline unchanged)
node scripts/run-oxlint.mjs --openclaw-focused-config \
  --config config/oxlint/boundary-guards.json ui/src           0 warnings, 0 errors
pnpm lint:ui:styles                                            STYLES_OK
pnpm check:import-cycles                                       0 runtime value cycle(s)
pnpm ui:build && node --import tsx \
  scripts/check-control-ui-performance.mts                     startup JS 324485 B (ceiling 324608 B)
pnpm test:ui                                                   579 files, 8623 passed, 1 skipped
pnpm test:ui:e2e ui/src/e2e/update-confirmation.e2e.test.ts \
  ui/src/e2e/update-coalesced.e2e.test.ts \
  ui/src/e2e/updates-settings.e2e.test.ts                      15 passed
```

### Startup bundle

The gate is loaded lazily, so the Control UI startup bundle got *smaller*, not larger:

```
before (main):  startup JS gzip 324587 B
after  (this):  startup JS gzip 324485 B   (ceiling 324608 B)
```

Nothing about the confirmation is needed until an operator clicks an update affordance, so
`update-confirmation.ts` only carries the params type and a dynamic import of
`update-confirmation.runtime.ts`. The startup-budget baseline is untouched.

### Size

`Production: +109/-5 (net +104) | Tests: +513/-6 (net +507) | Docs: +11/-0`

The production growth is the gate (a 23-line lazy entry plus a 52-line implementation), six
English strings, and the two call-site rewrites. It buys a named ownership boundary — one
place that owns the disruptive-action policy — and it removes the duplicate
bridge-versus-Gateway dispatch that previously lived in the card component. Splitting the
policy back across the four affordances would cost more lines and reintroduce the drift the
issue asks us to prevent.

### Follow-up noted, not fixed here

Inside the macOS app, **Settings → Updates → Update now** stays on the Gateway route while
the sidebar card hands the update to the Mac app. That predates this PR. Unifying it needs
the native-decline listener to move out of the card to a shared owner, otherwise a handoff
the app refuses would end in silence from that row — a behavior change beyond this issue's
confirmation scope. Called out in a code comment at the call site.
