### PR TITLE
fix(gateway): keep terminal chat history visible after a silent stretch

### DIFF
--- a/src/gateway/server-methods/chat-history-pages.ts
+++ b/src/gateway/server-methods/chat-history-pages.ts
@@ -19,6 +19,7 @@ import {
   readSessionMessagesAsync,
   readSessionMessagesPageWithStatsAsync,
   type ReadRecentSessionMessagesResult,
+  type SessionTranscriptReadScope,
 } from "../session-transcript-readers.js";
 import type { loadSessionEntry } from "../session-utils.js";
 
@@ -204,6 +205,100 @@ function dropLocalHistoryOverreadContextMessage(
   return [...messages.slice(0, index), ...messages.slice(index + 1)];
 }
 
+// A silent tail can outrun the bounded raw window: tool traffic, hidden
+// memory-flush prompts, and dropped silent turns all consume raw records
+// without producing a display row, so the newest window can project to nothing
+// while visible history is still on the branch. Snapshot clients rebuild
+// destructively from a first page, so returning that empty page erases a
+// rendered conversation the transcript still holds. Scan older pages until a
+// display row appears, bounded so a pathological transcript cannot turn the
+// tail read into a full scan.
+const SILENT_CHAT_HISTORY_TAIL_SCAN_MAX_MESSAGES = 8_000;
+// Chunk size stays independent of the requested display limit: a `limit: 1`
+// request must not turn the scan into one transcript read per raw record. Pages
+// are contiguous and released between iterations, and the chunk stays below the
+// record count an explicit offset page already materializes, so peak scan memory
+// never exceeds what one ordinary history page costs. A byte-budgeted read is
+// deliberately not used here: it drops oversized records from the middle of a
+// window, which would punch holes in the cursor and hide the oversized-message
+// placeholder the handler would otherwise render. Accepted tradeoff: a chunk is
+// materialized before its bytes can be counted, so the walk can overshoot its
+// budget by one page. That page is smaller than the one every explicit offset
+// request already reads, and closing the gap would need a stop-at-budget
+// contiguous reader that does not exist yet.
+const SILENT_CHAT_HISTORY_TAIL_SCAN_CHUNK_MESSAGES = 100;
+
+/** Keeps a first history page displayable by scanning past an all-silent raw tail. */
+async function resolveDisplayableChatHistoryTail(params: {
+  entry: ReturnType<typeof loadSessionEntry>["entry"];
+  readScope: SessionTranscriptReadScope;
+  effectiveMaxChars: number;
+  max: number;
+  maxBytes: number;
+  projected: unknown[];
+  rawMessages: unknown[];
+  rawPageMessages: number;
+  totalMessages: number;
+}): Promise<{ messages: unknown[]; rawPageMessages: number }> {
+  const unchanged = { messages: params.projected, rawPageMessages: params.rawPageMessages };
+  if (params.projected.length > 0 || params.totalMessages <= params.rawPageMessages) {
+    return unchanged;
+  }
+  const sessionStartedAt =
+    typeof params.entry?.sessionStartedAt === "number" ? params.entry.sessionStartedAt : undefined;
+  const scanLimit = params.rawPageMessages + SILENT_CHAT_HISTORY_TAIL_SCAN_MAX_MESSAGES;
+  let scanned = params.rawPageMessages;
+  // Record count alone does not bound a walk over large tool results, and the
+  // reader cannot bound it either: a byte-budgeted page skips an oversized
+  // record mid-window, which would strand it and its placeholder. Budget the
+  // whole walk instead, at the payload one history response may already return.
+  let scannedBytes = 0;
+  // Projection pairs records across turns (message-tool sends and their
+  // results, turn boundaries), so each chunk is projected together with the
+  // already-read newer records it borders. Only the neighbour is carried, which
+  // keeps the working set at two chunks plus the tail window.
+  let newerRawMessages = params.rawMessages;
+  while (scanned < params.totalMessages && scanned < scanLimit) {
+    const page = await readSessionMessagesPageWithStatsAsync(params.readScope, {
+      offset: scanned,
+      maxMessages: SILENT_CHAT_HISTORY_TAIL_SCAN_CHUNK_MESSAGES + 1,
+      allowResetArchiveFallback: true,
+    });
+    if (page.messages.length === 0) {
+      return unchanged;
+    }
+    // The extra oldest record only supplies pair-filter and turn-boundary
+    // context. Without it a chunk boundary between a stale announce and its
+    // reply would leak the reply that the tail read hides. Each chunk's context
+    // record is the newest record of the next chunk, so this one overread also
+    // covers every junction the walk creates, including tail-to-first-chunk.
+    const contextMessage =
+      page.messages.length > SILENT_CHAT_HISTORY_TAIL_SCAN_CHUNK_MESSAGES
+        ? page.messages[0]
+        : undefined;
+    scanned += page.messages.length - (contextMessage === undefined ? 0 : 1);
+    const chunkMessages = dropLocalHistoryOverreadContextMessage(
+      dropPreSessionStartAnnouncePairs(page.messages, sessionStartedAt),
+      contextMessage,
+    );
+    const projected = projectRecentChatDisplayMessages([...chunkMessages, ...newerRawMessages], {
+      maxChars: params.effectiveMaxChars,
+      maxMessages: params.max,
+      resolveCurrentUserProfileDisplay,
+      turnBoundaryPending: isHeartbeatHistoryTurnBoundaryMessage(contextMessage),
+    });
+    if (projected.length > 0) {
+      return { messages: projected, rawPageMessages: scanned };
+    }
+    scannedBytes += Buffer.byteLength(JSON.stringify(page.messages), "utf8");
+    if (scannedBytes >= params.maxBytes) {
+      return unchanged;
+    }
+    newerRawMessages = chunkMessages;
+  }
+  return unchanged;
+}
+
 export async function readChatHistoryPage(params: {
   entry: ReturnType<typeof loadSessionEntry>["entry"];
   provider: string | undefined;
@@ -338,23 +433,35 @@ export async function readChatHistoryPage(params: {
       : isTailPage
         ? projected
         : capOffsetChatHistoryProjectedMessages(projected, max);
-    const normalized = augmentChatHistoryWithCanvasBlocks(windowed);
     if (messageId) {
       // Numeric offsets do not encode the selected historical transcript source.
-      return { messages: normalized };
+      return { messages: augmentChatHistoryWithCanvasBlocks(windowed) };
     }
+    const tail = isTailPage
+      ? await resolveDisplayableChatHistoryTail({
+          entry,
+          readScope,
+          effectiveMaxChars,
+          max,
+          maxBytes: maxHistoryBytes,
+          projected: windowed,
+          rawMessages: recencyFilteredMessages,
+          rawPageMessages,
+          totalMessages: readPage.totalMessages,
+        })
+      : { messages: windowed, rawPageMessages };
     return {
       ...(isTailPage
         ? {
             activeLeafEntryId: resolveChatHistoryActiveLeafEntryId(readPage),
           }
         : {}),
-      messages: normalized,
+      messages: augmentChatHistoryWithCanvasBlocks(tail.messages),
       responseOffset: pageOffset,
       pagination: {
         offset: pageOffset,
         totalMessages: readPage.totalMessages,
-        rawPageMessages,
+        rawPageMessages: tail.rawPageMessages,
       },
     };
   }
@@ -447,18 +554,29 @@ export async function readChatHistoryPage(params: {
     resolveCurrentUserProfileDisplay,
     turnBoundaryPending,
   });
+  const tail = await resolveDisplayableChatHistoryTail({
+    entry,
+    readScope,
+    effectiveMaxChars,
+    max,
+    maxBytes: maxHistoryBytes,
+    projected: displayMessages,
+    rawMessages: recencyFilteredMessages,
+    // The extra record supplies pair-filter context; it was not returned and
+    // must remain reachable by the next strictly-older page.
+    rawPageMessages: Math.min(
+      rawHistoryWindow.maxMessages,
+      Math.max(readPage.messages.length, readPage.totalMessages > 0 ? 1 : 0),
+    ),
+    totalMessages: readPage.totalMessages,
+  });
   return {
     activeLeafEntryId,
-    messages: augmentChatHistoryWithCanvasBlocks(displayMessages),
+    messages: augmentChatHistoryWithCanvasBlocks(tail.messages),
     pagination: {
       offset: 0,
       totalMessages: readPage.totalMessages,
-      // The extra record supplies pair-filter context; it was not returned and
-      // must remain reachable by the next strictly-older page.
-      rawPageMessages: Math.min(
-        rawHistoryWindow.maxMessages,
-        Math.max(readPage.messages.length, readPage.totalMessages > 0 ? 1 : 0),
-      ),
+      rawPageMessages: tail.rawPageMessages,
     },
   };
 }

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -5269,7 +5269,7 @@ describe("gateway server chat", () => {
     });
   });
 
