### PR TITLE
fix(codex): deliver task-suggestion tools to Codex-harness runs with calibrated guidance

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -442,6 +442,25 @@ describe("Codex app-server dynamic tool build", () => {
     });
   });
 
+  it("forwards the task-suggestion delivery mode", async () => {
+    // Regression: spawn_task/dismiss_task silently never existed on the Codex
+    // app-server path because this harness dropped params.taskSuggestionDeliveryMode.
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.taskSuggestionDeliveryMode = "gateway";
+    let receivedOptions: unknown;
+    setOpenClawCodingToolsFactoryForTests((options) => {
+      receivedOptions = options;
+      return [createRuntimeDynamicTool("message")];
+    });
+
+    await buildDynamicToolsForTest(params, workspaceDir);
+
+    expect(receivedOptions).toMatchObject({ taskSuggestionDeliveryMode: "gateway" });
+  });
+
   it("preserves the host-provided OpenClaw tool through the Codex allowlist", async () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -328,6 +328,9 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
       requireExplicitMessageTarget:
         params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
       sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+      // Same sibling-harness rule as clientCaps above: without this forward,
+      // spawn_task/dismiss_task silently never exist for Codex-harness runs.
+      taskSuggestionDeliveryMode: params.taskSuggestionDeliveryMode,
       disableMessageTool: input.ignoreDisableMessageTool ? false : params.disableMessageTool,
       forceMessageTool: shouldForceMessageTool(messagePolicyParams),
       enableHeartbeatTool: params.trigger === "heartbeat" || input.forceHeartbeatTool === true,

--- a/src/agents/tools/task-suggestion-tools.ts
+++ b/src/agents/tools/task-suggestion-tools.ts
@@ -17,17 +17,20 @@ const SpawnTaskToolSchema = Type.Object(
     title: Type.String({
       minLength: 1,
       maxLength: 60,
-      description: "Imperative task title under 60 characters.",
+      description:
+        "Imperative task title under 60 characters (start with a verb); shown as the card title and the started session's name.",
     }),
     prompt: Type.String({
       minLength: 1,
       maxLength: 32_768,
-      description: "Self-contained task prompt with relevant file paths and context.",
+      description:
+        "Self-contained task prompt with file paths and enough context to act without this conversation.",
     }),
     tldr: Type.String({
       minLength: 1,
       maxLength: 1_024,
-      description: "One or two plain-language sentences explaining the value; no code or paths.",
+      description:
+        "One or two plain-language sentences shown on the card explaining the value; no code or paths.",
     }),
     cwd: Type.Optional(
       Type.String({
@@ -74,8 +77,14 @@ export function createTaskSuggestionTools(params: {
       name: "spawn_task",
       displaySummary: SPAWN_TASK_TOOL_DISPLAY_SUMMARY,
       description: [
-        "Suggest confirmed valuable out-of-scope follow-up: dead code, stale docs, missing coverage, verified TODO, security issue.",
-        "Operator suggestion only; does not start work. cwd must be an absolute path inside a git checkout.",
+        "Flag an out-of-scope issue as a separate follow-up task instead of ignoring it, fixing it inline, or only mentioning it in your reply — a follow-up described in prose is lost; recording it here is what surfaces it to the operator.",
+        "This is the tool behind requests like 'flag it as a follow-up', 'note that for later', or 'make a task for that'; whenever you would write 'Follow-up:' in a reply, call this instead.",
+        "Use this whenever work you were not asked to do surfaces along the way: dead code, stale docs, missing coverage, a confirmed TODO, or a security issue spotted in passing.",
+        "Requests to stay scoped or skip cleanup apply to doing the work, not to flagging it: this only records a suggestion card in the operator's UI; nothing runs unless they accept it, and your current turn continues uninterrupted.",
+        "Do not flag vague code-smell observations or low-confidence hunches.",
+        "The prompt must stand alone: the started task sees only that text, never this conversation.",
+        "cwd must be an absolute path inside a git checkout.",
+        "Suggestions are ephemeral; ids do not survive a gateway restart.",
       ].join(" "),
       parameters: SpawnTaskToolSchema,
       outputSchema: SpawnTaskOutputSchema,
@@ -110,8 +119,11 @@ export function createTaskSuggestionTools(params: {
       label: "Dismiss Task",
       name: "dismiss_task",
       displaySummary: DISMISS_TASK_TOOL_DISPLAY_SUMMARY,
-      description:
-        "Withdraw stale/irrelevant pending spawn_task. Accepted suggestion cannot withdraw.",
+      description: [
+        "Withdraw a pending suggestion card you created with spawn_task when it is now stale, superseded, or already handled in this session.",
+        "To replace a card, call spawn_task with the better suggestion first, then dismiss the old task_id.",
+        "Only cards the operator has not acted on can be withdrawn; accepted ones cannot.",
+      ].join(" "),
       parameters: DismissTaskToolSchema,
       execute: async (_toolCallId, args) => {
         const input = args as Record<string, unknown>;


### PR DESCRIPTION
# What Problem This Solves

Two defects found while live-testing the task-suggestion feature with a real OpenAI-backed web session against a dev gateway:

1. **`spawn_task`/`dismiss_task` never existed for Codex-harness runs (P1).** The Codex app-server tool builder forwards run facts into `createOpenClawCodingTools` but dropped `taskSuggestionDeliveryMode` — the exact sibling-harness omission class already fixed there once for `clientCaps` (the comment above the fix line documents that precedent). Every GPT-backed session silently lacked the tools while Anthropic-backed sessions (native embedded runner, which forwards the mode) had them. Proven live: a Control UI session on `gpt-5.6-luna` answered "None" when asked to list tools containing "task"; after the one-line forward it answers `spawn_task`, and instrumented runs show the mode arriving as `"gateway"` at tool construction.
2. **The model-facing tool text was too thin to steer usage.** The previous description ("Suggest confirmed valuable out-of-scope follow-up… Operator suggestion only; does not start work.") carried no anti-noise guidance, no explanation of what the card does, no self-containment rule for the prompt, and no ephemerality warning — and in six controlled live iterations GPT models either ignored follow-up bait entirely or reported follow-ups in prose ("Follow-up noted: …") that no one ever sees again.

# Why This Change Was Made

The tool advertises itself exclusively through its schema (deliberately — it is gated per session, so static prompt text would be hallucination bait). That makes the description the entire model-facing product surface. This PR ports the calibration that the equivalent Claude Code tool ships: when to use it (work you were not asked to do, surfacing along the way), when not to (vague code smells, low-confidence hunches), that scope requests apply to doing the work rather than flagging it, that a follow-up described only in prose is lost, the lexical bridge from operator phrasing ("flag it as a follow-up", "note that for later") to the tool, prompt self-containment, the git-checkout `cwd` requirement, and registry ephemerality. `dismiss_task` gains the replace pattern (spawn the better card first, then dismiss) and the pending-only rule. Parameter descriptions now say where each field renders (card title/session name, card summary, expander).

# User Impact

- GPT-backed sessions (Codex harness) can now produce suggested-task cards at all — previously the capability simply did not exist for them, with no error and no trace.
- Live-verified end to end on `gpt-5.6-sol`: given a natural request ("if you spot anything else worth doing, put it on a suggested-task card"), the model completed the scoped work, called `spawn_task` with the correct repo `cwd`, and the card rendered in the Control UI ("Remove the legacy sum alias") — screenshot below.
- Calibration reality, documented from the same live sessions: with the enriched text GPT models now reliably *notice and hold* out-of-scope items ("Follow-up: … left untouched as requested") but still prefer prose over the tool unless the operator's phrasing evokes a task/card artifact; fully spontaneous card creation under bare scope instructions was not achieved with Luna/medium or Sol/high. That gap is a harness-prompt/model-calibration matter, not a description one — the description is now at parity with the Claude Code original that exhibits spontaneous use on Claude models.

# Evidence

- Live before/after on a dev gateway (isolated state dir, Control UI driven by Playwright, real OpenAI models): tool-listing probe "None" → `spawn_task`; instrumented delivery-mode trace `admission "gateway" → reply run "gateway" → runner dispatch "gateway" → tool build null` pre-fix, `"gateway"` end-to-end post-fix; final natural-language run produced a live card (screenshot embedded).
- New regression test in `extensions/codex/src/app-server/dynamic-tool-build.test.ts` mirroring the existing `clientCaps` sibling-forward regression: the Codex tool builder must forward `taskSuggestionDeliveryMode` into `createOpenClawCodingTools`.
- `src/agents/tools/task-suggestion-tools.test.ts` green (schema/param behavior unchanged; descriptions only).
- oxlint / oxfmt clean on all touched files.
- Autoreview clean (see PR checks / artifacts).

## Screenshots

![gpt-5.6-sol completing scoped work and recording the out-of-scope TODO as a live suggested-task card](https://github.com/user-attachments/assets/86faeade-63ab-4bf4-b4d2-59408b849e02)

gpt-5.6-sol completing scoped work and recording the out-of-scope TODO as a live suggested-task card
