### PR TITLE
improve(ui): align session context menu rows, icons, and shortcut hints

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1454,6 +1454,10 @@ async function createChatPickerScenario(
     assistantAgentId: "main",
     assistantName: "Molty",
     defaultAgentId: "main",
+    // Advertised Gateway methods gate session actions (see
+    // ui/src/lib/session-method-access.ts). Omitting the mutation methods left
+    // every session context-menu row disabled, so the harness could not show
+    // the menu operators actually see.
     featureMethods: [
       "chat.metadata",
       "chat.startup",
@@ -1461,8 +1465,16 @@ async function createChatPickerScenario(
       "openclaw.changes.list",
       "openclaw.chat",
       "openclaw.chat.history",
+      "sessions.delete",
       "sessions.diff",
       "sessions.files.set",
+      "sessions.fork",
+      "sessions.groups.delete",
+      "sessions.groups.list",
+      "sessions.groups.put",
+      "sessions.groups.rename",
+      "sessions.patch",
+      "sessions.patchMany",
       "sessions.catalog.list",
       "sessions.catalog.read",
       "system.info",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2637,6 +2637,28 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   text-align: left;
 }
 
+/* Web Awesome's shadow row adds `margin-inline-end: 0.75em !important` to the
+   slotted icon, which the light DOM cannot outrank. Dropping the gap leaves
+   that margin as the icon column instead of stacking into a ~17px gutter. */
+wa-dropdown-item.session-menu__item {
+  gap: 0;
+}
+
+/* The icon slot wrapper is a block-level flex item, so its inline child sits on
+   the row's text baseline ~2px above the label's optical centre. */
+wa-dropdown-item.session-menu__item::part(icon) {
+  display: flex;
+  align-items: center;
+}
+
+/* Web Awesome insets the submenu chevron 1em at its own font size, landing it
+   inside the shortcut column and heavier than the hints. Share their rail. */
+wa-dropdown-item.session-menu__item::part(submenu-icon) {
+  inset-inline-end: 8px;
+  color: var(--muted);
+  font-size: 10px;
+}
+
 .session-menu__item:hover:not(:disabled),
 .session-menu__item:focus-visible,
 .sidebar-session-sort-menu__item:hover,
@@ -2700,12 +2722,15 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   white-space: nowrap;
 }
 
+/* Keycap hint, not content: the app's quiet mono shortcut idiom (see
+   .chat-question-panel__option kbd), fixed-width so letters and digits share
+   one rail beside the labels. */
 .session-menu__shortcut {
   flex: 0 0 auto;
+  min-width: 12px;
   color: var(--muted);
-  font-size: 11px;
-  font-weight: 550;
-  letter-spacing: 0.04em;
+  font: 11px/1 var(--mono);
+  text-align: center;
 }
 
 .session-menu__info {
@@ -2715,7 +2740,7 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
 }
 
 .session-menu__separator {
-  margin: 6px 4px;
+  margin: 4px 8px;
   border-top: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
 }
 


### PR DESCRIPTION
Closes #121382

## What Problem This Solves

Fixes an issue where operators opening the sidebar session row `⋯` menu would see a menu that reads as misaligned: shortcut hints as loud as the labels they annotate, an icon gutter roughly double the row's own inset, icons sitting above the label's optical centre, and a submenu chevron out of plumb with the hint column and heavier than the hints beside it. The same rows are shared by the sidebar group menu, the catalog session menu, and the native link menu, so all of them read the same way.

## Why This Change Was Made

Four measured causes, all in the shared `.session-menu__*` row primitives:

- **Doubled gutter.** The row sets `gap: 8px` and Web Awesome's `wa-dropdown-item` shadow root additionally applies `margin-inline-end: 0.75em !important` to the slotted icon. An inner-tree `!important` outranks anything the light DOM can say, so the two stack into a 17px gutter. Dropping the gap on dropdown rows leaves Web Awesome's margin as the single icon column; plain `<button>` rows (new-session pickers) have no such margin and keep the gap.
- **Icons riding high.** The shadow `#icon` wrapper is a block-level flex item, so its inline child sits on the row's text baseline, ~2px above the label's optical centre. `::part(icon)` now centres it.
- **Loud hints.** `.session-menu__shortcut` was `font-weight: 550` beside `font-weight: 400` labels. It now uses the app's existing quiet mono shortcut idiom (`.chat-question-panel__option kbd`), fixed-width so letters and the group-submenu digits share one rail.
- **Chevron out of plumb.** Web Awesome insets `#submenu-indicator` by `1em` at its own font size, landing 12px from the row edge while every hint is right-aligned at 8px. `::part(submenu-icon)` now shares the hints' inset, size, and tone.

The divider also moves from a 4px inset to 8px so it starts and ends on the same columns as the rows.

**Chevron decision.** I checked whether the shortcut-contrast fix alone made the chevron read acceptably: it did not. The chevron's problem is geometric, not relative — 12px vs 8px inset is a hard misalignment that no change to the hints can correct, and its glyph box (15×12 at a heavier stroke) stayed larger than the ~8px hint glyphs. So it got its own fix, aligned to the hint rail at 10px in `--muted`.

**Icon rationalization decision.** I deliberately did **not** drop icons from the verb rows. In this menu the icons are state, not decoration: pin/unpin, unread/read, and archive/restore swap glyph with the session's current state (`session.pinned ? icons.pinOff : icons.pin`, `session.unread ? icons.eye : icons.circle`, `session.archived ? icons.archiveRestore : icons.archive` in `ui/src/components/session-menu.ts`). Removing them would delete state feedback to buy rhythm. Mixing iconed and icon-less rows in one flat list would also force either a reserved empty column or two indent levels — the exact defect class this PR removes. The measured causes of the "mal espaçado" complaint were the gutter, the baseline offset, and the hint weight, and all three are fixed without touching the icon set.

**Blast radius.** `.session-menu__*` is the shared menu row primitive (`ui/src/styles/new-session.css` calls this out explicitly). The dropdown-scoped rules improve the session menu, sidebar group menu, catalog session menu, and native link menu. Plain `<button>` consumers (`ui/src/pages/new-session/cloud-target.ts`, `place-picker.ts`) are untouched by the dropdown-scoped rules and verified unchanged. The sidebar sort/filter rows (`.sidebar-session-sort-menu__item`) keep their own gap and check placement, deliberately left alone so this stays disjoint from the in-flight filter-popover work; only the shared separator inset touches them.

The mock harness change is fixture-only: `scripts/control-ui-mock-dev.ts` advertised no session mutation methods, so every row of this menu rendered disabled and the harness could not show the menu operators actually see. That is why the misalignment was never caught visually.

## User Impact

The session context menu (and the group, catalog, and native link menus that share its rows) reads as one grid: a single icon column, icons on the label's optical axis, shortcut hints as a quiet keycap rail, and the submenu chevron on that same rail. No behavior, keyboard shortcut, or action changes. Running `pnpm dev:ui:mock` now shows the session menu enabled instead of fully greyed out.

## Evidence

Playwright against the mock gateway harness, headless, 1440×900, `deviceScaleFactor: 2`, both `colorScheme` values, verified in both themes.

**Session menu — dark**

| Before | After |
|---|---|
| <img width="224" src="https://github.com/user-attachments/assets/2813da8a-33d4-4e57-8aef-c5485c4b9ead" /> | <img width="224" src="https://github.com/user-attachments/assets/c52449f0-942d-4842-bf7c-80e73160ea94" /> |

**Session menu — light**

| Before | After |
|---|---|
| <img width="224" src="https://github.com/user-attachments/assets/93acccbd-f7fe-4e93-9995-74ed0baee8ba" /> | <img width="224" src="https://github.com/user-attachments/assets/db92d2ef-e55d-40e5-b7a5-8ba91f314c2c" /> |

**"Move to group" submenu (chevron + digit rail) — dark, then light**

| Before | After |
|---|---|
| <img width="360" src="https://github.com/user-attachments/assets/86f3c228-3daf-4740-b61b-9d5c466c26df" /> | <img width="360" src="https://github.com/user-attachments/assets/af486803-f908-4d6c-9c69-8ce0f79205c6" /> |
| <img width="360" src="https://github.com/user-attachments/assets/57e0c9b5-b0ec-4d58-b838-03ecbe22bfd1" /> | <img width="360" src="https://github.com/user-attachments/assets/0b7942c5-3d47-4658-8e5f-28a5f8c94a4f" /> |

**Shared primitive — sidebar group menu (dark, then light)**

| Before | After |
|---|---|
| <img width="224" src="https://github.com/user-attachments/assets/0f6b6f0e-62a6-49a5-8e96-86c76f9a6351" /> | <img width="224" src="https://github.com/user-attachments/assets/2b211402-bc0b-4abe-af1e-4d29a7c40e4f" /> |
| <img width="224" src="https://github.com/user-attachments/assets/5ad2e64e-6d11-4667-ab26-fd0750bb1c00" /> | <img width="224" src="https://github.com/user-attachments/assets/4a8097be-2e3a-42e2-93cb-e07be7d60032" /> |

Measured geometry, every row of the session menu, identical in both themes:

| | before | after |
|---|---|---|
| icon centre Y (row centre 15) | 12.92 | **15.0** |
| label start X (row inset 8) | 39 | **31** |
| icon → label gutter | 17px | **9px** |
| shortcut hint | 11px / 550, sans | **11px / 400, mono, 12px rail** |
| chevron inset from row edge | 12px | **8px** (hints: 8px) |
| chevron box | 15×12 | **12.5×10** |

Contrast guard, measured on the live menu surface (`rgb(25,28,36)` dark, `rgb(255,255,255)` light):

- shortcut hint: **5.04:1** dark, **5.45:1** light — both above 4.5:1
- label for reference: 11.52:1 dark, 10.96:1 light, so hints stay clearly secondary
- the hint colour token (`--muted`) is unchanged by this PR; only weight, family, and rail width changed

Focused checks (local, trusted source):

```
ui vitest src/styles/theme-contrast.test.ts src/styles/base-theme-contrast.node.test.ts src/styles/base-theme-tokens.node.test.ts  → 3 files, 5 tests passed
ui vitest src/components/session-menu.test.ts src/components/menu-surface.test.ts        → 2 files, 39 tests passed
stylelint --config config/stylelint.config.mjs ui/src/styles/layout.css                  → clean
oxfmt --check ui/src/styles/layout.css scripts/control-ui-mock-dev.ts                    → clean
git diff --check                                                                          → clean
autoreview --mode branch                                                                  → clean, no accepted/actionable findings
```

Production LOC: `ui/src/styles/layout.css` +29/-4 (17 of the added lines are the required inline comments explaining the Web Awesome shadow-tree constraints). `scripts/control-ui-mock-dev.ts` +12/-0 is harness fixture data, not production.