-  test("chat.history advances past an oversized newest record when the tail parses empty", async () => {
+  test("chat.history serves older history past an oversized newest record", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await prepareMainHistoryHarness({ ws, createSessionDir });
       const historyMaxBytes = getMaxChatHistoryMessagesBytes();
@@ -5289,18 +5289,9 @@ describe("gateway server chat", () => {
         hasMore?: boolean;
       }>(ws, "chat.history", makeMainSessionParams({ limit: 1 }));
       expect(firstPage.ok).toBe(true);
-      expect(firstPage.payload?.messages).toEqual([]);
-      expect(firstPage.payload?.hasMore).toBe(true);
-      expect(firstPage.payload?.nextOffset).toBe(1);
-
-      const olderPage = await rpcReq<{ messages?: unknown[]; hasMore?: boolean }>(
-        ws,
-        "chat.history",
-        makeMainSessionParams({ limit: 1, offset: firstPage.payload?.nextOffset }),
-      );
-      expect(olderPage.ok).toBe(true);
-      expect(JSON.stringify(olderPage.payload?.messages)).toContain("reachable older message");
-      expect(olderPage.payload?.hasMore).toBe(false);
+      expect(JSON.stringify(firstPage.payload?.messages)).toContain("reachable older message");
+      expect(firstPage.payload?.hasMore).toBe(false);
+      expect(firstPage.payload?.nextOffset).toBeUndefined();
     });
   });
 
