### PR TITLE
fix(update): keep countdown stable during active work

### DIFF
--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -282,8 +282,10 @@ install time until their next verified successful update.
 ### Update campaigns
 
 When an automatic update is due, the campaign waits for active work to finish,
-then starts a one-minute countdown. A 15-minute hard deadline starts the update
-even if work remains, using the normal restart drain and session-recovery path.
+then starts a one-minute countdown. Once that countdown starts, new work does
+not reset it or return the campaign to waiting. A 15-minute hard deadline starts
+the update even if work remains, using the normal restart drain and
+session-recovery path.
 
 An admin can use **Hold 1 h** once to postpone the campaign and shift its hard
 deadline, or choose **Update now** from the sidebar update card or

--- a/src/infra/update-campaign.test.ts
+++ b/src/infra/update-campaign.test.ts
@@ -63,7 +63,7 @@ describe("UpdateCampaignController", () => {
     expect(apply).toHaveBeenCalledWith({ forced: false });
   });
 
-  it("resets the countdown when work appears, then forces at the hard deadline", async () => {
+  it("keeps an announced countdown stable when active work begins", async () => {
     const controller = createController();
     let busy = 0;
     const apply = vi.fn(async () => "applied" as const);
@@ -74,14 +74,14 @@ describe("UpdateCampaignController", () => {
       apply,
       onChange: vi.fn(),
     });
+    const applyAtMs = controller.getState()?.applyAtMs;
     busy = 1;
     await vi.advanceTimersByTimeAsync(5_000);
-    expect(controller.getState()).toMatchObject({ state: "waiting-for-idle" });
-    expect(controller.getState()?.applyAtMs).toBeUndefined();
+    expect(controller.getState()).toMatchObject({ state: "countdown", applyAtMs });
 
-    await vi.advanceTimersByTimeAsync(895_000);
+    await vi.advanceTimersByTimeAsync(55_000);
     expect(controller.getState()?.state).toBe("applying");
-    expect(apply).toHaveBeenCalledWith({ forced: true });
+    expect(apply).toHaveBeenCalledWith({ forced: false });
   });
 
   it("starts a fresh campaign for a newer target and clears availability", () => {

--- a/src/infra/update-campaign.ts
+++ b/src/infra/update-campaign.ts
@@ -163,26 +163,17 @@ export class UpdateCampaignController {
       return;
     }
 
-    let idle = false;
-    try {
-      idle = createGatewayActiveWorkSnapshot(announcement.inspect).idle;
-    } catch {
-      // Inspection failure must not erase the hard deadline or force an unsafe early apply.
-    }
-    if (!idle) {
-      this.transition({
-        id: campaign.id,
-        state: "waiting-for-idle",
-        announcedAtMs: campaign.announcedAtMs,
-        ...(campaign.holdUntilMs === undefined ? {} : { holdUntilMs: campaign.holdUntilMs }),
-        forceAtMs: campaign.forceAtMs,
-        updatedAtMs: now,
-      });
-      this.scheduleNext();
-      return;
-    }
-
     if (campaign.state === "waiting-for-idle") {
+      let idle = false;
+      try {
+        idle = createGatewayActiveWorkSnapshot(announcement.inspect).idle;
+      } catch {
+        // Inspection failure must not erase the hard deadline or force an unsafe early apply.
+      }
+      if (!idle) {
+        this.scheduleNext();
+        return;
+      }
       this.transition({
         id: campaign.id,
         state: "countdown",

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -1417,7 +1417,7 @@ describe("update-startup", () => {
     expect(getUpdateSchedule()?.install?.git?.status).not.toBe("current");
   });
 
-  it("resets a busy dev campaign and forces it at the deadline", async () => {
+  it("keeps a dev campaign countdown stable when active work begins", async () => {
     mockDevGitStatus();
     let busy = 1;
     const log = { info: vi.fn() };
@@ -1457,12 +1457,15 @@ describe("update-startup", () => {
         applyAtMs: expect.any(Number),
       }),
     );
+    const applyAtMs = getUpdateSchedule()?.campaign?.applyAtMs;
     busy = 1;
     await vi.advanceTimersByTimeAsync(5_000);
-    expect(getUpdateSchedule()?.campaign).toMatchObject({ state: "waiting-for-idle" });
-    expect(getUpdateSchedule()?.campaign?.applyAtMs).toBeUndefined();
+    expect(getUpdateSchedule()?.campaign).toMatchObject({
+      state: "countdown",
+      applyAtMs,
+    });
 
-    await vi.advanceTimersByTimeAsync(14 * 60_000 + 50_000);
+    await vi.advanceTimersByTimeAsync(55_000);
     expect(getUpdateSchedule()?.campaign?.state).toBe("applying");
     expect(runAutoUpdate).toHaveBeenCalledOnce();
     expect(log.info).toHaveBeenCalledWith(
@@ -1470,7 +1473,7 @@ describe("update-startup", () => {
       expect.objectContaining({
         channel: "dev",
         version: "upstream-sha",
-        forced: true,
+        forced: false,
       }),
     );
   });


### PR DESCRIPTION
Related: #120506

## What Problem This Solves

Fixes an issue where operators watching an automatic Gateway update would see the status repeatedly switch between **Updating in …** and **Waiting for active work …** whenever agent or chat work started and stopped during the countdown. The countdown deadline was also discarded and recreated on every switch.

## Why This Change Was Made

The update campaign now uses active-work inspection only to enter the countdown. Once the campaign reaches countdown, its phase and apply deadline stay fixed; **Hold 1 h** remains the intentional way to return it to waiting. Application still uses the existing Gateway restart drain and session-recovery path.

This removes the duplicate countdown-reset policy at the campaign owner rather than smoothing or debouncing the Control UI.

## User Impact

Automatic update status is stable and predictable while the server is busy. Agent turns no longer make the same update campaign jump backward and restart its one-minute countdown.

AI-assisted implementation; the resulting lifecycle change and tests were manually inspected.

## Evidence

- Live observation on `team.openclaw.ai`: the same campaign alternated between countdown and waiting as team work changed, then the Gateway restarted when the update applied.
- Pre-fix regression: `keeps an announced countdown stable when active work begins` failed because the campaign returned to `waiting-for-idle`; it passes with the owner-boundary repair.
- `node scripts/run-vitest.mjs src/infra/update-campaign.test.ts src/infra/update-startup.test.ts` — 83/83 passed.
- Targeted mocked Control UI E2E for Settings → Updates — 2/2 passed, including the advancing visible countdown and Gateway request flow.
- `oxfmt --check` on all changed files — passed.
- `git diff --check` — passed.
- Autoreview — clean, no accepted/actionable findings.
- Production LOC: +10/-19 (net -9). Tests: +13/-10. Docs: +4/-2.

![Stable update countdown](https://github.com/user-attachments/assets/eacbcfa9-7696-4549-a913-ba4831f3546f)

The broad local changed gate and targeted oxlint were blocked before execution by another worktree's legitimate shared PR-gates lock. Blacksmith Testbox was unavailable because its CLI is not installed on this host, so exact-head PR CI is the required broad proof before merge.
