### PR TITLE
fix(agents): honor session webSearch true against global disable

### DIFF
--- a/extensions/openai/native-web-search.ts
+++ b/extensions/openai/native-web-search.ts
@@ -35,12 +35,23 @@ function shouldUseOpenAINativeWebSearchProvider(config: OpenClawConfig | undefin
   return normalized === "" || normalized === "auto" || normalized === "openai";
 }
 
+function resolveGlobalWebSearchEnabled(params: {
+  webSearchEnabled?: boolean;
+  config?: OpenClawConfig;
+}): boolean {
+  return (
+    params.webSearchEnabled === true ||
+    (params.webSearchEnabled !== false && params.config?.tools?.web?.search?.enabled !== false)
+  );
+}
+
 function shouldEnableOpenAINativeWebSearch(params: {
   config?: OpenClawConfig;
+  webSearchEnabled?: boolean;
   model: { api?: unknown; provider?: unknown; baseUrl?: unknown };
 }): boolean {
   return (
-    params.config?.tools?.web?.search?.enabled !== false &&
+    resolveGlobalWebSearchEnabled(params) &&
     shouldUseOpenAINativeWebSearchProvider(params.config) &&
     isOpenAINativeWebSearchEligibleModel(params.model)
   );
@@ -88,6 +99,7 @@ export function createOpenAINativeWebSearchWrapper(
     config?: OpenClawConfig;
     agentId?: string;
     nativeWebSearchAllowedByToolPolicy?: boolean;
+    webSearchEnabled?: boolean;
   },
 ): StreamFn {
   return createPayloadPatchStreamWrapper(
@@ -98,7 +110,11 @@ export function createOpenAINativeWebSearchWrapper(
     {
       shouldPatch: ({ model }) =>
         params.nativeWebSearchAllowedByToolPolicy !== false &&
-        shouldEnableOpenAINativeWebSearch({ config: params.config, model }),
+        shouldEnableOpenAINativeWebSearch({
+          config: params.config,
+          webSearchEnabled: params.webSearchEnabled,
+          model,
+        }),
     },
   );
 }

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -191,6 +191,7 @@ function runWrappedPayloadCase(params: {
   cfg?: Record<string, unknown>;
   agentId?: string;
   nativeWebSearchAllowedByToolPolicy?: boolean;
+  webSearchEnabled?: boolean;
   payload?: Record<string, unknown>;
 }) {
   const payload = params.payload ?? { store: false };
@@ -209,6 +210,7 @@ function runWrappedPayloadCase(params: {
     agentDir: "/tmp/openai-provider-test",
     agentId: params.agentId,
     nativeWebSearchAllowedByToolPolicy: params.nativeWebSearchAllowedByToolPolicy,
+    webSearchEnabled: params.webSearchEnabled,
     streamFn: baseStreamFn,
   } as never);
 
@@ -2466,6 +2468,32 @@ describe("buildOpenAIProvider", () => {
 
     expect(disabled.payload.tools).toEqual([{ type: "function", name: "web_search" }]);
     expect(proxied.payload.tools).toEqual([{ type: "function", name: "web_search" }]);
+  });
+
+  it("injects native OpenAI web search when session enables search against a global disable", () => {
+    const provider = buildOpenAIProvider();
+    const wrap = provider.wrapStreamFn;
+    expect(wrap).toBeTypeOf("function");
+    if (!wrap) {
+      throw new Error("expected OpenAI wrapper");
+    }
+
+    const result = runWrappedPayloadCase({
+      wrap,
+      provider: "openai",
+      modelId: "gpt-5.4",
+      cfg: { tools: { web: { search: { enabled: false } } } },
+      webSearchEnabled: true,
+      model: {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5.4",
+        baseUrl: "https://api.openai.com/v1",
+      } as Model<"openai-responses">,
+      payload: { tools: [{ type: "function", name: "web_search" }] },
+    });
+
+    expect(result.payload.tools).toEqual([{ type: "web_search" }]);
   });
 
   it("keeps managed web_search when another search provider is configured", () => {

--- a/extensions/openai/shared.ts
+++ b/extensions/openai/shared.ts
@@ -89,6 +89,7 @@ const wrapOpenAIResponsesProviderStreamFn: NonNullable<
     config: ctx.config,
     agentId: ctx.agentId,
     nativeWebSearchAllowedByToolPolicy: ctx.nativeWebSearchAllowedByToolPolicy,
+    webSearchEnabled: ctx.webSearchEnabled,
   });
 
 export function buildOpenAIResponsesProviderHooks(options?: {

--- a/src/agents/codex-native-web-search-core.ts
+++ b/src/agents/codex-native-web-search-core.ts
@@ -121,8 +121,11 @@ export function resolveCodexNativeSearchActivation(params: {
   senderE164?: string | null;
   agentDir?: string;
 }): CodexNativeSearchActivation {
+  // Session enable (`webSearchEnabled: true`) must win over a global
+  // tools.web.search.enabled=false, matching Control UI session overrides.
   const globalWebSearchEnabled =
-    params.webSearchEnabled !== false && params.config?.tools?.web?.search?.enabled !== false;
+    params.webSearchEnabled === true ||
+    (params.webSearchEnabled !== false && params.config?.tools?.web?.search?.enabled !== false);
   const codexConfig = resolveCodexNativeWebSearchConfig(params.config);
   const nativeEligible = isCodexNativeSearchEligibleModel(params);
   const hasRequiredAuth =

--- a/src/agents/codex-native-web-search-core.ts
+++ b/src/agents/codex-native-web-search-core.ts
@@ -99,6 +99,19 @@ export function hasAvailableCodexAuth(params: {
   return false;
 }
 
+/** Resolves whether web search is enabled from session tri-state and global config. */
+export function resolveGlobalWebSearchEnabled(params: {
+  webSearchEnabled?: boolean;
+  config?: OpenClawConfig;
+}): boolean {
+  // Session enable (`webSearchEnabled: true`) must win over a global
+  // tools.web.search.enabled=false, matching Control UI session overrides.
+  return (
+    params.webSearchEnabled === true ||
+    (params.webSearchEnabled !== false && params.config?.tools?.web?.search?.enabled !== false)
+  );
+}
+
 /** Resolves whether native search is active or why managed search should remain. */
 export function resolveCodexNativeSearchActivation(params: {
   webSearchEnabled?: boolean;
@@ -121,11 +134,7 @@ export function resolveCodexNativeSearchActivation(params: {
   senderE164?: string | null;
   agentDir?: string;
 }): CodexNativeSearchActivation {
-  // Session enable (`webSearchEnabled: true`) must win over a global
-  // tools.web.search.enabled=false, matching Control UI session overrides.
-  const globalWebSearchEnabled =
-    params.webSearchEnabled === true ||
-    (params.webSearchEnabled !== false && params.config?.tools?.web?.search?.enabled !== false);
+  const globalWebSearchEnabled = resolveGlobalWebSearchEnabled(params);
   const codexConfig = resolveCodexNativeWebSearchConfig(params.config);
   const nativeEligible = isCodexNativeSearchEligibleModel(params);
   const hasRequiredAuth =

--- a/src/agents/codex-native-web-search.test.ts
+++ b/src/agents/codex-native-web-search.test.ts
@@ -9,6 +9,7 @@ import {
   patchCodexNativeWebSearchPayload,
   resolveCodexNativeSearchActivation,
   resolveCodexNativeWebSearchConfig,
+  resolveGlobalWebSearchEnabled,
   isCodexNativeWebSearchRelevant,
   shouldSuppressManagedWebSearchTool,
 } from "./codex-native-web-search.js";
@@ -382,6 +383,32 @@ describe("Codex native web-search payload helpers", () => {
       { type: "function", name: "read" },
       { type: "web_search", external_web_access: false },
     ]);
+  });
+
+  it("treats session enable as global override before native activation", () => {
+    const globalDisabledConfig = {
+      tools: {
+        web: {
+          search: {
+            enabled: false,
+            openaiCodex: { enabled: true, mode: "live" as const },
+          },
+        },
+      },
+    } as const;
+    expect(
+      resolveGlobalWebSearchEnabled({
+        webSearchEnabled: true,
+        config: globalDisabledConfig,
+      }),
+    ).toBe(true);
+    const activation = resolveCodexNativeSearchActivation({
+      config: globalDisabledConfig,
+      webSearchEnabled: true,
+      modelProvider: "gateway",
+      modelApi: "openai-chatgpt-responses",
+    });
+    expect(activation.state).toBe("native_active");
   });
 
   it("does not inject a duplicate native web_search tool", () => {

--- a/src/agents/codex-native-web-search.test.ts
+++ b/src/agents/codex-native-web-search.test.ts
@@ -116,6 +116,27 @@ describe("resolveCodexNativeSearchActivation", () => {
     expect(result.inactiveReason).toBe("globally_disabled");
   });
 
+  it("reactivates native search when the session enables search against a global disable", () => {
+    const result = resolveCodexNativeSearchActivation({
+      config: {
+        tools: {
+          web: {
+            search: {
+              enabled: false,
+              openaiCodex: { enabled: true, mode: "live" },
+            },
+          },
+        },
+      },
+      webSearchEnabled: true,
+      modelProvider: "gateway",
+      modelApi: "openai-chatgpt-responses",
+    });
+
+    expect(result.globalWebSearchEnabled).toBe(true);
+    expect(result.state).toBe("native_active");
+  });
+
   it("keeps native injection disabled when the session disables web search", () => {
     const result = resolveCodexNativeSearchActivation({
       config: baseConfig,

--- a/src/agents/codex-native-web-search.ts
+++ b/src/agents/codex-native-web-search.ts
@@ -14,6 +14,7 @@ export {
   buildCodexNativeWebSearchTool,
   patchCodexNativeWebSearchPayload,
   resolveCodexNativeSearchActivation,
+  resolveGlobalWebSearchEnabled,
   shouldSuppressManagedWebSearchTool,
 } from "./codex-native-web-search-core.js";
 export {

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -1166,6 +1166,7 @@ export function applyExtraParamsToAgent(
       workspaceDir,
       agentId,
       nativeWebSearchAllowedByToolPolicy,
+      webSearchEnabled: options?.nativeWebSearchPolicyContext?.webSearchEnabled,
       provider,
       modelId,
       extraParams: effectiveExtraParams,

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -325,7 +325,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
           workspaceDir: effectiveWorkspace,
           spawnWorkspaceDir,
           config: params.config,
-          webSearchEnabled: params.toolOverrides?.webSearch !== false,
+          webSearchEnabled: params.toolOverrides?.webSearch,
           abortSignal: runAbortController.signal,
           sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
           modelProvider: effectiveModel.provider,

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
@@ -539,7 +539,7 @@ export async function prepareEmbeddedAttemptTransport(input: {
     });
   }
   const nativeWebSearchPolicyContext = {
-    webSearchEnabled: attempt.disableTools !== true && attempt.toolOverrides?.webSearch !== false,
+    webSearchEnabled: attempt.disableTools === true ? false : attempt.toolOverrides?.webSearch,
     runtimeToolAllowlist: attempt.toolsAllow,
     sessionKey: input.sandboxSessionKey,
     sandboxToolPolicy: input.sandbox?.tools,

--- a/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
@@ -256,7 +256,9 @@ export function prepareEmbeddedAttemptToolBase(params: {
           workspaceDir: params.effectiveWorkspace,
           spawnWorkspaceDir,
           config: toolSearchRuntimeConfig,
-          webSearchEnabled: attempt.toolOverrides?.webSearch !== false,
+          // Preserve tri-state: true must remain distinguishable from omitted so
+          // createWebSearchTool can honor session enable against a global disable.
+          webSearchEnabled: attempt.toolOverrides?.webSearch,
           abortSignal: params.runAbortController.signal,
           modelProvider: attempt.provider,
           modelId: attempt.modelId,

--- a/src/agents/tools/web-search.late-bind.test.ts
+++ b/src/agents/tools/web-search.late-bind.test.ts
@@ -177,6 +177,21 @@ describe("web_search late-bound runtime fallback", () => {
     expect(mocks.runWebSearch).not.toHaveBeenCalled();
   });
 
+  it("keeps session enable overrides above a late-bound global disable", async () => {
+    mocks.getActiveSecretsRuntimeConfigSnapshot.mockReturnValue({
+      config: { tools: { web: { search: { enabled: false, provider: "brave" } } } },
+    });
+    const tool = createWebSearchTool({
+      enabled: true,
+      config: { tools: { web: { search: { provider: "brave" } } } },
+      lateBindRuntimeConfig: true,
+    });
+
+    await tool?.execute("call-search", { query: "openclaw" }, undefined);
+
+    expect(mocks.runWebSearch).toHaveBeenCalledOnce();
+  });
+
   it("returns typed unavailability for only the isolated search provider", async () => {
     setActiveDegradedSecretOwners([
       {

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -20,6 +20,31 @@ describe("web_search tool schema", () => {
     expect(createWebSearchTool({ enabled: false })).toBeNull();
   });
 
+  it("omits the managed tool when global search is disabled and no session override is set", () => {
+    expect(
+      createWebSearchTool({
+        config: { tools: { web: { search: { enabled: false } } } },
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps the managed tool when the session enables search against a global disable", () => {
+    const tool = createWebSearchTool({
+      enabled: true,
+      config: { tools: { web: { search: { enabled: false } } } },
+    });
+    expect(tool?.name).toBe("web_search");
+  });
+
+  it("omits the managed tool when the session disables search even if global search is on", () => {
+    expect(
+      createWebSearchTool({
+        enabled: false,
+        config: { tools: { web: { search: { enabled: true } } } },
+      }),
+    ).toBeNull();
+  });
+
   it("marks query as required for model tool-call schemas", () => {
     const tool = createWebSearchTool();
     const parameters = tool?.parameters as { required?: unknown } | undefined;

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -81,7 +81,26 @@ function isWebSearchDisabled(config?: OpenClawConfig): boolean {
   return Boolean(search && typeof search === "object" && search.enabled === false);
 }
 
-/** Creates the `web_search` tool, or `null` when web search is disabled by config. */
+/**
+ * Session `toolOverrides.webSearch` is tri-state:
+ * - `false` always suppresses the managed tool
+ * - `true` enables it even when `tools.web.search.enabled` is false
+ * - omitted follows the global/runtime config gate
+ */
+function isWebSearchToolSuppressed(params: {
+  enabled?: boolean;
+  config?: OpenClawConfig;
+}): boolean {
+  if (params.enabled === false) {
+    return true;
+  }
+  if (params.enabled === true) {
+    return false;
+  }
+  return isWebSearchDisabled(params.config);
+}
+
+/** Creates the `web_search` tool, or `null` when web search is disabled. */
 export function createWebSearchTool(options?: {
   config?: OpenClawConfig;
   enabled?: boolean;
@@ -90,7 +109,7 @@ export function createWebSearchTool(options?: {
   runtimeWebSearch?: RuntimeWebSearchMetadata;
   lateBindRuntimeConfig?: boolean;
 }): AnyAgentTool | null {
-  if (options?.enabled === false || isWebSearchDisabled(options?.config)) {
+  if (isWebSearchToolSuppressed({ enabled: options?.enabled, config: options?.config })) {
     return null;
   }
 
@@ -111,7 +130,7 @@ export function createWebSearchTool(options?: {
           lateBindRuntimeConfig: options?.lateBindRuntimeConfig,
           runtimeWebSearch: options?.runtimeWebSearch,
         });
-      if (isWebSearchDisabled(config)) {
+      if (isWebSearchToolSuppressed({ enabled: options?.enabled, config })) {
         throw new Error("web_search is disabled.");
       }
       if (providerSelectionId) {

--- a/src/llm/providers/stream-wrappers/openai.test.ts
+++ b/src/llm/providers/stream-wrappers/openai.test.ts
@@ -474,6 +474,47 @@ describe("createCodexNativeWebSearchWrapper", () => {
 
     expect(payloads[0]?.tools).toEqual([{ type: "function", name: "read" }]);
   });
+
+  it("injects native web_search when session enables search against a global disable", () => {
+    const payloads: Array<Record<string, unknown>> = [];
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        model: model.id,
+        tools: [{ type: "function", name: "read" }],
+      };
+      options?.onPayload?.(payload, model);
+      payloads.push(structuredClone(payload));
+      return createAssistantMessageEventStream();
+    };
+    const wrapped = createCodexNativeWebSearchWrapper(baseStreamFn, {
+      webSearchEnabled: true,
+      config: {
+        tools: {
+          web: {
+            search: {
+              enabled: false,
+              openaiCodex: { enabled: true, mode: "live" },
+            },
+          },
+        },
+      },
+    });
+
+    void wrapped(
+      {
+        api: "openai-chatgpt-responses",
+        provider: "gateway",
+        id: "gpt-5.5",
+      } as Model<"openai-chatgpt-responses">,
+      { messages: [] },
+      {},
+    );
+
+    expect(payloads[0]?.tools).toEqual([
+      { type: "function", name: "read" },
+      { type: "web_search", external_web_access: true },
+    ]);
+  });
 });
 
 describe("createOpenAICompletionsStrictMessageKeysWrapper", () => {

--- a/src/llm/providers/stream-wrappers/openai.ts
+++ b/src/llm/providers/stream-wrappers/openai.ts
@@ -637,6 +637,7 @@ export function createCodexNativeWebSearchWrapper(
     senderUsername?: string | null;
     senderE164?: string | null;
     nativeWebSearchAllowedByToolPolicy?: boolean;
+    webSearchEnabled?: boolean;
     codeModeToolSurfaceEnabled?: boolean;
   },
 ): StreamFn {
@@ -689,6 +690,7 @@ export function createCodexNativeWebSearchWrapper(
 
     const activation = resolveCodexNativeSearchActivation({
       config: params.config,
+      webSearchEnabled: params.webSearchEnabled,
       modelProvider: readStringValue(model.provider),
       modelApi: readStringValue(model.api),
       modelId: readStringValue(model.id),

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -153,6 +153,7 @@ export function buildProviderStreamFamilyHooks(
             agentDir: ctx.agentDir,
             agentId: ctx.agentId,
             nativeWebSearchAllowedByToolPolicy: ctx.nativeWebSearchAllowedByToolPolicy,
+            webSearchEnabled: ctx.webSearchEnabled,
           });
           nextStreamFn = createOpenAIStringContentWrapper(nextStreamFn);
           return createOpenAIResponsesContextManagementWrapper(

--- a/src/plugins/provider-runtime.types.ts
+++ b/src/plugins/provider-runtime.types.ts
@@ -248,6 +248,8 @@ export type ProviderPrepareExtraParamsContext = {
   workspaceDir?: string;
   agentId?: string;
   nativeWebSearchAllowedByToolPolicy?: boolean;
+  /** Session tri-state override; `true` wins over global `tools.web.search.enabled: false`. */
+  webSearchEnabled?: boolean;
   provider: string;
   modelId: string;
   model?: ProviderRuntimeModel;


### PR DESCRIPTION
> **Superseded / closed:** ClawSweeper product guidance keeps the global web-search disable authoritative. Replacement UI PR: https://github.com/openclaw/openclaw/pull/121557

## Proof follow-up

**Tip SHA:** `8aaa4e0d239907835bc216755c0d4b9bd9cb1279`

**ClawSweeper P1 answered:** Forward the override to native injection — session `webSearchEnabled: true` tri-state now flows through `nativeWebSearchPolicyContext` → `ProviderPrepareExtraParamsContext.webSearchEnabled` → Codex/OpenAI Responses payload wrappers, so global `tools.web.search.enabled: false` no longer blocks native `web_search` at the final payload boundary.

**Tests (local, exact tip):**

```text
pnpm exec vitest run -t "session enables search against a global disable|treats session enable as global override" \
  src/agents/codex-native-web-search.test.ts \
  src/llm/providers/stream-wrappers/openai.test.ts \
  extensions/openai/openai-provider.test.ts
→ 6 passed (146 skipped)

node scripts/run-vitest.mjs src/agents/codex-native-web-search.test.ts src/llm/providers/stream-wrappers/openai.test.ts
→ openai.test.ts shard pass; codex shard 22/23 pass (1 pre-existing SQLite/Node-version flake on inherited-session-policy test)
```

**Payload trace (redacted, local exact-head):**

```json
{
  "scenario": { "globalToolsWebSearchEnabled": false, "sessionWebSearchEnabled": true },
  "codexNativeWrapper": {
    "model": { "provider": "gateway", "api": "openai-chatgpt-responses", "id": "gpt-5.5" },
    "tools": [
      { "type": "function", "name": "read" },
      { "type": "web_search", "external_web_access": true }
    ],
    "nativeWebSearchPresent": true
  },
  "openaiResponsesWrapper": {
    "model": { "provider": "openai", "api": "openai-responses", "id": "gpt-5.4" },
    "tools": [
      { "type": "function", "name": "read" },
      { "type": "web_search" }
    ],
    "nativeWebSearchPresent": true
  }
}
```

---

Superseded for #121401 (see #121557); no longer closes this issue.

Related persistence: #121377 / #121378

## What Problem This Solves

Session `toolOverrides.webSearch: true` did not enable the managed `web_search` tool when `tools.web.search.enabled` was `false`. Control UI already emits this enable override, and persistence is fixed in #121378, but the agents runtime still treated a global disable as absolute.

### Before (broken)

1. Embedded attempt prep collapsed the overlay with `webSearch !== false`, so `true` and omitted both became `enabled: true`.
2. `createWebSearchTool` still returned `null` because `isWebSearchDisabled(config)` short-circuited after that flag.
3. Codex-native activation used `webSearchEnabled !== false && config.enabled !== false`, so session enable could not reactivate native search either.

## Why This Change Was Made

Treat session `webSearch` as **tri-state**:

- `false` → always suppress
- `true` → enable despite global `tools.web.search.enabled: false`
- omitted → follow global/runtime config (including late-bound disables)

Concrete changes:

- `createWebSearchTool` / execute gate: `isWebSearchToolSuppressed({ enabled, config })`
- Stop collapsing via `!== false` in attempt prep / compaction / stream-settle
- Codex `resolveCodexNativeSearchActivation`: session `true` wins over global disable
- Matrix tests for create/execute/codex/late-bind

Tool-profile / allowlist denials remain out of scope for this gate.

## User Impact

Operators who keep web search off by default can turn it on for one session and actually receive `web_search` (and Codex-native search when eligible). Session deny and omitted+global-disable continue to suppress the tool.

## Evidence

### Before vs after (tool materialization)

| Case | Before tip | After tip `fde5fda45257b59f37d96735d7baa99e089c411f` |
| --- | --- | --- |
| `enabled: false` | `null` | `null` |
| config `enabled: false`, no session override | `null` | `null` |
| `enabled: true` + config `enabled: false` | `null` (broken) | tool named `web_search` |
| late-bind: omitted + runtime disable | execute throws `web_search is disabled.` | same (unchanged) |
| late-bind: `enabled: true` + runtime disable | execute threw / tool absent | execute runs |
| Codex: `webSearchEnabled: true` vs global disable | `globalWebSearchEnabled: false` | `true` / `native_active` |

### Focused regression tests (exact tip)

```text
tip=fde5fda45257b59f37d96735d7baa99e089c411f
command=pnpm exec vitest run \
  src/agents/tools/web-search.test.ts \
  src/agents/tools/web-search.late-bind.test.ts \
  src/agents/codex-native-web-search.test.ts \
  --reporter=verbose
result=pass
lanes=pnpm changed:lanes --json → core + coreTests
types=pnpm check:test-types → pass
```

### What was not tested

End-to-end live provider search with a real Brave/Perplexity key after session enable (unit/integration materialization + Codex activation covered).