### PR TITLE
fix(discord): malformed gateway HELLO frame kills the bot's socket listener

### DIFF
--- a/extensions/discord/src/internal/gateway.test.ts
+++ b/extensions/discord/src/internal/gateway.test.ts
@@ -866,7 +866,8 @@ describe("GatewayPlugin", () => {
     ["a scalar body", "hello", 45_000],
     ["a zero interval", { heartbeat_interval: 0 }, 45_000],
     ["a negative interval", { heartbeat_interval: -1 }, 45_000],
-    ["a sub-second interval", { heartbeat_interval: 1 }, 45_000],
+    ["a sub-second interval a compatible gateway may negotiate", { heartbeat_interval: 500 }, 500],
+    ["the smallest positive interval", { heartbeat_interval: 1 }, 1],
     ["a stringified interval", { heartbeat_interval: "45000" }, 45_000],
     ["an interval past the timer ceiling", { heartbeat_interval: Number.MAX_SAFE_INTEGER }, 45_000],
   ])(

--- a/extensions/discord/src/internal/gateway.test.ts
+++ b/extensions/discord/src/internal/gateway.test.ts
@@ -100,6 +100,7 @@ function gatewaySessionState(gateway: GatewayPlugin): GatewaySessionState {
 describe("GatewayPlugin", () => {
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
     sharedGatewayIdentifyLimiter.reset();
   });
 
@@ -854,6 +855,51 @@ describe("GatewayPlugin", () => {
     expect(gateway.connectCalls).toEqual([false]);
     expect(gateway.sockets).toHaveLength(1);
   });
+
+  it.each([
+    ["a well-formed interval", { heartbeat_interval: 45_000 }, 45_000],
+    ["a shorter negotiated interval", { heartbeat_interval: 41_250 }, 41_250],
+    ["a null body", null, 45_000],
+    ["an absent body", undefined, 45_000],
+    ["an array body", [], 45_000],
+    ["an empty body", {}, 45_000],
+    ["a scalar body", "hello", 45_000],
+    ["a zero interval", { heartbeat_interval: 0 }, 45_000],
+    ["a negative interval", { heartbeat_interval: -1 }, 45_000],
+    ["a sub-second interval", { heartbeat_interval: 1 }, 45_000],
+    ["a stringified interval", { heartbeat_interval: "45000" }, 45_000],
+    ["an interval past the timer ceiling", { heartbeat_interval: Number.MAX_SAFE_INTEGER }, 45_000],
+  ])(
+    "survives a HELLO with %s and schedules the first heartbeat accordingly",
+    async (_case, helloData, expectedFirstHeartbeatMs) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      // Pin the start jitter to the top of its window so the scheduled delay is
+      // exactly the resolved interval; a storm shows up as a heartbeat at t=0.
+      vi.spyOn(Math, "random").mockReturnValue(1);
+      const gateway = new TestGatewayPlugin({
+        autoInteractions: false,
+        url: "wss://gateway.example.test",
+      });
+      gateway.emitter.on("error", () => {});
+      gateway.connect(false);
+      const socket = expectDefined(gateway.sockets[0], "Discord gateway socket");
+      socket.emit("open");
+
+      const hello = JSON.stringify({ op: GatewayOpcodes.Hello, d: helloData, s: null });
+      expect(() => socket.emit("message", hello)).not.toThrow();
+
+      let firstHeartbeatMs: number | undefined;
+      for (let tick = 0; tick < 4 && firstHeartbeatMs === undefined; tick += 1) {
+        await vi.advanceTimersToNextTimerAsync();
+        if (sentGatewayOpcodes(socket.send).includes(GatewayOpcodes.Heartbeat)) {
+          firstHeartbeatMs = Date.now();
+        }
+      }
+
+      expect(firstHeartbeatMs).toBe(expectedFirstHeartbeatMs);
+    },
+  );
 
   it("clears heartbeat timers before delayed reconnects", () => {
     vi.useFakeTimers();

--- a/extensions/discord/src/internal/gateway.ts
+++ b/extensions/discord/src/internal/gateway.ts
@@ -15,6 +15,8 @@ import {
   type GatewaySendPayload,
   type GatewayVoiceStateUpdateData,
 } from "discord-api-types/v10";
+import { asSafeIntegerInRange, MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import * as ws from "ws";
 import { Plugin, type Client } from "./client.js";
 import { canResumeAfterGatewayClose, isFatalGatewayCloseCode } from "./gateway-close-codes.js";
@@ -71,6 +73,9 @@ export const DISCORD_GATEWAY_WS_CLIENT_OPTIONS = Object.freeze({
 const INVALID_SESSION_MIN_DELAY_MS = 1_000;
 const INVALID_SESSION_JITTER_MS = 4_000;
 const RESUME_FAILURE_THRESHOLD = 3;
+// Discord negotiates ~41s; a sub-second interval is a broken HELLO. sendHeartbeat
+// clears the ACK flag, so every sub-second cycle ends in a zombie reconnect.
+const MIN_HEARTBEAT_INTERVAL_MS = 1_000;
 
 export class GatewayPlugin extends Plugin {
   readonly id = "gateway";
@@ -261,7 +266,10 @@ export class GatewayPlugin extends Plugin {
     switch (payload.op) {
       case GatewayOpcodes.Hello: {
         this.startHeartbeat(
-          (payload.d as { heartbeat_interval?: number }).heartbeat_interval ?? 45_000,
+          asSafeIntegerInRange(asOptionalRecord(payload.d)?.heartbeat_interval, {
+            min: MIN_HEARTBEAT_INTERVAL_MS,
+            max: MAX_TIMER_TIMEOUT_MS,
+          }) ?? 45_000,
         );
         const resumeState = resume ? this.getResumeState() : null;
         if (resumeState) {

--- a/extensions/discord/src/internal/gateway.ts
+++ b/extensions/discord/src/internal/gateway.ts
@@ -73,9 +73,6 @@ export const DISCORD_GATEWAY_WS_CLIENT_OPTIONS = Object.freeze({
 const INVALID_SESSION_MIN_DELAY_MS = 1_000;
 const INVALID_SESSION_JITTER_MS = 4_000;
 const RESUME_FAILURE_THRESHOLD = 3;
-// Discord negotiates ~41s; a sub-second interval is a broken HELLO. sendHeartbeat
-// clears the ACK flag, so every sub-second cycle ends in a zombie reconnect.
-const MIN_HEARTBEAT_INTERVAL_MS = 1_000;
 
 export class GatewayPlugin extends Plugin {
   readonly id = "gateway";
@@ -267,7 +264,7 @@ export class GatewayPlugin extends Plugin {
       case GatewayOpcodes.Hello: {
         this.startHeartbeat(
           asSafeIntegerInRange(asOptionalRecord(payload.d)?.heartbeat_interval, {
-            min: MIN_HEARTBEAT_INTERVAL_MS,
+            min: 1,
             max: MAX_TIMER_TIMEOUT_MS,
           }) ?? 45_000,
         );


### PR DESCRIPTION
## What Problem This Solves

Fixes two failures in the same read. A gateway `HELLO` frame whose `d` is `null`
or absent throws an uncaught exception out of the Discord plugin's socket
listener; and an interval the client cannot schedule — `0`, negative, or past
Node's timer ceiling — replaces the negotiated heartbeat schedule with an
immediate one. (`d` shaped as an array or a scalar does not throw; it simply has
no interval to read, and already fell back.) Both are stopped at that boundary in
`extensions/discord/src/internal/gateway.ts`; the reconnect path in that file is
unchanged.

`extensions/discord/src/internal/gateway.ts:263-265` read the heartbeat interval
out of that frame with a bare cast and a `??`:

```ts
this.startHeartbeat(
  (payload.d as { heartbeat_interval?: number }).heartbeat_interval ?? 45_000,
);
```

Nothing between the socket and that line validated `payload.d`.
`decodeGatewayMessage` is `JSON.parse` plus a type assertion, and its caller
null-checks the envelope only (`gateway.ts:211-214`). Two consequences, both
visible in the capture below over a real socket:

- **The throw escapes the socket listener.** `{"op":10,"d":null}` dereferences
  `null` on that line, and the capture records the `TypeError` arriving at a
  process-level `uncaughtException` handler rather than at any channel error
  path. The listener is registered at `gateway.ts:206`, `ws` invokes it from its
  own `emit`, and there is no try/catch between that registration and
  `handlePayload`. The only error surface in that listener is the
  `emitter.emit("error", …)` on the `!payload` branch at `gateway.ts:211-214`,
  which a HELLO with a parseable envelope never reaches. Whether an uncaught
  exception ends the process depends on whether the host installs a handler for
  it; either way the frame is never handled and no channel error is emitted.
- **The liveness schedule collapses.** `??` replaces only `null`/`undefined`, so
  `0`, a negative value and a value past Node's timer ceiling all reach
  `startHeartbeat`. On the pre-fix side the server receives the first heartbeat
  2 ms after the HELLO for each of them, instead of nothing inside a 1500 ms
  window as it does on a 45 s schedule. Node says why in the capture itself: on the
  pre-fix side it warns for the negative value and for the over-ceiling one, and
  in both cases reports that the timeout duration was set to 1. Neither warning
  appears on the post-fix side. `sendHeartbeat` clears `lastHeartbeatAck`
  (`gateway.ts:344`) and the timer's next cycle re-reads that flag, calling the
  `onAckTimeout` that `startHeartbeat` wires to
  `scheduleReconnect({ reason: "zombie" })`, so a gateway that cannot answer that
  fast gets a reconnect loop. That last link is read from the source; what the
  capture shows is the heartbeats themselves.

**Firing condition, stated plainly:** Discord documents `heartbeat_interval` as
the interval in milliseconds the client should heartbeat with
(https://discord.com/developers/docs/topics/gateway-events#hello) and its own
gateway sends a positive integer — the documentation fixes no constant; 41,250 ms
is the value I see it send in practice, and 45,000 ms is this code's own
pre-existing fallback. So this needs a gateway that violates its own protocol: a
broken or misconfigured proxy in front of the socket, or a self-hosted or
protocol-compatible gateway reached through the `url` option. I have not observed
Discord itself emitting such a frame. What makes it worth fixing is that the
repository already decided this input class must be normalized: the same defect
was repaired for QQ in https://github.com/openclaw/openclaw/pull/121031, merged
2026-08-09, and Discord was the only other reader of `heartbeat_interval`.

## Why This Change Was Made

This PR changes one expression plus the two imports it needs. The shape check and
the range check are not two changes bolted together: they are the single read that
was wrong. `payload.d` and `payload.d.heartbeat_interval` are dereferenced on the
same line, by the same cast, with the same absent validation — splitting them
would mean two PRs editing the same four lines, and #121031 fixed both halves of
the identical read in one change for QQ. The HELLO body is normalized with the
canonical non-array record guard, and the interval is accepted whenever it is an
integer this client can actually schedule:

```ts
this.startHeartbeat(
  asSafeIntegerInRange(asOptionalRecord(payload.d)?.heartbeat_interval, {
    min: 1,
    max: MAX_TIMER_TIMEOUT_MS,
  }) ?? 45_000,
);
```

The `as { heartbeat_interval?: number }` cast is **deleted**, not wrapped. It was
the defect: it asserted a shape nothing had checked, and every reader downstream
believed it. Putting a guard in front of it would have left the false assertion in
place. The `??` survives but stops doing validation work; it now supplies the
pre-existing default after an explicit range check instead of being the sole and
insufficient check. `asOptionalRecord` is the same non-array record guard
#121031 used for the QQ HELLO body, from
`openclaw/plugin-sdk/string-coerce-runtime`; `asSafeIntegerInRange` and
`MAX_TIMER_TIMEOUT_MS` come from `openclaw/plugin-sdk/number-runtime`, which this
plugin already consumes in `internal/rest.ts`.

**The bounds are only what the timer can hold.** `min: 1` rather than a protocol
policy: an interval Discord or a compatible gateway negotiates is honored,
including sub-second values. `MAX_TIMER_TIMEOUT_MS` is this repository's existing
ceiling for a `setTimeout` delay; above 2147483647 a delay is treated as 1 ms,
which is why the over-ceiling row heartbeats at 2 ms pre-fix.

**This is the second revision.** The first carried a 1,000 ms lower bound copied
from #121031's QQ constant. Review pointed out that this is an interoperability
break rather than hardening — a compatible gateway negotiating 500 ms would have
had its interval replaced by the 45 s default and then been dropped as
unresponsive — and that is right: Discord documents no lower bound, and QQ is a
different protocol whose bound does not transfer. The bound is gone. The capture
shows 500 ms and 1 ms behaving identically before and after, which is the check
that the removal actually landed.

One question that comes up about `min: 1`: does accepting `1` invite a heartbeat
storm? Measured over the real transport, `1` behaves the same on both sides of this
change: the capture shows its first heartbeat at 2 ms before the fix and 1 ms after it,
and a single heartbeat inside the 1500 ms window on both sides rather than one per
millisecond — the acceptance is what is unchanged; the arrival time is jittered and
differs run to run. The values that really did produce a 1 ms timer before this
change are the negative and over-ceiling ones, where Node clamps and says so in
the capture, and those are exactly what the range check now rejects. `GatewayHeartbeatTimers` gates each cycle on the previous ACK, so the
cadence is bounded by round-trip time. A gateway that cannot ACK inside its own negotiated
interval ends up in the existing zombie-reconnect path — that last step is read
from the source, not shown by the capture, whose server acknowledges every
heartbeat. Any rate bound on the
heartbeat cycle itself belongs to `gateway-lifecycle.ts`, which this change is not
limited to touching — see Non-scope.

**Production LOC: +6 / −1 added diff lines**, none of them comment: 4 at the call
site (the removed line is the one it replaces, so the call site is −1/+4) and 2
imports of existing helpers.

**Falling back is silent, unlike #121031.** That handler had an injected logger
and used it; this one has no logger, so the equivalent would be a new conditional
plus a new emit on the `emitter`, i.e. new branching and a new event on a path
this PR is otherwise only narrowing. The tradeoff is deliberate: an operator whose
gateway sends an unschedulable interval sees a bot on the default 45 s schedule
with nothing naming why. If that silence is the wrong call, the diagnostic is a
small follow-up rather than something this diff should carry.

### Non-scope

This change is limited to the HELLO branch of `handlePayload` in
`extensions/discord/src/internal/gateway.ts` and its colocated test. It is the
same boundary #121031 drew when it kept the QQ repair inside that plugin's HELLO
handler, so the timer mechanics in `gateway-lifecycle.ts`, the reconnect and
resume paths, and the remaining `payload.d` casts in that file all keep their
current behavior.

**Sibling coverage:**
`git grep heartbeat_interval -- src extensions packages ':!*.test.*'` returns two
production readers — `extensions/qqbot/src/engine/gateway/gateway-connection.ts:479`
(guarded by #121031) and this one. Both now guard the body shape and the timer
ceiling; they differ on the lower bound, deliberately, because their protocols
differ. That is the only claim being made about qqbot here. Other plugin
heartbeats (`buzz`, `codex/app-server/transport-websocket.ts`) take their interval
from local constants, not from a remote frame.

## User Impact

A `HELLO` frame whose `d` is not a usable object no longer throws out of the
Discord gateway's message listener, and an interval of `0`, a negative value or
one past the timer ceiling no longer replaces the negotiated schedule with an
immediate one — those fall back to the 45 s default. Intervals the client can
schedule, including Discord's usual 41,250 ms and sub-second values a compatible
gateway may negotiate, are passed through untouched. This does not claim the
connection then stays up: the reconnect and resume paths are unchanged and were
not exercised.

## Evidence

Behavior addressed: a HELLO frame whose `d` is not a usable object no longer
throws an uncaught exception out of the Discord gateway's socket listener, and an
interval this client cannot schedule no longer replaces the liveness schedule. An
interval it *can* schedule is left alone.

Real environment tested: Linux x86_64, node v24.18.0. Two pinned checkouts of this
repository — pre-fix baseline `1569400ea7470a27107232b9c5a3c3fe1d601b6c` and this
patch `b6680e19c73712a76f44fa89dd93a667b82ebe5f` — each running the real
`extensions/discord/src/internal/gateway.ts` against a real `ws` server over a
real socket. Not a connection to Discord itself; see Limitations.

Ten HELLO frames, the same ten on both sides. `first` is when the **server**
received the first heartbeat, in ms after it wrote the HELLO; the observation
window is 1500 ms:

| HELLO `d` | before | after |
| --- | --- | --- |
| `{"heartbeat_interval":45000}` | no heartbeat in window | no heartbeat in window |
| `{"heartbeat_interval":41250}` | no heartbeat in window | no heartbeat in window |
| `{"heartbeat_interval":500}` | 3 heartbeats, first at 206 ms | 3 heartbeats, first at 456 ms |
| `{"heartbeat_interval":1}` | heartbeat at 2 ms | heartbeat at 1 ms |
| `null` | **uncaught `TypeError`** | no exception, no heartbeat |
| absent | **uncaught `TypeError`** | no exception, no heartbeat |
| `[]` | no heartbeat in window | no heartbeat in window |
| `{"heartbeat_interval":0}` | **heartbeat at 2 ms** | no heartbeat in window |
| `{"heartbeat_interval":-1}` | **heartbeat at 2 ms** | no heartbeat in window |
| `{"heartbeat_interval":9007199254740991}` | **heartbeat at 2 ms** | no heartbeat in window |

How to read the two right-hand columns. The crash rows are exact: the `TypeError`
is present before and absent after, every run, and so are Node's own timer
warnings, which appear only on the pre-fix side and state the clamped duration
outright. The schedule rows are read through
the first-arrival time, because the shipped code jitters the first heartbeat by
`intervalMs * Math.random()` and this harness does not pin that: after the fix the
first heartbeat is drawn from a 45 s schedule, so it is usually outside a 1500 ms
window but not guaranteed to be. What the fix guarantees is narrower and exact:
no immediate timer is armed for those values. The heartbeat counts vary between runs for the same reason and are not
used as the discriminator. `500` and `1` are accepted on both sides and keep
heartbeating — the arrival times differ, as jittered times do, but the acceptance
does not. That is the point: this change does not take away an interval the
gateway can negotiate.

Exact steps or command run after this patch: the command below ran in both pinned
checkouts, and the two captures that follow are its two runs.

```sh
clawproof work start discord-gateway-hello-malformed --baseline 1569400ea7470a27107232b9c5a3c3fe1d601b6c
clawproof build plan discord-gateway-hello-malformed --worktree before --apply
clawproof build plan discord-gateway-hello-malformed --worktree after --apply
clawproof prove discord-gateway-hello-malformed --scenario default --final

# What `prove` runs inside each of the two checkouts. The script starts a real
# ws.WebSocketServer on a loopback address, points the production GatewayPlugin
# at it through its own `url` option so `createWebSocket` builds a real
# ws.WebSocket, writes each HELLO frame over that socket, and acknowledges every
# heartbeat with op:11 the way a real gateway does. Nothing in
# extensions/discord/src/internal/gateway.ts is stubbed, subclassed or
# overridden, and Math.random is not pinned. The script is not part of this
# diff, so this block is provenance for the capture; the runnable path is the
# test command under Limitations.
node --import tsx harness.mjs
```

Before (pre-fix, baseline `1569400ea747`):

```text
===== BEFORE (baseline 1569400ea747, unfixed source) =====
--- harness.stderr ---
[harness: importing [REDACTED:path]/before/extensions/discord/src/internal/gateway.ts]
[harness: running well-formed-45s]
[harness: done well-formed-45s]
[harness: done well-formed-45s in 1516ms]
[harness: running well-formed-41250]
[harness: done well-formed-41250]
[harness: done well-formed-41250 in 1511ms]
[harness: running negotiated-500ms]
[harness: done negotiated-500ms]
[harness: done negotiated-500ms in 1503ms]
[harness: running negotiated-1ms]
[harness: done negotiated-1ms]
[harness: done negotiated-1ms in 1507ms]
[harness: running d-null]
[harness: done d-null]
[harness: done d-null in 1506ms]
[harness: running d-absent]
[harness: done d-absent]
[harness: done d-absent in 1507ms]
[harness: running d-array]
[harness: done d-array]
[harness: done d-array in 1503ms]
[harness: running interval-zero]
[harness: done interval-zero]
[harness: done interval-zero in 1507ms]
[harness: running interval-negative]
(node:1210398) TimeoutNegativeWarning: -1 is a negative number.
Timeout duration was set to 1.
(Use `node --trace-warnings ...` to show where the warning was created)
[harness: done interval-negative]
[harness: done interval-negative in 1507ms]
[harness: running interval-past-timer-ceiling]
(node:1210398) TimeoutOverflowWarning: 3543622380973652.5 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
(node:1210398) TimeoutOverflowWarning: 9007199254740991 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
[harness: done interval-past-timer-ceiling]
[harness: done interval-past-timer-ceiling in 1502ms]
--- harness.stdout ---
{
  "moduleUnderTest": "extensions/discord/src/internal/gateway.ts",
  "observationWindowMs": 1500,
  "results": [
    {
      "case": "well-formed-45s",
      "frame": "{\"op\":10,\"d\":{\"heartbeat_interval\":45000},\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 0,
      "firstHeartbeatAfterMs": null,
      "firstServerReceivedOpcodes": [
        2
      ]
    },
    {
      "case": "well-formed-41250",
      "frame": "{\"op\":10,\"d\":{\"heartbeat_interval\":41250},\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 0,
      "firstHeartbeatAfterMs": null,
      "firstServerReceivedOpcodes": []
    },
    {
      "case": "negotiated-500ms",
      "frame": "{\"op\":10,\"d\":{\"heartbeat_interval\":500},\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 3,
      "firstHeartbeatAfterMs": 206,
      "firstServerReceivedOpcodes": [
        1,
        1,
        1
      ]
    },
    {
      "case": "negotiated-1ms",
      "frame": "{\"op\":10,\"d\":{\"heartbeat_interval\":1},\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 1,
      "firstHeartbeatAfterMs": 2,
      "firstServerReceivedOpcodes": [
        1
      ]
    },
    {
      "case": "d-null",
      "frame": "{\"op\":10,\"d\":null,\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": "TypeError: Cannot read properties of null (reading 'heartbeat_interval')",
      "heartbeatsReceivedByServer": 0,
      "firstHeartbeatAfterMs": null,
      "firstServerReceivedOpcodes": []
    },
    {
      "case": "d-absent",
      "frame": "{\"op\":10,\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": "TypeError: Cannot read properties of undefined (reading 'heartbeat_interval')",
      "heartbeatsReceivedByServer": 0,
      "firstHeartbeatAfterMs": null,
      "firstServerReceivedOpcodes": []
    },
    {
      "case": "d-array",
      "frame": "{\"op\":10,\"d\":[],\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 0,
      "firstHeartbeatAfterMs": null,
      "firstServerReceivedOpcodes": []
    },
    {
      "case": "interval-zero",
      "frame": "{\"op\":10,\"d\":{\"heartbeat_interval\":0},\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 2,
      "firstHeartbeatAfterMs": 2,
      "firstServerReceivedOpcodes": [
        1,
        1
      ]
    },
    {
      "case": "interval-negative",
      "frame": "{\"op\":10,\"d\":{\"heartbeat_interval\":-1},\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 1,
      "firstHeartbeatAfterMs": 2,
      "firstServerReceivedOpcodes": [
        1
      ]
    },
    {
      "case": "interval-past-timer-ceiling",
      "frame": "{\"op\":10,\"d\":{\"heartbeat_interval\":9007199254740991},\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 1,
      "firstHeartbeatAfterMs": 2,
      "firstServerReceivedOpcodes": [
        1
      ]
    }
  ]
}
```

Evidence after fix:

```text
===== AFTER (candidate b6680e19c737, fix applied) =====
--- harness.stderr ---
[harness: importing [REDACTED:path]/after/extensions/discord/src/internal/gateway.ts]
[harness: running well-formed-45s]
[harness: done well-formed-45s]
[harness: done well-formed-45s in 1514ms]
[harness: running well-formed-41250]
[harness: done well-formed-41250]
[harness: done well-formed-41250 in 1507ms]
[harness: running negotiated-500ms]
[harness: done negotiated-500ms]
[harness: done negotiated-500ms in 1501ms]
[harness: running negotiated-1ms]
[harness: done negotiated-1ms]
[harness: done negotiated-1ms in 1506ms]
[harness: running d-null]
[harness: done d-null]
[harness: done d-null in 1507ms]
[harness: running d-absent]
[harness: done d-absent]
[harness: done d-absent in 1507ms]
[harness: running d-array]
[harness: done d-array]
[harness: done d-array in 1505ms]
[harness: running interval-zero]
[harness: done interval-zero]
[harness: done interval-zero in 1506ms]
[harness: running interval-negative]
[harness: done interval-negative]
[harness: done interval-negative in 1506ms]
[harness: running interval-past-timer-ceiling]
[harness: done interval-past-timer-ceiling]
[harness: done interval-past-timer-ceiling in 1500ms]
--- harness.stdout ---
{
  "moduleUnderTest": "extensions/discord/src/internal/gateway.ts",
  "observationWindowMs": 1500,
  "results": [
    {
      "case": "well-formed-45s",
      "frame": "{\"op\":10,\"d\":{\"heartbeat_interval\":45000},\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 0,
      "firstHeartbeatAfterMs": null,
      "firstServerReceivedOpcodes": [
        2
      ]
    },
    {
      "case": "well-formed-41250",
      "frame": "{\"op\":10,\"d\":{\"heartbeat_interval\":41250},\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 0,
      "firstHeartbeatAfterMs": null,
      "firstServerReceivedOpcodes": []
    },
    {
      "case": "negotiated-500ms",
      "frame": "{\"op\":10,\"d\":{\"heartbeat_interval\":500},\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 3,
      "firstHeartbeatAfterMs": 456,
      "firstServerReceivedOpcodes": [
        1,
        1,
        1
      ]
    },
    {
      "case": "negotiated-1ms",
      "frame": "{\"op\":10,\"d\":{\"heartbeat_interval\":1},\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 1,
      "firstHeartbeatAfterMs": 1,
      "firstServerReceivedOpcodes": [
        1
      ]
    },
    {
      "case": "d-null",
      "frame": "{\"op\":10,\"d\":null,\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 0,
      "firstHeartbeatAfterMs": null,
      "firstServerReceivedOpcodes": []
    },
    {
      "case": "d-absent",
      "frame": "{\"op\":10,\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 0,
      "firstHeartbeatAfterMs": null,
      "firstServerReceivedOpcodes": []
    },
    {
      "case": "d-array",
      "frame": "{\"op\":10,\"d\":[],\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 0,
      "firstHeartbeatAfterMs": null,
      "firstServerReceivedOpcodes": []
    },
    {
      "case": "interval-zero",
      "frame": "{\"op\":10,\"d\":{\"heartbeat_interval\":0},\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 0,
      "firstHeartbeatAfterMs": null,
      "firstServerReceivedOpcodes": []
    },
    {
      "case": "interval-negative",
      "frame": "{\"op\":10,\"d\":{\"heartbeat_interval\":-1},\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 0,
      "firstHeartbeatAfterMs": null,
      "firstServerReceivedOpcodes": []
    },
    {
      "case": "interval-past-timer-ceiling",
      "frame": "{\"op\":10,\"d\":{\"heartbeat_interval\":9007199254740991},\"s\":null}",
      "transport": "real ws client -> local loopback ws server, ephemeral port",
      "uncaughtException": null,
      "heartbeatsReceivedByServer": 0,
      "firstHeartbeatAfterMs": null,
      "firstServerReceivedOpcodes": []
    }
  ]
}
```

Observed result after fix: no frame produces an uncaught exception. `0`, `-1` and
the over-ceiling value stop heartbeating within milliseconds and fall back to the
45 s default. `45000`, `41250`, `500` and `1` are unchanged, so the fix removes
only the schedules this client cannot honor.

What was not tested: a connection to Discord's own gateway, which will not emit
these frames. Coverage here stops at the HELLO handler in
`extensions/discord/src/internal/gateway.ts`; what happens after a schedule is
running is the reconnect path, whose behavior is unchanged.

### Limitations

- **This is not a connection to Discord.** These frames are outside Discord's
  documented gateway behavior and I have not seen its production gateway send
  one, so they are written by a local `ws` server rather than observed on the
  wire. The transport, the client and the module under test are all real: a real
  `ws.WebSocketServer` on a loopback address, the production `GatewayPlugin`
  reaching it through its own `url` option so `createWebSocket` builds a real
  `ws.WebSocket`, and the server acknowledging every heartbeat with op:11 the way
  a real gateway does. Nothing in the module under test is stubbed, subclassed or
  overridden, and `Math.random` is not pinned. #121031 landed with a comparable
  limitation stated ("No live QQ credentials were available. This is not
  live-channel proof.").
- The script that drives it is not in this diff. **The inspectable equivalent
  is**: the `it.each` table in
  `extensions/discord/src/internal/gateway.test.ts` drives the same frames
  through the same `socket.on("message")` listener and asserts the same
  scheduling, deterministically, with fake timers.
  `pnpm test extensions/discord/src/internal/gateway.test.ts` — 41 tests pass, 13
  of them the new table: the ten frames above plus three that need no separate
  capture because they behave the same on both sides — an empty object `{}`, a
  scalar `"hello"`, and a stringified `"45000"`. The whole plugin (`vitest run extensions/discord`) is
  green at 214 files / 2595 tests (`pnpm test extensions/discord`);
  `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` both exit 0; and
  `pnpm format:check` and `pnpm lint` are clean on both touched files. Reverting
  only the production hunk fails 5 of the new rows for
  the intended reasons: the two crash rows on
  `TypeError: Cannot read properties of null (reading 'heartbeat_interval')`, and
  the `0`, `-1` and ceiling rows on the first-heartbeat schedule.
- What the fix suppresses is the *immediate* heartbeat, not the possibility of
  one inside the window. The shipped code jitters the first heartbeat by
  `intervalMs * Math.random()`, so a 45 s fallback draws uniformly from that range
  and can occasionally land inside 1500 ms; it did not in this capture, and an
  earlier run of the same harness showed it once. The invariant that holds every
  run is narrower: before the fix these rows arm an immediate timer and the
  heartbeat lands at ~2 ms; after the fix no immediate timer is armed.
- The branch is based on `1569400ea74` and is 7 commits behind `main` at
  submission. That is deliberate: the newer commits introduce an unrelated
  `tsgo` regression in four test-harness files
  (`extensions/discord/src/monitor/message-handler.process.test-harness.ts` and
  three telegram ones) after `ReplyDispatchRuntimeInfo.onPlatformSendDispatch`
  became optional, which reproduces on an unmodified checkout of `main` with this
  change absent. `git log 1569400ea74..upstream/main -- extensions/discord/src/internal/gateway.ts
  extensions/discord/src/internal/gateway.test.ts` is empty, so nothing this PR
  touches has moved, and the branch merges cleanly. This is not a request to wait
  on anything — rebase it, or say the word and I will, as soon as that lane is
  green on `main`.
- `extensions/discord/src/monitor/message-handler.process.abort-retry.test.ts`,
  an abort-timing test under `monitor/`, failed once on an earlier full-suite run
  and could not be reproduced in 8 further runs of that file on this branch, 8 on
  a pre-fix baseline checkout, or in the full plugin suite on that baseline.

### Also in this diff

`extensions/discord/src/internal/gateway.test.ts` gains one line in `afterEach`:
`vi.restoreAllMocks()`. The file already had two `vi.spyOn(Math, "random")` calls
with nothing restoring them, and the new table pins `Math.random` as well, so the
leak had to close for the new cases to be deterministic. Flagging it because it is
not part of the fix.
