### PR TITLE
fix(slack): resolve implicit default account SecretRefs when named accounts override top-level tokens

### DIFF
--- a/extensions/slack/src/accounts.ts
+++ b/extensions/slack/src/accounts.ts
@@ -12,7 +12,7 @@ import {
   type ChannelDmPolicy,
 } from "openclaw/plugin-sdk/channel-config-helpers";
 import { resolveAccountEntry } from "openclaw/plugin-sdk/routing";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { SlackAccountSurfaceFields } from "./account-surface-fields.js";
 import type { SlackAccountConfig } from "./runtime-api.js";
 import { resolveSlackAppToken, resolveSlackBotToken, resolveSlackUserToken } from "./token.js";
@@ -63,52 +63,52 @@ const {
   resolveAccountConfig: resolveMergedSlackAccountConfig,
 } = createAccountListHelpers<SlackAccountConfig>("slack", {
   nestedObjectKeys: ["botLoopProtection", "relay"],
-  hasImplicitDefaultAccount: (cfg) => {
-    const slack = cfg.channels?.slack;
-    if (slack?.postAs === "user") {
-      const hasUserToken =
-        hasConfiguredAccountValue(slack.userToken) ||
-        hasConfiguredAccountValue(process.env.SLACK_USER_TOKEN);
-      if (!hasUserToken) {
-        return false;
-      }
-      if (slack.mode === "http") {
-        return hasConfiguredAccountValue(slack.signingSecret);
-      }
-      if (slack.mode === "relay") {
-        return (
-          hasConfiguredAccountValue(slack.relay?.url) &&
-          hasConfiguredAccountValue(slack.relay?.authToken) &&
-          hasConfiguredAccountValue(slack.relay?.gatewayId)
-        );
-      }
-      return (
-        hasConfiguredAccountValue(slack.appToken) ||
-        hasConfiguredAccountValue(process.env.SLACK_APP_TOKEN)
-      );
-    }
-    const hasBotToken =
-      hasConfiguredAccountValue(slack?.botToken) ||
-      hasConfiguredAccountValue(process.env.SLACK_BOT_TOKEN);
-    if (!hasBotToken) {
+  hasImplicitDefaultAccount: (cfg) =>
+    slackChannelHasImplicitDefaultAccount(cfg.channels?.slack, hasConfiguredAccountValue),
+});
+
+/**
+ * Shared implicit-default-account predicate for the Slack channel root.
+ *
+ * Slack synthesizes a `default` account from top-level credentials even when named
+ * accounts exist, as long as the root config carries the credentials needed to start
+ * one. Account listing and secret-contract collection must agree on this eligibility
+ * so root SecretRefs are resolved for the implicit default instead of being orphaned.
+ *
+ * `hasValue` is parameterized: account listing passes {@link hasConfiguredAccountValue}
+ * (plaintext + env fallback), while secret-contract collection passes a SecretRef-aware
+ * check (`hasConfiguredSecretInputValue`) since env vars are reached through SecretRef
+ * resolution, not direct `process.env` reads.
+ */
+export function slackChannelHasImplicitDefaultAccount(
+  slack: Record<string, unknown> | undefined,
+  hasValue: (value: unknown) => boolean,
+): boolean {
+  if (!slack) {
+    return false;
+  }
+  if (slack.postAs === "user") {
+    if (!hasValue(slack.userToken) && !hasValue(process.env.SLACK_USER_TOKEN)) {
       return false;
     }
-    if (slack?.mode === "http") {
-      return hasConfiguredAccountValue(slack.signingSecret);
-    }
-    if (slack?.mode === "relay") {
-      return (
-        hasConfiguredAccountValue(slack.relay?.url) &&
-        hasConfiguredAccountValue(slack.relay?.authToken) &&
-        hasConfiguredAccountValue(slack.relay?.gatewayId)
-      );
-    }
+  } else if (!hasValue(slack.botToken) && !hasValue(process.env.SLACK_BOT_TOKEN)) {
+    return false;
+  }
+  const mode = slack.mode;
+  if (mode === "http") {
+    return hasValue(slack.signingSecret);
+  }
+  if (mode === "relay") {
+    const relay = slack.relay;
     return (
-      hasConfiguredAccountValue(slack?.appToken) ||
-      hasConfiguredAccountValue(process.env.SLACK_APP_TOKEN)
+      isRecord(relay) &&
+      hasValue(relay.url) &&
+      hasValue(relay.authToken) &&
+      hasValue(relay.gatewayId)
     );
-  },
-});
+  }
+  return hasValue(slack.appToken) || hasValue(process.env.SLACK_APP_TOKEN);
+}
 export const listSlackAccountIds = listAccountIds;
 export const resolveDefaultSlackAccountId = resolveDefaultAccountId;
 

