### PR TITLE
feat(gateway): allow external restart recovery ownership

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -76,6 +76,11 @@ public enum WorkerDesktopAppId: String, Codable, Sendable {
     case terminal = "terminal"
 }
 
+public enum RestartRecoveryOwner: String, Codable, Sendable {
+    case openclaw = "openclaw"
+    case external = "external"
+}
+
 public enum WorktreeRepositoryStatus: String, Codable, Sendable {
     case git = "git"
     case notGit = "not_git"
@@ -2988,6 +2993,7 @@ public struct AgentParams: Codable, Sendable {
     public let replyto: String?
     public let sessionid: String?
     public let sessionkey: String?
+    public let restartrecoveryowner: RestartRecoveryOwner?
     public let expectedexistingsessionid: String?
     public let thinking: String?
     public let deliver: Bool?
@@ -3038,6 +3044,7 @@ public struct AgentParams: Codable, Sendable {
         replyto: String? = nil,
         sessionid: String? = nil,
         sessionkey: String? = nil,
+        restartrecoveryowner: RestartRecoveryOwner? = nil,
         expectedexistingsessionid: String? = nil,
         thinking: String? = nil,
         deliver: Bool? = nil,
@@ -3087,6 +3094,7 @@ public struct AgentParams: Codable, Sendable {
         self.replyto = replyto
         self.sessionid = sessionid
         self.sessionkey = sessionkey
+        self.restartrecoveryowner = restartrecoveryowner
         self.expectedexistingsessionid = expectedexistingsessionid
         self.thinking = thinking
         self.deliver = deliver
@@ -3138,6 +3146,7 @@ public struct AgentParams: Codable, Sendable {
         case replyto = "replyTo"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"
+        case restartrecoveryowner = "restartRecoveryOwner"
         case expectedexistingsessionid = "expectedExistingSessionId"
         case thinking
         case deliver

--- a/docs/gateway/external-apps.md
+++ b/docs/gateway/external-apps.md
@@ -55,8 +55,11 @@ families your app understands.
 
 If your app also persists its own timeout and retry state, set
 `restartRecoveryOwner: "external"` on its `agent` requests. The ownership marker
-persists on the session so OpenClaw does not independently resume the same work
-after a Gateway restart. Omit the field to preserve the current owner, or send
+persists through Gateway restarts so OpenClaw does not independently resume the
+same work. It is scoped to the current session generation: a session-ID rotation
+returns recovery to OpenClaw, and the first `agent` request for a replacement
+generation must send `"external"` again when the app still owns recovery. Omit
+the field to preserve the current generation's owner, or send
 `restartRecoveryOwner: "openclaw"` to return recovery to OpenClaw. See
 [Restart recovery](/gateway/restart-recovery#external-recovery-owners) for the
 full contract, `operator.admin` requirement, and failure-mode guidance.

--- a/docs/gateway/external-apps.md
+++ b/docs/gateway/external-apps.md
@@ -53,6 +53,14 @@ terminal result. For durable conversation state, use the `sessions.*` methods.
 For UI integrations, subscribe to Gateway events and render only the event
 families your app understands.
 
+If your app also persists its own timeout and retry state, set
+`restartRecoveryOwner: "external"` on its `agent` requests. The ownership marker
+persists on the session so OpenClaw does not independently resume the same work
+after a Gateway restart. Omit the field to preserve the current owner, or send
+`restartRecoveryOwner: "openclaw"` to return recovery to OpenClaw. See
+[Restart recovery](/gateway/restart-recovery#external-recovery-owners) for the
+full contract, `operator.admin` requirement, and failure-mode guidance.
+
 ## Cooperative host suspension
 
 Hosting controllers that freeze or snapshot a running process can use the

--- a/docs/gateway/operator-scopes.md
+++ b/docs/gateway/operator-scopes.md
@@ -88,7 +88,8 @@ request reaches its handler. Params-aware methods derive that scope before
 dispatch so authorization failures have one canonical structured response:
 
 - `agent` needs `operator.write` for ordinary turns and `operator.admin` for
-  `/new` or `/reset` session lifecycle commands.
+  `/new` or `/reset` session lifecycle commands, or whenever the request
+  supplies `restartRecoveryOwner` to transfer restart recovery ownership.
 - `node.invoke` needs `operator.write` for ordinary relay commands and
   `operator.admin` when relaying `browser.proxy`, `browser.proxy.upload.v1`,
   `fs.listDir`, or `terminal.upload` to a node.

--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -115,9 +115,12 @@ opt a Gateway session out of OpenClaw's automatic main-session recovery. Send
 }
 ```
 
-The setting is stored with the session and survives Gateway restarts. Omitting
-the field preserves the session's current owner; sessions that have never set
-it remain OpenClaw-owned for backward compatibility. Send
+The setting is scoped to the current session generation and survives Gateway
+restarts. A session-ID rotation clears it, so the first `agent` request for a
+replacement generation must send `"restartRecoveryOwner": "external"` again
+when the orchestrator still owns recovery. Omitting the field preserves the
+current generation's owner; new or rotated generations remain OpenClaw-owned
+for backward compatibility. Send
 `"restartRecoveryOwner": "openclaw"` to transfer automatic restart recovery
 back to OpenClaw. Changing the owner requires `operator.admin` and is rejected
 while another turn owns the session; retry after that turn settles. A successful

--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -10,7 +10,7 @@ title: "Restart recovery"
 Restarting the gateway does not lose agent state. Conversations, transcripts,
 scheduled jobs, background task records, and queued outbound messages all live
 on disk, and work that was interrupted mid-turn is detected and resumed
-automatically after the gateway comes back up. Recovery is always on and
+automatically after the gateway comes back up. Recovery is on by default and
 normally needs no manual intervention. Exhausted infrastructure retries, or a
 missing durable message-action authority claim, may quarantine one session
 until you inspect or replace it.
@@ -99,6 +99,37 @@ the gateway explicitly rejects the request before acceptance, and retains the
 charge when a post-dispatch result is uncertain to avoid replaying work.
 Foreground work that already owns the session keeps automatic recovery out
 until that work settles.
+
+### External recovery owners
+
+An external orchestrator that durably owns its own timeout and retry policy can
+opt a Gateway session out of OpenClaw's automatic main-session recovery. Send
+`restartRecoveryOwner` on the `agent` RPC that starts or continues the session:
+
+```json
+{
+  "message": "Run this orchestrated task",
+  "sessionKey": "agent:main:orchestrated-task",
+  "restartRecoveryOwner": "external",
+  "idempotencyKey": "orchestration-run-42"
+}
+```
+
+The setting is stored with the session and survives Gateway restarts. Omitting
+the field preserves the session's current owner; sessions that have never set
+it remain OpenClaw-owned for backward compatibility. Send
+`"restartRecoveryOwner": "openclaw"` to transfer automatic restart recovery
+back to OpenClaw. Changing the owner requires `operator.admin` and is rejected
+while another turn owns the session; retry after that turn settles. A successful
+transfer retires recovery state from the previous owner so an old interrupted
+cycle cannot run under the new policy.
+
+Externally owned sessions are skipped during restart-drain marking, startup
+orphan reconciliation, and recovery dispatch. The
+`main-session-restart-recovery` log records those decisions with
+`reason=external_owner`. Use this setting only when the external orchestrator
+will reliably reconcile interrupted work; OpenClaw will not resume it as a
+fallback.
 
 After the durable budget is exhausted, the session is tombstoned instead of
 looping forever. Inspect the failed session and use `/new` or `/reset` to start a
@@ -254,8 +285,9 @@ channels.start --params '{"channel":"<id>"}'`
 
 - Sessions excluded from main-session recovery because another owner already
   handles them: subagent sessions (subagent recovery), cron sessions (the
-  scheduler re-runs on schedule), and ACP-managed sessions (the connected IDE
-  or client owns the resume).
+  scheduler re-runs on schedule), ACP-managed sessions (the connected IDE or
+  client owns the resume), and sessions whose `restartRecoveryOwner` is
+  `external`.
 - Work that was never admitted: messages arriving during the drain window are
   rejected with an explicit restart error rather than silently queued into a
   dying process.

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -168,6 +168,7 @@ export {
   ChatStatusEventSchema,
   SendParamsSchema,
   PollParamsSchema,
+  RestartRecoveryOwnerSchema,
   AgentParamsSchema,
   AgentIdentityParamsSchema,
   AgentIdentityResultSchema,

--- a/packages/gateway-protocol/src/schema/agent.test.ts
+++ b/packages/gateway-protocol/src/schema/agent.test.ts
@@ -70,6 +70,31 @@ const musicCompletionEvent: AgentInternalEvent = {
 };
 
 describe("AgentParamsSchema", () => {
+  it.each(["openclaw", "external"])(
+    "accepts %s restart recovery ownership",
+    (restartRecoveryOwner) => {
+      expect(
+        Value.Check(AgentParamsSchema, {
+          message: "run under the selected recovery owner",
+          sessionKey: "agent:main:main",
+          restartRecoveryOwner,
+          idempotencyKey: `recovery-owner-${restartRecoveryOwner}`,
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it("rejects unknown restart recovery ownership", () => {
+    expect(
+      Value.Check(AgentParamsSchema, {
+        message: "run under an unknown recovery owner",
+        sessionKey: "agent:main:main",
+        restartRecoveryOwner: "scheduler",
+        idempotencyKey: "recovery-owner-unknown",
+      }),
+    ).toBe(false);
+  });
+
   it("accepts the backend expected-session binding", () => {
     expect(
       Value.Check(AgentParamsSchema, {

--- a/packages/gateway-protocol/src/schema/agent.ts
+++ b/packages/gateway-protocol/src/schema/agent.ts
@@ -22,6 +22,11 @@ const AGENT_INTERNAL_EVENT_SOURCES = [
 const AGENT_INTERNAL_EVENT_STATUSES = ["ok", "timeout", "error", "unknown"] as const;
 const CONVERSATION_REF_PATTERN = "^conv_[a-f0-9]{32}$";
 
+export const RestartRecoveryOwnerSchema = Type.Union([
+  Type.Literal("openclaw"),
+  Type.Literal("external"),
+]);
+
 /** Generated media/file attachment metadata carried by internal agent events. */
 const AgentGeneratedAttachmentSchema = closedObject({
   type: Type.Optional(Type.String({ enum: ["image", "audio", "video", "file"] })),
@@ -287,6 +292,9 @@ export const AgentParamsSchema = closedObject({
   replyTo: Type.Optional(Type.String()),
   sessionId: Type.Optional(Type.String()),
   sessionKey: Type.Optional(Type.String()),
+  // Durable owner for restart recovery of this session. Missing values preserve
+  // the current owner, and legacy sessions default to OpenClaw ownership.
+  restartRecoveryOwner: Type.Optional(RestartRecoveryOwnerSchema),
   // Backend-owned continuations can bind work to an already-admitted transcript.
   expectedExistingSessionId: Type.Optional(NonEmptyString),
   thinking: Type.Optional(Type.String()),
@@ -389,6 +397,7 @@ export const WakeParamsSchema = Type.Object(
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.
 export type AgentEvent = Static<typeof AgentEventSchema>;
+export type RestartRecoveryOwner = Static<typeof RestartRecoveryOwnerSchema>;
 export type AgentIdentityParams = Static<typeof AgentIdentityParamsSchema>;
 export type AgentIdentityResult = Static<typeof AgentIdentityResultSchema>;
 export type ConversationListParams = Static<typeof ConversationListParamsSchema>;

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-agent-control.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-agent-control.ts
@@ -47,6 +47,7 @@ export const AgentControlProtocolSchemas = {
   MessageActionParams: agent.MessageActionParamsSchema,
   SendParams: agent.SendParamsSchema,
   PollParams: agent.PollParamsSchema,
+  RestartRecoveryOwner: agent.RestartRecoveryOwnerSchema,
   AgentParams: agent.AgentParamsSchema,
   AgentIdentityParams: agent.AgentIdentityParamsSchema,
   AgentIdentityResult: agent.AgentIdentityResultSchema,

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -2867,6 +2867,7 @@ describe("recordCliCompactionInStore", () => {
         [sessionKey]: {
           sessionId,
           updatedAt: 1,
+          restartRecoveryOwner: "external",
         },
       };
       await seedSessionStore(storePath, sessionStore);
@@ -2882,10 +2883,12 @@ describe("recordCliCompactionInStore", () => {
       expect(sessionStore[sessionKey]?.sessionId).toBe(nextSessionId);
       expect(sessionStore[sessionKey]?.usageFamilyKey).toBe(sessionKey);
       expect(sessionStore[sessionKey]?.usageFamilySessionIds).toEqual([sessionId, nextSessionId]);
+      expect(sessionStore[sessionKey]?.restartRecoveryOwner).toBeUndefined();
       expect(sessionStore[sessionKey]).not.toHaveProperty("sessionFile");
 
       const persisted = loadPersistedSessionStore(storePath);
       expect(persisted[sessionKey]?.sessionId).toBe(nextSessionId);
+      expect(persisted[sessionKey]?.restartRecoveryOwner).toBeUndefined();
       expect(persisted[sessionKey]).not.toHaveProperty("sessionFile");
     });
   });

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -6,7 +6,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import {
   SESSION_TOTAL_TOKENS_VERSION,
   setSessionRuntimeModel,
-  type SessionEntry,
+  type InternalSessionEntry as SessionEntry,
 } from "../../config/sessions.js";
 import { patchSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import { projectSessionSnapshotChanges } from "../../config/sessions/session-snapshot-merge.js";
@@ -517,6 +517,7 @@ export async function recordCliCompactionInStore(params: {
   if (sessionIdChanged && newSessionId) {
     delete (next as { sessionFile?: unknown }).sessionFile;
     next.sessionId = newSessionId;
+    next.restartRecoveryOwner = undefined;
     next.usageFamilyKey = entry.usageFamilyKey ?? sessionKey;
     next.usageFamilySessionIds = Array.from(
       new Set([...(entry.usageFamilySessionIds ?? []), entry.sessionId, newSessionId]),

--- a/src/agents/command/session.provider-owned-reset.test.ts
+++ b/src/agents/command/session.provider-owned-reset.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import type { SessionEntry } from "../../config/sessions/types.js";
+import type { InternalSessionEntry as SessionEntry } from "../../config/sessions/types.js";
 
 const hoisted = vi.hoisted(() => ({
   store: {} as Record<string, SessionEntry>,
@@ -91,6 +91,30 @@ describe("command resolveSession provider-owned daily reset", () => {
     expect(result.isNewSession).toBe(true);
     expect(result.sessionId).not.toBe("old-session-id");
     expect(result.sessionEntry?.pendingTranscriptRepair).toBeUndefined();
+  });
+
+  it("clears external restart recovery ownership across a daily rotation", () => {
+    const sessionKey = "agent:main:cli";
+    const startedAt = Date.now() - DAY_MS;
+    hoisted.store = {
+      [sessionKey]: {
+        sessionId: "externally-owned-session-id",
+        updatedAt: startedAt,
+        sessionStartedAt: startedAt,
+        lastInteractionAt: startedAt,
+        restartRecoveryOwner: "external",
+      },
+    };
+
+    const result = resolveSession({
+      cfg: { session: { reset: { mode: "daily" } } } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe("externally-owned-session-id");
+    expect(result.sessionEntry?.restartRecoveryOwner).toBeUndefined();
   });
 
   it("keeps a model-locked session across the daily boundary", () => {

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -84,6 +84,7 @@ export function clearRotatedSessionMetadata(entry: SessionEntry): SessionEntry {
     endedAt: undefined,
     runtimeMs: undefined,
     abortedLastRun: undefined,
+    restartRecoveryOwner: undefined,
     restartRecoveryForceSafeTools: undefined,
     restartRecoveryDeliveryContext: undefined,
     restartRecoveryDeliveryMediaUrls: undefined,

--- a/src/agents/main-session-recovery/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery/main-session-recovery-state.ts
@@ -126,6 +126,9 @@ function recordLifecycleFence(entry: SessionEntry, run: RestartRecoveryRun): voi
 }
 
 export function isMainRestartRecoveryCandidate(entry: SessionEntry, sessionKey: string): boolean {
+  if (isExternalRestartRecoveryOwner(entry)) {
+    return false;
+  }
   if (typeof entry.spawnDepth === "number" && entry.spawnDepth > 0) {
     return false;
   }
@@ -137,6 +140,10 @@ export function isMainRestartRecoveryCandidate(entry: SessionEntry, sessionKey: 
     !isCronSessionKey(sessionKey) &&
     !isAcpSessionKey(sessionKey)
   );
+}
+
+export function isExternalRestartRecoveryOwner(entry: SessionEntry): boolean {
+  return entry.restartRecoveryOwner === "external";
 }
 
 export function isMainSessionRecoveryPending(entry: SessionEntry, sessionKey: string): boolean {

--- a/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
@@ -51,7 +51,7 @@ async function markRecoveryStore(params: {
           continue;
         }
         if (isExternalRestartRecoveryOwner(entry)) {
-          log.info("skipping main-session restart recovery", {
+          mainSessionRecoveryLog.info("skipping main-session restart recovery", {
             phase: "mark",
             reason: "external_owner",
             sessionKey,

--- a/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
@@ -17,6 +17,7 @@ import {
 } from "../embedded-agent-runner/run-state.js";
 import { resolveAgentSessionDirs } from "../session-dirs.js";
 import {
+  isExternalRestartRecoveryOwner,
   isMainRestartRecoveryCandidate,
   normalizeMainSessionRecoveryRunFences,
   transitionMainSessionRecovery,
@@ -48,6 +49,13 @@ async function markRecoveryStore(params: {
         const plan = params.plan(entry, sessionKey);
         if (!plan) {
           continue;
+        }
+        if (isExternalRestartRecoveryOwner(entry)) {
+          log.info("skipping main-session restart recovery", {
+            phase: "mark",
+            reason: "external_owner",
+            sessionKey,
+          });
         }
         if (!isMainRestartRecoveryCandidate(entry, sessionKey)) {
           counts.skipped++;

--- a/src/agents/main-session-recovery/main-session-restart-recovery-store.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-store.ts
@@ -25,7 +25,10 @@ import {
   listActiveEmbeddedRunSessionIds,
   listActiveEmbeddedRunSessionKeys,
 } from "../embedded-agent-runner/run-state.js";
-import { isMainRestartRecoveryCandidate } from "./main-session-recovery-state.js";
+import {
+  isExternalRestartRecoveryOwner,
+  isMainRestartRecoveryCandidate,
+} from "./main-session-recovery-state.js";
 import { commitMainSessionRecovery } from "./main-session-recovery-store.js";
 import {
   hasRestartRecoveryMessageActionAuthority,
@@ -288,6 +291,13 @@ export async function recoverStore(params: {
     let entry = loadedEntry;
     if (!entry || entry.status !== "running" || entry.abortedLastRun !== true) {
       continue;
+    }
+    if (isExternalRestartRecoveryOwner(entry)) {
+      log.info("skipping main-session restart recovery", {
+        phase: "dispatch",
+        reason: "external_owner",
+        sessionKey,
+      });
     }
     if (!isMainRestartRecoveryCandidate(entry, sessionKey)) {
       result.skipped++;

--- a/src/agents/main-session-recovery/main-session-restart-recovery-store.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-store.ts
@@ -293,7 +293,7 @@ export async function recoverStore(params: {
       continue;
     }
     if (isExternalRestartRecoveryOwner(entry)) {
-      log.info("skipping main-session restart recovery", {
+      mainSessionRecoveryLog.info("skipping main-session restart recovery", {
         phase: "dispatch",
         reason: "external_owner",
         sessionKey,

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -76,7 +76,10 @@ import {
 } from "../subagent-test-fixtures.test-helpers.js";
 import * as recoveryOwnerRelease from "./main-session-recovery-owner-release.js";
 import { claimMainSessionRecoveryOwner } from "./main-session-recovery-store.js";
-import { resolveRestartRecoveryStorePaths } from "./main-session-restart-recovery-shared.js";
+import {
+  mainSessionRecoveryLog,
+  resolveRestartRecoveryStorePaths,
+} from "./main-session-restart-recovery-shared.js";
 import { recoverStore } from "./main-session-restart-recovery-store.js";
 import {
   markRestartAbortedMainSessions,
@@ -619,6 +622,70 @@ describe("main-session-restart-recovery", () => {
       }),
     ).resolves.toEqual({ recovered: 1, failed: 0, skipped: 0 });
     expect(gatewayParams()).toMatchObject({ agentId: "main", sessionKey: "global" });
+  });
+
+  it("never marks or resumes externally owned sessions across repeated restarts", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const storePath = path.join(sessionsDir, "sessions.json");
+    await writeMainSession({
+      sessionsDir,
+      restartRecoveryOwner: "external",
+      abortedLastRun: false,
+    });
+    const infoSpy = vi
+      .spyOn(mainSessionRecoveryLog, "info")
+      .mockImplementation(() => undefined);
+
+    try {
+      await expect(
+        markRestartAbortedMainSessions({
+          stateDir: tmpDir,
+          sessionKeys: ["agent:main:main"],
+        }),
+      ).resolves.toEqual({ marked: 0, skipped: 1 });
+      await expect(
+        markStartupOrphanedMainSessionsForRecovery({ stateDir: tmpDir }),
+      ).resolves.toEqual({ marked: 0, skipped: 1 });
+      await expect(
+        markStartupOrphanedMainSessionsForRecovery({ stateDir: tmpDir }),
+      ).resolves.toEqual({ marked: 0, skipped: 1 });
+
+      expect(loadSessionEntry({ sessionKey: "agent:main:main", storePath })).toMatchObject({
+        restartRecoveryOwner: "external",
+        status: "running",
+      });
+      expect(
+        loadSessionEntry({ sessionKey: "agent:main:main", storePath })?.mainRestartRecovery,
+      ).toBeUndefined();
+      expect(loadSessionEntry({ sessionKey: "agent:main:main", storePath })?.abortedLastRun).toBe(
+        false,
+      );
+
+      await writeMainSession({
+        sessionsDir,
+        restartRecoveryOwner: "external",
+        abortedLastRun: true,
+        mainRestartRecovery: {
+          cycleId: "legacy-recovery-cycle",
+          revision: 1,
+          chargedAttempts: 0,
+        },
+      });
+      await expectRecovery({ recovered: 0, failed: 0, skipped: 1 });
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(infoSpy).toHaveBeenCalledWith("skipping main-session restart recovery", {
+        phase: "mark",
+        reason: "external_owner",
+        sessionKey: "agent:main:main",
+      });
+      expect(infoSpy).toHaveBeenCalledWith("skipping main-session restart recovery", {
+        phase: "dispatch",
+        reason: "external_owner",
+        sessionKey: "agent:main:main",
+      });
+    } finally {
+      infoSpy.mockRestore();
+    }
   });
 
   it("persists abort-registry runs after their event context was cleared", async () => {

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -632,9 +632,7 @@ describe("main-session-restart-recovery", () => {
       restartRecoveryOwner: "external",
       abortedLastRun: false,
     });
-    const infoSpy = vi
-      .spyOn(mainSessionRecoveryLog, "info")
-      .mockImplementation(() => undefined);
+    const infoSpy = vi.spyOn(mainSessionRecoveryLog, "info").mockImplementation(() => undefined);
 
     try {
       await expect(

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it } from "vitest";
-import type { SessionEntry } from "../../config/sessions.js";
+import type { InternalSessionEntry as SessionEntry } from "../../config/sessions.js";
 import {
   loadSessionEntry,
   upsertSessionEntryCore,
@@ -734,6 +734,7 @@ describe("incrementCompactionCount", () => {
       sessionId: "old-session-id",
       updatedAt: Date.now(),
       compactionCount: 1,
+      restartRecoveryOwner: "external",
     } as SessionEntry;
     const { storePath, sessionKey, sessionStore } = await createCompactionSessionFixture(entry);
 
@@ -748,6 +749,8 @@ describe("incrementCompactionCount", () => {
     const stored = { [sessionKey]: await loadStoredEntry(storePath, sessionKey) };
     expect(requireStoredSession(stored, sessionKey).sessionId).toBe("new-session-id");
     expect(requireStoredSession(stored, sessionKey).compactionCount).toBe(2);
+    expect(sessionStore[sessionKey]?.restartRecoveryOwner).toBeUndefined();
+    expect(requireStoredSession(stored, sessionKey).restartRecoveryOwner).toBeUndefined();
   });
 
   it("keeps sessionId when newSessionId matches current sessionId", async () => {
@@ -755,6 +758,7 @@ describe("incrementCompactionCount", () => {
       sessionId: "same-id",
       updatedAt: Date.now(),
       compactionCount: 0,
+      restartRecoveryOwner: "external",
     } as SessionEntry;
     const { storePath, sessionKey, sessionStore } = await createCompactionSessionFixture(entry);
 
@@ -769,6 +773,7 @@ describe("incrementCompactionCount", () => {
     const stored = { [sessionKey]: await loadStoredEntry(storePath, sessionKey) };
     expect(requireStoredSession(stored, sessionKey).sessionId).toBe("same-id");
     expect(requireStoredSession(stored, sessionKey).compactionCount).toBe(1);
+    expect(requireStoredSession(stored, sessionKey).restartRecoveryOwner).toBe("external");
   });
 
   it("marks totalTokens stale when tokensAfter is not provided", async () => {

--- a/src/auto-reply/reply/session-parent-fork-prepare.ts
+++ b/src/auto-reply/reply/session-parent-fork-prepare.ts
@@ -52,13 +52,14 @@ export async function prepareReplySessionParentFork(params: {
     `forking from parent session: parentKey=${params.parentSessionKey} → sessionKey=${params.sessionKey} ` +
       `parentTokens=${decision.parentTokens ?? "unknown"}`,
   );
-  // The fork replaces this thread's transcript identity; recovery state from
-  // the preseed row must not govern a later interruption of the fork.
+  // The fork replaces this thread's transcript identity; recovery policy and
+  // state from the preseed row must not govern a later interruption of the fork.
   const forkedEntry: InternalSessionEntry = {
     ...params.sessionEntry,
     ...buildMainSessionRecoveryClearPatch(params.sessionEntry),
     sessionId: fork.sessionId,
     lifecycleRunId: undefined,
+    restartRecoveryOwner: undefined,
     forkSource: {
       sessionKey: params.parentSessionKey,
       sessionId: parentEntry.sessionId,

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -5,7 +5,10 @@ import {
   type ExecPolicyOverrides,
   resolveNodeExecEligibility,
 } from "../../agents/exec-defaults.js";
-import { SESSION_TOTAL_TOKENS_VERSION, type SessionEntry } from "../../config/sessions.js";
+import {
+  SESSION_TOTAL_TOKENS_VERSION,
+  type InternalSessionEntry as SessionEntry,
+} from "../../config/sessions.js";
 import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
 import {
   patchSessionEntryCore,
@@ -355,6 +358,7 @@ export async function incrementCompactionCount(params: {
   const sessionIdChanged = Boolean(newSessionId && newSessionId !== entry.sessionId);
   if (sessionIdChanged && newSessionId) {
     updates.sessionId = newSessionId;
+    updates.restartRecoveryOwner = undefined;
     updates.usageFamilyKey = entry.usageFamilyKey ?? sessionKey;
     updates.usageFamilySessionIds = Array.from(
       new Set([...(entry.usageFamilySessionIds ?? []), entry.sessionId, newSessionId]),

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -610,6 +610,7 @@ describe("initSessionState thread forking", () => {
         totalTokens: 0,
         totalTokensFresh: true,
         abortedLastRun: true,
+        restartRecoveryOwner: "external",
         restartRecoveryRuns: [{ runId: "old-run", lifecycleGeneration: "old-generation" }],
         mainRestartRecovery: {
           cycleId: "old-cycle",
@@ -650,6 +651,7 @@ describe("initSessionState thread forking", () => {
     expect(first.sessionEntry.totalTokens).toBeUndefined();
     expect(first.sessionEntry.totalTokensFresh).toBe(false);
     expect(first.sessionEntry.abortedLastRun).toBe(false);
+    expect((first.sessionEntry as SessionEntry).restartRecoveryOwner).toBeUndefined();
     expect(first.sessionEntry.restartRecoveryRuns).toBeUndefined();
     expect((first.sessionEntry as SessionEntry).mainRestartRecovery).toBeUndefined();
 
@@ -666,6 +668,7 @@ describe("initSessionState thread forking", () => {
     expect(second.sessionEntry.forkedFromParent).toBe(true);
     expect(second.sessionEntry.totalTokens).toBeUndefined();
     expect(second.sessionEntry.totalTokensFresh).toBe(false);
+    expect((second.sessionEntry as SessionEntry).restartRecoveryOwner).toBeUndefined();
     expect(second.sessionEntry.restartRecoveryRuns).toBeUndefined();
     expect((second.sessionEntry as SessionEntry).mainRestartRecovery).toBeUndefined();
     warn.mockRestore();

--- a/src/config/sessions/session-accessor.parent-fork.test.ts
+++ b/src/config/sessions/session-accessor.parent-fork.test.ts
@@ -14,6 +14,7 @@ import {
   replaceSessionEntry,
   replaceTranscriptEvents,
 } from "./session-accessor.js";
+import type { InternalSessionEntry } from "./types.js";
 
 const roots: string[] = [];
 
@@ -740,16 +741,15 @@ describe("forkSessionFromParentTranscript", () => {
       { sessionKey: parentKey, storePath },
       { sessionId: parentSessionId, updatedAt: 1 },
     );
-    await replaceSessionEntry(
-      { sessionKey: childKey, storePath },
-      {
-        sessionId: "old-child",
-        updatedAt: 1,
-        totalTokens: 88_876,
-        totalTokensFresh: true,
-        totalTokensVersion: 1,
-      },
-    );
+    const previousChild: InternalSessionEntry = {
+      sessionId: "old-child",
+      updatedAt: 1,
+      totalTokens: 88_876,
+      totalTokensFresh: true,
+      totalTokensVersion: 1,
+      restartRecoveryOwner: "external",
+    };
+    await replaceSessionEntry({ sessionKey: childKey, storePath }, previousChild);
     await seedParentTranscript({
       storePath,
       parentSessionId,
@@ -775,5 +775,6 @@ describe("forkSessionFromParentTranscript", () => {
     expect(childEntry?.totalTokens).toBeUndefined();
     expect(childEntry?.totalTokensFresh).toBe(false);
     expect(childEntry?.totalTokensVersion).toBeUndefined();
+    expect((childEntry as InternalSessionEntry | undefined)?.restartRecoveryOwner).toBeUndefined();
   });
 });

--- a/src/config/sessions/session-accessor.sqlite-checkpoint.ts
+++ b/src/config/sessions/session-accessor.sqlite-checkpoint.ts
@@ -455,6 +455,7 @@ function cloneSqliteCheckpointSessionEntry(params: {
     systemSent: false,
     abortedLastRun: false,
     lifecycleRunId: undefined,
+    restartRecoveryOwner: undefined,
     startedAt: undefined,
     endedAt: undefined,
     runtimeMs: undefined,

--- a/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
@@ -223,6 +223,8 @@ describe("SQLite session message cuts", () => {
     "%s invalidates the source cache and lists the resulting branch",
     async (mode) => {
       const { env, scope } = await createSession();
+      const ownerPatch: Partial<InternalSessionEntry> = { restartRecoveryOwner: "external" };
+      await updateSessionEntry(scope, () => ownerPatch);
       const aliasKey = `${sessionKey}:alias`;
       const targetKey = `${sessionKey}:fork`;
       const sourceEntry = loadSessionEntry(scope);
@@ -256,6 +258,15 @@ describe("SQLite session message cuts", () => {
                 targetKey,
               });
       expect(result.status).toBe("created");
+      expect(
+        (
+          loadSessionEntry({
+            agentId,
+            env,
+            sessionKey: mode === "fork" ? targetKey : sessionKey,
+          }) as InternalSessionEntry | undefined
+        )?.restartRecoveryOwner,
+      ).toBeUndefined();
 
       const loadsBeforeAliasRead = fullTranscriptLoads();
       await listSessionBranches({ agentId, env, sessionKey: aliasKey });

--- a/src/config/sessions/session-accessor.sqlite-message-cut.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.ts
@@ -507,6 +507,7 @@ function cloneMessageCutSessionEntry(params: {
     systemSent: false,
     abortedLastRun: false,
     lifecycleRunId: undefined,
+    restartRecoveryOwner: undefined,
     startedAt: undefined,
     endedAt: undefined,
     runtimeMs: undefined,

--- a/src/config/sessions/session-accessor.sqlite-parent-session.ts
+++ b/src/config/sessions/session-accessor.sqlite-parent-session.ts
@@ -226,6 +226,7 @@ export async function forkSessionEntryFromParentTarget(
         },
         forkedFromParent: true,
         lifecycleRunId: undefined,
+        restartRecoveryOwner: undefined,
         sessionId: fork.transcript.sessionId,
         totalTokens: undefined,
         totalTokensFresh: false,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -302,6 +302,8 @@ export type RestartRecoveryRun = {
   lifecycleGeneration: string;
 };
 
+type RestartRecoveryOwner = "openclaw" | "external";
+
 type SessionEntryCore = SessionRestartRecoveryState &
   SessionEntryProvenance & {
     /** Collaboration mode. Missing legacy values are equivalent to "shared". */
@@ -603,6 +605,8 @@ export type InternalSessionEntryCore = SessionEntryCore & {
   lifecycleRunId?: string;
   /** Run admitted by the session lane; overwritten at admission and checked by transcript writes. */
   activeWriterRunId?: string;
+  /** Owner responsible for retrying work interrupted by a Gateway restart. */
+  restartRecoveryOwner?: RestartRecoveryOwner;
   mainRestartRecovery?: MainRestartRecoveryState;
 };
 

--- a/src/gateway/agent-turn/agent-session-persist.ts
+++ b/src/gateway/agent-turn/agent-session-persist.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import { buildMainSessionRecoveryClearPatch } from "../../agents/main-session-recovery/main-session-recovery-clear.js";
 import { transitionMainSessionRecovery } from "../../agents/main-session-recovery/main-session-recovery-state.js";
 import type { MainSessionRecoveryOwnerLease } from "../../agents/main-session-recovery/main-session-recovery-store.js";
 import { MAX_RECOVERY_RETRIES } from "../../agents/main-session-recovery/main-session-restart-recovery-shared.js";
@@ -21,6 +22,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeCronScheduledToolPolicy } from "../../cron/scheduled-tool-policy.js";
 import { assertAgentRunLifecycleGenerationCurrent } from "../../infra/agent-events.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
+import { isCompetingSessionWorkAdmissionActive } from "../../sessions/session-lifecycle-admission.js";
 import { recordSessionCreated } from "../../sessions/session-state-events.js";
 import { getGeneratedMediaTaskIdsForSessionKey } from "../../tasks/task-status-access.js";
 import { sessionDeliveryChannel } from "../../utils/delivery-context.shared.js";
@@ -151,6 +153,7 @@ export async function persistAgentSessionPhase(params: {
     let deletedDuringStoreUpdateError: string | undefined;
     let restoredCronContinuationError: string | undefined;
     let restartRecoveryReservationConflict: string | undefined;
+    let restartRecoveryOwnerConflict: string | undefined;
     try {
       persisted =
         (await patchSessionEntryTarget(
@@ -183,9 +186,36 @@ export async function persistAgentSessionPhase(params: {
               throw new Error(archivedError);
             }
             const internalFreshEntry = freshEntry as InternalSessionEntry | undefined;
+            const requestedRestartRecoveryOwner = params.request.restartRecoveryOwner;
+            const currentRestartRecoveryOwner =
+              internalFreshEntry?.restartRecoveryOwner ?? "openclaw";
+            const restartRecoveryOwnerChanged =
+              requestedRestartRecoveryOwner !== undefined &&
+              requestedRestartRecoveryOwner !== currentRestartRecoveryOwner;
+            const restartRecoveryClearPatch =
+              requestedRestartRecoveryOwner !== undefined &&
+              (requestedRestartRecoveryOwner === "external" || restartRecoveryOwnerChanged)
+                ? buildMainSessionRecoveryClearPatch(internalFreshEntry)
+                : {};
+            const retiresRestartRecoveryState = Object.keys(restartRecoveryClearPatch).length > 0;
+            if (
+              (restartRecoveryOwnerChanged || retiresRestartRecoveryState) &&
+              isCompetingSessionWorkAdmissionActive(params.storePath, [
+                params.canonicalSessionKey,
+                freshEntry?.sessionId,
+              ])
+            ) {
+              restartRecoveryOwnerConflict = restartRecoveryOwnerChanged
+                ? `Session "${params.canonicalSessionKey}" restart recovery owner cannot change ` +
+                  "while another turn is active; retry after it settles."
+                : `Session "${params.canonicalSessionKey}" restart recovery state cannot be ` +
+                  "retired while another turn is active; retry after it settles.";
+              throw new Error(restartRecoveryOwnerConflict);
+            }
             if (
               !params.isRestartRecoveryResumeRun &&
               internalFreshEntry &&
+              !retiresRestartRecoveryState &&
               (internalFreshEntry.mainRestartRecovery?.tombstone ||
                 (internalFreshEntry.status === "running" &&
                   internalFreshEntry.abortedLastRun === true &&
@@ -282,10 +312,19 @@ export async function persistAgentSessionPhase(params: {
                   ...lifecyclePatch,
                   ...buildSessionCreationStamp(params.creation),
                 };
+            const effectivePatchWithRecoveryOwner = {
+              ...effectivePatch,
+              ...(requestedRestartRecoveryOwner
+                ? {
+                    ...restartRecoveryClearPatch,
+                    restartRecoveryOwner: requestedRestartRecoveryOwner,
+                  }
+                : {}),
+            };
             createdNewEntry = freshEntry === undefined;
             const merged = withSqliteSessionFileMarker({
               agentId: params.sessionAgentId,
-              entry: mergeSessionEntry(entryForPatch, effectivePatch),
+              entry: mergeSessionEntry(entryForPatch, effectivePatchWithRecoveryOwner),
               sessionKey: params.canonicalSessionKey,
               storePath: params.storePath,
             });
@@ -382,6 +421,14 @@ export async function persistAgentSessionPhase(params: {
           false,
           undefined,
           errorShape(ErrorCodes.UNAVAILABLE, restartRecoveryReservationConflict),
+        );
+        return undefined;
+      }
+      if (restartRecoveryOwnerConflict) {
+        params.respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.UNAVAILABLE, restartRecoveryOwnerConflict),
         );
         return undefined;
       }

--- a/src/gateway/agent-turn/agent-turn-service.ts
+++ b/src/gateway/agent-turn/agent-turn-service.ts
@@ -420,49 +420,60 @@ export function createAgentTurnService({
         if (respondToGatewayAdmissionOutcome()) {
           return;
         }
-        const persistedSession = await persistAgentSessionPhase({
-          request,
-          cfg: cfgLocal,
-          storePath,
-          storeKeys,
-          entry,
-          canonicalSessionKey,
-          sessionAgentId,
-          mainSessionKey,
-          creation: resolveAgentRunSessionCreation(principal),
-          lifecycleGeneration,
-          isRestartRecoveryResumeRun,
-          runId,
-          agentId,
-          suppressVisibleSessionEffects,
-          restoredCronContinuationIdentity,
-          initialPatchBuild: patchBuild,
-          buildSessionPatch,
-          initialSessionEntry: sessionEntry,
-          initialResolvedSessionId: resolvedSessionId,
-          initialSessionPersistedBeforeGatewayAdmission: sessionPersistedBeforeGatewayAdmission,
-          initialSupersededSessionId: supersededSessionId,
-          touchInteraction,
-          requestedBestEffortDeliver,
-          bestEffortDeliver,
-          expectedSession,
-          maintenanceConfig: sessionMaintenanceConfig,
-          abortForLifecycleRotation,
-          assertGatewayWorkAdmissionAllowed,
-          respondToGatewayAdmissionOutcome,
-          updateAdmissionState: (state) => {
-            resolvedSessionId = state.resolvedSessionId;
-            admittedSessionId = state.admittedSessionId;
-            supersededSessionId = state.supersededSessionId;
-            sessionPersistedBeforeGatewayAdmission = state.sessionPersistedBeforeGatewayAdmission;
-          },
-          getAdmittedSessionId: () => admittedSessionId,
-          setCronContinuationClaim: cronContinuation.setClaim,
-          setMainRestartRecoveryOwnerLease: (lease) => {
-            mainRestartRecoveryOwnerLease = lease;
-          },
-          respond,
-        });
+        const sessionWorkAdmission = admissionController.getAdmission();
+        if (!sessionWorkAdmission) {
+          io.emitAcceptance([
+            false,
+            undefined,
+            errorShape(ErrorCodes.UNAVAILABLE, "agent session admission failed"),
+          ]);
+          return;
+        }
+        const persistSession = () =>
+          persistAgentSessionPhase({
+            request,
+            cfg: cfgLocal,
+            storePath,
+            storeKeys,
+            entry,
+            canonicalSessionKey,
+            sessionAgentId,
+            mainSessionKey,
+            creation: resolveAgentRunSessionCreation(principal),
+            lifecycleGeneration,
+            isRestartRecoveryResumeRun,
+            runId,
+            agentId,
+            suppressVisibleSessionEffects,
+            restoredCronContinuationIdentity,
+            initialPatchBuild: patchBuild,
+            buildSessionPatch,
+            initialSessionEntry: sessionEntry,
+            initialResolvedSessionId: resolvedSessionId,
+            initialSessionPersistedBeforeGatewayAdmission: sessionPersistedBeforeGatewayAdmission,
+            initialSupersededSessionId: supersededSessionId,
+            touchInteraction,
+            requestedBestEffortDeliver,
+            bestEffortDeliver,
+            expectedSession,
+            maintenanceConfig: sessionMaintenanceConfig,
+            abortForLifecycleRotation,
+            assertGatewayWorkAdmissionAllowed,
+            respondToGatewayAdmissionOutcome,
+            updateAdmissionState: (state) => {
+              resolvedSessionId = state.resolvedSessionId;
+              admittedSessionId = state.admittedSessionId;
+              supersededSessionId = state.supersededSessionId;
+              sessionPersistedBeforeGatewayAdmission = state.sessionPersistedBeforeGatewayAdmission;
+            },
+            getAdmittedSessionId: () => admittedSessionId,
+            setCronContinuationClaim: cronContinuation.setClaim,
+            setMainRestartRecoveryOwnerLease: (lease) => {
+              mainRestartRecoveryOwnerLease = lease;
+            },
+            respond,
+          });
+        const persistedSession = await sessionWorkAdmission.run(persistSession);
         if (!persistedSession) {
           return;
         }

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -155,6 +155,27 @@ describe("method scope resolution", () => {
     ).toEqual({ allowed: false, missingScope: "operator.admin" });
   });
 
+  it("raises agent restart recovery ownership changes from write to admin scope", () => {
+    expect(
+      resolveLeastPrivilegeOperatorScopesForMethod("agent", {
+        message: "start orchestrated work",
+        restartRecoveryOwner: "external",
+      }),
+    ).toEqual(["operator.admin"]);
+    expect(
+      resolveLeastPrivilegeOperatorScopesForMethod("agent", {
+        message: "return recovery to OpenClaw",
+        restartRecoveryOwner: "openclaw",
+      }),
+    ).toEqual(["operator.admin"]);
+    expect(
+      authorizeOperatorScopesForMethod("agent", ["operator.write"], {
+        message: "start orchestrated work",
+        restartRecoveryOwner: "external",
+      }),
+    ).toEqual({ allowed: false, missingScope: "operator.admin" });
+  });
+
   it("raises host-sensitive node commands from write to admin scope", () => {
     expect(
       resolveLeastPrivilegeOperatorScopesForMethod("node.invoke", { command: "device.info" }),

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -174,6 +174,18 @@ describe("method scope resolution", () => {
         restartRecoveryOwner: "external",
       }),
     ).toEqual({ allowed: false, missingScope: "operator.admin" });
+    expect(
+      resolveLeastPrivilegeOperatorScopesForMethod("agent", {
+        message: "reject malformed ownership",
+        restartRecoveryOwner: "scheduler",
+      }),
+    ).toEqual(["operator.write"]);
+    expect(
+      authorizeOperatorScopesForMethod("agent", ["operator.write"], {
+        message: "reject malformed ownership",
+        restartRecoveryOwner: "scheduler",
+      }),
+    ).toEqual({ allowed: true });
   });
 
   it("raises host-sensitive node commands from write to admin scope", () => {

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -141,7 +141,7 @@ function resolveDynamicLeastPrivilegeOperatorScopesForMethod(
       params && typeof params === "object" && !Array.isArray(params)
         ? (params as { restartRecoveryOwner?: unknown }).restartRecoveryOwner
         : undefined;
-    if (restartRecoveryOwner !== undefined) {
+    if (restartRecoveryOwner === "openclaw" || restartRecoveryOwner === "external") {
       return [ADMIN_SCOPE];
     }
     const message =

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -137,6 +137,13 @@ function resolveDynamicLeastPrivilegeOperatorScopesForMethod(
     return resolveSessionActionLeastPrivilegeScopes(params);
   }
   if (method === "agent") {
+    const restartRecoveryOwner =
+      params && typeof params === "object" && !Array.isArray(params)
+        ? (params as { restartRecoveryOwner?: unknown }).restartRecoveryOwner
+        : undefined;
+    if (restartRecoveryOwner !== undefined) {
+      return [ADMIN_SCOPE];
+    }
     const message =
       params && typeof params === "object" && !Array.isArray(params)
         ? (params as { message?: unknown }).message

--- a/src/gateway/server-methods/agent-request-types.ts
+++ b/src/gateway/server-methods/agent-request-types.ts
@@ -10,6 +10,7 @@ export type AgentRunRequest = {
   replyTo?: string;
   sessionId?: string;
   sessionKey?: string;
+  restartRecoveryOwner?: "openclaw" | "external";
   expectedExistingSessionId?: string;
   thinking?: string;
   deliver?: boolean;

--- a/src/gateway/server-methods/agent-session-patch.test.ts
+++ b/src/gateway/server-methods/agent-session-patch.test.ts
@@ -61,4 +61,36 @@ describe("agent session patch", () => {
   it("keeps the existing label when the request has none", () => {
     expect(buildPatch(false, { label: "Existing" }).label).toBe("Existing");
   });
+
+  it("clears restart recovery ownership when rotating the session generation", () => {
+    const entry: SessionEntry = {
+      sessionId: "session-old",
+      updatedAt: 0,
+      restartRecoveryOwner: "external",
+    };
+
+    const result = buildAgentSessionPatch({
+      freshEntry: entry,
+      initialEntry: entry,
+      cfg: {},
+      sessionAgentId: "main",
+      canonicalSessionKey: "agent:main:main",
+      storePath: "/tmp/openclaw-recovery-owner-rotation-test.json",
+      normalizedSpawned: {},
+      requestDeliveryHint: undefined,
+      hasRestoredCronContinuation: false,
+      resetPolicy: resolveSessionResetPolicy({ resetType: "direct" }),
+      now: 1_000,
+      isSystemGatewayRun: false,
+      visibleRequest: true,
+      fallbackSessionId: "session-new",
+      touchInteraction: true,
+      failedSessionTranscriptMissing: () => false,
+    });
+
+    expect(result).toMatchObject({ isNewSession: true, rotatedSessionId: true });
+    expect(result.patch.sessionId).toBe("session-new");
+    expect(Object.hasOwn(result.patch, "restartRecoveryOwner")).toBe(true);
+    expect(result.patch.restartRecoveryOwner).toBeUndefined();
+  });
 });

--- a/src/gateway/server-methods/agent-session-patch.ts
+++ b/src/gateway/server-methods/agent-session-patch.ts
@@ -230,6 +230,7 @@ export function buildAgentSessionPatch(params: {
         }
       : {}),
     ...automaticRecoveryClearPatch,
+    ...(shouldClearRotatedState ? { restartRecoveryOwner: undefined } : {}),
     delivery,
     ...(labelValue ? { label: labelValue } : {}),
     ...(freshSpawnedBy ? { spawnedBy: freshSpawnedBy } : {}),

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -3,10 +3,12 @@
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { AcpRuntimeError } from "../acp/runtime/errors.js";
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
-import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import type { InternalSessionEntry } from "../config/sessions.js";
+import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { registerAgentRunContext } from "../infra/agent-run-registry.js";
 import {
@@ -300,6 +302,207 @@ describe("gateway server agent", () => {
     expect(stored?.claudeCliSessionId).toBe("cli-session-123");
   });
 
+  test("agent persists restart recovery ownership across unrelated session updates", async () => {
+    await useTempSessionStorePath();
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-external-recovery-owner",
+          updatedAt: Date.now(),
+        },
+      },
+    });
+
+    const setExternal = await rpcReq(ws, "agent", {
+      message: "start externally orchestrated work",
+      sessionKey: "main",
+      restartRecoveryOwner: "external",
+      idempotencyKey: "idem-agent-recovery-owner-external",
+    });
+    expect(setExternal.ok).toBe(true);
+    await readAgentCommandCall({ runId: "idem-agent-recovery-owner-external" });
+
+    const sessionStorePath = testState.sessionStorePath;
+    if (!sessionStorePath) {
+      throw new Error("expected session store path");
+    }
+    const loadStored = () =>
+      loadSessionEntry({
+        sessionKey: "agent:main:main",
+        storePath: sessionStorePath,
+      }) as InternalSessionEntry | undefined;
+    expect(loadStored()?.restartRecoveryOwner).toBe("external");
+
+    const updateMetadata = await rpcReq(ws, "agent", {
+      message: "continue without changing recovery ownership",
+      sessionKey: "main",
+      label: "externally orchestrated",
+      idempotencyKey: "idem-agent-recovery-owner-preserved",
+    });
+    expect(updateMetadata.ok).toBe(true);
+    await readAgentCommandCall({ runId: "idem-agent-recovery-owner-preserved" });
+    expect(loadStored()?.restartRecoveryOwner).toBe("external");
+
+    const externalEntry = loadStored();
+    if (!externalEntry) {
+      throw new Error("expected externally owned session entry");
+    }
+    const interruptedExternalEntry: InternalSessionEntry = {
+      ...externalEntry,
+      status: "running",
+      abortedLastRun: true,
+      mainRestartRecovery: {
+        cycleId: "stale-external-cycle",
+        revision: 2,
+        chargedAttempts: 1,
+      },
+    };
+    await replaceSessionEntry(
+      { sessionKey: "agent:main:main", storePath: sessionStorePath },
+      interruptedExternalEntry,
+    );
+
+    const returnToOpenClaw = await rpcReq(ws, "agent", {
+      message: "return restart recovery to OpenClaw",
+      sessionKey: "main",
+      restartRecoveryOwner: "openclaw",
+      idempotencyKey: "idem-agent-recovery-owner-openclaw",
+    });
+    expect(returnToOpenClaw.ok).toBe(true);
+    await readAgentCommandCall({ runId: "idem-agent-recovery-owner-openclaw" });
+    expect(loadStored()?.restartRecoveryOwner).toBe("openclaw");
+    expect(loadStored()?.abortedLastRun).toBe(false);
+    expect(loadStored()?.mainRestartRecovery).toBeUndefined();
+  });
+
+  test.each([
+    {
+      name: "tombstoned",
+      entry: {
+        abortedLastRun: false,
+        mainRestartRecovery: {
+          chargedAttempts: 3,
+          cycleId: "tombstoned-cycle",
+          revision: 4,
+          tombstone: { reason: "automatic recovery exhausted" },
+        },
+        sessionId: "sess-tombstoned-recovery-owner",
+        status: "failed",
+        updatedAt: 10,
+      } satisfies InternalSessionEntry,
+    },
+    {
+      name: "exhausted",
+      entry: {
+        abortedLastRun: true,
+        mainRestartRecovery: {
+          chargedAttempts: 3,
+          cycleId: "exhausted-cycle",
+          revision: 4,
+        },
+        sessionId: "sess-exhausted-recovery-owner",
+        status: "running",
+        updatedAt: 10,
+      } satisfies InternalSessionEntry,
+    },
+  ])("agent transfers $name recovery quarantine to an external owner", async ({ name, entry }) => {
+    await useTempSessionStorePath();
+    const sessionStorePath = testState.sessionStorePath;
+    if (!sessionStorePath) {
+      throw new Error("expected session store path");
+    }
+    await replaceSessionEntry(
+      { sessionKey: "agent:main:main", storePath: sessionStorePath },
+      entry,
+    );
+
+    const runId = `idem-agent-recovery-owner-${name}`;
+    const transfer = await rpcReq(ws, "agent", {
+      message: `transfer ${name} recovery to the external orchestrator`,
+      sessionKey: "main",
+      restartRecoveryOwner: "external",
+      idempotencyKey: runId,
+    });
+    expect(transfer.ok).toBe(true);
+    await readAgentCommandCall({ runId });
+    const settled = await rpcReq(ws, "agent.wait", { runId, timeoutMs: 5_000 });
+    expect(settled.ok).toBe(true);
+
+    const stored = loadSessionEntry({
+      sessionKey: "agent:main:main",
+      storePath: sessionStorePath,
+    }) as InternalSessionEntry | undefined;
+    expect(stored?.restartRecoveryOwner).toBe("external");
+    expect(stored?.abortedLastRun).toBe(false);
+    expect(stored?.mainRestartRecovery).toBeUndefined();
+    expect(stored?.restartRecoveryRuns).toBeUndefined();
+  });
+
+  test("agent rejects restart recovery ownership changes during active work", async () => {
+    await writeMainSessionEntry({ sessionId: "sess-active-recovery-owner" });
+    const runCompletion = createDeferred();
+    vi.mocked(agentCommand).mockImplementationOnce(async () => {
+      await runCompletion.promise;
+    });
+
+    const firstRun = await rpcReq(ws, "agent", {
+      message: "keep this OpenClaw-owned turn active",
+      sessionKey: "main",
+      idempotencyKey: "idem-agent-recovery-owner-active",
+    });
+    expect(firstRun.ok).toBe(true);
+    await readAgentCommandCall({ runId: "idem-agent-recovery-owner-active" });
+
+    const conflictingChange = await rpcReq(ws, "agent", {
+      message: "change ownership while the prior turn is active",
+      sessionKey: "main",
+      restartRecoveryOwner: "external",
+      idempotencyKey: "idem-agent-recovery-owner-conflict",
+    });
+    expect(conflictingChange.ok).toBe(false);
+    expect(conflictingChange.error).toMatchObject({
+      code: "UNAVAILABLE",
+      message: expect.stringContaining("cannot change while another turn is active"),
+    });
+
+    const sessionStorePath = testState.sessionStorePath;
+    if (!sessionStorePath) {
+      throw new Error("expected session store path");
+    }
+    expect(
+      (
+        loadSessionEntry({
+          sessionKey: "agent:main:main",
+          storePath: sessionStorePath,
+        }) as InternalSessionEntry | undefined
+      )?.restartRecoveryOwner,
+    ).toBeUndefined();
+
+    runCompletion.resolve();
+    const settled = await rpcReq(ws, "agent.wait", {
+      runId: "idem-agent-recovery-owner-active",
+      timeoutMs: 5_000,
+    });
+    expect(settled.ok).toBe(true);
+
+    const idleChange = await rpcReq(ws, "agent", {
+      message: "change ownership after the prior turn settles",
+      sessionKey: "main",
+      restartRecoveryOwner: "external",
+      idempotencyKey: "idem-agent-recovery-owner-idle",
+    });
+    expect(idleChange.ok).toBe(true);
+    await readAgentCommandCall({ runId: "idem-agent-recovery-owner-idle" });
+    expect(
+      (
+        loadSessionEntry({
+          sessionKey: "agent:main:main",
+          storePath: sessionStorePath,
+        }) as InternalSessionEntry | undefined
+      )?.restartRecoveryOwner,
+    ).toBe("external");
+  });
+
   test("agent accepts built-in channel alias (imsg)", async () => {
     const registry = createRegistry([
       {
@@ -440,6 +643,23 @@ describe("gateway server agent", () => {
       });
       expect(viaAgent.ok).toBe(false);
       expect(viaAgent.error).toMatchObject({
+        code: "FORBIDDEN",
+        message: "missing scope: operator.admin",
+        details: {
+          code: "MISSING_SCOPE",
+          missingScope: "operator.admin",
+          requiredScopes: ["operator.admin"],
+        },
+      });
+
+      const recoveryOwnerChange = await rpcReq(writeWs, "agent", {
+        message: "start externally orchestrated work",
+        sessionKey: "main",
+        restartRecoveryOwner: "external",
+        idempotencyKey: "idem-agent-write-recovery-owner",
+      });
+      expect(recoveryOwnerChange.ok).toBe(false);
+      expect(recoveryOwnerChange.error).toMatchObject({
         code: "FORBIDDEN",
         message: "missing scope: operator.admin",
         details: {

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -476,7 +476,7 @@ describe("gateway server agent", () => {
   test("agent rejects restart recovery ownership changes during active work", async () => {
     await writeMainSessionEntry({ sessionId: "sess-active-recovery-owner" });
     const runCompletion = createDeferred();
-    vi.mocked(agentCommand).mockImplementationOnce(async () => {
+    vi.mocked(agentCommandMock).mockImplementationOnce(async () => {
       await runCompletion.promise;
     });
 

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -375,6 +375,38 @@ describe("gateway server agent", () => {
     expect(loadStored()?.mainRestartRecovery).toBeUndefined();
   });
 
+  test("agent validates malformed recovery ownership before admin authorization", async () => {
+    const writerWs = await connectWebchatClient({ port, scopes: ["operator.write"] });
+    try {
+      const malformed = await rpcReq(writerWs, "agent", {
+        message: "reject malformed recovery ownership",
+        sessionKey: "main",
+        restartRecoveryOwner: "scheduler",
+        idempotencyKey: "idem-agent-recovery-owner-malformed",
+      });
+      expect(malformed.ok).toBe(false);
+      expect(malformed.error).toMatchObject({
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("invalid agent params"),
+      });
+
+      const valid = await rpcReq(writerWs, "agent", {
+        message: "require admin for valid recovery ownership",
+        sessionKey: "main",
+        restartRecoveryOwner: "external",
+        idempotencyKey: "idem-agent-recovery-owner-admin",
+      });
+      expect(valid.ok).toBe(false);
+      expect(valid.error).toMatchObject({
+        code: "FORBIDDEN",
+        message: expect.stringContaining("operator.admin"),
+      });
+      expect(agentCommandMock).not.toHaveBeenCalled();
+    } finally {
+      writerWs.close();
+    }
+  });
+
   test("agent clears restart recovery ownership when rotating the session generation", async () => {
     await useTempSessionStorePath();
     const sessionStorePath = testState.sessionStorePath;

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -375,6 +375,41 @@ describe("gateway server agent", () => {
     expect(loadStored()?.mainRestartRecovery).toBeUndefined();
   });
 
+  test("agent clears restart recovery ownership when rotating the session generation", async () => {
+    await useTempSessionStorePath();
+    const sessionStorePath = testState.sessionStorePath;
+    if (!sessionStorePath) {
+      throw new Error("expected session store path");
+    }
+    const externalEntry: InternalSessionEntry = {
+      sessionId: "sess-external-owner-old-generation",
+      updatedAt: 0,
+      restartRecoveryOwner: "external",
+    };
+    await replaceSessionEntry(
+      { sessionKey: "agent:main:main", storePath: sessionStorePath },
+      externalEntry,
+    );
+
+    const runId = "idem-agent-recovery-owner-rotation";
+    const res = await rpcReq(ws, "agent", {
+      message: "start a fresh OpenClaw-owned generation",
+      sessionKey: "main",
+      idempotencyKey: runId,
+    });
+    expect(res.ok).toBe(true);
+    const call = await readAgentCommandCall({ runId });
+    expect(call.sessionId).toEqual(expect.any(String));
+    expect(call.sessionId).not.toBe("sess-external-owner-old-generation");
+
+    const stored = loadSessionEntry({
+      sessionKey: "agent:main:main",
+      storePath: sessionStorePath,
+    }) as InternalSessionEntry | undefined;
+    expect(stored?.sessionId).toBe(call.sessionId);
+    expect(stored?.restartRecoveryOwner).toBeUndefined();
+  });
+
   test.each([
     {
       name: "tombstoned",

--- a/src/gateway/session-compaction-checkpoints.test.ts
+++ b/src/gateway/session-compaction-checkpoints.test.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 import { CURRENT_SESSION_VERSION, SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { afterEach, describe, expect, test } from "vitest";
-import type { SessionCompactionCheckpoint } from "../config/sessions.js";
+import type { InternalSessionEntry, SessionCompactionCheckpoint } from "../config/sessions.js";
 import { formatSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import {
   appendTranscriptEvent,
@@ -143,6 +143,8 @@ describe("session-compaction-checkpoints", () => {
       updatedAt: Date.now(),
       compactionCheckpoints: [checkpoint],
     });
+    const ownerPatch: Partial<InternalSessionEntry> = { restartRecoveryOwner: "external" };
+    await updateSessionEntry(scope, () => ownerPatch);
 
     const store = createFileBackedCompactionCheckpointStore();
     const branchKey = "agent:main:checkpoint-branch";
@@ -167,6 +169,8 @@ describe("session-compaction-checkpoints", () => {
     }
     expect(branched.entry).not.toHaveProperty("sessionFile");
     expect(restored.entry).not.toHaveProperty("sessionFile");
+    expect((branched.entry as InternalSessionEntry).restartRecoveryOwner).toBeUndefined();
+    expect((restored.entry as InternalSessionEntry).restartRecoveryOwner).toBeUndefined();
     expect(fsSync.readdirSync(dir).some((file) => file.endsWith(".jsonl"))).toBe(false);
 
     const branchEvents = await loadTranscriptEvents({

--- a/src/gateway/session-create-fork-entry.test.ts
+++ b/src/gateway/session-create-fork-entry.test.ts
@@ -8,6 +8,7 @@ describe("buildForkedGatewaySessionEntry", () => {
       sessionId: "adopted-generation",
       updatedAt: 1,
       lifecycleRunId: "adopted-run",
+      restartRecoveryOwner: "external",
       forkSource: { sessionKey: "agent:main:original", sessionId: "original-generation" },
     };
 
@@ -24,6 +25,7 @@ describe("buildForkedGatewaySessionEntry", () => {
       forkSource: { sessionKey: "agent:main:original", sessionId: "original-generation" },
     });
     expect(forked.lifecycleRunId).toBeUndefined();
+    expect(forked.restartRecoveryOwner).toBeUndefined();
   });
 
   it("uses the requested ancestry for a genuinely new node", () => {

--- a/src/gateway/session-create-fork-entry.ts
+++ b/src/gateway/session-create-fork-entry.ts
@@ -7,12 +7,13 @@ export function buildForkedGatewaySessionEntry(
   forkSource: NonNullable<SessionEntry["forkSource"]>,
   previousEntry?: SessionEntry,
 ): SessionEntry {
-  // Replacing the transcript identity also replaces the recovery episode owned by the old row.
+  // Replacing the transcript identity also replaces the recovery policy and episode of the old row.
   return {
     ...entry,
     ...buildMainSessionRecoveryClearPatch(entry),
     sessionId: fork.sessionId,
     lifecycleRunId: undefined,
+    restartRecoveryOwner: undefined,
     forkSource: previousEntry?.forkSource ?? forkSource,
     ...(previousEntry?.sessionId && previousEntry.sessionId !== fork.sessionId
       ? { previousSessionId: previousEntry.sessionId }

--- a/src/plugin-sdk/session-store-runtime-internal.ts
+++ b/src/plugin-sdk/session-store-runtime-internal.ts
@@ -27,7 +27,9 @@ export function toSessionAccessScope(params: SessionStoreReadParams): SessionAcc
 
 export function projectPluginSessionEntry(entry: InternalSessionEntry): SessionEntry {
   const {
+    lifecycleRunId: _lifecycleRunId,
     activeWriterRunId: _activeWriterRunId,
+    restartRecoveryOwner: _restartRecoveryOwner,
     mainRestartRecovery: _mainRestartRecovery,
     ...publicEntry
   } = entry;
@@ -43,7 +45,9 @@ export function projectPluginSessionEntryPatch(
   patch: Partial<InternalSessionEntry>,
 ): Partial<SessionEntry> {
   const {
+    lifecycleRunId: _lifecycleRunId,
     activeWriterRunId: _activeWriterRunId,
+    restartRecoveryOwner: _restartRecoveryOwner,
     mainRestartRecovery: _mainRestartRecovery,
     ...publicPatch
   } = patch;
@@ -61,32 +65,54 @@ export function projectPluginSessionStore(
   );
 }
 
-export function activeRecoveryFieldsForSameSession(
+export function internalFieldsForSameSession(
   existingEntry: InternalSessionEntry | undefined,
   nextSessionId: string | undefined,
 ): Partial<InternalSessionEntry> | undefined {
-  if (
-    !existingEntry ||
-    existingEntry.sessionId !== nextSessionId ||
-    existingEntry.mainRestartRecovery === undefined
-  ) {
+  if (!existingEntry || existingEntry.sessionId !== nextSessionId) {
     return undefined;
   }
   return {
-    activeWriterRunId: existingEntry.activeWriterRunId,
-    abortedLastRun: existingEntry.abortedLastRun,
-    restartRecoveryRuns: existingEntry.restartRecoveryRuns,
-    mainRestartRecovery: existingEntry.mainRestartRecovery,
+    ...(existingEntry.lifecycleRunId !== undefined
+      ? { lifecycleRunId: existingEntry.lifecycleRunId }
+      : {}),
+    ...(existingEntry.activeWriterRunId !== undefined
+      ? { activeWriterRunId: existingEntry.activeWriterRunId }
+      : {}),
+    ...(existingEntry.restartRecoveryOwner !== undefined
+      ? { restartRecoveryOwner: existingEntry.restartRecoveryOwner }
+      : {}),
+    ...(existingEntry.mainRestartRecovery !== undefined
+      ? {
+          abortedLastRun: existingEntry.abortedLastRun,
+          restartRecoveryRuns: existingEntry.restartRecoveryRuns,
+          mainRestartRecovery: existingEntry.mainRestartRecovery,
+        }
+      : {}),
   };
 }
 
-export function clearRecoveryStateForRotatedSessionPatch(
+export function clearInternalStateForRotatedSessionPatch(
+  existingEntry: InternalSessionEntry,
+  publicPatch: SessionEntry,
+): InternalSessionEntry;
+export function clearInternalStateForRotatedSessionPatch(
+  existingEntry: InternalSessionEntry,
+  publicPatch: Partial<SessionEntry>,
+): Partial<InternalSessionEntry>;
+export function clearInternalStateForRotatedSessionPatch(
   existingEntry: InternalSessionEntry,
   publicPatch: Partial<SessionEntry>,
 ): Partial<InternalSessionEntry> {
   return Object.hasOwn(publicPatch, "sessionId") &&
     publicPatch.sessionId !== existingEntry.sessionId
-    ? { ...publicPatch, ...MAIN_SESSION_RECOVERY_CLEAR_PATCH }
+    ? {
+        ...publicPatch,
+        ...MAIN_SESSION_RECOVERY_CLEAR_PATCH,
+        lifecycleRunId: undefined,
+        activeWriterRunId: undefined,
+        restartRecoveryOwner: undefined,
+      }
     : publicPatch;
 }
 
@@ -101,16 +127,16 @@ export function reconcilePluginSessionStore(params: {
   }
   for (const [sessionKey, publicEntry] of Object.entries(params.publicStore)) {
     const projectedEntry = projectPluginSessionEntry(publicEntry as InternalSessionEntry);
-    const existingRecovery = activeRecoveryFieldsForSameSession(
+    const existingInternalFields = internalFieldsForSameSession(
       params.internalStore[sessionKey],
       projectedEntry.sessionId,
     );
     const existingEntry = params.internalStore[sessionKey];
     params.internalStore[sessionKey] =
       existingEntry && existingEntry.sessionId !== projectedEntry.sessionId
-        ? { ...projectedEntry, ...MAIN_SESSION_RECOVERY_CLEAR_PATCH }
-        : existingRecovery
-          ? { ...projectedEntry, ...existingRecovery }
+        ? clearInternalStateForRotatedSessionPatch(existingEntry, projectedEntry)
+        : existingInternalFields
+          ? { ...projectedEntry, ...existingInternalFields }
           : projectedEntry;
   }
 }

--- a/src/plugin-sdk/session-store-runtime.recovery.test.ts
+++ b/src/plugin-sdk/session-store-runtime.recovery.test.ts
@@ -1,9 +1,17 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { loadSessionEntry as loadInternalSessionEntry } from "../config/sessions/session-accessor.js";
 import {
+  loadSessionEntry as loadInternalSessionEntry,
+  patchSessionEntry as patchInternalSessionEntry,
+  replaceSessionEntry as replaceInternalSessionEntry,
+} from "../config/sessions/session-accessor.js";
+import type { InternalSessionEntry } from "../config/sessions/types.js";
+import {
+  getSessionEntry,
+  listSessionEntries,
   patchSessionEntry,
+  updateSessionStoreEntry,
   upsertSessionEntry,
   type SessionEntry,
 } from "./session-store-runtime.js";
@@ -18,6 +26,24 @@ describe("session-store-runtime recovery boundary", () => {
     tempDir = tempDirs.make("openclaw-sdk-session-recovery-");
     storePath = path.join(tempDir, "sessions.json");
   });
+
+  function expectRecoveryCleared(params: {
+    sessionId: string;
+    sessionKey: string;
+    storePath: string;
+  }): void {
+    const entry = loadInternalSessionEntry({
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+    });
+    expect(entry).toMatchObject({ sessionId: params.sessionId });
+    expect(entry?.abortedLastRun).not.toBe(true);
+    expect(entry?.restartRecoveryRuns).toBeUndefined();
+    expect(entry).not.toHaveProperty("mainRestartRecovery");
+    expect(entry).not.toHaveProperty("activeWriterRunId");
+    expect(entry).not.toHaveProperty("lifecycleRunId");
+    expect(entry).not.toHaveProperty("restartRecoveryOwner");
+  }
 
   it("allows public recovery fields to change without an active core transaction", async () => {
     const sessionKey = "agent:main:healthy-public-recovery";
@@ -47,7 +73,7 @@ describe("session-store-runtime recovery boundary", () => {
     });
   });
 
-  it("rejects core recovery state from runtime-escaped creation inputs", async () => {
+  it("rejects core recovery state and ownership from runtime-escaped creation inputs", async () => {
     const mainRestartRecovery = {
       chargedAttempts: 1,
       cycleId: "cycle-injected",
@@ -57,6 +83,7 @@ describe("session-store-runtime recovery boundary", () => {
     await patchSessionEntry({
       fallbackEntry: {
         mainRestartRecovery,
+        restartRecoveryOwner: "external",
         sessionId: "patch-created",
         updatedAt: 10,
       } as unknown as SessionEntry,
@@ -67,11 +94,15 @@ describe("session-store-runtime recovery boundary", () => {
     expect(loadInternalSessionEntry({ sessionKey: patchSessionKey, storePath })).not.toHaveProperty(
       "mainRestartRecovery",
     );
+    expect(loadInternalSessionEntry({ sessionKey: patchSessionKey, storePath })).not.toHaveProperty(
+      "restartRecoveryOwner",
+    );
 
     const upsertSessionKey = "agent:main:upsert-created";
     await upsertSessionEntry({
       entry: {
         mainRestartRecovery,
+        restartRecoveryOwner: "external",
         sessionId: "upsert-created",
         updatedAt: 10,
       } as unknown as SessionEntry,
@@ -81,5 +112,235 @@ describe("session-store-runtime recovery boundary", () => {
     expect(
       loadInternalSessionEntry({ sessionKey: upsertSessionKey, storePath }),
     ).not.toHaveProperty("mainRestartRecovery");
+    expect(
+      loadInternalSessionEntry({ sessionKey: upsertSessionKey, storePath }),
+    ).not.toHaveProperty("restartRecoveryOwner");
+  });
+
+  it("hides core recovery state and preserves it across public mutations", async () => {
+    const sessionKey = "agent:main:recovery-owned";
+    const mainRestartRecovery = {
+      chargedAttempts: 1,
+      cycleId: "cycle-1",
+      reservation: {
+        attempt: 1,
+        lifecycleGeneration: "generation-1",
+        runId: "run-1",
+      },
+      revision: 1,
+    };
+    await replaceInternalSessionEntry({ sessionKey, storePath }, {
+      activeWriterRunId: "run-writer",
+      abortedLastRun: true,
+      lifecycleRunId: "run-lifecycle",
+      mainRestartRecovery,
+      model: "gpt-5.5",
+      restartRecoveryOwner: "external",
+      restartRecoveryRuns: [{ lifecycleGeneration: "generation-1", runId: "run-1" }],
+      sessionId: "session-recovery",
+      updatedAt: 10,
+    } as InternalSessionEntry);
+
+    expect(getSessionEntry({ sessionKey, storePath })).not.toHaveProperty("mainRestartRecovery");
+    expect(getSessionEntry({ sessionKey, storePath })).not.toHaveProperty("activeWriterRunId");
+    expect(getSessionEntry({ sessionKey, storePath })).not.toHaveProperty("lifecycleRunId");
+    expect(getSessionEntry({ sessionKey, storePath })).not.toHaveProperty("restartRecoveryOwner");
+    expect(listSessionEntries({ storePath })[0]?.entry).not.toHaveProperty("mainRestartRecovery");
+
+    await patchSessionEntry({
+      sessionKey,
+      storePath,
+      update: (entry) => {
+        entry.restartRecoveryRuns?.splice(0);
+        return {
+          activeWriterRunId: "injected-writer",
+          abortedLastRun: false,
+          lifecycleRunId: "injected-lifecycle",
+          mainRestartRecovery: undefined,
+          model: "gpt-5.6",
+          restartRecoveryOwner: "openclaw",
+          restartRecoveryRuns: undefined,
+        } as unknown as Partial<SessionEntry>;
+      },
+    });
+    expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
+      activeWriterRunId: "run-writer",
+      abortedLastRun: true,
+      lifecycleRunId: "run-lifecycle",
+      mainRestartRecovery,
+      model: "gpt-5.6",
+      restartRecoveryOwner: "external",
+      restartRecoveryRuns: [{ lifecycleGeneration: "generation-1", runId: "run-1" }],
+    });
+
+    await updateSessionStoreEntry({
+      sessionKey,
+      storePath,
+      update: () => ({ abortedLastRun: false, restartRecoveryRuns: undefined }),
+    });
+    expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
+      activeWriterRunId: "run-writer",
+      abortedLastRun: true,
+      lifecycleRunId: "run-lifecycle",
+      mainRestartRecovery,
+      restartRecoveryOwner: "external",
+      restartRecoveryRuns: [{ lifecycleGeneration: "generation-1", runId: "run-1" }],
+    });
+
+    await upsertSessionEntry({
+      sessionKey,
+      storePath,
+      entry: {
+        sessionId: "session-recovery",
+        updatedAt: 20,
+      },
+    });
+    expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
+      activeWriterRunId: "run-writer",
+      abortedLastRun: true,
+      lifecycleRunId: "run-lifecycle",
+      mainRestartRecovery,
+      restartRecoveryOwner: "external",
+      restartRecoveryRuns: [{ lifecycleGeneration: "generation-1", runId: "run-1" }],
+      sessionId: "session-recovery",
+      updatedAt: 20,
+    });
+    expect(loadInternalSessionEntry({ sessionKey, storePath })?.model).toBeUndefined();
+  });
+
+  it("clears core recovery state when public replacements change session identity", async () => {
+    const patchKey = "agent:main:telegram:direct:patch-rotation";
+    const upsertKey = "agent:main:telegram:direct:upsert-rotation";
+    const upsertStorePath = path.join(tempDir, "upsert-sessions.json");
+    const mainRestartRecovery = {
+      chargedAttempts: 1,
+      cycleId: "rotation-cycle",
+      revision: 1,
+    };
+    await upsertSessionEntry({
+      agentId: "main",
+      entry: {
+        abortedLastRun: true,
+        restartRecoveryRuns: [{ lifecycleGeneration: "patch-generation", runId: "patch-run" }],
+        sessionId: "patch-before",
+        updatedAt: 10,
+      },
+      sessionKey: patchKey,
+      storePath,
+    });
+    await patchInternalSessionEntry(
+      { agentId: "main", sessionKey: patchKey, storePath },
+      () =>
+        ({
+          abortedLastRun: true,
+          mainRestartRecovery,
+          restartRecoveryRuns: [{ lifecycleGeneration: "patch-generation", runId: "patch-run" }],
+        }) as Partial<InternalSessionEntry>,
+    );
+    await upsertSessionEntry({
+      agentId: "main",
+      entry: { sessionId: "upsert-before", updatedAt: 10 },
+      sessionKey: upsertKey,
+      storePath: upsertStorePath,
+    });
+    await patchInternalSessionEntry(
+      { agentId: "main", sessionKey: upsertKey, storePath: upsertStorePath },
+      () =>
+        ({
+          abortedLastRun: true,
+          mainRestartRecovery,
+          restartRecoveryRuns: [{ lifecycleGeneration: "upsert-generation", runId: "upsert-run" }],
+        }) as Partial<InternalSessionEntry>,
+    );
+
+    await patchSessionEntry({
+      replaceEntry: true,
+      sessionKey: patchKey,
+      storePath,
+      update: () => ({ sessionId: "patch-after", updatedAt: 20 }),
+    });
+    await upsertSessionEntry({
+      entry: {
+        abortedLastRun: true,
+        restartRecoveryRuns: [{ lifecycleGeneration: "upsert-generation", runId: "upsert-run" }],
+        sessionId: "upsert-after",
+        updatedAt: 20,
+      },
+      sessionKey: upsertKey,
+      storePath: upsertStorePath,
+    });
+
+    expectRecoveryCleared({ sessionId: "patch-after", sessionKey: patchKey, storePath });
+    expectRecoveryCleared({
+      sessionId: "upsert-after",
+      sessionKey: upsertKey,
+      storePath: upsertStorePath,
+    });
+  });
+
+  it("clears core recovery state when public patches change session identity", async () => {
+    const patchKey = "agent:main:telegram:direct:patch-rotation";
+    const updateKey = "agent:main:telegram:direct:update-rotation";
+    const updateStorePath = path.join(tempDir, "update-patch-sessions.json");
+    const mainRestartRecovery = {
+      chargedAttempts: 1,
+      cycleId: "rotation-cycle",
+      revision: 1,
+    };
+    await upsertSessionEntry({
+      agentId: "main",
+      entry: {
+        abortedLastRun: true,
+        restartRecoveryRuns: [{ lifecycleGeneration: "patch-generation", runId: "patch-run" }],
+        sessionId: "patch-before",
+        updatedAt: 10,
+      },
+      sessionKey: patchKey,
+      storePath,
+    });
+    await upsertSessionEntry({
+      agentId: "main",
+      entry: { sessionId: "update-before", updatedAt: 10 },
+      sessionKey: updateKey,
+      storePath: updateStorePath,
+    });
+    await patchInternalSessionEntry(
+      { agentId: "main", sessionKey: patchKey, storePath },
+      () =>
+        ({
+          abortedLastRun: true,
+          mainRestartRecovery,
+          restartRecoveryRuns: [{ lifecycleGeneration: "patch-generation", runId: "patch-run" }],
+        }) as Partial<InternalSessionEntry>,
+    );
+    await patchInternalSessionEntry(
+      { agentId: "main", sessionKey: updateKey, storePath: updateStorePath },
+      () =>
+        ({
+          abortedLastRun: true,
+          mainRestartRecovery,
+          restartRecoveryRuns: [{ lifecycleGeneration: "update-generation", runId: "update-run" }],
+        }) as Partial<InternalSessionEntry>,
+    );
+
+    await patchSessionEntry({
+      sessionKey: patchKey,
+      skipMaintenance: true,
+      storePath,
+      update: () => ({ sessionId: "patch-after", updatedAt: 20 }),
+    });
+    await updateSessionStoreEntry({
+      sessionKey: updateKey,
+      skipMaintenance: true,
+      storePath: updateStorePath,
+      update: () => ({ sessionId: "update-after", updatedAt: 20 }),
+    });
+
+    expectRecoveryCleared({ sessionId: "patch-after", sessionKey: patchKey, storePath });
+    expectRecoveryCleared({
+      sessionId: "update-after",
+      sessionKey: updateKey,
+      storePath: updateStorePath,
+    });
   });
 });

--- a/src/plugin-sdk/session-store-runtime.recovery.test.ts
+++ b/src/plugin-sdk/session-store-runtime.recovery.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   loadSessionEntry as loadInternalSessionEntry,
-  patchSessionEntry as patchInternalSessionEntry,
+  patchSessionEntryCore as patchInternalSessionEntry,
   replaceSessionEntry as replaceInternalSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import type { InternalSessionEntry } from "../config/sessions/types.js";

--- a/src/plugin-sdk/session-store-runtime.test.ts
+++ b/src/plugin-sdk/session-store-runtime.test.ts
@@ -7,7 +7,6 @@ import {
   appendTranscriptMessage,
   loadSessionEntry as loadInternalSessionEntry,
   patchSessionEntryCore as patchInternalSessionEntry,
-  replaceSessionEntry as replaceInternalSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import type { InternalSessionEntry } from "../config/sessions/types.js";
 import type { SessionEntry as ConfigSessionEntry } from "../config/sessions/types.js";
@@ -60,21 +59,6 @@ describe("session-store-runtime compatibility surface", () => {
       storePath,
       entry,
     });
-  }
-
-  function expectRecoveryCleared(params: {
-    sessionId: string;
-    sessionKey: string;
-    storePath: string;
-  }): void {
-    const entry = loadInternalSessionEntry({
-      sessionKey: params.sessionKey,
-      storePath: params.storePath,
-    });
-    expect(entry).toMatchObject({ sessionId: params.sessionId });
-    expect(entry?.abortedLastRun).not.toBe(true);
-    expect(entry?.restartRecoveryRuns).toBeUndefined();
-    expect(entry).not.toHaveProperty("mainRestartRecovery");
   }
 
   it("keeps the public session read shape while using accessor-backed exports", async () => {
@@ -367,7 +351,13 @@ describe("session-store-runtime compatibility surface", () => {
     });
     await patchInternalSessionEntry(
       { agentId: "main", sessionKey: keptKey, storePath },
-      () => ({ mainRestartRecovery }) as Partial<InternalSessionEntry>,
+      () =>
+        ({
+          activeWriterRunId: "compat-writer",
+          lifecycleRunId: "compat-lifecycle",
+          mainRestartRecovery,
+          restartRecoveryOwner: "external",
+        }) as Partial<InternalSessionEntry>,
     );
     await seedSessionEntry(removedKey, {
       sessionId: "compat-removed-session",
@@ -376,29 +366,38 @@ describe("session-store-runtime compatibility surface", () => {
 
     const compatibilityStore = loadSessionStore(storePath);
     expect(Object.keys(compatibilityStore)).toContain(keptKey);
+    expect(compatibilityStore[keptKey]).not.toHaveProperty("activeWriterRunId");
+    expect(compatibilityStore[keptKey]).not.toHaveProperty("lifecycleRunId");
     expect(compatibilityStore[keptKey]).not.toHaveProperty("mainRestartRecovery");
+    expect(compatibilityStore[keptKey]).not.toHaveProperty("restartRecoveryOwner");
     await updateSessionStore(
       storePath,
       (store) => {
         expect(store[keptKey]).not.toHaveProperty("mainRestartRecovery");
         const escapedStore = store as unknown as Record<string, InternalSessionEntry>;
         escapedStore[keptKey] = {
+          activeWriterRunId: "injected-writer",
+          lifecycleRunId: "injected-lifecycle",
           mainRestartRecovery: {
             chargedAttempts: 99,
             cycleId: "injected-cycle",
             revision: 99,
           },
           model: "gpt-5.6",
+          restartRecoveryOwner: "openclaw",
           sessionId: "compat-recovery-session",
           updatedAt: 20,
         };
         delete escapedStore[removedKey];
         escapedStore["agent:main:telegram:direct:compat-created"] = {
+          activeWriterRunId: "created-writer",
+          lifecycleRunId: "created-lifecycle",
           mainRestartRecovery: {
             chargedAttempts: 1,
             cycleId: "created-injection",
             revision: 1,
           },
+          restartRecoveryOwner: "external",
           sessionId: "compat-created-session",
           updatedAt: 20,
         };
@@ -407,18 +406,23 @@ describe("session-store-runtime compatibility surface", () => {
     );
 
     expect(loadInternalSessionEntry({ sessionKey: keptKey, storePath })).toMatchObject({
+      activeWriterRunId: "compat-writer",
       abortedLastRun: true,
+      lifecycleRunId: "compat-lifecycle",
       mainRestartRecovery,
       model: "gpt-5.6",
+      restartRecoveryOwner: "external",
       restartRecoveryRuns: [{ lifecycleGeneration: "compat-generation", runId: "compat-run" }],
     });
     expect(loadInternalSessionEntry({ sessionKey: removedKey, storePath })).toBeUndefined();
-    expect(
-      loadInternalSessionEntry({
-        sessionKey: "agent:main:telegram:direct:compat-created",
-        storePath,
-      }),
-    ).not.toHaveProperty("mainRestartRecovery");
+    const createdEntry = loadInternalSessionEntry({
+      sessionKey: "agent:main:telegram:direct:compat-created",
+      storePath,
+    });
+    expect(createdEntry).not.toHaveProperty("activeWriterRunId");
+    expect(createdEntry).not.toHaveProperty("lifecycleRunId");
+    expect(createdEntry).not.toHaveProperty("mainRestartRecovery");
+    expect(createdEntry).not.toHaveProperty("restartRecoveryOwner");
 
     await updateSessionStore(
       storePath,
@@ -426,11 +430,14 @@ describe("session-store-runtime compatibility surface", () => {
         const escapedStore = store as unknown as Record<string, InternalSessionEntry>;
         escapedStore[keptKey] = {
           ...escapedStore[keptKey]!,
+          activeWriterRunId: "replacement-writer",
+          lifecycleRunId: "replacement-lifecycle",
           mainRestartRecovery: {
             chargedAttempts: 99,
             cycleId: "replacement-injection",
             revision: 99,
           },
+          restartRecoveryOwner: "openclaw",
           sessionId: "compat-replacement-session",
         };
       },
@@ -446,6 +453,9 @@ describe("session-store-runtime compatibility surface", () => {
     }) as InternalSessionEntry | undefined;
     expect(replacedEntry?.mainRestartRecovery).toBeUndefined();
     expect(replacedEntry?.restartRecoveryRuns).toBeUndefined();
+    expect(replacedEntry?.activeWriterRunId).toBeUndefined();
+    expect(replacedEntry?.lifecycleRunId).toBeUndefined();
+    expect(replacedEntry?.restartRecoveryOwner).toBeUndefined();
   });
 
   it("serializes compatibility callbacks with concurrent row writes", async () => {
@@ -608,205 +618,6 @@ describe("session-store-runtime compatibility surface", () => {
       model: "gpt-5.5",
       providerOverride: "openai",
       sessionId: "session-1",
-    });
-  });
-
-  it("hides core recovery state and preserves it across public mutations", async () => {
-    const sessionKey = "agent:main:recovery-owned";
-    const mainRestartRecovery = {
-      chargedAttempts: 1,
-      cycleId: "cycle-1",
-      reservation: {
-        attempt: 1,
-        lifecycleGeneration: "generation-1",
-        runId: "run-1",
-      },
-      revision: 1,
-    };
-    await replaceInternalSessionEntry({ sessionKey, storePath }, {
-      abortedLastRun: true,
-      mainRestartRecovery,
-      model: "gpt-5.5",
-      restartRecoveryRuns: [{ lifecycleGeneration: "generation-1", runId: "run-1" }],
-      sessionId: "session-recovery",
-      updatedAt: 10,
-    } as InternalSessionEntry);
-
-    expect(getSessionEntry({ sessionKey, storePath })).not.toHaveProperty("mainRestartRecovery");
-    expect(listSessionEntries({ storePath })[0]?.entry).not.toHaveProperty("mainRestartRecovery");
-
-    await patchSessionEntry({
-      sessionKey,
-      storePath,
-      update: (entry) => {
-        entry.restartRecoveryRuns?.splice(0);
-        return {
-          abortedLastRun: false,
-          mainRestartRecovery: undefined,
-          model: "gpt-5.6",
-          restartRecoveryRuns: undefined,
-        } as unknown as Partial<SessionEntry>;
-      },
-    });
-    expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
-      abortedLastRun: true,
-      mainRestartRecovery,
-      model: "gpt-5.6",
-      restartRecoveryRuns: [{ lifecycleGeneration: "generation-1", runId: "run-1" }],
-    });
-
-    await updateSessionStoreEntry({
-      sessionKey,
-      storePath,
-      update: () => ({ abortedLastRun: false, restartRecoveryRuns: undefined }),
-    });
-    expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
-      abortedLastRun: true,
-      mainRestartRecovery,
-      restartRecoveryRuns: [{ lifecycleGeneration: "generation-1", runId: "run-1" }],
-    });
-
-    await upsertSessionEntry({
-      sessionKey,
-      storePath,
-      entry: {
-        sessionId: "session-recovery",
-        updatedAt: 20,
-      },
-    });
-    expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
-      abortedLastRun: true,
-      mainRestartRecovery,
-      restartRecoveryRuns: [{ lifecycleGeneration: "generation-1", runId: "run-1" }],
-      sessionId: "session-recovery",
-      updatedAt: 20,
-    });
-    expect(loadInternalSessionEntry({ sessionKey, storePath })?.model).toBeUndefined();
-  });
-
-  it("clears core recovery state when public replacements change session identity", async () => {
-    const patchKey = "agent:main:telegram:direct:patch-rotation";
-    const upsertKey = "agent:main:telegram:direct:upsert-rotation";
-    const upsertStorePath = path.join(tempDir, "upsert-sessions.json");
-    const mainRestartRecovery = {
-      chargedAttempts: 1,
-      cycleId: "rotation-cycle",
-      revision: 1,
-    };
-    await seedSessionEntry(patchKey, {
-      abortedLastRun: true,
-      restartRecoveryRuns: [{ lifecycleGeneration: "patch-generation", runId: "patch-run" }],
-      sessionId: "patch-before",
-      updatedAt: 10,
-    });
-    await patchInternalSessionEntry(
-      { agentId: "main", sessionKey: patchKey, storePath },
-      () =>
-        ({
-          abortedLastRun: true,
-          mainRestartRecovery,
-          restartRecoveryRuns: [{ lifecycleGeneration: "patch-generation", runId: "patch-run" }],
-        }) as Partial<InternalSessionEntry>,
-    );
-    await upsertSessionEntry({
-      agentId: "main",
-      entry: { sessionId: "upsert-before", updatedAt: 10 },
-      sessionKey: upsertKey,
-      storePath: upsertStorePath,
-    });
-    await patchInternalSessionEntry(
-      { agentId: "main", sessionKey: upsertKey, storePath: upsertStorePath },
-      () =>
-        ({
-          abortedLastRun: true,
-          mainRestartRecovery,
-          restartRecoveryRuns: [{ lifecycleGeneration: "upsert-generation", runId: "upsert-run" }],
-        }) as Partial<InternalSessionEntry>,
-    );
-
-    await patchSessionEntry({
-      replaceEntry: true,
-      sessionKey: patchKey,
-      storePath,
-      update: () => ({ sessionId: "patch-after", updatedAt: 20 }),
-    });
-    await upsertSessionEntry({
-      entry: {
-        abortedLastRun: true,
-        restartRecoveryRuns: [{ lifecycleGeneration: "upsert-generation", runId: "upsert-run" }],
-        sessionId: "upsert-after",
-        updatedAt: 20,
-      },
-      sessionKey: upsertKey,
-      storePath: upsertStorePath,
-    });
-
-    expectRecoveryCleared({ sessionId: "patch-after", sessionKey: patchKey, storePath });
-    expectRecoveryCleared({
-      sessionId: "upsert-after",
-      sessionKey: upsertKey,
-      storePath: upsertStorePath,
-    });
-  });
-
-  it("clears core recovery state when public patches change session identity", async () => {
-    const patchKey = "agent:main:telegram:direct:patch-rotation";
-    const updateKey = "agent:main:telegram:direct:update-rotation";
-    const updateStorePath = path.join(tempDir, "update-patch-sessions.json");
-    const mainRestartRecovery = {
-      chargedAttempts: 1,
-      cycleId: "rotation-cycle",
-      revision: 1,
-    };
-    await seedSessionEntry(patchKey, {
-      abortedLastRun: true,
-      restartRecoveryRuns: [{ lifecycleGeneration: "patch-generation", runId: "patch-run" }],
-      sessionId: "patch-before",
-      updatedAt: 10,
-    });
-    await upsertSessionEntry({
-      agentId: "main",
-      entry: { sessionId: "update-before", updatedAt: 10 },
-      sessionKey: updateKey,
-      storePath: updateStorePath,
-    });
-    await patchInternalSessionEntry(
-      { agentId: "main", sessionKey: patchKey, storePath },
-      () =>
-        ({
-          abortedLastRun: true,
-          mainRestartRecovery,
-          restartRecoveryRuns: [{ lifecycleGeneration: "patch-generation", runId: "patch-run" }],
-        }) as Partial<InternalSessionEntry>,
-    );
-    await patchInternalSessionEntry(
-      { agentId: "main", sessionKey: updateKey, storePath: updateStorePath },
-      () =>
-        ({
-          abortedLastRun: true,
-          mainRestartRecovery,
-          restartRecoveryRuns: [{ lifecycleGeneration: "update-generation", runId: "update-run" }],
-        }) as Partial<InternalSessionEntry>,
-    );
-
-    await patchSessionEntry({
-      sessionKey: patchKey,
-      skipMaintenance: true,
-      storePath,
-      update: () => ({ sessionId: "patch-after", updatedAt: 20 }),
-    });
-    await updateSessionStoreEntry({
-      sessionKey: updateKey,
-      skipMaintenance: true,
-      storePath: updateStorePath,
-      update: () => ({ sessionId: "update-after", updatedAt: 20 }),
-    });
-
-    expectRecoveryCleared({ sessionId: "patch-after", sessionKey: patchKey, storePath });
-    expectRecoveryCleared({
-      sessionId: "update-after",
-      sessionKey: updateKey,
-      storePath: updateStorePath,
     });
   });
 

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -43,8 +43,8 @@ import type {
 import { replaceFileAtomicSync } from "../infra/replace-file.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import {
-  activeRecoveryFieldsForSameSession,
-  clearRecoveryStateForRotatedSessionPatch,
+  clearInternalStateForRotatedSessionPatch,
+  internalFieldsForSameSession,
   projectPluginSessionEntry,
   projectPluginSessionEntryPatch,
   projectPluginSessionStore,
@@ -148,17 +148,17 @@ type SessionLifecycleArtifactsCleanupResult = {
   removedEntries: number;
 };
 
-function preserveCoreRecoveryState(
+function preserveInternalSessionState(
   persistedEntry: InternalSessionEntry,
   publicPatch: Partial<SessionEntry>,
 ): Partial<InternalSessionEntry> {
   const nextSessionId = Object.hasOwn(publicPatch, "sessionId")
     ? publicPatch.sessionId
     : persistedEntry.sessionId;
-  const recoveryState = activeRecoveryFieldsForSameSession(persistedEntry, nextSessionId);
-  return recoveryState
-    ? { ...publicPatch, ...recoveryState }
-    : clearRecoveryStateForRotatedSessionPatch(persistedEntry, publicPatch);
+  const internalState = internalFieldsForSameSession(persistedEntry, nextSessionId);
+  return internalState
+    ? { ...publicPatch, ...internalState }
+    : clearInternalStateForRotatedSessionPatch(persistedEntry, publicPatch);
 }
 
 function resolveLegacySessionStoreTarget(storePath: string): {
@@ -307,7 +307,7 @@ export async function updateSessionStore<T>(
       const persist = !options.skipSaveWhenResult?.(result);
       if (persist) {
         // The deprecated callback owns public row changes and deletions, but
-        // core recovery coordination remains invisible and non-overwritable.
+        // internal lifecycle and recovery coordination remains invisible and non-overwritable.
         reconcilePluginSessionStore({ internalStore, publicStore });
       }
       return {
@@ -445,7 +445,7 @@ export async function patchSessionEntry(
       if (!patch) {
         return null;
       }
-      return preserveCoreRecoveryState(persistedEntry, projectPluginSessionEntryPatch(patch));
+      return preserveInternalSessionState(persistedEntry, projectPluginSessionEntryPatch(patch));
     },
     {
       fallbackEntry: params.fallbackEntry
@@ -490,7 +490,7 @@ export async function updateSessionStoreEntry(
         return null;
       }
       const persistedEntry = internalEntry as InternalSessionEntry;
-      return preserveCoreRecoveryState(persistedEntry, projectPluginSessionEntryPatch(patch));
+      return preserveInternalSessionState(persistedEntry, projectPluginSessionEntryPatch(patch));
     },
     {
       skipMaintenance: params.skipMaintenance,
@@ -508,7 +508,7 @@ export async function upsertSessionEntry(params: UpsertSessionEntryParams): Prom
     toSessionAccessScope(params),
     (internalEntry) => {
       const persistedEntry = internalEntry as InternalSessionEntry;
-      return preserveCoreRecoveryState(persistedEntry, publicEntry);
+      return preserveInternalSessionState(persistedEntry, publicEntry);
     },
     { fallbackEntry: publicEntry, replaceEntry: true },
   );

--- a/src/plugin-sdk/session-store-runtime.writer-claim.test.ts
+++ b/src/plugin-sdk/session-store-runtime.writer-claim.test.ts
@@ -9,13 +9,23 @@ import type { SessionEntry } from "./session-store-runtime.js";
 const sessionEntryKeepsWriterClaimPrivate: "activeWriterRunId" extends keyof SessionEntry
   ? false
   : true = true;
+const sessionEntryKeepsLifecycleOwnerPrivate: "lifecycleRunId" extends keyof SessionEntry
+  ? false
+  : true = true;
+const sessionEntryKeepsRecoveryOwnerPrivate: "restartRecoveryOwner" extends keyof SessionEntry
+  ? false
+  : true = true;
 void sessionEntryKeepsWriterClaimPrivate;
+void sessionEntryKeepsLifecycleOwnerPrivate;
+void sessionEntryKeepsRecoveryOwnerPrivate;
 
-describe("plugin session writer claim projection", () => {
-  it("excludes the durable writer claim from entries and patches", () => {
+describe("plugin internal session projection", () => {
+  it("excludes durable lifecycle and recovery owners from entries and patches", () => {
     const entry: InternalSessionEntry = {
       activeWriterRunId: "run-writer",
+      lifecycleRunId: "run-lifecycle",
       model: "gpt-5.6",
+      restartRecoveryOwner: "external",
       sessionId: "session-writer",
       updatedAt: 10,
     };
@@ -26,7 +36,12 @@ describe("plugin session writer claim projection", () => {
       updatedAt: 10,
     });
     expect(
-      projectPluginSessionEntryPatch({ activeWriterRunId: "run-next", model: "gpt-5.5" }),
+      projectPluginSessionEntryPatch({
+        activeWriterRunId: "run-next",
+        lifecycleRunId: "run-next-lifecycle",
+        model: "gpt-5.5",
+        restartRecoveryOwner: "openclaw",
+      }),
     ).toEqual({ model: "gpt-5.5" });
   });
 });

--- a/src/plugins/contracts/session-entry-projection.contract.test.ts
+++ b/src/plugins/contracts/session-entry-projection.contract.test.ts
@@ -300,6 +300,11 @@ describe("plugin session extension SessionEntry projection", () => {
           sessionEntrySlotKey: "mainRestartRecovery",
         });
         api.registerSessionExtension({
+          namespace: "restart-recovery-owner",
+          description: "bad restart recovery owner slot",
+          sessionEntrySlotKey: "restartRecoveryOwner",
+        });
+        api.registerSessionExtension({
           namespace: "recovery",
           description: "bad fresh-main slot",
           sessionEntrySlotKey: "subagentRecovery",
@@ -338,6 +343,10 @@ describe("plugin session extension SessionEntry projection", () => {
       {
         pluginId: "slot-collision",
         message: "sessionEntrySlotKey is reserved by SessionEntry: mainRestartRecovery",
+      },
+      {
+        pluginId: "slot-collision",
+        message: "sessionEntrySlotKey is reserved by SessionEntry: restartRecoveryOwner",
       },
       {
         pluginId: "slot-collision",

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -53,6 +53,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "inheritedToolAllow",
   "lifecycleRunId",
   "activeWriterRunId",
+  "restartRecoveryOwner",
   "mainRestartRecovery",
   "subagentRecovery",
   "pluginOwnerId",

--- a/test/e2e/qa-lab/runtime/gateway-restart-recovery-owner.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-restart-recovery-owner.e2e.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { afterEach, describe, expect, it } from "vitest";
 import { startQaLiveLaneGateway } from "../../../../extensions/qa-lab/runtime-api.js";
-import { resolveStorePath } from "../../../../src/config/sessions/paths.js";
+import { resolveSessionStorePathCore } from "../../../../src/config/sessions/paths.js";
 import {
   loadSessionEntry,
   replaceSessionEntry,
@@ -30,7 +30,7 @@ afterEach(async () => {
 });
 
 function sessionStorePath(gateway: GatewayHandle): string {
-  return resolveStorePath(undefined, {
+  return resolveSessionStorePathCore(undefined, {
     agentId: AGENT_ID,
     env: gateway.runtimeEnv,
   });

--- a/test/e2e/qa-lab/runtime/gateway-restart-recovery-owner.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-restart-recovery-owner.e2e.test.ts
@@ -98,6 +98,18 @@ async function readMockRequestCount(baseUrl: string): Promise<number> {
   return requests.length;
 }
 
+async function waitForMockRequestCount(baseUrl: string, expected: number): Promise<number> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < LOG_WAIT_TIMEOUT_MS) {
+    const count = await readMockRequestCount(baseUrl);
+    if (count >= expected) {
+      return count;
+    }
+    await sleep(100);
+  }
+  throw new Error(`mock provider request count did not reach ${expected}`);
+}
+
 function resolveGatewayFileLogPath(logs: string): string | undefined {
   return [...logs.matchAll(/\[gateway\] log file: (.+)$/gmu)].at(-1)?.[1]?.trim();
 }
@@ -156,7 +168,7 @@ async function writeVerdict(verdict: Record<string, unknown>): Promise<void> {
 
 describe("Gateway external restart recovery owner", () => {
   it(
-    "skips externally owned restart work and transfers a quarantined session",
+    "skips external recovery, resets ownership on rotation, and transfers quarantine",
     { timeout: 180_000 },
     async () => {
       harness = await startQaLiveLaneGateway({
@@ -226,6 +238,47 @@ describe("Gateway external restart recovery owner", () => {
         status: "running",
       });
 
+      const externalSessionId = loadInternalEntry(gateway, sessionKey).sessionId;
+      if (!externalSessionId) {
+        throw new Error("expected the externally owned session generation");
+      }
+      await gateway.restartAfterStateMutation(async () => {
+        await replaceInternalEntry(gateway, sessionKey, {
+          abortedLastRun: false,
+          mainRestartRecovery: undefined,
+          restartRecoveryRuns: undefined,
+          status: undefined,
+          updatedAt: 0,
+        });
+      });
+      await runAgent({
+        gateway,
+        sessionKey,
+        message: "Gateway generation rotation QA. Reply exactly `ROTATED_TO_OPENCLAW`.",
+      });
+      const rotated = loadInternalEntry(gateway, sessionKey);
+      expect(rotated.sessionId).toEqual(expect.any(String));
+      expect(rotated.sessionId).not.toBe(externalSessionId);
+      expect(rotated.restartRecoveryOwner).toBeUndefined();
+      const requestsAfterRotation = await readMockRequestCount(mock.baseUrl);
+      expect(requestsAfterRotation).toBe(requestsAfterExternalRestarts + 1);
+
+      await gateway.restartAfterStateMutation(async () => {
+        await replaceInternalEntry(gateway, sessionKey, {
+          abortedLastRun: false,
+          mainRestartRecovery: undefined,
+          restartRecoveryRuns: undefined,
+          status: "running",
+        });
+      });
+      const requestsAfterRotatedRecovery = await waitForMockRequestCount(
+        mock.baseUrl,
+        requestsAfterRotation + 1,
+      );
+      expect(requestsAfterRotatedRecovery).toBe(requestsAfterRotation + 1);
+      expect(loadInternalEntry(gateway, sessionKey).restartRecoveryOwner).toBeUndefined();
+      await sleep(500);
+
       await gateway.restartAfterStateMutation(async () => {
         await replaceInternalEntry(gateway, sessionKey, {
           abortedLastRun: false,
@@ -253,7 +306,7 @@ describe("Gateway external restart recovery owner", () => {
       expect(transferred.restartRecoveryRuns).toBeUndefined();
 
       const requestsAfterTransfer = await readMockRequestCount(mock.baseUrl);
-      expect(requestsAfterTransfer).toBe(requestsBeforeExternalRestarts + 1);
+      expect(requestsAfterTransfer).toBe(requestsAfterRotatedRecovery + 1);
       await writeVerdict({
         schemaVersion: 1,
         scenario: "gateway-external-restart-recovery-owner",
@@ -264,11 +317,13 @@ describe("Gateway external restart recovery owner", () => {
           restartSkipPhases: ["mark", "dispatch"],
           providerCallsDuringExternalRestarts:
             requestsAfterExternalRestarts - requestsBeforeExternalRestarts,
+          rotatedGenerationOwnerCleared: rotated.restartRecoveryOwner === undefined,
+          providerCallsForRotatedRecovery: requestsAfterRotatedRecovery - requestsAfterRotation,
           quarantinedTransferClearedRecovery:
             transferred.abortedLastRun === false &&
             transferred.mainRestartRecovery === undefined &&
             transferred.restartRecoveryRuns === undefined,
-          providerCallsForTransfer: requestsAfterTransfer - requestsAfterExternalRestarts,
+          providerCallsForTransfer: requestsAfterTransfer - requestsAfterRotatedRecovery,
         },
         pass: true,
       });

--- a/test/e2e/qa-lab/runtime/gateway-restart-recovery-owner.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-restart-recovery-owner.e2e.test.ts
@@ -1,0 +1,277 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { startQaLiveLaneGateway } from "../../../../extensions/qa-lab/runtime-api.js";
+import { resolveStorePath } from "../../../../src/config/sessions/paths.js";
+import {
+  loadSessionEntry,
+  replaceSessionEntry,
+} from "../../../../src/config/sessions/session-accessor.js";
+import type { InternalSessionEntry } from "../../../../src/config/sessions/types.js";
+
+type GatewayRunResult = {
+  runId?: unknown;
+  status?: unknown;
+};
+
+type GatewayHandle = Awaited<ReturnType<typeof startQaLiveLaneGateway>>["gateway"];
+
+const AGENT_ID = "qa";
+const LOG_WAIT_TIMEOUT_MS = 15_000;
+const VERDICT_PATH_ENV = "OPENCLAW_QA_RESTART_RECOVERY_OWNER_VERDICT_PATH";
+
+let harness: Awaited<ReturnType<typeof startQaLiveLaneGateway>> | undefined;
+
+afterEach(async () => {
+  await harness?.stop().catch(() => undefined);
+  harness = undefined;
+});
+
+function sessionStorePath(gateway: GatewayHandle): string {
+  return resolveStorePath(undefined, {
+    agentId: AGENT_ID,
+    env: gateway.runtimeEnv,
+  });
+}
+
+function loadInternalEntry(gateway: GatewayHandle, sessionKey: string): InternalSessionEntry {
+  const entry = loadSessionEntry({
+    agentId: AGENT_ID,
+    readConsistency: "latest",
+    sessionKey,
+    storePath: sessionStorePath(gateway),
+  }) as InternalSessionEntry | undefined;
+  if (!entry) {
+    throw new Error(`missing QA session entry: ${sessionKey}`);
+  }
+  return entry;
+}
+
+async function replaceInternalEntry(
+  gateway: GatewayHandle,
+  sessionKey: string,
+  patch: Partial<InternalSessionEntry>,
+): Promise<void> {
+  const nextEntry: InternalSessionEntry = {
+    ...loadInternalEntry(gateway, sessionKey),
+    ...patch,
+  };
+  await replaceSessionEntry(
+    { agentId: AGENT_ID, sessionKey, storePath: sessionStorePath(gateway) },
+    nextEntry,
+  );
+}
+
+async function runAgent(params: {
+  gateway: GatewayHandle;
+  message: string;
+  restartRecoveryOwner?: "openclaw" | "external";
+  sessionKey: string;
+}): Promise<GatewayRunResult> {
+  const result = (await params.gateway.call(
+    "agent",
+    {
+      message: params.message,
+      sessionKey: params.sessionKey,
+      deliver: false,
+      idempotencyKey: randomUUID(),
+      ...(params.restartRecoveryOwner ? { restartRecoveryOwner: params.restartRecoveryOwner } : {}),
+    },
+    { expectFinal: true, timeoutMs: 90_000 },
+  )) as GatewayRunResult;
+  expect(result.status).toBe("ok");
+  expect(typeof result.runId).toBe("string");
+  return result;
+}
+
+async function readMockRequestCount(baseUrl: string): Promise<number> {
+  const response = await fetch(`${baseUrl}/debug/requests`);
+  if (!response.ok) {
+    throw new Error(`mock provider request inspection failed: HTTP ${response.status}`);
+  }
+  const requests: unknown = await response.json();
+  if (!Array.isArray(requests)) {
+    throw new Error("mock provider request inspection returned a non-array payload");
+  }
+  return requests.length;
+}
+
+function resolveGatewayFileLogPath(logs: string): string | undefined {
+  return [...logs.matchAll(/\[gateway\] log file: (.+)$/gmu)].at(-1)?.[1]?.trim();
+}
+
+function hasStructuredSkipLog(
+  logs: string,
+  sessionKey: string,
+  phase: "mark" | "dispatch",
+): boolean {
+  return logs.split("\n").some((line) => {
+    try {
+      const record = JSON.parse(line) as Record<string, unknown>;
+      const fields = record["1"];
+      return (
+        record["2"] === "skipping main-session restart recovery" &&
+        typeof fields === "object" &&
+        fields !== null &&
+        (fields as Record<string, unknown>).phase === phase &&
+        (fields as Record<string, unknown>).reason === "external_owner" &&
+        (fields as Record<string, unknown>).sessionKey === sessionKey
+      );
+    } catch {
+      return false;
+    }
+  });
+}
+
+async function waitForStructuredSkipLog(
+  gateway: GatewayHandle,
+  sessionKey: string,
+  phase: "mark" | "dispatch",
+) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < LOG_WAIT_TIMEOUT_MS) {
+    const logPath = resolveGatewayFileLogPath(gateway.logs());
+    if (logPath) {
+      const fileLogs = await fs.readFile(logPath, "utf8").catch(() => "");
+      if (hasStructuredSkipLog(fileLogs, sessionKey, phase)) {
+        return;
+      }
+    }
+    await sleep(100);
+  }
+  throw new Error(`missing structured external-owner ${phase} log:\n${gateway.logs()}`);
+}
+
+async function writeVerdict(verdict: Record<string, unknown>): Promise<void> {
+  const outputPath = process.env[VERDICT_PATH_ENV]?.trim();
+  if (outputPath) {
+    const resolvedPath = path.resolve(outputPath);
+    await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
+    await fs.writeFile(resolvedPath, `${JSON.stringify(verdict, null, 2)}\n`, "utf8");
+  }
+  console.info(`[restart-recovery-owner-verdict] ${JSON.stringify(verdict)}`);
+}
+
+describe("Gateway external restart recovery owner", () => {
+  it(
+    "skips externally owned restart work and transfers a quarantined session",
+    { timeout: 180_000 },
+    async () => {
+      harness = await startQaLiveLaneGateway({
+        repoRoot: process.cwd(),
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        alternateModel: "mock-openai/gpt-5.6-luna-alt",
+        transport: {
+          requiredPluginIds: [],
+          createGatewayConfig: () => ({}),
+        },
+        transportBaseUrl: "http://127.0.0.1",
+        controlUiEnabled: false,
+      });
+      const { gateway, mock } = harness;
+      if (!mock) {
+        throw new Error("expected the managed mock OpenAI provider");
+      }
+
+      const sessionKey = `agent:${AGENT_ID}:restart-recovery-owner-${randomUUID()}`;
+      await runAgent({
+        gateway,
+        sessionKey,
+        restartRecoveryOwner: "external",
+        message: "Gateway owner QA. Reply exactly `EXTERNAL_OWNER_READY`.",
+      });
+      expect(loadInternalEntry(gateway, sessionKey).restartRecoveryOwner).toBe("external");
+      const requestsBeforeExternalRestarts = await readMockRequestCount(mock.baseUrl);
+
+      await gateway.restartAfterStateMutation(async () => {
+        await replaceInternalEntry(gateway, sessionKey, {
+          abortedLastRun: false,
+          mainRestartRecovery: undefined,
+          restartRecoveryRuns: undefined,
+          status: "running",
+        });
+      });
+      await waitForStructuredSkipLog(gateway, sessionKey, "mark");
+      expect(await readMockRequestCount(mock.baseUrl)).toBe(requestsBeforeExternalRestarts);
+      expect(loadInternalEntry(gateway, sessionKey)).toMatchObject({
+        abortedLastRun: false,
+        restartRecoveryOwner: "external",
+        status: "running",
+      });
+
+      await gateway.restartAfterStateMutation(async () => {
+        await replaceInternalEntry(gateway, sessionKey, {
+          abortedLastRun: true,
+          mainRestartRecovery: {
+            chargedAttempts: 1,
+            cycleId: "qa-external-owner-cycle",
+            revision: 2,
+          },
+          restartRecoveryRuns: [
+            { lifecycleGeneration: "qa-external-generation", runId: "qa-external-run" },
+          ],
+          status: "running",
+        });
+      });
+      await waitForStructuredSkipLog(gateway, sessionKey, "dispatch");
+      await sleep(500);
+      const requestsAfterExternalRestarts = await readMockRequestCount(mock.baseUrl);
+      expect(requestsAfterExternalRestarts).toBe(requestsBeforeExternalRestarts);
+      expect(loadInternalEntry(gateway, sessionKey)).toMatchObject({
+        abortedLastRun: true,
+        restartRecoveryOwner: "external",
+        status: "running",
+      });
+
+      await gateway.restartAfterStateMutation(async () => {
+        await replaceInternalEntry(gateway, sessionKey, {
+          abortedLastRun: false,
+          mainRestartRecovery: {
+            chargedAttempts: 3,
+            cycleId: "qa-tombstoned-owner-cycle",
+            revision: 4,
+            tombstone: { reason: "automatic recovery exhausted" },
+          },
+          restartRecoveryOwner: undefined,
+          restartRecoveryRuns: undefined,
+          status: "failed",
+        });
+      });
+      await runAgent({
+        gateway,
+        sessionKey,
+        restartRecoveryOwner: "external",
+        message: "Gateway quarantine transfer QA. Reply exactly `QUARANTINE_TRANSFERRED`.",
+      });
+      const transferred = loadInternalEntry(gateway, sessionKey);
+      expect(transferred.restartRecoveryOwner).toBe("external");
+      expect(transferred.abortedLastRun).toBe(false);
+      expect(transferred.mainRestartRecovery).toBeUndefined();
+      expect(transferred.restartRecoveryRuns).toBeUndefined();
+
+      const requestsAfterTransfer = await readMockRequestCount(mock.baseUrl);
+      expect(requestsAfterTransfer).toBe(requestsBeforeExternalRestarts + 1);
+      await writeVerdict({
+        schemaVersion: 1,
+        scenario: "gateway-external-restart-recovery-owner",
+        gatewayBoundary: "child-process-websocket-rpc",
+        providerMode: "mock-openai",
+        assertions: {
+          ownerPersisted: transferred.restartRecoveryOwner === "external",
+          restartSkipPhases: ["mark", "dispatch"],
+          providerCallsDuringExternalRestarts:
+            requestsAfterExternalRestarts - requestsBeforeExternalRestarts,
+          quarantinedTransferClearedRecovery:
+            transferred.abortedLastRun === false &&
+            transferred.mainRestartRecovery === undefined &&
+            transferred.restartRecoveryRuns === undefined,
+          providerCallsForTransfer: requestsAfterTransfer - requestsAfterExternalRestarts,
+        },
+        pass: true,
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #121570

## What Problem This Solves

External orchestrators can own timeout and retry policy for Gateway sessions, but OpenClaw currently treats those sessions like ordinary main sessions after a restart. That can resume work the orchestrator has already timed out or replaced, creating hidden model load and duplicate tool effects.

## Why This Change Was Made

This adds a narrow, durable `restartRecoveryOwner` contract to the `agent` RPC with `openclaw` and `external` values. Existing and omitted values preserve current behavior; valid ownership changes require `operator.admin`, are rejected while another turn owns the session, clear stale recovery state atomically, and are enforced by the canonical marking and dispatch predicates.

Only the two accepted enum values elevate authorization to admin. Malformed values remain write-scoped long enough to reach protocol validation, so a write-scoped caller receives `INVALID_REQUEST` rather than a misleading missing-admin error. The Gateway RPC regression covers both that malformed path and the retained admin requirement for valid ownership transfers.

An idle admin transfer can retire exhausted or tombstoned recovery state before quarantine rejects ordinary work. The competing-turn guard remains fail-closed. Ownership is scoped to one session generation: a session-ID replacement clears the private owner field, and an external orchestrator must set `external` again on the first request for the replacement generation.

The generation reset covers direct agent rotation, command-session expiry/reset, Gateway-created forks, reply parent forks, generic SQLite parent forks, rewind/switch/fork message cuts, checkpoint branch/restore, automatic reply compaction, and CLI harness compaction. Both compaction writers clear ownership only when compaction returns a different session ID; a same-ID compaction preserves the current generation's owner.

Lifecycle, writer-claim, recovery-owner, and recovery-state fields remain private across Plugin SDK session projections and cannot be overwritten by plugin compatibility updates. Externally owned skips are emitted as structured `main-session-restart-recovery` logs with `reason=external_owner`.

## User Impact

External schedulers and agent control planes can prevent OpenClaw from independently restart-recovering sessions whose lifecycle they own. They can explicitly return ownership to OpenClaw later, while existing clients continue to receive automatic recovery without changing requests.

## Review Follow-up

The compaction lifecycle finding from the review of `8b8aedae9c` is addressed in `522c4030bf`. Automatic reply compaction and CLI harness compaction both clear `restartRecoveryOwner` when they persist a successor session ID. Regressions start from an externally owned predecessor, verify both in-memory and persisted state, and retain a same-ID case proving ownership is not cleared without a generation change.

The branch was rebased onto `843017073cc27b28c1926ea21808b4209620ee03`. The final rebase was conflict-free, and range-diff confirms all seven contribution commits are patch-identical to the previously validated series.

## Evidence

Final head: `21e4417fa704441d04b8954ecbd50299c6255800`.

- Exact-head affected matrix passed across 17 files and 8 Vitest shards (`unit-fast`, `contracts-plugin`, `gateway`, `gateway-client`, `runtime-config`, `plugin-sdk`, `auto-reply`, and `agents-support`).
- Exact-head `pnpm protocol:check` passed with a clean generated-file diff.
- Exact-head `pnpm plugin-sdk:api:diff -- --base origin/main --head HEAD ...` passed with digest `3f1042f9`; the report identifies the nine reachable public declaration changes introduced by this API.
- On patch-identical predecessor `522c4030bf`, `pnpm check` and `pnpm build` passed, including all typechecks, lint, formatting, policies, CLI bootstrap guards, runtime postbuild, 144 public Plugin SDK subpaths, the Control UI production build, and performance budgets.
- On patch-identical predecessor `522c4030bf`, the real Gateway E2E passed in 51.72s against a child-process Gateway over admin WebSocket RPC with the managed mock OpenAI provider and multiple process restarts.
- `git diff --check` passed and the worktree is clean.

Exact-head Gateway verdict:

```json
{
  "schemaVersion": 1,
  "scenario": "gateway-external-restart-recovery-owner",
  "gatewayBoundary": "child-process-websocket-rpc",
  "providerMode": "mock-openai",
  "assertions": {
    "ownerPersisted": true,
    "restartSkipPhases": ["mark", "dispatch"],
    "providerCallsDuringExternalRestarts": 0,
    "rotatedGenerationOwnerCleared": true,
    "providerCallsForRotatedRecovery": 1,
    "quarantinedTransferClearedRecovery": true,
    "providerCallsForTransfer": 1
  },
  "pass": true
}
```

The local resolver used by the QA lane only pins workspace package imports to this checkout. Gateway behavior, persistence, RPC boundaries, process restarts, and provider request accounting all run through the repository QA harness.
