### PR TITLE
fix(plugin-sdk): back every workspace facade export with a real src facade

### DIFF
--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -28,74 +28,6 @@
       "types": "./dist/src/plugin-sdk/channel-activity-runtime.d.ts",
       "default": "./src/channel-activity-runtime.ts"
     },
-    "./concurrency-runtime": {
-      "types": "./dist/src/plugin-sdk/concurrency-runtime.d.ts",
-      "default": "./src/concurrency-runtime.ts"
-    },
-    "./dedupe-runtime": {
-      "types": "./dist/src/plugin-sdk/dedupe-runtime.d.ts",
-      "default": "./src/dedupe-runtime.ts"
-    },
-    "./delivery-queue-runtime": {
-      "types": "./dist/src/plugin-sdk/delivery-queue-runtime.d.ts",
-      "default": "./src/delivery-queue-runtime.ts"
-    },
-    "./file-access-runtime": {
-      "types": "./dist/src/plugin-sdk/file-access-runtime.d.ts",
-      "default": "./src/file-access-runtime.ts"
-    },
-    "./heartbeat-runtime": {
-      "types": "./dist/src/plugin-sdk/heartbeat-runtime.d.ts",
-      "default": "./src/heartbeat-runtime.ts"
-    },
-    "./number-runtime": {
-      "types": "./dist/src/plugin-sdk/number-runtime.d.ts",
-      "default": "./src/number-runtime.ts"
-    },
-    "./outbound-media": {
-      "types": "./dist/src/plugin-sdk/outbound-media.d.ts",
-      "default": "./src/outbound-media.ts"
-    },
-    "./secure-random-runtime": {
-      "types": "./dist/src/plugin-sdk/secure-random-runtime.d.ts",
-      "default": "./src/secure-random-runtime.ts"
-    },
-    "./system-event-runtime": {
-      "types": "./dist/src/plugin-sdk/system-event-runtime.d.ts",
-      "default": "./src/system-event-runtime.ts"
-    },
-    "./time-runtime": {
-      "types": "./dist/src/plugin-sdk/time-runtime.d.ts",
-      "default": "./src/time-runtime.ts"
-    },
-    "./transport-ready-runtime": {
-      "types": "./dist/src/plugin-sdk/transport-ready-runtime.d.ts",
-      "default": "./src/transport-ready-runtime.ts"
-    },
-    "./exec-approvals-runtime": {
-      "types": "./dist/src/plugin-sdk/exec-approvals-runtime.d.ts",
-      "default": "./src/exec-approvals-runtime.ts"
-    },
-    "./core": {
-      "types": "./dist/src/plugin-sdk/core.d.ts",
-      "default": "./src/core.ts"
-    },
-    "./config-runtime": {
-      "types": "./dist/src/plugin-sdk/config-runtime.d.ts",
-      "default": "./src/config-runtime.ts"
-    },
-    "./plugin-config-runtime": {
-      "types": "./dist/src/plugin-sdk/plugin-config-runtime.d.ts",
-      "default": "./src/plugin-config-runtime.ts"
-    },
-    "./config-mutation": {
-      "types": "./dist/src/plugin-sdk/config-mutation.d.ts",
-      "default": "./src/config-mutation.ts"
-    },
-    "./cron-store-runtime": {
-      "types": "./dist/src/plugin-sdk/cron-store-runtime.d.ts",
-      "default": "./src/cron-store-runtime.ts"
-    },
     "./channel-secret-runtime": {
       "types": "./dist/src/plugin-sdk/channel-secret-runtime.d.ts",
       "default": "./src/channel-secret-runtime.ts"
@@ -108,13 +40,77 @@
       "types": "./dist/src/plugin-sdk/cli-runtime.d.ts",
       "default": "./src/cli-runtime.ts"
     },