--- a/extensions/slack/src/secret-contract.ts
+++ b/extensions/slack/src/secret-contract.ts
@@ -1,14 +1,17 @@
 // Slack plugin module implements secret contract behavior.
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import {
   collectConditionalChannelFieldAssignments,
   collectNestedChannelFieldAssignments,
   collectSimpleChannelFieldAssignments,
   createChannelSecretTargetRegistryEntries,
   getChannelSurface,
+  hasConfiguredSecretInputValue,
   hasOwnProperty,
   type ResolverContext,
   type SecretDefaults,
 } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
+import { slackChannelHasImplicitDefaultAccount } from "./accounts.js";
 
 export const secretTargetRegistryEntries = createChannelSecretTargetRegistryEntries({
   channelKey: "slack",
@@ -26,6 +29,22 @@ export function collectRuntimeConfigAssignments(params: {
     return;
   }
   const { channel: slack, surface } = resolved;
+  // Slack account listing starts an implicit default account from top-level
+  // credentials even when every named account overrides them.  The shared
+  // surface helper only lists explicit accounts, so top-level SecretRefs would
+  // be marked inactive and orphaned when all accounts override.  Synthesize the
+  // implicit default surface entry here, reusing the same eligibility predicate
+  // as account listing (see slackChannelHasImplicitDefaultAccount) so the two
+  // paths agree on when a default account exists.
+  const hasValue = (value: unknown) => hasConfiguredSecretInputValue(value, params.defaults);
+  if (
+    surface.channelEnabled &&
+    surface.hasExplicitAccounts &&
+    slackChannelHasImplicitDefaultAccount(slack, hasValue) &&
+    !surface.accounts.some(({ accountId }) => normalizeAccountId(accountId) === DEFAULT_ACCOUNT_ID)
+  ) {
+    surface.accounts.push({ accountId: DEFAULT_ACCOUNT_ID, account: {}, enabled: true });
+  }
   const resolveMode = (value: unknown) =>
     value === "http" || value === "socket" || value === "relay" ? value : undefined;
   const baseMode = resolveMode(slack.mode) ?? "socket";

--- a/src/secrets/runtime-channel-inactive-variants.test.ts
+++ b/src/secrets/runtime-channel-inactive-variants.test.ts
@@ -157,6 +157,57 @@ describe("secrets runtime snapshot channel inactive variants", () => {
     expect(warningPaths).toContain("channels.slack.accounts.work.appToken");
   });
 
+  it("resolves Slack top-level botToken SecretRef for the implicit default account when named accounts override botToken", async () => {
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        channels: {
+          slack: {
+            enabled: true,
+            botToken: {
+              source: "env",
+              provider: "default",
+              id: "SLACK_BOT_TOKEN",
+            },
+            appToken: {
+              source: "env",
+              provider: "default",
+              id: "SLACK_APP_TOKEN",
+            },
+            accounts: {
+              sage: {
+                enabled: true,
+                botToken: {
+                  source: "env",
+                  provider: "default",
+                  id: "SAGE_SLACK_BOT_TOKEN",
+                },
+                appToken: {
+                  source: "env",
+                  provider: "default",
+                  id: "SAGE_SLACK_APP_TOKEN",
+                },
+              },
+            },
+          },
+        },
+      }),
+      env: {
+        SLACK_BOT_TOKEN: "xoxb-default-bot-token",
+        SLACK_APP_TOKEN: "xapp-default-app-token",
+        SAGE_SLACK_BOT_TOKEN: "xoxb-sage-bot-token",
+        SAGE_SLACK_APP_TOKEN: "xapp-sage-app-token",
+      },
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: () => loadAuthStoreWithProfiles({}),
+    });
+
+    expect(snapshot.config.channels?.slack?.botToken).toBe("xoxb-default-bot-token");
+    expect(snapshot.config.channels?.slack?.appToken).toBe("xapp-default-app-token");
+    expect(snapshot.config.channels?.slack?.accounts?.sage?.botToken).toBe("xoxb-sage-bot-token");
+    expect(snapshot.config.channels?.slack?.accounts?.sage?.appToken).toBe("xapp-sage-app-token");
+    expect(snapshot.warnings).toStrictEqual([]);
+  });
+
   it("treats top-level Google Chat serviceAccount as inactive when enabled accounts override it", async () => {
     const snapshot = await prepareSecretsRuntimeSnapshot({
       config: asConfig({


### PR DESCRIPTION
## What Problem This Solves

Adding any named account under `channels.slack.accounts` causes the implicit `default` account (served by top-level `channels.slack.botToken`/`appToken`) to silently stop resolving. The gateway logs `SECRETS_REF_IGNORED_INACTIVE_SURFACE` errors and the default Slack channel fails to start, even though the top-level fields are still present and previously worked.

This is the same bug class as the already-fixed Feishu issue #96929 — the Feishu fix was plugin-local and did not cover the Slack secret-contract path.

Fixes #121446

## Why This Change Was Made

`resolveChannelAccountSurface` (`src/secrets/channel-secret-basic-runtime.ts`) only synthesizes an implicit `default` account when `accounts` is **empty**. Once named accounts exist, the surface contains only explicit accounts. But Slack's `listSlackAccountIds` still yields `["default", ...]` (via `hasImplicitDefaultAccount`), so the secrets layer sees an active default account with no corresponding surface entry — top-level `botToken`/`appToken` are marked inactive and never resolved for the implicit default.

The fix mirrors the established Feishu repair pattern (`extensions/feishu/src/secret-contract.ts`): detect when the implicit default account is eligible and push a synthetic surface entry so top-level SecretRefs resolve for it.

Per ClawSweeper's best-fix recommendation, Slack's implicit-default eligibility is factored into one plugin-local predicate (`slackChannelHasImplicitDefaultAccount`) shared by both account listing and SecretRef collection, rather than duplicating the logic. The predicate is parameterized by the value-check function: account listing passes `hasConfiguredAccountValue` (plaintext + env fallback), while secret-contract collection passes a SecretRef-aware `hasConfiguredSecretInputValue` since env vars are reached through SecretRef resolution, not direct `process.env` reads.

## User Impact

Operators following the documented multi-account Slack pattern ("one channel account per agent" per https://docs.openclaw.ai/concepts/agent-bindings) no longer lose their existing default Slack account when adding the first named account. Both accounts start successfully without requiring the redundant `accounts.default` workaround.

## Evidence

### Real behavior proof (before/after on exact PR head)

The proof script exercises the **real secrets runtime pipeline** (`createResolverContext` → `collectChannelConfigAssignments` → `resolveAndApplySecretAssignments`), not a mock. It uses the actual Slack `secret-contract.ts` module and real SecretRef-to-env resolution.

Config matches the issue #121446 reproduction: top-level `botToken`+`appToken` with a named `sage` account that overrides both.

**BEFORE fix** (base commit `188a2484495`):

```
========================================================================
Slack implicit default account SecretRef resolution proof
host=LIN-66D8BD4EA2C pid=3686911 time=2026-08-10T10:20:03.650Z
========================================================================

--- Collected 2 secret assignments ---
  channels.slack.accounts.sage.botToken → owner=account:slack:sage ref=env:default:SAGE_SLACK_BOT_TOKEN
  channels.slack.accounts.sage.appToken → owner=account:slack:sage ref=env:default:SAGE_SLACK_APP_TOKEN

--- Resolved secrets ---
channels.slack.botToken (default account): [object Object]
channels.slack.appToken (default account): [object Object]
channels.slack.accounts.sage.botToken:    xoxb-sage-bot-token
channels.slack.accounts.sage.appToken:    xapp-sage-app-token

--- Warnings ---
[SECRETS_REF_IGNORED_INACTIVE_SURFACE] channels.slack.botToken: channels.slack.botToken: no enabled account inherits this top-level Slack botToken.
[SECRETS_REF_IGNORED_INACTIVE_SURFACE] channels.slack.appToken: channels.slack.appToken: no enabled Slack socket-mode surface inherits this top-level appToken.

--- Verdict ---
default account botToken resolved: FAIL
default account appToken resolved: FAIL
sage account botToken resolved:    PASS
sage account appToken resolved:    PASS
zero inactive-surface warnings:    FAIL

OVERALL: FAIL
host=LIN-66D8BD4EA2C pid=3686911 time=2026-08-10T10:20:04.350Z
```

Key observations:
- Only 2 assignments collected (sage only) — the implicit default account is missing from the surface
- Top-level `botToken` and `appToken` orphaned with `SECRETS_REF_IGNORED_INACTIVE_SURFACE` warnings
- Default account tokens remain unresolved SecretRef objects

**AFTER fix** (PR head `bc3be2717a2`):

```
========================================================================
Slack implicit default account SecretRef resolution proof
host=LIN-66D8BD4EA2C pid=3564946 time=2026-08-10T09:46:19.520Z
========================================================================

--- Collected 4 secret assignments ---
  channels.slack.botToken → owner=account:slack:default ref=env:default:SLACK_BOT_TOKEN
  channels.slack.accounts.sage.botToken → owner=account:slack:sage ref=env:default:SAGE_SLACK_BOT_TOKEN
  channels.slack.appToken → owner=account:slack:default ref=env:default:SLACK_APP_TOKEN
  channels.slack.accounts.sage.appToken → owner=account:slack:sage ref=env:default:SAGE_SLACK_APP_TOKEN

--- Resolved secrets ---
channels.slack.botToken (default account): xoxb-default-bot-token
channels.slack.appToken (default account): xapp-default-app-token
channels.slack.accounts.sage.botToken:    xoxb-sage-bot-token
channels.slack.accounts.sage.appToken:    xapp-sage-app-token

--- Warnings ---
[] (zero warnings — both accounts resolved successfully)

--- Verdict ---
default account botToken resolved: PASS
default account appToken resolved: PASS
sage account botToken resolved:    PASS
sage account appToken resolved:    PASS
zero inactive-surface warnings:    PASS

OVERALL: PASS
host=LIN-66D8BD4EA2C pid=3564946 time=2026-08-10T09:46:21.730Z
```

Key observations:
- 4 assignments collected — implicit default account now present in the surface alongside sage
- Both default and sage tokens resolve to real env values
- Zero warnings (no `SECRETS_REF_IGNORED_INACTIVE_SURFACE`)

### Unit tests

- `node scripts/run-vitest.mjs src/secrets/runtime-channel-inactive-variants.test.ts` — 6 passed
- `node scripts/run-vitest.mjs extensions/slack/src/accounts.test.ts` — 29 passed (no regression in account listing)
- `node scripts/run-vitest.mjs src/secrets/runtime-external-channel-audit.test.ts` — 8 passed (Feishu unaffected)
- `node scripts/run-vitest.mjs src/secrets/resolve.test.ts` — 37 passed
- `node scripts/run-vitest.mjs src/secrets/runtime-discord-surface.test.ts` — 11 passed

### Lint + type check

```
$ node_modules/.bin/oxlint extensions/slack/src/accounts.ts extensions/slack/src/secret-contract.ts
(no output — clean)

$ node_modules/.bin/oxfmt --check extensions/slack/src/accounts.ts extensions/slack/src/secret-contract.ts
All matched files use the correct format.

$ pnpm tsgo --project extensions/slack/tsconfig.json 2>&1 | grep -E "accounts\.ts|secret-contract\.ts"
(no output — no errors in changed files)
```

### Changed surfaces

- `extensions/slack/src/accounts.ts`: extracted `slackChannelHasImplicitDefaultAccount` shared predicate; `hasImplicitDefaultAccount` callback now delegates to it
- `extensions/slack/src/secret-contract.ts`: synthesize implicit default surface entry using the shared predicate before collecting field assignments
- `src/secrets/runtime-channel-inactive-variants.test.ts`: regression test for top-level botToken/appToken SecretRef resolution with an overriding named account

## Review
- Manually reviewed and verified
- AI-assisted: Yes
- Fixes #121446