### PR TITLE
improve(ui): polish Markdown table presentation

### DIFF
--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -82,18 +82,33 @@
    :where(p + ...) spacing rule below which intentionally omits table. */
 .chat-text :where(table) {
   margin-top: 0.75em;
-  border-collapse: collapse;
+  border: 1px solid color-mix(in srgb, var(--accent) 20%, var(--border));
+  border-radius: var(--radius-md);
+  border-collapse: separate;
+  border-spacing: 0;
   width: 100%;
   max-width: 100%;
+  background: color-mix(in srgb, var(--accent) 2%, var(--bg-elevated));
+  box-shadow: 0 6px 20px color-mix(in srgb, var(--accent) 4%, transparent);
   font-size: 13px;
   display: block;
   overflow-x: auto;
 }
 
 .chat-text :where(th, td) {
-  border: 1px solid var(--border);
-  padding: 6px 10px;
-  vertical-align: top;
+  padding: 8px 12px;
+  border-right: 1px solid color-mix(in srgb, var(--accent) 12%, var(--border));
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 12%, var(--border));
+  text-align: left;
+  vertical-align: middle;
+}
+
+.chat-text :where(th:last-child, td:last-child) {
+  border-right: none;
+}
+
+.chat-text :where(tbody tr:last-child td) {
+  border-bottom: none;
 }
 
 .chat-text :where(th:first-child, td:first-child) {
@@ -103,10 +118,32 @@
 }
 
 .chat-text :where(th) {
-  font-family: var(--mono);
+  border-bottom-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--accent) 10%, var(--secondary)),
+    color-mix(in srgb, var(--accent) 6%, var(--secondary))
+  );
+  color: var(--text-strong);
+  font-family: var(--font-body);
+  font-weight: 600;
+}
+
+.chat-text :where(tbody tr) {
+  transition: background var(--duration-fast) ease;
+}
+
+.chat-text :where(tbody tr:nth-child(even)) {
+  background: color-mix(in srgb, var(--accent) 3%, transparent);
+}
+
+.chat-text :where(tbody tr:hover) {
+  background: color-mix(in srgb, var(--accent) 7%, var(--bg-elevated));
+}
+
+.chat-text :where(tbody td:first-child) {
+  color: var(--text-strong);
   font-weight: 500;
-  color: var(--muted);
-  background: var(--secondary);
 }
 
 .chat-text :where(ul, ol) {


### PR DESCRIPTION
## What Problem This Solves

Markdown tables in Control UI chat currently use flat gray borders and a muted header, so table structure blends into the surrounding message and is harder to scan than other rich Markdown elements.

## Why This Change Was Made

This gives chat tables a clearer visual hierarchy using existing theme tokens: a restrained accent-tinted header, rounded accent-aware border, gentle zebra and hover states, stronger first-column labels, and balanced cell alignment. The colors use `color-mix()` with semantic theme variables rather than fixed palette values, preserving Claw, Knot, and Dash light/dark behavior.

## User Impact

Users can scan agent-generated Markdown tables more easily in both light and dark Control UI themes without changing Markdown parsing, transcript storage, or horizontal overflow behavior.

## Evidence

Live OpenAI GPT-5.6 response rendered through the built Control UI and inspected in Chromium:

### Light theme

![Markdown table in the light theme](https://ampcode.com/user-content/artifacts/bfc52b8f2fa642a0340fa0e5891380125e9868264f66fbae5811c4d84fed180e-file.png)

### Dark theme

![Markdown table in the dark theme](https://ampcode.com/user-content/artifacts/574a38b88532010bec84f71bfe2628481a38fdf9acc03582b4d6a2636ae54700-file.png)

Verification:

- `pnpm exec stylelint --config config/stylelint.config.mjs ui/src/styles/chat/text.css`
- `pnpm ui:build` (including precompressed-asset and Control UI performance checks)
- Playwright against the public Control UI portal: one visible HTML table, expected three headers, updated hashed stylesheet loaded, and zero console errors
- Structured Codex autoreview: no accepted/actionable findings
