### PR TITLE
test(ui): consolidate session pin coverage

### DIFF
--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import {
   GatewayRequestError,
   type GatewayBrowserClient,
@@ -8,11 +9,7 @@ import {
 import type { SessionsListResult } from "../../api/types.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createSessionCapability, reconcileSessionRunTerminal } from "./index.ts";
-import {
-  createGatewayHarness,
-  deferred,
-  sessionsResult,
-} from "./session-capability.test-support.ts";
+import { createGatewayHarness, sessionsResult } from "./session-capability.test-support.ts";
 
 function sessionChangedEvent(key: string): GatewayEventFrame {
   return {
@@ -152,7 +149,7 @@ describe("createSessionCapability", () => {
   });
 
   it("reports a group rename as stale after a same-client reconnect", async () => {
-    const renamed = deferred<{ groups: Array<{ name: string }> }>();
+    const renamed = createDeferred<{ groups: Array<{ name: string }> }>();
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.groups.rename") {
         return await renamed.promise;
@@ -180,7 +177,7 @@ describe("createSessionCapability", () => {
   });
 
   it("reports a group catalog replacement as stale after a same-client reconnect", async () => {
-    const replaced = deferred<{ groups: Array<{ name: string }> }>();
+    const replaced = createDeferred<{ groups: Array<{ name: string }> }>();
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.groups.put") {
         return await replaced.promise;
@@ -211,7 +208,7 @@ describe("createSessionCapability", () => {
   it.each(["rename", "delete"] as const)(
     "keeps a confirmed group %s completed when its row refresh outlives the connection",
     async (operation) => {
-      const refreshed = deferred<SessionsListResult>();
+      const refreshed = createDeferred<SessionsListResult>();
       const method = operation === "rename" ? "sessions.groups.rename" : "sessions.groups.delete";
       const request = vi.fn(async (requestedMethod: string) => {
         if (requestedMethod === method) {
@@ -256,8 +253,8 @@ describe("createSessionCapability", () => {
   });
 
   it("ignores an older group load failure after an event-driven load succeeds", async () => {
-    const firstGroups = deferred<{ groups: Array<{ name: string }> }>();
-    const currentGroups = deferred<{ groups: Array<{ name: string }> }>();
+    const firstGroups = createDeferred<{ groups: Array<{ name: string }> }>();
+    const currentGroups = createDeferred<{ groups: Array<{ name: string }> }>();
     let groupsCalls = 0;
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.groups.list") {
@@ -377,8 +374,8 @@ describe("createSessionCapability", () => {
   });
 
   it("starts a fresh list epoch when the same client reconnects", async () => {
-    const staleList = deferred<SessionsListResult>();
-    const currentList = deferred<SessionsListResult>();
+    const staleList = createDeferred<SessionsListResult>();
+    const currentList = createDeferred<SessionsListResult>();
     let listCalls = 0;
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.subscribe") {
@@ -409,7 +406,7 @@ describe("createSessionCapability", () => {
   });
 
   it("does not publish a created session from a retired same-client epoch", async () => {
-    const staleCreate = deferred<{ key: string }>();
+    const staleCreate = createDeferred<{ key: string }>();
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.create") {
         return await staleCreate.promise;
@@ -439,7 +436,7 @@ describe("createSessionCapability", () => {
   });
 
   it("creates a session while a list refresh is in flight", async () => {
-    const pendingList = deferred<SessionsListResult>();
+    const pendingList = createDeferred<SessionsListResult>();
     let listCalls = 0;
     const key = "agent:main:created";
     const request = vi.fn(async (method: string) => {
@@ -510,7 +507,7 @@ describe("createSessionCapability", () => {
   });
 
   it("reports a reset as stale when its connection epoch retires", async () => {
-    const staleReset = deferred<unknown>();
+    const staleReset = createDeferred<unknown>();
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.reset") {
         return await staleReset.promise;
@@ -559,7 +556,7 @@ describe("createSessionCapability", () => {
   });
 
   it("clears optimistic and settled model overrides when its connection epoch retires", async () => {
-    const stalePatch = deferred<unknown>();
+    const stalePatch = createDeferred<unknown>();
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.patch") {
         return await stalePatch.promise;
@@ -594,7 +591,7 @@ describe("createSessionCapability", () => {
   });
 
   it("does not dispatch a queued patch on a replacement connection", async () => {
-    const priorPatch = deferred<void>();
+    const priorPatch = createDeferred();
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.patch") {
         return { ok: true, path: "", key: "agent:main:main", entry: {} };
@@ -670,7 +667,7 @@ describe("createSessionCapability", () => {
   });
 
   it("keeps background hydration non-blocking and retains an omitted selected row", async () => {
-    const secondList = deferred<SessionsListResult>();
+    const secondList = createDeferred<SessionsListResult>();
     let listCalls = 0;
     const request = vi.fn(async (method: string, _params?: unknown) => {
       if (method !== "sessions.list") {
@@ -862,7 +859,7 @@ describe("createSessionCapability", () => {
   it("refreshes instead of inserting hidden sessions after configured-only lists", async () => {
     const visibleKey = "agent:main:main";
     const hiddenKey = "agent:local:hidden";
-    const refreshed = deferred<SessionsListResult>();
+    const refreshed = createDeferred<SessionsListResult>();
     let listCalls = 0;
     const request = vi.fn(async (method: string) => {
       if (method !== "sessions.list") {
@@ -908,7 +905,7 @@ describe("createSessionCapability", () => {
 
   it("publishes remote deletion before refreshing the canonical list", async () => {
     const visibleKey = "agent:main:main";
-    const refreshed = deferred<SessionsListResult>();
+    const refreshed = createDeferred<SessionsListResult>();
     let listCalls = 0;
     const request = vi.fn(async (method: string) => {
       if (method !== "sessions.list") {

--- a/ui/src/lib/sessions/session-capability.test-support.ts
+++ b/ui/src/lib/sessions/session-capability.test-support.ts
@@ -14,16 +14,6 @@ export function sessionsResult(
   };
 }
 
-export function deferred<T>() {
-  let resolve: (value: T) => void = () => undefined;
-  let reject: (error: unknown) => void = () => undefined;
-  const promise = new Promise<T>((next, fail) => {
-    resolve = next;
-    reject = fail;
-  });
-  return { promise, reject, resolve };
-}
-
 export function createGatewayHarness(client: GatewayBrowserClient, featureMethods?: string[]) {
   let snapshot: {
     client: GatewayBrowserClient | null;

--- a/ui/src/lib/sessions/session-pin-mutations.test.ts
+++ b/ui/src/lib/sessions/session-pin-mutations.test.ts
@@ -1,13 +1,10 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
 import { createSessionCapability } from "./index.ts";
-import {
-  createGatewayHarness,
-  deferred,
-  sessionsResult,
-} from "./session-capability.test-support.ts";
+import { createGatewayHarness, sessionsResult } from "./session-capability.test-support.ts";
 import type { SessionListSnapshot } from "./session-capability.ts";
 
 const SESSION_EVENT_REFRESH_DEBOUNCE_MS = 200;
@@ -59,40 +56,10 @@ function pinHarness(options: {
 }
 
 describe("session pin mutations", () => {
-  it("pins a row before sessions.patch resolves and holds it through refresh and events", async () => {
-    const committed = deferred<unknown>();
-    let serverPinned = false;
-    const { gateway, key, emitEvent } = pinHarness({
-      patchResponse: () => committed.promise,
-      serverPinned: () => serverPinned,
-    });
-    const sessions = createSessionCapability(gateway);
-
-    await sessions.refresh({ force: true });
-    expect(rowPinned(sessions.state.result, key)).toBe(false);
-
-    const operation = sessions.patch(key, { pinned: true });
-    expect(rowPinned(sessions.state.result, key)).toBe(true);
-
-    serverPinned = true;
-    committed.resolve({ ok: true, key, path: "", entry: {} });
-    await expect(operation).resolves.toBeTruthy();
-    expect(rowPinned(sessions.state.result, key)).toBe(true);
-    expect(sessions.state.error).toBeNull();
-
-    emitEvent({
-      type: "event",
-      event: "sessions.changed",
-      payload: sessionChangedPayload(key, true),
-    });
-    expect(rowPinned(sessions.state.result, key)).toBe(true);
-    sessions.dispose();
-  });
-
   it("keeps a pending pin through a stale Gateway event and its canonical refresh", async () => {
     vi.useFakeTimers();
     try {
-      const committed = deferred<unknown>();
+      const committed = createDeferred<unknown>();
       let serverPinned = false;
       const { gateway, key, emitEvent } = pinHarness({
         patchResponse: () => committed.promise,
@@ -196,39 +163,9 @@ describe("session pin mutations", () => {
     sessions.dispose();
   });
 
-  it("keeps the newest pin intent when an older completion refreshes the list first", async () => {
-    const pinCommitted = deferred<unknown>();
-    const unpinCommitted = deferred<unknown>();
-    let serverPinned = false;
-    const { gateway, key } = pinHarness({
-      patchResponse: (call) => (call === 1 ? pinCommitted.promise : unpinCommitted.promise),
-      serverPinned: () => serverPinned,
-    });
-    const sessions = createSessionCapability(gateway);
-
-    await sessions.refresh({ force: true });
-    const pin = sessions.patch(key, { pinned: true });
-    expect(rowPinned(sessions.state.result, key)).toBe(true);
-    const unpin = sessions.patch(key, { pinned: false });
-    expect(rowPinned(sessions.state.result, key)).toBe(false);
-
-    // The pin commits first, so its list refresh republishes a pinned row the
-    // unpin already replaced locally.
-    serverPinned = true;
-    pinCommitted.resolve({ ok: true, key, path: "", entry: {} });
-    await expect(pin).resolves.toBeTruthy();
-    expect(rowPinned(sessions.state.result, key)).toBe(false);
-
-    serverPinned = false;
-    unpinCommitted.resolve({ ok: true, key, path: "", entry: {} });
-    await expect(unpin).resolves.toBeTruthy();
-    expect(rowPinned(sessions.state.result, key)).toBe(false);
-    sessions.dispose();
-  });
-
   it("rolls a failed unpin back to the pin an overlapping completion confirmed", async () => {
-    const pinCommitted = deferred<unknown>();
-    const unpinRejected = deferred<unknown>();
+    const pinCommitted = createDeferred<unknown>();
+    const unpinRejected = createDeferred<unknown>();
     let serverPinned = false;
     const { gateway, key } = pinHarness({
       patchResponse: (call) => (call === 1 ? pinCommitted.promise : unpinRejected.promise),


### PR DESCRIPTION
## What Problem This Solves

The session pin test suite duplicated optimistic pinning and newest-intent coverage already exercised through the rendered Control UI E2E path, while two unit files carried a copied deferred-promise helper.

## Why This Change Was Made

This removes only the duplicated unit cases and replaces the local deferred helper with the canonical shared test helper. The lower-level stale-event, canonical-refresh, primary and filtered rollback, filtered-only rollback, and confirmed-baseline failure cases remain as focused unit coverage.

## User Impact

None. This is test and test-support cleanup only; production behavior is unchanged.

## Evidence

- `node scripts/run-vitest.mjs ui/src/lib/sessions/index.test.ts ui/src/lib/sessions/session-pin-mutations.test.ts` — 35 tests passed.
- Targeted `oxfmt` and `oxlint` passed for all three changed files.
- `git diff --check` passed; test/support delta is +22/-98 across three files, with production LOC unchanged.
- Pre-commit autoreview reported no actionable findings; its TruffleHog scan was clean.
- The Crabbox/Testbox wrapper failed before provisioning, so there was no remote pre-push proof. Exact-head [CI run 31374215190](https://github.com/openclaw/openclaw/actions/runs/31374215190) subsequently passed `check-test-types` (including `pnpm tsgo:core:test`) and all rendered Control UI E2E shards; shard 1 ran `ui/src/e2e/session-management.optimistic-pin.e2e.test.ts` with all 3 tests passing.

AI-assisted: yes.
