### PR TITLE
refactor(mac): delete dead onboarding surfaces after dashboard handoff

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -34899,7 +34899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 752,
+      "line": 744,
       "path": "apps/macos/Sources/OpenClaw/Onboarding.swift",
       "source": "Finish",
       "surface": "apple",
@@ -34907,7 +34907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 752,
+      "line": 744,
       "path": "apps/macos/Sources/OpenClaw/Onboarding.swift",
       "source": "Next",
       "surface": "apple",
@@ -34931,7 +34931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 255,
+      "line": 252,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift",
       "source": "The Gateway setup request failed.",
       "surface": "apple",
@@ -34939,7 +34939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 256,
+      "line": 253,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift",
       "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
       "surface": "apple",
@@ -34947,7 +34947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 347,
+      "line": 337,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift",
       "source": "\\(label) couldn’t complete the test.",
       "surface": "apple",
@@ -34955,7 +34955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 348,
+      "line": 338,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift",
       "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
       "surface": "apple",
@@ -34963,7 +34963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 138,
+      "line": 140,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Waiting for the previous AI test to finish…",
       "surface": "apple",
@@ -34971,7 +34971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 139,
+      "line": 141,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Looking for AI you already use…",
       "surface": "apple",
@@ -34979,7 +34979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 142,
+      "line": 144,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "OpenClaw will check again before changing any inference settings.",
       "surface": "apple",
@@ -34987,7 +34987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 143,
+      "line": 145,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Checking CLI logins, saved API keys, and local model servers on the Gateway.",
       "surface": "apple",
@@ -34995,7 +34995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 191,
+      "line": 188,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Couldn’t check this Gateway for AI accounts",
       "surface": "apple",
@@ -35003,7 +35003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 192,
+      "line": 189,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Couldn’t check this Gateway for AI access",
       "surface": "apple",
@@ -35011,7 +35011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 208,
+      "line": 205,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Couldn’t load the full provider list",
       "surface": "apple",
@@ -35019,7 +35019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 211,
+      "line": 208,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Try again",
       "surface": "apple",
@@ -35027,7 +35027,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 219,
+      "line": 216,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "None of the found options worked",
       "surface": "apple",