@@ -5807,6 +5798,83 @@ describe("gateway server chat", () => {
       expect(JSON.stringify(messages)).toContain("visible question");
       expect(JSON.stringify(messages)).toContain("visible answer");
       expect(JSON.stringify(messages)).not.toContain("NO_REPLY");
+    });
+  });
+
+  // A silent tail longer than the bounded raw window used to project to an empty
+  // first page while the branch still held visible turns, and snapshot clients
+  // erase their rendered conversation when that page comes back empty.
+  test.each([
+    { name: "tail request", params: { limit: 2, maxChars: 100 } },
+    { name: "explicit first page", params: { limit: 2, maxChars: 100, offset: 0 } },
+  ])(
+    "chat.history recovers visible history when the raw tail window is entirely silent ($name)",
+    async ({ params }) => {
+      await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+        await prepareMainHistoryHarness({ ws, createSessionDir });
+        // limit 2 reads at most 2 * 20 + 20 raw records, so 80 silent records
+        // push every visible turn out of the tail window.
+        const silentTail = Array.from({ length: 80 }, (_, index) =>
+          createTextTranscriptEvent("assistant", "NO_REPLY", {
+            timestamp: Date.now() + index + 2,
+          }),
+        );
+        await writeMainSessionTranscript([
+          createTextTranscriptEvent("user", "visible question", { timestamp: Date.now() }),
+          createTextTranscriptEvent("assistant", "visible answer", { timestamp: Date.now() + 1 }),
+          ...silentTail,
+        ]);
+
+        const page = await rpcReq<{ messages?: unknown[]; hasMore?: boolean }>(
+          ws,
+          "chat.history",
+          makeMainSessionParams(params),
+        );
+        expect(page.ok).toBe(true);
+        expect(JSON.stringify(page.payload?.messages)).toContain("visible question");
+        expect(JSON.stringify(page.payload?.messages)).toContain("visible answer");
+        expect(JSON.stringify(page.payload?.messages)).not.toContain("NO_REPLY");
+        expect(page.payload?.hasMore).toBe(false);
+      });
+    },
+  );
+
+  test("chat.history overreads context while scanning past a silent tail", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      await prepareMainHistoryHarness({ ws, createSessionDir });
+      const sessionStartedAt = Date.now();
+      await writeSessionStore({
+        entries: {
+          main: { sessionId: "sess-main", updatedAt: Date.now(), sessionStartedAt },
+        },
+      });
+      // limit 2 reads a 60-record tail, and the scan then walks 100-record
+      // chunks, so record 239 of 400 is the first chunk's context boundary.
+      const silent = (index: number, count: number) =>
+        Array.from({ length: count }, (_, offset) =>
+          createTextTranscriptEvent("assistant", "NO_REPLY", {
+            timestamp: sessionStartedAt + index + offset,
+          }),
+        );
+      await writeMainSessionTranscript([
+        createTextTranscriptEvent("user", "oldest visible question", {
+          timestamp: sessionStartedAt + 1,
+        }),
+        ...silent(2, 238),
+        createTextTranscriptEvent("user", "stale announce", {
+          timestamp: sessionStartedAt - 2_000,
+          message: { provenance: { kind: "inter_session", sourceTool: "subagent_announce" } },
+        }),
+        createTextTranscriptEvent("assistant", "stale announce reply", {
+          timestamp: sessionStartedAt - 1_000,
+        }),
+        ...silent(300, 159),
+      ]);
+
+      const messages = await fetchHistoryMessages(ws, { limit: 2, maxChars: 100 });
+      const serialized = JSON.stringify(messages);
+      expect(serialized).toContain("oldest visible question");
+      expect(serialized).not.toContain("stale announce reply");
     });
   });
 


