### PR TITLE
test(ui): remove retired source mirrors

### DIFF
--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -67,7 +67,6 @@ export type TestChatPane = HTMLElement & {
   handleSessionSuggestionEvent: (event: SessionSuggestionEvent) => void;
   handleSessionTypingEvent: (event: SessionTypingEvent) => void;
   typingActors: Map<string, { label: string; expiresAt: number }>;
-  typingActorViews: () => { id: string; label: string }[];
   refreshSessionSuggestions: () => Promise<void>;
   resolveCurrentSessionSuggestion: (
     suggestion: SessionSuggestion,

--- a/ui/src/pages/chat/chat-task-suggestions.test.ts
+++ b/ui/src/pages/chat/chat-task-suggestions.test.ts
@@ -132,11 +132,6 @@ describe("chat task suggestions", () => {
     expect(copy?.textContent?.trim()).toBe("Copied");
   });
 
-  it("renders no card icon column", () => {
-    const { container } = renderSuggestion();
-    expect(container.querySelector(".task-suggestion__icon")).toBeNull();
-  });
-
   it("offers no acceptance-mode actions when modes are not advertised", () => {
     const { container, onAccept } = renderSuggestion({
       canAcceptTaskSuggestionModes: false,


### PR DESCRIPTION
## What Problem This Solves

Two Control UI test surfaces were coupled to retired implementation details:

- a negative assertion pinned the absence of the deleted `.task-suggestion__icon` markup;
- `TestChatPane` exposed `typingActorViews()` even though no test called it.

Both required maintenance without protecting an independent behavior contract.

## Why This Change Was Made

The obsolete assertion and unused test-support member are deleted rather than replaced. Stronger retained coverage owns the behavior:

- task-suggestion start, copy, dismiss, mode gating, and rendered geometry remain covered by unit and E2E tests;
- typing footer placement, labels, three-avatar cap, accessibility hiding, session rotation, and visible Gateway events remain covered through rendered and lifecycle tests.

Production `typingActorViews()` remains unchanged and live.

## User Impact

None. This is behavior-neutral test cleanup.

Production delta: 0. Tests/test support: -6 lines.

## Evidence

- Focused UI proof: 78 tests passed across task suggestions, composer, pane lifecycle, and pane task-suggestion suites.
- UI/core-test typecheck passed.
- Full changed-surface gate passed formatting, i18n verification, dead exports, typecheck, and scoped lint.
- Mandatory autoreview and TruffleHog: clean, no accepted/actionable findings.
