### PR TITLE
fix: show cron code mode failures in run history

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -219,6 +219,14 @@ unrestricted `*` policy; `automations edit --clear-tools` restores that explicit
 policy. Existing jobs that predate an explicit tool policy retain their current behavior
 until their tool policy is explicitly edited or the job is recreated.
 
+For direct API/config edits, an omitted `toolsAllow` keeps the legacy inherited surface,
+an explicit empty list (`[]`) denies all optional tools, and `["*"]` is unrestricted.
+A finite list only materializes the named tool families. To include configured MCP tools,
+allow `bundle-mcp`, `group:plugins`, an exact `<server>__<tool>` selector, or `*`; a
+core-only list such as `["read", "exec"]` intentionally leaves the bundle MCP runtime off.
+OpenClaw records a warning in that run's diagnostics when a non-empty explicit list excludes
+configured MCP tools.
+
 `--model` sets the job's primary model; it does not replace a session `/model` override, so configured fallback chains still apply on top of it. An unresolved or disallowed model fails the run with an explicit validation error rather than silently falling back to the default. If a job has `--model` but no explicit or configured fallback list, OpenClaw passes an empty fallback override instead of silently appending the agent primary as a hidden retry target.
 
 Model-selection precedence for isolated jobs, highest first:

--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -576,6 +576,7 @@ export async function runPreparedEmbeddedLoop(
         hasPartialAssistantTextAfterPromptTimeout,
         attemptToolSummary,
         failureSignal,
+        terminalToolFailure,
       } = terminalPrepared;
 
       const terminalTimeoutResult = resolveEmbeddedRunTerminalTimeout({
@@ -595,6 +596,7 @@ export async function runPreparedEmbeddedLoop(
         finalAssistantRawText,
         attemptToolSummary,
         failureSignal,
+        terminalToolFailure,
       });
       if (terminalTimeoutResult) {
         return terminalTimeoutResult;
@@ -621,6 +623,7 @@ export async function runPreparedEmbeddedLoop(
         agentMeta,
         attemptToolSummary,
         failureSignal,
+        terminalToolFailure,
         maxReasoningOnlyRetryAttempts,
         maxEmptyResponseRetryAttempts,
         attemptCompactionCount: terminalAttemptCompactionCount,

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -92,6 +92,7 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
     };
   }
   const settledFailureSignal = prepared.failureSignal;
+  const settledTerminalToolFailure = prepared.terminalToolFailure;
 
   const runParams = input.terminalBase.runParams;
   const errorContext = input.terminalBase.activeErrorContext;
@@ -128,7 +129,11 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       terminalState,
     });
     // A failure-honest final answer cannot turn a settled cron denial into success.
