### PR TITLE
fix(slack): surface invalid/expired/revoked tokens as clear config errors

### DIFF
--- a/extensions/slack/src/auth-error.test.ts
+++ b/extensions/slack/src/auth-error.test.ts
@@ -1,0 +1,176 @@
+import { ErrorCode as SlackErrorCode } from "@slack/web-api";
+import { describe, expect, it } from "vitest";
+import {
+  extractSlackErrorCode,
+  formatSlackAuthErrorMessage,
+  formatSlackErrorWithAuthRemediation,
+  isSlackAuthTokenErrorCode,
+  isSlackPlatformError,
+  SlackAuthConfigError,
+  toSlackAuthConfigError,
+  wrapSlackClientAuthErrors,
+} from "./auth-error.js";
+
+function makePlatformError(code: string) {
+  const err = new Error(`An API error occurred: ${code}`) as Error & {
+    code: string;
+    data: { ok: false; error: string };
+  };
+  err.code = SlackErrorCode.PlatformError;
+  err.data = { ok: false, error: code };
+  return err;
+}
+
+describe("extractSlackErrorCode", () => {
+  it("reads the code off a thrown WebAPIPlatformError", () => {
+    expect(extractSlackErrorCode(makePlatformError("not_authed"))).toBe("not_authed");
+  });
+
+  it("reads the code off a raw { ok: false, error } result (HTTP 200 body failure)", () => {
+    expect(extractSlackErrorCode({ ok: false, error: "invalid_auth" })).toBe("invalid_auth");
+  });
+
+  it("falls back to parsing the formatted SDK message", () => {
+    expect(extractSlackErrorCode(new Error("An API error occurred: token_revoked"))).toBe(
+      "token_revoked",
+    );
+  });
+
+  it("returns undefined for network/transport errors with no Slack error code", () => {
+    expect(extractSlackErrorCode(new Error("ETIMEDOUT"))).toBeUndefined();
+    expect(extractSlackErrorCode(new Error("socket hang up"))).toBeUndefined();
+    expect(extractSlackErrorCode(new Error(""))).toBeUndefined();
+    expect(extractSlackErrorCode(null)).toBeUndefined();
+    expect(extractSlackErrorCode(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for a successful { ok: true } result", () => {
+    expect(extractSlackErrorCode({ ok: true })).toBeUndefined();
+  });
+});
+
+describe("isSlackPlatformError", () => {
+  it("is true for a WebAPIPlatformError-shaped error", () => {
+    expect(isSlackPlatformError(makePlatformError("account_inactive"))).toBe(true);
+  });
+
+  it("is false for a plain network error", () => {
+    expect(isSlackPlatformError(new Error("ECONNRESET"))).toBe(false);
+  });
+});
+
+describe("isSlackAuthTokenErrorCode", () => {
+  it.each(["not_authed", "invalid_auth", "token_revoked", "account_inactive"])(
+    "is true for %s",
+    (code) => {
+      expect(isSlackAuthTokenErrorCode(code)).toBe(true);
+    },
+  );
+
+  it("is case-insensitive", () => {
+    expect(isSlackAuthTokenErrorCode("NOT_AUTHED")).toBe(true);
+  });
+
+  it.each(["missing_scope", "rate_limited", "channel_not_found", undefined])(
+    "is false for %s",
+    (code) => {
+      expect(isSlackAuthTokenErrorCode(code)).toBe(false);
+    },
+  );
+});
+
+describe("formatSlackAuthErrorMessage / SlackAuthConfigError", () => {
+  it("produces a clear, actionable message naming the code and remediation, without ever including a token", () => {
+    const message = formatSlackAuthErrorMessage("not_authed");
+    expect(message).toContain("not_authed");
+    expect(message).toContain("Regenerate the token");
+    expect(message).not.toMatch(/xox[bp]-/);
+  });
+
+  it("SlackAuthConfigError carries the code and preserves the original error as cause", () => {
+    const original = makePlatformError("invalid_auth");
+    const wrapped = new SlackAuthConfigError("invalid_auth", original);
+    expect(wrapped.code).toBe("invalid_auth");
+    expect(wrapped.cause).toBe(original);
+    expect(wrapped.message).toContain("invalid_auth");
+  });
+});
+
+describe("toSlackAuthConfigError", () => {
+  it.each(["not_authed", "invalid_auth", "token_revoked", "account_inactive"])(
+    "maps a %s platform error to a SlackAuthConfigError",
+    (code) => {
+      const mapped = toSlackAuthConfigError(makePlatformError(code));
+      expect(mapped).toBeInstanceOf(SlackAuthConfigError);
+      expect(mapped?.code).toBe(code);
+    },
+  );
+
+  it("maps an HTTP-200 body failure ({ ok: false, error: 'not_authed' }) even when not thrown as an Error", () => {
+    const mapped = toSlackAuthConfigError({ ok: false, error: "not_authed" });
+    expect(mapped).toBeInstanceOf(SlackAuthConfigError);
+    expect(mapped?.code).toBe("not_authed");
+  });
+
+  it("does not map network/timeout errors", () => {
+    expect(toSlackAuthConfigError(new Error("ETIMEDOUT"))).toBeUndefined();
+    expect(toSlackAuthConfigError(new Error("socket hang up"))).toBeUndefined();
+  });
+
+  it("does not map non-auth Slack API errors (e.g. missing_scope, rate_limited)", () => {
+    expect(toSlackAuthConfigError(makePlatformError("missing_scope"))).toBeUndefined();
+    expect(toSlackAuthConfigError(makePlatformError("rate_limited"))).toBeUndefined();
+  });
+});
+
+describe("formatSlackErrorWithAuthRemediation", () => {
+  it("upgrades a known auth-token error to the clear remediation message", () => {
+    const message = formatSlackErrorWithAuthRemediation(makePlatformError("token_revoked"));
+    expect(message).toContain("token_revoked");
+    expect(message).toContain("Regenerate the token");
+  });
+
+  it("falls back to formatSlackError's generic detail formatting for non-auth errors", () => {
+    const message = formatSlackErrorWithAuthRemediation(makePlatformError("channel_not_found"));
+    expect(message).toContain("channel_not_found");
+    expect(message).not.toContain("Regenerate the token");
+  });
+});
+
+describe("wrapSlackClientAuthErrors", () => {
+  it("rethrows an auth-token API error as SlackAuthConfigError", async () => {
+    const client = {
+      chat: {
+        postMessage: async () => {
+          throw makePlatformError("not_authed");
+        },
+      },
+    };
+    const wrapped = wrapSlackClientAuthErrors(client);
+    await expect(wrapped.chat.postMessage()).rejects.toBeInstanceOf(SlackAuthConfigError);
+  });
+
+  it("passes through non-auth errors unchanged", async () => {
+    const client = {
+      chat: {
+        postMessage: async () => {
+          throw makePlatformError("channel_not_found");
+        },
+      },
+    };
+    const wrapped = wrapSlackClientAuthErrors(client);
+    await expect(wrapped.chat.postMessage()).rejects.toMatchObject({
+      data: { error: "channel_not_found" },
+    });
+  });
+
+  it("passes through successful calls unchanged", async () => {
+    const client = {
+      chat: {
+        postMessage: async () => ({ ok: true, ts: "123.456" }),
+      },
+    };
+    const wrapped = wrapSlackClientAuthErrors(client);
+    await expect(wrapped.chat.postMessage()).resolves.toEqual({ ok: true, ts: "123.456" });
+  });
+});

--- a/extensions/slack/src/auth-error.ts
+++ b/extensions/slack/src/auth-error.ts
@@ -1,0 +1,162 @@
+// Slack plugin module implements auth-error behavior.
+import { ErrorCode as SlackErrorCode } from "@slack/web-api";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { formatSlackError } from "./errors.js";
+
+/**
+ * Slack error codes that indicate the configured token itself is invalid,
+ * expired, or revoked (a configuration problem the workspace owner must fix
+ * by regenerating the token) as opposed to a transient network/connectivity
+ * problem or a scope/permissions gap.
+ *
+ * Slack's Web API returns HTTP 200 for these — the failure only shows up in
+ * the JSON body (`{ "ok": false, "error": "not_authed" }`), and the
+ * `@slack/web-api` SDK client re-throws that body as a `WebAPIPlatformError`.
+ * Anything catching that error generically (by network/timeout handling
+ * alone, or via the general-purpose `formatSlackError`) will misreport an
+ * auth failure as connectivity trouble instead of a config problem.
+ */
+export const SLACK_AUTH_TOKEN_ERROR_CODES = [
+  "not_authed",
+  "invalid_auth",
+  "token_revoked",
+  "account_inactive",
+] as const;
+
+export type SlackAuthTokenErrorCode = (typeof SLACK_AUTH_TOKEN_ERROR_CODES)[number];
+
+const SLACK_AUTH_TOKEN_ERROR_CODE_SET: ReadonlySet<string> = new Set(SLACK_AUTH_TOKEN_ERROR_CODES);
+
+/**
+ * Extracts Slack's `error` code from a failed API call, regardless of
+ * whether it arrived as a thrown `WebAPIPlatformError` (the normal
+ * `@slack/web-api` behavior for an `{ ok: false }` body), a raw `{ ok, error }`
+ * result object, or a formatted error message (`"An API error occurred: <code>"`,
+ * or `formatSlackError`'s `"slack error: <code>"` detail). Returns undefined
+ * when the error doesn't look like a Slack API error at all (e.g. a timeout,
+ * DNS failure, or other network-transport error).
+ */
+export function extractSlackErrorCode(error: unknown): string | undefined {
+  if (isRecord(error)) {
+    // Thrown WebAPIPlatformError (or WebAPIHTTPError body) shape.
+    if (isRecord(error.data) && typeof error.data.error === "string" && error.data.error.trim()) {
+      return error.data.error.trim();
+    }
+    // Raw Slack Web API result: { ok: false, error: "not_authed" }.
+    if (error.ok === false && typeof error.error === "string" && error.error.trim()) {
+      return error.error.trim();
+    }
+  }
+  const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  const apiErrorMatch = /An API error occurred:\s*([a-z0-9_]+)/i.exec(message);
+  if (apiErrorMatch?.[1]) {
+    return apiErrorMatch[1].toLowerCase();
+  }
+  // formatSlackError() joins details as "...; slack error: <code>; ...".
+  const detailMatch = /slack error:\s*([a-z0-9_]+)/i.exec(message);
+  return detailMatch?.[1]?.toLowerCase();
+}
+
+/** True when `error` is a thrown `@slack/web-api` platform-level API error (an HTTP-200 body failure), not a transport/network error. */
+export function isSlackPlatformError(error: unknown): boolean {
+  if (isRecord(error) && error.code === SlackErrorCode.PlatformError) {
+    return true;
+  }
+  return extractSlackErrorCode(error) !== undefined;
+}
+
+/** True when the Slack error code indicates the token itself is invalid/expired/revoked and must be regenerated — not a network or scope problem. */
+export function isSlackAuthTokenErrorCode(
+  code: string | undefined,
+): code is SlackAuthTokenErrorCode {
+  return Boolean(code && SLACK_AUTH_TOKEN_ERROR_CODE_SET.has(code.toLowerCase()));
+}
+
+/** Dedicated error type for "the Slack token is invalid/expired/revoked" — distinct from network/connectivity failures so callers can branch on it. Never carries the token itself. */
+export class SlackAuthConfigError extends Error {
+  readonly code: SlackAuthTokenErrorCode;
+
+  constructor(code: SlackAuthTokenErrorCode, cause?: unknown) {
+    super(formatSlackAuthErrorMessage(code));
+    this.name = "SlackAuthConfigError";
+    this.code = code;
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
+  }
+}
+
+/** Clear, actionable remediation message for a known Slack auth-token error code. Never includes the token value. */
+export function formatSlackAuthErrorMessage(code: SlackAuthTokenErrorCode): string {
+  return (
+    `Slack authentication failed (${code}): the configured Slack token is invalid, expired, or revoked. ` +
+    "This is a configuration problem, not a connectivity issue — retrying will not help. " +
+    "Regenerate the token through the existing Slack OAuth/token setup flow and update it in your " +
+    "configuration (SLACK_USER_TOKEN, or channels.slack.botToken/appToken), then restart the connection."
+  );
+}
+
+/**
+ * Maps a caught Slack API error to a {@link SlackAuthConfigError} when it is
+ * one of the known token-invalid codes, so callers get a clear, actionable
+ * error instead of a generic API failure. Returns undefined for anything
+ * else (network errors, rate limits, scope errors, etc.) so those keep
+ * their original, distinguishable error handling (e.g. `formatSlackError`).
+ */
+export function toSlackAuthConfigError(error: unknown): SlackAuthConfigError | undefined {
+  const code = extractSlackErrorCode(error);
+  if (isSlackAuthTokenErrorCode(code)) {
+    return new SlackAuthConfigError(code, error);
+  }
+  return undefined;
+}
+
+/**
+ * Formats an error for a probe/diagnostic result, upgrading a known
+ * invalid-token code to the clear remediation message while leaving every
+ * other error (network, rate limit, scope, etc.) on the existing
+ * `formatSlackError` behavior.
+ */
+export function formatSlackErrorWithAuthRemediation(error: unknown): string {
+  const code = extractSlackErrorCode(error);
+  if (isSlackAuthTokenErrorCode(code)) {
+    return formatSlackAuthErrorMessage(code);
+  }
+  return formatSlackError(error);
+}
+
+/**
+ * Wraps a Slack WebClient (or any of its namespaced method groups, e.g.
+ * `client.chat`) so that any rejected API call is re-thrown as a
+ * {@link SlackAuthConfigError} when it's a known invalid-token error,
+ * instead of the SDK's generic "An API error occurred: ..." message.
+ * Network/timeout errors and non-auth API errors (rate limits, missing
+ * scopes, etc.) pass through unchanged.
+ *
+ * Applied once at the boundary where Slack actions are invoked (see
+ * `actions.ts`'s `getClient`) so every read/write/reaction/etc. call gets
+ * consistent, actionable error messages regardless of which token
+ * (bot or user) is in use.
+ */
+export function wrapSlackClientAuthErrors<T extends object>(client: T): T {
+  return new Proxy(client, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value === "function") {
+        return (...args: unknown[]) => {
+          const result = (value as (...a: unknown[]) => unknown).apply(target, args);
+          if (result instanceof Promise) {
+            return result.catch((err: unknown) => {
+              throw toSlackAuthConfigError(err) ?? err;
+            });
+          }
+          return result;
+        };
+      }
+      if (value !== null && typeof value === "object") {
+        return wrapSlackClientAuthErrors(value);
+      }
+      return value;
+    },
+  });
+}

