### PR TITLE
fix: preserve GPT-5 personality through doctor migration

### DIFF
--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -306,7 +306,7 @@
         "type": "string",
         "enum": ["friendly", "on", "off"],
         "default": "friendly",
-        "description": "Legacy compatibility fallback for the shared GPT-5 friendly interaction-style overlay. Prefer agents.defaults.promptOverlays.gpt5.personality. `friendly` and `on` enable the style overlay; `off` disables only that style layer."
+        "description": "Controls the shared GPT-5 friendly interaction-style overlay. `friendly` and `on` enable the style overlay; `off` disables only that style layer."
       }
     }
   }

--- a/src/commands/doctor/shared/legacy-config-migrate.e2e.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.e2e.test.ts
@@ -128,6 +128,7 @@ describe("legacy config migration end to end", () => {
         defaults: { pdfMaxMb: 12, mediaModels: { image: "openai/image-1" } },
         entries: { main: { name: "Main", tools: { exec: { timeoutSeconds: 45 } } } },
       },
+      plugins: { entries: { openai: { config: { personality: "off" } } } },
       tools: { exec: { timeoutSeconds: 30 } },
       attachments: { ttlHours: 24 },
       logging: { consoleStyle: "pretty", audit: { enabled: false, messages: "direct" } },
@@ -155,6 +156,9 @@ describe("legacy config migration end to end", () => {
         },
       },
     });
+    expect(result.changes).toContain(
+      "Moved agents.defaults.promptOverlays.gpt5.personality → plugins.entries.openai.config.personality.",
+    );
     const validation = validateConfigObjectRaw(result.config);
     expect(validation.ok, validation.ok ? undefined : JSON.stringify(validation.issues)).toBe(true);
     expect(applyLegacyDoctorMigrations(result.config)).toEqual({ next: null, changes: [] });
@@ -170,6 +174,19 @@ describe("legacy config migration end to end", () => {
     ]) {
       expect(serialized).not.toContain(`"${key}"`);
     }
+  });
+
+  it("preserves canonical OpenAI personality over the retired prompt overlay", () => {
+    const result = migrateLegacyConfig({
+      agents: { defaults: { promptOverlays: { gpt5: { personality: "off" } } } },
+      plugins: { entries: { openai: { config: { personality: "friendly" } } } },
+    });
+
+    expect(result.config?.plugins?.entries?.openai?.config?.personality).toBe("friendly");
+    expect(result.config?.agents?.defaults?.promptOverlays).toBeUndefined();
+    expect(result.changes).toContain(
+      "Removed agents.defaults.promptOverlays.gpt5.personality (plugins.entries.openai.config.personality already set).",
+    );
   });
 
   it("repairs unsupported OTel grpc once and is then a no-op", () => {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.ts
@@ -223,8 +223,29 @@ function migrateFinalLayoutRenames(raw: Record<string, unknown>, changes: string
 
 function migrateFinalLayoutKills(raw: Record<string, unknown>, changes: string[]): void {
   const defaults = getRecord(getRecord(raw.agents)?.defaults);
+  if (defaults && Object.hasOwn(defaults, "promptOverlays")) {
+    const personality = getRecord(getRecord(defaults.promptOverlays)?.gpt5)?.personality;
+    if (personality !== undefined) {
+      const openaiConfig = ensureRecord(
+        ensureRecord(ensureRecord(ensureRecord(raw, "plugins"), "entries"), "openai"),
+        "config",
+      );
+      if (openaiConfig.personality === undefined) {
+        openaiConfig.personality = personality;
+        changes.push(
+          "Moved agents.defaults.promptOverlays.gpt5.personality → plugins.entries.openai.config.personality.",
+        );
+      } else {
+        changes.push(
+          "Removed agents.defaults.promptOverlays.gpt5.personality (plugins.entries.openai.config.personality already set).",
+        );
+      }
+    } else {
+      changes.push("Removed agents.defaults.promptOverlays; built-in behavior now applies.");
+    }
+    delete defaults.promptOverlays;
+  }
   for (const key of [
-    "promptOverlays",
     "envelopeTimestamp",
     "envelopeElapsed",
     "envelopeTimezone",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who disabled the GPT-5 friendly interaction style with `agents.defaults.promptOverlays.gpt5.personality: "off"` would have it silently re-enabled after running `openclaw doctor --fix`.

## Why This Change Was Made

The doctor migration now carries the retired personality value into `plugins.entries.openai.config.personality` only when the canonical plugin setting is unset. An existing canonical value still wins, the retired key is removed, and the OpenAI plugin configuration help now points operators at the live setting.

## User Impact

Explicit GPT-5 personality preferences survive the doctor migration instead of falling back to the friendly default. Operators who already configured the OpenAI plugin keep their current canonical value.

## Evidence

- `node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.e2e.test.ts` — 7 tests passed. The legacy `off` value survives at the canonical plugin path, an existing canonical `friendly` value wins, and the retired path is removed.
- `git diff --check` — passed.
- Codex autoreview (`--mode uncommitted`) — clean, no accepted/actionable findings.
- `node scripts/check-changed.mjs -- extensions/openai/openclaw.plugin.json src/commands/doctor/shared/legacy-config-migrations.runtime.retired.ts src/commands/doctor/shared/legacy-config-migrate.e2e.test.ts` — passed on Blacksmith Testbox lease `tbx_01kzmn0gjakk5egdcjv52qvsqn` (31m22s command time), action run https://github.com/openclaw/openclaw/actions/runs/31347532725.
- Exact-head hosted CI for `a1722bce4f2f80b1c4dd3c8e816c6941b706a432` — green, including `openclaw/ci-gate`: https://github.com/openclaw/openclaw/actions/runs/31348509990.
- Proof gaps: none known.

AI-assisted: yes.
