### PR TITLE
fix(ui): sidebar pin and unpin now respond immediately instead of waiting on the Gateway

### DIFF
--- a/ui/src/e2e/session-management.optimistic-pin.e2e.test.ts
+++ b/ui/src/e2e/session-management.optimistic-pin.e2e.test.ts
@@ -1,0 +1,184 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import {
+  activateMenuItem,
+  captureUiProof,
+  captureUiProofEnabled,
+  createSessionManagementE2eSuite,
+  installMockGateway,
+  sessionRow,
+  sessionsListResponse,
+  trimmedTextContents,
+  uiProofArtifactDir,
+} from "./session-management.test-support.ts";
+
+const suite = createSessionManagementE2eSuite();
+
+const candidateKey = "agent:main:candidate";
+const companionKey = "agent:main:companion";
+const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
+const pinFeatureMethods = ["chat.metadata", "chat.startup", "sessions.patch"];
+
+function unpinnedList() {
+  return sessionsListResponse([
+    sessionRow(candidateKey, "Pin me", baseTime),
+    sessionRow(companionKey, "Stay put", baseTime - 1_000),
+  ]);
+}
+
+function pinnedList() {
+  return sessionsListResponse([
+    sessionRow(candidateKey, "Pin me", baseTime, { pinned: true, pinnedAt: baseTime }),
+    sessionRow(companionKey, "Stay put", baseTime - 1_000),
+  ]);
+}
+
+suite.define(() => {
+  it("pins from the row button while the Gateway patch is still in flight", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+      recordVideo: captureUiProofEnabled
+        ? { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } }
+        : undefined,
+    });
+    const page = await context.newPage();
+    const proofVideo = page.video();
+    const gateway = await installMockGateway(page, {
+      methodResponses: { "sessions.list": unpinnedList(), "sessions.patch": {} },
+      featureMethods: pinFeatureMethods,
+      sessionKey: candidateKey,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const zoneEntry = page.locator(`[data-sidebar-entry="session:${candidateKey}"]`);
+      const threads = page.locator('[data-session-section="ungrouped"]');
+      const row = threads.locator(`.sidebar-recent-session[data-session-key="${candidateKey}"]`);
+      await expect.poll(() => row.count()).toBe(1);
+      await expect.poll(() => zoneEntry.count()).toBe(0);
+      await captureUiProof(page, "optimistic-pin-01-before-click.png");
+
+      await gateway.deferNext("sessions.patch");
+      await row.hover();
+      await row.getByRole("button", { name: "Pin session: Pin me" }).click();
+
+      // The Gateway response is still held, so this can only come from the
+      // optimistic snapshot write in the mutation owner.
+      await expect.poll(() => zoneEntry.count()).toBe(1);
+      await expect.poll(() => row.count()).toBe(0);
+      expect(await gateway.getRequests("sessions.list")).toHaveLength(1);
+      await captureUiProof(page, "optimistic-pin-02-pinned-while-in-flight.png");
+
+      await gateway.setMethodResponse("sessions.list", pinnedList());
+      await gateway.resolveDeferred("sessions.patch", { ok: true, key: candidateKey, path: "" });
+
+      await expect.poll(() => gateway.getRequests("sessions.list")).toHaveLength(2);
+      await expect.poll(() => zoneEntry.count()).toBe(1);
+      await expect.poll(() => row.count()).toBe(0);
+      expect(await page.locator("[data-sidebar-session-error]").count()).toBe(0);
+      await captureUiProof(page, "optimistic-pin-03-confirmed-after-refresh.png");
+    } finally {
+      await context.close();
+      if (proofVideo) {
+        await proofVideo.saveAs(path.join(uiProofArtifactDir, "optimistic-pin-button.webm"));
+      }
+    }
+  });
+
+  it("rolls a menu unpin back and surfaces the error when the Gateway rejects it", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: { "sessions.list": pinnedList(), "sessions.patch": {} },
+      featureMethods: pinFeatureMethods,
+      sessionKey: candidateKey,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const zoneEntry = page.locator(`[data-sidebar-entry="session:${candidateKey}"]`);
+      const threads = page.locator('[data-session-section="ungrouped"]');
+      const row = threads.locator(`.sidebar-recent-session[data-session-key="${candidateKey}"]`);
+      await expect.poll(() => zoneEntry.count()).toBe(1);
+
+      await gateway.deferNext("sessions.patch");
+      const pinnedRow = zoneEntry.locator(".sidebar-recent-session");
+      await pinnedRow.hover();
+      await pinnedRow.getByRole("button", { name: "Open session menu: Pin me" }).click();
+      const menuHost = page.locator("openclaw-session-menu");
+      await activateMenuItem(menuHost.getByRole("menuitem", { name: "Unpin session" }));
+
+      await expect.poll(() => zoneEntry.count()).toBe(0);
+      await expect.poll(() => row.count()).toBe(1);
+      await captureUiProof(page, "optimistic-pin-04-unpinned-while-in-flight.png");
+
+      await gateway.rejectDeferred("sessions.patch", { message: "pin storage unavailable" });
+
+      await expect.poll(() => zoneEntry.count()).toBe(1);
+      await expect.poll(() => row.count()).toBe(0);
+      await expect
+        .poll(() => trimmedTextContents(page.locator("[data-sidebar-session-error]")))
+        .toEqual([expect.stringContaining("pin storage unavailable")]);
+      await captureUiProof(page, "optimistic-pin-05-rolled-back-with-error.png");
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps the newest pin intent when the older completion refreshes the list first", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: { "sessions.list": unpinnedList(), "sessions.patch": {} },
+      featureMethods: pinFeatureMethods,
+      sessionKey: candidateKey,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const zoneEntry = page.locator(`[data-sidebar-entry="session:${candidateKey}"]`);
+      const threads = page.locator('[data-session-section="ungrouped"]');
+      const row = threads.locator(`.sidebar-recent-session[data-session-key="${candidateKey}"]`);
+      await expect.poll(() => row.count()).toBe(1);
+
+      await gateway.deferNext("sessions.patch");
+      await row.hover();
+      await row.getByRole("button", { name: "Pin session: Pin me" }).click();
+      await expect.poll(() => zoneEntry.count()).toBe(1);
+
+      await gateway.deferNext("sessions.patch");
+      const pinnedRow = zoneEntry.locator(".sidebar-recent-session");
+      await pinnedRow.hover();
+      await pinnedRow.getByRole("button", { name: "Unpin session: Pin me" }).click();
+      await expect.poll(() => row.count()).toBe(1);
+      await expect.poll(() => zoneEntry.count()).toBe(0);
+
+      // The pin commits first; its list refresh still carries the pinned row the
+      // unpin already replaced locally.
+      await gateway.setMethodResponse("sessions.list", pinnedList());
+      await gateway.resolveDeferred("sessions.patch", { ok: true, key: candidateKey, path: "" });
+      await expect.poll(() => gateway.getRequests("sessions.list")).toHaveLength(2);
+      await expect.poll(() => row.count()).toBe(1);
+      expect(await zoneEntry.count()).toBe(0);
+
+      await gateway.setMethodResponse("sessions.list", unpinnedList());
+      await gateway.resolveDeferred("sessions.patch", { ok: true, key: candidateKey, path: "" });
+      await expect.poll(() => gateway.getRequests("sessions.list")).toHaveLength(3);
+      await expect.poll(() => row.count()).toBe(1);
+      expect(await zoneEntry.count()).toBe(0);
+      await captureUiProof(page, "optimistic-pin-06-newest-intent-wins.png");
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -4,82 +4,15 @@ import {
   GatewayRequestError,
   type GatewayBrowserClient,
   type GatewayEventFrame,
-  type GatewayHelloOk,
 } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createSessionCapability, reconcileSessionRunTerminal } from "./index.ts";
