### PR TITLE
fix(cloud-workers): preserve reclaim teardown failures

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -19,7 +19,6 @@ import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "../../plugin-sdk/message-tool-d
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import { hasControlCommand } from "../command-detection.js";
 import { runReplyAgent } from "./agent-runner.runtime.js";
-import { applySessionHints } from "./body.js";
 import {
   loadAgentRunnerRuntime,
   loadEmbeddedAgentRuntime,

--- a/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
@@ -65,9 +65,16 @@ describe("worker placement dispatch reclaim", () => {
     ]);
   });
 
-  it("reconciles the workspace before destroying and reclaiming an active worker", async () => {
-    const harness = createHarness(placementStore);
-    await harness.service.dispatch(REQUEST);
+  it("reclaims an unchanged active placement through the fenced teardown lifecycle", async () => {
+    const harness = createHarness(placementStore, {
+      reconcileChanged: false,
+      reconcileCommitsManifest: false,
+    });
+    await expect(harness.service.dispatch(REQUEST)).resolves.toMatchObject({
+      state: "active",
+      turnClaim: null,
+      workspaceBaseManifestRef: MANIFEST_REF,
+    });
 
     await expect(
       harness.service.reclaim({
@@ -77,9 +84,11 @@ describe("worker placement dispatch reclaim", () => {
       }),
     ).resolves.toMatchObject({
       state: "reclaimed",
-      workspaceBaseManifestRef: harness.reconciledManifestRef,
+      turnClaim: null,
+      workspaceBaseManifestRef: MANIFEST_REF,
     });
 
+    expect(placementStore.listPendingWorkspaceResults()).toEqual([]);
     expect(harness.log.slice(-11)).toEqual([
       "tunnel:attached",
       "workspace:quiesce",

--- a/src/gateway/worker-environments/placement-dispatch.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch.test.ts
@@ -461,6 +461,30 @@ describe("worker placement dispatch", () => {
     expect(harness.log).toContain("workspace:resume");
   });
 
+  it("preserves a provider destroy failure after teardown owns the stopped tunnel", async () => {
+    const harness = createHarness(placementStore, {
+      destroyFails: true,
+      destroyFailureState: "destroying",
+      resumeFails: true,
+    });
+    const active = await harness.service.dispatch(REQUEST);
+
+    await expect(harness.service.reclaim(REQUEST)).rejects.toThrow("destroy pending");
+
+    expect(harness.environments.get(active.environmentId)).toMatchObject({
+      state: "destroying",
+      ownerEpoch: active.activeOwnerEpoch,
+    });
+    expect(harness.placements.current()).toMatchObject({
+      state: "active",
+      turnClaim: { owner: "worker" },
+    });
+    expect(placementStore.listPendingWorkspaceResults()).toMatchObject([
+      { workspaceAcceptedAtMs: expect.any(Number) },
+    ]);
+    expect(harness.log).not.toContain("workspace:resume");
+  });
+
   it.each<DispatchStage>([
     "barrier",
     "workspace",

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -90,6 +90,19 @@ function requireProvisionedEnvironment(
   };
 }
 
+function isExactAttachedEnvironment(
+  environment: ReturnType<WorkerDispatchEnvironmentService["get"]>,
+  placement: WorkerActiveDispatchPlacement,
+): boolean {
+  return (
+    environment?.environmentId === placement.environmentId &&
+    environment.state === "attached" &&
+    environment.ownerEpoch === placement.activeOwnerEpoch &&
+    environment.attachedSessionIds.length === 1 &&
+    environment.attachedSessionIds[0] === placement.sessionId
+  );
+}
+
 export function createWorkerPlacementDispatchService(options: WorkerPlacementDispatchOptions) {
   const { environments, placements } = options;
   const failure = createPlacementFailureActions({ environments, placements });
@@ -250,13 +263,7 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
           );
         }
         const environment = environments.get(current.environmentId);
-        if (
-          !environment ||
-          environment.state !== "attached" ||
-          environment.ownerEpoch !== current.activeOwnerEpoch ||
-          environment.attachedSessionIds.length !== 1 ||
-          environment.attachedSessionIds[0] !== current.sessionId
-        ) {
+        if (!isExactAttachedEnvironment(environment, current)) {
           throw new Error("Active cloud worker does not match its session placement");
         }
         const journalOwner = {
@@ -432,7 +439,10 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
                   },
                 });
               } finally {
-                if (!destroyed) {
+                if (
+                  !destroyed &&
+                  isExactAttachedEnvironment(environments.get(current.environmentId), current)
+                ) {
                   await quiescence.resume();
                 }
               }


### PR DESCRIPTION
Related: #121262

## What Problem This Solves

Fixes an issue where stopping an active Cloud Worker could lose the actionable provider-destroy failure when teardown had already stopped the tunnel and cleanup attempted an impossible workspace resume.

## Why This Change Was Made

Cleanup authority now follows the current environment state: only a still-attached exact owner may resume quiescence. This also adds the immediate no-turn, unchanged-reclaim regression for the Desktop acceptance lifecycle.

AI-assisted: yes. No agent transcript is included.

## User Impact

Normal unchanged reclaim remains safe. Teardown failures report the provider cause and keep pending-result fences for recovery instead of surfacing a misleading tunnel error.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/worker-environments/placement-dispatch.test.ts src/gateway/worker-environments/placement-dispatch-reclaim.test.ts` — 62 tests passed.
- `./node_modules/.bin/oxfmt --check src/gateway/worker-environments/placement-dispatch.ts src/gateway/worker-environments/placement-dispatch.test.ts src/gateway/worker-environments/placement-dispatch-reclaim.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts` — passed.
- `node scripts/run-oxlint.mjs src/gateway/worker-environments/placement-dispatch.ts src/gateway/worker-environments/placement-dispatch.test.ts src/gateway/worker-environments/placement-dispatch-reclaim.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts` — passed.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` — passed after shared-lock backoff.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo` — passed.
- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Final global Codex autoreview against `origin/main` was clean with no accepted/actionable findings.
- Exact-head CI previously found an unrelated current-main unused import; this PR removes that single dead import line per red-main landing policy. `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.media-only.test.ts` passed 110 tests, and targeted oxlint passed.
- The Cloud Worker rebase was patch-identical: `git range-diff` reported the rebased commit as unchanged.
- Production: +18/-8 (net +10). Tests: +37/-5 (net +32). No public/API, config, schema, protocol, baseline, dependency, docs, or changelog surface changed.

Release-note context: Cloud Worker reclaim now preserves provider teardown failures and recovery fences when tunnel teardown already owns the stopped transport. `CHANGELOG.md` is intentionally unchanged; release generation owns it.
