### PR TITLE
fix(agents): preserve rate-limit retries without a fallback model

### DIFF
--- a/src/agents/embedded-agent-runner/run/failover-retry-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-retry-controller.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FailoverError } from "../../failover-error.js";
+import { createEmbeddedRunFailoverRetryController } from "./failover-retry-controller.js";
+
+const { sleepWithAbortMock } = vi.hoisted(() => ({
+  sleepWithAbortMock: vi.fn(async () => {}),
+}));
+
+vi.mock("../../../infra/backoff.js", () => ({
+  sleepWithAbort: sleepWithAbortMock,
+}));
+
+function createController(fallbackConfigured: boolean) {
+  return createEmbeddedRunFailoverRetryController({
+    runParams: {
+      sessionId: "session:rate-limit-controller",
+      runId: "run:rate-limit-controller",
+    } as never,
+    provider: "openai",
+    modelId: "mock-1",
+    globalLane: "test",
+    agentDir: "/tmp/openclaw-rate-limit-controller-test",
+    fallbackConfigured,
+    profileFailureStore: { version: 1, profiles: {} } as never,
+    getLastProfileId: () => "openai:p1",
+    getSessionId: () => "session:rate-limit-controller",
+    harnessOwnsTransport: () => false,
+    getRuntimeAuthOwnerId: () => "pi",
+    getApiKeyInfo: () => null,
+  });
+}
+
+describe("createEmbeddedRunFailoverRetryController", () => {
+  beforeEach(() => {
+    sleepWithAbortMock.mockClear();
+  });
+
+  it("keeps the full same-model retry budget when no fallback rotation is configured", async () => {
+    const controller = createController(false);
+
+    controller.maybeEscalateRateLimitProfileFallback({
+      failoverProvider: "openai",
+      failoverModel: "mock-1",
+      logFallbackDecision: vi.fn(),
+    });
+
+    expect(controller.rateLimitProfileRotations).toBe(0);
+    expect(controller.rateLimitProfileRotations).toBeLessThan(
+      controller.rateLimitProfileRotationLimit,
+    );
+    await expect(controller.maybeRetrySameModelRateLimit()).resolves.toBe(true);
+    await expect(controller.maybeRetrySameModelRateLimit()).resolves.toBe(true);
+    await expect(controller.maybeRetrySameModelRateLimit()).resolves.toBe(true);
+    await expect(controller.maybeRetrySameModelRateLimit()).resolves.toBe(false);
+  });
+
+  it("counts one actual rotation and does not increment while enforcing the cap", () => {
+    const controller = createController(true);
+    const logFallbackDecision = vi.fn();
+    const escalation = {
+      failoverProvider: "groq",
+      failoverModel: "mock-2",
+      logFallbackDecision,
+    };
+
+    controller.maybeEscalateRateLimitProfileFallback(escalation);
+    expect(controller.rateLimitProfileRotations).toBe(1);
+
+    expect(() => controller.maybeEscalateRateLimitProfileFallback(escalation)).toThrow(
+      FailoverError,
+    );
+    expect(controller.rateLimitProfileRotations).toBe(1);
+    expect(logFallbackDecision).toHaveBeenCalledOnce();
+    expect(logFallbackDecision).toHaveBeenCalledWith("fallback_model", { status: 429 });
+  });
+});

--- a/src/agents/embedded-agent-runner/run/failover-retry-controller.ts
+++ b/src/agents/embedded-agent-runner/run/failover-retry-controller.ts
@@ -86,8 +86,13 @@ export function createEmbeddedRunFailoverRetryController(input: {
       failoverModel: string;
       logFallbackDecision: (decision: "fallback_model", extra?: { status?: number }) => void;
     }) => {
-      rateLimitProfileRotations += 1;
-      if (rateLimitProfileRotations <= rateLimitProfileRotationLimit || !fallbackConfigured) {
+      if (!fallbackConfigured) {
+        return;
+      }
+      if (rateLimitProfileRotations < rateLimitProfileRotationLimit) {
+        // This state gates same-model retries, so skipped rotations must not consume it;
+        // otherwise one rate-limit response can disable the remaining retry budget.
+        rateLimitProfileRotations += 1;
         return;
       }
       const status = resolveFailoverStatus("rate_limit");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users hitting a rate limit without a configured fallback model would silently lose the same-model retry budget. A skipped profile rotation incremented the rotation counter, so the next assistant failure no longer received the intended three bounded same-model retries.

## Why This Change Was Made

The failover retry controller now records a rate-limit profile rotation only when fallback policy permits that rotation. No-fallback and rotation-cap paths leave the counter unchanged, preserving the counter as the authoritative record of rotations actually performed while retaining the existing cross-model escalation after one rotation.

The regression coverage sits at the controller boundary because that owner couples the rotation counter to the same-model retry budget.

## User Impact

When no fallback model is configured, rate-limit handling keeps all three same-model retries available instead of silently disabling them after one skipped rotation. Configurations with fallback models still rotate once and then escalate to the configured fallback model.

## Evidence

- Red-before-fix controller regression: the no-fallback counter was `1` instead of `0`, and cap escalation inflated the counter from `1` to `2`.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/failover-retry-controller.test.ts` — 2/2 passed after the fix.
- `node scripts/run-vitest.mjs src/agents/model-fallback.run-embedded.e2e.test.ts` — 18/18 passed, including the #58348 and #58572 rotation-cap scenarios.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run` — 4,689/4,707 passed; 18 unrelated aggregate failures came from cross-file mock leakage (for example, the deliberate `bundle policy failed` mock from `attempt-bundle-tools.test.ts` leaking into `attempt.cwd-split.test.ts`). The representative isolated rerun `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts` passed 5/5.
- `pnpm format src/agents/embedded-agent-runner/run/failover-retry-controller.ts src/agents/embedded-agent-runner/run/failover-retry-controller.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, no accepted/actionable findings.
- Exact-head CI — [run 31344378408](https://github.com/openclaw/openclaw/actions/runs/31344378408) passed for `17ccc6e7ca47abe867177d0a3b13a5270b8a3bd1`.
