### PR TITLE
fix(gateway): persist sessions.patch toolOverrides.webSearch true

### DIFF
--- a/src/gateway/session-tool-overrides.ts
+++ b/src/gateway/session-tool-overrides.ts
@@ -27,11 +27,13 @@ export function normalizeSessionToolOverrides(
   );
   const mcpServers = normalizeBooleanMap(raw.mcpServers);
   const skills = normalizeBooleanMap(raw.skills);
+  // Keep both true and false: session enable overrides (base off → webSearch:true)
+  // must persist the same way skills/mcpServers boolean maps do.
   const normalized: SessionToolOverrides = {
     ...(mcpServers ? { mcpServers } : {}),
     ...(Object.keys(mcpToolsDeny).length > 0 ? { mcpToolsDeny } : {}),
     ...(skills ? { skills } : {}),
-    ...(raw.webSearch === false ? { webSearch: false } : {}),
+    ...(typeof raw.webSearch === "boolean" ? { webSearch: raw.webSearch } : {}),
   };
   return Object.keys(normalized).length > 0 ? normalized : undefined;
 }

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -749,6 +749,37 @@ describe("gateway sessions patch", () => {
     expect(set.toolOverrides).toEqual({
       mcpServers: { alpha: true, zeta: false },
       mcpToolsDeny: { alpha: ["read", "write"] },
+      webSearch: true,
+    });
+
+    const enableOnly = expectPatchOk(
+      await runPatch({
+        store,
+        patch: { key: MAIN_SESSION_KEY, toolOverrides: { webSearch: true } },
+      }),
+    );
+    expect(enableOnly.toolOverrides).toEqual({ webSearch: true });
+
+    const denyOnly = expectPatchOk(
+      await runPatch({
+        store,
+        patch: { key: MAIN_SESSION_KEY, toolOverrides: { webSearch: false } },
+      }),
+    );
+    expect(denyOnly.toolOverrides).toEqual({ webSearch: false });
+
+    const withSkillsTrue = expectPatchOk(
+      await runPatch({
+        store,
+        patch: {
+          key: MAIN_SESSION_KEY,
+          toolOverrides: { skills: { docs: true }, webSearch: true },
+        },
+      }),
+    );
+    expect(withSkillsTrue.toolOverrides).toEqual({
+      skills: { docs: true },
+      webSearch: true,
     });
 
     const replaced = expectPatchOk(


### PR DESCRIPTION
Closes #121377

## What Problem This Solves

`sessions.patch` silently dropped `toolOverrides.webSearch: true` during normalize, so a session-level **enable** override could not persist. `webSearch: false` already persisted, and sibling boolean maps (`skills`, `mcpServers`) already keep `true`.

### Before (broken)

Patching:

```json
{ "key": "agent:main:main", "toolOverrides": { "webSearch": true } }
```

succeeded, but read-back omitted `webSearch` (lone `{ webSearch: true }` normalized to an empty overlay / `undefined`).

Pre-fix normalize gate:

```ts
...(raw.webSearch === false ? { webSearch: false } : {})
```

Current `main` still retains `webSearch` only when it is `false`. The owner is now `src/gateway/session-tool-overrides.ts` (extracted from `sessions-patch.ts`).

## Why This Change Was Made

Keep both boolean values, matching `skills` / `mcpServers`:

```ts
...(typeof raw.webSearch === "boolean" ? { webSearch: raw.webSearch } : {})
```

Tip anchors (`c4ff336d9f23`):

- https://github.com/openclaw/openclaw/blob/c4ff336d9f230801f693e082a5baac8f3c56deb1/src/gateway/session-tool-overrides.ts#L30-L36

DIRTY rebase onto `7779a09c23c45520da1cd616879bd26d6eca4593`:
- Conflict file: `src/gateway/sessions-patch.ts` (upstream already extracted the normalizer). Kept upstream extraction and replayed the boolean-keep on `session-tool-overrides.ts`.
- Tests remain in `sessions-patch.test.ts` (enable-only, deny-only, skills+true adjacency, combined maps, `toolOverrides: null` clear).

Persistence-only. Global kill-switch UX honesty is tracked separately in #121401 / #121557 (Control UI). Runtime must not treat session `true` as overriding `tools.web.search.enabled: false`.

## User Impact

`sessions.patch` can now persist `toolOverrides.webSearch: true` (and still persist `false`). Whether the agent materializes `web_search` under a global disable is a separate product rule (global disable remains authoritative).

## Evidence

### DIRTY rebase

```text
starting_sha=300f10a6d62c831be60509b90c6415cd55114a8a
upstream_base=7779a09c23c45520da1cd616879bd26d6eca4593
new_head=c4ff336d9f230801f693e082a5baac8f3c56deb1
conflict_files=src/gateway/sessions-patch.ts
resolution=keep upstream extracted owner; replay boolean-keep on session-tool-overrides.ts
force_with_lease=success
```

### Real-behavior proof

<!-- issue-hunter-proof:start -->
```text
Exact-head Gateway RPC proof
reviewed_head=c4ff336d9f230801f693e082a5baac8f3c56deb1
date=2026-09-01T02:25:50Z
node=v24.15.0
workdir=/root/workspace/phone-worker-zyw02-openclaw

----- seed-readback -----
$ sessions.list → agent:main:main.toolOverrides
null
ok=true

----- patch-websearch-true -----
$ sessions.patch {"key":"agent:main:main","toolOverrides":{"webSearch":true}}
ok=true
payload={"ok":true,"path":"<TEMP>/openclaw-agent.sqlite","key":"agent:main:main","entry":{"sessionId":"sess-proof-websearch","updatedAt":1788229589977,"modelProvider":"anthropic","model":"claude-sonnet-4-6","delivery":{"kind":"none"},"toolOverrides":{"webSearch":true}},"resolved":{"modelProvider":"anthropic","model":"claude-opus-4-6","agentRuntime":{"id":"auto","source":"implicit"}}}

----- readback-after-patch -----
$ sessions.list → agent:main:main.toolOverrides
{"webSearch":true}
webSearch=true
PASS=yes

----- patch-websearch-false -----
$ sessions.patch {"key":"agent:main:main","toolOverrides":{"webSearch":false}}
ok=true

----- readback-deny -----
{"webSearch":false}
webSearch=false
PASS_DENY=yes
```

Interpretation on exact head `c4ff336d9f230801f693e082a5baac8f3c56deb1`:
- `sessions.patch` with `toolOverrides.webSearch: true` returns ok and the entry retains `webSearch: true`.
- Subsequent `sessions.list` readback shows `webSearch: true` (enable no longer dropped).
- Deny path `webSearch: false` still persists on readback.

Artifact SHA-256: `246eec3fa437e53eec40f8c90d8200983f2eeb97a88e5b65a63fdc98c18c2ae0`
<!-- issue-hunter-proof:end -->

Evidence scope: Official gateway sessions RPC harness (`startGatewayServerHarness` + `sessions.patch` / `sessions.list`) on reviewed head with an isolated temp session store. No Control UI credentials or private account data.

### Focused regression tests

```text
GATE tip=c4ff336d9f230801f693e082a5baac8f3c56deb1 mode=lean
- claw: DIRTY rebase onto 7779a09c23c4; replay boolean-keep on session-tool-overrides.ts; refresh exact-head Gateway RPC proof
- vitest: src/gateway/sessions-patch.test.ts → 104 passed
- transcript: Gateway RPC proof yes (above; PASS=yes / PASS_DENY=yes)
- oxlint: session-tool-overrides.ts + sessions-patch.test.ts → pass
- tsgo:core → pass
- format: oxfmt --check → pass
- full-types/lanes: skipped (DIRTY rebase follow-up; surface=session-tool-overrides.ts + sessions-patch.test.ts)
→ PUSH allowed: yes
```

## Remaining Risk

GitHub required checks and maintainer review on the final PR head remain the normal merge gate. This PR does not claim Control UI kill-switch UX (#121401 / #121557).

## AI-assisted development

This change was implemented with AI-assisted development and published through a guarded approval workflow. The exact diff and exact-head evidence were verified before publication.

Artifact SHA-256: `246eec3fa437e53eec40f8c90d8200983f2eeb97a88e5b65a63fdc98c18c2ae0`
