### PR TITLE
fix(test): gateway loopback LAN proof flakes in parallel CI

### DIFF
--- a/src/test-utils/ports.ts
+++ b/src/test-utils/ports.ts
@@ -15,11 +15,11 @@ export async function isPortFree(port: number): Promise<boolean> {
   });
 }
 
-export async function getFreePort(): Promise<number> {
+export async function getFreePort(host = "127.0.0.1"): Promise<number> {
   return await new Promise((resolve, reject) => {
     const server = createServer();
     server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
+    server.listen(0, host, () => {
       const addr = server.address();
       if (!addr || typeof addr === "string") {
         server.close();

--- a/test/e2e/qa-lab/runtime/gateway-loopback-lan-access.ts
+++ b/test/e2e/qa-lab/runtime/gateway-loopback-lan-access.ts
@@ -13,10 +13,10 @@ import { clearConfigCache, clearRuntimeConfigSnapshot } from "../../../../src/co
 import { clearSessionStoreCacheForTest } from "../../../../src/config/sessions/store-writer-state.js";
 import { pickPrimaryLanIPv4 } from "../../../../src/gateway/net.js";
 import { startGatewayServer, type GatewayServer } from "../../../../src/gateway/server.js";
-import { getFreeGatewayPort } from "../../../../src/gateway/test-helpers.e2e.js";
 import { GATEWAY_STARTUP_MUTATED_ENV_KEYS } from "../../../../src/gateway/test-helpers.env.js";
 import { resetAgentEventsForTest } from "../../../../src/infra/agent-events.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../../../src/test-utils/env.js";
+import { getFreePort } from "../../../../src/test-utils/ports.js";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -365,7 +365,7 @@ export async function runGatewayLoopbackLanProof(): Promise<GatewayLoopbackLanPr
     );
     resetGatewayTestState();
 
-    const loopbackPort = await getFreeGatewayPort();
+    const loopbackPort = await getFreePort("0.0.0.0");
     server = await startGateway(loopbackPort, "loopback", token);
     const loopbackHealthStatus = await probeHttpHealth({
       host: "127.0.0.1",
@@ -384,7 +384,7 @@ export async function runGatewayLoopbackLanProof(): Promise<GatewayLoopbackLanPr
     await stopGateway(server);
     server = undefined;
 
-    const lanPort = await getFreeGatewayPort();
+    const lanPort = await getFreePort("0.0.0.0");
     server = await startGateway(lanPort, "lan", token);
     const lanHealthStatus = await probeHttpHealth({
       host: lanIp,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the gateway loopback/LAN QA proof could fail with `GatewayLockError` when parallel CI processes selected the same deterministic test-port block.

Observed on unrelated #121331 in [Actions run 31347484644, attempt 1](https://github.com/openclaw/openclaw/actions/runs/31347484644), where the LAN phase exhausted bind retries on `0.0.0.0:56008`.

## Why This Change Was Made

The producer now uses the OS-ephemeral free-port helper for each gateway phase, probing on `0.0.0.0` so the selected port is free across IPv4 interfaces. The shared helper keeps its existing loopback default for all current callers, and the producer retains its isolated state directory and awaited gateway shutdown between phases and in final cleanup.

The deterministic gateway block allocator remains appropriate for tests that consume derived `port + N` listeners; this producer disables those sidecars and does not need a block.

## User Impact

No product behavior changes. Parallel CI is less likely to fail an unrelated PR because a sibling process selected the same gateway test port.

## Evidence

- Failure proof: attempt 1 of run 31347484644 failed only `gateway-loopback-lan-access.test.ts` with `EADDRINUSE` on the second deterministic block offset (`56008`); attempt 2 passed unchanged.
- Focused repeat: 10/10 isolated-Linux-network-namespace runs passed, totaling 30/30 assertions for real loopback isolation, LAN reachability, HTTP/WS health, token auth, and teardown.
  - Focused command per iteration: `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/gateway-loopback-lan-access.test.ts`
- `pnpm check:changed -- src/test-utils/ports.ts test/e2e/qa-lab/runtime/gateway-loopback-lan-access.ts` passed all selected format, guard, typecheck, lint, dead-code, and import-cycle checks via the documented local fallback (Testbox/Crabbox was unavailable in the orb).
- TruffleHog pre-review scan: clean.
- Independent source review: no blocking findings.

AI-assisted: yes. The implementation, failure logs, allocator ownership, network behavior, and validation results were manually inspected.
