### PR TITLE
[BACKPORT] fix(slack): support native slack approvals on enterprise grid

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -294,10 +294,12 @@ workspace-qualified outbound messages. Add any shortcuts to the app manifest's
 interaction path. The manifest examples register the single `/openclaw`
 command; native command mode still requires the administrator-managed command
 entries described below. Relay mode, channel-ID-change events, App Home, Agent
-and Assistant lifecycle events, Slack-native approvals, and bindings remain
-unavailable for an enterprise account. Slack action tools are supported for
-enterprise accounts across every group listed in
-[Actions and gates](#actions-and-gates); the configured
+and Assistant lifecycle events, and bindings
+remain unavailable for an enterprise account. Slack-native approvals that
+originate from a delivered, workspace-qualified Slack turn are supported;
+approval buttons use the same listener-owned, workspace-scoped interaction
+path. Slack action tools are supported for enterprise accounts across every
+group listed in [Actions and gates](#actions-and-gates); the configured
 `channels.slack.actions.*` gates and OAuth scopes still apply. Inbound
 membership, reaction, pin, channel-created, and channel-renamed notifications
 use validated listener-owned, workspace-scoped event routing. Outbound
@@ -1815,6 +1817,11 @@ Slack can act as a native approval client with interactive buttons and interacti
 - Plugin approvals use Slack-native buttons when Slack is enabled as a native approval client for the originating session, or when `approvals.plugin` routes to the originating Slack session or a Slack target.
 - Plugin approval DMs use Slack plugin approvers from `channels.slack.allowFrom`, named-account `allowFrom`, or the account default route.
 - Approver authorization is still enforced: exec-only approvers cannot approve plugin requests unless they are also plugin approvers.
+
+For Enterprise Grid org installs, the originating event's validated workspace
+is retained for the approval prompt, approver DM, button callback, and final
+message update. Approval delivery fails closed when an org-installed account
+does not have that event-owned workspace scope.
 
 This uses the same shared approval button surface as other channels. When `interactivity` is enabled in your Slack app settings, approval prompts render as Block Kit buttons directly in the conversation.
 When those buttons are present, they are the primary approval UX; OpenClaw

--- a/extensions/slack/src/approval-handler.enterprise.test.ts
+++ b/extensions/slack/src/approval-handler.enterprise.test.ts
@@ -1,0 +1,167 @@
+// Slack tests cover Enterprise Grid native approval delivery behavior.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMessageSlackMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./send.js", () => ({
+  sendMessageSlack: sendMessageSlackMock,
+}));
+
+const { slackApprovalNativeRuntime } = await import("./approval-handler.runtime.js");
+
+describe("Slack Enterprise Grid approval delivery", () => {
+  beforeEach(() => {
+    sendMessageSlackMock.mockReset().mockResolvedValue({
+      channelId: "C123",
+      messageId: "1712345678.123456",
+    });
+  });
+
+  it("prepares a qualified target without losing its team", async () => {
+    await expect(
+      slackApprovalNativeRuntime.transport.prepareTarget({
+        plannedTarget: {
+          surface: "origin",
+          reason: "preferred",
+          target: {
+            to: "team:T123:channel:C123",
+            threadId: "1712345678.000001",
+          },
+        },
+      } as never),
+    ).resolves.toEqual({
+      dedupeKey: expect.any(String),
+      target: {
+        to: "channel:C123",
+        teamId: "T123",
+        threadTs: "1712345678.000001",
+      },
+    });
+  });
+
+  it("uses the team client without requiring an Enterprise app id", async () => {
+    const chatUpdate = vi.fn().mockResolvedValue({ ok: true });
+    const teamClient = {
+      chat: { update: chatUpdate },
+      conversations: { open: vi.fn() },
+    };
+    const resolveClient = vi.fn().mockReturnValue(teamClient);
+    const context = {
+      app: { client: { chat: { update: vi.fn() } } },
+      config: {},
+      enterprise: { enterpriseId: "E123" },
+      resolveClient,
+    };
+
+    const entry = await slackApprovalNativeRuntime.transport.deliverPending({
+      cfg: {
+        channels: {
+          slack: {
+            botToken: "xoxb-test",
+            appToken: "xapp-test",
+            enterpriseOrgInstall: true,
+          },
+        },
+      },
+      accountId: "default",
+      context,
+      preparedTarget: {
+        to: "channel:C123",
+        teamId: "T123",
+      },
+      pendingPayload: { text: "approve", blocks: [] },
+    } as never);
+
+    expect(entry).toEqual({
+      channelId: "C123",
+      messageTs: "1712345678.123456",
+      teamId: "T123",
+    });
+    expect(resolveClient).toHaveBeenCalledWith("T123");
+    expect(sendMessageSlackMock).toHaveBeenCalledWith(
+      "channel:C123",
+      "approve",
+      expect.objectContaining({
+        client: teamClient,
+        eventScope: {
+          teamId: "T123",
+          client: teamClient,
+        },
+      }),
+    );
+
+    await slackApprovalNativeRuntime.transport.updateEntry?.({
+      cfg: {} as never,
+      accountId: "default",
+      context,
+      entry,
+      payload: { text: "approved", blocks: [] },
+      phase: "resolved",
+    } as never);
+
+    expect(resolveClient).toHaveBeenLastCalledWith("T123");
+    expect(chatUpdate).toHaveBeenCalledWith({
+      channel: "C123",
+      ts: "1712345678.123456",
+      text: "approved",
+      blocks: [],
+    });
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["unusable", () => undefined],
+  ])("fails closed when the workspace client resolver is %s", async (_name, resolveClient) => {
+    await expect(
+      slackApprovalNativeRuntime.transport.deliverPending({
+        cfg: {} as never,
+        accountId: "default",
+        context: {
+          app: { client: {} },
+          config: {},
+          enterprise: { enterpriseId: "E123" },
+          ...(resolveClient ? { resolveClient } : {}),
+        },
+        preparedTarget: {
+          to: "channel:C123",
+          teamId: "T123",
+        },
+        pendingPayload: { text: "approve", blocks: [] },
+      } as never),
+    ).rejects.toThrow("Slack Enterprise Grid approval client is unavailable");
+    expect(sendMessageSlackMock).not.toHaveBeenCalled();
+  });
+
+  it("opens an approver DM with the same team client", async () => {
+    const open = vi.fn().mockResolvedValue({ channel: { id: "D123" } });
+    const teamClient = {
+      chat: { update: vi.fn() },
+      conversations: { open },
+    };
+
+    await slackApprovalNativeRuntime.transport.deliverPending({
+      cfg: {} as never,
+      accountId: "default",
+      context: {
+        app: { client: {} },
+        config: {},
+        enterprise: { enterpriseId: "E123" },
+        resolveClient: () => teamClient,
+      },
+      preparedTarget: {
+        to: "user:U123",
+        teamId: "T123",
+      },
+      pendingPayload: { text: "approve", blocks: [] },
+    } as never);
+
+    expect(open).toHaveBeenCalledWith({ users: "U123", return_im: true });
+    expect(sendMessageSlackMock).toHaveBeenCalledWith(
+      "channel:D123",
+      "approve",
+      expect.objectContaining({
+        eventScope: expect.objectContaining({ teamId: "T123" }),
+      }),
+    );
+  });
+});

