### PR TITLE
fix(telegram): remove vacuous usage-limit assertion

### DIFF
--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -4833,10 +4833,6 @@ describe("createTelegramBot", () => {
     expect(requireValue(sendMessageSpy.mock.calls.at(0), "sendMessageSpy call")[1]).toBe(
       codexRateLimitText,
     );
-    // Keep this fallback copy aligned with src/auto-reply/reply/agent-runner-failure-reply.ts.
-    expect(
-      String(requireValue(sendMessageSpy.mock.calls.at(0), "sendMessageSpy call")[1]),
-    ).not.toContain("All attempted models were rate-limited or overloaded.");
   });
 
   it("honors threaded replies for replyToMode=first/all", async () => {


### PR DESCRIPTION
Related: #121291

## What Problem This Solves

#121291 corrected the stale literal, but the Telegram transport test still duplicates core fallback prose even though its preceding exact equality already proves the complete reply body.

## Why This Change Was Made

Delete the redundant negative assertion and its synchronization comment; keep the exact Codex usage-limit reply equality as the canonical regression signal; avoid exporting or importing core-owned copy across the plugin boundary. A same-file sweep found no other stale negative copy assertions.

## User Impact

No runtime behavior change. Regression coverage is clearer, with no future stale-copy synchronization burden.

## Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.test.ts` — 1 file passed, 144 tests passed on the rebased head.
- `git diff --check origin/main...HEAD` — passed.
- Simplify panel consensus — remove only the synchronization comment and redundant negative assertion while retaining the stronger exact equality.
- Fresh Codex-backed autoreview — clean, with no accepted or actionable findings.
- Exact-head CI — required green on the rebased head before prepare and merge; see this PR's checks when complete.
- AI-assisted: yes.

