### PR TITLE
fix(ui): pin compact task-suggestion split button to the card top-right

### DIFF
--- a/ui/src/pages/chat/components/chat-task-suggestions.ts
+++ b/ui/src/pages/chat/components/chat-task-suggestions.ts
@@ -69,19 +69,6 @@ export function renderChatTaskSuggestions(props: {
                 </div>
               </details>
             </div>
-            ${props.canDismiss
-              ? html`
-                  <button
-                    class="btn btn--ghost btn--icon task-suggestion__dismiss"
-                    type="button"
-                    ?disabled=${busy}
-                    aria-label=${t("chat.taskSuggestions.dismiss", { title })}
-                    @click=${() => props.onDismiss(suggestion)}
-                  >
-                    ${icons.x}
-                  </button>
-                `
-              : nothing}
             <div class="task-suggestion__actions">
               <div class="task-suggestion__split">
                 <button
@@ -165,6 +152,19 @@ export function renderChatTaskSuggestions(props: {
                   : nothing}
               </div>
             </div>
+            ${props.canDismiss
+              ? html`
+                  <button
+                    class="btn btn--ghost btn--icon task-suggestion__dismiss"
+                    type="button"
+                    ?disabled=${busy}
+                    aria-label=${t("chat.taskSuggestions.dismiss", { title })}
+                    @click=${() => props.onDismiss(suggestion)}
+                  >
+                    ${icons.x}
+                  </button>
+                `
+              : nothing}
           </article>
         `;
       })}

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1586,7 +1586,7 @@ openclaw-chat-video-player {
 .task-suggestion {
   position: relative;
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
   align-items: start;
   gap: 12px;
   padding: 12px;
@@ -1667,25 +1667,32 @@ openclaw-chat-video-player {
 }
 
 .task-suggestion__actions {
-  grid-column: 2 / -1;
   display: flex;
   align-items: center;
+  align-self: start;
   justify-self: end;
 }
 
+/* Compact split control pinned to the card's top-right; both halves share one
+   fixed height so the chevron cap can never overhang the primary segment. */
 .task-suggestion__split {
   display: inline-flex;
   align-items: stretch;
+  height: 26px;
 }
 
 .task-suggestion__start {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 5px;
+  height: 26px;
+  padding: 0 10px;
   border-color: var(--accent);
   border-radius: var(--radius-md) 0 0 var(--radius-md);
   background: var(--primary);
   color: var(--primary-foreground);
+  font-size: 12px;
+  line-height: 1;
   white-space: nowrap;
 }
 
@@ -1693,11 +1700,19 @@ openclaw-chat-video-player {
   border-radius: var(--radius-md);
 }
 
+.task-suggestion__start svg {
+  width: 12px;
+  height: 12px;
+}
+
 .task-suggestion__menu-trigger {
-  min-width: 34px;
-  height: 100%;
+  display: grid;
+  width: 26px;
+  min-width: 26px;
+  height: 26px;
   margin-left: -1px;
-  padding: 8px;
+  padding: 0;
+  place-items: center;
   border-color: var(--accent);
   border-radius: 0 var(--radius-md) var(--radius-md) 0;
   background: var(--primary);
@@ -1705,8 +1720,8 @@ openclaw-chat-video-player {
 }
 
 .task-suggestion__menu-trigger svg {
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
 }
 
 .task-suggestion__menu[open] .task-suggestion__menu-trigger svg {


### PR DESCRIPTION
# What Problem This Solves

Operator feedback on the redesigned task-suggestion card (#121173): the split action button was oversized, sat on its own row at the bottom of the card, its chevron cap could overhang the primary segment (visible seam/notch), and the primary could protrude past the card edge.

# Why This Change Was Made

Owner-directed polish to match the reference design: the actions belong in the card's top-right as a small control. The card grid gains a fourth column so the split button sits inline in the top row next to the dismiss button, and both split halves share one fixed 26px height inside a single inline-flex container — the chevron cap can no longer overhang the primary segment (invariant commented at the rule).

# User Impact

The suggestion card is visibly calmer: compact `▷ Start with worktree | ⌄` control pinned top-right beside ✕, smaller typography and icons, no clipped or overflowing button chrome. No behavioral change — same actions, same gating (menu only when the gateway negotiates acceptance modes; disabled "Send to cloud" hint when no worker profiles).

# Evidence

- `ui/src/pages/chat/chat-task-suggestions.test.ts` and `ui/src/e2e/chat-flow.follow-ups.e2e.test.ts` green on the branch (selectors unchanged; DOM order change covered by existing assertions).
- oxlint, oxfmt, and stylelint clean on both touched files.
- Autoreview (codex / gpt-5.6-sol, high): clean, 0.99.
- Live visual proof against a dev gateway on the rebuilt bundle: screenshots below (collapsed card, and menu open with the grayed no-cloud hint).

## Screenshots

![Compact suggested-task card with split action pinned top-right](https://github.com/user-attachments/assets/72178dfe-e1e7-4521-a1f9-3f29e54f2a5a)

![Suggested-task card with the compact split menu open](https://github.com/user-attachments/assets/a64844c2-3c0c-45ff-ba5a-be4c384103bb)