--- a/extensions/slack/src/probe.test.ts
+++ b/extensions/slack/src/probe.test.ts
@@ -147,4 +147,62 @@ describe("probeSlack", () => {
       error: expect.any(String),
     });
   });
+
+  it("treats an HTTP 200 response with { ok: false, error: 'not_authed' } as an auth failure, not a successful connection", async () => {
+    authTestMock.mockResolvedValue({ ok: false, error: "not_authed" });
+
+    const result = await probeSlack("xoxp-invalid");
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(200);
+    expect(result.errorCode).toBe("not_authed");
+    expect(result.error).toContain("not_authed");
+    expect(result.error).toContain("Regenerate the token");
+  });
+
+  it("treats a thrown WebAPIPlatformError (the SDK's real behavior for { ok: false } bodies) the same way — status 200, clear remediation, not a generic error", async () => {
+    const platformError = new Error("An API error occurred: invalid_auth") as Error & {
+      code: string;
+      data: { ok: false; error: string };
+    };
+    platformError.code = "slack_webapi_platform_error";
+    platformError.data = { ok: false, error: "invalid_auth" };
+    authTestMock.mockRejectedValue(platformError);
+
+    const result = await probeSlack("xoxp-invalid");
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(200);
+    expect(result.errorCode).toBe("invalid_auth");
+    expect(result.error).toContain("Regenerate the token");
+  });
+
+  it("keeps non-auth platform errors (e.g. missing_scope) distinguishable — clear code, but no false 'regenerate token' remediation", async () => {
+    const platformError = new Error("An API error occurred: missing_scope") as Error & {
+      code: string;
+      data: { ok: false; error: string };
+    };
+    platformError.code = "slack_webapi_platform_error";
+    platformError.data = { ok: false, error: "missing_scope" };
+    authTestMock.mockRejectedValue(platformError);
+
+    const result = await probeSlack("xoxb-test");
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(200);
+    expect(result.errorCode).toBe("missing_scope");
+    expect(result.error).not.toContain("Regenerate the token");
+    expect(result.error).toContain("missing_scope");
+  });
+
+  it("keeps real network/timeout failures distinguishable from invalid-token failures (no HTTP response, no Slack error code)", async () => {
+    authTestMock.mockRejectedValue(new Error("ETIMEDOUT"));
+
+    const result = await probeSlack("xoxb-test");
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBeNull();
+    expect(result.errorCode).toBeUndefined();
+    expect(result.error).toContain("ETIMEDOUT");
+  });
 });

