### PR TITLE
[superseded] fix: context engine never commits turns that run on a plugin agent harness

### DIFF
--- a/src/agents/embedded-agent-runner/run-entry.test.ts
+++ b/src/agents/embedded-agent-runner/run-entry.test.ts
@@ -443,6 +443,10 @@ describe("runEmbeddedAgentEntry", () => {
     expect(primaryReleased).toBe(true);
     expect(fallbackReleased).toBe(true);
     expect(state.finalizedAttempts).toEqual(["fallback"]);
+    // Both attempts published candidate facts before the winner was known. Publishing is
+    // inert: the rejected primary's facts are neither finalized nor discarded, they are
+    // simply superseded, so an early callback can never commit a losing attempt.
+    expect(state.discardedAttempts).toEqual([]);
   });
 
   it("accepts an empty result after a committed side effect and finalizes it once", async () => {

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.context-engine-turn-candidate.test.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.context-engine-turn-candidate.test.ts
@@ -1,0 +1,134 @@
+// The embedded runner must hand its host-owned turn-candidate callback down to the
+// harness attempt params. runSelectedAgentHarnessAttempt reads it from those params to
+// publish a completed plugin-harness turn for durable advancement; a plugin harness has
+// no in-harness after-turn path, so dropping it silently disables context-engine
+// ingestion for every plugin-harness turn.
+import "../../test-helpers/fast-coding-tools.js";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildEmbeddedRunnerAssistant,
+  cleanupEmbeddedAgentRunnerTestWorkspace,
+  createEmbeddedAgentRunnerOpenAiConfig,
+  createEmbeddedAgentRunnerTestWorkspace,
+  createResolvedEmbeddedRunnerModel,
+  immediateEnqueue,
+  makeEmbeddedRunnerAttempt,
+  type EmbeddedAgentRunnerTestWorkspace,
+} from "../../test-helpers/embedded-agent-runner-e2e-fixtures.js";
+import {
+  installEmbeddedRunnerBaseE2eMocks,
+  installEmbeddedRunnerFastRunE2eMocks,
+} from "../../test-helpers/embedded-agent-runner-e2e-mocks.js";
+
+type CapturedAttemptParams = {
+  onContextEngineTurnCandidate?: unknown;
+  contextEngineLogicalTurnLease?: unknown;
+  userTurnTranscriptRecorder?: unknown;
+};
+
+const capturedAttemptParams: CapturedAttemptParams[] = [];
+
+let runEmbeddedAgent: typeof import("./../run.js").runEmbeddedAgent;
+let workspace: EmbeddedAgentRunnerTestWorkspace | undefined;
+let agentDir: string;
+let workspaceDir: string;
+let runCounter = 0;
+
+beforeAll(async () => {
+  vi.resetModules();
+  installEmbeddedRunnerBaseE2eMocks();
+  installEmbeddedRunnerFastRunE2eMocks({
+    runEmbeddedAttempt: (params) => {
+      capturedAttemptParams.push(params as CapturedAttemptParams);
+      return Promise.resolve(
+        makeEmbeddedRunnerAttempt({
+          assistantTexts: ["ok"],
+          lastAssistant: buildEmbeddedRunnerAssistant({
+            content: [{ type: "text", text: "ok" }],
+          }),
+        }),
+      );
+    },
+  });
+  vi.doMock("./../model.js", async () => {
+    const actual = await vi.importActual<typeof import("./../model.js")>("./../model.js");
+    return {
+      ...actual,
+      resolveModelAsync: async (provider: string, modelId: string) =>
+        createResolvedEmbeddedRunnerModel(provider, modelId),
+    };
+  });
+  vi.doMock("../../models-config.js", async () => {
+    const actual =
+      await vi.importActual<typeof import("../../models-config.js")>("../../models-config.js");
+    return { ...actual, ensureOpenClawModelsJson: vi.fn(async () => ({ wrote: false })) };
+  });
+  ({ runEmbeddedAgent } = await import("./../run.js"));
+  workspace = await createEmbeddedAgentRunnerTestWorkspace("openclaw-f5-turn-candidate-");
+  ({ agentDir, workspaceDir } = workspace);
+}, 180_000);
+
+afterAll(async () => {
+  await cleanupEmbeddedAgentRunnerTestWorkspace(workspace);
+  workspace = undefined;
+});
+
+beforeEach(() => {
+  capturedAttemptParams.length = 0;
+});
+
+const runOneTurn = async (params: { onContextEngineTurnCandidate?: () => void }) => {
+  runCounter += 1;
+  return await runEmbeddedAgent({
+    sessionId: `session:f5-turn-candidate-${runCounter}`,
+    sessionKey: `agent:test:f5-turn-candidate-${runCounter}`,
+    workspaceDir,
+    agentDir,
+    config: createEmbeddedAgentRunnerOpenAiConfig(["mock-1"]),
+    prompt: "hello",
+    provider: "openai",
+    model: "mock-1",
+    // Route selection at the plugin-harness ("codex") arm, which is the only arm with
+    // no in-harness after-turn path of its own.
+    agentHarnessRuntimeOverride: "codex",
+    timeoutMs: 5_000,
+    runId: `run:f5-turn-candidate-${runCounter}`,
+    enqueue: immediateEnqueue,
+    ...(params.onContextEngineTurnCandidate
+      ? { onContextEngineTurnCandidate: params.onContextEngineTurnCandidate }
+      : {}),
+  });
+};
+
+describe("embedded run attempt dispatch — context-engine turn candidate", () => {
+  it("forwards the host turn-candidate callback to the harness attempt params", async () => {
+    const onContextEngineTurnCandidate = vi.fn();
+
+    await runOneTurn({ onContextEngineTurnCandidate });
+
+    expect(capturedAttemptParams).toHaveLength(1);
+    expect(capturedAttemptParams[0]?.onContextEngineTurnCandidate).toBe(
+      onContextEngineTurnCandidate,
+    );
+  });
+
+  it("omits the callback when the caller owns no logical turn", async () => {
+    await runOneTurn({});
+
+    expect(capturedAttemptParams).toHaveLength(1);
+    expect(capturedAttemptParams[0]).not.toHaveProperty("onContextEngineTurnCandidate");
+  });
+
+  it("does not forward the logical-turn lease", async () => {
+    // The run loop already selected this lease and called begin() on it. Re-entering
+    // selectContextEngineForTranscriptHost() on a started lease throws
+    // "context-engine logical turn selection is already pinned" whenever the current
+    // turn has no admission receipt yet, which is exactly the pre-dispatch state.
+    // Callers that own the lease keep it; the attempt params must not carry it.
+    const onContextEngineTurnCandidate = vi.fn();
+
+    await runOneTurn({ onContextEngineTurnCandidate });
+
+    expect(capturedAttemptParams[0]).not.toHaveProperty("contextEngineLogicalTurnLease");
+  });
+});

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.context-engine-turn-candidate.test.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.context-engine-turn-candidate.test.ts
@@ -1,8 +1,11 @@
-// The embedded runner must hand its host-owned turn-candidate callback down to the
-// harness attempt params. runSelectedAgentHarnessAttempt reads it from those params to
-// publish a completed plugin-harness turn for durable advancement; a plugin harness has
-// no in-harness after-turn path, so dropping it silently disables context-engine
-// ingestion for every plugin-harness turn.
+// Dispatch-seam coverage only: this asserts which fields `dispatchEmbeddedRunAttempt`
+// puts on the harness attempt params. The harness-selection module is mocked here, so
+// nothing below exercises a real harness, the terminal-anchor gate, or settlement —
+// `selection.test.ts` owns those contracts.
+//
+// The field matters because `runSelectedAgentHarnessAttempt` reads the callback from
+// these params to publish a completed turn to the outer logical-turn owner. Dropping it
+// leaves a plugin-harness turn with no write path at all.
 import "../../test-helpers/fast-coding-tools.js";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -88,8 +91,8 @@ const runOneTurn = async (params: { onContextEngineTurnCandidate?: () => void })
     prompt: "hello",
     provider: "openai",
     model: "mock-1",
-    // Route selection at the plugin-harness ("codex") arm, which is the only arm with
-    // no in-harness after-turn path of its own.
+    // Routing metadata only: the mocked selection module resolves this to a "codex"
+    // harness id. No plugin harness runs in this file.
     agentHarnessRuntimeOverride: "codex",
     timeoutMs: 5_000,
     runId: `run:f5-turn-candidate-${runCounter}`,

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -268,6 +268,14 @@ export async function dispatchEmbeddedRunAttempt(input: {
     finalizePromptForResolvedTools:
       pluginHarnessPrompt === undefined ? params.finalizePromptForResolvedTools : undefined,
     userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
+    // Host-owned turn authority. runSelectedAgentHarnessAttempt reads this from the
+    // attempt params to publish the completed turn to the logical-turn owner, then
+    // withoutInternalHarnessAuthority() strips it before any harness runs. Without it
+    // a plugin harness turn is never handed back for durable advancement, and plugin
+    // harnesses have no in-harness after-turn path of their own.
+    ...(params.onContextEngineTurnCandidate
+      ? { onContextEngineTurnCandidate: params.onContextEngineTurnCandidate }
+      : {}),
     skipPreparedUserTurnMessage: runtime.skipPreparedUserTurnMessage,
     currentInboundEventKind: params.currentInboundEventKind,
     currentInboundContext: params.currentInboundContext,

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -613,6 +613,88 @@ describe("runAgentHarnessAttempt", () => {
     },
   );
 
+  it("keeps host turn authority out of the plugin harness attempt params", async () => {
+    // The turn-candidate callback and the logical-turn lease are host-owned authority.
+    // They must reach runSelectedAgentHarnessAttempt so a completed plugin-harness turn
+    // can be published, and withoutInternalHarnessAuthority() must strip both before the
+    // harness itself runs.
+    const admission = {
+      ...createTranscriptAnchor("user-1", 1, 0),
+      logicalTurnId: "authority-turn",
+      role: "user" as const,
+    };
+    const terminal = createTranscriptAnchor("assistant-1", 2, 1);
+    const onContextEngineTurnCandidate = vi.fn();
+    const configuredEngine = createContextEngineRequiringAssembly();
+    const asEffective = (): ReturnType<ContextEngineLogicalTurnLease["begin"]> => ({
+      engine: configuredEngine,
+      registeredId: configuredEngine.info.id,
+      mode: "configured",
+    });
+    const lease = {
+      get engine() {
+        return configuredEngine;
+      },
+      get effectiveEngine() {
+        return configuredEngine;
+      },
+      get effectiveEngineId() {
+        return configuredEngine.info.id;
+      },
+      get effectiveEnginePluginId() {
+        return undefined;
+      },
+      get degraded() {
+        return false;
+      },
+      get degradedReason() {
+        return undefined;
+      },
+      selectForHost: vi.fn(() => asEffective()),
+      degradeBeforeStart: vi.fn(() => asEffective()),
+      begin: vi.fn(() => asEffective()),
+      deferDisposalUntil: vi.fn(),
+      dispose: vi.fn(async () => {}),
+    } satisfies ContextEngineLogicalTurnLease;
+    let harnessParamKeys: string[] = [];
+    registerAgentHarness(
+      {
+        id: "codex",
+        label: "Codex",
+        contextEngineHostCapabilities: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST.capabilities,
+        supports: () => ({ supported: true, priority: 100 }),
+        runAttempt: async (attemptParams) => {
+          harnessParamKeys = Object.keys(attemptParams);
+          return {
+            ...createAttemptResult("session-1"),
+            contextEngineTerminalAnchor: terminal,
+          };
+        },
+      },
+      { ownerPluginId: "codex" },
+    );
+    const params = createAttemptParams(providerRuntimeConfig("codex", "codex"));
+    params.agentHarnessRuntimeOverride = "codex";
+    params.sessionKey = admission.sessionKey;
+    params.sessionTarget = {
+      agentId: admission.agentId,
+      sessionId: admission.sessionId,
+      sessionKey: admission.sessionKey,
+      storePath: admission.storePath,
+    };
+    params.userTurnTranscriptRecorder = createTranscriptRecorder(admission);
+    params.contextEngineLogicalTurnLease = lease;
+    params.onContextEngineTurnCandidate = onContextEngineTurnCandidate;
+
+    await runAgentHarnessAttempt(params);
+
+    expect(harnessParamKeys).not.toContain("onContextEngineTurnCandidate");
+    expect(harnessParamKeys).not.toContain("contextEngineLogicalTurnLease");
+    expect(onContextEngineTurnCandidate).toHaveBeenCalledWith(
+      expect.objectContaining({ boundary: { admission, terminal }, harnessId: "codex" }),
+    );
+  });
+
   it("drains pending context-engine turns before pinning a plugin harness", async () => {
     const order: string[] = [];
     const configuredEngine = createContextEngineRequiringAssembly();

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -613,11 +613,11 @@ describe("runAgentHarnessAttempt", () => {
     },
   );
 
-  it("keeps host turn authority out of the plugin harness attempt params", async () => {
-    // The turn-candidate callback and the logical-turn lease are host-owned authority.
-    // They must reach runSelectedAgentHarnessAttempt so a completed plugin-harness turn
-    // can be published, and withoutInternalHarnessAuthority() must strip both before the
-    // harness itself runs.
+  it("strips both host authority fields before a plugin harness runs", async () => {
+    // Both fields are host-owned authority. When a caller supplies both,
+    // withoutInternalHarnessAuthority() must remove both from what the harness sees,
+    // while core keeps its retained copies and still publishes the completed turn.
+    // Callback-only settlement is covered separately below.
     const admission = {
       ...createTranscriptAnchor("user-1", 1, 0),
       logicalTurnId: "authority-turn",
@@ -656,7 +656,7 @@ describe("runAgentHarnessAttempt", () => {
       deferDisposalUntil: vi.fn(),
       dispose: vi.fn(async () => {}),
     } satisfies ContextEngineLogicalTurnLease;
-    let harnessParamKeys: string[] = [];
+    let harnessParams: object | undefined;
     registerAgentHarness(
       {
         id: "codex",
@@ -664,7 +664,7 @@ describe("runAgentHarnessAttempt", () => {
         contextEngineHostCapabilities: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST.capabilities,
         supports: () => ({ supported: true, priority: 100 }),
         runAttempt: async (attemptParams) => {
-          harnessParamKeys = Object.keys(attemptParams);
+          harnessParams = attemptParams;
           return {
             ...createAttemptResult("session-1"),
             contextEngineTerminalAnchor: terminal,
@@ -688,11 +688,96 @@ describe("runAgentHarnessAttempt", () => {
 
     await runAgentHarnessAttempt(params);
 
-    expect(harnessParamKeys).not.toContain("onContextEngineTurnCandidate");
-    expect(harnessParamKeys).not.toContain("contextEngineLogicalTurnLease");
+    // Assert on the object itself, not its own enumerable keys, so an inherited or
+    // non-enumerable reappearance of either field also fails.
+    expect(harnessParams).not.toHaveProperty("onContextEngineTurnCandidate");
+    expect(harnessParams).not.toHaveProperty("contextEngineLogicalTurnLease");
+    expect(onContextEngineTurnCandidate).toHaveBeenCalledTimes(1);
     expect(onContextEngineTurnCandidate).toHaveBeenCalledWith(
       expect.objectContaining({ boundary: { admission, terminal }, harnessId: "codex" }),
     );
+  });
+
+  it("publishes plugin harness turn facts when the caller supplies no logical-turn lease", async () => {
+    // This is the shape production actually uses: the run loop owns the lease and has
+    // already begun it, so the attempt params carry the callback alone. The post-attempt
+    // gate must not depend on a lease being present.
+    const admission = {
+      ...createTranscriptAnchor("user-1", 1, 0),
+      logicalTurnId: "callback-only-turn",
+      role: "user" as const,
+    };
+    const terminal = createTranscriptAnchor("assistant-1", 2, 1);
+    const onContextEngineTurnCandidate = vi.fn();
+    let harnessParams: object | undefined;
+    registerAgentHarness(
+      {
+        id: "codex",
+        label: "Codex",
+        supports: () => ({ supported: true, priority: 100 }),
+        runAttempt: async (attemptParams) => {
+          harnessParams = attemptParams;
+          return {
+            ...createAttemptResult("session-1"),
+            contextEngineTerminalAnchor: terminal,
+          };
+        },
+      },
+      { ownerPluginId: "codex" },
+    );
+    const params = createAttemptParams(providerRuntimeConfig("codex", "codex"));
+    params.agentHarnessRuntimeOverride = "codex";
+    params.sessionKey = admission.sessionKey;
+    params.sessionTarget = {
+      agentId: admission.agentId,
+      sessionId: admission.sessionId,
+      sessionKey: admission.sessionKey,
+      storePath: admission.storePath,
+    };
+    params.userTurnTranscriptRecorder = createTranscriptRecorder(admission);
+    params.onContextEngineTurnCandidate = onContextEngineTurnCandidate;
+
+    const result = await runAgentHarnessAttempt(params);
+
+    expect(params.contextEngineLogicalTurnLease).toBeUndefined();
+    expect(onContextEngineTurnCandidate).toHaveBeenCalledTimes(1);
+    expect(onContextEngineTurnCandidate).toHaveBeenCalledWith(
+      expect.objectContaining({ boundary: { admission, terminal }, harnessId: "codex" }),
+    );
+    expect(harnessParams).not.toHaveProperty("onContextEngineTurnCandidate");
+    // The anchor is host-private: core consumes it and keeps it off the public result.
+    expect(result).not.toHaveProperty("contextEngineTerminalAnchor");
+  });
+
+  it("publishes no turn facts for the built-in harness even when a callback is supplied", async () => {
+    // The built-in harness finalizes its own turn through the legacy after-turn path
+    // because the sanitizer strips the callback from what it receives. It reports no
+    // terminal anchor, so this gate must not publish a second time for the same turn.
+    // Ingesting once, in-harness, is the current built-in behavior; this pins that the
+    // restored plumbing does not add a second durable path on top of it.
+    const admission = {
+      ...createTranscriptAnchor("user-1", 1, 0),
+      logicalTurnId: "builtin-turn",
+      role: "user" as const,
+    };
+    const onContextEngineTurnCandidate = vi.fn();
+    const params = createAttemptParams();
+    params.sessionKey = admission.sessionKey;
+    params.sessionTarget = {
+      agentId: admission.agentId,
+      sessionId: admission.sessionId,
+      sessionKey: admission.sessionKey,
+      storePath: admission.storePath,
+    };
+    params.userTurnTranscriptRecorder = createTranscriptRecorder(admission);
+    params.onContextEngineTurnCandidate = onContextEngineTurnCandidate;
+
+    const result = await runAgentHarnessAttempt(params);
+
+    expect(result.sessionIdUsed).toBe("openclaw");
+    expect(agentRunAttempt).toHaveBeenCalledTimes(1);
+    expect(agentRunAttempt.mock.calls[0]?.[0]).not.toHaveProperty("onContextEngineTurnCandidate");
+    expect(onContextEngineTurnCandidate).not.toHaveBeenCalled();
   });
 
   it("drains pending context-engine turns before pinning a plugin harness", async () => {


### PR DESCRIPTION
Closes #121515


### Post-filing: end-to-end proof on a production instance

Applied this exact change to a running 2026.8.1 instance (built from source), restarted, and
measured the plugin-harness path with a real third-party context engine (LibraVDB) and the primary
model routed to the codex harness.

**Before** — the engine's own per-session manifest store had not been written since 2026-08-08
12:32, across two days of normal use. `assemble` ran on every turn; nothing was ever committed.

**After** — one ordinary turn:

```
$ openclaw agent --session-key doc-f5-prod-verify \
    -m "Please remember: the F5 verification codeword is TANGERINE. Reply with only OK."
OK

$ ls -lat ~/.openclaw/libravdb-manifests/*.manifest.json | head -2
-rw-------  1 admin  staff   869 Aug 10 17:49 6beaca4c…manifest.json   ← new
-rw-------  1 admin  staff  8211 Aug  8 12:32 22e24636…manifest.json   ← previous newest
```

The new manifest carries the real session id (`d6868cdb-b6ad-44b9-a6c2-a7cdfb6e2e06`) and 2 turns.

**Durability confirmed from a different session**, so this is not read-back from the live transcript:

```
$ openclaw agent --session-key doc-f5-recall-check \
    -m "Using your memory tools, what is the F5 verification codeword? Reply with just the word, or NOTFOUND."
TANGERINE
```

Write in one session, recall in another — the commit path is genuinely running.

⚠️ Scope: this instance also carries the fix from #121461, which is required for the engine to be
selected at all. This evidence therefore demonstrates the *commit* path that this PR restores, on
top of that selection fix; it is not independent of it.

*AI-assisted: authored and validated with Claude (Claude Code). Every command and every block of output below is from a real run.*

## What Problem This Solves

Fixes an issue where operators running a context engine plugin with a model routed to a plugin agent
harness — for example any `openai/*` model with `agentRuntime: { id: "codex" }` — would have context
read from memory on every turn but never written back. The engine's `assemble` runs, so the agent
still sees recalled context, but no completed turn is ever committed: `commitTurn` never runs and
nothing is ingested. Turns succeed and nothing is logged, so the only visible symptom is that durable
memory quietly stops growing.

The same engine on the same gateway keeps ingesting when a turn happens to run on the built-in
`openclaw` harness, which makes this look like a plugin problem rather than a host problem.

## Why This Change Was Made

A completed turn is committed by the outer logical-turn owner, not by the harness.
`runEmbeddedAgentEntry()` holds one lease for the whole model-fallback transaction and commits only
the accepted winner (`run-entry.ts:259-264`, `:463-480`). A plugin harness returns a host-private
terminal transcript anchor and writes nothing itself; core, outside the plugin handoff, turns that
anchor into candidate facts at `src/agents/harness/selection.ts:557-595`.

That gate reads `onContextEngineTurnCandidate` from the attempt params, but
`src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts` rebuilds those params field by field
with no spread and never copied it, so the gate could not fire and no facts were ever produced. The
field is optional, so nothing caught it at compile time. This change copies it, in the same shape
already used for the other host-owned field on that object (`trajectoryRecorder`, l.247).

**Host authority is unchanged.** `withoutInternalHarnessAuthority()` (`selection.ts:669-679`) still
strips this field before any harness runs, and `AgentHarnessAttemptParams`
(`src/agents/harness/types.ts:90-93`) still omits it from the type a harness can see. A new test
asserts the runtime side of that boundary directly.

### Non-goals

- **No write path is added to any harness.** A plugin harness performing its own `afterTurn`/
  `commitTurn` would break the ownership model and could ingest a rejected fallback attempt. Core
  post-return settlement is the intended plugin-harness write path, and this change only restores its
  input.
- **The built-in harness's immediate-`afterTurn` compatibility branch
  (`attempt-after-turn.ts:176-184`) is left alone.** It is how standalone embedded calls with no outer
  logical-turn owner finalize, and removing it would break them.
- **The logical-turn lease is deliberately not forwarded.** It is the other field
  `withoutInternalHarnessAuthority()` strips, so forwarding it looks symmetric, but it would be a
  regression. By the time the params reach `runSelectedAgentHarnessAttempt` the run loop has already
  called `begin()` on that lease (`run-loop.ts:297`), and the lease block at `selection.ts:508`
  re-enters `selectContextEngineForTranscriptHost`. At that point the current turn still has no
  admission receipt — measured `hasAdmission: false` on every turn — so stock code calls
  `degradeBeforeStart`, which throws `context-engine logical turn selection is already pinned` when the
  lease state is `"started"` (`context-engine-logical-turn.ts:100-112`). That would hard-fail the turn
  for exactly the operators this fixes. The lease stays with the run loop that owns it, and a
  regression test pins the decision with that reasoning in a comment.
- **A second, related plumbing defect is reported in #121515 and deliberately left unchanged here.**
  Core strips this same callback before calling the trusted built-in harness too, so an outer-owned
  built-in run keeps taking the compatibility branch. That branch calls the legacy `afterTurn`
  immediately, before model fallback has chosen a winner, so **an outer-owned rejected built-in
  fallback attempt can ingest early**. That defect pre-dates this change and is neither introduced
  nor worsened by it: the built-in harness still receives no callback and still returns no terminal
  anchor, so this PR adds no second write path on top of it (pinned by a new test). Repairing it
  changes default-path ingestion semantics rather than restoring dropped plumbing, so it wants its
  own decision; #121515 carries the measurement.

## User Impact

Operators using a context engine plugin with a plugin-harness model get durable memory writes again:
each completed turn is committed through the engine's `commitTurn`, and the engine ingests the turn.
No configuration change is needed.

Nothing changes for the built-in harness. It keeps its existing in-harness after-turn path and does
not double-ingest: it reports no `contextEngineTerminalAnchor`, so the candidate gate stays closed.
Operators on the legacy context engine see no change at all.

## Evidence

### 1. Regression test: fails on stock, passes patched

Reverting only the source file, never the tests:

```
$ git checkout origin/main -- src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
$ npx vitest run --config test/vitest/vitest.agents-embedded-agent-run.config.ts \
    run-attempt-dispatch.context-engine-turn-candidate

 FAIL  |agents-embedded-agent-run| .../run-attempt-dispatch.context-engine-turn-candidate.test.ts >
       embedded run attempt dispatch — context-engine turn candidate >
       forwards the host turn-candidate callback to the harness attempt params
AssertionError: expected undefined to be [Function Mock] // Object.is equality

- Expected: [Function Mock]
+ Received: undefined

 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
   Duration  6.80s
```

```
$ git checkout HEAD -- src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
$ npx vitest run --config test/vitest/vitest.agents-embedded-agent-run.config.ts \
    run-attempt-dispatch.context-engine-turn-candidate

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Duration  6.10s
```

That file covers the dispatch seam only — the harness-selection module is mocked there, so it proves
which fields land on the attempt params and nothing else. Its comments say so. The contracts below
are proven separately, against real selection.

### 2. Contracts proven against real harness selection

`src/agents/harness/selection.test.ts` (113 tests, +2 new, 1 tightened; all run real
`runAgentHarnessAttempt`):

- **Callback-only settlement** — "publishes plugin harness turn facts when the caller supplies no
  logical-turn lease". This is the shape production actually produces after this change: callback,
  admission, and a harness-returned anchor, with **no** lease. Asserts the callback fires exactly
  once with the boundary, the harness received no callback, and the anchor is stripped from the
  public result. Without it, nothing would catch an accidental dependence on a lease being present.
- **No second publish on the built-in harness** — "publishes no turn facts for the built-in harness
  even when a callback is supplied". The built-in harness receives no callback (sanitizer) and
  returns no `contextEngineTerminalAnchor`, so the post-attempt gate must not fire. Asserts the
  built-in `runAttempt` params carry no callback and the host callback is never invoked. This pins
  the implicit coupling that keeps this change from adding a second durable write path on top of the
  built-in legacy `afterTurn`.
- **Authority stripping** — the existing new case now asserts with `not.toHaveProperty` on the params
  object rather than on its own enumerable keys, so an inherited or non-enumerable reappearance of
  either field also fails, and asserts the callback fires exactly once.

`src/agents/embedded-agent-runner/run-entry.test.ts` (19 tests): the existing
"finalizes only the accepted fallback candidate" case, where both a rejected and an accepted attempt
publish facts, is extended with `expect(state.discardedAttempts).toEqual([])`. That states the
inertness contract directly: the rejected attempt's early callback is neither finalized nor
discarded, only superseded, so publishing before the winner is known cannot commit a loser.

```
$ npx vitest run --config test/vitest/vitest.agents-core.config.ts src/agents/harness/selection.test.ts
 Test Files  1 passed (1)
      Tests  113 passed (113)

$ npx vitest run --config test/vitest/vitest.agents-embedded-agent.config.ts \
    src/agents/embedded-agent-runner/run-entry.test.ts
 Test Files  1 passed (1)
      Tests  19 passed (19)
```

These four cases pass on stock as well as patched — they call `runAgentHarnessAttempt` directly and
so do not cross the dispatch builder. They are contract documentation and regression fences for the
behavior this change now depends on, not evidence of the defect. Only the dispatch test in section 1
distinguishes stock from patched.

### 3. End-to-end on a live gateway — before and after

Isolated profile on port 19301, a context engine plugin instrumented to log every lifecycle call, and
the host instrumented at each gate. Same gateway, same engine, same prompt shape.

**Before** — 7 codex-harness turns, all completed successfully:

```
harnessSelection:gate {harnessId:"codex", hasCandidateCb:FALSE, hasAdmission:true,
                       hasTerminalAnchor:true, recorderHasPersisted:true, terminalKind:"ok"}
runEntry:settle       {hasTurnAttempt:false, canAdvance:null, fallbackOutcome:"completed"}

engine lifecycle calls: assemble, dispose        (x7 turns; no commitTurn, no afterTurn)
per-session artifacts written by the engine: none
```

**After** — same profile, fix applied:

```
runLoop:params        {hasCandidateCb:true, hasLeaseParam:true, harnessId:"codex"}
harnessSelection:gate {harnessId:"codex", hasCandidateCb:TRUE, hasAdmission:true,
                       hasTerminalAnchor:true, terminalKind:"ok"}
runEntry:settle       {hasTurnAttempt:TRUE, canAdvance:TRUE, fallbackOutcome:"completed"}
finalizeAccepted:enter{engineId:"libravdb-memory", degraded:false,
                       idempotency:"atomic-idempotent-v1", commitTurnType:"function"}

engine lifecycle calls: assemble, commitTurn -> afterTurn -> {ok:true, queued:true},
                        commitTurn resolved {status:"committed"}
```

The engine wrote its per-session artifact for that turn, and a second turn on the same session
extended it rather than duplicating it:

```
15:40  <sha256-of-sessionId>.manifest.json   869 bytes   (turn 1)
15:41  <sha256-of-sessionId>.manifest.json  1566 bytes   (turn 2, same session)
```

**Built-in harness, fix applied — unchanged, and no double ingestion:**

```
completeAfterTurn:enter {hasActiveContextEngine:true, hasCandidateCb:false}   -> compatibility afterTurn
harnessSelection:gate   {harnessId:"openclaw", hasCandidateCb:true,
                         hasTerminalAnchor:FALSE}                             -> gate does not fire
runEntry:settle         {hasTurnAttempt:false}
```

The callback now reaches the gate, but the built-in harness returns no terminal anchor, so the gate
stays closed and only the existing in-harness path runs. One artifact written, one ingestion.

### 4. Repository checks — no new failures

`node --import tsx scripts/check.mts`, stock vs patched on this checkout. Both runs end with the same
single failing lane and the identical 7 errors, none in files this PR touches:

```
                          stock                     patched
  17 lanes                ok                        ok
  typecheck prod          failed:1                  failed:1

both runs, identical list:
  packages/terminal-core/src/ansi.ts(194,38): error TS2554: Expected 1 arguments, but got 2.
  src/agents/sandbox/fs-bridge-path-safety.ts(176,7): error TS2353: ... 'rejectSymlinks' ...
  src/cli/session-ref.ts(5,8): error TS2307: Cannot find module '@openclaw/session-url-contract/parse'
  src/config/includes.ts(502,5): error TS2353: ... 'rejectSymlinks' ...
  src/gateway/control-ui.ts(937,5): error TS2353: ... 'rejectSymlinks' ...
  src/hooks/workspace.ts(330,5): error TS2353: ... 'rejectSymlinks' ...
  src/skills/loading/local-loader.ts(33,5): error TS2353: ... 'rejectSymlinks' ...
```

These are a stale dependency tree on the machine used, not a regression from this change: the two
lists are byte-identical and the patched file appears in neither.

Test types (`pnpm tsgo:test`): 8 errors, the same family plus `ui/src/app-session-route-paths.ts`,
none in files this PR touches. Formatting: `oxfmt --check` clean on all three files.

### What this evidence does not establish

- No bisect: the commit that introduced the gap is unidentified, and it is unknown whether the
  plugin-harness path ever worked.
- Only the `codex` harness was exercised live. `extensions/copilot` also returns
  `contextEngineTerminalAnchor` and should benefit identically, but that was not measured.
- The end-to-end arms ran through the `openclaw agent` CLI dispatcher. The channel/auto-reply
  dispatcher shares `run-entry.ts` (instrumented in the traces above), so the drop point is common to
  both, but a channel-originated turn was not measured.
- The live before/after arms were produced by applying this one-field change in memory to the built
  `dist` chunk of the running gateway, not by rebuilding it. The deterministic proof that the source
  change does what it says is the regression test in section 1.
- `node scripts/run-oxlint.mjs` could not run on this machine: it fails during
  `prepare-extension-package-boundary-artifacts` from the same stale dependency tree, before reaching
  any of the changed files. CI lint is unverified locally.
- No test exercises a plugin harness end to end through the dispatch builder in one process: the
  dispatch test mocks selection, and the selection tests call `runAgentHarnessAttempt` directly. The
  live gateway arms in section 3 are what joins the two halves.
- The built-in case in section 2 pins the current coupling — no callback in, no anchor out, so no
  second publish. It does not prove the built-in harness ingests correctly; it deliberately documents
  today's behavior, including the pre-existing early-ingest defect named under Non-goals.
