### PR TITLE
fix(config): setup tools emit only canonical config

### DIFF
--- a/extensions/fal/onboard.test.ts
+++ b/extensions/fal/onboard.test.ts
@@ -1,0 +1,41 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
+import { describe, expect, it } from "vitest";
+import { applyFalConfig, FAL_DEFAULT_IMAGE_MODEL_REF } from "./onboard.js";
+
+describe("applyFalConfig", () => {
+  it("adds the canonical image default without replacing sibling media defaults", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          mediaModels: {
+            video: { primary: "video/model" },
+            music: { primary: "music/model" },
+          },
+        },
+        entries: { main: { default: true } },
+      },
+    };
+
+    const result = applyFalConfig(config);
+
+    expect(result.agents?.defaults?.mediaModels).toEqual({
+      image: { primary: FAL_DEFAULT_IMAGE_MODEL_REF },
+      video: { primary: "video/model" },
+      music: { primary: "music/model" },
+    });
+    expect(result.agents?.defaults).not.toHaveProperty("imageGenerationModel");
+  });
+
+  it("preserves an explicit canonical image default", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          mediaModels: { image: { primary: "custom/image" } },
+        },
+        entries: { main: { default: true } },
+      },
+    };
+
+    expect(applyFalConfig(config)).toBe(config);
+  });
+});

