### PR TITLE
[BACKPORT] feat(slack): add workspace routing for Enterprise Grid actions and events

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -69,12 +69,13 @@ The relay URL must use `wss://` unless it targets localhost. Treat the bearer to
 
 ### Enterprise Grid org-wide installs
 
-One Slack account can receive messages from every workspace covered by an
-Enterprise Grid org-wide installation. Choose direct Socket Mode or HTTP
-Request URLs; relay mode is not supported for enterprise accounts. Both
-least-privilege manifests below enable the V1 message, mention, membership,
-reaction, and pin event paths, immediate replies, and listener-owned status
-reactions.
+One Slack account can receive messages and interactions from every workspace
+covered by an Enterprise Grid org-wide installation. Choose direct Socket Mode
+or HTTP Request URLs; relay mode is not supported for enterprise accounts. Both
+least-privilege manifests below enable the Enterprise message, mention,
+reaction, pin, channel-created, and channel-renamed event paths, immediate
+replies, listener-owned status reactions, Slack interactivity for Block Kit
+actions and modal submissions, and the single `/openclaw` slash command.
 
 #### Socket Mode
 
@@ -85,7 +86,14 @@ reactions.
     "description": "Slack connector for OpenClaw"
   },
   "features": {
-    "bot_user": { "display_name": "OpenClaw", "always_online": true }
+    "bot_user": { "display_name": "OpenClaw", "always_online": true },
+    "slash_commands": [
+      {
+        "command": "/openclaw",
+        "description": "Send a message to OpenClaw",
+        "should_escape": false
+      }
+    ]
   },
   "oauth_config": {
     "scopes": {
@@ -94,6 +102,7 @@ reactions.
         "channels:history",
         "channels:read",
         "chat:write",
+        "commands",
         "files:read",
         "files:write",
         "groups:history",
@@ -112,9 +121,12 @@ reactions.
   "settings": {
     "org_deploy_enabled": true,
     "socket_mode_enabled": true,
+    "interactivity": { "is_enabled": true },
     "event_subscriptions": {
       "bot_events": [
         "app_mention",
+        "channel_created",
+        "channel_rename",
         "message.channels",
         "message.groups",
         "message.im",
@@ -147,6 +159,7 @@ uses the org-installed bot token:
       enterpriseOrgInstall: true,
       appToken: { source: "env", provider: "default", id: "SLACK_APP_TOKEN" },
       botToken: { source: "env", provider: "default", id: "SLACK_BOT_TOKEN" },
+      slashCommand: { enabled: true, name: "openclaw" },
       dmPolicy: "open",
       allowFrom: ["*"],
       groupPolicy: "allowlist",
@@ -171,7 +184,15 @@ Socket Mode connection. Replace the example URL with the Gateway's public
     "description": "Slack connector for OpenClaw"
   },
   "features": {
-    "bot_user": { "display_name": "OpenClaw", "always_online": true }
+    "bot_user": { "display_name": "OpenClaw", "always_online": true },
+    "slash_commands": [
+      {
+        "command": "/openclaw",
+        "description": "Send a message to OpenClaw",
+        "should_escape": false,
+        "url": "https://gateway-host.example.com/slack/events"
+      }
+    ]
   },
   "oauth_config": {
     "scopes": {
@@ -180,6 +201,7 @@ Socket Mode connection. Replace the example URL with the Gateway's public
         "channels:history",
         "channels:read",
         "chat:write",
+        "commands",
         "files:read",
         "files:write",
         "groups:history",
@@ -197,10 +219,16 @@ Socket Mode connection. Replace the example URL with the Gateway's public
   },
   "settings": {
     "org_deploy_enabled": true,
+    "interactivity": {
+      "is_enabled": true,
+      "request_url": "https://gateway-host.example.com/slack/events"
+    },
     "event_subscriptions": {
       "request_url": "https://gateway-host.example.com/slack/events",
       "bot_events": [
         "app_mention",
+        "channel_created",
+        "channel_rename",
         "message.channels",
         "message.groups",
         "message.im",
@@ -236,6 +264,7 @@ the enterprise account with the same Request URL path:
         provider: "default",
         id: "SLACK_SIGNING_SECRET",
       },
+      slashCommand: { enabled: true, name: "openclaw" },
       webhookPath: "/slack/events",
       dmPolicy: "open",
       allowFrom: ["*"],
@@ -252,28 +281,36 @@ At startup, OpenClaw verifies `enterpriseOrgInstall` with Slack `auth.test`.
 An org-installed token without the flag, or a workspace token with the flag,
 fails startup. Slack remains the source of truth for which workspaces have
 granted the installation; OpenClaw then applies the configured channel, user,
-DM, and mention policies to each delivered event. Enterprise V1 rejects all
+DM, and mention policies to each delivered event. Enterprise accounts reject all
 bot-authored `message` and `app_mention` events before dispatch, regardless of
 `allowBots`, because org installs do not provide a stable workspace-qualified
 bot identity for loop prevention.
 
 Enterprise support accepts direct Socket Mode or HTTP message, mention,
-membership, reaction, and pin events plus workspace-qualified outbound
-messages. Relay mode, slash commands, channel lifecycle events, interactions,
-App Home, Agent and Assistant lifecycle events, Slack-native approvals, and
-bindings remain unavailable for an enterprise account. Slack action tools
-remain unavailable except for file uploads and adding or removing emoji
-reactions. Inbound membership, reaction, and pin notifications use the
-listener-owned, workspace-scoped Slack client. Outbound acknowledgment, typing,
-and status reactions are also supported through that client and require
-`reactions:write`.
+membership, reaction, pin, channel-created, channel-renamed, Block Kit action,
+modal, and configured shortcut and slash-command payloads plus
+workspace-qualified outbound messages. Add any shortcuts to the app manifest's
+`features.shortcuts` list; OpenClaw accepts their callback IDs through the same
+interaction path. The manifest examples register the single `/openclaw`
+command; native command mode still requires the administrator-managed command
+entries described below. Relay mode, channel-ID-change events, App Home, Agent
+and Assistant lifecycle events, Slack-native approvals, and bindings remain
+unavailable for an enterprise account. Slack action tools are supported for
+enterprise accounts across every group listed in
+[Actions and gates](#actions-and-gates); the configured
+`channels.slack.actions.*` gates and OAuth scopes still apply. Inbound
+membership, reaction, pin, channel-created, and channel-renamed notifications
+use validated listener-owned, workspace-scoped event routing. Outbound
+acknowledgment, typing, and status reactions are also supported through that
+client and require `reactions:write`.
 
 OpenClaw records Enterprise Grid destinations as
 `team:<team-id>:channel:<channel-id>` or `team:<team-id>:user:<user-id>`.
-Current-conversation sends, uploads, and reactions inherit that destination.
-Detached or proactive calls must provide the workspace-qualified target;
-bare channel and user IDs fail closed because those IDs can be reused by
-different workspaces.
+Current-conversation Slack tool actions inherit that workspace. Detached or
+proactive calls must provide a workspace-qualified target; bare channel and
+user IDs fail closed because those IDs can be reused by different workspaces.
+Actions without a destination parameter, such as `member-info` and
+`emoji-list`, require trusted current Slack conversation context.
 
 Immediate replies reuse the standard Slack delivery behavior for chunks,
 media, metadata, identity fallback, unfurls, and receipts, but only while the
@@ -281,13 +318,16 @@ validated listener-owned client remains in the active event turn. The
 in-memory send queue and thread-participation records are partitioned by that
 event's workspace; the client itself is never serialized or persisted.
 
-Channel policy keys and `dm.groupChannels` entries must use raw stable Slack channel IDs or the
-`channel:<id>` form. OpenClaw normalizes either form to the raw channel ID for
-runtime matching; `slack:`, `group:`, and `mpim:` prefixes fail startup.
-User policy entries must use stable Slack user IDs; names, slugs, display names,
-and email addresses fail startup. IDs must use Slack's canonical uppercase
-prefix and body (for example, `C0123456789` or `U0123456789`); lowercase and
-short lookalikes fail startup. Enterprise accounts cannot enable
+Channel policy keys may use the `"*"` wildcard, raw stable Slack channel IDs,
+or the `channel:<id>` form. `dm.groupChannels` entries accept only the raw or
+`channel:<id>` forms. OpenClaw normalizes either ID form to the raw channel ID
+for runtime matching; `slack:`, `group:`, and `mpim:` prefixes fail startup.
+User allowlists may use raw stable Slack user IDs or the `slack:<id>` and
+`user:<id>` forms. `toolsBySender` keys may use raw IDs, `id:<id>`,
+`channel:slack:<id>`, or `"*"`. Names, slugs, display names, and email addresses
+fail startup. IDs must use Slack's canonical uppercase prefix and body (for
+example, `C0123456789` or `U0123456789`); lowercase and short lookalikes fail
+startup. Enterprise accounts cannot enable
 `dangerouslyAllowNameMatching`. Enterprise accounts may set the global
 `mentionPatterns.mode`, but `mentionPatterns.allowIn` and
 `mentionPatterns.denyIn` fail startup because bare Slack channel IDs are not

--- a/extensions/slack/src/interactive-dispatch.ts
+++ b/extensions/slack/src/interactive-dispatch.ts
@@ -125,17 +125,39 @@ export async function dispatchSlackPluginInteractiveHandler(params: {
     ? qualify(params.ctx.parentConversationId)
     : undefined;
 
-  return await dispatchSlackInteractive({
-    ...params,
+  return await dispatchPluginInteractiveHandler<SlackInteractiveHandlerRegistration>({
+    channel: "slack",
+    data: params.data,
     dedupeId: qualify(params.interactionId),
-    conversation: {
-      channel: "slack",
-      accountId: params.ctx.accountId,
-      conversationId: qualifiedThreadId ?? baseConversationId,
-      parentConversationId: qualifiedThreadId
-        ? (qualifiedParentConversationId ?? baseConversationId)
-        : qualifiedParentConversationId,
-      threadId: qualifiedThreadId,
-    },
+    onMatched: params.onMatched,
+    invoke: ({ registration, namespace, payload }) =>
+      registration.handler({
+        ...params.ctx,
+        channel: "slack",
+        interaction: {
+          ...params.ctx.interaction,
+          data: params.data,
+          namespace,
+          payload,
+        },
+        respond: params.respond,
+        ...createInteractiveConversationBindingHelpers({
+          // The shared helpers fail closed without owner authority; never expose it to unauthenticated actions.
+          registration:
+            params.ctx.auth.isAuthorizedSender && baseConversationId
+              ? registration
+              : { ...registration, pluginRoot: undefined },
+          senderId: params.ctx.senderId,
+          conversation: {
+            channel: "slack",
+            accountId: params.ctx.accountId,
+            conversationId: qualifiedThreadId ?? baseConversationId,
+            parentConversationId: qualifiedThreadId
+              ? (qualifiedParentConversationId ?? baseConversationId)
+              : qualifiedParentConversationId,
+            threadId: qualifiedThreadId,
+          },
+        }),
+      }),
   });
 }

--- a/extensions/slack/src/interactive-dispatch.ts
+++ b/extensions/slack/src/interactive-dispatch.ts
@@ -103,53 +103,39 @@ type SlackInteractiveDispatchContext = Omit<
 export async function dispatchSlackPluginInteractiveHandler(params: {
   data: string;
   interactionId: string;
+  teamId?: string;
   channelType?: "im" | "mpim" | "channel" | "group";
   ctx: SlackInteractiveDispatchContext;
   respond: SlackInteractiveHandlerContext["respond"];
   onMatched?: () => Promise<void> | void;
 }) {
   const senderId = params.ctx.senderId?.trim();
-  const baseConversationId =
+  const rawBaseConversationId =
     params.channelType === "im"
       ? senderId
         ? `user:${senderId}`
         : ""
       : params.ctx.conversationId.trim();
   const threadId = params.ctx.threadId?.trim() || undefined;
+  const qualify = (value: string) =>
+    params.teamId ? `team:${encodeURIComponent(params.teamId)}:${value}` : value;
+  const baseConversationId = qualify(rawBaseConversationId);
+  const qualifiedThreadId = threadId ? qualify(threadId) : undefined;
+  const qualifiedParentConversationId = params.ctx.parentConversationId
+    ? qualify(params.ctx.parentConversationId)
+    : undefined;
 
-  return await dispatchPluginInteractiveHandler<SlackInteractiveHandlerRegistration>({
-    channel: "slack",
-    data: params.data,
-    dedupeId: params.interactionId,
-    onMatched: params.onMatched,
-    invoke: ({ registration, namespace, payload }) =>
-      registration.handler({
-        ...params.ctx,
-        channel: "slack",
-        interaction: {
-          ...params.ctx.interaction,
-          data: params.data,
-          namespace,
-          payload,
-        },
-        respond: params.respond,
-        ...createInteractiveConversationBindingHelpers({
-          // The shared helpers fail closed without owner authority; never expose it to unauthenticated actions.
-          registration:
-            params.ctx.auth.isAuthorizedSender && baseConversationId
-              ? registration
-              : { ...registration, pluginRoot: undefined },
-          senderId: params.ctx.senderId,
-          conversation: {
-            channel: "slack",
-            accountId: params.ctx.accountId,
-            conversationId: threadId ?? baseConversationId,
-            parentConversationId: threadId
-              ? (params.ctx.parentConversationId ?? baseConversationId)
-              : params.ctx.parentConversationId,
-            threadId,
-          },
-        }),
-      }),
+  return await dispatchSlackInteractive({
+    ...params,
+    dedupeId: qualify(params.interactionId),
+    conversation: {
+      channel: "slack",
+      accountId: params.ctx.accountId,
+      conversationId: qualifiedThreadId ?? baseConversationId,
+      parentConversationId: qualifiedThreadId
+        ? (qualifiedParentConversationId ?? baseConversationId)
+        : qualifiedParentConversationId,
+      threadId: qualifiedThreadId,
+    },
   });
 }

--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -63,6 +63,7 @@ type SlackTestState = {
   appConstructorArgs?: Record<string, unknown>;
   appStartMock: Mock<(...args: unknown[]) => Promise<unknown>>;
   appStopMock: Mock<(...args: unknown[]) => Promise<unknown>>;
+  interactionRegistrations: string[];
   sendMock: Mock<(...args: unknown[]) => Promise<unknown>>;
   replyMock: Mock<(...args: unknown[]) => unknown>;
   updateLastRouteMock: Mock<(...args: unknown[]) => unknown>;
@@ -91,6 +92,7 @@ const slackTestState: SlackTestState = vi.hoisted(() => {
     appConstructorArgs: undefined,
     appStartMock: vi.fn(),
     appStopMock: vi.fn(),
+    interactionRegistrations: [],
     sendMock: vi.fn(),
     replyMock: vi.fn(),
     updateLastRouteMock: vi.fn(),
@@ -345,6 +347,7 @@ export function resetSlackTestState(config: Record<string, unknown> = defaultSla
   slackTestState.socketModeLogger = undefined;
   slackTestState.appStartMock.mockReset().mockResolvedValue(undefined);
   slackTestState.appStopMock.mockReset().mockResolvedValue(undefined);
+  slackTestState.interactionRegistrations.length = 0;
   slackTestState.sendMock.mockReset().mockResolvedValue(undefined);
   slackTestState.replyMock.mockReset();
   slackTestState.updateLastRouteMock.mockReset();
@@ -485,7 +488,16 @@ vi.mock("@slack/bolt", () => {
       });
     }
     command() {
-      /* no-op */
+      slackTestState.interactionRegistrations.push("command");
+    }
+    action() {
+      slackTestState.interactionRegistrations.push("action");
+    }
+    shortcut() {
+      slackTestState.interactionRegistrations.push("shortcut");
+    }
+    view() {
+      slackTestState.interactionRegistrations.push("view");
     }
     start = (...args: unknown[]) => slackTestState.appStartMock(...args);
     stop = (...args: unknown[]) => slackTestState.appStopMock(...args);

--- a/extensions/slack/src/monitor/deferred-action-routing.ts
+++ b/extensions/slack/src/monitor/deferred-action-routing.ts
@@ -1,0 +1,23 @@
+// Slack plugin module owns workspace-qualified routing for deferred actions.
+import type { SlackTargetKind } from "../target-parsing.js";
+import type { SlackEventScope } from "./event-scope.js";
+
+type SlackDeferredActionTarget = {
+  peerId: string;
+  target: string;
+};
+
+export function resolveSlackDeferredActionTarget(params: {
+  eventScope?: SlackEventScope;
+  kind: SlackTargetKind;
+  id: string;
+}): SlackDeferredActionTarget {
+  if (!params.id) {
+    throw new Error("Slack deferred action is missing a target ID");
+  }
+  if (!params.eventScope) {
+    return { peerId: params.id, target: `${params.kind}:${params.id}` };
+  }
+  const target = `team:${encodeURIComponent(params.eventScope.teamId)}:${params.kind}:${encodeURIComponent(params.id)}`;
+  return { peerId: target, target };
+}

--- a/extensions/slack/src/monitor/event-scope.test.ts
+++ b/extensions/slack/src/monitor/event-scope.test.ts
@@ -1,44 +1,41 @@
 import { WebClient } from "@slack/web-api";
 import { describe, expect, it } from "vitest";
-import { resolveSlackEventScope } from "./event-scope.js";
+import { resolveSlackListenerEventScope } from "./event-scope.js";
 
 const identity = { kind: "enterprise", apiAppId: "A123", enterpriseId: "E123" } as const;
 const client = new WebClient("listener-token");
 
-describe("resolveSlackEventScope", () => {
-  it.each(["T111", "T222"])("accepts authorized workspace %s in the same org", (teamId) => {
-    const listenerClient = new WebClient(`listener-token-${teamId.toLowerCase()}`);
-    const result = resolveSlackEventScope({
-      identity,
-      body: { api_app_id: "A123" },
-      context: { isEnterpriseInstall: true, enterpriseId: "E123", teamId },
-      client: listenerClient,
-    });
-    expect(result).toMatchObject({
-      ok: true,
-      scope: {
+describe("resolveSlackListenerEventScope", () => {
+  it.each(["T111", "workspace/Mixed Case"])(
+    "preserves authorized workspace %s in the same org",
+    (teamId) => {
+      const listenerClient = new WebClient(`listener-token-${teamId.toLowerCase()}`);
+      const result = resolveSlackListenerEventScope({
+        identity,
+        body: { api_app_id: "A123" },
+        context: { isEnterpriseInstall: true, enterpriseId: "E123", teamId },
+        client: listenerClient,
+      });
+      expect(result).toMatchObject({
         teamId,
         client: listenerClient,
-      },
-    });
-    expect(result.ok && result.scope?.client).toBe(listenerClient);
-    expect(result.ok && result.scope?.uploadCompletionClient).toBeInstanceOf(WebClient);
-    expect(result.ok && result.scope?.uploadCompletionClient).not.toBe(listenerClient);
-  });
+      });
+      expect(result?.client).toBe(listenerClient);
+      expect(result?.uploadCompletionClient).toBeInstanceOf(WebClient);
+      expect(result?.uploadCompletionClient).not.toBe(listenerClient);
+    },
+  );
 
-  it("accepts a signed enterprise event when startup auth.test omitted app_id", () => {
-    const result = resolveSlackEventScope({
-      identity: { kind: "enterprise", enterpriseId: "E123" },
-      body: { api_app_id: "A123" },
+  it("accepts a Bolt-authenticated payload that does not carry api_app_id", () => {
+    const result = resolveSlackListenerEventScope({
+      identity,
+      body: {},
       context: { isEnterpriseInstall: true, enterpriseId: "E123", teamId: "T111" },
       client,
     });
     expect(result).toMatchObject({
-      ok: true,
-      scope: {
-        teamId: "T111",
-        client,
-      },
+      teamId: "T111",
+      client,
     });
   });
 
@@ -77,7 +74,8 @@ describe("resolveSlackEventScope", () => {
       enterpriseId: "E123",
       teamId: "T111",
     };
-    const result = resolveSlackEventScope({
+    let droppedReason: string | undefined;
+    const result = resolveSlackListenerEventScope({
       identity,
       body: { api_app_id: "A123" },
       client,
@@ -86,8 +84,12 @@ describe("resolveSlackEventScope", () => {
         ...baseContext,
         ...("context" in override ? override.context : {}),
       },
+      onDrop: (value) => {
+        droppedReason = value;
+      },
     });
-    expect(result).toEqual({ ok: false, reason });
+    expect(result).toBeNull();
+    expect(droppedReason).toBe(reason);
   });
 
   it("rejects enterprise events for workspace and degraded accounts", () => {
@@ -95,14 +97,19 @@ describe("resolveSlackEventScope", () => {
       { kind: "workspace", apiAppId: "A123", teamId: "T111" } as const,
       { kind: "degraded", reason: "auth_test_failed" } as const,
     ]) {
+      let droppedReason: string | undefined;
       expect(
-        resolveSlackEventScope({
+        resolveSlackListenerEventScope({
           identity: workspaceIdentity,
           body: { api_app_id: "A123" },
           context: { isEnterpriseInstall: true, enterpriseId: "E123", teamId: "T111" },
           client,
+          onDrop: (value) => {
+            droppedReason = value;
+          },
         }),
-      ).toEqual({ ok: false, reason: "enterprise_event_for_workspace_account" });
+      ).toBeNull();
+      expect(droppedReason).toBe("enterprise_event_for_workspace_account");
     }
   });
 });

--- a/extensions/slack/src/monitor/event-scope.ts
+++ b/extensions/slack/src/monitor/event-scope.ts
@@ -19,15 +19,26 @@ type SlackEventScopeResolution =
       ok: false;
       reason:
         | "enterprise_event_for_workspace_account"
-        | "missing_api_app_id"
         | "wrong_app"
         | "not_enterprise_install"
         | "missing_enterprise_id"
         | "wrong_enterprise"
         | "missing_team_id"
-        | "invalid_team_id"
         | "missing_listener_client";
     };
+
+export function resolveSlackListenerEventScope(
+  params: Parameters<typeof resolveSlackEventScope>[0] & {
+    onDrop?: (reason: Extract<SlackEventScopeResolution, { ok: false }>["reason"]) => void;
+  },
+): SlackEventScope | null | undefined {
+  const resolved = resolveSlackEventScope(params);
+  if (!resolved.ok) {
+    params.onDrop?.(resolved.reason);
+    return null;
+  }
+  return resolved.scope;
+}
 
 export function resolveSlackEventScope(params: {
   identity: SlackInstallationIdentity;
@@ -49,10 +60,7 @@ export function resolveSlackEventScope(params: {
   const body =
     params.body && typeof params.body === "object" ? (params.body as { api_app_id?: unknown }) : {};
   const apiAppId = normalizeOptionalString(body.api_app_id);
-  if (!apiAppId) {
-    return { ok: false, reason: "missing_api_app_id" };
-  }
-  if (params.identity.apiAppId && apiAppId !== params.identity.apiAppId) {
+  if (apiAppId && params.identity.apiAppId && apiAppId !== params.identity.apiAppId) {
     return { ok: false, reason: "wrong_app" };
   }
   if (context.isEnterpriseInstall !== true) {
@@ -68,9 +76,6 @@ export function resolveSlackEventScope(params: {
   const teamId = normalizeOptionalString(context.teamId);
   if (!teamId) {
     return { ok: false, reason: "missing_team_id" };
-  }
-  if (!/^T[A-Z0-9]+$/i.test(teamId)) {
-    return { ok: false, reason: "invalid_team_id" };
   }
   if (!params.client) {
     return { ok: false, reason: "missing_listener_client" };

--- a/extensions/slack/src/monitor/events.enterprise.test.ts
+++ b/extensions/slack/src/monitor/events.enterprise.test.ts
@@ -8,6 +8,7 @@ const registrations = vi.hoisted(() => ({
   agent: vi.fn(),
   assistant: vi.fn(),
   channel: vi.fn(),
+  channelIdChanged: vi.fn(),
   home: vi.fn(),
   interaction: vi.fn(),
   member: vi.fn(),
@@ -20,7 +21,10 @@ vi.mock("./events/agent.js", () => ({ registerSlackAgentEvents: registrations.ag
 vi.mock("./events/assistant.js", () => ({
   registerSlackAssistantEvents: registrations.assistant,
 }));
-vi.mock("./events/channels.js", () => ({ registerSlackChannelEvents: registrations.channel }));
+vi.mock("./events/channels.js", () => ({
+  registerSlackChannelEvents: registrations.channel,
+  registerSlackChannelIdChangedEvent: registrations.channelIdChanged,
+}));
 vi.mock("./events/home.js", () => ({ registerSlackHomeEvents: registrations.home }));
 vi.mock("./events/interactions.js", () => ({
   registerSlackInteractionEvents: registrations.interaction,
@@ -57,17 +61,18 @@ describe("registerSlackMonitorEvents", () => {
     }
   });
 
-  it("registers messages, reactions, pins, and member events for enterprise installs", () => {
+  it("registers workspace-safe events for enterprise installs", () => {
     registerForInstallation("enterprise");
 
     expect(registrations.message).toHaveBeenCalledOnce();
     expect(registrations.reaction).toHaveBeenCalledOnce();
     expect(registrations.pin).toHaveBeenCalledOnce();
     expect(registrations.member).toHaveBeenCalledOnce();
-    expect(registrations.channel).not.toHaveBeenCalled();
+    expect(registrations.channel).toHaveBeenCalledOnce();
+    expect(registrations.channelIdChanged).not.toHaveBeenCalled();
     expect(registrations.home).not.toHaveBeenCalled();
     expect(registrations.agent).not.toHaveBeenCalled();
-    expect(registrations.interaction).not.toHaveBeenCalled();
+    expect(registrations.interaction).toHaveBeenCalledOnce();
     expect(registrations.assistant).not.toHaveBeenCalled();
   });
 

--- a/extensions/slack/src/monitor/events.ts
+++ b/extensions/slack/src/monitor/events.ts
@@ -3,7 +3,10 @@ import type { ResolvedSlackAccount } from "../accounts.js";
 import type { SlackMonitorContext } from "./context.js";
 import { registerSlackAgentEvents } from "./events/agent.js";
 import { registerSlackAssistantEvents } from "./events/assistant.js";
-import { registerSlackChannelEvents } from "./events/channels.js";
+import {
+  registerSlackChannelEvents,
+  registerSlackChannelIdChangedEvent,
+} from "./events/channels.js";
 import { registerSlackHomeEvents } from "./events/home.js";
 import { registerSlackInteractionEvents } from "./events/interactions.js";
 import { registerSlackMemberEvents } from "./events/members.js";
@@ -27,16 +30,17 @@ export function registerSlackMonitorEvents(params: {
   registerSlackReactionEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
   registerSlackPinEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
   registerSlackMemberEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
+  registerSlackChannelEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
+  registerSlackInteractionEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
   if (params.ctx.installationIdentity.kind === "enterprise") {
     return;
   }
-  registerSlackChannelEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
+  registerSlackChannelIdChangedEvent({ ctx: params.ctx, trackEvent: params.trackEvent });
   registerSlackHomeEvents({
     ctx: params.ctx,
     slashCommandName: params.appHomeSlashCommandName,
     trackEvent: params.trackEvent,
   });
   registerSlackAgentEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
-  registerSlackInteractionEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
   registerSlackAssistantEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
 }

--- a/extensions/slack/src/monitor/events/channels.test.ts
+++ b/extensions/slack/src/monitor/events/channels.test.ts
@@ -1,8 +1,10 @@
 // Slack tests cover channels plugin behavior.
+import type { AllMiddlewareArgs } from "@slack/bolt";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const enqueueSystemEventMock = vi.hoisted(() => vi.fn());
 let registerSlackChannelEvents: typeof import("./channels.js").registerSlackChannelEvents;
+let registerSlackChannelIdChangedEvent: typeof import("./channels.js").registerSlackChannelIdChangedEvent;
 let createSlackSystemEventTestHarness: typeof import("./system-event-test-harness.js").createSlackSystemEventTestHarness;
 
 vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
@@ -11,6 +13,8 @@ vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
 type SlackChannelHandler = (args: {
   event: Record<string, unknown>;
   body: unknown;
+  context?: Record<string, unknown>;
+  client?: AllMiddlewareArgs["client"];
 }) => Promise<void>;
 
 function createChannelContext(params?: {
@@ -22,6 +26,7 @@ function createChannelContext(params?: {
     harness.ctx.shouldDropMismatchedSlackEvent = params.shouldDropMismatchedSlackEvent;
   }
   registerSlackChannelEvents({ ctx: harness.ctx, trackEvent: params?.trackEvent });
+  registerSlackChannelIdChangedEvent({ ctx: harness.ctx, trackEvent: params?.trackEvent });
   return {
     getCreatedHandler: () => harness.getHandler("channel_created") as SlackChannelHandler | null,
   };
@@ -36,7 +41,8 @@ function requireChannelHandler(handler: SlackChannelHandler | null): SlackChanne
 
 describe("registerSlackChannelEvents", () => {
   beforeAll(async () => {
-    ({ registerSlackChannelEvents } = await import("./channels.js"));
+    ({ registerSlackChannelEvents, registerSlackChannelIdChangedEvent } =
+      await import("./channels.js"));
     ({ createSlackSystemEventTestHarness } = await import("./system-event-test-harness.js"));
   });
 
@@ -80,5 +86,150 @@ describe("registerSlackChannelEvents", () => {
       sessionKey: "agent:main:main",
       contextKey: "slack:channel:created:C1",
     });
+  });
+
+  it("keeps enterprise channel notifications isolated by listener workspace", async () => {
+    const { ctx, getHandler } = createChannelContext();
+    ctx.installationIdentity = {
+      kind: "enterprise",
+      apiAppId: "A_GRID",
+      enterpriseId: "E_GRID",
+    };
+    const resolveSessionKey = vi.fn(
+      (input: Parameters<typeof ctx.resolveSlackSystemEventSessionKey>[0]) =>
+        `session:${input.eventScope?.teamId ?? "workspace"}`,
+    );
+    ctx.resolveSlackSystemEventSessionKey = resolveSessionKey;
+
+    const cases = [
+      {
+        name: "channel_created",
+        event: { channel: { id: "C1", name: "general" } },
+        message: "Slack channel created: #general.",
+        kind: "created",
+      },
+      {
+        name: "channel_rename",
+        event: { channel: { id: "C1", name: "old-name", name_normalized: "new-name" } },
+        message: "Slack channel renamed: #new-name.",
+        kind: "renamed",
+      },
+    ] as const;
+
+    for (const teamId of ["T111", "T222"]) {
+      for (const eventCase of cases) {
+        const handler = requireChannelHandler(getHandler(eventCase.name));
+        await handler({
+          event: eventCase.event,
+          body: { api_app_id: "A_GRID", event_id: `Ev-${eventCase.name}-${teamId}` },
+          context: {
+            isEnterpriseInstall: true,
+            enterpriseId: "E_GRID",
+            teamId,
+          },
+          client: { token: `listener-${teamId}` } as AllMiddlewareArgs["client"],
+        });
+      }
+    }
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(4);
+    for (const [index, teamId] of ["T111", "T222"].entries()) {
+      for (const [caseIndex, eventCase] of cases.entries()) {
+        expect(enqueueSystemEventMock).toHaveBeenNthCalledWith(
+          index * cases.length + caseIndex + 1,
+          eventCase.message,
+          {
+            sessionKey: `session:${teamId}`,
+            contextKey: `slack:channel:${teamId}:${eventCase.kind}:C1:Ev-${eventCase.name}-${teamId}`,
+          },
+        );
+      }
+    }
+  });
+
+  it.each(["channel_created", "channel_rename"])(
+    "rejects enterprise %s events without validated listener scope",
+    async (eventName) => {
+      const trackEvent = vi.fn();
+      const { ctx, getHandler } = createChannelContext({ trackEvent });
+      ctx.installationIdentity = {
+        kind: "enterprise",
+        apiAppId: "A_GRID",
+        enterpriseId: "E_GRID",
+      };
+      const handler = requireChannelHandler(getHandler(eventName));
+
+      await handler({
+        event: { channel: { id: "C1", name: "general" } },
+        body: { api_app_id: "A_GRID", event_id: `Ev-${eventName}` },
+        context: {
+          isEnterpriseInstall: true,
+          enterpriseId: "E_GRID",
+        },
+        client: { token: "listener" } as AllMiddlewareArgs["client"],
+      });
+
+      expect(trackEvent).not.toHaveBeenCalled();
+      expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps live config unchanged when channel-ID persistence fails, then retries", async () => {
+    const oldChannelId = "C_OLD";
+    const newChannelId = "C_NEW";
+    const initialConfig = {
+      channels: { slack: { channels: { [oldChannelId]: { enabled: true } } } },
+    };
+    let persistedConfig = structuredClone(initialConfig);
+    const persistenceError = new Error("disk full");
+    readConfigSnapshotMock.mockImplementation(async () => ({
+      snapshot: {
+        hash: "base-hash",
+        sourceConfig: structuredClone(persistedConfig),
+      },
+    }));
+    mutateConfigFileMock
+      .mockRejectedValueOnce(persistenceError)
+      .mockImplementationOnce(
+        async (params: { mutate: (draft: typeof initialConfig) => unknown }) => {
+          const draft = structuredClone(persistedConfig);
+          const result = params.mutate(draft);
+          persistedConfig = draft;
+          return { result, nextConfig: draft };
+        },
+      );
+    const { ctx, getHandler } = createChannelContext();
+    ctx.cfg = structuredClone(initialConfig) as never;
+    ctx.accountId = "default";
+    ctx.runtime.error = vi.fn();
+    const handler = requireChannelHandler(getHandler("channel_id_changed"));
+    const turnAdoptionLifecycle = {
+      admission: "exclusive",
+      abortSignal: new AbortController().signal,
+      onAdopted: vi.fn(),
+      onDeferred: vi.fn(),
+      onAbandoned: vi.fn(),
+    };
+    const args = {
+      event: {
+        type: "channel_id_changed",
+        old_channel_id: oldChannelId,
+        new_channel_id: newChannelId,
+      },
+      body: {},
+      context: { openclawIngressLifecycle: turnAdoptionLifecycle },
+    };
+
+    await expect(handler(args)).rejects.toBe(persistenceError);
+    expect(ctx.cfg.channels?.slack?.channels).toHaveProperty(oldChannelId);
+    expect(ctx.cfg.channels?.slack?.channels).not.toHaveProperty(newChannelId);
+    expect(persistedConfig.channels.slack.channels).toHaveProperty(oldChannelId);
+
+    await expect(handler(args)).resolves.toBeUndefined();
+    expect(ctx.cfg.channels?.slack?.channels).not.toHaveProperty(oldChannelId);
+    expect(ctx.cfg.channels?.slack?.channels).toHaveProperty(newChannelId);
+    expect(persistedConfig.channels.slack.channels).not.toHaveProperty(oldChannelId);
+    expect(persistedConfig.channels.slack.channels).toHaveProperty(newChannelId);
+    expect(mutateConfigFileMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/slack/src/monitor/events/channels.test.ts
+++ b/extensions/slack/src/monitor/events/channels.test.ts
@@ -10,6 +10,7 @@ let createSlackSystemEventTestHarness: typeof import("./system-event-test-harnes
 vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
   enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
 }));
+
 type SlackChannelHandler = (args: {
   event: Record<string, unknown>;
   body: unknown;
@@ -28,13 +29,14 @@ function createChannelContext(params?: {
   registerSlackChannelEvents({ ctx: harness.ctx, trackEvent: params?.trackEvent });
   registerSlackChannelIdChangedEvent({ ctx: harness.ctx, trackEvent: params?.trackEvent });
   return {
-    getCreatedHandler: () => harness.getHandler("channel_created") as SlackChannelHandler | null,
+    ctx: harness.ctx,
+    getHandler: (name: string) => harness.getHandler(name) as SlackChannelHandler | null,
   };
 }
 
 function requireChannelHandler(handler: SlackChannelHandler | null): SlackChannelHandler {
   if (!handler) {
-    throw new Error("expected Slack channel_created handler");
+    throw new Error("expected Slack channel handler");
   }
   return handler;
 }
@@ -52,11 +54,11 @@ describe("registerSlackChannelEvents", () => {
 
   it("does not track mismatched events", async () => {
     const trackEvent = vi.fn();
-    const { getCreatedHandler } = createChannelContext({
+    const { getHandler } = createChannelContext({
       trackEvent,
       shouldDropMismatchedSlackEvent: () => true,
     });
-    const createdHandler = requireChannelHandler(getCreatedHandler());
+    const createdHandler = requireChannelHandler(getHandler("channel_created"));
 
     await createdHandler({
       event: {
@@ -71,8 +73,8 @@ describe("registerSlackChannelEvents", () => {
 
   it("tracks accepted events", async () => {
     const trackEvent = vi.fn();
-    const { getCreatedHandler } = createChannelContext({ trackEvent });
-    const createdHandler = requireChannelHandler(getCreatedHandler());
+    const { getHandler } = createChannelContext({ trackEvent });
+    const createdHandler = requireChannelHandler(getHandler("channel_created"));
 
     await createdHandler({
       event: {
@@ -121,7 +123,7 @@ describe("registerSlackChannelEvents", () => {
         const handler = requireChannelHandler(getHandler(eventCase.name));
         await handler({
           event: eventCase.event,
-          body: { api_app_id: "A_GRID", event_id: `Ev-${eventCase.name}-${teamId}` },
+          body: { api_app_id: "A_GRID" },
           context: {
             isEnterpriseInstall: true,
             enterpriseId: "E_GRID",
@@ -140,7 +142,7 @@ describe("registerSlackChannelEvents", () => {
           eventCase.message,
           {
             sessionKey: `session:${teamId}`,
-            contextKey: `slack:channel:${teamId}:${eventCase.kind}:C1:Ev-${eventCase.name}-${teamId}`,
+            contextKey: `slack:channel:${teamId}:${eventCase.kind}:C1`,
           },
         );
       }
@@ -161,7 +163,7 @@ describe("registerSlackChannelEvents", () => {
 
       await handler({
         event: { channel: { id: "C1", name: "general" } },
-        body: { api_app_id: "A_GRID", event_id: `Ev-${eventName}` },
+        body: { api_app_id: "A_GRID" },
         context: {
           isEnterpriseInstall: true,
           enterpriseId: "E_GRID",
@@ -173,63 +175,4 @@ describe("registerSlackChannelEvents", () => {
       expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     },
   );
-
-  it("keeps live config unchanged when channel-ID persistence fails, then retries", async () => {
-    const oldChannelId = "C_OLD";
-    const newChannelId = "C_NEW";
-    const initialConfig = {
-      channels: { slack: { channels: { [oldChannelId]: { enabled: true } } } },
-    };
-    let persistedConfig = structuredClone(initialConfig);
-    const persistenceError = new Error("disk full");
-    readConfigSnapshotMock.mockImplementation(async () => ({
-      snapshot: {
-        hash: "base-hash",
-        sourceConfig: structuredClone(persistedConfig),
-      },
-    }));
-    mutateConfigFileMock
-      .mockRejectedValueOnce(persistenceError)
-      .mockImplementationOnce(
-        async (params: { mutate: (draft: typeof initialConfig) => unknown }) => {
-          const draft = structuredClone(persistedConfig);
-          const result = params.mutate(draft);
-          persistedConfig = draft;
-          return { result, nextConfig: draft };
-        },
-      );
-    const { ctx, getHandler } = createChannelContext();
-    ctx.cfg = structuredClone(initialConfig) as never;
-    ctx.accountId = "default";
-    ctx.runtime.error = vi.fn();
-    const handler = requireChannelHandler(getHandler("channel_id_changed"));
-    const turnAdoptionLifecycle = {
-      admission: "exclusive",
-      abortSignal: new AbortController().signal,
-      onAdopted: vi.fn(),
-      onDeferred: vi.fn(),
-      onAbandoned: vi.fn(),
-    };
-    const args = {
-      event: {
-        type: "channel_id_changed",
-        old_channel_id: oldChannelId,
-        new_channel_id: newChannelId,
-      },
-      body: {},
-      context: { openclawIngressLifecycle: turnAdoptionLifecycle },
-    };
-
-    await expect(handler(args)).rejects.toBe(persistenceError);
-    expect(ctx.cfg.channels?.slack?.channels).toHaveProperty(oldChannelId);
-    expect(ctx.cfg.channels?.slack?.channels).not.toHaveProperty(newChannelId);
-    expect(persistedConfig.channels.slack.channels).toHaveProperty(oldChannelId);
-
-    await expect(handler(args)).resolves.toBeUndefined();
-    expect(ctx.cfg.channels?.slack?.channels).not.toHaveProperty(oldChannelId);
-    expect(ctx.cfg.channels?.slack?.channels).toHaveProperty(newChannelId);
-    expect(persistedConfig.channels.slack.channels).not.toHaveProperty(oldChannelId);
-    expect(persistedConfig.channels.slack.channels).toHaveProperty(newChannelId);
-    expect(mutateConfigFileMock).toHaveBeenCalledTimes(2);
-  });
 });

--- a/extensions/slack/src/monitor/events/channels.ts
+++ b/extensions/slack/src/monitor/events/channels.ts
@@ -1,5 +1,5 @@
 // Slack plugin module implements channels behavior.
-import type { SlackEventMiddlewareArgs } from "@slack/bolt";
+import type { AllMiddlewareArgs, SlackEventMiddlewareArgs } from "@slack/bolt";
 import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-writes";
 import { mutateConfigFile } from "openclaw/plugin-sdk/config-mutation";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
@@ -10,7 +10,6 @@ import { migrateSlackChannelConfig } from "../../channel-migration.js";
 import { resolveSlackChannelLabel } from "../channel-config.js";
 import type { SlackMonitorContext } from "../context.js";
 import type { SlackEventScope } from "../event-scope.js";
-import { resolveSlackIngressTurnLifecycle } from "../ingress.js";
 import type {
   SlackChannelCreatedEvent,
   SlackChannelIdChangedEvent,
@@ -28,7 +27,6 @@ export function registerSlackChannelEvents(params: {
     kind: "created" | "renamed";
     channelId: string | undefined;
     channelName: string | undefined;
-    eventId: string;
     eventScope?: SlackEventScope;
   }) => {
     if (
@@ -52,59 +50,59 @@ export function registerSlackChannelEvents(params: {
     });
     enqueueSystemEvent(`Slack channel ${paramsLocal.kind}: ${label}.`, {
       sessionKey,
-      contextKey: `slack:channel:${paramsLocal.eventScope ? `${paramsLocal.eventScope.teamId}:` : ""}${paramsLocal.kind}:${paramsLocal.channelId ?? paramsLocal.channelName ?? "unknown"}:${paramsLocal.eventId}`,
+      contextKey: `slack:channel:${paramsLocal.eventScope ? `${paramsLocal.eventScope.teamId}:` : ""}${paramsLocal.kind}:${paramsLocal.channelId ?? paramsLocal.channelName ?? "unknown"}`,
     });
   };
 
   ctx.app.event(
     "channel_created",
     async (args: SlackEventMiddlewareArgs<"channel_created"> & AllMiddlewareArgs) => {
-      const { event, body, context, client } = args;
-      const eventScope = resolveSlackListenerEventScope({ ctx, body, context, client });
-      if (eventScope === null) {
-        return;
-      }
-      if (ctx.shouldDropMismatchedSlackEvent(body)) {
-        return;
-      }
-      trackEvent?.();
+      try {
+        const { event, body, context, client } = args;
+        const eventScope = resolveSlackListenerEventScope({ ctx, body, context, client });
+        if (eventScope === null) {
+          return;
+        }
+        if (ctx.shouldDropMismatchedSlackEvent(body)) {
+          return;
+        }
+        trackEvent?.();
 
-      const payload = event as SlackChannelCreatedEvent;
-      const channelId = payload.channel?.id;
-      const channelName = payload.channel?.name;
-      enqueueChannelSystemEvent({
-        kind: "created",
-        channelId,
-        channelName,
-        eventId: body.event_id,
-        eventScope,
-      });
+        const payload = event as SlackChannelCreatedEvent;
+        const channelId = payload.channel?.id;
+        const channelName = payload.channel?.name;
+        enqueueChannelSystemEvent({ kind: "created", channelId, channelName, eventScope });
+      } catch (err) {
+        ctx.runtime.error?.(
+          danger(`slack channel created handler failed: ${formatErrorMessage(err)}`),
+        );
+      }
     },
   );
 
   ctx.app.event(
     "channel_rename",
     async (args: SlackEventMiddlewareArgs<"channel_rename"> & AllMiddlewareArgs) => {
-      const { event, body, context, client } = args;
-      const eventScope = resolveSlackListenerEventScope({ ctx, body, context, client });
-      if (eventScope === null) {
-        return;
-      }
-      if (ctx.shouldDropMismatchedSlackEvent(body)) {
-        return;
-      }
-      trackEvent?.();
+      try {
+        const { event, body, context, client } = args;
+        const eventScope = resolveSlackListenerEventScope({ ctx, body, context, client });
+        if (eventScope === null) {
+          return;
+        }
+        if (ctx.shouldDropMismatchedSlackEvent(body)) {
+          return;
+        }
+        trackEvent?.();
 
-      const payload = event as SlackChannelRenamedEvent;
-      const channelId = payload.channel?.id;
-      const channelName = payload.channel?.name_normalized ?? payload.channel?.name;
-      enqueueChannelSystemEvent({
-        kind: "renamed",
-        channelId,
-        channelName,
-        eventId: body.event_id,
-        eventScope,
-      });
+        const payload = event as SlackChannelRenamedEvent;
+        const channelId = payload.channel?.id;
+        const channelName = payload.channel?.name_normalized ?? payload.channel?.name;
+        enqueueChannelSystemEvent({ kind: "renamed", channelId, channelName, eventScope });
+      } catch (err) {
+        ctx.runtime.error?.(
+          danger(`slack channel rename handler failed: ${formatErrorMessage(err)}`),
+        );
+      }
     },
   );
 }

--- a/extensions/slack/src/monitor/events/channels.ts
+++ b/extensions/slack/src/monitor/events/channels.ts
@@ -9,11 +9,14 @@ import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { migrateSlackChannelConfig } from "../../channel-migration.js";
 import { resolveSlackChannelLabel } from "../channel-config.js";
 import type { SlackMonitorContext } from "../context.js";
+import type { SlackEventScope } from "../event-scope.js";
+import { resolveSlackIngressTurnLifecycle } from "../ingress.js";
 import type {
   SlackChannelCreatedEvent,
   SlackChannelIdChangedEvent,
   SlackChannelRenamedEvent,
 } from "../types.js";
+import { resolveSlackListenerEventScope } from "./system-event-context.js";
 
 export function registerSlackChannelEvents(params: {
   ctx: SlackMonitorContext;
@@ -25,6 +28,8 @@ export function registerSlackChannelEvents(params: {
     kind: "created" | "renamed";
     channelId: string | undefined;
     channelName: string | undefined;
+    eventId: string;
+    eventScope?: SlackEventScope;
   }) => {
     if (
       !ctx.isChannelAllowed({
@@ -43,54 +48,72 @@ export function registerSlackChannelEvents(params: {
     const sessionKey = ctx.resolveSlackSystemEventSessionKey({
       channelId: paramsLocal.channelId,
       channelType: "channel",
+      eventScope: paramsLocal.eventScope,
     });
     enqueueSystemEvent(`Slack channel ${paramsLocal.kind}: ${label}.`, {
       sessionKey,
-      contextKey: `slack:channel:${paramsLocal.kind}:${paramsLocal.channelId ?? paramsLocal.channelName ?? "unknown"}`,
+      contextKey: `slack:channel:${paramsLocal.eventScope ? `${paramsLocal.eventScope.teamId}:` : ""}${paramsLocal.kind}:${paramsLocal.channelId ?? paramsLocal.channelName ?? "unknown"}:${paramsLocal.eventId}`,
     });
   };
 
   ctx.app.event(
     "channel_created",
-    async ({ event, body }: SlackEventMiddlewareArgs<"channel_created">) => {
-      try {
-        if (ctx.shouldDropMismatchedSlackEvent(body)) {
-          return;
-        }
-        trackEvent?.();
-
-        const payload = event as SlackChannelCreatedEvent;
-        const channelId = payload.channel?.id;
-        const channelName = payload.channel?.name;
-        enqueueChannelSystemEvent({ kind: "created", channelId, channelName });
-      } catch (err) {
-        ctx.runtime.error?.(
-          danger(`slack channel created handler failed: ${formatErrorMessage(err)}`),
-        );
+    async (args: SlackEventMiddlewareArgs<"channel_created"> & AllMiddlewareArgs) => {
+      const { event, body, context, client } = args;
+      const eventScope = resolveSlackListenerEventScope({ ctx, body, context, client });
+      if (eventScope === null) {
+        return;
       }
+      if (ctx.shouldDropMismatchedSlackEvent(body)) {
+        return;
+      }
+      trackEvent?.();
+
+      const payload = event as SlackChannelCreatedEvent;
+      const channelId = payload.channel?.id;
+      const channelName = payload.channel?.name;
+      enqueueChannelSystemEvent({
+        kind: "created",
+        channelId,
+        channelName,
+        eventId: body.event_id,
+        eventScope,
+      });
     },
   );
 
   ctx.app.event(
     "channel_rename",
-    async ({ event, body }: SlackEventMiddlewareArgs<"channel_rename">) => {
-      try {
-        if (ctx.shouldDropMismatchedSlackEvent(body)) {
-          return;
-        }
-        trackEvent?.();
-
-        const payload = event as SlackChannelRenamedEvent;
-        const channelId = payload.channel?.id;
-        const channelName = payload.channel?.name_normalized ?? payload.channel?.name;
-        enqueueChannelSystemEvent({ kind: "renamed", channelId, channelName });
-      } catch (err) {
-        ctx.runtime.error?.(
-          danger(`slack channel rename handler failed: ${formatErrorMessage(err)}`),
-        );
+    async (args: SlackEventMiddlewareArgs<"channel_rename"> & AllMiddlewareArgs) => {
+      const { event, body, context, client } = args;
+      const eventScope = resolveSlackListenerEventScope({ ctx, body, context, client });
+      if (eventScope === null) {
+        return;
       }
+      if (ctx.shouldDropMismatchedSlackEvent(body)) {
+        return;
+      }
+      trackEvent?.();
+
+      const payload = event as SlackChannelRenamedEvent;
+      const channelId = payload.channel?.id;
+      const channelName = payload.channel?.name_normalized ?? payload.channel?.name;
+      enqueueChannelSystemEvent({
+        kind: "renamed",
+        channelId,
+        channelName,
+        eventId: body.event_id,
+        eventScope,
+      });
     },
   );
+}
+
+export function registerSlackChannelIdChangedEvent(params: {
+  ctx: SlackMonitorContext;
+  trackEvent?: () => void;
+}) {
+  const { ctx, trackEvent } = params;
 
   ctx.app.event(
     "channel_id_changed",

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -1,5 +1,5 @@
 // Slack plugin module implements interactions.block actions behavior.
-import type { SlackActionMiddlewareArgs } from "@slack/bolt";
+import type { AllMiddlewareArgs, SlackActionMiddlewareArgs } from "@slack/bolt";
 import type { Block, KnownBlock } from "@slack/web-api";
 import { resolveApprovalOverGateway } from "openclaw/plugin-sdk/approval-gateway-runtime";
 import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
@@ -41,6 +41,8 @@ import {
   parsePluginBindingApprovalCustomId,
   resolvePluginConversationBindingApproval,
 } from "../conversation.runtime.js";
+import { resolveSlackDeferredActionTarget } from "../deferred-action-routing.js";
+import { resolveSlackListenerEventScope, type SlackEventScope } from "../event-scope.js";
 import { escapeSlackMrkdwn } from "../mrkdwn.js";
 
 type InteractionMessageBlock = {
@@ -110,6 +112,8 @@ type SlackBlockActionBody = {
 };
 
 type SlackBlockActionRespond = NonNullable<SlackActionMiddlewareArgs["respond"]>;
+type SlackBlockActionHandlerArgs = SlackActionMiddlewareArgs &
+  Pick<AllMiddlewareArgs, "context" | "client">;
 
 type ParsedSlackBlockAction = {
   typedBody: SlackBlockActionBody;
@@ -475,6 +479,7 @@ async function respondEphemeral(
 
 async function updateSlackInteractionMessage(params: {
   ctx: SlackMonitorContext;
+  eventScope?: SlackEventScope;
   channelId?: string;
   messageTs?: string;
   text: string;
@@ -483,7 +488,7 @@ async function updateSlackInteractionMessage(params: {
   if (!params.channelId || !params.messageTs) {
     return;
   }
-  await params.ctx.app.client.chat.update({
+  await (params.eventScope?.client ?? params.ctx.app.client).chat.update({
     channel: params.channelId,
     ts: params.messageTs,
     text: params.text,
@@ -550,6 +555,7 @@ function buildSlackApprovalTerminalBlocks(params: {
 
 async function authorizeSlackBlockAction(params: {
   ctx: SlackMonitorContext;
+  eventScope?: SlackEventScope;
   parsed: ParsedSlackBlockAction;
   respond?: SlackBlockActionRespond;
 }): Promise<
@@ -561,8 +567,10 @@ async function authorizeSlackBlockAction(params: {
 > {
   const auth = await authorizeSlackSystemEventSender({
     ctx: params.ctx,
+    eventScope: params.eventScope,
     senderId: params.parsed.userId,
     channelId: params.parsed.channelId,
+    channelType: params.parsed.channelId ? undefined : "im",
     // Block action sender identity is verified by Slack's request signing.
     // Pass the Slack-verified userId as expectedSenderId to satisfy the
     // mandatory actor-binding requirement for interactive events.
@@ -581,6 +589,7 @@ async function authorizeSlackBlockAction(params: {
 
 async function handleSlackPluginBindingApproval(params: {
   ctx: SlackMonitorContext;
+  eventScope?: SlackEventScope;
   parsed: ParsedSlackBlockAction;
   pluginInteractionData: string;
   respond?: SlackBlockActionRespond;
@@ -597,6 +606,7 @@ async function handleSlackPluginBindingApproval(params: {
   try {
     await updateSlackInteractionMessage({
       ctx: params.ctx,
+      eventScope: params.eventScope,
       channelId: params.parsed.channelId,
       messageTs: params.parsed.messageTs,
       text: params.parsed.typedBody.message?.text ?? "",
@@ -611,6 +621,7 @@ async function handleSlackPluginBindingApproval(params: {
 
 async function handleSlackApprovalInteraction(params: {
   ctx: SlackMonitorContext;
+  eventScope?: SlackEventScope;
   parsed: ParsedSlackBlockAction;
   approval: SlackApprovalAction;
   respond?: SlackBlockActionRespond;
@@ -655,6 +666,7 @@ async function handleSlackApprovalInteraction(params: {
       const terminalText = `${prefix}: ${terminalLabel}`;
       await updateSlackInteractionMessage({
         ctx: params.ctx,
+        eventScope: params.eventScope,
         channelId: params.parsed.channelId,
         messageTs: params.parsed.messageTs,
         text: truncateSlackText(terminalText, 4000),
@@ -697,6 +709,7 @@ async function handleSlackApprovalInteraction(params: {
 
 async function handleSlackLegacyApprovalInteraction(params: {
   ctx: SlackMonitorContext;
+  eventScope?: SlackEventScope;
   parsed: ParsedSlackBlockAction;
   pluginInteractionData: string;
   respond?: SlackBlockActionRespond;
@@ -743,6 +756,7 @@ async function handleSlackLegacyApprovalInteraction(params: {
       try {
         await updateSlackInteractionMessage({
           ctx: params.ctx,
+          eventScope: params.eventScope,
           channelId: params.parsed.channelId,
           messageTs: params.parsed.messageTs,
           text: params.parsed.typedBody.message?.text ?? "",
@@ -767,6 +781,7 @@ async function handleSlackLegacyApprovalInteraction(params: {
 
 async function dispatchSlackPluginInteraction(params: {
   ctx: SlackMonitorContext;
+  eventScope?: SlackEventScope;
   parsed: ParsedSlackBlockAction;
   pluginInteractionData: string;
   auth: { isAuthorizedSender: boolean };
@@ -784,6 +799,7 @@ async function dispatchSlackPluginInteraction(params: {
   if (
     await handleSlackPluginBindingApproval({
       ctx: params.ctx,
+      eventScope: params.eventScope,
       parsed: params.parsed,
       pluginInteractionData: params.pluginInteractionData,
       respond: params.respond,
@@ -794,6 +810,7 @@ async function dispatchSlackPluginInteraction(params: {
   const pluginResult = await dispatchSlackPluginInteractiveHandler({
     data: params.pluginInteractionData,
     interactionId: pluginInteractionId,
+    teamId: params.eventScope?.teamId,
     channelType: params.channelType,
     ctx: {
       accountId: params.ctx.accountId,
@@ -840,6 +857,7 @@ async function dispatchSlackPluginInteraction(params: {
       editMessage: async ({ text, blocks }) => {
         await updateSlackInteractionMessage({
           ctx: params.ctx,
+          eventScope: params.eventScope,
           channelId: params.parsed.channelId,
           messageTs: params.parsed.messageTs,
           text: text ?? params.parsed.typedBody.message?.text ?? "",
@@ -853,6 +871,7 @@ async function dispatchSlackPluginInteraction(params: {
 
 async function resolveSlackBlockActionCommandAuthorized(params: {
   ctx: SlackMonitorContext;
+  eventScope?: SlackEventScope;
   parsed: ParsedSlackBlockAction;
   auth: { channelType?: "im" | "mpim" | "channel" | "group"; channelName?: string };
 }): Promise<boolean> {
@@ -882,7 +901,9 @@ async function resolveSlackBlockActionCommandAuthorized(params: {
   const allowFromLower = await resolveSlackEffectiveAllowFrom(params.ctx, {
     includePairingStore: isDirectMessage,
   });
-  const sender = await params.ctx.resolveUserName(params.parsed.userId).catch(() => undefined);
+  const sender = await params.ctx
+    .resolveUserName(params.parsed.userId, params.eventScope)
+    .catch(() => undefined);
   const senderName = sender?.name;
 
   let channelUsers: Array<string | number> = [];
@@ -916,17 +937,28 @@ async function resolveSlackBlockActionCommandAuthorized(params: {
 
 function enqueueSlackBlockActionEvent(params: {
   ctx: SlackMonitorContext;
+  eventScope?: SlackEventScope;
+  teamId?: string;
   parsed: ParsedSlackBlockAction;
   auth: { channelType?: "im" | "mpim" | "channel" | "group" };
   formatSystemEvent: (payload: Record<string, unknown>) => string;
 }): void {
+  const targetKind = params.auth.channelType === "im" ? "user" : "channel";
+  const targetId = targetKind === "user" ? params.parsed.userId : params.parsed.channelId;
+  const deferredTarget = targetId
+    ? resolveSlackDeferredActionTarget({
+        eventScope: params.eventScope,
+        kind: targetKind,
+        id: targetId,
+      })
+    : undefined;
   const eventPayload: InteractionSummary = {
     interactionType: "block_action",
     actionId: params.parsed.actionId,
     blockId: params.parsed.blockId,
     ...params.parsed.actionSummary,
     userId: params.parsed.userId,
-    teamId: params.parsed.typedBody.team?.id,
+    teamId: params.teamId,
     triggerId: params.parsed.typedBody.trigger_id,
     responseUrl: params.parsed.typedBody.response_url,
     channelId: params.parsed.channelId,
@@ -941,9 +973,11 @@ function enqueueSlackBlockActionEvent(params: {
     channelType: params.auth.channelType,
     senderId: params.parsed.userId,
     threadTs: params.parsed.threadTs,
+    eventScope: params.eventScope,
   });
   const contextParts = [
     "slack:interaction",
+    params.teamId,
     params.parsed.channelId,
     params.parsed.messageTs,
     params.parsed.actionId,
@@ -953,12 +987,7 @@ function enqueueSlackBlockActionEvent(params: {
     contextKey: contextParts.join(":"),
     deliveryContext: {
       channel: "slack",
-      to:
-        params.auth.channelType === "im"
-          ? `user:${params.parsed.userId}`
-          : params.parsed.channelId
-            ? `channel:${params.parsed.channelId}`
-            : undefined,
+      to: deferredTarget?.target,
       accountId: params.ctx.accountId,
       threadId: params.parsed.threadTs,
     },
@@ -1005,6 +1034,7 @@ function buildSlackConfirmationBlocks(params: {
 
 async function updateSlackLegacyBlockAction(params: {
   ctx: SlackMonitorContext;
+  eventScope?: SlackEventScope;
   parsed: ParsedSlackBlockAction;
   respond?: SlackBlockActionRespond;
 }): Promise<void> {
@@ -1020,6 +1050,7 @@ async function updateSlackLegacyBlockAction(params: {
   try {
     await updateSlackInteractionMessage({
       ctx: params.ctx,
+      eventScope: params.eventScope,
       channelId: params.parsed.channelId,
       messageTs: params.parsed.messageTs,
       text: params.parsed.typedBody.message?.text ?? "",
@@ -1036,11 +1067,22 @@ async function updateSlackLegacyBlockAction(params: {
 async function handleSlackBlockAction(params: {
   ctx: SlackMonitorContext;
   trackEvent?: () => void;
-  args: SlackActionMiddlewareArgs;
+  args: SlackBlockActionHandlerArgs;
   formatSystemEvent: (payload: Record<string, unknown>) => string;
 }): Promise<void> {
   const { ack, body, action, respond } = params.args;
   await ack();
+  const eventScope = resolveSlackListenerEventScope({
+    identity: params.ctx.installationIdentity,
+    body,
+    context: params.args.context,
+    client: params.args.client,
+    clientOptions: params.ctx.app.webClientOptions,
+    onDrop: (reason) => params.ctx.runtime.log?.(`slack:interaction drop action ${reason}`),
+  });
+  if (eventScope === null) {
+    return;
+  }
   if (params.ctx.shouldDropMismatchedSlackEvent?.(body)) {
     params.ctx.runtime.log?.("slack:interaction drop block action payload (mismatched app/team)");
     return;
@@ -1069,6 +1111,7 @@ async function handleSlackBlockAction(params: {
     }
     await handleSlackApprovalInteraction({
       ctx: params.ctx,
+      eventScope,
       parsed,
       approval,
       respond,
@@ -1081,7 +1124,12 @@ async function handleSlackBlockAction(params: {
       await respondEphemeral(respond, "This question action is invalid or expired.");
       return;
     }
-    const auth = await authorizeSlackBlockAction({ ctx: params.ctx, parsed, respond });
+    const auth = await authorizeSlackBlockAction({
+      ctx: params.ctx,
+      eventScope,
+      parsed,
+      respond,
+    });
     if (!auth.allowed) {
       return;
     }
@@ -1101,6 +1149,7 @@ async function handleSlackBlockAction(params: {
   if (pluginInteractionData && isSlackReplyActionId(parsed.actionId)) {
     const handledExecApproval = await handleSlackLegacyApprovalInteraction({
       ctx: params.ctx,
+      eventScope,
       parsed,
       pluginInteractionData,
       respond,
@@ -1111,6 +1160,7 @@ async function handleSlackBlockAction(params: {
   }
   const auth = await authorizeSlackBlockAction({
     ctx: params.ctx,
+    eventScope,
     parsed,
     respond,
   });
@@ -1120,6 +1170,7 @@ async function handleSlackBlockAction(params: {
   if (pluginInteractionData && isSlackReplyActionId(parsed.actionId)) {
     const handledBindingApproval = await handleSlackPluginBindingApproval({
       ctx: params.ctx,
+      eventScope,
       parsed,
       pluginInteractionData,
       respond,
@@ -1130,11 +1181,13 @@ async function handleSlackBlockAction(params: {
   } else if (pluginInteractionData) {
     const isAuthorizedSender = await resolveSlackBlockActionCommandAuthorized({
       ctx: params.ctx,
+      eventScope,
       parsed,
       auth,
     });
     const handled = await dispatchSlackPluginInteraction({
       ctx: params.ctx,
+      eventScope,
       parsed,
       pluginInteractionData,
       auth: {
@@ -1149,12 +1202,15 @@ async function handleSlackBlockAction(params: {
   }
   enqueueSlackBlockActionEvent({
     ctx: params.ctx,
+    eventScope,
+    teamId: params.args.context.teamId,
     parsed,
     auth,
     formatSystemEvent: params.formatSystemEvent,
   });
   await updateSlackLegacyBlockAction({
     ctx: params.ctx,
+    eventScope,
     parsed,
     respond,
   });
@@ -1168,7 +1224,7 @@ export function registerSlackBlockActionHandler(params: {
   if (typeof params.ctx.app.action !== "function") {
     return;
   }
-  params.ctx.app.action(/.+/, async (args: SlackActionMiddlewareArgs) => {
+  params.ctx.app.action(/.+/, async (args: SlackBlockActionHandlerArgs) => {
     await handleSlackBlockAction({
       ctx: params.ctx,
       trackEvent: params.trackEvent,

--- a/extensions/slack/src/monitor/events/interactions.modal.ts
+++ b/extensions/slack/src/monitor/events/interactions.modal.ts
@@ -1,15 +1,17 @@
 // Slack plugin module implements interactions.modal behavior.
+import type { AllMiddlewareArgs } from "@slack/bolt";
 import { requestHeartbeat } from "openclaw/plugin-sdk/heartbeat-runtime";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { dispatchSlackPluginInteractiveHandler } from "../../interactive-dispatch.js";
 import { parseSlackModalPrivateMetadata } from "../../modal-metadata.js";
 import { authorizeSlackSystemEventSender } from "../auth.js";
 import type { SlackMonitorContext } from "../context.js";
+import { resolveSlackDeferredActionTarget } from "../deferred-action-routing.js";
+import { resolveSlackListenerEventScope, type SlackEventScope } from "../event-scope.js";
 import type { ModalInputSummary } from "./modal-input-summary.js";
 
 type SlackModalBody = {
   user?: { id?: string };
-  team?: { id?: string };
   trigger_id?: string;
   view?: {
     id?: string;
@@ -50,7 +52,10 @@ type SlackModalEventBase = {
 };
 
 type SlackModalInteractionKind = "view_submission" | "view_closed";
-type SlackModalEventHandlerArgs = { ack: () => Promise<void>; body: unknown };
+type SlackModalEventHandlerArgs = { ack: () => Promise<void>; body: unknown } & Pick<
+  AllMiddlewareArgs,
+  "context" | "client"
+>;
 type RegisterSlackModalHandler = (
   matcher: RegExp,
   handler: (args: SlackModalEventHandlerArgs) => Promise<void>,
@@ -124,29 +129,44 @@ function resolveModalSessionRouting(params: {
   ctx: SlackMonitorContext;
   metadata: ReturnType<typeof parseSlackModalPrivateMetadata>;
   userId?: string;
+  eventScope?: SlackEventScope;
 }): { sessionKey: string; channelId?: string; channelType?: string } {
   const metadata = params.metadata;
-  if (metadata.sessionKey) {
+  if (metadata.sessionKey && !params.eventScope) {
     return {
       sessionKey: metadata.sessionKey,
       channelId: metadata.channelId,
       channelType: metadata.channelType,
     };
   }
-  if (metadata.channelId) {
-    return {
-      sessionKey: params.ctx.resolveSlackSystemEventSessionKey({
+  const routing = metadata.channelId
+    ? {
+        sessionKey: params.ctx.resolveSlackSystemEventSessionKey({
+          channelId: metadata.channelId,
+          channelType: metadata.channelType,
+          senderId: params.userId,
+          eventScope: params.eventScope,
+        }),
         channelId: metadata.channelId,
         channelType: metadata.channelType,
-        senderId: params.userId,
-      }),
-      channelId: metadata.channelId,
-      channelType: metadata.channelType,
-    };
+      }
+    : {
+        sessionKey: params.ctx.resolveSlackSystemEventSessionKey({
+          channelType: "im",
+          senderId: params.userId,
+          eventScope: params.eventScope,
+        }),
+        channelType: params.eventScope ? "im" : undefined,
+      };
+  if (
+    metadata.sessionKey &&
+    (metadata.sessionKey === routing.sessionKey ||
+      metadata.sessionKey.startsWith(`${routing.sessionKey}:thread:`))
+  ) {
+    // Preserve an exact thread only after its base is bound to this Enterprise workspace.
+    return { ...routing, sessionKey: metadata.sessionKey };
   }
-  return {
-    sessionKey: params.ctx.resolveSlackSystemEventSessionKey({}),
-  };
+  return routing;
 }
 
 function summarizeSlackViewLifecycleContext(view: {
@@ -177,6 +197,8 @@ function summarizeSlackViewLifecycleContext(view: {
 function resolveSlackModalEventBase(params: {
   ctx: SlackMonitorContext;
   body: SlackModalBody;
+  eventScope?: SlackEventScope;
+  teamId?: string;
   summarizeViewState: (values: unknown) => ModalInputSummary[];
 }): SlackModalEventBase {
   const metadata = parseSlackModalPrivateMetadata(params.body.view?.private_metadata);
@@ -188,6 +210,7 @@ function resolveSlackModalEventBase(params: {
     ctx: params.ctx,
     metadata,
     userId,
+    eventScope: params.eventScope,
   });
   return {
     callbackId,
@@ -201,7 +224,7 @@ function resolveSlackModalEventBase(params: {
       callbackId,
       viewId,
       userId,
-      teamId: params.body.team?.id,
+      teamId: params.teamId,
       ...summarizeSlackViewLifecycleContext({
         root_view_id: params.body.view?.root_view_id,
         previous_view_id: params.body.view?.previous_view_id,
@@ -219,6 +242,8 @@ function resolveSlackModalEventBase(params: {
 async function dispatchSlackModalPluginInteractiveHandler(params: {
   ctx: SlackMonitorContext;
   body: SlackModalBody;
+  eventScope?: SlackEventScope;
+  teamId?: string;
   interactionType: SlackModalInteractionKind;
   data: string | undefined;
   auth: { isAuthorizedSender: boolean };
@@ -249,6 +274,7 @@ async function dispatchSlackModalPluginInteractiveHandler(params: {
   const result = await dispatchSlackPluginInteractiveHandler({
     data: params.data,
     interactionId,
+    teamId: params.eventScope?.teamId,
     channelType: params.channelType,
     ctx: {
       accountId: params.ctx.accountId,
@@ -290,6 +316,8 @@ async function dispatchSlackModalPluginInteractiveHandler(params: {
 async function emitSlackModalLifecycleEvent(params: {
   ctx: SlackMonitorContext;
   body: SlackModalBody;
+  eventScope?: SlackEventScope;
+  teamId?: string;
   interactionType: SlackModalInteractionKind;
   contextPrefix: SlackInteractionContextPrefix;
   summarizeViewState: (values: unknown) => ModalInputSummary[];
@@ -299,6 +327,8 @@ async function emitSlackModalLifecycleEvent(params: {
     resolveSlackModalEventBase({
       ctx: params.ctx,
       body: params.body,
+      eventScope: params.eventScope,
+      teamId: params.teamId,
       summarizeViewState: params.summarizeViewState,
     });
   const metadata = parseSlackModalPrivateMetadata(params.body.view?.private_metadata);
@@ -335,6 +365,8 @@ async function emitSlackModalLifecycleEvent(params: {
         await dispatchSlackModalPluginInteractiveHandler({
           ctx: params.ctx,
           body: params.body,
+          eventScope: params.eventScope,
+          teamId: params.teamId,
           interactionType: params.interactionType,
           data: pluginInteractiveData,
           auth: { isAuthorizedSender: false },
@@ -356,6 +388,7 @@ async function emitSlackModalLifecycleEvent(params: {
 
   const auth = await authorizeSlackSystemEventSender({
     ctx: params.ctx,
+    eventScope: params.eventScope,
     senderId: userId,
     channelId: sessionRouting.channelId,
     channelType: sessionRouting.channelType,
@@ -376,6 +409,8 @@ async function emitSlackModalLifecycleEvent(params: {
     pluginDispatch = await dispatchSlackModalPluginInteractiveHandler({
       ctx: params.ctx,
       body: params.body,
+      eventScope: params.eventScope,
+      teamId: params.teamId,
       interactionType: params.interactionType,
       data: pluginInteractiveData,
       auth: { isAuthorizedSender: auth.allowed },
@@ -400,18 +435,26 @@ async function emitSlackModalLifecycleEvent(params: {
         }
       : {};
 
+  const targetKind = auth.channelType === "im" ? "user" : "channel";
+  const targetId = targetKind === "user" ? userId : sessionRouting.channelId;
+  const deferredTarget = targetId
+    ? resolveSlackDeferredActionTarget({
+        eventScope: params.eventScope,
+        kind: targetKind,
+        id: targetId,
+      })
+    : undefined;
+
   const queued = enqueueSystemEvent(
     params.formatSystemEvent({ ...eventPayload, ...pluginEventFields }),
     {
       sessionKey: sessionRouting.sessionKey,
-      contextKey: [params.contextPrefix, callbackId, viewId, userId].filter(Boolean).join(":"),
+      contextKey: [params.contextPrefix, params.teamId, callbackId, viewId, userId]
+        .filter(Boolean)
+        .join(":"),
       deliveryContext: {
         channel: "slack",
-        ...(auth.channelType === "im"
-          ? { to: `user:${userId}` }
-          : sessionRouting.channelId
-            ? { to: `channel:${sessionRouting.channelId}` }
-            : {}),
+        ...(deferredTarget ? { to: deferredTarget.target } : {}),
         accountId: params.ctx.accountId,
       },
     },
@@ -437,11 +480,24 @@ export function registerModalLifecycleHandler(params: {
   summarizeViewState: (values: unknown) => ModalInputSummary[];
   formatSystemEvent: (payload: Record<string, unknown>) => string;
 }) {
-  params.register(params.matcher, async ({ ack, body }: SlackModalEventHandlerArgs) => {
+  params.register(params.matcher, async (args: SlackModalEventHandlerArgs) => {
+    const { ack, body } = args;
     if (!shouldHandleSlackModalLifecycleBody(body)) {
       return;
     }
     await ack();
+    const eventScope = resolveSlackListenerEventScope({
+      identity: params.ctx.installationIdentity,
+      body,
+      context: args.context,
+      client: args.client,
+      clientOptions: params.ctx.app.webClientOptions,
+      onDrop: (reason) =>
+        params.ctx.runtime.log?.(`slack:interaction drop ${params.interactionType} ${reason}`),
+    });
+    if (eventScope === null) {
+      return;
+    }
     if (params.ctx.shouldDropMismatchedSlackEvent?.(body)) {
       params.ctx.runtime.log?.(
         `slack:interaction drop ${params.interactionType} payload (mismatched app/team)`,
@@ -449,9 +505,12 @@ export function registerModalLifecycleHandler(params: {
       return;
     }
     params.trackEvent?.();
+    const typedBody = body as SlackModalBody;
     await emitSlackModalLifecycleEvent({
       ctx: params.ctx,
-      body: body as SlackModalBody,
+      body: typedBody,
+      eventScope,
+      teamId: args.context.teamId,
       interactionType: params.interactionType,
       contextPrefix: params.contextPrefix,
       summarizeViewState: params.summarizeViewState,

--- a/extensions/slack/src/monitor/events/interactions.shortcuts.ts
+++ b/extensions/slack/src/monitor/events/interactions.shortcuts.ts
@@ -1,11 +1,20 @@
 // Slack plugin module implements shortcut interaction behavior.
-import type { GlobalShortcut, MessageShortcut, SlackShortcutMiddlewareArgs } from "@slack/bolt";
+import type {
+  AllMiddlewareArgs,
+  GlobalShortcut,
+  MessageShortcut,
+  SlackShortcutMiddlewareArgs,
+} from "@slack/bolt";
 import { requestHeartbeat } from "openclaw/plugin-sdk/heartbeat-runtime";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { authorizeSlackSystemEventSender } from "../auth.js";
 import type { SlackMonitorContext } from "../context.js";
+import { resolveSlackDeferredActionTarget } from "../deferred-action-routing.js";
+import { resolveSlackListenerEventScope } from "../event-scope.js";
 
 type SlackShortcutBody = GlobalShortcut | MessageShortcut;
+type SlackShortcutHandlerArgs = SlackShortcutMiddlewareArgs &
+  Pick<AllMiddlewareArgs, "context" | "client">;
 
 function resolveMessageThreadTs(body: MessageShortcut): string | undefined {
   const threadTs = body.message.thread_ts;
@@ -15,11 +24,22 @@ function resolveMessageThreadTs(body: MessageShortcut): string | undefined {
 async function handleSlackShortcut(params: {
   ctx: SlackMonitorContext;
   trackEvent?: () => void;
-  args: SlackShortcutMiddlewareArgs;
+  args: SlackShortcutHandlerArgs;
   formatSystemEvent: (payload: Record<string, unknown>) => string;
 }): Promise<void> {
   const { ack, body } = params.args;
   await ack();
+  const eventScope = resolveSlackListenerEventScope({
+    identity: params.ctx.installationIdentity,
+    body,
+    context: params.args.context,
+    client: params.args.client,
+    clientOptions: params.ctx.app.webClientOptions,
+    onDrop: (reason) => params.ctx.runtime.log?.(`slack:interaction drop shortcut ${reason}`),
+  });
+  if (eventScope === null) {
+    return;
+  }
   if (params.ctx.shouldDropMismatchedSlackEvent?.(body)) {
     params.ctx.runtime.log?.("slack:interaction drop shortcut payload (mismatched app/team)");
     return;
@@ -45,6 +65,7 @@ async function handleSlackShortcut(params: {
   const threadTs = messageBody ? resolveMessageThreadTs(messageBody) : undefined;
   const auth = await authorizeSlackSystemEventSender({
     ctx: params.ctx,
+    eventScope,
     senderId: userId,
     channelId,
     channelType: isMessageShortcut ? undefined : "im",
@@ -60,12 +81,18 @@ async function handleSlackShortcut(params: {
 
   const interactionType = isMessageShortcut ? "message_shortcut" : "global_shortcut";
   const messageTs = messageBody?.message.ts || messageBody?.message_ts;
+  const teamId = params.args.context.teamId;
+  const deferredTarget = resolveSlackDeferredActionTarget({
+    eventScope,
+    kind: auth.channelType === "im" ? "user" : "channel",
+    id: auth.channelType === "im" ? userId : (channelId ?? ""),
+  });
   const eventPayload = {
     interactionType,
     actionId: `shortcut:${callbackId}`,
     callbackId,
     userId,
-    teamId: body.team?.id ?? body.user.team_id,
+    teamId,
     triggerId: body.trigger_id,
     actionTs: body.action_ts,
     channelId,
@@ -81,10 +108,12 @@ async function handleSlackShortcut(params: {
     channelType: auth.channelType,
     senderId: userId,
     threadTs,
+    eventScope,
   });
   const contextKey = [
     "slack:interaction:shortcut",
     interactionType,
+    teamId,
     callbackId,
     channelId,
     messageTs,
@@ -101,7 +130,7 @@ async function handleSlackShortcut(params: {
     contextKey,
     deliveryContext: {
       channel: "slack",
-      to: auth.channelType === "im" ? `user:${userId}` : `channel:${channelId}`,
+      to: deferredTarget.target,
       accountId: params.ctx.accountId,
       threadId: threadTs,
     },
@@ -125,12 +154,18 @@ export function registerSlackShortcutHandler(params: {
   if (typeof params.ctx.app.shortcut !== "function") {
     return;
   }
-  params.ctx.app.shortcut(/.+/, async (args: SlackShortcutMiddlewareArgs<SlackShortcutBody>) => {
-    await handleSlackShortcut({
-      ctx: params.ctx,
-      trackEvent: params.trackEvent,
-      args,
-      formatSystemEvent: params.formatSystemEvent,
-    });
-  });
+  params.ctx.app.shortcut(
+    /.+/,
+    async (
+      args: SlackShortcutMiddlewareArgs<SlackShortcutBody> &
+        Pick<AllMiddlewareArgs, "context" | "client">,
+    ) => {
+      await handleSlackShortcut({
+        ctx: params.ctx,
+        trackEvent: params.trackEvent,
+        args,
+        formatSystemEvent: params.formatSystemEvent,
+      });
+    },
+  );
 }

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -150,8 +150,10 @@ vi.mock("../conversation.runtime.js", () => {
 
 type RegisteredHandler = (args: {
   ack: () => Promise<void>;
+  client?: TestSlackClient;
+  context?: TestBoltContext;
   body: {
-    user: { id: string };
+    user: { id: string; team_id?: string };
     team?: { id?: string };
     trigger_id?: string;
     response_url?: string;
@@ -165,8 +167,10 @@ type RegisteredHandler = (args: {
 
 type RegisteredViewHandler = (args: {
   ack: () => Promise<void>;
+  client?: TestSlackClient;
+  context?: TestBoltContext;
   body: {
-    user?: { id?: string };
+    user?: { id?: string; team_id?: string };
     team?: { id?: string };
     trigger_id?: string;
     view?: {
@@ -177,6 +181,7 @@ type RegisteredViewHandler = (args: {
       previous_view_id?: string;
       external_id?: string;
       hash?: string;
+      app_installed_team_id?: string;
       state?: { values?: Record<string, Record<string, Record<string, unknown>>> };
     };
     is_cleared?: boolean;
@@ -184,8 +189,21 @@ type RegisteredViewHandler = (args: {
 }) => Promise<void>;
 
 type RegisteredShortcutHandler = (
-  args: Pick<SlackShortcutMiddlewareArgs, "ack" | "body">,
+  args: Pick<SlackShortcutMiddlewareArgs, "ack" | "body"> & {
+    client?: TestSlackClient;
+    context?: TestBoltContext;
+  },
 ) => Promise<void>;
+
+type TestBoltContext = {
+  teamId?: string;
+  isEnterpriseInstall?: boolean;
+  enterpriseId?: string;
+};
+
+type TestSlackClient = {
+  chat: { update: (...args: unknown[]) => unknown };
+};
 
 function createContext(overrides?: {
   dmEnabled?: boolean;
@@ -195,6 +213,9 @@ function createContext(overrides?: {
   useAccessGroups?: boolean;
   channelsConfig?: Record<string, { users?: string[] }>;
   cfg?: Record<string, unknown>;
+  installationIdentity?:
+    | { kind: "workspace"; teamId: string }
+    | { kind: "enterprise"; enterpriseId: string };
   shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
   isChannelAllowed?: (params: {
     channelId?: string;
@@ -212,10 +233,45 @@ function createContext(overrides?: {
   let viewHandler: RegisteredViewHandler | null = null;
   let viewClosedHandler: RegisteredViewHandler | null = null;
   let shortcutHandler: RegisteredShortcutHandler | null = null;
+  const installationIdentity = overrides?.installationIdentity ?? {
+    kind: "workspace" as const,
+    teamId: "T_TEST",
+  };
+  const listenerClient = {
+    chat: {
+      update: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+  const withBoltScope = <
+    Args extends { body: unknown; context?: TestBoltContext; client?: TestSlackClient },
+  >(
+    args: Args,
+  ): Args & { context: TestBoltContext; client: TestSlackClient } => {
+    const body = args.body as {
+      team?: { id?: string };
+      user?: { team_id?: string };
+      view?: { app_installed_team_id?: string };
+    };
+    const context = args.context ?? {
+      teamId: body.view?.app_installed_team_id ?? body.team?.id ?? body.user?.team_id,
+    };
+    return {
+      ...args,
+      context:
+        installationIdentity.kind === "enterprise"
+          ? {
+              ...context,
+              isEnterpriseInstall: true,
+              enterpriseId: installationIdentity.enterpriseId,
+            }
+          : context,
+      client: args.client ?? listenerClient,
+    };
+  };
   const app = {
     action: vi.fn((matcher: RegExp, next: RegisteredHandler) => {
       actionMatcher = matcher;
-      handler = next;
+      handler = async (args) => await next(withBoltScope(args));
     }),
     view: vi.fn(
       (
@@ -223,20 +279,16 @@ function createContext(overrides?: {
         next: RegisteredViewHandler,
       ) => {
         if (matcher.type === "view_submission") {
-          viewHandler = next;
+          viewHandler = async (args) => await next(withBoltScope(args));
         } else {
-          viewClosedHandler = next;
+          viewClosedHandler = async (args) => await next(withBoltScope(args));
         }
       },
     ),
     shortcut: vi.fn((_matcher: RegExp, next: RegisteredShortcutHandler) => {
-      shortcutHandler = next;
+      shortcutHandler = async (args) => await next(withBoltScope(args));
     }),
-    client: {
-      chat: {
-        update: vi.fn().mockResolvedValue(undefined),
-      },
-    },
+    client: listenerClient,
   };
   const runtimeLog = vi.fn();
   const resolveSessionKey = vi.fn().mockReturnValue("agent:ops:slack:channel:C1");
@@ -265,6 +317,7 @@ function createContext(overrides?: {
   const ctx = {
     app,
     accountId: "default",
+    installationIdentity,
     cfg: overrides?.cfg ?? {
       channels: {
         slack: {
@@ -502,13 +555,16 @@ describe("registerSlackInteractionEvents", () => {
   });
 
   it("routes global shortcuts to the actor's direct session", async () => {
-    const { ctx, getShortcutHandler, resolveSessionKey } = createContext();
+    const { ctx, getShortcutHandler, resolveSessionKey } = createContext({
+      installationIdentity: { kind: "enterprise", enterpriseId: "E1" },
+    });
     const trackEvent = vi.fn();
     registerSlackInteractionEvents({ ctx: ctx as never, trackEvent });
 
     const ack = vi.fn().mockResolvedValue(undefined);
     await getShortcutHandler()({
       ack,
+      context: { teamId: "T9" },
       body: {
         type: "shortcut",
         callback_id: "capture-note",
@@ -527,6 +583,7 @@ describe("registerSlackInteractionEvents", () => {
       channelType: "im",
       senderId: "U123",
       threadTs: undefined,
+      eventScope: expect.objectContaining({ teamId: "T9" }),
     });
     expect(slackInteractionPayload()).toMatchObject({
       interactionType: "global_shortcut",
@@ -542,7 +599,7 @@ describe("registerSlackInteractionEvents", () => {
       sessionKey: "agent:ops:slack:channel:C1",
       deliveryContext: {
         channel: "slack",
-        to: "user:U123",
+        to: "team:T9:user:U123",
         accountId: "default",
       },
     });
@@ -551,12 +608,14 @@ describe("registerSlackInteractionEvents", () => {
 
   it("routes message shortcuts with selected-message context", async () => {
     const { ctx, getShortcutHandler, resolveSessionKey } = createContext({
+      installationIdentity: { kind: "enterprise", enterpriseId: "E1" },
       resolveChannelName: async () => ({ name: "ops", type: "channel" }),
     });
     registerSlackInteractionEvents({ ctx: ctx as never });
 
     await getShortcutHandler()({
       ack: vi.fn().mockResolvedValue(undefined),
+      context: { teamId: "T9" },
       body: {
         type: "message_action",
         callback_id: "summarize-message",
@@ -583,6 +642,7 @@ describe("registerSlackInteractionEvents", () => {
       channelType: "channel",
       senderId: "U123",
       threadTs: "200.100",
+      eventScope: expect.objectContaining({ teamId: "T9" }),
     });
     expect(slackInteractionPayload()).toMatchObject({
       interactionType: "message_shortcut",
@@ -601,7 +661,7 @@ describe("registerSlackInteractionEvents", () => {
     expect(mockCallArg(enqueueSystemEventMock, 0, "enqueueSystemEvent", 1)).toMatchObject({
       deliveryContext: {
         channel: "slack",
-        to: "channel:C1",
+        to: "team:T9:channel:C1",
         accountId: "default",
         threadId: "200.100",
       },
@@ -661,7 +721,9 @@ describe("registerSlackInteractionEvents", () => {
   });
 
   it("enqueues structured events and updates button rows", async () => {
-    const { ctx, app, getHandler, resolveSessionKey } = createContext();
+    const { ctx, app, getHandler, resolveSessionKey } = createContext({
+      installationIdentity: { kind: "enterprise", enterpriseId: "E1" },
+    });
     const trackEvent = vi.fn();
     registerSlackInteractionEvents({ ctx: ctx as never, trackEvent });
 
@@ -672,6 +734,7 @@ describe("registerSlackInteractionEvents", () => {
     await handler({
       ack,
       respond,
+      context: { teamId: "T9" },
       body: {
         user: { id: "U123" },
         team: { id: "T9" },
@@ -734,6 +797,10 @@ describe("registerSlackInteractionEvents", () => {
       channelType: "channel",
       senderId: "U123",
       threadTs: "100.100",
+      eventScope: expect.objectContaining({ teamId: "T9" }),
+    });
+    expect(mockCallArg(enqueueSystemEventMock, 0, "enqueueSystemEvent", 1)).toMatchObject({
+      deliveryContext: { to: "team:T9:channel:C1" },
     });
     expect(trackEvent).toHaveBeenCalledTimes(1);
     expect(app.client.chat.update).toHaveBeenCalledTimes(1);
@@ -3145,7 +3212,9 @@ describe("registerSlackInteractionEvents", () => {
 
   it("captures modal submissions and enqueues view submission event", async () => {
     enqueueSystemEventMock.mockClear();
-    const { ctx, getViewHandler, resolveSessionKey } = createContext();
+    const { ctx, getViewHandler, resolveSessionKey } = createContext({
+      installationIdentity: { kind: "enterprise", enterpriseId: "E1" },
+    });
     const trackEvent = vi.fn();
     registerSlackInteractionEvents({ ctx: ctx as never, trackEvent });
     const viewHandler = getViewHandler();
@@ -3153,6 +3222,7 @@ describe("registerSlackInteractionEvents", () => {
     const ack = vi.fn().mockResolvedValue(undefined);
     await viewHandler({
       ack,
+      context: { teamId: "T1" },
       body: {
         user: { id: "U777" },
         team: { id: "T1" },
@@ -3204,13 +3274,14 @@ describe("registerSlackInteractionEvents", () => {
       channelId: "D123",
       channelType: "im",
       senderId: "U777",
+      eventScope: expect.objectContaining({ teamId: "T1" }),
     });
     expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
     expect(mockCallArg(enqueueSystemEventMock, 0, "enqueueSystemEvent", 1)).toMatchObject({
       sessionKey: "agent:ops:slack:channel:C1",
       deliveryContext: {
         channel: "slack",
-        to: "user:U777",
+        to: "team:T1:user:U777",
         accountId: "default",
       },
     });

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -16,7 +16,7 @@ import { noteSlackDraftConversationMessage } from "../../draft-message-boundarie
 import type { SlackAppMentionEvent, SlackMessageEvent } from "../../types.js";
 import { normalizeSlackChannelType } from "../channel-type.js";
 import type { SlackMonitorContext } from "../context.js";
-import { resolveSlackEventScope, type SlackEventScope } from "../event-scope.js";
+import { resolveSlackListenerEventScope, type SlackEventScope } from "../event-scope.js";
 import { resolveSlackIngressTurnLifecycle } from "../ingress.js";
 import type { SlackMessageHandler } from "../message-handler.js";
 import type { SlackMessageChangedEvent } from "../types.js";
@@ -194,6 +194,20 @@ export function registerSlackMessageEvents(params: {
 }) {
   const { ctx, handleSlackMessage } = params;
 
+  const resolveEventScope = (args: {
+    body: unknown;
+    context: AllMiddlewareArgs["context"];
+    client: AllMiddlewareArgs["client"];
+  }) =>
+    resolveSlackListenerEventScope({
+      identity: ctx.installationIdentity,
+      body: args.body,
+      context: args.context,
+      client: args.client,
+      clientOptions: ctx.app.webClientOptions,
+      onDrop: (reason) => logVerbose(`slack: drop event (${reason})`),
+    });
+
   const noteConversationMessage = (
     message: SlackMessageEvent | SlackAppMentionEvent,
     eventScope?: SlackEventScope,
@@ -209,25 +223,6 @@ export function registerSlackMessageEvents(params: {
       botId: asString(message.bot_id),
       subtype: "subtype" in message ? asString(message.subtype) : undefined,
     });
-  };
-
-  const resolveEventScope = (args: {
-    body: unknown;
-    context: AllMiddlewareArgs["context"];
-    client: AllMiddlewareArgs["client"];
-  }): SlackEventScope | null | undefined => {
-    const resolved = resolveSlackEventScope({
-      identity: ctx.installationIdentity,
-      body: args.body,
-      context: args.context,
-      client: args.client,
-      clientOptions: ctx.app.webClientOptions,
-    });
-    if (!resolved.ok) {
-      logVerbose(`slack: drop event (${resolved.reason})`);
-      return null;
-    }
-    return resolved.scope;
   };
 
   const handleIncomingMessageEvent = async ({

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -314,6 +314,7 @@ describe("auth.test boot call", () => {
           enterpriseOrgInstall: true,
           dmPolicy: "disabled",
           groupPolicy: "open",
+          slashCommand: { enabled: true, name: "openclaw" },
         },
       },
     });
@@ -325,6 +326,14 @@ describe("auth.test boot call", () => {
     const monitor = startSlackMonitor(monitorSlackProvider, {
       appToken: "xapp-1-A1-opaque",
     });
+    await vi.waitFor(() => expect(getSlackTestState().appStartMock).toHaveBeenCalledTimes(1));
+    expect(getSlackTestState().interactionRegistrations).toEqual([
+      "command",
+      "action",
+      "shortcut",
+      "view",
+      "view",
+    ]);
     await expect(stopSlackMonitor(monitor)).resolves.toBeUndefined();
   });
 

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -692,10 +692,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   }
 
   // Resolve command registration first so App Home never advertises an inactive single command.
-  const commandRegistration =
-    installationIdentity.kind === "enterprise"
-      ? ({ mode: "disabled" } as const)
-      : await registerSlackMonitorSlashCommands({ ctx, account, trackEvent });
+  const commandRegistration = await registerSlackMonitorSlashCommands({ ctx, account, trackEvent });
   const appHomeSlashCommandName =
     commandRegistration.mode === "single" ? commandRegistration.name : undefined;
   registerSlackMonitorEvents({

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -373,6 +373,12 @@ function createDeferred<T>() {
 
 function createArgMenusHarness(
   cfg: OpenClawConfig = { commands: { native: true, nativeSkills: false } },
+  scope?: {
+    installationIdentity?:
+      | { kind: "workspace"; teamId: string }
+      | { kind: "enterprise"; enterpriseId: string };
+    teamId?: string;
+  },
 ) {
   const commands = new Map<string | RegExp, (args: unknown) => Promise<void>>();
   const actions = new Map<string | RegExp, (args: unknown) => Promise<void>>();
@@ -380,17 +386,39 @@ function createArgMenusHarness(
   const optionsReceiverContexts: unknown[] = [];
 
   const postEphemeral = vi.fn().mockResolvedValue({ ok: true });
+  const listenerClient = { chat: { postEphemeral } };
+  const installationIdentity = scope?.installationIdentity ?? {
+    kind: "workspace" as const,
+    teamId: scope?.teamId ?? "T1",
+  };
+  const boltContext =
+    installationIdentity.kind === "enterprise"
+      ? {
+          teamId: scope?.teamId,
+          enterpriseId: installationIdentity.enterpriseId,
+          isEnterpriseInstall: true,
+        }
+      : { teamId: installationIdentity.teamId, isEnterpriseInstall: false };
+  const withBoltScope = (args: unknown) => {
+    const typed = args as { context?: Record<string, unknown>; client?: unknown };
+    return {
+      ...typed,
+      context: { ...boltContext, ...typed.context },
+      client: typed.client ?? listenerClient,
+    };
+  };
   const app = {
-    client: { chat: { postEphemeral } },
+    client: listenerClient,
     command: (name: string | RegExp, handler: (args: unknown) => Promise<void>) => {
-      commands.set(name, handler);
+      commandRegistrations.push(name);
+      commands.set(name, async (args) => await handler(withBoltScope(args)));
     },
     action: (id: string | RegExp, handler: (args: unknown) => Promise<void>) => {
-      actions.set(id, handler);
+      actions.set(id, async (args) => await handler(withBoltScope(args)));
     },
     options(this: unknown, id: string, handler: (args: unknown) => Promise<void>) {
       optionsReceiverContexts.push(this);
-      options.set(id, handler);
+      options.set(id, async (args) => await handler(withBoltScope(args)));
     },
   };
 
@@ -399,7 +427,8 @@ function createArgMenusHarness(
     runtime: {},
     botToken: "bot-token",
     botUserId: "bot",
-    teamId: "T1",
+    teamId: installationIdentity.kind === "enterprise" ? "" : installationIdentity.teamId,
+    installationIdentity,
     allowFrom: ["*"],
     dmEnabled: true,
     dmPolicy: "open",
@@ -1061,6 +1090,36 @@ describe("Slack native command argument menus", () => {
     expect(call.ctx?.Body).toBe("/usage tokens");
   });
 
+  it("keeps the Enterprise Grid team on deferred argument-menu actions", async () => {
+    const enterpriseHarness = createArgMenusHarness(
+      { commands: { native: true, nativeSkills: false } },
+      {
+        installationIdentity: { kind: "enterprise", enterpriseId: "EGRID" },
+        teamId: "TGRID1",
+      },
+    );
+    await registerCommands(enterpriseHarness.ctx, enterpriseHarness.account);
+    const enterpriseArgMenuHandler = requireHandler(
+      enterpriseHarness.actions,
+      /^openclaw_cmdarg/,
+      "Enterprise arg-menu action",
+    );
+
+    await runArgMenuAction(enterpriseArgMenuHandler, {
+      action: {
+        value: encodeValue({ command: "tools", arg: "mode", value: "compact", userId: "U1" }),
+      },
+    });
+
+    expect(getSlackSlashMocks().resolveAgentRouteMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: "TGRID1",
+        peer: { kind: "direct", id: "team:TGRID1:user:U1" },
+      }),
+    );
+    expect(firstDispatchArg().ctx?.OriginatingTo).toBe("team:TGRID1:user:U1");
+  });
+
   it("does not apply the response_url call cap to Web API action replies", async () => {
     mockSixDispatchedReplies();
 
@@ -1362,15 +1421,39 @@ function createPolicyHarness(overrides?: {
   slashEphemeral?: boolean;
   slashCommandEnabled?: boolean;
   slashCommandName?: string;
+  teamId?: string;
+  installationIdentity?:
+    | { kind: "workspace"; teamId: string }
+    | { kind: "enterprise"; enterpriseId: string };
   shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
   resolveChannelName?: () => Promise<{ name?: string; type?: string }>;
 }) {
   const commands = new Map<unknown, (args: unknown) => Promise<void>>();
   const postEphemeral = vi.fn().mockResolvedValue({ ok: true });
+  const listenerClient = { chat: { postEphemeral } };
+  const installationIdentity = overrides?.installationIdentity ?? {
+    kind: "workspace" as const,
+    teamId: overrides?.teamId ?? "T1",
+  };
+  const boltContext =
+    installationIdentity.kind === "enterprise"
+      ? {
+          teamId: overrides?.teamId,
+          enterpriseId: installationIdentity.enterpriseId,
+          isEnterpriseInstall: true,
+        }
+      : { teamId: installationIdentity.teamId, isEnterpriseInstall: false };
   const app = {
-    client: { chat: { postEphemeral } },
+    client: listenerClient,
     command: (name: unknown, handler: (args: unknown) => Promise<void>) => {
-      commands.set(name, handler);
+      commands.set(name, async (args) => {
+        const typed = args as { context?: Record<string, unknown>; client?: unknown };
+        await handler({
+          ...typed,
+          context: { ...boltContext, ...typed.context },
+          client: typed.client ?? listenerClient,
+        });
+      });
     },
   };
 
@@ -1382,7 +1465,8 @@ function createPolicyHarness(overrides?: {
     runtime: {},
     botToken: "bot-token",
     botUserId: "bot",
-    teamId: "T1",
+    teamId: installationIdentity.kind === "enterprise" ? "" : installationIdentity.teamId,
+    installationIdentity,
     allowFrom: overrides?.allowFrom ?? ["*"],
     dmEnabled: true,
     dmPolicy: "open",
@@ -1778,6 +1862,32 @@ describe("slack slash command session metadata", () => {
     expect(call.ctx?.GroupSpace).toBe("T1");
     expect(call.sessionKey).toBeTypeOf("string");
     expect(call.sessionKey).not.toBe("");
+  });
+
+  it("partitions Enterprise Grid slash sessions and replies by event team", async () => {
+    const harness = createPolicyHarness({
+      groupPolicy: "open",
+      slashEphemeral: false,
+      installationIdentity: { kind: "enterprise", enterpriseId: "EGRID" },
+      teamId: "TGRID1",
+      channelId: "CGRID1",
+      channelName: "grid",
+    });
+
+    await registerAndRunPolicySlash({ harness });
+
+    expect(resolveAgentRouteMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: "TGRID1",
+        peer: { kind: "channel", id: "team:TGRID1:channel:CGRID1" },
+      }),
+    );
+    expect(firstDispatchArg().ctx).toMatchObject({
+      From: "slack:channel:team:TGRID1:channel:CGRID1",
+      To: "slash:team:TGRID1:user:U1",
+      OriginatingTo: "team:TGRID1:channel:CGRID1",
+      SessionKey: expect.stringContaining("team:tgrid1:user:u1"),
+    });
   });
 
   it("passes canonical hook correlation to slash reply delivery", async () => {

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -410,7 +410,6 @@ function createArgMenusHarness(
   const app = {
     client: listenerClient,
     command: (name: string | RegExp, handler: (args: unknown) => Promise<void>) => {
-      commandRegistrations.push(name);
       commands.set(name, async (args) => await handler(withBoltScope(args)));
     },
     action: (id: string | RegExp, handler: (args: unknown) => Promise<void>) => {

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -1,5 +1,10 @@
 // Slack plugin module implements slash behavior.
-import type { SlackActionMiddlewareArgs, SlackCommandMiddlewareArgs } from "@slack/bolt";
+import type {
+  AllMiddlewareArgs,
+  SlackActionMiddlewareArgs,
+  SlackCommandMiddlewareArgs,
+  SlackOptionsMiddlewareArgs,
+} from "@slack/bolt";
 import type { Block, KnownBlock } from "@slack/web-api";
 import {
   loadPreparedModelCatalog,
@@ -42,7 +47,9 @@ import { resolveSlackChannelConfig, type SlackChannelConfigResolved } from "./ch
 import { buildSlackSlashCommandMatcher, resolveSlackSlashCommandConfig } from "./commands.js";
 import type { SlackMonitorContext } from "./context.js";
 import { normalizeSlackChannelType, resolveSlackChatType } from "./context.js";
+import { resolveSlackDeferredActionTarget } from "./deferred-action-routing.js";
 import { authorizeSlackDirectMessage } from "./dm-auth.js";
+import { resolveSlackListenerEventScope, type SlackEventScope } from "./event-scope.js";
 import {
   createSlackExternalArgMenuStore,
   SLACK_EXTERNAL_ARG_MENU_PREFIX,
@@ -71,6 +78,13 @@ const SLACK_COMMAND_ARG_CONFIRM_TEXT_MAX = 300;
 const SLACK_HEADER_TEXT_MAX = 150;
 const SLACK_COMMAND_ARG_CHROME_BLOCKS = 3;
 const SLACK_COMMAND_ARG_ACTION_BLOCKS_MAX = SLACK_MAX_BLOCKS - SLACK_COMMAND_ARG_CHROME_BLOCKS;
+
+type SlackCommandHandlerArgs = SlackCommandMiddlewareArgs &
+  Pick<AllMiddlewareArgs, "context" | "client">;
+type SlackArgActionHandlerArgs = SlackActionMiddlewareArgs &
+  Pick<AllMiddlewareArgs, "context" | "client">;
+type SlackArgOptionsHandlerArgs = SlackOptionsMiddlewareArgs<"block_suggestion"> &
+  Pick<AllMiddlewareArgs, "context" | "client">;
 
 const loadSlashCommandsRuntime = createLazyRuntimeModule(
   () => import("./slash-commands.runtime.js"),
@@ -379,6 +393,19 @@ export async function registerSlackMonitorSlashCommands(params: {
   const { ctx, account, trackEvent } = params;
   const startupCfg = ctx.cfg;
   const runtime = ctx.runtime;
+  const resolveEventScope = (args: {
+    body: unknown;
+    context: AllMiddlewareArgs["context"];
+    client: AllMiddlewareArgs["client"];
+  }) =>
+    resolveSlackListenerEventScope({
+      identity: ctx.installationIdentity,
+      body: args.body,
+      context: args.context,
+      client: args.client,
+      clientOptions: ctx.app.webClientOptions,
+      onDrop: (reason) => runtime.log?.(`slack: drop slash payload (${reason})`),
+    });
 
   const supportsInteractiveArgMenus =
     typeof (ctx.app as { action?: unknown }).action === "function";
@@ -399,6 +426,7 @@ export async function registerSlackMonitorSlashCommands(params: {
     respond: SlackCommandMiddlewareArgs["respond"];
     responseTransport?: "response-url" | "web-api";
     body?: unknown;
+    eventScope?: SlackEventScope;
     prompt: string;
     commandArgs?: CommandArgs;
     commandDefinition?: ChatCommandDefinition;
@@ -408,6 +436,7 @@ export async function registerSlackMonitorSlashCommands(params: {
       ack,
       respond: respondWithoutBudget,
       body,
+      eventScope,
       prompt,
       commandArgs,
       commandDefinition,
@@ -443,7 +472,7 @@ export async function registerSlackMonitorSlashCommands(params: {
         return;
       }
 
-      const channelInfo = await ctx.resolveChannelName(command.channel_id);
+      const channelInfo = await ctx.resolveChannelName(command.channel_id, eventScope);
       const rawChannelType =
         channelInfo?.type ?? (command.channel_name === "directmessage" ? "im" : undefined);
       const channelType = normalizeSlackChannelType(rawChannelType, command.channel_id);
@@ -481,7 +510,7 @@ export async function registerSlackMonitorSlashCommands(params: {
           accountId: ctx.accountId,
           senderId: command.user_id,
           allowFromLower: effectiveAllowFromLower,
-          resolveSenderName: ctx.resolveUserName,
+          resolveSenderName: (userId) => ctx.resolveUserName(userId, eventScope),
           sendPairingReply: async (text) => {
             await respond({
               text,
@@ -549,7 +578,7 @@ export async function registerSlackMonitorSlashCommands(params: {
         }
       }
 
-      const sender = await ctx.resolveUserName(command.user_id);
+      const sender = await ctx.resolveUserName(command.user_id, eventScope);
       const senderName = sender?.name ?? command.user_name ?? command.user_id;
       const slashIngress = await resolveSlackCommandIngress({
         ctx,
@@ -586,6 +615,12 @@ export async function registerSlackMonitorSlashCommands(params: {
         }
       }
 
+      const routeTarget = resolveSlackDeferredActionTarget({
+        eventScope,
+        kind: isDirectMessage ? "user" : "channel",
+        id: isDirectMessage ? command.user_id : command.channel_id,
+      });
+      const routingTeamId = (eventScope?.teamId ?? ctx.teamId) || undefined;
       let resolvedSlashRoute: ResolvedAgentRoute | undefined;
       const resolveSlashRoute = async () => {
         if (resolvedSlashRoute) {
@@ -596,10 +631,10 @@ export async function registerSlackMonitorSlashCommands(params: {
           cfg,
           channel: "slack",
           accountId: account.accountId,
-          teamId: ctx.teamId || undefined,
+          teamId: routingTeamId,
           peer: {
             kind: isDirectMessage ? "direct" : isRoom ? "channel" : "group",
-            id: isDirectMessage ? command.user_id : command.channel_id,
+            id: routeTarget.peerId,
           },
         });
         return resolvedSlashRoute;
@@ -682,10 +717,10 @@ export async function registerSlackMonitorSlashCommands(params: {
           cfg,
           channel: "slack",
           accountId: account.accountId,
-          teamId: ctx.teamId || undefined,
+          teamId: routingTeamId,
           peer: {
             kind: isDirectMessage ? "direct" : isRoom ? "channel" : "group",
-            id: isDirectMessage ? command.user_id : command.channel_id,
+            id: routeTarget.peerId,
           },
         });
 
@@ -695,17 +730,23 @@ export async function registerSlackMonitorSlashCommands(params: {
         channelConfig,
       });
 
+      const slashUserTarget = resolveSlackDeferredActionTarget({
+        eventScope,
+        kind: "user",
+        id: command.user_id,
+      });
       const { sessionKey, commandTargetSessionKey } = resolveNativeCommandSessionTargets({
         agentId: route.agentId,
         sessionPrefix: slashCommand.sessionPrefix,
-        userId: command.user_id,
+        userId: slashUserTarget.peerId,
         targetSessionKey: route.sessionKey,
         sessionKeyCase: "lowercase",
       });
-      const slashReplyTarget =
-        !slashCommand.ephemeral && isRoomish
-          ? `channel:${command.channel_id}`
-          : `user:${command.user_id}`;
+      const slashReplyTarget = resolveSlackDeferredActionTarget({
+        eventScope,
+        kind: !slashCommand.ephemeral && isRoomish ? "channel" : "user",
+        id: !slashCommand.ephemeral && isRoomish ? command.channel_id : command.user_id,
+      }).target;
       const ctxPayload = finalizeInboundContext({
         Body: prompt,
         BodyForAgent: prompt,
@@ -713,11 +754,11 @@ export async function registerSlackMonitorSlashCommands(params: {
         CommandBody: prompt,
         CommandArgs: commandArgs,
         From: isDirectMessage
-          ? `slack:${command.user_id}`
+          ? `slack:${routeTarget.peerId}`
           : isRoom
-            ? `slack:channel:${command.channel_id}`
-            : `slack:group:${command.channel_id}`,
-        To: `slash:${command.user_id}`,
+            ? `slack:channel:${routeTarget.peerId}`
+            : `slack:group:${routeTarget.peerId}`,
+        To: `slash:${slashUserTarget.peerId}`,
         ChatType: chatType,
         ConversationLabel:
           resolveConversationLabel({
@@ -725,10 +766,10 @@ export async function registerSlackMonitorSlashCommands(params: {
             SenderName: senderName,
             GroupSubject: isRoomish ? roomLabel : undefined,
             From: isDirectMessage
-              ? `slack:${command.user_id}`
+              ? `slack:${routeTarget.peerId}`
               : isRoom
-                ? `slack:channel:${command.channel_id}`
-                : `slack:group:${command.channel_id}`,
+                ? `slack:channel:${routeTarget.peerId}`
+                : `slack:group:${routeTarget.peerId}`,
           }) ?? (isDirectMessage ? senderName : roomLabel),
         GroupSubject: isRoomish ? roomLabel : undefined,
         GroupSpace: ctx.teamId || undefined,
@@ -917,12 +958,24 @@ export async function registerSlackMonitorSlashCommands(params: {
   if (registration.mode === "single") {
     ctx.app.command(
       buildSlackSlashCommandMatcher(registration.name),
-      async ({ command, ack, respond, body }: SlackCommandMiddlewareArgs) => {
+      async (args: SlackCommandHandlerArgs) => {
+        const { command, ack, respond, body } = args;
+        const eventScope = resolveEventScope(args);
+        if (eventScope === null) {
+          await ack({ text: "This Slack workspace is unavailable.", response_type: "ephemeral" });
+          return;
+        }
         await handleSlashCommand({
           command,
           ack,
-          respond,
+          respond: createSlackSlashResponderWithFallback({
+            respond,
+            client: args.client,
+            command,
+            runtime,
+          }),
           body,
+          eventScope,
           prompt: command.text?.trim() ?? "",
         });
       },
@@ -932,35 +985,44 @@ export async function registerSlackMonitorSlashCommands(params: {
       throw new Error("Missing commands runtime for native Slack commands.");
     }
     for (const command of nativeCommands) {
-      ctx.app.command(
-        `/${command.name}`,
-        async ({ command: cmd, ack, respond, body }: SlackCommandMiddlewareArgs) => {
-          const commandDefinition = slashCommandsRuntime.findCommandByNativeName(
-            command.name,
-            "slack",
-          );
-          const rawText = cmd.text?.trim() ?? "";
-          const commandArgs = commandDefinition
-            ? slashCommandsRuntime.parseCommandArgs(commandDefinition, rawText)
-            : rawText
-              ? ({ raw: rawText } satisfies CommandArgs)
-              : undefined;
-          const prompt = commandDefinition
-            ? slashCommandsRuntime.buildCommandTextFromArgs(commandDefinition, commandArgs)
-            : rawText
-              ? `/${command.name} ${rawText}`
-              : `/${command.name}`;
-          await handleSlashCommand({
-            command: cmd,
-            ack,
+      ctx.app.command(`/${command.name}`, async (args: SlackCommandHandlerArgs) => {
+        const { command: cmd, ack, respond, body } = args;
+        const eventScope = resolveEventScope(args);
+        if (eventScope === null) {
+          await ack({ text: "This Slack workspace is unavailable.", response_type: "ephemeral" });
+          return;
+        }
+        const commandDefinition = slashCommandsRuntime.findCommandByNativeName(
+          command.name,
+          "slack",
+        );
+        const rawText = cmd.text?.trim() ?? "";
+        const commandArgs = commandDefinition
+          ? slashCommandsRuntime.parseCommandArgs(commandDefinition, rawText)
+          : rawText
+            ? ({ raw: rawText } satisfies CommandArgs)
+            : undefined;
+        const prompt = commandDefinition
+          ? slashCommandsRuntime.buildCommandTextFromArgs(commandDefinition, commandArgs)
+          : rawText
+            ? `/${command.name} ${rawText}`
+            : `/${command.name}`;
+        await handleSlashCommand({
+          command: cmd,
+          ack,
+          respond: createSlackSlashResponderWithFallback({
             respond,
-            body,
-            prompt,
-            commandArgs,
-            commandDefinition: commandDefinition ?? undefined,
-          });
-        },
-      );
+            client: args.client,
+            command: cmd,
+            runtime,
+          }),
+          body,
+          eventScope,
+          prompt,
+          commandArgs,
+          commandDefinition: commandDefinition ?? undefined,
+        });
+      });
     }
   } else {
     logVerbose("slack: slash commands disabled");
@@ -974,16 +1036,18 @@ export async function registerSlackMonitorSlashCommands(params: {
     const appWithOptions = ctx.app as unknown as {
       options?: (
         actionId: string,
-        handler: (args: {
-          ack: (payload: { options: unknown[] }) => Promise<void>;
-          body: unknown;
-        }) => Promise<void>,
+        handler: (args: SlackArgOptionsHandlerArgs) => Promise<void>,
       ) => void;
     };
     if (typeof appWithOptions.options !== "function") {
       return;
     }
-    appWithOptions.options(SLACK_COMMAND_ARG_ACTION_ID, async ({ ack, body }) => {
+    appWithOptions.options(SLACK_COMMAND_ARG_ACTION_ID, async (args) => {
+      const { ack, body } = args;
+      if (resolveEventScope(args) === null) {
+        await ack({ options: [] });
+        return;
+      }
       if (ctx.shouldDropMismatchedSlackEvent?.(body)) {
         await ack({ options: [] });
         runtime.log?.("slack: drop slash arg options payload (mismatched app/team)");
@@ -1021,7 +1085,7 @@ export async function registerSlackMonitorSlashCommands(params: {
           // straddling the 75-char Slack plain_text limit is dropped whole rather
           // than serialized as a lone `\uD83D` half that Slack rejects.
           text: {
-            type: "plain_text",
+            type: "plain_text" as const,
             text: truncateSlackText(choice.label, SLACK_COMMAND_ARG_SELECT_OPTION_TEXT_MAX),
           },
           value: choice.value,
@@ -1051,7 +1115,7 @@ export async function registerSlackMonitorSlashCommands(params: {
       ctx.app as unknown as {
         action: NonNullable<(typeof ctx.app & { action?: unknown })["action"]>;
       }
-    ).action(actionId, async (args: SlackActionMiddlewareArgs) => {
+    ).action(actionId, async (args: SlackArgActionHandlerArgs) => {
       const { ack, body } = args;
       const respond = (
         args as unknown as {
@@ -1060,6 +1124,10 @@ export async function registerSlackMonitorSlashCommands(params: {
       ).respond;
       const action = args.action as { value?: string; selected_option?: { value?: string } };
       await ack();
+      const eventScope = resolveEventScope(args);
+      if (eventScope === null) {
+        return;
+      }
       if (ctx.shouldDropMismatchedSlackEvent?.(body)) {
         runtime.log?.("slack: drop slash arg action payload (mismatched app/team)");
         return;
@@ -1078,7 +1146,7 @@ export async function registerSlackMonitorSlashCommands(params: {
                   blocks?: (Block | KnownBlock)[];
                   mrkdwn?: boolean;
                 });
-          await ctx.app.client.chat.postEphemeral({
+          await args.client.chat.postEphemeral({
             token: ctx.botToken,
             channel: body.channel.id,
             user: body.user.id,
@@ -1127,6 +1195,7 @@ export async function registerSlackMonitorSlashCommands(params: {
         channel_id: body.channel?.id ?? "",
         channel_name: body.channel?.name ?? body.channel?.id ?? "",
         trigger_id: triggerId,
+        team_id: args.context.teamId ?? "",
       } as SlackCommandMiddlewareArgs["command"];
       await handleSlashCommand({
         command: commandPayload,
@@ -1136,6 +1205,7 @@ export async function registerSlackMonitorSlashCommands(params: {
         // goes through the uncapped Web API path.
         responseTransport: respond ? "response-url" : "web-api",
         body,
+        eventScope,
         prompt,
         commandArgs,
         commandDefinition: commandDefinition ?? undefined,
@@ -1144,5 +1214,71 @@ export async function registerSlackMonitorSlashCommands(params: {
   };
   registerArgAction(SLACK_COMMAND_ARG_ACTION_LISTENER);
   return registration;
+}
+
+function createSlackSlashResponderWithFallback(params: {
+  respond: SlackCommandMiddlewareArgs["respond"];
+  client: AllMiddlewareArgs["client"];
+  command: SlackCommandMiddlewareArgs["command"];
+  runtime: SlackMonitorContext["runtime"];
+}): SlackCommandMiddlewareArgs["respond"] {
+  return async (message) => {
+    try {
+      return await params.respond(message);
+    } catch (error) {
+      if (!isSlackBoltRespondError(error)) {
+        throw error;
+      }
+      params.runtime.log?.(
+        warn(
+          `slack slash response_url failed; falling back to Web API: ${formatErrorMessage(error)}`,
+        ),
+      );
+      return await deliverSlackSlashResponseWithWebApi({
+        client: params.client,
+        command: params.command,
+        message,
+      });
+    }
+  };
+}
+
+async function deliverSlackSlashResponseWithWebApi(params: {
+  client: AllMiddlewareArgs["client"];
+  command: SlackCommandMiddlewareArgs["command"];
+  message: Parameters<SlackCommandMiddlewareArgs["respond"]>[0];
+}): Promise<Response> {
+  const payload = typeof params.message === "string" ? { text: params.message } : params.message;
+  const text = payload.text ?? "";
+  const blocks = "blocks" in payload && Array.isArray(payload.blocks) ? payload.blocks : undefined;
+  const mrkdwn =
+    "mrkdwn" in payload && typeof payload.mrkdwn === "boolean" ? payload.mrkdwn : undefined;
+
+  if (payload.response_type === "in_channel") {
+    const postSlackMessage = params.client.chat.postMessage;
+    await postSlackMessage({
+      channel: params.command.channel_id,
+      text,
+      ...(blocks ? { blocks } : {}),
+      ...(mrkdwn !== undefined ? { mrkdwn } : {}),
+    });
+  } else {
+    await params.client.chat.postEphemeral({
+      channel: params.command.channel_id,
+      user: params.command.user_id,
+      text,
+      ...(blocks ? { blocks } : {}),
+      ...(mrkdwn !== undefined ? { mrkdwn } : {}),
+    });
+  }
+  return new Response(null, { status: 200 });
+}
+
+function isSlackBoltRespondError(error: unknown): boolean {
+  return (
+    Boolean(error) &&
+    typeof error === "object" &&
+    (error as { code?: unknown }).code === "slack_bolt_respond_error"
+  );
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## Summary

Backports the merged workspace-routing change from #121014 onto the active OpenClaw release branch. The backport preserves workspace scope for Enterprise Grid interactions, deferred actions, slash commands, Slack tool actions, and supported channel lifecycle events.

## Release resolution

- applied landed squash `732108d973e0893ee245e0da0c1d52585a2876ba`
- retained the release branch's existing Grid reaction and pin event backports
- reconciled the four overlapping Slack interaction, channel-event, and slash-test files to preserve release-specific dispatch and error-handling behavior while adding the landed workspace-routing contract

## Validation

- source PR #121014 is merged
- focused Slack suite: 6 files passed, 169 tests passed
- extension source typecheck: passed
- extension test typecheck: passed
- targeted oxlint: passed
- targeted oxfmt check: 19 files passed
- docs index check: passed
- `git diff --check`: passed

## Tracking

Backport-Of: #121014

Release-Target: `sjf/openclaw-release-5-2026-08-04`
