### PR TITLE
fix(plugin-sdk): keep API baseline stable across internal file moves

### DIFF
--- a/src/plugin-sdk/api-baseline.test.ts
+++ b/src/plugin-sdk/api-baseline.test.ts
@@ -63,6 +63,7 @@ async function renderSourceFixture(
 }
 
 async function renderPrivateDeclarationFixture(params?: {
+  nestedOption?: boolean;
   optionalOption?: boolean;
   optionalResult?: boolean;
 }) {
@@ -81,20 +82,23 @@ async function renderPrivateDeclarationFixture(params?: {
       },
     })}\n`,
   );
+  const optionModule = params?.nestedOption ? "fixture-internal/fixture-option" : "fixture-option";
+  const optionImport = `./${optionModule}.js`;
   fs.writeFileSync(
     path.join(sourceDir, "fixture.ts"),
     [
-      'import type { FixtureOptionLeaf } from "./fixture-option.js";',
       'import type { FixtureResultLeaf } from "./fixture-result.js";',
-      "type FixtureOptions = { nested: FixtureOptionLeaf };",
+      `type FixtureOptions = { nested: import("${optionImport}").FixtureOptionLeaf };`,
       "type FixtureResult = { nested: FixtureResultLeaf };",
       "export declare function createFixture(options: FixtureOptions): FixtureResult;",
     ].join("\n"),
   );
+  const optionPath = path.join(sourceDir, `${optionModule}.ts`);
+  fs.mkdirSync(path.dirname(optionPath), { recursive: true });
   fs.writeFileSync(
-    path.join(sourceDir, "fixture-option.ts"),
+    optionPath,
     [
-      'import type { FixtureResultLeaf } from "./fixture-result.js";',
+      `import type { FixtureResultLeaf } from "${params?.nestedOption ? "../" : "./"}fixture-result.js";`,
       'import type { FixtureExternal } from "fixture-external";',
       `export type FixtureOptionLeaf = { required${params?.optionalOption ? "?" : ""}: string; result?: FixtureResultLeaf; external?: FixtureExternal };`,
     ].join("\n"),
@@ -106,7 +110,7 @@ async function renderPrivateDeclarationFixture(params?: {
   fs.writeFileSync(
     path.join(sourceDir, "fixture-result-shape.ts"),
     [
-      'import type { FixtureOptionLeaf } from "./fixture-option.js";',
+      `import type { FixtureOptionLeaf } from "${optionImport}";`,
       `export type FixtureResultLeaf = { value${params?.optionalResult ? "?" : ""}: string; option?: FixtureOptionLeaf };`,
     ].join("\n"),
   );
@@ -347,6 +351,13 @@ describe("Plugin SDK API baseline", () => {
     const secondRender = await renderPrivateDeclarationFixture();
 
     expect(secondRender.jsonl).toBe(firstRender.jsonl);
+  });
+
+  it("keeps the baseline byte-identical when a private closure file moves", async () => {
+    const baseline = await renderPrivateDeclarationFixture();
+    const moved = await renderPrivateDeclarationFixture({ nestedOption: true });
+
+    expect(moved.jsonl).toBe(baseline.jsonl);
   });
 
   it("fails checks on contract drift and passes after write", async () => {


### PR DESCRIPTION
Related: #120975, #121553

## What Problem This Solves

Resolves a problem where moving repository-owned files referenced by public Plugin SDK declarations rewrites unrelated closure hashes in the committed API manifest. The manifest therefore acts as a global merge-serialization token during concurrent refactors; #121553 has had five otherwise-proven landing attempts fail because move-only source layout changes churned this baseline.

## Why This Change Was Made

Declaration closures now use entrypoint-relative graph identity instead of repository paths. The renderer walks emitted declaration references in source order, assigns closure-local indexes, and rewrites every repository-owned import, re-export, import-equals, and `import("…")` type specifier to the resolved declaration's index before hashing. External package specifiers remain intact.

This preserves dependency edges and cycles, unlike stripping or sorting raw specifiers, while removing physical file paths from the hash input. The committed manifest remains the review surface introduced by #120975, including transitive private declarations.

## User Impact

No runtime or public Plugin SDK behavior changes. Maintainers can move internal declaration files without regenerating unrelated API hashes, while real public or closure-transitive private type changes still fail the drift check.

The one-time baseline migration is 4,446 added / 4,446 removed JSONL lines. Of 4,998 records, 4,427 change only the closure digest; 19 also reflect declaration-equivalent TypeScript union/property ordering after traversal stopped sorting by source path.

## Evidence

- Pre-fix regression: the moved-private-file fixture failed only because the closure hash changed (`0c7999…` → `322305…`).
- `node scripts/run-vitest.mjs src/plugin-sdk/api-baseline.test.ts` — 10/10 passed on exact head, covering move stability, transitive private-type drift, and deterministic generation.
- Two full generations produced the same committed blob (`f57f396c217d5b23a7181fc1180d031b7bdf97a1` before the final main rebase); exact-head `pnpm plugin-sdk:api:check` passed after canonical regeneration.
- `pnpm plugin-sdk:surface:check` — 151 public entrypoints, 4,847 exports, zero forbidden subpaths.
- `pnpm build` — passed before the final main-only rebase; all 151 public Plugin SDK subpaths verified, no ineffective dynamic-import finding. Exact-head `build-artifacts` also passed in hosted CI.
- `pnpm check:import-cycles` — 0 runtime value cycles.
- Exact-head CI: [run 31397454146, attempt 2](https://github.com/openclaw/openclaw/actions/runs/31397454146/attempts/2) passed after one unrelated `src/secrets/**` loaded-runner hook-timeout rerun; current rollup is 81 successful, 38 skipped, 0 failed, 0 pending.
- `git diff --check` — passed.
- Autoreview — clean; no accepted/actionable findings. The generated JSONL exceeded the review helper's eight-pass transport cap, so it was validated by the exact generator/check and record-level audit instead.
- Trusted Testbox execution was attempted first but unavailable because the host lacks the `blacksmith` CLI; repository policy's trusted-source local fallback was used.

AI-assisted: implementation and review were completed with coding-agent assistance; the maintainer reviewed the design, diff, and proof.
