### PR TITLE
fix(cli-session): preserve heartbeat context across policy gaps [AI-assisted]

### DIFF
--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -2490,6 +2490,50 @@ describe("prepareCliRunContext", () => {
     },
   );
 
+  it("reuses CLI sessions across chat-heartbeat-chat policy fingerprints", async () => {
+    const { dir } = fixture.session;
+    const staticPrompt = "direct:telegram:automatic";
+    const chat = await fixture.prepare({
+      extraSystemPrompt: staticPrompt,
+      sourceReplyDeliveryMode: "automatic",
+      cliSessionBindingFacts: {
+        extraSystemPromptStatic: staticPrompt,
+        sourceReplyDeliveryMode: "automatic",
+      },
+    });
+    const heartbeat = await fixture.prepare({
+      extraSystemPrompt: staticPrompt,
+      cliSessionBindingFacts: { extraSystemPromptStatic: staticPrompt },
+      cliSessionBinding: {
+        sessionId: "cli-session",
+        extraSystemPromptHash: chat.extraSystemPromptHash,
+        messageToolPolicyHash: chat.messageToolPolicyHash,
+        promptToolNamesHash: chat.promptToolNamesHash,
+        cwdHash: hashCliSessionText(dir),
+      },
+    });
+    const nextChat = await fixture.prepare({
+      extraSystemPrompt: staticPrompt,
+      sourceReplyDeliveryMode: "automatic",
+      cliSessionBindingFacts: {
+        extraSystemPromptStatic: staticPrompt,
+        sourceReplyDeliveryMode: "automatic",
+      },
+      cliSessionBinding: {
+        sessionId: "cli-session",
+        extraSystemPromptHash: heartbeat.extraSystemPromptHash,
+        messageToolPolicyHash: heartbeat.messageToolPolicyHash,
+        promptToolNamesHash: heartbeat.promptToolNamesHash,
+        cwdHash: hashCliSessionText(dir),
+      },
+    });
+
+    expect(chat.messageToolPolicyHash).toBeDefined();
+    expect(heartbeat.messageToolPolicyHash).toBeUndefined();
+    expect(heartbeat.reusableCliSession).toEqual({ mode: "reuse", sessionId: "cli-session" });
+    expect(nextChat.reusableCliSession).toEqual({ mode: "reuse", sessionId: "cli-session" });
+  });
+
   it("reuses CLI session bindings across explicit mention toggles with stable group prompt facts", async () => {
     const { dir } = fixture.session;
     const baseGroupCtx = {

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -388,6 +388,30 @@ describe("cli-session helpers", () => {
     ).toEqual({ mode: "reuse", sessionId: "cli-session-1" });
   });
 
+  it.each([
+    {
+      name: "heartbeat follows a chat turn",
+      bindingHash: "message-policy-a",
+      currentHash: undefined,
+    },
+    {
+      name: "chat turn follows a heartbeat",
+      bindingHash: undefined,
+      currentHash: "message-policy-a",
+    },
+  ])("reuses when only one side has a message-policy fingerprint: $name", (testCase) => {
+    expect(
+      resolveCliSessionReuse({
+        binding: {
+          sessionId: "cli-session-1",
+          messageToolPolicyHash: testCase.bindingHash,
+        },
+        authEpochVersion: 2,
+        messageToolPolicyHash: testCase.currentHash,
+      }),
+    ).toEqual({ mode: "reuse", sessionId: "cli-session-1" });
+  });
+
   it("invalidates reuse when the task cwd changes", () => {
     const binding = {
       sessionId: "cli-session-1",

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -207,7 +207,11 @@ export function resolveCliSessionReuse(params: {
     return { mode: "invalidate", invalidatedReason: "auth-epoch" };
   }
   const storedMessageToolPolicyHash = normalizeOptionalString(binding?.messageToolPolicyHash);
-  if (storedMessageToolPolicyHash !== currentMessageToolPolicyHash) {
+  if (
+    storedMessageToolPolicyHash &&
+    currentMessageToolPolicyHash &&
+    storedMessageToolPolicyHash !== currentMessageToolPolicyHash
+  ) {
     return { mode: "invalidate", invalidatedReason: "message-policy" };
   }
   const storedCwdHash = normalizeOptionalString(binding?.cwdHash);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users mixing scheduled heartbeats and chat turns on the same `claude-cli` session would lose provider conversation context at every chat↔heartbeat transition.

Closes #121485

## Why This Change Was Made

CLI reuse previously treated a missing message-policy fingerprint as a confirmed policy change. Synthetic heartbeat turns do not always produce that fingerprint, so alternating turn types repeatedly invalidated the provider session. Reuse now invalidates only when both sides provide fingerprints and they differ; known two-sided policy changes remain fail-closed.

The production change is net +4 lines. The rest of the diff adds unit coverage for both one-sided directions and an integration regression covering the full chat→heartbeat→chat sequence.

## User Impact

Heartbeats can retain the same reusable CLI session as nearby chat turns instead of starting without the conversation history. This also avoids unnecessary provider-session resets and prompt-cache churn. No configuration or public API changes are introduced.

## Evidence

- Before the fix: `node scripts/run-vitest.mjs src/agents/cli-session.test.ts` failed both new one-sided cases with `invalidatedReason: "message-policy"` (2 failed, 24 passed).
- After the fix and rebase onto current `main`: `node scripts/run-vitest.mjs src/agents/cli-session.test.ts src/agents/cli-runner/prepare.test.ts` — 129 passed across 2 files.
- `pnpm tsgo:core` — passed.
- `pnpm tsgo:test:src` — passed.
- `node scripts/run-oxlint.mjs src/agents/cli-session.ts src/agents/cli-session.test.ts src/agents/cli-runner/prepare.test.ts` — passed.
- Targeted `oxfmt --check` and `git diff --check` — passed.
- Repository `autoreview` (Codex `gpt-5.6-sol`, high reasoning) — clean, no accepted/actionable findings; TruffleHog diff scan clean.
- `pnpm check:changed -- <paths>` could not delegate because the local Crabbox binary failed its sanity check; the repository-documented trusted-source local fallback above was used.

No live `claude-cli` provider session was exercised locally; the regression is proven at the session-reuse comparator and CLI prepare integration boundaries.

AI-assisted: yes. I reviewed and understand the change and its tests.
