### PR TITLE
feat(health): report outbound dead-letter breakdowns

### DIFF
--- a/packages/gateway-protocol/src/schema/snapshot.test.ts
+++ b/packages/gateway-protocol/src/schema/snapshot.test.ts
@@ -88,4 +88,71 @@ describe("SnapshotSchema", () => {
 
     expect(Value.Check(SnapshotSchema, snapshot)).toBe(true);
   });
+
+  it("accepts the optional bounded outbound dead-letter breakdown", () => {
+    const snapshot = {
+      ...snapshotWithPresence({ ts: 1 }),
+      health: {
+        deliveryQueues: {
+          failed: [{ queueName: "outbound-prepared-v1", count: 2, oldestFailedAt: 1_000 }],
+          ingressFailed: [
+            { channelId: "telegram", accountId: "default", count: 1, oldestFailedAt: 900 },
+          ],
+          outboundFailed: {
+            count: 2,
+            oldestFailedAt: 1_000,
+            newestFailedAt: 2_000,
+            buckets: [
+              {
+                queue: "prepared",
+                channel: "telegram",
+                recoveryState: "unknownAfterSend",
+                count: 2,
+                oldestFailedAt: 1_000,
+                newestFailedAt: 2_000,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(Value.Check(SnapshotSchema, snapshot)).toBe(true);
+  });
+
+  it("rejects unknown categories and extra sensitive breakdown fields", () => {
+    const outboundFailed = {
+      count: 1,
+      buckets: [
+        {
+          queue: "prepared",
+          channel: "telegram",
+          recoveryState: "none",
+          count: 1,
+        },
+      ],
+    };
+    const snapshot = (value: Record<string, unknown>) => ({
+      ...snapshotWithPresence({ ts: 1 }),
+      health: { deliveryQueues: { failed: [], outboundFailed: value } },
+    });
+
+    expect(
+      Value.Check(SnapshotSchema, {
+        ...snapshot(outboundFailed),
+        health: {
+          deliveryQueues: {
+            failed: [],
+            outboundFailed: {
+              ...outboundFailed,
+              buckets: [{ ...outboundFailed.buckets[0], recoveryState: "private_future_state" }],
+            },
+          },
+        },
+      }),
+    ).toBe(false);
+    expect(Value.Check(SnapshotSchema, snapshot({ ...outboundFailed, accountId: "secret" }))).toBe(
+      false,
+    );
+  });
 });

--- a/packages/gateway-protocol/src/schema/snapshot.ts
+++ b/packages/gateway-protocol/src/schema/snapshot.ts
@@ -129,6 +129,46 @@ const HealthSnapshotSchema = closedObject({
           oldestFailedAt: Type.Optional(Type.Integer({ minimum: 0 })),
         }),
       ),
+      ingressFailed: Type.Optional(
+        Type.Array(
+          closedObject({
+            channelId: Type.String(),
+            accountId: Type.String(),
+            count: Type.Integer({ minimum: 0 }),
+            oldestFailedAt: Type.Optional(Type.Integer({ minimum: 0 })),
+          }),
+        ),
+      ),
+      outboundFailed: Type.Optional(
+        closedObject({
+          count: Type.Integer({ minimum: 0 }),
+          oldestFailedAt: Type.Optional(Type.Integer({ minimum: 0 })),
+          newestFailedAt: Type.Optional(Type.Integer({ minimum: 0 })),
+          buckets: Type.Array(
+            closedObject({
+              queue: Type.Union([
+                Type.Literal("prepared"),
+                Type.Literal("preparation"),
+                Type.Literal("migration"),
+                Type.Literal("legacy"),
+                Type.Literal("mediaStaging"),
+              ]),
+              channel: Type.String({ maxLength: 64 }),
+              recoveryState: Type.Union([
+                Type.Literal("none"),
+                Type.Literal("producerClaimed"),
+                Type.Literal("sendAttemptStarted"),
+                Type.Literal("unknownAfterSend"),
+                Type.Literal("other"),
+              ]),
+              count: Type.Integer({ minimum: 0 }),
+              oldestFailedAt: Type.Optional(Type.Integer({ minimum: 0 })),
+              newestFailedAt: Type.Optional(Type.Integer({ minimum: 0 })),
+            }),
+            { maxItems: 50 },
+          ),
+        }),
+      ),
     }),
   ),
   modelPricing: Type.Optional(

--- a/src/commands/health.delivery-queue.test.ts
+++ b/src/commands/health.delivery-queue.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const countOutbound = vi.fn();
 const countIngress = vi.fn();
+const summarizeOutbound = vi.fn();
 
 vi.mock("../infra/delivery-queue-sqlite.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../infra/delivery-queue-sqlite.js")>();
@@ -20,12 +21,54 @@ vi.mock("../channels/message/ingress-queue.js", async (importOriginal) => {
   };
 });
 
