### PR TITLE
fix(telegram): guard Codex usage-limit reply copy

### DIFF
--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -4833,9 +4833,10 @@ describe("createTelegramBot", () => {
     expect(requireValue(sendMessageSpy.mock.calls.at(0), "sendMessageSpy call")[1]).toBe(
       codexRateLimitText,
     );
+    // Keep this fallback copy aligned with src/auto-reply/reply/agent-runner-failure-reply.ts.
     expect(
       String(requireValue(sendMessageSpy.mock.calls.at(0), "sendMessageSpy call")[1]),
-    ).not.toContain("All models are temporarily rate-limited");
+    ).not.toContain("All attempted models were rate-limited or overloaded.");
   });
 
   it("honors threaded replies for replyToMode=first/all", async () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Telegram bot regression test excluded a retired generic rate-limit message, so the negative assertion passed vacuously and no longer protected the Codex usage-limit reset reply from the current generic fallback copy.

## Why This Change Was Made

The assertion now excludes the current fallback text owned by `src/auto-reply/reply/agent-runner-failure-reply.ts`, with a source breadcrumb beside the literal. The core literal remains private; the plugin test does not add a core-internal import or export production copy solely for testing.

AI-assisted: yes.

## User Impact

There is no runtime behavior change. This restores meaningful Telegram regression coverage so Codex usage-limit reset details cannot be silently replaced by the current generic multi-model rate-limit reply while the test still passes.

## Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.test.ts` — 144 tests passed.
- `pnpm format extensions/telegram/src/bot.create-telegram-bot.test.ts` — clean.
- `git diff --check` — clean.
- Autoreview — clean, no accepted/actionable findings.
- Swept all negative string assertions in the target file with exact `rg -F` checks; no additional stale production-copy assertion was found.
