### PR TITLE
fix(ui): remove assistant avatars from chat transcripts

### DIFF
--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -253,7 +253,7 @@ export function renderActivityGroup(
       class="chat-group tool chat-group--activity chat-group--with-footer"
       data-chat-row-key=${firstGroup.key}
     >
-      ${showAvatarGutter
+      ${showAvatarGutter && normalizeRoleForGrouping(firstGroup.role) !== "assistant"
         ? renderChatAvatar(
             firstGroup.role,
             {
@@ -414,7 +414,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
       style=${senderHue === null ? nothing : `--chat-sender-hue: ${senderHue}`}
       data-chat-row-key=${group.key}
     >
-      ${showAvatarGutter
+      ${showAvatarGutter && normalizedRole !== "assistant"
         ? renderChatAvatar(
             group.role,
             {

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -84,6 +84,7 @@ type RenderMessageGroupOptions = {
   userName?: string | null;
   userAvatar?: string | null;
   showAvatarGutter?: boolean;
+  showAssistantAvatar?: boolean;
   basePath?: string;
   localMediaPreviewRoots?: readonly string[];
   assistantAttachmentAuthToken?: string | null;
@@ -253,7 +254,9 @@ export function renderActivityGroup(
       class="chat-group tool chat-group--activity chat-group--with-footer"
       data-chat-row-key=${firstGroup.key}
     >
-      ${showAvatarGutter && normalizeRoleForGrouping(firstGroup.role) !== "assistant"
+      ${showAvatarGutter &&
+      (normalizeRoleForGrouping(firstGroup.role) !== "assistant" ||
+        opts.showAssistantAvatar !== false)
         ? renderChatAvatar(
             firstGroup.role,
             {
@@ -414,7 +417,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
       style=${senderHue === null ? nothing : `--chat-sender-hue: ${senderHue}`}
       data-chat-row-key=${group.key}
     >
-      ${showAvatarGutter && normalizedRole !== "assistant"
+      ${showAvatarGutter && (normalizedRole !== "assistant" || opts.showAssistantAvatar !== false)
         ? renderChatAvatar(
             group.role,
             {

--- a/ui/src/pages/chat/components/chat-message-stream.ts
+++ b/ui/src/pages/chat/components/chat-message-stream.ts
@@ -5,6 +5,7 @@ import { t } from "../../../i18n/index.ts";
 import type { AssistantIdentity } from "../../../lib/assistant-identity.ts";
 import type { ChatItem } from "../../../lib/chat/chat-types.ts";
 import { formatDurationCompact } from "../../../lib/format.ts";
+import { renderChatAvatar } from "../chat-avatar.ts";
 import type { ChatRunStartupPhase } from "../chat-run-startup.ts";
 import type { PlanStatus } from "../tool-stream.ts";
 import { renderGroupedMessage } from "./chat-message-bubble.ts";
@@ -44,6 +45,7 @@ type StreamMessageOptions = Pick<
 export type StreamGroupOptions = StreamMessageOptions & {
   onOpenSidebar?: (content: SidebarContent) => void;
   assistant?: AssistantIdentity;
+  showAssistantAvatar?: boolean;
   planStatus?: PlanStatus | null;
   planActive?: boolean;
   startupPhase?: ChatRunStartupPhase;
@@ -113,19 +115,28 @@ export function renderStreamGroupParts(
 }
 
 // One assistant group per contiguous run of streaming items: a reply that
-// arrives as several stream segments renders with one shared footer instead
-// of flashing a separate bubble per segment (#63956).
+// arrives as several stream segments renders under a single avatar/footer
+// instead of flashing a separate avatar+bubble per segment (#63956).
 export function renderStreamGroup(parts: StreamGroupPart[], opts: StreamGroupOptions = {}) {
-  const name = opts.assistant?.name ?? "Assistant";
+  const { assistant, basePath, assistantAttachmentAuthToken } = opts;
+  const name = assistant?.name ?? "Assistant";
   // Footer (sender + time) anchors to the earliest streamed segment; a run that
   // is only the reading indicator has no timestamp and therefore no footer.
   const streamStarts = parts.flatMap((part) => (part.kind === "stream" ? [part.startedAt] : []));
   const footerStartedAt = streamStarts.length > 0 ? Math.min(...streamStarts) : null;
+  // While the agent works with nothing streamed yet the run is pure claw: no
+  // avatar next to it - the punching pincer is the whole signal. The avatar
+  // arrives with the first stream part unless the presentation opts out.
   const workingOnly = parts.every((part) => part.kind !== "stream");
+  const avatar =
+    workingOnly || opts.showAssistantAvatar === false
+      ? nothing
+      : renderChatAvatar("assistant", assistant, undefined, basePath, assistantAttachmentAuthToken);
   const groupClass = `chat-group assistant${workingOnly ? " chat-group--working" : ""}${footerStartedAt !== null ? " chat-group--with-footer" : ""}`;
 
   return html`
     <div class=${groupClass} data-chat-row-key=${parts[0]?.key ?? nothing}>
+      ${avatar}
       <div class="chat-group-messages">${renderStreamGroupParts(parts, opts, "standalone")}</div>
       ${footerStartedAt !== null
         ? html`

--- a/ui/src/pages/chat/components/chat-message-stream.ts
+++ b/ui/src/pages/chat/components/chat-message-stream.ts
@@ -5,7 +5,6 @@ import { t } from "../../../i18n/index.ts";
 import type { AssistantIdentity } from "../../../lib/assistant-identity.ts";
 import type { ChatItem } from "../../../lib/chat/chat-types.ts";
 import { formatDurationCompact } from "../../../lib/format.ts";
-import { renderChatAvatar } from "../chat-avatar.ts";
 import type { ChatRunStartupPhase } from "../chat-run-startup.ts";
 import type { PlanStatus } from "../tool-stream.ts";
 import { renderGroupedMessage } from "./chat-message-bubble.ts";
@@ -114,27 +113,19 @@ export function renderStreamGroupParts(
 }
 
 // One assistant group per contiguous run of streaming items: a reply that
-// arrives as several stream segments renders under a single avatar/footer
-// instead of flashing a separate avatar+bubble per segment (#63956).
+// arrives as several stream segments renders with one shared footer instead
+// of flashing a separate bubble per segment (#63956).
 export function renderStreamGroup(parts: StreamGroupPart[], opts: StreamGroupOptions = {}) {
-  const { assistant, basePath, assistantAttachmentAuthToken } = opts;
-  const name = assistant?.name ?? "Assistant";
+  const name = opts.assistant?.name ?? "Assistant";
   // Footer (sender + time) anchors to the earliest streamed segment; a run that
   // is only the reading indicator has no timestamp and therefore no footer.
   const streamStarts = parts.flatMap((part) => (part.kind === "stream" ? [part.startedAt] : []));
   const footerStartedAt = streamStarts.length > 0 ? Math.min(...streamStarts) : null;
-  // While the agent works with nothing streamed yet the run is pure claw: no
-  // avatar next to it - the punching pincer is the whole signal. The avatar
-  // arrives with the first stream part.
   const workingOnly = parts.every((part) => part.kind !== "stream");
-  const avatar = workingOnly
-    ? nothing
-    : renderChatAvatar("assistant", assistant, undefined, basePath, assistantAttachmentAuthToken);
   const groupClass = `chat-group assistant${workingOnly ? " chat-group--working" : ""}${footerStartedAt !== null ? " chat-group--with-footer" : ""}`;
 
   return html`
     <div class=${groupClass} data-chat-row-key=${parts[0]?.key ?? nothing}>
-      ${avatar}
       <div class="chat-group-messages">${renderStreamGroupParts(parts, opts, "standalone")}</div>
       ${footerStartedAt !== null
         ? html`

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -722,11 +722,13 @@ describe("grouped chat rendering", () => {
     expect(container.querySelector('[aria-label="Read aloud"]')).toBeNull();
   });
 
-  it("renders assistant message actions in the footer row", () => {
+  it("renders assistant messages without an avatar and keeps actions in the footer row", () => {
     const container = document.createElement("div");
     renderAssistantMessage(container, createAssistantMessage("Short reply", { timestamp: 1000 }));
 
     const assistantGroup = expectElement(container, ".chat-group.assistant", HTMLElement);
+    expect(assistantGroup.classList.contains("chat-group--with-footer")).toBe(true);
+    expect(assistantGroup.querySelector(".chat-avatar")).toBeNull();
     expect(assistantGroup.querySelector(".chat-bubble-actions")).toBeNull();
     expect(
       assistantGroup.querySelector(".chat-group-footer-actions .chat-copy-btn"),
@@ -1671,7 +1673,7 @@ describe("grouped chat rendering", () => {
     expect(container.querySelectorAll(".chat-avatar.assistant")).toHaveLength(0);
   });
 
-  it("keeps the avatar once a stream part joins the reading indicator", () => {
+  it("keeps streamed assistant content in the guttered group without an avatar", () => {
     const container = document.createElement("div");
 
     render(
@@ -1684,7 +1686,8 @@ describe("grouped chat rendering", () => {
 
     const group = container.querySelector(".chat-group.assistant");
     expect(group?.classList.contains("chat-group--working")).toBe(false);
-    expect(container.querySelectorAll(".chat-avatar.assistant")).toHaveLength(1);
+    expect(group?.classList.contains("chat-group--with-footer")).toBe(true);
+    expect(container.querySelectorAll(".chat-avatar.assistant")).toHaveLength(0);
     expect(container.querySelectorAll(".chat-group-footer")).toHaveLength(1);
     expect(container.querySelectorAll(".chat-working-indicator")).toHaveLength(1);
     expect(container.querySelectorAll(".chat-reading-indicator")).toHaveLength(1);

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -724,7 +724,9 @@ describe("grouped chat rendering", () => {
 
   it("renders assistant messages without an avatar and keeps actions in the footer row", () => {
     const container = document.createElement("div");
-    renderAssistantMessage(container, createAssistantMessage("Short reply", { timestamp: 1000 }));
+    renderAssistantMessage(container, createAssistantMessage("Short reply", { timestamp: 1000 }), {
+      showAssistantAvatar: false,
+    });
 
     const assistantGroup = expectElement(container, ".chat-group.assistant", HTMLElement);
     expect(assistantGroup.classList.contains("chat-group--with-footer")).toBe(true);
@@ -1677,10 +1679,19 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
 
     render(
-      renderStreamGroup([
-        { kind: "stream", key: "stream:s:live", text: "reply", startedAt: 10, isStreaming: true },
-        { kind: "reading-indicator", key: "reading", startedAt: 10 },
-      ]),
+      renderStreamGroup(
+        [
+          {
+            kind: "stream",
+            key: "stream:s:live",
+            text: "reply",
+            startedAt: 10,
+            isStreaming: true,
+          },
+          { kind: "reading-indicator", key: "reading", startedAt: 10 },
+        ],
+        { showAssistantAvatar: false },
+      ),
       container,
     );
 

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -1569,6 +1569,7 @@ function renderChatThreadContents(
     canvasPluginSurfaceUrl: props.canvasPluginSurfaceUrl,
     embedSandboxMode: props.embedSandboxMode ?? "scripts",
     allowExternalEmbedUrls: props.allowExternalEmbedUrls ?? false,
+    showAssistantAvatar: false,
   } satisfies StreamGroupOptions;
   const streamGroupOptions = {
     ...sharedMessageRenderOptions,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where assistant replies in shared Control UI chats showed a repeated machine-grid avatar beside every persisted or streaming response, adding visual noise to the transcript.

## Why This Change Was Made

The main chat-thread presentation now explicitly opts out of assistant avatars across persisted groups, aggregated activity groups, and live streams. Generic chat renderers remain avatar-capable by default, so explicit branding consumers such as Custodian keep their assistant avatar. The existing shared-chat gutter grid remains unchanged, preserving message, tool-row, and footer alignment.

AI-assisted: yes.

## User Impact

Assistant replies in the main chat transcript now render without the repeated machine-grid avatar. Transcript content stays at the same horizontal position as before, while other UI surfaces that intentionally show an assistant identity remain unchanged.

## Evidence

### Before

![Assistant replies with repeated machine-grid avatars](https://github.com/user-attachments/assets/e621d454-f5e1-48a2-9a80-6fea4adcb479)

### After

![Assistant replies without machine-grid avatars and with unchanged alignment](https://github.com/user-attachments/assets/e9caf9f7-8fc1-4f69-8460-a6406d88da4b)

- Browser mock comparison: assistant avatars changed from 10 to 0; the first five assistant message left edges remained exactly `540px`; computed grid columns remained `36px 702px`.
- Initial focused chat rendering suite: 163 tests passed.
- First exact-head CI correctly exposed an over-broad implementation because Custodian intentionally expects `/favicon.svg`; the patch was narrowed so only main chat opts out and Custodian keeps the default-on behavior.
- Final local combined chat + Custodian reruns could not start because the repository-wide heavy-check lock remained occupied by unrelated worktrees; final exact-head CI is required before merge.
- `./node_modules/.bin/oxfmt --check ui/src/pages/chat/components/chat-message-group.ts ui/src/pages/chat/components/chat-message-stream.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/components/chat-thread.ts`
- `git diff --check`
- Fresh post-fix autoreview: no accepted/actionable findings.