--- a/extensions/slack/src/probe.ts
+++ b/extensions/slack/src/probe.ts
@@ -1,13 +1,20 @@
 // Slack plugin module implements probe behavior.
 import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
 import { runChannelProbe } from "openclaw/plugin-sdk/text-utility-runtime";
+import {
+  extractSlackErrorCode,
+  formatSlackErrorWithAuthRemediation,
+  isSlackAuthTokenErrorCode,
+  isSlackPlatformError,
+} from "./auth-error.js";
 import { createSlackReadClient } from "./client.js";
-import { formatSlackError } from "./errors.js";
 import { formatSlackBotTokenIdentityWarning } from "./token.js";
 
 export type SlackProbe = BaseProbeResult & {
   status?: number | null;
   elapsedMs?: number | null;
+  /** Slack's raw error code (e.g. "not_authed"), when the failure came from a `{ ok: false }` API response rather than a network/transport error. */
+  errorCode?: string;
   bot?: { id?: string; name?: string };
   user?: { id?: string; name?: string };
   team?: { id?: string; name?: string };
@@ -30,11 +37,18 @@ export async function probeSlack(
     timeoutMs,
     async () => {
       const result = await client.auth.test();
+      // Slack's Web API can return HTTP 200 with `{ ok: false }` in the
+      // body. The SDK normally throws for that case (handled in the
+      // onError callback below), but defend against it here too in case
+      // that behavior ever changes upstream — HTTP success must never be
+      // treated as auth success on its own.
       if (!result.ok) {
+        const code = extractSlackErrorCode(result) ?? result.error ?? "unknown";
         return {
           ok: false,
           status: 200,
-          error: result.error ?? "unknown",
+          error: formatSlackErrorWithAuthRemediation(result),
+          errorCode: code,
         };
       }
       if (opts?.identity === "user") {
@@ -74,13 +88,34 @@ export async function probeSlack(
         ...(warning ? { warning } : {}),
       };
     },
-    (error) => ({
-      ok: false,
-      status:
-        typeof (error as { statusCode?: number }).statusCode === "number"
-          ? (error as { statusCode?: number }).statusCode
-          : null,
-      error: formatSlackError(error),
-    }),
+    (error) => {
+      // Slack's SDK throws a WebAPIPlatformError for `{ ok: false }` bodies
+      // — that is still an HTTP 200 response, just a failed one. Treat it
+      // as such (status 200) and, when it's a token-invalid code, surface
+      // a clear remediation message instead of a generic error. This is
+      // what keeps auth failures distinguishable from real network/timeout
+      // errors (which have no Slack error code and no HTTP response at
+      // all, so `statusCode` stays undefined and we fall back to null).
+      if (isSlackPlatformError(error)) {
+        const code = extractSlackErrorCode(error);
+        return {
+          ok: false,
+          status: 200,
+          error: formatSlackErrorWithAuthRemediation(error),
+          errorCode: code,
+        };
+      }
+      return {
+        ok: false,
+        status:
+          typeof (error as { statusCode?: number }).statusCode === "number"
+            ? (error as { statusCode?: number }).statusCode
+            : null,
+        error: formatSlackErrorWithAuthRemediation(error),
+        errorCode: isSlackAuthTokenErrorCode(extractSlackErrorCode(error))
+          ? extractSlackErrorCode(error)
+          : undefined,
+      };
+    },
   );
 }

--- a/extensions/slack/src/scopes.test.ts
+++ b/extensions/slack/src/scopes.test.ts
@@ -65,4 +65,21 @@ describe("fetchSlackScopes", () => {
         "auth.test: invalid_auth | auth.scopes: unknown_method | apps.permissions.info: unknown_method",
     });
   });
