### PR TITLE
fix: preserve staged chat attachments across remounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI staged attachments:** preserve unsent images, files, pasted images, and large pasted text across same-tab route and narrow split-pane remounts while keeping pane close, session or Gateway ownership changes, application shutdown, and hard reload as cleanup boundaries. Fixes #121519. Thanks @shakkernerd.
+- **Control UI staged attachments:** preserve unsent images, files, pasted images, and large pasted text across same-tab route and narrow split-pane remounts while keeping pane close, mismatched pane/session/Gateway remounts, application shutdown, and hard reload as cleanup boundaries. Fixes #121519. Thanks @shakkernerd.
 - **Control UI browser annotations:** keep marked screenshots and generated page context together in structured composer cards, preserve user-written drafts when annotations are removed or replaced, retain complete unsent annotation packages across same-tab route and active split-pane remounts, and offer bounded Undo without restoring removed context into another session. Fixes #120744. Thanks @shakkernerd.
 - **Control UI profile avatar refreshes:** carry canonical content revisions through mutation responses and live presence so rapid replacements refresh every connected browser without stale cache rollback. Thanks @shakkernerd.
 - **Control UI appearance accessibility:** keep the unavailable custom-theme card announced as an Import command while preserving selected-state semantics for selectable themes and text sizes. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI staged attachments:** preserve unsent images, files, pasted images, and large pasted text across same-tab route and narrow split-pane remounts while keeping pane close, session or Gateway ownership changes, application shutdown, and hard reload as cleanup boundaries. Fixes #121519. Thanks @shakkernerd.
 - **Control UI browser annotations:** keep marked screenshots and generated page context together in structured composer cards, preserve user-written drafts when annotations are removed or replaced, retain complete unsent annotation packages across same-tab route and active split-pane remounts, and offer bounded Undo without restoring removed context into another session. Fixes #120744. Thanks @shakkernerd.
 - **Control UI profile avatar refreshes:** carry canonical content revisions through mutation responses and live presence so rapid replacements refresh every connected browser without stale cache rollback. Thanks @shakkernerd.
 - **Control UI appearance accessibility:** keep the unavailable custom-theme card announced as an Import command while preserving selected-state semantics for selectable themes and text sizes. Thanks @shakkernerd.

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -426,7 +426,7 @@ Two capture modes package page context for the agent:
 
 One composer accepts up to four browser annotation cards and 8,000 total characters of generated annotation context. When it reaches either limit, the browser panel keeps the current capture so you can remove a card and retry; Undo also preserves the limit instead of evicting another card.
 
-Within the same Control UI tab, staged annotation cards stay with their pane and session across ordinary route changes and narrow split-pane remounts. Switching sessions keeps them scoped to the original session and restores them only when that session is revisited. A hard reload, pane close, Gateway-owner change, or application shutdown discards them; ordinary attachments keep their existing lifecycle.
+Within the same Control UI tab, staged images, files, pasted images, large pasted text, browser annotations, and mixed attachment packages stay with their pane and session across ordinary route changes and narrow split-pane remounts. Switching sessions keeps them scoped to the original session and restores them only when that session is revisited. A hard reload, pane close, Gateway-owner change, or application shutdown discards the staged package.
 
 The macOS app keeps its native link-browser sidebar for links clicked in the dashboard; the browser panel works there too, and is the way to annotate pages on every other platform.
 

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -25,8 +25,8 @@ import {
 } from "../pages/model-setup/first-run.ts";
 import { createAgentSelectionCapability } from "./agent-selection.ts";
 import { resolveApprovalDocumentMode, type ApprovalDocumentMode } from "./approval-deep-link.ts";
-import { createBrowserAnnotationHandoff } from "./browser-annotation-handoff.ts";
 import { createBrowserHistory, resolveControlUiBasePath } from "./browser.ts";
