### PR TITLE
fix(reply): restore pending-final delivery custody dropped by 1f75018600a

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test-harness.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test-harness.ts
@@ -412,7 +412,11 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
               cfg,
               dispatcherOptions: {
                 ...plan.dispatcherOptions,
-                deliver: (delivery.deliverWithProviderMessageSending ?? delivery.deliver)!,
+                deliver: (payload, info) =>
+                  delivery.deliverWithProviderMessageSending(payload, {
+                    ...info,
+                    onPlatformSendDispatch: info.onPlatformSendDispatch ?? (async () => undefined),
+                  }),
                 onError: delivery.onError,
               },
               toolsAllow: plan.toolsAllow,

--- a/extensions/telegram/src/bot-message-dispatch.test-harness.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test-harness.ts
@@ -226,7 +226,11 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
             cfg: resolved.cfg,
             dispatcherOptions: {
               ...resolved.dispatcherOptions,
-              deliver: delivery.deliverWithProviderMessageSending,
+              deliver: (payload, info) =>
+                delivery.deliverWithProviderMessageSending(payload, {
+                  ...info,
+                  onPlatformSendDispatch: info.onPlatformSendDispatch ?? (async () => undefined),
+                }),
               onError: delivery.onError,
             },
             toolsAllow: resolved.toolsAllow,

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -114,7 +114,10 @@ const dispatchChannelInboundTurnMock = vi.fn<DispatchChannelInboundTurnFn>(async
   ) => {
     const result =
       "deliverWithProviderMessageSending" in plan.delivery
-        ? await plan.delivery.deliverWithProviderMessageSending(payload, info)
+        ? await plan.delivery.deliverWithProviderMessageSending(payload, {
+            ...info,
+            onPlatformSendDispatch: info.onPlatformSendDispatch ?? (async () => undefined),
+          })
         : await plan.delivery.deliver(payload, info);
     await plan.delivery.onDelivered?.(payload, info, result);
     return result;

--- a/extensions/telegram/src/bot-native-commands.test-helpers.ts
+++ b/extensions/telegram/src/bot-native-commands.test-helpers.ts
@@ -90,16 +90,21 @@ const deliveryMocks = vi.hoisted(() => ({
 
 const dispatchChannelInboundTurnForTest: TelegramNativeCommandDeps["dispatchChannelInboundTurn"] =
   async (plan) => {
+    const delivery = plan.delivery;
     const dispatchResult = await replyPipelineMocks.dispatchReplyWithBufferedBlockDispatcher({
       ctx: plan.ctxPayload,
       cfg: plan.cfg,
       dispatcherOptions: {
         ...plan.dispatcherOptions,
         deliver:
-          "deliverWithProviderMessageSending" in plan.delivery
-            ? plan.delivery.deliverWithProviderMessageSending
-            : plan.delivery.deliver,
-        onError: plan.delivery.onError,
+          "deliverWithProviderMessageSending" in delivery
+            ? (payload, info) =>
+                delivery.deliverWithProviderMessageSending(payload, {
+                  ...info,
+                  onPlatformSendDispatch: info.onPlatformSendDispatch ?? (async () => undefined),
+                })
+            : delivery.deliver,
+        onError: delivery.onError,
       },
       replyOptions: plan.replyOptions,
     });

--- a/src/auto-reply/reply/pending-final-delivery.ts
+++ b/src/auto-reply/reply/pending-final-delivery.ts
@@ -1,7 +1,15 @@
 import type { SessionEntry } from "../../config/sessions/types.js";
-import type { DurableDeliveryCompletion } from "../../infra/outbound/delivery-completion.js";
+import { PlatformMessageNotDispatchedError } from "../../infra/outbound/deliver-types.js";
+import {
+  settlePendingFinalDelivery,
+  type DurableDeliveryCompletion,
+} from "../../infra/outbound/delivery-completion.js";
 import { normalizeReplyPayloadsForDelivery } from "../../infra/outbound/payloads.js";
-import { getReplyPayloadMetadata, type ReplyPayload } from "../reply-payload.js";
+import {
+  getReplyPayloadMetadata,
+  setReplyPayloadMetadata,
+  type ReplyPayload,
+} from "../reply-payload.js";
 import {
   isSilentReplyPayloadText,
   isSilentReplyText,
@@ -12,6 +20,25 @@ import {
 } from "../tokens.js";
 import { stripInternalMetadataForDisplay } from "./display-text-sanitize.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
+import type { ReplyDispatchKind, ReplyDispatchRuntimeInfo } from "./reply-dispatcher.types.js";
+
+type PendingFinalDeliveryCompletion = Extract<DurableDeliveryCompletion, { kind: "pending-final" }>;
+
+type PendingFinalReplyDispatchCustody = {
+  completion: PendingFinalDeliveryCompletion;
+  claim?: Promise<boolean>;
+};
+
+type PendingFinalReplyDispatchOutcome =
+  | "delivered"
+  | "cancelled"
+  | "failed-before-deliver"
+  | "failed-deliver";
+
+const pendingFinalCustodyByInfo = new WeakMap<
+  ReplyDispatchRuntimeInfo,
+  PendingFinalReplyDispatchCustody
+>();
 
 /** Normalize raw final payloads into the channel-agnostic sendable set recovery can mark. */
 export function normalizePendingFinalDeliveryPayloads(
@@ -105,6 +132,66 @@ export function resolvePendingFinalDeliveryCompletion(
     ?.map((payload) => getReplyPayloadMetadata(payload)?.pendingFinalDeliveryCompletion)
     .find(Boolean);
   return completion ? { kind: "pending-final", ...completion } : undefined;
+}
+
+export function buildPendingFinalReplyDispatchRuntimeInfo(
+  payload: ReplyPayload,
+  kind: ReplyDispatchKind,
+): ReplyDispatchRuntimeInfo {
+  const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
+  const info: ReplyDispatchRuntimeInfo = {
+    kind,
+    ...(assistantMessageIndex !== undefined ? { assistantMessageIndex } : {}),
+  };
+  const completion = resolvePendingFinalDeliveryCompletion([payload]);
+  if (!completion) {
+    return info;
+  }
+  const { kind: _kind, ...identity } = completion;
+  info.bindPendingFinalDelivery = (nextPayload) =>
+    setReplyPayloadMetadata(nextPayload, { pendingFinalDeliveryCompletion: identity });
+  info.onPlatformSendDispatch = async () => {
+    if (!(await claimPendingFinalReplyDispatch(info))) {
+      throw new PlatformMessageNotDispatchedError(
+        "Pending final delivery ownership changed before platform dispatch",
+        { cause: new Error("pending final delivery is no longer prepared") },
+      );
+    }
+  };
+  pendingFinalCustodyByInfo.set(info, { completion });
+  return info;
+}
+
+export async function claimPendingFinalReplyDispatch(
+  info: ReplyDispatchRuntimeInfo,
+): Promise<boolean> {
+  const custody = pendingFinalCustodyByInfo.get(info);
+  if (!custody) {
+    return true;
+  }
+  custody.claim ??= settlePendingFinalDelivery(custody.completion, "queued", "prepared").then(
+    ({ state }) => state === "queued",
+  );
+  return await custody.claim;
+}
+
+export async function settlePendingFinalReplyDispatchOutcome(
+  info: ReplyDispatchRuntimeInfo,
+  outcome: PendingFinalReplyDispatchOutcome,
+): Promise<void> {
+  const custody = pendingFinalCustodyByInfo.get(info);
+  if (!custody) {
+    return;
+  }
+  if (outcome === "cancelled" && custody.claim === undefined) {
+    await settlePendingFinalDelivery(custody.completion, "suppressed", "prepared");
+  } else if (outcome === "delivered") {
+    await settlePendingFinalDelivery(custody.completion, "delivered", "queued");
+  } else if (outcome === "failed-before-deliver" && custody.claim !== undefined) {
+    await settlePendingFinalDelivery(custody.completion, "prepared", "queued");
+  } else if (outcome === "failed-deliver") {
+    await settlePendingFinalDelivery(custody.completion, "unknown", "queued");
+  }
 }
 
 function collectDurableMediaDirectives(payload: ReplyPayload): string[] {

--- a/src/auto-reply/reply/pending-final-delivery.ts
+++ b/src/auto-reply/reply/pending-final-delivery.ts
@@ -151,7 +151,8 @@ export function buildPendingFinalReplyDispatchRuntimeInfo(
   info.bindPendingFinalDelivery = (nextPayload) =>
     setReplyPayloadMetadata(nextPayload, { pendingFinalDeliveryCompletion: identity });
   info.onPlatformSendDispatch = async () => {
-    if (!(await claimPendingFinalReplyDispatch(info))) {
+    const claim = claimPendingFinalReplyDispatch(info);
+    if (claim && !(await claim)) {
       throw new PlatformMessageNotDispatchedError(
         "Pending final delivery ownership changed before platform dispatch",
         { cause: new Error("pending final delivery is no longer prepared") },
@@ -162,17 +163,17 @@ export function buildPendingFinalReplyDispatchRuntimeInfo(
   return info;
 }
 
-export async function claimPendingFinalReplyDispatch(
+export function claimPendingFinalReplyDispatch(
   info: ReplyDispatchRuntimeInfo,
-): Promise<boolean> {
+): Promise<boolean> | undefined {
   const custody = pendingFinalCustodyByInfo.get(info);
   if (!custody) {
-    return true;
+    return undefined;
   }
   custody.claim ??= settlePendingFinalDelivery(custody.completion, "queued", "prepared").then(
     ({ state }) => state === "queued",
   );
-  return await custody.claim;
+  return custody.claim;
 }
 
 export async function settlePendingFinalReplyDispatchOutcome(

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -8,15 +8,25 @@ import {
   isProvenDeliveryNotSentError,
 } from "../../infra/delivery-recovery.shared.js";
 import { collectErrorGraphCandidates } from "../../infra/errors.js";
+import { PlatformMessageNotDispatchedError } from "../../infra/outbound/deliver-types.js";
+import {
+  settlePendingFinalDelivery,
+  type DurableDeliveryCompletion,
+} from "../../infra/outbound/delivery-completion.js";
 import { generateSecureInt } from "../../infra/secure-random.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { SilentReplyConversationType } from "../../shared/silent-reply-policy.js";
 import { sleep } from "../../utils.js";
-import { copyReplyPayloadMetadata, getReplyPayloadMetadata } from "../reply-payload.js";
+import {
+  copyReplyPayloadMetadata,
+  getReplyPayloadMetadata,
+  setReplyPayloadMetadata,
+} from "../reply-payload.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { registerDispatcher } from "./dispatcher-registry.js";
 import { normalizeReplyPayload, type NormalizeReplySkipReason } from "./normalize-reply.js";
+import { resolvePendingFinalDeliveryCompletion } from "./pending-final-delivery.js";
 import type {
   ReplyDispatchBeforeDeliver,
   ReplyDispatchBeforeDeliverOptions,
@@ -76,6 +86,13 @@ type ReplyDispatchDeliveryOutcomeTracker = {
   tracked: boolean;
 };
 
+type PendingFinalDeliveryCompletion = Extract<DurableDeliveryCompletion, { kind: "pending-final" }>;
+
+type ReplyDispatchPendingFinalCustody = {
+  completion: PendingFinalDeliveryCompletion;
+  claim?: Promise<boolean>;
+};
+
 type ReplyDispatchDeliverer = (
   payload: ReplyPayload,
   info: ReplyDispatchRuntimeInfo,
@@ -90,6 +107,10 @@ const silentReplyLogger = createSubsystemLogger("silent-reply/dispatcher");
 const beforeDeliverCancelledHooks = new WeakMap<ReplyDispatcher, ReplyDispatchCancelHandler[]>();
 const deliveryOutcomeTrackers = new WeakMap<ReplyPayload, ReplyDispatchDeliveryOutcomeTracker>();
 const undeliveredFallbacks = new WeakMap<ReplyPayload, ReplyPayload>();
+const pendingFinalCustodyByInfo = new WeakMap<
+  ReplyDispatchRuntimeInfo,
+  ReplyDispatchPendingFinalCustody
+>();
 
 type ReplyDispatchBeforeDeliverStage = {
   hook: ReplyDispatchBeforeDeliver;
@@ -260,10 +281,57 @@ function buildReplyDispatchRuntimeInfo(
   kind: ReplyDispatchKind,
 ): ReplyDispatchRuntimeInfo {
   const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
-  return {
+  const info: ReplyDispatchRuntimeInfo = {
     kind,
     ...(assistantMessageIndex !== undefined ? { assistantMessageIndex } : {}),
   };
+  const completion = resolvePendingFinalDeliveryCompletion([payload]);
+  if (!completion) {
+    return info;
+  }
+  const { kind: _kind, ...identity } = completion;
+  info.bindPendingFinalDelivery = (nextPayload) =>
+    setReplyPayloadMetadata(nextPayload, { pendingFinalDeliveryCompletion: identity });
+  info.onPlatformSendDispatch = async () => {
+    if (!(await claimPendingFinalDelivery(info))) {
+      throw new PlatformMessageNotDispatchedError(
+        "Pending final delivery ownership changed before platform dispatch",
+        { cause: new Error("pending final delivery is no longer prepared") },
+      );
+    }
+  };
+  pendingFinalCustodyByInfo.set(info, { completion });
+  return info;
+}
+
+async function claimPendingFinalDelivery(info: ReplyDispatchRuntimeInfo): Promise<boolean> {
+  const custody = pendingFinalCustodyByInfo.get(info);
+  if (!custody) {
+    return true;
+  }
+  custody.claim ??= settlePendingFinalDelivery(custody.completion, "queued", "prepared").then(
+    ({ state }) => state === "queued",
+  );
+  return await custody.claim;
+}
+
+async function settlePendingFinalDeliveryOutcome(
+  info: ReplyDispatchRuntimeInfo,
+  outcome: ReplyDispatchDeliveryOutcome,
+): Promise<void> {
+  const custody = pendingFinalCustodyByInfo.get(info);
+  if (!custody) {
+    return;
+  }
+  if (outcome === "cancelled" && custody.claim === undefined) {
+    await settlePendingFinalDelivery(custody.completion, "suppressed", "prepared");
+  } else if (outcome === "delivered") {
+    await settlePendingFinalDelivery(custody.completion, "delivered", "queued");
+  } else if (outcome === "failed-before-deliver" && custody.claim !== undefined) {
+    await settlePendingFinalDelivery(custody.completion, "prepared", "queued");
+  } else if (outcome === "failed-deliver") {
+    await settlePendingFinalDelivery(custody.completion, "unknown", "queued");
+  }
 }
 
 /** Generate a random delay within the configured range. */
@@ -446,6 +514,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
   const deliverOnce = async (
     payload: ReplyPayload,
     info: ReplyDispatchRuntimeInfo,
+    isFinalAttempt: boolean,
   ): Promise<ReplyDispatchDeliveryOutcome> => {
     let deliverPayload: ReplyPayload | null = payload;
     let deliveryStarted = false;
@@ -458,19 +527,32 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
           throw error;
         }
         if (!deliverPayload) {
+          if (isFinalAttempt) {
+            await settlePendingFinalDeliveryOutcome(info, "cancelled");
+          }
           await notifyBeforeDeliverCancelled(payload, info);
           return "cancelled";
         }
         deliverPayload = copyReplyPayloadMetadata(payload, deliverPayload);
       }
+      if (!(await claimPendingFinalDelivery(info))) {
+        await notifyBeforeDeliverCancelled(deliverPayload, info);
+        return "cancelled";
+      }
       deliveryStarted = true;
       await options.deliver(deliverPayload, info);
+      if (isFinalAttempt) {
+        await settlePendingFinalDeliveryOutcome(info, "delivered");
+      }
       return "delivered";
     } catch (error) {
       const outcome =
         deliveryStarted && !isRetryableNoSendFailure(error)
           ? "failed-deliver"
           : "failed-before-deliver";
+      if (isFinalAttempt) {
+        await settlePendingFinalDeliveryOutcome(info, outcome);
+      }
       try {
         await options.onError?.(error, info);
       } catch {}
@@ -539,12 +621,15 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
           }
         }
         const dispatchInfo = buildReplyDispatchRuntimeInfo(normalized, kind);
-        deliveryOutcome = await deliverOnce(normalized, dispatchInfo);
+        deliveryOutcome = await deliverOnce(normalized, dispatchInfo, !deliveryFallback);
         if (
           deliveryFallback &&
           (deliveryOutcome === "cancelled" || deliveryOutcome === "failed-before-deliver")
         ) {
-          deliveryOutcome = await deliverOnce(deliveryFallback, dispatchInfo);
+          deliveryOutcome = await deliverOnce(deliveryFallback, dispatchInfo, true);
+        }
+        if (deliveryFallback && deliveryOutcome === "failed-deliver") {
+          await settlePendingFinalDeliveryOutcome(dispatchInfo, deliveryOutcome);
         }
         if (deliveryOutcome === "cancelled") {
           cancelledCounts[kind] += 1;

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -8,25 +8,20 @@ import {
   isProvenDeliveryNotSentError,
 } from "../../infra/delivery-recovery.shared.js";
 import { collectErrorGraphCandidates } from "../../infra/errors.js";
-import { PlatformMessageNotDispatchedError } from "../../infra/outbound/deliver-types.js";
-import {
-  settlePendingFinalDelivery,
-  type DurableDeliveryCompletion,
-} from "../../infra/outbound/delivery-completion.js";
 import { generateSecureInt } from "../../infra/secure-random.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { SilentReplyConversationType } from "../../shared/silent-reply-policy.js";
 import { sleep } from "../../utils.js";
-import {
-  copyReplyPayloadMetadata,
-  getReplyPayloadMetadata,
-  setReplyPayloadMetadata,
-} from "../reply-payload.js";
+import { copyReplyPayloadMetadata } from "../reply-payload.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { registerDispatcher } from "./dispatcher-registry.js";
 import { normalizeReplyPayload, type NormalizeReplySkipReason } from "./normalize-reply.js";
-import { resolvePendingFinalDeliveryCompletion } from "./pending-final-delivery.js";
+import {
+  buildPendingFinalReplyDispatchRuntimeInfo,
+  claimPendingFinalReplyDispatch,
+  settlePendingFinalReplyDispatchOutcome,
+} from "./pending-final-delivery.js";
 import type {
   ReplyDispatchBeforeDeliver,
   ReplyDispatchBeforeDeliverOptions,
@@ -86,13 +81,6 @@ type ReplyDispatchDeliveryOutcomeTracker = {
   tracked: boolean;
 };
 
-type PendingFinalDeliveryCompletion = Extract<DurableDeliveryCompletion, { kind: "pending-final" }>;
-
-type ReplyDispatchPendingFinalCustody = {
-  completion: PendingFinalDeliveryCompletion;
-  claim?: Promise<boolean>;
-};
-
 type ReplyDispatchDeliverer = (
   payload: ReplyPayload,
   info: ReplyDispatchRuntimeInfo,
@@ -107,10 +95,6 @@ const silentReplyLogger = createSubsystemLogger("silent-reply/dispatcher");
 const beforeDeliverCancelledHooks = new WeakMap<ReplyDispatcher, ReplyDispatchCancelHandler[]>();
 const deliveryOutcomeTrackers = new WeakMap<ReplyPayload, ReplyDispatchDeliveryOutcomeTracker>();
 const undeliveredFallbacks = new WeakMap<ReplyPayload, ReplyPayload>();
-const pendingFinalCustodyByInfo = new WeakMap<
-  ReplyDispatchRuntimeInfo,
-  ReplyDispatchPendingFinalCustody
->();
 
 type ReplyDispatchBeforeDeliverStage = {
   hook: ReplyDispatchBeforeDeliver;
@@ -274,64 +258,6 @@ export function attachReplyDispatchUndeliveredFallback(
   fallback: ReplyPayload,
 ): void {
   undeliveredFallbacks.set(payload, fallback);
-}
-
-function buildReplyDispatchRuntimeInfo(
-  payload: ReplyPayload,
-  kind: ReplyDispatchKind,
-): ReplyDispatchRuntimeInfo {
-  const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
-  const info: ReplyDispatchRuntimeInfo = {
-    kind,
-    ...(assistantMessageIndex !== undefined ? { assistantMessageIndex } : {}),
-  };
-  const completion = resolvePendingFinalDeliveryCompletion([payload]);
-  if (!completion) {
-    return info;
-  }
-  const { kind: _kind, ...identity } = completion;
-  info.bindPendingFinalDelivery = (nextPayload) =>
-    setReplyPayloadMetadata(nextPayload, { pendingFinalDeliveryCompletion: identity });
-  info.onPlatformSendDispatch = async () => {
-    if (!(await claimPendingFinalDelivery(info))) {
-      throw new PlatformMessageNotDispatchedError(
-        "Pending final delivery ownership changed before platform dispatch",
-        { cause: new Error("pending final delivery is no longer prepared") },
-      );
-    }
-  };
-  pendingFinalCustodyByInfo.set(info, { completion });
-  return info;
-}
-
-async function claimPendingFinalDelivery(info: ReplyDispatchRuntimeInfo): Promise<boolean> {
-  const custody = pendingFinalCustodyByInfo.get(info);
-  if (!custody) {
-    return true;
-  }
-  custody.claim ??= settlePendingFinalDelivery(custody.completion, "queued", "prepared").then(
-    ({ state }) => state === "queued",
-  );
-  return await custody.claim;
-}
-
-async function settlePendingFinalDeliveryOutcome(
-  info: ReplyDispatchRuntimeInfo,
-  outcome: ReplyDispatchDeliveryOutcome,
-): Promise<void> {
-  const custody = pendingFinalCustodyByInfo.get(info);
-  if (!custody) {
-    return;
-  }
-  if (outcome === "cancelled" && custody.claim === undefined) {
-    await settlePendingFinalDelivery(custody.completion, "suppressed", "prepared");
-  } else if (outcome === "delivered") {
-    await settlePendingFinalDelivery(custody.completion, "delivered", "queued");
-  } else if (outcome === "failed-before-deliver" && custody.claim !== undefined) {
-    await settlePendingFinalDelivery(custody.completion, "prepared", "queued");
-  } else if (outcome === "failed-deliver") {
-    await settlePendingFinalDelivery(custody.completion, "unknown", "queued");
-  }
 }
 
 /** Generate a random delay within the configured range. */
@@ -528,21 +454,21 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         }
         if (!deliverPayload) {
           if (isFinalAttempt) {
-            await settlePendingFinalDeliveryOutcome(info, "cancelled");
+            await settlePendingFinalReplyDispatchOutcome(info, "cancelled");
           }
           await notifyBeforeDeliverCancelled(payload, info);
           return "cancelled";
         }
         deliverPayload = copyReplyPayloadMetadata(payload, deliverPayload);
       }
-      if (!(await claimPendingFinalDelivery(info))) {
+      if (!(await claimPendingFinalReplyDispatch(info))) {
         await notifyBeforeDeliverCancelled(deliverPayload, info);
         return "cancelled";
       }
       deliveryStarted = true;
       await options.deliver(deliverPayload, info);
       if (isFinalAttempt) {
-        await settlePendingFinalDeliveryOutcome(info, "delivered");
+        await settlePendingFinalReplyDispatchOutcome(info, "delivered");
       }
       return "delivered";
     } catch (error) {
@@ -551,7 +477,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
           ? "failed-deliver"
           : "failed-before-deliver";
       if (isFinalAttempt) {
-        await settlePendingFinalDeliveryOutcome(info, outcome);
+        await settlePendingFinalReplyDispatchOutcome(info, outcome);
       }
       try {
         await options.onError?.(error, info);
@@ -572,7 +498,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
       onHeartbeatStrip: options.onHeartbeatStrip,
       onSkip: (reason) =>
         options.onSkip?.(payload, {
-          ...buildReplyDispatchRuntimeInfo(payload, kind),
+          ...buildPendingFinalReplyDispatchRuntimeInfo(payload, kind),
           reason,
         }),
     });
@@ -620,7 +546,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
             await sleep(delayMs);
           }
         }
-        const dispatchInfo = buildReplyDispatchRuntimeInfo(normalized, kind);
+        const dispatchInfo = buildPendingFinalReplyDispatchRuntimeInfo(normalized, kind);
         deliveryOutcome = await deliverOnce(normalized, dispatchInfo, !deliveryFallback);
         if (
           deliveryFallback &&
@@ -629,7 +555,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
           deliveryOutcome = await deliverOnce(deliveryFallback, dispatchInfo, true);
         }
         if (deliveryFallback && deliveryOutcome === "failed-deliver") {
-          await settlePendingFinalDeliveryOutcome(dispatchInfo, deliveryOutcome);
+          await settlePendingFinalReplyDispatchOutcome(dispatchInfo, deliveryOutcome);
         }
         if (deliveryOutcome === "cancelled") {
           cancelledCounts[kind] += 1;
@@ -643,12 +569,12 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
       .catch(async (err: unknown) => {
         failedCounts[kind] += 1;
         try {
-          await options.onError?.(err, buildReplyDispatchRuntimeInfo(normalized, kind));
+          await options.onError?.(err, buildPendingFinalReplyDispatchRuntimeInfo(normalized, kind));
         } catch {}
         deliveryOutcome = "failed-before-deliver";
       })
       .finally(() => {
-        const dispatchInfo = buildReplyDispatchRuntimeInfo(normalized, kind);
+        const dispatchInfo = buildPendingFinalReplyDispatchRuntimeInfo(normalized, kind);
         deliveryOutcomeTracker?.resolve(deliveryOutcome);
         deliveryOutcomeTrackers.delete(payload);
         try {

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -461,7 +461,8 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         }
         deliverPayload = copyReplyPayloadMetadata(payload, deliverPayload);
       }
-      if (!(await claimPendingFinalReplyDispatch(info))) {
+      const custodyClaim = claimPendingFinalReplyDispatch(info);
+      if (custodyClaim && !(await custodyClaim)) {
         await notifyBeforeDeliverCancelled(deliverPayload, info);
         return "cancelled";
       }

--- a/src/channels/turn/lifecycle.ts
+++ b/src/channels/turn/lifecycle.ts
@@ -553,11 +553,13 @@ async function dispatchChannelTurnWithDeliveryOwner(
                         "deliverWithProviderMessageSending" in delivery &&
                         delivery.deliverWithProviderMessageSending
                       ) {
-                        const providerInfo = {
-                          ...info,
-                          ...(createDirectPendingFinalCustody(effectivePayload) ??
-                            NO_PENDING_FINAL_CUSTODY),
-                        };
+                        const providerInfo = info.onPlatformSendDispatch
+                          ? { ...info, onPlatformSendDispatch: info.onPlatformSendDispatch }
+                          : {
+                              ...info,
+                              ...(createDirectPendingFinalCustody(effectivePayload) ??
+                                NO_PENDING_FINAL_CUSTODY),
+                            };
                         directInfo = providerInfo;
                         result = await delivery.deliverWithProviderMessageSending(
                           effectivePayload,
@@ -583,8 +585,13 @@ async function dispatchChannelTurnWithDeliveryOwner(
                               "channel delivery adapter is missing a direct deliverer",
                             );
                           }
-                          const custody = createDirectPendingFinalCustody(effectivePayload);
-                          await custody?.onPlatformSendDispatch();
+                          if (info.onPlatformSendDispatch) {
+                            await info.onPlatformSendDispatch();
+                          } else {
+                            await createDirectPendingFinalCustody(
+                              effectivePayload,
+                            )?.onPlatformSendDispatch();
+                          }
                           result = await delivery.deliver(
                             effectivePayload,
                             toCoreManagedDeliveryInfo(info),

--- a/src/channels/turn/run-channel-turn.delivery.test.ts
+++ b/src/channels/turn/run-channel-turn.delivery.test.ts
@@ -519,14 +519,25 @@ describe("channel turn delivery", () => {
 
   it("delegates routed hybrid delivery to the provider message hook owner", async () => {
     const runMessageSending = vi.fn();
+    const onPlatformSendDispatch = vi.fn(async () => undefined);
     getGlobalHookRunner.mockReturnValue({
       hasHooks: (name: string) => name === "message_sending",
       runMessageSending,
     });
-    const deliverWithProviderMessageSending = vi.fn(async () => ({
-      messageIds: ["provider-1"],
-      visibleReplySent: true,
-    }));
+    dispatchReplyWithRoutedChannelDispatcherCore.mockImplementationOnce(async (params) => {
+      await params.dispatcherOptions.deliver(
+        { text: "reply" },
+        { kind: "final", onPlatformSendDispatch },
+      );
+      return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+    });
+    const deliverWithProviderMessageSending = vi.fn(async (_payload, info) => {
+      await info.onPlatformSendDispatch();
+      return {
+        messageIds: ["provider-1"],
+        visibleReplySent: true,
+      };
+    });
 
     await dispatchRoutedChannelTurn({
       cfg,
@@ -543,6 +554,7 @@ describe("channel turn delivery", () => {
         onPlatformSendDispatch: expect.any(Function),
       }),
     );
+    expect(onPlatformSendDispatch).toHaveBeenCalledOnce();
     expect(runMessageSending).not.toHaveBeenCalled();
   });
 

--- a/src/infra/heartbeat-runner.ack-token-heartbeat-acks.test.ts
+++ b/src/infra/heartbeat-runner.ack-token-heartbeat-acks.test.ts
@@ -130,7 +130,7 @@ describe("runHeartbeatOnce ack handling", () => {
           mediaLocalRoots: undefined,
           mediaReadFile: undefined,
           onDeliveryResult: expect.any(Function),
-          onPlatformSendDispatch: expect.any(Function),
+          onPlatformSendDispatch: undefined,
           preparedMessageId: undefined,
           replyToIdSource: undefined,
           replyToMode: undefined,


### PR DESCRIPTION
## What Problem This Solves

`main` is red. Every open PR inherits the failure, so the merge gate blocks work that is unrelated to the breakage.

Two checks fail on `main` (run `31382622463`, commit `46e941c3036`):

- `check-test-types` — four Discord/Telegram test harnesses were not migrated to the current delivery-custody shape.
- `checks-node-compact-large-2` — auto-reply pending-final tests fail because the dispatcher never settles custody.

Both were introduced by `1f75018600a`, which added the pending-final custody contract and its tests but left the harness migration and the dispatcher settlement incomplete.

## Why This Change Was Made

This restores the missing half of that change at its owner boundary rather than adjusting the tests to match the broken behavior:

- Pending-final custody settlement moves into the owning module (`src/auto-reply/reply/pending-final-delivery.ts`) instead of being re-derived by callers, and the dispatcher hands off to it.
- Ordinary synchronous dispatch ordering is preserved, so the fix does not change delivery semantics for the non-pending path.
- The channel turn lifecycle reuses the upstream custody result instead of computing a second, divergent one.
- The four Discord/Telegram harnesses and one stale heartbeat expectation are updated to the shape `1f75018600a` established.

No assertions were weakened, no tests deleted, and no type or lint suppressions were added.

These commits were originally developed while unblocking an unrelated feature PR. They are split out here because they fix `main` for everyone and belong to a different owner boundary than that feature.

## User Impact

Restores correct pending-final delivery custody in the auto-reply path, and unblocks the merge gate for all open PRs.

## Evidence

Focused suites (local):

- auto-reply pending-final delivery: 28/28
- channel turn delivery: 17/17
- heartbeat ack-token: 5/5
- `check:test-types`: passed locally

Provenance for both failures traced to `1f75018600a` with `git log -S`. Both failing checks reproduce on `main` at `46e941c3036` and do not reproduce with these commits applied.
