### PR TITLE
fix(cron): reject blank --command-cwd before kind forge

### DIFF
--- a/src/cli/cron-cli/register.cron-edit-options.ts
+++ b/src/cli/cron-cli/register.cron-edit-options.ts
@@ -120,11 +120,24 @@ export async function resolveCronEditPayloadDeliveryPatch(
     throw new Error("Use --account or --clear-account, not both");
   }
 
+  // Blank --command-cwd / --command-input must not count as a command payload
+  // edit: presence-only checks forged `{ kind: "command" }` patches and could
+  // convert agentTurn/script jobs into empty command payloads.
+  const commandCwd = normalizeOptionalString(opts.commandCwd);
+  if (typeof opts.commandCwd === "string" && !commandCwd) {
+    throw new Error("--command-cwd must not be blank");
+  }
+  const commandInput =
+    typeof opts.commandInput === "string" ? String(opts.commandInput) : undefined;
+  if (commandInput !== undefined && commandInput.trim() === "") {
+    throw new Error("--command-input must not be blank");
+  }
+  const hasCommandInput = commandInput !== undefined;
   const hasCommandSpecificPayloadField =
     Boolean(commandShell) ||
     Boolean(commandArgv) ||
-    typeof opts.commandCwd === "string" ||
-    typeof opts.commandInput === "string" ||
+    Boolean(commandCwd) ||
+    hasCommandInput ||
     opts.commandEnv !== undefined ||
     noOutputTimeoutSeconds !== undefined ||
     outputMaxBytes !== undefined;
