### PR TITLE
refactor(extensions): remove unused compatibility exports

### DIFF
--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -1580,13 +1580,4 @@ export function normalizeCodexAppServerBindingModelProvider(params: {
   return modelProvider;
 }
 
-/** Restores the sole provider intentionally omitted from canonical binding rows. */
-export function resolveCodexAppServerBindingModelProvider(
-  params: CodexAppServerAuthProfileLookup & { modelProvider?: string },
-): string | undefined {
-  return (
-    params.modelProvider?.trim() ||
-    (isCodexAppServerNativeAuthProfile(params) ? PUBLIC_OPENAI_MODEL_PROVIDER : undefined)
-  );
-}
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/feishu/api.ts
+++ b/extensions/feishu/api.ts
@@ -29,5 +29,3 @@ export {
 } from "./src/thread-bindings.js";
 export { testing as feishuThreadBindingTesting } from "./src/thread-bindings.js";
 export { createClackPrompter } from "openclaw/plugin-sdk/setup-runtime";
-
-export const feishuSessionBindingAdapterChannels = ["feishu"] as const;

--- a/extensions/matrix/api.ts
+++ b/extensions/matrix/api.ts
@@ -33,5 +33,3 @@ export {
   setMatrixThreadBindingMaxAgeBySessionKey,
 } from "./src/matrix/thread-bindings-shared.js";
 export { matrixOnboardingAdapter as matrixSetupWizard } from "./src/onboarding.js";
-
-export const matrixSessionBindingAdapterChannels = ["matrix"] as const;

--- a/extensions/openai/api.ts
+++ b/extensions/openai/api.ts
@@ -14,6 +14,6 @@ export { openaiMediaUnderstandingProvider } from "./media-understanding-provider
 export { buildOpenAICodexProvider } from "./openai-chatgpt-catalog.js";
 export { loginOpenAICodexOAuth } from "./openai-chatgpt-oauth.runtime.js";
 export { refreshOpenAICodexToken } from "./openai-chatgpt-provider.runtime.js";
-export { buildOpenAICodexProviderPlugin, buildOpenAIProvider } from "./openai-provider.js";
+export { buildOpenAIProvider } from "./openai-provider.js";
 export { buildOpenAIRealtimeTranscriptionProvider } from "./realtime-transcription-provider.js";
 export { buildOpenAIRealtimeVoiceProvider } from "./realtime-voice-provider.js";

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -1135,14 +1135,6 @@ describe("buildOpenAIProvider", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
-  it("keeps the deprecated Codex provider builder on the public API barrel", async () => {
-    const { buildOpenAICodexProviderPlugin } = await import("./api.js");
-    const provider = buildOpenAICodexProviderPlugin();
-
-    expect(provider.id).toBe("openai");
-    expect(provider.hookAliases).toEqual(["azure-openai", "azure-openai-responses"]);
-  });
-
   it.each(["gpt-5.5", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])(
     "prefers auth-aware Codex runtime metadata for %s over static OpenAI catalog rows",
     (modelId) => {

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -579,7 +579,7 @@ async function buildOpenAICodexLiveProviderConfig(params: {
       fetchGuard: params.fetchGuard,
       signal: params.signal,
       ttlMs: OPENAI_CODEX_MODELS_CACHE_TTL_MS,
-      auditContext: "openai-codex-model-discovery",
+      auditContext: "openai-model-discovery",
       readRows: readCodexModelRows,
       buildRequestHeaders: ({ discoveryApiKey }) => ({
         Accept: "application/json",
@@ -1127,8 +1127,4 @@ export function buildOpenAIProvider(): ProviderPlugin {
   };
 }
 
-/** @deprecated Use buildOpenAIProvider; OpenAI Codex is now an OpenAI auth/transport mode. */
-export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
-  return buildOpenAIProvider();
-}
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/opencode-go/provider-policy-api.ts
+++ b/extensions/opencode-go/provider-policy-api.ts
@@ -48,11 +48,6 @@ function resolveEffortThinkingProfile(
   return { levels, defaultLevel };
 }
 
-export function isOpencodeGoDeepSeekV4ModelId(modelId: unknown): boolean {
-  const normalized = typeof modelId === "string" ? modelId.trim().toLowerCase() : "";
-  return normalized === "deepseek-v4-flash" || normalized === "deepseek-v4-pro";
-}
-
 export function isOpencodeGoFixedAnthropicReasoningModelId(modelId: unknown): boolean {
   return (
     typeof modelId === "string" &&


### PR DESCRIPTION
## What Problem This Solves

Removes stale compatibility exports and helpers that no longer have callers. Leaving these symbols in place enlarged the bundled plugin surface and implied support for obsolete seams, while one internal audit label still used the retired OpenAI Codex provider spelling.

## Why This Change Was Made

This is a conservative dead-code cleanup: it removes only zero-reference helpers, two unused session-binding channel constants, the deprecated OpenAI Codex provider-builder alias and its alias-only test, and an unused OpenCode Go predicate. It also renames the non-contract audit label to the current OpenAI naming.

Guarded or dynamically published contracts remain intact. In particular, this retains the guarded `openai-chatgpt-catalog.js` artifact, the shipped manual-only xAI device-code alias, the production-used `oc-path` wildcard helper, and top-level `api.ts` / `runtime-api.ts` barrels published by bundled-plugin scanning and runtime sidecars.

## User Impact

No user-visible behavior changes. The cleanup reduces production surface by 22 net lines and removes eight lines of alias-only test coverage without changing runtime contracts or configuration.

## Evidence

- Focused Vitest groups passed: OpenAI 72 tests, Codex 47, Feishu 8, Matrix 11, and OpenCode Go 26.
- Blacksmith Testbox changed checks passed in [run 31347189873](https://github.com/openclaw/openclaw/actions/runs/31347189873).
- `pnpm deadcode:full` passed remotely.
- `git diff --check` passed.
- Fresh uncommitted autoreview completed with no accepted or actionable findings.
- Production LOC: +2/-24 (net -22). Tests: +0/-8.
- The upstream Codex thread contract was checked directly in [`thread.rs` lines 57-66](https://github.com/openai/codex/blob/50ef7395faee1d0e2d01730f9636aa06091c7be3/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L57-L66) and [`thread_lifecycle.rs` lines 683-708](https://github.com/openai/codex/blob/50ef7395faee1d0e2d01730f9636aa06091c7be3/codex-rs/app-server/src/request_processors/thread_lifecycle.rs#L683-L708).

AI-assisted maintainer cleanup; no agent transcript is included.
