### PR TITLE
fix(qa): resolve Docker harness script entrypoints

### DIFF
--- a/scripts/e2e/gateway-network-docker.sh
+++ b/scripts/e2e/gateway-network-docker.sh
@@ -45,7 +45,7 @@ run_suspension_phase() {
     -e "GW_MODE=suspension-$stage-restart" \
     -e "GW_STATE_PATH=$SUSPENSION_STATE_PATH" \
     "$GW_NAME" \
-    node --import tsx scripts/e2e/lib/gateway-network/client.mts
+    node scripts/e2e/lib/gateway-network/client.mts
 }
 
 trap cleanup EXIT
@@ -84,7 +84,7 @@ DOCKER_COMMAND_TIMEOUT="$CLIENT_TIMEOUT" run_logged gateway-network-client docke
   -e "GW_URL=ws://$GW_NAME:$PORT" \
   -e "GW_TOKEN=$TOKEN" \
   "$IMAGE_NAME" \
-  node --import tsx scripts/e2e/lib/gateway-network/client.mts
+  node scripts/e2e/lib/gateway-network/client.mts
 
 phase_started="$SECONDS"
 echo "Running cooperative suspension lifecycle before container stop..."

--- a/scripts/e2e/kitchen-sink-rpc-docker.sh
+++ b/scripts/e2e/kitchen-sink-rpc-docker.sh
@@ -52,7 +52,7 @@ echo "Running kitchen-sink RPC Docker E2E..."
 docker_e2e_docker_cmd rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
 docker_e2e_harness_mount_args
 DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run --name "$CONTAINER_NAME" "${DOCKER_E2E_HARNESS_ARGS[@]}" "${DOCKER_ENV_ARGS[@]}" -i "$IMAGE_NAME" \
-  node --import tsx scripts/e2e/kitchen-sink-rpc-walk.mts >"$RUN_LOG" 2>&1 &
+  bash -lc "source scripts/lib/openclaw-e2e-instance.sh; openclaw_e2e_run_script_entrypoint scripts/e2e/kitchen-sink-rpc-walk" >"$RUN_LOG" 2>&1 &
 docker_pid="$!"
 
 docker_e2e_sample_stats_until_exit \

--- a/scripts/e2e/lib/release-upgrade-user-journey/scenario.sh
+++ b/scripts/e2e/lib/release-upgrade-user-journey/scenario.sh
@@ -50,7 +50,11 @@ candidate_version="$(
 if [ -n "${OPENCLAW_RELEASE_UPGRADE_BASELINE_SPEC:-}" ]; then
   BASELINE_SPEC="$OPENCLAW_RELEASE_UPGRADE_BASELINE_SPEC"
 else
-  BASELINE_SPEC="$(node --import tsx scripts/lib/release-upgrade-baseline.mts --candidate-version "$candidate_version")"
+  BASELINE_SPEC="$(
+    openclaw_e2e_run_script_entrypoint \
+      scripts/lib/release-upgrade-baseline \
+      --candidate-version "$candidate_version"
+  )"
 fi
 
 mock_pid=""