@@ -228,14 +241,9 @@ export async function resolveCronEditPayloadDeliveryPatch(
     const payload: Record<string, unknown> = { kind: "command" };
     assignIf(payload, "argv", commandArgv, Boolean(commandArgv));
     assignIf(payload, "argv", ["sh", "-lc", commandShell], Boolean(commandShell));
-    assignIf(
-      payload,
-      "cwd",
-      normalizeOptionalString(opts.commandCwd),
-      typeof opts.commandCwd === "string",
-    );
+    assignIf(payload, "cwd", commandCwd, Boolean(commandCwd));
     assignIf(payload, "env", parseCronCommandEnv(opts.commandEnv), opts.commandEnv !== undefined);
-    assignIf(payload, "input", opts.commandInput, typeof opts.commandInput === "string");
+    assignIf(payload, "input", commandInput, hasCommandInput);
     assignIf(payload, "timeoutSeconds", timeoutSeconds, hasTimeoutSeconds);
     assignIf(
       payload,

--- a/src/cli/cron-cli/register.cron-edit-options.ts
+++ b/src/cli/cron-cli/register.cron-edit-options.ts
@@ -25,6 +25,7 @@ export async function resolveCronEditPayloadDeliveryPatch(
   opts: Record<string, unknown>,
   loadExistingJob: () => Promise<CronJob>,
   webhookUrl: string | undefined,
+  commandCwd: string | undefined,
 ): Promise<Record<string, unknown>> {
   const patch: Record<string, unknown> = {};
   const hasSystemEventPatch = typeof opts.systemEvent === "string";
@@ -120,10 +121,6 @@ export async function resolveCronEditPayloadDeliveryPatch(
     throw new Error("Use --account or --clear-account, not both");
   }
 
-  const commandCwd = normalizeOptionalString(opts.commandCwd);
-  if (typeof opts.commandCwd === "string" && !commandCwd) {
-    throw new Error("--command-cwd must not be blank");
-  }
   // Unlike cwd, command stdin intentionally accepts empty and whitespace strings.
   const hasCommandInput = typeof opts.commandInput === "string";
   const hasCommandSpecificPayloadField =

--- a/src/cli/cron-cli/register.cron-edit-options.ts
+++ b/src/cli/cron-cli/register.cron-edit-options.ts
@@ -120,19 +120,16 @@ export async function resolveCronEditPayloadDeliveryPatch(
     throw new Error("Use --account or --clear-account, not both");
   }
 
-  // Blank --command-cwd / --command-input must not count as a command payload
-  // edit: presence-only checks forged `{ kind: "command" }` patches and could
-  // convert agentTurn/script jobs into empty command payloads.
+  // Blank --command-cwd must not count as a command payload edit: presence-only
+  // checks forged `{ kind: "command" }` patches with no usable cwd. Empty
+  // --command-input stays allowed (Gateway stdin is an unrestricted string;
+  // "" / whitespace clears or sets stdin on command jobs).
   const commandCwd = normalizeOptionalString(opts.commandCwd);
   if (typeof opts.commandCwd === "string" && !commandCwd) {
     throw new Error("--command-cwd must not be blank");
   }
-  const commandInput =
-    typeof opts.commandInput === "string" ? String(opts.commandInput) : undefined;
-  if (commandInput !== undefined && commandInput.trim() === "") {
-    throw new Error("--command-input must not be blank");
-  }
-  const hasCommandInput = commandInput !== undefined;
+  const hasCommandInput = typeof opts.commandInput === "string";
+  const commandInput = hasCommandInput ? String(opts.commandInput) : undefined;
   const hasCommandSpecificPayloadField =
     Boolean(commandShell) ||
     Boolean(commandArgv) ||

--- a/src/cli/cron-cli/register.cron-edit-options.ts
+++ b/src/cli/cron-cli/register.cron-edit-options.ts
@@ -120,16 +120,12 @@ export async function resolveCronEditPayloadDeliveryPatch(
     throw new Error("Use --account or --clear-account, not both");
   }
 
-  // Blank --command-cwd must not count as a command payload edit: presence-only
-  // checks forged `{ kind: "command" }` patches with no usable cwd. Empty
-  // --command-input stays allowed (Gateway stdin is an unrestricted string;
-  // "" / whitespace clears or sets stdin on command jobs).
   const commandCwd = normalizeOptionalString(opts.commandCwd);
   if (typeof opts.commandCwd === "string" && !commandCwd) {
     throw new Error("--command-cwd must not be blank");
   }
+  // Unlike cwd, command stdin intentionally accepts empty and whitespace strings.
   const hasCommandInput = typeof opts.commandInput === "string";
-  const commandInput = hasCommandInput ? String(opts.commandInput) : undefined;
   const hasCommandSpecificPayloadField =
     Boolean(commandShell) ||
     Boolean(commandArgv) ||
@@ -240,7 +236,7 @@ export async function resolveCronEditPayloadDeliveryPatch(
     assignIf(payload, "argv", ["sh", "-lc", commandShell], Boolean(commandShell));
     assignIf(payload, "cwd", commandCwd, Boolean(commandCwd));
     assignIf(payload, "env", parseCronCommandEnv(opts.commandEnv), opts.commandEnv !== undefined);
-    assignIf(payload, "input", commandInput, hasCommandInput);
+    assignIf(payload, "input", opts.commandInput, hasCommandInput);
     assignIf(payload, "timeoutSeconds", timeoutSeconds, hasTimeoutSeconds);
     assignIf(
       payload,

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -1033,57 +1033,20 @@ describe("cron edit command", () => {
     exitSpy.mockRestore();
   });
 
-  it.each([[""], ["   "]])(
-    "rejects blank --command-cwd (%j) before forging a command payload",
-    async (value) => {
-      const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-      const exitSpy = vi
-        .spyOn(defaultRuntime, "exit")
-        .mockImplementation((() => undefined) as never);
-      const program = createCronProgram();
+  it.each(["", "   "])("rejects blank --command-cwd %j", async (value) => {
+    await expectCronEditRejection(["--command-cwd", value], "--command-cwd must not be blank");
+  });
 
-      await program.parseAsync(["edit", "job-1", "--command-cwd", value], { from: "user" });
+  it.each(["", "   "])("preserves --command-input %j as command stdin", async (value) => {
+    await createCronProgram().parseAsync(["edit", "job-1", "--command-input", value], {
+      from: "user",
+    });
 
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("--command-cwd must not be blank"),
-      );
-      expect(callGatewayFromCli).not.toHaveBeenCalled();
-
-      errorSpy.mockRestore();
-      exitSpy.mockRestore();
-    },
-  );
-
-  it.each([
-    ["", ""],
-    ["   ", "   "],
-  ])(
-    "preserves empty/whitespace --command-input (%j) for command stdin",
-    async (value, expectedInput) => {
-      callGatewayFromCli.mockImplementation(async (method: string) => {
-        if (method === "cron.get") {
-          return {
-            id: "job-1",
-            payload: { kind: "command", argv: ["sh", "-lc", "cat"] },
-          };
-        }
-        return { ok: true };
-      });
-      const program = createCronProgram();
-
-      await program.parseAsync(["edit", "job-1", "--command-input", value], { from: "user" });
-
-      expect(callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
-        id: "job-1",
-        patch: {
-          payload: {
-            kind: "command",
-            input: expectedInput,
-          },
-        },
-      });
-    },
-  );
+    expect(callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+      id: "job-1",
+      patch: { payload: { kind: "command", input: value } },
+    });
+  });
 
   it("rejects --webhook combined with a delivery clear flag", async () => {
     const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -1033,24 +1033,57 @@ describe("cron edit command", () => {
     exitSpy.mockRestore();
   });
 
+  it.each([[""], ["   "]])(
+    "rejects blank --command-cwd (%j) before forging a command payload",
+    async (value) => {
+      const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+      const exitSpy = vi
+        .spyOn(defaultRuntime, "exit")
+        .mockImplementation((() => undefined) as never);
+      const program = createCronProgram();
+
+      await program.parseAsync(["edit", "job-1", "--command-cwd", value], { from: "user" });
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("--command-cwd must not be blank"),
+      );
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    },
+  );
+
   it.each([
-    ["--command-cwd", ""],
-    ["--command-cwd", "   "],
-    ["--command-input", ""],
-    ["--command-input", "   "],
-  ])("rejects blank %s before forging a command payload", async (flag, value) => {
-    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
-    const program = createCronProgram();
+    ["", ""],
+    ["   ", "   "],
+  ])(
+    "preserves empty/whitespace --command-input (%j) for command stdin",
+    async (value, expectedInput) => {
+      callGatewayFromCli.mockImplementation(async (method: string) => {
+        if (method === "cron.get") {
+          return {
+            id: "job-1",
+            payload: { kind: "command", argv: ["sh", "-lc", "cat"] },
+          };
+        }
+        return { ok: true };
+      });
+      const program = createCronProgram();
 
-    await program.parseAsync(["edit", "job-1", flag, value], { from: "user" });
+      await program.parseAsync(["edit", "job-1", "--command-input", value], { from: "user" });
 
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(`${flag} must not be blank`));
-    expect(callGatewayFromCli).not.toHaveBeenCalled();
-
-    errorSpy.mockRestore();
-    exitSpy.mockRestore();
-  });
+      expect(callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+        id: "job-1",
+        patch: {
+          payload: {
+            kind: "command",
+            input: expectedInput,
+          },
+        },
+      });
+    },
+  );
 
   it("rejects --webhook combined with a delivery clear flag", async () => {
     const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -1037,6 +1037,13 @@ describe("cron edit command", () => {
     await expectCronEditRejection(["--command-cwd", value], "--command-cwd must not be blank");
   });
 
+  it("rejects blank --command-cwd before loading an existing job", async () => {
+    await expectCronEditRejection(
+      ["--pacing-min", "30m", "--command-cwd", "   "],
+      "--command-cwd must not be blank",
+    );
+  });
+
   it.each(["", "   "])("preserves --command-input %j as command stdin", async (value) => {
     await createCronProgram().parseAsync(["edit", "job-1", "--command-input", value], {
       from: "user",

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -1033,6 +1033,25 @@ describe("cron edit command", () => {
     exitSpy.mockRestore();
   });
 
+  it.each([
+    ["--command-cwd", ""],
+    ["--command-cwd", "   "],
+    ["--command-input", ""],
+    ["--command-input", "   "],
+  ])("rejects blank %s before forging a command payload", async (flag, value) => {
+    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
+    const program = createCronProgram();
+
+    await program.parseAsync(["edit", "job-1", flag, value], { from: "user" });
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(`${flag} must not be blank`));
+    expect(callGatewayFromCli).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
   it("rejects --webhook combined with a delivery clear flag", async () => {
     const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -171,6 +171,10 @@ export function registerCronEditCommand(cron: Command) {
           if (opts.clearTools && opts.tools !== undefined) {
             throw new Error("Use --tools or --clear-tools, not both");
           }
+          const commandCwd = normalizeOptionalString(opts.commandCwd);
+          if (typeof opts.commandCwd === "string" && !commandCwd) {
+            throw new Error("--command-cwd must not be blank");
+          }
           let existingJobPromise: Promise<CronJobForEdit> | undefined;
           let expectedConfigRevision: string | undefined;
           const readExistingCronJob = async (): Promise<CronJobForEdit> => {
@@ -421,7 +425,12 @@ export function registerCronEditCommand(cron: Command) {
 
           Object.assign(
             patch,
-            await resolveCronEditPayloadDeliveryPatch(opts, readExistingCronJob, webhookUrl),
+            await resolveCronEditPayloadDeliveryPatch(
+              opts,
+              readExistingCronJob,
+              webhookUrl,
+              commandCwd,
+            ),
           );
 
           const hasFailureAlertAfter = typeof opts.failureAlertAfter === "string";


### PR DESCRIPTION
Closes #121534

## What Problem This Solves

`cron edit --command-cwd` used raw string presence to classify a command payload. Blank/whitespace cwd values could therefore forge a partial `{ kind: "command" }` patch and reach Gateway validation instead of failing locally. Empty or whitespace `--command-input`, however, is intentional command stdin and must remain valid.

The authoritative Gateway schema still requires non-empty cwd and rejects an argv-less cross-kind command replacement before persistence. This is a CLI owner-boundary / late-failure defect, not a persisted silent job-kind rewrite.

Provenance: `b8adc11977ab` introduced command cwd/input presence and command-kind classification. #111112 / `68771ebdfef1` subsequently extracted and carried that logic into the current cron CLI producer; it was not the sole origin.

## Fix

- Normalize `--command-cwd` once and reject blank values before **every** path that can load the existing job or call the Gateway.
- Use the normalized cwd for command-kind detection and assignment.
- Preserve raw string presence and the exact value for `--command-input`, including `""` and whitespace.
- Preserve the normalized webhook value landed by #121533 when wiring the shared payload/delivery helper.
- Keep protocol, Gateway validation, normalization, and payload merge contracts unchanged.

An independent review found that the first revision could still call `cron.get` when blank cwd was combined with `--pacing-min`. Exact head moves validation ahead of that read and adds a combined-option no-RPC regression test. Maintainer follow-ups preserve @zyw02's contributor-authored commits.

## Evidence

```text
head=4842535f7c5743a6b035f32f2647558303e2501b
rebased_onto=1fb4857e3cc24957b0e7bfadc525e35eb519a999 (#121533 squash)
merge_base=1fb4857e3cc24957b0e7bfadc525e35eb519a999
latest_origin_main_checked=6f52e9fc2f0ca89f3f1cefde5a3f6a5d9204aa54 (merge-tree clean)
production LOC=+17/-10 (net +7)
test LOC=+22/-0
CHANGELOG.md=unchanged
```

Focused combined sibling regressions:

```text
node scripts/run-vitest.mjs \
  src/cli/cron-cli/register.cron-edit.test.ts \
  src/cli/cron-cli.test.ts \
  src/cron/webhook-url.test.ts \
  src/cron/service/jobs-validation.test.ts \
  src/cron/normalize.test.ts \
  src/cron/service/payload-merge.test.ts \
  src/cron/cron-protocol-schema.test.ts \
  --reporter=dot

7 files passed; 375 tests passed (90 cron + 285 CLI)
```

`node scripts/check-changed.mjs -- <3 changed files>` passed formatting, production/test typechecks, lint, dead-code scans, schema/legacy-store/import-cycle/webhook/pairing checks, and remaining repository guards. `git diff --check` passed.

Repeated real CLI parsing on the exact head with isolated `OPENCLAW_HOME` (three runs per case):

- empty cwd: 3/3 local blank-value errors
- whitespace cwd combined with `--pacing-min`: 3/3 local errors before the credentials/RPC boundary
- padded valid cwd: 3/3 passed local normalization and reached the expected Gateway-credentials boundary
- empty stdin: 3/3 preserved and reached the Gateway-credentials boundary
- whitespace stdin: 3/3 preserved and reached the Gateway-credentials boundary
- blank/invalid webhook: 3/3 each failed locally
- padded valid webhook: 3/3 passed local normalization and reached the Gateway-credentials boundary

## Review

- Fresh repo autoreview on the exact rebased head: clean, patch correct, confidence 0.99, no actionable findings.
- Fresh independent read-only Codex review on the exact rebased head: **APPROVE**, no actionable findings.
- Codex source hard gate: sibling `openai/codex@bd19459358f` inspected, including cwd resolution and empty stdin preservation.

## Remaining risk

Low. Live command execution is outside this parsing/patch contract; unchanged Gateway validation remains authoritative.