### PR TITLE
fix(codex): open local images with uppercase file URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Codex image attachments: decode mixed-case `file://` URLs as local image paths while preserving existing file URL validation and platform behavior. (#121611) Thanks @sunlit-deng.
+
 - **Control UI agent files:** keep confirmed saves and file metadata intact when older reads or list refreshes finish later, preserve newer drafts, and rebuild invalidated file lists without losing the open editor.
 
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.

--- a/extensions/codex/src/conversation-turn-input.test.ts
+++ b/extensions/codex/src/conversation-turn-input.test.ts
@@ -1,6 +1,12 @@
 // Codex tests cover conversation turn input plugin behavior.
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { buildCodexConversationTurnInput } from "./conversation-turn-input.js";
+
+const localFileCases = ["file", "FILE", "FiLe"].flatMap((scheme) =>
+  ["mediaPath", "mediaUrl"].map((field) => ({ scheme, field })),
+);
 
 describe("codex conversation turn input", () => {
   it("forwards inbound image attachments to Codex app-server", () => {
@@ -87,27 +93,31 @@ describe("codex conversation turn input", () => {
     ]);
   });
 
-  it("decodes local file URLs for Codex local image input", () => {
-    expect(
-      buildCodexConversationTurnInput({
-        prompt: "look",
-        event: {
-          content: "look",
-          channel: "webchat",
-          isGroup: false,
-          metadata: {
-            mediaPath: "file:///tmp/OpenClaw%20QA/photo.png",
-            mediaType: "image/png",
+  it.each(localFileCases)(
+    "decodes $scheme URLs from $field for local images",
+    ({ scheme, field }) => {
+      const imagePath = path.resolve("OpenClaw QA", "photo #1?.png");
+      expect(
+        buildCodexConversationTurnInput({
+          prompt: "look",
+          event: {
+            content: "look",
+            channel: "webchat",
+            isGroup: false,
+            metadata: {
+              [field]: pathToFileURL(imagePath).href.replace(/^file:/, `${scheme}:`),
+              mediaType: "image/png",
+            },
           },
-        },
-      }),
-    ).toEqual([
-      { type: "text", text: "look", text_elements: [] },
-      { type: "localImage", path: "/tmp/OpenClaw QA/photo.png" },
-    ]);
-  });
+        }),
+      ).toEqual([
+        { type: "text", text: "look", text_elements: [] },
+        { type: "localImage", path: imagePath },
+      ]);
+    },
+  );
 
-  it("drops malformed local file URLs instead of throwing", () => {
+  it.each(localFileCases)("drops malformed $scheme URLs from $field", ({ scheme, field }) => {
     expect(
       buildCodexConversationTurnInput({
         prompt: "look",
@@ -116,7 +126,7 @@ describe("codex conversation turn input", () => {
           channel: "webchat",
           isGroup: false,
           metadata: {
-            mediaPath: "file:///tmp/%zz/photo.png",
+            [field]: `${scheme}:///tmp/%zz/photo.png`,
             mediaType: "image/png",
           },
         },
@@ -124,7 +134,45 @@ describe("codex conversation turn input", () => {
     ).toEqual([{ type: "text", text: "look", text_elements: [] }]);
   });
 
+  it.each(localFileCases)(
+    "rejects encoded separators in $scheme URLs from $field",
+    ({ scheme, field }) => {
+      expect(
+        buildCodexConversationTurnInput({
+          prompt: "look",
+          event: {
+            content: "look",
+            channel: "webchat",
+            isGroup: false,
+            metadata: { [field]: `${scheme}:///tmp/hidden%2Fphoto.png`, mediaType: "image/png" },
+          },
+        }),
+      ).toEqual([{ type: "text", text: "look", text_elements: [] }]);
+    },
+  );
+
+  it.skipIf(process.platform === "win32").each(localFileCases)(
+    "preserves POSIX backslash filenames in $scheme URLs from $field",
+    ({ scheme, field }) => {
+      expect(
+        buildCodexConversationTurnInput({
+          prompt: "look",
+          event: {
+            content: "look",
+            channel: "webchat",
+            isGroup: false,
+            metadata: { [field]: `${scheme}:///tmp/photo%5Cname.png`, mediaType: "image/png" },
+          },
+        }),
+      ).toEqual([
+        { type: "text", text: "look", text_elements: [] },
+        { type: "localImage", path: "/tmp/photo\\name.png" },
+      ]);
+    },
+  );
+
   it("treats local media URLs as Codex local image input", () => {
+    const secondImagePath = path.resolve("OpenClaw QA", "second.jpg");
     expect(
       buildCodexConversationTurnInput({
         prompt: "look",
@@ -133,7 +181,7 @@ describe("codex conversation turn input", () => {
           channel: "webchat",
           isGroup: false,
           metadata: {
-            mediaUrls: ["/tmp/staged-photo.png", "file:///tmp/OpenClaw%20QA/second.jpg"],
+            mediaUrls: ["/tmp/staged-photo.png", pathToFileURL(secondImagePath).href],
             mediaTypes: ["image/png", "image/jpeg"],
           },
         },
@@ -141,7 +189,7 @@ describe("codex conversation turn input", () => {
     ).toEqual([
       { type: "text", text: "look", text_elements: [] },
       { type: "localImage", path: "/tmp/staged-photo.png" },
-      { type: "localImage", path: "/tmp/OpenClaw QA/second.jpg" },
+      { type: "localImage", path: secondImagePath },
     ]);
   });
 

--- a/extensions/codex/src/conversation-turn-input.ts
+++ b/extensions/codex/src/conversation-turn-input.ts
@@ -75,7 +75,7 @@ function isImageMedia(media: InboundMedia): boolean {
 }
 
 function normalizeFileUrl(value: string): string | undefined {
-  if (!value.startsWith("file://")) {
+  if (!/^file:\/\//iu.test(value)) {
     return value;
   }
   try {
@@ -89,7 +89,7 @@ function readLocalMediaPath(value: string | undefined): string | undefined {
   if (!value) {
     return undefined;
   }
-  if (value.startsWith("file://")) {
+  if (/^file:\/\//iu.test(value)) {
     return value;
   }
   if (value.startsWith("//")) {


### PR DESCRIPTION
## What Problem This Solves

Codex conversation turns lose local image attachments when their `file://` URI scheme uses uppercase or mixed-case letters. A `mediaUrl` becomes an unusable remote image URL; a `mediaPath` reaches Codex as an undecoded URI instead of a filesystem path.

## Why This Change Was Made

Make the adapter's two file-URI checks case-insensitive. Keep Node's existing `fileURLToPath` conversion, including its malformed-URL rejection and platform behavior. The earlier converter replacement also rejected previously accepted POSIX backslash filenames and Windows network-file URLs; those policy changes are unnecessary for this repair.

The regression coverage now tests both metadata fields with lowercase, uppercase, and mixed-case schemes, encoded filename characters, malformed escapes, forbidden encoded separators, and preserved POSIX backslash filenames. Existing staged-path, remote-URL, protocol-relative-URL, and Windows-path controls remain covered. The retained list-field fixture is now platform-correct too.

## User Impact

Image attachments with mixed-case file URI schemes reach Codex as decoded local files. Path spelling, ordinary paths, remote URLs, and existing URL conversion rules remain unchanged. No configuration, dependency, protocol, or SDK changes.

## Evidence

- Reviewed and pushed head: `04269b84d1db7b36e1e793bd9a5137631fb221e8`; GitHub verifies its SSH signature and preserves @sunlit-deng as primary author. [Exact-head CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33032022522/attempts/2) and [Workflow Sanity](https://github.com/openclaw/openclaw/actions/runs/33032022572) are green, including the `openclaw/ci-gate` check from the expected GitHub Actions app.
- Before the production change, the expanded regression suite failed 16 cases and passed 14 on the current-main baseline. After the repair, 30 Codex input tests and 18 embedded-runtime media-reference tests pass: `node scripts/run-vitest.mjs extensions/codex/src/conversation-turn-input.test.ts src/agents/embedded-agent-runner/run/images.media-refs.test.ts`.
- Executed the production input builder with the real pinned Codex 0.149.1 app server, isolated temporary state, a synthetic PNG, and a local Responses receiver. Before: all four uppercase/mixed-case combinations failed to supply image bytes. After: both fields across all three scheme spellings produced exactly one PNG matching the fixture bytes and 1×1 dimensions, with no file URI or error placeholder in the provider request.
- Negative controls: a malformed mixed-case URI produces no image input; an invalid PNG produces no image and the runtime's explicit processing-error placeholder. Every test process, receiver, and temporary state directory was cleaned up.
- This is live adapter/app-server/byte-consumption proof with a controlled receiver. It does not claim an authenticated model inference or a complete `handleInboundClaim` run.
- Personally inspected the current pinned upstream contract at `rust-v0.149.1`: `codex-rs/app-server-protocol/src/protocol/v2/turn.rs`, `codex-rs/protocol/src/models.rs`, and `codex-rs/core/src/image_preparation.rs`. The production conversation binding passes this builder's output directly to `turn/start`; the embedded runtime already recognizes mixed-case file schemes.
- Fresh Codex autoreview, a separate independent Codex process, and two independent source/proof reviews found no actionable findings.
- The supported changed-file check completed successfully, including formatting, contract/ownership guards, dead-export scans, production/test typechecks, and extension lint.
- Hosted CI attempt 1 had one failing shard: two unchanged Discord CLI startup probes timed out while awaiting the same child-process pair. Both passed locally on this exact head in 13.30 seconds. A single targeted hosted retry passed as attempt 2 of run 33032022522, including its dependent aggregate gate; no timeout increases, weakened assertions, or unrelated source changes were made.

Production: +2/-2 (net zero). Tests: +70/-22. One changelog entry, included under explicit maintainer direction. The original case-sensitive path handling was present in `69566e43cb8b` (author and committer @steipete, April 24); URL-locality handling carried it forward in #77459 (code and PR author @vincentkoc, merged by @pashpashpash, May 4). The affected code is present in stable `v2026.7.1-2`.

Latest ClawSweeper review and rank-up disposition: keep the one-line Unreleased changelog entry under explicit maintainer direction; the policy-only removal suggestion is intentionally not applied. Direct pinned-Codex and file-converter contract inspection is complete, including lower-case/platform controls; the broader converter swap was removed. The reviewer environment's missing Codex checkout is covered by direct maintainer inspection of `rust-v0.149.1` protocol `turn.rs:292-341`, `models.rs:1886-1940`, and `image_preparation.rs:21-22,90`. Exact-head CI is now green. The reported stored-data/embedding marker refers only to test attachment metadata: there is no persistent-store, vector, embedding, schema, or migration change in this diff.

Contributor credit: @sunlit-deng. The maintainer revision keeps the original contribution and strengthens compatibility and runtime proof.
