### PR TITLE
feat: stream live edit diff progress

### DIFF
--- a/src/agents/embedded-agent-live-edit-diff.test.ts
+++ b/src/agents/embedded-agent-live-edit-diff.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type LiveEditDiffProgressState,
+  updateLiveEditDiffProgress,
+} from "./embedded-agent-live-edit-diff.js";
+
+function toolCallEvent(params: {
+  type?: "toolcall_delta" | "toolcall_end";
+  id: string;
+  name: string;
+  partialJson: string;
+}) {
+  const block = {
+    type: "toolCall",
+    id: params.id,
+    name: params.name,
+    arguments: {},
+    partialJson: params.partialJson,
+  };
+  return {
+    type: params.type ?? "toolcall_delta",
+    contentIndex: 0,
+    partial: { role: "assistant", content: [block] },
+    ...(params.type === "toolcall_end" ? { toolCall: block } : { delta: params.partialJson }),
+  };
+}
+
+describe("updateLiveEditDiffProgress", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps streamed edit counts monotonic, throttled, and scoped to tool completion", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const state = new Map<string, LiveEditDiffProgressState>();
+
+    const first = updateLiveEditDiffProgress(
+      state,
+      toolCallEvent({
+        id: "edit-1",
+        name: "edit",
+        partialJson: '{"edits":[{"oldText":"old\\n',
+      }),
+    );
+    expect(first?.diff).toEqual({ added: 0, removed: 1 });
+
+    vi.setSystemTime(1_100);
+    expect(
+      updateLiveEditDiffProgress(
+        state,
+        toolCallEvent({
+          id: "edit-1",
+          name: "edit",
+          partialJson: '{"edits":[{"oldText":"old\\nline","newText":"new\\n',
+        }),
+      ),
+    ).toBeUndefined();
+
+    vi.setSystemTime(1_250);
+    const second = updateLiveEditDiffProgress(
+      state,
+      toolCallEvent({
+        id: "edit-1",
+        name: "edit",
+        partialJson: '{"edits":[{"oldText":"old\\nline","newText":"new\\nline\\nnext\\n',
+      }),
+    );
+    expect(second?.diff).toEqual({ added: 3, removed: 1 });
+
+    updateLiveEditDiffProgress(
+      state,
+      toolCallEvent({ type: "toolcall_end", id: "edit-1", name: "edit", partialJson: "" }),
+    );
+    expect(state.size).toBe(0);
+  });
+
+  it("counts canonical write and patch arguments but ignores non-edit tools", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2_000);
+    const state = new Map<string, LiveEditDiffProgressState>();
+
+    expect(
+      updateLiveEditDiffProgress(
+        state,
+        toolCallEvent({
+          id: "write-1",
+          name: "write",
+          partialJson: '{"path":"a","content":"one\\ntwo\\n',
+        }),
+      )?.diff,
+    ).toEqual({ added: 2, removed: 0 });
+
+    vi.setSystemTime(2_300);
+    expect(
+      updateLiveEditDiffProgress(
+        state,
+        toolCallEvent({
+          id: "patch-1",
+          name: "apply_patch",
+          partialJson:
+            '{"input":"*** Begin Patch\\n*** Update File: a\\n@@\\n-old\\n+new\\n+next\\n',
+        }),
+      )?.diff,
+    ).toEqual({ added: 2, removed: 1 });
+
+    vi.setSystemTime(2_600);
+    expect(
+      updateLiveEditDiffProgress(
+        state,
+        toolCallEvent({ id: "read-1", name: "read", partialJson: '{"path":"a\\n' }),
+      ),
+    ).toBeUndefined();
+    expect(state.has("read-1")).toBe(false);
+  });
+});

--- a/src/agents/embedded-agent-live-edit-diff.test.ts
+++ b/src/agents/embedded-agent-live-edit-diff.test.ts
@@ -53,6 +53,7 @@ describe("updateLiveEditDiffProgress", () => {
         }),
       ),
     ).toBeUndefined();
