### PR TITLE
test(discord): remove duplicate inbound context contract

### DIFF
--- a/extensions/discord/src/monitor/message-handler.inbound-context.test.ts
+++ b/extensions/discord/src/monitor/message-handler.inbound-context.test.ts
@@ -1,17 +1,9 @@
 // Discord tests cover message handler.inbound context plugin behavior.
-import { expectChannelInboundContextContract as expectInboundContextContract } from "openclaw/plugin-sdk/channel-contract-testing";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { describe, expect, it } from "vitest";
 import { buildDiscordInboundAccessContext } from "./inbound-context.js";
-import { buildFinalizedDiscordDirectInboundContext } from "./inbound-context.test-helpers.js";
 
 describe("discord processDiscordMessage inbound context", () => {
-  it("builds a finalized direct-message MsgContext shape", () => {
-    const ctx = buildFinalizedDiscordDirectInboundContext();
-
-    expectInboundContextContract(ctx);
-  });
-
   it("keeps channel metadata out of GroupSystemPrompt", () => {
     const { groupSystemPrompt, channelStructuredContext } = buildDiscordInboundAccessContext({
       channelConfig: { systemPrompt: "Config prompt" } as never,


### PR DESCRIPTION
## What Problem This Solves

The Discord test shard invokes the finalized inbound-context contract twice with the same fixture and helper, adding redundant maintenance and execution cost without independent coverage.

## Why This Change Was Made

Remove the duplicate invocation and its unused imports from the message-handler test. The canonical `inbound-context.contract.test.ts` proof remains unchanged, and the independent `GroupSystemPrompt` metadata test remains in place.

## User Impact

None. This is test-only cleanup with no production behavior change.

## Evidence

- 13 focused Discord tests passed across the canonical contract, message-handler inbound-context, and message-handler context files.
- Targeted formatting and Discord extension lint passed.
- `git diff --check` passed; diff is one test file with eight deletions and no additions.
- Changed-check dry-run selected the `extensionTests` lane.
- Autoreview and TruffleHog completed cleanly with no actionable findings.
- Remote extension-test typecheck was unavailable because the Crabbox/Blacksmith tooling could not provide that proof; exact-head CI must pass the extension test types lane before prepare/merge.

AI-assisted; the final diff and proof were reviewed before submission.
