### PR TITLE
fix(ui): remove Labs reset buttons

### DIFF
--- a/ui/src/e2e/config-safe-write.e2e.test.ts
+++ b/ui/src/e2e/config-safe-write.e2e.test.ts
@@ -132,12 +132,13 @@ suite.define(() => {
         const labsLink = page.locator('.settings-sidebar__item[href="/settings/labs"]');
         await expect.poll(() => labsLink.getAttribute("aria-current")).toBe("page");
         const codeModeRow = settingsRow(page, "Code Mode");
-        await codeModeRow.getByRole("switch", { name: "Code Mode", exact: true }).waitFor();
+        const codeModeSwitch = codeModeRow.getByRole("switch", { name: "Code Mode", exact: true });
+        await codeModeSwitch.waitFor();
         await expect.poll(() => codeModeRow.textContent()).toContain("Default: Enabled");
 
         const configGetsBeforePatch = (await gateway.getRequests("config.get")).length;
         await gateway.deferNext("config.patch");
-        await codeModeRow.getByRole("button", { name: "Reset to default" }).click();
+        await codeModeRow.locator("wa-switch").click();
         const patchParams = mutationParams(await gateway.waitForRequest("config.patch"));
         expect(patchParams.baseHash).toBe("snapshot-1");
         expect(patchParams.sessionKey).toBe("main");

--- a/ui/src/e2e/curated-settings-defaults.e2e.test.ts
+++ b/ui/src/e2e/curated-settings-defaults.e2e.test.ts
@@ -120,7 +120,7 @@ suite.define(() => {
 
         const configGetsBeforeLabsReset = (await gateway.getRequests("config.get")).length;
         await gateway.deferNext("config.patch");
-        await codeModeRow.getByRole("button", { name: "Reset to default" }).click();
+        await codeModeRow.locator("wa-switch").click();
         const labsPatch = requestRaw(await gateway.waitForRequest("config.patch"));
         expect(labsPatch).toEqual({ tools: { codeMode: { enabled: null } } });
 

--- a/ui/src/pages/labs/labs-page.test.ts
+++ b/ui/src/pages/labs/labs-page.test.ts
@@ -266,7 +266,7 @@ describe("LabsPage", () => {
     );
   });
 
-  it("shows default provenance and reset actions only for overrides", async () => {
+  it("shows default provenance without reset actions", async () => {
     const inherited = await mountPage({});
     expect(labRow(inherited.page, "Code Mode").textContent).toContain("Using default: Enabled");
     expect(labRow(inherited.page, "Swarm").textContent).toContain("Using default: Disabled");
@@ -284,7 +284,7 @@ describe("LabsPage", () => {
     expect(labRow(overridden.page, "Code Mode").textContent).toContain("Default: Enabled");
     expect(labRow(overridden.page, "Swarm").textContent).toContain("Default: Disabled");
     expect(overridden.page.querySelectorAll("button[aria-label='Reset to default']")).toHaveLength(
-      2,
+      0,
     );
   });
 
@@ -343,9 +343,9 @@ describe("LabsPage", () => {
       },
     });
 
-    labRow(page, "Lean tools for local models")
-      .querySelector<HTMLButtonElement>("button[aria-label='Reset to default']")
-      ?.click();
+    const toggle = labToggle(page, "Lean tools for local models");
+    toggle.checked = false;
+    toggle.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
 
     await vi.waitFor(() => expect(runtimeConfig.patch).toHaveBeenCalledOnce());
     expect(runtimeConfig.patch).toHaveBeenCalledWith({
@@ -354,36 +354,6 @@ describe("LabsPage", () => {
         wizard: { localModelLeanAutoModel: null },
       },
       note: "labs: update localModelLean",
-    });
-  });
-
-  it("restores an object gate without deleting sibling settings", async () => {
-    const { page, runtimeConfig } = await mountPage({
-      tools: { loopDetection: { enabled: true, warningThreshold: 12 } },
-    });
-
-    labRow(page, "Tool-loop detection")
-      .querySelector<HTMLButtonElement>("button[aria-label='Reset to default']")
-      ?.click();
-
-    await vi.waitFor(() => expect(runtimeConfig.patch).toHaveBeenCalledOnce());
-    expect(runtimeConfig.patch).toHaveBeenCalledWith({
-      raw: { tools: { loopDetection: { enabled: null } } },
-      note: "labs: update loopDetection",
-    });
-  });
-
-  it("restores a shorthand gate at its owning parent path", async () => {
-    const { page, runtimeConfig } = await mountPage({ tools: { codeMode: "auto" } });
-
-    labRow(page, "Code Mode")
-      .querySelector<HTMLButtonElement>("button[aria-label='Reset to default']")
-      ?.click();
-
-    await vi.waitFor(() => expect(runtimeConfig.patch).toHaveBeenCalledOnce());
-    expect(runtimeConfig.patch).toHaveBeenCalledWith({
-      raw: { tools: { codeMode: null } },
-      note: "labs: update codeMode",
     });
   });
 });
@@ -504,22 +474,6 @@ describe("LabsPage tool search enablement", () => {
     await vi.waitFor(() => expect(runtimeConfig.patch).toHaveBeenCalledOnce());
     expect(runtimeConfig.patch).toHaveBeenCalledWith({
       raw: { tools: { toolSearch: { enabled: true, mode: "directory" } } },
-      note: "labs: update toolSearch",
-    });
-  });
-
-  it("resets an explicit enabled override as a Tool Search unit", async () => {
-    const { page, runtimeConfig } = await mountPage({
-      tools: { toolSearch: { enabled: true } },
-    });
-
-    labRow(page, "Tool Search")
-      .querySelector<HTMLButtonElement>("button[aria-label='Reset to default']")
-      ?.click();
-
-    await vi.waitFor(() => expect(runtimeConfig.patch).toHaveBeenCalledOnce());
-    expect(runtimeConfig.patch).toHaveBeenCalledWith({
-      raw: { tools: { toolSearch: null } },
       note: "labs: update toolSearch",
     });
   });

--- a/ui/src/pages/labs/labs-page.ts
+++ b/ui/src/pages/labs/labs-page.ts
@@ -5,7 +5,6 @@ import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import {
   renderDocsLink,
-  renderSettingsDefaultState,
   renderSettingsPage,
   renderSettingsRow,
   renderSettingsSection,
@@ -113,39 +112,26 @@ class LabsPage extends OpenClawLightDomElement {
     );
   }
 
-  private resetFeature(feature: LabFeature) {
-    const config = this.editableConfig();
-    const featureState = resolveLabFeatureState(config, feature);
-    const resetPatch = labFeatureResetPatch(config, feature);
-    if (!resetPatch) {
-      return;
-    }
-    void this.updateFeature(feature, featureState.defaultEnabled, resetPatch);
-  }
-
   private renderFeature(feature: LabFeature) {
     const title = feature.title();
     const featureState = resolveLabFeatureState(this.editableConfig(), feature);
     const canToggle = this.canToggle();
-    const defaultState = renderSettingsDefaultState({
-      value: featureState.defaultEnabled ? t("common.enabled") : t("common.disabled"),
-      overridden: featureState.overridden,
-      disabled: !canToggle,
-      onReset: () => this.resetFeature(feature),
-    });
+    const defaultDescription = t(
+      featureState.overridden ? "configForm.defaultValue" : "configForm.usingDefault",
+      { value: featureState.defaultEnabled ? t("common.enabled") : t("common.disabled") },
+    );
     const description = html`
       ${feature.description()}
       <a href=${feature.docsUrl} target=${EXTERNAL_LINK_TARGET} rel=${buildExternalLinkRel()}
         >${t("labsPage.documentation")}</a
       >${feature.restartHint ? html` <span>${feature.restartHint()}</span>` : nothing}
-      <span>${defaultState.description}</span>
+      <span>${defaultDescription}</span>
     `;
     return renderSettingsToggleRow({
       title,
       description,
       checked: this.featureEnabled(feature),
       disabled: !canToggle,
-      actions: defaultState.action,
       onChange: (enabled) => this.setFeatureEnabled(feature, enabled),
     });
   }


### PR DESCRIPTION
## What Problem This Solves

Settings > Labs showed a circular reset button beside overridden toggles even though moving a toggle back to its default already clears the override, adding duplicate clutter to every overridden row.

## Why This Change Was Made

Render default provenance directly on Labs rows and omit the separate reset action. Shared reset controls on other settings pages stay unchanged, and Labs toggle-to-default behavior remains canonical.

## User Impact

Labs rows now show only the toggle; titles, descriptions, docs links, restart hints, and default provenance remain.

## Evidence

| Before | After |
| --- | --- |
| ![Before: overridden Labs row with duplicate reset action](https://github.com/user-attachments/assets/c07edc76-31b5-482d-9f38-f140071dcfc0) | ![After: Labs rows with toggles only](https://github.com/user-attachments/assets/63f4d542-3873-4db3-afb9-df6a25716d2d) |

- Focused test: `node scripts/run-vitest.mjs ui/src/pages/labs/labs-page.test.ts` — 41/41 passed.
- Targeted mocked Control UI E2E: 2 files, 2 tests passed.
- Targeted formatting and `git diff --check` passed.
- Codex autoreview: clean, with no accepted/actionable findings.
- Local rendered DOM proof: 8 rows, 8 accessible switch labels, and 0 reset buttons at desktop and mobile widths.
- Production LOC: +5/-19 (net -14); tests: +5/-51 (net -46).