+    expect(state.get("edit-1")).toMatchObject({ added: 0, removed: 1 });
 
     vi.setSystemTime(1_250);
     const second = updateLiveEditDiffProgress(

--- a/src/agents/embedded-agent-live-edit-diff.test.ts
+++ b/src/agents/embedded-agent-live-edit-diff.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  type LiveEditDiffProgressState,
-  updateLiveEditDiffProgress,
-} from "./embedded-agent-live-edit-diff.js";
+import { updateLiveEditDiffProgress } from "./embedded-agent-live-edit-diff.js";
 
 function toolCallEvent(params: {
   type?: "toolcall_delta" | "toolcall_end";
@@ -33,7 +30,7 @@ describe("updateLiveEditDiffProgress", () => {
   it("keeps streamed edit counts monotonic, throttled, and scoped to tool completion", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);
-    const state = new Map<string, LiveEditDiffProgressState>();
+    const state = new Map();
 
     const first = updateLiveEditDiffProgress(
       state,
@@ -78,7 +75,7 @@ describe("updateLiveEditDiffProgress", () => {
   it("counts canonical write and patch arguments but ignores non-edit tools", () => {
     vi.useFakeTimers();
     vi.setSystemTime(2_000);
-    const state = new Map<string, LiveEditDiffProgressState>();
+    const state = new Map();
 
     expect(
       updateLiveEditDiffProgress(

--- a/src/agents/embedded-agent-live-edit-diff.ts
+++ b/src/agents/embedded-agent-live-edit-diff.ts
@@ -1,0 +1,191 @@
+import { parseStreamingJson } from "@openclaw/ai/internal/runtime";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+
+const LIVE_EDIT_DIFF_MIN_INTERVAL_MS = 250;
+const LIVE_EDIT_DIFF_MAX_PARTIAL_JSON_CHARS = 1024 * 1024;
+const LIVE_EDIT_DIFF_MAX_TRACKED_CALLS = 64;
+
+export type LiveEditToolKind = "write" | "edit" | "patch";
+
+export type LiveEditDiffProgressState = {
+  added: number;
+  removed: number;
+  emittedAdded: number;
+  emittedRemoved: number;
+  lastEmittedAtMs: number;
+};
+
+export type LiveEditDiffProgress = {
+  toolCallId: string;
+  name: string;
+  diff: { added: number; removed: number };
+};
+
+/** Classify the canonical file tools shared by live progress and patch summaries. */
+export function resolveLiveEditToolKind(toolName: string): LiveEditToolKind | undefined {
+  switch (normalizeLowercaseStringOrEmpty(toolName)) {
+    case "write":
+      return "write";
+    case "edit":
+      return "edit";
+    case "apply_patch":
+      return "patch";
+    default:
+      return undefined;
+  }
+}
+
+function countNewlines(value: unknown): number {
+  if (typeof value !== "string") {
+    return 0;
+  }
+  let count = 0;
+  for (let index = value.indexOf("\n"); index >= 0; index = value.indexOf("\n", index + 1)) {
+    count += 1;
+  }
+  return count;
+}
+
+function countEditLines(args: Record<string, unknown>): { added: number; removed: number } {
+  const replacements = Array.isArray(args.edits) ? args.edits : [args];
+  let added = 0;
+  let removed = 0;
+  for (const replacement of replacements) {
+    if (!replacement || typeof replacement !== "object" || Array.isArray(replacement)) {
+      continue;
+    }
+    const record = replacement as Record<string, unknown>;
+    added += countNewlines(record.newText ?? record.new_string);
+    removed += countNewlines(record.oldText ?? record.old_string);
+  }
+  return { added, removed };
+}
+
+function countPatchLines(patch: unknown): { added: number; removed: number } {
+  if (typeof patch !== "string") {
+    return { added: 0, removed: 0 };
+  }
+  let added = 0;
+  let removed = 0;
+  let lineStart = 0;
+  for (let lineEnd = patch.indexOf("\n"); lineEnd >= 0; lineEnd = patch.indexOf("\n", lineStart)) {
+    if (patch[lineStart] === "+") {
+      added += 1;
+    } else if (patch[lineStart] === "-") {
+      removed += 1;
+    }
+    lineStart = lineEnd + 1;
+  }
+  return { added, removed };
+}
+
+function countLiveEditDiff(
+  kind: LiveEditToolKind,
+  args: Record<string, unknown>,
+): { added: number; removed: number } {
+  if (kind === "write") {
+    return { added: countNewlines(args.content), removed: 0 };
+  }
+  if (kind === "edit") {
+    return countEditLines(args);
+  }
+  return countPatchLines(args.input ?? args.patch);
+}
+
+function readToolCallBlock(event: Record<string, unknown>): Record<string, unknown> | undefined {
+  const contentIndex = event.contentIndex;
+  const partial = event.partial;
+  if (
+    typeof contentIndex !== "number" ||
+    !Number.isInteger(contentIndex) ||
+    contentIndex < 0 ||
+    !partial ||
+    typeof partial !== "object"
+  ) {
+    return undefined;
+  }
+  const content = (partial as { content?: unknown }).content;
+  const block = Array.isArray(content) ? content[contentIndex] : undefined;
+  return block && typeof block === "object" && !Array.isArray(block)
+    ? (block as Record<string, unknown>)
+    : undefined;
+}
+
+function readToolCallId(event: Record<string, unknown>): string | undefined {
+  const toolCall = event.toolCall;
+  if (toolCall && typeof toolCall === "object" && !Array.isArray(toolCall)) {
+    const id = (toolCall as Record<string, unknown>).id;
+    if (typeof id === "string" && id) {
+      return id;
+    }
+  }
+  const block = readToolCallBlock(event);
+  return typeof block?.id === "string" && block.id ? block.id : undefined;
+}
+
+/** Update one run's bounded best-effort diff counters from a model stream event. */
+export function updateLiveEditDiffProgress(
+  stateByToolCallId: Map<string, LiveEditDiffProgressState>,
+  event: Record<string, unknown> | undefined,
+): LiveEditDiffProgress | undefined {
+  if (!event) {
+    return undefined;
+  }
+  const eventType = event.type;
+  if (eventType === "toolcall_end") {
+    const toolCallId = readToolCallId(event);
+    if (toolCallId) {
+      stateByToolCallId.delete(toolCallId);
+    }
+    return undefined;
+  }
+  if (eventType !== "toolcall_delta") {
+    return undefined;
+  }
+
+  const block = readToolCallBlock(event);
+  const toolCallId = typeof block?.id === "string" ? block.id : "";
+  const name = typeof block?.name === "string" ? block.name : "";
+  const kind = resolveLiveEditToolKind(name);
+  const partialJson = typeof block?.partialJson === "string" ? block.partialJson : "";
+  if (!toolCallId || !kind || !partialJson) {
+    return undefined;
+  }
+  if (partialJson.length > LIVE_EDIT_DIFF_MAX_PARTIAL_JSON_CHARS) {
+    stateByToolCallId.delete(toolCallId);
+    return undefined;
+  }
+
+  let progress = stateByToolCallId.get(toolCallId);
+  if (!progress) {
+    if (stateByToolCallId.size >= LIVE_EDIT_DIFF_MAX_TRACKED_CALLS) {
+      return undefined;
+    }
+    progress = { added: 0, removed: 0, emittedAdded: 0, emittedRemoved: 0, lastEmittedAtMs: 0 };
+    stateByToolCallId.set(toolCallId, progress);
+  }
+
+  const counted = countLiveEditDiff(kind, parseStreamingJson(partialJson));
+  // Streaming parses are best effort. Never move a visible counter backwards if
+  // an incomplete JSON boundary temporarily exposes less of the same arguments.
+  progress.added = Math.max(progress.added, counted.added);
+  progress.removed = Math.max(progress.removed, counted.removed);
+  if (progress.added === progress.emittedAdded && progress.removed === progress.emittedRemoved) {
+    return undefined;
+  }
+  const now = Date.now();
+  if (
+    progress.lastEmittedAtMs > 0 &&
+    now - progress.lastEmittedAtMs < LIVE_EDIT_DIFF_MIN_INTERVAL_MS
+  ) {
+    return undefined;
+  }
+  progress.emittedAdded = progress.added;
+  progress.emittedRemoved = progress.removed;
+  progress.lastEmittedAtMs = now;
+  return {
+    toolCallId,
+    name: normalizeLowercaseStringOrEmpty(name),
+    diff: { added: progress.added, removed: progress.removed },
+  };
+}

--- a/src/agents/embedded-agent-live-edit-diff.ts
+++ b/src/agents/embedded-agent-live-edit-diff.ts
@@ -12,7 +12,7 @@ type LiveEditDiffProgressState = {
   removed: number;
   emittedAdded: number;
   emittedRemoved: number;
-  lastEmittedAtMs: number;
+  lastCheckedAtMs: number;
 };
 
 type LiveEditDiffProgress = {
@@ -161,10 +161,20 @@ export function updateLiveEditDiffProgress(
     if (stateByToolCallId.size >= LIVE_EDIT_DIFF_MAX_TRACKED_CALLS) {
       return undefined;
     }
-    progress = { added: 0, removed: 0, emittedAdded: 0, emittedRemoved: 0, lastEmittedAtMs: 0 };
+    progress = { added: 0, removed: 0, emittedAdded: 0, emittedRemoved: 0, lastCheckedAtMs: 0 };
     stateByToolCallId.set(toolCallId, progress);
   }
 
+  const now = Date.now();
+  if (
+    progress.lastCheckedAtMs > 0 &&
+    now - progress.lastCheckedAtMs < LIVE_EDIT_DIFF_MIN_INTERVAL_MS
+  ) {
+    return undefined;
+  }
+  // Parsing is the expensive part. Rate-limit it before touching cumulative JSON
+  // so fragmented large arguments cannot create quadratic work on the event path.
+  progress.lastCheckedAtMs = now;
   const counted = countLiveEditDiff(kind, parseStreamingJson(partialJson));
   // Streaming parses are best effort. Never move a visible counter backwards if
   // an incomplete JSON boundary temporarily exposes less of the same arguments.
@@ -173,16 +183,8 @@ export function updateLiveEditDiffProgress(
   if (progress.added === progress.emittedAdded && progress.removed === progress.emittedRemoved) {
     return undefined;
   }
-  const now = Date.now();
-  if (
-    progress.lastEmittedAtMs > 0 &&
-    now - progress.lastEmittedAtMs < LIVE_EDIT_DIFF_MIN_INTERVAL_MS
-  ) {
-    return undefined;
-  }
   progress.emittedAdded = progress.added;
   progress.emittedRemoved = progress.removed;
-  progress.lastEmittedAtMs = now;
   return {
     toolCallId,
     name: normalizeLowercaseStringOrEmpty(name),

--- a/src/agents/embedded-agent-live-edit-diff.ts
+++ b/src/agents/embedded-agent-live-edit-diff.ts
@@ -5,9 +5,9 @@ const LIVE_EDIT_DIFF_MIN_INTERVAL_MS = 250;
 const LIVE_EDIT_DIFF_MAX_PARTIAL_JSON_CHARS = 1024 * 1024;
 const LIVE_EDIT_DIFF_MAX_TRACKED_CALLS = 64;
 
-export type LiveEditToolKind = "write" | "edit" | "patch";
+type LiveEditToolKind = "write" | "edit" | "patch";
 
-export type LiveEditDiffProgressState = {
+type LiveEditDiffProgressState = {
   added: number;
   removed: number;
   emittedAdded: number;
@@ -15,7 +15,7 @@ export type LiveEditDiffProgressState = {
   lastEmittedAtMs: number;
 };
 
-export type LiveEditDiffProgress = {
+type LiveEditDiffProgress = {
   toolCallId: string;
   name: string;
   diff: { added: number; removed: number };

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -67,6 +67,7 @@ export function handleAgentEnd(
   ctx: EmbeddedAgentSubscribeContext,
   evt?: Extract<AgentSessionEvent, { type: "agent_end" }>,
 ): void | Promise<void> {
+  ctx.state.liveEditDiffStateById.clear();
   type BeforeTerminalDeliveryDecision = void | { suppressTerminalDelivery?: boolean };
   const lastAssistant = ctx.state.lastAssistant;
   const isError = isAssistantMessage(lastAssistant) && lastAssistant.stopReason === "error";

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -67,7 +67,7 @@ export function handleAgentEnd(
   ctx: EmbeddedAgentSubscribeContext,
   evt?: Extract<AgentSessionEvent, { type: "agent_end" }>,
 ): void | Promise<void> {
-  ctx.state.liveEditDiffStateById.clear();
+  ctx.state.liveEditDiffStateById?.clear();
   type BeforeTerminalDeliveryDecision = void | { suppressTerminalDelivery?: boolean };
   const lastAssistant = ctx.state.lastAssistant;
   const isError = isAssistantMessage(lastAssistant) && lastAssistant.stopReason === "error";

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -14,6 +14,7 @@ import {
 } from "../auto-reply/reply/reply-directives.js";
 import { splitTrailingDirective } from "../auto-reply/reply/streaming-directives.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { emitAgentEvent } from "../infra/agent-events.js";
 import type { AssistantMessage } from "../llm/types.js";
 import { splitMediaFromOutput } from "../media/parse.js";
 import { coerceChatContentText } from "../shared/chat-content.js";
@@ -26,6 +27,7 @@ import {
   isMessagingToolDuplicateNormalized,
   normalizeTextForComparison,
 } from "./embedded-agent-helpers.js";
+import { updateLiveEditDiffProgress } from "./embedded-agent-live-edit-diff.js";
 import type { BlockReplyPayload } from "./embedded-agent-payloads.js";
 import { runBestEffortCallback } from "./embedded-agent-subscribe.callback.js";
 import type {
@@ -815,6 +817,16 @@ export function handleMessageUpdate(
       ? (assistantEvent as Record<string, unknown>)
       : undefined;
   const evtType = typeof assistantRecord?.type === "string" ? assistantRecord.type : "";
+  const liveEditDiff = updateLiveEditDiffProgress(ctx.state.liveEditDiffStateById, assistantRecord);
+  if (liveEditDiff) {
+    const data = { phase: "input_delta", ...liveEditDiff };
+    emitAgentEvent({ runId: ctx.params.runId, stream: "tool", data });
+    runBestEffortCallback({
+      label: "live edit diff agent event",
+      log: ctx.log,
+      callback: () => ctx.params.onAgentEvent?.({ stream: "tool", data }),
+    });
+  }
   const eventAssistantMessage =
     assistantRecord?.partial && typeof assistantRecord.partial === "object"
       ? (assistantRecord.partial as AssistantMessage)

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -52,6 +52,7 @@ import type { ApplyPatchSummary } from "./apply-patch.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import { sanitizeForConsole } from "./console-sanitize.js";
 import { normalizeTextForComparison } from "./embedded-agent-helpers.js";
+import { resolveLiveEditToolKind } from "./embedded-agent-live-edit-diff.js";
 import {
   isDeliveredMessageToolOnlySourceReplyResult,
   isDeliveredMessagingToolResult,
@@ -448,10 +449,6 @@ function buildToolItemTitle(toolName: string, meta?: string): string {
 
 function isExecToolName(toolName: string): boolean {
   return toolName === "exec" || toolName === "bash";
-}
-
-function isPatchToolName(toolName: string): boolean {
-  return toolName === "apply_patch";
 }
 
 function buildCommandItemId(toolCallId: string): string {
@@ -1087,6 +1084,7 @@ export function handleToolExecutionStart(
   },
 ): void | Promise<void> {
   const startToolName = normalizeToolName(evt.toolName);
+  ctx.state.liveEditDiffStateById?.delete(evt.toolCallId);
   const askUserPromptReservation =
     startToolName === "ask_user" && ctx.params.onToolResult
       ? buildAskUserPromptPayload(evt.toolCallId, ctx.params.sessionKey, ctx.params.runId, evt.args)
@@ -1266,7 +1264,7 @@ export function handleToolExecutionStart(
         toolCallId,
         startedAt,
       });
-    } else if (isPatchToolName(toolName)) {
+    } else if (resolveLiveEditToolKind(toolName) === "patch") {
       emitTrackedItemEvent(ctx, {
         itemId: buildPatchItemId(toolCallId),
         phase: "start",
@@ -1484,6 +1482,7 @@ export async function handleToolExecutionEnd(
   const toolName = normalizeToolName(rawToolName);
   const hideFromChannelProgress = evt.hideFromChannelProgress === true;
   const toolCallId = evt.toolCallId;
+  ctx.state.liveEditDiffStateById?.delete(toolCallId);
   if (toolName === "ask_user") {
     cancelAskUserPromptDelivery(toolCallId, ctx.params.sessionKey, ctx.params.runId);
   }
@@ -1921,7 +1920,7 @@ export async function handleToolExecutionEnd(
     }
   }
 
-  if (isPatchToolName(toolName)) {
+  if (resolveLiveEditToolKind(toolName) === "patch") {
     const patchSummary = readApplyPatchSummary(sanitizedResult);
     const patchItemId = buildPatchItemId(toolCallId);
     const summaryText = patchSummary ? buildPatchSummaryText(patchSummary) : undefined;

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -91,7 +91,7 @@ export type EmbeddedAgentSubscribeState = {
       removed: number;
       emittedAdded: number;
       emittedRemoved: number;
-      lastEmittedAtMs: number;
+      lastCheckedAtMs: number;
     }
   >;
   itemActiveIds: Set<string>;

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -13,6 +13,7 @@ import type { HookRunner } from "../plugins/hooks.js";
 import type { AssistantPhase } from "../shared/chat-message-content.js";
 import type { AcceptedSessionSpawn } from "./accepted-session-spawn.js";
 import type { EmbeddedBlockChunker } from "./embedded-agent-block-chunker.js";
+import type { LiveEditDiffProgressState } from "./embedded-agent-live-edit-diff.js";
 import type {
   MessagingToolSend,
   MessagingToolSourceReplyPayload,
@@ -84,6 +85,7 @@ export type EmbeddedAgentSubscribeState = {
   toolMetaById: Map<string, ToolCallSummary>;
   toolSummaryById: Set<string>;
   execLiveUpdateStateById?: Map<string, { lastEmittedAtMs: number }>;
+  liveEditDiffStateById: Map<string, LiveEditDiffProgressState>;
   itemActiveIds: Set<string>;
   itemStartedCount: number;
   itemCompletedCount: number;
@@ -353,7 +355,9 @@ type ToolHandlerState = Pick<
   | "deterministicApprovalPromptSent"
   | "toolExecutionSinceLastBlockReply"
   | "assistantMessageIndex"
->;
+> & {
+  liveEditDiffStateById?: EmbeddedAgentSubscribeState["liveEditDiffStateById"];
+};
 
 export type ToolHandlerContext = {
   params: ToolHandlerParams;

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -13,7 +13,6 @@ import type { HookRunner } from "../plugins/hooks.js";
 import type { AssistantPhase } from "../shared/chat-message-content.js";
 import type { AcceptedSessionSpawn } from "./accepted-session-spawn.js";
 import type { EmbeddedBlockChunker } from "./embedded-agent-block-chunker.js";
-import type { LiveEditDiffProgressState } from "./embedded-agent-live-edit-diff.js";
 import type {
   MessagingToolSend,
   MessagingToolSourceReplyPayload,
@@ -85,7 +84,16 @@ export type EmbeddedAgentSubscribeState = {
   toolMetaById: Map<string, ToolCallSummary>;
   toolSummaryById: Set<string>;
   execLiveUpdateStateById?: Map<string, { lastEmittedAtMs: number }>;
-  liveEditDiffStateById: Map<string, LiveEditDiffProgressState>;
+  liveEditDiffStateById: Map<
+    string,
+    {
+      added: number;
+      removed: number;
+      emittedAdded: number;
+      emittedRemoved: number;
+      lastEmittedAtMs: number;
+    }
+  >;
   itemActiveIds: Set<string>;
   itemStartedCount: number;
   itemCompletedCount: number;

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -1104,6 +1104,52 @@ describe("subscribeEmbeddedAgentSession", () => {
     emitAgentEventSpy.mockRestore();
   });
 
+  it("emits live edit diff progress while tool arguments stream", () => {
+    const emitAgentEventSpy = vi.spyOn(agentEvents, "emitAgentEvent").mockImplementation(() => {});
+    const { emit } = createSubscribedHarness({ runId: "run-live-edit-diff" });
+    const partialJson =
+      '{"path":"notes.md","edits":[{"oldText":"old\\nline","newText":"new\\nline\\n';
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "tool-live-edit",
+          name: "edit",
+          arguments: {},
+          partialJson,
+        },
+      ],
+    };
+
+    emit({
+      type: "message_update",
+      message,
+      assistantMessageEvent: {
+        type: "toolcall_delta",
+        contentIndex: 0,
+        delta: partialJson,
+        partial: message,
+      },
+    });
+
+    expect(
+      emitAgentEventSpy.mock.calls
+        .map(([event]) => event)
+        .find((event) => event.stream === "tool" && event.data?.phase === "input_delta"),
+    ).toMatchObject({
+      runId: "run-live-edit-diff",
+      stream: "tool",
+      data: {
+        phase: "input_delta",
+        toolCallId: "tool-live-edit",
+        name: "edit",
+        diff: { added: 2, removed: 1 },
+      },
+    });
+    emitAgentEventSpy.mockRestore();
+  });
+
   it("emits reasoning end once when native and tagged reasoning end overlap", () => {
     const onReasoningEnd = vi.fn();
 

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -207,6 +207,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     acceptedSessionSpawns: [],
     toolMetaById: new Map(),
     toolSummaryById: new Set(),
+    liveEditDiffStateById: new Map(),
     itemActiveIds: new Set(),
     itemStartedCount: 0,
     itemCompletedCount: 0,
@@ -1349,6 +1350,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     toolMetas.length = 0;
     toolMetaById.clear();
     toolSummaryById.clear();
+    state.liveEditDiffStateById.clear();
     state.itemActiveIds.clear();
     state.itemStartedCount = 0;
     state.itemCompletedCount = 0;
@@ -1459,6 +1461,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     // new un-resolvable promises during teardown.
     state.unsubscribed = true;
     cleanupRunToolStartData(params.runId);
+    state.liveEditDiffStateById.clear();
     // Reject pending compaction wait to unblock awaiting code.
     // Don't resolve, as that would incorrectly signal "compaction complete" when it's still in-flight.
     if (state.compactionRetryPromise) {

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -19,7 +19,6 @@ import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "../../plugin-sdk/message-tool-d
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import { hasControlCommand } from "../command-detection.js";
 import { runReplyAgent } from "./agent-runner.runtime.js";
-import { applySessionHints } from "./body.js";
 import {
   loadAgentRunnerRuntime,
   loadEmbeddedAgentRuntime,

--- a/src/gateway/server-chat-progress-snapshot.ts
+++ b/src/gateway/server-chat-progress-snapshot.ts
@@ -25,7 +25,9 @@ export function updateChatRunProgressSnapshot(
         ? data.id.trim()
         : "";
   const isTool =
-    event.stream === "tool" && Boolean(toolCallId) && ["start", "update", "result"].includes(phase);
+    event.stream === "tool" &&
+    Boolean(toolCallId) &&
+    ["start", "input_delta", "update", "result"].includes(phase);
   const isPreamble = event.stream === "item" && data.kind === "preamble";
   if (!isTool && !isPreamble) {
     return snapshot;
@@ -59,7 +61,7 @@ export function updateChatRunProgressSnapshot(
       if (candidate.stream !== "tool" || candidate.data?.toolCallId !== toolCallId) {
         return false;
       }
-      return phase !== "update" || candidate.data?.phase === "update";
+      return phase === "start" || phase === "result" || candidate.data?.phase === phase;
     });
     if (phase === "result") {
       return next;
@@ -81,6 +83,7 @@ export function updateChatRunProgressSnapshot(
         ...(phase === "update" && Object.hasOwn(data, "partialResult")
           ? { partialResult: data.partialResult }
           : {}),
+        ...(phase === "input_delta" && Object.hasOwn(data, "diff") ? { diff: data.diff } : {}),
       }
     : {
         kind: "preamble",

--- a/src/gateway/server-chat-state.test.ts
+++ b/src/gateway/server-chat-state.test.ts
@@ -72,43 +72,54 @@ describe("createChatRunState", () => {
       args: { path: "a" },
     });
     event(3, "tool", {
+      phase: "input_delta",
+      name: "edit",
+      toolCallId: "active",
+      diff: { added: 3, removed: 1 },
+    });
+    event(4, "tool", {
       phase: "update",
       name: "read",
       toolCallId: "active",
       partialResult: "halfway",
     });
-    event(4, "tool", { phase: "start", name: "exec", toolCallId: "done", args: {} });
-    event(5, "tool", {
+    event(5, "tool", { phase: "start", name: "exec", toolCallId: "done", args: {} });
+    event(6, "tool", {
       phase: "result",
       name: "exec",
       toolCallId: "done",
       result: "x".repeat(256_000),
     });
-    event(6, "item", {
+    event(7, "item", {
       kind: "preamble",
       itemId: "p-1",
       progressText: "Inspection complete",
     });
-    event(7, "item", {
+    event(8, "item", {
       kind: "preamble",
       itemId: "p-2",
       progressText: "Running autoreview",
     });
-    event(3, "tool", { phase: "result", name: "read", toolCallId: "active" });
+    event(4, "tool", { phase: "result", name: "read", toolCallId: "active" });
 
     expect(state.runs.get("run-1")?.progressSnapshot?.events).toMatchObject([
       { seq: 2, stream: "tool", data: { phase: "start", toolCallId: "active" } },
-      { seq: 3, stream: "tool", data: { phase: "update", toolCallId: "active" } },
       {
-        seq: 6,
+        seq: 3,
+        stream: "tool",
+        data: { phase: "input_delta", toolCallId: "active", diff: { added: 3, removed: 1 } },
+      },
+      { seq: 4, stream: "tool", data: { phase: "update", toolCallId: "active" } },
+      {
+        seq: 7,
         stream: "item",
         ts: 1_001,
         data: { itemId: "p-1", progressText: "Inspection complete" },
       },
-      { seq: 7, stream: "item", data: { itemId: "p-2", progressText: "Running autoreview" } },
+      { seq: 8, stream: "item", data: { itemId: "p-2", progressText: "Running autoreview" } },
     ]);
 
-    for (let seq = 8; seq <= 70; seq += 1) {
+    for (let seq = 9; seq <= 71; seq += 1) {
       event(seq, "tool", {
         phase: "start",
         name: "read",
@@ -122,7 +133,7 @@ describe("createChatRunState", () => {
     expect(snapshot?.events.at(-1)?.data).toEqual({
       phase: "start",
       name: "read",
-      toolCallId: "tool-70",
+      toolCallId: "tool-71",
     });
   });
 });

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1715,7 +1715,10 @@ describe("agent event handler", () => {
     expect(broadcast).not.toHaveBeenCalled();
     expect(broadcastToConnIds).toHaveBeenCalledTimes(1);
     expectRecordFields(
-      requireRecord(requireMockPayload(broadcastToConnIds, 0, 1, "run tool payload").data),
+      requireRecord(
+        requireMockPayload(broadcastToConnIds, 0, 1, "run tool payload").data,
+        "run tool data",
+      ),
       {
         phase: "input_delta",
         name: "edit",

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1697,7 +1697,7 @@ describe("agent event handler", () => {
     nowSpy.mockRestore();
   });
 
-  it("routes tool events only to registered recipients when verbose is enabled", () => {
+  it("routes live edit diff progress to registered run recipients", () => {
     const { broadcast, broadcastToConnIds, toolEventRecipients, handler } = createHarness({
       resolveSessionKeyForRun: () => "session-1",
     });
@@ -1705,10 +1705,23 @@ describe("agent event handler", () => {
     registerAgentRunContext("run-tool", { sessionKey: "session-1", verboseLevel: "on" });
     toolEventRecipients.add("run-tool", "conn-1");
 
-    emitAgentEvent(handler, "run-tool", "tool", { phase: "start", name: "read", toolCallId: "t1" });
+    emitAgentEvent(handler, "run-tool", "tool", {
+      phase: "input_delta",
+      name: "edit",
+      toolCallId: "t1",
+      diff: { added: 2, removed: 1 },
+    });
 
     expect(broadcast).not.toHaveBeenCalled();
     expect(broadcastToConnIds).toHaveBeenCalledTimes(1);
+    expectRecordFields(
+      requireRecord(requireMockPayload(broadcastToConnIds, 0, 1, "run tool payload").data),
+      {
+        phase: "input_delta",
+        name: "edit",
+        diff: { added: 2, removed: 1 },
+      },
+    );
   });
 
   it("broadcasts tool events to WS recipients even when verbose is off, but skips node send", () => {
@@ -1782,7 +1795,7 @@ describe("agent event handler", () => {
     expect(nodeToolCalls).toHaveLength(1);
   });
 
-  it("mirrors tool events to session subscribers so late-joining operator UIs can render them", () => {
+  it("mirrors live edit diff progress to session subscribers", () => {
     const { broadcastToConnIds, sessionEventSubscribers, handler } = createHarness({
       resolveSessionKeyForRun: () => "session-1",
     });
@@ -1797,10 +1810,10 @@ describe("agent event handler", () => {
       "run-session-tool",
       "tool",
       {
-        phase: "start",
-        name: "exec",
+        phase: "input_delta",
+        name: "edit",
         toolCallId: "tool-session-1",
-        args: { command: "echo hi" },
+        diff: { added: 4, removed: 2 },
       },
       { ts: 1_234 },
     );
@@ -1816,10 +1829,10 @@ describe("agent event handler", () => {
       ts: 1_234,
     });
     expectRecordFields(requireRecord(sessionToolPayload.data, "session tool payload data"), {
-      phase: "start",
-      name: "exec",
+      phase: "input_delta",
+      name: "edit",
       toolCallId: "tool-session-1",
-      args: { command: "echo hi" },
+      diff: { added: 4, removed: 2 },
     });
     expect(requireMockArg(broadcastToConnIds, 0, 2, "session tool recipients")).toEqual(
       new Set(["conn-session"]),

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -693,6 +693,16 @@ describe("task-registry", () => {
       emitAgentEvent({
         runId: "run-tools",
         stream: "tool",
+        data: {
+          phase: "input_delta",
+          name: "edit",
+          toolCallId: "call-streaming",
+          diff: { added: 3, removed: 1 },
+        },
+      });
+      emitAgentEvent({
+        runId: "run-tools",
+        stream: "tool",
         data: { phase: "end", name: "read", toolCallId: "call-1" },
       });
       emitAgentEvent({


### PR DESCRIPTION
## What Problem This Solves

Clients currently receive tool events only after a tool call has complete arguments and begins execution. While a model is still streaming a large file write or edit, they therefore cannot show a running line-count diff and appear idle.

## Why This Change Was Made

The embedded runner now consumes the cumulative partial tool arguments already present on `message_update` events for the canonical `write`, `edit`, and `apply_patch` tools. It emits a bounded, per-tool-call `tool` event with `phase: "input_delta"` and only `{ toolCallId, name, diff: { added, removed } }`; raw argument text never crosses the event boundary. Updates are monotonic and change-only, with cumulative parsing and emission both limited to four times per second and state cleared at stream, execution, retry, unsubscribe, and run boundaries.

Gateway run recipients, `session.tool` subscribers, reconnect snapshots, and task-registry folding preserve the new phase without treating it as a new tool use. Client rendering follows in later PRs in this series. CLI-runner coverage is also a stated follow-up; this PR intentionally covers only the embedded runner.

No Gateway protocol schema change is needed: agent-event `data` is already an open record on the wire at `packages/gateway-protocol/src/schema/agent.ts:58`. This PR does not change `ui/`, `apps/`, `packages/gateway-protocol/`, patch-summary output, or the changelog.

## User Impact

Server/runtime clients can now render live edit diff progress while model arguments are still streaming, without receiving file contents or waiting for tool execution to start. Existing clients continue to ignore the additive phase safely until their rendering follow-ups land.

## Evidence

- Pre-fix boundary reproduction: the focused embedded-subscriber test failed because no `input_delta` event reached the agent event bus.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-live-edit-diff.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts src/gateway/server-chat-state.test.ts` — 80 tests passed across the routed agent and Gateway projects.
- `node scripts/run-vitest.mjs src/gateway/server-chat.agent-events.test.ts -t "live edit diff progress"` — 2 passed.
- `node scripts/run-vitest.mjs src/tasks/task-registry.test.ts -t "tracks tool activity from tool-start events"` — 1 passed; `input_delta` did not increment `toolUseCount`.
- `node scripts/check-changed.mjs` — the earlier head exposed unrelated current-main Plugin SDK baseline drift; the landing rebase now includes the canonical repair from #121527.
- Landing-gate repair: latest `main` still imported an unused `applySessionHints` in `src/auto-reply/reply/get-reply-run.media-only.test.ts`; commit `fix(lint): remove unused import breaking main lint` removes that dead import so this PR does not land onto a red merge gate.
- ClawSweeper rank-up moves: applied the hot-path move by gating cumulative parsing before the 250 ms interval and extended the fake-timer regression to prove counters do not advance inside that window. Skipped counting non-newline-terminated trailing text because the frozen event contract intentionally reports newline counts as best-effort progress and does not require a final correction event.
- Autoreview: clean, no accepted/actionable findings.
- Production LOC: +232/-9 (net +223); tests: +216/-20 (net +196). Production growth is the bounded parser/counter lifecycle and Gateway replay support for the new runtime capability.

AI-assisted: yes. I reviewed the implementation and evidence.
