### PR TITLE
fix(ui): sidebar group headers read at the same weight as their sessions

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1876,14 +1876,18 @@ html.openclaw-native-macos
   stroke-width: 1.8px;
 }
 
+/* Structural label, not content: at the session row's 13px/500 a group reads as
+   just another session. Type carries the whole split because the head color
+   stays near `--text` for readability; case stays as authored (project names). */
 .sidebar-session-catalog-project__label {
   flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 13px;
-  font-weight: 500;
+  font-size: 12px;
+  font-weight: 650;
+  letter-spacing: 0.03em;
 }
 
 .sidebar-session-catalog-project__count {


### PR DESCRIPTION
Closes #121371

## What Problem This Solves

Fixes an issue where users browsing the Control UI sidebar would see a session group and the sessions inside it at the same visual weight, so the list read as one flat run of similar rows with no clear container level. The affected surface is the sidebar session organizer, specifically the collapsible aggregator rows (chevron + name + count) that the default `project` grouping produces for every session catalog.

## Why This Change Was Made

The sidebar already has a settled idiom for structural labels — the section eyebrows at `ui/src/styles/layout.css:1718` are small, heavy, tracked, uppercase, and muted — but the project/group header ignored that family and copied the session row instead: both `.sidebar-session-catalog-project__label` and `.sidebar-recent-session__name` were `font-size: 13px; font-weight: 500`, leaving a single faint color shift as the only separation between a container and its children.

The label now joins the same structural-label family one step down in intensity: `12px`, weight `650`, `letter-spacing: 0.03em`. Case stays as authored, because these labels carry project basenames, custom group names, and person names, where the uppercase transform used one level up would be destructive and would also collapse the distinction against the host row above.

Type carries the whole separation on purpose. The first draft of this change also muted the header row's color, but #115646 had deliberately raised that value (`--muted` 90% → 35%) for dark-theme readability and pinned it with an assertion in `ui/src/e2e/codex-sessions.e2e.test.ts:524` that the label must sit closer to `--text` than to `--muted`. That premise is correct — the defect was never that the header was too legible — so the color is left exactly as #115646 set it and the fix stays purely typographic. The comment at the rule records that constraint so the next person does not re-litigate it.

Non-goals: no markup, no logic, no new tokens, no layout or spacing changes, no test changes, and no change to the session rows themselves. The whole change is three declarations in one rule.

## User Impact

Group headers now read as wayfinding and session names read as content, so scanning the sidebar for "which rows are containers" no longer depends on spotting a small chevron and a trailing count. It applies on the out-of-box path — `normalizeCatalogProjectGrouping` defaults to `"project"` — and across all three grouping modes (project, custom group, person), since they share one template at `ui/src/components/app-sidebar-session-catalog-render.ts:337`.

## Evidence

Captured headless (Chromium, 2x DPR, 1280x900) against the Control UI mock-gateway harness (`pnpm dev:ui:mock`, `scripts/control-ui-mock-dev.ts`) using only its fixture roster. Every name shown is fixture data. Before and after are the same harness at the same scroll position, with only the stylesheet differing.

The catalog zone shows `CODEX` (section eyebrow) → `openclaw` (group header) → its two sessions, then `CLAUDE CODE` → `peekaboo` → its one session.

**claw — dark and light**

![Sidebar catalog zone before and after, claw dark](https://github.com/user-attachments/assets/a32440d7-b96e-4614-9b6d-24426cdc9614)

![Sidebar catalog zone before and after, claw light](https://github.com/user-attachments/assets/6fc477a8-2273-4b39-99e9-4fd107f2f4bf)

**openknot — dark and light**

![Sidebar catalog zone before and after, openknot dark](https://github.com/user-attachments/assets/3497107d-85f5-4dd6-887a-d1f209b7c9ff)

![Sidebar catalog zone before and after, openknot light](https://github.com/user-attachments/assets/12f0f295-d922-4a55-9cfc-8548912ff4ad)

**dash — dark and light**

![Sidebar catalog zone before and after, dash dark](https://github.com/user-attachments/assets/860f73cc-d96c-472c-b167-cf745143aca5)

![Sidebar catalog zone before and after, dash light](https://github.com/user-attachments/assets/f88397fa-1408-4418-a0ff-d245e61538de)

**Full sidebar, claw dark** — the change in context against the untouched sections above it:

| Before | After |
| --- | --- |
| ![Full sidebar before](https://github.com/user-attachments/assets/4014da28-d027-482a-ac3f-f7926242e0ba) | ![Full sidebar after](https://github.com/user-attachments/assets/34373b4e-56a1-41b1-8132-f14b03522b5d) |

**Checks**

- `node scripts/run-vitest.mjs ui/src/styles/base-theme-contrast.node.test.ts ui/src/styles/base-theme-tokens.node.test.ts` — 2 files, 3 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts ui/src/e2e/codex-sessions.e2e.test.ts` — the project-label tone assertion at line 524 passes with this change. The run then stops later in the same test at line 545 waiting on a view-menu `menuitemradio`; that step fails identically on a pristine `origin/main` copy of `layout.css` in this local environment, so it is not caused by this change. Hosted CI is the authority for that file.
- `oxfmt --check ui/src/styles/layout.css`, `stylelint --config config/stylelint.config.mjs ui/src/styles/layout.css`, `git diff --check` — all clean.
- No theme token or `color-mix` value changed, so `base-theme-contrast.node.test.ts` needs no extension.
- Final-head autoreview: clean, no accepted or actionable findings.

**Production LOC**

`ui/src/styles/layout.css`: +6 / -2, all in one rule. Three of the added lines are the comment recording the hierarchy contract; the net declaration delta is one line (`letter-spacing`), with `font-size` and `font-weight` edited in place. No test lines.

**ClawSweeper rank-up moves**

The review on `58b10072` raised one actionable finding — the CSS comment ran to eight lines and carried PR-specific lore, against the root guide's 1-3 short lines. Applied: the comment is now three lines stating the invariant (structural label vs content), the reason type carries the split (head color stays near `--text`), and the authored-case rule, with the PR reference dropped. That was the only item; hosted CI on `58b10072` was green at 75 passing, 0 failing, including `checks-ui-e2e`, and the head has moved only by that comment edit since.
