### PR TITLE
chore: lower OPENCLAW_* env var budget to 503

### DIFF
--- a/config/env-var-count-budget.txt
+++ b/config/env-var-count-budget.txt
@@ -1,3 +1,3 @@
 # Distinct OPENCLAW_* names in production source under src, packages, and extensions.
 # Ratchet: lower this number when cleanup removes names; never raise it.
-507
+503


### PR DESCRIPTION
## What Problem This Solves

Main's environment-variable count gate is red because the production count is 503 while `config/env-var-count-budget.txt` still records 507. The stale budget makes `check-changed` fail for unrelated pull requests.

## Why This Change Was Made

Commit `3b3c540896ab` (`refactor: remove dead branches and test-only helpers (#121345)`) moved two test-only agent helpers out of production-counted paths. That removed these four names from the production surface:

- `OPENCLAW_LIVE_ANTHROPIC_CACHE_MODEL`
- `OPENCLAW_LIVE_OPENAI_CACHE_MODEL`
- `OPENCLAW_LIVE_MODEL_FILE_PROBE`
- `OPENCLAW_LIVE_MODEL_IMAGE_PROBE`

The literals remain only in tests and `src/agents/test-helpers/**`; there are no runtime callers or other production locations missed by the collector. This lowers the budget from 507 to 503, which is the ratchet's sanctioned direction per its own header. No source, test, other ratchet, baseline, or expected-failure list changes.

## User Impact

No runtime behavior changes. The environment-variable ratchet passes again on main and no longer blocks unrelated pull requests.

## Evidence

Before:

```text
OPENCLAW_* count 503 is below budget 507; update config/env-var-count-budget.txt
```

After:

```text
OPENCLAW_* count 503/503
```

`git diff --check` passes. Structured autoreview reported no accepted/actionable findings.
