### PR TITLE
fix(memory): apply project affinity before MMR selection

### DIFF
--- a/extensions/memory-core/src/memory/hybrid.test.ts
+++ b/extensions/memory-core/src/memory/hybrid.test.ts
@@ -6,7 +6,6 @@ import {
   mergeHybridResults,
   scoreExactPathTieForTemporalDecay,
 } from "./hybrid.js";
-import { applyProjectRanking } from "./project-ranking.js";
 
 describe("memory hybrid helpers", () => {
   it("buildFtsQuery tokenizes and AND-joins", () => {
@@ -113,50 +112,110 @@ describe("memory hybrid helpers", () => {
   });
 
   it("boosts active-project results, demotes foreign results, and leaves global results neutral", async () => {
-    const merged = applyProjectRanking(
-      await mergeHybridResults({
-        vectorWeight: 1,
-        textWeight: 0,
-        keyword: [],
-        vector: [
-          {
-            id: "same",
-            path: "MEMORY.md",
-            startLine: 1,
-            endLine: 1,
-            source: "memory",
-            snippet: "same",
-            vectorScore: 0.8,
-            projectKey: "github.com/openclaw/openclaw",
-          },
-          {
-            id: "global",
-            path: "MEMORY.md",
-            startLine: 2,
-            endLine: 2,
-            source: "memory",
-            snippet: "global",
-            vectorScore: 0.8,
-          },
-          {
-            id: "foreign",
-            path: "MEMORY.md",
-            startLine: 3,
-            endLine: 3,
-            source: "memory",
-            snippet: "foreign",
-            vectorScore: 0.8,
-            projectKey: "github.com/example/other",
-          },
-        ],
-      }),
-      ["github.com/openclaw/openclaw"],
-    );
+    const merged = await mergeHybridResults({
+      vectorWeight: 1,
+      textWeight: 0,
+      activeProjectKeys: ["github.com/openclaw/openclaw"],
+      keyword: [],
+      vector: [
+        {
+          id: "same",
+          path: "MEMORY.md",
+          startLine: 1,
+          endLine: 1,
+          source: "memory",
+          snippet: "same",
+          vectorScore: 0.8,
+          projectKey: "github.com/openclaw/openclaw",
+        },
+        {
+          id: "global",
+          path: "MEMORY.md",
+          startLine: 2,
+          endLine: 2,
+          source: "memory",
+          snippet: "global",
+          vectorScore: 0.8,
+        },
+        {
+          id: "foreign",
+          path: "MEMORY.md",
+          startLine: 3,
+          endLine: 3,
+          source: "memory",
+          snippet: "foreign",
+          vectorScore: 0.8,
+          projectKey: "github.com/example/other",
+        },
+      ],
+    });
     expect(merged.map((entry) => [entry.snippet, entry.score])).toEqual([
       ["same", 0.9199999999999999],
       ["global", 0.8],
       ["foreign", 0.7200000000000001],
     ]);
+  });
+
+  it.each([
+    {
+      label: "without project affinity",
+      activeProjectKeys: undefined,
+      expected: ["memory/primary.md", "memory/diverse.md"],
+    },
+    {
+      label: "with project affinity",
+      activeProjectKeys: ["active-project"],
+      expected: ["memory/duplicate.md", "memory/diverse.md"],
+    },
+  ])("keeps a diverse hit in the selected set $label", async ({ activeProjectKeys, expected }) => {
+    const merged = await mergeHybridResults({
+      vectorWeight: 1,
+      textWeight: 0,
+      mmr: { enabled: true, lambda: 0.7 },
+      activeProjectKeys,
+      keyword: [],
+      vector: [
+        {
+          id: "primary",
+          path: "memory/primary.md",
+          startLine: 1,
+          endLine: 1,
+          source: "memory",
+          snippet: "alpha beta gamma",
+          vectorScore: 0.9,
+        },
+        {
+          id: "duplicate",
+          path: "memory/duplicate.md",
+          startLine: 1,
+          endLine: 1,
+          source: "memory",
+          snippet: "alpha beta gamma delta",
+          vectorScore: 0.8,
+          projectKey: "active-project",
+        },
+        {
+          id: "diverse",
+          path: "memory/diverse.md",
+          startLine: 1,
+          endLine: 1,
+          source: "memory",
+          snippet: "whiskey tango",
+          vectorScore: 0.75,
+        },
+        {
+          id: "floor",
+          path: "memory/floor.md",
+          startLine: 1,
+          endLine: 1,
+          source: "memory",
+          snippet: "alpha",
+          vectorScore: 0.2,
+        },
+      ],
+    });
+
+    expect(merged.slice(0, 2).map((entry) => entry.path)).toEqual(expected);
   });
 
   it("uses path BM25 only for partial path-only hybrid hits", async () => {

--- a/extensions/memory-core/src/memory/hybrid.ts
+++ b/extensions/memory-core/src/memory/hybrid.ts
@@ -3,6 +3,7 @@ import type { MemoryEntryProvenance } from "openclaw/plugin-sdk/memory-core-host
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { applyImportanceMultiplier } from "./importance.js";
 import { applyMMRToHybridResults, type MMRConfig, DEFAULT_MMR_CONFIG } from "./mmr.js";
+import { applyProjectRanking, projectScoreMultiplier } from "./project-ranking.js";
 import {
   applyTemporalDecayToHybridResults,
   type TemporalDecayConfig,
@@ -79,6 +80,7 @@ export async function mergeHybridResults(params: {
   mmr?: Partial<MMRConfig>;
   /** Temporal decay configuration for recency-aware scoring */
   temporalDecay?: Partial<TemporalDecayConfig>;
+  activeProjectKeys?: readonly string[];
   /** Test hook for deterministic time-dependent behavior */
   nowMs?: number;
 }): Promise<
@@ -245,13 +247,19 @@ export async function mergeHybridResults(params: {
     workspaceDir: params.workspaceDir,
     nowMs: params.nowMs,
   });
-  const rankable = applyImportanceMultiplier(decayed).map((entry) => {
+  const rankable = applyProjectRanking(
+    applyImportanceMultiplier(decayed),
+    params.activeProjectKeys,
+  ).map((entry) => {
     // Specificity owns cross-tier precedence. Keep the decayed weighted score
     // separately for within-tier ranking while exact public scores stay at 1.
     const exactPathTieScore = entry.score;
     return Object.assign(entry, {
       exactPathTieScore,
-      score: entry.exactPathSpecificity > 0 ? 1 : entry.score,
+      score:
+        entry.exactPathSpecificity > 0
+          ? projectScoreMultiplier(entry.projectKey, params.activeProjectKeys)
+          : entry.score,
     });
   });
   const nonExact = rankable
@@ -273,7 +281,11 @@ export async function mergeHybridResults(params: {
     return applyMMRToHybridResults(
       entries.map((entry) => Object.assign(entry, { score: entry.exactPathTieScore })),
       mmrConfig,
-    ).map((entry) => Object.assign(entry, { score: 1 }));
+    ).map((entry) =>
+      Object.assign(entry, {
+        score: projectScoreMultiplier(entry.projectKey, params.activeProjectKeys),
+      }),
+    );
   };
   const compareExactTieScores = (a: (typeof rankable)[number], b: (typeof rankable)[number]) =>
     b.exactPathTieScore - a.exactPathTieScore ||

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1118,18 +1118,17 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       ? Math.min(200, Math.max(maxResults, maxResults * 4))
       : maxResults;
     const candidateMinScore = hasActiveProject ? minScore / 1.15 : minScore;
-    const results = await this.searchUnranked(normalizedQuery, {
+    const results = await this.searchCandidates(normalizedQuery, {
       ...opts,
       maxResults: candidateMaxResults,
       minScore: candidateMinScore,
     });
-    const ranked = applyProjectRanking(results, opts?.activeProjectKeys);
     return hasActiveProject
-      ? ranked.filter((entry) => entry.score >= minScore).slice(0, maxResults)
-      : ranked;
+      ? results.filter((entry) => entry.score >= minScore).slice(0, maxResults)
+      : results;
   }
 
-  private async searchUnranked(
+  private async searchCandidates(
     normalizedQuery: string,
     opts?: MemoryIndexSearchOptions,
   ): Promise<MemorySearchResult[]> {
@@ -1290,6 +1289,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           temporalDecay: hybrid.temporalDecay,
           maxResults,
           minScore,
+          activeProjectKeys: opts?.activeProjectKeys,
         });
       }
       let semanticProvider = this.provider;
@@ -1329,6 +1329,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
             temporalDecay: hybrid.temporalDecay,
             maxResults,
             minScore,
+            activeProjectKeys: opts?.activeProjectKeys,
           });
         }
         try {
@@ -1402,6 +1403,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
               temporalDecay: hybrid.temporalDecay,
               maxResults,
               minScore,
+              activeProjectKeys: opts?.activeProjectKeys,
             });
           } else {
             throw err;
@@ -1429,14 +1431,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           temporalDecay: hybrid.temporalDecay,
           workspaceDir: this.workspaceDir,
         });
-        return applyImportanceMultiplier(decayed)
-          .toSorted(
-            (left, right) =>
-              right.score - left.score ||
-              left.path.localeCompare(right.path) ||
-              left.startLine - right.startLine ||
-              left.endLine - right.endLine,
-          )
+        return applyProjectRanking(applyImportanceMultiplier(decayed), opts?.activeProjectKeys)
           .filter((entry) => entry.score >= minScore)
           .slice(0, maxResults);
       }
@@ -1449,6 +1444,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         textWeight: hybrid.textWeight,
         mmr: hybrid.mmr,
         temporalDecay: hybrid.temporalDecay,
+        activeProjectKeys: opts?.activeProjectKeys,
       });
       const strict = merged.filter((entry) => entry.score >= minScore);
       if (strict.length > 0 || keywordResults.length === 0) {
@@ -1549,6 +1545,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     temporalDecay?: { enabled: boolean; halfLifeDays: number };
     maxResults: number;
     minScore: number;
+    activeProjectKeys?: readonly string[];
   }): Promise<MemorySearchResult[]> {
     const appliesTemporalDecay = params.temporalDecay?.enabled === true;
     const decayInputs = appliesTemporalDecay
@@ -1565,9 +1562,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       temporalDecay: params.temporalDecay,
       workspaceDir: this.workspaceDir,
     });
