### PR TITLE
perf(auth): reduce SQLite handle churn for profile reads

### DIFF
--- a/src/agents/auth-profiles.sqlite-store.test.ts
+++ b/src/agents/auth-profiles.sqlite-store.test.ts
@@ -9,6 +9,8 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as kyselySync from "../infra/kysely-sync.js";
+import * as nodeSqlite from "../infra/node-sqlite.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   OPENCLAW_AGENT_SCHEMA_VERSION,
@@ -27,6 +29,8 @@ import {
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   ensureAuthProfileStore,
+  getRuntimeAuthProfileStoreSnapshotRevision,
+  replaceRuntimeAuthProfileStoreSnapshots,
   saveAuthProfileStore,
 } from "./auth-profiles/store.js";
 import type { AuthProfileStore, OAuthCredential } from "./auth-profiles/types.js";
@@ -77,6 +81,7 @@ async function withAgentDirEnv(prefix: string, run: (agentDir: string) => void |
       async () => await run(agentDir),
     );
   } finally {
+    clearRuntimeAuthProfileStoreSnapshots();
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
     fs.rmSync(root, { recursive: true, force: true });
@@ -239,6 +244,87 @@ describe("auth profile sqlite store", () => {
 
       expect(loaded?.profiles["openai:default"]).toMatchObject({ key: "sk-test" });
       expect(fs.existsSync(stateDbPath)).toBe(false);
+    });
+  });
+
+  it("reuses path-keyed read handles until the runtime snapshot revision changes", async () => {
+    await withAgentDirEnv("openclaw-auth-sqlite-read-reuse-", (agentDir) => {
+      const secondaryAgentDir = path.join(
+        path.dirname(path.dirname(agentDir)),
+        "secondary",
+        "agent",
+      );
+      saveAuthProfileStore(apiKeyStore("sk-test"), agentDir);
+      saveAuthProfileStore(apiKeyStore("sk-secondary"), secondaryAgentDir);
+      closeOpenClawAgentDatabasesForTest();
+      clearRuntimeAuthProfileStoreSnapshots();
+      const openSpy = vi.spyOn(nodeSqlite, "openNodeSqliteDatabase");
+      const statementCacheSpy = vi.spyOn(kyselySync, "enableNodeSqliteKyselyStatementCache");
+      try {
+        const initialRevision = getRuntimeAuthProfileStoreSnapshotRevision(agentDir);
+        expect(loadPersistedAuthProfileStore(agentDir)).not.toBeNull();
+        expect(loadPersistedAuthProfileStore(secondaryAgentDir)).not.toBeNull();
+        expect(loadPersistedAuthProfileStore(agentDir)).not.toBeNull();
+        expect(loadPersistedAuthProfileStore(secondaryAgentDir)).not.toBeNull();
+        expect(openSpy.mock.calls.filter(([, options]) => options?.readOnly === true)).toHaveLength(
+          2,
+        );
+        expect(statementCacheSpy).toHaveBeenCalledTimes(2);
+        const firstDatabase = openSpy.mock.results[0]?.value as DatabaseSync | undefined;
+        const secondDatabase = openSpy.mock.results[1]?.value as DatabaseSync | undefined;
+        expect(firstDatabase?.isOpen).toBe(true);
+        expect(secondDatabase?.isOpen).toBe(true);
+
+        replaceRuntimeAuthProfileStoreSnapshots([{ agentDir, store: apiKeyStore("sk-test") }]);
+
+        expect(getRuntimeAuthProfileStoreSnapshotRevision(agentDir)).toBeGreaterThan(
+          initialRevision,
+        );
+        expect(firstDatabase?.isOpen).toBe(false);
+        expect(secondDatabase?.isOpen).toBe(false);
+        expect(loadPersistedAuthProfileStore(agentDir)).not.toBeNull();
+        expect(openSpy.mock.calls.filter(([, options]) => options?.readOnly === true)).toHaveLength(
+          3,
+        );
+        expect(statementCacheSpy).toHaveBeenCalledTimes(3);
+      } finally {
+        statementCacheSpy.mockRestore();
+        openSpy.mockRestore();
+      }
+    });
+  });
+
+  it("reuses the transaction database while filtering multiple inherited OAuth profiles", async () => {
+    await withAgentDirEnv("openclaw-auth-sqlite-save-reuse-", (mainAgentDir) => {
+      const customAgentDir = path.join(path.dirname(path.dirname(mainAgentDir)), "custom", "agent");
+      const profiles = Object.fromEntries(
+        Array.from({ length: 3 }, (_, index) => [
+          `openai:profile-${index}`,
+          {
+            type: "oauth" as const,
+            provider: "openai",
+            access: `access-${index}`,
+            refresh: `refresh-${index}`,
+            expires: Date.now() + 60_000,
+          },
+        ]),
+      );
+      const store: AuthProfileStore = { version: 1, profiles };
+      saveAuthProfileStore(store, mainAgentDir);
+      closeOpenClawAgentDatabasesForTest();
+      const openSpy = vi.spyOn(nodeSqlite, "openNodeSqliteDatabase");
+      try {
+        saveAuthProfileStore(store, customAgentDir);
+        const readOnlyOpens = openSpy.mock.calls.filter(
+          ([, options]) => options?.readOnly === true,
+        );
+        expect(readOnlyOpens).toHaveLength(1);
+        expect(path.resolve(String(readOnlyOpens[0]?.[0]))).toBe(
+          path.resolve(resolveAuthProfileDatabasePath(mainAgentDir)),
+        );
+      } finally {
+        openSpy.mockRestore();
+      }
     });
   });
 

