### PR TITLE
refactor(agents): remove dead subagent state variants

### DIFF
--- a/src/agents/subagents/registry/subagent-registry.store.sqlite.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.store.sqlite.test.ts
@@ -265,7 +265,7 @@ describe("subagent registry sqlite store", () => {
         delivery: {
           status: "suspended",
           suspendedAt: 300,
-          suspendedReason: "retry-limit",
+          suspendedReason: "permanent_failure",
           payload: {
             requesterSessionKey: "agent:main:main",
             requesterDisplayKey: "main",
@@ -318,6 +318,29 @@ describe("subagent registry sqlite store", () => {
         resultText: "NO_REPLY",
         fallbackResultText: "legacy retained result",
       });
+    });
+  });
+
+  it("normalizes the shipped retry-limit suspension on restore", async () => {
+    await withTempStateEnv(async () => {
+      const run = createRun({
+        delivery: {
+          status: "suspended",
+          suspendedAt: 300,
+          suspendedReason: "permanent_failure",
+        },
+      });
+      saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
+
+      const { db } = openOpenClawStateDatabase();
+      db.prepare(
+        "UPDATE subagent_runs SET payload_json = json_set(payload_json, '$.delivery.suspendedReason', 'retry-limit') WHERE run_id = ?",
+      ).run(run.runId);
+      closeOpenClawStateDatabaseForTest();
+
+      expect(loadSubagentRegistryFromSqlite().get(run.runId)?.delivery?.suspendedReason).toBe(
+        "permanent_failure",
+      );
     });
   });
 

--- a/src/agents/subagents/registry/subagent-registry.store.sqlite.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.store.sqlite.test.ts
@@ -321,29 +321,6 @@ describe("subagent registry sqlite store", () => {
     });
   });
 
