### PR TITLE
fix(slack): avoid duplicate Enterprise thread lookups

### DIFF
--- a/extensions/slack/src/monitor/message-handler.thread-resolution.test.ts
+++ b/extensions/slack/src/monitor/message-handler.thread-resolution.test.ts
@@ -1,85 +1,165 @@
-// Slack tests cover message handler thread-resolution integration behavior.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { App } from "@slack/bolt";
+import { WebClient } from "@slack/web-api";
+import { describe, expect, it, vi } from "vitest";
+import { resolveSlackAccount } from "../accounts.js";
+import type { SlackMessageEvent } from "../types.js";
+import { createSlackMonitorContext } from "./context.js";
 
-const enqueueMock = vi.fn(async (_entry: unknown) => {});
+const enqueue = vi.hoisted(() => vi.fn(async (_entry: unknown) => {}));
 
-vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/channel-inbound")>(
-    "openclaw/plugin-sdk/channel-inbound",
-  );
-  return {
-    ...actual,
-    createChannelInboundDebouncer: () => ({
-      debounceMs: 10,
-      debouncer: {
-        enqueue: enqueueMock,
-        flushKey: async () => {},
-        cancelKey: () => false,
-        drain: async () => {},
-      },
-    }),
-  };
-});
+vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>()),
+  createChannelInboundDebouncer: () => ({
+    debounceMs: 0,
+    debouncer: {
+      enqueue,
+      flushKey: async () => {},
+      cancelKey: () => false,
+      drain: async () => {},
+    },
+  }),
+}));
 
 const { createSlackMessageHandler } = await import("./message-handler.js");
 
 describe("Slack message handler thread resolution", () => {
-  beforeEach(() => {
-    enqueueMock.mockClear();
-  });
-
-  it("shares Enterprise history lookups per listener client while isolating replacement clients", async () => {
-    const history = vi.fn().mockResolvedValue({
-      messages: [{ ts: "1709000000.000200", thread_ts: "1709000000.000100" }],
+  it("coalesces Enterprise lookups and retains separate caches for replacement and default clients", async () => {
+    enqueue.mockClear();
+    const requests: Array<{ path?: string; token?: string; body: string }> = [];
+    const server = createServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk: Buffer) => {
+        chunks.push(chunk);
+      });
+      request.on("end", () => {
+        requests.push({
+          path: request.url,
+          token: request.headers.authorization,
+          body: Buffer.concat(chunks).toString("utf8"),
+        });
+        const root = request.headers.authorization?.endsWith("replacement") ? "100.2" : "100.1";
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ ok: true, messages: [{ ts: "100.3", thread_ts: root }] }));
+      });
     });
-    const replacementHistory = vi.fn().mockResolvedValue({
-      messages: [{ ts: "1709000000.000200", thread_ts: "1709000000.000100" }],
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
     });
-    const client = { conversations: { history } };
-    const replacementClient = { conversations: { history: replacementHistory } };
+    const { port } = server.address() as AddressInfo;
+    const client = (token: string) =>
+      new WebClient(token, {
+        slackApiUrl: `http://127.0.0.1:${port}/api/`,
+        retryConfig: { retries: 0 },
+      });
+    const app = new App({
+      token: "synthetic-default",
+      signingSecret: "synthetic-signing-secret",
+      tokenVerificationEnabled: false,
+      clientOptions: {
+        slackApiUrl: `http://127.0.0.1:${port}/api/`,
+        retryConfig: { retries: 0 },
+      },
+    });
+    const listenerClient = client("synthetic-listener");
+    const replacementClient = client("synthetic-replacement");
     const handler = createSlackMessageHandler({
-      ctx: {
+      ctx: createSlackMonitorContext({
         cfg: {},
-        accountId: "default",
-        app: { client: { conversations: { history: vi.fn() } } },
-        runtime: {},
-        rememberSlackChannelType: () => {},
-      } as never,
-      account: { accountId: "default" } as never,
+        accountId: "thread-test",
+        app,
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        botToken: "synthetic-default",
+        botUserId: "U111",
+        identityHealth: { lifecycle: "ready", lastError: null },
+        teamId: "T111",
+        apiAppId: "A111",
+        historyLimit: 0,
+        sessionScope: "per-sender",
+        mainKey: "main",
+        dmEnabled: true,
+        dmPolicy: "open",
+        allowFrom: [],
+        allowNameMatching: false,
+        groupDmEnabled: false,
+        groupDmChannels: [],
+        groupPolicy: "open",
+        useAccessGroups: true,
+        reactionMode: "off",
+        reactionAllowlist: [],
+        replyToMode: "off",
+        threadHistoryScope: "thread",
+        threadInheritParent: false,
+        slashCommand: {
+          enabled: false,
+          name: "openclaw",
+          ephemeral: true,
+          sessionPrefix: "slack:slash",
+        },
+        textLimit: 4000,
+        typingReaction: "",
+        ackReactionScope: "group-mentions",
+        mediaMaxBytes: 20 * 1024 * 1024,
+      }),
+      account: resolveSlackAccount({ cfg: {}, accountId: "thread-test" }),
     });
-    const message = {
+    const message: SlackMessageEvent = {
       type: "message",
       channel: "C111",
-      parent_user_id: "U222",
       user: "U111",
-      ts: "1709000000.000200",
+      parent_user_id: "U222",
+      ts: "100.3",
       text: "thread reply",
-    } as never;
+    };
+    const eventScope = { teamId: "T111", client: listenerClient };
+    try {
+      await Promise.all([
+        handler(message, { source: "message", eventScope }),
+        handler(message, { source: "app_mention", eventScope }),
+      ]);
+      await handler(message, { source: "message", eventScope });
+      expect(requests).toHaveLength(1);
+      expect(enqueue).toHaveBeenCalledTimes(3);
+      for (const [entry] of enqueue.mock.calls) {
+        expect(entry).toMatchObject({ message: { thread_ts: "100.1" } });
+      }
 
-    await handler(message, {
-      source: "message",
-      eventScope: { teamId: "T111", client } as never,
-    });
-    await handler(message, {
-      source: "app_mention",
-      eventScope: { teamId: "T111", client } as never,
-    });
+      await handler(message, {
+        source: "message",
+        eventScope: { teamId: "T111", client: replacementClient },
+      });
+      expect(requests).toHaveLength(2);
+      expect(enqueue).toHaveBeenLastCalledWith(
+        expect.objectContaining({ message: expect.objectContaining({ thread_ts: "100.2" }) }),
+      );
 
-    expect(history).toHaveBeenCalledTimes(1);
-    expect(enqueueMock).toHaveBeenCalledTimes(2);
-    expect(enqueueMock.mock.calls[0]?.[0]).toMatchObject({
-      message: { thread_ts: "1709000000.000100" },
-    });
-    expect(enqueueMock.mock.calls[1]?.[0]).toMatchObject({
-      message: { thread_ts: "1709000000.000100" },
-    });
-
-    await handler(message, {
-      source: "message",
-      eventScope: { teamId: "T111", client: replacementClient } as never,
-    });
-
-    expect(history).toHaveBeenCalledTimes(1);
-    expect(replacementHistory).toHaveBeenCalledTimes(1);
+      await Promise.all([
+        handler(message, { source: "message" }),
+        handler(message, { source: "app_mention" }),
+      ]);
+      await handler(message, { source: "message" });
+      expect(requests).toHaveLength(3);
+      expect(requests.map((request) => request.token)).toEqual([
+        "Bearer synthetic-listener",
+        "Bearer synthetic-replacement",
+        "Bearer synthetic-default",
+      ]);
+      for (const request of requests) {
+        expect(request.path).toBe("/api/conversations.history");
+        expect(Object.fromEntries(new URLSearchParams(request.body))).toMatchObject({
+          channel: "C111",
+          latest: "100.3",
+          oldest: "100.3",
+          inclusive: "true",
+          limit: "1",
+        });
+      }
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 });

