### PR TITLE
test(ios): trim duplicate root shell mirrors

### DIFF
--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -1253,7 +1253,7 @@ private struct RootCameraFlashOverlay: View {
     traits: .fixedLayout(width: 393, height: 852),
     .portrait)
 {
-    RootTabsPreviewHost(idiom: .phone)
+    RootTabsPreviewHost()
 }
 
 #Preview(
@@ -1261,7 +1261,7 @@ private struct RootCameraFlashOverlay: View {
     traits: .fixedLayout(width: 393, height: 852),
     .portrait)
 {
-    RootTabsPreviewHost(idiom: .phone, sidebarVisible: true)
+    RootTabsPreviewHost(sidebarVisible: true)
 }
 
 #Preview(
@@ -1269,7 +1269,7 @@ private struct RootCameraFlashOverlay: View {
     traits: .fixedLayout(width: 393, height: 852),
     .portrait)
 {
-    RootTabsPreviewHost(idiom: .phone, gatewayState: .connected)
+    RootTabsPreviewHost(gatewayState: .connected)
 }
 
 #Preview(
@@ -1277,7 +1277,7 @@ private struct RootCameraFlashOverlay: View {
     traits: .fixedLayout(width: 393, height: 852),
     .portrait)
 {
-    RootTabsPreviewHost(idiom: .phone, gatewayState: .error)
+    RootTabsPreviewHost(gatewayState: .error)
 }
 
 #Preview(
@@ -1285,7 +1285,7 @@ private struct RootCameraFlashOverlay: View {
     traits: .fixedLayout(width: 852, height: 393),
     .landscapeLeft)
 {
-    RootTabsPreviewHost(idiom: .phone)
+    RootTabsPreviewHost()
         .environment(\.horizontalSizeClass, .regular)
         .environment(\.verticalSizeClass, .compact)
 }
@@ -1295,7 +1295,7 @@ private struct RootCameraFlashOverlay: View {
     traits: .fixedLayout(width: 1024, height: 1366),
     .portrait)
 {
-    RootTabsPreviewHost(idiom: .pad)
+    RootTabsPreviewHost()
 }
 
 #Preview(
@@ -1303,7 +1303,7 @@ private struct RootCameraFlashOverlay: View {
     traits: .fixedLayout(width: 1366, height: 1024),
     .landscapeLeft)
 {
-    RootTabsPreviewHost(idiom: .pad, gatewayState: .connected)
+    RootTabsPreviewHost(gatewayState: .connected)
 }
 
 #Preview(
@@ -1311,7 +1311,7 @@ private struct RootCameraFlashOverlay: View {
     traits: .fixedLayout(width: 1366, height: 1024),
     .landscapeLeft)
 {
-    RootTabsPreviewHost(idiom: .pad, gatewayState: .connecting)
+    RootTabsPreviewHost(gatewayState: .connecting)
 }
 
 #Preview(
