### PR TITLE
fix(telegram): stabilize command menu ordering

### DIFF
--- a/extensions/telegram/src/bot-native-command-menu-sync.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu-sync.test.ts
@@ -327,7 +327,7 @@ describe("bot-native-command-menu sync lifecycle", () => {
     expect((localizedPayload[0] as { description: string }).description).toHaveLength(256);
   });
 
-  it("prioritizes configured, canonical, then alias commands under localization-only pressure", async () => {
+  it("preserves canonical source order under localization-only pressure", async () => {
     const deleteMyCommands = vi.fn(async () => undefined);
     const setMyCommands = vi.fn(async () => undefined);
     const localizedDescription = "한".repeat(250);
@@ -342,17 +342,16 @@ describe("bot-native-command-menu sync lifecycle", () => {
       setMyCommands,
       commandsToRegister: [
         {
-          command: "early_alias",
-          description: "Alias",
-          descriptionLocalizations: { ko: localizedDescription },
-          isAlias: true,
-        },
-        ...canonical,
-        {
           command: "configured",
           description: "Configured",
           descriptionLocalizations: { ko: localizedDescription },
-          isConfigured: true,
+        },
+        ...canonical,
+        {
+          command: "late_alias",
+          description: "Alias",
+          descriptionLocalizations: { ko: localizedDescription },
+          isAlias: true,
         },
       ],
       accountId: `test-localized-pressure-${Date.now()}`,
@@ -365,7 +364,7 @@ describe("bot-native-command-menu sync lifecycle", () => {
     expect(localizedNames).toEqual([
       "configured",
       ...canonical.map(({ command }) => command),
-      "early_alias",
+      "late_alias",
     ]);
     expect(setMyCommandsPayload(setMyCommands, 3)).toEqual(setMyCommandsPayload(setMyCommands, 2));
   });
@@ -379,10 +378,9 @@ describe("bot-native-command-menu sync lifecycle", () => {
       setMyCommands,
       commandsToRegister: [
         {
-          command: "early_alias",
-          description: "Alias",
-          descriptionLocalizations: { ko: "별칭" },
-          isAlias: true,
+          command: "configured",
+          description: "Configured",
+          descriptionLocalizations: { ko: "설정" },
         },
         {
           command: "canonical",
@@ -390,10 +388,10 @@ describe("bot-native-command-menu sync lifecycle", () => {
           descriptionLocalizations: { ko: "표준" },
         },
         {
-          command: "configured",
-          description: "Configured",
-          descriptionLocalizations: { ko: "설정" },
-          isConfigured: true,
+          command: "late_alias",
+          description: "Alias",
+          descriptionLocalizations: { ko: "별칭" },
+          isAlias: true,
         },
       ],
       accountId: `test-localized-no-pressure-${Date.now()}`,
@@ -401,9 +399,9 @@ describe("bot-native-command-menu sync lifecycle", () => {
 
     await waitForTelegramMenu(() => expect(setMyCommands).toHaveBeenCalledTimes(4));
     expect(setMyCommandsPayload(setMyCommands, 2)).toEqual([
-      { command: "early_alias", description: "별칭" },
-      { command: "canonical", description: "표준" },
       { command: "configured", description: "설정" },
+      { command: "canonical", description: "표준" },
+      { command: "late_alias", description: "별칭" },
     ]);
     expect(setMyCommandsPayload(setMyCommands, 3)).toEqual(setMyCommandsPayload(setMyCommands, 2));
   });
@@ -505,7 +503,7 @@ describe("bot-native-command-menu sync lifecycle", () => {
     expect(setMyCommands).toHaveBeenCalledTimes(2);
   });
 
-  it("ignores internal priority metadata in the requested-state hash (#32017)", async () => {
+  it("ignores isAlias and isSkill metadata in the requested-state hash (#32017)", async () => {
     const deleteMyCommands = vi.fn(async () => undefined);
     const setMyCommands = vi.fn(async () => undefined);
     const accountId = `test-priority-hash-${Date.now()}`;
@@ -518,7 +516,7 @@ describe("bot-native-command-menu sync lifecycle", () => {
           command: "skip_test",
           description: "Skip test command",
           isAlias: true,
-          isConfigured: true,
+          isSkill: true,
         },
       ],
       accountId,

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -12,6 +12,12 @@ function waitForTelegramMenu(assertion: () => void) {
   return vi.waitFor(assertion, { interval: 1 });
 }
 
+function waitForTelegramMenuTurn() {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
 type SyncMenuOptions = {
   deleteMyCommands: ReturnType<typeof vi.fn>;
   setMyCommands: ReturnType<typeof vi.fn>;
@@ -57,6 +63,31 @@ function setMyCommandsPayload(
   return payload;
 }
 
+function buildSkillRetryCommands(params: {
+  nativeCount: number;
+  skillCount: number;
+  pluginCount: number;
+}): SyncMenuOptions["commandsToRegister"] {
+  return [
+    { command: "custom_one", description: "Custom one" },
+    { command: "custom_two", description: "Custom two" },
+    ...Array.from({ length: params.nativeCount }, (_, index) => ({
+      command: `native_${index}`,
+      description: `Native ${index}`,
+    })),
+    { command: "skill", description: "Run a skill" },
+    ...Array.from({ length: params.skillCount }, (_, index) => ({
+      command: `skill_${index}`,
+      description: `Skill ${index}`,
+      isSkill: true,
+    })),
+    ...Array.from({ length: params.pluginCount }, (_, index) => ({
+      command: `plugin_${index}`,
+      description: `Plugin ${index}`,
+    })),
+  ];
+}
+
 describe("bot-native-command-menu", () => {
   const canonicalCommands = Array.from({ length: 100 }, (_, index) => ({
     command: `canonical_${index}`,
@@ -66,9 +97,9 @@ describe("bot-native-command-menu", () => {
     {
       label: ">100 count cap",
       allCommands: [
-        { command: "early_alias", description: "Alias", isAlias: true },
+        { command: "configured", description: "Configured" },
         ...canonicalCommands,
-        { command: "configured", description: "Configured", isConfigured: true },
+        { command: "late_alias", description: "Alias", isAlias: true },
       ],
       maxTotalChars: TELEGRAM_COMMAND_TEXT_LIMIT,
       retry: false,
@@ -77,9 +108,9 @@ describe("bot-native-command-menu", () => {
     {
       label: "sub-100 text omission",
       allCommands: [
-        { command: "early_alias", description: "Alias", isAlias: true },
+        { command: "custom_last", description: "Configured" },
         { command: "canonical_later", description: "Canonical" },
-        { command: "custom_last", description: "Configured", isConfigured: true },
+        { command: "late_alias", description: "Alias", isAlias: true },
       ],
       maxTotalChars: 28,
       retry: false,
@@ -88,11 +119,11 @@ describe("bot-native-command-menu", () => {
     {
       label: "BOT_COMMANDS_TOO_MUCH retry",
       allCommands: [
-        { command: "early_alias", description: "Alias", isAlias: true },
+        { command: "configured", description: "Configured" },
         { command: "canonical_a", description: "Canonical A" },
-        { command: "configured", description: "Configured", isConfigured: true },
         { command: "canonical_b", description: "Canonical B" },
         { command: "canonical_c", description: "Canonical C" },
+        { command: "late_alias", description: "Alias", isAlias: true },
       ],
       maxTotalChars: TELEGRAM_COMMAND_TEXT_LIMIT,
       retry: true,
@@ -101,49 +132,229 @@ describe("bot-native-command-menu", () => {
     {
       label: "no pressure",
       allCommands: [
-        { command: "early_alias", description: "🦞".repeat(250), isAlias: true },
+        { command: "configured", description: "Configured" },
         { command: "canonical", description: "Canonical" },
         { command: "plugin", description: "Plugin" },
-        { command: "configured", description: "Configured", isConfigured: true },
+        { command: "late_alias", description: "🦞".repeat(250), isAlias: true },
       ],
       maxTotalChars: TELEGRAM_COMMAND_TEXT_LIMIT,
       retry: false,
-      expected: ["early_alias", "canonical", "plugin", "configured"],
+      expected: ["configured", "canonical", "plugin", "late_alias"],
     },
-  ])(
-    "handles $label with configured, canonical, then alias pressure priority",
-    async (testCase) => {
-      const result = buildCappedTelegramMenuCommands({
-        allCommands: testCase.allCommands,
-        maxTotalChars: testCase.maxTotalChars,
-      });
-      if (!testCase.retry) {
-        expect(result.commandsToRegister.map(({ command }) => command)).toEqual(testCase.expected);
-        return;
+  ])("preserves canonical source order for $label", async (testCase) => {
+    const result = buildCappedTelegramMenuCommands({
+      allCommands: testCase.allCommands,
+      maxTotalChars: testCase.maxTotalChars,
+    });
+    if (!testCase.retry) {
+      expect(result.commandsToRegister.map(({ command }) => command)).toEqual(testCase.expected);
+      if (testCase.label === "no pressure") {
+        expect(result.commandsToRegister).toEqual(testCase.allCommands);
       }
+      return;
+    }
 
-      const setMyCommands = vi
-        .fn()
-        .mockRejectedValueOnce(new Error("400: Bad Request: BOT_COMMANDS_TOO_MUCH"))
-        .mockResolvedValue(undefined);
-      syncMenuCommandsWithMocks({
-        deleteMyCommands: vi.fn(async () => undefined),
-        setMyCommands,
-        commandsToRegister: result.commandsToRegister,
-        accountId: `test-pressure-${Date.now()}`,
-        botToken: "bot-a",
-      });
-      await waitForTelegramMenu(() => expect(setMyCommands).toHaveBeenCalledTimes(3));
-      const retryPayload = setMyCommandsPayload(setMyCommands, 1);
-      expect(retryPayload.map((command) => (command as { command: string }).command)).toEqual(
-        testCase.expected,
-      );
-      expect(setMyCommandsPayload(setMyCommands, 2)).toEqual(retryPayload);
-      expect(retryPayload.every((command) => Object.keys(command as object).length === 2)).toBe(
-        true,
-      );
+    const setMyCommands = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("400: Bad Request: BOT_COMMANDS_TOO_MUCH"))
+      .mockResolvedValue(undefined);
+    syncMenuCommandsWithMocks({
+      deleteMyCommands: vi.fn(async () => undefined),
+      setMyCommands,
+      commandsToRegister: result.commandsToRegister,
+      accountId: `test-pressure-${Date.now()}`,
+      botToken: "bot-a",
+    });
+    await waitForTelegramMenu(() => expect(setMyCommands).toHaveBeenCalledTimes(3));
+    const retryPayload = setMyCommandsPayload(setMyCommands, 1);
+    expect(retryPayload.map((command) => (command as { command: string }).command)).toEqual(
+      testCase.expected,
+    );
+    expect(setMyCommandsPayload(setMyCommands, 2)).toEqual(retryPayload);
+    expect(retryPayload.every((command) => Object.keys(command as object).length === 2)).toBe(true);
+  });
+
+  it("promotes /skill when local fitting omits every direct skill", () => {
+    const configured = Array.from({ length: 100 }, (_, index) => ({
+      command: `configured_${index}`,
+      description: `Configured ${index}`,
+    }));
+    const result = buildCappedTelegramMenuCommands({
+      allCommands: [
+        ...configured,
+        { command: "skill", description: "Run a skill" },
+        { command: "direct_one", description: "Direct one", isSkill: true },
+        { command: "direct_two", description: "Direct two", isSkill: true },
+      ],
+    });
+
+    expect(result.skillCommandsOmitted).toBe(true);
+    expect(result.commandsToRegister.map((command) => command.command)).toEqual([
+      "skill",
+      ...configured.slice(0, 99).map((command) => command.command),
+    ]);
+  });
+
+  it.each([
+    {
+      label: "partial direct-skill prefix",
+      nativeCount: 67,
+      source: buildSkillRetryCommands({ nativeCount: 67, skillCount: 20, pluginCount: 10 }),
+      expectedPluginTail: Array.from({ length: 10 }, (_, index) => `plugin_${index}`),
     },
-  );
+    {
+      label: "zero direct skills retained",
+      nativeCount: 77,
+      source: buildSkillRetryCommands({ nativeCount: 77, skillCount: 10, pluginCount: 10 }),
+      expectedPluginTail: [] as string[],
+    },
+  ])("collapses $label on BOT_COMMANDS_TOO_MUCH", async (testCase) => {
+    const setMyCommands = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("400: Bad Request: BOT_COMMANDS_TOO_MUCH"))
+      .mockResolvedValue(undefined);
+    const runtimeLog = vi.fn();
+    syncMenuCommandsWithMocks({
+      deleteMyCommands: vi.fn(async () => undefined),
+      setMyCommands,
+      runtimeLog,
+      commandsToRegister: testCase.source,
+      accountId: `test-skill-retry-${testCase.label}-${Date.now()}`,
+      botToken: "bot-skill-retry",
+    });
+    await waitForTelegramMenu(() => expect(setMyCommands).toHaveBeenCalledTimes(3));
+
+    const retryPayload = setMyCommandsPayload(setMyCommands, 1);
+    const retryNames = retryPayload.map((command) => (command as { command: string }).command);
+    expect(retryNames).toEqual([
+      "skill",
+      "custom_one",
+      "custom_two",
+      ...Array.from({ length: testCase.nativeCount }, (_, index) => `native_${index}`),
+      ...testCase.expectedPluginTail,
+    ]);
+    expect(retryNames.some((command) => command.startsWith("skill_"))).toBe(false);
+    expect(setMyCommandsCall(setMyCommands, 1).at(1)).toBeUndefined();
+    expect(setMyCommandsPayload(setMyCommands, 2)).toEqual(retryPayload);
+    expect(setMyCommandsCall(setMyCommands, 2).at(1)).toEqual({
+      scope: { type: "all_group_chats" },
+    });
+    expect(runtimeLog.mock.calls.map(([message]) => message)).toEqual([
+      "Telegram rejected 100 commands (BOT_COMMANDS_TOO_MUCH); retrying with 80.",
+      "Telegram accepted 80 commands after BOT_COMMANDS_TOO_MUCH (started with 100; omitted 20). Reduce plugin/skill/custom commands to expose more menu entries.",
+    ]);
+  });
+
+  it("logs and progresses from the actual underfilled retry length", async () => {
+    const setMyCommands = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("400: Bad Request: BOT_COMMANDS_TOO_MUCH"))
+      .mockResolvedValue(undefined);
+    const runtimeLog = vi.fn();
+    const source = buildSkillRetryCommands({ nativeCount: 37, skillCount: 60, pluginCount: 0 });
+    syncMenuCommandsWithMocks({
+      deleteMyCommands: vi.fn(async () => undefined),
+      setMyCommands,
+      runtimeLog,
+      commandsToRegister: source,
+      accountId: `test-underfilled-skill-retry-${Date.now()}`,
+      botToken: "bot-underfilled-skill-retry",
+    });
+    await waitForTelegramMenu(() => expect(setMyCommands).toHaveBeenCalledTimes(3));
+
+    const retryPayload = setMyCommandsPayload(setMyCommands, 1);
+    const retryNames = retryPayload.map((command) => (command as { command: string }).command);
+    expect(retryNames).toEqual([
+      "skill",
+      "custom_one",
+      "custom_two",
+      ...Array.from({ length: 37 }, (_, index) => `native_${index}`),
+    ]);
+    expect(retryNames.some((command) => command.startsWith("skill_"))).toBe(false);
+    expect(setMyCommandsCall(setMyCommands, 1).at(1)).toBeUndefined();
+    expect(setMyCommandsPayload(setMyCommands, 2)).toEqual(retryPayload);
+    expect(setMyCommandsCall(setMyCommands, 2).at(1)).toEqual({
+      scope: { type: "all_group_chats" },
+    });
+    expect(runtimeLog.mock.calls.map(([message]) => message)).toEqual([
+      "Telegram rejected 100 commands (BOT_COMMANDS_TOO_MUCH); retrying with 40.",
+      "Telegram accepted 40 commands after BOT_COMMANDS_TOO_MUCH (started with 100; omitted 60). Reduce plugin/skill/custom commands to expose more menu entries.",
+    ]);
+  });
+
+  it("refills a second BOT_COMMANDS_TOO_MUCH reduction from the original catalog", async () => {
+    const setMyCommands = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("400: Bad Request: BOT_COMMANDS_TOO_MUCH"))
+      .mockRejectedValueOnce(new Error("400: Bad Request: BOT_COMMANDS_TOO_MUCH"))
+      .mockResolvedValue(undefined);
+    const runtimeLog = vi.fn();
+    const source = buildSkillRetryCommands({ nativeCount: 57, skillCount: 20, pluginCount: 20 });
+    syncMenuCommandsWithMocks({
+      deleteMyCommands: vi.fn(async () => undefined),
+      setMyCommands,
+      runtimeLog,
+      commandsToRegister: source,
+      accountId: `test-second-skill-retry-${Date.now()}`,
+      botToken: "bot-second-skill-retry",
+    });
+    await waitForTelegramMenu(() => expect(setMyCommands).toHaveBeenCalledTimes(4));
+
+    const firstRetryNames = setMyCommandsPayload(setMyCommands, 1).map(
+      (command) => (command as { command: string }).command,
+    );
+    expect(firstRetryNames).toHaveLength(80);
+    expect(firstRetryNames.filter((command) => command.startsWith("skill_"))).toHaveLength(20);
+    expect(firstRetryNames.some((command) => command.startsWith("plugin_"))).toBe(false);
+    const secondRetryPayload = setMyCommandsPayload(setMyCommands, 2);
+    const secondRetryNames = secondRetryPayload.map(
+      (command) => (command as { command: string }).command,
+    );
+    expect(secondRetryNames).toHaveLength(64);
+    expect(secondRetryNames.slice(0, 3)).toEqual(["skill", "custom_one", "custom_two"]);
+    expect(secondRetryNames.some((command) => command.startsWith("skill_"))).toBe(false);
+    expect(secondRetryNames.slice(-4)).toEqual(
+      Array.from({ length: 4 }, (_, index) => `plugin_${index}`),
+    );
+    expect(setMyCommandsCall(setMyCommands, 2).at(1)).toBeUndefined();
+    expect(setMyCommandsPayload(setMyCommands, 3)).toEqual(secondRetryPayload);
+    expect(setMyCommandsCall(setMyCommands, 3).at(1)).toEqual({
+      scope: { type: "all_group_chats" },
+    });
+    expect(runtimeLog.mock.calls.map(([message]) => message)).toEqual([
+      "Telegram rejected 100 commands (BOT_COMMANDS_TOO_MUCH); retrying with 80.",
+      "Telegram rejected 80 commands (BOT_COMMANDS_TOO_MUCH); retrying with 64.",
+      "Telegram accepted 64 commands after BOT_COMMANDS_TOO_MUCH (started with 100; omitted 36). Reduce plugin/skill/custom commands to expose more menu entries.",
+    ]);
+  });
+
+  it("hashes effective localizations independently of insertion order", async () => {
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const setMyCommands = vi.fn(async () => undefined);
+    const accountId = `test-localization-hash-${Date.now()}`;
+    const sync = (descriptionLocalizations: Record<string, string>) =>
+      syncMenuCommandsWithMocks({
+        deleteMyCommands,
+        setMyCommands,
+        accountId,
+        botToken: "bot-localization-hash",
+        commandsToRegister: [
+          {
+            command: "localized",
+            description: "Default|value\0",
+            descriptionLocalizations,
+          },
+        ],
+      });
+
+    sync({ fr: "Français|value\0", ko: "한국어" });
+    await waitForTelegramMenu(() => expect(setMyCommands).toHaveBeenCalledTimes(6));
+    sync({ ko: "한국어", " FR ": " Français|value\0 " });
+    await waitForTelegramMenuTurn();
+    expect(setMyCommands).toHaveBeenCalledTimes(6);
+    sync({ ko: "변경됨", fr: "Français|value\0" });
+    await waitForTelegramMenu(() => expect(setMyCommands).toHaveBeenCalledTimes(12));
+  });
 
   it("does not reuse cached capped results for delimiter-like descriptions", () => {
     const first = buildCappedTelegramMenuCommands({
@@ -218,6 +429,43 @@ describe("bot-native-command-menu", () => {
 
     expect(result.commands).toEqual([{ command: "agent_run", description: "Run agent" }]);
     expect(result.issues).toStrictEqual([]);
+  });
+
+  it("sorts plugin commands deterministically and prefers exact normalized identities", () => {
+    const specs = [
+      { name: "zeta", description: "Zeta" },
+      {
+        name: "foo-bar",
+        description: "Transformed alias",
+        descriptionLocalizations: { ko: "변환됨" },
+      },
+      {
+        name: "foo_bar",
+        description: "Exact owner",
+        descriptionLocalizations: { ko: "정확함" },
+      },
+      { name: "alpha", description: "Alpha" },
+    ];
+    const build = (orderedSpecs: typeof specs) =>
+      buildPluginTelegramMenuCommands({
+        specs: orderedSpecs,
+        existingCommands: new Set<string>(),
+      });
+
+    const forward = build(specs);
+    const reverse = build(specs.toReversed());
+
+    expect(forward).toEqual(reverse);
+    expect(forward.commands).toEqual([
+      { command: "alpha", description: "Alpha" },
+      {
+        command: "foo_bar",
+        description: "Exact owner",
+        descriptionLocalizations: { ko: "정확함" },
+      },
+      { command: "zeta", description: "Zeta" },
+    ]);
+    expect(forward.issues).toContain('Plugin command "/foo_bar" is duplicated.');
   });
 
   it("ignores malformed plugin specs without crashing", () => {

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -33,7 +33,6 @@ export type TelegramMenuCommand = {
   description: string;
   descriptionLocalizations?: Record<string, string>;
   isAlias?: boolean;
-  isConfigured?: boolean;
   isSkill?: boolean;
 };
 
@@ -192,9 +191,31 @@ export function buildPluginTelegramMenuCommands(params: {
   const issues: string[] = [];
   const pluginCommandNames = new Set<string>();
 
-  for (const spec of specs) {
-    const rawName = typeof spec.name === "string" ? spec.name : "";
-    const normalized = normalizeTelegramCommandName(rawName);
+  // Settle normalized collision ownership before display priority so discovery order cannot win.
+  const sortedSpecs = specs
+    .map((spec) => {
+      const rawName = typeof spec.name === "string" ? spec.name : "";
+      return {
+        spec,
+        rawName,
+        normalized: normalizeTelegramCommandName(rawName),
+      };
+    })
+    .toSorted((a, b) => {
+      if (a.normalized !== b.normalized) {
+        return a.normalized < b.normalized ? -1 : 1;
+      }
+      const aExact = a.rawName.trim().toLowerCase() === a.normalized;
+      const bExact = b.rawName.trim().toLowerCase() === b.normalized;
+      if (aExact !== bExact) {
+        return aExact ? -1 : 1;
+      }
+      // Plugin registration rejects duplicate exact invocation keys, so equal raw names
+      // cannot represent distinct production owners; transformed collisions settle above.
+      return a.rawName < b.rawName ? -1 : a.rawName > b.rawName ? 1 : 0;
+    });
+
+  for (const { spec, rawName, normalized } of sortedSpecs) {
     if (!normalized || !TELEGRAM_COMMAND_NAME_PATTERN.test(normalized)) {
       const invalidName = rawName.trim() ? rawName : "<unknown>";
       issues.push(
@@ -252,12 +273,10 @@ export function buildCappedTelegramMenuCommands(params: {
   return result;
 }
 
-export function orderForPressure(commands: TelegramMenuCommand[]): TelegramMenuCommand[] {
-  return [
-    ...commands.filter((command) => command.isConfigured),
-    ...commands.filter((command) => !command.isConfigured && !command.isAlias),
-    ...commands.filter((command) => !command.isConfigured && command.isAlias),
-  ];
+function buildDirectSkillFallbackCommands(commands: TelegramMenuCommand[]): TelegramMenuCommand[] {
+  const fallback = commands.find((command) => command.command === "skill" && !command.isSkill);
+  const remaining = commands.filter((command) => !command.isSkill && command !== fallback);
+  return fallback ? [fallback, ...remaining] : remaining;
 }
 
 function buildUncachedCappedTelegramMenuCommands(params: {
@@ -272,30 +291,38 @@ function buildUncachedCappedTelegramMenuCommands(params: {
   maxTotalChars: number;
   descriptionTrimmed: boolean;
   textBudgetDropCount: number;
+  skillCommandsOmitted: boolean;
 } {
-  const { allCommands } = params;
-  const { maxCommands, maxTotalChars } = params;
-  const totalCommands = allCommands.length;
+  const { allCommands, maxCommands, maxTotalChars } = params;
+  const fitCommands = (commands: TelegramMenuCommand[]) => {
+    const cappedCommands = commands.slice(0, maxCommands);
+    const needsFitting =
+      cappedCommands.some(
+        (command) =>
+          countTelegramCommandText(command.description) > TELEGRAM_MAX_COMMAND_DESCRIPTION_LENGTH,
+      ) ||
+      cappedCommands.reduce(
+        (total, { command, description }) =>
+          total + countTelegramCommandText(command) + countTelegramCommandText(description),
+        0,
+      ) > maxTotalChars;
+    return needsFitting
+      ? fitTelegramCommandsWithinTextBudget(cappedCommands, maxTotalChars)
+      : { commands: cappedCommands, descriptionTrimmed: false, textBudgetDropCount: 0 };
+  };
+  let effectiveCommands = allCommands;
+  let fitted = fitCommands(allCommands);
+  // Direct skill menu entries are all-or-none; fallback keeps canonical /skill visible first.
+  const skillCommandCount = allCommands.filter((command) => command.isSkill).length;
+  const skillCommandsOmitted =
+    skillCommandCount > 0 &&
+    fitted.commands.filter((command) => command.isSkill).length < skillCommandCount;
+  if (skillCommandsOmitted) {
+    effectiveCommands = buildDirectSkillFallbackCommands(allCommands);
+    fitted = fitCommands(effectiveCommands);
+  }
+  const totalCommands = effectiveCommands.length;
   const overflowCount = Math.max(0, totalCommands - maxCommands);
-  const cappedCommands = allCommands.slice(0, maxCommands);
-  const totalText = cappedCommands.reduce(
-    (total, { command, description }) =>
-      total + countTelegramCommandText(command) + countTelegramCommandText(description),
-    0,
-  );
-  const hasMenuPressure =
-    overflowCount > 0 ||
-    totalText > maxTotalChars ||
-    cappedCommands.some(
-      (command) =>
-        countTelegramCommandText(command.description) > TELEGRAM_MAX_COMMAND_DESCRIPTION_LENGTH,
-    );
-  const fitted = hasMenuPressure
-    ? fitTelegramCommandsWithinTextBudget(
-        orderForPressure(allCommands).slice(0, maxCommands),
-        maxTotalChars,
-      )
-    : { commands: cappedCommands, descriptionTrimmed: false, textBudgetDropCount: 0 };
   return {
     commandsToRegister: fitted.commands,
     totalCommands,
@@ -304,6 +331,7 @@ function buildUncachedCappedTelegramMenuCommands(params: {
     maxTotalChars,
     descriptionTrimmed: fitted.descriptionTrimmed,
     textBudgetDropCount: fitted.textBudgetDropCount,
+    skillCommandsOmitted,
   };
 }
 
@@ -319,7 +347,6 @@ function buildTelegramMenuResultCacheKey(params: {
     updateTelegramCommandDigestField(digest, command.command);
     updateTelegramCommandDigestField(digest, command.description);
     updateTelegramCommandDigestField(digest, command.isAlias ? "1" : "0");
-    updateTelegramCommandDigestField(digest, command.isConfigured ? "1" : "0");
     updateTelegramCommandDigestField(digest, command.isSkill ? "1" : "0");
     updateTelegramCommandLocalizationDigest(digest, command.descriptionLocalizations);
   }
@@ -362,14 +389,26 @@ function rememberCappedTelegramMenuResult(
 }
 
 function hashCommandList(commands: TelegramMenuCommand[]): string {
-  const requestedCommands = commands.map((command) => ({
-    command: command.command,
-    description: command.description,
-    descriptionLocalizations: buildEffectiveTelegramCommandLocalizations(
-      command.descriptionLocalizations,
-    ),
-  }));
-  return createHash("sha256").update(JSON.stringify(requestedCommands)).digest("hex").slice(0, 16);
+  const digest = createHash("sha256");
+  updateTelegramCommandDigestField(digest, String(commands.length));
+  for (const command of commands) {
+    updateTelegramCommandDigestField(digest, command.command);
+    updateTelegramCommandDigestField(digest, command.description);
+    updateTelegramCommandLocalizationDigest(digest, command.descriptionLocalizations);
+  }
+  return digest.digest("hex").slice(0, 16);
+}
+
+function reduceTelegramMenuCommands(
+  commands: TelegramMenuCommand[],
+  maxCommands: number,
+): TelegramMenuCommand[] {
+  const reduced = commands.slice(0, maxCommands);
+  const skillCommandCount = commands.filter((command) => command.isSkill).length;
+  const reducedSkillCommandCount = reduced.filter((command) => command.isSkill).length;
+  return reducedSkillCommandCount < skillCommandCount
+    ? buildDirectSkillFallbackCommands(commands).slice(0, maxCommands)
+    : reduced;
 }
 
 function buildEffectiveTelegramCommandLocalizations(
@@ -640,16 +679,17 @@ export function syncTelegramMenuCommands(params: {
         const nextCount = Math.floor(retryCommands.length * TELEGRAM_COMMAND_RETRY_RATIO);
         const reducedCount =
           nextCount < retryCommands.length ? nextCount : retryCommands.length - 1;
-        if (reducedCount <= 0) {
+        const nextCommands = reduceTelegramMenuCommands(commandsToRegister, reducedCount);
+        if (reducedCount <= 0 || nextCommands.length === 0) {
           runtime.error?.(
             "Telegram rejected native command registration (BOT_COMMANDS_TOO_MUCH); leaving menu empty. Reduce commands or disable channels.telegram.commands.native.",
           );
           return;
         }
         runtime.log?.(
-          `Telegram rejected ${retryCommands.length} commands (BOT_COMMANDS_TOO_MUCH); retrying with ${reducedCount}.`,
+          `Telegram rejected ${retryCommands.length} commands (BOT_COMMANDS_TOO_MUCH); retrying with ${nextCommands.length}.`,
         );
-        retryCommands = orderForPressure(retryCommands).slice(0, reducedCount);
+        retryCommands = nextCommands;
       }
     }
 

--- a/extensions/telegram/src/bot-native-commands.registry.test.ts
+++ b/extensions/telegram/src/bot-native-commands.registry.test.ts
@@ -187,6 +187,36 @@ describe("registerTelegramNativeCommands real plugin registry", () => {
     expect(sendMessage).not.toHaveBeenCalledWith(123, "Command not found.");
   });
 
+  it("keeps a custom menu description while registering the same-name plugin handler", async () => {
+    const { bot, commandHandlers, sendMessage, setMyCommands } = createCommandBot();
+    registerPairPluginCommand();
+
+    registerTelegramNativeCommands({
+      ...createNativeCommandTestParams(
+        {},
+        {
+          telegramCfg: {
+            customCommands: [{ command: "pair", description: "Configured pair menu" }],
+          },
+        },
+      ),
+      bot,
+    });
+
+    const registeredCommands = await waitForRegisteredCommands(setMyCommands);
+    expect(registeredCommands.filter((command) => command.command === "pair")).toEqual([
+      { command: "pair", description: "Configured pair menu" },
+    ]);
+
+    await requireCommandHandler(
+      commandHandlers,
+      "pair",
+    )(createPrivateCommandContext({ match: "now" }));
+
+    expectLastDeliveredReplyText("paired:now");
+    expect(sendMessage).not.toHaveBeenCalledWith(123, "Command not found.");
+  });
+
   it("uses plugin command metadata to send and edit a Telegram progress placeholder", async () => {
     const { bot, commandHandlers, setMyCommands, sendMessage } = createCommandBot();
 

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -1,5 +1,6 @@
 // Telegram tests cover bot native commands plugin behavior.
 import type { OpenClawConfig, TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
+import { listNativeCommandSpecsForConfig } from "openclaw/plugin-sdk/native-command-registry";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -14,7 +15,7 @@ import {
   waitForRegisteredCommands,
 } from "./bot-native-commands.menu-test-support.js";
 import { resetTelegramForumFlagCacheForTest } from "./bot/helpers.js";
-import { TELEGRAM_COMMAND_NAME_PATTERN } from "./command-config.js";
+import { normalizeTelegramCommandName, TELEGRAM_COMMAND_NAME_PATTERN } from "./command-config.js";
 import { pluginCommandMocks, resetPluginCommandMocks } from "./test-support/plugin-command.js";
 
 let registerTelegramNativeCommands: typeof import("./bot-native-commands.js").registerTelegramNativeCommands;
@@ -198,66 +199,101 @@ describe("registerTelegramNativeCommands", () => {
     });
   });
 
-  it("prioritizes /skill and configured commands after per-skill pressure omission", async () => {
-    const { bot, commandHandlers, setMyCommands } = createCommandBot();
-    const runtimeLog = vi.fn();
-    listSkillCommandsForAgents.mockReturnValue([
+  it("builds one canonical no-pressure display order without changing descriptions", async () => {
+    const { bot, setMyCommands } = createCommandBot();
+    const skillCommands = [
       {
-        name: "export_session",
-        skillName: "export-session-collision",
-        description: "Colliding export skill",
+        name: "demo_skill",
+        skillName: "demo-skill",
+        description: "Demo skill unchanged",
       },
-      ...Array.from({ length: 120 }, (_, index) => ({
-        name: `demo_skill_${index}`,
-        skillName: `demo-skill-${index}`,
-        description: `Demo skill ${index}`,
-      })),
-    ]);
+    ];
+    const cfg: OpenClawConfig = {
+      commands: { native: true, nativeSkills: true },
+      agents: { list: [{ id: "main", default: true }] },
+    };
+    listSkillCommandsForAgents.mockReturnValue(skillCommands);
     pluginCommandMocks.getPluginCommandSpecs.mockReturnValue([
-      {
-        name: "demo_skill_0",
-        description: "Conflicting plugin command",
-      },
+      { name: "zeta", description: "Zeta unchanged" },
+      { name: "alpha", description: "Alpha unchanged" },
     ] as never);
 
     registerTelegramNativeCommands(
-      createNativeCommandTestParams(
-        {
-          commands: { native: true, nativeSkills: true },
-          agents: { list: [{ id: "main", default: true }] },
+      createNativeCommandTestParams(cfg, {
+        bot,
+        telegramCfg: {
+          customCommands: [
+            { command: "custom_two", description: "Custom two unchanged" },
+            { command: "custom_one", description: "Custom one unchanged" },
+          ],
         },
-        {
-          bot,
-          runtime: { log: runtimeLog } as unknown as RuntimeEnv,
-          telegramCfg: {
-            customCommands: [
-              { command: "custom_one", description: "Custom one" },
-              { command: "custom_two", description: "Custom two" },
-            ],
-          },
+      }),
+    );
+
+    const registered = (await waitForRegisteredCommands(setMyCommands)).map(
+      ({ command, description }) => ({ command, description }),
+    );
+    const native = listNativeCommandSpecsForConfig(cfg, {
+      skillCommands,
+      provider: "telegram",
+    }).map((command) => ({
+      command: normalizeTelegramCommandName(command.name),
+      description: command.description,
+      isAlias: command.isAlias,
+    }));
+    expect(registered).toEqual([
+      { command: "custom_two", description: "Custom two unchanged" },
+      { command: "custom_one", description: "Custom one unchanged" },
+      ...native.filter((command) => !command.isAlias).map(({ isAlias: _, ...command }) => command),
+      { command: "alpha", description: "Alpha unchanged" },
+      { command: "zeta", description: "Zeta unchanged" },
+      ...native.filter((command) => command.isAlias).map(({ isAlias: _, ...command }) => command),
+    ]);
+  });
+
+  it("promotes /skill when direct skills are omitted by local menu pressure", async () => {
+    const { bot, commandHandlers, setMyCommands } = createCommandBot();
+    const runtimeLog = vi.fn();
+    const cfg: OpenClawConfig = {
+      commands: { native: true, nativeSkills: true },
+      agents: { list: [{ id: "main", default: true }] },
+    };
+    const directSkills = Array.from({ length: 3 }, (_, index) => ({
+      name: `demo_skill_${index}`,
+      skillName: `demo-skill-${index}`,
+      description: `Demo skill ${index}`,
+    }));
+    const customCommands = Array.from({ length: 100 }, (_, index) => ({
+      command: `custom_${index}`,
+      description: `Custom ${index}`,
+    }));
+    listSkillCommandsForAgents.mockReturnValue(directSkills);
+
+    registerTelegramNativeCommands(
+      createNativeCommandTestParams(cfg, {
+        bot,
+        runtime: { log: runtimeLog } as unknown as RuntimeEnv,
+        telegramCfg: {
+          customCommands,
         },
-      ),
+      }),
     );
 
     const registeredCommands = await waitForRegisteredCommands(setMyCommands);
-    expect(registeredCommands.length).toBeLessThanOrEqual(100);
-    expect(registeredCommands.slice(0, 3).map(({ command }) => command)).toEqual([
+    const registeredNames = registeredCommands.map(({ command }) => command);
+    expect(registeredNames).toEqual([
       "skill",
-      "custom_one",
-      "custom_two",
+      ...customCommands.slice(0, 99).map((command) => command.command),
     ]);
     expect(registeredCommands.some((entry) => entry.command.startsWith("demo_skill_"))).toBe(false);
-    expect(registeredCommands.filter((entry) => entry.command === "export_session")).toHaveLength(
-      1,
-    );
-    expect(
-      Array.from({ length: 120 }, (_, index) => commandHandlers.has(`demo_skill_${index}`)).every(
-        Boolean,
-      ),
-    ).toBe(true);
-    expect(commandHandlers.has("export_session")).toBe(true);
+    expect(directSkills.every((command) => commandHandlers.has(command.name))).toBe(true);
     expect(runtimeLog).toHaveBeenCalledWith(
       "Telegram menu pressure omitted per-skill commands; removing per-skill commands and keeping /skill.",
+    );
+    const expectedTotalCommands =
+      customCommands.length + listNativeCommandSpecsForConfig(cfg, { provider: "telegram" }).length;
+    expect(runtimeLog).toHaveBeenCalledWith(
+      `Telegram limits bots to 100 commands. ${expectedTotalCommands} configured; registering first 100. Use channels.telegram.commands.native: false to disable, or reduce plugin/skill/custom commands.`,
     );
   });
 

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -53,10 +53,7 @@ import {
   type SessionEntry,
   updateSessionStoreEntry,
 } from "openclaw/plugin-sdk/session-store-runtime";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { escapeHtml } from "openclaw/plugin-sdk/text-utility-runtime";
 import { expandTelegramAllowFromWithAccessGroups } from "./access-groups.js";
 import { resolveTelegramAccount } from "./accounts.js";
@@ -76,7 +73,6 @@ import {
 import {
   buildCappedTelegramMenuCommands,
   buildPluginTelegramMenuCommands,
-  orderForPressure,
   syncTelegramMenuCommands as syncTelegramMenuCommandsRuntime,
   type TelegramMenuCommand,
 } from "./bot-native-command-menu.js";
@@ -945,114 +941,78 @@ export const registerTelegramNativeCommands = ({
     (
       telegramDeps.getPluginCommandSpecs ?? defaultTelegramNativeCommandDeps.getPluginCommandSpecs
     )?.("telegram", { config: cfg }) ?? [];
-  const resolveTelegramMenuCommandCatalog = (
-    activeSkillCommands: typeof skillCommands,
-    reservedSkillCommands = activeSkillCommands,
-  ) => {
-    const nativeCommands = nativeEnabled
-      ? listNativeCommandSpecsForConfig(cfg, {
-          skillCommands: activeSkillCommands,
-          provider: "telegram",
-        })
-      : [];
-    const reservedCommands = new Set(
-      listNativeCommandSpecs().map((command) => normalizeTelegramCommandName(command.name)),
-    );
-    for (const command of reservedSkillCommands) {
-      reservedCommands.add(normalizeLowercaseStringOrEmpty(command.name));
-    }
-    const customResolution = resolveTelegramCustomCommands({
-      commands: telegramCfg.customCommands,
-      reservedCommands,
-    });
-    for (const issue of customResolution.issues) {
-      runtime.error?.(danger(issue.message));
-    }
-    const customCommands = customResolution.commands;
-    const existingCommands = new Set(
-      [
-        ...nativeCommands.map((command) => normalizeTelegramCommandName(command.name)),
-        ...customCommands.map((command) => command.command),
-      ].map((command) => normalizeLowercaseStringOrEmpty(command)),
-    );
-    for (const command of reservedSkillCommands) {
-      existingCommands.add(normalizeTelegramCommandName(command.name));
-    }
-    const pluginCatalog = buildPluginTelegramMenuCommands({
-      specs: pluginCommandSpecs,
-      existingCommands,
-    });
-    for (const issue of pluginCatalog.issues) {
-      runtime.error?.(danger(issue));
-    }
-    const firstSkillCommandIndex = nativeEnabled
-      ? listNativeCommandSpecsForConfig(cfg, { provider: "telegram" }).length
-      : 0;
-    const allCommandsFull: TelegramMenuCommand[] = [
-      ...nativeCommands
-        .map((command, index): TelegramMenuCommand | null => {
-          const normalized = normalizeTelegramCommandName(command.name);
-          if (!TELEGRAM_COMMAND_NAME_PATTERN.test(normalized)) {
-            runtime.error?.(
-              danger(
-                `Native command "${command.name}" is invalid for Telegram (resolved to "${normalized}"). Skipping.`,
-              ),
-            );
-            return null;
-          }
-          const menuCommand: TelegramMenuCommand = {
-            command: normalized,
-            description: command.description,
-          };
-          if (command.isAlias) {
-            menuCommand.isAlias = true;
-          }
-          if (index >= firstSkillCommandIndex) {
-            menuCommand.isSkill = true;
-          }
-          if (command.descriptionLocalizations) {
-            menuCommand.descriptionLocalizations = command.descriptionLocalizations;
-          }
-          return menuCommand;
-        })
-        .filter((cmd) => cmd !== null),
-      ...(nativeEnabled ? pluginCatalog.commands : []),
-      ...customCommands.map((command) => ({ ...command, isConfigured: true })),
-    ];
-    return {
-      nativeCommands,
-      customCommands,
-      pluginCatalog,
-      allCommandsFull,
-      ...buildCappedTelegramMenuCommands({
-        allCommands: allCommandsFull,
-      }),
-    };
-  };
-  const fullCommandCatalog = resolveTelegramMenuCommandCatalog(skillCommands);
-  let menuCommandCatalog: ReturnType<typeof buildCappedTelegramMenuCommands> = fullCommandCatalog;
-  const omittedSkillCommand =
-    fullCommandCatalog.commandsToRegister.filter((command) => command.isSkill).length <
-    fullCommandCatalog.allCommandsFull.filter((command) => command.isSkill).length;
-  if (omittedSkillCommand) {
-    const skillFallback = fullCommandCatalog.allCommandsFull.find(
-      (command) => command.command === "skill" && !command.isSkill,
-    );
-    const fallbackCommands = fullCommandCatalog.allCommandsFull.filter(
-      (command) => command !== skillFallback && !command.isSkill,
-    );
-    menuCommandCatalog = buildCappedTelegramMenuCommands({
-      allCommands: orderForPressure(
-        skillFallback
-          ? [{ ...skillFallback, isConfigured: true }, ...fallbackCommands]
-          : fallbackCommands,
-      ),
-    });
+  const nativeCommands = nativeEnabled
+    ? listNativeCommandSpecsForConfig(cfg, { skillCommands, provider: "telegram" })
+    : [];
+  const reservedCommands = new Set(
+    listNativeCommandSpecs({ provider: "telegram" }).map((command) =>
+      normalizeTelegramCommandName(command.name),
+    ),
+  );
+  for (const command of skillCommands) {
+    reservedCommands.add(normalizeTelegramCommandName(command.name));
+  }
+  const customResolution = resolveTelegramCustomCommands({
+    commands: telegramCfg.customCommands,
+    reservedCommands,
+  });
+  for (const issue of customResolution.issues) {
+    runtime.error?.(danger(issue.message));
+  }
+  const customCommands = customResolution.commands;
+  const pluginCatalog = buildPluginTelegramMenuCommands({
+    specs: pluginCommandSpecs,
+    existingCommands: new Set(reservedCommands),
+  });
+  for (const issue of pluginCatalog.issues) {
+    runtime.error?.(danger(issue));
+  }
+  const firstSkillCommandIndex = nativeEnabled
+    ? listNativeCommandSpecsForConfig(cfg, { provider: "telegram" }).length
+    : 0;
+  const nativeMenuCommands = nativeCommands
+    .map((command, index): TelegramMenuCommand | null => {
+      const normalized = normalizeTelegramCommandName(command.name);
+      if (!TELEGRAM_COMMAND_NAME_PATTERN.test(normalized)) {
+        runtime.error?.(
+          danger(
+            `Native command "${command.name}" is invalid for Telegram (resolved to "${normalized}"). Skipping.`,
+          ),
+        );
+        return null;
+      }
+      const menuCommand: TelegramMenuCommand = {
+        command: normalized,
+        description: command.description,
+      };
+      if (command.isAlias) {
+        menuCommand.isAlias = true;
+      }
+      if (index >= firstSkillCommandIndex) {
+        menuCommand.isSkill = true;
+      }
+      if (command.descriptionLocalizations) {
+        menuCommand.descriptionLocalizations = command.descriptionLocalizations;
+      }
+      return menuCommand;
+    })
+    .filter((cmd) => cmd !== null);
+  const customCommandNames = new Set(customCommands.map((command) => command.command));
+  const fullCommandCatalog = buildCappedTelegramMenuCommands({
+    allCommands: [
+      ...customCommands,
+      ...nativeMenuCommands.filter((command) => !command.isAlias),
+      ...(nativeEnabled
+        ? pluginCatalog.commands.filter((command) => !customCommandNames.has(command.command))
+        : []),
+      ...nativeMenuCommands.filter((command) => command.isAlias),
+    ],
+  });
+  if (fullCommandCatalog.skillCommandsOmitted) {
     runtime.log?.(
       "Telegram menu pressure omitted per-skill commands; removing per-skill commands and keeping /skill.",
     );
   }
-  const { nativeCommands, pluginCatalog } = fullCommandCatalog;
   const loginCommand = listNativeCommandSpecsForConfig(cfg, { provider: "telegram" }).find(
     (command) => findCommandByNativeName(command.name, "telegram")?.key === "login",
   );
@@ -1072,7 +1032,7 @@ export const registerTelegramNativeCommands = ({
     maxTotalChars,
     descriptionTrimmed,
     textBudgetDropCount,
-  } = menuCommandCatalog;
+  } = fullCommandCatalog;
   if (overflowCount > 0) {
     runtime.log?.(
       `Telegram limits bots to ${maxCommands} commands. ` +

--- a/extensions/telegram/src/bot.command-menu.test.ts
+++ b/extensions/telegram/src/bot.command-menu.test.ts
@@ -130,11 +130,13 @@ describe("createTelegramBot command menu", () => {
     }).map((command) => ({
       command: normalizeTelegramCommandName(command.name),
       description: command.description,
+      isAlias: command.isAlias === true,
     }));
     expect(registered).toStrictEqual([
-      ...native,
       { command: "custom_backup", description: "Git backup" },
       { command: "custom_generate", description: "Create an image" },
+      ...native.filter((command) => !command.isAlias).map(({ isAlias: _, ...command }) => command),
+      ...native.filter((command) => command.isAlias).map(({ isAlias: _, ...command }) => command),
     ]);
   });
 
@@ -184,21 +186,27 @@ describe("createTelegramBot command menu", () => {
     }).map((command) => ({
       command: normalizeTelegramCommandName(command.name),
       description: command.description,
+      isAlias: command.isAlias === true,
     }));
     const nativeStatus = native.find((command) => command.command === "status");
     if (!nativeStatus) {
       throw new Error("expected native Telegram status command");
     }
     expect(registered).toStrictEqual([
-      ...native,
       { command: "custom_backup", description: "Git backup" },
+      ...native.filter((command) => !command.isAlias).map(({ isAlias: _, ...command }) => command),
+      ...native.filter((command) => command.isAlias).map(({ isAlias: _, ...command }) => command),
     ]);
-    expect(registered.find((command) => command.command === "status")).toEqual(nativeStatus);
+    expect(registered.find((command) => command.command === "status")).toEqual({
+      command: nativeStatus.command,
+      description: nativeStatus.description,
+    });
     expect(countMatching(registered, (command) => command.command === "status")).toBe(1);
     expect(errorSpy).toHaveBeenCalled();
   });
 
   it("registers custom commands when native commands are disabled", async () => {
+    const errorSpy = vi.fn();
     const config = {
       commands: { native: false },
       agents: {
@@ -212,6 +220,7 @@ describe("createTelegramBot command menu", () => {
           allowFrom: ["*"],
           customCommands: [
             { command: "custom_backup", description: "Git backup" },
+            { command: "login", description: "Custom login" },
             { command: "custom_generate", description: "Create an image" },
           ],
         },
@@ -220,7 +229,16 @@ describe("createTelegramBot command menu", () => {
     loadConfig.mockReturnValue(config);
     const commandsSynced = waitForNextSetMyCommands();
 
-    createTelegramBot({ token: "tok" });
+    createTelegramBot({
+      token: "tok",
+      runtime: {
+        log: vi.fn(),
+        error: errorSpy,
+        exit: ((code: number) => {
+          throw new Error(`exit ${code}`);
+        }) as (code: number) => never,
+      },
+    });
 
     await commandsSynced;
 
@@ -229,7 +247,12 @@ describe("createTelegramBot command menu", () => {
       { command: "custom_backup", description: "Git backup" },
       { command: "custom_generate", description: "Create an image" },
     ]);
-    const reserved = new Set(listNativeCommandSpecs().map((command) => command.name));
+    const reserved = new Set(
+      listNativeCommandSpecs({ provider: "telegram" }).map((command) => command.name),
+    );
     expect(registered.filter((command) => reserved.has(command.command))).toEqual([]);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Telegram custom command "/login" conflicts with a native command.'),
+    );
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Telegram command menus had more than one ordering policy: ordinary publication preserved source order, while local pressure, localized pressure, and Bot API retry pressure rebuilt priorities differently. That made configured, native, plugin, alias, and direct-skill entries move depending on which limit was encountered. Plugin names that normalize to the same Telegram command could also select a display owner by discovery order, and a menu-only custom entry could suppress a same-name plugin handler.

## Why This Change Was Made

This repair gives Telegram one canonical catalog order:

1. configured custom entries in configuration order;
2. canonical native commands, including active direct skills, in registry order;
3. plugin commands in deterministic Telegram-normalized order;
4. native aliases in registry order.

Normalized plugin collisions settle before display priority, with an exact `foo_bar` identity winning over a transformed `foo-bar` identity. Telegram-specific native reservations such as `/login` remain protected even when native menu publication is disabled, while a custom menu description can coexist with the executable same-name plugin handler.

Local count/text pressure, localized variants, and repeated `BOT_COMMANDS_TOO_MUCH` retries now share one direct-skill fallback policy. If any direct skill would be omitted, all direct-skill entries collapse to the documented leading `/skill` fallback. Every retry is derived from the immutable original catalog so later eligible plugin entries can refill after skill removal, and retry diagnostics report the actual payload size.

The duplicate `orderForPressure` path, second catalog build, temporary `/skill` promotion metadata, and obsolete configured-priority flag are removed. The resulting production delta is exactly net zero: +154/-154.

## User Impact

Telegram menus now remain stable and comprehensible across ordinary registration, localization, local limits, and Telegram-side reductions. Operators keep configured commands first during normal publication, retain a visible `/skill` recovery path when direct skills cannot all fit, and get deterministic plugin collision behavior. Hidden entries remain callable because menu display ownership is kept separate from handler registration.

The locale ledger, serialized menu-sync lifecycle, bot/token ownership, scope cleanup, account shutdown, and migration behavior from the existing Telegram lifecycle repairs are unchanged. Plugin execution identity/rematching is intentionally excluded for its separate owner-boundary repair.

## Evidence

- Final head: `68ef9071ba7830c3d02eb1a5b2f9344d420483e9` on current base `bff0494f33b24aef664990dafda0d38750d798bc`.
- Stable patch ID before and after rebase: `eb70805deb5178bd7b64ce696c050451ffd908df`.
- None of the seven changed Telegram files changed between reviewed base `40dbc7a65a8af246e7098e643a3bf2b15189fe3a` and the current base.
- Local focused menu/sync proof: 44/44 passed.
- Blacksmith Testbox lease `tbx_01kzm2nqvnenka5v9h5vf11mvx`: 82/82 focused Telegram tests passed.
- Real mock-gateway Telegram menu E2E: 1/1 passed, covering 100 custom commands plus `/skill`, repeated reduction, localization, and default/group scope parity.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/31333810339
- Exact formatting, extension lint, production and extension-test typechecks, build, and bundled plugin control-plane loading passed.
- Fresh P2 autoreview and independent exact-diff review found no accepted/actionable issue.
- The broader changed-surface gate stops only on the unchanged current-main `ui/package.json` noVNC dependency range; this branch has no dependency or UI delta.

No changelog edit is included because changelog generation is release-owned.
