### PR TITLE
fix(ui): stop chat sidebar flashing while opening

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -2312,6 +2312,35 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     },
   );
 
+  it("keeps newly opened sidebar columns transparent while panel owners retain their surface", async () => {
+    const page = await openBrowserPage(1_000, 700);
+    try {
+      await page.setContent(
+        `<!doctype html><html><head><style>${readUiCss()}</style></head><body>
+          <div class="sidebar-region" style="--panel: rgb(12, 34, 56)">
+            <main class="sidebar-region__primary">Primary chat</main>
+          </div>
+        </body></html>`,
+      );
+
+      const backgrounds = await page.evaluate(() => {
+        const column = document.createElement("section");
+        column.className = "sidebar-column";
+        column.innerHTML = '<div class="sidebar-panel">Owned panel surface</div>';
+        document.querySelector(".sidebar-region")?.append(column);
+        return {
+          column: getComputedStyle(column).backgroundColor,
+          panel: getComputedStyle(column.firstElementChild!).backgroundColor,
+        };
+      });
+
+      expect(backgrounds.column).toBe("rgba(0, 0, 0, 0)");
+      expect(backgrounds.panel).toBe("rgb(12, 34, 56)");
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
   it("collapses sidebar columns into one tabbed column below the pane breakpoint", async () => {
     const page = await openBrowserPage(900, 700);
     try {

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -225,7 +225,7 @@ openclaw-chat-sidebar-region,
   min-width: 260px;
   min-height: 0;
   overflow: hidden;
-  background: var(--panel);
+  background: transparent;
   flex-direction: column;
   animation: chat-sidebar-fade-in 160ms ease-out;
 }


### PR DESCRIPTION
Closes #121462
Related: #113712
Related: #121435

AI-assisted: this fix and its regression coverage were developed with Codex assistance, independently reviewed, and validated in deterministic browser fixtures.

## What Problem This Solves

Fixes an issue where opening a chat detail sidebar briefly painted an opaque panel-colored column before the actual sidebar content appeared.

## Why This Change Was Made

The shared structural sidebar column is now transparent during its opening fade. Explicit content owners—sidebar panels, headers, and discussion frames—continue to paint their themed surfaces, following the same transparent-default/explicit-owner boundary established by #121435.

## User Impact

Opening, closing, and reopening chat detail sidebars no longer produces an opaque white flash. Loaded sidebar content keeps its normal light or dark themed background.

Release-note context: Control UI chat sidebars no longer flash an opaque surface while opening.

## Evidence

| Before | After |
| --- | --- |
| ![Before: the structural sidebar column paints an opaque white surface](https://github.com/user-attachments/assets/9031bff3-a3e2-453f-a9cd-5120a6582452) | ![After: the structural sidebar remains transparent while opening](https://github.com/user-attachments/assets/d5704ae3-4cae-408c-ba7b-f445dd442e20) |

The screenshots use a sanitized diagnostic fixture for the 160 ms interval before the owned detail panel is ready. Measured structural background changed from `rgb(255, 255, 255)` to `rgba(0, 0, 0, 0)`.

- Regression proof: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts -t 'keeps newly opened sidebar columns transparent while panel owners retain their surface'` failed before the fix with `rgb(12, 34, 56)` and passed afterward with a transparent column and unchanged owned panel surface.
- Production bundle: `pnpm ui:build` — passed, including precompressed-asset and Control UI performance checks.
- Targeted static proof: oxfmt, stylelint, oxlint, and `git diff --check` — passed.
- Source-blind browser validation: initial and recreated columns remained transparent; sidebar panel and discussion frame surfaces retained supplied theme colors; close/reopen geometry, widths, disconnection, and one-current-column counts passed, including a varied 341px / `rgb(97, 83, 41)` anti-cheat probe.
- Codex autoreview (`--mode uncommitted`): clean, no accepted/actionable findings.
- LOC split: production `+1/-1` (net zero); tests `+29`.

- Exact-head CI: [run 31361985256](https://github.com/openclaw/openclaw/actions/runs/31361985256) — green on `3ac0471936dad7e06227e022a728b9076dc25710`, including `checks-ui-e2e` and `openclaw/ci-gate`.
- Live-profile verification gap: the signed-in Chrome relay was offline during this pass, so the direct behavior proof is deterministic mock-browser evidence rather than a live hosted-session capture.
