### PR TITLE
fix(ui): scope the Control UI cursor convention to app-like display modes

### DIFF
--- a/config/stylelint.config.mjs
+++ b/config/stylelint.config.mjs
@@ -10,6 +10,14 @@ export default {
     // per-site visual proof. Tighten in a follow-up, keep new code honest via
     // review until then.
     "no-duplicate-selectors": null,
+    // stylelint 17.14.1 knows display-mode as fullscreen | standalone |
+    // minimal-ui | browser | picture-in-picture (lib/reference/mediaFeatures.mjs),
+    // predating window-controls-overlay. Allow that one value only, so typos in
+    // the rest still fail.
+    "media-feature-name-value-no-unknown": [
+      true,
+      { ignoreMediaFeatureNameValues: { "display-mode": ["window-controls-overlay"] } },
+    ],
     // `clip` survives only inside the standard sr-only fallback pattern.
     "property-no-deprecated": [true, { ignoreProperties: ["clip"] }],
     // `word-break: break-word` is deprecated but swapping it for overflow-wrap

--- a/ui/index.html
+++ b/ui/index.html
@@ -199,7 +199,10 @@
         margin-top: 24px;
       }
 
+      /* The fallback renders when the bundle fails to load, so it cannot read
+         base.css tokens; it repeats the cursor policy locally for that reason. */
       .mount-fallback__button {
+        cursor: pointer;
         min-height: 42px;
         border: 1px solid rgba(148, 163, 184, 0.36);
         border-radius: 6px;
@@ -208,6 +211,14 @@
         background: transparent;
         font: inherit;
         font-weight: 700;
+      }
+
+      @media (display-mode: standalone),
+        (display-mode: minimal-ui),
+        (display-mode: window-controls-overlay) {
+        .mount-fallback__button {
+          cursor: default;
+        }
       }
 
       .mount-fallback__button--primary {

--- a/ui/index.html
+++ b/ui/index.html
@@ -221,6 +221,11 @@
         }
       }
 
