### PR TITLE
fix: onboarding stalls or loses progress during interrupted setup

### DIFF
--- a/extensions/ollama/src/setup-model-selection.test.ts
+++ b/extensions/ollama/src/setup-model-selection.test.ts
@@ -1,11 +1,25 @@
-import { describe, expect, it } from "vitest";
+import { requestUrl } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildOllamaModelsConfig,
+  discoverOllamaModelsForSetup,
   findAvailableOllamaModelName,
   mergeUniqueModelNames,
   normalizeOllamaModelName,
   selectAppGuidedOllamaModelId,
 } from "./setup-model-selection.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function pendingAbortableResponse(signal: AbortSignal | null | undefined): Promise<Response> {
+  return new Promise<Response>((_resolve, reject) => {
+    signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), {
+      once: true,
+    });
+  });
+}
 
 describe("Ollama onboarding model selection", () => {
   it("preserves catalog order while preferring an explicit latest tag", () => {
@@ -65,5 +79,52 @@ describe("Ollama onboarding model selection", () => {
         { id: "gemma4:e4b", contextWindow: 8_192, supportsTools: true },
       ]),
     ).toBe("qwen3:0.6b");
+  });
+
+  it("aborts pending model discovery with the setup signal", async () => {
+    const controller = new AbortController();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: string | URL | Request, init?: RequestInit) =>
+        pendingAbortableResponse(init?.signal),
+      ),
+    );
+
+    const discovery = discoverOllamaModelsForSetup({
+      baseUrl: "http://127.0.0.1:11434",
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => {
+      expect(vi.mocked(fetch)).toHaveBeenCalledOnce();
+    });
+    controller.abort();
+
+    await expect(discovery).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("aborts pending context enrichment with the setup signal", async () => {
+    const controller = new AbortController();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        if (requestUrl(input).endsWith("/api/tags")) {
+          return new Response(JSON.stringify({ models: [{ name: "gemma4" }] }), {
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return pendingAbortableResponse(init?.signal);
+      }),
+    );
+
+    const discovery = discoverOllamaModelsForSetup({
+      baseUrl: "http://127.0.0.1:11434",
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => {
+      expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
+    });
+    controller.abort();
+
+    await expect(discovery).rejects.toMatchObject({ name: "AbortError" });
   });
 });

--- a/extensions/ollama/src/setup-model-selection.ts
+++ b/extensions/ollama/src/setup-model-selection.ts
@@ -158,7 +158,9 @@ export async function discoverOllamaModelsForSetup(params: {
   inspectTools?: boolean;
   signal?: AbortSignal;
 }) {
-  const { reachable, models } = await fetchOllamaModels(params.baseUrl);
+  const { reachable, models } = await fetchOllamaModels(params.baseUrl, {
+    signal: params.signal,
+  });
   const firstModels = models.slice(0, OLLAMA_CONTEXT_ENRICH_LIMIT);
   const inspection: { inspected: OllamaModelWithContext[]; inspectionFailures: string[] } =
     !reachable
@@ -166,7 +168,9 @@ export async function discoverOllamaModelsForSetup(params: {
       : params.inspectTools
         ? await inspectOllamaModelsForSetup(params.baseUrl, firstModels, params.signal)
         : {
-            inspected: await enrichOllamaModelsWithContext(params.baseUrl, firstModels),
+            inspected: await enrichOllamaModelsWithContext(params.baseUrl, firstModels, {
+              signal: params.signal,
+            }),
             inspectionFailures: [],
           };
   if (

--- a/extensions/ollama/src/setup.cancellation.test.ts
+++ b/extensions/ollama/src/setup.cancellation.test.ts
@@ -1,0 +1,61 @@
+import type { WizardPrompter } from "openclaw/plugin-sdk/setup";
+import { requestUrl } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { promptAndConfigureOllama } from "./setup.js";
+
+function createLocalPrompter(): WizardPrompter {
+  return {
+    select: vi.fn().mockResolvedValueOnce("local-only"),
+    text: vi.fn().mockResolvedValueOnce("http://127.0.0.1:11434"),
+    note: vi.fn(async () => undefined),
+  } as unknown as WizardPrompter;
+}
+
+function abortReasonAsError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new Error("Request aborted", { cause: signal.reason });
+}
+
+describe("Ollama setup cancellation", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("aborts pending model discovery with the setup session", async () => {
+    const controller = new AbortController();
+    let markTagsStarted!: () => void;
+    const tagsStarted = new Promise<void>((resolve) => {
+      markTagsStarted = resolve;
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        if (!requestUrl(input).endsWith("/api/tags")) {
+          throw new Error(`Unexpected fetch: ${requestUrl(input)}`);
+        }
+        markTagsStarted();
+        return await new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) {
+            reject(new Error("expected model discovery abort signal"));
+            return;
+          }
+          signal.addEventListener("abort", () => reject(abortReasonAsError(signal)), {
+            once: true,
+          });
+        });
+      }),
+    );
+
+    const setup = promptAndConfigureOllama({
+      cfg: {},
+      prompter: createLocalPrompter(),
+      signal: controller.signal,
+    });
+    await tagsStarted;
+    controller.abort();
+
+    await expect(setup).rejects.toMatchObject({ name: "AbortError" });
+  });
+});

--- a/src/commands/cleanup-command.test-support.ts
+++ b/src/commands/cleanup-command.test-support.ts
@@ -5,7 +5,7 @@ import type { MockFn } from "../test-utils/vitest-mock-fn.js";
 
 const resolveCleanupPlanFromDisk = vi.fn();
 const removePath = vi.fn();