+vi.mock("../infra/outbound/delivery-queue-health.js", () => ({
+  summarizeOutboundFailedDeliveryQueueEntries: () => summarizeOutbound(),
+}));
+
 const { buildDeliveryQueueHealthSummary } = await import("../gateway/health/delivery-queue.js");
 
 describe("buildDeliveryQueueHealthSummary", () => {
   beforeEach(() => {
     countOutbound.mockReset().mockReturnValue([]);
     countIngress.mockReset().mockReturnValue([]);
+    summarizeOutbound.mockReset().mockReturnValue(undefined);
+  });
+
+  it("includes a bounded outbound dead-letter breakdown", () => {
+    summarizeOutbound.mockReturnValue({
+      count: 2,
+      oldestFailedAt: 1_000,
+      newestFailedAt: 2_000,
+      buckets: [
+        {
+          queue: "prepared",
+          channel: "telegram",
+          recoveryState: "unknownAfterSend",
+          count: 2,
+          oldestFailedAt: 1_000,
+          newestFailedAt: 2_000,
+        },
+      ],
+    });
+
+    expect(buildDeliveryQueueHealthSummary()).toEqual({
+      failed: [],
+      outboundFailed: {
+        count: 2,
+        oldestFailedAt: 1_000,
+        newestFailedAt: 2_000,
+        buckets: [
+          {
+            queue: "prepared",
+            channel: "telegram",
+            recoveryState: "unknownAfterSend",
+            count: 2,
+            oldestFailedAt: 1_000,
+            newestFailedAt: 2_000,
+          },
+        ],
+      },
+    });
   });
 
   it("preserves outbound failures when the ingress health read fails", () => {
@@ -50,6 +93,17 @@ describe("buildDeliveryQueueHealthSummary", () => {
     expect(buildDeliveryQueueHealthSummary()).toEqual({
       failed: [],
       ingressFailed: [{ channelId: "telegram", accountId: "ops", count: 1, oldestFailedAt: 2_000 }],
+    });
+  });
+
+  it("preserves existing totals when the outbound breakdown read fails", () => {
+    countOutbound.mockReturnValue([{ queueName: "outbound", count: 1, oldestFailedAt: 3_000 }]);
+    summarizeOutbound.mockImplementation(() => {
+      throw new Error("breakdown unavailable");
+    });
+
+    expect(buildDeliveryQueueHealthSummary()).toEqual({
+      failed: [{ queueName: "outbound", count: 1, oldestFailedAt: 3_000 }],
     });
   });
 });

--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -592,8 +592,8 @@ describe("collectGatewayHealthSnapshot", () => {
       await ingressQueue.fail(claim, { reason: "handler-error", failedAt: 50_000 });
 
       const snap = await getHealthSnapshot({ timeoutMs: 10, probe: false });
-      expect(snap.deliveryQueues).toEqual({
-        failed: [{ queueName: "outbound", count: 1, oldestFailedAt: expect.any(Number) }],
+      expect(snap.deliveryQueues).toMatchObject({
+        outboundFailed: { count: 1 },
         ingressFailed: [
           { channelId: "telegram", accountId: "ops", count: 1, oldestFailedAt: 50_000 },
         ],

--- a/src/gateway/health/delivery-queue.ts
+++ b/src/gateway/health/delivery-queue.ts
@@ -2,6 +2,7 @@ import { countFailedChannelIngressQueueEntries } from "../../channels/message/in
 import { countFailedDeliveryQueueEntries } from "../../infra/delivery-queue-sqlite.js";
 import { isDiagnosticFlagEnabled } from "../../infra/diagnostic-flags.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { summarizeOutboundFailedDeliveryQueueEntries } from "../../infra/outbound/delivery-queue-health.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { DeliveryQueueHealthSummary } from "./types.js";
 
@@ -50,11 +51,19 @@ export function buildDeliveryQueueHealthSummary(): DeliveryQueueHealthSummary | 
     debugHealth("channel ingress queue health read failed", error);
   }
 
-  if (failed.length === 0 && ingressFailed.length === 0) {
+  let outboundFailed: DeliveryQueueHealthSummary["outboundFailed"];
+  try {
+    outboundFailed = summarizeOutboundFailedDeliveryQueueEntries();
+  } catch (error) {
+    debugHealth("outbound dead-letter breakdown health read failed", error);
+  }
+
+  if (failed.length === 0 && ingressFailed.length === 0 && !outboundFailed) {
     return undefined;
   }
   return {
     failed,
     ...(ingressFailed.length > 0 ? { ingressFailed } : {}),
+    ...(outboundFailed ? { outboundFailed } : {}),
   };
 }

--- a/src/gateway/health/types.ts
+++ b/src/gateway/health/types.ts
@@ -77,6 +77,7 @@ export type DeliveryQueueHealthSummary = {
     count: number;
     oldestFailedAt?: number;
   }>;
+  outboundFailed?: import("../../infra/outbound/delivery-queue-health.js").OutboundDeadLetterHealthSummary;
 };
 
 /** Config hot-reload watcher status, present only when a reloader is running. */

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -4758,6 +4758,17 @@ describe("gateway healthHandlers.health cache freshness", () => {
         | {
             deliveryQueues?: {
               failed?: Array<{ queueName?: string; count?: number; oldestFailedAt?: number }>;
+              outboundFailed?: {
+                count?: number;
+                oldestFailedAt?: number;
+                newestFailedAt?: number;
+                buckets?: Array<{
+                  queue?: string;
+                  channel?: string;
+                  recoveryState?: string;
+                  count?: number;
+                }>;
+              };
             };
           }
         | undefined;
@@ -4767,6 +4778,19 @@ describe("gateway healthHandlers.health cache freshness", () => {
         count: 1,
       });
       expect(typeof payload?.deliveryQueues?.failed?.[0]?.oldestFailedAt).toBe("number");
+      expect(payload?.deliveryQueues?.outboundFailed).toMatchObject({
+        count: 1,
+        buckets: [
+          {
+            queue: "legacy",
+            channel: "[missing]",
+            recoveryState: "none",
+            count: 1,
+          },
+        ],
+      });
+      expect(typeof payload?.deliveryQueues?.outboundFailed?.oldestFailedAt).toBe("number");
+      expect(typeof payload?.deliveryQueues?.outboundFailed?.newestFailedAt).toBe("number");
       expect(mockCallArg(respond, 0, 3)).toEqual({ cached: true });
     } finally {
       await openClawState.cleanup();

--- a/src/infra/delivery-queue-sqlite.health.test.ts
+++ b/src/infra/delivery-queue-sqlite.health.test.ts
@@ -1,0 +1,109 @@
+// Delivery queue health storage tests cover metadata-only grouping and bounds.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  countFailedDeliveryQueueEntriesByMetadata,
+  upsertDeliveryQueueEntry,
+} from "./delivery-queue-sqlite.js";
+import { resolvePreferredOpenClawTmpDir } from "./tmp-openclaw-dir.js";
+
+describe("countFailedDeliveryQueueEntriesByMetadata", () => {
+  let tmpDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(resolvePreferredOpenClawTmpDir(), "openclaw-dq-meta-"));
+    stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function fail(params: {
+    queueName: string;
+    id: string;
+    failedAt: number;
+    channel?: string;
+    recoveryState?: string;
+  }) {
+    vi.setSystemTime(params.failedAt);
+    upsertDeliveryQueueEntry({
+      queueName: params.queueName,
+      entry: {
+        id: params.id,
+        enqueuedAt: params.failedAt - 100,
+        retryCount: 1,
+        ...(params.recoveryState ? { recoveryState: params.recoveryState } : {}),
+      },
+      metadata: { channel: params.channel },
+      status: "failed",
+      stateDir,
+    });
+  }
+
+  it("groups only selected failed queues and returns both failure boundaries", () => {
+    vi.useFakeTimers();
+    fail({ queueName: "outbound-prepared-v1", id: "one", failedAt: 1_000, channel: "telegram" });
+    fail({ queueName: "outbound-prepared-v1", id: "two", failedAt: 2_000, channel: "telegram" });
+    fail({
+      queueName: "outbound-preparing-v1",
+      id: "three",
+      failedAt: 3_000,
+      channel: "discord",
+      recoveryState: "unknown_after_send",
+    });
+    fail({ queueName: "session", id: "excluded", failedAt: 4_000, channel: "telegram" });
+    upsertDeliveryQueueEntry({
+      queueName: "outbound-prepared-v1",
+      entry: { id: "pending", enqueuedAt: 5_000, retryCount: 0 },
+      metadata: { channel: "telegram" },
+      stateDir,
+    });
+
+    expect(
+      countFailedDeliveryQueueEntriesByMetadata({
+        queueNames: ["outbound-prepared-v1", "outbound-preparing-v1"],
+        maxGroups: 10,
+        stateDir,
+      }),
+    ).toEqual({
+      truncated: false,
+      groups: [
+        {
+          queueName: "outbound-prepared-v1",
+          channel: "telegram",
+          recoveryState: null,
+          count: 2,
+          oldestFailedAt: 1_000,
+          newestFailedAt: 2_000,
+        },
+        {
+          queueName: "outbound-preparing-v1",
+          channel: "discord",
+          recoveryState: "unknown_after_send",
+          count: 1,
+          oldestFailedAt: 3_000,
+          newestFailedAt: 3_000,
+        },
+      ],
+    });
+  });
+
+  it("fails closed instead of returning a partial breakdown", () => {
+    vi.useFakeTimers();
+    fail({ queueName: "outbound", id: "one", failedAt: 1_000, channel: "telegram" });
+    fail({ queueName: "outbound", id: "two", failedAt: 2_000, channel: "discord" });
+
+    expect(
+      countFailedDeliveryQueueEntriesByMetadata({
+        queueNames: ["outbound"],
+        maxGroups: 1,
+        stateDir,
+      }),
+    ).toEqual({ truncated: true });
+  });
+});

--- a/src/infra/delivery-queue-sqlite.ts
+++ b/src/infra/delivery-queue-sqlite.ts
@@ -544,6 +544,20 @@ type FailedDeliveryQueueCount = {
   oldestFailedAt: number | null;
 };
 
+/** Metadata-only failed queue group used by bounded health projections. */
+export type FailedDeliveryQueueMetadataGroup = {
+  queueName: string;
+  channel: string | null;
+  recoveryState: string | null;
+  count: number;
+  oldestFailedAt: number | null;
+  newestFailedAt: number | null;
+};
+
+export type FailedDeliveryQueueMetadataBreakdown =
+  | { truncated: false; groups: FailedDeliveryQueueMetadataGroup[] }
+  | { truncated: true };
+
 /** Count dead-lettered (failed) entries per queue namespace for health reporting. */
 export function countFailedDeliveryQueueEntries(stateDir?: string): FailedDeliveryQueueCount[] {
   const database = openStateDatabase(stateDir);
@@ -570,6 +584,70 @@ export function countFailedDeliveryQueueEntries(stateDir?: string): FailedDelive
     count: Number(row.failed_count),
     oldestFailedAt: row.oldest_failed_at == null ? null : Number(row.oldest_failed_at),
   }));
+}
+
+/**
+ * Group failed entries using only routing and recovery metadata.
+ *
+ * The extra row is an overflow sentinel: callers never receive a partial
+ * breakdown when the fixed response bound is exceeded.
+ */
+export function countFailedDeliveryQueueEntriesByMetadata(params: {
+  queueNames: readonly string[];
+  maxGroups: number;
+  stateDir?: string;
+}): FailedDeliveryQueueMetadataBreakdown {
+  if (!Number.isSafeInteger(params.maxGroups) || params.maxGroups < 1 || params.maxGroups > 1_000) {
+    throw new Error("maxGroups must be an integer between 1 and 1000");
+  }
+  const queueNames = [...new Set(params.queueNames)];
+  if (queueNames.length === 0) {
+    return { truncated: false, groups: [] };
+  }
+
+  const database = openStateDatabase(params.stateDir);
+  const queueDb = getNodeSqliteKysely<DeliveryQueueDatabase>(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    queueDb
+      .selectFrom("delivery_queue_entries")
+      .select((eb) => [
+        "queue_name",
+        "channel",
+        "recovery_state",
+        eb.fn.countAll().as("failed_count"),
+        eb.fn.min("failed_at").as("oldest_failed_at"),
+        eb.fn.max("failed_at").as("newest_failed_at"),
+      ])
+      .where("queue_name", "in", queueNames)
+      .where("status", "=", "failed")
+      .groupBy(["queue_name", "channel", "recovery_state"])
+      .orderBy("queue_name", "asc")
+      .orderBy("channel", "asc")
+      .orderBy("recovery_state", "asc")
+      .limit(params.maxGroups + 1),
+  ).rows as Array<{
+    queue_name: string;
+    channel: string | null;
+    recovery_state: string | null;
+    failed_count: number | bigint;
+    oldest_failed_at: number | bigint | null;
+    newest_failed_at: number | bigint | null;
+  }>;
+  if (rows.length > params.maxGroups) {
+    return { truncated: true };
+  }
+  return {
+    truncated: false,
+    groups: rows.map((row) => ({
+      queueName: row.queue_name,
+      channel: row.channel,
+      recoveryState: row.recovery_state,
+      count: Number(row.failed_count),
+      oldestFailedAt: row.oldest_failed_at == null ? null : Number(row.oldest_failed_at),
+      newestFailedAt: row.newest_failed_at == null ? null : Number(row.newest_failed_at),
+    })),
+  };
 }
 
 /** Mark a pending delivery queue entry as failed for later diagnostics. */

--- a/src/infra/outbound/delivery-queue-health.test.ts
+++ b/src/infra/outbound/delivery-queue-health.test.ts
@@ -1,0 +1,188 @@
+// Outbound dead-letter health tests cover bounded categories and privacy.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { upsertDeliveryQueueEntry } from "../delivery-queue-sqlite.js";
+import { resolvePreferredOpenClawTmpDir } from "../tmp-openclaw-dir.js";
+import {
+  summarizeOutboundFailedDeliveryQueueEntries,
+  type OutboundDeliveryQueueCategory,
+  type OutboundDeliveryRecoveryCategory,
+} from "./delivery-queue-health.js";
+import {
+  DELIVERY_QUEUE_MEDIA_STAGING_QUEUE_NAME,
+  LEGACY_OUTBOUND_DELIVERY_QUEUE_NAME,
+  OUTBOUND_DELIVERY_MIGRATION_QUEUE_NAME,
+  OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
+  OUTBOUND_DELIVERY_QUEUE_NAME,
+  OUTBOUND_LEGACY_PREPARATION_QUEUE_NAME,
+} from "./delivery-queue-media-staging.js";
+
+describe("summarizeOutboundFailedDeliveryQueueEntries", () => {
+  let tmpDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(resolvePreferredOpenClawTmpDir(), "openclaw-dq-health-"));
+    stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(stateDir, { recursive: true });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function fail(params: {
+    queueName: string;
+    id: string;
+    failedAt: number;
+    channel?: string;
+    recoveryState?: string;
+  }) {
+    vi.setSystemTime(params.failedAt);
+    upsertDeliveryQueueEntry({
+      queueName: params.queueName,
+      entry: {
+        id: params.id,
+        enqueuedAt: params.failedAt - 100,
+        retryCount: 1,
+        ...(params.recoveryState ? { recoveryState: params.recoveryState } : {}),
+      },
+      metadata: { channel: params.channel },
+      status: "failed",
+      stateDir,
+    });
+  }
+
+  it("maps every outbound namespace and closed recovery category", () => {
+    fail({
+      queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+      id: "prepared",
+      failedAt: 1_000,
+      channel: "telegram",
+      recoveryState: "producer_claimed",
+    });
+    fail({
+      queueName: OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
+      id: "preparation-current",
+      failedAt: 2_000,
+      channel: "discord",
+      recoveryState: "send_attempt_started",
+    });
+    fail({
+      queueName: OUTBOUND_LEGACY_PREPARATION_QUEUE_NAME,
+      id: "preparation-legacy",
+      failedAt: 3_000,
+      channel: "discord",
+      recoveryState: "send_attempt_started",
+    });
+    fail({
+      queueName: OUTBOUND_DELIVERY_MIGRATION_QUEUE_NAME,
+      id: "migration",
+      failedAt: 4_000,
+      recoveryState: "unknown_after_send",
+    });
+    fail({
+      queueName: LEGACY_OUTBOUND_DELIVERY_QUEUE_NAME,
+      id: "legacy",
+      failedAt: 5_000,
+      channel: "x".repeat(65),
+      recoveryState: "future_private_state",
+    });
+    fail({
+      queueName: DELIVERY_QUEUE_MEDIA_STAGING_QUEUE_NAME,
+      id: "media",
+      failedAt: 6_000,
+      channel: "signal",
+    });
+
+    const summary = summarizeOutboundFailedDeliveryQueueEntries(stateDir);
+
+    expect(summary).toMatchObject({ count: 6, oldestFailedAt: 1_000, newestFailedAt: 6_000 });
+    expect(new Set(summary?.buckets.map((bucket) => bucket.queue))).toEqual(
+      new Set<OutboundDeliveryQueueCategory>([
+        "prepared",
+        "preparation",
+        "migration",
+        "legacy",
+        "mediaStaging",
+      ]),
+    );
+    expect(new Set(summary?.buckets.map((bucket) => bucket.recoveryState))).toEqual(
+      new Set<OutboundDeliveryRecoveryCategory>([
+        "none",
+        "producerClaimed",
+        "sendAttemptStarted",
+        "unknownAfterSend",
+        "other",
+      ]),
+    );
+    expect(summary?.buckets).toContainEqual({
+      queue: "preparation",
+      channel: "discord",
+      recoveryState: "sendAttemptStarted",
+      count: 2,
+      oldestFailedAt: 2_000,
+      newestFailedAt: 3_000,
+    });
+    expect(summary?.buckets.some((bucket) => bucket.channel === "[missing]")).toBe(true);
+    expect(summary?.buckets.some((bucket) => bucket.channel === "[other]")).toBe(true);
+  });
+
+  it("never serializes sensitive row or payload fields", () => {
+    const secrets = {
+      id: "private-id-canary",
+      sessionKey: "private-session-canary",
+      accountId: "private-account-canary",
+      target: "private-target-canary",
+      error: "private-error-canary",
+      body: "private-body-canary",
+      recoveryState: "private-recovery-canary",
+    };
+    vi.setSystemTime(7_000);
+    const entry = {
+      id: secrets.id,
+      enqueuedAt: 6_900,
+      retryCount: 2,
+      lastError: secrets.error,
+      recoveryState: secrets.recoveryState,
+      body: secrets.body,
+    };
+    upsertDeliveryQueueEntry({
+      queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+      entry,
+      metadata: {
+        sessionKey: secrets.sessionKey,
+        channel: "telegram",
+        target: secrets.target,
+        accountId: secrets.accountId,
+      },
+      status: "failed",
+      stateDir,
+    });
+
+    const serialized = JSON.stringify(summarizeOutboundFailedDeliveryQueueEntries(stateDir));
+
+    for (const secret of Object.values(secrets)) {
+      expect(serialized).not.toContain(secret);
+    }
+    expect(serialized).toContain('"recoveryState":"other"');
+  });
+
+  it("omits partial data when the fixed group bound is exceeded", () => {
+    for (let index = 0; index <= 50; index += 1) {
+      fail({
+        queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+        id: `dead-${index}`,
+        failedAt: 10_000 + index,
+        channel: `channel-${index}`,
+      });
+    }
+
+    expect(() => summarizeOutboundFailedDeliveryQueueEntries(stateDir)).toThrow(
+      "outbound dead-letter health breakdown exceeded its fixed group bound",
+    );
+  });
+});

--- a/src/infra/outbound/delivery-queue-health.ts
+++ b/src/infra/outbound/delivery-queue-health.ts
@@ -1,0 +1,150 @@
+// Builds a bounded, metadata-only health projection for outbound dead letters.
+import { countFailedDeliveryQueueEntriesByMetadata } from "../delivery-queue-sqlite.js";
+import {
+  DELIVERY_QUEUE_MEDIA_STAGING_QUEUE_NAME,
+  LEGACY_OUTBOUND_DELIVERY_QUEUE_NAME,
+  OUTBOUND_DELIVERY_MIGRATION_QUEUE_NAME,
+  OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME,
+  OUTBOUND_DELIVERY_QUEUE_NAME,
+  OUTBOUND_LEGACY_PREPARATION_QUEUE_NAME,
+} from "./delivery-queue-media-staging.js";
+
+const MAX_BREAKDOWN_GROUPS = 50;
+const MAX_CHANNEL_LENGTH = 64;
+const MISSING_CHANNEL = "[missing]";
+const OTHER_CHANNEL = "[other]";
+
+export type OutboundDeliveryQueueCategory =
+  | "prepared"
+  | "preparation"
+  | "migration"
+  | "legacy"
+  | "mediaStaging";
+
+export type OutboundDeliveryRecoveryCategory =
+  | "none"
+  | "producerClaimed"
+  | "sendAttemptStarted"
+  | "unknownAfterSend"
+  | "other";
+
+export type OutboundDeadLetterHealthBucket = {
+  queue: OutboundDeliveryQueueCategory;
+  channel: string;
+  recoveryState: OutboundDeliveryRecoveryCategory;
+  count: number;
+  oldestFailedAt?: number;
+  newestFailedAt?: number;
+};
+
+export type OutboundDeadLetterHealthSummary = {
+  count: number;
+  oldestFailedAt?: number;
+  newestFailedAt?: number;
+  buckets: OutboundDeadLetterHealthBucket[];
+};
+
+const queueCategoryByName = new Map<string, OutboundDeliveryQueueCategory>([
+  [OUTBOUND_DELIVERY_QUEUE_NAME, "prepared"],
+  [OUTBOUND_DELIVERY_PREPARATION_QUEUE_NAME, "preparation"],
+  [OUTBOUND_LEGACY_PREPARATION_QUEUE_NAME, "preparation"],
+  [OUTBOUND_DELIVERY_MIGRATION_QUEUE_NAME, "migration"],
+  [LEGACY_OUTBOUND_DELIVERY_QUEUE_NAME, "legacy"],
+  [DELIVERY_QUEUE_MEDIA_STAGING_QUEUE_NAME, "mediaStaging"],
+]);
+
+const outboundQueueNames = [...queueCategoryByName.keys()];
+
+function containsControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint != null && (codePoint <= 0x1f || codePoint === 0x7f)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function normalizeChannel(channel: string | null): string {
+  if (!channel) {
+    return MISSING_CHANNEL;
+  }
+  if (channel.length > MAX_CHANNEL_LENGTH || containsControlCharacter(channel)) {
+    return OTHER_CHANNEL;
+  }
+  return channel;
+}
+
+function recoveryCategory(recoveryState: string | null): OutboundDeliveryRecoveryCategory {
+  switch (recoveryState) {
+    case null:
+    case "":
+      return "none";
+    case "producer_claimed":
+      return "producerClaimed";
+    case "send_attempt_started":
+      return "sendAttemptStarted";
+    case "unknown_after_send":
+      return "unknownAfterSend";
+    default:
+      return "other";
+  }
+}
+
+function includeFailureTime(
+  target: { oldestFailedAt?: number; newestFailedAt?: number },
+  oldestFailedAt: number | null,
+  newestFailedAt: number | null,
+): void {
+  if (oldestFailedAt != null) {
+    target.oldestFailedAt = Math.min(target.oldestFailedAt ?? oldestFailedAt, oldestFailedAt);
+  }
+  if (newestFailedAt != null) {
+    target.newestFailedAt = Math.max(target.newestFailedAt ?? newestFailedAt, newestFailedAt);
+  }
+}
+
+/** Returns no value when there are no outbound dead letters. */
+export function summarizeOutboundFailedDeliveryQueueEntries(
+  stateDir?: string,
+): OutboundDeadLetterHealthSummary | undefined {
+  const breakdown = countFailedDeliveryQueueEntriesByMetadata({
+    queueNames: outboundQueueNames,
+    maxGroups: MAX_BREAKDOWN_GROUPS,
+    stateDir,
+  });
+  if (breakdown.truncated) {
+    throw new Error("outbound dead-letter health breakdown exceeded its fixed group bound");
+  }
+  if (breakdown.groups.length === 0) {
+    return undefined;
+  }
+
+  const summary: OutboundDeadLetterHealthSummary = { count: 0, buckets: [] };
+  const buckets = new Map<string, OutboundDeadLetterHealthBucket>();
+  for (const group of breakdown.groups) {
+    const queue = queueCategoryByName.get(group.queueName);
+    if (!queue) {
+      continue;
+    }
+    const channel = normalizeChannel(group.channel);
+    const recoveryState = recoveryCategory(group.recoveryState);
+    const key = JSON.stringify([queue, channel, recoveryState]);
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = { queue, channel, recoveryState, count: 0 };
+      buckets.set(key, bucket);
+    }
+    bucket.count += group.count;
+    includeFailureTime(bucket, group.oldestFailedAt, group.newestFailedAt);
+    summary.count += group.count;
+    includeFailureTime(summary, group.oldestFailedAt, group.newestFailedAt);
+  }
+  summary.buckets = [...buckets.values()].toSorted(
+    (left, right) =>
+      left.queue.localeCompare(right.queue) ||
+      left.channel.localeCompare(right.channel) ||
+      left.recoveryState.localeCompare(right.recoveryState),
+  );
+  return summary.count > 0 ? summary : undefined;
+}


### PR DESCRIPTION
## What Problem This Solves\nHealth output exposes aggregate delivery-queue failures but does not show which outbound queue, channel, and recovery state account for dead-letter backlog, making diagnosis require direct local database inspection.\n\n## Summary\n- expose an optional, bounded outbound dead-letter breakdown by queue, channel, and recovery state\n- keep the aggregation metadata-only and read-only, with closed categories and bounded channel values\n- cap output at 50 groups and fail closed on overflow or independent read failure\n- integrate the optional field through Health cache, protocol snapshots, and CLI output\n\n## Scope\n- no payloads, targets, errors, replay, deletion, migration, or delivery action\n\n## Evidence\n- focused protocol/infra/command tests: 53/53\n- type-aware lint and [ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND] No package.json (or package.yaml, or package.json5) was found in "/home/bruce/.openclaw/workspace".\n- format and \n- TruffleHog and fresh autoreview passed\n- exact-head preflight passed with zero P0/P1