### PR TITLE
feat(ui): turn the widget pin action into an icon button

### DIFF
--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -22,6 +22,7 @@ const cardboardProofDir = path.resolve(
   process.cwd(),
   ".artifacts/control-ui-e2e/workboard-cardboard",
 );
+const workboardPinProofDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/workboard-pin");
 const pluginWidgetsProofDir = path.resolve(
   process.cwd(),
   ".artifacts/control-ui-e2e/workboard-plugin-widgets",
@@ -261,6 +262,10 @@ suite.define(() => {
   });
 
   it("pins Canvas HTML, follows board commands, and persists dock resizing", async () => {
+    const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
+    if (recordProof) {
+      await mkdir(workboardPinProofDir, { recursive: true });
+    }
     const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
     const page = await context.newPage();
     const resizableBoardSnapshot = {
@@ -321,6 +326,17 @@ suite.define(() => {
 
     const preview = page.locator('.chat-tool-card__preview[data-kind="canvas"]');
     await preview.hover();
+    if (recordProof) {
+      await preview.locator(".chat-tool-card__preview-header").hover();
+      await expect
+        .poll(() =>
+          preview
+            .locator("[data-widget-actions]")
+            .evaluate((element) => getComputedStyle(element).opacity),
+        )
+        .toBe("1");
+      await preview.screenshot({ path: path.join(workboardPinProofDir, "01-pin-hover.png") });
+    }
     await preview.getByRole("button", { name: "Pin to dashboard" }).click();
     await expect.poll(async () => (await gateway.getRequests("board.widget.put")).length).toBe(1);
     expect((await gateway.getRequests("board.widget.put"))[0]?.params).toEqual({
@@ -332,6 +348,9 @@ suite.define(() => {
     await expect
       .poll(() => preview.getByRole("button", { name: "Pinned" }).isDisabled())
       .toBe(true);
+    if (recordProof) {
+      await preview.screenshot({ path: path.join(workboardPinProofDir, "02-pinned.png") });
+    }
     await gateway.setMethodResponse("board.get", resizablePinnedBoardSnapshot);
 
     await gateway.emitGatewayEvent("board.command", {

--- a/ui/src/pages/chat/components/widget-card.test.ts
+++ b/ui/src/pages/chat/components/widget-card.test.ts
@@ -298,7 +298,7 @@ describe("widget-card", () => {
       pinned,
     );
     expect(pinned.querySelector<HTMLButtonElement>("[data-pin-widget]")?.disabled).toBe(true);
-    expect(pinned.querySelector("[data-pin-widget]")?.textContent).toContain("Pinned");
+    expect(pinned.querySelector("[data-pin-widget]")?.getAttribute("aria-label")).toBe("Pinned");
 
     const external = document.createElement("div");
     render(

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -41,32 +41,45 @@ type WidgetCardOptions = {
   boardProvider?: BoardProvider;
 };
 
+async function pinWidget(event: Event, pin: () => Promise<void>): Promise<void> {
+  const button = event.currentTarget;
+  if (!(button instanceof HTMLButtonElement)) {
+    return;
+  }
+  button.disabled = true;
+  const pendingLabel = t("chat.toolCards.pinToDashboardPending");
+  button.title = pendingLabel;
+  button.setAttribute("aria-label", pendingLabel);
+  try {
+    await pin();
+    const pinnedLabel = t("chat.toolCards.pinnedToDashboard");
+    button.title = pinnedLabel;
+    button.setAttribute("aria-label", pinnedLabel);
+    button.dataset.pinned = "true";
+  } catch (error) {
+    button.disabled = false;
+    button.setAttribute("aria-label", t("chat.toolCards.pinToDashboard"));
+    button.title = error instanceof Error ? error.message : String(error);
+  }
+}
+
 async function pinCanvasWidget(
   event: Event,
   preview: ToolPreview,
   provider: BoardProvider,
   name: string,
 ): Promise<void> {
-  const button = event.currentTarget;
   const docId = preview.viewId?.trim();
-  if (!(button instanceof HTMLButtonElement) || !docId) {
+  if (!docId) {
     return;
   }
-  button.disabled = true;
-  button.textContent = t("chat.toolCards.pinToDashboardPending");
-  try {
-    await provider.pinWidget({
+  return pinWidget(event, () =>
+    provider.pinWidget({
       docId,
       name,
       ...(preview.title?.trim() ? { title: preview.title.trim() } : {}),
-    });
-    button.textContent = t("chat.toolCards.pinnedToDashboard");
-    button.dataset.pinned = "true";
-  } catch (error) {
-    button.disabled = false;
-    button.textContent = t("chat.toolCards.pinToDashboard");
-    button.title = error instanceof Error ? error.message : String(error);
-  }
+    }),
+  );
 }
 
 async function pinMcpAppWidget(
@@ -76,25 +89,13 @@ async function pinMcpAppWidget(
   name: string,
   viewId: string,
 ): Promise<void> {
-  const button = event.currentTarget;
-  if (!(button instanceof HTMLButtonElement)) {
-    return;
-  }
-  button.disabled = true;
-  button.textContent = t("chat.toolCards.pinToDashboardPending");
-  try {
-    await provider.pinMcpApp({
+  return pinWidget(event, () =>
+    provider.pinMcpApp({
       viewId,
       name,
       ...(preview.title?.trim() ? { title: preview.title.trim() } : {}),
-    });
-    button.textContent = t("chat.toolCards.pinnedToDashboard");
-    button.dataset.pinned = "true";
-  } catch (error) {
-    button.disabled = false;
-    button.textContent = t("chat.toolCards.pinToDashboard");
-    button.title = error instanceof Error ? error.message : String(error);
-  }
+    }),
+  );
 }
 
 function canvasWidgetName(preview: ToolPreview): string | undefined {
@@ -518,7 +519,7 @@ function renderWidgetCard(
       isManagedCanvasDocumentPreview(preview)) ||
       (contentKind === "mcp-app" && mcpAppViewId))
       ? html`<button
-          class="chat-tool-card__widget-action"
+          class="btn btn--ghost btn--icon chat-tool-card__widget-action"
           type="button"
           data-pin-widget
           ?disabled=${pinned}
@@ -532,7 +533,7 @@ function renderWidgetCard(
               ? void pinMcpAppWidget(event, preview, provider, pinName, mcpAppViewId)
               : void pinCanvasWidget(event, preview, provider, pinName)}
         >
-          ${t(pinned ? "chat.toolCards.pinnedToDashboard" : "chat.toolCards.pinToDashboard")}
+          ${icons.pin}
         </button>`
       : nothing;
   return html`

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -48,17 +48,15 @@ async function pinWidget(event: Event, pin: () => Promise<void>): Promise<void> 
   }
   button.disabled = true;
   const pendingLabel = t("chat.toolCards.pinToDashboardPending");
-  button.title = pendingLabel;
-  button.setAttribute("aria-label", pendingLabel);
+  button.title = button.ariaLabel = pendingLabel;
   try {
     await pin();
     const pinnedLabel = t("chat.toolCards.pinnedToDashboard");
-    button.title = pinnedLabel;
-    button.setAttribute("aria-label", pinnedLabel);
+    button.title = button.ariaLabel = pinnedLabel;
     button.dataset.pinned = "true";
   } catch (error) {
     button.disabled = false;
-    button.setAttribute("aria-label", t("chat.toolCards.pinToDashboard"));
+    button.ariaLabel = t("chat.toolCards.pinToDashboard");
     button.title = error instanceof Error ? error.message : String(error);
   }
 }
@@ -507,6 +505,7 @@ function renderWidgetCard(
     ? provider?.snapshot$.value.widgets.find((widget) => widget.name === pinName)
     : undefined;
   const pinned = Boolean(pinnedWidget);
+  const pinLabel = t(pinned ? "chat.toolCards.pinnedToDashboard" : "chat.toolCards.pinToDashboard");
   // Chat keeps its labeled card shell, but the inner inset follows the pinned
   // widget's presentation so authored edge-to-edge content matches the board.
   const bleed = pinned && (pinnedWidget?.presentation ?? "card") !== "card";
@@ -524,10 +523,8 @@ function renderWidgetCard(
           data-pin-widget
           ?disabled=${pinned}
           ?data-pinned=${pinned}
-          title=${t(pinned ? "chat.toolCards.pinnedToDashboard" : "chat.toolCards.pinToDashboard")}
-          aria-label=${t(
-            pinned ? "chat.toolCards.pinnedToDashboard" : "chat.toolCards.pinToDashboard",
-          )}
+          title=${pinLabel}
+          aria-label=${pinLabel}
           @click=${(event: Event) =>
             contentKind === "mcp-app" && mcpAppViewId
               ? void pinMcpAppWidget(event, preview, provider, pinName, mcpAppViewId)

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -785,7 +785,8 @@
   min-width: 176px;
 }
 
-.chat-tool-card__widget-actions-trigger {
+.chat-tool-card__widget-actions-trigger,
+.chat-tool-card__widget-action {
   width: 26px;
   height: 26px;
   min-height: 26px;
@@ -794,12 +795,15 @@
 }
 
 .chat-tool-card__widget-actions-trigger:hover,
-.chat-tool-card__widget-actions-trigger:focus-visible {
+.chat-tool-card__widget-actions-trigger:focus-visible,
+.chat-tool-card__widget-action:hover,
+.chat-tool-card__widget-action:focus-visible {
   color: var(--text);
   background: var(--bg-hover);
 }
 
-.chat-tool-card__widget-actions-trigger svg {
+.chat-tool-card__widget-actions-trigger svg,
+.chat-tool-card__widget-action svg {
   width: 16px;
   height: 16px;
 }
@@ -814,24 +818,13 @@
   opacity: 1;
 }
 
-.chat-tool-card__widget-action {
-  background: transparent;
-  border: 0;
-  color: var(--muted);
-  cursor: var(--cursor-action);
-  font: inherit;
-  font-size: 11px;
-  padding: 2px 4px;
-}
-
-.chat-tool-card__widget-action:hover,
-.chat-tool-card__widget-action:focus-visible {
-  color: var(--text);
+.chat-tool-card__widget-action[data-pinned] {
+  color: var(--accent);
 }
 
 .chat-tool-card__widget-action:disabled {
   cursor: default;
-  opacity: 0.7;
+  opacity: 1;
 }
 
 .chat-tool-card__preview-panel {


### PR DESCRIPTION
## What Problem This Solves

The chat widget card's "Pin to dashboard" action rendered as a bare text button, visually inconsistent with the icon-based widget-actions trigger (`…`) sitting next to it, and its three states (idle / pinning / pinned) mutated the button's text content.

## Why This Change Was Made

The pin action becomes a 26px icon button using the shared Lucide `pin` icon from `icons-tools.ts`, reusing the global `btn btn--ghost btn--icon` system plus the existing widget-actions-trigger sizing rules (now shared selectors, net-negative CSS). State labels move to `title`/`aria-label`, so tooltips and accessible names stay "Pin to dashboard" / "Pinning…" / "Pinned" with no i18n key changes; the pinned state shows the icon in the accent color and stays disabled. The two near-identical imperative pin handlers (Canvas / MCP app) collapse into one shared `pinWidget` helper that updates labels instead of destroying the icon markup via `textContent`.

## User Impact

Chat widget cards show a compact pin icon with a tooltip in the header hover actions instead of a text label; the pinned state reads as a toggled accent icon. Screen-reader names and the tooltip strings are unchanged.

| Before (hover) | After (hover) |
| --- | --- |
| ![before hover](https://github.com/user-attachments/assets/66130194-8829-476c-9420-e61e52e7585f) | ![after hover](https://github.com/user-attachments/assets/1d787004-9982-4d51-a783-9df397df1ed7) |

| Before (pinned) | After (pinned) |
| --- | --- |
| ![before pinned](https://github.com/user-attachments/assets/c1637df4-1e61-4b8f-a329-008ee0eaa000) | ![after pinned](https://github.com/user-attachments/assets/8e27c320-2f0d-4e49-8cfa-f0e7d2ba52cb) |

## Evidence

- `node scripts/run-vitest.mjs ui/src/e2e/session-dashboard.e2e.test.ts` — 7/7 passed, run both before and after the redesign (the existing `getByRole("button", { name: "Pin to dashboard" | "Pinned" })` queries now resolve via `aria-label`).
- The e2e records hover/pinned proof screenshots under `.artifacts/control-ui-e2e/workboard-pin/` when `OPENCLAW_UI_E2E_RECORD=1` (source of the images above).
- `oxfmt --check`, `oxlint`, and `stylelint` clean on the touched files; `git diff --check` clean.
- Codex autoreview (`gpt-5.6-sol`, high): clean, no actionable findings.
- Production LOC delta: +43/−49 (net −6); tests +19.
- Local `check:changed` could not acquire the machine-wide heavy-check lock (six sibling worktrees cycling it) and Crabbox had no ready provider; typecheck/lint fan-out lanes are proven by hosted PR CI on this head instead.
- `main` was already red on `check-plugin-sdk-api-baseline` in runs [31359841194](https://github.com/openclaw/openclaw/actions/runs/31359841194) and [31360357220](https://github.com/openclaw/openclaw/actions/runs/31360357220). This branch initially carried the reviewed regeneration after `3798dda6930` left the manifest stale; while resolving a real merge conflict after `main` advanced, `23d1eca4554` supplied the matching generated baseline and the duplicate repair commit became empty. The exact baseline check passes at the rebased head.
