### PR TITLE
fix(codex): keep authenticated user identity in agent turns

### DIFF
--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -365,6 +365,7 @@ type CodexTurnInterruptParams = JsonObject & {
 export type CodexTurnStartParams = JsonObject & {
   threadId: string;
   input: CodexUserInput[];
+  additionalContext?: Record<string, { kind: "untrusted" | "application"; value: string }>;
   cwd?: string;
   model?: string;
   approvalPolicy?: CodexApprovalPolicy | null;

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -5016,6 +5016,89 @@ describe("runCodexAppServerAttempt", () => {
     const resumeRequestParams = resumeRequest?.params as Record<string, unknown> | undefined;
     expect(resumeRequestParams?.developerInstructions).not.toContain(CODEX_GPT5_BEHAVIOR_CONTRACT);
   });
+  it("sends the current recorded sender on successive turns of one resumed Codex thread", async () => {
+    const { sessionFile, workspaceDir } = createRunPaths();
+    await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
+    const turnIds = ["turn-ada", "turn-grace"] as const;
+    let nextTurnIndex = 0;
+    const harness = createAppServerHarness(async (method, params) => {
+      if (method === "thread/resume") {
+        return threadStartResult((params as { threadId?: string }).threadId ?? "thread-existing");
+      }
+      if (method === "turn/start") {
+        const turnId = turnIds[nextTurnIndex++];
+        if (!turnId) {
+          throw new Error("unexpected extra turn/start");
+        }
+        return turnStartResult(turnId);
+      }
+      return {};
+    });
+
+    const runTurn = async (sender: { id: string; name: string }, prompt: string, runId: string) => {
+      const expectedTurnStarts =
+        harness.requests.filter((request) => request.method === "turn/start").length + 1;
+      const params = createParams(sessionFile, workspaceDir, { prompt, runId });
+      const message = {
+        role: "user" as const,
+        content: prompt,
+        timestamp: Date.now(),
+        __openclaw: { senderId: sender.id, senderName: sender.name },
+      };
+      params.userTurnTranscriptRecorder = {
+        message,
+        resolveMessage: async () => message,
+        getAdmissionReceipt: () => undefined,
+        markRuntimePersistencePending() {},
+        markRuntimePersisted() {},
+      } as EmbeddedRunAttemptParams["userTurnTranscriptRecorder"];
+      const run = runCodexAppServerAttempt(params);
+      await vi.waitFor(
+        () =>
+          expect(
+            harness.requests.filter((request) => request.method === "turn/start"),
+          ).toHaveLength(expectedTurnStarts),
+        fastWait,
+      );
+      await harness.completeTurn({
+        threadId: "thread-existing",
+        turnId: `turn-${sender.name.toLowerCase()}`,
+      });
+      await run;
+    };
+
+    await runTurn({ id: "profile-ada", name: "Ada" }, "first request", "run-ada");
+    await runTurn({ id: "profile-grace", name: "Grace" }, "second request", "run-grace");
+
+    expect(
+      harness.requests
+        .filter((request) =>
+          ["thread/start", "thread/resume", "turn/start"].includes(request.method),
+        )
+        .map((request) => request.method),
+    ).toEqual(["thread/resume", "turn/start", "turn/start"]);
+    expect(
+      harness.requests
+        .filter((request) => request.method === "turn/start")
+        .map(
+          (request) =>
+            (
+              request.params as {
+                additionalContext?: Record<string, { kind: string; value: string }>;
+              }
+            ).additionalContext?.openclaw_current_sender,
+        ),
+    ).toEqual([
+      {
+        kind: "untrusted",
+        value: '{"sender":{"id":"profile-ada","name":"Ada"}}',
+      },
+      {
+        kind: "untrusted",
+        value: '{"sender":{"id":"profile-grace","name":"Grace"}}',
+      },
+    ]);
+  });
   it("starts a fresh Codex thread before resume when the native rollout reaches the fallback fuse", async () => {
     const { sessionFile, workspaceDir, agentDir } = createRunPaths();
     await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -5039,6 +5039,7 @@ describe("runCodexAppServerAttempt", () => {
       const expectedTurnStarts =
         harness.requests.filter((request) => request.method === "turn/start").length + 1;
       const params = createParams(sessionFile, workspaceDir, { prompt, runId });
+      params.trigger = "user";
       const message = {
         role: "user" as const,
         content: prompt,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -5051,7 +5051,7 @@ describe("runCodexAppServerAttempt", () => {
         getAdmissionReceipt: () => undefined,
         markRuntimePersistencePending() {},
         markRuntimePersisted() {},
-      } as EmbeddedRunAttemptParams["userTurnTranscriptRecorder"];
+      } as unknown as EmbeddedRunAttemptParams["userTurnTranscriptRecorder"];
       const run = runCodexAppServerAttempt(params);
       await vi.waitFor(
         () =>

--- a/extensions/codex/src/app-server/turn-params.ts
+++ b/extensions/codex/src/app-server/turn-params.ts
@@ -1,5 +1,10 @@
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { GPT5_HEARTBEAT_PROMPT_OVERLAY as CODEX_GPT5_HEARTBEAT_PROMPT_OVERLAY } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  asOptionalRecord,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { codexSandboxPolicyForTurn, type CodexAppServerRuntimeOptions } from "./config.js";
 import type {
   CodexSandboxPolicy,
@@ -13,6 +18,37 @@ import {
   resolveReasoningEffort,
 } from "./thread-model-selection.js";
 import { buildCodexUserInput } from "./user-input.js";
+
+const CODEX_CURRENT_SENDER_FIELD_MAX_CHARS = 256;
+
+function buildCodexCurrentSenderContextValue(params: EmbeddedRunAttemptParams): string | undefined {
+  const metadata = asOptionalRecord(
+    asOptionalRecord(params.userTurnTranscriptRecorder?.message as unknown)?.["__openclaw"],
+  );
+  const recorded = [
+    normalizeOptionalString(metadata?.["senderId"]),
+    normalizeOptionalString(metadata?.["senderName"]),
+    normalizeOptionalString(metadata?.["senderUsername"]),
+  ] as const;
+  const [id, name, username] = recorded.some(Boolean)
+    ? recorded
+    : [
+        normalizeOptionalString(params.senderId),
+        normalizeOptionalString(params.senderName),
+        normalizeOptionalString(params.senderUsername),
+      ];
+  if (!id && !name && !username) {
+    return undefined;
+  }
+  const bound = (value: string) => truncateUtf16Safe(value, CODEX_CURRENT_SENDER_FIELD_MAX_CHARS);
+  return JSON.stringify({
+    sender: {
+      ...(id ? { id: bound(id) } : {}),
+      ...(name ? { name: bound(name) } : {}),
+      ...(username ? { username: bound(username) } : {}),
+    },
+  });
+}
 
 export function buildTurnStartParams(
   params: EmbeddedRunAttemptParams,
@@ -43,9 +79,15 @@ export function buildTurnStartParams(
         config: params.config,
       });
   const useThreadPermissionProfile = options.appServer.networkProxy && !options.sandboxPolicy;
+  const currentSenderContext = buildCodexCurrentSenderContextValue(params);
+  // Untrusted context exposes authenticated attribution without promoting human-controlled labels.
+  const additionalContext: CodexTurnStartParams["additionalContext"] = currentSenderContext
+    ? { openclaw_current_sender: { kind: "untrusted", value: currentSenderContext } }
+    : undefined;
   return {
     threadId: options.threadId,
     input: buildCodexUserInput(options.promptText ?? params.prompt, params.images),
+    ...(additionalContext ? { additionalContext } : {}),
     cwd: options.cwd,
     approvalPolicy: options.appServer.approvalPolicy,
     approvalsReviewer: options.appServer.approvalsReviewer,

--- a/extensions/codex/src/app-server/turn-params.ts
+++ b/extensions/codex/src/app-server/turn-params.ts
@@ -79,7 +79,8 @@ export function buildTurnStartParams(
         config: params.config,
       });
   const useThreadPermissionProfile = options.appServer.networkProxy && !options.sandboxPolicy;
-  const currentSenderContext = buildCodexCurrentSenderContextValue(params);
+  const currentSenderContext =
+    params.trigger === "user" ? buildCodexCurrentSenderContextValue(params) : undefined;
   // Untrusted context exposes authenticated attribution without promoting human-controlled labels.
   const additionalContext: CodexTurnStartParams["additionalContext"] = currentSenderContext
     ? { openclaw_current_sender: { kind: "untrusted", value: currentSenderContext } }

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -132,6 +132,12 @@
 
 ```json
 {
+  "additionalContext": {
+    "openclaw_current_sender": {
+      "kind": "untrusted",
+      "value": "{\"sender\":{\"id\":\"424242\",\"name\":\"Pash\",\"username\":\"pash\"}}"
+    }
+  },
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
   "collaborationMode": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -132,6 +132,12 @@
 
 ```json
 {
+  "additionalContext": {
+    "openclaw_current_sender": {
+      "kind": "untrusted",
+      "value": "{\"sender\":{\"id\":\"1000001\",\"name\":\"Pash\",\"username\":\"pash\"}}"
+    }
+  },
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
   "collaborationMode": {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where authenticated people using the same Codex-backed OpenClaw conversation could ask the agent who they were and receive an identity-less or stale answer. OpenClaw persisted each sender correctly, but the Codex `turn/start` request forwarded only prompt text, so the model did not receive the current sender attribution.

## Why This Change Was Made

The Codex harness now projects the canonical sender metadata from the durable user-turn recorder into Codex's native keyed `additionalContext` field. The context is bounded and marked `untrusted`, which keeps human-controlled names and identifiers model-visible without promoting them to developer instructions or rewriting the user's prompt. It is emitted only for user-triggered turns, so heartbeat and other system automation cannot be mislabeled as a human speaker.

This is intentionally scoped to the Codex app-server boundary; the embedded runtime already projects persisted sender attribution correctly.

AI-assisted implementation; the code path, upstream Codex contract, tests, and final diff were reviewed directly.

## User Impact

Codex-backed agents can distinguish the current authenticated person across successive turns in a shared or resumed conversation. Switching from one user to another updates the model-visible identity on the next turn instead of leaving the agent unaware of who is speaking.

## Evidence

- Pre-fix regression: two successive users on one resumed Codex thread produced `undefined` current-sender context for both `turn/start` requests.
- Post-fix regression: the same thread sends distinct bounded `openclaw_current_sender` entries for Ada and Grace.
- Gateway attribution proof:
  - `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat-b.test.ts -t "chat.send persists optional connection identity per turn"`
  - 1 passed, 93 skipped.
- Codex model-boundary proof:
  - `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t "sends the current recorded sender on successive turns of one resumed Codex thread"`
  - 1 passed, 126 skipped.
- Prompt contract proof:
  - `node --import tsx scripts/generate-prompt-snapshots.ts --check`
  - All 7 snapshots current; Telegram direct and Discord group record the sender context, while the heartbeat snapshot remains identity-free.
- Full changed-surface gate:
  - `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/check-changed.mjs -- extensions/codex/src/app-server/protocol.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/turn-params.ts test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md`
  - Passed snapshot drift, formatting, extension and test typechecks, oxlint, plugin boundaries/API baseline, dead-export scan, database/media/sidecar guards, and import-cycle checks.
- Upstream contract inspected directly:
  - `codex-rs/app-server-protocol/src/protocol/v2/turn.rs`
  - `codex-rs/app-server/src/request_processors/turn_processor.rs`
  - `codex-rs/core/src/state/additional_context.rs`
- Final Codex autoreview: clean, no accepted/actionable findings.

Production LOC: +44/-0 | Tests/snapshots: +96/-0. The production growth adds the previously missing model-context capability and its bounded trust boundary.
