### PR TITLE
fix(slack): support Enterprise Grid channel create and rename events

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -73,9 +73,9 @@ One Slack account can receive messages from every workspace covered by an
 Enterprise Grid org-wide installation. Choose direct Socket Mode or HTTP
 Request URLs; relay mode is not supported for enterprise accounts. Both
 least-privilege manifests below enable the V1 message, mention, membership,
-reaction, and pin event paths, immediate replies, listener-owned status
-reactions, Slack interactivity for Block Kit actions and modal submissions, and
-the single `/openclaw` slash command.
+reaction, pin, channel-created, and channel-renamed event paths, immediate
+replies, listener-owned status reactions, Slack interactivity for Block Kit
+actions and modal submissions, and the single `/openclaw` slash command.
 
 #### Socket Mode
 
@@ -125,6 +125,8 @@ the single `/openclaw` slash command.
     "event_subscriptions": {
       "bot_events": [
         "app_mention",
+        "channel_created",
+        "channel_rename",
         "message.channels",
         "message.groups",
         "message.im",
@@ -225,6 +227,8 @@ Socket Mode connection. Replace the example URL with the Gateway's public
       "request_url": "https://gateway-host.example.com/slack/events",
       "bot_events": [
         "app_mention",
+        "channel_created",
+        "channel_rename",
         "message.channels",
         "message.groups",
         "message.im",
@@ -283,19 +287,20 @@ bot-authored `message` and `app_mention` events before dispatch, regardless of
 bot identity for loop prevention.
 
 Enterprise support accepts direct Socket Mode or HTTP message, mention,
-membership, reaction, pin, Block Kit action, modal, and configured shortcut
-and slash-command payloads plus workspace-qualified outbound messages. Add any
-shortcuts to the app manifest's `features.shortcuts` list; OpenClaw accepts
-their callback IDs through the same interaction path. The manifest examples
-register the single `/openclaw` command; native command mode still requires the
-administrator-managed command entries described below. Relay mode, channel
-lifecycle events, App Home, Agent and Assistant lifecycle events, Slack-native
-approvals, and bindings remain unavailable for an enterprise account. Slack
-action tools remain unavailable except for file uploads and adding or removing
-emoji reactions. Inbound membership, reaction, and pin notifications use the
-listener-owned, workspace-scoped Slack client. Outbound acknowledgment, typing,
-and status reactions are also supported through that client and require
-`reactions:write`.
+membership, reaction, pin, channel-created, channel-renamed, Block Kit action,
+modal, and configured shortcut and slash-command payloads plus
+workspace-qualified outbound messages. Add any shortcuts to the app manifest's
+`features.shortcuts` list; OpenClaw accepts their callback IDs through the same
+interaction path. The manifest examples register the single `/openclaw`
+command; native command mode still requires the administrator-managed command
+entries described below. Relay mode, channel-ID-change events, App Home, Agent
+and Assistant lifecycle events, Slack-native approvals, and bindings remain
+unavailable for an enterprise account. Slack action tools remain unavailable
+except for file uploads and adding or removing emoji reactions. Inbound
+membership, reaction, pin, channel-created, and channel-renamed notifications
+use listener-owned, workspace-scoped Slack event routing. Outbound
+acknowledgment, typing, and status reactions are also supported through that
+client and require `reactions:write`.
 
 OpenClaw records Enterprise Grid destinations as
 `team:<team-id>:channel:<channel-id>` or `team:<team-id>:user:<user-id>`.

--- a/extensions/slack/src/monitor/events.enterprise.test.ts
+++ b/extensions/slack/src/monitor/events.enterprise.test.ts
@@ -8,6 +8,7 @@ const registrations = vi.hoisted(() => ({
   agent: vi.fn(),
   assistant: vi.fn(),
   channel: vi.fn(),
+  channelIdChanged: vi.fn(),
   home: vi.fn(),
   interaction: vi.fn(),
   member: vi.fn(),
@@ -20,7 +21,10 @@ vi.mock("./events/agent.js", () => ({ registerSlackAgentEvents: registrations.ag
 vi.mock("./events/assistant.js", () => ({
   registerSlackAssistantEvents: registrations.assistant,
 }));
-vi.mock("./events/channels.js", () => ({ registerSlackChannelEvents: registrations.channel }));
+vi.mock("./events/channels.js", () => ({
+  registerSlackChannelEvents: registrations.channel,
+  registerSlackChannelIdChangedEvent: registrations.channelIdChanged,
+}));
 vi.mock("./events/home.js", () => ({ registerSlackHomeEvents: registrations.home }));
 vi.mock("./events/interactions.js", () => ({
   registerSlackInteractionEvents: registrations.interaction,
@@ -57,17 +61,18 @@ describe("registerSlackMonitorEvents", () => {
     }
   });
 
-  it("registers messages, reactions, pins, and member events for enterprise installs", () => {
+  it("registers workspace-safe events for enterprise installs", () => {
     registerForInstallation("enterprise");
 
     expect(registrations.message).toHaveBeenCalledOnce();
     expect(registrations.reaction).toHaveBeenCalledOnce();
     expect(registrations.pin).toHaveBeenCalledOnce();
     expect(registrations.member).toHaveBeenCalledOnce();
-    expect(registrations.channel).not.toHaveBeenCalled();
+    expect(registrations.channel).toHaveBeenCalledOnce();
+    expect(registrations.channelIdChanged).not.toHaveBeenCalled();
     expect(registrations.home).not.toHaveBeenCalled();
     expect(registrations.agent).not.toHaveBeenCalled();
-    expect(registrations.interaction).not.toHaveBeenCalled();
+    expect(registrations.interaction).toHaveBeenCalledOnce();
     expect(registrations.assistant).not.toHaveBeenCalled();
   });
 

--- a/extensions/slack/src/monitor/events.ts
+++ b/extensions/slack/src/monitor/events.ts
@@ -3,7 +3,10 @@ import type { ResolvedSlackAccount } from "../accounts.js";
 import type { SlackMonitorContext } from "./context.js";
 import { registerSlackAgentEvents } from "./events/agent.js";
 import { registerSlackAssistantEvents } from "./events/assistant.js";
-import { registerSlackChannelEvents } from "./events/channels.js";
+import {
+  registerSlackChannelEvents,
+  registerSlackChannelIdChangedEvent,
+} from "./events/channels.js";
 import { registerSlackHomeEvents } from "./events/home.js";
 import { registerSlackInteractionEvents } from "./events/interactions.js";
 import { registerSlackMemberEvents } from "./events/members.js";
@@ -27,11 +30,12 @@ export function registerSlackMonitorEvents(params: {
   registerSlackReactionEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
   registerSlackPinEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
   registerSlackMemberEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
+  registerSlackChannelEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
   registerSlackInteractionEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
   if (params.ctx.installationIdentity.kind === "enterprise") {
     return;
   }
-  registerSlackChannelEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
+  registerSlackChannelIdChangedEvent({ ctx: params.ctx, trackEvent: params.trackEvent });
   registerSlackHomeEvents({
     ctx: params.ctx,
     slashCommandName: params.appHomeSlashCommandName,

--- a/extensions/slack/src/monitor/events/channels.test.ts
+++ b/extensions/slack/src/monitor/events/channels.test.ts
@@ -1,4 +1,5 @@
 // Slack tests cover channels plugin behavior.
+import type { AllMiddlewareArgs } from "@slack/bolt";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { enqueueSystemEventMock, mutateConfigFileMock, readConfigSnapshotMock } = vi.hoisted(() => ({
@@ -7,6 +8,7 @@ const { enqueueSystemEventMock, mutateConfigFileMock, readConfigSnapshotMock } =
   readConfigSnapshotMock: vi.fn(),
 }));
 let registerSlackChannelEvents: typeof import("./channels.js").registerSlackChannelEvents;
+let registerSlackChannelIdChangedEvent: typeof import("./channels.js").registerSlackChannelIdChangedEvent;
 let createSlackSystemEventTestHarness: typeof import("./system-event-test-harness.js").createSlackSystemEventTestHarness;
 
 vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
@@ -23,6 +25,7 @@ type SlackChannelHandler = (args: {
   event: Record<string, unknown>;
   body: unknown;
   context?: Record<string, unknown>;
+  client?: AllMiddlewareArgs["client"];
 }) => Promise<void>;
 
 function createChannelContext(params?: {
@@ -34,6 +37,7 @@ function createChannelContext(params?: {
     harness.ctx.shouldDropMismatchedSlackEvent = params.shouldDropMismatchedSlackEvent;
   }
   registerSlackChannelEvents({ ctx: harness.ctx, trackEvent: params?.trackEvent });
+  registerSlackChannelIdChangedEvent({ ctx: harness.ctx, trackEvent: params?.trackEvent });
   return {
     ctx: harness.ctx,
     getHandler: (name: string) => harness.getHandler(name) as SlackChannelHandler | null,
@@ -50,7 +54,8 @@ function requireChannelHandler(handler: SlackChannelHandler | null): SlackChanne
 
 describe("registerSlackChannelEvents", () => {
   beforeAll(async () => {
-    ({ registerSlackChannelEvents } = await import("./channels.js"));
+    ({ registerSlackChannelEvents, registerSlackChannelIdChangedEvent } =
+      await import("./channels.js"));
     ({ createSlackSystemEventTestHarness } = await import("./system-event-test-harness.js"));
   });
 
@@ -97,6 +102,92 @@ describe("registerSlackChannelEvents", () => {
       contextKey: "slack:channel:created:C1:Ev-channel-1",
     });
   });
+
+  it("keeps enterprise channel notifications isolated by listener workspace", async () => {
+    const { ctx, getHandler } = createChannelContext();
+    ctx.installationIdentity = {
+      kind: "enterprise",
+      apiAppId: "A_GRID",
+      enterpriseId: "E_GRID",
+    };
+    const resolveSessionKey = vi.fn(
+      (input: Parameters<typeof ctx.resolveSlackSystemEventSessionKey>[0]) =>
+        `session:${input.eventScope?.teamId ?? "workspace"}`,
+    );
+    ctx.resolveSlackSystemEventSessionKey = resolveSessionKey;
+
+    const cases = [
+      {
+        name: "channel_created",
+        event: { channel: { id: "C1", name: "general" } },
+        message: "Slack channel created: #general.",
+        kind: "created",
+      },
+      {
+        name: "channel_rename",
+        event: { channel: { id: "C1", name: "old-name", name_normalized: "new-name" } },
+        message: "Slack channel renamed: #new-name.",
+        kind: "renamed",
+      },
+    ] as const;
+
+    for (const teamId of ["T111", "T222"]) {
+      for (const eventCase of cases) {
+        const handler = requireChannelHandler(getHandler(eventCase.name));
+        await handler({
+          event: eventCase.event,
+          body: { api_app_id: "A_GRID", event_id: `Ev-${eventCase.name}-${teamId}` },
+          context: {
+            isEnterpriseInstall: true,
+            enterpriseId: "E_GRID",
+            teamId,
+          },
+          client: { token: `listener-${teamId}` } as AllMiddlewareArgs["client"],
+        });
+      }
+    }
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(4);
+    for (const [index, teamId] of ["T111", "T222"].entries()) {
+      for (const [caseIndex, eventCase] of cases.entries()) {
+        expect(enqueueSystemEventMock).toHaveBeenNthCalledWith(
+          index * cases.length + caseIndex + 1,
+          eventCase.message,
+          {
+            sessionKey: `session:${teamId}`,
+            contextKey: `slack:channel:${teamId}:${eventCase.kind}:C1:Ev-${eventCase.name}-${teamId}`,
+          },
+        );
+      }
+    }
+  });
+
+  it.each(["channel_created", "channel_rename"])(
+    "rejects enterprise %s events without validated listener scope",
+    async (eventName) => {
+      const trackEvent = vi.fn();
+      const { ctx, getHandler } = createChannelContext({ trackEvent });
+      ctx.installationIdentity = {
+        kind: "enterprise",
+        apiAppId: "A_GRID",
+        enterpriseId: "E_GRID",
+      };
+      const handler = requireChannelHandler(getHandler(eventName));
+
+      await handler({
+        event: { channel: { id: "C1", name: "general" } },
+        body: { api_app_id: "A_GRID", event_id: `Ev-${eventName}` },
+        context: {
+          isEnterpriseInstall: true,
+          enterpriseId: "E_GRID",
+        },
+        client: { token: "listener" } as AllMiddlewareArgs["client"],
+      });
+
+      expect(trackEvent).not.toHaveBeenCalled();
+      expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("keeps live config unchanged when channel-ID persistence fails, then retries", async () => {
     const oldChannelId = "C_OLD";

--- a/extensions/slack/src/monitor/events/channels.ts
+++ b/extensions/slack/src/monitor/events/channels.ts
@@ -11,12 +11,14 @@ import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { migrateSlackChannelConfig } from "../../channel-migration.js";
 import { resolveSlackChannelLabel } from "../channel-config.js";
 import type { SlackMonitorContext } from "../context.js";
+import type { SlackEventScope } from "../event-scope.js";
 import { resolveSlackIngressTurnLifecycle } from "../ingress.js";
 import type {
   SlackChannelCreatedEvent,
   SlackChannelIdChangedEvent,
   SlackChannelRenamedEvent,
 } from "../types.js";
+import { resolveSlackListenerEventScope } from "./system-event-context.js";
 
 export function registerSlackChannelEvents(params: {
   ctx: SlackMonitorContext;
@@ -29,6 +31,7 @@ export function registerSlackChannelEvents(params: {
     channelId: string | undefined;
     channelName: string | undefined;
     eventId: string;
+    eventScope?: SlackEventScope;
   }) => {
     if (
       !ctx.isChannelAllowed({
@@ -47,16 +50,22 @@ export function registerSlackChannelEvents(params: {
     const sessionKey = ctx.resolveSlackSystemEventSessionKey({
       channelId: paramsLocal.channelId,
       channelType: "channel",
+      eventScope: paramsLocal.eventScope,
     });
     enqueueSystemEvent(`Slack channel ${paramsLocal.kind}: ${label}.`, {
       sessionKey,
-      contextKey: `slack:channel:${paramsLocal.kind}:${paramsLocal.channelId ?? paramsLocal.channelName ?? "unknown"}:${paramsLocal.eventId}`,
+      contextKey: `slack:channel:${paramsLocal.eventScope ? `${paramsLocal.eventScope.teamId}:` : ""}${paramsLocal.kind}:${paramsLocal.channelId ?? paramsLocal.channelName ?? "unknown"}:${paramsLocal.eventId}`,
     });
   };
 
   ctx.app.event(
     "channel_created",
-    async ({ event, body }: SlackEventMiddlewareArgs<"channel_created">) => {
+    async (args: SlackEventMiddlewareArgs<"channel_created"> & AllMiddlewareArgs) => {
+      const { event, body, context, client } = args;
+      const eventScope = resolveSlackListenerEventScope({ ctx, body, context, client });
+      if (eventScope === null) {
+        return;
+      }
       if (ctx.shouldDropMismatchedSlackEvent(body)) {
         return;
       }
@@ -70,13 +79,19 @@ export function registerSlackChannelEvents(params: {
         channelId,
         channelName,
         eventId: body.event_id,
+        eventScope,
       });
     },
   );
 
   ctx.app.event(
     "channel_rename",
-    async ({ event, body }: SlackEventMiddlewareArgs<"channel_rename">) => {
+    async (args: SlackEventMiddlewareArgs<"channel_rename"> & AllMiddlewareArgs) => {
+      const { event, body, context, client } = args;
+      const eventScope = resolveSlackListenerEventScope({ ctx, body, context, client });
+      if (eventScope === null) {
+        return;
+      }
       if (ctx.shouldDropMismatchedSlackEvent(body)) {
         return;
       }
@@ -90,9 +105,17 @@ export function registerSlackChannelEvents(params: {
         channelId,
         channelName,
         eventId: body.event_id,
+        eventScope,
       });
     },
   );
+}
+
+export function registerSlackChannelIdChangedEvent(params: {
+  ctx: SlackMonitorContext;
+  trackEvent?: () => void;
+}) {
+  const { ctx, trackEvent } = params;
 
   ctx.app.event(
     "channel_id_changed",


### PR DESCRIPTION
Related: #121014

## What Problem This Solves

Fixes an issue where users with an Enterprise Grid org-wide Slack installation would not receive OpenClaw system notifications when a public channel was created or renamed.

## Why This Change Was Made

This stacked change registers only `channel_created` and `channel_rename` before the workspace-only event gate. Both handlers validate the listener-owned event scope introduced by #121014 and use its team ID for session routing and deduplication. `channel_id_changed` remains workspace-only because it mutates persisted channel configuration. The recommended organization manifests now subscribe to both supported events.

## User Impact

Enterprise Grid accounts can observe channel creation and rename events in the correct workspace without changing standard Slack behavior.

## Evidence

- `git diff --check`
- `./node_modules/.bin/oxfmt --check ...`: all 5 changed files use the correct format
- `node scripts/run-vitest.mjs extensions/slack/src/monitor/events/channels.test.ts extensions/slack/src/monitor/events.enterprise.test.ts`: 2 files passed, 8 tests passed
- `pnpm docs:check-mdx`: 770 files passed
- `pnpm test:extension slack`: 131 of 133 files passed and 2,296 of 2,299 tests passed. The two blocked-address upload assertions and one durable member-retry assertion also fail unchanged on the current #121014 head.
- `.agents/skills/autoreview/scripts/autoreview --mode local`: `autoreview clean: no accepted/actionable findings reported`
- AI-assisted by Codex; the implementation and generated test coverage were reviewed against the Slack event scope boundary.
