### PR TITLE
fix(protocol): align fallback reason schemas

### DIFF
--- a/packages/gateway-protocol/src/failover-reasons.ts
+++ b/packages/gateway-protocol/src/failover-reasons.ts
@@ -1,0 +1,20 @@
+export const FAILOVER_REASONS = [
+  "auth",
+  "auth_permanent",
+  "format",
+  "rate_limit",
+  "overloaded",
+  "billing",
+  "server_error",
+  "timeout",
+  "tls_certificate",
+  "context_overflow",
+  "model_not_found",
+  "session_expired",
+  "empty_response",
+  "no_error_details",
+  "unclassified",
+  "unknown",
+] as const;
+
+export type FailoverReason = (typeof FAILOVER_REASONS)[number];

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import { Type, type TSchema } from "typebox";
 import { closedObject } from "./closed-object.js";
+import { FailoverReasonSchema } from "./failover-reason.js";
 import { NonEmptyString } from "./primitives.js";
 
 /**
@@ -142,24 +143,6 @@ const CronScheduledToolPolicySchema = Type.Union([
   }),
 ]);
 const CronAnnounceChannelSchema = Type.Union([Type.Literal("last"), NonBlankString]);
-const CronFailoverReasonSchema = Type.Union([
-  Type.Literal("auth"),
-  Type.Literal("auth_permanent"),
-  Type.Literal("format"),
-  Type.Literal("rate_limit"),
-  Type.Literal("overloaded"),
-  Type.Literal("billing"),
-  Type.Literal("server_error"),
-  Type.Literal("timeout"),
-  Type.Literal("tls_certificate"),
-  Type.Literal("context_overflow"),
-  Type.Literal("model_not_found"),
-  Type.Literal("session_expired"),
-  Type.Literal("empty_response"),
-  Type.Literal("no_error_details"),
-  Type.Literal("unclassified"),
-  Type.Literal("unknown"),
-]);
 const CronRunDiagnosticSeveritySchema = Type.Union([
   Type.Literal("info"),
   Type.Literal("warn"),
@@ -447,7 +430,7 @@ export const CronJobStateSchema = closedObject({
   lastError: Type.Optional(Type.String()),
   lastDiagnostics: Type.Optional(CronRunDiagnosticsSchema),
   lastDiagnosticSummary: Type.Optional(Type.String()),
-  lastErrorReason: Type.Optional(CronFailoverReasonSchema),
+  lastErrorReason: Type.Optional(FailoverReasonSchema),
   lastDurationMs: Type.Optional(Type.Integer({ minimum: 0 })),
   consecutiveErrors: Type.Optional(Type.Integer({ minimum: 0 })),
   // Report-only scheduler ownership fact; callers cannot patch this field.
@@ -494,7 +477,7 @@ const CronJobStatePatchSchema = closedObject({
   lastRunStatus: Type.Optional(CronRunStatusSchema),
   lastStatus: Type.Optional(DeprecatedCronRunStatusSchema),
   lastError: Type.Optional(Type.String()),
-  lastErrorReason: Type.Optional(CronFailoverReasonSchema),
+  lastErrorReason: Type.Optional(FailoverReasonSchema),
   lastDurationMs: Type.Optional(Type.Integer({ minimum: 0 })),
   consecutiveErrors: Type.Optional(Type.Integer({ minimum: 0 })),
   consecutiveSkipped: Type.Optional(Type.Integer({ minimum: 0 })),
@@ -710,7 +693,7 @@ export const CronRunLogEntrySchema = closedObject({
   action: Type.Literal("finished"),
   status: Type.Optional(CronRunStatusSchema),
   error: Type.Optional(Type.String()),
-  errorReason: Type.Optional(CronFailoverReasonSchema),
+  errorReason: Type.Optional(FailoverReasonSchema),
   summary: Type.Optional(Type.String()),
   diagnostics: Type.Optional(CronRunDiagnosticsSchema),
   delivered: Type.Optional(Type.Boolean()),

--- a/packages/gateway-protocol/src/schema/failover-reason.ts
+++ b/packages/gateway-protocol/src/schema/failover-reason.ts
@@ -1,0 +1,33 @@
+import type { Static } from "typebox";
+import { Type } from "typebox";
+import { FAILOVER_REASONS } from "../failover-reasons.js";
+
+/** Closed failure reasons shared by model fallback producers and protocol consumers.
+ * The literal list stays explicit because Type.Union needs a tuple for
+ * Static inference (a mapped array collapses Static to never); the guard
+ * below keeps it in lockstep with FAILOVER_REASONS. */
+export const FailoverReasonSchema = Type.Union([
+  Type.Literal("auth"),
+  Type.Literal("auth_permanent"),
+  Type.Literal("format"),
+  Type.Literal("rate_limit"),
+  Type.Literal("overloaded"),
+  Type.Literal("billing"),
+  Type.Literal("server_error"),
+  Type.Literal("timeout"),
+  Type.Literal("tls_certificate"),
+  Type.Literal("context_overflow"),
+  Type.Literal("model_not_found"),
+  Type.Literal("session_expired"),
+  Type.Literal("empty_response"),
+  Type.Literal("no_error_details"),
+  Type.Literal("unclassified"),
+  Type.Literal("unknown"),
+]);
+
+type MutuallyAssignable<A, B> = [A] extends [B] ? ([B] extends [A] ? true : never) : never;
+const failoverReasonVocabularyInSync: MutuallyAssignable<
+  Static<typeof FailoverReasonSchema>,
+  (typeof FAILOVER_REASONS)[number]
+> = true;
+void failoverReasonVocabularyInSync;

