### PR TITLE
fix(ui): restore the monospace face on Control UI code surfaces

### DIFF
--- a/ui/src/components/dock-layout-controller.ts
+++ b/ui/src/components/dock-layout-controller.ts
@@ -227,7 +227,7 @@ export const dockPanelStyles = css`
     position: fixed;
     z-index: 60;
     color: var(--text, #d7dae0);
-    font-family: var(--font-sans, system-ui, sans-serif);
+    font-family: var(--font-body);
   }
   :is(.bp, .tp) {
     position: fixed;

--- a/ui/src/styles/base-theme-tokens.node.test.ts
+++ b/ui/src/styles/base-theme-tokens.node.test.ts
@@ -13,6 +13,11 @@ const undefinedTokenMappings = {
   "bg-subtle": "bg-muted",
   "border-subtle": "border",
   fg: "text",
+  // Font aliases arrive from surfaces that publish their own token names
+  // (canvas widgets, the MCP Apps spec keys in mcp-app-theme.ts); inside
+  // Control UI only --mono and --font-body exist.
+  "font-mono": "mono",
+  "font-sans": "font-body",
   foreground: "text",
   "panel-2": "panel-strong",
   success: "ok",

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -908,7 +908,7 @@ details.msg-meta:not([open]) .msg-meta__details {
   background: var(--bg-hover, rgba(255, 255, 255, 0.06));
   padding: 1px 6px;
   border-radius: var(--radius-sm, 4px);
-  font-family: var(--font-mono, monospace);
+  font-family: var(--mono);
 }
 
 .msg-meta__cost {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1661,7 +1661,7 @@ openclaw-chat-video-player {
   border-radius: 6px;
   background: color-mix(in srgb, var(--bg) 70%, transparent);
   color: var(--text);
-  font: 11px/1.4 var(--font-mono);
+  font: 11px/1.4 var(--mono);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
@@ -1982,7 +1982,7 @@ openclaw-chat-video-player {
   min-width: 0;
   overflow: hidden;
   color: var(--muted);
-  font: 12px/1.4 var(--font-mono);
+  font: 12px/1.4 var(--mono);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1997,7 +1997,7 @@ openclaw-chat-video-player {
 .chat-pr__diff {
   display: inline-flex;
   gap: 5px;
-  font: 12px/1.4 var(--font-mono);
+  font: 12px/1.4 var(--mono);
 }
 
 .chat-pr__additions {
@@ -5329,7 +5329,7 @@ openclaw-chat-video-player {
   display: inline-block;
   padding: 1px 6px;
   font-size: 12px; /* was 11px */
-  font-family: var(--font-mono);
+  font-family: var(--mono);
   background: var(--panel-strong);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -290,7 +290,7 @@ openclaw-session-owner-chip {
   display: block;
   margin: 4px 0 2px;
   padding: 5px 10px;
-  font-family: var(--font-mono);
+  font-family: var(--mono);
   font-size: 12px;
   background: var(--bg);
   border: 1px solid var(--border);
@@ -1018,7 +1018,7 @@ openclaw-session-owner-chip {
   align-items: center;
   padding: 0 12px;
   color: var(--text);
-  font-family: var(--font-mono);
+  font-family: var(--mono);
   font-size: 13px;
   letter-spacing: 0.08em;
   line-height: 1;

--- a/ui/src/styles/custodian-panel.css
+++ b/ui/src/styles/custodian-panel.css
@@ -2,7 +2,7 @@ openclaw-custodian-panel {
   position: fixed;
   z-index: 60;
   color: var(--text);
-  font-family: var(--font-sans);
+  font-family: var(--font-body);
 }
 
 .cp {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -324,7 +324,7 @@ html.openclaw-native-web-chrome .shell-chrome-controls {
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--card) 70%, transparent);
   color: var(--muted);
-  font-family: var(--font-mono, ui-monospace, monospace);
+  font-family: var(--mono);
   font-size: 10px;
   font-weight: 550;
   letter-spacing: 0.04em;
@@ -3472,7 +3472,7 @@ openclaw-tooltip.sidebar-hover-tooltip {
 }
 
 .sidebar-hover-card__metadata-value--mono {
-  font-family: var(--font-mono);
+  font-family: var(--mono);
   font-size: 11px;
 }
 
@@ -3594,7 +3594,7 @@ wa-dropdown.sidebar-identity-menu::part(menu) {
   min-width: 0;
   overflow: hidden;
   color: var(--muted);
-  font-family: var(--font-mono);
+  font-family: var(--mono);
   font-size: 11px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -3620,7 +3620,7 @@ wa-dropdown.sidebar-identity-menu::part(menu) {
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--danger) 12%, transparent);
   font-size: 11px;
-  font-family: var(--font-mono);
+  font-family: var(--mono);
   color: var(--danger);
 }
 

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -156,7 +156,7 @@
   border-radius: 50%;
   background: transparent;
   color: var(--muted);
-  font: 600 var(--control-ui-text-xs) / 1 var(--font-sans);
+  font: 600 var(--control-ui-text-xs) / 1 var(--font-body);
   cursor: var(--cursor-action);
 }
 


### PR DESCRIPTION
Closes #121307

## What Problem This Solves

Fixes an issue where operators looking at code-shaped values in the Control UI — the dev-checkout branch chip in the sidebar footer, the gateway commands in the disconnected login gate, the branch and diff counters on the chat PR chips, keyboard hints, the masked-secret field, hover-card metadata — saw them rendered in the proportional body font instead of the monospace face those surfaces ask for. Nothing errored and nothing logged; the text just quietly lost its font.

Four of those rules also silently lost their intended font size, weight, and line height, because they set the family through the `font:` shorthand.

## Why This Change Was Made

The Control UI declares its typography once, in `ui/src/styles/base.css`: `--mono` and `--font-body`. Fourteen rules asked for `--font-mono` / `--font-sans` instead. Those names are real elsewhere in the repo — the canvas widget host (`src/canvas/wrap.ts`, documented in `docs/tools/show-widget.md`), the standalone provider OAuth page (`src/plugin-sdk/provider-oauth-runtime.ts`), and the closed MCP Apps spec key set published to guest documents (`ui/src/components/mcp-app-theme.ts`) — but they do not exist in the Control UI document, so every reference was invalid at computed-value time and the whole declaration was dropped.

Eleven references had no fallback and inherited the body font outright; three degraded to a generic `ui-monospace` / `system-ui` stack; and the four `font:` shorthand sites (`ui/src/styles/chat/layout.css:1664`, `:1985`, `:2000`, `ui/src/styles/settings.css:159`) invalidated their size/weight/line-height along with the family.

Every reference now points at the canonical token, and the fallbacks that only existed to paper over the wrong name are gone, so `ui/src` has one spelling per font token (about 90 sibling rules already used the canonical names).

`ui/src/styles/base-theme-tokens.node.test.ts` already guards this exact bug class after it shipped twice for color tokens (#113726, #113776); it simply never listed the font aliases. Adding `font-mono` and `font-sans` to its mapping makes a re-introduction fail the existing lane instead of shipping silently — no new tooling, no allowlist to maintain.

Scope note: the pairing wizard is deliberately untouched. Its instance of this drift is already fixed on #121032's branch, and #121032 has not landed yet.

## User Impact

Build ids, git branches, PR branches and diff counters, CLI commands in the login gate, keyboard hints, masked secrets, and sidebar hover-card metadata render in the intended monospace face again, in both light and dark themes, on the default path with no configuration. The chat PR chips also get their intended 12px sizing back instead of inheriting 13px.

No configuration, API, or behavior changes; production line count is net zero (14 changed lines, no additions).

## Evidence

Real-behavior proof: mock-gateway Control UI harness (`installMockGateway` + isolated E2E server, source modules) driven through Playwright Chromium on a Blacksmith Testbox, captured twice from the same fixtures and viewport — once at this branch, once with the CSS reverted to `main`. All fixture data; no operator state involved.

Computed styles at the same elements:

| Surface | Before (`main`) | After |
| --- | --- | --- |
| `.sidebar-footer-branch` | `Inter, -apple-system, …` | `"JetBrains Mono", ui-monospace, …` |
| `.login-gate__steps code` | `Inter, -apple-system, …` | `"JetBrains Mono", ui-monospace, …` |
| `.chat-pr__branch` | `Inter, …` at **13px** | `"JetBrains Mono", …` at **12px** |
| `.chat-pr__diff` | `Inter, …` at **13px** | `"JetBrains Mono", …` at **12px** |

The 13px → 12px shift is the shorthand invalidation: on `main` the whole `font:` declaration was thrown away, so those chips inherited the chat text size too.

**Sidebar footer dev-branch chip — dark**

| Before | After |
| --- | --- |
| <img width="217" alt="dev branch chip in the body font" src="https://github.com/user-attachments/assets/5b9e9a96-5ed0-44cd-bc0e-ddf6095a8821"> | <img width="217" alt="dev branch chip in monospace" src="https://github.com/user-attachments/assets/00182c2a-0e6e-495b-bc5d-95d01723301e"> |

**Sidebar footer dev-branch chip — light**

| Before | After |
| --- | --- |
| <img width="217" alt="dev branch chip in the body font, light theme" src="https://github.com/user-attachments/assets/869da049-4c97-45b6-8f46-bb675f19aedf"> | <img width="217" alt="dev branch chip in monospace, light theme" src="https://github.com/user-attachments/assets/32b54b2c-36ea-4716-aa12-20bd06b9d274"> |

**Login gate — gateway commands**

| Before | After |
| --- | --- |
| <img width="454" alt="login gate command blocks in the body font" src="https://github.com/user-attachments/assets/58340ebb-f8f1-42f3-844e-c8c9e72c49cb"> | <img width="454" alt="login gate command blocks in monospace" src="https://github.com/user-attachments/assets/eafd7cee-ebcf-4707-831a-f27dbe40940f"> |

**Chat PR chip — branch and diff counters**

| Before | After |
| --- | --- |
| <img width="768" alt="PR chip branch and diff in the body font at 13px" src="https://github.com/user-attachments/assets/3623a8cf-3828-4c36-82ea-bb789342c3cc"> | <img width="768" alt="PR chip branch and diff in monospace at 12px" src="https://github.com/user-attachments/assets/c7dc2197-a806-4542-ac80-4bee50382ccc"> |

Guard proof: `node scripts/run-vitest.mjs ui/src/styles/base-theme-tokens.node.test.ts` passes on this branch (2 tests). The added mapping was verified to match every shape that existed on `main` (`var(--font-mono)`, `font: 11px/1.4 var(--font-mono)`, `var(--font-mono, monospace)`, `var(--font-sans, system-ui, sans-serif)`) and to accept the canonical `var(--mono)` / `var(--font-body)`.

A full sweep of `ui/src` for `var()` references with no fallback and no matching declaration now returns only names that are set at runtime through `setProperty`/`styleMap`; no undefined-token reference remains.

The two `--font-sans` surfaces (`ui/src/styles/custodian-panel.css`, `ui/src/components/dock-layout-controller.ts`) render inside panels the mock harness does not open, so they carry token-audit and guard proof rather than a screenshot; the settings help button (`ui/src/styles/settings.css:159`) is not rendered by the mocked config forms.

