### PR TITLE
fix(ui): give the session rail its own icon in the chat header

### DIFF
--- a/ui/src/pages/chat/chat-session-rail.test.ts
+++ b/ui/src/pages/chat/chat-session-rail.test.ts
@@ -1,5 +1,6 @@
 /* @vitest-environment jsdom */
 
+import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionObserverDigest } from "../../../../packages/gateway-protocol/src/schema/sessions.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
@@ -10,6 +11,8 @@ import {
   requestSessionCompanionState,
   resetSessionCompanion,
 } from "./chat-session-companion.ts";
+import { renderBackgroundTasksToggle } from "./components/chat-background-tasks-render.ts";
+import type { BackgroundTasksProps } from "./components/chat-background-tasks.types.ts";
 import {
   ChatSessionRailElement,
   ChatSessionRailState,
@@ -34,6 +37,33 @@ function input(overrides: Partial<SessionRailInput> = {}): SessionRailInput {
     digest: digest(),
     hasCompanionActivity: false,
     ...overrides,
+  };
+}
+
+function backgroundTasksToggleProps(): BackgroundTasksProps {
+  return {
+    sessionKey: "agent:main:run",
+    statusRowId: "status-row",
+    collapsed: true,
+    narrowLayout: false,
+    connected: true,
+    canCancel: false,
+    loading: false,
+    error: null,
+    tasks: null,
+    view: { kind: "list" },
+    taskDetails: new Map(),
+    taskDetailErrors: new Map(),
+    taskDetailLoadingIds: new Set(),
+    cancellingTaskIds: new Set(),
+    finishedCollapsed: true,
+    onToggleCollapsed: () => {},
+    onToggleFinished: () => {},
+    onRefresh: () => {},
+    onCancel: () => {},
+    onSelectTask: () => {},
+    onBack: () => {},
+    onOpenTranscript: () => {},
   };
 }
 
@@ -357,6 +387,22 @@ describe("ChatSessionRailElement", () => {
     expect(localStorage.getItem(displayPreferenceKey)).toBe("off");
     expect(onOpenRequestConsumed).toHaveBeenCalledWith(1);
     expect(onVisibilityChange).not.toHaveBeenCalled();
+  });
+
+  it("restores with its own glyph instead of the background-tasks one", async () => {
+    const element = await mount();
+    (element.querySelector(".chat-session-rail__hide") as HTMLButtonElement | null)?.click();
+    await element.updateComplete;
+
+    const railGlyph = element.querySelector(".chat-session-rail--restore svg")?.innerHTML;
+    const host = document.createElement("div");
+    document.body.append(host);
+    render(renderBackgroundTasksToggle(backgroundTasksToggleProps()), host);
+    const tasksGlyph = host.querySelector(".chat-tasks-toggle svg")?.innerHTML;
+
+    expect(railGlyph?.trim()).toBeTruthy();
+    expect(tasksGlyph?.trim()).toBeTruthy();
+    expect(railGlyph).not.toBe(tasksGlyph);
   });
 
   it("auto-opens from pill without persisting card, then collapses persistently", async () => {

--- a/ui/src/pages/chat/components/chat-session-rail.ts
+++ b/ui/src/pages/chat/components/chat-session-rail.ts
@@ -453,6 +453,10 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
       return nothing;
     }
     if (mode === "restore-icon") {
+      // This button sits with the pane header actions, where the
+      // background-tasks toggle owns icons.activity and the split-view controls
+      // own the panel glyphs. Keep a distinct companion glyph or neither action
+      // is readable without hovering for its tooltip.
       return html`
         <button
           class="btn btn--ghost btn--icon chat-icon-btn chat-session-rail chat-session-rail--restore"
@@ -461,7 +465,7 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
           title=${t("chat.rail.show")}
           @click=${() => this.show()}
         >
-          ${icons.activity}
+          ${icons.spark}
         </button>
       `;
     }


### PR DESCRIPTION
Closes #121418

## What Problem This Solves

Fixes an issue where operators reading the chat pane header could not tell two actions apart: the collapsed session rail ("Show session rail") and the background-tasks toggle ("Show background tasks") rendered the identical activity/pulse glyph. The two controls sit in the same top-right cluster, so the only way to know which was which was to hover and read a tooltip.

## Why This Change Was Made

One metaphor per action. Background tasks keep `icons.activity` — a pulse is a fair reading of ongoing work — so the session rail is the control that needed its own metaphor.

The rail is the session companion: a read-only assistant you ask about this session and its project. `icons.spark` is already the product's assist glyph (it backs the chat task suggestions), so the rail now reuses it rather than introducing a new drawing. A panel metaphor was deliberately rejected: the split-view controls at the end of the same row already own `columns2`, `panelRightOpen`, and `panelBottomOpen`, and a third panel-ish glyph would have recreated the same confusion one seat over.

No behavior, layout, copy, or i18n key changes — the button, its label, and its click handler are untouched.

## User Impact

The chat pane header action row is scannable again: five distinct glyphs, no tooltip needed to tell the session companion from background tasks.

## Evidence

Captures render the shipped stylesheets (`base`, `layout`, `components`, `chat/*`, `split-view`) and the shipped icon bodies, at the real header geometry: the action row, then the collapsed session rail inset 12px below the header edge.

**Before** — third header button (badge 2) is background tasks; the button below the divider is the session rail. Same glyph.

Light:

![before-light](https://github.com/user-attachments/assets/1ce4bb27-0f21-4c28-bac2-ee3d25bdab13)

Dark:

![before-dark](https://github.com/user-attachments/assets/7b62cecb-c98f-4ab3-beb8-e1dbefad16f1)

**After** — terminal, session diff, background tasks, workspace files, split view, and a distinct companion sparkle. Same 2px stroke, same optical weight.

Light:

![after-light](https://github.com/user-attachments/assets/5290f09d-30ae-45b3-85af-923ca0ae7b1f)

Dark:

![after-dark](https://github.com/user-attachments/assets/3b403a5d-fc4b-4d12-869d-036f51e7eb9e)

**Tests**

`node scripts/run-vitest.mjs ui/src/pages/chat/chat-session-rail.test.ts` — 21 passed, including the new regression test that renders the rail restore button and `renderBackgroundTasksToggle()` and asserts their glyphs differ. Reverting the icon to `icons.activity` fails that test, so it guards the invariant rather than restating the choice.

`node scripts/check-changed.mjs` — green (format, package patch guard, dead-export scan, Control UI i18n verify, core-test typecheck, UI typecheck, lint), delegated to Blacksmith Testbox `tbx_01kzmzztdwn5p6yz9c3jcpkgty`.

Production LOC: +5 / -1 (one glyph reference plus a four-line comment recording which neighbours own which metaphor). Test LOC: +46.
