### PR TITLE
fix(ui): rotated device tokens are lost instead of shown in WebViews without a dialog bridge

### DIFF
--- a/ui/src/components/secret-reveal-dialog.ts
+++ b/ui/src/components/secret-reveal-dialog.ts
@@ -1,0 +1,74 @@
+// Control UI helper reveals a one-time secret in-app. window.prompt cannot do this job:
+// it is unstyled, unlabeled, uncopyable on touch, and never renders at all in a webview
+// without a dialog bridge, which drops the only copy of a freshly issued credential.
+import { html, nothing, render } from "lit";
+import { t } from "../i18n/index.ts";
+import { renderCopyButton } from "./copy-button.ts";
+import "./modal-dialog.ts";
+
+type SecretRevealDialogOptions = {
+  title: string;
+  message: string;
+  secret: string;
+  acknowledgeLabel: string;
+  dismissHint: string;
+};
+
+/** Resolves only on the explicit acknowledgement; Escape and backdrop cannot settle it. */
+export function showSecretRevealDialog(options: SecretRevealDialogOptions): Promise<void> {
+  const host = document.createElement("div");
+  document.body.append(host);
+  return new Promise((resolve) => {
+    let dismissRefused = false;
+    const acknowledge = () => {
+      render(nothing, host);
+      host.remove();
+      resolve();
+    };
+    // The secret is shown once, so a stray Escape or backdrop click must not be the last
+    // thing that happens to it. Web Awesome pulses the refused dialog; the hint is the
+    // accessible half of that answer, because a silent no-op reads as a broken control.
+    const refuseDismiss = (event: Event) => {
+      event.preventDefault();
+      if (dismissRefused) {
+        return;
+      }
+      dismissRefused = true;
+      paint();
+    };
+    const paint = () => {
+      render(
+        html`
+          <openclaw-modal-dialog
+            label=${options.title}
+            description=${options.message}
+            @modal-cancel=${refuseDismiss}
+          >
+            <div class="exec-approval-card">
+              <div class="exec-approval-header">
+                <div>
+                  <div class="exec-approval-title">${options.title}</div>
+                  <div class="exec-approval-sub">${options.message}</div>
+                </div>
+              </div>
+              <div class="secret-reveal__value">
+                <code class="secret-reveal__code">${options.secret}</code>
+                ${renderCopyButton(options.secret, t("common.copy"))}
+              </div>
+              ${dismissRefused
+                ? html`<p class="secret-reveal__hint" role="status">${options.dismissHint}</p>`
+                : nothing}
+              <div class="exec-approval-actions">
+                <button type="button" class="btn primary" autofocus @click=${acknowledge}>
+                  ${options.acknowledgeLabel}
+                </button>
+              </div>
+            </div>
+          </openclaw-modal-dialog>
+        `,
+        host,
+      );
+    };
+    paint();
+  });
+}

--- a/ui/src/e2e/device-token-reconnect.e2e.test.ts
+++ b/ui/src/e2e/device-token-reconnect.e2e.test.ts
@@ -32,6 +32,7 @@ const ROSITA_GATEWAY_URL = "wss://gateway.example/rosita";
 const WILFRED_GATEWAY_URL = "wss://gateway.example/wilfred";
 const ROSITA_DEVICE_TOKEN = "rosita-device-token";
 const WILFRED_DEVICE_TOKEN = "wilfred-device-token";