--- a/extensions/slack/src/monitor/message-handler.thread-resolution.test.ts
+++ b/extensions/slack/src/monitor/message-handler.thread-resolution.test.ts
@@ -1,0 +1,85 @@
+// Slack tests cover message handler thread-resolution integration behavior.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const enqueueMock = vi.fn(async (_entry: unknown) => {});
+
+vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/channel-inbound")>(
+    "openclaw/plugin-sdk/channel-inbound",
+  );
+  return {
+    ...actual,
+    createChannelInboundDebouncer: () => ({
+      debounceMs: 10,
+      debouncer: {
+        enqueue: enqueueMock,
+        flushKey: async () => {},
+        cancelKey: () => false,
+        drain: async () => {},
+      },
+    }),
+  };
+});
+
+const { createSlackMessageHandler } = await import("./message-handler.js");
+
+describe("Slack message handler thread resolution", () => {
+  beforeEach(() => {
+    enqueueMock.mockClear();
+  });
+
+  it("shares Enterprise history lookups per listener client while isolating replacement clients", async () => {
+    const history = vi.fn().mockResolvedValue({
+      messages: [{ ts: "1709000000.000200", thread_ts: "1709000000.000100" }],
+    });
+    const replacementHistory = vi.fn().mockResolvedValue({
+      messages: [{ ts: "1709000000.000200", thread_ts: "1709000000.000100" }],
+    });
+    const client = { conversations: { history } };
+    const replacementClient = { conversations: { history: replacementHistory } };
+    const handler = createSlackMessageHandler({
+      ctx: {
+        cfg: {},
+        accountId: "default",
+        app: { client: { conversations: { history: vi.fn() } } },
+        runtime: {},
+        rememberSlackChannelType: () => {},
+      } as never,
+      account: { accountId: "default" } as never,
+    });
+    const message = {
+      type: "message",
+      channel: "C111",
+      parent_user_id: "U222",
+      user: "U111",
+      ts: "1709000000.000200",
+      text: "thread reply",
+    } as never;
+
+    await handler(message, {
+      source: "message",
+      eventScope: { teamId: "T111", client } as never,
+    });
+    await handler(message, {
+      source: "app_mention",
+      eventScope: { teamId: "T111", client } as never,
+    });
+
+    expect(history).toHaveBeenCalledTimes(1);
+    expect(enqueueMock).toHaveBeenCalledTimes(2);
+    expect(enqueueMock.mock.calls[0]?.[0]).toMatchObject({
+      message: { thread_ts: "1709000000.000100" },
+    });
+    expect(enqueueMock.mock.calls[1]?.[0]).toMatchObject({
+      message: { thread_ts: "1709000000.000100" },
+    });
+
+    await handler(message, {
+      source: "message",
+      eventScope: { teamId: "T111", client: replacementClient } as never,
+    });
+
+    expect(history).toHaveBeenCalledTimes(1);
+    expect(replacementHistory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -367,23 +367,11 @@ export function createSlackMessageHandler(params: {
       ctx.runtime.error?.(`slack inbound debounce flush failed: ${formatErrorMessage(err)}`);
     },
   });
-  const threadTsResolver = createSlackThreadTsResolver({ client: ctx.app.client });
-  const scopedThreadTsResolvers = new WeakMap<
+  // Keep cache and in-flight lookups with Bolt's client; replaced clients start fresh.
+  const threadTsResolvers = new WeakMap<
     SlackEventScope["client"],
     ReturnType<typeof createSlackThreadTsResolver>
   >();
-  const resolveThreadTsResolver = (eventScope?: SlackEventScope) => {
-    if (!eventScope) {
-      return threadTsResolver;
-    }
-    const existing = scopedThreadTsResolvers.get(eventScope.client);
-    if (existing) {
-      return existing;
-    }
-    const resolver = createSlackThreadTsResolver({ client: eventScope.client });
-    scopedThreadTsResolvers.set(eventScope.client, resolver);
-    return resolver;
-  };
   const pendingTopLevelDebounceKeys = new Map<string, Set<string>>();
 
   async function enqueueSlackMessage(
@@ -406,7 +394,13 @@ export function createSlackMessageHandler(params: {
     // Relay and native events can overlap; a following typeless bot event must see it.
     ctx.rememberSlackChannelType(message.channel, message.channel_type, opts.eventScope);
     trackEvent?.();
-    const resolvedMessage = await resolveThreadTsResolver(opts.eventScope).resolve({
+    const client = opts.eventScope?.client ?? ctx.app.client;
+    let threadTsResolver = threadTsResolvers.get(client);
+    if (!threadTsResolver) {
+      threadTsResolver = createSlackThreadTsResolver({ client });
+      threadTsResolvers.set(client, threadTsResolver);
+    }
+    const resolvedMessage = await threadTsResolver.resolve({
       message,
       source: opts.source,
       ...(opts.turnAdoptionLifecycle ? { turnAdoptionLifecycle: opts.turnAdoptionLifecycle } : {}),

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -368,6 +368,22 @@ export function createSlackMessageHandler(params: {
     },
   });
   const threadTsResolver = createSlackThreadTsResolver({ client: ctx.app.client });
+  const scopedThreadTsResolvers = new WeakMap<
+    SlackEventScope["client"],
+    ReturnType<typeof createSlackThreadTsResolver>
+  >();
+  const resolveThreadTsResolver = (eventScope?: SlackEventScope) => {
+    if (!eventScope) {
+      return threadTsResolver;
+    }
+    const existing = scopedThreadTsResolvers.get(eventScope.client);
+    if (existing) {
+      return existing;
+    }
+    const resolver = createSlackThreadTsResolver({ client: eventScope.client });
+    scopedThreadTsResolvers.set(eventScope.client, resolver);
+    return resolver;
+  };
   const pendingTopLevelDebounceKeys = new Map<string, Set<string>>();
 
   async function enqueueSlackMessage(
@@ -390,11 +406,7 @@ export function createSlackMessageHandler(params: {
     // Relay and native events can overlap; a following typeless bot event must see it.
     ctx.rememberSlackChannelType(message.channel, message.channel_type, opts.eventScope);
     trackEvent?.();
-    const resolvedMessage = await (
-      opts.eventScope
-        ? createSlackThreadTsResolver({ client: opts.eventScope.client })
-        : threadTsResolver
-    ).resolve({
+    const resolvedMessage = await resolveThreadTsResolver(opts.eventScope).resolve({
       message,
       source: opts.source,
       ...(opts.turnAdoptionLifecycle ? { turnAdoptionLifecycle: opts.turnAdoptionLifecycle } : {}),


### PR DESCRIPTION
Reviewed candidate head: `c788fd5676537e2a73a8c366568be53e1746896d`.

## What Problem This Solves

Enterprise Slack events rebuilt the thread resolver on every message, discarding its cache and in-flight lookup state. Keep one resolver per exact listener client in a WeakMap, and use that pool for both default and Enterprise clients. This removes the split construction paths while preserving the existing cache bounds, expiry, retry behavior, and client isolation. Production grows by six lines.

## Evidence

The replacement regression uses real Bolt/WebClients, the canonical monitor context, and loopback HTTP. It covers concurrent message/app_mention events, repeated cache hits, a replacement client returning a different thread root, and the default client. It fails before the repair and passes with the 62-test owner/sibling suite. The full build, final static gates, and fresh native-candidate P0 review pass; exact-head hosted gates are tracked before landing.

A real Gateway received signed synthetic Enterprise Slack events. Two unmentioned attempts and their mention twin shared one history lookup, produced one model request and an accepted reply in the recovered thread. Replacing the listener caused a fresh lookup:

```json
{"passed":true,"gateway":"real ephemeral Gateway","channelApi":"synthetic Slack HTTP with explicit Enterprise auth and inclusive-history fixtures","authenticatedSlack":false,"gatewayStarts":2,"firstListenerHistoryRequests":1,"replacementListenerHistoryRequests":1,"duplicateUnmentionedEvents":2,"modelRequests":1,"slackReplies":1,"replyInRecoveredThread":true,"gatewayTemporaryStateRemoved":true}
```

The single-pool and real-Gateway rank-up requests are addressed. Proof uses the existing default `replyToMode=off`, which preserves an existing thread. The same experiment with explicit `replyToMode=all` exposed a separate child-timestamp reply-tag observation that returned `thread_not_found`; it is retained as a named delivery-owner follow-up. Crabline's missing inclusive-history behavior is also a fixture follow-up, so the proof supplies that documented Slack API behavior explicitly.

Local proof ran on trusted main with the identical cache-owner blocks and test; no contributor checkout was executed locally. The final candidate follows the contributor head without unrelated main integration. Thanks @mikasa0818.

The requested current-main refresh is handled by focused owner-parity review and hosted merge validation; unrelated main integration is intentionally omitted. Historical contributor verification was marked malformed by the older review, so this repair relies on the independently recorded maintainer proof above.

A clean three-way application onto current main `f7bc0a08f6f8b7cd2ed69ca2e4e1cd7ae157dabe` produces complete handler and regression files byte-identical to the trusted proof checkout.
