### PR TITLE
test(zalo): remove private rate-limit size seam

### DIFF
--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -14,7 +14,6 @@ import { ZaloWebhookPayloadError } from "./webhook-spool.js";
 
 const {
   clearZaloWebhookSecurityStateForTest,
-  getZaloWebhookRateLimitStateSizeForTest,
   getZaloWebhookStatusCounterSizeForTest,
   handleZaloWebhookRequest: handleZaloWebhookRequestInternal,
   registerZaloWebhookTarget,
@@ -325,7 +324,6 @@ describe("handleZaloWebhookRequest", () => {
         });
 
         expect(saw429).toBe(true);
-        expect(getZaloWebhookRateLimitStateSizeForTest()).toBe(1);
       });
     } finally {
       unregister();
@@ -345,7 +343,6 @@ describe("handleZaloWebhookRequest", () => {
         });
 
         expect(saw429).toBe(true);
-        expect(getZaloWebhookRateLimitStateSizeForTest()).toBe(1);
       });
     } finally {
       unregister();

--- a/extensions/zalo/src/monitor.webhook.ts
+++ b/extensions/zalo/src/monitor.webhook.ts
@@ -50,10 +50,6 @@ function clearZaloWebhookSecurityStateForTest(): void {
   webhookAnomalyTracker.clear();
 }
 
-function getZaloWebhookRateLimitStateSizeForTest(): number {
-  return webhookRateLimiter.size();
-}
-
 function getZaloWebhookStatusCounterSizeForTest(): number {
   return webhookAnomalyTracker.size();
 }
@@ -192,7 +188,6 @@ async function handleZaloWebhookRequest(
 
 export const zaloWebhookRuntime = {
   clearZaloWebhookSecurityStateForTest,
-  getZaloWebhookRateLimitStateSizeForTest,
   getZaloWebhookStatusCounterSizeForTest,
   handleZaloWebhookRequest,
   registerZaloWebhookTarget,


### PR DESCRIPTION
## What Problem This Solves

The Zalo webhook tests duplicated the observable rate-limit contract by inspecting a private limiter map size. That private assertion coupled the tests and runtime surface to an implementation detail without proving additional behavior.

## Why This Change Was Made

Remove the private rate-limiter size accessor and its two assertions. The retained HTTP tests still prove that authenticated and unauthorized requests with 130 changing nonce queries share the intended stable key by observing a 429 response, while the anomaly status-counter hook and assertions remain intact.

## User Impact

None. This is a test-seam cleanup with no runtime behavior change.

## Evidence

- All 12 focused Zalo webhook tests pass, including authenticated and unauthorized nonce-churn rate limiting, trusted forwarded-client separation, auth-before-content-type ordering, and anomaly-counter coverage.
- The full classified extension changed gate passed through the trusted local fallback after the remote Crabbox binary failed its pre-execution sanity check. This included extension production and test typechecks, targeted extension lint, formatting, plugin boundary/API guards, dead-export scanning, and architecture guards.
- Targeted formatting, lint, and `git diff --check` pass.
- Autoreview and its exact-diff TruffleHog scan are clean.

AI-assisted: yes.
