### PR TITLE
fix(ci): stabilize Control UI sidebar reconnect check

### DIFF
--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -487,7 +487,7 @@ suite.define(() => {
       await expect
         .poll(() => gateway.getSocketCount(), { timeout: 15_000 })
         .toBe(socketsBefore + 1);
-      await gateway.deferNext("sessions.list");
+      await gateway.deferNext("sessions.list", { includeLastMessage: true });
       await gateway.setOnline(true);
       await waitForControlUiGatewayReady(page);
       await expect

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -293,7 +293,7 @@ export function setSharedControlUiE2eServerBaseUrl(baseUrl: string | null): void
 export type MockGatewayControls = {
   closeLatest: (code?: number, reason?: string) => Promise<void>;
   deliverLatest: (frame: unknown) => Promise<void>;
-  deferNext: (method: string) => Promise<void>;
+  deferNext: (method: string, match?: Record<string, unknown>) => Promise<void>;
   emitChatFinal: (params: { runId: string; sessionKey?: string; text: string }) => Promise<void>;
   emitGatewayEvent: (event: string, payload?: unknown) => Promise<void>;
   getRequests: (method?: string) => Promise<MockGatewayRequest[]>;
@@ -722,10 +722,14 @@ function installControlUiMockGateway(
     params?: unknown;
     socket: { deliver: (frame: unknown) => void };
   };
+  type DeferredMethod = {
+    method: string;
+    match?: Record<string, unknown>;
+  };
   type ExposedGateway = {
     closeLatest: (code?: number, reason?: string) => void;
     deliverLatest: (frame: unknown) => void;
-    deferNext: (method: string) => void;
+    deferNext: (method: string, match?: Record<string, unknown>) => void;
     emit: (event: string, payload?: unknown) => void;
     findRequests: (method?: string) => BrowserRequest[];
     rejectDeferred: (
@@ -765,7 +769,7 @@ function installControlUiMockGateway(
   } catch {
     // Opaque initial documents may not expose storage; the target page will.
   }
-  const deferredMethods: string[] = [...scenario.deferredMethods];
+  const deferredMethods: DeferredMethod[] = scenario.deferredMethods.map((method) => ({ method }));
   const deferredResponses: DeferredResponse[] = [];
   const requests: BrowserRequest[] = [];
   const methodResponseSequenceIndexes = new Map<string, number>();
@@ -1630,8 +1634,10 @@ function installControlUiMockGateway(
     }
   }
 
-  function shouldDefer(method: string): boolean {
-    const index = deferredMethods.indexOf(method);
+  function shouldDefer(method: string, params: unknown): boolean {
+    const index = deferredMethods.findIndex(
+      (candidate) => candidate.method === method && paramsMatch(params, candidate.match),
+    );
     if (index < 0) {
       return false;
     }
@@ -1732,7 +1738,7 @@ function installControlUiMockGateway(
         return;
       }
       requests.push({ id, method, params: frame.params });
-      if (shouldDefer(method)) {
+      if (shouldDefer(method, frame.params)) {
         deferredResponses.push({ id, method, params: frame.params, socket: this });
         return;
       }
@@ -1788,8 +1794,8 @@ function installControlUiMockGateway(
     deliverLatest(frame) {
       MockWebSocket.latest?.deliver(frame);
     },
-    deferNext(method) {
-      deferredMethods.push(method);
+    deferNext(method, match) {
+      deferredMethods.push({ method, match });
     },
     emit(event, payload) {
       MockWebSocket.latest?.deliver({
@@ -1994,20 +2000,23 @@ function createMockGatewayControls(page: Page, defaultSessionKey: string): MockG
       );
     },
     deliverLatest,
-    async deferNext(method) {
-      await page.evaluate((targetMethod) => {
-        const gateway = (
-          window as Window & {
-            openclawControlUiE2eGateway?: {
-              deferNext: (method: string) => void;
-            };
+    async deferNext(method, match) {
+      await page.evaluate(
+        ({ targetMethod, requestMatch }) => {
+          const gateway = (
+            window as Window & {
+              openclawControlUiE2eGateway?: {
+                deferNext: (method: string, match?: Record<string, unknown>) => void;
+              };
+            }
+          ).openclawControlUiE2eGateway;
+          if (!gateway) {
+            throw new Error("Mock Gateway is not installed");
           }
-        ).openclawControlUiE2eGateway;
-        if (!gateway) {
-          throw new Error("Mock Gateway is not installed");
-        }
-        gateway.deferNext(targetMethod);
-      }, method);
+          gateway.deferNext(targetMethod, requestMatch);
+        },
+        { targetMethod: method, requestMatch: match },
+      );
     },
     async emitChatFinal(params) {
       await emitGatewayEvent("chat", {


### PR DESCRIPTION
Related: #121438
Related: #120732

## What Problem This Solves

Resolves a flaky Control UI browser check where the sidebar reconnect scenario could time out waiting for the refreshed session label even though the production sidebar had correctly applied its canonical reconnect response. The failure reproduced on `main` locally and in the first attempt of CI run https://github.com/openclaw/openclaw/actions/runs/31363964382.

## Why This Change Was Made

The mock Gateway's one-shot deferral selected only by RPC method. During reconnect, the replacement connection legitimately sends two different `sessions.list` requests: a searched, archived route-resolution lookup and the canonical sidebar roster hydration. Whichever request arrived first consumed the method-global deferral, so the test could resolve the route lookup with the refreshed fixture while the sidebar correctly retained the canonical stale fixture.

The test harness now allows a deferred request to match a subset of request parameters. The sidebar scenario targets the canonical roster request through `includeLastMessage: true`; existing method-only deferrals keep their FIFO behavior. This completes the earlier #120732 stabilization, which isolated the replacement socket generation but could not distinguish request owners inside that generation.

No production behavior, timeout, retry, or assertion strength changed. Production LOC: +0/-0. Tests and test support: +31/-22 (net +9).

## User Impact

No user-visible behavior changes. Maintainers get deterministic Control UI reconnect coverage that exercises the real route-resolution and canonical roster requests without allowing one to impersonate the other.

## Evidence

- Unchanged local stress reproduction failed on iteration 4 at the `Reconnect refreshed` assertion.
- Temporary diagnostics captured the reconnect ordering:
  1. initial canonical list: `limit: 50`, `includeDerivedTitles: true`, `includeLastMessage: true`;
  2. route-resolution lookup: `limit: 20`, `archived: "all"`, searched by the session key;
  3. reconnect canonical list: `limit: 50`, `includeDerivedTitles: true`, `includeLastMessage: true`.
- Repaired sidebar scenario: passed.
- Adjacent catalog reconnect scenario (`resolves a pending catalog target after reconnect without clearing the draft`): passed and does not share this mechanism.
- Paired stress proof: 10 serial iterations, 20/20 target tests passed.
- Mock Gateway helper suites: 14/14 passed.
- Targeted `oxfmt --check`, type-aware `oxlint`, and `git diff --check`: passed.
- Codex autoreview: clean, no accepted/actionable findings.
- The separate `baseRef: "mainmain"` failure in the same historical CI shard is an unrelated input-control race in the terminal-start scenario and is intentionally not changed here.
- AI-assisted; the author reviewed and understands the change.
