### PR TITLE
fix(microsoft-foundry): MAI setup writes valid image defaults

### DIFF
--- a/docs/plugins/reference/microsoft-foundry.md
+++ b/docs/plugins/reference/microsoft-foundry.md
@@ -74,9 +74,11 @@ name in the request `model` field:
 {
   agents: {
     defaults: {
-      imageGenerationModel: {
-        primary: "microsoft-foundry/<deployment-name>",
-        timeoutMs: 600000,
+      mediaModels: {
+        image: {
+          primary: "microsoft-foundry/<deployment-name>",
+          timeoutMs: 600000,
+        },
       },
     },
   },

--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -932,9 +932,10 @@ describe("microsoft-foundry plugin", () => {
       authMethod: "entra-id",
     });
 
-    expect(result.configPatch?.agents?.defaults?.imageGenerationModel).toEqual({
+    expect(result.configPatch?.agents?.defaults?.mediaModels?.image).toEqual({
       primary: "microsoft-foundry/mai-image-prod",
     });
+    expect(result.configPatch?.agents?.defaults).not.toHaveProperty("imageGenerationModel");
     expect(result.defaultModel).toBeUndefined();
     expect(requireFoundryProviderPatch(result).models[0]?.name).toBe("MAI-Image-2.5");
   });
@@ -986,7 +987,7 @@ describe("microsoft-foundry plugin", () => {
       modelNameHint: "MAI-Image-2.5",
       api: "openai-completions",
     });
-    expect(result.configPatch?.agents?.defaults?.imageGenerationModel).toEqual({
+    expect(result.configPatch?.agents?.defaults?.mediaModels?.image).toEqual({
       primary: "microsoft-foundry/prod-image",
     });
     expect(result.defaultModel).toBeUndefined();
@@ -1150,7 +1151,7 @@ describe("microsoft-foundry plugin", () => {
       ],
     });
 
-    expect(result.configPatch?.agents?.defaults?.imageGenerationModel).toEqual({
+    expect(result.configPatch?.agents?.defaults?.mediaModels?.image).toEqual({
       primary: "microsoft-foundry/custom-image-prod",
     });
     expect(result.defaultModel).toBeUndefined();

--- a/extensions/microsoft-foundry/shared.ts
+++ b/extensions/microsoft-foundry/shared.ts
@@ -129,16 +129,6 @@ type FoundryConfigShape = {
   };
 };
 
-type FoundryImageDefaultPatch = {
-  agents?: {
-    defaults?: {
-      imageGenerationModel?: {
-        primary: string;
-      };
-    };
-  };
-};
-
 function normalizeFoundryModelName(value?: string | null): string | undefined {
   const trimmed = normalizeLowercaseStringOrEmpty(value);
   return trimmed || undefined;
@@ -614,15 +604,17 @@ function buildFoundryImageDefaultPatch(params: {
   modelId: string;
   modelNameHint?: string | null;
   deployments?: FoundryDeploymentConfigInput[];
-}): FoundryImageDefaultPatch {
+}) {
   if (!isSelectedMaiImageDeployment(params)) {
     return {};
   }
   return {
     agents: {
       defaults: {
-        imageGenerationModel: {
-          primary: `${PROVIDER_ID}/${params.modelId}`,
+        mediaModels: {
+          image: {
+            primary: `${PROVIDER_ID}/${params.modelId}`,
+          },
         },
       },
     },


### PR DESCRIPTION
Related: #121330

## What Problem This Solves

Fixes an issue where users onboarding a Microsoft Foundry MAI image deployment would receive an `agents.defaults.imageGenerationModel` config patch that strict config validation rejects as a retired key.

## Why This Change Was Made

Microsoft Foundry now writes the canonical `agents.defaults.mediaModels.image` default at the provider-owned setup boundary. The obsolete local patch type was removed, and the preserved manual section of the generated Microsoft Foundry reference page now shows the same canonical shape. Doctor remains the only owner of migration for already-written legacy config.

The Microsoft Foundry plugin contains no other retired image/video/music model config emitters. A repo-wide audit also found the pre-existing fal onboarding writer still using the retired image key; that separate plugin path is intentionally left for a focused follow-up rather than expanding this Microsoft Foundry repair.

AI-assisted by Codex; the resulting code and tests were reviewed against the provider auth merge/write path, strict schema, doctor migration, plugin siblings, generated-doc preservation behavior, and introducing history.

## User Impact

Microsoft Foundry MAI image onboarding now produces a config that passes strict validation and selects the deployment as the default image-generation model. Existing legacy files continue to migrate through `openclaw doctor --fix`.

## Evidence

- Before the production change, the updated focused regression assertions failed on all three MAI setup paths because `mediaModels.image` was absent (3 failed, 104 passed).
- `node scripts/run-vitest.mjs run extensions/microsoft-foundry/index.test.ts` (107 passed).
- Strict-schema probe: the fixed auth patch validates after merge into a valid agent config; the prior shape reports `Unrecognized key: "imageGenerationModel"`.
- `node scripts/run-vitest.mjs run src/config/dead-config-keys.test.ts`.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/microsoft-foundry/index.test.ts extensions/microsoft-foundry/shared.ts`.
- `node scripts/run-tsgo.mjs -p extensions/microsoft-foundry/tsconfig.json`.
- `node --import tsx scripts/generate-plugin-inventory-doc.mts --write` followed by `--check`; the self-hosted manual docs block is preserved.
- Targeted oxfmt check and `git diff --check` passed.
- Production LOC: +5/-13; tests: +4/-3; generated manual docs: +5/-3.
