### PR TITLE
fix(ui): make source builds deterministic

### DIFF
--- a/ui/src/app/vite-config.node.test.ts
+++ b/ui/src/app/vite-config.node.test.ts
@@ -78,26 +78,28 @@ describe("Control UI Vite config", () => {
     expect(readGitCommitTimestamp).toHaveBeenCalledWith("0123456789abcdef0123456789abcdef01234567");
   });
 
-  it("falls back to Git and the current UTC time only when inputs are absent", () => {
-    expect(
-      resolveControlUiBuildInfo({
-        env: {},
-        now: () => new Date("2026-07-10T13:14:15.000Z"),
-        readGitCommit: () => "a".repeat(40),
-        readGitCommitTimestamp: () => null,
-        readGitBranch: () => null,
-        readGitDirty: () => null,
-        readPackageVersion: () => null,
-      }),
-    ).toEqual({
+  it("keeps source-build identity stable when no build timestamp is provided", () => {
+    const sources = {
+      env: {},
+      readGitCommit: () => "a".repeat(40),
+      readGitCommitTimestamp: () => null,
+      readGitBranch: () => null,
+      readGitDirty: () => null,
+      readPackageVersion: () => null,
+    };
+    const first = resolveControlUiBuildInfo(sources);
+    const second = resolveControlUiBuildInfo(sources);
+
+    expect(first).toEqual(second);
+    expect(first).toEqual({
       version: null,
       commit: "a".repeat(40),
       commitAt: null,
-      builtAt: "2026-07-10T13:14:15.000Z",
+      builtAt: null,
       branch: null,
       dirty: null,
       release: false,
-      buildId: "aaaaaaaaaaaa-2026-07-10T13-14-15.000Z",
+      buildId: "aaaaaaaaaaaa",
     });
   });
 
@@ -182,7 +184,6 @@ describe("Control UI Vite config", () => {
     expect(
       resolveControlUiBuildInfo({
         env: { GITHUB_SHA: "b".repeat(40) },
-        now: () => new Date("2026-07-10T13:14:15.000Z"),
         readGitCommit,
         readPackageVersion: () => null,
       }),
@@ -191,7 +192,6 @@ describe("Control UI Vite config", () => {
     expect(
       resolveControlUiBuildInfo({
         env: { GITHUB_SHA: "b".repeat(40) },
-        now: () => new Date("2026-07-10T13:14:15.000Z"),
         readGitCommit: () => null,
         readPackageVersion: () => null,
       }).commit,
@@ -210,7 +210,6 @@ describe("Control UI Vite config", () => {
     expect(
       resolveControlUiBuildInfo({
         env: { GIT_SHA: "A".repeat(40), GITHUB_SHA: "b".repeat(40) },
-        now: () => new Date("2026-07-10T13:14:15.000Z"),
         readGitCommit,
         readPackageVersion: () => null,
       }).commit,

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -151,7 +151,6 @@ function readGitDirty(): boolean | null {
 
 type ControlUiBuildInfoSources = {
   env?: NodeJS.ProcessEnv;
-  now?: () => Date;
   readPackageVersion?: () => string | null;
   readGitCommit?: () => string | null;
   readGitCommitTimestamp?: (commit: string) => string | null;
@@ -159,19 +158,16 @@ type ControlUiBuildInfoSources = {
   readGitDirty?: () => boolean | null;
 };
 
-function normalizeBuildTimestamp(value: string | undefined, now: () => Date): string | null {
+function normalizeBuildTimestamp(value: string | undefined): string | null {
   const explicit = value?.trim();
-  if (explicit) {
-    const timestamp = normalizeControlUiBuildInfo({ builtAt: explicit }).builtAt;
-    if (!timestamp) {
-      throw new Error(
-        "OPENCLAW_BUILD_TIMESTAMP must be a valid UTC ISO-8601 timestamp ending in Z",
-      );
-    }
-    return timestamp;
+  if (!explicit) {
+    return null;
   }
-  const candidate = now();
-  return Number.isNaN(candidate.getTime()) ? null : candidate.toISOString();
+  const timestamp = normalizeControlUiBuildInfo({ builtAt: explicit }).builtAt;
+  if (!timestamp) {
+    throw new Error("OPENCLAW_BUILD_TIMESTAMP must be a valid UTC ISO-8601 timestamp ending in Z");
+  }
+  return timestamp;
 }
 
 export function resolveControlUiBuildInfo(
@@ -215,10 +211,7 @@ export function resolveControlUiBuildInfo(
         commitAt: readCommitTimestamp(commit),
       }).commitAt
     : null;
-  const builtAt = normalizeBuildTimestamp(
-    env.OPENCLAW_BUILD_TIMESTAMP,
-    sources.now ?? (() => new Date()),
-  );
+  const builtAt = normalizeBuildTimestamp(env.OPENCLAW_BUILD_TIMESTAMP);
   // Branch/dirty identity is advisory: the readers return null instead of
   // throwing, so malformed environment or Git state never blocks a build.
   // Tags must not be presented as branches in GitHub-built artifacts.


### PR DESCRIPTION
## What Problem This Solves

Exact-head CI for https://github.com/openclaw/openclaw/pull/121208 failed `QA Smoke CI (profile 3/4)` by four bytes:

- profile 1: 324,564 B startup JS gzip
- profile 2: 324,574 B
- profile 3: 324,612 B
- profile 4: 324,591 B

All four jobs built identical source. Their Control UI asset hashes differed because direct `pnpm ui:build` embedded each job's current wall-clock time into content-hashed startup JavaScript.

## Why This Change Was Made

`OPENCLAW_BUILD_TIMESTAMP` is now the only source of `builtAt`. When no owner supplies it, source builds record `builtAt: null` and derive a stable build ID from version/release/commit identity.

Release and packaged artifacts keep truthful build times because their owners already pin an explicit timestamp through the full build/prepack environment. The fix does not substitute commit time for build time, serialize QA profiles, or raise the protected performance baseline.

Production delta: -8 lines.

## User Impact

Repeated direct source builds now produce byte-identical Control UI artifacts. Service-worker and asset identities remain stable unless source or an explicit artifact identity changes, eliminating flaky bundle-budget failures caused only by build time.

## Evidence

- Focused Vite/build-info/performance tests: 39 passed.
- Rebased exact-head Vite config tests: 21 passed.
- Testbox https://github.com/openclaw/openclaw/actions/runs/31358060935 built the same dirty checkout twice with `OPENCLAW_BUILD_TIMESTAMP` unset and a delay between builds:
  - 1,725 emitted files had identical sorted SHA-256 manifests;
  - performance JSON was identical;
  - startup JS gzip was exactly 325,379 B both times, within the current protected ceiling;
  - build ID was stable and commit-derived.
- `config/control-ui-startup-budget-baseline.json` is unchanged.
- Oxfmt and `git diff --check` passed.
- Codex autoreview: clean, no accepted/actionable findings.
