### PR TITLE
fix(ui): handle keyboard context menu shortcuts

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -66,6 +66,7 @@ async function writeListToolsMcpServer(params: {
   filePath: string;
   logPath: string;
   delayMs?: number;
+  listToolsReleasePath?: string;
   initializeDelayMs?: number;
   hang?: boolean;
   inputSchema?: unknown;
@@ -105,6 +106,7 @@ import fs from "node:fs/promises";
 
 const logPath = ${JSON.stringify(params.logPath)};
 const delayMs = ${params.delayMs ?? 0};
+const listToolsReleasePath = ${JSON.stringify(params.listToolsReleasePath)};
 const initializeDelayMs = ${params.initializeDelayMs ?? 0};
 const hang = ${params.hang === true};
 const capabilities = ${JSON.stringify(params.capabilities ?? { tools: {} })};
@@ -233,7 +235,7 @@ function handle(message) {
     const currentListCount = listCount;
     const toolPageCursor = toolPageCursors?.[currentListCount - 1];
     log("delay tools/list " + delayMs);
-    pendingTimer = setTimeout(() => {
+    const sendListResponse = () => {
       send({
         jsonrpc: "2.0",
         id: message.id,
@@ -250,7 +252,20 @@ function handle(message) {
         log("notify tools/list_changed");
         send({ jsonrpc: "2.0", method: "notifications/tools/list_changed" });
       }
-    }, delayMs);
+    };
+    void (async () => {
+      while (listToolsReleasePath) {
+        const released = await fs
+          .access(listToolsReleasePath)
+          .then(() => true)
+          .catch(() => false);
+        if (released) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      pendingTimer = setTimeout(sendListResponse, delayMs);
+    })();
   }
   if (message.method === "tools/call") {
     if (hangToolCallsUntilRestart) {
@@ -5308,20 +5323,24 @@ process.stdin.on("end", () => {
   );
 
   it(
-    "parallelizes MCP server catalog loading across multiple slow servers",
+    "starts MCP server catalog loading concurrently",
     { timeout: LIST_TOOLS_TEST_DEADLINE_MS },
     async () => {
       const tempDir = makeTempDir(tempDirs, "bundle-mcp-parallel-");
-      const delays = [200, 400, 600];
-      const serverPaths = delays.map((delay, i) => {
+      const releasePath = path.join(tempDir, "release-list-tools");
+      const serverPaths = Array.from({ length: 3 }, (_, i) => {
         const serverPath = path.join(tempDir, `slow-server-${i}.mjs`);
         const logPath = path.join(tempDir, `server-${i}.log`);
-        return { serverPath, logPath, delay, serverName: `slowServer${i}` };
+        return { serverPath, logPath, serverName: `slowServer${i}` };
       });
 
       await Promise.all(
-        serverPaths.map(({ serverPath, logPath, delay }) =>
-          writeListToolsMcpServer({ filePath: serverPath, logPath, delayMs: delay }),
+        serverPaths.map(({ serverPath, logPath }) =>
+          writeListToolsMcpServer({
+            filePath: serverPath,
+            logPath,
+            listToolsReleasePath: releasePath,
+          }),
         ),
       );
 
@@ -5347,30 +5366,25 @@ process.stdin.on("end", () => {
         },
       });
 
+      const catalogPromise = runtime.getCatalog();
       try {
-        const sumDelays = delays.reduce((a, b) => a + b, 0);
-        const maxDelay = Math.max(...delays);
-        const parallelBudgetMs = maxDelay + 500;
+        await Promise.all(
+          serverPaths.map(({ logPath }) =>
+            waitForFileText(logPath, "tools/list cursor", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS),
+          ),
+        );
+        await fs.writeFile(releasePath, "released", "utf8");
+        const catalog = await catalogPromise;
 
-        const t0 = performance.now();
-        const catalog = await runtime.getCatalog();
-        const wallTime = performance.now() - t0;
-
-        // Must have successfully connected to all servers
-        expect(Object.keys(catalog.servers)).toHaveLength(delays.length);
+        expect(Object.keys(catalog.servers)).toHaveLength(serverPaths.length);
         expect(catalog.tools.map((t) => t.toolName)).toEqual([
           "slow_tool",
           "slow_tool",
           "slow_tool",
         ]);
-
-        // Sequential listing would have to wait roughly sumDelays before overhead;
-        // parallel listing should stay near the slowest server plus launch overhead.
-        expect(wallTime).toBeLessThan(parallelBudgetMs);
-        expect(parallelBudgetMs).toBeLessThan(sumDelays);
-
-        expect(wallTime).toBeGreaterThanOrEqual(maxDelay * 0.7);
       } finally {
+        await fs.writeFile(releasePath, "released", "utf8").catch(() => {});
+        await catalogPromise.catch(() => {});
         await runtime.dispose();
       }
     },

--- a/src/gateway/server-methods/setup-admission.ts
+++ b/src/gateway/server-methods/setup-admission.ts
@@ -28,9 +28,9 @@ export async function runExclusiveSystemAgentSetupActivation<T>(
   }
 }
 
-export function whenAdmittedWizardSessionSettled<T extends { whenSettled(): Promise<unknown> }>(
-  session: T,
-): Promise<unknown> {
+export function whenAdmittedWizardSessionSettled(session: {
+  whenSettled(): Promise<unknown>;
+}): Promise<unknown> {
   return wizardSessionAdmissionSettlements.get(session) ?? session.whenSettled();
 }
 

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -29,7 +29,10 @@ import type {
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { ExecApprovalManager } from "../exec-approval-manager.js";
 import { handleGatewayRequest } from "../server-methods.js";
-import { runExclusiveSystemAgentSetupActivation } from "./setup-admission.js";
+import {
+  runExclusiveSystemAgentSetupActivation,
+  whenAdmittedWizardSessionSettled,
+} from "./setup-admission.js";
 import { systemAgentHandlers, type SystemAgentChatSession } from "./system-agent.js";
 import type { GatewayClient, GatewayRequestContext } from "./types.js";
 
@@ -406,6 +409,7 @@ describe("openclaw.setup", () => {
     });
     await session.answer(first.step.id, null);
     await expect(session.next()).resolves.toMatchObject({ done: true, status: "done" });
+    await whenAdmittedWizardSessionSettled(session);
   });
   it("runs the selected provider method in a shared wizard session and commits its config", async () => {
     const preparedConfig: OpenClawConfig = {

--- a/test/vitest/vitest.ui-isolated-paths.mjs
+++ b/test/vitest/vitest.ui-isolated-paths.mjs
@@ -8,6 +8,7 @@ export const uiIsolatedTestFiles = [
   "ui/src/components/resizable-divider.test.ts",
   "ui/src/components/viewer-facepile.test.ts",
   "ui/src/pages/agents/memory/memory-panel.test.ts",
+  "ui/src/pages/chat/chat-page-attachment-handoff.test.ts",
   "ui/src/pages/chat/chat-pane-board.test.ts",
   "ui/src/pages/chat/chat-pane-history.test.ts",
   "ui/src/pages/chat/chat-pane-identity.test.ts",

--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -8,6 +8,7 @@ import type { GatewaySessionRow } from "../api/types.ts";
 import type { NavigationRouteId } from "../app-navigation.ts";
 import type { ApplicationNavigationOptions } from "../app/context.ts";
 import { t } from "../i18n/index.ts";
+import { handleContextMenuEvent } from "../lib/keyboard-shortcuts.ts";
 import { shouldHandleNavigationClick } from "../lib/navigation-click.ts";
 import type { CatalogSessionKey } from "../lib/sessions/catalog-key.ts";
 import { buildCatalogSessionKey } from "../lib/sessions/catalog-key.ts";
@@ -436,6 +437,14 @@ function renderCatalogSessionRow(
       y,
       trigger,
     );
+  const openMenuFromEvent = (event: MouseEvent | KeyboardEvent) =>
+    handleContextMenuEvent(
+      event,
+      event instanceof KeyboardEvent
+        ? (event.currentTarget as HTMLElement).querySelector("[data-catalog-session-menu]")
+        : null,
+      (trigger, x, y) => openMenu(x, y, trigger ?? undefined),
+    );
   return html`
     <div
       class="sidebar-recent-session session-row-host ${active
@@ -445,10 +454,8 @@ function renderCatalogSessionRow(
         : ""}"
       data-session-key=${key}
       role="listitem"
-      @contextmenu=${(event: MouseEvent) => {
-        event.preventDefault();
-        openMenu(event.clientX, event.clientY);
-      }}
+      @contextmenu=${openMenuFromEvent}
+      @keydown=${openMenuFromEvent}
     >
       <a
         href=${href}

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -10,6 +10,7 @@ import { t } from "../i18n/index.ts";
 import { sessionHasBoard } from "../lib/board/provider.ts";
 import { formatDurationCompact } from "../lib/format.ts";
 import { startHoverMarquee, stopHoverMarquee } from "../lib/hover-marquee.ts";
+import { handleContextMenuEvent } from "../lib/keyboard-shortcuts.ts";
 import { writeSessionDragData } from "../lib/sessions/drag.ts";
 import type { SidebarSessionsGrouping } from "../lib/sessions/grouping.ts";
 import type { NewSessionTarget } from "../pages/new-session/location.ts";
@@ -197,6 +198,14 @@ export function renderRecentSession(params: {
   const metaId = hasTrail ? sidebarSessionMetaId(session.key) : undefined;
   const stateId = trailingIndicator === nothing ? undefined : sidebarSessionStateId(session.key);
   const menuSession = display ? { ...session, meta } : session;
+  const openMenuFromEvent = session.isChild
+    ? undefined
+    : (event: MouseEvent | KeyboardEvent) =>
+        handleContextMenuEvent(
+          event,
+          (event.currentTarget as HTMLElement).querySelector("[data-session-menu]"),
+          (trigger, x, y) => host.sidebarMenus.openSessionMenu(menuSession, x, y, trigger),
+        );
   const title = [
     display?.title ?? [label, narration, rowMeta].filter(Boolean).join(" · "),
     trailingDescription,
@@ -257,18 +266,8 @@ export function renderRecentSession(params: {
         : () => {
             host.finishSessionDrag();
           }}
-      @contextmenu=${session.isChild
-        ? nothing
-        : (event: MouseEvent) => {
-            event.preventDefault();
-            const rowElement = event.currentTarget as HTMLElement;
-            const trigger =
-              rowElement.querySelector<HTMLElement>("[data-session-menu]") ??
-              (event.target instanceof Element
-                ? event.target.closest<HTMLElement>("a, button, [tabindex]")
-                : null);
-            host.sidebarMenus.openSessionMenu(menuSession, event.clientX, event.clientY, trigger);
-          }}
+      @contextmenu=${openMenuFromEvent ?? nothing}
+      @keydown=${openMenuFromEvent ?? nothing}
       @mouseenter=${(event: MouseEvent) => startHoverMarquee(event.currentTarget as HTMLElement)}
       @mouseleave=${(event: MouseEvent) => stopHoverMarquee(event.currentTarget as HTMLElement)}
     >

--- a/ui/src/lib/keyboard-shortcuts.ts
+++ b/ui/src/lib/keyboard-shortcuts.ts
@@ -2,6 +2,36 @@ const ASCII_SHORTCUT_KEY = /^[a-z0-9]$/;
 const PHYSICAL_LETTER_KEY = /^Key([A-Z])$/;
 const PHYSICAL_DIGIT_KEY = /^Digit([0-9])$/;
 
+export function handleContextMenuEvent(
+  event: MouseEvent | KeyboardEvent,
+  trigger: HTMLElement | null,
+  open: (trigger: HTMLElement | null, x: number, y: number) => void,
+): boolean {
+  if (event instanceof MouseEvent) {
+    event.preventDefault();
+    open(trigger, event.clientX, event.clientY);
+    return true;
+  }
+  if (
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey ||
+    (event.key !== "ContextMenu" && (event.key !== "F10" || !event.shiftKey))
+  ) {
+    return false;
+  }
+  if (!trigger && !(event.target instanceof HTMLElement)) {
+    return false;
+  }
+  // Chromium on macOS needs the keyboard path; preventing the key default also
+  // keeps platforms that synthesize `contextmenu` from opening the menu twice.
+  event.preventDefault();
+  const resolvedTrigger = trigger ?? (event.target as HTMLElement);
+  const rect = resolvedTrigger.getBoundingClientRect();
+  open(resolvedTrigger, rect.right, rect.bottom + 4);
+  return true;
+}
+
 export function resolveAsciiShortcutKey(event: KeyboardEvent): string | null {
   if (event.isComposing || event.keyCode === 229) {
     return null;

--- a/ui/src/pages/sessions/view.test.ts
+++ b/ui/src/pages/sessions/view.test.ts
@@ -592,7 +592,7 @@ describe("sessions view", () => {
     expect(onAssignCategory).not.toHaveBeenCalled();
   });
 
-  it("opens the session menu from the kebab and row context menu", async () => {
+  it("opens the session menu from the kebab and row context-menu shortcuts", async () => {
     const container = document.createElement("div");
     const onOpenSessionMenu = vi.fn();
     const session = {
@@ -642,6 +642,21 @@ describe("sessions view", () => {
       null,
     );
     expect(contextMenu.defaultPrevented).toBe(true);
+
+    const keyboardContextMenu = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "F10",
+      shiftKey: true,
+    });
+    row.dispatchEvent(keyboardContextMenu);
+    expect(onOpenSessionMenu).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ key: session.key }),
+      { x: expect.any(Number), y: expect.any(Number) },
+      button,
+    );
+    expect(keyboardContextMenu.defaultPrevented).toBe(true);
   });
 
   it("keeps pinned sessions above newer unpinned sessions", async () => {

--- a/ui/src/pages/sessions/view.ts
+++ b/ui/src/pages/sessions/view.ts
@@ -32,6 +32,7 @@ import {
   formatRelativeTimestamp,
   formatTokens,
 } from "../../lib/format.ts";
+import { handleContextMenuEvent } from "../../lib/keyboard-shortcuts.ts";
 import { shouldHandleNavigationClick } from "../../lib/navigation-click.ts";
 import { formatSessionTokens } from "../../lib/presenter.ts";
 import { isCronSessionKey } from "../../lib/session-display.ts";
@@ -1420,6 +1421,14 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
   const categoryMode = props.groupBy === "category";
   // Dropping on a row targets that row's group so the whole section area accepts drops.
   const rowDrop = categoryDropHandlers(props, normalizeOptionalString(row.category) ?? null);
+  const openMenuFromEvent = (event: MouseEvent | KeyboardEvent) =>
+    handleContextMenuEvent(
+      event,
+      event instanceof KeyboardEvent
+        ? (event.currentTarget as HTMLElement).querySelector('button[aria-haspopup="menu"]')
+        : null,
+      (trigger, x, y) => props.onOpenSessionMenu(row, { x, y }, trigger),
+    );
 
   return [
     html`<tr
@@ -1440,10 +1449,7 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
       @dragover=${rowDrop.dragover}
       @dragleave=${rowDrop.dragleave}
       @drop=${rowDrop.drop}
-      @contextmenu=${(event: MouseEvent) => {
-        event.preventDefault();
-        props.onOpenSessionMenu(row, { x: event.clientX, y: event.clientY }, null);
-      }}
+      @contextmenu=${openMenuFromEvent}
       @click=${(e: MouseEvent) => {
         if (isRowControlTarget(e.target)) {
           return;
@@ -1451,6 +1457,9 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
         props.onToggleDetails(row.key);
       }}
       @keydown=${(e: KeyboardEvent) => {
+        if (openMenuFromEvent(e)) {
+          return;
+        }
         if (isRowControlTarget(e.target)) {
           return;
         }

--- a/ui/src/test-helpers/app-sidebar-cases/interactions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/interactions.ts
@@ -638,7 +638,19 @@ describe("AppSidebar catalog session rows", () => {
       const items = menu.querySelectorAll<HTMLElement & { disabled: boolean }>("wa-dropdown-item");
       expect(items).toHaveLength(2);
       expect(items[1]?.disabled).toBe(true);
-      expect(row.querySelector("[data-catalog-session-menu]")).not.toBeNull();
+      const menuButton = row.querySelector<HTMLElement>("[data-catalog-session-menu]");
+      expect(menuButton).not.toBeNull();
+
+      const keyboardContextMenu = new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        key: "F10",
+        shiftKey: true,
+      });
+      row.querySelector("a")?.dispatchEvent(keyboardContextMenu);
+      await sidebar.updateComplete;
+      expect(sidebar.querySelector("openclaw-catalog-session-menu")).not.toBeNull();
+      expect(keyboardContextMenu.defaultPrevented).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -99,7 +99,6 @@ const nodeDrivenBrowserLayoutTests = [
 const mockRegistryUnitTests = [
   ...uiIsolatedTestFiles.map((testFile) => testFile.slice("ui/".length)),
   "src/components/mcp-app-view.test.ts",
-  "src/pages/chat/chat-page-attachment-handoff.test.ts",
   "src/pages/chat/chat-page.test.ts",
 ] as const;
 const chromiumExecutableOverrideEnvKey = "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where keyboard users could not open session-row action menus with Shift+F10 in the Control UI. On macOS Chromium, that shortcut emits key events without a `contextmenu` event, while the Context Menu key emits `contextmenu` with `button = -1` and a pointer right-click emits it with `button = 2`. The UI relied only on row-level `@contextmenu`, so Shift+F10 silently did nothing.

Linux Chromium CI on #117191 passed all four UI E2E shards because that browser synthesized the event, masking the missing product-owned keyboard path.

## Why This Change Was Made

One shared keyboard/pointer context-menu adapter now owns Shift+F10, Context Menu key, and pointer invocation across sidebar recent-session rows, catalog session rows, and Sessions table rows. It preserves pointer coordinates, anchors keyboard menus to the actual action button for focus ownership, and prevents the key default so browsers that synthesize `contextmenu` cannot open the menu twice.

This is the best-fix boundary because all three session-row surfaces share the same input invariant. Test weakening, a macOS-only branch, dispatching a synthetic mouse event, or increasing timeouts would either preserve the production accessibility gap or introduce a second event path without fixing ownership.

### Main CI gate repair

Exact-head CI exposed shared validation failures that were independently present on current `main`. Repository policy does not permit landing onto a red required gate, so the branch carried bounded owner-level repairs while the gate was red. Current main has since absorbed the YAML, package/generated-image typing, environment-ratchet, and cron-alert fixes. This PR retains only still-missing repairs: changed-target routing, UI isolation registration, the deterministic MCP rendezvous, the shared cursor token, thumbnail cache/E2E variants, and lifecycle assertions that tolerate new optional metadata.

Production LOC: +68/-23 (net +45). Tests and test support: +73/-28 (net +45). The production growth is the shared accessibility owner replacing three incomplete pointer-only handlers; the setup-admission type cleanup is net neutral. There are no config, protocol, storage, dependency, or migration changes.

## User Impact

Keyboard users can now open session action menus consistently with Shift+F10 or the Context Menu key in the sidebar, catalog, and Sessions table. The first menu action receives focus, Tab continues to the next visible session, and pointer right-click behavior remains unchanged.

Release-note context: Control UI session action menus now support keyboard context-menu shortcuts consistently across all session-row surfaces.

## Evidence

- Exact macOS Shift+F10 regression: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-management.sidebar.e2e.test.ts -t "names session-row actions and tabs from their menu"` — 1 passed, 10 skipped; repeated final-head runs passed.
- Sibling UI coverage: 300/300 passed across Sessions, sidebar, and keyboard-shortcut tests.
- Focused final repair proof: tooling 259 passed; MCP runtime 91/91; UI attachment tests 6 passed plus the isolated test 1 passed; deterministic MCP target 2 passed/180 skipped; cursor policy 4/4; isolated media lifecycle 14/14; cron regressions 27/27; lifecycle progress 19/19; managed-media E2E 15/15; original Shift+F10 E2E 1 passed/10 skipped.
- Broader proof: shared UI 8,295 passed/46 skipped; isolated UI 404 passed/1 skipped; MCP runtime 91/91; focused release/type/routing tests passed.
- Original UI-only Testbox changed gate `tbx_01kzp1bnhb3jvtj720ynwq07re`: [Actions run 31398605455](https://github.com/openclaw/openclaw/actions/runs/31398605455), exit 0.
- Earlier final Testbox attempt `tbx_01kzp6001mazf078xcdn2cqcpc` never allocated after 15 minutes; its full changed gate fallback ran locally under Node 24.18.0 and passed.
- Gate-repair Testbox `tbx_01kzp8vnsh4qc3vq9fgzv1nc68`, [Actions run 31410333717](https://github.com/openclaw/openclaw/actions/runs/31410333717), passed ratchets, format, dead exports, i18n, and all core/UI/scripts/root-test typechecks before identifying one current-main UI lint rule. Current main subsequently absorbed that shared fix. Retry Testbox `tbx_01kzpawt1vn305qwttemmt8wzh`, [Actions run 31413327349](https://github.com/openclaw/openclaw/actions/runs/31413327349), shut down during hydration before executing the command.
- Latest repair Testbox `tbx_01kzpcb2p4w1rd22h2hf8jz1wq`, [Actions run 31415430238](https://github.com/openclaw/openclaw/actions/runs/31415430238), passed ratchets, format, dead exports, i18n, core-test types, and UI types. Its serial full-repository lint tail was stopped after completed shards were clean; the exact changed TypeScript and CSS files passed targeted local lint, and hosted exact-head CI owns the full lint authority.
- Final exact-head hosted CI: [run 31423515880](https://github.com/openclaw/openclaw/actions/runs/31423515880), including successful `openclaw/ci-gate`.
- Fresh full-branch autoreview against current main found no accepted/actionable P0-P2 findings.
- `git diff --check origin/main...HEAD`: clean.
- Reviewed exact head: `0b62e9d1d817c4264a7f3be6ff8e333d8ff863dd`.

Before Shift+F10 (no menu):

![Before Shift+F10](https://github.com/user-attachments/assets/a9c1fb4d-b446-476e-a239-988323a04277)

After Shift+F10 (menu open with focus):

![After Shift+F10](https://github.com/user-attachments/assets/c2e54cd9-7ab5-48f4-98e3-3745c7328896)

Pointer context menu remains intact:

![Pointer context menu](https://github.com/user-attachments/assets/676ba902-da8d-49fd-80f9-78ee122e0dbf)

[Keyboard interaction screencast](https://github.com/user-attachments/assets/0934c8ce-8266-409f-b2c7-41956517d80c)

Known proof gap: this was not exercised with a physical keyboard in Safari; the macOS Chromium event probe, exact Playwright regression, mocked-Gateway interaction capture, sibling suites, changed gate, and exact-head CI cover the repaired boundary.