@@ -1319,24 +1319,21 @@ private struct RootCameraFlashOverlay: View {
     traits: .fixedLayout(width: 1366, height: 1024),
     .landscapeLeft)
 {
-    RootTabsPreviewHost(idiom: .pad, gatewayState: .error)
+    RootTabsPreviewHost(gatewayState: .error)
 }
 
 private struct RootTabsPreviewHost: View {
     @State private var appearanceModel = AppAppearanceModel()
     @State private var appModel: NodeAppModel
     @State private var gatewayController: GatewayConnectionController
-    private let idiom: UIUserInterfaceIdiom
     private let sidebarVisible: Bool?
 
     init(
-        idiom: UIUserInterfaceIdiom,
         gatewayState: RootTabsPreviewGatewayState = .offline,
         sidebarVisible: Bool? = nil)
     {
         let appModel = NodeAppModel()
         gatewayState.apply(to: appModel)
-        self.idiom = idiom
         self.sidebarVisible = sidebarVisible
         _appModel = State(initialValue: appModel)
         _gatewayController = State(

--- a/apps/ios/Tests/RootTabsSidebarRegressionTests.swift
+++ b/apps/ios/Tests/RootTabsSidebarRegressionTests.swift
@@ -2,32 +2,6 @@ import Foundation
 import Testing
 
 struct RootTabsSidebarRegressionTests {
-    @Test func `i pad split hidden sidebar uses header reveal instead of reserved rail`() throws {
-        let source = try String(contentsOf: Self.rootTabsSourceURL(), encoding: .utf8)
-        let navigationSource = try String(contentsOf: Self.rootTabsNavigationSourceURL(), encoding: .utf8)
-        let splitContent = try Self.extract(
-            source,
-            from: "private func sidebarNavigationSplitContent(sidebarWidth: CGFloat) -> some View",
-            to: "private func sidebarDrawerContent(")
-
-        #expect(splitContent.contains("HStack(spacing: 0)"))
-        #expect(splitContent.contains("self.sidebarColumn"))
-        #expect(splitContent.contains(".frame(width: sidebarWidth, alignment: .topLeading)"))
-        #expect(splitContent.contains(".overlay(alignment: .trailing)"))
-        #expect(!splitContent.contains("self.syncSidebarVisibility(from: visibility)"))
-        #expect(!source.contains("NavigationSplitViewVisibility"))
-        #expect(!source.contains("@State private var splitColumnVisibility: NavigationSplitViewVisibility"))
-        #expect(!splitContent.contains("NavigationSplitView"))
-        #expect(!splitContent.contains("self.collapsedSidebarRail"))
-        #expect(!source.contains("private var collapsedSidebarRail: some View"))
-        #expect(!source.contains("Self.sidebarCollapsedRailWidth"))
-        #expect(source.contains("shouldShowSidebarRevealInDestinationHeader"))
-        #expect(!navigationSource.contains("static let sidebarCollapsedRailWidth"))
-        #expect(!navigationSource.contains("static func sidebarSplitColumnVisibility(isSidebarVisible: Bool)"))
-        #expect(!navigationSource
-            .contains("static func sidebarIsVisible(splitColumnVisibility: NavigationSplitViewVisibility)"))
-    }
-
     @Test func `initial sidebar visibility survives first layout measurement`() throws {
         let source = try String(contentsOf: Self.rootTabsSourceURL(), encoding: .utf8)
         let layoutUpdate = try Self.extract(
@@ -215,13 +189,6 @@ struct RootTabsSidebarRegressionTests {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("Sources/RootSidebar.swift")
-    }
-
-    private static func rootTabsNavigationSourceURL() -> URL {
-        URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("Sources/RootTabsNavigation.swift")
     }
 
     private static func commandCenterSourceURL() -> URL {

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -528,20 +528,6 @@ struct RootTabsSourceGuardTests {
         #expect(!source.contains(".background(Color(uiColor: .systemBackground))"))
     }
 
-    @Test func `root shell preview matrix covers phone and I pad states`() throws {
-        let source = try String(contentsOf: Self.rootTabsSourceURL(), encoding: .utf8)
-
-        #expect(source.contains("#Preview(\n    \"Shell iPhone portrait\""))
-        #expect(source.contains("#Preview(\n    \"Shell iPhone drawer open\""))
-        #expect(source.contains("#Preview(\n    \"Shell iPhone landscape\""))
-        #expect(source.contains("#Preview(\n    \"Shell iPhone connected\""))
-        #expect(source.contains("#Preview(\n    \"Shell iPhone gateway error\""))
-        #expect(source.contains("#Preview(\n    \"Shell iPad portrait drawer\""))
-        #expect(source.contains("#Preview(\n    \"Shell iPad landscape split\""))
-        #expect(source.contains("#Preview(\n    \"Shell iPad connecting\""))
-        #expect(source.contains("#Preview(\n    \"Shell iPad gateway error\""))
-    }
-
     @Test func `shared chat preview matrix covers connection states`() throws {
         let source = try String(contentsOf: Self.sharedChatPreviewSourceURL(), encoding: .utf8)
 

--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -16,19 +16,6 @@ struct SwiftUIRenderSmokeTests {
         return window
     }
 
-    @Test @MainActor func `settings pro tab builds A view hierarchy`() {
-        let appModel = NodeAppModel()
-        let gatewayController = GatewayConnectionController(appModel: appModel, startDiscovery: false)
-
-        let root = SettingsProTab()
-            .environment(AppAppearanceModel())
-            .environment(appModel)
-            .environment(appModel.voiceWake)
-            .environment(gatewayController)
-
-        _ = Self.host(root)
-    }
-
     @Test @MainActor func `settings pro tab builds in light and dark mode`() {
         for scheme in [ColorScheme.light, ColorScheme.dark] {
             let appModel = NodeAppModel()
@@ -765,31 +752,26 @@ struct SwiftUIRenderSmokeTests {
     private static func rootTabsShellScenarios() -> [RootTabsShellScenario] {
         [
             RootTabsShellScenario(
-                idiom: .phone,
                 size: CGSize(width: 393, height: 852),
                 horizontalSizeClass: .compact,
                 verticalSizeClass: .regular,
                 sidebarVisible: false),
             RootTabsShellScenario(
-                idiom: .phone,
                 size: CGSize(width: 393, height: 852),
                 horizontalSizeClass: .compact,
                 verticalSizeClass: .regular,
                 sidebarVisible: true),
             RootTabsShellScenario(
-                idiom: .phone,
                 size: CGSize(width: 852, height: 393),
                 horizontalSizeClass: .regular,
                 verticalSizeClass: .compact,
                 sidebarVisible: false),
             RootTabsShellScenario(
-                idiom: .pad,
                 size: CGSize(width: 1024, height: 1366),
                 horizontalSizeClass: .regular,
                 verticalSizeClass: .regular,
                 sidebarVisible: true),
             RootTabsShellScenario(
-                idiom: .pad,
                 size: CGSize(width: 1366, height: 1024),
                 horizontalSizeClass: .regular,
                 verticalSizeClass: .regular,
@@ -798,7 +780,6 @@ struct SwiftUIRenderSmokeTests {
     }
 
     private struct RootTabsShellScenario {
-        let idiom: UIUserInterfaceIdiom
         let size: CGSize
         let horizontalSizeClass: UserInterfaceSizeClass
         let verticalSizeClass: UserInterfaceSizeClass


### PR DESCRIPTION
## What Problem This Solves

The iOS root shell test suite had several low-value mirrors: a Settings render smoke strictly contained by the retained light/dark smoke, a sidebar source regression duplicated by stronger retained source and presentation guards, and an exact preview-name inventory that coupled tests to preview labels. The DEBUG preview host and render scenarios also carried an unused device-idiom value.

## Why This Change Was Made

This trims only the duplicate mirrors and unused DEBUG-only idiom plumbing. All root shell previews, preview states, fixed-layout traits, light/dark Settings coverage, unique sidebar regressions, behavior-level sidebar presentation tests, render scenarios, and other source guards remain.

## User Impact

No user-visible behavior changes. The production delta is three deleted lines of DEBUG-only preview support; the rest is test cleanup.

## Evidence

- `./scripts/format-swift.sh ios` — clean (0/361 files require formatting)
- `./scripts/lint-swift.sh ios` — clean (0 violations)
- `git diff --check origin/main...HEAD` — clean
- `node scripts/check-changed.mjs --dry-run -- <four changed files>` — selects the `apps` lane and iOS lint/static guards
- Pre-commit autoreview and TruffleHog scan — clean, no findings
- Isolated exact-head macOS simulator proof (Xcode 27 beta, iOS 26.5): `xcodebuild` selected `RootTabsSourceGuardTests`, `RootTabsSidebarRegressionTests`, `RootTabsPresentationTests`, and `SwiftUIRenderSmokeTests`; 158 tests in four suites passed (`** TEST SUCCEEDED **`)
- Diff: four files, +9/-78; production +9/-12 (net -3, DEBUG-only), tests +0/-66
- Canonical exact-head Xcode 26 CI passed: Swift lint, Debug and Release iOS builds, focused lifecycle simulator tests, release screenshot snapshots, iOS Periphery, shared-kit scans, and the macOS Swift/native test lane.

No screenshots: this does not alter rendered UI or preview layout/state coverage.
