### PR TITLE
fix(workers): repair cloud session lifecycle and recovery

### DIFF
--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -128,7 +128,7 @@ Use `cloudWorkers.projectProfiles` to select a default profile from a managed se
 }
 ```
 
-An explicit `profileId` or `deviceId` in `sessions.dispatch` always wins. A target-less project-profile lookup requires `operator.admin`. If a configured mapping names a profile that is not present in `cloudWorkers.profiles`, dispatch fails closed and names both the repository key and missing profile. A worktree with no `origin` or no matching mapping returns a typed `INVALID_REQUEST` without provisioning or falling back to another target.
+An explicit `profileId` or `deviceId` in `sessions.dispatch` always wins. A target-less project-profile lookup requires `operator.admin`. Deleting a profile from the Cloud workers settings also removes project defaults that reference it. If a manually configured mapping names a profile that is not present in `cloudWorkers.profiles`, dispatch fails closed and names both the repository key and missing profile. A worktree with no `origin` or no matching mapping returns a typed `INVALID_REQUEST` without provisioning or falling back to another target.
 
 The enrolled node stores its identity, durable device token, endpoint, worker bundles, and workspaces under an isolated per-lease state directory on the disposable box. Provision replay first adopts the fixed Crabbox lease, then either resumes that node state or reuses the still-pending setup credential. It never mints a second environment identity for the same operation.
 
@@ -286,7 +286,7 @@ local Codex turn claim without waiting for an acknowledgment from the offline
 node. If the device is already available, use the
 ordinary reconcile-first move instead.
 
-When the work is complete and no turn is running, choose **Stop cloud worker…** from the same chip. The Gateway performs one final workspace reconciliation before it destroys the environment. A placement already in `draining` or `reconciling` is finishing teardown; wait for its badge to become `reclaimed` before deleting the session.
+When the work is complete and no turn is running, choose **Stop cloud worker…** from the same chip. The Gateway performs one final workspace reconciliation before it destroys the environment. A placement already in `draining` or `reconciling` is finishing teardown; wait for its badge to become `reclaimed` before resetting or deleting the session. Starting another turn after reclaim provisions a replacement worker only while its original cloud profile remains configured for the same provider; deleting that profile prevents new cloud allocation.
 
 Archiving a non-main cloud-worker session with an active placement also performs this safe stop and reclaim before the Gateway records it as archived. If the placement is still transitioning or failed without proof that its environment is gone, the session remains unarchived; wait for the placement to settle, then retry. Restoring the session retains the reclaimed placement metadata so the next turn can dispatch a fresh worker with the same workspace profile.
 

--- a/src/gateway/server-methods/sessions.dispatch.device.test.ts
+++ b/src/gateway/server-methods/sessions.dispatch.device.test.ts
@@ -49,7 +49,15 @@ function useDeviceSession(agentRuntimeOverride?: string): void {
   dispatchTestMocks.resolveTarget.mockReturnValue(
     makeSessionTarget({
       sessionId: dispatchTestSessionId,
-      ...(agentRuntimeOverride ? { agentRuntimeOverride } : {}),
+      ...(agentRuntimeOverride
+        ? {
+            agentHarnessId: agentRuntimeOverride,
+            agentRuntimeOverride,
+            modelSelectionLocked: true,
+            modelOverride: "gpt-test",
+            providerOverride: "openai",
+          }
+        : {}),
       worktree: { id: "worktree-1", branch: "openclaw/device-test", repoRoot: "/repo" },
     }),
   );

--- a/src/gateway/server-methods/sessions.dispatch.test.ts
+++ b/src/gateway/server-methods/sessions.dispatch.test.ts
@@ -406,6 +406,8 @@ describe("sessions.dispatch", () => {
       targetWithEntry({
         sessionId,
         agentRuntimeOverride: "codex",
+        providerOverride: "openai",
+        modelOverride: "gpt-test",
         worktree: { id: "worktree-1", branch: "openclaw/cloud-test", repoRoot: "/repo" },
       }),
     );
@@ -447,6 +449,36 @@ describe("sessions.dispatch", () => {
     );
   });
 
+  it("dispatches the selected runtime instead of an unlocked historical harness", async () => {
+    mocks.resolveTarget.mockReturnValue(
+      targetWithEntry({
+        sessionId,
+        agentHarnessId: "codex",
+        worktree: { id: "worktree-1", branch: "openclaw/cloud-test", repoRoot: "/repo" },
+      }),
+    );
+    mocks.findLiveByOwner.mockReturnValue({
+      id: "worktree-1",
+      ownerKind: "session",
+      ownerId: sessionKey,
+    });
+    const dispatch = vi.fn().mockRejectedValue(new Error("worker dispatch reached"));
+
+    await invoke(
+      makeContext({
+        workerEnvironmentService: { supportsExecutionMode: () => false } as never,
+        workerPlacementDispatchService: { dispatch },
+        workerSessionPlacementService: { getMany: () => new Map() },
+      }),
+    );
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ executionMode: "worker-turn" }),
+      expect.any(Function),
+      undefined,
+    );
+  });
+
   it.each([
     ["node-only", { supportsExecutionMode: () => false }],
     ["undeclared", { supportsExecutionMode: undefined }],
@@ -455,6 +487,8 @@ describe("sessions.dispatch", () => {
       targetWithEntry({
         sessionId,
         agentRuntimeOverride: "codex",
+        providerOverride: "openai",
+        modelOverride: "gpt-test",
         worktree: { id: "worktree-1", branch: "openclaw/cloud-test", repoRoot: "/repo" },
       }),
     );

--- a/src/gateway/server-methods/sessions.dispatch.test.ts
+++ b/src/gateway/server-methods/sessions.dispatch.test.ts
@@ -449,39 +449,6 @@ describe("sessions.dispatch", () => {
     );
   });
 
-  it("dispatches the selected runtime instead of an unlocked historical harness", async () => {
-    mocks.resolveTarget.mockReturnValue(
-      targetWithEntry({
-        sessionId,
-        agentHarnessId: "codex",
-        worktree: { id: "worktree-1", branch: "openclaw/cloud-test", repoRoot: "/repo" },
-      }),
-    );
-    mocks.findLiveByOwner.mockReturnValue({
-      id: "worktree-1",
-      ownerKind: "session",
-      ownerId: sessionKey,
-    });
-    const dispatch = vi.fn().mockRejectedValue(new Error("worker dispatch reached"));
-
-    await invoke(
-      makeContext({
-        workerEnvironmentService: {
-          supportsExecutionMode: (_profileId: string, mode: "worker-turn" | "remote-exec") =>
-            mode === "worker-turn",
-        } as never,
-        workerPlacementDispatchService: { dispatch },
-        workerSessionPlacementService: { getMany: () => new Map() },
-      }),
-    );
-
-    expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ executionMode: "worker-turn" }),
-      expect.any(Function),
-      undefined,
-    );
-  });
-
   it.each([
     ["node-only", { supportsExecutionMode: () => false }],
     ["undeclared", { supportsExecutionMode: undefined }],

--- a/src/gateway/server-methods/sessions.dispatch.test.ts
+++ b/src/gateway/server-methods/sessions.dispatch.test.ts
@@ -466,7 +466,10 @@ describe("sessions.dispatch", () => {
 
     await invoke(
       makeContext({
-        workerEnvironmentService: { supportsExecutionMode: () => false } as never,
+        workerEnvironmentService: {
+          supportsExecutionMode: (_profileId: string, mode: "worker-turn" | "remote-exec") =>
+            mode === "worker-turn",
+        } as never,
         workerPlacementDispatchService: { dispatch },
         workerSessionPlacementService: { getMany: () => new Map() },
       }),

--- a/src/gateway/server.sessions.worker-placement-lifecycle.test.ts
+++ b/src/gateway/server.sessions.worker-placement-lifecycle.test.ts
@@ -22,6 +22,7 @@ import type {
   WorkerSessionPlacementRetirementService,
   WorkerSessionPlacementStore,
 } from "./worker-environments/placement-store.js";
+import { resolveSessionWorkerPlacementMutationError } from "./worker-environments/session-placement-lifecycle.js";
 
 const { createSessionStoreDir, seedActiveMainSession } = setupGatewaySessionsHandlerTestHarness();
 
@@ -147,6 +148,35 @@ function sequencedPlacementService(
     retireSessionPlacement: vi.fn(retire),
   };
 }
+
+test.each([
+  { action: "fork" as const, allowed: true },
+  { action: "restore" as const, allowed: false },
+  { action: "rewind" as const, allowed: false },
+  { action: "switch" as const, allowed: false },
+])("stopped cloud placement only permits identity-preserving $action", ({ action, allowed }) => {
+  for (const state of ["reclaimed", "failed"] as const) {
+    const sessionId = `stopped-${state}-${action}`;
+    const placement = terminalPlacementRecord(sessionId, state);
+    const placementService = sequencedPlacementService([placement]);
+    const error = resolveSessionWorkerPlacementMutationError({
+      action,
+      context: {
+        workerEnvironmentService: { get: () => ({ state: "destroyed" }) } as never,
+        workerSessionPlacementService: placementService,
+      },
+      key: placement.sessionKey,
+      sessionId,
+    });
+
+    if (allowed) {
+      expect(error).toBeUndefined();
+    } else {
+      expect(error?.message).toContain(`cannot ${action} while cloud worker placement is ${state}`);
+    }
+    expect(placementService.retireSessionPlacement).not.toHaveBeenCalled();
+  }
+});
 
 async function beginClaimedLocalTurn(params: {
   events: string[];
@@ -576,13 +606,35 @@ test.each([
     name: "ordinary reset",
     sessionKey: "discord:group:local-reset",
     incognito: false,
+    state: "local" as const,
   },
   {
     name: "incognito reset",
     sessionKey: "agent:main:dashboard:incognito-local-reset",
     incognito: true,
+    state: "local" as const,
   },
-])("sessions.reset retires the old local placement before $name", async (testCase) => {
+  {
+    name: "reclaimed cloud reset",
+    sessionKey: "discord:group:reclaimed-reset",
+    incognito: false,
+    state: "reclaimed" as const,
+  },
+  {
+    name: "failed cloud reset after worker destruction",
+    sessionKey: "discord:group:destroyed-worker-reset",
+    incognito: false,
+    state: "failed" as const,
+    environment: { state: "destroyed" },
+  },
+  {
+    name: "failed cloud reset after proven bootstrap teardown",
+    sessionKey: "discord:group:failed-worker-reset",
+    incognito: false,
+    state: "failed" as const,
+    environment: { state: "failed", leaseId: null },
+  },
+])("sessions.reset retires the old placement before $name", async (testCase) => {
   await createSessionStoreDir();
   const sessionId = testCase.incognito
     ? await (async () => {
@@ -602,14 +654,25 @@ test.each([
       entries: { [testCase.sessionKey]: sessionStoreEntry(sessionId) },
     });
   }
-  const placementService = sequencedPlacementService([placementRecord(sessionId, "local")], () => {
+  const placement =
+    testCase.state === "local"
+      ? placementRecord(sessionId, "local")
+      : terminalPlacementRecord(sessionId, testCase.state);
+  const placementService = sequencedPlacementService([placement], () => {
     expect(loadSessionEntry(testCase.sessionKey).entry?.sessionId).toBe(sessionId);
   });
 
   const reset = await directSessionReq(
     "sessions.reset",
     { key: testCase.sessionKey },
-    { context: { workerSessionPlacementService: placementService } },
+    {
+      context: {
+        ...(testCase.state === "failed"
+          ? { workerEnvironmentService: { get: () => testCase.environment } as never }
+          : {}),
+        workerSessionPlacementService: placementService,
+      },
+    },
   );
 
   if (!reset.ok) {
@@ -618,8 +681,8 @@ test.each([
   expect(placementService.retireSessionPlacement).toHaveBeenCalledWith({
     status: "retirement-required",
     sessionId,
-    expectedState: "local",
-    expectedGeneration: 0,
+    expectedState: testCase.state,
+    expectedGeneration: placement.generation,
   });
   expect(loadSessionEntry(testCase.sessionKey).entry === undefined).toBe(testCase.incognito);
 });

--- a/src/gateway/worker-environments/live-events.test.ts
+++ b/src/gateway/worker-environments/live-events.test.ts
@@ -24,6 +24,7 @@ import {
   claimAgentRunContext,
   clearAgentRunContext,
   getAgentRunContext,
+  hasProjectedAgentRunForSession,
   releaseAgentRunContext,
   sweepStaleRunContexts,
 } from "../../infra/agent-run-registry.js";
@@ -651,19 +652,51 @@ describe("worker live events", () => {
     expect(deltas()).toEqual(["worker"]);
   });
 
-  it("adopts a visible dispatch-owned run context so worker live events stay visible", () => {
+  it.each(["terminal process turnover", "detach"])(
+    "clears an ownerless Gateway run context on %s",
+    (settledBy) => {
+      claimAgentRunContext(RUN, {
+        ...LOCAL,
+        lifecycleGeneration: getAgentEventLifecycleGeneration(),
+      });
+
+      ack(msg(1, "worker"));
+      if (settledBy === "terminal process turnover") {
+        ack(live(2, lifecycle({ phase: "end", startedAt: 100, endedAt: 200 })));
+        expect(
+          rx.rotateCredential({
+            credentialHash: "next-process-credential-hash",
+            environmentId: ID.environmentId,
+            newProcessTurn: true,
+            previousCredentialHash: ID.credentialHash,
+            runEpoch: EPOCH,
+            sessionId: SID,
+          }),
+        ).toBe(true);
+      } else {
+        rx.clearEnvironment(ID.environmentId);
+      }
+
+      expect(getAgentRunContext(RUN)).toBeUndefined();
+      expect(hasProjectedAgentRunForSession({ sessionKeys: [KEY], sessionId: SID })).toBe(false);
+    },
+  );
+
+  it("joins a visible dispatch-owned run context without blocking its terminal", () => {
     const lifecycleGeneration = getAgentEventLifecycleGeneration();
     // A worker-routed turn keeps its dispatch-owned Control UI visibility. The
     // gateway claims the run context (isControlUiVisible: true for a visible
-    // turn) before handing the turn to the remote worker; adopting live events
-    // must inherit that visibility instead of forcing the run hidden.
+    // turn) before handing the turn to the remote worker; joining live events
+    // must inherit that visibility without excluding the outer terminal.
     claimAgentRunContext(RUN, {
       ...LOCAL,
       isControlUiVisible: true,
       lifecycleGeneration,
     });
 
-    ack(msg(1, "worker"));
+    ack(live(1, lifecycle({ phase: "start", startedAt: 100 })));
+    ack(msg(2, "worker", 1));
+    ack(live(3, lifecycle({ phase: "finishing", startedAt: 100, endedAt: 200 })));
 
     expect(getAgentRunContext(RUN)).toMatchObject({
       ...LOCAL,
@@ -671,8 +704,25 @@ describe("worker live events", () => {
       lifecycleGeneration,
       projectSessionActive: true,
     });
-    expect(deltas()).toEqual(["worker"]);
-    expect(events[0]?.controlUiVisible).toBe(true);
+    expect(hasProjectedAgentRunForSession({ sessionKeys: [KEY], sessionId: SID })).toBe(true);
+    expect(events.map((event) => [event.stream, event.data.phase ?? event.data.delta])).toEqual([
+      ["lifecycle", "start"],
+      ["assistant", "worker"],
+      ["lifecycle", "finishing"],
+    ]);
+    expect(events.map((event) => event.controlUiVisible)).toEqual([true, true, true]);
+
+    emitAgentEvent({
+      runId: RUN,
+      stream: "lifecycle",
+      data: { phase: "end", startedAt: 100, endedAt: 200 },
+    });
+
+    const end = events.at(-1);
+    expect(end?.data.phase).toBe("end");
+    clearAgentRunContext(RUN, end?.lifecycleGeneration, end?.contextClaimId);
+    expect(getAgentRunContext(RUN)).toBeUndefined();
+    expect(hasProjectedAgentRunForSession({ sessionKeys: [KEY], sessionId: SID })).toBe(false);
   });
 
   it("shares a compatible non-exclusive Gateway run owner", () => {

--- a/src/gateway/worker-environments/live-events.test.ts
+++ b/src/gateway/worker-environments/live-events.test.ts
@@ -21,6 +21,7 @@ import {
   claimAgentRunContext,
   clearAgentRunContext,
   getAgentRunContext,
+  hasProjectedAgentRunForSession,
   releaseAgentRunContext,
   sweepStaleRunContexts,
 } from "../../infra/agent-run-registry.js";
@@ -660,19 +661,21 @@ describe("worker live events", () => {
     expect(deltas()).toEqual(["worker"]);
   });
 
-  it("adopts a visible dispatch-owned run context so worker live events stay visible", () => {
+  it("joins a visible dispatch-owned run context without blocking its terminal", () => {
     const lifecycleGeneration = getAgentEventLifecycleGeneration();
     // A worker-routed turn keeps its dispatch-owned Control UI visibility. The
     // gateway claims the run context (isControlUiVisible: true for a visible
-    // turn) before handing the turn to the remote worker; adopting live events
-    // must inherit that visibility instead of forcing the run hidden.
+    // turn) before handing the turn to the remote worker; joining live events
+    // must inherit that visibility without excluding the outer terminal.
     claimAgentRunContext(RUN, {
       ...LOCAL,
       isControlUiVisible: true,
       lifecycleGeneration,
     });
 
-    ack(msg(1, "worker"));
+    ack(live(1, lifecycle({ phase: "start", startedAt: 100 })));
+    ack(msg(2, "worker", 1));
+    ack(live(3, lifecycle({ phase: "finishing", startedAt: 100, endedAt: 200 })));
 
     expect(getAgentRunContext(RUN)).toMatchObject({
       ...LOCAL,
@@ -680,8 +683,25 @@ describe("worker live events", () => {
       lifecycleGeneration,
       projectSessionActive: true,
     });
-    expect(deltas()).toEqual(["worker"]);
-    expect(events[0]?.controlUiVisible).toBe(true);
+    expect(hasProjectedAgentRunForSession({ sessionKeys: [KEY], sessionId: SID })).toBe(true);
+    expect(events.map((event) => [event.stream, event.data.phase ?? event.data.delta])).toEqual([
+      ["lifecycle", "start"],
+      ["assistant", "worker"],
+      ["lifecycle", "finishing"],
+    ]);
+    expect(events.map((event) => event.controlUiVisible)).toEqual([true, true, true]);
+
+    emitAgentEvent({
+      runId: RUN,
+      stream: "lifecycle",
+      data: { phase: "end", startedAt: 100, endedAt: 200 },
+    });
+
+    const end = events.at(-1);
+    expect(end?.data.phase).toBe("end");
+    clearAgentRunContext(RUN, end?.lifecycleGeneration, end?.contextClaimId);
+    expect(getAgentRunContext(RUN)).toBeUndefined();
+    expect(hasProjectedAgentRunForSession({ sessionKeys: [KEY], sessionId: SID })).toBe(false);
   });
 
   it("shares a compatible non-exclusive Gateway run owner", () => {

--- a/src/gateway/worker-environments/live-events.ts
+++ b/src/gateway/worker-environments/live-events.ts
@@ -14,6 +14,7 @@ import {
 import {
   claimAgentRunContext,
   getAgentRunContext,
+  getAgentRunContextOwnership,
   getAgentRunContextOwnerStatus,
   registerAgentRunContext,
   releaseAgentRunContext,
@@ -491,13 +492,9 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
     }
     const lifecycleGeneration = getAgentEventLifecycleGeneration();
     const existingContext = getAgentRunContext(runId);
-    // A dispatch-owned turn context (e.g. a worker-routed turn) owns the run's
-    // Control UI visibility; adopt it so worker live events keep reaching the
-    // visible clients that started the turn. Identity still has to match, so a
-    // foreign run is rejected; only the visibility preference is inherited. With
-    // no pre-existing turn context we scope live events to this session.
+    // Existing dispatch contexts must admit their outer terminal. Ownerless contexts still need
+    // worker-owned cleanup so a definitive worker terminal cannot leave the session active.
     const controlUiVisible = existingContext?.isControlUiVisible ?? false;
-    const adoptExistingUnowned = existingContext !== undefined;
     if (
       existingContext &&
       (existingContext.sessionId !== window.sessionId ||
@@ -508,8 +505,10 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
     ) {
       return invalidEvent();
     }
-    let emissionMode: OwnedLiveRun["emissionMode"] = "exclusive";
-    let claimId = claimAgentRunContext(
+    const hasExistingTrackedOwner =
+      getAgentRunContextOwnership(runId)?.lifecycleGeneration === lifecycleGeneration;
+    const emissionMode: OwnedLiveRun["emissionMode"] = existingContext ? "shared" : "exclusive";
+    const claimId = claimAgentRunContext(
       runId,
       {
         ...(window.target.agentId ? { agentId: window.target.agentId } : {}),
@@ -520,44 +519,16 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
         sessionKey: window.target.sessionKey,
       },
       {
-        adoptExistingUnowned,
-        exclusive: true,
+        exclusive: existingContext === undefined,
         onClearRequested: (clearedClaimId) => {
           if (window.activeRuns.get(runId)?.claimId === clearedClaimId) {
             fenceReleasedRun(window, runId);
           }
         },
-        ownsContext: true,
+        ownsContext: !hasExistingTrackedOwner,
         trackOwner: true,
       },
     );
-    if (!claimId && existingContext) {
-      // Cron and other Gateway-owned handoffs retain a non-exclusive claim while the
-      // assigned worker runs. Share only that corroborated identity; exclusive owners
-      // still reject this claim and prevent a foreign execution from joining the run.
-      claimId = claimAgentRunContext(
-        runId,
-        {
-          ...(window.target.agentId ? { agentId: window.target.agentId } : {}),
-          isControlUiVisible: controlUiVisible,
-          lifecycleGeneration,
-          projectSessionActive: true,
-          sessionId: window.sessionId,
-          sessionKey: window.target.sessionKey,
-        },
-        {
-          exclusive: false,
-          onClearRequested: (clearedClaimId) => {
-            if (window.activeRuns.get(runId)?.claimId === clearedClaimId) {
-              fenceReleasedRun(window, runId);
-            }
-          },
-          ownsContext: false,
-          trackOwner: true,
-        },
-      );
-      emissionMode = "shared";
-    }
     if (!claimId) {
       return invalidEvent();
     }

--- a/src/gateway/worker-environments/live-events.ts
+++ b/src/gateway/worker-environments/live-events.ts
@@ -491,13 +491,10 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
     }
     const lifecycleGeneration = getAgentEventLifecycleGeneration();
     const existingContext = getAgentRunContext(runId);
-    // A dispatch-owned turn context (e.g. a worker-routed turn) owns the run's
-    // Control UI visibility; adopt it so worker live events keep reaching the
-    // visible clients that started the turn. Identity still has to match, so a
-    // foreign run is rejected; only the visibility preference is inherited. With
-    // no pre-existing turn context we scope live events to this session.
+    // A dispatch-owned turn context owns visibility and terminal cleanup. Join
+    // it without excluding the outer Gateway lifecycle; worker-only runs remain
+    // exclusively owned here. Identity must still match before either claim.
     const controlUiVisible = existingContext?.isControlUiVisible ?? false;
-    const adoptExistingUnowned = existingContext !== undefined;
     if (
       existingContext &&
       (existingContext.sessionId !== window.sessionId ||
@@ -508,8 +505,8 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
     ) {
       return invalidEvent();
     }
-    let emissionMode: OwnedLiveRun["emissionMode"] = "exclusive";
-    let claimId = claimAgentRunContext(
+    const emissionMode: OwnedLiveRun["emissionMode"] = existingContext ? "shared" : "exclusive";
+    const claimId = claimAgentRunContext(
       runId,
       {
         ...(window.target.agentId ? { agentId: window.target.agentId } : {}),
@@ -520,44 +517,16 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
         sessionKey: window.target.sessionKey,
       },
       {
-        adoptExistingUnowned,
-        exclusive: true,
+        exclusive: existingContext === undefined,
         onClearRequested: (clearedClaimId) => {
           if (window.activeRuns.get(runId)?.claimId === clearedClaimId) {
             fenceReleasedRun(window, runId);
           }
         },
-        ownsContext: true,
+        ownsContext: existingContext === undefined,
         trackOwner: true,
       },
     );
-    if (!claimId && existingContext) {
-      // Cron and other Gateway-owned handoffs retain a non-exclusive claim while the
-      // assigned worker runs. Share only that corroborated identity; exclusive owners
-      // still reject this claim and prevent a foreign execution from joining the run.
-      claimId = claimAgentRunContext(
-        runId,
-        {
-          ...(window.target.agentId ? { agentId: window.target.agentId } : {}),
-          isControlUiVisible: controlUiVisible,
-          lifecycleGeneration,
-          projectSessionActive: true,
-          sessionId: window.sessionId,
-          sessionKey: window.target.sessionKey,
-        },
-        {
-          exclusive: false,
-          onClearRequested: (clearedClaimId) => {
-            if (window.activeRuns.get(runId)?.claimId === clearedClaimId) {
-              fenceReleasedRun(window, runId);
-            }
-          },
-          ownsContext: false,
-          trackOwner: true,
-        },
-      );
-      emissionMode = "shared";
-    }
     if (!claimId) {
       return invalidEvent();
     }

--- a/src/gateway/worker-environments/placement-session-runtime.test.ts
+++ b/src/gateway/worker-environments/placement-session-runtime.test.ts
@@ -11,6 +11,7 @@ import {
   projectWorkerPlacementAgentRuntime,
   resolveWorkerPlacementCapabilities,
   resolveWorkerPlacementExecutionMode,
+  resolveWorkerPlacementSessionRuntime,
 } from "./placement-session-runtime.js";
 
 const originalPluginRegistry = getActivePluginRegistry();
@@ -26,6 +27,57 @@ describe("worker placement runtime capabilities", () => {
       return;
     }
     resetPluginRuntimeStateForTest();
+  });
+
+  it.each([
+    {
+      name: "ignores an unlocked historical runtime after selecting a different provider",
+      entry: { agentHarnessId: "codex" },
+      expected: "openclaw",
+    },
+    {
+      name: "ignores an unlocked historical runtime behind the default override",
+      entry: { agentHarnessId: "codex", agentRuntimeOverride: "default" },
+      expected: "openclaw",
+    },
+    {
+      name: "preserves locked transcript ownership",
+      entry: { agentHarnessId: "codex", modelSelectionLocked: true },
+      expected: "codex",
+    },
+    {
+      name: "does not let a historical embedded runtime override a Codex model",
+      entry: {
+        agentHarnessId: "openclaw",
+        providerOverride: "openai",
+        modelOverride: "gpt-5.6-sol",
+      },
+      expected: "codex",
+    },
+    {
+      name: "honors an explicit compatible runtime override",
+      entry: {
+        agentRuntimeOverride: "codex",
+        providerOverride: "openai",
+        modelOverride: "gpt-test",
+      },
+      expected: "codex",
+    },
+  ])("$name", ({ entry, expected }) => {
+    expect(
+      resolveWorkerPlacementSessionRuntime({
+        cfg: {},
+        entry: {
+          sessionId: "placement-runtime-session",
+          updatedAt: 0,
+          providerOverride: "anthropic",
+          modelOverride: "claude-test",
+          ...entry,
+        },
+        agentId: "main",
+        sessionKey: "agent:main:placement-runtime",
+      }),
+    ).toBe(expected);
   });
 
   it.each([

--- a/src/gateway/worker-environments/placement-session-runtime.ts
+++ b/src/gateway/worker-environments/placement-session-runtime.ts
@@ -1,10 +1,6 @@
-import {
-  isDefaultAgentRuntimeId,
-  OPENCLAW_AGENT_RUNTIME_ID,
-} from "../../agents/agent-runtime-id.js";
+import { OPENCLAW_AGENT_RUNTIME_ID } from "../../agents/agent-runtime-id.js";
 import { getRegisteredAgentHarness } from "../../agents/harness/registry.js";
 import { resolveSessionModelRef } from "../../agents/session-model-ref.js";
-import { resolvePersistedSessionRuntimeId } from "../../agents/session-runtime-compat.js";
 import { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -17,10 +13,6 @@ export function resolveWorkerPlacementSessionRuntime(params: {
   agentId: string;
   sessionKey: string;
 }): string {
-  const persistedRuntime = resolvePersistedSessionRuntimeId(params.entry);
-  if (persistedRuntime && !isDefaultAgentRuntimeId(persistedRuntime)) {
-    return persistedRuntime;
-  }
   const selectedModel = resolveSessionModelRef(params.cfg, params.entry, params.agentId);
   return resolveEffectiveAgentRuntime({
     cfg: params.cfg,
@@ -28,6 +20,7 @@ export function resolveWorkerPlacementSessionRuntime(params: {
     modelId: selectedModel.model,
     agentId: params.agentId,
     sessionKey: params.sessionKey,
+    sessionEntry: params.entry,
   });
 }
 

--- a/src/gateway/worker-environments/provider-lifecycle.ts
+++ b/src/gateway/worker-environments/provider-lifecycle.ts
@@ -1,5 +1,6 @@
 import { isDeepStrictEqual } from "node:util";
 import { expectDefined } from "@openclaw/normalization-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { WorkerAdmissionHandshake } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type { SecretRef } from "../../config/types.secrets.js";
 import { validateCloudWorkerProfileSettings } from "../../config/zod-schema.cloud-workers.js";
@@ -13,6 +14,7 @@ import {
 } from "../../plugins/types.js";
 import { verifyWorkerAdmissionHandshake } from "./admission.js";
 import type { WorkerInstallationArtifact } from "./bundle.js";
+import { DEVICE_WORKER_PROVIDER_ID } from "./device-provider-identity.js";
 import type { WorkerProviderLifecycleOptions } from "./provider-lifecycle.types.js";
 import { createWorkerNodeProvisioning } from "./provider-node-provisioning.js";
 import {
@@ -652,6 +654,24 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
         providerId = normalizeCapabilityProviderId(inherited.providerId) ?? inherited.providerId;
         if (providerId !== inherited.providerId) {
           throw serviceError("invalid_profile", "Inherited worker provider id is not canonical");
+        }
+        const inheritedSettings = inherited.profileSnapshot.settings;
+        const syntheticDeviceProfile =
+          providerId === DEVICE_WORKER_PROVIDER_ID &&
+          isRecord(inheritedSettings) &&
+          typeof inheritedSettings.device === "string" &&
+          normalizedProfileId === `device:${inheritedSettings.device}`;
+        if (!syntheticDeviceProfile) {
+          const configured = options.getConfig().cloudWorkers?.profiles?.[normalizedProfileId];
+          if (!configured) {
+            throw serviceError(
+              "profile_not_found",
+              `Unknown worker profile: ${normalizedProfileId}`,
+            );
+          }
+          if (normalizeCapabilityProviderId(configured.provider) !== providerId) {
+            throw serviceError("invalid_profile", "Inherited worker provider identity changed");
+          }
         }
         provider = providerFor(providerId);
         const resolvedProviderId = normalizeCapabilityProviderId(provider.id) ?? provider.id;

--- a/src/gateway/worker-environments/provider-lifecycle.ts
+++ b/src/gateway/worker-environments/provider-lifecycle.ts
@@ -1,6 +1,4 @@
 import { isDeepStrictEqual } from "node:util";
-import { expectDefined } from "@openclaw/normalization-core";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { WorkerAdmissionHandshake } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type { SecretRef } from "../../config/types.secrets.js";
 import { validateCloudWorkerProfileSettings } from "../../config/zod-schema.cloud-workers.js";
@@ -14,7 +12,6 @@ import {
 } from "../../plugins/types.js";
 import { verifyWorkerAdmissionHandshake } from "./admission.js";
 import type { WorkerInstallationArtifact } from "./bundle.js";
-import { DEVICE_WORKER_PROVIDER_ID } from "./device-provider-identity.js";
 import type { WorkerProviderLifecycleOptions } from "./provider-lifecycle.types.js";
 import { createWorkerNodeProvisioning } from "./provider-node-provisioning.js";
 import {
@@ -24,6 +21,7 @@ import {
 import { deriveEnvironmentIntent } from "./service-contract.js";
 import {
   normalizeWorkerMachineOptions,
+  requireInheritedWorkerProfileAuthorization,
   requireProviderProvisionTimeoutMs,
   requireWorkerLease,
   requireWorkerLeaseStatus,
@@ -650,29 +648,23 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
       let provider: WorkerProvider;
       let providerId: string;
       let profileSnapshot: WorkerProfile;
+      const profiles = options.getConfig().cloudWorkers?.profiles;
+      const configuredProfile =
+        profiles && Object.hasOwn(profiles, normalizedProfileId)
+          ? profiles[normalizedProfileId]
+          : undefined;
       if (inherited) {
         providerId = normalizeCapabilityProviderId(inherited.providerId) ?? inherited.providerId;
         if (providerId !== inherited.providerId) {
           throw serviceError("invalid_profile", "Inherited worker provider id is not canonical");
         }
-        const inheritedSettings = inherited.profileSnapshot.settings;
-        const syntheticDeviceProfile =
-          providerId === DEVICE_WORKER_PROVIDER_ID &&
-          isRecord(inheritedSettings) &&
-          typeof inheritedSettings.device === "string" &&
-          normalizedProfileId === `device:${inheritedSettings.device}`;
-        if (!syntheticDeviceProfile) {
-          const configured = options.getConfig().cloudWorkers?.profiles?.[normalizedProfileId];
-          if (!configured) {
-            throw serviceError(
-              "profile_not_found",
-              `Unknown worker profile: ${normalizedProfileId}`,
-            );
-          }
-          if (normalizeCapabilityProviderId(configured.provider) !== providerId) {
-            throw serviceError("invalid_profile", "Inherited worker provider identity changed");
-          }
-        }
+        requireInheritedWorkerProfileAuthorization(
+          normalizedProfileId,
+          providerId,
+          inherited.profileSnapshot.settings,
+          configuredProfile?.provider,
+          serviceError,
+        );
         provider = providerFor(providerId);
         const resolvedProviderId = normalizeCapabilityProviderId(provider.id) ?? provider.id;
         if (resolvedProviderId !== providerId) {
@@ -683,19 +675,14 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
           ...provisionSnapshot,
         });
       } else {
-        const profiles = options.getConfig().cloudWorkers?.profiles;
-        if (!profiles || !Object.hasOwn(profiles, normalizedProfileId)) {
+        if (!configuredProfile) {
           throw serviceError("profile_not_found", `Unknown worker profile: ${normalizedProfileId}`);
         }
-        const profile = expectDefined(
-          profiles[normalizedProfileId],
-          "profiles entry at normalized profile id",
-        );
-        provider = providerFor(profile.provider);
+        provider = providerFor(configuredProfile.provider);
         providerId = normalizeCapabilityProviderId(provider.id) ?? provider.id;
-        const settings = requireWorkerProfile(profile.settings ?? {});
+        const settings = requireWorkerProfile(configuredProfile.settings ?? {});
         profileSnapshot = requireWorkerProfile({
-          install: profile.install ?? "bundle",
+          install: configuredProfile.install ?? "bundle",
           settings,
           ...provisionSnapshot,
         });

--- a/src/gateway/worker-environments/provider-provisioning.test.ts
+++ b/src/gateway/worker-environments/provider-provisioning.test.ts
@@ -7,6 +7,7 @@ import {
   type WorkerProfile,
 } from "../../plugins/types.js";
 import { hashWorkerCredential } from "./credential.js";
+import { DEVICE_WORKER_PROVIDER_ID } from "./device-provider-identity.js";
 import * as support from "./service.test-support.js";
 
 type WorkerEnvironmentServiceError = support.WorkerEnvironmentServiceError;
@@ -337,6 +338,7 @@ describe("worker environment service", () => {
     );
     const parent = await workerService.create("development", "parent-profile-snapshot");
     support.getDevelopmentProfile().settings = { region: "mutated" };
+    support.getDevelopmentProfile().provider = "FaKe";
 
     const child = await workerService.createFromProfileSnapshot(
       {
@@ -353,6 +355,125 @@ describe("worker environment service", () => {
       providerId: parent.providerId,
       profileSnapshot: parent.profileSnapshot,
     });
+  });
+
+  it.each([
+    {
+      name: "removed",
+      mutate: () => {
+        support.testState.config.cloudWorkers = { profiles: {} };
+      },
+      code: "profile_not_found",
+    },
+    {
+      name: "assigned to a different provider",
+      mutate: () => {
+        support.getDevelopmentProfile().provider = "replacement";
+      },
+      code: "invalid_profile",
+    },
+  ])("rejects a fresh inherited environment when its profile was $name", async (testCase) => {
+    let lease = 0;
+    let credential = 0;
+    const provision = vi.fn(async () => ({
+      leaseId: `inherited-lease-${(lease += 1)}`,
+      ssh: support.SSH_ENDPOINT,
+    }));
+    const workerService = support.createService(support.createProvider({ provision }), {
+      generateWorkerCredential: () => `inherited-worker-credential-${(credential += 1)}`,
+    });
+    const parent = await workerService.create("development", "parent-inherited-profile");
+    const inherited = {
+      profileId: parent.profileId,
+      providerId: parent.providerId,
+      profileSnapshot: parent.profileSnapshot,
+    };
+    testCase.mutate();
+
+    await expect(
+      workerService.createFromProfileSnapshot(inherited, "fresh-inherited-profile"),
+    ).rejects.toMatchObject({ code: testCase.code });
+    expect(provision).toHaveBeenCalledOnce();
+    expect(support.testState.store.list()).toHaveLength(1);
+
+    await expect(
+      workerService.createFromProfileSnapshot(inherited, "parent-inherited-profile"),
+    ).resolves.toMatchObject({ environmentId: parent.environmentId });
+    expect(provision).toHaveBeenCalledOnce();
+  });
+
+  it("allows paired-device placement without configured cloud profiles", async () => {
+    support.testState.config.cloudWorkers = { profiles: {} };
+    const provision = vi.fn(async () => ({
+      leaseId: "device-lease",
+      node: { deviceId: "device-1" },
+    }));
+    const workerService = support.createService(
+      support.createProvider({
+        id: DEVICE_WORKER_PROVIDER_ID,
+        supportedExecutionModes: ["worker-turn"],
+        provision,
+      }),
+      { ensureNodeWorkerBundle: async () => structuredClone(support.BOOTSTRAP_RECEIPT) },
+    );
+
+    await expect(
+      workerService.createFromProfileSnapshot(
+        {
+          profileId: "device:device-1",
+          providerId: DEVICE_WORKER_PROVIDER_ID,
+          profileSnapshot: { install: "bundle", settings: { device: "device-1" } },
+        },
+        "paired-profileless",
+        undefined,
+        "worker-turn",
+      ),
+    ).resolves.toMatchObject({ state: "ready", nodeDeviceId: "device-1" });
+    expect(provision).toHaveBeenCalledOnce();
+  });
+
+  it("revokes removed configured device profiles without disabling synthetic paired devices", async () => {
+    let lease = 0;
+    let credential = 0;
+    const profile = support.getDevelopmentProfile();
+    profile.provider = DEVICE_WORKER_PROVIDER_ID;
+    profile.settings = { device: "device-1" };
+    const provision = vi.fn(async () => ({
+      leaseId: `named-device-lease-${(lease += 1)}`,
+      node: { deviceId: "device-1" },
+    }));
+    const workerService = support.createService(
+      support.createProvider({
+        id: DEVICE_WORKER_PROVIDER_ID,
+        supportedExecutionModes: ["worker-turn"],
+        provision,
+      }),
+      {
+        ensureNodeWorkerBundle: async () => structuredClone(support.BOOTSTRAP_RECEIPT),
+        generateWorkerCredential: () => `named-device-credential-${(credential += 1)}`,
+      },
+    );
+    const parent = await workerService.create(
+      "development",
+      "named-device-parent",
+      undefined,
+      "worker-turn",
+    );
+    support.testState.config.cloudWorkers = { profiles: {} };
+
+    await expect(
+      workerService.createFromProfileSnapshot(
+        {
+          profileId: parent.profileId,
+          providerId: parent.providerId,
+          profileSnapshot: parent.profileSnapshot,
+        },
+        "named-device-child",
+        undefined,
+        "worker-turn",
+      ),
+    ).rejects.toMatchObject({ code: "profile_not_found" });
+    expect(provision).toHaveBeenCalledOnce();
   });
 
   it("rejects plaintext secret fields before persisting intent", async () => {

--- a/src/gateway/worker-environments/service-validation.ts
+++ b/src/gateway/worker-environments/service-validation.ts
@@ -2,6 +2,7 @@ import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coerci
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { Value } from "typebox/value";
 import { WorkerMachineOptionsSchema } from "../../../packages/gateway-protocol/src/schema/environments.js";
+import { normalizeCapabilityProviderId } from "../../plugins/provider-registry-shared.js";
 import {
   WorkerProviderError,
   type WorkerDesktopEndpoint,
@@ -11,7 +12,31 @@ import {
   type WorkerMachineOption,
   type WorkerSshEndpoint,
 } from "../../plugins/types.js";
+import { DEVICE_WORKER_PROVIDER_ID } from "./device-provider-identity.js";
 import { normalizeWorkerDesktopEndpoint, normalizeWorkerSshEndpoint } from "./store.js";
+
+export function requireInheritedWorkerProfileAuthorization(
+  profileId: string,
+  providerId: string,
+  settings: unknown,
+  configuredProviderId: string | undefined,
+  serviceError: (code: "profile_not_found" | "invalid_profile", message: string) => Error,
+): void {
+  if (
+    providerId === DEVICE_WORKER_PROVIDER_ID &&
+    isRecord(settings) &&
+    typeof settings.device === "string" &&
+    profileId === `device:${settings.device}`
+  ) {
+    return;
+  }
+  if (!configuredProviderId) {
+    throw serviceError("profile_not_found", `Unknown worker profile: ${profileId}`);
+  }
+  if (normalizeCapabilityProviderId(configuredProviderId) !== providerId) {
+    throw serviceError("invalid_profile", "Inherited worker provider identity changed");
+  }
+}
 
 export function requireProviderProvisionTimeoutMs(
   timeoutMs: number | undefined,

--- a/src/gateway/worker-environments/session-placement-lifecycle.ts
+++ b/src/gateway/worker-environments/session-placement-lifecycle.ts
@@ -64,10 +64,10 @@ export function isFailedWorkerPlacementEnvironmentGone(params: {
   }
 }
 
-function isWorkerPlacementSafeForArchive(
+function isWorkerPlacementSafeForMutation(
   context: SessionWorkerPlacementContext,
   placement: Placement,
-): boolean {
+): placement is RetirablePlacement {
   if (placement.state === "failed") {
     return isFailedWorkerPlacementEnvironmentGone({
       environmentService: context.workerEnvironmentService,
@@ -82,7 +82,7 @@ export function resolveWorkerPlacementArchiveRestoreError(params: {
   key: string;
   placement: WorkerSessionPlacementRecord | undefined;
 }): string | undefined {
-  if (!params.placement || isWorkerPlacementSafeForArchive(params.context, params.placement)) {
+  if (!params.placement || isWorkerPlacementSafeForMutation(params.context, params.placement)) {
     return undefined;
   }
   return `Session ${params.key} cannot change archive state while cloud worker placement is ${params.placement.state}.`;
@@ -109,23 +109,13 @@ function resolveSessionWorkerPlacementMutationGuard(
     return { status: "allowed" };
   }
 
-  if (placement.state === "local") {
-    return params.action === "delete" || params.action === "reset"
-      ? retirementGuard(placement)
-      : { status: "allowed" };
-  }
-  if (params.action === "delete" && placement.state === "reclaimed") {
-    return retirementGuard(placement);
-  }
-  if (params.action === "delete" && placement.state === "failed") {
-    // Failed environments retain their lease until teardown is proven, so they stay fenced.
-    if (
-      isFailedWorkerPlacementEnvironmentGone({
-        environmentService: params.context.workerEnvironmentService,
-        placement,
-      })
-    ) {
+  if (isWorkerPlacementSafeForMutation(params.context, placement)) {
+    if (params.action === "delete" || params.action === "reset") {
       return retirementGuard(placement);
+    }
+    // History rewrites rotate the session identity and would strand stopped cloud affinity.
+    if (placement.state === "local" || params.action === "fork") {
+      return { status: "allowed" };
     }
   }
   return {
@@ -180,7 +170,7 @@ export async function prepareSessionWorkerPlacementForArchive(params: {
   if (!matches(placement)) {
     throw new Error(`Session ${sessionKey} cloud worker placement identity changed.`);
   }
-  if (isWorkerPlacementSafeForArchive(context, placement)) {
+  if (isWorkerPlacementSafeForMutation(context, placement)) {
     return;
   }
   if (placement.state !== "active") {

--- a/ui/src/e2e/cloud-workers-settings.e2e.test.ts
+++ b/ui/src/e2e/cloud-workers-settings.e2e.test.ts
@@ -386,7 +386,7 @@ suite.define(() => {
     }
   });
 
-  it("deletes a profile only after confirmation", async () => {
+  it("deletes a profile and its project defaults only after confirmation", async () => {
     const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();
     const pending = {
@@ -399,7 +399,18 @@ suite.define(() => {
         idleTimeout: "45m",
       },
     };
-    const initialConfig = { cloudWorkers: { profiles: { pending } } };
+    const retained = { ...pending, settings: { ...pending.settings, provider: "hetzner" } };
+    const retainedProjectProfiles = { "github.com/acme/retained": "retained" };
+    const initialConfig = {
+      cloudWorkers: {
+        profiles: { pending, retained },
+        projectProfiles: {
+          "github.com/acme/app": "pending",
+          "github.com/acme/docs": "pending",
+          ...retainedProjectProfiles,
+        },
+      },
+    };
     const gateway = await installMockGateway(page, {
       featureMethods: ["config.patch", "environments.list"],
       methodResponses: {
@@ -407,7 +418,9 @@ suite.define(() => {
         "config.patch": {
           ok: true,
           hash: "cloud-workers-delete-2",
-          config: { cloudWorkers: { profiles: {} } },
+          config: {
+            cloudWorkers: { profiles: { retained }, projectProfiles: retainedProjectProfiles },
+          },
         },
         "environments.list": { environments: [], profiles: [] },
       },
@@ -429,9 +442,13 @@ suite.define(() => {
         throw new Error("Expected delete config.patch request");
       }
       expect(requestRaw(deleteRequest)).toEqual({
-        cloudWorkers: { profiles: { pending: null } },
+        cloudWorkers: {
+          profiles: { pending: null, retained },
+          projectProfiles: { "github.com/acme/app": null, "github.com/acme/docs": null },
+        },
       });
       await expect.poll(() => pendingRow.count()).toBe(0);
+      await page.locator(".settings-row code", { hasText: /^retained$/ }).waitFor();
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
@@ -1,3 +1,5 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import { expect, it } from "vitest";
 import {
   SESSION_LIST_DEFAULTS,
@@ -11,6 +13,11 @@ import {
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofDir = path.resolve(
+  process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim() || ".artifacts/control-ui-e2e",
+  "cloud-session-recovery",
+);
 
 suite.define(() => {
   it("retries an ambiguous cloud create with the same session key and machine class", async () => {
@@ -218,6 +225,174 @@ suite.define(() => {
       await context.close();
     }
   });
+
+  it.each([
+    { name: "successful", cleanupError: undefined },
+    { name: "failed", cleanupError: "cleanup unavailable" },
+  ])(
+    "keeps the replacement cloud task intact after $name late cleanup",
+    async ({ cleanupError }) => {
+      const viewport = { height: 900, width: 1_280 };
+      const context = await suite.browser.newContext({
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport,
+        ...(captureUiProof ? { recordVideo: { dir: proofDir, size: viewport } } : {}),
+      });
+      const page = await context.newPage();
+      const message = "restart this interrupted cloud task";
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["sessions.create"],
+        workspaceGit: true,
+        methodResponses: {
+          "agents.list": {
+            agents: [
+              {
+                id: "cloud",
+                identity: { name: "Cloud" },
+                name: "Cloud",
+                workspace: WORKSPACE,
+                workspaceGit: true,
+              },
+            ],
+            defaultId: "cloud",
+            mainKey: "main",
+            scope: "agent",
+          },
+          "environments.list": {
+            environments: [],
+            profiles: [{ id: "aws", providerId: "crabbox" }],
+          },
+          "worktrees.branches": {
+            branches: [{ kind: "local", name: "main" }],
+            defaultBranch: "main",
+            repositoryStatus: "git",
+          },
+          "sessions.describe": { session: { sessionId: "session-abandoned-create" } },
+          "sessions.patch": { ok: true },
+          "sessions.delete": { deleted: true },
+          "sessions.dispatch": {
+            placement: { state: "active", environmentId: "worker-replacement-create" },
+          },
+          "sessions.send": { runId: "run-replacement-create", status: "started" },
+        },
+      });
+      const readRecovery = () =>
+        page.evaluate(() => {
+          const key = Object.keys(sessionStorage).find((candidate) =>
+            candidate.startsWith("openclaw.new-session.session-placement-recovery.v1:"),
+          );
+          return key
+            ? (JSON.parse(sessionStorage.getItem(key) ?? "null") as {
+                sessionKey: string;
+                message: string;
+                messageId: string;
+                phase: string;
+                target: { kind: string; profileId: string };
+              })
+            : null;
+        });
+
+      try {
+        await page.goto(`${suite.server.baseUrl}new`);
+        await gateway.waitForRequest("environments.list");
+        await page.locator("#new-session-where-trigger").click();
+        await page
+          .locator("wa-popover.new-session-page__where-popover")
+          .getByRole("button", { name: "Cloud · aws" })
+          .click();
+        const composer = page.locator(".new-session-page__message");
+        await composer.fill(message);
+        const start = page.getByRole("button", { name: "Start session" });
+        await start.click();
+        const firstCreate = await gateway.waitForRequest("sessions.create");
+        const abandonedKey = String((firstCreate.params as { key?: string }).key);
+
+        await page.evaluate(() => {
+          history.pushState(null, "", "new?agent=cloud");
+          dispatchEvent(new PopStateEvent("popstate"));
+        });
+        const interrupted = page.getByRole("alert").filter({ hasText: "interrupted" });
+        await interrupted.waitFor();
+        await expect.poll(() => composer.isDisabled()).toBe(true);
+        await expect.poll(() => start.isDisabled()).toBe(true);
+        if (captureUiProof) {
+          await mkdir(proofDir, { recursive: true });
+          await page.screenshot({
+            path: path.join(proofDir, "01-interrupted.png"),
+            fullPage: true,
+          });
+        }
+        const reset = interrupted.getByRole("button", { name: "Reset", exact: true });
+        expect(await reset.count()).toBe(1);
+        await reset.click();
+
+        await expect.poll(() => interrupted.count()).toBe(0);
+        await expect.poll(() => composer.isEnabled()).toBe(true);
+        await expect.poll(() => composer.inputValue()).toBe(message);
+        await expect.poll(() => start.isEnabled()).toBe(true);
+        expect(await readRecovery()).toBeNull();
+        if (captureUiProof) {
+          await page.screenshot({ path: path.join(proofDir, "02-recovered.png"), fullPage: true });
+        }
+
+        const previousCreateCount = (await gateway.getRequests("sessions.create")).length;
+        await gateway.deferNext("sessions.create");
+        await start.click();
+        const nextCreate = await gateway.waitForRequest("sessions.create", {
+          after: previousCreateCount,
+        });
+        const nextKey = String((nextCreate.params as { key?: string }).key);
+        expect(nextKey).not.toBe(abandonedKey);
+        const nextRecovery = await readRecovery();
+        expect(nextRecovery).toMatchObject({
+          sessionKey: nextKey,
+          message,
+          phase: "creating",
+          target: { kind: "profile", profileId: "aws" },
+        });
+
+        await gateway.deferNext("sessions.delete");
+        await gateway.resolveDeferred("sessions.create", { key: abandonedKey });
+        const deleted = await gateway.waitForRequest("sessions.delete");
+        expect(deleted.params).toMatchObject({
+          key: abandonedKey,
+          archivedOnly: true,
+          expectedSessionId: "session-abandoned-create",
+        });
+        if (cleanupError) {
+          await gateway.rejectDeferred("sessions.delete", {
+            code: "UNAVAILABLE",
+            message: cleanupError,
+          });
+          await pollLocatorText(
+            page.locator(".new-session-page__error").filter({ hasText: cleanupError }),
+          ).toContain(cleanupError);
+        } else {
+          await gateway.resolveDeferred("sessions.delete", { deleted: true });
+        }
+        await expect.poll(readRecovery).toMatchObject({
+          sessionKey: nextKey,
+          messageId: nextRecovery?.messageId,
+          message,
+          phase: "creating",
+        });
+
+        await gateway.resolveDeferred("sessions.create", { key: nextKey });
+        expect(await gateway.waitForRequest("sessions.dispatch")).toMatchObject({
+          params: { key: nextKey, agentId: "cloud", profileId: "aws" },
+        });
+        expect(await gateway.waitForRequest("sessions.send")).toMatchObject({
+          params: { key: nextKey, agentId: "cloud", message },
+        });
+        await page.waitForURL((url) => url.pathname === controlUiSessionPath(nextKey), {
+          timeout: 30_000,
+        });
+      } finally {
+        await context.close();
+      }
+    },
+  );
 
   it("retries an unpersisted cloud turn with its original recovery identity", async () => {
     const context = await suite.browser.newContext({

--- a/ui/src/pages/cloud-workers/cloud-worker-config.test.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-config.test.ts
@@ -138,4 +138,29 @@ describe("cloud worker settings state", () => {
       },
     });
   });
+
+  it("removes only project defaults that reference a deleted profile", () => {
+    const config = {
+      cloudWorkers: {
+        profiles: { production: configuredProfile, retained: configuredProfile },
+        projectProfiles: {
+          "github.com/acme/app": "production",
+          "github.com/acme/docs": "production",
+          "github.com/acme/retained": "retained",
+        },
+      },
+    };
+
+    expect(buildCloudWorkerDeletePatch(config, "production")).toEqual({
+      patch: {
+        cloudWorkers: {
+          profiles: { production: null, retained: configuredProfile },
+          projectProfiles: {
+            "github.com/acme/app": null,
+            "github.com/acme/docs": null,
+          },
+        },
+      },
+    });
+  });
 });

--- a/ui/src/pages/cloud-workers/cloud-worker-config.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-config.ts
@@ -187,10 +187,22 @@ export function buildCloudWorkerDeletePatch(
   if (!Object.hasOwn(profiles, profileId)) {
     return { error: "profileMissing" };
   }
+  const cloudWorkers = isRecord(config.cloudWorkers) ? config.cloudWorkers : null;
+  const projectProfiles = isRecord(cloudWorkers?.projectProfiles)
+    ? cloudWorkers.projectProfiles
+    : {};
+  const removedProjectProfiles = Object.fromEntries(
+    Object.entries(projectProfiles)
+      .filter(([, target]) => target === profileId)
+      .map(([project]) => [project, null]),
+  );
   return {
     patch: {
       cloudWorkers: {
         profiles: { ...profiles, [profileId]: null },
+        ...(Object.keys(removedProjectProfiles).length > 0
+          ? { projectProfiles: removedProjectProfiles }
+          : {}),
       },
     },
   };

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -196,13 +196,18 @@ export class NewSessionComposerTextareaController {
   }
 }
 
-export function renderDraftError(message: string) {
+export function renderDraftError(message: string, action?: { label: string; onClick: () => void }) {
   return html`
     <div class="callout danger new-session-page__error new-session-page__alert" role="alert">
       <span class="new-session-page__alert-icon" aria-hidden="true">${icons.alertTriangle}</span>
       <span class="callout__content new-session-page__alert-message"
         >${formatUiError(message)}</span
       >
