### PR TITLE
fix(mac): let users switch AI candidates during onboarding test

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -34931,7 +34931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 252,
+      "line": 258,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift",
       "source": "The Gateway setup request failed.",
       "surface": "apple",
@@ -34939,7 +34939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 253,
+      "line": 259,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift",
       "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
       "surface": "apple",
@@ -34947,7 +34947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 337,
+      "line": 350,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift",
       "source": "\\(label) couldn’t complete the test.",
       "surface": "apple",
@@ -34955,7 +34955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 338,
+      "line": 351,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift",
       "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -711,15 +711,22 @@ extension OnboardingAISetupModel {
         }
     }
 
-    private func captureAttemptContext() -> AttemptContext? {
+    private func captureAttemptContext(
+        supersededAttemptDeadline: Date? = nil) -> AttemptContext?
+    {
         let identity = self.routeIdentityProvider()?.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let identity, !identity.isEmpty else { return nil }
-        return AttemptContext(token: self.attemptToken, routeIdentity: identity)
+        return AttemptContext(
+            token: self.attemptToken,
+            routeIdentity: identity,
+            supersededAttemptDeadline: supersededAttemptDeadline)
     }
 
-    private func beginAttemptContext() -> AttemptContext? {
+    private func beginAttemptContext(
+        supersededAttemptDeadline: Date? = nil) -> AttemptContext?
+    {
         self.attemptToken = UUID()
-        return self.captureAttemptContext()
+        return self.captureAttemptContext(supersededAttemptDeadline: supersededAttemptDeadline)
     }
 
     private func isCurrentAttempt(_ context: AttemptContext) -> Bool {
@@ -759,9 +766,30 @@ extension OnboardingAISetupModel {
     }
 
     func userSelect(kind: String) {
-        guard !self.isBusy, !self.connected else { return }
-        guard let context = beginAttemptContext() else { return }
-        Task { await self.activate(kind: kind, context: context) }
+        guard self.canSelectCandidate(kind: kind) else { return }
+        var supersededKind: String?
+        var supersededAttemptDeadline: Date?
+        if self.phase == .testing, let selectedKind = self.selectedKind {
+            // A user pick supersedes auto-testing; the attempt token rejects every late result.
+            supersededKind = selectedKind
+            let routeIdentity = self.routeIdentityProvider()
+            supersededAttemptDeadline = routeIdentity.flatMap {
+                self.activePendingActivationDeadline(for: $0)
+            }
+                ?? Date().addingTimeInterval(
+                    Self.activationRequestTimeoutMs(for: selectedKind) / 1000 + 5)
+        }
+        guard let context = beginAttemptContext(
+            supersededAttemptDeadline: supersededAttemptDeadline)
+        else { return }
+        if let supersededKind {
+            self.statuses[supersededKind] = .untried
+            self.selectedKind = kind
+            self.statuses[kind] = .testing
+        }
+        Task {
+            await self.activate(kind: kind, context: context)
+        }
     }
 
     func activate(kind: String) async {
@@ -840,12 +868,15 @@ extension OnboardingAISetupModel {
         } ?? .unbound()
         self.pendingActivationOwner = activationOwner
         self.pendingActivationRequiresFreshActivation = true
+        let supersededWaitMs = max(
+            0,
+            (context.supersededAttemptDeadline?.timeIntervalSinceNow ?? 0) * 1000)
         // Activation can persist before the response reaches the app. Cover the
         // whole ambiguous window so relaunch can inspect the actual Gateway state.
         guard let activationDeadline = OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: context.routeIdentity,
             activationOwner: activationOwner,
-            activationTimeoutMs: requestTimeoutMs,
+            activationTimeoutMs: requestTimeoutMs + supersededWaitMs,
             defaults: defaults)
         else {
             let failure = Self.transportFailure(
@@ -861,11 +892,11 @@ extension OnboardingAISetupModel {
             return
         }
         do {
-            let data = try await gateway.request(
-                method: "openclaw.setup.activate",
+            let data = try await self.requestActivation(
                 params: params,
                 timeoutMs: requestTimeoutMs,
-                ifCurrentServerLease: lease)
+                serverLease: lease,
+                context: context)
             let result = try JSONDecoder().decode(ActivateResult.self, from: data)
             guard self.isCurrentAttempt(context), !Task.isCancelled else { return }
             guard await self.gateway.isCurrentServerLease(lease) else {
@@ -946,6 +977,34 @@ extension OnboardingAISetupModel {
                     ifOwnedBy: context,
                     activationOwner: activationOwner,
                     activationDeadline: activationDeadline)
+            }
+        }
+    }
+
+    private func requestActivation(
+        params: [String: AnyCodable],
+        timeoutMs: Double,
+        serverLease: GatewayConnection.ServerLease,
+        context: AttemptContext) async throws -> Data
+    {
+        var retryDelayMs: UInt64 = 250
+        while true {
+            guard self.isCurrentAttempt(context), !Task.isCancelled else {
+                throw CancellationError()
+            }
+            do {
+                return try await self.gateway.request(
+                    method: "openclaw.setup.activate",
+                    params: params,
+                    timeoutMs: timeoutMs,
+                    ifCurrentServerLease: serverLease)
+            } catch {
+                guard let supersededAttemptDeadline = context.supersededAttemptDeadline,
+                      Date() < supersededAttemptDeadline,
+                      Self.activationAdmissionIsBusy(error)
+                else { throw error }
+                try await Task.sleep(nanoseconds: retryDelayMs * 1_000_000)
+                retryDelayMs = min(retryDelayMs * 2, 5000)
             }
         }
     }

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
@@ -11,6 +11,7 @@ extension OnboardingAISetupModel {
     struct AttemptContext: Equatable {
         let token: UUID
         let routeIdentity: String
+        let supersededAttemptDeadline: Date?
     }
 
     struct PendingVerification {
@@ -191,6 +192,11 @@ extension OnboardingAISetupModel {
             self.pendingActivationVerification
     }
 
+    func canSelectCandidate(kind: String) -> Bool {
+        guard !self.connected else { return false }
+        return !self.isBusy || (self.phase == .testing && self.selectedKind != kind)
+    }
+
     /// Once setup starts changing inference, its successful result belongs to
     /// OpenClaw rather than the existing-Gateway onboarding bypass.
     var ownsInferenceTransition: Bool {
@@ -275,6 +281,13 @@ extension OnboardingAISetupModel {
         return error is GatewayConnectAuthError ||
             error is GatewayTLSValidationError ||
             error is OpenClawChatTransportSendError
+    }
+
+    static func activationAdmissionIsBusy(_ error: Error) -> Bool {
+        guard let response = error as? GatewayResponseError else { return false }
+        return response.method == "openclaw.setup.activate" &&
+            response.code.uppercased() == "UNAVAILABLE" &&
+            response.details["retryable"]?.value as? Bool == true
     }
 
     static func activationParams(

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
@@ -314,7 +314,7 @@ struct OnboardingAISetupView: View {
                 }
             }
             .buttonStyle(.plain)
-            .disabled(self.model.isBusy)
+            .disabled(!self.model.canSelectCandidate(kind: candidate.kind))
 
             if case let .failed(failure) = status {
                 OnboardingErrorDetails(text: failure.copyText)

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -304,6 +304,20 @@ private func actionableDetectedSetupResponse(id: String) -> Data {
     return Data(response.utf8)
 }
 
+private func selectableCandidatesDetectedSetupResponse(id: String) -> Data {
+    Data(
+        """
+        {"type":"res","id":"\(id)","ok":true,"payload":{
+          "candidates":[
+            {"kind":"codex-cli","label":"Codex CLI","detail":"installed",
+             "modelRef":"openai/gpt-5.5","recommended":false,"credentials":true},
+            {"kind":"claude-cli","label":"Claude Code","detail":"installed",
+             "modelRef":"claude-cli/claude-opus-4-8","recommended":false,"credentials":true}],
+          "manualProviders":[],"workspace":"/tmp/openclaw-workspace",
+          "configuredModel":null,"setupComplete":false}}
+        """.utf8)
+}
+
 private func persistedDetectedSetupResponse(
     id: String,
     configuredModel: String = "openai/gpt-5.5") -> Data
@@ -726,6 +740,12 @@ private func rejectedSetupVerificationResponse(id: String) -> Data {
 
 private func unavailableGatewayResponse(id: String) -> Data {
     Data(#"{"type":"res","id":"\#(id)","ok":false,"error":{"code":"UNAVAILABLE","message":"temporary failure"}}"#.utf8)
+}
+
+private func setupAdmissionBusyResponse(id: String) -> Data {
+    Data(
+        #"{"type":"res","id":"\#(id)","ok":false,"error":{"code":"UNAVAILABLE","message":"OpenClaw setup is already in progress; try again when it finishes.","retryable":true}}"#
+            .utf8)
 }
 
 @Suite(.serialized)
@@ -2869,6 +2889,187 @@ struct OnboardingAISetupTests {
 
         #expect(await observation.value())
         #expect(!isPending(defaults))
+    }
+
+    @Test func `different candidate supersedes busy activation and ignores its late result`() async throws {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingCandidateSupersedeTests"))
+        let firstActivation = AISetupRequestGate()
+        let claudeAttempts = AISetupSocketGeneration()
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let harness = AISetupHarness(url: url) { _, request, _ in
+            switch request.method {
+            case "openclaw.setup.detect":
+                return selectableCandidatesDetectedSetupResponse(id: request.id)
+            case "openclaw.setup.activate":
+                switch request.params["kind"] as? String {
+                case "codex-cli":
+                    await firstActivation.wait()
+                    return successfulActivationResponse(
+                        id: request.id,
+                        modelRef: "openai/gpt-5.5",
+                        latencyMs: 900)
+                case "claude-cli" where claudeAttempts.claim() == 0:
+                    return setupAdmissionBusyResponse(id: request.id)
+                case "claude-cli":
+                    return successfulActivationResponse(
+                        id: request.id,
+                        modelRef: "claude-cli/claude-opus-4-8",
+                        latencyMs: 120)
+                default:
+                    return failedActivationResponse(id: request.id)
+                }
+            default:
+                return nil
+            }
+        }
+        let model = harness.model(defaults: defaults)
+        var handoffCount = 0
+        model.onConnected = { handoffCount += 1 }
+
+        let automatic = Task { await model.detectAndAutoConnect() }
+        await firstActivation.waitUntilStarted()
+        model.userSelect(kind: "claude-cli")
+
+        #expect(model.selectedKind == "claude-cli")
+        #expect(model.statuses["codex-cli"] == .untried)
+        #expect(model.statuses["claude-cli"] == .testing)
+        _ = await waitForAISetupRequests(harness.recorder, count: 3)
+        await firstActivation.release()
+        await automatic.value
+        for _ in 0..<400 where !model.connected {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+
+        #expect(model.connected)
+        #expect(model.selectedKind == "claude-cli")
+        #expect(handoffCount == 1)
+        #expect(await (harness.recorder.snapshot()).methods == [
+            "openclaw.setup.detect",
+            "openclaw.setup.activate",
+            "openclaw.setup.activate",
+            "openclaw.setup.activate",
+        ])
+    }
+
+    @Test func `same candidate click during testing is a no-op`() async throws {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingSameCandidateClickTests"))
+        let activation = AISetupRequestGate()
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let harness = AISetupHarness(url: url) { _, request, _ in
+            switch request.method {
+            case "openclaw.setup.detect":
+                return selectableCandidatesDetectedSetupResponse(id: request.id)
+            case "openclaw.setup.activate":
+                await activation.wait()
+                return successfulActivationResponse(
+                    id: request.id,
+                    modelRef: "openai/gpt-5.5",
+                    latencyMs: 900)
+            default:
+                return nil
+            }
+        }
+        let model = harness.model(defaults: defaults)
+
+        let automatic = Task { await model.detectAndAutoConnect() }
+        await activation.waitUntilStarted()
+        let owner = try #require(storedActivationOwner(defaults))
+        model.userSelect(kind: "codex-cli")
+        await settleQueuedAISetupTasks()
+
+        #expect(model.selectedKind == "codex-cli")
+        #expect(model.statuses["codex-cli"] == .testing)
+        #expect(storedActivationOwner(defaults) == owner)
+        #expect(await (harness.recorder.snapshot()).methods == [
+            "openclaw.setup.detect",
+            "openclaw.setup.activate",
+        ])
+        await activation.release()
+        await automatic.value
+    }
+
+    @Test func `candidate click after connection is ignored`() async throws {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingConnectedCandidateClickTests"))
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let harness = AISetupHarness(url: url) { _, request, _ in
+            switch request.method {
+            case "openclaw.setup.detect":
+                selectableCandidatesDetectedSetupResponse(id: request.id)
+            case "openclaw.setup.activate":
+                successfulActivationResponse(
+                    id: request.id,
+                    modelRef: "openai/gpt-5.5",
+                    latencyMs: 120)
+            default:
+                nil
+            }
+        }
+        let model = harness.model(defaults: defaults)
+
+        await model.detectAndAutoConnect()
+        model.userSelect(kind: "claude-cli")
+        await settleQueuedAISetupTasks()
+
+        #expect(model.connected)
+        #expect(model.selectedKind == "codex-cli")
+        #expect(await (harness.recorder.snapshot()).methods == [
+            "openclaw.setup.detect",
+            "openclaw.setup.activate",
+        ])
+    }
+
+    @Test func `superseding candidate replaces and clears the pending activation owner`() async throws {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingCandidateLeaseReplacementTests"))
+        let firstActivation = AISetupRequestGate()
+        let secondActivation = AISetupRequestGate()
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let harness = AISetupHarness(url: url) { _, request, _ in
+            switch request.method {
+            case "openclaw.setup.detect":
+                return selectableCandidatesDetectedSetupResponse(id: request.id)
+            case "openclaw.setup.activate" where request.params["kind"] as? String == "codex-cli":
+                await firstActivation.wait()
+                return successfulActivationResponse(
+                    id: request.id,
+                    modelRef: "openai/gpt-5.5",
+                    latencyMs: 900)
+            case "openclaw.setup.activate":
+                await secondActivation.wait()
+                return failedActivationResponse(id: request.id)
+            default:
+                return nil
+            }
+        }
+        let model = harness.model(defaults: defaults)
+
+        let automatic = Task { await model.detectAndAutoConnect() }
+        await firstActivation.waitUntilStarted()
+        let supersededOwner = try #require(storedActivationOwner(defaults))
+        guard case let .activating(supersededDeadline) = pendingState(defaults) else {
+            Issue.record("expected the first candidate to own an activation lease")
+            return
+        }
+        model.userSelect(kind: "claude-cli")
+        await secondActivation.waitUntilStarted()
+        let replacementOwner = try #require(storedActivationOwner(defaults))
+        guard case let .activating(replacementDeadline) = pendingState(defaults) else {
+            Issue.record("expected the selected candidate to replace the activation lease")
+            return
+        }
+
+        #expect(replacementOwner != supersededOwner)
+        #expect(replacementDeadline >= supersededDeadline)
+        #expect(!isOwned(by: supersededOwner, defaults: defaults))
+        #expect(isOwned(by: replacementOwner, defaults: defaults))
+        await firstActivation.release()
+        await secondActivation.release()
+        await automatic.value
+        for _ in 0..<200 where isPending(defaults) {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+
+        #expect(pendingState(defaults) == .none)
+        #expect(!model.connected)
     }
 
     @Test func `stale queued detection cannot probe a replacement Gateway`() async throws {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users clicking a different detected AI during the automatic onboarding test saw nothing happen. The candidate row was disabled while the first option was testing, so the explicit choice produced no visible outcome and onboarding could not actually "let the user pick."

## Why This Change Was Made

A different candidate click now immediately supersedes the current attempt through the existing attempt-token boundary, moves the testing state to the selected row, and replaces the route-owned activation lease. If the previous Gateway activation is still holding setup admission, the selected attempt waits through that existing retryable admission window; late results from the superseded attempt cannot publish.

Same-candidate clicks remain no-ops, and connected onboarding still ignores candidate switching. `OnboardingSystemAgentResumeStore` is byte-identical; this change only uses its existing owner-aware mark/replace/clear lifecycle.

## User Impact

During fresh macOS onboarding, users can choose Claude Code (or another detected candidate) while Codex or a previous manual choice is still being tested. The spinner moves immediately, the selected candidate becomes the one that connects, and the previous attempt cannot reclaim the UI or leave an orphaned resume lease.

This fixes a product-doctrine violation: the previously enabled-looking user action ended in a silent non-outcome.

## Evidence

Focused behavior coverage:

- different candidate during a busy automatic activation supersedes it, survives the Gateway's retryable setup-admission response, and ignores the late first result
- same candidate during testing starts no duplicate activation
- candidate click after connection is ignored
- superseding candidate replaces the persisted activation owner, extends the replacement lease across the prior mutation window, and clears it after a definitive result

Validation:

- `swift test --package-path apps/macos --filter OnboardingAISetupTests` — 94 tests passed
- `swift test --package-path apps/macos --enable-code-coverage --no-parallel` — 1,677 tests in 181 suites passed
- `swift build --package-path apps/macos --configuration release` — passed
- `./scripts/lint-swift.sh macos` — 0 violations
- `./scripts/format-swift.sh macos` — clean
- `node --import tsx scripts/native-app-i18n.ts verify` — passed
- Codex autoreview — clean, no accepted/actionable findings

The regression failed against the pre-fix model at the candidate selection, row status, and final selected-kind assertions. Live signed-app proof with real Codex and Claude Code accounts is intentionally pending maintainer verification before landing.

LOC: production `+84/-12` (net `+72`), tests `+201/-0`, generated native i18n inventory `+4/-4`. The production growth is the bounded supersede capability and its lease/admission safety path; no activation pipeline, lease store, config, protocol, or post-connect switching surface was added.
