### PR TITLE
fix(secrets): keep store defaults source-specific

### DIFF
--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -210,6 +210,8 @@ Define providers under `secrets.providers`:
 }
 ```
 
+Provider aliases are source-specific. A matching explicit provider entry wins; if an `env` or `store` default alias is also used by an entry for another source, that source's built-in provider wins. Non-default aliases and `file` or `exec` providers must resolve to an explicit entry with the matching source.
+
 <Accordion title="Env provider">
 - Optional exact-name allowlist via `allowlist`.
 - Missing or empty env values fail resolution.

--- a/src/secrets/resolve-store.test.ts
+++ b/src/secrets/resolve-store.test.ts
@@ -41,6 +41,77 @@ describe("store SecretRef resolution", () => {
     ).resolves.toBe("resolved-store-secret");
   });
 
+  it("resolves the store default when an env provider uses the same alias", async () => {
+    const env = await createStateEnv();
+    writeSecretStoreEntry({
+      scope: { kind: "team" },
+      name: "STORED_API_KEY",
+      value: "resolved-store-secret",
+      kind: "secret",
+      updatedBy: "test",
+      database: { env },
+    });
+
+    await expect(
+      resolveSecretRefString(
+        { source: "store", provider: "default", id: "STORED_API_KEY" },
+        {
+          config: { secrets: { providers: { default: { source: "env" } } } },
+          env,
+        },
+      ),
+    ).resolves.toBe("resolved-store-secret");
+  });
+
+  it("resolves an explicitly configured store provider alias", async () => {
+    const env = await createStateEnv();
+    writeSecretStoreEntry({
+      scope: { kind: "team" },
+      name: "STORED_API_KEY",
+      value: "resolved-store-secret",
+      kind: "secret",
+      updatedBy: "test",
+      database: { env },
+    });
+
+    await expect(
+      resolveSecretRefString(
+        { source: "store", provider: "teamstore", id: "STORED_API_KEY" },
+        {
+          config: { secrets: { providers: { teamstore: { source: "store" } } } },
+          env,
+        },
+      ),
+    ).resolves.toBe("resolved-store-secret");
+  });
+
+  it("rejects a non-default store alias configured for another source", async () => {
+    await expect(
+      resolveSecretRefString(
+        { source: "store", provider: "envmain", id: "STORED_API_KEY" },
+        {
+          config: { secrets: { providers: { envmain: { source: "env" } } } },
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "SECRET_PROVIDER_INVALID",
+      source: "store",
+      provider: "envmain",
+    });
+  });
+
+  it("resolves the env default when a store provider uses the same alias", async () => {
+    await expect(
+      resolveSecretRefString(
+        { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+        {
+          config: { secrets: { providers: { default: { source: "store" } } } },
+          env: { OPENAI_API_KEY: "resolved-env-secret" },
+        },
+      ),
+    ).resolves.toBe("resolved-env-secret");
+  });
+
   it("maps a missing name to a retryable not-found degradation", async () => {
     const env = await createStateEnv();
     const error = await resolveSecretRefString(

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -157,16 +157,14 @@ function resolveConfiguredProvider(params: {
 }): SecretProviderConfig {
   const { ref, config } = params;
   const providerConfig = config.secrets?.providers?.[ref.provider];
+  if (
+    providerConfig?.source !== ref.source &&
+    (ref.source === "env" || ref.source === "store") &&
+    ref.provider === resolveDefaultSecretProviderAlias(config, ref.source)
+  ) {
+    return { source: ref.source };
+  }
   if (!providerConfig) {
-    if (ref.source === "env" && ref.provider === resolveDefaultSecretProviderAlias(config, "env")) {
-      return { source: "env" };
-    }
-    if (
-      ref.source === "store" &&
-      ref.provider === resolveDefaultSecretProviderAlias(config, "store")
-    ) {
-      return { source: "store" };
-    }
     throw providerResolutionError({
       code: "SECRET_PROVIDER_NOT_CONFIGURED",
       source: ref.source,


### PR DESCRIPTION
Addresses the ClawSweeper P1 rank-up move on #121559.

AI-assisted: Codex.

## What Problem This Solves

Fixes an issue where operators using the documented store SecretRef with `provider: "default"` would get `SECRET_PROVIDER_INVALID` when another secret source, such as `env`, also used the `default` alias. The alias-only lookup prevented the built-in SQLite store provider from running.

## Why This Change Was Made

Provider selection now treats default aliases as source-specific for the two built-in sources, `env` and `store`. A matching explicit provider still wins, while a wrong-source entry cannot shadow that source's built-in default. File and exec providers still require explicit matching entries, and non-default source mismatches still fail closed.

The resolver change replaces the duplicated env/store fallback branches and is production net-negative.

## User Impact

The documented store reference now resolves from SQLite even when `secrets.providers.default` configures the env source. Env refs receive the same symmetric behavior when a store provider uses the env default alias. Existing explicit file, exec, env, and store provider selections keep their current behavior.

## Evidence

Pre-fix focused proof, with the resolver fix temporarily stashed and the new tests present:

```text
Test Files  1 failed (1)
Tests       2 failed | 5 passed (7)

Secret provider "default" has source "env" but ref requests "store".
Secret provider "default" has source "store" but ref requests "env".
```

After the fix:

```text
Test Files  1 passed (1)
Tests       7 passed (7)
```

Complete secrets suite:

```text
Test Files  72 passed (72)
Tests       740 passed (740)
Duration    74.49s
```

Additional validation:

- `git diff --check`
- focused formatter on all three changed files
- mandatory autoreview: clean, no accepted/actionable findings
- production code: +7/-9 (net -2); tests: +71/-0; docs: +2/-0

The changed gate first attempted the preferred remote backend, then fell back locally because no remote provider was ready. Its local retry was blocked by the shared heavy-check lock held by another live checkout; hosted exact-head CI is the authoritative broad gate for this PR.

Landing refresh evidence:

- rebased cleanly onto `a0ad38e71ab`; post-rebase secrets proof: 72 files / 740 tests passed in 317.89s
- fixes red main: updated the changed-test owner expectation after `package-acceptance-workflow.test.ts` began importing `plan-release-workflow-matrix.mjs`
- fixes red main: made wizard cleanup wait for the real setup-admission boundary to release after the session settles, preserving the retryable lock contract without a test-only production seam
- focused wizard proof: 16/16 passed; exact changed-target owner probe returned the expected three targets
- follow-up autoreviews after both test-only repairs: clean, no accepted/actionable findings
- production diff remains +7/-9 (net -2); landing repairs are test-only

Final landing CI (`31414339733`) cleared the PR-owned lint/type/baseline failures but remained blocked by current-main failures outside this PR's two-file repair cap:

- `checks-node-compact-large-6`: Control UI cursor-policy assertion for `.chat-image-action`
- `checks-node-compact-small-9`: two agent-runner progress payload assertions after optional fields became explicit
- `checks-node-compact-small-11`: three cron failure-alert assertions after normalized alert text/payload changes
- `checks-windows-node-test`: SQLite snapshot inspection race (`publication source identity did not match`)

Landing stopped after the third CI cycle as required; no gate was bypassed.
