### PR TITLE
fix: make file reads safe and explicit

### DIFF
--- a/extensions/onepassword/package.json
+++ b/extensions/onepassword/package.json
@@ -5,7 +5,7 @@
   "description": "1Password SecretRef resolver and audited agent secrets broker for OpenClaw",
   "type": "module",
   "dependencies": {
-    "@openclaw/fs-safe": "0.5.2",
+    "@openclaw/fs-safe": "0.5.4",
     "execa": "10.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2020,7 +2020,7 @@
     "@modelcontextprotocol/sdk": "1.30.0",
     "@mozilla/readability": "0.6.0",
     "@openclaw/ai": "workspace:*",
-    "@openclaw/fs-safe": "0.5.2",
+    "@openclaw/fs-safe": "0.5.4",
     "@openclaw/proxyline": "0.3.4",
     "@silvia-odwyer/photon-node": "0.3.4",
     "@trycua/cua-driver": "0.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ importers:
         specifier: workspace:*
         version: link:packages/ai
       '@openclaw/fs-safe':
-        specifier: 0.5.2
-        version: 0.5.2
+        specifier: 0.5.4
+        version: 0.5.4
       '@openclaw/proxyline':
         specifier: 0.3.4
         version: 0.3.4(undici@8.9.0)
@@ -1496,8 +1496,8 @@ importers:
   extensions/onepassword:
     dependencies:
       '@openclaw/fs-safe':
-        specifier: 0.5.2
-        version: 0.5.2
+        specifier: 0.5.4
+        version: 0.5.4
       execa:
         specifier: 10.0.0
         version: 10.0.0
@@ -4144,8 +4144,8 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
-  '@openclaw/fs-safe@0.5.2':
-    resolution: {integrity: sha512-klidJFTE5FFAweNFpy/aVgschya3JYMWtXfdoSH3bTFN7+WAqlJtD+UQjOIFdkD42kJcWM7josNUpIIm7dnwXg==}
+  '@openclaw/fs-safe@0.5.4':
+    resolution: {integrity: sha512-lttlWKRBQU7eYDYykU2BPoF1S6AESGrT77mVCXsuWBxnRBTAI/PuGB89DB3D1lBCDaqTykIjymPJz4pFesGnkg==}
     engines: {node: '>=22'}
 
   '@openclaw/libterminal@0.3.2':
@@ -11435,7 +11435,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@openclaw/fs-safe@0.5.2':
+  '@openclaw/fs-safe@0.5.4':
     optionalDependencies:
       jszip: 3.10.1
       tar: 7.5.22

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ minimumReleaseAge: 2880
 
 minimumReleaseAgeExclude:
   - "@openclaw/crabline@0.1.11"
-  - "@openclaw/fs-safe@0.5.2"
+  - "@openclaw/fs-safe@0.5.4"
   - "@openclaw/libterminal@0.3.2"
   - "@openclaw/proxyline@0.3.4"
   - "@openclaw/uirouter@0.1.0"

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -62,6 +62,7 @@ const tinyPngBuffer = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2f7z8AAAAASUVORK5CYII=",
   "base64",
 );
