### PR TITLE
fix(ui): stop suggested cards flashing white after scrolling

### DIFF
--- a/ui/src/components/mcp-app-view.ts
+++ b/ui/src/components/mcp-app-view.ts
@@ -135,7 +135,7 @@ export class McpAppView extends LitElement {
       display: block;
       width: 100%;
       border: 0;
-      background: var(--board-surface, var(--card));
+      background: var(--board-surface, transparent);
     }
     .error {
       padding: 14px;

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1234,6 +1234,51 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
+  it("keeps inline MCP App reloads transparent without changing dashboard surfaces", async () => {
+    const page = await openBrowserPage(1366, 900);
+    try {
+      if (!realChatServer) {
+        throw new Error("Expected the Control UI server to be ready");
+      }
+      await page.goto(realChatServer.baseUrl, { waitUntil: "domcontentloaded" });
+      await page.addScriptTag({
+        type: "module",
+        url: new URL("src/components/mcp-app-view-registration.ts", realChatServer.baseUrl).href,
+      });
+      const backgrounds = await page.evaluate(async () => {
+        await customElements.whenDefined("mcp-app-view");
+        const readFrameBackground = async (boardSurface?: string) => {
+          const owner = document.createElement("div");
+          if (boardSurface) {
+            owner.style.setProperty("--board-surface", boardSurface);
+          }
+          const view = document.createElement("mcp-app-view") as HTMLElement & {
+            updateComplete: Promise<boolean>;
+          };
+          owner.append(view);
+          document.body.replaceChildren(owner);
+          await view.updateComplete;
+          const mount = view.shadowRoot?.querySelector(".mount");
+          if (!mount) {
+            throw new Error("MCP App mount is missing");
+          }
+          const frame = document.createElement("iframe");
+          mount.append(frame);
+          return getComputedStyle(frame).backgroundColor;
+        };
+        return {
+          dashboard: await readFrameBackground("rgb(12, 34, 56)"),
+          inline: await readFrameBackground(),
+        };
+      });
+
+      expect(backgrounds.dashboard).toBe("rgb(12, 34, 56)");
+      expect(backgrounds.inline).toBe("rgba(0, 0, 0, 0)");
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
   it("keeps wrapped message footers inside measured virtual rows", async () => {
     const page = await openBrowserPage(1366, 900);
     try {


### PR DESCRIPTION
Closes #121425
Related: #120820

AI-assisted: this fix and its regression coverage were developed with Codex assistance, independently reviewed, and validated in browser fixtures.

## What Problem This Solves

Fixes an issue where users scrolling back to an inline suggested-task or MCP App card would see an opaque white loading surface while transcript virtualization remounted and reloaded the card.

## Why This Change Was Made

The shared MCP App frame now uses an explicitly supplied dashboard surface when one exists, but falls back to transparent for inline chat cards. This preserves the dashboard dark-mode repair from #120820 while letting remounted chat cards reveal their stable surrounding surface instead of painting the generic card color.

## User Impact

Suggested-task and other inline MCP App cards no longer flash white when they reload after scrolling. Pinned dashboard widgets continue to use their themed dashboard loading surface.

Release-note context: Control UI suggested-task and MCP App cards no longer flash white when scrolling remounts them.

## Evidence

| Before | After |
| --- | --- |
| ![Before: opaque iframe fallback covers the surrounding chat-card surface](https://github.com/user-attachments/assets/eee5783c-4be3-45ae-a857-84390b902907) | ![After: transparent iframe reveals the stable surrounding chat-card surface](https://github.com/user-attachments/assets/a6990293-747e-4ae3-8f37-209429a9bde4) |

The screenshots use a sanitized diagnostic fixture for the empty-iframe interval before sandbox content paints. Measured background changed from `rgb(255, 255, 255)` to `rgba(0, 0, 0, 0)`.

- Regression proof: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts -t 'keeps inline MCP App reloads transparent without changing dashboard surfaces'` failed before the fix with `rgb(255, 255, 255)` and passed the assertion after the fix. The second local rerun then hit a Vitest browser-worker termination hang after reporting the pass.
- Dashboard sibling proof: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs ui/src/e2e/board-mcp-app.e2e.test.ts` — 3/3 passed.
- Production bundle: `pnpm ui:build` — passed, including precompressed-asset and Control UI performance checks.
- Targeted static proof: oxfmt, stylelint, oxlint, and `git diff --check` — passed.
- Source-blind browser validation: inline initial/remounted backgrounds were transparent; dashboard surfaces matched the supplied value; full-width layout and one-current-iframe lifecycle passed, including a varied 517px / `rgb(73, 109, 147)` anti-cheat probe.
- Codex autoreview (`--mode uncommitted`): clean, no accepted/actionable findings.
- LOC split: production `+1/-1` (net zero); tests `+45`.

- Exact-head CI: [run 31358664522](https://github.com/openclaw/openclaw/actions/runs/31358664522) — green on `e805b5b48bde5a4f3fc960d90d91f08b0122fb43`, including `checks-ui-e2e` and `openclaw/ci-gate`.
- Local/remote changed-gate note: Blacksmith Testbox was unavailable because its CLI was missing; the AWS fallback lacked hydrated modules, and the local fallback timed out behind another worktree's active heavy-check lock. Exact-head CI supplied the remaining type/lint/dead-export proof.
