### PR TITLE
fix(test): restore root-matrix unit-fast cleanup

### DIFF
--- a/test/vitest-projects-config.test.ts
+++ b/test/vitest-projects-config.test.ts
@@ -38,6 +38,7 @@ import { fullSuiteVitestShards } from "./vitest/vitest.test-shards.mjs";
 import { createUiVitestConfig } from "./vitest/vitest.ui.config.ts";
 import { createUnitFastFakeTimersVitestConfig } from "./vitest/vitest.unit-fast-fake-timers.config.ts";
 import { createUnitFastIsolatedVitestConfig } from "./vitest/vitest.unit-fast-isolated.config.ts";
+import unitFastRootConfig from "./vitest/vitest.unit-fast-root.config.ts";
 import { createUnitFastVitestConfig } from "./vitest/vitest.unit-fast.config.ts";
 import { createUnitVitestConfig } from "./vitest/vitest.unit.config.ts";
 
@@ -277,6 +278,14 @@ describe("projects vitest config", () => {
     const testConfig = requireTestConfig(config);
     expect(testConfig.isolate).toBe(false);
     expect(testConfig.runner).toBeUndefined();
+  });
+
+  it("keeps root-matrix unit-fast files on the cross-file cleanup runner", () => {
+    const testConfig = requireTestConfig(unitFastRootConfig);
+    expect(testConfig.isolate).toBe(false);
+    expect(normalizeConfigPath(testConfig.runner)).toBe("test/non-isolated-runner.ts");
+    expect(rootVitestProjects).toContain("test/vitest/vitest.unit-fast-root.config.ts");
+    expect(rootVitestProjects).not.toContain("test/vitest/vitest.unit-fast.config.ts");
   });
 
   it("isolates forced unit-fast files from shared module caches", () => {

--- a/test/vitest/vitest.config.ts
+++ b/test/vitest/vitest.config.ts
@@ -37,7 +37,7 @@ export const rootVitestProjects = [
   ...agentVitestProjectConfigs,
   "test/vitest/vitest.daemon.config.ts",
   "test/vitest/vitest.media.config.ts",
-  "test/vitest/vitest.unit-fast.config.ts",
+  "test/vitest/vitest.unit-fast-root.config.ts",
   "test/vitest/vitest.unit-fast-isolated.config.ts",
   "test/vitest/vitest.unit-fast-fake-timers.config.ts",
   "test/vitest/vitest.plugin-sdk-light.config.ts",

--- a/test/vitest/vitest.unit-fast-root.config.ts
+++ b/test/vitest/vitest.unit-fast-root.config.ts
@@ -1,0 +1,5 @@
+// Root-matrix unit-fast config preserves cross-file cleanup when CLI filters bypass lane ownership.
+import { nonIsolatedRunnerPath } from "./vitest.shared.config.ts";
+import { createUnitFastVitestConfig } from "./vitest.unit-fast.config.ts";
+
+export default createUnitFastVitestConfig(process.env, { runner: nonIsolatedRunnerPath });

--- a/test/vitest/vitest.unit-fast.config.ts
+++ b/test/vitest/vitest.unit-fast.config.ts
@@ -10,7 +10,7 @@ import {
 
 export function createUnitFastVitestConfig(
   env: Record<string, string | undefined> = process.env,
-  options: { argv?: string[] } = {},
+  options: { argv?: string[]; runner?: string } = {},
 ) {
   const sharedTest = sharedVitestConfig.test ?? {};
   const includeFromEnv = loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
@@ -27,7 +27,7 @@ export function createUnitFastVitestConfig(
       ...sharedTest,
       name: "unit-fast",
       isolate: false,
-      runner: undefined,
+      runner: options.runner,
       // Env isolation only (no shared-setup mocks): membership is auto-curated,
       // so tests must never read the developer's real config/state.
       setupFiles: [resolveRepoRootPath("test/setup.env.ts")],


### PR DESCRIPTION
## What Problem This Solves

Fixes an order-dependent test-infrastructure failure where root-matrix directory filtering could place runner-free unit-fast files that had evaluated real channel modules in shared workers before later mock-heavy channel owner files. The retained module cache could then leak real module state into tests expecting mocked ownership, producing failures that depended on file order rather than behavior.

## Why This Change Was Made

The existing `test/non-isolated-runner.ts` lifecycle already owns per-file evaluated-module and mock cleanup. This change adds a root-matrix-only unit-fast config that opts into that cleanup runner and points the root matrix at it, while keeping the standalone unit-fast lane runner-free for speed. No production paths or behavior change.

## User Impact

There is no user-visible runtime impact. Maintainers and contributors get deterministic root-matrix channel test execution without slowing the standalone unit-fast lane.

Production LOC: 0. Test/tooling diff: +17/-3.

No changelog entry is included because this is test infrastructure only.

## Evidence

- `node scripts/run-vitest.mjs test/vitest-projects-config.test.ts` — 1 file, 21 tests passed before commit; repeated after rebasing onto current `origin/main` with the same result.
- `node scripts/run-vitest.mjs src/channels/plugins` — 582 files, 5,590 tests passed.
- `node scripts/run-vitest.mjs src/channels/plugins/package-state-probes.test.ts src/channels/plugins/setup-promotion-helpers.test.ts` — 2 files, 25 tests passed.
- `./node_modules/.bin/oxfmt --check test/vitest-projects-config.test.ts test/vitest/vitest.config.ts test/vitest/vitest.unit-fast.config.ts test/vitest/vitest.unit-fast-root.config.ts` — clean.
- `git diff --check` — clean before commit and after rebase.
- Structured pre-commit autoreview of the frozen diff — clean, with no accepted or actionable findings.
- Rebase integrity: the binary patch SHA-256 remained `c6802bc5f62264e0f9530435c407d150e18ba690c3c96f8a8d014783991508b8`; no semantic edits were made.
