### PR TITLE
fix(signal): reject invalid UTF-8 in container REST JSON responses

### DIFF
--- a/extensions/signal/src/client-container.real-server.test.ts
+++ b/extensions/signal/src/client-container.real-server.test.ts
@@ -85,6 +85,22 @@ describe("signal REST real-server deadline", () => {
     expect(Date.now() - startedAt).toBeLessThan(2_000);
   });
 
+  it("rejects invalid UTF-8 in a successful JSON response", async () => {
+    const server = await startServer((_req, res) => {
+      const corrupted = Buffer.concat([
+        Buffer.from('{"version":"1.'),
+        Buffer.from([0xff]),
+        Buffer.from('0"}'),
+      ]);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(corrupted);
+    });
+
+    await expect(
+      containerRpcRequest("version", undefined, { baseUrl: server.baseUrl, timeoutMs: 1_000 }),
+    ).rejects.toThrow(/not valid for encoding utf-8/i);
+  });
+
   it("returns the parsed body when it completes within the deadline", async () => {
     const server = await startServer((_req, res) => {
       res.writeHead(200, { "content-type": "application/json" });

--- a/extensions/signal/src/client-container.real-server.test.ts
+++ b/extensions/signal/src/client-container.real-server.test.ts
@@ -98,7 +98,7 @@ describe("signal REST real-server deadline", () => {
 
     await expect(
       containerRpcRequest("version", undefined, { baseUrl: server.baseUrl, timeoutMs: 1_000 }),
-    ).rejects.toThrow(/not valid for encoding utf-8/i);
+    ).rejects.toBeInstanceOf(TypeError);
   });
 
   it("returns the parsed body when it completes within the deadline", async () => {

--- a/extensions/signal/src/client-container.real-server.test.ts
+++ b/extensions/signal/src/client-container.real-server.test.ts
@@ -9,7 +9,7 @@ import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { containerRpcRequest } from "./client-container.js";
+import { containerCheck, containerRpcRequest } from "./client-container.js";
 
 type StartedServer = { baseUrl: string; close: () => Promise<void> };
 
@@ -41,6 +41,35 @@ async function startServer(handler: http.RequestListener): Promise<StartedServer
 }
 
 describe("signal REST real-server deadline", () => {
+  it.each([{ bytes: [0xff] }, { bytes: [0xc3] }])(
+    "rejects malformed UTF-8 bytes $bytes before JSON parsing",
+    async ({ bytes }) => {
+      const server = await startServer((_req, res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(
+          Buffer.concat([Buffer.from('{"versions":["'), Buffer.from(bytes), Buffer.from('"]}')]),
+        );
+      });
+
+      await expect(
+        containerRpcRequest("version", undefined, { baseUrl: server.baseUrl }),
+      ).rejects.toBeInstanceOf(TypeError);
+    },
+  );
+
+  it("uses only the status when the unused health response is malformed UTF-8", async () => {
+    const server = await startServer((_req, res) => {
+      res.writeHead(200);
+      res.end(Buffer.from([0xff]));
+    });
+
+    await expect(containerCheck(server.baseUrl)).resolves.toEqual({
+      ok: true,
+      status: 200,
+      error: null,
+    });
+  });
+
   it("aborts a slow-drip body that never idles, at the request deadline", async () => {
     // Drip a byte every 50ms: below the 300ms idle guard, so only the total request
     // deadline can stop it. This is the exact slow-drip case the fix bounds.
@@ -83,22 +112,6 @@ describe("signal REST real-server deadline", () => {
       containerRpcRequest("version", undefined, { baseUrl: server.baseUrl, timeoutMs: 300 }),
     ).rejects.toThrow(/Signal REST (request timed out|response body stalled)/);
     expect(Date.now() - startedAt).toBeLessThan(2_000);
-  });
-
-  it("rejects invalid UTF-8 in a successful JSON response", async () => {
-    const server = await startServer((_req, res) => {
-      const corrupted = Buffer.concat([
-        Buffer.from('{"version":"1.'),
-        Buffer.from([0xff]),
-        Buffer.from('0"}'),
-      ]);
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end(corrupted);
-    });
-
-    await expect(
-      containerRpcRequest("version", undefined, { baseUrl: server.baseUrl, timeoutMs: 1_000 }),
-    ).rejects.toBeInstanceOf(TypeError);
   });
 
   it("returns the parsed body when it completes within the deadline", async () => {

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -176,7 +176,7 @@ async function readSignalRestText(
     onTimeout: signalRestRequestTimeoutError,
     onOverflow: ({ maxBytes }) => new Error(`Signal REST: text response exceeds ${maxBytes} bytes`),
   });
-  return new TextDecoder().decode(bytes);
+  return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
 }
 
 async function readSignalRestErrorText(

--- a/extensions/signal/src/client.test.ts
+++ b/extensions/signal/src/client.test.ts
@@ -71,6 +71,26 @@ afterEach(async () => {
 });
 
 describe("signalRpcRequest", () => {
+  it.each([{ bytes: [0xff] }, { bytes: [0xc3] }])(
+    "rejects malformed UTF-8 bytes $bytes before JSON parsing",
+    async ({ bytes }) => {
+      const baseUrl = await withSignalServer((_req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          Buffer.concat([
+            Buffer.from('{"jsonrpc":"2.0","result":{"version":"'),
+            Buffer.from(bytes),
+            Buffer.from('"},"id":"test-id"}'),
+          ]),
+        );
+      });
+
+      await expect(signalRpcRequest("version", undefined, { baseUrl })).rejects.toBeInstanceOf(
+        TypeError,
+      );
+    },
+  );
+
   it("returns parsed RPC result", async () => {
     const baseUrl = await withSignalServer(async (req, res) => {
       expect(req.method).toBe("POST");
@@ -90,24 +110,6 @@ describe("signalRpcRequest", () => {
     });
 
     expect(result).toEqual({ version: "0.13.22" });
-  });
-
-  it("rejects invalid UTF-8 in a successful JSON response", async () => {
-    const baseUrl = await withSignalServer((_req, res) => {
-      const corrupted = Buffer.concat([
-        Buffer.from('{"jsonrpc":"2.0","result":{"version":"1.'),
-        Buffer.from([0xff]),
-        Buffer.from('0"},"id":"test-id"}'),
-      ]);
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(corrupted);
-    });
-
-    await expect(
-      signalRpcRequest("version", undefined, {
-        baseUrl,
-      }),
-    ).rejects.toBeInstanceOf(TypeError);
   });
 
   it("preserves path-prefixed base URLs for RPC requests", async () => {
@@ -281,6 +283,15 @@ describe("signalRpcRequest", () => {
 });
 
 describe("signalCheck", () => {
+  it("uses only the status when the unused response body is malformed UTF-8", async () => {
+    const baseUrl = await withSignalServer((_req, res) => {
+      res.writeHead(200);
+      res.end(Buffer.from([0xff]));
+    });
+
+    await expect(signalCheck(baseUrl)).resolves.toEqual({ ok: true, status: 200, error: null });
+  });
+
   it("returns ok for a healthy signal-cli check", async () => {
     const baseUrl = await withSignalServer((req, res) => {
       expect(req.method).toBe("GET");
@@ -290,15 +301,6 @@ describe("signalCheck", () => {
     });
 
     await expect(signalCheck(baseUrl)).resolves.toEqual({ ok: true, status: 204, error: null });
-  });
-
-  it("keeps health checks status-only when the unused body is not valid UTF-8", async () => {
-    const baseUrl = await withSignalServer((_req, res) => {
-      res.writeHead(200);
-      res.end(Buffer.from([0xff]));
-    });
-
-    await expect(signalCheck(baseUrl)).resolves.toEqual({ ok: true, status: 200, error: null });
   });
 
   it("preserves path-prefixed base URLs for health checks", async () => {

--- a/extensions/signal/src/client.test.ts
+++ b/extensions/signal/src/client.test.ts
@@ -92,6 +92,24 @@ describe("signalRpcRequest", () => {
     expect(result).toEqual({ version: "0.13.22" });
   });
 
+  it("rejects invalid UTF-8 in a successful JSON response", async () => {
+    const baseUrl = await withSignalServer((_req, res) => {
+      const corrupted = Buffer.concat([
+        Buffer.from('{"jsonrpc":"2.0","result":{"version":"1.'),
+        Buffer.from([0xff]),
+        Buffer.from('0"},"id":"test-id"}'),
+      ]);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(corrupted);
+    });
+
+    await expect(
+      signalRpcRequest("version", undefined, {
+        baseUrl,
+      }),
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+
   it("preserves path-prefixed base URLs for RPC requests", async () => {
     const serverUrl = await withSignalServer(async (req, res) => {
       expect(req.method).toBe("POST");

--- a/extensions/signal/src/client.test.ts
+++ b/extensions/signal/src/client.test.ts
@@ -292,6 +292,15 @@ describe("signalCheck", () => {
     await expect(signalCheck(baseUrl)).resolves.toEqual({ ok: true, status: 204, error: null });
   });
 
+  it("keeps health checks status-only when the unused body is not valid UTF-8", async () => {
+    const baseUrl = await withSignalServer((_req, res) => {
+      res.writeHead(200);
+      res.end(Buffer.from([0xff]));
+    });
+
+    await expect(signalCheck(baseUrl)).resolves.toEqual({ ok: true, status: 200, error: null });
+  });
+
   it("preserves path-prefixed base URLs for health checks", async () => {
     const serverUrl = await withSignalServer((req, res) => {
       expect(req.method).toBe("GET");

--- a/extensions/signal/src/client.ts
+++ b/extensions/signal/src/client.ts
@@ -39,7 +39,7 @@ const MAX_SIGNAL_SSE_EVENT_DATA_BYTES = 1_048_576;
 type SignalHttpResponse = {
   status: number;
   statusText: string;
-  text: string;
+  body: Buffer;
 };
 
 function createSignalSseAbortError(): Error {
@@ -116,7 +116,7 @@ function normalizeSignalSseTimeoutMs(timeoutMs: number): number | null {
   return resolveTimerTimeoutMs(timeoutMs, DEFAULT_TIMEOUT_MS);
 }
 
-function requestSignalHttpText(
+function requestSignalHttpResponse(
   url: URL,
   options: {
     method: "GET" | "POST";
@@ -179,15 +179,11 @@ function requestSignalHttpText(
         });
         res.on("error", rejectOnce);
         res.on("end", () => {
-          try {
-            resolveOnce({
-              status: res.statusCode ?? 0,
-              statusText: res.statusMessage || "error",
-              text: new TextDecoder("utf-8", { fatal: true }).decode(Buffer.concat(chunks)),
-            });
-          } catch (error) {
-            rejectOnce(error);
-          }
+          resolveOnce({
+            status: res.statusCode ?? 0,
+            statusText: res.statusMessage || "error",
+            body: Buffer.concat(chunks),
+          });
         });
       },
     );
@@ -214,23 +210,27 @@ export async function signalRpcRequest<T = unknown>(
     params,
     id,
   });
-  const res = await requestSignalHttpText(resolveSignalEndpointUrl(opts.baseUrl, "/api/v1/rpc"), {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "Content-Length": String(Buffer.byteLength(body)),
+  const res = await requestSignalHttpResponse(
+    resolveSignalEndpointUrl(opts.baseUrl, "/api/v1/rpc"),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": String(Buffer.byteLength(body)),
+      },
+      body,
+      timeoutMs: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      maxResponseBytes: opts.maxResponseBytes,
     },
-    body,
-    timeoutMs: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-    maxResponseBytes: opts.maxResponseBytes,
-  });
+  );
   if (res.status === 201) {
     return undefined as T;
   }
-  if (!res.text) {
+  const text = new TextDecoder("utf-8", { fatal: true }).decode(res.body);
+  if (!text) {
     throw new Error(`Signal RPC empty response (status ${res.status})`);
   }
-  const parsed = parseSignalRpcResponse<T>(res.text, res.status);
+  const parsed = parseSignalRpcResponse<T>(text, res.status);
   if (parsed.error) {
     const code = parsed.error.code ?? "unknown";
     const msg = parsed.error.message ?? "Signal RPC error";
@@ -244,10 +244,14 @@ export async function signalCheck(
   timeoutMs = DEFAULT_TIMEOUT_MS,
 ): Promise<{ ok: boolean; status?: number | null; error?: string | null }> {
   try {
-    const res = await requestSignalHttpText(resolveSignalEndpointUrl(baseUrl, "/api/v1/check"), {
-      method: "GET",
-      timeoutMs,
-    });
+    // Health checks intentionally inspect only HTTP status; JSON-RPC decodes at its consumer boundary.
+    const res = await requestSignalHttpResponse(
+      resolveSignalEndpointUrl(baseUrl, "/api/v1/check"),
+      {
+        method: "GET",
+        timeoutMs,
+      },
+    );
     if (res.status < 200 || res.status >= 300) {
       return { ok: false, status: res.status, error: `HTTP ${res.status}` };
     }

--- a/extensions/signal/src/client.ts
+++ b/extensions/signal/src/client.ts
@@ -179,11 +179,15 @@ function requestSignalHttpText(
         });
         res.on("error", rejectOnce);
         res.on("end", () => {
-          resolveOnce({
-            status: res.statusCode ?? 0,
-            statusText: res.statusMessage || "error",
-            text: Buffer.concat(chunks).toString("utf8"),
-          });
+          try {
+            resolveOnce({
+              status: res.statusCode ?? 0,
+              statusText: res.statusMessage || "error",
+              text: new TextDecoder("utf-8", { fatal: true }).decode(Buffer.concat(chunks)),
+            });
+          } catch (error) {
+            rejectOnce(error);
+          }
         });
       },
     );

--- a/extensions/signal/src/client.ts
+++ b/extensions/signal/src/client.ts
@@ -38,7 +38,6 @@ const MAX_SIGNAL_SSE_EVENT_DATA_BYTES = 1_048_576;
 
 type SignalHttpResponse = {
   status: number;
-  statusText: string;
   body: Buffer;
 };
 
@@ -116,7 +115,7 @@ function normalizeSignalSseTimeoutMs(timeoutMs: number): number | null {
   return resolveTimerTimeoutMs(timeoutMs, DEFAULT_TIMEOUT_MS);
 }
 
-function requestSignalHttpResponse(
+function requestSignalHttp(
   url: URL,
   options: {
     method: "GET" | "POST";
@@ -181,7 +180,6 @@ function requestSignalHttpResponse(
         res.on("end", () => {
           resolveOnce({
             status: res.statusCode ?? 0,
-            statusText: res.statusMessage || "error",
             body: Buffer.concat(chunks),
           });
         });
@@ -210,22 +208,20 @@ export async function signalRpcRequest<T = unknown>(
     params,
     id,
   });
-  const res = await requestSignalHttpResponse(
-    resolveSignalEndpointUrl(opts.baseUrl, "/api/v1/rpc"),
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "Content-Length": String(Buffer.byteLength(body)),
-      },
-      body,
-      timeoutMs: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-      maxResponseBytes: opts.maxResponseBytes,
+  const res = await requestSignalHttp(resolveSignalEndpointUrl(opts.baseUrl, "/api/v1/rpc"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Length": String(Buffer.byteLength(body)),
     },
-  );
+    body,
+    timeoutMs: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    maxResponseBytes: opts.maxResponseBytes,
+  });
   if (res.status === 201) {
     return undefined as T;
   }
+  // Decode JSON bodies here; health checks use status without interpreting their bytes.
   const text = new TextDecoder("utf-8", { fatal: true }).decode(res.body);
   if (!text) {
     throw new Error(`Signal RPC empty response (status ${res.status})`);
@@ -244,14 +240,10 @@ export async function signalCheck(
   timeoutMs = DEFAULT_TIMEOUT_MS,
 ): Promise<{ ok: boolean; status?: number | null; error?: string | null }> {
   try {
-    // Health checks intentionally inspect only HTTP status; JSON-RPC decodes at its consumer boundary.
-    const res = await requestSignalHttpResponse(
-      resolveSignalEndpointUrl(baseUrl, "/api/v1/check"),
-      {
-        method: "GET",
-        timeoutMs,
-      },
-    );
+    const res = await requestSignalHttp(resolveSignalEndpointUrl(baseUrl, "/api/v1/check"), {
+      method: "GET",
+      timeoutMs,
+    });
     if (res.status < 200 || res.status >= 300) {
       return { ok: false, status: res.status, error: `HTTP ${res.status}` };
     }


### PR DESCRIPTION
## What Problem This Solves

Signal's native JSON-RPC and container REST readers previously replaced malformed UTF-8 before parsing JSON, silently changing response data. Preserve bounded native response bytes until the JSON consumer and use fatal UTF-8 decoding in both JSON readers. Status-only health checks continue to ignore unused response bytes. Removing the unused native `statusText` field keeps production code net-neutral; the PR adds 58 test lines.

## Why This Change Was Made

Raw HTTP regression tests cover invalid `0xff` and truncated `0xc3` in both clients and status-only health controls. The four malformed-input cases fail before the repair; all 133 focused owner and sibling tests pass after it. Full changed-file gates and independent P0 review pass. The actual `probeSignal` operator path was driven through both native and container loopback HTTP: Japanese/emoji versions survive intact, corrupted JSON produces a visible failure, and status-only health remains healthy.

## User Impact

Malformed JSON bytes produce a visible probe failure; valid Unicode and status-only health checks retain their behavior.

## Evidence

```json
{"passed":true,"productionEntry":"probeSignal → client-adapter → native/container HTTP","authenticatedSignal":false,"transportsTested":2,"healthUnusedInvalidBytesPreserved":true,"utf8ValuePreserved":true,"malformedJsonBytesReportedAsProbeFailure":true,"allLoopbackServersClosed":true}
```

The health-check finding remains fixed, and the production-growth concern is resolved. The old rebase rank-up is skipped because the four changed files and the adapter/probe owners are byte-identical from the PR merge base through the tested trusted-main baseline and freshly fetched main. The follow-up preserves contributor ancestry; exact-head hosted checks for `67366c010c13245817ecdd951a75ea6b3c8af31f` will validate the current merge context. The stale ClawSweeper review should be refreshed.

Malformed JSON bytes now fail intentionally; valid Unicode, 201/no-body RPC responses, error-prefix readers, attachments, and the separate SSE decoder keep their contracts. The contributor checkout was not executed locally. Thanks @sunlit-deng.


Maintainer-reviewed head: `67366c010c13245817ecdd951a75ea6b3c8af31f`. Contributor credit is preserved.
