### PR TITLE
fix(mac): adopt CLI identity during state migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS device identity startup:** let the app adopt canonical CLI-written identities while the shared SQLite schema migration is still pending, preserve underlying identity-store errors, and keep onboarding Gateway readiness current through startup progress.
 - **Control UI browser annotations:** keep marked screenshots and generated page context together in structured composer cards, preserve user-written drafts when annotations are removed or replaced, retain complete unsent annotation packages across same-tab route and active split-pane remounts, and offer bounded Undo without restoring removed context into another session. Fixes #120744. Thanks @shakkernerd.
 - **Control UI profile avatar refreshes:** carry canonical content revisions through mutation responses and live presence so rapid replacements refresh every connected browser without stale cache rollback. Thanks @shakkernerd.
 - **Control UI appearance accessibility:** keep the unavailable custom-theme card announced as an Import command while preserving selected-state semantics for selectable themes and text sizes. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS device identity startup:** let the app adopt canonical CLI-written identities while the shared SQLite schema migration is still pending, preserve underlying identity-store errors, and keep onboarding Gateway readiness current through startup progress.
 - **Control UI browser annotations:** keep marked screenshots and generated page context together in structured composer cards, preserve user-written drafts when annotations are removed or replaced, retain complete unsent annotation packages across same-tab route and active split-pane remounts, and offer bounded Undo without restoring removed context into another session. Fixes #120744. Thanks @shakkernerd.
 - **Control UI profile avatar refreshes:** carry canonical content revisions through mutation responses and live presence so rapid replacements refresh every connected browser without stale cache rollback. Thanks @shakkernerd.
 - **Control UI appearance accessibility:** keep the unavailable custom-theme card announced as an Import command while preserving selected-state semantics for selectable themes and text sizes. Thanks @shakkernerd.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -35523,7 +35523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 380,
+      "line": 383,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift",
       "source": "Back",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
