### PR TITLE
fix(signal): release ingress claim on any non-conflict debounce flush failure

### DIFF
--- a/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
+++ b/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
@@ -326,13 +326,23 @@ describe("signal reply session init conflict retry", () => {
     }
   });
 
-  it("does not retry non-conflict flush failures", async () => {
+  it("does not retry non-conflict flush failures, but releases the ingress claim", async () => {
     dispatchInboundMessageMock.mockRejectedValue(new Error("some other dispatch failure"));
 
     const handler = createSignalEventHandler(createBaseSignalEventHandlerDeps());
+    const onAbandoned = vi.fn().mockResolvedValue(undefined);
+    const turnAdoptionLifecycle = {
+      abortSignal: new AbortController().signal,
+      onAdopted: vi.fn(),
+      onDeferred: vi.fn(),
+      onAdoptionFinalizing: vi.fn(),
+      onAbandoned,
+    };
 
     vi.useFakeTimers();
     try {
+      // Without this release, an admission race (e.g. restart-recovery rotating
+      // session ownership) would strand the claim until the 300s stall watchdog.
       await handler(
         createSignalReceiveEvent({
           dataMessage: {
@@ -340,9 +350,11 @@ describe("signal reply session init conflict retry", () => {
             attachments: [],
           },
         }),
+        turnAdoptionLifecycle,
       );
 
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      expect(onAbandoned).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(10_000);
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -681,6 +681,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           await flushSignalInboundEntries(entries, admissionLifecycle, settle);
         } catch (err) {
           if (!isSignalReplySessionInitConflictError(err)) {
+            // Any other dispatch failure (e.g. a restart-recovery session-admission
+            // race) must release the claim now so queue retry policy redelivers it,
+            // instead of leaving it held for the full pre-adoption stall watchdog.
+            await admissionLifecycle.onAbandoned();
             throw err;
           }
           if (deps.abortSignal?.aborted) {


### PR DESCRIPTION
Closes #121269

🤖 AI-assisted PR (built with Claude). Marking per the "AI/Vibe-Coded PRs Welcome" checklist in CONTRIBUTING.md.

## What Problem This Solves

Fixes an issue where Signal users could go up to five minutes without any reply, and then permanently lose the message, whenever a debounced inbound flush failed for any reason other than the one specific "reply session initialization conflicted" error Signal already knew how to retry.

The reported production trigger is a gateway restart: `main-session-restart-recovery` resumes the interrupted session and, in doing so, wins the race for session-work admission. The original in-flight message's own admission attempt then loses that race and throws `Session "..." changed while starting work. Retry.` — a different error shape than the one Signal's retry logic recognizes. Today that error is rethrown bare, so the channel ingress claim for that message is never released. It sits held in `dispatching`/`deferred` until the core 300-second pre-adoption stall watchdog dead-letters it as `handler-timeout`, five minutes after the failure, with nothing in between telling the user anything went wrong.

## Why This Change Was Made

Signal's debounce flush (`extensions/signal/src/monitor/event-handler.ts`) only released the ingress claim (`onAbandoned()`) after exhausting its own retry loop for `isSignalReplySessionInitConflictError`. Every other dispatch failure skipped that release and was rethrown directly to the generic debounce error reporter, which only logs. Discord's equivalent flush (`extensions/discord/src/monitor/message-dispatcher.ts`) already wraps its dispatch body in a catch-all that calls `admissionLifecycle.onAbandoned()` before rethrowing *any* error, regardless of type. This PR brings Signal's non-retryable branch in line with that established sibling pattern: release the claim immediately on any dispatch failure that isn't the specific retryable conflict, so the existing queue retry policy (`releaseClaim` in `src/channels/message/ingress-drain.ts`) can redeliver the message right away instead of the watchdog eventually dead-lettering it. `onAbandoned()` is a documented no-op once a turn has already adopted, so this is safe to call unconditionally on any pre-adoption failure.

This does not change retry behavior for the recognized session-init-conflict case, and it does not touch the restart-recovery subsystem itself — it closes the specific "nothing retries" gap the issue calls out for Signal's debounce flush. The issue's other two asks (recovery reconciling ingress claims directly, and a user-visible surface for terminal dead-letters) are separate, larger changes better scoped as their own follow-ups.

## User Impact

**Before:** a Signal message caught in a restart-recovery admission race (or any other non-session-init-conflict dispatch failure) was held silently for the full 300-second watchdog window and then permanently dropped, with no reply and no retry.

**After:** the same failure releases the ingress claim immediately, so the message re-enters the normal queue retry path right away instead of waiting out the watchdog.

## Evidence

Added a regression case to the existing Signal retry-behavior suite (`extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts`) that drives a real (non-conflict) dispatch failure through the actual production catch block and asserts the ingress lifecycle's `onAbandoned()` was called.

Proved the test fails without the fix, by temporarily reverting only the production file and re-running:

```
$ git stash push -- extensions/signal/src/monitor/event-handler.ts
$ node scripts/run-vitest.mjs extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
 ❯ |extension-signal| extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts (7 tests | 1 failed)
     × does not retry non-conflict flush failures, but releases the ingress claim

AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
 ❯ extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts:357:27
    355|       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
    356|       expect(onAbandoned).toHaveBeenCalledTimes(1);
       |                           ^
 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)
$ git stash pop
```

With the fix restored, the full file passes:

```
$ node scripts/run-vitest.mjs extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Broader Signal monitor suite (no regressions):

```
$ node scripts/run-vitest.mjs extensions/signal/src/monitor
 Test Files  7 passed (7)
      Tests  132 passed (132)
```

Typecheck (both affected lanes, exit 0, no output):

```
$ pnpm tsgo:extensions
$ pnpm tsgo:extensions:test
```

Lint and formatting (both clean):

```
$ node scripts/run-oxlint.mjs extensions/signal/src/monitor/event-handler.ts extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
(exit 0, no findings)

$ ./node_modules/.bin/oxfmt --check extensions/signal/src/monitor/event-handler.ts extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
Checking formatting...
All matched files use the correct format.
```


## Additional Evidence (real-behavior proof, non-mocked)

ClawSweeper asked for a real (non-mocked) Signal ingress-and-durable-queue run showing that a non-conflict dispatch failure releases the claim and causes a queue retry redelivery, since the existing regression test above only asserts that `onAbandoned()` was *called* (mocked lifecycle).

**What's real, traced end-to-end through unchanged production code:**

The `admissionLifecycle` passed into Signal's flush `dispatch` callback (`extensions/signal/src/monitor/event-handler.ts:668-687`) is produced by `fanInChannelIngressLifecycles` (`src/plugin-sdk/channel-ingress-runtime.ts:125-155`, untouched by this PR). That function's `onAbandoned` is a pure passthrough — it calls `onAbandoned()` on each real per-entry `turnAdoptionLifecycle`, which is the actual `ChannelIngressDispatchLifecycle` object the durable drain (`src/channels/message/ingress-drain.ts`) hands to `dispatchClaimedEvent` for that claim. There is no Signal-specific indirection between this PR's new `await admissionLifecycle.onAbandoned()` call and the drain's real claim-release path.

That real (non-mocked) drain behavior — calling the real `turnAdoptionLifecycle.onAbandoned()` releases the durable claim back to `pending` with `lastError: "turn-abandoned"`, i.e. genuine queue-retry redelivery — is already proven against a real `createTestIngressQueue` + `createChannelIngressDrain` (no mocked lifecycle) by the existing, pre-this-PR test `src/channels/message/ingress-drain.test.ts` ("abandoned via turnAdoptionLifecycle releases claim with attempt increment", line ~377). Ran it just now on this branch:

```
$ node scripts/run-vitest.mjs src/channels/message/ingress-drain.test.ts -t "abandoned via turnAdoptionLifecycle"
 ✓ |channels| ../../src/channels/message/ingress-drain.test.ts > channel ingress drain > abandoned via turnAdoptionLifecycle releases claim with attempt increment 254ms
 Test Files  1 passed (1)
      Tests  1 passed | 28 skipped (29)
```

Combined with this PR's own regression test (re-run on this branch, still green):

```
$ node scripts/run-vitest.mjs extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

these two already-existing, non-mocked tests compose to cover the full claimed path: Signal's flush calls `admissionLifecycle.onAbandoned()` on a non-conflict failure → that call is an unmodified real passthrough to the drain's own lifecycle → the drain's own lifecycle, called for real against a real queue, verifiably releases the claim for retry.

**What I could not produce here:** a Signal-specific mock-gateway harness or live-channel run. There is no existing Signal QA scenario (`qa/scenarios/channels/` has 215 scenario files across Discord/Matrix/WhatsApp/etc.; none match "signal"), and no existing test wires the real `createSignalEventHandler` directly to the real `ingress-drain` queue in one harness — building either is new test/scenario infrastructure, not evidence-gathering, and there's no live Signal account or gateway available in this sandboxed environment to run one instead.


## Additional Evidence (single real end-to-end run: real Signal handler + real durable drain)

Per the latest ClawSweeper review, the prior "Additional Evidence" section combined two separately-run, pre-existing tests by reasoning about their contracts rather than driving both through one execution. To close that gap, I wrote a temporary (uncommitted, not part of this PR's diff) Vitest file that wires the *actual* `createSignalEventHandler` (`extensions/signal/src/monitor/event-handler.ts`, unmodified) directly to a *real* `createChannelIngressDrain` + `createTestIngressQueue` (`src/channels/message/ingress-drain.ts`, SQLite-backed, unmodified) — no fabricated lifecycle object, no separate reasoning step. `dispatchClaimedEvent` calls the real handler with the drain's real per-claim `ChannelIngressDispatchLifecycle`; only the network-facing Signal send calls and the agent dispatch call are mocked (same seam the existing `event-handler.reply-session-conflict.test.ts` mocks), matching a non-conflict dispatch failure.

Ran on this branch (head `a0fd5c01a1a1e06aacba72012857f9efad4c40aa`), one execution, real timers, real queue:

```
$ node scripts/run-vitest.mjs extensions/signal/src/monitor/event-handler.zzz-real-drain-proof.test.ts --reporter=verbose
[proof] first drainOnce started: 1
[proof] REAL claim released back to pending with lastError: turn-abandoned attempts: 1
[proof] REAL redelivery dispatched to the real Signal handler again: 1 time(s)
 ✓ |extension-signal| ... non-conflict dispatch failure releases the real claim and the real drain redelivers it 1466ms
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Proved this genuinely depends on the fix by reverting only `extensions/signal/src/monitor/event-handler.ts` to its pre-fix state (`git checkout HEAD~1 -- extensions/signal/src/monitor/event-handler.ts`) and re-running the same script unmodified:

```
$ node scripts/run-vitest.mjs extensions/signal/src/monitor/event-handler.zzz-real-drain-proof.test.ts --reporter=verbose
[proof] first drainOnce started: 1
 × ... non-conflict dispatch failure releases the real claim and the real drain redelivers it 5232ms
   → expected [] to have a length of 1 but got +0
AssertionError: expected [] to have a length of 1 but got +0
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

Without the fix, the real durable claim never returns to `pending` (it stays stuck in `dispatching`, matching the issue's "held until the 300s watchdog dead-letters it" description). Restored the fix (`git checkout HEAD -- extensions/signal/src/monitor/event-handler.ts`) and re-ran to confirm green again, then deleted the temporary proof file — it is intentionally not part of this PR's diff, since it only re-demonstrates the same behavior the existing committed regression test already asserts, now through the real drain instead of a stub lifecycle.
