### PR TITLE
fix(cron): reject blank/invalid --webhook before delivery.mode flip

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -771,6 +771,23 @@ describe("cron cli", () => {
     });
   });
 
+  it.each(["", "not-a-url"])("rejects invalid cron add --webhook %j", async (value) => {
+    await expectCronCommandExit([
+      "cron",
+      "add",
+      "Webhook reminder",
+      "--at",
+      "20m",
+      "--system-event",
+      "Summarize the latest status",
+      "--webhook",
+      value,
+    ]);
+
+    expectRuntimeErrorContaining("--webhook must be a valid http(s) URL");
+    expect(callGatewayFromCli).not.toHaveBeenCalled();
+  });
+
   it("accepts Hermes-style positional cron schedule and message on cron create", async () => {
     const params = await runCronAddAndGetParams([
       "0 2 * * *",

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -8,6 +8,7 @@ import type { Command } from "commander";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { THINKING_LEVELS_HELP } from "../../auto-reply/thinking.shared.js";
 import type { CronJob } from "../../cron/types.js";
+import { normalizeHttpWebhookUrl } from "../../cron/webhook-url.js";
 import { sanitizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
@@ -203,8 +204,12 @@ export function registerCronAddCommand(cron: Command) {
 
             const hasAnnounce = Boolean(opts.announce) || opts.deliver === true;
             const hasNoDeliver = opts.deliver === false;
-            const webhookUrl = normalizeOptionalString(opts.webhook);
-            const hasWebhook = typeof opts.webhook === "string";
+            const webhookUrl =
+              typeof opts.webhook === "string" ? normalizeHttpWebhookUrl(opts.webhook) : null;
+            if (typeof opts.webhook === "string" && !webhookUrl) {
+              throw new Error("--webhook must be a valid http(s) URL");
+            }
+            const hasWebhook = Boolean(webhookUrl);
             const deliveryFlagCount = [hasAnnounce, hasNoDeliver, hasWebhook].filter(
               Boolean,
             ).length;

--- a/src/cli/cron-cli/register.cron-edit-options.ts
+++ b/src/cli/cron-cli/register.cron-edit-options.ts
@@ -1,7 +1,6 @@
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { CronJob } from "../../cron/types.js";
-import { normalizeHttpWebhookUrl } from "../../cron/webhook-url.js";
 import {
   parseCronCommandArgv,
   parseCronCommandEnv,
@@ -25,6 +24,7 @@ const assignIf = (
 export async function resolveCronEditPayloadDeliveryPatch(
   opts: Record<string, unknown>,
   loadExistingJob: () => Promise<CronJob>,
+  webhookUrl: string | undefined,
 ): Promise<Record<string, unknown>> {
   const patch: Record<string, unknown> = {};
   const hasSystemEventPatch = typeof opts.systemEvent === "string";
@@ -87,14 +87,6 @@ export async function resolveCronEditPayloadDeliveryPatch(
     throw new Error("Invalid --script-tool-budget (must be a positive integer).");
   }
 
-  // Presence alone is not enough: blank/malformed --webhook used to flip
-  // delivery.mode to "webhook" with no URL (gateway then rejects after merge
-  // cleared the previous chat destination). Align with normalizeHttpWebhookUrl.
-  const webhookUrl =
-    typeof opts.webhook === "string" ? normalizeHttpWebhookUrl(opts.webhook) : null;
-  if (typeof opts.webhook === "string" && !webhookUrl) {
-    throw new Error("--webhook must be a valid http(s) URL");
-  }
   const hasWebhookDelivery = Boolean(webhookUrl);
   const hasDeliveryModeFlag =
     opts.announce || typeof opts.deliver === "boolean" || hasWebhookDelivery;

--- a/src/cli/cron-cli/register.cron-edit-options.ts
+++ b/src/cli/cron-cli/register.cron-edit-options.ts
@@ -1,6 +1,7 @@
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { CronJob } from "../../cron/types.js";
+import { normalizeHttpWebhookUrl } from "../../cron/webhook-url.js";
 import {
   parseCronCommandArgv,
   parseCronCommandEnv,
@@ -86,7 +87,15 @@ export async function resolveCronEditPayloadDeliveryPatch(
     throw new Error("Invalid --script-tool-budget (must be a positive integer).");
   }
 
-  const hasWebhookDelivery = typeof opts.webhook === "string";
+  // Presence alone is not enough: blank/malformed --webhook used to flip
+  // delivery.mode to "webhook" with no URL (gateway then rejects after merge
+  // cleared the previous chat destination). Align with normalizeHttpWebhookUrl.
+  const webhookUrl =
+    typeof opts.webhook === "string" ? normalizeHttpWebhookUrl(opts.webhook) : null;
+  if (typeof opts.webhook === "string" && !webhookUrl) {
+    throw new Error("--webhook must be a valid http(s) URL");
+  }
+  const hasWebhookDelivery = Boolean(webhookUrl);
   const hasDeliveryModeFlag =
     opts.announce || typeof opts.deliver === "boolean" || hasWebhookDelivery;
   const threadId = parseCronThreadIdOption(opts.threadId);
@@ -272,8 +281,7 @@ export async function resolveCronEditPayloadDeliveryPatch(
       delivery.channel = channel ? channel : undefined;
     }
     if (hasWebhookDelivery) {
-      const webhook = normalizeOptionalString(opts.webhook) ?? "";
-      delivery.to = webhook ? webhook : undefined;
+      delivery.to = webhookUrl;
     } else if (opts.clearTo) {
       delivery.to = null;
     } else if (typeof opts.to === "string") {

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -1040,25 +1040,8 @@ describe("cron edit command", () => {
     exitSpy.mockRestore();
   });
 
-  it.each([
-    ["", "empty"],
-    ["   ", "whitespace"],
-    ["not-a-url", "malformed"],
-    ["ftp://example.invalid/hook", "non-http"],
-  ])("rejects blank/invalid --webhook (%s) before gateway RPC", async (value) => {
-    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
-    const program = createCronProgram();
-
-    await program.parseAsync(["edit", "job-1", "--webhook", value], { from: "user" });
-
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("--webhook must be a valid http(s) URL"),
-    );
-    expect(callGatewayFromCli).not.toHaveBeenCalled();
-
-    errorSpy.mockRestore();
-    exitSpy.mockRestore();
+  it.each(["", "not-a-url"])("rejects invalid --webhook %j before gateway RPC", async (value) => {
+    await expectCronEditRejection(["--webhook", value], "--webhook must be a valid http(s) URL");
   });
 
   it("documents the delivery clear flags alongside the sibling --clear-model", () => {

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -1040,6 +1040,27 @@ describe("cron edit command", () => {
     exitSpy.mockRestore();
   });
 
+  it.each([
+    ["", "empty"],
+    ["   ", "whitespace"],
+    ["not-a-url", "malformed"],
+    ["ftp://example.invalid/hook", "non-http"],
+  ])("rejects blank/invalid --webhook (%s) before gateway RPC", async (value) => {
+    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
+    const program = createCronProgram();
+
+    await program.parseAsync(["edit", "job-1", "--webhook", value], { from: "user" });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("--webhook must be a valid http(s) URL"),
+    );
+    expect(callGatewayFromCli).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
   it("documents the delivery clear flags alongside the sibling --clear-model", () => {
     const editCommand = createCronProgram().commands.find((command) => command.name() === "edit");
     const help = editCommand?.helpInformation() ?? "";

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -7,6 +7,7 @@ import {
 import type { Command } from "commander";
 import { THINKING_LEVELS_HELP } from "../../auto-reply/thinking.shared.js";
 import type { CronJob } from "../../cron/types.js";
+import { normalizeHttpWebhookUrl } from "../../cron/webhook-url.js";
 import { danger } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { sanitizeAgentId } from "../../routing/session-key.js";
@@ -221,7 +222,12 @@ export function registerCronEditCommand(cron: Command) {
               "--channel, --to, --account, and --thread-id require a non-main agentTurn or command job with delivery.",
             );
           }
-          const hasWebhookDelivery = typeof opts.webhook === "string";
+          const webhookUrl =
+            typeof opts.webhook === "string" ? normalizeHttpWebhookUrl(opts.webhook) : null;
+          if (typeof opts.webhook === "string" && !webhookUrl) {
+            throw new Error("--webhook must be a valid http(s) URL");
+          }
+          const hasWebhookDelivery = Boolean(webhookUrl);
           const deliveryModeFlagCount = [
             Boolean(opts.announce),
             typeof opts.deliver === "boolean",

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -223,7 +223,9 @@ export function registerCronEditCommand(cron: Command) {
             );
           }
           const webhookUrl =
-            typeof opts.webhook === "string" ? normalizeHttpWebhookUrl(opts.webhook) : null;
+            typeof opts.webhook === "string"
+              ? (normalizeHttpWebhookUrl(opts.webhook) ?? undefined)
+              : undefined;
           if (typeof opts.webhook === "string" && !webhookUrl) {
             throw new Error("--webhook must be a valid http(s) URL");
           }
@@ -419,7 +421,7 @@ export function registerCronEditCommand(cron: Command) {
 
           Object.assign(
             patch,
-            await resolveCronEditPayloadDeliveryPatch(opts, readExistingCronJob),
+            await resolveCronEditPayloadDeliveryPatch(opts, readExistingCronJob, webhookUrl),
           );
 
           const hasFailureAlertAfter = typeof opts.failureAlertAfter === "string";


### PR DESCRIPTION
Closes #121530

## What Problem This Solves

Cron add/edit treated any string-valued `--webhook` as a delivery-mode request. Blank, whitespace, malformed, and non-HTTP values therefore reached the Gateway instead of producing the CLI's specific URL error.

The authoritative Gateway path was inspected end-to-end: it validates the cloned update before persistence and repeats validation under the update lock. An invalid webhook does **not** erase or corrupt the saved chat destination. The defect is late/unclear failure and an avoidable RPC, not persisted state loss.

Provenance: `2209faef405f` introduced webhook delivery-mode selection from raw string presence while carrying the normalized URL separately. #111112 / `68771ebdfef1` subsequently extracted and carried that logic into the current cron CLI producer; it was not the sole origin.

## Fix

- Normalize with the existing `normalizeHttpWebhookUrl` contract in both `cron add` and `cron edit`.
- Reject blank or malformed values before any Gateway RPC.
- Carry the normalized edit URL into delivery patch construction instead of validating twice.
- Keep Gateway protocol, validation, merge, and persistence code unchanged.

Maintainer follow-up preserves @zyw02's contributor-authored fix commit.

## Evidence

```text
head=0b42070bd8303331e9c6948feb11196e3c8ae709
merge_base=94f042ba861d1795da02e767c95ef2cc220757b5
latest_origin_main_checked=59e9765e777 (merge-tree clean; no overlap-driven rebase required)
production LOC=+20/-7 (net +13)
test LOC=+21/-0
CHANGELOG.md=unchanged
```

Focused tests:

```text
node scripts/run-vitest.mjs \
  src/cli/cron-cli/register.cron-edit.test.ts \
  src/cli/cron-cli.test.ts \
  src/cron/webhook-url.test.ts \
  src/cron/service/jobs-validation.test.ts \
  --reporter=dot

4 files passed; 286 tests passed (10 cron + 276 CLI)
```

`node scripts/check-changed.mjs -- <5 changed files>` passed formatting, production/test typechecks, lint, dead-code scans, and repository guards. `git diff --check` passed.

Repeated real CLI parsing with an isolated `OPENCLAW_HOME` (three runs per case):

- edit empty webhook: 3/3 local URL errors
- edit malformed webhook: 3/3 local URL errors
- add empty webhook: 3/3 local URL errors
- add malformed webhook: 3/3 local URL errors
- valid trimmed edit webhook: 3/3 passed local validation and reached the expected Gateway-credentials boundary

This distinguishes fail-before-RPC from valid input without requiring a live authenticated Gateway.

## Review

- Repo autoreview: clean, patch correct, confidence 0.98, no actionable findings.
- Independent read-only Codex review: **APPROVE**, no actionable findings; inspected CLI producer, canonical URL normalizer, Gateway schema/validation, update application, persistence, and tests.
- Codex source hard gate: sibling `openai/codex@bd19459358f` inspected; read-only/non-interactive review behavior confirmed.

## Remaining risk

Low. Live webhook POST delivery is outside this input-validation contract; the unchanged Gateway remains authoritative for persisted updates.