### PR TITLE
fix: test provider keys when Codex runtime is selected

### DIFF
--- a/src/commands/models/list.probe.test.ts
+++ b/src/commands/models/list.probe.test.ts
@@ -170,14 +170,22 @@ describe("runAuthProbes", () => {
     });
   });
 
-  it("runs Codex auth probes through raw OpenClaw model-run mode", async () => {
+  it("runs Codex-pinned auth probes through raw OpenClaw model-run mode", async () => {
     const runEmbeddedAgent = vi.fn(
-      async (_params: {
+      async (params: {
         agentDir?: string;
+        agentHarnessRuntimeOverride?: string;
         authProfileId?: string;
         authProfileIdSource?: string;
         config?: OpenClawConfig;
-      }) => ({ text: "OK" }),
+      }) => {
+        if (params.agentHarnessRuntimeOverride !== "openclaw") {
+          throw new Error(
+            'Requested agent harness "codex" does not support openai/gpt-5.5 (Codex cannot reproduce authored request transport overrides).',
+          );
+        }
+        return { text: "OK" };
+      },
     );
     vi.doMock("../../agents/embedded-agent.js", () => ({ runEmbeddedAgent }));
     vi.doMock("../../agents/auth-profiles.js", () => ({
@@ -217,7 +225,17 @@ describe("runAuthProbes", () => {
         `./list.probe.js?scope=${Math.random().toString(36).slice(2)}`,
       );
       const result = await module.runAuthProbes({
-        cfg: {} as never,
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                agentRuntime: { id: "codex" },
+                models: [],
+              },
+            },
+          },
+        } satisfies OpenClawConfig,
         agentId: "probe-agent",
         agentDir: "/tmp/openclaw-probe-agent",
         workspaceDir: "/tmp/openclaw-probe-workspace",
@@ -235,6 +253,7 @@ describe("runAuthProbes", () => {
       expect(result.results[0]?.status).toBe("ok");
       expect(runEmbeddedAgent).toHaveBeenCalledWith(
         expect.objectContaining({
+          agentHarnessRuntimeOverride: "openclaw",
           modelRun: true,
           disableTools: true,
           authProfileId: "openai:profile",

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -838,6 +838,7 @@ async function probeTarget(params: {
       reasoningLevel: "off",
       verboseLevel: "off",
       streamParams: { maxTokens },
+      agentHarnessRuntimeOverride: "openclaw",
       disableTools: true,
       modelRun: true,
       cleanupBundleMcpOnRunEnd: true,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Test connection failed immediately for provider keys when the selected model used the Codex runtime, even though the saved key worked for normal requests.

## Why This Change Was Made

Auth probes now always use the raw OpenClaw model-run path. This keeps the probe's bounded output request while avoiding Codex runtime rejection of provider transport overrides.

## User Impact

Test connection now reaches the configured provider instead of returning a false failure before network I/O.

## Evidence

- Live repro: probe failed in 4 ms with no provider request; the same saved key later received HTTP 200 from OpenAI.
- Regression before fix: expected `ok`, received `unknown` from the simulated Codex preflight rejection.
- Regression after fix: focused test passes; full `src/commands/models/list.probe.test.ts` passes 8/8 on Blacksmith Testbox.
