### PR TITLE
fix(telegram): ignore commands in disabled forum topics

### DIFF
--- a/extensions/telegram/src/bot-handlers.authorization-groups.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.authorization-groups.runtime.ts
@@ -84,7 +84,6 @@ export function shouldSkipTelegramGroupMessage(
     senderUsername,
     resolveGroupPolicy: runtime.resolveGroupPolicy,
     enforcePolicy: true,
-    useTopicAndGroupOverrides: true,
     enforceAllowlistAuthorization: true,
     allowEmptyAllowlistEntries: false,
     requireSenderForAllowlistAuthorization: true,

--- a/extensions/telegram/src/bot-native-commands.group-auth.test.ts
+++ b/extensions/telegram/src/bot-native-commands.group-auth.test.ts
@@ -1,7 +1,11 @@
 // Telegram tests cover bot native commands.group auth plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ChannelGroupPolicy } from "openclaw/plugin-sdk/config-contracts";
-import type { TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
+import type {
+  TelegramAccountConfig,
+  TelegramGroupConfig,
+  TelegramTopicConfig,
+} from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it, vi } from "vitest";
 import {
   createNativeCommandsHarness,
@@ -18,7 +22,8 @@ describe("native command auth in groups", () => {
     groupAllowFrom?: string[];
     storeAllowFrom?: string[];
     useAccessGroups?: boolean;
-    groupConfig?: Record<string, unknown>;
+    groupConfig?: TelegramGroupConfig;
+    topicConfig?: TelegramTopicConfig;
     resolveGroupPolicy?: () => ChannelGroupPolicy;
   }) {
     return createNativeCommandsHarness({
@@ -36,6 +41,7 @@ describe("native command auth in groups", () => {
             allowed: true,
           }) as ChannelGroupPolicy),
       groupConfig: params.groupConfig,
+      topicConfig: params.topicConfig,
     });
   }
 
@@ -114,7 +120,7 @@ describe("native command auth in groups", () => {
     );
   });
 