@@ -35035,7 +35035,7 @@
     },
     {
       "kind": "ui-named-argument-multiline",
-      "line": 220,
+      "line": 217,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
       "surface": "apple",
@@ -35043,39 +35043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 245,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
-      "source": "Your AI is ready",
-      "surface": "apple",
-      "id": "native.apple.6526ced182e1fe50"
-    },
-    {
-      "kind": "ui-call",
-      "line": 256,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
-      "source": "Setup details",
-      "surface": "apple",
-      "id": "native.apple.5d8998398be53d6f"
-    },
-    {
-      "kind": "ui-call",
-      "line": 270,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
-      "source": "Copy setup details",
-      "surface": "apple",
-      "id": "native.apple.1967fcaeb9e74257"
-    },
-    {
-      "kind": "ui-call",
-      "line": 279,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
-      "source": "Choose a different AI…",
-      "surface": "apple",
-      "id": "native.apple.c90ec3f0f60d21bc"
-    },
-    {
-      "kind": "ui-call",
-      "line": 293,
+      "line": 237,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "No usable AI access found on this Gateway",
       "surface": "apple",
@@ -35083,7 +35051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 296,
+      "line": 240,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect a provider below with an API key or token, then check again.",
       "surface": "apple",
@@ -35091,7 +35059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 297,
+      "line": 241,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Install one of these tools, then check again. You can also connect a provider below.",
       "surface": "apple",
@@ -35099,7 +35067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 302,
+      "line": 246,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Recommended installs",
       "surface": "apple",
@@ -35107,7 +35075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 325,
+      "line": 269,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Detected, but not auto-tested",
       "surface": "apple",
@@ -35115,7 +35083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 333,
+      "line": 277,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "\\(candidate.label) — \\(candidate.detail)",
       "surface": "apple",
@@ -35123,7 +35091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 451,
+      "line": 390,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "No key-based providers are available",
       "surface": "apple",
@@ -35131,7 +35099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 452,
+      "line": 391,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
       "surface": "apple",
@@ -35139,7 +35107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 454,
+      "line": 393,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Check again",
       "surface": "apple",
@@ -35147,7 +35115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 468,
+      "line": 407,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Set up a local model",
       "surface": "apple",
@@ -35155,7 +35123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 470,
+      "line": 409,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect a local model service, or prepare a model on this Gateway.",
       "surface": "apple",
@@ -35163,7 +35131,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 494,
+      "line": 433,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect / Set up",
       "surface": "apple",
@@ -35171,7 +35139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 514,
+      "line": 453,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Sign in with a provider",
       "surface": "apple",
@@ -35179,7 +35147,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 516,
+      "line": 455,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
       "surface": "apple",
@@ -35187,7 +35155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 531,
+      "line": 470,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "More sign-in options",
       "surface": "apple",
@@ -35195,7 +35163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 560,
+      "line": 499,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "API Keys",
       "surface": "apple",
@@ -35203,7 +35171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 600,
+      "line": 539,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Pair",
       "surface": "apple",
@@ -35211,7 +35179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 600,
+      "line": 539,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Sign in",
       "surface": "apple",
@@ -35219,7 +35187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 617,
+      "line": 556,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "OpenClaw will detect and verify the prepared model before using it.",
       "surface": "apple",
@@ -35227,7 +35195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 618,
+      "line": 557,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
       "surface": "apple",
@@ -35235,7 +35203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 647,
+      "line": 586,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Open sign-in page…",
       "surface": "apple",
@@ -35243,7 +35211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 655,
+      "line": 594,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Starting local model setup…",
       "surface": "apple",
@@ -35251,7 +35219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 656,
+      "line": 595,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Starting secure sign-in…",
       "surface": "apple",
@@ -35259,7 +35227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 663,
+      "line": 602,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Model setup didn’t complete",
       "surface": "apple",
@@ -35267,7 +35235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 664,
+      "line": 603,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Sign-in didn’t complete",
       "surface": "apple",
@@ -35275,7 +35243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 674,
+      "line": 613,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -35283,7 +35251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 697,
+      "line": 636,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Finish in your browser",
       "surface": "apple",
@@ -35291,7 +35259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 713,
+      "line": 652,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Copy",
       "surface": "apple",
@@ -35299,7 +35267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 722,
+      "line": 661,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Expires in \\(minutes) minutes",
       "surface": "apple",
@@ -35307,7 +35275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 729,
+      "line": 668,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Open sign-in page",
       "surface": "apple",
@@ -35315,7 +35283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 757,
+      "line": 696,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Option",
       "surface": "apple",
@@ -35323,7 +35291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 763,
+      "line": 702,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Confirm",
       "surface": "apple",
@@ -35331,7 +35299,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 772,
+      "line": 711,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "I've signed in",
       "surface": "apple",
@@ -35339,7 +35307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 774,
+      "line": 713,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Continue",
       "surface": "apple",
@@ -35347,7 +35315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 774,
+      "line": 713,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Submit",
       "surface": "apple",
@@ -35355,7 +35323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 779,
+      "line": 718,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect with an API key or token",
       "surface": "apple",
@@ -35363,7 +35331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 788,
+      "line": 727,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Provider",
       "surface": "apple",
@@ -35371,7 +35339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 796,
+      "line": 735,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "API key or token",
       "surface": "apple",
@@ -35379,7 +35347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 808,
+      "line": 747,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect",
       "surface": "apple",
@@ -35387,7 +35355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 824,
+      "line": 763,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "That key didn’t work",
       "surface": "apple",
@@ -35395,7 +35363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 906,
+      "line": 845,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Open help…",
       "surface": "apple",
@@ -35403,7 +35371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 945,
+      "line": 884,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Hide details",
       "surface": "apple",
@@ -35411,7 +35379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 945,
+      "line": 884,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Show details",
       "surface": "apple",
@@ -35419,7 +35387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 968,
+      "line": 907,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Copy error",
       "surface": "apple",
@@ -35523,7 +35491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 383,
+      "line": 381,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift",
       "source": "Back",
       "surface": "apple",
@@ -35531,7 +35499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 32,
+      "line": 28,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Welcome to OpenClaw",
       "surface": "apple",
@@ -35539,7 +35507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 34,
+      "line": 30,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Your personal AI assistant, living on your own Mac.",
       "surface": "apple",
@@ -35547,7 +35515,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 38,
+      "line": 34,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "It answers questions, works with your files and apps, and can chat with you on WhatsApp or Telegram. Setup takes about two minutes.",
       "surface": "apple",
@@ -35555,7 +35523,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 49,
+      "line": 45,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Ask, create, and automate",
       "surface": "apple",
@@ -35563,7 +35531,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 50,
+      "line": 46,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Give your assistant tasks and let it help across your Mac.",
       "surface": "apple",
@@ -35571,7 +35539,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 53,
+      "line": 49,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Chat wherever you like",
       "surface": "apple",
@@ -35579,7 +35547,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 54,
+      "line": 50,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "This app, WhatsApp, Telegram, Discord, Slack — your choice.",
       "surface": "apple",
@@ -35587,7 +35555,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 57,
+      "line": 53,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Stay in control",
       "surface": "apple",
@@ -35595,7 +35563,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 58,
+      "line": 54,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Everything runs where you decide, with permissions you grant.",
       "surface": "apple",
@@ -35603,7 +35571,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 64,
+      "line": 60,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "OpenClaw can take actions using the permissions and services you enable. Review prompts and only connect tools you trust.",
       "surface": "apple",
@@ -35611,7 +35579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 80,
+      "line": 76,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Where should your assistant live?",
       "surface": "apple",
@@ -35619,7 +35587,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 82,
+      "line": 78,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Most people pick this Mac — OpenClaw installs everything and keeps it running in the background. You can change this anytime in Settings.",
       "surface": "apple",
@@ -35627,7 +35595,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 94,
+      "line": 90,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "On this Mac",
       "surface": "apple",
@@ -35635,7 +35603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 104,
+      "line": 100,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "On another computer",
       "surface": "apple",
@@ -35643,7 +35611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 131,
+      "line": 127,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Set up later",
       "surface": "apple",
@@ -35651,7 +35619,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 137,
+      "line": 133,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Skip Gateway setup for now; pick Local or Remote later in Settings → General.",
       "surface": "apple",
@@ -35659,7 +35627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 141,
+      "line": 137,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "OK — OpenClaw won’t start anything yet. Pick Local or Remote later in Settings → General.",
       "surface": "apple",
@@ -35667,7 +35635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 180,
+      "line": 176,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Existing gateway detected",
       "surface": "apple",
@@ -35675,7 +35643,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 181,
+      "line": 177,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Port \\(probe.port) already in use",
       "surface": "apple",
@@ -35683,7 +35651,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 182,
+      "line": 178,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": " (\\(probe.command) pid \\(probe.pid))",
       "surface": "apple",
@@ -35691,7 +35659,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 193,
+      "line": 189,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "1 gateway found on your network — click to choose it.",
       "surface": "apple",
@@ -35699,7 +35667,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 194,
+      "line": 190,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "\\(count) gateways found on your network — click to choose one.",
       "surface": "apple",
@@ -35707,7 +35675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 208,
+      "line": 204,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "No gateways found on your network yet.",
       "surface": "apple",
@@ -35715,7 +35683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 211,
+      "line": 207,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Look again",
       "surface": "apple",
@@ -35723,7 +35691,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 216,
+      "line": 212,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Retry discovery (Bonjour + Tailscale DNS-SD).",
       "surface": "apple",
@@ -35731,7 +35699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 245,
+      "line": 241,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Advanced…",
       "surface": "apple",
@@ -35739,7 +35707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 363,
+      "line": 359,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Remote connection",
       "surface": "apple",
@@ -35747,7 +35715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 365,
+      "line": 361,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Verify OpenClaw can reach this gateway.",
       "surface": "apple",
@@ -35755,7 +35723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 378,
+      "line": 374,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Check connection",
       "surface": "apple",
@@ -35763,7 +35731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 420,
+      "line": 416,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Advanced options",
       "surface": "apple",
@@ -35771,7 +35739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 420,
+      "line": 416,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Hide advanced options",
       "surface": "apple",
@@ -35779,7 +35747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 439,
+      "line": 435,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Gateway token",
       "surface": "apple",
@@ -35787,7 +35755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 442,
+      "line": 438,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Paste the token from your gateway",
       "surface": "apple",
@@ -35795,7 +35763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 449,
+      "line": 445,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Only needed when the gateway requires token auth.",
       "surface": "apple",
@@ -35803,7 +35771,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 458,
+      "line": 454,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.",
       "surface": "apple",
@@ -35811,7 +35779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 476,
+      "line": 472,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Transport",
       "surface": "apple",
@@ -35819,7 +35787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 477,
+      "line": 473,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "SSH tunnel",
       "surface": "apple",
@@ -35827,7 +35795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 478,
+      "line": 474,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Direct (ws/wss)",
       "surface": "apple",
@@ -35835,7 +35803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 486,
+      "line": 482,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Gateway URL",
       "surface": "apple",
@@ -35843,7 +35811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 489,
+      "line": 485,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "wss://gateway.example.ts.net",
       "surface": "apple",
@@ -35851,7 +35819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 496,
+      "line": 492,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "SSH target",
       "surface": "apple",
@@ -35859,7 +35827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 516,
+      "line": 512,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Identity file",
       "surface": "apple",
@@ -35867,7 +35835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 519,
+      "line": 515,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/Users/you/.ssh/id_ed25519",
       "surface": "apple",
@@ -35875,7 +35843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 524,
+      "line": 520,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Project root",
       "surface": "apple",
@@ -35883,7 +35851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 527,
+      "line": 523,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/home/you/Projects/openclaw",
       "surface": "apple",
@@ -35891,7 +35859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 532,
+      "line": 528,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "CLI path",
       "surface": "apple",
@@ -35899,7 +35867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 535,
+      "line": 531,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/Applications/OpenClaw.app/.../openclaw",
       "surface": "apple",
@@ -35907,7 +35875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 546,
+      "line": 542,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "surface": "apple",
@@ -35915,7 +35883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 547,
+      "line": 543,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
       "surface": "apple",
@@ -35923,7 +35891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 561,
+      "line": 557,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Checking remote gateway…",
       "surface": "apple",
@@ -35931,7 +35899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 751,
+      "line": 747,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": " · ssh \\(parsed.port)",
       "surface": "apple",
@@ -35939,23 +35907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 820,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
-      "source": "Grant permissions",
-      "surface": "apple",
-      "id": "native.apple.4bad86566d023a64"
-    },
-    {
-      "kind": "ui-call-concatenated",
-      "line": 827,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
-      "source": "These macOS permissions let OpenClaw automate apps and capture context on this Mac. Status updates automatically.",
-      "surface": "apple",
-      "id": "native.apple.ce0d1241d7417406"
-    },
-    {
-      "kind": "ui-call",
-      "line": 864,
+      "line": 823,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Getting things ready",
       "surface": "apple",
@@ -35963,7 +35915,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 875,
+      "line": 834,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Install OpenClaw",
       "surface": "apple",
@@ -35971,7 +35923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 882,
+      "line": 841,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Prepare the Mac node",
       "surface": "apple",
@@ -35979,7 +35931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 882,
+      "line": 841,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Start the background service",
       "surface": "apple",
@@ -35987,7 +35939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 884,
+      "line": 843,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Runs inside the app and uses its macOS permissions.",
       "surface": "apple",
@@ -35995,7 +35947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 885,
+      "line": 844,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Runs quietly and starts again after a restart.",
       "surface": "apple",
@@ -36003,7 +35955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 888,
+      "line": 847,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Ready for the next step",
       "surface": "apple",
@@ -36011,7 +35963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 890,
+      "line": 849,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Once ready, this Mac connects to your selected Gateway.",
       "surface": "apple",
@@ -36019,7 +35971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 891,
+      "line": 850,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Once the service answers, you’ll connect your AI.",
       "surface": "apple",
@@ -36027,7 +35979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 897,
+      "line": 856,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "The Gateway didn’t start",
       "surface": "apple",
@@ -36035,7 +35987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 898,
+      "line": 857,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "OpenClaw installation failed",
       "surface": "apple",
@@ -36043,7 +35995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 901,
+      "line": 860,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Try again",
       "surface": "apple",
@@ -36051,23 +36003,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 992,
+      "line": 951,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "You’re all set!",
       "surface": "apple",
       "id": "native.apple.25e82538dc9e9aad"
     },
     {
-      "kind": "ui-call",
-      "line": 995,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
-      "source": "Finish opens the chat — say hi to your new agent.",
-      "surface": "apple",
-      "id": "native.apple.9f73f753266a9fa2"
-    },
-    {
       "kind": "ui-named-argument",
-      "line": 1003,
+      "line": 955,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Configure later",
       "surface": "apple",
@@ -36075,7 +36019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1004,
+      "line": 956,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Pick Local or Remote in Settings → General whenever you’re ready.",
       "surface": "apple",
@@ -36083,23 +36027,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1011,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
-      "source": "Remote gateway checklist",
-      "surface": "apple",
-      "id": "native.apple.2eb061cd9d5f19fe"
-    },
-    {
-      "kind": "ui-named-argument-multiline",
-      "line": 1012,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
-      "source": "On your gateway host: install/update the `openclaw` package and make sure credentials exist\n(typically `~/.openclaw/credentials/oauth.json`). Then connect again if needed.",
-      "surface": "apple",
-      "id": "native.apple.952e85bfb2d4b4f5"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 1021,
+      "line": 961,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open the menu bar panel",
       "surface": "apple",
@@ -36107,7 +36035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1022,
+      "line": 962,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
       "surface": "apple",
@@ -36115,7 +36043,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1025,
+      "line": 965,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Connect Discord, Slack, Telegram, WhatsApp, …",
       "surface": "apple",
@@ -36123,7 +36051,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1026,
+      "line": 966,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels to link channels and monitor status.",
       "surface": "apple",
@@ -36131,7 +36059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1028,
+      "line": 968,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels",
       "surface": "apple",
@@ -36139,7 +36067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1033,
+      "line": 973,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Try Voice Wake",
       "surface": "apple",
@@ -36147,7 +36075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1034,
+      "line": 974,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable Voice Wake in Settings for hands-free commands with a live transcript overlay.",
       "surface": "apple",
@@ -36155,7 +36083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1037,
+      "line": 977,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Use the panel + Canvas",
       "surface": "apple",
@@ -36163,7 +36091,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 1038,
+      "line": 978,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
       "surface": "apple",
@@ -36171,7 +36099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1042,
+      "line": 982,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Give your agent more powers",
       "surface": "apple",
@@ -36179,7 +36107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1043,
+      "line": 983,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable optional skills (Peekaboo, oracle, camsnap, …) from Settings → Skills.",
       "surface": "apple",
@@ -36187,7 +36115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1045,
+      "line": 985,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Skills",
       "surface": "apple",
@@ -36195,59 +36123,11 @@
     },
     {
       "kind": "ui-call",
-      "line": 1053,
+      "line": 992,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Launch at login",
       "surface": "apple",
       "id": "native.apple.e54dfc2913c56f6f"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1081,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
-      "source": "Skills included",
-      "surface": "apple",
-      "id": "native.apple.040f2884f928f376"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1088,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
-      "source": "Refresh",
-      "surface": "apple",
-      "id": "native.apple.e38ea89bafb6b75d"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1097,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
-      "source": "Couldn’t load skills from the Gateway.",
-      "surface": "apple",
-      "id": "native.apple.38fc7e2b80c4e0fa"
-    },
-    {
-      "kind": "ui-call-concatenated",
-      "line": 1100,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
-      "source": "Make sure the Gateway is running and connected, then hit Refresh (or open Settings → Skills).",
-      "surface": "apple",
-      "id": "native.apple.3b06694a81edc126"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1106,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
-      "source": "Details: \\(error)",
-      "surface": "apple",
-      "id": "native.apple.b6de2a51e5fb8397"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1112,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
-      "source": "No skills reported yet.",
-      "surface": "apple",
-      "id": "native.apple.b82621bc28d4c6e3"
     },
     {
       "kind": "ui-call",

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -635,11 +635,9 @@ struct OnboardingView: View {
     }
 
     @State var currentPage = 0
-    @State var isRequesting = false
     @State var installingCLI = false
     @State var cliInstallPhase: CLIInstallPhase = .idle
     @State var cliStatus: String?
-    @State var monitoringPermissions = false
     @State var monitoringDiscovery = false
     @State var cliExecutableReady = false
     @State var cliInstalled = false
@@ -655,15 +653,12 @@ struct OnboardingView: View {
     @State var remoteAuthIssue: RemoteGatewayAuthIssue?
     @State var suppressRemoteProbeReset = false
     @State var gatewayDiscovery: GatewayDiscoveryModel
-    @State var onboardingSkillsModel = SkillsSettingsModel()
     @State var finishState = OnboardingFinishState()
     @State var aiSetup = OnboardingAISetupModel()
     @State var configuredGatewayProbe = OnboardingConfiguredGatewayProbe()
-    @State var didLoadOnboardingSkills = false
     @State var localGatewayProbe: LocalGatewayProbe?
     @State var defaultsToLocalGateway: Bool
     @Bindable var state: AppState
-    var permissionMonitor: PermissionMonitor
     let systemAgentDefaults: UserDefaults
     let aiSetupRouteIdentityProvider: @MainActor () -> String?
     let gatewaySelectionPersister: @MainActor () -> Bool
@@ -677,10 +672,7 @@ struct OnboardingView: View {
     let connectionPageIndex = 1
     let cliPageIndex = 2
     let aiPageIndex = 3
-    let onboardingChatPageIndex = 8
     let readyPageIndex = 9
-
-    let permissionsPageIndex = 5
 
     var heroFrameHeight: CGFloat {
         145
@@ -822,7 +814,6 @@ struct OnboardingView: View {
 
     init(
         state: AppState = AppStateStore.shared,
-        permissionMonitor: PermissionMonitor = .shared,
         discoveryModel: GatewayDiscoveryModel = GatewayDiscoveryModel(
             localDisplayName: InstanceIdentity.displayName,
             filterLocalGateways: false),
@@ -836,7 +827,6 @@ struct OnboardingView: View {
         })
     {
         self.state = state
-        self.permissionMonitor = permissionMonitor
         self.systemAgentDefaults = systemAgentDefaults
         let routeIdentityProvider = aiSetupRouteIdentityProvider ?? {
             OnboardingSystemAgentResumeStore.selectedRouteIdentity(state: state)

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -65,9 +65,6 @@ final class OnboardingAISetupModel {
     private(set) var providerCatalogError: String?
     private(set) var statuses: [String: CandidateStatus] = [:]
     private(set) var selectedKind: String?
-    private(set) var connectedModelRef: String?
-    private(set) var connectedLatencyMs: Int?
-    private(set) var connectedSetupLines: [String] = []
     private(set) var detectError: Failure?
     private(set) var pendingActivationVerification = false
     private(set) var waitingForPendingActivationDeadline = false
@@ -93,10 +90,6 @@ final class OnboardingAISetupModel {
     private let connectionModeProvider: @MainActor () -> AppState.ConnectionMode
     private var started = false
     private var attemptToken = UUID()
-    /// One-shot: the next detection pass lists choices without auto-activating,
-    /// so the connected-state "choose a different AI" path ends at a picker
-    /// instead of re-connecting the same auto candidate.
-    @ObservationIgnored private var suppressNextAutoActivation = false
     @ObservationIgnored private var pendingVerification: PendingVerification?
     @ObservationIgnored private var pendingActivationOwner: OnboardingSystemAgentResumeStore.ActivationOwner?
     @ObservationIgnored private var completedHandoff: CompletedHandoff?
@@ -148,25 +141,6 @@ final class OnboardingAISetupModel {
         self.started = true
         self.phase = .detecting
         scheduleDetection()
-    }
-
-    /// Escape hatch from a successful auto-connect: re-detect and present every
-    /// candidate, provider, and API-key route without auto-activating, so the
-    /// user can replace the auto-chosen AI with one they pick themselves.
-    func chooseDifferentAI() {
-        guard self.beginChooseDifferentAI() else { return }
-        self.scheduleDetection()
-    }
-
-    /// Split from `chooseDifferentAI` so tests can drive the detection await.
-    @discardableResult
-    func beginChooseDifferentAI() -> Bool {
-        guard self.connected else { return false }
-        self.resetForGatewayChange()
-        self.suppressNextAutoActivation = true
-        self.started = true
-        self.phase = .detecting
-        return true
     }
 
     func waitForPendingActivationDeadline() {
@@ -373,7 +347,6 @@ final class OnboardingAISetupModel {
                     }
                     finishConnected(
                         kind: "existing-model",
-                        result: result,
                         activationOwner: self.pendingActivationOwner,
                         requireExistingReceipt: true)
                     if self.connected {
@@ -384,9 +357,7 @@ final class OnboardingAISetupModel {
                     self.retainCompletedReceiptForRetry(context: context)
                     return .notConnected
                 }
-                self.acceptVerifiedPendingInference(
-                    modelRef: modelRef,
-                    latencyMs: result.latencyMs)
+                self.acceptVerifiedPendingInference(modelRef: modelRef)
                 return self.connected ? .connected : .superseded
             }
             self.phase = .ready
@@ -521,19 +492,12 @@ final class OnboardingAISetupModel {
     }
 
     /// Complete a receipt-backed restored handoff after route-bound live inference.
-    func acceptVerifiedPendingInference(modelRef: String, latencyMs: Double? = nil) {
+    func acceptVerifiedPendingInference(modelRef: String) {
         let model = modelRef.trimmingCharacters(in: .whitespacesAndNewlines)
         guard self.pendingActivationVerification, !model.isEmpty else { return }
         guard self.pendingActivationOwner == nil else { return }
         finishConnected(
             kind: "existing-model",
-            result: ActivateResult(
-                ok: true,
-                modelRef: model,
-                latencyMs: latencyMs,
-                lines: nil,
-                status: nil,
-                error: nil),
             activationOwner: self.pendingActivationOwner)
     }
 
@@ -588,9 +552,6 @@ final class OnboardingAISetupModel {
         self.providerCatalogError = nil
         self.statuses = [:]
         self.selectedKind = nil
-        self.connectedModelRef = nil
-        self.connectedLatencyMs = nil
-        self.connectedSetupLines = []
         self.detectError = nil
         self.pendingActivationVerification = false
         self.waitingForPendingActivationDeadline = false
@@ -602,7 +563,6 @@ final class OnboardingAISetupModel {
         self.manualError = nil
         self.manualTesting = false
         self.showManualEntry = false
-        self.suppressNextAutoActivation = false
         if let authSessionToCancel, let authServerLease {
             Task {
                 await self.gateway.cancelWizardSession(authSessionToCancel, on: authServerLease)
@@ -690,18 +650,9 @@ extension OnboardingAISetupModel {
             if Self.canAcceptProviderAuthReconciliation(
                 pending: providerAuthReconciliationPending,
                 setupComplete: result.setupComplete == true,
-                configuredModel: result.configuredModel),
-                let configuredModel = result.configuredModel
+                configuredModel: result.configuredModel)
             {
-                finishConnected(
-                    kind: "provider-auth",
-                    result: ActivateResult(
-                        ok: true,
-                        modelRef: configuredModel,
-                        latencyMs: nil,
-                        lines: nil,
-                        status: nil,
-                        error: nil))
+                finishConnected(kind: "provider-auth")
                 return
             }
             self.candidates = result.candidates.map { detected in
@@ -725,13 +676,6 @@ extension OnboardingAISetupModel {
                 self.statuses[candidate.kind] = .untried
             }
             self.phase = .ready
-            if self.suppressNextAutoActivation {
-                // "Choose a different AI" pass: list every route and let the
-                // user pick; auto-activating here would redo the undone choice.
-                self.suppressNextAutoActivation = false
-                self.showManualEntry = !self.manualProviders.isEmpty
-                return
-            }
             if let preparedChoiceID {
                 // Detection kinds encode the provider-auth choice ID, while
                 // PrepareOption.brandId owns the model-ref namespace.
@@ -751,15 +695,12 @@ extension OnboardingAISetupModel {
                 return
             }
             if let first = autoCandidateAfter(kind: nil) {
-                // Candidate found: connect without asking. The connected banner
-                // keeps "Choose a different AI" so this choice stays reversible.
                 await self.activate(kind: first.kind, context: context)
             } else {
                 self.showManualEntry = !self.manualProviders.isEmpty
             }
         } catch {
             guard self.isCurrentAttempt(context) else { return }
-            self.suppressNextAutoActivation = false
             if self.connectionModeProvider() == .remote, let authIssue = RemoteGatewayAuthIssue(error: error) {
                 self.enterGatewayAuthBlocker(authIssue)
                 return
@@ -818,8 +759,7 @@ extension OnboardingAISetupModel {
     }
 
     func userSelect(kind: String) {
-        guard !self.isBusy else { return }
-        guard self.statuses[kind] != .connected else { return }
+        guard !self.isBusy, !self.connected else { return }
         guard let context = beginAttemptContext() else { return }
         Task { await self.activate(kind: kind, context: context) }
     }
@@ -948,7 +888,7 @@ extension OnboardingAISetupModel {
             }
             guard self.isCurrentAttempt(context), !Task.isCancelled else { return }
             if result.ok {
-                finishConnected(kind: kind, result: result, activationOwner: activationOwner)
+                finishConnected(kind: kind, activationOwner: activationOwner)
             } else {
                 self.pendingActivationVerification = false
                 self.clearPendingHandoff(ifOwnedBy: context, activationOwner: activationOwner)
@@ -1113,7 +1053,6 @@ extension OnboardingAISetupModel {
         else { return false }
         finishConnected(
             kind: kind,
-            result: result,
             activationOwner: activationOwner)
         return self.connected
     }
@@ -1431,15 +1370,7 @@ extension OnboardingAISetupModel {
         else { return false }
         self.serverLease = lease
         self.clearProviderAuth()
-        finishConnected(
-            kind: "provider-auth",
-            result: ActivateResult(
-                ok: true,
-                modelRef: configuredModel,
-                latencyMs: nil,
-                lines: nil,
-                status: nil,
-                error: nil))
+        finishConnected(kind: "provider-auth")
         return true
     }
 
@@ -1579,7 +1510,6 @@ extension OnboardingAISetupModel {
                 self.manualKey = ""
                 self.finishConnected(
                     kind: "api-key",
-                    result: result,
                     activationOwner: activationOwner)
             } else {
                 self.pendingActivationVerification = false
@@ -1621,7 +1551,6 @@ extension OnboardingAISetupModel {
 
     private func finishConnected(
         kind: String,
-        result: ActivateResult,
         activationOwner: OnboardingSystemAgentResumeStore.ActivationOwner? = nil,
         requireExistingReceipt: Bool = false)
     {
@@ -1641,11 +1570,7 @@ extension OnboardingAISetupModel {
         }
         self.pendingActivationVerification = false
         self.waitingForPendingActivationDeadline = false
-        self.statuses[kind] = .connected
         self.selectedKind = kind
-        self.connectedModelRef = result.modelRef
-        self.connectedLatencyMs = result.latencyMs.map { Int($0.rounded()) }
-        self.connectedSetupLines = Self.normalizedSetupLines(result.lines)
         self.phase = .connected
         self.pendingActivationOwner = activationOwner
         self.completedHandoff = completedReceipt ? routeIdentity.flatMap { routeIdentity in
@@ -1667,10 +1592,4 @@ extension OnboardingAISetupModel {
         self.exhaustedAutoCandidates = true
         self.showManualEntry = true
     }
-
-    #if DEBUG
-    func _test_setConnectedSetupLines(_ lines: [String]?) {
-        self.connectedSetupLines = Self.normalizedSetupLines(lines)
-    }
-    #endif
 }

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
@@ -56,8 +56,6 @@ extension OnboardingAISetupModel {
     struct ActivateResult: Decodable {
         let ok: Bool
         let modelRef: String?
-        let latencyMs: Double?
-        let lines: [String]?
         let status: String?
         let error: String?
     }
@@ -91,7 +89,6 @@ extension OnboardingAISetupModel {
         case untried
         case testing
         case failed(Failure)
-        case connected
     }
 
     struct Failure: Equatable {
@@ -303,13 +300,6 @@ extension OnboardingAISetupModel {
         requested == returned ? nil : returned
     }
 
-    static func normalizedSetupLines(_ lines: [String]?) -> [String] {
-        (lines ?? []).compactMap { line in
-            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? nil : trimmed
-        }
-    }
-
     /// Keep the exact Gateway-sanitized error available behind the friendly
     /// summary so users can copy it into support or diagnostics.
     static func failure(label: String, status: String?, error: String?) -> Failure {
@@ -347,22 +337,6 @@ extension OnboardingAISetupModel {
                 ? "\(label) couldn’t complete the test."
                 : "\(label) couldn’t complete the test. Show details to inspect or copy the error."
         }
-    }
-
-    var connectedSummary: String {
-        guard let modelRef = connectedModelRef else { return "Your AI is connected." }
-        let label = candidates.first { $0.kind == self.selectedKind }?.label ??
-            (selectedKind == "api-key" ? self.selectedManualProvider?.label : nil)
-        let via = label.map { " via \($0)" } ?? ""
-        if let latency = connectedLatencyMs {
-            let seconds = Double(latency) / 1000
-            return "\(modelRef)\(via) — replied in \(String(format: "%.1f", seconds))s"
-        }
-        return "\(modelRef)\(via)"
-    }
-
-    var connectedSetupCopyText: String {
-        connectedSetupLines.joined(separator: "\n")
     }
 
     static func activationTransitionWasPersisted(

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
@@ -113,8 +113,10 @@ struct OnboardingAISetupView: View {
             switch self.model.phase {
             case .idle, .detecting:
                 self.detectingView
-            default:
+            case .ready, .testing:
                 self.resultsView
+            case .connected:
+                EmptyView()
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -152,18 +154,13 @@ struct OnboardingAISetupView: View {
 
     @ViewBuilder
     private var resultsView: some View {
-        if self.model.connected {
-            self.connectedBanner
-        }
-
         if !self.model.candidates.isEmpty {
             VStack(spacing: 8) {
                 ForEach(self.model.candidates) { candidate in
                     self.candidateRow(candidate)
                 }
             }
-        } else if self.model.phase != .connected,
-                  self.model.detectError == nil,
+        } else if self.model.detectError == nil,
                   self.model.configuredGatewayAuthIssue == nil
         {
             // A failed detect must not claim "nothing found" — the error card
@@ -214,7 +211,7 @@ struct OnboardingAISetupView: View {
             }
         }
 
-        if self.model.exhaustedAutoCandidates, !self.model.connected {
+        if self.model.exhaustedAutoCandidates {
             OnboardingErrorCard(
                 title: "None of the found options worked",
                 message: """
@@ -228,64 +225,11 @@ struct OnboardingAISetupView: View {
             }
         }
 
-        if !self.model.connected, self.model.providerCatalogLoaded {
+        if self.model.providerCatalogLoaded {
             self.providerPrepareSection
             self.providerAuthSection
             self.manualSection
         }
-    }
-
-    private var connectedBanner: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .center, spacing: 10) {
-                Image(systemName: "checkmark.circle.fill")
-                    .font(.title2)
-                    .foregroundStyle(.green)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Your AI is ready")
-                        .font(.headline)
-                    Text(self.model.connectedSummary)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer(minLength: 0)
-            }
-
-            if !self.model.connectedSetupLines.isEmpty {
-                Divider()
-                Text("Setup details")
-                    .font(.caption.weight(.semibold))
-                ScrollView(.vertical) {
-                    Text(self.model.connectedSetupCopyText)
-                        .font(.system(.caption, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .frame(maxHeight: 150)
-                Button {
-                    OnboardingErrorDetails.copy(self.model.connectedSetupCopyText)
-                } label: {
-                    Label("Copy setup details", systemImage: "doc.on.doc")
-                }
-                .buttonStyle(.link)
-                .font(.caption)
-            }
-
-            Button {
-                self.model.chooseDifferentAI()
-            } label: {
-                Label("Choose a different AI…", systemImage: "arrow.triangle.2.circlepath")
-            }
-            .buttonStyle(.link)
-            .font(.caption)
-        }
-        .padding(12)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color.green.opacity(0.12)))
     }
 
     private var noCandidatesIntro: some View {
@@ -370,7 +314,7 @@ struct OnboardingAISetupView: View {
                 }
             }
             .buttonStyle(.plain)
-            .disabled(self.model.isBusy || self.model.connected)
+            .disabled(self.model.isBusy)
 
             if case let .failed(failure) = status {
                 OnboardingErrorDetails(text: failure.copyText)
@@ -390,8 +334,6 @@ struct OnboardingAISetupView: View {
             "Testing — asking \(candidate.modelRef) for a quick reply…"
         case let .failed(failure):
             failure.summary
-        case .connected:
-            self.model.connectedSummary
         case .untried:
             "\(candidate.modelRef) · \(candidate.detail)"
         }
@@ -415,9 +357,6 @@ struct OnboardingAISetupView: View {
         case .testing:
             ProgressView()
                 .controlSize(.small)
-        case .connected:
-            Image(systemName: "checkmark.circle.fill")
-                .foregroundStyle(.green)
         case .failed:
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.orange)

--- a/apps/macos/Sources/OpenClaw/OnboardingView+AISetupPage.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+AISetupPage.swift
@@ -49,9 +49,6 @@ extension OnboardingView {
         if self.aiSetup.configuredGatewayAuthIssue != nil {
             return "Finish the remote Gateway connection before continuing."
         }
-        if aiSetup.connected {
-            return "All good — your assistant has a working AI connection."
-        }
         if state.connectionMode == .remote {
             return "AI access is configured on the remote Gateway. OpenClaw will use that existing setup."
         }

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -68,7 +68,6 @@ extension OnboardingView {
             self.onboardingDidDisappear()
         }
         .task {
-            await self.refreshPerms()
             await self.refreshCLIStatus()
             self.preferredGatewayID = GatewayDiscoveryPreferences.preferredStableID()
         }
@@ -96,7 +95,6 @@ extension OnboardingView {
         // Queued detection can otherwise proceed into a mutating activation
         // after the window or its selected route has gone away.
         aiSetup.resetForGatewayChange(clearPendingHandoff: false)
-        stopPermissionMonitoring()
         stopDiscovery()
     }
 

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
@@ -1,27 +1,6 @@
 import Foundation
-import OpenClawIPC
 
 extension OnboardingView {
-    @MainActor
-    func refreshPerms() async {
-        await permissionMonitor.refreshNow()
-    }
-
-    @MainActor
-    func request(_ cap: Capability) async {
-        guard !isRequesting else { return }
-        isRequesting = true
-        defer { isRequesting = false }
-        _ = await PermissionManager.ensure([cap], interactive: true)
-        await self.refreshPerms()
-    }
-
-    func updatePermissionMonitoring(for pageIndex: Int) {
-        PermissionMonitoringSupport.setMonitoring(
-            pageIndex == permissionsPageIndex,
-            monitoring: &monitoringPermissions)
-    }
-
     func updateDiscoveryMonitoring(for pageIndex: Int) {
         let isConnectionPage = pageIndex == connectionPageIndex
         let shouldMonitor = isConnectionPage
@@ -40,7 +19,6 @@ extension OnboardingView {
     }
 
     func updateMonitoring(for pageIndex: Int) {
-        self.updatePermissionMonitoring(for: pageIndex)
         self.updateDiscoveryMonitoring(for: pageIndex)
         self.maybeInstallCLI(for: pageIndex)
         self.maybeStartAISetup(for: pageIndex)
@@ -158,10 +136,6 @@ extension OnboardingView {
         // Cmd-W bypasses the disabled close button; the delegate asks first.
         OnboardingController.shared.busyReason = "OpenClaw is installing the Gateway service."
         Task { @MainActor in await self.runCLIInstall() }
-    }
-
-    func stopPermissionMonitoring() {
-        PermissionMonitoringSupport.stopMonitoring(&monitoringPermissions)
     }
 
     func stopDiscovery() {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -1,7 +1,5 @@
 import AppKit
 import OpenClawDiscovery
-import OpenClawIPC
-import OpenClawKit
 import SwiftUI
 
 extension OnboardingView {
@@ -16,8 +14,6 @@ extension OnboardingView {
             self.cliPage()
         case 3:
             self.aiSetupPage(contentHeight: contentHeight)
-        case 5:
-            self.permissionsPage()
         case 9:
             self.readyPage()
         default:
@@ -812,43 +808,6 @@ extension OnboardingView {
         .buttonStyle(.plain)
     }
 
-    func permissionsPage() -> some View {
-        onboardingPage {
-            VStack(spacing: 12) {
-                // Keep intro and rows in one document so short windows can reveal every permission.
-                HStack(spacing: 8) {
-                    Text("Grant permissions")
-                        .font(.largeTitle.weight(.semibold))
-                    if self.isRequesting {
-                        ProgressView()
-                            .controlSize(.small)
-                    }
-                }
-                Text(
-                    "These macOS permissions let OpenClaw automate apps and capture context on this Mac. " +
-                        "Status updates automatically.")
-                    .font(.body)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: 520)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                self.onboardingCard(spacing: 4, padding: 12) {
-                    ForEach(Capability.importanceOrdered, id: \.self) { cap in
-                        PermissionRow(
-                            capability: cap,
-                            status: self.permissionMonitor.status[cap] ?? .notGranted,
-                            compact: true)
-                        {
-                            Task { await self.request(cap) }
-                        }
-                    }
-                }
-            }
-        }
-        // The root onboarding layout keeps navigation outside this scrollable document.
-    }
-
     func cliPage() -> some View {
         let remoteMode = self.state.connectionMode == .remote
         let setupDetail = if remoteMode {
@@ -991,32 +950,13 @@ extension OnboardingView {
         onboardingPage {
             Text("You’re all set!")
                 .font(.largeTitle.weight(.semibold))
-            if self.state.connectionMode != .unconfigured {
-                Text("Finish opens the chat — say hi to your new agent.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-            }
             self.onboardingCard {
-                if self.state.connectionMode == .unconfigured {
-                    self.featureRow(
-                        title: "Configure later",
-                        subtitle: "Pick Local or Remote in Settings → General whenever you’re ready.",
-                        systemImage: "gearshape")
-                    Divider()
-                        .padding(.vertical, 6)
-                }
-                if self.state.connectionMode == .remote {
-                    self.featureRow(
-                        title: "Remote gateway checklist",
-                        subtitle: """
-                        On your gateway host: install/update the `openclaw` package and make sure credentials exist
-                        (typically `~/.openclaw/credentials/oauth.json`). Then connect again if needed.
-                        """,
-                        systemImage: "network")
-                    Divider()
-                        .padding(.vertical, 6)
-                }
+                self.featureRow(
+                    title: "Configure later",
+                    subtitle: "Pick Local or Remote in Settings → General whenever you’re ready.",
+                    systemImage: "gearshape")
+                Divider()
+                    .padding(.vertical, 6)
                 self.featureRow(
                     title: "Open the menu bar panel",
                     subtitle: "Click the OpenClaw menu bar icon for the compact chat panel and status.",
@@ -1046,98 +986,12 @@ extension OnboardingView {
                 {
                     self.openSettings(tab: .skills)
                 }
-                self.skillsOverview
                 if AppProfile.current.isActive {
                     LabeledContent("Launch at login", value: "Unavailable under profile")
                 } else {
                     Toggle("Launch at login", isOn: self.$state.launchAtLogin)
                         .disabled(!self.state.bundleLocationAllowsPersistentIntegration && !self.state.launchAtLogin)
                 }
-            }
-        }
-        .task { await self.maybeLoadOnboardingSkills() }
-        .onChange(of: currentPage) { _, newValue in
-            // The pager builds every page up front, so the initial load above
-            // can run before the local gateway is configured and fail. Retry
-            // when the user actually lands here instead of latching the error.
-            guard self.activePageIndex(for: newValue) == self.pageOrder.last else { return }
-            Task { await self.maybeLoadOnboardingSkills() }
-        }
-    }
-
-    private func maybeLoadOnboardingSkills() async {
-        if self.onboardingSkillsModel.isLoading { return }
-        if self.didLoadOnboardingSkills, self.onboardingSkillsModel.error == nil { return }
-        self.didLoadOnboardingSkills = true
-        await self.onboardingSkillsModel.refresh()
-    }
-
-    private var skillsOverview: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Divider()
-                .padding(.vertical, 6)
-
-            HStack(spacing: 10) {
-                Text("Skills included")
-                    .font(.headline)
-                Spacer(minLength: 0)
-                if self.onboardingSkillsModel.isLoading {
-                    ProgressView()
-                        .controlSize(.small)
-                } else {
-                    Button("Refresh") {
-                        Task { await self.onboardingSkillsModel.refresh() }
-                    }
-                    .buttonStyle(.link)
-                }
-            }
-
-            if let error = self.onboardingSkillsModel.error {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Couldn’t load skills from the Gateway.")
-                        .font(.footnote.weight(.semibold))
-                        .foregroundStyle(.orange)
-                    Text(
-                        "Make sure the Gateway is running and connected, " +
-                            "then hit Refresh (or open Settings → Skills).")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                    Text("Details: \(error)")
-                        .font(.caption.monospaced())
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            } else if self.onboardingSkillsModel.skills.isEmpty {
-                Text("No skills reported yet.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            } else {
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 10) {
-                        ForEach(self.onboardingSkillsModel.skills) { skill in
-                            HStack(alignment: .top, spacing: 10) {
-                                Text(skill.emoji ?? "✨")
-                                    .font(.callout)
-                                    .frame(width: 22, alignment: .leading)
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(skill.name)
-                                        .font(.callout.weight(.semibold))
-                                    Text(skill.description)
-                                        .font(.footnote)
-                                        .foregroundStyle(.secondary)
-                                        .fixedSize(horizontal: false, vertical: true)
-                                }
-                                Spacer(minLength: 0)
-                            }
-                        }
-                    }
-                    .padding(10)
-                    .background(
-                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .fill(Color(NSColor.windowBackgroundColor)))
-                }
-                .frame(maxHeight: 160)
             }
         }
     }

--- a/apps/macos/Sources/OpenClaw/OnboardingWidgets.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingWidgets.swift
@@ -1,5 +1,4 @@
 import OpenClawChatUI
-import OpenClawIPC
 import SwiftUI
 
 /// Onboarding hero mascot with the openclaw.ai hero treatment: the animated
@@ -43,8 +42,6 @@ extension OnboardingView {
         case connection
         case cli
         case ai
-        case permissions
-        case chat
         case ready
     }
 
@@ -58,7 +55,6 @@ extension OnboardingView {
         var aiBusy = false
         var aiFailed = false
         var remoteProbeState: RemoteOnboardingProbeState = .idle
-        var allPermissionsGranted = false
     }
 
     /// The hero mascot mirrors what setup is doing: curious while choosing,
@@ -73,9 +69,7 @@ extension OnboardingView {
             aiPhase: self.aiSetup.phase,
             aiBusy: self.aiSetup.isBusy,
             aiFailed: Self.aiSetupLooksFailed(self.aiSetup),
-            remoteProbeState: self.remoteProbeState,
-            allPermissionsGranted: Capability.importanceOrdered
-                .allSatisfy { self.permissionMonitor.status[$0]?.isGranted == true }))
+            remoteProbeState: self.remoteProbeState))
     }
 
     var mascotAccessory: OpenClawMascotAccessory {
@@ -87,8 +81,6 @@ extension OnboardingView {
         case self.connectionPageIndex: .connection
         case self.cliPageIndex: .cli
         case self.aiPageIndex: .ai
-        case self.permissionsPageIndex: .permissions
-        case self.onboardingChatPageIndex: .chat
         case self.readyPageIndex: .ready
         default: .welcome
         }
@@ -137,10 +129,6 @@ extension OnboardingView {
             } else {
                 .curious
             }
-        case .permissions:
-            snapshot.allPermissionsGranted ? .happy : .curious
-        case .chat:
-            .attentive
         case .ready:
             .celebrating
         }
@@ -149,7 +137,7 @@ extension OnboardingView {
     static func mascotAccessory(for page: MascotPage) -> OpenClawMascotAccessory {
         switch page {
         case .ready: .gradCap
-        case .welcome, .connection, .cli, .ai, .permissions, .chat: .none
+        case .welcome, .connection, .cli, .ai: .none
         }
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -961,7 +961,8 @@ struct OnboardingAISetupTests {
         }
         #expect(model.activeAuthOption == nil)
         #expect(model.authError == nil)
-        #expect(model.connectedModelRef == preparedModelRef)
+        #expect(model.connected)
+        #expect(model.selectedKind == "provider-auto:llama-cpp")
         let completedRequests = await recorder.snapshot()
         #expect(completedRequests.methods.suffix(2) == [
             "wizard.next",
@@ -1029,7 +1030,8 @@ struct OnboardingAISetupTests {
             try? await Task.sleep(nanoseconds: 5_000_000)
         }
 
-        #expect(model.connectedModelRef == preparedModelRef)
+        #expect(model.connected)
+        #expect(model.selectedKind == "provider-auto:llama-cpp")
         #expect(await (recorder.snapshot()).methods == [
             "openclaw.setup.detect",
             "openclaw.setup.prepare.start",
@@ -1148,30 +1150,6 @@ struct OnboardingAISetupTests {
         #expect(candidates.allSatisfy { $0.detail == "installed" })
     }
 
-    @Test func `activation decodes and retains copyable setup lines`() throws {
-        let data = Data(
-            #"""
-            {"ok":true,"modelRef":"openai/gpt-5.5","lines":[
-              "Model: openai/gpt-5.5","  Plugin registry refresh failed: offline  ",""
-            ]}
-            """#.utf8)
-        let result = try JSONDecoder().decode(OnboardingAISetupModel.ActivateResult.self, from: data)
-        let model = OnboardingAISetupModel()
-
-        model._test_setConnectedSetupLines(result.lines)
-
-        #expect(model.connectedSetupLines == [
-            "Model: openai/gpt-5.5",
-            "Plugin registry refresh failed: offline",
-        ])
-        #expect(model.connectedSetupCopyText ==
-            "Model: openai/gpt-5.5\nPlugin registry refresh failed: offline")
-
-        model.resetForGatewayChange()
-        #expect(model.connectedSetupLines.isEmpty)
-        #expect(model.connectedSetupCopyText.isEmpty)
-    }
-
     @Test func `gateway hello maps exact-model setup capability`() throws {
         let data = Data(
             #"""
@@ -1247,47 +1225,6 @@ struct OnboardingAISetupTests {
         #expect(pendingState(defaults) == .none)
     }
 
-    @Test func `choose a different AI relists routes without auto-activating`() async throws {
-        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingChooseDifferentAITests"))
-        let url = try #require(URL(string: "ws://example.invalid"))
-        let harness = AISetupHarness(url: url) { _, request, _ in
-            switch request.method {
-            case "openclaw.setup.detect":
-                // credentials:true would auto-activate; the choose-different
-                // pass must end at the picker even for actionable candidates.
-                actionableDetectedSetupResponse(id: request.id)
-            case "openclaw.setup.activate": verifiedSetupResponse(id: request.id)
-            default: nil
-            }
-        }
-        let model = harness.model(defaults: defaults)
-
-        await model.detectAndAutoConnect()
-        #expect(model.connected)
-
-        #expect(model.beginChooseDifferentAI())
-        await model.detectAndAutoConnect()
-
-        #expect(!model.connected)
-        #expect(!model.isBusy)
-        #expect(model.candidates.count == 1)
-        #expect(model.statuses["claude-cli"] == .untried)
-        #expect(model.showManualEntry)
-        // Exactly one activation: the initial auto-connect. The re-detect pass
-        // must not redo the choice the user just asked to change.
-        let snapshot = await harness.recorder.snapshot()
-        #expect(snapshot.methods.filter { $0 == "openclaw.setup.activate" }.count == 1)
-        #expect(snapshot.methods.last == "openclaw.setup.detect")
-    }
-
-    @Test func `choose a different AI requires a connected setup`() throws {
-        let defaults = isolatedAISetupDefaults(prefix: "OnboardingChooseDifferentAIGuardTests") ?? .standard
-        let url = try #require(URL(string: "ws://example.invalid"))
-        let model = AISetupHarness(url: url).model(defaults: defaults)
-
-        #expect(!model.beginChooseDifferentAI())
-    }
-
     @Test func `adopts pending activation stored under the retired crestodian key`() throws {
         let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingRetiredKeyMigrationTests"))
 
@@ -1333,7 +1270,7 @@ struct OnboardingAISetupTests {
             "openclaw.setup.verify",
         ])
         #expect(model.connected)
-        #expect(model.connectedModelRef == "openai/gpt-5.5")
+        #expect(model.selectedKind == "codex-cli")
         #expect(handoffCount == 1)
         #expect(storedActivationOwner(defaults) == activationOwner)
         #expect(pendingState(defaults) == .completed)
@@ -1480,8 +1417,6 @@ struct OnboardingAISetupTests {
         model.resetForGatewayChange()
 
         #expect(model.phase == .idle)
-        #expect(model.connectedModelRef == nil)
-        #expect(model.connectedLatencyMs == nil)
         #expect(model.manualProviderID.isEmpty)
         #expect(model.manualKey.isEmpty)
         #expect(!model.showManualEntry)
@@ -1546,7 +1481,6 @@ struct OnboardingAISetupTests {
         #expect(!model.connected)
         #expect(model.pendingActivationVerification)
         #expect(model.phase == .detecting)
-        #expect(model.connectedModelRef == nil)
 
         await model.activate(kind: "codex-cli")
         #expect(model.pendingActivationVerification)
@@ -1556,9 +1490,7 @@ struct OnboardingAISetupTests {
 
         #expect(model.connected)
         #expect(!model.pendingActivationVerification)
-        #expect(model.connectedModelRef == "openai/gpt-5.5")
         #expect(model.selectedKind == "existing-model")
-        #expect(model.statuses["existing-model"] == .connected)
     }
 
     @Test func `pending handoff connects only after route-bound live verification`() async throws {
@@ -1574,8 +1506,7 @@ struct OnboardingAISetupTests {
         let requests = await harness.recorder.snapshot()
         #expect(requests.methods == ["openclaw.setup.verify"])
         #expect(model.connected)
-        #expect(model.connectedModelRef == "openai/gpt-5.5")
-        #expect(model.connectedLatencyMs == 42)
+        #expect(model.selectedKind == "existing-model")
     }
 
     @Test func `overlapping pending verification callers share one route-bound request`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingMascotMoodTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingMascotMoodTests.swift
@@ -43,13 +43,7 @@ struct OnboardingMascotMoodTests {
             "a live connection outranks stale failures")
     }
 
-    @Test func `permissions page warms up when everything is granted`() {
-        #expect(self.mood(.init(page: .permissions)) == .curious)
-        #expect(self.mood(.init(page: .permissions, allPermissionsGranted: true)) == .happy)
-    }
-
-    @Test func `chat and ready pages`() {
-        #expect(self.mood(.init(page: .chat)) == .attentive)
+    @Test func `ready page celebrates`() {
         #expect(self.mood(.init(page: .ready)) == .celebrating)
     }
 
@@ -63,7 +57,5 @@ struct OnboardingMascotMoodTests {
         #expect(self.accessory(.connection) == .none)
         #expect(self.accessory(.cli) == .none)
         #expect(self.accessory(.ai) == .none)
-        #expect(self.accessory(.permissions) == .none)
-        #expect(self.accessory(.chat) == .none)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingSystemAgentChatTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingSystemAgentChatTests.swift
@@ -260,7 +260,8 @@ struct OnboardingSystemAgentChatTests {
         let task = view.resumePendingSystemAgent(modelRef: "openai/gpt-5.5")
         await task.value
 
-        #expect(view.aiSetup.connectedModelRef == "openai/gpt-5.5")
+        #expect(view.aiSetup.connected)
+        #expect(view.aiSetup.selectedKind == "existing-model")
         #expect(view.finishState.didFinish)
         #expect(dashboardOpenCount == 1)
         #expect(!view.finish())
@@ -268,7 +269,8 @@ struct OnboardingSystemAgentChatTests {
         let repeatedResume = view.resumePendingSystemAgent(modelRef: "openai/gpt-5.5")
         await repeatedResume.value
 
-        #expect(view.aiSetup.connectedModelRef == "openai/gpt-5.5")
+        #expect(view.aiSetup.connected)
+        #expect(view.aiSetup.selectedKind == "existing-model")
         #expect(dashboardOpenCount == 1)
         #expect(await methods.snapshot() == [
             "health",

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -45,7 +45,6 @@ struct OnboardingViewSmokeTests {
         let state = AppState(preview: true)
         let view = OnboardingView(
             state: state,
-            permissionMonitor: PermissionMonitor.shared,
             discoveryModel: GatewayDiscoveryModel(localDisplayName: InstanceIdentity.displayName))
         _ = view.body
     }
@@ -80,25 +79,6 @@ struct OnboardingViewSmokeTests {
 
         #expect(short == 409)
         #expect(short < preferred)
-    }
-
-    @Test func `permissions page scrolls when the onboarding window is short`() throws {
-        let state = AppState(preview: true)
-        let view = OnboardingView(state: state)
-        let hosting = NSHostingView(rootView: view.permissionsPage())
-        let contentHeight = OnboardingView.contentHeight(
-            for: OnboardingView.minimumWindowHeight,
-            usesCompactHero: false)
-        hosting.frame = NSRect(
-            x: 0,
-            y: 0,
-            width: OnboardingView.windowWidth,
-            height: contentHeight)
-        hosting.layoutSubtreeIfNeeded()
-
-        let scrollView = try #require(Self.firstDescendant(of: NSScrollView.self, in: hosting))
-        #expect(contentHeight == 303)
-        #expect(scrollView.documentView != nil)
     }
 
     @Test func `configured flows end at AI setup and hand off to the dashboard`() {
@@ -302,7 +282,6 @@ struct OnboardingViewSmokeTests {
             state.remoteTarget = "user@old-host:2222"
             let view = OnboardingView(
                 state: state,
-                permissionMonitor: PermissionMonitor.shared,
                 discoveryModel: GatewayDiscoveryModel(localDisplayName: InstanceIdentity.displayName))
             let gateway = GatewayDiscoveryModel.DiscoveredGateway(
                 displayName: "Unresolved",
@@ -343,7 +322,6 @@ struct OnboardingViewSmokeTests {
             state.connectionMode = .remote
             let view = OnboardingView(
                 state: state,
-                permissionMonitor: PermissionMonitor.shared,
                 discoveryModel: GatewayDiscoveryModel(localDisplayName: InstanceIdentity.displayName),
                 systemAgentDefaults: defaults)
             view.aiSetup.manualKey = "route-a-secret"
@@ -450,7 +428,6 @@ struct OnboardingViewSmokeTests {
             state.connectionMode = .remote
             let view = OnboardingView(
                 state: state,
-                permissionMonitor: PermissionMonitor.shared,
                 discoveryModel: GatewayDiscoveryModel(localDisplayName: InstanceIdentity.displayName),
                 systemAgentDefaults: defaults)
             view.aiSetup.manualKey = "pending-secret"
@@ -542,13 +519,5 @@ struct OnboardingViewSmokeTests {
         #expect(Array(Capability.importanceOrdered.prefix(3))
             == [.appleScript, .accessibility, .screenRecording])
         #expect(Capability.importanceOrdered.last == Capability.location)
-    }
-
-    private static func firstDescendant<T: NSView>(of type: T.Type, in view: NSView) -> T? {
-        if let match = view as? T { return match }
-        for child in view.subviews {
-            if let match = self.firstDescendant(of: type, in: child) { return match }
-        }
-        return nil
     }
 }


### PR DESCRIPTION
Related: #120950

## What Problem This Solves

The macOS app still carried onboarding UI, state, and tests for pages and post-connection states that the dashboard-first handoff can no longer display. This left impossible permission/ready-page branches, an unconfigured-page Gateway fetch, and connected-success controls in the native onboarding maintenance surface.

## Why This Change Was Made

This specializes native onboarding to its current page graph and removes success-only presentation state after the synchronous dashboard handoff. It deliberately keeps the shared system-agent chat model/view because current source proves that Settings still constructs and presents it.

Per survey item:

1. **Retired onboarding chat surface — kept.** `SystemAgentSettings` constructs `SystemAgentOnboardingChatModel`, renders `SystemAgentOnboardingChatView`, starts it when the native OpenClaw settings tab becomes active, and consumes its typed draft handoff. `SettingsRootView` exposes that native tab whenever inference is configured. PR #120950 removed only the onboarding presentation wrapper; the shared Settings surface and its tests remain live.
2. **Connected-success UI — deleted.** Every activation success funnels through synchronous `finishConnected()`, which invokes the only production `onConnected` callback. That callback immediately calls `OnboardingView.finish()`, closes onboarding, and opens dashboard onboarding. The connected banner, setup-detail copy state, Choose Different path, and connected-only candidate presentation could not render.
3. **Impossible pages — deleted.** The sole page-order producer returns only `[0, 1, 2, 3]`, `[0, 1, 3]`, or `[0, 1, 9]`; the pager only constructs those entries. Page 5 permission UI/monitoring and stale page 8 mascot state had no production route. Live permission Settings behavior remains untouched.
4. **Ready page — specialized to unconfigured.** Page 9 occurs only in `[0, 1, 9]` for `.unconfigured`. Configured/remote copy and the Gateway-backed skills results/retry UI were impossible there. The skills task itself was eagerly reachable, but only while no Gateway endpoint existed, so the ready page now renders only its unconfigured content.

The activation lease store in `Onboarding.swift` is byte-for-byte unchanged (matching SHA-256 before/after). No compatibility shim, replacement abstraction, or `CHANGELOG.md` edit was added.

## User Impact

Configured local and remote onboarding still closes as soon as inference works and opens the dashboard. “Set up later” still ends on the native ready page, without attempting a Gateway skills request while no Gateway is configured. The native OpenClaw settings chat remains available after inference is configured.

This is a behavior-preserving deletion of unreachable UI; there is no meaningful before/after screenshot because the removed states cannot be presented through the production page graph.

## Evidence

- Production LOC: **+22/-389 (net -367)**
- Tests: **+11/-117 (net -106)**
- Generated native i18n inventory: **+140/-260 (net -120)**; 15 retired strings removed, no strings added
- `swift build --package-path apps/macos --product OpenClaw --configuration release` — passed
- `swift test --package-path apps/shared/OpenClawKit --parallel` — 1,328 tests / 103 suites passed
- `swift test --package-path apps/macos --enable-code-coverage --no-parallel` — 1,680 tests / 181 suites passed
- `./scripts/lint-swift.sh macos` — passed
- `./scripts/format-swift.sh macos` — passed
- `node --import tsx scripts/native-app-i18n.ts verify` — passed (`entries=5362`, no drift)
- `git diff --check origin/main...HEAD` — passed
- Autoreview — clean, no accepted/actionable findings

AI-assisted; the resulting deletion and reachability claims were verified against current source and history.
