### PR TITLE
fix(terminal): always emit full intro art

### DIFF
--- a/src/gateway/terminal/intro-banner.test.ts
+++ b/src/gateway/terminal/intro-banner.test.ts
@@ -22,7 +22,7 @@ const EXPECTED_ART = [
 
 describe("composeTerminalIntroBanner", () => {
   it("composes the exact colored CRLF intro and resets ANSI state", () => {
-    const banner = composeTerminalIntroBanner(80);
+    const banner = composeTerminalIntroBanner();
 
     expect(banner).toBe(
       `\r\n\x1b[38;5;223mWelcome to the Claw.\x1b[0m\r\n\r\n\x1b[38;5;216m${EXPECTED_ART.join("\r\n")}\r\n\r\n\x1b[0m`,
@@ -30,11 +30,5 @@ describe("composeTerminalIntroBanner", () => {
     expect(banner.startsWith("\r\n\x1b[38;5;223mWelcome to the Claw.\x1b[0m")).toBe(true);
     expect(banner.endsWith("\r\n\r\n\x1b[0m")).toBe(true);
     expect(banner.replaceAll("\r\n", "")).not.toContain("\n");
-  });
-
-  it("emits only the headline below 40 columns", () => {
-    expect(composeTerminalIntroBanner(39)).toBe(
-      "\r\n\x1b[38;5;223mWelcome to the Claw.\x1b[0m\r\n\r\n\x1b[0m",
-    );
   });
 });

--- a/src/gateway/terminal/intro-banner.ts
+++ b/src/gateway/terminal/intro-banner.ts
@@ -19,8 +19,11 @@ const TERMINAL_INTRO_ART = [
   "              .::•::•::",
 ] as const;
 
-export function composeTerminalIntroBanner(cols: number): string {
+// Always full art: open-time request.cols is the pre-fit boot grid (the client
+// resizes immediately after open), so width gating keyed on it suppressed the
+// art on real, wide terminals.
+export function composeTerminalIntroBanner(): string {
   const headline = `\x1b[38;5;223mWelcome to the Claw.${RESET}`;
-  const art = cols >= 40 ? `\x1b[38;5;216m${TERMINAL_INTRO_ART.join("\r\n")}\r\n\r\n` : "";
+  const art = `\x1b[38;5;216m${TERMINAL_INTRO_ART.join("\r\n")}\r\n\r\n`;
   return `\r\n${headline}\r\n\r\n${art}${RESET}`;
 }

--- a/src/gateway/terminal/session-manager.intro-banner.test.ts
+++ b/src/gateway/terminal/session-manager.intro-banner.test.ts
@@ -13,7 +13,7 @@ describe("TerminalSessionManager intro banner", () => {
       if (!operator.ok) {
         throw new Error("expected operator open");
       }
-      const intro = composeTerminalIntroBanner(80);
+      const intro = composeTerminalIntroBanner();
       expect(manager.snapshot(operator.sessionId)).toBe(intro);
 
       await vi.advanceTimersByTimeAsync(4);

--- a/src/gateway/terminal/session-manager.test.ts
+++ b/src/gateway/terminal/session-manager.test.ts
@@ -10,7 +10,7 @@ import {
 } from "./session-manager.test-helpers.js";
 const TERMINAL_EVENT_DATA = "terminal.data";
 const TERMINAL_EVENT_EXIT = "terminal.exit";
-const OPERATOR_INTRO = composeTerminalIntroBanner(80);
+const OPERATOR_INTRO = composeTerminalIntroBanner();
 
 function deferred<T>() {
   let resolve!: (value: T) => void;

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -269,7 +269,7 @@ export class TerminalSessionManager {
     this.sessions.set(session.id, session);
     if (request.owner.kind === "conn") {
       this.indexByConn(request.owner.connId, session.id);
-      session.output.push(composeTerminalIntroBanner(request.cols));
+      session.output.push(composeTerminalIntroBanner());
     }
 
     backend.onData((chunk) => {


### PR DESCRIPTION
## What Problem This Solves

The terminal intro banner (PR #121451) gated its art on the open-time cols, but the Control UI sends the pre-fit boot grid at `terminal.open` and resizes immediately after, so real terminals got only the headline.

## Why This Change Was Made

The `cols` value at open is not the terminal's real width. Remove the unreliable gate; the art is 31 columns and fits any real terminal.

## User Impact

Fresh web terminal sessions now always show the full dot-matrix intro.

## Evidence

- Focused tests green: `node scripts/run-vitest.mjs src/gateway/terminal/intro-banner.test.ts src/gateway/terminal/session-manager.intro-banner.test.ts` → 2 files, 2 tests passed.
- Autoreview clean: Codex `gpt-5.6-sol` high, “patch is correct (0.99)”.
- Live-verified on a dev gateway built from post-merge `main`: a raw WebSocket probe captured the exact banner bytes followed by clean Bash startup, and a fresh `/terminal` browser tab rendered the full art correctly.
- Net production delta: -3 lines.
