### PR TITLE
fix(sessions): avoid full cache scans after transcript writes

### DIFF
--- a/src/commands/doctor-session-entry-rewrite.ts
+++ b/src/commands/doctor-session-entry-rewrite.ts
@@ -1,4 +1,7 @@
-import { publishSqliteSessionEntryCacheInvalidation } from "../config/sessions/session-accessor.sqlite-entry-cache.js";
+import {
+  publishSqliteSessionEntryCacheInvalidation,
+  trackSqliteSessionEntryCacheWrite,
+} from "../config/sessions/session-accessor.sqlite-entry-cache.js";
 import { parseSqliteSessionEntryRecord } from "../config/sessions/session-entry-json.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
@@ -21,23 +24,29 @@ export function writeValidatedDoctorSessionEntryJson(
     throw new Error(`Refusing invalid SQLite session entry rewrite for ${row.session_key}`);
   }
   const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database.db);
-  executeSqliteQuerySync(
-    database.db,
-    db
-      .updateTable("session_nodes")
-      .set({ entry_json: entryJson })
-      .where("session_key", "=", row.session_key),
-  );
-  // The entry_json trigger marks every rewrite pending, including a value already validated
-  // above. Settle it separately so the next strict reader does not reject doctor's output.
-  executeSqliteQuerySync(
-    database.db,
-    db
-      .updateTable("session_nodes")
-      .set({ entry_valid: 1 })
-      .where("session_key", "=", row.session_key),
-  );
+  const writeGeneration = trackSqliteSessionEntryCacheWrite(database, () => {
+    executeSqliteQuerySync(
+      database.db,
+      db
+        .updateTable("session_nodes")
+        .set({ entry_json: entryJson })
+        .where("session_key", "=", row.session_key),
+    );
+    // The entry_json trigger marks every rewrite pending, including a value already validated
+    // above. Settle it separately so the next strict reader does not reject doctor's output.
+    executeSqliteQuerySync(
+      database.db,
+      db
+        .updateTable("session_nodes")
+        .set({ entry_valid: 1 })
+        .where("session_key", "=", row.session_key),
+    );
+  });
   // The transaction owner defers this row publication until commit; rollback must never
   // expose repaired JSON through a warm connection-local session cache.
-  publishSqliteSessionEntryCacheInvalidation(database, { ...row, entry_json: entryJson });
+  publishSqliteSessionEntryCacheInvalidation(
+    database,
+    { ...row, entry_json: entryJson },
+    writeGeneration,
+  );
 }