--- a/extensions/slack/src/approval-handler.runtime.ts
+++ b/extensions/slack/src/approval-handler.runtime.ts
@@ -1,6 +1,6 @@
 // Slack plugin module implements approval handler behavior.
 import type { App } from "@slack/bolt";
-import type { Block, KnownBlock } from "@slack/web-api";
+import type { Block, KnownBlock, WebClient } from "@slack/web-api";
 import type {
   ChannelApprovalCapabilityHandlerContext,
   ExecApprovalExpiredView,
@@ -26,14 +26,17 @@ import {
 } from "./approval-native-gates.js";
 import { normalizeSlackApproverId } from "./exec-approvals.js";
 import { SLACK_EDIT_TEXT_MAX_BYTES } from "./limits.js";
+import type { SlackEventScope } from "./monitor/event-scope.js";
 import { resolveSlackReplyBlocks } from "./reply-blocks.js";
 import { sendMessageSlack } from "./send.js";
+import { parseSlackTarget } from "./target-parsing.js";
 import { truncateSlackTextByUtf8Bytes } from "./truncate.js";
 
 type SlackBlock = Block | KnownBlock;
 type SlackPendingApproval = {
   channelId: string;
   messageTs: string;
+  teamId?: string;
 };
 type SlackPendingDelivery = {
   text: string;
@@ -58,6 +61,11 @@ type SlackExecApprovalConfig = NonNullable<
 type SlackApprovalHandlerContext = {
   app: App;
   config: SlackExecApprovalConfig;
+  resolveClient?: (teamId?: string) => WebClient | undefined;
+  enterprise?: {
+    apiAppId?: string;
+    enterpriseId: string;
+  };
 };
 
 function resolveHandlerContext(params: ChannelApprovalCapabilityHandlerContext): {
@@ -408,14 +416,14 @@ function buildSlackExpiredBlocks(view: ExpiredApprovalView): SlackBlock[] {
 }
 
 async function updateMessage(params: {
-  app: App;
+  client: WebClient;
   channelId: string;
   messageTs: string;
   text: string;
   blocks: SlackBlock[];
 }): Promise<void> {
   try {
-    await params.app.client.chat.update({
+    await params.client.chat.update({
       channel: params.channelId,
       ts: params.messageTs,
       text: truncateSlackTextByUtf8Bytes(params.text, SLACK_EDIT_TEXT_MAX_BYTES),
@@ -428,7 +436,7 @@ async function updateMessage(params: {
 
 export const slackApprovalNativeRuntime = createChannelApprovalNativeRuntimeAdapter<
   SlackPendingDelivery,
-  { to: string; threadTs?: string },
+  { to: string; threadTs?: string; teamId?: string },
   SlackPendingApproval,
   never,
   SlackPendingDelivery
@@ -478,29 +486,45 @@ export const slackApprovalNativeRuntime = createChannelApprovalNativeRuntimeAdap
     }),
   },
   transport: {
-    prepareTarget: ({ plannedTarget }) => ({
-      dedupeKey: buildChannelApprovalNativeTargetKey(plannedTarget.target),
-      target: {
-        to: plannedTarget.target.to,
-        threadTs:
-          plannedTarget.target.threadId != null ? String(plannedTarget.target.threadId) : undefined,
-      },
-    }),
+    prepareTarget: ({ plannedTarget }) => {
+      const parsed = parseSlackTarget(plannedTarget.target.to, {
+        defaultKind: "channel",
+      });
+      if (!parsed) {
+        throw new Error("Slack approval delivery target is missing");
+      }
+      return {
+        dedupeKey: buildChannelApprovalNativeTargetKey(plannedTarget.target),
+        target: {
+          to: `${parsed.kind}:${parsed.id}`,
+          threadTs:
+            plannedTarget.target.threadId != null
+              ? String(plannedTarget.target.threadId)
+              : undefined,
+          teamId: parsed.teamId,
+        },
+      };
+    },
     deliverPending: async ({ cfg, accountId, context, preparedTarget, pendingPayload }) => {
       const resolved = resolveHandlerContext({ cfg, accountId, context });
       if (!resolved) {
         return null;
       }
-      const message = await sendMessageSlack(preparedTarget.to, pendingPayload.text, {
+      const client = resolveApprovalClient(resolved.context, preparedTarget.teamId);
+      const to = await resolveApprovalChannel(client, preparedTarget.to, preparedTarget.teamId);
+      const eventScope = resolveApprovalEventScope(client, preparedTarget.teamId);
+      const message = await sendMessageSlack(to, pendingPayload.text, {
         cfg,
         accountId: resolved.accountId,
         threadTs: preparedTarget.threadTs,
         blocks: pendingPayload.blocks,
-        client: resolved.context.app.client,
+        client,
+        eventScope,
       });
       return {
         channelId: message.channelId,
         messageTs: message.messageId,
+        teamId: preparedTarget.teamId,
       };
     },
     updateEntry: async ({ cfg, accountId, context, entry, payload }) => {
@@ -509,8 +533,9 @@ export const slackApprovalNativeRuntime = createChannelApprovalNativeRuntimeAdap
         return;
       }
       const nextPayload = payload;
+      const client = resolveApprovalClient(resolved.context, entry.teamId);
       await updateMessage({
-        app: resolved.context.app,
+        client,
         channelId: entry.channelId,
         messageTs: entry.messageTs,
         text: nextPayload.text,
@@ -524,3 +549,49 @@ export const slackApprovalNativeRuntime = createChannelApprovalNativeRuntimeAdap
     },
   },
 });
+
+function resolveApprovalClient(context: SlackApprovalHandlerContext, teamId?: string): WebClient {
+  if (!teamId) {
+    return context.app.client;
+  }
+  if (!context.enterprise || !context.resolveClient) {
+    throw new Error("Slack Enterprise Grid approval client is unavailable");
+  }
+  const client = context.resolveClient(teamId);
+  if (!client) {
+    throw new Error("Slack Enterprise Grid approval client is unavailable");
+  }
+  return client;
+}
+
+function resolveApprovalEventScope(
+  client: WebClient,
+  teamId?: string,
+): SlackEventScope | undefined {
+  if (!teamId) {
+    return undefined;
+  }
+  return {
+    teamId,
+    client,
+  };
+}
+
+async function resolveApprovalChannel(client: WebClient, target: string, teamId?: string) {
+  if (!teamId) {
+    return target;
+  }
+  const parsed = parseSlackTarget(target, { defaultKind: "channel" });
+  if (!parsed) {
+    throw new Error("Slack approval delivery target is missing");
+  }
+  if (parsed.kind === "channel") {
+    return `channel:${parsed.id}`;
+  }
+  const opened = await client.conversations.open({ users: parsed.id, return_im: true });
+  const channelId = normalizeOptionalString(opened.channel?.id);
+  if (!channelId) {
+    throw new Error("Slack Enterprise Grid approval DM did not return a channel id");
+  }
+  return `channel:${channelId}`;
+}

--- a/extensions/slack/src/approval-native-gates.ts
+++ b/extensions/slack/src/approval-native-gates.ts
@@ -38,7 +38,6 @@ import {
   canonicalizeSlackApiTargetId,
   formatSlackTarget,
   parseSlackTarget,
-  type SlackTarget,
 } from "./target-parsing.js";
 
 export type SlackApprovalKind = "exec" | "plugin";
@@ -75,7 +74,7 @@ function isSlackApprovalTransportEnabled(params: {
   accountId?: string | null;
 }): boolean {
   const account = resolveSlackAccount(params);
-  return account.config.enterpriseOrgInstall !== true && isSlackPluginAccountConfigured(account);
+  return isSlackPluginAccountConfigured(account);
 }
 
 function resolveSlackNativeApprovalConfig(params: {
@@ -136,7 +135,7 @@ export function resolveTurnSourceSlackOriginTarget(
     return null;
   }
   return {
-    to: formatSlackApprovalTarget(parsed),
+    to: formatSlackTarget({ ...parsed, explicitKind: true }),
     threadId: stringifyRouteThreadId(request.request.turnSourceThreadId),
   };
 }
@@ -169,7 +168,11 @@ export function resolveSlackFallbackOriginTarget(
     return null;
   }
   return {
-    to: formatSlackApprovalTarget(parsed, canonicalizeSlackApiTargetId(parsed.kind, parsed.id)),
+    to: formatSlackTarget({
+      ...parsed,
+      id: canonicalizeSlackApiTargetId(parsed.kind, parsed.id),
+      explicitKind: true,
+    }),
     threadId: sessionTarget.threadId,
   };
 }
@@ -189,6 +192,9 @@ function isSlackDmChannelToUserRoutePair(a: SlackOriginTarget, b: SlackOriginTar
   const left = parseComparableSlackTarget(a);
   const right = parseComparableSlackTarget(b);
   if (!left || !right) {
+    return false;
+  }
+  if (left.teamId?.toLowerCase() !== right.teamId?.toLowerCase()) {
     return false;
   }
   return (
@@ -237,7 +243,7 @@ export function normalizeSlackForwardTarget(
     return null;
   }
   return {
-    to: formatSlackApprovalTarget(parsed),
+    to: formatSlackTarget({ ...parsed, explicitKind: true }),
     accountId: normalizeOptionalString(target.accountId),
     threadId: stringifyRouteThreadId(target.threadId),
   };
@@ -413,6 +419,13 @@ export function shouldHandleSlackNativeApprovalRequest(params: {
   approvalKind?: SlackApprovalKind;
   request: SlackNativeApprovalRequest;
 }): boolean {
+  const account = resolveSlackAccount(params);
+  if (
+    account.config.enterpriseOrgInstall === true &&
+    !resolveEnterpriseApprovalTeamId(params.request)
+  ) {
+    return false;
+  }
   const approvalKind = params.approvalKind ?? resolveSlackApprovalKind(params.request);
   if (approvalKind === "plugin") {
     return (
@@ -446,8 +459,13 @@ export function shouldHandleSlackNativeApprovalRequest(params: {
   });
 }
 
-function formatSlackApprovalTarget(target: SlackTarget, id = target.id): string {
-  return target.teamId
-    ? formatSlackTarget({ teamId: target.teamId, kind: target.kind, id })
-    : `${target.kind}:${id}`;
+export function resolveEnterpriseApprovalTeamId(
+  request: SlackNativeApprovalRequest,
+): string | undefined {
+  try {
+    const target = resolveTurnSourceSlackOriginTarget(request);
+    return target ? parseSlackTarget(target.to)?.teamId : undefined;
+  } catch {
+    return undefined;
+  }
 }

--- a/extensions/slack/src/approval-native.test.ts
+++ b/extensions/slack/src/approval-native.test.ts
@@ -217,6 +217,48 @@ describe("slack native approval adapter", () => {
     });
   });
 
+  it("preserves the Grid team on approval origin and approver DM targets", async () => {
+    const cfg = buildConfig({ enterpriseOrgInstall: true });
+    const request = {
+      ...createExecApprovalRequest(),
+      request: {
+        ...createExecApprovalRequest().request,
+        turnSourceTo: "team:T123:channel:C123",
+      },
+    };
+
+    expect(
+      slackApprovalCapability.native?.resolveOriginTarget?.({
+        cfg,
+        accountId: "default",
+        approvalKind: "exec",
+        request,
+      }),
+    ).toEqual({
+      to: "team:T123:channel:C123",
+      threadId: "1712345678.123456",
+    });
+    expect(
+      slackApprovalCapability.native?.resolveApproverDmTargets?.({
+        cfg,
+        accountId: "default",
+        approvalKind: "exec",
+        request,
+      }),
+    ).toEqual([{ to: "team:T123:user:U123APPROVER" }]);
+  });
+
+  it("does not enable Grid approval delivery without a trusted team-qualified origin", () => {
+    const capabilities = slackApprovalCapability.native?.describeDeliveryCapabilities({
+      cfg: buildConfig({ enterpriseOrgInstall: true }),
+      accountId: "default",
+      approvalKind: "exec",
+      request: createExecApprovalRequest(),
+    });
+
+    expect(capabilities?.enabled).toBe(false);
+  });
+
   it("resolves approver dm targets", async () => {
     const targets = await slackApprovalCapability.native?.resolveApproverDmTargets?.({
       cfg: buildConfig(),

--- a/extensions/slack/src/approval-native.ts
+++ b/extensions/slack/src/approval-native.ts
@@ -18,6 +18,7 @@ import {
   normalizeSlackOriginTarget,
   resolveSessionSlackOriginTarget,
   resolveSlackFallbackOriginTarget,
+  resolveEnterpriseApprovalTeamId,
   resolveTurnSourceSlackOriginTarget,
   shouldHandleSlackNativeApprovalRequest,
   shouldHandleSlackPluginViaForwardingSession,
@@ -32,6 +33,7 @@ import {
   isSlackExecApprovalClientEnabled,
   resolveSlackExecApprovalTarget,
 } from "./exec-approvals.js";
+import { formatSlackTarget } from "./target-parsing.js";
 
 type ApprovalRequest = SlackNativeApprovalRequest;
 type ApprovalKind = SlackApprovalKind;
@@ -105,7 +107,10 @@ function resolveSlackApproverDmTargets(params: {
     params.approvalKind === "plugin"
       ? getSlackApprovalApprovers(params)
       : getSlackExecApprovalApprovers(params);
-  return approvers.map((approver) => ({ to: `user:${approver}` }));
+  const teamId = resolveEnterpriseApprovalTeamId(params.request);
+  return approvers.map((approver) => ({
+    to: formatSlackTarget({ kind: "user", id: approver, teamId, explicitKind: true }),
+  }));
 }
 
 const shouldSuppressSlackForwardingFallback =

--- a/extensions/slack/src/monitor/provider.allowlist.test.ts
+++ b/extensions/slack/src/monitor/provider.allowlist.test.ts
@@ -4,6 +4,7 @@ import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   flush,
+  getSlackClient,
   getSlackHandlerOrThrow,
   getSlackTestState,
   resetSlackTestState,
@@ -101,6 +102,57 @@ describe("slack allowlist log formatting", () => {
 });
 
 describe("slack startup user allowlist resolution", () => {
+  it("registers one native approval client per Enterprise Grid team", async () => {
+    resetSlackTestState({
+      channels: {
+        slack: {
+          enabled: true,
+          botToken: "xoxb-test",
+          appToken: "xapp-1-A123-test",
+          enterpriseOrgInstall: true,
+          dmPolicy: "disabled",
+          groupPolicy: "open",
+          execApprovals: {
+            enabled: true,
+            approvers: ["U123OWNER"],
+            target: "both",
+          },
+        },
+      },
+    });
+    getSlackClient().auth.test.mockResolvedValueOnce({
+      enterprise_id: "E123",
+      app_id: "A123",
+      is_enterprise_install: true,
+    });
+    const { channelRuntime, register } = createRuntimeContextCapture();
+
+    const monitor = startSlackMonitor(monitorSlackProvider, {
+      channelRuntime,
+      appToken: "xapp-1-A123-test",
+    });
+    try {
+      await getSlackHandlerOrThrow("message");
+      await flush();
+
+      const registration = vi.mocked(register).mock.calls[0]?.[0] as
+        | { context?: { resolveClient?: (teamId?: string) => unknown } }
+        | undefined;
+      const resolveClient = registration?.context?.resolveClient;
+      expect(resolveClient).toBeTypeOf("function");
+      const teamOne = resolveClient?.("T111") as { teamId?: string };
+      const teamOneAgain = resolveClient?.("T111") as { teamId?: string };
+      const teamTwo = resolveClient?.("T222") as { teamId?: string };
+
+      expect(teamOneAgain).toBe(teamOne);
+      expect(teamTwo).not.toBe(teamOne);
+      expect(teamOne.teamId).toBe("T111");
+      expect(teamTwo.teamId).toBe("T222");
+    } finally {
+      await stopSlackMonitor(monitor);
+    }
+  });
+
   it("registers the native approval runtime for plugin-only Slack approvals", async () => {
     resetSlackTestState({
       channels: {

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -1,6 +1,6 @@
 // Slack provider module implements model/runtime integration.
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { type FetchFunction, WebClient } from "@slack/web-api";
+import { type FetchFunction, type WebClientOptions, WebClient } from "@slack/web-api";
 import {
   addAllowlistUserEntriesFromConfigEntry,
   buildAllowlistResolutionSummary,
@@ -39,7 +39,7 @@ import {
   resolveSlackProxyDispatcher,
   resolveSlackWebClientOptions,
 } from "../client-options.js";
-import { createSlackStartupAuthClient } from "../client.js";
+import { createSlackStartupAuthClient, createSlackWebClient } from "../client.js";
 import { normalizeSlackWebhookPath, registerSlackHttpHandler } from "../http/index.js";
 import { SLACK_TEXT_LIMIT } from "../limits.js";
 import { resolveSlackChannelAllowlist } from "../resolve-channels.js";
@@ -66,6 +66,7 @@ import {
   resolveSlackIdentityHealth,
   resolveSlackInstallationIdentity,
   type SlackAuthTestIdentity,
+  type SlackInstallationIdentity,
 } from "./enterprise-install.js";
 import { registerSlackMonitorEvents } from "./events.js";
 import { createSlackDurableIngress } from "./ingress.js";
@@ -301,11 +302,6 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   if (enterpriseOrgInstall && slackMode === "relay") {
     throw new Error(
       `Slack Enterprise Grid org account "${account.accountId}" requires direct socket or HTTP delivery; relay mode is unsupported`,
-    );
-  }
-  if (enterpriseOrgInstall && account.config.execApprovals?.enabled === true) {
-    throw new Error(
-      `Slack Enterprise Grid org account "${account.accountId}" does not support Slack-native exec approvals`,
     );
   }
   if (enterpriseOrgInstall) {
@@ -672,12 +668,17 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     onPrepared: presenceMonitor?.observe,
   });
   if (
-    installationIdentity.kind !== "enterprise" &&
     isSlackAnyNativeApprovalClientEnabled({
       cfg,
       accountId: account.accountId,
     })
   ) {
+    const resolveClient = createSlackApprovalClientResolver({
+      appClient: app.client,
+      token,
+      clientOptions,
+      installationIdentity,
+    });
     registerChannelRuntimeContext({
       channelRuntime: opts.channelRuntime,
       channelId: "slack",
@@ -686,6 +687,15 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       context: {
         app,
         config: slackCfg.execApprovals ?? {},
+        resolveClient,
+        ...(installationIdentity.kind === "enterprise"
+          ? {
+              enterprise: {
+                apiAppId: installationIdentity.apiAppId,
+                enterpriseId: installationIdentity.enterpriseId,
+              },
+            }
+          : {}),
       },
       abortSignal: opts.abortSignal,
     });
@@ -991,6 +1001,34 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     await gracefulStop();
     await slackDispatcher?.close();
   }
+}
+
+function createSlackApprovalClientResolver(params: {
+  appClient: WebClient;
+  token: string;
+  clientOptions: WebClientOptions;
+  installationIdentity: SlackInstallationIdentity;
+}): (teamId?: string) => WebClient {
+  if (params.installationIdentity.kind !== "enterprise") {
+    return () => params.appClient;
+  }
+  const clients = new Map<string, WebClient>();
+  return (rawTeamId?: string) => {
+    const teamId = rawTeamId?.trim().toUpperCase();
+    if (!teamId || !/^T[A-Z0-9]+$/.test(teamId)) {
+      throw new Error("Slack Enterprise Grid approval delivery requires a valid teamId");
+    }
+    const cached = clients.get(teamId);
+    if (cached) {
+      return cached;
+    }
+    const client = createSlackWebClient(params.token, {
+      ...params.clientOptions,
+      teamId,
+    });
+    clients.set(teamId, client);
+    return client;
+  };
 }
 
 export const resolveSlackRuntimeGroupPolicy = resolveOpenProviderRuntimeGroupPolicy;

--- a/extensions/slack/src/target-parsing.ts
+++ b/extensions/slack/src/target-parsing.ts
@@ -61,11 +61,12 @@ export function formatSlackTarget(params: {
   teamId?: string;
   kind: SlackTargetKind;
   id: string;
+  explicitKind?: boolean;
 }): string {
   const teamId = params.teamId?.trim();
   const id = params.id.trim();
   if (!teamId) {
-    return id;
+    return params.explicitKind ? `${params.kind}:${id}` : id;
   }
   const idPattern = params.kind === "user" ? /^[UW][A-Z0-9]+$/i : /^[CDG][A-Z0-9]+$/i;
   if (!/^T[A-Z0-9]+$/i.test(teamId) || !idPattern.test(id)) {


### PR DESCRIPTION
## Summary

Backports the current native Slack approval work from #120942 onto the active OpenClaw release branch. Enterprise Grid approval prompts, approver DMs, button callbacks, and final updates retain the validated event workspace and fail closed when that workspace scope is unavailable.

## Release resolution

- squashes the source PR's current 8 commits into one release commit
- applies the exact current 9-file source delta at `54f723bf4297fb84b0cea6411269c2fb546b49b9`
- excludes source-branch ancestry outside the commits listed on #120942

## Validation

- source delta applied cleanly with no conflict markers
- `git diff --check`: passed
- focused release-branch validation will run after PR creation

## Tracking

Backport-Of: #120942

Release-Target: `sjf/openclaw-release-5-2026-08-04`
