### PR TITLE
feat(terminal): fullscreen /terminal route and dot-matrix claw intro

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 324626,
-  "reason": "task-suggestion card feature (PR #121259) on top of accumulated main drift; CI-measured QA-profile bytes",
-  "updatedAt": "2026-08-09"
+  "startupJsGzipBytes": 325675,
+  "reason": "fullscreen terminal route and toolbar open action (PR #121451); CI-measured QA-profile bytes",
+  "updatedAt": "2026-08-10"
 }

--- a/docs/web/urls.md
+++ b/docs/web/urls.md
@@ -198,9 +198,11 @@ the agent path while keeping other query parameters and the fragment.
 These Gateway-served documents sit outside the application route table:
 
 - `/?onboarding=1` opens the first-run onboarding presentation.
-- `/?view=terminal` opens the full-screen terminal-only document used by the
-  mobile apps. Availability still requires `gateway.terminal.enabled` and
-  `operator.admin`.
+- `/terminal` opens the user-facing full-screen terminal. With a base path, use
+  `<basePath>/terminal`.
+- `/?view=terminal` opens the same terminal-only document in the WebView/embed
+  form used by the mobile apps. Terminal availability in either form still
+  requires `gateway.terminal.enabled` and `operator.admin`.
 - `/approve/<approvalId>` opens a standalone approval document. With a base
   path, use `<basePath>/approve/<approvalId>`. The id identifies an approval but
   never authorizes it; normal Gateway authentication still applies.

