### PR TITLE
fix(cli): dns setup prints valid wide-area config

### DIFF
--- a/scripts/anthropic-prompt-probe.ts
+++ b/scripts/anthropic-prompt-probe.ts
@@ -854,7 +854,6 @@ async function runGatewayPrompt(prompt: string): Promise<PromptResult> {
           },
           discovery: {
             mdns: { mode: "off" },
-            wideArea: { enabled: false },
           },
           ...(proxyPort
             ? {

--- a/src/cli/cli-utils.test.ts
+++ b/src/cli/cli-utils.test.ts
@@ -1,6 +1,7 @@
 // CLI utility tests cover shared command helpers, option parsing, and output formatting.
 import { Command } from "commander";
 import { describe, expect, it, vi } from "vitest";
+import { defaultRuntime } from "../runtime.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
 import { registerDnsCli } from "./dns-cli.js";
 import { parseByteSize } from "./parse-bytes.js";
@@ -129,6 +130,7 @@ describe("shouldSkipStartupEnvironmentRespawnForArgv", () => {
 describe("dns cli", () => {
   it("prints setup info (no apply)", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const writeJson = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
     try {
       const program = new Command();
       registerDnsCli(program);
@@ -136,7 +138,12 @@ describe("dns cli", () => {
       const output = log.mock.calls.map((call) => call.join(" ")).join("\\n");
       expect(output).toContain("DNS setup");
       expect(output).toContain("openclaw.internal");
+      expect(writeJson).toHaveBeenCalledWith({
+        gateway: { bind: "auto" },
+        discovery: { wideArea: { domain: "openclaw.internal." } },
+      });
     } finally {
+      writeJson.mockRestore();
       log.mockRestore();
     }
   });

--- a/src/cli/dns-cli.ts
+++ b/src/cli/dns-cli.ts
@@ -177,7 +177,7 @@ export function registerDnsCli(program: Command) {
       );
       defaultRuntime.writeJson({
         gateway: { bind: "auto" },
-        discovery: { wideArea: { enabled: true, domain: wideAreaDomain } },
+        discovery: { wideArea: { domain: wideAreaDomain } },
       });
       defaultRuntime.log("");
       defaultRuntime.log(theme.heading("Tailscale admin (DNS → Nameservers):"));

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -936,7 +936,7 @@ describe("gateway-status command", () => {
         config: {
           ...createSecretRefGatewayConfig({ gatewayMode: "remote" }),
           discovery: {
-            wideArea: { enabled: true },
+            wideArea: { domain: "openclaw.internal" },
           },
         },
         issues: [],

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -228,7 +228,8 @@ export function extractConfigSummary(snapshotUnknown: unknown): GatewayConfigSum
   const remoteTokenConfigured = hasConfiguredSecretInput(remote.token, secretDefaults);
   const remotePasswordConfigured = hasConfiguredSecretInput(remote.password, secretDefaults);
 
-  const wideAreaEnabled = typeof wideArea.enabled === "boolean" ? wideArea.enabled : null;
+  const wideAreaEnabled =
+    typeof wideArea.domain === "string" ? wideArea.domain.trim().length > 0 : null;
 
   return {
     path,


### PR DESCRIPTION
Related: #121330

## What Problem This Solves

Fixes an issue where users running `openclaw dns setup` would receive a recommended config containing the retired `discovery.wideArea.enabled` key, which strict config validation rejects.

## Why This Change Was Made

Wide-area discovery is enabled by a non-empty `discovery.wideArea.domain`, so the CLI now emits only that canonical field. The same rule now drives deep gateway-status output, and an isolated developer probe no longer writes the retired opt-out field. Legacy-key references remain only in doctor migration and dead-key rejection coverage.

## User Impact

Operators can copy the DNS setup recommendation into `openclaw.json` without introducing a retired key, and `gateway status --deep` correctly reports a configured wide-area domain as enabled.

## Evidence

- `node scripts/run-vitest.mjs src/cli/cli-utils.test.ts src/commands/gateway-status.test.ts src/commands/gateway-status/helpers.test.ts` (3 shards, 110 tests)
- `node scripts/run-vitest.mjs src/config/dead-config-keys.test.ts src/config/config.schema-regressions.test.ts test/scripts/dev-tooling-safety.test.ts` (2 shards, 330 tests)
- Focused oxfmt and oxlint checks for all five changed files
- `pnpm docs:list`
- `git diff --check`
- Exact-commit autoreview on `3343265ced7` (clean; no accepted/actionable findings, 0.99 confidence)

AI-assisted: yes. The emitted config shape, status derivation, sibling discovery paths, and focused regression coverage were reviewed directly.