### PR DESCRIPTION
Closes #114192

## What Problem This Solves

Fixes an issue where a long-running terminal (TUI) session could lose its entire visible conversation while the session itself stayed healthy. After a stretch of activity that produces no chat rows — tool traffic, a memory-flush turn, silent turns, or one very large record — `chat.history` returned an empty first page even though the transcript still held the conversation. The TUI rebuilds its chat log destructively from that page, so the screen went back to just the session header while the transcript, the session-history API, and the model's own continuity were all intact.

## Why This Change Was Made

`chat.history` reads a bounded raw tail (records and bytes) and then projects it for display. Anything the projection hides still consumes that budget, so the whole window can be spent on records that produce no display row while visible turns sit just past it. The page came back empty, and the response's paging metadata is no help to a client that asks for the tail once and renders what it gets.

The gateway now recovers at the producer: when the first page projects to no display rows and older records exist, it walks older transcript chunks until display rows appear. The scan is bounded three ways: fixed 100-record chunks — deliberately independent of the requested `limit`, so `limit: 1` cannot degenerate into one read per record, and small enough that peak scan memory stays under what one ordinary offset page already materializes — at most 8,000 scanned records, and an aggregate byte budget across the whole walk equal to what a single history response may already return. Pages are contiguous and released between iterations. A byte-budgeted *read* was tried and rejected: the bounded tail reader skips an oversized record in the middle of a window rather than stopping at it, which punches holes in the cursor and hides the oversized-message placeholder the handler would otherwise render. With contiguous pages an oversized record instead ends the scan with that placeholder, which is the visible outcome the reader should get — so the budget is enforced across the walk rather than inside each read.

Projection pairs records across turns, so each chunk is projected beside the newer records it borders: one extra older record as backward filter context (matching how offset pages already avoid leaking a stale inter-session reply whose announce fell outside the page), and the already-read newer neighbour so a message-tool send and its result still mirror when a chunk boundary falls between them. Only the neighbour is carried, which keeps the working set at two chunks plus the tail window. The reported raw-record count advances by everything scanned, so older paging still resumes strictly before the page that was served.

Only the first page is repaired. Explicit older pages keep their exact offset semantics.

## User Impact

Terminal sessions keep their visible conversation across long tool-heavy stretches and across compaction. The chat log no longer empties itself while the underlying session is fine. Normal sessions are unaffected: the scan only runs when the first page would otherwise be empty, so there is no added cost on the common path.

## Evidence

Two new gateway regression tests plus one existing test updated to the repaired contract. Proof ran on Blacksmith Testbox against the exact branch.