--- a/src/agents/auth-profiles/ownership.ts
+++ b/src/agents/auth-profiles/ownership.ts
@@ -1,0 +1,53 @@
+import { isDeepStrictEqual } from "node:util";
+import { asDateTimestampMs } from "../../shared/number-coercion.js";
+import { isSafeToAdoptMainStoreOAuthIdentity } from "./oauth-shared.js";
+import type { AuthProfileStore } from "./types.js";
+
+export type PersistedAuthProfileStores = Readonly<{
+  isMainStore: boolean;
+  localStore: AuthProfileStore | null;
+  mainStore: AuthProfileStore | null;
+}>;
+
+export function shouldUseMainOwnerForLocalOAuthCredential(params: {
+  local: AuthProfileStore["profiles"][string];
+  main: AuthProfileStore["profiles"][string] | undefined;
+}): boolean {
+  if (params.local.type !== "oauth" || params.main?.type !== "oauth") {
+    return false;
+  }
+  if (!isSafeToAdoptMainStoreOAuthIdentity(params.local, params.main)) {
+    return false;
+  }
+  if (isDeepStrictEqual(params.local, params.main)) {
+    return true;
+  }
+  const mainExpires = asDateTimestampMs(params.main.expires);
+  if (mainExpires === undefined) {
+    return false;
+  }
+  const localExpires = asDateTimestampMs(params.local.expires);
+  return localExpires === undefined || mainExpires >= localExpires;
+}
+
+export function isInheritedMainOAuthCredentialFromStores(params: {
+  profileId: string;
+  credential: AuthProfileStore["profiles"][string];
+  persistedStores: PersistedAuthProfileStores;
+}): boolean {
+  if (params.persistedStores.isMainStore || params.credential.type !== "oauth") {
+    return false;
+  }
+  if (params.persistedStores.localStore?.profiles[params.profileId]) {
+    return false;
+  }
+  const mainCredential = params.persistedStores.mainStore?.profiles[params.profileId];
+  return (
+    mainCredential?.type === "oauth" &&
+    (isDeepStrictEqual(mainCredential, params.credential) ||
+      shouldUseMainOwnerForLocalOAuthCredential({
+        local: params.credential,
+        main: mainCredential,
+      }))
+  );
+}

--- a/src/agents/auth-profiles/runtime-snapshots.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.ts
@@ -10,10 +10,7 @@ import {
   clearAllRuntimeAuthMaterializations,
   clearRuntimeAuthMaterializations,
 } from "./runtime-materializations.js";
-import {
-  closeAuthProfileReadPoolForSnapshotInvalidation,
-  resolveAuthProfileDatabasePath,
-} from "./sqlite.js";
+import { closeAuthProfileReadPool, resolveAuthProfileDatabasePath } from "./sqlite.js";
 import type { AuthProfileStore, RuntimeAuthProfileStore } from "./types.js";
 
 const runtimeAuthStoreSnapshots = new Map<string, RuntimeAuthProfileStore>();
@@ -47,7 +44,7 @@ const persistedMutationRecords = new Map<string, PersistedMutationRecord>();
 
 function advanceRuntimeAuthStoreSnapshotsRevision(): void {
   // Readers must close before consumers can observe the new snapshot generation.
-  closeAuthProfileReadPoolForSnapshotInvalidation();
+  closeAuthProfileReadPool();
   runtimeAuthStoreSnapshotsRevision += 1;
 }
 
