### PR TITLE
test(gateway): verify identity scopes reach workspace handlers

### DIFF
--- a/src/gateway/server.auth.identity-scopes.test.ts
+++ b/src/gateway/server.auth.identity-scopes.test.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { writeConfigFile } from "../config/config.js";
 import type { GatewayAuthConfig } from "../config/types.gateway.js";
 import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
@@ -20,6 +21,8 @@ import {
 } from "./server.auth.test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const BROWSER_ORIGIN = "https://control.example.com";
 const TRUSTED_PROXY_HEADERS = {
@@ -62,30 +65,43 @@ describe("gateway identity scope grants", () => {
     });
     const identityPath = deviceIdentityPath("identity-scope-device");
     const identity = loadOrCreateDeviceIdentity({ path: identityPath });
+    const configuredWorkspace = tempDirs.make("openclaw-identity-workspace-");
+    const outsideWorkspace = tempDirs.make("openclaw-identity-outside-");
+    testState.agentConfig = { workspace: configuredWorkspace };
 
-    await withGatewayServer(async ({ port }) => {
-      const ws = await openWs(port, {
-        ...TRUSTED_PROXY_HEADERS,
-        "x-forwarded-user": "Admin@Example.com",
-      });
-      try {
-        const connected = await connectReq(ws, {
-          skipDefaultAuth: true,
-          prePairDevice: true,
-          scopes: ["operator.read"],
-          client: CONTROL_UI_CLIENT,
-          deviceIdentityPath: identityPath,
-          browserOrigin: BROWSER_ORIGIN,
+    try {
+      await withGatewayServer(async ({ port }) => {
+        const ws = await openWs(port, {
+          ...TRUSTED_PROXY_HEADERS,
+          "x-forwarded-user": "Admin@Example.com",
         });
-        expect(connected.ok).toBe(true);
-        expect(responseScopes(connected)).toEqual(["operator.read", "operator.admin"]);
-        expect((await rpcReq(ws, "set-heartbeats", { enabled: false })).ok).toBe(true);
-      } finally {
-        ws.close();
-      }
-    });
+        try {
+          const connected = await connectReq(ws, {
+            skipDefaultAuth: true,
+            prePairDevice: true,
+            scopes: ["operator.write"],
+            client: CONTROL_UI_CLIENT,
+            deviceIdentityPath: identityPath,
+            browserOrigin: BROWSER_ORIGIN,
+          });
+          expect(connected.ok).toBe(true);
+          expect(responseScopes(connected)).toEqual(["operator.write", "operator.admin"]);
+          expect((await rpcReq(ws, "set-heartbeats", { enabled: false })).ok).toBe(true);
 
-    expect((await getPairedDevice(identity.deviceId))?.approvedScopes).toEqual(["operator.read"]);
+          const browse = await rpcReq<{ path?: string }>(ws, "fs.listDir", {
+            path: outsideWorkspace,
+          });
+          expect(browse.ok, JSON.stringify(browse.error)).toBe(true);
+          expect(browse.payload?.path).toBe(outsideWorkspace);
+        } finally {
+          ws.close();
+        }
+      });
+    } finally {
+      testState.agentConfig = undefined;
+    }
+
+    expect((await getPairedDevice(identity.deviceId))?.approvedScopes).toEqual(["operator.write"]);
     expect(
       (await listDevicePairing()).pending.filter((entry) => entry.deviceId === identity.deviceId),
     ).toEqual([]);


### PR DESCRIPTION
## What Problem This Solves

PR #121531 landed identity-carried operator scope grants, and PR #121417 landed workspace-contained filesystem/session authorization. Each feature had focused coverage, but there was no real WebSocket-to-handler test proving that the identity-augmented scope set stored on `client.connect.scopes` is what workspace-containment handlers observe.

This PR adds that cross-feature integration coverage. It no longer adds or changes the identity-scope feature itself.

Part of #121381

## Why This Change Was Made

The test connects a trusted-proxy user whose paired device grants only `operator.write`, while the verified identity grants `operator.admin`. That shape is intentional: method dispatch can reach `fs.listDir` with write scope, but listing an existing directory outside configured workspaces succeeds only if the handler reads the identity-added admin scope from `client.connect.scopes`.

The same test confirms the persistent pairing remains write-only and no scope-upgrade request is created. This protects the ownership boundary between connection-only identity authority and durable device pairing.

Production LOC: +0/-0. The diff is tests only.

## User Impact

No user-visible behavior or configuration changes are introduced here. The landed behavior from #121531 is protected against regressions where hello metadata is correct but downstream state-aware handlers see only the device grant.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server.auth.identity-scopes.test.ts src/gateway/server-methods/fs.test.ts` — 2 files passed; 23 tests passed.
- `node scripts/check-changed.mjs` — passed the selected core-test lane, including formatting, dead exports, core-test typecheck, lint, and architecture guards. Remote routing was unavailable/noisy, so the repository's worktree-scoped trusted-source local fallback completed the same gate without skipping checks.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.
- GitHub mergeability before readying: `MERGEABLE`.