-  it("keeps groupPolicy disabled enforced when commands.allowFrom is configured", async () => {
+  it("silently drops account-disabled native commands", async () => {
     const { handlers, sendMessage } = setup({
       cfg: {
         channels: {
@@ -140,12 +146,52 @@ describe("native command auth in groups", () => {
 
     await handlers.status?.(ctx);
 
-    expect(sendMessage).toHaveBeenCalledWith(-100999, "Telegram group commands are disabled.", {
-      message_thread_id: 42,
-    });
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("keeps group chat allowlists enforced when commands.allowFrom is configured", async () => {
+  it("silently drops topic-disabled native commands before dispatch", async () => {
+    const cfg = {
+      commands: {
+        allowFrom: {
+          telegram: ["12345"],
+        },
+      },
+    } as OpenClawConfig;
+    const disabled = setup({
+      cfg,
+      telegramCfg: { groupPolicy: "open" } as TelegramAccountConfig,
+      groupConfig: { groupPolicy: "open" },
+      topicConfig: { groupPolicy: "disabled" },
+      useAccessGroups: true,
+    });
+
+    await disabled.handlers.status?.(createTelegramGroupCommandContext({ threadId: 42 }));
+
+    expect(disabled.sendMessage).not.toHaveBeenCalled();
+    expect(disabled.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("silently drops native commands that inherit disabled group policy", async () => {
+    const { handlers, sendMessage, dispatchReplyWithBufferedBlockDispatcher } = setup({
+      cfg: {
+        commands: {
+          allowFrom: {
+            telegram: ["12345"],
+          },
+        },
+      } as OpenClawConfig,
+      telegramCfg: { groupPolicy: "open" } as TelegramAccountConfig,
+      groupConfig: { groupPolicy: "disabled" },
+      useAccessGroups: true,
+    });
+
+    await handlers.status?.(createTelegramGroupCommandContext());
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("silently drops native commands from groups outside the chat allowlist", async () => {
     const { handlers, sendMessage } = setup({
       cfg: {
         commands: {
@@ -166,9 +212,7 @@ describe("native command auth in groups", () => {
 
     await handlers.status?.(ctx);
 
-    expect(sendMessage).toHaveBeenCalledWith(-100999, "This group is not allowed.", {
-      message_thread_id: 42,
-    });
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it("rejects native commands in groups when sender is in neither allowlist", async () => {

--- a/extensions/telegram/src/bot-native-commands.test-helpers.ts
+++ b/extensions/telegram/src/bot-native-commands.test-helpers.ts
@@ -1,7 +1,11 @@
 // Telegram helper module supports bot native commands helpers behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ChannelGroupPolicy } from "openclaw/plugin-sdk/config-contracts";
-import type { TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
+import type {
+  TelegramAccountConfig,
+  TelegramGroupConfig,
+  TelegramTopicConfig,
+} from "openclaw/plugin-sdk/config-contracts";
 import type { MockFn } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { vi } from "vitest";
@@ -32,6 +36,7 @@ type AnyAsyncMock = MockFn<(...args: unknown[]) => Promise<unknown>>;
 type NativeCommandHarness = {
   handlers: Record<string, (ctx: unknown) => Promise<void>>;
   sendMessage: AnyAsyncMock;
+  dispatchReplyWithBufferedBlockDispatcher: typeof replyPipelineMocks.dispatchReplyWithBufferedBlockDispatcher;
   setMyCommands: AnyAsyncMock;
   log: AnyMock;
   bot: RegisterTelegramNativeCommandsParams["bot"];
@@ -155,9 +160,11 @@ export function createNativeCommandsHarness(params?: {
   readChannelAllowFromStore?: AnyAsyncMock;
   useAccessGroups?: boolean;
   nativeEnabled?: boolean;
-  groupConfig?: Record<string, unknown>;
+  groupConfig?: TelegramGroupConfig;
+  topicConfig?: TelegramTopicConfig;
   resolveGroupPolicy?: () => ChannelGroupPolicy;
 }): NativeCommandHarness {
+  replyPipelineMocks.dispatchReplyWithBufferedBlockDispatcher.mockClear();
   const handlers: Record<string, (ctx: unknown) => Promise<void>> = {};
   const sendMessage: AnyAsyncMock = vi.fn(async () => undefined);
   const setMyCommands: AnyAsyncMock = vi.fn(async () => undefined);
@@ -212,8 +219,8 @@ export function createNativeCommandsHarness(params?: {
           allowed: true,
         }) as ChannelGroupPolicy),
     resolveTelegramGroupConfig: () => ({
-      groupConfig: params?.groupConfig as undefined,
-      topicConfig: undefined,
+      groupConfig: params?.groupConfig,
+      topicConfig: params?.topicConfig,
     }),
     shouldSkipUpdate: () => false,
     opts: {
@@ -224,7 +231,16 @@ export function createNativeCommandsHarness(params?: {
     },
   });
 
-  return { handlers, sendMessage, setMyCommands, log, bot, readChannelAllowFromStore };
+  return {
+    handlers,
+    sendMessage,
+    dispatchReplyWithBufferedBlockDispatcher:
+      replyPipelineMocks.dispatchReplyWithBufferedBlockDispatcher,
+    setMyCommands,
+    log,
+    bot,
+    readChannelAllowFromStore,
+  };
 }
 
 export function createTelegramDmCommandContext(params?: { senderId?: number; username?: string }) {

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -819,10 +819,14 @@ async function resolveTelegramCommandAuth(params: {
   });
   if (!baseAccess.allowed) {
     if (baseAccess.reason === "group-disabled") {
-      return await sendAuthMessage("This group is disabled.");
+      logVerbose(`Blocked telegram command in group ${chatId} (group disabled)`);
+      return null;
     }
     if (baseAccess.reason === "topic-disabled") {
-      return await sendAuthMessage("This topic is disabled.");
+      logVerbose(
+        `Blocked telegram command in topic ${chatId} (${resolvedThreadId ?? "unknown"}) (topic disabled)`,
+      );
+      return null;
     }
     return await rejectNotAuthorized();
   }
@@ -839,7 +843,6 @@ async function resolveTelegramCommandAuth(params: {
     senderUsername,
     resolveGroupPolicy,
     enforcePolicy: true,
-    useTopicAndGroupOverrides: false,
     enforceAllowlistAuthorization: requireAuth && !commandsAllowFromConfigured,
     allowEmptyAllowlistEntries: true,
     requireSenderForAllowlistAuthorization: true,
@@ -847,7 +850,8 @@ async function resolveTelegramCommandAuth(params: {
   });
   if (!policyAccess.allowed) {
     if (policyAccess.reason === "group-policy-disabled") {
-      return await sendAuthMessage("Telegram group commands are disabled.");
+      logVerbose("Blocked telegram command (groupPolicy: disabled)");
+      return null;
     }
     if (
       policyAccess.reason === "group-policy-allowlist-no-sender" ||
@@ -856,7 +860,8 @@ async function resolveTelegramCommandAuth(params: {
       return await rejectNotAuthorized();
     }
     if (policyAccess.reason === "group-chat-not-allowed") {
-      return await sendAuthMessage("This group is not allowed.");
+      logVerbose(`Blocked telegram command in group ${chatId} (group not allowed)`);
+      return null;
     }
   }
 

--- a/extensions/telegram/src/group-access.base-access.test.ts
+++ b/extensions/telegram/src/group-access.base-access.test.ts
@@ -107,7 +107,6 @@ const DEFAULT_GROUP_ACCESS_PARAMS: GroupAccessParams = {
     groupConfig: { requireMention: false },
   }),
   enforcePolicy: true,
-  useTopicAndGroupOverrides: false,
   enforceAllowlistAuthorization: true,
   allowEmptyAllowlistEntries: false,
   requireSenderForAllowlistAuthorization: true,
@@ -230,6 +229,27 @@ describe("evaluateTelegramGroupPolicyAccess", () => {
       reason: "group-policy-disabled",
       groupPolicy: "disabled",
     });
+  });
+
+  it("uses topic policy before group and account policy", () => {
+    expect(
+      runAccess({
+        telegramCfg: { groupPolicy: "open" } as TelegramAccountConfig,
+        groupConfig: { groupPolicy: "open" },
+        topicConfig: { groupPolicy: "disabled" },
+      }),
+    ).toEqual({
+      allowed: false,
+      reason: "group-policy-disabled",
+      groupPolicy: "disabled",
+    });
+    expect(
+      runAccess({
+        telegramCfg: { groupPolicy: "open" } as TelegramAccountConfig,
+        groupConfig: { groupPolicy: "disabled" },
+        topicConfig: { groupPolicy: "open" },
+      }),
+    ).toEqual({ allowed: true, groupPolicy: "open" });
   });
 
   it("allows non-group messages without any checks", () => {

--- a/extensions/telegram/src/group-access.ts
+++ b/extensions/telegram/src/group-access.ts
@@ -122,24 +122,20 @@ export const resolveTelegramEffectiveGroupPolicy = (params: {
   telegramCfg: TelegramAccountConfig;
   groupConfig?: TelegramGroupConfig;
   topicConfig?: TelegramTopicConfig;
-  useTopicAndGroupOverrides: boolean;
 }) => {
   const { groupPolicy: runtimeFallbackPolicy } = resolveTelegramRuntimeGroupPolicy({
     providerConfigPresent: params.cfg.channels?.telegram !== undefined,
     groupPolicy: params.telegramCfg.groupPolicy,
     defaultGroupPolicy: params.cfg.channels?.defaults?.groupPolicy,
   });
-  const fallbackPolicy =
-    firstDefined(params.telegramCfg.groupPolicy, params.cfg.channels?.defaults?.groupPolicy) ??
-    runtimeFallbackPolicy;
-  return params.useTopicAndGroupOverrides
-    ? (firstDefined(
-        params.topicConfig?.groupPolicy,
-        params.groupConfig?.groupPolicy,
-        params.telegramCfg.groupPolicy,
-        params.cfg.channels?.defaults?.groupPolicy,
-      ) ?? runtimeFallbackPolicy)
-    : fallbackPolicy;
+  return (
+    firstDefined(
+      params.topicConfig?.groupPolicy,
+      params.groupConfig?.groupPolicy,
+      params.telegramCfg.groupPolicy,
+      params.cfg.channels?.defaults?.groupPolicy,
+    ) ?? runtimeFallbackPolicy
+  );
 };
 
 export const evaluateTelegramGroupPolicyAccess = (params: {
@@ -154,7 +150,6 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
   senderUsername?: string;
   resolveGroupPolicy: (chatId: string | number, cfg: OpenClawConfig) => ChannelGroupPolicy;
   enforcePolicy: boolean;
-  useTopicAndGroupOverrides: boolean;
   enforceAllowlistAuthorization: boolean;
   allowEmptyAllowlistEntries: boolean;
   requireSenderForAllowlistAuthorization: boolean;

--- a/extensions/telegram/src/send-special.ts
+++ b/extensions/telegram/src/send-special.ts
@@ -242,7 +242,6 @@ async function sendPollTelegramWithContext(
             telegramCfg: context.account.config,
             groupConfig: groupPolicyConfig,
             topicConfig,
-            useTopicAndGroupOverrides: true,
           }) === "disabled";
         if (groupIngressDisabled) {
           pollAnswerRouting = "unavailable";


### PR DESCRIPTION
Closes #56699

## What Problem This Solves

Fixes an issue where native Telegram commands in a disabled forum topic made every bot account respond and create topic session state, even when the operator assigned that topic to only one account.

## Why This Change Was Made

Telegram now resolves one effective group policy for every ingress surface: topic, then group, account, and channel defaults. Disabled scopes and disallowed groups remain silent before routing or dispatch; sender-specific command authorization still returns an explicit denial.

This replaces the closed one-line attempt in #56741 and its unmodifiable external fork. @JuniperTheDev retains commit credit for the original policy-lookup diagnosis.

## User Impact

Operators can partition a Telegram forum across bot accounts without native commands waking every bot. An enabled sibling topic still processes the same command normally.

## Evidence

- Current `main` (`551f5ade33e`): `/status@bot` in a temporary topic with `groupPolicy: "disabled"` produced a native status reply in that topic; provider requests: 0.
- Candidate, disabled topic: the same command reached the gateway, recorded an intentional policy block, produced 0 bot replies, and made 0 provider requests.
- Candidate, enabled sibling topic: the same command produced one native status reply in the originating topic; provider requests: 0.

Redacted real-user transcript:

```text
disabled topic
QA user > /status@<bot>
SUT     > [no message]
gateway > Blocked telegram command (groupPolicy: disabled)
provider requests: 0

enabled sibling topic
QA user > /status@<bot>
SUT     > 🦞 OpenClaw 2026.8.1 …
gateway > telegram sendMessage ok
provider requests: 0
```

- Focused Telegram tests: 267/267 passed, covering topic/group/account precedence, silent scope rejection before dispatch, actor denial, and poll/send siblings.
- Changed gate: extension production/test typechecks, Oxlint, formatting, boundaries, and cycle checks passed ([run](https://github.com/openclaw/openclaw/actions/runs/31355774392)).
- Autoreview: clean; no accepted or actionable findings.
- LOC: production +18/-20 (net -2); tests/helpers +95/-15.
