### PR TITLE
improve: start fresh gateways without migration overhead

### DIFF
--- a/src/channels/plugins/lifecycle-startup.ts
+++ b/src/channels/plugins/lifecycle-startup.ts
@@ -1,10 +1,7 @@
-/**
- * Channel plugin startup maintenance runner.
- *
- * Invokes optional plugin lifecycle hooks without blocking unrelated channels.
- */
+/** Invokes optional startup maintenance for loaded channel plugins. */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { listChannelPlugins } from "./registry.js";
+import { listLoadedChannelPlugins } from "./registry-loaded.js";
+import type { ChannelPlugin } from "./types.plugin.js";
 
 type ChannelStartupLogger = {
   info?: (message: string) => void;
@@ -21,7 +18,7 @@ export async function runChannelPluginStartupMaintenance(params: {
   trigger?: string;
   logPrefix?: string;
 }): Promise<void> {
-  for (const plugin of listChannelPlugins()) {
+  for (const plugin of listLoadedChannelPlugins() as ChannelPlugin[]) {
     const runStartupMaintenance = plugin.lifecycle?.runStartupMaintenance;
     if (!runStartupMaintenance) {
       continue;

--- a/src/channels/plugins/registry.ts
+++ b/src/channels/plugins/registry.ts
@@ -1,8 +1,4 @@
-/**
- * Runtime channel plugin registry facade.
- *
- * Lists, resolves, and normalizes active channel plugins with bundled fallback.
- */
+/** Active channel plugin registry with bundled fallback. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeAnyChannelId } from "../registry.js";
 import { getBundledChannelPlugin } from "./bundled.js";
@@ -14,12 +10,7 @@ import {
 import type { ChannelPlugin } from "./types.plugin.js";
 import type { ChannelId } from "./types.public.js";
 
-/**
- * Lists currently loaded channel plugins in registry order.
- */
-export function listChannelPlugins(): ChannelPlugin[] {
-  return listLoadedChannelPlugins() as ChannelPlugin[];
-}
+export const listChannelPlugins = listLoadedChannelPlugins as () => ChannelPlugin[];
 
 /**
  * Returns a loaded channel plugin without falling back to bundled metadata.

--- a/src/channels/plugins/registry.ts
+++ b/src/channels/plugins/registry.ts
@@ -10,7 +10,7 @@ import {
 import type { ChannelPlugin } from "./types.plugin.js";
 import type { ChannelId } from "./types.public.js";
 
-export const listChannelPlugins = listLoadedChannelPlugins as () => ChannelPlugin[];
+export const listChannelPlugins = () => listLoadedChannelPlugins() as ChannelPlugin[];
 
 /**
  * Returns a loaded channel plugin without falling back to bundled metadata.

--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -448,42 +448,47 @@ describe("JSON console style process output", () => {
     SLOW_DOTENV_TEST_TIMEOUT_MS,
   );
 
-  it("loads eligible dotenv before formatting a run-main import failure", async () => {
-    let failure: CliProcessFailure | undefined;
-    try {
-      await runCliProcess({
-        args: ["gateway", "status"],
-        config: {
-          logging: {
-            consoleStyle: "${OPENCLAW_TEST_CONSOLE_STYLE}",
-            level: "silent",
+  it(
+    "loads eligible dotenv before formatting a run-main import failure",
+    async () => {
+      let failure: CliProcessFailure | undefined;
+      try {
+        await runCliProcess({
+          args: ["gateway", "status"],
+          config: {
+            logging: {
+              consoleStyle: "${OPENCLAW_TEST_CONSOLE_STYLE}",
+              level: "silent",
+            },
           },
-        },
-        env: {
-          OPENCLAW_GATEWAY_STARTUP_TRACE: "1",
-          OPENCLAW_TEST_CONSOLE_STYLE: undefined,
-        },
-        failRunMainImport: true,
-        stateEnv: () => ({ OPENCLAW_TEST_CONSOLE_STYLE: "json" }),
-      });
-    } catch (error) {
-      failure = error as CliProcessFailure;
-    }
+          env: {
+            OPENCLAW_GATEWAY_STARTUP_TRACE: "1",
+            OPENCLAW_TEST_CONSOLE_STYLE: undefined,
+          },
+          failRunMainImport: true,
+          stateEnv: () => ({ OPENCLAW_TEST_CONSOLE_STYLE: "json" }),
+          timeoutMs: SLOW_DOTENV_CHILD_PROCESS_TIMEOUT_MS,
+        });
+      } catch (error) {
+        failure = error as CliProcessFailure;
+      }
 
-    expect(failure?.code).toBe(1);
-    expect(parseJsonLines(failure?.stderr ?? "")).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          level: "info",
-          message: expect.stringContaining("startup trace: entry.bootstrap"),
-        }),
-        expect.objectContaining({
-          level: "error",
-          message: expect.stringContaining("forced run-main import failure"),
-        }),
-      ]),
-    );
-  });
+      expect(failure?.code).toBe(1);
+      expect(parseJsonLines(failure?.stderr ?? "")).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            level: "info",
+            message: expect.stringContaining("startup trace: entry.bootstrap"),
+          }),
+          expect.objectContaining({
+            level: "error",
+            message: expect.stringContaining("forced run-main import failure"),
+          }),
+        ]),
+      );
+    },
+    SLOW_DOTENV_TEST_TIMEOUT_MS,
+  );
 
   it("structures unsupported-runtime diagnostics from included named-profile config", async () => {
     let failure: CliProcessFailure | undefined;

--- a/src/config/sessions/startup-migration.ts
+++ b/src/config/sessions/startup-migration.ts
@@ -1,32 +1,26 @@
-import { migrateOrphanedSessionKeys } from "../../infra/state-migrations.js";
+import { resolveAgentSessionDirs } from "../../agents/session-dirs.js";
+import { migrateOrphanedSessionKeys } from "../../infra/state-migrations.session-store.js";
 import type { PreparedLegacySessionSurfaces } from "../../plugins/legacy-session-surfaces.types.js";
 import {
   closeOpenClawAgentDatabaseByPath,
   isOpenClawAgentDatabaseOpen,
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
+import { resolveStateDir } from "../paths.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { setCanonicalSqliteSessionMainKey } from "./session-canonical-key.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 import { sweepOrphanSessionStoreTemps } from "./store-temp-cleanup.js";
 import { resolveAllAgentSessionStoreTargetsSync } from "./targets.js";
 
-export type SessionStartupMigrationLogger = {
-  info: (message: string) => void;
-  warn: (message: string) => void;
-};
+export type SessionStartupMigrationLogger = Record<"info" | "warn", (message: string) => void>;
 
 type PrepareLegacySessionSurfaces = (params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }) => PreparedLegacySessionSurfaces;
 
-/**
- * Run session migration and orphan-temp cleanup before runtime store reads.
- *
- * Both passes are idempotent and failure-isolated: startup continues if either
- * fails, but warnings stay visible for operator follow-up.
- */
+/** Runs best-effort session migration and orphan-temp cleanup before runtime reads. */
 export async function runSessionStartupMigration(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -37,10 +31,26 @@ export async function runSessionStartupMigration(params: {
     resolveAllAgentSessionStoreTargetsSync?: typeof resolveAllAgentSessionStoreTargetsSync;
     sweepOrphanSessionStoreTemps?: typeof sweepOrphanSessionStoreTemps;
   };
-}): Promise<void> {
+}): Promise<boolean> {
+  const env = params.env ?? process.env;
   const migrate = params.deps?.migrateOrphanedSessionKeys ?? migrateOrphanedSessionKeys;
+  const resolveTargets =
+    params.deps?.resolveAllAgentSessionStoreTargetsSync ?? resolveAllAgentSessionStoreTargetsSync;
+  let targets: ReturnType<typeof resolveTargets> | undefined;
   try {
-    const env = params.env ?? process.env;
+    if (
+      !params.cfg.session?.store &&
+      (await resolveAgentSessionDirs(resolveStateDir(env))).length === 0
+    ) {
+      return false;
+    }
+    targets = resolveTargets(params.cfg, { env });
+  } catch (err) {
+    params.log.warn(
+      `session: stale session store temp cleanup failed during startup; continuing: ${String(err)}`,
+    );
+  }
+  try {
     const prepareSurfaces =
       params.deps?.prepareLegacySessionSurfaces ??
       (await import("../../plugins/legacy-session-surfaces.js")).prepareLegacySessionSurfaces;
@@ -64,15 +74,14 @@ export async function runSessionStartupMigration(params: {
       `session: orphaned session key migration failed during startup; continuing: ${String(err)}`,
     );
   }
+  if (!targets) {
+    return true;
+  }
 
-  const resolveTargets =
-    params.deps?.resolveAllAgentSessionStoreTargetsSync ?? resolveAllAgentSessionStoreTargetsSync;
   const sweepTemps = params.deps?.sweepOrphanSessionStoreTemps ?? sweepOrphanSessionStoreTemps;
   try {
     let removedFiles = 0;
-    for (const target of resolveTargets(params.cfg, {
-      env: params.env ?? process.env,
-    })) {
+    for (const target of targets) {
       const path = resolveSqliteTargetFromSessionStorePath(target.storePath, {
         agentId: target.agentId,
         env: params.env,
@@ -93,4 +102,5 @@ export async function runSessionStartupMigration(params: {
       `session: stale session store temp cleanup failed during startup; continuing: ${String(err)}`,
     );
   }
+  return true;
 }

--- a/src/gateway/server-import-boundary.test.ts
+++ b/src/gateway/server-import-boundary.test.ts
@@ -90,6 +90,13 @@ describe("gateway startup import boundaries", () => {
     );
   });
 
+  it("keeps channel startup maintenance on the loaded-only registry", () => {
+    const lifecycleStartup = readSource("src/channels/plugins/lifecycle-startup.ts");
+
+    expect(lifecycleStartup).toContain('from "./registry-loaded.js"');
+    expect(lifecycleStartup).not.toContain('from "./registry.js"');
+  });
+
   it("defers retained plugin generation cleanup to the post-ready idle scheduler", () => {
     const serverImpl = readServerImplementation();
     const cleanup = readSource("src/gateway/server-retained-plugin-cleanup.ts");

--- a/src/gateway/server-methods/setup-admission.ts
+++ b/src/gateway/server-methods/setup-admission.ts
@@ -28,9 +28,9 @@ export async function runExclusiveSystemAgentSetupActivation<T>(
   }
 }
 
-export function whenAdmittedWizardSessionSettled<T extends { whenSettled(): Promise<unknown> }>(
-  session: T,
-): Promise<unknown> {
+export function whenAdmittedWizardSessionSettled(session: {
+  whenSettled(): Promise<unknown>;
+}): Promise<unknown> {
   return wizardSessionAdmissionSettlements.get(session) ?? session.whenSettled();
 }
 

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -29,7 +29,10 @@ import type {
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { ExecApprovalManager } from "../exec-approval-manager.js";
 import { handleGatewayRequest } from "../server-methods.js";
-import { runExclusiveSystemAgentSetupActivation } from "./setup-admission.js";
+import {
+  runExclusiveSystemAgentSetupActivation,
+  whenAdmittedWizardSessionSettled,
+} from "./setup-admission.js";
 import { systemAgentHandlers, type SystemAgentChatSession } from "./system-agent.js";
 import type { GatewayClient, GatewayRequestContext } from "./types.js";
 
@@ -406,6 +409,7 @@ describe("openclaw.setup", () => {
     });
     await session.answer(first.step.id, null);
     await expect(session.next()).resolves.toMatchObject({ done: true, status: "done" });
+    await whenAdmittedWizardSessionSettled(session);
   });
   it("runs the selected provider method in a shared wizard session and commits its config", async () => {
     const preparedConfig: OpenClawConfig = {

--- a/src/gateway/server-startup-session-migration.test-support.ts
+++ b/src/gateway/server-startup-session-migration.test-support.ts
@@ -27,9 +27,10 @@ function makeLog() {
 }
 
 function makeCfg() {
-  return { agents: { defaults: {} }, session: {} } as Parameters<
-    typeof runStartupSessionMigration
-  >[0]["cfg"];
+  return {
+    agents: { defaults: {} },
+    session: { store: "/tmp/{agentId}/sessions.json" },
+  } as Parameters<typeof runStartupSessionMigration>[0]["cfg"];
 }
 
 // Every test injects store-target and sweep mocks so startup never scans the
@@ -44,7 +45,7 @@ function makeDeps(
 ) {
   return {
     migrateOrphanedSessionKeys: migrate,
-    prepareLegacySessionSurfaces: () => EMPTY_LEGACY_SESSION_SURFACES,
+    prepareLegacySessionSurfaces: vi.fn(() => EMPTY_LEGACY_SESSION_SURFACES),
     resolveAllAgentSessionStoreTargetsSync: vi.fn<ResolveStoreTargets>().mockReturnValue([
       { agentId: "main", storePath: "/tmp/main/sessions.json" },
       { agentId: "ops", storePath: "/tmp/ops/sessions.json" },
@@ -97,6 +98,38 @@ function makeSessionSqliteImport(
 }
 
 describe("runStartupSessionMigration", () => {
+  it("skips legacy migration imports when no session stores exist", async () => {
+    const log = makeLog();
+    const migrate = vi.fn<MigrateSessionKeys>().mockResolvedValue({ changes: [], warnings: [] });
+    const deps = makeDeps(migrate);
+    deps.sessionSqliteDatabaseExists.mockReturnValue(false);
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-empty-session-startup-"));
+    const env = { OPENCLAW_STATE_DIR: path.join(stateDir, "missing") };
+
+    try {
+      await runStartupSessionMigration({ cfg: { session: {} }, env, log, deps });
+    } finally {
+      fs.rmSync(stateDir, { force: true, recursive: true });
+    }
+
+    expect(deps.resolveAllAgentSessionStoreTargetsSync).not.toHaveBeenCalled();
+    expect(migrate).not.toHaveBeenCalled();
+    expect(deps.prepareLegacySessionSurfaces).not.toHaveBeenCalled();
+    expect(deps.runDoctorSessionSqlite).not.toHaveBeenCalled();
+    expect(deps.reconcileSessionTranscriptIndexes).not.toHaveBeenCalled();
+  });
+
+  it("keeps custom stores on the migration path when discovery is inconclusive", async () => {
+    const migrate = vi.fn<MigrateSessionKeys>().mockResolvedValue({ changes: [], warnings: [] });
+    const deps = makeDeps(migrate);
+    deps.resolveAllAgentSessionStoreTargetsSync.mockReturnValue([]);
+
+    await runStartupSessionMigration({ cfg: makeCfg(), log: makeLog(), deps });
+
+    expect(migrate).toHaveBeenCalledOnce();
+    expect(deps.runDoctorSessionSqlite).toHaveBeenCalledOnce();
+  });
+
   it("logs changes when orphaned keys are canonicalized", async () => {
     const log = makeLog();
     const migrate = vi.fn<MigrateSessionKeys>().mockResolvedValue({
@@ -172,6 +205,8 @@ describe("runStartupSessionMigration", () => {
 
     await runStartupSessionMigration({ cfg: makeCfg(), log, deps });
 
+    expect(migrate).toHaveBeenCalledOnce();
+    expect(deps.runDoctorSessionSqlite).toHaveBeenCalledOnce();
     expect(log.warn).toHaveBeenCalledOnce();
     const warning = firstLogMessage(log.warn, "startup cleanup failure warning");
     expect(warning).toContain("temp cleanup failed during startup");

--- a/src/gateway/server-startup-session-migration.ts
+++ b/src/gateway/server-startup-session-migration.ts
@@ -55,8 +55,9 @@ export async function runStartupSessionMigration(params: {
   log: SessionStartupMigrationLogger;
   deps?: SessionMigrationDeps;
 }): Promise<void> {
-  await runSessionStartupMigration(params);
-  await runStartupSessionSqliteImport(params);
+  if (await runSessionStartupMigration(params)) {
+    await runStartupSessionSqliteImport(params);
+  }
   await reconcileStartupSessionTranscriptIndexes(params);
 }
 

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -9,7 +9,6 @@ export {
 } from "./state-migrations.doctor.js";
 export { migrateLegacyAgentDir } from "./state-migrations.legacy-sessions.js";
 export { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
-export { migrateOrphanedSessionKeys } from "./state-migrations.session-store.js";
 export {
   autoMigrateLegacyStateDir,
   autoMigrateLegacyTaskStateSidecars,

--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -158,7 +158,7 @@ suite.define(() => {
           welcomeVariant: "onboarding",
         });
         await page.getByRole("button", { name: "Skip for now" }).click();
-        await expect.poll(() => new URL(page.url()).pathname).toBe("/chat");
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/chat/main");
         await expect
           .poll(() => page.locator(".shell").getAttribute("class"))
           .not.toContain("shell--onboarding");


### PR DESCRIPTION
## What Problem This Solves

Fresh Gateway instances paid the full legacy session migration and plugin setup cost even when the default agent state root had no agent directories and therefore no session data to migrate. On the production startup benchmark this added roughly six seconds before HTTP listen/readiness.

## Why This Change Was Made

The startup path now proves the default session layout is pristine with a direct agent-root enumeration before loading legacy session surfaces or the Doctor SQLite migration graph. Custom session stores, existing agent directories, and all discovery errors stay on the existing conservative migration path. Channel startup maintenance also reads the loaded-only registry directly, avoiding a fallback-capable import without changing which plugins run maintenance. Narrowing the migration import made one barrel export dead, so this PR removes it.

Exact-head CI also exposed two stale test expectations unrelated to startup: the slow dotenv process case now uses its existing timeout guard, and onboarding exit asserts the canonical main-session route. Both repairs are test-only. After rebasing, current `main` also failed lint on a one-use setup-admission type parameter; the type-only repair removes it without runtime behavior or net LOC growth.

## User Impact

New/default-state Gateways become ready substantially faster. Existing, custom, retired-agent, SQLite, and legacy session stores retain the existing migration and cleanup behavior.

Production LOC: +40/-42 (net -2) | Tests/test support: +91/-40

## Evidence

Production build, Node 24.15.0, local Amp orb, `skipChannels`, 7 measured runs after 2 warmups:

| Metric | Before p50 | After p50 | Change |
| --- | ---: | ---: | ---: |
| Completion / health | 15,186 ms | 8,930 ms | -41.2% |
| HTTP listen | 13,754 ms | 7,374 ms | -46.4% |
| Gateway ready log | 13,775 ms | 7,402 ms | -46.3% |
| Max RSS | 1,143 MB | 1,082 MB | -5.3% |

The isolated no-state session migration fell from ~6,142 ms to 1.7-1.8 ms across five final production-build runs. Two final `--cpu-prof` runs no longer show Jiti/Babel among the top frames. A hosted profile node was unavailable, so these measurements are local Linux Node 24 profile evidence rather than hosted-profile evidence.

Validation:

- focused startup/import/registry runs (68 tests)
- focused CLI process timeout rerun (1 test; full 25-test file also passed before guard alignment)
- focused model-setup canonical-route rerun (1 test)
- setup-admission/wizard owner run (23 tests)
- full system-agent owner file (28 tests; deterministic pre-fix failure)
- targeted setup-admission oxlint/format check
- `pnpm tsgo:core`
- `pnpm tsgo:test:root`
- `pnpm tsgo:test:ui`
- `pnpm lint:ui:styles`
- `pnpm build`
- `pnpm deadcode:exports`
- `pnpm plugin-sdk:api:check`
- `pnpm test:startup:gateway --case skipChannels --runs 7 --warmup 2`
- `pnpm test:startup:gateway --case skipChannels --runs 2 --warmup 0 --cpu-prof-dir ...`
- fresh rebased-head Codex autoreview: clean (0.96); final focused reviews: clean (0.99)
- TruffleHog: clean
