### PR TITLE
fix(ui): keep typing indicator in the composer footer

### DIFF
--- a/ui/src/e2e/session-suggestions.e2e.test.ts
+++ b/ui/src/e2e/session-suggestions.e2e.test.ts
@@ -109,7 +109,7 @@ suite.define(() => {
       typing: true,
       ts: Date.now(),
     });
-    await expect(page.locator(".agent-chat__typing-indicator")).toHaveText("Owner is typing…");
+    await expect(page.locator(".agent-chat__typing-text")).toHaveText("Owner is typing…");
     await composer.fill("Try the focused change");
     const typing = await gateway.waitForRequest("session.typing");
     expect(typing.params).toMatchObject({ sessionId: "session-main" });

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -857,6 +857,10 @@ describe("renderChatComposer status", () => {
       expect(indicator?.closest(".agent-chat__composer-footer")).not.toBeNull();
       expect(indicator?.closest(".agent-chat__input")?.firstElementChild).not.toBe(indicator);
       expect(indicator?.querySelectorAll(".chat-author-avatar")).toHaveLength(expectedAvatars);
+      // The status text already names every typer; avatars must stay out of the
+      // accessibility tree or screen readers announce each name twice.
+      const avatars = indicator?.querySelector(".agent-chat__typing-avatars");
+      expect(avatars?.getAttribute("aria-hidden")).toBe("true");
       expect(indicator?.textContent).toContain(expectedText);
     },
   );

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -832,6 +832,35 @@ describe("renderChatComposer controls", () => {
 });
 
 describe("renderChatComposer status", () => {
+  it.each([
+    {
+      actors: [{ id: "ayaan", label: "Ayaan" }],
+      expectedText: "Ayaan is typing…",
+      expectedAvatars: 1,
+    },
+    {
+      actors: [
+        { id: "ayaan", label: "Ayaan" },
+        { id: "liam", label: "Liam" },
+        { id: "maya", label: "Maya" },
+        { id: "zoe", label: "Zoe" },
+      ],
+      expectedText: "Ayaan, Liam, Maya, Zoe are typing…",
+      expectedAvatars: 3,
+    },
+  ])(
+    "keeps $expectedText in the permanent composer footer",
+    ({ actors, expectedText, expectedAvatars }) => {
+      const { container } = renderComposer({ typingActors: actors });
+
+      const indicator = container.querySelector(".agent-chat__typing-indicator");
+      expect(indicator?.closest(".agent-chat__composer-footer")).not.toBeNull();
+      expect(indicator?.closest(".agent-chat__input")?.firstElementChild).not.toBe(indicator);
+      expect(indicator?.querySelectorAll(".chat-author-avatar")).toHaveLength(expectedAvatars);
+      expect(indicator?.textContent).toContain(expectedText);
+    },
+  );
+
   it("swaps the expanded question with the composer and restores its draft and focus", async () => {
     const container = document.createElement("div");
     document.body.append(container);

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -350,7 +350,7 @@ export class ChatPane extends ChatPaneBrowserAnnotationRender {
       gatewayClient: state.client,
       composerHoldToRecord: state.settings.composerHoldToRecord,
       suggestionComposer: suggestionViewer,
-      typingLabel: multiIdentity ? this.typingLabel() : null,
+      typingActors: multiIdentity ? this.typingActorViews() : [],
       onTypingChange: typingEnabled ? (typing) => this.sendTypingState(typing) : undefined,
       canSend: catalogKey
         ? this.catalogSession?.canContinue === true

--- a/ui/src/pages/chat/chat-pane-sharing.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.ts
@@ -663,14 +663,10 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
     this.requestUpdate();
   }
 
-  protected typingLabel(): string | null {
-    const names = [...this.typingActors.values()].map((actor) => actor.label).toSorted();
-    if (names.length === 0) {
-      return null;
-    }
-    return names.length === 1
-      ? t("chat.sessionSuggestions.typing", { name: names[0] ?? "" })
-      : t("chat.sessionSuggestions.typingMany", { names: names.join(", ") });
+  protected typingActorViews(): { id: string; label: string }[] {
+    return [...this.typingActors]
+      .map(([id, actor]) => ({ id, label: actor.label }))
+      .toSorted((left, right) => left.label.localeCompare(right.label));
   }
 
   protected sendTypingState(typing: boolean): void {

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -66,6 +66,7 @@ export type TestChatPane = HTMLElement & {
   handleSessionSuggestionEvent: (event: SessionSuggestionEvent) => void;
   handleSessionTypingEvent: (event: SessionTypingEvent) => void;
   typingActors: Map<string, { label: string; expiresAt: number }>;
+  typingActorViews: () => { id: string; label: string }[];
   refreshSessionSuggestions: () => Promise<void>;
   resolveCurrentSessionSuggestion: (
     suggestion: SessionSuggestion,

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -155,7 +155,7 @@ export type ChatProps = ChatTaskSuggestionTrayProps &
     gatewayClient?: GatewayBrowserClient | null;
     composerHoldToRecord?: boolean;
     suggestionComposer?: boolean;
-    typingLabel?: string | null;
+    typingActors?: readonly { id: string; label: string }[];
     onTypingChange?: (typing: boolean) => void;
     canSend: boolean;
     disabledReason: string | null;
@@ -497,7 +497,7 @@ export function renderChat(props: ChatProps) {
     gatewayClient: props.gatewayClient,
     composerHoldToRecord: props.composerHoldToRecord,
     suggestionComposer: props.suggestionComposer,
-    typingLabel: props.typingLabel,
+    typingActors: props.typingActors,
     onTypingChange: props.onTypingChange,
     composerControls: props.composerControls,
     getDraft: props.getDraft,

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -102,7 +102,7 @@ export type ChatComposerProps = {
   gatewayClient?: GatewayBrowserClient | null;
   composerHoldToRecord?: boolean;
   suggestionComposer?: boolean;
-  typingLabel?: string | null;
+  typingActors?: readonly { id: string; label: string }[];
   onTypingChange?: (typing: boolean) => void;
   composerControls?: TemplateResult | typeof nothing;
   getDraft?: () => string;

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -16,6 +16,7 @@ import {
   renderAttachmentPreview,
   renderChatAttachmentInputs,
 } from "./chat-attachments.ts";
+import { renderChatAuthorAvatar } from "./chat-author-avatar.ts";
 import type { ChatRunControlsProps } from "./chat-composer-controls.ts";
 import { renderChatPrimaryActions } from "./chat-composer-controls.ts";
 import { focusComposerFromChrome } from "./chat-composer-dom.ts";
@@ -172,11 +173,6 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
                         count: String(props.queuedOutboxCount),
                       })
                     : t("chat.composer.offlineHint")}
-                </div>`
-              : nothing}
-            ${props.typingLabel
-              ? html`<div class="agent-chat__typing-indicator" role="status">
-                  ${props.typingLabel}
                 </div>`
               : nothing}
             ${slashMenuVisible ? renderSlashMenu(requestUpdate, props, visibleDraft) : nothing}
@@ -462,6 +458,22 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
                       ${composerControls}
                     </div>
                   `
+                : nothing}
+              ${props.typingActors?.length
+                ? html`<div class="agent-chat__typing-indicator" role="status">
+                    ${props.typingActors
+                      .slice(0, 3)
+                      .map((actor) => renderChatAuthorAvatar({ id: actor.id, name: actor.label }))}
+                    <span class="agent-chat__typing-text"
+                      >${props.typingActors.length === 1
+                        ? t("chat.sessionSuggestions.typing", {
+                            name: props.typingActors[0]?.label ?? "",
+                          })
+                        : t("chat.sessionSuggestions.typingMany", {
+                            names: props.typingActors.map((actor) => actor.label).join(", "),
+                          })}</span
+                    >
+                  </div>`
                 : nothing}
               <div class="agent-chat__composer-meta">${contextNotice}</div>
             </div>

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -461,9 +461,15 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
                 : nothing}
               ${props.typingActors?.length
                 ? html`<div class="agent-chat__typing-indicator" role="status">
-                    ${props.typingActors
-                      .slice(0, 3)
-                      .map((actor) => renderChatAuthorAvatar({ id: actor.id, name: actor.label }))}
+                    <!-- Avatars stay aria-hidden: the status text already names every
+                         typer, and role="img" avatars would announce each name twice. -->
+                    <span class="agent-chat__typing-avatars" aria-hidden="true">
+                      ${props.typingActors
+                        .slice(0, 3)
+                        .map((actor) =>
+                          renderChatAuthorAvatar({ id: actor.id, name: actor.label }),
+                        )}
+                    </span>
                     <span class="agent-chat__typing-text"
                       >${props.typingActors.length === 1
                         ? t("chat.sessionSuggestions.typing", {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1580,6 +1580,13 @@ openclaw-chat-video-player {
   font-style: italic;
 }
 
+.agent-chat__typing-avatars {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+}
+
 .agent-chat__typing-indicator .chat-author-avatar {
   flex-basis: 18px;
   width: 18px;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1571,10 +1571,26 @@ openclaw-chat-video-player {
 }
 
 .agent-chat__typing-indicator {
-  padding: 0 4px 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
   color: var(--muted);
   font-size: 11px;
   font-style: italic;
+}
+
+.agent-chat__typing-indicator .chat-author-avatar {
+  flex-basis: 18px;
+  width: 18px;
+  height: 18px;
+}
+
+.agent-chat__typing-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 @media (max-width: 640px) {
@@ -2338,13 +2354,9 @@ openclaw-chat-video-player {
   display: flex;
   position: relative;
   align-items: center;
-  justify-content: flex-start;
   gap: 6px;
   flex: 1 1 auto;
-  width: auto;
   min-width: 0;
-  margin-left: 0;
-  padding: 0;
 }
 
 .agent-chat__composer-run-status {
@@ -2505,7 +2517,6 @@ openclaw-chat-video-player {
 .agent-chat__composer-footer {
   display: flex;
   align-items: center;
-  justify-content: flex-start;
   flex-shrink: 0;
   box-sizing: border-box;
   gap: 8px;
@@ -2520,11 +2531,7 @@ openclaw-chat-video-player {
   display: flex;
   align-items: center;
   gap: 4px;
-}
-
-.agent-chat__composer-meta {
   flex: 0 0 auto;
-  min-width: 0;
 }
 
 .agent-chat__composer-actions {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Control UI chat composer jumped under the user's cursor whenever a collaborator started or stopped typing. The typing indicator was the first row inside `.agent-chat__input`, so toggling it changed the composer's height and shifted the textarea.

## Why This Change Was Made

The indicator now renders inside the permanent 44px-min-height composer footer, so typing visibility changes do not change composer height. The pane passes sorted structured actors instead of a pre-joined label, allowing the composer to reuse the existing author-avatar renderer for up to three avatars before the unchanged localized label; the indicator is a truncating single line. Redundant default declarations and a duplicate composer-meta rule were removed without changing behavior.

## User Impact

Collaborative typing activity remains visible without moving the message field while someone is entering text. Users also see collaborator avatars, with the existing image/initials fallback, next to the typing label.

## Evidence

Before: the typing row sits above the input and increases the composer height.

![Typing indicator before](https://github.com/user-attachments/assets/d7c7ee8a-0b9b-4526-b55a-286e336b0bf0)

After: the avatar and typing label stay inside the fixed footer.

![Typing indicator after](https://github.com/user-attachments/assets/1eb4df91-0d8a-42aa-895c-6ff95e0230ae)

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-composer.test.ts`: 36/36 passed on the rebased head (28/28 on the original head). The two new footer-placement cases fail on the parent code and pass with this change.
- Mocked-Gateway Playwright E2E: the focused `session-suggestions` viewer/typing flow passed on both the parent and current code while producing the screenshots above. The existing assertion was mechanically retargeted to `.agent-chat__typing-text` because the indicator now intentionally also contains avatar fallback text.
- Codex autoreview was clean on the pre-rebase production and focused-unit-test diff. The conflict-required rebase preserved current `main`'s `ChatProps` structure and mechanically replayed only the `typingLabel` to `typingActors` rename; the follow-up commit only updates the E2E locator.
- Targeted `oxfmt --check` passed for every changed file; `git diff --check` passed.
- Production LOC: +42/-27 (net +15). The positive delta is the new avatar capability and structured-actor plumbing; moving the indicator itself is approximately net-neutral. Tests/test support: +31/-1 (net +30).
- Sibling-surface check: `rg -n "typingLabel" ui/src` has zero remaining references; the composer was its only consumer.
- AI-assisted; the author reviewed and understands the change.
- ClawSweeper P2 addressed: the avatar group is now `aria-hidden`, leaving the localized status text as the sole screen-reader announcement; the rebased focused test passes 36/36 and asserts the accessibility boundary.
- ClawSweeper P1 skipped: removing the avatar expansion would remove an explicitly requested capability of this PR, so the avatars remain while their accessibility behavior is corrected.
- Plugin SDK baseline: #121200 (`b81946d6af9`) changed the gateway-backed SDK surface without regenerating the manifest and made `check-plugin-sdk-api-baseline` red on `main`. Per the red-main landing rule, the exact generator was run after rebasing; current `origin/main` already contained subsequent mechanical manifest refreshes, so it produced zero tracked export-record changes, and the exact `--check` command prints `OK`.