+const WILFRED_ROTATED_TOKEN = "wilfred-rotated-device-token";
 
 function requireRecord(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -231,6 +232,12 @@ describeControlUiE2e("Control UI device-token reconnect E2E", () => {
           pending: [],
         },
         "device.token.revoke": {},
+        "device.token.rotate": {
+          deviceId,
+          role: "operator",
+          scopes: OPERATOR_SCOPES,
+          token: WILFRED_ROTATED_TOKEN,
+        },
         "node.list": { nodes: [] },
       },
       // Exercise the legacy /nodes alias while asserting the renamed Devices surface.
@@ -290,5 +297,22 @@ describeControlUiE2e("Control UI device-token reconnect E2E", () => {
     });
     expect(readConnectAuth(wilfredAfterRevoke.connect)?.token).toBeUndefined();
     expect(readConnectAuth(wilfredAfterRevoke.connect)?.deviceToken).toBeUndefined();
+
+    // Rotation hands back the only copy of the new credential, so it is revealed in-page:
+    // window.prompt rendered nothing in a webview without a dialog bridge. This runs last
+    // because Escape also exits the Settings takeover behind the dialog — pre-existing
+    // shell behavior shared by every modal — which must not disturb the assertions above.
+    await deviceEntry.getByRole("button", { name: "Rotate", exact: true }).click();
+    const rotateReveal = wilfredDevices.page.locator("openclaw-modal-dialog");
+    await rotateReveal.getByText("New operator token").waitFor();
+    await rotateReveal.getByText(WILFRED_ROTATED_TOKEN).waitFor();
+    await captureProof(wilfredDevices.page, "wilfred-rotated-token.png");
+    await wilfredDevices.page.keyboard.press("Escape");
+    await rotateReveal
+      .getByText("This dialog stays open until you confirm the token is saved.")
+      .waitFor();
+    await rotateReveal.getByText(WILFRED_ROTATED_TOKEN).waitFor({ state: "visible" });
+    await rotateReveal.getByRole("button", { name: "I saved this token", exact: true }).click();
+    await rotateReveal.waitFor({ state: "detached" });
   });
 });

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -580,6 +580,11 @@ export const en: TranslationMap = {
       rejectPromptBody: "The client must send a new pairing request before it can connect.",
       revokePromptTitle: "Revoke the {role} token?",
       revokePromptBody: "This token stops working immediately and cannot be restored.",
+      rotatePromptTitle: "New {role} token",
+      rotatePromptBody:
+        "Copy this token now and store it securely. It is shown once and cannot be recovered.",
+      rotateAcknowledge: "I saved this token",
+      rotateDismissHint: "This dialog stays open until you confirm the token is saved.",
       gateway: "gateway",
       unpaired: "unpaired",
       unknownClient: "unknown client",

--- a/ui/src/lib/nodes/device-token.test.ts
+++ b/ui/src/lib/nodes/device-token.test.ts
@@ -78,33 +78,31 @@ afterEach(() => {
 });
 
 describe("device token request lifecycle", () => {
-  it("does not reveal or persist a rotate response from a retired request epoch", async () => {
+  // A retired epoch is a reconnect, not a reason to destroy the credential: the previous
+  // token is already dead on the server, so the caller still needs this one to recover.
+  it("returns a rotate response from a retired request epoch without persisting it", async () => {
     const response = deferred<unknown>();
     const state = createState(() => response.promise);
-    const prompt = vi.spyOn(window, "prompt").mockImplementation(() => null);
 
     const operation = rotateDeviceToken(state, tokenParams);
     state.requestGeneration += 1;
-    response.resolve({ token: "stale-token", ...tokenParams });
-    await operation;
+    response.resolve({ token: "rotated-token", ...tokenParams });
 
-    expect(prompt).not.toHaveBeenCalled();
+    expect(await operation).toBe("rotated-token");
     expect(loadDeviceAuthToken(tokenParams)).toBeNull();
   });
 
   it("rechecks rotate ownership after loading the local identity", async () => {
     storeIdentity();
     const { digest, digestMock } = deferIdentityFingerprint();
-    const state = createState(async () => ({ token: "stale-token", ...tokenParams }));
-    const prompt = vi.spyOn(window, "prompt").mockImplementation(() => null);
+    const state = createState(async () => ({ token: "rotated-token", ...tokenParams }));
 
     const operation = rotateDeviceToken(state, tokenParams);
     await vi.waitFor(() => expect(digestMock).toHaveBeenCalledOnce());
     state.requestGeneration += 1;
     digest.resolve(new Uint8Array([0]).buffer);
-    await operation;
 
-    expect(prompt).not.toHaveBeenCalled();
+    expect(await operation).toBe("rotated-token");
     expect(loadDeviceAuthToken(tokenParams)).toBeNull();
   });
 
@@ -113,7 +111,6 @@ describe("device token request lifecycle", () => {
     storeDeviceAuthToken({ ...tokenParams, token: "current-token", scopes: ["operator.read"] });
     const { digest, digestMock } = deferIdentityFingerprint();
     const state = createState(async () => ({}));
-    vi.spyOn(window, "confirm").mockReturnValue(true);
 
     const operation = revokeDeviceToken(state, tokenParams);
     await vi.waitFor(() => expect(digestMock).toHaveBeenCalledOnce());

--- a/ui/src/lib/nodes/index.ts
+++ b/ui/src/lib/nodes/index.ts
@@ -1,7 +1,7 @@
 // Shared Nodes operations used by the Control UI page and Gateway event hooks.
-// Presentation-free by contract: destructive confirmations belong to the owning page,
-// because native window.confirm silently returns false in webviews with no dialog bridge
-// and would end the action with no outcome and no recorded reason.
+// Presentation-free by contract: confirmations and secret reveals belong to the owning
+// page, because native window.confirm/window.prompt silently answer in webviews with no
+// dialog bridge and would end the action with no outcome and no recorded reason.
 import { getPublicKeyAsync, signAsync, utils } from "@noble/ed25519";
 import { gatewayCredentialScope } from "@openclaw/gateway-client/browser";
 import {
@@ -405,13 +405,14 @@ export async function rejectNodePairingRequest(state: InventoryState, requestId:
   }
 }
 
+/** Returns the rotated token for the owning page to reveal; the Gateway never resends it. */
 export async function rotateDeviceToken(
   state: DevicesState,
   params: { deviceId: string; gatewayUrl: string; role: string; scopes?: string[] },
-) {
+): Promise<string | null> {
   const client = state.client;
   if (!client || !state.connected) {
-    return;
+    return null;
   }
   const generation = state.requestGeneration;
   try {
@@ -422,13 +423,17 @@ export async function rotateDeviceToken(
       deviceId?: string;
       scopes?: Array<string>;
     }>("device.token.rotate", requestParams);
+    const token = res?.token ?? null;
+    // A retired epoch stops every state write below, but never the return: the previous
+    // credential is already dead on the server, so discarding this response would leave
+    // the operator locked out with no way to ask for the replacement again.
     if (!isCurrentNodesRequest(state, client, generation)) {
-      return;
+      return token;
     }
-    if (res?.token) {
+    if (token) {
       const identity = await loadOrCreateDeviceIdentity();
       if (!isCurrentNodesRequest(state, client, generation)) {
-        return;
+        return token;
       }
       const role = res.role ?? params.role;
       if (res.deviceId === identity.deviceId || params.deviceId === identity.deviceId) {
@@ -436,19 +441,18 @@ export async function rotateDeviceToken(
           deviceId: identity.deviceId,
           gatewayUrl,
           role,
-          token: res.token,
+          token,
           scopes: res.scopes ?? params.scopes ?? [],
         });
       }
-      window.prompt("New device token (copy and store securely):", res.token);
     }
-    if (isCurrentNodesRequest(state, client, generation)) {
-      await loadDevices(state);
-    }
+    await loadDevices(state);
+    return token;
   } catch (err) {
     if (isCurrentNodesRequest(state, client, generation)) {
       state.devicesError = String(err);
     }
+    return null;
   }
 }
 

--- a/ui/src/pages/devices/devices-page.test.ts
+++ b/ui/src/pages/devices/devices-page.test.ts
@@ -43,7 +43,34 @@ type TestDevicesPage = HTMLElement & {
   }) => Promise<void>;
   confirmPairingReject: (target: "device" | "node", requestId: string) => Promise<void>;
   confirmTokenRevoke: (deviceId: string, role: string) => Promise<void>;
+  revealRotatedToken: (deviceId: string, role: string, scopes?: string[]) => Promise<void>;
 };
+
+const ROTATED_TOKEN = "rotated-operator-token";
+
+/** Keep the identity fingerprint off jsdom's absent SubtleCrypto. */
+function stubLocalDeviceIdentity() {
+  localStorage.setItem(
+    "openclaw-device-identity-v1",
+    JSON.stringify({ version: 1, deviceId: "00", publicKey: "AA", privateKey: "AA" }),
+  );
+  vi.stubGlobal("crypto", {
+    subtle: { digest: async () => new Uint8Array([0]).buffer },
+  });
+}
+
+function rotatingClient(token: string | null): GatewayBrowserClient {
+  const request = vi.fn(async (method: string) =>
+    method === "device.token.rotate"
+      ? { deviceId: "device-1", role: "operator", scopes: [], token }
+      : { paired: [], pending: [] },
+  );
+  return { request } as unknown as GatewayBrowserClient;
+}
+
+function secretDialogText(): string {
+  return document.body.querySelector(".secret-reveal__code")?.textContent?.trim() ?? "";
+}
 
 function clickDialogButton(label: string) {
   const button = [...document.body.querySelectorAll("button")].find(
@@ -127,6 +154,8 @@ describe("DevicesPage gateway lifecycle", () => {
   afterEach(() => {
     document.body.replaceChildren();
     restoreDialogPolyfill();
+    localStorage.clear();
+    vi.unstubAllGlobals();
   });
 
   it("preserves matching initial route data, then resets it on provider replacement", () => {
@@ -349,6 +378,95 @@ describe("DevicesPage gateway lifecycle", () => {
     await pending;
 
     expect(request).not.toHaveBeenCalled();
+    applyGatewaySnapshot(page, gatewaySnapshot(client, false));
+  });
+
+  it("reveals a rotated token with a copy control until it is acknowledged", async () => {
+    stubLocalDeviceIdentity();
+    const client = rotatingClient(ROTATED_TOKEN);
+    const page = createConnectedPage(client);
+
+    let acknowledged = false;
+    const pending = page.revealRotatedToken("device-1", "operator").then(() => {
+      acknowledged = true;
+    });
+    const { dialog } = await waitForRenderedModalDialog(document.body);
+
+    expect(dialog.getAttribute("aria-label")).toBe(
+      t("devices.inventory.rotatePromptTitle", { role: "operator" }),
+    );
+    expect(secretDialogText()).toBe(ROTATED_TOKEN);
+    expect(document.body.querySelector(".chat-copy-btn")).toBeInstanceOf(HTMLButtonElement);
+    expect(acknowledged).toBe(false);
+
+    clickDialogButton(t("devices.inventory.rotateAcknowledge"));
+    await pending;
+
+    expect(document.body.querySelector("openclaw-modal-dialog")).toBeNull();
+    applyGatewaySnapshot(page, gatewaySnapshot(client, false));
+  });
+
+  it("refuses dismissal gestures while the rotated token is still on screen", async () => {
+    stubLocalDeviceIdentity();
+    const client = rotatingClient(ROTATED_TOKEN);
+    const page = createConnectedPage(client);
+
+    let acknowledged = false;
+    const pending = page.revealRotatedToken("device-1", "operator").then(() => {
+      acknowledged = true;
+    });
+    const { modal, webAwesomeDialog } = await waitForRenderedModalDialog(document.body);
+
+    // Escape and backdrop clicks both reach the dialog as a cancelable wa-hide, which
+    // Web Awesome abandons when the listener cancels it; the secret stays on screen.
+    const dismissal = new Event("wa-hide", { bubbles: true, cancelable: true, composed: true });
+    webAwesomeDialog.dispatchEvent(dismissal);
+    await modal.updateComplete;
+
+    expect(dismissal.defaultPrevented).toBe(true);
+    expect(acknowledged).toBe(false);
+    expect(secretDialogText()).toBe(ROTATED_TOKEN);
+    expect(document.body.textContent).toContain(t("devices.inventory.rotateDismissHint"));
+
+    clickDialogButton(t("devices.inventory.rotateAcknowledge"));
+    await pending;
+    applyGatewaySnapshot(page, gatewaySnapshot(client, false));
+  });
+
+  it("reveals a rotated token that lands after the request generation moved on", async () => {
+    stubLocalDeviceIdentity();
+    const rotated = deferred<{ token: string }>();
+    const request = vi.fn(async (method: string) =>
+      method === "device.token.rotate" ? rotated.promise : { paired: [], pending: [] },
+    );
+    const client = { request } as unknown as GatewayBrowserClient;
+    const page = createConnectedPage(client);
+
+    const pending = page.revealRotatedToken("device-1", "operator");
+    page.pageState.requestGeneration += 1;
+    rotated.resolve({ token: ROTATED_TOKEN });
+    await waitForRenderedModalDialog(document.body);
+
+    // The rotate already killed the previous credential, so a mid-flight reconnect must
+    // not swallow its replacement; the epoch guard still blocks the follow-up state writes.
+    expect(secretDialogText()).toBe(ROTATED_TOKEN);
+    expect(request).toHaveBeenCalledTimes(1);
+
+    clickDialogButton(t("devices.inventory.rotateAcknowledge"));
+    await pending;
+    applyGatewaySnapshot(page, gatewaySnapshot(client, false));
+  });
+
+  it("shows no reveal when the rotate request fails", async () => {
+    stubLocalDeviceIdentity();
+    const request = vi.fn().mockRejectedValue(new Error("rotate refused"));
+    const client = { request } as unknown as GatewayBrowserClient;
+    const page = createConnectedPage(client);
+
+    await page.revealRotatedToken("device-1", "operator");
+
+    expect(document.body.querySelector("openclaw-modal-dialog")).toBeNull();
+    expect(page.pageState.devicesError).toContain("rotate refused");
     applyGatewaySnapshot(page, gatewaySnapshot(client, false));
   });
 });

--- a/ui/src/pages/devices/devices-page.ts
+++ b/ui/src/pages/devices/devices-page.ts
@@ -11,6 +11,7 @@ import {
 } from "../../app/context.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import { showConfirmDialog, type ConfirmDialogOptions } from "../../components/confirm-dialog.ts";
+import { showSecretRevealDialog } from "../../components/secret-reveal-dialog.ts";
 import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
@@ -416,6 +417,30 @@ class DevicesPage extends OpenClawLightDomElement {
     );
   }
 
+  // The rotate response carries the only copy of the new credential, so the reveal is
+  // deliberately outside pendingConfirmation: a reconnect aborts pending confirmations,
+  // and aborting this one would destroy a secret the Gateway cannot reissue.
+  private async revealRotatedToken(deviceId: string, role: string, scopes?: string[]) {
+    const token = await this.runPageTask((pageState) =>
+      rotateDeviceToken(pageState, {
+        deviceId,
+        gatewayUrl: this.context.gateway.connection.gatewayUrl,
+        role,
+        scopes,
+      }),
+    );
+    if (!token) {
+      return;
+    }
+    await showSecretRevealDialog({
+      title: t("devices.inventory.rotatePromptTitle", { role }),
+      message: t("devices.inventory.rotatePromptBody"),
+      secret: token,
+      acknowledgeLabel: t("devices.inventory.rotateAcknowledge"),
+      dismissHint: t("devices.inventory.rotateDismissHint"),
+    });
+  }
+
   private resolveExecApprovalsTarget(): ExecApprovalsTarget {
     return this.execApprovalsTarget === "node" && this.execApprovalsTargetNodeId
       ? { kind: "node", nodeId: this.execApprovalsTargetNodeId }
@@ -478,14 +503,7 @@ class DevicesPage extends OpenClawLightDomElement {
             }
           },
           onDeviceRotate: (deviceId, role, scopes) =>
-            void this.runPageTask((pageState) =>
-              rotateDeviceToken(pageState, {
-                deviceId,
-                gatewayUrl: this.context.gateway.connection.gatewayUrl,
-                role,
-                scopes,
-              }),
-            ),
+            void this.revealRotatedToken(deviceId, role, scopes),
           onDeviceRevoke: (deviceId, role) => void this.confirmTokenRevoke(deviceId, role),
           onLoadConfig: () =>
             void this.context.runtimeConfig.refresh({ discardPendingChanges: true }),

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3225,6 +3225,39 @@ td.data-table-key-col {
 }
 
 /* ===========================================
+   Secret Reveal Modal
+   =========================================== */
+
+.secret-reveal__value {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 12px;
+  padding: 10px 12px;
+  background: var(--secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+/* The value is shown once, so it wraps in full instead of truncating, and a single
+   tap or click selects all of it for operators without a working clipboard button. */
+.secret-reveal__code {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+  user-select: all;
+}
+
+.secret-reveal__hint {
+  margin: 10px 0 0;
+  color: var(--warn);
+  font-size: 12px;
+}
+
+/* ===========================================
    Agents
    =========================================== */
 


### PR DESCRIPTION
Closes #121296

## What Problem This Solves

Fixes an issue where operators who rotate a device token on Settings -> Devices would lose the new credential entirely when the Control UI runs inside an embedded WebView with no dialog bridge. The rotated token was revealed through native `window.prompt`, which returns `null` in that environment without rendering anything, so `device.token.rotate` succeeded, the previous token was invalidated, and the only copy of the replacement was discarded with no visible outcome and no recorded reason.

The same surface was wrong even where it did render: `window.prompt` is an editable text input, not a read-only reveal; it is dismissible to nothing; it is unlabelled and unstyled; its copy was hardcoded English, the last untranslated string on the Devices page after #121279; and its value cannot be reliably selected or copied on mobile browsers.

## Why This Change Was Made

`rotateDeviceToken` now returns the token and `DevicesPage`, the visual owner, presents it — the same owner boundary #121279 established when it moved the three destructive Devices confirmations out of the shared operations module. That module still presents no UI at all.

The reveal is a dedicated read-only modal (`ui/src/components/secret-reveal-dialog.ts`) built on the canonical `openclaw-modal-dialog` and `renderCopyButton`, deliberately not a second confirm dialog: it shows a selectable monospace value that wraps in full, a copy control, show-once copy, and a single acknowledgement action, all behind `devices.*` i18n keys.

Two design decisions worth reviewer attention:

**Dismissal is refused, not confirmed.** Escape and backdrop clicks reach the dialog as a cancelable `wa-hide`; Web Awesome's `requestClose` abandons the close and pulses the dialog when a listener cancels that event (`@awesome.me/webawesome@3.10.0`, `dist/chunks/chunk.Q4MSGKHB.js:81-90` `requestClose`, `dist/chunks/chunk.MQODJ75V.js:4-9` `WaHideEvent` constructed with `cancelable: true`). The modal cancels it, so a stray gesture cannot be the last thing that happens to an unrecoverable secret. A nested "close without copying?" confirm was rejected: it adds a second dismissible surface in front of the same value, and the failure it guards against is one click away from being the failure itself. Because a silent no-op reads as a broken control, the first refused gesture also reveals a hint line naming the control that does close the dialog — the accessible half of Web Awesome's pulse.

**The epoch guard no longer swallows the response.** `rotateDeviceToken` previously dropped the whole rotate result when `requestGeneration` moved on mid-flight. That is correct for the local-storage write and the device-list refresh, which are scope-owned state, but for the reveal it reproduced the exact bug being fixed: the previous credential is already dead on the Gateway, so a reconnect during the round trip must not be what destroys the replacement — most sharply when the rotated token is this browser's own, where dropping it locks the operator out with nothing on screen. The token is now returned in that case and still not persisted.

### Scope, stated plainly

This fixes the half of the rotate path where the Gateway **does** return the token. It does not invent an outcome for the half where the Gateway deliberately withholds it: `shouldReturnRotatedDeviceToken` in `src/gateway/server-methods/devices.ts` returns the token only when the caller is the device being rotated ("other rotations are notification/invalidations"), so rotating another device's token still ends with nothing on screen. That is a real silent non-outcome and it is filed as #121317 rather than patched here, because the right copy depends on a maintainer product decision — whether operator-initiated rotation of another device should exist at all next to **Revoke**, which already communicates the same effect honestly. The branch that would carry it (`if (!token) return;` in `revealRotatedToken`) is the obvious seam once that decision is made.

Non-goal: the other two `window.prompt` calls in the Control UI (`ui/src/components/session-organizer-controller.ts`, `ui/src/pages/sessions/sessions-page.ts`) are text *input* prompts for session-group names, not secret reveals. They share the WebView failure mode but need an input dialog rather than this surface, so they are out of scope here.

## User Impact

Rotating a device token now always ends in a visible outcome. The new token appears in a labelled, read-only panel that states it is shown once, can be copied with one click or selected with one tap on mobile, renders correctly in light and dark themes, and closes only when the operator confirms they saved it. Operators using the Control UI inside the macOS app WebView — where the rotate reveal previously produced nothing at all — get the token instead of a silent lockout.

## Evidence

### Before — pre-fix build, WebView with no dialog bridge

Captured against the Control UI mock dev server (`scripts/control-ui-mock-dev.ts`, mock gateway, fixture devices, fake token) with `window.prompt` stubbed to return `null`, i.e. an exact stand-in for a WebView with no dialog bridge. Clicking **Rotate** on the operator token:

```
before prompt calls: [["New device token (copy and store securely):","ocw_dev_9f4b21c7e0a54d6b8c3f27ae5d1908b4"]]
before modals: 0
```

The page is unchanged; the token is gone.

<img width="1440" alt="before-desktop-dark-after-rotate-click" src="https://github.com/user-attachments/assets/b82e3785-3071-43a9-b94a-73c16b48567e" />

### After — the show-once reveal

Desktop, dark:

<img width="1440" alt="after-desktop-dark-reveal" src="https://github.com/user-attachments/assets/2238c483-70b4-43be-b4c9-d3652c45e933" />

Desktop, light:

<img width="1440" alt="after-desktop-light-reveal" src="https://github.com/user-attachments/assets/3e8ed923-780d-409b-a2f6-1c85804f4652" />

Mobile (390x844), dark and light — the value wraps in full and the copy control stays reachable:

<img width="390" alt="after-mobile-dark-reveal" src="https://github.com/user-attachments/assets/51102b8b-6974-4c19-98db-174cab1ad6a6" />
<img width="390" alt="after-mobile-light-reveal" src="https://github.com/user-attachments/assets/50e94b49-e71b-493c-8206-5da59c083023" />

Escape pressed — the dialog stays, the token stays, and the hint names the control that closes it:

<img width="1440" alt="after-desktop-dark-dismiss-refused" src="https://github.com/user-attachments/assets/39439c6b-c9b2-4d32-9142-03bbd374938c" />

All screenshots use mock-gateway fixture data and a fake token value; no real device, credential, or configuration appears in them.

### Named follow-up found while testing this (not fixed here)

Escape over *any* stacked modal also exits the Settings takeover and navigates back to the app. Measured on this branch against the same harness, comparing the reveal with the revoke confirm that shipped in #121279:

```
{"action":"revoke","path":"/chat/main","settingsOpen":false,"dialogStillOpen":false,"tokenVisible":false}
{"action":"rotate","path":"/chat/main","settingsOpen":false,"dialogStillOpen":true,"tokenVisible":true}
```

The reveal behaves correctly — the dialog and the token survive the gesture — but both rows show `settingsOpen: false`, so the Settings-exit half is pre-existing and shared by every modal on that surface, owned by the plain-Escape branch in `ui/src/app/app-shell-chrome.ts` (which does not check whether a modal is open). Fixing it means changing global keyboard handling for every overlay in the app, so it belongs in its own issue rather than in this credential fix.

### Tests

`ui/src/pages/devices/devices-page.test.ts` gains four cases on the reveal: the token and copy control render and the promise stays unsettled until the acknowledgement; a dismissal gesture is refused, leaves the secret on screen, and surfaces the hint; a token that lands after the request generation moved on is still revealed while the follow-up state writes are skipped; and a failed rotate produces no modal and a recorded error.

`ui/src/lib/nodes/device-token.test.ts` now asserts the returned token on both retired-epoch paths instead of asserting `window.prompt` was not called, and drops a `window.confirm` stub left dead by #121279.

`ui/src/e2e/device-token-reconnect.e2e.test.ts` exercises rotate end to end in a real browser for the first time: the reveal renders the token, Escape does not close it, and the acknowledgement does.

```
node scripts/run-vitest.mjs ui/src/pages/devices/devices-page.test.ts ui/src/lib/nodes/device-token.test.ts
Test Files  2 passed (2)
     Tests  19 passed (19)
```

`pnpm check:changed` and `pnpm test:changed` run on Blacksmith Testbox; hosted CI on the exact head is the authority for the full lane.

### Control UI startup bundle budget (resolved)

This PR was briefly blocked by the Control UI startup-JS budget: the four new `devices.*` strings land in the startup chunk and `main` had only 21 bytes of headroom under the old 317 KiB ceiling. Shortening the copy was not a usable lever — a leaner wording measured *worse* (324650 B vs 324635 B), because gzip is non-monotonic at this granularity.

That ceiling moved to 318 KiB on `main` in #121259 for an unrelated feature, with the commit noting that prior landings had consumed the 317 KiB headroom to within ~20 B. This branch is rebased onto that `main` and the gate now passes; no budget or baseline file is touched by this PR.

### Production LOC

`+155 / -21` production (new modal component 74, CSS 33, i18n 5, page 26/-8, operations module 17/-13) and `+149 / -10` tests. The growth buys a capability native dialogs cannot provide — a read-only, copyable, non-dismissible one-time secret surface — and removes the last native-dialog call from the Devices page.
