### PR TITLE
fix(sessions): preserve thread on internal turns

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -5111,6 +5111,75 @@ describe("initSessionState stale threadId fallback", () => {
     expect(result.sessionEntry.deliveryContext?.threadId).toBe("650.000");
   });
 
+  it("preserves external thread routing for internal turns and clears it for external non-thread turns", async () => {
+    const storePath = await createStorePath("internal-thread-route-");
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const sessionKey = "agent:main:main";
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: "session-internal-thread-route",
+        updatedAt: Date.now(),
+        delivery: {
+          kind: "external",
+          route: {
+            channel: "imessage",
+            accountId: "imessage-default",
+            target: { to: "+15551234567", chatType: "direct" },
+            thread: { id: "thread-42", kind: "thread", source: "session" },
+          },
+          context: {
+            channel: "imessage",
+            to: "+15551234567",
+            accountId: "imessage-default",
+            threadId: "thread-42",
+          },
+          origin: {
+            provider: "webchat",
+            to: "+15551234567",
+            accountId: "imessage-default",
+            threadId: "thread-42",
+            chatType: "direct",
+            surface: "webchat",
+          },
+        },
+      },
+    });
+
+    const internal = await initSessionState({
+      ctx: {
+        Body: "internal control-ui turn",
+        SessionKey: sessionKey,
+        OriginatingChannel: "webchat",
+      },
+      cfg,
+    });
+    expect(internal.sessionEntry.lastThreadId).toBe("thread-42");
+    expect(internal.sessionEntry.deliveryContext).toEqual({
+      channel: "imessage",
+      to: "+15551234567",
+      accountId: "imessage-default",
+      threadId: "thread-42",
+    });
+
+    const plainExternal = await initSessionState({
+      ctx: {
+        Body: "plain external turn",
+        SessionKey: sessionKey,
+        OriginatingChannel: "imessage",
+        OriginatingTo: "+15551234567",
+        AccountId: "imessage-default",
+      },
+      cfg,
+    });
+    expect(plainExternal.sessionEntry.lastThreadId).toBeUndefined();
+    expect(plainExternal.sessionEntry.deliveryContext).toEqual({
+      channel: "imessage",
+      to: "+15551234567",
+      accountId: "imessage-default",
+    });
+  });
+
   it("preserves lastThreadId within the same thread session", async () => {
     const storePath = await createStorePath("preserve-thread-");
     const cfg = { session: { store: storePath } } as OpenClawConfig;

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -90,6 +90,7 @@ import {
   sessionDeliveryOrigin,
   sessionDeliveryRoute,
 } from "../../utils/delivery-context.shared.js";
+import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { resolveCommandTurnTargetSessionKey } from "../command-turn-context.js";
 import type {
   FinalizedRuntimeMsgContext,
@@ -837,14 +838,14 @@ async function initSessionStateAttemptLocked(
         accountIdRaw: ctx.AccountId,
         persistedLastAccountId: baseDeliveryContext?.accountId,
       });
-  // Only fall back to persisted threadId for thread sessions. Non-thread
-  // sessions (e.g. DM without topics) must not inherit a stale threadId from a
-  // previous interaction that happened inside a topic/thread.
+  // Internal turns share the established external route and must not erase its
+  // thread. External non-thread turns still clear stale thread routing.
+  const preservePersistedThread = isThread || isInternalMessageChannel(originatingChannelRaw);
   const lastThreadIdRaw = isSystemEvent
     ? baseDeliveryContext?.threadId
     : (ctx.MessageThreadId ??
       ctx.TransportThreadId ??
-      (isThread ? baseDeliveryContext?.threadId : undefined));
+      (preservePersistedThread ? baseDeliveryContext?.threadId : undefined));
   const delivery = isSystemEvent
     ? normalizeSessionDeliveryState({
         route: isThread ? baseDeliveryRoute : stripThreadFromSessionRoute(baseDeliveryRoute),


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation https://github.com/openclaw/openclaw/actions/runs/31360468578 passed normal CI, plugin prerelease, Docker/package/QA, and performance except for trusted Telegram candidate provenance.

The session-thread fix had been applied directly to `release/2026.8.1`, but GitHub reported the locally valid SSH signature as `unknown_key`. The trusted Telegram workflow correctly rejected that release head before accessing credentials.

## Why This Change Was Made

Backport the exact landed session lifecycle repair from https://github.com/openclaw/openclaw/pull/121321 through a release-target pull request so the resulting release head is GitHub-verified.

The code patch is unchanged: internal turns preserve an established external thread, while explicit thread fields still win and external non-thread turns still clear stale routing.

## User Impact

Threaded external sessions remain correctly correlated after Control UI/internal sends, and the release candidate satisfies the trusted Telegram provenance boundary without weakening it.

## Evidence

- Main PR landed commit: `93ba11138fc5e80d15c84f5af0c19234049ec2af`.
- Exact backport patch: `dc4f15b2d204589e630886ee3bb8a949e9f60be5`.
- Focused session lifecycle and delivery suites: 180 passed on the release branch.
- Codex autoreview of the exact backport: clean.
- The failed parent proved every other validation family green; only GitHub signature provenance blocked Telegram.
