### PR TITLE
fix(ui): make chat inline code readable on dark themes

### DIFF
--- a/ui/src/styles/base-theme-contrast.node.test.ts
+++ b/ui/src/styles/base-theme-contrast.node.test.ts
@@ -31,6 +31,20 @@ const SURFACE_TOKENS = ["--bg", "--bg-elevated", "--bg-muted", "--card", "--pane
 
 const AA_NORMAL_TEXT_MIN = 4.5;
 
+/*
+ * Separation guardrail for the markdown code chip.
+ *
+ * Text contrast was never the failure mode here: the chip surface itself
+ * collapsed. Every dark palette sets `--secondary` to the same hex as `--card`,
+ * so a chip painted with it was invisible inside a user bubble while light mode
+ * (which overrode the surface) looked correct. The chip tokens are read out of
+ * the live rule so swapping them back for a collapsing pair fails here.
+ */
+const CODE_CHIP_RULE = ".chat-text :where(:not(pre) > code)";
+const CODE_CHIP_HOST_SURFACES = ["--card", "--bg"] as const;
+const CHIP_SURFACE_MIN_STEP = 1.05;
+const CHIP_BORDER_MIN_STEP = 1.25;
+
 type TokenMap = Map<string, string>;
 
 function parseThemeBlocks(baseCss: string): Map<string, TokenMap> {
@@ -39,7 +53,10 @@ function parseThemeBlocks(baseCss: string): Map<string, TokenMap> {
   for (const match of baseCss.matchAll(blockPattern)) {
     const selector = match[1] ?? "";
     const body = match[2] ?? "";
-    const tokens: TokenMap = new Map();
+    // base.css declares `:root` more than once (palette, then the standalone
+    // --cursor-action blocks). Merging keeps the palette; overwriting made the
+    // default `dark` theme resolve to an empty map and skip every assertion.
+    const tokens: TokenMap = blocks.get(selector) ?? new Map();
     for (const line of body.split("\n")) {
       const declaration = line.match(/^\s*(--[\w-]+)\s*:\s*([^;]+);/);
       const name = declaration?.[1];
@@ -92,6 +109,17 @@ function contrastRatio(foregroundHex: string, backgroundHex: string): number {
   return (lighter + 0.05) / (darker + 0.05);
 }
 
+/** Read the surface/border tokens the shipped code-chip rule actually paints. */
+function readCodeChipTokens(chatTextCss: string): { surface: string; border: string } {
+  const rule = chatTextCss.split(CODE_CHIP_RULE)[1]?.split("}")[0] ?? "";
+  const surface = rule.match(/background:\s*var\((--[\w-]+)\)/u)?.[1];
+  const border = rule.match(/border:[^;]*var\((--[\w-]+)\)/u)?.[1];
+  if (!surface || !border) {
+    throw new Error(`could not read chip tokens from "${CODE_CHIP_RULE}"`);
+  }
+  return { surface, border };
+}
+
 describe("Control UI theme contrast", () => {
   const baseCss = fs.readFileSync(path.join(stylesDir, "base.css"), "utf8");
   const themes = resolveThemes(parseThemeBlocks(baseCss));
@@ -115,6 +143,37 @@ describe("Control UI theme contrast", () => {
               `${themeName}: ${textToken} ${foreground} on ${surfaceToken} ${background} = ${ratio.toFixed(2)}:1 (< ${AA_NORMAL_TEXT_MIN}:1)`,
             );
           }
+        }
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it("keeps the markdown code chip separated from every surface it sits on", () => {
+    const chatTextCss = fs.readFileSync(path.join(stylesDir, "chat", "text.css"), "utf8");
+    const chip = readCodeChipTokens(chatTextCss);
+    const failures: string[] = [];
+    for (const [themeName, tokens] of themes) {
+      const surface = tokens.get(chip.surface);
+      const border = tokens.get(chip.border);
+      expect(surface, `${themeName}: ${chip.surface} is not a hex token`).toMatch(/^#/u);
+      expect(border, `${themeName}: ${chip.border} is not a hex token`).toMatch(/^#/u);
+      for (const hostToken of CODE_CHIP_HOST_SURFACES) {
+        const host = tokens.get(hostToken);
+        if (!host?.startsWith("#")) {
+          continue;
+        }
+        const surfaceStep = contrastRatio(surface ?? "", host);
+        const borderStep = contrastRatio(border ?? "", host);
+        if (surfaceStep < CHIP_SURFACE_MIN_STEP) {
+          failures.push(
+            `${themeName}: chip ${chip.surface} ${surface} on ${hostToken} ${host} = ${surfaceStep.toFixed(2)}:1 (< ${CHIP_SURFACE_MIN_STEP}:1)`,
+          );
+        }
+        if (borderStep < CHIP_BORDER_MIN_STEP) {
+          failures.push(
+            `${themeName}: chip border ${chip.border} ${border} on ${hostToken} ${host} = ${borderStep.toFixed(2)}:1 (< ${CHIP_BORDER_MIN_STEP}:1)`,
+          );
         }
       }
     }

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -194,18 +194,21 @@
   margin-top: 0;
 }
 
+/* Code surfaces must lift off the host bubble in every theme. --secondary equals
+   --card on every dark palette, so chips painted with it vanished inside user
+   bubbles; --bg-muted/--border-strong separate in both modes without an override. */
 .chat-text :where(:not(pre) > code) {
-  background: var(--secondary);
+  background: var(--bg-muted);
   padding: 0.15em 0.35em;
   border-radius: var(--radius-sm);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-strong);
   overflow-wrap: anywhere;
   word-break: break-word;
 }
 
 .chat-text :where(pre) {
-  background: var(--secondary);
-  border: 1px solid var(--border);
+  background: var(--bg-muted);
+  border: 1px solid var(--border-strong);
   border-radius: var(--radius-md);
   margin-top: 0.75em;
   padding: 10px 12px;
@@ -268,16 +271,6 @@
 
 :root[data-theme-mode="light"] .chat-text :where(blockquote blockquote blockquote) {
   background: rgba(0, 0, 0, 0.04);
-}
-
-:root[data-theme-mode="light"] .chat-text :where(:not(pre) > code) {
-  background: var(--bg-muted);
-  border: 1px solid rgba(0, 0, 0, 0.1);
-}
-
-:root[data-theme-mode="light"] .chat-text :where(pre) {
-  background: var(--bg-muted);
-  border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 .chat-text :where(hr) {


### PR DESCRIPTION
Closes #121374

## What Problem This Solves

Fixes an issue where operators on any dark Control UI appearance would see inline code spans and fenced code blocks blend into the surrounding message. The chip had no usable surface step and no visible edge, so commands, paths, and flags in agent replies read as ordinary body text. Light mode was already correct, which is why the defect only ever showed on the default dark families.

## Why This Change Was Made

The chat markdown rule painted code surfaces with `--secondary` and `--border`. Every dark palette in `ui/src/styles/base.css` defines `--secondary` with the exact hex of `--card`, so a chip inside a message bubble was a 1.00:1 match with the bubble and only 1.06-1.08:1 against the flat assistant column, while `--border` sat at 1.08-1.13:1 against `--card`. Light mode looked right only because `ui/src/styles/chat/text.css` overrode both properties for `:root[data-theme-mode="light"]`, choosing `--bg-muted` plus a real border.

The fix promotes that light override into the single canonical rule instead of adding a second dark-only override: code chips and code blocks now paint `--bg-muted` with a `--border-strong` edge in every theme, and both mode-specific overrides (including the raw `rgba(0, 0, 0, 0.1)` border) are deleted. Dark deliberately lands slightly below light's edge presence, since a bright hairline reads stronger on a dark surface at equal ratio. Custom (shadcn-style) themes benefit too: `--bg-muted` maps to the theme's own muted surface and `--border-strong` is derived as `color-mix(in srgb, var(--border) 72%, var(--text) 28%)`, so both are guaranteed to separate.

The change also repairs the guard that should have caught this. `ui/src/styles/base-theme-contrast.node.test.ts` overwrote repeated `:root` blocks instead of merging them, and `base.css` declares `:root` more than once (palette, then the standalone `--cursor-action` blocks). The last tiny block won, so the default `dark` theme resolved to an empty token map and every assertion for it was silently skipped. With merging restored, a new case reads the chip's surface and border tokens out of the shipped rule and asserts separation from `--card` and `--bg` on all six themes, so swapping the tokens back for a collapsing pair fails in CI.

Sibling surfaces were checked and intentionally left alone: `ui/src/styles/sidebar-markdown.css` uses a different, working idiom (`rgba(0, 0, 0, 0.12)`, which darkens against a dark surface and does separate), and `ui/src/styles/chat/tool-cards.css` deliberately strips the pill from command and diff `<code>` used for semantics only.

## User Impact

Inline code and code blocks in chat are now clearly identifiable as code on Claw dark, OpenKnot dark, and Dash dark, with the same restrained weight light mode already had - a distinct surface and a soft edge, not a loud highlight. Light appearances are visually unchanged. No config, no migration, no opt-in.

## Evidence

Measured with the same WCAG relative-luminance math as the contrast guard. Chip surface and border, before -> after:

| Theme | chip vs `--card` | chip vs `--bg` | border vs `--card` |
| --- | --- | --- | --- |
| dark | 1.00 -> 1.12 | 1.08 -> 1.22 | 1.08 -> 1.35 |
| openknot | 1.00 -> 1.09 | 1.06 -> 1.15 | 1.09 -> 1.32 |
| dash | 1.00 -> 1.18 | 1.08 -> 1.28 | 1.13 -> 1.50 |
| light | 1.19 (unchanged) | 1.13 (unchanged) | 1.48 -> 1.53 |
| openknot-light | 1.20 (unchanged) | 1.14 (unchanged) | 1.49 -> 1.60 |
| dash-light | 1.34 (unchanged) | 1.20 (unchanged) | 1.66 -> 1.93 |

Light chip surfaces are byte-identical (verified by sampling the rendered pixels: `#efebe4` before and after). Only the light border moves, from the composited `rgba(0, 0, 0, 0.1)` to `--border-strong`, which is within one or two units per channel on claw-light and openknot-light and slightly firmer on dash-light.

Screenshots come from the mock-gateway Control UI E2E harness with fixture messages, captured headless at 1100x900. Each image is the same rendered line at 2x, before on top and after below.

Claw dark - the chip gains a surface step and a soft edge:

![Claw dark inline code, before above and after below](https://github.com/user-attachments/assets/a28e480a-c64b-408b-90c5-9b2ef0a1fc0e)

OpenKnot dark:

![OpenKnot dark inline code, before above and after below](https://github.com/user-attachments/assets/39a66e16-fef8-4ac8-b501-8189675390dc)

Dash dark:

![Dash dark inline code, before above and after below](https://github.com/user-attachments/assets/0bc38f24-d42f-468f-a9db-6981d6f8f8ce)

Claw light - unchanged:

![Claw light inline code, before above and after below, visually identical](https://github.com/user-attachments/assets/bb530837-b2f9-4c34-a482-6cf8646571d2)

Full message frame on Claw dark after the change, showing an inline chip inside a user bubble, inline chips in the flat assistant column, and a fenced block:

![Claw dark chat message after the change](https://github.com/user-attachments/assets/5b4a5a6c-f65d-431a-b9d0-94f46c7cc9bc)

Focused tests, all green:

```
node scripts/run-vitest.mjs ui/src/styles/base-theme-contrast.node.test.ts \
  ui/src/styles/base-theme-tokens.node.test.ts ui/src/styles/theme-contrast.test.ts
Test Files  3 passed (3)     Tests  6 passed (6)
```

The new guard was verified to actually fail on the pre-fix tokens rather than passing vacuously:

```
dark: chip --secondary #161920 on --card #161920 = 1.00:1 (< 1.05:1)
dark: chip border --border #1e2028 on --card #161920 = 1.08:1 (< 1.25:1)
openknot: chip --secondary #111113 on --card #111113 = 1.00:1 (< 1.05:1)
dash: chip --secondary #221a16 on --card #221a16 = 1.00:1 (< 1.05:1)
```

`git diff --check` clean, stylelint clean on the touched stylesheet, oxfmt clean on the touched test. Production LOC delta is -7 (7 added, 14 removed, 3 of the added lines being the invariant comment); the +59 lines are test-only.
