### PR TITLE
fix(ci): support frozen validation scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
       run_checks_fast_core: ${{ steps.manifest.outputs.run_checks_fast_core }}
       run_checks_fast: ${{ steps.manifest.outputs.run_checks_fast }}
       historical_target: ${{ steps.manifest.outputs.historical_target }}
+      frozen_target: ${{ steps.manifest.outputs.frozen_target }}
       run_qa_smoke_ci: ${{ steps.manifest.outputs.run_qa_smoke_ci }}
       run_prompt_snapshots: ${{ steps.manifest.outputs.run_prompt_snapshots }}
       checks_fast_core_matrix: ${{ steps.manifest.outputs.checks_fast_core_matrix }}
@@ -713,6 +714,7 @@ jobs:
             run_checks_fast_core: checksFastCoreTasks.length > 0,
             run_checks_fast: runNodeFull,
             historical_target: historicalTarget,
+            frozen_target: frozenTarget,
             compatibility_target: compatibilityTarget,
             run_qa_smoke_ci: runQaSmokeCi,
             run_prompt_snapshots: runNodeFull && changedScopeHasPromptSnapshotImpact,
@@ -1468,14 +1470,22 @@ jobs:
           sticky-disk: ${{ github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'true' || 'false' }}
           use-actions-cache: ${{ github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'false' || 'true' }}
 
-      - name: Install Playwright Chromium
+      - &install_playwright_chromium
+        name: Install Playwright Chromium
+        env:
+          FROZEN_TARGET: ${{ needs.preflight.outputs.frozen_target }}
         run: |
-          if [[ "$COMPATIBILITY_TARGET" == "true" ]]; then
+          if [[ "${COMPATIBILITY_TARGET:-false}" == "true" ]]; then
             # Legacy Vitest configs cannot pass a discovered system browser to Playwright.
             # Install the managed browser revision pinned by the selected target instead.
             pnpm --dir ui exec playwright install chromium
-          else
+          elif [[ -f scripts/ensure-playwright-chromium.mts ]]; then
             node --import tsx scripts/ensure-playwright-chromium.mts
+          elif [[ "$FROZEN_TARGET" == "true" && -f scripts/ensure-playwright-chromium.mjs ]]; then
+            node scripts/ensure-playwright-chromium.mjs
+          else
+            echo "Target does not provide a supported Playwright Chromium installer." >&2
+            exit 1
           fi
 
       - name: Lint Control UI window.open usage
@@ -1526,8 +1536,7 @@ jobs:
           sticky-disk: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.run_attempt > 1)) && 'false' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'true' || 'false') }}
           use-actions-cache: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.run_attempt > 1)) && 'true' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'false' || 'true') }}
 
-      - name: Install Playwright Chromium
-        run: node --import tsx scripts/ensure-playwright-chromium.mts
+      - *install_playwright_chromium
 
       - name: Test Control UI end-to-end
         run: >-
@@ -1563,8 +1572,7 @@ jobs:
           sticky-disk: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.run_attempt > 1)) && 'false' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'true' || 'false') }}
           use-actions-cache: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.run_attempt > 1)) && 'true' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'false' || 'true') }}
 
-      - name: Install Playwright Chromium
-        run: node --import tsx scripts/ensure-playwright-chromium.mts
+      - *install_playwright_chromium
 
       - name: Test MCP app conformance with a real Gateway
         run: >-
@@ -2279,6 +2287,7 @@ jobs:
 
       - name: Run check shard
         env:
+          FROZEN_TARGET: ${{ needs.preflight.outputs.frozen_target }}
           HISTORICAL_TARGET: ${{ needs.preflight.outputs.compatibility_target }}
           FORMAT_CHECK: ${{ needs.preflight.outputs.run_format_check }}
           RUN_CONTROL_UI_I18N: ${{ needs.preflight.outputs.run_control_ui_i18n }}
@@ -2298,10 +2307,10 @@ jobs:
           case "$TASK" in
             guards)
               pnpm check:no-conflict-markers
-              if [[ "$HISTORICAL_TARGET" == "true" ]]; then
-                echo "[skip] historical target skips the wall-clock doctor deprecation registry guard"
-              elif has_package_script "check:doctor-deprecation-registry"; then
+              if has_package_script "check:doctor-deprecation-registry"; then
                 pnpm check:doctor-deprecation-registry
+              elif [[ "$FROZEN_TARGET" == "true" ]]; then
+                echo "[skip] frozen target predates the wall-clock doctor deprecation registry guard"
               else
                 echo "Current CI targets must provide the check:doctor-deprecation-registry package script." >&2
                 exit 1

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4550,13 +4550,20 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(preflightGuards).toContain('has_package_script "check:doctor-deprecation-registry"');
     expect(preflightGuards).toContain("pnpm check:doctor-deprecation-registry");
     expect(preflightGuards).toContain(
-      "[skip] historical target skips the wall-clock doctor deprecation registry guard",
+      "[skip] frozen target predates the wall-clock doctor deprecation registry guard",
     );
     expect(preflightGuards).toContain(
       "Current CI targets must provide the check:doctor-deprecation-registry package script.",
     );
