### PR TITLE
fix: secrets audit falsely flags documented env-name markers in models.json

### DIFF
--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -517,6 +517,82 @@ describe("secrets audit", () => {
     });
   });
 
+  it.each([
+    { label: "env template string", apiKey: "${FACTCHAT_API_KEY}" },
+    {
+      label: "explicit SecretRef object",
+      apiKey: { source: "env", provider: "default", id: "FACTCHAT_API_KEY" },
+    },
+  ])(
+    "does not flag models.json bare env-name markers backed by a configured env SecretRef ($label)",
+    async ({ apiKey }) => {
+      await writeJsonFile(fixture.configPath, {
+        models: {
+          providers: {
+            factchat: {
+              baseUrl: "https://factchat.example/v1",
+              api: "openai-completions",
+              apiKey,
+              models: [{ id: "factchat-1", name: "factchat-1" }],
+            },
+          },
+        },
+      });
+      await writeJsonFile(fixture.modelsPath, {
+        providers: {
+          factchat: {
+            baseUrl: "https://factchat.example/v1",
+            api: "openai-completions",
+            apiKey: "FACTCHAT_API_KEY",
+            models: [{ id: "factchat-1", name: "factchat-1" }],
+          },
+        },
+      });
+
+      const report = await runSecretsAudit({
+        env: { ...fixture.env, FACTCHAT_API_KEY: "sk-factchat-key" }, // pragma: allowlist secret
+      });
+      expectModelsFinding(report, {
+        code: "PLAINTEXT_FOUND",
+        jsonPath: "providers.factchat.apiKey",
+        present: false,
+      });
+    },
+  );
+
+  it("flags models.json bare env-name apiKey values when the config ref id differs", async () => {
+    await writeJsonFile(fixture.configPath, {
+      models: {
+        providers: {
+          factchat: {
+            baseUrl: "https://factchat.example/v1",
+            api: "openai-completions",
+            apiKey: "${FACTCHAT_OTHER_API_KEY}",
+            models: [{ id: "factchat-1", name: "factchat-1" }],
+          },
+        },
+      },
+    });
+    await writeJsonFile(fixture.modelsPath, {
+      providers: {
+        factchat: {
+          baseUrl: "https://factchat.example/v1",
+          api: "openai-completions",
+          apiKey: "FACTCHAT_API_KEY",
+          models: [{ id: "factchat-1", name: "factchat-1" }],
+        },
+      },
+    });
+
+    const report = await runSecretsAudit({
+      env: { ...fixture.env, FACTCHAT_OTHER_API_KEY: "sk-factchat-other" }, // pragma: allowlist secret
+    });
+    expectModelsFinding(report, {
+      code: "PLAINTEXT_FOUND",
+      jsonPath: "providers.factchat.apiKey",
+    });
+  });
+
   it("does not flag models.json header marker values as plaintext", async () => {
     await writeModelsProvider({
       headers: {

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -14,6 +14,7 @@ import {
   isSecretRefHeaderValueMarker,
 } from "../agents/model-auth-markers.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
+import { normalizeProviderMapKeys } from "../agents/models-config.merge.js";
 import { resolveStateDir, type OpenClawConfig } from "../config/config.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
 import { resolveSecretInputRef, type SecretRef } from "../config/types.secrets.js";
@@ -308,8 +309,32 @@ function collectAuthStoreSecrets(params: {
   }
 }
 
+function resolveConfiguredEnvSecretRefId(
+  value: unknown,
+  defaults: SecretDefaults | undefined,
+): string | undefined {
+  const ref = resolveSecretInputRef({ value, defaults }).ref;
+  if (ref?.source !== "env" || !ref.id.trim()) {
+    return undefined;
+  }
+  return ref.id.trim();
+}
+
+function normalizeAuditConfigProviders(
+  config: OpenClawConfig | undefined,
+): Record<string, Record<string, unknown>> {
+  return normalizeProviderMapKeys(
+    Object.fromEntries(
+      Object.entries(config?.models?.providers ?? {}).filter(([, provider]) => isRecord(provider)),
+    ) as Record<string, Record<string, unknown>>,
+  );
+}
+
 function collectModelsJsonSecrets(params: {
   modelsJsonPath: string;
+  config: OpenClawConfig;
+  sourceConfig: OpenClawConfig | undefined;
+  defaults: SecretDefaults | undefined;
   collector: AuditCollector;
 }): void {
   if (!fs.existsSync(params.modelsJsonPath)) {
@@ -334,10 +359,17 @@ function collectModelsJsonSecrets(params: {
   if (!parsed || !isRecord(parsed.providers)) {
     return;
   }
+  // Config providers normalize to canonical keys the same way the source-managed
+  // writer does, so an alias key cannot masquerade as another provider's SecretRef owner.
+  const configProvidersByKey = normalizeAuditConfigProviders(params.config);
+  // Config load substitutes ${VAR} when the env var is set, erasing the template the
+  // writer anchored its bare env-name marker to, so also consult the raw parsed config.
+  const sourceProvidersByKey = normalizeAuditConfigProviders(params.sourceConfig);
   for (const [providerId, providerValue] of Object.entries(parsed.providers)) {
     if (!isRecord(providerValue)) {
       continue;
     }
+    const providerKey = normalizeProviderId(providerId);
     const apiKey = providerValue.apiKey;
     if (coerceSecretRef(apiKey)) {
       addFinding(params.collector, {
@@ -349,14 +381,25 @@ function collectModelsJsonSecrets(params: {
         provider: providerId,
       });
     } else if (isNonEmptyString(apiKey) && !isNonSecretApiKeyMarker(apiKey)) {
-      addFinding(params.collector, {
-        code: "PLAINTEXT_FOUND",
-        severity: "warn",
-        file: params.modelsJsonPath,
-        jsonPath: `providers.${providerId}.apiKey`,
-        message: "models.json provider apiKey is stored as plaintext.",
-        provider: providerId,
-      });
+      // The source-managed writer persists an env-backed SecretRef as the bare env var
+      // name; exempt it only when this provider's config apiKey resolves to the exact
+      // same env SecretRef id. Anything else is still plaintext.
+      const configuredEnvRefId =
+        resolveConfiguredEnvSecretRefId(
+          sourceProvidersByKey[providerKey]?.apiKey,
+          params.defaults,
+        ) ??
+        resolveConfiguredEnvSecretRefId(configProvidersByKey[providerKey]?.apiKey, params.defaults);
+      if (configuredEnvRefId !== apiKey.trim()) {
+        addFinding(params.collector, {
+          code: "PLAINTEXT_FOUND",
+          severity: "warn",
+          file: params.modelsJsonPath,
+          jsonPath: `providers.${providerId}.apiKey`,
+          message: "models.json provider apiKey is stored as plaintext.",
+          provider: providerId,
+        });
+      }
     }
 
     const headers = isRecord(providerValue.headers) ? providerValue.headers : undefined;
@@ -664,6 +707,9 @@ export async function runSecretsAudit(
     for (const modelsJsonPath of listAgentModelsJsonPaths(config, stateDir, env)) {
       collectModelsJsonSecrets({
         modelsJsonPath,
+        config,
+        sourceConfig: isRecord(snapshot.parsed) ? (snapshot.parsed as OpenClawConfig) : undefined,
+        defaults,
         collector,
       });
     }


### PR DESCRIPTION
Closes #121543

## What Problem This Solves

Fixes an issue where users who configure a custom model provider with an env-backed SecretRef apiKey (via `openclaw secrets configure`, stored as `${VAR}` in openclaw.json) would get a misleading `PLAINTEXT_FOUND` finding from `openclaw secrets audit --check` — even though no plaintext credential is stored anywhere. `models.json` intentionally persists the bare env var name (e.g. `"apiKey": "FACTCHAT_API_KEY"`) as a documented marker, and regenerating the file reproduces the same false positive every time.

## Why This Change Was Made

The writer contract is intentional and unchanged: env-backed SecretRefs are persisted as the bare env-name marker. The fix is audit-side only: the audit now exempts a bare-string apiKey only when the same canonical provider's configured apiKey resolves to an env SecretRef with the exact same id. Because config load substitutes `${VAR}` with the real value when the env var is set, the audit correlates against the raw parsed config first, then the substituted config as fallback. Provider keys are normalized with the same helpers the writer uses, so alias keys cannot masquerade as another provider's SecretRef owner. Arbitrary all-caps strings, unknown providers, and mismatched env-ref ids remain flagged, so genuine plaintext credentials cannot slip through the exemption.

## User Impact

Operators using SecretRef-managed custom providers no longer see a false `PLAINTEXT_FOUND` warning in `secrets audit` output; the audit's remaining plaintext findings stay trustworthy. No behavior change for any other case.

## Evidence

- New regression tests in `src/secrets/audit.test.ts`: bare env-name marker backed by a `${VAR}` config template → no finding; same via explicit SecretRef object → no finding; mismatched env-ref id → still `PLAINTEXT_FOUND`. Pre-existing boundary test (`flags arbitrary all-caps models.json apiKey values as plaintext`) unchanged and passing.
- `node scripts/run-vitest.mjs src/secrets/audit.test.ts`: all models.json/audit-logic tests pass (24 passed; 7 failures are pre-existing environment issues — this box runs Node 24.13.1 whose embedded SQLite the repo refuses, failing auth-profile fixture setup before any audit logic runs).
- `node scripts/run-vitest.mjs src/agents/models-config.runtime-source-snapshot.test.ts`: 11/11 passed (writer contract untouched).
- Structured code review (autoreview, claude-fable-5): clean, no accepted/actionable findings; reviewer independently confirmed the exemption cannot match real credential formats.

Known gap (documented, rare): a provider defined only via `$include` whose apiKey is a `${VAR}` template with the env var set can still false-positive, because the config snapshot does not expose the post-include/pre-substitution tree. Object-form SecretRefs in that setup are still handled.

Reported by @cho2559.