Before (fix reverted, tests present) — the first page comes back empty for a transcript that still holds visible turns:

```
× chat.history recovers visible history when the raw tail window is entirely silent ('tail request')
× chat.history recovers visible history when the raw tail window is entirely silent ('explicit first page')

AssertionError: expected '[]' to contain 'visible question'
Expected: "visible question"
Received: "[]"

Test Files  1 failed (1)
     Tests  2 failed | 94 skipped (96)
```

After:

```
✓ chat.history recovers visible history when the raw tail window is entirely silent ('tail request')
✓ chat.history recovers visible history when the raw tail window is entirely silent ('explicit first page')
✓ chat.history overreads context while scanning past a silent tail
✓ chat.history serves older history past an oversized newest record

Test Files  1 passed (1)
     Tests  97 passed (97)
```

The context-overread test is a real guard, not decoration — dropping the extra context record makes it fail by leaking a pre-session announce reply and losing the older visible turn:

```
AssertionError: expected '[{"role":"assistant","content":[{"type":"text","text":"stale announce reply"}],...}]'
to contain 'oldest visible question'
```

`chat.history advances past an oversized newest record when the tail parses empty` asserted the old behavior directly (empty first page, client must page). It is now `chat.history serves older history past an oversized newest record` and asserts the first page carries the reachable message. That test's fixture is also independent proof that the byte budget can trigger the same empty page, not just the record budget.

Sibling consumers and gates, all green on the same branch:

- `pnpm test src/gateway/server.chat.gateway-server-chat-b.test.ts src/gateway/session-transcript-readers.test.ts` — 127 passed
- `pnpm test src/tui/embedded-backend.test.ts src/gateway/session-history-state.test.ts src/gateway/chat-display-projection.test.ts src/gateway/server.chat.gateway-server-chat.test.ts` — passed
- `pnpm check:changed` — passed
- `pnpm test:changed` — 98 passed (`server.chat.gateway-server-chat-b`, `server-methods/chat-history-pages`)

Production lines: +118 net, all in `src/gateway/server-methods/chat-history-pages.ts`; tests +68 net. The growth buys one product invariant: a first history page must not report "no conversation" for a session that has one.

One named tradeoff: a scan chunk is materialized before its bytes can be counted, so the walk can overshoot its budget by a single page. That page is smaller than the one every explicit offset request already reads, and closing the gap would need a stop-at-budget contiguous transcript reader that does not exist yet. It is recorded at the constant so it stays a decision rather than an oversight.

Two sibling surfaces carry the same defect and are deliberately not touched here, tracked in #121386.

`GET /sessions/:sessionKey/history` (`src/gateway/sessions-history-http.ts`, backed by `src/gateway/session-history-state.ts`) reads through the same bounded-window helper and can produce the same empty first page. Cursor paging does not rescue it — it removes the escape hatch: `paginateSessionMessages` builds an empty page with `hasMore: false` and no `nextCursor` (`src/gateway/session-history-state.ts:127-155`, cursor emitted only when `start > 0` at `:154`), and the repair that would mark a truncated read as continuable is gated on `history.messages.length > 0` (`:173-178`). The caller is told "no history, nothing older" with no way to page back. The honest reason it is out of scope is not that its clients page — it is that this endpoint has no in-repo client today (registered at `src/gateway/server-http.ts:518-519`, no UI, TUI, app, or SDK consumer), so the exposure reaches external API callers only.

`src/agents/tools/embedded-gateway-stub.ts` is the second sibling and the one with no mitigation: it does not call `readChatHistoryPage` at all. It inlines the window formula at `:326`, duplicates the tail read at `:360-390`, the overread/announce filtering at `:395-419`, the projection at `:428-452`, and keeps its own `resolveChatHistoryNextOffset` at `:151` feeding `:453-465`. Being a copy, it does not inherit this repair, and its no-offset path is more exposed than the Gateway was — it reads `maxMessages: max` (`:348`) rather than the 20x window and hardcodes `hasMore: false` (`:465`). That path is the model's own view of session history in embedded mode.

Collapsing the stub onto `readChatHistoryPage` is the right follow-up rather than porting this scan into a second hand-written copy; #121386 says so and orders the work.
