### PR TITLE
fix: prevent startup failures from obsolete managed plugin shadows

### DIFF
--- a/src/cli/update-cli/post-core-plugin-convergence.test.ts
+++ b/src/cli/update-cli/post-core-plugin-convergence.test.ts
@@ -7,6 +7,7 @@ import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js"
 
 const mocks = vi.hoisted(() => ({
   listManagedPluginNpmRoots: vi.fn(),
+  maybeRepairStaleManagedNpmBundledPlugins: vi.fn(),
   repairMissingConfiguredPluginInstalls: vi.fn(),
   relinkOpenClawPeerDependenciesInManagedNpmRoot: vi.fn(),
   runPluginPayloadSmokeCheck: vi.fn(),
@@ -14,6 +15,9 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../../commands/doctor/shared/missing-configured-plugin-install.js", () => ({
   repairMissingConfiguredPluginInstalls: mocks.repairMissingConfiguredPluginInstalls,
+}));
+vi.mock("../../commands/doctor-plugin-registry.js", () => ({
+  maybeRepairStaleManagedNpmBundledPlugins: mocks.maybeRepairStaleManagedNpmBundledPlugins,
 }));
 vi.mock("../../plugins/plugin-peer-link.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../plugins/plugin-peer-link.js")>();
@@ -23,15 +27,20 @@ vi.mock("../../plugins/plugin-peer-link.js", async (importOriginal) => {
       mocks.relinkOpenClawPeerDependenciesInManagedNpmRoot,
   };
 });