-    "./gateway-method-runtime": {
-      "types": "./dist/src/plugin-sdk/gateway-method-runtime.d.ts",
-      "default": "./src/gateway-method-runtime.ts"
+    "./concurrency-runtime": {
+      "types": "./dist/src/plugin-sdk/concurrency-runtime.d.ts",
+      "default": "./src/concurrency-runtime.ts"
+    },
+    "./config-contracts": {
+      "types": "./dist/src/plugin-sdk/config-contracts.d.ts",
+      "default": "./src/config-contracts.ts"
+    },
+    "./config-mutation": {
+      "types": "./dist/src/plugin-sdk/config-mutation.d.ts",
+      "default": "./src/config-mutation.ts"
+    },
+    "./config-runtime": {
+      "types": "./dist/src/plugin-sdk/config-runtime.d.ts",
+      "default": "./src/config-runtime.ts"
+    },
+    "./core": {
+      "types": "./dist/src/plugin-sdk/core.d.ts",
+      "default": "./src/core.ts"
+    },
+    "./cron-store-runtime": {
+      "types": "./dist/src/plugin-sdk/cron-store-runtime.d.ts",
+      "default": "./src/cron-store-runtime.ts"
+    },
+    "./dedupe-runtime": {
+      "types": "./dist/src/plugin-sdk/dedupe-runtime.d.ts",
+      "default": "./src/dedupe-runtime.ts"
+    },
+    "./delivery-queue-runtime": {
+      "types": "./dist/src/plugin-sdk/delivery-queue-runtime.d.ts",
+      "default": "./src/delivery-queue-runtime.ts"
     },
     "./error-runtime": {
       "types": "./dist/src/plugin-sdk/error-runtime.d.ts",
       "default": "./src/error-runtime.ts"
+    },
+    "./exec-approvals-runtime": {
+      "types": "./dist/src/plugin-sdk/exec-approvals-runtime.d.ts",
+      "default": "./src/exec-approvals-runtime.ts"
+    },
+    "./file-access-runtime": {
+      "types": "./dist/src/plugin-sdk/file-access-runtime.d.ts",
+      "default": "./src/file-access-runtime.ts"
+    },
+    "./gateway-method-runtime": {
+      "types": "./dist/src/plugin-sdk/gateway-method-runtime.d.ts",
+      "default": "./src/gateway-method-runtime.ts"
+    },
+    "./heartbeat-runtime": {
+      "types": "./dist/src/plugin-sdk/heartbeat-runtime.d.ts",
+      "default": "./src/heartbeat-runtime.ts"
+    },
+    "./infra-runtime": {
+      "types": "./dist/src/plugin-sdk/infra-runtime.d.ts",
+      "default": "./src/infra-runtime.ts"
+    },
+    "./model-session-runtime": {
+      "types": "./dist/src/plugin-sdk/model-session-runtime.d.ts",
+      "default": "./src/model-session-runtime.ts"
+    },
+    "./number-runtime": {
+      "types": "./dist/src/plugin-sdk/number-runtime.d.ts",
+      "default": "./src/number-runtime.ts"
+    },
+    "./outbound-media": {
+      "types": "./dist/src/plugin-sdk/outbound-media.d.ts",
+      "default": "./src/outbound-media.ts"
+    },
+    "./plugin-config-runtime": {
+      "types": "./dist/src/plugin-sdk/plugin-config-runtime.d.ts",
+      "default": "./src/plugin-config-runtime.ts"
     },
     "./plugin-entry": {
       "types": "./dist/src/plugin-sdk/plugin-entry.d.ts",
@@ -128,45 +124,33 @@
       "types": "./dist/src/plugin-sdk/provider-auth.d.ts",
       "default": "./src/provider-auth.ts"
     },
-    "./provider-auth-runtime": {
-      "types": "./dist/src/plugin-sdk/provider-auth-runtime.d.ts",
-      "default": "./src/provider-auth-runtime.ts"
-    },
     "./provider-auth-login-flow-runtime": {
       "types": "./dist/src/plugin-sdk/provider-auth-login-flow-runtime.d.ts",
       "default": "./src/provider-auth-login-flow-runtime.ts"
     },
-    "./provider-env-vars": {
-      "types": "./dist/src/plugin-sdk/provider-env-vars.d.ts",
-      "default": "./src/provider-env-vars.ts"
+    "./provider-auth-runtime": {
+      "types": "./dist/src/plugin-sdk/provider-auth-runtime.d.ts",
+      "default": "./src/provider-auth-runtime.ts"
     },
     "./provider-entry": {
       "types": "./dist/src/plugin-sdk/provider-entry.d.ts",
       "default": "./src/provider-entry.ts"
     },
-    "./provider-usage": {
-      "types": "./dist/src/plugin-sdk/provider-usage.d.ts",
-      "default": "./src/provider-usage.ts"
+    "./provider-env-vars": {
+      "types": "./dist/src/plugin-sdk/provider-env-vars.d.ts",
+      "default": "./src/provider-env-vars.ts"
     },
     "./provider-http": {
       "types": "./dist/src/plugin-sdk/provider-http.d.ts",
       "default": "./src/provider-http.ts"
     },
-    "./provider-model-types": {
-      "types": "./dist/src/plugin-sdk/provider-model-types.d.ts",
-      "default": "./src/provider-model-types.ts"
-    },
     "./provider-model-shared": {
       "types": "./dist/src/plugin-sdk/provider-model-shared.d.ts",
       "default": "./src/provider-model-shared.ts"
     },
-    "./model-session-runtime": {
-      "types": "./dist/src/plugin-sdk/model-session-runtime.d.ts",
-      "default": "./src/model-session-runtime.ts"
-    },
-    "./talk-config-runtime": {
-      "types": "./dist/src/plugin-sdk/talk-config-runtime.d.ts",
-      "default": "./src/talk-config-runtime.ts"
+    "./provider-model-types": {
+      "types": "./dist/src/plugin-sdk/provider-model-types.d.ts",
+      "default": "./src/provider-model-types.ts"
     },
     "./provider-onboard": {
       "types": "./dist/src/plugin-sdk/provider-onboard.d.ts",
@@ -180,61 +164,77 @@
       "types": "./dist/src/plugin-sdk/provider-tools.d.ts",
       "default": "./src/provider-tools.ts"
     },
+    "./provider-usage": {
+      "types": "./dist/src/plugin-sdk/provider-usage.d.ts",
+      "default": "./src/provider-usage.ts"
+    },
     "./provider-web-search": {
       "types": "./dist/src/plugin-sdk/provider-web-search.d.ts",
       "default": "./src/provider-web-search.ts"
-    },
-    "./provider-web-search-contract": {
-      "types": "./dist/src/plugin-sdk/provider-web-search-contract.d.ts",
-      "default": "./src/provider-web-search-contract.ts"
     },
     "./provider-web-search-config-contract": {
       "types": "./dist/src/plugin-sdk/provider-web-search-config-contract.d.ts",
       "default": "./src/provider-web-search-config-contract.ts"
     },
+    "./provider-web-search-contract": {
+      "types": "./dist/src/plugin-sdk/provider-web-search-contract.d.ts",
+      "default": "./src/provider-web-search-contract.ts"
+    },
     "./runtime-env": {
       "types": "./dist/src/plugin-sdk/runtime-env.d.ts",
       "default": "./src/runtime-env.ts"
-    },
-    "./infra-runtime": {
-      "types": "./dist/src/plugin-sdk/infra-runtime.d.ts",
-      "default": "./src/infra-runtime.ts"
-    },
-    "./security-runtime": {
-      "types": "./dist/src/plugin-sdk/security-runtime.d.ts",
-      "default": "./src/security-runtime.ts"
-    },
-    "./secret-ref-runtime": {
-      "types": "./dist/src/plugin-sdk/secret-ref-runtime.d.ts",
-      "default": "./src/secret-ref-runtime.ts"
-    },
-    "./ssrf-runtime": {
-      "types": "./dist/src/plugin-sdk/ssrf-runtime.d.ts",
-      "default": "./src/ssrf-runtime.ts"
     },
     "./secret-input": {
       "types": "./dist/src/plugin-sdk/secret-input.d.ts",
       "default": "./src/secret-input.ts"
     },
-    "./tts-runtime": {
-      "types": "./dist/src/plugin-sdk/tts-runtime.d.ts",
-      "default": "./src/tts-runtime.ts"
+    "./secret-ref-runtime": {
+      "types": "./dist/src/plugin-sdk/secret-ref-runtime.d.ts",
+      "default": "./src/secret-ref-runtime.ts"
+    },
+    "./secure-random-runtime": {
+      "types": "./dist/src/plugin-sdk/secure-random-runtime.d.ts",
+      "default": "./src/secure-random-runtime.ts"
+    },
+    "./security-runtime": {
+      "types": "./dist/src/plugin-sdk/security-runtime.d.ts",
+      "default": "./src/security-runtime.ts"
+    },
+    "./ssrf-runtime": {
+      "types": "./dist/src/plugin-sdk/ssrf-runtime.d.ts",
+      "default": "./src/ssrf-runtime.ts"
+    },
+    "./system-event-runtime": {
+      "types": "./dist/src/plugin-sdk/system-event-runtime.d.ts",
+      "default": "./src/system-event-runtime.ts"
+    },
+    "./talk-config-runtime": {
+      "types": "./dist/src/plugin-sdk/talk-config-runtime.d.ts",
+      "default": "./src/talk-config-runtime.ts"
     },
     "./text-runtime": {
       "types": "./dist/src/plugin-sdk/text-runtime.d.ts",
       "default": "./src/text-runtime.ts"
     },
-    "./video-generation": {
-      "types": "./dist/src/plugin-sdk/video-generation.d.ts",
-      "default": "./src/video-generation.ts"
-    },
-    "./config-contracts": {
-      "types": "./dist/src/plugin-sdk/config-contracts.d.ts",
-      "default": "./src/config-contracts.ts"
-    },
     "./text-utility-runtime": {
       "types": "./dist/src/plugin-sdk/text-utility-runtime.d.ts",
       "default": "./src/text-utility-runtime.ts"
+    },
+    "./time-runtime": {
+      "types": "./dist/src/plugin-sdk/time-runtime.d.ts",
+      "default": "./src/time-runtime.ts"
+    },
+    "./transport-ready-runtime": {
+      "types": "./dist/src/plugin-sdk/transport-ready-runtime.d.ts",
+      "default": "./src/transport-ready-runtime.ts"
+    },
+    "./tts-runtime": {
+      "types": "./dist/src/plugin-sdk/tts-runtime.d.ts",
+      "default": "./src/tts-runtime.ts"
+    },
+    "./video-generation": {
+      "types": "./dist/src/plugin-sdk/video-generation.d.ts",
+      "default": "./src/video-generation.ts"
     },
     "./zod": {
       "types": "./dist/src/plugin-sdk/zod.d.ts",

--- a/packages/plugin-sdk/src/account-id.ts
+++ b/packages/plugin-sdk/src/account-id.ts
@@ -1,0 +1,3 @@
+// Public package facade for account id normalization helpers.
+
+export * from "../../../src/plugin-sdk/account-id.js";

--- a/packages/plugin-sdk/src/acp-runtime-backend.ts
+++ b/packages/plugin-sdk/src/acp-runtime-backend.ts
@@ -1,0 +1,3 @@
+// Public package facade for ACP runtime backend helpers.
+
+export * from "../../../src/plugin-sdk/acp-runtime-backend.js";

--- a/packages/plugin-sdk/src/acp-runtime.ts
+++ b/packages/plugin-sdk/src/acp-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for ACP runtime helpers.
+
+export * from "../../../src/plugin-sdk/acp-runtime.js";

--- a/packages/plugin-sdk/src/async-lock-runtime.ts
+++ b/packages/plugin-sdk/src/async-lock-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for async lock runtime helpers.
+
+export * from "../../../src/plugin-sdk/async-lock-runtime.js";

--- a/packages/plugin-sdk/src/channel-activity-runtime.ts
+++ b/packages/plugin-sdk/src/channel-activity-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for channel activity runtime helpers.
+
+export * from "../../../src/plugin-sdk/channel-activity-runtime.js";

--- a/packages/plugin-sdk/src/channel-secret-runtime.ts
+++ b/packages/plugin-sdk/src/channel-secret-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for channel secret runtime helpers.
+
+export * from "../../../src/plugin-sdk/channel-secret-runtime.js";

--- a/packages/plugin-sdk/src/channel-streaming.ts
+++ b/packages/plugin-sdk/src/channel-streaming.ts
@@ -1,0 +1,3 @@
+// Public package facade for channel streaming helpers.
+
+export * from "../../../src/plugin-sdk/channel-streaming.js";

--- a/packages/plugin-sdk/src/cli-runtime.ts
+++ b/packages/plugin-sdk/src/cli-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for CLI runtime helpers.
+
+export * from "../../../src/plugin-sdk/cli-runtime.js";

--- a/packages/plugin-sdk/src/concurrency-runtime.ts
+++ b/packages/plugin-sdk/src/concurrency-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for concurrency runtime helpers.
+
+export * from "../../../src/plugin-sdk/concurrency-runtime.js";

--- a/packages/plugin-sdk/src/config-contracts.ts
+++ b/packages/plugin-sdk/src/config-contracts.ts
@@ -1,0 +1,3 @@
+// Public package facade for config contracts.
+
+export * from "../../../src/plugin-sdk/config-contracts.js";

--- a/packages/plugin-sdk/src/config-mutation.ts
+++ b/packages/plugin-sdk/src/config-mutation.ts
@@ -1,0 +1,3 @@
+// Public package facade for config mutation helpers.
+
+export * from "../../../src/plugin-sdk/config-mutation.js";

--- a/packages/plugin-sdk/src/core.ts
+++ b/packages/plugin-sdk/src/core.ts
@@ -1,0 +1,3 @@
+// Public package facade for core plugin SDK contracts.
+
+export * from "../../../src/plugin-sdk/core.js";

--- a/packages/plugin-sdk/src/cron-store-runtime.ts
+++ b/packages/plugin-sdk/src/cron-store-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for cron store runtime helpers.
+
+export * from "../../../src/plugin-sdk/cron-store-runtime.js";

--- a/packages/plugin-sdk/src/dedupe-runtime.ts
+++ b/packages/plugin-sdk/src/dedupe-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for dedupe runtime helpers.
+
+export * from "../../../src/plugin-sdk/dedupe-runtime.js";

--- a/packages/plugin-sdk/src/delivery-queue-runtime.ts
+++ b/packages/plugin-sdk/src/delivery-queue-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for delivery queue runtime helpers.
+
+export * from "../../../src/plugin-sdk/delivery-queue-runtime.js";

--- a/packages/plugin-sdk/src/error-runtime.ts
+++ b/packages/plugin-sdk/src/error-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for error runtime helpers.
+
+export * from "../../../src/plugin-sdk/error-runtime.js";

--- a/packages/plugin-sdk/src/file-access-runtime.ts
+++ b/packages/plugin-sdk/src/file-access-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for file access runtime helpers.
+
+export * from "../../../src/plugin-sdk/file-access-runtime.js";

--- a/packages/plugin-sdk/src/heartbeat-runtime.ts
+++ b/packages/plugin-sdk/src/heartbeat-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for heartbeat runtime helpers.
+
+export * from "../../../src/plugin-sdk/heartbeat-runtime.js";

--- a/packages/plugin-sdk/src/infra-runtime.ts
+++ b/packages/plugin-sdk/src/infra-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for infra runtime helpers.
+
+export * from "../../../src/plugin-sdk/infra-runtime.js";

--- a/packages/plugin-sdk/src/model-session-runtime.ts
+++ b/packages/plugin-sdk/src/model-session-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for model session runtime helpers.
+
+export * from "../../../src/plugin-sdk/model-session-runtime.js";

--- a/packages/plugin-sdk/src/number-runtime.ts
+++ b/packages/plugin-sdk/src/number-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for number runtime helpers.
+
+export * from "../../../src/plugin-sdk/number-runtime.js";

--- a/packages/plugin-sdk/src/plugin-config-runtime.ts
+++ b/packages/plugin-sdk/src/plugin-config-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for plugin config runtime helpers.
+
+export * from "../../../src/plugin-sdk/plugin-config-runtime.js";

--- a/packages/plugin-sdk/src/provider-env-vars.ts
+++ b/packages/plugin-sdk/src/provider-env-vars.ts
@@ -1,0 +1,3 @@
+// Public package facade for provider environment variable contracts.
+
+export * from "../../../src/plugin-sdk/provider-env-vars.js";

--- a/packages/plugin-sdk/src/provider-usage.ts
+++ b/packages/plugin-sdk/src/provider-usage.ts
@@ -1,0 +1,3 @@
+// Public package facade for provider usage contracts.
+
+export * from "../../../src/plugin-sdk/provider-usage.js";

--- a/packages/plugin-sdk/src/provider-web-search-contract.ts
+++ b/packages/plugin-sdk/src/provider-web-search-contract.ts
@@ -1,0 +1,3 @@
+// Public package facade for provider web search contracts.
+
+export * from "../../../src/plugin-sdk/provider-web-search-contract.js";

--- a/packages/plugin-sdk/src/secret-ref-runtime.ts
+++ b/packages/plugin-sdk/src/secret-ref-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for secret ref runtime helpers.
+
+export * from "../../../src/plugin-sdk/secret-ref-runtime.js";

--- a/packages/plugin-sdk/src/secure-random-runtime.ts
+++ b/packages/plugin-sdk/src/secure-random-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for secure random runtime helpers.
+
+export * from "../../../src/plugin-sdk/secure-random-runtime.js";

--- a/packages/plugin-sdk/src/ssrf-runtime.ts
+++ b/packages/plugin-sdk/src/ssrf-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for SSRF runtime helpers.
+
+export * from "../../../src/plugin-sdk/ssrf-runtime.js";

--- a/packages/plugin-sdk/src/system-event-runtime.ts
+++ b/packages/plugin-sdk/src/system-event-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for system event runtime helpers.
+
+export * from "../../../src/plugin-sdk/system-event-runtime.js";

--- a/packages/plugin-sdk/src/talk-config-runtime.ts
+++ b/packages/plugin-sdk/src/talk-config-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for talk config runtime helpers.
+
+export * from "../../../src/plugin-sdk/talk-config-runtime.js";

--- a/packages/plugin-sdk/src/text-utility-runtime.ts
+++ b/packages/plugin-sdk/src/text-utility-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for text utility runtime helpers.
+
+export * from "../../../src/plugin-sdk/text-utility-runtime.js";

--- a/packages/plugin-sdk/src/time-runtime.ts
+++ b/packages/plugin-sdk/src/time-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for time runtime helpers.
+
+export * from "../../../src/plugin-sdk/time-runtime.js";

--- a/packages/plugin-sdk/src/transport-ready-runtime.ts
+++ b/packages/plugin-sdk/src/transport-ready-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for transport ready runtime helpers.
+
+export * from "../../../src/plugin-sdk/transport-ready-runtime.js";

--- a/packages/plugin-sdk/src/tts-runtime.ts
+++ b/packages/plugin-sdk/src/tts-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for TTS runtime helpers.
+
+export * from "../../../src/plugin-sdk/tts-runtime.js";

--- a/packages/plugin-sdk/src/zod.ts
+++ b/packages/plugin-sdk/src/zod.ts
@@ -1,0 +1,3 @@
+// Public package facade for the shared zod re-export.
+
+export * from "../../../src/plugin-sdk/zod.js";

--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -98,7 +98,7 @@ const SQLITE_SESSION_SCHEMA_BASELINE_PATH_RE =
 const PLUGIN_SDK_API_BASELINE_PATH_RE =
   /^(?:src\/|packages\/|extensions\/|pnpm-lock\.yaml$|tsconfig\.json$|scripts\/(?:generate-plugin-sdk-api-baseline\.ts|lib\/plugin-sdk-(?:doc-metadata\.ts|entries\.mts|entrypoints\.json|private-local-only-subpaths\.json))|docs\/\.generated\/plugin-sdk-api-baseline\.sha256$)/u;
 const PLUGIN_SDK_SURFACE_PATH_RE =
-  /^(?:package\.json$|src\/plugin-sdk\/|scripts\/(?:plugin-sdk-surface-report\.mts|sync-plugin-sdk-exports\.mts|lib\/plugin-sdk-(?:declaration-budget\.mts|deprecated-barrel-subpaths\.json|deprecated-public-subpaths\.json|entries\.mts|entrypoints\.json|private-local-only-subpaths\.json)))/u;
+  /^(?:package\.json$|src\/plugin-sdk\/|packages\/plugin-sdk\/|scripts\/(?:plugin-sdk-surface-report\.mts|sync-plugin-sdk-exports\.mts|lib\/plugin-sdk-(?:declaration-budget\.mts|deprecated-barrel-subpaths\.json|deprecated-public-subpaths\.json|entries\.mts|entrypoints\.json|private-local-only-subpaths\.json)))/u;
 const DEPRECATION_HYGIENE_PATH_RE =
   /^(?:package\.json$|src\/|extensions\/|packages\/|scripts\/(?:check-deprecated-api-usage\.mts$|plugin-boundary-report\.ts$|lib\/plugin-sdk))/u;
 const CANVAS_A2UI_NATIVE_RESOURCE_PATH_RE =

--- a/scripts/sync-plugin-sdk-exports.mts
+++ b/scripts/sync-plugin-sdk-exports.mts
@@ -1,49 +1,126 @@
 #!/usr/bin/env node
 
-// Regenerates package.json plugin-sdk export entries from the canonical entry list.
+// Regenerates package.json plugin-sdk export entries from the canonical entry list
+// and keeps the workspace facade package (@openclaw/plugin-sdk) exports aligned
+// with its src facade files.
 import fs from "node:fs";
 import path from "node:path";
-import { buildPluginSdkPackageExports } from "./lib/plugin-sdk-entries.mts";
+import { buildPluginSdkPackageExports, pluginSdkEntrypoints } from "./lib/plugin-sdk-entries.mts";
 
 const checkOnly = process.argv.includes("--check");
-const packageJsonPath = path.join(process.cwd(), "package.json");
-const packageJson: Record<string, unknown> & { exports?: Record<string, unknown> } = JSON.parse(
-  fs.readFileSync(packageJsonPath, "utf8"),
-);
-const currentExports = packageJson.exports ?? {};
-const syncedPluginSdkExports = buildPluginSdkPackageExports();
+const repoRoot = process.cwd();
+let failed = false;
 
-const nextExports: typeof currentExports = {};
-let insertedPluginSdkExports = false;
-for (const [key, value] of Object.entries(currentExports)) {
-  if (key.startsWith("./plugin-sdk")) {
-    if (!insertedPluginSdkExports) {
+function syncRootPackageExports() {
+  const packageJsonPath = path.join(repoRoot, "package.json");
+  const packageJson: Record<string, unknown> & { exports?: Record<string, unknown> } = JSON.parse(
+    fs.readFileSync(packageJsonPath, "utf8"),
+  );
+  const currentExports = packageJson.exports ?? {};
+  const syncedPluginSdkExports = buildPluginSdkPackageExports();
+
+  const nextExports: typeof currentExports = {};
+  let insertedPluginSdkExports = false;
+  for (const [key, value] of Object.entries(currentExports)) {
+    if (key.startsWith("./plugin-sdk")) {
+      if (!insertedPluginSdkExports) {
+        Object.assign(nextExports, syncedPluginSdkExports);
+        insertedPluginSdkExports = true;
+      }
+      continue;
+    }
+    nextExports[key] = value;
+    if (key === "." && !insertedPluginSdkExports) {
       Object.assign(nextExports, syncedPluginSdkExports);
       insertedPluginSdkExports = true;
     }
-    continue;
   }
-  nextExports[key] = value;
-  if (key === "." && !insertedPluginSdkExports) {
+
+  if (!insertedPluginSdkExports) {
     Object.assign(nextExports, syncedPluginSdkExports);
-    insertedPluginSdkExports = true;
   }
-}
 
-if (!insertedPluginSdkExports) {
-  Object.assign(nextExports, syncedPluginSdkExports);
-}
-
-const nextExportsJson = JSON.stringify(nextExports);
-const currentExportsJson = JSON.stringify(currentExports);
-if (checkOnly) {
-  if (currentExportsJson !== nextExportsJson) {
+  if (JSON.stringify(currentExports) === JSON.stringify(nextExports)) {
+    return;
+  }
+  if (checkOnly) {
     console.error("plugin-sdk exports out of sync. Run `pnpm plugin-sdk:sync-exports`.");
+    failed = true;
+    return;
+  }
+  packageJson.exports = nextExports;
+  fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+}
+
+// The workspace facade package mirrors a subset of plugin SDK entrypoints for
+// package-name resolution inside the monorepo. Every export key must have a src
+// facade file (its runtime `default` target) and name a canonical SDK entrypoint;
+// dangling keys typecheck via prebuilt dist d.ts but fail on runtime resolution.
+function syncFacadePackageExports() {
+  const facadePackageDir = path.join(repoRoot, "packages", "plugin-sdk");
+  const facadeSubpaths = fs
+    .readdirSync(path.join(facadePackageDir, "src"))
+    .filter((file) => file.endsWith(".ts"))
+    .map((file) => file.slice(0, -".ts".length))
+    .toSorted();
+  const entrypointSet = new Set(pluginSdkEntrypoints);
+  const staleFacades = facadeSubpaths.filter((subpath) => !entrypointSet.has(subpath));
+  if (staleFacades.length > 0) {
+    for (const subpath of staleFacades) {
+      console.error(
+        `packages/plugin-sdk/src/${subpath}.ts does not match any plugin SDK entrypoint. ` +
+          "Delete the facade or add the entrypoint to scripts/lib/plugin-sdk-entrypoints.json.",
+      );
+    }
+    failed = true;
+    return;
+  }
+
+  const facadePackageJsonPath = path.join(facadePackageDir, "package.json");
+  const facadePackageJson: Record<string, unknown> & { exports?: Record<string, unknown> } =
+    JSON.parse(fs.readFileSync(facadePackageJsonPath, "utf8"));
+  const nextExports = Object.fromEntries(
+    facadeSubpaths.map((subpath) => [
+      `./${subpath}`,
+      {
+        types: `./dist/src/plugin-sdk/${subpath}.d.ts`,
+        default: `./src/${subpath}.ts`,
+      },
+    ]),
+  );
+  if (JSON.stringify(facadePackageJson.exports ?? {}) === JSON.stringify(nextExports)) {
+    return;
+  }
+  if (checkOnly) {
+    const currentKeys = new Set(Object.keys(facadePackageJson.exports ?? {}));
+    const expectedKeys = new Set(Object.keys(nextExports));
+    for (const key of currentKeys) {
+      if (!expectedKeys.has(key)) {
+        console.error(`packages/plugin-sdk exports ${key} has no src facade file.`);
+      }
+    }
+    for (const key of expectedKeys) {
+      if (!currentKeys.has(key)) {
+        console.error(`packages/plugin-sdk src facade ${key} is missing from exports.`);
+      }
+    }
+    console.error("packages/plugin-sdk exports out of sync. Run `pnpm plugin-sdk:sync-exports`.");
+    failed = true;
+    return;
+  }
+  facadePackageJson.exports = nextExports;
+  fs.writeFileSync(
+    facadePackageJsonPath,
+    `${JSON.stringify(facadePackageJson, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+syncRootPackageExports();
+syncFacadePackageExports();
+if (checkOnly) {
+  if (failed) {
     process.exit(1);
   }
   console.log("plugin-sdk exports synced.");
-  process.exit(0);
 }
-
-packageJson.exports = nextExports;
-fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");

--- a/scripts/sync-plugin-sdk-exports.mts
+++ b/scripts/sync-plugin-sdk-exports.mts
@@ -56,27 +56,30 @@ function syncRootPackageExports() {
 // package-name resolution inside the monorepo. Every export key must have a src
 // facade file (its runtime `default` target) and name a canonical SDK entrypoint;
 // dangling keys typecheck via prebuilt dist d.ts but fail on runtime resolution.
-function syncFacadePackageExports() {
-  const facadePackageDir = path.join(repoRoot, "packages", "plugin-sdk");
+// Validation runs before any manifest write so an invalid facade cannot leave a
+// partially rewritten export map behind a zero exit status.
+function collectFacadeSubpaths(): string[] | null {
   const facadeSubpaths = fs
-    .readdirSync(path.join(facadePackageDir, "src"))
+    .readdirSync(path.join(repoRoot, "packages", "plugin-sdk", "src"))
     .filter((file) => file.endsWith(".ts"))
     .map((file) => file.slice(0, -".ts".length))
     .toSorted();
   const entrypointSet = new Set(pluginSdkEntrypoints);
   const staleFacades = facadeSubpaths.filter((subpath) => !entrypointSet.has(subpath));
-  if (staleFacades.length > 0) {
-    for (const subpath of staleFacades) {
-      console.error(
-        `packages/plugin-sdk/src/${subpath}.ts does not match any plugin SDK entrypoint. ` +
-          "Delete the facade or add the entrypoint to scripts/lib/plugin-sdk-entrypoints.json.",
-      );
-    }
-    failed = true;
-    return;
+  if (staleFacades.length === 0) {
+    return facadeSubpaths;
   }
+  for (const subpath of staleFacades) {
+    console.error(
+      `packages/plugin-sdk/src/${subpath}.ts does not match any plugin SDK entrypoint. ` +
+        "Delete the facade or add the entrypoint to scripts/lib/plugin-sdk-entrypoints.json.",
+    );
+  }
+  return null;
+}
 
-  const facadePackageJsonPath = path.join(facadePackageDir, "package.json");
+function syncFacadePackageExports(facadeSubpaths: string[]) {
+  const facadePackageJsonPath = path.join(repoRoot, "packages", "plugin-sdk", "package.json");
   const facadePackageJson: Record<string, unknown> & { exports?: Record<string, unknown> } =
     JSON.parse(fs.readFileSync(facadePackageJsonPath, "utf8"));
   const nextExports = Object.fromEntries(
@@ -116,11 +119,15 @@ function syncFacadePackageExports() {
   );
 }
 
+const facadeSubpaths = collectFacadeSubpaths();
+if (facadeSubpaths === null) {
+  process.exit(1);
+}
 syncRootPackageExports();
-syncFacadePackageExports();
+syncFacadePackageExports(facadeSubpaths);
+if (failed) {
+  process.exit(1);
+}
 if (checkOnly) {
-  if (failed) {
-    process.exit(1);
-  }
   console.log("plugin-sdk exports synced.");
 }


### PR DESCRIPTION
## What Problem This Solves

`packages/plugin-sdk/package.json` (the private `@openclaw/plugin-sdk` workspace facade package) declared 59 export subpaths, but only 24 had a matching `src/<name>.ts` facade file. The other 35 keys (`./core`, `./cli-runtime`, `./zod`, `./acp-runtime`, `./error-runtime`, `./ssrf-runtime`, `./config-contracts`, `./tts-runtime`, `./provider-usage`, `./talk-config-runtime`, and 25 more) had `"default": "./src/<name>.ts"` targets pointing at files that do not exist. Typecheck stayed green because their `types` targets resolve against the locally built boundary dist, so the rot was invisible until something resolved a dead subpath at runtime (plain Node/tsx resolution through the package, or the vitest `@openclaw/plugin-sdk/<subpath>` aliases in `test/vitest/vitest.shared.config.ts`, which point at the same missing files).

The existing guard could not catch this: `scripts/sync-plugin-sdk-exports.mts` only validated the root `package.json` `./plugin-sdk/*` keys, and the `check-changed` lane that runs it (`plugin-sdk:check-exports`) did not even trigger on `packages/plugin-sdk/**` changes.

## Why This Change Was Made

**Created 35 facades, pruned 0.** Every dead subpath maps to a live, current core entrypoint in `src/plugin-sdk/` (verified against `scripts/lib/plugin-sdk-entrypoints.json`; none is retired), and `src/plugins/contracts/extension-package-project-boundaries.test.ts` deliberately locks several of their `types` bridges (e.g. `./core`, `./cli-runtime`, `./error-runtime`). History shows the keys were added for boundary typing (e3cb19d1 "test(boundary): unify package sdk type paths") while facades were only added reactively when something broke (4c65fa8e, c627afe1, f7dc5f93). So the missing runtime half is rot, not intent — each new facade mirrors the sibling 3-line pattern (`export * from "../../../src/plugin-sdk/<name>.js"`).

To keep the map from rotting again, `scripts/sync-plugin-sdk-exports.mts` now also owns the workspace facade package: the exports map is regenerated from the `packages/plugin-sdk/src/` directory listing (sorted), every facade must name a canonical SDK entrypoint, and `--check` fails on either a dangling export key (no facade) or an orphan facade (no export / no entrypoint). The `check-changed` trigger (`PLUGIN_SDK_SURFACE_PATH_RE`) now includes `packages/plugin-sdk/`, so touching the package fires `plugin-sdk:check-exports` + `plugin-sdk:surface:check` in the same CI lane as before; release preflight already runs the same check.

Not user-visible: `@openclaw/plugin-sdk` is `private: true`, never published; external plugins consume `openclaw/plugin-sdk/*` from the root package, whose exports were already guarded.

## User Impact

None directly (dev-only workspace surface). For contributors: `@openclaw/plugin-sdk/<subpath>` now resolves for all 59 declared subpaths under vitest and tsx/Node, and the exports map can no longer drift from the facade files without CI failing.

## Evidence

- `pnpm plugin-sdk:check-exports` — green (and proven to fail on both rot directions: removing a facade → `exports ./zod has no src facade file`, exit 1; adding a non-entrypoint facade → `does not match any plugin SDK entrypoint`, exit 1).
- `pnpm plugin-sdk:surface:check` — green (`package-exported forbidden subpaths: 0`).
- `node scripts/run-vitest.mjs src/plugins/contracts/extension-package-project-boundaries.test.ts` — 8/8 passed (locks the exports map shape; key set unchanged at 59, verified against `git show HEAD`).
- Runtime resolution proof from `extensions/discord` (declares the workspace dep): `import('@openclaw/plugin-sdk/zod')` and `.../time-runtime` — previously `ERR_PACKAGE_PATH_NOT_EXPORTED`-class failures, now load. (`./core` still cannot fully load under plain Node because core entrypoints import workspace packages like `@openclaw/normalization-core` that only resolve through the vitest/jiti alias maps — pre-existing, unchanged by this PR.)
- `node scripts/check-changed.mjs --dry-run -- packages/plugin-sdk/package.json` now selects `pnpm plugin-sdk:check-exports` / `plugin-sdk:surface:check` (previously not selected).
