### PR TITLE
fix(qa): await gateway artifact startup

### DIFF
--- a/test/e2e/qa-lab/runtime/gateway-agent-artifact-apis.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-agent-artifact-apis.e2e.test.ts
@@ -210,7 +210,6 @@ describe("Gateway agent and artifact APIs", () => {
       bind: "loopback",
       auth: { mode: "token", token },
       controlUiEnabled: false,
-      sidecarStartup: "defer",
     });
     cleanup.push(() => server.close());
 
@@ -231,7 +230,6 @@ describe("Gateway agent and artifact APIs", () => {
         bind: "loopback",
         auth: { mode: "token", token },
         controlUiEnabled: false,
-        sidecarStartup: "defer",
       });
       client = await connectGatewayClient({
         url: `ws://127.0.0.1:${port}`,
@@ -291,6 +289,21 @@ describe("Gateway agent and artifact APIs", () => {
       workspace: createdWorkspace,
     });
     await restartGateway("gateway agent artifact APIs after create");
+    const createdEnvironmentAfterRestart = await client.request<{ id: string }>(
+      "environments.create",
+      {
+        profileId: "qa-provider",
+        idempotencyKey: "qa-environment-request-after-restart",
+      },
+    );
+    await expect(client.request("environments.list", {})).resolves.toMatchObject({
+      environments: expect.arrayContaining([
+        expect.objectContaining({
+          id: createdEnvironmentAfterRestart.id,
+          status: "available",
+        }),
+      ]),
+    });
     await expect(client.request("agents.list", {})).resolves.toMatchObject({
       agents: expect.arrayContaining([
         expect.objectContaining({


### PR DESCRIPTION
## What Problem This Solves

The `gateway-agent-artifact-apis` QA scenario opted into deferred Gateway sidecar startup even though it exercises steady-state agent, environment, and artifact API composition. That allowed `environments.create` to reach the intentional startup gate and fail with `environments.create unavailable during gateway startup`.

Historical failure: https://github.com/openclaw/openclaw/actions/runs/31349486745

## Why This Change Was Made

Use the Gateway harness default, which waits for sidecar startup, for both the initial server and the restarted server. Add a narrow post-restart `environments.create` plus `environments.list` assertion so the scenario proves the steady-state contract after restart as well as before it.

This changes no production behavior, retry policy, startup gate, or Testbox eligibility.

## User Impact

No runtime or product behavior changes. The QA scenario now records deterministic evidence for the intended Gateway API composition path instead of racing the startup lifecycle.

## Evidence

- Exact head: `e6be95b012d33b10a06323ed72894bcb3b4d278c`
- Mechanical refresh: stable patch-id `abae650d3d054e0fe8445674fff51eb834c05924`; task patch unchanged from reviewed head
- Exact-head focused proof: `1` scenario passed, `0` failed, `0` skipped; schema-v2 full evidence with `result.status=pass` and complete `1/1` profile coverage
- Focused proof comment: https://github.com/openclaw/openclaw/pull/121453#issuecomment-5237101934
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/31374461101 succeeded with `98` successful checks and no failures
- Exact-head ClawSweeper: https://github.com/openclaw/clawsweeper/actions/runs/31376029035 published a durable review with no findings, no security findings, sufficient proof, and no new Rank-up move
- Mandatory local autoreview: clean, overall patch correctness `0.99`
- `git diff --check`
- LOC: production `0`; tests `+15/-2`

No changelog: test-only repair.

## Punchcard

Attestation: `att_01KZNHA4D0H9JB3Q27SSAMT5KC`

Receipt: `pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaTkhBNEQwSDlKQjNRMjdTU0FNVDVLQwB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pGWE42TVBWRDRBMzM2VlZDWVdHUDQ1AGFtYmVyLXdvcmtzaG9wLXdvcmtzaG9wLTM2AG9wZW5jbGF3L29wZW5jbGF3AAAxMjE0NTMAYWRkMTdmZjdlMDI5ZmZjZjMyZWNhYWQ0ZmU2ZjdiZWNiNDg2ODdiYzQ2ODJlMjJkMGRjNmQ5Yjk3MDk4YzRmNABzaWduaW5nLXYxAElNSDhxeFpaM0JvcFduSy1iWlpudmR5ZVR2TkVQb0VBaWZnU3NibXdZZjc2dy1aOWFhY3hOeXd5dHIweDRiaTVZZXhkbnZtSmFLYVh4QnNMUzY5R0N3ADIwMjYtMDgtMTBUMDk6NTA6NTQuMzY4WgA.hcoTJvJbXK-6uMeB8_N7eBDXh7yCFaFPx7uJA2GBq20SLxBnIjW5LXLjImgusoWpAZ5qUHemIjop5T7ZwkC1Cw`