@@ -772,26 +772,15 @@ extension GatewayProcessManager {
             guard !Task.isCancelled, self.isCurrentGatewayStart(startGeneration) else { return }
             while Date() >= deadline {
                 guard deadline < finalProbeDeadline else { break readinessLoop }
-                if responsiveStartupProgressObserved {
-                    guard !Task.isCancelled,
-                          self.isCurrentGatewayStart(startGeneration),
-                          self.launchAgentReadinessRevision == context.readinessRevision
-                    else { return }
-                } else if freshInstallGraceAuthorized {
-                    // Repeating launchd status at every boundary would expand the wall-clock budget.
-                    // Generation/revision guard intermediate windows; success and final repair re-check ownership.
-                    guard self.isCurrentFreshInstallReadiness(
-                        context: context,
-                        startGeneration: startGeneration)
-                    else { return }
-                } else {
-                    guard let reusablePID = await self.currentInstallReusableLaunchdPID(
-                        context: context,
-                        startGeneration: startGeneration)
-                    else { break readinessLoop }
-                    readinessPID = reusablePID
-                    freshInstallGraceAuthorized = true
-                }
+                let extensionAuthorization = await self.authorizeReadinessExtension(
+                    context: context,
+                    startGeneration: startGeneration,
+                    responsiveStartupProgressObserved: responsiveStartupProgressObserved,
+                    freshInstallGraceAuthorized: freshInstallGraceAuthorized,
+                    readinessPID: readinessPID)
+                guard extensionAuthorization.allowed else { break readinessLoop }
+                readinessPID = extensionAuthorization.readinessPID
+                freshInstallGraceAuthorized = true
                 deadline = min(
                     deadline.addingTimeInterval(readinessWindow),
                     finalProbeDeadline)
@@ -850,6 +839,27 @@ extension GatewayProcessManager {
                 startGeneration: startGeneration,
                 expectedReadinessRevision: context.readinessRevision)
         }
+    }
+
+    private func authorizeReadinessExtension(
+        context: LaunchAgentStartupContext,
+        startGeneration: UInt64,
+        responsiveStartupProgressObserved: Bool,
+        freshInstallGraceAuthorized: Bool,
+        readinessPID: Int32?) async -> (allowed: Bool, readinessPID: Int32?)
+    {
+        if responsiveStartupProgressObserved || freshInstallGraceAuthorized {
+            // One live response or verified launchd owner authorizes the bounded migration window;
+            // repeating launchd status at every boundary would expand the wall-clock budget.
+            let isCurrent = !Task.isCancelled &&
+                self.isCurrentGatewayStart(startGeneration) &&
+                self.launchAgentReadinessRevision == context.readinessRevision
+            return (isCurrent, readinessPID)
+        }
+        let reusablePID = await self.currentInstallReusableLaunchdPID(
+            context: context,
+            startGeneration: startGeneration)
+        return (reusablePID != nil, reusablePID)
     }
 
     private func currentInstallReusableLaunchdPID(

--- a/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
@@ -767,11 +767,17 @@ extension GatewayProcessManager {
         var latestRetryDisposition: GatewayProbeFailureDisposition?
         var readinessPID = context.readinessPID
         var freshInstallGraceAuthorized = false
+        var responsiveStartupProgressObserved = false
         readinessLoop: while true {
             guard !Task.isCancelled, self.isCurrentGatewayStart(startGeneration) else { return }
             while Date() >= deadline {
                 guard deadline < finalProbeDeadline else { break readinessLoop }
-                if freshInstallGraceAuthorized {
+                if responsiveStartupProgressObserved {
+                    guard !Task.isCancelled,
+                          self.isCurrentGatewayStart(startGeneration),
+                          self.launchAgentReadinessRevision == context.readinessRevision
+                    else { return }
+                } else if freshInstallGraceAuthorized {
                     // Repeating launchd status at every boundary would expand the wall-clock budget.
                     // Generation/revision guard intermediate windows; success and final repair re-check ownership.
                     guard self.isCurrentFreshInstallReadiness(
@@ -821,6 +827,9 @@ extension GatewayProcessManager {
                 case .retryWithoutRepair:
                     // A responsive transient invalidates older connection-failure evidence.
                     latestRetryDisposition = .retryWithoutRepair
+                    if self.probeFailureShowsStartupProgress(error) {
+                        responsiveStartupProgressObserved = true
+                    }
                 }
                 let retryDelay = min(0.4, max(0, deadline.timeIntervalSinceNow))
                 if retryDelay > 0 {
@@ -996,6 +1005,11 @@ extension GatewayProcessManager {
         default:
             return .fail
         }
+    }
+
+    private func probeFailureShowsStartupProgress(_ error: Error) -> Bool {
+        guard let response = error as? GatewayResponseError else { return false }
+        return response.code.uppercased() == "UNAVAILABLE"
     }
 
     private func probeFailureIsCancellation(_ error: Error) -> Bool {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -61,6 +61,9 @@ extension OnboardingView {
             guard installed else { return }
             self.updateMonitoring(for: self.activePageIndex)
         }
+        .onChange(of: GatewayProcessManager.shared.status) { _, status in
+            self.reviseCLIActivationFailureIfGatewayReady(status)
+        }
         .onDisappear {
             self.onboardingDidDisappear()
         }

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
@@ -99,6 +99,31 @@ extension OnboardingView {
         isLocal && executableReady && !installing
     }
 
+    static func shouldReviseCLIActivationFailure(
+        gatewayStatus: GatewayProcessManager.Status,
+        isLocal: Bool,
+        executableReady: Bool,
+        installed: Bool) -> Bool
+    {
+        guard isLocal, executableReady, !installed else { return false }
+        return switch gatewayStatus {
+        case .running, .attachedExisting: true
+        case .stopped, .starting, .failed: false
+        }
+    }
+
+    func reviseCLIActivationFailureIfGatewayReady(_ status: GatewayProcessManager.Status) {
+        guard Self.shouldReviseCLIActivationFailure(
+            gatewayStatus: status,
+            isLocal: state.connectionMode == .local,
+            executableReady: cliExecutableReady,
+            installed: cliInstalled)
+        else { return }
+        cliInstalled = true
+        cliStatusKnown = true
+        cliStatus = "OpenClaw Gateway is ready."
+    }
+
     func finishExistingCLIActivation() async {
         defer {
             installingCLI = false

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
@@ -121,7 +121,7 @@ extension OnboardingView {
         else { return }
         cliInstalled = true
         cliStatusKnown = true
-        cliStatus = "OpenClaw Gateway is ready."
+        cliStatus = nil
     }
 
     func finishExistingCLIActivation() async {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
@@ -1153,6 +1153,43 @@ struct GatewayProcessManagerTests {
         }
     }
 
+    @Test func `responsive startup progress extends readiness without launchd status proof`() async throws {
+        let port = 19119
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let (_, connection, manager) = self.makeGatewayReadinessFixture(url: url) {
+            self.gatewayTask(healthSucceedsAfter: 1)
+        }
+        defer { manager.setTestingConnection(nil) }
+
+        try await self.withLaunchAgentEnvironment(
+            port: port,
+            statusPayload: #"{"ok":true,"service":{"loaded":false}}"#)
+        {
+            manager.setTestingSkipControlChannelRefresh(true)
+            manager._testClearLaunchAgentReadinessFailure()
+            let descriptor = self.gatewayDescriptor(pid: 4242)
+            await PortGuardian.shared.setTestingDescriptor(descriptor, forPort: port)
+            defer {
+                manager.setTestingSkipControlChannelRefresh(false)
+                manager._testClearLaunchAgentReadinessFailure()
+            }
+
+            manager._testStartLaunchdGatewayReadiness(
+                port: port,
+                pid: 4242,
+                readinessWindow: 0.05,
+                firstInstallReadinessBudget: 0.5)
+            await manager.waitForStartupAttempt()
+
+            #expect(manager.status == .running(details: "pid 4242"))
+            #expect(manager.lastFailureReason == nil)
+            #expect(!manager._testHasLaunchAgentReadinessFailure())
+
+            await connection.shutdown()
+            await PortGuardian.shared.setTestingDescriptor(nil, forPort: port)
+        }
+    }
+
     @Test func `delayed fresh install authorization cannot restart readiness budget`() async throws {
         let port = 19118
         let url = try #require(URL(string: "ws://example.invalid"))

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -234,6 +234,29 @@ struct OnboardingViewSmokeTests {
             installing: true))
     }
 
+    @Test func `later gateway readiness revises a pinned CLI activation failure`() {
+        #expect(OnboardingView.shouldReviseCLIActivationFailure(
+            gatewayStatus: .running(details: "pid 4242"),
+            isLocal: true,
+            executableReady: true,
+            installed: false))
+        #expect(OnboardingView.shouldReviseCLIActivationFailure(
+            gatewayStatus: .attachedExisting(details: "pid 4242"),
+            isLocal: true,
+            executableReady: true,
+            installed: false))
+        #expect(!OnboardingView.shouldReviseCLIActivationFailure(
+            gatewayStatus: .failed("still unavailable"),
+            isLocal: true,
+            executableReady: true,
+            installed: false))
+        #expect(!OnboardingView.shouldReviseCLIActivationFailure(
+            gatewayStatus: .running(details: nil),
+            isLocal: false,
+            executableReady: true,
+            installed: false))
+    }
+
     @Test func `connection mode change restarts full page monitoring`() {
         let state = AppState(preview: true)
         let view = OnboardingView(state: state)

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceAuthStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceAuthStore.swift
@@ -139,6 +139,7 @@ public enum DeviceAuthStore {
             .appendingPathComponent("openclaw.sqlite", isDirectory: false)
         guard let identity = try? DeviceIdentitySQLiteStore.loadExisting(
             databaseURL: databaseURL,
+            destinationStateDirURL: stateDirectoryURL,
             profile: profile)
         else { return }
         try? self.withStore(profile: profile) { database in

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
@@ -259,18 +259,26 @@ public enum DeviceIdentityStore {
     #endif
 
     public static func loadOrCreate(profile: GatewayDeviceIdentityProfile) -> DeviceIdentity {
-        guard let identity = loadOrCreatePersisted(profile: profile) else {
-            preconditionFailure("Could not persist the OpenClaw device identity")
+        do {
+            return try self.loadOrCreatePersistedOrThrow(profile: profile)
+        } catch {
+            preconditionFailure("Could not persist the OpenClaw device identity: \(error.localizedDescription)")
         }
-        return identity
     }
 
     /// Loads or creates an identity, returning nil unless its key material was durably persisted.
     public static func loadOrCreatePersisted(
         profile: GatewayDeviceIdentityProfile = .primary) -> DeviceIdentity?
     {
+        try? self.loadOrCreatePersistedOrThrow(profile: profile)
+    }
+
+    /// Loads or creates an identity and preserves the storage failure for callers that can report it.
+    static func loadOrCreatePersistedOrThrow(
+        profile: GatewayDeviceIdentityProfile = .primary) throws -> DeviceIdentity
+    {
         let stateDirURL = DeviceIdentityPaths.stateDirURL()
-        return try? DeviceIdentitySQLiteStore.loadOrCreate(
+        return try DeviceIdentitySQLiteStore.loadOrCreate(
             databaseURL: self.databaseURL(stateDirURL: stateDirURL),
             destinationStateDirURL: stateDirURL,
             profile: profile,

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
@@ -278,11 +278,22 @@ public enum DeviceIdentityStore {
         profile: GatewayDeviceIdentityProfile = .primary) throws -> DeviceIdentity
     {
         let stateDirURL = DeviceIdentityPaths.stateDirURL()
-        return try DeviceIdentitySQLiteStore.loadOrCreate(
-            databaseURL: self.databaseURL(stateDirURL: stateDirURL),
-            destinationStateDirURL: stateDirURL,
-            profile: profile,
-            legacySources: DeviceIdentityPaths.legacyIdentitySources(profile: profile))
+        do {
+            return try DeviceIdentitySQLiteStore.loadOrCreate(
+                databaseURL: self.databaseURL(stateDirURL: stateDirURL),
+                destinationStateDirURL: stateDirURL,
+                profile: profile,
+                legacySources: DeviceIdentityPaths.legacyIdentitySources(profile: profile))
+        } catch {
+            throw NSError(
+                domain: "ai.openclaw.device-identity-store",
+                code: 2,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Could not access the persisted device identity: \(error.localizedDescription)",
+                    NSUnderlyingErrorKey: error,
+                ])
+        }
     }
 
     public static func signPayload(_ payload: String, identity: DeviceIdentity) -> String? {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentitySQLiteStore.swift
@@ -98,14 +98,18 @@ enum DeviceIdentitySQLiteStore {
 
     static func loadExisting(
         databaseURL: URL,
+        destinationStateDirURL: URL,
         profile: GatewayDeviceIdentityProfile) throws -> DeviceIdentity?
     {
         let database = try OpenClawNativeStateSQLite(
             databaseURL: databaseURL,
             createIfMissing: false)
         guard try database.schemaObjectExists(type: "table", name: "device_identities") else { return nil }
-        try database.ensureCanonicalTable(.deviceIdentities, allowVersionZeroCreation: false)
-        return try self.readIdentity(database, key: profile.rawValue)?.identity
+        try self.ensureIdentityTable(database, allowVersionZeroCreation: false)
+        return try self.readIdentity(
+            database,
+            key: profile.rawValue,
+            stateDirectoryURL: destinationStateDirURL)?.identity
     }
 
     private static func loadOrCreateOwned(
@@ -139,7 +143,10 @@ enum DeviceIdentitySQLiteStore {
     {
         // SQLite owns an existing profile; leave any downgrade-recreated legacy source for Doctor.
         if self.pathMayExist(databaseURL),
-           let existing = try self.loadExisting(databaseURL: databaseURL, profile: profile)
+           let existing = try self.loadExisting(
+               databaseURL: databaseURL,
+               destinationStateDirURL: destinationStateDirURL,
+               profile: profile)
         {
             return existing
         }
@@ -181,8 +188,11 @@ enum DeviceIdentitySQLiteStore {
 
         let database = try OpenClawNativeStateSQLite(databaseURL: databaseURL)
         let authoritative = try database.withImmediateTransaction {
-            try database.ensureCanonicalTable(.deviceIdentities)
-            let existing = try self.readIdentity(database, key: profile.rawValue)
+            try self.ensureIdentityTable(database, allowVersionZeroCreation: true)
+            let existing = try self.readIdentity(
+                database,
+                key: profile.rawValue,
+                stateDirectoryURL: destinationStateDirURL)
             let selected: DeviceIdentityMaterial
             if let existing {
                 if let migrated = claims.first?.material,
@@ -207,12 +217,15 @@ enum DeviceIdentitySQLiteStore {
 
             // The row reread under the write transaction is authoritative. Never return generated
             // or migrated key material unless SQLite reports the exact canonical receipt.
-            guard let authoritative = try self.readIdentity(database, key: profile.rawValue),
-                  authoritative == selected
+            guard let authoritative = try self.readIdentity(
+                database,
+                key: profile.rawValue,
+                stateDirectoryURL: destinationStateDirURL),
+                authoritative == selected
             else {
                 throw DeviceIdentityStore.storageError("SQLite did not preserve the authoritative device identity")
             }
-            try database.ensureCanonicalTable(.deviceIdentities, allowVersionZeroCreation: false)
+            try self.ensureIdentityTable(database, allowVersionZeroCreation: false)
             return authoritative
         }
 
@@ -220,8 +233,11 @@ enum DeviceIdentitySQLiteStore {
             try afterLegacyCommit?()
             // The committed reread is the destructive-cleanup receipt. Doctor cannot alter the
             // row while the native claim remains visible to every Node identity entry point.
-            guard let committedIdentity = try self.readIdentity(database, key: profile.rawValue),
-                  committedIdentity == authoritative
+            guard let committedIdentity = try self.readIdentity(
+                database,
+                key: profile.rawValue,
+                stateDirectoryURL: destinationStateDirURL),
+                committedIdentity == authoritative
             else {
                 throw DeviceIdentityStore.storageError(
                     "Committed SQLite identity changed before legacy cleanup; native claim preserved")
@@ -381,7 +397,8 @@ enum DeviceIdentitySQLiteStore {
 
     private static func readIdentity(
         _ database: OpenClawNativeStateSQLite,
-        key: String) throws -> DeviceIdentityMaterial?
+        key: String,
+        stateDirectoryURL: URL) throws -> DeviceIdentityMaterial?
     {
         let statement = try database.prepare("""
         SELECT device_id, public_key_pem, private_key_pem, created_at_ms, updated_at_ms
@@ -391,21 +408,45 @@ enum DeviceIdentitySQLiteStore {
         try statement.bindText(key, at: 1)
         let result = try statement.step()
         if result == .done { return nil }
-        guard statement.valueType(at: 3) == .integer,
-              statement.valueType(at: 4) == .integer,
-              statement.int64(at: 4) >= 0
-        else {
-            throw DeviceIdentityStore.storageError("SQLite device identity timestamps must be integers")
+        do {
+            guard statement.valueType(at: 3) == .integer,
+                  statement.valueType(at: 4) == .integer,
+                  statement.int64(at: 4) >= 0
+            else {
+                throw DeviceIdentityStore.storageError("SQLite device identity timestamps must be integers")
+            }
+            let material = try DeviceIdentityStore.material(
+                deviceId: statement.requiredText(at: 0, field: "device_id"),
+                publicKeyPEM: statement.requiredText(at: 1, field: "public_key_pem"),
+                privateKeyPEM: statement.requiredText(at: 2, field: "private_key_pem"),
+                createdAtMs: statement.int64(at: 3))
+            guard try statement.step() == .done else {
+                throw DeviceIdentityStore.storageError("SQLite returned duplicate device identity keys")
+            }
+            return material
+        } catch {
+            throw DeviceIdentityStore.storageError(
+                "Could not decode device identity row \"\(key)\" in state directory " +
+                    "\(stateDirectoryURL.path): \(error.localizedDescription)")
         }
-        let material = try DeviceIdentityStore.material(
-            deviceId: statement.requiredText(at: 0, field: "device_id"),
-            publicKeyPEM: statement.requiredText(at: 1, field: "public_key_pem"),
-            privateKeyPEM: statement.requiredText(at: 2, field: "private_key_pem"),
-            createdAtMs: statement.int64(at: 3))
-        guard try statement.step() == .done else {
-            throw DeviceIdentityStore.storageError("SQLite returned duplicate device identity keys")
+    }
+
+    private static func ensureIdentityTable(
+        _ database: OpenClawNativeStateSQLite,
+        allowVersionZeroCreation: Bool) throws
+    {
+        let userVersion = try database.scalarInt64("PRAGMA user_version")
+        if userVersion == 0,
+           try database.schemaObjectExists(type: "table", name: "device_identities")
+        {
+            // Node can populate its canonical table before the global schema migration commits.
+            // Validate this owner surface without rejecting unrelated Node-owned v0 tables.
+            try database.validateCanonicalTable(.deviceIdentities)
+            return
         }
-        return material
+        try database.ensureCanonicalTable(
+            .deviceIdentities,
+            allowVersionZeroCreation: allowVersionZeroCreation)
     }
 
     private static func insertIdentity(

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -420,18 +420,23 @@ public actor GatewayChannelActor {
         }
     }
 
-    private static func loadDeviceIdentityForConnect(
+    static func loadDeviceIdentityForConnect(
         includeDeviceIdentity: Bool,
         profile: GatewayDeviceIdentityProfile) throws -> DeviceIdentity?
     {
         guard includeDeviceIdentity else { return nil }
-        guard let identity = DeviceIdentityStore.loadOrCreatePersisted(profile: profile) else {
+        do {
+            return try DeviceIdentityStore.loadOrCreatePersistedOrThrow(profile: profile)
+        } catch {
             throw NSError(
                 domain: "Gateway",
                 code: 3,
-                userInfo: [NSLocalizedDescriptionKey: "Could not access the persisted device identity"])
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Could not access the persisted device identity: \(error.localizedDescription)",
+                    NSUnderlyingErrorKey: error,
+                ])
         }
-        return identity
     }
 
     private func sendConnect(

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -425,18 +425,7 @@ public actor GatewayChannelActor {
         profile: GatewayDeviceIdentityProfile) throws -> DeviceIdentity?
     {
         guard includeDeviceIdentity else { return nil }
-        do {
-            return try DeviceIdentityStore.loadOrCreatePersistedOrThrow(profile: profile)
-        } catch {
-            throw NSError(
-                domain: "Gateway",
-                code: 3,
-                userInfo: [
-                    NSLocalizedDescriptionKey:
-                        "Could not access the persisted device identity: \(error.localizedDescription)",
-                    NSUnderlyingErrorKey: error,
-                ])
-        }
+        return try DeviceIdentityStore.loadOrCreatePersistedOrThrow(profile: profile)
     }
 
     private func sendConnect(

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
@@ -537,6 +537,66 @@ struct DeviceIdentityStoreTests {
     }
 
     @Test
+    func `adopts a Node row and creates primary while the global version zero migration is pending`() throws {
+        let fixture = DeviceIdentityMigrationFixture()
+        try Self.seedCanonicalSchema(fixture.databaseURL)
+        try Self.execute(fixture.databaseURL, """
+        CREATE TABLE plugin_state_entries (entry_key TEXT NOT NULL PRIMARY KEY) STRICT;
+        INSERT INTO device_identities (
+          identity_key, device_id, public_key_pem, private_key_pem, created_at_ms, updated_at_ms
+        ) VALUES (
+          'node', '\(Self.fixtureDeviceID)', '\(Self.sql(Self.fixturePublicKeyPEM))',
+          '\(Self.sql(Self.fixturePrivateKeyPEM))', 1800000000000, 1800000000123
+        )
+        """)
+
+        let nodeIdentity = try fixture.load(profile: .node)
+        let primaryIdentity = try fixture.load()
+
+        #expect(nodeIdentity.deviceId == Self.fixtureDeviceID)
+        #expect(nodeIdentity.createdAtMs == 1_800_000_000_000)
+        #expect(primaryIdentity.deviceId != nodeIdentity.deviceId)
+        #expect(try Self.scalarInt(fixture.databaseURL, "PRAGMA user_version") == 0)
+        #expect(try Self.scalarInt(
+            fixture.databaseURL,
+            "SELECT updated_at_ms FROM device_identities WHERE identity_key = 'node'") == 1_800_000_000_123)
+        #expect(try Self.scalarInt(fixture.databaseURL, "SELECT COUNT(*) FROM device_identities") == 2)
+    }
+
+    @Test
+    func `gateway identity failure names corrupt row and state directory without rotating it`() async throws {
+        let fixture = DeviceIdentityMigrationFixture(databasePath: "state/openclaw.sqlite")
+        try Self.seedCanonicalSchema(fixture.databaseURL)
+        try Self.execute(fixture.databaseURL, """
+        INSERT INTO device_identities (
+          identity_key, device_id, public_key_pem, private_key_pem, created_at_ms, updated_at_ms
+        ) VALUES (
+          'primary', '\(Self.fixtureDeviceID)', '\(Self.sql(Self.fixturePublicKeyPEM))',
+          'not-a-private-key', 1800000000000, 1800000000123
+        )
+        """)
+
+        await DeviceIdentityStore.withStateDirectory(fixture.destination) {
+            do {
+                _ = try GatewayChannelActor.loadDeviceIdentityForConnect(
+                    includeDeviceIdentity: true,
+                    profile: .primary)
+                Issue.record("corrupt identity unexpectedly loaded")
+            } catch {
+                let message = error.localizedDescription
+                #expect(message.contains("Could not access the persisted device identity"))
+                #expect(message.contains("row \"primary\""))
+                #expect(message.contains(fixture.destination.path))
+                #expect(message.contains("invalid key material"))
+            }
+        }
+        #expect(try Self.scalarText(
+            fixture.databaseURL,
+            "SELECT private_key_pem FROM device_identities WHERE identity_key = 'primary'") ==
+            "not-a-private-key")
+    }
+
+    @Test
     func `same key migration preserves the authoritative SQLite timestamp`() throws {
         let fixture = DeviceIdentityMigrationFixture()
         let source = try fixture.source()


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the macOS app could reject the CLI-created device identity during first-run shared-state migration, repeatedly report `Could not access the persisted device identity`, and pin onboarding on “The Gateway didn’t start” even after the profile Gateway became healthy.

Live profile evidence showed identity failures at 17:31:09–17:31:13, the Node state migration beginning at 17:31:14.948 (`fromVersion: 0`, `toVersion: 6`), the app-created `primary` row appearing at 17:31:17, a responsive `gateway starting; retry shortly` answer at 17:31:29, and the app timing out at 17:31:38 despite the Gateway becoming ready.

## Why This Change Was Made

The snapshot disproved the initial PEM hypothesis: both `node` and `primary` rows use canonical Ed25519 SPKI/PKCS8 DER, canonical PEM framing, matching keypairs, and matching SHA-256 device IDs. The actual divergence was lifecycle ownership: while `PRAGMA user_version` was still zero, Node-owned tables already existed alongside the canonical `device_identities` table, so the Swift whole-database version-zero ownership check rejected identity access before it inspected the row.

The identity store now validates its own already-existing canonical table during that bounded migration state, without weakening newer-schema checks or synthesizing a missing table in a foreign database. Corrupt existing rows remain authoritative and fail closed; the error names the row and state directory and is threaded through Gateway connection logs instead of collapsing to a constant string.

The macOS readiness loop also treats a responsive `UNAVAILABLE` startup answer as live progress through the existing bounded migration tolerance, and onboarding revises its recorded CLI activation failure when later Gateway readiness proves the fact changed.

## User Impact

Named-profile and first-run macOS app sessions can adopt CLI-written device identities without rotating pairing trust, survive long state migrations, and recover the setup card when the Gateway becomes healthy. Truly corrupt identities are not overwritten and now produce actionable diagnostics.

## Evidence

- Snapshot copy, before fix: canonical PEM/keypair/device-ID checks passed in Node and Swift at schema version 6.
- Snapshot copy with the reproduced in-flight state (`PRAGMA user_version = 0`), before fix: `Schema version zero database contains objects not owned by a native OpenClaw store`.
- The same snapshot copy after the fix loaded `primary` successfully without rewriting it.
- `swift test --package-path apps/shared/OpenClawKit --filter 'adopts a Node row|gateway identity failure|reads a canonical Node SQLite row'` — 3 tests passed.
- `node scripts/run-vitest.mjs src/infra/device-identity.test.ts -t 'device identity SQLite store'` — 16 tests passed.
- `swift test --filter 'responsive startup progress|later gateway readiness'` from `apps/macos` — 2 tests passed.
- `swift build` from `apps/macos` — passed.
- Autoreview: clean, no accepted/actionable findings.

Local retry note: the unfiltered Node identity file intermittently hit its existing concurrent-creator stress case with `database disk image is malformed`; the owning identity-store filter, including that case, passed. No Node production code changed in this PR; exact-head CI is the arbiter for that follow-up signal.
