### PR TITLE
fix(ui): microphone picker claims a selection while denying any input exists

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5188,7 +5188,7 @@ export const en: TranslationMap = {
       microphoneListUnsupported: "This browser cannot list microphone inputs.",
       noCameras: "No additional cameras found",
       noMicrophones: "No additional microphones found",
-      microphoneNoneFound: "No microphone inputs were found.",
+      microphoneNoneFound: "No microphone found. Plug one in and it appears here.",
       microphonePageInactive: "Microphone inputs are unavailable while this page is inactive.",
       microphonePermissionBlocked:
         "Microphone access is blocked. Allow it in browser site settings to list inputs.",

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -290,7 +290,7 @@ describe("renderChatComposer controls", () => {
         { deviceId: "studio-mic", label: "Studio microphone" },
         { deviceId: "headset", label: "USB headset" },
       ],
-      warning: null,
+      issue: null,
     });
     patchSettings({ realtimeTalkInputDeviceId: "studio-mic" });
     const container = document.createElement("div");
@@ -344,10 +344,55 @@ describe("renderChatComposer controls", () => {
     expect(dropdown?.open).toBe(true);
   });
 
-  it("shows discovery warnings and the next-session hint during active Talk", async () => {
+  it.each([
+    ["none-found", "chat.composer.microphoneNoneFound", false],
+    ["list-unsupported", "chat.composer.microphoneListUnsupported", false],
+    ["permission-blocked", "chat.composer.microphonePermissionBlocked", true],
+    ["busy", "chat.composer.microphoneBusy", true],
+    ["page-inactive", "chat.composer.microphonePageInactive", true],
+    ["failed", "chat.composer.microphoneAccessFailed", true],
+  ] as const)(
+    "renders %s as one empty state with no claimed selection",
+    async (issue, messageKey, fault) => {
+      discoverRealtimeTalkInputsMock.mockResolvedValue({ devices: [], issue });
+      const container = document.createElement("div");
+      document.body.append(container);
+      const composerProps = props({
+        onToggleRealtimeTalk: vi.fn(),
+        realtimeTalkActive: true,
+        realtimeTalkStatus: "listening",
+      });
+      const draw = () => render(renderChatComposer(composerProps), container);
+      composerProps.onRequestUpdate = draw;
+      draw();
+
+      const dropdown = container.querySelector<
+        HTMLElement & { open: boolean; updateComplete: Promise<unknown> }
+      >("wa-dropdown.chat-talk-input-picker");
+      await dropdown?.updateComplete;
+      button(container, t("chat.composer.microphoneInput")).click();
+      const empty = await vi.waitFor(() => {
+        const node = container.querySelector(".chat-talk-input-picker__empty");
+        expect(node?.textContent?.trim()).toBe(t(messageKey));
+        return node;
+      });
+
+      // One designed state: never a checked System default row, a second
+      // negative note, or a hint about a selection that cannot be made.
+      expect(container.querySelectorAll(".chat-talk-input-picker__item")).toHaveLength(0);
+      expect(container.querySelector(".chat-talk-input-picker__note")).toBeNull();
+      expect(container.querySelector(".chat-talk-input-picker__warning")).toBeNull();
+      expect(container.querySelector(".chat-talk-input-picker__hint")).toBeNull();
+      expect(container.querySelectorAll(".chat-talk-input-picker__empty")).toHaveLength(1);
+      expect(empty?.getAttribute("role")).toBe("status");
+      expect(empty?.classList.contains("chat-talk-input-picker__empty--fault")).toBe(fault);
+    },
+  );
+
+  it("keeps the list plus one warning when inputs exist but discovery reported an issue", async () => {
     discoverRealtimeTalkInputsMock.mockResolvedValue({
-      devices: [],
-      warning: "Microphone permission is blocked.",
+      devices: [{ deviceId: "headset", label: "USB headset" }],
+      issue: "busy",
     });
     const container = document.createElement("div");
     document.body.append(container);
@@ -366,17 +411,13 @@ describe("renderChatComposer controls", () => {
     await dropdown?.updateComplete;
     button(container, t("chat.composer.microphoneInput")).click();
     await vi.waitFor(() =>
-      expect(container.querySelector(".chat-talk-input-picker__warning")?.textContent).toContain(
-        "Microphone permission is blocked.",
-      ),
+      expect(container.querySelectorAll(".chat-talk-input-picker__item")).toHaveLength(2),
     );
 
-    expect(container.querySelector(".chat-talk-input-picker__warning")?.getAttribute("role")).toBe(
-      "alert",
+    expect(container.querySelector(".chat-talk-input-picker__warning")?.textContent?.trim()).toBe(
+      t("chat.composer.microphoneBusy"),
     );
-    expect(container.querySelector(".chat-talk-input-picker__note")?.textContent).toContain(
-      t("chat.composer.noMicrophones"),
-    );
+    expect(container.querySelector(".chat-talk-input-picker__empty")).toBeNull();
     expect(container.querySelector(".chat-talk-input-picker__hint")?.textContent).toContain(
       t("chat.composer.microphoneAppliesNextSession"),
     );
@@ -386,6 +427,39 @@ describe("renderChatComposer controls", () => {
     );
     await dropdown?.updateComplete;
     expect(dropdown?.open).toBe(false);
+  });
+
+  it("marks the selected input with a single trailing check", async () => {
+    discoverRealtimeTalkInputsMock.mockResolvedValue({
+      devices: [{ deviceId: "headset", label: "USB headset" }],
+      issue: null,
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const composerProps = props({ onToggleRealtimeTalk: vi.fn() });
+    const draw = () => render(renderChatComposer(composerProps), container);
+    composerProps.onRequestUpdate = draw;
+    draw();
+
+    const dropdown = container.querySelector<
+      HTMLElement & { open: boolean; updateComplete: Promise<unknown> }
+    >("wa-dropdown.chat-talk-input-picker");
+    await dropdown?.updateComplete;
+    button(container, t("chat.composer.microphoneInput")).click();
+    const items = await vi.waitFor(() => {
+      const rows = [...container.querySelectorAll(".chat-talk-input-picker__item")];
+      expect(rows).toHaveLength(2);
+      return rows;
+    });
+
+    // type="checkbox" would make wa-dropdown-item paint its own leading check
+    // and toggle it on click, so the row would show two disagreeing marks.
+    expect(items.map((item) => item.getAttribute("type"))).toEqual(["normal", "normal"]);
+    expect(items.map((item) => item.querySelectorAll("svg").length)).toEqual([1, 0]);
+    expect(items[0]?.querySelector(".chat-talk-input-picker__check")?.getAttribute("slot")).toBe(
+      "details",
+    );
+    expect(items.map((item) => item.getAttribute("aria-checked"))).toEqual(["true", "false"]);
   });
 
   it("offers camera only inside a video-capable active talk session", () => {

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -462,6 +462,59 @@ describe("renderChatComposer controls", () => {
     expect(items.map((item) => item.getAttribute("aria-checked"))).toEqual(["true", "false"]);
   });
 
+  it("follows devicechange while open and stops listening once closed", async () => {
+    const mediaDevices = new EventTarget();
+    Object.defineProperty(globalThis.navigator, "mediaDevices", {
+      configurable: true,
+      value: mediaDevices,
+    });
+    discoverRealtimeTalkInputsMock.mockResolvedValue({ devices: [], issue: "none-found" });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const composerProps = props({ onToggleRealtimeTalk: vi.fn() });
+    const draw = () => render(renderChatComposer(composerProps), container);
+    composerProps.onRequestUpdate = draw;
+    draw();
+
+    const dropdown = container.querySelector<
+      HTMLElement & { open: boolean; updateComplete: Promise<unknown> }
+    >("wa-dropdown.chat-talk-input-picker");
+    await dropdown?.updateComplete;
+    button(container, t("chat.composer.microphoneInput")).click();
+    await vi.waitFor(() =>
+      expect(container.querySelector(".chat-talk-input-picker__empty")?.textContent?.trim()).toBe(
+        t("chat.composer.microphoneNoneFound"),
+      ),
+    );
+
+    // The empty state promises the list keeps up, so plugging in has to land
+    // without reopening the popover.
+    discoverRealtimeTalkInputsMock.mockResolvedValue({
+      devices: [{ deviceId: "usb", label: "USB Audio Interface" }],
+      issue: null,
+    });
+    mediaDevices.dispatchEvent(new Event("devicechange"));
+    await vi.waitFor(() =>
+      expect(container.querySelectorAll(".chat-talk-input-picker__item")).toHaveLength(2),
+    );
+    expect(container.querySelector(".chat-talk-input-picker__empty")).toBeNull();
+
+    discoverRealtimeTalkInputsMock.mockResolvedValue({ devices: [], issue: "none-found" });
+    mediaDevices.dispatchEvent(new Event("devicechange"));
+    await vi.waitFor(() =>
+      expect(container.querySelectorAll(".chat-talk-input-picker__item")).toHaveLength(0),
+    );
+
+    dropdown?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+    );
+    await dropdown?.updateComplete;
+    const callsWhileClosed = discoverRealtimeTalkInputsMock.mock.calls.length;
+    mediaDevices.dispatchEvent(new Event("devicechange"));
+    await Promise.resolve();
+    expect(discoverRealtimeTalkInputsMock.mock.calls.length).toBe(callsWhileClosed);
+  });
+
   it("offers camera only inside a video-capable active talk session", () => {
     const onToggleRealtimeCamera = vi.fn();
     const { container } = renderComposer({

--- a/ui/src/pages/chat/components/chat-composer-controls.ts
+++ b/ui/src/pages/chat/components/chat-composer-controls.ts
@@ -5,7 +5,11 @@ import { syncDropdownItemRadio } from "../../../components/web-awesome.ts";
 import { t } from "../../../i18n/index.ts";
 import type { ControlUiFollowUpMode } from "../../../lib/chat/follow-up-mode.ts";
 import type { ComposerDictationController } from "../composer-dictation.ts";
-import type { RealtimeTalkInputDevice } from "../realtime-talk-input.ts";
+import {
+  realtimeTalkDeviceIssueMessage,
+  type RealtimeTalkDeviceIssue,
+  type RealtimeTalkInputDevice,
+} from "../realtime-talk-input.ts";
 import type { RealtimeTalkLevelSignal } from "../realtime-talk-level.ts";
 import type { RealtimeTalkStatus } from "../realtime-talk.ts";
 import { renderMicrophoneActivity, voiceStatusLabel } from "./chat-voice-activity.ts";
@@ -49,18 +53,30 @@ type MicrophonePickerProps = {
   open: boolean;
   selectedDeviceId: string;
   voiceActive: boolean;
-  warning: string | null;
+  issue: RealtimeTalkDeviceIssue | null;
   onOpen: () => void;
   onClose: () => void;
   onSelect: (deviceId: string) => void;
 };
 
 export function renderMicrophonePicker(props: MicrophonePickerProps) {
+  // Discovery reporting an issue with nothing enumerated is the browser stating
+  // there is no capture route at all: a "System default" row would claim a
+  // selection that cannot exist, so the popover shows one empty state instead
+  // of a checked row stacked on two ways of saying the same thing.
+  const unavailable = !props.loading && props.devices.length === 0 ? props.issue : null;
   // System default renders even while discovery runs: the dropdown's one-time
   // focus step needs at least one item or keyboard users never enter the menu.
-  const options = props.loading
-    ? [{ deviceId: "", label: t("chat.composer.systemDefaultMicrophone") }]
-    : [{ deviceId: "", label: t("chat.composer.systemDefaultMicrophone") }, ...props.devices];
+  const options = unavailable
+    ? []
+    : [
+        { deviceId: "", label: t("chat.composer.systemDefaultMicrophone") },
+        ...(props.loading ? [] : props.devices),
+      ];
+  // A machine without a microphone and a browser that cannot enumerate are
+  // facts, not faults; only the recoverable reasons earn the warn tone.
+  const unavailableIsFault =
+    unavailable !== null && unavailable !== "none-found" && unavailable !== "list-unsupported";
   const label = t("chat.composer.microphoneInput");
   return html`
     <wa-dropdown
@@ -84,38 +100,53 @@ export function renderMicrophonePicker(props: MicrophonePickerProps) {
         ${icons.chevronDown}
       </button>
       <div class="chat-talk-input-picker__heading">${label}</div>
-      ${options.map((option) => {
-        const selected = option.deviceId === props.selectedDeviceId;
-        return html`
-          <wa-dropdown-item
-            class="chat-talk-input-picker__item"
-            value=${option.deviceId}
-            type="checkbox"
-            role="menuitemradio"
-            aria-checked=${String(selected)}
-            ${ref((element) => syncDropdownItemRadio(element, selected))}
+      ${unavailable
+        ? html`<div
+            class="chat-talk-input-picker__empty${unavailableIsFault
+              ? " chat-talk-input-picker__empty--fault"
+              : ""}"
+            role="status"
           >
-            <span class="chat-talk-input-picker__label">${option.label}</span>
-            <span slot="details" class="chat-talk-input-picker__check" aria-hidden="true"
-              >${selected ? icons.check : nothing}</span
-            >
-          </wa-dropdown-item>
-        `;
-      })}
-      ${props.loading
-        ? html`<div class="chat-talk-input-picker__note" role="status">${t("common.loading")}</div>`
-        : nothing}
-      ${!props.loading && props.devices.length === 0
-        ? html`<div class="chat-talk-input-picker__note">${t("chat.composer.noMicrophones")}</div>`
-        : nothing}
-      ${props.warning
-        ? html`<div class="chat-talk-input-picker__warning" role="alert">${props.warning}</div>`
-        : nothing}
-      ${props.voiceActive
-        ? html`<div class="chat-talk-input-picker__hint">
-            ${t("chat.composer.microphoneAppliesNextSession")}
+            ${realtimeTalkDeviceIssueMessage(unavailable, "audioinput")}
           </div>`
-        : nothing}
+        : html`
+            ${options.map((option) => {
+              const selected = option.deviceId === props.selectedDeviceId;
+              // Selection is radio-shaped, so the row stays a plain menu item:
+              // wa-dropdown-item type="checkbox" paints its own leading check
+              // and flips it on click, which would contradict this trailing
+              // check whenever the click does not change the stored device.
+              return html`
+                <wa-dropdown-item
+                  class="chat-talk-input-picker__item"
+                  value=${option.deviceId}
+                  role="menuitemradio"
+                  aria-checked=${String(selected)}
+                  ${ref((element) => syncDropdownItemRadio(element, selected))}
+                >
+                  <span class="chat-talk-input-picker__label">${option.label}</span>
+                  <span slot="details" class="chat-talk-input-picker__check" aria-hidden="true"
+                    >${selected ? icons.check : nothing}</span
+                  >
+                </wa-dropdown-item>
+              `;
+            })}
+            ${props.loading
+              ? html`<div class="chat-talk-input-picker__note" role="status">
+                  ${t("common.loading")}
+                </div>`
+              : nothing}
+            ${props.issue
+              ? html`<div class="chat-talk-input-picker__warning" role="alert">
+                  ${realtimeTalkDeviceIssueMessage(props.issue, "audioinput")}
+                </div>`
+              : nothing}
+            ${props.voiceActive
+              ? html`<div class="chat-talk-input-picker__hint">
+                  ${t("chat.composer.microphoneAppliesNextSession")}
+                </div>`
+              : nothing}
+          `}
     </wa-dropdown>
   `;
 }

--- a/ui/src/pages/chat/components/chat-composer-state.ts
+++ b/ui/src/pages/chat/components/chat-composer-state.ts
@@ -34,7 +34,7 @@ function createChatComposerState(): ChatComposerState {
     microphonePickerOpen: false,
     microphonePickerLoading: false,
     microphoneDevices: [],
-    microphoneWarning: null,
+    microphoneIssue: null,
     microphoneDiscoveryRequest: 0,
     capabilityMenuOpen: false,
     capabilityMenuView: "root",

--- a/ui/src/pages/chat/components/chat-composer-state.ts
+++ b/ui/src/pages/chat/components/chat-composer-state.ts
@@ -35,6 +35,7 @@ function createChatComposerState(): ChatComposerState {
     microphonePickerLoading: false,
     microphoneDevices: [],
     microphoneIssue: null,
+    microphoneDeviceWatch: null,
     microphoneDiscoveryRequest: 0,
     capabilityMenuOpen: false,
     capabilityMenuView: "root",
@@ -144,16 +145,27 @@ export function suppressStaleSubmittedDraftReplay(
   return true;
 }
 
+/** Drops the devicechange subscription so a closed picker stops refreshing. */
+export function releaseMicrophoneDeviceWatch(state: ChatComposerState) {
+  state.microphoneDeviceWatch?.();
+  state.microphoneDeviceWatch = null;
+}
+
 export function resetChatComposerState(paneId?: string) {
   if (paneId) {
     // Goal elapsed timers are keyed by element and cleaned up when their
     // element leaves the DOM, so a per-pane reset does not need to touch them.
-    composerStates.get(paneId)?.dictation?.dispose();
+    const paneState = composerStates.get(paneId);
+    paneState?.dictation?.dispose();
+    if (paneState) {
+      releaseMicrophoneDeviceWatch(paneState);
+    }
     composerStates.delete(paneId);
     return;
   }
   for (const state of composerStates.values()) {
     state.dictation?.dispose();
+    releaseMicrophoneDeviceWatch(state);
   }
   composerStates.clear();
   clearGoalElapsedTimers();

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -11,7 +11,11 @@ import type { SessionToolOverrides } from "../../../lib/sessions/patch.ts";
 import type { ComposerDictationController } from "../composer-dictation.ts";
 import type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult } from "../input-history.ts";
 import type { RealtimeTalkConversationEntry } from "../realtime-talk-conversation.ts";
-import type { RealtimeTalkCameraDevice, RealtimeTalkInputDevice } from "../realtime-talk-input.ts";
+import type {
+  RealtimeTalkCameraDevice,
+  RealtimeTalkDeviceIssue,
+  RealtimeTalkInputDevice,
+} from "../realtime-talk-input.ts";
 import type { RealtimeTalkLevelSignal } from "../realtime-talk-level.ts";
 import type { RealtimeTalkStatus } from "../realtime-talk.ts";
 import type { ChatRunUiStatus } from "../run-lifecycle.ts";
@@ -172,7 +176,7 @@ export type ChatComposerState = {
   microphonePickerOpen: boolean;
   microphonePickerLoading: boolean;
   microphoneDevices: RealtimeTalkInputDevice[];
-  microphoneWarning: string | null;
+  microphoneIssue: RealtimeTalkDeviceIssue | null;
   microphoneDiscoveryRequest: number;
   capabilityMenuOpen: boolean;
   capabilityMenuView: ChatComposerPlusMenuView;

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -177,6 +177,8 @@ export type ChatComposerState = {
   microphonePickerLoading: boolean;
   microphoneDevices: RealtimeTalkInputDevice[];
   microphoneIssue: RealtimeTalkDeviceIssue | null;
+  /** Unsubscribe for the devicechange watch; non-null only while the picker is open. */
+  microphoneDeviceWatch: (() => void) | null;
   microphoneDiscoveryRequest: number;
   capabilityMenuOpen: boolean;
   capabilityMenuView: ChatComposerPlusMenuView;

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -5,7 +5,7 @@ import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
 import { areUiSessionKeysEquivalent } from "../../../lib/sessions/session-key.ts";
 import { ComposerDictationController, insertComposerDictation } from "../composer-dictation.ts";
-import { discoverRealtimeTalkInputs } from "../realtime-talk-input.ts";
+import { discoverRealtimeTalkInputs, observeRealtimeTalkDevices } from "../realtime-talk-input.ts";
 import { isLargePastedTextAttachment } from "./chat-attachments.ts";
 import { renderContextNotice } from "./chat-composer-context.ts";
 import { renderMicrophonePicker, type ChatRunControlsProps } from "./chat-composer-controls.ts";
@@ -48,6 +48,7 @@ import {
   hasTerminalRunStatus,
   isCurrentSessionSubmittedProgress,
   markComposerInputIntent,
+  releaseMicrophoneDeviceWatch,
   suppressStaleSubmittedDraftReplay,
 } from "./chat-composer-state.ts";
 import type { ChatComposerProps, ChatComposerState } from "./chat-composer-types.ts";
@@ -505,15 +506,15 @@ export function renderChatComposer(props: ChatComposerProps) {
     }
     props.onToggleRealtimeTalk?.();
   };
-  const openMicrophonePicker = () => {
-    if (state.microphonePickerOpen) {
-      return;
-    }
-    state.microphonePickerOpen = true;
+  const discoverMicrophones = () => {
     state.microphonePickerLoading = true;
     state.microphoneIssue = null;
     const request = ++state.microphoneDiscoveryRequest;
     requestUpdate();
+    // Permission-requesting discovery on every pass, including device changes:
+    // a microphone that just appeared has hidden labels until the probe runs,
+    // and the probe only prompts while the picker is the surface in front of
+    // the user.
     void discoverRealtimeTalkInputs(true)
       .then((result) => {
         if (request !== state.microphoneDiscoveryRequest) {
@@ -537,15 +538,25 @@ export function renderChatComposer(props: ChatComposerProps) {
         requestUpdate();
       });
   };
+  const openMicrophonePicker = () => {
+    if (state.microphonePickerOpen) {
+      return;
+    }
+    state.microphonePickerOpen = true;
+    state.microphoneDeviceWatch ??= observeRealtimeTalkDevices(discoverMicrophones);
+    discoverMicrophones();
+  };
   const closeMicrophonePicker = () => {
     if (!state.microphonePickerOpen) {
       return;
     }
+    releaseMicrophoneDeviceWatch(state);
     state.microphonePickerOpen = false;
     requestUpdate();
   };
   const selectMicrophone = (deviceId: string) => {
     patchSettings({ realtimeTalkInputDeviceId: deviceId.trim() || undefined });
+    releaseMicrophoneDeviceWatch(state);
     state.microphonePickerOpen = false;
     requestUpdate();
   };

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -511,7 +511,7 @@ export function renderChatComposer(props: ChatComposerProps) {
     }
     state.microphonePickerOpen = true;
     state.microphonePickerLoading = true;
-    state.microphoneWarning = null;
+    state.microphoneIssue = null;
     const request = ++state.microphoneDiscoveryRequest;
     requestUpdate();
     void discoverRealtimeTalkInputs(true)
@@ -520,15 +520,14 @@ export function renderChatComposer(props: ChatComposerProps) {
           return;
         }
         state.microphoneDevices = result.devices;
-        state.microphoneWarning = result.warning;
+        state.microphoneIssue = result.issue;
       })
-      .catch((error: unknown) => {
+      .catch(() => {
         if (request !== state.microphoneDiscoveryRequest) {
           return;
         }
         state.microphoneDevices = [];
-        state.microphoneWarning =
-          error instanceof Error ? error.message : t("chat.composer.microphoneAccessFailed");
+        state.microphoneIssue = "failed";
       })
       .finally(() => {
         if (request !== state.microphoneDiscoveryRequest) {
@@ -558,7 +557,7 @@ export function renderChatComposer(props: ChatComposerProps) {
         open: state.microphonePickerOpen,
         selectedDeviceId: selectedMicrophoneId,
         voiceActive: Boolean(props.realtimeTalkActive),
-        warning: state.microphoneWarning,
+        issue: state.microphoneIssue,
         onOpen: openMicrophonePicker,
         onClose: closeMicrophonePicker,
         onSelect: selectMicrophone,

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -177,7 +177,6 @@ function renderGatewayPicker(props: ChatPaneHeaderProps) {
         const selected = gateway.id === snapshot.currentId;
         return html`<wa-dropdown-item
           class="chat-pane__gateway-menu-item chat-pane__gateway-item"
-          type="checkbox"
           role="menuitemradio"
           aria-checked=${String(selected)}
           ${ref((element) => syncDropdownItemRadio(element, selected))}

--- a/ui/src/pages/chat/realtime-talk-input.test.ts
+++ b/ui/src/pages/chat/realtime-talk-input.test.ts
@@ -37,7 +37,7 @@ describe("realtime Talk microphone inputs", () => {
         { deviceId: "usb", label: "Microphone 2" },
       ],
       permissionRequired: true,
-      warning: null,
+      issue: null,
     });
     expect(getUserMedia).not.toHaveBeenCalled();
   });
@@ -63,7 +63,7 @@ describe("realtime Talk microphone inputs", () => {
         { deviceId: "loopback", label: "Loopback Audio" },
       ],
       permissionRequired: false,
-      warning: null,
+      issue: null,
     });
     expect(getUserMedia).toHaveBeenCalledWith({ audio: true });
     expect(stopFirst).toHaveBeenCalledOnce();
@@ -71,7 +71,7 @@ describe("realtime Talk microphone inputs", () => {
     expect(enumerateDevices).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps System default usable when microphone permission is denied", async () => {
+  it("reports the blocked reason when microphone permission is denied", async () => {
     vi.stubGlobal("navigator", {
       mediaDevices: {
         enumerateDevices: vi.fn(async () => [mediaDevice("audioinput", "", "")]),
@@ -85,7 +85,34 @@ describe("realtime Talk microphone inputs", () => {
 
     expect(result.devices).toEqual([]);
     expect(result.permissionRequired).toBe(true);
-    expect(result.warning).toContain("Microphone access is blocked");
+    expect(result.issue).toBe("permission-blocked");
+  });
+
+  it("separates an empty machine from a blocked browser", async () => {
+    vi.stubGlobal("navigator", {
+      mediaDevices: {
+        enumerateDevices: vi.fn(async () => []),
+        getUserMedia: vi.fn(async () => {
+          throw new DOMException("none", "NotFoundError");
+        }),
+      },
+    });
+
+    await expect(discoverRealtimeTalkInputs(true)).resolves.toEqual({
+      devices: [],
+      permissionRequired: true,
+      issue: "none-found",
+    });
+  });
+
+  it("reports an unsupported enumeration instead of a generic access failure", async () => {
+    vi.stubGlobal("navigator", { mediaDevices: {} });
+
+    await expect(discoverRealtimeTalkInputs(true)).resolves.toEqual({
+      devices: [],
+      permissionRequired: false,
+      issue: "list-unsupported",
+    });
   });
 
   it("does not silently fall back when the selected microphone is unavailable", async () => {
@@ -288,7 +315,7 @@ describe("realtime Talk camera inputs", () => {
         { deviceId: "back", label: "Camera 2" },
       ],
       permissionRequired: true,
-      warning: null,
+      issue: null,
     });
     expect(getUserMedia).not.toHaveBeenCalled();
   });
@@ -305,7 +332,7 @@ describe("realtime Talk camera inputs", () => {
     await expect(discoverRealtimeTalkCameras(true)).resolves.toEqual({
       devices: [{ deviceId: "camera", label: "Desk Camera" }],
       permissionRequired: false,
-      warning: null,
+      issue: null,
     });
     expect(getUserMedia).toHaveBeenCalledWith({ video: true });
     expect(stop).toHaveBeenCalledOnce();

--- a/ui/src/pages/chat/realtime-talk-input.test.ts
+++ b/ui/src/pages/chat/realtime-talk-input.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   discoverRealtimeTalkCameras,
   discoverRealtimeTalkInputs,
+  observeRealtimeTalkDevices,
   openRealtimeTalkCamera,
   openRealtimeTalkInput,
 } from "./realtime-talk-input.ts";
@@ -103,6 +104,24 @@ describe("realtime Talk microphone inputs", () => {
       permissionRequired: true,
       issue: "none-found",
     });
+  });
+
+  it("subscribes to devicechange and releases the listener on unsubscribe", () => {
+    const mediaDevices = new EventTarget();
+    let changes = 0;
+    vi.stubGlobal("navigator", { mediaDevices });
+
+    const unsubscribe = observeRealtimeTalkDevices(() => (changes += 1));
+    mediaDevices.dispatchEvent(new Event("devicechange"));
+    unsubscribe();
+    mediaDevices.dispatchEvent(new Event("devicechange"));
+
+    expect(changes).toBe(1);
+  });
+
+  it("stays inert where the browser exposes no media devices to watch", () => {
+    vi.stubGlobal("navigator", {});
+    expect(() => observeRealtimeTalkDevices(() => undefined)()).not.toThrow();
   });
 
   it("reports an unsupported enumeration instead of a generic access failure", async () => {

--- a/ui/src/pages/chat/realtime-talk-input.ts
+++ b/ui/src/pages/chat/realtime-talk-input.ts
@@ -7,27 +7,35 @@ export type RealtimeTalkInputDevice = {
 
 export type RealtimeTalkCameraDevice = RealtimeTalkInputDevice;
 
+/**
+ * Why discovery stopped is a fact only this module observes. Callers need the
+ * reason itself — not prose — to pick a coherent rendering, so the code travels
+ * and each surface owns its own wording and tone.
+ */
+const deviceIssueMessageKeys = {
+  "list-unsupported": [
+    "chat.composer.microphoneListUnsupported",
+    "chat.composer.cameraListUnsupported",
+  ],
+  "none-found": ["chat.composer.microphoneNoneFound", "chat.composer.cameraNoneFound"],
+  "permission-blocked": [
+    "chat.composer.microphonePermissionBlocked",
+    "chat.composer.cameraPermissionBlocked",
+  ],
+  busy: ["chat.composer.microphoneBusy", "chat.composer.cameraBusy"],
+  "page-inactive": ["chat.composer.microphonePageInactive", "chat.composer.cameraPageInactive"],
+  failed: ["chat.composer.microphoneAccessFailed", "chat.composer.cameraAccessFailed"],
+} as const;
+
+export type RealtimeTalkDeviceIssue = keyof typeof deviceIssueMessageKeys;
+
 type RealtimeTalkDeviceDiscovery = {
   devices: RealtimeTalkInputDevice[];
   permissionRequired: boolean;
-  warning: string | null;
+  issue: RealtimeTalkDeviceIssue | null;
 };
 
-type RealtimeTalkDeviceKind = "audioinput" | "videoinput";
-
-function mediaDevices(kind: RealtimeTalkDeviceKind): MediaDevices {
-  const devices = globalThis.navigator?.mediaDevices;
-  if (!devices?.enumerateDevices) {
-    throw new Error(
-      t(
-        kind === "audioinput"
-          ? "chat.composer.microphoneListUnsupported"
-          : "chat.composer.cameraListUnsupported",
-      ),
-    );
-  }
-  return devices;
-}
+export type RealtimeTalkDeviceKind = "audioinput" | "videoinput";
 
 function normalizeDevices(
   devices: MediaDeviceInfo[],
@@ -63,60 +71,48 @@ function deviceDetailsHidden(devices: MediaDeviceInfo[], kind: RealtimeTalkDevic
   return inputs.length === 0 || inputs.some((device) => !device.deviceId || !device.label);
 }
 
-function describeDeviceError(error: unknown, kind: RealtimeTalkDeviceKind): string {
-  const name = error instanceof DOMException ? error.name : "";
-  if (name === "NotAllowedError") {
-    return t(
-      kind === "audioinput"
-        ? "chat.composer.microphonePermissionBlocked"
-        : "chat.composer.cameraPermissionBlocked",
-    );
-  }
-  if (name === "NotFoundError") {
-    return t(
-      kind === "audioinput" ? "chat.composer.microphoneNoneFound" : "chat.composer.cameraNoneFound",
-    );
-  }
-  if (name === "NotReadableError") {
-    return t(kind === "audioinput" ? "chat.composer.microphoneBusy" : "chat.composer.cameraBusy");
-  }
-  if (name === "InvalidStateError") {
-    return t(
-      kind === "audioinput"
-        ? "chat.composer.microphonePageInactive"
-        : "chat.composer.cameraPageInactive",
-    );
-  }
-  return t(
-    kind === "audioinput"
-      ? "chat.composer.microphoneAccessFailed"
-      : "chat.composer.cameraAccessFailed",
+const deviceIssueByDomErrorName: Record<string, RealtimeTalkDeviceIssue> = {
+  NotAllowedError: "permission-blocked",
+  NotFoundError: "none-found",
+  NotReadableError: "busy",
+  InvalidStateError: "page-inactive",
+};
+
+function deviceIssueFromError(error: unknown): RealtimeTalkDeviceIssue {
+  return (
+    (error instanceof DOMException ? deviceIssueByDomErrorName[error.name] : undefined) ?? "failed"
   );
 }
 
+export function realtimeTalkDeviceIssueMessage(
+  issue: RealtimeTalkDeviceIssue,
+  kind: RealtimeTalkDeviceKind,
+): string {
+  const [microphoneKey, cameraKey] = deviceIssueMessageKeys[issue];
+  return t(kind === "audioinput" ? microphoneKey : cameraKey);
+}
+
 export function describeRealtimeTalkInputError(error: unknown): string {
-  return describeDeviceError(error, "audioinput");
+  return realtimeTalkDeviceIssueMessage(deviceIssueFromError(error), "audioinput");
 }
 
 async function discoverRealtimeTalkDevices(
   requestPermission: boolean,
   kind: RealtimeTalkDeviceKind,
 ): Promise<RealtimeTalkDeviceDiscovery> {
-  let devices: MediaDevices;
+  const devices = globalThis.navigator?.mediaDevices;
+  if (!devices?.enumerateDevices) {
+    return { devices: [], permissionRequired: false, issue: "list-unsupported" };
+  }
   let entries: MediaDeviceInfo[];
   try {
-    devices = mediaDevices(kind);
     entries = await devices.enumerateDevices();
   } catch (error) {
-    return {
-      devices: [],
-      permissionRequired: false,
-      warning: describeDeviceError(error, kind),
-    };
+    return { devices: [], permissionRequired: false, issue: deviceIssueFromError(error) };
   }
   const permissionRequired = deviceDetailsHidden(entries, kind);
   if (!requestPermission || !permissionRequired || !devices.getUserMedia) {
-    return { devices: normalizeDevices(entries, kind), permissionRequired, warning: null };
+    return { devices: normalizeDevices(entries, kind), permissionRequired, issue: null };
   }
 
   try {
@@ -128,13 +124,13 @@ async function discoverRealtimeTalkDevices(
     return {
       devices: normalizeDevices(entries, kind),
       permissionRequired: deviceDetailsHidden(entries, kind),
-      warning: null,
+      issue: null,
     };
   } catch (error) {
     return {
       devices: normalizeDevices(entries, kind),
       permissionRequired,
-      warning: describeDeviceError(error, kind),
+      issue: deviceIssueFromError(error),
     };
   }
 }

--- a/ui/src/pages/chat/realtime-talk-input.ts
+++ b/ui/src/pages/chat/realtime-talk-input.ts
@@ -35,7 +35,7 @@ type RealtimeTalkDeviceDiscovery = {
   issue: RealtimeTalkDeviceIssue | null;
 };
 
-export type RealtimeTalkDeviceKind = "audioinput" | "videoinput";
+type RealtimeTalkDeviceKind = "audioinput" | "videoinput";
 
 function normalizeDevices(
   devices: MediaDeviceInfo[],
@@ -90,6 +90,21 @@ export function realtimeTalkDeviceIssueMessage(
 ): string {
   const [microphoneKey, cameraKey] = deviceIssueMessageKeys[issue];
   return t(kind === "audioinput" ? microphoneKey : cameraKey);
+}
+
+/**
+ * Hardware appears and disappears while a picker is on screen, and the empty
+ * state promises the list keeps up. The caller owns the subscription window:
+ * run the returned unsubscribe when its surface closes, or the listener
+ * outlives the state it refreshes.
+ */
+export function observeRealtimeTalkDevices(onChange: () => void): () => void {
+  const devices = globalThis.navigator?.mediaDevices;
+  if (!devices?.addEventListener) {
+    return () => undefined;
+  }
+  devices.addEventListener("devicechange", onChange);
+  return () => devices.removeEventListener("devicechange", onChange);
 }
 
 export function describeRealtimeTalkInputError(error: unknown): string {

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -53,6 +53,7 @@ import { loadModels } from "../chat/models.ts";
 import {
   discoverRealtimeTalkCameras,
   discoverRealtimeTalkInputs,
+  realtimeTalkDeviceIssueMessage,
   type RealtimeTalkCameraDevice,
   type RealtimeTalkInputDevice,
 } from "../chat/realtime-talk-input.ts";
@@ -455,7 +456,9 @@ export class ConfigPage extends OpenClawLightDomElement {
       const result = await discoverRealtimeTalkInputs(requestPermission);
       this.microphoneDevices = result.devices;
       this.microphonePermissionRequired = result.permissionRequired;
-      this.microphoneError = result.warning;
+      this.microphoneError = result.issue
+        ? realtimeTalkDeviceIssueMessage(result.issue, "audioinput")
+        : null;
     } catch (error) {
       // Discovery is best-effort in blocked/inactive contexts; a rejection
       // must not wedge the picker in its loading state.
@@ -484,7 +487,9 @@ export class ConfigPage extends OpenClawLightDomElement {
       const result = await discoverRealtimeTalkCameras(requestPermission);
       this.cameraDevices = result.devices;
       this.cameraPermissionRequired = result.permissionRequired;
-      this.cameraError = result.warning;
+      this.cameraError = result.issue
+        ? realtimeTalkDeviceIssueMessage(result.issue, "videoinput")
+        : null;
     } catch (error) {
       this.cameraError = error instanceof Error ? error.message : String(error);
     } finally {

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -53,6 +53,7 @@ import { loadModels } from "../chat/models.ts";
 import {
   discoverRealtimeTalkCameras,
   discoverRealtimeTalkInputs,
+  observeRealtimeTalkDevices,
   realtimeTalkDeviceIssueMessage,
   type RealtimeTalkCameraDevice,
   type RealtimeTalkInputDevice,
@@ -243,6 +244,7 @@ export class ConfigPage extends OpenClawLightDomElement {
   @state() private systemInfoUnavailable = false;
   @state() private sessionObserverModels: ModelCatalogEntry[] = [];
   @state() private sessionObserverModelsUnavailable = false;
+  private mediaDeviceWatch: (() => void) | null = null;
   @state() private microphoneDevices: RealtimeTalkInputDevice[] = [];
   @state() private microphonePermissionRequired = true;
   @state() private microphoneLoading = false;
@@ -391,6 +393,13 @@ export class ConfigPage extends OpenClawLightDomElement {
       this.context.theme.serverSelection,
     );
     this.settings = loadSettings();
+    // Passive refresh only: the media rows already own the permission prompt
+    // behind their own controls, and a hardware change must never turn into an
+    // unasked-for browser dialog on a settings page.
+    this.mediaDeviceWatch = observeRealtimeTalkDevices(() => {
+      void this.refreshMicrophones(false);
+      void this.refreshCameras(false);
+    });
     this.syncRouteData();
   }
 
@@ -400,6 +409,8 @@ export class ConfigPage extends OpenClawLightDomElement {
       this.hiddenSessionCatalogsChanged,
     );
     this.customThemeImportOwner.retireImport();
+    this.mediaDeviceWatch?.();
+    this.mediaDeviceWatch = null;
     this.systemInfoPolling.stop();
     this.updateCountdownPolling.stop();
     this.invalidateSystemInfoRequest();

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3208,6 +3208,20 @@ openclaw-chat-video-player {
   color: var(--warn);
 }
 
+/* Sole content of the popover when no input can be selected, so it carries the
+   row's own weight instead of reading as a footnote under the heading. */
+.chat-talk-input-picker__empty {
+  padding: 4px 8px 8px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+  text-wrap: pretty;
+}
+
+.chat-talk-input-picker__empty--fault {
+  color: var(--warn);
+}
+
 .chat-talk-input-picker__hint {
   margin-top: 3px;
   border-top: 1px solid color-mix(in srgb, var(--border) 65%, transparent);


### PR DESCRIPTION
Closes #121396

## What Problem This Solves

Fixes an issue where operators opening **Microphone input** in the chat composer on a machine with no working microphone would see a popover that claims a device is selected while simultaneously stating that no input exists. It stacked a checked `System default` row, a muted `No additional microphones found` note, and an orange `No microphone inputs were found.` line — three independent conditionals that happened to be true together, reading as broken UI rather than a designed state. The message was also a dead end: it named a problem and offered nothing to do about it.

It also fixes the picker's rows carrying two competing selection marks. `wa-dropdown-item type="checkbox"` gives each row Web Awesome's own checked state, which the dropdown flips on every click and which nothing in OpenClaw reads or resets, while the trailing check is bound to the stored device. The two disagree as soon as a click does not change the selection. The chat pane gateway picker had the same mix.

## Why This Change Was Made

The reason discovery stops is a fact only `realtime-talk-input.ts` observes, and it was being flattened into pre-translated prose before it left the module — so no surface could tell "this machine has no microphone" from "this browser refused access", and the picker had nothing to branch on. Discovery now returns a reason code (`none-found`, `permission-blocked`, `busy`, `page-inactive`, `list-unsupported`, `failed`) and exports one message resolver; consumers translate at the edge.

With the reason recorded at its producer, the popover resolves to a single state. An issue with nothing enumerated means the browser has stated there is no capture route at all — `getUserMedia({audio: true})` answering `NotFoundError` is authoritative about the default route too — so `System default` is a phantom there and the popover shows one empty state instead. Where the probe succeeds, `System default` is genuinely usable and the list is unchanged; a warning may still sit under a non-empty list, which is truthful. Tone follows the fact: no microphone and no enumeration support are muted informational lines, while blocked, busy, page-inactive and failed keep the warn tone. Permission-not-granted stays its own state with its own copy, because plugging in a microphone does not reveal labels until access is allowed.

The empty state now promises the list keeps up — "No microphone found. Plug one in and it appears here." — so it has to be true. Both media surfaces subscribe to `navigator.mediaDevices` `devicechange` for exactly as long as they are on screen and drop the listener when they close. The composer popover re-runs permission-requesting discovery on each change, since a microphone that just appeared has hidden labels until the probe runs and the picker is the surface in front of the user; the settings rows refresh passively, because a hardware change must never turn into an unasked-for permission dialog on a settings page. Independently of the event, opening the picker always re-runs discovery, so the promise still holds on the next open even where the event never arrives.

Rows drop `type="checkbox"` and keep the trailing check bound to the stored device, matching the radio-row convention already used by the sidebar session menu and `session-menu.ts`. That also drops Web Awesome's `checkbox-adjacent` indent, so labels line up with sibling popovers, and removes the `menuitemradio` / `menuitemcheckbox` role conflict the sync helper was papering over.

Two smaller things fixed in passing because they share the invariant: `chat.composer.microphoneListUnsupported` was unreachable copy — the specific error was thrown and then re-described as the generic access failure — and the chat pane gateway picker's rows had the same duplicate-mark mix.

**No refresh button.** `devicechange` is supported everywhere OpenClaw ships the Control UI, so a manual refresh control would be UI apologising for a defect that does not exist. Host matrix, from MDN browser-compat-data `api/MediaDevices.json` (`devicechange_event`):

| Host | Engine | `devicechange` |
| --- | --- | --- |
| Desktop browsers | Chrome 57+, Firefox 52+, Edge 12+, Safari 11+ | supported |
| macOS app (`apps/macos`) | WKWebView / WebKit | supported — Safari 11+ |
| iOS app (`apps/ios`) | WKWebView | supported — `webview_ios` mirrors Safari iOS, 11+ |
| Android app (`apps/android`) | Android System WebView | supported — `webview_android` mirrors Chrome Android, 132+ (Jan 2025); WebView is Play-updated |

The one floor worth naming is Android System WebView below 132. That host still gets a correct list on every open — discovery re-runs when the popover opens — it just does not update live while open. No host we ship provably fails to emit the event, so no per-host fallback affordance was added.

Non-goals: the settings **Microphone input** row (`view-appearance-preferences.ts`) already picks exactly one message and needs a value in its `<select>`, so its `System default` option stays. `agent-select` and the model-setup provider picker use `type="checkbox"` **with** a `.checked` binding and no trailing check, so they show a single leading mark and are left alone.

## User Impact

Opening the microphone picker with no usable input now shows one clear line that says what to do — "No microphone found. Plug one in and it appears here." — instead of a checkmark claiming a selection next to two contradictory messages. Plug a microphone in with the popover open and it appears without reopening anything; unplug it and the list goes back to the empty state. When access is blocked, that stays its own message with the action named. When inputs exist, exactly one checkmark marks the selected one, on the right, and it stays put across clicks.

## Evidence

Headless Chromium captures of the real component with mocked `navigator.mediaDevices` outcomes, both themes, before and after.

**No microphone attached** (`enumerateDevices()` → `[]`, probe → `NotFoundError`):

![no microphone, dark](https://github.com/user-attachments/assets/d1e06303-5303-47c5-ad1b-6565e54f7d9a)

![no microphone, light](https://github.com/user-attachments/assets/b16de9c0-f8c0-45fd-96d6-79c9ff78b5d7)

**Permission denied** (probe → `NotAllowedError`) — the actionable variant keeps the warn tone and its own copy:

![blocked, dark](https://github.com/user-attachments/assets/23faaf5a-60e0-4fbf-8871-3167d4c77223)

![blocked, light](https://github.com/user-attachments/assets/b2676ddf-ea85-405c-82e4-107252686d99)

**Rows with inputs available**, focus on row 1 (unselected) while the stored selection is row 3 — focused-without-check and checked-without-focus in one frame. Note the labels move left in the after column: Web Awesome's `checkbox-adjacent` indent is gone with the checkbox type:

![rows, dark](https://github.com/user-attachments/assets/9ccaa291-8216-4420-a5c0-444d4cfa4472)

![rows, light](https://github.com/user-attachments/assets/99ad0a76-ffca-4d62-9e06-08dcebb6232e)

One honest gap on the visual proof: Web Awesome's leading checkmark is revealed by `:host(:state(checked))`, and the vitest browser harness does not apply Web Awesome's `ElementInternals` custom states at all (`:state(wa-defined)` is false there too), so that mark cannot paint in these captures. The mechanism is proven instead by source and by probe: `makeSelection` flips `item.checked` for checkbox items, and after one real click on the pre-fix tree the row reported `checked === true` with the stored `realtimeTalkInputDeviceId` unchanged and the leading check element laid out at the row's leading edge. After the fix the row is `type="normal"`, so Web Awesome never renders that element and never sets the state.

Focused tests (`node scripts/run-vitest.mjs`, 4 files, 111 passed):

- `ui/src/pages/chat/chat-composer.test.ts` — table-driven over all six reason codes: each renders exactly one `__empty` element with the right message and tone class, and no item rows, no note, no warning, no next-session hint. Plus a non-empty list keeping its rows and a single warning; a single trailing check with `type` never `checkbox`; and a `devicechange` case that drives empty → populated → empty with the popover open and proves no discovery runs after it closes.
- `ui/src/pages/chat/realtime-talk-input.test.ts` — an empty machine reports `none-found`, a denied probe reports `permission-blocked`, a browser without `enumerateDevices` reports `list-unsupported` instead of the generic failure, and the device watch adds then removes its listener (and stays inert where `mediaDevices` is absent).
- `ui/src/pages/chat/components/chat-pane-header.test.ts` and `ui/src/pages/config/config-page.test.ts` — unchanged, still green across the contract change.

`node --import tsx scripts/control-ui-i18n-verify.ts verify` clean after the copy change (no raw-copy baseline drift). `git diff --check` clean; `oxfmt` run on every touched file. Production LOC +208 / -109 (net +99) across both commits, carried by the reason-code table and message resolver that replace the prose-only error describer and by the device-change subscription; tests +139 / -18. `autoreview --mode branch` clean: no accepted or actionable findings.