--- a/packages/gateway-protocol/src/schema/worker-admission.test.ts
+++ b/packages/gateway-protocol/src/schema/worker-admission.test.ts
@@ -1,6 +1,7 @@
 import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../client-info.js";
+import { FAILOVER_REASONS } from "../failover-reasons.js";
 import {
   type WorkerAdmissionHandshake,
   WorkerAdmissionResponseFrameSchema,
@@ -162,12 +163,22 @@ const approval = (phase: string, status: string) =>
   event("approval", { phase, kind: "exec", status, title: "x" });
 const lifecycle = (phase: string, payload: Record<string, unknown> = {}) =>
   event("lifecycle", { phase, ...payload });
-const fallbackStep = (outcome: string) =>
+const fallbackStep = (outcome: string, reason?: string) =>
   lifecycle("fallback_step", {
     fallbackStepType: "fallback_step",
     fallbackStepFromModel: "p/m",
+    ...(reason === undefined ? {} : { fallbackStepFromFailureReason: reason }),
     fallbackStepFinalOutcome: outcome,
   });
+const fallbackReasonEvents = (reason: string) => [
+  lifecycle("fallback", {
+    ...models,
+    reasonSummary: "x",
+    attemptSummaries: ["x"],
+    attempts: [{ provider: "p", model: "m", error: "x", reason }],
+  }),
+  fallbackStep("next_fallback", reason),
+];
 const assistant = event("assistant", { text: "x", delta: "x" });
 const validateLive = validateWorkerLiveEventParams;
 const liveError = (details: Record<string, unknown>) => ({
@@ -413,6 +424,18 @@ describe("worker protocol schemas", () => {
     ] as const) {
       expect(validateLive(params(tool("update", { partialResult: value })))).toBe(false);
       expect(validateLive.errors?.[0]).toMatchObject({ keyword });
+    }
+  });
+
+  it("keeps both worker fallback reason fields aligned with the canonical vocabulary", () => {
+    for (const reason of FAILOVER_REASONS) {
+      for (const fallbackEvent of fallbackReasonEvents(reason)) {
+        expect(validateLive(params(fallbackEvent))).toBe(true);
+      }
+    }
+
+    for (const fallbackEvent of fallbackReasonEvents("not-a-reason")) {
+      expect(validateLive(params(fallbackEvent))).toBe(false);
     }
   });
 

--- a/packages/gateway-protocol/src/schema/worker-admission.ts
+++ b/packages/gateway-protocol/src/schema/worker-admission.ts
@@ -1,6 +1,7 @@
 import { Type, type Static, type TProperties } from "typebox";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../client-info.js";
 import { closedObject } from "./closed-object.js";
+import { FailoverReasonSchema } from "./failover-reason.js";
 import { withSince } from "./since.js";
 import {
   LiveIntegerSchema,
@@ -450,30 +451,11 @@ const WorkerLiveLifecycleStartPayloadSchema = workerLiveObject({
   startedAt: LiveIntegerSchema,
 });
 
-const WorkerLiveFallbackReasonSchema = Type.Union([
-  Type.Literal("auth"),
-  Type.Literal("auth_permanent"),
-  Type.Literal("format"),
-  Type.Literal("rate_limit"),
-  Type.Literal("overloaded"),
-  Type.Literal("billing"),
-  Type.Literal("server_error"),
-  Type.Literal("timeout"),
-  Type.Literal("tls_certificate"),
-  Type.Literal("context_overflow"),
-  Type.Literal("model_not_found"),
-  Type.Literal("session_expired"),
-  Type.Literal("empty_response"),
-  Type.Literal("no_error_details"),
-  Type.Literal("unclassified"),
-  Type.Literal("unknown"),
-]);
-
 const WorkerLiveFallbackAttemptSchema = workerLiveObject({
   provider: LiveIdentifierSchema,
   model: LiveIdentifierSchema,
   error: LiveTextSchema,
-  reason: Type.Optional(WorkerLiveFallbackReasonSchema),
+  reason: Type.Optional(FailoverReasonSchema),
   authMode: Type.Optional(LiveIdentifierSchema),
   status: OptionalLiveIntegerSchema,
   code: Type.Optional(Type.String({ minLength: 1, maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES })),
@@ -509,7 +491,7 @@ const WorkerLiveLifecycleFallbackStepPayloadSchema = workerLiveObject({
   fallbackStepType: Type.Literal("fallback_step"),
   fallbackStepFromModel: LiveIdentifierSchema,
   fallbackStepToModel: Type.Optional(LiveIdentifierSchema),
-  fallbackStepFromFailureReason: Type.Optional(WorkerLiveFallbackReasonSchema),
+  fallbackStepFromFailureReason: Type.Optional(FailoverReasonSchema),
   fallbackStepFromFailureDetail: OptionalLiveTextSchema,
   fallbackStepChainPosition: OptionalLiveIntegerSchema,
   fallbackStepFinalOutcome: Type.Union([

--- a/src/agents/runtime-plan/types.compat.test.ts
+++ b/src/agents/runtime-plan/types.compat.test.ts
@@ -1,9 +1,9 @@
 // Runtime plan type-compat tests keep copied structural aliases aligned with
 // their source runtime contracts without importing those sources in production.
 import { describe, expectTypeOf, it } from "vitest";
+import type { FailoverReason as ProtocolFailoverReason } from "../../../packages/gateway-protocol/src/failover-reasons.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
-import type { FailoverReason } from "../embedded-agent-helpers/types.js";
 import type { PromptMode } from "../system-prompt.types.js";
 import type { buildAgentRuntimeDeliveryPlan, buildAgentRuntimePlan } from "./build.js";
 import type {
@@ -31,9 +31,9 @@ type AgentRuntimeReplyPayload = Parameters<
 type AgentRuntimeThinkLevel = NonNullable<BuildAgentRuntimePlanParams["thinkingLevel"]>;
 
 describe("AgentRuntimePlan structural type compatibility", () => {
-  it("keeps copied scalar unions aligned with their source contracts", () => {
+  it("keeps scalar unions and the failover projection aligned with their owners", () => {
     expectTypeOf<AgentRuntimeThinkLevel>().toEqualTypeOf<Exclude<ThinkLevel, "ultra">>();
-    expectTypeOf<AgentRuntimeFailoverReason>().toEqualTypeOf<FailoverReason>();
+    expectTypeOf<AgentRuntimeFailoverReason>().toEqualTypeOf<ProtocolFailoverReason>();
     expectTypeOf<AgentRuntimePromptMode>().toEqualTypeOf<PromptMode>();
   });
 

--- a/src/cron/cron-protocol-conformance.test.ts
+++ b/src/cron/cron-protocol-conformance.test.ts
@@ -1,13 +1,13 @@
 // Cron protocol conformance tests cover schema compatibility for cron messages.
 import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
+import { FAILOVER_REASONS } from "../../packages/gateway-protocol/src/failover-reasons.js";
 import {
   CronDeliverySchema,
   CronJobStateSchema,
   CronRunLogEntrySchema,
 } from "../../packages/gateway-protocol/src/schema.js";
 import type { CronJob } from "../../packages/gateway-protocol/src/schema/cron.types.js";
-import type { FailoverReason } from "../agents/embedded-agent-helpers/types.js";
 
 type CronDelivery = NonNullable<CronJob["delivery"]>;
 
@@ -22,25 +22,6 @@ const DELIVERY_FIXTURES = {
   },
   webhook: { mode: "webhook", to: "https://example.test/result" },
 } satisfies Record<CronDelivery["mode"], CronDelivery>;
-
-const FAILOVER_REASONS = Object.keys({
-  auth: true,
-  auth_permanent: true,
-  format: true,
-  rate_limit: true,
-  overloaded: true,
-  billing: true,
-  server_error: true,
-  timeout: true,
-  tls_certificate: true,
-  context_overflow: true,
-  model_not_found: true,
-  session_expired: true,
-  empty_response: true,
-  no_error_details: true,
-  unclassified: true,
-  unknown: true,
-} satisfies Record<FailoverReason, true>) as FailoverReason[];
 
 describe("cron protocol conformance", () => {
   it("accepts every typed delivery mode and rejects unknown modes", () => {

--- a/src/cron/task-run-detail.ts
+++ b/src/cron/task-run-detail.ts
@@ -2,10 +2,13 @@
  * Deliberately free of agent/runtime imports so history reads stay dependency-light;
  * the event->entry write codec lives in task-run-event-codec.ts. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  FAILOVER_REASONS,
+  type FailoverReason,
+} from "../../packages/gateway-protocol/src/failover-reasons.js";
 import { isCronTimeoutErrorText } from "./execution-error-constants.js";
 import { normalizeCronRunDiagnostics } from "./run-diagnostics-normalize.js";
 
-type FailoverReason = import("../agents/embedded-agent-helpers/types.js").FailoverReason;
 type JsonValue = import("../tasks/task-registry.types.js").JsonValue;
 type TaskRecord = import("../tasks/task-registry.types.js").TaskRecord;
 type TaskStatus = import("../tasks/task-registry.types.js").TaskStatus;
@@ -14,24 +17,7 @@ type CronDeliveryStatus = import("./types.js").CronDeliveryStatus;
 type CronRunStatus = import("./types.js").CronRunStatus;
 
 const CRON_TASK_DETAIL_KIND = "cron-run";
-const CRON_FAILOVER_REASONS = new Set<FailoverReason>([
-  "auth",
-  "auth_permanent",
-  "format",
-  "rate_limit",
-  "overloaded",
-  "billing",
-  "server_error",
-  "timeout",
-  "tls_certificate",
-  "model_not_found",
-  "session_expired",
-  "context_overflow",
-  "empty_response",
-  "no_error_details",
-  "unclassified",
-  "unknown",
-]);
+const CRON_FAILOVER_REASONS = new Set(FAILOVER_REASONS);
 
 function toJsonValue(value: unknown): JsonValue | undefined {
   const serialized = JSON.stringify(value);

--- a/src/cron/task-run-history.test.ts
+++ b/src/cron/task-run-history.test.ts
@@ -1,5 +1,6 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
+import { FAILOVER_REASONS } from "../../packages/gateway-protocol/src/failover-reasons.js";
 import { saveTaskRegistryStateToSqlite } from "../tasks/task-registry.store.sqlite.js";
 import type { TaskRecord } from "../tasks/task-registry.types.js";
 import { resetTaskRegistryForTests } from "../tasks/task-runtime.test-helpers.js";
@@ -493,15 +494,17 @@ describe("cron task run history", () => {
     ).toBeUndefined();
   });
 
-  it("preserves TLS certificate failures in stored run history", () => {
-    const entry = {
-      ts: 100,
-      jobId: JOB_ID,
-      action: "finished",
-      status: "error",
-      errorReason: "tls_certificate",
-    } as const;
+  it("preserves every canonical failover reason in stored run history", () => {
+    for (const errorReason of FAILOVER_REASONS) {
+      const entry = {
+        ts: 100,
+        jobId: JOB_ID,
+        action: "finished",
+        status: "error",
+        errorReason,
+      } as const;
 
-    expect(parseCronRunLogEntryObject(entry)?.errorReason).toBe("tls_certificate");
+      expect(parseCronRunLogEntryObject(entry)?.errorReason).toBe(errorReason);
+    }
   });
 });

--- a/src/gateway/server/ws-connection/message-handler.worker.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.worker.test.ts
@@ -392,6 +392,35 @@ describe("dedicated worker websocket protocol", () => {
     expect(invalid.service.pushLiveEvent).not.toHaveBeenCalled();
   });
 
+  it("dispatches a TLS certificate fallback step without closing the worker", async () => {
+    const request = {
+      ...LIVE_EVENT,
+      event: {
+        kind: "lifecycle" as const,
+        payload: {
+          phase: "fallback_step" as const,
+          fallbackStepType: "fallback_step" as const,
+          fallbackStepFromModel: "openai/gpt-primary",
+          fallbackStepFromFailureReason: "tls_certificate" as const,
+          fallbackStepFinalOutcome: "next_fallback" as const,
+        },
+      },
+    };
+    const harness = attachHarness();
+    await admit(harness);
+    harness.sendRequest("worker.live-event", request);
+
+    await waitForWorkerProtocol(() => expect(harness.responses).toHaveLength(2));
+    expect(harness.service.pushLiveEvent).toHaveBeenCalledWith(IDENTITY, request);
+    expect(harness.responses[1]).toEqual({
+      type: "res",
+      id: "request-1",
+      ok: true,
+      payload: { ackedSeq: request.seq },
+    });
+    expect(harness.close).not.toHaveBeenCalled();
+  });
+
   it("rejects transcript commits when the admitted worker lacks the feature", async () => {
     const harness = attachHarness({
       identity: { ...IDENTITY, protocolFeatures: ["worker-heartbeat-v1"] },

--- a/src/gateway/worker-environments/live-events.test.ts
+++ b/src/gateway/worker-environments/live-events.test.ts
@@ -328,6 +328,7 @@ describe("worker live events", () => {
         phase: "fallback_step",
         fallbackStepType: "fallback_step",
         fallbackStepFromModel: "openai/gpt-primary",
+        fallbackStepFromFailureReason: "tls_certificate",
         fallbackStepFinalOutcome: "next_fallback",
       }),
     ];
@@ -340,6 +341,9 @@ describe("worker live events", () => {
     expect(events[4]?.data).toMatchObject({
       name: "exec",
       result: { content: [{ bytes: 6, omitted: true }], details: { aggregated: capped("r") } },
+    });
+    expect(events[8]?.data).toMatchObject({
+      fallbackStepFromFailureReason: "tls_certificate",
     });
     expect(JSON.stringify(events)).not.toContain(credential);
   });


### PR DESCRIPTION
## What Problem This Solves

Worker fallback producers and cron accepted `tls_certificate`, but the WorkerLiveEvent schema maintained a separate closed reason list that drifted. As a result, valid TLS certificate fallback payloads were rejected at the worker protocol boundary. #121285 added the missing literal on current main; this change completes the preventative ownership cleanup so the lists cannot drift again.

## Why This Change Was Made

This change gives the fallback vocabulary one dependency-light tuple owner and an explicit shared TypeBox schema. The schema keeps the existing `anyOf`/`const` wire representation, so the change needs no protocol version or feature bump. Public Plugin SDK declarations remain byte-compatible, and the approved API closure manifest was regenerated to verify that compatibility.

## User Impact

TLS certificate fallback live events are accepted and reach gateway and trajectory consumers instead of returning `invalid-event`; cron behavior stays aligned with the same canonical vocabulary.

## Evidence

- Worker admission schema: 23/23 focused tests passed.
- Runtime-plan compatibility: 3/3 focused tests passed.
- Cron conformance and history: 17/17 focused tests passed.
- WebSocket dispatch boundary: 19/19 focused tests passed.
- Worker live projection: 34/34 focused tests passed.
- Plugin SDK API baseline check, protocol registry check, and dead-export scan passed.
- Remaining tsgo, lint, import-cycle, storage, and security static lanes passed.
- Mandatory autoreview completed with no accepted or actionable findings.
- Full local `pnpm build` passed.
- A Daytona remote build reached declaration bundle 6/9 before the host was SIGKILLed for resources; this was an infrastructure-only attempt, and the identical full local build passed.
