### PR TITLE
fix(ui): keep own-message sender name stationary on footer hover

### DIFF
--- a/ui/src/e2e/chat-attributed-identity.e2e.test.ts
+++ b/ui/src/e2e/chat-attributed-identity.e2e.test.ts
@@ -105,6 +105,24 @@ suite.define(() => {
     await expect(page.locator(".chat-author-avatar")).toHaveCount(0);
     await captureProof(page, "after-hover.png");
 
+    // Own-message footer: the always-visible name must stay put when hover
+    // reveals the timestamp, which slots in to its left (right-aligned row).
+    const ownGroup = userGroups.first();
+    const ownName = ownGroup.locator(".chat-sender-name");
+    await page.mouse.move(0, 0);
+    await expect(ownGroup.locator(".chat-group-timestamp")).toHaveCSS("opacity", "0");
+    const restingNameBox = await ownName.boundingBox();
+    await ownGroup.hover();
+    const ownTimestamp = ownGroup.locator(".chat-group-timestamp");
+    await expect(ownTimestamp).toHaveCSS("opacity", "1");
+    await captureProof(page, "own-group-hover.png");
+    const hoveredNameBox = await ownName.boundingBox();
+    const timestampBox = await ownTimestamp.boundingBox();
+    expect(hoveredNameBox?.x).toBe(restingNameBox?.x);
+    expect((timestampBox?.x ?? 0) + (timestampBox?.width ?? 0)).toBeLessThan(
+      hoveredNameBox?.x ?? 0,
+    );
+
     const footerOrder = await userGroups
       .last()
       .locator(".chat-group-footer")

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -191,6 +191,13 @@
   min-width: 0;
 }
 
+/* Own-message footers are right-aligned, so hover-revealed time/actions must
+   slot in to the LEFT of the always-visible name; otherwise the name jumps
+   sideways on hover. Peer footers are left-aligned and already stable. */
+.chat-group.user:not(.chat-group--peer) .chat-group-footer--persistent-identity .chat-sender-name {
+  order: 1;
+}
+
 .chat-group-footer-actions,
 .chat-message-actions-row {
   display: flex;


### PR DESCRIPTION
## What Problem This Solves

In the Control UI chat, hovering a message from the signed-in user reveals the relative timestamp in the footer under the avatar. That footer is right-aligned, and the timestamp was rendered to the right of the always-visible sender name — so revealing it pushed the name ~50px sideways on every hover, making the UI feel busy.

## Why This Change Was Made

The persistent-identity footer (own messages with the avatar gutter) keeps the sender name visible at rest while the timestamp and actions fade in on hover. In a right-aligned flex row, anything that appears after the name displaces it. Flipping the visual order with a scoped CSS `order: 1` on `.chat-sender-name` makes the hover-revealed time and actions slot in to the left, keeping the name pinned under the avatar. Peer-sender footers are left-aligned and already stable, so they are excluded via `:not(.chat-group--peer)`; DOM order is untouched, so screen-reader reading order and existing DOM-order assertions stay the same.

## User Impact

Hovering your own message now reveals "8m ago" to the left of your name instead of shoving the name aside. No behavior change for peer senders, assistant footers, or non-gutter layouts.

Before (hover: name displaced left by the revealed time):
![before](https://github.com/user-attachments/assets/cc9a2c11-54e1-4b13-ba35-f9027acc7177)

After (hover: time slots in left, name stays pinned under the avatar):
![after](https://github.com/user-attachments/assets/cd5427c2-5e01-4ac6-bc64-c101cb0a221f)

## Evidence

- New regression assertions in `ui/src/e2e/chat-attributed-identity.e2e.test.ts`: the own-group sender name bounding box must not move across hover, and the revealed timestamp must sit left of the name. Verified failing pre-fix (name x 1013.8 → 964.5) and passing post-fix via `node scripts/run-vitest.mjs ui/src/e2e/chat-attributed-identity.e2e.test.ts` (2 passed).
- Targeted `oxfmt --check` and `stylelint` on the touched files: clean.
- Codex autoreview (`--mode local`, gpt-5.6-sol/high): clean, no findings.
- Production LOC delta: +7 lines CSS (comment + one scoped rule); the rest is test.
