### PR TITLE
fix(agents): surface Claude CLI no-response failures

### DIFF
--- a/src/agents/cli-output-contracts.ts
+++ b/src/agents/cli-output-contracts.ts
@@ -26,10 +26,12 @@ type CliProcessDiagnostics = {
   useResume: boolean;
 };
 
-export type CliTerminalFailure = {
-  reason: "max_turns";
-  limit?: number;
-};
+export type CliTerminalFailure =
+  | {
+      reason: "max_turns";
+      limit?: number;
+    }
+  | { reason: "synthetic_no_response" };
 
 /** Normalized result from a CLI-backed model provider turn. */
 export type CliOutput = {

--- a/src/agents/cli-output-stream.test.ts
+++ b/src/agents/cli-output-stream.test.ts
@@ -98,6 +98,17 @@ function claudeTextDelta(text: string, index?: number | string) {
   });
 }
 
+function claudeSyntheticNoResponse(text = "No response requested.") {
+  return {
+    type: "assistant",
+    message: {
+      model: "<synthetic>",
+      role: "assistant",
+      content: [{ type: "text", text }],
+    },
+  };
+}
+
 describe("createCliJsonlStreamingParser", () => {
   it.each(OPENAI_COMPATIBLE_CLI_USAGE_CASES)(
     "normalizes $name while incrementally streaming CLI JSONL",
@@ -168,6 +179,100 @@ describe("createCliJsonlStreamingParser", () => {
       { text: "hello", delta: "hello", sessionId: "session-stream", usage: undefined },
     ]);
     expect(sessionIds).toEqual(["session-stream"]);
+  });
+
+  it("records Claude's exact synthetic empty terminal as a failure", () => {
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "claude",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => {},
+    });
+
+    parser.push(
+      joinJsonlFrames(
+        claudeSyntheticNoResponse(),
+        { type: "result", subtype: "success", session_id: "synthetic-empty", result: "" },
+        "",
+      ),
+    );
+    parser.finish();
+
+    expect(parser.getOutput()).toEqual({
+      text: "",
+      sessionId: "synthetic-empty",
+      usage: undefined,
+      errorText: "Claude CLI returned a synthetic no-response result.",
+      terminalFailure: { reason: "synthetic_no_response" },
+    });
+  });
+
+  it.each([
+    {
+      name: "ordinary lookalike",
+      frames: [
+        {
+          ...claudeSyntheticNoResponse(),
+          message: { ...claudeSyntheticNoResponse().message, model: "claude-sonnet-4-6" },
+        },
+      ],
+      expectedText: "",
+    },
+    {
+      name: "different synthetic text",
+      frames: [claudeSyntheticNoResponse("No reply needed.")],
+      expectedText: "",
+    },
+    {
+      name: "real text",
+      frames: [claudeSyntheticNoResponse(), claudeTextDelta("real answer")],
+      expectedText: "real answer",
+    },
+    {
+      name: "tool activity",
+      frames: [
+        {
+          type: "assistant",
+          message: {
+            model: "claude-sonnet-4-6",
+            role: "assistant",
+            content: [{ type: "tool_use", id: "tool-1", name: "Read", input: {} }],
+          },
+        },
+        claudeSyntheticNoResponse(),
+      ],
+      expectedText: "",
+    },
+  ])("does not classify $name as a synthetic empty terminal", ({ frames, expectedText }) => {
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "claude",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => {},
+    });
+
+    parser.push(
+      joinJsonlFrames(
+        ...frames,
+        { type: "result", subtype: "success", session_id: "not-synthetic", result: "" },
+        "",
+      ),
+    );
+    parser.finish();
+
+    expect(parser.getOutput()).toEqual({
+      text: expectedText,
+      sessionId: "not-synthetic",
+      usage: undefined,
+    });
   });
 
   it.each([

--- a/src/agents/cli-output-stream.ts
+++ b/src/agents/cli-output-stream.ts
@@ -48,12 +48,29 @@ export const CLI_STREAM_JSON_DEFAULT_MAX_TURN_RAW_CHARS = 8 * 1024 * 1024;
 const CLI_STREAM_JSON_DEFAULT_MAX_TURN_LINES = 20_000;
 export const CLI_STREAM_JSON_MISSING_RESULT_ERROR =
   "CLI stream-json output ended without a result event.";
+const CLAUDE_SYNTHETIC_NO_RESPONSE_ERROR = "Claude CLI returned a synthetic no-response result.";
 
 export const CLI_STREAM_JSON_OUTPUT_LIMITS = Object.freeze({
   maxTurnRawChars: CLI_STREAM_JSON_DEFAULT_MAX_TURN_RAW_CHARS,
   maxPendingLineChars: CLI_STREAM_JSON_DEFAULT_MAX_TURN_RAW_CHARS,
   maxTurnLines: CLI_STREAM_JSON_DEFAULT_MAX_TURN_LINES,
 } satisfies CliStreamJsonOutputLimits);
+
+function isClaudeSyntheticNoResponse(parsed: Record<string, unknown>): boolean {
+  if (parsed.type !== "assistant" || !isRecord(parsed.message)) {
+    return false;
+  }
+  const message = parsed.message;
+  if (message.model !== "<synthetic>" || !Array.isArray(message.content)) {
+    return false;
+  }
+  return (
+    message.content.length === 1 &&
+    isRecord(message.content[0]) &&
+    message.content[0].type === "text" &&
+    message.content[0].text === "No response requested."
+  );
+}
 
 /** Frames arbitrary stdout chunks while bounding each individual raw JSONL line. */
 export function frameBoundedCliJsonlChunk(
@@ -158,6 +175,7 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
   let sawCustomJsonlEvent = false;
   let sawGeminiStructuredOutput = false;
   let sawTerminalResult = false;
+  let sawClaudeSyntheticNoResponse = false;
   const toolTracker = createToolUseTracker();
   const outputLimits = CLI_STREAM_JSON_OUTPUT_LIMITS;
   // Classification is keyed on consumer presence so reclassified pre-tool text
@@ -353,6 +371,9 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
     if (parsed.type === "assistant" && isRecord(parsed.message)) {
       resumeCheckpointId = pickCliResumeCheckpointId({ ...params, parsed }) ?? resumeCheckpointId;
       params.onAssistantMessage?.(parsed.message);
+      if (claudeStreamJson && isClaudeSyntheticNoResponse(parsed)) {
+        sawClaudeSyntheticNoResponse = true;
+      }
     }
     const geminiErrorText = isGeminiStreamJsonDialect(params)
       ? readGeminiCliStreamJsonError(parsed)
@@ -436,9 +457,22 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
       } else if (!nextText) {
         text = previousText;
       }
+      const syntheticNoResponse =
+        sawClaudeSyntheticNoResponse &&
+        parsed.subtype === "success" &&
+        !text &&
+        toolTracker.pendingByIndex.size === 0 &&
+        toolTracker.startedIds.size === 0 &&
+        toolTracker.resultDeliveredIds.size === 0;
       output = {
         ...result,
         text,
+        ...(syntheticNoResponse
+          ? {
+              errorText: CLAUDE_SYNTHETIC_NO_RESPONSE_ERROR,
+              terminalFailure: { reason: "synthetic_no_response" as const },
+            }
+          : {}),
         ...(resumeCheckpointId ? { resumeCheckpointId } : {}),
         ...(diagnosticUsage ? { diagnosticUsage } : {}),
       };
@@ -512,6 +546,8 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
         onToolUseStart: params.onToolUseStart,
         onToolResult: params.onToolResult,
       });
