### PR TITLE
test(gateway): exercise schema cache through handlers

### DIFF
--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -10,11 +10,7 @@ import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snaps
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { withEnvAsync } from "../../test-utils/env.js";
-import {
-  clearConfigSchemaResponseCacheForTests,
-  configHandlers,
-  loadConfigSchemaResponseForTests,
-} from "./config.js";
+import { clearConfigSchemaResponseCacheForTests, configHandlers } from "./config.js";
 import { createConfigHandlerHarness, createConfigWriteSnapshot } from "./config.test-helpers.js";
 
 const configWriteMocks = vi.hoisted(() => ({
@@ -128,6 +124,15 @@ async function invokeConfigPatch(args: {
   await expectDefined(
     configHandlers["config.patch"],
     'configHandlers["config.patch"] test invariant',
+  )(harness.options);
+  return harness;
+}
+
+async function invokeConfigSchema() {
+  const harness = createConfigHandlerHarness({ method: "config.schema" });
+  await expectDefined(
+    configHandlers["config.schema"],
+    'configHandlers["config.schema"] test invariant',
   )(harness.options);
   return harness;
 }
@@ -268,11 +273,7 @@ describe("config schema response cache", () => {
       uiHints: { "gateway.port": { advanced: false } },
       version: "test-schema",
     });
-    const harness = createConfigHandlerHarness({ method: "config.schema" });
-    await expectDefined(
-      configHandlers["config.schema"],
-      'configHandlers["config.schema"] test invariant',
-    )(harness.options);
+    const harness = await invokeConfigSchema();
 
     expect(harness.respond).toHaveBeenCalledWith(
       true,
@@ -283,25 +284,33 @@ describe("config schema response cache", () => {
     );
   });
 
-  it("reuses a recent schema build across burst config requests", () => {
-    loadConfigSchemaResponseForTests();
-    loadConfigSchemaResponseForTests();
+  it("reuses a recent schema build across burst config requests", async () => {
+    await invokeConfigSchema();
+    await invokeConfigSchema();
 
     expect(loadGatewayRuntimeConfigSchemaMock).toHaveBeenCalledTimes(1);
   });
 
-  it("can be cleared when config writes change schema inputs", () => {
-    loadConfigSchemaResponseForTests();
-    clearConfigSchemaResponseCacheForTests();
-    loadConfigSchemaResponseForTests();
+  it("rebuilds after config writes change schema inputs", async () => {
+    await invokeConfigSchema();
+    const patch = await invokeConfigPatch({ raw: { ui: { prefs: { theme: "knot" } } } });
+
+    expect(patch.respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ ok: true }),
+      undefined,
+    );
+    expect(loadGatewayRuntimeConfigSchemaMock).toHaveBeenCalledTimes(1);
+
+    await invokeConfigSchema();
 
     expect(loadGatewayRuntimeConfigSchemaMock).toHaveBeenCalledTimes(2);
   });
 
-  it("rebuilds when the active plugin registry generation changes", () => {
-    loadConfigSchemaResponseForTests();
+  it("rebuilds when the active plugin registry generation changes", async () => {
+    await invokeConfigSchema();
     setActivePluginRegistry(createTestRegistry([]));
-    loadConfigSchemaResponseForTests();
+    await invokeConfigSchema();
 
     expect(loadGatewayRuntimeConfigSchemaMock).toHaveBeenCalledTimes(2);
   });

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -660,10 +660,6 @@ export function clearConfigSchemaResponseCacheForTests() {
   invalidateConfigGetResponseCache();
 }
 
-export function loadConfigSchemaResponseForTests(): ConfigSchemaResponse {
-  return loadSchemaWithPlugins();
-}
-
 function clearConfigSchemaResponseCache() {
   configSchemaResponseCache = null;
 }


### PR DESCRIPTION
## What Problem This Solves

The Gateway config-schema cache tests used a private loader export, so the tests bypassed the `config.schema` request-handler boundary they claimed to cover. The invalidation test also cleared the cache directly instead of proving that a successful config write owns invalidation.

## Why This Change Was Made

The tests now exercise schema reuse and plugin-generation invalidation through the `config.schema` handler, then perform a successful `config.patch` between schema calls to prove write-owned invalidation. The private test-only schema loader is removed; the cache-clear hook remains for test isolation and `config.get` cache cleanup.

## User Impact

None. Runtime behavior is unchanged; this strengthens boundary coverage and removes a test-only production export.

## Evidence

- 78 focused tests passed across the Gateway config handler/patch and runtime-schema suites.
- The `core, coreTests` changed gate passed, including production/test types, targeted lint, dead-export checks, plugin boundaries, import cycles, and repository guards.
- `git diff --check` passed.
- Autoreview and the pre-review secret scan passed with no actionable findings.

AI-assisted: yes.
