### PR TITLE
fix(scripts): restore subagent lifecycle seam audit coverage

### DIFF
--- a/scripts/audit-seams.mts
+++ b/scripts/audit-seams.mts
@@ -552,11 +552,12 @@ function splitNameTokens(name: string) {
     .filter(Boolean);
 }
 
-function hasImportSource(source: string, specifier: string) {
+function hasImportSource(source: string, specifier: string, matchSuffix = false) {
   const escaped = escapeRegExp(specifier);
-  return new RegExp(`from\\s+["']${escaped}["']|import\\s*\\(\\s*["']${escaped}["']\\s*\\)`).test(
-    source,
-  );
+  const importSource = matchSuffix ? `(?:[^"']*/)?${escaped}` : escaped;
+  return new RegExp(
+    `from\\s+["']${importSource}["']|import\\s*\\(\\s*["']${importSource}["']\\s*\\)`,
+  ).test(source);
 }
 
 function hasAnyImportSource(source: string, specifiers: string[]) {
@@ -700,19 +701,20 @@ function describeSubagentSeamKinds(relativePath: string, source: string) {
     "../acp/control-plane/manager.js",
     "../../../acp/control-plane/manager.js",
   ]);
-  const importsLifecycleRegistry = hasAnyImportSource(source, [
-    "./subagent-registry-completion.js",
-    "./subagent-registry-cleanup.js",
-    "./subagent-registry-state.js",
-    "./subagent-registry.js",
-    "./subagent-lifecycle-events.js",
-    "../context-engine/init.js",
-    "../context-engine/registry.js",
-    "../sessions/session-lifecycle-events.js",
-    "../../../context-engine/init.js",
-    "../../../context-engine/registry.js",
-    "../../../sessions/session-lifecycle-events.js",
-  ]);
+  const importsLifecycleRegistry =
+    hasImportSource(source, "subagent-registry.js", true) ||
+    hasAnyImportSource(source, [
+      "./subagent-registry-completion.js",
+      "./subagent-registry-cleanup.js",
+      "./subagent-registry-state.js",
+      "./subagent-lifecycle-events.js",
+      "../context-engine/init.js",
+      "../context-engine/registry.js",
+      "../sessions/session-lifecycle-events.js",
+      "../../../context-engine/init.js",
+      "../../../context-engine/registry.js",
+      "../../../sessions/session-lifecycle-events.js",
+    ]);
   const importsAnnounceDelivery = hasAnyImportSource(source, [
     "./subagent-announce.js",
     "./subagent-announce-dispatch.js",

--- a/test/scripts/audit-seams.test.ts
+++ b/test/scripts/audit-seams.test.ts
@@ -52,11 +52,11 @@ describe("audit-seams cron seam classification", () => {
 });
 
 describe("audit-seams subagent seam classification", () => {
-  it("detects subagent spawn and cleanup handoff boundaries", () => {
+  it("detects relocated native spawn executor seams", () => {
     const source = `
       import { callGateway } from "../../../gateway/call.js";
-      import { emitSessionLifecycleEvent } from "../../../sessions/session-lifecycle-events.js";
       import { registerSubagentRun } from "../../subagent-registry.js";
+      import { emitSessionLifecycleEvent } from "./subagent-spawn.runtime.js";
 
       export async function spawnSubagentDirect() {
         const response = await callGateway({ method: "agent.run", params: { task: "do it" } });


### PR DESCRIPTION
Related: #121350

## What Problem This Solves

Fixes an audit-coverage regression where the relocated native subagent spawn executor was no longer classified with the `subagent-lifecycle-registry` seam. Provenance from the merged move PR:

> [P2] Recognize the relocated registry lifecycle seam — `scripts/audit-seams.mts:703-715`

## Why This Change Was Made

The import classifier now recognizes module sources ending in `subagent-registry.js` at any relative depth, so another planned directory move will not silently drop the seam again. The focused fixture mirrors the relocated executor: its lifecycle event comes through the runtime barrel, leaving the `../../subagent-registry.js` import as the fact that supplies lifecycle-registry classification. This is AI-assisted work reviewed with the repository autoreview workflow.

## User Impact

None. This repairs internal tooling coverage only; runtime behavior and public interfaces are unchanged.

## Evidence

- Pre-fix classifier reproduction returned only `["subagent-session-spawn"]` for the relocated executor fixture.
- `node scripts/run-vitest.mjs test/scripts/audit-seams.test.ts`: 1 file passed, 9 tests passed.
- Full audit CLI: `src/agents/subagents/spawn/subagent-spawn.ts` reports `["subagent-lifecycle-registry","subagent-session-spawn"]`.
- Targeted Oxlint passed for `scripts/audit-seams.mts` and `test/scripts/audit-seams.test.ts`.
- Targeted `oxfmt --check` passed for both changed files.
- `git diff --check`: passed.
- Autoreview: clean, no accepted/actionable findings.
- LOC: production +19/-17 (net +2); tests +2/-2 (net 0).
