### PR TITLE
fix(ui): prevent duplicate initial prompts during session startup

### DIFF
--- a/packages/gateway-client/src/browser.ts
+++ b/packages/gateway-client/src/browser.ts
@@ -7,7 +7,6 @@ export * from "./connect-auth.js";
 export * from "./protocol-client.js";
 export * from "./reconnect-policy.js";
 export * from "./session-projection.js";
-export * from "./session-projection-run-event.js";
 export * from "./session-subscriptions.js";
 export {
   DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,

--- a/packages/gateway-client/src/browser.ts
+++ b/packages/gateway-client/src/browser.ts
@@ -7,6 +7,7 @@ export * from "./connect-auth.js";
 export * from "./protocol-client.js";
 export * from "./reconnect-policy.js";
 export * from "./session-projection.js";
+export * from "./session-projection-run-event.js";
 export * from "./session-subscriptions.js";
 export {
   DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -8,5 +8,6 @@ export * from "./event-loop-ready.js";
 export * from "./gateway-origin-scope.js";
 export * from "./readiness.js";
 export * from "./session-projection.js";
+export * from "./session-projection-run-event.js";
 export * from "./session-subscriptions.js";
 export * from "./timeouts.js";

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -8,6 +8,5 @@ export * from "./event-loop-ready.js";
 export * from "./gateway-origin-scope.js";
 export * from "./readiness.js";
 export * from "./session-projection.js";
-export * from "./session-projection-run-event.js";
 export * from "./session-subscriptions.js";
 export * from "./timeouts.js";

--- a/packages/gateway-client/src/session-projection-run-event.test.ts
+++ b/packages/gateway-client/src/session-projection-run-event.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { reduceSessionProjectionRunEvent } from "./session-projection-run-event.js";
-import { createSessionProjection, type SessionProjectionScope } from "./session-projection.js";
+import {
+  createSessionProjection,
+  reduceSessionProjectionRunEvent,
+  type SessionProjectionScope,
+} from "./session-projection.js";
 
 const scope: SessionProjectionScope = {
   sessionKey: "agent:main:shared",

--- a/packages/gateway-client/src/session-projection-run-event.test.ts
+++ b/packages/gateway-client/src/session-projection-run-event.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { reduceSessionProjectionRunEvent } from "./session-projection-run-event.js";
+import { createSessionProjection, type SessionProjectionScope } from "./session-projection.js";
+
+const scope: SessionProjectionScope = {
+  sessionKey: "agent:main:shared",
+  sessionId: "session-1",
+  agentId: "main",
+  lifecycleRevision: 1,
+  activeLeafEntryId: "leaf-1",
+};
+
+describe("session projection Gateway run events", () => {
+  it.each([
+    { name: "regular final", event: { state: "final" }, status: "completed" },
+    {
+      name: "yielded end turn",
+      event: { state: "final", yielded: true, stopReason: "end_turn" },
+      status: "yielded",
+    },
+    {
+      name: "message-owned error",
+      event: {
+        state: "final",
+        message: { role: "assistant", content: "failure", stopReason: "error" },
+      },
+      status: "error",
+    },
+    {
+      name: "provider timeout",
+      event: { state: "error", errorKind: "timeout" },
+      status: "timeout",
+    },
+    { name: "aborted run", event: { state: "aborted" }, status: "aborted" },
+    { name: "live delta", event: { state: "delta" }, status: "streaming" },
+  ])("normalizes a $name identically for browser and TUI", ({ event, status }) => {
+    const result = reduceSessionProjectionRunEvent(
+      createSessionProjection(scope),
+      { ...event, runId: "shared-run" },
+      scope,
+    );
+    expect(result?.previousRun).toBeUndefined();
+    expect(result?.currentRun?.status).toBe(status);
+    expect(result?.projection.runs["shared-run"]?.status).toBe(status);
+  });
+
+  it("returns both canonical run projections for a duplicate Gateway terminal", () => {
+    const final = {
+      runId: "shared-run",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "delivered final" }],
+        __openclaw: { id: "final-1", seq: 1 },
+      },
+    };
+    const first = reduceSessionProjectionRunEvent(createSessionProjection(scope), final);
+    expect(first).not.toBeNull();
+    if (!first) {
+      return;
+    }
+    const repeated = reduceSessionProjectionRunEvent(first.projection, final);
+    expect(repeated?.previousRun).toBe(first.currentRun);
+    expect(repeated?.projection).toBe(first.projection);
+    expect(repeated?.currentRun).toBe(first.currentRun);
+  });
+
+  it.each(["status", "unknown", undefined])("rejects non-run Gateway event state %j", (state) => {
+    expect(
+      reduceSessionProjectionRunEvent(createSessionProjection(scope), {
+        runId: "shared-run",
+        state,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/gateway-client/src/session-projection-run-event.ts
+++ b/packages/gateway-client/src/session-projection-run-event.ts
@@ -1,27 +1,17 @@
 import {
   reduceSessionProjection,
   type SessionProjectionEvent,
+  type SessionProjectionGatewayRunEvent,
+  type SessionProjectionRunTransition,
   type SessionProjectionScope,
   type SessionProjectionState,
 } from "./session-projection.js";
-
-export type SessionProjectionGatewayRunEvent = {
-  state?: unknown;
-  yielded?: unknown;
-} & Partial<Record<"runId" | "message" | "stopReason" | "errorKind" | "errorMessage", unknown>>;
-
-export type SessionProjectionRunTransition = {
-  projection: SessionProjectionState;
-  previousRun: SessionProjectionState["runs"][string] | undefined;
-  currentRun: SessionProjectionState["runs"][string] | undefined;
-};
 
 function readNonemptyString(value: unknown): string | null {
   return typeof value === "string" ? value.trim() || null : null;
 }
 
-/** Normalizes Gateway run envelopes once for every browser and terminal adapter. */
-export function reduceSessionProjectionRunEvent(
+export function reduceSessionProjectionRunEventImpl(
   projection: SessionProjectionState,
   event: SessionProjectionGatewayRunEvent,
   scope: SessionProjectionScope = {},

--- a/packages/gateway-client/src/session-projection-run-event.ts
+++ b/packages/gateway-client/src/session-projection-run-event.ts
@@ -1,0 +1,69 @@
+import {
+  reduceSessionProjection,
+  type SessionProjectionEvent,
+  type SessionProjectionScope,
+  type SessionProjectionState,
+} from "./session-projection.js";
+
+export type SessionProjectionGatewayRunEvent = {
+  state?: unknown;
+  yielded?: unknown;
+} & Partial<Record<"runId" | "message" | "stopReason" | "errorKind" | "errorMessage", unknown>>;
+
+export type SessionProjectionRunTransition = {
+  projection: SessionProjectionState;
+  previousRun: SessionProjectionState["runs"][string] | undefined;
+  currentRun: SessionProjectionState["runs"][string] | undefined;
+};
+
+function readNonemptyString(value: unknown): string | null {
+  return typeof value === "string" ? value.trim() || null : null;
+}
+
+/** Normalizes Gateway run envelopes once for every browser and terminal adapter. */
+export function reduceSessionProjectionRunEvent(
+  projection: SessionProjectionState,
+  event: SessionProjectionGatewayRunEvent,
+  scope: SessionProjectionScope = {},
+): SessionProjectionRunTransition | null {
+  const runId = readNonemptyString(event.runId);
+  if (
+    !runId ||
+    typeof event.state !== "string" ||
+    !["delta", "final", "error", "aborted"].includes(event.state)
+  ) {
+    return null;
+  }
+  const message = event.message;
+  const messageStopReason =
+    message !== null && typeof message === "object" && !Array.isArray(message)
+      ? readNonemptyString((message as Record<string, unknown>).stopReason)
+      : null;
+  const stopReason = readNonemptyString(event.stopReason) ?? messageStopReason;
+  const errorKind = readNonemptyString(event.errorKind);
+  const base = { runId, ...(message === undefined ? {} : { message }), scope };
+  const action: SessionProjectionEvent =
+    event.state === "delta"
+      ? { type: "runDelta", ...base }
+      : {
+          type: "runTerminal",
+          ...base,
+          status:
+            event.state === "aborted"
+              ? "aborted"
+              : event.state === "error"
+                ? errorKind === "timeout"
+                  ? "timeout"
+                  : "error"
+                : event.yielded === true && stopReason === "end_turn"
+                  ? "yielded"
+                  : stopReason === "error"
+                    ? "error"
+                    : "completed",
+          ...(stopReason === null ? {} : { stopReason }),
+          ...(errorKind === null ? {} : { errorKind }),
+          ...(typeof event.errorMessage === "string" ? { errorMessage: event.errorMessage } : {}),
+        };
+  const next = reduceSessionProjection(projection, action);
+  return { projection: next, previousRun: projection.runs[runId], currentRun: next.runs[runId] };
+}

--- a/packages/gateway-client/src/session-projection.test.ts
+++ b/packages/gateway-client/src/session-projection.test.ts
@@ -11,7 +11,6 @@ import {
   readSessionMessageSequence,
   reconcileSessionProjectionSnapshot,
   reduceSessionProjection,
-  reduceSessionProjectionRunEvent,
   type SessionProjectionScope,
 } from "./session-projection.js";
 
@@ -420,32 +419,86 @@ describe("session transcript projection", () => {
     expect(state.messages).toEqual([partial, complete]);
   });
 
-  it("adopts a persisted pending run once and protects it from stale send failures", () => {
-    const firstPending = createMessage("user", "continue", { idempotencyKey: "first-run:user" });
-    const secondPending = createMessage("user", "continue", { idempotencyKey: "second-run:user" });
-    const firstPersisted = createMessage("user", "continue", {
-      id: "first-user",
+  it("explicitly promotes only the admitted sequenced handoff", () => {
+    const peer = createMessage("user", "continue", {
+      idempotencyKey: "initial-run:user",
       seq: 1,
-      idempotencyKey: "first-run:user",
     });
-    let state = createSessionProjection(primaryScope);
-    state = reduceSessionProjection(state, {
-      type: "sendPending",
-      runId: "first-run",
-      message: firstPending,
+    const handoff = createMessage("user", "continue", {
+      idempotencyKey: "initial-run:user",
+      seq: 2,
     });
-    state = reduceSessionProjection(state, {
-      type: "sendPending",
-      runId: "second-run",
-      message: secondPending,
-    });
-    const persisted = { type: "messagePersisted", message: firstPersisted } as const;
-    state = reduceSessionProjection(state, persisted);
+    const followingAssistant = createMessage("assistant", "already working", { seq: 3 });
+    let state = createSessionProjection(primaryScope, [peer, handoff, followingAssistant]);
 
-    expect(state.messages).toEqual([firstPersisted, secondPending]);
-    expect(state.entries[1]).toMatchObject({ pending: true, pendingRunId: "second-run" });
-    expect(reduceSessionProjection(state, { type: "sendFailed", runId: "first-run" })).toBe(state);
-    expect(reduceSessionProjection(state, persisted)).toBe(state);
+    state = reduceSessionProjection(state, {
+      type: "sendPending",
+      runId: "initial-run",
+      message: handoff,
+    });
+
+    expect(state.entries).toMatchObject([
+      { message: peer, pending: false },
+      { message: handoff, pending: true, pendingRunId: "initial-run" },
+      { message: followingAssistant, pending: false },
+    ]);
+    expect(
+      reduceSessionProjection(state, { type: "sendFailed", runId: "initial-run" }).messages,
+    ).toEqual([peer, followingAssistant]);
+
+    const wrongSequence = createMessage("user", "continue", {
+      id: "wrong-sequence-user",
+      idempotencyKey: "initial-run:user",
+      seq: 4,
+    });
+    state = reduceSessionProjection(state, {
+      type: "messagePersisted",
+      message: wrongSequence,
+    });
+    expect(state.messages).toEqual([peer, handoff, followingAssistant, wrongSequence]);
+    expect(state.entries[1]).toMatchObject({ pending: true, pendingRunId: "initial-run" });
+
+    const authoritative = createMessage("user", "continue", {
+      id: "initial-user",
+      idempotencyKey: "initial-run:user",
+      seq: 2,
+    });
+    state = reduceSessionProjection(state, {
+      type: "messagePersisted",
+      message: authoritative,
+    });
+
+    expect(state.messages).toEqual([peer, authoritative, followingAssistant, wrongSequence]);
+    expect(state.entries[1]).toMatchObject({
+      identity: { id: "initial-user" },
+      pending: false,
+    });
+    expect(reduceSessionProjection(state, { type: "sendFailed", runId: "initial-run" })).toBe(
+      state,
+    );
+    for (const protectedMessage of [
+      createMessage("user", "persisted", {
+        id: "persisted-user",
+        idempotencyKey: "protected-run:user",
+        seq: 4,
+      }),
+      createMessage("user", "imported", {
+        importedFrom: "claude-cli",
+        cliSessionId: "cli-session",
+        externalId: "external-user",
+        idempotencyKey: "protected-run:user",
+        seq: 4,
+      }),
+    ]) {
+      const protectedState = createSessionProjection(primaryScope, [protectedMessage]);
+      expect(
+        reduceSessionProjection(protectedState, {
+          type: "sendPending",
+          runId: "protected-run",
+          message: protectedMessage,
+        }),
+      ).toBe(protectedState);
+    }
   });
 
   it("reconciles an attachment-only optimistic turn solely by its actual send key", () => {
@@ -852,6 +905,7 @@ describe("session transcript projection", () => {
   it("classifies only metadata-free or send-key-only local turns as optimistic", () => {
     const pending = createMessage("user", "local", { idempotencyKey: "local-run:user" });
     const assistant = createMessage("assistant", "streaming locally");
+    const sequenced = createMessage("user", "durable sequence", { seq: 2 });
     const persisted = createMessage("user", "durable", {
       id: "persisted-user",
       seq: 3,
@@ -860,6 +914,7 @@ describe("session transcript projection", () => {
 
     expect(isLocallyOptimisticSessionMessage(pending)).toBe(true);
     expect(isLocallyOptimisticSessionMessage(assistant)).toBe(true);
+    expect(isLocallyOptimisticSessionMessage(sequenced)).toBe(false);
     expect(isLocallyOptimisticSessionMessage(persisted)).toBe(false);
     expect(isLocallyOptimisticSessionMessage({ role: "system", content: "marker" })).toBe(false);
   });
@@ -1007,79 +1062,6 @@ describe("session transcript projection", () => {
     });
 
     expect(projectLiveSessionMessage(state, prompt).messages).toEqual([prompt, assistant]);
-  });
-
-  it.each([
-    {
-      name: "regular final",
-      event: { state: "final" },
-      status: "completed",
-    },
-    {
-      name: "yielded end turn",
-      event: { state: "final", yielded: true, stopReason: "end_turn" },
-      status: "yielded",
-    },
-    {
-      name: "message-owned error",
-      event: {
-        state: "final",
-        message: { role: "assistant", content: "failure", stopReason: "error" },
-      },
-      status: "error",
-    },
-    {
-      name: "provider timeout",
-      event: { state: "error", errorKind: "timeout" },
-      status: "timeout",
-    },
-    {
-      name: "aborted run",
-      event: { state: "aborted" },
-      status: "aborted",
-    },
-    {
-      name: "live delta",
-      event: { state: "delta" },
-      status: "streaming",
-    },
-  ])("normalizes a $name identically for browser and TUI", ({ event, status }) => {
-    const result = reduceSessionProjectionRunEvent(
-      createSessionProjection(primaryScope),
-      { ...event, runId: "shared-run" },
-      primaryScope,
-    );
-
-    expect(result?.previousRun).toBeUndefined();
-    expect(result?.currentRun?.status).toBe(status);
-    expect(result?.projection.runs["shared-run"]?.status).toBe(status);
-  });
-
-  it("returns both canonical run projections for a duplicate Gateway terminal", () => {
-    const final = {
-      runId: "shared-run",
-      state: "final",
-      message: createMessage("assistant", "delivered final", { id: "final-1", seq: 1 }),
-    };
-    const first = reduceSessionProjectionRunEvent(createSessionProjection(primaryScope), final);
-    expect(first).not.toBeNull();
-    if (!first) {
-      return;
-    }
-    const repeated = reduceSessionProjectionRunEvent(first.projection, final);
-
-    expect(repeated?.previousRun).toBe(first.currentRun);
-    expect(repeated?.projection).toBe(first.projection);
-    expect(repeated?.currentRun).toBe(first.currentRun);
-  });
-
-  it.each(["status", "unknown", undefined])("rejects non-run Gateway event state %j", (state) => {
-    expect(
-      reduceSessionProjectionRunEvent(createSessionProjection(primaryScope), {
-        runId: "shared-run",
-        state,
-      }),
-    ).toBeNull();
   });
 
   it("does not mutate source messages, snapshots, or previous reducer states", () => {

--- a/packages/gateway-client/src/session-projection.ts
+++ b/packages/gateway-client/src/session-projection.ts
@@ -1,5 +1,7 @@
 /** Browser-safe identity and replay rules shared by Gateway conversation clients. */
 
+export { reduceSessionProjectionRunEvent } from "./session-projection-run-event.js";
+
 export type SessionMessageEnvelope = {
   messageId?: unknown;
   messageSeq?: unknown;
@@ -46,17 +48,6 @@ export type SessionProjectionRun = {
   stopReason?: string;
   errorKind?: string;
   errorMessage?: string;
-};
-
-export type SessionProjectionGatewayRunEvent = {
-  state?: unknown;
-  yielded?: unknown;
-} & Partial<Record<"runId" | "message" | "stopReason" | "errorKind" | "errorMessage", unknown>>;
-
-export type SessionProjectionRunTransition = {
-  projection: SessionProjectionState;
-  previousRun: SessionProjectionRun | undefined;
-  currentRun: SessionProjectionRun | undefined;
 };
 
 export type SessionProjectionEntry = {
@@ -331,11 +322,16 @@ function entryMatches(
   return Boolean(
     pending &&
     authoritative &&
-    pending.identity?.role === authoritative.identity?.role &&
-    !pending.identity?.isImported &&
-    !authoritative.identity?.isImported &&
+    pending.identity &&
+    authoritative.identity &&
+    pending.identity.role === authoritative.identity.role &&
+    !pending.identity.isImported &&
+    !authoritative.identity.isImported &&
     pending.pendingRunId &&
-    pending.pendingRunId === authoritative.identity?.runId,
+    pending.pendingRunId === authoritative.identity.runId &&
+    (pending.identity.sequence === null ||
+      authoritative.identity.sequence === null ||
+      pending.identity.sequence === authoritative.identity.sequence),
   );
 }
 
@@ -652,10 +648,26 @@ export function reduceSessionProjection(
       if (!pendingRunId || !incoming.identity) {
         return state;
       }
-      const index = state.entries.findIndex((entry) => entryMatches(entry, incoming));
-      return index < 0
-        ? withEntries(state, insertEntry(state.entries, incoming, state.runs))
-        : state;
+      const seed = state.entries.find((entry) => entry.message === event.message);
+      // Explicit send ownership may promote its same native seed. Durable and
+      // imported rows stay authoritative so send failure cannot remove them.
+      if (
+        seed &&
+        !seed.pending &&
+        incoming.identity.id === null &&
+        !incoming.identity.isImported &&
+        incoming.identity.runId === pendingRunId
+      ) {
+        return withEntries(
+          state,
+          state.entries.map((entry) =>
+            entry === seed ? { ...seed, pending: true, pendingRunId } : entry,
+          ),
+        );
+      }
+      return seed || state.entries.some((entry) => entryMatches(entry, incoming))
+        ? state
+        : withEntries(state, insertEntry(state.entries, incoming, state.runs));
     }
     case "sendAcknowledged": {
       const runId = normalizeSessionProjectionRunId(event.idempotencyKey ?? event.runId);
@@ -709,50 +721,4 @@ export function reduceSessionProjection(
     default:
       return state;
   }
-}
-
-/** Normalizes Gateway run envelopes once for every browser and terminal adapter. */
-export function reduceSessionProjectionRunEvent(
-  projection: SessionProjectionState,
-  event: SessionProjectionGatewayRunEvent,
-  scope: SessionProjectionScope = {},
-): SessionProjectionRunTransition | null {
-  const runId = readNonemptyString(event.runId);
-  const eventState = event.state;
-  if (
-    !runId ||
-    typeof eventState !== "string" ||
-    !["delta", "final", "error", "aborted"].includes(eventState)
-  ) {
-    return null;
-  }
-  const message = event.message;
-  const stopReason =
-    readNonemptyString(event.stopReason) ?? readNonemptyString(readRecord(message)?.stopReason);
-  const errorKind = readNonemptyString(event.errorKind);
-  const base = { runId, ...(message === undefined ? {} : { message }), scope };
-  const action: SessionProjectionEvent =
-    eventState === "delta"
-      ? { type: "runDelta", ...base }
-      : {
-          type: "runTerminal",
-          ...base,
-          status:
-            eventState === "aborted"
-              ? "aborted"
-              : eventState === "error"
-                ? errorKind === "timeout"
-                  ? "timeout"
-                  : "error"
-                : event.yielded === true && stopReason === "end_turn"
-                  ? "yielded"
-                  : stopReason === "error"
-                    ? "error"
-                    : "completed",
-          ...(stopReason === null ? {} : { stopReason }),
-          ...(errorKind === null ? {} : { errorKind }),
-          ...(typeof event.errorMessage === "string" ? { errorMessage: event.errorMessage } : {}),
-        };
-  const next = reduceSessionProjection(projection, action);
-  return { projection: next, previousRun: projection.runs[runId], currentRun: next.runs[runId] };
 }

--- a/packages/gateway-client/src/session-projection.ts
+++ b/packages/gateway-client/src/session-projection.ts
@@ -1,6 +1,6 @@
 /** Browser-safe identity and replay rules shared by Gateway conversation clients. */
 
-export { reduceSessionProjectionRunEvent } from "./session-projection-run-event.js";
+import { reduceSessionProjectionRunEventImpl } from "./session-projection-run-event.js";
 
 export type SessionMessageEnvelope = {
   messageId?: unknown;
@@ -48,6 +48,17 @@ export type SessionProjectionRun = {
   stopReason?: string;
   errorKind?: string;
   errorMessage?: string;
+};
+
+export type SessionProjectionGatewayRunEvent = {
+  state?: unknown;
+  yielded?: unknown;
+} & Partial<Record<"runId" | "message" | "stopReason" | "errorKind" | "errorMessage", unknown>>;
+
+export type SessionProjectionRunTransition = {
+  projection: SessionProjectionState;
+  previousRun: SessionProjectionRun | undefined;
+  currentRun: SessionProjectionRun | undefined;
 };
 
 export type SessionProjectionEntry = {
@@ -721,4 +732,13 @@ export function reduceSessionProjection(
     default:
       return state;
   }
+}
+
+/** Normalizes Gateway run envelopes once for every browser and terminal adapter. */
+export function reduceSessionProjectionRunEvent(
+  projection: SessionProjectionState,
+  event: SessionProjectionGatewayRunEvent,
+  scope: SessionProjectionScope = {},
+): SessionProjectionRunTransition | null {
+  return reduceSessionProjectionRunEventImpl(projection, event, scope);
 }

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -19,7 +19,6 @@ import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "../../plugin-sdk/message-tool-d
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import { hasControlCommand } from "../command-detection.js";
 import { runReplyAgent } from "./agent-runner.runtime.js";
-import { applySessionHints } from "./body.js";
 import {
   loadAgentRunnerRuntime,
   loadEmbeddedAgentRuntime,

--- a/ui/src/app/cloud-session-startup.runtime.ts
+++ b/ui/src/app/cloud-session-startup.runtime.ts
@@ -204,6 +204,7 @@ export default function createApplicationCloudStartupRuntime(
     params.initialUserMessage.prepare({
       sessionKey: entry.owner.sessionKey,
       owner: entry.scope.client,
+      pendingRunId: result.messageId,
       message: buildInitialUserMessage(recovery, entry.createdAt, result),
     });
   };

--- a/ui/src/app/cloud-session-startup.test.ts
+++ b/ui/src/app/cloud-session-startup.test.ts
@@ -493,8 +493,11 @@ describe("application cloud startup", () => {
     });
     expect(startup.get(input.recovery.sessionKey)).toBeNull();
     expect(initialUserMessage.read(input.recovery.sessionKey, client)).toMatchObject({
-      role: "user",
-      __openclaw: { idempotencyKey: "message-stable:user", seq: 7 },
+      pendingRunId: "message-stable",
+      message: {
+        role: "user",
+        __openclaw: { idempotencyKey: "message-stable:user", seq: 7 },
+      },
     });
     expect(sessions.refresh).not.toHaveBeenCalled();
     startup.dispose();

--- a/ui/src/app/initial-user-message-handoff.test.ts
+++ b/ui/src/app/initial-user-message-handoff.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   createInitialUserMessageHandoff,
   type ApplicationInitialUserMessage,
@@ -9,29 +9,28 @@ function message(text: string): ApplicationInitialUserMessage {
 }
 
 describe("initial user message handoff", () => {
-  it("notifies once for actual prepare and clear changes", () => {
+  it("stores run ownership and preserves client privacy until clearing", () => {
     const handoff = createInitialUserMessageHandoff();
-    const listener = vi.fn();
     const owner = {};
+    const replacementOwner = {};
     const first = message("first");
-    const unsubscribe = handoff.subscribe(listener);
+    handoff.prepare({
+      sessionKey: "agent:main:main",
+      message: first,
+      owner,
+      pendingRunId: "initial-run",
+    });
 
-    handoff.prepare({ sessionKey: "agent:main:main", message: first, owner });
-    expect(listener).toHaveBeenCalledTimes(1);
-    handoff.prepare({ sessionKey: "main", message: first, owner });
-    expect(listener).toHaveBeenCalledTimes(1);
-
-    handoff.prepare({ sessionKey: "main", message: message("replacement"), owner });
-    expect(listener).toHaveBeenCalledTimes(2);
+    expect(handoff.read("main", owner)).toEqual({
+      sessionKey: "agent:main:main",
+      message: first,
+      owner,
+      pendingRunId: "initial-run",
+    });
+    expect(handoff.read("main", replacementOwner)).toBeNull();
     handoff.clear("agent:main:missing");
-    expect(listener).toHaveBeenCalledTimes(2);
+    expect(handoff.read("main", owner)).not.toBeNull();
     handoff.clear("agent:main:main");
-    expect(listener).toHaveBeenCalledTimes(3);
-    handoff.clear();
-    expect(listener).toHaveBeenCalledTimes(3);
-
-    unsubscribe();
-    handoff.prepare({ sessionKey: "main", message: first, owner });
-    expect(listener).toHaveBeenCalledTimes(3);
+    expect(handoff.read("main", owner)).toBeNull();
   });
 });

--- a/ui/src/app/initial-user-message-handoff.ts
+++ b/ui/src/app/initial-user-message-handoff.ts
@@ -7,7 +7,7 @@ export type ApplicationInitialUserMessage = {
   __openclaw?: { idempotencyKey?: string; seq?: number };
 };
 
-export type ApplicationInitialUserMessageHandoffEntry = {
+type ApplicationInitialUserMessageHandoffEntry = {
   message: ApplicationInitialUserMessage;
   pendingRunId: string;
   /** Logical Gateway client; per-transport hello objects rotate on reconnect. */

--- a/ui/src/app/initial-user-message-handoff.ts
+++ b/ui/src/app/initial-user-message-handoff.ts
@@ -7,34 +7,28 @@ export type ApplicationInitialUserMessage = {
   __openclaw?: { idempotencyKey?: string; seq?: number };
 };
 
-type InitialUserMessageHandoff = {
+export type ApplicationInitialUserMessageHandoffEntry = {
   message: ApplicationInitialUserMessage;
+  pendingRunId: string;
   /** Logical Gateway client; per-transport hello objects rotate on reconnect. */
   owner: object;
   sessionKey: string;
 };
 
 export type ApplicationInitialUserMessageHandoff = {
-  prepare: (handoff: InitialUserMessageHandoff) => void;
-  read: (sessionKey: string, owner: object | null) => ApplicationInitialUserMessage | null;
+  prepare: (handoff: ApplicationInitialUserMessageHandoffEntry) => void;
+  read: (
+    sessionKey: string,
+    owner: object | null,
+  ) => ApplicationInitialUserMessageHandoffEntry | null;
   clear: (sessionKey?: string) => void;
-  subscribe: (listener: () => void) => () => void;
 };
 
 // Terminal history removes normal entries; this cap bounds abandoned active-session handoffs.
 const MAX_PENDING_INITIAL_USER_MESSAGES = 32;
 
 export function createInitialUserMessageHandoff(): ApplicationInitialUserMessageHandoff {
-  const pending = new Map<
-    string,
-    Pick<Parameters<ApplicationInitialUserMessageHandoff["prepare"]>[0], "message" | "owner">
-  >();
-  const listeners = new Set<() => void>();
-  const publish = () => {
-    for (const listener of listeners) {
-      listener();
-    }
-  };
+  const pending = new Map<string, Parameters<ApplicationInitialUserMessageHandoff["prepare"]>[0]>();
   const findKey = (sessionKey: string) => {
     for (const candidate of pending.keys()) {
       if (areUiSessionKeysEquivalent(candidate, sessionKey)) {
@@ -46,14 +40,10 @@ export function createInitialUserMessageHandoff(): ApplicationInitialUserMessage
   return {
     prepare: (handoff) => {
       const existingKey = findKey(handoff.sessionKey);
-      const existing = existingKey ? pending.get(existingKey) : undefined;
-      if (existing?.message === handoff.message && existing.owner === handoff.owner) {
-        return;
-      }
       if (existingKey) {
         pending.delete(existingKey);
       }
-      pending.set(handoff.sessionKey, { message: handoff.message, owner: handoff.owner });
+      pending.set(handoff.sessionKey, handoff);
       while (pending.size > MAX_PENDING_INITIAL_USER_MESSAGES) {
         const oldestKey = pending.keys().next().value;
         if (oldestKey === undefined) {
@@ -61,30 +51,20 @@ export function createInitialUserMessageHandoff(): ApplicationInitialUserMessage
         }
         pending.delete(oldestKey);
       }
-      publish();
     },
     read: (sessionKey, owner) => {
       const handoff = pending.get(findKey(sessionKey) ?? "");
-      return handoff && handoff.owner === owner ? handoff.message : null;
+      return handoff && handoff.owner === owner ? handoff : null;
     },
     clear: (sessionKey) => {
       if (sessionKey === undefined) {
-        if (pending.size === 0) {
-          return;
-        }
         pending.clear();
-        publish();
         return;
       }
       const key = findKey(sessionKey);
       if (key) {
         pending.delete(key);
-        publish();
       }
-    },
-    subscribe: (listener) => {
-      listeners.add(listener);
-      return () => listeners.delete(listener);
     },
   };
 }

--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -128,7 +128,12 @@ suite.define(() => {
       const activeOutputTimestamp = Date.now() + 60_000;
       const gateway = await installMockGateway(page, {
         methodResponses: {
-          "sessions.create": { key: sessionKey, runStarted: true },
+          "sessions.create": {
+            key: sessionKey,
+            runId: "visible-initial-run",
+            runStarted: true,
+            messageSeq: 1,
+          },
           "sessions.list": createdSessionListResult(sessionKey),
           "chat.startup": {
             messages: [
@@ -186,7 +191,12 @@ suite.define(() => {
       const message = "keep this first prompt through reconnect";
       const gateway = await installMockGateway(page, {
         methodResponses: {
-          "sessions.create": { key: sessionKey, runStarted: true },
+          "sessions.create": {
+            key: sessionKey,
+            runId: "reconnected-initial-run",
+            runStarted: true,
+            messageSeq: 1,
+          },
           "sessions.list": createdSessionListResult(sessionKey),
           "chat.startup": {
             messages: [],
@@ -237,7 +247,6 @@ suite.define(() => {
           fullPage: true,
         });
       }
-
       await pollLocatorText(page.locator(".chat-group.user")).toContain(message);
       await expect.poll(() => page.locator(".chat-group.user").count()).toBe(1);
     });
@@ -246,38 +255,43 @@ suite.define(() => {
   it("reconciles an image-bearing initial prompt into one user row", async () => {
     await withNewSessionPage(async (page) => {
       const sessionKey = "agent:main:single-image-prompt";
+      const runId = "initial-image-send";
       const message = "testing if dual prompts show";
+      const authoritative = {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: { type: "url", url: "/persisted-image.png" },
+          },
+          { type: "text", text: message },
+        ],
+        timestamp: Date.now(),
+        __openclaw: {
+          id: "persisted-image-prompt",
+          idempotencyKey: `${runId}:user`,
+          seq: 1,
+        },
+      };
       const gateway = await installMockGateway(page, {
         deferredMethods: ["chat.startup"],
         methodResponses: {
           "sessions.create": {
             key: sessionKey,
-            runId: "initial-image-send",
+            runId,
             runStarted: true,
             messageSeq: 1,
           },
           "sessions.list": createdSessionListResult(sessionKey),
           "chat.startup": {
-            messages: [
-              {
-                role: "user",
-                content: [
-                  {
-                    type: "image",
-                    source: { type: "url", url: "/persisted-image.png" },
-                  },
-                  { type: "text", text: message },
-                ],
-                timestamp: Date.now(),
-                __openclaw: {
-                  id: "persisted-image-prompt",
-                  idempotencyKey: "initial-image-send:user",
-                  seq: 1,
-                },
-              },
-            ],
+            messages: [authoritative],
             sessionId: "single-image-prompt",
-            sessionInfo: { hasActiveRun: true, key: sessionKey, status: "running" },
+            sessionInfo: {
+              activeRunIds: [runId],
+              hasActiveRun: true,
+              key: sessionKey,
+              status: "running",
+            },
           },
         },
       });
@@ -301,12 +315,40 @@ suite.define(() => {
       await pollLocatorText(userRow).toContain(message);
       await pollLocatorText(userRow).not.toContain("Attached image");
 
+      const promptBubbles = page.locator(".chat-bubble").filter({ hasText: message });
+      const durableBubble = page.locator('.chat-bubble[data-entry-id="persisted-image-prompt"]');
+      await expect.poll(() => promptBubbles.count()).toBe(1);
+      await gateway.emitGatewayEvent("session.message", {
+        activeRunIds: [runId],
+        clientRunId: runId,
+        hasActiveRun: true,
+        message: authoritative,
+        messageId: "persisted-image-prompt",
+        messageSeq: 1,
+        session: {
+          activeRunIds: [runId],
+          hasActiveRun: true,
+          key: sessionKey,
+          kind: "direct",
+          status: "running",
+          updatedAt: Date.now(),
+        },
+        sessionKey,
+      });
+      await durableBubble.waitFor({ timeout: 10_000 });
+      await expect.poll(() => durableBubble.count()).toBe(1);
+      await expect.poll(() => promptBubbles.count()).toBe(1);
+      await expect.poll(() => userImage.getAttribute("data-initial-image-node")).toBe("true");
+      await expect.poll(() => userImage.getAttribute("src")).toBe(initialImageSrc);
+
       await gateway.resolveDeferred("chat.startup");
 
       await expect.poll(() => userRow.count()).toBe(1);
       await expect.poll(() => userImage.count()).toBe(1);
       await expect.poll(() => userImage.getAttribute("data-initial-image-node")).toBe("true");
       await expect.poll(() => userImage.getAttribute("src")).toBe(initialImageSrc);
+      await expect.poll(() => promptBubbles.count()).toBe(1);
+      await expect.poll(() => durableBubble.count()).toBe(1);
       await pollLocatorText(userRow).toContain(message);
       await pollLocatorText(userRow).not.toContain("Attached image");
     });

--- a/ui/src/lib/sessions/create.test.ts
+++ b/ui/src/lib/sessions/create.test.ts
@@ -25,7 +25,7 @@ describe("requestSessionCreate", () => {
 
     await expect(requestSessionCreate(client as never, { message: "hello" })).resolves.toEqual({
       key: "agent:main:dashboard:new",
-      initialRun: { status: "started", messageId: "initial-send-id", messageSeq: 7 },
+      initialRun: { status: "started", runId: "initial-send-id", messageSeq: 7 },
     });
   });
 

--- a/ui/src/lib/sessions/create.ts
+++ b/ui/src/lib/sessions/create.ts
@@ -5,7 +5,7 @@ export type SessionCreateOutcome = {
   key: string;
   initialRun:
     | { status: "idle" }
-    | { status: "started"; messageId?: string; messageSeq?: number }
+    | { status: "started"; runId?: string; messageSeq?: number }
     | { status: "rejected"; error: string };
 };
 
@@ -61,13 +61,13 @@ export async function requestSessionCreate(
     throw new Error("sessions.create returned no key");
   }
   if (result.runStarted === true) {
-    const messageId = typeof result.runId === "string" ? result.runId.trim() : "";
+    const runId = typeof result.runId === "string" ? result.runId.trim() : "";
     const messageSeq = result.messageSeq;
     return {
       key,
       initialRun: {
         status: "started",
-        ...(messageId ? { messageId } : {}),
+        ...(runId ? { runId } : {}),
         ...(typeof messageSeq === "number" && Number.isSafeInteger(messageSeq) && messageSeq > 0
           ? { messageSeq }
           : {}),

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -59,7 +59,6 @@ import {
   readChatSessionProjectionScope,
   reduceChatSessionProjection,
 } from "./history-merge.ts";
-import { reconcileInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
 import {
   controlUiNowMs,
   recordControlUiPerformanceEvent,
@@ -1651,19 +1650,19 @@ async function loadChatHistoryUncached(
         messages: authoritativeMessages,
         options: { shouldIncludeMessage: (message) => !shouldHideHistoryMessage(message) },
       },
-      { scope, messages: retainsTranscriptIdentity ? state.chatMessages : [] },
+      {
+        scope,
+        messages: retainsTranscriptIdentity ? state.chatMessages : [],
+        runActive:
+          res.sessionInfo &&
+          (typeof res.sessionInfo.hasActiveRun === "boolean" ||
+            res.sessionInfo.status !== undefined)
+            ? isSessionRunActive(res.sessionInfo)
+            : undefined,
+      },
     );
     if (Object.hasOwn(res.sessionInfo ?? {}, "activeLeafEntryId")) {
       state.chatDisplayedLeafEntryId = res.sessionInfo?.activeLeafEntryId?.trim() || null;
-    }
-    if (state.initialUserMessage) {
-      reconcileInitialUserMessageHandoff(
-        state.initialUserMessage,
-        state,
-        sessionKey,
-        authoritativeMessages,
-        isSessionRunActive(res.sessionInfo ?? {}),
-      );
     }
     retireHistoryProvenSteeredChips(state);
     state.chatHistoryPagination = reconciledHistory?.pagination ?? nextPagination;

--- a/ui/src/pages/chat/chat-pane-board.test.ts
+++ b/ui/src/pages/chat/chat-pane-board.test.ts
@@ -76,6 +76,7 @@ function createTestPane(sessions: SessionCapability = {} as SessionCapability) {
   pane.state = {
     chatError: null,
     chatLoading: false,
+    chatMessages: [],
     chatQueue: [],
     chatRunId: null,
     chatSending: false,

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -120,6 +120,7 @@ describe("chat pane first-turn attachment lifecycle", () => {
       targetSessionKey,
       { attachments: [], createdAt: 1, text: "keep the first prompt visible" },
       client,
+      { runId: "initial-run" },
     );
     pane.sessionKey = targetSessionKey;
     pane.chatMessagesBySession = new Map();

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -61,10 +61,8 @@ import { toggleSessionWorkspace } from "./components/chat-session-workspace.ts";
 import { WIDGET_PROMPT_EVENT, type WidgetPromptEventDetail } from "./components/chat-tool-cards.ts";
 import { CHAT_COMPOSER_DRAFT_STORAGE_ERROR } from "./composer-persistence.ts";
 import { exportChatMarkdown } from "./export.ts";
-import {
-  admitInitialTurnHandoff,
-  admitInitialUserMessageHandoff as admitInitialMessage,
-} from "./initial-turn-handoff.ts";
+import { admitInitialUserMessageHandoff } from "./history-merge.ts";
+import { admitInitialTurnHandoff } from "./initial-turn-handoff.ts";
 import { readChatSessionSnapshot } from "./session-message-cache.ts";
 
 const COMPOSER_PREFILL_ATTENTION_DURATION_MS = 1_200;
@@ -504,7 +502,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneBoard {
           pageState.lastError = CHAT_COMPOSER_DRAFT_STORAGE_ERROR;
           pageState.chatError = CHAT_COMPOSER_DRAFT_STORAGE_ERROR;
         }
-        admitInitialMessage(pageState.initialUserMessage, pageState, initialSessionKey);
+        admitInitialUserMessageHandoff(pageState, initialSessionKey);
       }
     }
     chatState.attach(pageState);
@@ -615,8 +613,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneBoard {
         // would vanish instead of offering a retry, and the accepted prompt would
         // stay hidden until the transcript bootstrap resolved.
         const rejectedTurn = admitInitialTurnHandoff(this.state, nextSessionKey);
-        const initialUserMessage = this.state.initialUserMessage;
-        const acceptedPrompt = admitInitialMessage(initialUserMessage, this.state, nextSessionKey);
+        const acceptedPrompt = admitInitialUserMessageHandoff(this.state, nextSessionKey);
         if (rejectedTurn) {
           this.state.lastError = CHAT_COMPOSER_DRAFT_STORAGE_ERROR;
           this.state.chatError = CHAT_COMPOSER_DRAFT_STORAGE_ERROR;

--- a/ui/src/pages/chat/chat-pane-startup-subscriptions.ts
+++ b/ui/src/pages/chat/chat-pane-startup-subscriptions.ts
@@ -1,26 +1,18 @@
 import type { ApplicationContext } from "../../app/context.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
-import { admitInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
+import { admitInitialUserMessageHandoff } from "./history-merge.ts";
 
-type ChatPaneStartupContext = Pick<ApplicationContext, "cloudStartup" | "initialUserMessage">;
+type ChatPaneStartupContext = Pick<ApplicationContext, "cloudStartup">;
 
 export function subscribeChatPaneStartup(
   context: ChatPaneStartupContext,
   getState: () => ChatPageHost | undefined,
 ): () => void {
-  const stopInitialUserMessage = context.initialUserMessage.subscribe(() => {
+  return context.cloudStartup.subscribe(() => {
     const state = getState();
-    if (
-      state &&
-      admitInitialUserMessageHandoff(state.initialUserMessage, state, state.sessionKey)
-    ) {
+    if (state) {
+      admitInitialUserMessageHandoff(state, state.sessionKey);
       state.requestUpdate?.();
     }
   });
-  const stopCloudStartup = context.cloudStartup.subscribe(() => getState()?.requestUpdate?.());
-
-  return () => {
-    stopCloudStartup();
-    stopInitialUserMessage();
-  };
 }

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -59,7 +59,11 @@ function sessionMessageMatchesChat(
   return chatScopedEventSessionMatches(state, event.key, event.agentId ?? undefined);
 }
 
-function applyLiveUserMessage(state: ChatPageHost, payload: unknown): void {
+function applyLiveUserMessage(
+  state: ChatPageHost,
+  payload: unknown,
+  runActive: boolean | undefined,
+): void {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     return;
   }
@@ -105,7 +109,7 @@ function applyLiveUserMessage(state: ChatPageHost, payload: unknown): void {
   reduceChatSessionProjection(
     state,
     { type: "messagePersisted", message, envelope: event },
-    { scope },
+    { scope, runActive },
   );
 }
 
@@ -176,7 +180,7 @@ function handleSessionMessageEvent(state: ChatPageHost, payload: unknown) {
   }
   const matchesChat = sessionMessageMatchesChat(state, event);
   if (matchesChat) {
-    applyLiveUserMessage(state, payload);
+    applyLiveUserMessage(state, payload, event.hasActiveRun ?? undefined);
     void loadChatBranches(state);
   }
   if (matchesChat && event.archived !== null) {

--- a/ui/src/pages/chat/chat-state-route.ts
+++ b/ui/src/pages/chat/chat-state-route.ts
@@ -36,7 +36,8 @@ import {
   type ChatComposerDraftRetry,
   type StoredChatOutboxScope,
 } from "./composer-persistence.ts";
-import { admitInitialTurnHandoff, admitInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
+import { admitInitialUserMessageHandoff } from "./history-merge.ts";
+import { admitInitialTurnHandoff } from "./initial-turn-handoff.ts";
 import { reconcileChatRunLifecycle } from "./run-lifecycle.ts";
 import {
   cacheChatSessionSnapshot,
@@ -224,7 +225,7 @@ export function resetChatStateForRouteSession(
   // switchPaneSession requests an update only after adopting the new baseline.
   syncVisibleChatQueueProjection(state, { requestUpdate: false });
   const initialTurn = admitInitialTurnHandoff(state, sessionKey);
-  admitInitialUserMessageHandoff(state.initialUserMessage, state, sessionKey);
+  admitInitialUserMessageHandoff(state, sessionKey);
   const { fallback } = resolveChatComposerMemoryFallback(state, sessionKey);
   if (fallback) {
     state.chatMessage = fallback.message;

--- a/ui/src/pages/chat/history-merge.test.ts
+++ b/ui/src/pages/chat/history-merge.test.ts
@@ -4,12 +4,17 @@ import {
   type SessionProjectionScope,
 } from "@openclaw/gateway-client/browser";
 import { describe, expect, it } from "vitest";
+import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
 import {
+  admitInitialUserMessageHandoff,
   getChatSessionProjection,
   readChatSessionProjectionScope,
   reduceChatSessionProjection,
   setChatSessionProjection,
 } from "./history-merge.ts";
+import { prepareInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
+
+const imageDataUrl = "data:image/png;base64,iVBORw0KGgo=";
 
 function createHistoryMessage(
   role: "assistant" | "user",
@@ -31,6 +36,54 @@ function projectLiveMessage(owner: object, message: unknown, scope: SessionProje
   });
   setChatSessionProjection(owner, projection);
   return projection;
+}
+
+function createInitialHandoffFixture(messageSequence = 1) {
+  const sessionKey = "agent:main:initial-image";
+  const client = {};
+  const initialUserMessage = createInitialUserMessageHandoff();
+  const owner = {
+    sessionKey,
+    client,
+    initialUserMessage,
+    chatMessages: [] as unknown[],
+    currentSessionId: "initial-session",
+  };
+  prepareInitialUserMessageHandoff(
+    initialUserMessage,
+    sessionKey,
+    {
+      text: "inspect this image",
+      attachments: [
+        {
+          id: "image-1",
+          mimeType: "image/png",
+          fileName: "image.png",
+          sizeBytes: 68,
+          dataUrl: imageDataUrl,
+        },
+      ],
+      createdAt: 123,
+    },
+    client,
+    { runId: "initial-run", messageSeq: messageSequence },
+  );
+  return { client, initialUserMessage, owner, sessionKey };
+}
+
+function createAuthoritativeInitialMessage(sequence = 1) {
+  return {
+    role: "user",
+    content: [{ type: "image", source: { type: "url", url: "/persisted.png" } }],
+    timestamp: 456,
+    serverField: "authoritative",
+    __openclaw: {
+      id: "persisted-initial-user",
+      idempotencyKey: "initial-run:user",
+      seq: sequence,
+      media: [{ path: "/persisted.png", contentType: "image/png" }],
+    },
+  };
 }
 
 describe("pane-owned canonical session projection", () => {
@@ -74,6 +127,97 @@ describe("pane-owned canonical session projection", () => {
 
     expect(owner.chatMessages).toEqual([liveUser]);
     expect(getChatSessionProjection(owner, owner.chatMessages, projection.scope)).toBe(projection);
+  });
+
+  it.each([
+    {
+      name: "live-first active adoption",
+      admitFirst: true,
+      eventType: "messagePersisted" as const,
+    },
+    {
+      name: "history-first terminal adoption",
+      admitFirst: false,
+      eventType: "snapshotLoaded" as const,
+    },
+  ])("owns $name in one projection publication", ({ admitFirst, eventType }) => {
+    const { client, initialUserMessage, owner, sessionKey } = createInitialHandoffFixture();
+    const handoff = initialUserMessage.read(sessionKey, client);
+    expect(handoff).not.toBeNull();
+    if (!handoff) {
+      throw new Error("expected initial prompt handoff");
+    }
+    if (admitFirst) {
+      expect(admitInitialUserMessageHandoff(owner, sessionKey)).toBe(true);
+      const admittedMessage = owner.chatMessages[0];
+      owner.chatMessages = [];
+      expect(admitInitialUserMessageHandoff(owner, sessionKey)).toBe(true);
+      expect(owner.chatMessages).toEqual([admittedMessage]);
+      owner.chatMessages = [];
+      const reboundScope = readChatSessionProjectionScope(owner, {
+        sessionId: "rebound-session",
+      });
+      reduceChatSessionProjection(
+        owner,
+        { type: "snapshotLoaded", messages: [] },
+        { scope: reboundScope },
+      );
+      expect(owner.chatMessages).toEqual([admittedMessage]);
+      owner.currentSessionId = "rebound-session";
+    }
+    const localContent = handoff.message.content;
+    const authoritative = createAuthoritativeInitialMessage();
+    const event =
+      eventType === "messagePersisted"
+        ? ({ type: eventType, message: authoritative } as const)
+        : ({ type: eventType, messages: [authoritative] } as const);
+    const projection = reduceChatSessionProjection(owner, event, { runActive: admitFirst });
+    const adopted = owner.chatMessages[0] as Record<string, unknown>;
+
+    expect(owner.chatMessages).toHaveLength(1);
+    expect(projection.messages[0]).toBe(adopted);
+    expect(adopted.content).toBe(localContent);
+    expect(adopted).toMatchObject({
+      role: "user",
+      timestamp: 456,
+      serverField: "authoritative",
+      __openclaw: {
+        id: "persisted-initial-user",
+        idempotencyKey: "initial-run:user",
+        seq: 1,
+      },
+    });
+    expect((adopted["__openclaw"] as Record<string, unknown>).media).toBeUndefined();
+
+    if (admitFirst) {
+      expect(initialUserMessage.read(sessionKey, client)).not.toBeNull();
+      reduceChatSessionProjection(owner, { type: "sessionReset" });
+      expect(admitInitialUserMessageHandoff(owner, sessionKey)).toBe(true);
+      expect(owner.chatMessages).toEqual([handoff.message]);
+      reduceChatSessionProjection(
+        owner,
+        { type: "snapshotLoaded", messages: [authoritative] },
+        { runActive: false },
+      );
+      expect(initialUserMessage.read(sessionKey, client)).toBeNull();
+    } else {
+      expect(initialUserMessage.read(sessionKey, client)).toBeNull();
+      expect(admitInitialUserMessageHandoff(owner, sessionKey)).toBe(false);
+    }
+  });
+
+  it("requires the accepted sequence when adopting the initial run", () => {
+    const { client, initialUserMessage, owner, sessionKey } = createInitialHandoffFixture(2);
+    const authoritative = createAuthoritativeInitialMessage(1);
+    const projection = reduceChatSessionProjection(
+      owner,
+      { type: "snapshotLoaded", messages: [authoritative] },
+      { runActive: false },
+    );
+
+    expect(projection.messages[0]).toBe(authoritative);
+    expect(owner.chatMessages[0]).toBe(authoritative);
+    expect(initialUserMessage.read(sessionKey, client)).not.toBeNull();
   });
 
   it("keeps each split pane's live projection independent", () => {

--- a/ui/src/pages/chat/history-merge.ts
+++ b/ui/src/pages/chat/history-merge.ts
@@ -1,17 +1,23 @@
 import {
   createSessionProjection,
+  readSessionMessageIdentity,
   reconcileSessionProjectionSnapshot,
   reduceSessionProjection,
   type SessionProjectionEvent,
+  type SessionMessageEnvelope,
   type SessionProjectionScope,
   type SessionProjectionState,
 } from "@openclaw/gateway-client/browser";
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import type { ApplicationInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
 
 const chatSessionProjections = new WeakMap<object, SessionProjectionState>();
 
 type ChatSessionProjectionOwner = {
   sessionKey: string;
   chatMessages: unknown[];
+  client?: object | null;
+  initialUserMessage?: ApplicationInitialUserMessageHandoff;
   currentSessionId?: string | null;
   chatDisplayedLeafEntryId?: string | null;
 };
@@ -19,6 +25,9 @@ type ChatSessionProjectionOwner = {
 type ChatSessionProjectionScopeOptions = Omit<SessionProjectionScope, "sessionId"> & {
   sessionId?: string | null;
 };
+type InitialUserMessageHandoffEntry = NonNullable<
+  ReturnType<ApplicationInitialUserMessageHandoff["read"]>
+>;
 
 /** Every live, pending, terminal, and history path must identify the same pane and branch. */
 export function readChatSessionProjectionScope(
@@ -97,6 +106,54 @@ export function setChatSessionProjection(owner: object, projection: SessionProje
   chatSessionProjections.set(owner, projection);
 }
 
+function adoptInitialUserMessage(
+  message: unknown,
+  envelope: SessionMessageEnvelope | undefined,
+  handoff: InitialUserMessageHandoffEntry,
+): unknown {
+  const identity = readSessionMessageIdentity(message, envelope);
+  const handoffSequence = handoff.message["__openclaw"]?.seq ?? null;
+  if (
+    identity?.role !== "user" ||
+    identity.isImported ||
+    identity.runId !== handoff.pendingRunId ||
+    (handoffSequence !== null && identity.sequence !== handoffSequence)
+  ) {
+    return message;
+  }
+  const authoritative = asNullableRecord(message) ?? {};
+  const { media: _media, ...authoritativeMetadata } =
+    asNullableRecord(authoritative["__openclaw"]) ?? {};
+  return {
+    ...handoff.message,
+    ...authoritative,
+    content: handoff.message.content,
+    __openclaw: {
+      ...handoff.message["__openclaw"],
+      ...authoritativeMetadata,
+    },
+  };
+}
+
+/** Admit an accepted create-time prompt through the same reducer as ordinary sends. */
+export function admitInitialUserMessageHandoff(
+  owner: ChatSessionProjectionOwner,
+  sessionKey: string,
+): boolean {
+  const handoff = owner.initialUserMessage?.read(sessionKey, owner.client ?? null);
+  if (!handoff) {
+    return false;
+  }
+  const scope = readChatSessionProjectionScope(owner, { sessionKey });
+  const previousMessages = owner.chatMessages;
+  reduceChatSessionProjection(
+    owner,
+    { type: "sendPending", runId: handoff.pendingRunId, message: handoff.message },
+    { scope },
+  );
+  return owner.chatMessages !== previousMessages;
+}
+
 /** Publish the reducer and rendered transcript together; no caller maintains a second copy. */
 export function reduceChatSessionProjection(
   owner: ChatSessionProjectionOwner,
@@ -104,14 +161,46 @@ export function reduceChatSessionProjection(
   options: {
     scope?: SessionProjectionScope;
     messages?: readonly unknown[];
+    runActive?: boolean;
   } = {},
 ): SessionProjectionState {
   const scope = options.scope ?? readChatSessionProjectionScope(owner);
   const current = getChatSessionProjection(owner, options.messages ?? owner.chatMessages, scope);
-  const projection = reduceSessionProjection(current, { ...event, scope });
+  const sessionKey = scope.sessionKey ?? owner.sessionKey;
+  const handoff = owner.initialUserMessage?.read(sessionKey, owner.client ?? null) ?? null;
+  let adopted = false;
+  const adopt = (message: unknown, envelope?: SessionMessageEnvelope) => {
+    const next = handoff ? adoptInitialUserMessage(message, envelope, handoff) : message;
+    adopted ||= next !== message;
+    return next;
+  };
+  const preparedEvent =
+    event.type === "messagePersisted"
+      ? { ...event, message: adopt(event.message, event.envelope ?? event) }
+      : event.type === "snapshotLoaded"
+        ? { ...event, messages: event.messages.map((message) => adopt(message)) }
+        : event;
+  let projection = current;
+  if (event.type === "snapshotLoaded" && handoff && !adopted && options.runActive !== false) {
+    projection = reduceSessionProjection(projection, {
+      type: "sendPending",
+      runId: handoff.pendingRunId,
+      message: handoff.message,
+      scope,
+    });
+  }
+  projection = reduceSessionProjection(projection, { ...preparedEvent, scope });
+  const renderedMessagesMatch =
+    owner.chatMessages.length === projection.messages.length &&
+    owner.chatMessages.every((message, index) => message === projection.messages[index]);
   if (projection !== current) {
     setChatSessionProjection(owner, projection);
+  }
+  if (!renderedMessagesMatch) {
     owner.chatMessages = [...projection.messages];
+  }
+  if (adopted && options.runActive === false) {
+    owner.initialUserMessage?.clear(sessionKey);
   }
   return projection;
 }

--- a/ui/src/pages/chat/initial-turn-handoff.test.ts
+++ b/ui/src/pages/chat/initial-turn-handoff.test.ts
@@ -1,292 +1,73 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
-import {
-  admitInitialUserMessageHandoff,
-  prepareInitialUserMessageHandoff,
-  reconcileInitialUserMessageHandoff,
-} from "./initial-turn-handoff.ts";
+import { prepareInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
+
+const imageDataUrl = "data:image/png;base64,iVBORw0KGgo=";
 
 describe("initial user message handoff", () => {
-  it("adopts a late accepted prompt once through the observable handoff", () => {
-    const sessionKey = "agent:main:late-accepted";
-    const client = {};
-    const handoff = createInitialUserMessageHandoff();
-    const host = { chatMessages: [] as unknown[], client };
-    const listener = vi.fn(() => admitInitialUserMessageHandoff(handoff, host, sessionKey));
-    const unsubscribe = handoff.subscribe(listener);
-
-    prepareInitialUserMessageHandoff(
-      handoff,
-      sessionKey,
-      { text: "accepted after route mount", createdAt: 123 },
-      client,
-      { messageId: "late-message", messageSeq: 1 },
-    );
-    prepareInitialUserMessageHandoff(
-      handoff,
-      sessionKey,
-      { text: "accepted after route mount", createdAt: 123 },
-      client,
-      { messageId: "late-message", messageSeq: 1 },
-    );
-
-    expect(listener).toHaveBeenCalledTimes(2);
-    expect(host.chatMessages).toHaveLength(1);
-    unsubscribe();
-  });
-
-  it("reprojects an accepted first prompt across state replacement until history owns it", () => {
-    const sessionKey = "agent:main:new-session";
-    const client = {};
-    const handoff = createInitialUserMessageHandoff();
-    prepareInitialUserMessageHandoff(
-      handoff,
-      sessionKey,
-      {
-        text: "show this while the run is active",
-        createdAt: 123,
-      },
-      client,
-    );
-
-    const otherSession = { chatMessages: [] as unknown[], client };
-    expect(admitInitialUserMessageHandoff(handoff, otherSession, "agent:main:other")).toBe(false);
-    expect(otherSession.chatMessages).toEqual([]);
-
-    const createdSession = { chatMessages: [] as unknown[], client };
-    expect(admitInitialUserMessageHandoff(handoff, createdSession, sessionKey)).toBe(true);
-    expect(createdSession.chatMessages).toEqual([
-      {
-        role: "user",
-        content: [{ type: "text", text: "show this while the run is active" }],
-        timestamp: 123,
-      },
-    ]);
-    expect(admitInitialUserMessageHandoff(handoff, createdSession, sessionKey)).toBe(false);
-
-    const secondSessionKey = "agent:main:second-new-session";
-    prepareInitialUserMessageHandoff(
-      handoff,
-      secondSessionKey,
-      {
-        text: "keep the other active prompt too",
-        createdAt: 124,
-      },
-      client,
-    );
-    const secondActiveSession = { chatMessages: [] as unknown[], client };
-    expect(admitInitialUserMessageHandoff(handoff, secondActiveSession, secondSessionKey)).toBe(
-      true,
-    );
-
-    const assistantOutput = {
-      role: "assistant",
-      content: [{ type: "text", text: "already working" }],
-    };
-    const remountedSession = { chatMessages: [assistantOutput] as unknown[], client };
-    expect(admitInitialUserMessageHandoff(handoff, remountedSession, sessionKey)).toBe(true);
-    expect(remountedSession.chatMessages).toEqual([
-      ...createdSession.chatMessages,
-      assistantOutput,
-    ]);
-
-    const persisted = {
-      role: "user",
-      content: [{ type: "text", text: "show this while the run is active" }],
-      __openclaw: { seq: 1 },
-    };
-    remountedSession.chatMessages = [persisted];
-    expect(
-      reconcileInitialUserMessageHandoff(handoff, remountedSession, sessionKey, [persisted], true),
-    ).toBe(false);
-    const activeRunReset = { chatMessages: [] as unknown[], client };
-    expect(admitInitialUserMessageHandoff(handoff, activeRunReset, sessionKey)).toBe(true);
-    activeRunReset.chatMessages = [persisted];
-    expect(
-      reconcileInitialUserMessageHandoff(handoff, activeRunReset, sessionKey, [persisted], false),
-    ).toBe(false);
-    expect(admitInitialUserMessageHandoff(handoff, { chatMessages: [], client }, sessionKey)).toBe(
-      false,
-    );
-  });
-
-  it("does not duplicate a first prompt that history already loaded", () => {
+  it("prepares accepted prompts only with explicit run ownership", () => {
     const sessionKey = "agent:main:main";
-    const routeSessionKey = "main";
     const client = {};
     const handoff = createInitialUserMessageHandoff();
-    prepareInitialUserMessageHandoff(
-      handoff,
-      sessionKey,
-      {
-        text: "history won the race",
-        createdAt: 123,
-      },
-      client,
-    );
-    const persisted = {
-      role: "user",
-      content: [{ type: "text", text: "history won the race" }],
-      __openclaw: { seq: 1 },
+    const item = {
+      text: "inspect this image",
+      attachments: [
+        {
+          id: "image-1",
+          mimeType: "image/png",
+          fileName: "image.png",
+          sizeBytes: 68,
+          dataUrl: imageDataUrl,
+        },
+      ],
+      createdAt: 123,
     };
-    const createdSession = { chatMessages: [persisted] as unknown[], client };
 
-    expect(
-      reconcileInitialUserMessageHandoff(
-        handoff,
-        createdSession,
-        routeSessionKey,
-        [persisted],
-        false,
-      ),
-    ).toBe(false);
-    expect(createdSession.chatMessages).toEqual([persisted]);
-    expect(
-      admitInitialUserMessageHandoff(handoff, { chatMessages: [], client }, routeSessionKey),
-    ).toBe(false);
-  });
+    prepareInitialUserMessageHandoff(handoff, sessionKey, item, client);
+    expect(handoff.read(sessionKey, client)).toBeNull();
 
-  it("reconciles an image prompt by accepted message sequence", () => {
-    const sessionKey = "agent:main:image-session";
-    const client = {};
-    const handoff = createInitialUserMessageHandoff();
-    prepareInitialUserMessageHandoff(
-      handoff,
+    prepareInitialUserMessageHandoff(handoff, sessionKey, item, client, {
+      runId: "initial-image-run",
+      messageSeq: 1,
+    });
+
+    expect(handoff.read("main", client)).toEqual({
       sessionKey,
-      {
-        text: "inspect this image",
-        attachments: [
-          {
-            id: "image-1",
-            mimeType: "image/png",
-            fileName: "image.png",
-            sizeBytes: 68,
-            dataUrl: "data:image/png;base64,iVBORw0KGgo=",
-          },
-        ],
-        createdAt: 123,
-      },
-      client,
-      { messageId: "initial-image-send", messageSeq: 1 },
-    );
-    const projectedSession = { chatMessages: [] as unknown[], client };
-    expect(admitInitialUserMessageHandoff(handoff, projectedSession, sessionKey)).toBe(true);
-    expect(projectedSession.chatMessages).toEqual([
-      {
+      owner: client,
+      pendingRunId: "initial-image-run",
+      message: {
         role: "user",
         content: [
           { type: "text", text: "inspect this image" },
           {
             type: "image",
-            url: "data:image/png;base64,iVBORw0KGgo=",
-            source: { type: "url", url: "data:image/png;base64,iVBORw0KGgo=" },
+            url: imageDataUrl,
+            source: { type: "url", url: imageDataUrl },
           },
         ],
         timestamp: 123,
-        __openclaw: { idempotencyKey: "initial-image-send:user", seq: 1 },
+        __openclaw: { idempotencyKey: "initial-image-run:user", seq: 1 },
       },
-    ]);
-    const persisted = {
-      role: "user",
-      content: "inspect this image",
-      idempotencyKey: "initial-image-send:user",
-      __openclaw: {
-        id: "persisted-image-prompt",
-        seq: 1,
-        media: [{ path: "/media/image-1", contentType: "image/png" }],
-      },
-    };
-    const createdSession = { chatMessages: [persisted] as unknown[], client };
-    const projectedMessage = projectedSession.chatMessages[0];
-
-    expect(
-      reconcileInitialUserMessageHandoff(handoff, createdSession, sessionKey, [persisted], true),
-    ).toBe(true);
-    expect(createdSession.chatMessages).toEqual([
-      {
-        role: "user",
-        content: (projectedMessage as { content: unknown }).content,
-        timestamp: 123,
-        idempotencyKey: "initial-image-send:user",
-        __openclaw: {
-          id: "persisted-image-prompt",
-          idempotencyKey: "initial-image-send:user",
-          seq: 1,
-        },
-      },
-    ]);
+    });
   });
 
-  it("reconciles an attachment-only first prompt by visible content without a sequence", () => {
-    const sessionKey = "agent:main:image-session";
+  it("retains independent reconnect handoffs without exposing them to a replacement client", () => {
     const client = {};
+    const replacementClient = {};
     const handoff = createInitialUserMessageHandoff();
-    prepareInitialUserMessageHandoff(
-      handoff,
-      sessionKey,
-      {
-        text: "",
-        attachments: [
-          {
-            id: "image-1",
-            mimeType: "image/png",
-            fileName: "image.png",
-            sizeBytes: 68,
-            dataUrl: "data:image/png;base64,iVBORw0KGgo=",
-          },
-        ],
-        createdAt: 123,
-      },
-      client,
-    );
-
-    const projectedSession = { chatMessages: [] as unknown[], client };
-    expect(admitInitialUserMessageHandoff(handoff, projectedSession, sessionKey)).toBe(true);
-    const projected = projectedSession.chatMessages[0] as { content: unknown };
-    const persisted = { role: "user", content: projected.content };
-    const createdSession = { chatMessages: [persisted] as unknown[], client };
-
-    expect(
-      reconcileInitialUserMessageHandoff(handoff, createdSession, sessionKey, [persisted], false),
-    ).toBe(true);
-    expect(createdSession.chatMessages).toEqual([
-      { role: "user", content: projected.content, timestamp: 123, __openclaw: {} },
-    ]);
-    expect(admitInitialUserMessageHandoff(handoff, { chatMessages: [], client }, sessionKey)).toBe(
-      false,
-    );
-  });
-
-  it("keeps a pending prompt across reconnects from the same browser client", () => {
-    const sessionKey = "agent:main:new-session";
-    const client = {};
-    const handoff = createInitialUserMessageHandoff();
-    prepareInitialUserMessageHandoff(
-      handoff,
-      sessionKey,
-      { text: "private prompt", createdAt: 123 },
-      client,
-    );
-
-    const reconnectedSession = { chatMessages: [] as unknown[], client };
-    expect(admitInitialUserMessageHandoff(handoff, reconnectedSession, sessionKey)).toBe(true);
-    expect(reconnectedSession.chatMessages).toHaveLength(1);
-  });
-
-  it("does not expose a pending prompt to a replacement gateway client", () => {
-    const sessionKey = "agent:main:new-session";
-    const handoff = createInitialUserMessageHandoff();
-    prepareInitialUserMessageHandoff(
-      handoff,
-      sessionKey,
-      { text: "private prompt", createdAt: 123 },
-      {},
-    );
-
-    const replacementGatewaySession = { chatMessages: [] as unknown[], client: {} };
-    expect(admitInitialUserMessageHandoff(handoff, replacementGatewaySession, sessionKey)).toBe(
-      false,
-    );
-    expect(replacementGatewaySession.chatMessages).toEqual([]);
+    for (const [sessionKey, runId] of [
+      ["agent:main:first", "first-run"],
+      ["agent:main:second", "second-run"],
+    ] as const) {
+      prepareInitialUserMessageHandoff(
+        handoff,
+        sessionKey,
+        { text: runId, createdAt: 123 },
+        client,
+        { runId },
+      );
+      expect(handoff.read(sessionKey, client)?.pendingRunId).toBe(runId);
+      expect(handoff.read(sessionKey, replacementClient)).toBeNull();
+    }
   });
 });

--- a/ui/src/pages/chat/initial-turn-handoff.ts
+++ b/ui/src/pages/chat/initial-turn-handoff.ts
@@ -1,13 +1,8 @@
-import {
-  readSessionMessageIdentity,
-  readSessionMessageSequence,
-} from "@openclaw/gateway-client/browser";
 import type {
   ApplicationInitialUserMessage,
   ApplicationInitialUserMessageHandoff,
 } from "../../app/initial-user-message-handoff.ts";
 import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
-import { extractText } from "../../lib/chat/message-extract.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import {
   getChatAttachmentDataUrl,
@@ -54,127 +49,41 @@ export function prepareInitialUserMessageHandoff(
   sessionKey: string,
   item: Pick<ChatQueueItem, "attachments" | "createdAt" | "text">,
   owner: object,
-  identity: { messageId?: string; messageSeq?: number } = {},
+  identity: { runId?: string; messageSeq?: number } = {},
 ): void {
+  const runId = identity.runId?.trim();
+  if (!runId) {
+    return;
+  }
   const durableAttachments = item.attachments?.map((attachment) => {
     const dataUrl = getChatAttachmentDataUrl(attachment);
     return dataUrl ? { ...attachment, dataUrl, previewUrl: dataUrl } : attachment;
   });
-  const messageId = identity.messageId?.trim();
-  const metadata = {
-    ...(messageId ? { idempotencyKey: `${messageId}:user` } : {}),
-    ...(identity.messageSeq !== undefined ? { seq: identity.messageSeq } : {}),
-  };
-  const hasMetadata = Boolean(messageId) || identity.messageSeq !== undefined;
+  const messageSequence =
+    typeof identity.messageSeq === "number" &&
+    Number.isSafeInteger(identity.messageSeq) &&
+    identity.messageSeq > 0
+      ? identity.messageSeq
+      : undefined;
   const message: ApplicationInitialUserMessage = {
     role: "user",
-    // This bounded process-local handoff owns the durable bytes until
-    // authoritative history adopts messageSeq, so the first row can render now.
     content: buildUserChatMessageContentBlocks(item.text, durableAttachments, {
       renderInlineImageDataUrls: true,
     }),
     timestamp: item.createdAt,
-    ...(hasMetadata ? { __openclaw: metadata } : {}),
-  };
-  // Keep the projection until terminal history owns it so active first turns
-  // survive later pane/history resets.
-  handoff.prepare({ message, owner, sessionKey });
-}
-
-function initialUserMessageDisplaySignature(message: unknown): string | null {
-  const identity = readSessionMessageIdentity(message);
-  if (!identity) {
-    return null;
-  }
-  const text = extractText(message)?.trim();
-  if (text) {
-    return `${identity.role}:text:${text}`;
-  }
-  try {
-    const content = (message as { content?: unknown }).content;
-    return `${identity.role}:content:${JSON.stringify(content ?? null)}`;
-  } catch {
-    return null;
-  }
-}
-
-function isSameInitialUserMessage(candidate: unknown, message: ApplicationInitialUserMessage) {
-  const sequence = readSessionMessageSequence(message);
-  if (sequence !== null && readSessionMessageSequence(candidate) === sequence) {
-    return true;
-  }
-  const signature = initialUserMessageDisplaySignature(message);
-  return Boolean(signature && initialUserMessageDisplaySignature(candidate) === signature);
-}
-
-function hasInlineDataImage(message: ApplicationInitialUserMessage): boolean {
-  return message.content.some((block) => {
-    if (!block || typeof block !== "object" || Array.isArray(block)) {
-      return false;
-    }
-    const image = block as Record<string, unknown>;
-    if (image.type !== "image") {
-      return false;
-    }
-    if (typeof image.url === "string" && image.url.startsWith("data:image/")) {
-      return true;
-    }
-    const source = image.source;
-    return (
-      source !== null &&
-      typeof source === "object" &&
-      !Array.isArray(source) &&
-      typeof (source as Record<string, unknown>).url === "string" &&
-      ((source as Record<string, unknown>).url as string).startsWith("data:image/")
-    );
-  });
-}
-
-function preserveInlineInitialImageProjection(
-  host: { chatMessages: unknown[] },
-  message: ApplicationInitialUserMessage,
-): boolean {
-  if (!hasInlineDataImage(message)) {
-    return false;
-  }
-  const matchingIndex = host.chatMessages.findIndex((candidate) =>
-    isSameInitialUserMessage(candidate, message),
-  );
-  if (matchingIndex < 0 || host.chatMessages[matchingIndex] === message) {
-    return false;
-  }
-  const authoritative = host.chatMessages[matchingIndex];
-  const authoritativeRecord =
-    authoritative && typeof authoritative === "object" && !Array.isArray(authoritative)
-      ? (authoritative as Record<string, unknown>)
-      : {};
-  const {
-    content: _content,
-    __openclaw: authoritativeMetadata,
-    ...authoritativeFields
-  } = authoritativeRecord;
-  const normalizedAuthoritativeMetadata =
-    authoritativeMetadata &&
-    typeof authoritativeMetadata === "object" &&
-    !Array.isArray(authoritativeMetadata)
-      ? (authoritativeMetadata as Record<string, unknown>)
-      : {};
-  const { media: _media, ...authoritativeMetadataFields } = normalizedAuthoritativeMetadata;
-  const nextMessages = [...host.chatMessages];
-  // History projects canonical local attachment facts. Keep the already
-  // decoded inline projection for this page lifecycle so adopting history does
-  // not add a second image source or visibly flash the accepted first prompt.
-  nextMessages[matchingIndex] = {
-    ...message,
-    ...authoritativeFields,
-    content: message.content,
     __openclaw: {
-      ...authoritativeMetadataFields,
-      ...message["__openclaw"],
+      idempotencyKey: `${runId}:user`,
+      ...(messageSequence === undefined ? {} : { seq: messageSequence }),
     },
   };
-  host.chatMessages = nextMessages;
-  return true;
+  // This bounded process-local handoff owns the original inline bytes until
+  // the pane projection adopts the matching authoritative row.
+  handoff.prepare({
+    message,
+    owner,
+    sessionKey,
+    pendingRunId: runId,
+  });
 }
 
 function consumeInitialTurnHandoff(sessionKey: string): ChatQueueItem | null {
@@ -199,48 +108,4 @@ export function admitInitialTurnHandoff(
     keepVolatileQueuedMessage(host, sessionKey, item, item.agentId, { retryable: true });
   }
   return true;
-}
-
-export function admitInitialUserMessageHandoff(
-  handoff: ApplicationInitialUserMessageHandoff,
-  host: { chatMessages: unknown[]; client?: object | null },
-  sessionKey: string,
-): boolean {
-  const message = handoff.read(sessionKey, host.client ?? null);
-  if (!message) {
-    return false;
-  }
-  const matchingMessage = host.chatMessages.find((candidate) =>
-    isSameInitialUserMessage(candidate, message),
-  );
-  if (matchingMessage) {
-    return false;
-  }
-  host.chatMessages = [message, ...host.chatMessages];
-  return true;
-}
-
-/** Keeps the accepted prompt projected until authoritative history owns it. */
-export function reconcileInitialUserMessageHandoff(
-  handoff: ApplicationInitialUserMessageHandoff,
-  host: { chatMessages: unknown[]; client?: object | null },
-  sessionKey: string,
-  authoritativeMessages: unknown[],
-  runActive: boolean,
-): boolean {
-  const message = handoff.read(sessionKey, host.client ?? null);
-  if (!message) {
-    return false;
-  }
-  const historyOwnsMessage = authoritativeMessages.some((candidate) =>
-    isSameInitialUserMessage(candidate, message),
-  );
-  if (historyOwnsMessage) {
-    const projectionPreserved = preserveInlineInitialImageProjection(host, message);
-    if (!runActive) {
-      handoff.clear(sessionKey);
-    }
-    return projectionPreserved;
-  }
-  return admitInitialUserMessageHandoff(handoff, host, sessionKey);
 }

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -1450,7 +1450,7 @@ class NewSessionPage extends OpenClawLightDomElement {
           },
           submissionClient,
           {
-            messageId: result.initialRun.messageId,
+            runId: result.initialRun.runId,
             messageSeq: result.initialRun.messageSeq,
           },
         );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a newly created Control UI session could show the submitted initial prompt twice when authoritative message persistence arrived before the delayed startup transcript.

The duplicate was client-side: one create-time handoff and one persisted user row were projected as separate messages even though they represented the same send.

## Why This Change Was Made

Create-time prompts now enter the same explicit pending-send projection used by ordinary chat sends. The pane projection owns admission, reconnect rebound, live persistence, history adoption, terminal cleanup, and inline attachment enrichment as one flow.

This removes the previous display-signature matching, manual transcript prepending, post-reducer mutation, and separate image reconciliation paths. Sequence-aware run identity prevents same-text or wrong-sequence messages from being conflated. The shared run-event normalization was split into a focused companion module to keep the projection owner under the repository line limit without changing its public barrel API.

Production LOC: **+246/-273 (net -27)**  
Tests: **+436/-405 (net +31)**

## User Impact

A session's first prompt remains visible immediately, but it now stays one stable bubble as live events and startup history arrive. Image-bearing prompts keep the same inline image node and source, and active prompts survive Gateway reconnect and session-scope rebound without duplication or flicker.

## Evidence

### Before

A safe mocked-Gateway reproduction with distinct local and authoritative projections shows the prior two-bubble symptom:

![Before: duplicated initial prompt](https://github.com/user-attachments/assets/4327af76-53ad-43d0-ad07-9209b313f5c2)

### After

The matching authoritative row adopts the pending prompt in place:

![After: one adopted initial prompt](https://github.com/user-attachments/assets/1a55c73b-5ae8-458f-8694-d7737c139593)

### Focused proof

- Focused rebased implementation proof: **164 projection, handoff, history, cloud-startup, and lifecycle tests passed**.
- Exact current-main rebase proof: **133 focused Gateway-client and UI tests passed across three shards**.
- Mocked Control UI browser coverage: **11 tests passed**, including:
  - live persistence before delayed startup history;
  - one matching `.chat-bubble` throughout adoption;
  - stable image DOM node and inline source;
  - Gateway reconnect plus session-scope rebound.
- `tsgo` core, core-test, and UI lanes passed.
- Targeted `oxlint`, `oxfmt`, and `git diff --check` passed.
- Fresh post-repair Codex autoreview: no accepted/actionable findings.

### Started-create identity contract

Maintainer decision: keep create-time admission explicitly run-owned rather than synthesize an identity or restore display-text matching for a malformed started response.

Every shipped and current Gateway implementation of `sessions.create` has returned a non-empty `runId` and positive `messageSeq` whenever `runStarted` is true. The handler delegates to the canonical `chat.send` started acknowledgement, then attaches the sequence calculated before dispatch. This invariant shipped with the original implementation in `v2026.3.22`; the result fields were declared later as optional for additive client/schema compatibility and because the same result type also represents non-started outcomes.

A started response without `runId` is therefore treated as a protocol anomaly: the UI navigates to the created session and waits for authoritative live/history identity instead of creating an untrackable optimistic bubble that can duplicate or delete the wrong row.
