### PR TITLE
fix(update): detect markerless npm global installs

### DIFF
--- a/src/infra/update-check.global-install.test.ts
+++ b/src/infra/update-check.global-install.test.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { runCommandWithTimeout } from "../process/exec.js";
+import { withTempDir } from "../test-helpers/temp-dir.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { checkUpdateStatus } from "./update-check.js";
+
+describe("checkUpdateStatus global install detection", () => {
+  it("recognizes markerless packages under the active global npm root", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-npm-prefix-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      await withEnvAsync({ NPM_CONFIG_PREFIX: prefix }, async () => {
+        const npmRootResult = await runCommandWithTimeout(["npm", "root", "-g"], {
+          timeoutMs: 5000,
+        });
+        expect(npmRootResult.code).toBe(0);
+        const npmRoot = npmRootResult.stdout.trim();
+        const root = path.join(npmRoot, "openclaw");
+        await fs.mkdir(root, { recursive: true });
+        await fs.writeFile(
+          path.join(root, "package.json"),
+          JSON.stringify({ name: "openclaw" }),
+          "utf8",
+        );
+
+        const status = await checkUpdateStatus({
+          root,
+          includeRegistry: false,
+          fetchGit: false,
+          timeoutMs: 5000,
+        });
+
+        expect(status).toMatchObject({
+          installKind: "package",
+          packageManager: "npm",
+          deps: {
+            manager: "npm",
+            status: "unknown",
+            reason: "lockfile missing",
+          },
+        });
+      });
+    });
+  });
+
+  it("keeps markerless roots outside npm's global prefix unknown", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-npm-mismatch-" }, async (base) => {
+      const root = path.join(base, "package-root");
+      await fs.mkdir(root);
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ name: "openclaw", packageManager: "yarn@4.9.2" }),
+        "utf8",
+      );
+
+      const status = await checkUpdateStatus({
+        root,
+        includeRegistry: false,
+        fetchGit: false,
+        timeoutMs: 5000,
+      });
+
+      expect(status.installKind).toBe("package");
+      expect(status.packageManager).toBe("unknown");
+      expect(status.deps).toMatchObject({ manager: "unknown", status: "unknown" });
+    });
+  });
+
+  it("keeps markerless Git roots classified as Git inside an npm prefix", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-git-npm-prefix-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      await withEnvAsync({ NPM_CONFIG_PREFIX: prefix }, async () => {
+        const npmRootResult = await runCommandWithTimeout(["npm", "root", "-g"], {
+          timeoutMs: 5000,
+        });
+        expect(npmRootResult.code).toBe(0);
+        const root = path.join(npmRootResult.stdout.trim(), "openclaw");
+        await fs.mkdir(root, { recursive: true });
+        await fs.writeFile(
+          path.join(root, "package.json"),
+          JSON.stringify({ name: "openclaw" }),
+          "utf8",
+        );
+        const gitInit = await runCommandWithTimeout(["git", "init", "--initial-branch=main"], {
+          cwd: root,
+          timeoutMs: 5000,
+        });
+        expect(gitInit.code).toBe(0);
+
+        const status = await checkUpdateStatus({
+          root,
+          includeRegistry: false,
+          fetchGit: false,
+          timeoutMs: 5000,
+        });
+
+        expect(status.installKind).toBe("git");
+        expect(status.packageManager).toBe("unknown");
+      });
+    });
+  });
+});

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -15,6 +15,7 @@ import {
   fetchNpmPackageTargetStatus,
   type NpmMetadataCommandRunner,
 } from "./update-check-package-target.js";
+import { detectGlobalInstallManagerForRoot } from "./update-global.js";
 
 type PackageManager = "pnpm" | "bun" | "npm" | "unknown";
 
@@ -642,6 +643,10 @@ export async function checkUpdateStatus(params: {
     detectGitRoot(root),
   ]);
   const isGit = gitRoot && path.resolve(gitRoot) === path.resolve(rootRealpath);
+  const globalInstallManager =
+    !isGit && detectedPackageManager === "unknown"
+      ? await detectGlobalInstallManagerForRoot(runCommandWithTimeout, root, timeoutMs)
+      : null;
   const packageManager =
     !isGit &&
     (await isLocklessOpenClawNpmInstall({
@@ -649,7 +654,7 @@ export async function checkUpdateStatus(params: {
       manager: detectedPackageManager,
     }))
       ? "npm"
-      : detectedPackageManager;
+      : (globalInstallManager ?? detectedPackageManager);
 
   const installKind: UpdateCheckResult["installKind"] = isGit ? "git" : "package";
   const [git, deps] = await Promise.all([


### PR DESCRIPTION
## What Problem This Solves\nOpenClaw update status

┌──────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Item     │ Value                                                                                                     │
├──────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Install  │ unknown                                                                                                   │
│ Channel  │ beta (installed version)                                                                                  │
│ Update   │ available · pkg · npm beta update 2026.8.1-beta.1                                                         │
└──────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────┘

Update available (npm 2026.8.1-beta.1). Run: openclaw update can report a markerless npm global installation as unknown because the package root has neither packed markers nor a lockfile, even though the canonical global-install detector can identify its package manager.\n\n## Summary\n- fall back to the canonical global-install detector when packed/lock topology is unknown\n- preserve Git precedence and existing package-layout ownership\n- cover markerless npm-prefix roots, out-of-prefix unknown roots, and Git precedence\n\n## Evidence\n- focused update-check tests: 45/45\n- type-aware lint and [ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND] No package.json (or package.yaml, or package.json5) was found in "/home/bruce/.openclaw/workspace".\n- format and \n- TruffleHog, fresh autoreview, and exact-head preflight passed with no findings