-    prepared = { ...finalizedPrepared, failureSignal: settledFailureSignal };
+    prepared = {
+      ...finalizedPrepared,
+      failureSignal: settledFailureSignal,
+      terminalToolFailure: settledTerminalToolFailure,
+    };
     return {
       attempt,
       attemptAssistant: attempt.currentAttemptAssistant,

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
@@ -152,7 +152,7 @@ describe("prepareEmbeddedRunTerminal", () => {
     expect(prepared.terminalToolFailure).toEqual({
       source: "tool",
       toolName: "exec",
-      code: "invalid_input",
+      code: "UNKNOWN_TOOL_ID",
       message: "Unknown tool id: MCP.notes.read",
     });
   });

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
@@ -108,6 +108,54 @@ describe("prepareEmbeddedRunTerminal", () => {
       expect(prepared.finalAssistantRawText).toBeUndefined();
     },
   );
+
+  it("projects a Code Mode cron tool failure into terminal metadata", async () => {
+    const { prepareEmbeddedRunTerminal } = await import("./terminal-preparation.js");
+    const assistant = assistantMessage("stop");
+    const prepared = prepareEmbeddedRunTerminal({
+      runParams: {
+        sessionId: "session-1",
+        runId: "run-1",
+        workspaceDir: "/tmp/openclaw-test",
+        prompt: "hi",
+        trigger: "cron",
+        timeoutMs: 60_000,
+      },
+      attempt: attemptResult({
+        codeModeEngaged: true,
+        lastToolError: {
+          toolName: "exec",
+          errorCode: "invalid_input",
+          error: "Unknown tool id: MCP.notes.read",
+        },
+        lastAssistant: assistant,
+        currentAttemptAssistant: assistant,
+        currentAttemptCompletedAssistant: assistant,
+      }),
+      currentAttemptCompletedAssistant: assistant,
+      provider: "openai",
+      model: "gpt-5.4",
+      activeErrorContext: { provider: "openai", model: "gpt-5.4" },
+      authProfileStore: { version: 1, profiles: {} },
+      sessionIdUsed: "session-1",
+      outerContextTokenMeta: {},
+      usageAccumulator: createUsageAccumulator(),
+      contextRecoveryState: createEmbeddedRunContextRecoveryState(),
+      resolvedToolResultFormat: "markdown",
+      terminalState: {
+        outcome: { reason: "completed", status: "ok", stopReason: "stop" },
+        signalOwnedInterruption: false,
+      },
+    });
+
+    expect(prepared.failureSignal).toBeUndefined();
+    expect(prepared.terminalToolFailure).toEqual({
+      source: "tool",
+      toolName: "exec",
+      code: "invalid_input",
+      message: "Unknown tool id: MCP.notes.read",
+    });
+  });
 });
 
 describe("prepareEmbeddedRunTerminal run stats", () => {

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -6,6 +6,7 @@ import type { AgentRunTerminalReceipt } from "../../agent-run-terminal-receipt.j
 import type { AuthProfileStore } from "../../auth-profiles.js";
 import type { NormalizedUsage, UsageLike } from "../../usage.js";
 import { resolveEmbeddedRunFailureSignal } from "../failure-signal.js";
+import { resolveEmbeddedRunTerminalToolFailure } from "../terminal-tool-failure.js";
 import type { EmbeddedAgentMeta, EmbeddedAgentRunResult } from "../types.js";
 import type { UsageAccumulator } from "../usage-accumulator.js";
 import type { EmbeddedRunContextRecoveryState } from "./context-recovery-state.js";
@@ -56,6 +57,7 @@ export function prepareEmbeddedRunTerminal(input: {
   hasPartialAssistantTextAfterPromptTimeout: boolean;
   attemptToolSummary: ReturnType<typeof buildTraceToolSummary>;
   failureSignal: ReturnType<typeof resolveEmbeddedRunFailureSignal>;
+  terminalToolFailure: ReturnType<typeof resolveEmbeddedRunTerminalToolFailure>;
 } {
   const { runParams, attempt } = input;
   const { timedOutDuringCompaction, timedOutDuringToolExecution } = projectAgentRunAttemptTerminal(
@@ -251,6 +253,11 @@ export function prepareEmbeddedRunTerminal(input: {
     trigger: runParams.trigger,
     lastToolError: attempt.lastToolError,
   });
+  const terminalToolFailure = resolveEmbeddedRunTerminalToolFailure({
+    trigger: runParams.trigger,
+    codeModeEngaged: attempt.codeModeEngaged,
+    lastToolError: attempt.lastToolError,
+  });
   return {
     agentMeta,
     reportedModelRef,
@@ -264,6 +271,7 @@ export function prepareEmbeddedRunTerminal(input: {
     hasPartialAssistantTextAfterPromptTimeout,
     attemptToolSummary,
     failureSignal,
+    terminalToolFailure,
   };
 }
 

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -162,6 +162,7 @@ export async function resolveEmbeddedRunTerminal(input: {
   agentMeta: EmbeddedAgentMeta;
   attemptToolSummary: EmbeddedAgentRunResult["meta"]["toolSummary"];
   failureSignal?: EmbeddedRunFailureSignal;
+  terminalToolFailure?: EmbeddedAgentRunResult["meta"]["terminalToolFailure"];
   maxReasoningOnlyRetryAttempts: number;
   maxEmptyResponseRetryAttempts: number;
   attemptCompactionCount: number;
@@ -491,6 +492,7 @@ async function surfaceIncompleteTurn(
         },
         toolSummary: input.attemptToolSummary,
         ...(input.failureSignal ? { failureSignal: input.failureSignal } : {}),
+        ...(input.terminalToolFailure ? { terminalToolFailure: input.terminalToolFailure } : {}),
         agentHarnessResultClassification: input.attempt.agentHarnessResultClassification,
       },
       ...copyAttemptDeliveryState(input.attempt),
@@ -627,6 +629,7 @@ function completeEmbeddedRun(
         },
         toolSummary: input.attemptToolSummary,
         ...(input.failureSignal ? { failureSignal: input.failureSignal } : {}),
+        ...(input.terminalToolFailure ? { terminalToolFailure: input.terminalToolFailure } : {}),
         completion: {
           ...(stopReason ? { stopReason } : {}),
           ...(stopReason ? { finishReason: stopReason } : {}),

--- a/src/agents/embedded-agent-runner/run/terminal-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-timeout.ts
@@ -27,6 +27,7 @@ export function resolveEmbeddedRunTerminalTimeout(input: {
   finalAssistantRawText?: string;
   attemptToolSummary: EmbeddedAgentRunResult["meta"]["toolSummary"];
   failureSignal: EmbeddedAgentRunResult["meta"]["failureSignal"];
+  terminalToolFailure?: EmbeddedAgentRunResult["meta"]["terminalToolFailure"];
 }): EmbeddedAgentRunResult | undefined {
   if (
     !input.timedOutDuringPrompt ||
@@ -95,6 +96,7 @@ export function resolveEmbeddedRunTerminalTimeout(input: {
         : {}),
       toolSummary: input.attemptToolSummary,
       ...(input.failureSignal ? { failureSignal: input.failureSignal } : {}),
+      ...(input.terminalToolFailure ? { terminalToolFailure: input.terminalToolFailure } : {}),
       agentHarnessResultClassification: input.attempt.agentHarnessResultClassification,
     },
     ...copyAttemptDeliveryState(input.attempt),

--- a/src/agents/embedded-agent-runner/terminal-tool-failure.test.ts
+++ b/src/agents/embedded-agent-runner/terminal-tool-failure.test.ts
@@ -17,7 +17,7 @@ describe("resolveEmbeddedRunTerminalToolFailure", () => {
     ).toEqual({
       source: "tool",
       toolName: "exec",
-      code: "invalid_input",
+      code: "UNKNOWN_TOOL_ID",
       message: "Unknown tool id: MCP.notes.read",
     });
   });
@@ -36,12 +36,12 @@ describe("resolveEmbeddedRunTerminalToolFailure", () => {
     ).toEqual({
       source: "tool",
       toolName: "wait",
-      code: "invalid_input",
+      code: "UNKNOWN_TOOL_ID",
       message: "Unknown tool id: MCP.notes.read",
     });
   });
 
-  it("keeps ordinary exec and structured denial failures on their existing paths", () => {
+  it("keeps ordinary exec, structured denials, and arbitrary private errors on existing paths", () => {
     const base = {
       trigger: "cron",
       lastToolError: { toolName: "exec", error: "command failed" },
@@ -55,21 +55,43 @@ describe("resolveEmbeddedRunTerminalToolFailure", () => {
         lastToolError: { ...base.lastToolError, errorCode: "SYSTEM_RUN_DENIED" },
       }),
     ).toBeUndefined();
+    expect(
+      resolveEmbeddedRunTerminalToolFailure({
+        ...base,
+        codeModeEngaged: true,
+        lastToolError: {
+          ...base.lastToolError,
+          error: "Unknown tool id: MCP.notes.read; private output: /home/operator/.config/token",
+        },
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveEmbeddedRunTerminalToolFailure({
+        ...base,
+        codeModeEngaged: true,
+        lastToolError: {
+          ...base.lastToolError,
+          error: "OPENAI_API_KEY=sk-test-abcdefghijklmnopqrstuvwxyz",
+        },
+      }),
+    ).toBeUndefined();
   });
 
-  it("redacts, flattens, and bounds terminal metadata", () => {
+  it("normalizes only the allowlisted tool identifier into history metadata", () => {
     const result = resolveEmbeddedRunTerminalToolFailure({
       trigger: "cron",
       codeModeEngaged: true,
       lastToolError: {
         toolName: "exec",
-        error: `OPENAI_API_KEY=sk-test-abcdefghijklmnopqrstuvwxyz\n${"x".repeat(700)}`,
+        error: "Unknown tool id: MCP.notes.read",
       },
     });
 
-    expect(result?.message).not.toContain("sk-test-abcdefghijklmnopqrstuvwxyz");
-    expect(result?.message).not.toContain("\n");
-    expect(result?.message.length).toBeLessThanOrEqual(501);
-    expect(result?.message.endsWith("…")).toBe(true);
+    expect(result).toEqual({
+      source: "tool",
+      toolName: "exec",
+      code: "UNKNOWN_TOOL_ID",
+      message: "Unknown tool id: MCP.notes.read",
+    });
   });
 });

--- a/src/agents/embedded-agent-runner/terminal-tool-failure.test.ts
+++ b/src/agents/embedded-agent-runner/terminal-tool-failure.test.ts
@@ -1,0 +1,75 @@
+// Coverage for bounded Code Mode failure projection into terminal metadata.
+import { describe, expect, it } from "vitest";
+import { resolveEmbeddedRunTerminalToolFailure } from "./terminal-tool-failure.js";
+
+describe("resolveEmbeddedRunTerminalToolFailure", () => {
+  it("projects a sanitized Code Mode cron failure", () => {
+    expect(
+      resolveEmbeddedRunTerminalToolFailure({
+        trigger: "cron",
+        codeModeEngaged: true,
+        lastToolError: {
+          toolName: "exec",
+          errorCode: "invalid_input",
+          error: "Unknown tool id: MCP.notes.read",
+        },
+      }),
+    ).toEqual({
+      source: "tool",
+      toolName: "exec",
+      code: "invalid_input",
+      message: "Unknown tool id: MCP.notes.read",
+    });
+  });
+
+  it("projects a failed resumed Code Mode run from the wait control", () => {
+    expect(
+      resolveEmbeddedRunTerminalToolFailure({
+        trigger: "cron",
+        codeModeEngaged: true,
+        lastToolError: {
+          toolName: "wait",
+          errorCode: "invalid_input",
+          error: "Unknown tool id: MCP.notes.read",
+        },
+      }),
+    ).toEqual({
+      source: "tool",
+      toolName: "wait",
+      code: "invalid_input",
+      message: "Unknown tool id: MCP.notes.read",
+    });
+  });
+
+  it("keeps ordinary exec and structured denial failures on their existing paths", () => {
+    const base = {
+      trigger: "cron",
+      lastToolError: { toolName: "exec", error: "command failed" },
+    } as const;
+
+    expect(resolveEmbeddedRunTerminalToolFailure(base)).toBeUndefined();
+    expect(
+      resolveEmbeddedRunTerminalToolFailure({
+        ...base,
+        codeModeEngaged: true,
+        lastToolError: { ...base.lastToolError, errorCode: "SYSTEM_RUN_DENIED" },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("redacts, flattens, and bounds terminal metadata", () => {
+    const result = resolveEmbeddedRunTerminalToolFailure({
+      trigger: "cron",
+      codeModeEngaged: true,
+      lastToolError: {
+        toolName: "exec",
+        error: `OPENAI_API_KEY=sk-test-abcdefghijklmnopqrstuvwxyz\n${"x".repeat(700)}`,
+      },
+    });
+
+    expect(result?.message).not.toContain("sk-test-abcdefghijklmnopqrstuvwxyz");
+    expect(result?.message).not.toContain("\n");
+    expect(result?.message.length).toBeLessThanOrEqual(501);
+    expect(result?.message.endsWith("…")).toBe(true);
+  });
+});

--- a/src/agents/embedded-agent-runner/terminal-tool-failure.ts
+++ b/src/agents/embedded-agent-runner/terminal-tool-failure.ts
@@ -1,17 +1,18 @@
-/** Projects a bounded tool failure into terminal metadata for operator diagnostics. */
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { redactSensitiveText } from "../../logging/redact.js";
-import { truncateUtf16Safe } from "../../utils.js";
+/** Projects a safe Code Mode catalog miss into terminal metadata for operator diagnostics. */
 import { CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME } from "../code-mode-control-tools.js";
 import type { ToolErrorSummary } from "../tool-error-summary.js";
 import { normalizeToolName } from "../tool-policy.js";
 import type { EmbeddedRunTerminalToolFailure } from "./types.js";
 
-const MAX_TERMINAL_TOOL_FAILURE_CHARS = 500;
+// Only persist the catalog-miss form emitted by the Code Mode bridge. Tool
+// error text otherwise can contain command output, private paths, or values
+// that known-secret redaction cannot establish as safe for durable history.
+const SAFE_MCP_CATALOG_MISS = /^Unknown tool id: (MCP\.[A-Za-z0-9][A-Za-z0-9._-]*)$/;
 
 /**
- * Preserves the already-sanitized outer Code Mode failure for cron history.
- * Ordinary exec stderr stays on the existing generic presentation path.
+ * Preserves one strictly allowlisted Code Mode catalog-miss fact for cron
+ * history. All other tool errors stay on the existing generic presentation
+ * path.
  */
 export function resolveEmbeddedRunTerminalToolFailure(params: {
   trigger?: string | undefined;
@@ -29,22 +30,15 @@ export function resolveEmbeddedRunTerminalToolFailure(params: {
   ) {
     return undefined;
   }
-  if (failure.errorCode === "SYSTEM_RUN_DENIED" || failure.errorCode === "INVALID_REQUEST") {
+  const match =
+    typeof failure.error === "string" ? SAFE_MCP_CATALOG_MISS.exec(failure.error) : null;
+  if (!match) {
     return undefined;
   }
-  const rawMessage = normalizeOptionalString(failure.error);
-  if (!rawMessage) {
-    return undefined;
-  }
-  const singleLineMessage = redactSensitiveText(rawMessage, { mode: "tools" }).replace(/\s+/g, " ");
-  const message =
-    singleLineMessage.length > MAX_TERMINAL_TOOL_FAILURE_CHARS
-      ? `${truncateUtf16Safe(singleLineMessage, MAX_TERMINAL_TOOL_FAILURE_CHARS)}…`
-      : singleLineMessage;
   return {
     source: "tool",
     toolName: normalizedToolName,
-    ...(failure.errorCode ? { code: failure.errorCode } : {}),
-    message,
+    code: "UNKNOWN_TOOL_ID",
+    message: `Unknown tool id: ${match[1]}`,
   };
 }

--- a/src/agents/embedded-agent-runner/terminal-tool-failure.ts
+++ b/src/agents/embedded-agent-runner/terminal-tool-failure.ts
@@ -1,0 +1,50 @@
+/** Projects a bounded tool failure into terminal metadata for operator diagnostics. */
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { redactSensitiveText } from "../../logging/redact.js";
+import { truncateUtf16Safe } from "../../utils.js";
+import { CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME } from "../code-mode-control-tools.js";
+import type { ToolErrorSummary } from "../tool-error-summary.js";
+import { normalizeToolName } from "../tool-policy.js";
+import type { EmbeddedRunTerminalToolFailure } from "./types.js";
+
+const MAX_TERMINAL_TOOL_FAILURE_CHARS = 500;
+
+/**
+ * Preserves the already-sanitized outer Code Mode failure for cron history.
+ * Ordinary exec stderr stays on the existing generic presentation path.
+ */
+export function resolveEmbeddedRunTerminalToolFailure(params: {
+  trigger?: string | undefined;
+  codeModeEngaged?: boolean | undefined;
+  lastToolError?: ToolErrorSummary | undefined;
+}): EmbeddedRunTerminalToolFailure | undefined {
+  const failure = params.lastToolError;
+  const normalizedToolName = normalizeToolName(failure?.toolName ?? "");
+  if (
+    params.trigger !== "cron" ||
+    params.codeModeEngaged !== true ||
+    !failure ||
+    (normalizedToolName !== CODE_MODE_EXEC_TOOL_NAME &&
+      normalizedToolName !== CODE_MODE_WAIT_TOOL_NAME)
+  ) {
+    return undefined;
+  }
+  if (failure.errorCode === "SYSTEM_RUN_DENIED" || failure.errorCode === "INVALID_REQUEST") {
+    return undefined;
+  }
+  const rawMessage = normalizeOptionalString(failure.error);
+  if (!rawMessage) {
+    return undefined;
+  }
+  const singleLineMessage = redactSensitiveText(rawMessage, { mode: "tools" }).replace(/\s+/g, " ");
+  const message =
+    singleLineMessage.length > MAX_TERMINAL_TOOL_FAILURE_CHARS
+      ? `${truncateUtf16Safe(singleLineMessage, MAX_TERMINAL_TOOL_FAILURE_CHARS)}…`
+      : singleLineMessage;
+  return {
+    source: "tool",
+    toolName: normalizedToolName,
+    ...(failure.errorCode ? { code: failure.errorCode } : {}),
+    message,
+  };
+}

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -168,6 +168,13 @@ export type EmbeddedRunFailureSignal = {
   fatalForCron: true;
 };
 
+export type EmbeddedRunTerminalToolFailure = {
+  source: "tool";
+  toolName: string;
+  code?: string;
+  message: string;
+};
+
 export type EmbeddedAgentRunMeta = {
   durationMs: number;
   agentMeta?: EmbeddedAgentMeta;
@@ -200,6 +207,8 @@ export type EmbeddedAgentRunMeta = {
     terminalPresentation?: boolean;
   };
   failureSignal?: EmbeddedRunFailureSignal;
+  /** Bounded, sanitized unresolved Code Mode failure for operator diagnostics. */
+  terminalToolFailure?: EmbeddedRunTerminalToolFailure;
   /** Stop reason for the agent run (e.g., "completed", "tool_calls"). */
   stopReason?: string;
   /** Pending tool calls when stopReason is "tool_calls". */

--- a/src/cron/cron-execution-diagnostics.e2e.test.ts
+++ b/src/cron/cron-execution-diagnostics.e2e.test.ts
@@ -6,6 +6,7 @@ import { resetTaskRegistryForTests } from "../tasks/task-runtime.test-helpers.js
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
   loadRunCronIsolatedAgentTurn,
+  dispatchCronDeliveryMock,
   mockRunCronFallbackPassthrough,
   resetRunCronIsolatedAgentTurnHarness,
   resolveAllowedModelRefMock,
@@ -253,6 +254,58 @@ describe.sequential("cron execution diagnostics", () => {
               source: "tool",
               severity: "error",
               message: "SYSTEM_RUN_DENIED: approval required",
+            }),
+          ]),
+        },
+      });
+    }
+  });
+
+  it("persists and emits terminal tool detail while keeping the payload generic", async () => {
+    const modelRef = { provider: "openai", model: "gpt-5.4" };
+    resolveConfiguredModelRefMock.mockReturnValue(modelRef);
+    mockRunCronFallbackPassthrough();
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "⚠️ Exec failed", isError: true, toolName: "exec" }],
+      meta: {
+        agentMeta: {},
+        terminalToolFailure: {
+          source: "tool",
+          toolName: "exec",
+          code: "invalid_input",
+          message: "Unknown tool id: MCP.notes.read",
+        },
+      },
+    });
+
+    const { finished, history } = await runPersistedDiagnosticCase({
+      cfg: configFor(modelRef),
+      modelRef,
+      name: "unknown tool id",
+    });
+
+    expect(dispatchCronDeliveryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deliveryPayloads: [{ text: "cron isolated run returned an error payload", isError: true }],
+        outputText: "cron isolated run returned an error payload",
+        summary: "Unknown tool id: MCP.notes.read",
+      }),
+    );
+
+    for (const outcome of [finished, history]) {
+      expect(outcome).toMatchObject({
+        status: "error",
+        provider: "openai",
+        model: "gpt-5.4",
+        summary: "Unknown tool id: MCP.notes.read",
+        diagnostics: {
+          summary: "Unknown tool id: MCP.notes.read",
+          entries: expect.arrayContaining([
+            expect.objectContaining({
+              source: "tool",
+              severity: "error",
+              message: "Unknown tool id: MCP.notes.read",
+              toolName: "exec",
             }),
           ]),
         },

--- a/src/cron/isolated-agent/run-delivery-trace.tools-allow.test.ts
+++ b/src/cron/isolated-agent/run-delivery-trace.tools-allow.test.ts
@@ -10,6 +10,65 @@ const cfg = {
   },
 } as OpenClawConfig;
 
+const MCP_SUPPRESSION_WARNING =
+  "This automation's explicit toolsAllow omits every configured MCP selector, so the bundle MCP runtime will not start. Add bundle-mcp, group:plugins, an exact <server>__<tool> selector, or * to enable configured MCP tools.";
+
+function makePreflightParams(toolsAllow: string[] | undefined) {
+  return {
+    cfg,
+    jobId: "job-explicit-cap",
+    provider: "anthropic",
+    model: "claude-sonnet-5",
+    workspaceDir: "/workspace",
+    agentPayload: {
+      kind: "agentTurn" as const,
+      message: "run",
+      ...(toolsAllow !== undefined ? { toolsAllow } : {}),
+    },
+  };
+}
+
+describe("configured MCP explicit-cap diagnostics", () => {
+  it("persists an actionable warning when a finite explicit cap suppresses configured MCP", async () => {
+    const diagnostics = await createCronToolsAllowPreflightDiagnostics(
+      makePreflightParams(["read"]),
+    );
+
+    expect(diagnostics).toMatchObject({
+      summary: MCP_SUPPRESSION_WARNING,
+      entries: [
+        expect.objectContaining({
+          source: "cron-preflight",
+          severity: "warn",
+          message: MCP_SUPPRESSION_WARNING,
+        }),
+      ],
+    });
+  });
+
+  it.each([
+    { name: "omitted cap", toolsAllow: undefined },
+    { name: "intentional deny-all cap", toolsAllow: [] },
+    { name: "wildcard cap", toolsAllow: ["*"] },
+    { name: "bundle group", toolsAllow: ["bundle-mcp"] },
+    { name: "plugin group", toolsAllow: ["group:plugins"] },
+    { name: "exact MCP tool", toolsAllow: ["notes__read"] },
+  ])("does not warn for $name", async ({ toolsAllow }) => {
+    await expect(
+      createCronToolsAllowPreflightDiagnostics(makePreflightParams(toolsAllow)),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not warn when the run has no enabled configured MCP server", async () => {
+    await expect(
+      createCronToolsAllowPreflightDiagnostics({
+        ...makePreflightParams(["read"]),
+        cfg: {},
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
 describe("configured MCP inherited-cap diagnostics", () => {
   it("persists an actionable warning for legacy Codex default caps", async () => {
     const diagnostics = await createCronToolsAllowPreflightDiagnostics({

--- a/src/cron/isolated-agent/run-delivery-trace.ts
+++ b/src/cron/isolated-agent/run-delivery-trace.ts
@@ -1,5 +1,6 @@
 import { resolveStaticSessionMcpServerNames } from "../../agents/agent-bundle-mcp-runtime-config.js";
 import { resolveCodexMcpToolOverridesForAgent } from "../../agents/cli-runner/bundle-mcp-codex.js";
+import { shouldCreateBundleMcpRuntimeForAttempt } from "../../agents/embedded-agent-runner/run/attempt-tool-construction-plan.js";
 /** Delivery planning, prompt policy, and delivery trace construction for cron runs. */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type {
@@ -15,6 +16,7 @@ import {
 import {
   createCronRunDiagnosticsFromError,
   createCronRunDiagnosticsFromMissingWebSearchProvider,
+  mergeCronRunDiagnostics,
   toolsAllowRequestsWebSearch,
 } from "../run-diagnostics.js";
 import { resolveCronDeliverySessionKey } from "../session-target.js";
@@ -172,71 +174,89 @@ export async function createCronToolsAllowPreflightDiagnostics(params: {
   toolsAllowProvenance?: CronToolsAllowProvenance;
 }): Promise<CronRunDiagnostics | undefined> {
   const toolsAllow = params.agentPayload?.toolsAllow;
+  const diagnostics: Array<CronRunDiagnostics | undefined> = [];
+  const staticMcpServerNames = resolveStaticSessionMcpServerNames({
+    workspaceDir: params.workspaceDir,
+    cfg: params.cfg,
+    toolOverrides: resolveCodexMcpToolOverridesForAgent(params.cfg, {
+      agentId: params.agentId,
+      toolOverrides: undefined,
+    }),
+  });
+  const hasEnabledStaticMcp = staticMcpServerNames.length > 0;
   if (params.agentPayload?.toolsAllowIsDefault === true) {
-    const hasEnabledStaticMcp =
-      resolveStaticSessionMcpServerNames({
-        workspaceDir: params.workspaceDir,
-        cfg: params.cfg,
-        toolOverrides: resolveCodexMcpToolOverridesForAgent(params.cfg, {
-          agentId: params.agentId,
-          toolOverrides: undefined,
-        }),
-      }).length > 0;
     if (
       params.agentRuntime === "codex" &&
       hasEnabledStaticMcp &&
       params.toolsAllowProvenance?.source !== "final-executable-surface"
     ) {
-      return createCronRunDiagnosticsFromError(
-        "cron-preflight",
-        `This automation's inherited tool cap predates final configured-MCP capture, so it continues with its stored finite tools and may omit MCP capabilities. Reauthorize in place with an exact explicit cap: openclaw automations edit ${params.jobId} --tools <tool,...>.`,
-        { severity: "warn" },
+      diagnostics.push(
+        createCronRunDiagnosticsFromError(
+          "cron-preflight",
+          `This automation's inherited tool cap predates final configured-MCP capture, so it continues with its stored finite tools and may omit MCP capabilities. Reauthorize in place with an exact explicit cap: openclaw automations edit ${params.jobId} --tools <tool,...>.`,
+          { severity: "warn" },
+        ),
       );
     }
-    return undefined;
+    return mergeCronRunDiagnostics(...diagnostics);
   }
-  if (!toolsAllowRequestsWebSearch(toolsAllow)) {
-    return undefined;
+
+  if (
+    toolsAllow &&
+    toolsAllow.length > 0 &&
+    hasEnabledStaticMcp &&
+    !shouldCreateBundleMcpRuntimeForAttempt({ toolsEnabled: true, toolsAllow })
+  ) {
+    diagnostics.push(
+      createCronRunDiagnosticsFromError(
+        "cron-preflight",
+        "This automation's explicit toolsAllow omits every configured MCP selector, so the bundle MCP runtime will not start. Add bundle-mcp, group:plugins, an exact <server>__<tool> selector, or * to enable configured MCP tools.",
+        { severity: "warn" },
+      ),
+    );
   }
-  try {
-    const { shouldSuppressManagedWebSearchTool } = await loadCodexNativeWebSearch();
-    if (
-      shouldSuppressManagedWebSearchTool({
-        config: params.cfg,
-        modelProvider: params.provider,
-        modelApi: params.modelApi,
-        modelId: params.model,
-        agentId: params.agentId,
-        sessionKey: params.sessionKey,
-        agentDir: params.agentDir,
-      })
-    ) {
-      return undefined;
+
+  if (toolsAllowRequestsWebSearch(toolsAllow)) {
+    try {
+      const { shouldSuppressManagedWebSearchTool } = await loadCodexNativeWebSearch();
+      if (
+        !shouldSuppressManagedWebSearchTool({
+          config: params.cfg,
+          modelProvider: params.provider,
+          modelApi: params.modelApi,
+          modelId: params.model,
+          agentId: params.agentId,
+          sessionKey: params.sessionKey,
+          agentDir: params.agentDir,
+        })
+      ) {
+        const { resolveWebSearchToolRuntimeContext } = await loadWebToolRuntimeContext();
+        const { config, preferRuntimeProviders, runtimeWebSearch } =
+          resolveWebSearchToolRuntimeContext({
+            config: params.cfg,
+            lateBindRuntimeConfig: true,
+          });
+        const { hasUsableWebSearchProvider } = await loadWebSearchRuntime();
+        const hasWebSearchProvider = hasUsableWebSearchProvider({
+          config,
+          agentDir: params.agentDir,
+          runtimeWebSearch,
+          preferRuntimeProviders,
+        });
+        diagnostics.push(
+          createCronRunDiagnosticsFromMissingWebSearchProvider({
+            toolsAllow,
+            hasWebSearchProvider,
+          }),
+        );
+      }
+    } catch (error) {
+      logWarn(
+        `[cron:${params.jobId}] Failed to inspect web_search provider state for toolsAllow diagnostics: ${String(error)}`,
+      );
     }
-    const { resolveWebSearchToolRuntimeContext } = await loadWebToolRuntimeContext();
-    const { config, preferRuntimeProviders, runtimeWebSearch } = resolveWebSearchToolRuntimeContext(
-      {
-        config: params.cfg,
-        lateBindRuntimeConfig: true,
-      },
-    );
-    const { hasUsableWebSearchProvider } = await loadWebSearchRuntime();
-    const hasWebSearchProvider = hasUsableWebSearchProvider({
-      config,
-      agentDir: params.agentDir,
-      runtimeWebSearch,
-      preferRuntimeProviders,
-    });
-    return createCronRunDiagnosticsFromMissingWebSearchProvider({
-      toolsAllow,
-      hasWebSearchProvider,
-    });
-  } catch (error) {
-    logWarn(
-      `[cron:${params.jobId}] Failed to inspect web_search provider state for toolsAllow diagnostics: ${String(error)}`,
-    );
-    return undefined;
   }
+  return mergeCronRunDiagnostics(...diagnostics);
 }
 
 /** Resolves the delivery plan and concrete target for one isolated cron run. */

--- a/src/cron/isolated-agent/run-finalize.ts
+++ b/src/cron/isolated-agent/run-finalize.ts
@@ -307,6 +307,12 @@ export async function finalizeCronRun(params: {
     hasFatalErrorPayload,
     embeddedRunError,
   } = cronPayloadOutcome;
+  const terminalToolFailureMessage = normalizeOptionalString(
+    finalRunResult.meta?.terminalToolFailure?.message,
+  );
+  if (hasFatalErrorPayload && terminalToolFailureMessage) {
+    summary = terminalToolFailureMessage;
+  }
   const agentDiagnostics = createCronRunDiagnosticsFromAgentResult(finalRunResult, {
     finalStatus: hasFatalErrorPayload ? "error" : "ok",
   });
@@ -330,7 +336,7 @@ export async function finalizeCronRun(params: {
       delivery: result?.delivery,
       diagnostics: mergeCronRunDiagnostics(
         runDiagnostics,
-        hasFatalErrorPayload
+        hasFatalErrorPayload && !terminalToolFailureMessage
           ? createCronRunDiagnosticsFromError(
               "agent-run",
               embeddedRunError ?? "cron isolated run returned an error payload",

--- a/src/cron/isolated-agent/run.tools-allow.test.ts
+++ b/src/cron/isolated-agent/run.tools-allow.test.ts
@@ -18,6 +18,8 @@ import {
 
 const MISSING_WEB_SEARCH_PROVIDER_DIAGNOSTIC_MESSAGE =
   "web_search tool requested in toolsAllow but no web search provider is selected. Configure one with: openclaw configure --section web, or set tools.web.search.provider.";
+const MCP_SUPPRESSION_DIAGNOSTIC_MESSAGE =
+  "This automation's explicit toolsAllow omits every configured MCP selector, so the bundle MCP runtime will not start. Add bundle-mcp, group:plugins, an exact <server>__<tool> selector, or * to enable configured MCP tools.";
 
 const RUN_TOOLS_ALLOW_TIMEOUT_MS = 300_000;
 
@@ -237,6 +239,34 @@ describe("runCronIsolatedAgentTurn toolsAllow passthrough", () => {
           severity: "warn",
           message: MISSING_WEB_SEARCH_PROVIDER_DIAGNOSTIC_MESSAGE,
           toolName: "web_search",
+        },
+      ]);
+    },
+  );
+
+  it(
+    "persists MCP suppression diagnostics through a successful run",
+    { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
+    async () => {
+      const params = makeParamsWithToolsAllow(["read"]);
+      params.cfg = {
+        mcp: {
+          servers: {
+            notes: { transport: "stdio", command: "notes-mcp" },
+          },
+        },
+      } as never;
+
+      const result = await runCronIsolatedAgentTurn(params);
+
+      expect(result.status).toBe("ok");
+      expect(result.diagnostics?.summary).toBe(MCP_SUPPRESSION_DIAGNOSTIC_MESSAGE);
+      expect(result.diagnostics?.entries).toEqual([
+        {
+          ts: expect.any(Number),
+          source: "cron-preflight",
+          severity: "warn",
+          message: MCP_SUPPRESSION_DIAGNOSTIC_MESSAGE,
         },
       ]);
     },

--- a/src/cron/run-diagnostics.test.ts
+++ b/src/cron/run-diagnostics.test.ts
@@ -209,6 +209,41 @@ describe("cron run diagnostics", () => {
     });
   });
 
+  it("prefers a terminal tool failure over a generic failed-tool payload", () => {
+    const diagnostics = createCronRunDiagnosticsFromAgentResult(
+      {
+        payloads: [{ text: "⚠️ Exec failed", isError: true, toolName: "exec" }],
+        meta: {
+          terminalToolFailure: {
+            source: "tool",
+            toolName: "exec",
+            code: "invalid_input",
+            message: "Unknown tool id: MCP.notes.read",
+          },
+        },
+      },
+      { nowMs: () => 123 },
+    );
+
+    expect(diagnostics?.summary).toBe("Unknown tool id: MCP.notes.read");
+    expect(diagnostics?.entries).toEqual([
+      {
+        ts: 123,
+        source: "tool",
+        severity: "error",
+        message: "⚠️ Exec failed",
+        toolName: "exec",
+      },
+      {
+        ts: 123,
+        source: "tool",
+        severity: "error",
+        message: "Unknown tool id: MCP.notes.read",
+        toolName: "exec",
+      },
+    ]);
+  });
+
   it("keeps failed exec output tails valid at UTF-16 boundaries", () => {
     const diagnostics = createCronRunDiagnosticsFromAgentResult(
       {

--- a/src/cron/run-diagnostics.test.ts
+++ b/src/cron/run-diagnostics.test.ts
@@ -244,6 +244,33 @@ describe("cron run diagnostics", () => {
     ]);
   });
 
+  it("downgrades a recovered terminal tool failure to a warning", () => {
+    const diagnostics = createCronRunDiagnosticsFromAgentResult(
+      {
+        meta: {
+          terminalToolFailure: {
+            toolName: "exec",
+            message: "Unknown tool id: MCP.notes.read",
+          },
+        },
+      },
+      { nowMs: () => 123, finalStatus: "ok" },
+    );
+
+    expect(diagnostics).toEqual({
+      summary: "Unknown tool id: MCP.notes.read",
+      entries: [
+        {
+          ts: 123,
+          source: "tool",
+          severity: "warn",
+          message: "Unknown tool id: MCP.notes.read",
+          toolName: "exec",
+        },
+      ],
+    });
+  });
+
   it("keeps failed exec output tails valid at UTF-16 boundaries", () => {
     const diagnostics = createCronRunDiagnosticsFromAgentResult(
       {

--- a/src/cron/run-diagnostics.ts
+++ b/src/cron/run-diagnostics.ts
@@ -250,6 +250,21 @@ export function createCronRunDiagnosticsFromAgentResult(
   if (typeof metaError?.message === "string") {
     diagnostics.push(createCronRunDiagnosticsFromError("agent-run", metaError.message, opts));
   }
+  const terminalToolFailure =
+    meta.terminalToolFailure && typeof meta.terminalToolFailure === "object"
+      ? (meta.terminalToolFailure as { message?: unknown; toolName?: unknown })
+      : undefined;
+  if (typeof terminalToolFailure?.message === "string") {
+    diagnostics.push(
+      createCronRunDiagnosticsFromError("tool", terminalToolFailure.message, {
+        ...opts,
+        toolName:
+          typeof terminalToolFailure.toolName === "string"
+            ? terminalToolFailure.toolName
+            : undefined,
+      }),
+    );
+  }
   const failureSignal =
     meta.failureSignal && typeof meta.failureSignal === "object"
       ? (meta.failureSignal as { message?: unknown })

--- a/src/cron/run-diagnostics.ts
+++ b/src/cron/run-diagnostics.ts
@@ -258,6 +258,7 @@ export function createCronRunDiagnosticsFromAgentResult(
     diagnostics.push(
       createCronRunDiagnosticsFromError("tool", terminalToolFailure.message, {
         ...opts,
+        severity: opts?.finalStatus === "ok" ? "warn" : "error",
         toolName:
           typeof terminalToolFailure.toolName === "string"
             ? terminalToolFailure.toolName


### PR DESCRIPTION
Related: #120385

## What Problem This Solves

Fixes an issue where operators debugging failed Code Mode cron runs would see only a generic `Exec failed` result in run history, even though OpenClaw had already captured the bounded tool failure. It also addresses the related policy foot-gun where a finite explicit `toolsAllow` can suppress configured MCP tools without an actionable diagnostic.

## Why This Change Was Made

The embedded runner now projects unresolved Code Mode `exec`/`wait` failures into a separate bounded, redacted terminal diagnostic fact. Cron persists that fact as the actionable history summary while preserving the generic delivery payload; the existing fatal execution-denial signal and scheduler classification remain unchanged.

Cron preflight also records a warning when a non-empty explicit finite allowlist prevents configured MCP from materializing. Intentional deny-all `[]`, omitted policy, wildcard, plugin-group, and MCP selectors retain their established semantics. The automation documentation now spells out those distinctions.

This PR is AI-assisted. I reviewed the implementation and validation results and understand the shipped behavior.

## User Impact

Operators can see errors such as `Unknown tool id: MCP…` directly in cron run history instead of diagnosing a bare `Exec failed`. Jobs whose explicit allowlist excludes configured MCP receive a durable, actionable warning explaining the selectors that enable it. Chat delivery remains generic and no tool arguments or raw results are added to history.

## Evidence

- Focused unit/integration lane: 82 tests passed across terminal projection/preparation, cron diagnostics, preflight policy, and isolated-run persistence helpers.
- Dedicated persisted-history E2E: 4 tests passed, including actionable stored summary + diagnostics and generic stored delivery output.
- `pnpm format:docs:check`: 755 docs files clean.
- `pnpm check` preflight guards passed; the repository-wide production typecheck then stopped on two unrelated baseline/dependency-resolution errors in `packages/terminal-core/src/ansi.ts` and `src/cli/session-ref.ts`.
- Fresh independent diff review was repeated after fixes; final result: no actionable findings.

## Follow-up — exact head `413fdcb4114b3b6ffcf062e82b80e7a850f9abc0`

- Fixed the recovered-run status boundary: terminal Code Mode tool failures are now `warn` (not `error`) when cron final status is `ok`; terminal failures remain `error`.
- Added a regression asserting the persisted terminal diagnostic is warning-severity for a recovered run.
- Verified: `node scripts/run-vitest.mjs src/cron/run-diagnostics.test.ts` — 17 passed.
- The existing persisted-history E2E was invoked with the E2E config but exceeded a 75-second local timebox while rebuilding stale artifacts (exit 143), before assertions ran; no real external cron/model proof is claimed here.
- Current CI failure is `plugin-sdk:api:check` manifest drift from upstream main advancing after this branch fork; this PR does not modify Plugin SDK exports or the generated baseline.

## Follow-up — exact head `e1360fa9c03119246c451464eaebd668619619bd`

- Restricted durable terminal history detail to the strict Code Mode catalog-miss form `Unknown tool id: MCP.<safe-id>`; all other tool errors, including private suffixes/output, remain generic.
- Added privacy regression coverage for arbitrary tool-error text and for a catalog-miss string with a private suffix.
- Verified: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/terminal-tool-failure.test.ts src/agents/embedded-agent-runner/run/terminal-preparation.test.ts src/cron/run-diagnostics.test.ts` — 33 passed.
- Verified: `pnpm exec oxfmt --check` on changed files.
- Real configured-MCP cron evidence remains outstanding; no claim of runtime proof is made.
