### PR TITLE
fix(gateway): accept noVNC extended clipboard framing [AI-assisted]

### DIFF
--- a/src/gateway/worker-environments/rfb-view-only-filter.test.ts
+++ b/src/gateway/worker-environments/rfb-view-only-filter.test.ts
@@ -98,7 +98,9 @@ describe("RFB view-only client message filter", () => {
     const framebufferUpdateRequest = Buffer.from([3, 1, 0, 0, 0, 0, 0, 64, 0, 64]);
     const clientFence = Buffer.from([248, 0, 0, 0, 0, 0, 0, 0, 1, 0]);
     const enableContinuousUpdates = Buffer.from([150, 1, 0, 0, 0, 0, 0, 64, 0, 64]);
-    const cutText = Buffer.concat([Buffer.from([6, 0, 0, 0, 0, 0, 0, 8]), Buffer.alloc(8)]);
+    const cutText = Buffer.alloc(16);
+    cutText[0] = 6;
+    cutText.writeInt32BE(-8, 4);
     const capturedSequence = Buffer.concat([
       setPixelFormat,
       setEncodings,

--- a/src/gateway/worker-environments/rfb-view-only-filter.ts
+++ b/src/gateway/worker-environments/rfb-view-only-filter.ts
@@ -44,7 +44,8 @@ export function createRfbClientMessageFilter() {
       case 5:
         return 6;
       case 6:
-        return pending.length < 8 ? 8 : 8 + pending.readUInt32BE(4);
+        // noVNC marks extended clipboard payloads with a negative signed length.
+        return pending.length < 8 ? 8 : 8 + Math.abs(pending.readInt32BE(4));
       case 150:
         return 10;
       case 248:


### PR DESCRIPTION
Related: #121256

## What Problem This Solves
Fixes an issue where Cloud Worker Desktop view-only sessions still disconnected with `invalid view-only RFB stream` after noVNC 1.7 sent its extended clipboard capability message.

## Why This Change Was Made
noVNC encodes extended ClientCutText payload sizes as a negative signed 32-bit length. The gateway's view-only RFB parser now derives the payload size from the absolute signed length, so it can frame and drop the clipboard message while retaining the existing fail-closed 64 KiB bound and all input suppression.

## User Impact
View-only Cloud Worker Desktop sessions can complete the normal noVNC 1.7 handshake and remain connected without allowing clipboard, keyboard, or pointer input.

## Evidence
- Production deployment of #121256 reached the shipped noVNC/TigerVNC path but still closed with `invalid view-only RFB stream`.
- Safe frame/header tracing captured ClientCutText type 6, total length 16, with length field `0xfffffff8` (signed `-8`).
- Direct `@novnc/novnc` 1.7.0 inspection confirms extended clipboard uses `toUnsigned32bit(-data.length)`.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/rfb-view-only-filter.test.ts` — 13/13 passed; the captured sequence now uses the exact signed extended-clipboard header.
- Core production and test `tsgo` lanes passed.
- `pnpm format ...` and `git diff --check` passed.
- Codex-backed autoreview: clean, no accepted/actionable findings.

AI-assisted; implementation was manually reviewed and the dependency framing contract was verified directly.
