### PR TITLE
fix(ios/macos): pass namespaced @owner/slug to ClawHub skill detail and install

### DIFF
--- a/apps/ios/Sources/Design/AgentProModels.swift
+++ b/apps/ios/Sources/Design/AgentProModels.swift
@@ -266,6 +266,7 @@ struct ClawHubSearchResultLite: Decodable {
     let displayName: String
     let summary: String?
     let version: String?
+    let ownerHandle: String?
 }
 
 struct ClawHubInstallParams: Encodable {

--- a/apps/ios/Sources/Design/AgentProTab+Skills.swift
+++ b/apps/ios/Sources/Design/AgentProTab+Skills.swift
@@ -745,7 +745,8 @@ extension AgentProTab {
         clawHubErrorText = nil
         defer { self.clawHubInstallSlug = nil }
         do {
-            let params = ClawHubInstallParams(slug: result.slug)
+            let targetSlug = result.ownerHandle.map { "@\($0)/\(result.slug)" } ?? result.slug
+            let params = ClawHubInstallParams(slug: targetSlug)
             _ = try await self.requestGateway(method: "skills.install", params: params, timeoutSeconds: 125)
             await appModel.refreshGatewayOverviewIfConnected()
             await refreshOverview(force: true)

--- a/apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift
+++ b/apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift
@@ -295,7 +295,8 @@ private final class ClawHubSkillsBrowserModel {
             guard let route = await GatewayConnection.shared.captureRoute() else {
                 throw ClawHubSkillsBrowserError.gatewayUnavailable
             }
-            let detail = try await GatewayConnection.shared.skillsDetail(slug: skill.slug, on: route)
+            let targetSlug = skill.ownerHandle.map { "@\($0)/\(skill.slug)" } ?? skill.slug
+            let detail = try await GatewayConnection.shared.skillsDetail(slug: targetSlug, on: route)
             guard let review = ClawHubSkillInstallReview(detail: detail, fallback: skill) else {
                 throw ClawHubSkillsBrowserError.missingInstallVersion
             }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/SkillManagement.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/SkillManagement.swift
@@ -229,9 +229,11 @@ public struct ClawHubSkillSummary: Codable, Identifiable, Hashable, Sendable {
     public let displayName: String
     public let summary: String?
     public let version: String?
+    public let ownerHandle: String?
 
     public var id: String {
-        self.slug
+        if let ownerHandle { return "@\(ownerHandle)/\(self.slug)" }
+        return self.slug
     }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Companion to #121518. When multiple ClawHub skills share the same bare slug (e.g. `home-assistant`), clicking detail or install on a search result triggers a `409 AMBIGUOUS_SKILL_SLUG` error from the ClawHub API.

## Fix

### Shared (OpenClawKit)
- `ClawHubSkillSummary`: add `ownerHandle` field.
- `Identifiable.id`: updated to `@owner/slug` for correct SwiftUI list diffing with duplicate slugs.

### iOS
- `AgentProModels.swift`: add `ownerHandle` to `ClawHubSearchResultLite`.
- `AgentProTab+Skills.swift`: format `@owner/slug` in `installClawHubSkill` when `ownerHandle` is present.

### macOS
- `ClawHubSkillsBrowser.swift`: format `@owner/slug` for the `skillsDetail` call in `review()`.

## Evidence

- Code-level review: the Gateway already returns `ownerHandle` in search results (see #121518). These changes capture it and forward it.
- Needs iOS/macOS build verification before merge.