### PR TITLE
fix(update): prevent managed updates from switching checkouts

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -6761,6 +6761,22 @@ describe("update-cli", () => {
     expect(sentinel?.payload.stats?.after?.version).toBe("2026.4.24");
   });
 
+  it("rejects a managed handoff launched from a different canonical install root", async () => {
+    const sentinel = await runControlPlaneUpdate({
+      meta: {
+        root: path.join(process.cwd(), "other-checkout"),
+        handoffId: "wrong-root-handoff",
+      },
+      options: { yes: true, json: true },
+    });
+
+    expect(sentinel).toBeNull();
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+    expect(cleanupStaleManagedServiceUpdateHandoffs).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(getErrorOutput()).toContain("Managed update handoff root mismatch");
+  });
+
   it("does not write a control-plane sentinel when a dry-run preflight fails", async () => {
     const sentinel = await runControlPlaneUpdate({
       meta: {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -34,6 +34,7 @@ import {
   resolveGlobalInstallTarget,
   type ResolvedGlobalInstallTarget,
 } from "../../infra/update-global.js";
+import { updateInstallRootsMatch } from "../../infra/update-install-root.js";
 import { cleanupStaleManagedServiceUpdateHandoffs } from "../../infra/update-managed-service-handoff-cleanup.js";
 import { loadInstalledPluginIndexInstallRecords } from "../../plugins/installed-plugin-index-records.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -139,6 +140,16 @@ async function updateCommandInternal(
     defaultRuntime.exit(1);
     return;
   }
+  const controlPlaneUpdateSentinelMeta = await readControlPlaneUpdateSentinelMeta();
+  const discoveredRoot = await resolveUpdateRoot();
+  const handoffRoot = controlPlaneUpdateSentinelMeta?.root;
+  if (handoffRoot && !updateInstallRootsMatch(handoffRoot, discoveredRoot)) {
+    defaultRuntime.error(
+      `Managed update handoff root mismatch: expected ${handoffRoot}, running from ${discoveredRoot}.`,
+    );
+    defaultRuntime.exit(1);
+    return;
+  }
   if (opts.dryRun !== true) {
     try {
       assertConfigWriteAllowedInCurrentMode();
@@ -152,7 +163,7 @@ async function updateCommandInternal(
   }
   const updateStepTimeoutMs = timeoutMs ?? DEFAULT_UPDATE_STEP_TIMEOUT_MS;
 
-  let root = await resolveUpdateRoot();
+  let root = discoveredRoot;
   if (postCoreUpdateResume) {
     await resumePostCoreUpdate({
       root,
@@ -163,7 +174,6 @@ async function updateCommandInternal(
     return;
   }
 
-  const controlPlaneUpdateSentinelMeta = await readControlPlaneUpdateSentinelMeta();
   const updateStatus = await checkUpdateStatus({
     root,
     timeoutMs: timeoutMs ?? 3500,

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -532,13 +532,14 @@ describe("update.run restart scheduling", () => {
     expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledTimes(1);
     expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        root: "/tmp/openclaw",
+        root: "/tmp/openclaw-global",
         restartDrainTimeoutMs: 300_000,
         restartDelayMs: 2000,
         handoffId: expect.any(String),
         supervisor: "launchd",
         meta: expect.objectContaining({
           handoffId: expect.any(String),
+          root: "/tmp/openclaw-global",
         }),
       }),
     );
@@ -704,7 +705,7 @@ describe("update.run restart scheduling", () => {
     expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledTimes(1);
     expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        root: "/tmp/openclaw",
+        root: "/tmp/openclaw-global",
       }),
     );
   });
@@ -720,11 +721,12 @@ describe("update.run restart scheduling", () => {
     expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledTimes(1);
     expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        root: "/tmp/openclaw",
+        root: "/tmp/openclaw-git",
         handoffId: expect.any(String),
         supervisor: "launchd",
         meta: expect.objectContaining({
           handoffId: expect.any(String),
+          root: "/tmp/openclaw-git",
         }),
       }),
     );
@@ -854,7 +856,7 @@ describe("update.run restart scheduling", () => {
     expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledTimes(1);
     expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        root: "/tmp/openclaw",
+        root: "/tmp/openclaw-git",
         supervisor: "systemd",
       }),
     );

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -34,6 +34,7 @@ import {
 } from "../../infra/update-channels.js";
 import { checkUpdateStatus } from "../../infra/update-check.js";
 import { CONTROL_PLANE_UPDATE_HANDOFF_STARTED_REASON } from "../../infra/update-control-plane-sentinel.js";
+import { resolveUpdateInstallRoot } from "../../infra/update-install-root.js";
 import {
   buildManagedServiceHandoffUnavailableMessage,
   formatManagedServiceUpdateCommand,
@@ -318,6 +319,7 @@ export const updateHandlers: GatewayRequestHandlers = {
         cwd: root,
         argv1: process.argv[1],
       });
+      const installRoot = installSurface.root;
       const effectiveChannel = resolveEffectiveUpdateChannel({
         configChannel,
         currentVersion: VERSION,
@@ -373,6 +375,9 @@ export const updateHandlers: GatewayRequestHandlers = {
           durationMs: 0,
         };
       } else if (requiresManagedServiceHandoff) {
+        if (!installRoot) {
+          throw new Error("managed update install root is unavailable");
+        }
         const handoffChannel =
           installSurface.kind === "git"
             ? undefined
@@ -386,9 +391,7 @@ export const updateHandlers: GatewayRequestHandlers = {
         });
         if (supervisor && hasHandoffContext) {
           try {
-            const beforeVersion = installSurface.root
-              ? await readPackageVersion(installSurface.root)
-              : null;
+            const beforeVersion = await readPackageVersion(installRoot);
             const startedAt = Date.now();
             const handoffId = randomUUID();
             const managedRestartDelayMs = resolveManagedServiceHandoffRestartDelayMs(
@@ -396,11 +399,12 @@ export const updateHandlers: GatewayRequestHandlers = {
               supervisor,
             );
             sentinelMeta.handoffId = handoffId;
+            sentinelMeta.root = resolveUpdateInstallRoot(installRoot);
             // Managed services update from a detached helper so the running
             // gateway does not replace its own package or git-built dist tree
             // while still serving RPCs.
             const started = await startManagedServiceUpdateHandoff({
-              root,
+              root: installRoot,
               timeoutMs,
               restartDrainTimeoutMs: resolveGatewayRestartDeferralTimeoutMs(),
               ...(handoffChannel ? { channel: handoffChannel } : {}),
@@ -452,7 +456,7 @@ export const updateHandlers: GatewayRequestHandlers = {
             result = {
               status: "skipped",
               mode: installSurface.mode,
-              root: installSurface.root,
+              root: installRoot,
               reason: ownsManagedServiceHandoff
                 ? CONTROL_PLANE_UPDATE_HANDOFF_STARTED_REASON
                 : MANAGED_HANDOFF_ALREADY_RUNNING_REASON,
@@ -462,7 +466,7 @@ export const updateHandlers: GatewayRequestHandlers = {
                     {
                       name: "managed-service update handoff",
                       command: started.command,
-                      cwd: root,
+                      cwd: installRoot,
                       durationMs: Date.now() - startedAt,
                       exitCode: null,
                     },
@@ -477,16 +481,14 @@ export const updateHandlers: GatewayRequestHandlers = {
             result = {
               status: "error",
               mode: installSurface.mode,
-              root: installSurface.root,
+              root: installRoot,
               reason: "managed-service-handoff-failed",
               steps: [],
               durationMs: 0,
             };
           }
         } else {
-          const beforeVersion = installSurface.root
-            ? await readPackageVersion(installSurface.root)
-            : null;
+          const beforeVersion = await readPackageVersion(installRoot);
           handoff = {
             status: "unavailable",
             command,
@@ -495,7 +497,7 @@ export const updateHandlers: GatewayRequestHandlers = {
           result = {
             status: "skipped",
             mode: installSurface.mode,
-            root: installSurface.root,
+            root: installRoot,
             reason: "managed-service-handoff-unavailable",
             ...(beforeVersion ? { before: { version: beforeVersion } } : {}),
             steps: [],

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -543,33 +543,42 @@ describe("restart sentinel", () => {
 
   it("persists the verified Git install receipt after restart", async () => {
     await withRestartSentinelStateDir(async () => {
-      const ts = Date.now();
-      await writeRestartSentinel({
-        kind: "update",
-        status: "ok",
-        ts,
-        stats: {
-          mode: "git",
-          before: { sha: "aaaaaaaa" },
-          after: { sha: "bbbbbbbb", version: "expected-version" },
-        },
-      });
+      await withTempDir({ prefix: "openclaw-install-root-" }, async (tempDir) => {
+        const installRoot = path.join(tempDir, "checkout");
+        const installAlias = path.join(tempDir, "checkout-alias");
+        await fs.mkdir(installRoot);
+        await fs.symlink(installRoot, installAlias, "dir");
+        const ts = Date.now();
+        await writeRestartSentinel({
+          kind: "update",
+          status: "ok",
+          ts,
+          stats: {
+            mode: "git",
+            root: installAlias,
+            before: { sha: "aaaaaaaa" },
+            after: { sha: "bbbbbbbb", version: "expected-version" },
+          },
+        });
 
-      await finalizeUpdateRestartSentinelRunningVersion(
-        "actual-version",
-        process.env,
-        "bbbbbbbb1234",
-      );
-      await clearRestartSentinel();
+        await finalizeUpdateRestartSentinelRunningVersion(
+          "actual-version",
+          process.env,
+          "bbbbbbbb1234",
+          installRoot,
+        );
+        await clearRestartSentinel();
 
-      await expect(readUpdateInstallReceipt()).resolves.toMatchObject({
-        kind: "update",
-        status: "ok",
-        ts,
-        stats: {
-          mode: "git",
-          after: { sha: "bbbbbbbb", version: "actual-version" },
-        },
+        await expect(readUpdateInstallReceipt()).resolves.toMatchObject({
+          kind: "update",
+          status: "ok",
+          ts,
+          stats: {
+            mode: "git",
+            root: await fs.realpath(installRoot),
+            after: { sha: "bbbbbbbb", version: "actual-version" },
+          },
+        });
       });
     });
   });
@@ -582,12 +591,18 @@ describe("restart sentinel", () => {
         ts: Date.now(),
         stats: {
           mode: "git",
+          root: process.cwd(),
           before: { sha: "aaaaaaaa" },
           after: { sha: "aaaaaaaa", version: "expected-version" },
         },
       });
 
-      await finalizeUpdateRestartSentinelRunningVersion("actual-version", process.env, "aaaaaaaa");
+      await finalizeUpdateRestartSentinelRunningVersion(
+        "actual-version",
+        process.env,
+        "aaaaaaaa",
+        process.cwd(),
+      );
 
       await expect(readUpdateInstallReceipt()).resolves.toBeNull();
     });
@@ -601,11 +616,17 @@ describe("restart sentinel", () => {
         ts: Date.now(),
         stats: {
           mode: "git",
+          root: process.cwd(),
           after: { sha: "bbbbbbbb", version: "expected-version" },
         },
       });
 
-      await finalizeUpdateRestartSentinelRunningVersion("actual-version", process.env, "cccccccc");
+      await finalizeUpdateRestartSentinelRunningVersion(
+        "actual-version",
+        process.env,
+        "cccccccc",
+        process.cwd(),
+      );
 
       await expect(readRestartSentinel()).resolves.toMatchObject({
         payload: {
@@ -614,6 +635,43 @@ describe("restart sentinel", () => {
         },
       });
       await expect(readUpdateInstallReceipt()).resolves.toBeNull();
+    });
+  });
+
+  it("rejects the same Git revision when the restarted checkout root differs", async () => {
+    await withRestartSentinelStateDir(async () => {
+      await withTempDir({ prefix: "openclaw-install-root-mismatch-" }, async (tempDir) => {
+        const expectedRoot = path.join(tempDir, "expected");
+        const runningRoot = path.join(tempDir, "running");
+        await fs.mkdir(expectedRoot);
+        await fs.mkdir(runningRoot);
+        await writeRestartSentinel({
+          kind: "update",
+          status: "ok",
+          ts: Date.now(),
+          stats: {
+            mode: "git",
+            root: expectedRoot,
+            before: { sha: "aaaaaaaa" },
+            after: { sha: "bbbbbbbb", version: "expected-version" },
+          },
+        });
+
+        await finalizeUpdateRestartSentinelRunningVersion(
+          "actual-version",
+          process.env,
+          "bbbbbbbb1234",
+          runningRoot,
+        );
+
+        await expect(readRestartSentinel()).resolves.toMatchObject({
+          payload: {
+            status: "error",
+            stats: { reason: "restart-root-mismatch" },
+          },
+        });
+        await expect(readUpdateInstallReceipt()).resolves.toBeNull();
+      });
     });
   });
 

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -10,6 +10,7 @@ import {
 import { resolveRuntimeServiceVersion } from "../version.js";
 import { formatErrorMessage } from "./errors.js";
 import { resolveCommitHash } from "./git-commit.js";
+import { resolveOpenClawPackageRoot } from "./openclaw-root.js";
 import {
   deleteRestartSentinelRowSync,
   readRestartSentinelRowSync,
@@ -21,6 +22,7 @@ import {
   type RestartSentinelContinuation,
   type RestartSentinelPayload,
 } from "./restart-sentinel-store.js";
+import { resolveUpdateInstallRoot } from "./update-install-root.js";
 
 export type {
   RestartSentinelContinuation,
@@ -88,11 +90,32 @@ export async function finalizeUpdateRestartSentinelRunningVersion(
   version = resolveRuntimeServiceVersion(process.env),
   env: NodeJS.ProcessEnv = process.env,
   commit = resolveCommitHash({ env, moduleUrl: import.meta.url }),
+  runningRoot?: string | null,
 ): Promise<RestartSentinel | null> {
+  const snapshot = await readRestartSentinel(env);
+  if (!snapshot || snapshot.payload.kind !== "update") {
+    return null;
+  }
+  const snapshotRoot = snapshot.payload.stats?.root;
+  const expectedRoot =
+    typeof snapshotRoot === "string" ? resolveUpdateInstallRoot(snapshotRoot) : null;
+  const discoveredRoot = expectedRoot
+    ? (runningRoot ??
+      (await resolveOpenClawPackageRoot({
+        moduleUrl: import.meta.url,
+        argv1: process.argv[1],
+      })))
+    : null;
+  const actualRoot = discoveredRoot ? resolveUpdateInstallRoot(discoveredRoot) : null;
+
   return runOpenClawStateWriteTransaction(
     ({ db }) => {
       const current = readRestartSentinelRowSync(db);
-      if (current.kind !== "valid" || current.sentinel.payload.kind !== "update") {
+      if (
+        current.kind !== "valid" ||
+        current.sentinel.revision !== snapshot.revision ||
+        current.sentinel.payload.kind !== "update"
+      ) {
         return null;
       }
 
@@ -104,6 +127,10 @@ export async function finalizeUpdateRestartSentinelRunningVersion(
         after.version = version;
         changed = true;
       }
+      if (expectedRoot && stats.root !== expectedRoot) {
+        stats.root = expectedRoot;
+        changed = true;
+      }
 
       const before = isPlainRecord(stats.before) ? stats.before : {};
       const beforeSha = typeof before.sha === "string" ? before.sha.trim() : "";
@@ -111,10 +138,22 @@ export async function finalizeUpdateRestartSentinelRunningVersion(
       const actualSha = commit?.trim() ?? "";
       const verifiesGitRevision =
         stats.mode !== "git" || (expectedSha.length > 0 && commitsMatch(expectedSha, actualSha));
+      const verifiesInstallRoot =
+        expectedRoot !== null && actualRoot !== null && expectedRoot === actualRoot;
       const changedInstall =
         stats.mode !== "git" ||
         (beforeSha.length > 0 && expectedSha.length > 0 && !commitsMatch(beforeSha, expectedSha));
-      if (payload.status === "ok" && stats.mode === "git" && expectedSha && !verifiesGitRevision) {
+      if (payload.status === "ok" && expectedRoot && !verifiesInstallRoot) {
+        payload.status = "error";
+        stats.reason = actualRoot ? "restart-root-mismatch" : "restart-root-unavailable";
+        delete payload.continuation;
+        changed = true;
+      } else if (
+        payload.status === "ok" &&
+        stats.mode === "git" &&
+        expectedSha &&
+        !verifiesGitRevision
+      ) {
         payload.status = "error";
         stats.reason = actualSha ? "restart-revision-mismatch" : "restart-revision-unavailable";
         delete payload.continuation;
@@ -129,7 +168,7 @@ export async function finalizeUpdateRestartSentinelRunningVersion(
       if (!finalized) {
         return null;
       }
-      if (payload.status === "ok" && verifiesGitRevision && changedInstall) {
+      if (payload.status === "ok" && verifiesInstallRoot && verifiesGitRevision && changedInstall) {
         writeUpdateInstallReceiptRowSync(db, payload);
       }
       return changed ? finalized : null;

--- a/src/infra/update-control-plane-sentinel.ts
+++ b/src/infra/update-control-plane-sentinel.ts
@@ -68,6 +68,7 @@ function normalizeMeta(value: unknown): UpdateRestartSentinelMeta | null {
   const sessionKey = normalizeText(value.sessionKey);
   const threadId = normalizeText(value.threadId);
   const handoffId = normalizeText(value.handoffId);
+  const root = normalizeText(value.root);
   const channel = isRecord(value.deliveryContext)
     ? normalizeText(value.deliveryContext.channel)
     : undefined;
@@ -84,6 +85,7 @@ function normalizeMeta(value: unknown): UpdateRestartSentinelMeta | null {
         }
       : undefined;
   return {
+    ...(root ? { root } : {}),
     ...(sessionKey ? { sessionKey } : {}),
     ...(deliveryContext ? { deliveryContext } : {}),
     ...(threadId ? { threadId } : {}),

--- a/src/infra/update-install-root.ts
+++ b/src/infra/update-install-root.ts
@@ -1,0 +1,15 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/** Resolve the canonical identity of an update checkout/install root. */
+export function resolveUpdateInstallRoot(root: string): string {
+  try {
+    return fs.realpathSync.native(root);
+  } catch {
+    return path.resolve(root);
+  }
+}
+
+export function updateInstallRootsMatch(left: string, right: string): boolean {
+  return resolveUpdateInstallRoot(left) === resolveUpdateInstallRoot(right);
+}

--- a/src/infra/update-managed-service-handoff-command.test.ts
+++ b/src/infra/update-managed-service-handoff-command.test.ts
@@ -65,6 +65,13 @@ async function startHandoffAndReadCommand(params: {
   const helperParams = JSON.parse(await fs.readFile(paramsPath, "utf-8")) as {
     commandArgv?: string[];
   };
+  const metaPath = path.join(path.dirname(paramsPath), "sentinel-meta.json");
+  const metaFile = JSON.parse(await fs.readFile(metaPath, "utf-8")) as {
+    meta?: { root?: string };
+  };
+  expect(metaFile.meta?.root).toBe(
+    await fs.realpath("/tmp/openclaw").catch(() => path.resolve("/tmp/openclaw")),
+  );
   return { command: result.command, commandArgv: helperParams.commandArgv };
 }
 

--- a/src/infra/update-managed-service-handoff.single-flight.test.ts
+++ b/src/infra/update-managed-service-handoff.single-flight.test.ts
@@ -3,6 +3,7 @@
  */
 import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -10,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const { spawnMock } = vi.hoisted(() => ({
   spawnMock: vi.fn(),
 }));
+const tempRootDirs = new Set<string>();
 const FAST_WAIT_OPTS = { interval: 1 } as const;
 
 function createSpawnMock() {
@@ -45,6 +47,8 @@ afterEach(async () => {
     return scriptPath ? [path.dirname(scriptPath)] : [];
   });
   await Promise.all(handoffDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  await Promise.all([...tempRootDirs].map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  tempRootDirs.clear();
   vi.resetModules();
 });
 
@@ -146,5 +150,41 @@ describe("managed service update handoff single-flight", () => {
     expect(child.listenerCount("exit")).toBe(1);
     expect(child.listenerCount("error")).toBe(0);
     expect(child.stdout.destroyed).toBe(true);
+  });
+
+  it("joins canonical aliases but rejects a distinct active install root", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-handoff-root-"));
+    tempRootDirs.add(tempDir);
+    const installRoot = path.join(tempDir, "install");
+    const installAlias = path.join(tempDir, "install-alias");
+    const otherRoot = path.join(tempDir, "other");
+    await fs.mkdir(installRoot);
+    await fs.mkdir(otherRoot);
+    await fs.symlink(installRoot, installAlias, "dir");
+    const child = createSpawnMock();
+    spawnMock.mockReturnValue(child);
+    const { startManagedServiceUpdateHandoff } =
+      await import("./update-managed-service-handoff.js");
+    const baseParams = {
+      restartDrainTimeoutMs: 300_000,
+      parentPid: 12345,
+      execPath: "/usr/local/bin/node",
+      argv1: "/opt/openclaw/openclaw.mjs",
+      meta: {},
+    };
+
+    const first = startManagedServiceUpdateHandoff({ ...baseParams, root: installRoot });
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1), FAST_WAIT_OPTS);
+    signalHandoffReady(child);
+    await expect(first).resolves.toMatchObject({ status: "started" });
+    await expect(
+      startManagedServiceUpdateHandoff({ ...baseParams, root: installAlias }),
+    ).resolves.toMatchObject({ status: "joined" });
+    await expect(
+      startManagedServiceUpdateHandoff({ ...baseParams, root: otherRoot }),
+    ).rejects.toThrow("managed update handoff root mismatch");
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    child.emit("exit", 0, null);
   });
 });

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -18,6 +18,7 @@ import {
   CONTROL_PLANE_UPDATE_SENTINEL_META_ENV,
   type ControlPlaneUpdateSentinelMetaFile,
 } from "./update-control-plane-sentinel.js";
+import { resolveUpdateInstallRoot } from "./update-install-root.js";
 import { MANAGED_SERVICE_UPDATE_HANDOFF_TEMP_PREFIX } from "./update-managed-service-handoff-cleanup.js";
 import type { UpdateRestartSentinelMeta } from "./update-restart-sentinel-payload.js";
 
@@ -440,6 +441,7 @@ function buildFallbackFailurePayload(reason) {
     message: typeof meta.note === "string" ? meta.note : null,
     stats: {
       mode: "unknown",
+      ...(typeof meta.root === "string" && meta.root.trim() ? { root: meta.root } : {}),
       ...(typeof meta.handoffId === "string" && meta.handoffId.trim()
         ? { handoffId: meta.handoffId }
         : {}),
@@ -697,7 +699,10 @@ type ManagedServiceUpdateHandoffResult = Omit<StartedManagedServiceUpdateHandoff
 // Keep one helper per Gateway process through its lifetime. Readiness only
 // means it loaded its parameters; spawning another helper before it exits races
 // update mutation, service recovery, and restart sentinel ownership.
-let activeManagedServiceUpdateHandoff: Promise<StartedManagedServiceUpdateHandoff> | null = null;
+let activeManagedServiceUpdateHandoff: {
+  root: string;
+  flight: Promise<StartedManagedServiceUpdateHandoff>;
+} | null = null;
 
 function isNodeLikeRuntime(execPath: string | undefined): boolean {
   if (!execPath?.trim()) {
@@ -968,6 +973,7 @@ async function resolveHandoffSpawn(params: {
 
 async function spawnManagedServiceUpdateHandoff(
   params: ManagedServiceUpdateHandoffParams,
+  rootIdentity: string,
   onExit: () => void,
 ): Promise<StartedManagedServiceUpdateHandoff> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), MANAGED_SERVICE_UPDATE_HANDOFF_TEMP_PREFIX));
@@ -990,7 +996,7 @@ async function spawnManagedServiceUpdateHandoff(
   const handoffCwd = await resolveManagedServiceHandoffCwd(params.root);
   const metaFile: ControlPlaneUpdateSentinelMetaFile = {
     version: 1,
-    meta: params.meta,
+    meta: { ...params.meta, root: rootIdentity },
   };
   const stateDatabasePath = resolveOpenClawStateSqlitePath(params.env ?? process.env);
   const helperParams = {
@@ -1063,21 +1069,27 @@ async function spawnManagedServiceUpdateHandoff(
 export async function startManagedServiceUpdateHandoff(
   params: ManagedServiceUpdateHandoffParams,
 ): Promise<ManagedServiceUpdateHandoffResult> {
+  const root = resolveUpdateInstallRoot(params.root);
   const active = activeManagedServiceUpdateHandoff;
   if (active) {
-    return { ...(await active), status: "joined" };
+    if (active.root !== root) {
+      throw new Error(
+        `managed update handoff root mismatch: active=${active.root} requested=${root}`,
+      );
+    }
+    return { ...(await active.flight), status: "joined" };
   }
 
-  const flight = spawnManagedServiceUpdateHandoff(params, () => {
-    if (activeManagedServiceUpdateHandoff === flight) {
+  const flight = spawnManagedServiceUpdateHandoff(params, root, () => {
+    if (activeManagedServiceUpdateHandoff?.flight === flight) {
       activeManagedServiceUpdateHandoff = null;
     }
   });
-  activeManagedServiceUpdateHandoff = flight;
+  activeManagedServiceUpdateHandoff = { root, flight };
   try {
     return await flight;
   } catch (err) {
-    if (activeManagedServiceUpdateHandoff === flight) {
+    if (activeManagedServiceUpdateHandoff?.flight === flight) {
       activeManagedServiceUpdateHandoff = null;
     }
     throw err;

--- a/src/infra/update-restart-sentinel-payload.ts
+++ b/src/infra/update-restart-sentinel-payload.ts
@@ -10,6 +10,7 @@ import type { UpdateRunResult } from "./update-runner.js";
 // restart so the next gateway can report completion or failure.
 /** Metadata needed to route update restart continuation messages. */
 export type UpdateRestartSentinelMeta = {
+  root?: string;
   sessionKey?: string;
   deliveryContext?: {
     channel?: string;
@@ -62,7 +63,7 @@ export function buildUpdateRestartSentinelPayload(params: {
     doctorHint: formatDoctorNonInteractiveHint(),
     stats: {
       mode: result.mode,
-      ...(result.root ? { root: result.root } : {}),
+      ...(meta.root || result.root ? { root: meta.root ?? result.root } : {}),
       ...(meta.handoffId ? { handoffId: meta.handoffId } : {}),
       before: result.before ?? null,
       after: result.after ?? null,

--- a/src/infra/update-runner-install-surface.ts
+++ b/src/infra/update-runner-install-surface.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { detectGlobalInstallManagerForRoot } from "./update-global.js";
+import { resolveUpdateInstallRoot, updateInstallRootsMatch } from "./update-install-root.js";
 import { buildUpdateCommandRunner, DEFAULT_TIMEOUT_MS } from "./update-runner-command.js";
 import type {
   CommandRunner,
@@ -99,14 +100,6 @@ export async function findPackageRoot(candidates: string[]) {
   return null;
 }
 
-export async function resolveComparablePath(target: string): Promise<string> {
-  return await fs.realpath(target).catch(() => path.resolve(target));
-}
-
-export async function pathsReferToSameLocation(left: string, right: string): Promise<boolean> {
-  return (await resolveComparablePath(left)) === (await resolveComparablePath(right));
-}
-
 export async function looksLikeGitCheckout(root: string): Promise<boolean> {
   try {
     await fs.access(path.join(root, ".git"));
@@ -125,13 +118,13 @@ export async function resolveUpdateInstallSurface(
   const packageRoot = await findPackageRoot(candidates);
 
   let gitRoot = await resolveGitRoot(runCommand, candidates, timeoutMs);
-  if (gitRoot && packageRoot && path.resolve(gitRoot) !== path.resolve(packageRoot)) {
+  if (gitRoot && packageRoot && !updateInstallRootsMatch(gitRoot, packageRoot)) {
     gitRoot = null;
   }
   if (gitRoot && !packageRoot) {
-    return { kind: "missing", mode: "unknown", root: gitRoot };
+    return { kind: "missing", mode: "unknown", root: resolveUpdateInstallRoot(gitRoot) };
   }
-  if (gitRoot && packageRoot && path.resolve(gitRoot) === path.resolve(packageRoot)) {
+  if (gitRoot && packageRoot) {
     return { kind: "git", mode: "git", root: gitRoot, packageRoot };
   }
   if (!packageRoot) {

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -1,6 +1,7 @@
 import { readPackageVersion } from "./package-json.js";
 // Runs OpenClaw package update checks, package steps, and restart handoff.
 import { detectGlobalInstallManagerForRoot } from "./update-global.js";
+import { resolveUpdateInstallRoot, updateInstallRootsMatch } from "./update-install-root.js";
 import { buildUpdateCommandRunner, DEFAULT_TIMEOUT_MS } from "./update-runner-command.js";
 import { resolveUpdateDoctorExecutionPolicy } from "./update-runner-doctor.js";
 import { runGitUpdate } from "./update-runner-git.js";
@@ -10,8 +11,6 @@ import {
   findPackageRoot,
   looksLikeGitCheckout,
   normalizeDir,
-  pathsReferToSameLocation,
-  resolveComparablePath,
   resolveGitRoot,
   resolveUpdateInstallSurface,
 } from "./update-runner-install-surface.js";
@@ -38,13 +37,13 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
     const cwdRoot = normalizeDir(opts.cwd);
     if (
       cwdRoot &&
-      (await pathsReferToSameLocation(cwdRoot, pkgRoot)) &&
+      updateInstallRootsMatch(cwdRoot, pkgRoot) &&
       (await looksLikeGitCheckout(cwdRoot))
     ) {
-      gitRoot = await resolveComparablePath(cwdRoot);
+      gitRoot = resolveUpdateInstallRoot(cwdRoot);
     }
   }
-  if (gitRoot && pkgRoot && !(await pathsReferToSameLocation(gitRoot, pkgRoot))) {
+  if (gitRoot && pkgRoot && !updateInstallRootsMatch(gitRoot, pkgRoot)) {
     gitRoot = null;
   }
   if (gitRoot && !pkgRoot) {
@@ -57,7 +56,7 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       durationMs: Date.now() - startedAt,
     };
   }
-  if (gitRoot && pkgRoot && (await pathsReferToSameLocation(gitRoot, pkgRoot))) {
+  if (gitRoot && pkgRoot && updateInstallRootsMatch(gitRoot, pkgRoot)) {
     return await runGitUpdate({
       opts,
       gitRoot,

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -309,10 +309,10 @@ describe("update-startup", () => {
     mockNpmChannelTag(tag, version);
   }
 
-  function mockPackageInstallStatus() {
-    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue("/opt/openclaw");
+  function mockPackageInstallStatus(root = "/opt/openclaw") {
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
     vi.mocked(checkUpdateStatus).mockResolvedValue({
-      root: "/opt/openclaw",
+      root,
       installKind: "package",
       packageManager: "npm",
     } satisfies UpdateCheckResult);
@@ -1220,6 +1220,7 @@ describe("update-startup", () => {
         ts: installedAtMs,
         stats: {
           mode: "git",
+          root: "/opt/openclaw",
           after: { sha: "current-sha", version: "1.0.0" },
         },
       });
@@ -1238,6 +1239,35 @@ describe("update-startup", () => {
       currentSha: "current-sha",
       commitAtMs,
       installedAtMs,
+    });
+  });
+
+  it("does not inherit install time from a same-SHA receipt for another checkout", async () => {
+    const installedAtMs = Date.now() - 60 * 60 * 1000;
+    runOpenClawStateWriteTransaction(({ db }) => {
+      writeUpdateInstallReceiptRowSync(db, {
+        kind: "update",
+        status: "ok",
+        ts: installedAtMs,
+        stats: {
+          mode: "git",
+          root: "/opt/other-openclaw",
+          after: { sha: "current-sha", version: "1.0.0" },
+        },
+      });
+    });
+    mockDevGitStatus({ behind: 0 });
+
+    await runGatewayUpdateCheck({
+      cfg: { update: { channel: "dev" } },
+      log: { info: vi.fn() },
+      isNixMode: false,
+      allowInTests: true,
+    });
+
+    expect(getUpdateSchedule()?.install?.git).toEqual({
+      status: "current",
+      currentSha: "current-sha",
     });
   });
 
@@ -1573,7 +1603,11 @@ describe("update-startup", () => {
   });
 
   it("hands supervised auto-updates to a detached service handoff before restarting", async () => {
-    mockPackageInstallStatus();
+    const installRoot = path.join(tempDir, "pnpm-store-target");
+    const installOwner = path.join(tempDir, "pnpm-linked-owner");
+    await fs.mkdir(installRoot);
+    await fs.symlink(installRoot, installOwner, "dir");
+    mockPackageInstallStatus(installOwner);
     mockNpmChannelTag("beta", "2.0.0-beta.1");
     detectRespawnSupervisorMock.mockReturnValue("launchd");
     startManagedServiceUpdateHandoffMock.mockResolvedValueOnce({
@@ -1596,7 +1630,7 @@ describe("update-startup", () => {
     expect(runCommandWithTimeout).not.toHaveBeenCalled();
     expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        root: "/opt/openclaw",
+        root: installOwner,
         timeoutMs: 45 * 60 * 1000,
         restartDrainTimeoutMs: 300_000,
         channel: "beta",

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -1,7 +1,6 @@
 // Runs startup update checks and optional auto-update handoff.
 import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import {
   asDateTimestampMs,
@@ -58,6 +57,7 @@ import {
   type UpdateCheckResult,
 } from "./update-check.js";
 import { CONTROL_PLANE_UPDATE_HANDOFF_STARTED_REASON } from "./update-control-plane-sentinel.js";
+import { updateInstallRootsMatch } from "./update-install-root.js";
 import { startManagedServiceUpdateHandoff } from "./update-managed-service-handoff.js";
 
 type UpdateCheckState = {
@@ -415,17 +415,6 @@ function resolveStableAutoApplyAtMs(params: {
   return firstSeenMs + baseDelayMs + jitterMs;
 }
 
-function resolveAutoUpdateHandoffRoot(root: string | undefined): string {
-  if (root?.trim()) {
-    return root;
-  }
-  try {
-    return process.cwd();
-  } catch {
-    return os.homedir();
-  }
-}
-
 function resolveManagedAutoUpdateRestartDelayMs(supervisor: RespawnSupervisor): number {
   return supervisor === "systemd" ? MANAGED_AUTO_UPDATE_SYSTEMD_RESTART_GRACE_MS : 0;
 }
@@ -442,8 +431,11 @@ async function startManagedServiceAutoUpdateHandoff(params: {
   const restartDelayMs = resolveManagedAutoUpdateRestartDelayMs(params.supervisor);
   const handoffId = randomUUID();
   try {
+    if (!params.root?.trim()) {
+      throw new Error("managed auto-update install root is unavailable");
+    }
     const started = await startManagedServiceUpdateHandoff({
-      root: resolveAutoUpdateHandoffRoot(params.root),
+      root: params.root,
       timeoutMs: params.timeoutMs,
       restartDrainTimeoutMs: params.restartDrainTimeoutMs,
       channel: params.channel,
@@ -590,21 +582,21 @@ function clearAutoState(nextState: UpdateCheckState): void {
 }
 
 async function resolveStartupInstallStatus(fetchGit: boolean) {
-  const root = await resolveOpenClawPackageRoot({
+  const resolvedRoot = await resolveOpenClawPackageRoot({
     moduleUrl: import.meta.url,
     argv1: process.argv[1],
     cwd: process.cwd(),
   });
   const [status, installReceipt] = await Promise.all([
     checkUpdateStatus({
-      root,
+      root: resolvedRoot,
       timeoutMs: 2500,
       fetchGit,
       includeRegistry: false,
     }),
     readUpdateInstallReceipt(),
   ]);
-  return { root, status, installReceipt };
+  return { root: resolvedRoot, status, installReceipt };
 }
 
 type GitScheduleStatus = NonNullable<NonNullable<UpdateScheduleState["install"]>["git"]>;
@@ -622,12 +614,17 @@ function gitCommitsMatch(left: string, right: string): boolean {
 function resolveGitInstalledAtMs(
   git: NonNullable<UpdateCheckResult["git"]>,
   installReceipt: RestartSentinelPayload | null,
+  root: string | null,
 ): number | undefined {
   const receiptSha = installReceipt?.stats?.after?.sha;
+  const receiptRoot = installReceipt?.stats?.root;
   return installReceipt?.kind === "update" &&
     installReceipt.status === "ok" &&
     installReceipt.stats?.mode === "git" &&
     typeof receiptSha === "string" &&
+    typeof receiptRoot === "string" &&
+    root !== null &&
+    updateInstallRootsMatch(root, receiptRoot) &&
     git.sha &&
     gitCommitsMatch(receiptSha, git.sha)
     ? installReceipt.ts
@@ -637,12 +634,13 @@ function resolveGitInstalledAtMs(
 function resolveGitScheduleStatus(
   update: UpdateCheckResult,
   installReceipt: RestartSentinelPayload | null,
+  root: string | null,
 ): GitScheduleStatus | undefined {
   if (update.installKind !== "git") {
     return undefined;
   }
   const git = update.git;
-  const installedAtMs = git ? resolveGitInstalledAtMs(git, installReceipt) : undefined;
+  const installedAtMs = git ? resolveGitInstalledAtMs(git, installReceipt, root) : undefined;
   const metadata = git
     ? {
         ...(git.sha ? { currentSha: git.sha } : {}),
@@ -687,8 +685,9 @@ function withInstallStatus(
   update: UpdateCheckResult,
   includeGitStatus: boolean,
   installReceipt: RestartSentinelPayload | null,
+  root: string | null,
 ): UpdateScheduleState {
-  const git = includeGitStatus ? resolveGitScheduleStatus(update, installReceipt) : undefined;
+  const git = includeGitStatus ? resolveGitScheduleStatus(update, installReceipt, root) : undefined;
   return {
     ...schedule,
     install: {
@@ -704,12 +703,12 @@ export async function refreshGatewayUpdateStatus(cfg: OpenClawConfig): Promise<v
   if (channel !== "dev") {
     return;
   }
-  const { status, installReceipt } = await resolveStartupInstallStatus(true);
+  const { root, status, installReceipt } = await resolveStartupInstallStatus(true);
   const current =
     updateScheduleCache?.channel === channel
       ? updateScheduleCache
       : { channel, autoEnabled: Boolean(cfg.update?.auto?.enabled) };
-  setUpdateScheduleCache({ next: withInstallStatus(current, status, true, installReceipt) });
+  setUpdateScheduleCache({ next: withInstallStatus(current, status, true, installReceipt, root) });
 }
 
 async function resolveDevGitCommits(params: {
@@ -971,6 +970,7 @@ export async function runGatewayUpdateCheck(params: {
         installStatus.status,
         configuredChannel === "dev",
         installStatus.installReceipt,
+        installStatus.root,
       ),
       onUpdateScheduleChange: params.onUpdateScheduleChange,
     });
@@ -1062,6 +1062,7 @@ export async function runGatewayUpdateCheck(params: {
       status,
       isDevGit,
       installReceipt,
+      root,
     ),
     onUpdateScheduleChange: params.onUpdateScheduleChange,
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a managed Gateway update could hand control to a detached child associated with the wrong OpenClaw checkout. `update.run` resolved the authoritative `installSurface.root` but passed a generic root to the detached handoff, which then rediscovered its own root. Update receipts were associated by revision/profile but not checkout root, so another checkout at the same SHA could incorrectly inherit `installedAt`.

## Why This Change Was Made

Canonical install-root identity belongs to the update install-surface owner, so this change carries that identity through the managed handoff, restart sentinel, and install receipt. The lexical mutation path remains unchanged; only managed lifecycle ownership and validation are tightened.

## User Impact

Managed Gateway updates now reject handoffs and restarts that resolve to a different checkout. Symlink aliases that resolve to the same canonical checkout continue to work.

Release-note context: managed Gateway updates are now pinned to their originating install root, preventing detached update/restart work and update-age metadata from crossing between checkouts.

## Evidence

- Focused regression command:

  ```text
  node scripts/run-vitest.mjs src/gateway/server-methods/update.test.ts src/infra/update-managed-service-handoff-command.test.ts src/infra/update-managed-service-handoff.single-flight.test.ts src/infra/update-managed-service-handoff-lifecycle.test.ts src/infra/restart-sentinel.test.ts src/infra/update-startup.test.ts src/infra/update-runner.test.ts src/cli/update-cli.test.ts
  ```

  Result: 449 passed, 1 skipped across 3 Vitest shards.
- Targeted formatting: `./node_modules/.bin/oxfmt --check` over all 16 changed files passed.
- Diff hygiene: `git diff --check origin/main...HEAD` passed.
- Codex autoreview: clean, with no accepted/actionable findings.
- LOC: production +135/-61; tests +193/-36.
- Known changed-check limitation: the remote changed-check wrapper exited after policy checks without a named failure, while the local wrapper was blocked by an unrelated shared heavy-check lock. The full changed gate is therefore not claimed here; focused proof and exact-head PR CI remain the landing evidence.

AI-assisted: Codex; maintainer-owned implementation, review, and verification.