-    expect(preflightGuards.indexOf('if [[ "$HISTORICAL_TARGET" == "true" ]]')).toBeLessThan(
+    expect(preflightGuards.indexOf('elif [[ "$FROZEN_TARGET" == "true" ]]')).toBeGreaterThan(
       preflightGuards.indexOf("pnpm check:doctor-deprecation-registry"),
+    );
+    const checkShard = parsedWorkflow.jobs["check-shard"].steps.find(
+      (step: WorkflowStep) => step.name === "Run check shard",
+    );
+    expect(checkShard.env.FROZEN_TARGET).toBe("${{ needs.preflight.outputs.frozen_target }}");
+    expect(parsedWorkflow.jobs.preflight.outputs.frozen_target).toBe(
+      "${{ steps.manifest.outputs.frozen_target }}",
     );
     expect(npmLockGuards).toContain("pnpm deps:npm-lock:check");
     expect(preflightGuards).toContain("pnpm deps:patches:check");
@@ -5017,6 +5024,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       0,
     );
     expect(frozenMissingCurrentCapabilities.outputs.historical_target).toBe("false");
+    expect(frozenMissingCurrentCapabilities.outputs.frozen_target).toBe("true");
     expect(frozenMissingCurrentCapabilities.outputs.run_ios_build).toBe("false");
     expect(frozenMissingCurrentCapabilities.outputs.run_macos_swift).toBe("false");
     expect(frozenMissingCurrentCapabilities.outputs.run_native_i18n).toBe("false");
@@ -5195,9 +5203,17 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(workflow.jobs["checks-ui"].env.COMPATIBILITY_TARGET).toBe(
       "${{ needs.preflight.outputs.compatibility_target }}",
     );
-    expect(uiInstall.run).toContain('if [[ "$COMPATIBILITY_TARGET" == "true" ]]');
+    expect(uiInstall.env.FROZEN_TARGET).toBe("${{ needs.preflight.outputs.frozen_target }}");
+    expect(uiInstall.run).toContain('if [[ "${COMPATIBILITY_TARGET:-false}" == "true" ]]');
     expect(uiInstall.run).toContain("pnpm --dir ui exec playwright install chromium");
     expect(uiInstall.run).toContain("node --import tsx scripts/ensure-playwright-chromium.mts");
+    expect(uiInstall.run).toContain(
+      'elif [[ "$FROZEN_TARGET" == "true" && -f scripts/ensure-playwright-chromium.mjs ]]',
+    );
+    expect(uiInstall.run).toContain("node scripts/ensure-playwright-chromium.mjs");
+    expect(uiInstall.run).toContain(
+      "Target does not provide a supported Playwright Chromium installer.",
+    );
     expect(uiInstall.run).not.toContain("OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM");
     expect(uiTest.run).toContain('if [[ "$COMPATIBILITY_TARGET" == "true" ]]');
     expect(uiTest.run).toContain("pnpm --dir ui test --testTimeout=30000 --isolate");
@@ -5346,7 +5362,11 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       uiE2e.steps.find((step: WorkflowStep) => step.name === "Install Playwright Chromium"),
       "Control UI E2E Chromium installation",
     );
-    expect(chromiumInstall.run).toBe("node --import tsx scripts/ensure-playwright-chromium.mts");
+    expect(chromiumInstall.env.FROZEN_TARGET).toBe("${{ needs.preflight.outputs.frozen_target }}");
+    expect(chromiumInstall.run).toContain(
+      "node --import tsx scripts/ensure-playwright-chromium.mts",
+    );
+    expect(chromiumInstall.run).toContain("node scripts/ensure-playwright-chromium.mjs");
     const realGatewayChromiumInstall = expectDefined(
       uiE2eRealGateway.steps.find(
         (step: WorkflowStep) => step.name === "Install Playwright Chromium",


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation run https://github.com/openclaw/openclaw/actions/runs/31354472508 dispatched current CI against frozen candidate `da4e341b070b54c9fd3639453f88708eae226bf0`. The target predates two current workflow contracts:

- its Playwright Chromium helper is `scripts/ensure-playwright-chromium.mjs`, while current CI invoked only the renamed `.mts` entrypoint;
- it has no `check:doctor-deprecation-registry` package script, while current CI treated the absent current-only guard as fatal.

## Why This Change Was Made

The CI preflight now exposes its existing exact-SHA `frozenTarget` fact. UI jobs reuse one installer step that keeps `.mts` mandatory for current targets while accepting the candidate-owned `.mjs` entrypoint only for frozen dispatches. The doctor registry guard still runs whenever present and remains mandatory for current targets; only a frozen target that predates the script may skip it.

iOS, UI runtime behavior, release budgets, and product code are unchanged.

## User Impact

Maintainers can validate an immutable prerelease SHA with newer trusted workflow code without renaming scripts inside the candidate or weakening current-main CI contracts.

## Evidence

- Original normal-CI child failure: https://github.com/openclaw/openclaw/actions/runs/31354500443
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` - 112 passed, 2 skipped
- `node scripts/check-workflows.mts` - passed
- `pnpm format .github/workflows/ci.yml test/scripts/ci-workflow-guards.test.ts` - passed
- `git diff --check` - passed
- Signed commit: `c918064a4cdc1fdf97dfa46282b24b354d4276cc`