-vi.mock("../../plugins/npm-project-roots.js", () => ({
-  listManagedPluginNpmRoots: mocks.listManagedPluginNpmRoots,
-}));
+vi.mock("../../plugins/npm-project-roots.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../plugins/npm-project-roots.js")>();
+  return {
+    ...actual,
+    listManagedPluginNpmRoots: mocks.listManagedPluginNpmRoots,
+  };
+});
 vi.mock("./plugin-payload-validation.js", () => ({
   runPluginPayloadSmokeCheck: mocks.runPluginPayloadSmokeCheck,
 }));
 
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
+import { resolvePluginNpmGenerationProjectDir } from "../../plugins/install-paths.js";
 import { VERSION } from "../../version.js";
 import {
   filterRecordsToActive,
@@ -50,6 +59,7 @@ describe("runPostCorePluginConvergence", () => {
     mocks.listManagedPluginNpmRoots.mockImplementation((npmRoot: string) =>
       Promise.resolve([npmRoot]),
     );
+    mocks.maybeRepairStaleManagedNpmBundledPlugins.mockReturnValue(false);
     mocks.repairMissingConfiguredPluginInstalls.mockResolvedValue({
       changes: [],
       warnings: [],
@@ -64,7 +74,11 @@ describe("runPostCorePluginConvergence", () => {
     mocks.runPluginPayloadSmokeCheck.mockResolvedValue({ checked: [], failures: [] });
   });
 
-  function writeBundledPlugin(rootDir: string, pluginId: string): string {
+  function writeBundledPlugin(
+    rootDir: string,
+    pluginId: string,
+    version = "2026.5.20-beta.1",
+  ): string {
     const pluginDir = path.join(rootDir, pluginId);
     fs.mkdirSync(pluginDir, { recursive: true });
     fs.writeFileSync(path.join(pluginDir, "index.js"), "export default {};\n", "utf8");
@@ -73,7 +87,7 @@ describe("runPostCorePluginConvergence", () => {
       JSON.stringify({
         id: pluginId,
         name: pluginId,
-        version: "2026.5.20-beta.1",
+        version,
         configSchema: { type: "object" },
       }),
       "utf8",
@@ -82,7 +96,7 @@ describe("runPostCorePluginConvergence", () => {
       path.join(pluginDir, "package.json"),
       JSON.stringify({
         name: `@openclaw/${pluginId}`,
-        version: "2026.5.20-beta.1",
+        version,
       }),
       "utf8",
     );
@@ -96,6 +110,15 @@ describe("runPostCorePluginConvergence", () => {
       env: { OPENCLAW_UPDATE_IN_PROGRESS: "1" },
     });
     expect(mocks.repairMissingConfiguredPluginInstalls).toHaveBeenCalledTimes(1);
+    expect(mocks.maybeRepairStaleManagedNpmBundledPlugins).toHaveBeenCalledWith({
+      config: cfg,
+      env: {
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_COMPATIBILITY_HOST_VERSION: VERSION,
+        OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
+      },
+      prompter: { shouldRepair: true },
+    });
     expect(mocks.repairMissingConfiguredPluginInstalls).toHaveBeenCalledWith({
       cfg,
       env: {
@@ -104,6 +127,9 @@ describe("runPostCorePluginConvergence", () => {
         OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
       },
     });
+    expect(mocks.maybeRepairStaleManagedNpmBundledPlugins.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.repairMissingConfiguredPluginInstalls.mock.invocationCallOrder[0],
+    );
   });
 
   it("checks active payloads without running repair or peer-link convergence", async () => {
@@ -370,6 +396,54 @@ describe("runPostCorePluginConvergence", () => {
       'Removed stale local bundled plugin install record "discord".',
     ]);
     expect(result.installRecords).toEqual({ brave: baseline.brave });
+  });
+
+  it("retires a stale managed generation when its official plugin is now bundled", async () => {
+    const stateDir = tempDirs.make("openclaw-post-core-convergence-");
+    const bundledRoot = tempDirs.make("openclaw-post-core-bundled-");
+    writeBundledPlugin(bundledRoot, "codex", VERSION);
+    const npmRoot = resolvePluginNpmGenerationProjectDir({
+      npmDir: path.join(stateDir, "npm"),
+      packageName: "@openclaw/codex",
+      generationKey: "@openclaw/codex@2026.7.2-beta.7",
+    });
+    const packageDir = path.join(npmRoot, "node_modules", "@openclaw", "codex");
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(npmRoot, "package.json"),
+      JSON.stringify({ dependencies: { "@openclaw/codex": "2026.7.2-beta.7" } }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({ name: "@openclaw/codex", version: "2026.7.2-beta.7" }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(packageDir, "openclaw.plugin.json"),
+      JSON.stringify({ id: "codex", name: "codex", configSchema: { type: "object" } }),
+      "utf8",
+    );
+    const actualDoctorRegistry = await vi.importActual<
+      typeof import("../../commands/doctor-plugin-registry.js")
+    >("../../commands/doctor-plugin-registry.js");
+    mocks.maybeRepairStaleManagedNpmBundledPlugins.mockImplementation(
+      actualDoctorRegistry.maybeRepairStaleManagedNpmBundledPlugins,
+    );
+
+    await runPostCorePluginConvergence({
+      cfg: {
+        plugins: { allow: ["codex"], entries: { codex: { enabled: true } } },
+      },
+      env: {
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledRoot,
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+        VITEST: "true",
+      },
+    });
+
+    expect(fs.existsSync(packageDir)).toBe(false);
   });
 
   it("forwards ClawHub risk acknowledgement options to repair", async () => {

--- a/src/cli/update-cli/post-core-plugin-convergence.test.ts
+++ b/src/cli/update-cli/post-core-plugin-convergence.test.ts
@@ -127,8 +127,16 @@ describe("runPostCorePluginConvergence", () => {
         OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
       },
     });
-    expect(mocks.maybeRepairStaleManagedNpmBundledPlugins.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.repairMissingConfiguredPluginInstalls.mock.invocationCallOrder[0],
+    expect(
+      expectDefined(
+        mocks.maybeRepairStaleManagedNpmBundledPlugins.mock.invocationCallOrder[0],
+        "stale managed cleanup call order",
+      ),
+    ).toBeLessThan(
+      expectDefined(
+        mocks.repairMissingConfiguredPluginInstalls.mock.invocationCallOrder[0],
+        "missing configured plugin repair call order",
+      ),
     );
   });
 

--- a/src/cli/update-cli/post-core-plugin-convergence.ts
+++ b/src/cli/update-cli/post-core-plugin-convergence.ts
@@ -169,6 +169,15 @@ export async function runPostCorePluginConvergence(params: {
     OPENCLAW_COMPATIBILITY_HOST_VERSION: params.compatibilityHostVersion ?? VERSION,
     [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1",
   };
+  // Retire obsolete managed shadows before relinking or smoke-checking them. A package that
+  // became bundled with the new core must not survive into the next startup's contract graph.
+  const { maybeRepairStaleManagedNpmBundledPlugins } =
+    await import("../../commands/doctor-plugin-registry.js");
+  maybeRepairStaleManagedNpmBundledPlugins({
+    config: params.cfg,
+    env,
+    prompter: { shouldRepair: true },
+  });
   const prunedBaseline = params.baselineInstallRecords
     ? pruneStaleLocalBundledPluginInstallRecords({
         installRecords: params.baselineInstallRecords,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an update could leave an obsolete managed copy of a now-bundled plugin on disk, allowing recovery to select that stale copy and fail subsequent startup imports.

The reproduced trigger was a persisted `@openclaw/codex@2026.7.2-beta.7` generation on Node 24. Its removed `openclaw/plugin-sdk/runtime-doctor` import was caught, but a later lazy import failed with `ERR_INTERNAL_ASSERTION`.

## Why This Change Was Made

Post-core plugin convergence now invokes the existing stale-managed bundled-plugin cleanup before relinking and smoke checks. This retires obsolete managed shadows at the lifecycle owner while preserving retained and valid current generations.

This intentionally does not add a loader retry, assertion catch, broad fallback, or restore the removed compatibility export. The cleanup runs only in the update convergence path and does not add steady-state gateway or loader work.

## User Impact

Users upgrading OpenClaw no longer risk a startup failure caused by a stale managed generation shadowing the bundled plugin after core convergence. Explicitly retained managed packages and valid current generations remain available.

## Evidence

- Base: `e9cf5dde561349577d19f9dc1e9402845fdbe45b`
- Head: `f2f5c0b833f6bd94e409325a8a267388f4ecb8aa`
- Focused owner test: 34/34 passed on the exact head with disposable `HOME`, state, and npm roots.
- Test typecheck: the initial CI diagnostic was reproduced, corrected with an explicit defined-value assertion, and `tsgo:core:test` passed locally.
- Testbox focused proof on Node 24: 34/34 passed.
- Full build passed.
- Exact two-boot Node 24 matrix passed on the proposed patch content:
  - stale Codex generation: red on base, green after cleanup
  - stale Codex generation without semantic index: red on base, green after cleanup
  - ClickClack-only and Discord-only controls: no loader assertion; green after cleanup
  - no external generation: remains green
  - retained managed package: preserved and green
  - valid current generation: preserved and green
- Source-blind behavior validation passed all contract clauses.
- Default managed npm tree checksums were unchanged before and after proof.
- `check:changed` encountered an unrelated current-`main` dependency pin guard for `ui/package.json` (`@novnc/novnc`); the touched plugin convergence surface and focused/full validation are green.
