### PR TITLE
fix(delivery): preserve post-send queue evidence

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test-harness.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test-harness.ts
@@ -412,7 +412,11 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
               cfg,
               dispatcherOptions: {
                 ...plan.dispatcherOptions,
-                deliver: (delivery.deliverWithProviderMessageSending ?? delivery.deliver)!,
+                deliver: (payload, info) =>
+                  delivery.deliverWithProviderMessageSending(payload, {
+                    ...info,
+                    onPlatformSendDispatch: info.onPlatformSendDispatch ?? (async () => undefined),
+                  }),
                 onError: delivery.onError,
               },
               toolsAllow: plan.toolsAllow,

--- a/extensions/telegram/src/bot-message-dispatch.delivery-basics.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.delivery-basics.test.ts
@@ -77,7 +77,7 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-basics", () => {
 
     const outbound = expectRecordFields(mockCallArg(deliverInboundReplyWithMessageSendContext), {
       channel: "telegram",
-      to: "123",
+      to: "telegram:123",
       accountId: "default",
       info: { kind: "final" },
       replyToMode: "first",

--- a/extensions/telegram/src/bot-message-dispatch.test-harness.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test-harness.ts
@@ -226,7 +226,11 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
             cfg: resolved.cfg,
             dispatcherOptions: {
               ...resolved.dispatcherOptions,
-              deliver: delivery.deliverWithProviderMessageSending,
+              deliver: (payload, info) =>
+                delivery.deliverWithProviderMessageSending(payload, {
+                  ...info,
+                  onPlatformSendDispatch: info.onPlatformSendDispatch ?? (async () => undefined),
+                }),
               onError: delivery.onError,
             },
             toolsAllow: resolved.toolsAllow,

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -112,11 +112,18 @@ const dispatchChannelInboundTurnMock = vi.fn<DispatchChannelInboundTurnFn>(async
       DispatchReplyWithBufferedBlockDispatcherParams["dispatcherOptions"]["deliver"]
     >[1],
   ) => {
-    const result =
-      "deliverWithProviderMessageSending" in plan.delivery
-        ? await plan.delivery.deliverWithProviderMessageSending(payload, info)
-        : await plan.delivery.deliver(payload, info);
-    await plan.delivery.onDelivered?.(payload, info, result);
+    const delivery = plan.delivery;
+    if ("deliverWithProviderMessageSending" in delivery) {
+      const deliveryInfo = {
+        ...info,
+        onPlatformSendDispatch: info.onPlatformSendDispatch ?? (async () => undefined),
+      };
+      const result = await delivery.deliverWithProviderMessageSending(payload, deliveryInfo);
+      await delivery.onDelivered?.(payload, deliveryInfo, result);
+      return result;
+    }
+    const result = await delivery.deliver(payload, info);
+    await delivery.onDelivered?.(payload, info, result);
     return result;
   };
   const dispatchResult = await replyMocks.dispatchReplyWithBufferedBlockDispatcher({

--- a/extensions/telegram/src/bot-native-commands.test-helpers.ts
+++ b/extensions/telegram/src/bot-native-commands.test-helpers.ts
@@ -90,16 +90,21 @@ const deliveryMocks = vi.hoisted(() => ({
 
 const dispatchChannelInboundTurnForTest: TelegramNativeCommandDeps["dispatchChannelInboundTurn"] =
   async (plan) => {
+    const delivery = plan.delivery;
     const dispatchResult = await replyPipelineMocks.dispatchReplyWithBufferedBlockDispatcher({
       ctx: plan.ctxPayload,
       cfg: plan.cfg,
       dispatcherOptions: {
         ...plan.dispatcherOptions,
         deliver:
-          "deliverWithProviderMessageSending" in plan.delivery
-            ? plan.delivery.deliverWithProviderMessageSending
-            : plan.delivery.deliver,
-        onError: plan.delivery.onError,
+          "deliverWithProviderMessageSending" in delivery
+            ? (payload, info) =>
+                delivery.deliverWithProviderMessageSending(payload, {
+                  ...info,
+                  onPlatformSendDispatch: info.onPlatformSendDispatch ?? (async () => undefined),
+                })
+            : delivery.deliver,
+        onError: delivery.onError,
       },
       replyOptions: plan.replyOptions,
     });

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -584,13 +584,14 @@ export async function markDeliveryPlatformSendDispatched(
     stateDir,
     (entry) => ({
       ...entry,
-      // Dispatch still belongs to the promoted producer until provider I/O
-      // settles; clearing its lease lets another process replay an active send.
+      // Dispatch still belongs to the promoted producer until provider I/O settles;
+      // clearing its lease or send evidence lets another process replay a sent payload.
       availableAt: expectedPlatformSendAttemptId ? entry.availableAt : undefined,
       producerClaimId: undefined,
       platformSendStartedAt: Date.now(),
       ...(route && "replyToId" in route ? { effectiveReplyToId: route.replyToId ?? null } : {}),
-      recoveryState: "send_attempt_started",
+      recoveryState:
+        entry.recoveryState === "unknown_after_send" ? entry.recoveryState : "send_attempt_started",
     }),
     expectedPlatformSendAttemptId,
   );

--- a/src/infra/outbound/delivery-queue.storage.test.ts
+++ b/src/infra/outbound/delivery-queue.storage.test.ts
@@ -547,6 +547,30 @@ describe("delivery-queue storage", () => {
       expect(entry.recoveryState).toBe("send_attempt_started");
     });
 
+    it("refreshes a later dispatch without downgrading post-send evidence", async () => {
+      const id = await enqueueTextDelivery({
+        channel: "forum",
+        to: "123",
+        payloads: [{ text: "first" }, { text: "second" }],
+      });
+
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(1_000);
+        await markDeliveryPlatformSendDispatched(id, tmpDir());
+        await markDeliveryPlatformOutcomeUnknown(id, tmpDir());
+        vi.setSystemTime(9_000);
+        await markDeliveryPlatformSendDispatched(id, tmpDir());
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(readQueuedEntry(tmpDir(), id)).toMatchObject({
+        platformSendStartedAt: 9_000,
+        recoveryState: "unknown_after_send",
+      });
+    });
+
     it("increments retryCount, records attempt time, and sets lastError", async () => {
       const id = await enqueueTextDelivery(
         {


### PR DESCRIPTION
## Summary

- preserve `unknown_after_send` when a later payload refreshes the same durable delivery's dispatch timestamp
- keep every provider dispatch fenced while preventing earlier send evidence from being downgraded
- update Discord and Telegram test harnesses to satisfy the provider-owned dispatch callback contract

## Root cause

The provider delivery path now calls `onPlatformSendDispatch` before every payload in a batch. After the first payload recorded an ambiguous post-send outcome, the next dispatch unconditionally rewrote the durable row from `unknown_after_send` to `send_attempt_started`. That made a partially sent stable intent replayable after failure. The same provider-owned contract also exposed four stale test harnesses that passed generic dispatcher info directly into the stricter provider callback.

The storage owner now treats post-send evidence as monotonic while still validating the exact claim and refreshing its timestamp for each later provider I/O. Test harnesses enrich provider delivery info with the same no-op callback used by sibling harnesses when no durable queue is present.

## Proof

- Blacksmith Testbox `tbx_01kznr9xjjf22af1gd5brrbt1p`, run https://github.com/openclaw/openclaw/actions/runs/31385473186
- pre-fix focused storage regression: failed 1/29, expected `unknown_after_send`, received `send_attempt_started`
- post-fix queue storage + original integration regressions: 59/59 passed
- Discord message-handler representative suite: 39/39 passed
- Telegram message-dispatch and native-command suites: 86/86 passed
- `pnpm check:test-types`: passed
- `pnpm check:changed`: passed
- autoreview: no accepted actionable findings

Production LOC: +4/-3 (net +1, the monotonic state transition)  
Tests: +25/-1  
Test support: +31/-11

No changelog entry: this repairs an unreleased main-branch regression and its test harnesses.