+import { createChatAttachmentHandoff } from "./chat-attachment-handoff.ts";
 import { createApplicationCloudStartup } from "./cloud-session-startup.ts";
 import { createApplicationConfigCapability } from "./config.ts";
 import type {
@@ -356,7 +356,7 @@ export function bootstrapApplication(
   const skillWorkshopRevision = createSkillWorkshopRevisionHandoff();
   const initialUserMessage = createInitialUserMessageHandoff();
   const cloudStartup = createApplicationCloudStartup({ gateway, sessions, initialUserMessage });
-  const browserAnnotationHandoff = createBrowserAnnotationHandoff();
+  const chatAttachmentHandoff = createChatAttachmentHandoff();
   applyThemePresentation(settings);
   const router = createApplicationRouter();
   // /terminal is served by the Gateway's SPA fallback but renders before the
@@ -463,7 +463,7 @@ export function bootstrapApplication(
     webPush,
     skillWorkshopRevision,
     initialUserMessage,
-    browserAnnotationHandoff,
+    chatAttachmentHandoff,
     navigate: (routeId, options) => {
       const location = routeLocation(routeId, options);
       if (!routerStarted) {
@@ -582,7 +582,7 @@ export function bootstrapApplication(
       webPush.dispose();
       skillWorkshopRevision.clear();
       initialUserMessage.clear();
-      browserAnnotationHandoff.dispose();
+      chatAttachmentHandoff.dispose();
     },
   };
 }

--- a/ui/src/app/chat-attachment-handoff.test.ts
+++ b/ui/src/app/chat-attachment-handoff.test.ts
@@ -8,7 +8,7 @@ import {
   registerChatAttachmentPayload,
   releaseChatAttachmentPayload,
 } from "../pages/chat/attachment-payload-store.ts";
-import { createBrowserAnnotationHandoff } from "./browser-annotation-handoff.ts";
+import { createChatAttachmentHandoff } from "./chat-attachment-handoff.ts";
 
 const registeredIds = new Set<string>();
 
@@ -43,8 +43,8 @@ afterEach(() => {
   registeredIds.clear();
 });
 
-describe("browser annotation route handoff", () => {
-  it("transfers exact annotation objects once without transferring ordinary attachments", () => {
+describe("chat attachment route handoff", () => {
+  it("transfers every exact staged attachment object once", () => {
     const owner = {} as GatewayBrowserClient;
     const annotation = storedAttachment("annotation", "image/png", true);
     const ordinary = [
@@ -52,17 +52,19 @@ describe("browser annotation route handoff", () => {
       storedAttachment("file", "application/pdf", false),
       storedAttachment("pasted-text", "text/plain", false),
     ];
-    const handoff = createBrowserAnnotationHandoff();
+    const staged = [ordinary[0]!, annotation, ordinary[1]!, ordinary[2]!];
+    const handoff = createChatAttachmentHandoff();
     handoff.prepare({
       owner,
       paneId: "p1",
       scopeKey: "agent:main:one",
-      attachments: [ordinary[0]!, annotation, ordinary[1]!, ordinary[2]!],
+      attachments: staged,
     });
 
     const consumed = handoff.consume({ owner, paneId: "p1", scopeKey: "agent:main:one" });
-    expect(consumed).toEqual([annotation]);
-    expect(consumed?.[0]).toBe(annotation);
+    expect(consumed).toEqual(staged);
+    expect(consumed).not.toBe(staged);
+    expect(consumed?.every((attachment, index) => attachment === staged[index])).toBe(true);
     expect(handoff.consume({ owner, paneId: "p1", scopeKey: "agent:main:one" })).toBeNull();
     for (const attachment of ordinary) {
       expect(getChatAttachmentDataUrl(attachment)).not.toBeNull();
@@ -75,7 +77,7 @@ describe("browser annotation route handoff", () => {
       { ownerMatches: true, scopeKey: "agent:main:two" },
     ];
     for (const { ownerMatches, scopeKey } of cases) {
-      const handoff = createBrowserAnnotationHandoff();
+      const handoff = createChatAttachmentHandoff();
       const expectedOwner = {} as GatewayBrowserClient;
       const annotation = storedAttachment(
         `mismatch-${ownerMatches}-${scopeKey}`,
@@ -102,12 +104,15 @@ describe("browser annotation route handoff", () => {
 
   it("bounds abandoned entries and releases pane-clear and application disposal", () => {
     const owner = {} as GatewayBrowserClient;
-    const handoff = createBrowserAnnotationHandoff();
+    const handoff = createChatAttachmentHandoff();
     const oversized = Array.from({ length: 33 }, (_, index) =>
-      storedAttachment(`oversized-${index}`, "image/png", true),
+      storedAttachment(`oversized-${index}`, "image/png", false),
     );
     handoff.prepare({ owner, paneId: "oversized", scopeKey: "oversized", attachments: oversized });
-    expect(getChatAttachmentDataUrl(oversized[32]!)).toBeNull();
+    expect(handoff.consume({ owner, paneId: "oversized", scopeKey: "oversized" })).toEqual(
+      oversized,
+    );
+    expect(getChatAttachmentDataUrl(oversized[32]!)).not.toBeNull();
 
     const annotations = Array.from({ length: 33 }, (_, index) =>
       storedAttachment(`bounded-${index}`, "image/png", true),
@@ -130,7 +135,7 @@ describe("browser annotation route handoff", () => {
   });
 
   it("releases a late prepare after application disposal instead of restaging it", () => {
-    const handoff = createBrowserAnnotationHandoff();
+    const handoff = createChatAttachmentHandoff();
     const annotation = storedAttachment("late", "image/png", true);
     handoff.dispose();
 

--- a/ui/src/app/chat-attachment-handoff.test.ts
+++ b/ui/src/app/chat-attachment-handoff.test.ts
@@ -106,6 +106,33 @@ describe("chat attachment route handoff", () => {
     }
   });
 
+  it("keeps payloads reused by a replacement prepare", () => {
+    const owner = {} as GatewayBrowserClient;
+    const retained = storedAttachment("replacement-retained", "image/png", false);
+    const removed = storedAttachment("replacement-removed", "image/png", false);
+    const handoff = createChatAttachmentHandoff();
+    handoff.prepare({
+      owner,
+      paneId: "p1",
+      scopeKey: "one",
+      attachments: [retained, removed],
+      fallbacks: {},
+    });
+    handoff.prepare({
+      owner,
+      paneId: "p1",
+      scopeKey: "one",
+      attachments: [retained],
+      fallbacks: {},
+    });
+
+    expect(getChatAttachmentDataUrl(retained)).not.toBeNull();
+    expect(getChatAttachmentDataUrl(removed)).toBeNull();
+    expect(handoff.consume({ owner, paneId: "p1", scopeKey: "one" })?.attachments).toEqual([
+      retained,
+    ]);
+  });
+
   it("bounds abandoned entries and releases pane-clear and application disposal", () => {
     const owner = {} as GatewayBrowserClient;
     const handoff = createChatAttachmentHandoff();

--- a/ui/src/app/chat-attachment-handoff.test.ts
+++ b/ui/src/app/chat-attachment-handoff.test.ts
@@ -59,12 +59,15 @@ describe("chat attachment route handoff", () => {
       paneId: "p1",
       scopeKey: "agent:main:one",
       attachments: staged,
+      fallbacks: {},
     });
 
     const consumed = handoff.consume({ owner, paneId: "p1", scopeKey: "agent:main:one" });
-    expect(consumed).toEqual(staged);
-    expect(consumed).not.toBe(staged);
-    expect(consumed?.every((attachment, index) => attachment === staged[index])).toBe(true);
+    expect(consumed?.attachments).toEqual(staged);
+    expect(consumed?.attachments).not.toBe(staged);
+    expect(consumed?.attachments.every((attachment, index) => attachment === staged[index])).toBe(
+      true,
+    );
     expect(handoff.consume({ owner, paneId: "p1", scopeKey: "agent:main:one" })).toBeNull();
     for (const attachment of ordinary) {
       expect(getChatAttachmentDataUrl(attachment)).not.toBeNull();
@@ -89,6 +92,7 @@ describe("chat attachment route handoff", () => {
         paneId: "p1",
         scopeKey: "agent:main:one",
         attachments: [annotation],
+        fallbacks: {},
       });
 
       expect(
@@ -108,10 +112,16 @@ describe("chat attachment route handoff", () => {
     const oversized = Array.from({ length: 33 }, (_, index) =>
       storedAttachment(`oversized-${index}`, "image/png", false),
     );
-    handoff.prepare({ owner, paneId: "oversized", scopeKey: "oversized", attachments: oversized });
-    expect(handoff.consume({ owner, paneId: "oversized", scopeKey: "oversized" })).toEqual(
-      oversized,
-    );
+    handoff.prepare({
+      owner,
+      paneId: "oversized",
+      scopeKey: "oversized",
+      attachments: oversized,
+      fallbacks: {},
+    });
+    expect(
+      handoff.consume({ owner, paneId: "oversized", scopeKey: "oversized" })?.attachments,
+    ).toEqual(oversized);
     expect(getChatAttachmentDataUrl(oversized[32]!)).not.toBeNull();
 
     const annotations = Array.from({ length: 33 }, (_, index) =>
@@ -123,6 +133,7 @@ describe("chat attachment route handoff", () => {
         paneId: `p${index}`,
         scopeKey: `scope-${index}`,
         attachments: [annotation],
+        fallbacks: {},
       }),
     );
 
@@ -144,6 +155,7 @@ describe("chat attachment route handoff", () => {
       paneId: "p1",
       scopeKey: "agent:main:one",
       attachments: [annotation],
+      fallbacks: {},
     });
 
     expect(getChatAttachmentDataUrl(annotation)).toBeNull();

--- a/ui/src/app/chat-attachment-handoff.ts
+++ b/ui/src/app/chat-attachment-handoff.ts
@@ -1,4 +1,4 @@
-import type { ChatAttachment } from "../lib/chat/chat-types.ts";
+import type { ChatAttachment, ChatComposerMemoryFallback } from "../lib/chat/chat-types.ts";
 import { releaseChatAttachmentPayloads } from "../pages/chat/attachment-payload-store.ts";
 import type { ApplicationChatAttachmentHandoff } from "./context.ts";
 
@@ -10,6 +10,7 @@ type PendingChatAttachmentHandoff = {
   owner: NonNullable<Parameters<ApplicationChatAttachmentHandoff["prepare"]>[0]["owner"]>;
   scopeKey: string;
   attachments: ChatAttachment[];
+  fallbacks: Record<string, ChatComposerMemoryFallback>;
 };
 
 export function createChatAttachmentHandoff(): ApplicationChatAttachmentHandoff {
@@ -18,6 +19,18 @@ export function createChatAttachmentHandoff(): ApplicationChatAttachmentHandoff 
 
   const release = (attachments: readonly ChatAttachment[] = []) =>
     releaseChatAttachmentPayloads(attachments);
+  const releaseHandoff = (handoff: PendingChatAttachmentHandoff | undefined) => {
+    if (!handoff) {
+      return;
+    }
+    const byId = new Map(handoff.attachments.map((attachment) => [attachment.id, attachment]));
+    for (const fallback of Object.values(handoff.fallbacks)) {
+      for (const attachment of fallback.attachments) {
+        byId.set(attachment.id, attachment);
+      }
+    }
+    release([...byId.values()]);
+  };
   const take = (paneId: string) => {
     const handoff = pending.get(paneId);
     if (handoff) {
@@ -27,26 +40,39 @@ export function createChatAttachmentHandoff(): ApplicationChatAttachmentHandoff 
   };
 
   return {
-    prepare: ({ owner, paneId, scopeKey, attachments }) => {
+    prepare: ({ owner, paneId, scopeKey, attachments, fallbacks }) => {
       const previous = take(paneId);
-      if (attachments.length === 0) {
-        release(previous?.attachments);
+      const fallbackEntries = Object.entries(fallbacks);
+      if (attachments.length === 0 && fallbackEntries.length === 0) {
+        releaseHandoff(previous);
         return;
       }
-      const retainedIds = new Set(attachments.map((attachment) => attachment.id));
-      release(previous?.attachments.filter((attachment) => !retainedIds.has(attachment.id)));
+      releaseHandoff(previous);
       if (!owner || disposed) {
         release(attachments);
+        for (const fallback of Object.values(fallbacks)) {
+          release(fallback.attachments);
+        }
         return;
       }
-      pending.set(paneId, { owner, scopeKey, attachments: [...attachments] });
+      pending.set(paneId, {
+        owner,
+        scopeKey,
+        attachments: [...attachments],
+        fallbacks: Object.fromEntries(
+          fallbackEntries.map(([key, fallback]) => [
+            key,
+            { ...fallback, attachments: [...fallback.attachments] },
+          ]),
+        ),
+      });
       // Route handoffs normally consume immediately. Bounds make abandoned
       // split panes release their packages instead of leaking for the tab lifetime.
       for (const oldestPaneId of pending.keys()) {
         if (pending.size <= MAX_PENDING_CHAT_ATTACHMENT_ENTRIES) {
           break;
         }
-        release(take(oldestPaneId)?.attachments);
+        releaseHandoff(take(oldestPaneId));
       }
     },
     consume: ({ owner, paneId, scopeKey }) => {
@@ -54,16 +80,16 @@ export function createChatAttachmentHandoff(): ApplicationChatAttachmentHandoff 
       // Reusing a pane id with another session or Gateway is terminal for the
       // old owner; keeping it would allow a later remount to recover stale evidence.
       if (match?.owner === owner && match.scopeKey === scopeKey) {
-        return match.attachments;
+        return { attachments: match.attachments, fallbacks: match.fallbacks };
       }
-      release(match?.attachments);
+      releaseHandoff(match);
       return null;
     },
-    clearPane: (paneId) => release(take(paneId)?.attachments),
+    clearPane: (paneId) => releaseHandoff(take(paneId)),
     dispose: () => {
       disposed = true;
       for (const handoff of pending.values()) {
-        release(handoff.attachments);
+        releaseHandoff(handoff);
       }
       pending.clear();
     },

--- a/ui/src/app/chat-attachment-handoff.ts
+++ b/ui/src/app/chat-attachment-handoff.ts
@@ -19,17 +19,23 @@ export function createChatAttachmentHandoff(): ApplicationChatAttachmentHandoff 
 
   const release = (attachments: readonly ChatAttachment[] = []) =>
     releaseChatAttachmentPayloads(attachments);
-  const releaseHandoff = (handoff: PendingChatAttachmentHandoff | undefined) => {
-    if (!handoff) {
-      return;
-    }
+  const handoffAttachments = (handoff: PendingChatAttachmentHandoff) => {
     const byId = new Map(handoff.attachments.map((attachment) => [attachment.id, attachment]));
     for (const fallback of Object.values(handoff.fallbacks)) {
       for (const attachment of fallback.attachments) {
         byId.set(attachment.id, attachment);
       }
     }
-    release([...byId.values()]);
+    return [...byId.values()];
+  };
+  const releaseHandoff = (
+    handoff: PendingChatAttachmentHandoff | undefined,
+    retainedIds = new Set<string>(),
+  ) => {
+    if (!handoff) {
+      return;
+    }
+    release(handoffAttachments(handoff).filter((attachment) => !retainedIds.has(attachment.id)));
   };
   const take = (paneId: string) => {
     const handoff = pending.get(paneId);
@@ -47,7 +53,13 @@ export function createChatAttachmentHandoff(): ApplicationChatAttachmentHandoff 
         releaseHandoff(previous);
         return;
       }
-      releaseHandoff(previous);
+      const retainedIds = new Set(attachments.map((attachment) => attachment.id));
+      for (const fallback of Object.values(fallbacks)) {
+        for (const attachment of fallback.attachments) {
+          retainedIds.add(attachment.id);
+        }
+      }
+      releaseHandoff(previous, retainedIds);
       if (!owner || disposed) {
         release(attachments);
         for (const fallback of Object.values(fallbacks)) {

--- a/ui/src/app/chat-attachment-handoff.ts
+++ b/ui/src/app/chat-attachment-handoff.ts
@@ -1,64 +1,49 @@
 import type { ChatAttachment } from "../lib/chat/chat-types.ts";
-import { releaseChatAttachmentPayload } from "../pages/chat/attachment-payload-store.ts";
-import type { ApplicationBrowserAnnotationHandoff } from "./context.ts";
+import { releaseChatAttachmentPayloads } from "../pages/chat/attachment-payload-store.ts";
+import type { ApplicationChatAttachmentHandoff } from "./context.ts";
 
-const MAX_PENDING_BROWSER_ANNOTATION_ENTRIES = 32;
-const MAX_PENDING_BROWSER_ANNOTATIONS = 32;
+const MAX_PENDING_CHAT_ATTACHMENT_ENTRIES = 32;
 // Hidden split panes can remain unmounted indefinitely, so wall-clock expiry
 // would lose valid drafts. Bounded oldest-first eviction owns abandoned cleanup.
 
-type PendingBrowserAnnotationHandoff = {
-  owner: NonNullable<Parameters<ApplicationBrowserAnnotationHandoff["prepare"]>[0]["owner"]>;
+type PendingChatAttachmentHandoff = {
+  owner: NonNullable<Parameters<ApplicationChatAttachmentHandoff["prepare"]>[0]["owner"]>;
   scopeKey: string;
   attachments: ChatAttachment[];
 };
 
-function browserAnnotations(attachments: readonly ChatAttachment[]): ChatAttachment[] {
-  return attachments.filter((attachment) => attachment.browserAnnotation !== undefined);
-}
-
-export function createBrowserAnnotationHandoff(): ApplicationBrowserAnnotationHandoff {
-  const pending = new Map<string, PendingBrowserAnnotationHandoff>();
-  let annotationCount = 0;
+export function createChatAttachmentHandoff(): ApplicationChatAttachmentHandoff {
+  const pending = new Map<string, PendingChatAttachmentHandoff>();
   let disposed = false;
 
-  const release = (attachments: readonly ChatAttachment[] = []) => {
-    for (const attachment of attachments) {
-      releaseChatAttachmentPayload(attachment.id);
-    }
-  };
+  const release = (attachments: readonly ChatAttachment[] = []) =>
+    releaseChatAttachmentPayloads(attachments);
   const take = (paneId: string) => {
     const handoff = pending.get(paneId);
     if (handoff) {
       pending.delete(paneId);
-      annotationCount -= handoff.attachments.length;
     }
     return handoff;
   };
 
   return {
     prepare: ({ owner, paneId, scopeKey, attachments }) => {
-      const annotations = browserAnnotations(attachments);
       const previous = take(paneId);
-      if (annotations.length === 0) {
+      if (attachments.length === 0) {
         release(previous?.attachments);
         return;
       }
-      const retainedIds = new Set(annotations.map((attachment) => attachment.id));
+      const retainedIds = new Set(attachments.map((attachment) => attachment.id));
       release(previous?.attachments.filter((attachment) => !retainedIds.has(attachment.id)));
       if (!owner || disposed) {
-        release(annotations);
+        release(attachments);
         return;
       }
-      pending.set(paneId, { owner, scopeKey, attachments: annotations });
-      annotationCount += annotations.length;
+      pending.set(paneId, { owner, scopeKey, attachments: [...attachments] });
       // Route handoffs normally consume immediately. Bounds make abandoned
-      // split panes release their payload owners instead of leaking for the tab lifetime.
+      // split panes release their packages instead of leaking for the tab lifetime.
       for (const oldestPaneId of pending.keys()) {
-        if (
-          pending.size <= MAX_PENDING_BROWSER_ANNOTATION_ENTRIES &&
-          annotationCount <= MAX_PENDING_BROWSER_ANNOTATIONS
-        ) {
+        if (pending.size <= MAX_PENDING_CHAT_ATTACHMENT_ENTRIES) {
           break;
         }
         release(take(oldestPaneId)?.attachments);
@@ -81,7 +66,6 @@ export function createBrowserAnnotationHandoff(): ApplicationBrowserAnnotationHa
         release(handoff.attachments);
       }
       pending.clear();
-      annotationCount = 0;
     },
   };
 }

--- a/ui/src/app/context.ts
+++ b/ui/src/app/context.ts
@@ -4,7 +4,7 @@ import type { RouteId } from "../app-route-paths.ts";
 import type { AgentIdentityCapability } from "../lib/agents/identity.ts";
 import type { AgentCapability } from "../lib/agents/index.ts";
 import type { ChannelCapability } from "../lib/channels/index.ts";
-import type { ChatAttachment } from "../lib/chat/chat-types.ts";
+import type { ChatAttachment, ChatComposerMemoryFallback } from "../lib/chat/chat-types.ts";
 import type { RuntimeConfigCapability } from "../lib/config/index.ts";
 import type { SessionCapability } from "../lib/sessions/index.ts";
 import type { WorkboardCapability } from "../lib/workboard/capability.ts";
@@ -80,8 +80,16 @@ type ChatAttachmentHandoffKey = {
 };
 
 export type ApplicationChatAttachmentHandoff = {
-  prepare(handoff: ChatAttachmentHandoffKey & { attachments: readonly ChatAttachment[] }): void;
-  consume(handoff: ChatAttachmentHandoffKey): ChatAttachment[] | null;
+  prepare(
+    handoff: ChatAttachmentHandoffKey & {
+      attachments: readonly ChatAttachment[];
+      fallbacks: Readonly<Record<string, ChatComposerMemoryFallback>>;
+    },
+  ): void;
+  consume(handoff: ChatAttachmentHandoffKey): {
+    attachments: ChatAttachment[];
+    fallbacks: Record<string, ChatComposerMemoryFallback>;
+  } | null;
   clearPane(paneId: string): void;
   dispose(): void;
 };

--- a/ui/src/app/context.ts
+++ b/ui/src/app/context.ts
@@ -73,15 +73,15 @@ export type ApplicationSkillWorkshopRevisionHandoff = {
   clear: (handoff?: SkillWorkshopRevisionHandoff) => void;
 };
 
-type BrowserAnnotationHandoffKey = {
+type ChatAttachmentHandoffKey = {
   owner: ApplicationGateway["snapshot"]["client"];
   paneId: string;
   scopeKey: string;
 };
 
-export type ApplicationBrowserAnnotationHandoff = {
-  prepare(handoff: BrowserAnnotationHandoffKey & { attachments: readonly ChatAttachment[] }): void;
-  consume(handoff: BrowserAnnotationHandoffKey): ChatAttachment[] | null;
+export type ApplicationChatAttachmentHandoff = {
+  prepare(handoff: ChatAttachmentHandoffKey & { attachments: readonly ChatAttachment[] }): void;
+  consume(handoff: ChatAttachmentHandoffKey): ChatAttachment[] | null;
   clearPane(paneId: string): void;
   dispose(): void;
 };
@@ -106,7 +106,7 @@ export type ApplicationContext<TRouteId extends string = string> = {
   readonly webPush: WebPushCapability;
   readonly skillWorkshopRevision: ApplicationSkillWorkshopRevisionHandoff;
   readonly initialUserMessage: ApplicationInitialUserMessageHandoff;
-  readonly browserAnnotationHandoff: ApplicationBrowserAnnotationHandoff;
+  readonly chatAttachmentHandoff: ApplicationChatAttachmentHandoff;
   readonly navigate: (routeId: TRouteId, options?: ApplicationNavigationOptions) => void;
   readonly replace: (routeId: TRouteId, options?: ApplicationNavigationOptions) => void;
   readonly revalidate: (routeId?: TRouteId) => Promise<void>;

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -24,6 +24,19 @@ export type ChatAttachment = {
   browserAnnotation?: BrowserAnnotationAttachment;
 };
 
+export type ChatComposerDraftRetry = {
+  expectedDraftRevision: number;
+  draftRevision: number;
+};
+
+export type ChatComposerMemoryFallback = {
+  message: string;
+  attachments: ChatAttachment[];
+  storageFailed: boolean;
+  draftRetry?: ChatComposerDraftRetry;
+  sequence: number;
+};
+
 export type ChatQueueSkillWorkshopRevision = {
   proposalId: string;
   agentId?: string;

--- a/ui/src/pages/chat/chat-page-attachment-handoff.test.ts
+++ b/ui/src/pages/chat/chat-page-attachment-handoff.test.ts
@@ -1,0 +1,118 @@
+/* @vitest-environment jsdom */
+/* @vitest-environment-options {"url":"http://chat-page-attachment-handoff.test/"} */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./chat-pane.ts", () => ({}));
+vi.mock("../../app/native-gateways.runtime.ts", () => ({
+  nativeGatewaysCapability: () => null,
+}));
+
+import type { ApplicationContext } from "../../app/context.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { ChatPage } from "./chat-page.ts";
+import { insertPane, type ChatSplitLayout } from "./split-layout.ts";
+
+type RenderedPane = HTMLElement & {
+  paneId: string;
+  sessionKey: string;
+  onClosePane?: (paneId: string) => void;
+  discardStagedAttachments?: () => void;
+  resumeStagedAttachments?: () => void;
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function splitLayout(sessionKey: string): ChatSplitLayout {
+  const layout: ChatSplitLayout = {
+    columns: [{ id: "c1", panes: [{ id: "p1", sessionKey }], paneWeights: [1] }],
+    columnWeights: [1],
+    activePaneId: "p1",
+  };
+  return insertPane(layout, "p1", sessionKey, "right");
+}
+
+function configure(page: ChatPage) {
+  const context = {
+    sessions: { state: { result: null }, subscribe: () => () => undefined, patch: vi.fn() },
+    agents: { state: { agentsList: { defaultId: "main", mainKey: "main" } } },
+    gateway: { snapshot: { hello: null } },
+    navigate: vi.fn(),
+    replace: vi.fn(),
+    agentSelection: { state: { selectedId: "main" }, set: vi.fn() },
+    chatAttachmentHandoff: {
+      prepare: vi.fn(),
+      consume: vi.fn(() => null),
+      clearPane: vi.fn(),
+      dispose: vi.fn(),
+    },
+  } as unknown as ApplicationContext;
+  (page as unknown as { context: ApplicationContext }).context = context;
+  page.data = { sessionKey: "main" };
+}
+
+describe("chat page staged attachment rebound", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    );
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.unstubAllGlobals();
+  });
+
+  it("reactivates a closed pane when delayed MCP teardown rebounds to the same owner", async () => {
+    const page = new ChatPage();
+    configure(page);
+    document.body.append(page);
+    (page as unknown as { layout: ChatSplitLayout }).layout = splitLayout("main");
+    page.requestUpdate();
+    await page.updateComplete;
+
+    const closingPane = page.querySelectorAll<RenderedPane>("openclaw-chat-pane")[1]!;
+    const discard = vi.fn();
+    const resume = vi.fn();
+    closingPane.discardStagedAttachments = discard;
+    closingPane.resumeStagedAttachments = resume;
+    const teardown = deferred<void>();
+    const mcpApp = document.createElement("mcp-app-view");
+    const restartAfterTeardown = vi.fn();
+    mcpApp.restartAfterTeardown = restartAfterTeardown;
+    mcpApp.teardown = vi.fn(() => teardown.promise);
+    closingPane.append(mcpApp);
+
+    closingPane.onClosePane?.(closingPane.paneId);
+    await page.updateComplete;
+    expect(discard).toHaveBeenCalledOnce();
+    expect(closingPane.isConnected).toBe(true);
+
+    (page as unknown as { layout: ChatSplitLayout }).layout = splitLayout("main");
+    page.requestUpdate();
+    await page.updateComplete;
+    expect(resume).toHaveBeenCalled();
+
+    teardown.resolve();
+    await expect.poll(() => restartAfterTeardown).toHaveBeenCalledOnce();
+    expect(page.querySelectorAll<RenderedPane>("openclaw-chat-pane")[1]).toBe(closingPane);
+  });
+});

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -141,7 +141,7 @@ function setNavigationContext(page: ChatPage) {
   const setAgent = vi.fn((agentId: string) => {
     agentSelectionState.selectedId = agentId;
   });
-  const browserAnnotationHandoff = {
+  const chatAttachmentHandoff = {
     prepare: vi.fn(),
     consume: vi.fn(() => null),
     clearPane: vi.fn(),
@@ -155,10 +155,10 @@ function setNavigationContext(page: ChatPage) {
     navigate,
     replace,
     agentSelection: { state: agentSelectionState, set: setAgent },
-    browserAnnotationHandoff,
+    chatAttachmentHandoff,
   } as unknown as ApplicationContext;
   (page as unknown as { context: ApplicationContext }).context = context;
-  return { browserAnnotationHandoff, context, navigate, replace, setAgent, patch };
+  return { chatAttachmentHandoff, context, navigate, replace, setAgent, patch };
 }
 
 function setViewerPresenceContext(page: ChatPage) {

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -411,12 +411,11 @@ describe("chat page split layout host", () => {
     closingPane.discardStagedAttachments = discard;
     closingPane.resumeStagedAttachments = resume;
     const teardown = deferred<void>();
-    const mcpApp = document.createElement("mcp-app-view") as HTMLElement & {
-      restartAfterTeardown: ReturnType<typeof vi.fn>;
-      teardown: ReturnType<typeof vi.fn>;
-    };
-    mcpApp.restartAfterTeardown = vi.fn();
-    mcpApp.teardown = vi.fn(() => teardown.promise);
+    const mcpApp = document.createElement("mcp-app-view");
+    const restartAfterTeardown = vi.fn();
+    const teardownMcpApp = vi.fn(() => teardown.promise);
+    mcpApp.restartAfterTeardown = restartAfterTeardown;
+    mcpApp.teardown = teardownMcpApp;
     closingPane.append(mcpApp);
 
     closingPane.onClosePane?.(closingPane.paneId);
@@ -430,7 +429,7 @@ describe("chat page split layout host", () => {
     expect(resume).toHaveBeenCalled();
 
     teardown.resolve();
-    await expect.poll(() => mcpApp.restartAfterTeardown).toHaveBeenCalledOnce();
+    await expect.poll(() => restartAfterTeardown).toHaveBeenCalledOnce();
     expect(
       itemAt(page.querySelectorAll<RenderedPane>("openclaw-chat-pane"), 1, "reopened pane"),
     ).toBe(closingPane);

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -62,6 +62,8 @@ type RenderedPane = HTMLElement & {
   gatewaysSnapshot: NativeGatewaysSnapshot | null;
   onOpenSplitView?: () => void;
   onClosePane?: (paneId: string) => void;
+  discardStagedAttachments?: () => void;
+  resumeStagedAttachments?: () => void;
   onFaceChange?: (face: "chat" | "dashboard") => void;
 };
 
@@ -392,6 +394,46 @@ describe("chat page split layout host", () => {
     );
     expect(survivingPane).toBe(classicPane);
     expect(survivingPane.classList.contains("chat-split-view__pane")).toBe(false);
+  });
+
+  it("reactivates a closed pane when delayed MCP teardown rebounds to the same owner", async () => {
+    const page = new ChatPage();
+    setNavigationContext(page);
+    page.data = { sessionKey: "main" };
+    document.body.append(page);
+    setLayout(page, createSplitLayout("main"));
+    await page.updateComplete;
+
+    const panes = [...page.querySelectorAll<RenderedPane>("openclaw-chat-pane")];
+    const closingPane = itemAt(panes, 1, "closing pane");
+    const discard = vi.fn();
+    const resume = vi.fn();
+    closingPane.discardStagedAttachments = discard;
+    closingPane.resumeStagedAttachments = resume;
+    const teardown = deferred<void>();
+    const mcpApp = document.createElement("mcp-app-view") as HTMLElement & {
+      restartAfterTeardown: ReturnType<typeof vi.fn>;
+      teardown: ReturnType<typeof vi.fn>;
+    };
+    mcpApp.restartAfterTeardown = vi.fn();
+    mcpApp.teardown = vi.fn(() => teardown.promise);
+    closingPane.append(mcpApp);
+
+    closingPane.onClosePane?.(closingPane.paneId);
+    await page.updateComplete;
+    expect(discard).toHaveBeenCalledOnce();
+    expect(closingPane.isConnected).toBe(true);
+
+    setLayout(page, createSplitLayout("main"));
+    page.requestUpdate();
+    await page.updateComplete;
+    expect(resume).toHaveBeenCalled();
+
+    teardown.resolve();
+    await expect.poll(() => mcpApp.restartAfterTeardown).toHaveBeenCalledOnce();
+    expect(
+      itemAt(page.querySelectorAll<RenderedPane>("openclaw-chat-pane"), 1, "reopened pane"),
+    ).toBe(closingPane);
   });
 
   it("applies mounted UI split, focus, and close commands", () => {

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -62,8 +62,6 @@ type RenderedPane = HTMLElement & {
   gatewaysSnapshot: NativeGatewaysSnapshot | null;
   onOpenSplitView?: () => void;
   onClosePane?: (paneId: string) => void;
-  discardStagedAttachments?: () => void;
-  resumeStagedAttachments?: () => void;
   onFaceChange?: (face: "chat" | "dashboard") => void;
 };
 
@@ -394,45 +392,6 @@ describe("chat page split layout host", () => {
     );
     expect(survivingPane).toBe(classicPane);
     expect(survivingPane.classList.contains("chat-split-view__pane")).toBe(false);
-  });
-
-  it("reactivates a closed pane when delayed MCP teardown rebounds to the same owner", async () => {
-    const page = new ChatPage();
-    setNavigationContext(page);
-    page.data = { sessionKey: "main" };
-    document.body.append(page);
-    setLayout(page, createSplitLayout("main"));
-    await page.updateComplete;
-
-    const panes = [...page.querySelectorAll<RenderedPane>("openclaw-chat-pane")];
-    const closingPane = itemAt(panes, 1, "closing pane");
-    const discard = vi.fn();
-    const resume = vi.fn();
-    closingPane.discardStagedAttachments = discard;
-    closingPane.resumeStagedAttachments = resume;
-    const teardown = deferred<void>();
-    const mcpApp = document.createElement("mcp-app-view");
-    const restartAfterTeardown = vi.fn();
-    const teardownMcpApp = vi.fn(() => teardown.promise);
-    mcpApp.restartAfterTeardown = restartAfterTeardown;
-    mcpApp.teardown = teardownMcpApp;
-    closingPane.append(mcpApp);
-
-    closingPane.onClosePane?.(closingPane.paneId);
-    await page.updateComplete;
-    expect(discard).toHaveBeenCalledOnce();
-    expect(closingPane.isConnected).toBe(true);
-
-    setLayout(page, createSplitLayout("main"));
-    page.requestUpdate();
-    await page.updateComplete;
-    expect(resume).toHaveBeenCalled();
-
-    teardown.resolve();
-    await expect.poll(() => restartAfterTeardown).toHaveBeenCalledOnce();
-    expect(
-      itemAt(page.querySelectorAll<RenderedPane>("openclaw-chat-pane"), 1, "reopened pane"),
-    ).toBe(closingPane);
   });
 
   it("applies mounted UI split, focus, and close commands", () => {

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -20,10 +20,7 @@ import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { persistSessionBoardFace } from "./chat-board-face-persistence.ts";
 import { stillOwnsCanonicalLocation } from "./chat-canonical-location.ts";
-import {
-  closePaneStagedAttachments,
-  resumeVisiblePaneStagedAttachments,
-} from "./chat-pane-attachment-handoff.ts";
+import { closeStagedPane, resumeStagedPanes } from "./chat-pane-attachment-handoff.ts";
 import { ChatViewerPresenceController } from "./chat-viewer-presence.ts";
 import "../../styles/chat.css";
 import "./chat-pane.ts";
@@ -128,7 +125,7 @@ export class ChatPage extends OpenClawLightDomElement {
 
   override updated(changedProperties: Map<PropertyKey, unknown>) {
     const layout = this.layout ?? this.classicLayout();
-    resumeVisiblePaneStagedAttachments(this, layout, this.narrow);
+    resumeStagedPanes(this, layout, this.narrow);
     if (this.isConnected) {
       this.viewerPresence.sync(this.context?.gateway, layout, this.narrow);
     }
@@ -226,7 +223,7 @@ export class ChatPage extends OpenClawLightDomElement {
         : undefined;
     const survivingPane =
       command.kind === "close-pane" && targetPane
-        ? closePaneStagedAttachments(this.context, this, layout, targetPane.id)
+        ? closeStagedPane(this.context, this, layout, targetPane.id)
         : undefined;
     const next = applyUiCommandToSplitLayout(layout, command, sourceSessionKey);
     if (next === layout) {
@@ -523,7 +520,7 @@ export class ChatPage extends OpenClawLightDomElement {
     if (!layout) {
       return;
     }
-    const survivingPane = closePaneStagedAttachments(this.context, this, layout, paneId);
+    const survivingPane = closeStagedPane(this.context, this, layout, paneId);
     const next = closePane(layout, paneId);
     if (!next && survivingPane) {
       const survivingLocation = findPane(layout, survivingPane.id);

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -20,7 +20,10 @@ import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { persistSessionBoardFace } from "./chat-board-face-persistence.ts";
 import { stillOwnsCanonicalLocation } from "./chat-canonical-location.ts";
-import { closePaneStagedAttachments } from "./chat-pane-attachment-handoff.ts";
+import {
+  closePaneStagedAttachments,
+  resumeVisiblePaneStagedAttachments,
+} from "./chat-pane-attachment-handoff.ts";
 import { ChatViewerPresenceController } from "./chat-viewer-presence.ts";
 import "../../styles/chat.css";
 import "./chat-pane.ts";
@@ -125,6 +128,7 @@ export class ChatPage extends OpenClawLightDomElement {
 
   override updated(changedProperties: Map<PropertyKey, unknown>) {
     const layout = this.layout ?? this.classicLayout();
+    resumeVisiblePaneStagedAttachments(this, layout, this.narrow);
     if (this.isConnected) {
       this.viewerPresence.sync(this.context?.gateway, layout, this.narrow);
     }

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -20,7 +20,7 @@ import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { persistSessionBoardFace } from "./chat-board-face-persistence.ts";
 import { stillOwnsCanonicalLocation } from "./chat-canonical-location.ts";
-import { closePaneBrowserAnnotations } from "./chat-pane-browser-annotation.ts";
+import { closePaneStagedAttachments } from "./chat-pane-attachment-handoff.ts";
 import { ChatViewerPresenceController } from "./chat-viewer-presence.ts";
 import "../../styles/chat.css";
 import "./chat-pane.ts";
@@ -222,7 +222,7 @@ export class ChatPage extends OpenClawLightDomElement {
         : undefined;
     const survivingPane =
       command.kind === "close-pane" && targetPane
-        ? closePaneBrowserAnnotations(this.context, this, layout, targetPane.id)
+        ? closePaneStagedAttachments(this.context, this, layout, targetPane.id)
         : undefined;
     const next = applyUiCommandToSplitLayout(layout, command, sourceSessionKey);
     if (next === layout) {
@@ -519,7 +519,7 @@ export class ChatPage extends OpenClawLightDomElement {
     if (!layout) {
       return;
     }
-    const survivingPane = closePaneBrowserAnnotations(this.context, this, layout, paneId);
+    const survivingPane = closePaneStagedAttachments(this.context, this, layout, paneId);
     const next = closePane(layout, paneId);
     if (!next && survivingPane) {
       const survivingLocation = findPane(layout, survivingPane.id);

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
@@ -5,6 +5,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { createChatAttachmentHandoff } from "../../app/chat-attachment-handoff.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
+import type { SessionCapability } from "../../lib/sessions/index.ts";
 import {
   getChatAttachmentDataUrl,
   registerChatAttachmentPayload,
@@ -15,7 +16,9 @@ import {
   preparePaneStagedAttachments,
   restorePaneStagedAttachments,
 } from "./chat-pane-attachment-handoff.ts";
+import { createTestChatPane } from "./chat-pane.test-support.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
+import { resolveStoredChatOutboxScope, storedChatOutboxScopeKey } from "./composer-persistence.ts";
 import type { ChatSplitLayout } from "./split-layout.ts";
 
 function storedAttachment(id: string, mimeType = "image/png"): ChatAttachment {
@@ -66,6 +69,54 @@ describe("staged chat attachment pane handoff", () => {
 
     expect(closePaneStagedAttachments(context, root, layout, "p1")?.id).toBe("p2");
     expect(calls).toEqual(["discard", "clear"]);
+  });
+
+  it("does not restage a closed pane when its id is reused after disconnect", () => {
+    const owner = {} as GatewayBrowserClient;
+    const { pane, state: current } = createTestChatPane({
+      client: owner,
+      sessions: {} as SessionCapability,
+    });
+    pane.paneId = "p2";
+    const fallback = storedAttachment("closed-fallback");
+    current.chatComposerFallbackByScope = {
+      fallback: {
+        attachments: [fallback],
+        message: "closed pane draft",
+        sequence: 1,
+        storageFailed: false,
+      },
+    };
+    const root = { querySelectorAll: () => [pane] } as unknown as ParentNode;
+    const layout = {
+      columns: [
+        {
+          id: "c1",
+          panes: [
+            { id: "p1", sessionKey: "one" },
+            { id: "p2", sessionKey: current.sessionKey },
+          ],
+          paneWeights: [1, 1],
+        },
+      ],
+      columnWeights: [1],
+      activePaneId: "p2",
+    } satisfies ChatSplitLayout;
+    const scopeKey = storedChatOutboxScopeKey(
+      resolveStoredChatOutboxScope(current, current.sessionKey),
+    );
+
+    closePaneStagedAttachments(pane.context, root, layout, pane.paneId);
+    pane.disconnectedCallback();
+
+    expect(getChatAttachmentDataUrl(fallback)).toBeNull();
+    expect(
+      pane.context.chatAttachmentHandoff.consume({
+        owner,
+        paneId: "p2",
+        scopeKey,
+      }),
+    ).toBeNull();
   });
 
   it("deduplicates current and fallback payload release", () => {

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
@@ -107,9 +107,12 @@ describe("staged chat attachment pane handoff", () => {
     );
 
     closePaneStagedAttachments(pane.context, root, layout, pane.paneId);
+    const lateAttachment = storedAttachment("late-close-completion");
+    current.chatAttachments.push(lateAttachment);
     pane.disconnectedCallback();
 
     expect(getChatAttachmentDataUrl(fallback)).toBeNull();
+    expect(getChatAttachmentDataUrl(lateAttachment)).toBeNull();
     expect(
       pane.context.chatAttachmentHandoff.consume({
         owner,

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
@@ -1,0 +1,118 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { createChatAttachmentHandoff } from "../../app/chat-attachment-handoff.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
+import {
+  getChatAttachmentDataUrl,
+  registerChatAttachmentPayload,
+} from "./attachment-payload-store.ts";
+import {
+  closePaneStagedAttachments,
+  discardStateStagedAttachments,
+  preparePaneStagedAttachments,
+  restorePaneStagedAttachments,
+} from "./chat-pane-attachment-handoff.ts";
+import type { ChatPageHost } from "./chat-state-host.ts";
+import type { ChatSplitLayout } from "./split-layout.ts";
+
+function storedAttachment(id: string, mimeType = "image/png"): ChatAttachment {
+  return registerChatAttachmentPayload({
+    attachment: { id, mimeType },
+    dataUrl: `data:${mimeType};base64,${id}`,
+    file: new File([id], id, { type: mimeType }),
+  });
+}
+
+function state(attachments: ChatAttachment[], sessionKey = "agent:main:one") {
+  return {
+    agentsList: { defaultId: "main", mainKey: "main" },
+    assistantAgentId: "main",
+    chatAttachments: attachments,
+    chatComposerFallbackByScope: {},
+    hello: null,
+    sessionKey,
+    settings: { gatewayUrl: "ws://example.test" },
+  } as unknown as ChatPageHost;
+}
+
+describe("staged chat attachment pane handoff", () => {
+  it("discards a mounted package before clearing a closed pane handoff", () => {
+    const calls: string[] = [];
+    const pane = {
+      paneId: "p1",
+      discardStagedAttachments: () => calls.push("discard"),
+    };
+    const root = { querySelectorAll: () => [pane] } as unknown as ParentNode;
+    const context = {
+      chatAttachmentHandoff: { clearPane: () => calls.push("clear") },
+    } as unknown as ApplicationContext;
+    const layout = {
+      columns: [
+        {
+          id: "c1",
+          panes: [
+            { id: "p1", sessionKey: "one" },
+            { id: "p2", sessionKey: "two" },
+          ],
+          paneWeights: [1, 1],
+        },
+      ],
+      columnWeights: [1],
+      activePaneId: "p1",
+    } satisfies ChatSplitLayout;
+
+    expect(closePaneStagedAttachments(context, root, layout, "p1")?.id).toBe("p2");
+    expect(calls).toEqual(["discard", "clear"]);
+  });
+
+  it("deduplicates current and fallback payload release", () => {
+    const shared = storedAttachment("shared");
+    const fallback = storedAttachment("fallback", "application/pdf");
+    const current = state([shared]);
+    current.chatComposerFallbackByScope = {
+      fallback: {
+        attachments: [shared, fallback],
+        message: "",
+        sequence: 1,
+        storageFailed: false,
+      },
+    };
+
+    discardStateStagedAttachments(current);
+
+    expect(getChatAttachmentDataUrl(shared)).toBeNull();
+    expect(getChatAttachmentDataUrl(fallback)).toBeNull();
+    expect(current.chatAttachments).toEqual([]);
+    expect(current.chatComposerFallbackByScope.fallback?.attachments).toEqual([]);
+  });
+
+  it("restores a mixed package only to the exact mounted owner", () => {
+    const owner = {} as GatewayBrowserClient;
+    const otherOwner = {} as GatewayBrowserClient;
+    const handoff = createChatAttachmentHandoff();
+    const context = { chatAttachmentHandoff: handoff } as unknown as ApplicationContext;
+    const image = storedAttachment("image");
+    const file = storedAttachment("file", "application/pdf");
+    const pastedText = storedAttachment("pasted-text", "text/plain");
+    const mixed = [image, file, pastedText];
+
+    preparePaneStagedAttachments(context, "p1", state(mixed), owner);
+    const mismatched = state([]);
+    restorePaneStagedAttachments(context, "p1", mismatched, otherOwner);
+    expect(mismatched.chatAttachments).toEqual([]);
+    expect(mixed.every((attachment) => getChatAttachmentDataUrl(attachment) === null)).toBe(true);
+
+    const second = [storedAttachment("second-image"), storedAttachment("second-file")];
+    preparePaneStagedAttachments(context, "p2", state(second), owner);
+    const remount = state([]);
+    restorePaneStagedAttachments(context, "p2", remount, owner);
+    expect(remount.chatAttachments).toEqual(second);
+    expect(remount.chatAttachments.every((attachment, index) => attachment === second[index])).toBe(
+      true,
+    );
+    discardStateStagedAttachments(remount);
+  });
+});

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
@@ -12,7 +12,7 @@ import {
   releaseChatAttachmentPayload,
 } from "./attachment-payload-store.ts";
 import {
-  closePaneStagedAttachments,
+  closeStagedPane,
   discardStateStagedAttachments,
   preparePaneStagedAttachments,
   restorePaneStagedAttachments,
@@ -68,7 +68,7 @@ describe("staged chat attachment pane handoff", () => {
       activePaneId: "p1",
     } satisfies ChatSplitLayout;
 
-    expect(closePaneStagedAttachments(context, root, layout, "p1")?.id).toBe("p2");
+    expect(closeStagedPane(context, root, layout, "p1")?.id).toBe("p2");
     expect(calls).toEqual(["discard", "clear"]);
   });
 
@@ -107,7 +107,7 @@ describe("staged chat attachment pane handoff", () => {
       resolveStoredChatOutboxScope(current, current.sessionKey),
     );
 
-    closePaneStagedAttachments(pane.context, root, layout, pane.paneId);
+    closeStagedPane(pane.context, root, layout, pane.paneId);
     const lateAttachment = storedAttachment("late-close-completion");
     current.chatAttachments.push(lateAttachment);
     pane.disconnectedCallback();

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
@@ -115,4 +115,42 @@ describe("staged chat attachment pane handoff", () => {
     );
     discardStateStagedAttachments(remount);
   });
+
+  it("releases a restored fallback displaced by mounted state", () => {
+    const owner = {} as GatewayBrowserClient;
+    const handoff = createChatAttachmentHandoff();
+    const context = { chatAttachmentHandoff: handoff } as unknown as ApplicationContext;
+    const displaced = storedAttachment("displaced");
+    const mounted = storedAttachment("mounted");
+    handoff.prepare({
+      owner,
+      paneId: "p1",
+      scopeKey: "active",
+      attachments: [],
+      fallbacks: {
+        collision: {
+          attachments: [displaced],
+          message: "old",
+          sequence: 1,
+          storageFailed: false,
+        },
+      },
+    });
+    const remount = state([]);
+    remount.chatComposerFallbackByScope = {
+      collision: {
+        attachments: [mounted],
+        message: "new",
+        sequence: 2,
+        storageFailed: false,
+      },
+    };
+
+    restorePaneStagedAttachments(context, "p1", remount, owner);
+
+    expect(remount.chatComposerFallbackByScope.collision?.attachments).toEqual([mounted]);
+    expect(getChatAttachmentDataUrl(displaced)).toBeNull();
+    expect(getChatAttachmentDataUrl(mounted)).not.toBeNull();
+    discardStateStagedAttachments(remount);
+  });
 });

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.test.ts
@@ -9,6 +9,7 @@ import type { SessionCapability } from "../../lib/sessions/index.ts";
 import {
   getChatAttachmentDataUrl,
   registerChatAttachmentPayload,
+  releaseChatAttachmentPayload,
 } from "./attachment-payload-store.ts";
 import {
   closePaneStagedAttachments,
@@ -120,6 +121,40 @@ describe("staged chat attachment pane handoff", () => {
         scopeKey,
       }),
     ).toBeNull();
+  });
+
+  it("hands off new work after a retained closed pane is reactivated", () => {
+    const owner = {} as GatewayBrowserClient;
+    const { pane, state: current } = createTestChatPane({
+      client: owner,
+      sessions: {} as SessionCapability,
+    });
+    pane.paneId = "p2";
+    pane.discardStagedAttachments?.();
+    pane.resumeStagedAttachments?.();
+    pane.connectedClient = null;
+    pane.applyGatewaySnapshot({
+      ...pane.context.gateway.snapshot,
+      client: owner,
+      phase: "reconnecting",
+      hello: null,
+    });
+    const reopened = storedAttachment("reopened");
+    current.chatAttachments = [reopened];
+    const scopeKey = storedChatOutboxScopeKey(
+      resolveStoredChatOutboxScope(current, current.sessionKey),
+    );
+
+    pane.disconnectedCallback();
+
+    expect(
+      pane.context.chatAttachmentHandoff.consume({
+        owner,
+        paneId: pane.paneId,
+        scopeKey,
+      })?.attachments,
+    ).toEqual([reopened]);
+    releaseChatAttachmentPayload(reopened.id);
   });
 
   it("deduplicates current and fallback payload release", () => {

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.ts
@@ -29,13 +29,6 @@ function releaseAttachments(
   }
 }
 
-function releaseFallbackAttachments(state: ChatPageHost, retainedIds = new Set<string>()): void {
-  const releasedIds = new Set<string>();
-  for (const fallback of Object.values(state.chatComposerFallbackByScope)) {
-    releaseAttachments(fallback.attachments, retainedIds, releasedIds);
-  }
-}
-
 export function restorePaneStagedAttachments(
   context: ApplicationContext,
   paneId: string,
@@ -49,8 +42,12 @@ export function restorePaneStagedAttachments(
   const currentIds = new Set(state.chatAttachments.map((attachment) => attachment.id));
   state.chatAttachments = [
     ...state.chatAttachments,
-    ...restored.filter((attachment) => !currentIds.has(attachment.id)),
+    ...restored.attachments.filter((attachment) => !currentIds.has(attachment.id)),
   ];
+  state.chatComposerFallbackByScope = {
+    ...restored.fallbacks,
+    ...state.chatComposerFallbackByScope,
+  };
 }
 
 export function preparePaneStagedAttachments(
@@ -63,8 +60,8 @@ export function preparePaneStagedAttachments(
   context.chatAttachmentHandoff.prepare({
     ...handoffKey(paneId, state, owner),
     attachments,
+    fallbacks: state.chatComposerFallbackByScope,
   });
-  releaseFallbackAttachments(state, new Set(attachments.map((attachment) => attachment.id)));
 }
 
 export function discardStateStagedAttachments(state: ChatPageHost | undefined): void {

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.ts
@@ -1,0 +1,119 @@
+import type { ApplicationContext } from "../../app/context.ts";
+import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
+import { releaseChatAttachmentPayload } from "./attachment-payload-store.ts";
+import type { ChatPageHost } from "./chat-state-host.ts";
+import { resolveStoredChatOutboxScope, storedChatOutboxScopeKey } from "./composer-persistence.ts";
+import { panesOf, type ChatSplitLayout } from "./split-layout.ts";
+
+export type ChatAttachmentGatewayOwner = ApplicationContext["gateway"]["snapshot"]["client"];
+
+function handoffKey(paneId: string, state: ChatPageHost, owner: ChatAttachmentGatewayOwner) {
+  return {
+    owner,
+    paneId,
+    scopeKey: storedChatOutboxScopeKey(resolveStoredChatOutboxScope(state, state.sessionKey)),
+  };
+}
+
+function releaseAttachments(
+  attachments: readonly ChatAttachment[],
+  retainedIds = new Set<string>(),
+  releasedIds = new Set<string>(),
+): void {
+  for (const attachment of attachments) {
+    if (retainedIds.has(attachment.id) || releasedIds.has(attachment.id)) {
+      continue;
+    }
+    releasedIds.add(attachment.id);
+    releaseChatAttachmentPayload(attachment.id);
+  }
+}
+
+function releaseFallbackAttachments(state: ChatPageHost, retainedIds = new Set<string>()): void {
+  const releasedIds = new Set<string>();
+  for (const fallback of Object.values(state.chatComposerFallbackByScope)) {
+    releaseAttachments(fallback.attachments, retainedIds, releasedIds);
+  }
+}
+
+export function restorePaneStagedAttachments(
+  context: ApplicationContext,
+  paneId: string,
+  state: ChatPageHost,
+  owner: ChatAttachmentGatewayOwner,
+): void {
+  const restored = context.chatAttachmentHandoff.consume(handoffKey(paneId, state, owner));
+  if (!restored) {
+    return;
+  }
+  const currentIds = new Set(state.chatAttachments.map((attachment) => attachment.id));
+  state.chatAttachments = [
+    ...state.chatAttachments,
+    ...restored.filter((attachment) => !currentIds.has(attachment.id)),
+  ];
+}
+
+export function preparePaneStagedAttachments(
+  context: ApplicationContext,
+  paneId: string,
+  state: ChatPageHost,
+  owner: ChatAttachmentGatewayOwner,
+): void {
+  const attachments = [...state.chatAttachments];
+  context.chatAttachmentHandoff.prepare({
+    ...handoffKey(paneId, state, owner),
+    attachments,
+  });
+  releaseFallbackAttachments(state, new Set(attachments.map((attachment) => attachment.id)));
+}
+
+export function discardStateStagedAttachments(state: ChatPageHost | undefined): void {
+  if (!state) {
+    return;
+  }
+  const releasedIds = new Set<string>();
+  releaseAttachments(state.chatAttachments, new Set(), releasedIds);
+  for (const fallback of Object.values(state.chatComposerFallbackByScope)) {
+    releaseAttachments(fallback.attachments, new Set(), releasedIds);
+    fallback.attachments = [];
+  }
+  state.chatAttachments = [];
+}
+
+export function replacePaneStagedAttachmentGatewayOwner(
+  context: ApplicationContext,
+  paneId: string,
+  state: ChatPageHost | undefined,
+  previousOwner: ChatAttachmentGatewayOwner,
+  nextOwner: ChatAttachmentGatewayOwner,
+): ChatAttachmentGatewayOwner {
+  if (!nextOwner || previousOwner === nextOwner) {
+    return previousOwner;
+  }
+  discardStateStagedAttachments(state);
+  state?.requestUpdate?.();
+  context.chatAttachmentHandoff.clearPane(paneId);
+  // Rotating the token also invalidates any pending annotation Undo owned by the old client.
+  return nextOwner;
+}
+
+type StagedAttachmentPane = Element & {
+  paneId: string;
+  discardStagedAttachments?: () => void;
+};
+
+export function closePaneStagedAttachments(
+  context: ApplicationContext,
+  root: ParentNode,
+  layout: ChatSplitLayout,
+  paneId: string,
+) {
+  const survivingPane = panesOf(layout).find((candidate) => candidate.id !== paneId);
+  const pane = [...root.querySelectorAll<StagedAttachmentPane>("openclaw-chat-pane")].find(
+    (candidate) => candidate.paneId === paneId,
+  );
+  // Clear a mounted pane first so its disconnect cannot restage the closed package.
+  pane?.discardStagedAttachments?.();
+  context.chatAttachmentHandoff.clearPane(paneId);
+  return survivingPane;
+}

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.ts
@@ -111,7 +111,7 @@ type StagedAttachmentPane = Element & {
   resumeStagedAttachments?: () => void;
 };
 
-export function resumeVisiblePaneStagedAttachments(
+export function resumeStagedPanes(
   root: ParentNode,
   layout: ChatSplitLayout,
   narrow: boolean,
@@ -126,7 +126,7 @@ export function resumeVisiblePaneStagedAttachments(
   }
 }
 
-export function closePaneStagedAttachments(
+export function closeStagedPane(
   context: ApplicationContext,
   root: ParentNode,
   layout: ChatSplitLayout,

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.ts
@@ -44,10 +44,20 @@ export function restorePaneStagedAttachments(
     ...state.chatAttachments,
     ...restored.attachments.filter((attachment) => !currentIds.has(attachment.id)),
   ];
+  const displaced = Object.entries(restored.fallbacks)
+    .filter(([scopeKey]) => Object.hasOwn(state.chatComposerFallbackByScope, scopeKey))
+    .flatMap(([, fallback]) => fallback.attachments);
   state.chatComposerFallbackByScope = {
     ...restored.fallbacks,
     ...state.chatComposerFallbackByScope,
   };
+  const retainedIds = new Set(state.chatAttachments.map((attachment) => attachment.id));
+  for (const fallback of Object.values(state.chatComposerFallbackByScope)) {
+    for (const attachment of fallback.attachments) {
+      retainedIds.add(attachment.id);
+    }
+  }
+  releaseAttachments(displaced, retainedIds);
 }
 
 export function preparePaneStagedAttachments(

--- a/ui/src/pages/chat/chat-pane-attachment-handoff.ts
+++ b/ui/src/pages/chat/chat-pane-attachment-handoff.ts
@@ -3,7 +3,7 @@ import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
 import { releaseChatAttachmentPayload } from "./attachment-payload-store.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { resolveStoredChatOutboxScope, storedChatOutboxScopeKey } from "./composer-persistence.ts";
-import { panesOf, type ChatSplitLayout } from "./split-layout.ts";
+import { panesOf, type ChatSplitLayout, visiblePanesOf } from "./split-layout.ts";
 
 export type ChatAttachmentGatewayOwner = ApplicationContext["gateway"]["snapshot"]["client"];
 
@@ -106,8 +106,25 @@ export function replacePaneStagedAttachmentGatewayOwner(
 
 type StagedAttachmentPane = Element & {
   paneId: string;
+  sessionKey: string;
   discardStagedAttachments?: () => void;
+  resumeStagedAttachments?: () => void;
 };
+
+export function resumeVisiblePaneStagedAttachments(
+  root: ParentNode,
+  layout: ChatSplitLayout,
+  narrow: boolean,
+): void {
+  const visibleSessions = new Map(
+    visiblePanesOf(layout, narrow).map((pane) => [pane.id, pane.sessionKey]),
+  );
+  for (const pane of root.querySelectorAll<StagedAttachmentPane>("openclaw-chat-pane")) {
+    if (visibleSessions.get(pane.paneId) === pane.sessionKey) {
+      pane.resumeStagedAttachments?.();
+    }
+  }
+}
 
 export function closePaneStagedAttachments(
   context: ApplicationContext,

--- a/ui/src/pages/chat/chat-pane-browser-annotation-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-browser-annotation-lifecycle.test.ts
@@ -108,17 +108,24 @@ describe("staged attachment composer adoption", () => {
     pane.disconnectedCallback();
 
     expect(getChatAttachmentDataUrl(shared)).not.toBeNull();
-    expect(getChatAttachmentDataUrl(fallback)).toBeNull();
+    expect(getChatAttachmentDataUrl(fallback)).not.toBeNull();
     expect(getChatAttachmentDataUrl(ordinary)).not.toBeNull();
     const transferred = pane.context.chatAttachmentHandoff.consume({
       owner,
       paneId: pane.paneId,
       scopeKey,
     });
-    expect(transferred).toEqual([shared, ordinary]);
-    expect(transferred?.[0]).toBe(shared);
-    expect(transferred?.[1]).toBe(ordinary);
+    expect(transferred?.attachments).toEqual([shared, ordinary]);
+    expect(transferred?.attachments[0]).toBe(shared);
+    expect(transferred?.attachments[1]).toBe(ordinary);
+    expect(transferred?.fallbacks.fallback).toMatchObject({
+      message: "",
+      sequence: 1,
+      storageFailed: false,
+    });
+    expect(transferred?.fallbacks.fallback?.attachments).toEqual([shared, fallback, ordinary]);
     releaseChatAttachmentPayload(shared.id);
+    releaseChatAttachmentPayload(fallback.id);
     releaseChatAttachmentPayload(ordinary.id);
   });
 

--- a/ui/src/pages/chat/chat-pane-browser-annotation-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-browser-annotation-lifecycle.test.ts
@@ -368,7 +368,7 @@ describe("staged attachment composer adoption", () => {
     expect(getChatAttachmentDataUrl(ordinary)).toBeNull();
   });
 
-  it("discards an annotation captured without a client when the first client arrives", () => {
+  it("discards a staged package captured without a client when the first client arrives", () => {
     const client = {} as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({
       client,
@@ -381,6 +381,8 @@ describe("staged attachment composer adoption", () => {
       pane as TestChatPane & { receiveBrowserAnnotation: (candidate: Event) => void }
     ).receiveBrowserAnnotation(annotationEvent());
     const annotation = state.chatAttachments[0]!;
+    const ordinary = storedAttachment("no-client-ordinary", false);
+    state.chatAttachments.push(ordinary);
 
     pane.applyGatewaySnapshot({
       ...pane.context.gateway.snapshot,
@@ -391,6 +393,7 @@ describe("staged attachment composer adoption", () => {
 
     expect(state.chatAttachments).toEqual([]);
     expect(getChatAttachmentDataUrl(annotation)).toBeNull();
+    expect(getChatAttachmentDataUrl(ordinary)).toBeNull();
   });
 
   it("invalidates annotation Undo when the logical Gateway client is replaced", async () => {

--- a/ui/src/pages/chat/chat-pane-browser-annotation-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-browser-annotation-lifecycle.test.ts
@@ -23,7 +23,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe("browser annotation composer adoption", () => {
+describe("staged attachment composer adoption", () => {
   function annotationEvent() {
     return new CustomEvent<BrowserAnnotationDraft>("openclaw:browser-annotation", {
       detail: {
@@ -63,7 +63,7 @@ describe("browser annotation composer adoption", () => {
     });
   }
 
-  function connectPaneThroughAnnotationRestore(
+  function connectPaneThroughAttachmentRestore(
     context: ApplicationContext,
     paneId: string,
     sessionKey: string,
@@ -73,7 +73,7 @@ describe("browser annotation composer adoption", () => {
     pane.context = context;
     pane.paneId = paneId;
     pane.sessionKey = sessionKey;
-    const stopAfterRestore = new Error("stop after annotation restore");
+    const stopAfterRestore = new Error("stop after attachment restore");
     vi.spyOn(
       pane.chatState as unknown as { startComposerPersistence: () => void },
       "startComposerPersistence",
@@ -84,11 +84,11 @@ describe("browser annotation composer adoption", () => {
     return pane;
   }
 
-  it("releases annotation payloads before pane state is discarded on disconnect", () => {
-    const { pane, state } = createTestChatPane({
-      client: {} as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
-    });
+  it("transfers the mounted package and releases fallback-only payloads on disconnect", () => {
+    const owner = {} as GatewayBrowserClient;
+    const context = createSessionContext(owner, {} as SessionCapability);
+    const pane = connectPaneThroughAttachmentRestore(context, "p1", "agent:main:current");
+    const state = pane.state;
     const shared = storedAttachment("shared-annotation", true);
     const fallback = storedAttachment("fallback-annotation", true);
     const ordinary = storedAttachment("ordinary", false);
@@ -101,12 +101,24 @@ describe("browser annotation composer adoption", () => {
         storageFailed: false,
       },
     };
+    const scopeKey = storedChatOutboxScopeKey(
+      resolveStoredChatOutboxScope(state, state.sessionKey),
+    );
 
     pane.disconnectedCallback();
 
-    expect(getChatAttachmentDataUrl(shared)).toBeNull();
+    expect(getChatAttachmentDataUrl(shared)).not.toBeNull();
     expect(getChatAttachmentDataUrl(fallback)).toBeNull();
     expect(getChatAttachmentDataUrl(ordinary)).not.toBeNull();
+    const transferred = pane.context.chatAttachmentHandoff.consume({
+      owner,
+      paneId: pane.paneId,
+      scopeKey,
+    });
+    expect(transferred).toEqual([shared, ordinary]);
+    expect(transferred?.[0]).toBe(shared);
+    expect(transferred?.[1]).toBe(ordinary);
+    releaseChatAttachmentPayload(shared.id);
     releaseChatAttachmentPayload(ordinary.id);
   });
 
@@ -121,21 +133,48 @@ describe("browser annotation composer adoption", () => {
       pane as TestChatPane & { receiveBrowserAnnotation: (candidate: Event) => void }
     ).receiveBrowserAnnotation(annotationEvent());
     const annotation = state.chatAttachments[0]!;
+    const ordinary = storedAttachment("late-dispose-ordinary", false);
+    state.chatAttachments.push(ordinary);
     const scopeKey = storedChatOutboxScopeKey(
       resolveStoredChatOutboxScope(state, state.sessionKey),
     );
-    pane.context.browserAnnotationHandoff.dispose();
+    pane.context.chatAttachmentHandoff.dispose();
 
     pane.disconnectedCallback();
 
     expect(getChatAttachmentDataUrl(annotation)).toBeNull();
+    expect(getChatAttachmentDataUrl(ordinary)).toBeNull();
     expect(
-      pane.context.browserAnnotationHandoff.consume({
+      pane.context.chatAttachmentHandoff.consume({
         owner,
         paneId: pane.paneId,
         scopeKey,
       }),
     ).toBeNull();
+  });
+
+  it("restores an ordinary mixed package through a real pane remount", () => {
+    const owner = {} as GatewayBrowserClient;
+    const context = createSessionContext(owner, {} as SessionCapability);
+    const pane = connectPaneThroughAttachmentRestore(context, "p1", "agent:main:mixed-package");
+    const image = storedAttachment("remount-image", false);
+    const file = storedAttachment("remount-file", false);
+    file.mimeType = "application/pdf";
+    const pastedText = storedAttachment("remount-pasted-text", false);
+    pastedText.mimeType = "text/plain";
+    const staged = [image, file, pastedText];
+    pane.state.chatAttachments = staged;
+
+    pane.disconnectedCallback();
+    const remount = connectPaneThroughAttachmentRestore(context, "p1", "agent:main:mixed-package");
+
+    expect(remount.state.chatAttachments).toEqual(staged);
+    expect(
+      remount.state.chatAttachments.every((attachment, index) => attachment === staged[index]),
+    ).toBe(true);
+    expect(staged.every((attachment) => getChatAttachmentDataUrl(attachment) !== null)).toBe(true);
+    remount.discardStagedAttachments?.();
+    remount.disconnectedCallback();
   });
 
   it("keeps generated context on the attachment and leaves the user's draft unchanged", () => {
@@ -178,7 +217,7 @@ describe("browser annotation composer adoption", () => {
       markedRegionCount: 2,
       inspectedElement: true,
     });
-    pane.discardBrowserAnnotations?.();
+    pane.discardStagedAttachments?.();
   });
 
   it("lets only the active pane consume a shared annotation event", () => {
@@ -220,14 +259,14 @@ describe("browser annotation composer adoption", () => {
     expect(first.state.chatAttachments).toEqual([]);
     expect(second.state.chatAttachments).toHaveLength(1);
     expect(event.defaultPrevented).toBe(true);
-    second.pane.discardBrowserAnnotations?.();
+    second.pane.discardStagedAttachments?.();
   });
 
   it("restores through a new pane after a null mount acquires its first Gateway client", () => {
     const client = {} as GatewayBrowserClient;
     const context = createSessionContext(client, {} as SessionCapability);
     (context.gateway.snapshot as { client: GatewayBrowserClient | null }).client = null;
-    const pane = connectPaneThroughAnnotationRestore(context, "p1", "agent:main:delayed-client");
+    const pane = connectPaneThroughAttachmentRestore(context, "p1", "agent:main:delayed-client");
     pane.active = true;
     (context.gateway.snapshot as { client: GatewayBrowserClient | null }).client = client;
 
@@ -237,10 +276,10 @@ describe("browser annotation composer adoption", () => {
     const captured = pane.state.chatAttachments[0]!;
     pane.disconnectedCallback();
 
-    const remount = connectPaneThroughAnnotationRestore(context, "p1", "agent:main:delayed-client");
+    const remount = connectPaneThroughAttachmentRestore(context, "p1", "agent:main:delayed-client");
     remount.applyGatewaySnapshot(context.gateway.snapshot);
     expect(remount.state.chatAttachments[0]).toBe(captured);
-    remount.discardBrowserAnnotations?.();
+    remount.discardStagedAttachments?.();
     remount.disconnectedCallback();
   });
 
@@ -248,7 +287,7 @@ describe("browser annotation composer adoption", () => {
     const owner = {} as GatewayBrowserClient;
     const replacement = {} as GatewayBrowserClient;
     const context = createSessionContext(owner, {} as SessionCapability);
-    const pane = connectPaneThroughAnnotationRestore(context, "p1", "agent:main:replaced-client");
+    const pane = connectPaneThroughAttachmentRestore(context, "p1", "agent:main:replaced-client");
     pane.active = true;
     (
       pane as TestChatPane & { receiveBrowserAnnotation: (candidate: Event) => void }
@@ -257,7 +296,7 @@ describe("browser annotation composer adoption", () => {
     (context.gateway.snapshot as { client: GatewayBrowserClient | null }).client = replacement;
 
     pane.disconnectedCallback();
-    const remount = connectPaneThroughAnnotationRestore(
+    const remount = connectPaneThroughAttachmentRestore(
       context,
       "p1",
       "agent:main:replaced-client",
@@ -267,7 +306,7 @@ describe("browser annotation composer adoption", () => {
     remount.disconnectedCallback();
   });
 
-  it("preserves annotations on same-client reconnect and clears only annotations on replacement", () => {
+  it("preserves the package on same-client reconnect and clears it on replacement", () => {
     const owner = {} as GatewayBrowserClient;
     const replacement = {} as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({
@@ -322,12 +361,11 @@ describe("browser annotation composer adoption", () => {
       phase: "reconnecting",
       hello: null,
     });
-    expect(state.chatAttachments).toEqual([ordinary]);
-    expect(state.chatComposerFallbackByScope.fallback?.attachments).toEqual([ordinary]);
+    expect(state.chatAttachments).toEqual([]);
+    expect(state.chatComposerFallbackByScope.fallback?.attachments).toEqual([]);
     expect(getChatAttachmentDataUrl(current)).toBeNull();
     expect(getChatAttachmentDataUrl(fallback)).toBeNull();
-    expect(getChatAttachmentDataUrl(ordinary)).not.toBeNull();
-    releaseChatAttachmentPayload(ordinary.id);
+    expect(getChatAttachmentDataUrl(ordinary)).toBeNull();
   });
 
   it("discards an annotation captured without a client when the first client arrives", () => {
@@ -391,10 +429,9 @@ describe("browser annotation composer adoption", () => {
     });
     toastHost.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
 
-    expect(state.chatAttachments).toEqual([ordinary]);
+    expect(state.chatAttachments).toEqual([]);
     expect(getChatAttachmentDataUrl(annotation)).toBeNull();
-    expect(getChatAttachmentDataUrl(ordinary)).not.toBeNull();
+    expect(getChatAttachmentDataUrl(ordinary)).toBeNull();
     toastHost.remove();
-    releaseChatAttachmentPayload(ordinary.id);
   });
 });

--- a/ui/src/pages/chat/chat-pane-browser-annotation.test.ts
+++ b/ui/src/pages/chat/chat-pane-browser-annotation.test.ts
@@ -1,29 +1,14 @@
 /* @vitest-environment jsdom */
 
 import { describe, expect, it, vi } from "vitest";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { createBrowserAnnotationHandoff } from "../../app/browser-annotation-handoff.ts";
-import type { ApplicationContext } from "../../app/context.ts";
 import type {
   BrowserAnnotationDraft,
   BrowserAnnotationEvent,
 } from "../../components/browser/browser-annotation.ts";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
-import {
-  getChatAttachmentDataUrl,
-  registerChatAttachmentPayload,
-  releaseChatAttachmentPayload,
-} from "./attachment-payload-store.ts";
 import { canAdmitBrowserAnnotation } from "./browser-annotation-admission.ts";
-import {
-  closePaneBrowserAnnotations,
-  discardStateBrowserAnnotations,
-  preparePaneBrowserAnnotations,
-  receiveBrowserAnnotation,
-  restorePaneBrowserAnnotations,
-} from "./chat-pane-browser-annotation.ts";
+import { receiveBrowserAnnotation } from "./chat-pane-browser-annotation.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
-import type { ChatSplitLayout } from "./split-layout.ts";
 
 function annotation(id: string, modelContext = `Context ${id}`): ChatAttachment {
   return {
@@ -89,103 +74,5 @@ describe("browser annotation admission", () => {
     expect(event.defaultPrevented).toBe(false);
     expect((event as BrowserAnnotationEvent).rejection).toBe("limit");
     expect(state.chatAttachments).toHaveLength(4);
-  });
-});
-
-describe("browser annotation pane teardown", () => {
-  it("discards live annotations before clearing a closed pane handoff", () => {
-    const calls: string[] = [];
-    const pane = {
-      paneId: "p1",
-      discardBrowserAnnotations: () => calls.push("discard"),
-    };
-    const root = { querySelectorAll: () => [pane] } as unknown as ParentNode;
-    const context = {
-      browserAnnotationHandoff: { clearPane: () => calls.push("clear") },
-    } as unknown as ApplicationContext;
-    const layout = {
-      columns: [
-        {
-          id: "c1",
-          panes: [
-            { id: "p1", sessionKey: "one" },
-            { id: "p2", sessionKey: "two" },
-          ],
-          paneWeights: [1, 1],
-        },
-      ],
-      columnWeights: [1],
-      activePaneId: "p1",
-    } satisfies ChatSplitLayout;
-
-    expect(closePaneBrowserAnnotations(context, root, layout, "p1")?.id).toBe("p2");
-    expect(calls).toEqual(["discard", "clear"]);
-  });
-
-  it("deduplicates current and fallback annotations while preserving ordinary payloads", () => {
-    const stored = (attachment: ChatAttachment, payload: string) =>
-      registerChatAttachmentPayload({
-        attachment,
-        dataUrl: payload,
-        file: new File([payload], `${attachment.id}.png`, { type: attachment.mimeType }),
-      });
-    const shared = stored(annotation("shared"), "data:image/png;base64,c2hhcmVk");
-    const fallback = stored(annotation("fallback"), "data:image/png;base64,ZmFsbGJhY2s=");
-    const ordinary = stored(
-      { id: "ordinary", mimeType: "image/png" },
-      "data:image/png;base64,b3JkaW5hcnk=",
-    );
-    const state = {
-      chatAttachments: [shared, ordinary],
-      chatComposerFallbackByScope: {
-        fallback: {
-          attachments: [shared, fallback, ordinary],
-          message: "",
-          sequence: 1,
-          storageFailed: false,
-        },
-      },
-    } as unknown as ChatPageHost;
-
-    discardStateBrowserAnnotations(state);
-
-    expect(getChatAttachmentDataUrl(shared)).toBeNull();
-    expect(getChatAttachmentDataUrl(fallback)).toBeNull();
-    expect(getChatAttachmentDataUrl(ordinary)).not.toBeNull();
-    expect(state.chatAttachments).toEqual([ordinary]);
-    expect(state.chatComposerFallbackByScope.fallback?.attachments).toEqual([ordinary]);
-    releaseChatAttachmentPayload(ordinary.id);
-  });
-
-  it("restores route and split-pane annotations only to the exact mounted owner", () => {
-    const owner = {} as GatewayBrowserClient;
-    const otherOwner = {} as GatewayBrowserClient;
-    const handoff = createBrowserAnnotationHandoff();
-    const context = { browserAnnotationHandoff: handoff } as unknown as ApplicationContext;
-    const ordinary = { id: "ordinary", mimeType: "image/png" } satisfies ChatAttachment;
-    const first = annotation("first");
-    const second = annotation("second");
-    const state = (attachments: ChatAttachment[], sessionKey = "agent:main:one") =>
-      ({
-        agentsList: { defaultId: "main", mainKey: "main" },
-        assistantAgentId: "main",
-        chatAttachments: attachments,
-        chatComposerFallbackByScope: {},
-        hello: null,
-        sessionKey,
-        settings: { gatewayUrl: "ws://example.test" },
-      }) as unknown as ChatPageHost;
-
-    preparePaneBrowserAnnotations(context, "p1", state([ordinary, first]), owner);
-    preparePaneBrowserAnnotations(context, "p2", state([second]), owner);
-
-    const mismatched = state([]);
-    restorePaneBrowserAnnotations(context, "p1", mismatched, otherOwner);
-    expect(mismatched.chatAttachments).toEqual([]);
-
-    const secondRemount = state([ordinary]);
-    restorePaneBrowserAnnotations(context, "p2", secondRemount, owner);
-    expect(secondRemount.chatAttachments).toEqual([ordinary, second]);
-    expect(secondRemount.chatAttachments[1]).toBe(second);
   });
 });

--- a/ui/src/pages/chat/chat-pane-browser-annotation.ts
+++ b/ui/src/pages/chat/chat-pane-browser-annotation.ts
@@ -1,18 +1,11 @@
-import type { ApplicationContext } from "../../app/context.ts";
 import type {
   BrowserAnnotationDraft,
   BrowserAnnotationEvent,
 } from "../../components/browser/browser-annotation.ts";
-import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
-import { releaseChatAttachmentPayload } from "./attachment-payload-store.ts";
 import { canAdmitBrowserAnnotation } from "./browser-annotation-admission.ts";
 import { CHAT_COMPOSER_TEXTAREA_SELECTOR } from "./chat-pane-shared.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { chatAttachmentFromDataUrl } from "./components/chat-attachments.ts";
-import { resolveStoredChatOutboxScope, storedChatOutboxScopeKey } from "./composer-persistence.ts";
-import { panesOf, type ChatSplitLayout } from "./split-layout.ts";
-
-export type BrowserAnnotationGatewayOwner = ApplicationContext["gateway"]["snapshot"]["client"];
 
 export function focusBrowserAnnotationComposerAfterUpdate(
   host: ParentNode & { updateComplete: Promise<unknown> },
@@ -67,131 +60,4 @@ export function receiveBrowserAnnotation(
   ];
   state.requestUpdate?.();
   return true;
-}
-
-/** Releases only annotation-owned payloads when a pane's state is discarded. */
-function releasePaneBrowserAnnotations(
-  state: ChatPageHost,
-  releasePayload = releaseChatAttachmentPayload,
-  released = new Set<string>(),
-): void {
-  const release = (attachments: readonly ChatAttachment[]) => {
-    for (const attachment of attachments) {
-      if (attachment.browserAnnotation === undefined || released.has(attachment.id)) {
-        continue;
-      }
-      released.add(attachment.id);
-      releasePayload(attachment.id);
-    }
-  };
-  release(state.chatAttachments);
-  for (const fallback of Object.values(state.chatComposerFallbackByScope)) {
-    release(fallback.attachments);
-  }
-}
-
-function browserAnnotationHandoffKey(
-  paneId: string,
-  state: ChatPageHost,
-  owner: ApplicationContext["gateway"]["snapshot"]["client"],
-) {
-  return {
-    owner,
-    paneId,
-    scopeKey: storedChatOutboxScopeKey(resolveStoredChatOutboxScope(state, state.sessionKey)),
-  };
-}
-
-export function restorePaneBrowserAnnotations(
-  context: ApplicationContext,
-  paneId: string,
-  state: ChatPageHost,
-  owner: ApplicationContext["gateway"]["snapshot"]["client"],
-): void {
-  const restored = context.browserAnnotationHandoff.consume(
-    browserAnnotationHandoffKey(paneId, state, owner),
-  );
-  if (!restored) {
-    return;
-  }
-  const currentIds = new Set(state.chatAttachments.map((attachment) => attachment.id));
-  state.chatAttachments = [
-    ...state.chatAttachments,
-    ...restored.filter((attachment) => !currentIds.has(attachment.id)),
-  ];
-}
-
-export function preparePaneBrowserAnnotations(
-  context: ApplicationContext,
-  paneId: string,
-  state: ChatPageHost,
-  owner: ApplicationContext["gateway"]["snapshot"]["client"],
-): void {
-  const annotations = state.chatAttachments.filter(
-    (attachment) => attachment.browserAnnotation !== undefined,
-  );
-  context.browserAnnotationHandoff.prepare({
-    ...browserAnnotationHandoffKey(paneId, state, owner),
-    attachments: annotations,
-  });
-  // Memory fallbacks are pane-local. Only the mounted scope transfers; stale
-  // fallback annotations must release when their pane owner disappears.
-  releasePaneBrowserAnnotations(
-    state,
-    releaseChatAttachmentPayload,
-    new Set(annotations.map((attachment) => attachment.id)),
-  );
-}
-
-export function discardStateBrowserAnnotations(state: ChatPageHost | undefined): void {
-  if (!state) {
-    return;
-  }
-  releasePaneBrowserAnnotations(state);
-  state.chatAttachments = state.chatAttachments.filter(
-    (attachment) => attachment.browserAnnotation === undefined,
-  );
-  for (const fallback of Object.values(state.chatComposerFallbackByScope)) {
-    fallback.attachments = fallback.attachments.filter(
-      (attachment) => attachment.browserAnnotation === undefined,
-    );
-  }
-}
-
-export function replacePaneBrowserAnnotationGatewayOwner(
-  context: ApplicationContext,
-  paneId: string,
-  state: ChatPageHost | undefined,
-  previousOwner: BrowserAnnotationGatewayOwner,
-  nextOwner: BrowserAnnotationGatewayOwner,
-): BrowserAnnotationGatewayOwner {
-  if (!nextOwner || previousOwner === nextOwner) {
-    return previousOwner;
-  }
-  discardStateBrowserAnnotations(state);
-  state?.requestUpdate?.();
-  context.browserAnnotationHandoff.clearPane(paneId);
-  // Rotating the token also invalidates any pending Undo owned by the old client.
-  return nextOwner;
-}
-
-type BrowserAnnotationPane = Element & {
-  paneId: string;
-  discardBrowserAnnotations?: () => void;
-};
-
-export function closePaneBrowserAnnotations(
-  context: ApplicationContext,
-  root: ParentNode,
-  layout: ChatSplitLayout,
-  paneId: string,
-) {
-  const survivingPane = panesOf(layout).find((candidate) => candidate.id !== paneId);
-  const pane = [...root.querySelectorAll<BrowserAnnotationPane>("openclaw-chat-pane")].find(
-    (candidate) => candidate.paneId === paneId,
-  );
-  // Clear a mounted pane first so its disconnect cannot restage the closed annotation.
-  pane?.discardBrowserAnnotations?.();
-  context.browserAnnotationHandoff.clearPane(paneId);
-  return survivingPane;
 }

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -170,7 +170,7 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
     const sourceChanged = connectionLifecycle.transition(snapshot);
     const clientChanged = this.connectedClient !== snapshot.client;
     if (clientChanged) {
-      this.replaceBrowserAnnotationGatewayOwner(snapshot.client);
+      this.replaceStagedAttachmentGatewayOwner(snapshot.client);
     }
     if (snapshot.phase !== "connected") {
       this.presencePayload = undefined;

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -11,7 +11,7 @@ import type {
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
-import { createBrowserAnnotationHandoff } from "../../app/browser-annotation-handoff.ts";
+import { createChatAttachmentHandoff } from "../../app/chat-attachment-handoff.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
@@ -112,7 +112,7 @@ describe("chat pane first-turn attachment lifecycle", () => {
       agentSelection: { state: { selectedId: "main" } },
       agents: { state: { agentsList: null } },
       initialUserMessage: createInitialUserMessageHandoff(),
-      browserAnnotationHandoff: createBrowserAnnotationHandoff(),
+      chatAttachmentHandoff: createChatAttachmentHandoff(),
       sessions: {},
     } as unknown as ApplicationContext;
     prepareInitialUserMessageHandoff(

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -72,8 +72,12 @@ const COMPOSER_PREFILL_ATTENTION_CLASS = "agent-chat__input--prefill-attention";
 
 export abstract class ChatPaneLifecycle extends ChatPaneBoard {
   private stagedAttachmentGatewayOwner: ChatAttachmentGatewayOwner = null;
+  private suppressStagedAttachmentHandoffOnDisconnect = false;
 
   public discardStagedAttachments(): void {
+    // Explicit pane disposal is terminal. The DOM disconnect that follows must
+    // not recreate an empty fallback handoff under a later reused pane id.
+    this.suppressStagedAttachmentHandoffOnDisconnect = true;
     discardStateStagedAttachments(this.state);
   }
 
@@ -438,6 +442,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneBoard {
 
   override connectedCallback() {
     this.boardProviderLifecycleConnected = true;
+    this.suppressStagedAttachmentHandoffOnDisconnect = false;
     super.connectedCallback();
     const mountGatewayOwner = this.context.gateway.snapshot.client;
     this.stagedAttachmentGatewayOwner = mountGatewayOwner;
@@ -665,7 +670,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneBoard {
   }
 
   override disconnectedCallback() {
-    if (this.state) {
+    if (this.state && !this.suppressStagedAttachmentHandoffOnDisconnect) {
       preparePaneStagedAttachments(
         this.context,
         this.paneId,

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -26,15 +26,17 @@ import {
 } from "../../lib/sessions/session-key.ts";
 import { invalidateChatAvatarCache, refreshChatAvatar } from "./chat-avatar.ts";
 import { clearChatHistory } from "./chat-history.ts";
+import {
+  type ChatAttachmentGatewayOwner,
+  discardStateStagedAttachments,
+  preparePaneStagedAttachments,
+  replacePaneStagedAttachmentGatewayOwner,
+  restorePaneStagedAttachments,
+} from "./chat-pane-attachment-handoff.ts";
 import { ChatPaneBoard } from "./chat-pane-board.ts";
 import {
-  type BrowserAnnotationGatewayOwner,
-  discardStateBrowserAnnotations,
   focusBrowserAnnotationComposerAfterUpdate,
-  preparePaneBrowserAnnotations as prepareAnnotations,
   receiveBrowserAnnotation as admitBrowserAnnotation,
-  replacePaneBrowserAnnotationGatewayOwner,
-  restorePaneBrowserAnnotations,
 } from "./chat-pane-browser-annotation.ts";
 import {
   CHAT_COMPOSER_TEXTAREA_SELECTOR,
@@ -69,22 +71,22 @@ const COMPOSER_PREFILL_ATTENTION_DURATION_MS = 1_200;
 const COMPOSER_PREFILL_ATTENTION_CLASS = "agent-chat__input--prefill-attention";
 
 export abstract class ChatPaneLifecycle extends ChatPaneBoard {
-  private browserAnnotationGatewayOwner: BrowserAnnotationGatewayOwner = null;
+  private stagedAttachmentGatewayOwner: ChatAttachmentGatewayOwner = null;
 
-  public discardBrowserAnnotations(): void {
-    discardStateBrowserAnnotations(this.state);
+  public discardStagedAttachments(): void {
+    discardStateStagedAttachments(this.state);
   }
 
-  protected browserAnnotationOwner(): NonNullable<BrowserAnnotationGatewayOwner> | undefined {
-    return this.browserAnnotationGatewayOwner ?? undefined;
+  protected browserAnnotationOwner(): NonNullable<ChatAttachmentGatewayOwner> | undefined {
+    return this.stagedAttachmentGatewayOwner ?? undefined;
   }
 
-  protected replaceBrowserAnnotationGatewayOwner(nextOwner: BrowserAnnotationGatewayOwner): void {
-    this.browserAnnotationGatewayOwner = replacePaneBrowserAnnotationGatewayOwner(
+  protected replaceStagedAttachmentGatewayOwner(nextOwner: ChatAttachmentGatewayOwner): void {
+    this.stagedAttachmentGatewayOwner = replacePaneStagedAttachmentGatewayOwner(
       this.context,
       this.paneId,
       this.state,
-      this.browserAnnotationGatewayOwner,
+      this.stagedAttachmentGatewayOwner,
       nextOwner,
     );
   }
@@ -330,7 +332,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneBoard {
       return;
     }
     // A null mount binds only when its first annotation ownership begins.
-    this.browserAnnotationGatewayOwner ??= this.context.gateway.snapshot.client;
+    this.stagedAttachmentGatewayOwner ??= this.context.gateway.snapshot.client;
     focusBrowserAnnotationComposerAfterUpdate(this);
   }
 
@@ -438,7 +440,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneBoard {
     this.boardProviderLifecycleConnected = true;
     super.connectedCallback();
     const mountGatewayOwner = this.context.gateway.snapshot.client;
-    this.browserAnnotationGatewayOwner = mountGatewayOwner;
+    this.stagedAttachmentGatewayOwner = mountGatewayOwner;
     this.requestUpdate();
     if (typeof ResizeObserver === "function") {
       this.paneResizeObserver = new ResizeObserver((entries) => {
@@ -507,7 +509,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneBoard {
     }
     chatState.attach(pageState);
     chatState.restoreComposer({ preserveCurrent: true });
-    restorePaneBrowserAnnotations(this.context, this.paneId, pageState, mountGatewayOwner);
+    restorePaneStagedAttachments(this.context, this.paneId, pageState, mountGatewayOwner);
     chatState.startComposerPersistence();
     if (this.draft !== undefined) {
       this.state.handleChatDraftChange(this.draft);
@@ -664,9 +666,14 @@ export abstract class ChatPaneLifecycle extends ChatPaneBoard {
 
   override disconnectedCallback() {
     if (this.state) {
-      prepareAnnotations(this.context, this.paneId, this.state, this.browserAnnotationGatewayOwner);
+      preparePaneStagedAttachments(
+        this.context,
+        this.paneId,
+        this.state,
+        this.stagedAttachmentGatewayOwner,
+      );
     }
-    this.browserAnnotationGatewayOwner = null;
+    this.stagedAttachmentGatewayOwner = null;
     this.clearComposerPrefillAttention();
     this.retainedBoardSessionKey = "";
     this.boardProviderLifecycleConnected = false;

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -670,13 +670,19 @@ export abstract class ChatPaneLifecycle extends ChatPaneBoard {
   }
 
   override disconnectedCallback() {
-    if (this.state && !this.suppressStagedAttachmentHandoffOnDisconnect) {
-      preparePaneStagedAttachments(
-        this.context,
-        this.paneId,
-        this.state,
-        this.stagedAttachmentGatewayOwner,
-      );
+    if (this.state) {
+      if (this.suppressStagedAttachmentHandoffOnDisconnect) {
+        // MCP app teardown can delay DOM removal after pane close. Finalize any
+        // attachment that completed during that delay instead of leaking it.
+        discardStateStagedAttachments(this.state);
+      } else {
+        preparePaneStagedAttachments(
+          this.context,
+          this.paneId,
+          this.state,
+          this.stagedAttachmentGatewayOwner,
+        );
+      }
     }
     this.stagedAttachmentGatewayOwner = null;
     this.clearComposerPrefillAttention();

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -78,7 +78,12 @@ export abstract class ChatPaneLifecycle extends ChatPaneBoard {
     // Explicit pane disposal is terminal. The DOM disconnect that follows must
     // not recreate an empty fallback handoff under a later reused pane id.
     this.suppressStagedAttachmentHandoffOnDisconnect = true;
+    this.chatState.attachmentReads.abortReads();
     discardStateStagedAttachments(this.state);
+  }
+
+  public resumeStagedAttachments(): void {
+    this.suppressStagedAttachmentHandoffOnDisconnect = false;
   }
 
   protected browserAnnotationOwner(): NonNullable<ChatAttachmentGatewayOwner> | undefined {
@@ -442,7 +447,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneBoard {
 
   override connectedCallback() {
     this.boardProviderLifecycleConnected = true;
-    this.suppressStagedAttachmentHandoffOnDisconnect = false;
+    this.resumeStagedAttachments();
     super.connectedCallback();
     const mountGatewayOwner = this.context.gateway.snapshot.client;
     this.stagedAttachmentGatewayOwner = mountGatewayOwner;

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -13,7 +13,7 @@ import type { ControlUiSessionPullRequest } from "../../../../src/gateway/contro
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewayEventFrame, GatewayEventListener } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
-import { createBrowserAnnotationHandoff } from "../../app/browser-annotation-handoff.ts";
+import { createChatAttachmentHandoff } from "../../app/chat-attachment-handoff.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
 import type { CatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
@@ -41,7 +41,7 @@ export type TestChatPane = HTMLElement & {
   createSession: () => Promise<boolean>;
   restoreArchivedSession: (sessionKey: string) => Promise<void>;
   disconnectedCallback: () => void;
-  discardBrowserAnnotations?: () => void;
+  discardStagedAttachments?: () => void;
   acceptTaskSuggestion: (
     suggestion: TaskSuggestion,
     mode: TaskSuggestionAcceptMode,
@@ -191,7 +191,7 @@ export function createSessionContext(
       },
     },
     initialUserMessage: createInitialUserMessageHandoff(),
-    browserAnnotationHandoff: createBrowserAnnotationHandoff(),
+    chatAttachmentHandoff: createChatAttachmentHandoff(),
     nativeChatDrafts: { subscribe: () => () => undefined },
     sessions,
   } as unknown as ApplicationContext;

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -42,6 +42,7 @@ export type TestChatPane = HTMLElement & {
   restoreArchivedSession: (sessionKey: string) => Promise<void>;
   disconnectedCallback: () => void;
   discardStagedAttachments?: () => void;
+  resumeStagedAttachments?: () => void;
   acceptTaskSuggestion: (
     suggestion: TaskSuggestion,
     mode: TaskSuggestionAcceptMode,

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -11,7 +11,7 @@ import type {
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
-import { createBrowserAnnotationHandoff } from "../../app/browser-annotation-handoff.ts";
+import { createChatAttachmentHandoff } from "../../app/chat-attachment-handoff.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
 import { TERMINAL_PANEL_TOGGLE_EVENT } from "../../components/panel-toggle-contract.ts";
@@ -83,7 +83,7 @@ function createInitializationContext(): ApplicationContext {
     agentSelection: { state: { selectedId: "main" } },
     agents: { state: { agentsList: null } },
     initialUserMessage: createInitialUserMessageHandoff(),
-    browserAnnotationHandoff: createBrowserAnnotationHandoff(),
+    chatAttachmentHandoff: createChatAttachmentHandoff(),
     sessions: {},
   } as unknown as ApplicationContext;
 }

--- a/ui/src/pages/chat/chat-state-host.ts
+++ b/ui/src/pages/chat/chat-state-host.ts
@@ -8,7 +8,7 @@ import type {
 import type { ApplicationContext } from "../../app/context.ts";
 import type { UiSettings } from "../../app/settings.ts";
 import type { ImageLightboxItem } from "../../components/image-lightbox.ts";
-import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
+import type { ChatComposerMemoryFallback } from "../../lib/chat/chat-types.ts";
 import type { EmbedSandboxMode } from "../../lib/chat/tool-display.ts";
 import type { ChatState } from "./chat-history.ts";
 import type { ChatRealtimeState } from "./chat-realtime.ts";
@@ -18,7 +18,6 @@ import type { ChatProps } from "./chat-view.ts";
 import type { BackgroundTasksHost } from "./components/chat-background-tasks.ts";
 import type { SessionWorkspaceHost } from "./components/chat-session-workspace.ts";
 import type { SidebarContent } from "./components/chat-sidebar.ts";
-import type { ChatComposerDraftRetry } from "./composer-persistence.ts";
 import type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult } from "./input-history.ts";
 import type { RenderLifecycle } from "./render-lifecycle.ts";
 import type { PendingChatAbort } from "./run-lifecycle.ts";
@@ -32,13 +31,7 @@ import type {
   WaitingApprovalStatus,
 } from "./tool-stream.ts";
 
-export type ChatComposerMemoryFallback = {
-  message: string;
-  attachments: ChatAttachment[];
-  storageFailed: boolean;
-  draftRetry?: ChatComposerDraftRetry;
-  sequence: number;
-};
+export type { ChatComposerMemoryFallback } from "../../lib/chat/chat-types.ts";
 
 export type ChatPageHost = ChatHost &
   ChatState &

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -11,6 +11,7 @@ import type {
   ModelCatalogEntry,
   SessionsListResult,
 } from "../../api/types.ts";
+import { createChatAttachmentHandoff } from "../../app/chat-attachment-handoff.ts";
 import type { ExecApprovalRequest } from "../../app/exec-approval.ts";
 import type { UiSettings } from "../../app/settings.ts";
 import { i18n, t } from "../../i18n/index.ts";
@@ -4455,6 +4456,60 @@ describe("chat attachment picker", () => {
     expect(container.querySelector(".chat-attachment-text-action")?.textContent?.trim()).toBe(
       "Show in text field",
     );
+  });
+
+  it("preserves pasted-text presentation and restore behavior across handoff", () => {
+    let attachments: ChatAttachment[] = [];
+    const producer = renderAttachmentHarness(
+      () => attachments,
+      (next) => {
+        attachments = next;
+      },
+    );
+    const pastedText = `First words from a remounted paste ${"x".repeat(1100)}`;
+    getComposerTextarea(producer).dispatchEvent(createPasteEvent(pastedText));
+    const original = expectDefined(attachments[0], "pasted attachment");
+    const originalDataUrl = getChatAttachmentDataUrl(original);
+
+    const handoff = createChatAttachmentHandoff();
+    const owner = {} as GatewayBrowserClient;
+    handoff.prepare({
+      owner,
+      paneId: "p1",
+      scopeKey: "agent:main:one",
+      attachments,
+    });
+    attachments = expectDefined(
+      handoff.consume({ owner, paneId: "p1", scopeKey: "agent:main:one" }),
+      "restored attachments",
+    );
+
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]).toBe(original);
+    expect(getChatAttachmentDataUrl(original)).toBe(originalDataUrl);
+
+    const onAttachmentsChange = vi.fn();
+    const onDraftChange = vi.fn();
+    const remounted = renderChatView({
+      attachments,
+      getAttachments: () => attachments,
+      draft: "intro",
+      getDraft: () => "intro",
+      onAttachmentsChange,
+      onDraftChange,
+    });
+    expect(remounted.querySelector(".chat-attachment-file__name")?.textContent).toContain(
+      "First words from a r...",
+    );
+    requireElement(
+      remounted,
+      '[aria-label="Show in text field"]',
+      "show pasted text button",
+    ).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(onAttachmentsChange).toHaveBeenCalledWith([]);
+    expect(onDraftChange).toHaveBeenCalledWith(`intro\n\n${pastedText}`);
+    expect(getChatAttachmentDataUrl(original)).toBeNull();
   });
 
   it("keeps large paste previews UTF-16 well-formed at the display boundary", () => {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -4478,11 +4478,12 @@ describe("chat attachment picker", () => {
       paneId: "p1",
       scopeKey: "agent:main:one",
       attachments,
+      fallbacks: {},
     });
     attachments = expectDefined(
       handoff.consume({ owner, paneId: "p1", scopeKey: "agent:main:one" }),
       "restored attachments",
-    );
+    ).attachments;
 
     expect(attachments).toHaveLength(1);
     expect(attachments[0]).toBe(original);

--- a/ui/src/pages/chat/composer-persistence.ts
+++ b/ui/src/pages/chat/composer-persistence.ts
@@ -1,4 +1,8 @@
-import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import type {
+  ChatAttachment,
+  ChatComposerDraftRetry,
+  ChatQueueItem,
+} from "../../lib/chat/chat-types.ts";
 import {
   INTERRUPTED_SETTINGS_WAIT_ERROR,
   MAX_STORED_QUEUE_ITEMS,
@@ -66,10 +70,7 @@ type RestoreOptions = {
   sessionKey?: string;
 };
 
-export type ChatComposerDraftRetry = {
-  expectedDraftRevision: number;
-  draftRevision: number;
-};
+export type { ChatComposerDraftRetry } from "../../lib/chat/chat-types.ts";
 
 type ChatComposerPersistStatus = "persisted" | "conflict" | "storage-failed";
 

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -99,6 +99,7 @@ const nodeDrivenBrowserLayoutTests = [
 const mockRegistryUnitTests = [
   ...uiIsolatedTestFiles.map((testFile) => testFile.slice("ui/".length)),
   "src/components/mcp-app-view.test.ts",
+  "src/pages/chat/chat-page-attachment-handoff.test.ts",
   "src/pages/chat/chat-page.test.ts",
 ] as const;
 const chromiumExecutableOverrideEnvKey = "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH";


### PR DESCRIPTION
Fixes #121519

## What Problem This Solves

Fixes an issue where users staging images, files, pasted images, or large pasted text in the Control UI would silently lose them when the same pane and session remounted after navigation or a narrow split-pane switch, even though their text draft returned.

## Why This Change Was Made

The existing annotation-only same-tab handoff is now the single bounded owner for complete staged attachment packages. It transfers exact attachment objects and pane-local fallback scopes only for the same Gateway client, pane, and composer session, while pane closure, ownership mismatch, application shutdown, and hard reload remain cleanup boundaries. Queue, in-flight send, new-session, protocol, and persistent-storage behavior are unchanged.

## User Impact

Users can navigate away, return to the exact session, or temporarily hide a split pane without reattaching unsent images, files, pasted images, or large pasted text. Existing browser annotation cards, draft text, attachment removal, pasted-text restore, retries, and sends keep their current behavior.

## Evidence

- A pre-fix Testbox regression reproduced the bug by returning only the annotation from a mixed package; the repaired owner returns every exact attachment object once.
- Focused coverage exercises active and fallback session scopes, replacement prepares, owner/session mismatches, pane close and ID reuse, delayed MCP teardown rebound, Gateway replacement, late disconnect after disposal, pasted-text identity, annotation compatibility, and payload cleanup.
- Blacksmith Testbox changed-surface gates, UI typechecks/lint, dead-export/max-lines/docs/changelog guards, and the production Control UI build/performance budgets pass.
- In isolated OCM/Computer Use proof, a selected image, Markdown file, pasted image, and large pasted-text package survived exact-session route return and narrow split-pane remount. Hard reload preserved the draft but restored no staged package.
- The rendered real send contained two images and two files; the real provider confirmed the pasted-text sentinel.
- Auto-review and fresh independent Workloop review found no blocking defect on the final tree.
