### PR TITLE
fix(diagnostics): stalled lanes go unreported while messages keep arriving

### DIFF
--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -104,6 +104,26 @@ function countMatching<T>(items: readonly T[], predicate: (item: T) => boolean) 
   return count;
 }
 
+/** Drives a lane that keeps receiving inbound, the traffic that refreshes lastActivity. */
+function advanceLaneWithInbound(params: {
+  sessionId: string;
+  sessionKey: string;
+  totalMs: number;
+  inboundEveryMs: number;
+  onInbound?: () => void;
+}) {
+  const ticks = Math.floor(params.totalMs / params.inboundEveryMs);
+  for (let i = 0; i < ticks; i += 1) {
+    vi.advanceTimersByTime(params.inboundEveryMs);
+    logMessageQueued({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      source: "dispatch",
+    });
+    params.onInbound?.();
+  }
+}
+
 const requireRecord = createRequireRecord("object", "label-not-object");
 
 function expectRecordFields(record: Record<string, unknown>, fields: Record<string, unknown>) {
@@ -871,6 +891,130 @@ describe("stuck session diagnostics threshold", () => {
         });
         vi.advanceTimersByTime(1_000);
       }
+    } finally {
+      unsubscribe();
+    }
+
+    expect(events.some((event) => event.type === "session.stalled")).toBe(false);
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+  });
+
+  it("reports blocked tool calls on a lane whose inbound keeps refreshing the session clock", () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat({ diagnostics: { enabled: true } }, { recoverStuckSession });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      markDiagnosticToolStartedForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        runId: "run-1",
+        toolName: "bash",
+        toolCallId: "cmd-1",
+      });
+
+      advanceLaneWithInbound({
+        sessionId: "s1",
+        sessionKey: "main",
+        totalMs: 20 * 60_000,
+        inboundEveryMs: 25_000,
+      });
+    } finally {
+      unsubscribe();
+    }
+
+    const stalled = requireRecord(
+      events.findLast((event) => event.type === "session.stalled"),
+      "stalled event",
+    );
+    expectRecordFields(stalled, {
+      classification: "blocked_tool_call",
+      reason: "blocked_tool_call",
+      activeWorkKind: "tool_call",
+      activeToolName: "bash",
+    });
+    // Both the report and the recovery request carry the progress clock, not the
+    // 25s-old session touch: the ownerless-lane release window measures staleness.
+    expect(stalled.ageMs).toBeGreaterThanOrEqual(15 * 60_000);
+    const recovery = requireFirstMockCallArg(recoverStuckSession, "recoverStuckSession");
+    expect(recovery.ageMs).toBeGreaterThanOrEqual(15 * 60_000);
+  });
+
+  it("keeps a lane with fresh owned progress quiet while inbound keeps arriving", () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat({ diagnostics: { enabled: true } }, { recoverStuckSession });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      markDiagnosticToolStartedForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        runId: "run-1",
+        toolName: "bash",
+        toolCallId: "cmd-1",
+      });
+
+      advanceLaneWithInbound({
+        sessionId: "s1",
+        sessionKey: "main",
+        totalMs: 20 * 60_000,
+        inboundEveryMs: 25_000,
+        onInbound: () => {
+          markDiagnosticRunProgressForTest({
+            sessionId: "s1",
+            sessionKey: "main",
+            runId: "run-1",
+            reason: "cli_live:stream_progress",
+          });
+        },
+      });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(events.some((event) => event.type === "session.stalled")).toBe(false);
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+  });
+
+  it("leaves a busy lane with no owned work on the session clock", () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat({ diagnostics: { enabled: true } }, { recoverStuckSession });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      markDiagnosticToolStartedForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        runId: "run-1",
+        toolName: "bash",
+        toolCallId: "cmd-1",
+      });
+      // Terminal-but-unreleased state: the owner is gone, the activity row is not.
+      // Recording that fact belongs to the run lifecycle, not to this gate.
+      markDiagnosticEmbeddedRunEnded({ sessionId: "s1", sessionKey: "main" });
+      expect(
+        getDiagnosticSessionActivitySnapshot({ sessionId: "s1", sessionKey: "main" })
+          .activeWorkKind,
+      ).toBeUndefined();
+
+      advanceLaneWithInbound({
+        sessionId: "s1",
+        sessionKey: "main",
+        totalMs: 20 * 60_000,
+        inboundEveryMs: 25_000,
+      });
     } finally {
       unsubscribe();
     }

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1266,27 +1266,15 @@ export function startDiagnosticHeartbeat(
         activity,
         staleMs: stuckSessionWarnMs,
       });
