### PR TITLE
test(ui): remove source-mirror assertions

### DIFF
--- a/ui/src/app/service-worker-cache.test.ts
+++ b/ui/src/app/service-worker-cache.test.ts
@@ -10,37 +10,6 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const serviceWorkerPath = path.join(here, "../../public/sw.js");
 
 describe("Control UI service worker cache versioning", () => {
-  it("registers the service worker with a build id and bounds prior build caches", () => {
-    const mainSource = fs.readFileSync(path.join(here, "../main.ts"), "utf8");
-    const serviceWorkerSource = fs.readFileSync(serviceWorkerPath, "utf8");
-    const viteConfigSource = fs.readFileSync(path.join(here, "../../vite.config.ts"), "utf8");
-
-    expect(mainSource).toContain('swUrl.searchParams.set("v"');
-    expect(mainSource).toContain("CONTROL_UI_BUILD_INFO.buildId");
-    expect(mainSource).toContain('updateViaCache: "none"');
-    expect(mainSource).toContain('navigator.serviceWorker.addEventListener("message"');
-    expect(mainSource).toContain("event.data.version !== currentControlUiBuildId");
-    expect(serviceWorkerSource).toContain(
-      'const EMBEDDED_CACHE_VERSION = "__OPENCLAW_CONTROL_UI_BUILD_ID__"',
-    );
-    expect(serviceWorkerSource).toContain("URL_CACHE_VERSION");
-    expect(serviceWorkerSource).toContain("CONTROL_CACHE_LIMIT = 3");
-    expect(serviceWorkerSource).toContain("slice(-priorCacheLimit)");
-    expect(serviceWorkerSource).toContain("caches.delete");
-    expect(serviceWorkerSource).toContain("includeUncontrolled: true");
-    expect(serviceWorkerSource).not.toContain(
-      'postMessage({ type: "sw-updated", version: CACHE_VERSION },',
-    );
-    expect(viteConfigSource).toContain("source.replace(placeholder, JSON.stringify(buildId))");
-    expect(viteConfigSource).toContain(
-      '"globalThis.OPENCLAW_CONTROL_UI_BUILD_INFO": JSON.stringify(buildInfo)',
-    );
-    expect(viteConfigSource).not.toContain(
-      "OPENCLAW_CONTROL_UI_BUILD_ID: JSON.stringify(controlUiBuildId)",
-    );
-    expect(serviceWorkerSource).not.toContain('const CACHE_NAME = "openclaw-control-v1"');
-  });
-
   it("broadcasts updated versions to uncontrolled window clients during activation", async () => {
     const serviceWorkerSource = fs.readFileSync(serviceWorkerPath, "utf8");
     const windowClient = { postMessage: vi.fn() };

--- a/ui/src/pages/chat/realtime-talk-shared.browser-import.test.ts
+++ b/ui/src/pages/chat/realtime-talk-shared.browser-import.test.ts
@@ -2,22 +2,10 @@
 import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 
-function importLines(source: string): string[] {
-  return source
-    .split(/\r?\n/u)
-    .filter((line) => line.startsWith("import "))
-    .map((line) => line.trim());
-}
-
 describe("realtime talk shared browser imports", () => {
   it("keeps embedded run-control runtime out of the Control UI import path", async () => {
     const source = await readFile(new URL("./realtime-talk-shared.ts", import.meta.url), "utf8");
-    const imports = importLines(source);
 
-    expect(imports).toContain(
-      'import { REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME } from "../../../../src/talk/agent-consult-tool.js";',
-    );
-    expect(source).toContain('from "../../../../src/talk/agent-run-control-shared.js";');
-    expect(imports.some((line) => line.includes("agent-run-control.js"))).toBe(false);
+    expect(source).not.toMatch(/\bfrom\s+["'][^"']*\/agent-run-control\.js["']/u);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Source-mirror assertions made harmless Control UI refactors fail tests even when the executable behavior and browser boundary remained correct.

## Why This Change Was Made

Behavioral proof now owns the real contracts: the service-worker suite retains executable VM coverage for activation, cache eviction, broadcasts, and notifications, while the production Chromium update E2E covers built-artifact updates. The realtime browser-import test drops exact positive import paths but retains a multiline-safe prohibition against importing the server-only `agent-run-control.js` adapter.

## User Impact

None. This is a test-only cleanup with no production or user-visible changes.

## Evidence

- Six focused Control UI suites passed: 106 tests.
- Targeted formatting, UI lint, and `git diff --check` passed.
- Autoreview and its changed-content secret scan reported no actionable findings.
- Production LOC: +0/-0. Tests: +1/-44.
- The approved local Crabbox wrapper failed its own binary sanity check before allocating a remote box (`version=unknown providers=unknown`), so those heavy gates were not run locally.
- [Exact-head PR CI](https://github.com/openclaw/openclaw/actions/runs/31339407066) passed, including core test types, Control UI checks, and all four Chromium E2E shards.
- [Exact-SHA manual CI](https://github.com/openclaw/openclaw/actions/runs/31339474170) supplied the production `build-artifacts`/Control UI build proof and repeated the Control UI E2E steps successfully. Its broader release-gate matrix also reported a `native-i18n` failure outside this two-file test-only diff, so it is not cited as aggregate green proof.

AI-assisted: yes.