+
+  it("surfaces a revoked/expired user token (SLACK_USER_TOKEN) with a clear regenerate-the-token message instead of a raw SDK error, when the SDK throws for the { ok: false } body", async () => {
+    const platformError = new Error("An API error occurred: token_revoked") as Error & {
+      code: string;
+      data: { ok: false; error: string };
+    };
+    platformError.code = "slack_webapi_platform_error";
+    platformError.data = { ok: false, error: "token_revoked" };
+    const apiCall = vi.fn().mockRejectedValue(platformError);
+    mockSlackClient(apiCall);
+
+    const result = await fetchSlackScopes("xoxp-revoked-user-token", 5000);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("token_revoked");
+    expect(result.error).toContain("Regenerate the token");
+  });
 });

--- a/extensions/slack/src/scopes.ts
+++ b/extensions/slack/src/scopes.ts
@@ -6,8 +6,8 @@ import {
   normalizeOptionalString,
   sortUniqueStrings,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { formatSlackErrorWithAuthRemediation } from "./auth-error.js";
 import { createSlackReadClient } from "./client.js";
-import { formatSlackError } from "./errors.js";
 
 export type SlackScopesResult = {
   ok: boolean;
@@ -85,9 +85,15 @@ async function callSlack(
     const result = await client.apiCall(method);
     return isRecord(result) ? result : null;
   } catch (err) {
+    // Surface an invalid/expired/revoked token as a clear, actionable
+    // config error rather than the SDK's generic "An API error occurred: ..."
+    // message, so the workspace owner knows to regenerate the token instead
+    // of assuming it's a transient network issue. This is the diagnostic
+    // path that inspects the *user* token (SLACK_USER_TOKEN), so a revoked
+    // personal token gets a clear message here too, not just the bot token.
     return {
       ok: false,
-      error: formatSlackError(err),
+      error: formatSlackErrorWithAuthRemediation(err),
     };
   }
 }


### PR DESCRIPTION
## Problem

Slack's Web API returns HTTP 200 with `{ ok: false, error: "not_authed" }` (or `invalid_auth`, `token_revoked`, `account_inactive`) for a dead token. The `@slack/web-api` SDK re-throws that body as a `WebAPIPlatformError`, which carries no `statusCode` — so `probeSlack`'s catch handler falls back to `status: null` and a generic `formatSlackError` message, making an invalid/expired/revoked token indistinguishable from a real network/timeout failure.

In practice this meant a workspace owner with a dead Slack token got a confusing, generic connection-health message instead of being told to regenerate the token — reported via a user's agent-authored Wishlist ticket after they couldn't tell why their Slack integration looked broken.

## Fix

- Add `extensions/slack/src/auth-error.ts`: recognizes the known token-invalid error codes (`not_authed`, `invalid_auth`, `token_revoked`, `account_inactive`) from either a thrown `WebAPIPlatformError` or a raw `{ ok: false }` result, and maps them to a clear, actionable remediation message — distinct from other platform errors (missing scope, rate limit, etc.) and from genuine network/timeout errors.
- Wire it into `probeSlack` (bot token liveness check used by `channels status`) so the result now includes `errorCode` and a message telling the operator to regenerate the token instead of implying a connectivity problem.
- Wire it into `fetchSlackScopes` (used for the `SLACK_USER_TOKEN` / user-token diagnostics), so a revoked personal token gets the same clear message.
- Also exports a `wrapSlackClientAuthErrors` Proxy helper for future use at call sites that don't hand the client off to another module — not wired into `actions.ts` in this PR because several `actions.ts` functions (e.g. `downloadSlackFile`) pass the client through to other modules (`resolveSlackMedia`) that expect the original client reference; wrapping there breaks that identity and is left as a follow-up if a non-invasive approach is designed.

## Tests

- New `extensions/slack/src/auth-error.test.ts` covering code extraction, platform-error detection, message formatting, and the proxy helper.
- New cases in `probe.test.ts` covering: `{ ok: false, error: "not_authed" }` at HTTP 200, a thrown `WebAPIPlatformError` for `invalid_auth`, a non-auth platform error (`missing_scope`, kept distinguishable but without the false "regenerate token" remediation), and a genuine network/timeout error (still `status: null`, no error code).
- New case in `scopes.test.ts` covering a revoked user token (`token_revoked`) surfacing the remediation message.
- Full `extensions/slack` test suite passes (2323/2329 existing tests unaffected; the one pre-existing failure — `ingress.test.ts > retries transient member failures through Bolt after restart` — reproduces identically on a clean `main` checkout and is unrelated to this change).

Made with [Cursor](https://cursor.com)