+const avifHeaderBuffer = Buffer.from("00000018667479706176696600000000617669666d696631", "hex");
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const XAI_UNSUPPORTED_SCHEMA_KEYWORDS = new Set(["minContains", "maxContains"]);
 function collectActionValues(schema: unknown, values: Set<string>): void {
@@ -2684,6 +2685,39 @@ describe("createOpenClawCodingTools read behavior", () => {
     expect(readFile).not.toHaveBeenCalled();
   });
 
+  it("resolves Unicode-equivalent filenames through sandbox operations", async () => {
+    const tmpDir = tempDirs.make("openclaw-sbx-unicode-");
+    const storedName = "re\u0301sume\u0301 3.04\u202fPM d\u2019accord.txt";
+    await fs.writeFile(path.join(tmpDir, storedName), "sandbox match");
+    const readTool = createSandboxedReadTool({
+      root: tmpDir,
+      bridge: createHostSandboxFsBridge(tmpDir),
+    });
+
+    const result = await readTool.execute("sandbox-unicode", {
+      path: "r\u00e9sum\u00e9 3.04 PM d'accord.txt",
+    });
+
+    expect(extractToolText(result)).toContain("Resolved filename");
+    expect(extractToolText(result)).toContain("sandbox match");
+  });
+
+  it("classifies sandbox AVIF reads from the already-read buffer", async () => {
+    const tmpDir = tempDirs.make("openclaw-sbx-avif-");
+    await fs.writeFile(path.join(tmpDir, "photo.bin"), avifHeaderBuffer);
+    const hostBridge = createHostSandboxFsBridge(tmpDir);
+    const readFile = vi.fn(hostBridge.readFile.bind(hostBridge));
+    const readTool = createSandboxedReadTool({
+      root: tmpDir,
+      bridge: { ...hostBridge, readFile },
+    });
+
+    const result = await readTool.execute("sandbox-avif", { path: "photo.bin" });
+
+    expect(extractToolText(result)).toContain("Read image file [image/avif]");
+    expect(readFile).toHaveBeenCalledTimes(1);
+  });
+
   it("auto-pages read output across chunks when context window budget allows", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-autopage-"));
     const filePath = path.join(tmpDir, "big.txt");
@@ -2752,7 +2786,7 @@ describe("createOpenClawCodingTools read behavior", () => {
     }
   });
 
-  it("returns empty content for explicit offsets beyond EOF", async () => {
+  it("describes explicit offsets beyond EOF", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-offset-eof-"));
     await fs.writeFile(path.join(tmpDir, "notes.txt"), "one\ntwo\nthree", "utf8");
     try {
@@ -2766,13 +2800,15 @@ describe("createOpenClawCodingTools read behavior", () => {
         limit: 10,
       });
 
-      expect(extractToolText(result)).toBe("");
+      expect(extractToolText(result)).toBe(
+        "Offset 99 is beyond end of file (3 lines total). Retry with offset <= 3.",
+      );
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
   });
 
-  it("returns empty content for adaptive offsets beyond EOF", async () => {
+  it("ignores a trailing newline when describing offsets beyond EOF", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-offset-adaptive-"));
     await fs.writeFile(path.join(tmpDir, "notes.txt"), "one\ntwo\nthree\n", "utf8");
     try {
@@ -2785,13 +2821,15 @@ describe("createOpenClawCodingTools read behavior", () => {
         offset: 99,
       });
 
-      expect(extractToolText(result)).toBe("");
+      expect(extractToolText(result)).toBe(
+        "Offset 99 is beyond end of file (3 lines total). Retry with offset <= 3.",
+      );
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
   });
 
-  it("returns already-read adaptive content when pagination reaches EOF", async () => {
+  it("stops adaptive pagination when the current page reaches EOF", async () => {
     const readResult: AgentToolResult<unknown> = {
       content: [
         {
@@ -2803,14 +2841,12 @@ describe("createOpenClawCodingTools read behavior", () => {
         truncation: {
           truncated: true,
           outputLines: 1,
+          totalLines: 1,
           firstLineExceedsLimit: false,
         },
       },
     };
-    const execute = vi
-      .fn()
-      .mockResolvedValueOnce(readResult)
-      .mockRejectedValueOnce(new Error("Offset 2 is beyond end of file (1 lines total)"));
+    const execute = vi.fn().mockResolvedValue(readResult);
     const readTool = createOpenClawReadTool({
       name: "read",
       label: "read",
@@ -2828,7 +2864,7 @@ describe("createOpenClawCodingTools read behavior", () => {
     });
 
     expect(extractToolText(result)).toBe("one");
-    expect(execute).toHaveBeenCalledTimes(2);
+    expect(execute).toHaveBeenCalledTimes(1);
   });
 
   it("keeps unrelated read failures loud", async () => {

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -5,6 +5,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { URL } from "node:url";
+import { detectMime } from "@openclaw/media-core/mime";
 import { formatByteSize } from "@openclaw/normalization-core";
 import { isWindowsDrivePath } from "../infra/archive-path.js";
 import { isMissingPathError, toErrorObject } from "../infra/errors.js";
@@ -1043,6 +1044,10 @@ function createSandboxReadOperations(params: SandboxToolParams) {
     readFile: (absolutePath: string) =>
       params.bridge.readFile({ filePath: absolutePath, cwd: params.root }),
     access: (absolutePath: string) => assertSandboxFileExists(params, absolutePath),
+    detectImageMimeType: async (absolutePath: string, buffer: Buffer) => {
+      const mime = await detectMime({ buffer, filePath: absolutePath });
+      return mime?.startsWith("image/") ? mime : undefined;
+    },
   } as const;
 }
 

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -5,7 +5,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { URL } from "node:url";
-import { detectMime } from "@openclaw/media-core/mime";
 import { formatByteSize } from "@openclaw/normalization-core";
 import { isWindowsDrivePath } from "../infra/archive-path.js";
 import { isMissingPathError, toErrorObject } from "../infra/errors.js";
@@ -76,10 +75,10 @@ type SkillReadContent = {
 type ReadTruncationDetails = {
   truncated: boolean;
   outputLines: number;
+  totalLines: number;
   firstLineExceedsLimit: boolean;
 };
 
-const OFFSET_BEYOND_EOF_RE = /^Offset \d+ is beyond end of file \(\d+ lines total\)$/;
 const READ_CONTINUATION_NOTICE_RE =
   /\n\n\[(?:Showing lines [^\]]*?Use offset=\d+ to continue\.|\d+ more lines in file\. Use offset=\d+ to continue\.)\]\s*$/;
 const DAILY_MEMORY_PATH_RE = /^memory\/\d{4}-\d{2}-\d{2}\.md$/;
@@ -184,9 +183,15 @@ function extractReadTruncationDetails(
     typeof outputLinesRaw === "number" && Number.isFinite(outputLinesRaw)
       ? Math.max(0, Math.floor(outputLinesRaw))
       : 0;
+  const totalLinesRaw = record.totalLines;
+  const totalLines =
+    typeof totalLinesRaw === "number" && Number.isFinite(totalLinesRaw)
+      ? Math.max(0, Math.floor(totalLinesRaw))
+      : 0;
   return {
     truncated: true,
     outputLines,
+    totalLines,
     firstLineExceedsLimit: record.firstLineExceedsLimit === true,
   };
 }
@@ -222,22 +227,6 @@ function stripReadTruncationContentDetails(
       truncation: restTruncation,
     },
   };
-}
-
-function isOffsetBeyondEof(error: unknown, args: Record<string, unknown>): boolean {
-  const offset = args.offset;
-  return (
-    typeof offset === "number" &&
-    Number.isFinite(offset) &&
-    offset > 0 &&
-    error instanceof Error &&
-    OFFSET_BEYOND_EOF_RE.test(error.message)
-  );
-}
-
-function emptyReadResult(): AgentToolResult<unknown> {
-  const textBlock = { type: "text", text: "" } satisfies TextContentBlock;
-  return { content: [textBlock], details: undefined };
 }
 
 function missingDailyMemoryReadResult(relativePath: string): AgentToolResult<unknown> {
@@ -287,9 +276,6 @@ async function executeReadPage(params: {
   try {
     return await params.base.execute(params.toolCallId, params.args, params.signal);
   } catch (error) {
-    if (isOffsetBeyondEof(error, params.args)) {
-      return emptyReadResult();
-    }
     const missingDailyMemoryPath = normalizeDailyMemoryReadPath(params.args.path);
     if (missingDailyMemoryPath && isNotFoundError(error)) {
       return missingDailyMemoryReadResult(missingDailyMemoryPath);
@@ -339,12 +325,16 @@ async function executeReadWithAdaptivePaging(params: {
     }
 
     const truncation = extractReadTruncationDetails(pageResult);
+    const pageEndLine = nextOffset - 1 + (truncation?.outputLines ?? 0);
+    const reachedEof =
+      Boolean(truncation?.truncated) && pageEndLine >= (truncation?.totalLines ?? 0);
     const canContinue =
       Boolean(truncation?.truncated) &&
       !truncation?.firstLineExceedsLimit &&
       (truncation?.outputLines ?? 0) > 0 &&
+      pageEndLine < (truncation?.totalLines ?? 0) &&
       page < MAX_ADAPTIVE_READ_PAGES - 1;
-    const pageText = canContinue ? stripReadContinuationNotice(rawText) : rawText;
+    const pageText = canContinue || reachedEof ? stripReadContinuationNotice(rawText) : rawText;
     const delimiter = aggregatedText && pageText ? "\n\n" : "";
     const nextBytes = Buffer.byteLength(`${delimiter}${pageText}`, "utf-8");
 
@@ -1053,11 +1043,6 @@ function createSandboxReadOperations(params: SandboxToolParams) {
     readFile: (absolutePath: string) =>
       params.bridge.readFile({ filePath: absolutePath, cwd: params.root }),
     access: (absolutePath: string) => assertSandboxFileExists(params, absolutePath),
-    detectImageMimeType: async (absolutePath: string) => {
-      const buffer = await params.bridge.readFile({ filePath: absolutePath, cwd: params.root });
-      const mime = await detectMime({ buffer, filePath: absolutePath });
-      return mime && mime.startsWith("image/") ? mime : undefined;
-    },
   } as const;
 }
 

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -20,21 +20,16 @@ import { isNotFoundPathError, isPathInside } from "../infra/path-guards.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { resolveConfigDir, shortenHomePath } from "../utils.js";
 
-const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
 const DATA_URL_RE = /^data:/i;
 const SANDBOX_CONTAINER_WORKDIR = "/workspace";
 const MANAGED_MEDIA_SUBDIRS = new Set(["outbound"]);
-
-function normalizeUnicodeSpaces(str: string): string {
-  return str.replace(UNICODE_SPACES, " ");
-}
 
 function normalizeAtPrefix(filePath: string): string {
   return filePath.startsWith("@") ? filePath.slice(1) : filePath;
 }
 
 function expandPath(filePath: string): string {
-  const normalized = normalizeUnicodeSpaces(normalizeAtPrefix(filePath));
+  const normalized = normalizeAtPrefix(filePath);
   if (normalized === "~") {
     return os.homedir();
   }

--- a/src/agents/sandbox/fs-bridge-mutation-helper.test.ts
+++ b/src/agents/sandbox/fs-bridge-mutation-helper.test.ts
@@ -538,6 +538,30 @@ describe("sandbox pinned mutation helper", () => {
     });
   });
 
+  it.runIf(process.platform !== "win32")("rejects FIFO reads without blocking", async () => {
+    await withTempDir({ prefix: "openclaw-mutation-helper-fifo-" }, async (root) => {
+      const workspace = path.join(root, "workspace");
+      const fifoPath = path.join(workspace, "live.pipe");
+      await fs.mkdir(workspace, { recursive: true });
+      expect(spawnSync("mkfifo", [fifoPath]).status).toBe(0);
+
+      const result = spawnSync(
+        "python3",
+        ["-c", SANDBOX_PINNED_MUTATION_PYTHON, "read", workspace, "", "live.pipe"],
+        {
+          encoding: "utf8",
+          stdio: ["pipe", "pipe", "pipe"],
+          timeout: 1_000,
+          killSignal: "SIGKILL",
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toMatch(/only regular files are allowed/i);
+    });
+  });
+
   it.runIf(process.platform !== "win32")(
     "preserves stdin payload bytes when the pinned write plan runs through sh",
     async () => {

--- a/src/agents/sandbox/fs-bridge-mutation-helper.ts
+++ b/src/agents/sandbox/fs-bridge-mutation-helper.ts
@@ -48,6 +48,8 @@ export const SANDBOX_PINNED_MUTATION_PYTHON = [
   "READ_FLAGS = os.O_RDONLY",
   "if hasattr(os, 'O_NOFOLLOW'):",
   "    READ_FLAGS |= os.O_NOFOLLOW",
+  "if hasattr(os, 'O_NONBLOCK'):",
+  "    READ_FLAGS |= os.O_NONBLOCK",
   "",
   "WRITE_FLAGS = os.O_WRONLY | os.O_CREAT | os.O_EXCL",
   "if hasattr(os, 'O_NOFOLLOW'):",

--- a/src/agents/sandbox/fs-bridge-path-safety.ts
+++ b/src/agents/sandbox/fs-bridge-path-safety.ts
@@ -5,6 +5,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import { FsSafeError } from "../../infra/fs-safe.js";
 import type { PathAliasPolicy } from "../../infra/path-alias-guards.js";
 import { openRootFile, type RootFileOpenResult } from "./fs-bridge-path-safety.runtime.js";
 import type { SandboxResolvedFsPath, SandboxFsMount } from "./fs-paths.js";
@@ -16,17 +17,14 @@ import {
 
 type BoundaryAllowedType = "file" | "directory";
 
-const NON_BLOCKING_READ_FLAG = process.platform === "win32" ? 0 : fs.constants.O_NONBLOCK;
-const nonBlockingBoundaryFs = {
-  closeSync: fs.closeSync,
-  constants: fs.constants,
-  fstatSync: fs.fstatSync,
-  lstatSync: fs.lstatSync,
-  openSync: (filePath: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode | null) =>
-    fs.openSync(filePath, typeof flags === "number" ? flags | NON_BLOCKING_READ_FLAG : flags, mode),
-  readFileSync: fs.readFileSync,
-  realpathSync: fs.realpathSync,
-};
+function sandboxBoundaryError(action: string, containerPath: string, error: unknown): Error {
+  if (error instanceof Error && !(error instanceof FsSafeError && error.code === "not-file")) {
+    return error;
+  }
+  return new Error(`Sandbox boundary checks failed; cannot ${action}: ${containerPath}`, {
+    cause: error,
+  });
+}
 
 /** Caller-provided path safety requirements for one fs bridge operation. */
 type PathSafetyOptions = {
@@ -100,9 +98,7 @@ export class SandboxFsPathGuard {
   ): Promise<RootFileOpenResult & { ok: true }> {
     const opened = await this.openBoundaryWithinRequiredMount(target, "read files");
     if (!opened.ok) {
-      throw opened.error instanceof Error
-        ? opened.error
-        : new Error(`Sandbox boundary checks failed; cannot read files: ${target.containerPath}`);
+      throw sandboxBoundaryError("read files", target.containerPath, opened.error);
     }
     return opened;
   }
@@ -145,11 +141,7 @@ export class SandboxFsPathGuard {
         const canFallbackToDirectoryStat =
           options.allowedType === "directory" && this.pathIsExistingDirectory(target.hostPath);
         if (!canFallbackToDirectoryStat) {
-          throw guarded.error instanceof Error
-            ? guarded.error
-            : new Error(
-                `Sandbox boundary checks failed; cannot ${options.action}: ${target.containerPath}`,
-              );
+          throw sandboxBoundaryError(options.action, target.containerPath, guarded.error);
         }
       }
     } else {
@@ -182,15 +174,12 @@ export class SandboxFsPathGuard {
       absolutePath: target.hostPath,
       rootPath: lexicalMount.hostRoot,
       boundaryLabel: "sandbox mount root",
-      // Follow in-mount symlink hops (fs-safe 0.5.2 rejects them by default):
+      // Follow in-mount symlink hops (fs-safe rejects them by default):
       // escaping hops still fail with fs-safe's containment error, and the
       // canonical container path is re-checked against mounts afterwards.
       rejectSymlinks: false,
       aliasPolicy: options?.aliasPolicy,
       allowedType: options?.allowedType,
-      // Type validation happens after open; nonblocking prevents a raced FIFO
-      // or device from stalling before the descriptor can be rejected.
-      ioFs: nonBlockingBoundaryFs,
     });
     return guarded;
   }

--- a/src/agents/sandbox/fs-bridge-path-safety.ts
+++ b/src/agents/sandbox/fs-bridge-path-safety.ts
@@ -16,6 +16,18 @@ import {
 
 type BoundaryAllowedType = "file" | "directory";
 
+const NON_BLOCKING_READ_FLAG = process.platform === "win32" ? 0 : fs.constants.O_NONBLOCK;
+const nonBlockingBoundaryFs = {
+  closeSync: fs.closeSync,
+  constants: fs.constants,
+  fstatSync: fs.fstatSync,
+  lstatSync: fs.lstatSync,
+  openSync: (filePath: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode | null) =>
+    fs.openSync(filePath, typeof flags === "number" ? flags | NON_BLOCKING_READ_FLAG : flags, mode),
+  readFileSync: fs.readFileSync,
+  realpathSync: fs.realpathSync,
+};
+
 /** Caller-provided path safety requirements for one fs bridge operation. */
 type PathSafetyOptions = {
   action: string;
@@ -176,6 +188,9 @@ export class SandboxFsPathGuard {
       rejectSymlinks: false,
       aliasPolicy: options?.aliasPolicy,
       allowedType: options?.allowedType,
+      // Type validation happens after open; nonblocking prevents a raced FIFO
+      // or device from stalling before the descriptor can be rejected.
+      ioFs: nonBlockingBoundaryFs,
     });
     return guarded;
   }

--- a/src/agents/sandbox/fs-bridge.boundary.test.ts
+++ b/src/agents/sandbox/fs-bridge.boundary.test.ts
@@ -1,8 +1,10 @@
+import { spawnSync } from "node:child_process";
 // Sandbox filesystem bridge boundary tests cover host-side validation before
 // any Docker filesystem command can run.
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createHostEscapeFixture,
   createSandbox,
@@ -118,4 +120,39 @@ describe("sandbox fs bridge boundary validation", () => {
     await expect(bridge.readFile({ filePath: "a.txt" })).rejects.toThrow(/ENOENT|no such file/i);
     expect(mockedExecDockerRaw).not.toHaveBeenCalled();
   });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a regular file replaced by a FIFO at descriptor open",
+    async () => {
+      await withTempDir("openclaw-fs-bridge-fifo-swap-", async (stateDir) => {
+        const workspaceDir = path.join(stateDir, "workspace");
+        const filePath = path.join(workspaceDir, "live.pipe");
+        await fs.mkdir(workspaceDir, { recursive: true });
+        await fs.writeFile(filePath, "regular");
+        const bridge = createSandboxFsBridge({
+          sandbox: createSandbox({ workspaceDir, agentWorkspaceDir: workspaceDir }),
+        });
+        const realOpenSync = fsSync.openSync.bind(fsSync);
+        const openSync = vi.spyOn(fsSync, "openSync").mockImplementation((target, flags, mode) => {
+          if (path.resolve(String(target)) === filePath) {
+            if (typeof flags !== "number" || (flags & fsSync.constants.O_NONBLOCK) === 0) {
+              throw new Error("sandbox read descriptor open is blocking");
+            }
+            fsSync.unlinkSync(filePath);
+            expect(spawnSync("mkfifo", [filePath]).status).toBe(0);
+          }
+          return realOpenSync(target, flags, mode);
+        });
+
+        try {
+          await expect(bridge.readFile({ filePath: "live.pipe" })).rejects.toThrow(
+            /boundary checks|cannot read/i,
+          );
+        } finally {
+          openSync.mockRestore();
+        }
+        expect(mockedExecDockerRaw).not.toHaveBeenCalled();
+      });
+    },
+  );
 });

--- a/src/agents/sessions/tools/path-utils.ts
+++ b/src/agents/sessions/tools/path-utils.ts
@@ -6,7 +6,6 @@
 import * as os from "node:os";
 import { isAbsolute, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
-import { pathExistsSync } from "../../../infra/fs-safe.js";
 
 const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
 const NARROW_NO_BREAK_SPACE = "\u202F";
@@ -15,26 +14,16 @@ function normalizeUnicodeSpaces(str: string): string {
 }
 
 function tryMacOSScreenshotPath(filePath: string): string {
-  return filePath.replace(/ (AM|PM)\./gi, `${NARROW_NO_BREAK_SPACE}$1.`);
-}
-
-function tryNFDVariant(filePath: string): string {
-  // macOS stores filenames in NFD (decomposed) form, try converting user input to NFD
-  return filePath.normalize("NFD");
-}
-
-function tryCurlyQuoteVariant(filePath: string): string {
-  // macOS uses U+2019 (right single quotation mark) in screenshot names like "Capture d'écran"
-  // Users typically type U+0027 (straight apostrophe)
-  return filePath.replace(/'/g, "\u2019");
+  return filePath.replace(/ (?=(?:AM|PM)(?:\b|\.))/gi, NARROW_NO_BREAK_SPACE);
 }
 
 function normalizeAtPrefix(filePath: string): string {
   return filePath.startsWith("@") ? filePath.slice(1) : filePath;
 }
 
-function expandPath(filePath: string): string {
-  const normalized = normalizeUnicodeSpaces(normalizeAtPrefix(filePath));
+function expandPath(filePath: string, normalizeSpaces = true): string {
+  const withoutAtPrefix = normalizeAtPrefix(filePath);
+  const normalized = normalizeSpaces ? normalizeUnicodeSpaces(withoutAtPrefix) : withoutAtPrefix;
   if (normalized.startsWith("file://")) {
     try {
       return fileURLToPath(normalized);
@@ -64,35 +53,22 @@ export function resolveToCwd(filePath: string, cwd: string): string {
 }
 
 export function resolveReadPath(filePath: string, cwd: string): string {
-  const resolved = resolveToCwd(filePath, cwd);
+  const expanded = expandPath(filePath, false);
+  return isAbsolute(expanded) ? expanded : resolvePath(cwd, expanded);
+}
 
-  if (pathExistsSync(resolved)) {
-    return resolved;
+/** Equivalent spellings worth probing after an exact read path misses. */
+export function getReadPathVariants(filePath: string): string[] {
+  const variants = new Set<string>();
+  const asciiSpace = normalizeUnicodeSpaces(filePath);
+  for (const spaced of [asciiSpace, tryMacOSScreenshotPath(asciiSpace)]) {
+    const straightQuotes = spaced.replace(/[\u2018\u2019]/g, "'");
+    const curlyQuotes = spaced.replace(/['\u2018]/g, "\u2019");
+    for (const quoted of [straightQuotes, curlyQuotes]) {
+      variants.add(quoted.normalize("NFC"));
+      variants.add(quoted.normalize("NFD"));
+    }
   }
-
-  // Try macOS AM/PM variant (narrow no-break space before AM/PM)
-  const amPmVariant = tryMacOSScreenshotPath(resolved);
-  if (amPmVariant !== resolved && pathExistsSync(amPmVariant)) {
-    return amPmVariant;
-  }
-
-  // Try NFD variant (macOS stores filenames in NFD form)
-  const nfdVariant = tryNFDVariant(resolved);
-  if (nfdVariant !== resolved && pathExistsSync(nfdVariant)) {
-    return nfdVariant;
-  }
-
-  // Try curly quote variant (macOS uses U+2019 in screenshot names)
-  const curlyVariant = tryCurlyQuoteVariant(resolved);
-  if (curlyVariant !== resolved && pathExistsSync(curlyVariant)) {
-    return curlyVariant;
-  }
-
-  // Try combined NFD + curly quote (for French macOS screenshots like "Capture d'écran")
-  const nfdCurlyVariant = tryCurlyQuoteVariant(nfdVariant);
-  if (nfdCurlyVariant !== resolved && pathExistsSync(nfdCurlyVariant)) {
-    return nfdCurlyVariant;
-  }
-
-  return resolved;
+  variants.delete(filePath);
+  return [...variants];
 }

--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -198,6 +198,25 @@ describe("read tool", () => {
     expect(textContent(result)).toBe("File is empty (0 bytes).");
   });
 
+  it("reports the byte count when a BOM-only file decodes to empty text", async () => {
+    const tool = createReadToolDefinition("/workspace", {
+      operations: {
+        access: async () => {},
+        readFile: async () => Buffer.from([0xef, 0xbb, 0xbf]),
+      },
+    });
+
+    const result = await tool.execute(
+      "call-bom-only",
+      { path: "bom.txt" },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(result)).toBe("File contains no readable text (3 bytes).");
+  });
+
   it("describes newline-only files instead of returning blank content", async () => {
     const tempDir = tempDirs.make("openclaw-read-blank-line-");
     await fs.writeFile(path.join(tempDir, "blank.txt"), "\n");

--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -1,6 +1,7 @@
 // Read tool tests cover bounded file reads, continuation hints, and shell-safe
 // fallback commands in agent sessions.
 import { Buffer } from "node:buffer";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -11,7 +12,9 @@ import { withEnvAsync } from "../../../test-utils/env.js";
 import { createReadToolDefinition } from "./read.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "./truncate.js";
 
-const decodeWindowsTextFileBufferMock = vi.hoisted(() => vi.fn(() => ""));
+const decodeWindowsTextFileBufferMock = vi.hoisted(() =>
+  vi.fn(({ buffer }: { buffer: Buffer }) => buffer.toString("utf8")),
+);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 vi.mock("../../../infra/windows-encoding.js", () => ({
@@ -61,6 +64,7 @@ function renderReadCall(args: { path: string; offset?: number; limit?: number })
 describe("read tool", () => {
   beforeEach(() => {
     decodeWindowsTextFileBufferMock.mockReset();
+    decodeWindowsTextFileBufferMock.mockImplementation(({ buffer }) => buffer.toString("utf8"));
   });
 
   it("reads managed inbound media refs as image files", async () => {
@@ -128,6 +132,148 @@ describe("read tool", () => {
     ).rejects.toThrow(
       "Read requires a file path, but . is a directory. List the directory, then read a specific file.",
     );
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "refuses a FIFO without waiting for a writer",
+    async () => {
+      const tempDir = tempDirs.make("openclaw-read-fifo-");
+      const fifoPath = path.join(tempDir, "live.pipe");
+      expect(spawnSync("mkfifo", [fifoPath]).status).toBe(0);
+      const tool = createReadToolDefinition(tempDir);
+      const read = tool.execute("call-fifo", { path: fifoPath }, undefined, undefined, {} as never);
+      let timer: NodeJS.Timeout | undefined;
+      const outcome = await Promise.race([
+        read.then(
+          () => ({ kind: "resolved" as const }),
+          (error: unknown) => ({ kind: "rejected" as const, error }),
+        ),
+        new Promise<{ kind: "timeout" }>((resolve) => {
+          timer = setTimeout(() => resolve({ kind: "timeout" }), 1_000);
+        }),
+      ]);
+      if (timer) {
+        clearTimeout(timer);
+      }
+
+      if (outcome.kind === "timeout") {
+        const writer = spawn(
+          "/bin/sh",
+          ["-c", 'while :; do printf x > "$1"; done', "openclaw-read-fifo", fifoPath],
+          { stdio: "ignore" },
+        );
+        const writerExit = new Promise<void>((resolve) => {
+          writer.once("exit", () => resolve());
+        });
+        await Promise.race([
+          read.catch(() => undefined),
+          new Promise<void>((resolve) => {
+            setTimeout(resolve, 2_000);
+          }),
+        ]);
+        writer.kill("SIGKILL");
+        await writerExit;
+      }
+
+      expect(outcome).toMatchObject({
+        kind: "rejected",
+        error: { message: expect.stringMatching(/regular file/i) },
+      });
+    },
+  );
+
+  it("describes empty files instead of returning blank content", async () => {
+    const tempDir = tempDirs.make("openclaw-read-empty-");
+    await fs.writeFile(path.join(tempDir, "empty.txt"), "");
+    const tool = createReadToolDefinition(tempDir);
+
+    const result = await tool.execute(
+      "call-empty",
+      { path: "empty.txt" },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(result)).toBe("File is empty (0 bytes).");
+  });
+
+  it("describes newline-only files instead of returning blank content", async () => {
+    const tempDir = tempDirs.make("openclaw-read-blank-line-");
+    await fs.writeFile(path.join(tempDir, "blank.txt"), "\n");
+    const tool = createReadToolDefinition(tempDir);
+
+    const result = await tool.execute(
+      "call-blank-line",
+      { path: "blank.txt" },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(result)).toBe("File contains 1 blank line.");
+  });
+
+  it("resolves one Unicode-equivalent filename and names the correction", async () => {
+    const tempDir = tempDirs.make("openclaw-read-unicode-");
+    const storedName = "re\u0301sume\u0301 3.04\u202fPM d\u2019accord.txt";
+    await fs.writeFile(path.join(tempDir, storedName), "matched");
+    const tool = createReadToolDefinition(tempDir);
+
+    const result = await tool.execute(
+      "call-unicode",
+      { path: "r\u00e9sum\u00e9 3.04 PM d'accord.txt" },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(result)).toContain("Resolved filename");
+    expect(textContent(result)).toContain("matched");
+  });
+
+  it("keeps an exact Unicode spelling ahead of equivalent filenames", async () => {
+    const tempDir = tempDirs.make("openclaw-read-unicode-exact-");
+    await fs.writeFile(path.join(tempDir, "report\u00a0.txt"), "exact");
+    await fs.writeFile(path.join(tempDir, "report .txt"), "equivalent");
+    const tool = createReadToolDefinition(tempDir);
+
+    const result = await tool.execute(
+      "call-unicode-exact",
+      { path: "report\u00a0.txt" },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(result)).toBe("exact");
+  });
+
+  it("refuses ambiguous Unicode-equivalent filenames", async () => {
+    const tempDir = tempDirs.make("openclaw-read-unicode-ambiguous-");
+    await fs.writeFile(path.join(tempDir, "d'accord.txt"), "straight");
+    await fs.writeFile(path.join(tempDir, "d\u2019accord.txt"), "curly");
+    const tool = createReadToolDefinition(tempDir);
+
+    await expect(
+      tool.execute(
+        "call-unicode-ambiguous",
+        { path: "d\u2018accord.txt" },
+        undefined,
+        undefined,
+        {} as never,
+      ),
+    ).rejects.toThrow(/ambiguous.*d'accord\.txt.*d\u2019accord\.txt/i);
+  });
+
+  it("suggests a close filename without reading it", async () => {
+    const tempDir = tempDirs.make("openclaw-read-suggestion-");
+    await fs.writeFile(path.join(tempDir, "AGENTS.md"), "instructions");
+    const tool = createReadToolDefinition(tempDir);
+
+    await expect(
+      tool.execute("call-suggestion", { path: "AGENT.md" }, undefined, undefined, {} as never),
+    ).rejects.toThrow(/Did you mean: AGENTS\.md\?/);
   });
 
   it("shell-quotes the long-first-line fallback path", async () => {

--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -214,6 +214,46 @@ describe("read tool", () => {
     expect(textContent(result)).toBe("File contains 1 blank line.");
   });
 
+  it("applies line limits before describing blank-only content", async () => {
+    const tool = createReadToolDefinition("/workspace", {
+      operations: {
+        access: async () => {},
+        readFile: async () => Buffer.from("\n\n"),
+      },
+    });
+
+    const result = await tool.execute(
+      "call-blank-range",
+      { path: "blank.txt", limit: 1 },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(result)).toBe(
+      "Selected range contains 1 blank line.\n\n[1 more line in file. Use offset=2 to continue.]",
+    );
+  });
+
+  it("does not classify plaintext from a custom backend by its extension", async () => {
+    const tool = createReadToolDefinition("/workspace", {
+      operations: {
+        access: async () => {},
+        readFile: async () => Buffer.from("plain text"),
+      },
+    });
+
+    const result = await tool.execute(
+      "call-custom-png",
+      { path: "report.png" },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(result)).toBe("plain text");
+  });
+
   it("resolves one Unicode-equivalent filename and names the correction", async () => {
     const tempDir = tempDirs.make("openclaw-read-unicode-");
     const storedName = "re\u0301sume\u0301 3.04\u202fPM d\u2019accord.txt";

--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -217,9 +217,12 @@ describe("read tool", () => {
     expect(textContent(result)).toBe("File contains no readable text (3 bytes).");
   });
 
-  it("describes newline-only files instead of returning blank content", async () => {
+  it.each([
+    ["LF", "\n"],
+    ["CRLF", "\r\n"],
+  ])("describes %s-only files instead of returning blank content", async (_label, contents) => {
     const tempDir = tempDirs.make("openclaw-read-blank-line-");
-    await fs.writeFile(path.join(tempDir, "blank.txt"), "\n");
+    await fs.writeFile(path.join(tempDir, "blank.txt"), contents);
     const tool = createReadToolDefinition(tempDir);
 
     const result = await tool.execute(

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -547,7 +547,10 @@ export function createReadToolDefinition(
               const startLineDisplay = startLine + 1;
               let outputText: string;
               if (totalFileLines === 0) {
-                outputText = "File is empty (0 bytes).";
+                outputText =
+                  buffer.length === 0
+                    ? "File is empty (0 bytes)."
+                    : `File contains no readable text (${buffer.length} bytes).`;
               } else if (startLine >= totalFileLines) {
                 outputText = `Offset ${offset} is beyond end of file (${totalFileLines} lines total). Retry with offset <= ${totalFileLines}.`;
               } else {

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -534,9 +534,9 @@ export function createReadToolDefinition(
             } else {
               const decodedText =
                 ops.decodeText?.({ buffer, absolutePath }) ?? buffer.toString("utf8");
-              const textContent = decodedText.startsWith("\uFEFF")
-                ? decodedText.slice(1)
-                : decodedText;
+              const textContent = (
+                decodedText.startsWith("\uFEFF") ? decodedText.slice(1) : decodedText
+              ).replaceAll("\r\n", "\n");
               const allLines = textContent.split("\n");
               if (allLines.at(-1) === "") {
                 allLines.pop();

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -7,7 +7,6 @@ import {
 } from "node:fs/promises";
 import { basename, dirname, isAbsolute, relative, resolve as resolvePath, sep } from "node:path";
 import { Text } from "@earendil-works/pi-tui";
-import { detectMime } from "@openclaw/media-core/mime";
 import { Type } from "typebox";
 import { hasErrnoCode, toErrorObject } from "../../../infra/errors.js";
 import { decodeWindowsTextFileBuffer } from "../../../infra/windows-encoding.js";
@@ -215,7 +214,10 @@ export interface ReadOperations {
   /** Check if file is readable (throw if not) */
   access: (absolutePath: string) => Promise<void>;
   /** Detect image MIME type, return null or undefined for non-images */
-  detectImageMimeType?: (absolutePath: string) => Promise<string | null | undefined>;
+  detectImageMimeType?: (
+    absolutePath: string,
+    buffer: Buffer,
+  ) => Promise<string | null | undefined>;
 }
 
 const defaultReadOperations: ReadOperations = {
@@ -231,13 +233,9 @@ async function detectReadImageMimeType(
   absolutePath: string,
 ): Promise<string | null | undefined> {
   if (ops.detectImageMimeType) {
-    return await ops.detectImageMimeType(absolutePath);
+    return await ops.detectImageMimeType(absolutePath, buffer);
   }
-  if (ops === defaultReadOperations) {
-    return detectSupportedImageMimeType(buffer);
-  }
-  const mime = await detectMime({ buffer, filePath: absolutePath });
-  return mime?.startsWith("image/") ? mime : undefined;
+  return detectSupportedImageMimeType(buffer);
 }
 
 export interface ReadToolOptions {
@@ -552,8 +550,6 @@ export function createReadToolDefinition(
                 outputText = "File is empty (0 bytes).";
               } else if (startLine >= totalFileLines) {
                 outputText = `Offset ${offset} is beyond end of file (${totalFileLines} lines total). Retry with offset <= ${totalFileLines}.`;
-              } else if (allLines.every((line) => line.length === 0)) {
-                outputText = `File contains ${totalFileLines} blank line${totalFileLines === 1 ? "" : "s"}.`;
               } else {
                 const endLine =
                   limit === undefined
@@ -562,38 +558,50 @@ export function createReadToolDefinition(
                         startLine + normalizePositiveLimit(limit, DEFAULT_MAX_LINES),
                         totalFileLines,
                       );
-                let selectedContent = allLines.slice(startLine, endLine).join("\n");
-                if (endLine === totalFileLines && textContent.endsWith("\n")) {
-                  selectedContent += "\n";
-                }
+                const selectedLines = allLines.slice(startLine, endLine);
                 const userLimitedLines = limit === undefined ? undefined : endLine - startLine;
-                const truncation = truncateHead(selectedContent);
-                if (truncation.firstLineExceedsLimit) {
-                  const lineBreak = selectedContent.indexOf("\n");
-                  const firstLine =
-                    lineBreak === -1 ? selectedContent : selectedContent.slice(0, lineBreak);
-                  const firstLineSize = formatSize(Buffer.byteLength(firstLine, "utf-8"));
-                  outputText = `[Line ${startLineDisplay} is ${firstLineSize}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. Use bash: sed -n '${startLineDisplay}p' ${quotePosixShellArg(path)} | head -c ${DEFAULT_MAX_BYTES}]`;
-                  truncationDetails = { ...truncation, totalLines: totalFileLines };
-                } else if (truncation.truncated) {
-                  const endLineDisplay = startLineDisplay + truncation.outputLines - 1;
-                  const nextOffset = endLineDisplay + 1;
-                  outputText = truncation.content;
-                  if (truncation.truncatedBy === "lines") {
-                    outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines}. Use offset=${nextOffset} to continue.]`;
-                  } else {
-                    outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Use offset=${nextOffset} to continue.]`;
+                if (selectedLines.every((line) => line.length === 0)) {
+                  const selectedLineCount = selectedLines.length;
+                  const subject =
+                    startLine === 0 && endLine === totalFileLines ? "File" : "Selected range";
+                  outputText = `${subject} contains ${selectedLineCount} blank line${selectedLineCount === 1 ? "" : "s"}.`;
+                  if (userLimitedLines !== undefined && endLine < totalFileLines) {
+                    const remaining = totalFileLines - endLine;
+                    outputText += `\n\n[${remaining} more line${remaining === 1 ? "" : "s"} in file. Use offset=${endLine + 1} to continue.]`;
                   }
-                  truncationDetails = { ...truncation, totalLines: totalFileLines };
-                } else if (
-                  userLimitedLines !== undefined &&
-                  startLine + userLimitedLines < totalFileLines
-                ) {
-                  const remaining = totalFileLines - (startLine + userLimitedLines);
-                  const nextOffset = startLine + userLimitedLines + 1;
-                  outputText = `${truncation.content}\n\n[${remaining} more lines in file. Use offset=${nextOffset} to continue.]`;
                 } else {
-                  outputText = truncation.content;
+                  let selectedContent = selectedLines.join("\n");
+                  if (endLine === totalFileLines && textContent.endsWith("\n")) {
+                    selectedContent += "\n";
+                  }
+                  const truncation = truncateHead(selectedContent);
+                  if (truncation.firstLineExceedsLimit) {
+                    const lineBreak = selectedContent.indexOf("\n");
+                    const firstLine =
+                      lineBreak === -1 ? selectedContent : selectedContent.slice(0, lineBreak);
+                    const firstLineSize = formatSize(Buffer.byteLength(firstLine, "utf-8"));
+                    outputText = `[Line ${startLineDisplay} is ${firstLineSize}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. Use bash: sed -n '${startLineDisplay}p' ${quotePosixShellArg(path)} | head -c ${DEFAULT_MAX_BYTES}]`;
+                    truncationDetails = { ...truncation, totalLines: totalFileLines };
+                  } else if (truncation.truncated) {
+                    const endLineDisplay = startLineDisplay + truncation.outputLines - 1;
+                    const nextOffset = endLineDisplay + 1;
+                    outputText = truncation.content;
+                    if (truncation.truncatedBy === "lines") {
+                      outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines}. Use offset=${nextOffset} to continue.]`;
+                    } else {
+                      outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Use offset=${nextOffset} to continue.]`;
+                    }
+                    truncationDetails = { ...truncation, totalLines: totalFileLines };
+                  } else if (
+                    userLimitedLines !== undefined &&
+                    startLine + userLimitedLines < totalFileLines
+                  ) {
+                    const remaining = totalFileLines - (startLine + userLimitedLines);
+                    const nextOffset = startLine + userLimitedLines + 1;
+                    outputText = `${truncation.content}\n\n[${remaining} more lines in file. Use offset=${nextOffset} to continue.]`;
+                  } else {
+                    outputText = truncation.content;
+                  }
                 }
               }
               content = [{ type: "text", text: outputText }];

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -1,7 +1,13 @@
 import { constants } from "node:fs";
-import { access as fsAccess, readFile as fsReadFile } from "node:fs/promises";
+import {
+  access as fsAccess,
+  open as fsOpen,
+  readdir as fsReaddir,
+  stat as fsStat,
+} from "node:fs/promises";
 import { basename, dirname, isAbsolute, relative, resolve as resolvePath, sep } from "node:path";
 import { Text } from "@earendil-works/pi-tui";
+import { detectMime } from "@openclaw/media-core/mime";
 import { Type } from "typebox";
 import { hasErrnoCode, toErrorObject } from "../../../infra/errors.js";
 import { decodeWindowsTextFileBuffer } from "../../../infra/windows-encoding.js";
@@ -17,6 +23,7 @@ import {
  * Reads text and image files through local or injected operations with highlighting, resizing, and bounded output.
  */
 import { toPosixPath } from "../../../shared/ignore-rules.js";
+import { levenshteinDistance } from "../../../shared/levenshtein-distance.js";
 import { getReadmePath } from "../../config.js";
 import { keyHint, keyText } from "../../modes/interactive/components/keybinding-hints.js";
 import {
@@ -26,11 +33,11 @@ import {
 } from "../../modes/interactive/theme/theme.js";
 import type { AgentTool } from "../../runtime/index.js";
 import { processImage } from "../../utils/image-resize.js";
-import { detectSupportedImageMimeTypeFromFile } from "../../utils/mime.js";
+import { detectSupportedImageMimeType } from "../../utils/mime.js";
 import { formatPathRelativeToCwdOrAbsolute } from "../../utils/paths.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
 import { normalizePositiveLimit } from "./limits.js";
-import { resolveReadPath } from "./path-utils.js";
+import { getReadPathVariants, resolveReadPath } from "./path-utils.js";
 import { getTextOutput, invalidArgText, replaceTabs, shortenPath, str } from "./render-utils.js";
 import type { ReadToolDetails, ReadToolTruncationDetails } from "./tool-contracts.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
@@ -129,6 +136,64 @@ function normalizeReadError(error: unknown, filePath: string): Error {
   return toErrorObject(error, "Non-Error rejection");
 }
 
+function regularFileReadError(filePath: string): Error {
+  return new Error(`Read only supports regular files; no read was attempted: ${filePath}`);
+}
+
+async function assertLocalReadableFile(filePath: string): Promise<void> {
+  const stat = await fsStat(filePath);
+  if (stat.isDirectory()) {
+    throw Object.assign(new Error(`Read requires a file: ${filePath}`), { code: "EISDIR" });
+  }
+  if (!stat.isFile()) {
+    throw regularFileReadError(filePath);
+  }
+  await fsAccess(filePath, constants.R_OK);
+}
+
+async function readLocalRegularFile(filePath: string): Promise<Buffer> {
+  const before = await fsStat(filePath);
+  if (!before.isFile()) {
+    throw regularFileReadError(filePath);
+  }
+  const nonBlocking = process.platform === "win32" ? 0 : constants.O_NONBLOCK;
+  const handle = await fsOpen(filePath, constants.O_RDONLY | nonBlocking);
+  try {
+    const opened = await handle.stat();
+    if (!opened.isFile()) {
+      throw regularFileReadError(filePath);
+    }
+    if (before.dev !== opened.dev || before.ino !== opened.ino) {
+      throw new Error(`File changed during read: ${filePath}`);
+    }
+    return await handle.readFile();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function suggestLocalReadPaths(filePath: string): Promise<string[]> {
+  let entries: string[];
+  try {
+    entries = await fsReaddir(dirname(filePath));
+  } catch (error) {
+    if (hasErrnoCode(error, "ENOENT") || hasErrnoCode(error, "ENOTDIR")) {
+      return [];
+    }
+    throw error;
+  }
+  const requested = basename(filePath).toLowerCase();
+  const maxDistance = Math.max(1, Math.floor(requested.length * 0.4));
+  return entries
+    .map((entry) => ({ entry, distance: levenshteinDistance(requested, entry.toLowerCase()) }))
+    .filter(({ entry, distance }) => entry !== basename(filePath) && distance <= maxDistance)
+    .toSorted(
+      (left, right) => left.distance - right.distance || left.entry.localeCompare(right.entry),
+    )
+    .slice(0, 3)
+    .map(({ entry }) => entry);
+}
+
 interface CompactReadClassification {
   kind: "docs" | "resource" | "skill";
   label: string;
@@ -156,10 +221,24 @@ export interface ReadOperations {
 const defaultReadOperations: ReadOperations = {
   resolvePath: resolveLocalReadPath,
   decodeText: ({ buffer }) => decodeWindowsTextFileBuffer({ buffer }),
-  readFile: (path) => fsReadFile(path),
-  access: (path) => fsAccess(path, constants.R_OK),
-  detectImageMimeType: detectSupportedImageMimeTypeFromFile,
+  readFile: readLocalRegularFile,
+  access: assertLocalReadableFile,
 };
+
+async function detectReadImageMimeType(
+  ops: ReadOperations,
+  buffer: Buffer,
+  absolutePath: string,
+): Promise<string | null | undefined> {
+  if (ops.detectImageMimeType) {
+    return await ops.detectImageMimeType(absolutePath);
+  }
+  if (ops === defaultReadOperations) {
+    return detectSupportedImageMimeType(buffer);
+  }
+  const mime = await detectMime({ buffer, filePath: absolutePath });
+  return mime?.startsWith("image/") ? mime : undefined;
+}
 
 export interface ReadToolOptions {
   /** Whether to auto-resize images to 2000x2000 max. Default: true */
@@ -269,8 +348,52 @@ async function resolveReadToolPath(
   ops: ReadOperations,
   filePath: string,
   cwd: string,
-): Promise<string> {
-  return await (ops.resolvePath?.(filePath, cwd) ?? resolveReadPath(filePath, cwd));
+): Promise<{ absolutePath: string; note?: string }> {
+  const absolutePath = await (ops.resolvePath?.(filePath, cwd) ?? resolveReadPath(filePath, cwd));
+  try {
+    await ops.access(absolutePath);
+    return { absolutePath };
+  } catch (error) {
+    if (!hasErrnoCode(error, "ENOENT") && !hasErrnoCode(error, "ENOTDIR")) {
+      throw error;
+    }
+
+    const matches: string[] = [];
+    for (const candidate of getReadPathVariants(absolutePath)) {
+      try {
+        await ops.access(candidate);
+        matches.push(candidate);
+      } catch (candidateError) {
+        if (!hasErrnoCode(candidateError, "ENOENT") && !hasErrnoCode(candidateError, "ENOTDIR")) {
+          throw candidateError;
+        }
+      }
+    }
+
+    if (matches.length > 1) {
+      throw new Error(
+        `Read path is ambiguous: ${basename(absolutePath)} matches ${matches.map((match) => basename(match)).join(", ")}.`,
+        { cause: error },
+      );
+    }
+    const match = matches[0];
+    if (match !== undefined) {
+      return {
+        absolutePath: match,
+        note: `[Resolved filename: ${basename(absolutePath)} -> ${basename(match)}.]`,
+      };
+    }
+
+    const suggestions =
+      ops === defaultReadOperations ? await suggestLocalReadPaths(absolutePath) : [];
+    const suggestion = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}?` : "";
+    throw Object.assign(
+      new Error(`File not found: ${absolutePath}.${suggestion}`, { cause: error }),
+      {
+        code: "ENOENT",
+      },
+    );
+  }
 }
 
 function formatCompactReadCall(
@@ -379,21 +502,16 @@ export function createReadToolDefinition(
 
         void (async () => {
           try {
-            const absolutePath = await resolveReadToolPath(ops, path, cwd);
-            // Check if file exists and is readable.
-            await ops.access(absolutePath);
+            const { absolutePath, note } = await resolveReadToolPath(ops, path, cwd);
             if (aborted) {
               return;
             }
-            const mimeType = ops.detectImageMimeType
-              ? await ops.detectImageMimeType(absolutePath)
-              : undefined;
+            const buffer = await ops.readFile(absolutePath);
+            const mimeType = await detectReadImageMimeType(ops, buffer, absolutePath);
             let content: (TextContent | ImageContent)[];
             let truncationDetails: TruncationResult | undefined;
             const nonVisionImageNote = getNonVisionImageNote(ctx?.model);
             if (mimeType) {
-              // Read image as binary.
-              const buffer = await ops.readFile(absolutePath);
               const base64 = buffer.toString("base64");
               const processed = await processImage(
                 { type: "image", data: base64, mimeType },
@@ -416,71 +534,76 @@ export function createReadToolDefinition(
                 content = [{ type: "text", text: textNote }, processed.image];
               }
             } else {
-              // Read text content.
-              const buffer = await ops.readFile(absolutePath);
               const decodedText =
                 ops.decodeText?.({ buffer, absolutePath }) ?? buffer.toString("utf8");
               const textContent = decodedText.startsWith("\uFEFF")
                 ? decodedText.slice(1)
                 : decodedText;
               const allLines = textContent.split("\n");
+              if (allLines.at(-1) === "") {
+                allLines.pop();
+              }
               const totalFileLines = allLines.length;
               // Apply offset if specified. Convert from 1-indexed input to 0-indexed array access.
               const startLine = offset === undefined ? 0 : offset - 1;
               const startLineDisplay = startLine + 1;
-              // Check if offset is out of bounds.
-              if (startLine >= allLines.length) {
-                throw new Error(
-                  `Offset ${offset} is beyond end of file (${allLines.length} lines total)`,
-                );
-              }
-              let selectedContent: string;
-              let userLimitedLines: number | undefined;
-              // If limit is specified by the user, honor it first. Otherwise truncateHead decides.
-              if (limit !== undefined) {
-                const normalizedLimit = normalizePositiveLimit(limit, DEFAULT_MAX_LINES);
-                const endLine = Math.min(startLine + normalizedLimit, allLines.length);
-                selectedContent = allLines.slice(startLine, endLine).join("\n");
-                userLimitedLines = endLine - startLine;
-              } else {
-                selectedContent = allLines.slice(startLine).join("\n");
-              }
-              // Apply truncation, respecting both line and byte limits.
-              const truncation = truncateHead(selectedContent);
               let outputText: string;
-              if (truncation.firstLineExceedsLimit) {
-                // First line alone exceeds the byte limit. Point the model at a bash fallback.
-                const firstLine = allLines.at(startLine);
-                if (firstLine === undefined) {
-                  throw new Error("Requested line is outside the file.");
-                }
-                const firstLineSize = formatSize(Buffer.byteLength(firstLine, "utf-8"));
-                outputText = `[Line ${startLineDisplay} is ${firstLineSize}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. Use bash: sed -n '${startLineDisplay}p' ${quotePosixShellArg(path)} | head -c ${DEFAULT_MAX_BYTES}]`;
-                truncationDetails = truncation;
-              } else if (truncation.truncated) {
-                // Truncation occurred. Build an actionable continuation notice.
-                const endLineDisplay = startLineDisplay + truncation.outputLines - 1;
-                const nextOffset = endLineDisplay + 1;
-                outputText = truncation.content;
-                if (truncation.truncatedBy === "lines") {
-                  outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines}. Use offset=${nextOffset} to continue.]`;
-                } else {
-                  outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Use offset=${nextOffset} to continue.]`;
-                }
-                truncationDetails = truncation;
-              } else if (
-                userLimitedLines !== undefined &&
-                startLine + userLimitedLines < allLines.length
-              ) {
-                // User-specified limit stopped early, but the file still has more content.
-                const remaining = allLines.length - (startLine + userLimitedLines);
-                const nextOffset = startLine + userLimitedLines + 1;
-                outputText = `${truncation.content}\n\n[${remaining} more lines in file. Use offset=${nextOffset} to continue.]`;
+              if (totalFileLines === 0) {
+                outputText = "File is empty (0 bytes).";
+              } else if (startLine >= totalFileLines) {
+                outputText = `Offset ${offset} is beyond end of file (${totalFileLines} lines total). Retry with offset <= ${totalFileLines}.`;
+              } else if (allLines.every((line) => line.length === 0)) {
+                outputText = `File contains ${totalFileLines} blank line${totalFileLines === 1 ? "" : "s"}.`;
               } else {
-                // No truncation and no remaining user-limited content.
-                outputText = truncation.content;
+                const endLine =
+                  limit === undefined
+                    ? totalFileLines
+                    : Math.min(
+                        startLine + normalizePositiveLimit(limit, DEFAULT_MAX_LINES),
+                        totalFileLines,
+                      );
+                let selectedContent = allLines.slice(startLine, endLine).join("\n");
+                if (endLine === totalFileLines && textContent.endsWith("\n")) {
+                  selectedContent += "\n";
+                }
+                const userLimitedLines = limit === undefined ? undefined : endLine - startLine;
+                const truncation = truncateHead(selectedContent);
+                if (truncation.firstLineExceedsLimit) {
+                  const lineBreak = selectedContent.indexOf("\n");
+                  const firstLine =
+                    lineBreak === -1 ? selectedContent : selectedContent.slice(0, lineBreak);
+                  const firstLineSize = formatSize(Buffer.byteLength(firstLine, "utf-8"));
+                  outputText = `[Line ${startLineDisplay} is ${firstLineSize}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. Use bash: sed -n '${startLineDisplay}p' ${quotePosixShellArg(path)} | head -c ${DEFAULT_MAX_BYTES}]`;
+                  truncationDetails = { ...truncation, totalLines: totalFileLines };
+                } else if (truncation.truncated) {
+                  const endLineDisplay = startLineDisplay + truncation.outputLines - 1;
+                  const nextOffset = endLineDisplay + 1;
+                  outputText = truncation.content;
+                  if (truncation.truncatedBy === "lines") {
+                    outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines}. Use offset=${nextOffset} to continue.]`;
+                  } else {
+                    outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Use offset=${nextOffset} to continue.]`;
+                  }
+                  truncationDetails = { ...truncation, totalLines: totalFileLines };
+                } else if (
+                  userLimitedLines !== undefined &&
+                  startLine + userLimitedLines < totalFileLines
+                ) {
+                  const remaining = totalFileLines - (startLine + userLimitedLines);
+                  const nextOffset = startLine + userLimitedLines + 1;
+                  outputText = `${truncation.content}\n\n[${remaining} more lines in file. Use offset=${nextOffset} to continue.]`;
+                } else {
+                  outputText = truncation.content;
+                }
               }
               content = [{ type: "text", text: outputText }];
+            }
+
+            if (note && content[0]?.type === "text") {
+              content = [
+                { ...content[0], text: `${note}\n${content[0].text}` },
+                ...content.slice(1),
+              ];
             }
 
             if (aborted) {

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -1,14 +1,10 @@
 import { constants } from "node:fs";
-import {
-  access as fsAccess,
-  open as fsOpen,
-  readdir as fsReaddir,
-  stat as fsStat,
-} from "node:fs/promises";
+import { access as fsAccess, readdir as fsReaddir, stat as fsStat } from "node:fs/promises";
 import { basename, dirname, isAbsolute, relative, resolve as resolvePath, sep } from "node:path";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { hasErrnoCode, toErrorObject } from "../../../infra/errors.js";
+import { readRegularFile } from "../../../infra/regular-file.js";
 import { decodeWindowsTextFileBuffer } from "../../../infra/windows-encoding.js";
 import type { ImageContent, Model, TextContent } from "../../../llm/types.js";
 import {
@@ -150,27 +146,6 @@ async function assertLocalReadableFile(filePath: string): Promise<void> {
   await fsAccess(filePath, constants.R_OK);
 }
 
-async function readLocalRegularFile(filePath: string): Promise<Buffer> {
-  const before = await fsStat(filePath);
-  if (!before.isFile()) {
-    throw regularFileReadError(filePath);
-  }
-  const nonBlocking = process.platform === "win32" ? 0 : constants.O_NONBLOCK;
-  const handle = await fsOpen(filePath, constants.O_RDONLY | nonBlocking);
-  try {
-    const opened = await handle.stat();
-    if (!opened.isFile()) {
-      throw regularFileReadError(filePath);
-    }
-    if (before.dev !== opened.dev || before.ino !== opened.ino) {
-      throw new Error(`File changed during read: ${filePath}`);
-    }
-    return await handle.readFile();
-  } finally {
-    await handle.close();
-  }
-}
-
 async function suggestLocalReadPaths(filePath: string): Promise<string[]> {
   let entries: string[];
   try {
@@ -223,7 +198,7 @@ export interface ReadOperations {
 const defaultReadOperations: ReadOperations = {
   resolvePath: resolveLocalReadPath,
   decodeText: ({ buffer }) => decodeWindowsTextFileBuffer({ buffer }),
-  readFile: readLocalRegularFile,
+  readFile: async (filePath) => (await readRegularFile({ filePath })).buffer,
   access: assertLocalReadableFile,
 };
 

--- a/src/agents/utils/mime.ts
+++ b/src/agents/utils/mime.ts
@@ -4,13 +4,10 @@
  * The checks here avoid trusting file extensions and reject unsupported image
  * variants before provider upload paths try to process them.
  */
-import { open } from "node:fs/promises";
-
-const IMAGE_TYPE_SNIFF_BYTES = 4100;
 const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 
 /** Detects supported image MIME types from leading file bytes. */
-function detectSupportedImageMimeType(buffer: Uint8Array): string | null {
+export function detectSupportedImageMimeType(buffer: Uint8Array): string | null {
   if (startsWith(buffer, [0xff, 0xd8, 0xff])) {
     return buffer[3] === 0xf7 ? null : "image/jpeg";
   }
@@ -27,20 +24,6 @@ function detectSupportedImageMimeType(buffer: Uint8Array): string | null {
     return "image/bmp";
   }
   return null;
-}
-
-/** Reads a bounded prefix from disk and detects its supported image MIME type. */
-export async function detectSupportedImageMimeTypeFromFile(
-  filePath: string,
-): Promise<string | null> {
-  const fileHandle = await open(filePath, "r");
-  try {
-    const buffer = Buffer.alloc(IMAGE_TYPE_SNIFF_BYTES);
-    const { bytesRead } = await fileHandle.read(buffer, 0, IMAGE_TYPE_SNIFF_BYTES, 0);
-    return detectSupportedImageMimeType(buffer.subarray(0, bytesRead));
-  } finally {
-    await fileHandle.close();
-  }
 }
 
 function isPng(buffer: Uint8Array): boolean {

--- a/src/infra/boundary-file-read.ts
+++ b/src/infra/boundary-file-read.ts
@@ -25,7 +25,7 @@ export {
 } from "@openclaw/fs-safe/advanced";
 
 /**
- * Opens a root-scoped file after canonicalizing symlink parents. fs-safe 0.5.2
+ * Opens a root-scoped file after canonicalizing symlink parents. fs-safe
  * rejects every symlink path component by default; the workspace contract
  * follows contained parent symlinks (directory aliases) while final-symlink
  * targets and out-of-root escapes stay rejected by openRootFile itself.


### PR DESCRIPTION
## Problem

File reads could block on special files, miss Unicode-equivalent filenames, or return blank output for empty and past-EOF ranges.

## Fix

Use fs-safe 0.5.4 for nonblocking, descriptor-validated reads and reuse one buffer for MIME and text. Exact paths win, one Unicode-equivalent path may resolve, and ambiguous matches fail. Authoritative line counts now produce explicit empty/EOF results and stop paging at EOF.

## Proof

- [Before](https://github.com/openclaw/openclaw/actions/runs/31366605121): real FIFO read timed out; Unicode and empty/EOF regressions failed.
- Final local proof: 202 focused tests pass; targeted format, lint, core/extensions typecheck, and diff checks pass.
- Exact-head local ClawSweeper: zero findings, zero security concerns, no maintainer decision, zero Rank-up moves.
- Final-head Telegram E2E: DM completed with OPENCLAW_E2E_BASIC; 2 provider requests recorded.
