### PR TITLE
fix(agents): clean up SSH temp files when setup fails

### DIFF
--- a/src/agents/sandbox/ssh.test.ts
+++ b/src/agents/sandbox/ssh.test.ts
@@ -5,12 +5,13 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { makeTempDir } from "../../../test/helpers/temp-dir.js";
 import {
   buildExecRemoteCommand,
   buildRemoteWorkdirValidationCommand,
   buildValidatedExecRemoteCommand,
+  createSshSandboxSessionFromConfigText,
   createSshSandboxSessionFromSettings,
   disposeSshSandboxSession,
   ENSURE_REMOTE_REAL_DIRECTORY_SCRIPT,
@@ -65,6 +66,36 @@ describe("sandbox ssh helpers", () => {
       "example.com ssh-ed25519 AAAATEST\n",
     );
   });
+
+  it.each(["writeFile", "chmod"] as const)(
+    "removes the temp config directory when %s fails",
+    async (failurePoint) => {
+      const injectedError = new Error(`injected ${failurePoint} failure`);
+      const realMkdtemp = fs.mkdtemp.bind(fs);
+      let configDir: string | undefined;
+      vi.spyOn(fs, "mkdtemp").mockImplementation(async (prefix, options) => {
+        configDir = await realMkdtemp(prefix, options);
+        tempDirs.push(configDir);
+        return configDir;
+      });
+      if (failurePoint === "writeFile") {
+        vi.spyOn(fs, "writeFile").mockRejectedValueOnce(injectedError);
+      } else {
+        vi.spyOn(fs, "chmod").mockRejectedValueOnce(injectedError);
+      }
+
+      try {
+        const rejection = createSshSandboxSessionFromConfigText({
+          configText: "Host openclaw-test\n",
+        });
+        await expect(rejection).rejects.toBe(injectedError);
+        expect(configDir).toBeDefined();
+        await expect(fs.access(configDir as string)).rejects.toThrow();
+      } finally {
+        vi.restoreAllMocks();
+      }
+    },
+  );
 
   it("normalizes CRLF and escaped-newline private keys before writing temp files", async () => {
     const session = await createSshSandboxSessionFromSettings({

--- a/src/agents/sandbox/ssh.ts
+++ b/src/agents/sandbox/ssh.ts
@@ -581,15 +581,11 @@ export async function createSshSandboxSessionFromConfigText(params: {
   if (!host) {
     throw new Error("Failed to parse SSH config output.");
   }
-  const configDir = await fs.mkdtemp(path.join(resolveSshTmpRoot(), "openclaw-sandbox-ssh-"));
-  const configPath = path.join(configDir, "config");
-  await fs.writeFile(configPath, params.configText, { encoding: "utf8", mode: 0o600 });
-  await fs.chmod(configPath, 0o600);
-  return {
-    command: params.command?.trim() || "ssh",
-    configPath,
+  return await createSshSandboxSession(
+    params.command?.trim() || "ssh",
     host,
-  };
+    () => params.configText,
+  );
 }
 
 /** Create a temporary SSH session from structured sandbox SSH settings. */
@@ -601,71 +597,60 @@ export async function createSshSandboxSessionFromSettings(
     throw new Error(`Invalid sandbox SSH target: ${settings.target}`);
   }
 
-  const configDir = await fs.mkdtemp(path.join(resolveSshTmpRoot(), "openclaw-sandbox-ssh-"));
-  try {
-    // Inline secret material is written into the temp config dir with strict
-    // permissions so ssh can consume it without exposing values in argv/env.
-    const materializedIdentity = settings.identityData
-      ? await writeSecretMaterial(configDir, "identity", settings.identityData)
-      : undefined;
-    const materializedCertificate = settings.certificateData
-      ? await writeSecretMaterial(configDir, "certificate.pub", settings.certificateData)
-      : undefined;
-    const materializedKnownHosts = settings.knownHostsData
-      ? await writeSecretMaterial(configDir, "known_hosts", settings.knownHostsData)
-      : undefined;
-    const identityFile = materializedIdentity ?? resolveOptionalLocalPath(settings.identityFile);
-    const certificateFile =
-      materializedCertificate ?? resolveOptionalLocalPath(settings.certificateFile);
-    const knownHostsFile =
-      materializedKnownHosts ?? resolveOptionalLocalPath(settings.knownHostsFile);
-    assertSshConfigLineValue(identityFile, "identityFile");
-    assertSshConfigLineValue(certificateFile, "certificateFile");
-    assertSshConfigLineValue(knownHostsFile, "knownHostsFile");
-    const hostAlias = "openclaw-sandbox";
-    const configPath = path.join(configDir, "config");
-    const lines = [
-      `Host ${hostAlias}`,
-      `  HostName ${parsed.host}`,
-      `  Port ${parsed.port}`,
-      "  BatchMode yes",
-      "  ConnectTimeout 5",
-      "  ServerAliveInterval 15",
-      "  ServerAliveCountMax 3",
-      `  StrictHostKeyChecking ${settings.strictHostKeyChecking ? "yes" : "no"}`,
-      `  UpdateHostKeys ${settings.updateHostKeys ? "yes" : "no"}`,
-    ];
-    if (parsed.user) {
-      lines.push(`  User ${parsed.user}`);
-    }
-    if (knownHostsFile) {
-      lines.push(`  UserKnownHostsFile ${knownHostsFile}`);
-    } else if (!settings.strictHostKeyChecking) {
-      lines.push("  UserKnownHostsFile /dev/null");
-    }
-    if (identityFile) {
-      lines.push(`  IdentityFile ${identityFile}`);
-    }
-    if (certificateFile) {
-      lines.push(`  CertificateFile ${certificateFile}`);
-    }
-    if (identityFile || certificateFile) {
-      lines.push("  IdentitiesOnly yes");
-    }
-    await fs.writeFile(configPath, `${lines.join("\n")}\n`, {
-      encoding: "utf8",
-      mode: 0o600,
-    });
-    await fs.chmod(configPath, 0o600);
-    return {
-      command: settings.command.trim() || "ssh",
-      configPath,
-      host: hostAlias,
-    };
-  } catch (error) {
-    await fs.rm(configDir, { recursive: true, force: true });
-    throw error;
-  }
+  return await createSshSandboxSession(
+    settings.command.trim() || "ssh",
+    "openclaw-sandbox",
+    async (configDir) => {
+      // Inline secret material is written into the temp config dir with strict
+      // permissions so ssh can consume it without exposing values in argv/env.
+      const materializedIdentity = settings.identityData
+        ? await writeSecretMaterial(configDir, "identity", settings.identityData)
+        : undefined;
+      const materializedCertificate = settings.certificateData
+        ? await writeSecretMaterial(configDir, "certificate.pub", settings.certificateData)
+        : undefined;
+      const materializedKnownHosts = settings.knownHostsData
+        ? await writeSecretMaterial(configDir, "known_hosts", settings.knownHostsData)
+        : undefined;
+      const identityFile = materializedIdentity ?? resolveOptionalLocalPath(settings.identityFile);
+      const certificateFile =
+        materializedCertificate ?? resolveOptionalLocalPath(settings.certificateFile);
+      const knownHostsFile =
+        materializedKnownHosts ?? resolveOptionalLocalPath(settings.knownHostsFile);
+      assertSshConfigLineValue(identityFile, "identityFile");
+      assertSshConfigLineValue(certificateFile, "certificateFile");
+      assertSshConfigLineValue(knownHostsFile, "knownHostsFile");
+      const lines = [
+        "Host openclaw-sandbox",
+        `  HostName ${parsed.host}`,
+        `  Port ${parsed.port}`,
+        "  BatchMode yes",
+        "  ConnectTimeout 5",
+        "  ServerAliveInterval 15",
+        "  ServerAliveCountMax 3",
+        `  StrictHostKeyChecking ${settings.strictHostKeyChecking ? "yes" : "no"}`,
+        `  UpdateHostKeys ${settings.updateHostKeys ? "yes" : "no"}`,
+      ];
+      if (parsed.user) {
+        lines.push(`  User ${parsed.user}`);
+      }
+      if (knownHostsFile) {
+        lines.push(`  UserKnownHostsFile ${knownHostsFile}`);
+      } else if (!settings.strictHostKeyChecking) {
+        lines.push("  UserKnownHostsFile /dev/null");
+      }
+      if (identityFile) {
+        lines.push(`  IdentityFile ${identityFile}`);
+      }
+      if (certificateFile) {
+        lines.push(`  CertificateFile ${certificateFile}`);
+      }
+      if (identityFile || certificateFile) {
+        lines.push("  IdentitiesOnly yes");
+      }
+      return `${lines.join("\n")}\n`;
+    },
+  );
 }
 
 /** Remove temporary SSH config and materialized secret files. */
@@ -914,6 +899,23 @@ function resolveSshTmpRoot(): string {
   return path.resolve(resolvePreferredOpenClawTmpDir() ?? os.tmpdir());
 }
 
+async function createSshSandboxSession(
+  command: string,
+  host: string,
+  buildConfigText: (configDir: string) => string | Promise<string>,
+): Promise<SshSandboxSession> {
+  const configDir = await fs.mkdtemp(path.join(resolveSshTmpRoot(), "openclaw-sandbox-ssh-"));
+  const configPath = path.join(configDir, "config");
+  try {
+    await writePrivateFile(configPath, await buildConfigText(configDir));
+    return { command, configPath, host };
+  } catch (error) {
+    // Best-effort rollback must not replace the initialization failure.
+    await fs.rm(configDir, { recursive: true, force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
 function assertSshConfigLineValue(value: string | undefined, field: string): void {
   if (value && /[\r\n]/.test(value)) {
     throw new Error(`SSH sandbox ${field} must not contain line breaks.`);
@@ -931,11 +933,12 @@ async function writeSecretMaterial(
   contents: string,
 ): Promise<string> {
   const pathname = path.join(dir, filename);
-  await fs.writeFile(pathname, normalizeInlineSshMaterial(contents, filename), {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  await fs.chmod(pathname, 0o600);
+  await writePrivateFile(pathname, normalizeInlineSshMaterial(contents, filename));
   return pathname;
+}
+
+async function writePrivateFile(pathname: string, contents: string): Promise<void> {
+  await fs.writeFile(pathname, contents, { encoding: "utf8", mode: 0o600 });
+  await fs.chmod(pathname, 0o600);
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Related: #121148

AI-assisted: This repair was developed and reviewed with AI assistance. The maintainer understands the change; no model transcript is included.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where, after OpenShell-rendered SSH config setup created a temporary directory, a config write or chmod failure left private temporary material behind.

## Why This Change Was Made

One lifecycle owner now allocates the directory, materializes auxiliary private files, writes the canonical config, publishes the session only after successful initialization, and rolls the whole directory back on any initialization failure. Cleanup preserves the original setup error without including config or key text.

## User Impact

Failed SSH/OpenShell sandbox setup no longer leaves stale temporary config directories. Successful behavior and the public plugin SDK shape are unchanged.

## Evidence

- Before the fix, `node scripts/run-vitest.mjs src/agents/sandbox/ssh.test.ts` produced 2 failures and 31 passes. Both the `writeFile` and `chmod` failure cases observed `fs.access` resolve, proving the temporary directory remained.
- After the fix and rebase, `node scripts/run-vitest.mjs src/agents/sandbox/ssh.test.ts src/agents/sandbox/ssh-backend.test.ts` passed all 49 tests.
- After the fix and rebase, `node scripts/run-vitest.mjs extensions/openshell/src/openshell-core.test.ts` passed all 45 tests.
- After rebasing onto current `origin/main` at `23d1eca4554adef22508c5561e1e0145c65bc5e0`, `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check` passed. The earlier `check-plugin-sdk-api-baseline` failure in PR run 31361109501 matched main run 31361056506 at base `627e5bb06306`; incorporating current main's refreshed generated baseline repaired that main-owned blocker without changing this PR's product scope or baseline file.
- `node scripts/check-changed.mjs -- src/agents/sandbox/ssh.ts src/agents/sandbox/ssh.test.ts` exited 0 on Blacksmith Testbox lease `tbx_01kzn434tb3r6kmgrzg4z2enwt`: https://github.com/openclaw/openclaw/actions/runs/31360378271. Portal sync emitted an unrelated post-success 401; the command exited 0 and the lease stopped.
- Security review found no issues (confidence 9/10).
- Fresh Codex autoreview was clean, with no accepted or actionable findings.
- Production LOC: +81/-78 (net +3), justified by moving canonical config path/write ownership into the lifecycle owner. Tests: +32/-1.
- `git diff --check origin/main...HEAD` passed after the rebase.

No docs or changelog entry is needed because public behavior and API shape are unchanged, and `CHANGELOG.md` is release-owned.
