### PR TITLE
fix(ai): preserve explicit null Responses reasoning summaries

### DIFF
--- a/packages/ai/src/providers/openai-chatgpt-responses.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.test.ts
@@ -404,6 +404,30 @@ describe("streamOpenAICodexResponses transport", () => {
     });
   });
 
+  it("preserves an explicit null reasoning summary on Codex Responses payloads", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const stream = streamOpenAICodexResponses(model, context, {
+      apiKey: createJwt({
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "acct-1",
+        },
+      }),
+      reasoningEffort: "medium",
+      reasoningSummary: null,
+      transport: "sse",
+      onPayload: (payload) => {
+        capturedPayload = payload as Record<string, unknown>;
+        throw new Error("stop after payload");
+      },
+    });
+
+    await stream.result();
+
+    expect(capturedPayload).toMatchObject({
+      reasoning: { effort: "medium", summary: null },
+    });
+  });
+
   it("does not fall back to SSE when websocket transport is explicit", async () => {
     const fetchMock = vi.fn(async () => {
       throw new Error("fetch should not run");

--- a/packages/ai/src/providers/openai-chatgpt-responses.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.test.ts
@@ -428,6 +428,29 @@ describe("streamOpenAICodexResponses transport", () => {
     });
   });
 
+  it("includes an explicit null reasoning summary without an effort", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const stream = streamOpenAICodexResponses(model, context, {
+      apiKey: createJwt({
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "acct-1",
+        },
+      }),
+      reasoningSummary: null,
+      transport: "sse",
+      onPayload: (payload) => {
+        capturedPayload = payload as Record<string, unknown>;
+        throw new Error("stop after payload");
+      },
+    });
+
+    await stream.result();
+
+    expect(capturedPayload).toMatchObject({
+      reasoning: { effort: "medium", summary: null },
+    });
+  });
+
   it("does not fall back to SSE when websocket transport is explicit", async () => {
     const fetchMock = vi.fn(async () => {
       throw new Error("fetch should not run");

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -747,7 +747,7 @@ function buildRequestBody(
     }
   }
 
-  if (options?.reasoningEffort !== undefined) {
+  if (options?.reasoningEffort !== undefined || options?.reasoningSummary !== undefined) {
     const effort =
       options.reasoningEffort === "none"
         ? (model.thinkingLevelMap?.off ?? "none")

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -152,7 +152,7 @@ interface RequestBody {
   tool_choice?: "auto";
   parallel_tool_calls?: boolean;
   temperature?: number;
-  reasoning?: { effort?: string; summary?: string };
+  reasoning?: { effort?: string; summary?: string | null };
   service_tier?: ResponseCreateParamsStreaming["service_tier"];
   text?: { verbosity?: string };
   include?: string[];

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -748,10 +748,11 @@ function buildRequestBody(
   }
 
   if (options?.reasoningEffort !== undefined || options?.reasoningSummary !== undefined) {
+    const requestedEffort = options.reasoningEffort ?? "medium";
     const effort =
-      options.reasoningEffort === "none"
+      requestedEffort === "none"
         ? (model.thinkingLevelMap?.off ?? "none")
-        : (model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort);
+        : (model.thinkingLevelMap?.[requestedEffort] ?? requestedEffort);
     if (effort !== null) {
       body.reasoning = {
         effort,

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -755,7 +755,8 @@ function buildRequestBody(
     if (effort !== null) {
       body.reasoning = {
         effort,
-        summary: options.reasoningSummary ?? "auto",
+        // Preserve explicit null; only default when the field was omitted.
+        summary: options.reasoningSummary === undefined ? "auto" : options.reasoningSummary,
       };
     }
   }

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -361,6 +361,19 @@ describe("Responses reasoning effort", () => {
     expect(params).toMatchObject({ reasoning: { effort: "medium", summary: null } });
   });
 
+  it("preserves null reasoning summary without explicit effort (defaults effort to medium)", () => {
+    const params = {} as never;
+    applyCommonResponsesParams(
+      params,
+      nativeOpenAIModel,
+      { messages: [] },
+      {
+        reasoningSummary: null,
+      },
+    );
+    expect(params).toMatchObject({ reasoning: { effort: "medium", summary: null } });
+  });
+
   it("defaults an omitted reasoning summary to auto", () => {
     const params = {} as never;
     applyCommonResponsesParams(

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -347,6 +347,33 @@ describe("Responses reasoning effort", () => {
     expect(params).toMatchObject({ reasoning: { effort: "max", summary: "auto" } });
   });
 
+  it("preserves an explicit null reasoning summary instead of coercing to auto", () => {
+    const params = {} as never;
+    applyCommonResponsesParams(
+      params,
+      nativeOpenAIModel,
+      { messages: [] },
+      {
+        reasoningEffort: "medium",
+        reasoningSummary: null,
+      },
+    );
+    expect(params).toMatchObject({ reasoning: { effort: "medium", summary: null } });
+  });
+
+  it("defaults an omitted reasoning summary to auto", () => {
+    const params = {} as never;
+    applyCommonResponsesParams(
+      params,
+      nativeOpenAIModel,
+      { messages: [] },
+      {
+        reasoningEffort: "medium",
+      },
+    );
+    expect(params).toMatchObject({ reasoning: { effort: "medium", summary: "auto" } });
+  });
+
   it("raises unsupported minimal reasoning to low for GPT-5.6 Sol", () => {
     expect(resolveResponsesReasoningEffort(gpt56SolModel, "minimal")).toBe("low");
   });

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -212,7 +212,7 @@ export function applyCommonResponsesParams<TApi extends Api>(
     return;
   }
 
-  if (options?.reasoningEffort || options?.reasoningSummary) {
+  if (options?.reasoningEffort !== undefined || options?.reasoningSummary !== undefined) {
     const effort = options?.reasoningEffort
       ? (model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort)
       : "medium";

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -218,7 +218,9 @@ export function applyCommonResponsesParams<TApi extends Api>(
       : "medium";
     params.reasoning = {
       effort: effort as NonNullable<typeof params.reasoning>["effort"],
-      summary: options?.reasoningSummary || "auto",
+      // OpenAI allows summary:null. Default only when the caller omitted the field —
+      // both `||` and `??` would incorrectly coerce null → "auto".
+      summary: options?.reasoningSummary === undefined ? "auto" : options.reasoningSummary,
     };
     params.include = ["reasoning.encrypted_content"];
   } else if ((config?.setDefaultReasoningOff ?? true) && model.thinkingLevelMap?.off !== null) {

--- a/packages/ai/src/transports/openai-responses-contracts.ts
+++ b/packages/ai/src/transports/openai-responses-contracts.ts
@@ -206,7 +206,7 @@ export type OpenAIResponsesRequestParams = {
     | { effort: OpenAIApiReasoningEffort }
     | {
         effort: OpenAIApiReasoningEffort;
-        summary: NonNullable<OpenAIResponsesOptions["reasoningSummary"]>;
+        summary: Exclude<OpenAIResponsesOptions["reasoningSummary"], undefined>;
       };
   include?: string[];
 };

--- a/packages/ai/src/transports/openai-responses-params-internal.test.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.test.ts
@@ -78,8 +78,8 @@ describe("buildOpenAIResponsesParams reasoning summary", () => {
       reasoningSummary: null,
     });
 
-    expect(params.reasoning).toMatchObject({ summary: null });
-    expect(params.reasoning?.effort).toBeDefined();
+    // gpt-5.5 omitted-effort default is high (native Codex defaults medium).
+    expect(params.reasoning).toMatchObject({ effort: "high", summary: null });
   });
 
   it("defaults omitted reasoning summary to auto", () => {

--- a/packages/ai/src/transports/openai-responses-params-internal.test.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.test.ts
@@ -1,6 +1,9 @@
-import type { Model } from "@openclaw/llm-core";
+import type { Context, Model } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
-import { buildOpenAIResponsesCompactSystemMessage } from "./openai-responses-params-internal.js";
+import {
+  buildOpenAIResponsesCompactSystemMessage,
+  buildOpenAIResponsesParams,
+} from "./openai-responses-params-internal.js";
 
 const reasoningModel = {
   id: "gpt-5.6-luna",
@@ -14,6 +17,23 @@ const reasoningModel = {
   contextWindow: 256_000,
   maxTokens: 8_192,
 } satisfies Model<"openai-responses">;
+
+const summaryModel = {
+  id: "gpt-5.5",
+  name: "GPT-5.5",
+  api: "openai-responses",
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200_000,
+  maxTokens: 8192,
+} satisfies Model<"openai-responses">;
+
+const context = {
+  messages: [{ role: "user", content: "hello", timestamp: 0 }],
+} satisfies Context;
 
 describe("buildOpenAIResponsesCompactSystemMessage", () => {
   it("uses the developer role for reasoning models that support it", () => {
@@ -40,5 +60,33 @@ describe("buildOpenAIResponsesCompactSystemMessage", () => {
       "Retain the conversation.",
     );
     expect(message.role).toBe("system");
+  });
+});
+
+describe("buildOpenAIResponsesParams reasoning summary", () => {
+  it("preserves null reasoning summary with explicit effort", () => {
+    const params = buildOpenAIResponsesParams(summaryModel, context, {
+      reasoningEffort: "medium",
+      reasoningSummary: null,
+    });
+
+    expect(params.reasoning).toMatchObject({ effort: "medium", summary: null });
+  });
+
+  it("preserves null reasoning summary without explicit effort", () => {
+    const params = buildOpenAIResponsesParams(summaryModel, context, {
+      reasoningSummary: null,
+    });
+
+    expect(params.reasoning).toMatchObject({ summary: null });
+    expect(params.reasoning?.effort).toBeDefined();
+  });
+
+  it("defaults omitted reasoning summary to auto", () => {
+    const params = buildOpenAIResponsesParams(summaryModel, context, {
+      reasoningEffort: "medium",
+    });
+
+    expect(params.reasoning).toMatchObject({ effort: "medium", summary: "auto" });
   });
 });

--- a/packages/ai/src/transports/openai-responses-params-internal.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.ts
@@ -383,7 +383,12 @@ export function buildOpenAIResponsesParams(
       if (reasoningEffort) {
         params.reasoning = {
           effort: reasoningEffort,
-          ...(reasoningEffort === "none" ? {} : { summary: options?.reasoningSummary || "auto" }),
+          ...(reasoningEffort === "none"
+            ? {}
+            : {
+                summary:
+                  options?.reasoningSummary === undefined ? "auto" : options.reasoningSummary,
+              }),
         };
         if (reasoningEffort !== "none") {
           params.include = ["reasoning.encrypted_content"];

--- a/packages/ai/src/transports/openai-responses-params-internal.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.ts
@@ -367,7 +367,11 @@ export function buildOpenAIResponsesParams(
     }
   }
   if (model.reasoning) {
-    if (options?.reasoningEffort || options?.reasoning || options?.reasoningSummary) {
+    if (
+      options?.reasoningEffort !== undefined ||
+      options?.reasoning !== undefined ||
+      options?.reasoningSummary !== undefined
+    ) {
       const requestedReasoningEffort = resolveOpenAIReasoningEffort(options);
       const resolvedReasoningEffort = resolveOpenAIReasoningEffortForModel({
         model,


### PR DESCRIPTION
## Proof follow-up

**Tip SHA:** `c6acabd113623d601863ffe6f3b5b6a877bc8601`

### DIRTY rebase

Rebased onto current `main` `16eb38cf9725b073bec2cf89842c28d59509231d` from starting SHA `a947649ada7a98e10f5fddadcd8d51607cba9b02`. Published with `--force-with-lease`.

- **Conflict file:** `packages/ai/src/transports/openai-responses-params-internal.test.ts` (add/add). Kept upstream `buildOpenAIResponsesCompactSystemMessage` coverage and this PR's `reasoning.summary: null` matrix. Imports now use `@openclaw/llm-core`.
- **Production files:** auto-merged. Native ChatGPT builder still distinguishes omitted vs explicit-null summaries and defaults summary-only effort to `medium`. Shared and generic builders keep the same undefined-vs-null contract.

### ClawSweeper findings — this revision

- [x] **[P2] Assert the resolved generic transport effort** — `packages/ai/src/transports/openai-responses-params-internal.test.ts` asserts `{ effort: "high", summary: null }` for the gpt-5.5 summary-only fixture (omitted-effort default is `high`, not `medium`).
- [ ] **[P1] Verify native endpoint acceptance for null summaries** — still blocked: this environment has no OpenAI / ChatGPT-authenticated credentials. Local native tests still capture the request body via `onPayload` and stop before dispatch. Public SDK types allow `summary: null`; that is not `/codex/responses` acceptance proof.

### Before-merge checklist

- [x] Focused Vitest on the three owner test files after rebase (3 files, 142 tests)
- [x] Generic-transport proof text corrected from `medium` to `high`
- [x] oxfmt, oxlint (touched files), `tsgo:core`, and packages test-types
- [ ] Live OpenAI / ChatGPT-authenticated endpoint proof — **not available** (no credentials)

### Focused test transcript (exact head)

```text
[test] starting test/vitest/vitest.unit.config.ts
 ✓ |unit| packages/ai/src/transports/openai-responses-params-internal.test.ts > buildOpenAIResponsesCompactSystemMessage > uses the developer role for reasoning models that support it
 ✓ |unit| packages/ai/src/transports/openai-responses-params-internal.test.ts > buildOpenAIResponsesCompactSystemMessage > falls back to the system role for xAI's native route, which disables the developer role
 ✓ |unit| packages/ai/src/transports/openai-responses-params-internal.test.ts > buildOpenAIResponsesCompactSystemMessage > uses the system role for non-reasoning models
 ✓ |unit| packages/ai/src/transports/openai-responses-params-internal.test.ts > buildOpenAIResponsesParams reasoning summary > preserves null reasoning summary with explicit effort
 ✓ |unit| packages/ai/src/transports/openai-responses-params-internal.test.ts > buildOpenAIResponsesParams reasoning summary > preserves null reasoning summary without explicit effort
 ✓ |unit| packages/ai/src/transports/openai-responses-params-internal.test.ts > buildOpenAIResponsesParams reasoning summary > defaults omitted reasoning summary to auto
 Test Files  3 passed (3)
      Tests  142 passed (142)
[test] passed 1 Vitest shard in 17.25s
```

Command: `node scripts/run-vitest.mjs packages/ai/src/transports/openai-responses-params-internal.test.ts packages/ai/src/providers/openai-responses-shared.test.ts packages/ai/src/providers/openai-chatgpt-responses.test.ts --reporter=verbose`

### Wire payload proof (exact-head, redacted)

Path-local omitted-effort defaults remain intentionally different:

```text
=== exact-head builder proof: reasoning.summary:null without explicit effort ===
HEAD_SHA=c6acabd113623d601863ffe6f3b5b6a877bc8601
transport.buildOpenAIResponsesParams (gpt-5.5 fixture) => {"effort":"high","summary":null}
shared.applyCommonResponsesParams / native ChatGPT builder => {"effort":"medium","summary":null}
LIMIT: no live OpenAI or /codex/responses proof; payload construction is covered locally.
```

---

Closes #121443

## What Problem This Solves

OpenAI Responses payload builders coerced `reasoning.summary: null` to `"auto"`. The OpenAI SDK allows `summary?: 'auto' | 'concise' | 'detailed' | null`, so callers that pass `reasoningSummary: null` to disable summaries silently still requested auto summaries.

### Before (broken)

```ts
{ reasoningEffort: "medium", reasoningSummary: null }
```

became:

```ts
{ reasoning: { effort: "medium", summary: "auto" } }
```

because defaults used `|| "auto"` / `?? "auto"`, both of which treat `null` as missing.

Affected builders:

- `applyCommonResponsesParams` (`openai-responses-shared.ts`)
- Responses params-internal transport builder
- Codex Responses payload assembly (`openai-chatgpt-responses.ts`)

## Why This Change Was Made

Default `"auto"` only when the field is **omitted** (`undefined`):

```ts
summary: options?.reasoningSummary === undefined ? "auto" : options.reasoningSummary
```

Adjacent matrix:

- explicit `null` → `summary: null`
- omitted → `summary: "auto"`
- Codex Responses `onPayload` path preserves `null`

## User Impact

Clients that disable reasoning summaries via `null` now send `summary: null` on the wire instead of accidentally requesting auto summaries (token waste / unwanted reasoning exposure). Omitted summary still defaults to `"auto"`.

## Evidence

### Before vs after (payload projection)

| Case | Before tip | After tip `c6acabd113623d601863ffe6f3b5b6a877bc8601` |
| --- | --- | --- |
| `{ reasoningEffort: "medium", reasoningSummary: null }` | `summary: "auto"` | `summary: null` |
| `{ reasoningEffort: "medium" }` (omitted summary) | `summary: "auto"` | `summary: "auto"` (unchanged) |
| Generic transport `{ reasoningSummary: null }` (gpt-5.5, omitted effort) | coerced to `auto` | `effort: "high"`, `summary: null` |
| Shared / native `{ reasoningSummary: null }` (omitted effort) | coerced to `auto` | `effort: "medium"`, `summary: null` |
| Codex Responses `reasoningSummary: null` | coerced to `"auto"` | `summary: null` on captured payload |

### Focused regression tests (exact tip)

```text
tip=c6acabd113623d601863ffe6f3b5b6a877bc8601
command=node scripts/run-vitest.mjs \
  packages/ai/src/transports/openai-responses-params-internal.test.ts \
  packages/ai/src/providers/openai-responses-shared.test.ts \
  packages/ai/src/providers/openai-chatgpt-responses.test.ts \
  --reporter=verbose
result=3 files passed; 142 tests passed
```

### What was not tested

Live OpenAI and ChatGPT-authenticated `/codex/responses` calls with `summary: null` against production endpoints (payload construction covered in unit tests). Native tests still throw from `onPayload` before dispatch.
