### PR TITLE
fix(android): pass namespaced @owner/slug to ClawHub skill detail

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -6368,7 +6368,8 @@ class NodeRuntime private constructor(
         )
     }
     try {
-      val response = requestGatewayData(gatewayScope, "skills.detail", clawHubDetailParams(skill.slug))
+      val targetSlug = if (skill.ownerHandle != null) "@${skill.ownerHandle}/${skill.slug}" else skill.slug
+      val response = requestGatewayData(gatewayScope, "skills.detail", clawHubDetailParams(targetSlug))
       val review = parseClawHubInstallReview(response, skill, json)
       publishGatewayData(gatewayScope) {
         if (clawHubSkillReviewSeq.get() == reviewSeq) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/SkillManagement.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SkillManagement.kt
@@ -31,6 +31,7 @@ data class GatewayClawHubSkillSummary(
   val displayName: String,
   val summary: String?,
   val version: String?,
+  val ownerHandle: String?,
 )
 
 data class GatewayClawHubInstallReview(
@@ -63,6 +64,7 @@ internal fun parseClawHubSearchResults(
         displayName = displayName,
         summary = value.string("summary"),
         version = value.string("version"),
+        ownerHandle = value.string("ownerHandle"),
       )
     }.orEmpty()
 }


### PR DESCRIPTION
## What Problem This Solves

Companion to #121518. When multiple ClawHub skills share the same bare slug (e.g. `home-assistant`), clicking detail or install on a search result triggers a `409 AMBIGUOUS_SKILL_SLUG` error from the ClawHub API.

The Android app's `GatewayClawHubSkillSummary` lacked `ownerHandle`, so `reviewClawHubSkillInstallFromGateway` sent bare slugs to `skills.detail`.

## Fix

- `SkillManagement.kt`: add `ownerHandle` to `GatewayClawHubSkillSummary` and parse it from search results.
- `NodeRuntime.kt`: format `@owner/slug` in `reviewClawHubSkillInstallFromGateway` when `ownerHandle` is present.

## Evidence

- Code-level review: the Gateway already returns `ownerHandle` in search results (see #121518). This change captures it and forwards it.
- Needs Android build verification before merge.