### PR TITLE
fix(ui): align automation session checkmark in sidebar filter

### DIFF
--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -88,6 +88,38 @@ describe("external shared-state ownership", () => {
     expect(inspectOpenClawStateOwnershipAtPath(database.path)).toBeNull();
   });
 
+  it("reads ownership from a WAL when the SHM index is absent", () => {
+    const env = createEnv(true);
+    const databasePath = openOpenClawStateDatabase({ env }).path;
+    closeOpenClawStateDatabaseForTest();
+    const { DatabaseSync } = requireNodeSqlite();
+    const writer = new DatabaseSync(databasePath);
+    try {
+      writer.exec("PRAGMA journal_mode = WAL; PRAGMA wal_autocheckpoint = 0;");
+      const ownership = {
+        version: 1,
+        mode: "external",
+        managerId: "wal-only-manager",
+        claimedAt: 1,
+      } as const;
+      writer
+        .prepare(
+          "INSERT INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES (?, ?, ?)",
+        )
+        .run(STATE_SUPERVISION_KEY, JSON.stringify(ownership), ownership.claimedAt);
+
+      const copyDir = tempDirs.make("openclaw-state-ownership-wal-only-");
+      const copyPath = path.join(copyDir, "openclaw.sqlite");
+      fs.copyFileSync(databasePath, copyPath);
+      fs.copyFileSync(`${databasePath}-wal`, `${copyPath}-wal`);
+      expect(fs.existsSync(`${copyPath}-shm`)).toBe(false);
+
+      expect(inspectOpenClawStateOwnershipAtPath(copyPath)).toEqual(ownership);
+    } finally {
+      writer.close();
+    }
+  });
+
   it("requires the external marker and makes claims idempotent only for one manager", () => {
     const env = createEnv();
     expect(() => claimOpenClawStateOwnership("gateway-supervisor", { env })).toThrow(

--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -120,6 +120,51 @@ describe("external shared-state ownership", () => {
     }
   });
 
+  it("rechecks ownership when a WAL appears during immutable inspection", () => {
+    const env = createEnv(true);
+    const databasePath = openOpenClawStateDatabase({ env }).path;
+    closeOpenClawStateDatabaseForTest();
+    const ownership = {
+      version: 1,
+      mode: "external",
+      managerId: "transition-manager",
+      claimedAt: 2,
+    } as const;
+    const { DatabaseSync } = requireNodeSqlite();
+    const originalExec = Object.getOwnPropertyDescriptor(DatabaseSync.prototype, "exec")?.value as
+      | ((this: import("node:sqlite").DatabaseSync, sql: string) => void)
+      | undefined;
+    if (!originalExec) {
+      throw new Error("DatabaseSync.exec descriptor is unavailable");
+    }
+    let writer: InstanceType<typeof DatabaseSync> | undefined;
+    let injected = false;
+    const exec = vi.spyOn(DatabaseSync.prototype, "exec").mockImplementation(function (
+      this: import("node:sqlite").DatabaseSync,
+      sql: string,
+    ) {
+      if (!injected && sql.includes("PRAGMA busy_timeout")) {
+        injected = true;
+        writer = new DatabaseSync(databasePath);
+        originalExec.call(writer, "PRAGMA journal_mode = WAL; PRAGMA wal_autocheckpoint = 0;");
+        writer
+          .prepare(
+            "INSERT INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES (?, ?, ?)",
+          )
+          .run(STATE_SUPERVISION_KEY, JSON.stringify(ownership), ownership.claimedAt);
+      }
+      return originalExec.call(this, sql);
+    });
+
+    try {
+      expect(inspectOpenClawStateOwnershipAtPath(databasePath)).toEqual(ownership);
+      expect(injected).toBe(true);
+    } finally {
+      exec.mockRestore();
+      writer?.close();
+    }
+  });
+
   it("requires the external marker and makes claims idempotent only for one manager", () => {
     const env = createEnv();
     expect(() => claimOpenClawStateOwnership("gateway-supervisor", { env })).toThrow(

--- a/src/state/openclaw-state-ownership.ts
+++ b/src/state/openclaw-state-ownership.ts
@@ -132,7 +132,12 @@ export function inspectOpenClawStateOwnershipAtPath(
       database.exec(
         `PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS}; PRAGMA query_only = ON; PRAGMA trusted_schema = OFF;`,
       );
-      return inspectOpenClawStateOwnershipFromDatabase(database, resolvedPath);
+      const ownership = inspectOpenClawStateOwnershipFromDatabase(database, resolvedPath);
+      if (location !== resolvedPath && existsSync(`${resolvedPath}-wal`)) {
+        location = resolvedPath;
+        continue;
+      }
+      return ownership;
     } catch (error) {
       // External claims checkpoint before returning, so the main file is authoritative.
       // If a WAL appeared during immutable inspection, retry once with its live reader.

--- a/src/state/openclaw-state-ownership.ts
+++ b/src/state/openclaw-state-ownership.ts
@@ -4,6 +4,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { isGatewayExternallySupervised } from "../infra/gateway-supervision.js";
 import { openNodeSqliteDatabase, resolveImmutableSqliteFileUri } from "../infra/node-sqlite.js";
+import { isSqliteCorruptionError } from "../infra/sqlite-transaction.js";
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db-contract.js";
 import { tableExists } from "./openclaw-state-db-schema-helpers.js";
 
@@ -114,7 +115,26 @@ export function inspectOpenClawStateOwnershipFromDatabase(
   return parseExternalOwnership(row.value_json, databasePath);
 }
 
-/** Inspect one resolved state database path without mutating a quiescent SQLite family. */
+function hasLiveWal(databasePath: string): boolean {
+  return existsSync(`${databasePath}-wal`);
+}
+
+function inspectOpenClawStateOwnershipAtLocation(
+  databasePath: string,
+  location = databasePath,
+): OpenClawExternalStateOwnership | null {
+  const database = openNodeSqliteDatabase(location, { readOnly: true });
+  try {
+    database.exec(
+      `PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS}; PRAGMA query_only = ON; PRAGMA trusted_schema = OFF;`,
+    );
+    return inspectOpenClawStateOwnershipFromDatabase(database, databasePath);
+  } finally {
+    database.close();
+  }
+}
+
+/** Inspect one resolved state database path without joining the writable lifecycle. */
 export function inspectOpenClawStateOwnershipAtPath(
   databasePath: string,
 ): OpenClawExternalStateOwnership | null {
@@ -122,18 +142,21 @@ export function inspectOpenClawStateOwnershipAtPath(
   if (!existsSync(resolvedPath)) {
     return null;
   }
-  // WAL readers need the live sidecars. Rollback-journal recovery stays with the
-  // writable lifecycle after this ownership fence, so it remains immutable here.
-  const hasLiveWal = ["-shm", "-wal"].some((suffix) => existsSync(`${resolvedPath}${suffix}`));
-  const location = hasLiveWal ? resolvedPath : resolveImmutableSqliteFileUri(resolvedPath);
-  const database = openNodeSqliteDatabase(location, { readOnly: true });
+  if (hasLiveWal(resolvedPath)) {
+    return inspectOpenClawStateOwnershipAtLocation(resolvedPath);
+  }
   try {
-    database.exec(
-      `${hasLiveWal ? `PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS}; ` : ""}PRAGMA query_only = ON; PRAGMA trusted_schema = OFF;`,
+    return inspectOpenClawStateOwnershipAtLocation(
+      resolvedPath,
+      resolveImmutableSqliteFileUri(resolvedPath),
     );
-    return inspectOpenClawStateOwnershipFromDatabase(database, resolvedPath);
-  } finally {
-    database.close();
+  } catch (error) {
+    // External claims checkpoint before returning, so the main file is authoritative.
+    // If a WAL appeared during this open, retry with SQLite's normal WAL-aware reader.
+    if (!isSqliteCorruptionError(error) || !hasLiveWal(resolvedPath)) {
+      throw error;
+    }
+    return inspectOpenClawStateOwnershipAtLocation(resolvedPath);
   }
 }
 

--- a/src/state/openclaw-state-ownership.ts
+++ b/src/state/openclaw-state-ownership.ts
@@ -4,6 +4,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { isGatewayExternallySupervised } from "../infra/gateway-supervision.js";
 import { openNodeSqliteDatabase, resolveImmutableSqliteFileUri } from "../infra/node-sqlite.js";
+import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db-contract.js";
 import { tableExists } from "./openclaw-state-db-schema-helpers.js";
 
 export const STATE_SUPERVISION_KEY = "gateway.supervision";
@@ -113,7 +114,7 @@ export function inspectOpenClawStateOwnershipFromDatabase(
   return parseExternalOwnership(row.value_json, databasePath);
 }
 
-/** Inspect one resolved state database path through a read-only connection. */
+/** Inspect one resolved state database path without mutating a quiescent SQLite family. */
 export function inspectOpenClawStateOwnershipAtPath(
   databasePath: string,
 ): OpenClawExternalStateOwnership | null {
@@ -121,11 +122,15 @@ export function inspectOpenClawStateOwnershipAtPath(
   if (!existsSync(resolvedPath)) {
     return null;
   }
-  const database = openNodeSqliteDatabase(resolveImmutableSqliteFileUri(resolvedPath), {
-    readOnly: true,
-  });
+  const hasLiveJournal = ["-journal", "-shm", "-wal"].some((suffix) =>
+    existsSync(`${resolvedPath}${suffix}`),
+  );
+  const location = hasLiveJournal ? resolvedPath : resolveImmutableSqliteFileUri(resolvedPath);
+  const database = openNodeSqliteDatabase(location, { readOnly: true });
   try {
-    database.exec("PRAGMA query_only = ON; PRAGMA trusted_schema = OFF;");
+    database.exec(
+      `${hasLiveJournal ? `PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS}; ` : ""}PRAGMA query_only = ON; PRAGMA trusted_schema = OFF;`,
+    );
     return inspectOpenClawStateOwnershipFromDatabase(database, resolvedPath);
   } finally {
     database.close();

--- a/src/state/openclaw-state-ownership.ts
+++ b/src/state/openclaw-state-ownership.ts
@@ -115,25 +115,6 @@ export function inspectOpenClawStateOwnershipFromDatabase(
   return parseExternalOwnership(row.value_json, databasePath);
 }
 
-function hasLiveWal(databasePath: string): boolean {
-  return existsSync(`${databasePath}-wal`);
-}
-
-function inspectOpenClawStateOwnershipAtLocation(
-  databasePath: string,
-  location = databasePath,
-): OpenClawExternalStateOwnership | null {
-  const database = openNodeSqliteDatabase(location, { readOnly: true });
-  try {
-    database.exec(
-      `PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS}; PRAGMA query_only = ON; PRAGMA trusted_schema = OFF;`,
-    );
-    return inspectOpenClawStateOwnershipFromDatabase(database, databasePath);
-  } finally {
-    database.close();
-  }
-}
-
 /** Inspect one resolved state database path without joining the writable lifecycle. */
 export function inspectOpenClawStateOwnershipAtPath(
   databasePath: string,
@@ -142,21 +123,30 @@ export function inspectOpenClawStateOwnershipAtPath(
   if (!existsSync(resolvedPath)) {
     return null;
   }
-  if (hasLiveWal(resolvedPath)) {
-    return inspectOpenClawStateOwnershipAtLocation(resolvedPath);
-  }
-  try {
-    return inspectOpenClawStateOwnershipAtLocation(
-      resolvedPath,
-      resolveImmutableSqliteFileUri(resolvedPath),
-    );
-  } catch (error) {
-    // External claims checkpoint before returning, so the main file is authoritative.
-    // If a WAL appeared during this open, retry with SQLite's normal WAL-aware reader.
-    if (!isSqliteCorruptionError(error) || !hasLiveWal(resolvedPath)) {
-      throw error;
+  let location = existsSync(`${resolvedPath}-wal`)
+    ? resolvedPath
+    : resolveImmutableSqliteFileUri(resolvedPath);
+  while (true) {
+    const database = openNodeSqliteDatabase(location, { readOnly: true });
+    try {
+      database.exec(
+        `PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS}; PRAGMA query_only = ON; PRAGMA trusted_schema = OFF;`,
+      );
+      return inspectOpenClawStateOwnershipFromDatabase(database, resolvedPath);
+    } catch (error) {
+      // External claims checkpoint before returning, so the main file is authoritative.
+      // If a WAL appeared during immutable inspection, retry once with its live reader.
+      if (
+        location === resolvedPath ||
+        !isSqliteCorruptionError(error) ||
+        !existsSync(`${resolvedPath}-wal`)
+      ) {
+        throw error;
+      }
+      location = resolvedPath;
+    } finally {
+      database.close();
     }
-    return inspectOpenClawStateOwnershipAtLocation(resolvedPath);
   }
 }
 

--- a/src/state/openclaw-state-ownership.ts
+++ b/src/state/openclaw-state-ownership.ts
@@ -122,14 +122,14 @@ export function inspectOpenClawStateOwnershipAtPath(
   if (!existsSync(resolvedPath)) {
     return null;
   }
-  const hasLiveJournal = ["-journal", "-shm", "-wal"].some((suffix) =>
-    existsSync(`${resolvedPath}${suffix}`),
-  );
-  const location = hasLiveJournal ? resolvedPath : resolveImmutableSqliteFileUri(resolvedPath);
+  // WAL readers need the live sidecars. Rollback-journal recovery stays with the
+  // writable lifecycle after this ownership fence, so it remains immutable here.
+  const hasLiveWal = ["-shm", "-wal"].some((suffix) => existsSync(`${resolvedPath}${suffix}`));
+  const location = hasLiveWal ? resolvedPath : resolveImmutableSqliteFileUri(resolvedPath);
   const database = openNodeSqliteDatabase(location, { readOnly: true });
   try {
     database.exec(
-      `${hasLiveJournal ? `PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS}; ` : ""}PRAGMA query_only = ON; PRAGMA trusted_schema = OFF;`,
+      `${hasLiveWal ? `PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS}; ` : ""}PRAGMA query_only = ON; PRAGMA trusted_schema = OFF;`,
     );
     return inspectOpenClawStateOwnershipFromDatabase(database, resolvedPath);
   } finally {

--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -324,6 +324,9 @@ export function renderSidebarSessionSortMenu(params: {
             .checked=${params.showCron}
           >
             <span class="session-menu__text">${t("sessionsView.showCronSessions")}</span>
+            <span slot="details" class="session-menu__check" aria-hidden="true"
+              >${params.showCron ? icons.check : nothing}</span
+            >
           </wa-dropdown-item>
         </wa-dropdown>
       </openclaw-menu-surface>

--- a/ui/src/e2e/session-management.groups.e2e.test.ts
+++ b/ui/src/e2e/session-management.groups.e2e.test.ts
@@ -626,20 +626,28 @@ suite.define(() => {
       await expect.poll(() => showAutomationSessions.getAttribute("aria-checked")).toBe("true");
       await page.getByRole("menuitemradio", { name: "None" }).waitFor({ state: "visible" });
       await captureUiProof(page, "sidebar-groupby-sort-menu.png");
-      const groupingCheckBounds = await page
+      const groupingCheck = page
         .getByRole("menuitemradio", { name: "Custom groups" })
-        .locator(".session-menu__check svg")
-        .boundingBox();
+        .locator(".session-menu__check");
       const nativeAutomationCheck = showAutomationSessions.locator('[part="checkmark"]');
       await expect.poll(() => nativeAutomationCheck.count()).toBe(1);
       expect(await nativeAutomationCheck.boundingBox()).toBeNull();
-      const automationCheck = showAutomationSessions.locator(".session-menu__check svg");
+      const automationCheck = showAutomationSessions.locator(".session-menu__check");
       await expect.poll(() => automationCheck.count()).toBe(1);
-      const automationCheckBounds = await automationCheck.boundingBox();
-      if (!groupingCheckBounds || !automationCheckBounds) {
-        throw new Error("Expected visible trailing selection marks in the session sort menu");
-      }
-      expect(Math.abs(automationCheckBounds.x - groupingCheckBounds.x)).toBeLessThanOrEqual(1);
+      await expect
+        .poll(async () => {
+          const [groupingBounds, automationBounds] = await Promise.all([
+            groupingCheck.boundingBox(),
+            automationCheck.boundingBox(),
+          ]);
+          if (!groupingBounds || !automationBounds) {
+            return Number.POSITIVE_INFINITY;
+          }
+          const groupingRight = groupingBounds.x + groupingBounds.width;
+          const automationRight = automationBounds.x + automationBounds.width;
+          return Math.abs(automationRight - groupingRight);
+        })
+        .toBeLessThanOrEqual(1);
       await sortSessionsButton.click();
       await expect.poll(() => sortSessionsButton.getAttribute("aria-expanded")).toBe("false");
       await expect.poll(() => page.getByRole("menuitemradio", { name: "None" }).count()).toBe(0);

--- a/ui/src/e2e/session-management.groups.e2e.test.ts
+++ b/ui/src/e2e/session-management.groups.e2e.test.ts
@@ -616,8 +616,30 @@ suite.define(() => {
         "button.sidebar-session-sort:not(.sidebar-session-new)",
       );
       await sortSessionsButton.click();
+      const showAutomationSessions = page.getByRole("menuitemcheckbox", {
+        name: "Show automation sessions",
+      });
+      await activateMenuItem(showAutomationSessions);
+      await expect.poll(() => sortSessionsButton.getAttribute("aria-expanded")).toBe("false");
+
+      await sortSessionsButton.click();
+      await expect.poll(() => showAutomationSessions.getAttribute("aria-checked")).toBe("true");
       await page.getByRole("menuitemradio", { name: "None" }).waitFor({ state: "visible" });
       await captureUiProof(page, "sidebar-groupby-sort-menu.png");
+      const groupingCheckBounds = await page
+        .getByRole("menuitemradio", { name: "Custom groups" })
+        .locator(".session-menu__check svg")
+        .boundingBox();
+      const nativeAutomationCheck = showAutomationSessions.locator('[part="checkmark"]');
+      await expect.poll(() => nativeAutomationCheck.count()).toBe(1);
+      expect(await nativeAutomationCheck.boundingBox()).toBeNull();
+      const automationCheck = showAutomationSessions.locator(".session-menu__check svg");
+      await expect.poll(() => automationCheck.count()).toBe(1);
+      const automationCheckBounds = await automationCheck.boundingBox();
+      if (!groupingCheckBounds || !automationCheckBounds) {
+        throw new Error("Expected visible trailing selection marks in the session sort menu");
+      }
+      expect(Math.abs(automationCheckBounds.x - groupingCheckBounds.x)).toBeLessThanOrEqual(1);
       await sortSessionsButton.click();
       await expect.poll(() => sortSessionsButton.getAttribute("aria-expanded")).toBe("false");
       await expect.poll(() => page.getByRole("menuitemradio", { name: "None" }).count()).toBe(0);

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2673,6 +2673,12 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   color: var(--danger);
 }
 
+/* Web Awesome renders checkbox marks before the label. Selection state in this
+   menu uses the trailing details rail, so keep the native semantics but hide its visual. */
+.sidebar-session-sort-menu__item::part(checkmark) {
+  display: none;
+}
+
 .session-menu__icon,
 .session-menu__check {
   display: inline-flex;


### PR DESCRIPTION
Related: #121385

## What Problem This Solves

Fixes an issue where users enabling **Show automation sessions** in the Control UI sidebar filter saw its checkmark rendered outside the popover's left edge instead of aligned with the other selected options.

The automation row is the only native checkbox in this menu. Web Awesome renders that checkbox mark before the label with a negative leading margin, while OpenClaw's Group By, Sort By, Status, and People selections all use the shared trailing selection rail.

Exact-head CI also exposed an unrelated current-`main` blocker: concurrent device-identity startup could open a changing WAL database through SQLite `immutable=1`, which skips locking/change detection and can report false corruption. That owner-boundary repair remains here because the repository does not land onto red `main` or bypass required checks.

## Why This Change Was Made

The checkbox keeps Web Awesome's native `menuitemcheckbox` and `aria-checked` behavior, but its built-in leading visual is hidden and the existing OpenClaw checkmark is rendered through Web Awesome's supported trailing `details` slot. This keeps one consistent selection rail without reimplementing checkbox semantics.

The browser regression toggles the setting, reopens the popover, verifies `aria-checked=true`, proves the native leading mark is hidden, requires exactly one visible trailing mark, and polls both fixed-width selection containers until their trailing edges align within 1px. Polling the final rail geometry avoids sampling different points in Web Awesome's open animation.

For the state blocker, ownership preflight still uses immutable inspection for a quiescent family so it cannot create WAL/SHM files before the external-ownership fence. An existing `-wal` is always treated as live state, even when the rebuildable `-shm` index is absent. Before returning any successful immutable result, the bounded loop rechecks whether a WAL appeared and reruns through normal WAL-aware read-only access; the same retry handles SQLite corruption caused by a WAL transition during the immutable read. External ownership claims checkpoint before returning, so the main file remains authoritative; hot rollback journals still remain untouched until the canonical writable lifecycle performs crash recovery. No schema or schema-version change is involved.

This extracts and proves the checkbox-only repair independently from #121385's broader toast and recovery work. Credit to @vyctorbrzezowski for the original fix shape; contributor credit is preserved in the UI commit.

## User Impact

The **Show automation sessions** checkbox now reads like every other selected option in the session filter: one checkmark on the right edge, fully inside the popover.

Concurrent OpenClaw processes can also initialize/read device identity without a false SQLite corruption error when the shared state database has a live WAL, including a WAL whose SHM index must be rebuilt, while hot rollback-journal recovery still completes through the normal writer path.

| Before | After |
| --- | --- |
| ![Checkmark rendered outside the left edge](https://github.com/user-attachments/assets/559eb94a-81f3-43b8-9000-c215db3d317f) | ![Checkmark aligned with the trailing selection rail](https://github.com/user-attachments/assets/63c97a69-a5e5-4631-8ec4-624e12b27a14) |

## Evidence

### Checkbox repair

- Pre-fix browser regression failed because Web Awesome's native checkmark had a visible bounding box at the leading edge.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-management.groups.e2e.test.ts -t 'renames, deletes, and toggles sidebar session groups'` — passed after the fix; screenshots above came from this run.
- Final settled trailing-edge assertion: 5/5 serial passes.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/check-changed.mjs -- ui/src/components/app-sidebar-session-menu-renderers.ts ui/src/styles/layout.css ui/src/e2e/session-management.groups.e2e.test.ts` — passed. Remote routing was unavailable on this host, so the repository wrapper's approved trusted-source local path was used.
- Black-box behavior contract passed: native checkbox role and checked state preserved, exactly one visible mark, no leading mark, settled trailing alignment within 1px.

### SQLite CI blocker

- Original exact-head CI failure: `src/infra/device-identity.test.ts` reported `database disk image is malformed` from immutable inspection during concurrent creation.
- The same focused test reproduced locally before the repair.
- Focused concurrent creator test: 5/5 serial passes after the final repair.
- `node scripts/run-vitest.mjs src/infra/device-identity.test.ts` — 21/21 passed.
- `node scripts/run-vitest.mjs src/state/openclaw-state-ownership.test.ts` — 11/11 passed.
- New WAL-without-SHM regression failed pre-fix (`null` ownership) and passes on the final reader.
- New successful immutable-read/WAL-transition regression injects a committed ownership WAL after the immutable connection opens; it failed pre-fix (`null`) and passes with the before-return recheck.
- `node scripts/run-vitest.mjs src/state/openclaw-state-db.test.ts -t 'recovers a hot rollback journal privately before writable recovery'` — passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/check-changed.mjs -- src/state/openclaw-state-ownership.ts src/state/openclaw-state-ownership.test.ts` — passed, including schema guard, typechecks, lint, import cycles, and database-first guards.
- SQLite contract proof: https://www.sqlite.org/uri.html and https://www.sqlite.org/wal.html.

### Review resolution

- ClawSweeper's reviewed-head P1 findings were accepted. The final bounded loop rechecks for a WAL after both successful immutable inspection and immutable corruption, then switches once to the live WAL reader.
- The suggested all-normal-reader implementation was not used: `openclaw-state-ownership.test.ts` proves it creates persistent `-wal`/`-shm` files before an external-ownership block, violating the no-mutation fence. The final path preserves that invariant while closing the WAL transition race.
- A wider P1 autoreview is clean on the final state retry and WAL-only regression; separate P1 autoreview is clean on the settled UI geometry assertion.
- A prior exact-head shard also timed out running `acp --help`; the focused process suite passed locally (2/2) and is unrelated to these files.

### Size

- Production LOC: +41/-9 (net +32).
- Tests: +107/-0.
- Positive production delta consists of the Web Awesome visual override (+9) and the bounded SQLite ownership reader/retry (+32/-9). The test growth is two real database-family transition regressions plus the browser geometry proof. No fallback store, compatibility shim, alternate persistence path, retry loop beyond one WAL transition, or schema change was added.

AI-assisted; implementation and proof were reviewed against the Web Awesome 3.10 dropdown-item source, SQLite's official URI/WAL contracts, the current OpenClaw state ownership lifecycle, and the repository's no-mutation ownership tests.