-      const repeatedRequestAttention =
-        state.state === "processing" &&
-        (activity.repeatedRequestNoProgressAgeMs ?? 0) > stuckSessionWarnMs;
-      // logMessageQueuedWithBacklogPolicy refreshes state.lastActivity per queued
-      // inbound, so a wedged lane that keeps receiving messages never ages past the
-      // threshold. classifySessionAttention, the is*RecoveryEligible rules and the
-      // ownerless-lane release window all measure staleness on the progress clock,
-      // so owned work reaches and is handed that clock rather than the session touch.
-      const ownedWorkProgressAgeMs =
-        activity.activeWorkKind === undefined ? 0 : (activity.lastProgressAgeMs ?? 0);
-      const ownedWorkAttention =
-        state.state === "processing" && ownedWorkProgressAgeMs > stuckSessionWarnMs;
+      // Inbound traffic refreshes session age; owned work stalls on its progress clock.
+      const ownedWorkAgeMs = activity.activeWorkKind ? (activity.lastProgressAgeMs ?? 0) : 0;
+      const attentionAgeMs = idleQueuedRecoverableStall
+        ? (activity.lastProgressAgeMs ?? ageMs)
+        : Math.max(ageMs, activity.repeatedRequestNoProgressAgeMs ?? 0, ownedWorkAgeMs);
       if (
-        (state.state === "processing" && ageMs > stuckSessionWarnMs) ||
-        repeatedRequestAttention ||
-        ownedWorkAttention ||
+        (state.state === "processing" && attentionAgeMs > stuckSessionWarnMs) ||
         idleQueuedRecoverableStall
       ) {
-        const attentionAgeMs = idleQueuedRecoverableStall
-          ? (activity.lastProgressAgeMs ?? ageMs)
-          : Math.max(ageMs, activity.repeatedRequestNoProgressAgeMs ?? 0, ownedWorkProgressAgeMs);
         const classification = logSessionAttention({
           sessionId: state.sessionId,
           sessionKey: state.sessionKey,

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1269,14 +1269,24 @@ export function startDiagnosticHeartbeat(
       const repeatedRequestAttention =
         state.state === "processing" &&
         (activity.repeatedRequestNoProgressAgeMs ?? 0) > stuckSessionWarnMs;
+      // logMessageQueuedWithBacklogPolicy refreshes state.lastActivity per queued
+      // inbound, so a wedged lane that keeps receiving messages never ages past the
+      // threshold. classifySessionAttention, the is*RecoveryEligible rules and the
+      // ownerless-lane release window all measure staleness on the progress clock,
+      // so owned work reaches and is handed that clock rather than the session touch.
+      const ownedWorkProgressAgeMs =
+        activity.activeWorkKind === undefined ? 0 : (activity.lastProgressAgeMs ?? 0);
+      const ownedWorkAttention =
+        state.state === "processing" && ownedWorkProgressAgeMs > stuckSessionWarnMs;
       if (
         (state.state === "processing" && ageMs > stuckSessionWarnMs) ||
         repeatedRequestAttention ||
+        ownedWorkAttention ||
         idleQueuedRecoverableStall
       ) {
         const attentionAgeMs = idleQueuedRecoverableStall
           ? (activity.lastProgressAgeMs ?? ageMs)
-          : Math.max(ageMs, activity.repeatedRequestNoProgressAgeMs ?? 0);
+          : Math.max(ageMs, activity.repeatedRequestNoProgressAgeMs ?? 0, ownedWorkProgressAgeMs);
         const classification = logSessionAttention({
           sessionId: state.sessionId,
           sessionKey: state.sessionKey,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a wedged reply lane stays invisible for exactly as long as its user
keeps messaging it. When an agent turn stops making progress — the captured case is a tool call that never
returns; a model call that goes silent reaches this gate through the same
`ownedWorkAttention` disjunct and is classified by `classifySessionAttention`'s
`active_work_without_progress` branch — that is source inspection, not a captured run — the diagnostic
heartbeat is supposed to warn about the session, emit `session.stalled`, and issue a recovery request. It does that on a lane nobody is
messaging. On the same wedge, with the user still typing, the operator gets no warning, no
event and no recovery request at all, while their messages pile up behind a lane that
looks alive.

**Root cause.** The gate that decides whether to look reads a clock that inbound traffic
resets. `src/auto-reply/reply/dispatch-from-config.gather.ts:186` calls `markProcessing()`
for every dispatched message, which runs `logMessageQueued` →
`logMessageQueuedWithBacklogPolicy` (`src/logging/diagnostic-runtime.ts:47`) and
`logSessionStateChange` (`src/logging/diagnostic.ts`); both assign
`state.lastActivity = Date.now()`. The heartbeat's attention gate opens on
`recoveryObservationNow - state.lastActivity`, so a steady inbound stream pins that age
near the message interval and the gate never opens.

Everything behind the gate already decides on a different clock:

- `classifySessionAttention` (`src/logging/diagnostic-session-attention.ts:28-34`) takes no
  age argument at all — it reads `lastProgressAgeMs`, `activeToolAgeMs`,
  `repeatedRequestNoProgressAgeMs`, session state and queue depth.
- `isBlockedToolCallRecoveryEligible`, `isStalledModelCallRecoveryEligible` and
  `isStalledEmbeddedRunRecoveryEligible` (`src/logging/diagnostic.ts`) all key on
  `activity.lastProgressAgeMs` / `activeToolAgeMs`.
- `src/logging/diagnostic-stuck-session-recovery.runtime.ts:297` compares the age it is
  handed against `staleActiveLaneTaskReleaseMs` before releasing a command lane whose run
  handle is already gone.

So the gate is the only place still measuring staleness with the inbound-refreshed session clock, and it is
what stands between a busy wedged lane and rules that already exist.

[#119851](https://github.com/openclaw/openclaw/pull/119851) closed one sub-case of this in the same file: an active embedded run that
re-requests the model without semantic progress now opens the gate through
`repeatedRequestNoProgressAgeMs`. That clock is deliberately narrow —
`resolveRepeatedRequestNoProgressAgeMs`
(`src/logging/diagnostic-repeated-request-activity.ts:94-109`) returns `undefined` without
a current run owner and below a repeat count of 2 — so every other owned-work wedge is
still gated on the inbound-refreshed session clock.

## Why This Change Was Made

This PR changes which clock the gate measures owned work with, following the
`repeatedRequestAttention` disjunct that already sits in the same `if`:

```ts
const ownedWorkProgressAgeMs =
  activity.activeWorkKind === undefined ? 0 : (activity.lastProgressAgeMs ?? 0);
const ownedWorkAttention =
  state.state === "processing" && ownedWorkProgressAgeMs > stuckSessionWarnMs;
```

`buildDiagnosticSessionActivitySnapshot`
(`src/logging/diagnostic-run-activity-snapshot.ts:55-68`) sets `lastProgressAgeMs` on every
snapshot it builds and only reports an `activeWorkKind` from that same builder, so the
`?? 0` arm is unreachable in practice; it satisfies the optional field on the snapshot
type. `ownedWorkProgressAgeMs` then joins the `Math.max` that already produces the age passed to
`logSessionAttention` and to the recovery request. The production change is those two
consts, one disjunct and one extra `Math.max` term: 11 added lines and 1 removed, of which
5 added lines are the comment.

Two properties are worth naming:

- For any one snapshot the aggregate age can only grow, never shrink, so this term cannot
  close a gate that opened without it. It does not make observation permanent: once the
  lane reports progress again the age resets and the gate closes, as it does today. `Math.max` cannot close a gate that opened
  before, and a snapshot with no `activeWorkKind` resolves to exactly
  the old value, so it gains no visibility from this new term (the pre-existing disjuncts
  still apply to it unchanged).
- The eligibility predicates, the classification and the threshold constants are unchanged; what changes is the age they are given, and therefore which lanes reach them: `stuckSessionWarnMs`
  (120s), the 360s abort window and `BLOCKED_TOOL_CALL_ABORT_FLOOR_MS` (900s) keep their
  values. Behaviour on affected lanes does change, and that is the point — a busy wedged
  lane goes from never being observed to being observed and, at the unchanged thresholds,
  handed to recovery, and `staleActiveLaneTaskReleaseMs` is compared against real staleness
  instead of the inbound interval.

**Why the gate and the recovery request move together.** The invariant is that the gate and the
recovery request are answered with the same aggregate age: the value that decides *whether
this lane needs attention* is the value that decides *how long it has needed it*. That
aggregate is still a `Math.max` over several sources; what this PR changes is that its
owned-work term is the progress clock. Breaking that pair
is not a smaller change, it is a broken one — `diagnostic-stuck-session-recovery.runtime.ts:297`
is the only path that can release a command lane whose run handle is already gone, and it
gates on the age this loop hands it. A gate widened alone would newly observe such a lane
on every tick and never let it be released, because the value being compared against
`staleActiveLaneTaskReleaseMs` would still be the inbound interval. The recovery
*thresholds* are untouched; only the age they are given is now the same age the gate used.

Which recovery branch the capture exercises: the wedge keeps an active tool owner, so the
classification is `blocked_tool_call` and the request is issued with `allowActiveAbort:
true` — the abort branch. The command-lane release at `runtime.ts:297` needs the opposite
state (no active session id) and is not reached in this capture. That branch's rule is
unchanged; only its input age is. This part is read from the source, not captured: its own
freshness guard is independent of the age,
it refuses to reset a lane where `laneStartedFreshTask` is true, i.e. where a task appeared
that was not there before the abort attempt (`runtime.ts:292-297`). So an earlier release
still cannot reset a lane that has already unwedged.

**Design note.** The alternative repair is at the producer: stop letting queued inbound
refresh `state.lastActivity`. That field is not only a staleness clock — session pruning
evicts on it (`src/logging/diagnostic-session-state.ts:59`) and alias merging orders on it
(`:106-119`) — so redefining it would change eviction for every session. The reader that
needs a staleness clock is the one that has to ask for it. A second variant, widening only
the reported age and leaving the recovery request on the old clock, was implemented first
and dropped in review: a lane whose run handle is gone but whose command lane still holds
a task would then be newly observed and never released, because `runtime.ts:297` would
keep comparing the inbound-refreshed age against `staleActiveLaneTaskReleaseMs`. That is the same defect one layer down. Splitting it out would ship a
change that makes such a lane visible and permanently un-releasable, so the gate and the
request carry the same age in one PR.

**Non-scope.** Deliberately out of scope: the terminal-but-unreleased lane — the run lifecycle has cleared
`activeWorkKind` while a `run:completed` progress reason survives — is not covered:
`ownedWorkProgressAgeMs` is 0 there and the gate behaves exactly as it does today.
Recording that state belongs to the lifecycle owner that clears the owner, not to this
gate. The third test below pins that silence so the boundary is explicit rather than
accidental. Recovery latency, the threshold constants themselves, and
`isIdleQueuedRecoverableSessionStall` are also untouched.

Related: #119851 is the merged PR that introduced the repeated-request disjunct this one
follows. #103690 and #96834 describe this operator-visible family. The sub-case
this PR closes is narrow: a lane in `processing` with an owned work item whose progress
clock has aged past the warn threshold is now observed while inbound continues. Those
reports also involve queue admission and lane ownership beyond the diagnostic gate, both
carry `clawsweeper:no-new-fix-pr` and `needs-maintainer-review`, and this PR does not claim
to close either.

## User Impact

An operator whose lane wedges now learns about it while it is happening instead of after
they stop typing. The boundary of what was measured is stated under Evidence. the `stalled session` warning and the `session.stalled` event fire on
real staleness, a recovery request is issued at the thresholds those rules
already define (the capture shows the request being issued; what recovery then does with
it is not observed here), and the age handed to the release window for a command lane whose run handle is gone is
the lane's real staleness rather than the inbound interval. What that window then decides
is downstream of this change and is not observed in the capture. A lane that keeps reporting progress does not cross the
threshold, so it is not newly observed; the second added test pins that for a busy lane
receiving a progress frame with every inbound message. The captured wedge is a blocked tool
call; that a silent model call reaches the same gate is read from the source, not measured.

## Evidence

### Real behavior proof

Behavior addressed: one wedge, two arms. Quiet arm (control): a lane wedged on a tool call
that never returns is warned about and a recovery request is issued for it — the behaviour
that must not change. Busy arm (the defect): the same wedge produces no warning, no
`session.stalled` event and no recovery request for the whole 960s capture window, while
inbound messages keep arriving.
Real environment tested: linux/amd64, node v24.18.0, ClawProof package
`20260810t014147z-proof-b650302d` (final, generated 2026-08-10T02:53:25Z), baseline
`08507909ed7c` vs candidate `07a291de6c03`, production default timings (120s warn, 360s
abort, 900s blocked-tool-call floor), 960s per arm.

The two transcripts below are the captured output of the same harness file run twice,
abridged in exactly two ways: the session key `agent:main:whatsapp:direct:+15550000000` is
elided to `...`, and the per-tick warning lines (27 or 28 of them per stalled arm, one every
30s, identical apart from the ages) are shown as first and last rather than in full. Nothing
else is removed, and both arms of both sides are shown at the same granularity.

Before (pre-fix):

Baseline `08507909ed7c`.

```text
$ node --import tsx "$HARNESS"          # cwd = baseline worktree @ 08507909ed7c
===== BEFORE (baseline 08507909ed7c, unfixed source) =====
[harness: quiet_lane_control: wedged; observing 960s]
[diagnostic] stalled session: sessionId=wedged-session-1 sessionKey=... state=processing age=150s queueDepth=0 reason=blocked_tool_call classification=blocked_tool_call activeWorkKind=tool_call lastProgress=tool:bash:started lastProgressAge=150s activeTool=bash activeToolCallId=wedged-tool-1 activeToolAge=150s recovery=none
[diagnostic] stalled session: sessionId=wedged-session-1 sessionKey=... state=processing age=930s queueDepth=0 reason=blocked_tool_call classification=blocked_tool_call activeWorkKind=tool_call lastProgress=tool:bash:started lastProgressAge=930s activeTool=bash activeToolCallId=wedged-tool-1 activeToolAge=930s recovery=checking
[harness: quiet_lane_control: warnings=27 recoveries=1]
[harness: busy_lane_defect: wedged; observing 960s]
[harness: busy_lane_defect: warnings=0 recoveries=0]
      "arm": "busy_lane_defect",
      "inboundEveryMs": 45000,
      "observedSeconds": 960,
      "operatorWarnings": 0,
      "firstWarning": null,
      "attentionEvents": 0,
      "firstAttentionEvent": null,
      "recoveryRequests": 0,
      "_note": "attentionEvents counts session.stuck / session.stalled / session.long_running payloads received on the diagnostic event bus",
      "firstRecoveryRequest": null,
      "finalSessionState": "processing",
      "finalQueueDepth": 22,
      "finalSessionClockAgeTicks": 0
```

Across the 960s capture window the busy arm emits nothing at all while 22 messages queue
behind the wedge: no warning line, no `session.stalled` event, no recovery request. The
gate's input on that arm never grows past the inbound interval, so nothing in the capture
bounds how much longer the silence would continue. The quiet arm, same wedge,
warns 27 times and issues one recovery request.

Evidence after fix:

Candidate `07a291de6c03`.

```text
$ node --import tsx "$HARNESS"          # cwd = candidate worktree @ 07a291de6c03
===== AFTER (candidate 07a291de6c03, fix applied) =====
[harness: quiet_lane_control: wedged; observing 960s]
[diagnostic] stalled session: sessionId=wedged-session-1 sessionKey=... state=processing age=150s queueDepth=0 reason=blocked_tool_call classification=blocked_tool_call activeWorkKind=tool_call lastProgress=tool:bash:started lastProgressAge=150s activeTool=bash activeToolCallId=wedged-tool-1 activeToolAge=150s recovery=none
[diagnostic] stalled session: sessionId=wedged-session-1 sessionKey=... state=processing age=930s queueDepth=0 reason=blocked_tool_call classification=blocked_tool_call activeWorkKind=tool_call lastProgress=tool:bash:started lastProgressAge=930s activeTool=bash activeToolCallId=wedged-tool-1 activeToolAge=930s recovery=checking
[harness: quiet_lane_control: warnings=27 recoveries=1]
[harness: busy_lane_defect: wedged; observing 960s]
[diagnostic] stalled session: sessionId=wedged-session-1 sessionKey=... state=processing age=120s queueDepth=2 reason=blocked_tool_call classification=blocked_tool_call activeWorkKind=tool_call lastProgress=tool:bash:started lastProgressAge=120s activeTool=bash activeToolCallId=wedged-tool-1 activeToolAge=120s recovery=none
[diagnostic] stalled session: sessionId=wedged-session-1 sessionKey=... state=processing age=900s queueDepth=19 reason=blocked_tool_call classification=blocked_tool_call activeWorkKind=tool_call lastProgress=tool:bash:started lastProgressAge=900s activeTool=bash activeToolCallId=wedged-tool-1 activeToolAge=900s recovery=checking
[diagnostic] stalled session: sessionId=wedged-session-1 sessionKey=... state=processing age=930s queueDepth=20 reason=blocked_tool_call classification=blocked_tool_call activeWorkKind=tool_call lastProgress=tool:bash:started lastProgressAge=930s activeTool=bash activeToolCallId=wedged-tool-1 activeToolAge=930s recovery=checking
[harness: busy_lane_defect: warnings=28 recoveries=2]
      "arm": "busy_lane_defect",
      "inboundEveryMs": 45000,
      "observedSeconds": 960,
      "operatorWarnings": 28,
      "attentionEvents": 28,
      "firstAttentionEvent": { "atTick": 4, "type": "session.stalled", "reason": "blocked_tool_call", "classification": "blocked_tool_call", "activeWorkKind": "tool_call", "reportedAgeTicks": 4 },
      "recoveryRequests": 2,
      "firstRecoveryRequest": { "atTick": 30, "requestAgeTicks": 30, "queueDepth": 19, "allowActiveAbort": true },
      "finalSessionState": "processing",
      "finalQueueDepth": 22,
      "finalSessionClockAgeTicks": 0
```

`attentionEvents` counts payloads received on the diagnostic event bus through
`onDiagnosticEvent`, and `firstAttentionEvent` is the first such payload verbatim — on the
busy arm a `session.stalled` with `reason: blocked_tool_call`, which the baseline run
reports as `null`. The quiet control arm matches the baseline run exactly (27 warnings, 1
recovery request, first event `session.stalled` at tick 5). The busy arm now emits the warning, the `session.stalled` event and the recovery
request — the three signals the baseline run shows zero of.

Observed result after fix:

| 960s per arm | warnings | `session.stalled` events | recovery requests | queued behind the wedge |
|---|---|---|---|---|
| **BEFORE** quiet lane (control) | 27 | 27 | 1 | 1 |
| **BEFORE** busy lane (inbound / 45s) | **0** | **0** | **0** | **22** |
| **AFTER** quiet lane (control) | 27 | 27 | 1 | 1 |
| **AFTER** busy lane (inbound / 45s) | **28** | **28** | **2** | 22 |

Observed: the four rows above. Derived: within each side the only variable in the harness
stimulus is inbound cadence, and across the two sides the only variable is the source
version (the two worktrees differ by the two files listed in the command block below). The
control row is unchanged across sides, which is what isolates the busy row's change to the
patch. The AFTER busy row is one heartbeat tick ahead of the control in both columns
(28 vs 27 warnings, 2 vs 1 recovery requests) because it crossed the 120s threshold one
tick earlier: its first `session.stalled` reports `age=120s` (`"atTick": 4`) where the
control's reports `age=150s` (`"atTick": 5`). Those printed ages are
`Math.round(ageMs / 1000)`, so `age=120s` is an actual age just over the strict `> 120_000`
comparison, not exactly at it.

Read the second AFTER `recovery=checking` line against `finalSessionClockAgeTicks: 0`: an
inbound message arrived within the last 30s heartbeat tick, and the lane is still reported
at `age=900s` with 19 messages queued behind it. The first request lands at 900s rather
than at the 360s abort window because a blocked tool call takes the higher of the two:
`isBlockedToolCallRecoveryEligible` compares against
`Math.max(stuckSessionAbortMs, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS)`, i.e. 900s. An eligible
lane is re-requested on every tick it stays eligible; the only deduplication is against a
request still in flight (`diagnostic-session-recovery-coordinator.ts:179-203` returns
`already_in_flight`), and the injected seam here returns immediately, so the second tick
issues. That per-tick re-request is the pre-existing behaviour of the loop, unchanged by
this PR. The request carries that same 900s (`requestAgeTicks: 30`, in 30s ticks) — the
value `diagnostic-stuck-session-recovery.runtime.ts:297` compares against
`staleActiveLaneTaskReleaseMs`.

Exact steps or command run after this patch:

The two `node --import tsx "$HARNESS"` invocations above are the same command run twice —
once against the baseline checkout and once against this patch — which is what makes the
two captures comparable. Each worktree is a full checkout of this repository at the stated
SHA with dependencies installed; the harness file is the same bytes for both runs.

```sh
# A before/after harness, kept outside the repository. Both sides run the same
# bytes of it against the same harness stimulus; only the checked-out source differs.
HARNESS="$HOME/.clawproof/work-items/diagnostic-busy-lane-attention-gate/proof/harness/harness.mjs"

# cwd = the baseline worktree (checked out at 08507909ed7c, dependencies installed);
# the harness resolves every production module from process.cwd()
node --import tsx "$HARNESS"

# cwd = the candidate worktree (checked out at 07a291de6c03) — same file, same arguments
node --import tsx "$HARNESS"

# what differs between the two worktrees, and the production file the harness exercises
git diff --name-only 08507909ed7c 07a291de6c03
#   src/logging/diagnostic.test.ts
#   src/logging/diagnostic.ts
git diff 08507909ed7c 07a291de6c03 -- src/logging/diagnostic.ts

# cwd = this repository at the PR head; the regression tests need nothing else
node scripts/run-vitest.mjs src/logging/diagnostic.test.ts          # this patch: 85 passed

# the revert check (negative control). This PR's only production change is in this file, so
# restoring the baseline copy of it reverts exactly the expression under test and nothing else.
git checkout 08507909ed7c -- src/logging/diagnostic.ts
node scripts/run-vitest.mjs src/logging/diagnostic.test.ts          # 1 failed | 84 passed
git checkout 07a291de6c03 -- src/logging/diagnostic.ts
```

How the capture was produced: the harness imports the production modules directly — no
vitest, no `vi.mock`, no fake timers — and resolves every one of them from `process.cwd()`,
which is what makes the two runs differ only by the checked-out source. It arms the wedge at
the diagnostic event boundary rather than by writing activity rows: it emits
`tool.execution.started` on the event bus and `startDiagnosticRunActivityTracking` — which
`startDiagnosticHeartbeat` starts itself — records the activity. Only the documented
`opts.recoverStuckSession` seam is injected, to count invocations. The busy arm queues one
inbound every 45s through `logMessageQueued`. In production `markProcessing()` calls both
`logMessageQueued` and `logSessionStateChange` and each assigns `state.lastActivity`; the
harness calls only the first. Both writers set that field to the current time, so for
`state.lastActivity` the two writes per dispatched message and the harness's single write
are the same refresh moment at the resolution this capture measures (30s ticks).

What was not tested: the transcripts above are the complete captured output of both arms on
both sides, but the harness file that produced them is not part of this repository, so a
reviewer cannot re-run it from this checkout — the added tests are what reproduce the same
gate and the same classification path from the checkout alone, with the timings compressed
by `testTimings`. The capture is process-local: it does not stand in for a real dispatch, a
real tool execution, or a real channel. It shows the warning, the event, and the *issuing*
of a recovery request; what recovery then does — the abort, and the release of a command
lane whose run handle is gone — is read from the source and is not measured here. The wedge
is a blocked tool call; the silent-model-call variant reaches the same gate through the same
disjunct by source inspection and is not separately captured. The terminal-completed lane
named under Non-scope is deliberately not covered.

**Targeted tests.** `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts` — 85
passed (82 before), 3 cases added to the existing `stuck session diagnostics threshold`
describe:

1. a blocked tool call with inbound every 25s for 20 minutes now emits `session.stalled`
   (`blocked_tool_call`) and calls `recoverStuckSession`, with both the event age and the
   request age carrying the progress clock (≥ 15 min) while the last inbound is 25s old;
2. the same lane with fresh progress frames on every inbound stays silent — no event, no
   recovery — so the change did not simply make everything visible;
3. a lane whose run ended while its activity row survives stays silent as well, pinning
   the non-scope boundary above.

The revert check — restoring the baseline copy of the production file — turns case 1 RED and leaves 2 and 3 green
(`Tests 1 failed | 84 passed`).

`node scripts/check-changed.mjs --base upstream/main` — lanes `core`, `coreTests`; all
checks ok (conflict markers, env-var ratchet, max-lines ratchet, changelog attributions,
doctor deprecation registry, wildcard re-exports, duplicate coverage, dependency pins,
format, typecheck core + core tests, import cycles, dead-export scan).

