### PR TITLE
fix: configured context engine silently falls back to legacy on every fresh turn

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -353,6 +353,30 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(openSpy).not.toHaveBeenCalled();
   });
 
+  it("starts a fresh turn before the post-start mirror records admission", async () => {
+    const workspaceDir = path.join(tempDir, "workspace-fresh-admission");
+    const params = await createSqliteParams(workspaceDir, "fresh-admission");
+    params.contextEngine = createContextEngine();
+    const recorder = params.userTurnTranscriptRecorder;
+    if (!recorder) {
+      throw new Error("expected user turn transcript recorder");
+    }
+    const markRuntimePersisted = vi.fn();
+    recorder.markRuntimePersisted = markRuntimePersisted;
+    recorder.markSentToProvider = vi.fn(() => {
+      throw new Error("admission is not available before Codex turn/start");
+    });
+    const harness = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+
+    expect(recorder.markSentToProvider).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(markRuntimePersisted).toHaveBeenCalledOnce());
+    await harness.completeTurn();
+    await run;
+  });
+
   it("keeps context-engine history bound to the run session when sandbox key differs", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -1679,6 +1679,8 @@ export async function prepareCliRunContext(
         admission: params.userTurnTranscriptRecorder?.getAdmissionReceipt(),
         isHeartbeat: isHeartbeatLifecycleRunKind(params.bootstrapContextRunKind),
         lease: params.contextEngineLogicalTurnLease,
+        recorder: params.userTurnTranscriptRecorder,
+        sessionTarget: params.sessionTarget,
       });
       resolvedContextEngine = params.contextEngineLogicalTurnLease.begin().engine;
     } else {

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -2900,7 +2900,7 @@ describe("CLI attempt execution", () => {
     expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
   });
 
-  it("stamps CLI prompts with current timestamp context", async () => {
+  it("stamps CLI prompts and forwards the transcript target", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-06-05T15:30:00Z"));
     const sessionKey = "agent:main:direct:claude-timestamp";
@@ -2919,6 +2919,12 @@ describe("CLI attempt execution", () => {
         storePath,
       }),
     });
+    const sessionTarget = {
+      agentId: "main",
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      storePath,
+    };
     await runStoredAttempt({
       providerOverride: "claude-cli",
       modelOverride: "opus",
@@ -2930,6 +2936,7 @@ describe("CLI attempt execution", () => {
       runId: "run-cli-timestamp",
       messageChannel: "discord",
       sessionStore,
+      sessionTarget,
       userTurnTranscriptRecorder,
     });
 
@@ -2938,6 +2945,7 @@ describe("CLI attempt execution", () => {
       transcriptPrompt: "canonical timestamp question",
       imagePrompt: "what time is it?",
       userTurnTranscriptRecorder,
+      sessionTarget,
       suppressNextUserMessagePersistence: false,
     });
   });

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -22,6 +22,7 @@ import { messageToolOwnsVisibleReply } from "../../auto-reply/source-reply-deliv
 import type { ThinkLevel, VerboseLevel } from "../../auto-reply/thinking.js";
 import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
 import { persistSessionTranscriptTurn } from "../../config/sessions/session-accessor.js";
+import type { SessionTranscriptRuntimeTarget } from "../../config/sessions/session-accessor.types.js";
 import { readTailAssistantTextFromSessionTranscript } from "../../config/sessions/transcript.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -82,7 +83,6 @@ import { resolveCliRuntimeExecutionProvider } from "../model-runtime-aliases.js"
 import { isCliProvider } from "../model-selection.js";
 import { resolveOpenAIRuntimeProvider } from "../openai-routing.js";
 import { hasVerifiedRequesterCompletionHandoff } from "../requester-tool-policy.js";
-import type { AgentRunSessionTarget } from "../run-session-target.js";
 import { resolveAgentRunAbortLifecycleFields } from "../run-termination.js";
 import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
 import type { AgentMessage } from "../runtime/index.js";
@@ -527,7 +527,7 @@ export function runAgentAttempt(params: {
   agentHarnessRuntimeOverride?: string;
   sessionId: string;
   sessionKey: string | undefined;
-  sessionTarget?: AgentRunSessionTarget;
+  sessionTarget?: SessionTranscriptRuntimeTarget;
   sessionAgentId: string;
   sessionFile: string;
   workspaceDir: string;
@@ -939,6 +939,7 @@ export function runAgentAttempt(params: {
           runCliAgent({
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
+            sessionTarget: params.sessionTarget,
             sessionEntry: params.sessionEntry,
             chatType: params.sessionEntry?.chatType,
             agentId: params.sessionAgentId,

--- a/src/agents/embedded-agent-runner/run-entry.ts
+++ b/src/agents/embedded-agent-runner/run-entry.ts
@@ -356,7 +356,6 @@ export async function runEmbeddedAgentEntry<T extends EmbeddedAgentRunResult>(
               host,
               operation: "agent-run",
               requiresDurableCommit: false,
-              hasAdmissionFence: false,
             });
           } catch {
             contextEngineLogicalTurnLease.degradeBeforeStart(

--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -294,6 +294,8 @@ export async function runPreparedEmbeddedLoop(
     admission: params.userTurnTranscriptRecorder?.getAdmissionReceipt(),
     isHeartbeat: isHeartbeatLifecycleRunKind(params.bootstrapContextRunKind),
     lease: contextEngineLogicalTurnLease,
+    recorder: params.userTurnTranscriptRecorder,
+    sessionTarget: params.sessionTarget,
   });
   const contextEngine = contextEngineLogicalTurnLease.begin().engine;
   const resolveContextEnginePluginId = () =>

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -62,6 +62,8 @@ function makeDispatchInput(
       runId: "run-1",
       timeoutMs: 30_000,
       config: {},
+      contextEngineLogicalTurnLease: { owner: "logical-turn" },
+      onContextEngineTurnCandidate: vi.fn(),
     },
     transcriptOwnership: { kind: "caller-owned", sessionManager },
     runtime: {
@@ -131,7 +133,7 @@ describe("embedded run retry dispatch", () => {
     mocks.settleRequesterAfterSessionSpawns.mockReset();
   });
 
-  it("preserves caller-owned session and unsafe replay state on the next attempt", async () => {
+  it("preserves caller-owned turn facts and unsafe replay state on the next attempt", async () => {
     const sessionManager = { owner: "caller" };
     const replayState = observeReplayMetadata(
       observeReplayMetadata(createEmbeddedRunReplayState(), {
@@ -141,10 +143,15 @@ describe("embedded run retry dispatch", () => {
       { replaySafe: true, hadPotentialSideEffects: false },
     );
 
-    const result = await dispatchEmbeddedRunAttempt(makeDispatchInput(sessionManager, replayState));
+    const input = makeDispatchInput(sessionManager, replayState);
+    const result = await dispatchEmbeddedRunAttempt(input);
 
     expect(result.preparedAttempt.sessionManager).toBe(sessionManager);
     expect(result.preparedAttempt.sessionTarget).toBeUndefined();
+    expect(result.preparedAttempt.contextEngineLogicalTurnLease).toBeUndefined();
+    expect(result.preparedAttempt.onContextEngineTurnCandidate).toBe(
+      input.params.onContextEngineTurnCandidate,
+    );
     expect(replayState).toEqual({ replayInvalid: true, hadPotentialSideEffects: true });
     expect(result.preparedAttempt.initialReplayState).toBe(replayState);
     expect(mocks.runAttempt).toHaveBeenCalledWith(result.preparedAttempt);

--- a/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
@@ -1,4 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import {
+  appendTranscriptMessage,
+  readActiveTranscriptEntryAnchor,
+  upsertSessionEntry,
+} from "../../../config/sessions/session-accessor.js";
+import { createUserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../../state/openclaw-agent-db.js";
+import { SessionManager } from "../../sessions/session-manager.js";
 
 const hoisted = vi.hoisted(() => ({
   runAgentEndSideEffects: vi.fn(),
@@ -20,11 +30,17 @@ vi.mock("./attempt.async-tasks.js", () => ({
 import { completeEmbeddedAttemptAfterTurn } from "./attempt-finalize.js";
 import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
 describe("embedded attempt phase lifecycle state", () => {
   beforeEach(() => {
     hoisted.runAgentEndSideEffects.mockReset();
     hoisted.shouldWaitForCompletionRequiredAsyncTasks.mockReset().mockReturnValue(false);
     hoisted.waitForCompletionRequiredAsyncTasks.mockReset();
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
   });
 
   it("re-reads compaction timeout state after the retry wait", async () => {
@@ -289,7 +305,58 @@ describe("embedded attempt phase lifecycle state", () => {
     });
   });
 
-  it("records embedded turn facts for the outer fallback owner", async () => {
+  it("emits the persisted terminal boundary to the outer fallback owner", async () => {
+    const dir = tempDirs.make("openclaw-attempt-terminal-anchor-");
+    const target = {
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath: path.join(dir, "sessions.json"),
+    };
+    await upsertSessionEntry(target, { sessionId: target.sessionId, updatedAt: 1 });
+    const userMessage = { role: "user" as const, content: "hello", timestamp: 1 };
+    const persistedUser = await appendTranscriptMessage(target, {
+      cwd: dir,
+      eventId: "user-1",
+      message: userMessage,
+      now: 1,
+    });
+    if (!persistedUser?.anchor) {
+      throw new Error("expected persisted user anchor");
+    }
+    const recorder = createUserTurnTranscriptRecorder({
+      message: userMessage,
+      target: async () => undefined,
+    });
+    recorder.markRuntimePersisted(userMessage, persistedUser.anchor);
+    const sessionManager = SessionManager.open(target, dir);
+    const terminalEntryId = sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "done" }],
+      api: "openai-responses",
+      provider: "openai",
+      model: "test-model",
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 2,
+    });
+    const expectedTerminalAnchor = readActiveTranscriptEntryAnchor({
+      agentId: persistedUser.anchor.agentId,
+      sessionId: persistedUser.anchor.sessionId,
+      sessionKey: persistedUser.anchor.sessionKey,
+      storePath: persistedUser.anchor.storePath,
+      entryId: terminalEntryId,
+    });
+    if (!expectedTerminalAnchor) {
+      throw new Error("expected persisted terminal anchor");
+    }
     const afterTurn = vi.fn(async () => {});
     const maintain = vi.fn(async () => ({
       changed: false,
@@ -300,12 +367,14 @@ describe("embedded attempt phase lifecycle state", () => {
     await completeEmbeddedAttemptAfterTurn({
       attempt: {
         runId: "run-1",
-        sessionId: "session-1",
-        sessionKey: "agent:main:main",
-        sessionFile: "/tmp/session.jsonl",
+        sessionId: target.sessionId,
+        sessionKey: target.sessionKey,
+        sessionTarget: target,
+        sessionFile: target.sessionKey,
         provider: "test",
         modelId: "model",
         model: { api: "openai-responses" },
+        userTurnTranscriptRecorder: recorder,
         onContextEngineTurnCandidate,
       } as never,
       activeContextEngine: {
@@ -317,12 +386,12 @@ describe("embedded attempt phase lifecycle state", () => {
         maintain,
       } as never,
       activeSession: {} as never,
-      sessionManager: { appendCustomEntry: vi.fn(), getLeafId: vi.fn(() => "terminal") } as never,
+      sessionManager,
       withOwnedTranscriptWrite: async (operation) => await operation(),
       state: {
         promptError: null,
         yieldAborted: false,
-        sessionIdUsed: "session-1",
+        sessionIdUsed: target.sessionId,
         messagesSnapshot: [{ role: "assistant", content: "done" }] as never,
         prePromptMessageCount: 0,
         contextEngineAfterTurnCheckpoint: null,
@@ -350,9 +419,16 @@ describe("embedded attempt phase lifecycle state", () => {
       },
     });
 
+    expect(onContextEngineTurnCandidate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boundary: {
+          admission: recorder.getAdmissionReceipt(),
+          terminal: expectedTerminalAnchor,
+        },
+      }),
+    );
     expect(afterTurn).not.toHaveBeenCalled();
     expect(maintain).not.toHaveBeenCalled();
-    expect(onContextEngineTurnCandidate).not.toHaveBeenCalled();
   });
 
   it("emits an abort-classified agent_end event when a teardown error races the abort", async () => {

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -268,6 +268,9 @@ export async function dispatchEmbeddedRunAttempt(input: {
     finalizePromptForResolvedTools:
       pluginHarnessPrompt === undefined ? params.finalizePromptForResolvedTools : undefined,
     userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
+    // The outer run-loop owns the begun lease; the inner attempt reports only
+    // the accepted candidate boundary to that owner.
+    onContextEngineTurnCandidate: params.onContextEngineTurnCandidate,
     skipPreparedUserTurnMessage: runtime.skipPreparedUserTurnMessage,
     currentInboundEventKind: params.currentInboundEventKind,
     currentInboundContext: params.currentInboundContext,

--- a/src/agents/harness/context-engine-logical-turn.ts
+++ b/src/agents/harness/context-engine-logical-turn.ts
@@ -31,7 +31,6 @@ export type ContextEngineLogicalTurnLease = {
     host: ContextEngineHostSupport;
     operation: ContextEngineOperation;
     requiresDurableCommit: boolean;
-    hasAdmissionFence: boolean;
   }) => EffectiveContextEngineRef;
   degradeBeforeStart: (reason: string) => EffectiveContextEngineRef;
   begin: () => EffectiveContextEngineRef;
@@ -59,7 +58,6 @@ export function selectContextEngineForTranscriptHost(params: {
     host: params.host,
     operation: params.operation,
     requiresDurableCommit: params.recorder !== undefined,
-    hasAdmissionFence: admission !== undefined,
   });
 }
 
@@ -125,7 +123,6 @@ export async function createContextEngineLogicalTurnLease(params: {
     host: ContextEngineHostSupport;
     operation: ContextEngineOperation;
     requiresDurableCommit: boolean;
-    hasAdmissionFence: boolean;
   }): string | undefined => {
     const support = evaluateContextEngineHostSupport({
       contextEngineInfo: effective.engine.info,
@@ -145,7 +142,7 @@ export async function createContextEngineLogicalTurnLease(params: {
       // whether or not the receipt exists yet at selection time. Gating this on the receipt alone
       // would let an engine that declares durable advancement but omits current-turn fencing run
       // on fresh turns, which the documented contract sends to legacy.
-      (selection.hasAdmissionFence || selection.requiresDurableCommit) &&
+      selection.requiresDurableCommit &&
       effective.engine.info.transcriptSemantics?.currentTurnFence !== "before-current-turn-entry-v1"
     ) {
       return "current-turn transcript fencing is not declared";

--- a/src/agents/harness/context-engine-logical-turn.ts
+++ b/src/agents/harness/context-engine-logical-turn.ts
@@ -141,7 +141,11 @@ export async function createContextEngineLogicalTurnLease(params: {
       return undefined;
     }
     if (
-      selection.hasAdmissionFence &&
+      // A recorder-backed turn will be admitted during the run, so the declaration is required
+      // whether or not the receipt exists yet at selection time. Gating this on the receipt alone
+      // would let an engine that declares durable advancement but omits current-turn fencing run
+      // on fresh turns, which the documented contract sends to legacy.
+      (selection.hasAdmissionFence || selection.requiresDurableCommit) &&
       effective.engine.info.transcriptSemantics?.currentTurnFence !== "before-current-turn-entry-v1"
     ) {
       return "current-turn transcript fencing is not declared";

--- a/src/agents/harness/context-engine-logical-turn.ts
+++ b/src/agents/harness/context-engine-logical-turn.ts
@@ -43,10 +43,14 @@ export function selectContextEngineForTranscriptHost(params: {
   lease: ContextEngineLogicalTurnLease;
   host: ContextEngineHostSupport;
   operation: ContextEngineOperation;
-  recorder: Pick<UserTurnTranscriptRecorder, "getAdmissionReceipt"> | undefined;
+  recorder: Pick<UserTurnTranscriptRecorder, "getAdmissionReceipt" | "hasPersisted"> | undefined;
 }): EffectiveContextEngineRef {
   const admission = params.recorder?.getAdmissionReceipt();
-  if (params.recorder && !admission) {
+  // Selection runs during turn preparation, before the user turn is written, so an admitted
+  // receipt does not exist yet on the paths that persist during the run. A receipt is only
+  // owed once the turn has actually been persisted: until then there is no admitted entry for
+  // the fence to anchor to, so there is nothing to degrade over.
+  if (params.recorder && !admission && params.recorder.hasPersisted()) {
     return params.lease.degradeBeforeStart(
       "current-turn transcript admission receipt is unavailable",
     );

--- a/src/agents/harness/context-engine-turn-attempt.ts
+++ b/src/agents/harness/context-engine-turn-attempt.ts
@@ -9,6 +9,7 @@ import type {
   ContextEngineRuntimeSettings,
   ContextEngineSessionTarget,
 } from "../../context-engine/types.js";
+import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.types.js";
 import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import type { ContextEngineLogicalTurnLease } from "./context-engine-logical-turn.js";
 import {
@@ -54,10 +55,12 @@ export async function drainPendingContextEngineTurnsBeforeRun(params: {
   admission: TranscriptTurnBoundary["admission"] | undefined;
   isHeartbeat?: boolean;
   lease: ContextEngineLogicalTurnLease;
+  recorder?: UserTurnTranscriptRecorder;
+  sessionTarget?: ContextEngineSessionTarget;
   warn?: (message: string) => void;
 }): Promise<void> {
   if (
-    !params.admission ||
+    (!params.admission && !params.recorder) ||
     params.lease.degraded ||
     params.lease.engine.info.transcriptSemantics?.turnAdvancementIdempotency !==
       "atomic-idempotent-v1" ||
@@ -67,15 +70,22 @@ export async function drainPendingContextEngineTurnsBeforeRun(params: {
   }
   const warn = params.warn ?? console.warn;
   try {
+    const target = params.admission ?? params.sessionTarget;
+    if (!target?.agentId || !target.sessionId || !target.storePath) {
+      params.lease.degradeBeforeStart(
+        "durable transcript target is unavailable before context assembly",
+      );
+      return;
+    }
     const database = openOpenClawAgentDatabase({
-      agentId: params.admission.agentId,
-      path: params.admission.storePath,
+      agentId: target.agentId,
+      path: target.storePath,
     });
     recoverContextEngineTurnOutbox({
-      currentAdmission: params.admission,
       database,
       engineId: params.lease.effectiveEngineId,
       ownerPluginId: params.lease.effectiveEnginePluginId,
+      sessionId: target.sessionId,
       warn,
     });
     const result = await drainContextEngineTurnOutbox({
@@ -83,7 +93,7 @@ export async function drainPendingContextEngineTurnsBeforeRun(params: {
       engine: params.lease.engine,
       engineId: params.lease.effectiveEngineId,
       ownerPluginId: params.lease.effectiveEnginePluginId,
-      sessionId: params.admission.sessionId,
+      sessionId: target.sessionId,
       warn,
     });
     if (result.pending) {
@@ -92,15 +102,33 @@ export async function drainPendingContextEngineTurnsBeforeRun(params: {
       );
       return;
     }
-    // Persist the admission before provider dispatch. A later run can recover an accepted
-    // transcript if this process dies before finalization updates the row.
-    enqueueContextEngineTurnIntent({
-      admission: params.admission,
-      database,
-      engineId: params.lease.effectiveEngineId,
-      isHeartbeat: params.isHeartbeat === true,
-      ownerPluginId: params.lease.effectiveEnginePluginId,
-    });
+    const enqueueAdmission = (admission: TranscriptTurnBoundary["admission"]) => {
+      if (
+        admission.agentId !== target.agentId ||
+        admission.sessionId !== target.sessionId ||
+        admission.storePath !== target.storePath
+      ) {
+        throw new Error("context-engine transcript target changed before provider dispatch");
+      }
+      enqueueContextEngineTurnIntent({
+        admission,
+        database,
+        engineId: params.lease.effectiveEngineId,
+        isHeartbeat: params.isHeartbeat === true,
+        ownerPluginId: params.lease.effectiveEnginePluginId,
+      });
+    };
+    if (params.admission) {
+      enqueueAdmission(params.admission);
+      return;
+    }
+    if (!params.recorder?.setAdmissionHandler) {
+      params.lease.degradeBeforeStart(
+        "current-turn transcript admission cannot be recorded for durable advancement",
+      );
+      return;
+    }
+    params.recorder.setAdmissionHandler(enqueueAdmission);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     warn(`[context-engine] failed to retry pending turn advancement: ${message}`);

--- a/src/agents/harness/context-engine-turn-attempt.ts
+++ b/src/agents/harness/context-engine-turn-attempt.ts
@@ -1,5 +1,6 @@
 import {
   readClosedTranscriptTurn,
+  resolveSessionTranscriptDatabasePath,
   type TranscriptTurnBoundary,
 } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -71,15 +72,23 @@ export async function drainPendingContextEngineTurnsBeforeRun(params: {
   const warn = params.warn ?? console.warn;
   try {
     const target = params.admission ?? params.sessionTarget;
-    if (!target?.agentId || !target.sessionId || !target.storePath) {
+    if (!target?.agentId || !target.sessionId || !target.sessionKey || !target.storePath) {
       params.lease.degradeBeforeStart(
         "durable transcript target is unavailable before context assembly",
       );
       return;
     }
+    const databasePath = params.admission
+      ? params.admission.storePath
+      : resolveSessionTranscriptDatabasePath({
+          agentId: target.agentId,
+          sessionId: target.sessionId,
+          sessionKey: target.sessionKey,
+          storePath: target.storePath,
+        });
     const database = openOpenClawAgentDatabase({
       agentId: target.agentId,
-      path: target.storePath,
+      path: databasePath,
     });
     recoverContextEngineTurnOutbox({
       database,
@@ -106,7 +115,8 @@ export async function drainPendingContextEngineTurnsBeforeRun(params: {
       if (
         admission.agentId !== target.agentId ||
         admission.sessionId !== target.sessionId ||
-        admission.storePath !== target.storePath
+        admission.sessionKey !== target.sessionKey ||
+        admission.storePath !== databasePath
       ) {
         throw new Error("context-engine transcript target changed before provider dispatch");
       }

--- a/src/agents/harness/context-engine-turn-outbox.test.ts
+++ b/src/agents/harness/context-engine-turn-outbox.test.ts
@@ -239,7 +239,7 @@ describe("context-engine turn outbox", () => {
       isHeartbeat: false,
       lease,
       recorder,
-      sessionTarget: { ...target, storePath: admission.storePath },
+      sessionTarget: target,
     });
 
     expect(commitTurn).toHaveBeenCalledOnce();

--- a/src/agents/harness/context-engine-turn-outbox.test.ts
+++ b/src/agents/harness/context-engine-turn-outbox.test.ts
@@ -11,6 +11,7 @@ import type {
   TranscriptTurnBoundary,
 } from "../../config/sessions/transcript-entry-anchor.js";
 import type { ContextEngine } from "../../context-engine/types.js";
+import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -137,7 +138,7 @@ describe("context-engine turn outbox", () => {
     ).toBeUndefined();
   });
 
-  it("recovers an accepted terminal transcript when finalization crashed", async () => {
+  it("drains prior work before fresh-turn assembly and records dispatch admission", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-context-outbox-recovery-"));
     tempDirs.push(stateDir);
     const target = {
@@ -199,6 +200,11 @@ describe("context-engine turn outbox", () => {
       logicalTurnId: "current-logical-turn",
       role: "user" as const,
     } satisfies TranscriptTurnAdmission;
+    const currentMessage = { role: "user" as const, content: "second", timestamp: 3_000 };
+    const recorder = createUserTurnTranscriptRecorder({
+      message: currentMessage,
+      target: async () => undefined,
+    });
     const commitTurn = vi.fn(async () => ({ status: "committed" as const }));
     const engine = {
       info: {
@@ -229,9 +235,11 @@ describe("context-engine turn outbox", () => {
     } satisfies ContextEngineLogicalTurnLease;
 
     await drainPendingContextEngineTurnsBeforeRun({
-      admission: currentAdmission,
+      admission: undefined,
       isHeartbeat: false,
       lease,
+      recorder,
+      sessionTarget: { ...target, storePath: admission.storePath },
     });
 
     expect(commitTurn).toHaveBeenCalledOnce();
@@ -246,6 +254,11 @@ describe("context-engine turn outbox", () => {
         prePromptMessageCount: 0,
       }),
     );
+    expect(
+      database.db.prepare("SELECT advancement_key FROM context_engine_turn_outbox").all(),
+    ).toHaveLength(0);
+
+    recorder.markRuntimePersisted(currentMessage, currentAdmission);
     const queued = database.db
       .prepare("SELECT advancement_key, payload_json FROM context_engine_turn_outbox")
       .all() as Array<{ advancement_key: string; payload_json: string }>;
@@ -255,6 +268,9 @@ describe("context-engine turn outbox", () => {
       state: "admitted",
       isHeartbeat: false,
     });
+    expect(lease.degradeBeforeStart).not.toHaveBeenCalled();
+
+    await drainPendingContextEngineTurnsBeforeRun({ admission: undefined, lease });
     expect(lease.degradeBeforeStart).not.toHaveBeenCalled();
   });
 
@@ -383,9 +399,9 @@ describe("context-engine turn outbox", () => {
     const warn = vi.fn();
 
     recoverContextEngineTurnOutbox({
-      currentAdmission: payload.boundary.admission,
       database,
       engineId: "test",
+      sessionId: payload.boundary.admission.sessionId,
       warn,
     });
 

--- a/src/agents/harness/context-engine-turn-outbox.ts
+++ b/src/agents/harness/context-engine-turn-outbox.ts
@@ -256,10 +256,10 @@ export function discardContextEngineTurnIntent(params: {
 }
 
 export function recoverContextEngineTurnOutbox(params: {
-  currentAdmission: TranscriptTurnAdmission;
   database: OpenClawAgentDatabase;
   engineId: string;
   ownerPluginId?: string;
+  sessionId: string;
   warn: (message: string) => void;
 }): void {
   const db = outboxDb(params.database);
@@ -270,7 +270,7 @@ export function recoverContextEngineTurnOutbox(params: {
       .select(["advancement_key", "payload_json"])
       .where("engine_id", "=", params.engineId)
       .where("owner_plugin_id", params.ownerPluginId ? "=" : "is", params.ownerPluginId ?? null)
-      .where("session_id", "=", params.currentAdmission.sessionId)
+      .where("session_id", "=", params.sessionId)
       .orderBy(outboxEnqueueSequence(), "asc"),
   ).rows;
   for (const row of rows) {

--- a/src/agents/harness/runtime-plugin-load-plan.ts
+++ b/src/agents/harness/runtime-plugin-load-plan.ts
@@ -1,10 +1,11 @@
-/** Builds deterministic plugin load plans for selected native harness and memory owners. */
+/** Builds deterministic plugin load plans for selected harness, memory, and context-engine owners. */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withActivatedPluginIds } from "../../plugins/activation-context.js";
 import { resolveManifestActivationPlan } from "../../plugins/activation-planner.js";
 import {
   isTestDefaultMemorySlotDisabled,
   resolveEffectivePluginActivationState,
+  resolveSelectedContextEnginePluginId,
 } from "../../plugins/config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "../../plugins/default-enablement.js";
 import {
@@ -173,7 +174,7 @@ export function requiresAgentHarnessPluginSelection(
   );
 }
 
-/** Folds selected harness and memory owners into one deterministic plugin load plan. */
+/** Folds selected harness, memory, and context-engine owners into one deterministic load plan. */
 export function resolveAgentRuntimePluginLoadPlan(params: {
   config?: OpenClawConfig;
   workspaceDir: string;
@@ -185,11 +186,13 @@ export function resolveAgentRuntimePluginLoadPlan(params: {
     config: params.config,
     workspaceDir: params.workspaceDir,
   });
+  const contextEnginePluginId = resolveSelectedContextEnginePluginId(params.config);
+  const contextEnginePluginIds = contextEnginePluginId ? [contextEnginePluginId] : [];
   const basePluginIds = (params.basePluginIds ?? []).filter(
     (pluginId) => !restrictiveAllowlistOmitsPlugin(params.config, pluginId),
   );
-  const pluginIds = [...basePluginIds, ...memoryPluginIds];
-  const forceActivatedPluginIds = [...memoryPluginIds];
+  const pluginIds = [...basePluginIds, ...memoryPluginIds, ...contextEnginePluginIds];
+  const forceActivatedPluginIds = [...memoryPluginIds, ...contextEnginePluginIds];
   for (const selection of params.selections) {
     const runtime = resolveSelectedAgentHarnessRuntime(selection, config);
     if (!requiresAgentHarnessPluginSelection(selection, config)) {

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -73,6 +73,19 @@ describe("harness runtime plugins", () => {
     expect(plan.config?.plugins?.entries?.codex).toEqual({ enabled: true });
   });
 
+  it("includes and enables the context-engine owner in the prepared load plan", () => {
+    const plan = resolveAgentRuntimePluginLoadPlan({
+      config: { plugins: { slots: { contextEngine: "custom-context-engine" } } },
+      workspaceDir: "/tmp/workspace",
+      basePluginIds: [],
+      selections: [],
+    });
+
+    expect(plan.pluginIds).toEqual(["custom-context-engine"]);
+    expect(plan.config?.plugins?.allow).toEqual(["custom-context-engine"]);
+    expect(plan.config?.plugins?.entries?.["custom-context-engine"]).toEqual({ enabled: true });
+  });
+
   const memorySelectionCases: Array<{
     name: string;
     config: OpenClawConfig;

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -695,7 +695,13 @@ describe("runAgentHarnessAttempt", () => {
 
     expect(
       contextEngineTurnAttemptMocks.drainPendingContextEngineTurnsBeforeRun,
-    ).toHaveBeenCalledWith({ admission, isHeartbeat: false, lease });
+    ).toHaveBeenCalledWith({
+      admission,
+      isHeartbeat: false,
+      lease,
+      recorder: params.userTurnTranscriptRecorder,
+      sessionTarget: undefined,
+    });
     expect(order).toEqual(["drain", "begin", "run"]);
     expect(receivedContextEngines).toEqual([undefined]);
   });

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -547,7 +547,7 @@ async function runSelectedAgentHarnessAttempt(
         ),
       ]
     : [];
-  const pluginParams = withoutInternalHarnessAuthority(internalParams);
+  const attemptParams = withoutHarnessSetupAuthority(internalParams);
   logAgentHarnessSelection(selection, {
     provider: params.provider,
     modelId: params.modelId,
@@ -560,18 +560,20 @@ async function runSelectedAgentHarnessAttempt(
       // trusted setup authority and must survive ordinary deny-all policy.
       const hostOpenClawAuthority =
         isHostScopedAgentToolActive("openclaw") &&
-        isSystemAgentOnlyAllowlist(pluginParams.toolsAllow);
+        isSystemAgentOnlyAllowlist(attemptParams.toolsAllow);
       const preparedParams =
-        harness.id === "openclaw" ? pluginParams : preparePluginHarnessParams(pluginParams);
-      const attemptParams =
+        harness.id === "openclaw"
+          ? attemptParams
+          : preparePluginHarnessParams(withoutInternalHarnessAuthority(attemptParams));
+      const authorizedParams =
         hostOpenClawAuthority && preparedParams.pluginHarnessToolPolicyRestricted
           ? { ...preparedParams, pluginHarnessToolPolicyRestricted: false }
           : preparedParams;
       assertPluginHarnessConversationToolPolicySupport(
         harness,
-        attemptParams.pluginHarnessToolPolicyRestricted === true,
+        authorizedParams.pluginHarnessToolPolicyRestricted === true,
       );
-      return runAgentHarnessLifecycleAttempt(harness, attemptParams);
+      return runAgentHarnessLifecycleAttempt(harness, authorizedParams);
     }),
   );
   const admission = internalParams.userTurnTranscriptRecorder?.getAdmissionReceipt();
@@ -668,15 +670,21 @@ function isSystemAgentOnlyAllowlist(toolsAllow: readonly string[] | undefined): 
   return toolsAllow?.length === 1 && normalizeToolName(toolsAllow[0] ?? "") === "openclaw";
 }
 
-function withoutInternalHarnessAuthority(
+function withoutHarnessSetupAuthority(
   params: EmbeddedRunAttemptParams & { systemAgentTool?: SystemAgentToolOptions },
 ): EmbeddedRunAttemptParams {
   const {
     contextEngineLogicalTurnLease: _contextEngineLogicalTurnLease,
-    onContextEngineTurnCandidate: _onContextEngineTurnCandidate,
     systemAgentTool: _systemAgentTool,
-    ...pluginParams
+    ...attemptParams
   } = params;
+  return attemptParams;
+}
+
+function withoutInternalHarnessAuthority(
+  params: EmbeddedRunAttemptParams,
+): EmbeddedRunAttemptParams {
+  const { onContextEngineTurnCandidate: _onContextEngineTurnCandidate, ...pluginParams } = params;
   return pluginParams;
 }
 

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -528,6 +528,8 @@ async function runSelectedAgentHarnessAttempt(
       admission: internalParams.userTurnTranscriptRecorder?.getAdmissionReceipt(),
       isHeartbeat: isHeartbeatLifecycleRunKind(internalParams.bootstrapContextRunKind),
       lease: internalParams.contextEngineLogicalTurnLease,
+      recorder: internalParams.userTurnTranscriptRecorder,
+      sessionTarget: internalParams.sessionTarget,
     });
     const effective = internalParams.contextEngineLogicalTurnLease.begin();
     internalParams = {

--- a/src/agents/runtime-plugins.context-engine.integration.test.ts
+++ b/src/agents/runtime-plugins.context-engine.integration.test.ts
@@ -1,0 +1,77 @@
+// Verifies prepared agent turns retain runtime context-engine registrations from Gateway startup.
+import { afterAll, afterEach, expect, it } from "vitest";
+import { loadAndActivateRootPluginRegistry } from "../plugins/loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makeTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import { createContextEngineLogicalTurnLease } from "./harness/context-engine-logical-turn.js";
+import { loadAgentRuntimePluginRegistryHandle } from "./runtime-plugins.js";
+
+afterEach(() => {
+  resetPluginLoaderTestStateForTest();
+});
+
+afterAll(() => {
+  cleanupPluginLoaderFixturesForTest();
+});
+
+it("keeps the configured context engine active in a prepared turn", async () => {
+  useNoBundledPlugins();
+  const engineId = "prepared-context-engine";
+  const extraPluginId = "prepared-extra-plugin";
+  const plugin = writePlugin({
+    id: engineId,
+    body: `module.exports = {
+      id: ${JSON.stringify(engineId)},
+      register(api) {
+        api.registerContextEngine(${JSON.stringify(engineId)}, () => ({
+          info: { id: ${JSON.stringify(engineId)}, name: "Prepared Context Engine" },
+          async ingest() { return { ingested: false }; },
+          async assemble({ messages }) { return { messages, estimatedTokens: 0 }; },
+          async compact() { return { ok: true, compacted: false }; },
+        }));
+      },
+    };\n`,
+  });
+  const extraPlugin = writePlugin({
+    id: extraPluginId,
+    body: `module.exports = { id: ${JSON.stringify(extraPluginId)}, register() {} };\n`,
+  });
+  const config = {
+    plugins: {
+      allow: [engineId, extraPluginId],
+      load: { paths: [plugin.file, extraPlugin.file] },
+      entries: {
+        [engineId]: { enabled: true },
+        [extraPluginId]: { enabled: true },
+      },
+      slots: { contextEngine: engineId },
+    },
+  };
+
+  const activeRegistry = loadAndActivateRootPluginRegistry({
+    cache: false,
+    config,
+    workspaceDir: makeTempDir(),
+    onlyPluginIds: [engineId],
+  });
+  const preparedRegistry = loadAgentRuntimePluginRegistryHandle({
+    basePluginIds: [engineId, extraPluginId],
+    config,
+    workspaceDir: makeTempDir(),
+  });
+
+  expect(preparedRegistry).not.toBe(activeRegistry);
+  expect(preparedRegistry.plugins.some((entry) => entry.id === extraPluginId)).toBe(true);
+  await withPluginRuntimeRegistryScope(preparedRegistry, async () => {
+    const lease = await createContextEngineLogicalTurnLease({ config, workspaceDir: plugin.dir });
+    expect(lease.degraded).toBe(false);
+    expect(lease.effectiveEngineId).toBe(engineId);
+    await lease.dispose();
+  });
+});

--- a/src/agents/runtime-plugins.context-engine.integration.test.ts
+++ b/src/agents/runtime-plugins.context-engine.integration.test.ts
@@ -1,4 +1,4 @@
-// Verifies prepared agent turns retain runtime context-engine registrations from Gateway startup.
+// Verifies prepared agent turns retain their selected runtime context-engine owner.
 import { afterAll, afterEach, expect, it } from "vitest";
 import { loadAndActivateRootPluginRegistry } from "../plugins/loader.js";
 import {
@@ -20,10 +20,9 @@ afterAll(() => {
   cleanupPluginLoaderFixturesForTest();
 });
 
-it("keeps the configured context engine active in a prepared turn", async () => {
+it("keeps the configured context engine active in a prepared agent registry", async () => {
   useNoBundledPlugins();
   const engineId = "prepared-context-engine";
-  const extraPluginId = "prepared-extra-plugin";
   const plugin = writePlugin({
     id: engineId,
     body: `module.exports = {
@@ -32,24 +31,17 @@ it("keeps the configured context engine active in a prepared turn", async () => 
         api.registerContextEngine(${JSON.stringify(engineId)}, () => ({
           info: { id: ${JSON.stringify(engineId)}, name: "Prepared Context Engine" },
           async ingest() { return { ingested: false }; },
-          async assemble({ messages }) { return { messages, estimatedTokens: 0 }; },
+          async assemble({ messages }) {
+            return { messages, estimatedTokens: 0, systemPromptAddition: "prepared-engine" };
+          },
           async compact() { return { ok: true, compacted: false }; },
         }));
       },
     };\n`,
   });
-  const extraPlugin = writePlugin({
-    id: extraPluginId,
-    body: `module.exports = { id: ${JSON.stringify(extraPluginId)}, register() {} };\n`,
-  });
   const config = {
     plugins: {
-      allow: [engineId, extraPluginId],
-      load: { paths: [plugin.file, extraPlugin.file] },
-      entries: {
-        [engineId]: { enabled: true },
-        [extraPluginId]: { enabled: true },
-      },
+      load: { paths: [plugin.file] },
       slots: { contextEngine: engineId },
     },
   };
@@ -61,17 +53,20 @@ it("keeps the configured context engine active in a prepared turn", async () => 
     onlyPluginIds: [engineId],
   });
   const preparedRegistry = loadAgentRuntimePluginRegistryHandle({
-    basePluginIds: [engineId, extraPluginId],
+    basePluginIds: [],
     config,
-    workspaceDir: makeTempDir(),
+    workspaceDir: plugin.dir,
   });
 
   expect(preparedRegistry).not.toBe(activeRegistry);
-  expect(preparedRegistry.plugins.some((entry) => entry.id === extraPluginId)).toBe(true);
   await withPluginRuntimeRegistryScope(preparedRegistry, async () => {
     const lease = await createContextEngineLogicalTurnLease({ config, workspaceDir: plugin.dir });
     expect(lease.degraded).toBe(false);
     expect(lease.effectiveEngineId).toBe(engineId);
+    expect(lease.effectiveEnginePluginId).toBe(engineId);
+    await expect(
+      lease.begin().engine.assemble({ messages: [], sessionId: "prepared-session" }),
+    ).resolves.toMatchObject({ systemPromptAddition: "prepared-engine" });
     await lease.dispose();
   });
 });

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -3,8 +3,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   getCurrentPluginMetadataSnapshot: vi.fn(),
+  getActivePluginRegistry: vi.fn(),
   loadPluginRegistryHandle: vi.fn(),
+  promoteMatchingRuntimeContextEngineRegistrations: vi.fn(),
   resolveAgentRuntimePluginLoadPlan: vi.fn(),
+}));
+
+vi.mock("../context-engine/registry.js", () => ({
+  promoteMatchingRuntimeContextEngineRegistrations:
+    hoisted.promoteMatchingRuntimeContextEngineRegistrations,
+}));
+
+vi.mock("../plugins/runtime.js", () => ({
+  getActivePluginRegistry: hoisted.getActivePluginRegistry,
 }));
 
 vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
@@ -24,7 +35,9 @@ import { loadAgentRuntimePluginRegistryHandle } from "./runtime-plugins.js";
 describe("agent runtime plugin registries", () => {
   beforeEach(() => {
     hoisted.getCurrentPluginMetadataSnapshot.mockReset().mockReturnValue(undefined);
+    hoisted.getActivePluginRegistry.mockReset().mockReturnValue(undefined);
     hoisted.loadPluginRegistryHandle.mockReset().mockReturnValue({ handle: true });
+    hoisted.promoteMatchingRuntimeContextEngineRegistrations.mockReset();
     hoisted.resolveAgentRuntimePluginLoadPlan.mockReset().mockImplementation(({ config }) => ({
       config,
       pluginIds: ["codex", "memory-core"],
@@ -63,6 +76,19 @@ describe("agent runtime plugin registries", () => {
       workspaceDir: "/tmp/workspace",
       runtimeOptions: { allowGatewaySubagentBinding: true },
     });
+  });
+
+  it("promotes matching active context engines into the prepared registry", () => {
+    const activeRegistry = { active: true };
+    hoisted.getActivePluginRegistry.mockReturnValue(activeRegistry);
+
+    expect(
+      loadAgentRuntimePluginRegistryHandle({ config: {} as never, workspaceDir: "/tmp/workspace" }),
+    ).toEqual({ handle: true });
+    expect(hoisted.promoteMatchingRuntimeContextEngineRegistrations).toHaveBeenCalledWith(
+      { handle: true },
+      activeRegistry,
+    );
   });
 
   it("loads an explicit empty handle when plugins are globally disabled", () => {

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -44,6 +44,19 @@ describe("agent runtime plugin registries", () => {
     }));
   });
 
+  it("promotes matching active context engines into the prepared registry", () => {
+    const activeRegistry = { active: true };
+    hoisted.getActivePluginRegistry.mockReturnValue(activeRegistry);
+
+    expect(
+      loadAgentRuntimePluginRegistryHandle({ config: {} as never, workspaceDir: "/tmp/workspace" }),
+    ).toEqual({ handle: true });
+    expect(hoisted.promoteMatchingRuntimeContextEngineRegistrations).toHaveBeenCalledWith(
+      { handle: true },
+      activeRegistry,
+    );
+  });
+
   it("returns a non-activating handle for a prepared runtime", () => {
     const config = {} as never;
     const env = { OPENCLAW_STATE_DIR: "/tmp/openclaw-state" };
@@ -76,19 +89,6 @@ describe("agent runtime plugin registries", () => {
       workspaceDir: "/tmp/workspace",
       runtimeOptions: { allowGatewaySubagentBinding: true },
     });
-  });
-
-  it("promotes matching active context engines into the prepared registry", () => {
-    const activeRegistry = { active: true };
-    hoisted.getActivePluginRegistry.mockReturnValue(activeRegistry);
-
-    expect(
-      loadAgentRuntimePluginRegistryHandle({ config: {} as never, workspaceDir: "/tmp/workspace" }),
-    ).toEqual({ handle: true });
-    expect(hoisted.promoteMatchingRuntimeContextEngineRegistrations).toHaveBeenCalledWith(
-      { handle: true },
-      activeRegistry,
-    );
   });
 
   it("loads an explicit empty handle when plugins are globally disabled", () => {

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -1,8 +1,10 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { promoteMatchingRuntimeContextEngineRegistrations } from "../context-engine/registry.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { loadPluginRegistryHandle } from "../plugins/loader.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
 import {
   getPluginRuntimeGatewayRequestScope,
   withPluginRuntimeRegistryScope,
@@ -56,7 +58,6 @@ function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistr
       : undefined;
   if (params.config && !normalizePluginsConfig(params.config.plugins).enabled) {
     return {
-      requiredPluginIds: [],
       loadOptions: {
         config: params.config,
         activationSourceConfig: params.config,
@@ -91,7 +92,6 @@ function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistr
     ],
   });
   return {
-    requiredPluginIds: plan.pluginIds,
     loadOptions: {
       config: plan.config,
       ...(plan.config ? { activationSourceConfig: plan.config } : {}),
@@ -113,7 +113,12 @@ export function loadAgentRuntimePluginRegistryHandle(
   params: AgentRuntimePluginRegistryParams,
 ): PluginRegistry {
   const load = resolveAgentRuntimePluginRegistryLoad(params);
-  return loadPluginRegistryHandle({ ...load.loadOptions, activate: false });
+  const pluginRegistry = loadPluginRegistryHandle({ ...load.loadOptions, activate: false });
+  const activeRegistry = getActivePluginRegistry();
+  if (activeRegistry) {
+    promoteMatchingRuntimeContextEngineRegistrations(pluginRegistry, activeRegistry);
+  }
+  return pluginRegistry;
 }
 
 /** Binds a scoped plugin generation when a direct host has no Gateway owner. */

--- a/src/agents/session-tool-result-guard.transcript-events.test.ts
+++ b/src/agents/session-tool-result-guard.transcript-events.test.ts
@@ -6,12 +6,16 @@ import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { appendTranscriptMessage } from "../config/sessions/session-accessor.js";
 import {
   onInternalSessionTranscriptUpdate,
   type InternalSessionTranscriptUpdate,
 } from "../sessions/transcript-events.js";
 import { attachRuntimeUserTurnTranscriptContext } from "../sessions/user-turn-transcript-runtime-context.js";
-import type { UserTurnTranscriptRecorder } from "../sessions/user-turn-transcript.js";
+import {
+  createUserTurnTranscriptRecorder,
+  type UserTurnTranscriptRecorder,
+} from "../sessions/user-turn-transcript.js";
 import { guardSessionManager } from "./session-tool-result-guard-wrapper.js";
 
 const listeners: Array<() => void> = [];
@@ -31,7 +35,7 @@ async function openPersistedSessionManager() {
     ...target,
     entry: { sessionId, updatedAt: Date.now() },
   });
-  return { sessionManager: SessionManager.open(target, root), target };
+  return { root, sessionManager: SessionManager.open(target, root), target };
 }
 
 afterEach(() => {
@@ -43,6 +47,49 @@ afterEach(() => {
 });
 
 describe("guardSessionManager transcript updates", () => {
+  it("records the admission anchor when adopting an ingress-persisted user", async () => {
+    const { root, target } = await openPersistedSessionManager();
+    const message = {
+      role: "user" as const,
+      content: "canonical prompt",
+      idempotencyKey: "canonical-run:user",
+      timestamp: Date.now(),
+    };
+    await appendTranscriptMessage(target, {
+      cwd: root,
+      eventId: "ingress-persisted-user",
+      message,
+      now: message.timestamp,
+    });
+    const recorder = createUserTurnTranscriptRecorder({
+      message,
+      target: {
+        ...target,
+        sessionEntry: { sessionId: target.sessionId, updatedAt: message.timestamp },
+      },
+    });
+    const guarded = guardSessionManager(SessionManager.open(target, root), {
+      agentId: target.agentId,
+      sessionKey: target.sessionKey,
+      preparedUserTurnMessage: message,
+      preparedUserTurnTranscriptRecorder: recorder,
+    });
+
+    expect(recorder.getAdmissionReceipt()).toBeUndefined();
+    guarded.appendMessage({ ...message });
+
+    expect(recorder.hasPersisted()).toBe(true);
+    expect(recorder.getAdmissionReceipt()).toMatchObject({
+      agentId: target.agentId,
+      sessionId: target.sessionId,
+      sessionKey: target.sessionKey,
+      storePath: target.storePath,
+      entryId: "ingress-persisted-user",
+      idempotencyKey: message.idempotencyKey,
+      role: "user",
+    });
+  });
+
   it.each(["active", "side", "setup-metadata"] as const)(
     "adopts an ingress-persisted %s-branch user without broadcasting a duplicate",
     (branch) => {

--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -1,4 +1,7 @@
-import type { TranscriptEntryAnchor } from "../../config/sessions/session-accessor.js";
+import {
+  readActiveTranscriptEntryAnchor,
+  type TranscriptEntryAnchor,
+} from "../../config/sessions/session-accessor.js";
 import { isSessionTranscriptSideAppendEntry } from "../../config/sessions/transcript-tree.js";
 import type { ImageContent, Message, TextContent } from "../../llm/types.js";
 import {
@@ -137,7 +140,16 @@ export class SessionManagerEntries extends SessionManagerPersistence {
       if (currentUserId) {
         // Session setup may insert context-free metadata after the ingress-persisted user.
         // Keep that metadata as the append parent while adopting the canonical user once.
-        return { entryId: currentUserId };
+        const anchor = this.persistenceTarget
+          ? readActiveTranscriptEntryAnchor({
+              ...this.persistenceTarget,
+              entryId: currentUserId,
+            })
+          : undefined;
+        if (this.persistenceTarget && !anchor) {
+          throw new Error(`Session transcript anchor was not returned: ${currentUserId}`);
+        }
+        return { entryId: currentUserId, ...(anchor ? { anchor } : {}) };
       }
     }
     const entry: SessionMessageEntry = {

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -87,6 +87,16 @@ export async function runCliFallbackCandidate(params: {
   bootstrapPromptWarningSignaturesSeen: string[];
 }> {
   const turn = params.turn;
+  const sessionKey = turn.sessionKey ?? turn.followupRun.run.sessionKey;
+  const sessionTarget =
+    sessionKey && turn.storePath
+      ? {
+          agentId: turn.followupRun.run.agentId,
+          sessionId: turn.followupRun.run.sessionId,
+          sessionKey,
+          storePath: turn.storePath,
+        }
+      : undefined;
   const cliSessionBinding = getCliSessionBinding(
     turn.getActiveSessionEntry(),
     params.cliExecutionProvider,
@@ -331,6 +341,7 @@ export async function runCliFallbackCandidate(params: {
           runParams: {
             sessionId: turn.followupRun.run.sessionId,
             sessionKey: turn.sessionKey,
+            sessionTarget,
             chatType:
               normalizeChatType(turn.followupRun.originatingChatType) ??
               normalizeChatType(turn.sessionCtx.ChatType) ??

--- a/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
@@ -198,6 +198,12 @@ describe("executeAgentTurn: CLI session routing", () => {
       suppressNextUserMessagePersistence: false,
       persistAssistantTranscript: true,
       storePath: "/tmp/sessions.json",
+      sessionTarget: {
+        agentId: "agent",
+        sessionId: "session",
+        sessionKey: "main",
+        storePath: "/tmp/sessions.json",
+      },
     });
     const call = requireMockCall(state.runCliAgentMock, 0, "CLI runtime");
     const callParams = requireRecord(call[0], "CLI runtime");

--- a/src/config/sessions/session-accessor.transcript-target.ts
+++ b/src/config/sessions/session-accessor.transcript-target.ts
@@ -1,7 +1,12 @@
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { resolveOpenClawAgentSqlitePath } from "../../state/openclaw-agent-db.js";
 import { getRuntimeConfig } from "../io.js";
 import { resolveStorePath } from "./paths.js";
 import { resolveSessionEntrySelection } from "./session-accessor.entry.js";
+import {
+  resolveSqliteTranscriptScope,
+  toDatabaseOptions,
+} from "./session-accessor.sqlite-scope.js";
 import type {
   SessionTranscriptReadScope,
   SessionTranscriptReadTarget,
@@ -51,6 +56,14 @@ export async function resolveSessionTranscriptRuntimeTarget(
 ): Promise<SessionTranscriptRuntimeTarget> {
   const context = resolveRuntimeContext(scope);
   return { ...context, sessionId: scope.sessionId };
+}
+
+/** Resolves the physical agent database that owns one runtime transcript. */
+export function resolveSessionTranscriptDatabasePath(
+  target: SessionTranscriptRuntimeTarget,
+): string {
+  const resolved = resolveSqliteTranscriptScope(target);
+  return resolveOpenClawAgentSqlitePath(toDatabaseOptions(resolved));
 }
 
 export { resolveSessionTranscriptRuntimeTarget as resolveSessionTranscriptRuntimeReadTarget };

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -263,6 +263,7 @@ export {
 } from "./session-accessor.sqlite-transcript-watermark.js";
 export {
   resolveConcreteSessionStorePath,
+  resolveSessionTranscriptDatabasePath,
   resolveSessionTranscriptReadTarget,
   resolveSessionTranscriptRuntimeReadTarget,
   resolveSessionTranscriptRuntimeTarget,

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -767,7 +767,6 @@ describe("Default engine selection", () => {
       host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
       operation: "agent-run" as const,
       requiresDurableCommit: true,
-      hasAdmissionFence: true,
     };
 
     const first = lease.selectForHost(selection);
@@ -1027,7 +1026,6 @@ describe("Default engine selection", () => {
       },
       operation: "agent-run",
       requiresDurableCommit: true,
-      hasAdmissionFence: true,
     });
     lease.begin();
 
@@ -1040,7 +1038,6 @@ describe("Default engine selection", () => {
         },
         operation: "agent-run",
         requiresDurableCommit: true,
-        hasAdmissionFence: true,
       }),
     ).toThrow(
       'context-engine logical turn cannot change to incompatible agent harness "fallback": host "agent-harness:fallback" is missing thread-bootstrap-projection',
@@ -1049,14 +1046,38 @@ describe("Default engine selection", () => {
     await lease.dispose();
   });
 
-  it("degrades before start when the current turn has no admission receipt", async () => {
-    const engineId = uniqueEngineId("logical-turn-admission");
+  it.each([
+    {
+      label: "persisted without a receipt",
+      persisted: true,
+      declaresFence: true,
+      expectedEngine: "legacy",
+      expectedReason: "current-turn transcript admission receipt is unavailable",
+    },
+    {
+      label: "not yet persisted",
+      persisted: false,
+      declaresFence: true,
+      expectedEngine: "configured",
+      expectedReason: undefined,
+    },
+    {
+      label: "not yet persisted without declared fencing",
+      persisted: false,
+      declaresFence: false,
+      expectedEngine: "legacy",
+      expectedReason: "current-turn transcript fencing is not declared",
+    },
+  ])("selects $expectedEngine for a turn $label", async (testCase) => {
+    const engineId = uniqueEngineId("logical-turn-recorder-state");
     registerTestContextEngine(engineId, () => ({
       info: {
         id: engineId,
-        name: "Admission Fence",
+        name: "Recorder State",
         transcriptSemantics: {
-          currentTurnFence: "before-current-turn-entry-v1",
+          ...(testCase.declaresFence
+            ? { currentTurnFence: "before-current-turn-entry-v1" as const }
+            : {}),
           turnAdvancementIdempotency: "atomic-idempotent-v1",
         },
       },
@@ -1083,106 +1104,22 @@ describe("Default engine selection", () => {
       lease,
       host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
       operation: "agent-run",
-      recorder: { getAdmissionReceipt: () => undefined, hasPersisted: () => true },
+      recorder: {
+        getAdmissionReceipt: () => undefined,
+        hasPersisted: () => testCase.persisted,
+      },
     });
     lease.begin();
 
-    expect(selected.engine.info.id).toBe("legacy");
-    expect(lease.degradedReason).toBe("current-turn transcript admission receipt is unavailable");
-    expect(warn).toHaveBeenCalledWith(
-      `[context-engine] Context engine "${engineId}" degraded to "legacy" for this logical turn: current-turn transcript admission receipt is unavailable. The "legacy" engine will handle only this turn; configuration is unchanged, and "${engineId}" will be retried next turn.`,
+    expect(selected.engine.info.id).toBe(
+      testCase.expectedEngine === "configured" ? engineId : "legacy",
     );
-    await lease.dispose();
-  });
-
-  it("keeps the configured engine when the current turn has not been persisted yet", async () => {
-    const engineId = uniqueEngineId("logical-turn-unpersisted");
-    registerTestContextEngine(engineId, () => ({
-      info: {
-        id: engineId,
-        name: "Unpersisted Turn",
-        transcriptSemantics: {
-          currentTurnFence: "before-current-turn-entry-v1",
-          turnAdvancementIdempotency: "atomic-idempotent-v1",
-        },
-      },
-      async ingest() {
-        return { ingested: true };
-      },
-      async assemble({ messages }) {
-        return { messages, estimatedTokens: 0 };
-      },
-      async compact() {
-        return { ok: true, compacted: false };
-      },
-      async commitTurn() {
-        return { status: "committed" };
-      },
-    }));
-    const warn = vi.fn();
-    const lease = await createContextEngineLogicalTurnLease({
-      config: configWithSlot(engineId),
-      warn,
-    });
-
-    // Agent harnesses select during turn preparation and persist the user turn later in the
-    // run, so the recorder legitimately has neither a receipt nor a persisted message here.
-    const selected = selectContextEngineForTranscriptHost({
-      lease,
-      host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
-      operation: "agent-run",
-      recorder: { getAdmissionReceipt: () => undefined, hasPersisted: () => false },
-    });
-    lease.begin();
-
-    expect(selected.engine.info.id).toBe(engineId);
-    expect(lease.degraded).toBe(false);
-    expect(lease.degradedReason).toBeUndefined();
-    expect(warn).not.toHaveBeenCalled();
-    await lease.dispose();
-  });
-
-  it("still degrades an unpersisted turn when current-turn fencing is not declared", async () => {
-    const engineId = uniqueEngineId("logical-turn-partial-contract");
-    registerTestContextEngine(engineId, () => ({
-      info: {
-        id: engineId,
-        name: "Partial Contract",
-        // Declares durable advancement but omits currentTurnFence. Before the receipt is
-        // available this must not be allowed to slip through unvalidated.
-        transcriptSemantics: {
-          turnAdvancementIdempotency: "atomic-idempotent-v1",
-        },
-      },
-      async ingest() {
-        return { ingested: true };
-      },
-      async assemble({ messages }) {
-        return { messages, estimatedTokens: 0 };
-      },
-      async compact() {
-        return { ok: true, compacted: false };
-      },
-      async commitTurn() {
-        return { status: "committed" };
-      },
-    }));
-    const warn = vi.fn();
-    const lease = await createContextEngineLogicalTurnLease({
-      config: configWithSlot(engineId),
-      warn,
-    });
-
-    const selected = selectContextEngineForTranscriptHost({
-      lease,
-      host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
-      operation: "agent-run",
-      recorder: { getAdmissionReceipt: () => undefined, hasPersisted: () => false },
-    });
-    lease.begin();
-
-    expect(selected.engine.info.id).toBe("legacy");
-    expect(lease.degradedReason).toBe("current-turn transcript fencing is not declared");
+    expect(lease.degradedReason).toBe(testCase.expectedReason);
+    if (testCase.expectedReason) {
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(testCase.expectedReason));
+    } else {
+      expect(warn).not.toHaveBeenCalled();
+    }
     await lease.dispose();
   });
 });

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -1141,6 +1141,50 @@ describe("Default engine selection", () => {
     expect(warn).not.toHaveBeenCalled();
     await lease.dispose();
   });
+
+  it("still degrades an unpersisted turn when current-turn fencing is not declared", async () => {
+    const engineId = uniqueEngineId("logical-turn-partial-contract");
+    registerTestContextEngine(engineId, () => ({
+      info: {
+        id: engineId,
+        name: "Partial Contract",
+        // Declares durable advancement but omits currentTurnFence. Before the receipt is
+        // available this must not be allowed to slip through unvalidated.
+        transcriptSemantics: {
+          turnAdvancementIdempotency: "atomic-idempotent-v1",
+        },
+      },
+      async ingest() {
+        return { ingested: true };
+      },
+      async assemble({ messages }) {
+        return { messages, estimatedTokens: 0 };
+      },
+      async compact() {
+        return { ok: true, compacted: false };
+      },
+      async commitTurn() {
+        return { status: "committed" };
+      },
+    }));
+    const warn = vi.fn();
+    const lease = await createContextEngineLogicalTurnLease({
+      config: configWithSlot(engineId),
+      warn,
+    });
+
+    const selected = selectContextEngineForTranscriptHost({
+      lease,
+      host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
+      operation: "agent-run",
+      recorder: { getAdmissionReceipt: () => undefined, hasPersisted: () => false },
+    });
+    lease.begin();
+
+    expect(selected.engine.info.id).toBe("legacy");
+    expect(lease.degradedReason).toBe("current-turn transcript fencing is not declared");
+    await lease.dispose();
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -749,7 +749,7 @@ describe("Default engine selection", () => {
       lease,
       host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
       operation: "agent-run",
-      recorder: { getAdmissionReceipt: () => admission },
+      recorder: { getAdmissionReceipt: () => admission, hasPersisted: () => true },
     });
 
     expect(selected).toMatchObject({ registeredId: "legacy", mode: "configured" });
@@ -788,7 +788,7 @@ describe("Default engine selection", () => {
       lease,
       host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
       operation: "agent-run" as const,
-      recorder: { getAdmissionReceipt: () => undefined },
+      recorder: { getAdmissionReceipt: () => undefined, hasPersisted: () => true },
     };
 
     const first = selectContextEngineForTranscriptHost(selection);
@@ -811,7 +811,7 @@ describe("Default engine selection", () => {
         lease,
         host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
         operation: "agent-run",
-        recorder: { getAdmissionReceipt: () => undefined },
+        recorder: { getAdmissionReceipt: () => undefined, hasPersisted: () => true },
       }),
     ).toThrow("context-engine logical turn selection is already pinned");
   });
@@ -931,7 +931,7 @@ describe("Default engine selection", () => {
       lease,
       host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
       operation: "agent-run",
-      recorder: { getAdmissionReceipt: testAdmissionReceipt },
+      recorder: { getAdmissionReceipt: testAdmissionReceipt, hasPersisted: () => true },
     });
 
     expect(selected).toMatchObject({ registeredId: "legacy", mode: "legacy-degraded" });
@@ -1083,7 +1083,7 @@ describe("Default engine selection", () => {
       lease,
       host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
       operation: "agent-run",
-      recorder: { getAdmissionReceipt: () => undefined },
+      recorder: { getAdmissionReceipt: () => undefined, hasPersisted: () => true },
     });
     lease.begin();
 
@@ -1092,6 +1092,53 @@ describe("Default engine selection", () => {
     expect(warn).toHaveBeenCalledWith(
       `[context-engine] Context engine "${engineId}" degraded to "legacy" for this logical turn: current-turn transcript admission receipt is unavailable. The "legacy" engine will handle only this turn; configuration is unchanged, and "${engineId}" will be retried next turn.`,
     );
+    await lease.dispose();
+  });
+
+  it("keeps the configured engine when the current turn has not been persisted yet", async () => {
+    const engineId = uniqueEngineId("logical-turn-unpersisted");
+    registerTestContextEngine(engineId, () => ({
+      info: {
+        id: engineId,
+        name: "Unpersisted Turn",
+        transcriptSemantics: {
+          currentTurnFence: "before-current-turn-entry-v1",
+          turnAdvancementIdempotency: "atomic-idempotent-v1",
+        },
+      },
+      async ingest() {
+        return { ingested: true };
+      },
+      async assemble({ messages }) {
+        return { messages, estimatedTokens: 0 };
+      },
+      async compact() {
+        return { ok: true, compacted: false };
+      },
+      async commitTurn() {
+        return { status: "committed" };
+      },
+    }));
+    const warn = vi.fn();
+    const lease = await createContextEngineLogicalTurnLease({
+      config: configWithSlot(engineId),
+      warn,
+    });
+
+    // Agent harnesses select during turn preparation and persist the user turn later in the
+    // run, so the recorder legitimately has neither a receipt nor a persisted message here.
+    const selected = selectContextEngineForTranscriptHost({
+      lease,
+      host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
+      operation: "agent-run",
+      recorder: { getAdmissionReceipt: () => undefined, hasPersisted: () => false },
+    });
+    lease.begin();
+
+    expect(selected.engine.info.id).toBe(engineId);
+    expect(lease.degraded).toBe(false);
+    expect(lease.degradedReason).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
     await lease.dispose();
   });
 });

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -361,7 +361,7 @@ export function registerContextEngineInRegistry(
   return { ok: true };
 }
 
-/** Preserve runtime factories when a prepared registry reloads the same plugin for discovery. */
+/** Carries runtime-safe factories into a matching non-activating prepared registry. */
 export function promoteMatchingRuntimeContextEngineRegistrations(
   targetRegistry: PluginRegistry,
   runtimeRegistry: PluginRegistry,
@@ -374,9 +374,7 @@ export function promoteMatchingRuntimeContextEngineRegistrations(
     if (!runtime || runtime.lifecycle !== "runtime" || runtime.owner !== target.owner) {
       continue;
     }
-    const pluginId = target.owner.startsWith("plugin:")
-      ? target.owner.slice("plugin:".length).trim()
-      : "";
+    const pluginId = pluginIdFromContextEngineOwner(target.owner);
     const targetPlugin = targetRegistry.plugins.find((plugin) => plugin.id === pluginId);
     const runtimePlugin = runtimeRegistry.plugins.find((plugin) => plugin.id === pluginId);
     // Same ids can come from workspace shadows. Only carry a factory across registry generations
@@ -430,11 +428,14 @@ export function resolveContextEngineOwnerPluginId(
   // Downgraded work belongs to its core-owned fallback, never the disabled plugin.
   const owner =
     metadata && !getContextEngineQuarantine(metadata.engineId) ? metadata.owner : undefined;
-  if (!owner?.startsWith("plugin:")) {
+  return owner ? pluginIdFromContextEngineOwner(owner) : undefined;
+}
+
+function pluginIdFromContextEngineOwner(owner: string): string | undefined {
+  if (!owner.startsWith("plugin:")) {
     return undefined;
   }
-  const pluginId = owner.slice("plugin:".length).trim();
-  return pluginId || undefined;
+  return owner.slice("plugin:".length).trim() || undefined;
 }
 
 function describeResolvedContextEngineContractError(
@@ -564,9 +565,7 @@ function resolvedContextEngineRef(params: {
   registeredId: string;
   owner: string;
 }): ResolvedContextEngineRef {
-  const pluginId = params.owner.startsWith("plugin:")
-    ? params.owner.slice("plugin:".length).trim()
-    : "";
+  const pluginId = pluginIdFromContextEngineOwner(params.owner);
   return Object.freeze({
     engine: params.engine,
     registeredId: params.registeredId,

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -361,6 +361,33 @@ export function registerContextEngineInRegistry(
   return { ok: true };
 }
 
+/** Preserve runtime factories when a prepared registry reloads the same plugin for discovery. */
+export function promoteMatchingRuntimeContextEngineRegistrations(
+  targetRegistry: PluginRegistry,
+  runtimeRegistry: PluginRegistry,
+): void {
+  for (const [id, target] of targetRegistry.contextEngines) {
+    if (target.lifecycle !== "readOnlyDiscovery") {
+      continue;
+    }
+    const runtime = runtimeRegistry.contextEngines.get(id);
+    if (!runtime || runtime.lifecycle !== "runtime" || runtime.owner !== target.owner) {
+      continue;
+    }
+    const pluginId = target.owner.startsWith("plugin:")
+      ? target.owner.slice("plugin:".length).trim()
+      : "";
+    const targetPlugin = targetRegistry.plugins.find((plugin) => plugin.id === pluginId);
+    const runtimePlugin = runtimeRegistry.plugins.find((plugin) => plugin.id === pluginId);
+    // Same ids can come from workspace shadows. Only carry a factory across registry generations
+    // when both registrations came from the exact same trusted plugin source.
+    if (!targetPlugin || !runtimePlugin || targetPlugin.source !== runtimePlugin.source) {
+      continue;
+    }
+    targetRegistry.contextEngines.set(id, runtime);
+  }
+}
+
 /** Clear runtime quarantine only after a complete builder-local registry becomes active. */
 export function activateContextEngineRegistrations(pluginRegistry: PluginRegistry): void {
   for (const [id, registration] of pluginRegistry.contextEngines) {

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -86,6 +86,28 @@ export const normalizePluginsConfig = (
   return normalizePluginsConfigWithResolver(config, createScopedPluginIdNormalizer());
 };
 
+/** Resolves the enabled plugin selected to own the context-engine slot. */
+export function resolveSelectedContextEnginePluginId(config?: OpenClawConfig): string | undefined {
+  const plugins = normalizePluginsConfig(config?.plugins);
+  return resolveSelectedContextEnginePluginIdFromConfig(plugins, plugins.slots.contextEngine);
+}
+
+export function resolveSelectedContextEnginePluginIdFromConfig(
+  plugins: NormalizedPluginsConfig,
+  pluginId: string | null | undefined,
+): string | undefined {
+  if (
+    !plugins.enabled ||
+    !pluginId ||
+    pluginId === defaultSlotIdForKey("contextEngine") ||
+    plugins.deny.includes(pluginId) ||
+    plugins.entries[pluginId]?.enabled === false
+  ) {
+    return undefined;
+  }
+  return pluginId;
+}
+
 /** Canonicalizes one plugin entry and its policy-list ids before a targeted mutation. */
 export function normalizePluginTargetConfig(
   config: OpenClawConfig,

--- a/src/plugins/effective-plugin-ids.ts
+++ b/src/plugins/effective-plugin-ids.ts
@@ -13,12 +13,11 @@ import {
   loadGatewayStartupPluginPlan,
   resolveConfiguredChannelPluginIds,
 } from "./channel-plugin-ids.js";
-import { normalizePluginsConfig } from "./config-state.js";
+import { normalizePluginsConfig, resolveSelectedContextEnginePluginId } from "./config-state.js";
 import { loadManifestMetadataSnapshot } from "./manifest-contract-eligibility.js";
 import { passesManifestOwnerBasePolicy } from "./manifest-owner-policy.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
-import { defaultSlotIdForKey } from "./slots.js";
 
 function collectConfiguredChannelIds(
   config: OpenClawConfig,
@@ -129,24 +128,6 @@ function collectExplicitEffectivePluginIds(config: OpenClawConfig): string[] {
   return sortUniqueStrings(ids);
 }
 
-function collectSelectedContextEnginePluginIds(config: OpenClawConfig): string[] {
-  const plugins = normalizePluginsConfig(config.plugins);
-  if (!plugins.enabled) {
-    return [];
-  }
-  const pluginId = plugins.slots.contextEngine;
-  if (!pluginId || pluginId === defaultSlotIdForKey("contextEngine")) {
-    return [];
-  }
-  if (plugins.deny.includes(pluginId)) {
-    return [];
-  }
-  if (plugins.entries[pluginId]?.enabled === false) {
-    return [];
-  }
-  return [pluginId];
-}
-
 /** Lists plugin ids that are effectively enabled for a config/discovery context. */
 export function resolveEffectivePluginIds(params: {
   config: OpenClawConfig;
@@ -172,8 +153,9 @@ export function resolveEffectivePluginIds(params: {
   });
   const effectiveConfig = autoEnabled.config;
   const ids = new Set(collectExplicitEffectivePluginIds(effectiveConfig));
-  for (const pluginId of collectSelectedContextEnginePluginIds(effectiveConfig)) {
-    ids.add(pluginId);
+  const contextEnginePluginId = resolveSelectedContextEnginePluginId(effectiveConfig);
+  if (contextEnginePluginId) {
+    ids.add(contextEnginePluginId);
   }
   const configuredChannelIds = collectConfiguredChannelIds(
     effectiveConfig,

--- a/src/plugins/gateway-startup-plugin-config.ts
+++ b/src/plugins/gateway-startup-plugin-config.ts
@@ -20,7 +20,10 @@ import { readBundledDiscoveryMode } from "./bundled-discovery-state.js";
 import { listExplicitConfiguredChannelIdsForConfig } from "./channel-presence-policy.js";
 import { collectPluginConfigContractMatches } from "./config-contracts.js";
 import { normalizePluginsConfigWithResolver } from "./config-normalization-shared.js";
-import { resolveEffectivePluginActivationState } from "./config-state.js";
+import {
+  resolveEffectivePluginActivationState,
+  resolveSelectedContextEnginePluginIdFromConfig,
+} from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
 import type {
   ManifestRegistryLookup,
@@ -211,18 +214,10 @@ export function resolveContextEngineSlotStartupPluginId(params: {
   if (!configuredSlot) {
     return undefined;
   }
-  const normalized = normalizePluginId(configuredSlot);
-  // "legacy" is the built-in default engine — no plugin startup needed.
-  if (normalized === "legacy") {
-    return undefined;
-  }
-  if (activationSourcePlugins.deny.includes(normalized)) {
-    return undefined;
-  }
-  if (activationSourcePlugins.entries[normalized]?.enabled === false) {
-    return undefined;
-  }
-  return normalized;
+  return resolveSelectedContextEnginePluginIdFromConfig(
+    activationSourcePlugins,
+    normalizePluginId(configuredSlot),
+  );
 }
 
 export function shouldConsiderForGatewayStartup(params: {

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -458,6 +458,7 @@ export function createUserTurnTranscriptRecorder(
   let persistedMessageNotified = false;
   let runtimePersistedMessage: PersistedUserTurnMessage | undefined;
   let sentToProvider = false;
+  let admissionHandler: ((admission: UserTurnTranscriptAdmissionReceipt) => void) | undefined;
   let resolvedBeforeProvider = false;
   let replacementText: string | undefined;
 
@@ -532,6 +533,7 @@ export function createUserTurnTranscriptRecorder(
     }
     admissionReceipt = resolveUserTurnTranscriptAdmission({ logicalTurnId, receipt });
     admittedMessage = persistedMessage;
+    admissionHandler?.(admissionReceipt);
   };
 
   const waitForRuntimePersistence = async () => {
@@ -682,6 +684,7 @@ export function createUserTurnTranscriptRecorder(
     getPersistedMessage: () =>
       admittedMessage ?? runtimePersistedMessage ?? persistedResult?.message,
     getAdmissionReceipt: () => admissionReceipt,
+    setAdmissionHandler: (handler) => (admissionHandler = handler),
     markSentToProvider: () => {
       sentToProvider = true;
     },

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -154,6 +154,7 @@ export type UserTurnTranscriptRecorder = {
   replaceTextBeforePersistence?: (text: string) => void;
   getPersistedMessage?: () => PersistedUserTurnMessage | undefined;
   getAdmissionReceipt: () => UserTurnTranscriptAdmissionReceipt | undefined;
+  setAdmissionHandler?: (handler: (admission: UserTurnTranscriptAdmissionReceipt) => void) => void;
   markSentToProvider?: () => void;
   markRuntimePersistencePending: (pending: Promise<void>) => void;
   markRuntimePersisted: (

--- a/src/state/openclaw-agent-context-engine-turn-outbox-schema.ts
+++ b/src/state/openclaw-agent-context-engine-turn-outbox-schema.ts
@@ -6,6 +6,7 @@ export const CONTEXT_ENGINE_TURN_OUTBOX_TABLE = "context_engine_turn_outbox";
 
 const OUTBOX_SCHEMA_START = `CREATE TABLE IF NOT EXISTS ${CONTEXT_ENGINE_TURN_OUTBOX_TABLE} (`;
 const OUTBOX_SCHEMA_END = "CREATE TABLE IF NOT EXISTS cache_entries (";
+const ENSURED_DATABASES = new WeakSet<DatabaseSync>();
 
 function contextEngineTurnOutboxSchemaSql(): string {
   const start = OPENCLAW_AGENT_SCHEMA_SQL.indexOf(OUTBOX_SCHEMA_START);
@@ -18,6 +19,9 @@ function contextEngineTurnOutboxSchemaSql(): string {
 
 /** Lazily installs the additive context-engine turn outbox on first use. */
 export function ensureContextEngineTurnOutboxSchema(db: DatabaseSync): void {
+  if (ENSURED_DATABASES.has(db)) {
+    return;
+  }
   const ensure = () => {
     db.exec(contextEngineTurnOutboxSchemaSql()); // sqlite-allow-raw -- Canonical additive DDL only.
   };
@@ -26,4 +30,5 @@ export function ensureContextEngineTurnOutboxSchema(db: DatabaseSync): void {
     return;
   }
   runSqliteImmediateTransactionSync(db, ensure);
+  ENSURED_DATABASES.add(db);
 }


### PR DESCRIPTION
Closes #121460

## What Problem This Solves

Fixes an issue where operators who configure a context engine via `plugins.slots.contextEngine` would silently get the `legacy` engine on every fresh turn, no matter what their engine declares. The configured engine loads, registers in `full` mode, and is then never used — its `bootstrap`, `assemble` and `commitTurn` are never called — while each turn logs:

```
[context-engine] Context engine "<id>" degraded to "legacy" for this logical turn:
current-turn transcript admission receipt is unavailable.
```

Turns still return plausible answers, so the only symptom is a warning and a context engine that quietly does nothing.

## Why This Change Was Made

`selectContextEngineForTranscriptHost()` treated a missing admission receipt as a failure. But selection runs during turn *preparation* — `src/agents/harness/selection.ts:510`, `src/agents/embedded-agent-runner/run-loop.ts:282`, `src/agents/cli-runner/prepare.ts:1673` — while the user turn is persisted later in the run through `onUserMessagePersisted` (`src/agents/embedded-agent-runner/run/session-prompt-state.ts:81-113`), and the receipt is only assigned by `recordAdmission()` (`src/sessions/user-turn-transcript.ts:526-535`). On a fresh turn no receipt exists yet, so the engine was degraded before it could be considered. Retried attempts and restart recovery can supply an already-admitted recorder, which is why the effect is scoped to first attempts.

The guard now also requires `recorder.hasPersisted()`. A missing receipt is only a fault once a current-turn entry actually exists; until then there is no admitted entry for `before-current-turn-entry-v1` to anchor to, so there is nothing to degrade over. Engines that genuinely fail the contract still degrade, through the unchanged `transcriptSemantics` / `commitTurn` checks in `resolveSelectionIssue`.

`hasPersisted()` is `persisted || runtimePersisted` (`src/sessions/user-turn-transcript.ts:708`) — the canonical "a row now exists" signal. `isBlocked()` is a disposition rather than evidence of a row; `hasRuntimePersistencePending()` only means a write was scheduled. The one asymmetric case, `hasPersisted() === true` with no receipt (an anchorless `markRuntimePersisted`, used by `src/agents/session-tool-result-guard-wrapper.ts:221-230`), is exactly the state that should still degrade, and still does.

The `recorder` parameter type widens from `Pick<…, "getAdmissionReceipt">` to include `"hasPersisted"`. All three production call sites already pass a full `UserTurnTranscriptRecorder`; only structural test doubles needed updating. This is an internal module, not plugin-facing API.

Non-goal: this does not change the contract introduced in #119325, or the legacy fallback for engines that have not adopted it. It only stops that fallback firing for engines that have.

## User Impact

Operators running a conformant context engine get the engine they configured instead of a silent downgrade to `legacy` on every turn. No configuration change is needed and no behavior changes for the default `legacy` setup. Engines that do not declare the current contract degrade exactly as before.

## Evidence

**The new regression test fails on stock and passes with the fix.** Verified by stashing only the source hunk and keeping the test:

```
$ git stash push -- src/agents/harness/context-engine-logical-turn.ts
$ node node_modules/vitest/vitest.mjs run src/context-engine/context-engine.test.ts

 FAIL  src/context-engine/context-engine.test.ts > Default engine selection >
       keeps the configured engine when the current turn has not been persisted yet
 AssertionError: expected 'legacy' to be 'logical-turn-unpersisted-9'
   Expected: "logical-turn-unpersisted-9"
   Received: "legacy"

 Tests  1 failed | 63 passed (64)
```

```
$ git stash pop
$ node node_modules/vitest/vitest.mjs run src/context-engine/context-engine.test.ts \
      src/agents/cli-runner.context-engine.test.ts

 Test Files  3 passed (3)
      Tests  98 passed (98)
```

**Live gateway, before and after.** A minimal reference context engine that implements the contract in full (source in #121460) on OpenClaw 2026.8.1:

| build | turns | result |
|---|---|---|
| stock | 3 | all 3 degraded to `legacy`; `bootstrap`/`assemble` never called |
| patched | 4 | 0 degraded; `[ce-probe] bootstrap` and `[ce-probe] assemble` logged each turn |

Patched run:

```
[plugins] [ce-probe] registering mode=full
[gateway] http server listening (13 plugins: … ce-probe …)
[plugins] [ce-probe] assemble messages=0
```

The same build with a third-party engine (LibraVDB, once it declares the contract) also ran clean for 3/3 turns with no degradation.

**Repo checks.** `node --import tsx scripts/check.mts` reports the same 7 pre-existing typecheck errors before and after this change (stale local dependency tree; none in the touched files) — this diff introduces none.

**ClawSweeper P1 addressed (`e094cfc3019`).** The first revision let a partially declared engine
through: on a fresh turn `selectForHost` was reached with `hasAdmissionFence: false`, which skipped
the only `currentTurnFence` check, so an engine declaring `commitTurn` + atomic advancement but not
`before-current-turn-entry-v1` would have been selected instead of degrading. The fence declaration
is now validated whenever the turn is recorder-backed, independently of receipt availability — a
recorder-backed turn is admitted during the run, so the declaration is owed either way. New
regression test `still degrades an unpersisted turn when current-turn fencing is not declared`,
verified against a surgical revert of only that condition:

```
# with only the fencing condition reverted:
 FAIL  … > still degrades an unpersisted turn when current-turn fencing is not declared
 AssertionError: expected 'logical-turn-partial-contract-10' to be 'legacy'
 Tests  1 failed | 64 passed (65)

# restored:
 Test Files  3 passed (3)
      Tests  99 passed (99)
```

This keeps one canonical selection rule rather than adding a fallback path: the timing question
("is a receipt owed yet?") and the contract question ("is the engine conformant?") stay separate,
which is what the previous revision conflated.

**Scope of the claim.** The regression test proves the selector's state table. The live runs demonstrate the end-to-end effect on the cli-runner path. I have not added an end-to-end test that drives a full embedded preparation and asserts the fence on a later assembly; that would be a stronger test and I am happy to add it if you would like it in this PR.

AI-assisted: investigated, implemented and tested with Claude (Claude Code).