--- a/src/commands/doctor-session-incognito-key-repair.test.ts
+++ b/src/commands/doctor-session-incognito-key-repair.test.ts
@@ -134,6 +134,9 @@ describe("doctor reserved incognito session key repair", () => {
           "INSERT INTO session_members (session_key, identity_id, added_by, added_at) VALUES (?, 'member-1', 'owner-1', 1)",
         )
         .run(oldKey);
+      expect(listSessionEntries({ agentId: "main", clone: false, env })[0]?.sessionKey).toBe(
+        oldKey,
+      );
 
       expect(repairReservedIncognitoSessionKeys({ apply: false, cfg: {}, env })).toEqual({
         found: 1,
@@ -143,6 +146,9 @@ describe("doctor reserved incognito session key repair", () => {
         found: 1,
         repaired: 1,
       });
+      expect(listSessionEntries({ agentId: "main", clone: false, env })[0]?.sessionKey).toBe(
+        newKey,
+      );
 
       expect(
         database.db

--- a/src/commands/doctor-session-incognito-key-repair.ts
+++ b/src/commands/doctor-session-incognito-key-repair.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
+import { publishSqliteSessionEntryCacheInvalidation } from "../config/sessions/session-accessor.sqlite-entry-cache.js";
 import { resolveAllAgentSessionStoreCandidateTargetsSync } from "../config/sessions/targets.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
@@ -176,6 +177,8 @@ function applyReservedIncognitoKeyRenames(
     updateSessionKeyColumns(database.db, rename);
   }
   rewriteSessionEntryJsonReferences(database, new Map(renames.map((item) => [item.from, item.to])));
+  // Key and lineage columns reshape the cached map even when no entry JSON needs rewriting.
+  publishSqliteSessionEntryCacheInvalidation(database);
 }
 
 function legacyIncognitoSessionKey(sessionKey: string): string {

--- a/src/config/sessions/session-accessor.sqlite-data-version.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-data-version.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import type { Compilable, QueryResult } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { clearNodeSqliteKyselyCacheForDatabase } from "../../infra/kysely-sync.js";
@@ -11,8 +12,8 @@ import {
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import {
+  appendTranscriptMessage,
   listSessionEntries,
-  listSessionEntryKeysReadOnly,
   loadSessionEntry,
   openSessionEntryReadView,
   upsertSessionEntry,
@@ -22,6 +23,31 @@ import { ensureTranscriptSessionRoot } from "./session-accessor.sqlite-transcrip
 
 const parseSessionEntryCalls = vi.hoisted(() => vi.fn());
 const listProjectionCalls = vi.hoisted(() => vi.fn());
+const sessionNodeVersionScans = vi.hoisted(() => ({
+  onScan: undefined as ((database: DatabaseSync) => void) | undefined,
+  rowCounts: [] as number[],
+}));
+
+vi.mock("../../infra/kysely-sync.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/kysely-sync.js")>();
+  return {
+    ...actual,
+    executeSqliteQuerySync<Row>(database: DatabaseSync, query: Compilable<Row>): QueryResult<Row> {
+      const compiled = query.compile();
+      const result = actual.executeSqliteQuerySync(database, query);
+      if (
+        compiled.sql.replace(/\s+/gu, " ").trim() ===
+        'select "session_key", "updated_at" from "session_nodes"'
+      ) {
+        sessionNodeVersionScans.rowCounts.push(result.rows.length);
+        const onScan = sessionNodeVersionScans.onScan;
+        sessionNodeVersionScans.onScan = undefined;
+        onScan?.(database);
+      }
+      return result;
+    },
+  };
+});
 
 vi.mock("./session-accessor.sqlite-status.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./session-accessor.sqlite-status.js")>();
@@ -52,6 +78,8 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 beforeEach(() => {
   parseSessionEntryCalls.mockClear();
   listProjectionCalls.mockClear();
+  sessionNodeVersionScans.onScan = undefined;
+  sessionNodeVersionScans.rowCounts.length = 0;
 });
 
 afterEach(() => {
@@ -232,7 +260,7 @@ describe("SQLite session entry cache", () => {
     }
   });
 
-  it("reuses parsed entries and list projections after a same-connection non-entry write", async () => {
+  it("does not revalidate session nodes after a same-connection transcript write", async () => {
     const scope = createSessionScope("same-connection-non-entry");
     const siblingScope = { ...scope, sessionKey: "agent:main:same-connection-non-entry-2" };
     await upsertSessionEntry(scope, {
@@ -247,16 +275,9 @@ describe("SQLite session entry cache", () => {
     });
     const first = listSessionEntries({ ...scope, clone: false, projection: "list" });
 
-    const database = openOpenClawAgentDatabase(scope);
-    ensureTranscriptSessionRoot(
-      database,
-      {
-        agentId: scope.agentId,
-        env: scope.env,
-        sessionId: "same-connection-non-entry",
-        sessionKey: scope.sessionKey,
-      },
-      2,
+    await appendTranscriptMessage(
+      { ...scope, sessionId: "same-connection-non-entry" },
+      { message: { role: "user", content: [{ type: "text", text: "cache probe" }] }, now: 2 },
     );
     parseSessionEntryCalls.mockClear();
     listProjectionCalls.mockClear();
@@ -268,6 +289,7 @@ describe("SQLite session entry cache", () => {
     expect(second[1]?.entry).toBe(first[1]?.entry);
     expect(parseSessionEntryCalls).not.toHaveBeenCalled();
     expect(listProjectionCalls).not.toHaveBeenCalled();
+    expect(sessionNodeVersionScans.rowCounts).toEqual([]);
   });
 
   it("fully reloads after another connection commits", async () => {
@@ -358,6 +380,63 @@ describe("SQLite session entry cache", () => {
       expect(after[0]?.entry.label).toBe("projection-probe-after");
       expect(parseSessionEntryCalls).toHaveBeenCalledTimes(2);
       expect(listProjectionCalls).toHaveBeenCalledTimes(2);
+    } finally {
+      maintenance.close();
+      external.close();
+    }
+  });
+
+  it("fully reloads when an external commit races incremental row reads", async () => {
+    const scope = createSessionScope("external-race");
+    const siblingScope = { ...scope, sessionKey: "agent:main:external-race-sibling" };
+    await upsertSessionEntry(scope, {
+      label: "local-before",
+      sessionId: "external-race-local",
+      updatedAt: 1,
+    });
+    await upsertSessionEntry(siblingScope, {
+      label: "external-before",
+      sessionId: "external-race-sibling",
+      updatedAt: 1,
+    });
+    listSessionEntries(scope);
+
+    const database = openOpenClawAgentDatabase(scope);
+    const localEntry = {
+      label: "local-after",
+      sessionId: "external-race-local",
+      updatedAt: 2,
+    };
+    database.db
+      .prepare("UPDATE session_nodes SET entry_json = ?, updated_at = ? WHERE session_key = ?")
+      .run(JSON.stringify(localEntry), localEntry.updatedAt, scope.sessionKey);
+
+    const external = new DatabaseSync(database.path);
+    const maintenance = configureSqliteConnectionPragmas(external, {
+      checkpointIntervalMs: 0,
+      databaseLabel: "session-entry-external-race-writer",
+      databasePath: database.path,
+      foreignKeys: true,
+      synchronous: "NORMAL",
+    });
+    try {
+      const externalEntry = {
+        label: "external-after",
+        sessionId: "external-race-sibling",
+        updatedAt: 2,
+      };
+      sessionNodeVersionScans.onScan = () => {
+        external
+          .prepare("UPDATE session_nodes SET entry_json = ?, updated_at = ? WHERE session_key = ?")
+          .run(JSON.stringify(externalEntry), externalEntry.updatedAt, siblingScope.sessionKey);
+      };
+
+      const entries = listSessionEntries(scope);
+      const byId = new Map(entries.map((row) => [row.entry.sessionId, row.entry]));
+
+      expect(byId.get("external-race-local")?.label).toBe("local-after");
+      expect(byId.get("external-race-sibling")?.label).toBe("external-after");
+      expect(sessionNodeVersionScans.rowCounts).toEqual([2]);
     } finally {
       maintenance.close();
       external.close();
@@ -486,6 +565,7 @@ describe("SQLite session entry cache", () => {
     );
     expect(parseSessionEntryCalls).not.toHaveBeenCalled();
     expect(listProjectionCalls).toHaveBeenCalledOnce();
+    expect(sessionNodeVersionScans.rowCounts).toEqual([]);
   });
 
   it("adds a tracked upsert to a warm snapshot without reparsing siblings", async () => {
@@ -545,19 +625,20 @@ describe("SQLite session entry cache", () => {
       sessionId: "tracked",
     });
     expect(parseSessionEntryCalls).toHaveBeenCalledOnce();
+    expect(sessionNodeVersionScans.rowCounts).toEqual([2]);
   });
 
   it("invalidates cached keys when transcript creation inserts a placeholder node", async () => {
     const scope = createSessionScope("placeholder-key");
     await upsertSessionEntry(scope, { sessionId: "entry", updatedAt: 1 });
-    expect(listSessionEntryKeysReadOnly({ agentId: scope.agentId, env: scope.env })).toEqual([
-      scope.sessionKey,
-    ]);
+    const database = openOpenClawAgentDatabase(scope);
+    const before = readSqliteSessionEntryCache(database, { cache: true });
+    expect(before.keys).toEqual([scope.sessionKey]);
 
     const placeholderKey = "agent:main:placeholder-only";
-    runOpenClawAgentWriteTransaction((database) => {
+    runOpenClawAgentWriteTransaction((transactionDatabase) => {
       ensureTranscriptSessionRoot(
-        database,
+        transactionDatabase,
         {
           agentId: scope.agentId,
           env: scope.env,
@@ -568,10 +649,9 @@ describe("SQLite session entry cache", () => {
       );
     }, scope);
 
-    expect(listSessionEntryKeysReadOnly({ agentId: scope.agentId, env: scope.env })).toEqual([
-      scope.sessionKey,
-      placeholderKey,
-    ]);
+    const after = readSqliteSessionEntryCache(database, { cache: true });
+    expect(after.keys).toEqual([scope.sessionKey, placeholderKey]);
+    expect(after.entries.get(scope.sessionKey)).not.toBe(before.entries.get(scope.sessionKey));
   });
 
   it("bypasses the cache in a transaction and reuses the persisted snapshot after rollback", async () => {
@@ -621,7 +701,7 @@ describe("SQLite session entry cache", () => {
   it("honors latest reads after an untracked own-connection write", async () => {
     const scope = createSessionScope("latest");
     await upsertSessionEntry(scope, { label: "cached", sessionId: "latest", updatedAt: 1 });
-    expect(loadSessionEntry(scope)?.label).toBe("cached");
+    expect(listSessionEntries(scope)[0]?.entry.label).toBe("cached");
 
     const database = openOpenClawAgentDatabase(scope);
     const updated = { label: "latest", sessionId: "latest", updatedAt: 2 };
@@ -629,7 +709,8 @@ describe("SQLite session entry cache", () => {
       .prepare("UPDATE session_nodes SET entry_json = ?, updated_at = ? WHERE session_key = ?")
       .run(JSON.stringify(updated), updated.updatedAt, scope.sessionKey);
 
-    expect(loadSessionEntry(scope)?.label).toBe("latest");
+    expect(listSessionEntries(scope)[0]?.entry.label).toBe("latest");
+    expect(sessionNodeVersionScans.rowCounts).toEqual([1]);
     expect(loadSessionEntry({ ...scope, readConsistency: "latest" })?.label).toBe("latest");
   });
 });

--- a/src/config/sessions/session-accessor.sqlite-entry-cache.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-cache.ts
@@ -29,7 +29,12 @@ type LoadedSessionEntrySnapshot = SqliteSessionEntryCacheSnapshot & {
 
 type SqliteSessionEntryCacheValidityToken = {
   dataVersion: number;
-  totalChanges: number;
+  sessionNodesGeneration: number;
+};
+
+type SqliteSessionEntryCacheWriteGeneration = {
+  after: number;
+  before: number;
 };
 
 const MAX_INCREMENTAL_ENTRY_READ_KEYS = 500;
@@ -41,6 +46,7 @@ const MAX_INCREMENTAL_ENTRY_READ_KEYS = 500;
 // structural/unknown writes invalidate. Without both, every read would re-query and re-parse
 // every entry_json document.
 const sessionEntryCaches = new WeakMap<DatabaseSync, SqliteSessionEntryCache>();
+const sessionNodesGenerationTrackerSchemaVersions = new WeakMap<DatabaseSync, number>();
 
 function readDataVersion(database: DatabaseSync): number {
   const row = database.prepare("PRAGMA data_version").get() as { data_version?: unknown };
@@ -50,18 +56,52 @@ function readDataVersion(database: DatabaseSync): number {
   return row.data_version;
 }
 
-function readTotalChanges(database: DatabaseSync): number {
-  const row = database.prepare("SELECT total_changes() AS value").get() as { value?: unknown };
-  if (typeof row.value !== "number") {
-    throw new Error("SQLite did not return a numeric total_changes() value");
+function ensureSessionNodesGenerationTracker(database: DatabaseSync): void {
+  const schemaRow = database.prepare("PRAGMA schema_version").get() as {
+    schema_version?: unknown;
+  };
+  if (typeof schemaRow.schema_version !== "number") {
+    throw new Error("SQLite did not return a numeric PRAGMA schema_version");
   }
-  return row.value;
+  const trackedSchemaVersion = sessionNodesGenerationTrackerSchemaVersions.get(database);
+  if (trackedSchemaVersion === schemaRow.schema_version) {
+    return;
+  }
+  // sqlite-allow-raw -- TEMP triggers are the connection-local ownership boundary: they
+  // observe unpublished raw DML. A main-schema change bumps the generation before reinstalling
+  // them, so dropping/recreating session_nodes cannot make an old snapshot look current.
+  database.exec(`
+    CREATE TEMP TABLE IF NOT EXISTS openclaw_session_nodes_cache_generation (id INTEGER NOT NULL PRIMARY KEY CHECK (id = 1), generation INTEGER NOT NULL) STRICT;
+    INSERT OR IGNORE INTO openclaw_session_nodes_cache_generation (id, generation) VALUES (1, 0);
+    ${trackedSchemaVersion === undefined ? "" : "UPDATE openclaw_session_nodes_cache_generation SET generation = generation + 1 WHERE id = 1;"}
+    DROP TRIGGER IF EXISTS openclaw_session_nodes_cache_generation_insert;
+    DROP TRIGGER IF EXISTS openclaw_session_nodes_cache_generation_update;
+    DROP TRIGGER IF EXISTS openclaw_session_nodes_cache_generation_delete;
+    CREATE TEMP TRIGGER openclaw_session_nodes_cache_generation_insert
+      AFTER INSERT ON main.session_nodes BEGIN UPDATE openclaw_session_nodes_cache_generation SET generation = generation + 1 WHERE id = 1; END;
+    CREATE TEMP TRIGGER openclaw_session_nodes_cache_generation_update
+      AFTER UPDATE ON main.session_nodes BEGIN UPDATE openclaw_session_nodes_cache_generation SET generation = generation + 1 WHERE id = 1; END;
+    CREATE TEMP TRIGGER openclaw_session_nodes_cache_generation_delete
+      AFTER DELETE ON main.session_nodes BEGIN UPDATE openclaw_session_nodes_cache_generation SET generation = generation + 1 WHERE id = 1; END;
+  `);
+  sessionNodesGenerationTrackerSchemaVersions.set(database, schemaRow.schema_version);
+}
+
+function readSessionNodesGeneration(database: DatabaseSync): number {
+  ensureSessionNodesGenerationTracker(database);
+  const row = database
+    .prepare("SELECT generation FROM temp.openclaw_session_nodes_cache_generation WHERE id = 1")
+    .get() as { generation?: unknown };
+  if (typeof row.generation !== "number") {
+    throw new Error("SQLite session_nodes cache generation is unavailable");
+  }
+  return row.generation;
 }
 
 function readCacheValidityToken(database: DatabaseSync): SqliteSessionEntryCacheValidityToken {
   return {
     dataVersion: readDataVersion(database),
-    totalChanges: readTotalChanges(database),
+    sessionNodesGeneration: readSessionNodesGeneration(database),
   };
 }
 
@@ -69,7 +109,24 @@ function cacheValidityTokensEqual(
   left: SqliteSessionEntryCacheValidityToken,
   right: SqliteSessionEntryCacheValidityToken,
 ): boolean {
-  return left.dataVersion === right.dataVersion && left.totalChanges === right.totalChanges;
+  return (
+    left.dataVersion === right.dataVersion &&
+    left.sessionNodesGeneration === right.sessionNodesGeneration
+  );
+}
+
+/** Bracket one accessor-owned row write so its publication cannot hide earlier raw DML. */
+export function trackSqliteSessionEntryCacheWrite(
+  database: OpenClawAgentDatabase,
+  write: () => void,
+): SqliteSessionEntryCacheWriteGeneration | undefined {
+  const before = sessionEntryCaches.has(database.db)
+    ? readSessionNodesGeneration(database.db)
+    : undefined;
+  write();
+  return before === undefined
+    ? undefined
+    : { before, after: readSessionNodesGeneration(database.db) };
 }
 
 function createListProjection(entry: SessionEntry): SessionEntry {
@@ -205,8 +262,8 @@ export function readSqliteSessionEntryCache(
   if (cached && cached.validityToken.dataVersion === validityToken.dataVersion) {
     // updated_at is entry-controlled, not a rowversion. Other connections can rewrite entry_json
     // without advancing it, so data_version changes must fully reload or same-ms rewrites go stale.
-    // Tracked single-row upserts patch their row but retain this old token; unrelated local writes
-    // and any other same-connection changes are still discovered by this incremental diff.
+    // The TEMP generation changes only for session_nodes DML, including raw same-connection
+    // writers. Unrelated transcript-table writes therefore stay on the O(1) cache-hit path.
     const revalidated = incrementallyRevalidateSessionEntrySnapshot(
       database,
       cached,
@@ -265,6 +322,7 @@ function publishSqliteSessionEntryCacheUpsert(
     session_key: string;
     updated_at: number;
   },
+  writeGeneration?: SqliteSessionEntryCacheWriteGeneration,
 ): void {
   const entry = parseSqliteSessionEntryJson({
     current_session_id: row.current_session_id,
@@ -275,11 +333,17 @@ function publishSqliteSessionEntryCacheUpsert(
     invalidateTrackedCache(database);
     return;
   }
+  if (!writeGeneration) {
+    invalidateTrackedCache(database);
+    return;
+  }
   publishTrackedCacheUpdate(database, () => {
     const cached = sessionEntryCaches.get(database.db);
     if (!cached) {
       return;
     }
+    const generationIsContinuous =
+      cached.validityToken.sessionNodesGeneration === writeGeneration.before;
     const entries = new Map(cached.entries);
     entries.set(row.session_key, entry);
     const listProjections = new Map(cached.listProjections);
@@ -287,16 +351,20 @@ function publishSqliteSessionEntryCacheUpsert(
     const updatedAtByKey = new Map(cached.updatedAtByKey);
     const knownKey = updatedAtByKey.has(row.session_key);
     updatedAtByKey.set(row.session_key, row.updated_at);
-    // Patch only the authoritative row but retain the old validity token. The next read
-    // must still reconcile any other local total_changes, while a changed data_version
-    // forces a full reload; advancing either here could mask an earlier unknown write.
+    // Advance only across the bracketed row write. A raw write before/after this bracket leaves
+    // a generation gap, while the retained data_version still exposes external commits.
     sessionEntryCaches.set(database.db, {
       entries,
       keys: knownKey ? cached.keys : [...cached.keys, row.session_key].toSorted(),
       listEntries: createLazyListProjections(entries, listProjections),
       listProjections,
       updatedAtByKey,
-      validityToken: cached.validityToken,
+      validityToken: generationIsContinuous
+        ? {
+            ...cached.validityToken,
+            sessionNodesGeneration: writeGeneration.after,
+          }
+        : cached.validityToken,
     });
   });
 }
@@ -309,9 +377,10 @@ export function publishSqliteSessionEntryCacheInvalidation(
     session_key: string;
     updated_at: number;
   },
+  writeGeneration?: SqliteSessionEntryCacheWriteGeneration,
 ): void {
   if (row) {
-    publishSqliteSessionEntryCacheUpsert(database, row);
+    publishSqliteSessionEntryCacheUpsert(database, row, writeGeneration);
     return;
   }
   invalidateTrackedCache(database);

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -11,7 +11,10 @@ import {
   prepareSessionConversation,
   upsertConversationIdentity,
 } from "./session-accessor.sqlite-conversation.js";
-import { publishSqliteSessionEntryCacheInvalidation } from "./session-accessor.sqlite-entry-cache.js";
+import {
+  publishSqliteSessionEntryCacheInvalidation,
+  trackSqliteSessionEntryCacheWrite,
+} from "./session-accessor.sqlite-entry-cache.js";
 import {
   clearSessionCollaborationForKey,
   deleteSessionDeliveryArtifacts,
@@ -633,11 +636,7 @@ export function writeSessionEntry(
   const transcriptObservedAt =
     readTranscriptMutationStateInTransaction(database, normalizedEntry.sessionId).updatedAt ??
     updatedAt;
-  const boundSessionRoot = bindSqliteSessionRoot({
-    entry: normalizedEntry,
-    sessionKey,
-    updatedAt,
-  });
+  const boundSessionRoot = bindSqliteSessionRoot({ entry: normalizedEntry, sessionKey, updatedAt });
   const conversation = prepareSessionConversation({
     entry: normalizedEntry,
     sessionScope: boundSessionRoot.session_scope,
@@ -657,48 +656,46 @@ export function writeSessionEntry(
     entry: normalizedEntry,
     previousEntry,
   });
-  const sessionNode = bindSqliteSessionNode({
-    entry: normalizedEntry,
-    sessionKey,
-    updatedAt,
+  const sessionNode = bindSqliteSessionNode({ entry: normalizedEntry, sessionKey, updatedAt });
+  const writeGeneration = trackSqliteSessionEntryCacheWrite(database, () => {
+    executeSqliteQuerySync(
+      database.db,
+      db
+        .insertInto("session_nodes")
+        .values(sessionNode)
+        .onConflict((conflict) =>
+          conflict.column("session_key").doUpdateSet({
+            current_session_id: sessionNode.current_session_id,
+            entry_json: sessionNode.entry_json,
+            entry_valid: sessionNode.entry_valid,
+            updated_at: sessionNode.updated_at,
+            status: sessionNode.status,
+            created_at: sessionNode.created_at,
+            created_via: sessionNode.created_via,
+            created_actor_type: sessionNode.created_actor_type,
+            created_actor_id: sessionNode.created_actor_id,
+            parent_session_key: sessionNode.parent_session_key,
+            spawned_by: sessionNode.spawned_by,
+            fork_source_session_key: sessionNode.fork_source_session_key,
+            fork_source_session_id: sessionNode.fork_source_session_id,
+            fork_source_entry_id: sessionNode.fork_source_entry_id,
+            label: sessionNode.label,
+            display_name: sessionNode.display_name,
+            category: sessionNode.category,
+            icon: sessionNode.icon,
+            pinned_at: sessionNode.pinned_at,
+            archived_at: sessionNode.archived_at,
+            last_read_at: sessionNode.last_read_at,
+            last_interaction_at: sessionNode.last_interaction_at,
+            last_activity_at: sessionNode.last_activity_at,
+          }),
+        ),
+    );
+    executeSqliteQuerySync(
+      database.db,
+      db.updateTable("session_nodes").set({ entry_valid: 1 }).where("session_key", "=", sessionKey),
+    );
   });
-  executeSqliteQuerySync(
-    database.db,
-    db
-      .insertInto("session_nodes")
-      .values(sessionNode)
-      .onConflict((conflict) =>
-        conflict.column("session_key").doUpdateSet({
-          current_session_id: sessionNode.current_session_id,
-          entry_json: sessionNode.entry_json,
-          entry_valid: sessionNode.entry_valid,
-          updated_at: sessionNode.updated_at,
-          status: sessionNode.status,
-          created_at: sessionNode.created_at,
-          created_via: sessionNode.created_via,
-          created_actor_type: sessionNode.created_actor_type,
-          created_actor_id: sessionNode.created_actor_id,
-          parent_session_key: sessionNode.parent_session_key,
-          spawned_by: sessionNode.spawned_by,
-          fork_source_session_key: sessionNode.fork_source_session_key,
-          fork_source_session_id: sessionNode.fork_source_session_id,
-          fork_source_entry_id: sessionNode.fork_source_entry_id,
-          label: sessionNode.label,
-          display_name: sessionNode.display_name,
-          category: sessionNode.category,
-          icon: sessionNode.icon,
-          pinned_at: sessionNode.pinned_at,
-          archived_at: sessionNode.archived_at,
-          last_read_at: sessionNode.last_read_at,
-          last_interaction_at: sessionNode.last_interaction_at,
-          last_activity_at: sessionNode.last_activity_at,
-        }),
-      ),
-  );
-  executeSqliteQuerySync(
-    database.db,
-    db.updateTable("session_nodes").set({ entry_valid: 1 }).where("session_key", "=", sessionKey),
-  );
   executeSqliteQuerySync(
     database.db,
     db
@@ -740,7 +737,7 @@ export function writeSessionEntry(
       updatedAt,
     });
   }
-  publishSqliteSessionEntryCacheInvalidation(database, sessionNode);
+  publishSqliteSessionEntryCacheInvalidation(database, sessionNode, writeGeneration);
 }
 
 /** Resolves the parent fork decision using SQLite transcript rows when totals are stale. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where tool-heavy turns repeatedly scanned every SQLite session entry after persisted transcript messages. A 50-message probe caused 50 full `session_nodes` version scans: 2,500 rows at 50 sessions, 25,000 rows at 500 sessions, and 250,000 rows at 5,000 sessions.

## Why This Change Was Made

The cache validity token used connection-wide `total_changes()`, so writes to transcript tables looked indistinguishable from writes to `session_nodes`. This change replaces that local signal with a connection-local TEMP generation counter advanced by `session_nodes` INSERT/UPDATE/DELETE triggers, while retaining `PRAGMA data_version` for external commits and the existing post-read race check.

Tracked entry upserts bracket their exact generation range and patch one cached row immediately. Raw same-connection DML leaves a generation gap and forces revalidation, and structural doctor key repairs explicitly invalidate the cache. No persistent schema or schema-version change is required.

AI-assisted implementation; the final diff was manually reviewed and passed the repository autoreview gate.

## User Impact

Tool-heavy turns no longer pay an O(total sessions) cache revalidation after each persisted message. Unrelated transcript writes and tracked entry upserts stay on the constant-time cache path, while raw writers, doctor repairs, external commits, and external-commit races remain freshness-safe.

## Evidence

Before-change 50-write/read probe:

| Stored sessions | Revalidations | `session_nodes` rows scanned |
| ---: | ---: | ---: |
| 50 | 50 | 2,500 |
| 500 | 50 | 25,000 |
| 5,000 | 50 | 250,000 |

Focused regression proof:

- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-data-version.test.ts src/commands/doctor-session-incognito-key-repair.test.ts`
- 2 test files, 19 tests passed.
- Covers zero full-version scans after unrelated transcript writes and tracked upserts; raw/unpublished same-connection writes; structural placeholder and doctor repairs; external commits; same-millisecond rewrites; rollback; and the external-commit incremental-read race.

Changed-surface proof:

- `node scripts/check-changed.mjs`
- Passed on Blacksmith Testbox `tbx_01kzmnb2k287qzzz8abka8af10`.
- Includes core and core-test typecheck, formatting, lint, dead-export, schema-version, database-first, and import-cycle gates.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/31347786093

Review proof:

- Codex-backed autoreview: clean, no accepted/actionable findings.
- `git diff --check`: passed.
