### PR TITLE
fix(scripts): fall back to local check:changed lanes on full Crabbox provider outage

### DIFF
--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -429,13 +429,16 @@ const DELEGATION_OUTPUT_TAIL_LIMIT = 64 * 1024;
 
 /**
  * Signatures of a failure that happened before the remote command was dispatched:
- * the broker or its API was unreachable, or no lease was ever obtained.
+ * the broker or its API was unreachable, no lease was ever obtained, or workload
+ * routing exhausted its provider chain (every provider doctor failed).
  */
 const BACKEND_UNAVAILABLE_SIGNATURES = [
   /request failed: \w+ "https?:\/\/[^"]*blacksmith[^"]*"/iu,
   /context deadline exceeded/iu,
   /(?:no such host|dial tcp|connection refused|network is unreachable)/iu,
   /failed to (?:acquire|create|warm|start)\b[^\n]*\b(?:lease|testbox)/iu,
+  // crabbox-wrapper prints this and exits before dispatching anything remote.
+  /\[crabbox\] no ready provider for workload=/u,
 ];
 
 /**
@@ -1257,7 +1260,7 @@ async function main() {
           // Say this loudly: the proof below is local, so whoever reads the run
           // knows which machine produced it and that Linux-only lanes are unproven.
           console.error(
-            "[check:changed] Blacksmith never ran the checks (no run summary). Falling back to local execution; note this in the proof summary.",
+            "[check:changed] the remote backend never ran the checks (no run summary). Falling back to local execution; note this in the proof summary.",
           );
         }
         process.exitCode = delegated.backendUnavailable

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -2431,6 +2431,17 @@ describe("delegationFailedBeforeRunning", () => {
     expect(delegationFailedBeforeRunning(output)).toBe(false);
   });
 
+  it("treats a full workload-routing provider outage as never having run", () => {
+    // Provider selection happens before any dispatch, so an exhausted routing
+    // chain (every doctor failing) can never carry a remote verdict.
+    const output = [
+      "[crabbox] no ready provider for workload=ci-fast",
+      "[crabbox] provider readiness blacksmith-testbox:doctor exited 1,daytona:doctor exited 124,azure:doctor exited 124,aws:doctor exited 124",
+    ].join("\n");
+
+    expect(delegationFailedBeforeRunning(output)).toBe(true);
+  });
+
   it("does not mistake an infrastructure error kind for a command verdict", () => {
     const output = [
       "failed to acquire lease for testbox",


### PR DESCRIPTION
## What Problem This Solves

`scripts/check-changed.mts` delegates `check:changed` proof through `scripts/crabbox-wrapper.mjs` workload routing. When every provider doctor failed, the wrapper emitted `[crabbox] no ready provider for workload=...` and exited 2 before dispatch, but `delegationFailedBeforeRunning()` did not recognize that pre-dispatch outage. As a result, `backendUnavailable` stayed false and `check:changed` exited 2 without running the documented trusted-source local fallback.

## Why This Change Was Made

This adds the wrapper's exact pre-dispatch provider-exhaustion signature to `BACKEND_UNAVAILABLE_SIGNATURES` and updates the fallback notice to refer to the remote backend rather than only Blacksmith. The match is deliberately narrow: unsupported workloads, ineligible providers, and `--id` misuse remain configuration errors. The existing `"errorKind": "command-exit"` veto still runs first, so a remote command that actually ran and failed cannot be reclassified as backend unavailability.

Observed on 2026-08-09 in worktree `hetzner-deployment-perf-test-b6dc2e`: `blacksmith-testbox` doctor exited 1; `daytona`, `azure`, and `aws` doctors exited 124; the run ended with `[check:changed] FAILED (exit 2)` and no local lanes. The temporary workaround was `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1`.

## User Impact

Operators and agents running `check:changed` during a full remote-provider outage now get the documented loud local fallback instead of a dead exit 2.

## Evidence

- New regression test failed before the fix (misclassification reproduced), passes after.
- `node scripts/run-vitest.mjs test/scripts/changed-lanes.test.ts` → 150/150 passed.
- `./node_modules/.bin/oxfmt --check` on both files: clean.
- `node scripts/run-oxlint.mjs` on both files: clean (exit 0).
- Codex autoreview (`gpt-5.6-sol`, thinking high) on the uncommitted diff: clean, "no accepted/actionable findings reported", verdict "patch is correct (0.99)".
- Production LOC delta +3 (one signature regex plus comment/message wording); tests +11.
- Not channel-visible; scripts-only change, so no mock-gateway/live-channel proof applies.