@@ -334,7 +331,7 @@ export function clearRuntimeAuthProfileStoreSnapshots(): void {
   if (snapshotsChanged) {
     advanceRuntimeAuthStoreSnapshotsRevision();
   } else {
-    closeAuthProfileReadPoolForSnapshotInvalidation();
+    closeAuthProfileReadPool();
   }
   runtimeAuthStoreSnapshots.clear();
   clearAllRuntimeAuthMaterializations();

--- a/src/agents/auth-profiles/runtime-snapshots.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.ts
@@ -10,7 +10,10 @@ import {
   clearAllRuntimeAuthMaterializations,
   clearRuntimeAuthMaterializations,
 } from "./runtime-materializations.js";
-import { resolveAuthProfileDatabasePath } from "./sqlite.js";
+import {
+  closeAuthProfileReadPoolForSnapshotInvalidation,
+  resolveAuthProfileDatabasePath,
+} from "./sqlite.js";
 import type { AuthProfileStore, RuntimeAuthProfileStore } from "./types.js";
 
 const runtimeAuthStoreSnapshots = new Map<string, RuntimeAuthProfileStore>();
@@ -41,6 +44,12 @@ type PersistedMutationRecord = {
 };
 
 const persistedMutationRecords = new Map<string, PersistedMutationRecord>();
+
+function advanceRuntimeAuthStoreSnapshotsRevision(): void {
+  // Readers must close before consumers can observe the new snapshot generation.
+  closeAuthProfileReadPoolForSnapshotInvalidation();
+  runtimeAuthStoreSnapshotsRevision += 1;
+}
 
 function maxMutationRevision(record: PersistedMutationRecord): number {
   return Math.max(
@@ -186,7 +195,7 @@ function recordChangedSnapshotRevisions(
       continue;
     }
     changed = true;
-    runtimeAuthStoreSnapshotsRevision += 1;
+    advanceRuntimeAuthStoreSnapshotsRevision();
     if (next.has(key)) {
       runtimeAuthStoreSnapshotRevisions.set(key, runtimeAuthStoreSnapshotsRevision);
     } else {
@@ -323,7 +332,9 @@ export function clearRuntimeAuthProfileStoreSnapshots(): void {
     runtimeAuthStoreCredentialsRevision += 1;
   }
   if (snapshotsChanged) {
-    runtimeAuthStoreSnapshotsRevision += 1;
+    advanceRuntimeAuthStoreSnapshotsRevision();
+  } else {
+    closeAuthProfileReadPoolForSnapshotInvalidation();
   }
   runtimeAuthStoreSnapshots.clear();
   clearAllRuntimeAuthMaterializations();
@@ -343,7 +354,7 @@ export function clearRuntimeAuthProfileStoreSnapshot(agentDir?: string): boolean
   if (Object.keys(store.profiles).length > 0) {
     runtimeAuthStoreCredentialsRevision += 1;
   }
-  runtimeAuthStoreSnapshotsRevision += 1;
+  advanceRuntimeAuthStoreSnapshotsRevision();
   runtimeAuthStoreSnapshots.delete(key);
   clearRuntimeAuthMaterializations(agentDir);
   runtimeAuthStoreSnapshotRevisions.delete(key);
@@ -373,7 +384,7 @@ export function setRuntimeAuthProfileStoreSnapshot(
   const ownerChanged = !isDeepStrictEqual(ownerState(previousStore), ownerState(store));
   const snapshotChanged = !isDeepStrictEqual(previousStore, store);
   if (snapshotChanged) {
-    runtimeAuthStoreSnapshotsRevision += 1;
+    advanceRuntimeAuthStoreSnapshotsRevision();
     runtimeAuthStoreSnapshotRevisions.set(key, runtimeAuthStoreSnapshotsRevision);
   }
   runtimeAuthStoreSnapshots.set(key, cloneAuthProfileStore(store));
@@ -437,7 +448,7 @@ export function noteRuntimeAuthProfileStorePersistedMutation(
     }
   }
   if (deletedDerivedSnapshot) {
-    runtimeAuthStoreSnapshotsRevision += 1;
+    advanceRuntimeAuthStoreSnapshotsRevision();
   }
   if (mutation.credentialsChanged || mutation.profileSetChanged) {
     notifyRuntimeAuthStoreMutation(agentDir);

--- a/src/agents/auth-profiles/sqlite.ts
+++ b/src/agents/auth-profiles/sqlite.ts
@@ -161,7 +161,8 @@ function inspectAuthProfileJsonCell(
   }
 }
 
-function closeAuthProfileReadDatabase(pathname: string): void {
+function closeAuthProfileReadDatabase(databasePath: string): void {
+  const pathname = path.resolve(databasePath);
   const db = authProfileReadDatabases.get(pathname);
   if (!db) {
     return;
@@ -177,16 +178,16 @@ function closeAuthProfileReadDatabase(pathname: string): void {
   }
 }
 
-/** Internal lifecycle close for process-local pooled auth-profile readers. */
-export function closeAuthProfileReadPoolForSnapshotInvalidation(): void {
+/** Internal lifecycle close for one or all process-local pooled auth-profile readers. */
+export function closeAuthProfileReadPool(databasePath?: string): void {
+  if (databasePath !== undefined) {
+    closeAuthProfileReadDatabase(databasePath);
+    return;
+  }
   unregisterReadHandleExitClose?.();
   unregisterReadHandleExitClose = null;
-  for (const [pathname, db] of authProfileReadDatabases) {
-    authProfileReadDatabases.delete(pathname);
-    clearNodeSqliteKyselyCacheForDatabase(db);
-    if (db.isOpen) {
-      db.close();
-    }
+  for (const pathname of authProfileReadDatabases.keys()) {
+    closeAuthProfileReadDatabase(pathname);
   }
 }
 
@@ -241,9 +242,7 @@ function acquireAuthProfileReadDatabase(
     return { status: "unreadable" };
   }
   authProfileReadDatabases.set(resolvedPath, db);
-  unregisterReadHandleExitClose ??= registerSqliteCacheExitClose(
-    closeAuthProfileReadPoolForSnapshotInvalidation,
-  );
+  unregisterReadHandleExitClose ??= registerSqliteCacheExitClose(closeAuthProfileReadPool);
   return { status: "readable", db };
 }
 
@@ -261,7 +260,7 @@ function inspectAuthProfileJsonCellReadOnly(
   try {
     return inspectAuthProfileJsonCell(acquired.db, target);
   } catch {
-    closeAuthProfileReadDatabase(path.resolve(pathname));
+    closeAuthProfileReadDatabase(pathname);
     return { status: "unreadable" };
   }
 }

--- a/src/agents/auth-profiles/sqlite.ts
+++ b/src/agents/auth-profiles/sqlite.ts
@@ -10,6 +10,7 @@ import { safeParseJson } from "@openclaw/normalization-core";
 import { sha256HexPrefix } from "../../infra/crypto-digest.js";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
+  enableNodeSqliteKyselyStatementCache,
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
@@ -17,6 +18,7 @@ import {
 import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
 import { resolveSqliteDatabaseFilePaths } from "../../infra/sqlite-files.js";
 import { readSqliteUserVersion } from "../../infra/sqlite-user-version.js";
+import { registerSqliteCacheExitClose } from "../../infra/sqlite-wal.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
   OPENCLAW_AGENT_SCHEMA_VERSION,
@@ -36,6 +38,9 @@ type AuthProfileDatabase = Pick<
 // Auth profiles store one JSON blob for secrets and one JSON blob for runtime
 // state. SQLite owns durability/transactions; JSON shape owns compatibility.
 const PRIMARY_ROW_KEY = "primary";
+const AUTH_PROFILE_READ_HANDLE_CAP = 8;
+const authProfileReadDatabases = new Map<string, DatabaseSync>();
+let unregisterReadHandleExitClose: (() => void) | null = null;
 
 function resolveAgentDir(agentDir?: string): string {
   if (agentDir) {
@@ -156,34 +161,109 @@ function inspectAuthProfileJsonCell(
   }
 }
 
-function inspectAuthProfileJsonCellReadOnly(
-  pathname: string,
-  target: "store" | "state",
-): PersistedAuthProfileStoreInspection {
-  let db: DatabaseSync | undefined;
-  try {
-    db = openNodeSqliteDatabase(pathname, { readOnly: true });
-    // This short-lived reader bypasses the canonical agent DB bootstrap, but it
-    // must share its busy policy so brief rollback-journal locks do not look
-    // like missing credentials.
-    db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
-    if (readSqliteUserVersion(db) > OPENCLAW_AGENT_SCHEMA_VERSION) {
-      return { status: "unreadable" };
-    }
-    return inspectAuthProfileJsonCell(db, target);
-  } catch {
-    return { status: "unreadable" };
-  } finally {
-    if (db) {
-      clearNodeSqliteKyselyCacheForDatabase(db);
+function closeAuthProfileReadDatabase(pathname: string): void {
+  const db = authProfileReadDatabases.get(pathname);
+  if (!db) {
+    return;
+  }
+  authProfileReadDatabases.delete(pathname);
+  clearNodeSqliteKyselyCacheForDatabase(db);
+  if (db.isOpen) {
+    db.close();
+  }
+  if (authProfileReadDatabases.size === 0) {
+    unregisterReadHandleExitClose?.();
+    unregisterReadHandleExitClose = null;
+  }
+}
+
+/** Internal lifecycle close for process-local pooled auth-profile readers. */
+export function closeAuthProfileReadPoolForSnapshotInvalidation(): void {
+  unregisterReadHandleExitClose?.();
+  unregisterReadHandleExitClose = null;
+  for (const [pathname, db] of authProfileReadDatabases) {
+    authProfileReadDatabases.delete(pathname);
+    clearNodeSqliteKyselyCacheForDatabase(db);
+    if (db.isOpen) {
       db.close();
     }
   }
 }
 
-function readAuthProfileJsonCellReadOnly(pathname: string, target: "store" | "state"): unknown {
-  const result = inspectAuthProfileJsonCellReadOnly(pathname, target);
-  return result.status === "readable" ? result.raw : null;
+function isMissingDatabasePath(pathname: string): boolean {
+  try {
+    fs.statSync(pathname);
+    return false;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ENOENT";
+  }
+}
+
+function acquireAuthProfileReadDatabase(
+  pathname: string,
+): { status: "missing" } | { status: "unreadable" } | { status: "readable"; db: DatabaseSync } {
+  const resolvedPath = path.resolve(pathname);
+  const cached = authProfileReadDatabases.get(resolvedPath);
+  if (cached?.isOpen) {
+    authProfileReadDatabases.delete(resolvedPath);
+    authProfileReadDatabases.set(resolvedPath, cached);
+    return { status: "readable", db: cached };
+  }
+  if (cached) {
+    closeAuthProfileReadDatabase(resolvedPath);
+  }
+  while (authProfileReadDatabases.size >= AUTH_PROFILE_READ_HANDLE_CAP) {
+    const oldestPath = authProfileReadDatabases.keys().next().value;
+    if (oldestPath === undefined) {
+      break;
+    }
+    closeAuthProfileReadDatabase(oldestPath);
+  }
+  let db: DatabaseSync;
+  try {
+    db = openNodeSqliteDatabase(resolvedPath, { readOnly: true });
+  } catch {
+    return isMissingDatabasePath(resolvedPath) ? { status: "missing" } : { status: "unreadable" };
+  }
+  try {
+    enableNodeSqliteKyselyStatementCache(db);
+    // The pooled reader bypasses canonical agent DB bootstrap, but it shares
+    // the same busy policy and validates the process-stable schema on open.
+    db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
+    if (readSqliteUserVersion(db) > OPENCLAW_AGENT_SCHEMA_VERSION) {
+      clearNodeSqliteKyselyCacheForDatabase(db);
+      db.close();
+      return { status: "unreadable" };
+    }
+  } catch {
+    clearNodeSqliteKyselyCacheForDatabase(db);
+    db.close();
+    return { status: "unreadable" };
+  }
+  authProfileReadDatabases.set(resolvedPath, db);
+  unregisterReadHandleExitClose ??= registerSqliteCacheExitClose(
+    closeAuthProfileReadPoolForSnapshotInvalidation,
+  );
+  return { status: "readable", db };
+}
+
+function inspectAuthProfileJsonCellReadOnly(
+  pathname: string,
+  target: "store" | "state",
+): PersistedAuthProfileStoreInspection {
+  const acquired = acquireAuthProfileReadDatabase(pathname);
+  if (acquired.status === "missing") {
+    return { status: "missing", reason: "database" };
+  }
+  if (acquired.status === "unreadable") {
+    return { status: "unreadable" };
+  }
+  try {
+    return inspectAuthProfileJsonCell(acquired.db, target);
+  } catch {
+    closeAuthProfileReadDatabase(path.resolve(pathname));
+    return { status: "unreadable" };
+  }
 }
 
 /** Distinguishes an absent auth row from a present store that could not be read. */
@@ -194,11 +274,7 @@ export function inspectPersistedAuthProfileStoreRaw(
   if (database) {
     return inspectAuthProfileJsonCell(database.db, "store");
   }
-  const databasePath = resolveAuthProfileDatabasePath(agentDir);
-  if (!fs.existsSync(databasePath)) {
-    return { status: "missing", reason: "database" };
-  }
-  return inspectAuthProfileJsonCellReadOnly(databasePath, "store");
+  return inspectAuthProfileJsonCellReadOnly(resolveAuthProfileDatabasePath(agentDir), "store");
 }
 
 /** Distinguishes an absent auth-state row from state that could not be read. */
@@ -209,11 +285,7 @@ export function inspectPersistedAuthProfileStateRaw(
   if (database) {
     return inspectAuthProfileJsonCell(database.db, "state");
   }
-  const databasePath = resolveAuthProfileDatabasePath(agentDir);
-  if (!fs.existsSync(databasePath)) {
-    return { status: "missing", reason: "database" };
-  }
-  return inspectAuthProfileJsonCellReadOnly(databasePath, "state");
+  return inspectAuthProfileJsonCellReadOnly(resolveAuthProfileDatabasePath(agentDir), "state");
 }
 
 /** Reads the raw persisted secrets-store payload without coercing the schema. */
@@ -232,11 +304,11 @@ export function readPersistedAuthProfileStoreRaw(
     );
     return parseJsonCell(row?.store_json);
   }
-  const databasePath = resolveAuthProfileDatabasePath(agentDir);
-  if (!fs.existsSync(databasePath)) {
-    return null;
-  }
-  return readAuthProfileJsonCellReadOnly(databasePath, "store");
+  const result = inspectAuthProfileJsonCellReadOnly(
+    resolveAuthProfileDatabasePath(agentDir),
+    "store",
+  );
+  return result.status === "readable" ? result.raw : null;
 }
 
 /** Reads the raw persisted runtime-state payload without coercing the schema. */
@@ -255,11 +327,11 @@ export function readPersistedAuthProfileStateRaw(
     );
     return parseJsonCell(row?.state_json);
   }
-  const databasePath = resolveAuthProfileDatabasePath(agentDir);
-  if (!fs.existsSync(databasePath)) {
-    return null;
-  }
-  return readAuthProfileJsonCellReadOnly(databasePath, "state");
+  const result = inspectAuthProfileJsonCellReadOnly(
+    resolveAuthProfileDatabasePath(agentDir),
+    "state",
+  );
+  return result.status === "readable" ? result.raw : null;
 }
 
 /** Writes the raw persisted secrets-store payload inside the auth database. */

--- a/src/agents/auth-profiles/sqlite.ts
+++ b/src/agents/auth-profiles/sqlite.ts
@@ -16,6 +16,7 @@ import {
   getNodeSqliteKysely,
 } from "../../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
+import { isPathInside } from "../../infra/path-guards.js";
 import { resolveSqliteDatabaseFilePaths } from "../../infra/sqlite-files.js";
 import { readSqliteUserVersion } from "../../infra/sqlite-user-version.js";
 import { registerSqliteCacheExitClose } from "../../infra/sqlite-wal.js";
@@ -41,6 +42,10 @@ const PRIMARY_ROW_KEY = "primary";
 const AUTH_PROFILE_READ_HANDLE_CAP = 8;
 const authProfileReadDatabases = new Map<string, DatabaseSync>();
 let unregisterReadHandleExitClose: (() => void) | null = null;
+
+type AuthProfileReadPoolCloseScope =
+  | { kind: "database"; databasePath: string }
+  | { kind: "root"; rootPath: string };
 
 function resolveAgentDir(agentDir?: string): string {
   if (agentDir) {
@@ -178,10 +183,18 @@ function closeAuthProfileReadDatabase(databasePath: string): void {
   }
 }
 
-/** Internal lifecycle close for one or all process-local pooled auth-profile readers. */
-export function closeAuthProfileReadPool(databasePath?: string): void {
-  if (databasePath !== undefined) {
-    closeAuthProfileReadDatabase(databasePath);
+/** Internal lifecycle close for scoped or all process-local pooled auth-profile readers. */
+export function closeAuthProfileReadPool(scope?: AuthProfileReadPoolCloseScope): void {
+  if (scope?.kind === "database") {
+    closeAuthProfileReadDatabase(scope.databasePath);
+    return;
+  }
+  if (scope?.kind === "root") {
+    for (const pathname of authProfileReadDatabases.keys()) {
+      if (isPathInside(scope.rootPath, pathname)) {
+        closeAuthProfileReadDatabase(pathname);
+      }
+    }
     return;
   }
   unregisterReadHandleExitClose?.();

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -7,7 +7,6 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { isDeepStrictEqual } from "node:util";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isSecretRef } from "../../config/types.secrets.js";
-import { asDateTimestampMs } from "../../shared/number-coercion.js";
 import {
   deferOpenClawAgentPostCommitPublication,
   type OpenClawAgentDatabase,
@@ -31,10 +30,14 @@ import {
   warnLegacyAuthProfileSourcesIgnored,
 } from "./legacy-source-diagnostic.js";
 import {
-  isSafeToAdoptMainStoreOAuthIdentity,
   shouldPersistRuntimeExternalOAuthProfile,
   type RuntimeExternalOAuthProfile,
 } from "./oauth-shared.js";
+import {
+  isInheritedMainOAuthCredentialFromStores,
+  shouldUseMainOwnerForLocalOAuthCredential,
+  type PersistedAuthProfileStores,
+} from "./ownership.js";
 import {
   buildPersistedAuthProfileSecretsStore,
   loadPersistedAuthProfileStore,
@@ -237,6 +240,19 @@ function resolvePersistedLoadOptions(
   };
 }
 
+function loadPersistedAuthProfileStores(
+  agentDir?: string,
+  database?: OpenClawAgentDatabase,
+): PersistedAuthProfileStores {
+  const localStore = loadPersistedAuthProfileStore(agentDir, database ? { database } : undefined);
+  const isMainStore = resolveAuthStorePath(agentDir) === resolveAuthStorePath();
+  return {
+    isMainStore,
+    localStore,
+    mainStore: isMainStore ? localStore : loadPersistedAuthProfileStore(),
+  };
+}
+
 /**
  * A non-main agent store deliberately does not persist an OAuth credential the
  * main store already owns at the same or newer expiry. Callers that verify a
@@ -251,49 +267,11 @@ export function isInheritedMainOAuthCredential(params: {
   if (!params.agentDir || params.credential.type !== "oauth") {
     return false;
   }
-  const authPath = resolveAuthStorePath(params.agentDir);
-  const mainAuthPath = resolveAuthStorePath();
-  if (authPath === mainAuthPath) {
-    return false;
-  }
-
-  const localStore = loadPersistedAuthProfileStore(params.agentDir);
-  if (localStore?.profiles[params.profileId]) {
-    return false;
-  }
-
-  // Local agent stores can inherit main OAuth credentials. Do not persist the
-  // inherited copy unless the local store actually owns or improves it.
-  const mainCredential = loadPersistedAuthProfileStore()?.profiles[params.profileId];
-  return (
-    mainCredential?.type === "oauth" &&
-    (isDeepStrictEqual(mainCredential, params.credential) ||
-      shouldUseMainOwnerForLocalOAuthCredential({
-        local: params.credential,
-        main: mainCredential,
-      }))
-  );
-}
-
-function shouldUseMainOwnerForLocalOAuthCredential(params: {
-  local: AuthProfileStore["profiles"][string];
-  main: AuthProfileStore["profiles"][string] | undefined;
-}): boolean {
-  if (params.local.type !== "oauth" || params.main?.type !== "oauth") {
-    return false;
-  }
-  if (!isSafeToAdoptMainStoreOAuthIdentity(params.local, params.main)) {
-    return false;
-  }
-  if (isDeepStrictEqual(params.local, params.main)) {
-    return true;
-  }
-  const mainExpires = asDateTimestampMs(params.main.expires);
-  if (mainExpires === undefined) {
-    return false;
-  }
-  const localExpires = asDateTimestampMs(params.local.expires);
-  return localExpires === undefined || mainExpires >= localExpires;
+  return isInheritedMainOAuthCredentialFromStores({
+    profileId: params.profileId,
+    credential: params.credential,
+    persistedStores: loadPersistedAuthProfileStores(params.agentDir),
+  });
 }
 
 function resolveRuntimeAuthProfileStore(
@@ -474,16 +452,17 @@ function shouldKeepProfileInLocalStore(params: {
   credential: AuthProfileStore["profiles"][string];
   agentDir?: string;
   options?: SaveAuthProfileStoreOptions;
+  persistedStores: PersistedAuthProfileStores;
   externalProfiles: () => RuntimeExternalOAuthProfile[];
 }): boolean {
   if (params.credential.type !== "oauth") {
     return true;
   }
   if (
-    isInheritedMainOAuthCredential({
-      agentDir: params.agentDir,
+    isInheritedMainOAuthCredentialFromStores({
       profileId: params.profileId,
       credential: params.credential,
+      persistedStores: params.persistedStores,
     })
   ) {
     return false;
@@ -494,9 +473,7 @@ function shouldKeepProfileInLocalStore(params: {
   if (params.store.runtimeExternalProfileIds?.includes(params.profileId)) {
     // Runtime external profiles are normally overlays. Persist only when they
     // have explicit local state or differ from the runtime snapshot.
-    const persistedCredential = loadPersistedAuthProfileStore(params.agentDir)?.profiles[
-      params.profileId
-    ];
+    const persistedCredential = params.persistedStores.localStore?.profiles[params.profileId];
     if (persistedCredential) {
       return shouldPersistRuntimeExternalOAuthProfile({
         profileId: params.profileId,
@@ -572,6 +549,7 @@ function buildLocalAuthProfileStoreForSave(params: {
   store: AuthProfileStore;
   agentDir?: string;
   options?: SaveAuthProfileStoreOptions;
+  persistedStores: PersistedAuthProfileStores;
 }): AuthProfileStore {
   const localStore = cloneAuthProfileStore(params.store);
   let externalProfiles: RuntimeExternalOAuthProfile[] | undefined;
@@ -588,6 +566,7 @@ function buildLocalAuthProfileStoreForSave(params: {
         credential,
         agentDir: params.agentDir,
         options: params.options,
+        persistedStores: params.persistedStores,
         externalProfiles: getExternalProfiles,
       }),
     ),
@@ -601,9 +580,7 @@ function buildLocalAuthProfileStoreForSave(params: {
       keptOrderProfileIds.add(normalizedProfileId);
     }
   }
-  for (const profileIds of Object.values(
-    loadPersistedAuthProfileState(params.agentDir).order ?? {},
-  )) {
+  for (const profileIds of Object.values(params.persistedStores.localStore?.order ?? {})) {
     for (const profileId of profileIds) {
       keptOrderProfileIds.add(profileId);
     }
@@ -680,6 +657,7 @@ function buildRuntimeAuthProfileStoreForSave(params: {
   store: AuthProfileStore;
   agentDir?: string;
   options?: SaveAuthProfileStoreOptions;
+  persistedStores: PersistedAuthProfileStores;
 }): AuthProfileStore {
   return buildLocalAuthProfileStoreForSave({
     ...params,
@@ -1371,7 +1349,21 @@ function saveAuthProfileStoreInTransaction(
   const savedAuthPath = resolveAuthStorePath(agentDir);
   const mainAuthPath = resolveAuthStorePath();
   const savesMainStore = savedAuthPath === mainAuthPath;
-  const localStore = buildLocalAuthProfileStoreForSave({ store, agentDir, options });
+  const loadedPersistedStores = loadPersistedAuthProfileStores(agentDir, database);
+  const persistedStores: PersistedAuthProfileStores = {
+    ...loadedPersistedStores,
+    localStore: loadedPersistedStores.localStore ?? {
+      version: AUTH_STORE_VERSION,
+      profiles: {},
+      ...loadPersistedAuthProfileState(agentDir, database),
+    },
+  };
+  const localStore = buildLocalAuthProfileStoreForSave({
+    store,
+    agentDir,
+    options,
+    persistedStores,
+  });
   const existingRaw = readPersistedAuthProfileStoreRaw(agentDir, database);
   const payload = preserveLegacyOAuthRefsOnSave({
     payload: buildPersistedAuthProfileSecretsStore(localStore),
@@ -1396,7 +1388,7 @@ function saveAuthProfileStoreInTransaction(
   );
   const suppliedRuntimeStore = publishFromSuppliedStore
     ? markRuntimePersistedProfiles(
-        buildRuntimeAuthProfileStoreForSave({ store, agentDir, options }),
+        buildRuntimeAuthProfileStoreForSave({ store, agentDir, options, persistedStores }),
         localStore,
       )
     : undefined;

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -17,6 +17,7 @@ import {
   areOAuthCredentialsEquivalent,
   hasMatchingOAuthIdentity,
 } from "../agents/auth-profiles/oauth-shared.js";
+import { isInheritedMainOAuthCredentialFromStores } from "../agents/auth-profiles/ownership.js";
 import {
   applyLegacyAuthStore,
   coerceLegacyAuthStore,
@@ -35,7 +36,6 @@ import {
 import { coerceAuthProfileState } from "../agents/auth-profiles/state.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
-  isInheritedMainOAuthCredential,
   saveAuthProfileStore,
 } from "../agents/auth-profiles/store.js";
 import type {
@@ -1263,6 +1263,18 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
               database,
             );
             const loaded = loadMigratedStore(candidate.agentDir, { database });
+            const mainAgentDir = resolveSharedMainAuthAgentDir(params.env);
+            const persistedStores = {
+              isMainStore:
+                resolveAuthProfileDatabasePath(candidate.agentDir) ===
+                resolveAuthProfileDatabasePath(mainAgentDir),
+              localStore: loaded,
+              mainStore:
+                resolveAuthProfileDatabasePath(candidate.agentDir) ===
+                resolveAuthProfileDatabasePath(mainAgentDir)
+                  ? loaded
+                  : loadPersistedAuthProfileStore(mainAgentDir),
+            };
             // A non-main store drops an OAuth credential the main store already
             // owns at the same or newer expiry. That dedup is intentional, so
             // verifying it as missing would abort a migration that lost nothing
@@ -1273,10 +1285,10 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
                 return (
                   credential !== undefined &&
                   !loaded?.profiles[profileId] &&
-                  isInheritedMainOAuthCredential({
-                    agentDir: candidate.agentDir,
+                  isInheritedMainOAuthCredentialFromStores({
                     profileId,
                     credential,
+                    persistedStores,
                   })
                 );
               }),

--- a/src/test-utils/openclaw-test-state.test.ts
+++ b/src/test-utils/openclaw-test-state.test.ts
@@ -2,12 +2,16 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import { describe, expect, it, vi } from "vitest";
 import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
+import { closeAuthProfileReadPool } from "../agents/auth-profiles/sqlite.js";
+import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
 import {
   GATEWAY_STARTUP_MUTATED_ENV_KEYS,
   snapshotGatewayStartupEnv,
 } from "../gateway/test-helpers.env.js";
+import * as nodeSqlite from "../infra/node-sqlite.js";
 import {
   closeOpenClawAgentDatabaseByPath,
   openOpenClawAgentDatabase,
@@ -176,6 +180,22 @@ describe("openclaw test state", () => {
       layout: "state-only",
       label: "database-cleanup",
     });
+    const authStore = {
+      version: 1,
+      profiles: {
+        "openai:test": {
+          type: "api_key" as const,
+          provider: "openai",
+          key: "sk-test",
+        },
+      },
+    };
+    const fixtureAuthPath = await state.writeAuthProfiles(authStore, "auth-reader");
+    const unrelatedAgentDir = path.join(unrelatedRoot, "state", "agents", "outside", "agent");
+    saveAuthProfileStore(authStore, unrelatedAgentDir, {
+      filterExternalAuthProfiles: false,
+      syncExternalCli: false,
+    });
     const fixtureShared = openOpenClawStateDatabase({ env: state.env });
     const fixtureAgent = openOpenClawAgentDatabase({
       agentId: "worker",
@@ -186,12 +206,40 @@ describe("openclaw test state", () => {
       agentId: "outside",
       env: unrelatedEnv,
     });
+    const openSpy = vi.spyOn(nodeSqlite, "openNodeSqliteDatabase");
+    expect(loadPersistedAuthProfileStore(state.agentDir("auth-reader"))).not.toBeNull();
+    expect(loadPersistedAuthProfileStore(unrelatedAgentDir)).not.toBeNull();
+    const readOnlyDatabases = openSpy.mock.calls.flatMap((call, index) => {
+      if (call[1]?.readOnly !== true) {
+        return [];
+      }
+      const database = openSpy.mock.results[index]?.value as DatabaseSync | undefined;
+      return database ? [{ path: path.resolve(call[0]), database }] : [];
+    });
+    const fixtureAuthReader = readOnlyDatabases.find(
+      (entry) => entry.path === path.resolve(fixtureAuthPath),
+    )?.database;
+    const unrelatedAuthReader = readOnlyDatabases.find(
+      (entry) => entry.path === path.resolve(unrelatedAgent.path),
+    )?.database;
+    if (!fixtureAuthReader || !unrelatedAuthReader) {
+      throw new Error("expected fixture and unrelated pooled auth readers");
+    }
+    expect(fixtureAuthReader.isOpen).toBe(true);
+    expect(unrelatedAuthReader.isOpen).toBe(true);
     const restoreEnv = state.restoreEnv;
-    const rmSpy = vi.spyOn(fs, "rm");
+    const originalRm = fs.rm;
+    const rmSpy = vi.spyOn(fs, "rm").mockImplementation((...args) => {
+      expect(fixtureAuthReader.isOpen).toBe(false);
+      expect(unrelatedAuthReader.isOpen).toBe(true);
+      return originalRm(...args);
+    });
     state.restoreEnv = () => {
       expect(process.env.OPENCLAW_STATE_DIR).toBe(state.stateDir);
+      expect(fixtureAuthReader.isOpen).toBe(false);
       expect(fixtureShared.db.isOpen).toBe(false);
       expect(fixtureAgent.db.isOpen).toBe(false);
+      expect(unrelatedAuthReader.isOpen).toBe(true);
       expect(unrelatedShared.db.isOpen).toBe(true);
       expect(unrelatedAgent.db.isOpen).toBe(true);
       restoreEnv();
@@ -208,15 +256,19 @@ describe("openclaw test state", () => {
         retryDelay: 25,
       });
       await expectPathMissing(state.root);
+      expect(unrelatedAuthReader.isOpen).toBe(true);
       expect(unrelatedShared.db.isOpen).toBe(true);
       expect(unrelatedAgent.db.isOpen).toBe(true);
     } finally {
       state.restoreEnv = restoreEnv;
       restoreEnv();
+      closeAuthProfileReadPool(fixtureAuthPath);
+      closeAuthProfileReadPool(unrelatedAgent.path);
       closeOpenClawAgentDatabaseByPath(fixtureAgent.path);
       closeOpenClawAgentDatabaseByPath(unrelatedAgent.path);
       closeOpenClawStateDatabaseByPath(fixtureShared.path);
       closeOpenClawStateDatabaseByPath(unrelatedShared.path);
+      openSpy.mockRestore();
       rmSpy.mockRestore();
       await fs.rm(state.root, {
         recursive: true,

--- a/src/test-utils/openclaw-test-state.test.ts
+++ b/src/test-utils/openclaw-test-state.test.ts
@@ -5,7 +5,10 @@ import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { describe, expect, it, vi } from "vitest";
 import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
-import { closeAuthProfileReadPool } from "../agents/auth-profiles/sqlite.js";
+import {
+  closeAuthProfileReadPool,
+  resolveAuthProfileDatabasePath,
+} from "../agents/auth-profiles/sqlite.js";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
 import {
   GATEWAY_STARTUP_MUTATED_ENV_KEYS,
@@ -190,7 +193,12 @@ describe("openclaw test state", () => {
         },
       },
     };
-    const fixtureAuthPath = await state.writeAuthProfiles(authStore, "auth-reader");
+    const fixtureAuthDir = state.agentDir("auth-reader");
+    const fixtureAuthPath = resolveAuthProfileDatabasePath(fixtureAuthDir);
+    saveAuthProfileStore(authStore, fixtureAuthDir, {
+      filterExternalAuthProfiles: false,
+      syncExternalCli: false,
+    });
     const unrelatedAgentDir = path.join(unrelatedRoot, "state", "agents", "outside", "agent");
     saveAuthProfileStore(authStore, unrelatedAgentDir, {
       filterExternalAuthProfiles: false,
@@ -262,8 +270,8 @@ describe("openclaw test state", () => {
     } finally {
       state.restoreEnv = restoreEnv;
       restoreEnv();
-      closeAuthProfileReadPool(fixtureAuthPath);
-      closeAuthProfileReadPool(unrelatedAgent.path);
+      closeAuthProfileReadPool({ kind: "database", databasePath: fixtureAuthPath });
+      closeAuthProfileReadPool({ kind: "database", databasePath: unrelatedAgent.path });
       closeOpenClawAgentDatabaseByPath(fixtureAgent.path);
       closeOpenClawAgentDatabaseByPath(unrelatedAgent.path);
       closeOpenClawStateDatabaseByPath(fixtureShared.path);

--- a/src/test-utils/openclaw-test-state.ts
+++ b/src/test-utils/openclaw-test-state.ts
@@ -314,7 +314,6 @@ export async function createOpenClawTestState(
   const snapshot = captureEnv(uniqueStrings([...ENV_KEYS, ...Object.keys(envVars)]));
   let envApplied = false;
   let cleaned = false;
-  const authProfileDatabasePaths = new Set<string>();
   const agentDir = (agentId = "main") => path.join(paths.stateDir, "agents", agentId, "agent");
   const sessionsDir = (agentId = "main") =>
     path.join(paths.stateDir, "agents", agentId, "sessions");
@@ -339,13 +338,11 @@ export async function createOpenClawTestState(
     },
     writeAuthProfiles: (store, agentId = "main") => {
       const targetAgentDir = agentDir(agentId);
-      const databasePath = resolveAuthProfileDatabasePath(targetAgentDir);
-      authProfileDatabasePaths.add(databasePath);
       saveAuthProfileStore(store as AuthProfileStore, targetAgentDir, {
         filterExternalAuthProfiles: false,
         syncExternalCli: false,
       });
-      return Promise.resolve(databasePath);
+      return Promise.resolve(resolveAuthProfileDatabasePath(targetAgentDir));
     },
     applyEnv: () => {
       resetConfigRuntimeStateForTest();
@@ -372,9 +369,7 @@ export async function createOpenClawTestState(
       }
       cleaned = true;
       await cleanupSessionStateForTest().catch(() => undefined);
-      for (const databasePath of authProfileDatabasePaths) {
-        closeAuthProfileReadPool(databasePath);
-      }
+      closeAuthProfileReadPool({ kind: "root", rootPath: paths.stateDir });
       // Agent close releases leases through shared state; closing shared state first
       // can reopen it during teardown and leave Windows handles under the fixture root.
       for (const database of listOpenClawAgentDatabasesForTest()) {

--- a/src/test-utils/openclaw-test-state.ts
+++ b/src/test-utils/openclaw-test-state.ts
@@ -3,7 +3,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { resolveAuthProfileDatabasePath } from "../agents/auth-profiles/sqlite.js";
+import {
+  closeAuthProfileReadPool,
+  resolveAuthProfileDatabasePath,
+} from "../agents/auth-profiles/sqlite.js";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import * as configRuntime from "../config/config.js";
@@ -311,6 +314,7 @@ export async function createOpenClawTestState(
   const snapshot = captureEnv(uniqueStrings([...ENV_KEYS, ...Object.keys(envVars)]));
   let envApplied = false;
   let cleaned = false;
+  const authProfileDatabasePaths = new Set<string>();
   const agentDir = (agentId = "main") => path.join(paths.stateDir, "agents", agentId, "agent");
   const sessionsDir = (agentId = "main") =>
     path.join(paths.stateDir, "agents", agentId, "sessions");
@@ -335,11 +339,13 @@ export async function createOpenClawTestState(
     },
     writeAuthProfiles: (store, agentId = "main") => {
       const targetAgentDir = agentDir(agentId);
+      const databasePath = resolveAuthProfileDatabasePath(targetAgentDir);
+      authProfileDatabasePaths.add(databasePath);
       saveAuthProfileStore(store as AuthProfileStore, targetAgentDir, {
         filterExternalAuthProfiles: false,
         syncExternalCli: false,
       });
-      return Promise.resolve(resolveAuthProfileDatabasePath(targetAgentDir));
+      return Promise.resolve(databasePath);
     },
     applyEnv: () => {
       resetConfigRuntimeStateForTest();
@@ -366,6 +372,9 @@ export async function createOpenClawTestState(
       }
       cleaned = true;
       await cleanupSessionStateForTest().catch(() => undefined);
+      for (const databasePath of authProfileDatabasePaths) {
+        closeAuthProfileReadPool(databasePath);
+      }
       // Agent close releases leases through shared state; closing shared state first
       // can reopen it during teardown and leave Windows handles under the fixture root.
       for (const database of listOpenClawAgentDatabasesForTest()) {


### PR DESCRIPTION
## What Problem This Solves

Resolves a performance problem where persisted auth-profile reads repeatedly opened and closed the same SQLite database during one logical load or inherited-profile save. The redundant per-profile reads increased handle churn, latency, and memory use without changing the data returned.

## Why This Change Was Made

Auth-profile storage now owns a bounded, path-keyed pool of reusable read handles and closes them through the existing lifecycle boundary. The save path also prefetches inherited OAuth profiles once and passes that authoritative snapshot forward, removing duplicate per-profile loads while preserving the canonical SQLite owner and current behavior.

There are no SQLite schema, configuration, environment-variable, migration, or public behavior changes. This is an AI-assisted maintainer change; the exact patch received an independent clean autoreview before publication.

## User Impact

Operators with persisted or inherited auth profiles should see faster profile loading and lower transient memory pressure. Authentication behavior and stored data remain unchanged.

## Evidence

- Stable reviewed patch ID: `3e93b5175dc3a00e53884b4c3cea2bc37c713e13`.
- Deterministic handle instrumentation: two standalone persisted loads dropped from 4 opens to 1 per database path; saving 3 inherited OAuth profiles dropped from 10 read-only opens to 1 main-store open with zero extra local opens.
- Earlier scoped timing/RSS comparison: 13.49 seconds and 497,614,848 bytes before; 5.22 seconds and 435,159,040 bytes after. Handle counts are the primary deterministic proof.
- Rebased-head focused proof: `node scripts/run-vitest.mjs src/agents/auth-profiles.sqlite-store.test.ts src/agents/auth-profiles/runtime-snapshots.test.ts src/commands/doctor-auth-flat-profiles.test.ts` passed doctor 49/49, SQLite 15/15, and runtime snapshots 10/10.
- `git diff --check origin/main...HEAD` passed.
- Production delta: +241/-101 (net +140), justified by the bounded lifecycle-owned SQLite read pool and explicit prefetched ownership boundary. Tests: +86.
