### PR TITLE
fix(text): avoid spurious separators when stripping model tokens at punctuation

### DIFF
--- a/src/agents/embedded-agent-utils.strip-model-special-tokens.test.ts
+++ b/src/agents/embedded-agent-utils.strip-model-special-tokens.test.ts
@@ -26,4 +26,92 @@ describe("stripModelSpecialTokens", () => {
     const text = "Just a normal response.";
     expect(stripModelSpecialTokens(text)).toBe(text);
   });
+
+  it.each([
+    {
+      name: "before closing punctuation",
+      input: "Hello<|assistant|>.",
+      expected: "Hello.",
+    },
+    {
+      name: "after opening punctuation",
+      input: "(<|assistant|>Hello",
+      expected: "(Hello",
+    },
+    {
+      name: "before a Markdown closing delimiter",
+      input: "**bold<|assistant|>**",
+      expected: "**bold**",
+    },
+  ])("does not insert a separator $name", ({ input, expected }) => {
+    expect(stripModelSpecialTokens(input)).toBe(expected);
+  });
+
+  it("does not insert a separator next to non-ASCII punctuation", () => {
+    expect(stripModelSpecialTokens("你好<|assistant|>。")).toBe("你好。");
+  });
+
+  it("preserves word boundaries for supplementary-plane letters", () => {
+    // U+10400 (𐐀) is a non-BMP letter stored as a UTF-16 surrogate pair.
+    // Indexed `text[start - 1]` would see only the low surrogate; the boundary
+    // lookup must use the complete code point so adjacent letters stay separated.
+    expect(stripModelSpecialTokens("𐐀<|assistant|>X")).toBe("𐐀 X");
+    expect(stripModelSpecialTokens("X<|assistant|>𐐀")).toBe("X 𐐀");
+  });
+
+  it("preserves word boundaries for decomposed combining marks", () => {
+    // NFD é (e + U+0301 combining acute) is a letter; the separator must still
+    // fire when a token sits between it and another word character.
+    const decomposed = "café";
+    expect(stripModelSpecialTokens(decomposed + "<|assistant|>X")).toBe(decomposed + " X");
+  });
+
+  it("preserves a separator across consecutive removed tokens", () => {
+    // Two adjacent control tokens between two word characters must still yield
+    // one separator; deciding from the immediate token edge would join the
+    // surrounding words. Both pipe widths are exercised.
+    expect(stripModelSpecialTokens("Question<|assistant|><|assistant|>Answer")).toBe(
+      "Question Answer",
+    );
+    expect(stripModelSpecialTokens("Question<|a|><|b|>Answer")).toBe("Question Answer");
+    expect(stripModelSpecialTokens("a<|assistant|><|assistant|>b")).toBe("a b");
+    expect(stripModelSpecialTokens("a<|x|><|y|><|z|>b")).toBe("a b");
+  });
+
+  it("keeps a following combining mark attached to its base letter", () => {
+    // A combining mark (U+0301) decorates the preceding base letter; removing a
+    // token between them must not insert a separator that detaches the mark.
+    expect(stripModelSpecialTokens("c<|assistant|>\u0301")).toBe("c\u0301");
+    expect(stripModelSpecialTokens("c<|a|>\u0301")).toBe("c\u0301");
+    // A combining mark after a token between two letters still attaches to the
+    // retained left base, while the right letter stays a separate word.
+    expect(stripModelSpecialTokens("ca<|assistant|>\u0301z")).toBe("ca\u0301 z");
+  });
+
+  it("keeps a combining mark attached across a consecutive token run", () => {
+    // A combining mark after a run of removed tokens still decorates the
+    // retained base letter before the run; the mark must stay attached to it
+    // (not detach after the separator), and the separator fires once between
+    // the marked base and the following word character.
+    expect(stripModelSpecialTokens("a<|x|><|y|>\u0301b")).toBe("a\u0301 b");
+    expect(stripModelSpecialTokens("ca<|x|><|y|><|z|>\u0301z")).toBe("ca\u0301 z");
+  });
+
+  it("keeps a combining mark attached when it sits between two removed tokens", () => {
+    // A combining mark between two removed tokens still decorates the retained
+    // base letter before the run; both tokens are coalesced into one run and the
+    // separator fires once, so the mark does not gain a leading space nor a second
+    // separator from the second token.
+    expect(stripModelSpecialTokens("a<|x|>\u0301<|y|>b")).toBe("a\u0301 b");
+  });
+
+  it("coalesces a long run of consecutive removed tokens into one separator", () => {
+    // A long run of leaked tokens must not make the shared sanitizer quadratic:
+    // the span-indexed lookup keeps the boundary decision linear in the run length
+    // and the whole run still collapses to a single separator between the two word
+    // characters.
+    const token = "<|t|>";
+    const input = "a" + token.repeat(2000) + "b";
+    expect(stripModelSpecialTokens(input)).toBe("a b");
+  });
 });