--- a/scripts/check-control-ui-performance.mts
+++ b/scripts/check-control-ui-performance.mts
@@ -28,10 +28,9 @@ export const CONTROL_UI_STARTUP_JS_GZIP_TOLERANCE_BYTES = 1024;
 const controlUiPerformanceBudgets = {
   startupJsRequests: 18,
   startupCssRequests: 1,
-  // 318 KiB maintainer-approved 2026-08 for the task-suggestion card feature
-  // (floating tray, acceptance-mode menu, copy action); cumulative creep from
-  // prior landings had consumed the 317 KiB headroom to within ~20 B.
-  startupJsGzipBytes: 318 * KIB,
+  // 319 KiB maintainer-approved 2026-08 for the fullscreen terminal route and
+  // toolbar open action; CI measured 325675 B against the prior 318 KiB cap.
+  startupJsGzipBytes: 319 * KIB,
   // 45 KiB CSS ceilings maintainer-approved 2026-07 alongside the interleaved
   // sidebar zone styling; headroom over the ~36.5 KiB post-diet baseline.
   startupCssGzipBytes: 45 * KIB,

--- a/src/cli/claw-banner.test.ts
+++ b/src/cli/claw-banner.test.ts
@@ -32,12 +32,26 @@ async function runStatic() {
     .filter((row) => row.length > 0);
 }
 
+const EXPECTED_MASCOT = [
+  " •●●:.        .:●●•",
+  ":●●●●:        :●●●●:",
+  ".●●●●:.:•●●•:.:●●●●.",
+  " .●●●: •●●●●• :●●●.",
+  " ..:••●●●●●●●●••:..",
+  ".::••••●●●●●●••••::.",
+  " . .:  •●●●●•  :. .",
+  "    .  :●●●●:  .",
+  "      .●●●●●●.",
+  "       :••••:",
+] as const;
+
 describe("printClawBanner", () => {
   it("prints the static banner when not animatable", async () => {
     const { runtime, log } = runtimeStub();
     await printClawBanner(runtime, { columns: 120, isTty: false, env: {} });
     const output = stripAnsi(String(log.mock.calls[0]?.[0]));
-    expect(output.split("\n")[0]).toBe("▄███▄     ▄███▄");
+    const rows = output.split("\n").filter((row) => row.length > 0);
+    expect(rows.map((row) => row.slice(0, 20).trimEnd())).toEqual(EXPECTED_MASCOT);
     expect(output).toContain("█▀▀▀█ █▀▀▀█ █▀▀▀▀ █▄  █");
   });
 
@@ -62,6 +76,15 @@ describe("printClawBanner", () => {
     expect(chunks).toContain("\x1b[?25h");
     const frames = chunks.filter((chunk) => chunk.includes("\x1b[K"));
     expect(frames.length).toBeGreaterThan(10);
+    expect(
+      frames.some((frame) => {
+        const [first = "", second = ""] = stripAnsi(frame).split("\n");
+        return (
+          first.slice(0, 20).trimEnd() === "•●•.:.        .:.•●•" &&
+          second.slice(0, 20).trimEnd() === ":●●●•:        :•●●●:"
+        );
+      }),
+    ).toBe(true);
     const finalRows = stripAnsi(frames[frames.length - 1] ?? "")
       .split("\n")
       .filter((row) => row.length > 0);

--- a/src/cli/claw-banner.ts
+++ b/src/cli/claw-banner.ts
@@ -1,4 +1,4 @@
-// Shared OpenClaw banner: the pixel lobster mascot beside the OPENCLAW
+// Shared OpenClaw banner: the dot-matrix lobster mascot beside the OPENCLAW
 // wordmark, with a short startup animation on rich interactive terminals.
 // Used by the wizard flows (doctor/onboard/configure) and the foreground
 // gateway run; non-TTY and CI paths always get the plain static banner.
@@ -10,22 +10,25 @@ import { restoreTerminalState } from "../../packages/terminal-core/src/restore.j
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import type { RuntimeEnv } from "../runtime.js";
 
-// Art is pregenerated from pixel bitmaps (two pixel rows per terminal row via
-// ▀▄█). Mascot and wordmark are separate so they can be tinted independently;
-// the wordmark starts on mascot row 2, keeping the claws above the text line.
+// Mascot and wordmark are separate so they can be tinted independently; the
+// wordmark starts on mascot row 3, keeping the claws above the text line.
 const MASCOT_ART = [
-  "▄███▄     ▄███▄",
-  "▀█▄█▀     ▀█▄█▀",
-  "     ▀▄ ▄▀",
-  "    ██ █ ██",
-  "    ▀█████▀",
-  "   ▄█▀ █ ▀█▄",
+  " •●●:.        .:●●•",
+  ":●●●●:        :●●●●:",
+  ".●●●●:.:•●●•:.:●●●●.",
+  " .●●●: •●●●●• :●●●.",
+  " ..:••●●●●●●●●••:..",
+  ".::••••●●●●●●••••::.",
+  " . .:  •●●●●•  :. .",
+  "    .  :●●●●:  .",
+  "      .●●●●●●.",
+  "       :••••:",
 ] as const;
 // Claw tips with the pincer notch widened; swapping the top two rows in and
 // out produces the "snip".
-const MASCOT_OPEN_ROWS = ["▄█▀█▄     ▄█▀█▄", "▀█ █▀     ▀█ █▀"] as const;
-const MASCOT_WIDTH = 15;
-const WORDMARK_ROW_OFFSET = 2;
+const MASCOT_OPEN_ROWS = ["•●•.:.        .:.•●•", ":●●●•:        :•●●●:"] as const;
+const MASCOT_WIDTH = 20;
+const WORDMARK_ROW_OFFSET = 3;
 
 const WORDMARK_ART = [
   "█▀▀▀█ █▀▀▀█ █▀▀▀▀ █▄  █ █▀▀▀▀ █     █▀▀▀█ █   █",

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -58,10 +58,10 @@ describe("printWizardHeader", () => {
     await withColumns(120, () => printWizardHeader({ log } as unknown as RuntimeEnv));
     const output = stripAnsi(String(log.mock.calls[0]?.[0]));
     const rows = output.split("\n");
-    // Claw row stands alone above the wordmark; the eye row shares a line with it.
-    expect(rows[0]).toBe("▄███▄     ▄███▄");
-    expect(rows[2]).toContain("█▀▀▀█ █▀▀▀█ █▀▀▀▀ █▄  █ █▀▀▀▀ █     █▀▀▀█ █   █");
-    expect(rows[3]).toContain("██ █ ██");
+    // Claw rows stand above the wordmark; its first row shares the mascot body line.
+    expect(rows[0]).toBe(" •●●:.        .:●●•");
+    expect(rows[3]).toContain("█▀▀▀█ █▀▀▀█ █▀▀▀▀ █▄  █ █▀▀▀▀ █     █▀▀▀█ █   █");
+    expect(rows[3]).toContain(" .●●●: •●●●●• :●●●.");
   });
 
   it("falls back to the plain title on narrow terminals", async () => {

--- a/src/gateway/terminal/intro-banner.test.ts
+++ b/src/gateway/terminal/intro-banner.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { composeTerminalIntroBanner, TERMINAL_INTRO_ART } from "./intro-banner.js";
+
+const EXPECTED_ART = [
+  "          ..              ..",
+  "        .●●:.:          • •●●",
+  "       .●●●•●●          ●•●●●●",
+  "       :●●●●●•  ..  ..  ●●●●●●.",
+  "       .●●●●●::.:●••●:..•●●●●●",
+  "        :●●●●.  :●●●●.  :●●●●.",
+  "         •●●●•  ●●●●●● .●●●●:",
+  "        ..:••●●•●●●●●●•●●••...",
+  "       ..:●•●••●●●●●●●●••●●•:..",
+  "       :.:•:•••●●●●●●●••••••:.:",
+  "       .•. ●:..:●●●●●●...:• :•",
+  "          .:.   ●●●●●●   .:.",
+  "            .   ●●●●●•   .",
+  "           .   :●●●●●●.   .",
+  "              ●●●●●●●●●•",
+  "              .::•::•::",
+] as const;
+
+describe("composeTerminalIntroBanner", () => {
+  it("composes the exact colored CRLF intro and resets ANSI state", () => {
+    const banner = composeTerminalIntroBanner(80);
+
+    expect(TERMINAL_INTRO_ART).toEqual(EXPECTED_ART);
+    expect(banner).toBe(
+      `\r\n\x1b[38;5;223mWelcome to the Claw.\x1b[0m\r\n\r\n\x1b[38;5;216m${TERMINAL_INTRO_ART.join("\r\n")}\r\n\r\n\x1b[0m`,
+    );
+    expect(banner.startsWith("\r\n\x1b[38;5;223mWelcome to the Claw.\x1b[0m")).toBe(true);
+    expect(banner.endsWith("\r\n\r\n\x1b[0m")).toBe(true);
+    expect(banner.replaceAll("\r\n", "")).not.toContain("\n");
+  });
+
+  it("emits only the headline below 40 columns", () => {
+    expect(composeTerminalIntroBanner(39)).toBe(
+      "\r\n\x1b[38;5;223mWelcome to the Claw.\x1b[0m\r\n\r\n\x1b[0m",
+    );
+  });
+});

--- a/src/gateway/terminal/intro-banner.test.ts
+++ b/src/gateway/terminal/intro-banner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { composeTerminalIntroBanner, TERMINAL_INTRO_ART } from "./intro-banner.js";
+import { composeTerminalIntroBanner } from "./intro-banner.js";
 
 const EXPECTED_ART = [
   "          ..              ..",
@@ -24,9 +24,8 @@ describe("composeTerminalIntroBanner", () => {
   it("composes the exact colored CRLF intro and resets ANSI state", () => {
     const banner = composeTerminalIntroBanner(80);
 
-    expect(TERMINAL_INTRO_ART).toEqual(EXPECTED_ART);
     expect(banner).toBe(
-      `\r\n\x1b[38;5;223mWelcome to the Claw.\x1b[0m\r\n\r\n\x1b[38;5;216m${TERMINAL_INTRO_ART.join("\r\n")}\r\n\r\n\x1b[0m`,
+      `\r\n\x1b[38;5;223mWelcome to the Claw.\x1b[0m\r\n\r\n\x1b[38;5;216m${EXPECTED_ART.join("\r\n")}\r\n\r\n\x1b[0m`,
     );
     expect(banner.startsWith("\r\n\x1b[38;5;223mWelcome to the Claw.\x1b[0m")).toBe(true);
     expect(banner.endsWith("\r\n\r\n\x1b[0m")).toBe(true);

--- a/src/gateway/terminal/intro-banner.ts
+++ b/src/gateway/terminal/intro-banner.ts
@@ -1,6 +1,6 @@
 const RESET = "\x1b[0m";
 
-export const TERMINAL_INTRO_ART = [
+const TERMINAL_INTRO_ART = [
   "          ..              ..",
   "        .●●:.:          • •●●",
   "       .●●●•●●          ●•●●●●",

--- a/src/gateway/terminal/intro-banner.ts
+++ b/src/gateway/terminal/intro-banner.ts
@@ -1,0 +1,26 @@
+const RESET = "\x1b[0m";
+
+export const TERMINAL_INTRO_ART = [
+  "          ..              ..",
+  "        .●●:.:          • •●●",
+  "       .●●●•●●          ●•●●●●",
+  "       :●●●●●•  ..  ..  ●●●●●●.",
+  "       .●●●●●::.:●••●:..•●●●●●",
+  "        :●●●●.  :●●●●.  :●●●●.",
+  "         •●●●•  ●●●●●● .●●●●:",
+  "        ..:••●●•●●●●●●•●●••...",
+  "       ..:●•●••●●●●●●●●••●●•:..",
+  "       :.:•:•••●●●●●●●••••••:.:",
+  "       .•. ●:..:●●●●●●...:• :•",
+  "          .:.   ●●●●●●   .:.",
+  "            .   ●●●●●•   .",
+  "           .   :●●●●●●.   .",
+  "              ●●●●●●●●●•",
+  "              .::•::•::",
+] as const;
+
+export function composeTerminalIntroBanner(cols: number): string {
+  const headline = `\x1b[38;5;223mWelcome to the Claw.${RESET}`;
+  const art = cols >= 40 ? `\x1b[38;5;216m${TERMINAL_INTRO_ART.join("\r\n")}\r\n\r\n` : "";
+  return `\r\n${headline}\r\n\r\n${art}${RESET}`;
+}

--- a/src/gateway/terminal/session-manager.intro-banner.test.ts
+++ b/src/gateway/terminal/session-manager.intro-banner.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import { composeTerminalIntroBanner } from "./intro-banner.js";
+import { TerminalSessionManager } from "./session-manager.js";
+import { baseOpenRequest, makeFakePty } from "./session-manager.test-helpers.js";
+
+describe("TerminalSessionManager intro banner", () => {
+  it("seeds only fresh operator sessions and delivers the intro to the opening client", async () => {
+    vi.useFakeTimers();
+    const emit = vi.fn();
+    const manager = new TerminalSessionManager({ emit, spawn: async () => makeFakePty() });
+    try {
+      const operator = await manager.open(baseOpenRequest());
+      if (!operator.ok) {
+        throw new Error("expected operator open");
+      }
+      const intro = composeTerminalIntroBanner(80);
+      expect(manager.snapshot(operator.sessionId)).toBe(intro);
+
+      await vi.advanceTimersByTimeAsync(4);
+      expect(emit).toHaveBeenCalledWith("conn-1", "terminal.data", {
+        sessionId: operator.sessionId,
+        seq: intro.length,
+        data: intro,
+      });
+
+      emit.mockClear();
+      const agent = await manager.open(
+        baseOpenRequest({ owner: { kind: "agent", agentSessionKey: "agent:main:main" } }),
+      );
+      if (!agent.ok) {
+        throw new Error("expected agent open");
+      }
+      expect(manager.snapshotAgent("agent:main:main", agent.sessionId)).toBe("");
+      await vi.advanceTimersByTimeAsync(4);
+      expect(emit).not.toHaveBeenCalled();
+    } finally {
+      manager.disposeAll();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/gateway/terminal/session-manager.output-ring.test.ts
+++ b/src/gateway/terminal/session-manager.output-ring.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { TerminalSessionManager } from "./session-manager.js";
+import { baseOpenRequest, makeFakePty } from "./session-manager.test-helpers.js";
+
+describe("TerminalSessionManager output ring", () => {
+  it("bounds buffered output by evicting whole head chunks", async () => {
+    const fake = makeFakePty();
+    const manager = new TerminalSessionManager({
+      emit: vi.fn(),
+      spawn: async () => fake,
+      scrollbackChars: 8,
+    });
+    const outcome = await manager.open(baseOpenRequest());
+    if (!outcome.ok) {
+      throw new Error("expected open");
+    }
+    fake.emitData("abcd");
+    fake.emitData("efgh");
+    expect(manager.snapshot(outcome.sessionId)).toBe("abcdefgh");
+    fake.emitData("ijkl");
+    // Cap exceeded: the oldest whole chunk goes; boundaries stay intact.
+    expect(manager.snapshot(outcome.sessionId)).toBe("efghijkl");
+  });
+
+  it("keeps only the tail of a single oversized chunk", async () => {
+    const fake = makeFakePty();
+    const manager = new TerminalSessionManager({
+      emit: vi.fn(),
+      spawn: async () => fake,
+      scrollbackChars: 8,
+    });
+    const outcome = await manager.open(baseOpenRequest());
+    if (!outcome.ok) {
+      throw new Error("expected open");
+    }
+    fake.emitData("0123456789AB");
+    expect(manager.snapshot(outcome.sessionId)).toBe("456789AB");
+  });
+
+  it("does not retain a leading lone low surrogate from an oversized chunk", async () => {
+    const fake = makeFakePty();
+    const manager = new TerminalSessionManager({
+      emit: vi.fn(),
+      spawn: async () => fake,
+      scrollbackChars: 3,
+    });
+    const outcome = await manager.open(baseOpenRequest());
+    if (!outcome.ok) {
+      throw new Error("expected open");
+    }
+
+    fake.emitData("ab😀cd");
+
+    expect(manager.snapshot(outcome.sessionId)).toBe("cd");
+  });
+
+  it("returns undefined for unknown sessions", () => {
+    const manager = new TerminalSessionManager({ emit: vi.fn() });
+    expect(manager.snapshot("nope")).toBeUndefined();
+  });
+});

--- a/src/gateway/terminal/session-manager.test.ts
+++ b/src/gateway/terminal/session-manager.test.ts
@@ -21,41 +21,6 @@ function deferred<T>() {
 }
 
 describe("TerminalSessionManager", () => {
-  it("seeds only fresh operator sessions and delivers the intro to the opening client", async () => {
-    vi.useFakeTimers();
-    const emit = vi.fn();
-    const manager = new TerminalSessionManager({ emit, spawn: async () => makeFakePty() });
-    try {
-      const operator = await manager.open(baseRequest());
-      if (!operator.ok) {
-        throw new Error("expected operator open");
-      }
-      const intro = composeTerminalIntroBanner(80);
-      expect(manager.snapshot(operator.sessionId)).toBe(intro);
-
-      await vi.advanceTimersByTimeAsync(4);
-      expect(emit).toHaveBeenCalledWith("conn-1", TERMINAL_EVENT_DATA, {
-        sessionId: operator.sessionId,
-        seq: intro.length,
-        data: intro,
-      });
-
-      emit.mockClear();
-      const agent = await manager.open(
-        baseRequest({ owner: { kind: "agent", agentSessionKey: "agent:main:main" } }),
-      );
-      if (!agent.ok) {
-        throw new Error("expected agent open");
-      }
-      expect(manager.snapshotAgent("agent:main:main", agent.sessionId)).toBe("");
-      await vi.advanceTimersByTimeAsync(4);
-      expect(emit).not.toHaveBeenCalled();
-    } finally {
-      manager.disposeAll();
-      vi.useRealTimers();
-    }
-  });
-
   it("kills a backend that finishes after its open request is cancelled", async () => {
     const spawned = deferred<FakeTerminalPty>();
     const controller = new AbortController();
@@ -863,64 +828,6 @@ describe("TerminalSessionManager agent ownership", () => {
     expect(fake.paused).toBe(false);
     expect(fake.resumeCalls).toBeGreaterThanOrEqual(1);
     expect(manager.size).toBe(1);
-  });
-});
-
-describe("TerminalSessionManager output ring", () => {
-  it("bounds buffered output by evicting whole head chunks", async () => {
-    const fake = makeFakePty();
-    const manager = new TerminalSessionManager({
-      emit: vi.fn(),
-      spawn: async () => fake,
-      scrollbackChars: 8,
-    });
-    const outcome = await manager.open(baseRequest());
-    if (!outcome.ok) {
-      throw new Error("expected open");
-    }
-    fake.emitData("abcd");
-    fake.emitData("efgh");
-    expect(manager.snapshot(outcome.sessionId)).toBe("abcdefgh");
-    fake.emitData("ijkl");
-    // Cap exceeded: the oldest whole chunk goes; boundaries stay intact.
-    expect(manager.snapshot(outcome.sessionId)).toBe("efghijkl");
-  });
-
-  it("keeps only the tail of a single oversized chunk", async () => {
-    const fake = makeFakePty();
-    const manager = new TerminalSessionManager({
-      emit: vi.fn(),
-      spawn: async () => fake,
-      scrollbackChars: 8,
-    });
-    const outcome = await manager.open(baseRequest());
-    if (!outcome.ok) {
-      throw new Error("expected open");
-    }
-    fake.emitData("0123456789AB");
-    expect(manager.snapshot(outcome.sessionId)).toBe("456789AB");
-  });
-
-  it("does not retain a leading lone low surrogate from an oversized chunk", async () => {
-    const fake = makeFakePty();
-    const manager = new TerminalSessionManager({
-      emit: vi.fn(),
-      spawn: async () => fake,
-      scrollbackChars: 3,
-    });
-    const outcome = await manager.open(baseRequest());
-    if (!outcome.ok) {
-      throw new Error("expected open");
-    }
-
-    fake.emitData("ab😀cd");
-
-    expect(manager.snapshot(outcome.sessionId)).toBe("cd");
-  });
-
-  it("returns undefined for unknown sessions", () => {
-    const manager = new TerminalSessionManager({ emit: vi.fn() });
-    expect(manager.snapshot("nope")).toBeUndefined();
   });
 });
 

--- a/src/gateway/terminal/session-manager.test.ts
+++ b/src/gateway/terminal/session-manager.test.ts
@@ -1,6 +1,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import type { TerminalBackend } from "./backend.js";
+import { composeTerminalIntroBanner } from "./intro-banner.js";
 import { TerminalSessionManager } from "./session-manager.js";
 import {
   baseOpenRequest as baseRequest,
@@ -9,6 +10,7 @@ import {
 } from "./session-manager.test-helpers.js";
 const TERMINAL_EVENT_DATA = "terminal.data";
 const TERMINAL_EVENT_EXIT = "terminal.exit";
+const OPERATOR_INTRO = composeTerminalIntroBanner(80);
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -19,6 +21,41 @@ function deferred<T>() {
 }
 
 describe("TerminalSessionManager", () => {
+  it("seeds only fresh operator sessions and delivers the intro to the opening client", async () => {
+    vi.useFakeTimers();
+    const emit = vi.fn();
+    const manager = new TerminalSessionManager({ emit, spawn: async () => makeFakePty() });
+    try {
+      const operator = await manager.open(baseRequest());
+      if (!operator.ok) {
+        throw new Error("expected operator open");
+      }
+      const intro = composeTerminalIntroBanner(80);
+      expect(manager.snapshot(operator.sessionId)).toBe(intro);
+
+      await vi.advanceTimersByTimeAsync(4);
+      expect(emit).toHaveBeenCalledWith("conn-1", TERMINAL_EVENT_DATA, {
+        sessionId: operator.sessionId,
+        seq: intro.length,
+        data: intro,
+      });
+
+      emit.mockClear();
+      const agent = await manager.open(
+        baseRequest({ owner: { kind: "agent", agentSessionKey: "agent:main:main" } }),
+      );
+      if (!agent.ok) {
+        throw new Error("expected agent open");
+      }
+      expect(manager.snapshotAgent("agent:main:main", agent.sessionId)).toBe("");
+      await vi.advanceTimersByTimeAsync(4);
+      expect(emit).not.toHaveBeenCalled();
+    } finally {
+      manager.disposeAll();
+      vi.useRealTimers();
+    }
+  });
+
   it("kills a backend that finishes after its open request is cancelled", async () => {
     const spawned = deferred<FakeTerminalPty>();
     const controller = new AbortController();
@@ -120,8 +157,8 @@ describe("TerminalSessionManager", () => {
     await vi.waitFor(() => expect(emit).toHaveBeenCalledOnce());
     expect(emit).toHaveBeenCalledWith("conn-1", TERMINAL_EVENT_DATA, {
       sessionId: opened.sessionId,
-      seq: "relay output".length,
-      data: "relay output",
+      seq: OPERATOR_INTRO.length + "relay output".length,
+      data: `${OPERATOR_INTRO}relay output`,
     });
     expect(manager.write("conn-1", opened.sessionId, "input")).toBe(true);
     expect(write).toHaveBeenCalledWith("input");
@@ -216,8 +253,8 @@ describe("TerminalSessionManager", () => {
     await vi.waitFor(() => expect(emit).toHaveBeenCalledOnce());
     expect(emit).toHaveBeenCalledWith("conn-1", TERMINAL_EVENT_DATA, {
       sessionId: outcome.sessionId,
-      seq: 10,
-      data: "helloworld",
+      seq: OPERATOR_INTRO.length + 10,
+      data: `${OPERATOR_INTRO}helloworld`,
     });
   });
 
@@ -231,6 +268,8 @@ describe("TerminalSessionManager", () => {
       if (!outcome.ok) {
         throw new Error("expected open");
       }
+      await vi.advanceTimersByTimeAsync(4);
+      emit.mockClear();
 
       const chunk = "12345678";
       for (let index = 0; index < 10_000; index += 1) {
@@ -240,7 +279,10 @@ describe("TerminalSessionManager", () => {
 
       const frames = emit.mock.calls.filter(([, event]) => event === TERMINAL_EVENT_DATA);
       expect(frames.length).toBeLessThan(10);
-      expect(frames.map((call) => (call[2] as { seq: number }).seq)).toEqual([65_536, 80_000]);
+      expect(frames.map((call) => (call[2] as { seq: number }).seq)).toEqual([
+        OPERATOR_INTRO.length + 65_536,
+        OPERATOR_INTRO.length + 80_000,
+      ]);
       expect(
         frames.every(
           (call) => Buffer.byteLength((call[2] as { data: string }).data, "utf8") <= 64 * 1024,
@@ -262,13 +304,15 @@ describe("TerminalSessionManager", () => {
     if (!outcome.ok) {
       throw new Error("expected open");
     }
+    await vi.waitFor(() => expect(emit).toHaveBeenCalledOnce());
+    emit.mockClear();
 
     expect(manager.write("conn-1", outcome.sessionId, "x")).toBe(true);
     fake.emitData("x");
 
     expect(emit).toHaveBeenCalledWith("conn-1", TERMINAL_EVENT_DATA, {
       sessionId: outcome.sessionId,
-      seq: 1,
+      seq: OPERATOR_INTRO.length + 1,
       data: "x",
     });
   });
@@ -276,7 +320,7 @@ describe("TerminalSessionManager", () => {
   it("pauses local PTY reads above the socket watermark and reasserts resume below it", async () => {
     vi.useFakeTimers();
     try {
-      let bufferedAmount = Number.MAX_SAFE_INTEGER;
+      let bufferedAmount = 0;
       const fake = makeFakePty();
       const manager = new TerminalSessionManager({
         emit: vi.fn(),
@@ -287,13 +331,15 @@ describe("TerminalSessionManager", () => {
       if (!outcome.ok) {
         throw new Error("expected open");
       }
+      await vi.advanceTimersByTimeAsync(4);
+      bufferedAmount = Number.MAX_SAFE_INTEGER;
 
       for (let index = 0; index < 2_000; index += 1) {
         fake.emitData("chunk");
       }
       expect(fake.pauseCalls).toBe(1);
       expect(fake.deliveredChunks).toBe(1);
-      expect(manager.snapshot(outcome.sessionId)).toBe("chunk");
+      expect(manager.snapshot(outcome.sessionId)).toBe(`${OPERATOR_INTRO}chunk`);
 
       bufferedAmount = 0;
       await vi.advanceTimersByTimeAsync(5_000);
@@ -313,13 +359,15 @@ describe("TerminalSessionManager", () => {
     if (!outcome.ok) {
       throw new Error("expected open");
     }
+    await vi.waitFor(() => expect(emit).toHaveBeenCalledOnce());
+    emit.mockClear();
 
     fake.emitData("😀");
     await vi.waitFor(() => expect(emit).toHaveBeenCalledOnce());
 
     expect(emit).toHaveBeenCalledWith("conn-1", TERMINAL_EVENT_DATA, {
       sessionId: outcome.sessionId,
-      seq: 2,
+      seq: OPERATOR_INTRO.length + 2,
       data: "😀",
     });
   });
@@ -928,8 +976,8 @@ describe("TerminalSessionManager detach/reattach", () => {
       emit.mockClear();
 
       const attached = manager.attach("conn-2", sessionId);
-      expect(attached?.buffer).toBe("before away ");
-      expect(attached?.seq).toBe(12);
+      expect(attached?.buffer).toBe(`${OPERATOR_INTRO}before away `);
+      expect(attached?.seq).toBe(OPERATOR_INTRO.length + 12);
       expect(attached?.agentId).toBe("main");
       // The reaper is cancelled: the session survives past the grace deadline.
       vi.advanceTimersByTime(120_000);
@@ -939,7 +987,7 @@ describe("TerminalSessionManager detach/reattach", () => {
       await vi.advanceTimersByTimeAsync(4);
       expect(emit).toHaveBeenCalledWith("conn-2", TERMINAL_EVENT_DATA, {
         sessionId,
-        seq: 16,
+        seq: OPERATOR_INTRO.length + 16,
         data: "live",
       });
       expect(manager.write("conn-2", sessionId, "ls\n")).toBe(true);
@@ -953,6 +1001,8 @@ describe("TerminalSessionManager detach/reattach", () => {
     vi.useFakeTimers();
     try {
       const { manager, fake, emit, sessionId } = await openDetachable();
+      await vi.advanceTimersByTimeAsync(4);
+      emit.mockClear();
       fake.emitData("first");
       await vi.advanceTimersByTimeAsync(4);
       manager.handleDisconnect("conn-1");
@@ -972,9 +1022,9 @@ describe("TerminalSessionManager detach/reattach", () => {
           return { connId, sessionId: data.sessionId, seq: data.seq, data: data.data };
         });
       expect(dataEvents).toEqual([
-        { connId: "conn-1", sessionId, seq: 5, data: "first" },
-        { connId: "conn-2", sessionId, seq: 19, data: "second" },
-        { connId: "conn-3", sessionId, seq: 24, data: "third" },
+        { connId: "conn-1", sessionId, seq: OPERATOR_INTRO.length + 5, data: "first" },
+        { connId: "conn-2", sessionId, seq: OPERATOR_INTRO.length + 19, data: "second" },
+        { connId: "conn-3", sessionId, seq: OPERATOR_INTRO.length + 24, data: "third" },
       ]);
     } finally {
       vi.useRealTimers();

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -13,6 +13,7 @@ import {
   type TerminalBackend,
 } from "./backend.js";
 import { TERMINAL_EVENT_DATA, TERMINAL_EVENT_EXIT } from "./gateway-transport.js";
+import { composeTerminalIntroBanner } from "./intro-banner.js";
 import { TerminalOutputController } from "./output-flow-control.js";
 import { TerminalOutputRing } from "./output-ring.js";
 import {
@@ -268,6 +269,7 @@ export class TerminalSessionManager {
     this.sessions.set(session.id, session);
     if (request.owner.kind === "conn") {
       this.indexByConn(request.owner.connId, session.id);
+      session.output.push(composeTerminalIntroBanner(request.cols));
     }
 
     backend.onData((chunk) => {

--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -13,6 +13,7 @@ import { isTerminalAvailable } from "../lib/terminal-availability.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { bootstrapApplication, type ApplicationRuntime } from "./bootstrap.ts";
+import { resolveControlUiBasePath } from "./browser.ts";
 import { applicationContext, type ApplicationContext } from "./context.ts";
 import {
   APPROVAL_PAGE_ELEMENT,
@@ -22,15 +23,7 @@ import {
 } from "./lazy-custom-element.ts";
 import { resolveOnboardingMode } from "./onboarding-mode.ts";
 import { controlUiPublicAssetPath } from "./public-assets.ts";
-
-/**
- * Terminal-only document mode (`?view=terminal`): the mobile apps embed the
- * terminal as a full-screen WebView page instead of the whole Control UI.
- * Fixed per document load — the apps construct the URL, users never toggle it.
- */
-function isTerminalOnlyView(): boolean {
-  return new URLSearchParams(globalThis.location?.search ?? "").get("view") === "terminal";
-}
+import { isTerminalOnlyView } from "./terminal-document-mode.ts";
 
 export function resolveTerminalThemeMode(): "dark" | "light" {
   return document.documentElement.dataset.themeMode === "light" ? "light" : "dark";
@@ -75,7 +68,10 @@ export class OpenClawApp extends OpenClawLightDomElement {
   @state() private pendingGatewayUrl: string | null = null;
   @state() private onboarding = resolveOnboardingMode(globalThis.location?.search ?? "");
 
-  private readonly terminalOnly = isTerminalOnlyView();
+  private readonly terminalOnly = isTerminalOnlyView(
+    globalThis.location,
+    resolveControlUiBasePath(globalThis.location?.pathname ?? "/"),
+  );
   private runtime: ApplicationRuntime | undefined;
   private readonly contextProvider = new ContextProvider(this, {
     context: applicationContext,
@@ -200,8 +196,8 @@ export class OpenClawApp extends OpenClawLightDomElement {
           ></openclaw-gateway-url-confirmation>
         `
       : nothing;
-    // Embedded mobile terminals own the whole document. Keep the generic login
-    // gate out of this path or a connecting native session exposes Web UI chrome.
+    // Full-screen terminals own the whole document. Keep the generic login gate
+    // out of this path or a connecting native session exposes Web UI chrome.
     if (this.terminalOnly) {
       const terminalAvailable = isTerminalAvailable(
         gatewaySnapshot,

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -466,6 +466,7 @@ export function renderApplicationShell(host: ShellViewHost) {
         .available=${terminalAvailable}
         .suppressed=${settingsTakeover}
         .themeMode=${resolveTerminalThemeMode()}
+        .basePath=${context.basePath}
       ></openclaw-terminal-panel>
       <openclaw-browser-panel
         .client=${gatewayConnected ? gatewaySnapshot.client : null}

--- a/ui/src/app/bootstrap.test.ts
+++ b/ui/src/app/bootstrap.test.ts
@@ -563,6 +563,25 @@ describe("normalizeInitialApplicationLocation", () => {
     }
   });
 
+  it("keeps the terminal document route outside the application router", async () => {
+    const previousSettings = loadSettings();
+    const previousUrl = window.location.href;
+    window.history.replaceState({}, "", "/terminal");
+    const runtime = bootstrapApplication({ sessionPathBuilderReady: Promise.resolve() });
+    const routerStart = vi.spyOn(runtime.router, "start");
+
+    try {
+      await runtime.start();
+
+      expect(window.location.pathname).toBe("/terminal");
+      expect(routerStart).not.toHaveBeenCalled();
+    } finally {
+      runtime.stop();
+      window.history.replaceState({}, "", previousUrl);
+      saveSettings(previousSettings);
+    }
+  });
+
   it("keeps the latest navigation requested before router start", async () => {
     const previousSettings = loadSettings();
     const previousUrl = window.location.href;

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -54,6 +54,7 @@ import {
 import { createSkillWorkshopRevisionHandoff } from "./skill-workshop-revision-handoff.ts";
 import { createStartupLifecycle, type StartupStep } from "./startup-lifecycle.ts";
 import { resolveApplicationStartupSettings } from "./startup-settings.ts";
+import { isTerminalDocumentPath } from "./terminal-document-mode.ts";
 import { startThemeTransition } from "./theme-transition.ts";
 import { resolveTheme, type ThemeMode } from "./theme.ts";
 import { createWebPushCapability } from "./web-push.ts";
@@ -261,6 +262,7 @@ export function bootstrapApplication(
   const basePath = resolveControlUiBasePath(
     startup.location.pathname || globalThis.location?.pathname || "/",
   );
+  const terminalDocument = isTerminalDocumentPath(startup.location.pathname, basePath);
   const firstRunDefaultLanding =
     documentMode === null && isDefaultChatLanding(startup.location, basePath, routeIdFromPath);
   const sessionPathBuilderReady =
@@ -355,6 +357,9 @@ export function bootstrapApplication(
   const browserAnnotationHandoff = createBrowserAnnotationHandoff();
   applyThemePresentation(settings);
   const router = createApplicationRouter();
+  // /terminal is served by the Gateway's SPA fallback but renders before the
+  // shell; starting the page router would rewrite this special document to /chat.
+  const startsApplicationRouter = documentMode === null && !terminalDocument;
   let routerStarted = false;
   // Pre-start navigations are invisible to history; retain the latest request so
   // router.start() cannot resolve the stale browser URL over the user's route.
@@ -485,7 +490,7 @@ export function bootstrapApplication(
     cancelPendingGatewayConnection,
     start: () => {
       const stopRouter = () => router.stop();
-      if (!documentMode) {
+      if (startsApplicationRouter) {
         startupLifecycle.addDisposer(stopRouter);
       }
       const steps: StartupStep[] = [
@@ -508,7 +513,7 @@ export function bootstrapApplication(
       steps.push(() => {
         void config.refresh({ skipWithoutAuthCandidate: true });
       });
-      if (!documentMode) {
+      if (startsApplicationRouter) {
         steps.push(async () => {
           const pendingNavigation = pendingRouterStartNavigation;
           pendingRouterStartNavigation = null;

--- a/ui/src/app/terminal-document-mode.test.ts
+++ b/ui/src/app/terminal-document-mode.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { isTerminalOnlyView, terminalDocumentPath } from "./terminal-document-mode.ts";
+
+describe("terminal document mode", () => {
+  it.each([
+    ["the root route", { pathname: "/terminal", search: "" }, ""],
+    ["a base-mounted route", { pathname: "/openclaw/terminal", search: "" }, "/openclaw"],
+    ["the embedded query form", { pathname: "/", search: "?view=terminal" }, ""],
+  ])("recognizes %s", (_label, location, basePath) => {
+    expect(isTerminalOnlyView(location, basePath)).toBe(true);
+  });
+
+  it("does not treat an ordinary route as a terminal document", () => {
+    expect(isTerminalOnlyView({ pathname: "/chat", search: "" }, "")).toBe(false);
+  });
+
+  it("builds a base-path-aware user-facing route", () => {
+    expect(terminalDocumentPath("/openclaw/")).toBe("/openclaw/terminal");
+  });
+});

--- a/ui/src/app/terminal-document-mode.ts
+++ b/ui/src/app/terminal-document-mode.ts
@@ -1,0 +1,23 @@
+import { normalizeRouteBasePath, normalizeRoutePath } from "@openclaw/uirouter";
+
+const TERMINAL_DOCUMENT_PATH = "/terminal";
+
+type TerminalDocumentLocation = Pick<Location, "pathname" | "search">;
+
+export function terminalDocumentPath(basePath = ""): string {
+  return `${normalizeRouteBasePath(basePath)}${TERMINAL_DOCUMENT_PATH}`;
+}
+
+export function isTerminalDocumentPath(pathname: string, basePath: string): boolean {
+  return normalizeRoutePath(pathname) === terminalDocumentPath(basePath);
+}
+
+export function isTerminalOnlyView(
+  location: TerminalDocumentLocation | undefined = globalThis.location,
+  basePath = "",
+): boolean {
+  return (
+    new URLSearchParams(location?.search ?? "").get("view") === "terminal" ||
+    isTerminalDocumentPath(location?.pathname ?? "/", basePath)
+  );
+}

--- a/ui/src/components/terminal/terminal-panel-accessibility.test.ts
+++ b/ui/src/components/terminal/terminal-panel-accessibility.test.ts
@@ -59,6 +59,28 @@ describe("OpenClawTerminalPanel accessibility", () => {
     ).toBe(true);
   });
 
+  it("opens the base-mounted full-screen terminal in an isolated tab", async () => {
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+    const panel = createPanel(createPickerClient());
+    panel.basePath = "/openclaw";
+    await waitForFast(() =>
+      expect(
+        panel.renderRoot.querySelector('[aria-label="Open full-screen terminal"]'),
+      ).not.toBeNull(),
+    );
+
+    panel.renderRoot
+      .querySelector<HTMLButtonElement>('[aria-label="Open full-screen terminal"]')
+      ?.click();
+
+    expect(open).toHaveBeenCalledWith("/openclaw/terminal", "_blank", "noopener");
+
+    panel.fullscreen = true;
+    await panel.updateComplete;
+    expect(panel.renderRoot.querySelector('[aria-label="Open full-screen terminal"]')).toBeNull();
+    open.mockRestore();
+  });
+
   afterEach(async () => {
     document.body.replaceChildren();
     localStorage.clear();

--- a/ui/src/components/terminal/terminal-panel-accessibility.test.ts
+++ b/ui/src/components/terminal/terminal-panel-accessibility.test.ts
@@ -73,7 +73,11 @@ describe("OpenClawTerminalPanel accessibility", () => {
       .querySelector<HTMLButtonElement>('[aria-label="Open full-screen terminal"]')
       ?.click();
 
-    expect(open).toHaveBeenCalledWith("/openclaw/terminal", "_blank", "noopener");
+    expect(open).toHaveBeenCalledWith(
+      "http://localhost:3000/openclaw/terminal",
+      "_blank",
+      "noopener,noreferrer",
+    );
 
     panel.fullscreen = true;
     await panel.updateComplete;

--- a/ui/src/components/terminal/terminal-panel-chrome.ts
+++ b/ui/src/components/terminal/terminal-panel-chrome.ts
@@ -17,6 +17,7 @@ export function renderTerminalPanelToolbar(
   uploadController: TerminalPanelUploadController,
   sessionPicker: TemplateResult,
   setDock: (dock: TerminalDock) => void,
+  openFullscreen: () => void,
   hidePanel: () => void,
 ): TemplateResult {
   return renderTerminalPanelActions({
@@ -25,6 +26,7 @@ export function renderTerminalPanelToolbar(
     upload: uploadController,
     sessionPicker,
     onDock: setDock,
+    onOpenFullscreen: openFullscreen,
     onHide: hidePanel,
   });
 }

--- a/ui/src/components/terminal/terminal-panel-upload.ts
+++ b/ui/src/components/terminal/terminal-panel-upload.ts
@@ -12,6 +12,7 @@ const CLOSE_GLYPH = svg`<svg viewBox="0 0 16 16" width="12" height="12" fill="no
 const DOCK_BOTTOM_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.3"><rect x="2" y="2.5" width="12" height="11" rx="1.5" /><path d="M2 10h12" /></svg>`;
 const DOCK_RIGHT_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.3"><rect x="2" y="2.5" width="12" height="11" rx="1.5" /><path d="M10 2.5v11" /></svg>`;
 const DOCK_MAIN_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"><path d="M6 2.5H2.5V6M10 2.5h3.5V6M6 13.5H2.5V10M10 13.5h3.5V10" /></svg>`;
+const OPEN_FULLSCREEN_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M9 2.5h4.5V7M13.5 2.5 8 8" /><path d="M7 3H3.5A1.5 1.5 0 0 0 2 4.5v8A1.5 1.5 0 0 0 3.5 14h8a1.5 1.5 0 0 0 1.5-1.5V9" /></svg>`;
 const UPLOAD_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5.2 8.1 9.8 3.5a2.5 2.5 0 0 1 3.5 3.5l-6 6a3.5 3.5 0 0 1-5-5l5.8-5.8" /><path d="m4.4 9 5.2-5.2a1.4 1.4 0 0 1 2 2l-5.3 5.3a2.3 2.3 0 0 1-3.2-3.2l4.6-4.6" /></svg>`;
 
 type TerminalUploadTab = {
@@ -320,6 +321,7 @@ export function renderTerminalPanelActions(params: {
   upload: TerminalPanelUploadController;
   sessionPicker: unknown;
   onDock: (dock: "bottom" | "right" | "main") => void;
+  onOpenFullscreen: () => void;
   onHide: () => void;
 }) {
   return html`<div class="tp-actions">
@@ -374,6 +376,15 @@ export function renderTerminalPanelActions(params: {
               ${DOCK_MAIN_GLYPH}
             </button>
           </span>
+          <button
+            class="tp-icon tp-open-fullscreen"
+            type="button"
+            title=${t("terminal.openFullscreen")}
+            aria-label=${t("terminal.openFullscreen")}
+            @click=${params.onOpenFullscreen}
+          >
+            ${OPEN_FULLSCREEN_GLYPH}
+          </button>
           <button
             class="tp-icon"
             type="button"

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -7,6 +7,7 @@
 import { initialState, Task, TaskStatus } from "@lit/task";
 import { html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
+import { terminalDocumentPath } from "../../app/terminal-document-mode.ts";
 import { t } from "../../i18n/index.ts";
 import { OpenClawLitElement } from "../../lit/openclaw-element.ts";
 import { DockLayoutController, dockPanelStyles } from "../dock-layout-controller.ts";
@@ -63,9 +64,11 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
   @property({ type: Boolean }) suppressed = false;
   /** Active Control UI color mode, mirrored into the terminal theme. */
   @property({ attribute: false }) themeMode: "dark" | "light" = "dark";
+  /** Configured Control UI mount prefix used by document links. */
+  @property({ attribute: false }) basePath = "";
   /**
-   * Terminal-only document mode (`?view=terminal`), used by the mobile apps'
-   * WebViews: fills the viewport, always open while available, no dock chrome.
+   * Terminal-only document mode (`/terminal` or `?view=terminal`): fills the
+   * viewport, stays open while available, and omits dock chrome.
    */
   @property({ type: Boolean }) fullscreen = false;
 
@@ -313,6 +316,10 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
     void this.updateComplete.then(() => fitAllTerminalSessions(this.terminalSessions.tabs));
   }
 
+  private openFullscreen(): void {
+    window.open(terminalDocumentPath(this.basePath), "_blank", "noopener");
+  }
+
   resetTerminalSessionPicker(): void {
     this.closeSessionPicker(false);
     void this.sessionPickerTask.run([null]);
@@ -364,6 +371,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       this.terminalPanelUploadController,
       sessionPicker,
       (dock) => this.setDock(dock),
+      () => this.openFullscreen(),
       () => this.closeTerminalPanel(),
     );
     return html`

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -9,6 +9,7 @@ import { html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import { terminalDocumentPath } from "../../app/terminal-document-mode.ts";
 import { t } from "../../i18n/index.ts";
+import { openExternalUrlSafe } from "../../lib/open-external-url.ts";
 import { OpenClawLitElement } from "../../lit/openclaw-element.ts";
 import { DockLayoutController, dockPanelStyles } from "../dock-layout-controller.ts";
 import { createDockPanelLayout, type DockPanelPlacement } from "../dock-panel-layout.ts";
@@ -317,7 +318,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
   }
 
   private openFullscreen(): void {
-    window.open(terminalDocumentPath(this.basePath), "_blank", "noopener");
+    openExternalUrlSafe(terminalDocumentPath(this.basePath));
   }
 
   resetTerminalSessionPicker(): void {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1830,6 +1830,7 @@ export const en: TranslationMap = {
     title: "Terminal",
     toggle: "Toggle terminal",
     open: "Open terminal",
+    openFullscreen: "Open full-screen terminal",
     hide: "Hide terminal",
     resize: "Resize terminal panel",
     newSession: "New terminal session",


### PR DESCRIPTION
## What Problem This Solves

There is no user-facing URL for a full-screen terminal; the only existing form is the mobile WebView query route at `?view=terminal`. Web terminal sessions also start bare, without a brand moment.

## Why This Change Was Made

This adds a base-path-aware `/terminal` document route that renders the existing full-screen terminal document mode; the SPA router is deliberately not started for that route. The terminal toolbar gains an **Open full-screen terminal** button that opens the route in a new tab with `noopener`.

Fresh operator-owned (`conn`) sessions now receive a gateway-side dot-matrix lobster intro through the canonical `TerminalOutputController` path. Agent tool terminals stay byte-clean. The banner is written into the scrollback ring so attach replay shows it once, while terminals narrower than 40 columns receive only the headline. The CLI banner mascot in `src/cli/claw-banner.ts` is replaced with its compact dot-matrix cousin while preserving the wordmark layout and molt/shimmer/snip animation.

## User Impact

Operators can open a `<gateway>/terminal` deep link directly or use the new toolbar button. Fresh web terminals greet them with “Welcome to the Claw.” Doctor, onboard, and gateway CLI surfaces show the refreshed banner mascot.

## Evidence

- Focused Vitest runs are green:
  - `ui/src/app/terminal-document-mode.test.ts`, `ui/src/app/bootstrap.test.ts`, and `ui/src/components/terminal/terminal-panel-accessibility.test.ts`: 10 + 30 passed
  - `src/gateway/terminal/intro-banner.test.ts`: 2 passed
  - `src/cli/claw-banner.test.ts`: 7 passed
  - `src/gateway/terminal/session-manager.test.ts`: 43 passed
- Autoreview (Codex `gpt-5.6-sol`, high): clean, with no accepted findings.
- `git diff --check`: clean.
- AI-assisted change; the implementation and evidence were reviewed before submission.

![Faithful rendering of the exact production banner bytes (characters plus xterm-256 colors 223 and 216)](https://github.com/user-attachments/assets/e47fea23-3c0d-422d-8fd4-8a670383d5e0)

_Faithful rendering of the exact production banner bytes (characters plus xterm-256 colors 223 and 216)._
