### PR TITLE
fix(browser): bound Playwright CDP connection memory via max-age recycling

### DIFF
--- a/extensions/browser/src/browser/pw-session-actions.ts
+++ b/extensions/browser/src/browser/pw-session-actions.ts
@@ -33,6 +33,7 @@ import {
   retirePlaywrightBrowserConnectionExact,
   takeCachedPlaywrightBrowserConnection,
   ensureContextState,
+  withPlaywrightConnectionLease,
 } from "./pw-session-connection.js";
 import {
   cachedByCdpUrl,
@@ -307,7 +308,7 @@ async function withPlaywrightSafeReadReconnect<T>(
 ): Promise<T> {
   const connected = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
   try {
-    return await run(connected.browser);
+    return await withPlaywrightConnectionLease(connected, () => run(connected.browser));
   } catch (err) {
     if (!isRecoverablePlaywrightDisconnectError(err) || opts.attempt?.cancelled) {
       throw err;
@@ -317,7 +318,7 @@ async function withPlaywrightSafeReadReconnect<T>(
       throw err;
     }
     const retry = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
-    return await run(retry.browser);
+    return await withPlaywrightConnectionLease(retry, () => run(retry.browser));
   }
 }
 
@@ -478,7 +479,28 @@ export async function createPageViaPlaywright(
   url: string;
   type: string;
 }> {
-  const { browser } = await connectBrowser(opts.cdpUrl, opts.cdpPolicy ?? opts.ssrfPolicy);
+  const connected = await connectBrowser(opts.cdpUrl, opts.cdpPolicy ?? opts.ssrfPolicy);
+  // Page creation is not safely replayable after an ambiguous disconnect, so hold a
+  // lease for its whole duration: max-age recycling must not close this connection
+  // mid-flight.
+  return await withPlaywrightConnectionLease(connected, () =>
+    createPageOnConnection(connected.browser, opts),
+  );
+}
+
+async function createPageOnConnection(
+  browser: Browser,
+  opts: {
+    cdpUrl: string;
+    url: string;
+    cdpPolicy?: SsrFPolicy;
+  } & BrowserNavigationPolicyOptions,
+): Promise<{
+  targetId: string;
+  title: string;
+  url: string;
+  type: string;
+}> {
   const context = browser.contexts()[0] ?? (await browser.newContext());
   ensureContextState(context);
 

--- a/extensions/browser/src/browser/pw-session-connection.ts
+++ b/extensions/browser/src/browser/pw-session-connection.ts
@@ -148,10 +148,30 @@ export function clearBlockedPageRef(cdpUrl: string, page: Page): void {
   blockedPageRefsByCdpUrl.get(normalizeCdpUrl(cdpUrl))?.delete(page);
 }
 
+/**
+ * Timer handle for the max-age recycling sweep (see below). Declared here, ahead of
+ * takeCachedPlaywrightBrowserConnection, because every path that removes an entry from
+ * cachedByCdpUrl - not just the sweep's own eviction - must be able to stop the sweep
+ * once the cache is empty. A close driven by connection teardown, test cleanup, or an
+ * explicit retire all funnel through this one function; if only the sweep's own code
+ * path stopped the timer, any of those other paths could empty the cache while leaving
+ * a real (non-fake-timer-aware) interval running past the point anything is cached.
+ */
+let connectionRecycleSweep: ReturnType<typeof setInterval> | undefined;
+
+function stopConnectionRecycleSweepWhenIdle(): void {
+  if (!connectionRecycleSweep || cachedByCdpUrl.size > 0) {
+    return;
+  }
+  clearInterval(connectionRecycleSweep);
+  connectionRecycleSweep = undefined;
+}
+
 export function takeCachedPlaywrightBrowserConnection(cdpUrl: string): ConnectedBrowser | null {
   const normalized = normalizeCdpUrl(cdpUrl);
   const cur = cachedByCdpUrl.get(normalized);
   cachedByCdpUrl.delete(normalized);
+  stopConnectionRecycleSweepWhenIdle();
   const pending = connectingByCdpUrl.get(normalized);
   if (pending) {
     // Invalidation must also retire an in-flight connect. Otherwise it can
@@ -342,6 +362,89 @@ export function evictStalePlaywrightBrowserConnection(
   }
 }
 
+/**
+ * Max-age recycling for cached Playwright CDP connections.
+ *
+ * Playwright's connection-scoped object registry retains a client object and a
+ * dispatcher pair for every network request materialized by page event
+ * listeners, for the life of the connection. On a long-lived connectOverCDP
+ * connection that registry grows without bound, and it grows from browser
+ * EVENTS rather than from gateway operations: an idle tab running polling JS
+ * accumulates retained objects while no plugin code path executes at all. An
+ * acquisition-time age check therefore cannot bound it, because no acquisition
+ * may happen for hours. A periodic sweep can.
+ *
+ * Recycling is lease-aware. Closing a connection out from under an in-flight
+ * operation would turn a healthy action into a disconnect failure, and page
+ * creation and navigation are deliberately not replayable after an ambiguous
+ * disconnect. So an aged connection that still has leases is unpublished from
+ * the cache immediately - no new operation can join it, and the next
+ * connectBrowser() opens a fresh one - and is closed by whichever lease
+ * releases last.
+ */
+const PLAYWRIGHT_CONNECTION_MAX_AGE_MS = 30 * 60 * 1000;
+const PLAYWRIGHT_CONNECTION_SWEEP_INTERVAL_MS = 60 * 1000;
+
+/** Arm the sweep lazily, so importing this module never starts a timer on its own. */
+function ensureConnectionRecycleSweep(): void {
+  if (connectionRecycleSweep) {
+    return;
+  }
+  connectionRecycleSweep = setInterval(
+    recycleAgedPlaywrightConnections,
+    PLAYWRIGHT_CONNECTION_SWEEP_INTERVAL_MS,
+  );
+  connectionRecycleSweep.unref?.();
+}
+
+/** Record that an operation is using this connection; recycling defers until it releases. */
+export function acquirePlaywrightConnectionLease(connection: ConnectedBrowser): void {
+  connection.leases = (connection.leases ?? 0) + 1;
+}
+
+/** Release an operation's hold, closing the connection if recycling was waiting on it. */
+export function releasePlaywrightConnectionLease(connection: ConnectedBrowser): void {
+  const remaining = Math.max(0, (connection.leases ?? 0) - 1);
+  connection.leases = remaining;
+  if (remaining > 0 || !connection.recyclePending) {
+    return;
+  }
+  connection.recyclePending = false;
+  // The sweep already unpublished it, so this handle is the only thing left to close.
+  void closeTrackedPlaywrightConnection(connection).catch(() => {});
+}
+
+/** Run an operation under a lease so max-age recycling cannot close its connection. */
+export async function withPlaywrightConnectionLease<T>(
+  connection: ConnectedBrowser,
+  run: () => Promise<T>,
+): Promise<T> {
+  acquirePlaywrightConnectionLease(connection);
+  try {
+    return await run();
+  } finally {
+    releasePlaywrightConnectionLease(connection);
+  }
+}
+
+function recycleAgedPlaywrightConnections(): void {
+  const now = Date.now();
+  for (const [url, connection] of [...cachedByCdpUrl]) {
+    if (now - (connection.connectedAt ?? now) <= PLAYWRIGHT_CONNECTION_MAX_AGE_MS) {
+      continue;
+    }
+    if ((connection.leases ?? 0) > 0) {
+      connection.recyclePending = true;
+      // Unpublish now so no further operation joins a connection that is already
+      // scheduled to close; the last lease release closes it.
+      takeCachedPlaywrightBrowserConnection(url);
+      continue;
+    }
+    evictStalePlaywrightBrowserConnection(url, connection.browser);
+  }
+  stopConnectionRecycleSweepWhenIdle();
+}
+
 function hasBlockedTargetsForCdpUrl(cdpUrl: string): boolean {
   const prefix = `${normalizeCdpUrl(cdpUrl)}::`;
   for (const key of blockedTargetsByCdpUrl) {
@@ -478,8 +581,15 @@ export async function connectBrowser(
             cachedByCdpUrl.delete(normalized);
           }
         };
-        const connected: ConnectedBrowser = { browser, cdpUrl: normalized, onDisconnected };
+        const connected: ConnectedBrowser = {
+          browser,
+          cdpUrl: normalized,
+          onDisconnected,
+          connectedAt: Date.now(),
+          leases: 0,
+        };
         cachedByCdpUrl.set(normalized, connected);
+        ensureConnectionRecycleSweep();
         browser.on("disconnected", onDisconnected);
         observeBrowser(browser);
         return connected;
@@ -630,7 +740,16 @@ async function getPageForTargetIdOnce(opts: {
   if (opts.targetId && isBlockedTarget(opts.cdpUrl, opts.targetId)) {
     throw new BlockedBrowserTargetError();
   }
-  const { browser } = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
+  const connected = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
+  return await withPlaywrightConnectionLease(connected, () =>
+    resolvePageForTargetId(connected.browser, opts),
+  );
+}
+
+async function resolvePageForTargetId(
+  browser: Browser,
+  opts: { cdpUrl: string; targetId?: string },
+): Promise<Page> {
   const pages = await getAllPages(browser);
   if (!pages.length) {
     throw new Error("No pages available in the connected browser.");

--- a/extensions/browser/src/browser/pw-session-contracts.ts
+++ b/extensions/browser/src/browser/pw-session-contracts.ts
@@ -92,6 +92,12 @@ export type ConnectedBrowser = {
   browser: Browser;
   cdpUrl: string;
   onDisconnected?: () => void;
+  /** Epoch ms when this CDP connection was established; drives max-age recycling. */
+  connectedAt?: number;
+  /** In-flight operations holding this connection; recycling waits for it to drain to zero. */
+  leases?: number;
+  /** Set when max-age recycling was deferred because leases were still outstanding. */
+  recyclePending?: boolean;
 };
 
 export type DownloadPayload = PlaywrightDownload & {

--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -968,3 +968,128 @@ describe("pw-session connection scoping", () => {
     expect(connectOverCdpSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("pw-session connection max-age recycling", () => {
+  const CDP_URL = "http://127.0.0.1:9222";
+  const MAX_AGE_MS = 30 * 60 * 1000;
+
+  /** Browser mock whose page creation can be held open across a recycle boundary. */
+  function makeCreatePageBrowser(targetId: string) {
+    const browserClose = vi.fn(async () => {});
+    const openPages: import("playwright-core").Page[] = [];
+    let releaseNewPage: (() => void) | null = null;
+    const newPageGate = new Promise<void>((resolve) => {
+      releaseNewPage = resolve;
+    });
+    let gateNewPage = false;
+
+    const page = {
+      on: vi.fn(),
+      context: () => context,
+      goto: vi.fn(async () => null),
+      title: vi.fn(async () => `title:${targetId}`),
+      url: vi.fn(() => "about:blank"),
+      close: vi.fn(async () => {}),
+      route: vi.fn(async () => {}),
+      unroute: vi.fn(async () => {}),
+      mainFrame: () => ({}),
+    } as unknown as import("playwright-core").Page;
+
+    const context = {
+      pages: () => openPages,
+      on: vi.fn(),
+      newPage: vi.fn(async () => {
+        if (gateNewPage) {
+          await newPageGate;
+        }
+        openPages.push(page);
+        return page;
+      }),
+      newCDPSession: vi.fn(async () => ({
+        send: vi.fn(async (method: string) =>
+          method === "Target.getTargetInfo" ? { targetInfo: { targetId, title: targetId } } : {},
+        ),
+        detach: vi.fn(async () => {}),
+      })),
+    } as unknown as import("playwright-core").BrowserContext;
+
+    const browser = {
+      contexts: () => [context],
+      on: vi.fn(),
+      off: vi.fn(),
+      close: browserClose,
+    } as unknown as import("playwright-core").Browser;
+
+    return {
+      browser,
+      browserClose,
+      holdNextPageCreation: () => {
+        gateNewPage = true;
+      },
+      releasePageCreation: () => releaseNewPage?.(),
+    };
+  }
+
+  it("does not sever an in-flight page creation when the connection ages out", async () => {
+    vi.useFakeTimers();
+    const aged = makeCreatePageBrowser("T1");
+    connectOverCdpSpy.mockImplementation((async () => aged.browser) as never);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    // Establish and cache the connection, then start a mutation and hold it open.
+    await listPagesViaPlaywright({ cdpUrl: CDP_URL });
+    aged.holdNextPageCreation();
+    const creating = createPageViaPlaywright({ cdpUrl: CDP_URL, url: "about:blank" });
+
+    // Cross the max-age boundary while the mutation is still in flight.
+    await vi.advanceTimersByTimeAsync(MAX_AGE_MS + 2 * 60_000);
+    expect(aged.browserClose).not.toHaveBeenCalled();
+
+    aged.releasePageCreation();
+    // The mutation must still succeed - page creation is not safely replayable.
+    await expect(creating).resolves.toMatchObject({ targetId: "T1", type: "page" });
+
+    // Once the lease drains, the deferred recycle completes.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(aged.browserClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("recycles an idle aged connection and reconnects the next read", async () => {
+    vi.useFakeTimers();
+    const first = makeBrowser("A", "https://a.example/first");
+    const second = makeBrowser("A", "https://a.example/second");
+    let calls = 0;
+    connectOverCdpSpy.mockImplementation((async () => {
+      calls += 1;
+      return calls === 1 ? first.browser : second.browser;
+    }) as never);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await listPagesViaPlaywright({ cdpUrl: CDP_URL });
+    expect(connectOverCdpSpy).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(MAX_AGE_MS + 60_000);
+    expect(first.browserClose).toHaveBeenCalledTimes(1);
+
+    // The recycled connection is gone from the cache, so the next read opens a new one
+    // and returns normally rather than surfacing the disconnect.
+    const page = await getPageForTargetId({ cdpUrl: CDP_URL });
+    expect(page.url()).toBe("https://a.example/second");
+    expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
+    expect(second.browserClose).not.toHaveBeenCalled();
+  });
+
+  it("keeps a young connection cached across sweeps", async () => {
+    vi.useFakeTimers();
+    const fresh = makeBrowser("A", "https://a.example");
+    connectOverCdpSpy.mockImplementation((async () => fresh.browser) as never);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await listPagesViaPlaywright({ cdpUrl: CDP_URL });
+    await vi.advanceTimersByTimeAsync(MAX_AGE_MS - 60_000);
+
+    expect(fresh.browserClose).not.toHaveBeenCalled();
+    await listPagesViaPlaywright({ cdpUrl: CDP_URL });
+    expect(connectOverCdpSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Fixes #121572.

## What Problem This Solves

Resolves a problem where operators running a long-lived OpenClaw gateway against a persistent Chromium instance see the gateway's memory grow continuously until it is restarted, with no workload that explains it. On hosts left running with browser tabs open, heap growth of roughly 90 MB/hour has been observed, reaching multi-gigabyte resident size within a day and eventually degrading or killing the gateway process.

The growth does not require anyone to be *using* the browser tools. A tab left open on a page that polls in the background is enough. Operators experience this as "the gateway leaks if the browser plugin is loaded," and the only workaround today is a scheduled restart.

## Why This Change Was Made

Playwright's connection-scoped object registry retains client objects and dispatcher pairs for every network request materialized by the plugin's page event listeners, and holds them for the lifetime of the `connectOverCDP` connection. Because the registry grows from browser *events* rather than from gateway operations, a check performed when a connection is acquired cannot bound it — hours can pass with no acquisition while the registry keeps growing. The connection lifetime itself is the thing that has to be bounded.

This change stamps each cached CDP connection with its creation time and runs a periodic sweep that recycles connections past a fixed 30-minute maximum age. Eviction reuses the existing stuck-operation recovery path: the Chromium instance and its tabs are untouched, and the next operation reconnects transparently.

Recycling is **lease-aware**, which is the substance of this revision. A sweep that closed connections unconditionally could disconnect an operation that was using one, and page creation and navigation are deliberately not replayable after an ambiguous disconnect — the existing test suite enforces exactly that. So operations now hold a lease for their duration, and an aged connection that still has leases is unpublished from the cache immediately (no new operation can join it; the next `connectBrowser()` opens a fresh one) and closed by whichever lease releases last. Leases are taken at all three acquisition sites: page creation, the safe-read reconnect wrapper, and page resolution by target id.

Two deliberate boundaries:

- **No new configuration surface.** An earlier revision read an `OPENCLAW_PW_CONNECTION_MAX_AGE_MS` environment override. The browser plugin exposes no configuration properties today and the environment reference does not document it, so rather than introduce an unsupported operator-visible switch, the policy is now a single fixed 30-minute constant. If a supported setting is wanted, that is a separate change against the plugin's configuration contract.
- **No changes to Playwright client internals.** This bounds connection lifetime rather than attempting per-request disposal inside the registry. If per-navigation or per-completion disposal of request channel objects is preferred, I'm glad to rework it that way.

The sweep is armed lazily when the first connection is cached and cleared when the cache empties, so importing this module never starts a timer on its own; the interval is `unref()`'d so it cannot hold a process open.

## User Impact

Operators can run a gateway with the browser plugin loaded indefinitely without scheduled restarts to reclaim memory. Retention is bounded to roughly one browsing window of requests rather than to the process lifetime.

Behavior visible to users is unchanged. Tabs are not closed, the Chromium instance is not restarted, and no browser action fails as a result of a recycle: an operation in flight when its connection ages out runs to completion on the connection it already holds, and subsequent operations transparently open a new one. The 30-minute default is long enough that interactive flows rarely cross it and, with leases, crossing it is no longer harmful when they do.

## Evidence

Three pieces, and they cover different claims — I've said which is which rather than implying one covers all of them.

**1. That the retention is real, and what it consists of** (heap snapshots, pre-fix, production gateway):

| Retained constructor | Count at 19h uptime |
|---|---|
| `_Request` | 11,072 |
| `ManualPromise` | 61,515 |
| dispatchers | 5,486 |

Growth measured at ~90 MB/h of retained objects; heap reached 2.3+ GiB within 20h on an unpatched gateway.

**2. That max-age recycling bounds it** (48h soak, 7 hosts, node 22, persistent Chromium, mixed interactive and scheduled browser workloads):

- heapUsed bounded below 0.9 GiB across workloads that previously reached 2.3+ GiB in 20h
- retained `_Request` 11,072 → 3
- recycles observed on schedule including during unattended overnight activity
- zero attributable browser-operation failures across recycle boundaries

**This soak ran the unconditional sweep, not the lease-aware one in this revision.** It is evidence that bounding connection age bounds the heap — the mechanism this revision keeps unchanged. It is not evidence about the lease, which is new here and did not exist when that data was collected. Claiming otherwise is what an earlier version of this PR description did, and the correction is the point of this section.

**3. That recycling cannot sever an in-flight operation** — proven by three added regression tests in `extensions/browser/src/browser/pw-session.connections.test.ts`, which run in CI and are the inspectable artifact for this claim:

- `does not sever an in-flight page creation when the connection ages out` — holds a page creation open across the max-age boundary, asserts the connection is **not** closed while the mutation is in flight, asserts the mutation still **succeeds**, then asserts the deferred recycle completes once the lease drains. This is the direct regression for the reported P1.
- `recycles an idle aged connection and reconnects the next read` — the positive control. Without it, the first test passing would be consistent with recycling never happening at all. Asserts the aged idle connection *is* closed, that the following read opens a new connection, and that it returns normally rather than surfacing the disconnect.
- `keeps a young connection cached across sweeps` — asserts the sweep does not churn connections below the age threshold.

Test surface: 0 → 3 tests covering the timer, the operation-ordering boundary, and the negative case.

**What I have not shown:** a production soak of the lease-aware revision. The lease changes only what happens at the recycle boundary while an operation is in flight, which is precisely the case the first regression test drives deterministically; a soak would be unlikely to reproduce it on demand. Happy to run one if you'd rather have it before merge.

## Testing Notes (added at submission)

Ran the full `extensions/browser` suite (`vitest.extension-browser.config.ts`, 192 files / 2626 tests) against this revision before pushing. All three new regression tests pass; the only failure in the run (`server-context.tab-selection-state.test.ts`, one test) reproduces identically on unmodified `main` and is unrelated to this change.

While validating the new tests against the full suite (they pass in isolation but two failed when run alongside the rest of the file), found and fixed a real test-isolation bug in the sweep's timer-handle lifecycle: the handle was only ever cleared from the sweep's own eviction path, so a cache emptied by any other path (test `afterEach` cleanup, an explicit connection retire) left a stale timer handle in place, which silently prevented the next consumer's sweep from arming under its own clock. Moved the idle-stop check into `takeCachedPlaywrightBrowserConnection`, the single choke point every cache-removal path already funnels through, so the sweep's lifecycle now tracks the cache's actual contents regardless of which path emptied it.
