### PR TITLE
fix(agents): always classify claude-cli pre-tool narration as commentary

### DIFF
--- a/src/agents/cli-output-jsonl.test.ts
+++ b/src/agents/cli-output-jsonl.test.ts
@@ -116,7 +116,7 @@ describe("parseCliJsonl", () => {
     expect(result).toEqual(expected);
   });
 
-  it("keeps streamed pre-tool text over the final-message result in transcript reparses", () => {
+  it("drops pre-tool commentary from transcript reparses so fallbacks match live parses", () => {
     const result = parseCliJsonl(
       [
         JSON.stringify({ type: "init", session_id: "session-reparse" }),
@@ -156,7 +156,7 @@ describe("parseCliJsonl", () => {
     );
 
     expect(result).toEqual({
-      text: "Marker caribou-lampion-473 explanation.\n\nTEST DONE",
+      text: "TEST DONE",
       sessionId: "session-reparse",
       usage: undefined,
     });
@@ -216,7 +216,7 @@ describe("parseCliJsonl", () => {
       "local-cli",
     );
 
-    expect(result?.text).toBe("Interim answer.\nPre-tool follow-up.\n\nDONE");
+    expect(result?.text).toBe("Interim answer.\nDONE");
   });
 
   it.each([

--- a/src/agents/cli-output-reasoning.test.ts
+++ b/src/agents/cli-output-reasoning.test.ts
@@ -107,7 +107,9 @@ describe("createCliJsonlStreamingParser reasoning", () => {
       {
         text: "Visible answer.",
         delta: "Visible answer.",
-        sessionId: undefined,
+        // Classification defers the flush to the result, after the session id
+        // is known.
+        sessionId: "session-tagged",
         usage: undefined,
       },
     ]);
@@ -146,7 +148,7 @@ describe("createCliJsonlStreamingParser reasoning", () => {
     expect(parser.getOutput()?.text).toBe("Visible answer.");
   });
 
-  it("streams rejected angle prefixes while valid split reasoning stays buffered", () => {
+  it("keeps rejected angle prefixes visible while valid split reasoning stays buffered", () => {
     const visible = createClaudeTaggedReasoningHarness();
     const mixed = createClaudeTaggedReasoningHarness();
     const tagged = createClaudeTaggedReasoningHarness();
@@ -162,11 +164,13 @@ describe("createCliJsonlStreamingParser reasoning", () => {
       );
 
     pushText(visible.parser, "<div>Visible prefix <thi");
+    visible.parser.finish();
     expect(visible.assistant.at(-1)?.text).toBe("<div>Visible prefix <thi");
     expect(visible.parser.getOutput()?.text).toBe("<div>Visible prefix <thi");
 
     pushText(mixed.parser, "<div>Visible prefix ");
     pushText(mixed.parser, "<thi");
+    mixed.parser.finish();
     expect(mixed.assistant.at(-1)?.text).toBe("<div>Visible prefix <thi");
     expect(mixed.parser.getOutput()?.text).toBe("<div>Visible prefix <thi");
 
@@ -175,7 +179,10 @@ describe("createCliJsonlStreamingParser reasoning", () => {
     expect(tagged.assistant).toEqual([]);
     expect(tagged.thinking).toEqual([]);
     pushText(tagged.parser, "</thinking>Visible answer.");
+    // Reasoning still streams as soon as its close tag resolves; visible text
+    // waits for the classification flush at finish.
     expect(tagged.thinking.at(-1)?.text).toBe("Private analysis.");
+    tagged.parser.finish();
     expect(tagged.assistant.at(-1)?.text).toBe("Visible answer.");
   });
 
@@ -303,8 +310,9 @@ describe("createCliJsonlStreamingParser reasoning", () => {
     parser.finish();
 
     expect(thinking.map((entry) => entry.text)).toEqual(["First thought.", "Second thought."]);
-    expect(assistant.at(-1)?.text).toBe("Before tool.\n\nFinal answer.");
-    expect(parser.getOutput()?.text).toBe("Before tool.\n\nFinal answer.");
+    // "Before tool." is pre-tool commentary; only the closer message ships.
+    expect(assistant.at(-1)?.text).toBe("Final answer.");
+    expect(parser.getOutput()?.text).toBe("Final answer.");
   });
 
   it.each([

--- a/src/agents/cli-output-records.ts
+++ b/src/agents/cli-output-records.ts
@@ -526,35 +526,6 @@ export function parseClaudeCliJsonlResult(params: {
   return null;
 }
 
-// A tool-split turn streams pre-tool answer text the terminal result envelope
-// omits (it carries only the final message). Prefer the fuller streamed text so
-// final delivery cannot erase already-streamed content (#106760). The result
-// must match the complete final streamed message: a bare suffix match inside a
-// single divergent message defers to the authoritative result envelope.
-export function preferStreamedClaudeTextOverResult(params: {
-  streamedText: string;
-  finalMessageText: string;
-  resultText: string;
-}): boolean {
-  return (
-    Boolean(params.resultText) &&
-    params.streamedText !== params.resultText &&
-    params.finalMessageText === params.resultText
-  );
-}
-
-// Assistant-message boundaries join with one blank line; add only the missing
-// newlines so messages that already end or start with breaks are not
-// double-spaced.
-export function missingMessageBoundarySeparator(previousText: string, nextDelta: string): string {
-  if (!previousText) {
-    return "";
-  }
-  const trailing = previousText.match(/\n*$/u)?.[0].length ?? 0;
-  const leading = nextDelta.match(/^\n*/u)?.[0].length ?? 0;
-  return "\n".repeat(Math.max(0, 2 - trailing - leading));
-}
-
 export function parseClaudeCliStreamingDelta(params: {
   backend: CliBackendConfig;
   providerId: string;

--- a/src/agents/cli-output-stream.test.ts
+++ b/src/agents/cli-output-stream.test.ts
@@ -215,7 +215,7 @@ describe("createCliJsonlStreamingParser", () => {
     expect(parser.getOutput()).toEqual(expected);
   });
 
-  it("keeps streamed pre-tool text when the result envelope carries only the final message", () => {
+  it("drops unconsumed pre-tool commentary and delivers only the result envelope", () => {
     const deltas: Array<{ text: string; delta?: string }> = [];
     const parser = createCliJsonlStreamingParser({
       backend: {
@@ -262,20 +262,18 @@ describe("createCliJsonlStreamingParser", () => {
     parser.finish();
 
     expect(parser.getOutput()).toEqual({
-      text: "Marker caribou-lampion-473 explanation.\n\nTEST DONE",
+      text: "TEST DONE",
       sessionId: "session-tool-split",
       usage: undefined,
     });
-    // Cumulative text must stay reconstructible from deltas for preview streams.
-    expect(deltas.map((entry) => entry.delta).join("")).toBe(
-      "Marker caribou-lampion-473 explanation.\n\nTEST DONE",
-    );
-    expect(deltas.at(-1)?.text).toBe("Marker caribou-lampion-473 explanation.\n\nTEST DONE");
+    // Pre-tool narration is commentary; it must never reach assistant deltas.
+    expect(deltas.map((entry) => entry.delta).join("")).toBe("TEST DONE");
+    expect(deltas.at(-1)?.text).toBe("TEST DONE");
   });
 
   it.each([
     {
-      name: "keeps pre-tool text when text, tool_use, and text share one assistant message",
+      name: "drops pre-tool commentary when text, tool_use, and text share one assistant message",
       frames: [
         { type: "init", session_id: "session-single-message" },
         claudeMessageStart(),
@@ -284,10 +282,10 @@ describe("createCliJsonlStreamingParser", () => {
         claudeTextDelta("TEST DONE"),
         { type: "result", session_id: "session-single-message", result: "TEST DONE" },
       ],
-      expectedText: "Marker caribou-lampion-473 explanation.\n\nTEST DONE",
+      expectedText: "TEST DONE",
     },
     {
-      name: "keeps pre-tool text when a toolless closer message follows a tool-using message",
+      name: "delivers only the result envelope when mid-run summaries precede the closer message",
       frames: [
         { type: "init", session_id: "session-closer" },
         claudeMessageStart(),
@@ -299,7 +297,7 @@ describe("createCliJsonlStreamingParser", () => {
         claudeTextDelta("DONE"),
         { type: "result", session_id: "session-closer", result: "DONE" },
       ],
-      expectedText: "Pre-tool analysis.\n\nPost-tool summary.\n\nDONE",
+      expectedText: "DONE",
     },
   ])("$name", ({ frames, expectedText }) => {
     const parser = createCliJsonlStreamingParser({
@@ -376,43 +374,14 @@ describe("createCliJsonlStreamingParser", () => {
     );
     parser.finish();
 
-    expect(parser.getOutput()?.text).toBe("Interim answer.\nPre-tool follow-up.\n\nDONE");
-    // Preview snapshots stay cumulative across the interim result.
-    expect(deltas.at(-1)?.text).toBe("Interim answer.\n\nPre-tool follow-up.\n\nDONE");
-    expect(deltas.map((entry) => entry.delta).join("")).toBe(
-      "Interim answer.\n\nPre-tool follow-up.\n\nDONE",
-    );
+    expect(parser.getOutput()?.text).toBe("Interim answer.\nDONE");
+    // Preview snapshots stay cumulative across the interim result; the
+    // post-interim pre-tool follow-up is commentary and never streams.
+    expect(deltas.at(-1)?.text).toBe("Interim answer.DONE");
+    expect(deltas.map((entry) => entry.delta).join("")).toBe("Interim answer.DONE");
   });
 
   it.each([
-    {
-      name: "does not duplicate existing newlines at message boundaries",
-      frames: [
-        { type: "init", session_id: "session-newlines" },
-        claudeMessageStart(),
-        claudeTextDelta("Pre-tool explanation.\n\n"),
-        claudeBlockStart({ type: "tool_use", id: "tool-1", name: "session_status" }),
-        claudeMessageStart(),
-        claudeTextDelta("TEST DONE"),
-        { type: "result", session_id: "session-newlines", result: "TEST DONE" },
-      ],
-      expectedText: "Pre-tool explanation.\n\nTEST DONE",
-    },
-    {
-      name: "keeps a later tool split's pre-tool text after an earlier ordinary boundary",
-      frames: [
-        { type: "init", session_id: "session-mixed" },
-        claudeMessageStart(),
-        claudeTextDelta("Superseded draft."),
-        claudeMessageStop(),
-        claudeMessageStart(),
-        claudeTextDelta("Important pre-tool text."),
-        claudeBlockStart({ type: "tool_use", id: "tool-1", name: "session_status" }),
-        claudeTextDelta("DONE"),
-        { type: "result", session_id: "session-mixed", result: "DONE" },
-      ],
-      expectedText: "Important pre-tool text.\n\nDONE",
-    },
     {
       name: "drops an earlier draft when a fresh message starts with a tool call",
       frames: [
@@ -504,7 +473,7 @@ describe("createCliJsonlStreamingParser", () => {
     expect(parser.getOutput()).toEqual(expected);
   });
 
-  it("keeps pre-tool text in assistant deltas when no commentary consumer is wired", () => {
+  it("classifies pre-tool text as commentary even when no consumer is wired", () => {
     const deltas: Array<{ text: string; delta: string }> = [];
     const parser = createCliJsonlStreamingParser({
       backend: {
@@ -539,9 +508,9 @@ describe("createCliJsonlStreamingParser", () => {
     );
     parser.finish();
 
-    expect(deltas).toEqual([
-      { text: "Let me inspect the repo.", delta: "Let me inspect the repo." },
-    ]);
+    // Narration preceding tool_use is dropped from the assistant stream when
+    // nothing consumes commentary (cron/quiet lanes must not deliver it).
+    expect(deltas).toEqual([]);
   });
 
   it.each([

--- a/src/agents/cli-output-stream.ts
+++ b/src/agents/cli-output-stream.ts
@@ -32,16 +32,13 @@ import {
   isClaudeStreamJsonResult,
   isGeminiStreamJsonDialect,
   isStreamJsonDialect,
-  missingMessageBoundarySeparator,
   parseClaudeCliJsonlResult,
   parseClaudeCliStreamingDelta,
   pickCliResumeCheckpointId,
   pickCliSessionId,
   preferGeminiCliStreamJsonError,
-  preferStreamedClaudeTextOverResult,
   readCliUsage,
   readGeminiCliStreamJsonError,
-  supportsCliJsonlToolEvents,
 } from "./cli-output-records.js";
 
 export const CLI_STREAM_JSON_DEFAULT_MAX_TURN_RAW_CHARS = 8 * 1024 * 1024;
@@ -137,15 +134,7 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
   let assistantText = "";
   let customThinkingText = "";
   let pendingClaudeText = "";
-  let pendingMessageSeparator = false;
-  let currentMessageStart = 0;
   let segmentStart = 0;
-  // Streamed text from this offset on is still a candidate to outrank the
-  // result envelope; every non-tool boundary or interim result restarts it.
-  let preserveFrom = 0;
-  let sawToolUseSinceText = false;
-  let currentMessageHadToolUse = false;
-  let previousMessageHadToolUse = false;
   let sessionId: string | undefined;
   let resumeCheckpointId: string | undefined;
   let usage: CliUsage | undefined;
@@ -160,12 +149,14 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
   let sawTerminalResult = false;
   const toolTracker = createToolUseTracker();
   const outputLimits = CLI_STREAM_JSON_OUTPUT_LIMITS;
-  // Classification is keyed on consumer presence so reclassified pre-tool text
-  // always has a destination; a separate enable flag let it be dropped (#92092).
-  const classifyClaudeCommentary =
-    Boolean(params.onCommentaryText) && supportsCliJsonlToolEvents(params);
   const thinkingTracker = createThinkingTracker();
   const claudeStreamJson = isClaudeStreamJsonDialect(params);
+  // Claude's wire format carries no phase metadata, so pre-tool text is always
+  // classified as commentary regardless of consumer wiring; without an
+  // onCommentaryText consumer it is dropped instead of fused into the
+  // deliverable (#121558). The result envelope is the authoritative final
+  // text; streamed text only backfills an empty result.
+  const classifyClaudeCommentary = claudeStreamJson;
   let taggedReasoningRouter = createLeadingTaggedReasoningRouter();
   let currentTaggedReasoningText = "";
 
@@ -203,30 +194,8 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
       pendingClaudeText = `${pendingClaudeText}${delta}`;
       return;
     }
-    // A tool_use block starts a new post-tool segment even inside one assistant
-    // message; only tool-split boundaries may later outrank the result envelope.
-    // A message boundary is a tool split only when the PREVIOUS message used a
-    // tool: a tool-first fresh message must not connect an earlier draft, while
-    // a tool-using message keeps its text connected across its own boundary.
-    const boundaryPending = pendingMessageSeparator || sawToolUseSinceText;
-    const isToolSplitBoundary = pendingMessageSeparator
-      ? previousMessageHadToolUse
-      : sawToolUseSinceText;
-    const separator =
-      boundaryPending && assistantText ? missingMessageBoundarySeparator(assistantText, delta) : "";
-    if (boundaryPending && assistantText) {
-      currentMessageStart = assistantText.length + separator.length;
-      // Text before a non-tool boundary may be a superseded draft; only text
-      // connected to the result through tool splits stays a candidate.
-      if (!isToolSplitBoundary) {
-        preserveFrom = currentMessageStart;
-      }
-    }
-    pendingMessageSeparator = false;
-    sawToolUseSinceText = false;
-    const deltaText = `${separator}${delta}`;
-    assistantText = `${assistantText}${deltaText}`;
-    params.onAssistantDelta({ text: assistantText, delta: deltaText, sessionId, usage });
+    assistantText = `${assistantText}${delta}`;
+    params.onAssistantDelta({ text: assistantText, delta, sessionId, usage });
   };
 
   const routeTaggedReasoningDeltas = (
@@ -373,11 +342,11 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
       return;
     }
 
-    if (classifyClaudeCommentary && parsed.type === "result") {
+    if (parsed.type === "result") {
       finishTaggedReasoningMessage();
-      flushPendingClaudeAssistantText();
-    } else if (parsed.type === "result") {
-      finishTaggedReasoningMessage();
+      if (classifyClaudeCommentary) {
+        flushPendingClaudeAssistantText();
+      }
     }
 
     let result = parseClaudeCliJsonlResult({
@@ -412,15 +381,7 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
       }
       // Empty terminal result can follow already-streamed text; keep that text.
       const streamedText = assistantText.slice(segmentStart).trim();
-      const preservedCandidate = assistantText.slice(preserveFrom).trim();
-      const keepStreamed = preferStreamedClaudeTextOverResult({
-        streamedText: preservedCandidate,
-        finalMessageText: assistantText.slice(currentMessageStart).trim(),
-        resultText: result.text,
-      });
-      const nextText = (
-        keepStreamed ? preservedCandidate : result.text || streamedText || texts.join("\n").trim()
-      ).trim();
+      const nextText = (result.text || streamedText || texts.join("\n").trim()).trim();
       const previousText = output?.text?.trim() ?? "";
       // Claude Code may emit an interim result while background agents run, then
       // a second result after task-notification. Preserve earlier result text
@@ -442,15 +403,9 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
         ...(resumeCheckpointId ? { resumeCheckpointId } : {}),
         ...(diagnosticUsage ? { diagnosticUsage } : {}),
       };
-      // An interim result commits its segment. Rebase boundary state so later
-      // text is judged on its own, while delta snapshots stay cumulative.
+      // An interim result commits its segment; later streamed text backfills
+      // only its own segment while delta snapshots stay cumulative.
       segmentStart = assistantText.length;
-      currentMessageStart = segmentStart;
-      preserveFrom = segmentStart;
-      pendingMessageSeparator = false;
-      sawToolUseSinceText = false;
-      currentMessageHadToolUse = false;
-      previousMessageHadToolUse = false;
       return;
     }
 
@@ -464,26 +419,20 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
 
     if (parsed.type === "stream_event" && isRecord(parsed.event)) {
       const evt = parsed.event;
-      // Tool-split turns stream as separate assistant messages. Mark the
-      // boundary so accumulated text joins with a paragraph break instead of
-      // gluing the pre-tool text to the next message's first delta.
       if (evt.type === "message_start") {
         beginTaggedReasoningMessage();
-        pendingMessageSeparator = true;
-        previousMessageHadToolUse = currentMessageHadToolUse;
-        currentMessageHadToolUse = false;
       } else if (evt.type === "message_stop") {
         finishTaggedReasoningMessage();
       }
-      const isToolUseBlockStart =
-        evt.type === "content_block_start" &&
-        isRecord(evt.content_block) &&
-        isClaudeToolUseBlockType(evt.content_block.type);
-      if (isToolUseBlockStart) {
-        sawToolUseSinceText = true;
-        currentMessageHadToolUse = true;
-      }
       if (classifyClaudeCommentary) {
+        // Text still pending when a tool_use block starts is pre-tool
+        // narration; text pending at any other block or message boundary is
+        // (part of) the reply. Misrouting either direction leaks narration
+        // into deliveries or drops answer text.
+        const isToolUseBlockStart =
+          evt.type === "content_block_start" &&
+          isRecord(evt.content_block) &&
+          isClaudeToolUseBlockType(evt.content_block.type);
         if (isToolUseBlockStart) {
           flushPendingClaudeCommentaryText();
         } else if (evt.type === "content_block_start" || evt.type === "message_stop") {

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1872,9 +1872,10 @@ describe("runCliAgent spawn path", () => {
       const result = await executePreparedCliRun(buildPreparedCliRunContext({}));
 
       expect(result.text).toBe("Hello world");
+      // Commentary classification buffers deltas until a flush boundary; the
+      // streamed text reaches consumers as one merged delta at the result.
       expect(agentEvents).toEqual([
-        { stream: "assistant", text: "Hello", delta: "Hello" },
-        { stream: "assistant", text: "Hello world", delta: " world" },
+        { stream: "assistant", text: "Hello world", delta: "Hello world" },
       ]);
     } finally {
       stop();

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -1405,8 +1405,8 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   }
   turn.onPhase?.("resolve");
   const raw = turn.rawLines.join("\n");
-  // Reuse the parser that classified pre-tool text as commentary. Reparsing the
-  // transcript loses that boundary when Claude's terminal result is empty.
+  // Prefer the streaming parser's state; the reparse fallback classifies
+  // commentary identically but cannot replay consumer-facing streams.
   const output =
     turn.streamingParser.getOutput() ??
     parseCliOutput({

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -836,10 +836,9 @@ describe("executePreparedCliRun supervisor output capture", () => {
       expect(spawnInput.captureOutput).toBe(false);
       expect(result.text).toBe("Hello world");
       expect(result.toolSummary).toEqual({ calls: 0, tools: [], failures: 0 });
-      expect(agentEvents).toEqual([
-        { text: "Hello", delta: "Hello" },
-        { text: "Hello world", delta: " world" },
-      ]);
+      // Commentary classification buffers deltas until a flush boundary; the
+      // streamed text reaches consumers as one merged delta at the result.
+      expect(agentEvents).toEqual([{ text: "Hello world", delta: "Hello world" }]);
       expect(context.params.onExecutionPhase).toHaveBeenCalledTimes(2);
       expect(context.params.onExecutionPhase).toHaveBeenNthCalledWith(2, {
         phase: "assistant_output_started",

--- a/src/auto-reply/reply/agent-runner-execution-cli-progress.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-progress.test.ts
@@ -491,8 +491,8 @@ describe("executeAgentTurn: CLI progress bridging", () => {
     }));
     state.runCliAgentMock.mockImplementationOnce(
       async (params: { runId: string; emitCommentaryText?: boolean }) => {
-        // With no commentary lane or headline consumer, pre-tool text stays in
-        // the assistant stream instead of being split into progress events.
+        // With no commentary lane or headline consumer, pre-tool text is
+        // classified as commentary and dropped; no progress events are emitted.
         expect(params.emitCommentaryText).toBe(false);
         return { payloads: [{ text: "done" }], meta: {} };
       },


### PR DESCRIPTION
Closes #121558

## What Problem This Solves

Cron and isolated runs on `claude-cli`-backed agents delivered the model's run narration fused onto the front of the announced message — "Connected. Let me pull the daily summaries…", inter-tool status lines, even self-corrections ("HEARTBEAT_OK / Wait — that's wrong…"). Root cause (full evidence in #121558): Claude Code's stream-json carries no phase metadata on assistant text, so OpenClaw classifies pre-tool narration as commentary heuristically — but only when a commentary consumer is wired. Cron wires none, so the classifier never engaged, narration accumulated into the assistant text, and `preferStreamedClaudeTextOverResult` then promoted the fused concatenation over the clean terminal result envelope.

## Why This Change Was Made

Commentary classification for the Claude stream-json dialect is now unconditional instead of consumer-keyed (`src/agents/cli-output-stream.ts`). Narration streams to the consumer when one exists (interactive progress lanes — behavior unchanged) and is dropped when none does (cron/quiet lanes). The result envelope becomes the authoritative final text, with streamed text still backfilling an empty result (the #90450 guarantee).

This matches how every clean lane already works — the codex harness honors the Responses API's protocol-native `phase: commentary` tag, and the embedded anthropic/openai transports stamp commentary phases in the transcript unconditionally, with delivery filtering by phase (see the cross-harness comparison on #121558). Classification-as-recorded-fact, consumer-independent, is the established architecture; claude-cli was the outlier.

With classification unconditional, the superseded-draft boundary machinery (`preferStreamedClaudeTextOverResult`, `missingMessageBoundarySeparator`, six boundary-tracking state variables) became dead on every live path and is removed in the same change. The live-session fallback reparse now also classifies identically to the streaming parser, closing its documented boundary-loss gap.

## User Impact

- Scheduled/cron announce deliveries from `claude-cli` agents carry only the final reply. No cron-executor changes were needed; the fix lands at the parser owner boundary.
- Interactive lanes with commentary/progress streaming enabled are byte-identical.
- Interactive lanes with commentary off no longer fuse narration into replies, aligning claude-cli with the embedded anthropic/openai lanes and the codex harness (also softens #25592 for this backend).
- Streaming granularity: with no consumer, assistant deltas now arrive merged at flush boundaries — the granularity commentary-enabled lanes already had.
- Known limitation (documented in #121558): narration the model writes inside its single final message when extended thinking does not engage is a model behavior, out of reach of the parser; mitigation is prompt-side.

Production LOC is net negative: 51 insertions / 163 deletions across the change; the production files alone drop ~80 lines.

## Evidence

- Root cause proven end-to-end in #121558: OTel/Phoenix trace comparison (clean runs = narration in reasoning blocks; leaky runs = narration in visible text), raw Claude CLI session transcripts showing narration as separate pre-tool text blocks, and three weeks of delivery mirrors from a production instance.
- Focused suites green post-change and post-rebase: parser suites (36), cli-runner + live-session + cron isolated-agent + subagent announce delivery (308), gateway agent-events (142), auto-reply CLI progress/dispatch (39). `pnpm tsgo` clean, oxlint clean, oxfmt applied.
- Rewritten tests pin the new invariant, including the exact cron shape: "classifies pre-tool text as commentary even when no consumer is wired" and "drops unconsumed pre-tool commentary and delivers only the result envelope". With-consumer commentary tests unchanged.
- Autoreview (codex, gpt-5.6-sol, high reasoning): clean, no P0 findings — "behavioral changes are deliberate and covered by updated tests."
