### PR TITLE
fix(ui): auto-scroll to bottom when switching chat sessions

### DIFF
--- a/ui/src/pages/chat/chat-state-route.ts
+++ b/ui/src/pages/chat/chat-state-route.ts
@@ -247,6 +247,7 @@ export function resetChatStateForRouteSession(
     requestUpdate: false,
   });
   state.resetChatScroll();
+  state.scrollToBottom({ smooth: false });
   // Deliberately no saveRouteSessionSettings here: this runs for every split
   // pane, and only the active pane may write the global sessionKey /
   // lastActiveSessionKey settings (chat-pane applyActiveSessionBindings).


### PR DESCRIPTION
Previously, resetChatStateForRouteSession only called resetChatScroll() which resets internal scroll state but does NOT trigger actual DOM scroll. This caused the chat view to stay at the previous session's scroll position when switching to a different session.

Fix: call scrollToBottom({ smooth: false }) after resetChatScroll() so the view scrolls to the latest content immediately on session switch.

Fixes two related UX issues:
- Switching sessions leaves the view stuck at old scroll position
- New replies in the current session are invisible because the viewport is pinned to the previous session's scroll location

<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->
