### PR TITLE
fix: exec approvals fail with a pairing prompt when the device pairing lacks operator.approvals

### DIFF
--- a/src/agents/tools/gateway.test.ts
+++ b/src/agents/tools/gateway.test.ts
@@ -328,7 +328,7 @@ describe("gateway tool defaults", () => {
     expect(call.method).toBe("exec.approval.request");
     expect(call.scopes).toEqual(["operator.approvals"]);
     expect(call.approvalRuntimeToken).toEqual(expect.any(String));
-    expect(call.deviceIdentity).toEqual(mocks.deviceIdentity);
+    expect(call).not.toHaveProperty("deviceIdentity");
   });
 
   it.each([
@@ -568,10 +568,10 @@ describe("gateway tool defaults", () => {
     expect(call.method).toBe("exec.approval.waitDecision");
     expect(call.scopes).toEqual(["operator.approvals"]);
     expect(call.approvalRuntimeToken).toEqual(expect.any(String));
-    expect(call.deviceIdentity).toEqual(mocks.deviceIdentity);
+    expect(call).not.toHaveProperty("deviceIdentity");
   });
 
-  it("marks local plugin approval wait calls with runtime and device identity", async () => {
+  it("marks local plugin approval wait calls as approval runtime calls", async () => {
     mocks.callGateway.mockResolvedValueOnce({ decision: "allow-once" });
 
     await callGatewayTool("plugin.approval.waitDecision", {}, { id: "approval-id" });
@@ -580,7 +580,7 @@ describe("gateway tool defaults", () => {
     expect(call.method).toBe("plugin.approval.waitDecision");
     expect(call.scopes).toEqual(["operator.approvals"]);
     expect(call.approvalRuntimeToken).toEqual(expect.any(String));
-    expect(call.deviceIdentity).toEqual(mocks.deviceIdentity);
+    expect(call).not.toHaveProperty("deviceIdentity");
   });
 
   it("attaches trusted turn-source metadata to node invokes", async () => {
@@ -784,7 +784,7 @@ describe("gateway tool defaults", () => {
     expect(mocks.callGateway).toHaveBeenCalledTimes(1);
   });
 
-  it("marks local plugin approval request calls with runtime and device identity", async () => {
+  it("marks local plugin approval request calls as approval runtime calls", async () => {
     mocks.callGateway.mockResolvedValueOnce({ id: "plugin:approval-id" });
 
     await callGatewayTool("plugin.approval.request", {}, { title: "approve", description: "test" });
@@ -793,7 +793,7 @@ describe("gateway tool defaults", () => {
     expect(call.method).toBe("plugin.approval.request");
     expect(call.scopes).toEqual(["operator.approvals"]);
     expect(call.approvalRuntimeToken).toEqual(expect.any(String));
-    expect(call.deviceIdentity).toEqual(mocks.deviceIdentity);
+    expect(call).not.toHaveProperty("deviceIdentity");
   });
 
   it("marks local approval resolve calls as approval runtime calls", async () => {
@@ -809,7 +809,7 @@ describe("gateway tool defaults", () => {
     expect(call.method).toBe("exec.approval.resolve");
     expect(call.scopes).toEqual(["operator.approvals"]);
     expect(call.approvalRuntimeToken).toEqual(expect.any(String));
-    expect(call.deviceIdentity).toEqual(mocks.deviceIdentity);
+    expect(call).not.toHaveProperty("deviceIdentity");
   });
 
   it("does not attach agent provenance to ordinary contextual approval resolutions", async () => {
@@ -875,6 +875,26 @@ describe("gateway tool defaults", () => {
     expect(call).not.toHaveProperty("deviceIdentity");
   });
 
+  it.each([
+    "exec.approval.request",
+    "exec.approval.resolve",
+    "exec.approval.waitDecision",
+    "plugin.approval.request",
+    "plugin.approval.waitDecision",
+  ])("never pairs a requester device identity with the %s runtime token", async (method) => {
+    mocks.callGateway.mockResolvedValueOnce({ ok: true });
+
+    await callGatewayTool(method, {}, { id: "approval-id", decision: "allow-once" });
+
+    const call = capturedGatewayCall();
+    expect(call.approvalRuntimeToken).toEqual(expect.any(String));
+    // Sending both would put the approval bridge back under the shared CLI device's
+    // paired scope baseline. A device paired before operator.approvals existed then
+    // fails the scope-upgrade pairing gate, and the prompt that would re-pair it is
+    // exactly what these calls carry.
+    expect(call).not.toHaveProperty("deviceIdentity");
+  });
+
   it("does not send the local approval runtime token to configured remote gateways", async () => {
     mocks.configState.value = {
       gateway: {
@@ -907,7 +927,7 @@ describe("gateway tool defaults", () => {
     await callGatewayTool("exec.approval.waitDecision", {}, { id: "approval-id" });
 
     const call = capturedGatewayCall();
-    expect(call.deviceIdentity).toEqual(mocks.deviceIdentity);
+    expect(call).not.toHaveProperty("deviceIdentity");
     expect(call.approvalRuntimeToken).toEqual(expect.any(String));
   });
 

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -291,7 +291,7 @@ function resolveApprovalRequesterDeviceIdentityForGatewayTool(params: {
   method: string;
   callParams: unknown;
   opts: GatewayCallOptions;
-  target: GatewayOverrideTarget;
+  approvalRuntimeToken: string | undefined;
 }): DeviceIdentity | undefined {
   const isApprovalRuntimeMethod = APPROVAL_RUNTIME_METHODS.has(params.method);
   const isNodeApprovalReplay = isApprovalReplayNodeSystemRun(params.method, params.callParams);
@@ -299,6 +299,14 @@ function resolveApprovalRequesterDeviceIdentityForGatewayTool(params: {
     return undefined;
   }
   if (isApprovalRuntimeMethod && trimToUndefined(params.opts.gatewayUrl) !== undefined) {
+    return undefined;
+  }
+  if (params.approvalRuntimeToken !== undefined) {
+    // The approval-runtime token already proves this is the local approval bridge, and
+    // the gateway grants record visibility from it. Sending the shared device identity
+    // too would put the connect back under that device's paired role/scope baseline,
+    // so an operator paired before operator.approvals existed can never reach the
+    // prompt that would re-pair it. Same rule as the operator approvals client.
     return undefined;
   }
   try {
@@ -322,9 +330,6 @@ function resolveApprovalRequesterDeviceIdentityForGatewayTool(params: {
         ].join(" "),
         { cause: error },
       );
-    }
-    if (params.target === "local") {
-      return undefined;
     }
     throw new Error(
       [
@@ -536,7 +541,7 @@ export async function callGatewayTool<T = Record<string, unknown>>(
     method,
     callParams,
     opts,
-    target: gateway.target,
+    approvalRuntimeToken,
   });
   const callOptions = {
     url: gateway.url,

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -19,7 +19,6 @@ import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "../../plugin-sdk/message-tool-d
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import { hasControlCommand } from "../command-detection.js";
 import { runReplyAgent } from "./agent-runner.runtime.js";
-import { applySessionHints } from "./body.js";
 import {
   loadAgentRunnerRuntime,
   loadEmbeddedAgentRuntime,


### PR DESCRIPTION
Closes #121525

## What Problem This Solves

Fixes an issue where operators whose local device pairing does not already include `operator.approvals` could not use exec or plugin approvals at all. Every approval prompt the agent tried to raise was rejected at connect with `scope upgrade pending approval` / `pairing required: device is asking for more scopes than currently approved`, and the pairing request that would grant the missing scope is delivered by the very call that was rejected — so the session could not recover on its own. The only ways out were re-pairing the device out of band or patching the client.

Any pairing record created before these methods started requesting `operator.approvals` is in the affected state, so this hits existing installs rather than fresh ones.

## Why This Change Was Made

The agent gateway tool put two mutually exclusive requester credentials on the same connect: the process-local approval-runtime token **and** the shared device identity. The device identity is what pulls the connect back under the paired device's role/scope cap in `connect-existing-device.ts`, so the local approval bridge inherited a baseline it can never satisfy — `requirePairing` forces `silent: false` for `scope-upgrade`, which closes the connect.

The fix makes the two exclusive at the only place that can decide it: the resolved approval-runtime token is passed into the requester-identity resolver, which returns no identity when the token is present. That also removes a now-unreachable local-target branch in the resolver's `catch`.

This is the rule the sibling surface already follows. `createOperatorApprovalsGatewayClient` sends `deviceIdentity: null` whenever it sends the token (`shouldOmitApprovalRuntimeDeviceIdentity` in `src/gateway/operator-approvals-client.ts`), added by #74472 "keep native approvals off stale pairing baselines". This PR applies the same invariant to the agent gateway-tool surface, where `1c28c3914a9` re-introduced the exposure.

Non-goals / boundaries:

- No server-side pairing change. The paired scope cap for local backend reconnects stays exactly as it is; `src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts:205` protects it and still passes.
- Remote, env-selected, and `gatewayUrl`-override approval calls still require a stable device identity and still fail closed without one.
- Approved `node.invoke` `system.run` replay still requires the persisted identity and still fails closed without it.
- Requester binding is not lost: the token is sent under exactly the conditions the identity was attached (approval-runtime method, no `gatewayUrl` override, local target), and when the gateway honors the token, `internal.approvalRuntime` short-circuits approval-record visibility in `src/gateway/server-methods/approval-shared.ts:153` before `requestedByDeviceId` is consulted.

## User Impact

Exec and plugin approval prompts work on a local gateway regardless of which scopes the device pairing was created with. Operators with older pairings no longer have to re-pair before they can approve a command. No configuration change, and no behavior change for remote or URL-overridden gateways.

## Evidence

Before/after on the changed surface — 11 assertions in `src/agents/tools/gateway.test.ts` fail on the pre-fix source and pass with the fix (5 new mutual-exclusion cases, one per `APPROVAL_RUNTIME_METHODS` entry, plus 6 updated expectations):

```
# pre-fix (fix stashed, tests kept)
Tests  11 failed | 46 passed (57)
AssertionError: expected { url: undefined, …(12) } to not have property "deviceIdentity"

# with the fix
pnpm test src/agents/tools/gateway.test.ts
Test Files  1 passed (1)
      Tests  57 passed (57)
```

Sibling approval/pairing surfaces, unchanged and green:

```
pnpm test src/gateway/operator-approvals-client.test.ts \
  src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts \
  src/gateway/call.test.ts src/gateway/exec-approval-manager.test.ts \
  src/gateway/node-invoke-system-run-approval.test.ts \
  src/gateway/server-methods/approval-shared.test.ts \
  src/gateway/server-methods/approval.test.ts \
  src/gateway/server-methods/plugin-approval.test.ts
Test Files  8 passed (8)
      Tests  360 passed (360)
```

Callers that route approvals through `callGatewayTool`:

```
pnpm test src/agents/bash-tools.exec-approval-followup.test.ts \
  src/agents/bash-tools.exec-approval-request.test.ts \
  src/agents/bash-tools.exec.approval-id.test.ts \
  src/agents/cli-runner/claude-live-tool-approval.test.ts \
  src/agents/harness/native-hook-relay.approval-binding.test.ts \
  src/agents/harness/native-hook-relay.approval-wait.test.ts
Tests  83 passed (83)   # agents-core shard
Tests  27 passed (27)   # agents-support shard
```

Gates:

- `node scripts/check-changed.mjs -- src/agents/tools/gateway.ts src/agents/tools/gateway.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts` → `exit=0` (rerun on the rebased base, all three changed files; delegated to Blacksmith Testbox lease `tbx_01kznevbmcf0p21r5fq0zy29m5`, 10m59s, `runStatus: succeeded`)
- `pnpm tsgo:core` → exit 0; `pnpm tsgo:test:src` → exit 0
- `oxfmt` clean on both files; `node scripts/run-oxlint.mjs` clean; `git diff --check` clean
- `autoreview --mode uncommitted` (codex `gpt-5.6-sol`, high) → `autoreview clean: no accepted/actionable findings reported`, `overall: patch is correct (0.98)`

Re-verified after rebasing onto `c9d39979f27`: `pnpm test src/agents/tools/gateway.test.ts` → `57 passed (57)`.

Known proof gap: no live-gateway repro is included. The deadlock itself is established by reading the connect path (`connect-device-pairing.ts` → `connect-existing-device.ts:111-121`) plus the mutual-exclusion assertions above; the equivalent live-server proof for the sibling surface already exists at `src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts:312`. A live-server test for this surface was deliberately not added to that gateway-lane file, because an assertion owned by `src/agents/tools/` living in the gateway suite would not be selected by PR change classification for changes to this file.

