### PR TITLE
fix(feishu): advertise group chat type in capabilities

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -119,6 +119,10 @@ describe("feishuPlugin metadata", () => {
   it("opts announce delivery into persisted session lookup", () => {
     expect(feishuPlugin.meta.preferSessionLookupForAnnounceTarget).toBe(true);
   });
+
+  it("declares exact native chat types", () => {
+    expect(feishuPlugin.capabilities.chatTypes).toEqual(["direct", "group"]);
+  });
 });
 
 describe("feishuPlugin config", () => {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -964,7 +964,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
         ...meta,
       },
       capabilities: {
-        chatTypes: ["direct", "channel"],
+        chatTypes: ["direct", "group"],
         polls: false,
         threads: true,
         media: true,


### PR DESCRIPTION
Closes #114544

## What Problem This Solves

Fixes an issue where Feishu group conversations would be misclassified as `channel` type in outbound session routing. The Feishu channel plugin declared `chatTypes: ["direct", "channel"]`, omitting `"group"` despite fully supporting group conversations. When `outbound-session.ts` encountered a resolved Feishu group target, the `supportsChannel && !supportsGroup` fallback returned `"channel"` instead of `"group"`.

## Why This Change Was Made

Changed Feishu's `capabilities.chatTypes` from `["direct", "channel"]` to `["direct", "group"]` so it accurately reflects the channel's native conversation types. Feishu's inbound path (`bot.ts`) already creates conversations with `kind: "group"` for group messages, and the session-route resolver returns `chatType: "group"` for group chats. The legacy `"channel"` entry was not a native Feishu conversation type — it was a target-parser alias that leaked into advertised capability metadata, causing metadata consumers to treat Feishu as a channel-capable provider.

Per ClawSweeper review feedback, the test uses an exact `toEqual(["direct", "group"])` assertion rather than `toContain("group")`, ensuring the capability set stays semantically consistent and preventing stale aliases from persisting.

## User Impact

Feishu group conversations now get correct `group` peer-kind classification in outbound session routing, session keys, and binding configuration. Previously, group messages could produce `channel`-typed session metadata, creating latent routing and binding mismatches.

## Evidence

### Real Feishu API Proof (exact-head SHA: 8e964d5dde9)

Real behavior verification against live Feishu Open API (`open.feishu.cn`) using real app credentials. No mocks — verifies `feishuPlugin.capabilities.chatTypes` directly, creates a real group chat, and resolves session route through the real Feishu resolver.

**Feishu app setup used for proof:**
- App ID: `cli_aac94f8829b8dcc4`
- App type: Custom Enterprise App (自建应用)
- Required scope: `im:message:send_as_bot`, `im:chat:create`
- Domain: `feishu` (open.feishu.cn)
- SDK: `@larksuiteoapi/node-sdk` 1.71.1

```
$ GIT_SHA=8e964d5dde9 node --import tsx feishu-chattype-proof.mjs
[info]: [ 'client ready' ]
=== Feishu capabilities.chatTypes Real Behavior Proof ===
Head SHA: 8e964d5dde9
Timestamp: 2026-08-11T05:45:40.483Z
Domain: feishu (open.feishu.cn)
App ID: cli_aac94f8829b8dcc4

[1/4] Verifying feishuPlugin.capabilities.chatTypes...
  chatTypes = ["direct","group"]
  OK: exact native chat type set declared

[2/4] Creating a real Feishu group chat...
  OK: chat created, chatId=oc_382e8c9e79e071f3ce02e60d1eb9d45f

[3/4] Verifying Feishu session-route resolver returns 'group'...
  peer.kind = group
  chatType = group
  OK: session route correctly classifies as 'group'

[4/4] Sending a test message to the group to prove it's real...
  OK: message sent to group, messageId=om_x100b689f3c2808b4c22cbde569346ac

PASS: feishuPlugin.capabilities.chatTypes is ["direct","group"] and real Feishu group chat routes correctly
```

**Before this PR:** `chatTypes = ["direct", "channel"]` — no `"group"`, stale `"channel"` alias, generic fallback misclassifies group targets as `"channel"`.

**After this PR:** `chatTypes = ["direct", "group"]` — exact native set, session-route resolver returns `peer.kind = "group"` and `chatType = "group"` for real Feishu group chats.

### Unit Tests

```
$ node scripts/run-vitest.mjs extensions/feishu/src/channel.test.ts
 Test Files  1 passed (1)
      Tests  105 passed (105)
```

Test changes:
- **Added** `declares exact native chat types` in `extensions/feishu/src/channel.test.ts` — `toEqual(["direct", "group"])` assertion that fails on the base revision and prevents stale aliases
- **Removed** synthetic generic-fallback test from `src/infra/outbound/outbound-session.test.ts` — per ClawSweeper review, it used a hardcoded post-change capability list instead of observing the real `feishuPlugin`

### Type Check + Lint

```
$ oxlint extensions/feishu/src/channel.test.ts src/infra/outbound/outbound-session.test.ts  # Clean
```
