### PR TITLE
fix(gateway): keep view-only desktop sessions connected [AI-assisted]

### DIFF
--- a/src/gateway/worker-environments/rfb-view-only-filter.test.ts
+++ b/src/gateway/worker-environments/rfb-view-only-filter.test.ts
@@ -112,10 +112,10 @@ describe("RFB view-only client message filter", () => {
 
     for (const byte of capturedSequence) {
       const result = filter.filter(Buffer.of(byte));
-      expect(result).not.toHaveProperty("error");
-      if ("forward" in result) {
-        forwarded.push(result.forward);
+      if ("error" in result) {
+        throw new Error(result.error);
       }
+      forwarded.push(result.forward);
     }
 
     expect(Buffer.concat(forwarded)).toEqual(

--- a/src/gateway/worker-environments/rfb-view-only-filter.test.ts
+++ b/src/gateway/worker-environments/rfb-view-only-filter.test.ts
@@ -89,6 +89,63 @@ describe("RFB view-only client message filter", () => {
     });
   });
 
+  it("forwards the fragmented noVNC 1.7 display and flow-control sequence", () => {
+    const filter = enterMessagePhase();
+    const setPixelFormat = Buffer.alloc(20);
+    const setEncodings = Buffer.alloc(100);
+    setEncodings[0] = 2;
+    setEncodings.writeUInt16BE(24, 2);
+    const framebufferUpdateRequest = Buffer.from([3, 1, 0, 0, 0, 0, 0, 64, 0, 64]);
+    const clientFence = Buffer.from([248, 0, 0, 0, 0, 0, 0, 0, 1, 0]);
+    const enableContinuousUpdates = Buffer.from([150, 1, 0, 0, 0, 0, 0, 64, 0, 64]);
+    const cutText = Buffer.concat([Buffer.from([6, 0, 0, 0, 0, 0, 0, 8]), Buffer.alloc(8)]);
+    const capturedSequence = Buffer.concat([
+      setPixelFormat,
+      setEncodings,
+      framebufferUpdateRequest,
+      clientFence,
+      enableContinuousUpdates,
+      cutText,
+      enableContinuousUpdates,
+    ]);
+    const forwarded: Buffer[] = [];
+
+    for (const byte of capturedSequence) {
+      const result = filter.filter(Buffer.of(byte));
+      expect(result).not.toHaveProperty("error");
+      if ("forward" in result) {
+        forwarded.push(result.forward);
+      }
+    }
+
+    expect(Buffer.concat(forwarded)).toEqual(
+      Buffer.concat([
+        setPixelFormat,
+        setEncodings,
+        framebufferUpdateRequest,
+        clientFence,
+        enableContinuousUpdates,
+        enableContinuousUpdates,
+      ]),
+    );
+  });
+
+  it("uses the ClientFence payload length to preserve message boundaries", () => {
+    const filter = enterMessagePhase();
+    const clientFence = Buffer.concat([
+      Buffer.from([248, 0, 0, 0, 0, 0, 0, 0, 3]),
+      Buffer.from("abc"),
+    ]);
+    const framebufferUpdateRequest = Buffer.from([3, 1, 0, 0, 0, 0, 0, 64, 0, 64]);
+
+    expect(filter.filter(clientFence.subarray(0, 10))).toEqual({ forward: Buffer.alloc(0) });
+    expect(
+      filter.filter(Buffer.concat([clientFence.subarray(10), framebufferUpdateRequest])),
+    ).toEqual({
+      forward: Buffer.concat([clientFence, framebufferUpdateRequest]),
+    });
+  });
+
   it("reassembles a message split across three chunks", () => {
     const filter = enterMessagePhase();
     const completePrefix = Buffer.from([3, 1, 0, 0, 0, 0, 0, 64, 0, 64]);

--- a/src/gateway/worker-environments/rfb-view-only-filter.ts
+++ b/src/gateway/worker-environments/rfb-view-only-filter.ts
@@ -45,6 +45,11 @@ export function createRfbClientMessageFilter() {
         return 6;
       case 6:
         return pending.length < 8 ? 8 : 8 + pending.readUInt32BE(4);
+      case 150:
+        return 10;
+      case 248:
+        // ClientFence's payload length byte follows its 8-byte fixed header.
+        return pending.length < 9 ? 9 : 9 + pending[8];
       default:
         return `unsupported RFB client message type ${pending[0]}`;
     }
@@ -75,7 +80,13 @@ export function createRfbClientMessageFilter() {
       pending[0] = 1;
       forwarded.push(pending);
       phase = "messages";
-    } else if (pending[0] === 0 || pending[0] === 2 || pending[0] === 3) {
+    } else if (
+      pending[0] === 0 ||
+      pending[0] === 2 ||
+      pending[0] === 3 ||
+      pending[0] === 150 ||
+      pending[0] === 248
+    ) {
       forwarded.push(pending);
     }
     pending = Buffer.alloc(0);

--- a/src/gateway/worker-environments/rfb-view-only-filter.ts
+++ b/src/gateway/worker-environments/rfb-view-only-filter.ts
@@ -49,7 +49,7 @@ export function createRfbClientMessageFilter() {
         return 10;
       case 248:
         // ClientFence's payload length byte follows its 8-byte fixed header.
-        return pending.length < 9 ? 9 : 9 + pending[8];
+        return pending.length < 9 ? 9 : 9 + pending.readUInt8(8);
       default:
         return `unsupported RFB client message type ${pending[0]}`;
     }


### PR DESCRIPTION
## What Problem This Solves
Fixes an issue where users opening a Cloud Worker Desktop in view-only mode would be disconnected with `invalid view-only RFB stream` when noVNC 1.7 sent its normal post-handshake flow-control messages.

## Why This Change Was Made
The gateway's server-enforced view-only RFB parser now recognizes and forwards noVNC's harmless variable-length ClientFence and fixed-length EnableContinuousUpdates messages. Keyboard, pointer, and clipboard input remain dropped, unknown message types still fail closed, and framing remains independent of WebSocket chunk boundaries.

## User Impact
View-only Cloud Worker Desktop sessions can stay connected with noVNC 1.7 and TigerVNC without granting input control.

## Evidence
- Production before-fix acceptance on `team.openclaw.ai` reproduced the disconnect and captured the exact post-handshake message shapes.
- Direct dependency inspection of `@novnc/novnc` 1.7.0 confirmed ClientFence is `9 + payloadLength` bytes with the length byte at offset 8, and EnableContinuousUpdates is exactly 10 bytes.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/rfb-view-only-filter.test.ts` — 13/13 tests passed, including the captured sequence byte-by-byte, variable-length fence fragmentation, input drops, unknown-message fail-closed behavior, and the 64 KiB bound.
- `pnpm format src/gateway/worker-environments/rfb-view-only-filter.ts src/gateway/worker-environments/rfb-view-only-filter.test.ts`
- `git diff --check`
- Codex-backed autoreview: clean, no accepted/actionable findings.

AI-assisted; implementation was manually reviewed and the upstream framing contract was verified directly.