+      html:is(.openclaw-native-macos, .openclaw-native-nav, .openclaw-native-web-chrome)
+        .mount-fallback__button {
+        cursor: default;
+      }
+
       .mount-fallback__button--primary {
         border-color: #66c2ff;
         color: #061019;

--- a/ui/src/components/form-controls.browser.test.ts
+++ b/ui/src/components/form-controls.browser.test.ts
@@ -321,7 +321,7 @@ describeBrowserLayout("touch-primary form controls", () => {
 });
 
 describeBrowserLayout("mount fallback cursor", () => {
-  it("uses the default cursor for its controls and the pointer for its real link", async () => {
+  it("advertises its controls with the hand in a browser tab, alongside its real link", async () => {
     const page = await desktopContext.newPage();
     try {
       await page.setContent(readStyleSheet("ui/index.html"));
@@ -340,9 +340,11 @@ describeBrowserLayout("mount fallback cursor", () => {
         };
       });
 
+      // A browser tab is display-mode: browser, so the fallback follows the same
+      // cursor policy as the app it is standing in for.
       expect(cursors).toEqual({
-        retry: "default",
-        wait: "default",
+        retry: "pointer",
+        wait: "pointer",
         docs: "pointer",
       });
     } finally {

--- a/ui/src/components/terminal/terminal-panel-upload-styles.ts
+++ b/ui/src/components/terminal/terminal-panel-upload-styles.ts
@@ -85,7 +85,7 @@ export const terminalPanelUploadStyles = css`
     background: transparent;
     color: var(--muted, #8a919e);
     font: inherit;
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .tp-upload-card__action:hover {
     background: color-mix(in srgb, var(--text, #d7dae0) 10%, transparent);

--- a/ui/src/styles/about.css
+++ b/ui/src/styles/about.css
@@ -17,7 +17,7 @@
   border: 0;
   background: transparent;
   border-radius: var(--radius-lg);
-  cursor: pointer;
+  cursor: var(--cursor-action);
   transition: transform 160ms ease;
 }
 
@@ -251,7 +251,7 @@
   border-radius: 6px;
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
+  cursor: var(--cursor-action);
   transition:
     opacity var(--duration-fast, 120ms) ease,
     color var(--duration-fast, 120ms) ease,

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -44,7 +44,7 @@
   gap: var(--space-1);
   color: var(--text);
   font-size: var(--control-ui-text-sm);
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .activity-status-filter input {

--- a/ui/src/styles/apps.css
+++ b/ui/src/styles/apps.css
@@ -158,7 +158,7 @@
   font-size: var(--control-ui-text-sm);
   font-weight: 550;
   text-decoration: none;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   transition:
     transform 140ms ease,
     background 140ms ease,
@@ -200,7 +200,7 @@
   background: none;
   color: var(--text);
   font: inherit;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   text-decoration: underline;
   text-underline-offset: 2px;
 }

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -693,10 +693,54 @@ openclaw-app {
   }
 }
 
-/* Cursor convention: app chrome (buttons, menus, tabs, rails, controls) uses
-   the default arrow cursor; the pointer hand is reserved for real hyperlinks
-   (UA default on a[href]). Do not add `cursor: pointer` to controls; anchors
-   that act as chrome override to `cursor: default` instead. */
+/* Cursor policy. A browser tab gets the pointer hand, the only hover affordance
+   a page owns; installed/app-like windows are desktop chrome and keep the arrow.
+   Controls consume --cursor-action rather than hardcoding a cursor, and real
+   hyperlinks keep the UA pointer in every mode. */
+:root {
+  --cursor-action: pointer;
+}
+
+/* Separate from the standalone block above, which owns viewport and safe-area
+   insets; widening its condition would change those too. `fullscreen` is absent
+   on purpose: it is a transient presentation state any window can enter, and
+   the manifest installs this UI as `standalone`. */
+@media (display-mode: standalone),
+  (display-mode: minimal-ui),
+  (display-mode: window-controls-overlay) {
+  :root {
+    --cursor-action: default;
+  }
+}
+
+/* Generic actionable controls, at element/attribute specificity only so the
+   component rules that own semantic cursors (not-allowed, disabled, grab,
+   resize, deliberate `default` on non-actionable elements) still win. */
+button,
+summary,
+select,
+[role="button"],
+[role="checkbox"],
+[role="menuitem"],
+[role="menuitemcheckbox"],
+[role="menuitemradio"],
+[role="option"],
+[role="radio"],
+[role="switch"],
+[role="tab"],
+input:is(
+  [type="button"],
+  [type="checkbox"],
+  [type="color"],
+  [type="file"],
+  [type="radio"],
+  [type="range"],
+  [type="reset"],
+  [type="submit"]
+) {
+  cursor: var(--cursor-action);
+}
+
 a {
   color: var(--accent);
   text-decoration: underline;
@@ -708,10 +752,10 @@ a:hover {
 }
 
 /* Web Awesome dropdown items ship `cursor: pointer` on their shadow host.
-   Document rules beat `:host`, so restore the chrome arrow here — and re-add
-   the disabled cue this override would otherwise clobber. */
+   Document rules beat `:host`, so route them through the policy here — and
+   re-add the disabled cue this override would otherwise clobber. */
 wa-dropdown-item {
-  cursor: default;
+  cursor: var(--cursor-action);
 }
 
 wa-dropdown-item[disabled] {

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -713,6 +713,13 @@ openclaw-app {
   }
 }
 
+/* Native app hosts are installed desktop windows too, but they embed a plain
+   web view that reports `display-mode: browser`; they announce themselves with
+   these `<html>` markers instead (all three, as layout.css already matches). */
+html:is(.openclaw-native-macos, .openclaw-native-nav, .openclaw-native-web-chrome) {
+  --cursor-action: default;
+}
+
 /* Generic actionable controls, at element/attribute specificity only so the
    component rules that own semantic cursors (not-allowed, disabled, grab,
    resize, deliberate `default` on non-actionable elements) still win. */

--- a/ui/src/styles/board.css
+++ b/ui/src/styles/board.css
@@ -95,7 +95,7 @@ openclaw-board-view {
   border: 0;
   border-radius: 7px;
   color: var(--muted);
-  cursor: pointer;
+  cursor: var(--cursor-action);
   display: inline-flex;
   justify-content: center;
   user-select: none;

--- a/ui/src/styles/channels.css
+++ b/ui/src/styles/channels.css
@@ -171,7 +171,7 @@
 
 .channels-pairing-request__details summary {
   width: fit-content;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .channels-pairing-request__details .settings-kv {
@@ -201,7 +201,7 @@
   align-items: flex-start;
   gap: var(--space-2);
   color: var(--text);
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .channels-pairing-dialog__option input {
@@ -328,7 +328,7 @@ wa-radio-group.channels-wizard__options::part(radios) {
   padding: var(--space-2) var(--space-3);
   background: var(--card);
   text-align: left;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   transition:
     border-color var(--duration-fast) var(--ease-out),
     background var(--duration-fast) var(--ease-out);
@@ -413,7 +413,7 @@ wa-radio-group.channels-wizard__options::part(radios) {
   color: inherit;
   font: inherit;
   text-align: left;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .channels-item__detail:focus-visible {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -429,7 +429,7 @@ openclaw-chat-page {
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
   box-shadow: var(--shadow-sm);
-  cursor: pointer;
+  cursor: var(--cursor-action);
   pointer-events: auto;
   transform: translateX(-50%);
 }
@@ -1099,7 +1099,7 @@ openclaw-chat-video-player {
   border-radius: 999px;
   color: var(--accent);
   background: color-mix(in srgb, var(--accent) 12%, var(--card));
-  cursor: pointer;
+  cursor: var(--cursor-action);
   transition:
     transform 120ms ease,
     background 120ms ease;
@@ -1140,7 +1140,7 @@ openclaw-chat-video-player {
       var(--chat-audio-buffered),
     color-mix(in srgb, var(--border) 72%, transparent) var(--chat-audio-buffered) 100%
   );
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .chat-audio-player__seek::-webkit-slider-thumb {
@@ -2017,7 +2017,7 @@ openclaw-chat-video-player {
   padding: 2px 8px;
   border-radius: var(--radius-full);
   background: color-mix(in srgb, currentColor 12%, transparent);
-  cursor: pointer;
+  cursor: var(--cursor-action);
   font-size: 12px;
   font-weight: 600;
   list-style: none;
@@ -2163,7 +2163,7 @@ openclaw-chat-video-player {
   border: none;
   background: none;
   color: var(--muted);
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .chat-pr__dismiss:hover {
@@ -2182,7 +2182,7 @@ openclaw-chat-video-player {
   border-radius: var(--radius-full);
   background: color-mix(in srgb, var(--muted) 14%, transparent);
   color: var(--muted);
-  cursor: pointer;
+  cursor: var(--cursor-action);
   font-size: 12px;
   font-weight: 600;
 }
@@ -2770,7 +2770,7 @@ openclaw-chat-video-player {
   background: transparent;
   color: var(--text);
   font: inherit;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .agent-chat__session-overrides-open {
@@ -3330,7 +3330,7 @@ openclaw-chat-video-player {
   border-radius: var(--radius-full);
   background: color-mix(in srgb, #000 68%, transparent);
   color: white;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   place-items: center;
   backdrop-filter: blur(8px);
 }
@@ -3905,7 +3905,7 @@ openclaw-chat-video-player {
 }
 
 .chat-browser-annotation-card__remove:not(:disabled) {
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .chat-browser-annotation-card__remove:focus-visible {
@@ -4024,7 +4024,7 @@ openclaw-chat-video-player {
   border: none;
   color: var(--muted);
   background: transparent;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   font: inherit;
   line-height: 1.15;
   text-align: left;
@@ -4630,7 +4630,7 @@ openclaw-chat-video-player {
   border-radius: 4px;
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
+  cursor: var(--cursor-action);
   font-size: 12px;
   font-weight: 600;
 }

--- a/ui/src/styles/chat/plan-checklist.css
+++ b/ui/src/styles/chat/plan-checklist.css
@@ -40,7 +40,7 @@
   min-width: 0;
   padding: 7px 9px;
   color: var(--text);
-  cursor: pointer;
+  cursor: var(--cursor-action);
   list-style: none;
   user-select: none;
 }

--- a/ui/src/styles/chat/question-card.css
+++ b/ui/src/styles/chat/question-card.css
@@ -77,7 +77,7 @@ openclaw-chat-question-panel {
   border-radius: var(--radius-sm);
   background: transparent;
   color: inherit;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .chat-question-panel__request-nav button:hover,
@@ -132,7 +132,7 @@ openclaw-chat-question-panel {
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .chat-question-panel__collapse:hover,
@@ -203,7 +203,7 @@ openclaw-chat-question-panel {
   color: var(--text);
   font: inherit;
   text-align: left;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .chat-question-panel__option:hover:not(:disabled),
@@ -310,7 +310,7 @@ openclaw-chat-question-panel {
   border: 0;
   background: transparent;
   color: inherit;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .chat-question-panel__skip {
@@ -351,7 +351,7 @@ openclaw-chat-question-panel {
   font-size: var(--control-ui-text-sm);
   font-weight: 600;
   text-align: left;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .chat-question-panel__collapsed-button > :first-child {

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -999,7 +999,7 @@ openclaw-chat-sidebar-region,
   border: 1px solid transparent;
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--bg-elevated) 62%, transparent);
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .chat-tasks-rail__task:hover,
@@ -1026,7 +1026,7 @@ openclaw-chat-sidebar-region,
   color: inherit;
   font: inherit;
   text-align: left;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .chat-tasks-rail__task-chevron {
@@ -1301,7 +1301,7 @@ openclaw-chat-sidebar-region,
   font: inherit;
   font-size: var(--control-ui-text-xs);
   line-height: 1.3;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   text-decoration: underline;
   text-decoration-color: color-mix(in srgb, var(--muted) 45%, transparent);
   text-underline-offset: 2px;
@@ -1987,7 +1987,7 @@ openclaw-session-discussion {
   font: inherit;
   font-size: var(--control-ui-text-sm);
   text-align: left;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .session-diff__chevron {

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -251,7 +251,7 @@ openclaw-chat-pane {
   background: var(--panel);
   color: var(--muted);
   font-size: 11px;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .chat-pane__gateway-chip:hover,
@@ -366,7 +366,7 @@ openclaw-chat-pane {
   background: var(--panel);
   color: var(--muted);
   font-size: 11px;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .chat-pane__workspace-chip:hover,

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -50,7 +50,7 @@
   font-size: var(--control-ui-text-sm);
   font-weight: 500;
   line-height: 1.2;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .chat-message-disclosure__toggle:hover {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -635,7 +635,7 @@
   background: transparent;
   font: inherit;
   text-align: left;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .chat-tool-card__detail-link:hover,
@@ -818,7 +818,7 @@
   background: transparent;
   border: 0;
   color: var(--muted);
-  cursor: pointer;
+  cursor: var(--cursor-action);
   font: inherit;
   font-size: 11px;
   padding: 2px 4px;
@@ -1966,7 +1966,7 @@
   background: transparent;
   color: var(--muted);
   font: inherit;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   text-decoration: underline;
   text-decoration-color: color-mix(in srgb, var(--muted) 45%, transparent);
   text-underline-offset: 2px;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1059,7 +1059,7 @@ openclaw-session-owner-chip {
   border-radius: 0 var(--radius-md) var(--radius-md) 0;
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
+  cursor: var(--cursor-action);
   touch-action: manipulation;
 }
 
@@ -1710,7 +1710,7 @@ openclaw-chat-session-rail {
   color: inherit;
   font: inherit;
   text-align: left;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .chat-session-rail__hide,
@@ -2890,7 +2890,7 @@ td.data-table-key-col {
   font-size: 11.5px;
   font-weight: 600;
   line-height: 1;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .chat-queue__steer svg,
@@ -2920,7 +2920,7 @@ td.data-table-key-col {
   border-radius: var(--radius-sm);
   background: none;
   color: var(--muted);
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .chat-queue__remove:hover {
@@ -3188,7 +3188,7 @@ td.data-table-key-col {
   background: transparent;
   color: var(--text);
   text-align: left;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .exec-approval-list__item:hover,
@@ -4851,7 +4851,7 @@ td.data-table-key-col {
   background: none;
   color: var(--text);
   font: inherit;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
@@ -4927,7 +4927,7 @@ td.data-table-key-col {
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .device-pair-setup__access label:has(input:checked) {

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -678,7 +678,7 @@
 
 /* Collapsible nested-object summary behaves like a nav row. */
 .cfg-object__summary {
-  cursor: pointer;
+  cursor: var(--cursor-action);
   list-style: none;
   transition: background var(--duration-fast) ease;
 }

--- a/ui/src/styles/cron.css
+++ b/ui/src/styles/cron.css
@@ -38,7 +38,7 @@
   text-align: left;
   font: inherit;
   color: inherit;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   border: 0;
   background: transparent;
   margin: calc(-1 * var(--space-2));
@@ -289,7 +289,7 @@
 .cron-table__row {
   padding-top: var(--space-2);
   padding-bottom: var(--space-2);
-  cursor: pointer;
+  cursor: var(--cursor-action);
   transition: background var(--duration-fast) var(--ease-out);
 }
 
@@ -468,7 +468,7 @@
   font-size: var(--control-ui-text-sm);
   font-weight: 600;
   padding: 2px 0;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   transition: color var(--duration-fast) var(--ease-out);
 }
 
@@ -686,7 +686,7 @@
 /* Advanced (collapsible section: summary stands in for the heading) */
 
 .cron-advanced__summary {
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .cron-advanced > .settings-section__desc {
@@ -731,7 +731,7 @@
   text-align: left;
   text-decoration: underline;
   text-underline-offset: 2px;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .cron-form-status__link:hover {
@@ -790,7 +790,7 @@
   text-align: left;
   padding: 7px 10px;
   border-radius: var(--radius-sm);
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .cron-job-menu__item:hover {
@@ -831,7 +831,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .cron-run-sort:hover {

--- a/ui/src/styles/cursor-policy.browser.test.ts
+++ b/ui/src/styles/cursor-policy.browser.test.ts
@@ -1,0 +1,190 @@
+// Control UI tests cover the display-mode cursor policy.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { readStyleSheet } from "../../../test/helpers/ui-style-fixtures.js";
+import {
+  canRunPlaywrightChromium,
+  resolvePlaywrightChromiumExecutablePath,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const describeCursorPolicy = canRunPlaywrightChromium(chromiumExecutablePath)
+  ? describe
+  : describe.skip;
+
+type CursorCase = {
+  /** Expected cursor in an installed/app window (`display-mode: standalone`). */
+  readonly appWindow: string;
+  /** Expected cursor in an ordinary tab (`display-mode: browser`). */
+  readonly browserTab: string;
+  readonly selector: string;
+};
+
+const CURSOR_CASES: readonly CursorCase[] = [
+  // Actionable controls follow the window they run in.
+  { appWindow: "default", browserTab: "pointer", selector: ".btn" },
+  { appWindow: "default", browserTab: "pointer", selector: "#plain-summary" },
+  { appWindow: "default", browserTab: "pointer", selector: "#plain-select" },
+  { appWindow: "default", browserTab: "pointer", selector: "#plain-checkbox" },
+  { appWindow: "default", browserTab: "pointer", selector: "#role-button" },
+  { appWindow: "default", browserTab: "pointer", selector: ".nav-item" },
+  { appWindow: "default", browserTab: "pointer", selector: ".settings-secret__toggle" },
+  // Real links keep the hand in both windows: a[href] through the UA, the
+  // href-less content link through its own documented rule.
+  { appWindow: "pointer", browserTab: "pointer", selector: "#real-link" },
+  { appWindow: "pointer", browserTab: "pointer", selector: ".markdown-file-link" },
+  // Semantic cursors belong to their component and never follow the policy.
+  { appWindow: "text", browserTab: "text", selector: "#plain-text-input" },
+  { appWindow: "text", browserTab: "text", selector: ".chat-pane__session-title-button" },
+  { appWindow: "grab", browserTab: "grab", selector: ".sidebar-session-group-drag-handle" },
+  { appWindow: "col-resize", browserTab: "col-resize", selector: ".sw-queue-resizer" },
+  { appWindow: "zoom-in", browserTab: "zoom-in", selector: ".chat-message-image-button" },
+  { appWindow: "not-allowed", browserTab: "not-allowed", selector: ".btn--ghost:disabled" },
+  { appWindow: "wait", browserTab: "wait", selector: ".sidebar-update-card__hold:disabled" },
+  // Deliberate `default` on non-actionable elements survives in both windows.
+  { appWindow: "default", browserTab: "default", selector: ".session-tokens" },
+  { appWindow: "default", browserTab: "default", selector: ".agent-tools-runtime-chip--more" },
+];
+
+function readUiCss(): string {
+  return [
+    "ui/src/styles/base.css",
+    "ui/src/styles/components.css",
+    "ui/src/styles/layout.css",
+    "ui/src/styles/sessions.css",
+    "ui/src/styles/settings.css",
+    "ui/src/styles/skill-workshop.css",
+    "ui/src/styles/chat/layout.css",
+    "ui/src/styles/chat/split-view.css",
+    "ui/src/styles/chat/text.css",
+  ]
+    .map((file) => readStyleSheet(file))
+    .join("\n");
+}
+
+function fixtureDocument(): string {
+  return `<!doctype html><html data-theme-mode="light"><head><style>${readUiCss()}</style></head><body>
+    <main>
+      <button class="btn" type="button">Primary</button>
+      <button class="btn btn--ghost" type="button" disabled>Ghost disabled</button>
+      <details><summary id="plain-summary">Details</summary><p>body</p></details>
+      <select id="plain-select"><option>option</option></select>
+      <input id="plain-checkbox" type="checkbox" />
+      <input id="plain-text-input" type="text" value="text" />
+      <div id="role-button" role="button" tabindex="0">Role button</div>
+      <a id="real-link" href="https://example.com">Real link</a>
+      <a class="nav-item" href="#/chat">Nav rail</a>
+      <button class="settings-secret__toggle" type="button">Reveal</button>
+      <button class="sidebar-update-card__hold" type="button" disabled>Hold</button>
+      <button class="chat-pane__session-title-button" type="button">Session title</button>
+      <button class="chat-message-image-button" type="button">Image</button>
+      <div class="sidebar-session-group-drag-handle"></div>
+      <div class="sw-queue-resizer"></div>
+      <div class="session-tokens"><span class="session-tokens__value">12k</span></div>
+      <span class="agent-tools-runtime-chip--more">+3</span>
+      <div class="chat-text"><a class="markdown-file-link">src/index.ts</a></div>
+    </main>
+  </body></html>`;
+}
+
+type WindowProbe = {
+  readonly cursors: Record<string, string>;
+  readonly displayMode: string;
+};
+
+async function probeWindow(page: Page): Promise<WindowProbe> {
+  return await page.evaluate(
+    (selectors: readonly string[]) => {
+      const modes = [
+        "browser",
+        "standalone",
+        "minimal-ui",
+        "window-controls-overlay",
+        "fullscreen",
+      ];
+      const cursors = selectors.map((selector) => {
+        const element = document.querySelector(selector);
+        if (!element) {
+          throw new Error(`Missing cursor fixture element for ${selector}`);
+        }
+        return [selector, getComputedStyle(element).cursor] as const;
+      });
+      return {
+        cursors: Object.fromEntries(cursors),
+        displayMode:
+          modes.find((mode) => matchMedia(`(display-mode: ${mode})`).matches) ?? "unknown",
+      };
+    },
+    CURSOR_CASES.map((cursorCase) => cursorCase.selector),
+  );
+}
+
+function expectedCursors(key: "appWindow" | "browserTab"): Record<string, string> {
+  return Object.fromEntries(
+    CURSOR_CASES.map((cursorCase) => [cursorCase.selector, cursorCase[key]]),
+  );
+}
+
+let fixtureDirectory: string;
+let fixtureFile: string;
+let tabBrowser: Browser;
+let appContext: BrowserContext;
+
+beforeAll(async () => {
+  if (!canRunPlaywrightChromium(chromiumExecutablePath)) {
+    return;
+  }
+  fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "cursor-policy-"));
+  fixtureFile = path.join(fixtureDirectory, "fixture.html");
+  fs.writeFileSync(fixtureFile, fixtureDocument(), "utf8");
+  tabBrowser = await chromium.launch({ executablePath: chromiumExecutablePath, headless: true });
+  try {
+    // `--app=` opens a real Chromium app window, which is the only way to get a
+    // genuine `display-mode: standalone` match; CDP media emulation does not
+    // drive this feature.
+    appContext = await chromium.launchPersistentContext(path.join(fixtureDirectory, "profile"), {
+      args: [`--app=file://${fixtureFile}`],
+      executablePath: chromiumExecutablePath,
+      headless: true,
+    });
+  } catch (error) {
+    await tabBrowser.close().catch(() => {});
+    throw error;
+  }
+});
+
+afterAll(async () => {
+  await appContext?.close().catch(() => {});
+  await tabBrowser?.close().catch(() => {});
+  if (fixtureDirectory) {
+    fs.rmSync(fixtureDirectory, { force: true, recursive: true });
+  }
+});
+
+describeCursorPolicy("Control UI cursor policy", () => {
+  it("advertises actionable controls with the hand in a browser tab", async () => {
+    const page = await tabBrowser.newPage();
+    try {
+      await page.goto(`file://${fixtureFile}`);
+      const probe = await probeWindow(page);
+
+      expect(probe.displayMode).toBe("browser");
+      expect(probe.cursors).toEqual(expectedCursors("browserTab"));
+    } finally {
+      await page.close().catch(() => {});
+    }
+  });
+
+  it("keeps the desktop arrow on app chrome in an installed window", async () => {
+    const [page] = appContext.pages();
+    expect(page, "Chromium --app window did not expose a page").toBeDefined();
+    await page!.waitForLoadState("load");
+    const probe = await probeWindow(page!);
+
+    expect(probe.displayMode).toBe("standalone");
+    expect(probe.cursors).toEqual(expectedCursors("appWindow"));
+  });
+});

--- a/ui/src/styles/cursor-policy.browser.test.ts
+++ b/ui/src/styles/cursor-policy.browser.test.ts
@@ -15,8 +15,14 @@ const describeCursorPolicy = canRunPlaywrightChromium(chromiumExecutablePath)
   ? describe
   : describe.skip;
 
+// What `DashboardWindowController.installNativeChromeScript` stamps on <html>.
+const NATIVE_HOST_MARKERS = ["openclaw-native-macos", "openclaw-native-web-chrome"] as const;
+
 type CursorCase = {
-  /** Expected cursor in an installed/app window (`display-mode: standalone`). */
+  /**
+   * Expected cursor in an installed/app window: a `display-mode: standalone`
+   * window, or a native app host that stamps `NATIVE_HOST_MARKERS` instead.
+   */
   readonly appWindow: string;
   /** Expected cursor in an ordinary tab (`display-mode: browser`). */
   readonly browserTab: string;
@@ -173,6 +179,24 @@ describeCursorPolicy("Control UI cursor policy", () => {
 
       expect(probe.displayMode).toBe("browser");
       expect(probe.cursors).toEqual(expectedCursors("browserTab"));
+    } finally {
+      await page.close().catch(() => {});
+    }
+  });
+
+  it("keeps the desktop arrow on app chrome in a native app host", async () => {
+    const page = await tabBrowser.newPage();
+    try {
+      await page.goto(`file://${fixtureFile}`);
+      // The macOS dashboard is a plain web view, so it reports display-mode
+      // browser and marks itself with these classes at document end instead.
+      await page.evaluate((markers: readonly string[]) => {
+        document.documentElement.classList.add(...markers);
+      }, NATIVE_HOST_MARKERS);
+      const probe = await probeWindow(page);
+
+      expect(probe.displayMode).toBe("browser");
+      expect(probe.cursors).toEqual(expectedCursors("appWindow"));
     } finally {
       await page.close().catch(() => {});
     }

--- a/ui/src/styles/cursor-policy.node.test.ts
+++ b/ui/src/styles/cursor-policy.node.test.ts
@@ -7,6 +7,12 @@ import { describe, expect, it } from "vitest";
 const stylesDir = path.dirname(fileURLToPath(import.meta.url));
 
 const APP_LIKE_MODES = ["standalone", "minimal-ui", "window-controls-overlay"] as const;
+/** `<html>` markers the native app hosts stamp; they report display-mode browser. */
+const NATIVE_HOST_MARKERS = [
+  "openclaw-native-macos",
+  "openclaw-native-nav",
+  "openclaw-native-web-chrome",
+] as const;
 
 function collectStyleSources(directory: string): string[] {
   return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -60,6 +66,18 @@ describe("Control UI cursor policy", () => {
     expect(appLikeQuery).not.toContain("fullscreen");
   });
 
+  it("gives the native app hosts the same arrow as an app-like display mode", () => {
+    const baseCss = fs.readFileSync(path.join(stylesDir, "base.css"), "utf8");
+
+    const nativeHostRule = baseCss.match(
+      /html:is\([^)]*\)\s*\{\s*--cursor-action:\s*default;/u,
+    )?.[0];
+    expect(nativeHostRule, "base.css must map the native host markers to the arrow").toBeDefined();
+    for (const marker of NATIVE_HOST_MARKERS) {
+      expect(nativeHostRule).toContain(`.${marker}`);
+    }
+  });
+
   it("repeats the same app-like mode list in the pre-boot mount fallback", () => {
     // The fallback ships its own inline stylesheet because it has to render when
     // the bundle fails to load, so the policy is duplicated there on purpose.
@@ -71,6 +89,17 @@ describe("Control UI cursor policy", () => {
     expect(fallbackQuery, "ui/index.html must keep the fallback on the policy").toBeDefined();
     for (const mode of APP_LIKE_MODES) {
       expect(fallbackQuery).toContain(`display-mode: ${mode}`);
+    }
+
+    const fallbackNativeRule = indexHtml.match(
+      /html:is\([^)]*\)\s*\.mount-fallback__button\s*\{\s*cursor:\s*default;/u,
+    )?.[0];
+    expect(
+      fallbackNativeRule,
+      "ui/index.html must keep the fallback on the native host policy",
+    ).toBeDefined();
+    for (const marker of NATIVE_HOST_MARKERS) {
+      expect(fallbackNativeRule).toContain(`.${marker}`);
     }
   });
 

--- a/ui/src/styles/cursor-policy.node.test.ts
+++ b/ui/src/styles/cursor-policy.node.test.ts
@@ -1,0 +1,93 @@
+// Control UI tests cover the cursor policy's source-level shape.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const stylesDir = path.dirname(fileURLToPath(import.meta.url));
+
+const APP_LIKE_MODES = ["standalone", "minimal-ui", "window-controls-overlay"] as const;
+
+function collectStyleSources(directory: string): string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === "node_modules" ? [] : collectStyleSources(entryPath);
+    }
+    if (!entry.isFile() || entry.name.includes(".test.")) {
+      return [];
+    }
+    return entry.name.endsWith(".css") || entry.name.endsWith(".ts") ? [entryPath] : [];
+  });
+}
+
+/** Walks back from a declaration line to the selector list that owns it. */
+function selectorFor(lines: readonly string[], declarationIndex: number): string {
+  const parts: string[] = [];
+  for (let index = declarationIndex - 1; index >= 0; index -= 1) {
+    const line = lines[index]?.trim() ?? "";
+    if (line.endsWith("{")) {
+      parts.unshift(line.slice(0, -1).trim());
+      for (let above = index - 1; above >= 0 && lines[above]?.trim().endsWith(","); above -= 1) {
+        parts.unshift(lines[above]!.trim());
+      }
+      break;
+    }
+    if (line === "" || line.endsWith("}")) {
+      break;
+    }
+  }
+  return parts.join(" ");
+}
+
+const ANCHOR_SELECTOR = /(^|[\s,(>~+])a([.#:[]|\b)/u;
+
+describe("Control UI cursor policy", () => {
+  it("selects the cursor token by display mode and leaves fullscreen alone", () => {
+    const baseCss = fs.readFileSync(path.join(stylesDir, "base.css"), "utf8");
+
+    expect(baseCss).toMatch(/:root\s*\{[^}]*--cursor-action:\s*pointer;/u);
+
+    const appLikeQuery = baseCss.match(
+      /@media\s*\(display-mode:[^{]*\{\s*:root\s*\{\s*--cursor-action:\s*default;/u,
+    )?.[0];
+    expect(appLikeQuery, "base.css must map app-like display modes to the arrow").toBeDefined();
+    for (const mode of APP_LIKE_MODES) {
+      expect(appLikeQuery).toContain(`display-mode: ${mode}`);
+    }
+    // `fullscreen` is a transient presentation state any window can enter; the
+    // manifest installs this UI as `standalone`, so it never appears here.
+    expect(appLikeQuery).not.toContain("fullscreen");
+  });
+
+  it("repeats the same app-like mode list in the pre-boot mount fallback", () => {
+    // The fallback ships its own inline stylesheet because it has to render when
+    // the bundle fails to load, so the policy is duplicated there on purpose.
+    const indexHtml = fs.readFileSync(path.join(stylesDir, "..", "..", "index.html"), "utf8");
+
+    const fallbackQuery = indexHtml.match(
+      /@media\s*\(display-mode:[^{]*\{\s*\.mount-fallback__button\s*\{\s*cursor:\s*default;/u,
+    )?.[0];
+    expect(fallbackQuery, "ui/index.html must keep the fallback on the policy").toBeDefined();
+    for (const mode of APP_LIKE_MODES) {
+      expect(fallbackQuery).toContain(`display-mode: ${mode}`);
+    }
+  });
+
+  it("keeps the unconditional pointer hand on link rules only", () => {
+    const offenders = collectStyleSources(path.join(stylesDir, ".."))
+      .flatMap((filePath) => {
+        const lines = fs.readFileSync(filePath, "utf8").split("\n");
+        return lines.flatMap((line, index) =>
+          /^\s*cursor:\s*pointer;\s*$/u.test(line)
+            ? [{ file: path.relative(stylesDir, filePath), selector: selectorFor(lines, index) }]
+            : [],
+        );
+      })
+      .filter((hit) => !ANCHOR_SELECTOR.test(hit.selector));
+
+    // Controls consume var(--cursor-action); a hardcoded hand is how the policy
+    // drifted apart before (92 declarations by the time it was caught).
+    expect(offenders).toEqual([]);
+  });
+});

--- a/ui/src/styles/custodian.css
+++ b/ui/src/styles/custodian.css
@@ -209,7 +209,7 @@ openclaw-custodian-page {
 .custodian__nudge-action {
   padding: 5px 2px;
   text-align: left;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .custodian__nudge-action:disabled {
@@ -225,7 +225,7 @@ openclaw-custodian-page {
   place-items: center;
   border-radius: 50%;
   color: var(--muted);
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .custodian__nudge-action:focus-visible,
@@ -418,7 +418,7 @@ openclaw-custodian-page {
 
 .custodian__change-paths summary {
   width: fit-content;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .custodian__change-paths ul {

--- a/ui/src/styles/devices.css
+++ b/ui/src/styles/devices.css
@@ -42,7 +42,7 @@
 .device-entry__details > summary {
   color: var(--muted);
   user-select: none;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .device-entry__details > summary:hover {
@@ -83,7 +83,7 @@
   font-size: var(--control-ui-text-sm);
   color: var(--muted);
   user-select: none;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .device-group__dups > summary:hover {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -502,7 +502,7 @@ html.openclaw-native-web-chrome .shell-chrome-controls {
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
-  cursor: default;
+  cursor: var(--cursor-action);
   text-decoration: none;
   transition:
     border-color var(--duration-fast) ease,
@@ -574,7 +574,7 @@ html.openclaw-native-web-chrome .shell-chrome-controls {
   padding: 0 9px;
   border-radius: var(--radius-sm);
   color: var(--text);
-  cursor: default;
+  cursor: var(--cursor-action);
   text-decoration: none;
 }
 
@@ -1059,7 +1059,7 @@ openclaw-settings-save-indicator {
   color: inherit;
   font: inherit;
   text-align: left;
-  cursor: default;
+  cursor: var(--cursor-action);
 }
 
 .sidebar-attention__dismiss {
@@ -1071,7 +1071,7 @@ openclaw-settings-save-indicator {
   border: 0;
   background: transparent;
   color: var(--muted);
-  cursor: default;
+  cursor: var(--cursor-action);
   opacity: 0.6;
 }
 
@@ -1189,7 +1189,7 @@ html.openclaw-native-macos
   border-radius: var(--radius-lg);
   background: color-mix(in srgb, var(--accent-subtle) 48%, var(--bg-elevated));
   color: var(--text);
-  cursor: pointer;
+  cursor: var(--cursor-action);
   text-align: left;
   transition:
     background var(--duration-fast) ease,
@@ -1216,7 +1216,7 @@ html.openclaw-native-macos
   border-radius: var(--radius-lg);
   background: var(--bg-elevated);
   color: var(--muted);
-  cursor: pointer;
+  cursor: var(--cursor-action);
   font-size: 11px;
   font-weight: 600;
   white-space: nowrap;
@@ -1305,7 +1305,7 @@ html.openclaw-native-macos
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .sidebar-update-card__dismiss:hover {
@@ -1370,9 +1370,9 @@ html.openclaw-native-macos
   flex-direction: column;
   gap: 10px;
   margin: 0 -8px;
-  /* Sessions are app chrome, not hyperlinks: the whole region uses the
-     default arrow cursor; the pointer hand is reserved for real links. */
-  cursor: default;
+  /* Sessions are app chrome, not hyperlinks: the whole region follows the
+     base.css cursor policy so it tracks the window it is running in. */
+  cursor: var(--cursor-action);
 }
 
 .sidebar-shell__body--scroll-top {
@@ -1847,7 +1847,7 @@ html.openclaw-native-macos
   background: transparent;
   color: color-mix(in srgb, var(--muted) 35%, var(--text) 65%);
   font: inherit;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   text-align: left;
   transition:
     background var(--duration-fast) ease,
@@ -1961,7 +1961,7 @@ html.openclaw-native-macos
   padding-right: 4px;
   border-radius: var(--radius-md);
   color: var(--muted);
-  cursor: default;
+  cursor: var(--cursor-action);
   transition:
     background var(--duration-fast) ease,
     color var(--duration-fast) ease;
@@ -1997,7 +1997,7 @@ html.openclaw-native-macos
   min-width: 0;
   padding: 3px 4px 3px 0;
   color: inherit;
-  cursor: default;
+  cursor: var(--cursor-action);
   text-decoration: none;
 }
 
@@ -2200,7 +2200,7 @@ html.openclaw-native-macos
   border: none;
   border-radius: var(--radius-full);
   background: none;
-  cursor: default;
+  cursor: var(--cursor-action);
 }
 
 .viewer-facepile-trigger:hover,
@@ -2488,8 +2488,8 @@ wa-dropdown.sidebar-customize-menu::part(menu) {
   font: inherit;
   font-size: 13px;
   text-align: left;
-  /* More-menu route rows are anchors acting as chrome (see base.css cursor convention). */
-  cursor: default;
+  /* More-menu route rows are anchors acting as chrome (see base.css cursor policy). */
+  cursor: var(--cursor-action);
   text-decoration: none;
 }
 
@@ -2849,7 +2849,7 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   border: 1px solid transparent;
   background: transparent;
   color: var(--muted);
-  cursor: default;
+  cursor: var(--cursor-action);
   text-decoration: none;
   transition:
     border-color var(--duration-fast) ease,
@@ -3054,7 +3054,7 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   border-radius: var(--radius-md);
   background: transparent;
   text-align: left;
-  cursor: default;
+  cursor: var(--cursor-action);
   transition: background var(--duration-fast) ease;
 }
 
@@ -3185,7 +3185,7 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
-  cursor: default;
+  cursor: var(--cursor-action);
   transition:
     color var(--duration-fast) ease,
     background var(--duration-fast) ease;
@@ -3241,7 +3241,7 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   color: var(--text);
   font: inherit;
   text-align: left;
-  cursor: default;
+  cursor: var(--cursor-action);
   transition: background var(--duration-fast) ease;
 }
 
@@ -3486,7 +3486,7 @@ openclaw-tooltip.sidebar-hover-tooltip {
   border-radius: var(--radius-full);
   background: color-mix(in srgb, var(--danger) 12%, transparent);
   color: var(--danger);
-  cursor: pointer;
+  cursor: var(--cursor-action);
   font-family: inherit;
   font-size: 11px;
   font-weight: 600;

--- a/ui/src/styles/lobster-pet.css
+++ b/ui/src/styles/lobster-pet.css
@@ -1466,7 +1466,7 @@ openclaw-lobster-pet[data-dex-complete]::after {
   height: 20px;
   transform: translateX(-50%);
   pointer-events: auto;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   user-select: none;
   -webkit-user-select: none;
   -webkit-tap-highlight-color: transparent;
@@ -1727,7 +1727,7 @@ openclaw-lobster-pet[data-dex-complete]::after {
   background: color-mix(in srgb, var(--card) 82%, transparent);
   opacity: 0;
   pointer-events: none;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   transition:
     opacity 0.16s ease,
     color 0.16s ease,

--- a/ui/src/styles/memory-import.css
+++ b/ui/src/styles/memory-import.css
@@ -33,7 +33,7 @@
   padding: 7px 12px;
   border-top: 1px solid var(--border);
   color: var(--muted);
-  cursor: pointer;
+  cursor: var(--cursor-action);
   font-size: 10px;
   font-weight: 650;
   list-style: none;
@@ -59,7 +59,7 @@
   align-items: flex-start;
   gap: 9px;
   min-width: 0;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .memory-import__collection-choice input {

--- a/ui/src/styles/model-setup.css
+++ b/ui/src/styles/model-setup.css
@@ -171,7 +171,7 @@
 }
 
 .model-setup__more summary {
-  cursor: pointer;
+  cursor: var(--cursor-action);
   color: var(--muted);
   font-weight: 600;
 }
@@ -226,7 +226,7 @@
   font: inherit;
   outline: none;
   text-align: left;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 :root[data-theme-mode="light"] .model-setup-provider-select__trigger {

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -65,7 +65,7 @@ openclaw-new-session-page {
   color: var(--muted);
   font: inherit;
   font-size: 11px;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .new-session-page__visibility:hover:not(:disabled),
@@ -156,7 +156,7 @@ openclaw-new-session-page {
   font-size: 12px;
   color: var(--muted);
   list-style: none;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   user-select: none;
   border: 0;
   border-radius: 999px;
@@ -426,7 +426,7 @@ wa-dropdown.new-session-page__start-menu {
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .new-session-page__browser-nav:hover:not(:disabled) {
@@ -492,7 +492,7 @@ wa-dropdown.new-session-page__start-menu {
   color: var(--text);
   font-size: 13px;
   text-align: left;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .new-session-page__browser-entry:hover {
@@ -582,7 +582,7 @@ wa-dropdown.new-session-page__start-menu {
   color: var(--primary-foreground);
   font-size: 13px;
   font-weight: 600;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .new-session-page__browser-use:disabled {

--- a/ui/src/styles/onboarding-memory-import.css
+++ b/ui/src/styles/onboarding-memory-import.css
@@ -52,7 +52,7 @@
   display: flex;
   align-items: flex-start;
   gap: 12px;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .onboarding-memory-import__provider input {

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -83,7 +83,7 @@
  * expand/collapse the pre-migration skill groups had (cfg-object pattern). */
 .skills-group__summary {
   align-items: center;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   list-style: none;
 }
 
@@ -178,7 +178,7 @@
 }
 
 .plugins-item--clickable {
-  cursor: pointer;
+  cursor: var(--cursor-action);
   transition: background var(--duration-fast) var(--ease-out);
 }
 
@@ -196,7 +196,7 @@
   color: inherit;
   font: inherit;
   text-align: left;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .plugins-item__detail-button:focus-visible {

--- a/ui/src/styles/sessions.css
+++ b/ui/src/styles/sessions.css
@@ -169,7 +169,7 @@
   text-align: left;
   background: transparent;
   border: 0;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   transition: background var(--duration-fast) var(--ease-out);
 }
 

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -157,7 +157,7 @@
   background: transparent;
   color: var(--muted);
   font: 600 var(--control-ui-text-xs) / 1 var(--font-sans);
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .settings-section__help-button > span {
@@ -243,7 +243,7 @@
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .config-advanced-divider__toggle:hover {
@@ -376,7 +376,7 @@
 
 /* Label-wrapped toggle row: whole row toggles the switch. */
 .settings-row--toggle {
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .settings-row--toggle:has(wa-switch[disabled]) {
@@ -391,7 +391,7 @@
   font: inherit;
   text-align: left;
   color: inherit;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   transition: background var(--duration-fast) var(--ease-out);
 }
 
@@ -474,7 +474,7 @@ select.settings-select:not([multiple]) {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .settings-control__sr-label {
@@ -530,7 +530,7 @@ wa-radio-group.settings-segmented::part(radios) {
   background: transparent;
   color: var(--muted);
   white-space: nowrap;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   transition:
     color var(--duration-normal) var(--ease-out),
     background var(--duration-normal) var(--ease-out),
@@ -693,7 +693,7 @@ select.settings-select:not([multiple]) {
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
+  cursor: var(--cursor-action);
   transition: color var(--duration-fast) var(--ease-out);
 }
 
@@ -745,7 +745,7 @@ wa-select.settings-select::part(combobox) {
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--bg) 80%, var(--bg-elevated) 20%);
   color: var(--text);
-  cursor: default;
+  cursor: var(--cursor-action);
   transition: border-color var(--duration-fast) var(--ease-out);
 }
 
@@ -782,7 +782,7 @@ wa-select.settings-select wa-option {
   border-radius: calc(var(--radius-md) - 4px);
   font-size: var(--control-ui-text-md);
   color: var(--text);
-  cursor: default;
+  cursor: var(--cursor-action);
 }
 
 /* The roving "current" option already carries the accent fill; the global

--- a/ui/src/styles/usage.css
+++ b/ui/src/styles/usage.css
@@ -827,7 +827,7 @@
   font-family: inherit;
   font-size: 12px; /* was 9px */
   line-height: 1;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   opacity: 0.7;
   transition:
     border-color 0.15s var(--ease-out),
@@ -1090,7 +1090,7 @@
 .usage-hour-cell {
   min-height: 46px;
   padding: 0;
-  cursor: pointer;
+  cursor: var(--cursor-action);
   appearance: none;
   transition:
     transform 0.18s var(--ease-out),
@@ -1536,7 +1536,7 @@
   color: inherit;
   font: inherit;
   text-align: left;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .session-bar-selection:focus-visible {

--- a/ui/src/styles/wizard-step-controls.css
+++ b/ui/src/styles/wizard-step-controls.css
@@ -35,7 +35,7 @@
   padding: 10px;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .wizard-step__option small {

--- a/ui/src/styles/workboard.css
+++ b/ui/src/styles/workboard.css
@@ -1355,7 +1355,7 @@ openclaw-workboard-card-dashboard {
   border: 0;
   color: var(--muted);
   background: transparent;
-  cursor: pointer;
+  cursor: var(--cursor-action);
 }
 
 .workboard-card-dashboard__toggle:focus-visible {

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -94,6 +94,7 @@ const nodeDrivenBrowserLayoutTests = [
   "src/pages/chat/chat-responsive.browser.test.ts",
   "src/components/form-controls.browser.test.ts",
   "src/pages/sessions/view.browser.test.ts",
+  "src/styles/cursor-policy.browser.test.ts",
 ] as const;
 const mockRegistryUnitTests = [
   ...uiIsolatedTestFiles.map((testFile) => testFile.slice("ui/".length)),


### PR DESCRIPTION
Closes #121242

## What Problem This Solves

The Control UI cursor convention was written for an installed app window but applied to every window the same bundle is served into. In an ordinary browser tab, buttons, menus, tabs, nav rails, selects and accordion summaries showed the desktop arrow — removing the only hover affordance a web page owns. Installation is opt-in and the terminal-first setup hands operators a URL, so the browser tab is the default path.

The convention had also drifted: `ui/src/**` was back to **92** `cursor: pointer` declarations across 31 files (only one of them a real link rule), so neither window presented one coherent convention — most surfaces showed the arrow while 92 showed the hand, including inside the installed window the convention was written for.

### Verified provenance

Roles separated; no inference about anyone's intent beyond what the PRs and commits record.

| Role | Evidence |
| --- | --- |
| Convention introduced | PR #103357 — code author **@steipete**, PR author **@steipete**, merged by **@steipete**, 2026-07-10, landed `d3fae3c783`. Recorded rationale: *"Desktop-style app chrome should use the default arrow cursor and reserve the pointer hand for real hyperlinks."* |
| Convention generalized | PR #103411 — code author **@steipete**, PR author **@steipete**, merged by **@steipete**, 2026-07-10, landed `a39a3ee1d0` (+22/−177, 24 files). Same commit authored the `base.css` convention comment (`git blame -L 696,699 -- ui/src/styles/base.css` → `a39a3ee1d0a`). |
| Follow-on fixes | PR #103448 (`7d87cedcda`) for #103444 (mount fallback); PR #110469 (`d8b1831769`) for Web Awesome dropdown items. |
| App-window premise | `ui/public/manifest.webmanifest` declares `"display": "standalone"` — PR #44590, author **@eduardocruz**, merged 2026-04-25 (`21b7ad58054`). |
| Display mode already a signal here | `base.css` already branched on `@media (display-mode: standalone)` for viewport/safe-area insets — PR #76072, author **@kvncrw**, merged 2026-05-02 (`d22da871266`). |

Neither #103357 nor #103411 has any recorded discussion of `display-mode`; their review threads contain no comments on it. This is an un-evaluated premise, not a rejected one. Both PRs remain correct for the window they describe, and this change does not revert either.

Current PR author: **@vyctorbrzezowski**. `Provenance: introduced by a39a3ee1d0 (PR #103411; code author @steipete, PR author @steipete, merged by @steipete, 2026-07-10), carried forward by the 92 later declarations. Confidence: clear.`

## Why This Change Was Made

**Root cause:** the cursor policy encoded a *window-type* decision as an unconditional global rule. `standalone` is one of several display modes the bundle is served into, and the stylesheet never read which one it was in.

**Architectural owner:** `ui/src/styles/base.css` — where the convention is declared and where every other stylesheet's comment points (`ui/src/styles/layout.css:2491`). Per-component stylesheets are consumers; they should not each re-decide window-type policy.

**The fix.** `base.css` now owns one policy token:

- `--cursor-action` defaults to `pointer`, and resolves to `default` under `standalone`, `minimal-ui`, and `window-controls-overlay`. The base value is the browser-tab value, so an unsupported or unenumerated mode degrades to keeping the affordance.
- One low-specificity rule maps generic actionable controls (`button`, `summary`, `select`, clickable `input` types, and the standard interactive ARIA roles) onto the token. This restores the affordance on the surfaces #103411 stripped bare (~160 declarations removed there), with no component allowlist.
- The 92 drifted declarations now consume the token instead of hardcoding the hand, so they stop contradicting the policy in an installed window.
- Native app hosts are the same window class arriving without a display mode. The macOS dashboard embeds this bundle in a plain web view, which reports `display-mode: browser`; it announces itself by stamping `openclaw-native-macos`/`openclaw-native-nav`/`openclaw-native-web-chrome` on `<html>` instead (`apps/macos/Sources/OpenClaw/DashboardWindowController.swift:808`). Those markers resolve the token to `default` as well, so the installed Mac app keeps the arrow it has always had. The selector lists all three because that is exactly what `ui/src/styles/layout.css:3812` already matches on for the same "is this a native host" question.
- The pre-boot mount fallback in `ui/index.html` repeats the policy locally — it has to render when the bundle fails to load, so it cannot read `base.css` tokens. That duplication is deliberate and commented.

Element/attribute specificity only: no `!important`, no selector escalation, no new fallback stack, and every existing component rule keeps winning naturally.

**`fullscreen` is deliberately excluded.** I checked this in Chromium rather than assuming: entering fullscreen from a tab via the Fullscreen API sets `document.fullscreenElement` but leaves `matchMedia("(display-mode: fullscreen)")` false, so it would not even fire there. Independently of UA behavior, fullscreen is a transient presentation state any window can enter, and the manifest installs this UI as `standalone` — so it is never evidence of an installed window.

### Alternatives considered and rejected

1. **Re-add per-component `cursor: pointer`.** Reintroduces the duplicate policy #103411 removed and still ignores display mode. Rejected.
2. **Runtime `matchMedia` class toggle in JS.** Adds a runtime owner and a flash of the wrong cursor before boot, for something CSS answers declaratively — and the mount fallback renders before any JS runs. Rejected.
3. **Drop the app-chrome convention entirely.** Discards a deliberate, documented product decision that is correct in installed windows. Rejected.
4. **Delete the 92 declarations the canonical rule already covers.** Tempting for LOC, but ~10 of them sit on `div`/`article`/`span`/Web Awesome custom elements the generic rule does not match, and confirming the rest needs per-site markup verification. A wrong deletion is a silent affordance loss. Left as a named follow-up below; the policy itself is already centralized in the token, so this is cleanup, not correctness.

### Follow-up recorded

Collapsing the per-component `cursor: var(--cursor-action)` declarations that the canonical rule already covers is a safe mechanical cleanup once each site's element type is verified. Not bundled here to keep this diff behavior-preserving in browser mode.

## User Impact

- **Browser tab:** buttons, menus, tabs, nav rails, session rows, selects, checkboxes and accordion summaries show the pointer hand again.
- **Installed / app-like window:** unchanged — app chrome keeps the desktop arrow, now including the 92 surfaces that had drifted back to the hand.
- **Native macOS dashboard:** unchanged — the app window keeps the desktop arrow, on the same 92 surfaces plus the generic control rule.
- **Real hyperlinks:** pointer in every mode, unchanged.
- **Accessibility:** hover-only. No element changed type, role, name, keyboard behavior, focus ring, focus order, hit target, or contrast. Cursor never substitutes for semantics.

**Semantic cursor exceptions preserved in both modes** (verified by computed style, not by reading the diff): `text` (text inputs, `.chat-pane__session-title-button`), `grab`/`grabbing` (drag handles), `col-resize`/`ns-resize`/`ew-resize`/`row-resize`/`nwse-resize` (dividers), `zoom-in` (image buttons), `crosshair`, `help`, `copy`, `progress`/`wait` (busy controls), `not-allowed` and `default` on disabled controls, and deliberate `default` on non-actionable elements such as `.session-tokens`, `.agent-tools-runtime-chip--more`, `.chat-pr__link--static` and `.new-session-page__runtime`.

## Evidence

### Production vs test LOC

`git diff --numstat $(git merge-base HEAD origin/main)..HEAD`, classified per file across 37 files:

| | + | − | net |
| --- | --- | --- | --- |
| Production | 191 | 116 | **+75** |
| Tests (incl. the `ui/vitest.config.ts` routing entry) | 342 | 3 | +339 |

**106** of the changed production lines are the 1:1 mechanical swap (`cursor: pointer` / chrome `cursor: default` → `cursor: var(--cursor-action)`), which is net zero. The remaining **+75** is the policy itself: the token, the display-mode query, the native-host branch, the canonical control rule with its contract comments (`base.css`), the mount-fallback copy (`ui/index.html`), and the stylelint entry below. Justification under Repair Doctrine: a concrete capability (display-mode-aware cursor policy) established at its architectural owner boundary, replacing a decision that previously had no owner.

### Real-browser behavior proof

Two windows against the same mocked Control UI (`pnpm dev:ui:mock`, `/chat`, 1280×820, light theme, identical crop and scroll state). A screenshot cannot capture the OS cursor, so each capture carries an overlay reporting the computed `cursor` for the same elements in the same page state. The only visual difference between a before/after pair is the live mock's elapsed-time counter.

**Ordinary browser tab (`display-mode: browser`) — the bug and the fix**

| Before | After |
| --- | --- |
| <img width="640" alt="Control UI in a browser tab before the change: overlay reports nav rail item, button, sidebar session row and new session all resolving to cursor default; composer text input text; real hyperlink pointer" src="https://github.com/user-attachments/assets/31dab5bb-cc1c-4064-8084-bf5dbf858b28" /> | <img width="640" alt="Control UI in a browser tab after the change: overlay reports nav rail item, button, sidebar session row and new session all resolving to cursor pointer; composer text input still text; real hyperlink still pointer" src="https://github.com/user-attachments/assets/e8cc2ae0-5b25-4e92-823c-162c6e833539" /> |
| Every actionable control resolves to `default`. | The same controls resolve to `pointer`; the semantic `text` input and the real hyperlink are untouched. |

**Installed app window (`display-mode: standalone`) — proof the app behavior is preserved**

| Before | After |
| --- | --- |
| <img width="640" alt="Control UI in an installed standalone app window before the change: overlay reports all app chrome resolving to cursor default and the real hyperlink to pointer" src="https://github.com/user-attachments/assets/3f332365-311c-442e-b953-6c6f6bdcfa05" /> | <img width="640" alt="Control UI in an installed standalone app window after the change: overlay reports all app chrome still resolving to cursor default and the real hyperlink still pointer" src="https://github.com/user-attachments/assets/6fff4124-2c08-4703-84df-9f262f56c43f" /> |
| App chrome is `default`. | App chrome is still `default` — unchanged. |

**Native macOS dashboard host — proof the app behavior is preserved there too**

The Mac dashboard is a plain web view: it reports `display-mode: browser` and identifies itself with the `<html>` markers above. Same mock, same viewport, same overlay, with those markers stamped exactly as `installNativeChromeScript` stamps them.

| Before | After |
| --- | --- |
| <img width="640" alt="Control UI with the native macOS host markers stamped, before the native-host rule: overlay reports display-mode browser, html classes openclaw-native-macos openclaw-native-web-chrome, and nav rail item, button, topbar icon button and new session all resolving to cursor pointer" src="https://github.com/user-attachments/assets/030222cc-3674-4217-aa59-4b12fa9e590f" /> | <img width="640" alt="Control UI with the native macOS host markers stamped, after the native-host rule: overlay reports the same display-mode browser and html classes, with nav rail item, button, topbar icon button and new session all back to cursor default; composer input still text and the real hyperlink still pointer" src="https://github.com/user-attachments/assets/1a7f66b4-14ff-4c85-934d-9ac447c9f153" /> |
| App chrome had become `pointer` — the regression ClawSweeper flagged. | App chrome is `default` again, matching every shipped Mac app build. The semantic `text` input and the real hyperlink are untouched. |

Both captures assert `display-mode: browser` and print the marker classes they are running under, so the reading cannot be confused with the standalone case above.

The standalone window is a real Chromium app window (`--app=`), not media emulation: CDP `Emulation.setEmulatedMedia` does not drive the `display-mode` feature (verified — it kept reporting `browser`), so emulation would have proven nothing. Each capture asserts its own `display-mode` before reading cursors.

### Tests

New `ui/src/styles/cursor-policy.browser.test.ts` — Playwright-from-Node, same lane as the existing `form-controls.browser.test.ts`. It renders one fixture in three real windows (ordinary tab; the same tab with the native macOS host markers stamped; and a Chromium `--app=` window), asserts each window's own `display-mode` first, then asserts the complete cursor table in one comparison: actionable controls flip, real links stay `pointer`, and every semantic cursor (`text`, `grab`, `col-resize`, `zoom-in`, `not-allowed`, `wait`, deliberate `default`) is unchanged in both.

New `ui/src/styles/cursor-policy.node.test.ts` — guards the drift that caused this bug: the token exists, the app-like query lists exactly `standalone`/`minimal-ui`/`window-controls-overlay` and never `fullscreen`, the native-host markers resolve the token to the arrow, the mount fallback repeats both the same mode list and the same marker list, and no `ui/src` stylesheet hardcodes `cursor: pointer` outside a rule targeting an anchor.

Updated `ui/src/components/form-controls.browser.test.ts` — the mount-fallback assertion from #103448 now expects the hand in a browser tab, matching the new contract.

`minimal-ui` and `window-controls-overlay` are covered at the policy level (source test) rather than by a live window: Chromium exposes no launch flag that produces them. Stated openly rather than implied.

### Exact-head proof

Head `8f6a7e4a588` (`66d985bea3b` plus the native-host commit). Proof for the first two commits ran the full `checks-ui` lane exactly as CI runs it on a Blacksmith Testbox (`ensure-playwright-chromium` → `pnpm lint:ui:no-raw-window-open` → `pnpm --dir ui vitest run --maxWorkers 3`): **580 files, 8619 tests passed, 1 skipped, exit 0**; plus `pnpm check:changed` (`CI=1`) exit 0 across lanes `coreTests, ui, tooling`, `pnpm lint:ui:styles` clean, and `oxfmt` clean.

For the native-host commit on top:

- `ui` cursor-policy and form-controls lanes, real Chromium: **3 files, 14 tests passed, exit 0** — including the new `keeps the desktop arrow on app chrome in a native app host` case.
- `pnpm lint:ui:styles` — clean (Testbox). `oxfmt` — clean on the changed files.
- Real-behavior capture above, taken against the running mock Control UI with the native markers stamped.
- Fresh structured autoreview on the exact head.
- Zero merge conflicts against current `main`.

The second commit exists because `ui/vitest.config.ts` keeps an explicit list of the `*.browser.test.ts` files that are Playwright-from-Node rather than in-browser; the first push did not register the new test there, so the in-browser `chromium` project tried to import it and failed on `node:fs`/`playwright`. Caught by exact-head CI on `556ed400e7`, fixed by registering it alongside `form-controls.browser.test.ts`, and re-proven with the full lane above.

`config/stylelint.config.mjs` gained one entry: stylelint 17.14.1 knows `display-mode` as `fullscreen | standalone | minimal-ui | browser | picture-in-picture` (`lib/reference/mediaFeatures.mjs`), predating `window-controls-overlay`. The config allows that single value so typos in the rest still fail, matching how this repo handles rule exceptions (centrally and commented) rather than inline suppressions — `ui/src` has none.

### Status

ClawSweeper's review of `66d985bea3b` is answered in full: the native macOS host regression is repaired at the same owner boundary with real-window proof and focused coverage, and the reported task-suggestion layout hunk does not exist in this branch (details in the review response comment). No merge, release, or issue closure performed by this PR.