-  it("normalizes the shipped retry-limit suspension on restore", async () => {
-    await withTempStateEnv(async () => {
-      const run = createRun({
-        delivery: {
-          status: "suspended",
-          suspendedAt: 300,
-          suspendedReason: "permanent_failure",
-        },
-      });
-      saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
-
-      const { db } = openOpenClawStateDatabase();
-      db.prepare(
-        "UPDATE subagent_runs SET payload_json = json_set(payload_json, '$.delivery.suspendedReason', 'retry-limit') WHERE run_id = ?",
-      ).run(run.runId);
-      closeOpenClawStateDatabaseForTest();
-
-      expect(loadSubagentRegistryFromSqlite().get(run.runId)?.delivery?.suspendedReason).toBe(
-        "permanent_failure",
-      );
-    });
-  });
-
   it("loads a canonical lightweight session-list projection", async () => {
     await withTempStateEnv(async () => {
       const run = createRun({

--- a/src/agents/subagents/registry/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagents/registry/subagent-registry.store.sqlite.ts
@@ -93,7 +93,8 @@ function rowToSubagentRunRecord(row: SubagentRunSqliteRow): SubagentRunRecord | 
   if (!isCanonicalSubagentRunRecord(payload)) {
     return null;
   }
-  if (payload.delivery.suspendedReason === "retry-limit") {
+  const suspendedReason: unknown = payload.delivery.suspendedReason;
+  if (suspendedReason === "retry-limit") {
     payload.delivery.suspendedReason = "permanent_failure";
   }
   // This module owns every production write and commits indexed columns with

--- a/src/agents/subagents/registry/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagents/registry/subagent-registry.store.sqlite.ts
@@ -59,20 +59,18 @@ function hasStateStatus(
   return isRecord(value) && typeof value.status === "string" && statuses.has(value.status);
 }
 
-function hasCanonicalDeliveryState(value: unknown): value is Record<string, unknown> {
-  return (
-    hasStateStatus(value, DELIVERY_STATUSES) &&
-    !("handoffLeaseId" in value || "handoffLeasedAt" in value || "handoffInjectedAt" in value)
-  );
-}
-
 function isCanonicalSubagentRunRecord(value: unknown): value is CanonicalSubagentRunRecord {
   return (
     isRecord(value) &&
     hasStateStatus(value.execution, EXECUTION_STATUSES) &&
     isRecord(value.completion) &&
     typeof value.completion.required === "boolean" &&
-    hasCanonicalDeliveryState(value.delivery)
+    hasStateStatus(value.delivery, DELIVERY_STATUSES) &&
+    !(
+      "handoffLeaseId" in value.delivery ||
+      "handoffLeasedAt" in value.delivery ||
+      "handoffInjectedAt" in value.delivery
+    )
   );
 }
 
@@ -81,10 +79,7 @@ function jsonStringify(value: unknown): string | null {
 }
 
 function parseJson(raw: string | null): unknown {
-  if (!raw) {
-    return undefined;
-  }
-  return safeParseJson(raw);
+  return raw ? safeParseJson(raw) : undefined;
 }
 
 function boolToSqlite(value: boolean | undefined): number | null {
@@ -94,9 +89,12 @@ function boolToSqlite(value: boolean | undefined): number | null {
 /** Rehydrates one sqlite row into the normalized subagent run record shape. */
 function rowToSubagentRunRecord(row: SubagentRunSqliteRow): SubagentRunRecord | null {
   const payload = parseJson(row.payload_json);
-  // SQLite shipped after nested state became canonical; unowned rows are transient.
+  // SQLite nested state is canonical; remove v2026.6.34's retry-limit map after its 7-day retention window.
   if (!isCanonicalSubagentRunRecord(payload)) {
     return null;
+  }
+  if (payload.delivery.suspendedReason === "retry-limit") {
+    payload.delivery.suspendedReason = "permanent_failure";
   }
   // This module owns every production write and commits indexed columns with
   // this complete payload atomically; rehydrating both created competing state.

--- a/src/agents/subagents/registry/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagents/registry/subagent-registry.store.sqlite.ts
@@ -89,13 +89,8 @@ function boolToSqlite(value: boolean | undefined): number | null {
 /** Rehydrates one sqlite row into the normalized subagent run record shape. */
 function rowToSubagentRunRecord(row: SubagentRunSqliteRow): SubagentRunRecord | null {
   const payload = parseJson(row.payload_json);
-  // SQLite nested state is canonical; remove v2026.6.34's retry-limit map after its 7-day retention window.
   if (!isCanonicalSubagentRunRecord(payload)) {
     return null;
-  }
-  const suspendedReason: unknown = payload.delivery.suspendedReason;
-  if (suspendedReason === "retry-limit") {
-    payload.delivery.suspendedReason = "permanent_failure";
   }
   // This module owns every production write and commits indexed columns with
   // this complete payload atomically; rehydrating both created competing state.

--- a/src/agents/subagents/registry/subagent-registry.types.ts
+++ b/src/agents/subagents/registry/subagent-registry.types.ts
@@ -88,7 +88,7 @@ type SubagentExecutionState = {
   endedAt?: number;
   outcome?: SubagentRunOutcome;
   interruptedAt?: number;
-  interruptionReason?: "gateway-restart" | "lost-execution-context";
+  interruptionReason?: "gateway-restart";
   transcriptTarget?: AgentRunSessionTarget;
 };
 
@@ -154,7 +154,7 @@ export type SubagentCompletionDeliveryState = {
   steeringLeasedAt?: number;
   steeringInjectedAt?: number;
   suspendedAt?: number;
-  suspendedReason?: "retry-limit" | "expiry" | "permanent_failure";
+  suspendedReason?: "expiry" | "permanent_failure";
   dismissedAt?: number;
   discardedAt?: number;
   discardReason?: "expired";

--- a/src/state/openclaw-state-db-legacy-backfills.test.ts
+++ b/src/state/openclaw-state-db-legacy-backfills.test.ts
@@ -1,9 +1,21 @@
 import { DatabaseSync } from "node:sqlite";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   repairLegacySubagentExecutionPayloads,
   repairLegacySubagentRetainedResults,
 } from "./openclaw-state-db-legacy-backfills.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "./openclaw-state-db.js";
+
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+    cleanup();
+  });
+});
 
 type StoredRun = {
   run_id: string;
@@ -53,6 +65,57 @@ function readWithShippedBeta6Projection(row: StoredRun) {
     },
   };
 }
+
+describe("repairLegacySubagentSuspensionReasons", () => {
+  it("rewrites the shipped reason on open and stays canonical after a second open", () => {
+    const stateDir = tempDirs.make("openclaw-subagent-suspension-backfill-");
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const initial = openOpenClawStateDatabase(options);
+    const runId = "legacy-retry-limit";
+    initial.db
+      .prepare(
+        `INSERT INTO subagent_runs (
+          run_id, child_session_key, requester_session_key, requester_display_key,
+          task, cleanup, created_at, payload_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        runId,
+        "agent:main:subagent:legacy",
+        "agent:main:main",
+        "main",
+        "legacy retry limit",
+        "keep",
+        100,
+        JSON.stringify({
+          runId,
+          childSessionKey: "agent:main:subagent:legacy",
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          task: "legacy retry limit",
+          cleanup: "keep",
+          createdAt: 100,
+          execution: { status: "terminal" },
+          completion: { required: true },
+          delivery: { status: "suspended", suspendedReason: "retry-limit" },
+        }),
+      );
+    closeOpenClawStateDatabaseForTest();
+
+    const firstOpen = openOpenClawStateDatabase(options);
+    const firstStored = firstOpen.db
+      .prepare("SELECT payload_json FROM subagent_runs WHERE run_id = ?")
+      .get(runId) as { payload_json: string };
+    expect(JSON.parse(firstStored.payload_json).delivery.suspendedReason).toBe("permanent_failure");
+    closeOpenClawStateDatabaseForTest();
+
+    const secondOpen = openOpenClawStateDatabase(options);
+    const secondStored = secondOpen.db
+      .prepare("SELECT payload_json FROM subagent_runs WHERE run_id = ?")
+      .get(runId);
+    expect(secondStored).toEqual(firstStored);
+  });
+});
 
 describe("repairLegacySubagentExecutionPayloads", () => {
   it("moves shipped paused and killed terminal facts into execution once", () => {

--- a/src/state/openclaw-state-db-legacy-backfills.ts
+++ b/src/state/openclaw-state-db-legacy-backfills.ts
@@ -295,6 +295,20 @@ export function repairLegacySubagentExecutionPayloads(db: DatabaseSync): void {
   `);
 }
 
+/** Canonicalize the shipped suspension reason before runtime hydrates subagent state. */
+export function repairLegacySubagentSuspensionReasons(db: DatabaseSync): void {
+  if (!tableExists(db, "subagent_runs")) {
+    return;
+  }
+  // v2026.6.34 persisted retry-limit; remove this backfill after its 7-day retention window.
+  db.exec(`
+    UPDATE subagent_runs
+    SET payload_json = json_set(payload_json, '$.delivery.suspendedReason', 'permanent_failure')
+    WHERE json_valid(payload_json)
+      AND json_extract(payload_json, '$.delivery.suspendedReason') = 'retry-limit';
+  `);
+}
+
 export function backfillAcpReplayEstimatedBytes(db: DatabaseSync): void {
   if (
     !tableExists(db, "acp_replay_events") ||

--- a/src/state/openclaw-state-db-schema-additive.ts
+++ b/src/state/openclaw-state-db-schema-additive.ts
@@ -13,6 +13,7 @@ import {
   repairLegacyTaskDeliveryStatuses,
   repairLegacySubagentExecutionPayloads,
   repairLegacySubagentRetainedResults,
+  repairLegacySubagentSuspensionReasons,
 } from "./openclaw-state-db-legacy-backfills.js";
 import { ensureColumn } from "./openclaw-state-db-schema-helpers.js";
 
@@ -347,6 +348,7 @@ export function ensureAdditiveStateColumns(db: DatabaseSync): void {
   ensureColumn(db, "subagent_runs", "swarm_structured_json TEXT");
   ensureColumn(db, "subagent_runs", "swarm_schema_error TEXT");
   ensureColumn(db, "subagent_runs", "swarm_usage_json TEXT");
+  repairLegacySubagentSuspensionReasons(db);
   repairLegacySubagentExecutionPayloads(db);
   repairLegacySubagentRetainedResults(db);
   ensureColumn(db, "worker_environments", "bootstrap_bundle_hash TEXT");


### PR DESCRIPTION
Related context: maintainer-approved doc 06a state-machine audit (pre-PR work order, 2026-08-10)

## What Problem This Solves

The persisted subagent state types still advertised `retry-limit` suspension and `lost-execution-context` interruption variants even though current production code cannot produce either state. That made impossible states look supported and left future readers responsible for branches that cannot run.

## Why This Change Was Made

This removes both dead type variants and keeps the representable state machine unchanged. `v2026.6.34` production code persisted `retry-limit`, so database opening now durably rewrites that retained value to the canonical `permanent_failure` state before runtime hydration. `lost-execution-context` had no shipped production writer and needs no compatibility path.

The migration lives in the established shared-state legacy-backfill owner, is guarded by the presence of `subagent_runs`, and is idempotent. Runtime registry reads now consume canonical rows only.

AI-assisted; the implementation and proof were reviewed before publication.

## User Impact

No behavior changes for representable subagent states. Operators with a still-retained `v2026.6.34` retry-limit row have it canonicalized once during database open, while new code can no longer construct either dead variant.

## Evidence

- Branch scope: three commits touching only the subagent registry types/store and the shared-state legacy-backfill owner/registration/test.
- ClawSweeper finding addressed: moved conversion from read-time hydration into the database-open backfill and added raw stored-row plus second-open regression coverage.
- `node scripts/run-vitest.mjs src/state/openclaw-state-db-legacy-backfills.test.ts src/agents/subagents/registry/subagent-registry.store.sqlite.test.ts` — 7/7 backfill tests and 16/16 store tests passed.
- `node scripts/check-changed.mjs` — passed locally end-to-end after the Azure sparse checkout lacked its hydrated workspace-module link; core production/test typechecks, changed-file lint, dead-code scans, formatting, SDK/API, storage, and architecture guards passed.
- `pnpm plugin-sdk:surface:check` — clean, zero surface delta.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings; patch rated correct at 0.98.
- LOC: production `+25/-15` (net `+10`, required to move compatibility into the durable migration owner); tests `+65/-2`; generated `0`.