-
-function sessionsResult(sessions: SessionsListResult["sessions"], ts: number): SessionsListResult {
-  return {
-    ts,
-    path: "(multiple)",
-    count: sessions.length,
-    defaults: { modelProvider: null, model: null, contextTokens: null },
-    sessions,
-  };
-}
-
-function deferred<T>() {
-  let resolve: (value: T) => void = () => undefined;
-  let reject: (error: unknown) => void = () => undefined;
-  const promise = new Promise<T>((next, fail) => {
-    resolve = next;
-    reject = fail;
-  });
-  return { promise, reject, resolve };
-}
-
-function createGatewayHarness(client: GatewayBrowserClient, featureMethods?: string[]) {
-  let snapshot: {
-    client: GatewayBrowserClient | null;
-    phase: "connected" | "reconnecting";
-    sessionKey: string;
-    assistantAgentId: string | null;
-    hello: GatewayHelloOk | null;
-  } = {
-    client,
-    phase: "connected" as const,
-    sessionKey: "agent:main:main",
-    assistantAgentId: "main",
-    hello:
-      featureMethods === undefined
-        ? null
-        : ({ features: { methods: featureMethods } } as GatewayHelloOk),
-  };
-  const listeners = new Set<(next: typeof snapshot) => void>();
-  const eventListeners = new Set<(event: GatewayEventFrame) => void>();
-  return {
-    gateway: {
-      get snapshot() {
-        return snapshot;
-      },
-      subscribe(listener: (next: typeof snapshot) => void) {
-        listeners.add(listener);
-        return () => listeners.delete(listener);
-      },
-      subscribeEvents(listener: (event: GatewayEventFrame) => void) {
-        eventListeners.add(listener);
-        return () => eventListeners.delete(listener);
-      },
-    },
-    emitEvent: (event: GatewayEventFrame) => {
-      for (const listener of eventListeners) {
-        listener(event);
-      }
-    },
-    publish: (connected: boolean, nextClient: GatewayBrowserClient | null = snapshot.client) => {
-      snapshot = {
-        ...snapshot,
-        client: nextClient,
-        phase: connected ? "connected" : "reconnecting",
-      };
-      for (const listener of listeners) {
-        listener(snapshot);
-      }
-    },
-  };
-}
+import {
+  createGatewayHarness,
+  deferred,
+  sessionsResult,
+} from "./session-capability.test-support.ts";
 
 function sessionChangedEvent(key: string): GatewayEventFrame {
   return {

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -178,6 +178,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     readState: () => state,
     publish,
     refreshReplacement: (agentId) => roster.refreshReplacement(agentId),
+    redecorateLists: () => roster.redecorateLists(),
     notifyCreated(key) {
       for (const listener of createdListeners) {
         listener(key);

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -123,13 +123,19 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     pullRequestSummaries.delete(normalizedKey);
   };
 
+  // Canonical Gateway rows are the source of truth for everything except the
+  // UI-owned facts the capability keeps beside them, so every published result
+  // passes through the same overlay: swarm notes, then in-flight pin intents.
+  const decorateRows = (result: SessionsListResult | null): SessionsListResult | null =>
+    mutations.applyPendingPins(swarmActivity.decorate(result));
+
   const roster = createSessionRosterRefresh({
     connection,
     snapshot: () => gateway.snapshot,
     readState: () => state,
     publish,
     observerError: () => sessionEventSubscriptionError,
-    decorate: (result) => swarmActivity.decorate(result),
+    decorate: decorateRows,
     onCanonicalList(result) {
       mutations.settlePrepared(result);
       canonicalListRevision += 1;
@@ -225,9 +231,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     defaults?: SessionsListResult["defaults"],
     options?: SessionReconcileOptions,
   ): boolean => {
-    const result = swarmActivity.decorate(
-      reconcileSessionHistory(state.result, row, defaults, options),
-    );
+    const result = decorateRows(reconcileSessionHistory(state.result, row, defaults, options));
     if (result === state.result) {
       return false;
     }
@@ -255,7 +259,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     options?: SessionReconcileOptions,
   ): SessionChangedResult => {
     const base = reconcileSessionChanged(state.result, payload, options);
-    const result = swarmActivity.decorate(base.result);
+    const result = decorateRows(base.result);
     const reconciled =
       result === base.result
         ? base
@@ -355,7 +359,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       return;
     }
     swarmActivity.observe(event.payload);
-    const decoratedResult = swarmActivity.decorate(state.result);
+    const decoratedResult = decorateRows(state.result);
     if (decoratedResult !== state.result) {
       publish({ ...state, result: decoratedResult });
     }

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -178,6 +178,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     readState: () => state,
     publish,
     refreshReplacement: (agentId) => roster.refreshReplacement(agentId),
+    publishedRow: (key) => roster.publishedRow(key),
     redecorateLists: () => roster.redecorateLists(),
     notifyCreated(key) {
       for (const listener of createdListeners) {

--- a/ui/src/lib/sessions/session-capability.test-support.ts
+++ b/ui/src/lib/sessions/session-capability.test-support.ts
@@ -1,0 +1,76 @@
+import type { GatewayBrowserClient, GatewayEventFrame, GatewayHelloOk } from "../../api/gateway.ts";
+import type { SessionsListResult } from "../../api/types.ts";
+
+export function sessionsResult(
+  sessions: SessionsListResult["sessions"],
+  ts: number,
+): SessionsListResult {
+  return {
+    ts,
+    path: "(multiple)",
+    count: sessions.length,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions,
+  };
+}
+
+export function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (error: unknown) => void = () => undefined;
+  const promise = new Promise<T>((next, fail) => {
+    resolve = next;
+    reject = fail;
+  });
+  return { promise, reject, resolve };
+}
+
+export function createGatewayHarness(client: GatewayBrowserClient, featureMethods?: string[]) {
+  let snapshot: {
+    client: GatewayBrowserClient | null;
+    phase: "connected" | "reconnecting";
+    sessionKey: string;
+    assistantAgentId: string | null;
+    hello: GatewayHelloOk | null;
+  } = {
+    client,
+    phase: "connected" as const,
+    sessionKey: "agent:main:main",
+    assistantAgentId: "main",
+    hello:
+      featureMethods === undefined
+        ? null
+        : ({ features: { methods: featureMethods } } as GatewayHelloOk),
+  };
+  const listeners = new Set<(next: typeof snapshot) => void>();
+  const eventListeners = new Set<(event: GatewayEventFrame) => void>();
+  return {
+    gateway: {
+      get snapshot() {
+        return snapshot;
+      },
+      subscribe(listener: (next: typeof snapshot) => void) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+      subscribeEvents(listener: (event: GatewayEventFrame) => void) {
+        eventListeners.add(listener);
+        return () => eventListeners.delete(listener);
+      },
+    },
+    emitEvent: (event: GatewayEventFrame) => {
+      for (const listener of eventListeners) {
+        listener(event);
+      }
+    },
+    publish: (connected: boolean, nextClient: GatewayBrowserClient | null = snapshot.client) => {
+      snapshot = {
+        ...snapshot,
+        client: nextClient,
+        phase: connected ? "connected" : "reconnecting",
+      };
+      for (const listener of listeners) {
+        listener(snapshot);
+      }
+    },
+  };
+}

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -27,6 +27,9 @@ import {
   requestSessionReset,
 } from "./session-requests.ts";
 
+/** The Gateway's single pin fact: `pinned` is a projection of `pinnedAt`. */
+type SessionPinFields = { pinned: boolean; pinnedAt: number | undefined };
+
 type SessionMutationsHost = {
   connection: SessionConnectionOwner;
   readState: () => SessionState;
@@ -41,7 +44,10 @@ export function createSessionMutations(host: SessionMutationsHost) {
     string,
     { token: symbol; previous: string | null | undefined; revision: number }
   >();
-  const pendingPinPatches = new Map<string, { token: symbol; previous: boolean; next: boolean }>();
+  const pendingPinPatches = new Map<
+    string,
+    { token: symbol; previous: SessionPinFields; next: SessionPinFields }
+  >();
   const preparedWorkSessionKeys = new Set<string>();
 
   const setModelOverride = (key: string, value: string | null | undefined) => {
@@ -93,8 +99,16 @@ export function createSessionMutations(host: SessionMutationsHost) {
     }
   };
 
-  const rowPinned = (key: string) =>
-    host.readState().result?.sessions.find((row) => row.key === key)?.pinned === true;
+  const sessionRow = (key: string) =>
+    host.readState().result?.sessions.find((row) => row.key === key);
+
+  // The Gateway derives `pinned` from `pinnedAt` and both row comparators order
+  // by `pinnedAt` inside each pin group, so an optimistic write has to move the
+  // pair or the row lands in a slot the Gateway would never produce.
+  const pinRowFields = (pinned: boolean, pinnedAt: number | undefined): SessionPinFields =>
+    pinned
+      ? { pinned: true, pinnedAt: pinnedAt ?? Date.now() }
+      : { pinned: false, pinnedAt: undefined };
 
   const retireModelOverride = (key: string) => {
     const normalizedKey = key.trim();
@@ -206,15 +220,17 @@ export function createSessionMutations(host: SessionMutationsHost) {
         return;
       }
       const pendingPinPatch = pendingPinPatches.get(normalizedKey);
+      const row = sessionRow(normalizedKey);
       pinPatchStarted = true;
+      const next = pinRowFields(nextPinned, row?.pinnedAt);
       // `previous` chains through an in-flight pin so a rollback lands on the
       // last Gateway-confirmed value instead of an older operation's guess.
       pendingPinPatches.set(normalizedKey, {
         token: pinPatchToken,
-        previous: pendingPinPatch ? pendingPinPatch.previous : rowPinned(normalizedKey),
-        next: nextPinned,
+        previous: pendingPinPatch?.previous ?? pinRowFields(row?.pinned === true, row?.pinnedAt),
+        next,
       });
-      patchRowLocal(normalizedKey, { pinned: nextPinned });
+      patchRowLocal(normalizedKey, next);
     };
     const startOptimisticPatch = () => {
       startModelPatch();
@@ -242,20 +258,17 @@ export function createSessionMutations(host: SessionMutationsHost) {
         return;
       }
       if (pendingPinPatch.token !== pinPatchToken) {
-        // A newer pin intent owns this row. A completed patch republishes
-        // Gateway truth that predates that intent, so restore the newer value
-        // and hand it this confirmed baseline for its own rollback.
+        // A newer pin intent owns this row; republishing it is the canonical
+        // overlay's job. Hand that intent the baseline this patch just
+        // confirmed so its own rollback lands on Gateway truth.
         if (completed) {
-          pendingPinPatch.previous = nextPinned;
-          if (host.connection.isCurrent(scope)) {
-            patchRowLocal(normalizedKey, { pinned: pendingPinPatch.next });
-          }
+          pendingPinPatch.previous = pinRowFields(nextPinned, undefined);
         }
         return;
       }
       pendingPinPatches.delete(normalizedKey);
       if (!completed && host.connection.isCurrent(scope)) {
-        patchRowLocal(normalizedKey, { pinned: pendingPinPatch.previous });
+        patchRowLocal(normalizedKey, pendingPinPatch.previous);
       }
     };
     const settleOptimisticPatch = (completed: boolean) => {
@@ -403,6 +416,27 @@ export function createSessionMutations(host: SessionMutationsHost) {
     deleteMany: removeMany,
     patch,
     patchRowLocal,
+    /**
+     * Re-asserts in-flight pin intents over canonical Gateway rows: every
+     * `sessions.changed` payload and list refresh carries the server's pin
+     * state, which is the pre-click value until this operation's patch lands.
+     */
+    applyPendingPins(result: SessionsListResult | null): SessionsListResult | null {
+      if (!result || pendingPinPatches.size === 0) {
+        return result;
+      }
+      let changed = false;
+      const sessions = result.sessions.map((row) => {
+        const pendingPinPatch = pendingPinPatches.get(row.key);
+        // Once the Gateway agrees, its own `pinnedAt` is authoritative again.
+        if (!pendingPinPatch || (row.pinned === true) === pendingPinPatch.next.pinned) {
+          return row;
+        }
+        changed = true;
+        return { ...row, ...pendingPinPatch.next };
+      });
+      return changed ? { ...result, sessions } : result;
+    },
     reset,
     retireModelOverride,
     setModelOverride,

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -41,6 +41,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
     string,
     { token: symbol; previous: string | null | undefined; revision: number }
   >();
+  const pendingPinPatches = new Map<string, { token: symbol; previous: boolean; next: boolean }>();
   const preparedWorkSessionKeys = new Set<string>();
 
   const setModelOverride = (key: string, value: string | null | undefined) => {
@@ -91,6 +92,9 @@ export function createSessionMutations(host: SessionMutationsHost) {
       host.publish({ ...state, result: { ...state.result, sessions } });
     }
   };
+
+  const rowPinned = (key: string) =>
+    host.readState().result?.sessions.find((row) => row.key === key)?.pinned === true;
 
   const retireModelOverride = (key: string) => {
     const normalizedKey = key.trim();
@@ -191,8 +195,33 @@ export function createSessionMutations(host: SessionMutationsHost) {
       setModelOverride(key, patchParams.model);
       modelPatchRevision = pendingModelPatches.get(normalizedKey)?.revision ?? 0;
     };
-    if (!options.waitFor) {
+    const nextPinned = patchParams.pinned === true;
+    const pinPatchToken = Symbol();
+    let pinPatchStarted = false;
+    // Sidebar rows read `pinned` straight off the snapshot, so a pin/unpin has
+    // no visible outcome until this flip; the Gateway patch and its list
+    // refresh confirm it afterwards.
+    const startPinPatch = () => {
+      if (patchParams.pinned === undefined || pinPatchStarted) {
+        return;
+      }
+      const pendingPinPatch = pendingPinPatches.get(normalizedKey);
+      pinPatchStarted = true;
+      // `previous` chains through an in-flight pin so a rollback lands on the
+      // last Gateway-confirmed value instead of an older operation's guess.
+      pendingPinPatches.set(normalizedKey, {
+        token: pinPatchToken,
+        previous: pendingPinPatch ? pendingPinPatch.previous : rowPinned(normalizedKey),
+        next: nextPinned,
+      });
+      patchRowLocal(normalizedKey, { pinned: nextPinned });
+    };
+    const startOptimisticPatch = () => {
       startModelPatch();
+      startPinPatch();
+    };
+    if (!options.waitFor) {
+      startOptimisticPatch();
     }
     const settleModelOverride = (completed: boolean) => {
       const pendingModelPatch = pendingModelPatches.get(normalizedKey);
@@ -207,31 +236,57 @@ export function createSessionMutations(host: SessionMutationsHost) {
         }
       }
     };
+    const settlePinPatch = (completed: boolean) => {
+      const pendingPinPatch = pendingPinPatches.get(normalizedKey);
+      if (!pinPatchStarted || !pendingPinPatch) {
+        return;
+      }
+      if (pendingPinPatch.token !== pinPatchToken) {
+        // A newer pin intent owns this row. A completed patch republishes
+        // Gateway truth that predates that intent, so restore the newer value
+        // and hand it this confirmed baseline for its own rollback.
+        if (completed) {
+          pendingPinPatch.previous = nextPinned;
+          if (host.connection.isCurrent(scope)) {
+            patchRowLocal(normalizedKey, { pinned: pendingPinPatch.next });
+          }
+        }
+        return;
+      }
+      pendingPinPatches.delete(normalizedKey);
+      if (!completed && host.connection.isCurrent(scope)) {
+        patchRowLocal(normalizedKey, { pinned: pendingPinPatch.previous });
+      }
+    };
+    const settleOptimisticPatch = (completed: boolean) => {
+      settleModelOverride(completed);
+      settlePinPatch(completed);
+    };
     try {
       if (options.waitFor) {
         await options.waitFor;
         if (!host.connection.isCurrent(scope)) {
-          settleModelOverride(false);
+          settleOptimisticPatch(false);
           return null;
         }
       }
-      startModelPatch();
+      startOptimisticPatch();
       const result = await requestSessionPatch(scope.client, key, patchParams, options);
       if (!host.connection.isCurrent(scope)) {
-        settleModelOverride(false);
+        settleOptimisticPatch(false);
         return null;
       }
       if (!options.deferListRefresh) {
         await host.refreshReplacement(options.agentId);
         if (!host.connection.isCurrent(scope)) {
-          settleModelOverride(false);
+          settleOptimisticPatch(false);
           return null;
         }
       }
-      settleModelOverride(true);
+      settleOptimisticPatch(true);
       return result;
     } catch (error) {
-      settleModelOverride(false);
+      settleOptimisticPatch(false);
       if (!host.connection.isCurrent(scope)) {
         return null;
       }
@@ -361,6 +416,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
     },
     retireConnection() {
       pendingModelPatches.clear();
+      pendingPinPatches.clear();
       preparedWorkSessionKeys.clear();
       const state = host.readState();
       if (Object.keys(state.modelOverrides).length > 0) {
@@ -369,6 +425,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
     },
     dispose() {
       pendingModelPatches.clear();
+      pendingPinPatches.clear();
       preparedWorkSessionKeys.clear();
     },
   };

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -465,6 +465,9 @@ export function createSessionMutations(host: SessionMutationsHost) {
     },
     retireConnection() {
       pendingModelPatches.clear();
+      // Pin intents live inside `result`, which the replacement connection
+      // rehydrates wholesale; only the model-override side map outlives that
+      // replacement, so it is the one that needs an explicit rollback below.
       pendingPinPatches.clear();
       preparedWorkSessionKeys.clear();
       const state = host.readState();

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -35,6 +35,7 @@ type SessionMutationsHost = {
   readState: () => SessionState;
   publish: (state: SessionState, errorSource?: "session-observer" | "operation") => void;
   refreshReplacement: (agentId?: string | null) => Promise<void>;
+  publishedRow: (key: string) => GatewaySessionRow | undefined;
   redecorateLists: () => void;
   notifyCreated: (key: string) => void;
   retirePullRequestSummary: (key: string) => void;
@@ -99,9 +100,6 @@ export function createSessionMutations(host: SessionMutationsHost) {
       host.publish({ ...state, result: { ...state.result, sessions } });
     }
   };
-
-  const sessionRow = (key: string) =>
-    host.readState().result?.sessions.find((row) => row.key === key);
 
   // The Gateway derives `pinned` from `pinnedAt` and both row comparators order
   // by `pinnedAt` inside each pin group, so an optimistic write has to move the
@@ -221,7 +219,10 @@ export function createSessionMutations(host: SessionMutationsHost) {
         return;
       }
       const pendingPinPatch = pendingPinPatches.get(normalizedKey);
-      const row = sessionRow(normalizedKey);
+      // The baseline comes from wherever the row is published: a sidebar on
+      // `archived`/`all` renders its own snapshot, and inferring `previous`
+      // from the primary state alone would roll such a row back to a guess.
+      const row = host.publishedRow(normalizedKey);
       pinPatchStarted = true;
       const next = pinRowFields(nextPinned, row?.pinnedAt);
       // `previous` chains through an in-flight pin so a rollback lands on the

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -254,6 +254,17 @@ export function createSessionMutations(host: SessionMutationsHost) {
         }
       }
     };
+    // The Gateway has committed by the time this runs, so a newer intent's
+    // rollback baseline moves here rather than after the list refresh, which
+    // can fail and would leave that intent rolling back to a pre-patch value.
+    // The Gateway stamps `pinnedAt` with its own clock, so the baseline is a
+    // round trip off — accurate enough to order a row it just pinned.
+    const confirmPinPatch = () => {
+      const pendingPinPatch = pendingPinPatches.get(normalizedKey);
+      if (pinPatchStarted && pendingPinPatch && pendingPinPatch.token !== pinPatchToken) {
+        pendingPinPatch.previous = pinRowFields(nextPinned, undefined);
+      }
+    };
     const settlePinPatch = (completed: boolean) => {
       const pendingPinPatch = pendingPinPatches.get(normalizedKey);
       if (!pinPatchStarted || !pendingPinPatch) {
@@ -261,13 +272,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
       }
       if (pendingPinPatch.token !== pinPatchToken) {
         // A newer pin intent owns this row; republishing it is the canonical
-        // overlay's job. Hand that intent the baseline this patch just
-        // confirmed. The Gateway stamps `pinnedAt` with its own clock, so this
-        // baseline is a round trip off — accurate enough to order a row the
-        // Gateway pinned moments ago, and the next list replaces it outright.
-        if (completed) {
-          pendingPinPatch.previous = pinRowFields(nextPinned, undefined);
-        }
+        // overlay's job and its baseline moved at confirmation time.
         return;
       }
       if (!completed && host.connection.isCurrent(scope)) {
@@ -296,6 +301,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
         settleOptimisticPatch(false);
         return null;
       }
+      confirmPinPatch();
       if (!options.deferListRefresh) {
         await host.refreshReplacement(options.agentId);
         if (!host.connection.isCurrent(scope)) {

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -35,6 +35,7 @@ type SessionMutationsHost = {
   readState: () => SessionState;
   publish: (state: SessionState, errorSource?: "session-observer" | "operation") => void;
   refreshReplacement: (agentId?: string | null) => Promise<void>;
+  redecorateLists: () => void;
   notifyCreated: (key: string) => void;
   retirePullRequestSummary: (key: string) => void;
 };
@@ -230,7 +231,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
         previous: pendingPinPatch?.previous ?? pinRowFields(row?.pinned === true, row?.pinnedAt),
         next,
       });
-      patchRowLocal(normalizedKey, next);
+      host.redecorateLists();
     };
     const startOptimisticPatch = () => {
       startModelPatch();
@@ -260,16 +261,21 @@ export function createSessionMutations(host: SessionMutationsHost) {
       if (pendingPinPatch.token !== pinPatchToken) {
         // A newer pin intent owns this row; republishing it is the canonical
         // overlay's job. Hand that intent the baseline this patch just
-        // confirmed so its own rollback lands on Gateway truth.
+        // confirmed. The Gateway stamps `pinnedAt` with its own clock, so this
+        // baseline is a round trip off — accurate enough to order a row the
+        // Gateway pinned moments ago, and the next list replaces it outright.
         if (completed) {
           pendingPinPatch.previous = pinRowFields(nextPinned, undefined);
         }
         return;
       }
-      pendingPinPatches.delete(normalizedKey);
       if (!completed && host.connection.isCurrent(scope)) {
-        patchRowLocal(normalizedKey, pendingPinPatch.previous);
+        // Roll back through the same overlay that published the intent so the
+        // primary state and every filtered snapshot land on one value.
+        pendingPinPatch.next = pendingPinPatch.previous;
+        host.redecorateLists();
       }
+      pendingPinPatches.delete(normalizedKey);
     };
     const settleOptimisticPatch = (completed: boolean) => {
       settleModelOverride(completed);
@@ -428,7 +434,9 @@ export function createSessionMutations(host: SessionMutationsHost) {
       let changed = false;
       const sessions = result.sessions.map((row) => {
         const pendingPinPatch = pendingPinPatches.get(row.key);
-        // Once the Gateway agrees, its own `pinnedAt` is authoritative again.
+        // Once the Gateway agrees on `pinned`, its own `pinnedAt` wins again.
+        // A row predating a rapid unpin/repin can keep the older stamp for the
+        // patch window; that beats overwriting confirmed stamps with our clock.
         if (!pendingPinPatch || (row.pinned === true) === pendingPinPatch.next.pinned) {
           return row;
         }

--- a/ui/src/lib/sessions/session-pin-mutations.test.ts
+++ b/ui/src/lib/sessions/session-pin-mutations.test.ts
@@ -37,9 +37,8 @@ function pinHarness(options: {
     }
     throw new Error(`Unexpected request: ${method}`);
   });
-  const client = { request } as unknown as GatewayBrowserClient;
-  const harness = createGatewayHarness(client);
-  return { ...harness, client, key, request };
+  const harness = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+  return { ...harness, key };
 }
 
 describe("session pin mutations", () => {

--- a/ui/src/lib/sessions/session-pin-mutations.test.ts
+++ b/ui/src/lib/sessions/session-pin-mutations.test.ts
@@ -9,8 +9,24 @@ import {
   sessionsResult,
 } from "./session-capability.test-support.ts";
 
+const SESSION_EVENT_REFRESH_DEBOUNCE_MS = 200;
+
 function rowPinned(result: SessionsListResult | null, key: string): boolean {
   return result?.sessions.find((row) => row.key === key)?.pinned === true;
+}
+
+// Shape of `buildGatewaySessionEventFields`: every payload carries the server's
+// current pin state, which is the pre-click value while a patch is in flight.
+function sessionChangedPayload(key: string, pinned: boolean) {
+  return {
+    sessionKey: key,
+    reason: "send",
+    key,
+    kind: "direct",
+    updatedAt: 3,
+    pinned,
+    pinnedAt: pinned ? 2 : null,
+  };
 }
 
 function pinHarness(options: {
@@ -66,10 +82,45 @@ describe("session pin mutations", () => {
     emitEvent({
       type: "event",
       event: "sessions.changed",
-      payload: { sessionKey: key, reason: "send", key, kind: "direct", updatedAt: 3 },
+      payload: sessionChangedPayload(key, true),
     });
     expect(rowPinned(sessions.state.result, key)).toBe(true);
     sessions.dispose();
+  });
+
+  it("keeps a pending pin through a stale Gateway event and its canonical refresh", async () => {
+    vi.useFakeTimers();
+    try {
+      const committed = deferred<unknown>();
+      let serverPinned = false;
+      const { gateway, key, emitEvent } = pinHarness({
+        patchResponse: () => committed.promise,
+        serverPinned: () => serverPinned,
+      });
+      const sessions = createSessionCapability(gateway);
+
+      await sessions.refresh({ force: true });
+      const operation = sessions.patch(key, { pinned: true });
+      expect(rowPinned(sessions.state.result, key)).toBe(true);
+
+      // A routine turn event for the same row, still carrying the pre-patch pin
+      // value, reaches both the direct merge and the canonical list refresh.
+      const stalePayload = sessionChangedPayload(key, false);
+      sessions.reconcileChanged(stalePayload);
+      expect(rowPinned(sessions.state.result, key)).toBe(true);
+
+      emitEvent({ type: "event", event: "sessions.changed", payload: stalePayload });
+      await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
+      expect(rowPinned(sessions.state.result, key)).toBe(true);
+
+      serverPinned = true;
+      committed.resolve({ ok: true, key, path: "", entry: {} });
+      await expect(operation).resolves.toBeTruthy();
+      expect(rowPinned(sessions.state.result, key)).toBe(true);
+      sessions.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("rolls a rejected unpin back to the pinned row and publishes the error", async () => {

--- a/ui/src/lib/sessions/session-pin-mutations.test.ts
+++ b/ui/src/lib/sessions/session-pin-mutations.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SessionsListResult } from "../../api/types.ts";
+import { createSessionCapability } from "./index.ts";
+import {
+  createGatewayHarness,
+  deferred,
+  sessionsResult,
+} from "./session-capability.test-support.ts";
+
+function rowPinned(result: SessionsListResult | null, key: string): boolean {
+  return result?.sessions.find((row) => row.key === key)?.pinned === true;
+}
+
+function pinHarness(options: {
+  patchResponse: (call: number) => Promise<unknown>;
+  serverPinned: () => boolean;
+}) {
+  const key = "agent:main:alpha";
+  let patchCalls = 0;
+  let listTs = 0;
+  const request = vi.fn(async (method: string) => {
+    if (method === "sessions.patch") {
+      patchCalls += 1;
+      return await options.patchResponse(patchCalls);
+    }
+    if (method === "sessions.list") {
+      listTs += 1;
+      return sessionsResult(
+        [{ key, kind: "direct", updatedAt: 1, pinned: options.serverPinned() }],
+        listTs,
+      );
+    }
+    if (method === "sessions.subscribe") {
+      return { subscribed: true };
+    }
+    throw new Error(`Unexpected request: ${method}`);
+  });
+  const client = { request } as unknown as GatewayBrowserClient;
+  const harness = createGatewayHarness(client);
+  return { ...harness, client, key, request };
+}
+
+describe("session pin mutations", () => {
+  it("pins a row before sessions.patch resolves and holds it through refresh and events", async () => {
+    const committed = deferred<unknown>();
+    let serverPinned = false;
+    const { gateway, key, emitEvent } = pinHarness({
+      patchResponse: () => committed.promise,
+      serverPinned: () => serverPinned,
+    });
+    const sessions = createSessionCapability(gateway);
+
+    await sessions.refresh({ force: true });
+    expect(rowPinned(sessions.state.result, key)).toBe(false);
+
+    const operation = sessions.patch(key, { pinned: true });
+    expect(rowPinned(sessions.state.result, key)).toBe(true);
+
+    serverPinned = true;
+    committed.resolve({ ok: true, key, path: "", entry: {} });
+    await expect(operation).resolves.toBeTruthy();
+    expect(rowPinned(sessions.state.result, key)).toBe(true);
+    expect(sessions.state.error).toBeNull();
+
+    emitEvent({
+      type: "event",
+      event: "sessions.changed",
+      payload: { sessionKey: key, reason: "send", key, kind: "direct", updatedAt: 3 },
+    });
+    expect(rowPinned(sessions.state.result, key)).toBe(true);
+    sessions.dispose();
+  });
+
+  it("rolls a rejected unpin back to the pinned row and publishes the error", async () => {
+    const { gateway, key } = pinHarness({
+      patchResponse: () => Promise.reject(new Error("pin rejected")),
+      serverPinned: () => true,
+    });
+    const sessions = createSessionCapability(gateway);
+
+    await sessions.refresh({ force: true });
+    expect(rowPinned(sessions.state.result, key)).toBe(true);
+
+    const operation = sessions.patch(key, { pinned: false });
+    expect(rowPinned(sessions.state.result, key)).toBe(false);
+
+    await expect(operation).rejects.toThrow("pin rejected");
+    expect(rowPinned(sessions.state.result, key)).toBe(true);
+    expect(sessions.state.error).toContain("pin rejected");
+    sessions.dispose();
+  });
+
+  it("keeps the newest pin intent when an older completion refreshes the list first", async () => {
+    const pinCommitted = deferred<unknown>();
+    const unpinCommitted = deferred<unknown>();
+    let serverPinned = false;
+    const { gateway, key } = pinHarness({
+      patchResponse: (call) => (call === 1 ? pinCommitted.promise : unpinCommitted.promise),
+      serverPinned: () => serverPinned,
+    });
+    const sessions = createSessionCapability(gateway);
+
+    await sessions.refresh({ force: true });
+    const pin = sessions.patch(key, { pinned: true });
+    expect(rowPinned(sessions.state.result, key)).toBe(true);
+    const unpin = sessions.patch(key, { pinned: false });
+    expect(rowPinned(sessions.state.result, key)).toBe(false);
+
+    // The pin commits first, so its list refresh republishes a pinned row the
+    // unpin already replaced locally.
+    serverPinned = true;
+    pinCommitted.resolve({ ok: true, key, path: "", entry: {} });
+    await expect(pin).resolves.toBeTruthy();
+    expect(rowPinned(sessions.state.result, key)).toBe(false);
+
+    serverPinned = false;
+    unpinCommitted.resolve({ ok: true, key, path: "", entry: {} });
+    await expect(unpin).resolves.toBeTruthy();
+    expect(rowPinned(sessions.state.result, key)).toBe(false);
+    sessions.dispose();
+  });
+
+  it("rolls a failed unpin back to the pin an overlapping completion confirmed", async () => {
+    const pinCommitted = deferred<unknown>();
+    const unpinRejected = deferred<unknown>();
+    let serverPinned = false;
+    const { gateway, key } = pinHarness({
+      patchResponse: (call) => (call === 1 ? pinCommitted.promise : unpinRejected.promise),
+      serverPinned: () => serverPinned,
+    });
+    const sessions = createSessionCapability(gateway);
+
+    await sessions.refresh({ force: true });
+    const pin = sessions.patch(key, { pinned: true });
+    const unpin = sessions.patch(key, { pinned: false });
+    expect(rowPinned(sessions.state.result, key)).toBe(false);
+
+    serverPinned = true;
+    pinCommitted.resolve({ ok: true, key, path: "", entry: {} });
+    await expect(pin).resolves.toBeTruthy();
+    expect(rowPinned(sessions.state.result, key)).toBe(false);
+
+    unpinRejected.reject(new Error("unpin rejected"));
+    await expect(unpin).rejects.toThrow("unpin rejected");
+    expect(rowPinned(sessions.state.result, key)).toBe(true);
+    expect(sessions.state.error).toContain("unpin rejected");
+    sessions.dispose();
+  });
+});

--- a/ui/src/lib/sessions/session-pin-mutations.test.ts
+++ b/ui/src/lib/sessions/session-pin-mutations.test.ts
@@ -155,6 +155,47 @@ describe("session pin mutations", () => {
     sessions.dispose();
   });
 
+  it("rolls a filtered-only row back to the pin the Gateway kept", async () => {
+    const key = "agent:other:beta";
+    const request = vi.fn(async (method: string, params?: { archived?: unknown }) => {
+      if (method === "sessions.patch") {
+        throw new Error("unpin rejected");
+      }
+      if (method === "sessions.list") {
+        // Only the all-filtered sidebar publishes this row, so the rollback
+        // baseline cannot come from the primary snapshot.
+        return params?.archived === "all"
+          ? sessionsResult([{ key, kind: "direct", updatedAt: 1, pinned: true, pinnedAt: 7 }], 1)
+          : sessionsResult([], 1);
+      }
+      if (method === "sessions.subscribe") {
+        return { subscribed: true };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const { gateway } = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+    const sessions = createSessionCapability(gateway);
+    const filtered: SessionListSnapshot[] = [];
+    const stopFiltered = sessions.subscribeList({ archivedFilter: "all" }, (snapshot) => {
+      filtered.push(snapshot);
+    });
+    const filteredRow = () => filtered.at(-1)?.result?.sessions.find((row) => row.key === key);
+
+    await sessions.refresh({ force: true });
+    await sessions.refreshList({ archivedFilter: "all", force: true });
+    expect(sessions.state.result?.sessions).toHaveLength(0);
+    expect(filteredRow()?.pinned).toBe(true);
+
+    const operation = sessions.patch(key, { pinned: false });
+    expect(filteredRow()?.pinned).toBe(false);
+
+    await expect(operation).rejects.toThrow("unpin rejected");
+    expect(filteredRow()?.pinned).toBe(true);
+    expect(filteredRow()?.pinnedAt).toBe(7);
+    stopFiltered();
+    sessions.dispose();
+  });
+
   it("keeps the newest pin intent when an older completion refreshes the list first", async () => {
     const pinCommitted = deferred<unknown>();
     const unpinCommitted = deferred<unknown>();

--- a/ui/src/lib/sessions/session-pin-mutations.test.ts
+++ b/ui/src/lib/sessions/session-pin-mutations.test.ts
@@ -8,6 +8,7 @@ import {
   deferred,
   sessionsResult,
 } from "./session-capability.test-support.ts";
+import type { SessionListSnapshot } from "./session-capability.ts";
 
 const SESSION_EVENT_REFRESH_DEBOUNCE_MS = 200;
 
@@ -123,22 +124,34 @@ describe("session pin mutations", () => {
     }
   });
 
-  it("rolls a rejected unpin back to the pinned row and publishes the error", async () => {
+  it("rolls a rejected unpin back across the primary and filtered lists", async () => {
     const { gateway, key } = pinHarness({
       patchResponse: () => Promise.reject(new Error("pin rejected")),
       serverPinned: () => true,
     });
     const sessions = createSessionCapability(gateway);
+    // The archived/all sidebar reads its own snapshot, so the intent has to
+    // reach that list and leave it on the same value the primary state shows.
+    const filtered: SessionListSnapshot[] = [];
+    const stopFiltered = sessions.subscribeList({ archivedFilter: "all" }, (snapshot) => {
+      filtered.push(snapshot);
+    });
+    const filteredRowPinned = () => rowPinned(filtered.at(-1)?.result ?? null, key);
 
     await sessions.refresh({ force: true });
+    await sessions.refreshList({ archivedFilter: "all", force: true });
     expect(rowPinned(sessions.state.result, key)).toBe(true);
+    expect(filteredRowPinned()).toBe(true);
 
     const operation = sessions.patch(key, { pinned: false });
     expect(rowPinned(sessions.state.result, key)).toBe(false);
+    expect(filteredRowPinned()).toBe(false);
 
     await expect(operation).rejects.toThrow("pin rejected");
     expect(rowPinned(sessions.state.result, key)).toBe(true);
+    expect(filteredRowPinned()).toBe(true);
     expect(sessions.state.error).toContain("pin rejected");
+    stopFiltered();
     sessions.dispose();
   });
 

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -438,7 +438,9 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     refresh,
     refreshReplacement,
     /** The row as currently published. The archived/all sidebars render their
-     * own snapshot, so a displayed row can be absent from the primary state. */
+     * own snapshot, so a displayed row can be absent from the primary state.
+     * Lists refresh independently, so when both hold the row the primary one
+     * wins rather than guessing which snapshot the caller was looking at. */
     publishedRow(key: string): GatewaySessionRow | undefined {
       const primary = host.readState().result?.sessions.find((row) => row.key === key);
       if (primary) {

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -437,6 +437,21 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     },
     refresh,
     refreshReplacement,
+    /** Republishes every held list through `decorate` so a UI-owned overlay
+     * reaches the archived/all snapshots too, not just the primary state. */
+    redecorateLists() {
+      const state = host.readState();
+      const result = host.decorate(state.result);
+      if (result !== state.result) {
+        host.publish({ ...state, result });
+      }
+      for (const entry of filteredLists.values()) {
+        const decorated = host.decorate(entry.snapshot.result);
+        if (decorated !== entry.snapshot.result) {
+          publishFilteredList(entry, { ...entry.snapshot, result: decorated });
+        }
+      }
+    },
     setCreatorFilter(creatorId: string | null) {
       const options = { ...lastListOptions, creatorId: creatorId?.trim() || undefined };
       delete options.offset;

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -1,4 +1,4 @@
-import type { SessionsListResult } from "../../api/types.ts";
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import { createSessionEventRefreshCoordinator } from "./event-refresh-coordinator.ts";
 import { appendSessionResults } from "./reconcile.ts";
 import type {
@@ -437,6 +437,21 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     },
     refresh,
     refreshReplacement,
+    /** The row as currently published. The archived/all sidebars render their
+     * own snapshot, so a displayed row can be absent from the primary state. */
+    publishedRow(key: string): GatewaySessionRow | undefined {
+      const primary = host.readState().result?.sessions.find((row) => row.key === key);
+      if (primary) {
+        return primary;
+      }
+      for (const entry of filteredLists.values()) {
+        const row = entry.snapshot.result?.sessions.find((candidate) => candidate.key === key);
+        if (row) {
+          return row;
+        }
+      }
+      return undefined;
+    },
     /** Republishes every held list through `decorate` so a UI-owned overlay
      * reaches the archived/all snapshots too, not just the primary state. */
     redecorateLists() {


### PR DESCRIPTION
Closes #121247

## What Problem This Solves

Fixes an issue where operators who pin or unpin a session from the Control UI sidebar would see nothing happen until the Gateway answered. The row, its pin icon, and its section placement all kept the pre-click value for the whole `sessions.patch` round trip plus the canonical `sessions.list` refresh that follows it. On a slow or unreachable Gateway the click looked like it did nothing, so operators re-clicked and ended up with a pin/unpin flip-flop whose final state depended on which completion landed last rather than on their last intent.

This is a default-path regression class the repo's Product Doctrine calls out first: an action that produces nothing, with nothing explaining why.

## Why This Change Was Made

The mutation owner already knew how to do this. `createSessionMutations.patch` (`ui/src/lib/sessions/session-mutations.ts`) carries a full optimistic lifecycle for model overrides — a pending intent keyed by session key, a captured previous value, rollback on failure, and last-writer-wins across overlapping patches. Pin/unpin simply never used it.

So the pin gets its own pending intent in that same owner rather than a per-button patch:

- The published row flips up front; the Gateway patch and its list refresh confirm it afterwards.
- The intent is re-asserted wherever canonical Gateway rows become published rows. The capability already funnels every list, event merge, and history reconcile through one row-decoration seam for Swarm notes, so the pending pin joins it there. Without that, any `sessions.changed` arriving mid-flight queues a canonical list whose rows still carry the server's pre-click `pinned`, and the click looks ignored again — every Gateway session payload ships `pinned`/`pinnedAt` (`src/gateway/session-event-payload.ts:43`), not just patch reasons.
- Starting an intent and rolling one back both republish through that seam, so the primary snapshot and the `archived`/`all` sidebar lists — which keep their own published snapshots — always land on one value in one pass.
- The rollback baseline comes from wherever the row is currently published. A sidebar on `archived`/`all` renders its own subscribed list, so a row shown only there would otherwise record an unpinned baseline and a rejected unpin would leave a still-pinned session looking unpinned.
- The optimistic write moves `pinned` and `pinnedAt` together. The Gateway derives `pinned` from `pinnedAt` (`src/gateway/session-utils-row.ts:443`) and both row comparators order by `pinnedAt` inside each pin group, so writing only the boolean parks an in-flight row in a slot the Gateway would never produce.
- `previous` chains through an in-flight pin, so a rollback lands on the last Gateway-confirmed value instead of an older operation's guess. A patch rebaselines a newer intent's `previous` the moment the Gateway confirms — not after its list refresh, which can fail — so a later rollback is exact even when a pin and an unpin overlap.
- Rollback and re-assertion stay behind the existing connection epoch, and `retireConnection`/`dispose` drop pending intents. The sidebar's own mutation epoch is untouched: the snapshot is capability-owned, so the optimistic write correctly lives below that layer.

Because every pin surface routes through this one operation, the sidebar pin button, the row menu, sidebar drag/drop onto and out of the pinned zone, and the Sessions page `toggle-pin` all get the same immediate feedback and the same rollback with no per-surface code. A rejected zone drop still writes no sidebar slot — `handleSidebarZoneDrop` persists the dropped position only on `completed`, and the failed pin rolls the row back out of the zone.

Non-goals: `category`, `label`, `icon`, and `archived` stay non-optimistic. Batch pin through `sessions.patchMany` also stays as-is; it is not an interactive pin toggle.

## User Impact

Pinning and unpinning a sidebar session is now instant, in every sidebar status filter. The row moves, the icon flips, and the section changes on click, while the Gateway write happens in the background. Ordinary session activity arriving mid-flight no longer snaps the row back. If the write fails, the row snaps back to its real state everywhere it is displayed and the existing sidebar error callout explains why — nothing is silently left in a lying state. Rapid pin/unpin settles on what you clicked last.

## Evidence

**Before/after, captured from the mocked-Gateway Control UI E2E with the `sessions.patch` response deliberately held open.**

Pin button, before the click — "Pin me" sits under SESSIONS:

<img width="1280" alt="before click" src="https://github.com/user-attachments/assets/d19e94fb-c56e-4e8e-b5ef-54d8f4224eab" />

Same run, immediately after the click and **while the Gateway patch is still in flight** — the row has already moved into the pinned zone above SESSIONS. Only one `sessions.list` has been issued at this point, so this can only come from the optimistic snapshot write:

<img width="1280" alt="pinned while the patch is in flight" src="https://github.com/user-attachments/assets/09df0053-8a2b-4568-a184-ce0675e7a7ca" />

Row menu unpin, in flight — the row drops back into SESSIONS immediately:

<img width="1280" alt="unpinned while the patch is in flight" src="https://github.com/user-attachments/assets/3fd47c6b-fe53-4560-9b36-c3ad0c5c6d27" />

Gateway rejects that unpin — the row returns to the pinned zone and the existing error callout surfaces the failure:

<img width="1280" alt="rolled back with the error preserved" src="https://github.com/user-attachments/assets/7e9fb714-a290-422c-abe6-8c03c6cfb50a" />

Screen recording of the pin-button run:

https://github.com/user-attachments/assets/f56070c1-75f2-4f6b-b402-fa457cb29dd3

**Tests.** Every new test was confirmed to fail on the unfixed production file and pass with it — they are regression proof, not restatements.

`ui/src/lib/sessions/session-pin-mutations.test.ts` (capability-level, deferred RPC):

- pins a row before `sessions.patch` resolves and holds it through refresh and events
- keeps a pending pin through a stale Gateway event and its canonical refresh — the event carries the server's pre-patch `pinned`/`pinnedAt`, and both the direct merge and the debounced list replacement are exercised while the patch is still open
- rolls a rejected unpin back across the primary and filtered lists, asserting a subscribed `archivedFilter: "all"` snapshot flips with the click and returns with the rollback
- rolls a filtered-only row back to the pin the Gateway kept, with the row published solely in the `all` snapshot and absent from the primary state
- keeps the newest pin intent when an older completion refreshes the list first
- rolls a failed unpin back to the pin an overlapping completion confirmed

`ui/src/e2e/session-management.optimistic-pin.e2e.test.ts` (Control UI E2E, mocked Gateway, deferred/rejected `sessions.patch`):

- pins from the row button while the Gateway patch is still in flight
- rolls a menu unpin back and surfaces the error when the Gateway rejects it
- keeps the newest pin intent when the older completion refreshes the list first

Verification, all on a Blacksmith Testbox (Linux, Node 24) at the branch head:

```
pnpm test ui/src/lib/sessions ui/src/components ui/src/pages/sessions ui/src/pages/chat
pnpm tsgo:ui
pnpm check:test-types
node scripts/run-oxlint.mjs --openclaw-focused-config ui/src/lib/sessions
oxfmt --check ui/src/lib/sessions
```

Negative runs on the same branch: dropping the pin overlay from the decoration seam fails 3 of the 6 capability cases, publishing the intent to the primary snapshot alone fails the filtered-list case, and reading the rollback baseline from the primary snapshot alone fails the filtered-only case.

**Production vs test LOC** (`git diff --numstat` against `59ec484`):

| file | + | - | kind |
| --- | --- | --- | --- |
| `ui/src/lib/sessions/session-mutations.ts` | 113 | 7 | production |
| `ui/src/lib/sessions/session-roster-refresh.ts` | 33 | 1 | production |
| `ui/src/lib/sessions/index.ts` | 12 | 6 | production |
| `ui/src/lib/sessions/session-pin-mutations.test.ts` | 255 | 0 | test |
| `ui/src/e2e/session-management.optimistic-pin.e2e.test.ts` | 184 | 0 | test |
| `ui/src/lib/sessions/session-capability.test-support.ts` | 76 | 0 | test support |
| `ui/src/lib/sessions/index.test.ts` | 5 | 72 | test |

Net production delta is **+144 lines**, all in the session capability and its two owners. It buys a capability that cannot be expressed more simply: a per-key pending pin intent whose rollback baseline is read from the row as published, last-intent-wins ordering rebaselined at Gateway confirmation, re-assertion over canonical rows, and one publication path that covers every held list. There is no new abstraction layer, no new config or public surface, and no compatibility branch. Roughly a fifth of the production lines are the inline invariant comments this repo requires at owner boundaries.

The shared capability harness (`sessionsResult`, `deferred`, `createGatewayHarness`) was extracted from `index.test.ts` into `session-capability.test-support.ts` rather than duplicated, which also kept `index.test.ts` under its `max-lines` ceiling instead of growing it toward a suppression.

**Accepted tradeoffs, recorded rather than silently skipped.**

- Pending intents are keyed by session key, matching the capability's existing `pendingModelPatches`/`modelOverrides` convention rather than forking it for pins alone.
- Once the Gateway agrees on the `pinned` boolean, the overlay yields to the canonical `pinnedAt`. A canonical row that predates a rapid unpin/repin can therefore carry the older stamp for the rest of the patch window, which reorders within the pinned group only. The alternative — overwriting confirmed Gateway stamps with a client clock — is worse.
- When both the primary and a filtered snapshot publish the row and they momentarily disagree, the primary one supplies the baseline rather than the capability guessing which list the caller was looking at.
- Dragging an already-pinned row onto a named category section sends `{ category, pinned: false }`. The unpin is optimistic and the category move is not, so that one path shows the row leave the pinned zone immediately and reach its target category after the refresh — two hops instead of one. Making `category` optimistic is a separate product decision with its own placement and undo semantics; it is deliberately out of scope here and worth a follow-up if the two-hop move bothers operators.
