### PR TITLE
fix(agents): acknowledge rejected/refused mutating tool outcomes

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -860,6 +860,25 @@ describe("buildEmbeddedRunPayloads", () => {
     expectSinglePayloadSummary(payloads, { text });
   });
 
+  it.each([
+    "The sub-issue API rejected the link so each body carries a Related pointer instead.",
+    "The API refused the update, so I left the existing body unchanged.",
+    "GitHub denied the request to create the issue.",
+    "The update was rejected by the remote API.",
+  ])("suppresses write warnings when reply uses rejection vocabulary: %s", (text) => {
+    const payloads = buildPayloads({
+      assistantTexts: [text],
+      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
+      lastToolError: {
+        toolName: "write",
+        error: "HTTP 422: Validation Failed",
+        mutatingAction: true,
+      },
+    });
+
+    expectSinglePayloadSummary(payloads, { text });
+  });
+
   it("does not treat session_status read failures as mutating when explicitly flagged", () => {
     const payloads = buildPayloads({
       assistantTexts: ["Status loaded."],

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -879,6 +879,27 @@ describe("buildEmbeddedRunPayloads", () => {
     expectSinglePayloadSummary(payloads, { text });
   });
 
+  it.each([
+    "The update was not rejected; it succeeded.",
+    "The API was never refused; the write completed cleanly.",
+    "The request was not denied by GitHub.",
+  ])("keeps write warnings when reply only negates rejection vocabulary: %s", (text) => {
+    const payloads = buildPayloads({
+      assistantTexts: [text],
+      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
+      lastToolError: {
+        toolName: "write",
+        error: "HTTP 422: Validation Failed",
+        mutatingAction: true,
+      },
+    });
+
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]?.text).toBe(text);
+    expect(payloads[1]?.isError).toBe(true);
+    expect(payloads[1]?.text).toContain("Write");
+  });
+
   it("does not treat session_status read failures as mutating when explicitly flagged", () => {
     const payloads = buildPayloads({
       assistantTexts: ["Status loaded."],

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -900,6 +900,21 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[1]?.text).toContain("Write");
   });
 
+  it("suppresses write warnings when a later genuine failure follows negated success", () => {
+    const text = "The first attempt was not rejected. The second write failed.";
+    const payloads = buildPayloads({
+      assistantTexts: [text],
+      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
+      lastToolError: {
+        toolName: "write",
+        error: "HTTP 422: Validation Failed",
+        mutatingAction: true,
+      },
+    });
+
+    expectSinglePayloadSummary(payloads, { text });
+  });
+
   it("does not treat session_status read failures as mutating when explicitly flagged", () => {
     const payloads = buildPayloads({
       assistantTexts: ["Status loaded."],

--- a/src/agents/embedded-agent-runner/run/tool-failure-acknowledgement.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-failure-acknowledgement.test.ts
@@ -1,0 +1,31 @@
+// Regression coverage for mutating-tool failure acknowledgement vocabulary (#110153).
+import { describe, expect, it } from "vitest";
+import { hasExplicitMutatingToolFailureAcknowledgement } from "./tool-failure-acknowledgement.js";
+
+describe("hasExplicitMutatingToolFailureAcknowledgement", () => {
+  it.each([
+    "I couldn't update the file, so no changes were applied.",
+    "I couldn't run the command because python was not found.",
+    "The write failed with a permission error.",
+    "Command failed while applying the patch.",
+    "The sub-issue API rejected the link so each body carries a Related pointer instead.",
+    "The API refused the update, so I left the existing body unchanged.",
+    "GitHub denied the request to create the issue.",
+    "The shell command was blocked by the approval policy.",
+    "The outbound message bounced, so nothing was delivered.",
+    "The update was rejected by the remote API.",
+  ])("acknowledges truthful negative outcome: %s", (text) => {
+    expect(hasExplicitMutatingToolFailureAcknowledgement(text)).toBe(true);
+  });
+
+  it.each([
+    "No issues found. The update is complete.",
+    "I did not find any issues in the file. The update is complete.",
+    "I did not need to update the file; it is already correct.",
+    "There were no failures during the write path.",
+    "The command did not fail; it completed with exit 0.",
+    "Status loaded.",
+  ])("does not treat non-failure phrasing as acknowledgement: %s", (text) => {
+    expect(hasExplicitMutatingToolFailureAcknowledgement(text)).toBe(false);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/tool-failure-acknowledgement.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-failure-acknowledgement.test.ts
@@ -14,6 +14,9 @@ describe("hasExplicitMutatingToolFailureAcknowledgement", () => {
     "The shell command was blocked by the approval policy.",
     "The outbound message bounced, so nothing was delivered.",
     "The update was rejected by the remote API.",
+    // Negated success then genuine later failure must still acknowledge.
+    "The first attempt was not rejected. The second write failed.",
+    "The API was never refused on try one, but the final request failed.",
   ])("acknowledges truthful negative outcome: %s", (text) => {
     expect(hasExplicitMutatingToolFailureAcknowledgement(text)).toBe(true);
   });
@@ -25,7 +28,6 @@ describe("hasExplicitMutatingToolFailureAcknowledgement", () => {
     "There were no failures during the write path.",
     "The command did not fail; it completed with exit 0.",
     "Status loaded.",
-    // Negated success must not suppress integrity warnings (Claw P1 on #121579).
     "The update was not rejected; it succeeded.",
     "The API was never refused; the write completed cleanly.",
     "The request was not denied by GitHub.",

--- a/src/agents/embedded-agent-runner/run/tool-failure-acknowledgement.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-failure-acknowledgement.test.ts
@@ -25,7 +25,14 @@ describe("hasExplicitMutatingToolFailureAcknowledgement", () => {
     "There were no failures during the write path.",
     "The command did not fail; it completed with exit 0.",
     "Status loaded.",
-  ])("does not treat non-failure phrasing as acknowledgement: %s", (text) => {
+    // Negated success must not suppress integrity warnings (Claw P1 on #121579).
+    "The update was not rejected; it succeeded.",
+    "The API was never refused; the write completed cleanly.",
+    "The request was not denied by GitHub.",
+    "The command was not blocked by the approval policy.",
+    "The message was not bounced.",
+    "There was no rejection from the remote API.",
+  ])("does not treat non-failure or negated-success phrasing as acknowledgement: %s", (text) => {
     expect(hasExplicitMutatingToolFailureAcknowledgement(text)).toBe(false);
   });
 });

--- a/src/agents/embedded-agent-runner/run/tool-failure-acknowledgement.ts
+++ b/src/agents/embedded-agent-runner/run/tool-failure-acknowledgement.ts
@@ -22,30 +22,35 @@ const MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN = new RegExp(
   `\\b(?:hit|encountered|ran into)\\b.{0,60}\\berror\\b.{0,100}\\b(?:while|trying to|when)\\b.{0,100}\\b${MUTATING_FAILURE_ACTION_PATTERN}\\b`,
   "u",
 );
-// Passive forms near an action noun: "the update was rejected", "request was refused".
-const MUTATING_FAILURE_PASSIVE_NEAR_ACTION_PATTERN = new RegExp(
-  `\\b${MUTATING_FAILURE_ACTION_PATTERN}\\b.{0,40}\\b(?:was|were|got)\\s+${MUTATING_FAILURE_OUTCOME_PATTERN}\\b|\\b(?:was|were|got)\\s+${MUTATING_FAILURE_OUTCOME_PATTERN}\\b.{0,40}\\b${MUTATING_FAILURE_ACTION_PATTERN}\\b`,
-  "u",
-);
+// Successful statements that must not count as failure acknowledgement
+// ("the update was not rejected", "never refused", "no denial", etc.).
 const DID_NOT_FAIL_PATTERN = /\b(?:did not|didn't)\s+fail\b/u;
 const NEGATED_FAILURE_PATTERN = /\b(?:no|not|without)\s+(?:failures?|errors?)\b/u;
+const NEGATED_OUTCOME_PATTERN = new RegExp(
+  `\\b(?:did not|didn't|does not|doesn't|was not|wasn't|were not|weren't|is not|isn't|are not|aren't|not|never|no|without)\\s+(?:been\\s+)?${MUTATING_FAILURE_OUTCOME_PATTERN}\\b|\\b(?:no|without)\\s+(?:rejection|refusal|denial|block(?:age)?|bounce)\\b`,
+  "u",
+);
 
 /** Detect a user-visible acknowledgement that a mutating action did not complete. */
 export function hasExplicitMutatingToolFailureAcknowledgement(text: string): boolean {
   const normalizedText = normalizeTextForComparison(text);
-  if (!normalizedText || DID_NOT_FAIL_PATTERN.test(normalizedText)) {
+  if (!normalizedText) {
+    return false;
+  }
+  // Negated success phrasing must win before positive outcome matching.
+  if (
+    DID_NOT_FAIL_PATTERN.test(normalizedText) ||
+    NEGATED_FAILURE_PATTERN.test(normalizedText) ||
+    NEGATED_OUTCOME_PATTERN.test(normalizedText)
+  ) {
     return false;
   }
   if (MUTATING_FAILURE_INABILITY_PATTERN.test(normalizedText)) {
     return true;
   }
-  if (NEGATED_FAILURE_PATTERN.test(normalizedText)) {
-    return false;
-  }
   return (
     MUTATING_FAILURE_ACTION_THEN_FAILURE_PATTERN.test(normalizedText) ||
     MUTATING_FAILURE_FAILURE_THEN_ACTION_PATTERN.test(normalizedText) ||
-    MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN.test(normalizedText) ||
-    MUTATING_FAILURE_PASSIVE_NEAR_ACTION_PATTERN.test(normalizedText)
+    MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN.test(normalizedText)
   );
 }

--- a/src/agents/embedded-agent-runner/run/tool-failure-acknowledgement.ts
+++ b/src/agents/embedded-agent-runner/run/tool-failure-acknowledgement.ts
@@ -1,21 +1,30 @@
 import { normalizeTextForComparison } from "../../embedded-agent-helpers.js";
 
 const MUTATING_FAILURE_ACTION_PATTERN =
-  "(?:write|edit|update|save|create|delete|remove|modify|change|apply|patch|move|rename|send|reply|message|run|execute|execution|command|script|shell|bash|exec|tool|action|operation)";
+  "(?:write|edit|update|save|create|delete|remove|modify|change|apply|patch|move|rename|send|reply|message|run|execute|execution|command|script|shell|bash|exec|tool|action|operation|request|call|api|link)";
+// Truthful negative outcomes models use when describing a failed mutation
+// without the words "failed"/"failure" (see openclaw/openclaw#110153).
+const MUTATING_FAILURE_OUTCOME_PATTERN =
+  "(?:failed|failure|errored|rejected|refused|denied|blocked|bounced)";
 const MUTATING_FAILURE_INABILITY_PATTERN = new RegExp(
   `\\b(?:couldn't|could not|can't|cannot|unable to|am unable to|wasn't able to|was not able to|were unable to)\\b.{0,100}\\b${MUTATING_FAILURE_ACTION_PATTERN}\\b`,
   "u",
 );
 const MUTATING_FAILURE_ACTION_THEN_FAILURE_PATTERN = new RegExp(
-  `\\b${MUTATING_FAILURE_ACTION_PATTERN}\\b.{0,100}\\b(?:failed|failure|errored)\\b`,
+  `\\b${MUTATING_FAILURE_ACTION_PATTERN}\\b.{0,100}\\b${MUTATING_FAILURE_OUTCOME_PATTERN}\\b`,
   "u",
 );
 const MUTATING_FAILURE_FAILURE_THEN_ACTION_PATTERN = new RegExp(
-  `\\b(?:failed|failure)\\b.{0,100}\\b${MUTATING_FAILURE_ACTION_PATTERN}\\b`,
+  `\\b${MUTATING_FAILURE_OUTCOME_PATTERN}\\b.{0,100}\\b${MUTATING_FAILURE_ACTION_PATTERN}\\b`,
   "u",
 );
 const MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN = new RegExp(
   `\\b(?:hit|encountered|ran into)\\b.{0,60}\\berror\\b.{0,100}\\b(?:while|trying to|when)\\b.{0,100}\\b${MUTATING_FAILURE_ACTION_PATTERN}\\b`,
+  "u",
+);
+// Passive forms near an action noun: "the update was rejected", "request was refused".
+const MUTATING_FAILURE_PASSIVE_NEAR_ACTION_PATTERN = new RegExp(
+  `\\b${MUTATING_FAILURE_ACTION_PATTERN}\\b.{0,40}\\b(?:was|were|got)\\s+${MUTATING_FAILURE_OUTCOME_PATTERN}\\b|\\b(?:was|were|got)\\s+${MUTATING_FAILURE_OUTCOME_PATTERN}\\b.{0,40}\\b${MUTATING_FAILURE_ACTION_PATTERN}\\b`,
   "u",
 );
 const DID_NOT_FAIL_PATTERN = /\b(?:did not|didn't)\s+fail\b/u;
@@ -36,6 +45,7 @@ export function hasExplicitMutatingToolFailureAcknowledgement(text: string): boo
   return (
     MUTATING_FAILURE_ACTION_THEN_FAILURE_PATTERN.test(normalizedText) ||
     MUTATING_FAILURE_FAILURE_THEN_ACTION_PATTERN.test(normalizedText) ||
-    MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN.test(normalizedText)
+    MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN.test(normalizedText) ||
+    MUTATING_FAILURE_PASSIVE_NEAR_ACTION_PATTERN.test(normalizedText)
   );
 }

--- a/src/agents/embedded-agent-runner/run/tool-failure-acknowledgement.ts
+++ b/src/agents/embedded-agent-runner/run/tool-failure-acknowledgement.ts
@@ -22,13 +22,12 @@ const MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN = new RegExp(
   `\\b(?:hit|encountered|ran into)\\b.{0,60}\\berror\\b.{0,100}\\b(?:while|trying to|when)\\b.{0,100}\\b${MUTATING_FAILURE_ACTION_PATTERN}\\b`,
   "u",
 );
-// Successful statements that must not count as failure acknowledgement
-// ("the update was not rejected", "never refused", "no denial", etc.).
 const DID_NOT_FAIL_PATTERN = /\b(?:did not|didn't)\s+fail\b/u;
 const NEGATED_FAILURE_PATTERN = /\b(?:no|not|without)\s+(?:failures?|errors?)\b/u;
-const NEGATED_OUTCOME_PATTERN = new RegExp(
-  `\\b(?:did not|didn't|does not|doesn't|was not|wasn't|were not|weren't|is not|isn't|are not|aren't|not|never|no|without)\\s+(?:been\\s+)?${MUTATING_FAILURE_OUTCOME_PATTERN}\\b|\\b(?:no|without)\\s+(?:rejection|refusal|denial|block(?:age)?|bounce)\\b`,
-  "u",
+// Strip successful "not rejected" phrasing so a later real failure can still match.
+const NEGATED_OUTCOME_PHRASE_PATTERN = new RegExp(
+  `\\b(?:did not|didn't|does not|doesn't|was not|wasn't|were not|weren't|is not|isn't|are not|aren't|not|never)\\s+(?:been\\s+)?${MUTATING_FAILURE_OUTCOME_PATTERN}\\b|\\b(?:no|without)\\s+(?:rejection|refusal|denial|block(?:age)?|bounce)\\b`,
+  "gu",
 );
 
 /** Detect a user-visible acknowledgement that a mutating action did not complete. */
@@ -37,20 +36,23 @@ export function hasExplicitMutatingToolFailureAcknowledgement(text: string): boo
   if (!normalizedText) {
     return false;
   }
-  // Negated success phrasing must win before positive outcome matching.
-  if (
-    DID_NOT_FAIL_PATTERN.test(normalizedText) ||
-    NEGATED_FAILURE_PATTERN.test(normalizedText) ||
-    NEGATED_OUTCOME_PATTERN.test(normalizedText)
-  ) {
+  if (DID_NOT_FAIL_PATTERN.test(normalizedText) || NEGATED_FAILURE_PATTERN.test(normalizedText)) {
     return false;
   }
-  if (MUTATING_FAILURE_INABILITY_PATTERN.test(normalizedText)) {
+  // Remove negated success phrases only; keep later genuine failure wording.
+  const withoutNegatedOutcomes = normalizedText
+    .replace(NEGATED_OUTCOME_PHRASE_PATTERN, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!withoutNegatedOutcomes) {
+    return false;
+  }
+  if (MUTATING_FAILURE_INABILITY_PATTERN.test(withoutNegatedOutcomes)) {
     return true;
   }
   return (
-    MUTATING_FAILURE_ACTION_THEN_FAILURE_PATTERN.test(normalizedText) ||
-    MUTATING_FAILURE_FAILURE_THEN_ACTION_PATTERN.test(normalizedText) ||
-    MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN.test(normalizedText)
+    MUTATING_FAILURE_ACTION_THEN_FAILURE_PATTERN.test(withoutNegatedOutcomes) ||
+    MUTATING_FAILURE_FAILURE_THEN_ACTION_PATTERN.test(withoutNegatedOutcomes) ||
+    MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN.test(withoutNegatedOutcomes)
   );
 }


### PR DESCRIPTION
## What Problem This Solves

After a mutating tool fails, the gateway posts a channel warning unless the assistant reply already acknowledges the failure. The acknowledgement matcher only recognized inability phrasing (could not / unable to) and the verbs failed / failure / errored. Truthful replies such as "The sub-issue API rejected the link..." still left the mutating failure unresolved, so a duplicate tool-error warning was posted even though the user already saw an accurate negative outcome. That trains people to ignore the integrity backstop.

A follow-up also fixed negation handling: short-circuiting on any "not rejected" phrase dropped later genuine failures ("was not rejected. The second write failed."). The tip strips negated outcome phrases and re-scans so compound replies still acknowledge.

## Evidence

Production matcher import on tip (rebased, shared-CI files removed; product files only). macOS, Node v26.5.1, worktree `/tmp/oc-fix-121579`.

```console
=== production hasExplicitMutatingToolFailureAcknowledgement ===
commit: 0de88fc0d52
OK want=ACK got=ACK :: The sub-issue API rejected the link so each body carries a Related pointer instead.
OK want=ACK got=ACK :: The API refused the update, so I left the existing body unchanged.
OK want=ACK got=ACK :: GitHub denied the request to create the issue.
OK want=NO got=NO :: No issues found. The update is complete.
OK want=NO got=NO :: There were no failures during the write path.
OK want=ACK got=ACK :: The first attempt was not rejected. The second write failed.
OK want=NO got=NO :: The update was not rejected; it succeeded.
PROOF_ACK_PRODUCTION_OK
```

Scope: only `tool-failure-acknowledgement` (+ tests). Shared main reds live on #121659 only.


## Real behavior proof

- **Behavior or issue addressed:** extend mutating-tool failure acknowledgement to truthful negative outcomes (rejected, refused, denied) and strip negated outcome phrases so later real failures still acknowledge; do not treat "no failures" or pure negated-success phrasing as acknowledgement.
- **Real environment tested:** macOS, Node v26.5.1, OpenClaw worktree `/tmp/oc-fix-121579` at commit shown in terminal output (after dropping unrelated shared-CI commits).
- **Exact steps or command run after this patch:** imported production `hasExplicitMutatingToolFailureAcknowledgement` via `node --import tsx` and classified fixed strings.
- **Evidence after fix:** terminal output under Evidence (production module, not a mirrored harness copy).
- **Observed result after fix:** rejection vocabulary is ACK; pure success and "no failures" remain NO; compound "was not rejected. The second write failed." is ACK after strip.
- **What was not tested:** live Slack/Discord channel end-to-end with a real gateway session.


## Summary

Matches ClawSweeper remainder for #110153 after #115737: leave completed-exit classification alone; only broaden the acknowledgement matcher with narrow regressions, plus negation strip so compound replies still ack.

Closes #110153