-    const ranked = this.rankKeywordOnlyResults(
-      applyImportanceMultiplier(decayed),
-      !appliesTemporalDecay,
+    const ranked = applyProjectRanking(
+      this.rankKeywordOnlyResults(applyImportanceMultiplier(decayed), !appliesTemporalDecay),
+      params.activeProjectKeys,
     );
     return this.toMemorySearchResults(
       this.selectScoredResults(ranked, params.maxResults, params.minScore, 0),
@@ -1860,6 +1857,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     textWeight: number;
     mmr?: { enabled: boolean; lambda: number };
     temporalDecay?: { enabled: boolean; halfLifeDays: number };
+    activeProjectKeys?: readonly string[];
   }): Promise<MemorySearchResult[]> {
     return mergeHybridResults({
       vector: params.vector.map((r) => ({
@@ -1898,6 +1896,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         classifyMemoryMultimodalPath(path, this.settings.multimodal) !== null,
       mmr: params.mmr,
       temporalDecay: params.temporalDecay,
+      activeProjectKeys: params.activeProjectKeys,
       workspaceDir: this.workspaceDir,
     }).then((entries) => entries.map((entry) => entry as MemorySearchResult));
   }

--- a/extensions/memory-core/src/memory/project-ranking.ts
+++ b/extensions/memory-core/src/memory/project-ranking.ts
@@ -8,7 +8,7 @@ type ProjectRankable = {
   projectKey?: string;
 };
 
-function projectScoreMultiplier(
+export function projectScoreMultiplier(
   projectKey: string | null | undefined,
   activeProjectKeys: readonly string[] | undefined,
 ): number {


### PR DESCRIPTION
## What Problem This Solves

Project-affinity multipliers ran after MMR diversity selection, reordering results post-selection and partially undoing the diversity MMR (default since #121224) had chosen — a sequencing bug between two ranking stages.

## Why This Change Was Made

Project affinity now folds into candidate scoring before MMR across hybrid, vector-only, and keyword-only paths — joining temporal decay and importance in the canonical scoring owner — and the post-MMR reorder path is deleted. Candidate widening and result limits are preserved; exact-path score behavior is unchanged.

## User Impact

Memory results in project contexts keep both project relevance and diversity instead of trading one for the other.

## Evidence

- Hybrid/MMR: 29 tests, including the two-row diversity regression table.
- Project/tool integration: 147 tests.
- Full memory-core: 1,061 tests.
- Typechecks, lint, and format passed.
- Codex autoreview clean (0.97).
- Production +31/-20, threading project affinity to the canonical scoring owner.
- Local `check-changed` stopped on pre-existing stale max-lines entries for `src/infra/clawhub.ts`, which this branch does not touch. If the same failure appears in PR CI, we will verify whether it reproduces on `origin/main` before treating it as branch-related.