+      ${action
+        ? html`<button class="btn btn--sm" type="button" @click=${action.onClick}>
+            ${action.label}
+          </button>`
+        : nothing}
     </div>
   `;
 }

--- a/ui/src/pages/new-session/draft-submission-flow.test.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test.ts
@@ -442,6 +442,7 @@ describe("DraftSubmissionFlow", () => {
 
     expect(flow.submissionOutcomeUnknown).toBe("gateway-changed");
     expect(flow.submitting).toBe(false);
+    expect(flow.canSubmit()).toBe(false);
     expect(context.sessions.createResult).toHaveBeenCalledOnce();
     finishOriginal({ key: "agent:main:old", initialRun: { status: "idle" } });
     await initialSubmission;

--- a/ui/src/pages/new-session/draft-submission-flow.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.ts
@@ -562,11 +562,13 @@ export class DraftSubmissionFlow {
             submissionAgentId,
           );
           if (cleanupError) {
-            this.pendingPlacement.promoteToDispatching(result.key);
-            this.pendingPlacement.retryAllowed = true;
+            if (ownsSubmissionRecovery()) {
+              this.pendingPlacement.promoteToDispatching(result.key);
+              this.pendingPlacement.retryAllowed = true;
+            }
             this.error = t("newSession.placementStartFailed", { error: cleanupError });
             this.callbacks.requestUpdate();
-          } else {
+          } else if (ownsSubmissionRecovery()) {
             this.clearPendingPlacementRecovery();
           }
           return;

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -329,7 +329,9 @@ export class NewSessionPage extends OpenClawLightDomElement {
   }
 
   private setMessageFromUser(message: string) {
-    this.setMessage(message, catalog.routeKeyFromSearch(window.location.search));
+    if (!this.submission.submitting && !this.submission.pendingPlacement.sessionKey) {
+      this.setMessage(message, catalog.routeKeyFromSearch(window.location.search));
+    }
   }
 
   private renderAgentSelect() {
@@ -590,6 +592,12 @@ export class NewSessionPage extends OpenClawLightDomElement {
                   ? "newSession.createOutcomeUnknown"
                   : "newSession.placementSetupInterrupted",
               ),
+              this.submission.pendingPlacement.sessionKey
+                ? {
+                    label: t("common.reset"),
+                    onClick: () => this.submission.clearPendingPlacementRecovery(),
+                  }
+                : undefined,
             )
           : nothing}
         ${renderNewSessionDraftComposer({
@@ -618,11 +626,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
                 onStart: () => void this.submission.startInTerminal(),
               }
             : undefined,
-          onInput: (message) => {
-            if (!this.submission.submitting && !this.submission.pendingPlacement.sessionKey) {
-              this.setMessageFromUser(message);
-            }
-          },
+          onInput: (message) => this.setMessageFromUser(message),
           onOpenImage: (item) => {
             this.imageLightbox = item;
           },
@@ -659,11 +663,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
         agentsList: this.context?.agents.state.agentsList ?? null,
         hello: gateway?.hello ?? null,
       },
-      onDraftChange: (next) => {
-        if (!this.submission.submitting && !this.submission.pendingPlacement.sessionKey) {
-          this.setMessageFromUser(next);
-        }
-      },
+      onDraftChange: (next) => this.setMessageFromUser(next),
       onSend: () => void this.submission.submit(),
       onOpenSession: (sessionKey) => {
         if (this.submission.submitting || this.submission.pendingPlacement.sessionKey) {


### PR DESCRIPTION
## What Problem This Solves

Cloud worker sessions could remain permanently marked as working, choose a stale historical runtime, reject safe stopped-session resets, continue provisioning after a profile was removed, leave dangling project defaults, or strand an interrupted new task with no safe recovery path.

## Root Cause

Worker live events incorrectly claimed existing Gateway run contexts exclusively, suppressing the outer terminal event. Placement selection also treated historical transcript ownership as authority for the next model turn, and stopped-placement lifecycle decisions were split across inconsistent guards. Inherited worker provisioning did not revalidate current profile authorization, while the Control UI had no safe discard flow for an interrupted placement and allowed stale asynchronous cleanup to race with its replacement.

## Fix

- Share existing Gateway run contexts without suppressing the outer terminal, while retaining worker-owned cleanup for contexts that lack another tracked owner.
- Resolve placement runtime through the canonical selected-model policy and preserve locked transcript ownership, explicit compatible overrides, paired-device authority, and dual-mode provider selection.
- Retire stopped placements before reset or deletion; keep identity-rotating history mutations fenced so cloud affinity cannot silently become local execution.
- Revalidate configured inherited profiles before allocating a new worker, preserve exact durable idempotency replay, canonicalize provider identity, and exempt only exact synthetic paired-device profiles.
- Remove project-to-profile mappings when their target profile is deleted.
- Offer an explicit Reset only for interrupted cloud placement recovery, preserve the message, prevent late cleanup from changing replacement-task recovery, and surface cleanup failures without corrupting the new task.
- Consolidate draft edit authorization and duplicate cleanup handling; production code is net negative.

## Verification

- 485 passing focused Gateway, worker lifecycle, provider replay/shutdown, paired-device, runtime-selection, Codex, Crabbox, and Control UI unit/integration tests across six Vitest shards.
- 15 passing real-Chromium Control UI scenarios, including both runtime destinations, profile deletion, interrupted cloud creation, successful late cleanup, and failed late cleanup.
- Repository changed-file quality gate, production/test/UI TypeScript checks, formatting, lint, database-first, security, import-cycle, and dead-export checks passed.
- Fresh structured Codex autoreview completed with no actionable findings after the current-main rebase.
- Existing live worker-turn evidence remains in the original PR history; browser scenarios use a deterministic mocked Gateway and are not represented as live cloud-provider proof.

## Before / After

Interrupted task with explicit safe recovery:

![Interrupted cloud session with its Reset recovery action](https://github.com/user-attachments/assets/b69eaf97-d0fb-439a-b6e3-b9dfe5e2e20d)

Recovered task with the original prompt preserved:

![Recovered cloud session with its preserved task prompt](https://github.com/user-attachments/assets/d3798665-e2eb-44ea-87d9-c87440f140d4)