+    }
+    if (claudeStreamJson || params.onToolUseStart || params.onToolResult) {
       dispatchClaudeCliStreamingToolEvent({
         backend: params.backend,
         providerId: params.providerId,

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -2405,7 +2405,7 @@ describe("runCliAgent reliability", () => {
     expect(clearBeforeRetry).not.toHaveBeenCalled();
   });
 
-  it.each(["timeout", "unknown", "context_overflow"] as const)(
+  it.each(["timeout", "unknown", "context_overflow", "format"] as const)(
     "retries a fresh CLI session after recoverable %s failover without a failed agent_end",
     async (reason) => {
       const runId = `run-retry-${reason}`;
@@ -2457,10 +2457,29 @@ describe("runCliAgent reliability", () => {
             stderr: "Prompt is too long",
           });
         }
+        if (spawnCount === 1 && reason === "format") {
+          return makeManagedRun({
+            stdout: [
+              JSON.stringify({
+                type: "assistant",
+                message: {
+                  model: "<synthetic>",
+                  content: [{ type: "text", text: "No response requested." }],
+                },
+              }),
+              JSON.stringify({ type: "result", subtype: "success", result: "" }),
+            ].join("\n"),
+          });
+        }
         if (spawnCount === 1) {
           return makeManagedRun({
             exitCode: 1,
             durationMs: 150,
+          });
+        }
+        if (reason === "format") {
+          return makeManagedRun({
+            stdout: JSON.stringify({ type: "result", result: "hello from fresh cli" }),
           });
         }
         return makeManagedRun({ stdout: "hello from fresh cli" });
@@ -2480,6 +2499,15 @@ describe("runCliAgent reliability", () => {
           cliSessionId: "stale-cli-session",
           openClawHistoryPrompt: CLI_RESEED_PROMPT,
         });
+        if (reason === "format") {
+          context.preparedBackend.backend = {
+            ...context.preparedBackend.backend,
+            output: "jsonl",
+            input: "stdin",
+            jsonlDialect: "claude-stream-json",
+          };
+          context.backendResolved.config = context.preparedBackend.backend;
+        }
         const result = await runPreparedCliAgent({
           ...context,
           params: {

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -363,6 +363,54 @@ describe("runCliAgent spawn path", () => {
     );
   });
 
+  it("surfaces a node-placed Claude synthetic empty terminal through the shared parser", async () => {
+    const invokeNode = vi.fn(async (params: Parameters<typeof invokeNodeClaudeCliRun>[0]) => {
+      params.onProgress(
+        [
+          JSON.stringify({
+            type: "assistant",
+            message: {
+              model: "<synthetic>",
+              role: "assistant",
+              content: [{ type: "text", text: "No response requested." }],
+            },
+          }),
+          JSON.stringify({
+            type: "result",
+            subtype: "success",
+            session_id: "node-synthetic-empty",
+            result: "",
+          }),
+          "",
+        ].join("\n"),
+      );
+      return {
+        ok: true,
+        payloadJSON: JSON.stringify({ exitCode: 0, stderrTail: "", truncated: false }),
+      };
+    });
+    setCliRunnerExecuteTestDeps({ invokeNodeClaudeCliRun: invokeNode });
+    const context = buildClaudeLiveRunContext({
+      model: "claude-opus-4-8",
+      runId: "run-node-synthetic-empty",
+      prompt: "current turn",
+      sessionEntry: {
+        sessionId: "openclaw-session",
+        updatedAt: 1,
+        execHost: "node",
+        execNode: "node-a",
+      },
+    });
+
+    await expect(executePreparedCliRun(context)).rejects.toMatchObject({
+      name: "FailoverError",
+      reason: "format",
+      code: "cli_synthetic_no_response",
+    });
+    expect(invokeNode).toHaveBeenCalledOnce();
+    expect(supervisorSpawnMock).not.toHaveBeenCalled();
+  });
+
   it("rejects a truncated node stream that lost the terminal result", async () => {
     const invokeNode = vi.fn(async (params: Parameters<typeof invokeNodeClaudeCliRun>[0]) => {
       params.onProgress(

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -197,6 +197,8 @@ function shouldRetryFreshCliSessionAfterFailover(params: {
       return params.error.code === "cli_unknown_empty_failure";
     case "empty_response":
       return params.error.code === "cli_unknown_empty_failure";
+    case "format":
+      return params.error.code === "cli_synthetic_no_response";
     case "timeout":
       return params.error.code === "cli_no_output_timeout";
     case "context_overflow":

--- a/src/agents/cli-runner/claude-live-session.background-tasks.test.ts
+++ b/src/agents/cli-runner/claude-live-session.background-tasks.test.ts
@@ -597,69 +597,49 @@ describe("claude live session provisional results", () => {
     expect(driver.cancel).not.toHaveBeenCalled();
   });
 
-  it("does not defer ordinary or non-empty results that resemble a synthetic placeholder", async () => {
-    const ordinaryDriver = installLiveStdoutDriver({
-      onWrite: (stdout) => {
-        stdout(
-          jsonl([
-            { type: "system", subtype: "init", session_id: "live-ordinary-placeholder" },
-            {
-              type: "assistant",
-              session_id: "live-ordinary-placeholder",
-              message: {
-                model: "claude-fable-5",
-                role: "assistant",
-                content: [{ type: "text", text: "No response requested." }],
-              },
-            },
-            {
-              type: "result",
-              subtype: "success",
-              session_id: "live-ordinary-placeholder",
-              result: "",
-            },
-          ]),
-        );
-      },
-    });
-    const ordinary = await startLiveTurn({ runId: "run-ordinary-placeholder" });
-    expect(ordinary.output.text).toBe("");
-    expect(ordinaryDriver.cancel).not.toHaveBeenCalled();
+  it("keeps a synthetic result provisional while background work continues", async () => {
+    const driver = installLiveStdoutDriver({ autoStart: false });
+    const resultPromise = startLiveTurn({ runId: "run-synthetic-background" });
+    await driver.stdout.waitReady();
+    driver.stdout.startCurrentInput();
+    driver.stdout.emit(
+      jsonl([
+        { type: "system", subtype: "init", session_id: "live-synthetic-background" },
+        {
+          type: "system",
+          subtype: "background_tasks_changed",
+          tasks: [{ task_id: "task-1", task_type: "local_agent" }],
+        },
+        {
+          type: "assistant",
+          message: {
+            model: "<synthetic>",
+            content: [{ type: "text", text: "No response requested." }],
+          },
+        },
+        { type: "result", subtype: "success", result: "" },
+      ]),
+    );
+    let settled = false;
+    void resultPromise.then(
+      () => (settled = true),
+      () => (settled = true),
+    );
+    await Promise.resolve();
+    expect(settled).toBe(false);
 
-    resetClaudeLiveSessionsForTest();
-    const nonEmptyDriver = installLiveStdoutDriver({
-      onWrite: (stdout) => {
-        stdout(
-          jsonl([
-            { type: "system", subtype: "init", session_id: "live-synthetic-nonempty" },
-            {
-              type: "assistant",
-              session_id: "live-synthetic-nonempty",
-              message: {
-                model: "<synthetic>",
-                role: "assistant",
-                content: [{ type: "text", text: "No response requested." }],
-              },
-            },
-            {
-              type: "result",
-              subtype: "success",
-              session_id: "live-synthetic-nonempty",
-              result: "real answer",
-            },
-          ]),
-        );
-      },
-    });
-    const nonEmpty = await startLiveTurn({
-      runId: "run-synthetic-nonempty",
-      useResume: true,
-    });
-    expect(nonEmpty.output.text).toBe("real answer");
-    expect(nonEmptyDriver.cancel).not.toHaveBeenCalled();
+    driver.stdout.emit(
+      jsonl([
+        { type: "system", subtype: "background_tasks_changed", tasks: [] },
+        { type: "result", subtype: "success", result: "background answer" },
+      ]),
+    );
+
+    await expect(resultPromise).resolves.toMatchObject({ output: { text: "background answer" } });
+    expect(driver.cancel).not.toHaveBeenCalled();
   });
 
-  it("does not defer a synthetic placeholder on a fresh live process", async () => {
+  it("fails a current-input synthetic placeholder on a fresh live process", async () => {
     const driver = installLiveStdoutDriver({
       onWrite: (stdout) => {
         stdout(
@@ -685,9 +665,12 @@ describe("claude live session provisional results", () => {
       },
     });
 
-    const result = await startLiveTurn({ runId: "run-synthetic-fresh" });
-    expect(result.output.text).toBe("");
-    expect(driver.cancel).not.toHaveBeenCalled();
+    await expect(startLiveTurn({ runId: "run-synthetic-fresh" })).rejects.toMatchObject({
+      name: "FailoverError",
+      reason: "format",
+      code: "cli_synthetic_no_response",
+    });
+    expect(driver.cancel).toHaveBeenCalledWith("manual-cancel");
   });
 
   it("times out and cleans up when lifecycle records never start the current input", async () => {

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -1417,7 +1417,10 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
       outputMode: "jsonl",
       fallbackSessionId: turn.sessionId,
     });
-  if (output.errorText) {
+  const syntheticNoResponsePendingContinuation =
+    output.terminalFailure?.reason === "synthetic_no_response" &&
+    session.outstandingBackgroundTaskIds.size > 0;
+  if (output.errorText && !syntheticNoResponsePendingContinuation) {
     const error = createCliOutputFailoverError({
       output,
       provider: session.providerId,

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -444,6 +444,51 @@ describe("executePreparedCliRun supervisor output capture", () => {
     });
   });
 
+  it("surfaces a local Claude synthetic empty terminal through the output error path", async () => {
+    const stdout = [
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          model: "<synthetic>",
+          role: "assistant",
+          content: [{ type: "text", text: "No response requested." }],
+        },
+      }),
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        session_id: "claude-synthetic-empty",
+        result: "",
+      }),
+      "",
+    ].join("\n");
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as SupervisorSpawnInput;
+      input.onStdout?.(stdout);
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: input.captureOutput === false ? "" : stdout,
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    await expect(
+      executePreparedCliRun(
+        buildPreparedCliRunContext({ output: "jsonl", provider: "claude-cli" }),
+      ),
+    ).rejects.toMatchObject({
+      name: "FailoverError",
+      reason: "format",
+      code: "cli_synthetic_no_response",
+      rawError: "Claude CLI returned a synthetic no-response result.",
+    });
+  });
+
   it("surfaces Claude max-turn results with run and session recovery context", async () => {
     const stdout = `${JSON.stringify({
       type: "result",

--- a/src/agents/cli-runner/output-error.ts
+++ b/src/agents/cli-runner/output-error.ts
@@ -18,13 +18,18 @@ export function createCliOutputFailoverError(params: {
     runId: params.runId,
     sessionId: params.sessionId,
   });
-  const reason = classifyFailoverReason(message, { provider: params.provider }) ?? "unknown";
+  const syntheticNoResponse = params.output.terminalFailure?.reason === "synthetic_no_response";
+  const reason = syntheticNoResponse
+    ? "format"
+    : (classifyFailoverReason(message, { provider: params.provider }) ?? "unknown");
   const code =
     params.output.terminalFailure?.reason === "max_turns"
       ? "cli_max_turns"
-      : reason === "context_overflow"
-        ? "cli_context_overflow"
-        : undefined;
+      : syntheticNoResponse
+        ? "cli_synthetic_no_response"
+        : reason === "context_overflow"
+          ? "cli_context_overflow"
+          : undefined;
   return new FailoverError(message, {
     reason,
     provider: params.provider,

--- a/src/auto-reply/reply/get-reply-run-context.ts
+++ b/src/auto-reply/reply/get-reply-run-context.ts
@@ -49,6 +49,7 @@ import {
   resolveBareResetBootstrapFileAccess,
   resolveBareSessionResetPromptState,
 } from "./session-reset-prompt.js";
+import { isExplicitSourceReplyCommand } from "./source-reply-delivery-mode.js";
 import { shouldApplyStartupContext, buildSessionStartupContextPrelude } from "./startup-context.js";
 import { resolveTypingMode } from "./typing-mode.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
@@ -177,7 +178,11 @@ export async function prepareReplyRunContext(params: RunPreparedReplyParams) {
     : "";
   // Claude CLI fixes the system prompt at session creation; group intro must stay session-stable.
   const groupIntro = isGroupChat ? buildGroupIntro({ sessionEntry, defaultActivation }) : "";
-  const allowEmptyAssistantReplyAsSilent = isGroupChat && silentReplySettings.policy === "allow";
+  const isDirectedTurn =
+    isExplicitSourceReplyCommand(ctx, cfg) ||
+    (inboundEventKind !== "room_event" && (isDirectChat || ctx.WasMentioned === true));
+  const allowEmptyAssistantReplyAsSilent =
+    isGroupChat && !isDirectedTurn && silentReplySettings.policy === "allow";
   const groupSystemPrompt = normalizeOptionalString(promptSessionCtx.GroupSystemPrompt) ?? "";
   const inboundMetaPrompt = buildInboundMetaSystemPrompt(
     isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -428,6 +428,54 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.run.allowEmptyAssistantReplyAsSilent).toBe(true);
   });
 
+  it.each([
+    {
+      name: "mention",
+      ctx: { WasMentioned: true },
+    },
+    {
+      name: "native command",
+      ctx: {
+        CommandTurn: {
+          kind: "native" as const,
+          source: "native" as const,
+          authorized: true,
+          commandName: "status",
+          body: "/status",
+        },
+      },
+    },
+  ])("keeps empty-assistant silence disabled for a directed group $name", async ({ ctx }) => {
+    await runPrepared({
+      ctx: {
+        ...baseParams().ctx,
+        ...ctx,
+      },
+    });
+
+    const call = requireLastRunReplyAgentCall();
+    expect(call?.followupRun.run.allowEmptyAssistantReplyAsSilent).toBe(false);
+  });
+
+  it("keeps empty-assistant silence available for ambient room events", async () => {
+    const defaults = baseParams();
+    await runPrepared({
+      ctx: {
+        ...defaults.ctx,
+        InboundEventKind: "room_event",
+        WasMentioned: true,
+      },
+      sessionCtx: {
+        ...defaults.sessionCtx,
+        InboundEventKind: "room_event",
+        WasMentioned: true,
+      },
+    });
+
+    const call = requireLastRunReplyAgentCall();
+    expect(call?.followupRun.run.allowEmptyAssistantReplyAsSilent).toBe(true);
+  });
+
   it("hydrates runtime thinking metadata before trusting static provider support", async () => {
     const resolveThinkingCatalog = vi.fn(async () => [
       {


### PR DESCRIPTION
Related: #90789

## What Problem This Solves

Fixes an issue where a directed Claude CLI turn could end silently when the runtime returned its exact synthetic `No response requested.` placeholder followed by a successful empty result. Direct chats, mentions, and commands could produce neither a reply nor a recorded failure.

## Why This Change Was Made

The shared CLI JSONL parser now records that exact dependency-owned terminal fact only when the turn has no real text or tool activity. Live, spawned, and paired-node runners route it through the existing failover path; the existing replay-safe, same-model fresh-session recovery remains the only retry. Background-task continuation stays provisional, and ambient room-event silence remains unchanged.

No channel special case, config, persisted state, fallback stack, or new retry loop. Per-frame work remains one fixed-shape check plus existing tool tracking.

This extends the continuation work in #90799 and preserves credit for Lu Wang and Shakker in the commit.

## User Impact

Directed users now receive the normal bounded recovery or visible failure outcome instead of an unexplained `NO_REPLY`. Genuine ambient group silence still stays silent.

Production: +63/-10 (net +53). Tests: +321/-64 (net +257). Generated: 0.

## Evidence

- Current-main regression: the exact current-input synthetic placeholder plus successful empty result resolved to an empty payload; group policy converted that payload to `NO_REPLY`.
- Focused local proof: 426/426 passing across the shared parser, local spawn, paired-node, persistent live session/background continuation, bounded fresh-session recovery, and directed/ambient policy tests (4 shards, 38.36s).
- `git diff --check`: clean.
- Targeted Oxfmt and Oxlint: clean.
- `pnpm tsgo:core`: clean.
- Core test typecheck has one untouched baseline error at `src/infra/outbound/message-action-gateway-reconciliation.test.ts:526`; this PR's prior fixture error was corrected and no changed file remains in the output.
- Dependency contract: verified against Claude Code 2.1.226 stream-JSON behavior and the exact `<synthetic>` / `No response requested.` signature.
- Exact-head local ClawSweeper: patch correct; 0 findings; security cleared; no maintainer decision; 0 Rank-up moves.
- Exact-head local Telegram userbot: a real QA-user DM drove the exact controlled Claude synthetic-empty contract through the candidate gateway. Telegram recorded exactly one actionable SUT failure message after 2.49s, with 0 edits and 0 deletions; neither the internal marker nor placeholder text leaked. Gateway evidence recorded the typed synthetic no-response failure, one requested-model attempt, no configured fallback, and bounded chain exhaustion. Runner cleanup released the QA lease and stopped its gateway.
