### PR TITLE
fix(gateway): preserve paired restart session refs

### DIFF
--- a/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
@@ -8,10 +8,13 @@ import {
 } from "../../config/sessions.js";
 import { applySessionEntryReplacements } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { resolveGatewaySessionStoreTarget } from "../../gateway/session-utils.js";
+import type { RestartRecoveryCandidate } from "../../gateway/chat-abort.js";
 import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { listAgentRunsForSession } from "../../infra/agent-run-registry.js";
-import { collectActiveSessionWorkAdmissions } from "../../sessions/session-lifecycle-admission.js";
+import {
+  collectActiveSessionWorkAdmissions,
+  isSessionWorkAdmissionTargetActive,
+} from "../../sessions/session-lifecycle-admission.js";
 import {
   listActiveEmbeddedRunSessionIds,
   listActiveEmbeddedRunSessionKeys,
@@ -99,47 +102,17 @@ export async function markRestartAbortedMainSessions(params: {
   cfg?: OpenClawConfig;
   additionalCfgs?: Iterable<OpenClawConfig | undefined>;
   stateDir?: string;
-  sessionKeys?: Iterable<string>;
-  sessionIds?: Iterable<string>;
-  activeRuns?: Iterable<
-    RestartRecoveryRun & {
-      sessionKey: string;
-      sessionId: string;
-      observedAt?: number;
-    }
-  >;
-  isActiveRun?: (
-    run: RestartRecoveryRun & {
-      sessionKey: string;
-      sessionId: string;
-      observedAt?: number;
-    },
-  ) => boolean;
+  activeRuns: Iterable<RestartRecoveryCandidate>;
+  isActiveRun?: (run: RestartRecoveryCandidate) => boolean;
   reason?: string;
 }): Promise<{ marked: number; skipped: number }> {
-  const sessionKeys = normalizeStringSet(params.sessionKeys);
-  const sessionIds = normalizeStringSet(params.sessionIds);
-  const preferSessionIdMatch = sessionIds.size > 0;
-  const activeRuns = [...(params.activeRuns ?? [])]
-    .map((run) => ({
-      runId: run.runId.trim(),
-      lifecycleGeneration: run.lifecycleGeneration.trim(),
-      sessionKey: run.sessionKey.trim(),
-      sessionId: run.sessionId.trim(),
-      observedAt: normalizeFiniteTimestamp(run.observedAt),
-    }))
-    .filter((run) => run.runId && run.lifecycleGeneration && (run.sessionKey || run.sessionId));
+  const activeRuns = [...params.activeRuns];
   const currentLifecycleGeneration = getAgentEventLifecycleGeneration();
   const result = { marked: 0, skipped: 0 };
   // Channel work can outlive its chat-run registration. The admission owner
   // retains the authoritative store and session identities until the turn releases.
   const activeAdmissions = collectActiveSessionWorkAdmissions();
-  if (
-    sessionKeys.size === 0 &&
-    sessionIds.size === 0 &&
-    activeRuns.length === 0 &&
-    activeAdmissions.size === 0
-  ) {
+  if (activeRuns.length === 0 && activeAdmissions.size === 0) {
     return result;
   }
 
@@ -162,25 +135,6 @@ export async function markRestartAbortedMainSessions(params: {
         `failed to resolve configured session stores for restart marker: ${String(err)}`,
       );
     }
-    for (const sessionKey of preferSessionIdMatch ? [] : sessionKeys) {
-      try {
-        const target = resolveGatewaySessionStoreTarget({
-          cfg,
-          key: sessionKey,
-        });
-        storePaths.add(path.resolve(target.storePath));
-        for (const storeKey of target.storeKeys) {
-          const trimmed = storeKey.trim();
-          if (trimmed) {
-            sessionKeys.add(trimmed);
-          }
-        }
-      } catch (err) {
-        mainSessionRecoveryLog.warn(
-          `failed to resolve session store for restart marker ${sessionKey}: ${String(err)}`,
-        );
-      }
-    }
   }
 
   for (const sessionsDir of await resolveAgentSessionDirs(stateDir)) {
@@ -191,17 +145,15 @@ export async function markRestartAbortedMainSessions(params: {
     storePaths.add(storePath);
   }
   for (const storePath of storePaths) {
-    const activeAdmissionIdentities = activeAdmissions.get(storePath) ?? new Set<string>();
     const storeResult = await markRecoveryStore({
       storePath,
       plan: (entry, sessionKey) => {
-        const registeredActiveRuns = listAgentRunsForSession({
-          sessionKey,
-          sessionId: entry.sessionId,
-        });
+        // The shutdown owner supplies paired identities. Recheck ownership after
+        // store discovery; an ID collision must not select a row or attach its fences.
         const matchingActiveRuns = activeRuns.filter(
           (run) =>
-            (run.sessionId ? run.sessionId === entry.sessionId : run.sessionKey === sessionKey) &&
+            run.sessionKey === sessionKey &&
+            run.sessionId === entry.sessionId &&
             (entry.status === "running" ||
               run.observedAt === undefined ||
               normalizeFiniteTimestamp(entry.updatedAt) === undefined ||
@@ -209,24 +161,12 @@ export async function markRestartAbortedMainSessions(params: {
                 run.lifecycleGeneration !== currentLifecycleGeneration)) &&
             params.isActiveRun?.(run) !== false,
         );
-        if (
-          entry.status !== "running" &&
-          matchingActiveRuns.length === 0 &&
-          registeredActiveRuns.length === 0 &&
-          !activeAdmissionIdentities.has(sessionKey) &&
-          !activeAdmissionIdentities.has(entry.sessionId)
-        ) {
-          return undefined;
-        }
-        const matchedActiveAdmission =
-          activeAdmissionIdentities.has(sessionKey) ||
-          activeAdmissionIdentities.has(entry.sessionId);
-        const matches =
-          matchedActiveAdmission ||
-          (typeof entry.sessionId === "string" && sessionIds.has(entry.sessionId)
-            ? true
-            : !preferSessionIdMatch && sessionKeys.has(sessionKey));
-        if (!matches) {
+        const matchedActiveAdmission = isSessionWorkAdmissionTargetActive({
+          scope: storePath,
+          sessionKey,
+          sessionId: entry.sessionId,
+        });
+        if (matchingActiveRuns.length === 0 && !matchedActiveAdmission) {
           return undefined;
         }
         const wasRunning = entry.status === "running";
@@ -234,7 +174,7 @@ export async function markRestartAbortedMainSessions(params: {
           ...(entry.restartRecoveryRuns ?? []).filter(
             (run) => run.lifecycleGeneration === currentLifecycleGeneration,
           ),
-          ...registeredActiveRuns,
+          ...listAgentRunsForSession({ sessionKey, sessionId: entry.sessionId }),
           ...matchingActiveRuns.map(({ runId, lifecycleGeneration }) => ({
             runId,
             lifecycleGeneration,

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -601,7 +601,12 @@ describe("main-session-restart-recovery", () => {
     ]);
   });
 
-  it.each([
+  it.each<{
+    name: string;
+    identities: string[][];
+    expected: string[];
+    release?: boolean;
+  }>([
     { name: "paired channel turn", identities: [["main", "session-main"]], expected: ["main"] },
     { name: "key-only channel turn", identities: [["main"]], expected: ["main"] },
     { name: "ID-only turn", identities: [["session-main"]], expected: ["main", "stale"] },

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -23,9 +23,9 @@ import {
 } from "../../config/sessions/session-accessor.js";
 import { resolveAgentRestartRecoveryExecutionIdentityAdmission } from "../../gateway/agent-turn/agent-restart-recovery-context.js";
 import { callGateway } from "../../gateway/call.js";
+import type { RestartRecoveryCandidate } from "../../gateway/chat-abort.js";
 import type { GatewayRecoveryRuntime } from "../../gateway/server-instance-runtime.types.js";
 import { persistGatewaySessionLifecycleEvent } from "../../gateway/session-lifecycle-state.js";
-import * as gatewaySessionUtils from "../../gateway/session-utils.js";
 import {
   getAgentEventLifecycleGeneration,
   resetAgentEventsForTest,
@@ -246,6 +246,20 @@ function runningSessionEntry(sessionId: string, overrides: SessionEntryFixture =
     status: "running",
     ...overrides,
   });
+}
+
+function activeRestartRun(
+  sessionKey = "agent:main:main",
+  sessionId = "main-session",
+  overrides: Partial<RestartRecoveryCandidate> = {},
+): RestartRecoveryCandidate {
+  return {
+    sessionKey,
+    sessionId,
+    runId: "restart-run",
+    lifecycleGeneration: getAgentEventLifecycleGeneration(),
+    ...overrides,
+  };
 }
 
 function mainSessionStore(
@@ -486,7 +500,50 @@ function codeModeWaitCallMessage() {
 }
 
 describe("main-session-restart-recovery", () => {
-  it("marks only matching running main sessions by active session key", async () => {
+  it.each([
+    { name: "stale same-id rows", keys: ["active"], live: true },
+    { name: "cross-session run fences", keys: ["active", "sibling"], live: true },
+    { name: "closed owners of running rows", keys: ["active"], live: false },
+  ])("preserves exact restart identities against $name", async ({ keys, live }) => {
+    const sessionsDir = await makeSessionsDir();
+    const storePath = path.join(sessionsDir, "sessions.json");
+    const sessionKeys = ["agent:main:active", "agent:main:sibling"];
+    await writeStore(
+      sessionsDir,
+      Object.fromEntries(sessionKeys.map((key) => [key, runningSessionEntry("shared-session")])),
+    );
+    const activeRuns = keys.map((key) => ({
+      runId: `run-${key}`,
+      lifecycleGeneration: getAgentEventLifecycleGeneration(),
+      sessionKey: `agent:main:${key}`,
+      sessionId: "shared-session",
+    }));
+    for (const run of activeRuns) {
+      registerAgentRunContext(run.runId, run);
+    }
+    let ownerActive = true;
+    queueMicrotask(() => {
+      ownerActive = live;
+    });
+    const result = await markRestartAbortedMainSessions({
+      stateDir: tmpDir,
+      activeRuns,
+      isActiveRun: () => ownerActive,
+    });
+    expect(result).toEqual({ marked: live ? keys.length : 0, skipped: 0 });
+    const store = readStore(storePath);
+    for (const key of sessionKeys) {
+      const expected = activeRuns.filter((run) => live && run.sessionKey === key);
+      expect(store[key]?.abortedLastRun).toBe(expected.length > 0 ? true : undefined);
+      expect(store[key]?.restartRecoveryRuns).toEqual(
+        expected.length > 0
+          ? expected.map(({ runId, lifecycleGeneration }) => ({ runId, lifecycleGeneration }))
+          : undefined,
+      );
+    }
+  });
+
+  it("marks only recoverable sessions owned by active runs", async () => {
     // Only top-level running main sessions are restart-recoverable. Completed,
     // child, cron, and non-active sessions must not be marked.
     const sessionsDir = await makeSessionsDir();
@@ -524,7 +581,10 @@ describe("main-session-restart-recovery", () => {
     });
     const result = await markRestartAbortedMainSessions({
       stateDir: tmpDir,
-      sessionKeys: ["agent:main:main", "agent:main:completed", "agent:main:subagent:child"],
+      activeRuns: [
+        activeRestartRun(),
+        activeRestartRun("agent:main:subagent:child", "child-session"),
+      ],
     });
 
     const store = readStore(path.join(sessionsDir, "sessions.json"));
@@ -541,31 +601,71 @@ describe("main-session-restart-recovery", () => {
     ]);
   });
 
-  it("marks an admitted channel turn when no chat run remains", async () => {
+  it.each([
+    { name: "paired channel turn", identities: [["main", "session-main"]], expected: ["main"] },
+    { name: "key-only channel turn", identities: [["main"]], expected: ["main"] },
+    { name: "ID-only turn", identities: [["session-main"]], expected: ["main", "stale"] },
+    {
+      name: "crossed pairs from separate turns",
+      identities: [
+        ["main", "session-sibling"],
+        ["sibling", "session-main"],
+      ],
+      expected: [],
+    },
+    { name: "stale paired ID", identities: [["main", "old-session"]], expected: [] },
+    {
+      name: "released channel turn",
+      identities: [["main", "session-main"]],
+      expected: [],
+      release: true,
+    },
+  ])("recovers an admitted $name without a chat run", async ({ identities, expected, release }) => {
     const storePath = path.join(tmpDir, "admitted-channel", "sessions.json");
-    const sessionKey = "agent:main:main";
-    const sessionId = "admitted-channel-session";
-    await writeStorePath(storePath, {
-      [sessionKey]: runningSessionEntry(sessionId),
-    });
-    const admission = await beginSessionWorkAdmission({
-      scope: storePath,
-      identities: [sessionKey, sessionId],
-      assertAllowed: () => undefined,
-    });
-
+    const otherStorePath = path.join(tmpDir, "other-admitted-channel", "sessions.json");
+    const key = (name: string) => `agent:main:${name}`;
+    const entries = {
+      [key("main")]: runningSessionEntry("session-main"),
+      [key("sibling")]: runningSessionEntry("session-sibling"),
+      [key("stale")]: runningSessionEntry("session-main"),
+    };
+    await writeStorePath(storePath, entries);
+    await writeStorePath(otherStorePath, entries);
+    const admissions = await Promise.all(
+      identities.map((group) =>
+        beginSessionWorkAdmission({
+          scope: storePath,
+          identities: group.map((identity) =>
+            identity === "main" || identity === "sibling" ? key(identity) : identity,
+          ),
+          assertAllowed: () => undefined,
+        }),
+      ),
+    );
+    if (release) {
+      queueMicrotask(() => admissions.forEach((admission) => admission.release()));
+    }
     try {
-      await expect(markRestartAbortedMainSessions({ stateDir: tmpDir })).resolves.toEqual({
-        marked: 1,
+      await expect(
+        markRestartAbortedMainSessions({
+          cfg: { session: { store: otherStorePath } },
+          stateDir: tmpDir,
+          activeRuns: [],
+        }),
+      ).resolves.toEqual({
+        marked: expected.length,
         skipped: 0,
       });
-      expect(readStore(storePath)[sessionKey]).toMatchObject({
-        status: "running",
-        abortedLastRun: true,
-        restartRecoveryForceSafeTools: true,
-      });
+      const store = readStore(storePath);
+      for (const name of ["main", "sibling", "stale"]) {
+        expect(store[key(name)]?.abortedLastRun).toBe(expected.includes(name) ? true : undefined);
+        expect(store[key(name)]?.restartRecoveryForceSafeTools).toBe(
+          expected.includes(name) ? true : undefined,
+        );
+        expect(readStore(otherStorePath)[key(name)]?.abortedLastRun).toBeUndefined();
+      }
     } finally {
-      admission.release();
+      admissions.forEach((admission) => admission.release());
     }
   });
 
@@ -617,7 +717,7 @@ describe("main-session-restart-recovery", () => {
     const result = await markRestartAbortedMainSessions({
       cfg: { session: { store: storePath } },
       stateDir: tmpDir,
-      sessionKeys: ["agent:main:issue-82433"],
+      activeRuns: [activeRestartRun("agent:main:issue-82433", "custom-session")],
     });
 
     const store = readStore(storePath);
@@ -687,8 +787,6 @@ describe("main-session-restart-recovery", () => {
 
     const result = await markRestartAbortedMainSessions({
       stateDir: tmpDir,
-      sessionKeys: ["agent:main:main"],
-      sessionIds: ["main-session"],
       activeRuns: [
         {
           runId: "cleared-context-run",
@@ -724,8 +822,6 @@ describe("main-session-restart-recovery", () => {
 
     const result = await markRestartAbortedMainSessions({
       stateDir: tmpDir,
-      sessionKeys: ["agent:main:main"],
-      sessionIds: ["main-session"],
       activeRuns: [
         {
           runId: "queued-run",
@@ -753,42 +849,6 @@ describe("main-session-restart-recovery", () => {
     expect(store["agent:main:main"]?.startedAt).toBeUndefined();
     expect(store["agent:main:main"]?.endedAt).toBeUndefined();
     expect(store["agent:main:main"]?.runtimeMs).toBeUndefined();
-  });
-
-  it("marks queued registered runs before lifecycle start without explicit candidates", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, {
-      "agent:main:main": {
-        sessionId: "main-session",
-        updatedAt: Date.now() - 10_000,
-        status: "done",
-      },
-    });
-    registerAgentRunContext("queued-context-run", {
-      sessionKey: "agent:main:main",
-      sessionId: "main-session",
-    });
-
-    const result = await markRestartAbortedMainSessions({
-      stateDir: tmpDir,
-      sessionKeys: ["agent:main:main"],
-      sessionIds: ["main-session"],
-    });
-
-    const store = readStore(path.join(sessionsDir, "sessions.json"));
-    expect(result).toEqual({ marked: 1, skipped: 0 });
-    expect(store["agent:main:main"]).toEqual(
-      expect.objectContaining({
-        status: "running",
-        abortedLastRun: true,
-        restartRecoveryRuns: [
-          {
-            runId: "queued-context-run",
-            lifecycleGeneration: getAgentEventLifecycleGeneration(),
-          },
-        ],
-      }),
-    );
   });
 
   it.each([
@@ -836,8 +896,6 @@ describe("main-session-restart-recovery", () => {
 
     const result = await markRestartAbortedMainSessions({
       stateDir: tmpDir,
-      sessionKeys: ["agent:main:main"],
-      sessionIds: ["main-session"],
       activeRuns: [
         {
           runId,
@@ -873,8 +931,6 @@ describe("main-session-restart-recovery", () => {
 
     await markRestartAbortedMainSessions({
       stateDir: tmpDir,
-      sessionKeys: ["agent:main:main"],
-      sessionIds: ["main-session"],
       activeRuns: [
         {
           runId: "second-restart-run",
@@ -912,8 +968,6 @@ describe("main-session-restart-recovery", () => {
 
     await markRestartAbortedMainSessions({
       stateDir: tmpDir,
-      sessionKeys: ["agent:main:main"],
-      sessionIds: ["main-session"],
       activeRuns: [
         {
           runId: "shared-run",
@@ -933,7 +987,7 @@ describe("main-session-restart-recovery", () => {
     ]);
   });
 
-  it("uses active session ids to avoid marking stale duplicate keys in another store", async () => {
+  it("uses active pairs to avoid marking stale duplicate keys in another store", async () => {
     // Custom and default stores can contain the same session key. Active ids
     // keep restart marking tied to the store that owned the interrupted run.
     const defaultSessionsDir = await makeSessionsDir();
@@ -953,8 +1007,7 @@ describe("main-session-restart-recovery", () => {
     const result = await markRestartAbortedMainSessions({
       cfg: { session: { store: storePath } },
       stateDir: tmpDir,
-      sessionIds: ["active-custom-session"],
-      sessionKeys: ["agent:main:issue-82433"],
+      activeRuns: [activeRestartRun("agent:main:issue-82433", "active-custom-session")],
     });
 
     const defaultStore = readStore(path.join(defaultSessionsDir, "sessions.json"));
@@ -962,56 +1015,6 @@ describe("main-session-restart-recovery", () => {
     expect(result).toEqual({ marked: 1, skipped: 0 });
     expect(defaultStore["agent:main:issue-82433"]?.abortedLastRun).toBeUndefined();
     expect(customStore["agent:main:issue-82433"]?.abortedLastRun).toBe(true);
-  });
-
-  it("does not resolve session keys when session ids are authoritative", async () => {
-    const candidates = Array.from({ length: 24 }, (_, index) => ({
-      sessionId: `active-session-${index}`,
-      sessionKey: `agent:main:active-${index}`,
-    }));
-    const storePath = path.join(tmpDir, "custom-many-active", "sessions.json");
-    await writeStorePath(
-      storePath,
-      Object.fromEntries(
-        candidates.map(({ sessionId, sessionKey }) => [sessionKey, runningSessionEntry(sessionId)]),
-      ),
-    );
-    const resolveTarget = vi.spyOn(gatewaySessionUtils, "resolveGatewaySessionStoreTarget");
-
-    try {
-      const result = await markRestartAbortedMainSessions({
-        cfg: { session: { store: storePath } },
-        stateDir: tmpDir,
-        sessionIds: candidates.map(({ sessionId }) => sessionId),
-        sessionKeys: candidates.map(({ sessionKey }) => sessionKey),
-      });
-
-      const store = readStore(storePath);
-      expect(result).toEqual({ marked: candidates.length, skipped: 0 });
-      expect(candidates.every(({ sessionKey }) => store[sessionKey]?.abortedLastRun)).toBe(true);
-      expect(resolveTarget).not.toHaveBeenCalled();
-    } finally {
-      resolveTarget.mockRestore();
-    }
-  });
-
-  it("marks custom-store sessions by session id when no session key is available", async () => {
-    const storePath = path.join(tmpDir, "custom-by-id", "sessions.json");
-    await writeStorePath(storePath, {
-      "agent:main:custom-by-id": {
-        ...runningSessionEntry("custom-session-id-only"),
-      },
-    });
-
-    const result = await markRestartAbortedMainSessions({
-      cfg: { session: { store: storePath } },
-      stateDir: tmpDir,
-      sessionIds: ["custom-session-id-only"],
-    });
-
-    const store = readStore(storePath);
-    expect(result).toEqual({ marked: 1, skipped: 0 });
-    expect(store["agent:main:custom-by-id"]?.abortedLastRun).toBe(true);
   });
 
   it("resumes marked sessions with a tool-result transcript tail", async () => {
@@ -1042,7 +1045,7 @@ describe("main-session-restart-recovery", () => {
     await expect(
       markRestartAbortedMainSessions({
         stateDir: tmpDir,
-        sessionKeys: [sessionKey],
+        activeRuns: [activeRestartRun(sessionKey)],
         reason: "gateway restart drain",
       }),
     ).resolves.toEqual({ marked: 1, skipped: 0 });
@@ -1113,8 +1116,6 @@ describe("main-session-restart-recovery", () => {
       await expect(
         markRestartAbortedMainSessions({
           stateDir: tmpDir,
-          sessionKeys: [sessionKey],
-          sessionIds: ["main-session"],
           activeRuns: [{ runId, lifecycleGeneration, sessionKey, sessionId: "main-session" }],
           reason: "gateway restart drain",
         }),

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -853,8 +853,6 @@ describe("createGatewayCloseHandler", () => {
     expect(result.warnings).toContain("restart-reply-drain");
     expect(markMainSessionsAbortedForRestart).toHaveBeenCalledWith(
       expect.objectContaining({
-        sessionKeys: new Set(),
-        sessionIds: new Set(),
         activeRuns: [],
         reason: "gateway restart shutdown",
       }),
@@ -1222,12 +1220,6 @@ describe("createGatewayCloseHandler", () => {
     expect(events[0]).toBe("marker");
     const markerCall = firstMockCall(markMainSessionsAbortedForRestart);
     expect(markerCall?.[0]?.reason).toBe("gateway restart shutdown");
-    expect(markerCall?.[0]?.sessionKeys).toStrictEqual(
-      new Set(["agent:main:main", "agent:main:test:direct:source"]),
-    );
-    expect(markerCall?.[0]?.sessionIds).toStrictEqual(
-      new Set(["current-session-id-1", "session-id-2"]),
-    );
     expect(markerCall?.[0]?.activeRuns).toEqual([
       {
         runId: "run-1",
@@ -1402,8 +1394,6 @@ describe("createGatewayCloseHandler", () => {
 
     expect(markMainSessionsAbortedForRestart).toHaveBeenCalledWith(
       expect.objectContaining({
-        sessionKeys: new Set(),
-        sessionIds: new Set(),
         activeRuns: [],
       }),
     );
@@ -1557,6 +1547,7 @@ describe("createGatewayCloseHandler", () => {
           controller,
           sessionId: "session-id-1",
           sessionKey: "agent:main:main",
+          lifecycleGeneration: "generation-1",
           startedAtMs: Date.now(),
           expiresAtMs: Date.now() + 60_000,
         },

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -208,23 +208,9 @@ type RestartRunAbortParams = {
   broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
   nodeSendToSession: (sessionKey: string, event: string, payload: unknown) => void;
   markMainSessionsAbortedForRestart?: (params: {
-    sessionKeys: Set<string>;
-    sessionIds: Set<string>;
-    activeRuns: Array<{
-      runId: string;
-      lifecycleGeneration: string;
-      sessionKey: string;
-      sessionId: string;
-      observedAt?: number;
-    }>;
+    activeRuns: RestartRecoveryCandidate[];
     reason: string;
-    isActiveRun: (run: {
-      runId: string;
-      lifecycleGeneration: string;
-      sessionKey: string;
-      sessionId: string;
-      observedAt?: number;
-    }) => boolean;
+    isActiveRun: (run: RestartRecoveryCandidate) => boolean;
   }) => Promise<void> | void;
   resolveActiveSessionIdForKey?: (sessionKey: string) => string | undefined;
 };
@@ -270,24 +256,10 @@ function collectActiveRestartSessionRefs(
     RestartRunAbortParams,
     "chatAbortControllers" | "resolveActiveSessionIdForKey" | "restartRecoveryCandidates"
   >,
-): {
-  sessionKeys: Set<string>;
-  sessionIds: Set<string>;
-  activeRuns: Array<{
-    runId: string;
-    lifecycleGeneration: string;
-    sessionKey: string;
-    sessionId: string;
-    observedAt?: number;
-  }>;
-} {
-  const sessionKeys = new Set<string>();
-  const sessionIds = new Set<string>();
+): RestartRecoveryCandidate[] {
   const activeRuns = new Map<string, RestartRecoveryCandidate>();
   const observedAt = Date.now();
   const addRun = (run: RestartRecoveryCandidate) => {
-    sessionKeys.add(run.sessionKey);
-    sessionIds.add(run.sessionId);
     activeRuns.set(`${run.runId}\u0000${run.lifecycleGeneration}`, {
       ...run,
       observedAt: run.observedAt ?? observedAt,
@@ -295,18 +267,12 @@ function collectActiveRestartSessionRefs(
   };
   for (const [runId, entry] of listRestartRecoveryRuns(params.chatAbortControllers)) {
     const sessionKey = entry.sessionKey.trim();
-    if (sessionKey) {
-      sessionKeys.add(sessionKey);
-    }
     // Registration metadata can predate a reset or compaction session-id rotation.
     const resolvedSessionId =
       entry.kind === "agent" || !sessionKey
         ? undefined
         : params.resolveActiveSessionIdForKey?.(sessionKey);
     const sessionId = resolvedSessionId || entry.sessionId.trim();
-    if (sessionId) {
-      sessionIds.add(sessionId);
-    }
     if (runId && entry.lifecycleGeneration && sessionKey && sessionId) {
       addRun({
         runId,
@@ -324,7 +290,7 @@ function collectActiveRestartSessionRefs(
       sessionId: resolvedSessionId || candidate.sessionId,
     });
   }
-  return { sessionKeys, sessionIds, activeRuns: [...activeRuns.values()] };
+  return [...activeRuns.values()];
 }
 
 async function settleTerminalSessionPersistenceForRestart(
@@ -374,7 +340,7 @@ async function markActiveRunsForRestartRecovery(
     return;
   }
   await settleTerminalSessionPersistenceForRestart(params.chatAbortControllers);
-  const refs = collectActiveRestartSessionRefs(params);
+  const activeRuns = collectActiveRestartSessionRefs(params);
   try {
     const markerTimeout = createTimeoutRace(
       RESTART_MARKER_SLOW_WARNING_MS,
@@ -382,7 +348,7 @@ async function markActiveRunsForRestartRecovery(
     );
     const markerOutcome = Promise.resolve(
       params.markMainSessionsAbortedForRestart({
-        ...refs,
+        activeRuns,
         reason: params.reason,
         isActiveRun: (run) => {
           const entry = params.chatAbortControllers.get(run.runId);
@@ -415,7 +381,7 @@ async function markActiveRunsForRestartRecovery(
     } else if (firstOutcome.status === "failed") {
       throw firstOutcome.error;
     }
-    for (const run of refs.activeRuns) {
+    for (const run of activeRuns) {
       params.restartRecoveryCandidates?.delete(run.runId);
     }
   } catch (err) {

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -528,20 +528,10 @@ export async function prepareGatewayLifecycle(params: {
       agentRunSeq,
       nodeSendToSession,
       resolveActiveSessionIdForKey: resolveActiveEmbeddedRunSessionId,
-      markMainSessionsAbortedForRestart: async ({
-        sessionKeys,
-        sessionIds,
-        activeRuns,
-        reason,
-        isActiveRun,
-      }) => {
+      markMainSessionsAbortedForRestart: async (restart) => {
         await shutdownRuntime.markRestartAbortedMainSessions({
           cfg: getRuntimeConfig(),
-          sessionKeys,
-          sessionIds,
-          activeRuns,
-          isActiveRun,
-          reason,
+          ...restart,
         });
       },
       getPendingReplyCount: getTotalPendingReplies,

--- a/src/infra/agent-run-registry.ts
+++ b/src/infra/agent-run-registry.ts
@@ -527,9 +527,9 @@ export function listAgentRunsForSession(params: {
   const state = getAgentRunRegistryState();
   const runs: Array<{ runId: string; lifecycleGeneration: string }> = [];
   for (const [runId, context] of state.contexts) {
-    const matches = context.sessionId
-      ? context.sessionId === params.sessionId
-      : context.sessionKey === params.sessionKey;
+    const matches =
+      context.sessionKey === params.sessionKey &&
+      (!context.sessionId || context.sessionId === params.sessionId);
     if (matches && context.lifecycleGeneration === state.lifecycleGeneration) {
       runs.push({ runId, lifecycleGeneration: context.lifecycleGeneration });
     }

--- a/src/sessions/session-lifecycle-admission.ts
+++ b/src/sessions/session-lifecycle-admission.ts
@@ -337,6 +337,26 @@ export function isSessionWorkAdmissionActive(
   );
 }
 
+export function isSessionWorkAdmissionTargetActive(params: {
+  scope: string;
+  sessionKey: string;
+  sessionId: string;
+}): boolean {
+  const identities = normalizeSessionIdentities(params.scope, [
+    params.sessionKey,
+    params.sessionId,
+  ]);
+  // Singleton leases intentionally own one identity. Multi-identity leases must
+  // cover the pair together; pooling owners would manufacture a false pair.
+  return identities.some((identity) =>
+    Array.from(ACTIVE_SESSION_WORK_ADMISSIONS.get(identity) ?? []).some(
+      (admission) =>
+        admission.identities.size === 1 ||
+        identities.every((target) => admission.identities.has(target)),
+    ),
+  );
+}
+
 /** Whether another admitted turn currently owns any of these session identities. */
 export function isCompetingSessionWorkAdmissionActive(
   scope: string,


### PR DESCRIPTION
Closes #121869

## What Problem This Solves

Fixes an issue where operators restarting the Gateway could have a stale conversation marked for recovery when it shared only a session key or ID with a known active conversation. Two active conversations sharing an ID could also acquire each other's recovery run fences.

## Why This Change Was Made

The Gateway shutdown owner already supplies complete active-run identities. This repair keeps each key and ID together through row selection and registry-fence lookup, removing independent key/ID arguments, duplicate normalization/store resolution, and parallel shutdown bookkeeping. The obsolete CLI marker removed by #129316 stays removed.

The rewrite also preserves #130491's newly landed recovery for admitted channel turns after chat-run cleanup. Restart marking now checks the existing live admission owner: a multi-identity lease must contain the row's key and ID together; identities from different leases cannot be combined. Genuine singleton leases retain their scoped one-identity behavior, including key-only channel leases that span backing-ID rotation. The flat admission collector remains unchanged for maintenance's broader protect-any-owned-identity contract.

Admission-only recovery still sets restart-safe-tools policy and discovers the admission's store. Released leases are rechecked after asynchronous store discovery. Startup-orphan recovery and database transactions remain unchanged; no new configuration, schema, migration, retention, or persisted fields are introduced.

## User Impact

Complete active identities no longer widen into unrelated rows or cross-session recovery fences. Admitted channel work remains recoverable even after its chat-run registration is gone, and existing unpaired lease behavior is preserved.

Thanks @barbarhan for the report and initial repair. The current rewrite is **-84 production LOC, -3 test LOC, -87 total LOC** across seven files. Removed tests cover retired internal invocation modes; new tests exercise the actual owner boundary.

## Evidence

Current head: `c02a1f6a83f179bc6d682f19c8eb5def696bd0f8`, based on `0b0cff180bedb7e8c628549e201efcc4488f752a`. All seven source/test files were frozen and SHA-256 recorded. The last commit only declares the test table's case type; production code and test behavior are identical to the preceding `a8f9d9026ae5` candidate.

- Before the original repair, three real-SQLite regressions failed: stale same-ID row selection, cross-session run fences, and a running row selected after its active-run owner closed.
- Integrating #130491 exposed four additional real-SQLite failures before the admission predicate: paired collision selected 2 rows instead of 1; crossed leases selected 3 instead of 0; stale paired ID selected 1 instead of 0; a released lease selected 2 instead of 0. The key-only and ID-only contracts passed before and after.
- **367 focused and sibling tests passed** on the production-equivalent candidate: restart recovery 177, Gateway close 56, agent events 46, lifecycle admission 30, history eviction 10, reply-turn admission 48. This covers genuine active shutdown, admission-only shutdown, queued/terminal rows, compaction rotation, custom stores, startup-orphan recovery, maintenance protection, and failures. After the type-only correction, all six admission regressions, the owning TypeScript graph, formatting, and lint passed again.
- Two independent no-mock temporary-SQLite probes passed on the current head: all three active-run scenarios and all six admission scenarios. They check exact fences, safe-tools marking, stale same-key/different-ID exclusion, identical rows in another store remaining untouched, and temporary-state removal.
- Full build passed, including all runtime/plugin phases, SDK output, Control UI build and performance guards. The build records `a8f9d9026ae5ed6944fb3650a72d9a9ea8f595f8`; the subsequent `c02a1f6a` commit only adds an erased test-case type. This is production-equivalent build proof, not a relabeled build stamp.
- Fresh real built-Gateway proof passed on the final checkout: an actual admitted chat reached a held loopback HTTP/SSE provider, a stale different-key/same-ID SQLite row was seeded, and the real CLI ran `gateway restart --force --json`. At shutdown marking, the active row was marked with its own run fence and the stale row remained untouched. CLI exit was 0 after 57.197 seconds; both the Gateway client and real Control UI completed second handshakes, and the conversation remained visible. The browser, Gateway, model server, and temporary state were cleaned up; the probe exited 0.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33049138786) passed on `c02a1f6a83f179bc6d682f19c8eb5def696bd0f8`. The full local changed gate also exited 0, including all core/core-test typechecks, lint, formatting, Knip, dependency/architecture, database-first, runtime import and pairing guards.
- Fresh Codex autoreview reported no findings under its configured P0-only threshold. Owner/caller/sibling source review and behavior verification were performed separately.

```sh
env -u OPENCLAW_TESTBOX node scripts/run-vitest.mjs \
  src/agents/main-session-recovery/main-session-restart-recovery.test.ts \
  src/gateway/server-close.test.ts src/infra/agent-events.test.ts \
  src/sessions/session-lifecycle-admission.test.ts \
  src/config/sessions/session-history-eviction.test.ts \
  src/auto-reply/reply/reply-turn-admission.test.ts

env -u OPENCLAW_TESTBOX OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree \
  node scripts/check-changed.mjs --base 0b0cff180bedb7e8c628549e201efcc4488f752a -- \
  src/agents/main-session-recovery/main-session-restart-recovery-marking.ts \
  src/agents/main-session-recovery/main-session-restart-recovery.test.ts \
  src/gateway/server-close.ts src/gateway/server-close.test.ts \
  src/gateway/server-lifecycle.ts src/infra/agent-run-registry.ts \
  src/sessions/session-lifecycle-admission.ts

env -u OPENCLAW_TESTBOX pnpm build
```

### Review follow-through

Both rank-up moves from the [latest ClawSweeper review, August 27 at 07:24 UTC](https://github.com/openclaw/openclaw/pull/121478#issuecomment-5236878034) are addressed below: current-head actual-accessor collision output and a fresh built-Gateway restart trace with marked/untouched row results. No line-level defect remained in that review. Its older recommendation to propagate pairs through a second CLI marker is superseded by #129316, which deleted that duplicate owner. The current CLI restart goes through Gateway shutdown. The automated serialized-state flag does not represent a schema change: the added admission predicate only reads existing in-memory leases; no stored shape or database migration changed.

### Current-candidate behavior evidence

Redacted excerpts from the actual temporary-SQLite accessor probes on `c02a1f6a83f179bc6d682f19c8eb5def696bd0f8`:

```text
stale-key-same-id: marked=1, exactFences=true, staleSameKeyDifferentIdUntouched=true
two-active-pairs-share-id: marked=2, exactFences=true
owner-closes-during-store-discovery: marked=0
admission paired: marked=1, safeToolsExact=true, otherStoreUntouched=true
admission key-only: marked=1
admission ID-only: marked=2 (existing intentional singleton contract)
admission crossed-leases / stale-paired-ID / released: marked=0 each
temporaryStateRemoved=true
```

Real CLI/Gateway probe terminal output, with synthetic run fence omitted:

```json
{"stage":"shutdown-marker","elapsedMs":47936,"observed":{"activeMarked":true,"staleMarked":false}}
{"stage":"restart-command-complete","elapsedMs":57197,"code":0}
{"stage":"pass","gatewayRestartExit":0,"connections":2,"uiReconnected":true}
{"stage":"cleanup-complete","stateRemoved":true}
```

Before accepted restart, the real Control UI has the synthetic conversation in flight:

![Synthetic active conversation before restart](https://github.com/user-attachments/assets/5d405ade-5b01-4f18-b1a5-bcc834c0c27a)

After the second handshake, the conversation is still visible with recovery notices. This proves reconnection, not completed automatic recovery; see the startup-orphan limitation below.

![Synthetic conversation after Gateway reconnection](https://github.com/user-attachments/assets/a78f3b14-7d66-4219-816a-757de9326bc6)

Full 64-second recording (includes the cold-start delay):

https://github.com/user-attachments/assets/ba5857f3-e934-4731-b82e-35a150e195f6

### Boundaries and follow-ups

- The initial static gate and CI caught empty expected arrays inferred as `never[]`. The follow-up declares the table's case type explicitly; no assertion was weakened and no production logic changed.
- Liveness is rechecked after discovery, not atomically with the SQL commit. The existing replacement-plan/commit asynchronous gap needs a separately accepted accessor/concurrency design; this PR does not claim to close it.
- The first rebuilt live attempt timed out at the unchanged 120-second CLI deadline before any shutdown marker. Its persisted intent and CLI audit showed SIGUSR1 was sent but not consumed while cold Control UI catalog/auth work occupied the Gateway. A traced retry, without increasing the timeout or changing runtime code, passed: catalog/auth requests completed at about 47 seconds and the pending signal was then handled. Follow-up: investigate cold catalog/plugin discovery starving Gateway lifecycle processing. The successful 64-second recording includes this delay rather than hiding it.
- Visual proof covers shutdown selection and UI reconnection, not completed automatic recovery. The synthetic stale running row is subsequently picked up by the unchanged startup-orphan pass; sharing an ID also shares transcript state, so the capture shows two recovery notices and the stale row's recovery attempt reports a placement mismatch. Those startup-orphan/collision semantics remain a separate follow-up. The older candidate's stale-catalog warning was not present in the fresh post-reconnect capture.
- The test-instance command helper retains its losing deadline sleep after successful child exit. This can leave a standalone probe idle until its deadline after all Gateway/browser/model resources are cleaned. Follow-up: cancel that timer.