-const listAgentSessionDirs = vi.fn();
+export const listAgentSessionDirs = vi.fn();
 export const prepareLegacyWorkspaceStateReset = vi.fn();
 export const removeLegacyWorkspaceStateForReset = vi.fn();
 export const removeStateAndLinkedPaths = vi.fn();

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -26,6 +26,7 @@ vi.mock("../agents/workspace-state-store.js", async () => ({
 
 import {
   buildCleanupPlan,
+  listAgentSessionDirs,
   removePath,
   removeStateAndLinkedPaths,
   removeWorkspaceDirs,
@@ -336,6 +337,20 @@ describe("cleanup path removals", () => {
     } finally {
       cwdSpy.mockRestore();
       await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("listAgentSessionDirs", () => {
+  it("treats a missing agents root as empty but propagates inspection failures", async () => {
+    await expect(listAgentSessionDirs("/tmp/openclaw-missing-state")).resolves.toEqual([]);
+
+    const error = Object.assign(new Error("permission denied"), { code: "EACCES" });
+    const readdir = vi.spyOn(fs, "readdir").mockRejectedValueOnce(error);
+    try {
+      await expect(listAgentSessionDirs("/tmp/openclaw-unreadable-state")).rejects.toBe(error);
+    } finally {
+      readdir.mockRestore();
     }
   });
 });

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -302,6 +302,22 @@ describe("cleanup path removals", () => {
     expect(workspaceStateMocks.deleteWorkspaceState).not.toHaveBeenCalled();
   });
 
+  it("continues after an injected workspace remover rejects", async () => {
+    const runtime = createRuntimeMock();
+    const removeWorkspace = vi
+      .fn<(workspace: string) => Promise<boolean>>()
+      .mockRejectedValueOnce(new Error("trash unavailable"))
+      .mockResolvedValueOnce(true);
+
+    const failures = await removeWorkspaceDirs(["/tmp/first", "/tmp/second"], runtime, {
+      removeWorkspace,
+    });
+
+    expect(removeWorkspace).toHaveBeenCalledTimes(2);
+    expect(failures).toEqual(["/tmp/first"]);
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("trash unavailable"));
+  });
+
   it("refuses to remove the current working directory", async () => {
     const runtime = createRuntimeMock();
     const result = await removePath(process.cwd(), runtime, { dryRun: true });

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -236,46 +236,61 @@ export async function removeStateAndLinkedPaths(
 export async function removeWorkspaceDirs(
   workspaceDirs: readonly string[],
   runtime: RuntimeEnv,
-  opts?: { dryRun?: boolean; removeStateRows?: boolean },
-): Promise<void> {
-  for (const workspace of workspaceDirs) {
-    const legacyPlan = prepareLegacyWorkspaceStateReset(workspace);
-    const statePlan = opts?.removeStateRows ? prepareWorkspaceStateDeletion(workspace) : undefined;
-    const result = await removePath(workspace, runtime, {
-      dryRun: opts?.dryRun,
-      label: workspace,
-    });
-    if (opts?.dryRun) {
-      if (!result.ok) {
-        continue;
-      }
-      const legacyCleanup = await removeLegacyWorkspaceStateForReset(legacyPlan, { dryRun: true });
-      for (const removedPath of legacyCleanup.removedPaths) {
-        runtime.log(`[dry-run] remove ${shortenHomeInString(removedPath)}`);
-      }
-      for (const warning of legacyCleanup.warnings) {
-        runtime.error(warning);
-      }
-      continue;
-    }
-    if (!result.ok || result.skipped) {
-      continue;
-    }
+  opts?: {
+    dryRun?: boolean;
+    removeStateRows?: boolean;
+    removeWorkspace?: (workspace: string) => Promise<boolean>;
+  },
+): Promise<string[]> {
+  const failures = new Set<string>();
+  const attempt = async <T>(label: string, action: () => T | Promise<T>) => {
     try {
-      const legacyCleanup = await removeLegacyWorkspaceStateForReset(legacyPlan);
-      for (const warning of legacyCleanup.warnings) {
-        runtime.error(warning);
-      }
-      if (!opts?.removeStateRows) {
-        continue;
-      }
-      deleteWorkspaceState(statePlan!);
+      return await action();
     } catch (error) {
-      runtime.error(
-        `Failed to remove workspace state for ${shortenHomeInString(workspace)}: ${String(error)}`,
+      failures.add(label);
+      runtime.error?.(`Failed to clean up ${shortenHomeInString(label)}: ${String(error)}`);
+      return undefined;
+    }
+  };
+  for (const workspace of workspaceDirs) {
+    const legacyLabel = `${workspace} (retired workspace state)`;
+    const stateLabel = `${workspace} (workspace state)`;
+    const legacyPlan = await attempt(legacyLabel, () =>
+      prepareLegacyWorkspaceStateReset(workspace),
+    );
+    const statePlan = opts?.removeStateRows
+      ? await attempt(stateLabel, () => prepareWorkspaceStateDeletion(workspace))
+      : undefined;
+    const result = opts?.removeWorkspace
+      ? { ok: (await attempt(workspace, () => opts.removeWorkspace!(workspace))) === true }
+      : await removePath(workspace, runtime, { dryRun: opts?.dryRun, label: workspace });
+    if (!result.ok) {
+      failures.add(workspace);
+      continue;
+    }
+    if (legacyPlan) {
+      const legacyCleanup = await attempt(legacyLabel, () =>
+        removeLegacyWorkspaceStateForReset(legacyPlan, opts?.dryRun ? { dryRun: true } : undefined),
       );
+      if (legacyCleanup) {
+        if (opts?.dryRun) {
+          for (const removedPath of legacyCleanup.removedPaths) {
+            runtime.log(`[dry-run] remove ${shortenHomeInString(removedPath)}`);
+          }
+        }
+        for (const warning of legacyCleanup.warnings) {
+          (opts?.removeWorkspace ? runtime.log : runtime.error)(warning);
+          failures.add(warning);
+        }
+      }
+    }
+    if (!opts?.dryRun && statePlan) {
+      await attempt(stateLabel, () => {
+        deleteWorkspaceState(statePlan);
+      });
     }
   }
+  return [...failures];
 }
 
 /** List per-agent session directories beneath a state directory. */

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -286,7 +286,10 @@ export async function listAgentSessionDirs(stateDir: string): Promise<string[]> 
     return entries
       .filter((entry) => entry.isDirectory())
       .map((entry) => path.join(root, entry.name, "sessions"));
-  } catch {
-    return [];
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
   }
 }

--- a/src/commands/configure.wizard.default-agent.test.ts
+++ b/src/commands/configure.wizard.default-agent.test.ts
@@ -30,6 +30,18 @@ vi.mock("../config/logging.js", () => ({ logConfigUpdated: vi.fn() }));
 
 vi.mock("../plugins/install-record-commit.js", () => ({
   commitConfigWithPendingPluginInstalls: mocks.commitConfig,
+  transformConfigWithPendingPluginInstalls: async (params: {
+    transform: (config: OpenClawConfig) => { nextConfig: OpenClawConfig };
+    writeOptions?: Record<string, unknown>;
+  }) => {
+    const snapshot = mocks.state.snapshot as {
+      sourceConfig?: OpenClawConfig;
+      config: OpenClawConfig;
+    };
+    const nextConfig = params.transform(snapshot.sourceConfig ?? snapshot.config).nextConfig;
+    const committed = await mocks.commitConfig({ nextConfig, writeOptions: params.writeOptions });
+    return { nextConfig: committed.config };
+  },
 }));
 
 vi.mock("../wizard/clack-prompter.js", () => ({

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -85,6 +85,40 @@ vi.mock("../config/config.js", () => ({
       ownedConfigPathForWrite: "/tmp/openclaw.json",
     },
   }),
+  resolveConfigWriteAfterWrite: (afterWrite?: { mode: string }) => afterWrite ?? { mode: "auto" },
+  transformConfigFileWithRetry: async (
+    params: Parameters<typeof import("../config/config.js").transformConfigFileWithRetry>[0],
+  ) => {
+    const maxAttempts = params.maxAttempts ?? 5;
+    for (let attempt = 0; ; attempt += 1) {
+      const snapshot = await mocks.readConfigFileSnapshot();
+      const previousHash = snapshot.hash ?? null;
+      const config =
+        params.base === "runtime"
+          ? (snapshot.runtimeConfig ?? snapshot.config)
+          : (snapshot.sourceConfig ?? snapshot.config);
+      try {
+        const transformed = await params.transform(config, { snapshot, previousHash, attempt });
+        const committed = await params.commit!({
+          nextConfig: transformed.nextConfig,
+          snapshot,
+          ...(previousHash ? { baseHash: previousHash } : {}),
+          writeOptions: params.writeOptions,
+          afterWrite: { mode: "auto" },
+        });
+        return { nextConfig: committed.config };
+      } catch (error) {
+        if (
+          !(error instanceof Error) ||
+          error.name !== "ConfigMutationConflictError" ||
+          (error as { retryable?: boolean }).retryable === false ||
+          attempt === maxAttempts - 1
+        ) {
+          throw error;
+        }
+      }
+    }
+  },
   writeConfigFile: mocks.writeConfigFile,
   replaceConfigFile: mocks.replaceConfigFile,
   resolveGatewayPort: mocks.resolveGatewayPort,
@@ -962,7 +996,6 @@ describe("runConfigureWizard", () => {
     let callCount = 0;
     const originalHash = "hash-before-plugin-mutation";
     const newHashAfterMutation = "hash-after-plugin-mutation";
-    const finalHashAfterWrite = "hash-after-wizard-write";
 
     mocks.replaceConfigFile.mockImplementation(
       async (params: { nextConfig: unknown; baseHash?: string }) => {
@@ -982,6 +1015,12 @@ describe("runConfigureWizard", () => {
 
     // Mock readConfigFileSnapshot to return different hashes/configs on each call
     mocks.readConfigFileSnapshot
+      .mockResolvedValueOnce({
+        ...EMPTY_CONFIG_SNAPSHOT,
+        hash: originalHash,
+        config: baseConfig,
+        sourceConfig: baseConfig,
+      })
       .mockResolvedValueOnce({
         ...EMPTY_CONFIG_SNAPSHOT,
         hash: originalHash,
@@ -1018,11 +1057,6 @@ describe("runConfigureWizard", () => {
           },
         },
         valid: true,
-      })
-      .mockResolvedValueOnce({
-        ...EMPTY_CONFIG_SNAPSHOT,
-        hash: finalHashAfterWrite,
-        config: {},
       });
 
     await runConfigureWizard({ command: "configure", sections: ["workspace"] }, createRuntime());
@@ -1074,6 +1108,6 @@ describe("runConfigureWizard", () => {
     ).rejects.toThrow("config path changed since last load");
 
     expect(mocks.replaceConfigFile).toHaveBeenCalledTimes(1);
-    expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(1);
+    expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -7,13 +7,8 @@ import { describeCodexNativeWebSearch } from "../agents/codex-native-web-search.
 import { formatCliCommand } from "../cli/command-format.js";
 import { formatPortRangeHint } from "../cli/error-format.js";
 import { parsePort } from "../cli/shared/parse-port.js";
-import {
-  createConfigIO,
-  readConfigFileSnapshotForWrite,
-  resolveGatewayPort,
-} from "../config/config.js";
+import { readConfigFileSnapshotForWrite, resolveGatewayPort } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
-import { ConfigMutationConflictError } from "../config/mutate.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatWindowsGatewayFirewallGuidance } from "../infra/windows-gateway-firewall-diagnostics.js";
 import { commitConfigWithPendingPluginInstalls } from "../plugins/install-record-commit.js";
@@ -25,7 +20,7 @@ import { resolveUserPath } from "../utils.js";
 import { createClackPrompter } from "../wizard/clack-prompter.js";
 import { WizardCancelledError } from "../wizard/prompts.js";
 import { resolveSetupSecretInputString } from "../wizard/setup.secret-input.js";
-import { mergeWizardConfigOntoLatest } from "../wizard/setup.shared.js";
+import { writeWizardConfigFile } from "../wizard/setup.shared.js";
 import { removeChannelConfigWizard } from "./configure.channels.js";
 import { maybeInstallDaemon } from "./configure.daemon.js";
 import { promptAuthConfig } from "./configure.gateway-auth.js";
@@ -405,13 +400,7 @@ export async function runConfigureWizard(
       expectedConfigPath: prepared.writeOptions.expectedConfigPath,
       ownedConfigPathForWrite: prepared.writeOptions.ownedConfigPathForWrite,
     };
-    const readOwnedConfigSnapshot = async () =>
-      (
-        await createConfigIO({
-          configPath: configWriteOwnership.ownedConfigPathForWrite,
-        }).readConfigFileSnapshotForWrite()
-      ).snapshot;
-    let currentBaseHash = snapshot.hash;
+    const currentBaseHash = snapshot.hash;
     const baseConfig: OpenClawConfig = snapshot.valid
       ? (snapshot.sourceConfig ?? snapshot.config)
       : {};
@@ -528,7 +517,6 @@ export async function runConfigureWizard(
         writeOptions: configWriteOwnership,
       });
       remoteConfig = committed.config;
-      currentBaseHash = undefined;
       logConfigUpdated(runtime);
       outro("Remote gateway configured.");
       return;
@@ -557,44 +545,12 @@ export async function runConfigureWizard(
         mode: metadataMode,
       });
 
-      // Retry loop: if config was mutated by a plugin, re-read and merge before retry
-      const maxRetries = 3;
-      for (let attempt = 0; attempt < maxRetries; attempt++) {
-        try {
-          const committed = await commitConfigWithPendingPluginInstalls({
-            nextConfig,
-            ...(currentBaseHash !== undefined ? { baseHash: currentBaseHash } : {}),
-            writeOptions: configWriteOwnership,
-          });
-          nextConfig = committed.config;
-
-          // After successful write, re-read the snapshot to get the new hash
-          const freshSnapshot = await readOwnedConfigSnapshot();
-          currentBaseHash = freshSnapshot.hash ?? undefined;
-          mergeBaseConfig = structuredClone(nextConfig);
-
-          logConfigUpdated(runtime);
-          return;
-        } catch (err) {
-          if (
-            err instanceof ConfigMutationConflictError &&
-            err.retryable &&
-            attempt < maxRetries - 1
-          ) {
-            // Config was mutated externally (e.g. plugin wrote token during auth setup).
-            // Re-read the on-disk config and merge plugin changes into nextConfig so
-            // the retry won't silently overwrite them.
-            const freshSnapshot = await readOwnedConfigSnapshot();
-            currentBaseHash = freshSnapshot.hash ?? undefined;
-            const diskConfig = freshSnapshot.valid
-              ? (freshSnapshot.sourceConfig ?? freshSnapshot.config)
-              : {};
-            nextConfig = mergeWizardConfigOntoLatest(diskConfig, mergeBaseConfig, nextConfig);
-            continue;
-          }
-          throw err;
-        }
-      }
+      nextConfig = await writeWizardConfigFile(nextConfig, {
+        mergeBase: mergeBaseConfig,
+        writeOptions: configWriteOwnership,
+      });
+      mergeBaseConfig = structuredClone(nextConfig);
+      logConfigUpdated(runtime);
     };
 
     const configureWorkspace = async () => {

--- a/src/commands/onboard-guided.ts
+++ b/src/commands/onboard-guided.ts
@@ -638,24 +638,11 @@ async function runGuidedOnboardingFlow(
     });
     const recommendedConfig = recommendationOutcome.config;
     if (recommendedConfig !== persistedConfig) {
-      const latestSnapshot = await readConfigFileSnapshot();
-      if (!latestSnapshot.valid) {
-        throw new Error("App recommendations could not update an invalid OpenClaw config.");
-      }
-      const latestConfig = latestSnapshot.sourceConfig ?? latestSnapshot.config;
-      const { mergeWizardConfigOntoLatest, writeWizardConfigFile } =
-        await import("../wizard/setup.shared.js");
-      const mergedConfig = mergeWizardConfigOntoLatest(
-        latestConfig,
-        persistedConfig,
-        recommendedConfig,
-      );
-      await writeWizardConfigFile(mergedConfig, {
+      const { writeWizardConfigFile } = await import("../wizard/setup.shared.js");
+      persistedConfig = await writeWizardConfigFile(recommendedConfig, {
         allowConfigSizeDrop: false,
-        ...(latestSnapshot.hash ? { baseHash: latestSnapshot.hash } : {}),
-        migrationBaseConfig: latestConfig,
+        mergeBase: persistedConfig,
       });
-      persistedConfig = mergedConfig;
     }
     recommendationOutcome.commitResult();
   }

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -93,6 +93,13 @@ const mocks = vi.hoisted(() => ({
   probeGateway: vi.fn(),
   deleteWorkspaceState: vi.fn(),
   prepareWorkspaceStateDeletion: vi.fn((workspaceDir: string) => ({ workspaceDir })),
+  prepareLegacyWorkspaceStateReset: vi.fn(() => ({ candidates: [] })),
+  removeLegacyWorkspaceStateForReset: vi.fn(
+    async (): Promise<{ removedPaths: string[]; warnings: string[] }> => ({
+      removedPaths: [],
+      warnings: [],
+    }),
+  ),
 }));
 
 vi.mock("../infra/fs-safe.js", async (importOriginal) => ({
@@ -124,8 +131,18 @@ vi.mock("../agents/workspace-state-store.js", async () => ({
   prepareWorkspaceStateDeletion: mocks.prepareWorkspaceStateDeletion,
 }));
 
+vi.mock("../agents/workspace-legacy-state.js", async () => ({
+  ...(await vi.importActual<typeof import("../agents/workspace-legacy-state.js")>(
+    "../agents/workspace-legacy-state.js",
+  )),
+  prepareLegacyWorkspaceStateReset: mocks.prepareLegacyWorkspaceStateReset,
+  removeLegacyWorkspaceStateForReset: mocks.removeLegacyWorkspaceStateForReset,
+}));
+
 afterEach(() => {
   vi.clearAllMocks();
+  mocks.movePathToTrash.mockReset();
+  mocks.movePathToTrash.mockImplementation(async (targetPath: string) => `${targetPath}.trashed`);
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
 });
@@ -235,6 +252,200 @@ describe("handleReset", () => {
     expect(mocks.deleteWorkspaceState).toHaveBeenCalledWith({ workspaceDir });
   });
 
+  it("rejects a config-only reset when the existing config cannot be trashed", async () => {
+    const homeDir = tempDirs.make("openclaw-reset-config-failure-");
+    const configPath = path.join(homeDir, "openclaw.json");
+    fs.writeFileSync(configPath, "{}\n");
+    mocks.movePathToTrash.mockRejectedValueOnce(new Error("trash unavailable"));
+    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+
+    await withEnvAsync(
+      { HOME: homeDir, OPENCLAW_HOME: homeDir, OPENCLAW_CONFIG_PATH: configPath },
+      async () => {
+        await expect(handleReset("config", "unused", runtime)).rejects.toThrow(configPath);
+      },
+    );
+
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringMatching(/Failed to move to Trash \(manual delete\): .*openclaw\.json$/),
+    );
+  });
+
+  it("reports config, credentials, and session failures together", async () => {
+    const homeDir = tempDirs.make("openclaw-reset-state-failures-");
+    const stateDir = path.join(homeDir, ".openclaw");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const credentialsDir = path.join(stateDir, "credentials");
+    const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
+    fs.mkdirSync(credentialsDir, { recursive: true });
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    fs.writeFileSync(configPath, "{}\n");
+    mocks.movePathToTrash.mockRejectedValue(new Error("trash unavailable"));
+    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+
+    await withEnvAsync(
+      {
+        HOME: homeDir,
+        OPENCLAW_HOME: homeDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: configPath,
+      },
+      async () => {
+        await expect(handleReset("config+creds+sessions", "unused", runtime)).rejects.toThrow(
+          new RegExp(
+            [configPath, credentialsDir, sessionsDir]
+              .map((targetPath) => targetPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+              .join("[\\s\\S]*"),
+          ),
+        );
+      },
+    );
+  });
+
+  it("fails closed on unreadable session state but still removes a selected workspace", async () => {
+    const homeDir = tempDirs.make("openclaw-reset-session-enumeration-");
+    const stateDir = path.join(homeDir, ".openclaw");
+    const workspaceDir = path.join(stateDir, "workspace");
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    const inspectError = Object.assign(new Error("permission denied"), { code: "EACCES" });
+    const readdir = vi.spyOn(fsPromises, "readdir").mockRejectedValueOnce(inspectError);
+    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+
+    try {
+      await withEnvAsync(
+        {
+          HOME: homeDir,
+          OPENCLAW_HOME: homeDir,
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+        },
+        async () => {
+          await expect(handleReset("full", workspaceDir, runtime)).rejects.toThrow(
+            path.join(stateDir, "agents"),
+          );
+        },
+      );
+    } finally {
+      readdir.mockRestore();
+    }
+
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith(expectedTrashSourcePath(workspaceDir), {
+      allowedRoots: [path.dirname(expectedTrashSourcePath(workspaceDir))],
+    });
+    expect(mocks.deleteWorkspaceState).toHaveBeenCalledWith({ workspaceDir });
+  });
+
+  it("attempts workspace removal even when state deletion planning fails", async () => {
+    const homeDir = tempDirs.make("openclaw-reset-workspace-plan-");
+    const stateDir = path.join(homeDir, ".openclaw");
+    const workspaceDir = path.join(stateDir, "workspace");
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    mocks.prepareWorkspaceStateDeletion.mockImplementationOnce(() => {
+      throw new Error("workspace state unavailable");
+    });
+
+    await withEnvAsync(
+      {
+        HOME: homeDir,
+        OPENCLAW_HOME: homeDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+      },
+      async () => {
+        await expect(
+          handleReset("full", workspaceDir, { log: vi.fn() } as unknown as RuntimeEnv),
+        ).rejects.toThrow(`${workspaceDir} (workspace state)`);
+      },
+    );
+
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith(expectedTrashSourcePath(workspaceDir), {
+      allowedRoots: [path.dirname(expectedTrashSourcePath(workspaceDir))],
+    });
+    expect(mocks.deleteWorkspaceState).not.toHaveBeenCalled();
+  });
+
+  it("fails closed after attempting workspace state cleanup when retired state remains", async () => {
+    const homeDir = tempDirs.make("openclaw-reset-retired-state-");
+    const stateDir = path.join(homeDir, ".openclaw");
+    const workspaceDir = path.join(stateDir, "workspace");
+    const warning = `Could not remove retired workspace state at ${workspaceDir}.attested`;
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    mocks.removeLegacyWorkspaceStateForReset.mockResolvedValueOnce({
+      removedPaths: [],
+      warnings: [warning],
+    });
+    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+
+    await withEnvAsync(
+      {
+        HOME: homeDir,
+        OPENCLAW_HOME: homeDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+      },
+      async () => {
+        await expect(handleReset("full", workspaceDir, runtime)).rejects.toThrow(warning);
+      },
+    );
+
+    expect(mocks.deleteWorkspaceState).toHaveBeenCalledWith({ workspaceDir });
+    expect(runtime.log).toHaveBeenCalledWith(warning);
+  });
+
+  it("reports rejected retired and workspace state cleanup after attempting both", async () => {
+    const homeDir = tempDirs.make("openclaw-reset-state-cleanup-rejections-");
+    const stateDir = path.join(homeDir, ".openclaw");
+    const workspaceDir = path.join(stateDir, "workspace");
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    mocks.removeLegacyWorkspaceStateForReset.mockRejectedValueOnce(
+      new Error("retired state unavailable"),
+    );
+    mocks.deleteWorkspaceState.mockImplementationOnce(() => {
+      throw new Error("state database unavailable");
+    });
+
+    const reset = withEnvAsync(
+      {
+        HOME: homeDir,
+        OPENCLAW_HOME: homeDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+      },
+      async () =>
+        await handleReset("full", workspaceDir, {
+          log: vi.fn(),
+        } as unknown as RuntimeEnv),
+    );
+
+    await expect(reset).rejects.toThrow(`${workspaceDir} (retired workspace state)`);
+    await expect(reset).rejects.toThrow(`${workspaceDir} (workspace state)`);
+    expect(mocks.deleteWorkspaceState).toHaveBeenCalledWith({ workspaceDir });
+  });
+
+  it("reports a workspace state deletion failure after trash succeeds", async () => {
+    const homeDir = tempDirs.make("openclaw-reset-state-delete-");
+    const stateDir = path.join(homeDir, ".openclaw");
+    const workspaceDir = path.join(stateDir, "workspace");
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    mocks.deleteWorkspaceState.mockImplementationOnce(() => {
+      throw new Error("state database unavailable");
+    });
+
+    await withEnvAsync(
+      {
+        HOME: homeDir,
+        OPENCLAW_HOME: homeDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+      },
+      async () => {
+        await expect(
+          handleReset("full", workspaceDir, { log: vi.fn() } as unknown as RuntimeEnv),
+        ).rejects.toThrow(`${workspaceDir} (workspace state)`);
+      },
+    );
+  });
+
   it("retains workspace state when workspace removal fails", async () => {
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-reset-profile-"));
     const profileStateDir = path.join(homeDir, ".openclaw-work");
@@ -264,13 +475,18 @@ describe("handleReset", () => {
           OPENCLAW_STATE_DIR: profileStateDir,
           OPENCLAW_CONFIG_PATH: profileConfigPath,
         },
-        async () => await handleReset("full", workspaceDir, runtime),
+        async () => {
+          await expect(handleReset("full", workspaceDir, runtime)).rejects.toThrow(workspaceDir);
+        },
       );
     } finally {
       fs.rmSync(homeDir, { recursive: true, force: true });
     }
 
     expect(mocks.deleteWorkspaceState).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringMatching(/Failed to move to Trash \(manual delete\): .*workspace$/),
+    );
   });
 });
 

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -302,13 +302,14 @@ describe("handleReset", () => {
     );
   });
 
-  it("fails closed on unreadable session state but still removes a selected workspace", async () => {
+  it("deduplicates unreadable session state while still attempting workspace removal", async () => {
     const homeDir = tempDirs.make("openclaw-reset-session-enumeration-");
     const stateDir = path.join(homeDir, ".openclaw");
-    const workspaceDir = path.join(stateDir, "workspace");
+    const workspaceDir = path.join(stateDir, "agents");
     fs.mkdirSync(workspaceDir, { recursive: true });
     const inspectError = Object.assign(new Error("permission denied"), { code: "EACCES" });
     const readdir = vi.spyOn(fsPromises, "readdir").mockRejectedValueOnce(inspectError);
+    mocks.movePathToTrash.mockRejectedValueOnce(new Error("trash unavailable"));
     const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
 
     try {
@@ -320,8 +321,11 @@ describe("handleReset", () => {
           OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
         },
         async () => {
-          await expect(handleReset("full", workspaceDir, runtime)).rejects.toThrow(
-            path.join(stateDir, "agents"),
+          const failure = await handleReset("full", workspaceDir, runtime).catch(
+            (error: unknown) => error,
+          );
+          expect(failure).toEqual(
+            new Error(`Reset failed to remove required state:\n${workspaceDir}`),
           );
         },
       );
@@ -332,7 +336,7 @@ describe("handleReset", () => {
     expect(mocks.movePathToTrash).toHaveBeenCalledWith(expectedTrashSourcePath(workspaceDir), {
       allowedRoots: [path.dirname(expectedTrashSourcePath(workspaceDir))],
     });
-    expect(mocks.deleteWorkspaceState).toHaveBeenCalledWith({ workspaceDir });
+    expect(mocks.deleteWorkspaceState).not.toHaveBeenCalled();
   });
 
   it("attempts workspace removal even when state deletion planning fails", async () => {

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -13,14 +13,6 @@ import {
 } from "../../packages/gateway-protocol/src/connect-error-details.js";
 import { stylePromptTitle } from "../../packages/terminal-core/src/prompt-style.js";
 import { resolveAgentEffectiveModelPrimary, resolveDefaultAgentId } from "../agents/agent-scope.js";
-import {
-  prepareLegacyWorkspaceStateReset,
-  removeLegacyWorkspaceStateForReset,
-} from "../agents/workspace-legacy-state.js";
-import {
-  deleteWorkspaceState,
-  prepareWorkspaceStateDeletion,
-} from "../agents/workspace-state-store.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../agents/workspace.js";
 import { printClawBanner } from "../cli/claw-banner.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
@@ -50,7 +42,7 @@ import {
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveConfigDir, shortenHomeInString, shortenHomePath, sleep } from "../utils.js";
 import { VERSION } from "../version.js";
-import { listAgentSessionDirs } from "./cleanup-utils.js";
+import { listAgentSessionDirs, removeWorkspaceDirs } from "./cleanup-utils.js";
 import type { OnboardMode, ResetScope } from "./onboard-types.js";
 export { randomToken } from "./random-token.js";
 
@@ -359,41 +351,12 @@ export async function handleReset(scope: ResetScope, workspaceDir: string, runti
     failures.push(path.join(stateDir, "agents"));
   }
   if (scope === "full") {
-    let legacyPlan: ReturnType<typeof prepareLegacyWorkspaceStateReset> | undefined;
-    let statePlan: ReturnType<typeof prepareWorkspaceStateDeletion> | undefined;
-    try {
-      legacyPlan = prepareLegacyWorkspaceStateReset(workspaceDir);
-    } catch {
-      failures.push(`${workspaceDir} (retired workspace state)`);
-    }
-    try {
-      statePlan = prepareWorkspaceStateDeletion(workspaceDir);
-    } catch {
-      failures.push(`${workspaceDir} (workspace state)`);
-    }
-    const workspaceRemoved = await moveToTrash(workspaceDir, runtime);
-    if (workspaceRemoved) {
-      if (legacyPlan) {
-        try {
-          const legacyCleanup = await removeLegacyWorkspaceStateForReset(legacyPlan);
-          for (const warning of legacyCleanup.warnings) {
-            runtime.log(warning);
-            failures.push(warning);
-          }
-        } catch {
-          failures.push(`${workspaceDir} (retired workspace state)`);
-        }
-      }
-      if (statePlan) {
-        try {
-          deleteWorkspaceState(statePlan);
-        } catch {
-          failures.push(`${workspaceDir} (workspace state)`);
-        }
-      }
-    } else {
-      failures.push(workspaceDir);
-    }
+    failures.push(
+      ...(await removeWorkspaceDirs([workspaceDir], runtime, {
+        removeStateRows: true,
+        removeWorkspace: (workspace) => moveToTrash(workspace, runtime),
+      })),
+    );
   }
   throwIfResetFailed(failures);
 }

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -362,8 +362,9 @@ export async function handleReset(scope: ResetScope, workspaceDir: string, runti
 }
 
 function throwIfResetFailed(failures: string[]): void {
-  if (failures.length > 0) {
-    throw new Error(`Reset failed to remove required state:\n${failures.join("\n")}`);
+  const uniqueFailures = [...new Set(failures)];
+  if (uniqueFailures.length > 0) {
+    throw new Error(`Reset failed to remove required state:\n${uniqueFailures.join("\n")}`);
   }
 }
 

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -336,26 +336,71 @@ export async function handleReset(scope: ResetScope, workspaceDir: string, runti
     // no partial destructive effects and cannot discard its own lock sidecar.
     await assertFullResetPreservesOnboardingLock(workspaceDir);
   }
-  await moveToTrash(resolveConfigPath(), runtime);
+  const failures: string[] = [];
+  const trashRequiredPath = async (targetPath: string) => {
+    if (!(await moveToTrash(targetPath, runtime))) {
+      failures.push(targetPath);
+    }
+  };
+
+  await trashRequiredPath(resolveConfigPath());
   if (scope === "config") {
+    throwIfResetFailed(failures);
     return;
   }
-  await moveToTrash(path.join(resolveConfigDir(), "credentials"), runtime);
-  const sessionDirs = await listAgentSessionDirs(resolveStateDir());
-  for (const sessionDir of sessionDirs) {
-    await moveToTrash(sessionDir, runtime);
+  await trashRequiredPath(path.join(resolveConfigDir(), "credentials"));
+  const stateDir = resolveStateDir();
+  try {
+    const sessionDirs = await listAgentSessionDirs(stateDir);
+    for (const sessionDir of sessionDirs) {
+      await trashRequiredPath(sessionDir);
+    }
+  } catch {
+    failures.push(path.join(stateDir, "agents"));
   }
   if (scope === "full") {
-    const legacyPlan = prepareLegacyWorkspaceStateReset(workspaceDir);
-    const statePlan = prepareWorkspaceStateDeletion(workspaceDir);
+    let legacyPlan: ReturnType<typeof prepareLegacyWorkspaceStateReset> | undefined;
+    let statePlan: ReturnType<typeof prepareWorkspaceStateDeletion> | undefined;
+    try {
+      legacyPlan = prepareLegacyWorkspaceStateReset(workspaceDir);
+    } catch {
+      failures.push(`${workspaceDir} (retired workspace state)`);
+    }
+    try {
+      statePlan = prepareWorkspaceStateDeletion(workspaceDir);
+    } catch {
+      failures.push(`${workspaceDir} (workspace state)`);
+    }
     const workspaceRemoved = await moveToTrash(workspaceDir, runtime);
     if (workspaceRemoved) {
-      const legacyCleanup = await removeLegacyWorkspaceStateForReset(legacyPlan);
-      for (const warning of legacyCleanup.warnings) {
-        runtime.log(warning);
+      if (legacyPlan) {
+        try {
+          const legacyCleanup = await removeLegacyWorkspaceStateForReset(legacyPlan);
+          for (const warning of legacyCleanup.warnings) {
+            runtime.log(warning);
+            failures.push(warning);
+          }
+        } catch {
+          failures.push(`${workspaceDir} (retired workspace state)`);
+        }
       }
-      deleteWorkspaceState(statePlan);
+      if (statePlan) {
+        try {
+          deleteWorkspaceState(statePlan);
+        } catch {
+          failures.push(`${workspaceDir} (workspace state)`);
+        }
+      }
+    } else {
+      failures.push(workspaceDir);
     }
+  }
+  throwIfResetFailed(failures);
+}
+
+function throwIfResetFailed(failures: string[]): void {
+  if (failures.length > 0) {
+    throw new Error(`Reset failed to remove required state:\n${failures.join("\n")}`);
   }
 }
 

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
@@ -15,7 +15,7 @@ import type { installGatewayDaemonNonInteractive } from "./onboard-non-interacti
 
 const ensureWorkspaceAndSessionsMock = vi.fn(async (..._args: unknown[]) => {});
 const testConfigStore = new Map<string, OpenClawConfig>();
-const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
+const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn<() => Promise<ConfigFileSnapshot>>());
 const pluginLifecycleLeaseState = vi.hoisted(() => ({ depth: 0 }));
 const configWritePluginLeaseDepths: number[] = [];
 type InstallGatewayDaemonResult = Awaited<ReturnType<typeof installGatewayDaemonNonInteractive>>;
@@ -55,35 +55,33 @@ function readTestConfig<T = OpenClawConfig>(): T {
   return (testConfigStore.get(resolveTestConfigPath()) ?? {}) as T;
 }
 
-readConfigFileSnapshotMock.mockImplementation(async () => {
-  const configPath = resolveTestConfigPath();
-  const config = testConfigStore.get(configPath);
-  if (config) {
-    const raw = `${JSON.stringify(config, null, 2)}\n`;
-    return {
-      exists: true,
-      valid: true,
-      config,
-      sourceConfig: config,
-      raw,
-      hash: "test-config-hash",
-    };
-  }
+function readTestConfigSnapshot(): ConfigFileSnapshot {
+  const config = testConfigStore.get(resolveTestConfigPath()) ?? {};
+  const exists = testConfigStore.has(resolveTestConfigPath());
   return {
-    exists: false,
+    path: resolveTestConfigPath(),
+    exists,
+    raw: exists ? `${JSON.stringify(config, null, 2)}\n` : null,
+    parsed: config,
+    sourceConfig: config,
+    resolved: config,
     valid: true,
-    config: {},
-    sourceConfig: {},
-    raw: null,
-    hash: undefined,
+    runtimeConfig: config,
+    config,
+    ...(exists ? { hash: "test-config-hash" } : {}),
+    issues: [],
+    warnings: [],
+    legacyIssues: [],
   };
-});
+}
+
+readConfigFileSnapshotMock.mockImplementation(async () => readTestConfigSnapshot());
 
 vi.mock("../config/io.js", () => ({
   createConfigIO: () => ({
     configPath: resolveTestConfigPath(),
   }),
-  loadConfig: () => testConfigStore.get(resolveTestConfigPath()) ?? {},
+  loadConfig: () => readTestConfig(),
   readConfigFileSnapshot: readConfigFileSnapshotMock,
 }));
 
@@ -116,20 +114,46 @@ const capturedReplaceConfigFileCalls: Array<{
   writeOptions?: { allowConfigSizeDrop?: boolean; unsetPaths?: string[][] };
 }> = [];
 
-vi.mock("../config/config.js", () => ({
-  replaceConfigFile: async ({
-    nextConfig,
-    writeOptions,
-  }: {
-    nextConfig: OpenClawConfig;
-    writeOptions?: { allowConfigSizeDrop?: boolean; unsetPaths?: string[][] };
-  }) => {
-    configWritePluginLeaseDepths.push(pluginLifecycleLeaseState.depth);
-    capturedReplaceConfigFileCalls.push({ nextConfig, ...(writeOptions ? { writeOptions } : {}) });
-    testConfigStore.set(resolveTestConfigPath(), nextConfig);
-  },
-  resolveGatewayPort: (cfg: OpenClawConfig) => cfg.gateway?.port ?? 18789,
-}));
+vi.mock("../config/config.js", async (importActual) => {
+  const actual = await importActual<typeof import("../config/config.js")>();
+  return {
+    replaceConfigFile: async ({
+      nextConfig,
+      writeOptions,
+    }: {
+      nextConfig: OpenClawConfig;
+      writeOptions?: { allowConfigSizeDrop?: boolean; unsetPaths?: string[][] };
+    }) => {
+      configWritePluginLeaseDepths.push(pluginLifecycleLeaseState.depth);
+      capturedReplaceConfigFileCalls.push({
+        nextConfig,
+        ...(writeOptions ? { writeOptions } : {}),
+      });
+      testConfigStore.set(resolveTestConfigPath(), nextConfig);
+    },
+    resolveConfigWriteAfterWrite: actual.resolveConfigWriteAfterWrite,
+    resolveGatewayPort: (cfg: OpenClawConfig) => cfg.gateway?.port ?? 18789,
+    transformConfigFileWithRetry: async (
+      params: Parameters<typeof import("../config/config.js").transformConfigFileWithRetry>[0],
+    ) => {
+      const snapshot = await readConfigFileSnapshotMock();
+      const previousHash = snapshot.hash ?? null;
+      const transformed = await params.transform(snapshot.sourceConfig, {
+        snapshot,
+        previousHash,
+        attempt: 0,
+      });
+      const committed = await params.commit!({
+        nextConfig: transformed.nextConfig,
+        snapshot,
+        ...(previousHash ? { baseHash: previousHash } : {}),
+        writeOptions: params.writeOptions,
+        afterWrite: { mode: "auto" },
+      });
+      return { nextConfig: committed.config };
+    },
+  };
+});
 
 vi.mock("./onboard-agent.js", () => ({ ensureOnboardingAgent: mockOnboardingAgent }));
 
@@ -441,7 +465,6 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
 
         releaseFirstSetup();
         await Promise.all([first, second]);
-        expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(readsBeforeSecond + 1);
         expect(maxActiveWorkspaceSetups).toBe(1);
         expect(configWritePluginLeaseDepths).toHaveLength(2);
         expect(configWritePluginLeaseDepths.every((depth) => depth > 0)).toBe(true);
@@ -542,7 +565,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
     });
   }, 60_000);
 
-  it("allows local onboard plugin install-record migration size drops", async () => {
+  it("migrates local onboard plugin install records in the setup write", async () => {
     await withStateDir("state-local-plugin-installs-", async (stateDir) => {
       const workspace = path.join(stateDir, "openclaw");
       testConfigStore.set(resolveTestConfigPath(), {
@@ -572,14 +595,10 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
         runtime,
       );
 
-      const migrationWrite = capturedReplaceConfigFileCalls.at(-2);
-      expect(migrationWrite?.nextConfig.plugins?.installs).toBeUndefined();
-      expect(migrationWrite?.writeOptions?.unsetPaths).toEqual([["plugins", "installs"]]);
-      expect(migrationWrite?.writeOptions?.allowConfigSizeDrop).toBe(true);
-
+      expect(capturedReplaceConfigFileCalls).toHaveLength(1);
       const onboardWrite = capturedReplaceConfigFileCalls.at(-1);
       expect(onboardWrite?.nextConfig.plugins?.installs).toBeUndefined();
-      expect(onboardWrite?.writeOptions?.unsetPaths).toBeUndefined();
+      expect(onboardWrite?.writeOptions?.unsetPaths).toEqual([["plugins", "installs"]]);
       expect(onboardWrite?.writeOptions?.allowConfigSizeDrop).toBe(false);
     });
   }, 60_000);
@@ -804,7 +823,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
     });
   }, 60_000);
 
-  it("allows remote onboard plugin install-record migration size drops", async () => {
+  it("migrates remote onboard plugin install records in the setup write", async () => {
     await withStateDir("state-remote-plugin-installs-", async (stateDir) => {
       const port = getPseudoPort(30_000);
       const token = "tok_remote_seed";
@@ -835,14 +854,10 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
         runtime,
       );
 
-      const migrationWrite = capturedReplaceConfigFileCalls.at(-2);
-      expect(migrationWrite?.nextConfig.plugins?.installs).toBeUndefined();
-      expect(migrationWrite?.writeOptions?.unsetPaths).toEqual([["plugins", "installs"]]);
-      expect(migrationWrite?.writeOptions?.allowConfigSizeDrop).toBe(true);
-
+      expect(capturedReplaceConfigFileCalls).toHaveLength(1);
       const remoteWrite = capturedReplaceConfigFileCalls.at(-1);
       expect(remoteWrite?.nextConfig.plugins?.installs).toBeUndefined();
-      expect(remoteWrite?.writeOptions?.unsetPaths).toBeUndefined();
+      expect(remoteWrite?.writeOptions?.unsetPaths).toEqual([["plugins", "installs"]]);
       expect(remoteWrite?.writeOptions?.allowConfigSizeDrop).toBe(false);
     });
   }, 60_000);

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -215,9 +215,7 @@ async function loadGatewayOnboardModules(): Promise<void> {
     await import("./onboard-non-interactive/local.test-support.js"));
 }
 
-function getPseudoPort(base: number): number {
-  return base + (process.pid % 1000);
-}
+const getPseudoPort = (base: number): number => base + (process.pid % 1000);
 
 const runtime = createThrowingRuntime();
 
@@ -407,13 +405,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
     testConfigStore.clear();
     capturedReplaceConfigFileCalls.length = 0;
     configWritePluginLeaseDepths.length = 0;
-    readConfigFileSnapshotMock.mockClear();
-    ensureWorkspaceAndSessionsMock.mockClear();
-    installGatewayDaemonNonInteractiveMock.mockClear();
-    healthCommandMock.mockClear();
-    gatewayServiceMock.isLoaded.mockClear();
-    gatewayServiceMock.readRuntime.mockClear();
-    readLastGatewayErrorLineMock.mockClear();
+    vi.clearAllMocks();
   });
 
   it("serializes concurrent onboarding runs sharing one state directory", async () => {
@@ -684,7 +676,6 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
   }, 60_000);
 
   it("persists skipBootstrap and skips workspace bootstrap creation", async () => {
-    ensureWorkspaceAndSessionsMock.mockClear();
     await withStateDir("state-skip-bootstrap-", async (stateDir) => {
       const workspace = path.join(stateDir, "openclaw");
 

--- a/src/commands/onboard-non-interactive/config-write.test.ts
+++ b/src/commands/onboard-non-interactive/config-write.test.ts
@@ -13,21 +13,14 @@ describe("commitNonInteractiveOnboardConfig", () => {
     writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) => config);
   });
 
-  it("keeps the verified config hash and pending-install owner on the canonical writer", async () => {
-    const baseConfig: OpenClawConfig = {
-      plugins: {
-        installs: { demo: { source: "npm", spec: "demo@1.0.0" } },
-      },
-    };
+  it("keeps the verified config hash on the canonical writer", async () => {
     const nextConfig: OpenClawConfig = {
-      ...baseConfig,
       gateway: { port: 19_001 },
     };
 
     await expect(
       commitNonInteractiveOnboardConfig({
         nextConfig,
-        baseConfig,
         baseHash: "verified-config-hash",
       }),
     ).resolves.toBe(nextConfig);
@@ -35,23 +28,19 @@ describe("commitNonInteractiveOnboardConfig", () => {
     expect(writeWizardConfigFile).toHaveBeenCalledWith(nextConfig, {
       allowConfigSizeDrop: false,
       baseHash: "verified-config-hash",
-      migrationBaseConfig: baseConfig,
     });
   });
 
   it("permits config size reduction only for an explicitly requested reset", async () => {
-    const baseConfig: OpenClawConfig = { gateway: { port: 19_001 } };
     const nextConfig: OpenClawConfig = {};
 
     await commitNonInteractiveOnboardConfig({
       nextConfig,
-      baseConfig,
       reset: true,
     });
 
     expect(writeWizardConfigFile).toHaveBeenCalledWith(nextConfig, {
       allowConfigSizeDrop: true,
-      migrationBaseConfig: baseConfig,
     });
   });
 });

--- a/src/commands/onboard-non-interactive/config-write.ts
+++ b/src/commands/onboard-non-interactive/config-write.ts
@@ -3,7 +3,6 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 /** Commits a non-interactive onboard config update with pending plugin records handled first. */
 export async function commitNonInteractiveOnboardConfig(params: {
   nextConfig: OpenClawConfig;
-  baseConfig: OpenClawConfig;
   baseHash?: string;
   reset?: boolean;
 }): Promise<OpenClawConfig> {
@@ -13,6 +12,5 @@ export async function commitNonInteractiveOnboardConfig(params: {
   return await writeWizardConfigFile(params.nextConfig, {
     allowConfigSizeDrop: params.reset === true,
     ...(params.baseHash !== undefined ? { baseHash: params.baseHash } : {}),
-    migrationBaseConfig: params.baseConfig,
   });
 }

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -278,7 +278,6 @@ export async function runNonInteractiveLocalSetup(params: {
   nextConfig = applyWizardMetadata(nextConfig, { command: "onboard", mode });
   nextConfig = await commitNonInteractiveOnboardConfig({
     nextConfig,
-    baseConfig,
     baseHash: effectiveBaseHash,
     reset: opts.reset,
   });

--- a/src/commands/onboard-non-interactive/local/auth-choice.test.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.test.ts
@@ -260,7 +260,6 @@ describe("applyNonInteractiveAuthChoice", () => {
     expect(result).not.toBeNull();
     await commitNonInteractiveOnboardConfig({
       nextConfig: result!,
-      baseConfig: nextConfig,
     });
 
     const persistedConfig = writeWizardConfigFile.mock.calls.at(-1)?.[0];

--- a/src/commands/onboard-non-interactive/remote.ts
+++ b/src/commands/onboard-non-interactive/remote.ts
@@ -71,7 +71,6 @@ export async function runNonInteractiveRemoteSetup(params: {
   nextConfig = applyWizardMetadata(nextConfig, { command: "onboard", mode });
   await commitNonInteractiveOnboardConfig({
     nextConfig,
-    baseConfig,
     baseHash,
     reset: opts.reset,
   });

--- a/src/commands/reset.test.ts
+++ b/src/commands/reset.test.ts
@@ -4,6 +4,7 @@ import {
   cleanupCommandLogMessages,
   createCleanupCommandRuntime,
   gatewayService,
+  listAgentSessionDirs,
   removeStateAndLinkedPaths,
   removeWorkspaceDirs,
   resetCleanupCommandMocks,
@@ -104,5 +105,21 @@ describe("resetCommand", () => {
       dryRun: false,
       removeStateRows: true,
     });
+  });
+
+  it("continues a scoped reset when session directory inspection fails", async () => {
+    listAgentSessionDirs.mockRejectedValueOnce(new Error("permission denied"));
+
+    await expect(
+      resetCommand(runtime, {
+        scope: "config+creds+sessions",
+        yes: true,
+        nonInteractive: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Failed to inspect session directories: Error: permission denied",
+    );
   });
 });

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -146,7 +146,10 @@ export async function resetCommand(runtime: RuntimeEnv, opts: ResetOptions) {
   if (scope === "config+creds+sessions") {
     await removePath(configPath, runtime, { dryRun, label: configPath });
     await removePath(oauthDir, runtime, { dryRun, label: oauthDir });
-    const sessionDirs = await listAgentSessionDirs(stateDir);
+    const sessionDirs = await listAgentSessionDirs(stateDir).catch((error: unknown) => {
+      runtime.error(`Failed to inspect session directories: ${String(error)}`);
+      return [];
+    });
     // Session stores are per-agent directories under state; enumerate them from
     // disk so reset handles agents that are no longer present in config.
     for (const dir of sessionDirs) {

--- a/src/gateway/server-methods/setup-admission.test.ts
+++ b/src/gateway/server-methods/setup-admission.test.ts
@@ -3,7 +3,6 @@ import { createDeferred } from "../../../test/helpers/promise.js";
 import {
   createAdmittedSetupSession,
   runExclusiveSystemAgentSetupActivation,
-  tryAcquireSetupAdmission,
 } from "./setup-admission.js";
 
 describe("setup admission", () => {
@@ -41,32 +40,30 @@ describe("setup admission", () => {
   });
 
   it("holds an admitted session lease until its runner settles", async () => {
-    const release = tryAcquireSetupAdmission();
-    expect(release).toBeDefined();
     const settled = createDeferred();
-    createAdmittedSetupSession(release as () => void, () => ({
+    createAdmittedSetupSession(() => ({
       whenSettled: () => settled.promise,
     }));
 
-    expect(tryAcquireSetupAdmission()).toBeUndefined();
+    expect(
+      createAdmittedSetupSession(() => ({ whenSettled: () => Promise.resolve() })),
+    ).toBeUndefined();
     settled.resolve();
     await settled.promise;
     await Promise.resolve();
-    const nextRelease = tryAcquireSetupAdmission();
-    expect(nextRelease).toBeTypeOf("function");
-    nextRelease?.();
+    const next = createAdmittedSetupSession(() => ({ whenSettled: () => Promise.resolve() }));
+    expect(next).toBeDefined();
+    await next?.whenSettled();
   });
 
   it("releases an admitted session lease when construction fails", () => {
-    const release = tryAcquireSetupAdmission();
-    expect(release).toBeDefined();
     expect(() =>
-      createAdmittedSetupSession(release as () => void, () => {
+      createAdmittedSetupSession(() => {
         throw new Error("construction failed");
       }),
     ).toThrow("construction failed");
-    const nextRelease = tryAcquireSetupAdmission();
-    expect(nextRelease).toBeTypeOf("function");
-    nextRelease?.();
+    expect(
+      createAdmittedSetupSession(() => ({ whenSettled: () => Promise.resolve() })),
+    ).toBeDefined();
   });
 });

--- a/src/gateway/server-methods/setup-admission.test.ts
+++ b/src/gateway/server-methods/setup-admission.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import {
+  createAdmittedSetupSession,
+  runExclusiveSystemAgentSetupActivation,
+  tryAcquireSetupAdmission,
+} from "./setup-admission.js";
+
+describe("setup admission", () => {
+  it("rejects concurrent work instead of queueing it", async () => {
+    const firstStarted = createDeferred();
+    const releaseFirst = createDeferred();
+    const events: string[] = [];
+    const first = runExclusiveSystemAgentSetupActivation(async () => {
+      events.push("first:start");
+      firstStarted.resolve();
+      await releaseFirst.promise;
+      events.push("first:end");
+    });
+    await firstStarted.promise;
+
+    const secondTask = vi.fn(async () => events.push("second:start"));
+    await expect(runExclusiveSystemAgentSetupActivation(secondTask)).rejects.toThrow(
+      "setup is already in progress",
+    );
+    expect(secondTask).not.toHaveBeenCalled();
+    releaseFirst.resolve();
+    await first;
+    await runExclusiveSystemAgentSetupActivation(async () => events.push("third:start"));
+    expect(events).toEqual(["first:start", "first:end", "third:start"]);
+  });
+
+  it("releases the admission lease when work fails", async () => {
+    await expect(
+      runExclusiveSystemAgentSetupActivation(async () => {
+        throw new Error("probe failed");
+      }),
+    ).rejects.toThrow("probe failed");
+
+    await expect(runExclusiveSystemAgentSetupActivation(async () => "ok")).resolves.toBe("ok");
+  });
+
+  it("holds an admitted session lease until its runner settles", async () => {
+    const release = tryAcquireSetupAdmission();
+    expect(release).toBeDefined();
+    const settled = createDeferred();
+    createAdmittedSetupSession(release as () => void, () => ({
+      whenSettled: () => settled.promise,
+    }));
+
+    expect(tryAcquireSetupAdmission()).toBeUndefined();
+    settled.resolve();
+    await settled.promise;
+    await Promise.resolve();
+    const nextRelease = tryAcquireSetupAdmission();
+    expect(nextRelease).toBeTypeOf("function");
+    nextRelease?.();
+  });
+
+  it("releases an admitted session lease when construction fails", () => {
+    const release = tryAcquireSetupAdmission();
+    expect(release).toBeDefined();
+    expect(() =>
+      createAdmittedSetupSession(release as () => void, () => {
+        throw new Error("construction failed");
+      }),
+    ).toThrow("construction failed");
+    const nextRelease = tryAcquireSetupAdmission();
+    expect(nextRelease).toBeTypeOf("function");
+    nextRelease?.();
+  });
+});

--- a/src/gateway/server-methods/setup-admission.test.ts
+++ b/src/gateway/server-methods/setup-admission.test.ts
@@ -1,11 +1,27 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { withSetupMigrationTargetLock } from "../../wizard/setup.migration-snapshot.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+const mocks = vi.hoisted(() => ({ stateDir: "" }));
+
+vi.mock("../../config/paths.js", async () => ({
+  ...(await vi.importActual<typeof import("../../config/paths.js")>("../../config/paths.js")),
+  resolveStateDir: () => mocks.stateDir,
+}));
+
 import {
-  createAdmittedSetupSession,
+  createAdmittedWizardSession,
   runExclusiveSystemAgentSetupActivation,
 } from "./setup-admission.js";
 
 describe("setup admission", () => {
+  beforeEach(() => {
+    mocks.stateDir = tempDirs.make("openclaw-setup-admission-");
+  });
+
   it("rejects concurrent work instead of queueing it", async () => {
     const firstStarted = createDeferred();
     const releaseFirst = createDeferred();
@@ -39,31 +55,87 @@ describe("setup admission", () => {
     await expect(runExclusiveSystemAgentSetupActivation(async () => "ok")).resolves.toBe("ok");
   });
 
+  it("does not misclassify a task's own file-lock timeout as setup contention", async () => {
+    const taskError = Object.assign(new Error("config lock timed out"), {
+      code: "file_lock_timeout",
+    });
+
+    await expect(
+      runExclusiveSystemAgentSetupActivation(async () => {
+        throw taskError;
+      }),
+    ).rejects.toBe(taskError);
+  });
+
   it("holds an admitted session lease until its runner settles", async () => {
     const settled = createDeferred();
-    createAdmittedSetupSession(() => ({
+    await createAdmittedWizardSession(() => ({
       whenSettled: () => settled.promise,
     }));
 
-    expect(
-      createAdmittedSetupSession(() => ({ whenSettled: () => Promise.resolve() })),
-    ).toBeUndefined();
+    await expect(
+      createAdmittedWizardSession(() => ({ whenSettled: () => Promise.resolve() })),
+    ).resolves.toBeUndefined();
     settled.resolve();
     await settled.promise;
-    await Promise.resolve();
-    const next = createAdmittedSetupSession(() => ({ whenSettled: () => Promise.resolve() }));
-    expect(next).toBeDefined();
-    await next?.whenSettled();
+    await vi.waitFor(async () => {
+      const next = await createAdmittedWizardSession(() => ({
+        whenSettled: () => Promise.resolve(),
+      }));
+      expect(next).toBeDefined();
+      await next?.whenSettled();
+    });
   });
 
-  it("releases an admitted session lease when construction fails", () => {
-    expect(() =>
-      createAdmittedSetupSession(() => {
+  it("releases an admitted session lease when construction fails", async () => {
+    await expect(
+      createAdmittedWizardSession(() => {
         throw new Error("construction failed");
       }),
-    ).toThrow("construction failed");
-    expect(
-      createAdmittedSetupSession(() => ({ whenSettled: () => Promise.resolve() })),
-    ).toBeDefined();
+    ).rejects.toThrow("construction failed");
+    await expect(
+      createAdmittedWizardSession(() => ({ whenSettled: () => Promise.resolve() })),
+    ).resolves.toBeDefined();
+  });
+
+  it("reserves wizard admission while setup waits to acquire its target lock", async () => {
+    const lockAcquired = createDeferred();
+    const releaseLock = createDeferred();
+    const lockOwner = withSetupMigrationTargetLock(mocks.stateDir, async () => {
+      lockAcquired.resolve();
+      await releaseLock.promise;
+    });
+    await lockAcquired.promise;
+
+    const setupAttempt = createAdmittedWizardSession(() => ({
+      whenSettled: () => Promise.resolve(),
+    }));
+    const channelFactory = vi.fn(() => ({ whenSettled: () => Promise.resolve() }));
+    await expect(createAdmittedWizardSession(channelFactory, false)).resolves.toBeUndefined();
+    expect(channelFactory).not.toHaveBeenCalled();
+    await expect(setupAttempt).resolves.toBeUndefined();
+
+    releaseLock.resolve();
+    await lockOwner;
+  });
+
+  it("rejects Gateway setup while the canonical onboarding target lock is held", async () => {
+    const lockAcquired = createDeferred();
+    const releaseLock = createDeferred();
+    const lockOwner = withSetupMigrationTargetLock(mocks.stateDir, async () => {
+      lockAcquired.resolve();
+      await releaseLock.promise;
+    });
+    await lockAcquired.promise;
+
+    const task = vi.fn(async () => "unexpected");
+    await expect(runExclusiveSystemAgentSetupActivation(task)).rejects.toThrow(
+      "setup is already in progress",
+    );
+    expect(task).not.toHaveBeenCalled();
+
+    releaseLock.resolve();
+    await lockOwner;
+    await expect(runExclusiveSystemAgentSetupActivation(async () => "ok")).resolves.toBe("ok");
   });
 });

--- a/src/gateway/server-methods/setup-admission.ts
+++ b/src/gateway/server-methods/setup-admission.ts
@@ -1,0 +1,52 @@
+export const SETUP_ADMISSION_BUSY_MESSAGE =
+  "OpenClaw setup is already in progress; try again when it finishes.";
+
+let setupAdmissionInProgress = false;
+
+export class SetupAdmissionBusyError extends Error {}
+
+/** Acquire the process-wide setup mutation lease without queueing. */
+export function tryAcquireSetupAdmission(): (() => void) | undefined {
+  if (setupAdmissionInProgress) {
+    return undefined;
+  }
+  setupAdmissionInProgress = true;
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    setupAdmissionInProgress = false;
+  };
+}
+
+/** Build a setup session and hold its acquired lease until the runner settles. */
+export function createAdmittedSetupSession<T extends { whenSettled(): Promise<unknown> }>(
+  releaseAdmission: () => void,
+  createSession: () => T,
+): T {
+  try {
+    const session = createSession();
+    void session.whenSettled().then(releaseAdmission, releaseAdmission);
+    return session;
+  } catch (error) {
+    releaseAdmission();
+    throw error;
+  }
+}
+
+/** Admit one setup mutation without queueing work past a caller timeout. */
+export async function runExclusiveSystemAgentSetupActivation<T>(
+  task: () => Promise<T>,
+): Promise<T> {
+  const release = tryAcquireSetupAdmission();
+  if (!release) {
+    throw new SetupAdmissionBusyError(SETUP_ADMISSION_BUSY_MESSAGE);
+  }
+  try {
+    return await task();
+  } finally {
+    release();
+  }
+}

--- a/src/gateway/server-methods/setup-admission.ts
+++ b/src/gateway/server-methods/setup-admission.ts
@@ -1,50 +1,60 @@
+import { resolveStateDir } from "../../config/paths.js";
+import { FILE_LOCK_TIMEOUT_ERROR_CODE } from "../../infra/file-lock.js";
+import { withSetupMigrationTargetLock } from "../../wizard/setup.migration-snapshot.js";
+
 export const SETUP_ADMISSION_BUSY_MESSAGE =
   "OpenClaw setup is already in progress; try again when it finishes.";
 
-let setupAdmissionInProgress = false;
+let wizardSessionInProgress = false;
 
 export class SetupAdmissionBusyError extends Error {}
 
-/** Acquire the process-wide setup mutation lease without queueing. */
-function tryAcquireSetupAdmission(): (() => void) | undefined {
-  if (setupAdmissionInProgress) {
-    return undefined;
-  }
-  setupAdmissionInProgress = true;
-  return () => {
-    setupAdmissionInProgress = false;
+export async function runExclusiveSystemAgentSetupActivation<T>(
+  task: () => Promise<T>,
+): Promise<T> {
+  let admitted = false;
+  const admittedTask = async () => {
+    admitted = true;
+    return await task();
   };
-}
-
-/** Admit a setup session and hold its lease until the runner settles. */
-export function createAdmittedSetupSession<T extends { whenSettled(): Promise<unknown> }>(
-  createSession: () => T,
-): T | undefined {
-  const releaseAdmission = tryAcquireSetupAdmission();
-  if (!releaseAdmission) {
-    return undefined;
-  }
   try {
-    const session = createSession();
-    void session.whenSettled().then(releaseAdmission, releaseAdmission);
-    return session;
+    return await withSetupMigrationTargetLock(resolveStateDir(), admittedTask, { wait: false });
   } catch (error) {
-    releaseAdmission();
+    if (!admitted && (error as { code?: unknown }).code === FILE_LOCK_TIMEOUT_ERROR_CODE) {
+      throw new SetupAdmissionBusyError(SETUP_ADMISSION_BUSY_MESSAGE);
+    }
     throw error;
   }
 }
 
-/** Admit one setup mutation without queueing work past a caller timeout. */
-export async function runExclusiveSystemAgentSetupActivation<T>(
-  task: () => Promise<T>,
-): Promise<T> {
-  const release = tryAcquireSetupAdmission();
-  if (!release) {
-    throw new SetupAdmissionBusyError(SETUP_ADMISSION_BUSY_MESSAGE);
+export async function createAdmittedWizardSession<T extends { whenSettled(): Promise<unknown> }>(
+  createSession: () => T,
+  lockSetupTarget = true,
+): Promise<T | undefined> {
+  if (wizardSessionInProgress) {
+    return undefined;
   }
+  wizardSessionInProgress = true;
+  const releaseSession = () => {
+    wizardSessionInProgress = false;
+  };
   try {
-    return await task();
-  } finally {
-    release();
+    const session = lockSetupTarget
+      ? await new Promise<T>((resolve, reject) => {
+          void runExclusiveSystemAgentSetupActivation(async () => {
+            const createdSession = createSession();
+            resolve(createdSession);
+            await createdSession.whenSettled();
+          }).catch(reject);
+        })
+      : createSession();
+    void session.whenSettled().then(releaseSession, releaseSession);
+    return session;
+  } catch (error) {
+    releaseSession();
+    if (error instanceof SetupAdmissionBusyError) {
+      return undefined;
+    }
+    throw error;
   }
 }

--- a/src/gateway/server-methods/setup-admission.ts
+++ b/src/gateway/server-methods/setup-admission.ts
@@ -6,26 +6,24 @@ let setupAdmissionInProgress = false;
 export class SetupAdmissionBusyError extends Error {}
 
 /** Acquire the process-wide setup mutation lease without queueing. */
-export function tryAcquireSetupAdmission(): (() => void) | undefined {
+function tryAcquireSetupAdmission(): (() => void) | undefined {
   if (setupAdmissionInProgress) {
     return undefined;
   }
   setupAdmissionInProgress = true;
-  let released = false;
   return () => {
-    if (released) {
-      return;
-    }
-    released = true;
     setupAdmissionInProgress = false;
   };
 }
 
-/** Build a setup session and hold its acquired lease until the runner settles. */
+/** Admit a setup session and hold its lease until the runner settles. */
 export function createAdmittedSetupSession<T extends { whenSettled(): Promise<unknown> }>(
-  releaseAdmission: () => void,
   createSession: () => T,
-): T {
+): T | undefined {
+  const releaseAdmission = tryAcquireSetupAdmission();
+  if (!releaseAdmission) {
+    return undefined;
+  }
   try {
     const session = createSession();
     void session.whenSettled().then(releaseAdmission, releaseAdmission);

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -30,11 +30,8 @@ import type {
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { ExecApprovalManager } from "../exec-approval-manager.js";
 import { handleGatewayRequest } from "../server-methods.js";
-import {
-  systemAgentHandlers,
-  runExclusiveSystemAgentSetupActivation,
-  type SystemAgentChatSession,
-} from "./system-agent.js";
+import { runExclusiveSystemAgentSetupActivation } from "./setup-admission.js";
+import { systemAgentHandlers, type SystemAgentChatSession } from "./system-agent.js";
 import type { GatewayClient, GatewayRequestContext } from "./types.js";
 
 const setupInferenceMocks = vi.hoisted(() => ({
@@ -467,7 +464,6 @@ describe("openclaw.setup", () => {
       allowConfigSizeDrop: false,
       baseSnapshot: expect.objectContaining({ hash: "prepare-base-hash" }),
       baseHash: "prepare-base-hash",
-      migrationBaseConfig: verifiedConfig,
     });
   });
 });

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -307,33 +307,6 @@ async function callChat(
 }
 
 describe("openclaw.setup", () => {
-  it("rejects a concurrent activation instead of queueing stale work", async () => {
-    const firstStarted = createDeferred();
-    const releaseFirst = createDeferred();
-    const events: string[] = [];
-
-    const first = runExclusiveSystemAgentSetupActivation(async () => {
-      events.push("first:start");
-      firstStarted.resolve();
-      await releaseFirst.promise;
-      events.push("first:end");
-    });
-    await firstStarted.promise;
-
-    const secondTask = vi.fn(async () => events.push("second:start", "second:end"));
-    expect(events).toEqual(["first:start"]);
-    await expect(runExclusiveSystemAgentSetupActivation(secondTask)).rejects.toThrow(
-      "setup is already in progress",
-    );
-    expect(secondTask).not.toHaveBeenCalled();
-    releaseFirst.resolve();
-    await first;
-    expect(events).toEqual(["first:start", "first:end"]);
-
-    await runExclusiveSystemAgentSetupActivation(async () => events.push("third:start"));
-    expect(events).toEqual(["first:start", "first:end", "third:start"]);
-  });
-
   it("returns a retryable busy error while another activation is running", async () => {
     const firstStarted = createDeferred();
     const releaseFirst = createDeferred();
@@ -367,16 +340,42 @@ describe("openclaw.setup", () => {
     }
   });
 
-  it("releases the activation slot when the owning task fails", async () => {
-    await expect(
-      runExclusiveSystemAgentSetupActivation(async () => {
-        throw new Error("probe failed");
-      }),
-    ).rejects.toThrow("probe failed");
+  it.each([
+    [
+      "openclaw.setup.auth.start" as const,
+      { sessionId: "busy-auth", authChoice: "github-copilot" },
+    ],
+    ["openclaw.setup.prepare.start" as const, { sessionId: "busy-prepare", authChoice: "ollama" }],
+  ])("rejects %s before creating a wizard session when setup is busy", async (method, params) => {
+    const ownerStarted = createDeferred();
+    const releaseOwner = createDeferred();
+    const owner = runExclusiveSystemAgentSetupActivation(async () => {
+      ownerStarted.resolve();
+      await releaseOwner.promise;
+    });
+    await ownerStarted.promise;
+    const { wizardSessions, context } = makeWizardContext();
 
-    const nextTask = vi.fn(async () => "ok");
-    await expect(runExclusiveSystemAgentSetupActivation(nextTask)).resolves.toBe("ok");
-    expect(nextTask).toHaveBeenCalledOnce();
+    try {
+      const { calls, respond } = makeRespond();
+      await systemAgentHandler(method)({ params, respond, context } as never);
+
+      expect(calls).toEqual([
+        {
+          ok: false,
+          payload: undefined,
+          error: {
+            code: "UNAVAILABLE",
+            message: "OpenClaw setup is already in progress; try again when it finishes.",
+            retryable: true,
+          },
+        },
+      ]);
+      expect(wizardSessions.size).toBe(0);
+    } finally {
+      releaseOwner.resolve();
+      await owner;
+    }
   });
   it("starts provider auth as an interactive wizard session", async () => {
     const { wizardSessions, context } = makeWizardContext();

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -50,6 +50,13 @@ import {
   handlePendingApprovalRequest,
   listVisiblePendingApprovalRequests,
 } from "./approval-shared.js";
+import {
+  createAdmittedSetupSession,
+  runExclusiveSystemAgentSetupActivation,
+  SETUP_ADMISSION_BUSY_MESSAGE,
+  SetupAdmissionBusyError,
+  tryAcquireSetupAdmission,
+} from "./setup-admission.js";
 import { sanitizeSystemAgentChatParams } from "./system-agent-chat-params.js";
 import {
   buildSystemAgentChatResult,
@@ -57,7 +64,10 @@ import {
   runSystemAgentChatInput,
 } from "./system-agent-chat-turn.js";
 import type { GatewayClient, GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
+import type { RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
+
+export { runExclusiveSystemAgentSetupActivation } from "./setup-admission.js";
 
 /**
  * `openclaw.chat` lets clients (macOS app onboarding, future UIs) run the
@@ -138,27 +148,6 @@ function resolveSystemAgentSessionOwnerKey(params: {
   }
   const connId = params.client?.connId?.trim();
   return connId ? `connection:${connId}` : undefined;
-}
-
-let systemAgentSetupActivationInProgress = false;
-
-class SystemAgentSetupActivationBusyError extends Error {}
-
-/** Admit one setup mutation without queueing work past a caller timeout. */
-export async function runExclusiveSystemAgentSetupActivation<T>(
-  task: () => Promise<T>,
-): Promise<T> {
-  if (systemAgentSetupActivationInProgress) {
-    throw new SystemAgentSetupActivationBusyError(
-      "OpenClaw setup is already in progress; try again when it finishes.",
-    );
-  }
-  systemAgentSetupActivationInProgress = true;
-  try {
-    return await task();
-  } finally {
-    systemAgentSetupActivationInProgress = false;
-  }
 }
 
 async function evictOldestSession(
@@ -264,6 +253,10 @@ function queueDelegatedApproval(params: {
   return record.id;
 }
 
+function respondRetryableSetupUnavailable(respond: RespondFn, message: string): void {
+  respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, message, { retryable: true }));
+}
+
 export const systemAgentHandlers: GatewayRequestHandlers = {
   "openclaw.approval.list": async ({ respond, client, context }) => {
     const manager = context.systemAgentApprovalManager;
@@ -338,42 +331,49 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
       return;
     }
     if (context.findRunningWizard()) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "wizard already running"));
+      respondRetryableSetupUnavailable(respond, "wizard already running");
+      return;
+    }
+    const releaseSetupAdmission = tryAcquireSetupAdmission();
+    if (!releaseSetupAdmission) {
+      respondRetryableSetupUnavailable(respond, SETUP_ADMISSION_BUSY_MESSAGE);
       return;
     }
     const sessionId = params.sessionId;
-    const session = new WizardSession(
-      async (prompter, signal) => {
-        // Match setup.activate's lock order: setup admission before the Gateway
-        // queue. Both stay held for the session, so a relaunched client cannot
-        // start competing setup work while this server-owned flow can commit.
-        const result = await runExclusiveSystemAgentSetupActivation(async () =>
-          runSystemAgentGatewayTask(async () => {
-            const { activateSetupInference } =
-              await import("../../system-agent/setup-inference.js");
-            return await activateSetupInference({
-              kind: "provider-auth",
-              authChoice: params.authChoice,
-              ...(params.workspace !== undefined ? { workspace: params.workspace } : {}),
-              surface: "gateway",
-              runtime: {
-                ...defaultRuntime,
-                exit: (code: number | undefined): never => {
-                  throw new Error(`setup step exited with code ${String(code)}`);
+    const session = createAdmittedSetupSession(
+      releaseSetupAdmission,
+      () =>
+        new WizardSession(
+          async (prompter, signal) => {
+            // Match setup.activate's lock order: setup admission before the Gateway
+            // queue. Both stay held for the session, so a relaunched client cannot
+            // start competing setup work while this server-owned flow can commit.
+            const result = await runSystemAgentGatewayTask(async () => {
+              const { activateSetupInference } =
+                await import("../../system-agent/setup-inference.js");
+              return await activateSetupInference({
+                kind: "provider-auth",
+                authChoice: params.authChoice,
+                ...(params.workspace !== undefined ? { workspace: params.workspace } : {}),
+                surface: "gateway",
+                runtime: {
+                  ...defaultRuntime,
+                  exit: (code: number | undefined): never => {
+                    throw new Error(`setup step exited with code ${String(code)}`);
+                  },
                 },
-              },
-              prompter,
-              signal,
-              isCancelled: () => signal.aborted,
-              onCommitStarted: () => session.lockCancellation(),
+                prompter,
+                signal,
+                isCancelled: () => signal.aborted,
+                onCommitStarted: () => session.lockCancellation(),
+              });
             });
-          }),
-        );
-        if (!result.ok) {
-          throw new Error(result.error);
-        }
-      },
-      { timeoutMs: PROVIDER_AUTH_SESSION_TIMEOUT_MS },
+            if (!result.ok) {
+              throw new Error(result.error);
+            }
+          },
+          { timeoutMs: PROVIDER_AUTH_SESSION_TIMEOUT_MS },
+        ),
     );
     context.wizardSessions.set(sessionId, session);
     // Return ownership immediately so the client can cancel while provider auth waits.
@@ -392,66 +392,75 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
       return;
     }
     if (context.findRunningWizard()) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "wizard already running"));
+      respondRetryableSetupUnavailable(respond, "wizard already running");
+      return;
+    }
+    const releaseSetupAdmission = tryAcquireSetupAdmission();
+    if (!releaseSetupAdmission) {
+      respondRetryableSetupUnavailable(respond, SETUP_ADMISSION_BUSY_MESSAGE);
       return;
     }
     const sessionId = params.sessionId;
-    const session = new WizardSession(
-      async (prompter, signal) => {
-        await runExclusiveSystemAgentSetupActivation(async () =>
-          runSystemAgentGatewayTask(async () => {
-            const [{ applyAuthChoiceLoadedPluginProvider }, setupShared] = await Promise.all([
-              import("../../plugins/provider-auth-choice.js"),
-              import("../../wizard/setup.shared.js"),
-            ]);
-            const snapshot = await setupShared.readSetupConfigFileSnapshot();
-            if (!snapshot.valid) {
-              throw new Error("Config is invalid. Run `openclaw doctor` before preparing a model.");
-            }
-            // Match the classic wizard: mutate the authored shape, not runtimeConfig,
-            // so setup never writes resolved runtime defaults into openclaw.json.
-            const baseConfig = snapshot.exists ? snapshot.sourceConfig : {};
-            const workspaceDir = params.workspace?.trim()
-              ? resolveUserPath(params.workspace.trim())
-              : undefined;
-            const applied = await applyAuthChoiceLoadedPluginProvider({
-              authChoice: params.authChoice,
-              config: baseConfig,
-              prompter,
-              runtime: {
-                ...defaultRuntime,
-                exit: (code: number | undefined): never => {
-                  throw new Error(`setup step exited with code ${String(code)}`);
+    const session = createAdmittedSetupSession(
+      releaseSetupAdmission,
+      () =>
+        new WizardSession(
+          async (prompter, signal) => {
+            await runSystemAgentGatewayTask(async () => {
+              const [{ applyAuthChoiceLoadedPluginProvider }, setupShared] = await Promise.all([
+                import("../../plugins/provider-auth-choice.js"),
+                import("../../wizard/setup.shared.js"),
+              ]);
+              const snapshot = await setupShared.readSetupConfigFileSnapshot();
+              if (!snapshot.valid) {
+                throw new Error(
+                  "Config is invalid. Run `openclaw doctor` before preparing a model.",
+                );
+              }
+              // Match the classic wizard: mutate the authored shape, not runtimeConfig,
+              // so setup never writes resolved runtime defaults into openclaw.json.
+              const baseConfig = snapshot.exists ? snapshot.sourceConfig : {};
+              const workspaceDir = params.workspace?.trim()
+                ? resolveUserPath(params.workspace.trim())
+                : undefined;
+              const applied = await applyAuthChoiceLoadedPluginProvider({
+                authChoice: params.authChoice,
+                config: baseConfig,
+                prompter,
+                runtime: {
+                  ...defaultRuntime,
+                  exit: (code: number | undefined): never => {
+                    throw new Error(`setup step exited with code ${String(code)}`);
+                  },
                 },
-              },
-              setDefaultModel: false,
-              preserveExistingDefaultModel: true,
-              ...(workspaceDir ? { workspaceDir } : {}),
-              signal,
-              isRemote: true,
-              beforePersistentEffect: () => {
-                signal.throwIfAborted();
-                session.lockCancellation();
-              },
+                setDefaultModel: false,
+                preserveExistingDefaultModel: true,
+                ...(workspaceDir ? { workspaceDir } : {}),
+                signal,
+                isRemote: true,
+                beforePersistentEffect: () => {
+                  signal.throwIfAborted();
+                  session.lockCancellation();
+                },
+              });
+              if (!applied || applied.retrySelection) {
+                throw new Error(`Provider prepare method is unavailable: ${params.authChoice}`);
+              }
+              signal.throwIfAborted();
+              session.lockCancellation();
+              await setupShared.writeWizardConfigFile(applied.config, {
+                allowConfigSizeDrop: false,
+                baseSnapshot: snapshot,
+                ...(snapshot.hash ? { baseHash: snapshot.hash } : {}),
+                migrationBaseConfig: baseConfig,
+              });
+              if (applied.agentModelOverride) {
+                session.setPreparedModelRef(applied.agentModelOverride);
+              }
             });
-            if (!applied || applied.retrySelection) {
-              throw new Error(`Provider prepare method is unavailable: ${params.authChoice}`);
-            }
-            signal.throwIfAborted();
-            session.lockCancellation();
-            await setupShared.writeWizardConfigFile(applied.config, {
-              allowConfigSizeDrop: false,
-              baseSnapshot: snapshot,
-              ...(snapshot.hash ? { baseHash: snapshot.hash } : {}),
-              migrationBaseConfig: baseConfig,
-            });
-            if (applied.agentModelOverride) {
-              session.setPreparedModelRef(applied.agentModelOverride);
-            }
-          }),
-        );
-      },
-      { timeoutMs: PROVIDER_PREPARE_SESSION_TIMEOUT_MS },
+          },
+          { timeoutMs: PROVIDER_PREPARE_SESSION_TIMEOUT_MS },
+        ),
     );
     context.wizardSessions.set(sessionId, session);
     respond(true, { sessionId, done: false, status: "running" }, undefined);
@@ -499,14 +508,10 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
         });
       });
     } catch (error) {
-      if (!(error instanceof SystemAgentSetupActivationBusyError)) {
+      if (!(error instanceof SetupAdmissionBusyError)) {
         throw error;
       }
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.UNAVAILABLE, error.message, { retryable: true }),
-      );
+      respondRetryableSetupUnavailable(respond, error.message);
     }
   },
   "openclaw.chat": async ({ params: rawParams, respond, client, context }) => {

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -51,7 +51,7 @@ import {
   listVisiblePendingApprovalRequests,
 } from "./approval-shared.js";
 import {
-  createAdmittedSetupSession,
+  createAdmittedWizardSession,
   runExclusiveSystemAgentSetupActivation,
   SETUP_ADMISSION_BUSY_MESSAGE,
   SetupAdmissionBusyError,
@@ -327,18 +327,11 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
     ) {
       return;
     }
-    if (context.findRunningWizard()) {
-      respondRetryableSetupUnavailable(respond, "wizard already running");
-      return;
-    }
     const sessionId = params.sessionId;
-    const session = createAdmittedSetupSession(
+    const session = await createAdmittedWizardSession(
       () =>
         new WizardSession(
           async (prompter, signal, runnerSession) => {
-            // Match setup.activate's lock order: setup admission before the Gateway
-            // queue. Both stay held for the session, so a relaunched client cannot
-            // start competing setup work while this server-owned flow can commit.
             const result = await runSystemAgentGatewayTask(async () => {
               const { activateSetupInference } =
                 await import("../../system-agent/setup-inference.js");
@@ -386,12 +379,8 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
     ) {
       return;
     }
-    if (context.findRunningWizard()) {
-      respondRetryableSetupUnavailable(respond, "wizard already running");
-      return;
-    }
     const sessionId = params.sessionId;
-    const session = createAdmittedSetupSession(
+    const session = await createAdmittedWizardSession(
       () =>
         new WizardSession(
           async (prompter, signal, runnerSession) => {

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -55,7 +55,6 @@ import {
   runExclusiveSystemAgentSetupActivation,
   SETUP_ADMISSION_BUSY_MESSAGE,
   SetupAdmissionBusyError,
-  tryAcquireSetupAdmission,
 } from "./setup-admission.js";
 import { sanitizeSystemAgentChatParams } from "./system-agent-chat-params.js";
 import {
@@ -66,8 +65,6 @@ import {
 import type { GatewayClient, GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 import type { RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
-
-export { runExclusiveSystemAgentSetupActivation } from "./setup-admission.js";
 
 /**
  * `openclaw.chat` lets clients (macOS app onboarding, future UIs) run the
@@ -334,17 +331,11 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
       respondRetryableSetupUnavailable(respond, "wizard already running");
       return;
     }
-    const releaseSetupAdmission = tryAcquireSetupAdmission();
-    if (!releaseSetupAdmission) {
-      respondRetryableSetupUnavailable(respond, SETUP_ADMISSION_BUSY_MESSAGE);
-      return;
-    }
     const sessionId = params.sessionId;
     const session = createAdmittedSetupSession(
-      releaseSetupAdmission,
       () =>
         new WizardSession(
-          async (prompter, signal) => {
+          async (prompter, signal, runnerSession) => {
             // Match setup.activate's lock order: setup admission before the Gateway
             // queue. Both stay held for the session, so a relaunched client cannot
             // start competing setup work while this server-owned flow can commit.
@@ -365,7 +356,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
                 prompter,
                 signal,
                 isCancelled: () => signal.aborted,
-                onCommitStarted: () => session.lockCancellation(),
+                onCommitStarted: () => runnerSession.lockCancellation(),
               });
             });
             if (!result.ok) {
@@ -375,6 +366,10 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
           { timeoutMs: PROVIDER_AUTH_SESSION_TIMEOUT_MS },
         ),
     );
+    if (!session) {
+      respondRetryableSetupUnavailable(respond, SETUP_ADMISSION_BUSY_MESSAGE);
+      return;
+    }
     context.wizardSessions.set(sessionId, session);
     // Return ownership immediately so the client can cancel while provider auth waits.
     respond(true, { sessionId, done: false, status: "running" }, undefined);
@@ -395,17 +390,11 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
       respondRetryableSetupUnavailable(respond, "wizard already running");
       return;
     }
-    const releaseSetupAdmission = tryAcquireSetupAdmission();
-    if (!releaseSetupAdmission) {
-      respondRetryableSetupUnavailable(respond, SETUP_ADMISSION_BUSY_MESSAGE);
-      return;
-    }
     const sessionId = params.sessionId;
     const session = createAdmittedSetupSession(
-      releaseSetupAdmission,
       () =>
         new WizardSession(
-          async (prompter, signal) => {
+          async (prompter, signal, runnerSession) => {
             await runSystemAgentGatewayTask(async () => {
               const [{ applyAuthChoiceLoadedPluginProvider }, setupShared] = await Promise.all([
                 import("../../plugins/provider-auth-choice.js"),
@@ -440,28 +429,31 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
                 isRemote: true,
                 beforePersistentEffect: () => {
                   signal.throwIfAborted();
-                  session.lockCancellation();
+                  runnerSession.lockCancellation();
                 },
               });
               if (!applied || applied.retrySelection) {
                 throw new Error(`Provider prepare method is unavailable: ${params.authChoice}`);
               }
               signal.throwIfAborted();
-              session.lockCancellation();
+              runnerSession.lockCancellation();
               await setupShared.writeWizardConfigFile(applied.config, {
                 allowConfigSizeDrop: false,
                 baseSnapshot: snapshot,
                 ...(snapshot.hash ? { baseHash: snapshot.hash } : {}),
-                migrationBaseConfig: baseConfig,
               });
               if (applied.agentModelOverride) {
-                session.setPreparedModelRef(applied.agentModelOverride);
+                runnerSession.setPreparedModelRef(applied.agentModelOverride);
               }
             });
           },
           { timeoutMs: PROVIDER_PREPARE_SESSION_TIMEOUT_MS },
         ),
     );
+    if (!session) {
+      respondRetryableSetupUnavailable(respond, SETUP_ADMISSION_BUSY_MESSAGE);
+      return;
+    }
     context.wizardSessions.set(sessionId, session);
     respond(true, { sessionId, done: false, status: "running" }, undefined);
   },

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -11,6 +11,7 @@ import {
 import type { RuntimeEnv } from "../../runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { createWizardSessionTracker } from "../server-wizard-sessions.js";
+import { runExclusiveSystemAgentSetupActivation, systemAgentHandlers } from "./system-agent.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 import { type SetupWizardRunner, wizardHandlers } from "./wizard.js";
 
@@ -144,6 +145,99 @@ describe("hosted wizard runtime isolation", () => {
 });
 
 describe("wizard setup ownership", () => {
+  it("rejects classic setup while structured setup owns admission, then permits it", async () => {
+    const structuredStarted = createDeferred();
+    const releaseStructured = createDeferred();
+    const structured = runExclusiveSystemAgentSetupActivation(async () => {
+      structuredStarted.resolve();
+      await releaseStructured.promise;
+    });
+    await structuredStarted.promise;
+    const tracker = createWizardSessionTracker();
+    const wizardRunner = vi.fn(async (_opts, _runtime, prompter: WizardPrompter) => {
+      await prompter.note("ready");
+    });
+    const context = { ...tracker, wizardRunner };
+
+    const blockedRespond = vi.fn();
+    await expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizard.start test invariant",
+    )({
+      params: { mode: "local" },
+      respond: blockedRespond,
+      context,
+    } as never);
+    expect(blockedRespond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "UNAVAILABLE" }),
+    );
+    expect(wizardRunner).not.toHaveBeenCalled();
+
+    releaseStructured.resolve();
+    await structured;
+    const admittedRespond = vi.fn();
+    await expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizard.start test invariant",
+    )({
+      params: { mode: "local" },
+      respond: admittedRespond,
+      context,
+    } as never);
+    expect(admittedRespond.mock.calls[0]?.[1]).toMatchObject({ status: "running" });
+    const session = expectDefined(
+      [...tracker.wizardSessions.values()][0],
+      "admitted classic setup session",
+    );
+    session.cancel();
+    await session.whenSettled();
+  });
+
+  it("makes structured setup retry while a classic runner owns admission, then releases", async () => {
+    const runnerSettled = createDeferred();
+    const tracker = createWizardSessionTracker();
+    const context = {
+      ...tracker,
+      wizardRunner: async (_opts: unknown, _runtime: RuntimeEnv, prompter: WizardPrompter) => {
+        prompter.progress("working");
+        await runnerSettled.promise;
+      },
+    };
+    const startRespond = vi.fn();
+    await expectDefined(
+      wizardHandlers["wizard.start"],
+      "wizard.start test invariant",
+    )({
+      params: { mode: "local" },
+      respond: startRespond,
+      context,
+    } as never);
+    expect(startRespond.mock.calls[0]?.[1]).toMatchObject({ status: "running" });
+
+    const activateRespond = vi.fn();
+    await expectDefined(
+      systemAgentHandlers["openclaw.setup.activate"],
+      "openclaw.setup.activate test invariant",
+    )({ params: { kind: "claude-cli" }, respond: activateRespond } as never);
+    expect(activateRespond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "UNAVAILABLE", retryable: true }),
+    );
+
+    runnerSettled.resolve();
+    const session = expectDefined(
+      [...tracker.wizardSessions.values()][0],
+      "active classic setup session",
+    );
+    await session.whenSettled();
+    const structuredTask = vi.fn(async () => "ok");
+    await expect(runExclusiveSystemAgentSetupActivation(structuredTask)).resolves.toBe("ok");
+    expect(structuredTask).toHaveBeenCalledOnce();
+  });
+
   it("retains gateway work admission between requests until the wizard settles", async () => {
     resetGatewayWorkAdmission();
     const runnerSettled = createDeferred();

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -11,7 +11,8 @@ import {
 import type { RuntimeEnv } from "../../runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { createWizardSessionTracker } from "../server-wizard-sessions.js";
-import { runExclusiveSystemAgentSetupActivation, systemAgentHandlers } from "./system-agent.js";
+import { runExclusiveSystemAgentSetupActivation } from "./setup-admission.js";
+import { systemAgentHandlers } from "./system-agent.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 import { type SetupWizardRunner, wizardHandlers } from "./wizard.js";
 

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -47,6 +47,15 @@ async function invokeWizard(
   return readSuccessfulResponse(respond);
 }
 
+async function cancelWizardSessions(
+  sessions: Map<string, import("../../wizard/session.js").WizardSession>,
+) {
+  for (const session of sessions.values()) {
+    session.cancel();
+    await session.whenSettled();
+  }
+}
+
 describe("wizard session lookup", () => {
   it.each([
     { method: "wizard.next", params: { sessionId: "expired" } },
@@ -346,9 +355,7 @@ describe("wizard setup ownership", () => {
     } as never);
     expect(replacementRespond.mock.calls[0]?.[1]).toMatchObject({ status: "running" });
 
-    for (const session of tracker.wizardSessions.values()) {
-      session.cancel();
-    }
+    await cancelWizardSessions(tracker.wizardSessions);
   });
 
   it.each([
@@ -376,9 +383,7 @@ describe("wizard setup ownership", () => {
     expect(receivedInstallDaemon).toBe(expected);
     expect(respond.mock.calls[0]?.[1]).toMatchObject({ done: false, status: "running" });
 
-    for (const session of tracker.wizardSessions.values()) {
-      session.cancel();
-    }
+    await cancelWizardSessions(tracker.wizardSessions);
   });
 });
 
@@ -394,9 +399,7 @@ describe("wizard step serialization", () => {
     const result = await invokeWizard("wizard.start", {}, context);
     expect(result.step).toMatchObject({ sensitive: true });
     expect(result.step).not.toHaveProperty("initialValue");
-    for (const session of context.wizardSessions.values()) {
-      session.cancel();
-    }
+    await cancelWizardSessions(context.wizardSessions);
   });
 
   it("keeps a plain default but strips the next sensitive one from wizard.next", async () => {
@@ -426,8 +429,6 @@ describe("wizard step serialization", () => {
     const nextResult = await invokeWizard("wizard.next", params, context);
     expect(nextResult.step).toMatchObject({ sensitive: true });
     expect(nextResult.step).not.toHaveProperty("initialValue");
-    for (const session of context.wizardSessions.values()) {
-      session.cancel();
-    }
+    await cancelWizardSessions(context.wizardSessions);
   });
 });

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -21,11 +21,7 @@ import {
   type WizardStep,
 } from "../../wizard/session.js";
 import { formatForLog } from "../ws-log.js";
-import {
-  createAdmittedSetupSession,
-  SETUP_ADMISSION_BUSY_MESSAGE,
-  tryAcquireSetupAdmission,
-} from "./setup-admission.js";
+import { createAdmittedSetupSession, SETUP_ADMISSION_BUSY_MESSAGE } from "./setup-admission.js";
 import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -125,15 +121,6 @@ export const wizardHandlers: GatewayRequestHandlers = {
     }
     const sessionId = randomUUID();
     const flow = params.flow ?? "setup";
-    const releaseSetupAdmission = flow === "setup" ? tryAcquireSetupAdmission() : undefined;
-    if (flow === "setup" && !releaseSetupAdmission) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.UNAVAILABLE, SETUP_ADMISSION_BUSY_MESSAGE, { retryable: true }),
-      );
-      return;
-    }
     const createSession = () =>
       flow === "channels"
         ? new WizardSession((prompter, _signal, wizardSession) =>
@@ -166,9 +153,15 @@ export const wizardHandlers: GatewayRequestHandlers = {
           );
     // The setup lease follows the runner, not the session map: cancellation can
     // purge ownership before a cancellation-locked persistent effect has settled.
-    const session = releaseSetupAdmission
-      ? createAdmittedSetupSession(releaseSetupAdmission, createSession)
-      : createSession();
+    const session = flow === "setup" ? createAdmittedSetupSession(createSession) : createSession();
+    if (!session) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.UNAVAILABLE, SETUP_ADMISSION_BUSY_MESSAGE, { retryable: true }),
+      );
+      return;
+    }
     retainGatewayWorkUntilSettled(session);
     context.wizardSessions.set(sessionId, session);
     const result = await session.next();

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -21,6 +21,11 @@ import {
   type WizardStep,
 } from "../../wizard/session.js";
 import { formatForLog } from "../ws-log.js";
+import {
+  createAdmittedSetupSession,
+  SETUP_ADMISSION_BUSY_MESSAGE,
+  tryAcquireSetupAdmission,
+} from "./setup-admission.js";
 import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -111,12 +116,25 @@ export const wizardHandlers: GatewayRequestHandlers = {
     }
     const running = context.findRunningWizard();
     if (running) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "wizard already running"));
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.UNAVAILABLE, "wizard already running", { retryable: true }),
+      );
       return;
     }
     const sessionId = randomUUID();
     const flow = params.flow ?? "setup";
-    const session =
+    const releaseSetupAdmission = flow === "setup" ? tryAcquireSetupAdmission() : undefined;
+    if (flow === "setup" && !releaseSetupAdmission) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.UNAVAILABLE, SETUP_ADMISSION_BUSY_MESSAGE, { retryable: true }),
+      );
+      return;
+    }
+    const createSession = () =>
       flow === "channels"
         ? new WizardSession((prompter, _signal, wizardSession) =>
             runHostedWizard((runtime) =>
@@ -146,6 +164,11 @@ export const wizardHandlers: GatewayRequestHandlers = {
               ),
             ),
           );
+    // The setup lease follows the runner, not the session map: cancellation can
+    // purge ownership before a cancellation-locked persistent effect has settled.
+    const session = releaseSetupAdmission
+      ? createAdmittedSetupSession(releaseSetupAdmission, createSession)
+      : createSession();
     retainGatewayWorkUntilSettled(session);
     context.wizardSessions.set(sessionId, session);
     const result = await session.next();

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -21,7 +21,7 @@ import {
   type WizardStep,
 } from "../../wizard/session.js";
 import { formatForLog } from "../ws-log.js";
-import { createAdmittedSetupSession, SETUP_ADMISSION_BUSY_MESSAGE } from "./setup-admission.js";
+import { createAdmittedWizardSession, SETUP_ADMISSION_BUSY_MESSAGE } from "./setup-admission.js";
 import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -110,15 +110,6 @@ export const wizardHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateWizardStartParams, "wizard.start", respond)) {
       return;
     }
-    const running = context.findRunningWizard();
-    if (running) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.UNAVAILABLE, "wizard already running", { retryable: true }),
-      );
-      return;
-    }
     const sessionId = randomUUID();
     const flow = params.flow ?? "setup";
     const createSession = () =>
@@ -151,9 +142,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
               ),
             ),
           );
-    // The setup lease follows the runner, not the session map: cancellation can
-    // purge ownership before a cancellation-locked persistent effect has settled.
-    const session = flow === "setup" ? createAdmittedSetupSession(createSession) : createSession();
+    const session = await createAdmittedWizardSession(createSession, flow === "setup");
     if (!session) {
       respond(
         false,

--- a/src/system-agent/chat-engine.channel-hooks.test.ts
+++ b/src/system-agent/chat-engine.channel-hooks.test.ts
@@ -140,7 +140,7 @@ describe("OpenClaw chat channel setup", () => {
     expect(reply.text).toContain("matrix is configured");
     expect(mocks.writeWizardConfigFile).toHaveBeenCalledWith(
       { channels: { matrix: { enabled: true } } },
-      { allowConfigSizeDrop: false, baseHash: "hash", migrationBaseConfig: {} },
+      { allowConfigSizeDrop: false, baseHash: "hash" },
     );
     expect(mocks.setupChannels).toHaveBeenCalledWith(
       {},

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -893,7 +893,6 @@ describe("SystemAgentChatEngine", () => {
       {
         allowConfigSizeDrop: false,
         baseHash: "skills-base-hash",
-        migrationBaseConfig: baseConfig,
       },
     );
     expect(appendAuditEntry).toHaveBeenCalledWith(
@@ -1354,7 +1353,6 @@ describe("SystemAgentChatEngine", () => {
       {
         allowConfigSizeDrop: false,
         baseHash: "gateway-base-hash",
-        migrationBaseConfig: baseConfig,
         afterWrite: {
           mode: "none",
           reason: "Gateway setup defers runtime apply until explicit restart",
@@ -1806,7 +1804,6 @@ describe("SystemAgentChatEngine", () => {
       }),
       expect.objectContaining({
         baseHash: "base-hash",
-        migrationBaseConfig: baseConfig,
       }),
     );
     expect(currentConfig).toEqual(concurrentConfig);

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -247,7 +247,6 @@ async function runHostedConfigWizard(params: {
   const committedConfig = await writeWizardConfigFile(result.nextConfig, {
     allowConfigSizeDrop: false,
     baseHash: snapshot.hash,
-    migrationBaseConfig: baseConfig,
     ...(params.afterWrite ? { afterWrite: params.afterWrite } : {}),
   });
   await result.afterWrite?.(committedConfig);

--- a/src/system-agent/tui-backend.ts
+++ b/src/system-agent/tui-backend.ts
@@ -469,7 +469,6 @@ async function runSetupHandoff(
     await writeWizardConfigFile(result.nextConfig, {
       allowConfigSizeDrop: false,
       baseHash: snapshot.hash,
-      migrationBaseConfig: baseConfig,
       afterWrite: GATEWAY_SETUP_AFTER_WRITE,
     });
     runtime.log("Done — gateway settings saved. Run `openclaw gateway restart` to apply them.");
@@ -507,7 +506,6 @@ async function runSetupHandoff(
     await writeWizardConfigFile(searchSetup.config, {
       allowConfigSizeDrop: false,
       baseHash: snapshot.hash,
-      migrationBaseConfig: baseConfig,
     });
     return;
   }

--- a/src/wizard/setup.default-agent.test.ts
+++ b/src/wizard/setup.default-agent.test.ts
@@ -22,19 +22,23 @@ vi.mock("./navigation-prompter.js", () => ({
   ) => await run(prompter),
 }));
 
-vi.mock("./setup.shared.js", () => ({
-  readSetupConfigFileSnapshot: mocks.readSnapshot,
-  readValidSetupConfigFile: vi.fn(),
-  requireRiskAcknowledgement: async ({ config }: { config: OpenClawConfig }) => config,
-  resolveQuickstartGatewayDefaults: () => ({
-    hasExisting: false,
-    port: 18789,
-    bind: "loopback",
-    authMode: "token",
-    tailscaleMode: "off",
-  }),
-  writeWizardConfigFile: mocks.writeConfig,
-}));
+vi.mock("./setup.shared.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./setup.shared.js")>();
+  return {
+    ...actual,
+    readSetupConfigFileSnapshot: mocks.readSnapshot,
+    readValidSetupConfigFile: vi.fn(),
+    requireRiskAcknowledgement: async ({ config }: { config: OpenClawConfig }) => config,
+    resolveQuickstartGatewayDefaults: () => ({
+      hasExisting: false,
+      port: 18789,
+      bind: "loopback",
+      authMode: "token",
+      tailscaleMode: "off",
+    }),
+    writeWizardConfigFile: mocks.writeConfig,
+  };
+});
 
 vi.mock("./setup.migration-import.js", () => ({
   detectSetupMigrationSources: vi.fn(async () => []),

--- a/src/wizard/setup.migration-snapshot.ts
+++ b/src/wizard/setup.migration-snapshot.ts
@@ -307,6 +307,7 @@ export async function prepareSetupMigrationAttemptBoundary(params: {
 export async function withSetupMigrationTargetLock<T>(
   stateDir: string,
   fn: () => Promise<T>,
+  options?: { wait?: boolean },
 ): Promise<T> {
   const resolvedStateDir = path.resolve(stateDir);
   const activeStateDir = activeSetupMigrationTargetLock.getStore();
@@ -320,7 +321,12 @@ export async function withSetupMigrationTargetLock<T>(
   await fs.mkdir(migrationDir, { recursive: true, mode: 0o700 });
   return await withFileLock(
     path.join(migrationDir, "onboarding.lock-target"),
-    ONBOARDING_TARGET_LOCK_OPTIONS,
+    options?.wait === false
+      ? {
+          ...ONBOARDING_TARGET_LOCK_OPTIONS,
+          retries: { ...ONBOARDING_TARGET_LOCK_OPTIONS.retries, retries: 0 },
+        }
+      : ONBOARDING_TARGET_LOCK_OPTIONS,
     async () => await activeSetupMigrationTargetLock.run(resolvedStateDir, fn),
   );
 }

--- a/src/wizard/setup.shared.test.ts
+++ b/src/wizard/setup.shared.test.ts
@@ -1,20 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
-import { withoutPluginInstallRecords } from "../plugins/installed-plugin-index-records.js";
 
 const mocks = vi.hoisted(() => ({
-  commitConfigWriteWithPendingPluginInstalls: vi.fn(),
-  replaceConfigFile: vi.fn(),
-}));
-
-vi.mock("../config/config.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../config/config.js")>()),
-  replaceConfigFile: mocks.replaceConfigFile,
+  currentConfig: {} as OpenClawConfig,
+  transformConfigWithPendingPluginInstalls: vi.fn(),
 }));
 
 vi.mock("../plugins/install-record-commit.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../plugins/install-record-commit.js")>()),
-  commitConfigWriteWithPendingPluginInstalls: mocks.commitConfigWriteWithPendingPluginInstalls,
+  transformConfigWithPendingPluginInstalls: mocks.transformConfigWithPendingPluginInstalls,
 }));
 
 import { resolveQuickstartGatewayDefaults, writeWizardConfigFile } from "./setup.shared.js";
@@ -117,126 +111,66 @@ describe("resolveQuickstartGatewayDefaults", () => {
   });
 });
 
-describe("writeWizardConfigFile pending install ownership", () => {
+describe("writeWizardConfigFile", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.commitConfigWriteWithPendingPluginInstalls.mockImplementation(
-      async (params: { nextConfig: OpenClawConfig }) => ({
-        config: withoutPluginInstallRecords(params.nextConfig),
-        installRecords: {},
-        movedInstallRecords: true,
-        persistedHash: "test-hash",
-      }),
+    mocks.currentConfig = {};
+    mocks.transformConfigWithPendingPluginInstalls.mockImplementation(
+      async (params: {
+        transform: (current: OpenClawConfig) => { nextConfig: OpenClawConfig };
+      }) => ({ nextConfig: params.transform(mocks.currentConfig).nextConfig }),
     );
-    mocks.replaceConfigFile.mockResolvedValue({ persistedHash: "next-hash" });
   });
 
-  it("rejects a normal write with pending records but no migration base", async () => {
-    const config: OpenClawConfig = {
-      plugins: { installs: { demo: { source: "npm", spec: "demo@1.0.0" } } },
-    };
-
-    await expect(writeWizardConfigFile(config, { allowConfigSizeDrop: false })).rejects.toThrow(
-      "declare migration ownership",
-    );
-    expect(mocks.commitConfigWriteWithPendingPluginInstalls).not.toHaveBeenCalled();
-  });
-
-  it("migrates the baseline as source before the final wizard write", async () => {
-    const baseConfig: OpenClawConfig = {
-      plugins: { installs: { demo: { source: "npm", spec: "demo@1.0.0" } } },
-    };
-
-    await writeWizardConfigFile(baseConfig, {
-      allowConfigSizeDrop: false,
-      migrationBaseConfig: baseConfig,
-    });
-
-    expect(mocks.commitConfigWriteWithPendingPluginInstalls).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        nextConfig: baseConfig,
-        sourceConfig: baseConfig,
-        writeOptions: { allowConfigSizeDrop: true },
-      }),
-    );
-    expect(mocks.commitConfigWriteWithPendingPluginInstalls).toHaveBeenCalledTimes(2);
-  });
-
-  it("commits fresh pending records after baseline migration is complete", async () => {
-    const config: OpenClawConfig = {
-      plugins: { installs: { fresh: { source: "npm", spec: "fresh@1.0.0" } } },
-    };
+  it("delegates CAS and pending-install ownership to the canonical transform", async () => {
+    const config: OpenClawConfig = { gateway: { port: 18789 } };
+    const baseSnapshot = { path: "/tmp/openclaw.json", exists: false } as ConfigFileSnapshot;
+    const afterWrite = { mode: "none" as const, reason: "restart after setup" };
 
     await writeWizardConfigFile(config, {
       allowConfigSizeDrop: false,
-      migrationBaseConfig: undefined,
+      baseHash: "verified-hash",
+      baseSnapshot,
+      afterWrite,
     });
 
-    expect(mocks.commitConfigWriteWithPendingPluginInstalls).toHaveBeenCalledOnce();
-    expect(mocks.commitConfigWriteWithPendingPluginInstalls).toHaveBeenCalledWith(
-      expect.objectContaining({ nextConfig: config }),
-    );
+    expect(mocks.transformConfigWithPendingPluginInstalls).toHaveBeenCalledWith({
+      baseHash: "verified-hash",
+      maxAttempts: 1,
+      afterWrite,
+      writeOptions: { allowConfigSizeDrop: false, baseSnapshot },
+      transform: expect.any(Function),
+    });
   });
 
-  it("binds the final write to the live-verified config hash", async () => {
-    const config: OpenClawConfig = { gateway: { port: 18789 } };
+  it("replaces config directly when no merge base is supplied", async () => {
+    const config: OpenClawConfig = {
+      plugins: { installs: { fresh: { source: "npm", spec: "fresh@1.0.0" } } },
+    };
+    mocks.currentConfig = { gateway: { port: 19001 } };
 
-    await writeWizardConfigFile(config, { baseHash: "verified-hash" });
-
-    const commit = mocks.commitConfigWriteWithPendingPluginInstalls.mock.calls[0]?.[0]?.commit;
-    expect(commit).toBeTypeOf("function");
-    await commit(config);
-    expect(mocks.replaceConfigFile).toHaveBeenCalledWith(
-      expect.objectContaining({
-        nextConfig: config,
-        baseHash: "verified-hash",
-        afterWrite: { mode: "auto" },
-      }),
-    );
+    await expect(writeWizardConfigFile(config)).resolves.toEqual(config);
   });
 
-  it("forwards an explicit deferred runtime follow-up to the config writer", async () => {
-    const config: OpenClawConfig = { gateway: { mode: "local", port: 19001 } };
-    const afterWrite = {
-      mode: "none" as const,
-      reason: "Gateway setup defers runtime apply until explicit restart",
+  it("applies only the wizard delta to a fresh concurrent config", async () => {
+    const base: OpenClawConfig = {
+      agents: { defaults: { workspace: "/old" } },
+      gateway: { port: 18789 },
+    };
+    const next: OpenClawConfig = {
+      agents: { defaults: { workspace: "/old" } },
+      gateway: { port: 19001 },
+    };
+    mocks.currentConfig = {
+      agents: { defaults: { workspace: "/concurrent" } },
+      gateway: { port: 18789 },
+      plugins: { entries: { demo: { enabled: true } } },
     };
 
-    await writeWizardConfigFile(config, { afterWrite });
-
-    const commit = mocks.commitConfigWriteWithPendingPluginInstalls.mock.calls[0]?.[0]?.commit;
-    expect(commit).toBeTypeOf("function");
-    await commit(config);
-    expect(mocks.replaceConfigFile).toHaveBeenCalledWith(
-      expect.objectContaining({ nextConfig: config, afterWrite }),
-    );
-  });
-
-  it("preserves an absent config snapshot through the final write", async () => {
-    const config: OpenClawConfig = { gateway: { port: 18789 } };
-    const baseSnapshot: ConfigFileSnapshot = {
-      path: "/tmp/openclaw.json",
-      exists: false,
-      raw: null,
-      parsed: undefined,
-      sourceConfig: {},
-      resolved: {},
-      valid: true,
-      runtimeConfig: {},
-      config: {},
-      issues: [],
-      warnings: [],
-      legacyIssues: [],
-    };
-
-    await writeWizardConfigFile(config, { baseSnapshot });
-
-    const commit = mocks.commitConfigWriteWithPendingPluginInstalls.mock.calls[0]?.[0]?.commit;
-    expect(commit).toBeTypeOf("function");
-    await commit(config);
-    expect(mocks.replaceConfigFile).toHaveBeenCalledWith(
-      expect.objectContaining({ nextConfig: config, snapshot: baseSnapshot }),
-    );
+    await expect(writeWizardConfigFile(next, { mergeBase: base })).resolves.toEqual({
+      agents: { defaults: { workspace: "/concurrent" } },
+      gateway: { port: 19001 },
+      plugins: { entries: { demo: { enabled: true } } },
+    });
   });
 });

--- a/src/wizard/setup.shared.ts
+++ b/src/wizard/setup.shared.ts
@@ -1,17 +1,12 @@
 // Shared setup-wizard steps used by the classic wizard and the bootstrap onboarding flow.
-import { isDeepStrictEqual } from "node:util";
 import type { GatewayAuthChoice, OnboardOptions } from "../commands/onboard-types.js";
-import { createConfigIO, replaceConfigFile, resolveGatewayPort } from "../config/config.js";
+import { createConfigIO, resolveGatewayPort } from "../config/config.js";
+import type { ConfigWriteOptions } from "../config/io.js";
+import { applyMergePatch, createMergePatch } from "../config/merge-patch.js";
 import type { ConfigWriteAfterWrite } from "../config/runtime-snapshot.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  commitConfigWriteWithPendingPluginInstalls,
-  hasPendingPluginInstallRecords,
-  stripPendingPluginInstallRecords,
-  unchangedPendingPluginInstallRecordIds,
-} from "../plugins/install-record-commit.js";
+import { transformConfigWithPendingPluginInstalls } from "../plugins/install-record-commit.js";
 import { resolveDefaultSecretProviderAlias } from "../secrets/ref-contract.js";
-import { isPlainObject } from "../utils.js";
 import { t } from "./i18n/index.js";
 import { WizardCancelledError, type WizardPrompter } from "./prompts.js";
 import {
@@ -48,105 +43,44 @@ export function hasQuickstartGatewayOverrides(
   );
 }
 
-function mergeWizardConfigValueOntoLatest(current: unknown, base: unknown, next: unknown): unknown {
-  if (isDeepStrictEqual(next, base)) {
-    return current;
-  }
-  if (isPlainObject(current) && isPlainObject(base) && isPlainObject(next)) {
-    const merged: Record<string, unknown> = { ...current };
-    const keys = new Set([...Object.keys(current), ...Object.keys(base), ...Object.keys(next)]);
-    for (const key of keys) {
-      const mergedValue = mergeWizardConfigValueOntoLatest(current[key], base[key], next[key]);
-      if (mergedValue === undefined) {
-        delete merged[key];
-      } else {
-        merged[key] = mergedValue;
-      }
-    }
-    return merged;
-  }
-  return structuredClone(next);
-}
-
-/** Preserve concurrent edits while applying only changes made by an interactive wizard. */
-export function mergeWizardConfigOntoLatest(
-  current: OpenClawConfig,
-  base: OpenClawConfig,
-  next: OpenClawConfig,
-): OpenClawConfig {
-  return mergeWizardConfigValueOntoLatest(current, base, next) as OpenClawConfig;
-}
-
 /**
  * Config writes go through the pending-plugin-install commit helper so wizard
  * flows never drop install records that a concurrent migration already staged.
  */
 export async function writeWizardConfigFile(
-  configInput: OpenClawConfig,
+  config: OpenClawConfig,
   opts: {
     allowConfigSizeDrop?: boolean;
     /** Reject the write if config changed after the caller's verified snapshot. */
     baseHash?: string;
     /** Preserve an absent-file precondition that cannot be represented by baseHash. */
     baseSnapshot?: ConfigFileSnapshot;
-    migrationBaseConfig?: OpenClawConfig;
-    onPendingPluginInstallMigration?: () => void;
+    /** Apply only the wizard's delta to the latest authored config. */
+    mergeBase?: OpenClawConfig;
+    writeOptions?: ConfigWriteOptions;
     /** Runtime follow-up intent for the Gateway config watcher. */
     afterWrite?: ConfigWriteAfterWrite;
   } = {},
 ): Promise<OpenClawConfig> {
-  let config = configInput;
-  let baseHash = opts.baseHash;
-  let baseSnapshot = opts.baseSnapshot;
-  const allowConfigSizeDrop = opts.allowConfigSizeDrop === true;
-  const afterWrite = opts.afterWrite ?? { mode: "auto" };
-  if (!allowConfigSizeDrop && hasPendingPluginInstallRecords(config)) {
-    // Explicit undefined means this writer already migrated its baseline; an omitted
-    // key cannot distinguish fresh pending records from stale authored metadata.
-    if (!Object.hasOwn(opts, "migrationBaseConfig")) {
-      throw new Error(
-        "Wizard config writes with pending plugin installs must declare migration ownership.",
-      );
-    }
-    const migrationBaseConfig = opts.migrationBaseConfig;
-    if (migrationBaseConfig && hasPendingPluginInstallRecords(migrationBaseConfig)) {
-      const migration = await commitConfigWriteWithPendingPluginInstalls({
-        nextConfig: migrationBaseConfig,
-        sourceConfig: migrationBaseConfig,
-        writeOptions: { allowConfigSizeDrop: true },
-        commit: async (nextConfig, writeOptions) => {
-          return await replaceConfigFile({
-            nextConfig,
-            ...(baseSnapshot ? { snapshot: baseSnapshot } : {}),
-            ...(baseHash !== undefined ? { baseHash } : {}),
-            ...(writeOptions ? { writeOptions } : {}),
-            afterWrite,
-          });
-        },
-      });
-      baseHash = migration.persistedHash ?? undefined;
-      baseSnapshot = undefined;
-      config = stripPendingPluginInstallRecords(
-        config,
-        unchangedPendingPluginInstallRecordIds(config, migrationBaseConfig),
-      );
-      opts.onPendingPluginInstallMigration?.();
-    }
-  }
-  const committed = await commitConfigWriteWithPendingPluginInstalls({
-    nextConfig: config,
-    writeOptions: { allowConfigSizeDrop },
-    commit: async (nextConfig, writeOptions) => {
-      return await replaceConfigFile({
-        nextConfig,
-        ...(baseSnapshot ? { snapshot: baseSnapshot } : {}),
-        ...(baseHash !== undefined ? { baseHash } : {}),
-        ...(writeOptions ? { writeOptions } : {}),
-        afterWrite,
-      });
+  const committed = await transformConfigWithPendingPluginInstalls({
+    ...(opts.baseHash !== undefined ? { baseHash: opts.baseHash } : {}),
+    // Caller-owned snapshots are one-shot CAS preconditions, not retry baselines.
+    ...(opts.baseHash !== undefined || opts.baseSnapshot ? { maxAttempts: 1 } : {}),
+    ...(opts.afterWrite ? { afterWrite: opts.afterWrite } : {}),
+    writeOptions: {
+      ...opts.writeOptions,
+      ...(opts.allowConfigSizeDrop !== undefined
+        ? { allowConfigSizeDrop: opts.allowConfigSizeDrop }
+        : {}),
+      ...(opts.baseSnapshot ? { baseSnapshot: opts.baseSnapshot } : {}),
     },
+    transform: (current) => ({
+      nextConfig: opts.mergeBase
+        ? (applyMergePatch(current, createMergePatch(opts.mergeBase, config)) as OpenClawConfig)
+        : config,
+    }),
   });
-  return committed.config;
+  return committed.nextConfig;
 }
 
 export async function readSetupConfigFileSnapshot() {

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../agents/auth-profiles/oauth-test-utils.js";
 import { upsertAuthProfileWithLock } from "../agents/auth-profiles/profiles.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../agents/workspace.js";
+import { ConfigMutationConflictError } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginCompatibilityNotice } from "../plugins/status.js";
 import type { ProviderAuthResult } from "../plugins/types.js";
@@ -169,7 +170,13 @@ function providerPluginStub(
 const healthCommand = vi.hoisted(() => vi.fn(async () => {}));
 const ensureWorkspaceAndSessions = vi.hoisted(() => vi.fn(async () => {}));
 const replaceConfigFile = vi.hoisted(() =>
-  vi.fn(async (params: { nextConfig: OpenClawConfig }) => ({ config: params.nextConfig })),
+  vi.fn(
+    async (params: {
+      nextConfig: OpenClawConfig;
+      snapshot?: { hash?: string };
+      baseHash?: string;
+    }) => ({ config: params.nextConfig }),
+  ),
 );
 const resolveGatewayPort = vi.hoisted(() =>
   vi.fn((_cfg?: unknown, env?: NodeJS.ProcessEnv) => {
@@ -404,13 +411,17 @@ vi.mock("../system-agent/setup-inference.js", () => ({
   verifySetupInferenceConfig,
 }));
 
-vi.mock("../config/config.js", () => ({
-  DEFAULT_GATEWAY_PORT: 18789,
-  createConfigIO,
-  readConfigFileSnapshot,
-  resolveGatewayPort,
-  replaceConfigFile,
-}));
+vi.mock("../config/config.js", async (importActual) => {
+  const actual = await importActual<typeof import("../config/config.js")>();
+  return {
+    DEFAULT_GATEWAY_PORT: 18789,
+    ConfigMutationConflictError: actual.ConfigMutationConflictError,
+    createConfigIO,
+    readConfigFileSnapshot,
+    resolveGatewayPort,
+    replaceConfigFile,
+  };
+});
 vi.mock("../commands/onboard-agent.js", async () => {
   const { resolveDefaultAgentId } = await import("../agents/agent-scope-config.js");
   return {
@@ -585,10 +596,18 @@ describe("runSetupWizard", () => {
         tailscaleResetOnExit: false,
       },
     }));
+    let authoredConfig: OpenClawConfig | undefined;
     readConfigFileSnapshot.mockReset();
-    readConfigFileSnapshot.mockResolvedValue(
-      configSnapshot({}, false, { agents: { entries: { main: { default: true } } } }),
+    readConfigFileSnapshot.mockImplementation(async () =>
+      authoredConfig
+        ? configSnapshot(authoredConfig)
+        : configSnapshot({}, false, { agents: { entries: { main: { default: true } } } }),
     );
+    replaceConfigFile.mockReset();
+    replaceConfigFile.mockImplementation(async (params) => {
+      authoredConfig = structuredClone(params.nextConfig);
+      return { config: params.nextConfig };
+    });
     probeGatewayReachable.mockReset();
     probeGatewayReachable.mockResolvedValue({ ok: false });
     resolvePreferredProviderForAuthChoice.mockReset();
@@ -799,6 +818,99 @@ describe("runSetupWizard", () => {
     expect(setupSkills).not.toHaveBeenCalled();
     expect(healthCommand).not.toHaveBeenCalled();
     expect(runTui).not.toHaveBeenCalled();
+  });
+
+  it("preserves an unrelated config edit made during classic onboarding", async () => {
+    const initialConfig: OpenClawConfig = { ui: { seamColor: "blue" } };
+    let diskConfig = structuredClone(initialConfig);
+    let diskHash = "hash-1";
+    const snapshotFromDisk = () => ({
+      ...configSnapshot(diskConfig),
+      hash: diskHash,
+    });
+    readConfigFileSnapshot.mockImplementation(async () => snapshotFromDisk());
+    replaceConfigFile.mockImplementation(async (params) => {
+      expect(params.snapshot?.hash).toBe(diskHash);
+      expect(params.baseHash).toBe(diskHash);
+      diskConfig = structuredClone(params.nextConfig);
+      diskHash = `hash-${Number(diskHash.slice(5)) + 1}`;
+      return { config: diskConfig };
+    });
+    setupChannels.mockImplementationOnce(async (config) => {
+      diskConfig = {
+        ...diskConfig,
+        ui: { ...diskConfig.ui, seamColor: "green" },
+      };
+      diskHash = "external-edit";
+      return config;
+    });
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        authChoice: "skip",
+        installDaemon: false,
+        skipChannels: false,
+        skipSkills: true,
+        skipSearch: true,
+        skipHealth: true,
+        skipUi: true,
+        workspace: "/tmp/concurrent-onboarding-workspace",
+      },
+      createRuntime(),
+      buildWizardPrompter(),
+    );
+
+    expect(diskConfig.ui?.seamColor).toBe("green");
+    expect(diskConfig.agents?.defaults?.workspace).toBe("/tmp/concurrent-onboarding-workspace");
+    expect(diskConfig.hooks?.internal?.entries?.["session-memory"]?.enabled).toBe(true);
+  });
+
+  it("re-reads and merges the latest config after a write conflict", async () => {
+    let diskConfig: OpenClawConfig = { ui: { seamColor: "blue" } };
+    let diskHash = "hash-1";
+    let writeAttempts = 0;
+    readConfigFileSnapshot.mockImplementation(async () => ({
+      ...configSnapshot(diskConfig),
+      hash: diskHash,
+    }));
+    replaceConfigFile.mockImplementation(async (params) => {
+      expect(params.snapshot?.hash).toBe(diskHash);
+      expect(params.baseHash).toBe(diskHash);
+      writeAttempts += 1;
+      if (writeAttempts === 1) {
+        diskConfig = { ...diskConfig, ui: { ...diskConfig.ui, seamColor: "green" } };
+        diskHash = "external-edit";
+        throw new ConfigMutationConflictError("config changed since last load", {
+          currentHash: diskHash,
+        });
+      }
+      diskConfig = structuredClone(params.nextConfig);
+      diskHash = `committed-${writeAttempts}`;
+      return { config: diskConfig, persistedHash: diskHash };
+    });
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        authChoice: "skip",
+        installDaemon: false,
+        skipChannels: true,
+        skipSkills: true,
+        skipSearch: true,
+        skipHealth: true,
+        skipUi: true,
+        workspace: "/tmp/conflicting-onboarding-workspace",
+      },
+      createRuntime(),
+      buildWizardPrompter(),
+    );
+
+    expect(writeAttempts).toBe(4);
+    expect(diskConfig.ui?.seamColor).toBe("green");
+    expect(diskConfig.agents?.defaults?.workspace).toBe("/tmp/conflicting-onboarding-workspace");
   });
 
   it("seeds interactive remote setup from command flags", async () => {
@@ -1321,13 +1433,9 @@ describe("runSetupWizard", () => {
 
   it("keeps verification optional when provider setup supplies the post-import model", async () => {
     const workspaceDir = await makeCaseDir("provider-after-import-");
-    readConfigFileSnapshot
-      .mockResolvedValueOnce(
-        configSnapshot({}, false, { agents: { entries: { main: { default: true } } } }),
-      )
-      .mockResolvedValue(
-        configSnapshot({}, true, { agents: { entries: { main: { default: true } } } }),
-      );
+    readConfigFileSnapshot.mockResolvedValueOnce(
+      configSnapshot({}, false, { agents: { entries: { main: { default: true } } } }),
+    );
     applyAuthChoice.mockImplementation(async (args) => ({
       config: {
         ...args.config,
@@ -1445,9 +1553,8 @@ describe("runSetupWizard", () => {
     expect(prompter.select).not.toHaveBeenCalled();
   });
 
-  it("allows size-drop writes for pending plugin install record migration", async () => {
-    replaceConfigFile.mockClear();
-    readConfigFileSnapshot.mockResolvedValueOnce({
+  it("preserves concurrent edits while migrating pending plugin install records", async () => {
+    const pendingInstallSnapshot = {
       path: "/tmp/.openclaw/openclaw.json",
       exists: true,
       raw: "{}",
@@ -1466,6 +1573,40 @@ describe("runSetupWizard", () => {
       issues: [],
       warnings: [],
       legacyIssues: [],
+    };
+    let diskConfig = structuredClone(pendingInstallSnapshot.config) as OpenClawConfig;
+    let diskHash = "pending-1";
+    let snapshotReads = 0;
+    let writeAttempts = 0;
+    readConfigFileSnapshot.mockImplementation(async () => {
+      snapshotReads += 1;
+      if (snapshotReads === 2) {
+        diskConfig = { ...diskConfig, ui: { seamColor: "red" } };
+        diskHash = "external-before-migration";
+      }
+      return {
+        ...pendingInstallSnapshot,
+        config: diskConfig,
+        sourceConfig: diskConfig,
+        parsed: diskConfig,
+        resolved: diskConfig,
+        sourceConfigBeforeMigrations: diskConfig,
+        hash: diskHash,
+      };
+    });
+    replaceConfigFile.mockImplementation(async (params) => {
+      expect(params.snapshot?.hash ?? params.baseHash).toBe(diskHash);
+      writeAttempts += 1;
+      if (writeAttempts === 2) {
+        diskConfig = { ...diskConfig, ui: { seamColor: "green" } };
+        diskHash = "external-pending-edit";
+        throw new ConfigMutationConflictError("config changed since last load", {
+          currentHash: diskHash,
+        });
+      }
+      diskConfig = structuredClone(params.nextConfig);
+      diskHash = `pending-${writeAttempts + 1}`;
+      return { config: diskConfig, persistedHash: diskHash };
     });
 
     const workspaceDir = await makeCaseDir("plugin-install-migration-");
@@ -1503,8 +1644,8 @@ describe("runSetupWizard", () => {
       prompter,
     );
 
-    // Migration write + pre-channels persist + post-channels write + final write.
-    expect(replaceConfigFile).toHaveBeenCalledTimes(4);
+    // Migration write + conflicted persist + retry + post-channels write + final write.
+    expect(replaceConfigFile).toHaveBeenCalledTimes(5);
     const migrationParams = requireRecord(
       getMockCallArg(replaceConfigFile, 0, 0, "migration config replacement"),
       "migration config replacement params",
@@ -1512,6 +1653,9 @@ describe("runSetupWizard", () => {
     expect(
       requireRecord(migrationParams.nextConfig, "migration next config").plugins,
     ).toBeUndefined();
+    expect(requireRecord(migrationParams.nextConfig, "migration next config").ui).toEqual({
+      seamColor: "red",
+    });
     const migrationWriteOptions = expectRecordFields(
       migrationParams.writeOptions,
       { allowConfigSizeDrop: true },
@@ -1520,10 +1664,13 @@ describe("runSetupWizard", () => {
     expect(migrationWriteOptions.unsetPaths).toContainEqual(["plugins", "installs"]);
 
     const replaceParams = requireRecord(
-      getMockCallArg(replaceConfigFile, 3, 0, "config replacement"),
+      getMockCallArg(replaceConfigFile, 4, 0, "config replacement"),
       "config replacement params",
     );
     expect(requireRecord(replaceParams.nextConfig, "next config").plugins).toBeUndefined();
+    expect(requireRecord(replaceParams.nextConfig, "next config").ui).toEqual({
+      seamColor: "green",
+    });
     expectRecordFields(
       replaceParams.writeOptions,
       { allowConfigSizeDrop: false },

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -13,7 +13,7 @@ import {
 import { upsertAuthProfileWithLock } from "../agents/auth-profiles/profiles.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../agents/workspace.js";
 import { ConfigMutationConflictError } from "../config/config.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginCompatibilityNotice } from "../plugins/status.js";
 import type { ProviderAuthResult } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -418,8 +418,53 @@ vi.mock("../config/config.js", async (importActual) => {
     ConfigMutationConflictError: actual.ConfigMutationConflictError,
     createConfigIO,
     readConfigFileSnapshot,
+    resolveConfigWriteAfterWrite: actual.resolveConfigWriteAfterWrite,
     resolveGatewayPort,
     replaceConfigFile,
+    transformConfigFileWithRetry: async (params: {
+      base?: "runtime" | "source";
+      maxAttempts?: number;
+      writeOptions?: Record<string, unknown>;
+      transform: (
+        config: OpenClawConfig,
+        context: {
+          snapshot: Record<string, unknown>;
+          previousHash: string | null;
+          attempt: number;
+        },
+      ) => Promise<{ nextConfig: OpenClawConfig }> | { nextConfig: OpenClawConfig };
+      commit: (params: Record<string, unknown>) => Promise<{ config: OpenClawConfig }>;
+    }) => {
+      const maxAttempts = params.maxAttempts ?? 5;
+      for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+        const snapshot = (await readConfigFileSnapshot()) as ConfigFileSnapshot;
+        const previousHash = snapshot.hash ?? null;
+        const config =
+          params.base === "runtime"
+            ? (snapshot.runtimeConfig ?? snapshot.config)
+            : (snapshot.sourceConfig ?? snapshot.config);
+        try {
+          const transformed = await params.transform(config, { snapshot, previousHash, attempt });
+          const committed = await params.commit({
+            nextConfig: transformed.nextConfig,
+            snapshot,
+            ...(previousHash ? { baseHash: previousHash } : {}),
+            writeOptions: params.writeOptions,
+            afterWrite: { mode: "auto" },
+          });
+          return { nextConfig: committed.config };
+        } catch (error) {
+          if (
+            !(error instanceof actual.ConfigMutationConflictError) ||
+            !error.retryable ||
+            attempt === maxAttempts - 1
+          ) {
+            throw error;
+          }
+        }
+      }
+      throw new Error("unreachable");
+    },
   };
 });
 vi.mock("../commands/onboard-agent.js", async () => {
@@ -1644,8 +1689,8 @@ describe("runSetupWizard", () => {
       prompter,
     );
 
-    // Migration write + conflicted persist + retry + post-channels write + final write.
-    expect(replaceConfigFile).toHaveBeenCalledTimes(5);
+    // Initial commit (including migration) + conflicted persist + retry + final write.
+    expect(replaceConfigFile).toHaveBeenCalledTimes(4);
     const migrationParams = requireRecord(
       getMockCallArg(replaceConfigFile, 0, 0, "migration config replacement"),
       "migration config replacement params",
@@ -1658,13 +1703,13 @@ describe("runSetupWizard", () => {
     });
     const migrationWriteOptions = expectRecordFields(
       migrationParams.writeOptions,
-      { allowConfigSizeDrop: true },
+      { allowConfigSizeDrop: false },
       "migration config replacement write options",
     );
     expect(migrationWriteOptions.unsetPaths).toContainEqual(["plugins", "installs"]);
 
     const replaceParams = requireRecord(
-      getMockCallArg(replaceConfigFile, 4, 0, "config replacement"),
+      getMockCallArg(replaceConfigFile, 3, 0, "config replacement"),
       "config replacement params",
     );
     expect(requireRecord(replaceParams.nextConfig, "next config").plugins).toBeUndefined();
@@ -1706,7 +1751,7 @@ describe("runSetupWizard", () => {
     applyAuthChoice.mockClear();
     promptDefaultModel.mockClear();
     replaceConfigFile.mockClear();
-    readConfigFileSnapshot.mockResolvedValueOnce({
+    readConfigFileSnapshot.mockResolvedValue({
       path: "/tmp/.openclaw/openclaw.json",
       exists: true,
       raw: "{}",

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -32,7 +32,6 @@ import { runSetupModelAuthStep, type SetupModelAuthCandidate } from "./setup.mod
 import { resolveSetupSecretInputString } from "./setup.secret-input.js";
 import {
   hasQuickstartGatewayOverrides,
-  mergeWizardConfigOntoLatest,
   readSetupConfigFileSnapshot,
   readValidSetupConfigFile,
   requireRiskAcknowledgement,
@@ -94,44 +93,16 @@ async function runSetupWizardOnce(
   // Ordinary onboard reruns must preserve existing agents.list / bindings. Only
   // explicit reset or import flows are allowed to shrink the config — see issue
   // openclaw#84692.
-  let shouldMigratePendingPluginInstalls = true;
   const writeSetupConfigFile = async (
     config: OpenClawConfig,
     optsLocal: { allowConfigSizeDrop?: boolean } = {},
   ) => {
-    const maxAttempts = 3;
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const latest = await readSetupConfigFileSnapshot();
-      if (!latest.valid) {
-        throw new Error("Setup target config became invalid. Run `openclaw doctor`.");
-      }
-      const latestConfig = latest.exists ? (latest.sourceConfig ?? latest.config) : {};
-      const mergedConfig = mergeWizardConfigOntoLatest(latestConfig, setupConfigMergeBase, config);
-      try {
-        const committed = await writeWizardConfigFile(mergedConfig, {
-          ...optsLocal,
-          baseSnapshot: latest,
-          ...(latest.hash !== undefined ? { baseHash: latest.hash } : {}),
-          // The migration payload must come from the same fresh snapshot as its
-          // CAS precondition, or an unrelated concurrent edit can be overwritten.
-          migrationBaseConfig: shouldMigratePendingPluginInstalls ? latestConfig : undefined,
-          onPendingPluginInstallMigration: () => {
-            shouldMigratePendingPluginInstalls = false;
-          },
-        });
-        setupConfigMergeBase = structuredClone(committed);
-        return committed;
-      } catch (error) {
-        if (
-          !(error instanceof ConfigMutationConflictError) ||
-          !error.retryable ||
-          attempt === maxAttempts - 1
-        ) {
-          throw error;
-        }
-      }
-    }
-    throw new Error("Setup config write retry limit exhausted.");
+    const committed = await writeWizardConfigFile(config, {
+      ...optsLocal,
+      mergeBase: setupConfigMergeBase,
+    });
+    setupConfigMergeBase = structuredClone(committed);
+    return committed;
   };
 
   if (snapshot.exists && !snapshot.valid) {
@@ -305,7 +276,6 @@ async function runSetupWizardOnce(
     currentSetupSnapshot = migratedSnapshot;
     baseConfig = migratedSnapshot.runtimeConfig ?? migratedSnapshot.config;
     setupConfigMergeBase = structuredClone(baseConfig);
-    shouldMigratePendingPluginInstalls = true;
     const importedModelRef = resolveAgentModelPrimaryValue(baseConfig.agents?.defaults?.model);
     importedInferenceVerified =
       migrationOutcome.kind === "verified-inference" &&

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -32,6 +32,7 @@ import { runSetupModelAuthStep, type SetupModelAuthCandidate } from "./setup.mod
 import { resolveSetupSecretInputString } from "./setup.secret-input.js";
 import {
   hasQuickstartGatewayOverrides,
+  mergeWizardConfigOntoLatest,
   readSetupConfigFileSnapshot,
   readValidSetupConfigFile,
   requireRiskAcknowledgement,
@@ -88,22 +89,50 @@ async function runSetupWizardOnce(
   let baseConfig: OpenClawConfig = snapshot.valid
     ? (snapshot.runtimeConfig ?? snapshot.config)
     : {};
+  let setupConfigMergeBase = structuredClone(baseConfig);
   baseConfig = await requireRiskAcknowledgement({ opts, prompter, config: baseConfig });
   // Ordinary onboard reruns must preserve existing agents.list / bindings. Only
   // explicit reset or import flows are allowed to shrink the config — see issue
   // openclaw#84692.
-  let pendingPluginInstallMigrationBaseConfig: OpenClawConfig | undefined = baseConfig;
+  let shouldMigratePendingPluginInstalls = true;
   const writeSetupConfigFile = async (
     config: OpenClawConfig,
     optsLocal: { allowConfigSizeDrop?: boolean } = {},
-  ) =>
-    await writeWizardConfigFile(config, {
-      ...optsLocal,
-      migrationBaseConfig: pendingPluginInstallMigrationBaseConfig,
-      onPendingPluginInstallMigration: () => {
-        pendingPluginInstallMigrationBaseConfig = undefined;
-      },
-    });
+  ) => {
+    const maxAttempts = 3;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const latest = await readSetupConfigFileSnapshot();
+      if (!latest.valid) {
+        throw new Error("Setup target config became invalid. Run `openclaw doctor`.");
+      }
+      const latestConfig = latest.exists ? (latest.sourceConfig ?? latest.config) : {};
+      const mergedConfig = mergeWizardConfigOntoLatest(latestConfig, setupConfigMergeBase, config);
+      try {
+        const committed = await writeWizardConfigFile(mergedConfig, {
+          ...optsLocal,
+          baseSnapshot: latest,
+          ...(latest.hash !== undefined ? { baseHash: latest.hash } : {}),
+          // The migration payload must come from the same fresh snapshot as its
+          // CAS precondition, or an unrelated concurrent edit can be overwritten.
+          migrationBaseConfig: shouldMigratePendingPluginInstalls ? latestConfig : undefined,
+          onPendingPluginInstallMigration: () => {
+            shouldMigratePendingPluginInstalls = false;
+          },
+        });
+        setupConfigMergeBase = structuredClone(committed);
+        return committed;
+      } catch (error) {
+        if (
+          !(error instanceof ConfigMutationConflictError) ||
+          !error.retryable ||
+          attempt === maxAttempts - 1
+        ) {
+          throw error;
+        }
+      }
+    }
+    throw new Error("Setup config write retry limit exhausted.");
+  };
 
   if (snapshot.exists && !snapshot.valid) {
     await prompter.note(
@@ -275,7 +304,8 @@ async function runSetupWizardOnce(
     }
     currentSetupSnapshot = migratedSnapshot;
     baseConfig = migratedSnapshot.runtimeConfig ?? migratedSnapshot.config;
-    pendingPluginInstallMigrationBaseConfig = baseConfig;
+    setupConfigMergeBase = structuredClone(baseConfig);
+    shouldMigratePendingPluginInstalls = true;
     const importedModelRef = resolveAgentModelPrimaryValue(baseConfig.agents?.defaults?.model);
     importedInferenceVerified =
       migrationOutcome.kind === "verified-inference" &&

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -30,6 +30,42 @@ async function settleUi(page: Page): Promise<void> {
 }
 
 suite.define(() => {
+  it("does not reopen agent chat when a deferred setup reply arrives after exit", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
+          deferredMethods: ["openclaw.chat"],
+          methodResponses: {},
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}custodian?onboarding=1`);
+        expect(response?.status()).toBe(200);
+        await gateway.waitForRequest("openclaw.chat");
+        await page.getByRole("button", { name: "Exit setup" }).click();
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/chat/main");
+        const destination = page.url();
+        const agentListRequests = (await gateway.getRequests("agents.list")).length;
+
+        await gateway.resolveDeferred("openclaw.chat", {
+          sessionId: "late-e2e-custodian",
+          reply: "Your agent is hatching — handing you over now.",
+          action: "open-agent",
+          agentId: "main",
+          agentDraft: "hatch",
+        });
+        await expect.poll(() => page.url()).toBe(destination);
+        expect(new URL(page.url()).searchParams.has("draft")).toBe(false);
+        expect((await gateway.getRequests("agents.list")).length).toBe(agentListRequests);
+      },
+    );
+  });
+
   it("shows one consequential nudge and sends its canonical message", async () => {
     if (captureUiProofEnabled) {
       await mkdir(uiProofArtifactDir, { recursive: true });

--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -42,6 +42,9 @@ suite.define(() => {
   it("hands first-run model setup to the custodian in onboarding chrome", async () => {
     await suite.withPage(
       {
+        ...(artifactDir
+          ? { recordVideo: { dir: artifactDir, size: { width: 1280, height: 900 } } }
+          : {}),
         locale: "en-US",
         serviceWorkers: "block",
         viewport: { height: 900, width: 1280 },
@@ -116,6 +119,23 @@ suite.define(() => {
         await expect
           .poll(async () => page.locator(".model-setup-success").textContent())
           .toContain("Verified in 73 ms");
+        await gateway.setMethodResponse("openclaw.setup.detect", {
+          candidates: [],
+          manualProviders: [{ id: "openai", label: "OpenAI" }],
+          workspace: "/tmp/openclaw-e2e",
+          setupComplete: true,
+          configuredModel: "openai/gpt-5",
+        });
+        await page.getByRole("button", { name: "Stay in settings" }).click();
+        await page.getByRole("button", { name: "Continue setup" }).waitFor();
+        await page.reload();
+        await page.getByRole("button", { name: "Continue setup" }).waitFor();
+        if (artifactDir) {
+          await mkdir(artifactDir, { recursive: true });
+          await page.screenshot({
+            path: path.join(artifactDir, "model-setup-durable-continuation.png"),
+          });
+        }
         await page.getByRole("button", { name: "Continue setup" }).click();
         await expect.poll(() => new URL(page.url()).pathname).toBe("/custodian");
         expect(new URL(page.url()).searchParams.get("onboarding")).toBe("1");
@@ -126,6 +146,11 @@ suite.define(() => {
           .poll(() => page.locator(".shell").getAttribute("class"))
           .toContain("shell--onboarding");
         expect(await page.locator(".shell-nav").isVisible()).toBe(false);
+        if (artifactDir) {
+          await page.screenshot({
+            path: path.join(artifactDir, "custodian-onboarding-handoff.png"),
+          });
+        }
 
         const chatRequest = await gateway.waitForRequest("openclaw.chat");
         expect(chatRequest.params).toMatchObject({

--- a/ui/src/pages/custodian/custodian-session-store.test.ts
+++ b/ui/src/pages/custodian/custodian-session-store.test.ts
@@ -105,11 +105,13 @@ describe("CustodianSessionStore", () => {
 
   it("does not let a late onboarding reply navigate after the destination rotates context", async () => {
     let resolveReply!: (value: unknown) => void;
+    let requestSignal: AbortSignal | undefined;
     const request = vi
       .fn()
       .mockImplementationOnce(
-        () =>
+        (_method: string, _params: unknown, options?: { signal?: AbortSignal }) =>
           new Promise((resolve) => {
+            requestSignal = options?.signal;
             resolveReply = resolve;
           }),
       )
@@ -120,6 +122,7 @@ describe("CustodianSessionStore", () => {
     await waitForFast(() => expect(request).toHaveBeenCalledOnce());
 
     store.exitSetup();
+    expect(requestSignal?.aborted).toBe(true);
     store.connect(context, "caretaker");
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     resolveReply({
@@ -139,10 +142,13 @@ describe("CustodianSessionStore", () => {
 
   it("does not let a late reply navigate away from channel setup", async () => {
     let resolveReply!: (value: unknown) => void;
-    const request = vi.fn().mockReturnValue(
-      new Promise((resolve) => {
-        resolveReply = resolve;
-      }),
+    let requestSignal: AbortSignal | undefined;
+    const request = vi.fn().mockImplementation(
+      (_method: string, _params: unknown, options?: { signal?: AbortSignal }) =>
+        new Promise((resolve) => {
+          requestSignal = options?.signal;
+          resolveReply = resolve;
+        }),
     );
     const { context } = createContext(request);
     const store = new CustodianSessionStore();
@@ -150,6 +156,8 @@ describe("CustodianSessionStore", () => {
     await waitForFast(() => expect(request).toHaveBeenCalledOnce());
 
     store.openChannelsFromOnboarding();
+    expect(requestSignal?.aborted).toBe(true);
+    expect(store.sending).toBe(false);
     resolveReply({
       sessionId: "late-channel-session",
       reply: "Your agent is ready.",
@@ -157,19 +165,23 @@ describe("CustodianSessionStore", () => {
       agentId: "main",
       agentDraft: "hatch",
     });
-    await waitForFast(() => expect(store.messages.at(-1)?.text).toBe("Your agent is ready."));
+    await Promise.resolve();
 
     expect(context.navigate).toHaveBeenCalledTimes(1);
     expect(context.navigate).toHaveBeenCalledWith("channels");
     expect(context.agents.refreshList).not.toHaveBeenCalled();
+    expect(store.canRetry()).toBe(false);
   });
 
   it("does not let a late reply navigate away from model setup", async () => {
     let resolveReply!: (value: unknown) => void;
-    const request = vi.fn().mockReturnValue(
-      new Promise((resolve) => {
-        resolveReply = resolve;
-      }),
+    let requestSignal: AbortSignal | undefined;
+    const request = vi.fn().mockImplementation(
+      (_method: string, _params: unknown, options?: { signal?: AbortSignal }) =>
+        new Promise((resolve) => {
+          requestSignal = options?.signal;
+          resolveReply = resolve;
+        }),
     );
     const { context } = createContext(request);
     const store = new CustodianSessionStore();
@@ -177,6 +189,8 @@ describe("CustodianSessionStore", () => {
     await waitForFast(() => expect(request).toHaveBeenCalledOnce());
 
     store.openModelSetup();
+    expect(requestSignal?.aborted).toBe(true);
+    expect(store.sending).toBe(false);
     resolveReply({
       sessionId: "late-model-setup-session",
       reply: "Your agent is ready.",
@@ -184,7 +198,7 @@ describe("CustodianSessionStore", () => {
       agentId: "main",
       agentDraft: "hatch",
     });
-    await waitForFast(() => expect(store.messages.at(-1)?.text).toBe("Your agent is ready."));
+    await Promise.resolve();
 
     expect(context.navigate).toHaveBeenCalledTimes(1);
     expect(context.navigate).toHaveBeenCalledWith("model-setup");

--- a/ui/src/pages/custodian/custodian-session-store.test.ts
+++ b/ui/src/pages/custodian/custodian-session-store.test.ts
@@ -103,6 +103,94 @@ describe("CustodianSessionStore", () => {
     await expect(store.send("should not send")).resolves.toBe("rejected");
   });
 
+  it("does not let a late onboarding reply navigate after the destination rotates context", async () => {
+    let resolveReply!: (value: unknown) => void;
+    const request = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveReply = resolve;
+          }),
+      )
+      .mockReturnValue(new Promise(() => {}));
+    const { context } = createContext(request);
+    const store = new CustodianSessionStore();
+    store.connect(context, "onboarding");
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    store.exitSetup();
+    store.connect(context, "caretaker");
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+    resolveReply({
+      sessionId: "late-session",
+      reply: "Your agent is ready.",
+      action: "open-agent",
+      agentId: "main",
+      agentDraft: "hatch",
+    });
+    await Promise.resolve();
+
+    expect(context.navigate).toHaveBeenCalledTimes(1);
+    expect(context.navigate).toHaveBeenCalledWith("chat");
+    expect(context.agents.refreshList).not.toHaveBeenCalled();
+    expect(store.messages).toEqual([]);
+  });
+
+  it("does not let a late reply navigate away from channel setup", async () => {
+    let resolveReply!: (value: unknown) => void;
+    const request = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveReply = resolve;
+      }),
+    );
+    const { context } = createContext(request);
+    const store = new CustodianSessionStore();
+    store.connect(context, "onboarding");
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    store.openChannelsFromOnboarding();
+    resolveReply({
+      sessionId: "late-channel-session",
+      reply: "Your agent is ready.",
+      action: "open-agent",
+      agentId: "main",
+      agentDraft: "hatch",
+    });
+    await waitForFast(() => expect(store.messages.at(-1)?.text).toBe("Your agent is ready."));
+
+    expect(context.navigate).toHaveBeenCalledTimes(1);
+    expect(context.navigate).toHaveBeenCalledWith("channels");
+    expect(context.agents.refreshList).not.toHaveBeenCalled();
+  });
+
+  it("does not let a late reply navigate away from model setup", async () => {
+    let resolveReply!: (value: unknown) => void;
+    const request = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveReply = resolve;
+      }),
+    );
+    const { context } = createContext(request);
+    const store = new CustodianSessionStore();
+    store.connect(context, "caretaker");
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    store.openModelSetup();
+    resolveReply({
+      sessionId: "late-model-setup-session",
+      reply: "Your agent is ready.",
+      action: "open-agent",
+      agentId: "main",
+      agentDraft: "hatch",
+    });
+    await waitForFast(() => expect(store.messages.at(-1)?.text).toBe("Your agent is ready."));
+
+    expect(context.navigate).toHaveBeenCalledTimes(1);
+    expect(context.navigate).toHaveBeenCalledWith("model-setup");
+    expect(context.agents.refreshList).not.toHaveBeenCalled();
+  });
+
   it("accepts new event nudges after a conversation variant rotates", async () => {
     const request = vi.fn().mockResolvedValue({
       sessionId: "shared-session",

--- a/ui/src/pages/custodian/custodian-session-store.ts
+++ b/ui/src/pages/custodian/custodian-session-store.ts
@@ -67,6 +67,7 @@ export class CustodianSessionStore {
   private sessionVariant: CustodianSessionVariant | null = null;
   private sessionId = createCustodianSessionId();
   private requestEpoch = 0;
+  private navigationGeneration = 0;
   private nextMessageId = 1;
   private retryParams: SystemAgentChatParams | null = null;
   private sessionClient: GatewayBrowserClient | null = null;
@@ -261,6 +262,7 @@ export class CustodianSessionStore {
 
   openChannelsFromOnboarding(): void {
     this.channelOnboardingNudgeClosed = true;
+    this.revokeNavigationAuthority();
     this.emit();
     this.context?.navigate("channels");
   }
@@ -316,10 +318,18 @@ export class CustodianSessionStore {
   }
 
   exitSetup(): void {
+    // Leaving setup revokes navigation authority from every in-flight reply.
+    // The destination surface separately decides whether to retain or rotate context.
+    this.revokeNavigationAuthority();
     this.context?.navigate("chat");
   }
 
+  private revokeNavigationAuthority(): void {
+    this.navigationGeneration += 1;
+  }
+
   openModelSetup(): void {
+    this.revokeNavigationAuthority();
     this.context?.navigate("model-setup");
   }
 
@@ -589,6 +599,7 @@ export class CustodianSessionStore {
       return "rejected";
     }
     const epoch = ++this.requestEpoch;
+    const navigationGeneration = this.navigationGeneration;
     let delivery: eventNudgeState.CustodianSendDelivery = "unsent";
     this.sending = true;
     this.error = null;
@@ -620,10 +631,17 @@ export class CustodianSessionStore {
         this.appendAssistant(silentReply ? "" : result.reply, question, step);
       }
       if (result.action === "open-agent") {
+        if (navigationGeneration !== this.navigationGeneration) {
+          return "sent";
+        }
         let sessionKey = context.gateway.snapshot.sessionKey?.trim();
         if (result.agentId) {
           const roster = await context.agents.refreshList();
-          if (epoch !== this.requestEpoch || client !== this.activeClient) {
+          if (
+            epoch !== this.requestEpoch ||
+            client !== this.activeClient ||
+            navigationGeneration !== this.navigationGeneration
+          ) {
             return "sent";
           }
           sessionKey = buildAgentMainSessionKey({
@@ -645,7 +663,7 @@ export class CustodianSessionStore {
         } else {
           this.exitSetup();
         }
-      } else if (result.action === "exit") {
+      } else if (result.action === "exit" && navigationGeneration === this.navigationGeneration) {
         this.exitSetup();
       }
       return "sent";

--- a/ui/src/pages/custodian/custodian-session-store.ts
+++ b/ui/src/pages/custodian/custodian-session-store.ts
@@ -67,7 +67,7 @@ export class CustodianSessionStore {
   private sessionVariant: CustodianSessionVariant | null = null;
   private sessionId = createCustodianSessionId();
   private requestEpoch = 0;
-  private navigationGeneration = 0;
+  private requestAbort: AbortController | null = null;
   private nextMessageId = 1;
   private retryParams: SystemAgentChatParams | null = null;
   private sessionClient: GatewayBrowserClient | null = null;
@@ -325,7 +325,13 @@ export class CustodianSessionStore {
   }
 
   private revokeNavigationAuthority(): void {
-    this.navigationGeneration += 1;
+    this.requestAbort?.abort();
+    this.requestAbort = null;
+    this.requestEpoch += 1;
+    this.sending = false;
+    this.questionReplyUncertain = false;
+    this.retryParams = null;
+    this.error = null;
   }
 
   openModelSetup(): void {
@@ -598,8 +604,10 @@ export class CustodianSessionStore {
     ) {
       return "rejected";
     }
+    this.requestAbort?.abort();
+    const requestAbort = new AbortController();
+    this.requestAbort = requestAbort;
     const epoch = ++this.requestEpoch;
-    const navigationGeneration = this.navigationGeneration;
     let delivery: eventNudgeState.CustodianSendDelivery = "unsent";
     this.sending = true;
     this.error = null;
@@ -612,6 +620,7 @@ export class CustodianSessionStore {
       const result = await client.request<SystemAgentChatResult>("openclaw.chat", params, {
         timeoutMs: SYSTEM_AGENT_CHAT_TIMEOUT_MS,
         onSent: () => (delivery = "sent"),
+        signal: requestAbort.signal,
       });
       delivery = "received";
       if (epoch !== this.requestEpoch || client !== this.activeClient) {
@@ -631,17 +640,10 @@ export class CustodianSessionStore {
         this.appendAssistant(silentReply ? "" : result.reply, question, step);
       }
       if (result.action === "open-agent") {
-        if (navigationGeneration !== this.navigationGeneration) {
-          return "sent";
-        }
         let sessionKey = context.gateway.snapshot.sessionKey?.trim();
         if (result.agentId) {
           const roster = await context.agents.refreshList();
-          if (
-            epoch !== this.requestEpoch ||
-            client !== this.activeClient ||
-            navigationGeneration !== this.navigationGeneration
-          ) {
+          if (epoch !== this.requestEpoch || client !== this.activeClient) {
             return "sent";
           }
           sessionKey = buildAgentMainSessionKey({
@@ -663,7 +665,7 @@ export class CustodianSessionStore {
         } else {
           this.exitSetup();
         }
-      } else if (result.action === "exit" && navigationGeneration === this.navigationGeneration) {
+      } else if (result.action === "exit") {
         this.exitSetup();
       }
       return "sent";
@@ -690,6 +692,9 @@ export class CustodianSessionStore {
       }
       return eventNudgeState.classifyCustodianSendFailure(error, delivery);
     } finally {
+      if (this.requestAbort === requestAbort) {
+        this.requestAbort = null;
+      }
       if (epoch === this.requestEpoch) {
         this.sending = false;
       }

--- a/ui/src/pages/model-setup/configured-model.test.ts
+++ b/ui/src/pages/model-setup/configured-model.test.ts
@@ -6,7 +6,7 @@ import type { SystemAgentSetupDetectResult } from "../../api/types.ts";
 import { i18n } from "../../i18n/index.ts";
 import { renderConfiguredModel } from "./configured-model.ts";
 
-function mount(result: SystemAgentSetupDetectResult) {
+function mount(result: SystemAgentSetupDetectResult, onContinue?: () => void) {
   const container = document.createElement("div");
   document.body.append(container);
   const onVerify = vi.fn();
@@ -21,6 +21,7 @@ function mount(result: SystemAgentSetupDetectResult) {
       canVerify: true,
       actionsDisabled: false,
       onVerify,
+      onContinue,
     }),
     container,
   );
@@ -95,5 +96,25 @@ describe("renderConfiguredModel", () => {
 
     button?.click();
     expect(onVerify).toHaveBeenCalledOnce();
+  });
+
+  it("renders the optional continuation action in the configured card", () => {
+    const onContinue = vi.fn();
+    const { container } = mount(
+      {
+        candidates: [],
+        manualProviders: [],
+        prepareOptions: [],
+        workspace: "/tmp/workspace",
+        configuredModel: "openai/gpt-5",
+        setupComplete: true,
+      },
+      onContinue,
+    );
+    const button = [...container.querySelectorAll("button")].find(
+      (candidate) => candidate.textContent?.trim() === "Continue setup",
+    );
+    button?.click();
+    expect(onContinue).toHaveBeenCalledOnce();
   });
 });

--- a/ui/src/pages/model-setup/configured-model.ts
+++ b/ui/src/pages/model-setup/configured-model.ts
@@ -86,6 +86,7 @@ export function renderConfiguredModel(props: {
   canVerify: boolean;
   actionsDisabled: boolean;
   onVerify: () => void;
+  onContinue?: () => void;
 }): TemplateResult {
   const configuredRef = props.result.configuredModel!;
   // A successful verify reports the model that actually answered; prefer it over
@@ -136,16 +137,23 @@ export function renderConfiguredModel(props: {
                   : nothing}
           </div>
         </div>
-        ${props.canVerify
-          ? html`<button
-              type="button"
-              class="btn"
-              ?disabled=${props.actionsDisabled}
-              @click=${props.onVerify}
-            >
-              ${verificationButtonLabel(props.verify)}
-            </button>`
-          : nothing}
+        <div class="model-setup__row-actions">
+          ${props.canVerify
+            ? html`<button
+                type="button"
+                class="btn"
+                ?disabled=${props.actionsDisabled}
+                @click=${props.onVerify}
+              >
+                ${verificationButtonLabel(props.verify)}
+              </button>`
+            : nothing}
+          ${props.onContinue
+            ? html`<button type="button" class="btn primary" @click=${props.onContinue}>
+                ${icons.messageSquare} ${t("modelSetup.success.continueSetup")}
+              </button>`
+            : nothing}
+        </div>
       </div>
     </section>
   `;

--- a/ui/src/pages/model-setup/view.first-run.test.ts
+++ b/ui/src/pages/model-setup/view.first-run.test.ts
@@ -1,0 +1,102 @@
+/* @vitest-environment jsdom */
+
+import { nothing, render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SystemAgentSetupDetectResult } from "../../api/types.ts";
+import { i18n } from "../../i18n/index.ts";
+import { renderModelSetup } from "./view.ts";
+
+type ModelSetupViewProps = Parameters<typeof renderModelSetup>[0];
+
+const ready: SystemAgentSetupDetectResult = {
+  candidates: [],
+  unavailableCandidates: [],
+  manualProviders: [],
+  authOptions: [],
+  prepareOptions: [],
+  recommendedInstalls: [],
+  workspace: "/tmp/workspace",
+  configuredModel: "openai/gpt-5",
+  setupComplete: true,
+};
+
+function mount(overrides: Partial<ModelSetupViewProps> = {}): HTMLDivElement {
+  const noop = vi.fn();
+  const props: ModelSetupViewProps = {
+    page: { phase: "ready", result: ready },
+    activation: { phase: "idle" },
+    verify: { phase: "idle" },
+    wizard: { phase: "idle" },
+    wizardMode: "auth",
+    wizardValue: undefined,
+    canAdmin: true,
+    canVerify: true,
+    canPrepare: true,
+    gatewayTooOld: false,
+    refreshWarning: null,
+    actionsDisabled: false,
+    manualProviderId: "",
+    manualApiKey: "",
+    manualError: null,
+    moreSignInOpen: false,
+    firstRun: true,
+    iconUrls: {},
+    onDetect: noop,
+    onVerify: noop,
+    onActivateCandidate: noop,
+    onStartAuth: noop,
+    onStartPrepare: noop,
+    onManualProviderChange: noop,
+    onUseManualProvider: noop,
+    onManualApiKeyChange: noop,
+    onManualConnect: noop,
+    onMoreSignInToggle: noop,
+    onIconError: noop,
+    onOpenChat: noop,
+    onSuccessClose: noop,
+    onWizardValueChange: noop,
+    onWizardAnswer: noop,
+    onWizardCancel: noop,
+    onWizardClose: noop,
+    ...overrides,
+  };
+  const container = document.createElement("div");
+  document.body.append(container);
+  render(renderModelSetup(props), container);
+  return container;
+}
+
+describe("renderModelSetup first-run continuation", () => {
+  beforeEach(async () => {
+    await i18n.setLocale("en");
+  });
+
+  afterEach(() => {
+    for (const container of document.body.querySelectorAll("div")) {
+      render(nothing, container);
+    }
+    document.body.replaceChildren();
+  });
+
+  it("keeps durable continuation without duplicating a fresh success action", () => {
+    const onOpenChat = vi.fn();
+    const container = mount({ onOpenChat });
+
+    expect(container.textContent).toContain("Connection verified");
+    container
+      .querySelector<HTMLButtonElement>(
+        'section[aria-labelledby="model-setup-continue-title"] .primary',
+      )
+      ?.click();
+    expect(onOpenChat).toHaveBeenCalledOnce();
+
+    const freshSuccess = mount({
+      activation: { phase: "success", modelRef: "openai/gpt-5" },
+    });
+    expect(
+      [...freshSuccess.querySelectorAll("button")].filter(
+        (button) => button.textContent?.trim() === "Continue setup",
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/ui/src/pages/model-setup/view.first-run.test.ts
+++ b/ui/src/pages/model-setup/view.first-run.test.ts
@@ -82,12 +82,11 @@ describe("renderModelSetup first-run continuation", () => {
     const onOpenChat = vi.fn();
     const container = mount({ onOpenChat });
 
-    expect(container.textContent).toContain("Connection verified");
-    container
-      .querySelector<HTMLButtonElement>(
-        'section[aria-labelledby="model-setup-continue-title"] .primary',
-      )
-      ?.click();
+    const continueButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Continue setup",
+    );
+    expect(continueButton).toBeDefined();
+    continueButton?.click();
     expect(onOpenChat).toHaveBeenCalledOnce();
 
     const freshSuccess = mount({
@@ -98,5 +97,18 @@ describe("renderModelSetup first-run continuation", () => {
         (button) => button.textContent?.trim() === "Continue setup",
       ),
     ).toHaveLength(1);
+  });
+
+  it.each([{ canAdmin: false }, { gatewayTooOld: true }])(
+    "keeps continuation available with restricted setup controls",
+    (access) => {
+      const container = mount(access);
+      expect(container.textContent).toContain("Continue setup");
+    },
+  );
+
+  it("omits continuation outside first run", () => {
+    const container = mount({ firstRun: false });
+    expect(container.textContent).not.toContain("Continue setup");
   });
 });

--- a/ui/src/pages/model-setup/view.ts
+++ b/ui/src/pages/model-setup/view.ts
@@ -556,18 +556,39 @@ function renderReady(props: ModelSetupViewProps, result: SystemAgentSetupDetectR
         onVerify: props.onVerify,
       })
     : nothing;
+  const continueSetup =
+    props.firstRun &&
+    result.setupComplete &&
+    result.configuredModel &&
+    props.activation.phase !== "success"
+      ? html`
+          <section class="settings-section" aria-labelledby="model-setup-continue-title">
+            <div class="settings-section__header">
+              <div>
+                <h2 id="model-setup-continue-title">${t("modelSetup.success.title")}</h2>
+                <p>${t("modelSetup.success.body", { modelRef: result.configuredModel })}</p>
+              </div>
+              <div class="settings-section__actions">
+                <button type="button" class="btn primary" @click=${props.onOpenChat}>
+                  ${icons.messageSquare} ${t("modelSetup.success.continueSetup")}
+                </button>
+              </div>
+            </div>
+          </section>
+        `
+      : nothing;
   if (!props.canAdmin) {
-    return html`${current}
+    return html`${current} ${continueSetup}
       <div class="callout warning" role="note">${t("modelSetup.access.adminRequired")}</div>`;
   }
   if (props.gatewayTooOld) {
-    return html`${current}
+    return html`${current} ${continueSetup}
       <div class="callout warning" role="note">${t("modelSetup.access.gatewayTooOld")}</div>`;
   }
   return html`
-    ${current} ${renderEmptyState(props, result)} ${renderCandidateRows(props, result)}
-    ${renderUnavailable(props, result)} ${renderPrepare(props, result)}
-    ${renderSignIn(props, result)} ${renderManual(props, result)}
+    ${current} ${continueSetup} ${renderEmptyState(props, result)}
+    ${renderCandidateRows(props, result)} ${renderUnavailable(props, result)}
+    ${renderPrepare(props, result)} ${renderSignIn(props, result)} ${renderManual(props, result)}
   `;
 }
 

--- a/ui/src/pages/model-setup/view.ts
+++ b/ui/src/pages/model-setup/view.ts
@@ -547,6 +547,10 @@ function renderManual(props: ModelSetupViewProps, result: SystemAgentSetupDetect
 }
 
 function renderReady(props: ModelSetupViewProps, result: SystemAgentSetupDetectResult) {
+  const onContinue =
+    props.firstRun && result.setupComplete && props.activation.phase !== "success"
+      ? props.onOpenChat
+      : undefined;
   const current = result.configuredModel
     ? renderConfiguredModel({
         result,
@@ -554,41 +558,21 @@ function renderReady(props: ModelSetupViewProps, result: SystemAgentSetupDetectR
         canVerify: props.canVerify,
         actionsDisabled: props.actionsDisabled,
         onVerify: props.onVerify,
+        onContinue,
       })
     : nothing;
-  const continueSetup =
-    props.firstRun &&
-    result.setupComplete &&
-    result.configuredModel &&
-    props.activation.phase !== "success"
-      ? html`
-          <section class="settings-section" aria-labelledby="model-setup-continue-title">
-            <div class="settings-section__header">
-              <div>
-                <h2 id="model-setup-continue-title">${t("modelSetup.success.title")}</h2>
-                <p>${t("modelSetup.success.body", { modelRef: result.configuredModel })}</p>
-              </div>
-              <div class="settings-section__actions">
-                <button type="button" class="btn primary" @click=${props.onOpenChat}>
-                  ${icons.messageSquare} ${t("modelSetup.success.continueSetup")}
-                </button>
-              </div>
-            </div>
-          </section>
-        `
-      : nothing;
   if (!props.canAdmin) {
-    return html`${current} ${continueSetup}
+    return html`${current}
       <div class="callout warning" role="note">${t("modelSetup.access.adminRequired")}</div>`;
   }
   if (props.gatewayTooOld) {
-    return html`${current} ${continueSetup}
+    return html`${current}
       <div class="callout warning" role="note">${t("modelSetup.access.gatewayTooOld")}</div>`;
   }
   return html`
-    ${current} ${continueSetup} ${renderEmptyState(props, result)}
-    ${renderCandidateRows(props, result)} ${renderUnavailable(props, result)}
-    ${renderPrepare(props, result)} ${renderSignIn(props, result)} ${renderManual(props, result)}
+    ${current} ${renderEmptyState(props, result)} ${renderCandidateRows(props, result)}
+    ${renderUnavailable(props, result)} ${renderPrepare(props, result)}
+    ${renderSignIn(props, result)} ${renderManual(props, result)}
   `;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes a set of onboarding failures found through adversarial end-to-end testing:

- canceling Ollama setup could leave model discovery and context inspection running;
- reset could report success while config, sessions, retired metadata, or canonical workspace state remained;
- classic and structured setup surfaces could mutate onboarding state concurrently;
- classic setup could overwrite unrelated config edits made while the wizard was open, including during pending-plugin migration;
- first-run model setup lost its continuation action after reload; and
- a late Custodian reply could navigate away after the user had already exited setup or opened another setup surface.

## Why This Change Was Made

The repair moves each invariant to its owning boundary instead of adding caller-specific workarounds:

- Ollama discovery now carries the setup `AbortSignal` through both `/api/tags` and `/api/show` requests.
- Reset now treats selected cleanup as required work: it attempts every independent target, suppresses only genuine missing paths, and aggregates failures after cleanup completes.
- Gateway wizard sessions reserve process-local admission synchronously, closing check-to-insert races across classic, channel, auth, and prepare flows. Setup mutations additionally hold the canonical filesystem-backed onboarding target lock, so CLI and Gateway setup cannot overlap across processes. Both leases follow runner settlement and release on contention, construction failure, cancellation, or rejection.
- Classic setup rereads the authored config before every write, applies only the wizard delta onto that fresh snapshot, CAS-writes, and retries retryable conflicts. Pending-plugin migration now commits the same fresh payload associated with its CAS precondition.
- First-run model setup derives a durable continuation action from authoritative setup state, while Custodian uses a separate navigation generation to revoke authority from stale replies.

AI-assisted: yes. The implementation, ownership boundaries, and failure sequences were manually inspected and independently reviewed.

## User Impact

Users can safely cancel, retry, reload, or leave onboarding without background requests, stale replies, or overlapping setup flows taking control later. Reset now fails closed when required state remains, concurrent config edits are preserved, and a completed first-run model setup always has a visible path into Custodian onboarding.

## Evidence

### Focused automated proof

- Reset/cleanup: **78 passed**
- Shared Gateway setup admission and system-agent/classic wizard methods: **51 passed**
- Classic, shared, default-agent, and migration wizard flows: **75 passed**
- Non-interactive Gateway onboarding: **18 passed**
- Ollama setup, model selection, and cancellation: **47 passed**
- Model setup and Custodian UI units: **49 passed**
- Chromium onboarding scenarios: **12 passed** across model setup and late Custodian event handling
- The single provider-picker keyboard assertion that timed out once passed on immediate targeted rerun, then the complete 12-scenario Chromium suite passed cleanly.

```text
node scripts/run-vitest.mjs src/commands/cleanup-utils.test.ts src/commands/onboard-helpers.test.ts src/commands/reset.test.ts src/commands/onboard-non-interactive.gateway.test.ts
node scripts/run-vitest.mjs src/gateway/server-methods/setup-admission.test.ts src/gateway/server-methods/system-agent.test.ts src/gateway/server-methods/wizard.test.ts
node scripts/run-vitest.mjs src/wizard/setup.test.ts src/wizard/setup.shared.test.ts src/wizard/setup.default-agent.test.ts src/wizard/setup.migration-import.test.ts src/wizard/setup.migration-transaction.test.ts
node scripts/run-vitest.mjs extensions/ollama/src/setup-model-selection.test.ts extensions/ollama/src/setup.cancellation.test.ts extensions/ollama/src/setup.test.ts
node scripts/run-vitest.mjs ui/src/pages/model-setup/view.test.ts ui/src/pages/model-setup/view.first-run.test.ts ui/src/pages/custodian/custodian-session-store.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/model-setup.e2e.test.ts ui/src/e2e/custodian-event-nudge.e2e.test.ts
pnpm check:test-types
```

The final changed gate passed formatting, five TypeScript lanes, changed-file lint, boundaries, dead exports, max-lines, state/database guards, and runtime cycle checks:

```text
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree CI=1 node scripts/check-changed.mjs --base origin/main
```

The packaged build passed:

```text
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm build
```

### Production surface

Measured from the current PR merge base, with tests counted separately:

```text
Production: +372 / -375, net -3
Tests:      +1379 / -292, net +1087
```

The net-negative production result comes from deleting duplicate cleanup, config-write, request-lifecycle, and in-process setup policy after moving each invariant to its canonical owner. No production behavior was line-packed or shifted into tests.

### Browser proof

Durable first-run continuation after a reload:

![Model setup showing the durable Continue setup action](https://ampcode.com/user-content/artifacts/6c68a3a4c04de306e7166b882fa83b46b885c1d7488384668d47b3837a754459-file.png)

Custodian handoff with onboarding chrome and no ordinary app sidebar:

![Custodian onboarding handoff](https://ampcode.com/user-content/artifacts/fb749b86acb8dbb9ab336160012e66edc26895e458bcd4d0427d6c1f29161dc5-file.png)

Both screenshots were captured by the asserted mocked-Gateway Chromium scenario and inspected for clipping, layout breakage, and route/chrome correctness.

### Live local Ollama proof

Ollama `0.32.6` ran locally with no hosted inference credentials:

- `qwen3.6:27b` (27.8B, Q4_K_M) completed a native `/api/chat` capability probe and emitted a valid native tool call.
- The full built Gateway seam used `qwen3:8b` because the 27B model's CPU prompt processing exceeded OpenClaw's six-minute stale-run guard in two attempts. The 8B model completed the same native Ollama route in 295.9 seconds with exactly one successful `read` tool call, two assistant turns, and no fallback.

```json
{
  "status": "ok",
  "provider": "ollama",
  "model": "qwen3:8b",
  "modelApi": "ollama",
  "assistantTurns": 2,
  "toolSummary": { "calls": 1, "tools": ["read"], "failures": 0 },
  "toolResult": "ONBOARDING_TOOL_RESULT_7341",
  "final": "ONBOARDING_GATEWAY_TOOL_OK:ONBOARDING_TOOL_RESULT_7341"
}
```

The 27B Gateway timeout was CPU throughput versus the existing stale-run guard, not a setup or provider failure; direct 27B inference and tool capability were proven separately.

### Adversarial review and proof limitations

- Multiple independent adversarial reviews found and drove final root-cause fixes for cross-process Gateway/CLI setup overlap, an async wizard check-to-insert race, standalone reset's strictness regression, and duplicate reset labels across cleanup phases. Fresh lock-focused and reset-focused re-reviews both returned **SHIP**, and the full-diff reviewer reported no findings.
- The mandatory TruffleHog review pre-scan was clean. The structured `autoreview` engine could not run because this orb has no `codex` reviewer CLI; this is reported rather than bypassed.
- Blacksmith Testbox proof was unavailable because the environment has no organization credential. Per repository policy, trusted-source validation fell back to the local orb.
- The exact rebased head passed the full local changed-file gate after its max-lines and lint findings were resolved through test-harness consolidation rather than suppressions. Fresh hosted exact-head CI is required before merge.
- One provider-picker keyboard assertion timed out once during capture-heavy video generation; the target visual scenario passed, and the complete model-setup file immediately passed 5/5 without capture overhead.