--- a/scripts/lib/docker-e2e-image.sh
+++ b/scripts/lib/docker-e2e-image.sh
@@ -167,11 +167,7 @@ docker_e2e_test_state_entrypoint() {
 docker_e2e_run_test_state() {
   local entrypoint
   entrypoint="$(docker_e2e_test_state_entrypoint)" || return
-  if [[ "$entrypoint" == *.mts ]]; then
-    node --import tsx "$entrypoint" "$@"
-  else
-    node "$entrypoint" "$@"
-  fi
+  node "$entrypoint" "$@"
 }
 
 docker_e2e_test_state_shell_b64() {

--- a/scripts/lib/docker-e2e-package.sh
+++ b/scripts/lib/docker-e2e-package.sh
@@ -268,7 +268,10 @@ docker_e2e_harness_mount_args() {
   DOCKER_E2E_HARNESS_ARGS=(
     -v "$harness_root/scripts/e2e:/app/scripts/e2e:ro"
     -v "$harness_root/scripts/lib:/app/scripts/lib:ro"
+    -v "$harness_root/packages/gateway-client/src:/app/packages/gateway-client/src:ro"
+    -v "$harness_root/packages/normalization-core/package.json:/app/packages/normalization-core/package.json:ro"
     -v "$harness_root/packages/normalization-core/src:/app/packages/normalization-core/src:ro"
+    -v "$harness_root/tsconfig.json:/app/tsconfig.json:ro"
     -v "$harness_root/test/e2e/qa-lab:/app/test/e2e/qa-lab:ro"
     -v "$harness_root/test/helpers:/app/test/helpers:ro"
     -v "$harness_root/scripts/windows-cmd-helpers.mjs:/app/scripts/windows-cmd-helpers.mjs:ro"

--- a/scripts/lib/openclaw-e2e-instance.sh
+++ b/scripts/lib/openclaw-e2e-instance.sh
@@ -47,6 +47,20 @@ openclaw_e2e_resolve_entrypoint() {
   echo "OpenClaw entrypoint not found under dist/" >&2
   return 1
 }
+openclaw_e2e_run_script_entrypoint() {
+  local stem="${1:?missing OpenClaw E2E script stem}"
+  shift
+  if [ -f "$stem.mts" ]; then
+    tsx "$stem.mts" "$@"
+    return
+  fi
+  if [ -f "$stem.mjs" ]; then
+    node "$stem.mjs" "$@"
+    return
+  fi
+  echo "OpenClaw E2E script entrypoint not found: $stem.{mts,mjs}" >&2
+  return 1
+}
 openclaw_e2e_package_root() {
   local prefix="${1:-}"
   if [ -n "$prefix" ]; then

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -14,6 +14,7 @@ const DOCKER_ALL_SCHEDULER_PATH = "scripts/test-docker-all.mts";
 const DOCKER_E2E_PACKAGE_HELPER_PATH = "scripts/lib/docker-e2e-package.sh";
 const DOCKER_E2E_IMAGE_HELPER_PATH = "scripts/lib/docker-e2e-image.sh";
 const DOCKER_E2E_SCENARIOS_PATH = "scripts/lib/docker-e2e-scenarios.mts";
+const OPENCLAW_E2E_INSTANCE_HELPER_PATH = "scripts/lib/openclaw-e2e-instance.sh";
 const COMPOSE_SETUP_E2E_PATH = "scripts/e2e/compose-setup.sh";
 const CLI_INSTALLER_DISTRIBUTION_E2E_PATH = "scripts/e2e/cli-installer-distribution-docker.sh";
 const DOCKER_PACKAGE_INSTALL_E2E_PATH = "scripts/e2e/docker-package-install.sh";
@@ -565,6 +566,72 @@ print_log_tail "$LOG_PATH"
     const compiledResult = resolveEntrypoint(compiledRoot);
     expect(compiledResult.status, compiledResult.stderr).toBe(0);
     expect(compiledResult.stdout.trim()).toBe(compiledEntrypoint);
+  });
+
+  it("runs current TypeScript and frozen JavaScript Docker harness entrypoints", () => {
+    const fixtureRoot = tempDirs.make("openclaw-docker-script-entrypoint-");
+    const scriptStem = join(fixtureRoot, "fixture");
+    const runFixture = (value: string) =>
+      spawnSync(
+        "bash",
+        [
+          "-c",
+          `source "${OPENCLAW_E2E_INSTANCE_HELPER_PATH}"; openclaw_e2e_run_script_entrypoint "$1" "$2"`,
+          "openclaw-docker-script-entrypoint",
+          scriptStem,
+          value,
+        ],
+        {
+          cwd: process.cwd(),
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            PATH: `${join(process.cwd(), "node_modules/.bin")}:${process.env.PATH ?? ""}`,
+          },
+        },
+      );
+
+    writeFileSync(
+      `${scriptStem}.mts`,
+      'enum Choice { Current = "current" }\nconst value: Choice = process.argv[2] as Choice; process.stdout.write(`mts:${value}`);\n',
+      "utf8",
+    );
+    const sourceResult = runFixture("current");
+    expect(sourceResult.status, sourceResult.stderr).toBe(0);
+    expect(sourceResult.stdout).toBe("mts:current");
+
+    rmSync(`${scriptStem}.mts`);
+    writeFileSync(
+      `${scriptStem}.mjs`,
+      'process.stdout.write(`mjs:${process.argv[2] ?? ""}`);\n',
+      "utf8",
+    );
+    const compiledResult = runFixture("frozen");
+    expect(compiledResult.status, compiledResult.stderr).toBe(0);
+    expect(compiledResult.stdout).toBe("mjs:frozen");
+
+    rmSync(`${scriptStem}.mjs`);
+    const missingResult = runFixture("missing");
+    expect(missingResult.status).toBe(1);
+    expect(missingResult.stderr).toContain("script entrypoint not found");
+  });
+
+  it("routes package-only Docker TypeScript entrypoints through their required runtime", () => {
+    const gatewayRunner = readFileSync(GATEWAY_NETWORK_DOCKER_E2E_PATH, "utf8");
+    const imageHelper = readFileSync(DOCKER_E2E_IMAGE_HELPER_PATH, "utf8");
+    const kitchenSinkRunner = readFileSync(KITCHEN_SINK_RPC_DOCKER_E2E_PATH, "utf8");
+    const releaseUpgradeScenario = readFileSync(RELEASE_UPGRADE_USER_JOURNEY_SCENARIO_PATH, "utf8");
+    expect(gatewayRunner).toContain("node scripts/e2e/lib/gateway-network/client.mts");
+    expect(kitchenSinkRunner).toContain(
+      "openclaw_e2e_run_script_entrypoint scripts/e2e/kitchen-sink-rpc-walk",
+    );
+    expect(releaseUpgradeScenario).toContain(
+      "openclaw_e2e_run_script_entrypoint \\\n      scripts/lib/release-upgrade-baseline",
+    );
+    expect(gatewayRunner).not.toContain("node --import tsx");
+    expect(imageHelper).not.toContain('node --import tsx "$entrypoint"');
+    expect(kitchenSinkRunner).not.toContain("node --import tsx");
+    expect(releaseUpgradeScenario).not.toContain("node --import tsx");
   });
 
   it("rejects malformed Docker E2E resource limits before a suite starts", () => {
@@ -4315,7 +4382,10 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
       "--allow-unreleased-changelog",
       'local harness_root="${DOCKER_E2E_HARNESS_ROOT_DIR:-$ROOT_DIR}"',
       '-v "$harness_root/scripts/windows-cmd-helpers.mjs:/app/scripts/windows-cmd-helpers.mjs:ro"',
+      '-v "$harness_root/packages/gateway-client/src:/app/packages/gateway-client/src:ro"',
+      '-v "$harness_root/packages/normalization-core/package.json:/app/packages/normalization-core/package.json:ro"',
       '-v "$harness_root/packages/normalization-core/src:/app/packages/normalization-core/src:ro"',
+      '-v "$harness_root/tsconfig.json:/app/tsconfig.json:ro"',
       '-v "$harness_root/test/e2e/qa-lab:/app/test/e2e/qa-lab:ro"',
       '-v "$harness_root/test/helpers:/app/test/helpers:ro"',
     ]);

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -271,7 +271,9 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
     expect(script).toContain("OPENCLAW_KITCHEN_SINK_COMMAND_MAX_RSS_MIB");
     expect(script).toContain("docker_e2e_sample_stats_until_exit");
     expect(script).toContain("scripts/e2e/lib/docker-stats/assert-resource-ceiling.mjs");
-    expect(script).toContain("node --import tsx scripts/e2e/kitchen-sink-rpc-walk.mts");
+    expect(script).toContain(
+      "openclaw_e2e_run_script_entrypoint scripts/e2e/kitchen-sink-rpc-walk",
+    );
     expect(walkScript).toContain("commands.list");
     expect(walkScript).toContain("tools.invoke");
     expect(walkScript).toContain("tts.providers");


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/121005
Related: https://github.com/openclaw/openclaw/pull/121208

## What Problem This Solves

Package-only and root-image Docker QA lanes could fail before their assertions because harness scripts invoked TypeScript through `node --import tsx`. The images expose the public `tsx` CLI globally, not as a package import resolvable from `/app`, and package harnesses did not mount all workspace-alias sources needed by alias-dependent entrypoints.

Current-main qualification at `1383144b027a6b10c746636687182064d24b3bf9` reproduced the owner failures:

- `gateway-network` and root-image `agents-delete-shared-workspace` could not resolve package-local `tsx`.
- `mcp-channels` and `cron-mcp-cleanup` could not resolve `packages/gateway-client/src/websocket-data.ts`.
- `kitchen-sink-rpc` could not resolve package-local `tsx`.

## Why This Change Was Made

- `openclaw-e2e-instance.sh` now runs source entrypoints through the public global `tsx` CLI, preferring the preserved `.mts` source and falling back to compiled `.mjs`.
- Erasable TypeScript entrypoints (`gateway-network/client.mts` and `openclaw-test-state.mts`) run directly with Node.
- Alias-dependent kitchen-sink and release-upgrade entrypoints use the shared helper.
- The package harness mounts `packages/gateway-client/src` read-only for workspace alias resolution.
- Focused tests cover `.mts` selection, real `tsx` compilation, `.mjs` fallback, missing entrypoints, direct-Node lanes, package mounts, and prerelease-plan wiring.

The harness owner now selects the runtime based on the entrypoint contract instead of relying on a package loader that is unavailable inside the image.

## User Impact

No production behavior changes. Maintainers regain deterministic Docker coverage for package-installed and root-Dockerfile QA lanes while TypeScript `.mts` sources remain canonical.

- Production runtime LOC: `+0`
- QA harness scripts: `+26/-9` (net `+17`)
- Tests: `+73/-1` (net `+72`)

## Evidence

- Exact head: `fed7daf987cca9cfcc74e64a4d7394cdf3794465`
- Exact tree: `49a09fac7858446a715421c45b0a42750a738677`
- Focused Vitest:
  - `test/scripts/docker-build-helper.test.ts`
  - `test/scripts/gateway-network-client.test.ts`
  - `test/scripts/kitchen-sink-rpc-walk.test.ts`
  - `test/scripts/plugin-prerelease-test-plan.test.ts`
  - `test/scripts/release-upgrade-baseline.test.ts`
  - Result: 5 files, 337 tests passed across 3 shards.
- `bash -n` passed for all changed shell scripts.
- Targeted `oxfmt --check` passed.
- `git diff origin/main...HEAD --check` passed.
- Exact-head local autoreview: clean, no accepted/actionable findings.
- Exact-head Blacksmith Testbox changed gate:
  - Testbox: `tbx_01kzrsb1w0nmss1j17fbvzfh2z`
  - Run: https://github.com/openclaw/openclaw/actions/runs/31510860355
  - Result: `check:changed` passed, including root test typecheck and scripts lint.
- Exact-tree Blacksmith Testbox root-Dockerfile proof:
  - Testbox: `tbx_01kzrsc4vqymy746k0hgsb4zee`
  - Run: https://github.com/openclaw/openclaw/actions/runs/31510912811
  - Root Dockerfile image built successfully.
  - `gateway-network`: connect/health, pre-restart suspension, same-container restart, and post-restart suspension passed.
  - `agents-delete-shared-workspace` passed on the root image.
  - The delegated wrapper was later cancelled while building the separate functional image, so the remaining three lanes were split into the successful run below.
- Exact-tree Blacksmith Testbox functional-image proof:
  - Testbox: `tbx_01kzrvrw0xjdc0yh9yzppv7066`
  - Run: https://github.com/openclaw/openclaw/actions/runs/31514593379
  - `mcp-channels`, `cron-mcp-cleanup`, and `kitchen-sink-rpc` passed on one shared functional image.
  - Final marker: `OPENCLAW_DOCKER_FUNCTIONAL_SMOKES_OK sha=fed7daf987cca9cfcc74e64a4d7394cdf3794465 tree=49a09fac7858446a715421c45b0a42750a738677`
- Hosted exact-head CI:
  - Run: https://github.com/openclaw/openclaw/actions/runs/31510834897
  - Result: `openclaw/ci-gate` passed. The untouched ACP CLI process-exit test passed on the isolated failed-job rerun.
- Current-main incident proof:
  - Plugin prerelease qualification: https://github.com/openclaw/openclaw/actions/runs/31512898619
  - Release qualification: https://github.com/openclaw/openclaw/actions/runs/31512918029
  - The separate `update-restart-auth` failure occurred after candidate update/restart succeeded and was caused by ClawHub fixture request drift, not this entrypoint repair.

No changelog entry: test-only QA harness repair.

Punchcard-Session: amber-workshop-workshop-36
