### PR TITLE
fix(ui): dark-mode body text renders brighter than the dark-reading comfort band

### DIFF
--- a/ui/docs/design-system/accessibility.md
+++ b/ui/docs/design-system/accessibility.md
@@ -8,7 +8,7 @@ OpenClaw targets **WCAG 2.1 AA**. This checklist applies to every UI component �
 
 | Context                                   | Minimum Ratio    | Notes                                              |
 | ----------------------------------------- | ---------------- | -------------------------------------------------- |
-| Normal body text (< 18px / < 14px bold)   | **4.5:1**        | Use `--text` (#d4d4d8) or stronger on `--bg`       |
+| Normal body text (< 18px / < 14px bold)   | **4.5:1**        | Use `--text` (#bcbcc0) or stronger on `--bg`       |
 | Large text (≥ 18px regular / ≥ 14px bold) | **3:1**          | Headings in chat thread                            |
 | UI component boundaries (inputs, buttons) | **3:1**          | Border colours against adjacent background         |
 | Focus indicators                          | **3:1** (AA)     | `--focus-ring` / `--focus-glow` already compliant  |

--- a/ui/docs/design-system/color-tokens.md
+++ b/ui/docs/design-system/color-tokens.md
@@ -32,7 +32,7 @@ Light mode uses a warm paper palette: ivory backgrounds, warm gray borders (`#e8
 
 | Token            | Dark Value | Contrast on `--bg` | Use                                                |
 | ---------------- | ---------- | ------------------ | -------------------------------------------------- |
-| `--text`         | `#d4d4d8`  | ~12.9:1 ✅         | Body copy, labels                                  |
+| `--text`         | `#bcbcc0`  | ~10.1:1 ✅         | Body copy, labels                                  |
 | `--text-strong`  | `#f4f4f5`  | ~17.3:1 ✅         | Headings, emphasis                                 |
 | `--muted`        | `#8b8b94`  | ~5.6:1 ✅          | Placeholder, metadata                              |
 | `--muted-strong` | `#898990`  | ~5.5:1 ✅          | Secondary text, captions; prefer `--text` for body |

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -21,11 +21,13 @@
   --chrome-strong: rgba(14, 16, 21, 0.98);
 
   /* Text - Clean contrast
-   * Keep --muted AA on dark surfaces; do not dim muted body text with opacity. */
+   * Keep --muted AA on dark surfaces; do not dim muted body text with opacity.
+   * --text targets ~12:1 on --bg (12.0 on #0e1015, 11.1 on --card) — the dark
+   * comfort band tops out around 12; brighter body text halates on dark. */
 
-  --text: #d4d4d8;
+  --text: #cdcdd1;
   --text-strong: #f4f4f5;
-  --chat-text: #d4d4d8;
+  --chat-text: #cdcdd1;
   --muted: #8b8b94;
   --muted-strong: #898990;
   --muted-foreground: #8b8b94;

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -22,12 +22,12 @@
 
   /* Text - Clean contrast
    * Keep --muted AA on dark surfaces; do not dim muted body text with opacity.
-   * --text targets ~12:1 on --bg (12.0 on #0e1015, 11.1 on --card) — the dark
-   * comfort band tops out around 12; brighter body text halates on dark. */
+   * --text targets the 10-12 dark comfort band (11.4 on --bg #0e1015, 10.5 on
+   * --card) — brighter body text halates on dark backgrounds. */
 
-  --text: #cdcdd1;
+  --text: #c8c8cc;
   --text-strong: #f4f4f5;
-  --chat-text: #cdcdd1;
+  --chat-text: #c8c8cc;
   --muted: #8b8b94;
   --muted-strong: #898990;
   --muted-foreground: #8b8b94;

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -22,12 +22,12 @@
 
   /* Text - Clean contrast
    * Keep --muted AA on dark surfaces; do not dim muted body text with opacity.
-   * --text targets the 10-12 dark comfort band (11.4 on --bg #0e1015, 10.5 on
-   * --card) — brighter body text halates on dark backgrounds. */
+   * --text targets ~10:1 on --bg #0e1015 (10.1; 9.3 on --card) — the dark
+   * comfort band is ~10-12 and brighter body text halates on dark. */
 
-  --text: #c8c8cc;
+  --text: #bcbcc0;
   --text-strong: #f4f4f5;
-  --chat-text: #c8c8cc;
+  --chat-text: #bcbcc0;
   --muted: #8b8b94;
   --muted-strong: #898990;
   --muted-foreground: #8b8b94;


### PR DESCRIPTION
## What Problem This Solves

Resolves a comfort issue where dark-mode body text in the Control UI (chat messages, cards, and every surface using `--text`/`--chat-text`) rendered brighter than the dark-reading comfort band, at 12.87:1 contrast on the page background. High-contrast light text on dark backgrounds halates (blooms), which is fatiguing for long reading sessions and worst for astigmatic readers.

## Why This Change Was Made

The default dark theme's `--text`/`--chat-text` drop from `#d4d4d8` to `#bcbcc0`, landing at 10.05:1 on `--bg` (`#0e1015`) and 9.29:1 on `--card` (`#161920`) — the low end of the 10–12 dark comfort band (slightly under it on cards, chosen by visual preview) while staying far above WCAG AAA (7:1). Non-goals kept unchanged: `--text-strong` (headings keep their pop against softer body text), `--muted` (AA-gated by `theme-contrast.test.ts`), light mode, and the openknot/dash theme families. A token-site comment now documents the ~10:1 comfort target so a future brightness pass hits the rationale first.

## User Impact

Dark-mode body text reads slightly softer and less glary; headings and emphasis stand out a touch more by comparison. No layout, light-mode, or accessibility-threshold changes — body text remains well above AAA.

## Evidence

Before/after (same markup, only the token changed):

![dark-mode body text before/after](https://github.com/user-attachments/assets/1fa54039-ae31-4d2f-accd-cb3fa1e37e82)

Measured WCAG 2.1 relative-luminance ratios:

| Pair | Before | After |
|---|---|---|
| `--text` on `--bg` `#0e1015` | 12.87:1 | 10.05:1 |
| `--text` on `--card` `#161920` | 11.90:1 | 9.29:1 |

Focused proof: `node scripts/run-vitest.mjs ui/src/styles/theme-contrast.test.ts ui/src/styles/base-theme-tokens.node.test.ts` — 2 files, 4 tests passed.
