### PR TITLE
fix(ui): commentary survives refresh after steering

### DIFF
--- a/src/gateway/server-chat-progress-snapshot.ts
+++ b/src/gateway/server-chat-progress-snapshot.ts
@@ -38,6 +38,11 @@ export function updateChatRunProgressSnapshot(
     return next;
   }
   next.lastSeq = event.seq;
+  const matchesPreamble = (candidate: AgentEventPayload) =>
+    candidate.stream === "item" &&
+    candidate.data?.kind === "preamble" &&
+    (candidate.data.itemId ?? "") === preambleItemId;
+  const previousPreamble = preambleItemId ? next.events.find(matchesPreamble) : undefined;
 
   const removeWhere = (predicate: (candidate: AgentEventPayload) => boolean) => {
     next.events = next.events.filter((candidate) => {
@@ -61,18 +66,10 @@ export function updateChatRunProgressSnapshot(
     }
   } else {
     const progressText = typeof data.progressText === "string" ? data.progressText.trim() : "";
+    removeWhere(matchesPreamble);
     if (!progressText) {
-      if (preambleItemId) {
-        removeWhere((candidate) => {
-          if (candidate.stream !== "item" || candidate.data?.kind !== "preamble") {
-            return false;
-          }
-          return candidate.data.itemId === preambleItemId;
-        });
-      }
       return next;
     }
-    removeWhere((candidate) => candidate.stream === "item" && candidate.data?.kind === "preamble");
   }
 
   const storedData: Record<string, unknown> = isTool
@@ -94,7 +91,8 @@ export function updateChatRunProgressSnapshot(
     runId: event.runId,
     seq: event.seq,
     stream: event.stream,
-    ts: event.ts,
+    // Keep first-seen time so reload cannot move updated commentary across a later steer.
+    ts: previousPreamble?.ts ?? event.ts,
     data: storedData,
     ...(event.sessionKey ? { sessionKey: event.sessionKey } : {}),
     ...(event.agentId ? { agentId: event.agentId } : {}),

--- a/src/gateway/server-chat-state.test.ts
+++ b/src/gateway/server-chat-state.test.ts
@@ -84,15 +84,31 @@ describe("createChatRunState", () => {
       toolCallId: "done",
       result: "x".repeat(256_000),
     });
+    event(6, "item", {
+      kind: "preamble",
+      itemId: "p-1",
+      progressText: "Inspection complete",
+    });
+    event(7, "item", {
+      kind: "preamble",
+      itemId: "p-2",
+      progressText: "Running autoreview",
+    });
     event(3, "tool", { phase: "result", name: "read", toolCallId: "active" });
 
     expect(state.runs.get("run-1")?.progressSnapshot?.events).toMatchObject([
-      { seq: 1, stream: "item", data: { itemId: "p-1", progressText: "Inspecting" } },
       { seq: 2, stream: "tool", data: { phase: "start", toolCallId: "active" } },
       { seq: 3, stream: "tool", data: { phase: "update", toolCallId: "active" } },
+      {
+        seq: 6,
+        stream: "item",
+        ts: 1_001,
+        data: { itemId: "p-1", progressText: "Inspection complete" },
+      },
+      { seq: 7, stream: "item", data: { itemId: "p-2", progressText: "Running autoreview" } },
     ]);
 
-    for (let seq = 6; seq <= 70; seq += 1) {
+    for (let seq = 8; seq <= 70; seq += 1) {
       event(seq, "tool", {
         phase: "start",
         name: "read",

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -641,7 +641,7 @@ describe("gateway server chat", () => {
         createSessionEventSubscriberRegistry,
         createSessionMessageSubscriberRegistry,
       } = await import("./server-chat.js");
-      const { storePath } = openDirectChatSession();
+      openDirectChatSession();
       const context = createDirectChatContext();
       const handler = createAgentEventHandler({
         broadcast: context.broadcast,
@@ -671,37 +671,12 @@ describe("gateway server chat", () => {
           clientRunId: "run-active",
         });
 
-        const transcriptScope = {
-          agentId: "main",
-          sessionId: "sess-main",
-          sessionKey: "main",
-          storePath,
-        };
-        const initialMessageId = "message-initial";
-        await appendTranscriptMessage(transcriptScope, {
-          eventId: initialMessageId,
-          message: {
-            role: "user",
-            content: [{ type: "text", text: "Start the requested work." }],
-            timestamp: 1_000,
-          },
-        });
-
         handler({
           runId: "provider-run",
           seq: 1,
           stream: "item",
           ts: 1_001,
           data: { kind: "preamble", itemId: "preamble-1", progressText: "Checking files" },
-        });
-        await appendTranscriptMessage(transcriptScope, {
-          eventId: "message-steer",
-          parentId: initialMessageId,
-          message: {
-            role: "user",
-            content: [{ type: "text", text: "Please run autoreview here." }],
-            timestamp: 1_001.5,
-          },
         });
         handler({
           runId: "provider-run",
@@ -772,13 +747,6 @@ describe("gateway server chat", () => {
 
         expect(responses).toHaveLength(1);
         expect(responses[0]?.ok).toBe(true);
-        expect(
-          (responses[0]?.payload as { messages?: Array<{ content?: unknown }> } | undefined)
-            ?.messages,
-        ).toMatchObject([
-          { role: "user", content: [{ type: "text", text: "Start the requested work." }] },
-          { role: "user", content: [{ type: "text", text: "Please run autoreview here." }] },
-        ]);
         expect(
           (responses[0]?.payload as { inFlightRun?: unknown } | undefined)?.inFlightRun,
         ).toEqual({

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -641,7 +641,7 @@ describe("gateway server chat", () => {
         createSessionEventSubscriberRegistry,
         createSessionMessageSubscriberRegistry,
       } = await import("./server-chat.js");
-      openDirectChatSession();
+      const { storePath } = openDirectChatSession();
       const context = createDirectChatContext();
       const handler = createAgentEventHandler({
         broadcast: context.broadcast,
@@ -671,12 +671,37 @@ describe("gateway server chat", () => {
           clientRunId: "run-active",
         });
 
+        const transcriptScope = {
+          agentId: "main",
+          sessionId: "sess-main",
+          sessionKey: "main",
+          storePath,
+        };
+        const initialMessageId = "message-initial";
+        await appendTranscriptMessage(transcriptScope, {
+          eventId: initialMessageId,
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "Start the requested work." }],
+            timestamp: 1_000,
+          },
+        });
+
         handler({
           runId: "provider-run",
           seq: 1,
           stream: "item",
           ts: 1_001,
           data: { kind: "preamble", itemId: "preamble-1", progressText: "Checking files" },
+        });
+        await appendTranscriptMessage(transcriptScope, {
+          eventId: "message-steer",
+          parentId: initialMessageId,
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "Please run autoreview here." }],
+            timestamp: 1_001.5,
+          },
         });
         handler({
           runId: "provider-run",
@@ -725,6 +750,17 @@ describe("gateway server chat", () => {
           ts: 1_006,
           data: { phase: "result", name: "read", toolCallId: "tool-active", result: "stale" },
         });
+        handler({
+          runId: "provider-run",
+          seq: 6,
+          stream: "item",
+          ts: 1_006,
+          data: {
+            kind: "preamble",
+            itemId: "preamble-2",
+            progressText: "Autoreview is running",
+          },
+        });
 
         const responses: Array<{ ok: boolean; payload?: unknown }> = [];
         await callDirectChat(method, {
@@ -736,6 +772,13 @@ describe("gateway server chat", () => {
 
         expect(responses).toHaveLength(1);
         expect(responses[0]?.ok).toBe(true);
+        expect(
+          (responses[0]?.payload as { messages?: Array<{ content?: unknown }> } | undefined)
+            ?.messages,
+        ).toMatchObject([
+          { role: "user", content: [{ type: "text", text: "Start the requested work." }] },
+          { role: "user", content: [{ type: "text", text: "Please run autoreview here." }] },
+        ]);
         expect(
           (responses[0]?.payload as { inFlightRun?: unknown } | undefined)?.inFlightRun,
         ).toEqual({
@@ -779,6 +822,18 @@ describe("gateway server chat", () => {
                 name: "read",
                 toolCallId: "tool-active",
                 partialResult: "halfway",
+              },
+            },
+            {
+              runId: "run-active",
+              seq: 6,
+              stream: "item",
+              ts: 1_006,
+              sessionKey: "main",
+              data: {
+                kind: "preamble",
+                itemId: "preamble-2",
+                progressText: "Autoreview is running",
               },
             },
           ],

--- a/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
@@ -18,6 +18,12 @@ const suite = createControlUiE2eSuite({
 
 const proofDir = path.resolve(".artifacts/control-ui-e2e/active-turn-recovery");
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+type ActiveRunSnapshotOptions = {
+  events?: unknown[];
+  messages?: unknown[];
+  persistedToolCall?: boolean;
+  startedAt?: number;
+};
 
 async function capture(page: Page, name: string): Promise<void> {
   if (!captureProof) {
@@ -31,14 +37,14 @@ function activeRunSnapshot(
   runId: string,
   prompt: string,
   streamText: string,
-  opts?: { persistedToolCall?: boolean; startedAt?: number },
+  opts?: ActiveRunSnapshotOptions,
 ) {
   return {
     inFlightRun: {
       runId,
       text: streamText,
       startedAt: opts?.startedAt,
-      events: [
+      events: opts?.events ?? [
         {
           runId,
           seq: 1,
@@ -54,7 +60,7 @@ function activeRunSnapshot(
         },
       ],
     },
-    messages: [
+    messages: opts?.messages ?? [
       {
         __openclaw: { idempotencyKey: `${runId}:user` },
         content: [{ text: prompt, type: "text" }],
@@ -137,7 +143,7 @@ async function installActiveRunSnapshot(
   runId: string,
   prompt: string,
   streamText: string,
-  opts?: { persistedToolCall?: boolean; startedAt?: number },
+  opts?: ActiveRunSnapshotOptions,
 ): Promise<void> {
   const snapshot = activeRunSnapshot(runId, prompt, streamText, opts);
   await gateway.setMethodResponse("chat.startup", snapshot);
@@ -219,17 +225,59 @@ async function finishRecoveredTurn(
   expect(await visibleFinal.count()).toBe(1);
 }
 
-async function openActiveTurn() {
+async function openActiveTurn(scenario: Parameters<typeof installMockGateway>[1] = {}) {
   const context = await suite.newBrowserContext({
     locale: "en-US",
     serviceWorkers: "block",
     viewport: { height: 900, width: 1280 },
   });
   const page = await context.newPage();
-  const gateway = await installMockGateway(page);
+  const gateway = await installMockGateway(page, scenario);
   await page.goto(`${suite.server.baseUrl}chat`);
   await page.locator(".agent-chat__composer-combobox textarea").waitFor({ timeout: 10_000 });
   return { context, page, gateway };
+}
+
+async function assertSteeredRecoveryOrder(
+  page: Page,
+  texts: { original: string; beforeSteer: string; steer: string; afterSteer: string },
+): Promise<void> {
+  const thread = page.locator(".chat-thread");
+  for (const text of Object.values(texts)) {
+    await thread.getByText(text, { exact: true }).waitFor({ timeout: 10_000 });
+    await expect.poll(() => thread.getByText(text, { exact: true }).count()).toBe(1);
+  }
+  const activeTool = thread.locator(".chat-tool-row--running");
+  await activeTool.waitFor({ timeout: 10_000 });
+  await page.getByRole("button", { name: "Stop generating" }).waitFor({ timeout: 10_000 });
+  await page.locator(".chat-working-indicator").waitFor({ timeout: 10_000 });
+
+  const order = await thread.evaluate((element, expected) => {
+    const groups = Array.from(element.querySelectorAll<HTMLElement>(".chat-group"));
+    const groupWithText = (text: string) =>
+      groups.find((group) => (group.textContent ?? "").includes(text));
+    const original = groupWithText(expected.original);
+    const beforeSteer = groupWithText(expected.beforeSteer);
+    const steer = groupWithText(expected.steer);
+    const tool = element.querySelector<HTMLElement>(".chat-tool-row--running");
+    const afterSteer = groupWithText(expected.afterSteer);
+    const precedes = (upper: Element | undefined | null, lower: Element | undefined | null) =>
+      Boolean(
+        upper && lower && upper.compareDocumentPosition(lower) & Node.DOCUMENT_POSITION_FOLLOWING,
+      );
+    return {
+      originalBeforeCommentary: precedes(original, beforeSteer),
+      commentaryBeforeSteer: precedes(beforeSteer, steer),
+      steerBeforeTool: precedes(steer, tool),
+      toolBeforeLaterCommentary: precedes(tool, afterSteer),
+    };
+  }, texts);
+  expect(order).toEqual({
+    originalBeforeCommentary: true,
+    commentaryBeforeSteer: true,
+    steerBeforeTool: true,
+    toolBeforeLaterCommentary: true,
+  });
 }
 
 suite.define(() => {
@@ -313,6 +361,96 @@ suite.define(() => {
       ).not.toHaveCount(0);
       await capture(page, "06-reload-after");
       await finishRecoveredTurn(page, gateway, runId, "Reload delivery complete.");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("preserves pre-steer commentary order through a full reload", async () => {
+    const runId = "run-steer-refresh";
+    const texts = {
+      original: "Review the fixture.",
+      beforeSteer: "The first recovery note is visible.",
+      steer: "Please include the verification pass.",
+      afterSteer: "The second recovery note is visible.",
+    };
+    const fixtureNow = Date.now();
+    const snapshot = activeRunSnapshot(runId, texts.original, "", {
+      startedAt: fixtureNow,
+      messages: [
+        {
+          __openclaw: {
+            id: "fixture-original-user",
+            idempotencyKey: `${runId}:user`,
+            seq: 1,
+          },
+          content: [{ text: texts.original, type: "text" }],
+          role: "user",
+          timestamp: fixtureNow,
+        },
+        {
+          __openclaw: {
+            id: "fixture-steering-user",
+            idempotencyKey: "fixture-steer:user",
+            seq: 2,
+          },
+          content: [{ text: texts.steer, type: "text" }],
+          role: "user",
+          timestamp: fixtureNow + 2_000,
+        },
+      ],
+      events: [
+        {
+          runId,
+          seq: 1,
+          stream: "item",
+          ts: fixtureNow + 1_000,
+          sessionKey: "main",
+          data: {
+            kind: "preamble",
+            itemId: "fixture-preamble-before-steer",
+            progressText: texts.beforeSteer,
+          },
+        },
+        {
+          runId,
+          seq: 2,
+          stream: "tool",
+          ts: fixtureNow + 3_000,
+          sessionKey: "main",
+          data: {
+            toolCallId: "fixture-active-tool",
+            name: "read",
+            phase: "start",
+            args: { path: "fixture.txt" },
+          },
+        },
+        {
+          runId,
+          seq: 3,
+          stream: "item",
+          ts: fixtureNow + 4_000,
+          sessionKey: "main",
+          data: {
+            kind: "preamble",
+            itemId: "fixture-preamble-after-steer",
+            progressText: texts.afterSteer,
+          },
+        },
+      ],
+    });
+    const { context, page } = await openActiveTurn({
+      historyMessages: snapshot.messages,
+      inFlightRun: snapshot.inFlightRun,
+      sessionInfo: snapshot.sessionInfo,
+    });
+    try {
+      await assertSteeredRecoveryOrder(page, texts);
+      await capture(page, "07-steer-refresh-before");
+
+      await page.reload();
+      await assertSteeredRecoveryOrder(page, texts);
+      await capture(page, "08-steer-refresh-after");
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
@@ -158,7 +158,7 @@ async function installActiveRunSnapshot(
 }
 
 async function assertActiveTurnVisible(page: Page, streamText: string): Promise<void> {
-  await page.getByText(streamText, { exact: true }).waitFor({ timeout: 10_000 });
+  await expect(page.getByText(streamText, { exact: true })).toHaveCount(1, { timeout: 10_000 });
   await page.locator(".chat-tool-row--running").waitFor({ timeout: 10_000 });
   await page.getByRole("button", { name: "Stop generating" }).waitFor({ timeout: 10_000 });
   await expect
@@ -243,14 +243,11 @@ async function assertSteeredRecoveryOrder(
   texts: { original: string; beforeSteer: string; steer: string; afterSteer: string },
 ): Promise<void> {
   const thread = page.locator(".chat-thread");
-  for (const text of Object.values(texts)) {
-    await thread.getByText(text, { exact: true }).waitFor({ timeout: 10_000 });
-    await expect.poll(() => thread.getByText(text, { exact: true }).count()).toBe(1);
+  await assertActiveTurnVisible(page, texts.afterSteer);
+  for (const text of [texts.original, texts.beforeSteer, texts.steer]) {
+    await expect(thread.getByText(text, { exact: true })).toHaveCount(1, { timeout: 10_000 });
   }
-  const activeTool = thread.locator(".chat-tool-row--running");
-  await activeTool.waitFor({ timeout: 10_000 });
-  await page.getByRole("button", { name: "Stop generating" }).waitFor({ timeout: 10_000 });
-  await page.locator(".chat-working-indicator").waitFor({ timeout: 10_000 });
+  await expect(page.locator(".chat-working-indicator")).toHaveCount(1, { timeout: 10_000 });
 
   const order = await thread.evaluate((element, expected) => {
     const groups = Array.from(element.querySelectorAll<HTMLElement>(".chat-group"));

--- a/ui/src/pages/chat/chat-history.inflight.test.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test.ts
@@ -71,22 +71,8 @@ function activeHistory(runId: string): ChatHistoryResult {
 }
 
 describe("chat history in-flight assistant recovery", () => {
-  it("restores active tool state and causal preamble timestamps from the in-flight run snapshot", async () => {
+  it("restores active tool state and authoritative preamble time from the in-flight run snapshot", async () => {
     const history = activeHistory("run-live");
-    history.messages = [
-      {
-        role: "user",
-        content: "Original prompt",
-        timestamp: 800,
-        __openclaw: { id: "original-user", seq: 1, idempotencyKey: "run-live:user" },
-      },
-      {
-        role: "user",
-        content: "Please run autoreview here",
-        timestamp: 1_050,
-        __openclaw: { id: "steering-user", seq: 2, idempotencyKey: "steer-send:user" },
-      },
-    ];
     (history.inFlightRun as { events?: unknown[] }).events = [
       {
         runId: "run-live",
@@ -104,25 +90,13 @@ describe("chat history in-flight assistant recovery", () => {
         runId: "run-live",
         seq: 2,
         stream: "tool",
-        ts: 1_075,
+        ts: 1_000,
         sessionKey: "main",
         data: {
           toolCallId: "call-restored",
           name: "read",
           phase: "start",
           args: { path: "README.md" },
-        },
-      },
-      {
-        runId: "run-live",
-        seq: 3,
-        stream: "item",
-        ts: 1_100,
-        sessionKey: "main",
-        data: {
-          kind: "preamble",
-          itemId: "preamble-after-steer",
-          progressText: "Autoreview is running",
         },
       },
     ];
@@ -135,20 +109,14 @@ describe("chat history in-flight assistant recovery", () => {
       toolCallId: "call-restored",
       content: [expect.objectContaining({ type: "toolcall", name: "read" })],
     });
-    expect(state.chatStreamSegments).toMatchObject([
-      {
+    expect(state.chatStreamSegments).toContainEqual(
+      expect.objectContaining({
         itemId: "preamble-restored",
         runId: "run-live",
         text: "Checking the workspace",
         ts: 900,
-      },
-      {
-        itemId: "preamble-after-steer",
-        runId: "run-live",
-        text: "Autoreview is running",
-        ts: 1_100,
-      },
-    ]);
+      }),
+    );
   });
 
   it("restores cleared activity for an already-owned run after reconnect", async () => {

--- a/ui/src/pages/chat/chat-history.inflight.test.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test.ts
@@ -71,8 +71,22 @@ function activeHistory(runId: string): ChatHistoryResult {
 }
 
 describe("chat history in-flight assistant recovery", () => {
-  it("restores active tool state from the in-flight run snapshot", async () => {
+  it("restores active tool state and causal preamble timestamps from the in-flight run snapshot", async () => {
     const history = activeHistory("run-live");
+    history.messages = [
+      {
+        role: "user",
+        content: "Original prompt",
+        timestamp: 800,
+        __openclaw: { id: "original-user", seq: 1, idempotencyKey: "run-live:user" },
+      },
+      {
+        role: "user",
+        content: "Please run autoreview here",
+        timestamp: 1_050,
+        __openclaw: { id: "steering-user", seq: 2, idempotencyKey: "steer-send:user" },
+      },
+    ];
     (history.inFlightRun as { events?: unknown[] }).events = [
       {
         runId: "run-live",
@@ -90,13 +104,25 @@ describe("chat history in-flight assistant recovery", () => {
         runId: "run-live",
         seq: 2,
         stream: "tool",
-        ts: 1_000,
+        ts: 1_075,
         sessionKey: "main",
         data: {
           toolCallId: "call-restored",
           name: "read",
           phase: "start",
           args: { path: "README.md" },
+        },
+      },
+      {
+        runId: "run-live",
+        seq: 3,
+        stream: "item",
+        ts: 1_100,
+        sessionKey: "main",
+        data: {
+          kind: "preamble",
+          itemId: "preamble-after-steer",
+          progressText: "Autoreview is running",
         },
       },
     ];
@@ -109,13 +135,20 @@ describe("chat history in-flight assistant recovery", () => {
       toolCallId: "call-restored",
       content: [expect.objectContaining({ type: "toolcall", name: "read" })],
     });
-    expect(state.chatStreamSegments).toContainEqual(
-      expect.objectContaining({
+    expect(state.chatStreamSegments).toMatchObject([
+      {
         itemId: "preamble-restored",
         runId: "run-live",
         text: "Checking the workspace",
-      }),
-    );
+        ts: 900,
+      },
+      {
+        itemId: "preamble-after-steer",
+        runId: "run-live",
+        text: "Autoreview is running",
+        ts: 1_100,
+      },
+    ]);
   });
 
   it("restores cleared activity for an already-owned run after reconnect", async () => {

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -134,7 +134,9 @@ function resolveRunInsertionBounds(
     return findRunTurnBounds(items, runId);
   }
   if (runId === currentRunId) {
-    return currentTurnBounds;
+    // Active runs can span steers: the original prompt is a floor, not a ceiling.
+    const runBounds = findRunTurnBounds(items, runId);
+    return runBounds?.afterKey ? { afterKey: runBounds.afterKey } : currentTurnBounds;
   }
   // Legacy rows may lack the user-run identity needed for exact bounds. Keep
   // their timestamp ordering across historical turns, but never cross the

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -130,21 +130,18 @@ function resolveRunInsertionBounds(
   if (typeof runId !== "string" || !runId.trim()) {
     return currentRunId != null ? currentTurnBounds : null;
   }
-  if (currentRunId == null) {
-    return findRunTurnBounds(items, runId);
-  }
+  const runBounds = findRunTurnBounds(items, runId);
   if (runId === currentRunId) {
     // Active runs can span steers: the original prompt is a floor, not a ceiling.
-    const runBounds = findRunTurnBounds(items, runId);
-    return runBounds?.afterKey ? { afterKey: runBounds.afterKey } : currentTurnBounds;
+    return runBounds ? { afterKey: runBounds.afterKey } : currentTurnBounds;
+  }
+  if (runBounds || currentRunId == null) {
+    return runBounds;
   }
   // Legacy rows may lack the user-run identity needed for exact bounds. Keep
   // their timestamp ordering across historical turns, but never cross the
   // current prompt and become current-run output.
-  return (
-    findRunTurnBounds(items, runId) ??
-    (currentTurnBounds?.afterKey ? { beforeKey: currentTurnBounds.afterKey } : null)
-  );
+  return currentTurnBounds?.afterKey ? { beforeKey: currentTurnBounds.afterKey } : null;
 }
 
 function liveRenderedToolRefs(toolMessages: unknown[]): LiveToolStreamRef[] {

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -339,6 +339,59 @@ describe("assistant commentary grouping", () => {
     ]);
   });
 
+  it("keeps same-run commentary on its causal side of a persisted steer", () => {
+    const items = buildCachedChatItems(
+      createProps({
+        runId: "run-active",
+        messages: [
+          userMessage("Original prompt", 1_000, {
+            __openclaw: {
+              id: "original-user",
+              seq: 1,
+              idempotencyKey: "run-active:user",
+            },
+          }),
+          userMessage("Please run autoreview here", 3_000, {
+            __openclaw: {
+              id: "steering-user",
+              seq: 2,
+              idempotencyKey: "steer-send:user",
+            },
+          }),
+        ],
+        streamSegments: [
+          {
+            text: "First progress update",
+            ts: 2_000,
+            runId: "run-active",
+            itemId: "preamble-a",
+          },
+          {
+            text: "Autoreview is running",
+            ts: 4_000,
+            runId: "run-active",
+            itemId: "preamble-b",
+          },
+        ],
+      }),
+    );
+
+    expect(items).toMatchObject([
+      {
+        kind: "group",
+        role: "user",
+        messages: [{ message: { content: "Original prompt" } }],
+      },
+      { kind: "stream", text: "First progress update" },
+      {
+        kind: "group",
+        role: "user",
+        messages: [{ message: { content: "Please run autoreview here" } }],
+      },
+      { kind: "stream", text: "Autoreview is running" },
+    ]);
+  });
+
   it("keeps replayed tool and commentary items inside their older turn", () => {
     const items = buildCachedChatItems(
       createProps({

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -864,7 +864,7 @@ function handlePreambleProgressEvent(host: ToolStreamHost, payload: AgentEventPa
     ...host.chatStreamSegments,
     {
       text: progress.text,
-      ts: Date.now(),
+      ts: payload.ts,
       runId: payload.runId,
       ...(progress.itemId ? { itemId: progress.itemId } : {}),
     },


### PR DESCRIPTION
Closes #121448

AI-assisted: yes. The implementation, tests, and final diff were reviewed directly before publication.

## What Problem This Solves

Fixes an issue where users steering a still-running agent in the Control UI could lose earlier assistant commentary, or see it move below the steering message, after refreshing or reconnecting the browser.

The live event stream displayed the active turn correctly, but `chat.startup` / `chat.history` recovery retained only the newest keyed preamble and reconstructed surviving progress with refresh-time ordering.

## Why This Change Was Made

Active-run recovery now retains distinct keyed preambles, preserves each preamble's first-seen timestamp across updates, and replays Gateway event timestamps into the UI. Current-run projections use the original prompt as their causal floor, allowing persisted steering messages to remain between earlier and later commentary without reintroducing clock-skew movement above the original prompt.

The fix stays runtime-agnostic, keeps the existing event/byte bounds, adds no config or schema surface, and simplifies the surrounding replay path to a net-negative production diff.

## User Impact

Refreshing or reconnecting during a steered active run now preserves all visible commentary exactly once and keeps tool/commentary rows on the same side of the steering message where they originally appeared.

## Evidence

Focused regression proof:

- `node scripts/run-vitest.mjs src/gateway/server-chat-state.test.ts` — 11 passed
- `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat-b.test.ts` — 94 passed
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-history.inflight.test.ts ui/src/pages/chat/chat-thread.test.ts ui/src/pages/chat/tool-stream.node.test.ts ui/src/pages/chat/tool-stream-fallback.node.test.ts` — 247 passed
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-active-turn-recovery.e2e.test.ts -t 'preserves pre-steer commentary order through a full reload'` — 1 passed
- Targeted `oxfmt`, `oxlint`, and `git diff --check` — clean
- Fresh autoreview on the final uncommitted diff — no accepted/actionable findings
- Source-blind screenshot validation — all seven visibility/order/no-duplicate/active-state clauses passed

The local `check:changed` wrapper delegated to a remote runner but exited before producing actionable lane output; exact-head PR CI remains the authoritative broad gate.

### Before refresh

The sanitized fixture shows the original prompt, first commentary, steering message, active tool, and later commentary in causal order.

![Before refresh](https://github.com/user-attachments/assets/a6354a36-a5b1-412b-ad0e-97eaf2a59dc5)

### After refresh

The same content remains exactly once and in the same order, with the active working and Stop states intact.

![After refresh](https://github.com/user-attachments/assets/4daad165-7496-4cf9-af96-c76c3a555f98)

Production LOC: +16/-19 (net -3) | Tests: +238/-10

Provenance: regression introduced by #118472 (`5bb27ecd46b`, 2026-08-03), authored and merged by @Patrick-Erichsen while adding active-turn reconnect recovery.