### PR TITLE
fix(ui): center the onboarding dashboard and fix its card chrome

### DIFF
--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -125,7 +125,9 @@ export function renderApplicationShell(host: ShellViewHost) {
       ? pluginTabRefFromSearch(host.routeState.location?.search ?? "")
       : null;
   const activePluginTabId = activePluginRef ? pluginTabKey(activePluginRef) : "";
-  const settingsTakeover = isSettingsNavigationRoute(activeRoute);
+  // Onboarding renders without any navigation chrome, so the settings takeover
+  // must not reserve its fixed sidebar column (the grid would stay off-center).
+  const settingsTakeover = isSettingsNavigationRoute(activeRoute) && !host.onboardingMode;
   const runtimeConfig = context.runtimeConfig.state;
   const settingsSearchBlocks = findSettingsSearchBlocks({
     query: host.settingsSearchQuery,

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -423,7 +423,8 @@ suite.define(() => {
 
         const response = await page.goto(`${suite.server.baseUrl}custodian?onboarding=1`);
         expect(response?.status()).toBe(200);
-        await page.getByRole("heading", { name: "OpenClaw", exact: true }).waitFor();
+        // Onboarding chrome keeps only the header actions; no identity heading.
+        await page.locator(".custodian__header--minimal").waitFor();
         await gateway.emitGatewayEvent("health", {
           channelLabels: { telegram: "Telegram" },
           channels: {

--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -119,7 +119,9 @@ suite.define(() => {
         await page.getByRole("button", { name: "Continue setup" }).click();
         await expect.poll(() => new URL(page.url()).pathname).toBe("/custodian");
         expect(new URL(page.url()).searchParams.get("onboarding")).toBe("1");
-        await page.getByRole("heading", { name: "OpenClaw", exact: true }).waitFor();
+        // Onboarding chrome keeps only the header actions; no identity heading.
+        await page.locator(".custodian__header--minimal").waitFor();
+        await page.getByRole("button", { name: "Exit setup" }).waitFor();
         await expect
           .poll(() => page.locator(".shell").getAttribute("class"))
           .toContain("shell--onboarding");

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -57,7 +57,8 @@ describe("custodian page", () => {
         .querySelector<HTMLImageElement>("img.chat-avatar.assistant")
         ?.getAttribute("src"),
     ).toBe("/favicon.svg");
-    expect(page.querySelector(".custodian__mark openclaw-mascot")).not.toBeNull();
+    // Onboarding strips the header identity; the thread avatar is the only mascot.
+    expect(page.querySelector(".custodian__mark openclaw-mascot")).toBeNull();
     const card = page.querySelector("openclaw-option-card")!;
     await card.updateComplete;
     expect(page.querySelector(".option-card__choice--recommended")?.textContent).toContain(

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -224,19 +224,25 @@ export class CustodianPage extends OpenClawLightDomElement {
           ? "custodian--setup-required"
           : ""}"
       >
-        <header class="custodian__header custodian__column">
-          <div class="custodian__identity">
-            <div class="custodian__mark" aria-hidden="true">
-              <openclaw-mascot
-                .mood=${this.store.sending ? "thinking" : "idle"}
-                .size=${38}
-              ></openclaw-mascot>
-            </div>
-            <div>
-              <h1>${t("custodian.title")}</h1>
-              <p>${t(this.onboarding ? "custodian.subtitle" : "custodian.subtitleCaretaker")}</p>
-            </div>
-          </div>
+        <header
+          class="custodian__header custodian__column ${this.onboarding
+            ? "custodian__header--minimal"
+            : ""}"
+        >
+          ${this.onboarding
+            ? nothing
+            : html`<div class="custodian__identity">
+                <div class="custodian__mark" aria-hidden="true">
+                  <openclaw-mascot
+                    .mood=${this.store.sending ? "thinking" : "idle"}
+                    .size=${38}
+                  ></openclaw-mascot>
+                </div>
+                <div>
+                  <h1>${t("custodian.title")}</h1>
+                  <p>${t("custodian.subtitleCaretaker")}</p>
+                </div>
+              </div>`}
           <div class="custodian__header-actions">
             ${this.historyAvailable
               ? html`<button

--- a/ui/src/pages/custodian/route.test.ts
+++ b/ui/src/pages/custodian/route.test.ts
@@ -96,8 +96,9 @@ describe("custodian route", () => {
     >("openclaw-custodian-page");
     await onboardingPage?.updateComplete;
     expect(onboardingPage?.querySelector(".custodian__header .btn")).not.toBeNull();
-    expect(onboardingPage?.querySelector(".custodian__header p")?.textContent?.trim()).toBe(
-      "Your system setup guide",
-    );
+    // Onboarding renders the minimal header: actions only, no identity block.
+    expect(onboardingPage?.querySelector(".custodian__header--minimal")).not.toBeNull();
+    expect(onboardingPage?.querySelector(".custodian__header p")).toBeNull();
+    expect(onboardingPage?.querySelector(".custodian__identity")).toBeNull();
   });
 });

--- a/ui/src/styles/custodian.css
+++ b/ui/src/styles/custodian.css
@@ -260,14 +260,15 @@ openclaw-custodian-page {
 
 .custodian__option-card {
   /* Left offset = avatar column (36px) + group gap (10px) so cards align with
-     the message text column, not the avatar gutter. */
-  margin: -12px 16px 14px 46px;
+     the message text column, not the avatar gutter. No negative top margin:
+     it overlays the preceding message's sender/timestamp row. */
+  margin: 4px 16px 14px 46px;
 }
 
 .custodian__wizard-step {
   display: grid;
   gap: 12px;
-  margin: -12px 16px 14px 46px;
+  margin: 4px 16px 14px 46px;
   padding: 16px;
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);

--- a/ui/src/styles/custodian.css
+++ b/ui/src/styles/custodian.css
@@ -109,6 +109,14 @@ openclaw-custodian-page {
   gap: 8px;
 }
 
+/* Onboarding: the thread already introduces the mascot, so the header keeps
+   only its actions as a quiet top-right row. */
+.custodian__header--minimal {
+  justify-content: flex-end;
+  padding-bottom: 8px;
+  border-bottom: 0;
+}
+
 .custodian__identity {
   display: flex;
   align-items: center;

--- a/ui/src/styles/option-card.css
+++ b/ui/src/styles/option-card.css
@@ -48,14 +48,12 @@
   transition:
     border-color var(--duration-fast) var(--ease-out),
     background var(--duration-fast) var(--ease-out),
-    box-shadow var(--duration-fast) var(--ease-out),
-    transform var(--duration-fast) var(--ease-out);
+    box-shadow var(--duration-fast) var(--ease-out);
 }
 
 .option-card__choice:hover:not(:disabled) {
   border-color: var(--border-strong);
   background: var(--bg-hover);
-  transform: translateY(-1px);
 }
 
 .option-card__choice:focus-visible {
@@ -65,6 +63,14 @@
 
 .option-card__choice--recommended,
 .option-card__choice--selected {
+  border-color: var(--accent);
+  background: var(--accent-subtle);
+}
+
+/* Hover must not swap the accent tint for the neutral one; the mismatched
+   layers read as the card overlapping itself. */
+.option-card__choice--recommended:hover:not(:disabled),
+.option-card__choice--selected:hover:not(:disabled) {
   border-color: var(--accent);
   background: var(--accent-subtle);
 }


### PR DESCRIPTION
## What Problem This Solves

Operator feedback on the fresh-onboarding dashboard (the custodian page the Mac app opens right after inference connects):

1. The whole page rendered off-center: the custodian route is a settings-group route, so the shell kept the settings takeover's fixed 288px sidebar column even though onboarding hides all navigation chrome.
2. The "OpenClaw / Your system setup guide" header duplicated the mascot the chat thread already shows.
3. The NEXT STEP / wizard cards pulled themselves up with a `-12px` top margin and covered the preceding message's "OpenClaw · just now" sender/timestamp row.
4. Hovering an option card lifted it 1px and re-tinted the recommended card with the neutral hover color, reading as the card overlapping itself.

## Why This Change Was Made

Onboarding now opts out of the settings takeover (`settingsTakeover` is false in onboarding mode), so the shell renders its single-column onboarding grid and the content centers. The onboarding header keeps only its actions (History / Exit setup) as a quiet top-right row; the caretaker/settings variant keeps the full identity header. Thread-attached cards use a positive top margin, and option-card hover changes border/background only, with the recommended/selected tint preserved on hover.

## User Impact

The first screen a new operator lands on after connecting an AI is centered, has one mascot, and its cards no longer clip the message metadata or jiggle on hover.

## Evidence

- Before (duplicate header, off-center at wide widths):
  ![before](https://github.com/user-attachments/assets/bfc43586-ffec-41d9-a11a-b04898f6debf)
- Intermediate (centered + minimal header; card still overlaying the "OpenClaw · just now" row):
  ![overlay bug](https://github.com/user-attachments/assets/c337a85c-da35-4104-af59-d8f70a4deab0)
- After (final live run, fresh OPENCLAW_PROFILE onboarding through Codex auto-connect to this dashboard):
  ![after](https://github.com/user-attachments/assets/45d7d6be-eab2-4838-9da7-1b98eed2afd8)
- Live-measured in the served bundle: shell grid `288px 992px` → single column; card top clears the meta row by 14px (was overlapping).
- `node scripts/run-vitest.mjs ui/src/pages/custodian` — 87/87; `ui/src/app` — 696 passed / 1 skipped; `ui/src/e2e/model-setup.e2e.test.ts` — 5/5 (assertions updated to the minimal-header contract).
- `pnpm lint:ui:styles` clean; autoreview clean (0.99).
- Settings/caretaker variant visually verified unchanged (sidebar + identity header intact).
