### PR TITLE
test(macos): keep mocked gateway probe routes off the operator identity store

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -225,6 +225,22 @@ actor GatewayConnection {
             sessionProvider: sessionProvider)
         self.clientShutdown = clientShutdown
     }
+
+    init(
+        testEndpointProvider: @escaping EndpointProvider,
+        sessionBox: WebSocketSessionBox? = nil)
+    {
+        self.endpointProvider = testEndpointProvider
+        self.supportsSharedEndpointRecovery = false
+        self.activationBindingKeyProvider = { GatewayConnection.testingActivationBindingKey }
+        // Mock WebSocket routes do not exercise device authentication and must not
+        // depend on the process-global persisted identity store.
+        self.includeDeviceIdentity = false
+        self.sessionProvider = Self.resolveSessionProvider(
+            sessionBox: sessionBox,
+            sessionProvider: nil)
+        self.clientShutdown = { client in await client.shutdown() }
+    }
     #endif
 
     private static func resolveSessionProvider(

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
@@ -234,8 +234,10 @@ private func onboardingProbeFixture(
     reply: OnboardingProbeReply = .configured) -> OnboardingProbeFixture
 {
     let session = GatewayTestWebSocketSession(taskFactory: onboardingProbeTaskFactory(reply: reply))
+    // The production endpointProvider init reads the process-global persisted
+    // identity store; mocked routes must stay off the operator's real state.
     let gateway = GatewayConnection(
-        endpointProvider: endpointProvider,
+        testEndpointProvider: endpointProvider,
         sessionBox: WebSocketSessionBox(session: session))
     return OnboardingProbeFixture(
         session: session,


### PR DESCRIPTION
## What Problem This Solves

The `ssh gateway replacement cannot reuse same loopback websocket` test builds a fully mocked WebSocket route through `GatewayConnection`'s production `endpointProvider:` initializer, which sets `includeDeviceIdentity = true`. Connecting therefore loads the process-global persisted device identity — the operator's real state. On a machine whose real store legitimately fails closed (e.g. conflicting legacy `device.json` sources awaiting Doctor repair), the probe returns `.unavailable` and the test fails deterministically, while clean CI environments never see it.

## Why This Change Was Made

The sibling `configProvider:` DEBUG initializer already documents the invariant: "Mock WebSocket routes do not exercise device authentication and must not depend on the process-global persisted identity store." The endpoint-provider fixture violated it. This adds the matching DEBUG-only `testEndpointProvider:` initializer (identity excluded, testing binding key, no shared-endpoint recovery) and points the probe fixture at it.

## User Impact

None at runtime — DEBUG-only test seam. Developers on machines with real OpenClaw state no longer get a false failure from `OnboardingConfiguredGatewayProbeTests`.

## Evidence

- Root cause traced live: instrumented run showed `stateDir=~/Library/Application Support/OpenClaw` and `Legacy device identity sources conflict; all sources preserved` surfacing as probe `.unavailable`; the same test passes with any isolated state dir.
- `swift build --package-path apps/macos` — passed.
- `swift test --package-path apps/macos --filter OnboardingConfiguredGatewayProbe` — 17/17 passed on a machine with the conflicting real store (previously 1 deterministic failure).
- `./scripts/lint-swift.sh macos` — 0 violations.
- Autoreview clean (0.99).

Follow-up: other test files use the production `endpointProvider:` init but currently pass because they never reach identity load during connect; migrating them to the test seam is a candidate cleanup.
