### PR TITLE
test(gateway): await setup admission cleanup

### DIFF
--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -29,7 +29,10 @@ import type {
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { ExecApprovalManager } from "../exec-approval-manager.js";
 import { handleGatewayRequest } from "../server-methods.js";
-import { runExclusiveSystemAgentSetupActivation } from "./setup-admission.js";
+import {
+  runExclusiveSystemAgentSetupActivation,
+  whenAdmittedWizardSessionSettled,
+} from "./setup-admission.js";
 import { systemAgentHandlers, type SystemAgentChatSession } from "./system-agent.js";
 import type { GatewayClient, GatewayRequestContext } from "./types.js";
 
@@ -406,6 +409,7 @@ describe("openclaw.setup", () => {
     });
     await session.answer(first.step.id, null);
     await expect(session.next()).resolves.toMatchObject({ done: true, status: "done" });
+    await whenAdmittedWizardSessionSettled(session);
   });
   it("runs the selected provider method in a shared wizard session and commits its config", async () => {
     const preparedConfig: OpenClawConfig = {
@@ -459,6 +463,7 @@ describe("openclaw.setup", () => {
       status: "done",
       preparedModelRef: "ollama/qwen3:0.6b",
     });
+    await whenAdmittedWizardSessionSettled(session);
     expect(setupSharedMocks.writeWizardConfigFile).toHaveBeenCalledWith(preparedConfig, {
       allowConfigSizeDrop: false,
       baseSnapshot: expect.objectContaining({ hash: "prepare-base-hash" }),


### PR DESCRIPTION
## What Problem This Solves

Fixes a CI ordering failure where `system-agent.test.ts` completed one admitted setup session and immediately began the next test before the shared setup owner had released admission. The next structured setup start then returned `UNAVAILABLE` instead of creating its wizard session.

## Why This Change Was Made

`main` now owns production admission settlement through `whenAdmittedWizardSessionSettled`. The two structured setup tests use that canonical lifecycle promise after their terminal wizard result, so each test releases both session and setup ownership before the next case begins.

## User Impact

No production behavior changes. This keeps the gateway-method shard deterministic while testing the production admission lifecycle accurately.

## Evidence

- Exact `main` head `55afad26c0729f2f1b5bb395011231ef204818c9` reproduced the failure in `checks-node-compact-large-6`: https://github.com/openclaw/openclaw/actions/runs/31422091396/job/93569145163.
- The preceding repair head passed the same large-6 shard with these two waits present: https://github.com/openclaw/openclaw/actions/runs/31402200517/job/93500003851.
- Final branch autoreview reported no accepted/actionable findings.
- Exact head `bab02e2e86a23d6436f517d1a2d8da5d920bbabc` passes `git diff --check`; PR CI provides exact-head matrix proof.
- LOC: production 0, tests +6/-1.