--- a/extensions/fal/onboard.ts
+++ b/extensions/fal/onboard.ts
@@ -4,7 +4,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
 export const FAL_DEFAULT_IMAGE_MODEL_REF = "fal/fal-ai/flux/dev";
 
 export function applyFalConfig(cfg: OpenClawConfig): OpenClawConfig {
-  if (cfg.agents?.defaults?.imageGenerationModel) {
+  if (cfg.agents?.defaults?.mediaModels?.image) {
     return cfg;
   }
   return {
@@ -13,8 +13,9 @@ export function applyFalConfig(cfg: OpenClawConfig): OpenClawConfig {
       ...cfg.agents,
       defaults: {
         ...cfg.agents?.defaults,
-        imageGenerationModel: {
-          primary: FAL_DEFAULT_IMAGE_MODEL_REF,
+        mediaModels: {
+          ...cfg.agents?.defaults?.mediaModels,
+          image: { primary: FAL_DEFAULT_IMAGE_MODEL_REF },
         },
       },
     },

--- a/scripts/anthropic-prompt-probe.ts
+++ b/scripts/anthropic-prompt-probe.ts
@@ -815,6 +815,42 @@ async function readLogTail(logPath: string, maxBytes = GATEWAY_LOG_TAIL_BYTES): 
   }
 }
 
+function buildGatewayPromptConfig(params: { profileId: string; proxyPort: number | undefined }) {
+  return {
+    gateway: {
+      mode: "local",
+      controlUi: { enabled: false },
+      tailscale: { mode: "off" },
+    },
+    discovery: {
+      mdns: { mode: "off" },
+    },
+    ...(params.proxyPort
+      ? {
+          models: {
+            providers: {
+              anthropic: {
+                baseUrl: `http://127.0.0.1:${params.proxyPort}`,
+                api: "anthropic-messages",
+                models: [],
+              },
+            },
+          },
+        }
+      : {}),
+    auth: {
+      profiles: { [params.profileId]: { provider: "anthropic", mode: "token" } },
+      order: { anthropic: [params.profileId] },
+    },
+    agents: {
+      defaults: {
+        model: "anthropic/claude-sonnet-4-6",
+      },
+      entries: { main: { default: true } },
+    },
+  };
+}
+
 async function runGatewayPrompt(prompt: string): Promise<PromptResult> {
   const tokenSource = await resolveSetupTokenSource();
   const [{ callGateway }, { extractPayloadText }] = await Promise.all([
@@ -846,42 +882,7 @@ async function runGatewayPrompt(prompt: string): Promise<PromptResult> {
     await fs.writeFile(
       configPath,
       `${JSON.stringify(
-        {
-          gateway: {
-            mode: "local",
-            controlUi: { enabled: false },
-            tailscale: { mode: "off" },
-          },
-          discovery: {
-            mdns: { mode: "off" },
-            wideArea: { enabled: false },
-          },
-          ...(proxyPort
-            ? {
-                models: {
-                  providers: {
-                    anthropic: {
-                      baseUrl: `http://127.0.0.1:${proxyPort}`,
-                      api: "anthropic-messages",
-                      models: [],
-                    },
-                  },
-                },
-              }
-            : {}),
-          auth: {
-            profiles: { [tokenSource.profileId]: { provider: "anthropic", mode: "token" } },
-            order: { anthropic: [tokenSource.profileId] },
-          },
-          agents: {
-            defaults: {
-              model: "anthropic/claude-sonnet-4-6",
-              heartbeat: {
-                includeSystemPromptSection: false,
-              },
-            },
-          },
-        },
+        buildGatewayPromptConfig({ profileId: tokenSource.profileId, proxyPort }),
         null,
         2,
       )}\n`,
@@ -1006,6 +1007,7 @@ async function main() {
 }
 
 export const testing = {
+  buildGatewayPromptConfig,
   cleanupPromptProbeTmpDir,
   installGatewayPromptParentSignalHandlers,
   matchesExtraUsage400,

--- a/src/cli/dns-cli.test.ts
+++ b/src/cli/dns-cli.test.ts
@@ -36,6 +36,7 @@ vi.mock("../config/config.js", async () => {
 });
 
 import { Command } from "commander";
+import { defaultRuntime } from "../runtime.js";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 import { registerDnsCli } from "./dns-cli.js";
 
@@ -70,7 +71,7 @@ describe("dns-cli probe bounds", () => {
     vi.restoreAllMocks();
   });
 
-  async function runDnsSetupApply(): Promise<void> {
+  async function runDnsSetup(options?: { apply?: boolean }): Promise<void> {
     const program = new Command();
     program.exitOverride();
     registerDnsCli(program);
@@ -83,13 +84,24 @@ describe("dns-cli probe bounds", () => {
         "setup",
         "--domain",
         "openclaw.internal",
-        "--apply",
+        ...(options?.apply ? ["--apply"] : []),
       ]),
     );
   }
 
+  it("prints the canonical wide-area discovery config", async () => {
+    const writeJson = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => undefined);
+
+    await runDnsSetup();
+
+    expect(writeJson).toHaveBeenCalledWith({
+      gateway: { bind: "auto" },
+      discovery: { wideArea: { domain: "openclaw.internal." } },
+    });
+  });
+
   it("bounds the brew prefix probe with a SIGKILL-backed timeout", async () => {
-    await runDnsSetupApply();
+    await runDnsSetup({ apply: true });
 
     const probeCall = spawnSyncMock.mock.calls.find(isBrewPrefixProbe);
     expect(probeCall).toBeDefined();
@@ -97,7 +109,7 @@ describe("dns-cli probe bounds", () => {
   });
 
   it("leaves long-running setup subprocesses unbounded", async () => {
-    await runDnsSetupApply();
+    await runDnsSetup({ apply: true });
 
     const nonProbeCalls = spawnSyncMock.mock.calls.filter((call) => !isBrewPrefixProbe(call));
     expect(nonProbeCalls.length).toBeGreaterThan(0);

--- a/src/cli/dns-cli.ts
+++ b/src/cli/dns-cli.ts
@@ -177,7 +177,7 @@ export function registerDnsCli(program: Command) {
       );
       defaultRuntime.writeJson({
         gateway: { bind: "auto" },
-        discovery: { wideArea: { enabled: true, domain: wideAreaDomain } },
+        discovery: { wideArea: { domain: wideAreaDomain } },
       });
       defaultRuntime.log("");
       defaultRuntime.log(theme.heading("Tailscale admin (DNS → Nameservers):"));

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -936,7 +936,7 @@ describe("gateway-status command", () => {
         config: {
           ...createSecretRefGatewayConfig({ gatewayMode: "remote" }),
           discovery: {
-            wideArea: { enabled: true },
+            wideArea: { domain: "openclaw.internal" },
           },
         },
         issues: [],

--- a/src/commands/gateway-status/helpers.test.ts
+++ b/src/commands/gateway-status/helpers.test.ts
@@ -16,6 +16,22 @@ import {
 import { createSecretRefGatewayConfig } from "./test-support.js";
 
 describe("extractConfigSummary", () => {
+  it.each([
+    ["canonical domain", { discovery: { wideArea: { domain: "openclaw.internal" } } }, true],
+    ["no domain", {}, false],
+  ] as const)("derives wide-area discovery state from %s", (_label, config, expected) => {
+    const summary = extractConfigSummary({
+      path: "/tmp/openclaw.json",
+      exists: true,
+      valid: true,
+      issues: [],
+      legacyIssues: [],
+      config,
+    });
+
+    expect(summary.discovery.wideAreaEnabled).toBe(expected);
+  });
+
   it("marks SecretRef-backed gateway auth credentials as configured", () => {
     const summary = extractConfigSummary({
       path: "/tmp/openclaw.json",

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -52,7 +52,7 @@ export type GatewayConfigSummary = {
     tailscaleMode: string | null;
   };
   discovery: {
-    wideAreaEnabled: boolean | null;
+    wideAreaEnabled: boolean;
   };
 };
 
@@ -228,7 +228,7 @@ export function extractConfigSummary(snapshotUnknown: unknown): GatewayConfigSum
   const remoteTokenConfigured = hasConfiguredSecretInput(remote.token, secretDefaults);
   const remotePasswordConfigured = hasConfiguredSecretInput(remote.password, secretDefaults);
 
-  const wideAreaEnabled = typeof wideArea.enabled === "boolean" ? wideArea.enabled : null;
+  const wideAreaEnabled = Boolean(normalizeOptionalString(wideArea.domain));
 
   return {
     path,

--- a/src/commands/gateway-status/output.test.ts
+++ b/src/commands/gateway-status/output.test.ts
@@ -131,7 +131,7 @@ function createReachableTarget(
         tailscaleMode: null,
       },
       discovery: {
-        wideAreaEnabled: null,
+        wideAreaEnabled: false,
       },
     },
   };

--- a/src/commands/gateway-status/output.ts
+++ b/src/commands/gateway-status/output.ts
@@ -277,12 +277,7 @@ export function writeGatewayStatusText(params: {
       );
     }
     if (result.configSummary) {
-      const wideArea =
-        result.configSummary.discovery.wideAreaEnabled === true
-          ? "enabled"
-          : result.configSummary.discovery.wideAreaEnabled === false
-            ? "disabled"
-            : "unknown";
+      const wideArea = result.configSummary.discovery.wideAreaEnabled ? "enabled" : "disabled";
       params.runtime.log(
         `  ${colorize(params.rich, theme.info, "Wide-area discovery")}: ${wideArea}`,
       );

--- a/test/scripts/dev-tooling-safety.test.ts
+++ b/test/scripts/dev-tooling-safety.test.ts
@@ -23,6 +23,7 @@ import {
   redactJsonValueForDevToolLog,
 } from "../../scripts/lib/dev-tooling-safety.ts";
 import { resolveWindowsTaskkillPath } from "../../scripts/lib/windows-taskkill.mjs";
+import { validateConfigObjectRaw } from "../../src/config/validation.ts";
 
 const tempDirs: string[] = [];
 
@@ -226,6 +227,22 @@ describe("dev tooling safety helpers", () => {
 });
 
 describe("script-specific dev tooling hardening", () => {
+  it.each([
+    ["direct", undefined],
+    ["capture proxy", 12_345],
+  ] as const)(
+    "builds a strict-valid Anthropic gateway prompt probe config for %s",
+    (_mode, proxyPort) => {
+      const config = promptProbeTesting.buildGatewayPromptConfig({
+        profileId: "anthropic:test",
+        proxyPort,
+      });
+      const result = validateConfigObjectRaw(config, { validateBundledChannels: true });
+
+      expect(result.ok, result.ok ? undefined : JSON.stringify(result.issues)).toBe(true);
+    },
+  );
+
   it("rejects unknown Discord smoke drivers instead of silently using token mode", () => {
     expect(discordSmokeTesting.parseDriverMode("webhook")).toBe("webhook");
     expect(() => discordSmokeTesting.parseDriverMode("curl")).toThrow(/Invalid --driver/u);


### PR DESCRIPTION
Related: #121330
Related: #121370

## What Problem This Solves

Fixes an issue where several setup and diagnostic paths continued to write, recommend, or read retired config keys after strict validation moved to canonical shapes:

- Fal API-key onboarding wrote `agents.defaults.imageGenerationModel`.
- `openclaw dns setup` recommended `discovery.wideArea.enabled`.
- The Anthropic gateway prompt probe generated both `discovery.wideArea.enabled` and `agents.defaults.heartbeat.includeSystemPromptSection`, then lacked the required canonical default-agent roster once those invalid nested keys were removed.
- `openclaw gateway status` read the retired wide-area flag, so current configs with `discovery.wideArea.domain` appeared as `unknown`.

## Why This Change Was Made

Each owner now uses the current contract at its producer boundary: Fal preserves sibling media defaults under `agents.defaults.mediaModels.image`; DNS prints the domain-only enabling shape; the prompt probe constructs one strict-valid config with an explicit default `main` agent; and gateway status derives enabled/disabled state from the canonical domain. The obsolete three-state status renderer was reduced to the two states the current config supports.

Doctor remains the sole owner of migrating already-written legacy files. Docs already use the canonical keys after #121330, so no docs projection changes are needed. A production sweep found no other retired-key writers/readers in this cluster; the remaining QA-lab `imageGenerationModel` identifiers are in-memory parameter names and already serialize to `mediaModels.image`.

AI-assisted by Codex. The repository's `autoreview`, `test-audit`, and maintainer skills were unavailable in this agent catalog, so the change was reviewed directly against current source, schemas, doctor migrations, callers, sibling provider implementations, history, focused tests, and changed-lane planning.

## User Impact

Fal onboarding and DNS setup now produce copyable config that passes strict validation. The Anthropic prompt probe can start with a valid generated config, and gateway status accurately reports wide-area discovery for current domain-based configurations.

No new config surface or migration is introduced.

## Evidence

Pre-fix regressions failed for the intended reasons:

- Fal: 2 failures (canonical image default absent; explicit canonical default overwritten by a legacy sibling key).
- DNS: recommended JSON contained retired `enabled: true`.
- Gateway status: canonical domain resolved to `null`/`unknown`.
- Prompt probe: strict validation rejected retired `includeSystemPromptSection` and `wideArea.enabled`; removing those exposed the missing required default-agent roster.

Passing proof:

- `node scripts/run-vitest.mjs run extensions/fal/*.test.ts` — 77 passed.
- `node scripts/run-vitest.mjs run src/cli/dns-cli.test.ts` — 3 passed.
- `node scripts/run-vitest.mjs run src/commands/gateway-status/helpers.test.ts` — 23 passed.
- `node scripts/run-vitest.mjs run src/commands/gateway-status.test.ts src/commands/gateway-status/output.test.ts` — 46 passed.
- `node scripts/run-vitest.mjs run test/scripts/dev-tooling-safety.test.ts` — 66 passed.
- `node scripts/run-vitest.mjs run src/config/dead-config-keys.test.ts` — 218 passed.
- Targeted oxlint for core, extension, and scripts projects passed.
- `node scripts/run-tsgo.mjs -p extensions/fal/tsconfig.json` passed.
- `node scripts/run-tsgo.mjs -p tsconfig.scripts.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/scripts.tsbuildinfo` passed.
- Targeted oxfmt and `git diff --check` passed.

Production LOC: +46/-48 (net -2). Tests: +92/-6.