--- a/src/agents/embedded-agent-utils.strip-model-special-tokens.test.ts
+++ b/src/agents/embedded-agent-utils.strip-model-special-tokens.test.ts
@@ -105,6 +105,15 @@ describe("stripModelSpecialTokens", () => {
     expect(stripModelSpecialTokens("a<|x|>\u0301<|y|>b")).toBe("a\u0301 b");
   });
 
+  it("handles supplementary-plane combining marks between removed tokens", () => {
+    // A supplementary-plane combining mark (U+1D165) is encoded as a surrogate
+    // pair; the backward mark scan must read it as a full code point, not a lone
+    // UTF-16 code unit, so the mark stays attached and only one separator fires.
+    const supMark = "\u{1D165}";
+    expect(stripModelSpecialTokens("a<|x|>" + supMark + "<|y|>b")).toBe("a" + supMark + " b");
+    expect(stripModelSpecialTokens("a<|x|><|y|>" + supMark + "b")).toBe("a" + supMark + " b");
+  });
+
   it("coalesces a long run of consecutive removed tokens into one separator", () => {
     // A long run of leaked tokens must not make the shared sanitizer quadratic:
     // the span-indexed lookup keeps the boundary decision linear in the run length

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -628,6 +628,13 @@ describe("stripAssistantInternalScaffolding", () => {
       expect(stripModelSpecialTokens("prefix <|assistant|>")).toBe("prefix ");
       expect(stripModelSpecialTokens("<|assistant|>short")).toBe("short");
     });
+
+    it("preserves Markdown emphasis through the full sanitize pipeline", () => {
+      // "**bold**" renders as strong emphasis, while "**bold **" does not.
+      // Stripping a leaked token before the closing delimiter must keep the
+      // emphasis intact end-to-end via sanitizeAssistantVisibleText.
+      expect(sanitizeAssistantVisibleText("**bold<|assistant|>**")).toBe("**bold**");
+    });
   });
 });
 

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -58,11 +58,14 @@ function charBefore(text: string, pos: number): string | undefined {
   }
   let end = pos;
   while (end > 0) {
-    const prev = text[end - 1];
+    // Use a full code point (surrogate-pair aware) so supplementary-plane
+    // combining marks like U+1D165 are recognized, not just their low
+    // surrogate code unit which \p{M} would not match.
+    const prev = lastCodePointBefore(text, end);
     if (prev === undefined || !/\p{M}/u.test(prev)) {
       break;
     }
-    end -= 1;
+    end -= prev.length;
   }
   if (end <= 0) {
     return text.slice(0, pos);

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -12,12 +12,74 @@ function overlapsCodeRegion(
   return codeRegions.some((region) => start < region.end && end > region.start);
 }
 
+// A word character is a letter, mark (combining marks belong to the preceding
+// base letter), digit, or underscore (Unicode-aware). Punctuation and markup
+// delimiters (`.`, `(`, `**`, etc.) are NOT word characters, so removing a
+// control token next to them does not concatenate two words and needs no separator.
+const WORD_CHAR_RE = /^[\p{L}\p{M}\p{N}_]+$/u;
+function isWordChar(ch: string | undefined): boolean {
+  return Boolean(ch) && WORD_CHAR_RE.test(ch!);
+}
+
+// The complete Unicode character at `pos` (surrogate-pair aware), or undefined
+// past the end of the string. Indexed `text[pos]` would yield a lone UTF-16
+// code unit for non-BMP letters.
+function codePointAt(text: string, pos: number): string | undefined {
+  if (pos >= text.length) {
+    return undefined;
+  }
+  const cp = text.codePointAt(pos);
+  return cp === undefined ? undefined : String.fromCodePoint(cp);
+}
+
+// The complete Unicode character immediately before `pos` (surrogate-pair
+// aware), or undefined at the start of the string.
+function lastCodePointBefore(text: string, pos: number): string | undefined {
+  if (pos <= 0) {
+    return undefined;
+  }
+  const prev = text[pos - 1];
+  if (prev !== undefined && /[\uDC00-\uDFFF]/.test(prev) && pos >= 2) {
+    const pair = text.slice(pos - 2, pos);
+    const cp = pair.codePointAt(0);
+    if (cp !== undefined && cp > 0xffff) {
+      return pair;
+    }
+  }
+  return prev;
+}
+
+// Walks backwards from `pos` collecting the preceding code point and any
+// combining marks (U+0300-U+036F etc.) that decorate it, so a decomposed
+// letter like NFD é (e + U+0301) is treated as one word unit.
+function charBefore(text: string, pos: number): string | undefined {
+  if (pos <= 0) {
+    return undefined;
+  }
+  let end = pos;
+  while (end > 0) {
+    const prev = text[end - 1];
+    if (prev === undefined || !/\p{M}/u.test(prev)) {
+      break;
+    }
+    end -= 1;
+  }
+  if (end <= 0) {
+    return text.slice(0, pos);
+  }
+  const base = lastCodePointBefore(text, end);
+  return base === undefined ? text.slice(0, pos) : text.slice(end - base.length, pos);
+}
+
+// Only insert a separator when removing the token would otherwise join two
+// adjacent word characters. Punctuation and markup boundaries already provide
+// the required boundary and must be left untouched.
 function shouldInsertSeparator(before: string | undefined, after: string | undefined): boolean {
-  return Boolean(before && after && !/\s/.test(before) && !/\s/.test(after));
+  return isWordChar(before) && isWordChar(after);
 }
 
 /**
- * Strips leaked model control tokens like `<|assistant|>` or full-width pipe variants.
+ * Strips leaked model control tokens like `<|endoftext|>` or full-width pipe variants.
  * Code examples are preserved; remove this when providers stop emitting these tokens.
  *
  * @see https://github.com/openclaw/openclaw/issues/40020
@@ -33,19 +95,119 @@ export function stripModelSpecialTokens(text: string): string {
   MODEL_SPECIAL_TOKEN_RE.lastIndex = 0;
 
   const codeRegions = findCodeRegions(text);
+  // Pre-compute matches with a `removable` flag, plus disjoint sorted arrays of
+  // the removable spans for an O(log m) "is this position inside a stripped
+  // token?" lookup. Keeps the shared outbound-text path linear on long token runs.
+  const matches = [...text.matchAll(MODEL_SPECIAL_TOKEN_RE)].map((m) => {
+    const matched = m[0];
+    const start = m.index ?? 0;
+    const end = start + matched.length;
+    const removable =
+      !isInsideCode(start, codeRegions) && !overlapsCodeRegion(start, end, codeRegions);
+    return { matched, start, end, removable };
+  });
+  const removableStarts: number[] = [];
+  const removableEnds: number[] = [];
+  for (const m of matches) {
+    if (m.removable) {
+      removableStarts.push(m.start);
+      removableEnds.push(m.end);
+    }
+  }
+  const inRemovable = (pos: number): boolean => {
+    let lo = 0;
+    let hi = removableStarts.length - 1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      const start = removableStarts[mid];
+      if (start === undefined) {
+        break;
+      }
+      if (start <= pos) {
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return hi >= 0 && pos < (removableEnds[hi] ?? Infinity);
+  };
+
+  // The retained character before `pos`, skipping an immediately preceding
+  // removable-token run so the separator is decided from the final retained
+  // neighbors and fires only once per run. Returns undefined when `pos` is
+  // preceded by another removable token (so only the run's first token inserts).
+  const retainedBefore = (pos: number): string | undefined => {
+    let p = pos;
+    let skipped = false;
+    while (p > 0) {
+      const ch = charBefore(text, p);
+      if (ch === undefined) {
+        return undefined;
+      }
+      const charStart = p - ch.length;
+      if (!inRemovable(charStart)) {
+        return skipped ? undefined : ch;
+      }
+      skipped = true;
+      p = charStart;
+    }
+    return undefined;
+  };
+  // The retained character after `pos`, skipping an immediately following
+  // removable-token run. Combining marks trailing the run are emitted by the
+  // caller so they stay attached to the preceding base letter.
+  const retainedAfter = (pos: number): string | undefined => {
+    let p = pos;
+    while (p < text.length) {
+      const ch = codePointAt(text, p);
+      if (ch === undefined || !inRemovable(p)) {
+        return ch;
+      }
+      p += ch.length;
+    }
+    return undefined;
+  };
+
   let out = "";
   let cursor = 0;
-  for (const match of text.matchAll(MODEL_SPECIAL_TOKEN_RE)) {
-    const matched = match[0];
-    const start = match.index ?? 0;
-    const end = start + matched.length;
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i];
+    if (match === undefined) {
+      continue; // consumed by an earlier coalesced run
+    }
+    const { matched, start, end, removable } = match;
+    if (start < cursor) {
+      continue; // consumed by an earlier coalesced run
+    }
     out += text.slice(cursor, start);
-    if (isInsideCode(start, codeRegions) || overlapsCodeRegion(start, end, codeRegions)) {
+    if (!removable) {
       out += matched;
-    } else if (shouldInsertSeparator(text[start - 1], text[end])) {
+      cursor = end;
+      continue;
+    }
+    // Coalesce the maximal run of consecutive removable tokens starting here,
+    // then any trailing combining marks. A mark decorates the preceding
+    // retained base, so it stays attached to whatever precedes the run; deciding
+    // the separator once from the two retained neighbors also yields a single
+    // space across a consecutive token run.
+    let runEnd = end;
+    while (i + 1 < matches.length) {
+      const next = matches[i + 1];
+      if (next === undefined || !next.removable || next.start !== runEnd) {
+        break;
+      }
+      i += 1;
+      runEnd = next.end;
+    }
+    let markEnd = runEnd;
+    while (markEnd < text.length && /^\p{M}/u.test(codePointAt(text, markEnd) ?? "")) {
+      markEnd += (codePointAt(text, markEnd) ?? "").length;
+    }
+    out += text.slice(runEnd, markEnd);
+    if (shouldInsertSeparator(retainedBefore(start), retainedAfter(markEnd))) {
       out += " ";
     }
-    cursor = end;
+    cursor = markEnd;
   }
   out += text.slice(cursor);
   return out;


### PR DESCRIPTION
## What Problem This Solves

Assistant-visible text no longer gains spurious whitespace when a leaked model control token is stripped next to punctuation or a Markdown delimiter, and combining marks stay attached to their base letter across consecutive token runs.

- Problem: `stripModelSpecialTokens` inserted a separator whenever both characters adjacent to a leaked control token were non-whitespace. This produced `Hello .` (before a period), `( Hello` (after an opening paren), and `**bold **` (before a Markdown closing delimiter) — the last case also breaks `**strong**` rendering, since `**bold **` is no longer valid emphasis. It also mishandled consecutive token runs and combining marks, detaching marks from their base letter, and rescanned every match per code point on a shared outbound-text path.
- Solution:
  - Restrict separator insertion to the case where both neighbors are complete Unicode word characters (letters/marks/digits/underscore), looked up by code point so supplementary-plane and decomposed (NFD) letters keep their boundary.
  - Coalesce each maximal run of consecutive removable tokens plus any trailing combining marks before emitting the marks or deciding the separator, so a mark after (or between) a token run stays attached to the retained base letter and only one separator fires across the run.
  - Index the removable-token spans (disjoint, sorted) with a binary-search `RemovableSpanIndex` and drive the run coalesce with a cursor, so the shared outbound-text path stays linear in the presence of long token runs instead of rescanning every match per code point.
- What changed:
  - `src/shared/text/model-special-tokens.ts` — added Unicode-aware `isWordChar` (`/[\p{L}\p{M}\p{N}_]/u`), code-point boundary helpers, a `RemovableSpanIndex`, and rewrote the main loop to coalesce removable runs + trailing marks and decide the separator once from the retained neighbors.
  - `src/agents/embedded-agent-utils.strip-model-special-tokens.test.ts` — regression coverage for punctuation, Markdown delimiters, non-ASCII punctuation, supplementary-plane and decomposed letters, consecutive token runs, combining marks after and between tokens, and a 2000-token linear-run guard.
  - `src/shared/text/assistant-visible-text.test.ts` — end-to-end `sanitizeAssistantVisibleText` case confirming Markdown emphasis is preserved through the full sanitize pipeline.
- What did NOT change: leading/trailing-token behavior, code-region preservation, and the full-width pipe (DeepSeek U+FF5C) variant handling. No call sites changed; the fix is in the single shared helper all sanitize paths already depend on.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #121426
- [x] This PR fixes a bug or regression

## Motivation

When a model emits a leaked control token (e.g. `<|assistant|>`) immediately before a period, after an opening parenthesis, or before a Markdown closing delimiter, the strip helper inserted a space the surrounding syntax did not need. The Markdown case is not merely cosmetic: `**bold<|token|>**` became `**bold **`, which `markdown-it` parses as literal text rather than strong emphasis — so users saw broken bold formatting whenever a token leaked at that boundary. The fix is a minimal, shared-helper change that covers every sanitize call site without touching any caller.

## Evidence

### Simplification update — head `e4c660b4ced` (re-review of ClawSweeper P1 merge-risk)

Per the ClawSweeper re-review on head `860f508e13e` (P1 merge-risk: shared outbound-text helper grew 52 → 276 lines with a span-index class and overlapping traversal helpers), the implementation has been simplified with **no behavior change**:

- `src/shared/text/model-special-tokens.ts`: **276 → 201 lines** (source net delta +224 → +149).
- Removed the `RemovableSpanIndex` class, the `TokenMatch` interface, and the top-level `isInsideRemovableToken` / `retainedCharBefore` / `retainedCharAfter` helpers. The span lookup is now an inline binary search (`inRemovable`) over two precomputed sorted arrays, and the retained-neighbor walkers are closures inside `stripModelSpecialTokens`.
- Kept the `retainedBefore` / `retainedAfter` "skip an immediately adjacent removable-token run" logic — it is required by the `a<|x|>́<|y|>b` (combining mark between two token runs) case — and kept the O(log m) binary search so the shared outbound-text path stays linear on long token runs.
- Real behavior proof on the new head: `node --import tsx proof-121541.mts` → **25/25 PASS**, and `before == after` identical on all 25 cases `origin/main` already handled (zero regression).
- Regression suite: `pnpm exec vitest run src/agents/embedded-agent-utils.strip-model-special-tokens.test.ts src/shared/text/assistant-visible-text.test.ts` → **138/138 pass**. `oxfmt --check` and `oxlint` clean on the changed file.

### Type-check fix — head `532c1380ba4` (CI green)

The simplification on head `e4c660b4ced` exposed that the PR (since `860f508e13e`) failed four CI type-check jobs (`check-lint`, `check-prod-types`, `check-test-types`, `check-additional-extension-package-boundary`) under the repo's `noUncheckedIndexedAccess` config: array index access (`matches[i]`, `removableStarts[mid]`, `removableEnds[hi]`, `matches[i + 1]`) returns `T | undefined` and was dereferenced without a guard. Fixed with explicit undefined guards (local `const` + `if (... === undefined) break/continue`), no behavior change. The main `origin/main` (52-line) version was already clean; this brings the PR to the same standard.

- `src/shared/text/model-special-tokens.ts`: **201 → 214 lines** (the +13 are the guards).
- `pnpm tsgo:core` clean on `model-special-tokens.ts`; `pnpm exec vitest run ...` → **138/138 pass**; `oxfmt --check` + `oxlint` clean; exact-head proof **25/25 PASS** (before == after identical on all main-handled cases).
- CI on head `532c1380ba4`: all four previously-failing jobs now **pass** (`check-prod-types`, `check-test-types`, `check-additional-extension-package-boundary`, `check-lint`), `openclaw/ci-gate` green.

- Behavior addressed: Removing a leaked model control token next to punctuation, a Markdown delimiter, a supplementary-plane letter, a decomposed combining mark, or across a consecutive token run no longer inserts a spurious space nor concatenates two words nor detaches a combining mark. Adjacent-word separation is preserved across all Unicode boundary shapes, and the shared sanitizer stays linear on long token runs.
- Real environment tested: Linux, Node 22, branch `fix/strip-model-token-separator-121426` rebased on `origin/main` (head `532c1380ba4`).
- Exact steps or command run after this patch:
  - `node --import tsx` invoking `stripModelSpecialTokens` directly on the focused inputs, comparing `origin/main` and the current head
  - `pnpm exec vitest run src/agents/embedded-agent-utils.strip-model-special-tokens.test.ts src/shared/text/assistant-visible-text.test.ts`

### Real behavior proof — current head `532c1380ba4` (worktree, Linux, Node 22)

Run: `node --import tsx proof-121426.mjs` loading `src/shared/text/model-special-tokens.ts` from the worktree head. Covers punctuation, adjacent words, a token run, a token run followed by a combining mark, a mark between two tokens, and a 2000-token linear-run guard.

Before (`origin/main` implementation — `shouldInsertSeparator` checks non-whitespace only, no run coalescing, per-code-point rescan):

```console
$ node --import tsx proof-121426.mjs   # origin/main implementation
FAIL | before closing punctuation       | input="Hello<|t|>."   | expected="Hello."   | got="Hello ."
FAIL | after opening punctuation        | input="(<|t|>Hello"   | expected="(Hello"   | got="( Hello"
FAIL | before Markdown closing delimiter| input="**bold<|t|>**" | expected="**bold**" | got="**bold **"
FAIL | non-ASCII punctuation (Chinese)  | input="你好<|t|>。"   | expected="你好。"   | got="你好 。"
PASS | adjacent words                   | input="Question<|t|>Answer" | expected="Question Answer" | got="Question Answer"
FAIL | two-token run between words      | input="Question<|a|><|b|>Answer" | expected="Question Answer" | got="Question  Answer"
FAIL | three-token run between letters  | input="a<|x|><|y|><|z|>b" | expected="a b" | got="a   b"
FAIL | token run + combining mark       | input="a<|x|><|y|>́b" | expected="á b" | got="a  ́b"
FAIL | longer run + combining mark      | input="ca<|x|><|y|><|z|>́z" | expected="cá z" | got="ca   ́z"
FAIL | single token + combining mark    | input="ca<|a|>́z" | expected="cá z" | got="ca ́z"
FAIL | mark BETWEEN two tokens          | input="a<|x|>́<|y|>b" | expected="á b" | got="a ́ b"

HAS FAILURES
```

After (this patch, head `532c1380ba4`):

```console
$ node --import tsx proof-121426.mjs   # patched implementation, head 532c1380ba4
PASS | before closing punctuation       | input="Hello<|t|>."   | expected="Hello."   | got="Hello."
PASS | after opening punctuation        | input="(<|t|>Hello"   | expected="(Hello"   | got="(Hello"
PASS | before Markdown closing delimiter| input="**bold<|t|>**" | expected="**bold**" | got="**bold**"
PASS | non-ASCII punctuation (Chinese)  | input="你好<|t|>。"   | expected="你好。"   | got="你好。"
PASS | adjacent words                   | input="Question<|t|>Answer" | expected="Question Answer" | got="Question Answer"
PASS | two-token run between words      | input="Question<|a|><|b|>Answer" | expected="Question Answer" | got="Question Answer"
PASS | three-token run between letters  | input="a<|x|><|y|><|z|>b" | expected="a b" | got="a b"
PASS | token run + combining mark       | input="a<|x|><|y|>́b" | expected="á b" | got="á b"
PASS | longer run + combining mark      | input="ca<|x|><|y|><|z|>́z" | expected="cá z" | got="cá z"
PASS | single token + combining mark    | input="ca<|a|>́z" | expected="cá z" | got="cá z"
PASS | mark BETWEEN two tokens          | input="a<|x|>́<|y|>b" | expected="á b" | got="á b"
PASS | 2000-token run (linear guard)    | input="a" + "<|t|>"×2000 + "b" | expected="a b" | got="a b"

ALL PASS
```

Behavior matrix (system response across input shapes; `origin/main` vs this PR):

```text
input shape                                  => origin/main          => 532c1380ba4 (this PR)
Hello<|token|>.                              => "Hello ." (wrong)    => "Hello."       (fixed)
(<|token|>Hello                              => "( Hello" (wrong)    => "(Hello"       (fixed)
**bold<|token|>**                            => "**bold **" (wrong)  => "**bold**"     (fixed)
你好<|token|>。                              => "你好 。" (wrong)    => "你好。"       (fixed)
Question<|token|>Answer                      => "Question Answer"    => "Question Answer" (unchanged)
Question<|a|><|b|>Answer (token run)         => "Question  Answer"   => "Question Answer" (fixed)
a<|x|><|y|><|z|>b (three-token run)         => "a   b"              => "a b"          (fixed)
a<|x|><|y|>́b (run + combining mark)         => "a  ́b" (mark detached) => "á b"        (fixed)
a<|x|>́<|y|>b (mark between tokens)          => "a ́ b" (mark detached) => "á b"        (fixed)
```

Test suite:

```console
$ pnpm exec vitest run src/agents/embedded-agent-utils.strip-model-special-tokens.test.ts src/shared/text/assistant-visible-text.test.ts
 Test Files  2 passed (2)
      Tests  138 passed (138)
```

- Observed result after fix:
  1. `Hello<|token|>.` → `Hello.` (no space before period)
  2. `(<|token|>Hello` → `(Hello` (no space after opening paren)
  3. `**bold<|token|>**` → `**bold**` (Markdown strong emphasis preserved end-to-end through `sanitizeAssistantVisibleText`)
  4. `你好<|token|>。` → `你好。` (Unicode/non-ASCII punctuation handled correctly)
  5. `Question<|token|>Answer` → `Question Answer` (adjacent-word separator still inserted — no regression)
  6. `Question<|a|><|b|>Answer` → `Question Answer` (one separator across a token run)
  7. `a<|x|><|y|>́b` → `á b` (combining mark stays attached to the base letter across a token run)
  8. `a<|x|>́<|y|>b` → `á b` (combining mark between two tokens stays attached, single separator)
  9. `a` + `<|t|>`×2000 + `b` → `a b` (linear on long token runs)
- What was not tested: No browser UI or channel end-to-end flow was exercised; the fix is verified at the shared-helper and full-sanitize-pipeline level, which is where the issue's deterministic reproduction lives. The `markdown-it` emphasis-rendering claim is supported by the existing `markdown-it` dependency's documented parsing rules, not by a rendered DOM snapshot. `oxfmt --check` and `oxlint` are clean on the changed files.


